### PR TITLE
CORE-2325 Fix quarterly bug; Fix workflow test suite session bug

### DIFF
--- a/src/ggrc_workflows/services/workflow_cycle_calculator/annually_cycle_calculator.py
+++ b/src/ggrc_workflows/services/workflow_cycle_calculator/annually_cycle_calculator.py
@@ -25,7 +25,8 @@ class AnnuallyCycleCalculator(CycleCalculator):
     base_date = self.get_base_date(base_date)
     self.reified_tasks = {}
     for task in self.tasks:
-      start_date, end_date = self.non_adjusted_task_date_range(task, base_date)
+      start_date, end_date = self.non_adjusted_task_date_range(
+        task, base_date, initialisation=True)
       self.reified_tasks[task.id] = {
         'start_date': start_date,
         'end_date': end_date,

--- a/src/ggrc_workflows/services/workflow_cycle_calculator/monthly_cycle_calculator.py
+++ b/src/ggrc_workflows/services/workflow_cycle_calculator/monthly_cycle_calculator.py
@@ -25,7 +25,7 @@ class MonthlyCycleCalculator(CycleCalculator):
     self.reified_tasks = {}
     for task in self.tasks:
       start_date, end_date = self.non_adjusted_task_date_range(
-        task, base_date=base_date)
+        task, base_date=base_date, initialisation=True)
       self.reified_tasks[task.id] = {
         'start_date': start_date,
         'end_date': end_date,

--- a/src/ggrc_workflows/services/workflow_cycle_calculator/quarterly_cycle_calculator.py
+++ b/src/ggrc_workflows/services/workflow_cycle_calculator/quarterly_cycle_calculator.py
@@ -30,7 +30,8 @@ class QuarterlyCycleCalculator(CycleCalculator):
     base_date = self.get_base_date(base_date)
     self.reified_tasks = {}
     for task in self.tasks:
-      start_date, end_date = self.non_adjusted_task_date_range(task, base_date)
+      start_date, end_date = self.non_adjusted_task_date_range(
+        task, base_date, initialisation=True)
       self.reified_tasks[task.id] = {
         'start_date': start_date,
         'end_date': end_date,

--- a/src/ggrc_workflows/services/workflow_cycle_calculator/weekly_cycle_calculator.py
+++ b/src/ggrc_workflows/services/workflow_cycle_calculator/weekly_cycle_calculator.py
@@ -25,7 +25,8 @@ class WeeklyCycleCalculator(CycleCalculator):
 
     self.reified_tasks = {}
     for task in self.tasks:
-      start_date, end_date = self.non_adjusted_task_date_range(task, base_date)
+      start_date, end_date = self.non_adjusted_task_date_range(
+        task, base_date, initialisation=True)
       self.reified_tasks[task.id] = {
         'start_date': start_date,
         'end_date': end_date,

--- a/src/tests/ggrc/api_helper.py
+++ b/src/tests/ggrc/api_helper.py
@@ -28,8 +28,8 @@ class Api():
 
   def set_user(self, person=None):
     # Refresh the person instance from the db:
-    person = person.__class__.query.get(person.id)
     if person:
+      person = person.__class__.query.get(person.id)
       self.user_headers = {
           "X-ggrc-user": self.resource.as_json({
               "name": person.name,
@@ -71,8 +71,10 @@ class Api():
 
     json_data = self.resource.as_json(data)
     logging.info("request json" + json_data)
-
     response = request(api_link, data=json_data, headers=headers.items())
+    if response.status_code == 302:
+      self.set_user()
+      response = request(api_link, data=json_data, headers=headers.items())
     return self.data_to_json(response)
 
   def put(self, obj, data):

--- a/src/tests/ggrc_workflows/workflow_cycle_calculator/test_quarterly_workflow.py
+++ b/src/tests/ggrc_workflows/workflow_cycle_calculator/test_quarterly_workflow.py
@@ -762,3 +762,481 @@ class TestQuarterlyWorkflow(BaseWorkflowTestCase):
 
       active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
       self.assertEqual(active_wf.next_cycle_start_date, date(2016, 7, 13))
+
+  def test_multiple_task_groups_multiple_tasks_multiple_quarters_future(self):
+    """Test behaviour of multiple task groups with multiple tasks spread across multiple quarters
+
+    Task group  | Tasks | Start day           | End day
+    1           | 1     | Feb/May/Aug/Nov  1  | Feb/May/Aug/Nov  5
+    1           | 2     | Feb/May/Aug/Nov 10  | Feb/May/Aug/Nov 20
+    2           | 3     | Feb/May/Aug/Nov 20  | Feb/May/Aug/Nov 25
+    2           | 4     | Mar/Jun/Sep/Dec  1  | Mar/Jun/Sep/Dec  5
+
+    Cycle should last from:
+    Feb 1 - Mar 5
+    May 1 - Jun 5
+    Aug 1 - Sep 5
+    Nov 1 - Dec 5
+    """
+    quarterly_wf = {
+      "title": "quarterly thingy",
+      "description": "start this many a time",
+      "frequency": "quarterly",
+      "task_groups": [{
+        "title": "task group",
+        "task_group_tasks": [
+          {
+            'title': 'quarterly task 1',
+            "relative_start_day": 1,
+            "relative_start_month": 2,
+            "relative_end_day": 5,
+            "relative_end_month": 2,
+          }, {
+            'title': 'quarterly task 2',
+            "relative_start_day": 10,
+            "relative_start_month": 2,
+            "relative_end_day": 20,
+            "relative_end_month": 2,
+          }],
+        "task_group_objects": []
+      }, {
+        "title": "task group",
+        "task_group_tasks": [
+          {
+            'title': 'quarterly task 3',
+            "relative_start_day": 20,
+            "relative_start_month": 2,
+            "relative_end_day": 25,
+            "relative_end_month": 2,
+          }, {
+            'title': 'quarterly task 4',
+            "relative_start_day": 1,
+            "relative_start_month": 3,
+            "relative_end_day": 5,
+            "relative_end_month": 3,
+          }],
+        "task_group_objects": []
+      }]
+    }
+
+    with freeze_time("2015-6-9 13:00:00"):  # Tuesday, 6/9/2015
+      _, wf = self.generator.generate_workflow(quarterly_wf)
+      _, awf = self.generator.activate_workflow(wf)
+
+      active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
+      self.assertEqual(active_wf.status, "Active")
+      self.assertEqual(active_wf.next_cycle_start_date, date(2015, 7, 31))
+
+      _, cycle = self.generator.generate_cycle(wf)
+      self.assertEqual(cycle.start_date, date(2015, 7, 31))
+      self.assertEqual(cycle.end_date, date(2015, 9, 4))
+      active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
+      self.assertEqual(active_wf.next_cycle_start_date, date(2015, 10, 30))
+
+      _, cycle = self.generator.generate_cycle(wf)
+      self.assertEqual(cycle.start_date, date(2015, 10, 30))
+      self.assertEqual(cycle.end_date, date(2015, 12, 4))
+      active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
+      self.assertEqual(active_wf.next_cycle_start_date, date(2016, 2, 1))
+
+      _, cycle = self.generator.generate_cycle(wf)
+      self.assertEqual(cycle.start_date, date(2016, 2, 1))
+      self.assertEqual(cycle.end_date, date(2016, 3, 4))
+      active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
+      self.assertEqual(active_wf.next_cycle_start_date, date(2016, 4, 29))
+
+      _, cycle = self.generator.generate_cycle(wf)
+      self.assertEqual(cycle.start_date, date(2016, 4, 29))
+      self.assertEqual(cycle.end_date, date(2016, 6, 3))
+      active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
+      self.assertEqual(active_wf.next_cycle_start_date, date(2016, 8, 1))
+
+      _, cycle = self.generator.generate_cycle(wf)
+      self.assertEqual(cycle.start_date, date(2016, 8, 1))
+      self.assertEqual(cycle.end_date, date(2016, 9, 2))
+      active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
+      self.assertEqual(active_wf.next_cycle_start_date, date(2016, 11, 1))
+
+      _, cycle = self.generator.generate_cycle(wf)
+      self.assertEqual(cycle.start_date, date(2016, 11, 1))
+      self.assertEqual(cycle.end_date, date(2016, 12, 5))
+      active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
+      self.assertEqual(active_wf.next_cycle_start_date, date(2017, 2, 1))
+
+      _, cycle = self.generator.generate_cycle(wf)
+      self.assertEqual(cycle.start_date, date(2017, 2, 1))
+      self.assertEqual(cycle.end_date, date(2017, 3, 3))
+      active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
+      self.assertEqual(active_wf.next_cycle_start_date, date(2017, 5, 1))
+
+      _, cycle = self.generator.generate_cycle(wf)
+      self.assertEqual(cycle.start_date, date(2017, 5, 1))
+      self.assertEqual(cycle.end_date, date(2017, 6, 5))
+      active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
+      self.assertEqual(active_wf.next_cycle_start_date, date(2017, 8, 1))
+
+      _, cycle = self.generator.generate_cycle(wf)
+      self.assertEqual(cycle.start_date, date(2017, 8, 1))
+      self.assertEqual(cycle.end_date, date(2017, 9, 5))
+      active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
+      self.assertEqual(active_wf.next_cycle_start_date, date(2017, 11, 1))
+
+      _, cycle = self.generator.generate_cycle(wf)
+      self.assertEqual(cycle.start_date, date(2017, 11, 1))
+      self.assertEqual(cycle.end_date, date(2017, 12, 5))
+      active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
+      self.assertEqual(active_wf.next_cycle_start_date, date(2018, 2, 1))
+
+      _, cycle = self.generator.generate_cycle(wf)
+      self.assertEqual(cycle.start_date, date(2018, 2, 1))
+      self.assertEqual(cycle.end_date, date(2018, 3, 5))
+      active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
+      self.assertEqual(active_wf.next_cycle_start_date, date(2018, 5, 1))
+
+      _, cycle = self.generator.generate_cycle(wf)
+      self.assertEqual(cycle.start_date, date(2018, 5, 1))
+      self.assertEqual(cycle.end_date, date(2018, 6, 5))
+      active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
+      self.assertEqual(active_wf.next_cycle_start_date, date(2018, 8, 1))
+
+  def test_multiple_task_groups_multiple_tasks_multiple_quarters_in_middle(self):
+    """Test behaviour of multiple task groups with multiple tasks spread across multiple quarters
+
+    Task group  | Tasks | Start day           | End day
+    1           | 1     | Feb/May/Aug/Nov  1  | Feb/May/Aug/Nov  5
+    1           | 2     | Feb/May/Aug/Nov 10  | Feb/May/Aug/Nov 20
+    2           | 3     | Feb/May/Aug/Nov 20  | Feb/May/Aug/Nov 25
+    2           | 4     | Mar/Jun/Sep/Dec  1  | Mar/Jun/Sep/Dec  5
+
+    Cycle should last from:
+    Feb 1 - Mar 5
+    May 1 - Jun 5
+    Aug 1 - Sep 5
+    Nov 1 - Dec 5
+    """
+    quarterly_wf = {
+      "title": "quarterly thingy",
+      "description": "start this many a time",
+      "frequency": "quarterly",
+      "task_groups": [{
+        "title": "task group",
+        "task_group_tasks": [
+          {
+            'title': 'quarterly task 1',
+            "relative_start_day": 1,
+            "relative_start_month": 2,
+            "relative_end_day": 5,
+            "relative_end_month": 2,
+          }, {
+            'title': 'quarterly task 2',
+            "relative_start_day": 10,
+            "relative_start_month": 2,
+            "relative_end_day": 20,
+            "relative_end_month": 2,
+          }],
+        "task_group_objects": []
+      }, {
+        "title": "task group",
+        "task_group_tasks": [
+          {
+            'title': 'quarterly task 3',
+            "relative_start_day": 20,
+            "relative_start_month": 2,
+            "relative_end_day": 25,
+            "relative_end_month": 2,
+          }, {
+            'title': 'quarterly task 4',
+            "relative_start_day": 1,
+            "relative_start_month": 3,
+            "relative_end_day": 5,
+            "relative_end_month": 3,
+          }],
+        "task_group_objects": []
+      }]
+    }
+    with freeze_time("2015-6-3 13:00:00"):  # Tuesday, 6/3/2015
+      _, wf = self.generator.generate_workflow(quarterly_wf)
+      _, awf = self.generator.activate_workflow(wf)
+
+      active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
+      self.assertEqual(active_wf.status, "Active")
+      self.assertEqual(active_wf.next_cycle_start_date, date(2015, 7, 31))
+
+      cycle = db.session.query(Cycle).filter(
+        Cycle.workflow_id == wf.id).one()
+      self.assertEqual(cycle.start_date, date(2015, 5, 1))
+      self.assertEqual(cycle.end_date, date(2015, 6, 5))
+
+      _, cycle = self.generator.generate_cycle(wf)
+      self.assertEqual(cycle.start_date, date(2015, 7, 31))
+      self.assertEqual(cycle.end_date, date(2015, 9, 4))
+      active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
+      self.assertEqual(active_wf.next_cycle_start_date, date(2015, 10, 30))
+
+      _, cycle = self.generator.generate_cycle(wf)
+      self.assertEqual(cycle.start_date, date(2015, 10, 30))
+      self.assertEqual(cycle.end_date, date(2015, 12, 4))
+      active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
+      self.assertEqual(active_wf.next_cycle_start_date, date(2016, 2, 1))
+
+      _, cycle = self.generator.generate_cycle(wf)
+      self.assertEqual(cycle.start_date, date(2016, 2, 1))
+      self.assertEqual(cycle.end_date, date(2016, 3, 4))
+      active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
+      self.assertEqual(active_wf.next_cycle_start_date, date(2016, 4, 29))
+
+      _, cycle = self.generator.generate_cycle(wf)
+      self.assertEqual(cycle.start_date, date(2016, 4, 29))
+      self.assertEqual(cycle.end_date, date(2016, 6, 3))
+      active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
+      self.assertEqual(active_wf.next_cycle_start_date, date(2016, 8, 1))
+
+  def test_multiple_task_groups_multiple_tasks_multiple_quarters_last_quarter_middle(self):
+    """Test behaviour of multiple task groups with multiple tasks spread across multiple quarters
+
+    Task group  | Tasks | Start day           | End day
+    1           | 1     | Feb/May/Aug/Nov  1  | Feb/May/Aug/Nov  5
+    1           | 2     | Feb/May/Aug/Nov 10  | Feb/May/Aug/Nov 20
+    2           | 3     | Feb/May/Aug/Nov 20  | Feb/May/Aug/Nov 25
+    2           | 4     | Mar/Jun/Sep/Dec  1  | Mar/Jun/Sep/Dec  5
+
+    Cycle should last from:
+    Feb 1 - Mar 5
+    May 1 - Jun 5
+    Aug 1 - Sep 5
+    Nov 1 - Dec 5
+    """
+    quarterly_wf = {
+      "title": ("quarterly thingy test_multiple_task_groups_multiple_tasks_"
+               "multiple_quarters_last_quarter_middle"),
+      "description": "start this many a time",
+      "frequency": "quarterly",
+      "task_groups": [{
+        "title": "task group",
+        "task_group_tasks": [
+          {
+            'title': 'quarterly task 1',
+            "relative_start_day": 1,
+            "relative_start_month": 2,
+            "relative_end_day": 5,
+            "relative_end_month": 2,
+          }, {
+            'title': 'quarterly task 2',
+            "relative_start_day": 10,
+            "relative_start_month": 2,
+            "relative_end_day": 20,
+            "relative_end_month": 2,
+          }],
+        "task_group_objects": []
+      }, {
+        "title": "task group",
+        "task_group_tasks": [
+          {
+            'title': 'quarterly task 3',
+            "relative_start_day": 20,
+            "relative_start_month": 2,
+            "relative_end_day": 25,
+            "relative_end_month": 2,
+          }, {
+            'title': 'quarterly task 4',
+            "relative_start_day": 1,
+            "relative_start_month": 3,
+            "relative_end_day": 5,
+            "relative_end_month": 3,
+          }],
+        "task_group_objects": []
+      }]
+    }
+    with freeze_time("2015-12-01 13:00:00"):  # Tuesday, 12/1/2015
+      _, wf = self.generator.generate_workflow(quarterly_wf)
+      _, awf = self.generator.activate_workflow(wf)
+
+      active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
+      self.assertEqual(active_wf.status, "Active")
+      self.assertEqual(active_wf.next_cycle_start_date, date(2016, 2, 1))
+
+      cycle = db.session.query(Cycle).filter(
+        Cycle.workflow_id == wf.id).one()
+      self.assertEqual(cycle.start_date, date(2015, 10, 30))
+      self.assertEqual(cycle.end_date, date(2015, 12, 4))
+
+      _, cycle = self.generator.generate_cycle(wf)
+      self.assertEqual(cycle.start_date, date(2016, 2, 1))
+      self.assertEqual(cycle.end_date, date(2016, 3, 4))
+      active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
+      self.assertEqual(active_wf.next_cycle_start_date, date(2016, 4, 29))
+
+      _, cycle = self.generator.generate_cycle(wf)
+      self.assertEqual(cycle.start_date, date(2016, 4, 29))
+      self.assertEqual(cycle.end_date, date(2016, 6, 3))
+      active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
+      self.assertEqual(active_wf.next_cycle_start_date, date(2016, 8, 1))
+
+  def test_multiple_task_groups_multiple_tasks_multiple_quarters_last_quarter_past(self):
+    """Test behaviour of multiple task groups with multiple tasks spread across multiple quarters
+
+    Task group  | Tasks | Start day           | End day
+    1           | 1     | Feb/May/Aug/Nov  1  | Feb/May/Aug/Nov  5
+    1           | 2     | Feb/May/Aug/Nov 10  | Feb/May/Aug/Nov 20
+    2           | 3     | Feb/May/Aug/Nov 20  | Feb/May/Aug/Nov 25
+    2           | 4     | Mar/Jun/Sep/Dec  1  | Mar/Jun/Sep/Dec  5
+
+    Cycle should last from:
+    Feb 1 - Mar 5
+    May 1 - Jun 5
+    Aug 1 - Sep 5
+    Nov 1 - Dec 5
+    """
+    quarterly_wf = {
+      "title": "quarterly thingy",
+      "description": "start this many a time",
+      "frequency": "quarterly",
+      "task_groups": [{
+        "title": "task group",
+        "task_group_tasks": [
+          {
+            'title': 'quarterly task 1',
+            "relative_start_day": 1,
+            "relative_start_month": 2,
+            "relative_end_day": 5,
+            "relative_end_month": 2,
+          }, {
+            'title': 'quarterly task 2',
+            "relative_start_day": 10,
+            "relative_start_month": 2,
+            "relative_end_day": 20,
+            "relative_end_month": 2,
+          }],
+        "task_group_objects": []
+      }, {
+        "title": "task group",
+        "task_group_tasks": [
+          {
+            'title': 'quarterly task 3',
+            "relative_start_day": 20,
+            "relative_start_month": 2,
+            "relative_end_day": 25,
+            "relative_end_month": 2,
+          }, {
+            'title': 'quarterly task 4',
+            "relative_start_day": 1,
+            "relative_start_month": 3,
+            "relative_end_day": 5,
+            "relative_end_month": 3,
+          }],
+        "task_group_objects": []
+      }]
+    }
+    with freeze_time("2015-12-7 13:00:00"):  # Mon, 12/7/2015
+      _, wf = self.generator.generate_workflow(quarterly_wf)
+      _, awf = self.generator.activate_workflow(wf)
+
+      active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
+      self.assertEqual(active_wf.status, "Active")
+      self.assertEqual(active_wf.next_cycle_start_date, date(2016, 2, 1))
+
+      _, cycle = self.generator.generate_cycle(wf)
+      self.assertEqual(cycle.start_date, date(2016, 2, 1))
+      self.assertEqual(cycle.end_date, date(2016, 3, 4))
+      active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
+      self.assertEqual(active_wf.next_cycle_start_date, date(2016, 4, 29))
+
+      _, cycle = self.generator.generate_cycle(wf)
+      self.assertEqual(cycle.start_date, date(2016, 4, 29))
+      self.assertEqual(cycle.end_date, date(2016, 6, 3))
+      active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
+      self.assertEqual(active_wf.next_cycle_start_date, date(2016, 8, 1))
+
+  def test_multiple_task_groups_multiple_tasks_multiple_quarters_tasks_in_reverse_order(self):
+    """Test behaviour of multiple task groups with multiple tasks spread across multiple quarters
+
+    Task group  | Tasks | Start day           | End day
+    2           | 4     | Mar/Jun/Sep/Dec  1  | Mar/Jun/Sep/Dec  5
+    2           | 3     | Feb/May/Aug/Nov 20  | Feb/May/Aug/Nov 25
+    1           | 2     | Feb/May/Aug/Nov 10  | Feb/May/Aug/Nov 20
+    1           | 1     | Feb/May/Aug/Nov  1  | Feb/May/Aug/Nov  5
+
+    Cycle should last from:
+    Feb 1 - Mar 5
+    May 1 - Jun 5
+    Aug 1 - Sep 5
+    Nov 1 - Dec 5
+    """
+    quarterly_wf = {
+      "title": "quarterly thingy",
+      "description": "start this many a time",
+      "frequency": "quarterly",
+      "task_groups": [{
+        "title": "task group",
+        "task_group_tasks": [
+          {
+            'title': 'quarterly task 4',
+            "relative_start_day": 1,
+            "relative_start_month": 3,
+            "relative_end_day": 5,
+            "relative_end_month": 3,
+          }, {
+            'title': 'quarterly task 3',
+            "relative_start_day": 20,
+            "relative_start_month": 2,
+            "relative_end_day": 25,
+            "relative_end_month": 2,
+          }
+        ],
+        "task_group_objects": []
+      }, {
+        "title": "task group",
+        "task_group_tasks": [
+          {
+            'title': 'quarterly task 2',
+            "relative_start_day": 10,
+            "relative_start_month": 2,
+            "relative_end_day": 20,
+            "relative_end_month": 2,
+          }, {
+            'title': 'quarterly task 1',
+            "relative_start_day": 1,
+            "relative_start_month": 2,
+            "relative_end_day": 5,
+            "relative_end_month": 2,
+          }
+        ],
+        "task_group_objects": []
+      }]
+    }
+    with freeze_time("2015-6-3 13:00:00"):  # Tuesday, 6/3/2015
+      _, wf = self.generator.generate_workflow(quarterly_wf)
+      _, awf = self.generator.activate_workflow(wf)
+
+      active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
+      self.assertEqual(active_wf.status, "Active")
+      self.assertEqual(active_wf.next_cycle_start_date, date(2015, 7, 31))
+
+      cycle = db.session.query(Cycle).filter(
+        Cycle.workflow_id == wf.id).one()
+      self.assertEqual(cycle.start_date, date(2015, 5, 1))
+      self.assertEqual(cycle.end_date, date(2015, 6, 5))
+
+      _, cycle = self.generator.generate_cycle(wf)
+      self.assertEqual(cycle.start_date, date(2015, 7, 31))
+      self.assertEqual(cycle.end_date, date(2015, 9, 4))
+      active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
+      self.assertEqual(active_wf.next_cycle_start_date, date(2015, 10, 30))
+
+      _, cycle = self.generator.generate_cycle(wf)
+      self.assertEqual(cycle.start_date, date(2015, 10, 30))
+      self.assertEqual(cycle.end_date, date(2015, 12, 4))
+      active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
+      self.assertEqual(active_wf.next_cycle_start_date, date(2016, 2, 1))
+
+      _, cycle = self.generator.generate_cycle(wf)
+      self.assertEqual(cycle.start_date, date(2016, 2, 1))
+      self.assertEqual(cycle.end_date, date(2016, 3, 4))
+      active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
+      self.assertEqual(active_wf.next_cycle_start_date, date(2016, 4, 29))
+
+      _, cycle = self.generator.generate_cycle(wf)
+      self.assertEqual(cycle.start_date, date(2016, 4, 29))
+      self.assertEqual(cycle.end_date, date(2016, 6, 3))
+      active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
+      self.assertEqual(active_wf.next_cycle_start_date, date(2016, 8, 1))

--- a/src/tests/ggrc_workflows/workflow_cycle_calculator/test_quarterly_workflow.py
+++ b/src/tests/ggrc_workflows/workflow_cycle_calculator/test_quarterly_workflow.py
@@ -17,6 +17,8 @@ from tests.ggrc.api_helper import Api
 from tests.ggrc.generator import ObjectGenerator
 
 from tests.ggrc_workflows.workflow_cycle_calculator.base_workflow_test_case import BaseWorkflowTestCase
+from ggrc_workflows.services.workflow_cycle_calculator import \
+  QuarterlyCycleCalculator
 
 
 if os.environ.get('TRAVIS', False):
@@ -27,6 +29,285 @@ class TestQuarterlyWorkflow(BaseWorkflowTestCase):
 
   All test cases based on spec.
   """
+  def test_relative_day_to_date(self):
+    """Verify relative_day_to_date conversion for all possible quarterly scenarios"""
+    quarterly_wf = {
+      "title": "quarterly thingy",
+      "description": "start this many a time",
+      "frequency": "quarterly",
+      "task_groups": [{
+        "title": "task group",
+        "task_group_tasks": [
+          {
+            'title': 'quarterly task 1',
+            "relative_start_day": 30,
+            "relative_start_month": 1,
+            "relative_end_day": 15,
+            "relative_end_month": 1,
+          }],
+        "task_group_objects": self.random_objects
+      },
+      ]
+    }
+    _, wf = self.generator.generate_workflow(quarterly_wf)
+    _, awf = self.generator.activate_workflow(wf)
+    active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
+
+    QuarterlyCycleCalculator.__abstractmethods__ = set()
+    qcc = QuarterlyCycleCalculator(active_wf)
+
+    rdd = qcc.relative_day_to_date
+
+    # Test first-quarter option conversion
+    # 1/1 in first quarter
+    self.assertEqual(rdd(relative_day=1, relative_month=1,
+                         base_date=date(2015, 1, 1)),
+                     date(2015, 1, 1))
+    self.assertEqual(rdd(relative_day=1, relative_month=1,
+                         base_date=date(2015, 2, 1)),
+                     date(2015, 1, 1))
+    self.assertEqual(rdd(relative_day=1, relative_month=1,
+                         base_date=date(2015, 3, 1)),
+                     date(2015, 1, 1))
+    # 1/1 in second quarter
+    self.assertEqual(rdd(relative_day=1, relative_month=1,
+                         base_date=date(2015, 4, 1)),
+                     date(2015, 4, 1))
+    self.assertEqual(rdd(relative_day=1, relative_month=1,
+                         base_date=date(2015, 5, 1)),
+                     date(2015, 4, 1))
+    self.assertEqual(rdd(relative_day=1, relative_month=1,
+                         base_date=date(2015, 6, 1)),
+                     date(2015, 4, 1))
+    # 1/1 in third quarter
+    self.assertEqual(rdd(relative_day=1, relative_month=1,
+                         base_date=date(2015, 7, 1)),
+                     date(2015, 7, 1))
+    self.assertEqual(rdd(relative_day=1, relative_month=1,
+                         base_date=date(2015, 8, 1)),
+                     date(2015, 7, 1))
+    self.assertEqual(rdd(relative_day=1, relative_month=1,
+                         base_date=date(2015, 9, 1)),
+                     date(2015, 7, 1))
+    # 1/1 in fourth quarter
+    self.assertEqual(rdd(relative_day=1, relative_month=1,
+                         base_date=date(2015, 10, 1)),
+                     date(2015, 10, 1))
+    self.assertEqual(rdd(relative_day=1, relative_month=1,
+                         base_date=date(2015, 11, 1)),
+                     date(2015, 10, 1))
+    self.assertEqual(rdd(relative_day=1, relative_month=1,
+                         base_date=date(2015, 12, 1)),
+                     date(2015, 10, 1))
+    #########################################################################
+    # # 2/1 in first quarter
+    self.assertEqual(rdd(relative_day=1, relative_month=2,
+                         base_date=date(2015, 1, 1)),
+                     date(2014, 11, 1))
+    self.assertEqual(rdd(relative_day=1, relative_month=2,
+                         base_date=date(2015, 2, 1)),
+                     date(2015, 2, 1))
+    self.assertEqual(rdd(relative_day=1, relative_month=2,
+                         base_date=date(2015, 3, 1)),
+                     date(2015, 2, 1))
+    # 2/1 in second quarter
+    self.assertEqual(rdd(relative_day=1, relative_month=2,
+                         base_date=date(2015, 4, 1)),
+                     date(2015, 2, 1))
+    self.assertEqual(rdd(relative_day=1, relative_month=2,
+                         base_date=date(2015, 5, 1)),
+                     date(2015, 5, 1))
+    self.assertEqual(rdd(relative_day=1, relative_month=2,
+                         base_date=date(2015, 6, 1)),
+                     date(2015, 5, 1))
+    # 2/1 in third quarter
+    self.assertEqual(rdd(relative_day=1, relative_month=2,
+                         base_date=date(2015, 7, 1)),
+                     date(2015, 5, 1))
+    self.assertEqual(rdd(relative_day=1, relative_month=2,
+                         base_date=date(2015, 8, 1)),
+                     date(2015, 8, 1))
+    self.assertEqual(rdd(relative_day=1, relative_month=2,
+                         base_date=date(2015, 9, 1)),
+                     date(2015, 8, 1))
+    # 2/1 in fourth quarter
+    self.assertEqual(rdd(relative_day=1, relative_month=2,
+                         base_date=date(2015, 10, 1)),
+                     date(2015, 8, 1))
+    self.assertEqual(rdd(relative_day=1, relative_month=2,
+                         base_date=date(2015, 11, 1)),
+                     date(2015, 11, 1))
+    self.assertEqual(rdd(relative_day=1, relative_month=2,
+                         base_date=date(2015, 12, 1)),
+                     date(2015, 11, 1))
+    self.assertEqual(rdd(relative_day=1, relative_month=2,
+                         base_date=date(2016, 1, 1)),
+                     date(2015, 11, 1))
+    #########################################################################
+    # 3/1 in first quarter
+    self.assertEqual(rdd(relative_day=1, relative_month=3,
+                         base_date=date(2015, 1, 1)),
+                     date(2014, 12, 1))
+    self.assertEqual(rdd(relative_day=1, relative_month=3,
+                         base_date=date(2015, 2, 1)),
+                     date(2014, 12, 1))
+    self.assertEqual(rdd(relative_day=1, relative_month=3,
+                         base_date=date(2015, 3, 1)),
+                     date(2015, 3, 1))
+    # 3/1 in second quarter
+    self.assertEqual(rdd(relative_day=1, relative_month=3,
+                         base_date=date(2015, 4, 1)),
+                     date(2015, 3, 1))
+    self.assertEqual(rdd(relative_day=1, relative_month=3,
+                         base_date=date(2015, 5, 1)),
+                     date(2015, 3, 1))
+    self.assertEqual(rdd(relative_day=1, relative_month=3,
+                         base_date=date(2015, 6, 1)),
+                     date(2015, 6, 1))
+    # 3/1 in third quarter
+    self.assertEqual(rdd(relative_day=1, relative_month=3,
+                         base_date=date(2015, 7, 1)),
+                     date(2015, 6, 1))
+    self.assertEqual(rdd(relative_day=1, relative_month=3,
+                         base_date=date(2015, 8, 1)),
+                     date(2015, 6, 1))
+    self.assertEqual(rdd(relative_day=1, relative_month=3,
+                         base_date=date(2015, 9, 1)),
+                     date(2015, 9, 1))
+    # 3/1 in fourht quarter
+    self.assertEqual(rdd(relative_day=1, relative_month=3,
+                         base_date=date(2015, 10, 1)),
+                     date(2015, 9, 1))
+    self.assertEqual(rdd(relative_day=1, relative_month=3,
+                         base_date=date(2015, 11, 1)),
+                     date(2015, 9, 1))
+    self.assertEqual(rdd(relative_day=1, relative_month=3,
+                         base_date=date(2015, 12, 1)),
+                     date(2015, 12, 1))
+    self.assertEqual(rdd(relative_day=1, relative_month=3,
+                         base_date=date(2016, 1, 1)),
+                     date(2015, 12, 1))
+    self.assertEqual(rdd(relative_day=1, relative_month=3,
+                         base_date=date(2016, 2, 1)),
+                     date(2015, 12, 1))
+
+  def test_start_wf_1_1(self):
+    """Test quarterly WF 1/1 activating through months"""
+    quarterly_wf = {
+      "title": "quarterly thingy",
+      "description": "start this many a time",
+      "frequency": "quarterly",
+      "task_groups": [{
+        "title": "task group",
+        "task_group_tasks": [
+          {
+            'title': 'quarterly task 1',
+            "relative_start_day": 1,
+            "relative_start_month": 1,
+            "relative_end_day": 1,
+            "relative_end_month": 1,
+          }],
+        "task_group_objects": self.random_objects
+      },
+      ]
+    }
+    base_dates = [date(2014, 12, 1),
+                  date(2015, 1, 1), date(2015, 2, 1), date(2015, 3, 1),
+                  date(2015, 4, 1), date(2015, 5, 1), date(2015, 6, 1),
+                  date(2015, 7, 1), date(2015, 8, 1), date(2015, 9, 1),
+                  date(2015, 10, 1), date(2015, 11, 1), date(2015, 12, 1)]
+    expected_dates = [date(2015, 1, 1),
+                      date(2015, 4, 1), date(2015, 4, 1), date(2015, 4, 1),
+                      date(2015, 7, 1), date(2015, 7, 1), date(2015, 7, 1),
+                      date(2015, 10, 1), date(2015, 10, 1), date(2015, 10, 1),
+                      date(2016, 1, 1), date(2016, 1, 1), date(2016, 1, 1)]
+
+    for i, bd in enumerate(base_dates):
+      with freeze_time("{} 13:00".format(bd)):
+        _, wf = self.generator.generate_workflow(quarterly_wf)
+        _, awf = self.generator.activate_workflow(wf)
+        active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
+        self.assertEqual(active_wf.non_adjusted_next_cycle_start_date,
+                         expected_dates[i])
+
+  def test_start_wf_2_1(self):
+    """Test quarterly WF 2/1 activating through months"""
+    quarterly_wf = {
+      "title": "quarterly thingy",
+      "description": "start this many a time",
+      "frequency": "quarterly",
+      "task_groups": [{
+        "title": "task group",
+        "task_group_tasks": [
+          {
+            'title': 'quarterly task 1',
+            "relative_start_day": 1,
+            "relative_start_month": 2,
+            "relative_end_day": 1,
+            "relative_end_month": 2,
+          }],
+        "task_group_objects": self.random_objects
+      },
+      ]
+    }
+    base_dates = [date(2014, 12, 1),
+                  date(2015, 1, 1), date(2015, 2, 1), date(2015, 3, 1),
+                  date(2015, 4, 1), date(2015, 5, 1), date(2015, 6, 1),
+                  date(2015, 7, 1), date(2015, 8, 1), date(2015, 9, 1),
+                  date(2015, 10, 1), date(2015, 11, 1), date(2015, 12, 1)]
+    expected_dates = [date(2015, 2, 1),
+                      date(2015, 2, 1), date(2015, 5, 1), date(2015, 5, 1),
+                      date(2015, 5, 1), date(2015, 8, 1), date(2015, 8, 1),
+                      date(2015, 8, 1), date(2015, 11, 1), date(2015, 11, 1),
+                      date(2015, 11, 1), date(2016, 2, 1), date(2016, 2, 1)]
+
+    for i, bd in enumerate(base_dates):
+      with freeze_time("{} 13:00".format(bd)):
+        _, wf = self.generator.generate_workflow(quarterly_wf)
+        _, awf = self.generator.activate_workflow(wf)
+        active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
+        self.assertEqual(active_wf.non_adjusted_next_cycle_start_date,
+                         expected_dates[i])
+
+  def test_start_wf_3_1(self):
+    """Test quarterly WF 3/1 activating through months"""
+    quarterly_wf = {
+      "title": "quarterly thingy",
+      "description": "start this many a time",
+      "frequency": "quarterly",
+      "task_groups": [{
+        "title": "task group",
+        "task_group_tasks": [
+          {
+            'title': 'quarterly task 1',
+            "relative_start_day": 1,
+            "relative_start_month": 3,
+            "relative_end_day": 1,
+            "relative_end_month": 3,
+          }],
+        "task_group_objects": self.random_objects
+      },
+      ]
+    }
+    base_dates = [date(2014, 12, 1),
+                  date(2015, 1, 1), date(2015, 2, 1), date(2015, 3, 1),
+                  date(2015, 4, 1), date(2015, 5, 1), date(2015, 6, 1),
+                  date(2015, 7, 1), date(2015, 8, 1), date(2015, 9, 1),
+                  date(2015, 10, 1), date(2015, 11, 1), date(2015, 12, 1)]
+    expected_dates = [date(2015, 3, 1),
+                      date(2015, 3, 1), date(2015, 3, 1), date(2015, 6, 1),
+                      date(2015, 6, 1), date(2015, 6, 1), date(2015, 9, 1),
+                      date(2015, 9, 1), date(2015, 9, 1), date(2015, 12, 1),
+                      date(2015, 12, 1), date(2015, 12, 1), date(2016, 3, 1)]
+
+
+    for i, bd in enumerate(base_dates):
+      with freeze_time("{} 13:00".format(bd)):
+        _, wf = self.generator.generate_workflow(quarterly_wf)
+        _, awf = self.generator.activate_workflow(wf)
+        active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
+        self.assertEqual(active_wf.non_adjusted_next_cycle_start_date,
+                         expected_dates[i])
 
   def test_equal_month_end_day_before_start_day(self):
     """

--- a/src/tests/ggrc_workflows/workflow_cycle_calculator/test_quarterly_workflow.py
+++ b/src/tests/ggrc_workflows/workflow_cycle_calculator/test_quarterly_workflow.py
@@ -60,136 +60,67 @@ class TestQuarterlyWorkflow(BaseWorkflowTestCase):
 
     # Test first-quarter option conversion
     # 1/1 in first quarter
-    self.assertEqual(rdd(relative_day=1, relative_month=1,
-                         base_date=date(2015, 1, 1)),
-                     date(2015, 1, 1))
-    self.assertEqual(rdd(relative_day=1, relative_month=1,
-                         base_date=date(2015, 2, 1)),
-                     date(2015, 1, 1))
-    self.assertEqual(rdd(relative_day=1, relative_month=1,
-                         base_date=date(2015, 3, 1)),
-                     date(2015, 1, 1))
-    # 1/1 in second quarter
-    self.assertEqual(rdd(relative_day=1, relative_month=1,
-                         base_date=date(2015, 4, 1)),
-                     date(2015, 4, 1))
-    self.assertEqual(rdd(relative_day=1, relative_month=1,
-                         base_date=date(2015, 5, 1)),
-                     date(2015, 4, 1))
-    self.assertEqual(rdd(relative_day=1, relative_month=1,
-                         base_date=date(2015, 6, 1)),
-                     date(2015, 4, 1))
-    # 1/1 in third quarter
-    self.assertEqual(rdd(relative_day=1, relative_month=1,
-                         base_date=date(2015, 7, 1)),
-                     date(2015, 7, 1))
-    self.assertEqual(rdd(relative_day=1, relative_month=1,
-                         base_date=date(2015, 8, 1)),
-                     date(2015, 7, 1))
-    self.assertEqual(rdd(relative_day=1, relative_month=1,
-                         base_date=date(2015, 9, 1)),
-                     date(2015, 7, 1))
-    # 1/1 in fourth quarter
-    self.assertEqual(rdd(relative_day=1, relative_month=1,
-                         base_date=date(2015, 10, 1)),
-                     date(2015, 10, 1))
-    self.assertEqual(rdd(relative_day=1, relative_month=1,
-                         base_date=date(2015, 11, 1)),
-                     date(2015, 10, 1))
-    self.assertEqual(rdd(relative_day=1, relative_month=1,
-                         base_date=date(2015, 12, 1)),
-                     date(2015, 10, 1))
+    test_and_expected_dates = [
+      ((2015, 1, 1), (2015, 1, 1)),
+      ((2015, 2, 1), (2015, 1, 1)),
+      ((2015, 3, 1), (2015, 1, 1)),
+      ((2015, 4, 1), (2015, 4, 1)),
+      ((2015, 5, 1), (2015, 4, 1)),
+      ((2015, 6, 1), (2015, 4, 1)),
+      ((2015, 7, 1), (2015, 7, 1)),
+      ((2015, 8, 1), (2015, 7, 1)),
+      ((2015, 9, 1), (2015, 7, 1)),
+      ((2015, 10, 1), (2015, 10, 1)),
+      ((2015, 11, 1), (2015, 10, 1)),
+      ((2015, 12, 1), (2015, 10, 1))
+    ]
+    for test_date, expected_date in test_and_expected_dates:
+      self.assertEqual(
+        rdd(relative_day=1, relative_month=1, base_date=date(*test_date)),
+        date(*expected_date))
+
     #########################################################################
-    # # 2/1 in first quarter
-    self.assertEqual(rdd(relative_day=1, relative_month=2,
-                         base_date=date(2015, 1, 1)),
-                     date(2014, 11, 1))
-    self.assertEqual(rdd(relative_day=1, relative_month=2,
-                         base_date=date(2015, 2, 1)),
-                     date(2015, 2, 1))
-    self.assertEqual(rdd(relative_day=1, relative_month=2,
-                         base_date=date(2015, 3, 1)),
-                     date(2015, 2, 1))
-    # 2/1 in second quarter
-    self.assertEqual(rdd(relative_day=1, relative_month=2,
-                         base_date=date(2015, 4, 1)),
-                     date(2015, 2, 1))
-    self.assertEqual(rdd(relative_day=1, relative_month=2,
-                         base_date=date(2015, 5, 1)),
-                     date(2015, 5, 1))
-    self.assertEqual(rdd(relative_day=1, relative_month=2,
-                         base_date=date(2015, 6, 1)),
-                     date(2015, 5, 1))
-    # 2/1 in third quarter
-    self.assertEqual(rdd(relative_day=1, relative_month=2,
-                         base_date=date(2015, 7, 1)),
-                     date(2015, 5, 1))
-    self.assertEqual(rdd(relative_day=1, relative_month=2,
-                         base_date=date(2015, 8, 1)),
-                     date(2015, 8, 1))
-    self.assertEqual(rdd(relative_day=1, relative_month=2,
-                         base_date=date(2015, 9, 1)),
-                     date(2015, 8, 1))
-    # 2/1 in fourth quarter
-    self.assertEqual(rdd(relative_day=1, relative_month=2,
-                         base_date=date(2015, 10, 1)),
-                     date(2015, 8, 1))
-    self.assertEqual(rdd(relative_day=1, relative_month=2,
-                         base_date=date(2015, 11, 1)),
-                     date(2015, 11, 1))
-    self.assertEqual(rdd(relative_day=1, relative_month=2,
-                         base_date=date(2015, 12, 1)),
-                     date(2015, 11, 1))
-    self.assertEqual(rdd(relative_day=1, relative_month=2,
-                         base_date=date(2016, 1, 1)),
-                     date(2015, 11, 1))
+    test_and_expected_dates = [
+      ((2015, 1, 1), (2014, 11, 1)),
+      ((2015, 2, 1), (2015, 2, 1)),
+      ((2015, 3, 1), (2015, 2, 1)),
+      ((2015, 4, 1), (2015, 2, 1)),
+      ((2015, 5, 1), (2015, 5, 1)),
+      ((2015, 6, 1), (2015, 5, 1)),
+      ((2015, 7, 1), (2015, 5, 1)),
+      ((2015, 8, 1), (2015, 8, 1)),
+      ((2015, 9, 1), (2015, 8, 1)),
+      ((2015, 10, 1), (2015, 8, 1)),
+      ((2015, 11, 1), (2015, 11, 1)),
+      ((2015, 12, 1), (2015, 11, 1)),
+      ((2016, 1, 1), (2015, 11, 1))
+    ]
+    for test_date, expected_date in test_and_expected_dates:
+      self.assertEqual(
+        rdd(relative_day=1, relative_month=2, base_date=date(*test_date)),
+        date(*expected_date))
+
     #########################################################################
-    # 3/1 in first quarter
-    self.assertEqual(rdd(relative_day=1, relative_month=3,
-                         base_date=date(2015, 1, 1)),
-                     date(2014, 12, 1))
-    self.assertEqual(rdd(relative_day=1, relative_month=3,
-                         base_date=date(2015, 2, 1)),
-                     date(2014, 12, 1))
-    self.assertEqual(rdd(relative_day=1, relative_month=3,
-                         base_date=date(2015, 3, 1)),
-                     date(2015, 3, 1))
-    # 3/1 in second quarter
-    self.assertEqual(rdd(relative_day=1, relative_month=3,
-                         base_date=date(2015, 4, 1)),
-                     date(2015, 3, 1))
-    self.assertEqual(rdd(relative_day=1, relative_month=3,
-                         base_date=date(2015, 5, 1)),
-                     date(2015, 3, 1))
-    self.assertEqual(rdd(relative_day=1, relative_month=3,
-                         base_date=date(2015, 6, 1)),
-                     date(2015, 6, 1))
-    # 3/1 in third quarter
-    self.assertEqual(rdd(relative_day=1, relative_month=3,
-                         base_date=date(2015, 7, 1)),
-                     date(2015, 6, 1))
-    self.assertEqual(rdd(relative_day=1, relative_month=3,
-                         base_date=date(2015, 8, 1)),
-                     date(2015, 6, 1))
-    self.assertEqual(rdd(relative_day=1, relative_month=3,
-                         base_date=date(2015, 9, 1)),
-                     date(2015, 9, 1))
-    # 3/1 in fourht quarter
-    self.assertEqual(rdd(relative_day=1, relative_month=3,
-                         base_date=date(2015, 10, 1)),
-                     date(2015, 9, 1))
-    self.assertEqual(rdd(relative_day=1, relative_month=3,
-                         base_date=date(2015, 11, 1)),
-                     date(2015, 9, 1))
-    self.assertEqual(rdd(relative_day=1, relative_month=3,
-                         base_date=date(2015, 12, 1)),
-                     date(2015, 12, 1))
-    self.assertEqual(rdd(relative_day=1, relative_month=3,
-                         base_date=date(2016, 1, 1)),
-                     date(2015, 12, 1))
-    self.assertEqual(rdd(relative_day=1, relative_month=3,
-                         base_date=date(2016, 2, 1)),
-                     date(2015, 12, 1))
+    test_and_expected_dates = [
+      ((2015, 1, 1), (2014, 12, 1)),
+      ((2015, 2, 1), (2014, 12, 1)),
+      ((2015, 3, 1), (2015, 3, 1)),
+      ((2015, 4, 1), (2015, 3, 1)),
+      ((2015, 5, 1), (2015, 3, 1)),
+      ((2015, 6, 1), (2015, 6, 1)),
+      ((2015, 7, 1), (2015, 6, 1)),
+      ((2015, 8, 1), (2015, 6, 1)),
+      ((2015, 9, 1), (2015, 9, 1)),
+      ((2015, 10, 1), (2015, 9, 1)),
+      ((2015, 11, 1), (2015, 9, 1)),
+      ((2015, 12, 1), (2015, 12, 1)),
+      ((2016, 1, 1), (2015, 12, 1)),
+      ((2016, 2, 1), (2015, 12, 1))
+    ]
+    for test_date, expected_date in test_and_expected_dates:
+      self.assertEqual(
+        rdd(relative_day=1, relative_month=3, base_date=date(*test_date)),
+        date(*expected_date))
 
   def test_start_wf_1_1(self):
     """Test quarterly WF 1/1 activating through months"""
@@ -207,28 +138,28 @@ class TestQuarterlyWorkflow(BaseWorkflowTestCase):
             "relative_end_day": 1,
             "relative_end_month": 1,
           }],
-        "task_group_objects": self.random_objects
+        "task_group_objects": []
       },
       ]
     }
-    base_dates = [date(2014, 12, 1),
-                  date(2015, 1, 1), date(2015, 2, 1), date(2015, 3, 1),
-                  date(2015, 4, 1), date(2015, 5, 1), date(2015, 6, 1),
-                  date(2015, 7, 1), date(2015, 8, 1), date(2015, 9, 1),
-                  date(2015, 10, 1), date(2015, 11, 1), date(2015, 12, 1)]
-    expected_dates = [date(2015, 1, 1),
-                      date(2015, 4, 1), date(2015, 4, 1), date(2015, 4, 1),
-                      date(2015, 7, 1), date(2015, 7, 1), date(2015, 7, 1),
-                      date(2015, 10, 1), date(2015, 10, 1), date(2015, 10, 1),
-                      date(2016, 1, 1), date(2016, 1, 1), date(2016, 1, 1)]
+    base_dates = [(2014, 12, 1),
+                  (2015, 1, 1), (2015, 2, 1), (2015, 3, 1),
+                  (2015, 4, 1), (2015, 5, 1), (2015, 6, 1),
+                  (2015, 7, 1), (2015, 8, 1), (2015, 9, 1),
+                  (2015, 10, 1), (2015, 11, 1), (2015, 12, 1)]
+    expected_dates = [(2015, 1, 1),
+                      (2015, 4, 1), (2015, 4, 1), (2015, 4, 1),
+                      (2015, 7, 1), (2015, 7, 1), (2015, 7, 1),
+                      (2015, 10, 1), (2015, 10, 1), (2015, 10, 1),
+                      (2016, 1, 1), (2016, 1, 1), (2016, 1, 1)]
 
     for i, bd in enumerate(base_dates):
-      with freeze_time("{} 13:00".format(bd)):
+      with freeze_time("{} 13:00".format(date(*bd))):
         _, wf = self.generator.generate_workflow(quarterly_wf)
         _, awf = self.generator.activate_workflow(wf)
         active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
         self.assertEqual(active_wf.non_adjusted_next_cycle_start_date,
-                         expected_dates[i])
+                         date(*expected_dates[i]))
 
   def test_start_wf_2_1(self):
     """Test quarterly WF 2/1 activating through months"""
