### PR TITLE
CORE-2449 Add Dockerfile based dev environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM phusion/baseimage
+ADD . /vagrant
+
+WORKDIR /vagrant
+
+RUN apt-get update && apt-get install -y ansible python-apt python-pycurl wget
+
+RUN useradd -G sudo -m vagrant \
+ && echo "vagrant ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers \
+ && chown -R vagrant.vagrant . \
+ && rm /usr/sbin/policy-rc.d
+
+RUN su vagrant -c "ansible-playbook -i provision/docker/inventory provision/site.yml"
+
+RUN /etc/init.d/mysql stop \
+ && cd /var/lib && mv mysql mysql-hd && ln -s mysql-hd mysql \
+ && cp /vagrant/provision/docker/01_start_mysql.sh /etc/my_init.d/ \
+ && chmod +x /etc/my_init.d/01_start_mysql.sh
+
+RUN rm -rf /vagrant \
+ && mkdir /vagrant \
+ && chown vagrant.vagrant /vagrant

--- a/README.md
+++ b/README.md
@@ -21,9 +21,10 @@ environment:
 
 Or alternatively (see Quickstart with docker)
 
-|               Prerequisite      |         Description        |
-|---------------------------------|----------------------------|
-|[Docker](https://www.docker.com/)| Container management toool |
+|               Prerequisite                       |                 Description              |
+|--------------------------------------------------|------------------------------------------|
+|[Docker](https://www.docker.com/)                 | Container management tool                |
+|[Docker compose](https://docs.docker.com/compose/)| A tool for defining multi-container apps |
 
 Quick Start
 -----------

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ environment:
 |[Vagrant](http://www.vagrantup.com/)      | Handy scriptable VM management           |
 |[Ansible](http://www.ansible.com/home)    | Provisioning and deployment tool         |
 
+Or alternatively (see Quickstart with docker)
+
+|               Prerequisite      |         Description        |
+|---------------------------------|----------------------------|
+|[Docker](https://www.docker.com/)| Container management toool |
+
 Quick Start
 -----------
 
@@ -46,10 +52,32 @@ VM](#provision-a-running-vagrant-vm) below for more).
 
 Now you're in the VM and ready to rock. Get to work!
 
+### Quickstart with docker
+
+Alternative setup is using just docker. Run a vagrant-like fat docker container
+named *ggrccore_dev_1* with this command (from the repo root)
+
+    docker-compose up
+
+Add `-d` to automatically daemonize.
+To enter a running container run
+
+    docker exec -it ggrccore_dev_1 su vagrant
+
+And then continue just like with vagrant
+
+    build_compass
+    build_assets
+    db_migrate
+
+`docker-compose` will manage the containers for you. If you want to reuse old container use
+
+    docker-compose --no-recreate
+
 ### Launching gGRC as Stand-alone Flask
 
-Most development is done in a stand-alone flask. We strive to make getting up 
-and running as simple as possible; to that end, launching the application is 
+Most development is done in a stand-alone flask. We strive to make getting up
+and running as simple as possible; to that end, launching the application is
 simple:
 
 ```sh
@@ -58,7 +86,7 @@ launch_ggrc
 
 ### Launching gGRC in Google App Engine SDK
 
-We strive to make getting up and running as simple as possible; to that end, 
+We strive to make getting up and running as simple as possible; to that end,
 launching the application in the Google App Engine SDK environment is simple:
 
 ```sh
@@ -76,7 +104,7 @@ deploy_appengine extras/deploy_settings_local.sh
 
 The application will be accessible via this URL: <http://localhost:8080/>
 
-If you're running the Google App Engine SDK, the App Engine management console 
+If you're running the Google App Engine SDK, the App Engine management console
 will be avaiable via this URL: <http://localhost:8000/>
 
 ### Running Tests
@@ -97,7 +125,7 @@ For Python tests:
 run_pytests
 ```
 
-The script will run unit tests and integration tests. 
+The script will run unit tests and integration tests.
 
 For better usage of unit tests you can use sniffer inside the test/unit folder.
 This will run the tests on each file update.
@@ -361,6 +389,6 @@ build_assets
 # Copyright Notice
 
 Copyright (C) 2013-2015 Google Inc., authors, and contributors (see the AUTHORS
-file).  
+file).
 Licensed under the [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0)
 license (see the LICENSE file).

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,10 +7,7 @@
 # Maintained By: dan@reciprocitylabs.com
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "ggrc"
-
-  # Fetch the box if it doesn't already exist.
-  config.vm.box_url = "http://files.vagrantup.com/precise64.box"
+  config.vm.box = "ubuntu/trusty64"
 
   # If you are installing repeatedly, you can download the box from the above
   # link and use this local `box_url` instead:

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,4 @@
+#!/bin/bash
+build_compass
+build_assets
+db_migrate

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+dev:
+  build: .
+  command: /sbin/my_init
+  ports:
+   - "8000:8000"
+   - "8080:8080"
+   - "9876:9876"
+  volumes:
+    - ".:/vagrant"
+  privileged: true

--- a/provision/docker/01_start_mysql.sh
+++ b/provision/docker/01_start_mysql.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+cd /
+mkdir /ram
+mount -t tmpfs -o size=2G none /ram
+if [ $? -eq 0 ]; then
+  mkdir /ram/mysql
+  rsync -aSx /var/lib/mysql-hd/. /ram/mysql/.
+  cd /var/lib
+  rm mysql
+  ln -s /ram/mysql
+  (
+    while true; do
+      sleep 300
+      rsync -aSx /ram/mysql/. /var/lib/mysql-hd/.
+    done
+  ) &
+else
+  rmdir /ram
+fi
+
+/etc/init.d/mysql start

--- a/provision/docker/inventory
+++ b/provision/docker/inventory
@@ -1,0 +1,2 @@
+[localhost]
+localhost   ansible_connection=local

--- a/provision/inventory
+++ b/provision/inventory
@@ -1,0 +1,2 @@
+[localhost]
+localhost	ansible_connection=local

--- a/provision/roles/ggrc/tasks/main.yml
+++ b/provision/roles/ggrc/tasks/main.yml
@@ -50,7 +50,6 @@
     name: "{{ item.name }}"
     global: yes
     state: present
-    registry: http://registry.npmjs.org/
 
 - name: install local npm modules
   sudo: no
@@ -58,7 +57,6 @@
   npm:
     name: "{{ item.name }}"
     state: present
-    registry: http://registry.npmjs.org/
     path: "/vagrant/node_modules"
 
 - name: run make appengine

--- a/provision/roles/ggrc/templates/.bashrc.j2
+++ b/provision/roles/ggrc/templates/.bashrc.j2
@@ -113,3 +113,6 @@ fi
 source /vagrant/bin/init_vagrant_env
 
 export NODE_PATH=/usr/local/lib/node_modules/
+export TERM=xterm-color
+export EDITOR=vim
+PS1='\[\033[01;35m\]\u@\h\[\033[01;34m\] \w \n\$\[\033[00m\] '

--- a/provision/roles/ggrc/vars/main.yml
+++ b/provision/roles/ggrc/vars/main.yml
@@ -15,7 +15,7 @@ ggrc_packages:
   - name: python-imaging
   - name: sqlite3
   - name: python-dev
-  - name: rubygems
+  - name: ruby
   - name: nodejs
 
 ggrc_development_directories:


### PR DESCRIPTION
~~Completely Dockerfile based provisioning that does not break existing Vagrant VMs using Ubuntu 12.04.~~ Dockerfile that uses the same Ansible provisioning as the Vagrant setup. Also updated Vagrant to use ubuntu 14.04.

This may not be idiomatic Docker setup since mysql is running in the same container but I find it very convenient because it let's me run multiple containers with independent databases without manually linking containers together. 
If we're willing to drop this it's quite easy to drop the database and link in a *mysql service* in the `docker-compose.yml` 

I'm not sure about the development workflow using docker. Currently `docker-compose up` will locally build the image (takes 5-10min) if not present. If `requirements.txt` changes you will likely want to rebuild the image. This may take a bit. You will also need to run migrations manually. 
We could have an official binary on docker hub. We could have a base image and another image that bases on it and builds quickly. Or we could just run `pip` and `db_migrate` on container startup. I haven't implemented any of this yet.