### PR TITLE
Remove .pyc files before running tests

### DIFF
--- a/bin/run_pytests
+++ b/bin/run_pytests
@@ -6,6 +6,7 @@
 
 SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
 cd "${SCRIPTPATH}/../src"
+find . -iname "*.pyc" -delete
 mysql -uroot -proot -e "DROP DATABASE IF EXISTS ggrcdevtest; CREATE DATABASE ggrcdevtest; USE ggrcdevtest;"
 export GGRC_SETTINGS_MODULE="testing ggrc_basic_permissions.settings.development ggrc_gdrive_integration.settings.development ggrc_risk_assessments.settings.development ggrc_workflows.settings.development"
 db_migrate


### PR DESCRIPTION
Remove .pyc files before running tests to ensure clean slate of files