### PR TITLE
CORE-2911 Fix hiding the optional Verifier(s) form field

### DIFF
--- a/src/ggrc/assets/mustache/base_templates/people_list.mustache
+++ b/src/ggrc/assets/mustache/base_templates/people_list.mustache
@@ -13,7 +13,7 @@
     <li>
         <people-group deferred="deferred" editable="editable" instance="instance" mapping="related_assignees" required="true" type="assignee"></people-group>
     </li>
-    <li>
+    <li class="hidable">
         <people-group deferred="deferred" editable="editable" instance="instance" mapping="related_verifiers" type="verifier"></people-group>
     </li>
 </ul>


### PR DESCRIPTION
The hiding functionality relies on the presence of the `hidable` CSS class which this PR adds to the corresponding Verifier(s) filed on the Request edit form.