### PR TITLE
CORE-3261 Attached evidence isn't shown in the comments section under the a request

### DIFF
--- a/src/ggrc_basic_permissions/roles/Creator.py
+++ b/src/ggrc_basic_permissions/roles/Creator.py
@@ -94,14 +94,6 @@ owner_base = [
         "condition": "contains"
     },
     {
-        "type": "Document",
-        "terms": {
-            "list_property": "owners",
-            "value": "$current_user"
-        },
-        "condition": "contains"
-    },
-    {
         "type": "Facility",
         "terms": {
             "list_property": "owners",


### PR DESCRIPTION
The condition was always false becasue we don't
assign object owners to documents anywhere.
Additionally, the owners condition prevented read
permission from audit contexts from propagating.