### PR TITLE
CORE-2269 Relevant filters

### DIFF
--- a/src/ggrc/models/relationship_helper.py
+++ b/src/ggrc/models/relationship_helper.py
@@ -157,6 +157,21 @@ class RelationshipHelper(object):
           all_models.RiskAssessment.program_id.in_(related_ids))
 
   @classmethod
+  def task_group_object(cls, object_type, related_type, related_ids):
+    if not related_ids:
+      return None
+    if object_type == "TaskGroup":
+      return db.session.query(all_models.TaskGroupObject.task_group_id).filter(
+          (all_models.TaskGroupObject.object_type == related_type) &
+          all_models.TaskGroupObject.object_id.in_(related_ids))
+    elif related_type == "TaskGroup":
+      return db.session.query(all_models.TaskGroupObject.object_id).filter(
+          (all_models.TaskGroupObject.object_type == related_type) &
+          all_models.TaskGroupObject.task_group_id.in_(related_ids))
+    else:
+      return None
+
+  @classmethod
   def get_special_mappings(cls, object_type, related_type, related_ids):
     return [
         cls.audit_request(object_type, related_type, related_ids),
@@ -169,6 +184,7 @@ class RelationshipHelper(object):
         cls.request_audit_object(object_type, related_type, related_ids),
         cls.request_response(object_type, related_type, related_ids),
         cls.section_directive(object_type, related_type, related_ids),
+        cls.task_group_object(object_type, related_type, related_ids),
     ]
 
   @classmethod

--- a/src/ggrc/models/relationship_helper.py
+++ b/src/ggrc/models/relationship_helper.py
@@ -10,6 +10,7 @@ from ggrc import db
 from ggrc.extensions import get_extension_modules
 from ggrc import models
 from ggrc.models import Audit
+from ggrc.models import AuditObject
 from ggrc.models import Section
 from ggrc.models import Request
 from ggrc.models.relationship import Relationship
@@ -119,6 +120,19 @@ class RelationshipHelper(object):
           Request.assignee_id.in_(related_ids))
 
   @classmethod
+  def request_audit_object(cls, object_type, related_type, related_ids):
+    if object_type == "Request":
+      return db.session.query(Request.id).join(AuditObject).filter(
+          (AuditObject.auditable_type == related_type) &
+          AuditObject.auditable_id.in_(related_ids))
+    elif related_type == "Request":
+      return db.session.query(AuditObject.auditable_id).join(Request).filter(
+          (AuditObject.auditable_type == related_type) &
+          Request.id.in_(related_ids))
+    else:
+      return None
+
+  @classmethod
   def get_special_mappings(cls, object_type, related_type, related_ids):
     return [
         cls.audit_request(object_type, related_type, related_ids),
@@ -127,6 +141,7 @@ class RelationshipHelper(object):
         cls.person_withcontact(object_type, related_type, related_ids),
         cls.program_audit(object_type, related_type, related_ids),
         cls.request_assignee(object_type, related_type, related_ids),
+        cls.request_audit_object(object_type, related_type, related_ids),
         cls.section_directive(object_type, related_type, related_ids),
     ]
 

--- a/src/ggrc/models/relationship_helper.py
+++ b/src/ggrc/models/relationship_helper.py
@@ -13,6 +13,7 @@ from ggrc.models import Audit
 from ggrc.models import AuditObject
 from ggrc.models import Section
 from ggrc.models import Request
+from ggrc.models import Response
 from ggrc.models.relationship import Relationship
 
 
@@ -133,6 +134,17 @@ class RelationshipHelper(object):
       return None
 
   @classmethod
+  def request_response(cls, object_type, related_type, related_ids):
+    if {object_type, related_type} != {"Request", "Response"} or not related_ids:
+      return None
+    if object_type == "Request":
+      return db.session.query(Response.request_id).filter(
+          Response.id.in_(related_ids))
+    else:
+      return db.session.query(Response.id).filter(
+          Response.request_id.in_(related_ids))
+
+  @classmethod
   def get_special_mappings(cls, object_type, related_type, related_ids):
     return [
         cls.audit_request(object_type, related_type, related_ids),
@@ -142,6 +154,7 @@ class RelationshipHelper(object):
         cls.program_audit(object_type, related_type, related_ids),
         cls.request_assignee(object_type, related_type, related_ids),
         cls.request_audit_object(object_type, related_type, related_ids),
+        cls.request_response(object_type, related_type, related_ids),
         cls.section_directive(object_type, related_type, related_ids),
     ]
 

