### PR TITLE
CORE-2105, CORE-2137 Add missing column handlern to Controls

### DIFF
--- a/src/ggrc/converters/column_handlers.py
+++ b/src/ggrc/converters/column_handlers.py
@@ -35,6 +35,8 @@ _column_handlers = {
     "control": handlers.ControlColumnHandler,
     "audit": handlers.AuditColumnHandler,
     "program_mapped": handlers.ObjectPersonColumnHandler,
+    "categories": handlers.ControlCategoryColumnHandler,
+    "assertions": handlers.ControlAssertionColumnHandler,
 }
 
 

--- a/src/ggrc/converters/errors.py
+++ b/src/ggrc/converters/errors.py
@@ -46,8 +46,12 @@ UNKNOWN_USER_ERROR = ("Specified user '{email}' does not exist. That user will"
 OWNER_MISSING = ("Line {line}: Owner field does not contain a valid owner."
                  " You will be assigned as object owner.")
 
+WRONG_MULTI_VALUE = ("Line {line}: {column_name} contains invalid line. The"
+                     " value '{value}' will be ignored.")
+
 WRONG_VALUE = ("Line {line}: {column_name} contains invalid data. The value"
                " will be ignored.")
+
 WRONG_VALUE_ERROR = ("Line {line}: {column_name} contains invalid data. The"
                      " line will be ignored.")
 

--- a/src/ggrc/converters/handlers.py
+++ b/src/ggrc/converters/handlers.py
@@ -544,10 +544,17 @@ class CategoryColumnHandler(ColumnHandler):
 
   def parse_item(self):
     names = [v.strip() for v in self.raw_value.split("\n")]
-    return CategoryBase.query.filter(and_(
+    categories = CategoryBase.query.filter(and_(
         CategoryBase.name.in_(names),
         CategoryBase.type == self.category_base_type
     )).all()
+    category_names = set([c.name for c in categories])
+    for name in names:
+      if name not in category_names:
+        self.add_warning(errors.WRONG_MULTI_VALUE,
+                         column_name=self.display_name,
+                         value=name)
+    return categories
 
   def set_obj_attr(self):
     if self.value is None:

--- a/src/ggrc/converters/handlers.py
+++ b/src/ggrc/converters/handlers.py
@@ -544,6 +544,9 @@ class CategoryColumnHandler(ColumnHandler):
 
   def parse_item(self):
     names = [v.strip() for v in self.raw_value.split("\n")]
+    names = [name for name in names if name != ""]
+    if not names:
+      return None
     categories = CategoryBase.query.filter(and_(
         CategoryBase.name.in_(names),
         CategoryBase.type == self.category_base_type

--- a/src/ggrc/converters/handlers.py
+++ b/src/ggrc/converters/handlers.py
@@ -548,7 +548,7 @@ class CategoryColumnHandler(ColumnHandler):
         CategoryBase.name.in_(names),
         CategoryBase.type == self.category_base_type
     )).all()
-    category_names = set([c.name for c in categories])
+    category_names = set([c.name.strip() for c in categories])
     for name in names:
       if name not in category_names:
         self.add_warning(errors.WRONG_MULTI_VALUE,

--- a/src/ggrc/converters/handlers.py
+++ b/src/ggrc/converters/handlers.py
@@ -14,6 +14,7 @@ from ggrc import db
 from ggrc.converters import get_importables
 from ggrc.converters import errors
 from ggrc.login import get_current_user
+from ggrc.models import CategoryBase
 from ggrc.models import CustomAttributeValue
 from ggrc.models import CustomAttributeDefinition
 from ggrc.models import ObjectPerson
@@ -537,3 +538,37 @@ class ObjectPersonColumnHandler(UserColumnHandler):
       )
       db.session.add(user_role)
     self.dry_run = True
+
+
+class CategoryColumnHandler(ColumnHandler):
+
+  def parse_item(self):
+    names = [v.strip() for v in self.raw_value.split("\n")]
+    return CategoryBase.query.filter(and_(
+        CategoryBase.name.in_(names),
+        CategoryBase.type == self.category_base_type
+    )).all()
+
+  def set_obj_attr(self):
+    if self.value is None:
+      return
+    setattr(self.row_converter.obj, self.key, self.value)
+
+  def get_value(self):
+    categories = getattr(self.row_converter.obj, self.key, self.value)
+    categorie_names = [c.name for c in categories]
+    return "\n".join(categorie_names)
+
+
+class ControlCategoryColumnHandler(CategoryColumnHandler):
+
+  def __init__(self, row_converter, key, **options):
+    self.category_base_type = "ControlCategory"
+    super(self.__class__, self).__init__(row_converter, key, **options)
+
+
+class ControlAssertionColumnHandler(CategoryColumnHandler):
+
+  def __init__(self, row_converter, key, **options):
+    self.category_base_type = "ControlAssertion"
+    super(self.__class__, self).__init__(row_converter, key, **options)

--- a/src/tests/ggrc/__init__.py
+++ b/src/tests/ggrc/__init__.py
@@ -26,7 +26,8 @@ class TestCase(BaseTestCase):
   @classmethod
   def clear_data(cls):
     ignore_tables = (
-        "test_model", "roles", "notification_types", "object_types", "options"
+        "test_model", "roles", "notification_types", "object_types", "options",
+        "categories",
     )
     tables = set(db.metadata.tables).difference(ignore_tables)
     for _ in range(len(tables)):

--- a/src/tests/ggrc/converters/test_csvs/full_good_import_no_warnings.csv
+++ b/src/tests/ggrc/converters/test_csvs/full_good_import_no_warnings.csv
@@ -278,17 +278,17 @@ Not Launched
 In Scope
 Not in Scope
 Deprecated",,,,MM/DD/YYYY,MM/DD/YYYY,,,,,,,
-control,code*,title*,description,owner,state,notes,primary contact,secondary contact,effective date,stop date,control url,reference url,test plan,principal assessor,secondary assessor,,
-,control-1,control-1,test,user1@ggrc.com,Draft,this is a note,user1@ggrc.com,user2@ggrc.com,7/1/2015,7/15/2015,google.com,ggrc.com,plan,user1@ggrc.com,user2@ggrc.com,,
-,control-2,control-2,test,user1@ggrc.com,Final,this is a note,user1@ggrc.com,user2@ggrc.com,7/1/2015,7/15/2015,google.com,ggrc.com,plan,user1@ggrc.com,user2@ggrc.com,,
-,control-3,control 3,test,user1@ggrc.com,Effective,this is a note,user1@ggrc.com,user2@ggrc.com,7/1/2015,7/15/2015,google.com,ggrc.com,plan,user1@ggrc.com,user2@ggrc.com,,
-,control-4,control-4,test,user1@ggrc.com,Ineffective,this is a note,user1@ggrc.com,user2@ggrc.com,7/1/2015,7/15/2015,google.com,ggrc.com,plan,user1@ggrc.com,user2@ggrc.com,,
-,control-5,control-5,test,user1@ggrc.com,Launched,this is a note,user1@ggrc.com,user2@ggrc.com,7/1/2015,7/15/2015,google.com,ggrc.com,plan,user1@ggrc.com,user2@ggrc.com,,
-,control-6,control-6,test,user1@ggrc.com,Not Launched,this is a note,user1@ggrc.com,user2@ggrc.com,7/1/2015,7/15/2015,google.com,ggrc.com,plan,user1@ggrc.com,user2@ggrc.com,,
-,control-7,control-7,test,user1@ggrc.com,In Scope,this is a note,user1@ggrc.com,user2@ggrc.com,7/1/2015,7/15/2015,google.com,ggrc.com,plan,user1@ggrc.com,user2@ggrc.com,,
-,control-8,control 8,test,user1@ggrc.com,Not in Scope,this is a note,user1@ggrc.com,user2@ggrc.com,7/1/2015,7/15/2015,google.com,ggrc.com,plan,user1@ggrc.com,user2@ggrc.com,,
-,control-9,control-9,test,user1@ggrc.com,Deprecated,this is a note,user1@ggrc.com,user2@ggrc.com,7/1/2015,7/15/2015,google.com,ggrc.com,plan,user1@ggrc.com,user2@ggrc.com,,
-,control-10,control-10,test,user1@ggrc.com,Draft,this is a note,user1@ggrc.com,user2@ggrc.com,7/1/2015,7/15/2015,google.com,ggrc.com,plan,user1@ggrc.com,user2@ggrc.com,,
+control,code*,title*,description,owner,state,notes,primary contact,secondary contact,effective date,stop date,control url,reference url,test plan,principal assessor,secondary assessor,Assertions,Categories
+,control-1,control-1,test,user1@ggrc.com,Draft,this is a note,user1@ggrc.com,user2@ggrc.com,7/1/2015,7/15/2015,google.com,ggrc.com,plan,user1@ggrc.com,user2@ggrc.com,Privacy,Data Centers
+,control-2,control-2,test,user1@ggrc.com,Final,this is a note,user1@ggrc.com,user2@ggrc.com,7/1/2015,7/15/2015,google.com,ggrc.com,plan,user1@ggrc.com,user2@ggrc.com,Security,Disaster Recovery
+,control-3,control 3,test,user1@ggrc.com,Effective,this is a note,user1@ggrc.com,user2@ggrc.com,7/1/2015,7/15/2015,google.com,ggrc.com,plan,user1@ggrc.com,user2@ggrc.com,Availability,Logical Access/ Access Control
+,control-4,control-4,test,user1@ggrc.com,Ineffective,this is a note,user1@ggrc.com,user2@ggrc.com,7/1/2015,7/15/2015,google.com,ggrc.com,plan,user1@ggrc.com,user2@ggrc.com,Integrity,Sites
+,control-5,control-5,test,user1@ggrc.com,Launched,this is a note,user1@ggrc.com,user2@ggrc.com,7/1/2015,7/15/2015,google.com,ggrc.com,plan,user1@ggrc.com,user2@ggrc.com,Confidentiality,Training
+,control-6,control-6,test,user1@ggrc.com,Not Launched,this is a note,user1@ggrc.com,user2@ggrc.com,7/1/2015,7/15/2015,google.com,ggrc.com,plan,user1@ggrc.com,user2@ggrc.com,Privacy,Policies & Procedures
+,control-7,control-7,test,user1@ggrc.com,In Scope,this is a note,user1@ggrc.com,user2@ggrc.com,7/1/2015,7/15/2015,google.com,ggrc.com,plan,user1@ggrc.com,user2@ggrc.com,Security,Package Verification and Code release
+,control-8,control 8,test,user1@ggrc.com,Not in Scope,this is a note,user1@ggrc.com,user2@ggrc.com,7/1/2015,7/15/2015,google.com,ggrc.com,plan,user1@ggrc.com,user2@ggrc.com,Availability,Org and Admin/Governance
+,control-9,control-9,test,user1@ggrc.com,Deprecated,this is a note,user1@ggrc.com,user2@ggrc.com,7/1/2015,7/15/2015,google.com,ggrc.com,plan,user1@ggrc.com,user2@ggrc.com,Integrity,Segregation of Duties
+,control-10,control-10,test,user1@ggrc.com,Draft,this is a note,user1@ggrc.com,user2@ggrc.com,7/1/2015,7/15/2015,google.com,ggrc.com,plan,user1@ggrc.com,user2@ggrc.com,Confidentiality,Monitoring
 ,,,,,,,,,,,,,,,,,
 Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
 Other values are:


### PR DESCRIPTION
The issue CORE-2137 is to big for one PR. Here I've only fixed last two items. Others are comming up.

- [ ] Export: Processes (object type) + Network Zone (attribute) + filter query = error
- [ ] Export: Person (Object type) + Role (Attribute) + filter query = error
- [ ] Export: various (object type) + map:* OR [Person] (attributes) + filter query
- [ ] Export: Controls (Object type) + Frequency (Attribute) + filter query = error
- [ ] Export: Controls (Object type) + Type/Means (Attribute) + filter query = error
- [ ] Export: Controls (Object type) + Kind/Nature (Attribute) + filter query = error
- [ ] Export: Directives (object type) + Kind/Type (attribute) = error
- [ ] Export: Control Assessments (object type) + Control (attribute) = error
- [ ] Export: Controls (object type) + Significance (attribute) = error
- [ ] Export: Controls (object type) + Fraud Related (attribute) = error
- [x] Export: Controls (object type) + Categories (attribute) = error
- [x] Export: Controls (object type) + Assertions (attribute) = error