### PR TITLE
CORE-3310 Enable editing an existing AssessmentTemplate

### DIFF
--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -1101,10 +1101,25 @@
       Workflow: true
     }),
 
-    // TODO: docstring, tests
-    // isNewObject: boolean (true if creating new object)
+    /**
+     * An event handler when the add/edit form is about to be displayed.
+     *
+     * It builds a list of all object types used to populate the corresponding
+     * dropdown menu on the form.
+     * It also deserializes the default people settings so that those form
+     * fields are correctly populated.
+     *
+     * @param {Boolean} isNewObject - true if creating a new instance, false if
+     *   editing and existing one
+     *
+     */
     form_preload: function (isNewObject) {
+      if (isNewObject) {
+        this.attr('default_people', {});
+      }
+
       this.attr('_objectTypes', this._choosableObjectTypes());
+      this._unpackPeopleData();
     },
 
     /**
@@ -1114,7 +1129,6 @@
      *   depending on the outcome of the undrelying API request
      */
     save: function () {
-      this.attr('test_plan_procedure', !!this.attr('test_plan_procedure'));
       this.attr('default_people', this._packPeopleData());
 
       return this._super.apply(this, arguments);
@@ -1146,8 +1160,8 @@
         return _.uniq(_.filter(result));
       }
 
-      data.assessors = this.attr('default_assessors');
-      data.verifiers = this.attr('default_verifiers');
+      data.assessors = this.attr('default_people.assessors');
+      data.verifiers = this.attr('default_people.verifiers');
 
       if (data.assessors === 'other') {
         data.assessors = makeList(this.attr('assessors_list'));
@@ -1158,6 +1172,23 @@
       }
 
       return JSON.stringify(data);
