### PR TITLE
CORE-1863 Add endpoint to generate csv import template

### DIFF
--- a/src/ggrc/converters/__init__.py
+++ b/src/ggrc/converters/__init__.py
@@ -3,11 +3,11 @@
 # Created By: dan@reciprocitylabs.com
 # Maintained By: dan@reciprocitylabs.com
 
-from .sections import SectionsConverter
+from ggrc.converters.sections import SectionsConverter
 
-all_converters = [
-    ('sections', SectionsConverter)
-    ]
+all_converters = [('sections', SectionsConverter)]
+
+HANDLERS = {}
 
 def get_converter(name):
   return all_converters(name)

--- a/src/ggrc/converters/__init__.py
+++ b/src/ggrc/converters/__init__.py
@@ -4,10 +4,58 @@
 # Maintained By: dan@reciprocitylabs.com
 
 from ggrc.converters.sections import SectionsConverter
+from ggrc.models import (
+    Audit, Control, ControlAssessment, DataAsset, Directive, Contract,
+    Policy, Regulation, Standard, Facility, Market, Objective, Option,
+    OrgGroup, Vendor, Person, Product, Program, Project, Request, Response,
+    Section, Clause, System, Process, Issue,
+)
+
 
 all_converters = [('sections', SectionsConverter)]
 
 HANDLERS = {}
 
+
 def get_converter(name):
   return all_converters(name)
+
+COLUMN_ORDER = (
+    "slug",
+    "title",
+    "description",
+    "notes",
+    "owners",
+)
+
+IMPORTABLE = {
+    "audit": Audit,
+    "control": Control,
+    "control assessment": ControlAssessment,
+    "control_assessment": ControlAssessment,
+    "data asset": DataAsset,
+    "data_asset": DataAsset,
+    "directive": Directive,
+    "contract": Contract,
+    "policy": Policy,
+    "regulation": Regulation,
+    "standard": Standard,
+    "facility": Facility,
+    "market": Market,
+    "objective": Objective,
+    "option": Option,
+    "org group": OrgGroup,
+    "org_group": OrgGroup,
+    "vendor": Vendor,
+    "person": Person,
+    "product": Product,
+    "program": Program,
+    "project": Project,
+    "request": Request,
+    "response": Response,
+    "section": Section,
+    "clause": Clause,
+    "system": System,
+    "process": Process,
+    "issue": Issue,
+}

--- a/src/ggrc/converters/base_row.py
+++ b/src/ggrc/converters/base_row.py
@@ -424,8 +424,7 @@ class ContactEmailHandler(ColumnHandler):
 class AssigneeHandler(ContactEmailHandler):
 
   def parse_item(self, value):
-    # in case Assignee field does not exist or stripped version is empty
-    if not value or len(value.strip()) == 0:
+    if not value or not value.strip():
       # Use current request owner if there is one
       current_request_assignee = self.importer.obj.assignee
       if current_request_assignee:

--- a/src/ggrc/converters/common.py
+++ b/src/ggrc/converters/common.py
@@ -1,21 +1,23 @@
-# Copyright (C) 2013 Google Inc., authors, and contributors <see AUTHORS file>
+# Copyright (C) 2015 Google Inc., authors, and contributors <see AUTHORS file>
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 # Created By: dan@reciprocitylabs.com
-# Maintained By: dan@reciprocitylabs.com
+# Maintained By: miha@reciprocitylabs.com
 
 import re
 
-# Temporary as I test new import functionality
-DEBUG_IMPORT = True
 
 def prepare_slug(slug):
-  return re.sub(r'\r|\n'," ", slug.strip())
+  return re.sub(r'\r|\n', " ", slug.strip())
+
 
 class ImportException(Exception):
+
   def __init__(self, message, show_preview=False, converter=None):
     self.message = message
     self.show_preview = show_preview
     self.converter = converter
 
   def __str__(self):
-    return self.message if self.message else "Could not import: verify the file is correctly formatted."
+    if self.message:
+      return self.message
+    return "Import error: verify the file is correctly formatted."

--- a/src/ggrc/converters/import_helper.py
+++ b/src/ggrc/converters/import_helper.py
@@ -11,6 +11,7 @@ from StringIO import StringIO
 
 from ggrc.converters import base_row
 from ggrc.converters import HANDLERS
+from ggrc.converters import COLUMN_ORDER
 from ggrc.converters.common import ImportException
 from ggrc.models import Directive
 from ggrc.models.reflection import AttributeInfo
@@ -28,6 +29,7 @@ def get_custom_attributes_definitions(target_class):
         "handler": handler,
         "validator": None,
         "default": None,
+        "description": "",
     }
   return definitions
 
@@ -60,6 +62,7 @@ def get_object_column_definitions(target_class):
         "handler": getattr(target_class, "default_{}".format(key), None),
         "validator": getattr(target_class, "validate_{}".format(key), None),
         "default": HANDLERS.get(key, base_row.ColumnHandler),
+        "description": "",
     }
 
     if type(value) is dict:
@@ -149,3 +152,16 @@ def handle_converter_csv_export(filename, objects, converter_class, **options):
   body = output_buffer.getvalue()
   output_buffer.close()
   return current_app.make_response((body, 200, headers))
+
+
+def generate_array(width, height, value=None):
+  return [[value for _ in range(width)] for _ in range(height)]
+
+
+def get_column_order(attr_list):
+  def sort_index(item):
+    if item in COLUMN_ORDER:
+      return COLUMN_ORDER.index(item)
+    else:
+      return len(COLUMN_ORDER)
+  return sorted(attr_list, key=sort_index)

--- a/src/ggrc/models/audit.py
+++ b/src/ggrc/models/audit.py
@@ -65,7 +65,7 @@ class Audit(
   _include_links = []
 
   _aliases = {
-      "map:program": "Program",
+      "program_id": "Program",
       "user_role:Auditor": "Auditors",
       "status": "Status",
       "start_date": "Planned Start Date",

--- a/src/ggrc/models/audit.py
+++ b/src/ggrc/models/audit.py
@@ -7,7 +7,7 @@ from ggrc import db
 from .mixins import (
     deferred, Timeboxed, Noted, Described, Hyperlinked, WithContact,
     Titled, Slugged, CustomAttributable
-    )
+)
 from .relationship import Relatable
 from .object_person import Personable
 from .context import HasOwnContext
@@ -15,24 +15,25 @@ from .reflection import PublishOnly
 
 
 class Audit(
-    CustomAttributable, Personable, HasOwnContext, Relatable,
-    Timeboxed, Noted, Described, Hyperlinked, WithContact, Titled, Slugged,
-    db.Model):
+        CustomAttributable, Personable, HasOwnContext, Relatable,
+        Timeboxed, Noted, Described, Hyperlinked, WithContact, Titled, Slugged,
+        db.Model):
   __tablename__ = 'audits'
   _slug_uniqueness = False
 
   VALID_STATES = (
       u'Planned', u'In Progress', u'Manager Review',
       u'Ready for External Review', u'Completed'
-      )
+  )
 
   report_start_date = deferred(db.Column(db.Date), 'Audit')
   report_end_date = deferred(db.Column(db.Date), 'Audit')
   audit_firm_id = deferred(
       db.Column(db.Integer, db.ForeignKey('org_groups.id')), 'Audit')
   audit_firm = db.relationship('OrgGroup', uselist=False)
+  # TODO: this should be stateful mixin
   status = deferred(db.Column(db.Enum(*VALID_STATES), nullable=False),
-    'Audit')
+                    'Audit')
   gdrive_evidence_folder = deferred(db.Column(db.String), 'Audit')
   program_id = deferred(
       db.Column(db.Integer, db.ForeignKey('programs.id'), nullable=False),
@@ -41,28 +42,46 @@ class Audit(
       'Request', backref='audit', cascade='all, delete-orphan')
   audit_objects = db.relationship(
       'AuditObject', backref='audit', cascade='all, delete-orphan')
-  object_type = db.Column(db.String(length=250), nullable=False, default='Control')
+  object_type = db.Column(
+      db.String(length=250), nullable=False, default='Control')
 
   _publish_attrs = [
-    'report_start_date',
-    'report_end_date',
-    'audit_firm',
-    'status',
-    'gdrive_evidence_folder',
-    'program',
-    'requests',
-    'object_type',
-    PublishOnly('audit_objects')
-    ]
+      'report_start_date',
+      'report_end_date',
+      'audit_firm',
+      'status',
+      'gdrive_evidence_folder',
+      'program',
+      'requests',
+      'object_type',
+      PublishOnly('audit_objects')
+  ]
 
   _sanitize_html = [
-    'gdrive_evidence_folder',
-    'description',
-    ]
+      'gdrive_evidence_folder',
+      'description',
+  ]
 
-  _include_links = [
-    #'requests',
-    ]
+  _include_links = []
+
+  _aliases = {
+      "map:program": "Program",
+      "user_role:Auditor": "Auditors",
+      "status": "Status",
+      "start_date": "Planned Start Date",
+      "end_date": "Planned End Date",
+      "report_start_date": "Planned Report Period from",
+      "report_end_date": "Planned Report Period to",
+      "contact": {
+          "display_name": "Internal Audit Lead",
+          "mandatory": True
+      },
+      "slug": None,
+      "secondary_contact": None,
+      "notes": None,
+      "url": None,
+      "reference_url": None,
+  }
 
   @classmethod
   def eager_query(cls):
@@ -70,6 +89,6 @@ class Audit(
 
     query = super(Audit, cls).eager_query()
     return query.options(
-      orm.joinedload('program'),
-      orm.subqueryload('requests'),
-      orm.subqueryload('object_people').joinedload('person'))
+        orm.joinedload('program'),
+        orm.subqueryload('requests'),
+        orm.subqueryload('object_people').joinedload('person'))

--- a/src/ggrc/models/control.py
+++ b/src/ggrc/models/control.py
@@ -38,6 +38,7 @@ class ControlAssertion(CategoryBase):
 
 
 class ControlCategorized(Categorizable):
