### PR TITLE
QUICK-FIX Allow Creators / Readers to map people to their Objects

### DIFF
--- a/src/ggrc/assets/javascripts/components/mapper.js
+++ b/src/ggrc/assets/javascripts/components/mapper.js
@@ -479,7 +479,9 @@
             __permission_model: join_model
           };
         }
-        data.options.__permission_type = data.options.__permission_type || "update";
+        if (join_model !== "ObjectPerson") {
+          data.options.__permission_type = data.options.__permission_type || "update";
+        }
         data.model_name = _.isString(data.model_name) ? [data.model_name] : data.model_name;
 
         return GGRC.Models.Search.search_for_types(data.term || "", data.model_name, data.options);

--- a/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
+++ b/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
@@ -59,9 +59,9 @@
                                                 : (target.type || target);
       source_type = source.constructor.shortName || source;
 
-      can_map = Permission.is_allowed_for("update", source);
+      can_map = Permission.is_allowed_for("update", source) || source_type === "Person";
       if (target instanceof can.Model) {
-        can_map = can_map && Permission.is_allowed_for("update", target);
+        can_map = can_map && Permission.is_allowed_for("update", target) || target_type === "Person";
       }
       return can_map;
     }


### PR DESCRIPTION
Prior to this change creators and readers were not able to map People
to their Programs / Workflows and other objects.