### PR TITLE
CORE-2779 CORE-2888 Fix relationship access filter for creator

### DIFF
--- a/src/ggrc/assets/javascripts/components/people_list.js
+++ b/src/ggrc/assets/javascripts/components/people_list.js
@@ -78,6 +78,7 @@
             destination.mark_for_addition("related_objects_as_destination", person, {
               attrs: {
                 "AssigneeType": role,
+                "context": destination.context,
               }
             });
           }
@@ -93,7 +94,7 @@
                 type: person.type,
                 id: person.id
               },
-              context: {},
+              context: destination.context,
               destination: {
                 href: destination.href,
                 type: destination.type,

--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -1350,9 +1350,14 @@ def filter_resource(resource, depth=0, user_permissions=None):
         if not inst:
           # If object was deleted but relationship still exists
           continue
-        contexts = permissions.read_contexts_for(inst['type']) or []
+        contexts = permissions.read_contexts_for(inst['type'])
+        if contexts is None:
+          # read_contexts_for returns None if the user has access to all the
+          # objects of this type. If the user doesn't have access to any object
+          # an empty list ([]) will be returned
+          continue
         resources = permissions.read_resources_for(inst['type']) or []
-        if None in contexts or inst['context_id'] in contexts or inst['id'] in resources:
+        if inst['context_id'] in contexts or inst['id'] in resources:
           continue
         can_read = False
       if not can_read:

--- a/test/integration/ggrc/converters/test_import_block_order.py
+++ b/test/integration/ggrc/converters/test_import_block_order.py
@@ -18,38 +18,38 @@ class TestBasicCsvImport(TestCase):
   def test_people_import(self):
     filename = "people_basic_import.csv"
     self.import_file(filename)
-    self.assertEquals(5, Person.query.count())
+    self.assertEqual(5, Person.query.count())
 
   def test_people_import_correct_order_dry_run(self):
     filename = "people_import_correct_order.csv"
     response = self.import_file(filename, dry_run=True)
-    self.assertEquals(1, Person.query.count())
-    self.assertEquals(response[1]["name"], "Org Group")
-    self.assertEquals(set(), set(response[1]["row_warnings"]))
-    self.assertEquals(set(), set(response[1]["row_errors"]))
+    self.assertEqual(1, Person.query.count())
+    self.assertEqual(response[1]["name"], "Org Group")
+    self.assertEqual(set(), set(response[1]["row_warnings"]))
+    self.assertEqual(set(), set(response[1]["row_errors"]))
 
   def test_people_import_wrong_order_dry_run(self):
     filename = "people_import_correct_order.csv"
     filename = "people_import_wrong_order.csv"
     response = self.import_file(filename, dry_run=True)
-    self.assertEquals(1, Person.query.count())
-    self.assertEquals(response[1]["name"], "Org Group")
-    self.assertEquals(set(), set(response[1]["row_warnings"]))
-    self.assertEquals(set(), set(response[1]["row_errors"]))
+    self.assertEqual(1, Person.query.count())
+    self.assertEqual(response[1]["name"], "Org Group")
+    self.assertEqual(set(), set(response[1]["row_warnings"]))
+    self.assertEqual(set(), set(response[1]["row_errors"]))
 
   def test_people_import_correct_order(self):
     filename = "people_import_correct_order.csv"
     response = self.import_file(filename)
-    self.assertEquals(5, Person.query.count())
-    self.assertEquals(response[1]["name"], "Org Group")
-    self.assertEquals(set(), set(response[1]["row_warnings"]))
-    self.assertEquals(set(), set(response[1]["row_errors"]))
+    self.assertEqual(5, Person.query.count())
+    self.assertEqual(response[1]["name"], "Org Group")
+    self.assertEqual(set(), set(response[1]["row_warnings"]))
+    self.assertEqual(set(), set(response[1]["row_errors"]))
 
   def test_people_import_wrong_order(self):
     filename = "people_import_correct_order.csv"
     filename = "people_import_wrong_order.csv"
     response = self.import_file(filename)
-    self.assertEquals(5, Person.query.count())
-    self.assertEquals(response[1]["name"], "Org Group")
-    self.assertEquals(set(), set(response[1]["row_warnings"]))
-    self.assertEquals(set(), set(response[1]["row_errors"]))
+    self.assertEqual(5, Person.query.count())
+    self.assertEqual(response[1]["name"], "Org Group")
+    self.assertEqual(set(), set(response[1]["row_warnings"]))
+    self.assertEqual(set(), set(response[1]["row_errors"]))

--- a/test/integration/ggrc/converters/test_import_csv.py
+++ b/test/integration/ggrc/converters/test_import_csv.py
@@ -142,15 +142,15 @@ class TestBasicCsvImport(converters.TestCase):
 
     for response_block in response:
       for message in messages:
-        self.assertEquals(set(), set(response_block[message]))
+        self.assertEqual(set(), set(response_block[message]))
 
     ca = models.ControlAssessment.query.filter_by(slug="CA.PCI 1.1").first()
     au = models.Audit.query.filter_by(slug="AUDIT-Consolidated").first()
-    self.assertEquals(len(ca.owners), 1)
-    self.assertEquals(ca.owners[0].email, "danny@reciprocitylabs.com")
-    self.assertEquals(ca.contact.email, "danny@reciprocitylabs.com")
-    self.assertEquals(ca.design, "Effective")
-    self.assertEquals(ca.operationally, "Effective")
+    self.assertEqual(len(ca.owners), 1)
+    self.assertEqual(ca.owners[0].email, "danny@reciprocitylabs.com")
+    self.assertEqual(ca.contact.email, "danny@reciprocitylabs.com")
+    self.assertEqual(ca.design, "Effective")
+    self.assertEqual(ca.operationally, "Effective")
     self.assertIsNone(models.Relationship.find_related(ca, au))
 
     filename = "pci_program_update.csv"
@@ -158,14 +158,14 @@ class TestBasicCsvImport(converters.TestCase):
 
     for response_block in response:
       for message in messages:
-        self.assertEquals(set(), set(response_block[message]))
+        self.assertEqual(set(), set(response_block[message]))
 
     ca = models.ControlAssessment.query.filter_by(slug="CA.PCI 1.1").first()
     au = models.Audit.query.filter_by(slug="AUDIT-Consolidated").first()
-    self.assertEquals(ca.owners[0].email, "miha@reciprocitylabs.com")
-    self.assertEquals(ca.contact.email, "albert@reciprocitylabs.com")
-    self.assertEquals(ca.design, "Needs improvement")
-    self.assertEquals(ca.operationally, "Ineffective")
+    self.assertEqual(ca.owners[0].email, "miha@reciprocitylabs.com")
+    self.assertEqual(ca.contact.email, "albert@reciprocitylabs.com")
+    self.assertEqual(ca.design, "Needs improvement")
+    self.assertEqual(ca.operationally, "Ineffective")
     self.assertIsNotNone(models.Relationship.find_related(ca, au))
 
   def test_person_imports(self):

--- a/test/integration/ggrc/converters/test_import_special_objects.py
+++ b/test/integration/ggrc/converters/test_import_special_objects.py
@@ -30,20 +30,20 @@ class TestSpecialObjects(TestCase):
 
     filename = "program_audit.csv"
     self.import_file(filename)
-    self.assertEquals(2, Audit.query.count())
+    self.assertEqual(2, Audit.query.count())
     audit = Audit.query.filter(Audit.slug == "Aud-1").first()
     program = Program.query.filter(Program.slug == "prog-1").first()
-    self.assertEquals(audit.program_id, program.id)
+    self.assertEqual(audit.program_id, program.id)
 
   def test_program_roles_imports(self):
     """ this tests if the audit gets imported with a mapped program """
 
     filename = "program_audit.csv"
     self.import_file(filename)
-    self.assertEquals(2, Program.query.count())
+    self.assertEqual(2, Program.query.count())
     program = Program.query.filter(Program.slug == "prog-1").first()
     p1_roles = UserRole.query.filter_by(context_id=program.context_id).all()
-    self.assertEquals(5, len(p1_roles))
+    self.assertEqual(5, len(p1_roles))
     owner_ids = [r.person_id for r in p1_roles if r.role_id == 1]
     editor_ids = [r.person_id for r in p1_roles if r.role_id == 2]
     reader_ids = [r.person_id for r in p1_roles if r.role_id == 3]

--- a/test/integration/ggrc/converters/test_import_update.py
+++ b/test/integration/ggrc/converters/test_import_update.py
@@ -23,10 +23,10 @@ class TestImportUpdates(TestCase):
     response = self.import_file(filename)
     for block in response:
       for message in messages:
-        self.assertEquals(set(), set(block[message]))
+        self.assertEqual(set(), set(block[message]))
 
     filename = "policy_basic_import_update.csv"
     response = self.import_file(filename)
     for block in response:
       for message in messages:
-        self.assertEquals(set(), set(block[message]))
+        self.assertEqual(set(), set(block[message]))

--- a/test/integration/ggrc/converters/test_multi_import_csv.py
+++ b/test/integration/ggrc/converters/test_multi_import_csv.py
@@ -135,23 +135,23 @@ class TestCsvImport(TestCase):
   def test_big_import_with_mappings(self):
     response = self.import_file("data_for_export_testing.csv")
     for block in response:
-      self.assertEquals(set(), set(block["row_warnings"]),
+      self.assertEqual(set(), set(block["row_warnings"]),
                         json.dumps(block, indent=2, sort_keys=True))
-      self.assertEquals(set(), set(block["row_errors"]),
+      self.assertEqual(set(), set(block["row_errors"]),
                         json.dumps(block, indent=2, sort_keys=True))
-      self.assertEquals(set(), set(block["block_warnings"]),
+      self.assertEqual(set(), set(block["block_warnings"]),
                         json.dumps(block, indent=2, sort_keys=True))
-      self.assertEquals(set(), set(block["block_errors"]),
+      self.assertEqual(set(), set(block["block_errors"]),
                         json.dumps(block, indent=2, sort_keys=True))
 
   def test_big_import_with_mappings_dry_run(self):
     response = self.import_file("data_for_export_testing.csv", dry_run=True)
     for block in response:
-      self.assertEquals(set(), set(block["row_warnings"]),
+      self.assertEqual(set(), set(block["row_warnings"]),
                         json.dumps(block, indent=2, sort_keys=True))
-      self.assertEquals(set(), set(block["row_errors"]),
+      self.assertEqual(set(), set(block["row_errors"]),
                         json.dumps(block, indent=2, sort_keys=True))
-      self.assertEquals(set(), set(block["block_warnings"]),
+      self.assertEqual(set(), set(block["block_warnings"]),
                         json.dumps(block, indent=2, sort_keys=True))
-      self.assertEquals(set(), set(block["block_errors"]),
+      self.assertEqual(set(), set(block["block_errors"]),
                         json.dumps(block, indent=2, sort_keys=True))

--- a/test/integration/ggrc/services/test_common.py
+++ b/test/integration/ggrc/services/test_common.py
@@ -107,7 +107,7 @@ class TestResource(TestCase):
     self.assertIn('Last-Modified', response.headers)
     self.assertIn('Content-Type', response.headers)
     for k, v in headers.items():
-      self.assertEquals(v, response.headers.get(k))
+      self.assertEqual(v, response.headers.get(k))
 
   def assertAllow(self, response, allowed=None):
     self.assert405(response)

--- a/test/integration/ggrc_basic_permissions/test_creator.py
+++ b/test/integration/ggrc_basic_permissions/test_creator.py
@@ -38,7 +38,7 @@ class TestCreator(TestCase):
   def test_admin_page_access(self):
     for role, code in (("creator", 403), ("admin", 200)):
       self.api.set_user(self.users[role])
-      self.assertEquals(self.api.tc.get("/admin").status_code, code)
+      self.assertEqual(self.api.tc.get("/admin").status_code, code)
 
   def test_creator_can_crud(self):
     """ Test Basic create/read,update/delete operations """
@@ -118,7 +118,7 @@ class TestCreator(TestCase):
       except:
           all_errors.append("{} exception thrown".format(model_singular))
           raise
-    self.assertEquals(all_errors, [])
+    self.assertEqual(all_errors, [])
 
   def test_creator_search(self):
     """ Test if creator can see the correct object while using the search api """
@@ -141,11 +141,11 @@ class TestCreator(TestCase):
         }, "context": None}})
     response, _ = self.api.search("Regulation,Policy")
     entries = response.json["results"]["entries"]
-    self.assertEquals(len(entries), 1)
-    self.assertEquals(entries[0]["type"], "Policy")
+    self.assertEqual(len(entries), 1)
+    self.assertEqual(entries[0]["type"], "Policy")
     response, _ = self.api.search("Regulation,Policy", counts=True)
-    self.assertEquals(response.json["results"]["counts"]["Policy"], 1)
-    self.assertEquals(
+    self.assertEqual(response.json["results"]["counts"]["Policy"], 1)
+    self.assertEqual(
         response.json["results"]["counts"].get("Regulation"), None)
 
   def _get_count(self, obj):
@@ -159,7 +159,7 @@ class TestCreator(TestCase):
     admin_count = self._get_count("Person")
     self.api.set_user(self.users['creator'])
     creator_count = self._get_count("Person")
-    self.assertEquals(admin_count, creator_count)
+    self.assertEqual(admin_count, creator_count)
 
   def test_creator_cannot_be_owner(self):
     """ Test if creater cannot become owner of the object he has not created """
@@ -176,7 +176,7 @@ class TestCreator(TestCase):
             "type": "Regulation",
             "id": obj.id,
         }, "context": None}})
-    self.assertEquals(response.status_code, 403)
+    self.assertEqual(response.status_code, 403)
 
   def test_relationships_access(self):
     """Check if creator cannot access relationship objects"""
@@ -197,9 +197,9 @@ class TestCreator(TestCase):
         }, "context": None},
     })
     relationship_id = rel.id
