### PR TITLE
CORE-1002 Add SaveQueue for batching POST/PUT requests

### DIFF
--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -93,6 +93,7 @@ dashboard-js-files:
   - pbc/workflow_controller.js
   - models/category.js
   - models/refresh_queue.js
+  - models/save_queue.js
   - models/custom_attributes.js
   - apps/quick_search.js
   - apps/business_objects.js

--- a/src/ggrc/assets/javascripts/controllers/modal_selector_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/modal_selector_controller.js
@@ -737,7 +737,7 @@
           this.set_option_descriptor(this.options.default_option_descriptor);
         }
         this.init_bindings();
-        this.init_view();
+        this._view_dfd = this.init_view();
         this.init_data();
       }
 
@@ -1428,7 +1428,10 @@
   }, {
     init: function(){
       GGRC.Controllers.MultitypeModalSelector.prototype.init.apply(this, arguments);
-      this.refresh_option_list();
+      this._load_dfd = this.refresh_option_list();
+      this._view_dfd.then(function(){
+        this.bindXHRToButton(this._load_dfd, this.element.find('.modalSearchButton'));
+      }.bind(this))
     }
 
     , init_spinner: function(){

--- a/src/ggrc/assets/javascripts/models/cacheable.js
+++ b/src/ggrc/assets/javascripts/models/cacheable.js
@@ -978,18 +978,17 @@ can.Model("can.Model.Cacheable", {
   , delay_resolving_save_until : function(dfd) {
     return this.notifier.queue(dfd);
   }
-
-  , save : function() {
+  , _save: function() {
     var that = this,
-        _super = this._super,
+        _super = Array.prototype.pop.call(arguments),
         isNew = this.isNew(),
         xhr,
-        dfd = new $.Deferred(),
+        dfd = this._dfd,
         pre_save_notifier = new PersistentNotifier({ name : this.constructor.model_singular + " (pre-save)" })
         ;
 
     this.before_save && this.before_save(pre_save_notifier);
-    if(isNew) {
+    if (isNew) {
       this.attr("provisional_id", "provisional_" + Math.floor(Math.random() * 10000000));
       can.getObject("provisional_cache", can.Model.Cacheable, true)[this.provisional_id] = this;
       this.before_create && this.before_create(pre_save_notifier);
@@ -1000,7 +999,7 @@ can.Model("can.Model.Cacheable", {
     pre_save_notifier.on_empty(function() {
 
       xhr = _super.apply(that, arguments).then(function(result) {
-        if(isNew) {
+        if (isNew) {
           that.after_create && that.after_create();
         } else {
           that.after_update && that.after_update();
@@ -1014,7 +1013,7 @@ can.Model("can.Model.Cacheable", {
 
       xhr.always(function() {
         that.notifier.on_empty(function() {
-          dfd.resolve();
+          dfd.resolve(that);
         });
       });
 
@@ -1022,7 +1021,13 @@ can.Model("can.Model.Cacheable", {
       GGRC.delay_leaving_page_until(dfd);
 
     });
-    return dfd.then(function() { return xhr; });
+    return dfd;
+  }
+  , save: function() {
+    Array.prototype.push.call(arguments, this._super);
+    this._dfd = new $.Deferred();
+    GGRC.SaveQueue.enqueue(this, arguments);
+    return this._dfd;
   },
   refresh_all: function() {
     var props = Array.prototype.slice.call(arguments, 0);
@@ -1068,7 +1073,7 @@ can.Model("can.Model.Cacheable", {
     }.bind(this));
 
     return values;
-  }, 
+  },
 
   hash_fragment: function () {
     var type = can.spaceCamelCase(this.type)

--- a/src/ggrc/assets/javascripts/models/save_queue.js
+++ b/src/ggrc/assets/javascripts/models/save_queue.js
@@ -41,12 +41,10 @@
         // Finished
         return;
       }
-      var objs = this._queue.splice(0, this.constructor.BATCH), ret;
+      var ret, objs = this._queue.splice(0, this.constructor.BATCH);
       $.when.apply($, objs.map(function (obj) {
         return obj.o._save.apply(obj.o, obj.a);
-      })).always(function () {
-        this._resolve(); // Move on to the next one
-      }.bind(this));
+      })).always(this._resolve.bind(this)); // Move on to the next one
     }
   });
 

--- a/src/ggrc/assets/javascripts/models/save_queue.js
+++ b/src/ggrc/assets/javascripts/models/save_queue.js
@@ -28,21 +28,26 @@
        clearTimeout(this._timeout);
      }
      this._timeout = setTimeout(function () {
-       this._resolve();
+       new GGRC.SaveQueue(this._queue.splice(0, this._queue.length));
      }.bind(this), this.DELAY);
+    },
+  }, {
+    init: function (queue) {
+      this._queue = queue;
+      this._resolve();
     },
     _resolve: function() {
       if (!this._queue.length) {
         // Finished
         return;
       }
-      var objs = this._queue.splice(0, this.BATCH), ret;
+      var objs = this._queue.splice(0, this.constructor.BATCH), ret;
       $.when.apply($, objs.map(function (obj) {
         return obj.o._save.apply(obj.o, obj.a);
       })).always(function () {
         this._resolve(); // Move on to the next one
       }.bind(this));
     }
-  }, {});
+  });
 
 })(window.can, window.can.$);

--- a/src/ggrc/assets/javascripts/models/save_queue.js
+++ b/src/ggrc/assets/javascripts/models/save_queue.js
@@ -1,0 +1,48 @@
+/*!
+    Copyright (C) 2015 Google Inc., authors, and contributors <see AUTHORS file>
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+    Created By: anze@reciprocitylabs.com
+    Maintained By: anze@reciprocitylabs.com
+*/
+
+(function(can, $) {
+
+  /*  GGRC.SaveQueue
+   *
+   *  SaveQueue is used by CMS.Models.Cacheable to prevent firing
+   *  multiple requests to the server at once. It makes sure the requests
+   *  are grouped together (inside _queue) and then resolved in batches.
+   *
+   *  enqueue(obj: CMS.Models.Cacheable, save_args) -> null
+   */
+  can.Construct("GGRC.SaveQueue", {
+
+    DELAY: 100, // Number of ms to wait before the first batch is fired
+    BATCH: 3,   // Maximum number of POST/PUT requests at any given time
+    _queue: [],
+    _timeout: null,
+
+    enqueue: function (obj, args) {
+     this._queue.push({o: obj, a: args});
+     if (typeof this._timeout === "number") {
+       clearTimeout(this._timeout);
+     }
+     this._timeout = setTimeout(function () {
+       this._resolve();
+     }.bind(this), this.DELAY);
+    },
+    _resolve: function() {
+      if (!this._queue.length) {
+        // Finished
+        return;
+      }
+      var objs = this._queue.splice(0, this.BATCH), ret;
+      $.when.apply($, objs.map(function (obj) {
+        return obj.o._save.apply(obj.o, obj.a);
+      })).always(function () {
+        this._resolve(); // Move on to the next one
+      }.bind(this));
+    }
+  }, {});
+
+})(window.can, window.can.$);

--- a/src/ggrc_workflows/assets/mustache/selectors/multitype_multiselect_base_modal.mustache
+++ b/src/ggrc_workflows/assets/mustache/selectors/multitype_multiselect_base_modal.mustache
@@ -91,9 +91,9 @@
                           <input type="checkbox" value="1" class="object-check-all" id='objectAll'>
                         </label>
                       {{else}}
-                        <label rel="tooltip" data-placement="right" data-original-title="Only 100 items can be mapped at a time. Please refine your search criteria.">
+                        <label rel="tooltip" data-placement="right" data-original-title="Mapping more than 100 items may take a long time to process. Please consider refining your search criteria.">
                           Select all
-                          <input type="checkbox" value="1" class="object-check-all" id='objectAll' disabled="disabled">
+                          <input type="checkbox" value="1" class="object-check-all" id='objectAll'>
                         </label>
                       {{/if_less}}
                     </label>


### PR DESCRIPTION
 This PR basically transforms this:

![screen shot 2015-04-17 at 17 51 49](https://cloud.githubusercontent.com/assets/513444/7207037/bfda7ee4-e536-11e4-8856-7f722492fd68.png)

Into this:

![screen shot 2015-04-17 at 17 49 12](https://cloud.githubusercontent.com/assets/513444/7207039/c162fe62-e536-11e4-9329-22f9616a413e.png)

The benefit is that the server is not spammed by over 9000 POST/PUT requests. Now the app will dispense up to 3 requests at a time and only fire new ones when those were resolved.

This also opens the door for us to create a new api endpoint that handles POST/PUT requests in batch. But this feature is out of scope for now.
