### PR TITLE
QUICK-FIX Add all nightly cron jobs to one endpoint

### DIFF
--- a/src/cron.yaml
+++ b/src/cron.yaml
@@ -5,13 +5,7 @@
 #
 # See https://developers.google.com/appengine/docs/python/config/appconfig
 
-cron:
-- description: gGRC daily notification email digests
-  url: /_notifications/send_todays_digest
-  schedule: every day 01:00
-  timezone: US/Pacific
-
-- description: gGRC workflow - start cycles for workflows with a new period starting today
-  url: /start_recurring_cycles
+- description: gGRC workflow - starting point for all batch jobs
+  url: /nightly_cron_endpoint
   schedule: every day 12:01
   timezone: US/Pacific

--- a/src/ggrc_workflows/views/__init__.py
+++ b/src/ggrc_workflows/views/__init__.py
@@ -20,6 +20,12 @@ env = Environment(loader=PackageLoader('ggrc_workflows', 'templates'))
 # module.
 
 
+def nightly_cron_endpoint():
+  start_recurring_cycles()
+  send_todays_digest_notifications()
+  return 'Ok'
+
+
 def modify_data(data):
   """
   for easyer use in templates, it joins the due_in and due today fields
@@ -40,11 +46,6 @@ def modify_data(data):
         data["cycle_started_tasks"].update(cycle["my_tasks"])
 
   return data
-
-
-def do_start_recurring_cycles():
-  start_recurring_cycles()
-  return 'Ok'
 
 
 def show_pending_notifications():
@@ -91,8 +92,8 @@ def send_todays_digest_notifications():
 
 def init_extra_views(app):
   app.add_url_rule(
-      "/start_recurring_cycles", "start_recurring_cycles",
-      view_func=do_start_recurring_cycles)
+      "/nightly_cron_endpoint", "nightly_cron_endpoint",
+      view_func=nightly_cron_endpoint)
 
   app.add_url_rule(
       "/_notifications/show_pending", "show_pending_notifications",


### PR DESCRIPTION
We need to make sure one cron job is executed after the previous one has
finished. Instead of doing that with an arbitrary time gap, we should
just run them in one cron endpoint and make sure we call all the cron
jobs in the rigth order.