### PR TITLE
CORE-3067 Remove CSS3 prefixes on mixins

### DIFF
--- a/src/ggrc/assets/stylesheets/mixins/_background-size.scss
+++ b/src/ggrc/assets/stylesheets/mixins/_background-size.scss
@@ -6,8 +6,5 @@
  */
 
 @mixin background-size($size){
-  -webkit-background-size: $size;
-  -moz-background-size: $size;
-  -o-background-size: $size;
   background-size: $size;
 }

--- a/src/ggrc/assets/stylesheets/mixins/_border-radius.scss
+++ b/src/ggrc/assets/stylesheets/mixins/_border-radius.scss
@@ -6,9 +6,5 @@
  */
 
 @mixin border-radius($radius: $default-border-radius) {
-  -moz-border-radius: $radius;
-  -ms-border-radius: $radius;
-  -o-border-radius: $radius;
-  -webkit-border-radius: $radius;
   border-radius: $radius;
 }

--- a/src/ggrc/assets/stylesheets/mixins/_box-shadow.scss
+++ b/src/ggrc/assets/stylesheets/mixins/_box-shadow.scss
@@ -6,7 +6,5 @@
  */
 
 @mixin box-shadow($shadow...) {
-  -moz-box-shadow: $shadow;
-  -webkit-box-shadow: $shadow;
   box-shadow: $shadow;
 }

--- a/src/ggrc/assets/stylesheets/mixins/_input-placeholder.scss
+++ b/src/ggrc/assets/stylesheets/mixins/_input-placeholder.scss
@@ -7,8 +7,4 @@
 
  @mixin input-placeholder {
   &.placeholder { @content; }
-  &:-moz-placeholder { @content; }
-  &::-moz-placeholder { @content; }
-  &:-ms-input-placeholder { @content; }
-  &::-webkit-input-placeholder { @content; }
 }

--- a/src/ggrc/assets/stylesheets/mixins/_transition.scss
+++ b/src/ggrc/assets/stylesheets/mixins/_transition.scss
@@ -6,8 +6,5 @@
  */
 
 @mixin transition($transition...) {
-    -moz-transition: $transition;
-    -o-transition: $transition;
-    -webkit-transition: $transition;
-    transition: $transition;
+  transition: $transition;
 }


### PR DESCRIPTION
We are implementing webpack autoprefixer so I've removed CSS3 prefixes
from all mixins where we have it.