### PR TITLE
QUICK-FIX Fix empty branch name in ESLint check script

### DIFF
--- a/bin/check_eslint_diff
+++ b/bin/check_eslint_diff
@@ -79,7 +79,7 @@ else
   MERGE_BASE_HASH=$(git show --pretty=raw HEAD | grep parent | head -1 | grep -oE "[^ ]*$")
 fi
 
-echo -n "Checking out the merge base of $TARGET_BRANCH and the current branch"
+echo -n "Checking out the merge base of ${TARGET_BRANCH:-the target} and the current branch"
 echo -n " (${MERGE_BASE_HASH:0:7})..."
 git checkout --quiet "$MERGE_BASE_HASH"
 git clean -xdfq


### PR DESCRIPTION
If not given, the `$TARGET_BRANCH` variable is empty, resulting in a missing part of the sentence in the output. This PR fixes that by making the output sentence generic.