### PR TITLE
QUICK-FIX Add error reporting to export relevant filter

### DIFF
--- a/src/ggrc/converters/query_helper.py
+++ b/src/ggrc/converters/query_helper.py
@@ -113,7 +113,14 @@ class QueryHelper(object):
       ids = expression.get("ids", [])
       ids.extend(self.slugs_to_ids(expression["object_name"], slugs))
       expression["ids"] = ids
-    expression["ids"] = map(int, expression.get("ids", []))
+    try:
+      expression["ids"] = map(int, expression.get("ids", []))
+    except ValueError as e:
+      # catch missing relevant filter (undefined id)
+      if expression.get("op", {}).get("name", "") == "relevant":
+        raise BadQueryException("Invalid relevant filter for {}".format(
+                                expression.get("object_name", "")))
+      raise e
     self.clean_filters(expression.get("left"))
     self.clean_filters(expression.get("right"))
 


### PR DESCRIPTION
In case of empty "Relevant-to" filter report this as an error instead of just saying server error.

For better UX we would have to handle this on the frontend but there are several possibilities and none is as straightforward as this one. So I propose we do a user-friendlier fix for the next release, this server-side check will not hurt anyway.