### PR TITLE
QUICK-FIX Add message when user doesn't have access to folder

### DIFF
--- a/src/ggrc/assets/mustache/base_templates/attachment_list.mustache
+++ b/src/ggrc/assets/mustache/base_templates/attachment_list.mustache
@@ -14,33 +14,31 @@
 
 {{#is_allowed 'update' instance context='for'}}
   {{#with_mapping 'extended_folders' instance}}
-  {{#defer 'extended_folders' instance.extended_folders allow_fail=true}}
-    {{#if extended_folders.0.computed_errors}}
-      <small class="error-inline">
-        <strong>Warning:</strong> You need permission to upload files to
-        the Audit evidence folder.
-        <a href="https://drive.google.com/folderview?id={{extended_folders.0.instance.id}}&amp;usp=sharing#"
-        >Request access</a>.
+    <div class="oneline">
+      {{#if extended_folders.length}}
+        <ggrc-gdrive-picker-launcher
+          instance="instance"
+          link_text="Attach evidence"
+          click_event="trigger_upload_parent">
+        </ggrc-gdrive-picker-launcher>
+      {{else}}
+        <small class="error-inline">
+          <strong>Warning:</strong> The corresponding Audit's evidence folder
+          is not set. Please select a folder before uploading evidence files.
+        </small>
+      {{/if}}
+    </div>
+  {{else}}
+    {{! This is a failure state for with_mapping, if something in the mapping doesn't refresh properly }}
+    {{#if error.errors}}
+      <small>
+        You need permission to upload files to the audit folder. <a href="https://drive.google.com/folderview?id={{grdive_msg_to_id error.message}}&usp=sharing#">Request access.</a>
       </small>
     {{else}}
-      <div class="oneline">
-        {{#if extended_folders.length}}
-          <ggrc-gdrive-picker-launcher
-            instance="instance"
-            link_text="Attach evidence"
-            click_event="trigger_upload_parent">
-          </ggrc-gdrive-picker-launcher>
-        {{else}}
-          <small class="error-inline">
-            <strong>Warning:</strong> The corresponding Audit's evidence folder
-            is not set. Please select a folder before uploading evidence files.
-          </small>
-        {{/if}}
-      </div>
-    {{/need_permission}}
-
-  {{else}}
-    <div {{attach_spinner '{ "radius": 3, "length": 3, "width": 2 }' 'display:inline-block; top: -5px; margin-left: 5px;' }}></div>
-  {{/defer}}
+      The GDrive folder for this evidence could not be accessed.
+      {{#using request=parent_instance.request}}
+        {{{render '/static/mustache/gdrive/gapi_errors.mustache' type="file" instance=request error=error}}}
+      {{/using}}
+    {{/if}}
   {{/with_mapping}}
 {{/is_allowed}}


### PR DESCRIPTION
If the user doesn't have access to attached audit folder we will now print an error with a link for requesting access.