### PR TITLE
QUICK-FIX Ignore real time updates flag

### DIFF
--- a/src/ggrc/notification/__init__.py
+++ b/src/ggrc/notification/__init__.py
@@ -115,6 +115,6 @@ def should_receive(notif, force_notif, person_id, nightly_cron=True):
     return result.one().enable_flag
 
   has_instant = force_notif or is_enabled("Email_Now")
-  has_digest = has_instant or is_enabled("Email_Digest")
+  has_digest = force_notif or is_enabled("Email_Digest")
 
   return has_digest


### PR DESCRIPTION
This code vas done for future releases where you can not have real time
updates without having email digest first. In grapes the real time
updates are disabled and this is a fix to ignore all flags that users
already have in the database.