### PR TITLE
QUICK-FIX Remove an invalid jQuery expression

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
@@ -221,7 +221,7 @@ can.Control("CMS.Controllers.Dashboard", {
     }
 
   , get_active_widget_elements: function() {
-      return this.element.find("section.widget[id]:not([id=])").toArray();
+      return this.element.find("section.widget[id]:not([id=''])").toArray();
     }
 
   , add_widget_from_descriptor: function() {


### PR DESCRIPTION
I am not sure why the :not(id=) part was added back in 2013, but it
causes a script error on export page in jQuery 1.11.3 (but not in
1.11.0).