### PR TITLE
CORE-2875: Fix setting the upload folder for new Audits

### DIFF
--- a/src/ggrc/assets/mustache/audits/modal_content.mustache
+++ b/src/ggrc/assets/mustache/audits/modal_content.mustache
@@ -122,6 +122,7 @@
           <div class="row-fluid inner-hide spacing-bottom">
             <div data-id="auditors_hidden" class="span12 hidable">
               <ggrc-modal-connector
+                instance="instance"
                 parent_instance="instance"
                 instance_attr="context"
                 source_mapping="auditors"


### PR DESCRIPTION
If an evidence upload folder is set, it is now correctly linked with the Audit object that has just been created.

The Audit's `modal_content.mustache` template was the only one that did not set the `instance="instance"` attribute of the `<ggrc-modal-connector>` element, and consequently the `deferred_update()` handler was not able to link the GDrive folder with the new Audit instance, because it [couldn't find it](https://github.com/google/ggrc-core/blob/develop/src/ggrc/assets/javascripts/controllers/modals_controller.js#L1025) (it was `null`).