### PR TITLE
CORE-2803 Render datetime in local time

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,6 +14,7 @@
     "lodash": "3.10.1",
     "mousetrap": "1.5.3",
     "moment": "2.10.6",
+    "moment-timezone": "0.5.0",
     "jasmine-fixture": "1.3.3",
     "spinjs": "1.3.3",
     "fontawesome": "~4.4.0",

--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -30,6 +30,7 @@ dashboard-js-files:
   - wysihtml5/wysihtml5-0.4.0pre.js
   - wysihtml5/bootstrap-wysihtml5-0.0.2.js
   - moment/min/moment.min.js
+  - moment-timezone/builds/moment-timezone-with-data.min.js
   - spinjs/spin.js
   - string-natural-compare/natural-compare.min.js
   # end 3rd party

--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -1181,6 +1181,8 @@ Mustache.registerHelper("link_to_tree", function () {
 Mustache.registerHelper('date', function (date, hide_time) {
   var current_timezone = moment.tz.guess();
   var m;
+
+  if (date === undefined || date === null) {
     return '';
   }
 

--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -1173,13 +1173,13 @@ Mustache.registerHelper("link_to_tree", function () {
 /**
  *  Helper for rendering date or datetime values in current local time
  *
- *  @param {boolean} hide_time - if set to true, render date only
+ *  @param {boolean} hideTime - if set to true, render date only
  *  @return {String} - date or datetime string in the following format:
  *    * date: MM/DD/YYYY),
  *    * datetime (MM/DD/YYYY hh:mm:ss [PM|AM] [local timezone])
  */
-Mustache.registerHelper('date', function (date, hide_time) {
-  var current_timezone = moment.tz.guess();
+Mustache.registerHelper('date', function (date, hideTime) {
+  var currentTimezone = moment.tz.guess();
   var m;
 
   if (date === undefined || date === null) {
@@ -1187,10 +1187,10 @@ Mustache.registerHelper('date', function (date, hide_time) {
   }
 
   m = moment(new Date(date.isComputed ? date() : date));
-  if (hide_time === true) {
+  if (hideTime === true) {
     return m.format('MM/DD/YYYY');
   }
-  return m.tz(current_timezone).format('MM/DD/YYYY hh:mm:ss A z');
+  return m.tz(currentTimezone).format('MM/DD/YYYY hh:mm:ss A z');
 });
 
 /**

--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -1172,18 +1172,19 @@ Mustache.registerHelper("link_to_tree", function () {
 
 // Returns date formated like 01/28/2015 02:59:02am PST
 // To omit time pass in a second parameter {{date updated_at true}}
-Mustache.registerHelper("date", function (date) {
-    if (typeof date == 'undefined')
-      return '';
-  var m = moment(new Date(date.isComputed ? date() : date))
-    , dst = m.isDST()
-    , no_time = arguments.length > 2
-    ;
+Mustache.registerHelper('date', function (date) {
+  if (typeof date == 'undefined') {
+    return '';
+  }
+  var current_timezone = moment.tz.guess();
+  var m = moment(new Date(date.isComputed ? date() : date));
+  var no_time = arguments.length > 2;
 
   if (no_time) {
-    return m.format("MM/DD/YYYY");
+    return m.format('MM/DD/YYYY');
   }
-  return m.utcOffset(dst ? "-0700" : "-0800").format("MM/DD/YYYY hh:mm:ssa") + " " + (dst ? 'PDT' : 'PST');
+
+  return m.tz(current_timezone).format('MM/DD/YYYY hh:mm:ss A z');
 });
 
 /**

--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -1170,8 +1170,14 @@ Mustache.registerHelper("link_to_tree", function () {
   return link.join("/");
 });
 
-// Returns date formated like 01/28/2015 02:59:02am PST
-// To omit time pass in a second parameter {{date updated_at true}}
+/**
+ *  Helper for rendering date or datetime values in current local time
+ *
+ *  @param {boolean} time flag - if set to true, render date only
+ *  @return {String} - date or datetime string in the following format:
+ *    * date: MM/DD/YYYY),
+ *    * datetime (MM/DD/YYYY hh:mm:ss [PM|AM] [local timezone])
+ */
 Mustache.registerHelper('date', function (date) {
   if (typeof date == 'undefined') {
     return '';

--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -1178,18 +1178,16 @@ Mustache.registerHelper("link_to_tree", function () {
  *    * date: MM/DD/YYYY),
  *    * datetime (MM/DD/YYYY hh:mm:ss [PM|AM] [local timezone])
  */
-Mustache.registerHelper('date', function (date) {
-  if (typeof date == 'undefined') {
+Mustache.registerHelper('date', function (date, hide_time) {
+  var current_timezone = moment.tz.guess();
+  var m;
     return '';
   }
-  var current_timezone = moment.tz.guess();
-  var m = moment(new Date(date.isComputed ? date() : date));
-  var no_time = arguments.length > 2;
 
-  if (no_time) {
+  m = moment(new Date(date.isComputed ? date() : date));
+  if (hide_time === true) {
     return m.format('MM/DD/YYYY');
   }
-
   return m.tz(current_timezone).format('MM/DD/YYYY hh:mm:ss A z');
 });
 

--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -1173,7 +1173,7 @@ Mustache.registerHelper("link_to_tree", function () {
 /**
  *  Helper for rendering date or datetime values in current local time
  *
- *  @param {boolean} time flag - if set to true, render date only
+ *  @param {boolean} hide_time - if set to true, render date only
  *  @return {String} - date or datetime string in the following format:
  *    * date: MM/DD/YYYY),
  *    * datetime (MM/DD/YYYY hh:mm:ss [PM|AM] [local timezone])

--- a/src/ggrc/assets/js_specs/mustache_helpers/date_spec.js
+++ b/src/ggrc/assets/js_specs/mustache_helpers/date_spec.js
@@ -9,57 +9,57 @@ describe('can.mustache.helper.date', function () {
   'use strict';
 
   var helper;
-  var instance;
+  var testDate;
 
   beforeAll(function () {
     helper = can.Mustache._helpers.date.fn;
   });
 
   it('returns date only when boolean true is passed in', function () {
-    instance = new Date(2015, 4, 3, 7, 34, 56);
-    expect(helper(instance, true)).toEqual('05/03/2015');
+    testDate = new Date(2015, 4, 3, 7, 34, 56);
+    expect(helper(testDate, true)).toEqual('05/03/2015');
   });
 
   it('returns datetime when stringy truthy value is passed in', function () {
     var timezone = moment(
       '2015-05-03T12:34:45Z').tz(moment.tz.guess()).format('z');
-    instance = new Date(2015, 4, 3, 7, 34, 56);
+    testDate = new Date(2015, 4, 3, 7, 34, 56);
 
-    expect(helper(instance, 'true')).toEqual('05/03/2015 07:34:56 AM '+ timezone);
+    expect(helper(testDate, 'true')).toEqual('05/03/2015 07:34:56 AM '+ timezone);
   });
 
   it('returns datetime when stringy falsey value is passed in', function () {
     var timezone = moment(
       '2015-05-03T12:34:45Z').tz(moment.tz.guess()).format('z');
-    instance = new Date(2015, 4, 3, 7, 34, 56);
+    testDate = new Date(2015, 4, 3, 7, 34, 56);
 
     expect(
-      helper(instance, 'false')).toEqual('05/03/2015 07:34:56 AM '+ timezone);
+      helper(testDate, 'false')).toEqual('05/03/2015 07:34:56 AM '+ timezone);
   });
 
   it('returns datetime when false value is passed in', function () {
     var timezone = moment(
       '2015-05-03T12:34:45Z').tz(moment.tz.guess()).format('z');
-    instance = new Date(2015, 4, 3, 7, 34, 56);
+    testDate = new Date(2015, 4, 3, 7, 34, 56);
 
     expect(
-      helper(instance, false)).toEqual('05/03/2015 07:34:56 AM '+ timezone);
+      helper(testDate, false)).toEqual('05/03/2015 07:34:56 AM '+ timezone);
   });
 
 
   it('returns datetime when random values are passed in', function () {
     var timezone = moment(
       '2015-05-03T12:34:45Z').tz(moment.tz.guess()).format('z');
-    instance = new Date(2015, 4, 3, 7, 34, 56);
+    testDate = new Date(2015, 4, 3, 7, 34, 56);
 
     expect(
-      helper(instance, 'asdasd')).toEqual('05/03/2015 07:34:56 AM '+ timezone);
+      helper(testDate, 'asdasd')).toEqual('05/03/2015 07:34:56 AM '+ timezone);
     expect(
-      helper(instance, {a: 1})).toEqual('05/03/2015 07:34:56 AM '+ timezone);
+      helper(testDate, {a: 1})).toEqual('05/03/2015 07:34:56 AM '+ timezone);
     expect(
-      helper(instance, '{a: 1}')).toEqual('05/03/2015 07:34:56 AM '+ timezone);
+      helper(testDate, '{a: 1}')).toEqual('05/03/2015 07:34:56 AM '+ timezone);
     expect(
-      helper(instance, 123)).toEqual('05/03/2015 07:34:56 AM '+ timezone);
+      helper(testDate, 123)).toEqual('05/03/2015 07:34:56 AM '+ timezone);
   });
 
 });

--- a/src/ggrc/assets/js_specs/mustache_helpers/date_spec.js
+++ b/src/ggrc/assets/js_specs/mustache_helpers/date_spec.js
@@ -25,7 +25,8 @@ describe('can.mustache.helper.date', function () {
       '2015-05-03T12:34:45Z').tz(moment.tz.guess()).format('z');
     testDate = new Date(2015, 4, 3, 7, 34, 56);
 
-    expect(helper(testDate, 'true')).toEqual('05/03/2015 07:34:56 AM '+ timezone);
+    expect(
+      helper(testDate, 'true')).toEqual('05/03/2015 07:34:56 AM ' + timezone);
   });
 
   it('returns datetime when stringy falsey value is passed in', function () {
@@ -34,7 +35,7 @@ describe('can.mustache.helper.date', function () {
     testDate = new Date(2015, 4, 3, 7, 34, 56);
 
     expect(
-      helper(testDate, 'false')).toEqual('05/03/2015 07:34:56 AM '+ timezone);
+      helper(testDate, 'false')).toEqual('05/03/2015 07:34:56 AM ' + timezone);
   });
 
   it('returns datetime when false value is passed in', function () {
@@ -43,9 +44,8 @@ describe('can.mustache.helper.date', function () {
     testDate = new Date(2015, 4, 3, 7, 34, 56);
 
     expect(
-      helper(testDate, false)).toEqual('05/03/2015 07:34:56 AM '+ timezone);
+      helper(testDate, false)).toEqual('05/03/2015 07:34:56 AM ' + timezone);
   });
-
 
   it('returns datetime when random values are passed in', function () {
     var timezone = moment(
@@ -53,13 +53,12 @@ describe('can.mustache.helper.date', function () {
     testDate = new Date(2015, 4, 3, 7, 34, 56);
 
     expect(
-      helper(testDate, 'asdasd')).toEqual('05/03/2015 07:34:56 AM '+ timezone);
+      helper(testDate, 'asdasd')).toEqual('05/03/2015 07:34:56 AM ' + timezone);
     expect(
-      helper(testDate, {a: 1})).toEqual('05/03/2015 07:34:56 AM '+ timezone);
+      helper(testDate, {a: 1})).toEqual('05/03/2015 07:34:56 AM ' + timezone);
     expect(
-      helper(testDate, '{a: 1}')).toEqual('05/03/2015 07:34:56 AM '+ timezone);
+      helper(testDate, '{a: 1}')).toEqual('05/03/2015 07:34:56 AM ' + timezone);
     expect(
-      helper(testDate, 123)).toEqual('05/03/2015 07:34:56 AM '+ timezone);
+      helper(testDate, 123)).toEqual('05/03/2015 07:34:56 AM ' + timezone);
   });
-
 });

--- a/src/ggrc/assets/js_specs/mustache_helpers/date_spec.js
+++ b/src/ggrc/assets/js_specs/mustache_helpers/date_spec.js
@@ -16,50 +16,50 @@ describe('can.mustache.helper.date', function () {
   });
 
   it('returns date only when boolean true is passed in', function () {
-    instance = new Date(2015, 4, 3, 12, 34, 56);
+    instance = new Date(2015, 4, 3, 7, 34, 56);
     expect(helper(instance, true)).toEqual('05/03/2015');
   });
 
   it('returns datetime when stringy truthy value is passed in', function () {
     var timezone = moment(
-      '2015-05-03T12:34:45Z').tz(moment.tz.guess()).format('A z');
-    instance = new Date(2015, 4, 3, 12, 34, 56);
+      '2015-05-03T12:34:45Z').tz(moment.tz.guess()).format('z');
+    instance = new Date(2015, 4, 3, 7, 34, 56);
 
-    expect(helper(instance, 'true')).toEqual('05/03/2015 12:34:56 '+ timezone);
+    expect(helper(instance, 'true')).toEqual('05/03/2015 07:34:56 AM '+ timezone);
   });
 
   it('returns datetime when stringy falsey value is passed in', function () {
     var timezone = moment(
-      '2015-05-03T12:34:45Z').tz(moment.tz.guess()).format('A z');
-    instance = new Date(2015, 4, 3, 12, 34, 56);
+      '2015-05-03T12:34:45Z').tz(moment.tz.guess()).format('z');
+    instance = new Date(2015, 4, 3, 7, 34, 56);
 
     expect(
-      helper(instance, 'false')).toEqual('05/03/2015 12:34:56 '+ timezone);
+      helper(instance, 'false')).toEqual('05/03/2015 07:34:56 AM '+ timezone);
   });
 
   it('returns datetime when false value is passed in', function () {
     var timezone = moment(
-      '2015-05-03T12:34:45Z').tz(moment.tz.guess()).format('A z');
-    instance = new Date(2015, 4, 3, 12, 34, 56);
+      '2015-05-03T12:34:45Z').tz(moment.tz.guess()).format('z');
+    instance = new Date(2015, 4, 3, 7, 34, 56);
 
     expect(
-      helper(instance, false)).toEqual('05/03/2015 12:34:56 '+ timezone);
+      helper(instance, false)).toEqual('05/03/2015 07:34:56 AM '+ timezone);
   });
 
 
   it('returns datetime when random values are passed in', function () {
     var timezone = moment(
-      '2015-05-03T12:34:45Z').tz(moment.tz.guess()).format('A z');
-    instance = new Date(2015, 4, 3, 12, 34, 56);
+      '2015-05-03T12:34:45Z').tz(moment.tz.guess()).format('z');
+    instance = new Date(2015, 4, 3, 7, 34, 56);
 
     expect(
-      helper(instance, 'asdasd')).toEqual('05/03/2015 12:34:56 '+ timezone);
+      helper(instance, 'asdasd')).toEqual('05/03/2015 07:34:56 AM '+ timezone);
     expect(
-      helper(instance, {a: 1})).toEqual('05/03/2015 12:34:56 '+ timezone);
+      helper(instance, {a: 1})).toEqual('05/03/2015 07:34:56 AM '+ timezone);
     expect(
-      helper(instance, '{a: 1}')).toEqual('05/03/2015 12:34:56 '+ timezone);
+      helper(instance, '{a: 1}')).toEqual('05/03/2015 07:34:56 AM '+ timezone);
     expect(
-      helper(instance, 123)).toEqual('05/03/2015 12:34:56 '+ timezone);
+      helper(instance, 123)).toEqual('05/03/2015 07:34:56 AM '+ timezone);
   });
 
 });

--- a/src/ggrc/assets/js_specs/mustache_helpers/date_spec.js
+++ b/src/ggrc/assets/js_specs/mustache_helpers/date_spec.js
@@ -3,7 +3,7 @@
  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  Created By: urban@reciprocitylabs.com
  Maintained By: urban@reciprocitylabs.com
- //*/
+ */
 
 describe('can.mustache.helper.date', function () {
   'use strict';

--- a/src/ggrc/assets/js_specs/mustache_helpers/date_spec.js
+++ b/src/ggrc/assets/js_specs/mustache_helpers/date_spec.js
@@ -1,0 +1,65 @@
+/*!
+ Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ Created By: urban@reciprocitylabs.com
+ Maintained By: urban@reciprocitylabs.com
+ //*/
+
+describe('can.mustache.helper.date', function () {
+  'use strict';
+
+  var helper;
+  var instance;
+
+  beforeAll(function () {
+    helper = can.Mustache._helpers.date.fn;
+  });
+
+  it('returns date only when boolean true is passed in', function () {
+    instance = new Date(2015, 4, 3, 12, 34, 56);
+    expect(helper(instance, true)).toEqual('05/03/2015');
+  });
+
+  it('returns datetime when stringy truthy value is passed in', function () {
+    var timezone = moment(
+      '2015-05-03T12:34:45Z').tz(moment.tz.guess()).format('A z');
+    instance = new Date(2015, 4, 3, 12, 34, 56);
+
+    expect(helper(instance, 'true')).toEqual('05/03/2015 12:34:56 '+ timezone);
+  });
+
+  it('returns datetime when stringy falsey value is passed in', function () {
+    var timezone = moment(
+      '2015-05-03T12:34:45Z').tz(moment.tz.guess()).format('A z');
+    instance = new Date(2015, 4, 3, 12, 34, 56);
+
+    expect(
+      helper(instance, 'false')).toEqual('05/03/2015 12:34:56 '+ timezone);
+  });
+
+  it('returns datetime when false value is passed in', function () {
+    var timezone = moment(
+      '2015-05-03T12:34:45Z').tz(moment.tz.guess()).format('A z');
+    instance = new Date(2015, 4, 3, 12, 34, 56);
+
+    expect(
+      helper(instance, false)).toEqual('05/03/2015 12:34:56 '+ timezone);
+  });
+
+
+  it('returns datetime when random values are passed in', function () {
+    var timezone = moment(
+      '2015-05-03T12:34:45Z').tz(moment.tz.guess()).format('A z');
+    instance = new Date(2015, 4, 3, 12, 34, 56);
+
+    expect(
+      helper(instance, 'asdasd')).toEqual('05/03/2015 12:34:56 '+ timezone);
+    expect(
+      helper(instance, {a: 1})).toEqual('05/03/2015 12:34:56 '+ timezone);
+    expect(
+      helper(instance, '{a: 1}')).toEqual('05/03/2015 12:34:56 '+ timezone);
+    expect(
+      helper(instance, 123)).toEqual('05/03/2015 12:34:56 '+ timezone);
+  });
+
+});

--- a/src/ggrc/assets/mustache/base_templates/attachment.mustache
+++ b/src/ggrc/assets/mustache/base_templates/attachment.mustache
@@ -17,7 +17,7 @@
   {{/instance}}
   {{/is_allowed}}
   <i class="fa fa-file-{{file_type instance}}-o"></i>
-  <span class="date">{{date instance.created_at "no_time"}}</span>
+  <span class="date">{{date instance.created_at true}}</span>
   <a href="{{schemed_url instance.link}}" href="{{schemed_url instance.link}}" target="_blank">
     <span>{{firstnonempty instance.title instance.link}}</span>
   </a>

--- a/src/ggrc/assets/mustache/base_templates/dates_list.mustache
+++ b/src/ggrc/assets/mustache/base_templates/dates_list.mustache
@@ -13,7 +13,7 @@
         <label>
           Created on
         </label>
-        <span name="created_at">{{date created_at notime}}</span>
+        <span name="created_at">{{date created_at true}}</span>
       </li>
       <li>
         {{#toggle change_due_date}}
@@ -33,7 +33,7 @@
           <label>
             Due on
           </label>
-          {{date due_on notime}}
+          {{date due_on true}}
         {{/toggle}}
       </li>
     </ul>


### PR DESCRIPTION
This PR renders times in local time but it has issues with times that go across winter/summer time. Winter/summer label (CET/CEST) gets render correctly but the rendering sets offset from UTC per current offset and not offset at the time of post - this means that a post made during the winter at 4:35 PM CET (3:35 PM UTC) get rendered as 5:35 PM CET during summer when +2 offset is in play for CEST.

Per discussion with Prasanna that is not an issue for now (since we save in UTC anyway and it's only a rendering issue), created a ticket for technical debt.