### PR TITLE
QUICK-FIX Clean up python test code

### DIFF
--- a/test/integration/ggrc/converters/test_import_helpers.py
+++ b/test/integration/ggrc/converters/test_import_helpers.py
@@ -3,17 +3,13 @@
 # Created By: miha@reciprocitylabs.com
 # Maintained By: miha@reciprocitylabs.com
 
-from copy import copy
 from os.path import abspath, dirname, join
-from random import shuffle
 
 from ggrc import converters
 from ggrc import models
 from ggrc.converters import column_handlers
 from ggrc.converters import import_helper
-from ggrc.converters.import_helper import get_column_order
 from ggrc.converters.import_helper import get_object_column_definitions
-from ggrc.converters.import_helper import split_array
 from ggrc.utils import get_mapping_rules
 from ggrc.utils import title_from_camelcase
 from ggrc_risk_assessments import models as ra_models
@@ -31,123 +27,6 @@ def get_mapping_names(class_name):
   mapping_names = {"map:{}".format(name) for name in pretty_rules}
   unmapping_names = {"unmap:{}".format(name) for name in pretty_rules}
   return mapping_names.union(unmapping_names)
-
-
-class TestSplitArry(TestCase):
-
-  def test_sigle_block(self):
-    test_data = [
-        ["hello", "world"],
-        ["hello", "world"],
-        ["hello", "world"],
-    ]
-    offests, data_blocks = split_array(test_data)
-    self.assertEqual(len(data_blocks), 1)
-    self.assertEqual(data_blocks[0], test_data)
-    self.assertEqual(offests[0], 0)
-
-  def test_sigle_block_with_padding(self):
-    test_data = [
-        ["", ""],
-        ["hello", "world"],
-        ["hello", "world", "uet"],
-        ["hello", "world"],
-        ["hello", "world"],
-    ]
-    offests, data_blocks = split_array(test_data)
-    self.assertEqual(len(data_blocks), 1)
-    self.assertEqual(data_blocks[0], test_data[1:])
-    self.assertEqual(offests[0], 1)
-
-    test_data = [
-        ["", ""],
-        ["", ""],
-        ["", ""],
-        ["hello", "world"],
-        ["hello", "world", "uet"],
-        ["hello", "world"],
-        ["hello", "world"],
-        ["", ""],
-        ["", ""],
-    ]
-    offests, data_blocks = split_array(test_data)
-    self.assertEqual(len(data_blocks), 1)
-    self.assertEqual(data_blocks[0], test_data[3:7])
-    self.assertEqual(offests[0], 3)
-
-  def test_multiple_blocks(self):
-    test_data = [
-        ["", ""],
-        ["hello", "world"],
-        ["hello", "world", "uet"],
-        ["", ""],
-        ["hello", "world"],
-        ["hello", "world"],
-    ]
-    offests, data_blocks = split_array(test_data)
-    self.assertEqual(len(data_blocks), 2)
-    self.assertEqual(data_blocks[0], test_data[1:3])
-    self.assertEqual(data_blocks[1], test_data[4:6])
-    self.assertEqual(offests[0], 1)
-    self.assertEqual(offests[1], 4)
-
-    test_data = [
-        ["", ""],
-        ["hello", "world"],
-        ["hello", "world", "uet"],
-        ["hello", "world"],
-        ["", ""],
-        ["", ""],
-        ["hello", "world"],
-        ["", ""],
-        ["", ""],
-        ["hello", "world"],
-        ["hello", "world"],
-        ["hello", "world"],
-    ]
-    offests, data_blocks = split_array(test_data)
-    self.assertEqual(len(data_blocks), 3)
-    self.assertEqual(data_blocks[0], test_data[1:4])
-    self.assertEqual(data_blocks[1], test_data[6:7])
-    self.assertEqual(data_blocks[2], test_data[9:])
-    self.assertEqual(offests[0], 1)
-    self.assertEqual(offests[1], 6)
-    self.assertEqual(offests[2], 9)
-
-
-class TestCulumnOrder(TestCase):
-
-  def test_column_order(self):
-    attr_list = [
-        "slug",
-        "title",
-        "description",
-        "notes",
-        "test_plan",
-        "owners",
-        "start_date",
-        "status",
-        "kind",
-        "url",
-        "reference_url",
-        "name",
-        "email",
-        "is_enabled",
-        "company",
-        "A Capital custom attribute",
-        "a simple custom attribute",
-        "some custom attribute",
-        "map:A thing",
-        "map:B thing",
-        "map:c thing",
-        "map:Program",
-        "map:some other mapping",
-    ]
-    original_list = copy(attr_list)
-    for _ in range(1):
-      shuffle(attr_list)
-      column_order = get_column_order(attr_list)
-      self.assertEqual(original_list, column_order)
 
 
 class TestCustomAttributesDefinitions(TestCase):

