### PR TITLE
Improve how tests handle database

### DIFF
--- a/bin/run_pytests
+++ b/bin/run_pytests
@@ -5,7 +5,7 @@
 # Maintained By: dan@reciprocitylabs.com
 
 mysql -uroot -proot -e "DROP DATABASE IF EXISTS ggrcdevtest; CREATE DATABASE ggrcdevtest; USE ggrcdevtest;"
-export GGRC_SETTINGS_MODULE="testing ggrc_basic_permissions.settings.development" 
+export GGRC_SETTINGS_MODULE="testing ggrc_basic_permissions.settings.development ggrc_gdrive_integration.settings.development ggrc_risk_assessments.settings.development ggrc_workflows.settings.development"
 db_migrate
 
 SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )

--- a/src/tests/ggrc/__init__.py
+++ b/src/tests/ggrc/__init__.py
@@ -19,7 +19,8 @@ if os.environ.get('TRAVIS', False):
 class TestCase(BaseTestCase):
   def setUp(self):
     for table in reversed(db.metadata.sorted_tables):
-      db.engine.execute(table.delete())
+      if not table.name == "test_model":
+        db.engine.execute(table.delete())
     db.session.commit()
 
     # if getattr(settings, 'MEMCACHE_MECHANISM', False) is True:

--- a/src/tests/ggrc/__init__.py
+++ b/src/tests/ggrc/__init__.py
@@ -18,7 +18,9 @@ if os.environ.get('TRAVIS', False):
 
 class TestCase(BaseTestCase):
   def setUp(self):
-    pass
+    for table in reversed(db.metadata.sorted_tables):
+      db.engine.execute(table.delete())
+    db.session.commit()
 
     # if getattr(settings, 'MEMCACHE_MECHANISM', False) is True:
     #   from google.appengine.api import memcache


### PR DESCRIPTION
This PR changes two things:
 - before each test runs, the test db is emptied
 - the test db actually contains all the tables it's supposed to