### PR TITLE
QUICK-FIX: Update .editorconfig rules 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,18 +2,27 @@
 
 root = true
 
-[*.js]
-indent_style = space
-indent_size = 2
+# Unix-style newlines with a newline ending every file
+[*]
 end_of_line = lf
+
+[*.js]
 charset = utf-8
-trim_trailing_whitespace = true
+indent_size = 2
+indent_style = space
 insert_final_newline = true
+trim_trailing_whitespace = true
 
 [*.{html,css,scss,sass}]
-indent_style = space
-indent_size = 2
-trim_trailing_whitespace = true
-end_of_line = lf
 charset = utf-8
+indent_size = 2
+indent_style = space
 insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.py]
+charset = utf-8
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
NOTE: Even though the settings are currently the same for all our source files types (Javascript, CSS, Python), I left them as separate config blocks for a slightly better readability (IMO), and because they are still short enough to easily fit into a single screen page.