### PR TITLE
QUICK-FIX Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ have the prerequisite software installed. Here are the steps:
 
 * clone the repo
 * cd to the project directory
+* make sure your ansible installation is up-to-date i.e. version 1.9.3 or higher (if it's not in the repositories, you can
+install it via pip)
 * run the following:
 
     ```sh


### PR DESCRIPTION
Since the app cannot be deployed without a recent ansible version which isn't mentioned in the readme or docs, I opened a hotfix branch. Users should now be able to deploy ggrc-core following the Quick Start guide.