### PR TITLE
QUICK-FIX Use Ubuntu 14.04 for vagrant development

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,10 +7,7 @@
 # Maintained By: dan@reciprocitylabs.com
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "ggrc"
-
-  # Fetch the box if it doesn't already exist.
-  config.vm.box_url = "http://files.vagrantup.com/precise64.box"
+  config.vm.box = "ubuntu/trusty64"
 
   # If you are installing repeatedly, you can download the box from the above
   # link and use this local `box_url` instead:

--- a/provision/roles/ggrc/tasks/main.yml
+++ b/provision/roles/ggrc/tasks/main.yml
@@ -80,7 +80,6 @@
     name: "{{ item.name }}"
     global: yes
     state: present
-    registry: http://registry.npmjs.org/
 
 - name: install local npm modules
   sudo: no
@@ -88,5 +87,4 @@
   npm:
     name: "{{ item.name }}"
     state: present
-    registry: http://registry.npmjs.org/
     path: "/vagrant/node_modules"

--- a/provision/roles/ggrc/vars/main.yml
+++ b/provision/roles/ggrc/vars/main.yml
@@ -15,7 +15,7 @@ ggrc_packages:
   - name: python-imaging
   - name: sqlite3
   - name: python-dev
-  - name: rubygems
+  - name: ruby
   - name: nodejs
 
 ggrc_development_directories:


### PR DESCRIPTION
**Warning** this breaks existing vagrant setups. On `vagrant up` it will re-provision.

I've been using 14.04 for last two weeks and everything works. 

This is a prerequisite for the docker based development setup I'm planing to merge if I get this in now :smile: 