### PR TITLE
QUICK-FIX Fix Make request FCO migration

### DIFF
--- a/src/ggrc/migrations/versions/20151016174806_27684e5f313a_make_request_first_class_object.py
+++ b/src/ggrc/migrations/versions/20151016174806_27684e5f313a_make_request_first_class_object.py
@@ -90,7 +90,8 @@ def upgrade():
     op.drop_constraint("requests_ibfk_1", "requests", type_="foreignkey")
   except sqlaexceptions.OperationalError as oe:
     # Ignores error in case constraint no longer exists
-    if "1025" not in oe.message:
+    error_code, _ = oe.orig.args  # error_code, message
+    if error_code != 1025:
       raise oe
 
   # Drop index on assignee_id
@@ -98,7 +99,8 @@ def upgrade():
     op.drop_index("assignee_id", "requests")
   except sqlaexceptions.OperationalError as oe:
     # Ignores error in case index no longer exists
-    if "1091" not in oe.message:
+    error_code, _ = oe.orig.args  # error_code, message
+    if error_code != 1091:
       raise oe
 
   # Make assignee_id nullable


### PR DESCRIPTION
This fixes the migration that sometimes fails on instances because FK doesn't exist. It also drops the index (possibly problematic, create new migration for it?)