### PR TITLE
QUICK-FIX Stop existing due notifications for ended cycles

### DIFF
--- a/src/ggrc_workflows/notification/__init__.py
+++ b/src/ggrc_workflows/notification/__init__.py
@@ -13,7 +13,6 @@ from ggrc_workflows.services.common import Signals
 from .data_handler import (
     get_cycle_data,
     get_workflow_data,
-    get_task_group_task_data,
     get_cycle_task_data,
 )
 
@@ -25,13 +24,18 @@ from .notification_handler import (
 )
 
 
+def empty_notification(*agrs):
+  """ Used for ignoring notificaitons of a certain type """
+  return {}
+
+
 def contributed_notifications():
   """ return handler functions for all object types
   """
   return {
       'Cycle': get_cycle_data,
       'Workflow': get_workflow_data,
-      'TaskGroupTask': get_task_group_task_data,
+      'TaskGroupTask': empty_notification,
       'CycleTaskGroupObjectTask': get_cycle_task_data,
   }
 
@@ -77,19 +81,6 @@ All notifications handle the following structure:
                       { workflow_owner.id: workflow_owner_info, ...},
                   "start_date": MM/DD/YYYY
                   "fuzzy_start_date": "in X days/weeks ..."
-
-                  "my_tasks" : # list of all tasks assigned to the user
-                      { (task.id, object.id): { task_info, obj_info}, ... }
-
-                  # list of all task groups assigned to the user, including
-                  # tasks
-                  "my_task_groups" :
-                      { task_group.id:
-                          { (task.id, object.id): { task_info, obj_info}, ... }
-                      }
-
-                  "workflow_tasks" : # list of all tasks in the workflow
-                      { (task.id, object.id): { task_info, obj_info}, ... }
               }
               , ...
           }

--- a/src/ggrc_workflows/notification/data_handler.py
+++ b/src/ggrc_workflows/notification/data_handler.py
@@ -186,6 +186,11 @@ def get_cycle_task_declined_data(notification):
 
 
 def get_cycle_task_data(notification):
+
+  cycle_task = get_object(CycleTaskGroupObjectTask, notification.object_id)
+  if not cycle_task.cycle_task_group.cycle.is_current:
+    return {}
+
   notification_name = notification.notification_type.name
   if notification_name in ["manual_cycle_created", "cycle_created"]:
     return get_cycle_created_task_data(notification)

--- a/src/ggrc_workflows/notification/data_handler.py
+++ b/src/ggrc_workflows/notification/data_handler.py
@@ -20,7 +20,6 @@ from ggrc_workflows.models import (
 exposed functions
     get_cycle_data,
     get_workflow_data,
-    get_task_group_task_data,
     get_cycle_task_data,
 """
 
@@ -206,80 +205,6 @@ def get_cycle_task_data(notification):
     return get_cycle_task_due(notification)
 
   return {}
-
-
-def get_task_group_task_data(notification):
-  task_group_task = get_object(TaskGroupTask, notification.object_id)
-  if not task_group_task:
-    return {}
-
-  task_group = task_group_task.task_group
-  workflow = task_group.workflow
-  force = workflow.notify_on_change
-
-  if workflow.status != "Active":
-    return {}
-  if workflow.next_cycle_start_date < date.today():
-    return {}  # this can only be if the cycle has successfully started
-
-  tasks = {}
-
-  task_assignee = get_person_dict(task_group_task.contact)
-  task_group_assignee = get_person_dict(task_group.contact)
-  workflow_owners = get_workflow_owners_dict(workflow.context_id)
-
-  for task_group_object in task_group.task_group_objects:
-    tasks[task_group_task.id, task_group_object.id] = {
-        "task_title": task_group_task.title,
-        "object_title": task_group_object.object.title,
-    }
-
-  result = {}
-  assignee_data = {
-      task_assignee['email']: {
-          "user": task_assignee,
-          "force_notifications": {
-              notification.id: force
-          },
-          "cycle_starts_in": {
-              workflow.id: {
-                  "my_tasks": tasks
-              }
-          }
-      }
-  }
-  tg_assignee_data = {
-      task_group_assignee['email']: {
-          "user": task_group_assignee,
-          "force_notifications": {
-              notification.id: force
-          },
-          "cycle_starts_in": {
-              workflow.id: {
-                  "my_task_groups": {
-                      task_group.id: tasks
-                  }
-              }
-          }
-      }
-  }
-  for workflow_owner in workflow_owners.itervalues():
-    wf_owner_data = {
-        workflow_owner['email']: {
-            "user": workflow_owner,
-            "force_notifications": {
-                notification.id: force
-            },
-            "cycle_starts_in": {
-                workflow.id: {
-                    "workflow_tasks": tasks
-                }
-            }
-        }
-    }
-    result = merge_dicts(result, wf_owner_data)
-
-  return merge_dicts(result, tg_assignee_data, assignee_data)
 
 
 def get_workflow_starts_in_data(notification, workflow):


### PR DESCRIPTION
This fix is to stop and due date notification for a task that in a cycle
that was already manually stopped. There is already a fix to stop
creating such notifications and this is a quick patch for the old
notifications.