### PR TITLE
QUICK-FIX Disable request warmup

### DIFF
--- a/src/app.yaml.dist
+++ b/src/app.yaml.dist
@@ -40,10 +40,6 @@ handlers:
     script: ggrc.app.app.wsgi_app
     secure: always
 
-# enable Warmup Requests in GAE
-inbound_services:
-  - warmup
-
 libraries:
   - name: jinja2
     version: "2.6"


### PR DESCRIPTION
We don't have the `/_ah/start` endpoint set up so this setting in not needed.