-    self.assertEquals(response.status_code, 201)
+    self.assertEqual(response.status_code, 201)
     self.api.set_user(self.users['creator'])
     response = self.api.get_collection(all_models.Relationship, relationship_id)
-    self.assertEquals(response.status_code, 200)
+    self.assertEqual(response.status_code, 200)
     num = len(response.json["relationships_collection"]["relationships"])
-    self.assertEquals(num, 0)
+    self.assertEqual(num, 0)

--- a/test/integration/ggrc_basic_permissions/test_creator_program.py
+++ b/test/integration/ggrc_basic_permissions/test_creator_program.py
@@ -198,7 +198,7 @@ class TestCreatorProgram(TestCase):
     response = self.api.post(all_models.Program, {
         "program": {"title": random_title, "context": None},
     })
-    self.assertEquals(response.status_code, 201)
+    self.assertEqual(response.status_code, 201)
     context_id = response.json.get("program").get("context").get("id")
     program_id = response.json.get("program").get("id")
     self.objects["program"] = all_models.Program.query.get(program_id)
@@ -208,7 +208,7 @@ class TestCreatorProgram(TestCase):
       response = self.api.post(all_models.System, {
           "system": {"title": random_title, "context": None},
       })
-      self.assertEquals(response.status_code, 201)
+      self.assertEqual(response.status_code, 201)
       system_id = response.json.get("system").get("id")
       self.objects[obj] = all_models.System.query.get(system_id)
       # Become the owner
