### PR TITLE
CORE-1704 Add declined tasks data to notifications

### DIFF
--- a/src/ggrc_workflows/notification/data_handler.py
+++ b/src/ggrc_workflows/notification/data_handler.py
@@ -125,12 +125,24 @@ def get_cycle_data(notification):
   return {}
 
 
+def get_cycle_task_declined_data(notification):
+  cycle_task = get_object(CycleTaskGroupObjectTask, notification.object_id)
+  return {
+      cycle_task.contact.email: {
+          "user": get_person_dict(cycle_task.contact),
+          "task_declined": {
+              cycle_task.id: get_cycle_task_dict(cycle_task)
+          }
+      }
+  }
+
+
 def get_cycle_task_data(notification):
   notification_name = notification.notification_type.name
   if notification_name in ["manual_cycle_created", "cycle_created"]:
     return get_cycle_created_task_data(notification)
   elif notification_name == "cycle_task_declined":
-    return {}
+    return get_cycle_task_declined_data(notification)
   elif notification_name in ["cycle_task_due_in",
                              "one_time_cycle_task_due_in",
                              "weekly_cycle_task_due_in",

--- a/src/tests/ggrc_workflows/notifications/test_one_time_wf_decline_accept_tasks.py
+++ b/src/tests/ggrc_workflows/notifications/test_one_time_wf_decline_accept_tasks.py
@@ -166,7 +166,6 @@ class TestCycleTaskStatusChange(TestCase):
 
       self.assertEqual(len(notif), 1, "notifications: {}".format(str(notif)))
 
-  @SkipTest
   @patch("ggrc.notification.email.send_email")
   def test_single_task_declined(self, mock_mail):
     """


### PR DESCRIPTION
- Add the declined task data to the main notifications object
- Add test for declined notifications.