### PR TITLE
QUCIK-FIX Set CA audit program only in new form

### DIFF
--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -905,7 +905,7 @@ can.Model.Cacheable("CMS.Models.Meeting", {
       }
     },
     before_save: function (newForm) {
-      if (!newForm) {
+      if (!this.isNew()) {
         return;
       }
       this.mark_for_addition('related_objects_as_destination', this.audit.program);


### PR DESCRIPTION
This fixes script error on Control Assessment editing.