### PR TITLE
CORE-2825 Update tier2 menu in search

### DIFF
--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -136,6 +136,7 @@ dashboard-js-template-files:
   - base_objects/notes.mustache
   - base_objects/info.mustache
   - base_objects/dropdown_menu.mustache
+  - base_objects/dropdown_menu_tier2.mustache
   - base_objects/view_link.mustache
   - base_objects/unmap.mustache
   - base_objects/map_related_modal_content.mustache

--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -766,6 +766,14 @@ Mustache.registerHelper("get_permalink", function () {
   return window.location.href;
 });
 
+Mustache.registerHelper("get_permalink_for_object", function (instance, options) {
+  instance = resolve_computed(instance);
+  if (!instance.viewLink) {
+    return "";
+  }
+  return window.location.origin + instance.viewLink;
+});
+
 Mustache.registerHelper("get_view_link", function (instance, options) {
   function finish(link) {
     return "<a href=" + link + " target=\"_blank\"><i class=\"grcicon-to-right\"></i></a>";

--- a/src/ggrc/assets/js_specs/mustache_helpers/get_permalink_for_object_spec.js
+++ b/src/ggrc/assets/js_specs/mustache_helpers/get_permalink_for_object_spec.js
@@ -1,0 +1,36 @@
+/*!
+  Copyright (C) 2015 Google Inc., authors, and contributors <see AUTHORS file>
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+  Created By: jure@reciprocitylabs.com
+  Maintained By: jure@reciprocitylabs.com
+*/
+
+describe("can.mustache.helper.get_permalink_for_object", function () {
+  var fakeOptions,
+      helper;
+
+  beforeAll(function () {
+    fakeOptions = {
+      fn: jasmine.createSpy()
+    };
+
+    helper = can.Mustache._helpers["get_permalink_for_object"].fn;
+  });
+
+  it("concatenates window.location.origin and objects view link",
+    function () {
+      var instance = {
+        viewLink: "/facility/1"
+      };
+      expect(helper(instance)).toBe(window.location.origin + "/facility/1");
+    }
+  );
+
+  it("returns empty string when objects view link is not present",
+    function () {
+      var instance = {};
+      expect(helper(instance)).toBe("");
+    }
+  );
+
+});

--- a/src/ggrc/assets/mustache/base_objects/dropdown_menu_tier2.mustache
+++ b/src/ggrc/assets/mustache/base_objects/dropdown_menu_tier2.mustache
@@ -1,0 +1,46 @@
+{{!
+    Copyright (C) 2015 Google Inc., authors, and contributors <see AUTHORS file>
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+    Created By: jure@reciprocitylabs.com
+    Maintained By: jure@reciprocitylabs.com
+}}
+
+{{#if_helpers "\
+   #is_allowed" "view_object_page" instance "\
+   or #if" options.allow_mapping "\
+   or #is_allowed" "update" instance}}
+<div class="details-wrap">
+  <a class="btn btn-small btn-draft dropdown-toggle" href="#" data-toggle="dropdown"><i class="grcicon-setup-color"></i></a>
+  <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
+
+    {{> /static/mustache/base_objects/edit_object_link.mustache}}
+
+    <li>
+      <clipboard-link title="Get permalink" notify="true" text="{{get_permalink_for_object instance}}" />
+    </li>
+
+    {{> /static/mustache/base_objects/unmap.mustache}}
+
+    {{#if instance.viewLink}}
+      {{#is_allowed "view_object_page" instance}}
+        <li>
+          <a href="{{instance.viewLink}}">
+            <i class="grcicon-goto"></i>
+            View {{instance.class.title_singular}}
+          </a>
+        </li>
+      {{/is_allowed}}
+    {{/if}}
+
+    {{#is_allowed 'delete' instance}}
+      <li>
+        <a data-toggle="modal-ajax-deleteform" data-object-plural="{{instance.class.model_plural}}" data-object-singular="{{instance.class.model_singular}}" data-modal-reset="reset" data-modal-class="modal" data-object-id="{{instance.id}}" href="javascript://">
+          <i class="grcicon-deleted"></i>
+          Delete
+        </a>
+      </li>
+    {{/is_allowed}}
+
+  </ul>
+</div>
+{{/if_helpers}}

--- a/src/ggrc/assets/mustache/base_objects/tier2_content.mustache
+++ b/src/ggrc/assets/mustache/base_objects/tier2_content.mustache
@@ -5,28 +5,7 @@
     Maintained By: brad@reciprocitylabs.com
 }}
 
-{{#if_helpers "\
-   #is_allowed" "view_object_page" instance "\
-   or #if" options.allow_mapping "\
-   or #is_allowed" "update" instance}}
-<div class="details-wrap">
-  <a class="btn btn-small btn-draft dropdown-toggle" href="#" data-toggle="dropdown"><i class="grcicon-setup-color"></i></a>
-  <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
-    {{#if instance.viewLink}}
-      {{#is_allowed "view_object_page" instance}}
-        <li>
-          <a href="{{instance.viewLink}}">
-            <i class="grcicon-goto"></i>
-            View {{instance.class.title_singular}}
-          </a>
-        </li>
-      {{/is_allowed}}
-    {{/if}}
-    {{> /static/mustache/base_objects/unmap.mustache}}
-    {{> /static/mustache/base_objects/edit_object_link.mustache}}
-  </ul>
-</div>
-{{/if_helpers}}
+{{> /static/mustache/base_objects/dropdown_menu_tier2.mustache}}
 
 <div class="tier-content">
   {{{render '/static/mustache/base_objects/general_info.mustache' instance=instance }}}

--- a/src/ggrc/assets/mustache/controls/tier2_content.mustache
+++ b/src/ggrc/assets/mustache/controls/tier2_content.mustache
@@ -5,28 +5,7 @@
     Maintained By: brad@reciprocitylabs.com
 }}
 
-{{#if_helpers "\
-   #is_allowed" "view_object_page" instance "\
-   or #if" options.allow_mapping "\
-   or #is_allowed" "update" instance}}
-<div class="details-wrap">
-  <a class="btn btn-small btn-draft dropdown-toggle" href="#" data-toggle="dropdown"><i class="grcicon-setup-color"></i></a>
-  <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
-    {{#if instance.viewLink}}
-      {{#is_allowed "view_object_page" instance}}
-        <li>
-          <a href="{{instance.viewLink}}">
-            <i class="grcicon-goto"></i>
-            View {{instance.class.title_singular}}
-          </a>
-        </li>
-      {{/is_allowed}}
-    {{/if}}
-    {{> /static/mustache/base_objects/unmap.mustache}}
-    {{> /static/mustache/base_objects/edit_object_link.mustache}}
-  </ul>
-</div>
-{{/if_helpers}}
+{{> /static/mustache/base_objects/dropdown_menu_tier2.mustache}}
 
 <div class="tier-content">
   {{{render '/static/mustache/base_objects/general_info.mustache' instance=instance }}}

--- a/src/ggrc/assets/mustache/directives/tier2_content.mustache
+++ b/src/ggrc/assets/mustache/directives/tier2_content.mustache
@@ -5,28 +5,7 @@
     Maintained By: brad@reciprocitylabs.com
 }}
 
-{{#if_helpers "\
-   #is_allowed" "view_object_page" instance "\
-   or #if" options.allow_mapping "\
-   or #is_allowed" "update" instance}}
-<div class="details-wrap">
-  <a class="btn btn-small btn-draft dropdown-toggle" href="#" data-toggle="dropdown"><i class="grcicon-setup-color"></i></a>
-  <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
-    {{#if instance.viewLink}}
-      {{#is_allowed "view_object_page" instance}}
-        <li>
-          <a href="{{instance.viewLink}}">
-            <i class="grcicon-goto"></i>
-            View {{instance.class.title_singular}}
-          </a>
-        </li>
-      {{/is_allowed}}
-    {{/if}}
-    {{> /static/mustache/base_objects/unmap.mustache}}
-    {{> /static/mustache/base_objects/edit_object_link.mustache}}
-  </ul>
-</div>
-{{/if_helpers}}
+{{> /static/mustache/base_objects/dropdown_menu_tier2.mustache}}
 
 <div class="tier-content">
   {{{render '/static/mustache/base_objects/general_info.mustache' instance=instance }}}

--- a/src/ggrc/assets/mustache/documents/tier2_content.mustache
+++ b/src/ggrc/assets/mustache/documents/tier2_content.mustache
@@ -5,38 +5,7 @@
     Maintained By: brad@reciprocitylabs.com
 }}
 
-{{#if_helpers "\
-   #is_allowed" "view_object_page" instance "\
-   or ^is_dashboard" "\
-   or #is_allowed" "update" instance}}
-<div class="details-wrap">
-  <a class="btn btn-small btn-draft dropdown-toggle" href="#" data-toggle="dropdown"><i class="grcicon-setup-color"></i></a>
-  <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
-    {{#if instance.viewLink}}
-      {{#is_allowed "view_object_page" instance}}
-        <a href="{{instance.viewLink}}" class="info-action">
-          <i class="grcicon-goto"></i>
-          View {{instance.class.title_singular}}
-        </a>
-      {{/is_allowed}}
-    {{/if}}
-    {{#if mappings}}
-    {{#is_allowed_all 'delete' mappings}}
-    {{^is_dashboard}}
-      <li class="border">
-        <a href="javascript://" class="info-action unmap pull-right" data-toggle="unmap">
-          {{#result}}<span class="result" {{data 'result'}}></span>{{/result}}
-          <i class="grcicon-remove"></i>
-          Unmap
-        </a>
-      </li>
-    {{/is_dashboard}}
-    {{/is_allowed_all}}
-    {{/if}}
-    {{> /static/mustache/base_objects/edit_object_link.mustache}}
-  </ul>
-</div>
-{{/if_helpers}}
+{{> /static/mustache/base_objects/dropdown_menu_tier2.mustache}}
 
 <div class="tier-content">
   {{#instance.description}}

--- a/src/ggrc/assets/mustache/objectives/tier2_content.mustache
+++ b/src/ggrc/assets/mustache/objectives/tier2_content.mustache
@@ -5,28 +5,7 @@
     Maintained By: brad@reciprocitylabs.com
 }}
 
-{{#if_helpers "\
-   #is_allowed" "view_object_page" instance "\
-   or #if" options.allow_mapping "\
-   or #is_allowed" "update" instance}}
-<div class="details-wrap">
-  <a class="btn btn-small btn-draft dropdown-toggle" href="#" data-toggle="dropdown"><i class="grcicon-setup-color"></i></a>
-  <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
-    {{#if instance.viewLink}}
-      {{#is_allowed "view_object_page" instance}}
-        <li>
-          <a href="{{instance.viewLink}}">
-            <i class="grcicon-goto"></i>
-            View {{instance.class.title_singular}}
-          </a>
-        </li>
-      {{/is_allowed}}
-    {{/if}}
-    {{> /static/mustache/base_objects/unmap.mustache}}
-    {{> /static/mustache/base_objects/edit_object_link.mustache}}
-  </ul>
-</div>
-{{/if_helpers}}
+{{> /static/mustache/base_objects/dropdown_menu_tier2.mustache}}
 
 <div class="tier-content">
   {{{render '/static/mustache/base_objects/general_info.mustache' instance=instance }}}

--- a/src/ggrc/assets/mustache/people/tier2_content.mustache
+++ b/src/ggrc/assets/mustache/people/tier2_content.mustache
@@ -5,30 +5,7 @@
     Maintained By: brad@reciprocitylabs.com
 }}
 
-{{#if_helpers "\
-   #is_allowed" "view_object_page" instance "\
-   or #if" options.allowed_mapping}}
-<div class="details-wrap">
-  <a class="btn btn-small btn-draft dropdown-toggle" href="#" data-toggle="dropdown"><i class="grcicon-setup-color"></i></a>
-  <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
-    {{#if instance.viewLink}}
-      {{#is_allowed "view_object_page" instance}}
-        <li>
-          <a href="{{instance.viewLink}}">
-            <i class="grcicon-goto"></i>
-            View {{instance.class.title_singular}}
-          </a>
-        </li>
-      {{/is_allowed}}
-    {{/if}}
-    {{#if is_in_selector}}
-    {{else}}
-      {{> /static/mustache/base_objects/unmap.mustache}}
-    {{/if}}
-  </ul>
-</div>
-{{/if_helpers}}
-
+{{> /static/mustache/base_objects/dropdown_menu_tier2.mustache}}
 
 <div class="tier-content">
   {{#if instance.email}}

--- a/src/ggrc/assets/mustache/programs/tier2_content.mustache
+++ b/src/ggrc/assets/mustache/programs/tier2_content.mustache
@@ -5,29 +5,7 @@
     Maintained By: brad@reciprocitylabs.com
 }}
 
-{{#if_helpers "\
-   #if" options.allow_mapping "\
-   or #is_allowed" "update" instance "\
-   or #is_allowed" "view_object_page" "Program" "\
-   " _2_context=instance.context}}
-<div class="details-wrap">
-  <a class="btn btn-small btn-draft dropdown-toggle" href="#" data-toggle="dropdown"><i class="grcicon-setup-color"></i></a>
-  <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
-    {{#if instance.viewLink}}
-      {{#is_allowed 'view_object_page' 'Program' context=instance.context}}
-        <li>
-          <a href="{{instance.viewLink}}">
-            <i class="grcicon-goto"></i>
-            View {{instance.class.title_singular}}
-          </a>
-        </li>
-      {{/is_allowed}}
-    {{/if}}
-    {{> /static/mustache/base_objects/unmap.mustache}}
-    {{> /static/mustache/base_objects/edit_object_link.mustache}}
-  </ul>
-</div>
-{{/if_helpers}}
+{{> /static/mustache/base_objects/dropdown_menu_tier2.mustache}}
 
 <div class="tier-content">
   {{{render '/static/mustache/base_objects/general_info.mustache' instance=instance }}}

--- a/src/ggrc/assets/mustache/requests/tier2_content.mustache
+++ b/src/ggrc/assets/mustache/requests/tier2_content.mustache
@@ -5,28 +5,7 @@
     Maintained By: ivan@reciprocitylabs.com
 }}
 
-{{#if_helpers "\
-   #is_allowed" "view_object_page" instance "\
-   or #if" options.allow_mapping "\
-   or #is_allowed" "update" instance}}
-<div class="details-wrap">
-  <a class="btn btn-small btn-draft dropdown-toggle" href="#" data-toggle="dropdown"><i class="grcicon-setup-color"></i></a>
-  <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
-    {{#if instance.viewLink}}
-      {{#is_allowed "view_object_page" instance}}
-        <li>
-          <a href="{{instance.viewLink}}">
-            <i class="grcicon-goto"></i>
-            View {{instance.class.title_singular}}
-          </a>
-        </li>
-      {{/is_allowed}}
-    {{/if}}
-    {{> /static/mustache/base_objects/unmap.mustache}}
-    {{> /static/mustache/base_objects/edit_object_link.mustache}}
-  </ul>
-</div>
-{{/if_helpers}}
+{{> /static/mustache/base_objects/dropdown_menu_tier2.mustache}}
 
 <div class="tier-content">
   {{{render '/static/mustache/requests/general_info.mustache' instance=instance }}}

--- a/src/ggrc_workflows/assets/mustache/tasks/tier2_content.mustache
+++ b/src/ggrc_workflows/assets/mustache/tasks/tier2_content.mustache
@@ -5,36 +5,7 @@
     Maintained By: ivan@reciprocitylabs.com
 }}
 
-        <div class="row-fluid">
-          <!-- View Task link -->
-          <div class="span6">
-          {{#if instance.viewLink}}
-            {{#is_allowed "view_object_page" instance}}
-              <a href="{{instance.viewLink}}" class="info-action">
-                <i class="grcicon-goto"></i>
-                View {{instance.class.title_singular}}
-              </a>
-            {{/is_allowed}}
-          {{/if}}
-          </div>
-
-          <!-- edit and unmap link -->
-          <div class="span6">
-          {{#if mappings}}
-          {{#is_allowed_all 'delete' mappings}}
-          {{^is_dashboard}}
-            <a href="javascript://" class="info-action unmap pull-right" data-toggle="unmap">
-              {{#result}}<span class="result" {{data 'result'}}></span>{{/result}}
-              <i class="grcicon-remove"></i>
-              Unmap
-            </a>
-          {{/is_dashboard}}
-          {{/is_allowed_all}}
-          {{/if}}
-          {{> /static/mustache/base_objects/edit_object_link.mustache}}
-          </div>
-
-        </div>
+{{> /static/mustache/base_objects/dropdown_menu_tier2.mustache}}
 
         <!-- description -->
         {{#instance.description}}

--- a/src/ggrc_workflows/assets/mustache/workflows/tier2_content.mustache
+++ b/src/ggrc_workflows/assets/mustache/workflows/tier2_content.mustache
@@ -5,20 +5,7 @@
     Maintained By: ivan@reciprocitylabs.com
 }}
 
-{{#if_helpers "\
-   #if" instance.viewLink "\
-   or #if" options.allow_mapping "\
-   or #is_allowed" "update" instance "\
-   " _2_context='for'}}
-<div class="details-wrap">
-  <a class="btn btn-small btn-draft dropdown-toggle" href="#" data-toggle="dropdown"><i class="grcicon-setup-color"></i></a>
-  <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
-    {{> /static/mustache/base_objects/view_link.mustache }}
-    {{> /static/mustache/base_objects/unmap.mustache}}
-    {{> /static/mustache/base_objects/edit_object_link.mustache}}
-  </ul>
-</div>
-{{/if_helpers}}
+{{> /static/mustache/base_objects/dropdown_menu_tier2.mustache}}
 
 <div class="tier-content">
   {{{render '/static/mustache/base_objects/general_info.mustache' instance=instance }}}


### PR DESCRIPTION
This PR removes a bunch of tier2 templates, so that the default template in base_objects is used.

"Get permalink" doesn't yet work as expected.