### PR TITLE
CORE-2473 response documents

### DIFF
--- a/src/ggrc/models/response.py
+++ b/src/ggrc/models/response.py
@@ -14,7 +14,7 @@ from ggrc.models.relationship import Relatable
 from ggrc.models.request import Request
 
 
-class Response(Noted, Described, Documentable, Hyperlinked, WithContact,
+class Response(Noted, Described, Hyperlinked, WithContact,
                Titled, Slugged, db.Model):
   __tablename__ = 'responses'
   __mapper_args__ = {
@@ -123,7 +123,7 @@ class Response(Noted, Described, Documentable, Hyperlinked, WithContact,
         orm.joinedload('request'))
 
 
-class DocumentationResponse(Relatable, Personable, Response):
+class DocumentationResponse(Relatable, Personable, Documentable, Response):
 
   __mapper_args__ = {
       'polymorphic_identity': 'documentation'
@@ -134,7 +134,7 @@ class DocumentationResponse(Relatable, Personable, Response):
   _sanitize_html = []
 
 
-class InterviewResponse(Relatable, Personable, Response):
+class InterviewResponse(Relatable, Personable, Documentable, Response):
 
   __mapper_args__ = {
       'polymorphic_identity': 'interview'
@@ -160,7 +160,7 @@ class InterviewResponse(Relatable, Personable, Response):
         orm.subqueryload('meetings'))
 
 
-class PopulationSampleResponse(Relatable, Personable, Response):
+class PopulationSampleResponse(Relatable, Personable, Documentable, Response):
 
   __mapper_args__ = {
       'polymorphic_identity': 'population sample'


### PR DESCRIPTION
Mixin init logic fired at the wrong time after abstracting the mixin into
the common parent. Fixed by manually inlining.