### PR TITLE
QUICK-FIX Update test id tags for selenium tests

### DIFF
--- a/src/ggrc/assets/mustache/base_objects/notes.mustache
+++ b/src/ggrc/assets/mustache/base_objects/notes.mustache
@@ -10,7 +10,9 @@
   <div class="row-fluid wrap-row">
     <div data-test-id="title_notes_ef5bc3a71e88" class="span12">
       <h6>Notes</h6>
-      {{{firstnonempty notes '<span class="empty-message">None</span>'}}}
+      <div data-test-id="title_notes_content_ef5bc3a71e88" class="rtf-block">
+        {{{firstnonempty notes '<span class="empty-message">None</span>'}}}
+      </div>
     </div>
   </div>
 

--- a/src/ggrc/assets/mustache/programs/modal_content.mustache
+++ b/src/ggrc/assets/mustache/programs/modal_content.mustache
@@ -39,7 +39,8 @@
         <i class="grcicon-help-black" rel="tooltip" title="Provide more details on the purpose of this {{model.model_singular}} and provide context for how and when this {{model.model_singular}} might be used."></i>
         <a href="javascript://" class="field-hide" tabindex="-1">hide</a>
       </label>
-      <div class="wysiwyg-area">
+      <div data-test-id="new_program_field_description_1fb8bc06"
+           class="wysiwyg-area">
         <textarea tabindex="3" id="program_description" class="span12 triple wysihtml5" name="description" placeholder="Enter Description">{{{description}}}</textarea>
       </div>
     </div>


### PR DESCRIPTION
- Wrapping notes in a div so we can compare the notes content with what
  we wrote in the modal field.
- Add description test id for wysiwyg.