### PR TITLE
CORE-2886 Add permissions to map to Auditor

### DIFF
--- a/src/ggrc/converters/handlers.py
+++ b/src/ggrc/converters/handlers.py
@@ -611,7 +611,7 @@ class ParentColumnHandler(ColumnHandler):
                      object_type=self.parent._inflector.human_singular.title(),
                      slug=slug)
       return None
-    if not permissions.is_allowed_update_for(obj):
+    if not permissions.is_allowed_map_to_for(obj):
       self.add_error(errors.MAPPING_PERMISSION_ERROR,
                      object_type=obj.type, slug=slug)
       return None

--- a/src/ggrc/rbac/permissions.py
+++ b/src/ggrc/rbac/permissions.py
@@ -47,7 +47,8 @@ def is_allowed_read(resource_type, resource_id, context_id):
   """Whether or not the user is allowed to read a resource of the specified
   type in the context.
   """
-  return permissions_for(get_user()).is_allowed_read(resource_type, resource_id, context_id)
+  return permissions_for(get_user()).is_allowed_read(
+      resource_type, resource_id, context_id)
 
 
 def is_allowed_read_for(instance):
@@ -64,11 +65,13 @@ def is_allowed_update(resource_type, resource_id, context_id):
   return permissions_for(get_user()).is_allowed_update(
       resource_type, resource_id, context_id)
 
+
 def is_allowed_update_for(instance):
   """Whether or not the user is allowed to update this particular resource
   instance.
   """
   return permissions_for(get_user()).is_allowed_update_for(instance)
+
 
 def is_allowed_delete(resource_type, resource_id, context_id):
   """Whether or not the user is allowed to delete a resource of the specified
@@ -77,46 +80,72 @@ def is_allowed_delete(resource_type, resource_id, context_id):
   return permissions_for(get_user()).is_allowed_delete(
       resource_type, resource_id, context_id)
 
+
 def is_allowed_delete_for(instance):
   return permissions_for(get_user()).is_allowed_delete_for(instance)
+
+
+def is_allowed_map_to(resource_type, resource_id, context_id):
+  """Whether or not the user is allowed to map to a resource of the specified
+  type in the context
+  """
+  return permissions_for(get_user()).is_allowed_map_to(
+      resource_type, resource_id, context_id)
+
+
+def is_allowed_map_to_for(instance):
+  """Whether or not the user is allowed to map to a resource of the specified
+  type in the context.
+  """
+  return permissions_for(get_user()).is_allowed_map_to_for(instance)
+
 
 def create_contexts_for(resource_type):
   """All contexts in which the user has create permission."""
   return permissions_for(get_user()).create_contexts_for(resource_type)
 
+
 def read_contexts_for(resource_type):
   """All contexts in which the user has read permission."""
   return permissions_for(get_user()).read_contexts_for(resource_type)
+
 
 def update_contexts_for(resource_type):
   """All contexts in which the user has update permission."""
   return permissions_for(get_user()).update_contexts_for(resource_type)
 
+
 def delete_contexts_for(resource_type):
   """All contexts in which the user has delete permission."""
   return permissions_for(get_user()).delete_contexts_for(resource_type)
+
 
 def create_resources_for(resource_type):
   """All resources in which the user has create permission."""
   return permissions_for(get_user()).create_resources_for(resource_type)
 
+
 def read_resources_for(resource_type):
   """All resources in which the user has read permission."""
   return permissions_for(get_user()).read_resources_for(resource_type)
+
 
 def update_resources_for(resource_type):
   """All resources in which the user has update permission."""
   return permissions_for(get_user()).update_resources_for(resource_type)
 
+
 def delete_resources_for(resource_type):
   """All resources in which the user has delete permission."""
   return permissions_for(get_user()).delete_resources_for(resource_type)
+
 
 def is_allowed_view_object_page_for(instance):
   """Whether or not the user is allwoed to access the object page view for the
   given instance.
   """
   return permissions_for(get_user()).is_allowed_view_object_page_for(instance)
+
 
 def is_admin():
   """Whether the current user has ADMIN permission"""

--- a/src/ggrc/rbac/permissions_provider.py
+++ b/src/ggrc/rbac/permissions_provider.py
@@ -270,6 +270,24 @@ class DefaultUserPermissions(UserPermissions):
     """Whether or not the user is allowed to delete the given instance"""
     return self._is_allowed_for(instance, 'delete')
 
+  def is_allowed_map_to(self, resource_type, resource_id, context_id):
+    """Whether or not the user is allowed to map to a resource of the
+    specified type in the context."""
+    can_map = self._is_allowed(Permission('map_to', resource_type,
+                                          resource_id, context_id))
+    if can_map:
+      return True
+    else:
+      return self.is_allowed_update(resource_type, resource_id, context_id)
+
+  def is_allowed_map_to_for(self, instance):
+    """Whether or not the user is allowed to map to the given instance"""
+    can_map = self._is_allowed_for(instance, 'map_to')
+    if can_map:
+      return True
+    else:
+      return self.is_allowed_update_for(instance)
+
   def _get_resources_for(self, action, resource_type):
     """Get resources resources (object ids) for a given action and resource_type"""
     permissions = self._permissions()

--- a/src/ggrc_basic_permissions/roles/Auditor.py
+++ b/src/ggrc_basic_permissions/roles/Auditor.py
@@ -56,4 +56,8 @@ permissions = {
         "InterviewResponse",
         "PopulationSampleResponse",
     ],
+    "map_to": [
+        "Audit",
+        "Program",
+    ]
 }


### PR DESCRIPTION
So she can map objects to programs and requests via imports while not being able
to modify those objects.

This is quite a fundamental change to RBAC so feedback is very much appreciated.