### PR TITLE
CORE-2216 import delete

### DIFF
--- a/src/ggrc/assets/javascripts/components/csv/export.js
+++ b/src/ggrc/assets/javascripts/components/csv/export.js
@@ -21,8 +21,9 @@
           return new can.List();
         }),
         columns: can.compute(function () {
-          return _.filter(GGRC.model_attr_defs[this.attr("type")], function(el) { 
-            return el.display_name.indexOf("unmap:") == -1; 
+          return _.filter(GGRC.model_attr_defs[this.attr("type")], function(el) {
+            return (!el.import_only) &&
+                   (el.display_name.indexOf("unmap:") === -1);
           });
         })
       }),

--- a/src/ggrc/cache/memcache.py
+++ b/src/ggrc/cache/memcache.py
@@ -37,7 +37,7 @@ class MemCache(Cache):
 
     Returns:
       All or None policy is applied by default
-      None on any errors 
+      None on any errors
       otherwise returns JSON string representation
     """
 
@@ -73,7 +73,7 @@ class MemCache(Cache):
     return data
 
   def add(self, category, resource, data, expiration_time=0):
-    """ add data to mem cache 
+    """ add data to mem cache
 
     Args:
       category: collection or stub
@@ -121,7 +121,7 @@ class MemCache(Cache):
       filter: dictionary containing ids and attrs
 
     Returns:
-      None on any errors 
+      None on any errors
       Mapping of DTO formatted string, e.g. JSON string representation
     """
     if not self.is_caching_supported(category, resource):
@@ -151,7 +151,7 @@ class MemCache(Cache):
       data: List of keys
 
     Returns:
-      None on any errors 
+      None on any errors
       mapping of DTO formatted string, e.g. JSON string representation
     """
     if not self.is_caching_supported(category, resource):
@@ -204,7 +204,7 @@ class MemCache(Cache):
     Args:
       category: collection or stub
       resource: regulation, controls, etc.
-      data: dictionary containing ids 
+      data: dictionary containing ids
 
     Returns:
       memcache client API get_multi
@@ -221,7 +221,7 @@ class MemCache(Cache):
       data: dictionary containing ids and dictionary of attrs
 
     Returns:
-      memcache client API cas_multi (compare and set) 
+      memcache client API cas_multi (compare and set)
     """
     return self.memcache_client.cas_multi(data, expiration_time)
 
@@ -239,4 +239,6 @@ class MemCache(Cache):
     return self.memcache_client.delete_multi(data, lockadd_seconds)
 
   def clean(self):
-    pass
+    """ flush everything from memcache """
+    return self.memcache_client.flush_all()
+

--- a/src/ggrc/converters/base.py
+++ b/src/ggrc/converters/base.py
@@ -36,6 +36,7 @@ class Converter(object):
   priortiy_colums = [
       "email",
       "slug",
+      "delete",
   ]
 
   def __init__(self, **kwargs):

--- a/src/ggrc/converters/base.py
+++ b/src/ggrc/converters/base.py
@@ -13,6 +13,7 @@ from ggrc.converters import errors
 from ggrc.converters.base_block import BlockConverter
 from ggrc.converters.import_helper import extract_relevant_data
 from ggrc.converters.import_helper import split_array
+from ggrc.fulltext import get_indexer
 
 
 class Converter(object):
@@ -48,6 +49,7 @@ class Converter(object):
     self.shared_state = {}
     self.response_data = []
     self.importable = get_importables()
+    self.indexer = get_indexer()
 
   def to_array(self, data_grid=False):
     self.block_converters_from_ids()

--- a/src/ggrc/converters/base.py
+++ b/src/ggrc/converters/base.py
@@ -8,8 +8,10 @@ from flask import current_app
 from itertools import chain
 from itertools import product
 
-from ggrc.converters import get_importables
+from ggrc import settings
+from ggrc.cache.memcache import MemCache
 from ggrc.converters import errors
+from ggrc.converters import get_importables
 from ggrc.converters.base_block import BlockConverter
 from ggrc.converters.import_helper import extract_relevant_data
 from ggrc.converters.import_helper import split_array
