### PR TITLE
CORE-2978 Fix request modal error when page_model is not defined

### DIFF
--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -473,7 +473,7 @@ can.Model.Cacheable("CMS.Models.Request", {
       // Current user should be Requester
       assignees[current_user.email] = "Requester";
 
-      if (GGRC.page_model.type == "Audit") {
+      if (_.exists(GGRC, 'page_model.type') === 'Audit') {
         this.attr("audit", { id: GGRC.page_model.id, type: "Audit" });
       }
 


### PR DESCRIPTION
The script error occurs on pages where GGRC.page_model is not defined
(Import, Export, Admin etc).