### PR TITLE
QUICK-FIX Switch travis to containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@
 
 python:
   - "2.7"
+sudo: false  # to enable container-based infrastructure
 services: mysql
 virtualenv:
   system_site_packages: true
@@ -17,18 +18,13 @@ install:
   - "wget https://commondatastorage.googleapis.com/appengine-sdks/deprecated/193/google_appengine_1.9.3.zip  -nv"
   - "unzip -qd src google_appengine_1.9.3.zip"
   - "mv src/google_appengine/google src/"
-  - "sudo pip install -r src/requirements.txt"
-  - "sudo pip install -r src/dev-requirements.txt"
-  - "sudo pip install google-api-python-client"
-  - "sudo pip install mysql-python"
-  - "sudo pip install webob"
+  - "pip install --user -r src/requirements.txt"
+  - "pip install --user -r src/dev-requirements.txt"
+  - "pip install --user google-api-python-client"
+  - "pip install --user mysql-python"
+  - "pip install --user webob"
   - 'gem install sass --version "=3.4.9"'
   - 'gem install compass --version "=1.0.1"'
- # weird travis-ci python paths
-  - "export PYTHONPATH=$PYTHONPATH:/usr/lib/pymodules/python2.7/"
-  - "export PYTHONPATH=$PYTHONPATH:/usr/lib/python2.7/dist-packages"
-  - "export PYTHONPATH=$PYTHONPATH:/usr/lib/pyshared/python2.7/"
-  - "export PYTHONPATH=$PYTHONPATH:/usr/local/lib/python2.7/site-packages/"
   - npm install karma karma-jasmine jasmine-core phantomjs karma-chrome-launcher
 before_script:
   - "source bin/init_env"

--- a/src/dev-requirements.txt
+++ b/src/dev-requirements.txt
@@ -8,19 +8,19 @@ Jinja2==2.6
 # This will be unnecessary when behave==1.2.2.16 is released to PyPI
 # see: https://github.com/behave/behave/issues/69
 git+https://github.com/behave/behave.git@1.2.3a19#egg=behave
-Flask-Testing
+Flask-Testing==0.4.2
 git+https://github.com/rbarrois/factory_boy.git#egg=factory-boy
-mock
+mock==1.0.1
 nose==1.3.0
-sniffer
+sniffer==0.3.5
 requests==2.0.0
-PyYAML
-Flask-Jasmine
+PyYAML==3.11
+Flask-Jasmine==1.4
 Alembic==0.6.7
-ipdb
-ipython
+ipdb==0.8.1
+ipython==3.2.0
 MonthDelta==0.9.1
-webob
-names
-flask-debugtoolbar
+webob==1.4.1
+names==0.3.0
+flask-debugtoolbar==0.10.0
 freezegun==0.3.1

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -18,7 +18,7 @@ Flask-Login==0.2.2
 webassets==0.8
 Flask-Assets==0.8
 git+https://github.com/danring/HamlPy.git#egg=HamlPy
-iso8601
+iso8601==0.1.0
 blinker==1.3
 bleach==1.2.2
 html5lib==0.95
@@ -32,4 +32,4 @@ python-dateutil==2.2
 MonthDelta==0.9.1
 babel==1.3
 pytz==2015.2
-holidays
+holidays==0.3.1


### PR DESCRIPTION
This improves travis build speed for a minute or even two if you're lucky and supposedly reduces the queue time (I didn't measure).
Only real configuration change is to `pip` install locally for user not globally. This drops requirement for `sudo` and enables use to use the not-deprecated container-based infrastructure on travis. 
As a side effect we can drop the custom `PYTHONPATH`.

I also needed to freeze versions of all dependencies to get everything to work but I think this is a good idea in general.