### PR TITLE
CORE-2783 Fix a script error for request user autocomplete

### DIFF
--- a/src/ggrc/assets/javascripts/components/people_list.js
+++ b/src/ggrc/assets/javascripts/components/people_list.js
@@ -53,6 +53,11 @@
           }
         }, this);
       },
+      autocomplete_select: function (el, ev, ui) {
+        if (ui && ui.item) {
+          el.trigger("autocomplete:select", [ui]);
+        }
+      },
     },
     events: {
       "init": function () {
@@ -136,6 +141,10 @@
             model.save();
           }.bind(this));
         }
+      },
+      "modal:success": function () {
+        // prevent navigating to a new object page when a new user is created
+        return false;
       },
     },
     helpers: {

--- a/src/ggrc/assets/javascripts/plugins/autocomplete.js
+++ b/src/ggrc/assets/javascripts/plugins/autocomplete.js
@@ -133,7 +133,8 @@
           } else {
             original_event = ev;
             $(document.body).off(".autocomplete").one("modal:success.autocomplete", function(_ev, new_obj) {
-              ctl.autocomplete_select($this, original_event, {
+              var autocomplete_select = ctl.autocomplete_select || ctl.scope.autocomplete_select;
+              autocomplete_select($this, original_event, {
                 item: new_obj
               });
               $this.trigger("modal:success", new_obj);


### PR DESCRIPTION
When "create new" is selected we have to wire the new object callback with the
autocomplete event and prevent navigation to the page of the newly created user.