### PR TITLE
CORE-2546 Improve auto mapping performance

### DIFF
--- a/src/ggrc/automapper/__init__.py
+++ b/src/ggrc/automapper/__init__.py
@@ -62,9 +62,7 @@ class AutomapperGenerator(object):
         cols.filter(
             tuple_(Relationship.destination_type,
                    Relationship.destination_id).in_(
-                [(s.type, s.id) for s in stubs]
-            )
-        )
+                       [(s.type, s.id) for s in stubs]))
     ).all()
     for (src_type, src_id, dst_type, dst_id) in relationships:
       src = Stub(src_type, src_id)
@@ -154,9 +152,9 @@ class AutomapperGenerator(object):
           if (src, dst) != original]))  # (src, dst) is sorted
 
   def _step(self, src, dst):
-      explicit, implicit = rules[src.type, dst.type]
-      self._step_explicit(src, dst, explicit)
-      self._step_implicit(src, dst, implicit)
+    explicit, implicit = rules[src.type, dst.type]
+    self._step_explicit(src, dst, explicit)
+    self._step_implicit(src, dst, implicit)
 
   def _step_explicit(self, src, dst, explicit):
     if len(explicit) != 0:

--- a/src/ggrc/converters/handlers/handlers.py
+++ b/src/ggrc/converters/handlers/handlers.py
@@ -397,8 +397,12 @@ class MappingColumnHandler(ColumnHandler):
       elif self.unmap and mapping:
         db.session.delete(mapping)
     db.session.flush()
+    # it is safe to reuse this automapper since no other objects will be
+    # created while creating automappings and cache reuse yields significant
+    # performance boost
+    automapper = AutomapperGenerator(use_benchmark=False)
     for relation in relationships:
-      AutomapperGenerator(relation, False).generate_automappings()
+      automapper.generate_automappings(relation)
     self.dry_run = True
 
   def get_value(self):
@@ -817,8 +821,12 @@ class ResponseMappedObjectsColumnHandler(ColumnHandler):
       new_relationships.append(rel)
       db.session.add(rel)
     db.session.flush()
+    # it is safe to reuse this automapper since no other objects will be
+    # created while creating automappings and cache reuse yields significant
+    # performance boost
+    automapper = AutomapperGenerator(use_benchmark=False)
     for rel in new_relationships:
-      AutomapperGenerator(rel, False).generate_automappings()
+      automapper.generate_automappings(rel)
     self.dry_run = True
 
   def set_obj_attr(self):


### PR DESCRIPTION
This massively improves performance of auto mappings, especially in imports where there may be a lot of them. 
The problematic CSA import mentioned in the ticket doesn't finish in about 3 days (aborted after that much time) and successfully completes in about 5 minutes on this branch.

I cannot compare the results since before and after this change since nobody managed to import the file on develop but I did compare the results before and after adding the cut optimization - no changes (which is good).

I suggest reviewing this commit-by-commit since I tried to logically separate optimizations and add some minimal documentation in form of comments. 