### PR TITLE
CORE-2000 Add styling for nested tree view placeholders

### DIFF
--- a/src/ggrc/assets/stylesheets/_tree.scss
+++ b/src/ggrc/assets/stylesheets/_tree.scss
@@ -938,6 +938,11 @@ ul.new-tree {
 .inner-tree {
   ul.new-tree {
     margin-bottom: 0;
+    .tree-item-placeholder {
+      font-size: 13px;
+      height: 25px;
+      padding: 4px 60% 0 84px;
+    }
     li.tree-item {
       line-height: 28px;
       .generated-link {


### PR DESCRIPTION
Nodes in nested tree views have slightly different look. This added styling
makes the respective placeholders look appropriately to maintain the illusion.