### PR TITLE
CORE-2268 Fix export filtering on Workflow -> No Access

### DIFF
--- a/src/ggrc_workflows/models/workflow.py
+++ b/src/ggrc_workflows/models/workflow.py
@@ -148,7 +148,7 @@ class Workflow(CustomAttributable, HasOwnContext, Timeboxed, Described, Titled,
   def _filter_by_no_access(cls, predicate):
     is_no_access = not_(UserRole.query.filter(
         (UserRole.person_id == Person.id) &
-        (UserRole.context_id == cls.context_id)
+        (UserRole.context_id == WorkflowPerson.context_id)
     ).exists())
     return WorkflowPerson.query.filter(
         (cls.id == WorkflowPerson.workflow_id) & is_no_access


### PR DESCRIPTION
Query generation is silently broken when there are two layers of EXISTS nesting
so the workaround is to rely on a context_id available from WorkflowPeople since
it should be the same as the one in the Workflow and is available just one layer
of nesting away.

This now allows you to correctly export `all plum workflows containing no access users` using this query `title ~ plum and "no access" ~ "@"`.