### PR TITLE
CORE-2157 Fix script error on tooltips

### DIFF
--- a/src/ggrc/assets/javascripts/plugins/tooltip.js
+++ b/src/ggrc/assets/javascripts/plugins/tooltip.js
@@ -13,6 +13,10 @@
       container_width = document.width,
       tip_pos, $arrow, offset, return_value;
 
+    if (!this.hasContent() || !this.enabled) {
+      return; // because _tooltip_show will do this too
+    }
+
     _tooltip_show.apply(this);
 
     return_value = this.$tip.css({


### PR DESCRIPTION
`_tooltip_show` will short-circuit if there is no content or the tooltip is
disabled. This means that the new `show` we're overriding it with should also
short-circuit because the state of the tooltip will not be as expected
otherwise.