### PR TITLE
CORE-2716 Correct import error messages

### DIFF
--- a/src/ggrc/converters/base_row.py
+++ b/src/ggrc/converters/base_row.py
@@ -124,21 +124,14 @@ class RowConverter(object):
   def get_object_by_key(self, key="slug"):
     """ Get object if the slug is in the system or return a new object """
     value = self.get_value(key)
-    if value is None:
-      column_name = "Code" if key == slug else "Email"
-      self.add_error(errors.MISSING_COLUMN, s="", column_names=column_name)
-      return
-    obj = None
     self.is_new = False
-    if value:
-      obj = self.find_by_key(key, value)
+    obj = self.find_by_key(key, value)
     if not obj:
       obj = self.object_class()
       self.is_new = True
     elif not permissions.is_allowed_update_for(obj):
       self.ignore = True
       self.add_error(errors.PERMISSION_ERROR)
-
     return obj
 
   def setup_secondary_objects(self, slugs_dict):

--- a/src/ggrc/converters/base_row.py
+++ b/src/ggrc/converters/base_row.py
@@ -86,10 +86,10 @@ class RowConverter(object):
   def chect_mandatory_fields(self):
     if not self.is_new or self.is_delete:
       return
-    mandatory = [key for key, header in
-                 self.block_converter.object_headers.items()
-                 if header["mandatory"]]
-    missing = set(mandatory).difference(set(self.headers.keys()))
+    headers = self.block_converter.object_headers
+    mandatory = [key for key, header in headers.items() if header["mandatory"]]
+    missing_keys = set(mandatory).difference(set(self.headers.keys()))
+    missing = [headers[key]["display_name"] for key in missing_keys]
     if missing:
       self.add_error(errors.MISSING_COLUMN,
                      s="s" if len(missing) > 1 else "",
@@ -125,7 +125,8 @@ class RowConverter(object):
     """ Get object if the slug is in the system or return a new object """
     value = self.get_value(key)
     if value is None:
-      self.add_error(errors.MISSING_COLUMN, s="", column_names=key)
+      column_name = "Code" if key == slug else "Email"
+      self.add_error(errors.MISSING_COLUMN, s="", column_names=column_name)
       return
     obj = None
     self.is_new = False

--- a/src/ggrc/converters/handlers.py
+++ b/src/ggrc/converters/handlers.py
@@ -197,7 +197,7 @@ class UserColumnHandler(ColumnHandler):
       if email != "":
         self.add_warning(errors.UNKNOWN_USER_WARNING, email=email)
       elif self.mandatory:
-        self.add_error(errors.MISSING_VALUE_ERROR, column_name=self.key)
+        self.add_error(errors.MISSING_VALUE_ERROR, column_name=self.display_name)
     return person
 
   def get_value(self):

--- a/test/integration/ggrc/converters/test_multi_import_csv.py
+++ b/test/integration/ggrc/converters/test_multi_import_csv.py
@@ -87,10 +87,10 @@ class TestCsvImport(TestCase):
             line_list="21, 26, 27", column_name="Code", value="pro 1",
             s="s", ignore_lines="26, 27"),
         errors.OWNER_MISSING.format(line=26),
-        errors.MISSING_COLUMN.format(line=13, column_names="owners", s=""),
-        errors.MISSING_COLUMN.format(line=14, column_names="owners", s=""),
-        errors.MISSING_COLUMN.format(line=15, column_names="owners", s=""),
-        errors.MISSING_COLUMN.format(line=16, column_names="owners", s=""),
+        errors.MISSING_COLUMN.format(line=13, column_names="Owner", s=""),
+        errors.MISSING_COLUMN.format(line=14, column_names="Owner", s=""),
+        errors.MISSING_COLUMN.format(line=15, column_names="Owner", s=""),
+        errors.MISSING_COLUMN.format(line=16, column_names="Owner", s=""),
     ])
 
     self.assertEqual(expected_warnings, set(row_messages))


### PR DESCRIPTION
The error messages on imports should always display user facing names
and not actual model keys that are used on the back end.