### PR TITLE
CORE-1824 Fix bugs on import prototypes

### DIFF
--- a/src/ggrc/assets/stylesheets/_import-export.scss
+++ b/src/ggrc/assets/stylesheets/_import-export.scss
@@ -136,7 +136,7 @@ form.import {
   }
   .import-progress {
     float: left;
-    width: 450px;
+    width: 300px;
     margin-top: -6px;
     margin-left: 20px;
   }

--- a/src/ggrc/templates/mockups/import-export/index.html
+++ b/src/ggrc/templates/mockups/import-export/index.html
@@ -48,6 +48,12 @@
                   </span>
                 </a>
               </li>
+              <li class="">
+                <a href="javascript://">
+                  <i class="grcicon-imp-exp"></i>
+                  <span>Import</span>
+                </a>
+              </li>
               <li class="user user-dropdown dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button">
                   <i class="grcicon-user-black"></i>
@@ -94,7 +100,7 @@
               <li>
                 <a class="nav-trigger active" href="javascript://">
                   <i class="grcicon-nav-trigger"></i>
-                  <span>Hide menu</span>
+                  <span>Menu</span>
                 </a>
               </li>
               <li>


### PR DESCRIPTION
This fix is for progress bar and header. Width of progress bar is
reduced so it won't go into second row.

In header "Import" was missing so it was added and "Hide Menu" was
renamend into "Menu".