### PR TITLE
CORE-2092 Fix tree view task sorting by workflow/object

### DIFF
--- a/src/ggrc_workflows/assets/javascripts/models/cycle_models.js
+++ b/src/ggrc_workflows/assets/javascripts/models/cycle_models.js
@@ -314,8 +314,8 @@
       show_view: _mustache_path + "/tree.mustache",
       attr_list : [
         {attr_title: 'Title', attr_name: 'title'},
-        {attr_title: 'Mapped Object', attr_name: 'mapped_object', attr_sort_field: 'mapped_object.title'},
-        {attr_title: 'Workflow', attr_name: 'workflow', attr_sort_field: 'workflow.title'},
+        {attr_title: 'Mapped Object', attr_name: 'mapped_object', attr_sort_field: 'cycle_task_group_object.title'},
+        {attr_title: 'Workflow', attr_name: 'workflow', attr_sort_field: 'cycle.workflow.title'},
         {attr_title: 'State', attr_name: 'status'},
         {attr_title: 'Assignee', attr_name: 'assignee', attr_sort_field: 'contact.name|email'},
         {attr_title: 'Start Date', attr_name: 'start_date'},


### PR DESCRIPTION
This uncovers an unrelated bug: where there is no mapped object the sorting is not consistent when changing direction. This is a  problem in the new sorting logic and I'll fix it in a separate PR.