### PR TITLE
QUCK-FIX Update pylint evaluation function

### DIFF
--- a/bin/check_pylint_diff
+++ b/bin/check_pylint_diff
@@ -45,6 +45,6 @@ git checkout --quiet $TEST_COMMIT
 PYLINT_RESULT=$(echo "$CHANGED_FILES" | xargs pylint 2> /dev/null | tail -n 2) 
 
 echo "$PYLINT_RESULT"
-echo "$PYLINT_RESULT" | grep -q "+" && rc=$? || rc=$?
+echo "$PYLINT_RESULT" | grep -qv "+" && rc=$? || rc=$?
 
 exit $rc

--- a/pylintrc
+++ b/pylintrc
@@ -85,7 +85,12 @@ reports=yes
 # respectively contain the number of errors / warnings messages and the total
 # number of statements analyzed. This is used by the global evaluation report
 # (RP0004).
-evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# This expression does not return a value between 0 and 10 because it is used
+# for reducing the amount of issues in the code. Having anything normalized to
+# LOC would mean that we could add more errors to the code as long as the
+# number of new lines of code was high enough.
+evaluation=2 * error + warning + refactor + convention
 
 # Add a comment according to your evaluation note. This is used by the global
 # evaluation report (RP0004).


### PR DESCRIPTION
Our evaluation function should prevent the issue count from rising no
matter how many lines of code are added.

This PR is mostly made because I saw that @edofic's PR https://github.com/google/ggrc-core/pull/3550 passed the tests when it should not have