### PR TITLE
QUICK-FIX Add custom attributes to request object

### DIFF
--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -199,6 +199,7 @@ dashboard-js-template-files:
   - issues/remediation_plan.mustache
   - custom_attributes/modal_content.mustache
   - custom_attributes/info.mustache
+  - custom_attributes/expanded_attrs.mustache
   - custom_attribute_definitions/modal_content.mustache
   - custom_attribute_definitions/tree.mustache
   - custom_attribute_definitions/subtree.mustache

--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -343,6 +343,7 @@ can.Model.Cacheable("CMS.Models.Request", {
   , update : "PUT /api/requests/{id}"
   , destroy : "DELETE /api/requests/{id}"
   , mixins : ["unique_title"]
+  , is_custom_attributable: true
   , attributes : {
       context : "CMS.Models.Context.stub"
     , assignee : "CMS.Models.Person.stub"
@@ -350,6 +351,7 @@ can.Model.Cacheable("CMS.Models.Request", {
     , due_on : "date"
     , documents : "CMS.Models.Document.stubs"
     , audit : "CMS.Models.Audit.stub"
+    , custom_attribute_values : "CMS.Models.CustomAttributeValue.stubs"
   }
   , defaults : {
     status : "Unstarted"

--- a/src/ggrc/assets/mustache/custom_attributes/expanded_attrs.mustache
+++ b/src/ggrc/assets/mustache/custom_attributes/expanded_attrs.mustache
@@ -1,0 +1,42 @@
+{{!
+    Copyright (C) 2015 Google Inc., authors, and contributors <see AUTHORS file>
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+    Created By: urban@reciprocitylabs.com
+    Maintained By: urban@reciprocitylabs.com
+}}
+
+<custom-attributes instance="instance" load="true">
+{{#if instance.custom_attribute_definitions.length}}
+  {{#iterate_by_two instance.custom_attribute_definitions}}
+    <div class="row-fluid wrap-row">
+      <div class="span12">
+        <h6>Custom Attributes</h6>
+        {{#list}}
+        <div class="span6">
+          <div data-custom-attribute="{{id}}" data-type="{{attribute_type}}">
+            {{#with_value_for_id id}}
+              {{#switch attribute_type}}
+                {{#case 'Checkbox'}}
+                  <h6>
+                    <input type="checkbox" disabled="disabled" {{#if_equals value "1"}}checked="checked"{{/if_equals}}>
+                    {{title}}
+                  </h6>
+                {{/case}}
+                {{#case 'Rich Text'}}
+                  <h6>{{title}}</h6>
+                  {{{value}}}
+                {{/case}}
+                {{#default}}
+                  <h6>{{title}}</h6>
+                  {{value}}
+                {{/default}}
+              {{/switch}}
+            {{/with_value_for_id}}
+          </div>
+        </div>
+      {{/list}}
+      </div>
+    </div>
+  {{/instance.custom_attribute_definitions}}
+{{/if}}
+</custom-attributes>

--- a/src/ggrc/assets/mustache/requests/info.mustache
+++ b/src/ggrc/assets/mustache/requests/info.mustache
@@ -81,6 +81,12 @@
               {{> /static/mustache/base_templates/mapped_objects.mustache}}
             </div>
           </div>
+          <hr />
+          <div class="row-fluid wrap-row">
+            <div class="span12">
+              {{> /static/mustache/custom_attributes/expanded_attrs.mustache }}
+            </div>
+          </div>
 
         </div>
         <div class="span4">


### PR DESCRIPTION
While custom attributes were added on the backend, we forgot to include them on the front end. This PR fixes that.