### PR TITLE
CORE-3001 Show more object types on export relevant dropdown

### DIFF
--- a/src/ggrc/assets/javascripts/components/relevant_filters.js
+++ b/src/ggrc/assets/javascripts/components/relevant_filters.js
@@ -5,79 +5,85 @@
     Maintained By: ivan@reciprocitylabs.com
 */
 
-(function(can, $) {
+(function (can, $) {
   can.Component.extend({
-    tag: "relevant-filter",
-    template: can.view(GGRC.mustache_path + "/mapper/relevant_filter.mustache"),
+    tag: 'relevant-filter',
+    template: can.view(GGRC.mustache_path + '/mapper/relevant_filter.mustache'),
     scope: {
-      relevant_menu_item: "@",
-      show_all: "@",
+      relevant_menu_item: '@',
+      show_all: '@',
       menu: can.compute(function () {
-        var type = this.attr("type"),
-            showAll = /true/i.test(this.attr("show_all")),
-            isAll = type === "AllObject",
-            mappings, models;
+        var type = this.attr('type');
+        var showAll = /true/i.test(this.attr('show_all'));
+        var isAll = type === 'AllObject';
+        var mappings;
+        var models;
 
         if (showAll) {
           // find all widget types and manually add Cycle since it's missing
           // convert names to CMS models and prune invalid (undefined)
-          models = ["Cycle"];
-          models = Array.prototype.concat.apply(models, _.values(GGRC.tree_view.base_widgets_by_type));
+          models = ['Cycle'];
+          models = Array.prototype.concat.apply(models,
+              _.values(GGRC.tree_view.base_widgets_by_type));
           models = _.map(_.unique(models), function (mapping) {
             return CMS.Models[mapping];
           });
-          return _.sortBy(_.compact(models), "model_singular");
+          return _.sortBy(_.compact(models), 'model_singular');
         }
-        if (this.attr("search_only") && isAll) {
+        if (this.attr('search_only') && isAll) {
           mappings = GGRC.tree_view.base_widgets_by_type;
         } else {
-          type = isAll ? GGRC.page_model.type : this.attr("type");
+          type = isAll ? GGRC.page_model.type : this.attr('type');
           mappings = GGRC.Mappings.get_canonical_mappings_for(type);
         }
 
         return _.sortBy(_.compact(_.map(_.keys(mappings), function (mapping) {
           return CMS.Models[mapping];
-        })), "model_singular");
+        })), 'model_singular');
       })
     },
     events: {
-      ".add-filter-rule click": function (el, ev) {
+      '.add-filter-rule click': function (el, ev) {
+        var menu;
         ev.preventDefault();
-        var menu = this.scope.attr("menu");
 
-        if (this.scope.attr("relevant_menu_item") === "parent"
-            && +this.scope.attr("panel_number") !== 0
-            && !this.scope.attr("has_parent")) {
+        menu = this.scope.attr('menu');
+
+        if (this.scope.attr('relevant_menu_item') === 'parent' &&
+             Number(this.scope.attr('panel_number')) !== 0 &&
+             !this.scope.attr('has_parent')) {
           menu.unshift({
-            title_singular: "Previous objects",
-            model_singular: "__previous__"
+            title_singular: 'Previous objects',
+            model_singular: '__previous__'
           });
         }
 
-        this.scope.attr("relevant").push({
+        this.scope.attr('relevant').push({
           value: false,
           filter: new can.Map(),
           menu: menu,
           model_name: menu[0].model_singular
         });
       },
-      ".ui-autocomplete-input autocomplete:select": function (el, ev, data) {
-        var index = el.data("index"),
-            panel = this.scope.attr("relevant")[index];
+      '.ui-autocomplete-input autocomplete:select': function (el, ev, data) {
+        var index = el.data('index');
+        var panel = this.scope.attr('relevant')[index];
 
-        panel.attr("filter", data.item);
-        panel.attr("value", true);
+        panel.attr('filter', data.item);
+        panel.attr('value', true);
       },
-      ".remove_filter click": function (el) {
-        this.scope.attr("relevant").splice(el.data("index"), 1);
+      '.remove_filter click': function (el) {
+        this.scope.attr('relevant').splice(el.data('index'), 1);
       },
-      "{scope.relevant} change": function (list, item, which, type, val, oldVal) {
-        this.scope.attr("has_parent", _.findWhere(this.scope.attr("relevant"), {model_name: "__previous__"}));
+      '{scope.relevant} change': function (list, item, which, type, val, old) {
+        this.scope.attr('has_parent',
+                        _.findWhere(this.scope.attr('relevant'),
+                        {model_name: '__previous__'}));
         if (!/model_name/gi.test(which)) {
           return;
         }
-        item.target.attr("filter", new can.Map());
-        item.target.attr("value", false);
+        item.target.attr('filter', new can.Map());
+        item.target.attr('value', false);
       }
     }
   });

--- a/src/ggrc/assets/javascripts/components/relevant_filters.js
+++ b/src/ggrc/assets/javascripts/components/relevant_filters.js
@@ -16,12 +16,17 @@
         var type = this.attr("type"),
             showAll = /true/i.test(this.attr("show_all")),
             isAll = type === "AllObject",
-            mappings;
+            mappings, models;
 
         if (showAll) {
-          return _.sortBy(_.compact(_.map(GGRC.tree_view.base_widgets_by_type[type], function (mapping) {
+          // find all widget types and manually add Cycle since it's missing
+          // convert names to CMS models and prune invalid (undefined)
+          models = ["Cycle"];
+          models = Array.prototype.concat.apply(models, _.values(GGRC.tree_view.base_widgets_by_type));
+          models = _.map(_.unique(models), function (mapping) {
             return CMS.Models[mapping];
-          })), "model_singular");
+          });
+          return _.sortBy(_.compact(models), "model_singular");
         }
         if (this.attr("search_only") && isAll) {
           mappings = GGRC.tree_view.base_widgets_by_type;


### PR DESCRIPTION
Since there is indirect relevancy implemented on the backend export code you must be able to pick some types that you cannot directly see as a widget. 
Currently there is no easy way to get the list of supported indirect mappings on the back end so I opted for listing all widget types. 

We could restructure the indirect mapping helpers and serve the meta-data but it think this is not of great benefit until we're also serving mapping rules from the back-end (for everything).