### PR TITLE
CORE-2365 Include MySQLdb library on GAE

### DIFF
--- a/src/app.yaml.dist
+++ b/src/app.yaml.dist
@@ -40,6 +40,8 @@ handlers:
     secure: always
 
 libraries:
+  - name: MySQLdb
+    version: "latest"
   - name: jinja2
     version: "2.6"
 


### PR DESCRIPTION
Include MYSQLdb library for GAE. Future `DATABASE_URI` should be:

````
  GGRC_DATABASE_URI: "mysql+mysqldb://root@/<database-name>?unix_socket=/cloudsql/<CLOUD SQL instance>?charset=utf8"
````