### PR TITLE
QUICK-FIX Add eslint checks back

### DIFF
--- a/bin/init_env
+++ b/bin/init_env
@@ -28,4 +28,4 @@ source "${DEV_PREFIX}/opt/dev_virtualenv/bin/activate"
 
 export PYTHONPATH="${PREFIX}/src:${DEV_PREFIX}/opt/google_appengine:${DEV_PREFIX}/opt/linked_packages:${PYTHONPATH}:${PREFIX}/test/selenium/src"
 
-export PATH="${PREFIX}/bin:${DEV_PREFIX}/opt/google_appengine:$PATH"
+export PATH="${PREFIX}/bin:${DEV_PREFIX}/opt/google_appengine:$PATH:${DEV_PREFIX}/node_modules/.bin/"

--- a/bin/jenkins/run_code_style
+++ b/bin/jenkins/run_code_style
@@ -52,6 +52,23 @@ else
   flake8_error='<error type="flake8" message="Flake8 error"></error>'
 fi
 
+echo "
+###############################################################################
+"
+
+echo "Running eslint"
+docker exec -i ${PROJECT}_dev_1 su vagrant -c "
+  export PATH=\$PATH:/vagrant-dev/node_modules/.bin
+  /vagrant/bin/check_eslint_diff
+" && eslint_rc=$? || eslint_rc=$?
+
+if [[ eslint_rc -eq 0 ]]; then
+  echo "PASS"
+  eslint_error=''
+else
+  echo "FAIL"
+  eslint_error='<error type="eslint" message="ESLint error"></error>'
+fi
 
 echo "
 ###############################################################################
@@ -63,6 +80,7 @@ echo '<?xml version="1.0" encoding="UTF-8"?>
 <testsuite name="code-style" tests="3" errors="'$((pylint_rc + flake_rc))'" failures="0" skip="0">
   <testcase classname="pylint.pylint" name="pylint" time="0">'$pylint_error'</testcase>
   <testcase classname="flake8.flake8" name="flake8" time="0">'$flake8_error'</testcase>
+  <testcase classname="eslint.eslint" name="eslint" time="0">'$eslint_error'</testcase>
 </testsuite>' > test/lint.xml
 
-exit $((pylint_rc * pylint_rc + flake_rc * flake_rc))
+exit $((pylint_rc * pylint_rc + flake_rc * flake_rc + eslint_rc * eslint_rc))

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "pegjs": "^0.9.0"
   },
   "devDependencies": {
+    "eslint-config-google": "^0.4.0",
+    "eslint-config-xo": "^0.10.1",
+    "eslint": "^2.1.0"
   },
   "scripts": {
     "test": "run_unittests"


### PR DESCRIPTION
Es lint checks were broken due to missing dependecies and missing node path. Hopefully this PR fixes all eslint issues.