@@ -246,28 +177,28 @@ class TestQuarterlyWorkflow(BaseWorkflowTestCase):
             "relative_end_day": 1,
             "relative_end_month": 2,
           }],
-        "task_group_objects": self.random_objects
+        "task_group_objects": []
       },
       ]
     }
-    base_dates = [date(2014, 12, 1),
-                  date(2015, 1, 1), date(2015, 2, 1), date(2015, 3, 1),
-                  date(2015, 4, 1), date(2015, 5, 1), date(2015, 6, 1),
-                  date(2015, 7, 1), date(2015, 8, 1), date(2015, 9, 1),
-                  date(2015, 10, 1), date(2015, 11, 1), date(2015, 12, 1)]
-    expected_dates = [date(2015, 2, 1),
-                      date(2015, 2, 1), date(2015, 5, 1), date(2015, 5, 1),
-                      date(2015, 5, 1), date(2015, 8, 1), date(2015, 8, 1),
-                      date(2015, 8, 1), date(2015, 11, 1), date(2015, 11, 1),
-                      date(2015, 11, 1), date(2016, 2, 1), date(2016, 2, 1)]
+    base_dates = [(2014, 12, 1),
+                  (2015, 1, 1), (2015, 2, 1), (2015, 3, 1),
+                  (2015, 4, 1), (2015, 5, 1), (2015, 6, 1),
+                  (2015, 7, 1), (2015, 8, 1), (2015, 9, 1),
+                  (2015, 10, 1), (2015, 11, 1), (2015, 12, 1)]
+    expected_dates = [(2015, 2, 1),
+                      (2015, 2, 1), (2015, 5, 1), (2015, 5, 1),
+                      (2015, 5, 1), (2015, 8, 1), (2015, 8, 1),
+                      (2015, 8, 1), (2015, 11, 1), (2015, 11, 1),
+                      (2015, 11, 1), (2016, 2, 1), (2016, 2, 1)]
 
     for i, bd in enumerate(base_dates):
