### PR TITLE
QUICK-FIX Add prefixes to keys of attribute definitions

### DIFF
--- a/src/ggrc/converters/handlers.py
+++ b/src/ggrc/converters/handlers.py
@@ -26,6 +26,10 @@ from ggrc.models import Relationship
 from ggrc.models.relationship import RelationshipHelper
 
 
+MAPPING_PREFIX = "__mapping__:"
+CUSTOM_ATTR_PREFIX = "__custom__:"
+
+
 class ColumnHandler(object):
 
   def __init__(self, row_converter, key, **options):
@@ -237,7 +241,7 @@ class MappingColumnHandler(ColumnHandler):
 
   def __init__(self, row_converter, key, **options):
     self.key = key
-    self.mapping_name = key[4:]  # remove "map:" prefix
+    self.mapping_name = key[len(MAPPING_PREFIX):]
     importable = get_importables()
     self.mapping_object = importable.get(self.mapping_name)
     self.new_slugs = row_converter.block_converter.converter.new_objects[
@@ -328,7 +332,7 @@ class CustomAttributeColumHandler(TextColumnHandler):
   def get_ca_definition(self):
     for definition in self.row_converter.object_class\
             .get_custom_attribute_definitions():
-      if definition.title == self.key:
+      if definition.title == self.display_name:
         return definition
     return None
 
@@ -468,7 +472,7 @@ class SectionDirectiveColumnHandler(ColumnHandler):
 class ControlColumnHandler(MappingColumnHandler):
 
   def __init__(self, row_converter, key, **options):
-    key = "map:control"
+    key = "{}control".format(MAPPING_PREFIX)
     super(ControlColumnHandler, self).__init__(row_converter, key, **options)
 
   def set_obj_attr(self):
@@ -480,6 +484,6 @@ class ControlColumnHandler(MappingColumnHandler):
 
 class AuditColumnHandler(MappingColumnHandler):
   def __init__(self, row_converter, key, **options):
-    key = "map:audit"
+    key = "{}audit".format(MAPPING_PREFIX)
     super(AuditColumnHandler, self).__init__(row_converter, key, **options)
 

--- a/src/ggrc/converters/import_helper.py
+++ b/src/ggrc/converters/import_helper.py
@@ -25,9 +25,9 @@ def get_mapping_definitions(object_class):
 
   for mapping_class in mapping_rules[object_class.__name__]:
     class_name = pretty_name(mapping_class)
-    mapping_name = "map:{}".format(class_name)
+    mapping_name = "{}{}".format(handlers.MAPPING_PREFIX, class_name)
     definitions[mapping_name.lower()] = {
-        "display_name": mapping_name,
+        "display_name": "map:{}".format(class_name),
         "mandatory": False,
         "handler": handlers.MappingColumnHandler,
         "validator": None,
@@ -47,11 +47,11 @@ def get_custom_attr_definitions(object_class):
     return definitions
   custom_attributes = object_class.get_custom_attribute_definitions()
   for attr in custom_attributes:
-    handler = handlers.CustomAttributeColumHandler
-    definitions[attr.title] = {
+    attr_name = "{}{}".format(handlers.CUSTOM_ATTR_PREFIX, attr.id)
+    definitions[attr_name] = {
         "display_name": attr.title,
         "mandatory": attr.mandatory,
-        "handler": handler,
+        "handler": handlers.CustomAttributeColumHandler,
         "validator": None,
         "default": None,
         "unique": False,


### PR DESCRIPTION
We have to add propper prefixes for non standard attributes such as
mappings and custom attributes. Without unique prefixes, custom
attributes with the same name as original attributes would be hidden and
ignored when importing objects. Example would be if we had a custom
attribute with the name "Title". then imports would fail for that
object.