### PR TITLE
CORE-1518 Rename Submit for Review modal button

### DIFF
--- a/src/ggrc/assets/mustache/modals/save_cancel_buttons.mustache
+++ b/src/ggrc/assets/mustache/modals/save_cancel_buttons.mustache
@@ -15,7 +15,7 @@
     </div>
     <div class="span3">
       <div class="confirm-buttons">
-        <a class="btn btn-small btn-success preventdoubleclick {{#instance.computed_unsuppressed_errors}}disabled{{/instance.computed_unsuppressed_errors}}" data-toggle="modal-submit" href="javascript://">{{firstnonempty custom_save_button_text 'Submit'}}</a>
+        <a class="btn btn-small btn-success preventdoubleclick {{#instance.computed_unsuppressed_errors}}disabled{{/instance.computed_unsuppressed_errors}}" data-toggle="modal-submit" href="javascript://">{{firstnonempty custom_save_button_text 'Save'}}</a>
       </div>
     </div>
   </div>

--- a/src/ggrc/assets/mustache/modals/save_cancel_buttons.mustache
+++ b/src/ggrc/assets/mustache/modals/save_cancel_buttons.mustache
@@ -15,7 +15,7 @@
     </div>
     <div class="span3">
       <div class="confirm-buttons">
-        <a class="btn btn-small btn-success preventdoubleclick {{#instance.computed_unsuppressed_errors}}disabled{{/instance.computed_unsuppressed_errors}}" data-toggle="modal-submit" href="javascript://">{{firstnonempty custom_save_button_text 'Save'}}</a>
+        <a class="btn btn-small btn-success preventdoubleclick {{#instance.computed_unsuppressed_errors}}disabled{{/instance.computed_unsuppressed_errors}}" data-toggle="modal-submit" href="javascript://">{{firstnonempty custom_save_button_text 'Submit'}}</a>
       </div>
     </div>
   </div>

--- a/src/ggrc_workflows/assets/javascripts/controllers/approval_workflow_controller.js
+++ b/src/ggrc_workflows/assets/javascripts/controllers/approval_workflow_controller.js
@@ -13,6 +13,7 @@ GGRC.Controllers.Modals("GGRC.Controllers.ApprovalWorkflow", {
     new_object_form: true,
     model: CMS.ModelHelpers.ApprovalWorkflow,
     modal_title: "Submit for review",
+    custom_save_button_text: "Submit",
     content_view: GGRC.mustache_path + "/wf_objects/approval_modal_content.mustache",
     button_view : GGRC.Controllers.Modals.BUTTON_VIEW_SAVE_CANCEL
   }
@@ -63,7 +64,7 @@ jQuery(function($){
     var calenderAuthWin = null,
       href = window.location.origin + "/calendar_oauth_request", //"https://ggrc-dev.googleplex.com/calendar_oauth_request"
       name = "Calendar Authentication";
-    
+
     if(calenderAuthWin === null || calenderAuthWin.closed){
       calenderAuthWin = window.open(href, name);
       calenderAuthWin.focus();
@@ -71,5 +72,5 @@ jQuery(function($){
     else{
       calenderAuthWin.focus();
     }
-  }); 
+  });
 });


### PR DESCRIPTION
Maybe this could be made better. Instead of just renaming button text, can we say if this is "Submit for Review" modal, button should have text "Submit"?

Can someone help me with this?