### PR TITLE
QUICK-FIX: Fix Mustache debugger helper (multiple arguments)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -20,6 +20,7 @@ Reciprocity Labs, Inc
 "Urban Škudnik" <urban@reciprocitylabs.com>
 "Ivan Križnar" <ivan@reciprocitylabs.com>
 "Andraž Bajt" <andraz@reciprocitylabs.com>
+"Peter Lamut" <peter@reciprocitylabs.com>
 
 Google
 ======

--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -2933,11 +2933,13 @@ Mustache.registerHelper("if_draw_icon", function(instance, options) {
     return options.inverse(options.contexts);
 });
 
-Mustache.registerHelper("debugger", function (options) {
+Mustache.registerHelper("debugger", function () {
   // This just gives you a helper that you can wrap around some code in a
-  // template to see what's in the context. Set a breakpoint in dev tools
-  // on the return statement on the line below to debug.
+  // template to see what's in the context. Dev tools need to be open for this
+  // to work (in Chrome at least).
   debugger;
+
+  var options = arguments[arguments.length - 1];
   return options.fn(options.contexts);
 });
 

--- a/src/ggrc/assets/js_specs/mustache_helpers/debugger_spec.js
+++ b/src/ggrc/assets/js_specs/mustache_helpers/debugger_spec.js
@@ -1,0 +1,30 @@
+/*!
+  Copyright (C) 2015 Google Inc., authors, and contributors <see AUTHORS file>
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+  Created By: peter@reciprocitylabs.com
+  Maintained By: peter@reciprocitylabs.com
+*/
+
+describe("can.mustache.helper.debugger", function () {
+  var fakeOptions,
+      helper;
+
+  beforeAll(function () {
+    fakeOptions = {
+      fn: jasmine.createSpy()
+    };
+
+    helper = can.Mustache._helpers["debugger"].fn;
+  });
+
+  it("does not throw an error when called with more than one argument",
+    function () {
+      try {
+        helper(1, "foo", ["bar"], fakeOptions);
+      } catch (ex) {
+        fail("Helper threw an error: " + ex.message);
+      }
+    }
+  );
+
+});


### PR DESCRIPTION
It now works even if invoked with more than one argument (no error is thrown), e.g. by invoking it like the following in a template:

```js
{{debugger 1 2 foo="bar" 4 baz="qux"}}
```