### PR TITLE
CORE-2886 Fix direct mapping permission check in import

### DIFF
--- a/src/ggrc/converters/handlers.py
+++ b/src/ggrc/converters/handlers.py
@@ -611,10 +611,17 @@ class ParentColumnHandler(ColumnHandler):
                      object_type=self.parent._inflector.human_singular.title(),
                      slug=slug)
       return None
-    if not permissions.is_allowed_update_for(obj):
-      self.add_error(errors.MAPPING_PERMISSION_ERROR,
-                     object_type=obj.type, slug=slug)
-      return None
+    context_id = None
+    if hasattr(obj, "context_id") and \
+       hasattr(self.row_converter.obj, "context_id"):
+      context_id = obj.context_id
+      if context_id is not None:
+        name = self.row_converter.obj.__class__.__name__
+        if not permissions.is_allowed_create(name, None, context_id) \
+           and not permissions.has_conditions('create', name):
+          self.add_error(errors.MAPPING_PERMISSION_ERROR,
+                         object_type=obj.type, slug=slug)
+          return None
     return obj
 
   def set_obj_attr(self):

--- a/src/ggrc/rbac/permissions.py
+++ b/src/ggrc/rbac/permissions.py
@@ -121,3 +121,13 @@ def is_allowed_view_object_page_for(instance):
 def is_admin():
   """Whether the current user has ADMIN permission"""
   return permissions_for(get_user()).is_admin()
+
+def has_conditions(action, resource):
+  """
+  Checks if the resource has a condition that needs to be checked with
+  is_allowed_for
+  """
+  _permissions = permissions_for()._permissions()
+  return bool(_permissions.get(action, {})
+              .get(resource, {})
+              .get('conditions', {}))

--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -716,7 +716,7 @@ class Resource(ModelView):
           'application/json', 406, [('Content-Type', 'text/plain')]))
     with benchmark("Query read permissions"):
       if not permissions.is_allowed_read(self.model.__name__, obj.id, obj.context_id)\
-         and not has_conditions('read', self.model.__name__):
+         and not permissions.has_conditions('read', self.model.__name__):
         raise Forbidden()
       if not permissions.is_allowed_read_for(obj):
         raise Forbidden()
@@ -764,14 +764,14 @@ class Resource(ModelView):
     src = UnicodeSafeJsonWrapper(self.request.json)
     with benchmark("Query update permissions"):
       if not permissions.is_allowed_update(self.model.__name__, obj.id, obj.context_id)\
-         and not has_conditions('update', self.model.__name__):
+         and not permissions.has_conditions('update', self.model.__name__):
         raise Forbidden()
       if not permissions.is_allowed_update_for(obj):
         raise Forbidden()
       new_context = self.get_context_id_from_json(src)
       if new_context != obj.context_id \
          and not permissions.is_allowed_update(self.model.__name__, obj.id, new_context)\
-         and not has_conditions('update', self.model.__name__):
+         and not permissions.has_conditions('update', self.model.__name__):
         raise Forbidden()
     if self.request.mimetype != 'application/json':
       return current_app.make_response(
@@ -831,7 +831,7 @@ class Resource(ModelView):
         return self.not_found_response()
       with benchmark("Query delete permissions"):
         if not permissions.is_allowed_delete(self.model.__name__, obj.id, obj.context_id)\
-           and not has_conditions("delete", self.model.__name__):
+           and not permissions.has_conditions("delete", self.model.__name__):
           raise Forbidden()
         if not permissions.is_allowed_delete_for(obj):
           raise Forbidden()
@@ -1052,7 +1052,7 @@ class Resource(ModelView):
       with benchmark("Query create permissions"):
         if not permissions.is_allowed_create(self.model.__name__, None,
                                              self.get_context_id_from_json(src))\
-           and not has_conditions('create', self.model.__name__):
+           and not permissions.has_conditions('create', self.model.__name__):
           raise Forbidden()
       if src.get('private') == True and src.get('context') is not None \
          and src['context'].get('id') is not None:
@@ -1295,17 +1295,6 @@ class ReadOnlyResource(Resource):
       return super(ReadOnlyResource, self).dispatch_request(*args, **kwargs)
     else:
       raise NotImplementedError()
-
-
-def has_conditions(action, resource):
-  """
-  Checks if the resource has a condition that needs to be checked with
-  is_allowed_for
-  """
-  _permissions = permissions.permissions_for(get_current_user())._permissions()
-  return bool(_permissions.get(action, {})
-              .get(resource, {})
-              .get('conditions', {}))
 
 
 def filter_resource(resource, depth=0, user_permissions=None):


### PR DESCRIPTION
Use create (in context) to handle cases where the user is allowed to create
mappings but not to update the target object (e.g. Auditor)