### PR TITLE
CORE-2688 Trigger request auto-mappings

### DIFF
--- a/src/ggrc/automapper/__init__.py
+++ b/src/ggrc/automapper/__init__.py
@@ -11,6 +11,7 @@ from sqlalchemy import and_
 from datetime import datetime
 from ggrc import models
 from ggrc.models.relationship import Relationship
+from ggrc.models.request import Request
 from ggrc.services.common import Resource
 from ggrc import db
 from ggrc.automapper.rules import rules
@@ -109,6 +110,8 @@ class AutomapperGenerator(object):
       # it means that the mapping was already created by another request
       # and we can safely ignore it.
       inserter = Relationship.__table__.insert().prefix_with("IGNORE")
+      original = self.relate(Stub.from_source(self.relationship),
+                             Stub.from_destination(self.relationship))
       db.session.execute(inserter.values([{
           "id": None,
           "modified_by_id": current_user.id,
@@ -122,7 +125,8 @@ class AutomapperGenerator(object):
           "context_id": None,
           "status": None,
           "automapping_id": self.relationship.id}
-          for src, dst in self.auto_mappings]))
+          for src, dst in self.auto_mappings
+          if (src, dst) != original])) # (src, dst) is sorted
 
   def _step(self, src, dst):
       explicit, implicit = rules[src.type, dst.type]
@@ -185,3 +189,18 @@ def register_automapping_listeners():
       logging.warning("Automapping listener: no obj, no mappings created")
       return
     AutomapperGenerator(obj).generate_automappings()
+
+  @Resource.model_posted_after_commit.connect_via(Request)
+  @Resource.model_put_after_commit.connect_via(Request)
+  def handle_request(sender, obj=None, src=None, service=None):
+    if obj is None:
+      logging.warning("Automapping request listener: no obj, no mappings created")
+      return
+    if obj.audit is None:
+      logging.warning("Automapping request listener: no audit, no mappings created")
+      return
+    rel = Relationship(source_type=obj.type,
+                       source_id=obj.id,
+                       destination_type=obj.audit.type,
+                       destination_id=obj.audit.id)
+    handle_relationship_post(sender, obj=rel)

--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -610,10 +610,34 @@ class Resource(ModelView):
         :src: The original POSTed JSON dictionary.
         :service: The instance of Resource handling the POST request.
       """,)
+  model_posted_after_commit = signals.signal(
+      'Model POSTed - after',
+      """
+      Indicates that a model object was received via POST and has been
+      committed to the database. The sender in the signal will be the model
+      aclass of the POSTed resource. The following arguments will be sent along
+      with the signal:
+
+        :obj: The model instance created from the POSTed JSON.
+        :src: The original POSTed JSON dictionary.
+        :service: The instance of Resource handling the POST request.
+      """,)
   model_put = signals.signal(
       'Model PUT',
       """
       Indicates that a model object update was received via PUT and will be
+      updated in the database. The sender in the signal will be the model class
+      of the PUT resource. The following arguments will be sent along with the
+      signal:
+
+        :obj: The model instance updated from the PUT JSON.
+        :src: The original PUT JSON dictionary.
+        :service: The instance of Resource handling the PUT request.
+      """,)
+  model_put_after_commit = signals.signal(
+      'Model PUT - after',
+      """
+      Indicates that a model object update was received via PUT and has been
       updated in the database. The sender in the signal will be the model class
       of the PUT resource. The following arguments will be sent along with the
       signal:
@@ -627,6 +651,16 @@ class Resource(ModelView):
       """
       Indicates that a model object was DELETEd and will be removed from the
       databse. The sender in the signal will be the model class of the DELETEd
+      resource. The followin garguments will be sent along with the signal:
+
+        :obj: The model instance removed.
+        :service: The instance of Resource handling the DELETE request.
+      """,)
+  model_deleted_after_commit = signals.signal(
+      'Model DELETEd - after',
+      """
+      Indicates that a model object was DELETEd and has been removed from the
+      database. The sender in the signal will be the model class of the DELETEd
       resource. The followin garguments will be sent along with the signal:
 
         :obj: The model instance removed.
@@ -771,6 +805,9 @@ class Resource(ModelView):
       update_index(db.session, modified_objects)
     with benchmark("Update memcache after commit for resource collection PUT"):
       update_memcache_after_commit(self.request)
+    with benchmark("Send PUT - after commit event"):
+      self.model_put_after_commit.send(obj.__class__, obj=obj,
+                                       src=src, service=self)
     with benchmark("Serialize collection"):
       object_for_json = self.object_for_json(obj)
     with benchmark("Make response"):
@@ -816,6 +853,9 @@ class Resource(ModelView):
         update_index(db.session, modified_objects)
       with benchmark("Update memcache after commit for resource collection DELETE"):
         update_memcache_after_commit(self.request)
+      with benchmark("Send DELETEd - after commit event"):
+        self.model_deleted_after_commit.send(obj.__class__, obj=obj,
+                                             service=self)
       with benchmark("Query for object"):
         object_for_json = self.object_for_json(obj)
       with benchmark("Make response"):
@@ -1047,6 +1087,9 @@ class Resource(ModelView):
         update_index(db.session, modified_objects)
       with benchmark("Update memcache after commit for resource collection POST"):
         update_memcache_after_commit(self.request)
+      with benchmark("Send model POSTed - after commit event"):
+        self.model_posted_after_commit.send(obj.__class__, obj=obj,
+                                            src=src, service=self)
       with benchmark("Serialize object"):
         object_for_json = self.object_for_json(obj)
       with benchmark("Make response"):

--- a/test/integration/ggrc/automapper/test_automappings.py
+++ b/test/integration/ggrc/automapper/test_automappings.py
@@ -309,7 +309,5 @@ class TestAutomappings(integration.ggrc.TestCase):
         'requested_on': '1/1/2015',
         'due_on': '1/1/2016',
     })
-    self.assert_mapping_implication(
-        to_create=[(audit, request)],
-        implied=[(program, request)]
-    )
+    self.assert_mapping(request, program)
+    self.assert_mapping(request, audit, missing=True)

--- a/test/integration/ggrc/automapper/test_automappings.py
+++ b/test/integration/ggrc/automapper/test_automappings.py
@@ -300,6 +300,10 @@ class TestAutomappings(integration.ggrc.TestCase):
         'program': {'id': program.id},
         'status': 'Planned',
     })
+    control = self.create_object(models.Control, {
+        'title': next('Test control')
+    })
+    self.create_mapping(audit, control)
     request = self.create_object(models.Request, {
         'audit': {'id': audit.id},
         'title': next('Request'),
@@ -311,3 +315,4 @@ class TestAutomappings(integration.ggrc.TestCase):
     })
     self.assert_mapping(request, program)
     self.assert_mapping(request, audit, missing=True)
+    self.assert_mapping(request, control, missing=True)


### PR DESCRIPTION
This triggers auto-mappings based on the request-audit direct mapping. It is necessary because this mapping has not been transitioned to relationships in Zucchini.