### PR TITLE
QUICK-FIX Fix delete button in gear menu

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/delete_modal_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/delete_modal_controller.js
@@ -22,7 +22,9 @@ GGRC.Controllers.Modals("GGRC.Controllers.Delete", {
         cancel_button = this.element.find("a.btn[data-dismiss=modal]"),
         modal_backdrop = this.element.data("modal_form").$backdrop;
 
-    this.bindXHRToButton(this.options.instance.destroy().then(function(instance) {
+    this.bindXHRToButton(this.options.instance.refresh().then(function(instance) {
+      return instance.destroy();
+    }).then(function(instance) {
       // If this modal is spawned from an edit modal, make sure that one does
       // not refresh the instance post-delete.
       var parent_controller = $(that.options.$trigger).closest('.modal').control();


### PR DESCRIPTION
This change makes sure the instance is refreshed before trying to
delete the object. This is necessary because before we added the delete
button to the gear menu, deleting objects was only possible from the
edit modal and the edit modal forced a refresh when it opened.