### PR TITLE
QUICK-FIX Allow auditors to CR comments in context

### DIFF
--- a/src/ggrc_basic_permissions/roles/Auditor.py
+++ b/src/ggrc_basic_permissions/roles/Auditor.py
@@ -24,6 +24,7 @@ permissions = {
         "Document",
         "Meeting",
         "UserRole",
+        "Comment",
         "Context",
     ],
     "create": [
@@ -34,6 +35,7 @@ permissions = {
         "DocumentationResponse",
         "InterviewResponse",
         "PopulationSampleResponse",
+        "Comment",
     ],
     "view_object_page": [
         "__GGRC_ALL__"


### PR DESCRIPTION
So they can respond on requests

Also see #3265 