### PR TITLE
CORE-3304 Display AssessmentTemplate's info on the info pane

### DIFF
--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -316,6 +316,41 @@ Mustache.registerHelper("if_null", function (val1, options) {
   return exec();
 });
 
+  /**
+   * Check if the given argument is a string and render the corresponding
+   * block in the template.
+   *
+   * Example usage:
+   *
+   *   {{#if_string someValue}}
+   *      {{someValue}} is a string
+   *   {{else}}
+   *     {{someValue}} is NOT a string
+   *   {{/if_string}}
+   *
+   * @param {*} thing - the argument to check
+   * @param {Object} options - a CanJS options argument passed to every helper
+   *
+   */
+  Mustache.registerHelper('if_string', function (thing, options) {
+    var resolved;
+
+    if (arguments.length !== 2) {
+      throw new Error(
+        'Invalid number of arguments (' +
+        (arguments.length - 1) +  // do not count the auto-provided options arg
+        '), expected 1.');
+    }
+
+    resolved = Mustache.resolve(thing);
+
+    if (_.isString(resolved)) {
+      return options.fn(options.context);
+    }
+
+    return options.inverse(options.context);
+  });
+
 // Resolve and return the first computed value from a list
 Mustache.registerHelper("firstexist", function () {
   var args = can.makeArray(arguments).slice(0, arguments.length - 1);  // ignore the last argument (some Can object)

--- a/src/ggrc/assets/js_specs/mustache_helpers/if_string_spec.js
+++ b/src/ggrc/assets/js_specs/mustache_helpers/if_string_spec.js
@@ -1,0 +1,76 @@
+/*!
+  Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+  Created By: peter@reciprocitylabs.com
+  Maintained By: peter@reciprocitylabs.com
+*/
+
+describe('can.mustache.helper.if_string', function () {
+  'use strict';
+
+  var fakeOptions;  // fake mustache options object passed to the helper
+  var helper;
+  var someContext;
+
+  beforeAll(function () {
+    helper = can.Mustache._helpers.if_string.fn;
+  });
+
+  beforeEach(function () {
+    someContext = {foo: 'bar'};
+
+    fakeOptions = {
+      fn: jasmine.createSpy(),
+      inverse: jasmine.createSpy(),
+      context: someContext
+    };
+  });
+
+  it('triggers rendering of the "truthy" block for string arguments',
+    function () {
+      var callArgs;
+      var expectedArgs = [someContext];
+
+      helper('this is a string', fakeOptions);
+
+      expect(fakeOptions.fn.calls.count()).toEqual(1);
+      callArgs = fakeOptions.fn.calls.mostRecent().args;
+      expect(callArgs).toEqual(expectedArgs);
+    }
+  );
+
+  it('triggers rendering of the inverse block for non-string arguments',
+    function () {
+      var callArgs;
+      var expectedArgs = [someContext];
+      var params = [
+        ['not', 'a', 'string'],
+        {isString: false},
+        1234,
+        function foo() {}
+      ];
+
+      params.forEach(function (param) {
+        fakeOptions.inverse.calls.reset();
+
+        helper(param, fakeOptions);
+
+        expect(fakeOptions.inverse.calls.count()).toEqual(1);
+        callArgs = fakeOptions.inverse.calls.mostRecent().args;
+        expect(callArgs).toEqual(expectedArgs);
+      });
+    }
+  );
+
+  it('raises an error on missing arguments', function () {
+    expect(function () {
+      helper(fakeOptions);
+    }).toThrow(new Error('Invalid number of arguments (0), expected 1.'));
+  });
+
+  it('raises an error on too many arguments', function () {
+    expect(function () {
+      helper('argument 1', 'argument 2', fakeOptions);
+    }).toThrow(new Error('Invalid number of arguments (2), expected 1.'));
+  });
+});

--- a/src/ggrc/assets/mustache/assessment_templates/info.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/info.mustache
@@ -5,4 +5,116 @@
   Maintained By: peter@reciprocitylabs.com
 }}
 
