### PR TITLE
CORE-3135 Define a read-only Revision object on the client.

### DIFF
--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -103,6 +103,7 @@ dashboard-js-files:
   - pbc/workflow_controller.js
   - models/category.js
   - models/refresh_queue.js
+  - models/revision.js
   - models/save_queue.js
   - models/custom_attributes.js
   - apps/quick_search.js

--- a/src/ggrc/assets/javascripts/models/revision.js
+++ b/src/ggrc/assets/javascripts/models/revision.js
@@ -1,0 +1,29 @@
+/*!
+    Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+    Created By: peter@reciprocitylabs.com
+    Maintained By: peter@reciprocitylabs.com
+*/
+
+(function (can) {
+  /**
+   * A model holding data and metadata describing a particular revision of
+   * some business object at a particular point, i.e. the business object's
+   * state.
+   *
+   * This is useful for e.g. reconstruction of an object's change history.
+   */
+  can.Model.Cacheable('CMS.Models.Revision', {
+    root_object: 'revision',
+    root_collection: 'revisions',
+
+    // NOTE: only read API methods, because Revisions should not be modified
+    // by the client directly
+    findAll: '/api/revisions',
+    findOne: '/api/revisions/{id}',
+
+    mixins: [],
+    attributes: {}
+  },
+  {});
+})(this.can);


### PR DESCRIPTION
_(please give this a slightly higher priority, because it is blocking other work on the ObjectHistoryLoader feature)_

---

This object is needed as an API client for fetching the revision history from the server, needed by the upcoming ObjectHistoryLoader.

Since this object will not be visible to the users, it has no associated controller and view metadata, just the bare essentials. Please let me know if any other essential part/attribute needs to be defined, or if it still contains something redundant.

No tests, because there's nothing to test really (unless we test the methods that are auto-generated based on the object model's configuration?).
