### PR TITLE
QUICK-FIX Update pylint checker

### DIFF
--- a/bin/check_pylint_diff
+++ b/bin/check_pylint_diff
@@ -25,13 +25,26 @@ PARENT_1=$(git show --pretty=raw $TEST_COMMIT | grep parent | head -1 | grep -oE
 
 echo "Comparing commits $TEST_COMMIT and $PARENT_1."
 
+CHANGED_FILES=$(git diff --name-only $TEST_COMMIT $PARENT_1 | grep "\.py$" || true )
+if [[ "$CHANGED_FILES" == "" ]]; then
+  echo "No python files changed. Skipping flake checks"
+  exit 0
+fi
+
+echo "Checking files:"
+echo "$CHANGED_FILES"
+echo ""
+
+# Run pylint on the old and new code, to compare the quality.
+# If pylint is run multiple times it will store the previous results and show
+# the change in quality with a non-negative number if code was improved or not 
+# changed, and a negative number if more code issues have been introduced.
 git checkout --quiet $PARENT_1
-pylint src/* > /dev/null 2>&1 | true
+echo "$CHANGED_FILES" | xargs pylint > /dev/null 2>&1 | true
 git checkout --quiet $TEST_COMMIT
-PYLINT_RESULT=$(pylint src/* 2> /dev/null | tail -n 2) 
-git checkout --quiet $CURRENT_COMMIT
+PYLINT_RESULT=$(echo "$CHANGED_FILES" | xargs pylint 2> /dev/null | tail -n 2) 
 
 echo "$PYLINT_RESULT"
-echo "$PYLINT_RESULT" | grep "+" && rc=$? || rc=$?
+echo "$PYLINT_RESULT" | grep -q "+" && rc=$? || rc=$?
 
 exit $rc


### PR DESCRIPTION
- Only check modified files.
- Hide double status output on success (-q option on grep).
- List which files will be checked by pylint for users.