-      with freeze_time("{} 13:00".format(bd)):
+      with freeze_time("{} 13:00".format(date(*bd))):
         _, wf = self.generator.generate_workflow(quarterly_wf)
         _, awf = self.generator.activate_workflow(wf)
         active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
         self.assertEqual(active_wf.non_adjusted_next_cycle_start_date,
-                         expected_dates[i])
+                         date(*expected_dates[i]))
 
   def test_start_wf_3_1(self):
     """Test quarterly WF 3/1 activating through months"""
@@ -285,29 +216,29 @@ class TestQuarterlyWorkflow(BaseWorkflowTestCase):
             "relative_end_day": 1,
             "relative_end_month": 3,
           }],
-        "task_group_objects": self.random_objects
+        "task_group_objects": []
       },
       ]
     }
-    base_dates = [date(2014, 12, 1),
-                  date(2015, 1, 1), date(2015, 2, 1), date(2015, 3, 1),
-                  date(2015, 4, 1), date(2015, 5, 1), date(2015, 6, 1),
-                  date(2015, 7, 1), date(2015, 8, 1), date(2015, 9, 1),
-                  date(2015, 10, 1), date(2015, 11, 1), date(2015, 12, 1)]
-    expected_dates = [date(2015, 3, 1),
-                      date(2015, 3, 1), date(2015, 3, 1), date(2015, 6, 1),
-                      date(2015, 6, 1), date(2015, 6, 1), date(2015, 9, 1),
-                      date(2015, 9, 1), date(2015, 9, 1), date(2015, 12, 1),
-                      date(2015, 12, 1), date(2015, 12, 1), date(2016, 3, 1)]
+    base_dates = [(2014, 12, 1),
+                  (2015, 1, 1), (2015, 2, 1), (2015, 3, 1),
+                  (2015, 4, 1), (2015, 5, 1), (2015, 6, 1),
+                  (2015, 7, 1), (2015, 8, 1), (2015, 9, 1),
+                  (2015, 10, 1), (2015, 11, 1), (2015, 12, 1)]
+    expected_dates = [(2015, 3, 1),
+                      (2015, 3, 1), (2015, 3, 1), (2015, 6, 1),
+                      (2015, 6, 1), (2015, 6, 1), (2015, 9, 1),
+                      (2015, 9, 1), (2015, 9, 1), (2015, 12, 1),
+                      (2015, 12, 1), (2015, 12, 1), (2016, 3, 1)]
 
 
     for i, bd in enumerate(base_dates):
