### PR TITLE
QUICK-FIX Update the PR review guide

### DIFF
--- a/doc/pull_request_reviews.md
+++ b/doc/pull_request_reviews.md
@@ -231,10 +231,31 @@ are required. Along with the tagging, the reviewer should clearly explain why
 the PR has temporarily been rejected, and what needs to be done before it can
 be merged.
 
-On the other hand, if the PR looks good to merge, the reviewer expresses this
-by giving a thumb-up icon in a comment (:+1:). For this reason, the thumb-up
-icon _should not_ be used in other comments, as it might give a false
-impression that the pull request has been verified and confirmed.
+On the other hand, if the PR looks good, it can be merged immediately (subject
+to the conditions described in the [next section](#merging-pull-requests)).
+
+Sometimes, however, a PR looks good, but the reviewer is nevertheless not yet
+100% confident with merging it, usually due to its complexity and/or size, or
+his own lesser familiarity with the project codebase. In such cases, the
+reviewer can still express the approval of the PR, but defer the final verdict
+on merging to other reviewers.
+
+An approval is given by posting a comment containing a thumb-up icon (:+1:).
+For this reason, this icon icon _should not_ be used in regular comments, as it
+might mislead somebody to a false conclusion.
+
+
+#### Merging pull requests
+
+A pull request can be merged if all of the following is true:
+
+* _You_ have gone through all the verification steps and concluded that
+  everything works as expected (other people's approvals by themselves
+  _are not enough_!),
+* All automatic continuous integration checks have passed,
+* The pull request does not contain **any of your commits**. You are not
+  allowed to merge your own work, including the pull requests that you have at
+  least partially contributed to.
 
 #### Using GitHub labels
 

--- a/doc/pull_request_reviews.md
+++ b/doc/pull_request_reviews.md
@@ -94,8 +94,10 @@ TODO: if PR is marked as "migration"
     _NOTE: You have to close all current incognito browsers to get a clean
     session._
 
-    After you have verified that everything works correctly, you can remove
-    the temporary branch used for the testing:
+    Test the pull request as decribed in
+    [Part 2](#how-to-properly-review-a-pull-request) of this guide. After you
+    have verified that everything works correctly, you can remove the temporary
+    branch that was used for the testing:
 
     ```console
     git checkout develop
@@ -140,5 +142,87 @@ git pr 5678
 
 This command will automatically fetch and checkout the branch containing the
 changes in the pull request 5678.
+
+\[[Back to top](#top)\]
+
+
+## How to properly review a pull request
+
+First of all, make sure that you have properly set up the local environment as
+described in
+[Part 1](#setting-up-and-tearing-down-the-environment-for-pr-testing). Then
+follow the guidelines described in the following sections.
+
+#### Reviewing a bugfix PR
+
+If reviewing a pull request that contains a bug fix, you **must** first
+reproduce the bug on the vanilla `develop` branch, i.e. the one without the PR
+branch merged. Only after the bug has been reproduced, you can actually verify
+that the PR indeed fixes something.
+
+It is highly recommended that you also test a few other application features
+that might have been affected by the same code changes.
+
+#### Reviewing a PR containing a database migration script
+
+TODO: Ivan?
+
+TODO: should we also add a section on DB upgrade/downgrade to Part 1 (seetting
+up) the dev environment?
+
+#### Acceptance criteria
+
+A pull request **must be rejected** if **any** of the following is true:
+
+* It does not do/fix what it claims to and/or it does that only partially,
+* The review reveals that the PR has introduced new issues,
+* At least one of the automatic checks on the continuous integration server
+  fails, i.e. the build is broken,
+* The new code contains severe readability, logical and/or architectural
+  issues,
+* The new code is not sufficiently covered with automated tests (subject to
+  exceptions, e.g. when a test would be disproportionally difficult and
+  time-consuiming to write, or for little UI changes like changing an icon or a
+  font color).
+
+The reviewer must mark the pull request with the `needs work` label, signalling
+to the author that the PR cannot yet been merged as-is, and additional changes
+are required. Along with the tagging, the reviewer should clearly explain why
+the PR has temporarily been rejected, and what needs to be done before it can
+be merged.
+
+On the other hand, if the PR looks good to merge, the reviewer expresses this
+by giving a thumb-up icon in a comment (:+1:). For this reason, the thumb-up
+icon _should not_ be used in other comments, as it might give a false
+impression that the pull request has been verified and confirmed.
+
+#### Using GitHub labels
+
+There are several labels defined on the GitHub project repository page that can
+(and should!) be used for tagging pull requests. Labeling enables easier PR
+categorization and searching, thus make sure to use them.
+
+The meaning of the lables and their intended usage is as follows (sorted
+alphabetically):
+
+* `documentation` - a PR contains the updates of project documentation,
+* `migration` - a PR contains a migration script that changes the database
+  schema. Such pull requests require additional setup and verification steps,
+* `needs work` - a reviewer has concluded that the PR requires additional work
+  before it can be accepted and merged,
+* `next release` - the PR will be merged after the next release and should not
+  be merged in the current release cycle,
+* `please review` - the author asked that the PR should be reviewed with a
+  higher pripority. This label is usually used when the PR has not received
+  enough attention for a considerable time period, or because it is important
+  and attempts to resolve an important/blocking issue,
+* `question` - a reviewer requires additional explanation from the PR author
+  before a decision can be made on whether the PR meets all the requirements.
+  Occasionally, this label is also used when a reviewer makes a non-essential
+  suggestion for a PR change, but that change is not required to deem the PR
+  ready to merge,
+* `wrong branch` - the author sent the PR to the wrong branch. The author
+  should re-issue the same PR against the correct branch.
+
 
 \[[Back to top](#top)\]

--- a/doc/pull_request_reviews.md
+++ b/doc/pull_request_reviews.md
@@ -1,51 +1,144 @@
-## Simple helper/guide for reviewing pull requests
+<a name="top"></a>
+# A simple helper/guide for reviewing pull requests
 
-_Note: some steps may be ommited depending on your setup, if you're not sure, just run it all._
+This guide consists of two parts:
+* **Part 1:** Instructions on how to properly set up (and tear down) the local
+    environment for testing the pull request -
+    [link to Part 1](#setting-up-and-tearing-down-the-environment-for-pr-testing).
+* **Part 2**: Instructions on how to actually review a pull request -
+    [link to Part 2](#how-to-properly-review-a-pull-request).
 
-1. make sure you're up to date
+
+## Setting up (and tearing down) the environment for PR testing
+
+_NOTE: Before doing anything else, if you are reviewing a bugfix pull request,
+you must first reproduce the issue on the main development branch as described
+in [Part 2](#reviewing-a-bugfix-pr)._
+
+_NOTE: Depending on your setup, some of the following steps may be omitted. If
+you are not sure, just run them all._
+
+1. Make sure your local files are up to date:
+
+    ```console
+    cd to/your/ggrc/clone
+    git stash
+    git checkout develop
+    git fetch <remote_main>
+    git rebase <remote_main>/develop
+    ```
+
+    Here `<remote_main>` stands for the name of the _remote_ representing the
+    main development repository, i.e. the one the pull requests are sent to.
+    Such a remote is commonly named `upstream`.
+
+1. Test should be done on the merged branch:
+
+    _NOTE: The merge must be a fast-forward, since all pull requests are merged
+    with the `--no-ff` flag._
+
+    ```console
+    git checkout -b temp_branch
+    git fetch <pr_origin>
+    git merge --no-ff <pr_origin>/<feature_branch_name>
+    ```
+
+    Here `<pr_origin>` stands for the name of the _remote_ the pull request
+    is originating from. This is most often a fork of the `<remote_main>` by
+    one of the fellow developers on the project.
+
+    `<feature_branch_name>` must of course be replaced with the actual name of
+    the remote branch containing the changes, e.g. `feature/CORE-1234`.
+
+    If you don't yet have the `<pr_origin>` defined, you need to add it
+    ([instructions](https://git-scm.com/book/en/v2/Git-Basics-Working-with-Remotes#Adding-Remote-Repositories)).
+
+1. Start your local development environment (Vagrant or Docker). No need if you
+already have it running.
+
+    ##### If using Vagrant
+
+    ```console
+    vagrant up
+
+    # run the following if there were any changes in the provisioning files,
+    # requirements, dev-requirements, or npm requirements...
+    vagrant provision
+
+    vagrant ssh
+    ```
+
+    ##### If using Docker
+
+    ```console
+    # TODO: write Docker commands
+    ```
+
+1. (optional) Run database migration
+
+TODO: if PR is marked as "migration"
+
+1. Rebuild all asset files and lauch the application:
+
+    ```console
+    deploy_appengine extras/deploy_settings_local.sh
+    launch_ggrc
+    ```
+
+1. Test in the application in incognito mode.
+
+    _HINT: For incognito mode in Chrome press
+    <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>n</kbd>
+    (or <kbd>⌘Cmd</kbd>+<kbd>Shift</kbd>+<kbd>n</kbd> on Mac)_
+
+    _NOTE: You have to close all current incognito browsers to get a clean
+    session._
+
+    After you have verified that everything works correctly, you can remove
+    the temporary branch used for the testing:
+
+    ```console
+    git checkout develop
+    git branch -D temp_branch
+    ```
+
+1. Go back to your branch and continue with your work:
+
+    ```console
+    git checkout my/previous-branch
+    git stash pop  # only needed if you had any changes stashed in Step 1
+    ```
+
+#### Tip: Automatically checking out a pull request by its ID
+
+If you feel that manually fetching and merging a pull request branch is too
+tedious, you can add the following convenient git alias to your `.gitconfig`
+file (e.g. the one located in your home directory):
+
+```ini
+[alias]
+  pr = "!f() { \
+    git checkout develop; \
+    git branch -D pr-$1; \
+    git fetch upstream develop:pr-$1; \
+    git checkout pr-$1; \
+    git fetch upstream pull/$1/head; \
+    git merge --no-ff FETCH_HEAD -m \"Automatic merge\"; \
+  }; f"
+```
+
+_NOTE: The alias assumes that the _remote_ representing the main development
+repository is referred to as `upstream`. This is a common convention, but if
+your local configuration uses a different name, you must replace the two
+appearances of the word `upstream` in the alias with that name._
+
+With this alias defined, you can now simply type the following:
 
 ```
-cd to/your/ggrc/clone 
-git stash
-git checkout develop 
-git fetch origin 
-git rebase origin/develop 
+git pr 5678
 ```
 
-2.  test should be done on the merged branch.
-_Note: if the merge is not a fast-forward, it could break a few things._
+This command will automatically fetch and checkout the branch containing the
+changes in the pull request 5678.
 
-```
-git checkout -b temp_branch 
-git merge origin/feature/CORE-1195 
-```
-
-3. Start your dev env. No need if you already have it running
-```
-vagrant up
-
-# run this if there were any changes in the provision/ foder
-vagrant provision 
-
-vagrant ssh
-```
-
-4. Lauch the app
-```
-git checkout developy_appengine extras/deploy_settings_local.sh
-launch_ggrc
-```
-
-5. test in the incognito mode. Chrome: ctrl+shift+n
-_Note: that you have to close all current incognito browsers to get a clean sesion._
-```
-git checkout develop 
-git branch -D temp_branch
-```
-
-6. Go back to your branch and contiue with your work
-```
-git checkout my/previous-branch
-git stash pop
-```
-
+\[[Back to top](#top)\]

--- a/doc/pull_request_reviews.md
+++ b/doc/pull_request_reviews.md
@@ -22,10 +22,9 @@ you are not sure, just run them all._
 
     ```console
     cd to/your/ggrc/clone
-    git stash
-    git checkout develop
+    git stash  # make sure you don't have any local changes
     git fetch <remote_main>
-    git rebase <remote_main>/develop
+    git checkout <remote_main>/develop
     ```
 
     Here `<remote_main>` stands for the name of the _remote_ representing the
@@ -34,8 +33,8 @@ you are not sure, just run them all._
 
 1. Test should be done on the merged branch:
 
-    _NOTE: The merge must be a fast-forward, since all pull requests are merged
-    with the `--no-ff` flag._
+    _NOTE: The merge must **not** be a fast-forward, since all pull requests
+    are merged with the `--no-ff` flag._
 
     ```console
     git checkout -b temp_branch
@@ -156,7 +155,7 @@ file (e.g. the one located in your home directory):
   }; f"
 ```
 
-_NOTE: The alias assumes that the _remote_ representing the main development
+_NOTE: The alias assumes that the remote representing the main development
 repository is referred to as `upstream`. This is a common convention, but if
 your local configuration uses a different name, you must replace the two
 appearances of the word `upstream` in the alias with that name._
@@ -247,7 +246,7 @@ might mislead somebody to a false conclusion.
 
 #### Merging pull requests
 
-A pull request can be merged if all of the following is true:
+A pull request can be merged only if **all** of the following is true:
 
 * _You_ have gone through all the verification steps and concluded that
   everything works as expected (other people's approvals by themselves
@@ -256,6 +255,8 @@ A pull request can be merged if all of the following is true:
 * The pull request does not contain **any of your commits**. You are not
   allowed to merge your own work, including the pull requests that you have at
   least partially contributed to.
+* The pull request is **not** labeled with the `needs work` or the `question`
+  label, meaning that all open questions and issues have been resolved.
 
 #### Using GitHub labels
 
@@ -271,17 +272,19 @@ alphabetically):
   schema. Such pull requests require additional setup and verification steps,
 * `needs work` - a reviewer has concluded that the PR requires additional work
   before it can be accepted and merged,
-* `next release` - the PR will be merged after the next release and should not
-  be merged in the current release cycle,
+* `next release` - the PR will be merged after the current release has branched
+  off of the main development branch, and should not be merged just yet,
 * `please review` - the author asked that the PR should be reviewed with a
   higher pripority. This label is usually used when the PR has not received
   enough attention for a considerable time period, or because it is important
   and attempts to resolve an important/blocking issue,
-* `question` - a reviewer requires additional explanation from the PR author
-  before a decision can be made on whether the PR meets all the requirements.
-  Occasionally, this label is also used when a reviewer makes a non-essential
-  suggestion for a PR change, but that change is not required to deem the PR
-  ready to merge,
+* `question` - the PR author seeks advice/feedback on some code feature and/or
+  design decision. It can also be used by a reviewer to ask the PR author for
+  additional explanation before a decision can be made on whether the PR meets
+  all the requirements.
+  On top of that, this label is occasionally used when a reviewer makes a
+  non-essential suggestion for a PR change, but that change is not required to
+  deem the PR ready to merge,
 * `wrong branch` - the author sent the PR to the wrong branch. The author
   should re-issue the same PR against the correct branch.
 


### PR DESCRIPTION
**NOTE:** There are still two pieces missing - the section on Docker and on reviewing the PRs containing DB migration scripts. Both are marked with a TODO comment. I need help on this, as I have almost no experience with either. Please send any pull request to my `fix-pr-guide` branch, thanks!

----

For convenience, here's the link to the rendered version of the new file - https://github.com/plamut/ggrc-core/blob/fix-pr-guide/doc/pull_request_reviews.md

The existing file - https://github.com/google/ggrc-core/blob/develop/doc/pull_request_reviews.md