### PR TITLE
QUICK-FIX Reduce lint errors in migration script templates

### DIFF
--- a/src/ggrc/migrations/script.py.mako
+++ b/src/ggrc/migrations/script.py.mako
@@ -1,27 +1,30 @@
-## Copyright (C) 2013 Google Inc., authors, and contributors <see AUTHORS file>
-## Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
-## Created By: dan@reciprocitylabs.com
-## Maintained By: dan@reciprocitylabs.com
-
-"""${message}
-
-Revision ID: ${up_revision}
-Revises: ${down_revision}
-Create Date: ${create_date}
+# Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+# Created By: dan@reciprocitylabs.com
+# Maintained By: peter@reciprocitylabs.com
 
 """
+${message}
+
+Create Date: ${create_date}
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+import sqlalchemy as sa
+
+from alembic import op
+${imports if imports else ""}
 
 # revision identifiers, used by Alembic.
 revision = ${repr(up_revision)}
 down_revision = ${repr(down_revision)}
 
-from alembic import op
-import sqlalchemy as sa
-${imports if imports else ""}
 
 def upgrade():
-    ${upgrades if upgrades else "pass"}
-
+    """Upgrade database schema and/or data, creating a new revision."""
+    ${upgrades if upgrades else ""}
 
 def downgrade():
-    ${downgrades if downgrades else "pass"}
+    """Downgrade database schema and/or data back to the previous revision."""
+    ${downgrades if downgrades else ""}

--- a/src/ggrc_basic_permissions/migrations/script.py.mako
+++ b/src/ggrc_basic_permissions/migrations/script.py.mako
@@ -1,27 +1,30 @@
-## Copyright (C) 2013 Google Inc., authors, and contributors <see AUTHORS file>
-## Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
-## Created By: dan@reciprocitylabs.com
-## Maintained By: dan@reciprocitylabs.com
-
-"""${message}
-
-Revision ID: ${up_revision}
-Revises: ${down_revision}
-Create Date: ${create_date}
+# Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+# Created By: dan@reciprocitylabs.com
+# Maintained By: peter@reciprocitylabs.com
 
 """
+${message}
+
+Create Date: ${create_date}
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+import sqlalchemy as sa
+
+from alembic import op
+${imports if imports else ""}
 
 # revision identifiers, used by Alembic.
 revision = ${repr(up_revision)}
 down_revision = ${repr(down_revision)}
 
-from alembic import op
-import sqlalchemy as sa
-${imports if imports else ""}
 
 def upgrade():
-    ${upgrades if upgrades else "pass"}
-
+    """Upgrade database schema and/or data, creating a new revision."""
+    ${upgrades if upgrades else ""}
 
 def downgrade():
-    ${downgrades if downgrades else "pass"}
+    """Downgrade database schema and/or data back to the previous revision."""
+    ${downgrades if downgrades else ""}

--- a/src/ggrc_gdrive_integration/migrations/script.py.mako
+++ b/src/ggrc_gdrive_integration/migrations/script.py.mako
@@ -1,22 +1,30 @@
-"""${message}
-
-Revision ID: ${up_revision}
-Revises: ${down_revision}
-Create Date: ${create_date}
+# Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+# Created By: dan@reciprocitylabs.com
+# Maintained By: peter@reciprocitylabs.com
 
 """
+${message}
+
+Create Date: ${create_date}
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+import sqlalchemy as sa
+
+from alembic import op
+${imports if imports else ""}
 
 # revision identifiers, used by Alembic.
 revision = ${repr(up_revision)}
 down_revision = ${repr(down_revision)}
 
-from alembic import op
-import sqlalchemy as sa
-${imports if imports else ""}
 
 def upgrade():
-    ${upgrades if upgrades else "pass"}
-
+    """Upgrade database schema and/or data, creating a new revision."""
+    ${upgrades if upgrades else ""}
 
 def downgrade():
-    ${downgrades if downgrades else "pass"}
+    """Downgrade database schema and/or data back to the previous revision."""
+    ${downgrades if downgrades else ""}


### PR DESCRIPTION
This PR modifies the template used for generating DB migration scripts. While it doesn't make the generated files code style-compliant out of the box (that would require patching Alembic's methods for the auto-generated code), it nevertheless removes at least some of the current annoyances by the following:
* The Copyright info header is now automatically added
* The revision numbers are removed from the module's docstring  - these were frequently forgotten to be updated, and they are obvious anyway from the corresponding module-level variables
* The imports have been moved to the top of the file where they should be, right after the module docstring,
* The pylint's "invalid name" warning is automatically silenced - the complaints about the invalid module name and Alembic variables' names not in UPPER CASE served no goog
* The `upgrade()` and `downgrade()` functions now have docstrings.

CC: @samotarnik @Smotko 