-      with freeze_time("{} 13:00".format(bd)):
+      with freeze_time("{} 13:00".format(date(*bd))):
         _, wf = self.generator.generate_workflow(quarterly_wf)
         _, awf = self.generator.activate_workflow(wf)
         active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
         self.assertEqual(active_wf.non_adjusted_next_cycle_start_date,
-                         expected_dates[i])
+                         date(*expected_dates[i]))
 
   def test_equal_month_end_day_before_start_day(self):
     """
@@ -1108,77 +1039,27 @@ class TestQuarterlyWorkflow(BaseWorkflowTestCase):
       self.assertEqual(active_wf.status, "Active")
       self.assertEqual(active_wf.next_cycle_start_date, date(2015, 7, 31))
 
-      _, cycle = self.generator.generate_cycle(wf)
-      self.assertEqual(cycle.start_date, date(2015, 7, 31))
-      self.assertEqual(cycle.end_date, date(2015, 9, 4))
-      active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
-      self.assertEqual(active_wf.next_cycle_start_date, date(2015, 10, 30))
-
-      _, cycle = self.generator.generate_cycle(wf)
-      self.assertEqual(cycle.start_date, date(2015, 10, 30))
-      self.assertEqual(cycle.end_date, date(2015, 12, 4))
-      active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
-      self.assertEqual(active_wf.next_cycle_start_date, date(2016, 2, 1))
-
-      _, cycle = self.generator.generate_cycle(wf)
-      self.assertEqual(cycle.start_date, date(2016, 2, 1))
-      self.assertEqual(cycle.end_date, date(2016, 3, 4))
-      active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
-      self.assertEqual(active_wf.next_cycle_start_date, date(2016, 4, 29))
-
-      _, cycle = self.generator.generate_cycle(wf)
-      self.assertEqual(cycle.start_date, date(2016, 4, 29))
-      self.assertEqual(cycle.end_date, date(2016, 6, 3))
-      active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
-      self.assertEqual(active_wf.next_cycle_start_date, date(2016, 8, 1))
-
-      _, cycle = self.generator.generate_cycle(wf)
-      self.assertEqual(cycle.start_date, date(2016, 8, 1))
-      self.assertEqual(cycle.end_date, date(2016, 9, 2))
-      active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
-      self.assertEqual(active_wf.next_cycle_start_date, date(2016, 11, 1))
-
-      _, cycle = self.generator.generate_cycle(wf)
-      self.assertEqual(cycle.start_date, date(2016, 11, 1))
-      self.assertEqual(cycle.end_date, date(2016, 12, 5))
-      active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
-      self.assertEqual(active_wf.next_cycle_start_date, date(2017, 2, 1))
-
-      _, cycle = self.generator.generate_cycle(wf)
-      self.assertEqual(cycle.start_date, date(2017, 2, 1))
-      self.assertEqual(cycle.end_date, date(2017, 3, 3))
-      active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
-      self.assertEqual(active_wf.next_cycle_start_date, date(2017, 5, 1))
-
-      _, cycle = self.generator.generate_cycle(wf)
-      self.assertEqual(cycle.start_date, date(2017, 5, 1))
-      self.assertEqual(cycle.end_date, date(2017, 6, 5))
-      active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
-      self.assertEqual(active_wf.next_cycle_start_date, date(2017, 8, 1))
-
-      _, cycle = self.generator.generate_cycle(wf)
-      self.assertEqual(cycle.start_date, date(2017, 8, 1))
-      self.assertEqual(cycle.end_date, date(2017, 9, 5))
-      active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
-      self.assertEqual(active_wf.next_cycle_start_date, date(2017, 11, 1))
-
-      _, cycle = self.generator.generate_cycle(wf)
-      self.assertEqual(cycle.start_date, date(2017, 11, 1))
-      self.assertEqual(cycle.end_date, date(2017, 12, 5))
-      active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
-      self.assertEqual(active_wf.next_cycle_start_date, date(2018, 2, 1))
-
-      _, cycle = self.generator.generate_cycle(wf)
-      self.assertEqual(cycle.start_date, date(2018, 2, 1))
-      self.assertEqual(cycle.end_date, date(2018, 3, 5))
-      active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
-      self.assertEqual(active_wf.next_cycle_start_date, date(2018, 5, 1))
-
-      _, cycle = self.generator.generate_cycle(wf)
-      self.assertEqual(cycle.start_date, date(2018, 5, 1))
-      self.assertEqual(cycle.end_date, date(2018, 6, 5))
-      active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
-      self.assertEqual(active_wf.next_cycle_start_date, date(2018, 8, 1))
+      dates = [
+        ((2015, 7, 31), (2015, 9, 4), (2015, 10, 30)),
+        ((2015, 10, 30), (2015, 12, 4), (2016, 2, 1)),
+        ((2016, 2, 1), (2016, 3, 4), (2016, 4, 29)),
+        ((2016, 4, 29), (2016, 6, 3), (2016, 8, 1)),
+        ((2016, 8, 1), (2016, 9, 2), (2016, 11, 1)),
+        ((2016, 11, 1), (2016, 12, 5), (2017, 2, 1)),
+        ((2017, 2, 1), (2017, 3, 3), (2017, 5, 1)),
+        ((2017, 5, 1), (2017, 6, 5), (2017, 8, 1)),
+        ((2017, 8, 1), (2017, 9, 5), (2017, 11, 1)),
+        ((2017, 11, 1), (2017, 12, 5), (2018, 2, 1)),
+        ((2018, 2, 1), (2018, 3, 5), (2018, 5, 1)),
+        ((2018, 5, 1), (2018, 6, 5), (2018, 8, 1)),
+      ]
+      for csd, ced, ncsd in dates:
+        _, cycle = self.generator.generate_cycle(wf)
+        self.assertEqual(cycle.start_date, date(*csd))
+        self.assertEqual(cycle.end_date, date(*ced))
+        active_wf = db.session.query(Workflow).filter(
+          Workflow.id == wf.id).one()
+        self.assertEqual(active_wf.next_cycle_start_date, date(*ncsd))
 
   def test_multiple_task_groups_multiple_tasks_multiple_quarters_in_middle(self):
     """Test behaviour of multiple task groups with multiple tasks spread across multiple quarters