--- a/src/ggrc/models/relationship_helper.py
+++ b/src/ggrc/models/relationship_helper.py
@@ -15,6 +15,7 @@ from ggrc.models import Section
 from ggrc.models import Request
 from ggrc.models import Response
 from ggrc.models.relationship import Relationship
+from ggrc.models import all_models
 
 
 class RelationshipHelper(object):
@@ -145,6 +146,17 @@ class RelationshipHelper(object):
           Response.request_id.in_(related_ids))
 
   @classmethod
+  def program_risk_assessment(cls, object_type, related_type, related_ids):
+    if {object_type, related_type} != {"Program", "RiskAssessment"} or not related_ids:
+      return None
+    if object_type == "Program":
+      return db.session.query(all_models.RiskAssessment.program_id).filter(
+          all_models.RiskAssessment.id.in_(related_ids))
+    else:
+      return db.session.query(all_models.RiskAssessment.id).filter(
+          all_models.RiskAssessment.program_id.in_(related_ids))
+
+  @classmethod
   def get_special_mappings(cls, object_type, related_type, related_ids):
     return [
         cls.audit_request(object_type, related_type, related_ids),
@@ -152,6 +164,7 @@ class RelationshipHelper(object):
         cls.person_ownable(object_type, related_type, related_ids),
         cls.person_withcontact(object_type, related_type, related_ids),
         cls.program_audit(object_type, related_type, related_ids),
+        cls.program_risk_assessment(object_type, related_type, related_ids),
         cls.request_assignee(object_type, related_type, related_ids),
         cls.request_audit_object(object_type, related_type, related_ids),
         cls.request_response(object_type, related_type, related_ids),

--- a/src/ggrc_workflows/models/relationship_helper.py
+++ b/src/ggrc_workflows/models/relationship_helper.py
@@ -59,6 +59,17 @@ def workflow_tgt(object_type, related_type, related_ids):
         TaskGroup.workflow_id.in_(related_ids))
 
 
+def workflow_ctg(object_type, related_type, related_ids):
+  """ indirect relationships between Workflows and Cycle Task Groups """
+
+  if object_type == "Workflow":
+    return db.session.query(Cycle.workflow_id).join(CycleTaskGroup).filter(
+        CycleTaskGroup.id.in_(related_ids))
+  else:
+    return db.session.query(CycleTaskGroup.id).join(Cycle).filter(
+        Cycle.workflow_id.in_(related_ids))
+
+
 def cycle_ctg(object_type, related_type, related_ids):
   """ relationships between Cycle and Cycle Task Group """
 
@@ -96,6 +107,7 @@ _function_map = {
     ("Cycle", "CycleTaskGroup"): cycle_ctg,
     ("Cycle", "Workflow"): cycle_workflow,
     ("CycleTaskGroup", "CycleTaskGroupObjectTask"): ctg_ctgot,
+    ("CycleTaskGroup", "Workflow"): workflow_ctg,
     ("TaskGroup", "TaskGroupTask"): tg_task,
     ("TaskGroup", "Workflow"): workflow_tg,
     ("TaskGroupTask", "Workflow"): workflow_tgt,

--- a/src/ggrc_workflows/models/relationship_helper.py
+++ b/src/ggrc_workflows/models/relationship_helper.py
@@ -94,6 +94,19 @@ def cycle_ctg(object_type, related_type, related_ids):
         CycleTaskGroup.cycle_id.in_(related_ids))
 
 
+def cycle_ctogt(object_type, related_type, related_ids):
+  """ indirect relationships between Cycle and Cycle Task """
+
+  if object_type == "Workflow":
+    return db.session.query(Cycle.workflow_id) \
+        .join(CycleTaskGroup).join(CycleTask).filter(
+            CycleTask.id.in_(related_ids))
+  else:
+    return db.session.query(CycleTask.id) \
+        .join(CycleTaskGroup).join(Cycle).filter(
+            Cycle.workflow_id.in_(related_ids))
+
+
 def ctg_ctgot(object_type, related_type, related_ids):
   """ relationships between Cycle Task Groups and Cycle Tasks """
   if object_type == "CycleTaskGroup":
