### PR TITLE
QUICK-FIX Add karma-junit-reporter to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "karma": "^0.13.15",
     "karma-cli": "^0.1.1",
     "karma-jasmine": "^0.3.6",
+    "karma-junit-reporter": "^0.3.8",
     "mkdirp": "^0.5.1",
     "nodeunit": "^0.9.1",
     "pegjs": "^0.9.0"


### PR DESCRIPTION
Karma unit tests were not reported correctly by jenkins because of the missing dependency.

```
Running karma tests
Initializing environment
[33m15 02 2016 13:16:57.031:WARN [reporter]: [39mCan not load "junit", it is not registered!
  Perhaps you are missing some plugin?
```