@@ -230,7 +230,7 @@ class TestCreatorProgram(TestCase):
             "type": "System"
         }, "context": None},
     })
-    self.assertEquals(response.status_code, 201)
+    self.assertEqual(response.status_code, 201)
 
     # Map people to Program:
     if test_case_name != "notmapped":
@@ -268,7 +268,7 @@ class TestCreatorProgram(TestCase):
               "id": context_id,
               "href": "/api/contexts/{}".format(context_id)
           }}})
-      self.assertEquals(response.status_code, 201)
+      self.assertEqual(response.status_code, 201)
 
   def test_creator_program_roles(self):
     """ Test creator role with all program scoped roles """
@@ -293,7 +293,7 @@ class TestCreatorProgram(TestCase):
                 "{}: Tried {} on {}, but received {} instead of {}".format(
                     test_case, action, obj, res, actions[action]))
       # Try mapping
-    self.assertEquals(errors, [])
+    self.assertEqual(errors, [])
 
   def test_creator_audit_request_creation(self):
     self.init_objects("ProgramOwner")
@@ -319,7 +319,7 @@ class TestCreatorProgram(TestCase):
             }
         },
     })
-    self.assertEquals(response.status_code, 201)
+    self.assertEqual(response.status_code, 201)
     audit_id = response.json.get("audit").get("id")
     audit_context_id = response.json.get("audit").get("context").get("id")
     # Create a request
