### PR TITLE
QUICK-FIX Fix performance regression in canjs 2.2.9

### DIFF
--- a/src/ggrc/assets/javascripts/models/cacheable.js
+++ b/src/ggrc/assets/javascripts/models/cacheable.js
@@ -968,42 +968,6 @@ can.Model("can.Model.Cacheable", {
     this._pending_refresh.fn();
     return dfd;
   }
-  , serialize : function() {
-    var that = this, serial = {};
-    if(arguments.length) {
-      return this._super.apply(this, arguments);
-    }
-    this.each(function(val, name) {
-      var fun_name;
-      if(that.constructor.attributes && that.constructor.attributes[name]) {
-        fun_name = that.constructor.attributes[name];
-        fun_name = fun_name.substr(fun_name.lastIndexOf(".") + 1);
-        if (fun_name === "stubs" || fun_name === "get_stubs"
-            ||fun_name === "models" || fun_name === "get_instances") {
-          // val can be null in some cases
-          val && (serial[name] = val.stubs().serialize());
-        } else if (fun_name === "stub" || fun_name === "get_stub"
-                   || fun_name === "model" || fun_name === "get_instance") {
-          serial[name] = (val ? val.stub().serialize() : null);
-        } else {
-          serial[name] = that._super(name);
-        }
-      } else if(val && typeof val.save === "function") {
-        serial[name] = val.stub().serialize();
-      } else if(typeof val === "object" && val != null && val.length != null) {
-        serial[name] = can.map(val, function(v) {
-          return (v && typeof v.save === "function") ? v.stub().serialize() : (v.serialize ? v.serialize() : v);
-        });
-      } else if(typeof val !== 'function') {
-        if(that[name] && that[name].isComputed) {
-          serial[name] = val && val.serialize ? val.serialize() : val;
-        } else {
-          serial[name] = that[name] && that[name].serialize ? that[name].serialize() : that._super(name);
-        }
-      }
-    });
-    return serial;
-  }
   , display_name : function() {
     return this.title || this.name;
   }

--- a/src/ggrc/assets/javascripts/models/simple_models.js
+++ b/src/ggrc/assets/javascripts/models/simple_models.js
@@ -93,6 +93,11 @@ can.Model.Cacheable("CMS.Models.Program", {
 
 can.Model.Cacheable("CMS.Models.Option", {
   root_object : "option"
+  , findAll : "GET /api/options"
+  , findOne : "GET /api/options/{id}"
+  , create : "POST /api/options"
+  , update : "PUT /api/options/{id}"
+  , destroy : "DELETE /api/options/{id}"
   , root_collection : "options"
   , cache_by_role: {}
   , for_role: function(role) {


### PR DESCRIPTION
Our custom serialize function caused a serious regression when we upgraded
from canjs 2.0.9 to 2.2.9. From what I can tell (ac7112ab, 5f71b7c), we implemented a custom serialize
function when we weren't using stubs in lists in order to prevent update events going out of control.

The only difference in the output of our serialize and canjs's
serialize is that canjs's function also serializes the instance class.