### PR TITLE
QUICK-FIX Disable instant notification checkbox

### DIFF
--- a/src/ggrc/assets/javascripts/dashboard.js
+++ b/src/ggrc/assets/javascripts/dashboard.js
@@ -345,7 +345,7 @@ jQuery(function($) {
 
   $('body').on('click', 'input[name=notifications]', function(ev, el){
     var li = $(ev.target).closest('.notify-wrap'),
-        inputs = li.find('input'),
+        inputs = li.find('input[name=notifications]'),
         active = [];
 
     inputs.prop('disabled', true);

--- a/src/ggrc/templates/layouts/dashboard.haml
+++ b/src/ggrc/templates/layouts/dashboard.haml
@@ -67,11 +67,12 @@
                       %i.grcicon-alarm-black
                       Notifications
                     %div.inner-list
-                      %label
+                      %label{style: "opacity: .6"}
                         %input{
                           'type': 'checkbox',
-                          'name': 'notifications',
-                          'value': 'Email_Now'
+                          'name': 'notifications_disabled',
+                          'value': 'Email_Now',
+                          'disabled': 'true'
                         }
                         Real-time email updates
                       %label


### PR DESCRIPTION
Cancel all click events as soon as they happen, make sure the javascript doesn't pick up on the checkbox being there, and make it appear translucent so users can tell it's disabled.