@@ -96,6 +98,7 @@ class Converter(object):
     self.handle_priority_columns()
     self.import_objects()
     self.import_secondary_objects()
+    self.drop_cache()
 
   def handle_priority_columns(self):
     for attr_name in self.priortiy_colums:
@@ -159,3 +162,10 @@ class Converter(object):
 
   def get_object_names(self):
     return [c.object_class.__name__ for c in self.block_converters]
+
+  def drop_cache(self):
+    if not getattr(settings, 'MEMCACHE_MECHANISM', False):
+      return
+    memcache = MemCache()
+    memcache.clean()
+

--- a/src/ggrc/converters/base_block.py
+++ b/src/ggrc/converters/base_block.py
@@ -138,9 +138,6 @@ class BlockConverter(object):
     headers = [self._sanitize_header(val) for val in raw_headers]
     clean_headers = OrderedDict()
     header_names = self.get_header_names()
-    if 'delete' in headers:
-      header_names = {k: v for (k, v) in header_names.items()
-                      if k in {"code", "delete", "email"}}
     removed_count = 0
     for index, header in enumerate(headers):
       if header in header_names:

--- a/src/ggrc/converters/base_block.py
+++ b/src/ggrc/converters/base_block.py
@@ -202,12 +202,23 @@ class BlockConverter(object):
 
   def get_info(self):
     stats = [(r.is_new, r.ignore) for r in self.row_converters]
