### PR TITLE
CORE-2111 Move custom attr list from tree_view controller

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
@@ -528,7 +528,7 @@ CMS.Controllers.TreeLoader("CMS.Controllers.TreeView", {
         model_definition = model().class.root_object,
         mandatory_attr_names, display_attr_names;
 
-    //get standard attrs for each model
+    //get standard attrs and custom attributes for each model
     can.each(model.tree_view_options.attr_list || can.Model.Cacheable.attr_list, function (item) {
         if (!item.attr_sort_field) {
           item.attr_sort_field = item.attr_name;
@@ -539,18 +539,6 @@ CMS.Controllers.TreeLoader("CMS.Controllers.TreeView", {
     mandatory_attr_names = model.tree_view_options.mandatory_attr_names ?
       model.tree_view_options.mandatory_attr_names :
         can.Model.Cacheable.tree_view_options.mandatory_attr_names;
-
-    //get custom attrs
-    can.each(GGRC.custom_attr_defs, function (def, i) {
-      if (def.definition_type === model_definition && def.attribute_type !== 'Rich Text') {
-        var obj = {};
-        obj.attr_title = obj.attr_name = def.title;
-        obj.display_status = false;
-        obj.attr_type = 'custom';
-        obj.attr_sort_field = 'custom:'+obj.attr_name;
-        select_attr_list.push(obj);
-      }
-    });
 
     //Get the display attr_list from local storage
     saved_attr_list = this.display_prefs.getTreeViewHeaders(model_name);

--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -764,6 +764,9 @@ can.Model.Cacheable("CMS.Models.ControlAssessment", {
   create : "POST /api/control_assessments",
   mixins : ["ownable", "contactable", "unique_title"],
   is_custom_attributable: true,
+  tree_view_options : {
+    attr_list: can.Model.Cacheable.attr_list
+  },
   attributes : {
     control : "CMS.Models.Control.stub",
     context : "CMS.Models.Context.stub",

--- a/src/ggrc/assets/javascripts/models/cacheable.js
+++ b/src/ggrc/assets/javascripts/models/cacheable.js
@@ -7,7 +7,22 @@
 
 //= require can.jquery-all
 
+
 (function(can) {
+
+function get_custom_attr_list(model) {
+  var custom_list = [];
+  can.each(GGRC.custom_attr_defs, function (def, i) {
+    if (def.definition_type === model && def.attribute_type !== 'Rich Text') {
+      var obj = {};
+      obj.attr_title = obj.attr_name = def.title;
+      obj.attr_type = 'custom';
+      obj.attr_sort_field = 'custom:'+obj.attr_name;
+      custom_list.push(obj);
+    }
+  });
+  return custom_list;
+};
 
 var makeFindRelated = function(thistype, othertype) {
   return function(params) {
@@ -376,6 +391,26 @@ can.Model("can.Model.Cacheable", {
         GGRC.custom_attributable_types = [];
       }
       GGRC.custom_attributable_types.push($.extend({}, this));
+      this.update_custom_attr_list();
+    }
+  }
+
+  , update_custom_attr_list: function () {
+    var model_name = this.model_singular,
+        model_type = this.table_singular,
+        custom_attr_list = get_custom_attr_list(model_type);
+
+    if(custom_attr_list.length === 0)
+      return;
+
+    if (this.tree_view_options.attr_list) {
+      this.tree_view_options.attr_list = this.tree_view_options.attr_list.concat(custom_attr_list);
+    } else if (this.tree_view_options) {
+      var attr_list = [];
+      can.each(can.Model.Cacheable.attr_list, function (item) {
+        attr_list.push(item);
+      });
+      this.tree_view_options.attr_list = attr_list.concat(custom_attr_list);
     }
   }
 

--- a/src/ggrc/assets/javascripts/models/cacheable.js
+++ b/src/ggrc/assets/javascripts/models/cacheable.js
@@ -12,13 +12,14 @@
 
 function get_custom_attr_list(model) {
   var custom_list = [];
-  can.each(GGRC.custom_attr_defs, function (def, i) {
+  can.each(GGRC.custom_attr_defs, function (def) {
     if (def.definition_type === model && def.attribute_type !== 'Rich Text') {
-      var obj = {};
-      obj.attr_title = obj.attr_name = def.title;
-      obj.attr_type = 'custom';
-      obj.attr_sort_field = 'custom:'+obj.attr_name;
-      custom_list.push(obj);
+      custom_list.push({
+        attr_title : def.title,
+        attr_name : def.title,
+        attr_type :'custom',
+        attr_sort_field : 'custom:' + def.title
+      });
     }
   });
   return custom_list;
@@ -400,17 +401,14 @@ can.Model("can.Model.Cacheable", {
         model_type = this.table_singular,
         custom_attr_list = get_custom_attr_list(model_type);
 
-    if(custom_attr_list.length === 0)
+    if(custom_attr_list.length === 0) {
       return;
+    }
 
-    if (this.tree_view_options.attr_list) {
+    if(this.tree_view_options.attr_list) {
       this.tree_view_options.attr_list = this.tree_view_options.attr_list.concat(custom_attr_list);
     } else if (this.tree_view_options) {
-      var attr_list = [];
-      can.each(can.Model.Cacheable.attr_list, function (item) {
-        attr_list.push(item);
-      });
-      this.tree_view_options.attr_list = attr_list.concat(custom_attr_list);
+      this.tree_view_options.attr_list = [].concat(can.Model.Cacheable.attr_list, custom_attr_list);
     }
   }
 

--- a/src/ggrc/assets/javascripts/models/directive_models.js
+++ b/src/ggrc/assets/javascripts/models/directive_models.js
@@ -101,10 +101,13 @@ CMS.Models.Directive("CMS.Models.Standard", {
   }
   , is_custom_attributable: true
   , attributes : {}
+  , tree_view_options : {}
   , meta_kinds : [ "Standard" ]
   , cache : can.getObject("cache", CMS.Models.Directive, true)
   , init : function() {
     can.extend(this.attributes, CMS.Models.Directive.attributes);
+    can.extend(this.tree_view_options, CMS.Models.Directive.tree_view_options);
+    this.tree_view_options.attr_list = can.Model.Cacheable.attr_list;
     this._super.apply(this, arguments);
   }
 }, {});
@@ -128,10 +131,13 @@ CMS.Models.Directive("CMS.Models.Regulation", {
   }
   , is_custom_attributable: true
   , attributes : {}
+  , tree_view_options : {}
   , meta_kinds : [ "Regulation" ]
   , cache : can.getObject("cache", CMS.Models.Directive, true)
   , init : function() {
     can.extend(this.attributes, CMS.Models.Directive.attributes);
+    can.extend(this.tree_view_options, CMS.Models.Directive.tree_view_options);
+    this.tree_view_options.attr_list = can.Model.Cacheable.attr_list;
     this._super.apply(this, arguments);
   }
 }, {});
@@ -190,10 +196,13 @@ CMS.Models.Directive("CMS.Models.Contract", {
   , is_custom_attributable: true
   , attributes : {
   }
+  , tree_view_options : {}
   , meta_kinds : [ "Contract" ]
   , cache : can.getObject("cache", CMS.Models.Directive, true)
   , init : function() {
     can.extend(this.attributes, CMS.Models.Directive.attributes);
+    can.extend(this.tree_view_options, CMS.Models.Directive.tree_view_options);
+    this.tree_view_options.attr_list = can.Model.Cacheable.attr_list;
     this._super.apply(this, arguments);
   }
 }, {});

--- a/src/ggrc/assets/javascripts/models/directive_models.js
+++ b/src/ggrc/assets/javascripts/models/directive_models.js
@@ -107,7 +107,6 @@ CMS.Models.Directive("CMS.Models.Standard", {
   , init : function() {
     can.extend(this.attributes, CMS.Models.Directive.attributes);
     can.extend(this.tree_view_options, CMS.Models.Directive.tree_view_options);
-    this.tree_view_options.attr_list = can.Model.Cacheable.attr_list;
     this._super.apply(this, arguments);
   }
 }, {});
@@ -137,7 +136,6 @@ CMS.Models.Directive("CMS.Models.Regulation", {
   , init : function() {
     can.extend(this.attributes, CMS.Models.Directive.attributes);
     can.extend(this.tree_view_options, CMS.Models.Directive.tree_view_options);
-    this.tree_view_options.attr_list = can.Model.Cacheable.attr_list;
     this._super.apply(this, arguments);
   }
 }, {});
@@ -202,7 +200,6 @@ CMS.Models.Directive("CMS.Models.Contract", {
   , init : function() {
     can.extend(this.attributes, CMS.Models.Directive.attributes);
     can.extend(this.tree_view_options, CMS.Models.Directive.tree_view_options);
-    this.tree_view_options.attr_list = can.Model.Cacheable.attr_list;
     this._super.apply(this, arguments);
   }
 }, {});

--- a/src/ggrc/assets/javascripts/models/issue.js
+++ b/src/ggrc/assets/javascripts/models/issue.js
@@ -15,6 +15,9 @@
     create : "POST /api/issues",
     mixins : ["ownable", "contactable"],
     is_custom_attributable: true,
+    tree_view_options : {
+      attr_list: can.Model.Cacheable.attr_list
+    },
     attributes : {
       context : "CMS.Models.Context.stub",
       modified_by : "CMS.Models.Person.stub",


### PR DESCRIPTION
Cacheable.js loads the custom attribute list to existing attr_list for each model type