### PR TITLE
CORE-1783 Remove freezegun from production requirements

### DIFF
--- a/src/dev-requirements.txt
+++ b/src/dev-requirements.txt
@@ -22,3 +22,4 @@ ipython
 MonthDelta==0.9.1
 webob
 names
+freezegun==0.3.1

--- a/src/ggrc/notification/__init__.py
+++ b/src/ggrc/notification/__init__.py
@@ -5,7 +5,6 @@
 
 
 from collections import defaultdict
-from freezegun import freeze_time
 from datetime import date, datetime
 from ggrc.extensions import get_extension_modules
 from ggrc.models import Notification
@@ -71,9 +70,8 @@ def get_pending_notifications():
   today = datetime.combine(date.today(), datetime.min.time())
   for day, notif in notif_by_day.iteritems():
     current_day = max(day, today)
-    with freeze_time(current_day):
-      data[current_day] = merge_dict(data[current_day],
-                                     get_notification_data(notif))
+    data[current_day] = merge_dict(data[current_day],
+                                   get_notification_data(notif))
 
   return notifications, data
 

--- a/src/ggrc_workflows/views/__init__.py
+++ b/src/ggrc_workflows/views/__init__.py
@@ -75,21 +75,6 @@ def set_notification_sent_time(notifications):
   db.session.commit()
 
 
-def send_pending_notifications():
-  digest_template = env.get_template("notifications/email_digest.html")
-  notifications, notif_data = notification.get_pending_notifications()
-  sent_emails = []
-  for day, day_notif in notif_data.iteritems():
-    subject = "gGRC daily digest for {}".format(day.strftime("%b %d"))
-    for user_email, data in day_notif.iteritems():
-      data = modify_data(data)
-      email_body = digest_template.render(digest=data)
-      email.send_email(user_email, subject, email_body)
-      sent_emails.append(user_email)
-  set_notification_sent_time(notifications)
-  return "emails sent to: <br> {}".format("<br>".join(sent_emails))
-
-
 def send_todays_digest_notifications():
   digest_template = env.get_template("notifications/email_digest.html")
   notifications, notif_data = notification.get_todays_notifications()
@@ -116,10 +101,6 @@ def init_extra_views(app):
   app.add_url_rule(
       "/_notifications/show_todays_digest", "show_todays_digest_notifications",
       view_func=login_required(show_todays_digest_notifications))
-
-  app.add_url_rule(
-      "/_notifications/send_pending", "send_pending_notifications",
-      view_func=login_required(send_pending_notifications))
 
   app.add_url_rule(
       "/_notifications/send_todays_digest", "send_todays_digest_notifications",

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -32,4 +32,3 @@ python-dateutil==2.2
 MonthDelta==0.9.1
 babel==1.3
 pytz==2015.2
-freezegun==0.3.1


### PR DESCRIPTION
Freezegun seems to cause key errors with handling dates even when it's not
used, so we will only have it in the dev enviroment for testing.

This commit will break the dates in show pending notifications, which
will not be relative to the send date anymore. That is still better than
having server errors while trying to send digest notifications.