### PR TITLE
QUICKFIX filters for section (failing build)

### DIFF
--- a/src/ggrc/models/section.py
+++ b/src/ggrc/models/section.py
@@ -3,22 +3,26 @@
 # Created By: dan@reciprocitylabs.com
 # Maintained By: vraj@reciprocitylabs.com
 
-from sqlalchemy.orm import validates
-
 from ggrc import db
-from ggrc.models.exceptions import ValidationError
-from ggrc.models.mixins import (
-    deferred, Hierarchical, Noted, Described, Hyperlinked, WithContact,
-    Titled, Slugged, CustomAttributable, Stateful, Timeboxed
-)
 from ggrc.models.directive import Directive
+from ggrc.models.mixins import CustomAttributable
+from ggrc.models.mixins import Described
+from ggrc.models.mixins import Hierarchical
+from ggrc.models.mixins import Hyperlinked
+from ggrc.models.mixins import Noted
+from ggrc.models.mixins import Slugged
+from ggrc.models.mixins import Stateful
+from ggrc.models.mixins import Titled
+from ggrc.models.mixins import WithContact
+from ggrc.models.mixins import deferred
 from ggrc.models.object_document import Documentable
 from ggrc.models.object_owner import Ownable
 from ggrc.models.object_person import Personable
-from ggrc.models.relationship import Relatable
 from ggrc.models.reflection import AttributeInfo
-from ggrc.models.track_object_state import track_state_for_class
+from ggrc.models.relationship import Relatable
+from ggrc.models.relationship import Relationship
 from ggrc.models.track_object_state import HasObjectState
+from ggrc.models.track_object_state import track_state_for_class
 
 
 class Section(HasObjectState, Hierarchical, Noted, Described, Hyperlinked,
@@ -40,14 +44,14 @@ class Section(HasObjectState, Hierarchical, Noted, Described, Hyperlinked,
   _table_plural = 'sections'
   _title_uniqueness = False
   _aliases = {
-    "url": "Section URL",
-    "description": "Text of Section",
-    "directive": {
-      "display_name": "Policy / Regulation / Standard / Contract",
-      "type": AttributeInfo.Type.MAPPING
-    }
+      "url": "Section URL",
+      "description": "Text of Section",
+      "directive": {
+          "display_name": "Policy / Regulation / Standard / Contract",
+          "type": AttributeInfo.Type.MAPPING,
+          "filter_by": "_filter_by_directive",
+      }
   }
-
 
   na = deferred(db.Column(db.Boolean, default=False, nullable=False),
                 'Section')
@@ -59,5 +63,27 @@ class Section(HasObjectState, Hierarchical, Noted, Described, Hyperlinked,
   ]
   _sanitize_html = ['notes']
   _include_links = []
+
+  @classmethod
+  def _filter_by_directive(cls, predicate):
+    types = ["Policy", "Regulation", "Standard", "Contract"]
+    dst = Relationship.query \
+        .filter(
+            (Relationship.source_id == cls.id) &
+            (Relationship.source_type == cls.__name__) &
+            (Relationship.destination_type.in_(types))) \
+        .join(Directive, Directive.id == Relationship.destination_id) \
+        .filter(predicate(Directive.slug) | predicate(Directive.title)) \
+        .exists()
+    src = Relationship.query \
+        .filter(
+            (Relationship.destination_id == cls.id) &
+            (Relationship.destination_type == cls.__name__) &
+            (Relationship.source_type.in_(types))) \
+        .join(Directive, Directive.id == Relationship.source_id) \
+        .filter(predicate(Directive.slug) | predicate(Directive.title)) \
+        .exists()
+    return dst | src
+
 
 track_state_for_class(Section)


### PR DESCRIPTION
Implement filter by directive using a join on the relationships table as this is
now just a convenience import field.

(I also cleaned-up imports and indentation to make the file PEP8 clean)

A short explanation is in order:
I enabled the export filters test on a pull request and everything worked (tests passed) but before it was merged the Section object changed in develop leading to failures post-merge. This implements the missing filter to make everything green again.