### PR TITLE
CORE-3105 Reduce sql queries on cycle requests

### DIFF
--- a/src/ggrc_workflows/models/cycle.py
+++ b/src/ggrc_workflows/models/cycle.py
@@ -73,7 +73,7 @@ class Cycle(WithContact, Stateful, Timeboxed, Described, Titled, Slugged,
   def eager_query(cls):
     """Add cycle task groups to cycle eager query
 
-    This function add cycle_task_groups as a join option when fetching cycles,
+    This function adds cycle_task_groups as a join option when fetching cycles,
     and makes sure we fetch all cycle related data needed for generating cycle
     json, in one query.
 

--- a/src/ggrc_workflows/models/cycle.py
+++ b/src/ggrc_workflows/models/cycle.py
@@ -3,17 +3,24 @@
 # Created By: dan@reciprocitylabs.com
 # Maintained By: dan@reciprocitylabs.com
 
+"""Module contains a workflow Cycle model
+"""
 
 from sqlalchemy import orm
 
 from ggrc import db
-from ggrc.models.mixins import (
-    Slugged, Titled, Described, Timeboxed, Stateful, WithContact
-)
+from ggrc.models.mixins import Described
+from ggrc.models.mixins import Slugged
+from ggrc.models.mixins import Stateful
+from ggrc.models.mixins import Timeboxed
+from ggrc.models.mixins import Titled
+from ggrc.models.mixins import WithContact
 
 
 class Cycle(WithContact, Stateful, Timeboxed, Described, Titled, Slugged,
             db.Model):
+  """Workflow Cycle model
+  """
   __tablename__ = 'cycles'
   _title_uniqueness = False
 
@@ -49,8 +56,8 @@ class Cycle(WithContact, Stateful, Timeboxed, Described, Titled, Slugged,
 
   _aliases = {
       "cycle_workflow": {
-        "display_name": "Workflow",
-        "filter_by": "_filter_by_cycle_workflow",
+          "display_name": "Workflow",
+          "filter_by": "_filter_by_cycle_workflow",
       },
   }
 
@@ -58,12 +65,21 @@ class Cycle(WithContact, Stateful, Timeboxed, Described, Titled, Slugged,
   def _filter_by_cycle_workflow(cls, predicate):
     from ggrc_workflows.models.workflow import Workflow
     return Workflow.query.filter(
-      (Workflow.id == cls.workflow_id) &
-      (predicate(Workflow.slug) | predicate(Workflow.title))
+        (Workflow.id == cls.workflow_id) &
+        (predicate(Workflow.slug) | predicate(Workflow.title))
     ).exists()
 
   @classmethod
   def eager_query(cls):
+    """Add cycle task groups to cycle eager query
+
+    This function add cycle_task_groups as a join option when fetching cycles,
+    and makes sure we fetch all cycle related data needed for generating cycle
+    json, in one query.
+
+    Returns:
+      a query object with cycle_task_groups added to joined load options.
+    """
     query = super(Cycle, cls).eager_query()
     return query.options(
         orm.joinedload('cycle_task_groups'),

--- a/src/ggrc_workflows/models/cycle.py
+++ b/src/ggrc_workflows/models/cycle.py
@@ -4,6 +4,8 @@
 # Maintained By: dan@reciprocitylabs.com
 
 
+from sqlalchemy import orm
+
 from ggrc import db
 from ggrc.models.mixins import (
     Slugged, Titled, Described, Timeboxed, Stateful, WithContact
@@ -59,3 +61,10 @@ class Cycle(WithContact, Stateful, Timeboxed, Described, Titled, Slugged,
       (Workflow.id == cls.workflow_id) &
       (predicate(Workflow.slug) | predicate(Workflow.title))
     ).exists()
+
+  @classmethod
+  def eager_query(cls):
+    query = super(Cycle, cls).eager_query()
+    return query.options(
+        orm.joinedload('cycle_task_groups'),
+    )

--- a/src/ggrc_workflows/models/cycle_task_group.py
+++ b/src/ggrc_workflows/models/cycle_task_group.py
@@ -3,16 +3,26 @@
 # Created By: dan@reciprocitylabs.com
 # Maintained By: dan@reciprocitylabs.com
 
+"""Module for cycle task group model.
+"""
+
 from sqlalchemy import orm
 
 from ggrc import db
-from ggrc.models.mixins import (
-    Base, Titled, Described, Timeboxed, Slugged, Stateful, WithContact
-)
+from ggrc.models.mixins import Base
+from ggrc.models.mixins import Described
+from ggrc.models.mixins import Slugged
+from ggrc.models.mixins import Stateful
+from ggrc.models.mixins import Timeboxed
+from ggrc.models.mixins import Titled
+from ggrc.models.mixins import WithContact
 from ggrc_workflows.models.cycle import Cycle
+
 
 class CycleTaskGroup(WithContact, Stateful, Slugged, Timeboxed, Described,
                      Titled, Base, db.Model):
+  """Cycle Task Group model.
+  """
   __tablename__ = 'cycle_task_groups'
   _title_uniqueness = False
 
@@ -52,16 +62,26 @@ class CycleTaskGroup(WithContact, Stateful, Slugged, Timeboxed, Described,
 
   _aliases = {
       "cycle": {
-        "display_name": "Cycle",
-        "filter_by": "_filter_by_cycle",
+          "display_name": "Cycle",
+          "filter_by": "_filter_by_cycle",
       },
   }
 
   @classmethod
   def _filter_by_cycle(cls, predicate):
+    """Get query that filters cycle task groups.
+
+    Args:
+      predicate: lambda function that excepts a single parameter and returns
+      true of false.
+
+    Returns:
+      An sqlalchemy query that evaluates to true or false and can be used in
+      filtering cycle task groups by related cycle.
+    """
     return Cycle.query.filter(
-      (Cycle.id == cls.cycle_id) &
-      (predicate(Cycle.slug) | predicate(Cycle.title))
+        (Cycle.id == cls.cycle_id) &
+        (predicate(Cycle.slug) | predicate(Cycle.title))
     ).exists()
 
   @classmethod

--- a/src/ggrc_workflows/models/cycle_task_group.py
+++ b/src/ggrc_workflows/models/cycle_task_group.py
@@ -3,6 +3,7 @@
 # Created By: dan@reciprocitylabs.com
 # Maintained By: dan@reciprocitylabs.com
 
+from sqlalchemy import orm
 
 from ggrc import db
 from ggrc.models.mixins import (
@@ -62,3 +63,19 @@ class CycleTaskGroup(WithContact, Stateful, Slugged, Timeboxed, Described,
       (Cycle.id == cls.cycle_id) &
       (predicate(Cycle.slug) | predicate(Cycle.title))
     ).exists()
+
+  @classmethod
+  def eager_query(cls):
+    """Add cycle tasks and objects to cycle task group eager query.
+
+    Make sure we load all cycle task group relevant data in a single query.
+
+    Returns:
+      a query object with cycle_task_group_tasks and cycle_task_group_objects
+      added to joined load options.
+    """
+    query = super(CycleTaskGroup, cls).eager_query()
+    return query.options(
+        orm.joinedload('cycle_task_group_tasks'),
+        orm.joinedload('cycle_task_group_objects'),
+    )

--- a/src/ggrc_workflows/models/cycle_task_group_object_task.py
+++ b/src/ggrc_workflows/models/cycle_task_group_object_task.py
@@ -4,6 +4,8 @@
 # Maintained By: dan@reciprocitylabs.com
 
 
+from sqlalchemy import orm
+
 from ggrc import db
 from ggrc.models.types import JsonType
 from ggrc.models.mixins import (
@@ -141,3 +143,20 @@ class CycleTaskGroupObjectTask(
         (CycleTaskGroupObject.id == cls.cycle_task_group_object_id) &
         or_(*parts)
     ).exists()
+
+  @classmethod
+  def eager_query(cls):
+    """Add cycle task entries to cycle task eager query
+
+    This function add cycle_task_entries as a join option when fetching cycles
+    tasks, and makes sure that with one query we fetch all cycle task related
+    data needed for generating cycle taks json for a response.
+
+    Returns:
+      a query object with cycle_task_entries added to joined load options.
+    """
+    query = super(CycleTaskGroupObjectTask, cls).eager_query()
+    return query.options(
+        orm.joinedload('cycle_task_entries'),
+    )
+

--- a/src/ggrc_workflows/models/cycle_task_group_object_task.py
+++ b/src/ggrc_workflows/models/cycle_task_group_object_task.py
@@ -3,26 +3,33 @@
 # Created By: dan@reciprocitylabs.com
 # Maintained By: dan@reciprocitylabs.com
 
+"""Module containing Cycle tasks.
+"""
 
 from sqlalchemy import orm
+from sqlalchemy import or_
 
 from ggrc import db
-from ggrc.models.types import JsonType
-from ggrc.models.mixins import (
-    Base, Titled, Described, Timeboxed, Slugged, Stateful, WithContact
-    )
 from ggrc.models import all_models
+from ggrc.models.mixins import Base
+from ggrc.models.mixins import Described
+from ggrc.models.mixins import Slugged
+from ggrc.models.mixins import Stateful
+from ggrc.models.mixins import Timeboxed
+from ggrc.models.mixins import Titled
+from ggrc.models.mixins import WithContact
 from ggrc.models.reflection import PublishOnly
+from ggrc.models.types import JsonType
 from ggrc_workflows.models.cycle import Cycle
 from ggrc_workflows.models.cycle_task_group import CycleTaskGroup
 from ggrc_workflows.models.cycle_task_group_object import CycleTaskGroupObject
 
-from sqlalchemy import or_
-
 
 class CycleTaskGroupObjectTask(
-    WithContact, Stateful, Slugged, Timeboxed,
-    Described, Titled, Base, db.Model):
+        WithContact, Stateful, Slugged, Timeboxed,
+        Described, Titled, Base, db.Model):
+  """Cycle task model
+  """
   __tablename__ = 'cycle_task_group_object_tasks'
   _title_uniqueness = False
 
@@ -30,7 +37,8 @@ class CycleTaskGroupObjectTask(
   def generate_slug_prefix_for(cls, obj):
     return "CYCLETASK"
 
-  VALID_STATES = (None, 'InProgress', 'Assigned', 'Finished', 'Declined', 'Verified')
+  VALID_STATES = (None, 'InProgress', 'Assigned',
+                  'Finished', 'Declined', 'Verified')
 
   cycle_id = db.Column(
       db.Integer, db.ForeignKey('cycles.id'), nullable=False)
@@ -41,9 +49,9 @@ class CycleTaskGroupObjectTask(
   task_group_task_id = db.Column(
       db.Integer, db.ForeignKey('task_group_tasks.id'), nullable=False)
   task_group_task = db.relationship(
-    "TaskGroupTask",
-    foreign_keys="CycleTaskGroupObjectTask.task_group_task_id"
-    )
+      "TaskGroupTask",
+      foreign_keys="CycleTaskGroupObjectTask.task_group_task_id"
+  )
   task_type = db.Column(
       db.String(length=250), nullable=False)
   response_options = db.Column(
@@ -69,15 +77,15 @@ class CycleTaskGroupObjectTask(
       'selected_response_options',
       PublishOnly('finished_date'),
       PublishOnly('verified_date')
-      ]
+  ]
 
   default_description = "<ol>"\
-                        +"<li>Expand the object review task.</li>"\
-                        +"<li>Click on the Object to be reviewed.</li>"\
-                        +"<li>Review the object in the Info tab.</li>"\
-                        +"<li>Click \"Approve\" to approve the object.</li>"\
-                        +"<li>Click \"Decline\" to decline the object.</li>"\
-                        +"</ol>"
+                        + "<li>Expand the object review task.</li>"\
+                        + "<li>Click on the Object to be reviewed.</li>"\
+                        + "<li>Review the object in the Info tab.</li>"\
+                        + "<li>Click \"Approve\" to approve the object.</li>"\
+                        + "<li>Click \"Decline\" to decline the object.</li>"\
+                        + "</ol>"
 
   _aliases = {
       "title": "Summary",
@@ -93,8 +101,8 @@ class CycleTaskGroupObjectTask(
       "finished_date": "Actual Finish Date",
       "verified_date": "Actual Verified Date",
       "cycle": {
-        "display_name": "Cycle",
-        "filter_by": "_filter_by_cycle",
+          "display_name": "Cycle",
+          "filter_by": "_filter_by_cycle",
       },
       "cycle_task_group": {
           "display_name": "Task Group",
@@ -113,20 +121,50 @@ class CycleTaskGroupObjectTask(
 
   @classmethod
   def _filter_by_cycle(cls, predicate):
+    """Get query that filters cycle tasks by related cycles.
+
+    Args:
+      predicate: lambda function that excepts a single parameter and returns
+      true of false.
+
+    Returns:
+      An sqlalchemy query that evaluates to true or false and can be used in
+      filtering cycle tasks by related cycles.
+    """
     return Cycle.query.filter(
-      (Cycle.id == cls.cycle_id) &
-      (predicate(Cycle.slug) | predicate(Cycle.title))
+        (Cycle.id == cls.cycle_id) &
+        (predicate(Cycle.slug) | predicate(Cycle.title))
     ).exists()
 
   @classmethod
   def _filter_by_cycle_task_group(cls, predicate):
+    """Get query that filters cycle tasks by related cycle task groups.
+
+    Args:
+      predicate: lambda function that excepts a single parameter and returns
+      true of false.
+
+    Returns:
+      An sqlalchemy query that evaluates to true or false and can be used in
+      filtering cycle tasks by related cycle task groups.
+    """
     return CycleTaskGroup.query.filter(
-      (CycleTaskGroup.id == cls.cycle_id) &
-      (predicate(CycleTaskGroup.slug) | predicate(CycleTaskGroup.title))
+        (CycleTaskGroup.id == cls.cycle_id) &
+        (predicate(CycleTaskGroup.slug) | predicate(CycleTaskGroup.title))
     ).exists()
 
   @classmethod
   def _filter_by_cycle_object(cls, predicate):
+    """Get query that filters cycle tasks by mapped objects.
+
+    Args:
+      predicate: lambda function that excepts a single parameter and returns
+      true of false.
+
+    Returns:
+      An sqlalchemy query that evaluates to true or false and can be used in
+      filtering cycle tasks by objects mapped to them.
+    """
     parts = []
     for model_name in all_models.__all__:
       model = getattr(all_models, model_name)
@@ -159,4 +197,3 @@ class CycleTaskGroupObjectTask(
     return query.options(
         orm.joinedload('cycle_task_entries'),
     )
-

--- a/src/ggrc_workflows/models/cycle_task_group_object_task.py
+++ b/src/ggrc_workflows/models/cycle_task_group_object_task.py
@@ -186,7 +186,7 @@ class CycleTaskGroupObjectTask(
   def eager_query(cls):
     """Add cycle task entries to cycle task eager query
 
-    This function add cycle_task_entries as a join option when fetching cycles
+    This function adds cycle_task_entries as a join option when fetching cycles
     tasks, and makes sure that with one query we fetch all cycle task related
     data needed for generating cycle taks json for a response.
 


### PR DESCRIPTION
This makes user that number of database lookups is not dependent on the ammount of cycle task groups that are related to cycle (or cycles) that we're trying to fetch.