### PR TITLE
CORE-2819 Upload request evidence to the correct folder

### DIFF
--- a/src/ggrc/assets/javascripts/models/mappings.js
+++ b/src/ggrc/assets/javascripts/models/mappings.js
@@ -607,6 +607,9 @@
         "context": "Context",
         "related_objects_as_source": ["ControlAssessment", "Issue"]
       },
+      folders: Proxy(
+        "ObjectFolder", "folderable", "folder",
+        "object_folders", "GDriveFolder"),
       requests: Direct("Request", "audit", "requests"),
       active_requests: CustomFilter('requests', function (result) {
         return result.instance.status !== 'Accepted';
@@ -703,6 +706,7 @@
       _mixins: ["related_object", "personable", "ownable", "business_object", "documentable"],
       business_objects: Multi(["related_objects", "controls", "documents", "people", "sections", "clauses"]),
       audits: Direct("Audit", "requests", "audit"),
+      extended_folders: Cross("audits", "folders"),
       urls: TypeFilter("related_objects", "Document"),
       related_assignees: AttrFilter("related_objects", "AssigneeType", "Assignee", "Person"),
       related_requesters: AttrFilter("related_objects", "AssigneeType", "Requester", "Person"),

--- a/src/ggrc/assets/mustache/base_templates/attachment_list.mustache
+++ b/src/ggrc/assets/mustache/base_templates/attachment_list.mustache
@@ -8,8 +8,9 @@
 {{#add_to_current_scope parent_instance=instance}}
   <ul class="attachment-list" data-update-count="{{update_count}}" data-disable-lazy-loading="true" {{data 'options'}} {{ (el) -> el.cms_controllers_tree_view(el.data('options')).control("tree_view").display() }} data-info-controller="true">
   </ul>
+
   {{#is_allowed 'update' instance context='for'}}
-    <ggrc-gdrive-picker-launcher instance="instance" link_text="Attach evidence" click_event="trigger_upload">
+    <ggrc-gdrive-picker-launcher instance="instance" link_text="Attach evidence" click_event="trigger_upload_parent">
     </ggrc-gdrive-picker-launcher>
   {{/is_allowed}}
 {{/add_to_current_scope}}

--- a/src/ggrc/assets/mustache/base_templates/attachment_list.mustache
+++ b/src/ggrc/assets/mustache/base_templates/attachment_list.mustache
@@ -6,12 +6,50 @@
 }}
 {{#instance.class.info_pane_options.evidence}}
 {{#add_to_current_scope parent_instance=instance}}
-  <ul class="attachment-list" data-update-count="{{update_count}}" data-disable-lazy-loading="true" {{data 'options'}} {{ (el) -> el.cms_controllers_tree_view(el.data('options')).control("tree_view").display() }} data-info-controller="true">
+
+  <ul
+    class="attachment-list"
+    data-update-count="{{update_count}}"
+    data-disable-lazy-loading="true"
+    {{data 'options'}}
+    {{ (el) -> el.cms_controllers_tree_view(el.data('options')).control("tree_view").display() }}
+    data-info-controller="true">
   </ul>
 
   {{#is_allowed 'update' instance context='for'}}
-    <ggrc-gdrive-picker-launcher instance="instance" link_text="Attach evidence" click_event="trigger_upload_parent">
-    </ggrc-gdrive-picker-launcher>
+
+    {{#with_mapping 'extended_folders' instance}}
+    {{#defer 'extended_folders' instance.extended_folders allow_fail=true}}
+      {{#if extended_folders.0.computed_errors}}
+        <small class="error-inline">
+          <strong>Warning:</strong> You need permission to upload files to
+          the Audit evidence folder.
+          <a href="https://drive.google.com/folderview?id={{extended_folders.0.instance.id}}&amp;usp=sharing#"
+          >Request access</a>.
+        </small>
+      {{else}}
+        <div class="oneline">
+          {{#if extended_folders.length}}
+            <ggrc-gdrive-picker-launcher
+              instance="instance"
+              link_text="Attach evidence"
+              click_event="trigger_upload_parent">
+            </ggrc-gdrive-picker-launcher>
+          {{else}}
+            <small class="error-inline">
+              <strong>Warning:</strong> The corresponding Audit's evidence folder
+              is not set. Please select a folder before uploading evidence files.
+            </small>
+          {{/if}}
+        </div>
+      {{/need_permission}}
+
+    {{else}}
+      <div {{attach_spinner '{ "radius": 3, "length": 3, "width": 2 }' 'display:inline-block; top: -5px; margin-left: 5px;' }}></div>
+    {{/defer}}
+    {{/with_mapping}}
+
   {{/is_allowed}}
+
 {{/add_to_current_scope}}
 {{/instance}}


### PR DESCRIPTION
This fix has been completely revamped. The fix for uploading the evidence files to the correct GDrive folder (as set on the Audit) has been stripped down to the bare essentials - it's just a different click handler that is now executed (`trigger_upload_parent` instead of `trigger_upload`).

On top of that and as per @Smotko's suggestion, the upload evidence button is now only displayed if an evidence upload folder is actually set on the Audit, otherwise an error message is displayed.

~~Files are not uploaded to GDrive root anymore, but to the directory specified
in the audit's settings.~~

~~Not test for this, unfortunately, because after a lot of researching and digging, me and @edofic eventually concluded that some of the objects that the `trigger_upload()` method uses would be very difficult, if not impossible, to mock (e.g. e.g. Google Picker objects and its event triggering).~~

~~BTW, the reason that the audit-specific code has been written in the `ggrc-gdrive-picker-launcher` component itself is that there is no other "good" place to tell the picker, which folder to upload the files to - there is no special "audit" component, where the folder would be set as e.g. a property in its scope and then become available (by inheritance) to the picker component.
(@edofic please correct me if I misunderstood it, thanks)~~