### PR TITLE
QUICK-FIX Explicitly set which karma to use

### DIFF
--- a/bin/run_karma
+++ b/bin/run_karma
@@ -2,6 +2,6 @@
 # Copyright (C) 2015 Google Inc., authors, and contributors <see AUTHORS file>
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 # Created By: swizec@reciprocitylabs.com
-# Maintained By: swizec@reciprocitylabs.com
+# Maintained By: urban@reciprocitylabs.com
 
-karma start --reporters dots & watch_assets
+/vagrant/node_modules/karma/bin/karma start --reporters dots & watch_assets


### PR DESCRIPTION
Specify to use our karma and not system default (which doesn't
have additional modules that we need)