### PR TITLE
CORE-2576 Fix people imports

### DIFF
--- a/src/ggrc/converters/base_row.py
+++ b/src/ggrc/converters/base_row.py
@@ -51,8 +51,8 @@ class RowConverter(object):
     handle_fields = self.headers if field_list is None else field_list
     for i, (attr_name, header_dict) in enumerate(self.headers.items()):
       if attr_name not in handle_fields or \
-          attr_name in self.attrs or \
-          self.is_delete:
+              attr_name in self.attrs or \
+              self.is_delete:
         continue
       Handler = header_dict["handler"]
       item = Handler(self, attr_name, raw_value=self.row[i], **header_dict)
@@ -60,7 +60,10 @@ class RowConverter(object):
         self.attrs[attr_name] = item
       else:
         self.objects[attr_name] = item
-      if attr_name in ("slug", "email"):
+
+      if attr_name == "email" and not self.get_value(attr_name):
+        self.add_error(errors.MISSING_VALUE_ERROR, column_name="Email")
+      elif attr_name in ("slug", "email"):
         self.id_key = attr_name
         self.obj = self.get_or_generate_object(attr_name)
         item.set_obj_attr()

--- a/src/ggrc/migrations/versions/20151107123018_1bad7fe16295_make_person_email_not_null.py
+++ b/src/ggrc/migrations/versions/20151107123018_1bad7fe16295_make_person_email_not_null.py
@@ -1,0 +1,30 @@
+# Copyright (C) 2015 Google Inc., authors, and contributors <see AUTHORS file>
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+# Created By: miha@reciprocitylabs.com
+# Maintained By: miha@reciprocitylabs.com
+
+"""Make person email not null
+
+Revision ID: 1bad7fe16295
+Revises: 29b63100d61c
+Create Date: 2015-11-07 12:30:18.465786
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '1bad7fe16295'
+down_revision = '29b63100d61c'
+
+
+def upgrade():
+  op.execute("DELETE FROM people WHERE email IS NULL")
+  op.alter_column("people", "email", nullable=False,
+                  existing_type=sa.String(length=250))
+
+
+def downgrade():
+  op.alter_column("people", "email", nullable=True,
+                  existing_type=sa.String(length=250))

--- a/test/integration/ggrc/converters/test_csvs/people_test.csv
+++ b/test/integration/ggrc/converters/test_csvs/people_test.csv
@@ -1,0 +1,13 @@
+Object type,,,,"Admin,
+creator, 
+reader,
+editor,
+no access - default"
+Person,name,email,company,role
+,user 1,user1@example.com,google,Admin 
+,user 2,user2@example.com,google,gGRC Admin
+,user 10,user10@example.com,google,creator
+,user 11,user11@example.com,google,
+,user 12,user12@example.com,,reader
+,Fail,,facebook,Admin 
+,,user14@example.com,linkedin,gGRC Admin

--- a/test/integration/ggrc/converters/test_import_csv.py
+++ b/test/integration/ggrc/converters/test_import_csv.py
@@ -159,4 +159,6 @@ class TestBasicCsvImport(converters.TestCase):
     response_dry = self.import_file(filename, dry_run=True)
     response = self.import_file(filename)
     self.assertEqual(response, response_dry)
+    self.assertIn("Line 8: Field Email is required. The line will be ignored.",
+                  response[0]["row_errors"])
     self.assertEqual(0, models.Person.query.filter_by(email=None).count())

--- a/test/integration/ggrc/converters/test_import_csv.py
+++ b/test/integration/ggrc/converters/test_import_csv.py
@@ -3,20 +3,17 @@
 # Created By: miha@reciprocitylabs.com
 # Maintained By: miha@reciprocitylabs.com
 
+from ggrc import models
 from ggrc.converters import errors
-from ggrc.models import Audit
-from ggrc.models import ControlAssessment
-from ggrc.models import Policy
-from ggrc.models import Relationship
-from integration.ggrc.converters import TestCase
-from integration.ggrc.generator import ObjectGenerator
+from integration.ggrc import converters
+from integration.ggrc import generator
 
 
-class TestBasicCsvImport(TestCase):
+class TestBasicCsvImport(converters.TestCase):
 
   def setUp(self):
-    TestCase.setUp(self)
-    self.generator = ObjectGenerator()
+    converters.TestCase.setUp(self)
+    self.generator = generator.ObjectGenerator()
     self.client.get("/login")
 
   def tearDown(self):
@@ -32,7 +29,7 @@ class TestBasicCsvImport(TestCase):
   def test_policy_basic_import(self):
     filename = "policy_basic_import.csv"
     self.import_file(filename)
-    self.assertEqual(Policy.query.count(), 3)
+    self.assertEqual(models.Policy.query.count(), 3)
 
   def test_policy_import_working_with_warnings_dry_run(self):
     filename = "policy_import_working_with_warnings.csv"
@@ -52,7 +49,7 @@ class TestBasicCsvImport(TestCase):
     response_errors = response_json[0]["row_errors"]
     self.assertEqual(set(), set(response_errors))
     self.assertEqual(4, response_json[0]["created"])
-    policies = Policy.query.all()
+    policies = models.Policy.query.all()
     self.assertEqual(len(policies), 0)
 
   def test_policy_import_working_with_warnings(self):
@@ -62,7 +59,7 @@ class TestBasicCsvImport(TestCase):
     filename = "policy_import_working_with_warnings.csv"
     self.import_file(filename)
 
-    policies = Policy.query.all()
+    policies = models.Policy.query.all()
     self.assertEqual(len(policies), 4)
     for policy in policies:
       test_owners(policy)
@@ -94,7 +91,7 @@ class TestBasicCsvImport(TestCase):
     response_errors = response_json[0]["row_errors"]
     self.assertEqual(expected_errors, set(response_errors))
 
-    policies = Policy.query.all()
+    policies = models.Policy.query.all()
     self.assertEqual(len(policies), 3)
     for policy in policies:
       test_owners(policy)
@@ -109,7 +106,7 @@ class TestBasicCsvImport(TestCase):
 
     response_warnings = response_json[0]["row_warnings"]
     self.assertEqual(set(), set(response_warnings))
-    self.assertEqual(0, Relationship.query.count())
+    self.assertEqual(0, models.Relationship.query.count())
 
   def test_facilities_intermappings(self):
     self.generate_people(["miha", "predrag", "vladan", "ivan"])
@@ -121,7 +118,7 @@ class TestBasicCsvImport(TestCase):
 
     response_warnings = response_json[0]["row_warnings"]
     self.assertEqual(set(), set(response_warnings))
-    self.assertEqual(4, Relationship.query.count())
+    self.assertEqual(4, models.Relationship.query.count())
 
   def test_control_assessments_import_update(self):
     messages = ("block_errors", "block_warnings", "row_errors", "row_warnings")
@@ -133,14 +130,14 @@ class TestBasicCsvImport(TestCase):
       for message in messages:
         self.assertEquals(set(), set(response_block[message]))
 
-    ca = ControlAssessment.query.filter_by(slug="CA.PCI 1.1").first()
-    au = Audit.query.filter_by(slug="AUDIT-Consolidated").first()
+    ca = models.ControlAssessment.query.filter_by(slug="CA.PCI 1.1").first()
+    au = models.Audit.query.filter_by(slug="AUDIT-Consolidated").first()
     self.assertEquals(len(ca.owners), 1)
     self.assertEquals(ca.owners[0].email, "danny@reciprocitylabs.com")
     self.assertEquals(ca.contact.email, "danny@reciprocitylabs.com")
     self.assertEquals(ca.design, "Effective")
     self.assertEquals(ca.operationally, "Effective")
-    self.assertIsNone(Relationship.find_related(ca, au))
+    self.assertIsNone(models.Relationship.find_related(ca, au))
 
     filename = "pci_program_update.csv"
     response = self.import_file(filename)
@@ -149,10 +146,10 @@ class TestBasicCsvImport(TestCase):
       for message in messages:
         self.assertEquals(set(), set(response_block[message]))
 
-    ca = ControlAssessment.query.filter_by(slug="CA.PCI 1.1").first()
-    au = Audit.query.filter_by(slug="AUDIT-Consolidated").first()
+    ca = models.ControlAssessment.query.filter_by(slug="CA.PCI 1.1").first()
+    au = models.Audit.query.filter_by(slug="AUDIT-Consolidated").first()
     self.assertEquals(ca.owners[0].email, "miha@reciprocitylabs.com")
     self.assertEquals(ca.contact.email, "albert@reciprocitylabs.com")
     self.assertEquals(ca.design, "Needs improvement")
     self.assertEquals(ca.operationally, "Ineffective")
-    self.assertIsNotNone(Relationship.find_related(ca, au))
+    self.assertIsNotNone(models.Relationship.find_related(ca, au))

--- a/test/integration/ggrc/converters/test_import_csv.py
+++ b/test/integration/ggrc/converters/test_import_csv.py
@@ -153,3 +153,10 @@ class TestBasicCsvImport(converters.TestCase):
     self.assertEquals(ca.design, "Needs improvement")
     self.assertEquals(ca.operationally, "Ineffective")
     self.assertIsNotNone(models.Relationship.find_related(ca, au))
+
+  def test_person_imports(self):
+    filename = "people_test.csv"
+    response_dry = self.import_file(filename, dry_run=True)
+    response = self.import_file(filename)
+    self.assertEqual(response, response_dry)
+    self.assertEqual(0, models.Person.query.filter_by(email=None).count())


### PR DESCRIPTION
People imports must notify a user if an email is missing and that line must be ignored. 
Importing people without emails worked and it broke the admin panel, so an email can't be added to that person from within the app.