### PR TITLE
CORE-2268 Fix No Access column on workflow export

### DIFF
--- a/src/ggrc_workflows/converters/handlers.py
+++ b/src/ggrc_workflows/converters/handlers.py
@@ -12,6 +12,7 @@ from ggrc import models
 from ggrc.converters import errors
 from ggrc.converters import get_importables
 from ggrc.converters.handlers import handlers
+from ggrc_basic_permissions import models as bp_models
 from ggrc_workflows import models as wf_models
 
 
@@ -257,7 +258,12 @@ class WorkflowPersonColumnHandler(handlers.UserColumnHandler):
   def get_value(self):
     workflow_person = db.session.query(wf_models.WorkflowPerson.person_id)\
         .filter_by(workflow_id=self.row_converter.obj.id,)
-    users = models.Person.query.filter(models.Person.id.in_(workflow_person))
+    workflow_roles = db.session.query(bp_models.UserRole.person_id)\
+        .filter_by(context_id=self.row_converter.obj.context_id)
+    users = models.Person.query.filter(
+        models.Person.id.in_(workflow_person) &
+        models.Person.id.notin_(workflow_roles)
+    )
     emails = [user.email for user in users]
     return "\n".join(emails)
 

--- a/test/integration/ggrc_workflows/converters/test_workflow_export_csv.py
+++ b/test/integration/ggrc_workflows/converters/test_workflow_export_csv.py
@@ -270,3 +270,19 @@ class TestExportMultipleObjects(TestCase):
     self.assertEqual(2, response.count("CYCLETASK-"))
     self.assertEqual(2, response.count("Policy: p1"))
     self.assertIn(",p1,", response)
+
+  def test_workflow_no_access_users(self):
+    """ test export of No Access users """
+    data = [
+        {
+            "object_name": "Workflow",
+            "fields": ["workflow_mapped"],
+            "filters": {
+                "expression": {}
+            }
+        }
+    ]
+    response = self.export_csv(data).data
+    users = response.splitlines()[2:-2]
+    expected = [",user20@ggrc.com"] * 10
+    self.assertEqual(expected, users)


### PR DESCRIPTION
Only list "No Access" users by filtering out users with roles on that workflow.