### PR TITLE
CORE-1775 Fix script error when deleting objects

### DIFF
--- a/src/ggrc/assets/javascripts/models/mappers.js
+++ b/src/ggrc/assets/javascripts/models/mappers.js
@@ -1112,7 +1112,7 @@
       }
 
     , get_instance_from_mapping: function(binding, mapping) {
-        return mapping[this.option_attr].reify();
+        return mapping[this.options_attr] && mapping[this.option_attr].reify();
       }
 
     , find_result_from_mapping: function(binding, mapping) {


### PR DESCRIPTION
If you deleted object A that was mapped to object B,
then tried to delete object B without refreshing the page
it caused an error because there was a hanging reference left.

Now get_instance_from_mapping returns undefined when
a hanging reference is encountered instead of erroring out.
This is be easier for the calling code to deal with.