+
   @declared_attr
   def categorizations(cls):
     return cls.declare_categorizable(
@@ -50,6 +51,8 @@ class ControlCategorized(Categorizable):
 
   _include_links = []
 
+  _aliases = {"categories": "Categories"}
+
   @classmethod
   def eager_query(cls):
     from sqlalchemy import orm
@@ -60,6 +63,7 @@ class ControlCategorized(Categorizable):
 
 
 class AssertionCategorized(Categorizable):
+
   @declared_attr
   def assertations(cls):
     return cls.declare_categorizable(
@@ -69,8 +73,8 @@ class AssertionCategorized(Categorizable):
       'assertions',
       PublishOnly('assertations'),
   ]
-
   _include_links = []
+  _aliases = {"assertions": "Assertions"}
 
   @classmethod
   def eager_query(cls):
@@ -110,17 +114,17 @@ class Control(HasObjectState, Relatable, CustomAttributable, Documentable,
 
   kind = db.relationship(
       'Option',
-      primaryjoin='and_(foreign(Control.kind_id) == Option.id, '\
+      primaryjoin='and_(foreign(Control.kind_id) == Option.id, '
                   'Option.role == "control_kind")',
       uselist=False)
   means = db.relationship(
       'Option',
-      primaryjoin='and_(foreign(Control.means_id) == Option.id, '\
+      primaryjoin='and_(foreign(Control.means_id) == Option.id, '
                   'Option.role == "control_means")',
       uselist=False)
   verify_frequency = db.relationship(
       'Option',
-      primaryjoin='and_(foreign(Control.verify_frequency_id) == Option.id, '\
+      primaryjoin='and_(foreign(Control.verify_frequency_id) == Option.id, '
                   'Option.role == "verify_frequency")',
       uselist=False)
 
@@ -153,6 +157,17 @@ class Control(HasObjectState, Relatable, CustomAttributable, Documentable,
   ]
 
   _include_links = []
+
+  _aliases = {
+      "url": "Control URL",
+      "kind": "Kind/Nature",
+      "means": "Type/Means",
+      "verify_frequency": "Frequency",
+      "fraud_related": "Fraud Related",
+      "principal_assessor": "Principal Assessor",
+      "secondary_assessor": "Secondary Assessor",
+      "key_control": "Significance",
+  }
 
   @validates('kind', 'means', 'verify_frequency')
   def validate_control_options(self, key, option):

--- a/src/ggrc/models/control_assessment.py
+++ b/src/ggrc/models/control_assessment.py
@@ -3,16 +3,21 @@
 # Created By: anze@reciprocitylabs.com
 # Maintained By: anze@reciprocitylabs.com
 
+from sqlalchemy.orm import validates
+
 from ggrc import db
-from .mixins import (
-    deferred, BusinessObject, Timeboxed, CustomAttributable, TestPlanned
-)
-from .object_document import Documentable
-from .object_owner import Ownable
-from .object_person import Personable
-from .relationship import Relatable
-from .track_object_state import HasObjectState, track_state_for_class
+from ggrc.models.mixins import BusinessObject
+from ggrc.models.mixins import CustomAttributable
+from ggrc.models.mixins import TestPlanned
+from ggrc.models.mixins import Timeboxed
+from ggrc.models.mixins import deferred
+from ggrc.models.object_document import Documentable
+from ggrc.models.object_owner import Ownable
+from ggrc.models.object_person import Personable
 from ggrc.models.reflection import PublishOnly
+from ggrc.models.relationship import Relatable
+from ggrc.models.track_object_state import HasObjectState
+from ggrc.models.track_object_state import track_state_for_class
 
 
 class ControlAssessment(HasObjectState, TestPlanned, CustomAttributable,
@@ -28,6 +33,11 @@ class ControlAssessment(HasObjectState, TestPlanned, CustomAttributable,
 
   audit = {}  # we add this for the sake of client side error checking
 
+  VALID_CONCLUSIONS = frozenset([
+      "Effective", "Material weakness", "Needs improvement",
+      "Significant deficiency", "Not Applicable"
+  ])
+
   # REST properties
   _publish_attrs = [
       'design',
@@ -35,6 +45,31 @@ class ControlAssessment(HasObjectState, TestPlanned, CustomAttributable,
       'control',
       PublishOnly('audit')
   ]
+
+  _aliases = {
+      "control": {
+          "display_name": "Control",
+          "mandatory": True,
+      },
+      "audit": {
+          "display_name": "Audit",
+          "mandatory": True,
+      },
+      "url": "Assessment URL",
+      "design": "Conclusion: Design",
+      "operationally": "Conclusion: Operation",
+  }
+
+  def validate_conclusion(self, value):
+    return value if value in self.VALID_CONCLUSIONS else ""
+
+  @validates("operationally")
+  def validate_opperationally(self, value):
+    return self.validate_conclusion(value)
+
+  @validates("design")
+  def validate_design(self, value):
+    return self.validate_conclusion(value)
 
   @classmethod
   def eager_query(cls):

--- a/src/ggrc/models/data_asset.py
+++ b/src/ggrc/models/data_asset.py
@@ -17,4 +17,6 @@ class DataAsset(HasObjectState,
                 Timeboxed, Ownable, BusinessObject, db.Model):
   __tablename__ = 'data_assets'
 
+  _aliases = {"url": "Data Asset URL"}
+
 track_state_for_class(DataAsset)

--- a/src/ggrc/models/directive.py
+++ b/src/ggrc/models/directive.py
@@ -35,13 +35,13 @@ class Directive(HasObjectState, Timeboxed, BusinessObject, db.Model):
       'Control', backref='directive', order_by='Control.slug')
   audit_frequency = db.relationship(
       'Option',
-      primaryjoin='and_(foreign(Directive.audit_frequency_id) == Option.id, '\
+      primaryjoin='and_(foreign(Directive.audit_frequency_id) == Option.id, '
                   'Option.role == "audit_frequency")',
       uselist=False,
   )
   audit_duration = db.relationship(
       'Option',
-      primaryjoin='and_(foreign(Directive.audit_duration_id) == Option.id, '\
+      primaryjoin='and_(foreign(Directive.audit_duration_id) == Option.id, '
                   'Option.role == "audit_duration")',
       uselist=False,
   )
@@ -70,11 +70,13 @@ class Directive(HasObjectState, Timeboxed, BusinessObject, db.Model):
 
   _include_links = []
 
+  _aliases = {'kind': "Kind/Type", }
+
   @validates('kind')
   def validate_kind(self, key, value):
     if not value:
       return None
-    if value not in self.valid_kinds:
+    if value not in self.VALID_KINDS:
       message = "Invalid value '{}' for attribute {}.{}.".format(
                 value, self.__class__.__name__, key)
       raise ValueError(message)
@@ -108,11 +110,15 @@ class Policy(CustomAttributable, Relatable, Documentable,
   __mapper_args__ = {
       'polymorphic_identity': 'Policy'
   }
+
   _table_plural = 'policies'
-  valid_kinds = (
+
+  VALID_KINDS = frozenset([
       "Company Policy", "Org Group Policy", "Data Asset Policy",
       "Product Policy", "Contract-Related Policy", "Company Controls Policy"
-  )
+  ])
+
+  _aliases = {"url": "Policy URL"}
 
   @validates('meta_kind')
   def validates_meta_kind(self, key, value):
@@ -124,8 +130,15 @@ class Regulation(CustomAttributable, Relatable, Documentable,
   __mapper_args__ = {
       'polymorphic_identity': 'Regulation'
   }
+
   _table_plural = 'regulations'
-  valid_kinds = ("Regulation",)
+
+  VALID_KINDS = ("Regulation",)
+
+  _aliases = {
+      "url": "Regulation URL",
+      "kind": None,
+  }
 
   @validates('meta_kind')
   def validates_meta_kind(self, key, value):
@@ -137,8 +150,15 @@ class Standard(CustomAttributable, Relatable, Documentable,
   __mapper_args__ = {
       'polymorphic_identity': 'Standard'
   }
+
   _table_plural = 'standards'
-  valid_kinds = ("Standard",)
+
+  VALID_KINDS = ("Standard",)
+
+  _aliases = {
+      "url": "Standard URL",
+      "kind": None,
+  }
 
   @validates('meta_kind')
   def validates_meta_kind(self, key, value):
@@ -150,8 +170,15 @@ class Contract(CustomAttributable, Relatable, Documentable,
   __mapper_args__ = {
       'polymorphic_identity': 'Contract'
   }
+
   _table_plural = 'contracts'
-  valid_kinds = ("Contract",)
+
+  VALID_KINDS = ("Contract",)
+
+  _aliases = {
+      "url": "Contract URL",
+      "kind": None,
+  }
 
   @validates('meta_kind')
   def validates_meta_kind(self, key, value):

--- a/src/ggrc/models/document.py
+++ b/src/ggrc/models/document.py
@@ -3,11 +3,14 @@
 # Created By: david@reciprocitylabs.com
 # Maintained By: david@reciprocitylabs.com
 
-from ggrc import db
 from sqlalchemy.orm import validates
-from .mixins import deferred, Base
-from .object_owner import Ownable
-from .utils import validate_option
+
+from ggrc import db
+from ggrc.models.mixins import deferred
+from ggrc.models.mixins import Base
+from ggrc.models.object_owner import Ownable
+from ggrc.models.utils import validate_option
+
 
 class Document(Ownable, Base, db.Model):
   __tablename__ = 'documents'
@@ -19,31 +22,33 @@ class Document(Ownable, Base, db.Model):
   year_id = deferred(db.Column(db.Integer), 'Document')
   language_id = deferred(db.Column(db.Integer), 'Document')
 
-  object_documents = db.relationship('ObjectDocument', backref='document', cascade='all, delete-orphan')
+  object_documents = db.relationship(
+      'ObjectDocument', backref='document', cascade='all, delete-orphan')
   kind = db.relationship(
       'Option',
-      primaryjoin='and_(foreign(Document.kind_id) == Option.id, '\
-                       'Option.role == "reference_type")',
+      primaryjoin='and_(foreign(Document.kind_id) == Option.id, '
+      'Option.role == "reference_type")',
       uselist=False,
-      )
+  )
   year = db.relationship(
       'Option',
-      primaryjoin='and_(foreign(Document.year_id) == Option.id, '\
-                       'Option.role == "document_year")',
+      primaryjoin='and_(foreign(Document.year_id) == Option.id, '
+      'Option.role == "document_year")',
       uselist=False,
-      )
+  )
   language = db.relationship(
       'Option',
-      primaryjoin='and_(foreign(Document.language_id) == Option.id, '\
-                       'Option.role == "language")',
+      primaryjoin='and_(foreign(Document.language_id) == Option.id, '
+      'Option.role == "language")',
       uselist=False,
-      )
+  )
 
   _fulltext_attrs = [
       'title',
       'link',
       'description',
-      ]
+  ]
+
   _publish_attrs = [
       'title',
       'link',
@@ -52,16 +57,23 @@ class Document(Ownable, Base, db.Model):
       'kind',
       'year',
       'language',
-      ]
+  ]
+
   _sanitize_html = [
       'title',
       'description',
-      ]
+  ]
+
+  _aliases = {
+      'title': "Title",
+      'link': "Link",
+      'description': "description",
+  }
 
   @validates('kind', 'year', 'language')
   def validate_document_options(self, key, option):
     if key == 'year':
-      desired_role  = 'document_year'
+      desired_role = 'document_year'
     elif key == 'kind':
       desired_role = 'reference_type'
     else:

--- a/src/ggrc/models/facility.py
+++ b/src/ggrc/models/facility.py
@@ -17,5 +17,6 @@ class Facility(HasObjectState,
                Relatable, Timeboxed, Ownable,
                BusinessObject, db.Model):
   __tablename__ = 'facilities'
+  _aliases = {"url": "Facility URL"}
 
 track_state_for_class(Facility)

--- a/src/ggrc/models/issue.py
+++ b/src/ggrc/models/issue.py
@@ -24,4 +24,6 @@ class Issue(HasObjectState, TestPlanned, CustomAttributable, Documentable,
   _publish_attrs = [
   ]
 
+  _aliases = {"url": "Issue URL"}
+
 track_state_for_class(Issue)

--- a/src/ggrc/models/market.py
+++ b/src/ggrc/models/market.py
@@ -16,5 +16,6 @@ class Market(HasObjectState, CustomAttributable, Documentable, Personable,
              Relatable, Timeboxed, Ownable,
              BusinessObject, db.Model):
   __tablename__ = 'markets'
+  _aliases = {"url": "Market URL"}
 
 track_state_for_class(Market)

--- a/src/ggrc/models/mixins.py
+++ b/src/ggrc/models/mixins.py
@@ -204,6 +204,7 @@ class Titled(object):
   _publish_attrs = ['title']
   _fulltext_attrs = ['title']
   _sanitize_html = ['title']
+  _aliases = {"title": "Title"}
 
 
 class Described(object):
@@ -216,6 +217,7 @@ class Described(object):
   _publish_attrs = ['description']
   _fulltext_attrs = ['description']
   _sanitize_html = ['description']
+  _aliases = {"description": "Description"}
 
 
 class Noted(object):
@@ -228,6 +230,7 @@ class Noted(object):
   _publish_attrs = ['notes']
   _fulltext_attrs = ['notes']
   _sanitize_html = ['notes']
+  _aliases = {"notes": "Notes"}
 
 
 class Hyperlinked(object):
@@ -242,6 +245,11 @@ class Hyperlinked(object):
 
   # REST properties
   _publish_attrs = ['url', 'reference_url']
+
+  _aliases = {
+      "url": "Url",
+      "reference_url": "Reference URL",
+  }
 
 
 class Hierarchical(object):
@@ -290,6 +298,11 @@ class Timeboxed(object):
   # REST properties
   _publish_attrs = ['start_date', 'end_date']
 
+  _aliases = {
+      "start_date": "Effective Date",
+      "end_date": "Stop Date",
+  }
+
 
 class Stateful(object):
 
@@ -299,6 +312,7 @@ class Stateful(object):
         db.Column(db.String, default=cls.default_status), cls.__name__)
 
   _publish_attrs = ['status']
+  _aliases = {"status": "State"}
 
   @classmethod
   def default_status(cls):
@@ -397,6 +411,7 @@ class Slugged(Base):
   _publish_attrs = ['slug']
   _fulltext_attrs = ['slug']
   _sanitize_html = ['slug']
+  _aliases = {"slug": "Code"}
 
   @classmethod
   def generate_slug_for(cls, obj):
@@ -433,10 +448,10 @@ event.listen(
 
 
 class Mapping(Stateful, Base):
-  VALID_STATES = [
+  VALID_STATES = (
       'Draft',
       'Final',
-  ]
+  )
 
 
 class WithContact(object):
@@ -474,11 +489,15 @@ class WithContact(object):
     )
 
   _publish_attrs = ['contact', 'secondary_contact']
+  _aliases = {
+      "contact": "Primary Contact",
+      "secondary_contact": "Secondary Contact",
+  }
 
 
 class BusinessObject(
         Stateful, Noted, Described, Hyperlinked, WithContact, Titled, Slugged):
-  VALID_STATES = [
+  VALID_STATES = (
       'Draft',
       'Final',
       'Effective',
@@ -488,7 +507,7 @@ class BusinessObject(
       'In Scope',
       'Not in Scope',
       'Deprecated',
-  ]
+  )
 
 # This class is just a marker interface/mixin to indicate that a model type
 # supports custom attributes.
@@ -558,16 +577,10 @@ class CustomAttributable(object):
       # av.context_id = cls.context_id
       db.session.add(av)
 
-  _publish_attrs = [
-      'custom_attribute_values',
-      # PublishOnly('custom_attribute_definitions')
-  ]
-  _update_attrs = [
-      'custom_attributes'
-  ]
-  _include_links = [
-      # 'custom_attribute_values',
-  ]
+  _publish_attrs = ['custom_attribute_values', ]
+  _update_attrs = ['custom_attributes']
+  _include_links = []
+  _aliases = {"custom_attributes": "Custom Attributes"}
 
   @declared_attr
   def custom_attribute_definitions(cls):
@@ -586,6 +599,12 @@ class CustomAttributable(object):
         primaryjoin=join_function
     )
 
+  @classmethod
+  def get_custom_attribute_definitions(cls):
+    from ggrc.models.custom_attribute_definition import CustomAttributeDefinition
+    return CustomAttributeDefinition.query.filter(
+        CustomAttributeDefinition.definition_type == cls.__name__).all()
+
 
 class TestPlanned(object):
 
@@ -597,3 +616,4 @@ class TestPlanned(object):
   _publish_attrs = ['test_plan']
   _fulltext_attrs = ['test_plan']
   _sanitize_html = ['test_plan']
+  _aliases = {"test_plan": "Test Plan"}

--- a/src/ggrc/models/objective.py
+++ b/src/ggrc/models/objective.py
@@ -16,9 +16,8 @@ from .relationship import Relatable
 class Objective(HasObjectState, CustomAttributable, Auditable, Relatable,
                 Documentable, Personable, Ownable, BusinessObject, db.Model):
   __tablename__ = 'objectives'
-
   _publish_attrs = []
-
   _include_links = []
+  _aliases = {"url": "Objective URL"}
 
 track_state_for_class(Objective)

--- a/src/ggrc/models/org_group.py
+++ b/src/ggrc/models/org_group.py
@@ -16,5 +16,6 @@ class OrgGroup(HasObjectState, CustomAttributable, Documentable,
                Personable, Relatable, Timeboxed,
                Ownable, BusinessObject, db.Model):
   __tablename__ = 'org_groups'
+  _aliases = {"url": "Org Group URL"}
 
 track_state_for_class(OrgGroup)

--- a/src/ggrc/models/product.py
+++ b/src/ggrc/models/product.py
@@ -32,9 +32,11 @@ class Product(HasObjectState, CustomAttributable, Documentable, Personable,
       'kind',
       'version',
   ]
-  _sanitize_html = [
-      'version',
-  ]
+  _sanitize_html = ['version',]
+  _aliases = {
+    "url": "Product URL",
+    "kind": "Kind/Type",
+  }
 
   @validates('kind')
   def validate_product_options(self, key, option):

--- a/src/ggrc/models/program.py
+++ b/src/ggrc/models/program.py
@@ -18,13 +18,8 @@ class Program(HasObjectState, CustomAttributable, Documentable,
               Ownable, BusinessObject, db.Model):
   __tablename__ = 'programs'
 
-  KINDS = [
-      'Directive',
-  ]
-
-  KINDS_HIDDEN = [
-      'Company Controls Policy',
-  ]
+  KINDS = ['Directive']
+  KINDS_HIDDEN = ['Company Controls Policy']
 
   private = db.Column(db.Boolean, default=False, nullable=False)
   kind = deferred(db.Column(db.String), 'Program')
@@ -37,8 +32,12 @@ class Program(HasObjectState, CustomAttributable, Documentable,
       'audits',
       'private',
   ]
-
   _include_links = []
+  _aliases = {
+    "url": "Program URL",
+    "kind": "Kind/Type",
+    "private": "Privacy",
+  }
 
   @classmethod
   def eager_query(cls):

--- a/src/ggrc/models/project.py
+++ b/src/ggrc/models/project.py
@@ -15,5 +15,6 @@ from .track_object_state import HasObjectState, track_state_for_class
 class Project(HasObjectState, CustomAttributable, Documentable, Personable,
               Relatable, Timeboxed, Ownable, BusinessObject, db.Model):
   __tablename__ = 'projects'
+  _aliases = {"url": "Project URL"}
 
 track_state_for_class(Project)

--- a/src/ggrc/models/reflection.py
+++ b/src/ggrc/models/reflection.py
@@ -1,4 +1,3 @@
-
 # Copyright (C) 2013 Google Inc., authors, and contributors <see AUTHORS file>
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 # Created By: dan@reciprocitylabs.com
@@ -7,7 +6,9 @@
 """Utilties to deal with introspecting gGRC models for publishing, creation,
 and update from resource format representations, such as JSON."""
 
+
 class DontPropagate(object):
+
   """Attributes wrapped by ``DontPropagate`` instances should not be considered
   to be a part of an inherited list. For example, ``_update_attrs`` can be
   inherited from ``_publish_attrs`` if left unspecified. This class provides
@@ -33,25 +34,32 @@ class DontPropagate(object):
     'inherited_attr',
     ]
   """
+
   def __init__(self, attr_name):
     self.attr_name = attr_name
 
+
 class PublishOnly(DontPropagate):
+
   """Alias of ``DontPropagate`` for use in a ``_publish_attrs`` specification.
   """
   pass
 
+
 class AttributeInfo(object):
+
   """Gather model CRUD information by reflecting on model classes. Builds and
   caches a list of the publishing properties for a class by walking the
   class inheritance tree.
   """
+
   def __init__(self, tgt_class):
     self._publish_attrs = AttributeInfo.gather_publish_attrs(tgt_class)
     self._stub_attrs = AttributeInfo.gather_stub_attrs(tgt_class)
     self._update_attrs = AttributeInfo.gather_update_attrs(tgt_class)
     self._create_attrs = AttributeInfo.gather_create_attrs(tgt_class)
     self._include_links = AttributeInfo.gather_include_links(tgt_class)
+    self._aliases = AttributeInfo.gather_aliases(tgt_class)
 
   @classmethod
   def iter_bases_attrs(cls, tgt_class, src_attrs):
@@ -62,7 +70,19 @@ class AttributeInfo(object):
           yield getattr(tgt_class, attr, None)
 
   @classmethod
-  def gather_attrs(cls, tgt_class, src_attrs, accumulator=None, main_class=None):
+  def gather_attr_dicts(cls, tgt_class, src_attr):
+    """ Gather dictionaries from target class parets """
+    result = {}
+    for base_class in tgt_class.__bases__:
+      base_result = cls.gather_attr_dicts(base_class, src_attr)
+      result.update(base_result)
+    attrs = getattr(tgt_class, src_attr, {})
+    result.update(attrs)
+    return result
+
+  @classmethod
+  def gather_attrs(cls, tgt_class, src_attrs, accumulator=None,
+                   main_class=None):
     """Gathers the attrs to be included in a list for publishing, update, or
     some other purpose. Supports inheritance by iterating the list of
     ``src_attrs`` until a list is found.
@@ -87,8 +107,8 @@ class AttributeInfo(object):
         if not ignore_dontpropagate:
           attrs = [a for a in attrs if not isinstance(a, DontPropagate)]
         else:
-          attrs = [a if not isinstance(a, DontPropagate) else a.attr_name for \
-              a in attrs]
+          attrs = [a if not isinstance(a, DontPropagate) else a.attr_name for
+                   a in attrs]
         accumulator.update(attrs)
         break
       else:
@@ -102,6 +122,10 @@ class AttributeInfo(object):
     return cls.gather_attrs(tgt_class, '_publish_attrs')
 
   @classmethod
+  def gather_aliases(cls, tgt_class):
+    return cls.gather_attr_dicts(tgt_class, '_aliases')
+
+  @classmethod
   def gather_stub_attrs(cls, tgt_class):
     return cls.gather_attrs(tgt_class, '_stub_attrs')
 
@@ -113,13 +137,15 @@ class AttributeInfo(object):
   @classmethod
   def gather_create_attrs(cls, tgt_class):
     return cls.gather_attrs(tgt_class, [
-      '_create_attrs', '_update_attrs', '_publish_attrs'])
+        '_create_attrs', '_update_attrs', '_publish_attrs'])
 
   @classmethod
   def gather_include_links(cls, tgt_class):
     return cls.gather_attrs(tgt_class, ['_include_links'])
 
+
 class SanitizeHtmlInfo(AttributeInfo):
+
   def __init__(self, tgt_class):
     self._sanitize_html = SanitizeHtmlInfo.gather_attrs(
         tgt_class, '_sanitize_html')

--- a/src/ggrc/models/section.py
+++ b/src/ggrc/models/section.py
@@ -6,17 +6,17 @@
 from sqlalchemy.orm import validates
 
 from ggrc import db
-from .associationproxy import association_proxy
-from .exceptions import ValidationError
-from .mixins import (
+from ggrc.models.exceptions import ValidationError
+from ggrc.models.mixins import (
     deferred, Hierarchical, Noted, Described, Hyperlinked, WithContact,
     Titled, Slugged, CustomAttributable, Stateful, Timeboxed
 )
-from .object_document import Documentable
-from .object_owner import Ownable
-from .object_person import Personable
-from .relationship import Relatable
-from .track_object_state import HasObjectState, track_state_for_class
+from ggrc.models.object_document import Documentable
+from ggrc.models.object_owner import Ownable
+from ggrc.models.object_person import Personable
+from ggrc.models.relationship import Relatable
+from ggrc.models.track_object_state import track_state_for_class
+from ggrc.models.track_object_state import HasObjectState
 
 
 class SectionBase(HasObjectState, Hierarchical, Noted, Described, Hyperlinked,
@@ -53,11 +53,9 @@ class SectionBase(HasObjectState, Hierarchical, Noted, Described, Hyperlinked,
       'na',
       'notes',
   ]
-  _sanitize_html = [
-      'notes',
-  ]
-
+  _sanitize_html = ['notes']
   _include_links = []
+  _aliases = {"directive_id": "Policy / Regulation / Standard"}
 
   @validates('type')
   def validates_type(self, key, value):
@@ -87,6 +85,10 @@ class Section(CustomAttributable, Documentable, Personable,
       'polymorphic_identity': 'Section'
   }
   _table_plural = 'sections'
+  _aliases = {
+      "url": "Section URL",
+      "description": "Text of Section",
+  }
 
   @validates('directive_id')
   def validates_directive_id(self, key, value):
@@ -107,3 +109,7 @@ class Clause(CustomAttributable, Documentable, Personable, Ownable,
       'polymorphic_identity': 'Clause'
   }
   _table_plural = 'clauses'
+  _aliases = {
+      "url": "Clause URL",
+      "directive_id": None,
+  }

--- a/src/ggrc/models/system.py
+++ b/src/ggrc/models/system.py
@@ -47,9 +47,8 @@ class SystemOrProcess(HasObjectState, Timeboxed, BusinessObject, db.Model):
       'version',
       'network_zone',
   ]
-  _sanitize_html = [
-      'version',
-  ]
+  _sanitize_html = ['version']
+  _aliases = {"network_zone": "Network Zone"}
 
   @validates('network_zone')
   def validate_system_options(self, key, option):
@@ -81,6 +80,8 @@ class System(CustomAttributable, Documentable, Personable,
   }
   _table_plural = 'systems'
 
+  _aliases = {"url": "System URL"}
+
   @validates('is_biz_process')
   def validates_is_biz_process(self, key, value):
     return False
@@ -92,6 +93,8 @@ class Process(CustomAttributable, Documentable, Personable,
       'polymorphic_identity': True
   }
   _table_plural = 'processes'
+
+  _aliases = {"url": "Process URL"}
 
   @validates('is_biz_process')
   def validates_is_biz_process(self, key, value):

--- a/src/ggrc/models/vendor.py
+++ b/src/ggrc/models/vendor.py
@@ -16,4 +16,6 @@ class Vendor(HasObjectState, CustomAttributable, Documentable, Personable,
              Relatable, Timeboxed, Ownable, BusinessObject, db.Model):
   __tablename__ = 'vendors'
 
+  _aliases = {"url": "Vendor URL"}
+
 track_state_for_class(Vendor)

--- a/src/ggrc/views/converters.py
+++ b/src/ggrc/views/converters.py
@@ -16,6 +16,7 @@ from werkzeug.exceptions import Forbidden
 from werkzeug.utils import secure_filename
 import json
 import urllib
+import re
 
 from ggrc.app import app
 from ggrc.converters.common import ImportException
@@ -23,6 +24,9 @@ from ggrc.converters.controls import ControlsConverter
 from ggrc.converters.help import HelpConverter
 from ggrc.converters.import_helper import handle_converter_csv_export
 from ggrc.converters.import_helper import handle_csv_import
+from ggrc.converters.import_helper import generate_array
+from ggrc.converters.import_helper import get_object_column_definitions
+from ggrc.converters.import_helper import get_column_order
 from ggrc.converters.objectives import ObjectivesConverter
 from ggrc.converters.people import PeopleConverter
 from ggrc.converters.requests import RequestsConverter
@@ -49,6 +53,8 @@ from ggrc.rbac import permissions
 from ggrc.utils import view_url_for
 
 _default_context = object()
+
+
 def ensure_read_permissions_for(resource_type, context_id=_default_context):
   if context_id is _default_context:
     context_id = resource_type.context_id
@@ -86,25 +92,28 @@ def import_dump(data):
   # The textarea here is a custom response for 'remoteipart' to
   # proxy a JSON response through an iframe.
   return app.make_response((
-    '<textarea data-type="application/json" response-code="200">{0}</textarea>'.format(
-      json.dumps(data)), 200, [('Content-Type', 'text/html')]))
+      '<textarea data-type="application/json" response-code="200">{0}</textarea>'.format(
+          json.dumps(data)), 200, [('Content-Type', 'text/html')]))
+
 
 def import_redirect(location):
   # The textarea here is a custom response for 'remoteipart' to
   # proxy a JSON response through an iframe.
   return app.make_response((
-    '<textarea data-type="application/json" response-code="200">{0}</textarea>'.format(
-      json.dumps({ 'location': location })), 200, [('Content-Type', 'text/html')]))
+      '<textarea data-type="application/json" response-code="200">{0}</textarea>'.format(
+          json.dumps({'location': location})), 200, [('Content-Type', 'text/html')]))
+
 
 def allowed_file(filename):
   return filename.rsplit('.', 1)[1] == 'csv'
 
 ADMIN_KIND_TEMPLATES = {
-  "processes": "Process_Import_Template.csv",
-  "systems": "System_Import_Template.csv",
-  "people": "People_Import_Template.csv",
-  "help": "Help_Import_Template.csv",
+    "processes": "Process_Import_Template.csv",
+    "systems": "System_Import_Template.csv",
+    "people": "People_Import_Template.csv",
+    "help": "Help_Import_Template.csv",
 }
+
 
 @app.route("/<admin_kind>/import_template", methods=['GET'])
 @login_required
@@ -114,13 +123,14 @@ def process_import_template(admin_kind):
   if admin_kind in ADMIN_KIND_TEMPLATES:
     filename = ADMIN_KIND_TEMPLATES[admin_kind]
     headers = [
-      ('Content-Type', 'text/csv'),
-      ('Content-Disposition', 'attachment; filename="{}"'.format(filename))
+        ('Content-Type', 'text/csv'),
+        ('Content-Disposition', 'attachment; filename="{}"'.format(filename))
     ]
     body = render_template("csv_files/" + filename)
     return current_app.make_response((body, 200, headers))
   return current_app.make_response((
       "No template for that type.", 404, []))
+
 
 @app.route("/programs/<program_id>/import_template", methods=['GET'])
 @login_required
@@ -131,8 +141,9 @@ def system_program_import_template(program_id):
   if program:
     template_name = "System_Program_Import_Template.csv"
     headers = [
-      ('Content-Type', 'text/csv'),
-      ('Content-Disposition', 'attachment; filename="{}"'.format(template_name))
+        ('Content-Type', 'text/csv'),
+        ('Content-Disposition',
+            'attachment; filename="{}"'.format(template_name))
     ]
     options = {"program_slug": program.slug}
     body = render_template("csv_files/" + template_name, **options)
@@ -150,7 +161,8 @@ def import_people_task(task):
   try:
     options = {}
     options['dry_run'] = dry_run
-    converter = handle_csv_import(PeopleConverter, csv_file.splitlines(True), **options)
+    converter = handle_csv_import(
+        PeopleConverter, csv_file.splitlines(True), **options)
     if dry_run:
       options['converter'] = converter
       options['results'] = converter.objects
@@ -164,15 +176,17 @@ def import_people_task(task):
     if e.show_preview:
       converter = e.converter
       return render_template("people/import_result.haml", exception_message=e,
-          converter=converter, results=converter.objects, heading_map=converter.object_map)
+                             converter=converter, results=converter.objects, heading_map=converter.object_map)
     return render_template("directives/import_errors.haml",
-          directive_id="People", exception_message=str(e))
+                           directive_id="People", exception_message=str(e))
+
 
 @app.route("/admin/help_redirect/<count>", methods=["GET"])
 def help_redirect(count):
   flash(u'Successfully imported {} help page{}'.format(
-    count, 's' if count > 1 else ''), 'notice alert-success')
+      count, 's' if count > 1 else ''), 'notice alert-success')
   return redirect("/admin")
+
 
 @app.route("/_background_tasks/import_help", methods=['POST'])
 @queued_task
@@ -183,7 +197,8 @@ def import_help_task(task):
   try:
     options = {}
     options['dry_run'] = dry_run
-    converter = handle_csv_import(HelpConverter, csv_file.splitlines(True), **options)
+    converter = handle_csv_import(
+        HelpConverter, csv_file.splitlines(True), **options)
     if dry_run:
       options['converter'] = converter
       options['results'] = converter.objects
@@ -197,9 +212,10 @@ def import_help_task(task):
     if e.show_preview:
       converter = e.converter
       return render_template("help/import_result.haml", exception_message=e,
-          converter=converter, results=converter.objects, heading_map=converter.object_map)
+                             converter=converter, results=converter.objects, heading_map=converter.object_map)
     return render_template("directives/import_errors.haml",
-          directive_id="Help", exception_message=str(e))
+                           directive_id="Help", exception_message=str(e))
+
 
 @app.route("/programs/<program_id>/import_controls", methods=['GET', 'POST'])
 @login_required
@@ -211,8 +227,8 @@ def import_controls_to_program(program_id):
 
   if request.method != 'POST':
     return render_template(
-      "programs/import_controls.haml", program_id=program_id,
-      import_kind='Controls', return_to=return_to, parent_type="Program")
+        "programs/import_controls.haml", program_id=program_id,
+        import_kind='Controls', return_to=return_to, parent_type="Program")
 
   if 'cancel' in request.form:
     program_url = request.args.get("return_to") or view_url_for(program)
@@ -224,7 +240,7 @@ def import_controls_to_program(program_id):
   else:
     file_msg = "Could not import: invalid csv file."
     return render_template("programs/import_errors.haml",
-        directive_id=directive_id, exception_message=file_msg)
+                           directive_id=directive_id, exception_message=file_msg)
   parameters = {
       'parent_type': Program,
       'parent_id': int(program_id),
@@ -239,6 +255,7 @@ def import_controls_to_program(program_id):
       import_control_program_task,
       parameters)
   return tq.make_response(import_dump({"id": tq.id, "status": tq.status}))
+
 
 @app.route("/standards/<directive_id>/import_objectives", methods=['GET', 'POST'])
 @app.route("/regulations/<directive_id>/import_objectives", methods=['GET', 'POST'])
@@ -264,7 +281,7 @@ def import_objectives(directive_id):
   else:
     file_msg = "Could not import: invalid csv file."
     return render_template("directives/import_errors.haml",
-        directive_id=directive_id, exception_message=file_msg)
+                           directive_id=directive_id, exception_message=file_msg)
   parameters = {
       'parent_type': Directive,
       'parent_id': int(directive_id),
@@ -279,6 +296,7 @@ def import_objectives(directive_id):
       import_objective_directive_task,
       parameters)
   return tq.make_response(import_dump({"id": tq.id, "status": tq.status}))
+
 
 @app.route("/programs/<program_id>/import_objectives", methods=['GET', 'POST'])
 @login_required
@@ -302,7 +320,7 @@ def import_objectives_to_program(program_id):
   else:
     file_msg = "Could not import: invalid csv file."
     return render_template("programs/import_errors.haml",
-        directive_id=directive_id, exception_message=file_msg)
+                           directive_id=directive_id, exception_message=file_msg)
   parameters = {
       'parent_type': Program,
       'parent_id': int(program_id),
@@ -318,6 +336,7 @@ def import_objectives_to_program(program_id):
       parameters)
   return tq.make_response(import_dump({"id": tq.id, "status": tq.status}))
 
+
 @app.route("/_background_tasks/import_objective_directive", methods=['POST'])
 @queued_task
 def import_objective_directive_task(task):
@@ -330,7 +349,8 @@ def import_objective_directive_task(task):
   return_to = task.parameters.get("return_to") or directive_url
 
   try:
-    converter = handle_csv_import(ObjectivesConverter, csv_file.splitlines(True), **task.parameters)
+    converter = handle_csv_import(
+        ObjectivesConverter, csv_file.splitlines(True), **task.parameters)
     if dry_run:
       options = {
           'converter': converter,
@@ -340,20 +360,22 @@ def import_objective_directive_task(task):
       return render_template("directives/import_objectives_result.haml", **options)
     else:
       count = len(converter.objects)
-      flash(u'Successfully imported {} objective{}'.format(count, 's' if count > 1 else ''), 'notice')
+      flash(u'Successfully imported {} objective{}'.format(
+          count, 's' if count > 1 else ''), 'notice')
       return import_redirect(return_to)
   except ImportException as e:
     if e.show_preview:
       converter = e.converter
       return render_template("directives/import_objectives_result.haml",
-          exception_message=e, converter=converter, results=converter.objects,
-          directive_id=directive_id, heading_map=converter.object_map)
+                             exception_message=e, converter=converter, results=converter.objects,
+                             directive_id=directive_id, heading_map=converter.object_map)
     return render_template("directives/import_errors.haml",
-        directive_id=directive_id, exception_message=str(e))
+                           directive_id=directive_id, exception_message=str(e))
 
   return render_template("directives/import.haml", directive_id=directive_id,
                          import_kind='Objectives', return_to=return_to,
                          parent_type=(directive.kind or directive.meta_kind))
+
 
 @app.route("/standards/<directive_id>/import_controls", methods=['GET', 'POST'])
 @app.route("/regulations/<directive_id>/import_controls", methods=['GET', 'POST'])
@@ -380,7 +402,7 @@ def import_controls(directive_id):
   else:
     file_msg = "Could not import: invalid csv file."
     return render_template("directives/import_errors.haml",
-        directive_id=directive_id, exception_message=file_msg)
+                           directive_id=directive_id, exception_message=file_msg)
   parameters = {
       'parent_type': Directive,
       'parent_id': int(directive_id),
@@ -396,6 +418,7 @@ def import_controls(directive_id):
       parameters)
   return tq.make_response(import_dump({"id": tq.id, "status": tq.status}))
 
+
 @app.route("/_background_tasks/import_control_directive", methods=['POST'])
 @queued_task
 def import_control_directive_task(task):
@@ -408,7 +431,7 @@ def import_control_directive_task(task):
   return_to = task.parameters.get("return_to") or directive_url
   try:
     converter = handle_csv_import(
-      ControlsConverter, csv_file.splitlines(True), **task.parameters)
+        ControlsConverter, csv_file.splitlines(True), **task.parameters)
     if dry_run:
       options = {
           'converter': converter,
@@ -419,16 +442,17 @@ def import_control_directive_task(task):
     else:
       count = len(converter.objects)
       flash(u'Successfully imported {} control{}'.format(
-        count, 's' if count > 1 else ''), 'notice')
+          count, 's' if count > 1 else ''), 'notice')
       return import_redirect(return_to)
   except ImportException as e:
     if e.show_preview:
       converter = e.converter
       return render_template("directives/import_controls_result.haml",
-          exception_message=e, converter=converter, results=converter.objects,
-          directive_id=directive_id, heading_map=converter.object_map)
+                             exception_message=e, converter=converter, results=converter.objects,
+                             directive_id=directive_id, heading_map=converter.object_map)
     return render_template("directives/import_errors.haml",
-       directive_id=directive_id, exception_message=str(e))
+                           directive_id=directive_id, exception_message=str(e))
+
 
 @app.route("/_background_tasks/import_control_program", methods=['POST'])
 @queued_task
@@ -443,7 +467,7 @@ def import_control_program_task(task):
 
   try:
     converter = handle_csv_import(
-      ControlsConverter, csv_file.splitlines(True), **task.parameters)
+        ControlsConverter, csv_file.splitlines(True), **task.parameters)
     if dry_run:
       options = {
           'converter': converter,
@@ -454,17 +478,18 @@ def import_control_program_task(task):
     else:
       count = len(converter.objects)
       flash(u'Successfully imported {} control{}'.format(
-        count, 's' if count > 1 else ''), 'notice')
+          count, 's' if count > 1 else ''), 'notice')
       return import_redirect(return_to)
 
   except ImportException as e:
     if e.show_preview:
       converter = e.converter
       return render_template("programs/import_controls_result.haml",
-          exception_message=e, converter=converter, results=converter.objects,
-          program_id=program.id, heading_map=converter.object_map)
+                             exception_message=e, converter=converter, results=converter.objects,
+                             program_id=program.id, heading_map=converter.object_map)
     return render_template("programs/import_errors.haml",
-        program_id=program.id, exception_message=str(e))
+                           program_id=program.id, exception_message=str(e))
+
 
 @app.route("/_background_tasks/import_objective_program", methods=['POST'])
 @queued_task
@@ -478,7 +503,7 @@ def import_objective_program_task(task):
 
   try:
     converter = handle_csv_import(
-      ObjectivesConverter, csv_file.splitlines(True), **task.parameters)
+        ObjectivesConverter, csv_file.splitlines(True), **task.parameters)
     if dry_run:
       options = {
           'converter': converter,
@@ -489,17 +514,18 @@ def import_objective_program_task(task):
     else:
       count = len(converter.objects)
       flash(u'Successfully imported {} objectives{}'.format(
-        count, 's' if count > 1 else ''), 'notice')
+          count, 's' if count > 1 else ''), 'notice')
       return import_redirect(return_to)
 
   except ImportException as e:
     if e.show_preview:
       converter = e.converter
       return render_template("programs/import_objectives_result.haml",
-          exception_message=e, converter=converter, results=converter.objects,
-          program_id=program.id, heading_map=converter.object_map)
+                             exception_message=e, converter=converter, results=converter.objects,
+                             program_id=program.id, heading_map=converter.object_map)
     return render_template("programs/import_errors.haml",
-        program_id=program.id, exception_message=str(e))
+                           program_id=program.id, exception_message=str(e))
+
 
 @app.route("/_background_tasks/import_system", methods=["POST"])
 @app.route("/_background_tasks/import_process", methods=["POST"])
@@ -518,14 +544,14 @@ def import_system_task(task):
 
   try:
     converter = handle_csv_import(
-      converter_kind, csv_file.splitlines(True), **options)
+        converter_kind, csv_file.splitlines(True), **options)
     if dry_run:
       return render_template("systems/import_result.haml", converter=converter,
                              results=converter.objects, heading_map=converter.object_map)
     else:
       count = len(converter.objects)
       flash(u'Successfully imported {} {}'.format(
-        count, kind_lookup[object_kind]), 'notice alert-success')
+          count, kind_lookup[object_kind]), 'notice alert-success')
       return import_redirect("/admin")
 
   except ImportException as e:
@@ -536,6 +562,7 @@ def import_system_task(task):
                              heading_map=converter.object_map)
     return render_template("directives/import_errors.haml", exception_message=e)
 
+
 @app.route("/_background_tasks/export_people", methods=['GET'])
 @queued_task
 def export_people_task(task):
@@ -545,6 +572,7 @@ def export_people_task(task):
   filename = "PEOPLE.csv"
   return handle_converter_csv_export(filename, people, PeopleConverter, **options)
 
+
 @app.route("/_background_tasks/export_help", methods=['GET'])
 @queued_task
 def export_help_task(task):
@@ -553,6 +581,7 @@ def export_help_task(task):
   people = Help.query.all()
   filename = "HELP.csv"
   return handle_converter_csv_export(filename, people, HelpConverter, **options)
+
 
 @app.route("/_background_tasks/export_process", methods=['GET'])
 @queued_task
@@ -565,6 +594,7 @@ def export_process_task(task):
   filename = "PROCESSES.csv"
   return handle_converter_csv_export(filename, procs, ProcessesConverter, **options)
 
+
 @app.route("/_background_tasks/export_system", methods=['GET'])
 @queued_task
 def export_system_task(task):
@@ -575,18 +605,20 @@ def export_system_task(task):
   filename = "SYSTEMS.csv"
   return handle_converter_csv_export(filename, systems, SystemsConverter, **options)
 
+
 @app.route("/admin/people_redirect/<count>", methods=["GET"])
 def people_redirect(count):
   flash(u'Successfully imported {} {}'.format(
-    count, 'people' if count > 1 else 'person'), 'notice alert-success')
+      count, 'people' if count > 1 else 'person'), 'notice alert-success')
   return redirect("/admin")
+
 
 @app.route("/admin/import/<import_type>", methods=['GET', 'POST'])
 @login_required
 def import_people(import_type):
   import_task = {
-    "people": import_people_task,
-    "help": import_help_task
+      "people": import_people_task,
+      "help": import_help_task
   }
 
   ensure_admin_permissions()
@@ -606,7 +638,7 @@ def import_people(import_type):
   else:
     file_msg = "Could not import: invalid csv file."
     return render_template("directives/import_errors.haml",
-        directive_id=import_type.capitalize(), exception_message=file_msg)
+                           directive_id=import_type.capitalize(), exception_message=file_msg)
 
   parameters = {"dry_run": dry_run,
                 "csv_file": csv_file.read(),
@@ -616,7 +648,8 @@ def import_people(import_type):
       url_for(import_task[import_type].__name__),
       import_task[import_type],
       parameters)
-  return tq.make_response(import_dump({"id":tq.id, "status":tq.status}))
+  return tq.make_response(import_dump({"id": tq.id, "status": tq.status}))
+
 
 @app.route("/audits/<audit_id>/import_pbcs", methods=['GET', 'POST'])
 @login_required
@@ -638,7 +671,7 @@ def import_requests(audit_id):
       if csv_file and allowed_file(csv_file.filename):
         filename = secure_filename(csv_file.filename)
         converter = handle_csv_import(RequestsConverter, csv_file,
-          program_id=program.id, audit_id=audit.id, dry_run=dry_run)
+                                      program_id=program.id, audit_id=audit.id, dry_run=dry_run)
 
         if dry_run:
           return render_template("programs/import_request_result.haml",
@@ -649,37 +682,40 @@ def import_requests(audit_id):
           count = len(converter.objects)
           urlparts = urlparse(request.args.get("return_to"))
           return_to = urlunparse(
-            (urlparts.scheme,
-              urlparts.netloc,
-              u"/audits/post_import_request_hook",
-              u'',
-              u'return_to=' + urllib.quote_plus(request.args.get("return_to")) \
-              + u'&ids=' + json.dumps([object.obj.id for object in converter.objects])
-              + u'&audit_id=' + unicode(int(audit_id)),
-              '')
+              (urlparts.scheme,
+               urlparts.netloc,
+               u"/audits/post_import_request_hook",
+               u'',
+               u'return_to=' + urllib.quote_plus(request.args.get("return_to"))
+               + u'&ids=' +
+               json.dumps([object.obj.id for object in converter.objects])
+               + u'&audit_id=' + unicode(int(audit_id)),
+               '')
           )
           return import_redirect(return_to)
 
       else:
         file_msg = "Could not import: invalid csv file."
         return render_template("programs/import_request_errors.haml",
-              exception_message=file_msg)
+                               exception_message=file_msg)
 
     except ImportException as e:
       if e.show_preview:
         converter = e.converter
         return render_template("programs/import_request_result.haml", exception_message=e,
-            converter=converter, results=converter.objects,
-            heading_map=converter.object_map)
+                               converter=converter, results=converter.objects,
+                               heading_map=converter.object_map)
       return render_template("programs/import_request_errors.haml",
-            exception_message=e)
+                             exception_message=e)
 
   return render_template(
-    "programs/import_request.haml", import_kind='Requests', return_to=return_to)
+      "programs/import_request.haml", import_kind='Requests', return_to=return_to)
+
 
 @app.route("/audits/post_import_request_hook", methods=['GET'])
 def post_import_requests():
   return import_redirect(request.args.get("return_to"))
+
 
 @app.route("/audits/<audit_id>/import_pbc_template", methods=['GET'])
 @login_required
@@ -691,11 +727,12 @@ def import_requests_template(audit_id):
   template = "Request_Import_Template.csv"
   filename = "PBC Request Import Template.csv"
   headers = [
-    ('Content-Type', 'text/csv'),
-    ('Content-Disposition', 'attachment; filename="{}"'.format(filename))]
+      ('Content-Type', 'text/csv'),
+      ('Content-Disposition', 'attachment; filename="{}"'.format(filename))]
   options = {'program_slug': program.slug}
   body = render_template("csv_files/" + template, **options)
   return current_app.make_response((body, 200, headers))
+
 
 @app.route("/standards/<directive_id>/import_sections", methods=['GET', 'POST'])
 @app.route("/regulations/<directive_id>/import_sections", methods=['GET', 'POST'])
@@ -736,8 +773,8 @@ def import_sections(directive_id):
         converter = handle_csv_import(object_converter, csv_file, **options)
         if dry_run:
           return render_template("directives/import_sections_result.haml",
-              directive_id=directive_id, converter=converter,
-              results=converter.objects, heading_map=converter.object_map)
+                                 directive_id=directive_id, converter=converter,
+                                 results=converter.objects, heading_map=converter.object_map)
         else:
           count = len(converter.objects)
           flash(u'Successfully imported {0} {2}{1}'.format(
@@ -746,20 +783,21 @@ def import_sections(directive_id):
       else:
         file_msg = "Could not import: invalid csv file."
         return render_template("directives/import_errors.haml",
-              directive_id=directive_id, exception_message=file_msg)
+                               directive_id=directive_id, exception_message=file_msg)
 
     except ImportException as e:
       if e.show_preview:
         converter = e.converter
         return render_template(
-          "directives/import_sections_result.haml", exception_message=e,
+            "directives/import_sections_result.haml", exception_message=e,
             converter=converter, results=converter.objects,
             directive_id=int(directive_id), heading_map=converter.object_map)
       return render_template("directives/import_errors.haml",
-            directive_id=int(directive_id), exception_message=e)
+                             directive_id=int(directive_id), exception_message=e)
 
   return render_template(
       "directives/import.haml", directive_id=directive_id, import_kind=import_kind, return_to=return_to)
+
 
 @app.route("/<object_kind>/import", methods=['GET', 'POST'])
 @login_required
@@ -792,16 +830,17 @@ def import_systems_processes(object_kind):
     file_msg = "Could not import: invalid csv file."
     return render_template("directives/import_errors.haml", exception_message=file_msg)
   parameters = {
-    "dry_run": dry_run,
-    "csv_file": csv_file.read(),
-    "csv_filename": filename,
-    "object_kind": object_kind}
+      "dry_run": dry_run,
+      "csv_file": csv_file.read(),
+      "csv_filename": filename,
+      "object_kind": object_kind}
   tq = create_task(
       "import_system",
       url_for(import_system_task.__name__),
       import_system_task,
       parameters)
   return tq.make_response(import_dump({"id": tq.id, "status": tq.status}))
+
 
 @app.route("/programs/<program_id>/import_systems", methods=['GET', 'POST'])
 @login_required
@@ -829,7 +868,7 @@ def import_systems_to_program(program_id):
         converter = handle_csv_import(SystemsConverter, csv_file, **options)
         if dry_run:
           return render_template("systems/import_result.haml",
-            converter=converter, results=converter.objects, heading_map=converter.object_map)
+                                 converter=converter, results=converter.objects, heading_map=converter.object_map)
         else:
           count = len(converter.objects)
           flash(
@@ -849,10 +888,11 @@ def import_systems_to_program(program_id):
       if e.show_preview:
         converter = e.converter
         return render_template("systems/import_result.haml", exception_message=e,
-            converter=converter, results=converter.objects, heading_map=converter.object_map)
+                               converter=converter, results=converter.objects, heading_map=converter.object_map)
       return render_template("directives/import_errors.haml", exception_message=e)
 
   return render_template("systems/import.haml", import_kind='Systems')
+
 
 @app.route("/admin/export/<export_type>", methods=['GET'])
 @login_required
@@ -860,17 +900,18 @@ def export(export_type):
   ensure_admin_permissions()
 
   export_task = {
-    "people": export_people_task,
-    "help": export_help_task,
-    "process": export_process_task,
-    "system": export_system_task,
+      "people": export_people_task,
+      "help": export_help_task,
+      "process": export_process_task,
+      "system": export_system_task,
   }
 
   tq = create_task(
       "export_" + export_type,
       url_for(export_task[export_type].__name__),
       export_task[export_type])
-  return import_dump({"id":tq.id, "status":tq.status})
+  return import_dump({"id": tq.id, "status": tq.status})
+
 
 @app.route("/standards/<directive_id>/export_sections", methods=['GET'])
 @app.route("/regulations/<directive_id>/export_sections", methods=['GET'])
@@ -887,6 +928,7 @@ def export_sections(directive_id):
   sections = directive.sections
   return handle_converter_csv_export(filename, sections, SectionsConverter, **options)
 
+
 @app.route("/contracts/<directive_id>/export_clauses", methods=['GET'])
 @login_required
 def export_clauses(directive_id):
@@ -899,6 +941,7 @@ def export_clauses(directive_id):
   filename = "{}.csv".format(directive.slug)
   sections = directive.joined_sections
   return handle_converter_csv_export(filename, sections, SectionsConverter, **options)
+
 
 @app.route("/standards/<directive_id>/export_objectives", methods=['GET'])
 @app.route("/regulations/<directive_id>/export_objectives", methods=['GET'])
@@ -922,6 +965,7 @@ def export_objectives(directive_id):
     objectives = directive.objectives
   return handle_converter_csv_export(filename, objectives, ObjectivesConverter, **options)
 
+
 @app.route("/programs/<program_id>/export_objectives", methods=['GET'])
 @login_required
 def export_objectives_from_program(program_id):
@@ -941,6 +985,7 @@ def export_objectives_from_program(program_id):
   else:
     objectives = program.objectives
   return handle_converter_csv_export(filename, objectives, ObjectivesConverter, **options)
+
 
 @app.route("/standards/<directive_id>/import_sections_template", methods=['GET'])
 @app.route("/regulations/<directive_id>/import_sections_template", methods=['GET'])
@@ -962,16 +1007,18 @@ def import_directive_sections_template(directive_id):
   output_filename = "{0}_{1}_Import_Template.csv".format(
       directive_type, section_term)
   headers = [
-    ('Content-Type', 'text/csv'),
-    ('Content-Disposition', 'attachment; filename="{}"'.format(output_filename))
+      ('Content-Type', 'text/csv'),
+      ('Content-Disposition',
+          'attachment; filename="{}"'.format(output_filename))
   ]
   options = {
-    'section_term': section_term,
-    'directive_type': directive_type,
-    'directive_slug': directive.slug,
+      'section_term': section_term,
+      'directive_type': directive_type,
+      'directive_slug': directive.slug,
   }
   body = render_template("csv_files/Section_Import_Template.csv", **options)
   return current_app.make_response((body, 200, headers))
+
 
 @app.route("/audits/<audit_id>/export_pbcs", methods=['GET'])
 @login_required
@@ -990,6 +1037,7 @@ def export_requests(audit_id):
     requests = audit.requests
   options['export'] = True
   return handle_converter_csv_export(filename, requests, RequestsConverter, **options)
+
 
 @app.route("/standards/<directive_id>/export_controls", methods=['GET'])
 @app.route("/regulations/<directive_id>/export_controls", methods=['GET'])
@@ -1036,6 +1084,7 @@ def export_controls_from_program(program_id):
     controls = program.controls
   return handle_converter_csv_export(filename, controls, ControlsConverter, **options)
 
+
 @app.route("/programs/<program_id>/export_systems", methods=['GET'])
 @login_required
 def export_systems_from_program(program_id):
@@ -1056,8 +1105,10 @@ def export_systems_from_program(program_id):
   else:
     # if no id list given, look up from which relationships of this
     # program have a System as destination
-    systems = [r.System_destination for r in program.related_destinations if r.System_destination]
+    systems = [
+        r.System_destination for r in program.related_destinations if r.System_destination]
   return handle_converter_csv_export(filename, systems, SystemsConverter, **options)
+
 
 @app.route("/<object_type>/<object_id>/import_objectives_template", methods=['GET'])
 @app.route("/<object_type>/<object_id>/import_controls_template", methods=['GET'])
@@ -1094,9 +1145,9 @@ def import_controls_template(object_type, object_id):
       )
   ]
   options = {
-    # (Policy/Regulation/Contract) Code
-    'object_kind': parent_kind,
-    'object_slug': parent_object.slug,
+      # (Policy/Regulation/Contract) Code
+      'object_kind': parent_kind,
+      'object_slug': parent_object.slug,
   }
   body = render_template("csv_files/" + template_name, **options)
   return current_app.make_response((body, 200, headers))

--- a/src/tests/ggrc/converters/test_helpers.py
+++ b/src/tests/ggrc/converters/test_helpers.py
@@ -12,7 +12,6 @@ TEST_FILE2 = join(CSV_DIR, "helper_test2.csv")
 IRREL_DIF_FILE = join(CSV_DIR, "irrel_diff.csv")
 NO_ROWS = join(CSV_DIR, "helper_test_no_row.csv")
 
-@SkipTest
 class TestCSVCompare(unittest.TestCase):
   def setUp(self):
     with open(TEST_FILE1, "r") as f:

--- a/src/tests/ggrc/converters/test_import_helpers.py
+++ b/src/tests/ggrc/converters/test_import_helpers.py
@@ -1,0 +1,632 @@
+# Copyright (C) 2015 Google Inc., authors, and contributors <see AUTHORS file>
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+# Created By: miha@reciprocitylabs.com
+# Maintained By: miha@reciprocitylabs.com
+
+from os.path import abspath, dirname, join
+
+from ggrc import models
+from ggrc.converters.import_helper import get_object_column_definitions
+from ggrc.models import CustomAttributeDefinition
+from tests.ggrc import TestCase
+from tests.ggrc.api_helper import Api
+
+THIS_ABS_PATH = abspath(dirname(__file__))
+CSV_DIR = join(THIS_ABS_PATH, 'example_csvs/')
+
+
+def generate_custom_attr(definition_type, title, attribute_type="Text",
+                         mandatory=False, helptext="", multi_choice=""):
+  api = Api()
+  custom_attr = {
+      "custom_attribute_definition": {
+          "title": title,
+          "custom_attribute_definitions": [],
+          "custom_attributes": {},
+          "definition_type": definition_type,
+          "modal_title": title,
+          "attribute_type": attribute_type,
+          "mandatory": mandatory,
+          "helptext": helptext,
+          "placeholder": "",
+          "context": {"id": None},
+          "multi_choice_options": multi_choice
+      }
+  }
+  api.post(CustomAttributeDefinition, custom_attr)
+
+
+class TestCustomAttributesDefinitions(TestCase):
+
+  def test_policy_definitions(self):
+    generate_custom_attr("policy", "My Attribute")
+    generate_custom_attr("policy", "Mandatory Attribute", mandatory=True)
+    definitions = get_object_column_definitions(models.Policy)
+    display_names = set([val["display_name"] for val in definitions.values()])
+    expected_names = set([
+        "Code",
+        "Title",
+        "Description",
+        "Notes",
+        "Owner",
+        "Primary Contact",
+        "Secondary Contact",
+        "Policy URL",
+        "Reference URL",
+        "Kind/Type",
+        "Effective Date",
+        "Stop Date",
+        "State",
+        "My Attribute",
+        "Mandatory Attribute",
+    ])
+    self.assertEquals(expected_names, display_names)
+    mandatory = {val["display_name"]: val["mandatory"]
+                 for val in definitions.values()}
+    self.assertTrue(mandatory["Title"])
+    self.assertTrue(mandatory["Mandatory Attribute"])
+
+  def test_program_definitions(self):
+    """ test custom attribute headers for Program """
+    generate_custom_attr("program", "My Attribute")
+    generate_custom_attr("program", "Mandatory Attribute", mandatory=True)
+    generate_custom_attr(
+        "program", "Choose",
+        mandatory=True,
+        attribute_type="Dropdown",
+        multi_choice="hello,world,what's,up"
+    )
+    definitions = get_object_column_definitions(models.Program)
+    display_names = set([val["display_name"] for val in definitions.values()])
+    expected_names = set([
+        "Title",
+        "Description",
+        "Notes",
+        "Privacy",
+        "Owner",
+        "Primary Contact",
+        "Secondary Contact",
+        "Program URL",
+        "Reference URL",
+        "Kind/Type",
+        "Code",
+        "Effective Date",
+        "Stop Date",
+        "State",
+        "My Attribute",
+        "Mandatory Attribute",
+        "Choose",
+    ])
+    self.assertEquals(expected_names, display_names)
+    mandatory = {val["display_name"]: val["mandatory"]
+                 for val in definitions.values()}
+    self.assertTrue(mandatory["Title"])
+    self.assertTrue(mandatory["Mandatory Attribute"])
+    self.assertTrue(mandatory["Choose"])
+
+
+class TestGetObjectColumnDefinitions(TestCase):
+
+  """
+  Test default column difinitions for all objcts
+
+  order of these test functions is the same as the objects in LHN
+  """
+
+  def test_program_definitions(self):
+    """ test default headers for Program """
+    definitions = get_object_column_definitions(models.Program)
+    display_names = set([val["display_name"] for val in definitions.values()])
+    expected_names = set([
+        "Title",
+        "Description",
+        "Notes",
+        "Privacy",
+        "Owner",
+        "Primary Contact",
+        "Secondary Contact",
+        "Program URL",
+        "Reference URL",
+        "Kind/Type",
+        "Code",
+        "Effective Date",
+        "Stop Date",
+        "State",
+    ])
+    self.assertEquals(expected_names, display_names)
+    mandatory = {val["display_name"]: val["mandatory"]
+                 for val in definitions.values()}
+    self.assertTrue(mandatory["Title"])
+
+  def test_audit_definitions(self):
+    """ test default headers for Audit """
+    definitions = get_object_column_definitions(models.Audit)
+    display_names = set([val["display_name"] for val in definitions.values()])
+    expected_names = set([
+        "Program",
+        "Title",
+        "Description",
+        "Internal Audit Lead",
+        "Status",
+        "Planned Start Date",
+        "Planned End Date",
+        "Planned Report Period from",
+        "Planned Report Period to",
+        "Auditors",
+    ])
+    self.assertEquals(expected_names, display_names)
+    mandatory = {val["display_name"]: val["mandatory"]
+                 for val in definitions.values()}
+    self.assertTrue(mandatory["Title"])
+    self.assertTrue(mandatory["Internal Audit Lead"])
+
+  def test_control_assessment_definitions(self):
+    """ test default headers for Control Assessment """
+    definitions = get_object_column_definitions(models.ControlAssessment)
+    display_names = set([val["display_name"] for val in definitions.values()])
+    expected_names = set([
+        "Title",
+        "Description",
+        "Notes",
+        "Test Plan",
+        "Control",
+        "Audit",
+        "Owner",
+        "Primary Contact",
+        "Secondary Contact",
+        "Assessment URL",
+        "Reference URL",
+        "Code",
+        "Effective Date",
+        "Stop Date",
+        "State",
+        "Conclusion: Design",
+        "Conclusion: Operation",
+    ])
+    self.assertEquals(expected_names, display_names)
+    mandatory = {val["display_name"]: val["mandatory"]
+                 for val in definitions.values()}
+    self.assertTrue(mandatory["Title"])
+    self.assertTrue(mandatory["Control"])
+    self.assertTrue(mandatory["Audit"])
+
+  def test_issue_definitions(self):
+    """ test default headers for Issue """
+    definitions = get_object_column_definitions(models.Issue)
+    display_names = set([val["display_name"] for val in definitions.values()])
+    expected_names = set([
+        "Title",
+        "Description",
+        "Notes",
+        "Test Plan",
+        "Owner",
+        "Primary Contact",
+        "Secondary Contact",
+        "Issue URL",
+        "Reference URL",
+        "Code",
+        "Effective Date",
+        "Stop Date",
+        "State",
+    ])
+    self.assertEquals(expected_names, display_names)
+    mandatory = {val["display_name"]: val["mandatory"]
+                 for val in definitions.values()}
+    self.assertTrue(mandatory["Title"])
+
+  def test_regulation_definitions(self):
+    """ test default headers for Regulation """
+    definitions = get_object_column_definitions(models.Regulation)
+    display_names = set([val["display_name"] for val in definitions.values()])
+    expected_names = set([
+        "Title",
+        "Description",
+        "Notes",
+        "Owner",
+        "Primary Contact",
+        "Secondary Contact",
+        "Regulation URL",
+        "Reference URL",
+        "Code",
+        "Effective Date",
+        "Stop Date",
+        "State",
+    ])
+    self.assertEquals(expected_names, display_names)
+    mandatory = {val["display_name"]: val["mandatory"]
+                 for val in definitions.values()}
+    self.assertTrue(mandatory["Title"])
+
+  def test_policy_definitions(self):
+    """ test default headers for Policy """
+    definitions = get_object_column_definitions(models.Policy)
+    display_names = set([val["display_name"] for val in definitions.values()])
+    expected_names = set([
+        "Title",
+        "Description",
+        "Notes",
+        "Owner",
+        "Primary Contact",
+        "Secondary Contact",
+        "Policy URL",
+        "Reference URL",
+        "Kind/Type",
+        "Code",
+        "Effective Date",
+        "Stop Date",
+        "State",
+    ])
+    self.assertEquals(expected_names, display_names)
+    mandatory = {val["display_name"]: val["mandatory"]
+                 for val in definitions.values()}
+    self.assertTrue(mandatory["Title"])
+
+  def test_standard_definitions(self):
+    """ test default headers for Standard """
+    definitions = get_object_column_definitions(models.Standard)
+    display_names = set([val["display_name"] for val in definitions.values()])
+    expected_names = set([
+        "Title",
+        "Description",
+        "Notes",
+        "Owner",
+        "Primary Contact",
+        "Secondary Contact",
+        "Standard URL",
+        "Reference URL",
+        "Code",
+        "Effective Date",
+        "Stop Date",
+        "State",
+    ])
+    self.assertEquals(expected_names, display_names)
+    mandatory = {val["display_name"]: val["mandatory"]
+                 for val in definitions.values()}
+    self.assertTrue(mandatory["Title"])
+
+  def test_contract_definitions(self):
+    """ test default headers for Contract """
+    definitions = get_object_column_definitions(models.Contract)
+    display_names = set([val["display_name"] for val in definitions.values()])
+    expected_names = set([
+        "Title",
+        "Description",
+        "Notes",
+        "Owner",
+        "Primary Contact",
+        "Secondary Contact",
+        "Contract URL",
+        "Reference URL",
+        "Code",
+        "Effective Date",
+        "Stop Date",
+        "State",
+    ])
+    self.assertEquals(expected_names, display_names)
+    mandatory = {val["display_name"]: val["mandatory"]
+                 for val in definitions.values()}
+    self.assertTrue(mandatory["Title"])
+
+  def test_clause_definitions(self):
+    """ test default headers for Clause """
+    definitions = get_object_column_definitions(models.Clause)
+    display_names = set([val["display_name"] for val in definitions.values()])
+    expected_names = set([
+        "Title",
+        "Description",
+        "Notes",
+        "Owner",
+        "Primary Contact",
+        "Secondary Contact",
+        "Clause URL",
+        "Reference URL",
+        "Code",
+        "Effective Date",
+        "Stop Date",
+        "State",
+    ])
+    self.assertEquals(expected_names, display_names)
+    mandatory = {val["display_name"]: val["mandatory"]
+                 for val in definitions.values()}
+    self.assertTrue(mandatory["Title"])
+
+  def test_section_definitions(self):
+    """ test default headers for Section """
+    definitions = get_object_column_definitions(models.Section)
+    display_names = set([val["display_name"] for val in definitions.values()])
+    expected_names = set([
+        "Title",
+        "Text of Section",
+        "Notes",
+        "Policy / Regulation / Standard",
+        "Owner",
+        "Primary Contact",
+        "Secondary Contact",
+        "Section URL",
+        "Reference URL",
+        "Code",
+        "State",
+    ])
+    self.assertEquals(expected_names, display_names)
+    mandatory = {val["display_name"]: val["mandatory"]
+                 for val in definitions.values()}
+    self.assertTrue(mandatory["Title"])
+
+  def test_control_definitions(self):
+    """ test default headers for Control """
+    definitions = get_object_column_definitions(models.Control)
+    display_names = set([val["display_name"] for val in definitions.values()])
+    expected_names = set([
+        "Title",
+        "Description",
+        "Test Plan",
+        "Notes",
+        "Owner",
+        "Primary Contact",
+        "Secondary Contact",
+        "Control URL",
+        "Reference URL",
+        "Code",
+        "Kind/Nature",
+        "Fraud Related",
+        "Significance",
+        "Type/Means",
+        "Effective Date",
+        "Stop Date",
+        "Frequency",
+        "Assertions",
+        "Categories",
+        "Principal Assessor",
+        "Secondary Assessor",
+        "State",
+    ])
+    self.assertEquals(expected_names, display_names)
+    mandatory = {val["display_name"]: val["mandatory"]
+                 for val in definitions.values()}
+    self.assertTrue(mandatory["Title"])
+
+  def test_objective_definitions(self):
+    """ test default headers for Objective """
+    definitions = get_object_column_definitions(models.Objective)
+    display_names = set([val["display_name"] for val in definitions.values()])
+    expected_names = set([
+        "Title",
+        "Description",
+        "Notes",
+        "Owner",
+        "Primary Contact",
+        "Secondary Contact",
+        "Objective URL",
+        "Reference URL",
+        "Code",
+        "State",
+    ])
+    self.assertEquals(expected_names, display_names)
+    mandatory = {val["display_name"]: val["mandatory"]
+                 for val in definitions.values()}
+    self.assertTrue(mandatory["Title"])
+
+  def test_person_definitions(self):
+    """ test default headers for Person """
+    definitions = get_object_column_definitions(models.Person)
+    display_names = set([val["display_name"] for val in definitions.values()])
+    expected_names = set([
+        "Name",
+        "Email",
+        "enabled user",
+        "Company",
+    ])
+    self.assertEquals(expected_names, display_names)
+    mandatory = {val["display_name"]: val["mandatory"]
+                 for val in definitions.values()}
+    self.assertTrue(mandatory["Email"])
+
+  def test_org_group_definitions(self):
+    """ test default headers for OrgGroup """
+    definitions = get_object_column_definitions(models.OrgGroup)
+    display_names = set([val["display_name"] for val in definitions.values()])
+    expected_names = set([
+        "Title",
+        "Description",
+        "Notes",
+        "Owner",
+        "Primary Contact",
+        "Secondary Contact",
+        "Org Group URL",
+        "Reference URL",
+        "Code",
+        "Effective Date",
+        "Stop Date",
+        "State",
+    ])
+    self.assertEquals(expected_names, display_names)
+    mandatory = {val["display_name"]: val["mandatory"]
+                 for val in definitions.values()}
+    self.assertTrue(mandatory["Title"])
+
+  def test_vendor_definitions(self):
+    """ test default headers for Vendor """
+    definitions = get_object_column_definitions(models.Vendor)
+    display_names = set([val["display_name"] for val in definitions.values()])
+    expected_names = set([
+        "Title",
+        "Description",
+        "Notes",
+        "Owner",
+        "Primary Contact",
+        "Secondary Contact",
+        "Vendor URL",
+        "Reference URL",
+        "Code",
+        "Effective Date",
+        "Stop Date",
+        "State",
+    ])
+    self.assertEquals(expected_names, display_names)
+    mandatory = {val["display_name"]: val["mandatory"]
+                 for val in definitions.values()}
+    self.assertTrue(mandatory["Title"])
+
+  def test_system_definitions(self):
+    """ test default headers for System """
+    definitions = get_object_column_definitions(models.System)
+    display_names = set([val["display_name"] for val in definitions.values()])
+    expected_names = set([
+        "Title",
+        "Description",
+        "Notes",
+        "Owner",
+        "Primary Contact",
+        "Secondary Contact",
+        "System URL",
+        "Reference URL",
+        "Code",
+        "Network Zone",
+        "Effective Date",
+        "Stop Date",
+        "State",
+    ])
+    self.assertEquals(expected_names, display_names)
+    mandatory = {val["display_name"]: val["mandatory"]
+                 for val in definitions.values()}
+    self.assertTrue(mandatory["Title"])
+
+  def test_process_definitions(self):
+    """ test default headers for Process """
+    definitions = get_object_column_definitions(models.Process)
+    display_names = set([val["display_name"] for val in definitions.values()])
+    expected_names = set([
+        "Title",
+        "Description",
+        "Notes",
+        "Owner",
+        "Primary Contact",
+        "Secondary Contact",
+        "Process URL",
+        "Reference URL",
+        "Code",
+        "Network Zone",
+        "Effective Date",
+        "Stop Date",
+        "State",
+    ])
+    self.assertEquals(expected_names, display_names)
+    mandatory = {val["display_name"]: val["mandatory"]
+                 for val in definitions.values()}
+    self.assertTrue(mandatory["Title"])
+
+  def test_data_asset_definitions(self):
+    """ test default headers for DataAsset """
+    definitions = get_object_column_definitions(models.DataAsset)
+    display_names = set([val["display_name"] for val in definitions.values()])
+    expected_names = set([
+        "Title",
+        "Description",
+        "Notes",
+        "Owner",
+        "Primary Contact",
+        "Secondary Contact",
+        "Data Asset URL",
+        "Reference URL",
+        "Code",
+        "Effective Date",
+        "Stop Date",
+        "State",
+    ])
+    self.assertEquals(expected_names, display_names)
+    mandatory = {val["display_name"]: val["mandatory"]
+                 for val in definitions.values()}
+    self.assertTrue(mandatory["Title"])
+
+  def test_product_definitions(self):
+    """ test default headers for Product """
+    definitions = get_object_column_definitions(models.Product)
+    display_names = set([val["display_name"] for val in definitions.values()])
+    expected_names = set([
+        "Title",
+        "Description",
+        "Notes",
+        "Owner",
+        "Primary Contact",
+        "Secondary Contact",
+        "Product URL",
+        "Reference URL",
+        "Code",
+        "Kind/Type",
+        "Effective Date",
+        "Stop Date",
+        "State",
+    ])
+    self.assertEquals(expected_names, display_names)
+    mandatory = {val["display_name"]: val["mandatory"]
+                 for val in definitions.values()}
+    self.assertTrue(mandatory["Title"])
+
+  def test_project_definitions(self):
+    """ test default headers for Project """
+    definitions = get_object_column_definitions(models.Project)
+    display_names = set([val["display_name"] for val in definitions.values()])
+    expected_names = set([
+        "Title",
+        "Description",
+        "Notes",
+        "Owner",
+        "Primary Contact",
+        "Secondary Contact",
+        "Project URL",
+        "Reference URL",
+        "Code",
+        "Effective Date",
+        "Stop Date",
+        "State",
+    ])
+    self.assertEquals(expected_names, display_names)
+    mandatory = {val["display_name"]: val["mandatory"]
+                 for val in definitions.values()}
+    self.assertTrue(mandatory["Title"])
+
+  def test_facility_definitions(self):
+    """ test default headers for Facility """
+    definitions = get_object_column_definitions(models.Facility)
+    display_names = set([val["display_name"] for val in definitions.values()])
+    expected_names = set([
+        "Title",
+        "Description",
+        "Notes",
+        "Owner",
+        "Primary Contact",
+        "Secondary Contact",
+        "Facility URL",
+        "Reference URL",
+        "Code",
+        "Effective Date",
+        "Stop Date",
+        "State",
+    ])
+    self.assertEquals(expected_names, display_names)
+    mandatory = {val["display_name"]: val["mandatory"]
+                 for val in definitions.values()}
+    self.assertTrue(mandatory["Title"])
+
+  def test_market_definitions(self):
+    """ test default headers for Market """
+    definitions = get_object_column_definitions(models.Market)
+    display_names = set([val["display_name"] for val in definitions.values()])
+    expected_names = set([
+        "Title",
+        "Description",
+        "Notes",
+        "Owner",
+        "Primary Contact",
+        "Secondary Contact",
+        "Market URL",
+        "Reference URL",
+        "Code",
+        "Effective Date",
+        "Stop Date",
+        "State",
+    ])
+    self.assertEquals(expected_names, display_names)
+    mandatory = {val["display_name"]: val["mandatory"]
+                 for val in definitions.values()}
+    self.assertTrue(mandatory["Title"])


### PR DESCRIPTION
All importable object types should have working downloadable templates at url like
http://localhost:8080/_service/export_csv/Program 

object types with spaces "Org Group" should also work, but they have additional url endpoint with underscore
http://localhost:8080/_service/export_csv/org_group
http://localhost:8080/_service/export_csv/control_assessment

resolves: CORE-1863, CORE-1776, CORE-977