### PR TITLE
CORE-1758 Add migration to prevent null assignee values for tasks and related t…

### DIFF
--- a/src/ggrc_workflows/migrations/versions/20150513061634_17f4ddff502e_disable_task_assignee_nullification.py
+++ b/src/ggrc_workflows/migrations/versions/20150513061634_17f4ddff502e_disable_task_assignee_nullification.py
@@ -1,0 +1,43 @@
+
+"""Disable task assignee nullification
+
+Revision ID: 17f4ddff502e
+Revises: 2b89912f95f1
+Create Date: 2015-05-13 06:16:34.895339
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '17f4ddff502e'
+down_revision = '2b89912f95f1'
+
+from alembic import op
+import sqlalchemy as sa
+
+tables = ["cycle_task_group_object_tasks", "cycle_task_group_objects",
+          "cycle_task_groups", "task_group_tasks", "task_groups"]
+
+def upgrade():
+    for table in tables:
+        op.execute("""
+        UPDATE %s
+        SET contact_id=(
+           SELECT person_id FROM user_roles
+           WHERE role_id=(SELECT id FROM roles
+                          WHERE name="gGRC Admin")
+           ORDER BY created_at  ASC
+           LIMIT 1
+        )
+        WHERE contact_id IS NULL;
+        """ % table)
+
+        op.execute("""
+        ALTER TABLE %s MODIFY contact_id int(11) NOT NULL
+        """ % table)
+
+
+def downgrade():
+    for table in tables:
+        op.execute("""
+        ALTER TABLE %s MODIFY contact_id int(11);
+        """ % table)

--- a/src/ggrc_workflows/migrations/versions/20150513061634_17f4ddff502e_disable_task_assignee_nullification.py
+++ b/src/ggrc_workflows/migrations/versions/20150513061634_17f4ddff502e_disable_task_assignee_nullification.py
@@ -17,19 +17,56 @@ import sqlalchemy as sa
 tables = ["cycle_task_group_object_tasks", "cycle_task_group_objects",
           "cycle_task_groups", "task_group_tasks", "task_groups"]
 
+def get_first_admin():
+    conn = op.get_bind()
+
+    res = conn.execute("""
+    SELECT id FROM people
+    WHERE email="prasannav@google.com"
+    ORDER BY created_at ASC
+    LIMIT 1
+    """)
+    prasanna = res.fetchall()
+
+    if len(prasanna):
+        return prasanna[0][0]
+
+    res = conn.execute("""
+    SELECT person_id FROM user_roles
+    WHERE role_id=(SELECT id FROM roles
+                   WHERE name="Superuser")
+    ORDER BY created_at  ASC
+    LIMIT 1
+    """)
+    superuser = res.fetchall()
+
+    if len(superuser):
+        return superuser[0][0]
+
+
+    res = conn.execute("""
+    SELECT person_id FROM user_roles
+    WHERE role_id=(SELECT id FROM roles
+                   WHERE name="gGRC Admin")
+    ORDER BY created_at  ASC
+    LIMIT 1
+    """)
+    admin = res.fetchall()
+
+    if len(admin):
+        return admin[0][0]
+
+    raise LookupError("Can't find default admin user")
+
 def upgrade():
+    first_admin_id = get_first_admin()
+
     for table in tables:
         op.execute("""
         UPDATE %s
-        SET contact_id=(
-           SELECT person_id FROM user_roles
-           WHERE role_id=(SELECT id FROM roles
-                          WHERE name="gGRC Admin")
-           ORDER BY created_at  ASC
-           LIMIT 1
-        )
+        SET contact_id=%d
         WHERE contact_id IS NULL;
-        """ % table)
+        """ % (table, first_admin_id))
 
         op.execute("""
         ALTER TABLE %s MODIFY contact_id int(11) NOT NULL


### PR DESCRIPTION
I've implemented a migration that makes it so `contact_id` cannot be null in any tables related to tasks. It also makes sure any `contact_id` that is currently null gets set to the first Admin in the database.

But I have two problems:
   * how do I make Prasanna default in the absence of such an Admin?
   * in the dev environment, `user@example.com` is an Admin, but isn't in the `user_roles` table as such

I think @zidarsk8 is the likeliest to be able to help with SQL magic.