### PR TITLE
CORE-2098 Fix infinite spinner for comments under tasks

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
@@ -316,13 +316,6 @@ can.Control("CMS.Controllers.TreeLoader", {
           child_tree_display_list = [],
           refreshed_deferred;
 
-      if (!items || items.length === 0) {
-        return new $.Deferred().resolve();
-      }
-
-      //Debug: No filter
-      //filtered_items = items;
-
       //find current widget model and check if first layer tree
       if (GGRC.page_object && this.options.parent) { //this is a second label tree
         var parent_model_name = this.options.parent.options.model.shortName,


### PR DESCRIPTION
This short-circuit failed to trigger post-load events and left the spinner
running indefinitely. I think doing a bit of extra work for the empty `items` is
better than duplicating logic for a proper short circuit so I just removed the
short circuit.

Note: there are still cases of comments not showing up, but this is a separate
issue (on the back end). This commit only fixes the indefinite spinner.