+    created, updated, ignored, deleted = 0, 0, 0, 0
+    for row in self.row_converters:
+      if row.ignore:
+        ignored += 1
+      elif row.is_delete:
+        deleted += 1
+      elif row.is_new:
+        created += 1
+      else:
+        updated += 1
     info = {
         "name": self.name,
         "rows": len(self.rows),
-        "created": stats.count((True, False)),
-        "updated": stats.count((False, False)),
-        "ignored": stats.count((False, True)) + stats.count((True, True)),
+        "created": created,
+        "updated": updated,
+        "ignored": ignored,
+        "deleted": deleted,
         "block_warnings": self.block_warnings,
         "block_errors": self.block_errors,
         "row_warnings": self.row_warnings,

--- a/src/ggrc/converters/base_block.py
+++ b/src/ggrc/converters/base_block.py
@@ -138,6 +138,9 @@ class BlockConverter(object):
     headers = [self._sanitize_header(val) for val in raw_headers]
     clean_headers = OrderedDict()
     header_names = self.get_header_names()
+    if 'delete' in headers:
+      header_names = {k: v for (k, v) in header_names.items()
+                      if k in {"code", "delete", "email"}}
     removed_count = 0
     for index, header in enumerate(headers):
       if header in header_names:

--- a/src/ggrc/converters/base_row.py
+++ b/src/ggrc/converters/base_row.py
@@ -150,7 +150,7 @@ class RowConverter(object):
     is in some related object such as "UserRole" it should be added there and
     handled by the handler defined in attrs.
     """
-    if self.ignore or self.is_delete:
+    if self.ignore:
       return
 
     for item_handler in self.attrs.values():
@@ -167,10 +167,8 @@ class RowConverter(object):
           self.object_class, obj=self.obj, src={}, service=service_class)
 
   def insert_object(self):
-    if self.ignore:
+    if self.ignore or self.is_delete:
       return
-    if self.is_delete:
-      db.session.delete(self.obj)
     else:
       self.send_signals()
       if self.is_new:

--- a/src/ggrc/converters/base_row.py
+++ b/src/ggrc/converters/base_row.py
@@ -22,6 +22,7 @@ class RowConverter(object):
     self.obj = options.get("obj")
     self.from_ids = self.obj is not None
     self.is_new = True
+    self.is_delete = False
     self.ignore = False
     self.index = options.get("index", -1)
     self.row = options.get("row", [])
@@ -49,7 +50,9 @@ class RowConverter(object):
     """ Pack row data with handlers """
     handle_fields = self.headers if field_list is None else field_list
     for i, (attr_name, header_dict) in enumerate(self.headers.items()):
-      if attr_name not in handle_fields or attr_name in self.attrs:
+      if attr_name not in handle_fields or \
+          attr_name in self.attrs or \
+          self.is_delete:
         continue
       Handler = header_dict["handler"]
       item = Handler(self, attr_name, raw_value=self.row[i], **header_dict)
@@ -78,7 +81,7 @@ class RowConverter(object):
       self.handle_csv_row_data(field_list)
 
   def chect_mandatory_fields(self):
-    if not self.is_new:
+    if not self.is_new or self.is_delete:
       return
     mandatory = [key for key, header in
                  self.block_converter.object_headers.items()
@@ -135,7 +138,7 @@ class RowConverter(object):
     return obj
 
   def setup_secondary_objects(self, slugs_dict):
-    if not self.obj or self.ignore:
+    if not self.obj or self.ignore or self.is_delete:
       return
     for mapping in self.objects.values():
       mapping.set_obj_attr()
@@ -147,7 +150,7 @@ class RowConverter(object):
     is in some related object such as "UserRole" it should be added there and
     handled by the handler defined in attrs.
     """
-    if self.ignore:
+    if self.ignore or self.is_delete:
       return
 
     for item_handler in self.attrs.values():
@@ -166,14 +169,17 @@ class RowConverter(object):
   def insert_object(self):
     if self.ignore:
       return
-    self.send_signals()
-    if self.is_new:
-      db.session.add(self.obj)
-    for handler in self.attrs.values():
-      handler.insert_object()
+    if self.is_delete:
+      db.session.delete(self.obj)
+    else:
+      self.send_signals()
+      if self.is_new:
+        db.session.add(self.obj)
+      for handler in self.attrs.values():
+        handler.insert_object()
 
   def insert_secondary_objecs(self):
-    if not self.obj or self.ignore:
+    if not self.obj or self.ignore or self.is_delete:
       return
     for secondery_object in self.objects.values():
       secondery_object.insert_object()

--- a/src/ggrc/converters/column_handlers.py
+++ b/src/ggrc/converters/column_handlers.py
@@ -16,6 +16,7 @@ _column_handlers = {
     "company": handlers.TextColumnHandler,
     "contact": handlers.UserColumnHandler,
     "control": handlers.ControlColumnHandler,
+    "delete": handlers.DeleteColumnHandler,
     "description": handlers.TextareaColumnHandler,
     "design": handlers.OptionColumnHandler,
     "directive": handlers.SectionDirectiveColumnHandler,

--- a/src/ggrc/converters/errors.py
+++ b/src/ggrc/converters/errors.py
@@ -72,4 +72,7 @@ PERMISSION_ERROR = ("Line {line}: You don't have permission to update/delete"
 MAPPING_PERMISSION_ERROR = ("Line {line}: You don't have permission to update"
                             " mappings for {object_type}: {title} ({slug}).")
 
+DELETE_NEW_OBJECT_ERROR = ("Line {line}: Tried to create and delete the same"
+                           " object {object_type}: {slug} in one import.")
+
 UNKNOWN_ERROR = "Line {line}: Import failed due to unknown error."

--- a/src/ggrc/converters/errors.py
+++ b/src/ggrc/converters/errors.py
@@ -75,4 +75,7 @@ MAPPING_PERMISSION_ERROR = ("Line {line}: You don't have permission to update"
 DELETE_NEW_OBJECT_ERROR = ("Line {line}: Tried to create and delete the same"
                            " object {object_type}: {slug} in one import.")
 
+DELETE_CASCADE_ERROR = ("Line {line}: Cannot delete object {object_type}:"
+                        " {slug} without deleting other objects")
+
 UNKNOWN_ERROR = "Line {line}: Import failed due to unknown error."

--- a/src/ggrc/converters/handlers.py
+++ b/src/ggrc/converters/handlers.py
@@ -116,7 +116,9 @@ class DeleteColumnHandler(ColumnHandler):
     tr = db.session.begin_nested()
     try:
       tr.session.delete(self.row_converter.obj)
-      if len(tr.session.deleted) != 1:
+      deleted = len([o for o in tr.session.deleted
+                    if o.type != "Relationship"])
+      if deleted != 1:
         self.add_error(errors.DELETE_CASCADE_ERROR,
                        object_type=self.row_converter.obj.type,
                        slug=self.row_converter.obj.slug)

--- a/src/ggrc/converters/handlers.py
+++ b/src/ggrc/converters/handlers.py
@@ -99,9 +99,13 @@ class DeleteColumnHandler(ColumnHandler):
     return ""
 
   def parse_item(self):
-    return self.raw_value.lower() in ["true", "yes"]
+    is_delete = self.raw_value.lower() in ["true", "yes"]
+    self.row_converter.is_delete = is_delete
+    return is_delete
 
   def set_obj_attr(self):
+    if not self.value:
+      return
     if self.row_converter.is_new:
       self.add_error(errors.DELETE_NEW_OBJECT_ERROR,
                      object_type=self.row_converter.obj.type,

--- a/src/ggrc/converters/handlers.py
+++ b/src/ggrc/converters/handlers.py
@@ -93,6 +93,25 @@ class ColumnHandler(object):
     pass
 
 
+class DeleteColumnHandler(ColumnHandler):
+
+  def get_value(self):
+    return ""
+
+  def parse_item(self):
+    return self.raw_value.lower() in ["true", "yes"]
+
+  def set_obj_attr(self):
+    if self.row_converter.is_new:
+      self.add_error(errors.DELETE_NEW_OBJECT_ERROR,
+                     object_type=self.row_converter.obj.type,
+                     slug=self.row_converter.obj.slug)
+      return
+    if self.dry_run:
+      return
+    db.session.delete(self.row_converter.obj)
+
+
 class StatusColumnHandler(ColumnHandler):
 
   def __init__(self, row_converter, key, **options):

--- a/src/ggrc/converters/handlers.py
+++ b/src/ggrc/converters/handlers.py
@@ -95,6 +95,10 @@ class ColumnHandler(object):
 
 class DeleteColumnHandler(ColumnHandler):
 
+  # this is a white list of objects that can be deleted in a cascade
+  # e.g. deleting a Market can delete the associated ObjectOwner objectect too
+  delete_whitelist = {"Relationship", "ObjectOwner", "ObjectPerson"}
+
   def get_value(self):
     return ""
 
@@ -118,7 +122,7 @@ class DeleteColumnHandler(ColumnHandler):
     try:
       tr.session.delete(obj)
       deleted = len([o for o in tr.session.deleted
-                    if o.type != "Relationship"])
+                    if o.type not in self.delete_whitelist])
       if deleted != 1:
         self.add_error(errors.DELETE_CASCADE_ERROR,
                        object_type=obj.type, slug=obj.slug)

--- a/src/ggrc/models/audit_object.py
+++ b/src/ggrc/models/audit_object.py
@@ -56,7 +56,10 @@ class AuditObject(Base, db.Model):
         orm.subqueryload('audit'))
 
   def _display_name(self):
-    return self.audit.display_name + '<->' + self.auditable.display_name
+    return '{} <-> {} {}'.format(str(self.audit.display_name),
+                                 str(self.auditable_type),
+                                 str(self.auditable_id))
+
 
 class Auditable(object):
   @declared_attr

--- a/src/ggrc/models/reflection.py
+++ b/src/ggrc/models/reflection.py
@@ -284,6 +284,10 @@ class AttributeInfo(object):
     aliases = AttributeInfo.gather_aliases(object_class)
     filtered_aliases = [(k, v) for k, v in aliases.items() if v is not None]
 
+    # push the extra delete column at the end to override any custom behavior
+    if hasattr(object_class, "slug") or hasattr(object_class, "email"):
+      filtered_aliases.append(("delete", "Delete"))
+
     unique_columns = cls.get_unique_constraints(object_class)
 
     for key, value in filtered_aliases:

--- a/src/ggrc/models/reflection.py
+++ b/src/ggrc/models/reflection.py
@@ -286,7 +286,10 @@ class AttributeInfo(object):
 
     # push the extra delete column at the end to override any custom behavior
     if hasattr(object_class, "slug") or hasattr(object_class, "email"):
-      filtered_aliases.append(("delete", "Delete"))
+      filtered_aliases.append(("delete", {
+        "display_name": "Delete",
+        "import_only": True,
+      }))
 
     unique_columns = cls.get_unique_constraints(object_class)
 

--- a/src/tests/ggrc/converters/test_import_helpers.py
+++ b/src/tests/ggrc/converters/test_import_helpers.py
@@ -176,6 +176,7 @@ class TestCustomAttributesDefinitions(TestCase):
         "State",
         "My Attribute",
         "Mandatory Attribute",
+        "Delete",
     ])
     expected_names = element_names.union(mapping_names)
     self.assertEquals(expected_names, display_names)
