### PR TITLE
CORE-3077 Add revision history property to Request object

### DIFF
--- a/src/ggrc/assets/javascripts/models/mappings.js
+++ b/src/ggrc/assets/javascripts/models/mappings.js
@@ -719,6 +719,7 @@
       urls_from_comments: Cross("comments", "urls"),
       all_documents: Multi(["documents", "documents_from_comments"]),
       all_urls: Multi(["urls", "urls_from_comments"]),
+      revision_history: Direct('Revision', 'resource', 'revisions'),
       related_objects_via_search: Search(function (binding) {
         var types = [
           "Program", "Regulation", "Contract", "Policy", "Standard",

--- a/src/ggrc/models/request.py
+++ b/src/ggrc/models/request.py
@@ -5,13 +5,12 @@
 
 import datetime
 
-from ggrc import db
 from sqlalchemy import or_
 from sqlalchemy import and_
 from sqlalchemy import inspect
 from sqlalchemy import orm
 
-
+from ggrc import db
 from ggrc.models import person
 from ggrc.models import audit
 from ggrc.models import reflection
@@ -197,7 +196,7 @@ def _date_has_changes(attr):
   added, deleted = attr.history.added[0], attr.history.deleted[0]
   if isinstance(added, datetime.datetime):
     added = added.date()
-  return not added == deleted
+  return added != deleted
 
 
 @Resource.model_put.connect_via(Request)

--- a/src/ggrc/models/request.py
+++ b/src/ggrc/models/request.py
@@ -20,6 +20,7 @@ from ggrc.models.mixins import Base
 from ggrc.models.mixins import CustomAttributable
 from ggrc.models.mixins import deferred
 from ggrc.models.mixins import Described
+from ggrc.models.mixins import Revisionable
 from ggrc.models.mixins import Slugged
 from ggrc.models.mixins import Titled
 from ggrc.models.object_document import Documentable
@@ -31,7 +32,8 @@ from ggrc.services.common import Resource
 
 
 class Request(Assignable, Documentable, Personable, CustomAttributable,
-              Relatable, Titled, Slugged, Described, Base, db.Model):
+              Relatable, Titled, Slugged, Described, Revisionable,
+              Base, db.Model):
   __tablename__ = 'requests'
   _title_uniqueness = False
 
@@ -96,8 +98,8 @@ class Request(Assignable, Documentable, Personable, CustomAttributable,
       "request_type": "Request Type",
       "requested_on": "Requested On",
       "status": {
-        "display_name": "Status",
-        "handler_key": "request_status",
+          "display_name": "Status",
+          "handler_key": "request_status",
       },
       "test": "Test",
       "related_assignees": {


### PR DESCRIPTION
This PR depends on #3550 - since it was blocked, it was based on it, thus it includes the change set from #3550 

The ListLoader described in the [ticket](https://reciprocitylabs.atlassian.net/browse/CORE-3077) was not created, because it turned out that is not needed.