### PR TITLE
ZGOOG-41 Integrate workflows and risks

### DIFF
--- a/src/ggrc_workflows/assets/javascripts/apps/workflows.js
+++ b/src/ggrc_workflows/assets/javascripts/apps/workflows.js
@@ -11,7 +11,8 @@
         'Program Regulation Policy Standard Contract Clause Section'.split(' '),
         'Control Objective'.split(' '),
         'OrgGroup Vendor'.split(' '),
-        'System Process DataAsset Product Project Facility Market Issue'.split(' ')
+        'System Process DataAsset Product Project Facility Market Issue'.split(' '),
+        'Risk ThreatActor'.split(' ')
       ),
       _task_sort_function = function(a, b) {
         var date_a = +new Date(a.end_date),
@@ -248,7 +249,11 @@
 
     // Insert `workflows` mappings to all business object types
     can.each(_workflow_object_types, function (type) {
-      CMS.Models[type].attributes.cycle_objects = 'CMS.Models.CycleTaskGroupObject.stubs';
+      var model = CMS.Models[type];
+      if (model === undefined || model === null) {
+        return;
+      }
+      model.attributes.cycle_objects = 'CMS.Models.CycleTaskGroupObject.stubs';
       mappings[type] = {
         task_groups: new GGRC.ListLoaders.ProxyListLoader('TaskGroupObject', 'object', 'task_group', 'task_group_objects', null),
         cycle_objects: Direct('CycleTaskGroupObject', 'object', 'cycle_task_group_objects'),
@@ -606,7 +611,11 @@
     }
   });
   can.each(_workflow_object_types, function(model_name) {
-    draft_on_update_mixin.add_to(CMS.Models[model_name]);
+    var model = CMS.Models[model_name];
+    if (model === undefined || model === null) {
+      return;
+    }
+    draft_on_update_mixin.add_to(model);
   });
 
 })(this.can.$, this.CMS, this.GGRC);

--- a/src/ggrc_workflows/models/__init__.py
+++ b/src/ggrc_workflows/models/__init__.py
@@ -5,8 +5,8 @@
 
 
 from ggrc.models.all_models import register_model
+from ggrc.models import all_models
 
-from .mixins import RelativeTimeboxed
 from .task_group_task import TaskGroupTask
 from .task_group import TaskGroup
 from .task_group_object import TaskGroupObject
@@ -36,5 +36,10 @@ WORKFLOW_OBJECT_TYPES = {
     "Regulation", "Standard", "Policy", "Contract",
     "Objective", "Control", "Section", "Clause",
     "System", "Process",
-    "DataAsset", "Facility", "Market", "Product", "Project", "Issue"
+    "DataAsset", "Facility", "Market", "Product", "Project", "Issue",
+    "Risk", "RiskObject", "ThreatActor",
 }
+
+WORKFLOW_OBJECT_TYPES = set(t for t in WORKFLOW_OBJECT_TYPES if
+                            hasattr(all_models, t))
+


### PR DESCRIPTION
Another PR for ZGOOG-41

Sorry, this is ungly - workflows extension needs to be aware of the risks
extension because imports mutate state of the rest of the application. This can
go away when we have proper stateless extension imports.

**note** this depends on #3111 which fixes the mapping ui
**another note** this still does not complete ZGOOG-41 - still bugs left