### PR TITLE
CORE-2197 Fix memcache issue when importing user_roles

### DIFF
--- a/src/ggrc_basic_permissions/converters/handlers.py
+++ b/src/ggrc_basic_permissions/converters/handlers.py
@@ -50,7 +50,7 @@ class ObjectRoleColumnHandler(UserColumnHandler):
     for owner in self.value:
       user_role = UserRole(
           role=self.role,
-          context_id=self.row_converter.obj.context_id,
+          context=self.row_converter.obj.context,
           person=owner
       )
       db.session.add(user_role)


### PR DESCRIPTION
Because context was not set, memcache did not properly delete the
context, causing user_roles to disappear from program page.