### PR TITLE
CORE-2416 Add '<' and '>' to export filters

### DIFF
--- a/src/ggrc/converters/query_helper.py
+++ b/src/ggrc/converters/query_helper.py
@@ -190,7 +190,7 @@ class QueryHelper(object):
     object_class = self.object_map[object_name]
 
     def autocast(o_key, value):
-      if type(o_key) is not str:
+      if type(o_key) not in [str, unicode]:
         return value
       key, _ = self.attr_name_map[object_class].get(o_key, (o_key, None))
       # handle dates
@@ -263,6 +263,8 @@ class QueryHelper(object):
                                  l.ilike("%{}%".format(rhs()))),
           "!~": lambda: not_(with_left(
                              lambda l: l.ilike("%{}%".format(rhs())))),
+          "<": lambda: with_left(lambda l: l < rhs()),
+          ">": lambda: with_left(lambda l: l > rhs()),
           "relevant": relevant,
           "text_search": text_search
       }


### PR DESCRIPTION
Checked for string properties (lexicographic comparison) and date properties.
Relative dates *are broken* - but this is not an expected use case.
Also fixed a bug in `autocast`.

Tree view filters already support '<' and '>' and the search modal only has full text search.