### PR TITLE
QUICK-FIX Patch workflow task imports for Plum

### DIFF
--- a/src/ggrc/converters/handlers.py
+++ b/src/ggrc/converters/handlers.py
@@ -76,15 +76,15 @@ class ColumnHandler(object):
       return
     try:
       setattr(self.row_converter.obj, self.key, self.value)
-      # TODO: The next peace of code should be deleted when Plum patch gets
+      # TODO: The next piece of code should be deleted when Plum patch gets
       # merged back into develop branch. This fix is here because we don't want
       # to risk introducing new bugs to solve this one. The propper fix is
       # already in the Zucchini release.
       # This is a hack to make task group tasks work with other task types
-      if self.key == "description" and \
-          isinstance(self.value, basestring) and \
-          self.row_converter.obj.__class__.__name__ == "TaskGroupTask" and \
-          hasattr(self.row_converter.obj, "response_options"):
+      if (self.key == "description" and
+          isinstance(self.value, basestring) and
+          self.row_converter.obj.__class__.__name__ == "TaskGroupTask" and
+          hasattr(self.row_converter.obj, "response_options")):
         json_value = [i.strip() for i in self.value.split(",")]
         setattr(self.row_converter.obj, "response_options", json_value)
 
@@ -314,6 +314,16 @@ class RequiredTextColumnHandler(TextColumnHandler):
     if not clean_value:
       self.add_error(errors.MISSING_VALUE_ERROR, column_name=self.display_name)
     return clean_value
+
+  def get_value(self):
+    if (self.key == "description" and
+        self.row_converter.obj.__class__.__name__ == "TaskGroupTask" and
+        hasattr(self.row_converter.obj, "response_options") and
+        self.row_converter.obj.response_options and
+        hasattr(self.row_converter.obj, "task_type") and
+        self.row_converter.obj.task_type in {"menu", "checkbox"}):
+      return ", ".join(self.row_converter.obj.response_options)
+    return getattr(self.row_converter.obj, self.key, self.value)
 
 
 class TextareaColumnHandler(ColumnHandler):

--- a/src/ggrc/converters/handlers.py
+++ b/src/ggrc/converters/handlers.py
@@ -76,6 +76,18 @@ class ColumnHandler(object):
       return
     try:
       setattr(self.row_converter.obj, self.key, self.value)
+      # TODO: The next peace of code should be deleted when Plum patch gets
+      # merged back into develop branch. This fix is here because we don't want
+      # to risk introducing new bugs to solve this one. The propper fix is
+      # already in the Zucchini release.
+      # This is a hack to make task group tasks work with other task types
+      if self.key == "description" and \
+          isinstance(self.value, basestring) and \
+          self.row_converter.obj.__class__.__name__ == "TaskGroupTask" and \
+          hasattr(self.row_converter.obj, "response_options"):
+        json_value = [i.strip() for i in self.value.split(",")]
+        setattr(self.row_converter.obj, "response_options", json_value)
+
     except:
       self.row_converter.add_error(errors.UNKNOWN_ERROR)
       trace = traceback.format_exc()

--- a/src/ggrc_workflows/converters/handlers.py
+++ b/src/ggrc_workflows/converters/handlers.py
@@ -153,12 +153,12 @@ class TaskStartColumnHandler(TaskDateColumnHandler):
         return
       month, day, year = self.value
       try:
-        self.row_converter.obj.end_date = datetime.date(year, month, day)
+        self.row_converter.obj.start_date = datetime.date(year, month, day)
       except ValueError:
         self.add_error(errors.WRONG_VALUE_ERROR,
                        column_name=self.display_name)
         return
-      self.row_converter.obj.end_date = datetime.date(year, month, day)
+      self.row_converter.obj.start_date = datetime.date(year, month, day)
     elif freq in ["weekly", "monthly"]:
       if len(self.value) != 1 or \
          (freq == "weekly" and not (1 <= self.value[0] <= 5)) or \
@@ -232,7 +232,7 @@ class TaskTypeColumnHandler(ColumnHandler):
 
   type_map = {
       "rich text": "text",
-      "drop down": "menu",
+      "dropdown": "menu",
       "checkboxes": "checkbox",
   }
 

--- a/src/tests/ggrc/converters/test_csvs/full_good_import_no_warnings.csv
+++ b/src/tests/ggrc/converters/test_csvs/full_good_import_no_warnings.csv
@@ -53,17 +53,17 @@ Task Group,code*,Summary*,details,assignee,workflow*,,,,,,,,,,,,
 ,,,,,,,,,,,,,,,,,
 Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",Mandatory field,This is a mandatory field. Each task must be associated with some task group.,,,"Options are:
 Rich Text
