### PR TITLE
QUICK-FIX Update jenkins runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ cd test/unit; sniffer
 On the host machine in the root of the repository run:
 
 ```sh
-./bin/run_selenium
+./bin/jenkins/run_selenium
 ```
 
 Quickstart Breakdown

--- a/bin/check_eslint_diff
+++ b/bin/check_eslint_diff
@@ -21,12 +21,12 @@ function eslint_issues() {
 }
 
 function print_usage() {
-  echo $"Usage: $0 [-t BRANCH_NAME] [--merge-target BRANCH_NAME]"
+  echo $"Usage: $0 [-t BRANCH_NAME]"
 }
 
 
 # the name of the branch the current branch will be merged into
-TARGET_BRANCH="develop"
+TARGET_BRANCH=""
 
 
 # parse the command line options
@@ -35,7 +35,7 @@ do
   OPT_NAME="$1"
 
   case $OPT_NAME in
-    -t|--merge-target)
+    -t)
     if [[ "$#" -lt 2 ]]; then  # option value not specified
       print_usage
       exit 1
@@ -67,10 +67,14 @@ echo "*** Javascript code style check ***"
 SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
 cd "${SCRIPTPATH}/../"
 
-
-# Determine the number of JS code issues at the point the PR branch was
-# forked off from the $TARGET_BRANCH branch (i.e. the merge base)
-MERGE_BASE_HASH=$(git merge-base "$TARGET_BRANCH" HEAD)
+if [[ "$TARGET_BRANCH" != "" ]]; then
+  # Determine the number of JS code issues at the point the PR branch was
+  # forked off from the $TARGET_BRANCH branch (i.e. the merge base)
+  MERGE_BASE_HASH=$(git merge-base "$TARGET_BRANCH" HEAD)
+else
+  # Previous commit on current branch
+  MERGE_BASE_HASH=$(git show --pretty=raw HEAD | grep parent | head -1 | grep -oE "[^ ]*$")
+fi
 
 echo -n "Checking out the merge base of $TARGET_BRANCH and the current branch"
 echo -n " (${MERGE_BASE_HASH:0:7})..."

--- a/bin/check_eslint_diff
+++ b/bin/check_eslint_diff
@@ -8,8 +8,8 @@
 set -o nounset
 set -o errexit
 
