### PR TITLE
CORE-2464 Show all object types in sub trees by default

### DIFF
--- a/src/ggrc/assets/javascripts/models/business_object_models.js
+++ b/src/ggrc/assets/javascripts/models/business_object_models.js
@@ -294,7 +294,6 @@ can.Model.Cacheable("CMS.Models.Product", {
       {attr_title: 'URL', attr_name: 'url'},
       {attr_title: 'Reference URL', attr_name: 'reference_url'}
     ])
-    , child_tree_display_list : ['System']
     , add_item_view : GGRC.mustache_path + "/base_objects/tree_add_item.mustache"
     , child_options : [{
       model : null

--- a/src/ggrc/assets/javascripts/models/control.js
+++ b/src/ggrc/assets/javascripts/models/control.js
@@ -71,7 +71,6 @@ can.Model.Cacheable("CMS.Models.Control", {
     ])
     , add_item_view : GGRC.mustache_path + "/controls/tree_add_item.mustache"
     , draw_children : true
-    , child_tree_display_list : ['System', 'Process']
     , child_options : [{
         model : can.Model.Cacheable
       , mapping : "related_objects" //"related_and_able_objects"

--- a/src/ggrc/assets/javascripts/models/directive_models.js
+++ b/src/ggrc/assets/javascripts/models/directive_models.js
@@ -25,7 +25,6 @@ can.Model.Cacheable("CMS.Models.Directive", {
       {attr_title: 'Effective Date', attr_name: 'start_date'},
       {attr_title: 'Stop Date', attr_name: 'end_date'}
     ])
-    , child_tree_display_list : ['Section', 'Clause']
     , add_item_view : GGRC.mustache_path + "/directives/tree_add_item.mustache"
     }
 

--- a/src/ggrc/assets/javascripts/models/section.js
+++ b/src/ggrc/assets/javascripts/models/section.js
@@ -50,7 +50,6 @@ can.Model.Cacheable("CMS.Models.Section", {
       {attr_title: 'URL', attr_name: 'url'},
       {attr_title: 'Reference URL', attr_name: 'reference_url'}
     ])
-    , child_tree_display_list : ['Objective']
     , add_item_view : GGRC.mustache_path + "/sections/tree_add_item.mustache"
     , child_options : [{
         model : can.Model.Cacheable
@@ -121,7 +120,6 @@ can.Model.Cacheable("CMS.Models.Clause", {
       {attr_title: 'URL', attr_name: 'url'},
       {attr_title: 'Reference URL', attr_name: 'reference_url'}
     ])
-    , child_tree_display_list : ['Objective']
     , add_item_view : GGRC.mustache_path + "/sections/tree_add_item.mustache"
     , child_options: [{
         model: can.Model.Cacheable

--- a/src/ggrc/assets/javascripts/models/simple_models.js
+++ b/src/ggrc/assets/javascripts/models/simple_models.js
@@ -67,7 +67,6 @@ can.Model.Cacheable("CMS.Models.Program", {
       {attr_title: 'Effective Date', attr_name: 'start_date'},
       {attr_title: 'Stop Date', attr_name: 'end_date'}
     ])
-    , child_tree_display_list : ['Standard', 'Regulation', 'Policy', 'Contract']
     , add_item_view : GGRC.mustache_path + "/base_objects/tree_add_item.mustache"
     }
   , links_to : {
@@ -152,7 +151,6 @@ can.Model.Cacheable("CMS.Models.Objective", {
       {attr_title: 'URL', attr_name: 'url'},
       {attr_title: 'Reference URL', attr_name: 'reference_url'}
     ])
-    , child_tree_display_list : ['Control']
     , add_item_view : GGRC.mustache_path + "/objectives/tree_add_item.mustache"
     , create_link : true
     //, draw_children : true

--- a/src/ggrc/assets/javascripts/models/system.js
+++ b/src/ggrc/assets/javascripts/models/system.js
@@ -57,7 +57,6 @@ can.Model.Cacheable("CMS.Models.SystemOrProcess", {
         {attr_title: 'URL', attr_name: 'url'},
         {attr_title: 'Reference URL', attr_name: 'reference_url'}
       ])
-      , child_tree_display_list : ['Control']
       , add_item_view : GGRC.mustache_path + "/base_objects/tree_add_item.mustache"
       , link_buttons : true
       , child_options : []


### PR DESCRIPTION
Implemented by removing default settings - just defaults to all.

To test this open the app in incognito window or reset local storage (`localStorage.clear()` in js console) to clear saved preferences.