### PR TITLE
CORE-3074 CORE-3076 Search revisions of join objects

### DIFF
--- a/src/ggrc/migrations/versions/20160128111512_4e989ef86619_add_connected_objects_to_revisions.py
+++ b/src/ggrc/migrations/versions/20160128111512_4e989ef86619_add_connected_objects_to_revisions.py
@@ -1,0 +1,46 @@
+"""Add connected objects to revisions
+
+Revision ID: 4e989ef86619
+Revises: 262bbe790f4c
+Create Date: 2016-01-28 11:15:12.300329
+
+"""
+
+# pylint: disable=invalid-name
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '4e989ef86619'  # pylint: disable=invalid-name
+down_revision = '37b2a060bdd6'  # pylint: disable=invalid-name
+
+
+def upgrade():
+  """ Add extra fields and indexes to revisions table """
+  op.add_column('revisions', sa.Column('source_type', sa.String(length=250)))
+  op.add_column('revisions', sa.Column('source_id', sa.Integer()))
+
+  op.add_column('revisions',
+                sa.Column('destination_type', sa.String(length=250)))
+  op.add_column('revisions', sa.Column('destination_id', sa.Integer()))
+
+  op.create_index('fk_revisions_resource', 'revisions',
+                  ['resource_type', 'resource_id'], unique=False)
+  op.create_index('fk_revisions_source', 'revisions',
+                  ['source_type', 'source_id'], unique=False)
+  op.create_index('fk_revisions_destination', 'revisions',
+                  ['destination_type', 'destination_id'], unique=False)
+
+
+def downgrade():
+  """ Remove indexes and fields from revisions """
+  op.drop_index('fk_revisions_resource', table_name='revisions')
+  op.drop_index('fk_revisions_source', table_name='revisions')
+  op.drop_index('fk_revisions_destination', table_name='revisions')
+
+  op.drop_column('revisions', 'source_type')
+  op.drop_column('revisions', 'source_id')
+  op.drop_column('revisions', 'destination_type')
+  op.drop_column('revisions', 'destination_id')

--- a/src/ggrc/models/mixins.py
+++ b/src/ggrc/models/mixins.py
@@ -554,6 +554,7 @@ class Revisionable(object):
     return db.relationship(
         "Revision",
         primaryjoin=join_function,
+        viewonly=True,
         foreign_keys="Revision.resource_type, Revision.resource_id")
 
 

--- a/src/ggrc/models/revision.py
+++ b/src/ggrc/models/revision.py
@@ -23,6 +23,11 @@ class Revision(Base, db.Model):
                      nullable=False)
   content = db.Column(JsonType, nullable=False)
 
+  source_type = db.Column(db.String, nullable=True)
+  source_id = db.Column(db.Integer, nullable=True)
+  destination_type = db.Column(db.String, nullable=True)
+  destination_id = db.Column(db.Integer, nullable=True)
+
   @staticmethod
   def _extra_table_args(_):
     return (db.Index('revisions_modified_by', 'modified_by_id'),)
