### PR TITLE
CORE-1715 Adding missing fields in Assessments and Issues modal

### DIFF
--- a/src/ggrc/assets/mustache/control_assessments/modal_content.mustache
+++ b/src/ggrc/assets/mustache/control_assessments/modal_content.mustache
@@ -109,22 +109,43 @@
     </div>
 
     <div class="row-fluid">
-    <div data-id="note_hidden" class="span6 hidable">
-      <label>
-        Notes
-        <i class="grcicon-help-black" rel="tooltip" title="Append simple text or html notes here."></i>
-        <a data-id="hide_note_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
-      </label>
-      <div class="wysiwyg-area">
-        <textarea data-id="note_txtbx" tabindex="5" id="notes" class="span12 double wysihtml5" name="notes" placeholder="Enter Notes">{{{notes}}}</textarea>
+      <div data-id="note_hidden" class="span6 hidable">
+        <label>
+          Notes
+          <i class="grcicon-help-black" rel="tooltip" title="Append simple text or html notes here."></i>
+          <a data-id="hide_note_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
+        </label>
+        <div class="wysiwyg-area">
+          <textarea data-id="note_txtbx" tabindex="5" id="notes" class="span12 double wysihtml5" name="notes" placeholder="Enter Notes">{{{notes}}}</textarea>
+        </div>
+      </div>
+      <div class="span6 hide-wrap hidable">
+        <div class="row-fluid inner-hide">
+          <div data-id="url_hidden" class="span12 hidable">
+            <label>
+              Assessment URL
+              <i class="grcicon-help-black" rel="tooltip" title="Web link to the Sites page / {{model.model_singular}} documentation."></i>
+              <a data-id="hide_url_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
+            </label>
+            <input data-id="url_txtbx" tabindex="7" class="input-block-level" name="url" placeholder="http://www.domain.com/" type="text" value="{{url}}">
+          </div>
+        </div>
+        <div class="row-fluid inner-hide">
+          <div data-id="reference_url_hidden" class="span12 hidable">
+            <label>
+              Reference URL
+              <i class="grcicon-help-black" rel="tooltip" title="Web links to other references."></i>
+              <a data-id="hide_reference_url_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
+            </label>
+            <input data-id="reference_url_txtbx" tabindex="8" id="reference_url" class="input-block-level" placeholder="https://www.example.com/" name="reference_url" type="text" value="{{reference_url}}">
+          </div>
+        </div>
       </div>
     </div>
 
-  </div>
-
   <div>
     <div class="row-fluid">
-      <div data-id="code_hidden" class="span6 hidable">
+      <div data-id="code_hidden" class="span4 hidable">
         <label>
           Code
           <i class="grcicon-help-black" rel="tooltip" title="The gGRC application will automatically provide codes for new objects.  If you would like to override this feature you may manually enter a code of your choosing.  You should have a specific reason for doing this."></i>
@@ -132,7 +153,25 @@
         </label>
         <input data-id="code_txtbx" tabindex="8" class="input-block-level" name="slug" placeholder="CONTROL-XXX" type="text" value="{{slug}}">
       </div>
-      <div data-id="state_hidden" class="span6 hidable">
+      <div data-id="effective_date_hidden" class="span4 hidable">
+        <label>
+          Effective Date
+          <i class="grcicon-help-black" rel="tooltip" title="Enter the date this object becomes effective."></i>
+          <a data-id="hide_effective_date_lk"href="javascript://" class="field-hide" tabindex="-1">hide</a>
+        </label>
+        <input data-id="effective_date_txtbx" tabindex="10" class="input-block-level date" name="start_date" data-toggle="datepicker" data-before="end_date" placeholder="MM/DD/YYYY" type="text" value="{{localize_date start_date}}">
+      </div>
+      <div data-id="stop_date_hidden" class="span4 hidable">
+        <label>
+          Stop Date
+          <i class="grcicon-help-black" rel="tooltip" title="Enter the date the object stops being effective."></i>
+          <a data-id="hide_stop_date_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
+        </label>
+        <input data-id="stop_date_txtbx" tabindex="11" class="input-block-level date" name="end_date" data-toggle="datepicker" data-after="start_date" placeholder="MM/DD/YYYY" type="text" value="{{localize_date end_date}}">
+      </div>
+    </div>
+    <div class="row-fluid">
+      <div data-id="state_hidden" class="span4 hidable">
         <label>
           State
           <i class="grcicon-help-black" rel="tooltip" title="Indicates the status of this object."></i>

