### PR TITLE
CORE-1800 Fix info pin jumpines

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
@@ -430,10 +430,12 @@ can.Control("CMS.Controllers.InnerNav", {
       widget = this.widget_by_selector(widget);
     }
 
-    widget.attr("force_show", true);
-    this.update_add_more_link();
-    this.options.contexts.attr("active_widget", widget);
-    this.show_active_widget();
+    if (widget !== this.options.contexts.attr("active_widget")) {
+      widget.attr("force_show", true);
+      this.update_add_more_link();
+      this.options.contexts.attr("active_widget", widget);
+      this.show_active_widget();
+    }
   }
 
   , show_active_widget: function (selector) {
@@ -445,7 +447,7 @@ can.Control("CMS.Controllers.InnerNav", {
     if (info_pin_controller) {
       info_pin_controller.hideInstance();
     }
-
+      
     if (widget.length) {
       dashboard_controller.show_widget_area();
       widget.siblings(':visible').hide().end().show();


### PR DESCRIPTION
Changing the URL called set_active_widget, this then called show_active_widget,
this then reset info pin from scratch. There is no need to reset active widget
when setting to the same as before. As a result this fixes info pin jumpines.