### PR TITLE
QUICK-FIX Remove duplicate person icon in tree views

### DIFF
--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -1704,11 +1704,7 @@ Mustache.registerHelper("infer_roles", function (instance, options) {
   }
   else {
     if (state.attr('roles').attr('length')) {
-      var result = [];
-      can.each(state.attr('roles'), function (role) {
-        result.push(options.fn(role));
-      });
-      return result.join('');
+      return options.fn(options.contexts.add(state.attr('roles').join(', ')));
     }
   }
 });


### PR DESCRIPTION
If a person is both an owner and a contact two person icons
used to show up in the tree view. Now one icon with a tooltip
with all the roles will show up