### PR TITLE
CORE-1990 Fix a script error on audit's response widget

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
@@ -707,6 +707,10 @@ CMS.Controllers.TreeLoader("CMS.Controllers.TreeView", {
       }
 
       if (this.options.mapping) {
+        if (this.options.parent_instance === undefined) {
+          // TODO investigate why is this method sometimes called twice
+          return; // not ready, will try again
+        }
         this.find_all_deferred =
           this.options.parent_instance.get_list_loader(this.options.mapping);
       } else if (this.options.list_loader) {


### PR DESCRIPTION
Since this is the second bug cause by wrong order of events/method-calls I'm assuming the optimization of timeouts in tree view was a bit too aggressive. 
But I'm not confident I will not cause more regressions if I try to fix it now. So I just try to short circuit if the problematic computation should not be running yet (if indicated by missing values). 
Although I'm not quite comfortable with this approach either is worked for me for now. And the small changes (like in this PR) cannot break anything else. 

This PR exposes more script errors on audit page and those are incidentally fixed by #2874. I really don't think copy-pasting code into this PR is a good idea so I propose we don't merge this one until #2874 is merged (the scrip errors are not blocking, just annoying and may confuse the user).