### PR TITLE
QUICK-FIX Update pytest-selenium package

### DIFF
--- a/src/dev-requirements.txt
+++ b/src/dev-requirements.txt
@@ -34,7 +34,7 @@ pytest-cache==1.0
 pytest-flask==0.10.0
 pytest-html==1.7
 pytest-pep8==1.0.6
-pytest-selenium==1.0
+pytest-selenium==1.1
 pytest-variables==1.2
 pytest-xdist==1.13.1
 pytest==2.8.2


### PR DESCRIPTION
The pytest selenium 1.0 has a bug that always throws this warning:

```
======================= pytest-warning summary =======================
WI1 /vagrant-dev/opt/dev_virtualenv/local/lib/python2.7/site-packages/
pytest_selenium/pytest_selenium.py:90 'pytest_runtest_makereport' hook
uses deprecated __multicall__ argument
```

Upgrading to version 1.1 will make sure that our tests can pass without
a warning.