### PR TITLE
CORE-1994 Prevent wrong warnings on program import

### DIFF
--- a/src/ggrc_basic_permissions/converters/handlers.py
+++ b/src/ggrc_basic_permissions/converters/handlers.py
@@ -31,7 +31,7 @@ class ProgramRoleColumnHandler(UserColumnHandler):
       else:
         self.add_warning(errors.UNKNOWN_USER_WARNING, email=email)
 
-    if not users:
+    if not users and self.key == "program_owner":
       self.add_warning(errors.OWNER_MISSING)
       users.add(get_current_user())
 


### PR DESCRIPTION
Owner missing warnings should not be displaye on empty program reader
and program editor columns.