### PR TITLE
QUICK-FIX Fix script error in my work

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
@@ -764,6 +764,13 @@ CMS.Controllers.TreeLoader("CMS.Controllers.TreeView", {
 
     for (var i = lo; i <= hi; i++) {
       var control = $(children[i]).control();
+      if (control === undefined || control === null) {
+        // TODO this should not be necessary
+        // draw_visible is called too soon when controlers are not yet
+        // available and then again when they are. Remove the too soon
+        // invocation and this continue can be dropped too.
+        continue;
+      }
       if (!_.contains(visible, control)) {
         visible.push(control);
         control.draw_node();


### PR DESCRIPTION
This is a quick and dirty fix for the script error thrown when switching tabs in my work. I will investigate the underlying issue.

The quick solution is to just ignore visible nodes without attached controllers. This will only waste a millisecond of scripting time computing the visible nodes.