### PR TITLE
QUICK-FIX Fix flake8 checks

### DIFF
--- a/bin/check_flake8_diff
+++ b/bin/check_flake8_diff
@@ -13,7 +13,7 @@ SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
 cd "${SCRIPTPATH}/../"
 
 
-if [ "$ARG1" == "-h" || "$ARG1" == "--help" ]; then
+if [[ "$ARG1" == "-h" || "$ARG1" == "--help" ]]; then
   echo "
 Usage: $SCRIPT [base_commit] [-h]
 
@@ -41,7 +41,7 @@ Given the commit tree:
 fi
 
 CURRENT_COMMIT=$(git rev-parse HEAD)
-if [ "$ARG1" == "" ]; then
+if [[ "$ARG1" == "" ]]; then
   BASE_COMMIT="$ARG1"
   PARENT_2=$CURRENT_COMMIT
 else

--- a/bin/check_pylint_diff
+++ b/bin/check_pylint_diff
@@ -12,7 +12,7 @@ TMP_REPO="/tmp/ggrc-core"
 SCRIPT=$(basename "$0")
 SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
 
-if [ "$ARG1" == "-h" || "$ARG1" == "--help" ]; then
+if [[ "$ARG1" == "-h" || "$ARG1" == "--help" ]]; then
   echo "
 Usage: $SCRIPT [test_commit] [-h]
 


### PR DESCRIPTION
The if statement was broken, causing all flake8 checks to pass. This
makes sure that the conditions in the if statement work as intended.

This was the result before:
 https://jenkins.reciprocitylabs.com/job/ggrc_code_style/261/console