### PR TITLE
CORE-2675 Constrain Requests from Creator to owned audits

### DIFF
--- a/src/ggrc_basic_permissions/roles/Creator.py
+++ b/src/ggrc_basic_permissions/roles/Creator.py
@@ -300,7 +300,6 @@ permissions = {
             "condition": "is"
         },
         "Program",
-        "Request",
         "Context",
         {
             "type": "BackgroundTask",

--- a/src/ggrc_basic_permissions/roles/ProgramAuditReader.py
+++ b/src/ggrc_basic_permissions/roles/ProgramAuditReader.py
@@ -27,22 +27,10 @@ permissions = {
         "UserRole",
         "Context",
     ],
-    "create": [
-        "DocumentationResponse",
-        "InterviewResponse",
-        "Response",
-        "ObjectDocument",
-        "ObjectPerson",
-        "Relationship",
-        "Document"
-    ],
+    "create": [],
     "view_object_page": [
         "__GGRC_ALL__"
     ],
     "update": [],
-    "delete": [
-        "ObjectDocument",
-        "ObjectPerson",
-        "Relationship"
-    ]
+    "delete": []
 }


### PR DESCRIPTION
Creator should only be able to create requests for audits for which she has
update access. So she does not need a general Request create permission since
she inherits permission form the audit context.