### PR TITLE
QUICK-FIX Fix Autocomplete dropdowns

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,8 +9,8 @@
   "dependencies": {
     "canjs": "2.0.7",
     "bootstrap": "2.0.4",
-    "jquery-ui": "1.11.0",
-    "jquery": "1.11.0",
+    "jquery-ui": "1.11.4",
+    "jquery": "1.11.3",
     "lodash": "3.10.0",
     "mousetrap": "1.5.3",
     "moment": "2.10.3",

--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -366,7 +366,7 @@ dashboard-js-spec-helpers:
 mockup-js-files:
   # 3rd party
   - jquery/dist/jquery.js
-  - jquery-ui/jquery-ui.js
+  - jquery-ui/jquery-ui.min.js
   - bootstrap/js/bootstrap-modal.js
   - bootstrap/js/bootstrap-collapse.js
   - bootstrap/js/bootstrap-dropdown.js

--- a/src/ggrc/assets/stylesheets/_modal.scss
+++ b/src/ggrc/assets/stylesheets/_modal.scss
@@ -1023,7 +1023,7 @@ p.modal-value {
   overflow: visible;
   top: 28px;
   left: 24px;
-  z-index: 100;
+  z-index: 2000; /* Needs to be greater than modals */
   &.in {
     border: 1px solid $tabTitle;
     overflow: visible;


### PR DESCRIPTION
It turns out that our app is using jquery 1.11 and jquery ui 1.10. When I naively updated jquery ui to 1.11 it broke autocomplete. This now reverts jqeury ui back to 1.10, but we need to make a proper fix for this.