@@ -225,6 +226,7 @@ class TestCustomAttributesDefinitions(TestCase):
         "My Attribute",
         "Mandatory Attribute",
         "Choose",
+        "Delete",
     ])
     expected_names = element_names.union(mapping_names)
     self.assertEquals(expected_names, display_names)
@@ -269,6 +271,7 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Effective Date",
         "Stop Date",
         "State",
+        "Delete",
     ])
     expected_names = element_names.union(mapping_names)
     self.assertEquals(expected_names, display_names)
@@ -296,6 +299,7 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Planned Report Period from",
         "Planned Report Period to",
         "Auditors",
+        "Delete",
     ])
     expected_names = element_names.union(mapping_names)
     self.assertEquals(expected_names, display_names)
@@ -327,6 +331,7 @@ class TestGetObjectColumnDefinitions(TestCase):
         "State",
         "Conclusion: Design",
         "Conclusion: Operation",
+        "Delete",
     ])
     expected_names = element_names.union(mapping_names)
     self.assertEquals(expected_names, display_names)
@@ -356,6 +361,7 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Effective Date",
         "Stop Date",
         "State",
+        "Delete",
     ])
     expected_names = element_names.union(mapping_names)
     self.assertEquals(expected_names, display_names)
@@ -382,6 +388,7 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Effective Date",
         "Stop Date",
         "State",
