### PR TITLE
QUICK-FIX Add pylint to dev-requirements

### DIFF
--- a/src/dev-requirements.txt
+++ b/src/dev-requirements.txt
@@ -23,4 +23,5 @@ MonthDelta==0.9.1
 webob==1.4.1
 names==0.3.0
 flask-debugtoolbar==0.10.0
-freezegun==0.3.1
+freezegun==0.3.5
+pylint==1.5.1

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -22,7 +22,7 @@ iso8601==0.1.0
 blinker==1.3
 bleach==1.2.2
 html5lib==0.95
-six==1.3.0
+six==1.10.0
 chardet==2.1.1
 google-api-python-client==1.2
 httplib2==0.8


### PR DESCRIPTION
Update the six library as it's required by pylint and update freezegun
so it works with the new six lib.