### PR TITLE
CORE-2088 Make tree view for cycle entries strict

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
@@ -617,8 +617,8 @@ CMS.Controllers.TreeLoader("CMS.Controllers.TreeView", {
           this.options.allow_mapping || this.options.allow_creating);
       }
 
-      if (this.element.parent().length === 0) {
-        // element not attached
+      if (this.element.parent().length === 0 // element not attached
+        || this.element.hasClass("entry-list")) { // comment list
         this.options.disable_lazy_loading = true;
       }
       if(!this.options.scroll_element) {


### PR DESCRIPTION
This disables lazy loading in the comments under a cycle task.
The placeholders in there were not styled (at all) and this botched the size
calculations and messed up rendering completely. The end result: displaying only
one comment.
I don't think we need yet another placeholder style since the volume of comments
is rather low so I just disabled lazy loading and this fixes the problem.

Please do let me know if there is a valid reason to have lazy loading of comments.