### PR TITLE
QUICK-FIX Make task_group_id nullable

### DIFF
--- a/src/ggrc_workflows/migrations/versions/20150812104803_1a4241cfd4cd_make_task_group_id_nullable.py
+++ b/src/ggrc_workflows/migrations/versions/20150812104803_1a4241cfd4cd_make_task_group_id_nullable.py
@@ -1,0 +1,33 @@
+
+"""Make task_group_id nullable
+
+Revision ID: 1a4241cfd4cd
+Revises: 44047daa31a9
+Create Date: 2015-08-12 10:48:03.112117
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '1a4241cfd4cd'
+down_revision = '44047daa31a9'
+
+
+def upgrade():
+  op.alter_column(
+      "cycle_task_groups",
+      "task_group_id",
+      existing_type=sa.Integer(),
+      nullable=True
+  )
+
+
+def downgrade():
+  op.alter_column(
+      "cycle_task_groups",
+      "task_group_id",
+      existing_type=sa.Integer(),
+      nullable=False
+  )


### PR DESCRIPTION
The sql table structure should match our models. The column
task_group_id can be null in CycleTaskGroup model but not in the
cycle_task_groups table. We need to make the column nullable so that our
database does not fall into some incosistent state where task_group_ids
have values of non existent task groups.

To show the issue create a WF and start a cycle, then delete the TG and
you should see a warning in the console.