### PR TITLE
QUICK-FIX Add selenium docker container

### DIFF
--- a/Dockerfile-selenium
+++ b/Dockerfile-selenium
@@ -8,3 +8,4 @@ RUN apt-get update \
 
 RUN pip install -r /selenium/resources/requirements.txt
 
+COPY ./provision/docker/selenium.bashrc.j2 /root/.bashrc

--- a/Dockerfile-selenium
+++ b/Dockerfile-selenium
@@ -1,0 +1,10 @@
+FROM selenium/standalone-chrome-debug
+COPY ./test/selenium /selenium
+
+WORKDIR /selenium
+
+RUN apt-get update \
+  && apt-get install -y python python-pip xserver-xephyr
+
+RUN pip install -r /selenium/resources/requirements.txt
+

--- a/README.md
+++ b/README.md
@@ -135,6 +135,17 @@ This will run the tests on each file update.
 cd test/unit; sniffer
 ```
 
+For Selenium tests:
+
+First you have to manually launch the server inside you dev container.
+Then you can run the selenium tests with:
+
+```sh
+docker exec -it ggrccore_selenium_1 python /selenium/src/run_selenium.py
+```
+
+Note: The tests should pass if you launch the server with a clean database.
+
 Quickstart Breakdown
 --------------------
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ dev:
   volumes:
    - ".:/vagrant"
   privileged: true
+  environment:
+   - PYTHONDONTWRITEBYTECODE=true
 
 selenium:
   build: .
@@ -19,3 +21,5 @@ selenium:
    - "/dev/shm:/dev/shm"
   links:
    - dev 
+  environment:
+   - PYTHONDONTWRITEBYTECODE=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,3 +24,4 @@ selenium:
    - dev 
   environment:
    - PYTHONDONTWRITEBYTECODE=true
+   - PYTHONPATH=/selenium/src

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ dev:
    - "9876:9876"
   volumes:
    - ".:/vagrant"
+   - "./provision/docker/mysql:/etc/mysql/conf.d"
   privileged: true
   environment:
    - PYTHONDONTWRITEBYTECODE=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,5 +6,16 @@ dev:
    - "8080:8080"
    - "9876:9876"
   volumes:
-    - ".:/vagrant"
+   - ".:/vagrant"
   privileged: true
+
+selenium:
+  build: .
+  dockerfile: Dockerfile-selenium
+  ports:
+   - "4444:4444"
+  volumes:
+   - "./test/selenium:/selenium"
+   - "/dev/shm:/dev/shm"
+  links:
+   - dev 

--- a/provision/docker/mysql/default_utf8.cnf
+++ b/provision/docker/mysql/default_utf8.cnf
@@ -1,0 +1,10 @@
+[client]
+default-character-set = utf8
+
+[mysqld]
+collation-server      = utf8_general_ci
+init-connect          = 'SET NAMES utf8'
+character-set-server  = utf8
+
+[mysql]
+default-character-set = utf8

--- a/provision/docker/selenium.bashrc.j2
+++ b/provision/docker/selenium.bashrc.j2
@@ -1,0 +1,117 @@
+# Copyright (C) 2014 Google Inc., authors, and contributors <see AUTHORS file>
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+# Created By: goran@reciprocitylabs.com
+# Maintained By: goran@reciprocitylabs.com
+
+# ~/.bashrc: executed by bash(1) for non-login shells.
+# see /usr/share/doc/bash/examples/startup-files (in the package bash-doc)
+# for examples
+
+# If not running interactively, don't do anything
+[ -z "$PS1" ] && return
+
+# don't put duplicate lines or lines starting with space in the history.
+# See bash(1) for more options
+HISTCONTROL=ignoreboth
+
+# append to the history file, don't overwrite it
+shopt -s histappend
+
+# for setting history length see HISTSIZE and HISTFILESIZE in bash(1)
+HISTSIZE=1000
+HISTFILESIZE=2000
+
+# check the window size after each command and, if necessary,
+# update the values of LINES and COLUMNS.
+shopt -s checkwinsize
+
+# If set, the pattern "**" used in a pathname expansion context will
+# match all files and zero or more directories and subdirectories.
+#shopt -s globstar
+
+# make less more friendly for non-text input files, see lesspipe(1)
+[ -x /usr/bin/lesspipe ] && eval "$(SHELL=/bin/sh lesspipe)"
+
+# set variable identifying the chroot you work in (used in the prompt below)
+if [ -z "$debian_chroot" ] && [ -r /etc/debian_chroot ]; then
+    debian_chroot=$(cat /etc/debian_chroot)
+fi
+
+# set a fancy prompt (non-color, unless we know we "want" color)
+case "$TERM" in
+    xterm-color) color_prompt=yes;;
+esac
+
+# uncomment for a colored prompt, if the terminal has the capability; turned
+# off by default to not distract the user: the focus in a terminal window
+# should be on the output of commands, not on the prompt
+#force_color_prompt=yes
+
+if [ -n "$force_color_prompt" ]; then
+    if [ -x /usr/bin/tput ] && tput setaf 1 >&/dev/null; then
+	# We have color support; assume it's compliant with Ecma-48
+	# (ISO/IEC-6429). (Lack of such support is extremely rare, and such
+	# a case would tend to support setf rather than setaf.)
+	color_prompt=yes
+    else
+	color_prompt=
+    fi
+fi
+
+if [ "$color_prompt" = yes ]; then
+    PS1='${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '
+else
+    PS1='${debian_chroot:+($debian_chroot)}\u@\h:\w\$ '
+fi
+unset color_prompt force_color_prompt
+
+# If this is an xterm set the title to user@host:dir
+case "$TERM" in
+xterm*|rxvt*)
+    PS1="\[\e]0;${debian_chroot:+($debian_chroot)}\u@\h: \w\a\]$PS1"
+    ;;
+*)
+    ;;
+esac
+
+# enable color support of ls and also add handy aliases
+if [ -x /usr/bin/dircolors ]; then
+    test -r ~/.dircolors && eval "$(dircolors -b ~/.dircolors)" || eval "$(dircolors -b)"
+    alias ls='ls --color=auto'
+    #alias dir='dir --color=auto'
+    #alias vdir='vdir --color=auto'
+
+    alias grep='grep --color=auto'
+    alias fgrep='fgrep --color=auto'
+    alias egrep='egrep --color=auto'
+fi
+
+# some more ls aliases
+alias ll='ls -alF'
+alias la='ls -A'
+alias l='ls -CF'
+
+# Add an "alert" alias for long running commands.  Use like so:
+#   sleep 10; alert
+alias alert='notify-send --urgency=low -i "$([ $? = 0 ] && echo terminal || echo error)" "$(history|tail -n1|sed -e '\''s/^\s*[0-9]\+\s*//;s/[;&|]\s*alert$//'\'')"'
+
+# Alias definitions.
+# You may want to put all your additions into a separate file like
+# ~/.bash_aliases, instead of adding them here directly.
+# See /usr/share/doc/bash-doc/examples in the bash-doc package.
+
+if [ -f ~/.bash_aliases ]; then
+    . ~/.bash_aliases
+fi
+
+# enable programmable completion features (you don't need to enable
+# this, if it's already enabled in /etc/bash.bashrc and /etc/profile
+# sources /etc/bash.bashrc).
+if [ -f /etc/bash_completion ] && ! shopt -oq posix; then
+    . /etc/bash_completion
+fi
+
+export TERM=xterm-color
+export EDITOR=vim
+export PYTHONPATH=$PYTHONPATH:/selenium/src
+PS1='\[\033[01;35m\]\u@\h\[\033[01;34m\] \w \n\$\[\033[00m\] '

--- a/test/selenium/.gitignore
+++ b/test/selenium/.gitignore
@@ -4,8 +4,6 @@
 *.pyo
 *.swp
 .idea
-*.yaml
-*.cfg
 logs
 virtual_env
 chromedriver

--- a/test/selenium/resources/ggrc_test_local.yaml
+++ b/test/selenium/resources/ggrc_test_local.yaml
@@ -1,14 +1,13 @@
-
 logging:
- level: 10     # see python logging module for reference
+ level: 10  # see python logging module for reference
  format: "%(asctime)s:%(name)s:%(levelname)s:%(module)s:%(funcName):%(lineno)s:%(message)s"
 
 webdriver:
- path: /home/jonny/Downloads/chromedriver
+ path: /usr/bin/chromedriver
 
 app:
- url: http://localhost:8080/
+ url: http://dev:8080/
 
 browser:
- display: True
+ display: False
  resolution: (1920, 1080)

--- a/test/selenium/setup.cfg
+++ b/test/selenium/setup.cfg
@@ -8,7 +8,7 @@ markers=
     smoke_tests: test from the smoke test suite in test grid
 
 # free to configure
-driver-path=/home/dev/workspace/ggrc-test/resources/chromedriver
-base-url=http://localhost
+driver-path=/usr/bin/chromedriver
+base-url=http://dev
 port=8080
 selenium_capture_debug=always

--- a/test/selenium/src/run_selenium.py
+++ b/test/selenium/src/run_selenium.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python2.7
+# Copyright (C) 2015 Google Inc., authors, and contributors <see AUTHORS file>
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+# Created By: miha@reciprocitylabs.com
+# Maintained By: miha@reciprocitylabs.com
+
+import sys
+import os
+import commands
+import logging
+import pytest
+
+from lib import constants
+from lib import file_ops
+from lib import log
+from lib import virtual_env
+from lib import environment
+
+PROJECT_ROOT_PATH = os.path.dirname(os.path.abspath(__file__)) + "/../"
+
+logger = logging.getLogger("selenium.webdriver.remote.remote_connection")
+
+
+if __name__ == "__main__":
+    file_ops.create_directory(environment.LOG_PATH)
+    file_ops.delete_directory_contents(environment.LOG_PATH)
+
+    log.set_default_file_handler(
+        logger,
+        PROJECT_ROOT_PATH + constants.path.LOGS_DIR +
+        constants.path.TEST_RUNNER
+    )
+
+    logger.setLevel(environment.LOGGING_LEVEL)
+
+    pytest.main()


### PR DESCRIPTION
We wish to move away from vagrant and this pull requst make sure we can run selenium tests inside docker containers.

These tests will run, but they will also fail untill we merge https://github.com/google/ggrc-core/pull/3371.