@@ -340,7 +340,7 @@ class TestCreatorProgram(TestCase):
             "request_type": "documentation"
         },
     })
-    self.assertEquals(response.status_code, 201)
+    self.assertEqual(response.status_code, 201)
     request_id = response.json.get("request").get("id")
 
     # Create assignee/requester relationships
@@ -364,8 +364,8 @@ class TestCreatorProgram(TestCase):
             }
         },
     })
-    self.assertEquals(response.status_code, 201)
+    self.assertEqual(response.status_code, 201)
     relationship_id = response.json.get("relationship").get("id")
     response = self.api.get_collection(all_models.Relationship, relationship_id)
     num = len(response.json["relationships_collection"]["relationships"])
-    self.assertEquals(num, 2)
+    self.assertEqual(num, 2)

--- a/test/integration/ggrc_basic_permissions/test_reader.py
+++ b/test/integration/ggrc_basic_permissions/test_reader.py
@@ -38,7 +38,7 @@ class TestReader(TestCase):
     return
     for role, code in (("reader", 403), ("admin", 200)):
       self.api.set_user(self.users[role])
-      self.assertEquals(self.api.tc.get("/admin").status_code, code)
+      self.assertEqual(self.api.tc.get("/admin").status_code, code)
 
   def test_reader_can_crud(self):
     return
