### PR TITLE
CORE=2291 Add update filter to some modal dropdowns

### DIFF
--- a/src/ggrc/assets/javascripts/plugins/autocomplete.js
+++ b/src/ggrc/assets/javascripts/plugins/autocomplete.js
@@ -166,12 +166,16 @@
           base_search = $that.data("lookup"),
           from_list = $that.data("from-list"),
           search_params = $that.data("params"),
+          permission = $that.data("permission-type"),
           searchtypes;
 
         this._super.apply(this, arguments);
         this.options.search_params = {
-          extra_params: search_params
+          extra_params: search_params,
         };
+        if (permission) {
+          this.options.search_params.__permission_type = permission;
+        }
 
         $that.data("autocomplete-widget-name", this.widgetFullName);
 

--- a/src/ggrc/assets/javascripts/plugins/autocomplete.js
+++ b/src/ggrc/assets/javascripts/plugins/autocomplete.js
@@ -171,7 +171,7 @@
 
         this._super.apply(this, arguments);
         this.options.search_params = {
-          extra_params: search_params,
+          extra_params: search_params
         };
         if (permission) {
           this.options.search_params.__permission_type = permission;

--- a/src/ggrc/assets/mustache/audits/modal_content.mustache
+++ b/src/ggrc/assets/mustache/audits/modal_content.mustache
@@ -19,7 +19,7 @@
               Program
             <span class="required">*</span>
             </label>
-            <input data-id="program_dd" type="text" class="input-block-level" name="program.id" tabindex="1" {{autocomplete_select}} data-lookup="Program" autofocus/>
+            <input data-id="program_dd" type="text" class="input-block-level" name="program.id" tabindex="1" data-permission-type="update" {{autocomplete_select}} data-lookup="Program" autofocus/>
           </div>
           {{#instance.computed_errors.program}}
             <label class="help-inline warning">

--- a/src/ggrc/assets/mustache/control_assessments/modal_content.mustache
+++ b/src/ggrc/assets/mustache/control_assessments/modal_content.mustache
@@ -28,7 +28,7 @@
           <span class="required">*</span>
           <i class="grcicon-help-black" rel="tooltip" title="Control for this Control Assessment"></i>
         </label>
-        <input tabindex="2" class="input-block-level" name="control.title" data-lookup="Control" data-template="/directives/autocomplete_result.mustache" placeholder="Choose Control" type="text" value="{{firstexist control.title ''}}" />
+        <input tabindex="2" class="input-block-level" name="control.title" data-permission-type="update" data-lookup="Control" data-template="/directives/autocomplete_result.mustache" placeholder="Choose Control" type="text" value="{{firstexist control.title ''}}" />
     </div>
     <div class="span3">
         <label>
@@ -36,7 +36,7 @@
           <span class="required">*</span>
           <i class="grcicon-help-black" rel="tooltip" title="Audit for this Control Assessment"></i>
         </label>
-        <input tabindex="2" class="input-block-level" name="audit.title" data-lookup="Audit" data-template="/directives/autocomplete_result.mustache" placeholder="Choose Audit" type="text" value="{{firstexist audit.title ''}}" />
+        <input tabindex="2" class="input-block-level" name="audit.title" data-permission-type="update" data-lookup="Audit" data-template="/directives/autocomplete_result.mustache" placeholder="Choose Audit" type="text" value="{{firstexist audit.title ''}}" />
     </div>
     {{else}}
       {{#with_mapping "related_controls" instance}}

--- a/src/ggrc/assets/mustache/sections/modal_content.mustache
+++ b/src/ggrc/assets/mustache/sections/modal_content.mustache
@@ -6,7 +6,7 @@
 }}
 
 {{!div class="modal-body"}}
-<div class="hideable-holder"> 
+<div class="hideable-holder">
 {{#instance}}
 <form action="javascript://">
   {{> /static/mustache/base_objects/form_restore.mustache}}
@@ -30,7 +30,7 @@
           <span class="required">*</span>
           <i class="grcicon-help-black" rel="tooltip" title="Policy / Regulation / Standard containing this Section"></i>
         </label>
-        <input tabindex="2" class="input-block-level" name="directive.title" data-lookup="Policy,Regulation,Standard" data-template="/directives/autocomplete_result.mustache" placeholder="Choose Policy / Regulation / Standard" type="text" value="{{firstexist directive.title ''}}" />
+        <input tabindex="2" class="input-block-level" name="directive.title" data-lookup="Policy,Regulation,Standard" data-permission-type="update" data-template="/directives/autocomplete_result.mustache" placeholder="Choose Policy / Regulation / Standard" type="text" value="{{firstexist directive.title ''}}" />
         {{/using}}
       {{else}}
         &nbsp;
@@ -51,7 +51,7 @@
       </div>
     </div>
 
-    <div class="span6 hide-wrap hidable">      
+    <div class="span6 hide-wrap hidable">
       <div class="row-fluid inner-hide">
         <div data-id="owner_hidden" class="span12 hidable bottom-spacing">
           {{> /static/mustache/people/owners_modal_connector.mustache}}
@@ -60,7 +60,7 @@
       {{> /static/mustache/base_objects/modal_contact_fields.mustache}}
     </div>
   </div>
-  
+
   <div class="row-fluid">
     <div data-id="note_hidden" class="span6 hidable">
       <label>
@@ -96,7 +96,7 @@
     </div>
   </div>
 
-  
+
   <div>
     <div class="row-fluid">
       <div data-id="code_hidden" class="span6 hidable">
@@ -120,7 +120,7 @@
           {{/iterate}}
         </select>
       </div>
-    </div>   
+    </div>
   </div>
 </form>
 {{/instance}}


### PR DESCRIPTION
If a modal dropdown creates a mapping we should only show results that
the user can update.