### PR TITLE
CORE-3289 Fix font variable value

### DIFF
--- a/src/ggrc/assets/stylesheets/_setup.scss
+++ b/src/ggrc/assets/stylesheets/_setup.scss
@@ -11,7 +11,7 @@ $topBorderRadius: 4px 4px 0 0;
 $bottomBorderRadius: 0 0 4px 4px;
 
 // Typography configuration
-$baseFontSize: 14;
+$baseFontSize: 14px;
 $f-regular:90%; // equals 16px ?????
 $f-medium:85%;
 $f-small:75%;


### PR DESCRIPTION
When there is no `px` unit in `$baseFontSize` variable we are having some issues in application.