### PR TITLE
CORE-2972 Remove old Data Grid export

### DIFF
--- a/src/ggrc/assets/javascripts/components/csv/export.js
+++ b/src/ggrc/assets/javascripts/components/csv/export.js
@@ -40,9 +40,6 @@
         filename: "Export Objects",
         get_filename: can.compute(function () {
           return this.attr("filename").replace(/\s+/, "_").toLowerCase() + ".csv";
-        }),
-        data_grid: can.compute(function () {
-          return _.has(url, "data_grid");
         })
       });
 
@@ -125,25 +122,17 @@
         ev.preventDefault();
         this.scope.attr("export.loading", true);
         var panels = this.scope.attr("export.panels.items"),
-            data_grid = this.scope.attr("export.data_grid"),
             only_relevant = this.scope.attr("export.only_relevant"),
             query = _.map(panels, function (panel, index) {
               var relevant_filter = "",
                   predicates;
-              if (data_grid && index > 0) {
-                relevant_filter = "#__previous__," + (index - 1) + "#";
-                if (only_relevant && index > 1) {
-                  relevant_filter += " AND #__previous__,0#";
-                }
-              } else {
-                predicates = _.map(panel.attr("relevant"), function (el) {
-                  var id = el.model_name === "__previous__" ? index - 1 : el.filter.id;
-                  return "#" + el.model_name + "," + id + "#";
-                });
-                relevant_filter = _.reduce(predicates, function (p1, p2) {
-                  return p1 + " AND " + p2;
-                });
-              }
+              predicates = _.map(panel.attr("relevant"), function (el) {
+                var id = el.model_name === "__previous__" ? index - 1 : el.filter.id;
+                return "#" + el.model_name + "," + id + "#";
+              });
+              relevant_filter = _.reduce(predicates, function (p1, p2) {
+                return p1 + " AND " + p2;
+              });
               return {
                 object_name: panel.type,
                 fields: _.compact(_.map(Object.keys(panel.selected), function (key) {
@@ -154,14 +143,10 @@
                   GGRC.query_parser.parse(panel.filter || "")
                 )
               };
-            }),
-            view = data_grid ? "grid" : "blocks";
+            });
 
         GGRC.Utils.export_request({
-          data: query,
-          headers: {
-            "X-export-view": view
-          }
+          data: query
         }).then(function (data) {
           GGRC.Utils.download(this.scope.attr("export.get_filename"), data);
         }.bind(this))

--- a/src/ggrc/assets/mustache/base_objects/page_header.mustache
+++ b/src/ggrc/assets/mustache/base_objects/page_header.mustache
@@ -128,11 +128,6 @@
         </a>
       </li>
       <li>
-        <a href="/export?data_grid=true">
-          Data grid
-        </a>
-      </li>
-      <li>
         <a class="nav-logout" href="/logout" tabindex="-1">
           <i class="grcicon-logout-black"></i>
           Logout

--- a/src/ggrc/assets/mustache/import_export/export.mustache
+++ b/src/ggrc/assets/mustache/import_export/export.mustache
@@ -18,11 +18,7 @@
             </div>
           {{else}}
             <h2 class="title">
