### PR TITLE
QUICK-FIX Use dots reporter for karma tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,6 @@ before_script:
 script:
   - bin/run_travis_tests unit
   - bin/run_travis_tests integration
-  - ./node_modules/karma/bin/karma start karma.conf.js --single-run
+  - ./node_modules/karma/bin/karma start karma.conf.js --single-run --reporters dots
 notifications:
   email: false

--- a/bin/run_karma
+++ b/bin/run_karma
@@ -4,4 +4,4 @@
 # Created By: swizec@reciprocitylabs.com
 # Maintained By: swizec@reciprocitylabs.com
 
-karma start & watch_assets
+karma start --reporters dots & watch_assets


### PR DESCRIPTION
This makes the output of karma tests the same as the output of all our
other tests.