### PR TITLE
CORE-2360 Make assignee mandatory when importing a request

### DIFF
--- a/src/ggrc/converters/handlers.py
+++ b/src/ggrc/converters/handlers.py
@@ -183,8 +183,11 @@ class UserColumnHandler(ColumnHandler):
   def parse_item(self):
     email = self.raw_value.lower()
     person = self.get_person(email)
-    if not person and email != "":
-      self.add_warning(errors.UNKNOWN_USER_WARNING, email=email)
+    if not person:
+      if email != "":
+        self.add_warning(errors.UNKNOWN_USER_WARNING, email=email)
+      elif self.mandatory:
+        self.add_error(errors.MISSING_VALUE_ERROR, column_name=self.key)
     return person
 
   def get_value(self):

--- a/src/ggrc/models/request.py
+++ b/src/ggrc/models/request.py
@@ -68,6 +68,7 @@ class Request(Titled, Slugged, Described, Base, db.Model):
   _aliases = {
     "assignee": {
       "display_name": "Assignee",
+      "mandatory": True,
       "filter_by": "_filter_by_assignee",
     },
     "audit_object": {


### PR DESCRIPTION
Since it is mandatory in the DB import will silently fail otherwise. Also add
reporting for this in the dry run.