### PR TITLE
CORE-2376 Add Comment(able)

### DIFF
--- a/src/ggrc/migrations/versions/20151023130018_4cd52e0a17b8_add_comments.py
+++ b/src/ggrc/migrations/versions/20151023130018_4cd52e0a17b8_add_comments.py
@@ -1,0 +1,37 @@
+# Copyright (C) 2015 Google Inc., authors, and contributors <see AUTHORS file>
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+# Created By: andraz@reciprocitylabs.com
+# Maintained By: andraz@reciprocitylabs.com
+
+"""Add Comments
+
+Revision ID: 4cd52e0a17b8
+Revises: 3c8f204ba7a9
+Create Date: 2015-10-23 13:00:18.555497
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '4cd52e0a17b8'
+down_revision = '45693b1959f7'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+  op.create_table(
+      'comments',
+      sa.Column('id', sa.Integer(), primary_key=True, nullable=False),
+      sa.Column('commentable_id', sa.Integer(), nullable=False),
+      sa.Column('commentable_type', sa.String(length=250), nullable=False),
+      sa.Column('description', sa.Text()),
+      sa.Column('created_at', sa.DateTime()),
+      sa.Column('modified_by_id', sa.Integer()),
+      sa.Column('updated_at', sa.DateTime()),
+      sa.Column('context_id', sa.Integer(), sa.ForeignKey('contexts.id'))
+  )
+
+
+def downgrade():
+  op.drop_table('comments')

--- a/src/ggrc/models/all_models.py
+++ b/src/ggrc/models/all_models.py
@@ -10,6 +10,7 @@
 from access_group import AccessGroup
 from ggrc.models.audit import Audit
 from ggrc.models.audit_object import AuditObject
+from ggrc.models.comment import Comment
 from ggrc.models.categorization import Categorization
 from ggrc.models.category import CategoryBase
 from ggrc.models.context import Context
@@ -67,6 +68,7 @@ all_models = [
     Context,
     Control,
     ControlAssessment,
+    Comment,
     CustomAttributeDefinition,
     CustomAttributeValue,
     DataAsset,

--- a/src/ggrc/models/comment.py
+++ b/src/ggrc/models/comment.py
@@ -1,0 +1,54 @@
+# Copyright (C) 2015 Google Inc., authors, and contributors <see AUTHORS file>
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+# Created By: andraz@reciprocitylabs.com
+# Maintained By: andraz@reciprocitylabs.com
+
+from ggrc import db
+from ggrc.models.mixins import Base, Described
+from ggrc.models.object_document import Documentable
+from sqlalchemy.ext.declarative import declared_attr
+
+
+class Comment(Described, Documentable, Base, db.Model):
+  __tablename__ = "comments"
+
+  commentable_id = db.Column(db.Integer, nullable=False)
+  commentable_type = db.Column(db.String, nullable=False)
+
+  @property
+  def commentable_attr(self):
+    return '{0}_commentable'.format(self.commentable_type)
+
+  @property
+  def commentable(self):
+    return getattr(self, self.commentable_type)
+
+  @commentable.setter
+  def commentable(self, value):
+    self.commentable_id = value.id if value is not None else None
+    self.commentable_type = \
+        value.__class__.__name__ if value is not None else None
+    return setattr(self, self.commentable_attr, value)
+
+  _publish_attrs = [
+      "commentable"
+  ]
+
+
+class Commentable(object):
+
+  @declared_attr
+  def comments(cls):
+    joinstr = 'and_(remote(Comment.commentable_id) == {type}.id, '\
+        'remote(Comment.commentable_type) == "{type}")'
+    joinstr = joinstr.format(type=cls.__name__)
+    return db.relationship(
+        'Comment',
+        primaryjoin=joinstr,
+        foreign_keys='Comment.commentable_id',
+        backref='{0}_commentable'.format(cls.__name__),
+        cascade='all, delete-orphan')
+
+  _publish_attrs = [
+      "comments"
+  ]

--- a/src/ggrc/services/__init__.py
+++ b/src/ggrc/services/__init__.py
@@ -27,6 +27,7 @@ def contributed_services():
       service('contexts', models.Context),
       service('controls', models.Control),
       service('control_assessments', models.ControlAssessment),
+      service('comments', models.Comment),
       service('custom_attribute_definitions',
               models.CustomAttributeDefinition),
       service('custom_attribute_values', models.CustomAttributeValue),


### PR DESCRIPTION
This adds a standalone `Comment` object as well as a `Commentable` mixin that provides the necessary relationships.
Permissions for these objects are not set up yet so only admin has access. I will implement this once we have a commentable object. 