### PR TITLE
QUICK-FIX Risk notes

### DIFF
--- a/src/ggrc_risks/models/risk.py
+++ b/src/ggrc_risks/models/risk.py
@@ -21,7 +21,7 @@ from ggrc.models.track_object_state import HasObjectState
 class Risk(HasObjectState, mixins.CustomAttributable, mixins.Stateful,
            Relatable, Documentable, mixins.Described, Ownable,
            mixins.WithContact, mixins.Titled, mixins.Timeboxed,
-           mixins.Slugged, mixins.Base, db.Model):
+           mixins.Slugged, mixins.Noted, mixins.Base, db.Model):
   __tablename__ = 'risks'
 
   VALID_STATES = [


### PR DESCRIPTION
bring back the Noted mixin that was accidentally removed in a refactor