### PR TITLE
CORE-2497 request automapping

### DIFF
--- a/src/ggrc/automapper/__init__.py
+++ b/src/ggrc/automapper/__init__.py
@@ -6,7 +6,7 @@
 import logging
 from collections import namedtuple
 
-from sqlalchemy import or_, and_
+from sqlalchemy import and_
 
 from datetime import datetime
 from ggrc import models
@@ -51,10 +51,10 @@ class AutomapperGenerator(object):
         and_(Relationship.source_type == obj.type,
              Relationship.source_id == obj.id),
     ).union_all(
-      Relationship.query.filter(
-        and_(Relationship.destination_type == obj.type,
-             Relationship.destination_id == obj.id),
-    )).all()
+        Relationship.query.filter(
+            and_(Relationship.destination_type == obj.type,
+                 Relationship.destination_id == obj.id))
+    ).all()
     res = set((Stub.from_destination(r)
                if r.source_type == obj.type and r.source_id == obj.id
                else Stub.from_source(r))

--- a/src/ggrc/automapper/rules.py
+++ b/src/ggrc/automapper/rules.py
@@ -163,4 +163,11 @@ rules = RuleSet(count_limit=10000, rule_list=[
         {'Control'},
         {'Control'},
     ),
+
+    Rule(
+        'mapping request to audit',
+        {Attr('program')},
+        {'Audit'},
+        {'Request'},
+    ),
 ])

--- a/src/tests/ggrc/automapper/test_automappings.py
+++ b/src/tests/ggrc/automapper/test_automappings.py
@@ -291,3 +291,25 @@ class TestAutomappings(tests.ggrc.TestCase):
                  (section, regulation),
                  (control, section)],
     )
+
+  def test_automapping_request_audit(self):
+    _, creator = self.gen.generate_person(user_role="Creator")
+    program = self.create_object(models.Program, {'title': next('Program')})
+    audit = self.create_object(models.Audit, {
+        'title': next('Audit'),
+        'program': {'id': program.id},
+        'status': 'Planned',
+    })
+    request = self.create_object(models.Request, {
+        'audit': {'id': audit.id},
+        'title': next('Request'),
+        'assignee': {'id': creator.id},
+        'request_type': 'documentation',
+        'status': 'Draft',
+        'requested_on': '1/1/2015',
+        'due_on': '1/1/2016',
+    })
+    self.assert_mapping_implication(
+        to_create=[(audit, request)],
+        implied=[(program, request)]
+    )

--- a/src/tests/ggrc/automapper/test_automappings.py
+++ b/src/tests/ggrc/automapper/test_automappings.py
@@ -3,20 +3,13 @@
 # Created By: andraz@reciprocitylabs.com
 # Maintained By: andraz@reciprocitylabs.com
 
-from ggrc import db
-from ggrc.automapper.rules import rules
-from ggrc.models import Control
-from ggrc.models import Objective
-from ggrc.models import Program
-from ggrc.models import Regulation
-from ggrc.models import Relationship
-from ggrc.models import Section
-from tests.ggrc import TestCase
-from tests.ggrc.api_helper import Api
-from tests.ggrc.generator import ObjectGenerator
+import ggrc
+import ggrc.models as models
 import itertools
 import os
 import random
+import tests.ggrc
+import tests.ggrc.generator
 
 
 if os.environ.get('TRAVIS', False):
@@ -37,22 +30,22 @@ class automapping_count_limit:
     self.new_limit = new_limit
 
   def __enter__(self):
-    self.original_limit = rules.count_limit
-    rules.count_limit = self.new_limit
+    self.original_limit = ggrc.automapper.rules.count_limit
+    ggrc.automapper.rules.count_limit = self.new_limit
 
   def __exit__(self, type, value, traceback):
-    rules.count_limit = self.original_limit
+    ggrc.automapper.rules.count_limit = self.original_limit
 
 
-class TestAutomappings(TestCase):
+class TestAutomappings(tests.ggrc.TestCase):
 
   def setUp(self):
