### PR TITLE
CORE-2078 Fix gear icon dropdown on CA page

### DIFF
--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -3098,7 +3098,7 @@ Mustache.registerHelper("with_create_issue_json", function (instance, options) {
       audit, programs, program, control, json;
 
   if (!audits.length) {
-    return "{}";
+    return "";
   }
 
   audit = audits[0].instance.reify();


### PR DESCRIPTION
In case the CA has no audits mapped. A proper long-term fix will be to always ensure that a CA has exactly one audit mapped. But this may prove to be quite tricky. 

A short explanation of this bug because I find it interesting
When there were no audits the helper behaved like it returns a stringified JSON and defaulted to `"{}"`. But when there was an audit (the normal case) it called its continuation with the stringified JSON as a parameter and returned the result. 
I fixed it by returning `""` (which is now an html string, not json) in the edge case and thus not rendering anything audit-related.