### PR TITLE
QUICK-FIX Allow custom project names for jenkins runners

### DIFF
--- a/bin/jenkins/functions.sh
+++ b/bin/jenkins/functions.sh
@@ -6,6 +6,38 @@
 set -o nounset
 set -o errexit
 
+project_name () {
+  # Get propper project name
+  # args: 
+  #  -p: if set the project name will be the name of the repo parent folder.
+  #  -d: default project name, if parent folder is not set or valid.
+  # returns: project name containing only alphanumeric characters
+
+  # parse the command line options
+  while [[ "$#" -gt 0 ]]
+  do
+    OPT_NAME="$1"
+
+    case $OPT_NAME in
+      -p|--parent)
+        RESULT=$( cd "$(dirname "$0")/../.." ; echo ${PWD##*/}  )
+      ;;
+      -d|--default)
+        DEFAULT="$2"
+        shift  # extra shift for the current options's value
+      ;;
+      *)  # an unknown option found
+      ;;
+    esac
+    shift  # drop the just-processed option/argument
+  done
+  if [[ -n "${RESULT:-}" ]]; then
+    echo "${RESULT:-}" | sed 's/[^A-Za-z0-9]//g'
+  else
+    echo "${DEFAULT:-}" | sed 's/[^A-Za-z0-9]//g'
+  fi
+}
+
 setup () {
   if [ -z "${1:-}" ]; then
     echo "Missing mandatory project parameter"

--- a/bin/jenkins/functions.sh
+++ b/bin/jenkins/functions.sh
@@ -46,6 +46,8 @@ setup () {
     PROJECT="${1}"
   fi
 
+  git submodule update --init
+
   docker-compose --file docker-compose-testing.yml \
     --project-name ${PROJECT} \
     up --force-recreate -d

--- a/bin/jenkins/run_code_style
+++ b/bin/jenkins/run_code_style
@@ -9,9 +9,10 @@ set -o errexit
 
 PROJECT="codestyle"
 SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
-
 cd "${SCRIPTPATH}/../.."
 source bin/jenkins/functions.sh
+
+PROJECT=$( project_name "$@" -d "$PROJECT" )
 
 setup $PROJECT
 

--- a/bin/jenkins/run_integration
+++ b/bin/jenkins/run_integration
@@ -9,9 +9,10 @@ set -o errexit
 
 PROJECT="integration"
 SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
-
 cd "${SCRIPTPATH}/../.."
 source bin/jenkins/functions.sh
+
+PROJECT=$( project_name "$@" -d "$PROJECT" )
 
 setup $PROJECT
 

--- a/bin/jenkins/run_selenium
+++ b/bin/jenkins/run_selenium
@@ -11,6 +11,8 @@ PROJECT="selenium"
 SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
 source bin/jenkins/functions.sh
 
+PROJECT=$( project_name "$@" -d "$PROJECT" )
+
 setup $PROJECT
 
 echo "

--- a/bin/jenkins/run_unittests
+++ b/bin/jenkins/run_unittests
@@ -9,9 +9,10 @@ set -o errexit
 
 PROJECT="unittests"
 SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
-
 cd "${SCRIPTPATH}/../.."
 source bin/jenkins/functions.sh
+
+PROJECT=$( project_name "$@" -d "$PROJECT" )
 
 setup $PROJECT
 


### PR DESCRIPTION
This PR adds option to run jenkins runners with "-p" parameter which
will set the project name to the parent folder of the repo. This should
be used on jenkins to allow concurrent builds which will have workspaces
marked with cosecutive numbers in the folder name.