### PR TITLE
QUICK-FIX add relationship attributes

### DIFF
--- a/src/ggrc/migrations/versions/20151016102822_45693b1959f7_add_relationship_attrs.py
+++ b/src/ggrc/migrations/versions/20151016102822_45693b1959f7_add_relationship_attrs.py
@@ -1,0 +1,31 @@
+
+"""add relationship attrs
+
+Revision ID: 45693b1959f7
+Revises: 1ef8f4f504ae
+Create Date: 2015-10-16 10:28:22.241136
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '45693b1959f7'
+down_revision = '3c8f204ba7a9'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+  op.create_table(
+      'relationship_attrs',
+      sa.Column('id', sa.Integer(), nullable=False),
+      sa.Column('relationship_id',  sa.Integer(), nullable=False),
+      sa.Column('attr_name', sa.String(length=250), nullable=False),
+      sa.Column('attr_value', sa.String(length=250), nullable=False),
+      sa.PrimaryKeyConstraint('id'),
+      sa.ForeignKeyConstraint(['relationship_id'], ['relationships.id'])
+  )
+
+
+def downgrade():
+  op.drop_table('relationship_attrs')

--- a/src/ggrc/models/all_models.py
+++ b/src/ggrc/models/all_models.py
@@ -35,7 +35,9 @@ from ggrc.models.person import Person
 from ggrc.models.product import Product
 from ggrc.models.program import Program
 from ggrc.models.project import Project
-from ggrc.models.relationship import Relationship, RelationshipType
+from ggrc.models.relationship import Relationship
+from ggrc.models.relationship import RelationshipAttr
+from ggrc.models.relationship import RelationshipType
 from ggrc.models.request import Request
 from ggrc.models.response import (
     Response, DocumentationResponse, InterviewResponse,
@@ -92,6 +94,7 @@ all_models = [
     Project,
     Relationship,
     RelationshipType,
+    RelationshipAttr,
     Request,
     Response,
     DocumentationResponse,

--- a/src/ggrc/models/relationship.py
+++ b/src/ggrc/models/relationship.py
@@ -43,7 +43,8 @@ class Relationship(Mapping, db.Model):
   relationship_attrs = db.relationship(
       lambda: RelationshipAttr,
       collection_class=attribute_mapped_collection("attr_name"),
-      lazy='joined'  # eager loading
+      lazy='joined',  # eager loading
+      cascade='all, delete-orphan'
   )
   attrs = association_proxy(
       "relationship_attrs", "attr_value",
@@ -109,7 +110,9 @@ class Relationship(Mapping, db.Model):
       'source',
       'destination',
       'relationship_type_id',
+      'attrs',
   ]
+  attrs.publish_raw = True
 
   def _display_name(self):
     return self.source.display_name + '<->' + self.destination.display_name
@@ -177,7 +180,7 @@ class RelationshipAttr(Identifiable, db.Model):
   __tablename__ = 'relationship_attrs'
   relationship_id = db.Column(
       db.Integer,
-      db.ForeignKey('relationships.id', ondelete='SET NULL'),
+      db.ForeignKey('relationships.id'),
       primary_key=True
   )
   attr_name = db.Column(db.String, nullable=False)

--- a/src/ggrc/models/relationship.py
+++ b/src/ggrc/models/relationship.py
@@ -5,16 +5,17 @@
 
 from ggrc import db
 from ggrc.models.mixins import Base
-from ggrc.models.mixins import deferred
 from ggrc.models.mixins import Described
 from ggrc.models.mixins import Identifiable
 from ggrc.models.mixins import Mapping
+from ggrc.models.mixins import deferred
 from sqlalchemy import or_, and_
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.orm import validates
 from sqlalchemy.orm.collections import attribute_mapped_collection
 from werkzeug.exceptions import BadRequest
+import functools
 
 
 class Relationship(Mapping, db.Model):
@@ -239,4 +240,4 @@ class RelationshipAttr(Identifiable, db.Model):
       validator = getattr(cls, "_validate_relationship_attr", None)
       if validator is not None:
         validators.add(validator)
-    return [lambda *args: v(target_class, *args) for v in validators]
+    return [functools.partial(v, target_class) for v in validators]

--- a/src/ggrc/models/relationship.py
+++ b/src/ggrc/models/relationship.py
@@ -84,6 +84,10 @@ class Relationship(Mapping, db.Model):
 
   @validates('relationship_attrs')
   def _validate_attr(self, key, attr):
+    """
+      Only white-listed attributes can be stored, so users don't use this
+      for storing arbitrary data.
+    """
     RelationshipAttr.validate_attr(self.source, self.destination, attr)
     return attr
 
@@ -184,6 +188,12 @@ class Relatable(object):
 
 
 class RelationshipAttr(Identifiable, db.Model):
+  """
+    Extended attributes for relationships. Used to store relations meta-data
+    so the Relationship table can be used in place of join-tables that carry
+    extra information
+  """
+
   __tablename__ = 'relationship_attrs'
   relationship_id = db.Column(
       db.Integer,
@@ -197,6 +207,10 @@ class RelationshipAttr(Identifiable, db.Model):
 
   @classmethod
   def validate_attr(cls, source, destination, attr):
+    """
+      Checks both source and destination type (with mixins) for
+      defined validators _validate_relationship_attr
+    """
     attr_name = attr.attr_name
     attr_value = attr.attr_value
     validators = cls._get_validators(source) + cls._get_validators(destination)

--- a/src/tests/ggrc/models/test_relationship.py
+++ b/src/tests/ggrc/models/test_relationship.py
@@ -3,8 +3,68 @@
 # Created By: andraz@reciprocitylabs.com
 # Maintained By: andraz@reciprocitylabs.com
 
+from ggrc import db
+from ggrc.models.mixins import Base
+from ggrc.models.relationship import Relationship
 from ggrc.models.relationship import RelationshipAttr
 from tests.ggrc import TestCase
+import ggrc
+import ggrc.builder
+import ggrc.services
+import random
+import werkzeug.exceptions
+
+
+class RelationshipTestMockModel(Base, ggrc.db.Model):
+  __tablename__ = 'relationship_test_mock_model'
+  foo = db.Column(db.String)
+
+  # REST properties
+  _publish_attrs = ['modified_by_id', 'foo']
+  _update_attrs = ['foo']
+
+  @staticmethod
+  def _validate_relationship_attr(cls, source, destination, name, value):
+    if cls.__name__ not in {source.type, destination.type}:
+      return False
+    if name != "validated_attr":
+      return False
+    try:
+      int(value)
+    except ValueError:
+      return False
+    return True
+
+
+class TestRelationship(TestCase):
+
+  def setUp(self):
+    super(TestRelationship, self).setUp()
+    if RelationshipTestMockModel.__table__.exists(db.engine):
+      RelationshipTestMockModel.__table__.drop(db.engine)
+    RelationshipTestMockModel.__table__.create(db.engine)
+    with self.client.session_transaction() as session:
+      session['permissions'] = {
+          "__GGRC_ADMIN__": {"__GGRC_ALL__": {"contexts": [0]}}
+      }
+
+  def mock_model(self, id=None, modified_by_id=1, **kwarg):
+    if 'id' not in kwarg:
+      kwarg['id'] = random.randint(0, 999999999)
+    if 'modified_by_id' not in kwarg:
+      kwarg['modified_by_id'] = 1
+    mock = RelationshipTestMockModel(**kwarg)
+    return mock
+
+  def test_attrs_validation(self):
+    m1 = self.mock_model()
+    m2 = self.mock_model()
+    rel = Relationship(source=m1, destination=m2)
+    with self.assertRaises(werkzeug.exceptions.BadRequest):
+      rel.attrs["foo"] = "bar"
+    with self.assertRaises(werkzeug.exceptions.BadRequest):
+      rel.attrs["validated_attr"] = "wrong value"
+    rel.attrs["validated_attr"] = "123"
 
 
 class TestRelationshipAttr(TestCase):

--- a/src/tests/ggrc/models/test_relationship.py
+++ b/src/tests/ggrc/models/test_relationship.py
@@ -1,0 +1,24 @@
+# Copyright (C) 2015 Google Inc., authors, and contributors <see AUTHORS file>
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+# Created By: andraz@reciprocitylabs.com
+# Maintained By: andraz@reciprocitylabs.com
+
+from ggrc.models.relationship import RelationshipAttr
+from tests.ggrc import TestCase
+
+
+class TestRelationshipAttr(TestCase):
+
+  def test_gather_validators(self):
+    class ValidatorParent(object):
+      @staticmethod
+      def _validate_relationship_attr(cls):
+        return True
+
+    class ValidatorChild(ValidatorParent):
+      @staticmethod
+      def _validate_relationship_attr(cls):
+        return False
+
+    validators = RelationshipAttr._gather_validators(ValidatorChild)
+    self.assertEqual({True, False}, {v() for v in validators})


### PR DESCRIPTION
This implements extensible relationship attributes that finally allow dropping of all special mapping tables. 
I wrote it as a part of [assignable mixin](https://github.com/edofic/ggrc-core/tree/feature/CORE-2375-assignable-mixin) but I think it's better to consider it a standalone thing.
Relationship attributes have to be white listed (example of this is the assignable mixin - will be another PR) and thi PR does not white list any so there arent any major differences in the API: you get an `attr` field that is always an empty dict and you cannot post anything to it - you would get `Bad request: invalid attribute <x>`