-AssessmentTemplate's info.mustache
+{{#instance}}
+  <section class="info{{#is_info_pin}} sticky-info-panel{{/is_info_pin}}">
+
+    {{#is_info_pin}}
+      {{{render '/static/mustache/base_objects/info-pin.mustache'}}}
+    {{/is_info_pin}}
+
+    <div class="info-pane-utility">
+      {{> /static/mustache/base_objects/dropdown_menu.mustache}}
+    </div>
+
+    <div class="tier-content">
+
+      <div class="pane-header">
+        <div class="row-fluid wrap-row">
+          <div data-test-id="title_0ad9fbaf" class="span9">
+            <h6>Title</h6>
+            <h3>{{title}}</h3>
+
+            {{#if type}}
+              <p>{{type.title}}</p>
+            {{/if}}
+          </div>
+        </div>
+      </div>
+
+      <div class="row-fluid wrap-row">
+        <div class="span4">
+          <h6>Objects under assessment</h6>
+          {{#if template_object_type}}
+            {{template_object_type}}
+          {{else}}
+            <span class="empty-message">None</span>
+          {{/if}}
+        </div>
+
+        <div class="span4">
+          <h6>Use control test plans as procedures</h6>
+          {{#if test_plan_procedure}}YES{{else}}NO{{/if}}
+        </div>
+
+        <div class="span4">
+          <h6>Default procedure description</h6>
+          {{#if procedure_description}}
+            {{procedure_description}}
+          {{else}}
+            <span class="empty-message">None</span>
+          {{/if}}
+        </div>
+      </div>
+
+      <div class="row-fluid wrap-row">
+        <div class="span4">
+          <h6>Default Assessors</h6>
+          {{#if default_people.assessors}}
+            {{#if_string default_people.assessors}}
+              {{default_people.assessors}}
+            {{else}}
+              {{#if default_people.assessors.length}}
+                <ul>
+                  {{#each default_people.assessors}}
+                    <li>User {{.}}</li>  {{!TODO: get the actual User object}}
+                  {{/each}}
+                </ul>
+              {{else}}
+                <span class="empty-message">None</span>
+              {{/if}}
+            {{/if_string}}
+          {{else}}
+            <span class="empty-message">None</span>
+          {{/if}}
+        </div>
+
+        <div class="span4">
+          <h6>Default Verifier</h6>
+          {{#if default_people.verifiers}}
+            {{#if_string default_people.verifiers}}
+              {{default_people.verifiers}}
+            {{else}}
+              {{#if default_people.verifiers.length}}
+                <ul>
+                  {{#each default_people.verifiers}}
+                    <li>User {{.}}</li>  {{!TODO: get the actual User object}}
+                  {{/each}}
+                </ul>
+              {{else}}
+                <span class="empty-message">None</span>
+              {{/if}}
+            {{/if_string}}
+          {{else}}
+            <span class="empty-message">None</span>
+          {{/if}}
+        </div>
+      </div>
+
+    </div><!-- tier-content end -->
+
+    {{{render '/static/mustache/custom_attributes/info.mustache' instance=instance}}}
+
+  </section>
+
+  <div class="info-widget-footer">
+    <p>
+      <small>
+        <em>
+          Created at {{date created_at}}
+          &nbsp;&nbsp;&nbsp;&nbsp;
+          Modified by {{#using person=modified_by}}{{{render '/static/mustache/people/popover.mustache' person=person}}}{{/using}} on {{date updated_at}}
+        </em>
+      </small>
+    </p>
+  </div>
+{{/instance}}

--- a/src/ggrc/models/assessment_template.py
+++ b/src/ggrc/models/assessment_template.py
@@ -8,6 +8,7 @@
 from ggrc import db
 from ggrc.models.mixins import Base
 from ggrc.models.relationship import Relatable
+from ggrc.models.types import JsonType
 
 
 class AssessmentTemplate(Base, Relatable, db.Model):
@@ -27,11 +28,11 @@ class AssessmentTemplate(Base, Relatable, db.Model):
   test_plan_procedure = db.Column(db.Boolean, nullable=False)
 
   # procedure description
-  procedure_description = db.Column(db.Text)
+  procedure_description = db.Column(db.Text, nullable=True)
 
   # the people that should be assigned by default to each assessment created
   # within the releated audit
-  default_people = db.Column(db.Text)
+  default_people = db.Column(JsonType, nullable=False)
 
   # REST properties
   _publish_attrs = [


### PR DESCRIPTION
This PR makes the AssessmentTemplate's `info.mustache` template useful. It also adds transparent (de)serializiation of the the `default_people` JSON field.

**Note:** Due to time constraints the actual users are not show, only their IDs. I primarily wanted to unblock @Smotko because he will need this info when working on a related feature.