@@ -95,7 +95,7 @@ class TestReader(TestCase):
       except:
           all_errors.append("{} exception thrown".format(model_singular))
           raise
-    self.assertEquals(all_errors, [])
+    self.assertEqual(all_errors, [])
 
   def test_reader_search(self):
     return
@@ -119,10 +119,10 @@ class TestReader(TestCase):
         }, "context": None}})
     response, _ = self.api.search("Regulation,Policy")
     entries = response.json["results"]["entries"]
-    self.assertEquals(len(entries), 2)
+    self.assertEqual(len(entries), 2)
     response, _ = self.api.search("Regulation,Policy", counts=True)
-    self.assertEquals(response.json["results"]["counts"]["Policy"], 1)
-    self.assertEquals(response.json["results"]["counts"]["Regulation"], 1)
+    self.assertEqual(response.json["results"]["counts"]["Policy"], 1)
+    self.assertEqual(response.json["results"]["counts"]["Regulation"], 1)
 
   def _get_count(self, obj):
     """ Return the number of counts for the given object from search """
@@ -135,7 +135,7 @@ class TestReader(TestCase):
     admin_count = self._get_count("Person")
     self.api.set_user(self.users['reader'])
     reader_count = self._get_count("Person")
-    self.assertEquals(admin_count, reader_count)
+    self.assertEqual(admin_count, reader_count)
 
   def test_reader_cannot_be_owner(self):
     """ Test if reader cannot become owner of the object he has not created """
