### PR TITLE
Add GET method to action column in events table

### DIFF
--- a/src/ggrc/migrations/versions/20150411175351_4d690ff85863_add_get_to_event_table.py
+++ b/src/ggrc/migrations/versions/20150411175351_4d690ff85863_add_get_to_event_table.py
@@ -1,0 +1,38 @@
+# Copyright (C) 2015 Google Inc., authors, and contributors <see AUTHORS file>
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+# Created By: miha@reciprocitylabs.com
+# Maintained By: miha@reciprocitylabs.com
+
+"""add get to event table
+
+Revision ID: 4d690ff85863
+Revises: 5180ce718082
+Create Date: 2015-04-11 17:53:51.630881
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '4d690ff85863'
+down_revision = '5180ce718082'
+
+
+def upgrade():
+  op.alter_column(
+      'events', 'action',
+      type_=sa.Enum(u'POST', u'PUT', u'DELETE', u'IMPORT', u'GET'),
+      existing_type=sa.Enum(u'POST', u'PUT', u'DELETE', u'IMPORT'),
+      nullable=False
+  )
+
+
+def downgrade():
+  op.alter_column(
+      'events', 'action',
+      type_=sa.Enum(u'POST', u'PUT', u'DELETE', u'IMPORT'),
+      existing_type=sa.Enum(
+          u'POST', u'PUT', u'DELETE', u'IMPORT', u'GET'),
+      nullable=False
+  )

--- a/src/ggrc/models/event.py
+++ b/src/ggrc/models/event.py
@@ -9,7 +9,7 @@ from .mixins import Base, created_at_args
 class Event(Base, db.Model):
   __tablename__ = 'events'
 
-  action = db.Column(db.Enum(u'POST', u'PUT', u'DELETE', u'IMPORT'), nullable = False)
+  action = db.Column(db.Enum(u'POST', u'PUT', u'DELETE', u'IMPORT', u'GET'), nullable = False)
   resource_id = db.Column(db.Integer)
   resource_type = db.Column(db.String)
 


### PR DESCRIPTION
trying to login with a new user and email, creates a an entry in the events table with empty action column. 

and it's showing annoying warinings while testing

    /vagrant-dev/opt/dev_virtualenv/local/lib/python2.7/site-packages/sqlalchemy/engine/default.py:435: Warning: Data truncated for column 'action' at row 1
      cursor.execute(statement, parameters)

ps: i'm not sure of the correct fix would be to remove the get entries from the events table, but this fix makes more sense, since creating a new user can be done with GET and not POST.