### PR TITLE
CORE-1741 Fix notifications for multiple workflow owners

### DIFF
--- a/src/ggrc_workflows/notification/__init__.py
+++ b/src/ggrc_workflows/notification/__init__.py
@@ -68,7 +68,8 @@ All notifications handle the following structure:
                   "custom_message": ""
                   "title": ""
                   "workflow_url": "",
-                  "workflow_owner": workflow_owner,
+                  "workflow_owners":
+                      { workflow_owner.id: workflow_owner_info, ...},
                   "start_date": MM/DD/YYYY
                   "fuzzy_start_date": "in X days/weeks ..."
 
@@ -96,7 +97,8 @@ All notifications handle the following structure:
                   "custom_message": ""
                   "cycle_title": ""
                   "cycle_url": ""
-                  "workflow_owner": workflow_owner,
+                  "workflow_owners":
+                      { workflow_owner.id: workflow_owner_info, ...},
 
                   "my_tasks" : # list of all tasks assigned to the user
                       { cycle_task.id: { task_info }, ...}

--- a/src/ggrc_workflows/templates/notifications/email_digest_content.html
+++ b/src/ggrc_workflows/templates/notifications/email_digest_content.html
@@ -74,8 +74,8 @@ Maintained By: miha@reciprocitylabs.com
                   <ul {{ style.list_wrap() }} >
                   {% for cycle_id, cycle in digest['cycle_started'].items() %}
                     <li {{ style.list_item() }} >
-                      New cycle of {{ cycle['cycle_title'] }},
-                      by {{ macro.user_name(cycle['workflow_owner']) }}.
+                      New cycle of {{ cycle['cycle_title'] }}.
+                      <!--by {# macro.user_name(cycle['workflow_owner']) #}.-->
                     </li>
                   {% endfor %}
                   </ul>
@@ -89,8 +89,8 @@ Maintained By: miha@reciprocitylabs.com
                       New cycle of 
                       <a href="{{ workflow['workflow_url'] }}" {{ style.link_text() }} >
                         {{ workflow['title'] }}</a>
-                      starts {{ workflow['fuzzy_start_date'] }},
-                      by {{ macro.user_name(workflow['workflow_owner']) }}.
+                      starts {{ workflow['fuzzy_start_date'] }}.
+                      <!--by {# macro.user_name(cycle['workflow_owner']) #}.-->
                     </li>
                   {% endfor %}
                   </ul>


### PR DESCRIPTION
Since workflows can have any number of owners and not just one, we need
to make sure all of them will get the correct notifications. We also
removed the "by xyz" part in the notifications until it is decided if
that part should display just one owner or list them all.