### PR TITLE
CORE-2694 Fix task date validation

### DIFF
--- a/src/ggrc_workflows/models/task_group_task.py
+++ b/src/ggrc_workflows/models/task_group_task.py
@@ -23,6 +23,7 @@ class TaskGroupTask(WithContact, Slugged, Titled, Described, RelativeTimeboxed,
       schema.CheckConstraint('start_date <= end_date'),
   )
   _title_uniqueness = False
+  _start_changed = False
 
   @classmethod
   def default_task_type(cls):
@@ -65,7 +66,10 @@ class TaskGroupTask(WithContact, Slugged, Titled, Described, RelativeTimeboxed,
   @orm.validates("start_date", "end_date")
   def validate_end_date(self, key, value):
     value = self.validate_date(value)
-    if key == "end_date" and self.start_date and self.start_date > value:
+    if key == "start_date":
+      self._start_changed = True
+    if key == "end_date" and self._start_changed and self.start_date > value:
+      self._start_changed = False
       raise ValueError("Start date can not be after end date.")
     return value
 

--- a/test/unit/ggrc_workflows/models/test_task_group_task.py
+++ b/test/unit/ggrc_workflows/models/test_task_group_task.py
@@ -34,3 +34,19 @@ class TestTaskGroupTask(unittest.TestCase):
     t.start_date = date(2015, 4, 17)
     self.assertRaises(ValueError,
                       t.validate_end_date, "end_date", date(2014, 2, 5))
+
+    t.end_date = date(2015, 2, 17)
+    self.assertEqual(date(2015, 2, 17), t.end_date)
+
+  def test_validate_start_date_decorator(self):
+    t = task_group_task.TaskGroupTask()
+    t.start_date = date(16, 4, 21)
+    self.assertEqual(date(2016, 4, 21), t.start_date)
+
+    t.end_date = date(2016, 4, 21)
+
+    t.start_date = date(2015, 2, 25)
+    self.assertEqual(date(2015, 2, 25), t.start_date)
+
+    t.start_date = date(2015, 6, 17)
+    self.assertEqual(date(2015, 6, 17), t.start_date)

--- a/test/unit/ggrc_workflows/models/test_task_group_task.py
+++ b/test/unit/ggrc_workflows/models/test_task_group_task.py
@@ -34,12 +34,3 @@ class TestTaskGroupTask(unittest.TestCase):
     t.start_date = date(2015, 4, 17)
     self.assertRaises(ValueError,
                       t.validate_end_date, "end_date", date(2014, 2, 5))
-
-  def test_validate_start_date_decorator(self):
-    t = task_group_task.TaskGroupTask()
-    t.start_date = date(16, 4, 21)
-    self.assertEqual(date(2016, 4, 21), t.start_date)
-
-    t.end_date = date(2016, 4, 21)
-    self.assertRaises(ValueError,
-                      t.validate_start_date, "start_date", date(2020, 2, 5))


### PR DESCRIPTION
The validats decorator depends on the order of edits. Start date has to
be set before end date. If that's not the case it might miss an error,
which is fine because imports make sure that the order of editing is
correct. This decorator is used mostli for displaying the correct
warning to the user during import of csv files. The real check happens
with schema.CheckConstraint which should work in all cases, but the
error is not user friendly.