### PR TITLE
CORE-2795 Limit audits in the request modal to editable

### DIFF
--- a/src/ggrc/assets/mustache/requests/modal_content.mustache
+++ b/src/ggrc/assets/mustache/requests/modal_content.mustache
@@ -27,7 +27,7 @@
       </label>
         <div class="objective-selector">
           {{#using audit=instance.audit }}
-            <input tabindex="11" type="text" name="audit.title" class="span12 search-icon" data-lookup="Audit" placeholder="Enter text to search for Audit" null-if-empty="false" value="{{firstnonempty audit.title ''}}">
+            <input tabindex="11" type="text" name="audit.title" class="span12 search-icon" data-lookup="Audit" data-permission-type="update" placeholder="Enter text to search for Audit" null-if-empty="false" value="{{firstnonempty audit.title ''}}">
           {{/using}}
         </div>
     </div>


### PR DESCRIPTION
Only show Audits where the current user has edit permissions because otherwise
we'll throw forbidden errors.