### PR TITLE
CORE-2992 Fix email checkboxes

### DIFF
--- a/src/ggrc/assets/javascripts/models/notification_config.js
+++ b/src/ggrc/assets/javascripts/models/notification_config.js
@@ -14,11 +14,11 @@
     root_object: "notification_config",
     root_collection: "notification_configs",
     category: "person",
-    findAll: "GET /api/notification_config",
-    findOne: "GET /api/notification_config/{id}",
-    create: "POST /api/notification_config",
-    update: "PUT /api/notification_config/{id}",
-    destroy: "DELETE /api/notification_config/{id}",
+    findAll: "GET /api/notification_configs",
+    findOne: "GET /api/notification_configs/{id}",
+    create: "POST /api/notification_configs",
+    update: "PUT /api/notification_configs/{id}",
+    destroy: "DELETE /api/notification_configs/{id}",
     active: "POST /api/set_active_notifications",
 
     findActive: function(){

--- a/src/ggrc/assets/mustache/base_objects/page_header.mustache
+++ b/src/ggrc/assets/mustache/base_objects/page_header.mustache
@@ -111,10 +111,6 @@
             <input type="checkbox" name="notifications" value="Email_Digest">
             Daily email digest
           </label>
-          <label class="inner disabled">
-            <input type="checkbox" name="notifications" value="Email_Now" disabled>
-            Real-time email updates
-          </label>
         </div>
       </li>
       <li>

--- a/src/ggrc/services/__init__.py
+++ b/src/ggrc/services/__init__.py
@@ -67,7 +67,7 @@ def contributed_services():
           'systems_or_processes', models.SystemOrProcess, ReadOnlyResource),
       service('systems', models.System),
       service('processes', models.Process),
-      service('notification_config', models.NotificationConfig),
+      service('notification_configs', models.NotificationConfig),
       service('issues', models.Issue),
   ]
 

--- a/src/ggrc/templates/base_objects/_page_header.haml
+++ b/src/ggrc/templates/base_objects/_page_header.haml
@@ -62,13 +62,6 @@
               'value': 'Email_Digest'
             }
             Daily email digest
-          %label.inner
-            %input{
-              'type': 'checkbox',
-              'name': 'notifications',
-              'value': 'Email_Now'
-            }
-            Real-time email updates
       %li
         %a{'href': "/import"}
           Data import


### PR DESCRIPTION
Two things:

1. I have removed the real-time updates checkbox as we don't have real-time email notifications implemented yet.
2. I had to rename our notification_config service endpoint to notification_configs as otherwise the POST request was failing.

steps to reproduce 2.: 

1. Make sure your current user has no rows in the notification_configs table (this is not the same as not having any notifications enabled). If the user already has a row in notification_configs table PUT request will be sent and not POST.
2. Try to disable email digest notifications.