@@ -118,6 +131,7 @@ def ctgot_wot(object_type, related_type, related_ids):
 
 _function_map = {
     ("Cycle", "CycleTaskGroup"): cycle_ctg,
+    ("Cycle", "CycleTaskGroupObjectTask"): cycle_ctogt,
     ("Cycle", "Workflow"): cycle_workflow,
     ("CycleTaskGroup", "CycleTaskGroupObjectTask"): ctg_ctgot,
     ("CycleTaskGroup", "Workflow"): workflow_ctg,

--- a/src/ggrc_workflows/models/relationship_helper.py
+++ b/src/ggrc_workflows/models/relationship_helper.py
@@ -70,6 +70,19 @@ def workflow_ctg(object_type, related_type, related_ids):
         Cycle.workflow_id.in_(related_ids))
 
 
+def workflow_ctgot(object_type, related_type, related_ids):
+  """ indirect relationships between Workflows and Cycle Tasks """
+
+  if object_type == "Workflow":
+    return db.session.query(Cycle.workflow_id) \
+        .join(CycleTaskGroup).join(CycleTask).filter(
+            CycleTask.id.in_(related_ids))
+  else:
+    return db.session.query(CycleTask.id) \
+        .join(CycleTaskGroup).join(Cycle).filter(
+            Cycle.workflow_id.in_(related_ids))
+
+
 def cycle_ctg(object_type, related_type, related_ids):
   """ relationships between Cycle and Cycle Task Group """
 
@@ -108,6 +121,7 @@ _function_map = {
     ("Cycle", "Workflow"): cycle_workflow,
     ("CycleTaskGroup", "CycleTaskGroupObjectTask"): ctg_ctgot,
     ("CycleTaskGroup", "Workflow"): workflow_ctg,
+    ("CycleTaskGroupObjectTask", "Workflow"): workflow_ctgot,
     ("TaskGroup", "TaskGroupTask"): tg_task,
     ("TaskGroup", "Workflow"): workflow_tg,
     ("TaskGroupTask", "Workflow"): workflow_tgt,

--- a/src/ggrc_workflows/models/relationship_helper.py
+++ b/src/ggrc_workflows/models/relationship_helper.py
@@ -48,6 +48,17 @@ def workflow_tg(object_type, related_type, related_ids):
         TaskGroup.workflow_id.in_(related_ids))
 
 
+def workflow_tgt(object_type, related_type, related_ids):
+  """ indirect relationships between Workflows and Tasks """
+
+  if object_type == "Workflow":
+    return db.session.query(TaskGroup.workflow_id).join(TaskGroupTask).filter(
+        TaskGroupTask.id.in_(related_ids))
+  else:
+    return db.session.query(TaskGroupTask.id).join(TaskGroup).filter(
+        TaskGroup.workflow_id.in_(related_ids))
+
+
 def cycle_ctg(object_type, related_type, related_ids):
   """ relationships between Cycle and Cycle Task Group """
 
@@ -82,11 +93,12 @@ def ctgot_wot(object_type, related_type, related_ids):
         .filter(CycleTask.id.in_(related_ids))
 
 _function_map = {
-    ("TaskGroup", "Workflow"): workflow_tg,
-    ("TaskGroup", "TaskGroupTask"): tg_task,
-    ("Cycle", "Workflow"): cycle_workflow,
     ("Cycle", "CycleTaskGroup"): cycle_ctg,
+    ("Cycle", "Workflow"): cycle_workflow,
     ("CycleTaskGroup", "CycleTaskGroupObjectTask"): ctg_ctgot,
+    ("TaskGroup", "TaskGroupTask"): tg_task,
+    ("TaskGroup", "Workflow"): workflow_tg,
+    ("TaskGroupTask", "Workflow"): workflow_tgt,
 }
 
 # add mappings for cycle tasks and cycle task objects


### PR DESCRIPTION
This adds a few helpers to make "relevant to" filtering on export more consistent. It still does not implement the full ticket but it forms a logical unit so I'd like to have it merged and not wait to implement everything.