### PR TITLE
CORE-2778 Allow auditor to create relationship in context

### DIFF
--- a/src/ggrc_basic_permissions/roles/Auditor.py
+++ b/src/ggrc_basic_permissions/roles/Auditor.py
@@ -30,6 +30,7 @@ permissions = {
         "Request",
         "ControlAssessment",
         "Issue",
+        "Relationship",
         "DocumentationResponse",
         "InterviewResponse",
         "PopulationSampleResponse",


### PR DESCRIPTION
This allows the auditor to map objects to the audit but not to unmap them while
not giving him edit permissions on the audit.