### PR TITLE
CORE-1964 Fix error text when object instance is not available

### DIFF
--- a/src/ggrc_workflows/assets/mustache/cycle_task_group_objects/info.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_group_objects/info.mustache
@@ -12,13 +12,13 @@
       <div class="clearfix">
         {{{render '/static/mustache/base_objects/info-pin.mustache'}}}
         <div class="tier-content pin">
-          {{#if object}}
+          {{#if object.title}}
             {{{render '/static/mustache/base_objects/general_info.mustache' instance=object}}}
           {{else}}
             <div class="row-fluid wrap-row">
               <div class="span6">
                 <h6>Title</h6>
-                <h3><span class="gray">[deleted]</span> {{title}}</h3>
+                <h3>{{title}} <span class="gray">Sorry, you do not have access</span> </h3>
               </div>
             </div>
           {{/if}}
@@ -27,7 +27,7 @@
       {{/is_info_pin}}
 
       <div class="details-wrap no-top">
-        {{#if object}}
+        {{#if object.title}}
           <a class="btn btn-small btn-draft dropdown-toggle" href="#" data-toggle="dropdown"><i class="grcicon-setup-color"></i></a>
           <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
             {{#is_allowed 'update' object context='for'}}

--- a/src/ggrc_workflows/assets/mustache/cycle_task_group_objects/tree.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_group_objects/tree.mustache
@@ -16,7 +16,7 @@
             <div class="span4">
               <div class="title tree-title-area">
                 {{#using object=instance.object}}
-                  {{#if object}}
+                  {{#if object.title}}
                     <div class="span11">
                       <i class="grcicon-{{object.class.table_singular}}-black"></i>
                       {{#if_helpers '\
@@ -29,7 +29,7 @@
                       {{object.title}}
                     </div>
                   {{else}}
-                    <span class="gray">[deleted]</span> {{instance.title}}
+                    {{instance.title}} <span class="gray">Sorry, you do not have access</span>
                   {{/if}}
                 {{/using}}
               </div>


### PR DESCRIPTION
Because we can't differentiate between the object being deleted and not
having access to the object we are now displaying a no access error
instead of a deleted flag.