### PR TITLE
CORE-1630 & CORE-2008 Fix "Create objective from section"

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/modals_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/modals_controller.js
@@ -768,10 +768,10 @@ can.Control("GGRC.Controllers.Modals", {
         // If this was an Objective created directly from a Section, create a join
         var params = that.options.object_params;
         if (obj instanceof CMS.Models.Objective && params && params.section) {
-          new CMS.Models.SectionObjective({
-            objective: obj
-            , section: CMS.Models.Section.findInCacheById(params.section.id)
-            , context: { id: null }
+          new CMS.Models.Relationship({
+            source: obj,
+            destination: CMS.Models.Section.findInCacheById(params.section.id),
+            context: { id: null }
           }).save()
           .fail(that.save_error.bind(that))
           .done(function(){

--- a/src/ggrc/assets/javascripts/models/simple_models.js
+++ b/src/ggrc/assets/javascripts/models/simple_models.js
@@ -119,9 +119,6 @@ can.Model.Cacheable("CMS.Models.Objective", {
   , update : "PUT /api/objectives/{id}"
   , destroy : "DELETE /api/objectives/{id}"
   , mixins : ["ownable", "contactable", "unique_title"]
-  , links_to : {
-      "Section" : "SectionObjective"
-  }
   , is_custom_attributable: true
   , attributes : {
       context : "CMS.Models.Context.stub"

--- a/src/ggrc/assets/mustache/base_objects/create_objective_dropdown_option.mustache
+++ b/src/ggrc/assets/mustache/base_objects/create_objective_dropdown_option.mustache
@@ -12,6 +12,6 @@
     data-modal-class="modal-wide"
     data-object-singular="Objective"
     data-object-plural="objectives"
-    data-object-params='{ "section": { "id": {{instance.id}}, "title": "{{title}}" }, "title": "{{title}}", "description": "{{json_escape description}}" }'>Convert to Objective
+    data-object-params='{ "section": { "id": {{instance.id}}, "title": "{{title}}" }, "title": "{{title}}", "description": "{{json_escape description}}" }'>Create Objective from Section
   </a>
 </li>


### PR DESCRIPTION
`Regulation -> Section -> Convert to objective` now renamed to `Create objective from section` and fixed to use `Relationship` instead of custom join that does not exist anymore.
Auto-mappings fire as expected.