### PR TITLE
CORE-1671 Don't error out when browser submits import form

### DIFF
--- a/src/ggrc/assets/javascripts/dashboard.js
+++ b/src/ggrc/assets/javascripts/dashboard.js
@@ -119,6 +119,10 @@ jQuery(function($) {
       file_select_elem = 'form.import input[type=file]';
 
   function onSubmitClick(ev){
+    if (typeof ev !== "object") {
+      // sometimes browser triggers submit, not the user -> ignore
+      return;
+    }
     if ($(this).hasClass('disabled') || $(file_select_elem).val() === "") {
       ev && ev.preventDefault();
     }


### PR DESCRIPTION
A script error was triggered when you uploaded a CSV, clicked "submit&review", then uploaded a new CSV, but canceled.