### PR TITLE
QUICK-FIX Fix Make request FCO migration

### DIFF
--- a/src/ggrc/migrations/versions/20151016174806_27684e5f313a_make_request_first_class_object.py
+++ b/src/ggrc/migrations/versions/20151016174806_27684e5f313a_make_request_first_class_object.py
@@ -160,6 +160,8 @@ def upgrade():
       destination=comment)
 
     for rel in related:
+      if not rel.source or not rel.destination:
+        continue
       if rel.source.type == "DocumentationResponse":
         destination = rel.destination
       elif rel.destination.type == "DocumentationResponse":
@@ -205,6 +207,8 @@ def upgrade():
       destination=comment)
 
     for rel in related:
+      if not rel.source or not rel.destination:
+        continue
       if rel.source.type == "InterviewResponse":
         destination = rel.destination
       elif rel.destination.type == "InterviewResponse":


### PR DESCRIPTION
Fix "Make request FCO" migration by skipping over relationships
when source/destination object doesn't exist anymore.