### PR TITLE
CORE-2999 Fix permissions for jenkins runners

### DIFF
--- a/bin/check_pylint_diff
+++ b/bin/check_pylint_diff
@@ -28,6 +28,7 @@ git checkout --quiet $TEST_COMMIT
 PYLINT_RESULT=$(pylint src/* 2> /dev/null | tail -n 2) 
 git checkout --quiet $CURRENT_COMMIT
 
+echo "$PYLINT_RESULT"
 echo "$PYLINT_RESULT" | grep "+" && rc=$? || rc=$?
 
 exit $rc

--- a/bin/jenkins/run_code_style
+++ b/bin/jenkins/run_code_style
@@ -16,15 +16,19 @@ docker-compose --file docker-compose-testing.yml \
   --project-name ${PROJECT} \
   up --force-recreate -d
 
-if [[ $UID -eq 1000 ]]; then
+if [[ $UID -eq 0 ]]; then
+  # This fixes permissions with bindfs only on jenkins.
+  chown 1000:1000 -R .
+elif [[ $UID -eq 1000 ]]; then
   docker exec -i ${PROJECT}_dev_1 sh -c "
   bindfs /vagrant_bind /vagrant --map=$UID/1000 -o nonempty
   "
 fi
 
 echo "Provisioning ${PROJECT}_dev_1"
-docker exec -i ${PROJECT}_dev_1 su vagrant -c \
-  "ansible-playbook -i provision/docker/inventory provision/site.yml > /dev/null"
+docker exec -i ${PROJECT}_dev_1 su vagrant -c "
+  ansible-playbook -i provision/docker/inventory provision/site.yml
+"
 
 echo "
 ###############################################################################

--- a/bin/jenkins/run_code_style
+++ b/bin/jenkins/run_code_style
@@ -74,4 +74,4 @@ docker exec -i ${PROJECT}_selenium_1 sh -c "chown $UID -R /selenium"
 
 docker-compose -p ${PROJECT} stop
 
-exit $((pylint_rc + flake_rc + eslint_rc))
+exit $((pylint_rc * pylint_rc + flake_rc * flake_rc + eslint_rc * eslint_rc))

--- a/bin/jenkins/run_selenium
+++ b/bin/jenkins/run_selenium
@@ -12,9 +12,14 @@ SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
 
 cd "${SCRIPTPATH}/../.."
 
-docker-compose -f docker-compose-testing.yml -p ${PROJECT} up --force-recreate -d
+docker-compose --file docker-compose-testing.yml \
+  --project-name ${PROJECT} \
+  up --force-recreate -d
 
-if [[ $UID != 1000 ]]; then
+if [[ $UID -eq 0 ]]; then
+  # This fixes permissions with bindfs only on jenkins.
+  chown 1000:1000 -R .
+elif [[ $UID -eq 1000 ]]; then
   docker exec -i ${PROJECT}_dev_1 sh -c "
   bindfs /vagrant_bind /vagrant --map=$UID/1000 -o nonempty
   "


### PR DESCRIPTION
Running scripts in bin/jenkins folder as root causes permission issues
inside docker containers. This fix changes the permissions of the shared
folder to match the vagrant user inside the containers.