### PR TITLE
QUICK-FIX Fix relevant mappings filter for exports

### DIFF
--- a/src/ggrc/assets/stylesheets/_widget.scss
+++ b/src/ggrc/assets/stylesheets/_widget.scss
@@ -1525,6 +1525,9 @@ ul.model-list {
       width: 79%;
     }
   }
+  .objective-selector {
+    display: inline-block;
+  }
 }
 
 .relevant-filter-group {


### PR DESCRIPTION
Make relevant filters show in a single line. like everywhere else.