### PR TITLE
CORE-1838 Unique-title validation for CA

### DIFF
--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -745,7 +745,7 @@ can.Model.Cacheable("CMS.Models.ControlAssessment", {
   update : "PUT /api/control_assessments/{id}",
   destroy : "DELETE /api/control_assessments/{id}",
   create : "POST /api/control_assessments",
-  mixins : ["ownable", "contactable"],
+  mixins : ["ownable", "contactable", "unique_title"],
   is_custom_attributable: true,
   attributes : {
     control : "CMS.Models.Control.stub",


### PR DESCRIPTION
Add unique title validation for control assessment object
When user tabs out from the title field, the validation triggers and
save buttons are activated