### PR TITLE
QUICK-FIX Silence automapper on import and drop step logs

### DIFF
--- a/src/ggrc/converters/handlers.py
+++ b/src/ggrc/converters/handlers.py
@@ -309,7 +309,7 @@ class MappingColumnHandler(ColumnHandler):
         db.session.delete(mapping)
     db.session.flush()
     for relationship in relationships:
-      AutomapperGenerator(relationship).generate_automappings()
+      AutomapperGenerator(relationship, False).generate_automappings()
     self.dry_run = True
 
   def get_value(self):

--- a/src/ggrc/utils.py
+++ b/src/ggrc/utils.py
@@ -214,4 +214,18 @@ class BenchmarkContextManager(object):
     end = time.time()
     current_app.logger.info("{:.4f} {}".format(end - self.start, self.message))
 
+
+class WithNop(object):
+
+  def __init__(self, message):
+    pass
+
+  def __enter__(self):
+    pass
+
+  def __exit__(self, exc_type, exc_value, exc_trace):
+    pass
+
+
 benchmark = BenchmarkContextManager
+with_nop = WithNop


### PR DESCRIPTION
This makes for a less noisy log, especially on imports. It also makes imports
faster as logging a ton of lines is a major slowdown.