### PR TITLE
CORE-2862 Show object icons in subtrees only

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
@@ -413,6 +413,7 @@ CMS.Controllers.TreeLoader("CMS.Controllers.TreeView", {
     // { property : "controls", model : CMS.Models.Control, }
     // { parent_find_param : "system_id" ... }
     , scroll_page_count: 0.5 // pages above and below viewport
+    , is_subtree: false
   },
   do_not_propagate : [
     'header_view', 'footer_view', 'add_item_view', 'list', 'original_list', 'single_object', 'find_function',
@@ -455,7 +456,6 @@ CMS.Controllers.TreeLoader("CMS.Controllers.TreeView", {
     hash.pop();
     window.location.hash = hash.join('/');
   },
-
   // Total display with is set to be span12.
   // Default: title : span4
   //          middle selectable : span4, by default 2 attributes are selected
@@ -1464,6 +1464,7 @@ can.Control("CMS.Controllers.TreeViewNode", {
         this._draw_node_deferred.resolve();
       }.bind(this)));
       this._draw_node_in_progress = false;
+      this.options.attr('is_subtree', this.element && this.element.closest('.inner-tree').length > 0);
     }.bind(this), 2); // We give the browser a 2ms pause for scrolling
   }
   , draw_placeholder: function() {

--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -2965,47 +2965,6 @@ Mustache.registerHelper("iterate_by_two", function (list, options) {
   return output.join("");
 });
 
-/*
-  This helper should be called from widget/tree_view where parent_instance is expected.
-  Purpose: don't show the object icon in the first level tree, as the tab has the icon already.
-
-  Get the current type of object.
-  If the object-type == widget shown, draw = false (First level tree)
-*/
-Mustache.registerHelper("if_draw_icon", function(instance, options) {
-  var draw = true,
-    ins,
-    type,
-    uri,
-    regex;
-
-  ins = Mustache.resolve(instance);
-  type = ins.type;
-
-  switch (type) {
-    case "OrgGroup":
-      type = "org_group";
-      break;
-    case "DataAsset":
-      type = "data_asset";
-      break;
-    default:
-      break;
-  }
-
-  if (type){
-    uri = type.slice(1) + "_widget";
-    regex = new RegExp(uri);
-      if (regex.test(window.location))
-        draw = false;
-  }
-
-  if (draw)
-    return options.fn(options.contexts);
-  else
-    return options.inverse(options.contexts);
-});
-
 /**
  * Helper method for determining the file type of a Document object from its
  * file name extension.

--- a/src/ggrc/assets/mustache/audits/tree.mustache
+++ b/src/ggrc/assets/mustache/audits/tree.mustache
@@ -16,9 +16,9 @@
           <div class="row-fluid">
             <div class="span{{display_options.title_width}}">
               <div class="title tree-title-area" rel="tooltip" data-placement="left" title="" data-original-title="{{instance.title}}">
-                {{#if_draw_icon instance}}
+                {{#is_subtree}}
                   <i class="grcicon-{{instance.class.table_singular}}-color"></i>
-                {{/if_draw_icon}}
+                {{/is_subtree}}
                 {{instance.title}}
               </div>
             </div>

--- a/src/ggrc/assets/mustache/base_objects/tree.mustache
+++ b/src/ggrc/assets/mustache/base_objects/tree.mustache
@@ -14,9 +14,9 @@
             <div class="row-fluid">
               <div class="span{{display_options.title_width}}">
                 <div class="title tree-title-area" rel="tooltip" data-placement="left" title="" data-original-title="{{instance.title}}">
-                  {{#if_draw_icon instance}}
+                  {{#is_subtree}}
                     <i class="grcicon-{{instance.class.table_singular}}-color"></i>
-                  {{/if_draw_icon}}
+                  {{/is_subtree}}
                   {{{firstnonempty instance.title instance.description_inline instance.name instance.email ''}}}
                 </div>
               </div>

--- a/src/ggrc/assets/mustache/control_assessments/tree.mustache
+++ b/src/ggrc/assets/mustache/control_assessments/tree.mustache
@@ -15,9 +15,9 @@
             <div class="row-fluid">
               <div class="span4">
                 <div class="title tree-title-area">
-                  {{#if_draw_icon instance}}
+                  {{#is_subtree}}
                     <i class="grcicon-{{instance.class.table_singular}}-color"></i>
-                  {{/if_draw_icon}}
+                  {{/is_subtree}}
                   {{{firstnonempty instance.title instance.description_inline instance.name instance.email ''}}}
                 </div>
               </div>

--- a/src/ggrc/assets/mustache/controls/tree.mustache
+++ b/src/ggrc/assets/mustache/controls/tree.mustache
@@ -15,9 +15,9 @@
             <div class="row-fluid">
               <div class="span{{display_options.title_width}}">
                 <div class="title tree-title-area" rel="tooltip" data-placement="left" title="" data-original-title="{{instance.title}}">
-                  {{#if_draw_icon instance}}
+                  {{#is_subtree}}
                     <i class="grcicon-{{instance.class.table_singular}}-color"></i>
-                  {{/if_draw_icon}}
+                  {{/is_subtree}}
                   {{instance.title}}
                 </div>
               </div>

--- a/src/ggrc/assets/mustache/directives/tree.mustache
+++ b/src/ggrc/assets/mustache/directives/tree.mustache
@@ -14,9 +14,9 @@
             <div class="row-fluid">
               <div class="span{{display_options.title_width}}">
                 <div class="title tree-title-area" rel="tooltip" data-placement="left" title="" data-original-title="{{instance.title}}">
-                  {{#if_draw_icon instance}}
+                  {{#is_subtree}}
                     <i class="grcicon-{{instance.class.table_singular}}-color"></i>
-                  {{/if_draw_icon}}
+                  {{/is_subtree}}
                   {{instance.title}}
                 </div>
               </div>

--- a/src/ggrc/assets/mustache/documents/tree.mustache
+++ b/src/ggrc/assets/mustache/documents/tree.mustache
@@ -15,9 +15,9 @@
             <div class="row-fluid">
               <div class="span4">
                 <div class="title tree-title-area">
-                  {{#if_draw_icon instance}}
+                  {{#is_subtree}}
                     <i class="grcicon-{{instance.class.table_singular}}-color"></i>
-                  {{/if_draw_icon}}
+                  {{/is_subtree}}
                   {{firstnonempty instance.title instance.link}}
                 </div>
               </div>

--- a/src/ggrc/assets/mustache/objectives/tree.mustache
+++ b/src/ggrc/assets/mustache/objectives/tree.mustache
@@ -15,9 +15,9 @@
             <div class="row-fluid">
               <div class="span{{display_options.title_width}}">
                 <div class="title tree-title-area" rel="tooltip" data-placement="left" title="" data-original-title="{{instance.title}}">
-                  {{#if_draw_icon instance}}
+                  {{#is_subtree}}
                     <i class="grcicon-{{instance.class.table_singular}}-color"></i>
-                    {{/if_draw_icon}}
+                  {{/is_subtree}}
                   {{instance.title}}
                 </div>
               </div>

--- a/src/ggrc/assets/mustache/people/tree.mustache
+++ b/src/ggrc/assets/mustache/people/tree.mustache
@@ -14,9 +14,9 @@
             <div class="row-fluid">
               <div class="span4">
                 <div class="title tree-title-area">
-                  {{#if_draw_icon instance}}
+                  {{#is_subtree}}
                     <i class="grcicon-person-color"></i>
-                  {{/if_draw_icon}}
+                  {{/is_subtree}}
                   {{{firstnonempty instance.title instance.description_inline instance.name instance.email ''}}}
                 </div>
               </div>

--- a/src/ggrc/assets/mustache/programs/tree.mustache
+++ b/src/ggrc/assets/mustache/programs/tree.mustache
@@ -15,9 +15,9 @@
             <div class="row-fluid">
               <div class="span{{display_options.title_width}}">
                 <div class="title tree-title-area" rel="tooltip" data-placement="left" title="" data-original-title="{{instance.title}}">
-                  {{#if_draw_icon instance}}
+                  {{#is_subtree}}
                     <i class="grcicon-{{instance.class.table_singular}}-color"></i>
-                  {{/if_draw_icon}}
+                  {{/is_subtree}}
                   {{#instance.title}}
                     {{instance.title}}
                   {{/instance.title}}

--- a/src/ggrc/assets/mustache/requests/tree.mustache
+++ b/src/ggrc/assets/mustache/requests/tree.mustache
@@ -14,9 +14,9 @@
           <div class="row-fluid">
             <div class="span{{display_options.title_width}}">
               <div class="title tree-title-area">
-                {{#if_draw_icon instance}}
+                {{#is_subtree}}
                   <i class="grcicon-{{instance.request_type}}"></i>
-                {{/if_draw_icon}}
+                {{/is_subtree}}
                 <span>{{instance.title}}</span>
               </div>
             </div>

--- a/src/ggrc/assets/mustache/responses/tree.mustache
+++ b/src/ggrc/assets/mustache/responses/tree.mustache
@@ -15,9 +15,9 @@
             <div class="row-fluid">
               <div class="span4">
                 <div class="title tree-title-area">
-                  {{#if_draw_icon instance}}
+                  {{#is_subtree}}
                     <i class="grcicon-{{instance.class.table_singular}}-color"></i>
-                  {{/if_draw_icon}}
+                  {{/is_subtree}}
                   {{{truncate instance.description}}}
                 </div>
               </div>

--- a/src/ggrc/assets/mustache/sections/tree.mustache
+++ b/src/ggrc/assets/mustache/sections/tree.mustache
@@ -15,9 +15,9 @@
             <div class="row-fluid">
               <div class="span{{display_options.title_width}}">
                 <div class="title tree-title-area" rel="tooltip" data-placement="left" title="" data-original-title="{{instance.title}}">
-                  {{#if_draw_icon instance}}
+                  {{#is_subtree}}
                     <i class="grcicon-{{instance.class.table_singular}}-color"></i>
-                  {{/if_draw_icon}}
+                  {{/is_subtree}}
                   {{instance.title}}
                 </div>
               </div>


### PR DESCRIPTION
In the top level of the tree the icon is not needed, since we have an icon in the objects tab already.