### PR TITLE
CORE-2897 Audit Lead and Auditor cannot remove Evidence, URL, Mapped Objects

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/comment_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/comment_controller.js
@@ -62,6 +62,7 @@
       newInstance: function () {
         var instance = CMS.Models.Comment();
         instance._source_mapping = this.scope.attr("source_mapping");
+        instance.attr("context", this.scope.attr('parent_instance.context'));
         this.scope.attr("instance", instance);
       },
       "cleanPanel": function () {

--- a/src/ggrc/assets/mustache/base_templates/attachment.mustache
+++ b/src/ggrc/assets/mustache/base_templates/attachment.mustache
@@ -6,13 +6,15 @@
 }}
 
 <li data-object-id="{{instance.id}}" data-object-type="{{instance.class.table_singular}}">
-  {{#is_allowed 'update' instance}}
-  <span class="file-controls">
-    <a href="javascript://" class="info-action unmap" data-toggle="unmap">
-      <span class="result" {{data 'result'}}></span>
-      <i class="grcicon-deleted"></i>
-    </a>
-  </span>
+  {{#is_allowed 'update' parentInstance context='for'}}
+  {{#instance}}
+    <span class="file-controls">
+      <a href="javascript://" class="info-action unmap" data-toggle="unmap">
+          <span class="result" {{data 'result'}}></span>
+        <i class="grcicon-deleted"></i>
+      </a>
+    </span>
+  {{/instance}}
   {{/is_allowed}}
   <i class="grcicon-file-{{file_type instance}}"></i>
   <span class="date">{{date instance.created_at "no_time"}}</span>

--- a/src/ggrc/assets/mustache/base_templates/mapping_tree_view.mustache
+++ b/src/ggrc/assets/mustache/base_templates/mapping_tree_view.mustache
@@ -8,7 +8,7 @@
 <ul class="attachment-list">
   {{#with_mapping mapping parentInstance}}
     {{#results}}
-      {{{render itemTemplate}}}
+      {{{render itemTemplate parentInstance=parentInstance}}}
     {{/results}}
   {{/with_mapping}}
 </ul>

--- a/src/ggrc/assets/mustache/base_templates/people_group.mustache
+++ b/src/ggrc/assets/mustache/base_templates/people_group.mustache
@@ -24,6 +24,7 @@
     {{/if}}
   {{/if}}
 </label>
+{{#using parentInstance=instance}}
 {{#with_mapping mapping instance}}
   <ul class="inner-count-list">
     {{^if results.length}}
@@ -33,7 +34,7 @@
     {{/if}}
     {{#results}}
       <li>
-        {{#is_allowed 'update' instance context='for'}}
+        {{#is_allowed 'update' parentInstance context='for'}}
         {{#can_unmap}}
         <span class="file-controls">
           <a href="javascript://" class="info-action unmap" can-click="remove_role" data-person={{instance.id}}>
@@ -70,3 +71,4 @@
     </li>
   </ul>
 {{/with_mapping}}
+{{/using}}

--- a/src/ggrc/assets/mustache/base_templates/urls.mustache
+++ b/src/ggrc/assets/mustache/base_templates/urls.mustache
@@ -6,13 +6,15 @@
 }}
 
 <li data-object-id="{{instance.id}}" data-object-type="{{instance.class.table_singular}}">
-  {{#is_allowed 'update' instace}}
-  <span class="file-controls">
-    <a href="javascript://" class="info-action unmap" data-toggle="unmap">
-      <span class="result" {{data 'result'}}></span>
-      <i class="grcicon-deleted"></i>
-    </a>
-  </span>
+  {{#is_allowed 'update' parentInstance context='for'}}
+  {{#instance}}
+    <span class="file-controls">
+      <a href="javascript://" class="info-action unmap" data-toggle="unmap">
+        <span class="result" {{data 'result'}}></span>
+        <i class="grcicon-deleted"></i>
+      </a>
+    </span>
+  {{/instance}}
   {{/is_allowed}}
   <a href="{{schemed_url instance.link}}" target="_blank">
     <span>{{firstnonempty instance.title instance.link}}</span>

--- a/src/ggrc_basic_permissions/roles/Auditor.py
+++ b/src/ggrc_basic_permissions/roles/Auditor.py
@@ -46,7 +46,8 @@ permissions = {
         "Issue",
         "DocumentationResponse",
         "InterviewResponse",
-        "PopulationSampleResponse"
+        "PopulationSampleResponse",
+        "Comment"
     ],
     "delete": [
         "Request",


### PR DESCRIPTION
Reopened https://github.com/google/ggrc-core/pull/3407 against the zucchini branch.