### PR TITLE
CORE-2358 Make sure Auditor role propagates permissions

### DIFF
--- a/src/ggrc_basic_permissions/__init__.py
+++ b/src/ggrc_basic_permissions/__init__.py
@@ -100,9 +100,10 @@ def objects_via_relationships_query(user_id, context_not_role=False):
       literal(None).label('context_id') if context_not_role else _role.name))
 
   # We also need to return relationships themselves:
-  relationships = _add_relationship_join(db.session.query(_relationship.id, literal("Relationship"), _relationship.context_id))
+  query = db.session.query(_relationship.id, literal("Relationship"),
+                           _relationship.context_id)
+  relationships = _add_relationship_join(query)
   return objects.union(relationships)
-
 
 
 class CompletePermissionsProvider(object):

--- a/src/ggrc_basic_permissions/__init__.py
+++ b/src/ggrc_basic_permissions/__init__.py
@@ -67,6 +67,7 @@ def objects_via_relationships_query(user_id, context_not_role=False):
   _program = aliased(all_models.Program, name="p")
   _relationship = aliased(all_models.Relationship, name="rl")
   _user_role = aliased(all_models.UserRole, name="ur")
+  _context_implications = aliased(all_models.ContextImplication, name="ci")
 
   def _add_relationship_join(query):
     return query.join(_program, or_(
@@ -74,10 +75,18 @@ def objects_via_relationships_query(user_id, context_not_role=False):
              _program.id == _relationship.source_id),
         and_(_relationship.destination_type == 'Program',
              _program.id == _relationship.destination_id))).\
-        join(_user_role, _program.context_id == _user_role.context_id).\
+        outerjoin(_context_implications, and_(
+            _context_implications.source_context_id == _program.context_id,
+            _context_implications.source_context_scope == 'Program',
+            _context_implications.context_scope == 'Audit',
+        )).\
+        join(_user_role, _user_role.context_id.in_([
+            _program.context_id,
+            _context_implications.context_id
+        ])).\
         join(_role, _user_role.role_id == _role.id).\
         filter(and_(_user_role.person_id == user_id, _role.name.in_(
-            ('ProgramEditor', 'ProgramOwner', 'ProgramReader'))))
+            ('ProgramEditor', 'ProgramOwner', 'ProgramReader', 'Auditor'))))
 
   objects = _add_relationship_join(db.session.query(
       case([


### PR DESCRIPTION
Auditor role has the audit context id and not the program context id.
Because of this we need to find all the context implications from
Program to Audit and check those contexts in addition to the program
context.