### PR TITLE
CORE-2421 Add automappings for nested controls

### DIFF
--- a/src/ggrc/automapper/rules.py
+++ b/src/ggrc/automapper/rules.py
@@ -156,4 +156,11 @@ rules = RuleSet(count_limit=10000, rule_list=[
         {'Objective'},
         {'Objective', 'Control'},
     ),
+
+    Rule(
+        'mapping nested controls',
+        {'Objective'},
+        {'Control'},
+        {'Control'},
+    ),
 ])

--- a/src/tests/ggrc/automapper/test_automappings.py
+++ b/src/tests/ggrc/automapper/test_automappings.py
@@ -214,3 +214,17 @@ class TestAutomappings(TestCase):
             (regulation, objective2),
         ]
     )
+
+  def test_mapping_nested_controls(self):
+    objective = self.create_object(Objective, {
+        'title': next('Test Objective')
+    })
+    controlP = self.create_object(Control, {'title': next('Test control')})
+    control1 = self.create_object(Control, {'title': next('Test control')})
+    control2 = self.create_object(Control, {'title': next('Test control')})
+    self.assert_mapping_implication(
+        to_create=[(objective, controlP),
+                   (controlP, control1),
+                   (controlP, control2)],
+        implied=[(objective, control1), (objective, control2)]
+    )


### PR DESCRIPTION
Nested objectives are already covered by the `mapping to objective` rule.
This is compatible with the rule sanity checker as it obeys the implicit tree structure and is thus guaranteed to not explode.