### PR TITLE
QUICK-FIX Fix sticky filter and tree header

### DIFF
--- a/src/ggrc/assets/mustache/audits/tree_header.mustache
+++ b/src/ggrc/assets/mustache/audits/tree_header.mustache
@@ -7,7 +7,7 @@
 
 {{{> "/static/mustache/base_objects/tree_view_filter.mustache"}}}
 
-<header class="header sticky tree-header {{#filter_is_hidden}}no-filter{{/filter_is_hidden}}">
+<header class="header sticky sticky-header tree-header {{#filter_is_hidden}}no-filter{{/filter_is_hidden}}">
   <div class="row-fluid">
     <div class="span{{display_options.title_width}}">
       <div class="title-heading oneline">

--- a/src/ggrc/assets/mustache/base_objects/tree_header.mustache
+++ b/src/ggrc/assets/mustache/base_objects/tree_header.mustache
@@ -6,7 +6,7 @@
 }}
 
 {{{> "/static/mustache/base_objects/tree_view_filter.mustache"}}}
-<header class="header sticky tree-header {{#filter_is_hidden}}no-filter{{/filter_is_hidden}}">
+<header class="header sticky sticky-header tree-header {{#filter_is_hidden}}no-filter{{/filter_is_hidden}}">
   <div class="row-fluid">
     <div class="span{{display_options.title_width}}">
       <div class="title-heading oneline">

--- a/src/ggrc/assets/mustache/base_objects/tree_view_filter.mustache
+++ b/src/ggrc/assets/mustache/base_objects/tree_view_filter.mustache
@@ -1,5 +1,5 @@
 
-  <div class="sticky filter-holder" {{#filter_is_hidden}}style="height: 0px; margin-bottom: 0px;"{{/filter_is_hidden}} data-height="42" data-margin-bottom="25">
+  <div class="sticky sticky-header filter-holder" {{#filter_is_hidden}}style="height: 0px; margin-bottom: 0px;"{{/filter_is_hidden}} data-height="42" data-margin-bottom="25">
     <div class="sticky-filter inner-filter-sticky">
       <div class="inline-filtering" {{ (el) -> el.ggrc_controllers_tree_filter() }} >
         <div class="row-fluid">

--- a/src/ggrc/assets/mustache/control_assessments/tree_header.mustache
+++ b/src/ggrc/assets/mustache/control_assessments/tree_header.mustache
@@ -7,7 +7,7 @@
 
 {{{> "/static/mustache/base_objects/tree_view_filter.mustache"}}}
 
-<header class="header sticky tree-header {{#filter_is_hidden}}no-filter{{/filter_is_hidden}}">
+<header class="header sticky sticky-header tree-header {{#filter_is_hidden}}no-filter{{/filter_is_hidden}}">
   <div class="row-fluid">
     <div class="span4">
         <div class="title-heading oneline">

--- a/src/ggrc/assets/mustache/people/tree_header.mustache
+++ b/src/ggrc/assets/mustache/people/tree_header.mustache
@@ -7,7 +7,7 @@
 
 {{{> "/static/mustache/base_objects/tree_view_filter.mustache"}}}
 
-<header class="header sticky tree-header {{#filter_is_hidden}}no-filter{{/filter_is_hidden}}">
+<header class="header sticky sticky-header tree-header {{#filter_is_hidden}}no-filter{{/filter_is_hidden}}">
   <div class="row-fluid">
     <div class="span4">
       <div class="title-heading oneline">

--- a/src/ggrc/assets/mustache/requests/tree_header.mustache
+++ b/src/ggrc/assets/mustache/requests/tree_header.mustache
@@ -7,7 +7,7 @@
 
 {{{> "/static/mustache/base_objects/tree_view_filter.mustache"}}}
 
-<header class="header sticky tree-header {{#filter_is_hidden}}no-filter{{/filter_is_hidden}}">
+<header class="header sticky sticky-header tree-header {{#filter_is_hidden}}no-filter{{/filter_is_hidden}}">
   <div class="row-fluid">
     <div class="span{{display_options.title_width}}">
       <div class="title-heading oneline">

--- a/src/ggrc/assets/stylesheets/_common.scss
+++ b/src/ggrc/assets/stylesheets/_common.scss
@@ -690,7 +690,6 @@ select.multiple-selector {
 // Sticky headers
 .sticky-header {
   @extend %sticky;
-  @include box-shadow(inset 0 0 3px 0 #bbb);
   border-top: none !important;
 }
 

--- a/src/ggrc_risk_assessments/assets/mustache/risk_assessments/tree_header.mustache
+++ b/src/ggrc_risk_assessments/assets/mustache/risk_assessments/tree_header.mustache
@@ -7,7 +7,7 @@
 
 {{{> "/static/mustache/base_objects/tree_view_filter.mustache"}}}
 
-<header class="header sticky tree-header {{#filter_is_hidden}}no-filter{{/filter_is_hidden}}">
+<header class="header sticky sticky-header tree-header {{#filter_is_hidden}}no-filter{{/filter_is_hidden}}">
   <div class="row-fluid">
     <div class="span4">
       <div class="title-heading oneline">

--- a/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/tree_header.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/tree_header.mustache
@@ -7,7 +7,7 @@
 
 {{{> "/static/mustache/base_objects/tree_view_filter.mustache"}}}
 
-<header class="header sticky tree-header {{#filter_is_hidden}}no-filter{{/filter_is_hidden}}">
+<header class="header sticky sticky-header tree-header {{#filter_is_hidden}}no-filter{{/filter_is_hidden}}">
   <div class="row-fluid">
     <div class="span{{display_options.title_width}}">
       <div class="title-heading oneline">

--- a/src/ggrc_workflows/assets/mustache/cycles/tree_header.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycles/tree_header.mustache
@@ -7,7 +7,7 @@
 
 {{{> "/static/mustache/base_objects/tree_view_filter.mustache"}}}
 
-<header class="header sticky tree-header {{#filter_is_hidden}}no-filter{{/filter_is_hidden}}">
+<header class="header sticky sticky-header tree-header {{#filter_is_hidden}}no-filter{{/filter_is_hidden}}">
   <div class="row-fluid">
     <div class="span6">
       <div class="title-heading oneline">

--- a/src/ggrc_workflows/assets/mustache/task_groups/tree_header.mustache
+++ b/src/ggrc_workflows/assets/mustache/task_groups/tree_header.mustache
@@ -7,7 +7,7 @@
 
 {{{> "/static/mustache/base_objects/tree_view_filter.mustache"}}}
 
-<header class="header sticky tree-header {{#filter_is_hidden}}no-filter{{/filter_is_hidden}}">
+<header class="header sticky sticky-header tree-header {{#filter_is_hidden}}no-filter{{/filter_is_hidden}}">
   <div class="row-fluid">
     <div class="span6">
       <div class="title-heading oneline">


### PR DESCRIPTION
As a side effect the tree view can now be scrolled to the bottom.