### PR TITLE
CORE-2912 Ignore blocks with no data rows on import

### DIFF
--- a/src/ggrc/converters/base.py
+++ b/src/ggrc/converters/base.py
@@ -134,6 +134,8 @@ class Converter(object):
   def block_converters_from_csv(self):
     offsets, data_blocks = split_array(self.csv_data)
     for offset, data in zip(offsets, data_blocks):
+      if len(data) < 2:
+        continue  # empty block
       class_name = data[1][0].strip().lower()
       object_class = self.exportable.get(class_name)
       raw_headers, rows = extract_relevant_data(data)


### PR DESCRIPTION
A pleasant side effect of this is that you can now have single line comments in
the import as they will be considered headers for blocks.