### PR TITLE
QUICK-FIX Fix script error caused by linting

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
@@ -936,12 +936,12 @@ CMS.Controllers.TreeLoader('CMS.Controllers.TreeView', {
       if (!control) {
         return;
       }
-      if (Math.abs(this.elPosition(control.element)) <= pageCount) {
+      if (Math.abs(elPosition(control.element)) <= pageCount) {
         visible.push(control);
       } else {
         control.draw_placeholder();
       }
-    }.bind(this));
+    });
 
     for (i = lo; i <= hi; i++) {
       index = this._is_scrolling_up ? (hi - (i - lo)) : i;


### PR DESCRIPTION
When linting the merge from zucchini, I accidentally broke tree view rendering when scrolling. This fixes the regression caused.