### PR TITLE
CORE-2439 Fix multiple-word object name export of custom attributes

### DIFF
--- a/src/ggrc/models/mixins.py
+++ b/src/ggrc/models/mixins.py
@@ -21,6 +21,7 @@ from ggrc.models.reflection import AttributeInfo
 from ggrc.models.reflection import PublishOnly
 from ggrc.models.computed_property import computed_property
 
+from ggrc.utils import underscore_from_camelcase
 
 """Mixins to add common attributes and relationships. Note, all model classes
 must also inherit from ``db.Model``. For example:
@@ -625,7 +626,8 @@ class CustomAttributable(object):
   @declared_attr
   def custom_attribute_definitions(cls):
     # FIXME definitions should be class scoped, not instance scoped.
-    from ggrc.models.custom_attribute_definition import CustomAttributeDefinition
+    from ggrc.models.custom_attribute_definition import \
+      CustomAttributeDefinition
     definition_type = foreign(CustomAttributeDefinition.definition_type)
     join_function = lambda: or_(
         definition_type == cls.__name__,
@@ -641,9 +643,11 @@ class CustomAttributable(object):
 
   @classmethod
   def get_custom_attribute_definitions(cls):
-    from ggrc.models.custom_attribute_definition import CustomAttributeDefinition
+    from ggrc.models.custom_attribute_definition import \
+      CustomAttributeDefinition
     return CustomAttributeDefinition.query.filter(
-        CustomAttributeDefinition.definition_type == cls.__name__).all()
+        CustomAttributeDefinition.definition_type ==
+        underscore_from_camelcase(cls.__name__)).all()
 
 
 class TestPlanned(object):

--- a/src/ggrc/models/mixins.py
+++ b/src/ggrc/models/mixins.py
@@ -630,7 +630,7 @@ class CustomAttributable(object):
       CustomAttributeDefinition
     definition_type = foreign(CustomAttributeDefinition.definition_type)
     join_function = lambda: or_(
-        definition_type == cls.__name__,
+        definition_type == underscore_from_camelcase(cls.__name__),
         # The bottom statement always evaluates to False, and is here just to
         # satisfy sqlalchemys need for use of foreing keys while defining a
         # relationship.

--- a/src/ggrc/services/custom_attribute_service.py
+++ b/src/ggrc/services/custom_attribute_service.py
@@ -5,6 +5,8 @@
 
 from ggrc import db
 from ggrc.models import CustomAttributeDefinition
+from ggrc.utils import underscore_from_camelcase
+
 
 class CustomAttributeService(object):
 
@@ -12,8 +14,9 @@ class CustomAttributeService(object):
 
   """
   @staticmethod
-  def attribute_definitions_for_type(type):
+  def attribute_definitions_for_type(ttype):
     return db.session.query(CustomAttributeDefinition)\
-      .filter(CustomAttributeDefinition.definition_type == type)\
+      .filter(CustomAttributeDefinition.definition_type ==
+              underscore_from_camelcase(ttype))\
       .order_by(CustomAttributeDefinition.title)\
       .all()

--- a/src/tests/ggrc/converters/test_csvs/multi_word_object_custom_attribute_test.csv
+++ b/src/tests/ggrc/converters/test_csvs/multi_word_object_custom_attribute_test.csv
@@ -1,0 +1,21 @@
+Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
+Other values are:
+Final
+Effective
+Ineffective
+Launched
+Not Launched
+In Scope
+Not in Scope
+Deprecated",,,,,,MM/DD/YYYY,MM/DD/YYYY,
+Access Group,code*,title*,description,owner,state,notes,primary contact,secondary contact,access group url,reference url,effective date,stop date,access group test custom
+,ag-1,ag-1,test,user1@ggrc.com,Draft,this is a note,user1@ggrc.com,someone.else@ggrc.com,google.com,ggrc.com,7/1/2015,7/15/2015,some text 1
+,ag-2,ag-2,test,user1@ggrc.com,Final,this is a note,user1@ggrc.com,someone.else@ggrc.com,google.com,ggrc.com,7/1/2015,7/15/2015,some text 2
+,ag-3,ag-3,test,user1@ggrc.com,Effective,this is a note,user1@ggrc.com,someone.else@ggrc.com,google.com,ggrc.com,7/1/2015,7/15/2015,some text 3
+,ag-4,ag-4,test,user1@ggrc.com,Ineffective,this is a note,user1@ggrc.com,someone.else@ggrc.com,google.com,ggrc.com,7/1/2015,7/15/2015,some text 4
+,ag-5,ag-5,test,user1@ggrc.com,Launched,this is a note,user1@ggrc.com,someone.else@ggrc.com,google.com,ggrc.com,7/1/2015,7/15/2015,some text 5
+,ag-6,ag-6,test,user1@ggrc.com,Not Launched,this is a note,user1@ggrc.com,someone.else@ggrc.com,google.com,ggrc.com,7/1/2015,7/15/2015,some text 6
+,ag-7,ag-7,test,user1@ggrc.com,In Scope,this is a note,user1@ggrc.com,someone.else@ggrc.com,google.com,ggrc.com,7/1/2015,7/15/2015,some text 7
+,ag-8,ag-8,test,user1@ggrc.com,Not in Scope,this is a note,user1@ggrc.com,someone.else@ggrc.com,google.com,ggrc.com,7/1/2015,7/15/2015,some text 8
+,ag-9,ag-9,test,user1@ggrc.com,Deprecated,this is a note,user1@ggrc.com,someone.else@ggrc.com,google.com,ggrc.com,7/1/2015,7/15/2015,some text 9
+,ag-10,ag-10,test,user1@ggrc.com,Draft,this is a note,user1@ggrc.com,someone.else@ggrc.com,google.com,ggrc.com,7/1/2015,7/15/2015,some text 10


### PR DESCRIPTION
Fix multiple-word object name export of custom attributes by
converting object name from camel case to snake case on custom
attribute search