@@ -152,7 +152,7 @@ class TestReader(TestCase):
             "type": "Regulation",
             "id": obj.id,
         }, "context": None}})
-    self.assertEquals(response.status_code, 403)
+    self.assertEqual(response.status_code, 403)
 
   def test_relationships_access(self):
     """Check if reader can access relationship objects"""
@@ -175,13 +175,13 @@ class TestReader(TestCase):
         }
     )
     relationship_id = rel.id
-    self.assertEquals(response.status_code, 201)
+    self.assertEqual(response.status_code, 201)
     self.api.set_user(self.users['reader'])
     response = self.api.get_collection(all_models.Relationship,
                                        relationship_id)
-    self.assertEquals(response.status_code, 200)
+    self.assertEqual(response.status_code, 200)
     num = len(response.json["relationships_collection"]["relationships"])
-    self.assertEquals(num, 1)
+    self.assertEqual(num, 1)
 
   def test_creation_of_mappings(self):
     self.generator.api.set_user(self.users["admin"])
@@ -206,4 +206,4 @@ class TestReader(TestCase):
                 "type": "context"
             }},
         })
-    self.assertEquals(response.status_code, 403)
+    self.assertEqual(response.status_code, 403)

--- a/test/integration/ggrc_workflows/converters/test_import_workflow_objects.py
+++ b/test/integration/ggrc_workflows/converters/test_import_workflow_objects.py
@@ -49,8 +49,8 @@ class TestWorkflowObjectsImport(TestCase):
     self.assertEqual(2, TaskGroupObject.query.count())
 
     task2 = TaskGroupTask.query.filter_by(slug="t-2").first()
-    self.assertEquals(task2.start_date, date(2015, 7, 10))
-    self.assertEquals(task2.end_date, date(2016, 12, 30))
+    self.assertEqual(task2.start_date, date(2015, 7, 10))
+    self.assertEqual(task2.end_date, date(2016, 12, 30))
 
   def test_import_task_date_format(self):
     """Test import of tasks for workflows with various frequencies"""

--- a/test/integration/ggrc_workflows/converters/test_workflow_export_csv.py
+++ b/test/integration/ggrc_workflows/converters/test_workflow_export_csv.py
@@ -134,7 +134,7 @@ class TestExportMultipleObjects(TestCase):
         },
     ]
     response = self.export_csv(data).data
-    self.assertEquals(3, response.count("wf-1"))  # 1 for wf and 1 on each tg
+    self.assertEqual(3, response.count("wf-1"))  # 1 for wf and 1 on each tg
     self.assertIn("tg-1", response)
     self.assertIn("tg-6", response)
 
@@ -164,7 +164,7 @@ class TestExportMultipleObjects(TestCase):
         },
     ]
     response = self.export_csv(data).data
-    self.assertEquals(3, response.count("tg-1"))  # 2 for tasks and 1 for tg
+    self.assertEqual(3, response.count("tg-1"))  # 2 for tasks and 1 for tg
     self.assertIn("task-1", response)
     self.assertIn("task-7", response)
 
@@ -235,11 +235,11 @@ class TestExportMultipleObjects(TestCase):
         },
     ]
     response = self.export_csv(data).data
-    self.assertEquals(3, response.count("wf-1"))  # 2 for cycles and 1 for wf
+    self.assertEqual(3, response.count("wf-1"))  # 2 for cycles and 1 for wf
     # 3rd block = 2, 5th block = 11, 6th block = 2.
-    self.assertEquals(15, response.count("CYCLEGROUP-"))
-    self.assertEquals(17, response.count("CYCLE-"))
-    self.assertEquals(11, response.count("CYCLETASK-"))
+    self.assertEqual(15, response.count("CYCLEGROUP-"))
+    self.assertEqual(17, response.count("CYCLE-"))
+    self.assertEqual(11, response.count("CYCLETASK-"))
 
   def test_cycle_taks_objects(self):
     """ test cycle task and various objects """
