### PR TITLE
CORE-2003 Add static file handler to app.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ src/ggrc/settings/build_number.py
 # Asset-pipeline/cache related files
 src/ggrc/static/.webassets-cache
 src/ggrc/static/webassets-external
-src/ggrc/static/assets.manifest
+src/ggrc/assets/assets.manifest
 src/ggrc/static/dashboard*
 src/ggrc/static/app-init*
 src/ggrc/static/mockup*

--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ setup_dev : dev_virtualenv_packages linked_packages
 src/ggrc/assets/stylesheets/dashboard.css : src/ggrc/assets/stylesheets/*.scss
 	bin/build_compass
 
-src/ggrc/static/assets.manifest : src/ggrc/assets/stylesheets/dashboard.css src/ggrc/assets
+src/ggrc/assets/assets.manifest : src/ggrc/assets/stylesheets/dashboard.css src/ggrc/assets
 	source "bin/init_env"; \
 		GGRC_SETTINGS_MODULE="$(SETTINGS_MODULE)" bin/build_assets
 
@@ -159,11 +159,11 @@ bower_components : bower.json
 clean_bower_components :
 	rm -rf $(BOWER_PATH) $(FLASH_PATH) $(STATIC_PATH)/fonts
 
-deploy : appengine_packages_zip bower_components src/ggrc/static/assets.manifest src/app.yaml
+deploy : appengine_packages_zip bower_components src/ggrc/assets/assets.manifest src/app.yaml
 
 clean_deploy :
 	rm -f src/ggrc/assets/stylesheets/dashboard.css
-	rm -f src/ggrc/static/dashboard-*.* src/ggrc/static/assets.manifest
+	rm -f src/ggrc/static/dashboard-*.* src/ggrc/assets/assets.manifest
 	rm -f src/app.yaml
 
 clean : clean_deploy clean_bower_components

--- a/src/app.yaml.dist
+++ b/src/app.yaml.dist
@@ -15,6 +15,12 @@ manual_scaling:
   instances: {MAX_INSTANCES}
 
 handlers:
+  - url: /(static/(fonts|images|flash).*)
+    static_files: ggrc/\1
+    upload: ggrc/static/(fonts|images|flash).*
+    http_headers:
+      Access-Control-Allow-Origin: '*'
+
   - url: /login
     script: ggrc.app.app.wsgi_app
     login: required

--- a/src/app.yaml.dist
+++ b/src/app.yaml.dist
@@ -15,9 +15,8 @@ manual_scaling:
   instances: {MAX_INSTANCES}
 
 handlers:
-  - url: /(static/(fonts|images|flash).*)
-    static_files: ggrc/\1
-    upload: ggrc/static/(fonts|images|flash).*
+  - url: /static
+    static_dir: ggrc/static
     http_headers:
       Access-Control-Allow-Origin: '*'
 

--- a/src/ggrc/assets.py
+++ b/src/ggrc/assets.py
@@ -27,10 +27,13 @@ from . import settings
 
 # Initialize webassets to handle the asset pipeline
 import webassets
+import os
+import yaml
+import imp
 
 environment = webassets.Environment()
-
-environment.manifest = 'file:assets.manifest'
+manifest = os.path.join(settings.BASE_DIR, 'ggrc', 'assets', 'assets.manifest')
+environment.manifest = 'file:' + manifest
 environment.versions = 'hash:32'
 
 # `asset-debug` mode doesn't merge bundles into a single file
@@ -44,7 +47,7 @@ import webassets.updater
 environment.updater = webassets.updater.TimestampUpdater()
 
 # Read asset listing from YAML file
-import os, yaml, imp
+
 assets_yamls = [os.path.join(settings.MODULE_DIR, 'assets', 'assets.yaml'),]
 
 module_load_paths = [settings.MODULE_DIR, ]


### PR DESCRIPTION
This should fix broken font loading on appengine and it also makes sure that static/images/ static/flash and static/fonts folders are loaded by appengine as static files instead of them being handled by flask.

I still need to figure out why I can't simply add the whole /ggrc/static folder as a static asset. I have tried this, but I started getting server errors from our asset bundler:

```
 File "/base/data/home/apps/s~grc-dev/1.389836182148955331/packages.zip/webassets/bundle.py", line 227, in get_version
    'determined dynamically, because: %s') % (self, reason))
BundleError: Cannot find version of <Bundle output=dashboard-%(version)s.css, filters=(), contents=('dashboard.css', 'wysihtml5/bootstrap-wysihtml5-0.0.2.css', 'jquery/jquery-ui.css')>. There is no manifest which knows the version, and it cannot be determined dynamically, because: output target has a placeholder
```