--- a/test/integration/ggrc/converters/test_import_helpers.py
+++ b/test/integration/ggrc/converters/test_import_helpers.py
@@ -115,38 +115,6 @@ class TestSplitArry(TestCase):
     self.assertEqual(offests[2], 9)
 
 
-class TestGetObjectColumnDefinitons(TestCase):
-
-  def test_object_column_handlers(self):
-
-    def test_single_object(obj):
-      handlers = column_handlers.COLUMN_HANDLERS
-      column_definitions = import_helper.get_object_column_definitions(obj)
-      for key, value in column_definitions.items():
-        if key in handlers:
-          handler_key = value.get("handler_key", key)
-          self.assertEqual(
-              value["handler"],
-              handlers[handler_key],
-              "Object '{}', column '{}': expected {}, found {}".format(
-                  obj.__name__,
-                  key,
-                  handlers[key].__name__,
-                  value["handler"].__name__,
-              )
-          )
-
-    verificationErrors = []
-    for obj in set(converters.get_exportables().values()):
-      try:
-        test_single_object(obj)
-      except AssertionError as e:
-        verificationErrors.append(str(e))
-
-    verificationErrors.sort()
-    self.assertEqual(verificationErrors, [])
-
-
 class TestCulumnOrder(TestCase):
 
   def test_column_order(self):
@@ -346,6 +314,53 @@ class TestGetObjectColumnDefinitions(TestCase):
           obj_class.__name__, str(e))
 
     self.assertEqual(errors, "", errors)
+
+  def test_object_column_handlers(self):
+    """Test column handlers on all exportable objects.
+
+    This function makes sure that we don't use get wrong hadlers when fetching
+    object column definitions. If a column has a specified handler_key then
+    the appropriate handler must override the default handler for the column
+    with the same name.
+
+    Raises:
+      AssertionError if any unexpected colum handlers are found.
+    """
+
+    def test_single_object(obj):
+      """Test colum handlers for a single object.
+
+      Args:
+        obj: sqlachemy model.
+
+      Raises:
+        AssertionError if object definiton contains the wrong handler.
+      """
+      handlers = column_handlers.COLUMN_HANDLERS
+      column_definitions = import_helper.get_object_column_definitions(obj)
+      for key, value in column_definitions.items():
+        if key in handlers:
+          handler_key = value.get("handler_key", key)
+          self.assertEqual(
+              value["handler"],
+              handlers[handler_key],
+              "Object '{}', column '{}': expected {}, found {}".format(
+                  obj.__name__,
+                  key,
+                  handlers[key].__name__,
+                  value["handler"].__name__,
+              )
+          )
+
+    verificationErrors = []
+    for obj in set(converters.get_exportables().values()):
+      try:
+        test_single_object(obj)
+      except AssertionError as e:
+        verificationErrors.append(str(e))
+
+    verificationErrors.sort()
+    self.assertEqual(verificationErrors, [])
 
   def test_program_definitions(self):
     """ test default headers for Program """

--- a/test/integration/ggrc/converters/test_import_helpers.py
+++ b/test/integration/ggrc/converters/test_import_helpers.py
@@ -248,6 +248,13 @@ class TestGetObjectColumnDefinitions(TestCase):
   order of these test functions is the same as the objects in LHN
   """
 
+  @classmethod
+  def setUpClass(cls):
+    TestCase.clear_data()
+
+  def setUp(self):
+    pass
+
   def _test_definiton_names(self, obj_class, names, has_mappings=True):
     """ Test name definitions for one class
 
@@ -1033,10 +1040,15 @@ class TestGetObjectColumnDefinitions(TestCase):
 
 
 class TestGetWorkflowObjectColumnDefinitions(TestCase):
+  """Test default column difinitions for workflow objcts.
+  """
 
-  """
-  Test default column difinitions for workflow objcts
-  """
+  @classmethod
+  def setUpClass(cls):
+    TestCase.clear_data()
+
+  def setUp(self):
+    pass
 
   def test_workflow_definitions(self):
     """ test default headers for Workflow """
@@ -1130,10 +1142,15 @@ class TestGetWorkflowObjectColumnDefinitions(TestCase):
 
 
 class TestGetRiskAssessmentObjectColumnDefinitions(TestCase):
+  """Test default column difinitions for risk assessment objcts.
+  """
 
-  """
-  Test default column difinitions for risk assessment objcts
-  """
+  @classmethod
+  def setUpClass(cls):
+    TestCase.clear_data()
+
+  def setUp(self):
+    pass
 
   def test_risk_assessemnt_definitions(self):
     """ test default headers for Workflow """

