### PR TITLE
QUICK-FIX Freeze all python requirements

### DIFF
--- a/src/dev-requirements.txt
+++ b/src/dev-requirements.txt
@@ -8,19 +8,19 @@ Jinja2==2.6
 # This will be unnecessary when behave==1.2.2.16 is released to PyPI
 # see: https://github.com/behave/behave/issues/69
 git+https://github.com/behave/behave.git@1.2.3a19#egg=behave
-Flask-Testing
+Flask-Testing==0.4.2
 git+https://github.com/rbarrois/factory_boy.git#egg=factory-boy
-mock
+mock==1.0.1
 nose==1.3.0
-sniffer
+sniffer==0.3.5
 requests==2.0.0
-PyYAML
-Flask-Jasmine
+PyYAML==3.11
+Flask-Jasmine==1.4
 Alembic==0.6.7
-ipdb
-ipython
+ipdb==0.8.1
+ipython==3.2.0
 MonthDelta==0.9.1
-webob
-names
-flask-debugtoolbar
+webob==1.4.1
+names==0.3.0
+flask-debugtoolbar==0.10.0
 freezegun==0.3.1

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -18,7 +18,7 @@ Flask-Login==0.2.2
 webassets==0.8
 Flask-Assets==0.8
 git+https://github.com/danring/HamlPy.git#egg=HamlPy
-iso8601
+iso8601==0.1.0
 blinker==1.3
 bleach==1.2.2
 html5lib==0.95
@@ -32,4 +32,4 @@ python-dateutil==2.2
 MonthDelta==0.9.1
 babel==1.3
 pytz==2015.2
-holidays
+holidays==0.3.1


### PR DESCRIPTION
Travis builds started failing. Freezing requirements to specific versions fixes this. 