### PR TITLE
CORE-1777 Fix notifications for deleted objects

### DIFF
--- a/src/ggrc_workflows/notification/data_handler.py
+++ b/src/ggrc_workflows/notification/data_handler.py
@@ -28,6 +28,9 @@ exposed functions
 
 def get_cycle_created_task_data(notification):
   cycle_task = get_object(CycleTaskGroupObjectTask, notification.object_id)
+  if not cycle_task:
+    return {}
+
   cycle_task_group = cycle_task.cycle_task_group
   cycle = cycle_task_group.cycle
 
@@ -79,6 +82,9 @@ def get_cycle_created_task_data(notification):
 
 def get_cycle_task_due(notification):
   cycle_task = get_object(CycleTaskGroupObjectTask, notification.object_id)
+  if not cycle_task:
+    return {}
+
   notif_name = notification.notification_type.name
   due = "due_today" if notif_name == "cycle_task_due_today" else "due_in"
   return {
@@ -124,6 +130,9 @@ def get_cycle_created_data(notification, cycle):
 
 def get_cycle_data(notification):
   cycle = get_object(Cycle, notification.object_id)
+  if not cycle:
+    return {}
+
   notification_name = notification.notification_type.name
   if notification_name in ["manual_cycle_created", "cycle_created"]:
     return get_cycle_created_data(notification, cycle)
@@ -135,6 +144,9 @@ def get_cycle_data(notification):
 
 def get_cycle_task_declined_data(notification):
   cycle_task = get_object(CycleTaskGroupObjectTask, notification.object_id)
+  if not cycle_task:
+    return {}
+
   return {
       cycle_task.contact.email: {
           "user": get_person_dict(cycle_task.contact),
@@ -165,6 +177,9 @@ def get_cycle_task_data(notification):
 
 def get_task_group_task_data(notification):
   task_group_task = get_object(TaskGroupTask, notification.object_id)
+  if not task_group_task:
+    return {}
+
   task_group = task_group_task.task_group
   workflow = task_group.workflow
 
@@ -221,6 +236,8 @@ def get_task_group_task_data(notification):
 
 def get_workflow_data(notification):
   workflow = get_object(Workflow, notification.object_id)
+  if not workflow:
+    return {}
 
   if workflow.frequency == "one_time":
     # one time workflows get cycles manually created and that triggers
@@ -250,7 +267,10 @@ def get_workflow_data(notification):
 
 
 def get_object(obj_class, obj_id):
-  return db.session.query(obj_class).filter(obj_class.id == obj_id).one()
+  result = db.session.query(obj_class).filter(obj_class.id == obj_id)
+  if result.count() == 1:
+    return result.one()
+  return None
 
 
 def get_fuzzy_date(end_date):

--- a/src/ggrc_workflows/views/__init__.py
+++ b/src/ggrc_workflows/views/__init__.py
@@ -87,7 +87,7 @@ def send_pending_notifications():
       email.send_email(user_email, subject, email_body)
       sent_emails.append(user_email)
   set_notification_sent_time(notifications)
-  return "emails sent to: <br> {}".format("", "<br>".join(sent_emails))
+  return "emails sent to: <br> {}".format("<br>".join(sent_emails))
 
 
 def send_todays_digest_notifications():
@@ -101,7 +101,7 @@ def send_todays_digest_notifications():
     email.send_email(user_email, subject, email_body)
     sent_emails.append(user_email)
   set_notification_sent_time(notifications)
-  return "emails sent to: <br> {}".format("", "<br>".join(sent_emails))
+  return "emails sent to: <br> {}".format("<br>".join(sent_emails))
 
 
 def init_extra_views(app):

--- a/src/tests/ggrc_workflows/notifications/test_deleted_objects.py
+++ b/src/tests/ggrc_workflows/notifications/test_deleted_objects.py
@@ -1,0 +1,108 @@
+# Copyright (C) 2015 Google Inc., authors, and contributors <see AUTHORS file>
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+# Created By: miha@reciprocitylabs.com
+# Maintained By: miha@reciprocitylabs.com
+
+import random
+from tests.ggrc import TestCase
+from freezegun import freeze_time
+from datetime import datetime
+from mock import patch
+
+import os
+from ggrc import notification
+from ggrc.models import Notification, Person
+from ggrc_workflows.models import Workflow
+from tests.ggrc_workflows.generator import WorkflowsGenerator
+from tests.ggrc.api_helper import Api
+from tests.ggrc.generator import GgrcGenerator
+
+
+if os.environ.get('TRAVIS', False):
+  random.seed(1)  # so we can reproduce the tests if needed
+
+
+class TestNotificationsForDeletedObjects(TestCase):
+
+  """ This class contains simple one time workflow tests that are not
+  in the gsheet test grid
+  """
+
+  def setUp(self):
+    TestCase.setUp(self)
+    self.api = Api()
+    self.wf_generator = WorkflowsGenerator()
+    self.ggrc_generator = GgrcGenerator()
+    Notification.query.delete()
+
+    self.random_objects = self.ggrc_generator.generate_random_objects(2)
+    _, self.user = self.ggrc_generator.generate_person(user_role="gGRC Admin")
+    self.create_test_cases()
+
+    def init_decorator(init):
+      def new_init(self, *args, **kwargs):
+        init(self, *args, **kwargs)
+        if hasattr(self, "created_at"):
+          self.created_at = datetime.now()
+      return new_init
+
+    Notification.__init__ = init_decorator(Notification.__init__)
+
+  @patch("ggrc.notification.email.send_email")
+  def test_delete_activated_workflow(self, mock_mail):
+
+    with freeze_time("2015-02-01 13:39:20"):
+      _, wf = self.wf_generator.generate_workflow(self.quarterly_wf_1)
+      response, wf = self.wf_generator.activate_workflow(wf)
+
+      self.assert200(response)
+
+      user = Person.query.get(self.user.id)
+
+    with freeze_time("2015-01-01 13:39:20"):
+      _, notif_data = notification.get_todays_notifications()
+      self.assertNotIn(user.email, notif_data)
+
+    with freeze_time("2015-01-29 13:39:20"):
+      _, notif_data = notification.get_todays_notifications()
+      self.assertIn(user.email, notif_data)
+      self.assertIn("cycle_starts_in", notif_data[user.email])
+
+      workflow = Workflow.query.get(wf.id)
+
+      response = self.wf_generator.api.delete(workflow, workflow.id)
+      self.assert200(response)
+
+      _, notif_data = notification.get_todays_notifications()
+      user = Person.query.get(self.user.id)
+
+      self.assertNotIn(user.email, notif_data)
+
+  def create_test_cases(self):
+    def person_dict(person_id):
+      return {
+          "href": "/api/people/%d" % person_id,
+          "id": person_id,
+          "type": "Person"
+      }
+
+    self.quarterly_wf_1 = {
+        "title": "quarterly wf 1",
+        "description": "",
+        "owners": [person_dict(self.user.id)],
+        "frequency": "quarterly",
+        "task_groups": [{
+            "title": "tg_1",
+            "contact": person_dict(self.user.id),
+            "task_group_tasks": [{
+                "contact": person_dict(self.user.id),
+                "description": self.wf_generator.random_str(100),
+                "relative_start_day": 5,
+                "relative_start_month": 2,
+                "relative_end_day": 25,
+                "relative_end_month": 2,
+            },
+            ],
+        },
+        ]
+    }

--- a/src/tests/ggrc_workflows/notifications/test_middle_level_one_time_wf.py
+++ b/src/tests/ggrc_workflows/notifications/test_middle_level_one_time_wf.py
@@ -32,6 +32,7 @@ class TestOneTimeWorkflowNotification(TestCase):
   """
 
   def setUp(self):
+    TestCase.setUp(self)
     self.api = Api()
     self.wf_generator = WorkflowsGenerator()
     self.ggrc_generator = GgrcGenerator()

--- a/src/tests/ggrc_workflows/notifications/test_recurring_cycles.py
+++ b/src/tests/ggrc_workflows/notifications/test_recurring_cycles.py
@@ -25,6 +25,7 @@ if os.environ.get('TRAVIS', False):
 class TestRecurringCycleNotifications(TestCase):
 
   def setUp(self):
+    TestCase.setUp(self)
     self.api = Api()
     self.generator = WorkflowsGenerator()
     self.ggrc_generator = GgrcGenerator()

--- a/src/tests/ggrc_workflows/test_api_calls.py
+++ b/src/tests/ggrc_workflows/test_api_calls.py
@@ -19,6 +19,7 @@ if os.environ.get('TRAVIS', False):
 class TestWorkflowsApiPost(TestCase):
 
   def setUp(self):
+    TestCase.setUp(self)
     self.api = Api()
 
   def tearDown(self):

--- a/src/tests/ggrc_workflows/test_basic_workflow_actions.py
+++ b/src/tests/ggrc_workflows/test_basic_workflow_actions.py
@@ -23,6 +23,7 @@ if os.environ.get('TRAVIS', False):
 class TestBasicWorkflowActions(TestCase):
 
   def setUp(self):
+    TestCase.setUp(self)
     self.api = Api()
     self.generator = WorkflowsGenerator()
     self.ggrc_generator = GgrcGenerator()


### PR DESCRIPTION
If the object was delete after notification entry was created the entry
is invalid and should be ignored.