### PR TITLE
CORE-2950 Fix Request Comment folder upload

### DIFF
--- a/src/ggrc/assets/mustache/base_templates/add_comment.mustache
+++ b/src/ggrc/assets/mustache/base_templates/add_comment.mustache
@@ -9,8 +9,38 @@
     <div class="span8">
       <div class="controls top">
         {{#is_allowed 'update' parent_instance context='for'}}
-        <ggrc-gdrive-picker-launcher icon="attach" instance="instance" link_text="Attach evidence" deferred="true" click_event="trigger_upload">
-        </ggrc-gdrive-picker-launcher>
+          {{#with_mapping 'extended_folders' parent_instance}}
+            {{#if extended_folders.length}}
+              <ggrc-gdrive-picker-launcher
+                icon="attach"
+                instance="instance"
+                folder_instance="parent_instance"
+                link_text="Attach evidence"
+                deferred="true"
+                click_event="trigger_upload_parent">
+              </ggrc-gdrive-picker-launcher>
+            {{else}}
+              <ggrc-gdrive-picker-launcher
+                icon="attach"
+                instance="instance"
+                link_text="Attach evidence"
+                deferred="true"
+                click_event="trigger_upload">
+              </ggrc-gdrive-picker-launcher><i class="grcicon-warning" style="margin-top:4px" rel="tooltip" data-placement="bottom" data-original-title="Audit folder not set. Files will be uploaded to your GDrive root folder."></i>
+            {{/if}}
+          {{else}}
+            {{! This is a failure state for with_mapping, if something in the mapping doesn't refresh properly }}
+            {{#if error.errors}}
+              <small>
+                You need permission to upload files to the audit folder. <a href="https://drive.google.com/folderview?id={{grdive_msg_to_id error.message}}&usp=sharing#">Request access.</a>
+              </small>
+            {{else}}
+              The GDrive folder for this evidence could not be accessed.
+              {{#using request=parent_instance.request}}
+                {{{render '/static/mustache/gdrive/gapi_errors.mustache' type="file" instance=request error=error}}}
+              {{/using}}
+            {{/if}}
+          {{/with_mapping}}
           {{#toggle show_new_object_form}}
             <ggrc-quick-add parent_instance="instance" join_model="Relationship" deferred="true" quick_create="create_url">
               {{#prune_context}}

--- a/src/ggrc/assets/mustache/base_templates/attachment_list.mustache
+++ b/src/ggrc/assets/mustache/base_templates/attachment_list.mustache
@@ -15,8 +15,8 @@
 {{#is_allowed 'update' instance context='for'}}
   {{#with_mapping 'extended_folders' instance}}
     <div class="oneline">
-      {{#if extended_folders.length}}
-        {{#if_in instance.status "Open,Final,Verified"}}
+      {{#if_in instance.status "Open,Final,Verified"}}
+        {{#if extended_folders.length}}
           <ggrc-gdrive-picker-launcher
             instance="instance"
             link_text="Attach evidence"
@@ -31,14 +31,32 @@
           <ggrc-gdrive-picker-launcher
             instance="instance"
             link_text="Attach evidence"
-            click_event="trigger_upload_parent">
+            click_event="trigger_upload"
+            verify_event="true"
+            modal_description='You are about to move request from "{{instance.status}}" to "In Progress" - are you sure about that?'
+            modal_title='Confirm moving Request to "In Progress"'
+            modal_button='Confirm'
+            >
           </ggrc-gdrive-picker-launcher>
+          <i class="grcicon-warning" style="margin-top:4px" rel="tooltip" data-placement="bottom" data-original-title="Audit folder not set. Files will be uploaded to your GDrive root folder."></i>
         {{/if_in}}
       {{else}}
-        <small class="error-inline">
-          <strong>Warning:</strong> The corresponding Audit's evidence folder
-          is not set. Please select a folder before uploading evidence files.
-        </small>
+        {{#if extended_folders.length}}
+          <ggrc-gdrive-picker-launcher
+            icon="attach"
+            instance="instance"
+            link_text="Attach evidence"
+            click_event="trigger_upload_parent">
+          </ggrc-gdrive-picker-launcher>
+        {{else}}
+          <ggrc-gdrive-picker-launcher
+            icon="attach"
+            instance="instance"
+            link_text="Attach evidence"
+            click_event="trigger_upload">
+          </ggrc-gdrive-picker-launcher>
+          <i class="grcicon-warning" style="margin-top:4px" rel="tooltip" data-placement="bottom" data-original-title="Audit folder not set. Files will be uploaded to your GDrive root folder."></i>
+        {{/if_in}}
       {{/if}}
     </div>
   {{else}}

--- a/src/ggrc_gdrive_integration/assets/javascripts/controllers/gdrive_workflows_controller.js
+++ b/src/ggrc_gdrive_integration/assets/javascripts/controllers/gdrive_workflows_controller.js
@@ -1159,6 +1159,7 @@ can.Component.extend({
   template: can.view(GGRC.mustache_path + "/gdrive/gdrive_file.mustache"),
   scope: {
     instance: null,
+    folder_instance: null,
     deferred: "@",
     icon: "@",
     link_text: "@",
@@ -1259,8 +1260,10 @@ can.Component.extend({
       // upload files with a parent folder (audits and workflows)
       var that = this,
           verify_dfd = $.Deferred(),
-          parent_folder_dfd;
+          parent_folder_dfd,
+          folder_instance;
 
+      folder_instance = this.folder_instance || this.instance;
       function is_own_folder(mapping, instance) {
         if(mapping.binding.instance !== instance)
           return false;
@@ -1286,9 +1289,9 @@ can.Component.extend({
 
       verify_dfd.done(function () {
         if(that.instance.attr("_transient.folder")) {
-          parent_folder_dfd = $.when([{ instance: that.instance.attr("_transient.folder") }]);
+          parent_folder_dfd = $.when([{ instance: folder_instance.attr("_transient.folder") }]);
         } else {
-          parent_folder_dfd = that.instance.get_binding("extended_folders").refresh_instances();
+          parent_folder_dfd = folder_instance.get_binding("extended_folders").refresh_instances();
         }
         can.Control.prototype.bindXHRToButton(parent_folder_dfd, el);
 


### PR DESCRIPTION
1. Comment now correctly uploads to the folder set in the audit.
2. When Audit folder is not set, files will be uploaded to the
persons's root folder.
3. Redesigned the no audit folder warning - now a warning icon with a
tooltip