### PR TITLE
CORE-3270 Add component registry

### DIFF
--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -49,6 +49,7 @@ dashboard-js-files:
   - plugins/autocomplete.js
   - plugins/ajax_extensions.js
   - plugins/canjs_extensions.js
+  - plugins/component_registry.js
   - plugins/openclose.js
   - plugins/tooltip.js
   - plugins/popover.js

--- a/src/ggrc/assets/javascripts/plugins/component_registry.js
+++ b/src/ggrc/assets/javascripts/plugins/component_registry.js
@@ -6,10 +6,10 @@
   Maintained By: peter@reciprocitylabs.com
 */
 
-(function (GGRC, can) {
+(function (GGRC, can, _) {
   'use strict';
 
-  if (typeof GGRC.Components === 'function') {
+  if (_.isFunction(GGRC.Components)) {
     return;  // no need to create the component registry again
   }
 
@@ -35,7 +35,7 @@
   function Components(name, config) {
     var constructor;
 
-    if (!name || typeof name !== 'string') {
+    if (!name || !_.isString(name)) {
       throw new Error('Component name must be a nonempty string.');
     }
 
@@ -71,7 +71,7 @@
    * @return {Boolean} - true if the component exists, false false otherwise
    */
   Components.isRegistered = function (name) {
-    return typeof Components._registry[name] !== 'undefined';
+    return !_.isUndefined(Components._registry[name]);
   };
 
   /**
@@ -91,4 +91,4 @@
 
     return Components._registry[name];
   };
-})(window.GGRC = window.GGRC || {}, can);
+})(window.GGRC = window.GGRC || {}, can, _);

--- a/src/ggrc/assets/javascripts/plugins/component_registry.js
+++ b/src/ggrc/assets/javascripts/plugins/component_registry.js
@@ -1,0 +1,94 @@
+
+/*!
+  Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+  Created By: peter@reciprocitylabs.com
+  Maintained By: peter@reciprocitylabs.com
+*/
+
+(function (GGRC, can) {
+  'use strict';
+
+  if (typeof GGRC.Components === 'function') {
+    return;  // no need to create the component registry again
+  }
+
+  // make the registry publicly avilable
+  GGRC.Components = Components;
+
+  /**
+   * An object representing the CanJS component registry.
+   *
+   * If invoked directly as a function, it creates a new component by
+   * delegating the work to can.Component.extend(), and registers the resulting
+   * constructor function under the given name.
+   *
+   * The name must be a nonempty string, and an error is thrown if the name has
+   * already been taken.
+   *
+   * @param {String} name - the name under which to register the component
+   * @param {Object} config - the component configuration object as expected
+   *   by the underlying can.Component.extend() method
+   *
+   * @return {Function} - the created component constructor
+   */
+  function Components(name, config) {
+    var constructor;
+
+    if (!name || typeof name !== 'string') {
+      throw new Error('Component name must be a nonempty string.');
+    }
+
+    if (Components._registry[name]) {
+      throw new Error('Component already exists: ' + name);
+    }
+
+    constructor = can.Component.extend(config);
+    Components._registry[name] = constructor;
+
+    return constructor;
+  }
+
+  // the internal storage of the registered components
+  Components._registry = {};
+
+  /**
+   * Remove a registered component from the registry.
+   *
+   * If the component already does not exist, the function silently does
+   * nothing.
+   *
+   * @param {String} name - the name of the component to deregister
+   */
+  Components.unregister = function (name) {
+    delete Components._registry[name];
+  };
+
+  /**
+   * Checks whether a component exists in the registry.
+   *
+   * @param {String} name - the name of the component
+   * @return {Boolean} - true if the component exists, false false otherwise
+   */
+  Components.isRegistered = function (name) {
+    return typeof Components._registry[name] !== 'undefined';
+  };
+
+  /**
+   * Retrieve a component from the registry.
+   *
+   * If the component is not found, an error is thrown.
+   *
+   * @param {String} name - the name of the component to retrieve
+   * @return {Function} - the component's constructor function
+   */
+  Components.get = function (name) {
+    var component = Components._registry[name];
+
+    if (!component) {
+      throw new Error('Component not found: ' + name);
+    }
+
+    return Components._registry[name];
+  };
+})(window.GGRC = window.GGRC || {}, can);

--- a/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
+++ b/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
@@ -14,7 +14,7 @@
       date = moment(date);
       // 6 is Saturday 0 is Sunday
       while (_.contains([0, 6], date.day())) {
-        date.add(1, "day");
+        date.add(1, 'day');
       }
       return date.toDate();
     },
@@ -28,7 +28,8 @@
     },
     download: function (filename, text) {
       var element = document.createElement('a');
-      element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(text));
+      element.setAttribute(
+        'href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(text));
       element.setAttribute('download', filename);
       element.style.display = 'none';
       document.body.appendChild(element);
@@ -37,20 +38,21 @@
     },
     export_request: function (request) {
       return $.ajax({
-        type: "POST",
-        dataType: "text",
+        type: 'POST',
+        dataType: 'text',
         headers: $.extend({
-          "Content-Type": "application/json",
-          "X-export-view": "blocks",
-          "X-requested-by": "gGRC"
+          'Content-Type': 'application/json',
+          'X-export-view': 'blocks',
+          'X-requested-by': 'gGRC'
         }, request.headers || {}),
-        url: "/_service/export_csv",
+        url: '/_service/export_csv',
         data: JSON.stringify(request.data || {})
       });
     },
     is_mapped: function (target, destination) {
-      var table_plural = CMS.Models[destination.type].table_plural,
-          bindings = target.get_binding((target.has_binding(table_plural) ? "" : "related_") + table_plural);
+      var tablePlural = CMS.Models[destination.type].table_plural;
+      var bindings = target.get_binding(
+        (target.has_binding(tablePlural) ? '' : 'related_') + tablePlural);
 
       if (bindings && bindings.list && bindings.list.length) {
         return _.find(bindings.list, function (item) {

--- a/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
+++ b/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
@@ -1,10 +1,14 @@
 /*!
-    Copyright (C) 2015 Google Inc., authors, and contributors <see AUTHORS file>
-    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
-    Created By: ivan@reciprocitylabs.com
-    Maintained By: ivan@reciprocitylabs.com
+  Copyright (C) 2015 Google Inc., authors, and contributors <see AUTHORS file>
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+  Created By: ivan@reciprocitylabs.com
+  Maintained By: ivan@reciprocitylabs.com
 */
-(function($, GGRC, moment, Permission) {
+
+(function ($, GGRC, moment, Permission) {
+  /**
+   * A module containing various utility functions.
+   */
   GGRC.Utils = {
     firstWorkingDay: function (date) {
       date = moment(date);

--- a/src/ggrc/assets/javascripts/plugins/tests/component_registry_spec.js
+++ b/src/ggrc/assets/javascripts/plugins/tests/component_registry_spec.js
@@ -1,0 +1,132 @@
+/*!
+  Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+  Created By: peter@reciprocitylabs.com
+  Maintained By: peter@reciprocitylabs.com
+*/
+
+describe('GGRC component registry', function () {
+  'use strict';
+
+  var origStorage;  // the existing component private storage
+  var Components;  // the component registry utility
+
+  beforeAll(function () {
+    Components = GGRC.Components;
+  });
+
+  beforeEach(function () {
+    origStorage = Components._registry;
+    Components._registry = {};
+  });
+
+  afterEach(function () {
+    Components._registry = origStorage;
+  });
+
+  describe('using the Components registry as a function', function () {
+    var componentConfig;
+    var fakeComponent;
+
+    beforeEach(function () {
+      componentConfig = {
+        tag: 'foo-bar',
+        template: 'Hello World!'
+      };
+      fakeComponent = function FooBar() {};
+
+      spyOn(can.Component, 'extend').and.returnValue(fakeComponent);
+    });
+
+    it('adds a new component to the registry', function () {
+      delete Components._registry.foo;
+      Components('foo', componentConfig);
+      expect(Components._registry.foo).toBe(fakeComponent);
+    });
+
+    it('returns the newly created component', function () {
+      var result;
+      delete Components._registry.foo;
+      result = Components('foo', componentConfig);
+      expect(result).toBe(fakeComponent);
+    });
+
+    it('throws an error if a component is already registered', function () {
+      var componentConfig = {};
+
+      Components._registry.foo = function FooBar() {};
+
+      expect(function () {
+        Components('foo', componentConfig);
+      })
+      .toThrow(new Error('Component already exists: foo'));
+    });
+
+    it('throws an error if registering a component under a blank name',
+      function () {
+        var componentConfig = {};
+
+        expect(function () {
+          Components('', componentConfig);
+        })
+        .toThrow(new Error('Component name must be a nonempty string.'));
+      }
+    );
+
+    it('throws an error if the given name is not a string', function () {
+      var componentConfig = {};
+
+      expect(function () {
+        Components(123, componentConfig);
+      })
+      .toThrow(new Error('Component name must be a nonempty string.'));
+    });
+  });
+
+  describe('unregister() method', function () {
+    it('removes a component from the registry', function () {
+      Components._registry.foo = function FooBar() {};
+      Components.unregister('foo');
+      expect(Components._registry.foo).toBeUndefined();
+    });
+
+    it('silently does nothing if a component does not exist', function () {
+      delete Components._registry.foo;  // the "foo" component does not exist
+
+      try {
+        Components.unregister('foo');
+      } catch (err) {
+        fail('An error should not have be thrown.');
+      }
+    });
+  });
+
+  describe('isRegistered() method', function () {
+    it('returns true if a component is registered', function () {
+      Components._registry.foo = function FooBar() {};
+      expect(Components.isRegistered('foo')).toBe(true);
+    });
+
+    it('returns false if a component is not registered', function () {
+      delete Components._registry.foo;
+      expect(Components.isRegistered('foo')).toBe(false);
+    });
+  });
+
+  describe('get() method', function () {
+    it('returns the component registered under the given name', function () {
+      var componentFoo = function () {};
+      Components._registry.foo = componentFoo;
+      expect(Components.get('foo')).toBe(componentFoo);
+    });
+
+    it('raises an error if a component does not exist', function () {
+      delete Components._registry.foo;
+
+      expect(function () {
+        Components.get('foo');
+      })
+      .toThrow(new Error('Component not found: foo'));
+    });
+  });
+});


### PR DESCRIPTION
This will allow us to register CanJS components, making it possible for the tests suites to obtain references to them, and hence test them.