### PR TITLE
CORE-3214 CORE-3215 Prevent XSS attack in script error alert

### DIFF
--- a/src/ggrc/assets/javascripts/apps/quick_search.js
+++ b/src/ggrc/assets/javascripts/apps/quick_search.js
@@ -89,26 +89,20 @@ $(function() {
             error : [
               "Failed to map"
               , inst.constructor.title_singular
-              , "<strong>"
               , inst.title
-              , "</strong> to"
+              , "to"
               , page_model.title_singular
-              , "<strong>"
               , page_instance.title
-              , "</strong>"
               ].join(" ")
             }
           : {
             success : [
               "Mapped"
               , inst.constructor.title_singular
-              , "<strong>"
               , inst.title
-              , "</strong> to"
+              , "to"
               , page_model.title_singular
-              , "<strong>"
               , page_instance.title
-              , "</strong>"
               ].join(" ")
             }
         );

--- a/src/ggrc/assets/javascripts/bootstrap/modal-form.js
+++ b/src/ggrc/assets/javascripts/bootstrap/modal-form.js
@@ -313,48 +313,53 @@
       }
     });
 
-    $('body').on('ajax:flash', function(e, flash) {
-      var $target, $flash_holder
-        , type, message_i
-        , flash_class
-        , flash_class_mappings = { notice: "success" }
-        , html
-        , got_message = _.some(_.values(flash),
-                               function (msg) { return !!msg; });
+    $('body').on('ajax:flash', function (e, flash) {
+      var $target;
+      var $flashHolder;
+      var type;
+      var messageI;
+      var flashClass;
+      var flashClassMappings = {notice: 'success'};
+      var $html;
+      var gotMessage = _.some(_.values(flash), function (msg) {
+        return !!msg;
+      });
 
-      if (!got_message) {
+      if (!gotMessage) {
         // sometimes ajax:flash is triggered with bad data
         return;
       }
 
       // Find or create the flash-message holder
       $target = $(e.target);
-      if($target.has(".modal-body").length < 1)
+      if ($target.has('.modal-body').length < 1) {
         $target = $('body');
-      $flash_holder = $target.find('.flash');
+      }
+      $flashHolder = $target.find('.flash');
 
-      if ($flash_holder.length == 0) {
-        $flash_holder = $('<div class="flash"></div>');
-        $target.find('.modal-body').prepend($flash_holder);
+      if ($flashHolder.length === 0) {
+        $flashHolder = $('<div class="flash"></div>');
+        $target.find('.modal-body').prepend($flashHolder);
       } else {
-        $flash_holder.empty();
+        $flashHolder.empty();
       }
 
       for (type in flash) {
         if (flash[type]) {
-          if (typeof(flash[type]) == "string")
+          if (typeof (flash[type]) === 'string') {
             flash[type] = [flash[type]];
-
-          flash_class = flash_class_mappings[type] || type;
-
-          html = $('<div></div>');
-          html.addClass('alert').addClass('alert-' + flash_class);
-          html.append('<a href="#" class="close" data-dismiss="alert">x</a>');
-
-          for (message_i in flash[type]) {
-            html.append($('<span></span>').text(flash[type][message_i]));
           }
-          $flash_holder.append(html);
+
+          flashClass = flashClassMappings[type] || type;
+
+          $html = $('<div></div>');
+          $html.addClass('alert').addClass('alert-' + flashClass);
+          $html.append('<a href="#" class="close" data-dismiss="alert">x</a>');
+
+          for (messageI in flash[type]) {
+            $html.append($('<span></span>').text(flash[type][messageI]));
+          }
+          $flashHolder.append($html);
         }
       }
     });

--- a/src/ggrc/assets/javascripts/bootstrap/modal-form.js
+++ b/src/ggrc/assets/javascripts/bootstrap/modal-form.js
@@ -347,15 +347,14 @@
 
           flash_class = flash_class_mappings[type] || type;
 
-          html =
-            [ '<div class="alert alert-' + flash_class + '">'
-            ,   '<a href="#" class="close" data-dismiss="alert">x</a>'
-            ];
+          html = $('<div></div>');
+          html.addClass('alert').addClass('alert-' + flash_class);
+          html.append('<a href="#" class="close" data-dismiss="alert">x</a>');
+
           for (message_i in flash[type]) {
-            html.push('<span>' + flash[type][message_i] + '</span>');
+            html.append($('<span></span>').text(flash[type][message_i]));
           }
-          html.push('</div>');
-          $flash_holder.append(html.join(''));
+          $flash_holder.append(html);
         }
       }
     });

--- a/src/ggrc/assets/javascripts/controllers/assessment_generator.js
+++ b/src/ggrc/assets/javascripts/controllers/assessment_generator.js
@@ -103,12 +103,12 @@ can.Component.extend({
           };
         } else {
           msg = {
-            success: "<span class='user-string'>" + count + "</span> Control Assessments successfully created."
+            success: count + " Control Assessments successfully created."
           };
         }
       } else {
         msg = {
-          error: "An error occured when creating Control Assessments."
+          error: "An error occurred when creating Control Assessments."
         };
       }
 

--- a/src/ggrc/assets/javascripts/controllers/delete_modal_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/delete_modal_controller.js
@@ -32,7 +32,7 @@ GGRC.Controllers.Modals("GGRC.Controllers.Delete", {
         parent_controller.options.skip_refresh = true;
       }
 
-      msg = "<span class='user-string'>" + instance.display_name() + "</span>" + " deleted successfully";
+      msg = instance.display_name() + " deleted successfully";
       $(document.body).trigger("ajax:flash", { success : msg});
       if (that.element) {
         that.element.trigger("modal:success", that.options.instance);

--- a/src/ggrc/assets/javascripts/controllers/delete_modal_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/delete_modal_controller.js
@@ -28,6 +28,7 @@ GGRC.Controllers.Modals("GGRC.Controllers.Delete", {
       // If this modal is spawned from an edit modal, make sure that one does
       // not refresh the instance post-delete.
       var parent_controller = $(that.options.$trigger).closest('.modal').control();
+      var msg;
       if (parent_controller) {
         parent_controller.options.skip_refresh = true;
       }

--- a/src/ggrc/assets/javascripts/controllers/modals_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/modals_controller.js
@@ -849,12 +849,12 @@ can.Control("GGRC.Controllers.Modals", {
               if (obj.is_declining_review && obj.is_declining_review == '1') {
                 msg = "Review declined";
               } else if (name) {
-                msg = "New " + type + " <span class='user-string'>" + name + "</span>" + " added successfully.";
+                msg = "New " + type + " " + name + " added successfully.";
               } else {
                 msg = "New " + type + " added successfully.";
               }
             } else {
-              msg = "<span class='user-string'>" + name + "</span>" + " modified successfully.";
+              msg = name + " modified successfully.";
             }
             $(document.body).trigger("ajax:flash", { success : msg });
             finish();

--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -1143,7 +1143,7 @@ class Resource(ModelView):
           errors.append((res_status, body))
       if len(errors) > 0:
         status = errors[0][0]
-        headers["X-Flash-Error"] = '<hr>'.join((error for _, error in errors))
+        headers["X-Flash-Error"] = ' || '.join((error for _, error in errors))
       else:
         status = 200
     return current_app.make_response(


### PR DESCRIPTION
We were creating alert boxes by concatenating strings of html along with the error message. This fix makes sure the error message is properly escaped before appending it to the DOM (using jQuery.text()).