+    },
+
+    /**
+     * Inspect the default people settings object, convert any lists of
+     * user IDs to comma-separated strings, and use that to populate the
+     * corresponding text input fields.
+     */
+    _unpackPeopleData: function () {
+      var instance = this;  // the AssessmentTemplate model instance
+      var peopleData = instance.default_people;
+
+      ['assessors', 'verifiers'].forEach(function (name) {
+        if (peopleData[name] instanceof can.List) {
+          instance.attr(name + '_list', peopleData[name].join(', '));
+          instance.attr('default_people.' + name, 'other');
+        }
+      });
     },
 
     /**

--- a/src/ggrc/assets/js_specs/models/assessment_template_spec.js
+++ b/src/ggrc/assets/js_specs/models/assessment_template_spec.js
@@ -152,8 +152,11 @@ describe('can.Model.AssessmentTemplate', function () {
   describe('_packPeopleData() method', function () {
     it('packs default people data into a JSON string', function () {
       var result;
-      instance.attr('default_assessors', 'Rabbits');
-      instance.attr('default_verifiers', 'Turtles');
+
+      instance.attr('default_people', {
+        assessors: 'Rabbits',
+        verifiers: 'Turtles'
+      });
 
       result = instance._packPeopleData();
 
@@ -167,9 +170,13 @@ describe('can.Model.AssessmentTemplate', function () {
 
     it('uses the user-provided list if assessors set to "other"', function () {
       var result;
-      instance.attr('default_assessors', 'other');
+
+      instance.attr('default_people', {
+        assessors: 'other',
+        verifiers: 'Whatever'
+      });
+
       instance.attr('assessors_list', '  John,, Jack Mac,John,  Jill,  , ');
-      instance.attr('default_verifiers', 'Whatever');
 
       result = instance._packPeopleData();
 
@@ -183,8 +190,12 @@ describe('can.Model.AssessmentTemplate', function () {
 
     it('uses the user-provided list if verifiers set to "other"', function () {
       var result;
-      instance.attr('default_assessors', 'Whatever');
-      instance.attr('default_verifiers', 'other');
+
+      instance.attr('default_people', {
+        assessors: 'Whatever',
+        verifiers: 'other'
+      });
+
       instance.attr('verifiers_list', '  First, ,, Sec ond   ,First, Third ');
 
       result = instance._packPeopleData();
@@ -195,6 +206,54 @@ describe('can.Model.AssessmentTemplate', function () {
         assessors: 'Whatever',
         verifiers: ['First', 'Sec ond', 'Third']
       });
+    });
+  });
+
+  describe('_unpackPeopleData() method', function () {
+    it('converts the default assessors list to a string', function () {
+      instance.attr('default_people', {
+        assessors: new can.List([12, 5, 7])
+      });
+      instance.attr('assessors_list', '');
+
+      instance._unpackPeopleData();
+
+      expect(instance.assessors_list).toEqual('12, 5, 7');
+    });
+
+    it('sets the default assessors option to "other" if needed', function () {
+      // this is needed when the default assessors setting is actually
+      // a list of User IDs...
+      instance.attr('default_people', {
+        assessors: new can.List([12, 5, 7])
+      });
+
+      instance._unpackPeopleData();
+
+      expect(instance.default_people.assessors).toEqual('other');
+    });
+
+    it('converts the default verifiers list to a string', function () {
+      instance.attr('default_people', {
+        verifiers: new can.List([12, 5, 7])
+      });
+      instance.attr('verifiers_list', '');
+
+      instance._unpackPeopleData();
+
+      expect(instance.verifiers_list).toEqual('12, 5, 7');
+    });
+
+    it('sets the default verifiers option to "other" if needed', function () {
+      // this is needed when the default verifiers setting is actually
+      // a list of User IDs...
+      instance.attr('default_people', {
+        verifiers: new can.List([12, 5, 7])
+      });
+
+      instance._unpackPeopleData();
+
+      expect(instance.default_people.verifiers).toEqual('other');
     });
   });
 });

--- a/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
@@ -5,192 +5,198 @@
   Maintained By: peter@reciprocitylabs.com
 }}
 
-<div class="row-fluid">
-  <div class="span6">
-    <label>Audit</label>
-    <strong>{{object_params.audit_title}}</strong>
-  </div>
-</div>
+<div class="hideable-holder">
+  <form action="javascript://">
+    {{> /static/mustache/base_objects/form_restore.mustache}}
 
-<br />
+    <div class="row-fluid">
+      <div class="span6">
+        <label>Audit</label>
+        <strong>{{object_params.audit_title}}</strong>
+      </div>
+    </div>
 
-<div class="row-fluid choose-object">
-  <div class="span12">
-    <label>
-      Objects under assessment
-    </label>
+    <br />
 
-    {{#add_to_current_scope objectTypes=instance._objectTypes}}
-    <select
-      class="input-medium pull-left"
-      can-value="objectTypes.type"
-      name="template_object_type">
-      {{#each objectTypes}}
-        {{#if items}}
-          {{#if items.length}}
-          <optgroup label="{{name}}">
-            {{#each items}}
-              {{#if name}}
-                <option value="{{value}}" label="{{name}}"></option>
+    <div class="row-fluid choose-object">
+      <div class="span12">
+        <label>
+          Objects under assessment
+        </label>
+
+        {{#add_to_current_scope objectTypes=instance._objectTypes}}
+        <select
+          class="input-medium pull-left"
+          can-value="instance.template_object_type">
+          {{#each objectTypes}}
+            {{#if items}}
+              {{#if items.length}}
+              <optgroup label="{{name}}">
+                {{#each items}}
+                  {{#if name}}
+                    <option value="{{value}}" label="{{name}}"></option>
+                  {{/if}}
+                {{/each}}
+              </optgroup>
               {{/if}}
-            {{/each}}
-          </optgroup>
-          {{/if}}
-        {{/if}}
-      {{/each}}
-    </select>
-    {{/add_to_current_scope}}
-
-    <label class="inline-check pull-left">
-      <input type="checkbox"
-        name="test_plan_procedure"
-        class="js-toggle-controlplans">
-      Use control test plans as procedures
-    </label>
-  </div>
-</div>
-
-<div class="row-fluid">
-  <div class="span6">
-    <label>
-      Default procedure
-      <i class="grcicon-help-black" rel="tooltip"
-        title="Provide more details on the purpose of this Assessment and
-               provide context for how and when this CA might be used."></i>
-      <a data-id="hide_description_lk" href="javascript://"
-        class="field-hide">hide</a>
-    </label>
-    <div class="wysiwyg-area">
-      <textarea tabindex="2" id="system_description"
-        class="span12 triple wysihtml5"
-        name="procedure_description"
-        placeholder="Enter Description"></textarea>
-    </div>
-  </div>
-
-  <div class="span6">
-    <div class="row-fluid choose-from-select">
-      <div class="span6 bottom-spacing">
-        <label>
-          Default Assessors
-          <span class="required">*</span>
-        </label>
-
-        <select
-          name="default_assessors"
-          class="input-block-level js-toggle-field"
-          can-value="">
-          <option value="Object Owners">Object Owners</option>
-          <option value="Audit Lead">Audit Lead</option>
-          <option value="Object Contact">Object Contact</option>
-          <option value="Primary Assessor">Primary Assessor</option>
-          <option value="Secondary Assessors">Secondary Assessors</option>
-          <option value="other">Others...</option>
+            {{/if}}
+          {{/each}}
         </select>
+        {{/add_to_current_scope}}
+
+        <label class="inline-check pull-left">
+          <input type="checkbox"
+            can-value="instance.test_plan_procedure"
+            class="js-toggle-controlplans">
+          Use control test plans as procedures
+        </label>
+      </div>
+    </div>
+
+    <div class="row-fluid">
+      <div class="span6">
+        <label>
+          Default procedure
+          <i class="grcicon-help-black" rel="tooltip"
+            title="Provide more details on the purpose of this Assessment and
+                   provide context for how and when this CA might be used."></i>
+          <a data-id="hide_description_lk" href="javascript://"
+            class="field-hide">hide</a>
+        </label>
+        <div class="wysiwyg-area">
+          <textarea
+            id="system_description"
+            can-value="instance.procedure_description"
+            class="span12 triple wysihtml5"
+            placeholder="Enter Description"
+            tabindex="2"
+            ></textarea>
+        </div>
       </div>
 
       <div class="span6">
-        <label>&nbsp;</label>
-        <input type="text"
-          name="assessors_list"
-          class="input-block-level choose-input choose-assessor"
-          placeholder="Add person 1, Add person 2...">
+        <div class="row-fluid choose-from-select">
+          <div class="span6 bottom-spacing">
+            <label>
+              Default Assessors
+              <span class="required">*</span>
+            </label>
+
+            <select
+              can-value="instance.default_people.assessors"
+              class="input-block-level js-toggle-field">
+              <option value="Object Owners">Object Owners</option>
+              <option value="Audit Lead">Audit Lead</option>
+              <option value="Object Contact">Object Contact</option>
+              <option value="Primary Assessor">Primary Assessor</option>
+              <option value="Secondary Assessors">Secondary Assessors</option>
+              <option value="other">Others...</option>
+            </select>
+          </div>
+
+          <div class="span6">
+            <label>&nbsp;</label>
+            <input type="text"
+              can-value="instance.assessors_list"
+              class="input-block-level choose-input choose-assessor"
+              placeholder="Add person 1, Add person 2...">
+          </div>
+        </div>
+
+        <div class="row-fluid choose-from-select">
+          <div class="span6 bottom-spacing">
+            <label>
+              Default Verifier
+              <span class="required">*</span>
+            </label>
+
+            <select
+              can-value="instance.default_people.verifiers"
+              class="input-block-level js-toggle-field">
+              <option value="Object Owners">Object Owners</option>
+              <option value="Audit Lead">Audit Lead</option>
+              <option value="Object Contact">Object Contact</option>
+              <option value="Primary Assessor">Primary Assessor</option>
+              <option value="Secondary Assessors">Secondary Assessors</option>
+              <option value="other">Others...</option>
+            </select>
+          </div>
+
+          <div class="span6">
+            <label>&nbsp;</label>
+            <input type="text"
+              can-value="instance.verifiers_list"
+              class="input-block-level choose-input choose-verifier"
+              placeholder="Add person 1, Add person 2...">
+          </div>
+        </div>
       </div>
     </div>
 
-    <div class="row-fluid choose-from-select">
-      <div class="span6 bottom-spacing">
-        <label>
-          Default Verifier
-          <span class="required">*</span>
-        </label>
+    <div class="custom-attr-wrap define-attr">
 
-        <select
-          name="default_verifiers"
-          class="input-block-level js-toggle-field"
-          can-value="">
-          <option value="Object Owners">Object Owners</option>
-          <option value="Audit Lead">Audit Lead</option>
-          <option value="Object Contact">Object Contact</option>
-          <option value="Primary Assessor">Primary Assessor</option>
-          <option value="Secondary Assessors">Secondary Assessors</option>
-          <option value="other">Others...</option>
-        </select>
+      <div class="row-fluid">
+        <div class="span12">
+          <div class="info-expand">
+            <a class="show-hidden-fields info-show-hide" href="javascript://">
+              <span class="out">
+                <i class="fa fa-caret-right"></i>
+                Custom attributes
+              </span>
+              <span class="in">
+                <i class="fa fa-caret-down"></i>
+                Custom attributes
+              </span>
+            </a>
+          </div>
+        </div>
       </div>
 
-      <div class="span6">
-        <label>&nbsp;</label>
-        <input type="text"
-          name="verifiers_list"
-          class="input-block-level choose-input choose-verifier"
-          placeholder="Add person 1, Add person 2...">
+      <div class="hidden-fields-area">
+        <div class="row-fluid wrap-row">
+          <div class="custom-attr-list span12">
+            <assessment-template-attributes>
+              <div class="attr-titles">
+                <ul>
+                  <li class="row-fluid">
+                    <div class="span-custom2-and-half">
+                      <h6>Attribute Title</h6>
+                    </div>
+                    <div class="span-custom1-and-half">
+                      <h6>Attribute type</h6>
+                    </div>
+                    <div class="span2">
+                      <h6>Attribute values</h6>
+                    </div>
+                    <div class="span2 centered">
+                      <h6>Attachment required</h6>
+                    </div>
+                    <div class="span-custom1-and-half centered">
+                      <h6>Comment required</h6>
+                    </div>
+                    <div class="span-custom1-and-half centered">
+                      <h6>Mandatory</h6>
+                    </div>
+                    <div class="span-custom1-and-half">
+                      &nbsp;
+                    </div>
+                  </li>
+                </ul>
+              </div>
+              <div class="new-attr-list">
+                <ul>
+                  <add-template-filed fields="fields">
+                  </add-template-filed>
+                  {{#fields}}
+                    <template-filed field="." fields="fields"></template-filed>
+                  {{/fields}}
+                </ul>
+              </div>
+            </assessment-template-attributes>
+          </div>
+        </div>
       </div>
-    </div>
-  </div>
+    </div><!-- custom-attr-wrap end -->
+
+ </form>
 </div>
-
-<div class="custom-attr-wrap define-attr">
-
-  <div class="row-fluid">
-    <div class="span12">
-      <div class="info-expand">
-        <a class="show-hidden-fields info-show-hide" href="javascript://">
-          <span class="out">
-            <i class="fa fa-caret-right"></i>
-            Custom attributes
-          </span>
-          <span class="in">
-            <i class="fa fa-caret-down"></i>
-            Custom attributes
-          </span>
-        </a>
-      </div>
-    </div>
-  </div>
-
-  {{! <div class="hidden-fields-area" style="display:none;"> }}
-  <div class="hidden-fields-area">
-    <div class="row-fluid wrap-row">
-      <div class="custom-attr-list span12">
-        <assessment-template-attributes>
-          <div class="attr-titles">
-            <ul>
-              <li class="row-fluid">
-                <div class="span-custom2-and-half">
-                  <h6>Attribute Title</h6>
-                </div>
-                <div class="span-custom1-and-half">
-                  <h6>Attribute type</h6>
-                </div>
-                <div class="span2">
-                  <h6>Attribute values</h6>
-                </div>
-                <div class="span2 centered">
-                  <h6>Attachment required</h6>
-                </div>
-                <div class="span-custom1-and-half centered">
-                  <h6>Comment required</h6>
-                </div>
-                <div class="span-custom1-and-half centered">
-                  <h6>Mandatory</h6>
-                </div>
-                <div class="span-custom1-and-half">
-                  &nbsp;
-                </div>
-              </li>
-            </ul>
-          </div>
-          <div class="new-attr-list">
-            <ul>
-              <add-template-filed fields="fields">
-              </add-template-filed>
-              {{#fields}}
-                <template-filed field="." fields="fields"></template-filed>
-              {{/fields}}
-            </ul>
-          </div>
-        </assessment-template-attributes>
-      </div>
-    </div>
-  </div>
-</div><!-- custom-attr-wrap end -->


### PR DESCRIPTION
This populates AssessmentTemplate's the add/edit form, establishes proper two-way bindings between the form fields and the model, and basically makes the whole thing usable for editing existing objects.

Depends on #3657 