### PR TITLE
CORE-2606 Hide empty email notifications

### DIFF
--- a/src/ggrc/notification/__init__.py
+++ b/src/ggrc/notification/__init__.py
@@ -63,6 +63,9 @@ def get_notification_data(notifications):
     filtered_data = get_filter_data(notification)
     aggregate_data = merge_dict(aggregate_data, filtered_data)
 
+  # Remove notifications for objects without a contact (such as task groups)
+  aggregate_data.pop("", None)
+
   return aggregate_data
 
 

--- a/test/unit/ggrc/notification/__init__.py
+++ b/test/unit/ggrc/notification/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (C) 2015 Google Inc., authors, and contributors <see AUTHORS file>
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+# Created By: miha@reciprocitylabs.com
+# Maintained By: miha@reciprocitylabs.com

--- a/test/unit/ggrc/notification/test_init.py
+++ b/test/unit/ggrc/notification/test_init.py
@@ -1,0 +1,25 @@
+# Copyright (C) 2015 Google Inc., authors, and contributors <see AUTHORS file>
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+# Created By: miha@reciprocitylabs.com
+# Maintained By: miha@reciprocitylabs.com
+
+import unittest
+from mock import patch
+
+from ggrc import app  # noqa
+from ggrc import notification
+
+
+class TestNotificationsInit(unittest.TestCase):
+
+  @patch("ggrc.notification.get_filter_data")
+  def test_get_notification_data(self, get_filter_data):
+    """ Test that data does not contain empty emails """
+
+    get_filter_data.return_value = {
+        "email@example.com": {},
+        "": {},
+    }
+    notifications = notification.get_notification_data([1, 2])
+    self.assertIn("email@example.com", notifications)
+    self.assertNotIn("", notifications)


### PR DESCRIPTION
This is just a fix for the show_pending helper view, that can display
emtpy email notifications. The underlying cause for this is that
mandatory assignees or contacts can be missing. These emails would not
get sent in any case since there is no recipient, but we should stop
them from showing to avoid confusion during testing.