### PR TITLE
CORE-1945 Remove delete button from people info

### DIFF
--- a/src/ggrc_basic_permissions/assets/mustache/ggrc_basic_permissions/people_roles/info.mustache
+++ b/src/ggrc_basic_permissions/assets/mustache/ggrc_basic_permissions/people_roles/info.mustache
@@ -77,15 +77,6 @@
       {{/options.mapped_and_or_authorized_people}}
       {{/is_info_pin}}
       {{/is_allowed}}
-
-      {{#is_allowed 'delete' instance}}
-        <li>
-          <a data-toggle="modal-ajax-deleteform" data-object-plural="{{model.table_plural}}" data-object-singular="{{model.model_singular}}" data-modal-reset="reset" data-modal-class="modal" data-object-id="{{instance.id}}" href="javascript://">
-            <i class="grcicon-deleted"></i>
-            Delete
-          </a>
-        </li>
-      {{/is_allowed}}
     </ul>
   </div>
 


### PR DESCRIPTION
We do not allow deleting people at this time (not even on the Admin page).