### PR TITLE
CORE-3163 Fix migrations

### DIFF
--- a/src/ggrc/migrations/versions/20151015124337_1ef8f4f504ae_remove_relationship_types.py
+++ b/src/ggrc/migrations/versions/20151015124337_1ef8f4f504ae_remove_relationship_types.py
@@ -11,12 +11,12 @@ Create Date: 2015-10-15 12:43:37.846021
 
 """
 
+from alembic import op
+import sqlalchemy as sa
+
 # revision identifiers, used by Alembic.
 revision = '1ef8f4f504ae'
 down_revision = '262bbe790f4c'
-
-from alembic import op
-import sqlalchemy as sa
 
 
 def upgrade():

--- a/src/ggrc/migrations/versions/20151015124337_1ef8f4f504ae_remove_relationship_types.py
+++ b/src/ggrc/migrations/versions/20151015124337_1ef8f4f504ae_remove_relationship_types.py
@@ -20,8 +20,21 @@ import sqlalchemy as sa
 
 
 def upgrade():
-  op.drop_column('relationships', 'relationship_type_id')
-  op.drop_table('relationship_types')
+  try:
+    op.drop_column('relationships', 'relationship_type_id')
+  except sa.exc.OperationalError as operr:
+    # Ignores error in case relationship_type_id no longer exists
+    error_code, _ = operr.orig.args  # error_code, message
+    if error_code != 1091:
+      raise operr
+
+  try:
+    op.drop_table('relationship_types')
+  except sa.exc.OperationalError as operr:
+    # Ignores error in case relationship_types table no longer exists
+    error_code, _ = operr.orig.args  # error_code, message
+    if error_code != 1051:
+      raise operr
 
 
 def downgrade():

--- a/src/ggrc/migrations/versions/20160113150536_4003827b3d48_drop_unused_tables.py
+++ b/src/ggrc/migrations/versions/20160113150536_4003827b3d48_drop_unused_tables.py
@@ -19,19 +19,30 @@ from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.dialects import mysql
 
+
 def upgrade():
-  op.drop_table('object_sections')
-  op.drop_table('control_sections')
-  op.drop_table('objective_controls')
-  op.drop_table('program_controls')
-  op.drop_table('directive_controls')
-  op.drop_table('control_controls')
-  op.drop_table('calendar_entries')
-  op.drop_table('object_objectives')
-  op.drop_table('object_controls')
-  op.drop_table('section_objectives')
-  op.drop_table('program_directives')
-  op.drop_table('directive_sections')
+  tables = [
+      "object_sections",
+      "control_sections",
+      "objective_controls",
+      "program_controls",
+      "directive_controls",
+      "control_controls",
+      "calendar_entries",
+      "object_objectives",
+      "object_controls",
+      "section_objectives",
+      "program_directives",
+      "directive_sections"
+  ]
+  for table in tables:
+    try:
+      op.drop_table(table)
+    except sa.exc.OperationalError as operr:
+      # Ignores error in case relationship_types table no longer exists
+      error_code, _ = operr.orig.args  # error_code, message
+      if error_code != 1051:
+        raise operr
 
 
 def downgrade():

--- a/src/ggrc/migrations/versions/20160113150536_4003827b3d48_drop_unused_tables.py
+++ b/src/ggrc/migrations/versions/20160113150536_4003827b3d48_drop_unused_tables.py
@@ -11,13 +11,13 @@ Create Date: 2016-01-13 15:05:36.008456
 
 """
 
-# revision identifiers, used by Alembic.
-revision = '4003827b3d48'
-down_revision = '5410607088f9'
-
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.dialects import mysql
+
+# revision identifiers, used by Alembic.
+revision = '4003827b3d48'
+down_revision = '5410607088f9'
 
 
 def upgrade():

--- a/src/ggrc/migrations/versions/20160113152055_1abb0a2e8ca0_rename_control_assessments.py
+++ b/src/ggrc/migrations/versions/20160113152055_1abb0a2e8ca0_rename_control_assessments.py
@@ -11,12 +11,12 @@ Create Date: 2016-01-13 15:20:55.866368
 
 """
 
+from alembic import op
+import sqlalchemy as sa
+
 # revision identifiers, used by Alembic.
 revision = '1abb0a2e8ca0'
 down_revision = '4003827b3d48'
-
-from alembic import op
-import sqlalchemy as sa
 
 
 def upgrade():

--- a/src/ggrc/migrations/versions/20160113152055_1abb0a2e8ca0_rename_control_assessments.py
+++ b/src/ggrc/migrations/versions/20160113152055_1abb0a2e8ca0_rename_control_assessments.py
@@ -16,9 +16,22 @@ revision = '1abb0a2e8ca0'
 down_revision = '4003827b3d48'
 
 from alembic import op
+import sqlalchemy as sa
+
 
 def upgrade():
-  op.execute("RENAME TABLE control_assessments TO assessments")
+  try:
+    op.execute("RENAME TABLE control_assessments TO assessments")
+  except sa.exc.OperationalError as operr:
+    # Ignores error in case table assessment already exists
+    error_code, _ = operr.orig.args  # error_code, message
+    if error_code != 1050:
+      raise operr
+    # We don't perform migration if table assessment already exists;
+    # that can only happen if the migration already happened and there
+    # is no longer need to perform it second time
+    return
+
   # Migrate all possible mappings where object_type = 'ControlAssessment'
   objects = {
       "relationships": ("source_type", "destination_type"),
@@ -41,6 +54,7 @@ def upgrade():
            WHERE {value} = 'control_assessment'"""
   op.execute(sql.format(key='custom_attribute_definitions',
                         value='definition_type'))
+
 
 def downgrade():
   op.execute("RENAME TABLE assessments TO control_assessments")

--- a/src/ggrc/migrations/versions/20160203143912_6bed0575a0b_migrate_assessment_to_assignable_mixin.py
+++ b/src/ggrc/migrations/versions/20160203143912_6bed0575a0b_migrate_assessment_to_assignable_mixin.py
@@ -37,7 +37,7 @@ def upgrade():
   """)
 
   op.execute("""
-      INSERT INTO relationship_attrs (
+      INSERT IGNORE INTO relationship_attrs (
         relationship_id, attr_name, attr_value
       )
       SELECT r.id, 'AssigneeType', 'Creator,Assessor'


### PR DESCRIPTION
With https://github.com/google/ggrc-core/commit/3f5d9653b648dd76de86e76da0337e7bccb8e1a7 we broke the migrations for existing databases, this fixes those migration to only execute certain actions if needed.