--- a/src/ggrc/assets/mustache/issues/modal_content.mustache
+++ b/src/ggrc/assets/mustache/issues/modal_content.mustache
@@ -103,22 +103,43 @@
     </div>
 
     <div class="row-fluid">
-    <div data-id="note_hidden" class="span6 hidable">
-      <label>
-        Notes
-        <i class="grcicon-help-black" rel="tooltip" title="Append simple text or html notes here."></i>
-        <a data-id="hide_note_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
-      </label>
-      <div class="wysiwyg-area">
-        <textarea data-id="note_txtbx" tabindex="5" id="notes" class="span12 double wysihtml5" name="notes" placeholder="Enter Notes">{{{notes}}}</textarea>
+      <div data-id="note_hidden" class="span6 hidable">
+        <label>
+          Notes
+          <i class="grcicon-help-black" rel="tooltip" title="Append simple text or html notes here."></i>
+          <a data-id="hide_note_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
+        </label>
+        <div class="wysiwyg-area">
+          <textarea data-id="note_txtbx" tabindex="5" id="notes" class="span12 double wysihtml5" name="notes" placeholder="Enter Notes">{{{notes}}}</textarea>
+        </div>
+      </div>
+      <div class="span6 hide-wrap hidable">
+        <div class="row-fluid inner-hide">
+          <div data-id="url_hidden" class="span12 hidable">
+            <label>
+              Issue URL
+              <i class="grcicon-help-black" rel="tooltip" title="Web link to the Sites page / {{model.model_singular}} documentation."></i>
+              <a data-id="hide_url_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
+            </label>
+            <input data-id="url_txtbx" tabindex="7" class="input-block-level" name="url" placeholder="http://www.domain.com/" type="text" value="{{url}}">
+          </div>
+        </div>
+        <div class="row-fluid inner-hide">
+          <div data-id="reference_url_hidden" class="span12 hidable">
+            <label>
+              Reference URL
+              <i class="grcicon-help-black" rel="tooltip" title="Web links to other references."></i>
+              <a data-id="hide_reference_url_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
+            </label>
+            <input data-id="reference_url_txtbx" tabindex="8" id="reference_url" class="input-block-level" placeholder="https://www.example.com/" name="reference_url" type="text" value="{{reference_url}}">
+          </div>
+        </div>
       </div>
     </div>
 
-  </div>
-
   <div>
     <div class="row-fluid">
-      <div data-id="code_hidden" class="span6 hidable">
+      <div data-id="code_hidden" class="span4 hidable">
         <label>
           Code
           <i class="grcicon-help-black" rel="tooltip" title="The gGRC application will automatically provide codes for new objects.  If you would like to override this feature you may manually enter a code of your choosing.  You should have a specific reason for doing this."></i>
@@ -126,7 +147,25 @@
         </label>
         <input data-id="code_txtbx" tabindex="8" class="input-block-level" name="slug" placeholder="CONTROL-XXX" type="text" value="{{slug}}">
       </div>
-      <div data-id="state_hidden" class="span6 hidable">
+      <div data-id="effective_date_hidden" class="span4 hidable">
+        <label>
+          Effective Date
+          <i class="grcicon-help-black" rel="tooltip" title="Enter the date this object becomes effective."></i>
+          <a data-id="hide_effective_date_lk"href="javascript://" class="field-hide" tabindex="-1">hide</a>
+        </label>
+        <input data-id="effective_date_txtbx" tabindex="10" class="input-block-level date" name="start_date" data-toggle="datepicker" data-before="end_date" placeholder="MM/DD/YYYY" type="text" value="{{localize_date start_date}}">
+      </div>
+      <div data-id="stop_date_hidden" class="span4 hidable">
+        <label>
+          Stop Date
+          <i class="grcicon-help-black" rel="tooltip" title="Enter the date the object stops being effective."></i>
+          <a data-id="hide_stop_date_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
+        </label>
+        <input data-id="stop_date_txtbx" tabindex="11" class="input-block-level date" name="end_date" data-toggle="datepicker" data-after="start_date" placeholder="MM/DD/YYYY" type="text" value="{{localize_date end_date}}">
+      </div>
+    </div>
+    <div class="row-fluid">
+      <div data-id="state_hidden" class="span4 hidable">
         <label>
           State
           <i class="grcicon-help-black" rel="tooltip" title="Indicates the status of this object."></i>


### PR DESCRIPTION
Missing fields are added into modals. Check and add respective fields into DB.
Fields that are added:
- Assessment URL / Issue URL *(respectively)*
- Reference URL *(for both objects)*
- Effective date *(for both objects)*
- Stop date *(for both objects)*