### PR TITLE
CORE-1998 Add import/export of responses

### DIFF
--- a/src/ggrc/assets/javascripts/components/csv/export.js
+++ b/src/ggrc/assets/javascripts/components/csv/export.js
@@ -64,6 +64,7 @@
         {model_singular: "Project", title_plural: "Projects"},
         {model_singular: "Regulation", title_plural: "Regulations"},
         {model_singular: "Request", title_plural: "Requests"},
+        {model_singular: "Response", title_plural: "Responses"},
         {model_singular: "RiskAssessment", title_plural: "Risk Assessments"},
         {model_singular: "Section", title_plural: "Sections"},
         {model_singular: "Standard", title_plural: "Standards"},

--- a/src/ggrc/converters/column_handlers.py
+++ b/src/ggrc/converters/column_handlers.py
@@ -37,6 +37,8 @@ _column_handlers = {
     "reference_url": handlers.TextColumnHandler,
     "report_end_date": handlers.DateColumnHandler,
     "report_start_date": handlers.DateColumnHandler,
+    "request": handlers.RequestColumnHandler,
+    "response_type": handlers.ResponseTypeColumnHandler,
     "secondary_assessor": handlers.UserColumnHandler,
     "secondary_contact": handlers.UserColumnHandler,
     "slug": handlers.SlugColumnHandler,

--- a/src/ggrc/converters/handlers.py
+++ b/src/ggrc/converters/handlers.py
@@ -25,6 +25,8 @@ from ggrc.models import Policy
 from ggrc.models import Program
 from ggrc.models import Regulation
 from ggrc.models import Relationship
+from ggrc.models import Request
+from ggrc.models import Response
 from ggrc.models import Standard
 from ggrc.models.relationship_helper import RelationshipHelper
 from ggrc.rbac import permissions
@@ -628,3 +630,30 @@ class ControlAssertionColumnHandler(CategoryColumnHandler):
   def __init__(self, row_converter, key, **options):
     self.category_base_type = "ControlAssertion"
     super(self.__class__, self).__init__(row_converter, key, **options)
+
+
+class RequestColumnHandler(ColumnHandler):
+
+  def get_value(self):
+    return self.row_converter.obj.request.slug
+
+  def parse_item(self):
+    slug = self.raw_value
+    new_objects = self.row_converter.block_converter.converter.new_objects
+    request = new_objects[Request].get(slug)
+    if request is None:
+      request = Request.query.filter(Request.slug == slug).first()
+    if request is None:
+      self.add_error(errors.MISSING_VALUE_ERROR, column_name=self.display_name)
+    return request
+
+
+class ResponseTypeColumnHandler(ColumnHandler):
+
+  def parse_item(self):
+    value = self.raw_value.lower().strip()
+    if value not in Response.VALID_TYPES:
+      self.add_error(errors.WRONG_MULTI_VALUE,
+                     column_name=self.display_name,
+                     value=value)
+    return value

--- a/src/ggrc/models/response.py
+++ b/src/ggrc/models/response.py
@@ -75,6 +75,23 @@ class Response(Noted, Described, Hyperlinked, WithContact,
       'description',
   ]
 
+  _aliases = {
+      "description": "Response",
+      "request": {
+        "display_name": "Request",
+        "mandatory": True,
+      },
+      "response_type": {
+        "display_name": "Response Type",
+        "mandatory": True,
+      },
+      "status": "Status",
+      "title": None,
+      "secondary_contact": None,
+      "notes": None,
+
+  }
+
   def _display_name(self):
     return u'Response with id={0} for Audit "{1}"'.format(
         self.id, self.request.audit.display_name)


### PR DESCRIPTION
This is the last missing object type for import/export.
I was not sure about exposed attributes since responses seem "a bit polymorphic but not that much" and it's hard to figure out what the normal form should be. Feedback welcome but we can still tune that later now that we have at least something for all object types.