### PR TITLE
CORE-3203 Use display names in request log

### DIFF
--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -3350,16 +3350,25 @@ Mustache.registerHelper("un_camel_case", function (str, options) {
       updatedAt: null,
       changes: []
     };
+    var attrDefs = GGRC.model_attr_defs[rev2.resource_type];
 
     diff.madeBy = 'User ' + rev2.modified_by.id;
     diff.updatedAt = rev2.updated_at;
 
     can.each(rev2.content, function (value, fieldName) {
       var origVal = rev1.content[fieldName];
+      var displayName;
+      if (attrDefs) {
+        displayName = (_.find(attrDefs, function (attr) {
+          return attr.attr_name === fieldName;
+        }) || {}).display_name;
+      } else {
+        displayName = fieldName;
+      }
 
-      if (value !== origVal) {
+      if (displayName && value !== origVal) {
         diff.changes.push({
-          fieldName: fieldName,
+          fieldName: displayName,
           origVal: origVal,
           newVal: value
         });

--- a/src/ggrc/assets/js_specs/mustache_helpers/revisions_diff_spec.js
+++ b/src/ggrc/assets/js_specs/mustache_helpers/revisions_diff_spec.js
@@ -24,6 +24,8 @@ describe('can.mustache.helper.revisions_diff', function () {
         })
       }
     };
+
+    GGRC.model_attr_defs = {};
   });
 
   beforeEach(function () {


### PR DESCRIPTION
Snatch attribute names from exports and hide non-exportable fields.