### PR TITLE
CORE-2323 Fix export of risk assessments with corrupt data

### DIFF
--- a/src/ggrc/converters/handlers.py
+++ b/src/ggrc/converters/handlers.py
@@ -509,6 +509,8 @@ class ProgramColumnHandler(ColumnHandler):
 
   def get_value(self):
     val = getattr(self.row_converter.obj, self.key, False)
+    if not val:
+      return
     return val.slug
 
 


### PR DESCRIPTION
Risk assessments are missing a foreign key on program (to be fixed) so when
program id is invalid the program will be `None`. This is the best we can do
since the mapped program does not exist.