### PR TITLE
QUICK-FIX Enable multi tenant docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ADD . /vagrant
 
 WORKDIR /vagrant
 
-RUN apt-get update && apt-get install -y ansible python-apt python-pycurl wget
+RUN apt-get update && apt-get install -y ansible python-apt python-pycurl wget bindfs
 
 RUN useradd -G sudo -m vagrant \
  && echo "vagrant ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers \

--- a/bin/run_selenium
+++ b/bin/run_selenium
@@ -7,25 +7,32 @@
 set -o nounset
 set -o errexit
 
+PROJECT=testing
 SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
 
 cd "${SCRIPTPATH}/.."
 
-docker-compose -f docker-compose-testing.yml -p testing up --force-recreate -d
+docker-compose -f docker-compose-testing.yml -p ${PROJECT} up --force-recreate -d
+
+if [[ $UID != 1000 ]]; then
+  docker exec -i ${PROJECT}_dev_1 sh -c "
+  bindfs /vagrant_bind /vagrant --map=$UID/1000 -o nonempty
+  "
+fi
 
 # This provisioning is needed until the provision script stops changing the
 # /vagrant folder and so the containe can then be propperly provisioned with
 # docker-compose build.
 
-echo "Provisioning testing_dev_1"
-docker exec -i testing_dev_1 su vagrant -c \
+echo "Provisioning ${PROJECT}_dev_1"
+docker exec -i ${PROJECT}_dev_1 su vagrant -c \
   "ansible-playbook -i provision/docker/inventory provision/site.yml"
 
 echo "Running Test server"
-docker exec -id testing_dev_1 /vagrant/bin/launch_ggrc_test
+docker exec -id ${PROJECT}_dev_1 /vagrant/bin/launch_ggrc_test
 
 echo "Running Selenium tests"
-docker exec -i testing_selenium_1 python /selenium/src/run_selenium.py && \
+docker exec -i ${PROJECT}_selenium_1 python /selenium/src/run_selenium.py && \
   rc=$? || rc=$?
 
 docker-compose stop

--- a/bin/run_selenium
+++ b/bin/run_selenium
@@ -35,6 +35,9 @@ echo "Running Selenium tests"
 docker exec -i ${PROJECT}_selenium_1 python /selenium/src/run_selenium.py && \
   rc=$? || rc=$?
 
+docker exec -i ${PROJECT}_dev_1 sh -c "chown $UID -R /vagrant"
+docker exec -i ${PROJECT}_selenium_1 sh -c "chown $UID -R /selenium"
+
 docker-compose stop
 
 exit $rc

--- a/docker-compose-testing.yml
+++ b/docker-compose-testing.yml
@@ -3,6 +3,7 @@ dev:
   command: /sbin/my_init
   volumes:
    - ".:/vagrant"
+   - ".:/vagrant_bind"
    - "./provision/docker/mysql:/etc/mysql/conf.d"
   privileged: true
   environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ dev:
    - "9876:9876"
   volumes:
    - ".:/vagrant"
+   - ".:/vagrant_bind"
    - "./provision/docker/mysql:/etc/mysql/conf.d"
   privileged: true
   environment:


### PR DESCRIPTION
This makes sure that any user with any uid can run the run_selenium
script in a clean repo clone without and always get the correct results.