### PR TITLE
CORE-1714 Added missing fields into info widget for Assessments and Issus

### DIFF
--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -162,6 +162,7 @@ dashboard-js-template-files:
   - control_assessments/tree_footer.mustache
   - control_assessments/info.mustache
   - issues/modal_content.mustache
+  - issues/info.mustache
   - custom_attributes/modal_content.mustache
   - custom_attributes/info.mustache
   - custom_attribute_definitions/modal_content.mustache

--- a/src/ggrc/assets/javascripts/apps/business_objects.js
+++ b/src/ggrc/assets/javascripts/apps/business_objects.js
@@ -262,6 +262,8 @@ $(function() {
     , 'systems': GGRC.mustache_path + "/systems/info.mustache"
     , 'processes': GGRC.mustache_path + "/processes/info.mustache"
     , 'products': GGRC.mustache_path + "/products/info.mustache"
+    , 'control_assessments': GGRC.mustache_path + "/control_assessments/info.mustache"
+    , 'issues': GGRC.mustache_path + "/issues/info.mustache"
   };
   widget_list.add_widget(object.constructor.shortName, "info", {
     widget_id : "info",

--- a/src/ggrc/assets/mustache/base_objects/description.mustache
+++ b/src/ggrc/assets/mustache/base_objects/description.mustache
@@ -4,7 +4,7 @@
     <div class="span12">
       <h6>Description</h6>
       <div class="rtf-block">
-        {{{firstnonempty description '<h4 class="no-data">No description</h4>'}}}
+        {{{firstnonempty description '<em>No description</em>'}}}
       </div>
     </div>
   </div>

--- a/src/ggrc/assets/mustache/base_objects/test_plan.mustache
+++ b/src/ggrc/assets/mustache/base_objects/test_plan.mustache
@@ -4,7 +4,7 @@
     <div class="span12">
       <h6>Test Plan</h6>
       <div class="rtf-block">
-        {{{firstnonempty test_plan '<h4 class="no-data">No test plan</h4>'}}}
+        {{{firstnonempty test_plan '<em>No test plan</em>'}}}
       </div>
     </div>
   </div>

--- a/src/ggrc/assets/mustache/control_assessments/info.mustache
+++ b/src/ggrc/assets/mustache/control_assessments/info.mustache
@@ -70,10 +70,7 @@
 
       <div class="row-fluid wrap-row" {{#instance}}{{data 'model'}}{{/instance}} data-force-refresh="true" data-model="true" {{ (el) -> el.ggrc_controllers_quick_form({ instance : el.data('model')}); }}>
         <div class="span6">
-          <h6>Test plan</h6>
-          <div class="rtf-block">
-            {{{firstnonempty test_plan '<em>No test plan</em>'}}}
-          </div>
+          {{{render '/static/mustache/base_objects/test_plan.mustache' instance=instance}}}
         </div>
         <div class="span3">
           <h6>Conclusion: Design</h6>

--- a/src/ggrc/assets/mustache/control_assessments/info.mustache
+++ b/src/ggrc/assets/mustache/control_assessments/info.mustache
@@ -66,12 +66,13 @@
       {{^is_info_pin}}
         {{{render '/static/mustache/base_objects/general_info.mustache' instance=instance}}}
       {{/is_info_pin}}
+      {{{render '/static/mustache/base_objects/description.mustache' instance=instance}}}
 
       <div class="row-fluid wrap-row" {{#instance}}{{data 'model'}}{{/instance}} data-force-refresh="true" data-model="true" {{ (el) -> el.ggrc_controllers_quick_form({ instance : el.data('model')}); }}>
         <div class="span6">
           <h6>Test plan</h6>
           <div class="rtf-block">
-            {{{firstnonempty test_plan '<h4 class="no-data">No description</h4>'}}}
+            {{{firstnonempty test_plan '<em>No test plan</em>'}}}
           </div>
         </div>
         <div class="span3">
@@ -95,6 +96,8 @@
           </select>
         </div>
       </div>
+
+      {{{render '/static/mustache/base_objects/notes.mustache' instance=instance}}}
 
       <div class="row-fluid wrap-row">
         <div class="span6">
@@ -157,6 +160,7 @@
         </div>
       </div>
 
+      {{{render '/static/mustache/base_objects/urls.mustache' is_program=true instance=instance}}}
 
       <div class="custom-attr-wrap">
         <div class="row-fluid">

--- a/src/ggrc/assets/mustache/issues/info.mustache
+++ b/src/ggrc/assets/mustache/issues/info.mustache
@@ -1,0 +1,106 @@
+{{!
+    Copyright (C) 2013 Google Inc., authors, and contributors <see AUTHORS file>
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+    Created By: brad@reciprocitylabs.com
+    Maintained By: brad@reciprocitylabs.com
+}}
+
+{{#instance}}
+  <section class="info">
+    {{#is_info_pin}}
+    <div class="clearfix">
+      {{{render '/static/mustache/base_objects/info-pin.mustache'}}}
+      <div class="tier-content">
+        {{{render '/static/mustache/base_objects/general_info.mustache' instance=instance}}}
+      </div>
+    </div>
+    {{/is_info_pin}}
+
+    {{> /static/mustache/base_objects/dropdown_menu.mustache}}
+
+    <div class="tier-content">
+      {{^is_info_pin}}
+        {{{render '/static/mustache/base_objects/general_info.mustache' instance=instance}}}
+      {{/is_info_pin}}
+      {{{render '/static/mustache/base_objects/description.mustache' instance=instance}}}
+
+      <div class="row-fluid wrap-row" {{#instance}}{{data 'model'}}{{/instance}} data-force-refresh="true" data-model="true" {{ (el) -> el.ggrc_controllers_quick_form({ instance : el.data('model')}); }}>
+        <div class="span6">
+          <h6>Test plan</h6>
+          <div class="rtf-block">
+            {{{firstnonempty test_plan '<em>No test plan</em>'}}}
+          </div>
+        </div>
+      </div>
+
+      {{{render '/static/mustache/base_objects/notes.mustache' instance=instance}}}
+      {{{render '/static/mustache/base_objects/contacts.mustache' instance=instance}}}
+      {{{render '/static/mustache/base_objects/urls.mustache' instance=instance}}}
+
+      <div class="custom-attr-wrap">
+        <div class="row-fluid">
+          <div class="span12">
+            <div class="info-expand">
+              <a class="show-hidden-fields info-show-hide" href="javascript://">
+                <span class="out">
+                  <i class="grcicon-arrow-right"></i>
+                  Show
+                </span>
+                <span class="in">
+                  <i class="grcicon-arrow-bottom"></i>
+                  Hide
+                </span>
+                Advanced
+              </a>
+            </div>
+          </div>
+        </div><!-- row-fluid end -->
+        <div class="hidden-fields-area" style="display:none;">
+          <div class="row-fluid wrap-row">
+            <div class="span4">
+              <h6>Code</h6>
+              <p>
+                {{slug}}
+              </p>
+            </div>
+            <div class="span4">
+              <h6>Effective Date</h6>
+              <p>
+                {{localize_date start_date}}
+              </p>
+            </div>
+            <div class="span4">
+              <h6>Stop Date</h6>
+              <p>
+              {{localize_date end_date}}
+              </p>
+            </div>
+          </div><!-- row-fluid end -->
+          <div class="row-fluid wrap-row">
+            <div class="span4">
+              <h6>State</h6>
+              <p>
+                {{status}}
+              </p>
+            </div>
+          </div><!-- row-fluid end -->
+        </div><!-- hidden-fields-area end -->
+      </div><!-- custom-attr-wrap end -->
+    </div><!-- tier-content end -->
+
+  {{{render '/static/mustache/custom_attributes/info.mustache' instance=instance}}}
+
+  </section>
+
+  <div class="info-widget-footer">
+    <p>
+      <small>
+        <em>
+          Created at {{date created_at}}
+          &nbsp;&nbsp;&nbsp;&nbsp;
+          Modified by {{#using person=modified_by}}{{{render '/static/mustache/people/popover.mustache' person=person}}}{{/using}} on {{date updated_at}}
+        </em>
+      </small>
+    </p>
+  </div>
+{{/instance}}

--- a/src/ggrc/assets/mustache/issues/info.mustache
+++ b/src/ggrc/assets/mustache/issues/info.mustache
@@ -23,16 +23,7 @@
         {{{render '/static/mustache/base_objects/general_info.mustache' instance=instance}}}
       {{/is_info_pin}}
       {{{render '/static/mustache/base_objects/description.mustache' instance=instance}}}
-
-      <div class="row-fluid wrap-row" {{#instance}}{{data 'model'}}{{/instance}} data-force-refresh="true" data-model="true" {{ (el) -> el.ggrc_controllers_quick_form({ instance : el.data('model')}); }}>
-        <div class="span6">
-          <h6>Test plan</h6>
-          <div class="rtf-block">
-            {{{firstnonempty test_plan '<em>No test plan</em>'}}}
-          </div>
-        </div>
-      </div>
-
+      {{{render '/static/mustache/base_objects/test_plan.mustache' instance=instance}}}
       {{{render '/static/mustache/base_objects/notes.mustache' instance=instance}}}
       {{{render '/static/mustache/base_objects/contacts.mustache' instance=instance}}}
       {{{render '/static/mustache/base_objects/urls.mustache' instance=instance}}}


### PR DESCRIPTION
Missing fields are added into info widget.
Fields that are added:
- Test plan *(for Assessment and for Issues info widget)*
- URLs
- Notes
- Description