@@ -30,6 +35,10 @@ class Revision(Base, db.Model):
   _publish_attrs = [
       'resource_id',
       'resource_type',
+      'source_type',
+      'source_id',
+      'destination_type',
+      'destination_id',
       'action',
       'content',
       'description',
@@ -50,6 +59,12 @@ class Revision(Base, db.Model):
     self.resource_type = str(obj.__class__.__name__)
     self.action = action
     self.content = content
+
+    for attr in ["source_type",
+                 "source_id",
+                 "destination_type",
+                 "destination_id"]:
+      setattr(self, attr, getattr(obj, attr, None))
 
   def _description_mapping(self, link_objects):
     """Compute description for revisions with <-> in display name."""

--- a/src/ggrc/models/revision.py
+++ b/src/ggrc/models/revision.py
@@ -3,26 +3,29 @@
 # Created By: vraj@reciprocitylabs.com
 # Maintained By: vraj@reciprocitylabs.com
 
+"""Defines a Revision model for storing snapshots."""
+
 from ggrc import db
-from .all_models import Directive
-from .mixins import Base
-from .types import JsonType
-from .computed_property import computed_property
+from ggrc.models.computed_property import computed_property
+from ggrc.models.mixins import Base
+from ggrc.models.types import JsonType
+
 
 class Revision(Base, db.Model):
+  """Revision object holds a JSON snapshot of the object at a time."""
+
   __tablename__ = 'revisions'
 
-  resource_id = db.Column(db.Integer, nullable = False)
-  resource_type = db.Column(db.String, nullable = False)
-  event_id = db.Column(db.Integer, db.ForeignKey('events.id'), nullable = False)
-  action = db.Column(db.Enum(u'created', u'modified', u'deleted'), nullable = False)
+  resource_id = db.Column(db.Integer, nullable=False)
+  resource_type = db.Column(db.String, nullable=False)
+  event_id = db.Column(db.Integer, db.ForeignKey('events.id'), nullable=False)
+  action = db.Column(db.Enum(u'created', u'modified', u'deleted'),
+                     nullable=False)
   content = db.Column(JsonType, nullable=False)
 
   @staticmethod
-  def _extra_table_args(cls):
-    return (
-        db.Index('revisions_modified_by', 'modified_by_id'),
-        )
+  def _extra_table_args(_):
+    return (db.Index('revisions_modified_by', 'modified_by_id'),)
 
   _publish_attrs = [
       'resource_id',
@@ -39,7 +42,7 @@ class Revision(Base, db.Model):
     query = super(Revision, cls).eager_query()
     return query.options(
         orm.subqueryload('modified_by'),
-        )
+    )
 
   def __init__(self, obj, modified_by_id, action, content):
     self.resource_id = obj.id
@@ -48,32 +51,30 @@ class Revision(Base, db.Model):
     self.action = action
     self.content = content
 
+  def _description_mapping(self, link_objects):
+    """Compute description for revisions with <-> in display name."""
+    display_name = self.content['display_name']
+    source, destination = display_name.split('<->')[:2]
+    mapping_verb = "linked" if self.resource_type in link_objects else "mapped"
+    if self.action == 'created':
+      result = u"{1} {2} to {0}".format(source, destination, mapping_verb)
+    elif self.action == 'deleted':
+      result = u"{1} un{2} from {0}".format(source, destination, mapping_verb)
+    else:
+      result = u"{0} {1}".format(display_name, self.action)
+    return result
+
   @computed_property
   def description(self):
+    """Compute a human readable description from action and content."""
     link_objects = ['ObjectDocument']
-    # TODO: Remove check below if migration can guarantee display_name in content
     if 'display_name' not in self.content:
       return ''
     display_name = self.content['display_name']
     if not display_name:
       result = u"{0} {1}".format(self.resource_type, self.action)
     elif u'<->' in display_name:
-      #TODO: Fix too many values to unpack below
-      source, destination = display_name.split('<->')[:2]
-      if self.resource_type in link_objects:
-        if self.action == 'created':
-          result = u"{1} linked to {0}".format(source, destination)
-        elif self.action == 'deleted':
-          result = u"{1} unlinked from {0}".format(source, destination)
-        else:
-          result = u"{0} {1}".format(display_name, self.action)
-      else:
-        if self.action == 'created':
-          result = u"{1} mapped to {0}".format(source, destination)
-        elif self.action == 'deleted':
-          result = u"{1} unmapped from {0}".format(source, destination)
-        else:
-          result = u"{0} {1}".format(display_name, self.action)
+      result = self._description_mapping(link_objects)
     else:
       if 'mapped_directive' in self.content:
         # then this is a special case of combined map/creation

--- a/test/integration/ggrc/models/test_revision.py
+++ b/test/integration/ggrc/models/test_revision.py
@@ -1,0 +1,112 @@
+# Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+# Created By: andraz@reciprocitylabs.com
+# Maintained By: andraz@reciprocitylabs.com
+
+""" Tests for ggrc.models.Revision """
+
+import integration.ggrc
+import integration.ggrc.generator
+import ggrc.models
+
+
+def _get_revisions(obj, field="resource"):
+  return ggrc.models.Revision.query.filter_by(**{
+      field + "_type": obj.__class__.__name__,
+      field + "_id": obj.id
+  }).all()
+
+
+def _project_content(content):
+  return {
+      "source": {
+          "type": content["source_type"],
+          "id": content["source_id"],
+      },
+      "destination": {
+          "type": content["destination_type"],
+          "id": content["destination_id"],
+      },
+  }
+
+
+class TestRevisions(integration.ggrc.TestCase):
+  """ Tests for ggrc.models.Revision """
+
+  def setUp(self):
+    integration.ggrc.TestCase.setUp(self)
+    self.gen = integration.ggrc.generator.ObjectGenerator()
+
+  def test_revisions(self):
+    """ Test revision creation for POST and PUT """
+    cls = ggrc.models.DataAsset
+    name = cls._inflector.table_singular  # pylint: disable=protected-access
+    _, obj = self.gen.generate(cls, name, {name: {
+        "title": "revisioned v1",
+        "context": None,
+    }})
+    revisions = _get_revisions(obj)
+    self.assertEqual(len(revisions), 1)
+
+    _, obj = self.gen.modify(obj, name, {name: {
+        "slug": obj.slug,
+        "title": "revisioned v2",
+        "context": None,
+    }})
+    revisions = _get_revisions(obj)
+    expected = {("created", "revisioned v1"), ("modified", "revisioned v2")}
+    actual = {(r.action, r.content["title"]) for r in revisions}
+    self.assertEqual(actual, expected)
+
+  def test_relevant_revisions(self):
+    """ Test revision creation for mapping to an object """
+    cls = ggrc.models.DataAsset
+    name = cls._inflector.table_singular  # pylint: disable=protected-access
+
+    _, obj1 = self.gen.generate(cls, name, {name: {
+        "title": "connected 1",
+        "context": None,
+    }})
+
+    _, obj2 = self.gen.generate(cls, name, {name: {
+        "title": "connected 2",
+        "context": None,
+    }})
+
+    rel_data = {
+        "source": {"id": obj1.id, "type": cls.__name__},
+        "destination": {"id": obj2.id, "type": cls.__name__},
+        "context": None,
+    }
+    _, rel = self.gen.generate(ggrc.models.Relationship, "relationship", {
+                               "relationship": rel_data})
+
+    revisions_source = _get_revisions(obj1, "source")
+    revisions_destination = _get_revisions(obj2, "destination")
+
+    self.assertEqual(revisions_source, revisions_destination)
+    self.assertEqual(len(revisions_source), 1)
+
+    self.gen.api.delete(rel, rel.id)
+
+    revisions_source = _get_revisions(obj1, "source")
+    revisions_destination = _get_revisions(obj2, "destination")
+
+    self.assertEqual(revisions_source, revisions_destination)
+    self.assertEqual(len(revisions_source), 2)
+
+    expected_data = {
+        "source": {
+            "type": cls.__name__,
+            "id": obj1.id,
+        },
+        "destination": {
+            "type": cls.__name__,
+            "id": obj2.id,
+        },
+    }
+    expected = [(u"created", expected_data), ("deleted", expected_data)]
+
+    actual = [(r.action, _project_content(r.content))
+              for r in revisions_source]
+    self.assertEqual(sorted(actual), sorted(expected))


### PR DESCRIPTION
This stores connected objects in revisions for join objects so you can fetch revisions of join objects given only object type and id.

Still needs some work, but I'd like some feedback on naming and overall design.

TODO:
- [x] indexes
- [x] finish linting revision model
- [x] tests