### PR TITLE
CORE-2929 Display the object tooltip above the modal window

### DIFF
--- a/src/ggrc/assets/stylesheets/_lhs.scss
+++ b/src/ggrc/assets/stylesheets/_lhs.scss
@@ -711,7 +711,7 @@ h4.search-title {
   position:absolute;
   top:-1px;
   right:-422px;
-  z-index:2000;
+  z-index:3100;
   width:400px;
   padding:2px 10px;
   background:#fff;


### PR DESCRIPTION
NOTE: this fix reveals another issue, the ticket for the latter can be found [here (CORE-2933)](https://reciprocitylabs.atlassian.net/browse/CORE-2933).