### PR TITLE
QUICK-FIX Update obsolete request status in test

### DIFF
--- a/test/integration/ggrc/automapper/test_automappings.py
+++ b/test/integration/ggrc/automapper/test_automappings.py
@@ -309,7 +309,7 @@ class TestAutomappings(integration.ggrc.TestCase):
         'title': next('Request'),
         'assignee': {'id': creator.id},
         'request_type': 'documentation',
-        'status': 'Unstarted',
+        'status': 'Open',
         'requested_on': '1/1/2015',
         'due_on': '1/1/2016',
     })


### PR DESCRIPTION
The request in test still returns 201 status code, which shadows the actual error. There was a warning though, @Smotko knows about it.