### PR TITLE
CORE-2358 Create a reader role when auditor is added

### DIFF
--- a/src/ggrc/assets/javascripts/pbc/workflow_controller.js
+++ b/src/ggrc/assets/javascripts/pbc/workflow_controller.js
@@ -39,6 +39,34 @@ can.Control("GGRC.Controllers.PbcWorkflows", {
     instance.delay_resolving_save_until($.when(audit_dfd, control_dfd));
 
   },
+  "{CMS.Models.UserRole} created": function(model, ev, instance) {
+    if(!(instance instanceof CMS.Models.UserRole)) {
+      return;
+    }
+    if (instance.role_name !== "Auditor") {
+      return;
+    }
+    // Find the program context
+    var dfd = instance.refresh_all("context", "related_object", "program", "context").then(function (program_context) {
+      // Find existing auditor roles for program context
+      return $.when(
+          program_context,
+          CMS.Models.UserRole.findAll({context_id: program_context.id, person_id: instance.person.id}),
+          CMS.Models.Role.findAll({ name : "ProgramReader" }));
+    }).then(function (program_context, auditor_program_roles, reader_roles) {
+      // Check if there are any existing roles for the user and program context
+      if (auditor_program_roles.length) {
+        return;
+      }
+      // If no program role exists for the user, we create a reader role
+      return new CMS.Models.UserRole({
+        person: instance.person,
+        role: reader_roles[0].stub(),
+        context: program_context
+      }).save();
+    });
+    instance.delay_resolving_save_until(dfd);
+  },
   _create_relationship: function(source, destination) {
 
     if (!destination) {

--- a/src/ggrc/models/audit.py
+++ b/src/ggrc/models/audit.py
@@ -11,6 +11,7 @@ from .mixins import (
 from ggrc.models.relationship import Relatable
 from ggrc.models.object_person import Personable
 from ggrc.models.context import HasOwnContext
+from ggrc.models.reflection import AttributeInfo
 from ggrc.models.reflection import PublishOnly
 from ggrc.models.program import Program
 
@@ -70,7 +71,10 @@ class Audit(
         "display_name": "Program",
         "filter_by": "_filter_by_program",
       },
-      "user_role:Auditor": "Auditors",
+      "user_role:Auditor": {
+        "display_name": "Auditors",
+        "type": AttributeInfo.Type.USER_ROLE,
+      },
       "status": "Status",
       "start_date": "Planned Start Date",
       "end_date": "Planned End Date",

--- a/src/tests/ggrc/converters/test_import_special_objects.py
+++ b/src/tests/ggrc/converters/test_import_special_objects.py
@@ -43,7 +43,7 @@ class TestSpecialObjects(TestCase):
     self.assertEquals(2, Program.query.count())
     program = Program.query.filter(Program.slug == "prog-1").first()
     p1_roles = UserRole.query.filter_by(context_id=program.context_id).all()
-    self.assertEquals(4, len(p1_roles))
+    self.assertEquals(5, len(p1_roles))
     owner_ids = [r.person_id for r in p1_roles if r.role_id == 1]
     editor_ids = [r.person_id for r in p1_roles if r.role_id == 2]
     reader_ids = [r.person_id for r in p1_roles if r.role_id == 3]
@@ -55,7 +55,7 @@ class TestSpecialObjects(TestCase):
                      Person.query.filter(Person.id.in_(reader_ids)).all()]
     expected_owners = set(["user1@example.com", "user11@example.com"])
     expected_editors = set(["user11@example.com"])
-    expected_readers = set(["user12@example.com"])
+    expected_readers = set(["user12@example.com", "user2@example.com"])
     self.assertEqual(set(owner_emails), expected_owners)
     self.assertEqual(set(editor_emails), expected_editors)
     self.assertEqual(set(reader_emails), expected_readers)


### PR DESCRIPTION
Instead of expanding our role propagation query with context implications we just add a program reader role when an auditor is created.