### PR TITLE
CORE-1632 Let users unmap objects they mapped

### DIFF
--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -245,6 +245,7 @@ dashboard-js-template-files:
   - sections/info.mustache
   - sections/modal_content.mustache
   - sections/tree.mustache
+  - sections/dropdown_menu.mustache
   - selectors/active_column.mustache
   - selectors/base_modal.mustache
   - selectors/multitype_base_modal.mustache

--- a/src/ggrc/assets/javascripts/controllers/info_pin_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/info_pin_controller.js
@@ -73,7 +73,8 @@ can.Control("CMS.Controllers.InfoPin", {
       model: instance.class,
       is_info_pin: true,
       options: options,
-      result: options.result
+      result: options.result,
+      page_instance: GGRC.page_instance()
     }));
 
     // Load trees inside info pin

--- a/src/ggrc/assets/mustache/base_objects/dropdown_menu.mustache
+++ b/src/ggrc/assets/mustache/base_objects/dropdown_menu.mustache
@@ -5,11 +5,17 @@
     Maintained By: anze@reciprocitylabs.com
 }}
 
-{{> /static/mustache/base_objects/edit_object_link.mustache}}
+{{#is_allowed_update instance context='for'}}
+    {{> /static/mustache/base_objects/edit_object_link.mustache}}
+{{/is_allowed_update}}
+
 {{#is_info_pin}}
-  {{^options.is_in_selector}}
-    {{> /static/mustache/base_objects/unmap.mustache}}
-  {{/options}}
+  {{#is_allowed_to_map page_instance instance}}
+      {{^options.is_in_selector}}
+          {{> /static/mustache/base_objects/unmap.mustache}}
+
+      {{/options}}
+  {{/is_allowed_to_map}}
   {{#if instance.viewLink}}
     {{#is_allowed "view_object_page" instance}}
       <li>

--- a/src/ggrc/assets/mustache/base_objects/dropdown_menu.mustache
+++ b/src/ggrc/assets/mustache/base_objects/dropdown_menu.mustache
@@ -5,25 +5,40 @@
     Maintained By: anze@reciprocitylabs.com
 }}
 
-{{#is_allowed_update instance context='for'}}
-    {{> /static/mustache/base_objects/edit_object_link.mustache}}
-{{/is_allowed_update}}
+{{#if_helpers '\
+   #if' is_info_pin '\
+   and #is_allowed_to_map' page_instance instance '\
+   or #if' is_info_pin '\
+   and #if' instance.viewLink '\
+   or #is_allowed' 'update' instance '\
+   ' context='for'}}
+<div class="details-wrap">
+  <a class="btn btn-small btn-draft dropdown-toggle" href="#" data-toggle="dropdown"><i class="grcicon-setup-color"></i></a>
+  <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
 
-{{#is_info_pin}}
-  {{#is_allowed_to_map page_instance instance}}
-      {{^options.is_in_selector}}
+    {{#is_allowed 'update' instance context='for'}}
+      {{> /static/mustache/base_objects/edit_object_link.mustache}}
+    {{/is_allowed}}
+
+    {{#is_info_pin}}
+      {{#is_allowed_to_map page_instance instance}}
+        {{^options.is_in_selector}}
           {{> /static/mustache/base_objects/unmap.mustache}}
 
-      {{/options}}
-  {{/is_allowed_to_map}}
-  {{#if instance.viewLink}}
-    {{#is_allowed "view_object_page" instance}}
-      <li>
-        <a href="{{instance.viewLink}}">
-          View {{instance.class.title_singular}}
-          <i class="grcicon-goto"></i>
-        </a>
-      </li>
-    {{/is_allowed}}
-  {{/if}}
-{{/is_info_pin}}
+        {{/options}}
+      {{/is_allowed_to_map}}
+      {{#if instance.viewLink}}
+        {{#is_allowed "view_object_page" instance}}
+          <li>
+            <a href="{{instance.viewLink}}">
+              View {{instance.class.title_singular}}
+              <i class="grcicon-goto"></i>
+            </a>
+          </li>
+        {{/is_allowed}}
+      {{/if}}
+    {{/is_info_pin}}
+
+  </ul>
+</div>
+{{/if_helpers}}

--- a/src/ggrc/assets/mustache/base_objects/info.mustache
+++ b/src/ggrc/assets/mustache/base_objects/info.mustache
@@ -16,14 +16,7 @@
     </div>
     {{/is_info_pin}}
 
-    {{#is_allowed 'update' instance context='for'}}
-      <div class="details-wrap">
-        <a class="btn btn-small btn-draft dropdown-toggle" href="#" data-toggle="dropdown"><i class="grcicon-setup-color"></i></a>
-        <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
-          {{> /static/mustache/base_objects/dropdown_menu.mustache}}
-        </ul>
-      </div>
-    {{/is_allowed}}
+    {{> /static/mustache/base_objects/dropdown_menu.mustache}}
 
     <div class="tier-content">
       {{^is_info_pin}}

--- a/src/ggrc/assets/mustache/controls/info.mustache
+++ b/src/ggrc/assets/mustache/controls/info.mustache
@@ -16,15 +16,12 @@
     </div>
     {{/is_info_pin}}
 
-    {{#is_allowed 'update' instance context='for'}}
       <div class="details-wrap">
         <a class="btn btn-small btn-draft dropdown-toggle" href="#" data-toggle="dropdown"><i class="grcicon-setup-color"></i></a>
         <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
           {{> /static/mustache/base_objects/dropdown_menu.mustache}}
         </ul>
       </div>
-
-    {{/is_allowed}}
 
     <div class="tier-content">
       {{^is_info_pin}}

--- a/src/ggrc/assets/mustache/controls/info.mustache
+++ b/src/ggrc/assets/mustache/controls/info.mustache
@@ -16,12 +16,7 @@
     </div>
     {{/is_info_pin}}
 
-      <div class="details-wrap">
-        <a class="btn btn-small btn-draft dropdown-toggle" href="#" data-toggle="dropdown"><i class="grcicon-setup-color"></i></a>
-        <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
-          {{> /static/mustache/base_objects/dropdown_menu.mustache}}
-        </ul>
-      </div>
+    {{> /static/mustache/base_objects/dropdown_menu.mustache}}
 
     <div class="tier-content">
       {{^is_info_pin}}

--- a/src/ggrc/assets/mustache/objectives/info.mustache
+++ b/src/ggrc/assets/mustache/objectives/info.mustache
@@ -16,14 +16,7 @@
     </div>
     {{/is_info_pin}}
 
-    {{#is_allowed 'update' instance context='for'}}
-      <div class="details-wrap">
-        <a class="btn btn-small btn-draft dropdown-toggle" href="#" data-toggle="dropdown"><i class="grcicon-setup-color"></i></a>
-        <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
-          {{> /static/mustache/base_objects/dropdown_menu.mustache}}
-        </ul>
-      </div>
-    {{/is_allowed}}
+    {{> /static/mustache/base_objects/dropdown_menu.mustache}}
 
     <div class="tier-content">
       {{^is_info_pin}}

--- a/src/ggrc/assets/mustache/policies/info.mustache
+++ b/src/ggrc/assets/mustache/policies/info.mustache
@@ -16,14 +16,7 @@
     </div>
     {{/is_info_pin}}
 
-    {{#is_allowed 'update' instance context='for'}}
-      <div class="details-wrap">
-        <a class="btn btn-small btn-draft dropdown-toggle" href="#" data-toggle="dropdown"><i class="grcicon-setup-color"></i></a>
-        <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
-          {{> /static/mustache/base_objects/dropdown_menu.mustache}}
-        </ul>
-      </div>
-    {{/is_allowed}}
+    {{> /static/mustache/base_objects/dropdown_menu.mustache}}
 
     <div class="tier-content">
       {{^is_info_pin}}

--- a/src/ggrc/assets/mustache/processes/info.mustache
+++ b/src/ggrc/assets/mustache/processes/info.mustache
@@ -16,14 +16,7 @@
     </div>
     {{/is_info_pin}}
 
-    {{#is_allowed 'update' instance context='for'}}
-      <div class="details-wrap">
-        <a class="btn btn-small btn-draft dropdown-toggle" href="#" data-toggle="dropdown"><i class="grcicon-setup-color"></i></a>
-        <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
-          {{> /static/mustache/base_objects/dropdown_menu.mustache}}
-        </ul>
-      </div>
-    {{/is_allowed}}
+    {{> /static/mustache/base_objects/dropdown_menu.mustache}}
 
     <div class="tier-content">
       {{^is_info_pin}}

--- a/src/ggrc/assets/mustache/products/info.mustache
+++ b/src/ggrc/assets/mustache/products/info.mustache
@@ -16,15 +16,7 @@
     </div>
     {{/is_info_pin}}
 
-    {{#is_allowed 'update' instance context='for'}}
-      <div class="details-wrap">
-        <a class="btn btn-small btn-draft dropdown-toggle" href="#" data-toggle="dropdown"><i class="grcicon-setup-color"></i></a>
-        <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
-          {{> /static/mustache/base_objects/dropdown_menu.mustache}}
-        </ul>
-      </div>
-
-    {{/is_allowed}}
+    {{> /static/mustache/base_objects/dropdown_menu.mustache}}
 
     <div class="tier-content">
       {{^is_info_pin}}

--- a/src/ggrc/assets/mustache/programs/info.mustache
+++ b/src/ggrc/assets/mustache/programs/info.mustache
@@ -17,14 +17,7 @@
     </div>
     {{/is_info_pin}}
 
-    {{#is_allowed 'update' instance context='for'}}
-      <div class="details-wrap">
-        <a class="btn btn-small btn-draft dropdown-toggle" href="#" data-toggle="dropdown"><i class="grcicon-setup-color"></i></a>
-        <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
-          {{> /static/mustache/base_objects/dropdown_menu.mustache}}
-        </ul>
-      </div>
-    {{/is_allowed}}
+    {{> /static/mustache/base_objects/dropdown_menu.mustache}}
 
     <div class="tier-content">
       {{^is_info_pin}}

--- a/src/ggrc/assets/mustache/sections/dropdown_menu.mustache
+++ b/src/ggrc/assets/mustache/sections/dropdown_menu.mustache
@@ -1,0 +1,47 @@
+{{!
+    Copyright (C) 2015 Google Inc., authors, and contributors <see AUTHORS file>
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+    Created By: swizec@reciprocitylabs.com
+    Maintained By: swizec@reciprocitylabs.com
+}}
+
+{{#if_helpers '\
+   #if' is_info_pin '\
+   and #is_allowed_to_map' page_instance instance '\
+   or #if' is_info_pin '\
+   and #if' instance.viewLink '\
+   or #is_allowed' 'update' instance '\
+   ' context='for'}}
+<div class="details-wrap">
+  <a class="btn btn-small btn-draft dropdown-toggle" href="#" data-toggle="dropdown"><i class="grcicon-setup-color"></i></a>
+  <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
+
+    {{#is_allowed 'update' instance context='for'}}
+      {{> /static/mustache/base_objects/edit_object_link.mustache}}
+    {{/is_allowed}}
+
+    {{#is_info_pin}}
+      {{#is_allowed_to_map page_instance instance}}
+        {{^options.is_in_selector}}
+          {{> /static/mustache/base_objects/unmap.mustache}}
+
+        {{/options}}
+      {{/is_allowed_to_map}}
+      {{#if instance.viewLink}}
+        {{#is_allowed "view_object_page" instance}}
+          <li>
+            <a href="{{instance.viewLink}}">
+              View {{instance.class.title_singular}}
+              <i class="grcicon-goto"></i>
+            </a>
+          </li>
+        {{/is_allowed}}
+      {{/if}}
+    {{/is_info_pin}}
+
+    {{#is_parent_of_type 'Policy,Regulation,Standard'}}
+      {{> /static/mustache/base_objects/create_objective_dropdown_option.mustache}}
+    {{/is_parent_of_type}}
+  </ul>
+</div>
+{{/if_helpers}}

--- a/src/ggrc/assets/mustache/sections/info.mustache
+++ b/src/ggrc/assets/mustache/sections/info.mustache
@@ -16,18 +16,7 @@
     </div>
     {{/is_info_pin}}
 
-    {{#is_allowed 'update' instance context='for'}}
-      <div class="details-wrap">
-        <a class="btn btn-small btn-draft dropdown-toggle" href="#" data-toggle="dropdown"><i class="grcicon-setup-color"></i></a>
-        <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
-          {{> /static/mustache/base_objects/dropdown_menu.mustache}}
-
-          {{#is_parent_of_type 'Policy,Regulation,Standard'}}
-              {{> /static/mustache/base_objects/create_objective_dropdown_option.mustache}}
-          {{/is_parent_of_type}}
-        </ul>
-      </div>
-    {{/is_allowed}}
+    {{> /static/mustache/sections/dropdown_menu.mustache}}
 
     {{^is_info_pin}}
       {{{render '/static/mustache/base_objects/general_info.mustache' instance=instance}}}

--- a/src/ggrc/assets/mustache/systems/info.mustache
+++ b/src/ggrc/assets/mustache/systems/info.mustache
@@ -16,15 +16,7 @@
     </div>
     {{/is_info_pin}}
 
-    {{#is_allowed 'update' instance context='for'}}
-      <div class="details-wrap">
-        <a class="btn btn-small btn-draft dropdown-toggle" href="#" data-toggle="dropdown"><i class="grcicon-setup-color"></i></a>
-        <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
-          {{> /static/mustache/base_objects/dropdown_menu.mustache}}
-        </ul>
-      </div>
-    {{/is_allowed}}
-
+    {{> /static/mustache/base_objects/dropdown_menu.mustache}}
 
     <div class="tier-content">
       {{^is_info_pin}}


### PR DESCRIPTION
When a `Reader` user was given permissions to toy with a Program, they couldn't access the menu to unmap objects they mapped. Now they can.