### PR TITLE
CORE-2570 Only refresh workflow when needed

### DIFF
--- a/src/ggrc_workflows/assets/javascripts/workflow_mustache_helpers.js
+++ b/src/ggrc_workflows/assets/javascripts/workflow_mustache_helpers.js
@@ -151,8 +151,12 @@ Mustache.registerHelper("if_task_group_assignee_privileges", function(instance, 
   if(admin) {
     return options.fn(options.contexts);
   }
-
-  workflow_dfd = instance.workflow.reify().refresh().then(function(workflow){
+  if (instance.workflow.id in CMS.Models.Workflow.cache) {
+    workflow_dfd = new $.Deferred().resolve(instance.workflow.reify());
+  } else {
+    workflow_dfd = instance.workflow.reify().refresh();
+  }
+  workflow_dfd = workflow_dfd.then(function(workflow){
     return $.when(
       workflow.get_binding("authorizations").refresh_instances(),
       workflow.get_binding("owner_authorizations").refresh_instances()


### PR DESCRIPTION
if_task_group_assignee_privileges was in a endless loop refreshing the
workflow which prevented edit/add buttons from rendering. Now the
workflow will only refresh itself if it's not already in cache.