-Drop Down
+Dropdown
 Checkboxes",MM/DD/YYYY,MM/DD/YYYY,,,,,,,,,
 Task,code*,summary*,task group,task description,assignee*,task type,start*,end*,,,,,,,,,
 ,task-1,One time,tg-1,test,user1@ggrc.com,Rich Text,7/1/2015,7/15/2015,,,,,,,,,
 ,task-2,Weekly,tg-2,test,user1@ggrc.com,Rich Text,2,5,,,,,,,,,
 ,task-3,Monthly,tg-3,test,user1@ggrc.com,Checkboxes,1,22,,,,,,,,,
 ,task-4,Quarterly,tg-4,test,user1@ggrc.com,Rich Text,1/5,2/15,,,,,,,,,
-,task-5,Annually,tg-5,test,user1@ggrc.com,Drop Down,5/7,7/15,,,,,,,,,
+,task-5,Annually,tg-5,test,user1@ggrc.com,Dropdown,5/7,7/15,,,,,,,,,
 ,task-6,One time,tg-6,test,user1@ggrc.com,Checkboxes,7/1/2015,7/15/2015,,,,,,,,,
 ,task-7,One time,tg-1,test,user1@ggrc.com,Rich Text,7/1/2015,7/15/2015,,,,,,,,,
-,task-8,Weekly,tg-2,test,user1@ggrc.com,Drop Down,2,5,,,,,,,,,
+,task-8,Weekly,tg-2,test,user1@ggrc.com,Dropdown,2,5,,,,,,,,,
 ,task-9,Monthly,tg-3,test,user1@ggrc.com,Checkboxes,1,22,,,,,,,,,
 ,task-10,Quarterly,tg-4,test,user1@ggrc.com,Rich Text,1/5,2/15,,,,,,,,,
 ,,,,,,,,,,,,,,,,,

--- a/src/tests/ggrc_workflows/converters/test_csvs/simple_workflow_test_no_warnings.csv
+++ b/src/tests/ggrc_workflows/converters/test_csvs/simple_workflow_test_no_warnings.csv
@@ -3,7 +3,7 @@ Person,name,email,company,role,,,,
 ,user 1,user1@ggrc.com,google,Admin ,,,,
 ,,,,,,,,
 Object type,,,,,,,,
-Workflow,code*,title*,description ,Manager,frequency,force real-time email updates,custom email message,
+Workflow,code*,title*,description ,manager,frequency,force real-time email updates,custom email message,
 ,wf-1,wf-1,test,user1@ggrc.com,One time,no,this is super custom ,
 ,,,,,,,,
 Object type,,,,,,,,
@@ -12,8 +12,11 @@ Task Group,code*,Summary*,details,assignee,workflow*,Objects,,
 objective : obj-3",,
 ,,,,,,,,
 Object type,,,,,,,,
-Task,code*,summary*,task group,task description,assignee*,task type,start,end
+Task,code*,Summary*,task group,task description,assignee*,task type,start,end
 ,t-1,task for wf-1,tg-1,test,user1@ggrc.com,Rich text,7/1/2015,7/15/2015
+,t-2,task for wf-2,tg-1,test,user1@ggrc.com,Rich text,7/10/2015,12/30/2016
+,t-3,checkbox task,tg-1,"ch1, ch2 , some checkbox 3",user1@ggrc.com,Checkboxes,7/10/2016,12/30/2017
+,t-4,dropdown task,tg-1,"option 1, another option ,   o3",user1@ggrc.com,Dropdown,7/10/2017,12/30/2018
 ,,,,,,,,
 Object type,,,,,,,,
 objective,code*,title*,description,owner,state,notes,,

--- a/src/tests/ggrc_workflows/converters/test_import_workflow_objects.py
+++ b/src/tests/ggrc_workflows/converters/test_import_workflow_objects.py
@@ -3,6 +3,7 @@
 # Created By: miha@reciprocitylabs.com
 # Maintained By: miha@reciprocitylabs.com
 
+from datetime import date
 from flask import json
 from os.path import abspath
 from os.path import dirname
@@ -47,5 +48,13 @@ class TestWorkflowObjectsImport(TestCase):
 
     self.assertEquals(1, Workflow.query.count())
     self.assertEquals(1, TaskGroup.query.count())
-    self.assertEquals(1, TaskGroupTask.query.count())
+    self.assertEquals(4, TaskGroupTask.query.count())
     self.assertEquals(2, TaskGroupObject.query.count())
+
+    task2 = TaskGroupTask.query.filter_by(slug="t-2").first()
+    task3 = TaskGroupTask.query.filter_by(slug="t-3").first()
+    task4 = TaskGroupTask.query.filter_by(slug="t-4").first()
+    self.assertEqual(task2.start_date, date(2015, 7, 10))
+    self.assertEqual(task2.end_date, date(2016, 12, 30))
+    self.assertIn("ch2", task3.response_options)
+    self.assertIn("option 1", task4.response_options)


### PR DESCRIPTION
Make sure that workflow tasks are imported propperly

- start and end date are set correctly.
- Comma separated values are stored if task type is Checkboxes or Dropdown.