### PR TITLE
CORE-2794 Make sure _create_relationship calls run after pending_joins

### DIFF
--- a/src/ggrc/assets/javascripts/models/cacheable.js
+++ b/src/ggrc/assets/javascripts/models/cacheable.js
@@ -440,7 +440,9 @@ can.Model("can.Model.Cacheable", {
         });
 
         obj.attr('_pending_joins', []);
+        obj.attr('_pending_joins_dfd', $.when.apply($, dfds));
         return $.when.apply($, dfds).then(function() {
+          can.trigger(this, "resolved");
           return obj.refresh();
         });
       });


### PR DESCRIPTION
To reproduce the original issue run the app locally with `launch_gae_ggrc`. The issue was that the relationship were created at the same moment as owners which caused relationships to fail.