+        "Delete",
     ])
     expected_names = element_names.union(mapping_names)
     self.assertEquals(expected_names, display_names)
@@ -409,6 +416,7 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Effective Date",
         "Stop Date",
         "State",
+        "Delete",
     ])
     expected_names = element_names.union(mapping_names)
     self.assertEquals(expected_names, display_names)
@@ -435,6 +443,7 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Effective Date",
         "Stop Date",
         "State",
+        "Delete",
     ])
     expected_names = element_names.union(mapping_names)
     self.assertEquals(expected_names, display_names)
@@ -461,6 +470,7 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Effective Date",
         "Stop Date",
         "State",
+        "Delete",
     ])
     expected_names = element_names.union(mapping_names)
     self.assertEquals(expected_names, display_names)
@@ -487,6 +497,7 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Effective Date",
         "Stop Date",
         "State",
+        "Delete",
     ])
     expected_names = element_names.union(mapping_names)
     self.assertEquals(expected_names, display_names)
@@ -512,6 +523,7 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Reference URL",
         "Code",
         "State",
+        "Delete",
     ])
     expected_names = element_names.union(mapping_names)
     self.assertEquals(expected_names, display_names)
@@ -548,6 +560,7 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Principal Assessor",
         "Secondary Assessor",
         "State",
+        "Delete",
     ])
     expected_names = element_names.union(mapping_names)
     self.assertEquals(expected_names, display_names)
@@ -572,6 +585,7 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Reference URL",
         "Code",
         "State",
+        "Delete",
     ])
     expected_names = element_names.union(mapping_names)
     self.assertEquals(expected_names, display_names)
@@ -590,6 +604,7 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Email",
         "Company",
         "Role",
+        "Delete",
     ])
     expected_names = element_names.union(mapping_names)
     self.assertEquals(expected_names, display_names)
@@ -615,6 +630,7 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Effective Date",
         "Stop Date",
         "State",
