### PR TITLE
QUICK-FIX Remove obsolete options from pylintrc

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -7,9 +7,6 @@
 # pygtk.require().
 #init-hook=
 
-# Profiled execution.
-profile=no
-
 # Add files or directories to the blacklist. They should be base names, not
 # paths.
 ignore=CVS
@@ -91,19 +88,12 @@ reports=yes
 # number of new lines of code was high enough.
 evaluation=2 * error + warning + refactor + convention
 
-# Add a comment according to your evaluation note. This is used by the global
-# evaluation report (RP0004).
-comment=no
-
 # Template used to display messages. This is a python new-style format string
 # used to format the message information. See doc for all details
 #msg-template=
 
 
 [BASIC]
-
-# Required attributes for module, separated by a comma
-required-attributes=
 
 # List of builtins function names that should not be used, separated by a comma
 bad-functions=map,filter,input
@@ -279,10 +269,6 @@ ignored-modules=
 # (useful for classes with attributes dynamically set).
 ignored-classes=SQLObject
 
-# When zope mode is activated, add a predefined set of Zope acquired attributes
-# to generated-members.
-zope=no
-
 # List of members which are set dynamically and missed by pylint inference
 # system, and so shouldn't trigger E0201 when accessed. Python regular
 # expressions are accepted.
@@ -308,10 +294,6 @@ callbacks=cb_,_cb
 
 
 [CLASSES]
-
-# List of interface methods to ignore, separated by a comma. This is used for
-# instance to not check methods defines in Zope's Interface base class.
-ignore-iface-methods=isImplementedBy,deferred,extends,names,namesAndDescriptions,queryDescriptionFor,getBases,getDescriptionFor,getDoc,getName,getTaggedValue,getTaggedValueTags,isEqualOrExtendedBy,setTaggedValue,isImplementedByInstancesOf,adaptWith,is_implemented_by
 
 # List of method names used to declare (i.e. assign) instance attributes.
 defining-attr-methods=__init__,__new__,setUp


### PR DESCRIPTION
This commit addresses these warnings when running pylint:

- option profile is obsolete and it is slated for removal in Pylint 1.6.
- option comment is obsolete and it is slated for removal in Pylint 1.6.
- option required-attributes is obsolete and it is slated for removal in
  Pylint 1.6.
- option ignore-iface-methods is obsolete and it is slated for removal
  in Pylint 1.6.
- option zope is obsolete and it is slated for removal in Pylint 1.6.