### PR TITLE
QUICK-FIX Add a CodeClimate badge

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,7 @@
+languages:
+  Python: true
+  JavaScript: true
+exclude_paths:
+  - "src/ggrc/assets/javascripts/generated/*"
+  - "src/ggrc/assets/vendor/*"
+  - "src/ggrc/static/mockups/js/lib"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ gGRC-Core
 =========
 
 [![Travis status](https://travis-ci.org/google/ggrc-core.svg?branch=develop)](https://travis-ci.org/google/ggrc-core)
+[![Code Climate](https://codeclimate.com/github/google/ggrc-core/badges/gpa.svg)](https://codeclimate.com/github/google/ggrc-core)
 
 Google Governance, Risk and Compliance. Migrated from [Google](https://code.google.com/p/compliance-management/)
 [Code](https://code.google.com/p/ggrc-core).


### PR DESCRIPTION
Since this is an open source project CodeClimate will run analysis for free. I'd like to have this badge showing the status of our code and provide a quick link to a list of potential issues. 
Sadly we cannot have this on PRs without a subscription. 

We can however enable the [linthub](http:/linthub.io) bot to comment on our PRs providing feedback on style issues. 