### PR TITLE
QUICK-FIX Clean current repo before running linters

### DIFF
--- a/bin/check_eslint_diff
+++ b/bin/check_eslint_diff
@@ -67,6 +67,8 @@ SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
 rm -rf $TMP_REPO
 cp -a /vagrant $TMP_REPO
 cd $TMP_REPO
+git clean -xdfq
+git reset --hard HEAD
 
 if [[ "$TARGET_BRANCH" != "" ]]; then
   # Determine the number of JS code issues at the point the PR branch was
@@ -80,6 +82,8 @@ fi
 echo -n "Checking out the merge base of $TARGET_BRANCH and the current branch"
 echo -n " (${MERGE_BASE_HASH:0:7})..."
 git checkout --quiet "$MERGE_BASE_HASH"
+git clean -xdfq
+git reset --hard HEAD
 echo " DONE"
 
 echo -n "Running ESLint on the merge base commit (${MERGE_BASE_HASH:0:7})... "
@@ -91,6 +95,8 @@ echo "found $N_ISSUES_BASE issue(s)"
 # the number of JS code issues on it
 echo -n "Checking out back the current branch..."
 git checkout --quiet -
+git clean -xdfq
+git reset --hard HEAD
 echo " DONE"
 
 echo -n "Running ESLint on the current (PR) branch... "

--- a/bin/check_pylint_diff
+++ b/bin/check_pylint_diff
@@ -37,6 +37,7 @@ rm -rf $TMP_REPO
 cp -a /vagrant $TMP_REPO
 cd $TMP_REPO
 git clean -xdfq
+git reset --hard HEAD
 
 if [[ "$ARG1" != "" ]]; then
   TEST_COMMIT=$ARG1
@@ -71,10 +72,14 @@ function run_pylint() {
 }
 
 git checkout -q $PARENT_1
+git clean -xdfq
+git reset --hard HEAD
 echo "running pylint on parent commit"
 RESULT_1=$( run_pylint )
 
 git checkout -q $TEST_COMMIT
+git clean -xdfq
+git reset --hard HEAD
 echo "running pylint on test commit"
 RESULT_2=$( run_pylint )
 


### PR DESCRIPTION
Since we have diff checks for js and python linters, we have to compare
the results from different commits. This commit makes sure that we
always perform these checks on a clean repo and that checkouts never
fail.