### PR TITLE
CORE-1771 Prevent infinite recursion when opening New Audit modal

### DIFF
--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -1921,7 +1921,7 @@ Mustache.registerHelper('default_audit_title', function (instance, options) {
     // Mark the title to be populated when computed_program is defined,
     // returning an empty string here would disable the save button.
     instance.attr('title', '');
-    instance.attr('_transient', {default_title: instance.title});
+    instance.attr('_transient.default_title', instance.title);
     return;
   }
   if (instance._transient.default_title !== instance.title) {

--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -1938,7 +1938,8 @@ Mustache.registerHelper("default_audit_title", function (instance, options) {
       index = result.getCountFor("Audit") + 1;
       title = title + " " + index;
       instance.attr("title", title);
-      instance.attr("_transient.default_title", instance.title);
+      // this needs to be different than above, otherwise CanJS throws a strange error
+      instance.attr("_transient", {default_title: instance.title});
     });
   });
 });


### PR DESCRIPTION
When @hyperNURb fixed CORE-1732, a script error appearing when saving Audits, that introduced another script error when opening a New Audit modal. The error appeared if you did this anywhere *but* a program's page.

I seem to have fixed it so @hyperNURb's case still works, but so that CORE-1771 also works.

Worryingly, I have no idea *why* it works this way.