### PR TITLE
QUICK-FIX Add helper script for pylint

### DIFF
--- a/bin/check
+++ b/bin/check
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -o nounset
+set -o errexit
+
+TEMPLATE="{msg_id}:{line:3d},{column}: {obj}: {msg}"
+SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
+
+cd "${SCRIPTPATH}/../"
+
+function py_files() {
+  git status --porcelain -uno | cut -c4- | grep ".py$"
+}
+
+if [[ $(py_files) ]]; then
+  py_files | xargs pylint --msg-template="$TEMPLATE"
+else
+  echo "No python files changed."
+fi
+
+# TODO: add jshint and jscs checks.


### PR DESCRIPTION
This is a helper script for running pylint on modified files that are
tracked by git. Other checkers should eventually be added to this
script.