### PR TITLE
QUICK-FIX Update request automapping test with valid status

### DIFF
--- a/test/integration/ggrc/automapper/test_automappings.py
+++ b/test/integration/ggrc/automapper/test_automappings.py
@@ -305,7 +305,7 @@ class TestAutomappings(integration.ggrc.TestCase):
         'title': next('Request'),
         'assignee': {'id': creator.id},
         'request_type': 'documentation',
-        'status': 'Draft',
+        'status': 'Unstarted',
         'requested_on': '1/1/2015',
         'due_on': '1/1/2016',
     })


### PR DESCRIPTION
This was causing a bogus warning in the test output.