--- a/test/unit/ggrc/converters/test_import_helpers.py
+++ b/test/unit/ggrc/converters/test_import_helpers.py
@@ -1,0 +1,155 @@
+# Copyright (C) 2015 Google Inc., authors, and contributors <see AUTHORS file>
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+# Created By: miha@reciprocitylabs.com
+# Maintained By: miha@reciprocitylabs.com
+
+"""Tests for functions inside import_helper module.
+"""
+
+import unittest
+import copy
+import random
+
+from ggrc import app  # noqa - this is neede for imports to work
+from ggrc.converters import import_helper
+
+
+class TestSplitArry(unittest.TestCase):
+  """Class for testing the split array function
+  """
+
+  def test_sigle_block(self):
+    """Test splitting of a single csv block
+
+    The array reprisents a read csv file with no lines that contain only
+    commas.
+    """
+    test_data = [
+        ["hello", "world"],
+        ["hello", "world"],
+        ["hello", "world"],
+    ]
+    offests, data_blocks = import_helper.split_array(test_data)
+    self.assertEqual(len(data_blocks), 1)
+    self.assertEqual(data_blocks[0], test_data)
+    self.assertEqual(offests[0], 0)
+
+  def test_sigle_block_with_padding(self):
+    """Test stripping away empty csv lins
+    """
+    test_data = [
+        ["", ""],
+        ["hello", "world"],
+        ["hello", "world", "uet"],
+        ["hello", "world"],
+        ["hello", "world"],
+    ]
+    offests, data_blocks = import_helper.split_array(test_data)
+    self.assertEqual(len(data_blocks), 1)
+    self.assertEqual(data_blocks[0], test_data[1:])
+    self.assertEqual(offests[0], 1)
+
+    test_data = [
+        ["", ""],
+        ["", ""],
+        ["", ""],
+        ["hello", "world"],
+        ["hello", "world", "uet"],
+        ["hello", "world"],
+        ["hello", "world"],
+        ["", ""],
+        ["", ""],
+    ]
+    offests, data_blocks = import_helper.split_array(test_data)
+    self.assertEqual(len(data_blocks), 1)
+    self.assertEqual(data_blocks[0], test_data[3:7])
+    self.assertEqual(offests[0], 3)
+
+  def test_multiple_blocks(self):
+    """Test splitting blocks of csv file
+
+    Test that split_array function splits a csv file by one or more empty
+    lines. The lines with only empty strings represent comma only lines in a
+    read csv file.
+    """
+    test_data = [
+        ["", ""],
+        ["hello", "world"],
+        ["hello", "world", "uet"],
+        ["", ""],
+        ["hello", "world"],
+        ["hello", "world"],
+    ]
+    offests, data_blocks = import_helper.split_array(test_data)
+    self.assertEqual(len(data_blocks), 2)
+    self.assertEqual(data_blocks[0], test_data[1:3])
+    self.assertEqual(data_blocks[1], test_data[4:6])
+    self.assertEqual(offests[0], 1)
+    self.assertEqual(offests[1], 4)
+
+    test_data = [
+        ["", ""],
+        ["hello", "world"],
+        ["hello", "world", "uet"],
+        ["hello", "world"],
+        ["", ""],
+        ["", ""],
+        ["hello", "world"],
+        ["", ""],
+        ["", ""],
+        ["hello", "world"],
+        ["hello", "world"],
+        ["hello", "world"],
+    ]
+    offests, data_blocks = import_helper.split_array(test_data)
+    self.assertEqual(len(data_blocks), 3)
+    self.assertEqual(data_blocks[0], test_data[1:4])
+    self.assertEqual(data_blocks[1], test_data[6:7])
+    self.assertEqual(data_blocks[2], test_data[9:])
+    self.assertEqual(offests[0], 1)
+    self.assertEqual(offests[1], 6)
+    self.assertEqual(offests[2], 9)
+
+
+class TestCulumnOrder(unittest.TestCase):
+
+  """Tests for colum order function.
+  """
+
+  def test_column_order(self):
+    """Test sorting of colums by a predined positions.
+
+    The predifined positions for all columns can be found in reflection.py.
+    Attr_list is created in an expected correct order, aganist which a newly
+    orderd list is compaired.
+    """
+    attr_list = [
+        "slug",
+        "title",
+        "description",
+        "notes",
+        "test_plan",
+        "owners",
+        "start_date",
+        "status",
+        "kind",
+        "url",
+        "reference_url",
+        "name",
+        "email",
+        "is_enabled",
+        "company",
+        "A Capital custom attribute",
+        "a simple custom attribute",
+        "some custom attribute",
+        "map:A thing",
+        "map:B thing",
+        "map:c thing",
+        "map:Program",
+        "map:some other mapping",
+    ]
+    original_list = copy.copy(attr_list)
+    for _ in range(10):
+      random.shuffle(attr_list)
+      column_order = import_helper.get_column_order(attr_list)
+      self.assertEqual(original_list, column_order)


### PR DESCRIPTION
This is mostly due to the typo in the class name, which should not even
exist.