### PR TITLE
QUICK-FIX Remove install packages task

### DIFF
--- a/provision/roles/ggrc/tasks/main.yml
+++ b/provision/roles/ggrc/tasks/main.yml
@@ -4,11 +4,6 @@
 # Maintained By: goran@reciprocitylabs.com
 
 ---
-- name: install requirements
-  sudo: yes
-  pip:
-    requirements: "/vagrant/src/requirements.txt"
-
 - name: install packages
   sudo: yes
   with_items: ggrc_packages


### PR DESCRIPTION
There is no need to install python packages globally we install them
to the virtual env in a later step