@@ -267,6 +267,6 @@ class TestExportMultipleObjects(TestCase):
         },
     ]
     response = self.export_csv(data).data
-    self.assertEquals(2, response.count("CYCLETASK-"))
-    self.assertEquals(2, response.count("Policy: p1"))
+    self.assertEqual(2, response.count("CYCLETASK-"))
+    self.assertEqual(2, response.count("Policy: p1"))
     self.assertIn(",p1,", response)

--- a/test/integration/ggrc_workflows/notifications/test_one_time_wf.py
+++ b/test/integration/ggrc_workflows/notifications/test_one_time_wf.py
@@ -125,7 +125,7 @@ class TestOneTimeWorkflowNotification(TestCase):
       self.assertEqual(len(notif_data[user]["due_today"]), 3)
 
       send_todays_digest_notifications()
-      self.assertEquals(mock_mail.call_count, 1)
+      self.assertEqual(mock_mail.call_count, 1)
 
   def create_test_cases(self):
     def person_dict(person_id):

--- a/test/integration/ggrc_workflows/notifications/test_one_time_wf_decline_accept_tasks.py
+++ b/test/integration/ggrc_workflows/notifications/test_one_time_wf_decline_accept_tasks.py
@@ -189,7 +189,7 @@ class TestCycleTaskStatusChange(TestCase):
       self.task_change_status(task1, "Finished")
 
       _, notif_data = notification.get_todays_notifications()
-      self.assertEquals(notif_data, {})
+      self.assertEqual(notif_data, {})
 
     with freeze_time("2015-05-02"):
       send_todays_digest_notifications()
@@ -229,7 +229,7 @@ class TestCycleTaskStatusChange(TestCase):
       self.task_change_status(task1, "Finished")
 
       _, notif_data = notification.get_todays_notifications()
-      self.assertEquals(notif_data, {})
+      self.assertEqual(notif_data, {})
 
     with freeze_time("2015-05-03"):
       cycle = Cycle.query.get(cycle.id)

--- a/test/integration/ggrc_workflows/notifications/test_one_time_wf_end_date_change.py
+++ b/test/integration/ggrc_workflows/notifications/test_one_time_wf_end_date_change.py
@@ -75,10 +75,10 @@ class TestOneTimeWfEndDateChange(TestCase):
     with freeze_time("2015-05-02 03:21:34"):
       send_todays_digest_notifications()
       _, notif_data = notification.get_todays_notifications()
-      self.assertEquals(notif_data, {})
+      self.assertEqual(notif_data, {})
 
       # one email to owner and one to assigne
-      self.assertEquals(mock_mail.call_count, 2)
+      self.assertEqual(mock_mail.call_count, 2)
 
     with freeze_time("2015-05-04 03:21:34"):  # one day befor due date
       _, notif_data = notification.get_todays_notifications()
@@ -90,10 +90,10 @@ class TestOneTimeWfEndDateChange(TestCase):
     with freeze_time("2015-05-04 03:21:34"):  # one day befor due date
       send_todays_digest_notifications()
       _, notif_data = notification.get_todays_notifications()
-      self.assertEquals(notif_data, {})
+      self.assertEqual(notif_data, {})
 
       # one email to owner and one to assigne
-      self.assertEquals(mock_mail.call_count, 3)
+      self.assertEqual(mock_mail.call_count, 3)
 
     with freeze_time("2015-05-05 03:21:34"):  # due date
       _, notif_data = notification.get_todays_notifications()
@@ -131,10 +131,10 @@ class TestOneTimeWfEndDateChange(TestCase):
     with freeze_time("2015-05-02 03:21:34"):
       send_todays_digest_notifications()
       _, notif_data = notification.get_todays_notifications()
-      self.assertEquals(notif_data, {})
+      self.assertEqual(notif_data, {})
 
       # one email to owner and one to assigne
