### PR TITLE
CORE-1759 Fix Control deletion

### DIFF
--- a/src/ggrc/models/control.py
+++ b/src/ggrc/models/control.py
@@ -15,6 +15,7 @@ from .mixins import (
 from .object_document import Documentable
 from .object_owner import Ownable
 from .object_person import Personable
+from .audit_object import Auditable
 from .reflection import PublishOnly
 from .utils import validate_option
 
@@ -84,7 +85,7 @@ class AssertionCategorized(Categorizable):
 
 class Control(HasObjectState,
     CustomAttributable, Documentable, Personable, ControlCategorized, AssertionCategorized,
-    Hierarchical, Timeboxed, Ownable, BusinessObject, db.Model):
+    Hierarchical, Timeboxed, Ownable, BusinessObject, Auditable, db.Model):
   __tablename__ = 'controls'
 
   company_control = deferred(db.Column(db.Boolean), 'Control')
@@ -107,17 +108,6 @@ class Control(HasObjectState,
       'Person', uselist=False, foreign_keys='Control.principal_assessor_id')
   secondary_assessor = db.relationship(
       'Person', uselist=False, foreign_keys='Control.secondary_assessor_id')
-
-  @declared_attr
-  def audit_objects(cls):
-
-    joinstr = 'and_(foreign(AuditObject.auditable_id) == {type}.id, '\
-              'foreign(AuditObject.auditable_type) == "{type}")'
-    joinstr = joinstr.format(type=cls.__name__)
-    return db.relationship(
-        'AuditObject',
-        primaryjoin=joinstr,
-    )
 
   kind = db.relationship(
       'Option',
@@ -196,7 +186,6 @@ class Control(HasObjectState,
       'version',
       'principal_assessor',
       'secondary_assessor',
-      PublishOnly('audit_objects'),
       PublishOnly('control_controls'),
       PublishOnly('control_sections'),
       PublishOnly('objective_controls'),


### PR DESCRIPTION
Audit object wasn't cascading properly on delete which caused deletion
of controls to fail. We could just add cascade = 'all, delete-orphan'
on the audit_objects relationship, but it's cleaner to just add the
auditable mixin which basically does exactly that.