### PR TITLE
QUICK-FIX Update python checker scripts

### DIFF
--- a/bin/check
+++ b/bin/check
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+# Created By: miha@reciprocitylabs.com
+# Maintained By: miha@reciprocitylabs.com
 
 set -o nounset
 set -o errexit

--- a/bin/check_flake8_diff
+++ b/bin/check_flake8_diff
@@ -7,18 +7,54 @@
 set -o nounset
 set -o errexit
 
+ARG1=${1:-}
+SCRIPT=$(basename "$0")
 SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
 cd "${SCRIPTPATH}/../"
 
+
+if [ "$ARG1" == "-h" || "$ARG1" == "--help" ]; then
+  echo "
+Usage: $SCRIPT [base_commit] [-h]
+
+This script will run flake8 over a list of changed files. It has three modes of
+operation depending on where and how we run it. Without parameters on a normal
+commit, it will use the files of that commit. Without parameters on a merge
+commit, it will use files that were modified on the branch that was merged into
+the current one. With a parameter, it will use the files that were changed
+between the current commit and the latest common commit if it's on a different
+branch.
+
+Given the commit tree:
+
+       D---E---F---G---H
+            \\         /
+             A---B---C
+
+- Running '$SCRIPT' on C will use files changed in the commit C.
+- Running '$SCRIPT' on H will use files changed in commits A, B, C.
+- Running '$SCRIPT H' on C will use files changed in commits A, B, C.
+- Running '$SCRIPT D' on C will use files changed in commits E, A, B, C.
+- Running '$SCRIPT F' on H will use files changed in commits G, H.
+"
+  exit 0
+fi
+
 CURRENT_COMMIT=$(git rev-parse HEAD)
-PARENT_1=$(git show --pretty=raw $CURRENT_COMMIT | grep parent | head -1 | grep -oE "[^ ]*$")
-PARENT_2=$(git show --pretty=raw $CURRENT_COMMIT | head -6 | grep parent | tail -1 | grep -oE "[^ ]*$")
-BASE_COMMIT=$(git merge-base $PARENT_1 $PARENT_2)
+if [ "$ARG1" == "" ]; then
+  BASE_COMMIT="$ARG1"
+  PARENT_2=$CURRENT_COMMIT
+else
+  PARENT_1=$(git show --pretty=raw $CURRENT_COMMIT | grep parent | head -1 | grep -oE "[^ ]*$")
+  PARENT_2=$(git show --pretty=raw $CURRENT_COMMIT | head -6 | grep parent | tail -1 | grep -oE "[^ ]*$")
+  BASE_COMMIT=$(git merge-base $PARENT_1 $PARENT_2)
+fi
+
 
 # List files changed in a commit, or if it's a merge commit, list files chaged
 # from the begin of the branch to the last commit on the merged branch.
 if [[ "$PARENT_2" == "$BASE_COMMIT" ]]; then
-  CHANGED_FILES=$(git diff-tree --no-commit-id --name-only -r $BASE_COMMIT | grep "\.py$" || true )
+  CHANGED_FILES=$(git diff-tree --no-commit-id --name-only -r $CURRENT_COMMIT | grep "\.py$" || true )
 else
   CHANGED_FILES=$(git diff --name-only $BASE_COMMIT $PARENT_2 | grep "\.py$" || true )
 fi

--- a/bin/check_pylint_diff
+++ b/bin/check_pylint_diff
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-
 # Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 # Created By: miha@reciprocitylabs.com
@@ -8,14 +7,39 @@
 set -o nounset
 set -o errexit
 
+ARG1=${1:-}
 TMP_REPO="/tmp/ggrc-core"
+SCRIPT=$(basename "$0")
 SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
+
+if [ "$ARG1" == "-h" || "$ARG1" == "--help" ]; then
+  echo "
+Usage: $SCRIPT [test_commit] [-h]
+
+This script will compare pylint error count from two different commits.
+Note: all changes that are not committed will be ignored.
+
+
+Given the commit tree:
+
+       D---E---F---G---H
+            \\         /
+             A---B---C
+
+- Running '$SCRIPT' on C will check the diff between B and C
+- Running '$SCRIPT' on H will check the diff between G and H
+- Running '$SCRIPT F' on H will check the diff between F and H
+"
+  exit 0
+fi
+
 rm -rf $TMP_REPO
 cp -a /vagrant $TMP_REPO
 cd $TMP_REPO
+git clean -xdf
 
-if [[ "${1:-}" != "" ]]; then
-  TEST_COMMIT=$1
+if [[ "$ARG1" != "" ]]; then
+  TEST_COMMIT=$ARG1
 else
   TEST_COMMIT=$(git rev-parse HEAD)
 fi


### PR DESCRIPTION
- Add a missing license header.
- Add help texts.
- Allow flake8 checker to specify what branch to check.
- Fix flake8 chekc on a normal commit. Now it checks the current commit
  instead of the previous one.