+        "Delete",
     ])
     expected_names = element_names.union(mapping_names)
     self.assertEquals(expected_names, display_names)
@@ -641,6 +657,7 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Effective Date",
         "Stop Date",
         "State",
+        "Delete",
     ])
     expected_names = element_names.union(mapping_names)
     self.assertEquals(expected_names, display_names)
@@ -668,6 +685,7 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Effective Date",
         "Stop Date",
         "State",
+        "Delete",
     ])
     expected_names = element_names.union(mapping_names)
     self.assertEquals(expected_names, display_names)
@@ -695,6 +713,7 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Effective Date",
         "Stop Date",
         "State",
+        "Delete",
     ])
     expected_names = element_names.union(mapping_names)
     self.assertEquals(expected_names, display_names)
@@ -721,6 +740,7 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Effective Date",
         "Stop Date",
         "State",
+        "Delete",
     ])
     expected_names = element_names.union(mapping_names)
     self.assertEquals(expected_names, display_names)
@@ -748,6 +768,7 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Effective Date",
         "Stop Date",
         "State",
+        "Delete",
     ])
     expected_names = element_names.union(mapping_names)
     self.assertEquals(expected_names, display_names)
@@ -774,6 +795,7 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Effective Date",
         "Stop Date",
         "State",
+        "Delete",
     ])
     expected_names = element_names.union(mapping_names)
     self.assertEquals(expected_names, display_names)
@@ -800,6 +822,7 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Effective Date",
         "Stop Date",
         "State",
+        "Delete",
     ])
     expected_names = element_names.union(mapping_names)
     self.assertEquals(expected_names, display_names)
@@ -826,6 +849,7 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Effective Date",
         "Stop Date",
         "State",
+        "Delete",
     ])
     expected_names = element_names.union(mapping_names)
     self.assertEquals(expected_names, display_names)
@@ -851,6 +875,7 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Requested On",
         "Status",
         "Test",
+        "Delete",
     ])
     expected_names = element_names.union(mapping_names)
     self.assertEquals(expected_names, display_names)
@@ -876,6 +901,7 @@ class TestGetWorkflowObjectColumnDefinitions(TestCase):
         "Frequency",
         "Force real-time email updates",
         "Code",
+        "Delete",
     ])
     self.assertEquals(expected_names, display_names)
     vals = {val["display_name"]: val for val in definitions.values()}
@@ -898,6 +924,7 @@ class TestGetWorkflowObjectColumnDefinitions(TestCase):
         "Code",
         "Workflow",
         "Objects",
+        "Delete",
     ])
     self.assertEquals(expected_names, display_names)
     vals = {val["display_name"]: val for val in definitions.values()}
@@ -917,6 +944,7 @@ class TestGetWorkflowObjectColumnDefinitions(TestCase):
         "End",
         "Task Group",
         "Code",
+        "Delete",
     ])
     self.assertEquals(expected_names, display_names)
     vals = {val["display_name"]: val for val in definitions.values()}
@@ -939,6 +967,7 @@ class TestGetWorkflowObjectColumnDefinitions(TestCase):
         "Task Group",
         "Cycle Object",
         "State",
+        "Delete",
     ])
     self.assertEquals(expected_names, display_names)
     vals = {val["display_name"]: val for val in definitions.values()}
@@ -966,6 +995,7 @@ class TestGetRiskAssessmentObjectColumnDefinitions(TestCase):
         "Risk Counsel",
         "Code",
         "Program",
+        "Delete",
     ])
     self.assertEquals(expected_names, display_names)
     vals = {val["display_name"]: val for val in definitions.values()}


### PR DESCRIPTION
This implements the special `delete` column in imports. Valid values are `yes` and `true` (case insensitive).
Deletes will not cascade - this is an error during import. 
There is now a "deleted" counter in the import UI.

I would really like some feedback especially on the non-cascading part.

*NOTE* dry-run might be broken now since it doesn't take deletions into account. That would be really hard to properly simulate. I'm working on a simplified dry run that just does the import and then reverts it. That will trivially support deletion too.