### PR TITLE
QUICK-FIX Remove zlib from compressed type

### DIFF
--- a/src/ggrc/migrations/versions/20151216132037_5410607088f9_delete_background_tasks.py
+++ b/src/ggrc/migrations/versions/20151216132037_5410607088f9_delete_background_tasks.py
@@ -1,0 +1,30 @@
+# Copyright (C) 2015 Google Inc., authors, and contributors <see AUTHORS file>
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+# Created By: miha@reciprocitylabs.com
+# Maintained By: miha@reciprocitylabs.com
+
+"""Delete background tasks
+
+Revision ID: 5410607088f9
+Revises: 504f541411a5
+Create Date: 2015-12-16 13:20:37.341342
+
+"""
+
+# pylint: disable=C0103,E1101
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '5410607088f9'
+down_revision = '504f541411a5'
+
+
+def upgrade():
+  """Remove all entries from background_tasks"""
+  op.execute("truncate background_tasks")
+
+
+def downgrade():
+  """Remove all entries from background_tasks"""
+  op.execute("truncate background_tasks")

--- a/src/ggrc/migrations/versions/20151216132037_5410607088f9_delete_background_tasks.py
+++ b/src/ggrc/migrations/versions/20151216132037_5410607088f9_delete_background_tasks.py
@@ -6,7 +6,7 @@
 """Delete background tasks
 
 Revision ID: 5410607088f9
-Revises: 504f541411a5
+Revises: 1ef8f4f504ae
 Create Date: 2015-12-16 13:20:37.341342
 
 """
@@ -17,7 +17,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '5410607088f9'
-down_revision = '504f541411a5'
+down_revision = '1ef8f4f504ae'
 
 
 def upgrade():

--- a/src/ggrc/models/types.py
+++ b/src/ggrc/models/types.py
@@ -17,13 +17,13 @@ from ggrc.models import exceptions
 
 class JsonType(types.TypeDecorator):
   # pylint: disable=W0223
-
   """ Custom Json data type
 
   Custom type for storing Json objects in our database as serialized text.
   The Limit for the serialized Json is the same as the database text column
   limit (65534).
   """
+  MAX_TEXT_LENGTH = 65534
   impl = types.Text
 
   def process_result_value(self, value, dialect):
@@ -36,21 +36,19 @@ class JsonType(types.TypeDecorator):
       pass
     else:
       value = utils.as_json(value)
-      # Detect if the byte-length of the encoded JSON is larger than the
-      # database "TEXT" column type can handle
-      if len(value.encode('utf-8')) > 65534:
+      if len(value.encode('utf-8')) > self.MAX_TEXT_LENGTH:
         raise exceptions.ValidationError("Log record content too long")
     return value
 
 
 class CompressedType(types.TypeDecorator):
   # pylint: disable=W0223
-
   """ Custom Compresed data type
 
   Custom type for storing any python object in our database as serialized text.
   """
-  impl = types.LargeBinary(length=16777215)
+  MAX_BINARY_LENGTH = 16777215
+  impl = types.LargeBinary(length=MAX_BINARY_LENGTH)
 
   def process_result_value(self, value, dialect):
     if value is not None:
@@ -59,8 +57,6 @@ class CompressedType(types.TypeDecorator):
 
   def process_bind_param(self, value, dialect):
     value = pickle.dumps(value)
-    # Detect if the byte-length of the compressed pickle is larger than the
-    # database "LargeBinary" column type can handle
-    if len(value) > 16777215:
+    if len(value) > self.MAX_BINARY_LENGTH:
       raise exceptions.ValidationError("Log record content too long")
     return value

--- a/src/ggrc/models/types.py
+++ b/src/ggrc/models/types.py
@@ -3,19 +3,27 @@
 # Created By: vraj@reciprocitylabs.com
 # Maintained By: vraj@reciprocitylabs.com
 
-import sqlalchemy.types as types
+"""Declaration of custom ORM data types.
+
+Add Json and Compressed type declaration for use in ORM models.
+"""
+
 import json
 import pickle
+import sqlalchemy.types as types
 from ggrc import utils
 from ggrc.models import exceptions
 
 
 class JsonType(types.TypeDecorator):
-  '''
-  Marshals Python structures to and from JSON stored
-  as Text in the db
-  '''
-  # FIXME: Change this to a larger column type and fix validation below
+  # pylint: disable=W0223
+
+  """ Custom Json data type
+
+  Custom type for storing Json objects in our database as serialized text.
+  The Limit for the serialized Json is the same as the database text column
+  limit (65534).
+  """
   impl = types.Text
 
   def process_result_value(self, value, dialect):
@@ -36,10 +44,12 @@ class JsonType(types.TypeDecorator):
 
 
 class CompressedType(types.TypeDecorator):
-  '''
-  Marshals Python structures to and from a compressed pickle format
-  as LargeBinary in the db
-  '''
+  # pylint: disable=W0223
+
+  """ Custom Compresed data type
+
+  Custom type for storing any python object in our database as serialized text.
+  """
   impl = types.LargeBinary(length=16777215)
 
   def process_result_value(self, value, dialect):

--- a/src/ggrc/models/types.py
+++ b/src/ggrc/models/types.py
@@ -42,12 +42,12 @@ class CompressedType(types.TypeDecorator):
   def process_result_value(self, value, dialect):
     import pickle, zlib
     if value is not None:
-      value = pickle.loads(zlib.decompress(value))
+      value = pickle.loads(value)
     return value
 
   def process_bind_param(self, value, dialect):
     import pickle, zlib
-    value = zlib.compress(pickle.dumps(value))
+    value = pickle.dumps(value)
     # Detect if the byte-length of the compressed pickle is larger than the
     # database "LargeBinary" column type can handle
     if len(value) > 16777215:


### PR DESCRIPTION
Even though we have a blob field to store compressed types, we still get
a warning from the database about some invalid utf8 characters. This is
just to remove that warning.

Since delete is the only operation that uses bacground tasks, we are not
worried about clearing the database before changing this model. And
performance is not affected much since most of the parameters that are
stored in the compressed type are tiny.