### PR TITLE
CORE-2403 Cache permissions query

### DIFF
--- a/src/ggrc_basic_permissions/__init__.py
+++ b/src/ggrc_basic_permissions/__init__.py
@@ -213,10 +213,12 @@ def load_permissions_for(user):
       # remove all permissions related keys from memcache
       cached_keys_set.add(key)
       cache.set('permissions:list', cached_keys_set, PERMISSION_CACHE_TIMEOUT)
-    elif cache.get(key):
-      # If the key is both in permissions:list and in memcache itself
-      # it is safe to return the cached permissions
-      return cache.get(key)
+    else:
+      permissions_cache = cache.get(key)
+      if permissions_cache:
+        # If the key is both in permissions:list and in memcache itself
+        # it is safe to return the cached permissions
+        return permissions_cache
 
   # Add default `Help` and `NotificationConfig` permissions for everyone
   # FIXME: This should be made into a global base role so it can be extended

--- a/src/ggrc_basic_permissions/__init__.py
+++ b/src/ggrc_basic_permissions/__init__.py
@@ -22,6 +22,7 @@ from ggrc.rbac import permissions
 from ggrc.rbac.permissions_provider import DefaultUserPermissions
 from ggrc.services.registry import service
 from ggrc.services.common import Resource
+from ggrc.services.common import _get_cache_manager
 from . import basic_roles
 from ggrc.utils import benchmark
 from .contributed_roles import lookup_role_implications
@@ -199,7 +200,23 @@ def load_permissions_for(user):
   'condition' is the string name of a conditional operator, such as 'contains'.
   'terms' are the arguments to the 'condition'.
   """
+  PERMISSION_CACHE_TIMEOUT = 1800 # 30 minutes
   permissions = {}
+  key = 'permissions:{}'.format(user.id)
+  cache = None
+
+  if getattr(settings, 'MEMCACHE_MECHANISM', False):
+    cache = _get_cache_manager().cache_object.memcache_client
+    cached_keys_set = cache.get('permissions:list') or set()
+    if key not in cached_keys_set:
+      # We set the permissions:list variable so that we are able to batch
+      # remove all permissions related keys from memcache
+      cached_keys_set.add(key)
+      cache.set('permissions:list', cached_keys_set, PERMISSION_CACHE_TIMEOUT)
+    elif cache.get(key):
+      # If the key is both in permissions:list and in memcache itself
+      # it is safe to return the cached permissions
+      return cache.get(key)
 
   # Add default `Help` and `NotificationConfig` permissions for everyone
   # FIXME: This should be made into a global base role so it can be extended
@@ -353,6 +370,15 @@ def load_permissions_for(user):
       .setdefault('__GGRC_ALL__', dict())\
       .setdefault('contexts', list())\
       .append(personal_context.id)
+
+  if cache is not None:
+    cached_keys_set = cache.get('permissions:list') or set()
+    if key in cached_keys_set:
+      # We only add the permissions to the cache if the
+      # key still exists in the permissions:list after
+      # the query has executed.
+      cache.set(key, permissions, PERMISSION_CACHE_TIMEOUT)
+
   return permissions
 
 


### PR DESCRIPTION
You can test these changes locally by running `launch_gae_ggrc`. 

From my testing there seems to be a visible improvement when testing locally:

Without permissions cache:
<img width="680" alt="screen shot 2016-01-12 at 09 30 12" src="https://cloud.githubusercontent.com/assets/513444/12258581/f6e405e2-b90f-11e5-9827-3a45c90bdb39.png">

With permissions cache:
<img width="680" alt="screen shot 2016-01-12 at 09 29 26" src="https://cloud.githubusercontent.com/assets/513444/12258579/f567e864-b90f-11e5-9137-40f2502baa5c.png">

But I believe the performance improvement on appengine will be even grater, because without caching grc-dev looks like this:

<img width="574" alt="screen shot 2016-01-12 at 09 39 20" src="https://cloud.githubusercontent.com/assets/513444/12258640/66738356-b910-11e5-9fa4-dbbeebca1972.png">

And I have verified that the bulk of the time in these 17s requests is spent inside the load_permissions_for function that this PR is going to cache:

<img width="1636" alt="screen shot 2016-01-12 at 09 41 27" src="https://cloud.githubusercontent.com/assets/513444/12258688/b7f996ca-b910-11e5-865b-d42f1ced6e83.png">

