### PR TITLE
Fix travis link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 gGRC-Core
 =========
 
-[![Travis status](https://travis-ci.org/google/ggrc-core.svg)](https://travis-ci.org/google/ggrc-core)
+[![Travis status](https://travis-ci.org/google/ggrc-core.svg?branch=develop)](https://travis-ci.org/google/ggrc-core)
 
 Google Governance, Risk and Compliance. Migrated from [Google](https://code.google.com/p/compliance-management/)
 [Code](https://code.google.com/p/ggrc-core).


### PR DESCRIPTION
The link should point to the develop branch, not the last branch that got pushed to the repository.