### PR TITLE
CORE-3154 Add AssessmentTemplate entity

### DIFF
--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -210,6 +210,8 @@ dashboard-js-template-files:
   - assessments/tree_footer.mustache
   - assessments/tree_add_item.mustache
   - assessments/info.mustache
+  - assessment_templates/modal_content.mustache
+  - assessment_templates/info.mustache
   - issues/modal_content.mustache
   - issues/info.mustache
   - issues/remediation_plan.mustache

--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -119,6 +119,7 @@ dashboard-js-files:
   - components/mapped_tree_view.js
   - components/paginate.js
   - components/tabs.js
+  - components/assessment_attributes.js
   #- d3.v2.js
   #- related_graph.js
 
@@ -210,6 +211,8 @@ dashboard-js-template-files:
   - assessments/tree_footer.mustache
   - assessments/tree_add_item.mustache
   - assessments/info.mustache
+  - assessment_templates/attribute_field.mustache
+  - assessment_templates/attribute_add_field.mustache
   - assessment_templates/modal_content.mustache
   - assessment_templates/info.mustache
   - issues/modal_content.mustache

--- a/src/ggrc/assets/javascripts/apps/base_widgets.js
+++ b/src/ggrc/assets/javascripts/apps/base_widgets.js
@@ -8,7 +8,7 @@
 (function (GGRC, _) {
   var base_widgets_by_type = {
     AccessGroup: 'Audit Clause Contract Control Assessment DataAsset Facility Issue Market Objective OrgGroup Person Policy Process Product Program Project Regulation Request Section Standard System Vendor',
-    Audit: 'Control Assessment Issue Person Program Request Regulation Policy Standard Contract Section Clause Objective',
+    Audit: 'Control Assessment AssessmentTemplate Issue Person Program Request Regulation Policy Standard Contract Section Clause Objective',
     Clause: 'AccessGroup Audit Contract Control Assessment DataAsset Facility Issue Market Objective OrgGroup Person Policy Process Product Program Project Regulation Request Section Standard System Vendor',
     Contract: 'AccessGroup Audit Clause Control Assessment DataAsset Facility Issue Market Objective OrgGroup Person Process Product Program Project Request Section System Vendor',
     Control: 'AccessGroup Audit Clause Contract Control Assessment DataAsset Facility Issue Market Objective OrgGroup Person Policy Process Product Program Project Regulation Request Request Section Standard System Vendor',

--- a/src/ggrc/assets/javascripts/apps/business_objects.js
+++ b/src/ggrc/assets/javascripts/apps/business_objects.js
@@ -39,6 +39,7 @@
         process: CMS.Models.Process,
         control: CMS.Models.Control,
         assessment: CMS.Models.Assessment,
+        assessment_template: CMS.Models.AssessmentTemplate,
         request: CMS.Models.Request,
         issue: CMS.Models.Issue,
         objective: CMS.Models.Objective,
@@ -65,8 +66,8 @@
       if (!GGRC.page_object) {
         return;
       }
-      // Info widgets display the object information instead of listing connected
-      //  objects.
+      // Info widgets display the object information instead of listing
+      // connected objects.
       info_widget_views = {
         programs: GGRC.mustache_path + '/programs/info.mustache',
         audits: GGRC.mustache_path + '/audits/info.mustache',
@@ -78,6 +79,8 @@
         processes: GGRC.mustache_path + '/processes/info.mustache',
         products: GGRC.mustache_path + '/products/info.mustache',
         assessments: GGRC.mustache_path + '/assessments/info.mustache',
+        assessment_templates:
+          GGRC.mustache_path + '/assessment_templates/info.mustache',
         requests: GGRC.mustache_path + '/requests/info.mustache',
         issues: GGRC.mustache_path + '/issues/info.mustache'
       };

--- a/src/ggrc/assets/javascripts/apps/business_objects.js
+++ b/src/ggrc/assets/javascripts/apps/business_objects.js
@@ -493,7 +493,17 @@
             header_view: GGRC.mustache_path + "/base_objects/tree_header.mustache",
             footer_view: GGRC.mustache_path + "/assessments/tree_footer.mustache",
             add_item_view: GGRC.mustache_path + "/assessments/tree_add_item.mustache"
-          }
+          },
+          AssessmentTemplate: {
+            mapping: 'related_assessment_templates',
+            draw_children: true,
+            show_view:
+              GGRC.mustache_path + '/base_objects/tree.mustache',
+            footer_view:
+              GGRC.mustache_path + '/base_objects/tree_footer.mustache',
+            add_item_view:
+              GGRC.mustache_path + '/base_objects/tree_add_item.mustache'
+          },
         },
         directive: {
           _mixins: [

--- a/src/ggrc/assets/javascripts/bootstrap/modal-ajax.js
+++ b/src/ggrc/assets/javascripts/bootstrap/modal-ajax.js
@@ -255,11 +255,6 @@
         , model : model
         , current_user : GGRC.current_user
         , instance : instance
-
-        // the instance in the context of the element that triggered
-        // opening the modal
-        , parentInstance: $trigger.data('instance')
-
         , modal_title : object_params.modal_title || modal_title
         , content_view : content_view
         , mapping : mapping

--- a/src/ggrc/assets/javascripts/bootstrap/modal-ajax.js
+++ b/src/ggrc/assets/javascripts/bootstrap/modal-ajax.js
@@ -255,6 +255,11 @@
         , model : model
         , current_user : GGRC.current_user
         , instance : instance
+
+        // the instance in the context of the element that triggered
+        // opening the modal
+        , parentInstance: $trigger.data('instance')
+
         , modal_title : object_params.modal_title || modal_title
         , content_view : content_view
         , mapping : mapping

--- a/src/ggrc/assets/javascripts/components/assessment_attributes.js
+++ b/src/ggrc/assets/javascripts/components/assessment_attributes.js
@@ -1,0 +1,86 @@
+/*!
+    Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+    Created By: ivan@reciprocitylabs.com
+    Maintained By: ivan@reciprocitylabs.com
+*/
+
+(function (can, $) {
+  can.Component.extend({
+    tag: 'assessment-template-attributes',
+    template: '<content></content>',
+    scope: {
+      fields: new can.List()
+    }
+  });
+  can.Component.extend({
+    tag: 'template-filed',
+    template: can.view(GGRC.mustache_path + '/assessment_templates/attribute_field.mustache'),
+    scope: {
+      removeField: function (scope, el, ev) {
+
+      },
+      attrs: function () {
+        return _.compact(_.map(this.attr('field.values').split(','), function (value) {
+          value = $.trim(value);
+          if (value) {
+            return value;
+          }
+        }));
+      }
+    }
+  });
+  can.Component.extend({
+    tag: 'add-template-filed',
+    template: can.view(GGRC.mustache_path + '/assessment_templates/attribute_add_field.mustache'),
+    scope: {
+      selected: new can.Map(),
+      types: [{
+        type: 'Dropdown',
+        text: 'Type values separated by comma'
+      }, {
+        type: 'Checkbox',
+        text: 'Type label'
+      }, {
+        type: 'Radio',
+        text: 'Type values separated by comma'
+      }, {
+        type: 'Text',
+        text: 'Type description'
+      }],
+      addFiled: function (scope, el, ev) {
+        var fields = this.attr('fields');
+        var selected = this.attr('selected');
+
+        ev.preventDefault();
+
+        fields.push({
+          title: selected.title,
+          type: selected.type,
+          values: selected.values
+        });
+        _.each(['title', 'values'], function (type) {
+          selected.attr(type, '');
+        });
+      }
+    },
+    events: {
+      inserted: function () {
+        if (!this.scope.attr('selected.type')) {
+          this.scope.attr('selected', this.scope.attr('types')[0]);
+        }
+      }
+    },
+    helpers: {
+      placeholder: function (options) {
+        var types = this.attr('types');
+        var item = _.findWhere(types, {
+          type: this.attr('selected.type')
+        });
+        if (item) {
+          return item.text;
+        }
+      }
+    }
+  });
+})(window.can, window.can.$);

--- a/src/ggrc/assets/javascripts/components/assessment_attributes.js
+++ b/src/ggrc/assets/javascripts/components/assessment_attributes.js
@@ -6,6 +6,12 @@
 */
 
 (function (can, $) {
+  /*
+   * Assessment template main component
+   *
+   * It collects fields data and it transforms them into appropriate
+   * format for saving
+   */
   can.Component.extend({
     tag: 'assessment-template-attributes',
     template: '<content></content>',
@@ -13,10 +19,20 @@
       fields: new can.List()
     }
   });
+
+  /*
+   * Template field
+   *
+   * Represents each `field` passed from assessment-template-attributes `fields`
+   */
   can.Component.extend({
     tag: 'template-filed',
-    template: can.view(GGRC.mustache_path + '/assessment_templates/attribute_field.mustache'),
+    template: can.view(GGRC.mustache_path +
+      '/assessment_templates/attribute_field.mustache'),
     scope: {
+      /*
+       * Removes `field` from `fileds`
+       */
       removeField: function (scope, el, ev) {
         var fileds = scope.attr('fields');
         var field = scope.attr('field');
@@ -29,6 +45,11 @@
           fileds.splice(index, 1);
         }
       },
+      /*
+       * Split field values
+       *
+       * @return {Array} attrs - Returns split values as an array
+       */
       attrs: function () {
         return _.splitTrim(this.attr('field.values'), {
           compact: true
@@ -38,7 +59,8 @@
   });
   can.Component.extend({
     tag: 'add-template-filed',
-    template: can.view(GGRC.mustache_path + '/assessment_templates/attribute_add_field.mustache'),
+    template: can.view(GGRC.mustache_path +
+      '/assessment_templates/attribute_add_field.mustache'),
     scope: {
       selected: new can.Map(),
       types: [{
@@ -54,6 +76,16 @@
         type: 'Text',
         text: 'Type description'
       }],
+      /*
+       * Create new field
+       *
+       * Field must contain value title, type, values and opts.
+       * Opts are populated, once we start changing checkbox values
+       *
+       * @param {Object} scope - current (add-template-field) scope
+       * @param {jQuery.Object} el - clicked element
+       * @param {Object} ev - click event handler
+       */
       addField: function (scope, el, ev) {
         var fields = this.attr('fields');
         var selected = this.attr('selected');
@@ -80,6 +112,9 @@
       }
     },
     events: {
+      /*
+       * Set default dropdown type on init
+       */
       inserted: function () {
         var types = this.scope.attr('types');
 
@@ -89,6 +124,11 @@
       }
     },
     helpers: {
+      /*
+       * Get input placeholder value depended on type
+       *
+       * @param {Object} options - Mustache options
+       */
       placeholder: function (options) {
         var types = this.attr('types');
         var item = _.findWhere(types, {

--- a/src/ggrc/assets/javascripts/components/assessment_attributes.js
+++ b/src/ggrc/assets/javascripts/components/assessment_attributes.js
@@ -55,7 +55,7 @@
         type: 'Text',
         text: 'Type description'
       }],
-      addFiled: function (scope, el, ev) {
+      addField: function (scope, el, ev) {
         var fields = this.attr('fields');
         var selected = this.attr('selected');
         var title = _.trim(selected.title);

--- a/src/ggrc/assets/javascripts/components/assessment_attributes.js
+++ b/src/ggrc/assets/javascripts/components/assessment_attributes.js
@@ -28,12 +28,9 @@
         fileds.splice(index, 1);
       },
       attrs: function () {
-        return _.compact(_.map(this.attr('field.values').split(','), function (value) {
-          value = $.trim(value);
-          if (value) {
-            return value;
-          }
-        }));
+        return _.splitTrim(this.attr('field.values'), {
+          compact: true
+        });
       }
     }
   });
@@ -60,8 +57,9 @@
         var selected = this.attr('selected');
         var title = _.trim(selected.title);
         var type = _.trim(selected.type);
-        var values = _.uniq(_.map(
-          selected.values.split(','), _.trim)).join(',');
+        var values = _.splitTrim(selected.values, {
+          unique: true
+        }).join(',');
 
         ev.preventDefault();
         if (!type || !values || !title) {

--- a/src/ggrc/assets/javascripts/components/assessment_attributes.js
+++ b/src/ggrc/assets/javascripts/components/assessment_attributes.js
@@ -25,7 +25,9 @@
         });
 
         ev.preventDefault();
-        fileds.splice(index, 1);
+        if (index !== -1) {
+          fileds.splice(index, 1);
+        }
       },
       attrs: function () {
         return _.splitTrim(this.attr('field.values'), {

--- a/src/ggrc/assets/javascripts/components/assessment_attributes.js
+++ b/src/ggrc/assets/javascripts/components/assessment_attributes.js
@@ -18,7 +18,14 @@
     template: can.view(GGRC.mustache_path + '/assessment_templates/attribute_field.mustache'),
     scope: {
       removeField: function (scope, el, ev) {
+        var fileds = scope.attr('fields');
+        var field = scope.attr('field');
+        var index = _.findIndex(fileds, function (item) {
+          return item.type === field.type && item.title === field.title;
+        });
 
+        ev.preventDefault();
+        fileds.splice(index, 1);
       },
       attrs: function () {
         return _.compact(_.map(this.attr('field.values').split(','), function (value) {
@@ -51,13 +58,21 @@
       addFiled: function (scope, el, ev) {
         var fields = this.attr('fields');
         var selected = this.attr('selected');
+        var title = _.trim(selected.title);
+        var type = _.trim(selected.type);
+        var values = _.uniq(_.map(
+          selected.values.split(','), _.trim)).join(',');
 
         ev.preventDefault();
+        if (!type || !values || !title) {
+          return;
+        }
 
         fields.push({
-          title: selected.title,
-          type: selected.type,
-          values: selected.values
+          title: title,
+          type: type,
+          values: values,
+          opts: new can.Map()
         });
         _.each(['title', 'values'], function (type) {
           selected.attr(type, '');
@@ -66,8 +81,10 @@
     },
     events: {
       inserted: function () {
+        var types = this.scope.attr('types');
+
         if (!this.scope.attr('selected.type')) {
-          this.scope.attr('selected', this.scope.attr('types')[0]);
+          this.scope.attr('selected.type', _.first(types).attr('type'));
         }
       }
     },

--- a/src/ggrc/assets/javascripts/components/mapper.js
+++ b/src/ggrc/assets/javascripts/components/mapper.js
@@ -5,215 +5,276 @@
     Maintained By: ivan@reciprocitylabs.com
 */
 
-(function(can, $) {
-  "use strict";
-  var MapperModel = can.Map({
-      type: "AllObject", // We set default as All Object
-      contact: {},
-      deferred: "@",
-      deferred_to: "@",
-      term: "",
-      object: "",
-      model: {},
-      bindings: {},
-      is_loading: false,
-      page_loading: false,
-      is_saving: false,
-      all_selected: false,
-      search_only: false,
-      join_object_id: "",
-      selected: new can.List(),
-      entries: new can.List(),
-      options: new can.List(),
-      relevant: new can.List(),
-      get_instance: can.compute(function () {
-        return CMS.Models.get_instance(this.attr("object"), this.attr("join_object_id"));
-      }),
-      get_binding_name: function (instance, plural) {
-        return (instance.has_binding(plural) ? "" : "related_") + plural;
-      },
-      model_from_type: function (type) {
-        var types = _.reduce(_.values(this.types()), function (memo, val) {
-          if (val.items) {
-            return memo.concat(val.items);
-          }
-          return memo;
-        }, []);
-        return _.findWhere(types, {value: type});
-      },
-      get_forbidden: function (type) {
-        var forbidden = {
-          Program: ["Audit"],
-          Audit: ["Assessment", "Program", "Request"],
-          Assessment: ["Control"],
-          Request: ["Workflow", "TaskGroup", "Person"]
-        };
-        return forbidden[type] ? forbidden[type] : [];
-      },
-      get_whitelist: function () {
-        var whitelisted = ["TaskGroupTask", "TaskGroup", "CycleTaskGroupObjectTask"];
-        return this.attr("search_only") ? whitelisted : [];
-      },
-      types: can.compute(function () {
-        var selector_list,
-            canonical = GGRC.Mappings.get_canonical_mappings_for(this.object),
-            list = GGRC.tree_view.base_widgets_by_type[this.object],
-            forbidden = this.get_forbidden(this.object),
-            whitelist = this.get_whitelist(),
-            groups = {
-              "all_objects": {
-                name: "All Objects",
-                value: "AllObject",
-                plural: "allobjects",
-                table_plural: "allobjects",
-                singular: "AllObject",
-                models: []
-              },
-              "entities": {
-                name: "People/Groups",
-                items: []
-              },
-              "business": {
-                name: "Assets/Business",
-                items: []
-              },
-              "governance": {
-                name: "Governance",
-                items: []
-              }
-            };
+(function (can, $) {
+  'use strict';
 
-        selector_list = _.intersection.apply(_, _.compact([_.keys(canonical), list]));
-        selector_list = _.union(selector_list, whitelist);
-        can.each(selector_list, function (model_name) {
-          if (!model_name || !CMS.Models[model_name] || ~forbidden.indexOf(model_name)) {
-            return;
-          }
-          var cms_model = CMS.Models[model_name],
-              group = !groups[cms_model.category] ? "governance" : cms_model.category;
+  var MapperModel = GGRC.Models.MapperModel = can.Map({
+    type: 'AllObject', // We set default as All Object
+    contact: {},
+    deferred: '@',
+    deferred_to: '@',
+    term: '',
+    object: '',
+    model: {},
+    bindings: {},
+    is_loading: false,
+    page_loading: false,
+    is_saving: false,
+    all_selected: false,
+    search_only: false,
+    join_object_id: '',
+    selected: new can.List(),
+    entries: new can.List(),
+    options: new can.List(),
+    relevant: new can.List(),
+    get_instance: can.compute(function () {
+      return CMS.Models.get_instance(
+        this.attr('object'),
+        this.attr('join_object_id')
+      );
+    }),
 
-          groups[group]["items"].push({
-            name: cms_model.title_plural,
-            value: cms_model.shortName,
-            singular: cms_model.shortName,
-            plural: cms_model.title_plural.toLowerCase().replace(/\s+/, "_"),
-            table_plural: cms_model.table_plural,
-            title_singular: cms_model.title_singular,
-            isSelected: cms_model.shortName === this.type
-          });
-          groups["all_objects"]["models"].push(cms_model.shortName);
-        }, this);
-        if (groups["all_objects"]["models"].length < 2) {
-          delete groups["all_objects"];
+    get_binding_name: function (instance, plural) {
+      return (instance.has_binding(plural) ? '' : 'related_') + plural;
+    },
+
+    model_from_type: function (type) {
+      var types = _.reduce(_.values(this.types()), function (memo, val) {
+        if (val.items) {
+          return memo.concat(val.items);
         }
-        return groups;
-      })
-    });
+        return memo;
+      }, []);
+      return _.findWhere(types, {value: type});
+    },
+
+    get_forbidden: function (type) {
+      var forbidden = {
+        Program: ['Audit'],
+        Audit: ['Assessment', 'Program', 'Request'],
+        Assessment: ['Control'],
+        Request: ['Workflow', 'TaskGroup', 'Person']
+      };
+      return forbidden[type] ? forbidden[type] : [];
+    },
+
+    get_whitelist: function () {
+      var whitelisted = [
+        'TaskGroupTask', 'TaskGroup', 'CycleTaskGroupObjectTask'
+      ];
+      return this.attr('search_only') ? whitelisted : [];
+    },
+
+    types: can.compute(function () {
+      var selectorList;
+      var canonical = GGRC.Mappings.get_canonical_mappings_for(this.object);
+      var list = GGRC.tree_view.base_widgets_by_type[this.object];
+      var forbidden = this.get_forbidden(this.object);
+      var whitelist = this.get_whitelist();
+
+      var groups = {
+        all_objects: {
+          name: 'All Objects',
+          value: 'AllObject',
+          plural: 'allobjects',
+          table_plural: 'allobjects',
+          singular: 'AllObject',
+          models: []
+        },
+        entities: {
+          name: 'People/Groups',
+          items: []
+        },
+        business: {
+          name: 'Assets/Business',
+          items: []
+        },
+        governance: {
+          name: 'Governance',
+          items: []
+        }
+      };
+
+      selectorList = _.intersection.apply(
+        _, _.compact([_.keys(canonical), list]));
+
+      selectorList = _.union(selectorList, whitelist);
+
+      can.each(selectorList, function (modelName) {
+        var cmsModel;
+        var group;
+
+        if (!modelName ||
+            !CMS.Models[modelName] ||
+            ~forbidden.indexOf(modelName)) {
+          return;
+        }
+
+        cmsModel = CMS.Models[modelName];
+        group = !groups[cmsModel.category] ? 'governance' : cmsModel.category;
+
+        groups[group].items.push({
+          name: cmsModel.title_plural,
+          value: cmsModel.shortName,
+          singular: cmsModel.shortName,
+          plural: cmsModel.title_plural.toLowerCase().replace(/\s+/, '_'),
+          table_plural: cmsModel.table_plural,
+          title_singular: cmsModel.title_singular,
+          isSelected: cmsModel.shortName === this.type
+        });
+        groups.all_objects.models.push(cmsModel.shortName);
+      }, this);
+      if (groups.all_objects.models.length < 2) {
+        delete groups.all_objects;
+      }
+      return groups;
+    })
+  });
 
   can.Component.extend({
-    tag: "modal-mapper",
-    template: can.view(GGRC.mustache_path + "/modals/mapper/base.mustache"),
-    scope: function (attrs, parentScope, el) {
-      var $el = $(el),
-          data = {},
-          id = +$el.attr("join-object-id"),
-          object = $el.attr("object"),
-          type = $el.attr("type"),
-          tree_view = GGRC.tree_view.sub_tree_for[object];
+    tag: 'modal-mapper',
+    template: can.view(GGRC.mustache_path + '/modals/mapper/base.mustache'),
 
-      if ($el.attr("search-only")) {
-        data["search_only"] =  /true/i.test($el.attr("search-only"));
+    scope: function (attrs, parentScope, el) {
+      var $el = $(el);
+      var data = {};
+      var id = Number($el.attr('join-object-id'));
+      var object = $el.attr('object');
+      var type = $el.attr('type');
+      var treeView = GGRC.tree_view.sub_tree_for[object];
+
+      if ($el.attr('search-only')) {
+        data.search_only = /true/i.test($el.attr('search-only'));
       }
+
       if (object) {
-        data["object"] = object;
+        data.object = object;
       }
 
       type = CMS.Models[type] && type;
-      if (!data["search_only"]) {
+
+      if (!data.search_only) {
         if (type) {
-          data["type"] = type;
-        } else if (id === GGRC.page_instance().id || !tree_view) {
-          data["type"] = "AllObject";
+          data.type = type;
+        } else if (id === GGRC.page_instance().id || !treeView) {
+          data.type = 'AllObject';
         } else {
-          data["type"] = tree_view.display_list[0];
+          data.type = treeView.display_list[0];
         }
       }
+
       if (id || GGRC.page_instance()) {
-        data["join_object_id"] = id || GGRC.page_instance().id;
+        data.join_object_id = id || GGRC.page_instance().id;
       }
+
       return {
         mapper: new MapperModel(data)
       };
     },
+
     events: {
-      "inserted": function () {
+      inserted: function () {
         this.setModel();
         this.setBinding();
       },
-      "deferredSave": function () {
-        var source = this.scope.attr("deferred_to").instance || this.scope.attr("mapper.object"),
-            data = {
-              multi_map: true,
-              arr: _.compact(_.map(this.scope.attr("mapper.selected"), function (desination) {
-                    var isAllowed = GGRC.Utils.allowed_to_map(source, desination),
-                        inst = _.find(this.scope.attr("mapper.entries"), function (entry) {
-                          return entry.instance.id === desination.id && entry.instance.type === desination.type;
-                        });
-                    if (inst && isAllowed) {
-                      return inst.instance;
-                    }
-                  }.bind(this)))
-            };
-        this.scope.attr("deferred_to").controller.element.trigger("defer:add", [data, {map_and_save: true}]);
-        // TODO: Find proper way to dismiss the modal
-        this.element.find(".modal-dismiss").trigger("click");
-      },
-      ".add-button .btn modal:added": "addNew",
-      ".add-button .btn modal:success": "addNew",
-      "addNew": function (el, ev, model) {
-        var entries = this.scope.attr("mapper.entries"),
-            len = entries.length,
-            get_binding_name = this.scope.attr("mapper").get_binding_name,
-            binding, mapping, selected, item;
 
-        selected = this.scope.attr("mapper.get_instance");
-        binding = selected.get_binding(get_binding_name(selected, model.constructor.table_plural));
-        mapping = GGRC.Mappings.get_canonical_mapping_name(selected.type, model.type);
+      deferredSave: function () {
+        var source = this.scope.attr('deferred_to').instance ||
+                     this.scope.attr('mapper.object');
+
+        var data = {
+          multi_map: true,
+          arr: _.compact(_.map(
+            this.scope.attr('mapper.selected'),
+            function (desination) {
+              var isAllowed = GGRC.Utils.allowed_to_map(source, desination);
+              var inst = _.find(
+                this.scope.attr('mapper.entries'),
+                function (entry) {
+                  return (entry.instance.id === desination.id &&
+                          entry.instance.type === desination.type);
+                }
+              );
+
+              if (inst && isAllowed) {
+                return inst.instance;
+              }
+            }.bind(this)
+          ))
+        };
+
+        this.scope.attr('deferred_to').controller.element.trigger(
+          'defer:add', [data, {map_and_save: true}]);
+        // TODO: Find proper way to dismiss the modal
+        this.element.find('.modal-dismiss').trigger('click');
+      },
+
+      '.add-button .btn modal:added': 'addNew',
+
+      '.add-button .btn modal:success': 'addNew',
+
+      addNew: function (el, ev, model) {
+        var entries = this.scope.attr('mapper.entries');
+        var getBindingName = this.scope.attr('mapper').get_binding_name;
+        var binding;
+        var item;
+        var mapping;
+        var selected;
+
+        selected = this.scope.attr('mapper.get_instance');
+        binding = selected.get_binding(
+          getBindingName(selected, model.constructor.table_plural));
+        mapping = GGRC.Mappings.get_canonical_mapping_name(
+          selected.type, model.type);
         mapping = model.get_mapping(mapping);
 
         item = new GGRC.ListLoaders.MappingResult(model, mapping, binding);
         item.append = true;
         entries.unshift(item);
       },
-      ".modal-footer .btn-map click": function (el, ev) {
+
+      '.modal-footer .btn-map click': function (el, ev) {
+        var data = {};
+        var defer = [];
+        var instance;
+        var isAllObject;
+        var mapping;
+        var Model;
+        var object;
+        var que;
+        var type;
+
         ev.preventDefault();
-        if (el.hasClass("disabled")) {
-          return;
+
+        if (el.hasClass('disabled')) {
+          return undefined;
         }
         // TODO: Figure out nicer / proper way to handle deferred save
-        if (this.scope.attr("deferred")) {
+        if (this.scope.attr('deferred')) {
           return this.deferredSave();
         }
 
-        var type = this.scope.attr("mapper.type"),
-            object = this.scope.attr("mapper.object"),
-            isAllObject = type === "AllObject",
-            instance = CMS.Models[object].findInCacheById(this.scope.attr("mapper.join_object_id")),
-            mapping, Model, data = {}, defer = [],
-            que = new RefreshQueue();
+        type = this.scope.attr('mapper.type');
+        object = this.scope.attr('mapper.object');
+        isAllObject = type === 'AllObject';
+        instance = CMS.Models[object].findInCacheById(
+          this.scope.attr('mapper.join_object_id'));
+        que = new RefreshQueue();
 
-        this.scope.attr("mapper.is_saving", true);
+        this.scope.attr('mapper.is_saving', true);
+
         que.enqueue(instance).trigger().done(function (inst) {
-          data["context"] = instance.context || null;
-          _.each(this.scope.attr("mapper.selected"), function (destination) {
-            var modelInstance,
-                isMapped = GGRC.Utils.is_mapped(instance, destination),
-                isAllowed = GGRC.Utils.allowed_to_map(instance, destination);
+          data.context = instance.context || null;
+          _.each(this.scope.attr('mapper.selected'), function (destination) {
+            var modelInstance;
+            var isMapped = GGRC.Utils.is_mapped(instance, destination);
+            var isAllowed = GGRC.Utils.allowed_to_map(instance, destination);
 
             if (isMapped || !isAllowed) {
               return;
             }
-            mapping = GGRC.Mappings.get_canonical_mapping(object, isAllObject ? destination.type : type);
+            mapping = GGRC.Mappings.get_canonical_mapping(
+              object, isAllObject ? destination.type : type);
             Model = CMS.Models[mapping.model_name];
             data[mapping.object_attr] = {
               href: instance.href,
@@ -227,18 +288,20 @@
 
           $.when.apply($, defer)
             .fail(function (response, message) {
-              $("body").trigger("ajax:flash", {"error": message});
-            }.bind(this))
+              $('body').trigger('ajax:flash', {error: message});
+            })
             .always(function () {
-              this.scope.attr("mapper.is_saving", false);
+              this.scope.attr('mapper.is_saving', false);
               // TODO: Find proper way to dismiss the modal
-              this.element.find(".modal-dismiss").trigger("click");
+              this.element.find('.modal-dismiss').trigger('click');
 
-              // there is some kind of a race condition when filling the treview with new elements
-              // so many don't get rendered. To solve it, at the end of the loading
-              // we refresh the whole tree view. Other solutions could be to batch add the objects.
-              $(".cms_controllers_tree_view:visible").each(function () {
-                // TODO: This is terrible solution, but it's only way to refresh all tree views on page
+              // there is some kind of a race condition when filling the
+              // treview with new elements so many don't get rendered. To
+              // solve it, at the end of the loading we refresh the whole tree
+              // view. Other solutions could be to batch add the objects.
+              $('.cms_controllers_tree_view:visible').each(function () {
+                // TODO: This is terrible solution, but it's only way to
+                // refresh all tree views on page
                 var control = $(this).control();
                 if (control) {
                   control.reload_list();
@@ -247,76 +310,92 @@
             }.bind(this));
         }.bind(this));
       },
-      "setBinding": function () {
-        if (this.scope.attr("mapper.search_only")) {
-          return;
-        }
-        var get_binding_name = this.scope.attr("mapper").get_binding_name,
-            selected = this.scope.attr("mapper.get_instance"),
-            table_plural = get_binding_name(selected, this.scope.attr("mapper.model.table_plural")),
-            binding;
 
-        if (!selected.has_binding(table_plural)) {
+      setBinding: function () {
+        var binding;
+        var getBindingName = this.scope.attr('mapper').get_binding_name;
+        var selected = this.scope.attr('mapper.get_instance');
+        var tablePlural = getBindingName(
+          selected, this.scope.attr('mapper.model.table_plural'));
+
+        if (this.scope.attr('mapper.search_only')) {
           return;
         }
-        binding = selected.get_binding(table_plural);
+
+        if (!selected.has_binding(tablePlural)) {
+          return;
+        }
+
+        binding = selected.get_binding(tablePlural);
         binding.refresh_list().then(function (mappings) {
           can.each(mappings, function (mapping) {
-            this.scope.attr("mapper.bindings")[mapping.instance.id] = mapping;
+            this.scope.attr('mapper.bindings')[mapping.instance.id] = mapping;
           }, this);
         }.bind(this));
       },
-      "setModel": function () {
-        var type = this.scope.attr("mapper.type"),
-            types = this.scope.attr("mapper.types");
 
-        if (~["All Object", "AllObject"].indexOf(type)) {
-          return this.scope.attr("mapper.model", types["all_objects"]);
+      setModel: function () {
+        var type = this.scope.attr('mapper.type');
+        var types = this.scope.attr('mapper.types');
+
+        if (~['All Object', 'AllObject'].indexOf(type)) {
+          return this.scope.attr('mapper.model', types.all_objects);
         }
-        this.scope.attr("mapper.model", this.scope.mapper.model_from_type(type));
+        this.scope.attr(
+          'mapper.model', this.scope.mapper.model_from_type(type));
       },
-      "{mapper} type": function () {
-        this.scope.attr("mapper.term", "");
-        this.scope.attr("mapper.contact", {});
-        this.scope.attr("mapper.relevant", []);
+
+      '{mapper} type': function () {
+        this.scope.attr('mapper.term', '');
+        this.scope.attr('mapper.contact', {});
+        this.scope.attr('mapper.relevant', []);
 
         this.setModel();
         this.setBinding();
       },
-      "#search-by-owner autocomplete:select": function (el, ev, data) {
-        this.scope.attr("mapper.contact", data.item);
+
+      '#search-by-owner autocomplete:select': function (el, ev, data) {
+        this.scope.attr('mapper.contact', data.item);
       },
-      "#search-by-owner keyup": function (el, ev) {
+
+      '#search-by-owner keyup': function (el, ev) {
         if (!el.val()) {
-          this.scope.attr("mapper.contact", {});
+          this.scope.attr('mapper.contact', {});
         }
       },
-      "allSelected": function () {
-        var selected = this.scope.attr("mapper.selected"),
-            entries = this.scope.attr("mapper.entries");
+
+      allSelected: function () {
+        var selected = this.scope.attr('mapper.selected');
+        var entries = this.scope.attr('mapper.entries');
 
         if (!entries.length && !selected.length) {
           return;
         }
-        this.scope.attr("mapper.all_selected", selected.length === entries.length);
+        this.scope.attr(
+          'mapper.all_selected', selected.length === entries.length);
       },
-      "{mapper.entries} length": "allSelected",
-      "{mapper.selected} length": "allSelected"
+      '{mapper.entries} length': 'allSelected',
+      '{mapper.selected} length': 'allSelected'
     },
+
     helpers: {
-      "get_title": function (options) {
-        var instance = this.attr("mapper.get_instance");
-        return instance && instance.title ? instance.title : this.attr("mapper.object");
+      get_title: function (options) {
+        var instance = this.attr('mapper.get_instance');
+        return (
+          (instance && instance.title) ?
+          instance.title :
+          this.attr('mapper.object')
+        );
       },
-      "get_object": function (options) {
-        var type = CMS.Models[this.attr("mapper.type")];
+      get_object: function (options) {
+        var type = CMS.Models[this.attr('mapper.type')];
         if (type && type.title_plural) {
           return type.title_plural;
         }
-        return "Objects";
+        return 'Objects';
       },
-      "loading_or_saving": function (options) {
-        if (this.attr("mapper.page_loading") || this.attr("mapper.is_saving")) {
+      loading_or_saving: function (options) {
+        if (this.attr('mapper.page_loading') || this.attr('mapper.is_saving')) {
           return options.fn();
         }
         return options.inverse();
@@ -325,43 +404,55 @@
   });
 
   can.Component.extend({
-    tag: "mapper-checkbox",
-    template: "<content />",
+    tag: 'mapper-checkbox',
+    template: '<content />',
     scope: {
-      "instance_id": "@",
-      "instance_type": "@",
-      "is_mapped": "@",
-      "is_allowed_to_map": "@",
-      "checkbox": can.compute(function (status) {
-        return /true/gi.test(this.attr("is_mapped")) || this.attr("select_state") || this.attr("appended");
+      instance_id: '@',
+      instance_type: '@',
+      is_mapped: '@',
+      is_allowed_to_map: '@',
+      checkbox: can.compute(function (status) {
+        return (
+          /true/gi.test(this.attr('is_mapped')) ||
+          this.attr('select_state') ||
+          this.attr('appended')
+        );
       })
     },
+
     events: {
-      "{scope} selected": function () {
-        this.element.find(".object-check-single").prop("checked", _.findWhere(this.scope.attr("selected"), {
-          id: +this.scope.attr("instance_id")
-        }));
+      '{scope} selected': function () {
+        this.element
+          .find('.object-check-single')
+          .prop(
+            'checked',
+            _.findWhere(this.scope.attr('selected'), {
+              id: Number(this.scope.attr('instance_id'))
+            })
+          );
       },
-      ".object-check-single change": function (el, ev) {
-        if (el.prop("disabled") || el.hasClass("disabled")) {
+
+      '.object-check-single change': function (el, ev) {
+        var scope = this.scope;
+        var uid = Number(scope.attr('instance_id'));
+        var type = scope.attr('instance_type');
+        var item = _.find(scope.attr('options'), function (option) {
+          return option.instance.id === uid && option.instance.type === type;
+        });
+        var status = el.prop('checked');
+        var selected = this.scope.attr('selected');
+        var needle = {id: item.instance.id, type: item.instance.type};
+        var index;
+
+        if (el.prop('disabled') || el.hasClass('disabled')) {
           return false;
         }
-        var scope = this.scope,
-            uid = +scope.attr("instance_id"),
-            type = scope.attr("instance_type"),
-            item = _.find(scope.attr("options"), function (option) {
-              return option.instance.id === uid && option.instance.type === type;
-            }),
-            status = el.prop("checked"),
-            selected = this.scope.attr("selected"),
-            needle = {id: item.instance.id, type: item.instance.type},
-            index;
 
         if (!status) {
           index = _.findIndex(selected, needle);
           selected.splice(index, 1);
-        } else {
-          _.findWhere(selected, needle) || selected.push({
+        } else if (!_.findWhere(selected, needle)) {
+          selected.push({
             id: item.instance.id,
             type: item.instance.type,
             href: item.instance.href
@@ -369,87 +460,120 @@
         }
       }
     },
+
     helpers: {
-      "not_allowed_to_map": function (options) {
-        if (/false/gi.test(this.attr("is_allowed_to_map"))) {
+      not_allowed_to_map: function (options) {
+        if (/false/gi.test(this.attr('is_allowed_to_map'))) {
           return options.fn();
         }
         return options.inverse();
       },
-      "is_disabled": function (options) {
-        if (/true/gi.test(this.attr("is_mapped"))
-            || this.attr("is_saving")
-            || this.attr("is_loading")
-            || /false/gi.test(this.attr("is_allowed_to_map"))) {
+
+      is_disabled: function (options) {
+        if (
+          /true/gi.test(this.attr('is_mapped')) ||
+          this.attr('is_saving') ||
+          this.attr('is_loading') ||
+          /false/gi.test(this.attr('is_allowed_to_map'))
+        ) {
           return options.fn();
         }
+
         return options.inverse();
       }
     }
   });
 
   can.Component.extend({
-    tag: "mapper-results",
-    template: "<content />",
+    tag: 'mapper-results',
+    template: '<content />',
     scope: {
-      "items-per-page": "@",
+      'items-per-page': '@',
       page: 0,
       page_loading: false,
       select_state: false,
       loading_or_saving: can.compute(function () {
-        return this.attr("page_loading") || this.attr("mapper.is_saving");
+        return this.attr('page_loading') || this.attr('mapper.is_saving');
       })
     },
     events: {
-      "inserted":  function () {
-        this.element.find(".results-wrap").cms_controllers_infinite_scroll();
+      inserted: function () {
+        this.element.find('.results-wrap').cms_controllers_infinite_scroll();
         this.getResults();
       },
-      ".modalSearchButton click": "getResults",
-      "{scope} type": "getResults",
-      "{scope.entries} add": function (list, ev, added) {
+
+      '.modalSearchButton click': 'getResults',
+
+      '{scope} type': 'getResults',
+
+      '{scope.entries} add': function (list, ev, added) {
+        var instance;
+        var option;
+
         // TODO: I'm assuming we are adding only one item manually
         if (!added[0].append) {
           return;
         }
-        var instance = added[0].instance,
-            option = this.getItem(instance);
+
+        instance = added[0].instance;
+        option = this.getItem(instance);
+
         option.appended = true;
-        this.scope.attr("options").unshift(option);
-        this.scope.attr("selected").push({
+        this.scope.attr('options').unshift(option);
+        this.scope.attr('selected').push({
           id: instance.id,
           type: instance.type,
           href: instance.href
         });
       },
-      ".results-wrap scrollNext": "drawPage",
-      ".object-check-all click": function (el, ev) {
-        ev.preventDefault();
-        if (el.hasClass("disabled")) {
-          return;
-        }
-        var que = new RefreshQueue(),
-            entries = this.scope.attr("entries");
 
-        this.scope.attr("select_state", true);
-        this.scope.attr("mapper.all_selected", true);
-        this.scope.attr("is_loading", true);
-        que.enqueue(_.pluck(entries, "instance")).trigger().then(function (models) {
-          this.scope.attr("is_loading", false);
-          this.scope.attr("selected", _.map(models, function (model) {
-            return {
-              id: model.id,
-              type: model.type,
-              href: model.href
-            };
-          }));
-        }.bind(this));
-      },
-      "getItem": function (model) {
-        if (!model.type) {
+      '.results-wrap scrollNext': 'drawPage',
+
+      '.object-check-all click': function (el, ev) {
+        var entries;
+        var que;
+
+        ev.preventDefault();
+
+        if (el.hasClass('disabled')) {
           return;
         }
-        if (this.scope.attr("mapper.search_only")) {
+
+        que = new RefreshQueue();
+        entries = this.scope.attr('entries');
+
+        this.scope.attr('select_state', true);
+        this.scope.attr('mapper.all_selected', true);
+        this.scope.attr('is_loading', true);
+
+        que.enqueue(_.pluck(entries, 'instance'))
+          .trigger()
+          .then(function (models) {
+            this.scope.attr('is_loading', false);
+            this.scope.attr(
+              'selected',
+              _.map(models, function (model) {
+                return {
+                  id: model.id,
+                  type: model.type,
+                  href: model.href
+                };
+              })
+            );
+          }.bind(this));
+      },
+
+      getItem: function (model) {
+        var selected;
+        var mapper;
+        var binding;
+        var bindings;
+
+        if (!model.type) {
+          return undefined;
+        }
+
+        if (this.scope.attr('mapper.search_only')) {
           return {
             instance: model,
             selected_object: false,
@@ -457,18 +581,21 @@
             mappings: []
           };
         }
-        var selected = this.scope.attr("mapper.get_instance"),
-            mapper = this.scope.mapper.model_from_type(model.type),
-            binding, bindings = this.scope.attr("mapper.bindings");
+
+        selected = this.scope.attr('mapper.get_instance');
+        mapper = this.scope.mapper.model_from_type(model.type);
+        bindings = this.scope.attr('mapper.bindings');
 
         if (bindings[model.id]) {
           return _.extend(bindings[model.id], {
             selected_object: selected
           });
         }
+
         if (selected.has_binding(mapper.plural.toLowerCase())) {
           binding = selected.get_binding(mapper.plural.toLowerCase());
         }
+
         return {
           instance: model,
           selected_object: selected,
@@ -476,139 +603,178 @@
           mappings: []
         };
       },
-      "drawPage": function () {
-        if (this.scope.attr("mapper.page_loading")) {
-          return;
+
+      drawPage: function () {
+        var page = this.scope.attr('page');
+        var nextPage = page + 1;
+        var perPage = Number(this.scope.attr('items-per-page'));
+        var pageItems = this.scope.attr('entries').slice(
+          page * perPage,
+          nextPage * perPage
+        );
+        var options = this.scope.attr('options');
+        var que = new RefreshQueue();
+
+        if (this.scope.attr('mapper.page_loading') || !pageItems.length) {
+          return undefined;
         }
-        var page = this.scope.attr("page"),
-            next_page = page + 1,
-            per_page = +this.scope.attr("items-per-page"),
-            page_items = this.scope.attr("entries").slice(page * per_page, next_page * per_page),
-            options = this.scope.attr("options"),
-            que = new RefreshQueue();
 
-        if (!page_items.length) {
-          return;
-        }
-        this.scope.attr("mapper.page_loading", true);
+        this.scope.attr('mapper.page_loading', true);
 
-        return que.enqueue(_.pluck(page_items, "instance")).trigger().then(function (models) {
-          this.scope.attr("mapper.page_loading", false);
-          this.scope.attr("page", next_page);
-
-          options.push.apply(options, can.map(models, this.getItem.bind(this)));
-        }.bind(this));
+        return que.enqueue(
+            _.pluck(pageItems, 'instance')
+          ).trigger().then(
+            function (models) {
+              this.scope.attr('mapper.page_loading', false);
+              this.scope.attr('page', nextPage);
+              options.push.apply(
+                options,
+                can.map(models, this.getItem.bind(this))
+              );
+            }.bind(this)
+          );
       },
-      "searchFor": function (data) {
-        data.options = data.options || {};
-        var join_model = GGRC.Mappings.join_model_name_for(this.scope.attr("mapper.object"), data.model_name);
 
-        if (join_model !== "TaskGroupObject" && data.model_name === "Program") {
+      searchFor: function (data) {
+        var joinModel;
+
+        data.options = data.options || {};
+
+        joinModel = GGRC.Mappings.join_model_name_for(
+          this.scope.attr('mapper.object'), data.model_name);
+
+        if (joinModel !== 'TaskGroupObject' && data.model_name === 'Program') {
           data.options.permission_parms = {
-            __permission_model: join_model
+            __permission_model: joinModel
           };
         }
-        if (!_.includes(["ObjectPerson", "WorkflowPerson"], join_model) &&
-            !this.options.scope.attr("mapper.search_only")) {
-          data.options.__permission_type = data.options.__permission_type || "update";
-        }
-        data.model_name = _.isString(data.model_name) ? [data.model_name] : data.model_name;
 
-        return GGRC.Models.Search.search_for_types(data.term || "", data.model_name, data.options);
+        if (!_.includes(['ObjectPerson', 'WorkflowPerson'], joinModel) &&
+            !this.options.scope.attr('mapper.search_only')) {
+          data.options.__permission_type =
+            data.options.__permission_type || 'update';
+        }
+
+        data.model_name = _.isString(data.model_name) ?
+          [data.model_name] :
+          data.model_name;
+
+        return GGRC.Models.Search.search_for_types(
+          data.term || '', data.model_name, data.options);
       },
-      "getResults": function () {
-        if (this.scope.attr("mapper.page_loading") || this.scope.attr("mapper.is_saving")) {
+
+      getResults: function () {
+        var contact = this.scope.attr('contact');
+        var filters;
+        var list;
+        var modelName = this.scope.attr('type');
+        var permissionParams = {};
+        var search = [];
+
+        if (this.scope.attr('mapper.page_loading') ||
+            this.scope.attr('mapper.is_saving')) {
           return;
         }
-        var model_name = this.scope.attr("type"),
-            contact = this.scope.attr("contact"),
-            permission_parms = {},
-            search = [],
-            filters,
-            list;
 
-        this.scope.attr("page", 0);
-        this.scope.attr("entries", []);
-        this.scope.attr("selected", []);
-        this.scope.attr("options", []);
-        this.scope.attr("select_state", false);
-        this.scope.attr("mapper.all_selected", false);
+        this.scope.attr('page', 0);
+        this.scope.attr('entries', []);
+        this.scope.attr('selected', []);
+        this.scope.attr('options', []);
+        this.scope.attr('select_state', false);
+        this.scope.attr('mapper.all_selected', false);
 
-        filters = _.compact(_.map(this.scope.attr("mapper.relevant"), function (relevant) {
-          if (!relevant.value) {
-            return;
+        filters = _.compact(_.map(
+          this.scope.attr('mapper.relevant'),
+          function (relevant) {
+            var Loader;
+            var mappings;
+
+            if (!relevant.value) {
+              return undefined;
+            }
+
+            if (modelName === 'AllObject') {
+              Loader = GGRC.ListLoaders.MultiListLoader;
+              mappings = _.compact(_.map(
+                GGRC.Mappings.get_mappings_for(
+                  relevant.filter.constructor.shortName),
+                function (mapping) {
+                  if (mapping instanceof GGRC.ListLoaders.DirectListLoader ||
+                      mapping instanceof GGRC.ListLoaders.ProxyListLoader) {
+                    return mapping;
+                  }
+                }
+              ));
+            } else {
+              Loader = GGRC.ListLoaders.TypeFilteredListLoader;
+              mappings = GGRC.Mappings.get_canonical_mapping_name(
+                relevant.model_name, modelName);
+              mappings = mappings.replace('_as_source', '');
+            }
+            return new Loader(mappings, [modelName]).attach(relevant.filter);
           }
-          var mappings, Loader;
-          if (model_name === "AllObject") {
-            Loader = GGRC.ListLoaders.MultiListLoader;
-            mappings = _.compact(_.map(GGRC.Mappings.get_mappings_for(relevant.filter.constructor.shortName), function (mapping) {
-              if (mapping instanceof GGRC.ListLoaders.DirectListLoader
-                  || mapping instanceof GGRC.ListLoaders.ProxyListLoader) {
-                return mapping;
-              }
-            }));
-          } else {
-            Loader = GGRC.ListLoaders.TypeFilteredListLoader;
-            mappings = GGRC.Mappings.get_canonical_mapping_name(relevant.model_name, model_name);
-            mappings = mappings.replace("_as_source", "");
-          }
-          return new Loader(mappings, [model_name]).attach(relevant.filter);
-        }));
-        if (model_name === "AllObject") {
-          model_name = this.scope.attr("types.all_objects.models");
+        ));
+
+        if (modelName === 'AllObject') {
+          modelName = this.scope.attr('types.all_objects.models');
         }
+
         if (!_.isEmpty(contact)) {
-          permission_parms.contact_id = contact.id;
+          permissionParams.contact_id = contact.id;
         }
 
-        this.scope.attr("mapper.page_loading", true);
+        this.scope.attr('mapper.page_loading', true);
+
         search = new GGRC.ListLoaders.SearchListLoader(function (binding) {
-            return this.searchFor({
-              term: this.scope.attr("term"),
-              model_name: model_name,
-              options: permission_parms
-            }).then(function (mappings) {
-              return mappings.entries;
-            });
-          }.bind(this)).attach({});
+          return this.searchFor({
+            term: this.scope.attr('term'),
+            model_name: modelName,
+            options: permissionParams
+          }).then(function (mappings) {
+            return mappings.entries;
+          });
+        }.bind(this)).attach({});
 
         search = filters.concat(search);
         list = (search.length > 1) ?
-                  new GGRC.ListLoaders.IntersectingListLoader(search).attach()
-                : search[0];
+                new GGRC.ListLoaders.IntersectingListLoader(search).attach() :
+                search[0];
 
         list.refresh_stubs().then(function (options) {
-          this.scope.attr("mapper.page_loading", false);
-          this.scope.attr("entries", options);
+          this.scope.attr('mapper.page_loading', false);
+          this.scope.attr('entries', options);
           this.drawPage();
         }.bind(this));
       }
     }
   });
 
+  $('body').on(
+    'click',
+    '[data-toggle="unified-mapper"], [data-toggle="unified-search"]',
+    function (ev) {
+      var btn;
+      var data = {};
+      var isSearch;
 
-  $("body").on("click",
-  '[data-toggle="unified-mapper"], \
-   [data-toggle="unified-search"]',
-  function (ev) {
-    ev.preventDefault();
-    var btn = $(ev.currentTarget),
-        data = {},
-        isSearch;
+      ev.preventDefault();
 
-    _.each(btn.data(), function (val, key) {
-      data[can.camelCaseToUnderscore(key)] = val;
-    });
+      btn = $(ev.currentTarget);
 
-    if (data.tooltip) {
-      data.tooltip.hide();
+      _.each(btn.data(), function (val, key) {
+        data[can.camelCaseToUnderscore(key)] = val;
+      });
+
+      if (data.tooltip) {
+        data.tooltip.hide();
+      }
+      isSearch = /unified-search/ig.test(data.toggle);
+      GGRC.Controllers.MapperModal.launch($(this), _.extend({
+        object: btn.data('join-object-type'),
+        type: btn.data('join-option-type'),
+        'join-object-id': btn.data('join-object-id'),
+        'search-only': isSearch
+      }, data));
     }
-    isSearch = /unified-search/ig.test(data.toggle);
-    GGRC.Controllers.MapperModal.launch($(this), _.extend({
-      "object": btn.data("join-object-type"),
-      "type": btn.data("join-option-type"),
-      "join-object-id": btn.data("join-object-id"),
-      "search-only": isSearch
-    }, data));
-  });
+  );
 })(window.can, window.can.$);

--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -1087,8 +1087,33 @@
      */
     init: function () {
       this._super.apply(this, arguments);
-      this.validateNonBlank('title');
+      // TODO: perform any validation here?
     }
   },
-  {});
+  {
+    // TODO: docstring, tests
+    // isNewObject: boolean (true if creating new object)
+    form_preload: function (isNewObject) {
+      console.log('formPreload in Ass. Template');
+      // TODO: needed? to init/pre-fetch some data or what?
+    },
+
+    // TODO: docstring, tests
+    // TODO: why this isn't called? To perform validation, data packing etc.
+    before_save: function () {
+      console.log('AssessmentTemplate before_save');
+      debugger;
+    },
+
+    before_create: function () {
+      console.log('AssessmentTemplate before_create');
+      debugger;
+    },
+
+    // save: function () {
+    //   console.log('AssessmentTemplate saved');
+    //   // return this._super.apply(this, arguments);
+    //   return 'DDDD';
+    // }
+  });
 })(this.can);

--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -1074,7 +1074,6 @@
     destroy: 'DELETE /api/assessment_templates/{id}',
     create: 'POST /api/assessment_templates',
 
-    mixins: ['unique_title'],  // TODO: does not even have a title? remove?
     is_custom_attributable: false,
 
     attributes: {

--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -1050,4 +1050,45 @@
         'related_objects_as_destination', this.audit.program);
     }
   });
+
+  /**
+   * A model describing a template for the newly created Assessment objects.
+   *
+   * This is useful when creating multiple similar Assessment objects. Using an
+   * AssessmentTemplate helps avoiding repeatedly defining the same set of
+   * Assessment object properties for each new instance.
+   */
+  can.Model.Cacheable('CMS.Models.AssessmentTemplate', {
+    root_object: 'assessment_template',
+    root_collection: 'assessment_templates',
+    model_singular: 'AssessmentTemplate',
+    model_plural: 'AssessmentTemplates',
+    title_singular: 'AssessmentTemplate',
+    title_plural: 'AssessmentTemplates',
+    table_singular: 'assessment_template',
+    table_plural: 'assessment_templates',
+
+    findOne: 'GET /api/assessment_templates/{id}',
+    findAll: 'GET /api/assessment_templates',
+    update: 'PUT /api/assessment_templates/{id}',
+    destroy: 'DELETE /api/assessment_templates/{id}',
+    create: 'POST /api/assessment_templates',
+
+    mixins: ['unique_title'],
+    is_custom_attributable: false,
+
+    attributes: {
+      audit: 'CMS.Models.Audit.stub'
+    },
+
+    /**
+     * Initialize the newly created object instance. Essentially just validate
+     * that its title is non-blank.
+     */
+    init: function () {
+      this._super.apply(this, arguments);
+      this.validateNonBlank('title');
+    }
+  },
+  {});
 })(this.can);

--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -1074,7 +1074,7 @@
     destroy: 'DELETE /api/assessment_templates/{id}',
     create: 'POST /api/assessment_templates',
 
-    mixins: ['unique_title'],
+    mixins: ['unique_title'],  // TODO: does not even have a title? remove?
     is_custom_attributable: false,
 
     attributes: {

--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -1077,7 +1077,8 @@
     is_custom_attributable: false,
 
     attributes: {
-      audit: 'CMS.Models.Audit.stub'
+      audit: 'CMS.Models.Audit.stub',
+      context: 'CMS.Models.Context.stub'
     },
 
     /**

--- a/src/ggrc/assets/javascripts/models/mappings.js
+++ b/src/ggrc/assets/javascripts/models/mappings.js
@@ -705,6 +705,9 @@
       }),
       people: AttrFilter("related_objects", "AssigneeType", null, "Person"),
     },
+    AssessmentTemplate: {
+      _mixins: ['related_object']
+    },
     Issue: {
       _mixins: [
         "related_object", "personable", "ownable"

--- a/src/ggrc/assets/javascripts/models/mappings.js
+++ b/src/ggrc/assets/javascripts/models/mappings.js
@@ -312,10 +312,11 @@
     related_object: {
       _canonical: {
         "related_objects_as_source": [
-          "DataAsset", "Facility", "Market", "OrgGroup", "Vendor", "Process", "Product",
-          "Project", "System", "Regulation", "Policy", "Contract", "Standard",
-          "Program", "Issue", "Control", "Section", "Clause", "Objective",
-          "Audit", "Assessment", "AccessGroup", "Request", "Document"
+          "DataAsset", "Facility", "Market", "OrgGroup", "Vendor", "Process",
+          "Product", "Project", "System", "Regulation", "Policy", "Contract",
+          "Standard", "Program", "Issue", "Control", "Section", "Clause",
+          "Objective", "Audit", "Assessment", "AssessmentTemplate",
+          "AccessGroup", "Request", "Document"
         ]
       },
       related_objects_as_source: Proxy(
@@ -682,6 +683,8 @@
         null, "source", "Relationship", "destination", "related_sources"),
       related_objects: Multi(["related_objects_as_source", "related_objects_as_destination"]),
       related_assessments: TypeFilter("related_objects", "Assessment"),
+      related_assessment_templates: TypeFilter(
+        'related_objects', 'AssessmentTemplate'),
       related_issues: TypeFilter('related_objects', 'Issue'),
       regulations: TypeFilter('related_objects', 'Regulation'),
       policies: TypeFilter('related_objects', 'Policy'),

--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -3307,6 +3307,36 @@ Mustache.registerHelper("add_to_current_scope", function (options) {
   return options.fn(options.contexts.add(_.extend({}, options.context, options.hash)));
 });
 
+  /**
+   * Return a value of a CMS.Model constructor's property.
+   *
+   * If a Model is not found, an error is raised. If a property does not exist
+   * on the model, undefined is returned.
+   *
+   * @param {String} modelName - the name of the Model to inspect
+   * @param {String} attr - the name of a modelName's property
+   *
+   * @return {*} - the value of the modelName[attr]
+   */
+  Mustache.registerHelper('model_info', function (modelName, attr, options) {
+    var model;
+
+    if (arguments.length !== 3) {
+      throw new Error(
+        'Invalid number of arguments (' +
+        (arguments.length - 1) +  // do not count the auto-provided options arg
+        '), expected 2.');
+    }
+
+    model = CMS.Models[modelName];
+
+    if (typeof model === 'undefined') {
+      throw new Error('Model not found (' + modelName + ').');
+    }
+
+    return model[attr];
+  });
+
 /*
 Add spaces to a CamelCase string.
 

--- a/src/ggrc/assets/javascripts/pbc/workflow_controller.js
+++ b/src/ggrc/assets/javascripts/pbc/workflow_controller.js
@@ -23,6 +23,19 @@
         instance.delay_resolving_save_until($.when(auditDfd, objectDfd));
       }.bind(this));
     },
+    '{CMS.Models.AssessmentTemplate} created': function (model, ev, instance) {
+      var auditDfd;
+
+      if (!(instance instanceof CMS.Models.AssessmentTemplate)) {
+        return;
+      }
+
+      this._after_pending_joins(instance, function () {
+        auditDfd = this._create_relationship(instance,
+            instance.audit, instance.audit.context);
+        instance.delay_resolving_save_until(auditDfd);
+      }.bind(this));
+    },
     '{CMS.Models.Issue} created': function (model, ev, instance) {
       var auditDfd;
       var controlDfd;

--- a/src/ggrc/assets/javascripts/plugins/lodash_helpers.js
+++ b/src/ggrc/assets/javascripts/plugins/lodash_helpers.js
@@ -45,6 +45,8 @@
 
       values = values.split(splitter);
       values = _.map(values, _.trim);
+
+      options = options || {};
       if (options.unique) {
         values = _.uniq(values);
       }

--- a/src/ggrc/assets/javascripts/plugins/lodash_helpers.js
+++ b/src/ggrc/assets/javascripts/plugins/lodash_helpers.js
@@ -4,16 +4,53 @@
     Created By: ivan@reciprocitylabs.com
     Maintained By: ivan@reciprocitylabs.com
 */
-(function(_) {
+
+(function (_) {
   _.mixin({
     exists: function (obj, key) {
+      var keys;
+      var slice = Array.prototype.slice;
+
       if (!key) {
         return obj;
       }
-      var keys = arguments.length > 2 ? Array.prototype.slice.call(arguments).slice(1) : key.split(".");
+      if (arguments.length > 2) {
+        keys = slice.call(arguments).slice(1);
+      } else {
+        keys = key.split('.');
+      }
       return keys.reduce(function (base, memo) {
         return (_.isUndefined(base) || _.isNull(base)) ? base : base[memo];
       }, obj);
+    },
+    /*
+     * Splits string into array and trims it's values
+     *
+     * @param {String} values - Input string that should be manipulated
+     * @param {String} splitter - String that is used to split `values`
+     *                            - Default splitter is comma - `,`
+     * @param {Object} options - Additional options
+     *                           - Unique - returns only unique values
+     *                           - Compact - removes `falsy` values
+     * @return {Array} - Returns array of splited values
+     */
+    splitTrim: function (values, splitter, options) {
+      if (_.isUndefined(splitter)) {
+        splitter = ',';
+      }
+      if (_.isObject(splitter)) {
+        options = splitter;
+        splitter = ',';
+      }
+      values = values.split(splitter);
+      values = _.map(values, _.trim);
+      if (options.unique) {
+        values = _.uniq(values);
+      }
+      if (options.compact) {
+        values = _.compact(values);
+      }
+      return values;
     }
   });
 })(_);

--- a/src/ggrc/assets/javascripts/plugins/lodash_helpers.js
+++ b/src/ggrc/assets/javascripts/plugins/lodash_helpers.js
@@ -24,7 +24,7 @@
       }, obj);
     },
     /*
-     * Splits string into array and trims it's values
+     * Splits string into array and trims its values
      *
      * @param {String} values - Input string that should be manipulated
      * @param {String} splitter - String that is used to split `values`
@@ -42,6 +42,7 @@
         options = splitter;
         splitter = ',';
       }
+
       values = values.split(splitter);
       values = _.map(values, _.trim);
       if (options.unique) {

--- a/src/ggrc/assets/javascripts/plugins/lodash_helpers.js
+++ b/src/ggrc/assets/javascripts/plugins/lodash_helpers.js
@@ -35,6 +35,9 @@
      * @return {Array} - Returns array of splited values
      */
     splitTrim: function (values, splitter, options) {
+      if (!values || !values.length) {
+        return [];
+      }
       if (_.isUndefined(splitter)) {
         splitter = ',';
       }

--- a/src/ggrc/assets/javascripts/plugins/tests/lodash_helpers_spec.js
+++ b/src/ggrc/assets/javascripts/plugins/tests/lodash_helpers_spec.js
@@ -5,7 +5,7 @@
   Maintained By: ivan@reciprocitylabs.com
 */
 
-describe('_.splitTrim method', function () {
+describe('_.splitTrim() method', function () {
   'use strict';
 
   describe('Given an string with dots and dot splitter', function () {
@@ -14,21 +14,21 @@ describe('_.splitTrim method', function () {
 
     it('return split without spaces', function () {
       var result = _.splitTrim(input, splitter);
-      expect(result).toBe(['a', 'b', 'c', 'd', 'a', '', 'b']);
+      expect(result).toEqual(['a', 'b', 'c', 'd', 'a', 'b', '', 'b']);
     });
 
     it('return unique values without spaces', function () {
       var result = _.splitTrim(input, splitter, {
         unique: true
       });
-      expect(result).toBe(['a', 'b', 'c', 'd', '']);
+      expect(result).toEqual(['a', 'b', 'c', 'd', '']);
     });
 
     it('return compact values without spaces', function () {
       var result = _.splitTrim(input, splitter, {
         compact: true
       });
-      expect(result).toBe(['a', 'b', 'c', 'd', 'a', 'b', 'b']);
+      expect(result).toEqual(['a', 'b', 'c', 'd', 'a', 'b', 'b']);
     });
 
     it('return compact and uniquee values without spaces', function () {
@@ -36,29 +36,30 @@ describe('_.splitTrim method', function () {
         unique: true,
         compact: true
       });
-      expect(result).toBe(['a', 'b', 'c', 'd']);
+      expect(result).toEqual(['a', 'b', 'c', 'd']);
     });
   });
+
   describe('Given an string with commas given default splitter', function () {
     var input = 'a,b,c , d ,c,a  b, , , f';
 
     it('return values without spaces', function () {
       var result = _.splitTrim(input);
-      expect(result).toBe(['a', 'b', 'c', 'd', 'c', 'ab', '', '', 'f']);
+      expect(result).toEqual(['a', 'b', 'c', 'd', 'c', 'a  b', '', '', 'f']);
     });
 
     it('return unique split values without spaces', function () {
       var result = _.splitTrim(input, {
         unique: true
       });
-      expect(result).toBe(['a', 'b', 'c', 'd', 'ab', '', '', 'f']);
+      expect(result).toEqual(['a', 'b', 'c', 'd', 'a  b', '', 'f']);
     });
 
     it('return compact split values without spaces', function () {
       var result = _.splitTrim(input, {
         compact: true
       });
-      expect(result).toBe(['a', 'b', 'c', 'd', 'c', 'ab', 'f']);
+      expect(result).toEqual(['a', 'b', 'c', 'd', 'c', 'a  b', 'f']);
     });
 
     it('return unique and compact split values without spaces', function () {
@@ -66,7 +67,7 @@ describe('_.splitTrim method', function () {
         compact: true,
         unique: true
       });
-      expect(result).toBe(['a', 'b', 'c', 'd', 'ab', 'f']);
+      expect(result).toEqual(['a', 'b', 'c', 'd', 'a  b', 'f']);
     });
   });
 });

--- a/src/ggrc/assets/javascripts/plugins/tests/lodash_helpers_spec.js
+++ b/src/ggrc/assets/javascripts/plugins/tests/lodash_helpers_spec.js
@@ -70,4 +70,11 @@ describe('_.splitTrim() method', function () {
       expect(result).toEqual(['a', 'b', 'c', 'd', 'a  b', 'f']);
     });
   });
+
+  describe('Given no value', function () {
+    it('returns empty array', function () {
+      var result = _.splitTrim(undefined);
+      expect(result).toEqual([]);
+    });
+  });
 });

--- a/src/ggrc/assets/javascripts/plugins/tests/lodash_helpers_spec.js
+++ b/src/ggrc/assets/javascripts/plugins/tests/lodash_helpers_spec.js
@@ -1,0 +1,72 @@
+/*!
+  Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+  Created By: ivan@reciprocitylabs.com
+  Maintained By: ivan@reciprocitylabs.com
+*/
+
+describe('_.splitTrim method', function () {
+  'use strict';
+
+  describe('Given an string with dots and dot splitter', function () {
+    var input = 'a. b. c. d. a. b . . b';
+    var splitter = '.';
+
+    it('return split without spaces', function () {
+      var result = _.splitTrim(input, splitter);
+      expect(result).toBe(['a', 'b', 'c', 'd', 'a', '', 'b']);
+    });
+
+    it('return unique values without spaces', function () {
+      var result = _.splitTrim(input, splitter, {
+        unique: true
+      });
+      expect(result).toBe(['a', 'b', 'c', 'd', '']);
+    });
+
+    it('return compact values without spaces', function () {
+      var result = _.splitTrim(input, splitter, {
+        compact: true
+      });
+      expect(result).toBe(['a', 'b', 'c', 'd', 'a', 'b', 'b']);
+    });
+
+    it('return compact and uniquee values without spaces', function () {
+      var result = _.splitTrim(input, splitter, {
+        unique: true,
+        compact: true
+      });
+      expect(result).toBe(['a', 'b', 'c', 'd']);
+    });
+  });
+  describe('Given an string with commas given default splitter', function () {
+    var input = 'a,b,c , d ,c,a  b, , , f';
+
+    it('return values without spaces', function () {
+      var result = _.splitTrim(input);
+      expect(result).toBe(['a', 'b', 'c', 'd', 'c', 'ab', '', '', 'f']);
+    });
+
+    it('return unique split values without spaces', function () {
+      var result = _.splitTrim(input, {
+        unique: true
+      });
+      expect(result).toBe(['a', 'b', 'c', 'd', 'ab', '', '', 'f']);
+    });
+
+    it('return compact split values without spaces', function () {
+      var result = _.splitTrim(input, {
+        compact: true
+      });
+      expect(result).toBe(['a', 'b', 'c', 'd', 'c', 'ab', 'f']);
+    });
+
+    it('return unique split values without spaces', function () {
+      var result = _.splitTrim(input, {
+        compact: true,
+        unique: true
+      });
+      expect(result).toBe(['a', 'b', 'c', 'd', 'ab', 'f']);
+    });
+  });
+});

--- a/src/ggrc/assets/javascripts/plugins/tests/lodash_helpers_spec.js
+++ b/src/ggrc/assets/javascripts/plugins/tests/lodash_helpers_spec.js
@@ -61,7 +61,7 @@ describe('_.splitTrim method', function () {
       expect(result).toBe(['a', 'b', 'c', 'd', 'c', 'ab', 'f']);
     });
 
-    it('return unique split values without spaces', function () {
+    it('return unique and compact split values without spaces', function () {
       var result = _.splitTrim(input, {
         compact: true,
         unique: true

--- a/src/ggrc/assets/js_specs/models/assessment_template_spec.js
+++ b/src/ggrc/assets/js_specs/models/assessment_template_spec.js
@@ -1,0 +1,151 @@
+/*!
+  Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+  Created By: peter@reciprocitylabs.com
+  Maintained By: peter@reciprocitylabs.com
+*/
+
+describe('can.Model.AssessmentTemplate', function () {
+  'use strict';
+
+  var AssessmentTemplate;
+  var instance;  // an AssessmentTemplate instance
+
+  beforeAll(function () {
+    AssessmentTemplate = CMS.Models.AssessmentTemplate;
+  });
+
+  beforeEach(function () {
+    instance = new AssessmentTemplate();
+  });
+
+  describe('_choosableObjectTypes() method', function () {
+    var fakeMapper;  // an instance of the fake MapperModel
+    var origMapperModel;
+
+    beforeEach(function () {
+      var FakeMapperModel;
+
+      origMapperModel = GGRC.Models.MapperModel;
+
+      // mock the MapperModel used by the method under test
+      fakeMapper = {
+        types: jasmine.createSpy()
+      };
+      FakeMapperModel = jasmine.createSpy().and.callFake(function (config) {
+        return fakeMapper;
+      });
+
+      GGRC.Models.MapperModel = FakeMapperModel;
+    });
+
+    afterEach(function () {
+      // restore the mocked MapperModel
+      GGRC.Models.MapperModel = origMapperModel;
+    });
+
+    it('returns the types obtained from the mapper model', function () {
+      var result;
+
+      var objectTypes = {
+        groupFoo: {
+          name: 'Foo Objects',
+          items: [{name: 'Foo1'}, {value: 'Foo2'}]
+        },
+        groupBar: {
+          name: 'Bar Objects',
+          items: [{value: 'Bar1'}, {value: 'Bar2'}]
+        }
+      };
+
+      fakeMapper.types.and.returnValue(objectTypes);
+      result = instance._choosableObjectTypes();
+      expect(result).toEqual(objectTypes);
+    });
+
+    it('sorts types within a group by name', function () {
+      var result;
+
+      var objectTypes = {
+        groupFoo: {
+          name: 'Bar-ish Objects',
+          items: [
+            {name: 'Car'}, {name: 'Bar'}, {name: 'Zar'}, {name: 'Dar'}
+          ]
+        }
+      };
+
+      var expected = [
+        {name: 'Bar'}, {name: 'Car'}, {name: 'Dar'}, {name: 'Zar'}
+      ];
+
+      fakeMapper.types.and.returnValue(objectTypes);
+      result = instance._choosableObjectTypes();
+      expect(result.groupFoo.items).toEqual(expected);
+    });
+
+    it('omits the all_objects group from result', function () {
+      var result;
+
+      var objectTypes = {
+        all_objects: {
+          models: ['Foo', 'Bar', 'Baz'],
+          name: 'FooBarBaz-type Objects'
+        }
+      };
+
+      fakeMapper.types.and.returnValue(objectTypes);
+      result = instance._choosableObjectTypes();
+      expect(result.all_objects).toBeUndefined();
+    });
+
+    it('omits the types not relevant to the AssessmentTemplate from result',
+      function () {
+        var result;
+
+        var objectTypes = {
+          groupFoo: {
+            name: 'Foo Objects',
+            items: [
+              {value: 'Contract'},  // this object type is relevant
+              {value: 'Assessment'},
+              {value: 'Audit'},
+              {value: 'CycleTaskGroupObjectTask'},
+              {value: 'Request'}
+            ]
+          },
+          groupBar: {
+            name: 'Bar Objects',
+            items: [
+              {value: 'Policy'},  // this object type is relevant
+              {value: 'TaskGroup'},
+              {value: 'TaskGroupTask'}
+            ]
+          },
+          groupBaz: {
+            name: 'Baz Objects',
+            items: [
+              {value: 'Workflow'}
+            ]
+          }
+        };
+
+        var expected = {
+          groupFoo: {
+            name: 'Foo Objects',
+            items: [{value: 'Contract'}]
+          },
+          groupBar: {
+            name: 'Bar Objects',
+            items: [{value: 'Policy'}]
+          }
+          // the groupBaz group, being empty, is expected to have been removed
+        };
+
+        fakeMapper.types.and.returnValue(objectTypes);
+        result = instance._choosableObjectTypes();
+        expect(result).toEqual(expected);
+      }
+    );
+  });
+});

--- a/src/ggrc/assets/js_specs/models/assessment_template_spec.js
+++ b/src/ggrc/assets/js_specs/models/assessment_template_spec.js
@@ -148,4 +148,53 @@ describe('can.Model.AssessmentTemplate', function () {
       }
     );
   });
+
+  describe('_packPeopleData() method', function () {
+    it('packs default people data into a JSON string', function () {
+      var result;
+      instance.attr('default_assessors', 'Rabbits');
+      instance.attr('default_verifiers', 'Turtles');
+
+      result = instance._packPeopleData();
+
+      expect(typeof result).toEqual('string');
+      result = JSON.parse(result);
+      expect(result).toEqual({
+        assessors: 'Rabbits',
+        verifiers: 'Turtles'
+      });
+    });
+
+    it('uses the user-provided list if assessors set to "other"', function () {
+      var result;
+      instance.attr('default_assessors', 'other');
+      instance.attr('assessors_list', '  John,, Jack Mac,John,  Jill,  , ');
+      instance.attr('default_verifiers', 'Whatever');
+
+      result = instance._packPeopleData();
+
+      expect(typeof result).toEqual('string');
+      result = JSON.parse(result);
+      expect(result).toEqual({
+        assessors: ['John', 'Jack Mac', 'Jill'],
+        verifiers: 'Whatever'
+      });
+    });
+
+    it('uses the user-provided list if verifiers set to "other"', function () {
+      var result;
+      instance.attr('default_assessors', 'Whatever');
+      instance.attr('default_verifiers', 'other');
+      instance.attr('verifiers_list', '  First, ,, Sec ond   ,First, Third ');
+
+      result = instance._packPeopleData();
+
+      expect(typeof result).toEqual('string');
+      result = JSON.parse(result);
+      expect(result).toEqual({
+        assessors: 'Whatever',
+        verifiers: ['First', 'Sec ond', 'Third']
+      });
+    });
+  });
 });

--- a/src/ggrc/assets/js_specs/mustache_helpers/model_info_spec.js
+++ b/src/ggrc/assets/js_specs/mustache_helpers/model_info_spec.js
@@ -1,0 +1,58 @@
+/*!
+  Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+  Created By: peter@reciprocitylabs.com
+  Maintained By: peter@reciprocitylabs.com
+*/
+
+describe('can.mustache.helper.model_info', function () {
+  'use strict';
+
+  var helper;
+  var fakeModel;
+  var fakeOptions;  // a fake "options" argument
+  var origModel;  // the original model, if any, in the CMS.Models
+
+  beforeAll(function () {
+    helper = can.Mustache._helpers.model_info.fn;
+  });
+
+  beforeEach(function () {
+    origModel = CMS.Models.ModelFoo;
+    fakeModel = {};
+    CMS.Models.ModelFoo = fakeModel;
+
+    fakeOptions = {};
+  });
+
+  afterEach(function () {
+    CMS.Models.ModelFoo = origModel;
+  });
+
+  it('returns the value of the correct model attribute', function () {
+    var result;
+    fakeModel.someAttribute = 'foo bar baz';
+    result = helper('ModelFoo', 'someAttribute', fakeOptions);
+    expect(result).toEqual('foo bar baz');
+  });
+
+  it('raises an error on missing arguments', function () {
+    expect(function () {
+      helper('ModelFoo', fakeOptions);
+    }).toThrow(new Error('Invalid number of arguments (1), expected 2.'));
+  });
+
+  it('raises an error on too many arguments', function () {
+    expect(function () {
+      helper('ModelFoo', 'property1', 'property2', fakeOptions);
+    }).toThrow(new Error('Invalid number of arguments (3), expected 2.'));
+  });
+
+  it('raises an error on an unknown model', function () {
+    delete CMS.Models.ModelFoo;
+
+    expect(function () {
+      helper('ModelFoo', 'property', fakeOptions);
+    }).toThrow(new Error('Model not found (ModelFoo).'));
+  });
+});

--- a/src/ggrc/assets/mustache/assessment_templates/attribute_add_field.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/attribute_add_field.mustache
@@ -5,30 +5,29 @@
   Maintained By: ivan@reciprocitylabs.com
 }}
 
-<tr>
-  <td>
-    <input can-value="selected.title" type="text" placeholder="Enter title">
-  </td>
-  <td>
-    <select can-value="selected.type">
+<li class="row-fluid add-field">
+  <div class="span-custom2-and-half">
+    <input class="input-block-level" can-value="selected.title" type="text" placeholder="Enter title">
+  </div>
+  <div class="span-custom1-and-half">
+    <select class="input-block-level" can-value="selected.type">
       {{#types}}
         <option>{{type}}</option>
       {{/types}}
     </select>
-  </td>
-  <td>
-    <p>{{placeholder}}</p>
-    <input can-value="selected.values" type="text" placeholder="{{placeholder}}">
-  </td>
-  <td class="centered checkbox-wrap">
-  </td>
-  <td class="centered checkbox-wrap">
-  </td>
-  <td class="centered checkbox-wrap">
-  </td>
-  <td>
+  </div>
+  <div class="span2">
+    <input class="input-block-level" can-value="selected.values" type="text" placeholder="{{placeholder}}">
+  </div>
+  <div class="span2 centered checkbox-wrap">
+  </div>
+  <div class="span-custom1-and-half centered checkbox-wrap">
+  </div>
+  <div class="span-custom1-and-half centered checkbox-wrap">
+  </div>
+  <div class="span-custom1-and-half">
     <div class="pull-right">
       <a can-click="addFiled" class="btn btn-small btn-info" href="#">Add field</a>
     </div>
-  </td>
-</tr>
+  </div>
+</li>

--- a/src/ggrc/assets/mustache/assessment_templates/attribute_add_field.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/attribute_add_field.mustache
@@ -1,0 +1,38 @@
+{{!
+  Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+  Created By: ivan@reciprocitylabs.com
+  Maintained By: ivan@reciprocitylabs.com
+}}
+
+<table class="table">
+  <tbody>
+    <tr>
+      <td>
+        <input can-value="selected.title" type="text" placeholder="Enter title">
+      </td>
+      <td>
+        <select can-value="selected.type">
+          {{#types}}
+            <option>{{type}}</option>
+          {{/types}}
+        </select>
+      </td>
+      <td>
+        <p>{{placeholder}}</p>
+        <input can-value="selected.values" type="text" placeholder="{{placeholder}}">
+      </td>
+      <td class="centered checkbox-wrap">
+      </td>
+      <td class="centered checkbox-wrap">
+      </td>
+      <td class="centered checkbox-wrap">
+      </td>
+      <td>
+        <div class="pull-right">
+          <a can-click="addFiled" class="btn btn-small btn-info" href="#">Add field</a>
+        </div>
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/src/ggrc/assets/mustache/assessment_templates/attribute_add_field.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/attribute_add_field.mustache
@@ -27,7 +27,7 @@
   </div>
   <div class="span-custom1-and-half">
     <div class="pull-right">
-      <a can-click="addFiled" class="btn btn-small btn-info" href="#">Add field</a>
+      <a can-click="addField" class="btn btn-small btn-info" href="#">Add field</a>
     </div>
   </div>
 </li>

--- a/src/ggrc/assets/mustache/assessment_templates/attribute_add_field.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/attribute_add_field.mustache
@@ -5,34 +5,30 @@
   Maintained By: ivan@reciprocitylabs.com
 }}
 
-<table class="table">
-  <tbody>
-    <tr>
-      <td>
-        <input can-value="selected.title" type="text" placeholder="Enter title">
-      </td>
-      <td>
-        <select can-value="selected.type">
-          {{#types}}
-            <option>{{type}}</option>
-          {{/types}}
-        </select>
-      </td>
-      <td>
-        <p>{{placeholder}}</p>
-        <input can-value="selected.values" type="text" placeholder="{{placeholder}}">
-      </td>
-      <td class="centered checkbox-wrap">
-      </td>
-      <td class="centered checkbox-wrap">
-      </td>
-      <td class="centered checkbox-wrap">
-      </td>
-      <td>
-        <div class="pull-right">
-          <a can-click="addFiled" class="btn btn-small btn-info" href="#">Add field</a>
-        </div>
-      </td>
-    </tr>
-  </tbody>
-</table>
+<tr>
+  <td>
+    <input can-value="selected.title" type="text" placeholder="Enter title">
+  </td>
+  <td>
+    <select can-value="selected.type">
+      {{#types}}
+        <option>{{type}}</option>
+      {{/types}}
+    </select>
+  </td>
+  <td>
+    <p>{{placeholder}}</p>
+    <input can-value="selected.values" type="text" placeholder="{{placeholder}}">
+  </td>
+  <td class="centered checkbox-wrap">
+  </td>
+  <td class="centered checkbox-wrap">
+  </td>
+  <td class="centered checkbox-wrap">
+  </td>
+  <td>
+    <div class="pull-right">
+      <a can-click="addFiled" class="btn btn-small btn-info" href="#">Add field</a>
+    </div>
+  </td>
+</tr>

--- a/src/ggrc/assets/mustache/assessment_templates/attribute_field.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/attribute_field.mustache
@@ -28,8 +28,8 @@
   </td>
   <td>
     <div class="pull-right">
-      <a href="#"><i class="grcicon-edit"></i></a>
-      <a can-click="removeField" href="#"><i class="grcicon-deleted"></i></a>
+      <a href="#"><i class="fa fa-pencil-square-o"></i></a>
+      <a can-click="removeField" href="#"><i class="fa fa-trash"></i></a>
     </div>
   </td>
 </tr>

--- a/src/ggrc/assets/mustache/assessment_templates/attribute_field.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/attribute_field.mustache
@@ -5,31 +5,31 @@
   Maintained By: ivan@reciprocitylabs.com
 }}
 
-<tr>
-  <td>{{field.title}}</td>
-  <td>{{field.type}}</td>
-  <td>
+<li class="row-fluid">
+  <div class="span-custom2-and-half">{{field.title}}</div>
+  <div class="span-custom1-and-half">{{field.type}}</div>
+  <div class="span2">
     {{#attrs}}
       <span class="block">{{.}}</span>
     {{/attrs}}
-  </td>
-  <td class="centered checkbox-wrap">
+  </div>
+  <div class="span2 centered checkbox-wrap">
     {{#attrs}}
       <input can-value="field.opts.attachment-{{.}}" type="checkbox">
     {{/attrs}}
-  </td>
-  <td class="centered checkbox-wrap">
+  </div>
+  <div class="span-custom1-and-half centered checkbox-wrap">
     {{#attrs}}
       <input can-value="field.opts.comment-{{.}}" type="checkbox">
     {{/attrs}}
-  </td>
-  <td class="centered checkbox-wrap">
+  </div>
+  <div class="span-custom1-and-half centered checkbox-wrap">
     <input type="checkbox" can-value="field.opts.mandatory-{{title}}">
-  </td>
-  <td>
+  </div>
+  <div class="span-custom1-and-half">
     <div class="pull-right">
       <a href="#"><i class="fa fa-pencil-square-o"></i></a>
       <a can-click="removeField" href="#"><i class="fa fa-trash"></i></a>
     </div>
-  </td>
-</tr>
+  </div>
+</li>

--- a/src/ggrc/assets/mustache/assessment_templates/attribute_field.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/attribute_field.mustache
@@ -28,7 +28,7 @@
   </div>
   <div class="span-custom1-and-half">
     <div class="pull-right">
-      <a href="#"><i class="fa fa-pencil-square-o"></i></a>
+      {{! <a href="#"><i class="fa fa-pencil-square-o"></i></a> }}
       <a can-click="removeField" href="#"><i class="fa fa-trash"></i></a>
     </div>
   </div>

--- a/src/ggrc/assets/mustache/assessment_templates/attribute_field.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/attribute_field.mustache
@@ -1,0 +1,35 @@
+{{!
+  Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+  Created By: ivan@reciprocitylabs.com
+  Maintained By: ivan@reciprocitylabs.com
+}}
+
+<tr>
+  <td>{{field.title}}</td>
+  <td>{{field.type}}</td>
+  <td>
+    {{#attrs}}
+      <span class="block">{{.}}</span>
+    {{/attrs}}
+  </td>
+  <td class="centered checkbox-wrap">
+    {{#attrs}}
+      <input can-value="field.opts.attachment-{{.}}" type="checkbox">
+    {{/attrs}}
+  </td>
+  <td class="centered checkbox-wrap">
+    {{#attrs}}
+      <input can-value="field.opts.comment-{{.}}" type="checkbox">
+    {{/attrs}}
+  </td>
+  <td class="centered checkbox-wrap">
+    <input type="checkbox" can-value="field.opts.mandatory-{{title}}">
+  </td>
+  <td>
+    <div class="pull-right">
+      <a href="#"><i class="grcicon-edit"></i></a>
+      <a can-click="removeField" href="#"><i class="grcicon-deleted"></i></a>
+    </div>
+  </td>
+</tr>

--- a/src/ggrc/assets/mustache/assessment_templates/info.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/info.mustache
@@ -1,0 +1,8 @@
+{{!
+  Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+  Created By: peter@reciprocitylabs.com
+  Maintained By: peter@reciprocitylabs.com
+}}
+
+AssessmentTemplate's info.mustache

--- a/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
@@ -151,28 +151,44 @@
   {{! <div class="hidden-fields-area" style="display:none;"> }}
   <div class="hidden-fields-area">
     <div class="row-fluid wrap-row">
-      <div class="custom-attr-table span12">
+      <div class="custom-attr-list span12">
         <assessment-template-attributes>
-          <table class="table">
-            <thead>
-              <tr>
-                <th><h6>Attribute Title</h6></th>
-                <th><h6>Attribute type</h6></th>
-                <th><h6>Attribute values</h6></th>
-                <th class="centered"><h6>Attachment required</h6></th>
-                <th class="centered"><h6>Comment required</h6></th>
-                <th class="centered"><h6>Mandatory</h6></th>
-                <th>&nbsp;</th>
-              </tr>
-            </thead>
-            <tbody>
+          <div class="attr-titles">
+            <ul>
+              <li class="row-fluid">
+                <div class="span-custom2-and-half">
+                  <h6>Attribute Title</h6>
+                </div>
+                <div class="span-custom1-and-half">
+                  <h6>Attribute type</h6>
+                </div>
+                <div class="span2">
+                  <h6>Attribute values</h6>
+                </div>
+                <div class="span2 centered">
+                  <h6>Attachment required</h6>
+                </div>
+                <div class="span-custom1-and-half centered">
+                  <h6>Comment required</h6>
+                </div>
+                <div class="span-custom1-and-half centered">
+                  <h6>Mandatory</h6>
+                </div>
+                <div class="span-custom1-and-half">
+                  &nbsp;
+                </div>
+              </li>
+            </ul>
+          </div>
+          <div class="new-attr-list">
+            <ul>
               <add-template-filed fields="fields">
               </add-template-filed>
               {{#fields}}
-              <template-filed field="." fields="fields"></template-filed>
+                <template-filed field="." fields="fields"></template-filed>
               {{/fields}}
-            </tbody>
-          </table>
+            </ul>
+          </div>
         </assessment-template-attributes>
       </div>
     </div>

--- a/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
@@ -24,7 +24,7 @@
     <select
       class="input-medium pull-left"
       can-value="objectTypes.type"
-      name="assessed-obj-type">
+      name="template_object_type">
       {{#each objectTypes}}
         {{#if items}}
           {{#if items.length}}
@@ -42,7 +42,9 @@
     {{/add_to_current_scope}}
 
     <label class="inline-check pull-left">
-      <input type="checkbox" class="js-toggle-controlplans">
+      <input type="checkbox"
+        name="test_plan_procedure"
+        class="js-toggle-controlplans">
       Use control test plans as procedures
     </label>
   </div>
@@ -52,11 +54,17 @@
   <div class="span6">
     <label>
       Default procedure
-      <i class="grcicon-help-black" rel="tooltip" title="Provide more details on the purpose of this Assessment and provide context for how and when this CA might be used."></i>
-      <a data-id="hide_description_lk" href="javascript://" class="field-hide">hide</a>
+      <i class="grcicon-help-black" rel="tooltip"
+        title="Provide more details on the purpose of this Assessment and
+               provide context for how and when this CA might be used."></i>
+      <a data-id="hide_description_lk" href="javascript://"
+        class="field-hide">hide</a>
     </label>
     <div class="wysiwyg-area">
-      <textarea tabindex="2" id="system_description" class="span12 triple wysihtml5" name="description" placeholder="Enter Description"></textarea>
+      <textarea tabindex="2" id="system_description"
+        class="span12 triple wysihtml5"
+        name="procedure_description"
+        placeholder="Enter Description"></textarea>
     </div>
   </div>
 
@@ -68,16 +76,25 @@
           <span class="required">*</span>
         </label>
 
-        <select class="input-block-level js-toggle-field" data-target=".choose-assessor" data-value="other">
-          <option>Object Owners</option>
-          <option>Audit Lead</option>
+        <select
+          name="default_assessors"
+          class="input-block-level js-toggle-field"
+          can-value="">
+          <option value="Object Owners">Object Owners</option>
+          <option value="Audit Lead">Audit Lead</option>
+          <option value="Object Contact">Object Contact</option>
+          <option value="Primary Assessor">Primary Assessor</option>
+          <option value="Secondary Assessors">Secondary Assessors</option>
           <option value="other">Others...</option>
         </select>
       </div>
 
       <div class="span6">
         <label>&nbsp;</label>
-        <input type="text" class="input-block-level choose-input choose-assessor" placeholder="Add person 1, Add person 2..." disabled>
+        <input type="text"
+          name="assessors_list"
+          class="input-block-level choose-input choose-assessor"
+          placeholder="Add person 1, Add person 2...">
       </div>
     </div>
 
@@ -88,17 +105,25 @@
           <span class="required">*</span>
         </label>
 
-        <select class="input-block-level js-toggle-field" data-target=".choose-verifier" data-value="other">
-          <option>Object contact</option>
-          <option>Primary assessor</option>
-          <option>Secondary assessors</option>
+        <select
+          name="default_verifiers"
+          class="input-block-level js-toggle-field"
+          can-value="">
+          <option value="Object Owners">Object Owners</option>
+          <option value="Audit Lead">Audit Lead</option>
+          <option value="Object Contact">Object Contact</option>
+          <option value="Primary Assessor">Primary Assessor</option>
+          <option value="Secondary Assessors">Secondary Assessors</option>
           <option value="other">Others...</option>
         </select>
       </div>
 
       <div class="span6">
         <label>&nbsp;</label>
-        <input type="text" class="input-block-level choose-input choose-verifier" placeholder="Add person 1, Add person 2..." disabled>
+        <input type="text"
+          name="verifiers_list"
+          class="input-block-level choose-input choose-verifier"
+          placeholder="Add person 1, Add person 2...">
       </div>
     </div>
   </div>

--- a/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
@@ -20,19 +20,29 @@
       Objects under assessment
     </label>
 
-    <select class="input-medium pull-left" id="underAssessment">
-      <optgroup label="FOO">
-        <option value="foo_1" label="foo_1"></option>
-        <option value="foo_2" label="foo_2"></option>
-      </optgroup>
-      <optgroup label="BAR">
-        <option value="bar_1" label="bar_1"></option>
-        <option value="bar_2" label="bar_2"></option>
-      </optgroup>
+    {{#add_to_current_scope objectTypes=instance._objectTypes}}
+    <select
+      class="input-medium pull-left"
+      can-value="objectTypes.type"
+      name="assessed-obj-type">
+      {{#each objectTypes}}
+        {{#if items}}
+          {{#if items.length}}
+          <optgroup label="{{name}}">
+            {{#each items}}
+              {{#if name}}
+                <option value="{{value}}" label="{{name}}"></option>
+              {{/if}}
+            {{/each}}
+          </optgroup>
+          {{/if}}
+        {{/if}}
+      {{/each}}
     </select>
+    {{/add_to_current_scope}}
 
-    <label class="inline-check pull-left disabled">
-      <input type="checkbox" class="js-toggle-controlplans" disabled>
+    <label class="inline-check pull-left">
+      <input type="checkbox" class="js-toggle-controlplans">
       Use control test plans as procedures
     </label>
   </div>

--- a/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
@@ -130,98 +130,28 @@
 </div>
 
 <div class="custom-attr-wrap">
-  <div class="row-fluid">
-    <div class="span12">
-      <div class="info-expand-mapped">
-        <a class="show-hidden-fields info-show-hide" href="javascript://">
-          <span class="out">
-            <i class="grcicon-arrow-right"></i>
-            Custom attributes
-          </span>
-          <span class="in">
-            <i class="grcicon-arrow-bottom"></i>
-            Custom attributes
-          </span>
-        </a>
-      </div>
-    </div>
-  </div><!-- row-fluid end -->
+  <assessment-template-attributes>
+    <add-template-filed fields="fields">
+    </add-template-filed>
+    <table class="table">
+      <thead>
+        <tr>
+          <th><h6>Attribute Title</h6></th>
+          <th><h6>Attribute type</h6></th>
+          <th><h6>Attribute values</h6></th>
+          <th class="centered"><h6>Attachment required</h6></th>
+          <th class="centered"><h6>Comment required</h6></th>
+          <th class="centered"><h6>Mandatory</h6></th>
+          <th>&nbsp;</th>
+        </tr>
+      </thead>
+      <tbody>
+        {{#fields}}
+        <template-filed field="." fields="fields"></template-filed>
+        {{/fields}}
+      </tbody>
+  </tbody>
+</table>
 
-  <div class="hidden-fields-area" style="display:none;">
-    <div class="row-fluid wrap-row">
-      <div class="custom-attr-table span12">
-        <table class="table">
-          <thead>
-            <tr>
-              <th><h6>Attribute Title</h6></th>
-              <th><h6>Attribute type</h6></th>
-              <th><h6>Attribute values</h6></th>
-              <th class="centered"><h6>Attachment required</h6></th>
-              <th class="centered"><h6>Comment required</h6></th>
-              <th class="centered"><h6>Mandatory</h6></th>
-              <th>&nbsp;</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>Assessment results</td>
-              <td>Radio</td>
-              <td>Yes, No, At Risk, Unclear, In Remediation</td>
-              <td class="centered checkbox-wrap"><input type="checkbox" checked></td>
-              <td class="centered checkbox-wrap"><input type="checkbox" checked></td>
-              <td class="centered checkbox-wrap"><input type="checkbox" checked></td>
-              <td>
-                <div class="pull-right">
-                  <a href="#"><i class="grcicon-edit"></i></a>
-                  <a href="#"><i class="grcicon-deleted"></i></a>
-                </div>
-              </td>
-            </tr>
-            <tr>
-              <td>Bug number</td>
-              <td>Text</td>
-              <td></td>
-              <td class="centered checkbox-wrap"><input type="checkbox"></td>
-              <td class="centered checkbox-wrap"><input type="checkbox"></td>
-              <td class="centered checkbox-wrap"><input type="checkbox"></td>
-              <td>
-                <div class="pull-right">
-                  <a href="#"><i class="grcicon-edit"></i></a>
-                  <a href="#"><i class="grcicon-deleted"></i></a>
-                </div>
-              </td>
-            </tr>
-            <tr>
-              <td><input type="text"></td>
-              <td>
-                <select>
-                  <option>Dropdown</option>
-                  <option>Checkbox</option>
-                  <option>Radio</option>
-                  <option>Text</option>
-                </select>
-              </td>
-              <td>
-                <input type="text" placeholder="Type values separated by comma">
-              </td>
-              <td class="centered checkbox-wrap">
-                <input type="checkbox">
-              </td>
-              <td class="centered checkbox-wrap">
-                <input type="checkbox">
-              </td>
-              <td class="centered checkbox-wrap">
-                <input type="checkbox">
-              </td>
-              <td>
-                <div class="pull-right">
-                  <a class="btn btn-small btn-info" href="#">Add field</a>
-                </div>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </div>
-  </div>
+  </assessment-template-attributes>
 </div><!-- custom-attr-wrap end -->

--- a/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
@@ -1,0 +1,8 @@
+{{!
+  Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+  Created By: peter@reciprocitylabs.com
+  Maintained By: peter@reciprocitylabs.com
+}}
+
+AssessmentTemplate's modal_content.mustache

--- a/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
@@ -8,7 +8,7 @@
 <div class="row-fluid">
   <div class="span6">
     <label>Audit</label>
-    <strong>{{parentInstance.title}}</strong>
+    <strong>{{object_params.audit_title}}</strong>
   </div>
 </div>
 

--- a/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
@@ -131,8 +131,6 @@
 
 <div class="custom-attr-wrap">
   <assessment-template-attributes>
-    <add-template-filed fields="fields">
-    </add-template-filed>
     <table class="table">
       <thead>
         <tr>
@@ -146,6 +144,8 @@
         </tr>
       </thead>
       <tbody>
+        <add-template-filed fields="fields">
+        </add-template-filed>
         {{#fields}}
         <template-filed field="." fields="fields"></template-filed>
         {{/fields}}

--- a/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
@@ -129,29 +129,52 @@
   </div>
 </div>
 
-<div class="custom-attr-wrap">
-  <assessment-template-attributes>
-    <table class="table">
-      <thead>
-        <tr>
-          <th><h6>Attribute Title</h6></th>
-          <th><h6>Attribute type</h6></th>
-          <th><h6>Attribute values</h6></th>
-          <th class="centered"><h6>Attachment required</h6></th>
-          <th class="centered"><h6>Comment required</h6></th>
-          <th class="centered"><h6>Mandatory</h6></th>
-          <th>&nbsp;</th>
-        </tr>
-      </thead>
-      <tbody>
-        <add-template-filed fields="fields">
-        </add-template-filed>
-        {{#fields}}
-        <template-filed field="." fields="fields"></template-filed>
-        {{/fields}}
-      </tbody>
-  </tbody>
-</table>
+<div class="custom-attr-wrap define-attr">
 
-  </assessment-template-attributes>
+  <div class="row-fluid">
+    <div class="span12">
+      <div class="info-expand">
+        <a class="show-hidden-fields info-show-hide" href="javascript://">
+          <span class="out">
+            <i class="fa fa-caret-right"></i>
+            Custom attributes
+          </span>
+          <span class="in">
+            <i class="fa fa-caret-down"></i>
+            Custom attributes
+          </span>
+        </a>
+      </div>
+    </div>
+  </div>
+
+  {{! <div class="hidden-fields-area" style="display:none;"> }}
+  <div class="hidden-fields-area">
+    <div class="row-fluid wrap-row">
+      <div class="custom-attr-table span12">
+        <assessment-template-attributes>
+          <table class="table">
+            <thead>
+              <tr>
+                <th><h6>Attribute Title</h6></th>
+                <th><h6>Attribute type</h6></th>
+                <th><h6>Attribute values</h6></th>
+                <th class="centered"><h6>Attachment required</h6></th>
+                <th class="centered"><h6>Comment required</h6></th>
+                <th class="centered"><h6>Mandatory</h6></th>
+                <th>&nbsp;</th>
+              </tr>
+            </thead>
+            <tbody>
+              <add-template-filed fields="fields">
+              </add-template-filed>
+              {{#fields}}
+              <template-filed field="." fields="fields"></template-filed>
+              {{/fields}}
+            </tbody>
+          </table>
+        </assessment-template-attributes>
+      </div>
+    </div>
+  </div>
 </div><!-- custom-attr-wrap end -->

--- a/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
@@ -7,10 +7,8 @@
 
 <div class="row-fluid">
   <div class="span6">
-    <label>
-      Audit
-    </label>
-    <strong>TODO: audit ID</strong>
+    <label>Audit</label>
+    <strong>{{parentInstance.title}}</strong>
   </div>
 </div>
 

--- a/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
@@ -5,4 +5,190 @@
   Maintained By: peter@reciprocitylabs.com
 }}
 
-AssessmentTemplate's modal_content.mustache
+<div class="row-fluid">
+  <div class="span6">
+    <label>
+      Audit
+    </label>
+    <strong>TODO: audit ID</strong>
+  </div>
+</div>
+
+<br />
+
+<div class="row-fluid choose-object">
+  <div class="span12">
+    <label>
+      Objects under assessment
+    </label>
+
+    <select class="input-medium pull-left" id="underAssessment">
+      <optgroup label="FOO">
+        <option value="foo_1" label="foo_1"></option>
+        <option value="foo_2" label="foo_2"></option>
+      </optgroup>
+      <optgroup label="BAR">
+        <option value="bar_1" label="bar_1"></option>
+        <option value="bar_2" label="bar_2"></option>
+      </optgroup>
+    </select>
+
+    <label class="inline-check pull-left disabled">
+      <input type="checkbox" class="js-toggle-controlplans" disabled>
+      Use control test plans as procedures
+    </label>
+  </div>
+</div>
+
+<div class="row-fluid">
+  <div class="span6">
+    <label>
+      Default procedure
+      <i class="grcicon-help-black" rel="tooltip" title="Provide more details on the purpose of this Assessment and provide context for how and when this CA might be used."></i>
+      <a data-id="hide_description_lk" href="javascript://" class="field-hide">hide</a>
+    </label>
+    <div class="wysiwyg-area">
+      <textarea tabindex="2" id="system_description" class="span12 triple wysihtml5" name="description" placeholder="Enter Description"></textarea>
+    </div>
+  </div>
+
+  <div class="span6">
+    <div class="row-fluid choose-from-select">
+      <div class="span6 bottom-spacing">
+        <label>
+          Default Assessors
+          <span class="required">*</span>
+        </label>
+
+        <select class="input-block-level js-toggle-field" data-target=".choose-assessor" data-value="other">
+          <option>Object Owners</option>
+          <option>Audit Lead</option>
+          <option value="other">Others...</option>
+        </select>
+      </div>
+
+      <div class="span6">
+        <label>&nbsp;</label>
+        <input type="text" class="input-block-level choose-input choose-assessor" placeholder="Add person 1, Add person 2..." disabled>
+      </div>
+    </div>
+
+    <div class="row-fluid choose-from-select">
+      <div class="span6 bottom-spacing">
+        <label>
+          Default Verifier
+          <span class="required">*</span>
+        </label>
+
+        <select class="input-block-level js-toggle-field" data-target=".choose-verifier" data-value="other">
+          <option>Object contact</option>
+          <option>Primary assessor</option>
+          <option>Secondary assessors</option>
+          <option value="other">Others...</option>
+        </select>
+      </div>
+
+      <div class="span6">
+        <label>&nbsp;</label>
+        <input type="text" class="input-block-level choose-input choose-verifier" placeholder="Add person 1, Add person 2..." disabled>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="custom-attr-wrap">
+  <div class="row-fluid">
+    <div class="span12">
+      <div class="info-expand-mapped">
+        <a class="show-hidden-fields info-show-hide" href="javascript://">
+          <span class="out">
+            <i class="grcicon-arrow-right"></i>
+            Custom attributes
+          </span>
+          <span class="in">
+            <i class="grcicon-arrow-bottom"></i>
+            Custom attributes
+          </span>
+        </a>
+      </div>
+    </div>
+  </div><!-- row-fluid end -->
+
+  <div class="hidden-fields-area" style="display:none;">
+    <div class="row-fluid wrap-row">
+      <div class="custom-attr-table span12">
+        <table class="table">
+          <thead>
+            <tr>
+              <th><h6>Attribute Title</h6></th>
+              <th><h6>Attribute type</h6></th>
+              <th><h6>Attribute values</h6></th>
+              <th class="centered"><h6>Attachment required</h6></th>
+              <th class="centered"><h6>Comment required</h6></th>
+              <th class="centered"><h6>Mandatory</h6></th>
+              <th>&nbsp;</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Assessment results</td>
+              <td>Radio</td>
+              <td>Yes, No, At Risk, Unclear, In Remediation</td>
+              <td class="centered checkbox-wrap"><input type="checkbox" checked></td>
+              <td class="centered checkbox-wrap"><input type="checkbox" checked></td>
+              <td class="centered checkbox-wrap"><input type="checkbox" checked></td>
+              <td>
+                <div class="pull-right">
+                  <a href="#"><i class="grcicon-edit"></i></a>
+                  <a href="#"><i class="grcicon-deleted"></i></a>
+                </div>
+              </td>
+            </tr>
+            <tr>
+              <td>Bug number</td>
+              <td>Text</td>
+              <td></td>
+              <td class="centered checkbox-wrap"><input type="checkbox"></td>
+              <td class="centered checkbox-wrap"><input type="checkbox"></td>
+              <td class="centered checkbox-wrap"><input type="checkbox"></td>
+              <td>
+                <div class="pull-right">
+                  <a href="#"><i class="grcicon-edit"></i></a>
+                  <a href="#"><i class="grcicon-deleted"></i></a>
+                </div>
+              </td>
+            </tr>
+            <tr>
+              <td><input type="text"></td>
+              <td>
+                <select>
+                  <option>Dropdown</option>
+                  <option>Checkbox</option>
+                  <option>Radio</option>
+                  <option>Text</option>
+                </select>
+              </td>
+              <td>
+                <input type="text" placeholder="Type values separated by comma">
+              </td>
+              <td class="centered checkbox-wrap">
+                <input type="checkbox">
+              </td>
+              <td class="centered checkbox-wrap">
+                <input type="checkbox">
+              </td>
+              <td class="centered checkbox-wrap">
+                <input type="checkbox">
+              </td>
+              <td>
+                <div class="pull-right">
+                  <a class="btn btn-small btn-info" href="#">Add field</a>
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div><!-- custom-attr-wrap end -->

--- a/src/ggrc/assets/mustache/base_objects/dropdown_menu.mustache
+++ b/src/ggrc/assets/mustache/base_objects/dropdown_menu.mustache
@@ -22,6 +22,27 @@
     {{#is_allowed 'update' instance context='for'}}
       {{> /static/mustache/base_objects/edit_object_link.mustache}}
     {{/is_allowed}}
+
+    {{! Audit-specific link for defining its AssessmentTemplate}}
+    {{#if_equals instance.type 'Audit'}}
+    {{#is_allowed 'update' instance context='for'}}
+    <li>
+      <a href="javascript://"
+        data-toggle="modal-ajax-form"
+        data-modal-reset="reset"
+        data-modal-class="modal-wide"
+        data-object-singular="{{model_info 'AssessmentTemplate' 'model_singular'}}"
+        data-object-plural="{{model_info 'AssessmentTemplate' 'root_collection'}}"
+        data-object-params='{
+          "audit_id": {{instance.id}},
+          "audit_title": "{{json_escape instance.title}}"
+        }'>
+        Define Assessment template
+      </a>
+    </li>
+    {{/is_allowed}}
+    {{/if_equals}}
+
     <li>
       <clipboard-link title="Get permalink" notify="true" text="{{get_permalink_for_object instance}}" />
     </li>

--- a/src/ggrc/assets/mustache/base_objects/dropdown_menu.mustache
+++ b/src/ggrc/assets/mustache/base_objects/dropdown_menu.mustache
@@ -34,9 +34,17 @@
         data-object-singular="{{model_info 'AssessmentTemplate' 'model_singular'}}"
         data-object-plural="{{model_info 'AssessmentTemplate' 'root_collection'}}"
         data-object-params='{
-          "audit_id": {{instance.id}},
+          "audit": {
+            "id": {{instance.id}},
+            "type": "{{json_escape instance.type}}"
+          },
+          "context": {
+            "id": {{instance.context.id}},
+            "type": "{{json_escape instance.context.type}}"
+          },
           "audit_title": "{{json_escape instance.title}}"
-        }'>
+        }'
+        >
         Define Assessment template
       </a>
     </li>

--- a/src/ggrc/assets/stylesheets/_common.scss
+++ b/src/ggrc/assets/stylesheets/_common.scss
@@ -743,26 +743,49 @@ p {
   margin-top: 6px;
 }
 
-.custom-attr-table {
+.custom-attr-list {
   font-size: 11px;
-  .table {
-    td.centered,
-    th.centered {
-      text-align: center;
+  .row-fluid {
+    [class*="span"] {
+      margin-left: 1.2%;
     }
-    .checkbox-wrap {
-      input {
-        margin-top: 3px;
+  }
+  select {
+    width: 100px;
+  }
+  h6 {
+    font-size: 9px;
+  }
+  .centered {
+    text-align: center;
+  }
+  .checkbox-wrap {
+    input {
+      margin-top: 3px;
+      margin-bottom: 0;
+    }
+  }
+  .block {
+    display: block;
+  }
+  .attr-titles {
+    @extend %clearfix;
+    ul {
+      @extend %reset-list;
+    }
+  }
+  .new-attr-list {
+    @extend .attr-titles;
+    li {
+      padding: 6px 0;
+      line-height: 24px;
+      border-top: 1px solid $tabBorder;
+    }
+    .add-field {
+      input,
+      select {
         margin-bottom: 0;
       }
-    }
-    tbody {
-      td {
-        vertical-align: top;
-      }
-    }
-    .block {
-      display: block;
     }
   }
 }

--- a/src/ggrc/assets/stylesheets/_common.scss
+++ b/src/ggrc/assets/stylesheets/_common.scss
@@ -742,3 +742,109 @@ p {
   display: inline-block;
   margin-top: 6px;
 }
+
+.custom-attr-table {
+  font-size: 11px;
+  .table {
+    td.centered,
+    th.centered {
+      text-align: center;
+    }
+    .checkbox-wrap {
+      input {
+        margin-top: 3px;
+        margin-bottom: 0;
+      }
+    }
+    tbody {
+      td {
+        vertical-align: top;
+      }
+    }
+    .block {
+      display: block;
+    }
+  }
+}
+
+.add-trigger {
+  .disable {
+    cursor: not-allowed;
+    &:hover {
+      i {
+        @include opacity(.25);
+      }
+    }
+  }
+}
+
+.text-top-space {
+  margin-top: 30px;
+  h3 {
+    margin-bottom: 10px;
+  }
+}
+
+.popover-child-node {
+  @include box-shadow(0 5px 10px rgba(0, 0, 0, .2));
+  border: 1px solid rgba(0,0,0, .2);
+  .arrow {
+    display: none !important;
+  }
+}
+
+.child-node-wrap {
+  a {
+    @include transition(color .2s ease);
+    padding: 0 14px 0 10px;
+    display: block;
+    line-height: 29px;
+    font-size: 13px;
+    color: $gray;
+    text-transform: none;
+    i {
+      @include opacity(.4);
+    }
+    &:hover {
+      color: $black;
+      text-decoration: none;
+      i {
+        @include opacity(1);
+      }
+    }
+  }
+}
+
+.child-node {
+  .popover-template:hover {
+    i {
+      background-position: -246px -416px;
+    }
+  }
+}
+
+.label-light {
+  background-color: lighten($blue, 55%);
+  span,
+  a {
+    color: $black;
+    text-shadow: none;
+    font-weight: normal;
+  }
+  a {
+    font-weight: bold;
+    text-decoration: none;
+    padding: 0 2px;
+    &:hover {
+      text-decoration: none;
+    }
+  }
+}
+
+.person-selector {
+  input {
+    float: left;
+    margin-right: 5px;
+    width: 70%;
+  }
+}

--- a/src/ggrc/assets/stylesheets/layout/_container.scss
+++ b/src/ggrc/assets/stylesheets/layout/_container.scss
@@ -11,3 +11,15 @@
     @include transition(width 0.2s);
   }
 }
+
+.row-fluid {
+  .span-custom2-and-half {
+    width: 19.14894%;
+  }
+  .span-custom1-and-half {
+    width: 10.63830%;
+  }
+  .span-custom0-and-half {
+    width: 3.19149%;
+  }
+}

--- a/src/ggrc/assets/stylesheets/modules/_modal.scss
+++ b/src/ggrc/assets/stylesheets/modules/_modal.scss
@@ -347,6 +347,9 @@
         &:first-child {
           margin-top: 6px;
         }
+        &:last-child {
+          margin-bottom: 0;
+        }
       }
     }
     .objective-selector {
@@ -812,17 +815,6 @@
 .define-attr {
   .hidden-fields-area {
     padding-left: 0;
-  }
-  .custom-attr-table {
-    select {
-      width: 100px;
-    }
-    input[type="text"] {
-      width: 150px;
-    }
-    h6 {
-      font-size: 9px;
-    }
   }
 }
 

--- a/src/ggrc/assets/stylesheets/modules/_modal.scss
+++ b/src/ggrc/assets/stylesheets/modules/_modal.scss
@@ -342,7 +342,11 @@
     }
     .checkbox-wrap {
       input[type="checkbox"] {
-        margin-bottom: 0;
+        display: block;
+        margin: 0 auto 12px;
+        &:first-child {
+          margin-top: 6px;
+        }
       }
     }
     .objective-selector {
@@ -764,7 +768,48 @@
 }
 
 // Mockups Assessment Page V1.0
-#AssessmentDefineTemplate {
+.note {
+  font-size: $f-medium;
+}
+.workflow-accordion {
+  .accordion-group {
+    @include border-radius(0);
+    border: none;
+    border-bottom: 1px solid $footerBorder;
+    &:last-child {
+      border-bottom: none;
+    }
+  }
+  .accordion-heading {
+    .accordion-toggle  {
+      padding: 4px 0;
+      font-weight: bold;
+    }
+  }
+  .accordion-inner {
+    border-top: none;
+    padding-left: 19px;
+    button {
+      border: none;
+      background: none;
+      padding: 0;
+      i {
+        margin-top: 5px;
+      }
+      &:focus,
+      &:active {
+        outline: 0;
+      }
+    }
+    .workflow-repeat {
+      float: left;
+      line-height: 26px;
+      margin-right: 4px;
+    }
+  }
+}
+
+.define-attr {
   .hidden-fields-area {
     padding-left: 0;
   }

--- a/src/ggrc/cache/cache.py
+++ b/src/ggrc/cache/cache.py
@@ -29,6 +29,7 @@ def all_cache_entries():
       resource('contexts', 'Context'),
       resource('controls', 'Control'),
       resource('assessments', 'Assessments'),
+      resource('assessment_templates', 'AssessmentTemplate'),
       resource('data_assets', 'DataAsset'),
       resource('directives', 'Directive'),
       resource('contracts', 'Contract'),

--- a/src/ggrc/migrations/versions/20160225114925_1894405f14ef_add_assessmenttemplate.py
+++ b/src/ggrc/migrations/versions/20160225114925_1894405f14ef_add_assessmenttemplate.py
@@ -1,0 +1,51 @@
+# Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+# Created By: peter@reciprocitylabs.com
+# Maintained By: peter@reciprocitylabs.com
+
+"""Add AssessmentTemplate
+
+Revision ID: 1894405f14ef
+Revises: 4e989ef86619
+Create Date: 2016-02-25 11:49:25.128231
+
+"""
+
+# pylint: disable=invalid-name
+
+import sqlalchemy as sa
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '1894405f14ef'
+down_revision = '1e2abee7566c'
+
+
+def upgrade():
+  """Upgrade database schema to a new revision."""
+  op.create_table(
+      'assessment_templates',
+      sa.Column('id', sa.Integer(), nullable=False),
+      sa.Column('audit_id', sa.Integer(), nullable=True),
+      sa.Column(
+          'template_object_type', sa.String(length=250), nullable=True),
+      sa.Column('test_plan_procedure', sa.Boolean(), nullable=False),
+      sa.Column('procedure_description', sa.Text(), nullable=True),
+      sa.Column('default_people', sa.Text(), nullable=False),
+
+      sa.Column('created_at', sa.DateTime()),
+      sa.Column('modified_by_id', sa.Integer()),
+      sa.Column('updated_at', sa.DateTime()),
+      sa.Column(
+          'context_id', sa.Integer(), sa.ForeignKey('contexts.id')),
+
+      sa.PrimaryKeyConstraint('id'),
+      sa.ForeignKeyConstraint(['audit_id'], ['audits.id'], ),
+  )
+
+
+def downgrade():
+  """Downgrade the database schema to the previous revision."""
+  op.drop_table('assessment_templates')

--- a/src/ggrc/migrations/versions/20160225114925_1894405f14ef_add_assessmenttemplate.py
+++ b/src/ggrc/migrations/versions/20160225114925_1894405f14ef_add_assessmenttemplate.py
@@ -28,7 +28,6 @@ def upgrade():
   op.create_table(
       'assessment_templates',
       sa.Column('id', sa.Integer(), nullable=False),
-      sa.Column('audit_id', sa.Integer(), nullable=True),
       sa.Column(
           'template_object_type', sa.String(length=250), nullable=True),
       sa.Column('test_plan_procedure', sa.Boolean(), nullable=False),
@@ -41,8 +40,7 @@ def upgrade():
       sa.Column(
           'context_id', sa.Integer(), sa.ForeignKey('contexts.id')),
 
-      sa.PrimaryKeyConstraint('id'),
-      sa.ForeignKeyConstraint(['audit_id'], ['audits.id'], ),
+      sa.PrimaryKeyConstraint('id')
   )
 
 

--- a/src/ggrc/models/all_models.py
+++ b/src/ggrc/models/all_models.py
@@ -10,6 +10,7 @@ import sys
 from ggrc.models import inflector
 from ggrc.models.access_group import AccessGroup
 from ggrc.models.assessment import Assessment
+from ggrc.models.assessment_template import AssessmentTemplate
 from ggrc.models.audit import Audit
 from ggrc.models.audit_object import AuditObject
 from ggrc.models.background_task import BackgroundTask
@@ -65,6 +66,8 @@ from ggrc.models.vendor import Vendor
 
 all_models = [
     AccessGroup,
+    Assessment,
+    AssessmentTemplate,
     Audit,
     AuditObject,
     Categorization,
@@ -73,7 +76,6 @@ all_models = [
     ControlAssertion,
     Context,
     Control,
-    Assessment,
     Comment,
     CustomAttributeDefinition,
     CustomAttributeValue,

--- a/src/ggrc/models/assessment_template.py
+++ b/src/ggrc/models/assessment_template.py
@@ -20,9 +20,6 @@ class AssessmentTemplate(Base, Relatable, db.Model):
   """
   __tablename__ = "assessment_templates"
 
-  # the audit related to this assessment template
-  audit_id = db.Column(db.Integer, db.ForeignKey("audits.id"), nullable=True)
-
   # the type of the object under assessment
   template_object_type = db.Column(db.String, nullable=True)
 
@@ -38,7 +35,6 @@ class AssessmentTemplate(Base, Relatable, db.Model):
 
   # REST properties
   _publish_attrs = [
-      'audit_id',
       'template_object_type',
       'test_plan_procedure',
       'procedure_description',

--- a/src/ggrc/models/assessment_template.py
+++ b/src/ggrc/models/assessment_template.py
@@ -38,6 +38,7 @@ class AssessmentTemplate(Base, Relatable, db.Model):
 
   # REST properties
   _publish_attrs = [
+      'audit_id',
       'template_object_type',
       'test_plan_procedure',
       'procedure_description',

--- a/src/ggrc/models/assessment_template.py
+++ b/src/ggrc/models/assessment_template.py
@@ -1,0 +1,45 @@
+# Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+# Created By: peter@reciprocitylabs.com
+# Maintained By: peter@reciprocitylabs.com
+
+"""A module containing the implementation of the assessment template entity."""
+
+from ggrc import db
+from ggrc.models.mixins import Base
+from ggrc.models.relationship import Relatable
+
+
+class AssessmentTemplate(Base, Relatable, db.Model):
+  """A class representing the assessment template entity.
+
+  An Assessment Template is a template that allows users for easier creation of
+  multiple Assessments that are somewhat similar to each other, avoiding the
+  need to repeatedly define the same set of properties for every new Assessment
+  object.
+  """
+  __tablename__ = "assessment_templates"
+
+  # the audit related to this assessment template
+  audit_id = db.Column(db.Integer, db.ForeignKey("audits.id"), nullable=True)
+
+  # the type of the object under assessment
+  template_object_type = db.Column(db.String, nullable=True)
+
+  # whether to use the control test plan as a procedure
+  test_plan_procedure = db.Column(db.Boolean, nullable=False)
+
+  # procedure description
+  procedure_description = db.Column(db.Text)
+
+  # the people that should be assigned by default to each assessment created
+  # within the releated audit
+  default_people = db.Column(db.Text)
+
+  # REST properties
+  _publish_attrs = [
+      'template_object_type',
+      'test_plan_procedure',
+      'procedure_description',
+      'default_people',
+  ]

--- a/src/ggrc/services/__init__.py
+++ b/src/ggrc/services/__init__.py
@@ -3,10 +3,10 @@
 # Created By: david@reciprocitylabs.com
 # Maintained By: miha@reciprocitylabs.com
 
-from .common import *
-from .registry import service
-
 """All gGRC REST services."""
+
+from ggrc.services.common import ReadOnlyResource
+from ggrc.services.registry import service
 
 
 def contributed_services():

--- a/src/ggrc/services/__init__.py
+++ b/src/ggrc/services/__init__.py
@@ -27,6 +27,7 @@ def contributed_services():
       service('contexts', models.Context),
       service('controls', models.Control),
       service('assessments', models.Assessment),
+      service('assessment_templates', models.AssessmentTemplate),
       service('comments', models.Comment),
       service('custom_attribute_definitions',
               models.CustomAttributeDefinition),

--- a/src/ggrc/views/__init__.py
+++ b/src/ggrc/views/__init__.py
@@ -8,6 +8,7 @@ Handle non-RESTful views, e.g. routes which return HTML rather than JSON
 """
 
 import json
+
 from flask import flash
 from flask import g
 from flask import render_template
@@ -45,7 +46,6 @@ from ggrc.views.registry import object_view
 
 
 # Needs to be secured as we are removing @login_required
-
 
 @app.route("/_background_tasks/reindex", methods=["POST"])
 @queued_task

--- a/src/ggrc/views/__init__.py
+++ b/src/ggrc/views/__init__.py
@@ -258,6 +258,7 @@ def contributed_object_views():
       object_view(models.Section),
       object_view(models.Control),
       object_view(models.Assessment),
+      object_view(models.AssessmentTemplate),
       object_view(models.Objective),
       object_view(models.System),
       object_view(models.Process),

--- a/src/ggrc_basic_permissions/roles/ProgramAuditOwner.py
+++ b/src/ggrc_basic_permissions/roles/ProgramAuditOwner.py
@@ -1,7 +1,12 @@
-# Copyright (C) 2015 Google Inc., authors, and contributors <see AUTHORS file>
+# Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 # Created By: anze@reciprocitylabs.com
 # Maintained By: anze@reciprocitylabs.com
+
+"""A module with configuration of the ProgramAuditOwner role's permissions."""
+
+# pylint: disable=invalid-name
+
 
 scope = "Audit Implied"
 description = """
@@ -12,6 +17,7 @@ permissions = {
     "read": [
         "Request",
         "Assessment",
+        "AssessmentTemplate",
         "Issue",
         "DocumentationResponse",
         "InterviewResponse",
@@ -31,6 +37,7 @@ permissions = {
     "create": [
         "Request",
         "Assessment",
+        "AssessmentTemplate",
         "Issue",
         "DocumentationResponse",
         "InterviewResponse",
@@ -53,6 +60,7 @@ permissions = {
     "update": [
         "Request",
         "Assessment",
+        "AssessmentTemplate",
         "Issue",
         "DocumentationResponse",
         "InterviewResponse",
@@ -72,6 +80,7 @@ permissions = {
         "UserRole",
         "Request",
         "Assessment",
+        "AssessmentTemplate",
         "Issue",
         "ObjectControl",
         "ObjectDocument",

--- a/src/ggrc_basic_permissions/roles/Reader.py
+++ b/src/ggrc_basic_permissions/roles/Reader.py
@@ -1,9 +1,15 @@
-# Copyright (C) 2015 Google Inc., authors, and contributors <see AUTHORS file>
+# Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 # Created By: anze@reciprocitylabs.com
 # Maintained By: anze@reciprocitylabs.com
 
+"""A module with configuration of the Reader role's permissions."""
+
+# pylint: disable=invalid-name
+
+
 from ggrc_basic_permissions.roles.Creator import owner_update
+
 
 scope = "System"
 description = """
@@ -19,6 +25,7 @@ permissions = {
         "ControlAssertion",
         "Control",
         "Assessment",
+        "AssessmentTemplate",
         "CustomAttributeDefinition",
         "CustomAttributeValue",
         "Issue",


### PR DESCRIPTION
This is the first working version of the PR. It is now possible to open an AssessmentTemplate modal (from the Audit's info pane only) and create a new AssessmentTemplate.

It probably needs more polishing, e.g. conditionally enabling/disabling form fields based on their values. 

We probably also need a way to edit an existing Audit's AssessmentTemplate, but to my knowledge we don't have UI mockups to see how an Audit's existing (if any) AssessmentTemplate should be shown. Might be better to resolve this under a separate ticket...

I am also not sure about the status of the custom attributes functionality, please ping @hyperNURb for that.

**Update:** It seems that there are a lot of failed and erroneous Selenium/integration tests, lots of timeout errors in the Jenkins build log. Not sure whether this PR has caused them, or if there is some "external" cause...