-      self.assertEquals(mock_mail.call_count, 2)
+      self.assertEqual(mock_mail.call_count, 2)
 
     with freeze_time("2015-05-03 03:21:34"):
       cycle = Cycle.query.get(cycle.id)
@@ -151,11 +151,11 @@ class TestOneTimeWfEndDateChange(TestCase):
     with freeze_time("2015-05-04 03:21:34"):  # one day befor due date
       _, notif_data = notification.get_todays_notifications()
       user = get_person(self.user.id)
-      self.assertEquals(notif_data, {})
+      self.assertEqual(notif_data, {})
 
     with freeze_time("2015-05-05 03:21:34"):  # due date
       _, notif_data = notification.get_todays_notifications()
-      self.assertEquals(notif_data, {})
+      self.assertEqual(notif_data, {})
 
     with freeze_time("2015-05-14 03:21:34"):  # due date
       _, notif_data = notification.get_todays_notifications()
@@ -189,10 +189,10 @@ class TestOneTimeWfEndDateChange(TestCase):
     with freeze_time("2015-05-02 03:21:34"):
       send_todays_digest_notifications()
       _, notif_data = notification.get_todays_notifications()
-      self.assertEquals(notif_data, {})
+      self.assertEqual(notif_data, {})
 
       # one email to owner and one to assigne
-      self.assertEquals(mock_mail.call_count, 2)
+      self.assertEqual(mock_mail.call_count, 2)
 
     with freeze_time("2015-05-03 03:21:34"):
       cycle = Cycle.query.get(cycle.id)
@@ -208,15 +208,15 @@ class TestOneTimeWfEndDateChange(TestCase):
 
     with freeze_time("2015-05-03 03:21:34"):  # one day befor due date
       _, notif_data = notification.get_todays_notifications()
-      self.assertEquals(notif_data, {})
+      self.assertEqual(notif_data, {})
 
     with freeze_time("2015-05-04 03:21:34"):  # due date
       _, notif_data = notification.get_todays_notifications()
-      self.assertEquals(notif_data, {})
+      self.assertEqual(notif_data, {})
 
     with freeze_time("2015-05-05 03:21:34"):  # due date
       _, notif_data = notification.get_todays_notifications()
-      self.assertEquals(notif_data, {})
+      self.assertEqual(notif_data, {})
 
   @patch("ggrc.notification.email.send_email")
   def test_move_end_date_to_today(self, mock_mail):
@@ -232,10 +232,10 @@ class TestOneTimeWfEndDateChange(TestCase):
     with freeze_time("2015-05-02 03:21:34"):
       send_todays_digest_notifications()
       _, notif_data = notification.get_todays_notifications()
-      self.assertEquals(notif_data, {})
+      self.assertEqual(notif_data, {})
 
       # one email to owner and one to assigne
-      self.assertEquals(mock_mail.call_count, 2)
+      self.assertEqual(mock_mail.call_count, 2)
 
     with freeze_time("2015-05-03 03:21:34"):
       cycle = Cycle.query.get(cycle.id)
@@ -271,7 +271,7 @@ class TestOneTimeWfEndDateChange(TestCase):
 
     with freeze_time("2015-05-05 03:21:34"):  # due date
       _, notif_data = notification.get_todays_notifications()
-      self.assertEquals(notif_data, {})
+      self.assertEqual(notif_data, {})
 
   def create_test_cases(self):
     def person_dict(person_id):

--- a/test/unit/ggrc/test_utils.py
+++ b/test/unit/ggrc/test_utils.py
@@ -77,7 +77,7 @@ class TestUtilsFunctions(TestCase):
 
     result = utils.merge_dict(dict1, dict2)
 
-    self.assertEquals(result, expected_result)
+    self.assertEqual(result, expected_result)
 
   def test_merge_dicts(self):
     dict1 = {


### PR DESCRIPTION
If None is in the contexts read_contexts_for will return None and not a
list of context_ids including None.