### PR TITLE
QUICK-FIX Update python linters

### DIFF
--- a/bin/check_flake8_diff
+++ b/bin/check_flake8_diff
@@ -41,7 +41,7 @@ Given the commit tree:
 fi
 
 CURRENT_COMMIT=$(git rev-parse HEAD)
-if [[ "$ARG1" == "" ]]; then
+if [[ "$ARG1" != "" ]]; then
   BASE_COMMIT="$ARG1"
   PARENT_2=$CURRENT_COMMIT
 else

--- a/bin/check_pylint_diff
+++ b/bin/check_pylint_diff
@@ -36,7 +36,7 @@ fi
 rm -rf $TMP_REPO
 cp -a /vagrant $TMP_REPO
 cd $TMP_REPO
-git clean -xdf
+git clean -xdfq
 
 if [[ "$ARG1" != "" ]]; then
   TEST_COMMIT=$ARG1


### PR DESCRIPTION
- Use branch argument on flake8 check only if it's actually set.
- Hide git clean messages from pylint checker.


If you take a look at the code style result here https://jenkins.reciprocitylabs.com/job/ggrc_code_style/300/console
you'll see that no file changes were found for flake8 and the pylint has teh ugly remove messages for non tracked files. This PR just fixes these two issues.