### PR TITLE
CORE-2633 Use the first related control if directly mapped control is null

### DIFF
--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -3097,7 +3097,7 @@ Mustache.registerHelper("with_create_issue_json", function (instance, options) {
   instance = Mustache.resolve(instance);
 
   var audits = instance.get_mapping("related_audits"),
-      audit, programs, program, control, json;
+      audit, programs, program, control, json, related_controls;
 
   if (!audits.length) {
     return "";
@@ -3107,7 +3107,11 @@ Mustache.registerHelper("with_create_issue_json", function (instance, options) {
   programs = audit.get_mapping("_program");
   program = programs[0].instance.reify();
   control = instance.control ? instance.control.reify() : {};
+  related_controls = instance.get_mapping('related_controls');
 
+  if (!control.id && related_controls.length) {
+    control = related_controls[0].instance;
+  }
   json = {
     audit: {title: audit.title, id: audit.id, type: audit.type},
     program: {title: program.title, id: program.id, type: program.type},

--- a/src/ggrc/assets/mustache/control_assessments/info.mustache
+++ b/src/ggrc/assets/mustache/control_assessments/info.mustache
@@ -34,6 +34,7 @@
             </li>
             {{#is_allowed 'update' instance context='for'}}
             {{#with_mapping 'related_audits' instance}}
+            {{#with_mapping 'related_controls' instance}}
             {{#using control=control}}
             {{#with_create_issue_json instance}}
               <li class="border">
@@ -50,6 +51,7 @@
               </li>
             {{/with_create_issue_json}}
             {{/using}}
+            {{/with_mapping}}
             {{/with_mapping}}
             {{/is_allowed}}
             {{#with_page_object_as 'page_instance'}}
@@ -130,6 +132,7 @@
           <ul class="repeated-utility">
             {{#is_allowed 'update' instance context='for'}}
             {{#with_mapping 'related_audits' instance}}
+            {{#with_mapping 'related_controls' instance}}
             {{#using control=control}}
             {{#with_create_issue_json instance}}
             <li>
@@ -144,6 +147,7 @@
             </li>
             {{/with_create_issue_json}}
             {{/using}}
+            {{/with_mapping}}
             {{/with_mapping}}
             {{/is_allowed}}
           </ul>


### PR DESCRIPTION
We are moving away from directly mapped controls to control assessments
in plum jelly, but until we do we need to support both directly mapped
controls and controls mapped via relationships table. This commit makes
sure we either set the directly mapped control or the first control
mapped via relationships.