### PR TITLE
QUICK-FIX Make sure lint checks can be run simultaniously

### DIFF
--- a/bin/check_eslint_diff
+++ b/bin/check_eslint_diff
@@ -59,13 +59,14 @@ do
     shift  # drop the just-processed option/argument
 done
 
-
 echo "*** Javascript code style check ***"
 
-
-# move to the project root directory
+# move to a temporary directory for these checks
+TMP_REPO="/tmp/ggrc-core"
 SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
-cd "${SCRIPTPATH}/../"
+rm -rf $TMP_REPO
+cp -a /vagrant $TMP_REPO
+cd $TMP_REPO
 
 if [[ "$TARGET_BRANCH" != "" ]]; then
   # Determine the number of JS code issues at the point the PR branch was

--- a/bin/check_pylint_diff
+++ b/bin/check_pylint_diff
@@ -8,8 +8,11 @@
 set -o nounset
 set -o errexit
 
+TMP_REPO="/tmp/ggrc-core"
 SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
-cd "${SCRIPTPATH}/.."
+rm -rf $TMP_REPO
+cp -a /vagrant $TMP_REPO
+cd $TMP_REPO
 
 if [[ "${1:-}" != "" ]]; then
   TEST_COMMIT=$1


### PR DESCRIPTION
Linters that compare code from differnt commits should not just checkout
commits on docker volume, since a user might still be working or another
checker might need the current code. Also results of running these
linters is a detached head which is not nice for developers.

This commit makes sure we move everytihng needed for running lint test
to a temp folder before running any tests.