@@ -1248,29 +1129,19 @@ class TestQuarterlyWorkflow(BaseWorkflowTestCase):
       self.assertEqual(cycle.start_date, date(2015, 5, 1))
       self.assertEqual(cycle.end_date, date(2015, 6, 5))
 
-      _, cycle = self.generator.generate_cycle(wf)
-      self.assertEqual(cycle.start_date, date(2015, 7, 31))
-      self.assertEqual(cycle.end_date, date(2015, 9, 4))
-      active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
-      self.assertEqual(active_wf.next_cycle_start_date, date(2015, 10, 30))
-
-      _, cycle = self.generator.generate_cycle(wf)
-      self.assertEqual(cycle.start_date, date(2015, 10, 30))
-      self.assertEqual(cycle.end_date, date(2015, 12, 4))
-      active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
-      self.assertEqual(active_wf.next_cycle_start_date, date(2016, 2, 1))
-
-      _, cycle = self.generator.generate_cycle(wf)
-      self.assertEqual(cycle.start_date, date(2016, 2, 1))
-      self.assertEqual(cycle.end_date, date(2016, 3, 4))
-      active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
-      self.assertEqual(active_wf.next_cycle_start_date, date(2016, 4, 29))
-
-      _, cycle = self.generator.generate_cycle(wf)
-      self.assertEqual(cycle.start_date, date(2016, 4, 29))
-      self.assertEqual(cycle.end_date, date(2016, 6, 3))
-      active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
-      self.assertEqual(active_wf.next_cycle_start_date, date(2016, 8, 1))
+      dates = [
+        ((2015, 7, 31), (2015, 9, 4), (2015, 10, 30)),
+        ((2015, 10, 30), (2015, 12, 4), (2016, 2, 1)),
+        ((2016, 2, 1), (2016, 3, 4), (2016, 4, 29)),
+        ((2016, 4, 29), (2016, 6, 3), (2016, 8, 1)),
+      ]
+      for csd, ced, ncsd in dates:
+        _, cycle = self.generator.generate_cycle(wf)
+        self.assertEqual(cycle.start_date, date(*csd))
+        self.assertEqual(cycle.end_date, date(*ced))
+        active_wf = db.session.query(Workflow).filter(
+          Workflow.id == wf.id).one()
+        self.assertEqual(active_wf.next_cycle_start_date, date(*ncsd))
 
   def test_multiple_task_groups_multiple_tasks_multiple_quarters_last_quarter_middle(self):
     """Test behaviour of multiple task groups with multiple tasks spread across multiple quarters
@@ -1498,26 +1369,17 @@ class TestQuarterlyWorkflow(BaseWorkflowTestCase):
       self.assertEqual(cycle.start_date, date(2015, 5, 1))
       self.assertEqual(cycle.end_date, date(2015, 6, 5))
 
-      _, cycle = self.generator.generate_cycle(wf)
-      self.assertEqual(cycle.start_date, date(2015, 7, 31))
-      self.assertEqual(cycle.end_date, date(2015, 9, 4))
-      active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
-      self.assertEqual(active_wf.next_cycle_start_date, date(2015, 10, 30))
+      dates = [
+        ((2015, 7, 31), (2015, 9, 4), (2015, 10, 30)),
+        ((2015, 10, 30), (2015, 12, 4), (2016, 2, 1)),
+        ((2016, 2, 1), (2016, 3, 4), (2016, 4, 29)),
+        ((2016, 4, 29), (2016, 6, 3), (2016, 8, 1))
+      ]
 
-      _, cycle = self.generator.generate_cycle(wf)
-      self.assertEqual(cycle.start_date, date(2015, 10, 30))
-      self.assertEqual(cycle.end_date, date(2015, 12, 4))
-      active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
-      self.assertEqual(active_wf.next_cycle_start_date, date(2016, 2, 1))
-
-      _, cycle = self.generator.generate_cycle(wf)
-      self.assertEqual(cycle.start_date, date(2016, 2, 1))
-      self.assertEqual(cycle.end_date, date(2016, 3, 4))
-      active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
-      self.assertEqual(active_wf.next_cycle_start_date, date(2016, 4, 29))
-
-      _, cycle = self.generator.generate_cycle(wf)
-      self.assertEqual(cycle.start_date, date(2016, 4, 29))
-      self.assertEqual(cycle.end_date, date(2016, 6, 3))
-      active_wf = db.session.query(Workflow).filter(Workflow.id == wf.id).one()
-      self.assertEqual(active_wf.next_cycle_start_date, date(2016, 8, 1))
+      for csd, ced, ncsd in dates:
+        _, cycle = self.generator.generate_cycle(wf)
+        self.assertEqual(cycle.start_date, date(*csd))
+        self.assertEqual(cycle.end_date, date(*ced))
+        active_wf = db.session.query(Workflow).filter(
+          Workflow.id == wf.id).one()
+        self.assertEqual(active_wf.next_cycle_start_date, date(*ncsd))


### PR DESCRIPTION
Quarterly bug - in certain cases (multiple tasks spanning
multiple quarters) certain tasks' reified values could be before
actual first task, resulting in wrong reified dates.

Workflow test suite - due to at this time unknown underlying
issue test cases could lose sessions information - this fixes it
by reinitializing login if 302 redirect is returned.

Rewrite quarterly relative day to date calculator to use 
transformation matrix to convert from base date to a reified 
value in current quarter.