-              {{#if export.data_grid}}
-                Data Grid
-              {{else}}
-                Export Objects
-              {{/if}}
+              Export Objects
             </h2>
           {{/if}}
         </div>
@@ -33,7 +29,7 @@
       <div class="relevant-filter-group">
         {{#each panels.items}}
           <div class="new-relevant-block">
-            <export-panel type="{{type}}" data_grid="export.data_grid" item="." panel_number="{{@index}}">
+            <export-panel type="{{type}}" item="." panel_number="{{@index}}">
               <div class="row-fluid">
                 <div class="span4">
                   <h6>Export object type</h6>
@@ -55,13 +51,7 @@
               {{> /static/mustache/import_export/export/attribute_selector.mustache}}
               {{> /static/mustache/import_export/export/filter_query.mustache}}
 
-              {{#if export.data_grid}}
-                {{#if_equals panel_number 0}}
-                  <relevant-filter show_all="true" type="export.type" panel_number="panel_number" relevant="item.relevant"></relevant-filter>
-                {{/if}}
-              {{else}}
-                <relevant-filter show_all="true" has_parent="item.has_parent" relevant_menu_item="parent" type="export.type" panel_number="panel_number" relevant="item.relevant"></relevant-filter>
-              {{/if}}
+              <relevant-filter show_all="true" has_parent="item.has_parent" relevant_menu_item="parent" type="export.type" panel_number="panel_number" relevant="item.relevant"></relevant-filter>
             </export-panel>
           </div>
         {{/each}}
@@ -72,23 +62,11 @@
     </export-group>
   </div>
   <div class="save-template-wrap">
-    {{#export.data_grid}}
-      <div class="left-content">
-        <label class="checkbox-inline">
-          <input type="checkbox" can-value="export.only_relevant" name="only_relevant" checked="checked">
-          Show only objects relevant to selected anchor objects
-        </label>
-      </div>
-    {{/data_grid}}
     <div class="btn-group pull-right">
       {{^export.loading}}
         <button type="submit" id="export-csv-button" class="btn btn-success btn-small">
           <i class="grcicon-export-white"></i>
-          {{#if export.data_grid}}
-            Export Data Grid
-          {{else}}
-            Export Objects
-          {{/if}}
+          Export Objects
         </button>
       {{/loading }}
       {{#export.loading}}

--- a/src/ggrc/converters/base.py
+++ b/src/ggrc/converters/base.py
@@ -54,11 +54,9 @@ class Converter(object):
     self.exportable = get_exportables()
     self.indexer = get_indexer()
 
-  def to_array(self, data_grid=False):
+  def to_array(self):
     self.block_converters_from_ids()
     self.handle_row_data()
-    if data_grid:
-      return self.to_data_grid()
     return self.to_block_array()
 
   def to_block_array(self):
@@ -77,21 +75,6 @@ class Converter(object):
       block_data[1][0] = block_converter.name
       csv_data.extend(block_data)
     return csv_data
-
-  def to_data_grid(self):
-    """ multi join datagrid with all objects in one block
-
-    Generate 2d array where each cell represents a cell in a csv file
-    """
-    grid_blocks = []
-    grid_header = []
-    for block_converter in self.block_converters:
-      csv_header, csv_body = block_converter.to_array()
-      grid_header.extend(csv_header[1])
-      if csv_body:
-        grid_blocks.append(csv_body)
-    grid_data = [list(chain(*i)) for i in product(*grid_blocks)]
-    return [grid_header] + grid_data
 
   def import_csv(self):
     self.block_converters_from_csv()

--- a/src/ggrc/templates/base_objects/_page_header.haml
+++ b/src/ggrc/templates/base_objects/_page_header.haml
@@ -76,9 +76,6 @@
         %a{'href': "/export"}
           Data export
       %li
-        %a{'href': "/export?data_grid=true"}
-          Data grid
-      %li
         %a{'href': '={ url_for("logout") }', 'tabindex': "-1"}
           %i.grcicon-logout-black
           Logout

--- a/src/ggrc/templates/import_export/export_content.haml
+++ b/src/ggrc/templates/import_export/export_content.haml
@@ -16,10 +16,7 @@
 -block widget_title
   .oneline
     %i.grcicon-imp-exp
-    - if data_grid
-      Data Grid
-    - else
-      Export Objects
+    Export Objects
 
 -block main
   #csv_export.info

--- a/src/ggrc/views/converters.py
+++ b/src/ggrc/views/converters.py
@@ -37,16 +37,15 @@ def parse_export_request():
       "X-export-view": ["blocks", "grid"],
   }
   check_required_headers(required_headers)
-  data_grid = request.headers["X-export-view"] == "grid"
-  return data_grid, request.json
+  return request.json
 
 
 def handle_export_request():
   try:
-    data_grid, data = parse_export_request()
+    data = parse_export_request()
     query_helper = QueryHelper(data)
     converter = Converter(ids_by_type=query_helper.get_ids())
-    csv_data = converter.to_array(data_grid)
+    csv_data = converter.to_array()
     csv_string = generate_csv_string(csv_data)
 
     object_names = "_".join(converter.get_object_names())
@@ -119,5 +118,4 @@ def init_converter_views():
   @app.route("/export")
   @login_required
   def export_view():
-    data_grid = request.args.get("data_grid", "").lower() == "true"
-    return render_template("import_export/export.haml", data_grid=data_grid)
+    return render_template("import_export/export.haml")


### PR DESCRIPTION
The old data grid export is broken and needs to be fully replaced, This
is a cleanup that is much easier now than it will be once the new data
grid object is fully implemented.