### PR TITLE
CORE-2947 Fix gdrive zIndex setting

### DIFF
--- a/src/ggrc_gdrive_integration/assets/javascripts/controllers/gdrive_workflows_controller.js
+++ b/src/ggrc_gdrive_integration/assets/javascripts/controllers/gdrive_workflows_controller.js
@@ -1038,12 +1038,12 @@ can.Component.extend({
             picker.setVisible(true);
             // use undocumented fu to make the Picker be "modal" - https://b2.corp.google.com/issues/18628239
             // this is the "mask" displayed behind the dialog box div
-            $('div.picker-dialog-bg').css('zIndex', 2000);  // there are multiple divs of that sort
+            $('div.picker-dialog-bg').css('zIndex', 4000);  // there are multiple divs of that sort
             // and this is the dialog box modal div, which we must display on top of our modal, if any
 
             dialog = GGRC.Utils.getPickerElement(picker);
             if (dialog) {
-              dialog.style.zIndex = 2001; // our modals start with 1050
+              dialog.style.zIndex = 4001; // our modals start with 2050
             }
           });
         }
@@ -1205,7 +1205,7 @@ can.Component.extend({
 
           dialog = GGRC.Utils.getPickerElement(picker);
           if (dialog) {
-            dialog.style.zIndex = 2001; // our modals start with 1050
+            dialog.style.zIndex = 4001; // our modals start with 2050
           }
         });
       }

--- a/src/ggrc_gdrive_integration/assets/javascripts/models/gdrive_models.js
+++ b/src/ggrc_gdrive_integration/assets/javascripts/models/gdrive_models.js
@@ -305,7 +305,7 @@ CMS.Models.GDriveFile("CMS.Models.GDriveFolder", {
           picker.setVisible(true);
           dialog = GGRC.Utils.getPickerElement(picker);
           if (dialog) {
-            dialog.style.zIndex = 2001; // our modals start with 1050
+            dialog.style.zIndex = 4001; // our modals start with 2050
           }
         });
       }


### PR DESCRIPTION
Moving modals from zIndex 1050 to 2050 caused our gdrive modals to show
behind our edit modals.