### PR TITLE
CORE-1903 Stop notifications for inactive cycles

### DIFF
--- a/src/ggrc_workflows/notification/__init__.py
+++ b/src/ggrc_workflows/notification/__init__.py
@@ -21,6 +21,7 @@ from .notification_handler import (
     handle_workflow_modify,
     handle_cycle_task_group_object_task_put,
     handle_cycle_created,
+    handle_cycle_modify,
     handle_cycle_task_status_change,
 )
 
@@ -46,6 +47,10 @@ def register_listeners():
   def cycle_task_group_object_task_put_listener(
           sender, obj=None, src=None, service=None):
     handle_cycle_task_group_object_task_put(obj)
+
+  @Resource.model_put.connect_via(Cycle)
+  def cycle_post_listener(sender, obj=None, src=None, service=None):
+    handle_cycle_modify(sender, obj, src, service)
 
   @Resource.model_posted.connect_via(Cycle)
   def cycle_post_listener(sender, obj=None, src=None, service=None):

--- a/src/ggrc_workflows/notification/notification_handler.py
+++ b/src/ggrc_workflows/notification/notification_handler.py
@@ -16,6 +16,7 @@ exposed functions
     handle_workflow_modify,
     handle_cycle_task_group_object_task_put,
     handle_cycle_created,
+    handle_cycle_modify,
     handle_cycle_task_status_change,
 """
 
@@ -161,6 +162,15 @@ def handle_cycle_task_group_object_task_put(obj):
   if inspect(obj).attrs.end_date.history.has_changes():
     modify_cycle_task_end_date(obj)
 
+
+def remove_all_cycle_task_notifications(obj):
+  for cycle_task in obj.cycle_task_group_object_tasks:
+    for notif in get_notification(cycle_task):
+      db.session.delete(notif)
+
+def handle_cycle_modify(sender, obj=None, src=None, service=None):
+  if not obj.is_current:
+    remove_all_cycle_task_notifications(obj)
 
 def handle_cycle_created(sender, obj=None, src=None, service=None,
                          manually=False):

--- a/src/tests/ggrc_workflows/generator.py
+++ b/src/tests/ggrc_workflows/generator.py
@@ -160,10 +160,10 @@ class WorkflowsGenerator(Generator):
 
     return response, workflow
 
-  def modify_cycle_task_group_object_task(self, obj, data={}):
+  def modify_object(self, obj, data={}):
     self._session_add(obj)
 
-    obj_name = "cycle_task_group_object_task"
+    obj_name = obj._inflector.table_singular
 
     obj_dict = builder.json.publish(obj)
     builder.json.publish_representation(obj_dict)

--- a/src/tests/ggrc_workflows/notifications/test_one_time_wf_end_date_change.py
+++ b/src/tests/ggrc_workflows/notifications/test_one_time_wf_end_date_change.py
@@ -143,9 +143,9 @@ class TestOneTimeWfEndDateChange(TestCase):
       task2 = CycleTaskGroupObjectTask.query.get(
         cycle.cycle_task_group_object_tasks[1].id)
 
-      self.wf_generator.modify_cycle_task_group_object_task(
+      self.wf_generator.modify_object(
         task1, data = {"end_date": date(2015, 5, 15)})
-      self.wf_generator.modify_cycle_task_group_object_task(
+      self.wf_generator.modify_object(
         task2, data = {"end_date": date(2015, 5, 15)})
 
     with freeze_time("2015-05-04 03:21:34"):  # one day befor due date
@@ -201,9 +201,9 @@ class TestOneTimeWfEndDateChange(TestCase):
       task2 = CycleTaskGroupObjectTask.query.get(
         cycle.cycle_task_group_object_tasks[1].id)
 
-      self.wf_generator.modify_cycle_task_group_object_task(
+      self.wf_generator.modify_object(
         task1, data = {"end_date": date(2015, 5, 1)})
-      self.wf_generator.modify_cycle_task_group_object_task(
+      self.wf_generator.modify_object(
         task2, data = {"end_date": date(2015, 5, 1)})
 
     with freeze_time("2015-05-03 03:21:34"):  # one day befor due date
@@ -244,9 +244,9 @@ class TestOneTimeWfEndDateChange(TestCase):
       task2 = CycleTaskGroupObjectTask.query.get(
         cycle.cycle_task_group_object_tasks[1].id)
 
-      self.wf_generator.modify_cycle_task_group_object_task(
+      self.wf_generator.modify_object(
         task1, data = {"end_date": date(2015, 5, 3)})
-      self.wf_generator.modify_cycle_task_group_object_task(
+      self.wf_generator.modify_object(
         task2, data = {"end_date": date(2015, 5, 4)})
 
     with freeze_time("2015-05-03 03:21:34"):  # one day befor due date


### PR DESCRIPTION
Notifications should be disabled for inactive cycles, no matter how the
cycle ended (by finishing all tasks or manually ending it).
