### PR TITLE
QUICK-FIX Explain queries that ran for more than 0.5s

### DIFF
--- a/src/ggrc/app.py
+++ b/src/ggrc/app.py
@@ -130,6 +130,8 @@ def _display_sql_queries():
       """
       explain_threshold = 0.5  # EXPLAIN queries that ran for more than 0.5s
       queries = get_debug_queries()
+      # We have to copy the queries list below otherwise queries executed
+      # in the for loop will be appended causing an endless loop
       for query in queries[:]:
         app.logger.info("{:.8f} {}\n{}".format(
             query.duration,

--- a/src/ggrc/app.py
+++ b/src/ggrc/app.py
@@ -7,6 +7,7 @@
 Sets up Flask app
 """
 
+import re
 from flask import Flask
 from flask.ext.sqlalchemy import get_debug_queries
 from flask.ext.sqlalchemy import SQLAlchemy
@@ -133,11 +134,13 @@ def _display_sql_queries():
       # We have to copy the queries list below otherwise queries executed
       # in the for loop will be appended causing an endless loop
       for query in queries[:]:
-        app.logger.info("{:.8f} {}\n{}".format(
+        app.logger.info("{:.8f} {}\n{}\n{}".format(
             query.duration,
             query.context,
-            query.statement % query.parameters))
-        if query.duration > explain_threshold:
+            query.statement,
+            query.parameters))
+        is_select = bool(re.match('SELECT', query.statement, re.I))
+        if query.duration > explain_threshold and is_select:
           statement = 'EXPLAIN ' + query.statement
           engine = SQLAlchemy().get_engine(app)
           result = engine.execute(statement, query.parameters)

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -29,6 +29,7 @@ python-dateutil==2.2
 pytz==2015.2
 six==1.10.0
 SQLAlchemy==0.9.4
+tabulate==0.7.5
 webassets==0.8
 Werkzeug==0.9.3
 # Flask-SQLAlchemy must be last - it somehow mangles `distribute` / `setuptools`


### PR DESCRIPTION
When SQLALCHEMY_RECORD_QUERIES is enabled we will now run EXPLAIN on
queries that ran longer than 0.5s. This will allow us to see potential
bottlenecks in logs on cloud console.