-    TestCase.setUp(self)
-    self.gen = ObjectGenerator()
+    tests.ggrc.TestCase.setUp(self)
+    self.gen = tests.ggrc.generator.ObjectGenerator()
     self.api = self.gen.api
 
   def tearDown(self):
-    TestCase.tearDown(self)
+    tests.ggrc.TestCase.tearDown(self)
 
   def create_object(self, cls, data):
     name = cls.__name__.lower()
@@ -62,14 +55,14 @@ class TestAutomappings(TestCase):
     return obj
 
   def create_mapping(self, src, dst):
-    return self.create_object(Relationship, {
+    return self.create_object(models.Relationship, {
         'source': {'id': src.id, 'type': src.type},
         'destination': {'id': dst.id, 'type': dst.type}
     })
 
   def assert_mapping(self, obj1, obj2, missing=False):
-    db.session.flush()
-    rel = Relationship.find_related(obj1, obj2)
+    ggrc.db.session.flush()
+    rel = models.Relationship.find_related(obj1, obj2)
     if not missing:
       self.assertIsNotNone(rel,
                            msg='%s not mapped to %s' % (obj1.type, obj2.type))
@@ -117,34 +110,42 @@ class TestAutomappings(TestCase):
 
   def test_mapping_directive_to_a_program(self):
     self.with_permutations(
-        lambda: self.create_object(Program, {'title': next('Program')}),
-        lambda: self.create_object(Regulation, {
+        lambda: self.create_object(models.Program, {'title': next('Program')}),
+        lambda: self.create_object(models.Regulation, {
             'title': next('Test PD Regulation')
         }),
-        lambda: self.create_object(Objective, {'title': next('Objective')}),
+        lambda: self.create_object(models.Objective, {
+            'title': next('Objective')
+        }),
     )
-    program = self.create_object(Program, {'title': next('Program')})
-    objective1 = self.create_object(Objective, {'title': next('Objective')})
-    objective2 = self.create_object(Objective, {'title': next('Objective')})
+    program = self.create_object(models.Program, {'title': next('Program')})
+    objective1 = self.create_object(models.Objective, {
+        'title': next('Objective')
+    })
+    objective2 = self.create_object(models.Objective, {
+        'title': next('Objective')
+    })
     self.assert_mapping_implication(
         to_create=[(program, objective1), (objective1, objective2)],
         implied=[],
     )
 
   def test_mapping_to_sections(self):
-    regulation = self.create_object(Regulation, {
+    regulation = self.create_object(models.Regulation, {
         'title': next('Test Regulation')
     })
-    section = self.create_object(Section, {
+    section = self.create_object(models.Section, {
         'title': next('Test section'),
     })
-    objective = self.create_object(Objective, {'title': next('Objective')})
+    objective = self.create_object(models.Objective, {
+        'title': next('Objective')
+    })
     self.assert_mapping_implication(
         to_create=[(regulation, section), (objective, section)],
         implied=(objective, regulation),
 
     )
-    program = self.create_object(Program, {'title': next('Program')})
+    program = self.create_object(models.Program, {'title': next('Program')})
     self.assert_mapping_implication(
         to_create=[(objective, program)],
         implied=[(regulation, section),
@@ -155,26 +156,32 @@ class TestAutomappings(TestCase):
 
   def test_automapping_limit(self):
     with automapping_count_limit(-1):
-      program = self.create_object(Program, {'title': next('Program')})
-      regulation = self.create_object(Regulation, {
+      program = self.create_object(models.Program, {'title': next('Program')})
+      regulation = self.create_object(models.Regulation, {
           'title': next('Test PD Regulation')
       })
-      objective = self.create_object(Objective, {'title': next('Objective')})
+      objective = self.create_object(models.Objective, {
+          'title': next('Objective')
+      })
       self.assert_mapping_implication(
           to_create=[(regulation, objective), (objective, program)],
           implied=[],
       )
 
   def test_mapping_to_objective(self):
-    regulation = self.create_object(Regulation, {
+    regulation = self.create_object(models.Regulation, {
         'title': next('Test PD Regulation')
     })
-    section = self.create_object(Section, {
+    section = self.create_object(models.Section, {
         'title': next('Test section'),
         'directive': {'id': regulation.id},
     })
-    control = self.create_object(Control, {'title': next('Test control')})
-    objective = self.create_object(Objective, {'title': next('Test control')})
+    control = self.create_object(models.Control, {
+        'title': next('Test control')
+    })
+    objective = self.create_object(models.Objective, {
+        'title': next('Test control')
+    })
     self.assert_mapping_implication(
         to_create=[(regulation, section),
                    (section, objective),
@@ -186,7 +193,7 @@ class TestAutomappings(TestCase):
         ]
     )
 
-    program = self.create_object(Program, {'title': next('Program')})
+    program = self.create_object(models.Program, {'title': next('Program')})
     self.assert_mapping_implication(
         to_create=[(control, program)],
         implied=[
@@ -201,17 +208,17 @@ class TestAutomappings(TestCase):
     )
 
   def test_mapping_between_objectives(self):
-    regulation = self.create_object(Regulation, {
+    regulation = self.create_object(models.Regulation, {
         'title': next('Test PD Regulation')
     })
-    section = self.create_object(Section, {
+    section = self.create_object(models.Section, {
         'title': next('Test section'),
         'directive': {'id': regulation.id},
     })
-    objective1 = self.create_object(Objective, {
+    objective1 = self.create_object(models.Objective, {
         'title': next('Test Objective')
     })
-    objective2 = self.create_object(Objective, {
+    objective2 = self.create_object(models.Objective, {
         'title': next('Test Objective')
     })
     self.assert_mapping_implication(
@@ -226,12 +233,18 @@ class TestAutomappings(TestCase):
     )
 
   def test_mapping_nested_controls(self):
-    objective = self.create_object(Objective, {
+    objective = self.create_object(models.Objective, {
         'title': next('Test Objective')
     })
-    controlP = self.create_object(Control, {'title': next('Test control')})
-    control1 = self.create_object(Control, {'title': next('Test control')})
-    control2 = self.create_object(Control, {'title': next('Test control')})
+    controlP = self.create_object(models.Control, {
+        'title': next('Test control')
+    })
+    control1 = self.create_object(models.Control, {
+        'title': next('Test control')
+    })
+    control2 = self.create_object(models.Control, {
+        'title': next('Test control')
+    })
     self.assert_mapping_implication(
         to_create=[(objective, controlP),
                    (controlP, control1),
@@ -243,24 +256,24 @@ class TestAutomappings(TestCase):
     _, creator = self.gen.generate_person(user_role="Creator")
     _, admin = self.gen.generate_person(user_role="gGRC Admin")
 
-    program = self.create_object(Program, {'title': next('Program')})
-    regulation = self.create_object(Regulation, {
-      'title': next('Regulation'),
-      'owners': [{"id": admin.id}],
+    program = self.create_object(models.Program, {'title': next('Program')})
+    regulation = self.create_object(models.Regulation, {
+        'title': next('Regulation'),
+        'owners': [{"id": admin.id}],
     })
     owners = [{"id": creator.id}]
     self.api.set_user(creator)
-    section = self.create_object(Section, {
-      'title': next('Section'),
-      'owners': owners,
+    section = self.create_object(models.Section, {
+        'title': next('Section'),
+        'owners': owners,
     })
-    objective = self.create_object(Objective, {
-      'title': next('Objective'),
-      'owners': owners,
+    objective = self.create_object(models.Objective, {
+        'title': next('Objective'),
+        'owners': owners,
     })
-    control = self.create_object(Control, {
-      'title': next('Control'),
-      'owners': owners,
+    control = self.create_object(models.Control, {
+        'title': next('Control'),
+        'owners': owners,
     })
 
     self.api.set_user(admin)


### PR DESCRIPTION
This now triggers for manually created relationships between audits and
requests. These will be automatically created once Requests are first class.
