### PR TITLE
CORE-2332 Fix imports where task groups have duplicate objs

### DIFF
--- a/src/ggrc_workflows/converters/handlers.py
+++ b/src/ggrc_workflows/converters/handlers.py
@@ -264,7 +264,12 @@ class ObjectsColumnHandler(ColumnHandler):
     return "\n".join(lines)
 
   def insert_object(self):
+    obj = self.row_converter.obj
+    existing = set((t.object_type, t.object_id)
+                   for t in self.row_converter.obj.task_group_objects)
     for object_ in self.value:
+      if (object_.type, object_.id) in existing:
+        continue
       tgo = TaskGroupObject(
           task_group=self.row_converter.obj,
           object=object_,


### PR DESCRIPTION
~~This is a poorman's `INSERT IGNORE`. Just looking at
`self.row_converter.obj.task_group_objects` is not enough.~~

~~Better ideas are much appreciated.~~
Check existing task group objects (there may be some if this is an update) and skip that objects.