### PR TITLE
CORE-2878 Add missing "map to this" in tree view for risk objects

### DIFF
--- a/src/ggrc_risks/assets/javascripts/apps/risks.js
+++ b/src/ggrc_risks/assets/javascripts/apps/risks.js
@@ -157,6 +157,7 @@
         widget_name: model.model_plural,
         widget_icon: model.table_singular,
         content_controller_options: {
+          add_item_view : GGRC.mustache_path + "/base_objects/tree_add_item.mustache",
           child_options: [],
           draw_children: false,
           parent_instance: page_instance,


### PR DESCRIPTION
Update related objects descriptors for risk extension objects (risk & threat) to
show the `+` icon on right hand side in tree view.