### PR TITLE
QUICK-FIX Add a list of predefined widths for selected attrs

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
@@ -395,40 +395,24 @@ CMS.Controllers.TreeLoader("CMS.Controllers.TreeView", {
   // When user selects 3 middle selectable attribute, title width is reduced to span3
   // and when user selects 4 attributes, the action column is also reduced to span3
   setup_column_width: function () {
-    var display_options = {},
-        title_width = 4,
-        action_width = 4,
-        selectable_width = 4,
-        display_width = 12;
+    var display_options,
+        display_width = 12,
+        attr_count = this.options.display_attr_list.length,
+        widths = {
+          defaults: [4, 4, 4],
+          0: [7, 1, 4],
+          3: [3, 5, 4],
+          4: [3, 6, 3],
+        },
+        selected_widths = widths[attr_count] || widths.defaults;
 
-    if (this.options.display_attr_list.length) {
-      switch (this.options.display_attr_list.length) {
-        case 3:
-          display_options.title_width = title_width - 1;
-          display_options.action_width = action_width;
-          display_options.selectable_width = selectable_width + 1;
-          break;
-        case 4:
-          display_options.title_width = title_width - 1;
-          display_options.action_width = action_width - 1;
-          display_options.selectable_width = selectable_width + 2;
-          break;
-        default:
-          display_options.title_width = title_width;
-          display_options.action_width = action_width;
-          display_options.selectable_width = selectable_width;
-          break;
-      }
-      display_options.selectable_attr_width =
-        Math.floor(display_width/this.options.display_attr_list.length);
-    } else {
-      display_options.title_width = title_width + selectable_width - 1; //leave a little space
-      display_options.action_width = action_width;
-      display_options.selectable_width = 1;
-      display_options.selectable_attr_width = display_width;
+    display_options = {
+      title_width: selected_widths[0],
+      action_width: selected_widths[1],
+      selectable_width: selected_widths[2],
+      selectable_attr_width: display_width / Math.max(attr_count, 1)
     }
     this.options.attr('display_options', display_options);
-
   },
 
   //Displays attribute list for tree-header, Select attribute list drop down


### PR DESCRIPTION
As discussed, we need to have a list of pre-defined widths for different
counts of selected attributes in the tree view. This commit should not
change the display_option widths, it should only refactor the code to
make it easyer to support more selected attributes.