### PR TITLE
CORE-1966 Prevent deleting objects under a non-current Cycle

### DIFF
--- a/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/info.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/info.mustache
@@ -32,6 +32,7 @@
               <clipboard-link title="Get permalink" notify="true" text="{{get_permalink_url}}" />
             </li>
 
+            {{#if_equals instance.cycle.reify.is_current true}}
             {{#is_allowed 'delete' instance}}
               <li>
                 <a data-toggle="modal-ajax-deleteform" data-object-plural="{{model.table_plural}}" data-object-singular="{{model.model_singular}}" data-modal-reset="reset" data-modal-class="modal" data-object-id="{{instance.id}}" href="javascript://">
@@ -40,6 +41,7 @@
                 </a>
               </li>
             {{/is_allowed}}
+            {{/if_equals}}
           </ul>
         </div>
       {{/is_allowed}}

--- a/src/ggrc_workflows/assets/mustache/cycle_task_group_objects/info.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_group_objects/info.mustache
@@ -44,6 +44,7 @@
                 {{/is_allowed}}
               {{/if}}
 
+              {{#if_equals instance.cycle.reify.is_current true}}
               {{#is_allowed 'delete' instance}}
                 <li>
                   <a data-toggle="modal-ajax-deleteform" data-object-plural="{{model.table_plural}}" data-object-singular="{{model.model_singular}}" data-modal-reset="reset" data-modal-class="modal" data-object-id="{{instance.id}}" href="javascript://">
@@ -52,6 +53,7 @@
                   </a>
                 </li>
               {{/is_allowed}}
+              {{/if_equals}}
             </ul>
           {{/if}}
         </div>

--- a/src/ggrc_workflows/assets/mustache/cycles/info.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycles/info.mustache
@@ -12,7 +12,7 @@
   {{/is_info_pin}}
 
   <div class="info-pane-utility">
-    {{#using instance=instance.workflow}}
+    {{#using workflow=instance.workflow}}
     <!-- This should have only view link, shouldn't edit cycle instance of workflow while active -->
       <div class="details-wrap">
         <a class="btn btn-small btn-draft dropdown-toggle" href="#" data-toggle="dropdown">
@@ -21,12 +21,12 @@
           <span class="bubble"></span>
         </a>
         <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
-          {{#if instance.viewLink}}
+          {{#if workflow.viewLink}}
             {{!#is_allowed "view_object_page" instance}}
               <li>
-                <a href="{{instance.viewLink}}">
+                <a href="{{workflow.viewLink}}">
                   <i class="fa fa-long-arrow-right"></i>
-                  View {{instance.class.title_singular}}
+                  View {{workflow.class.title_singular}}
                 </a>
               </li>
             {{!/is_allowed}}
@@ -35,14 +35,16 @@
             <clipboard-link title="Get permalink" notify="true" text="{{get_permalink_url}}" />
           </li>
 
-          {{#is_allowed 'delete' instance}}
-            <li>
-              <a data-toggle="modal-ajax-deleteform" data-object-plural="{{model.table_plural}}" data-object-singular="{{model.model_singular}}" data-modal-reset="reset" data-modal-class="modal" data-object-id="{{instance.id}}" href="javascript://">
-                <i class="fa fa-trash"></i>
-                Delete
-              </a>
-            </li>
+          {{#if_equals instance.is_current true}}
+          {{#is_allowed 'delete' workflow}}
+              <li>
+                <a data-toggle="modal-ajax-deleteform" data-object-plural="{{model.table_plural}}" data-object-singular="{{model.model_singular}}" data-modal-reset="reset" data-modal-class="modal" data-object-id="{{workflow.id}}" href="javascript://">
+                  <i class="fa fa-trash"></i>
+                  Delete
+                </a>
+              </li>
           {{/is_allowed}}
+          {{/if_equals}}
         </ul>
       </div>
     {{/using}}


### PR DESCRIPTION
If the cycle being viewed is not a current one (e.g. on the workflow's History tab), the delete icon is simply not displayed.