### PR TITLE
QUICK-FIX Ignore non existing files with flake8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,9 @@
 [flake8]
-ignore = E111,E114
+ignore = E111,E114,E902
 max-complexity = 10
+
+# Notes:
+# - E902 is dissabled to prevent IO errors. The automated tests generate a list
+#   of files that were changed (added, removed and edited) and runs the flake8
+#   on those. Disabling this error will prevent false negative tests when a
+#   python file has been removed.


### PR DESCRIPTION
This prevents flake8 from showing a "No such file or directory" error
which can occur when running automated checks on deleted files.


This commit is already in https://github.com/google/ggrc-core/pull/3546 but we can't wait on that commit, because selenium pr is blocked by this issue.