### PR TITLE
CORE-1643 Fix edit control assessment modal

### DIFF
--- a/src/ggrc/assets/mustache/control_assessments/modal_content.mustache
+++ b/src/ggrc/assets/mustache/control_assessments/modal_content.mustache
@@ -47,7 +47,7 @@
               <span class="required">*</span>
               <i class="grcicon-help-black" rel="tooltip" title="Control for this Control Assessment"></i>
             </label>
-            <input tabindex="2" class="input-block-level" name="control" readonly="readonly" value="{{firstexist title ''}}" />
+            <input tabindex="2" class="input-block-level" readonly="readonly" value="{{firstexist title ''}}" />
           </div>
         {{/related_audits}}
       {{/with_mapping}}
@@ -61,7 +61,7 @@
               <span class="required">*</span>
               <i class="grcicon-help-black" rel="tooltip" title="Audit for this Control Assessment"></i>
             </label>
-            <input tabindex="2" class="input-block-level" name="audit" readonly="readonly" type="text" value="{{firstexist title ''}}" />
+            <input tabindex="2" class="input-block-level" readonly="readonly" type="text" value="{{firstexist title ''}}" />
           </div>
         {{/related_audits}}
       {{/with_mapping}}

--- a/src/ggrc/models/control_assessment.py
+++ b/src/ggrc/models/control_assessment.py
@@ -36,4 +36,12 @@ class ControlAssessment(HasObjectState, TestPlanned, CustomAttributable,
       PublishOnly('audit')
   ]
 
+  @classmethod
+  def eager_query(cls):
+    from sqlalchemy import orm
+
+    query = super(ControlAssessment, cls).eager_query()
+    return query.options(
+        orm.subqueryload('control'))
+
 track_state_for_class(ControlAssessment)

--- a/src/ggrc/models/control_assessment.py
+++ b/src/ggrc/models/control_assessment.py
@@ -15,9 +15,9 @@ from .track_object_state import HasObjectState, track_state_for_class
 from ggrc.models.reflection import PublishOnly
 
 
-class ControlAssessment(HasObjectState, TestPlanned, CustomAttributable, Documentable,
-                        Personable, Timeboxed, Ownable, Relatable,
-                        BusinessObject, db.Model):
+class ControlAssessment(HasObjectState, TestPlanned, CustomAttributable,
+                        Documentable, Personable, Timeboxed, Ownable,
+                        Relatable, BusinessObject, db.Model):
   __tablename__ = 'control_assessments'
 
   design = deferred(db.Column(db.String), 'ControlAssessment')

--- a/src/ggrc/models/control_assessment.py
+++ b/src/ggrc/models/control_assessment.py
@@ -26,11 +26,14 @@ class ControlAssessment(HasObjectState, TestPlanned, CustomAttributable,
   control_id = db.Column(db.Integer, db.ForeignKey('controls.id'))
   control = db.relationship('Control', foreign_keys=[control_id])
 
+  audit = {}  # we add this for the sake of client side error checking
+
   # REST properties
   _publish_attrs = [
       'design',
       'operationally',
-      'control'
+      'control',
+      PublishOnly('audit')
   ]
 
 track_state_for_class(ControlAssessment)


### PR DESCRIPTION
This isn't pretty but it works, because our client side verification checks only if the audit attr exists.

ref: core-1643