-FAIL_PREFIX="$(tput bold)$(tput setaf 1)FAIL$(tput sgr0)"
-PASS_PREFIX="$(tput bold)$(tput setaf 2)PASS$(tput sgr0)"
+FAIL_PREFIX="FAIL"
+PASS_PREFIX="PASS"
 
 # runs ESLint on the sources and extract the number of code style issues found
 function eslint_issues() {
@@ -97,11 +97,11 @@ echo "found $N_ISSUES_PR issue(s)"
 N_ISS_DIFF=$((N_ISSUES_PR - N_ISSUES_BASE))
 
 if [[ "$N_ISS_DIFF" -gt 0 ]]; then
-  N_ISS_DIFF_TEXT="$(tput setaf 1)$N_ISS_DIFF$(tput sgr0)"
+  N_ISS_DIFF_TEXT="$N_ISS_DIFF"
   MSG="$FAIL_PREFIX: The PR would increase the ESLInt issue count."
   EXIT_CODE=1
 else
-  N_ISS_DIFF_TEXT="$(tput setaf 2)$N_ISS_DIFF$(tput sgr0)"
+  N_ISS_DIFF_TEXT="$N_ISS_DIFF"
   MSG="$PASS_PREFIX: The PR branch will not increase the ESLint issue count."
   EXIT_CODE=0
 fi

--- a/bin/check_flake8_diff
+++ b/bin/check_flake8_diff
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+# Created By: miha@reciprocitylabs.com
+# Maintained By: miha@reciprocitylabs.com
+
+set -o nounset
+set -o errexit
+
+SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
+cd "${SCRIPTPATH}/../"
+
+CURRENT_COMMIT=$(git rev-parse HEAD)
+PARENT_1=$(git show --pretty=raw $CURRENT_COMMIT | grep parent | head -1 | grep -oE "[^ ]*$")
+PARENT_2=$(git show --pretty=raw $CURRENT_COMMIT | head -6 | grep parent | tail -1 | grep -oE "[^ ]*$")
+BASE_COMMIT=$(git merge-base $PARENT_1 $PARENT_2)
+
+# List files changed in a commit, or if it's a merge commit, list files chaged
+# from the begin of the branch to the last commit on the merged branch.
+if [[ "$PARENT_2" == "$BASE_COMMIT" ]]; then
+  CHANGED_FILES=$(git diff-tree --no-commit-id --name-only -r $BASE_COMMIT)
+else
+  CHANGED_FILES=$(git diff --name-only $BASE_COMMIT $PARENT_2 | grep "\.py$" || true )
+fi
+
+if [[ "$CHANGED_FILES" == "" ]]; then
+  echo "No python files changed. Skipping flake checks"
+  exit 0
+fi
+
+echo "Checking files:"
+echo "$CHANGED_FILES"
+echo ""
+
+echo $CHANGED_FILES | xargs flake8

--- a/bin/check_pylint_diff
+++ b/bin/check_pylint_diff
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+# Created By: miha@reciprocitylabs.com
+# Maintained By: miha@reciprocitylabs.com
+
+set -o nounset
+set -o errexit
+
+if [[ "${1:-}" != "" ]]; then
+  TEST_COMMIT=$1
+else
+  TEST_COMMIT=$(git rev-parse HEAD)
+fi
+
+CURRENT_COMMIT=$(git rev-parse HEAD)
+PARENT_1=$(git show --pretty=raw $TEST_COMMIT | grep parent | head -1 | grep -oE "[^ ]*$")
+
+echo "Comparing commits $TEST_COMMIT and $PARENT_1."
+
+git checkout --quiet $PARENT_1
+pylint src/* > /dev/null 2>&1 | true
+
+git checkout --quiet $TEST_COMMIT
+PYLINT_RESULT=$(pylint src/* 2> /dev/null | tail -n 2) 
+
+git checkout --quiet $CURRENT_COMMIT
+
+echo $PYLINT_RESULT
+echo $PYLINT_RESULT | grep "+" && rc=$? || rc=$?
+
+exit $rc

--- a/bin/check_pylint_diff
+++ b/bin/check_pylint_diff
@@ -8,6 +8,9 @@
 set -o nounset
 set -o errexit
 
+SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
+cd "${SCRIPTPATH}/.."
+
 if [[ "${1:-}" != "" ]]; then
   TEST_COMMIT=$1
 else
@@ -21,13 +24,10 @@ echo "Comparing commits $TEST_COMMIT and $PARENT_1."
 
 git checkout --quiet $PARENT_1
 pylint src/* > /dev/null 2>&1 | true
-
 git checkout --quiet $TEST_COMMIT
 PYLINT_RESULT=$(pylint src/* 2> /dev/null | tail -n 2) 
-
 git checkout --quiet $CURRENT_COMMIT
 
-echo $PYLINT_RESULT
-echo $PYLINT_RESULT | grep "+" && rc=$? || rc=$?
+echo "$PYLINT_RESULT" | grep "+" && rc=$? || rc=$?
 
 exit $rc

--- a/bin/jenkins/run_eslint
+++ b/bin/jenkins/run_eslint
@@ -24,12 +24,12 @@ echo "Provisioning ${PROJECT}_dev_1"
 docker exec -i ${PROJECT}_dev_1 su vagrant -c \
   "ansible-playbook -i provision/docker/inventory provision/site.yml"
 
-echo "Running eslint"
+echo "Running ${PROJECT}"
 docker exec -i ${PROJECT}_dev_1 /vagrant/bin/check_eslint_diff && rc=$? || rc=$?
 
 docker exec -i ${PROJECT}_dev_1 sh -c "chown $UID -R /vagrant"
 docker exec -i ${PROJECT}_selenium_1 sh -c "chown $UID -R /selenium"
 
-docker-compose stop
+docker-compose -p ${PROJECT} stop
 
 exit $rc

--- a/bin/jenkins/run_eslint
+++ b/bin/jenkins/run_eslint
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+# Created By: miha@reciprocitylabs.com
+# Maintained By: miha@reciprocitylabs.com
+
+set -o nounset
+set -o errexit
+
+PROJECT="eslint"
+SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
+
+cd "${SCRIPTPATH}/../.."
+
+docker-compose -f docker-compose-testing.yml -p ${PROJECT} up --force-recreate -d
+
+if [[ $UID != 1000 ]]; then
+  docker exec -i ${PROJECT}_dev_1 sh -c "
+  bindfs /vagrant_bind /vagrant --map=$UID/1000 -o nonempty
+  "
+fi
+
+echo "Provisioning ${PROJECT}_dev_1"
+docker exec -i ${PROJECT}_dev_1 su vagrant -c \
+  "ansible-playbook -i provision/docker/inventory provision/site.yml"
+
+echo "Running eslint"
+docker exec -i ${PROJECT}_dev_1 /vagrant/bin/check_eslint_diff && rc=$? || rc=$?
+
+docker exec -i ${PROJECT}_dev_1 sh -c "chown $UID -R /vagrant"
+docker exec -i ${PROJECT}_selenium_1 sh -c "chown $UID -R /selenium"
+
+docker-compose stop
+
+exit $rc

--- a/bin/jenkins/run_flake8
+++ b/bin/jenkins/run_flake8
@@ -7,7 +7,7 @@
 set -o nounset
 set -o errexit
 
-PROJECT="integration"
+PROJECT="flake"
 SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
 
 cd "${SCRIPTPATH}/../.."
@@ -27,7 +27,7 @@ docker exec -i ${PROJECT}_dev_1 su vagrant -c \
 echo "Running ${PROJECT}"
 docker exec -i ${PROJECT}_dev_1 su vagrant -c "
   source /vagrant/bin/init_vagrant_env
-  /vagrant/bin/run_integration
+  /vagrant/bin/check_flake8_diff
 " && rc=$? || rc=$?
 
 docker exec -i ${PROJECT}_dev_1 sh -c "chown $UID -R /vagrant"

--- a/bin/jenkins/run_integration
+++ b/bin/jenkins/run_integration
@@ -7,7 +7,7 @@
 set -o nounset
 set -o errexit
 
-PROJECT="pylint"
+PROJECT="integration"
 SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
 
 cd "${SCRIPTPATH}/../.."
@@ -24,7 +24,7 @@ echo "Provisioning ${PROJECT}_dev_1"
 docker exec -i ${PROJECT}_dev_1 su vagrant -c \
   "ansible-playbook -i provision/docker/inventory provision/site.yml"
 
-echo "Running pylint"
+echo "Running ${PROJECT}"
 docker exec -i ${PROJECT}_dev_1 su vagrant -c "
   source /vagrant/bin/init_vagrant_env
   /vagrant/run_integration
@@ -33,6 +33,6 @@ docker exec -i ${PROJECT}_dev_1 su vagrant -c "
 docker exec -i ${PROJECT}_dev_1 sh -c "chown $UID -R /vagrant"
 docker exec -i ${PROJECT}_selenium_1 sh -c "chown $UID -R /selenium"
 
-docker-compose stop
+docker-compose -p ${PROJECT} stop
 
 exit $rc

--- a/bin/jenkins/run_integration
+++ b/bin/jenkins/run_integration
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+# Created By: miha@reciprocitylabs.com
+# Maintained By: miha@reciprocitylabs.com
+
+set -o nounset
+set -o errexit
+
+PROJECT="pylint"
+SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
+
+cd "${SCRIPTPATH}/../.."
+
+docker-compose -f docker-compose-testing.yml -p ${PROJECT} up --force-recreate -d
+
+if [[ $UID != 1000 ]]; then
+  docker exec -i ${PROJECT}_dev_1 sh -c "
+  bindfs /vagrant_bind /vagrant --map=$UID/1000 -o nonempty
+  "
+fi
+
+echo "Provisioning ${PROJECT}_dev_1"
+docker exec -i ${PROJECT}_dev_1 su vagrant -c \
+  "ansible-playbook -i provision/docker/inventory provision/site.yml"
+
+echo "Running pylint"
+docker exec -i ${PROJECT}_dev_1 su vagrant -c "
+  source /vagrant/bin/init_vagrant_env
+  /vagrant/run_integration
+"&& rc=$? || rc=$?
+
+docker exec -i ${PROJECT}_dev_1 sh -c "chown $UID -R /vagrant"
+docker exec -i ${PROJECT}_selenium_1 sh -c "chown $UID -R /selenium"
+
+docker-compose stop
+
+exit $rc

--- a/bin/jenkins/run_integration
+++ b/bin/jenkins/run_integration
@@ -27,7 +27,7 @@ docker exec -i ${PROJECT}_dev_1 su vagrant -c \
 echo "Running ${PROJECT}"
 docker exec -i ${PROJECT}_dev_1 su vagrant -c "
   source /vagrant/bin/init_vagrant_env
-  /vagrant/run_integration
+  /vagrant/bin/run_integration
 "&& rc=$? || rc=$?
 
 docker exec -i ${PROJECT}_dev_1 sh -c "chown $UID -R /vagrant"

--- a/bin/jenkins/run_pylint
+++ b/bin/jenkins/run_pylint
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+# Created By: miha@reciprocitylabs.com
+# Maintained By: miha@reciprocitylabs.com
+
+set -o nounset
+set -o errexit
+
+PROJECT="pylint"
+SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
+
+cd "${SCRIPTPATH}/../.."
+
+docker-compose -f docker-compose-testing.yml -p ${PROJECT} up --force-recreate -d
+
+if [[ $UID != 1000 ]]; then
+  docker exec -i ${PROJECT}_dev_1 sh -c "
+  bindfs /vagrant_bind /vagrant --map=$UID/1000 -o nonempty
+  "
+fi
+
+echo "Provisioning ${PROJECT}_dev_1"
+docker exec -i ${PROJECT}_dev_1 su vagrant -c \
+  "ansible-playbook -i provision/docker/inventory provision/site.yml"
+
+echo "Running pylint"
+docker exec -i ${PROJECT}_dev_1 /vagrant/bin/check_pylint_diff && rc=$? || rc=$?
+
+docker exec -i ${PROJECT}_dev_1 sh -c "chown $UID -R /vagrant"
+docker exec -i ${PROJECT}_selenium_1 sh -c "chown $UID -R /selenium"
+
+docker-compose stop
+
+exit $rc

--- a/bin/jenkins/run_pylint
+++ b/bin/jenkins/run_pylint
@@ -25,7 +25,10 @@ docker exec -i ${PROJECT}_dev_1 su vagrant -c \
   "ansible-playbook -i provision/docker/inventory provision/site.yml"
 
 echo "Running ${PROJECT}"
-docker exec -i ${PROJECT}_dev_1 /vagrant/bin/check_pylint_diff && rc=$? || rc=$?
+docker exec -i ${PROJECT}_dev_1 su vagrant -c "
+  source /vagrant/bin/init_vagrant_env
+  /vagrant/bin/check_pylint_diff
+" && rc=$? || rc=$?
 
 docker exec -i ${PROJECT}_dev_1 sh -c "chown $UID -R /vagrant"
 docker exec -i ${PROJECT}_selenium_1 sh -c "chown $UID -R /selenium"

--- a/bin/jenkins/run_pylint
+++ b/bin/jenkins/run_pylint
@@ -24,12 +24,12 @@ echo "Provisioning ${PROJECT}_dev_1"
 docker exec -i ${PROJECT}_dev_1 su vagrant -c \
   "ansible-playbook -i provision/docker/inventory provision/site.yml"
 
-echo "Running pylint"
+echo "Running ${PROJECT}"
 docker exec -i ${PROJECT}_dev_1 /vagrant/bin/check_pylint_diff && rc=$? || rc=$?
 
 docker exec -i ${PROJECT}_dev_1 sh -c "chown $UID -R /vagrant"
 docker exec -i ${PROJECT}_selenium_1 sh -c "chown $UID -R /selenium"
 
-docker-compose stop
+docker-compose -p ${PROJECT} stop
 
 exit $rc

--- a/bin/jenkins/run_selenium
+++ b/bin/jenkins/run_selenium
@@ -34,6 +34,6 @@ docker exec -i ${PROJECT}_selenium_1 python /selenium/src/run_selenium.py && \
 docker exec -i ${PROJECT}_dev_1 sh -c "chown $UID -R /vagrant"
 docker exec -i ${PROJECT}_selenium_1 sh -c "chown $UID -R /selenium"
 
-docker-compose stop
+docker-compose -p ${PROJECT} stop
 
 exit $rc

--- a/bin/jenkins/run_selenium
+++ b/bin/jenkins/run_selenium
@@ -7,10 +7,10 @@
 set -o nounset
 set -o errexit
 
-PROJECT=testing
+PROJECT="selenium"
 SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
 
-cd "${SCRIPTPATH}/.."
+cd "${SCRIPTPATH}/../.."
 
 docker-compose -f docker-compose-testing.yml -p ${PROJECT} up --force-recreate -d
 
@@ -19,10 +19,6 @@ if [[ $UID != 1000 ]]; then
   bindfs /vagrant_bind /vagrant --map=$UID/1000 -o nonempty
   "
 fi
-
-# This provisioning is needed until the provision script stops changing the
-# /vagrant folder and so the containe can then be propperly provisioned with
-# docker-compose build.
 
 echo "Provisioning ${PROJECT}_dev_1"
 docker exec -i ${PROJECT}_dev_1 su vagrant -c \

--- a/bin/jenkins/run_unit
+++ b/bin/jenkins/run_unit
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+# Created By: miha@reciprocitylabs.com
+# Maintained By: miha@reciprocitylabs.com
+
+set -o nounset
+set -o errexit
+
+PROJECT="unit"
+SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
+
+cd "${SCRIPTPATH}/../.."
+
+docker-compose -f docker-compose-testing.yml -p ${PROJECT} up --force-recreate -d
+
+if [[ $UID != 1000 ]]; then
+  docker exec -i ${PROJECT}_dev_1 sh -c "
+  bindfs /vagrant_bind /vagrant --map=$UID/1000 -o nonempty
+  "
+fi
+
+echo "Provisioning ${PROJECT}_dev_1"
+docker exec -i ${PROJECT}_dev_1 su vagrant -c \
+  "ansible-playbook -i provision/docker/inventory provision/site.yml"
+
+echo "Running ${PROJECT}"
+docker exec -i ${PROJECT}_dev_1 su vagrant -c "
+  source /vagrant/bin/init_vagrant_env
+  /vagrant/bin/run_unit
+" && rc=$? || rc=$?
+
+docker exec -i ${PROJECT}_dev_1 sh -c "chown $UID -R /vagrant"
+docker exec -i ${PROJECT}_selenium_1 sh -c "chown $UID -R /selenium"
+
+docker-compose -p ${PROJECT} stop
+
+exit $rc

--- a/bin/run_integration
+++ b/bin/run_integration
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+# Created By: miha@reciprocitylabs.com
+# Maintained By: miha@reciprocitylabs.com
+
+SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
+cd "${SCRIPTPATH}/../test"
+find . -iname "*.pyc" -delete
+mysql -uroot -proot -e "DROP DATABASE IF EXISTS ggrcdevtest; CREATE DATABASE ggrcdevtest CHARACTER SET utf8; USE ggrcdevtest;"
+export GGRC_SETTINGS_MODULE="testing ggrc_basic_permissions.settings.development ggrc_gdrive_integration.settings.development ggrc_risk_assessments.settings.development ggrc_risks.settings.development ggrc_workflows.settings.development"
+db_migrate
+
+echo -e "\nRunning integration tests"
+nosetests integration --logging-clear-handlers ${@:1}

--- a/bin/run_unit
+++ b/bin/run_unit
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+# Created By: miha@reciprocitylabs.com
+# Maintained By: miha@reciprocitylabs.com
+
+SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
+cd "${SCRIPTPATH}/../test"
+find ./../ -iname "*.pyc" -delete
+
+echo -e "\nRunning unit tests"
+nosetests unit --logging-clear-handlers ${@:1}

--- a/doc/commit_guidelines.md
+++ b/doc/commit_guidelines.md
@@ -163,7 +163,7 @@ To run the full-fledged end-to-end system tests, go to the project root
 directory **on the host machine** and run the following from its console:
 
 ```console
-./bin/run_selenium
+./bin/jenkins/run_selenium
 ```
 
 Please keep in mind that, for various technical reasons, Selenium tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[flake8]
+ignore = E111,E114
+max-complexity = 10

--- a/src/dev-requirements.txt
+++ b/src/dev-requirements.txt
@@ -25,3 +25,4 @@ names==0.3.0
 flask-debugtoolbar==0.10.0
 freezegun==0.3.5
 pylint==1.5.1
+flake8==2.5.1


### PR DESCRIPTION
Since most scripts in bin folder are meant to be run inside the vm or a container, I think it's wrong that we have scripts for running on the host machine there as well. This PR just moves all scripts that should be run on the host machine into bin/jenkins since that is the primary reason for those scripts.

The name bin/jenkins may be missleading since people can run those on their machines too, and I'm open for better suggestions.

relates to: CORE-2999