### PR TITLE
CORE-2293 Improve error handling on export filters

### DIFF
--- a/src/ggrc/converters/query_helper.py
+++ b/src/ggrc/converters/query_helper.py
@@ -11,8 +11,10 @@ from ggrc.models.reflection import AttributeInfo
 from ggrc.models.relationship_helper import RelationshipHelper
 from ggrc.converters import get_importables
 
+
 class BadQueryException(Exception):
   pass
+
 
 class QueryHelper(object):
 
@@ -141,7 +143,7 @@ class QueryHelper(object):
           attr = getattr(object_class, key, None)
           if attr is None:
             raise BadQueryException("Bad query: object '{}' does "
-                                    "not have attribute   '{}'."
+                                    "not have attribute '{}'."
                                     .format(object_class.__name__, key))
           return p(attr)
 
@@ -161,14 +163,17 @@ class QueryHelper(object):
         ))
 
       ops = {
-        "AND": lambda: lift_bin(and_),
-        "OR": lambda: lift_bin(or_),
-        "=": lambda: with_left(lambda l: l == exp["right"]),
-        "!=": lambda: not_(with_left(lambda l: l == exp["right"])),
-        "~": lambda: with_left(lambda l: l.ilike("%{}%".format(exp["right"]))),
-        "!~": lambda: not_(with_left(lambda l: l.ilike("%{}%".format(exp["right"])))),
-        "relevant": relevant,
-        "text_search": text_search
+          "AND": lambda: lift_bin(and_),
+          "OR": lambda: lift_bin(or_),
+          "=": lambda: with_left(lambda l: l == exp["right"]),
+          "!=": lambda: not_(with_left(
+                             lambda l: l == exp["right"])),
+          "~": lambda: with_left(lambda l:
+                                 l.ilike("%{}%".format(exp["right"]))),
+          "!~": lambda: not_(with_left(
+                             lambda l: l.ilike("%{}%".format(exp["right"])))),
+          "relevant": relevant,
+          "text_search": text_search
       }
 
       return ops.get(exp["op"]["name"], lambda: None)()
@@ -177,7 +182,6 @@ class QueryHelper(object):
     filter_expression = build_expression(expression)
     if filter_expression is not None:
       query = query.filter(filter_expression)
-    objects = query.all()
     object_ids = [o.id for o in query.all()]
     return object_ids
 

--- a/src/ggrc/converters/query_helper.py
+++ b/src/ggrc/converters/query_helper.py
@@ -120,6 +120,7 @@ class QueryHelper(object):
     def build_expression(exp):
       if "op" not in exp:
         return None
+
       def relevant():
         query = (self.query[exp["ids"][0]]
                  if exp["object_name"] == "__previous__" else exp)
@@ -131,14 +132,8 @@ class QueryHelper(object):
             )
         )
 
-      text_search = lambda: or_(
-          *(getattr(object_class, field).ilike("%{}%".format(exp["text"]))
-            for field in object_query.get("fields", [])
-            if hasattr(object_class, field))
-      )
-
-      def with_left(p):
-        key = exp["left"].lower()
+      def with_key(key, p):
+        key = key.lower()
         key, filter_by = self.attr_name_map[object_class].get(key, (key, None))
         if hasattr(filter_by, "__call__"):
           return filter_by(p)
@@ -150,8 +145,20 @@ class QueryHelper(object):
                                     .format(object_class.__name__, key))
           return p(attr)
 
+      with_left = lambda p: with_key(exp["left"], p)
+
       lift_bin = lambda f: f(build_expression(exp["left"]),
                              build_expression(exp["right"]))
+
+      def text_search():
+        existing_fields = self.attr_name_map[object_class]
+        text = "%{}%".format(exp["text"])
+        p = lambda f: f.ilike(text)
+        return or_(*(
+            with_key(field, p)
+            for field in object_query.get("fields", [])
+            if field in existing_fields
+        ))
 
       ops = {
         "AND": lambda: lift_bin(and_),

--- a/src/ggrc/converters/query_helper.py
+++ b/src/ggrc/converters/query_helper.py
@@ -11,6 +11,8 @@ from ggrc.models.reflection import AttributeInfo
 from ggrc.models.relationship_helper import RelationshipHelper
 from ggrc.converters import get_importables
 
+class BadQueryException(Exception):
+  pass
 
 class QueryHelper(object):
 
@@ -143,8 +145,9 @@ class QueryHelper(object):
         else:
           attr = getattr(object_class, key, None)
           if attr is None:
-            raise Exception("Bad search query: object '{}' does not have "
-                            "attribute '{}'.".format(object_class.__name__, key))
+            raise BadQueryException("Bad query: object '{}' does "
+                                    "not have attribute   '{}'."
+                                    .format(object_class.__name__, key))
           return p(attr)
 
       lift_bin = lambda f: f(build_expression(exp["left"]),

--- a/src/ggrc/views/converters.py
+++ b/src/ggrc/views/converters.py
@@ -12,7 +12,7 @@ from werkzeug.exceptions import BadRequest
 from ggrc.app import app
 from ggrc.login import login_required
 from ggrc.converters.base import Converter
-from ggrc.converters.query_helper import QueryHelper
+from ggrc.converters.query_helper import QueryHelper, BadQueryException
 from ggrc.converters.import_helper import generate_csv_string
 from ggrc.converters.import_helper import read_csv_file
 
@@ -57,10 +57,11 @@ def handle_export_request():
         ("Content-Disposition", "attachment; filename='{}'".format(filename)),
     ]
     return current_app.make_response((csv_string, 200, headers))
+  except BadQueryException as e:
+    raise BadRequest(e.message)
   except Exception as e:
     current_app.logger.exception(e)
   raise BadRequest("Export failed due to server error.")
-
 
 
 def check_import_file():


### PR DESCRIPTION
Currently user gets a generic sounding `Export failed due to server error` if
she makes a typo in a field name in her filter query. This replaces the error
with a more helpful `Bad query: object Program does not have attribute owner`

It also fixes text search by using the special filters and ignoring fields.