### PR TITLE
CORE-3155 Object level custom attribute definitions

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment_attributes.js
+++ b/src/ggrc/assets/javascripts/components/assessment_attributes.js
@@ -163,7 +163,7 @@
           multi_choice_options: values,
           opts: new can.Map()
         });
-        _.each(['title', 'multi_choice_options'], function (type) {
+        _.each(['title', 'values', 'multi_choice_options'], function (type) {
           selected.attr(type, '');
         });
       }

--- a/src/ggrc/assets/javascripts/components/assessment_attributes.js
+++ b/src/ggrc/assets/javascripts/components/assessment_attributes.js
@@ -34,16 +34,8 @@
        * Removes `field` from `fileds`
        */
       removeField: function (scope, el, ev) {
-        var fileds = scope.attr('fields');
-        var field = scope.attr('field');
-        var index = _.findIndex(fileds, function (item) {
-          return item.type === field.type && item.title === field.title;
-        });
-
         ev.preventDefault();
-        if (index !== -1) {
-          fileds.splice(index, 1);
-        }
+        scope.attr('_pending_delete', true);
       },
       /*
        * Split field values
@@ -52,9 +44,9 @@
        */
       attrs: function () {
         if (_.contains(['Person', 'Text'], this.field.attr('type'))) {
-          return [this.attr('field.values')];
+          return [this.attr('field.multi_choice_options')];
         }
-        return _.splitTrim(this.attr('field.values'), {
+        return _.splitTrim(this.attr('field.multi_choice_options'), {
           compact: true
         });
       }
@@ -110,11 +102,11 @@
 
         fields.push({
           title: title,
-          type: type,
-          values: values,
+          attribute_type: type,
+          multi_choice_options: values,
           opts: new can.Map()
         });
-        _.each(['title', 'values'], function (type) {
+        _.each(['title', 'multi_choice_options'], function (type) {
           selected.attr(type, '');
         });
       }

--- a/src/ggrc/assets/javascripts/components/assessment_attributes.js
+++ b/src/ggrc/assets/javascripts/components/assessment_attributes.js
@@ -51,6 +51,9 @@
        * @return {Array} attrs - Returns split values as an array
        */
       attrs: function () {
+        if (_.contains(['Person', 'Text'], this.field.attr('type'))) {
+          return [this.attr('field.values')];
+        }
         return _.splitTrim(this.attr('field.values'), {
           compact: true
         });
@@ -79,6 +82,7 @@
         type: 'Person',
         text: 'Type description'
       }],
+      valueAttrs: ['Dropdown', 'Checkbox', 'Radio'],
       /*
        * Create new field
        *
@@ -99,7 +103,8 @@
         }).join(',');
 
         ev.preventDefault();
-        if (!type || !values || !title) {
+        if (!type || !title ||
+            (_.contains(scope.valueAttrs, type) && !values)) {
           return;
         }
 

--- a/src/ggrc/assets/javascripts/components/assessment_attributes.js
+++ b/src/ggrc/assets/javascripts/components/assessment_attributes.js
@@ -75,6 +75,9 @@
       }, {
         type: 'Text',
         text: 'Type description'
+      }, {
+        type: 'Person',
+        text: 'Type description'
       }],
       /*
        * Create new field

--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -1088,8 +1088,7 @@
       default_people: {
         assessors: "Object Owners",
         verifiers: "Object Owners"
-      },
-      _template_attributes: new can.List()
+      }
     },
 
     /**
@@ -1126,6 +1125,9 @@
      *
      */
     form_preload: function (isNewObject) {
+      if (!this.custom_attribute_definitions) {
+        this.attr('custom_attribute_definitions', new can.List());
+      }
       this.attr('_objectTypes', this._choosableObjectTypes());
       this._unpackPeopleData();
     },

--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -1082,6 +1082,15 @@
       audit: 'CMS.Models.Audit.stub',
       context: 'CMS.Models.Context.stub'
     },
+    defaults: {
+      test_plan_procedure: false,
+      template_object_type: "Control",
+      default_people: {
+        assessors: "Object Owners",
+        verifiers: "Object Owners"
+      },
+      _template_attributes: new can.List()
+    },
 
     /**
      * Initialize the newly created object instance. Essentially just validate
@@ -1117,11 +1126,6 @@
      *
      */
     form_preload: function (isNewObject) {
-      if (isNewObject) {
-        this.attr('default_people', {});
-        this.attr('_template_attributes', new can.List());
-      }
-
       this.attr('_objectTypes', this._choosableObjectTypes());
       this._unpackPeopleData();
     },

--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -1119,6 +1119,7 @@
     form_preload: function (isNewObject) {
       if (isNewObject) {
         this.attr('default_people', {});
+        this.attr('_template_attributes', new can.List());
       }
 
       this.attr('_objectTypes', this._choosableObjectTypes());

--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -1238,6 +1238,7 @@
       });
 
       return objectTypes;
-    }
+    },
+    ignore_ca_errors: true
   });
 })(this.can);

--- a/src/ggrc/assets/javascripts/models/cacheable.js
+++ b/src/ggrc/assets/javascripts/models/cacheable.js
@@ -732,7 +732,7 @@ can.Model("can.Model.Cacheable", {
       }
     });
   },
-  load_custom_attribute_definitions: function loadAttrDefinitions() {
+  load_custom_attribute_definitions: function () {
     var definitions;
     if (this.attr('custom_attribute_definitions')) {
       return;

--- a/src/ggrc/assets/javascripts/models/cacheable.js
+++ b/src/ggrc/assets/javascripts/models/cacheable.js
@@ -731,14 +731,15 @@ can.Model("can.Model.Cacheable", {
         }
       }
     });
-  }
-  , load_custom_attribute_definitions: function custom_attribute_definitions() {
+  },
+  load_custom_attribute_definitions: function loadAttrDefinitions() {
     var definitions;
     if (this.attr('custom_attribute_definitions')) {
       return;
     }
-    definitions = can.map(GGRC.custom_attr_defs, function(def) {
-      if (def.definition_type && def.definition_type === this.constructor.table_singular) {
+    definitions = can.map(GGRC.custom_attr_defs, function (def) {
+      var idCheck = !def.definition_id || def.definition_id === this.id;
+      if (idCheck && def.definition_type === this.constructor.table_singular) {
         return def;
       }
     }.bind(this));

--- a/src/ggrc/assets/javascripts/models/cacheable.js
+++ b/src/ggrc/assets/javascripts/models/cacheable.js
@@ -758,7 +758,8 @@ can.Model("can.Model.Cacheable", {
       }
     }
     can.each(this.custom_attribute_definitions, function (definition) {
-      if (definition.mandatory) {
+
+      if (definition.mandatory && !this.ignore_ca_errors) {
         if (definition.attribute_type === 'Checkbox') {
           self.class.validate('custom_attributes.' + definition.id,
               function (val) {
@@ -768,7 +769,7 @@ can.Model("can.Model.Cacheable", {
           self.class.validateNonBlank('custom_attributes.' + definition.id);
         }
       }
-    });
+    }.bind(this));
     if (!this.custom_attributes) {
       this.attr('custom_attributes', new can.Map());
       can.each(this.custom_attribute_values, function (value) {

--- a/src/ggrc/assets/javascripts/models/mappings.js
+++ b/src/ggrc/assets/javascripts/models/mappings.js
@@ -814,7 +814,8 @@
     CustomAttributable: {
       custom_attribute_definitions: Search(function (binding) {
         return CMS.Models.CustomAttributeDefinition.findAll({
-          definition_type: binding.instance.root_object
+          definition_type: binding.instance.root_object,
+          definition_id: null
         });
       }, 'CustomAttributeDefinition')
     }

--- a/src/ggrc/assets/javascripts/pbc/workflow_controller.js
+++ b/src/ggrc/assets/javascripts/pbc/workflow_controller.js
@@ -42,6 +42,7 @@
           definition_type: "assessment_template",
           attribute_type: attr.attribute_type,
           multi_choice_options: attr.multi_choice_options,
+          mandatory: attr.mandatory,
           context: instance.context
         }).save();
       });
@@ -68,6 +69,7 @@
             definition_type: "assessment_template",
             attribute_type: attr.attribute_type,
             multi_choice_options: attr.multi_choice_options,
+            mandatory: attr.mandatory,
             context: instance.context
           }).save();
         });

--- a/src/ggrc/assets/javascripts/pbc/workflow_controller.js
+++ b/src/ggrc/assets/javascripts/pbc/workflow_controller.js
@@ -24,16 +24,27 @@
       }.bind(this));
     },
     '{CMS.Models.AssessmentTemplate} created': function (model, ev, instance) {
-      var auditDfd;
-
       if (!(instance instanceof CMS.Models.AssessmentTemplate)) {
         return;
       }
 
       this._after_pending_joins(instance, function () {
+        var auditDfd;
+        var attrDfd;
+
         auditDfd = this._create_relationship(instance,
             instance.audit, instance.audit.context);
-        instance.delay_resolving_save_until(auditDfd);
+        attrDfd = $.map(instance._template_attributes, function (attr) {
+          return new CMS.Models.CustomAttributeDefinition({
+            title: attr.title,
+            definition_id: instance.id,
+            definition_type: "assessment_template",
+            attribute_type: attr.type,
+            multi_choice_options: attr.values,
+            context: instance.context
+          }).save();
+        });
+        instance.delay_resolving_save_until($.when(auditDfd, attrDfd));
       }.bind(this));
     },
     '{CMS.Models.Issue} created': function (model, ev, instance) {

--- a/src/ggrc/assets/mustache/assessment_templates/attribute_add_field.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/attribute_add_field.mustache
@@ -21,11 +21,11 @@
   </div>
   <div class="span2 centered checkbox-wrap">
   </div>
-  <div class="span-custom1-and-half centered checkbox-wrap">
+  <div class="span1 centered checkbox-wrap">
   </div>
-  <div class="span-custom1-and-half centered checkbox-wrap">
+  <div class="span1 centered checkbox-wrap">
   </div>
-  <div class="span-custom1-and-half">
+  <div class="span2">
     <div class="pull-right">
       <a can-click="addField" class="btn btn-small btn-info" href="#">Add field</a>
     </div>

--- a/src/ggrc/assets/mustache/assessment_templates/attribute_field.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/attribute_field.mustache
@@ -25,7 +25,7 @@
     {{/attrs}}
   </div>
   <div class="span1 centered checkbox-wrap">
-    <input type="checkbox" can-value="field.opts.mandatory-{{title}}">
+    <input type="checkbox" can-value="field.mandatory">
   </div>
   <div class="span2">
     <div class="pull-right">

--- a/src/ggrc/assets/mustache/assessment_templates/attribute_field.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/attribute_field.mustache
@@ -18,15 +18,15 @@
       <input can-value="field.opts.attachment-{{.}}" type="checkbox">
     {{/attrs}}
   </div>
-  <div class="span-custom1-and-half centered checkbox-wrap">
+  <div class="span1 centered checkbox-wrap">
     {{#attrs}}
       <input can-value="field.opts.comment-{{.}}" type="checkbox">
     {{/attrs}}
   </div>
-  <div class="span-custom1-and-half centered checkbox-wrap">
+  <div class="span1 centered checkbox-wrap">
     <input type="checkbox" can-value="field.opts.mandatory-{{title}}">
   </div>
-  <div class="span-custom1-and-half">
+  <div class="span2">
     <div class="pull-right">
       {{! <a href="#"><i class="fa fa-pencil-square-o"></i></a> }}
       <a can-click="removeField" href="#"><i class="fa fa-trash"></i></a>

--- a/src/ggrc/assets/mustache/assessment_templates/attribute_field.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/attribute_field.mustache
@@ -5,9 +5,10 @@
   Maintained By: ivan@reciprocitylabs.com
 }}
 
+{{^field._pending_delete}}
 <li class="row-fluid">
   <div class="span-custom2-and-half">{{field.title}}</div>
-  <div class="span-custom1-and-half">{{field.type}}</div>
+  <div class="span-custom1-and-half">{{field.attribute_type}}</div>
   <div class="span2">
     {{#attrs}}
       <span class="block">{{.}}</span>
@@ -29,7 +30,10 @@
   <div class="span2">
     <div class="pull-right">
       {{! <a href="#"><i class="fa fa-pencil-square-o"></i></a> }}
+      {{#field}}
       <a can-click="removeField" href="#"><i class="fa fa-trash"></i></a>
+      {{/field}}
     </div>
   </div>
 </li>
+{{/field._pending_delete}}

--- a/src/ggrc/assets/mustache/assessment_templates/info.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/info.mustache
@@ -101,9 +101,6 @@
       </div>
 
     </div><!-- tier-content end -->
-
-    {{{render '/static/mustache/custom_attributes/info.mustache' instance=instance}}}
-
   </section>
 
   <div class="info-widget-footer">

--- a/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
@@ -179,13 +179,13 @@
                     <div class="span2 centered">
                       <h6>Attachment required</h6>
                     </div>
-                    <div class="span-custom1-and-half centered">
+                    <div class="span1 centered">
                       <h6>Comment required</h6>
                     </div>
-                    <div class="span-custom1-and-half centered">
+                    <div class="span1 centered">
                       <h6>Mandatory</h6>
                     </div>
-                    <div class="span-custom1-and-half">
+                    <div class="span2">
                       &nbsp;
                     </div>
                   </li>

--- a/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
@@ -163,7 +163,7 @@
       <div class="hidden-fields-area">
         <div class="row-fluid wrap-row">
           <div class="custom-attr-list span12">
-            <assessment-template-attributes fields="instance._template_attributes">
+            <assessment-template-attributes fields="instance.custom_attribute_definitions">
               <div class="attr-titles">
                 <ul>
                   <li class="row-fluid">

--- a/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
@@ -181,7 +181,7 @@
       <div class="hidden-fields-area">
         <div class="row-fluid wrap-row">
           <div class="custom-attr-list span12">
-            <assessment-template-attributes>
+            <assessment-template-attributes fields="instance._template_attributes">
               <div class="attr-titles">
                 <ul>
                   <li class="row-fluid">

--- a/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
@@ -160,24 +160,6 @@
     </div>
 
     <div class="custom-attr-wrap define-attr">
-
-      <div class="row-fluid">
-        <div class="span12">
-          <div class="info-expand">
-            <a class="show-hidden-fields info-show-hide" href="javascript://">
-              <span class="out">
-                <i class="fa fa-caret-right"></i>
-                Custom attributes
-              </span>
-              <span class="in">
-                <i class="fa fa-caret-down"></i>
-                Custom attributes
-              </span>
-            </a>
-          </div>
-        </div>
-      </div>
-
       <div class="hidden-fields-area">
         <div class="row-fluid wrap-row">
           <div class="custom-attr-list span12">

--- a/src/ggrc/migrations/versions/20160314155056_39aec99639d5_add_defintion_id_to_ca_definitions.py
+++ b/src/ggrc/migrations/versions/20160314155056_39aec99639d5_add_defintion_id_to_ca_definitions.py
@@ -1,0 +1,51 @@
+# Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+# Created By: anze@reciprocitylabs.com
+# Maintained By: anze@reciprocitylabs.com
+
+"""
+Add definition_id to custom attribute definitions
+
+Create Date: 2016-03-14 15:50:56.407589
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '39aec99639d5'
+down_revision = '204540106539'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  op.add_column('custom_attribute_definitions',
+                sa.Column('definition_id', sa.Integer(), nullable=True))
+  op.alter_column('custom_attribute_definitions', 'helptext',
+                  existing_type=mysql.VARCHAR(length=250), nullable=True)
+  op.create_index('ix_custom_attributes_definition',
+                  'custom_attribute_definitions',
+                  ['definition_type', 'definition_id'], unique=False)
+  op.drop_constraint(u'uq_custom_attribute',
+                     'custom_attribute_definitions', type_='unique')
+  op.create_unique_constraint('uq_custom_attribute',
+                              'custom_attribute_definitions',
+                              ['title', 'definition_type', 'definition_id'])
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  op.drop_constraint('uq_custom_attribute',
+                     'custom_attribute_definitions', type_='unique')
+  op.create_unique_constraint(u'uq_custom_attribute',
+                              'custom_attribute_definitions',
+                              ['title', 'definition_type'])
+  op.drop_index('ix_custom_attributes_definition',
+                table_name='custom_attribute_definitions')
+  op.alter_column('custom_attribute_definitions', 'helptext',
+                  existing_type=mysql.VARCHAR(length=250),
+                  nullable=False)
+  op.drop_column('custom_attribute_definitions', 'definition_id')

--- a/src/ggrc/migrations/versions/20160314155056_39aec99639d5_add_defintion_id_to_ca_definitions.py
+++ b/src/ggrc/migrations/versions/20160314155056_39aec99639d5_add_defintion_id_to_ca_definitions.py
@@ -24,6 +24,8 @@ def upgrade():
   """Add the new id field and fix some indexes/nullable issues."""
   op.add_column('custom_attribute_definitions',
                 sa.Column('definition_id', sa.Integer(), nullable=True))
+  op.add_column('custom_attribute_definitions',
+                sa.Column('multi_choice_mandatory', sa.Text(), nullable=True))
   op.alter_column('custom_attribute_definitions', 'helptext',
                   existing_type=mysql.VARCHAR(length=250), nullable=True)
   op.drop_constraint(u'uq_custom_attribute',
@@ -43,4 +45,5 @@ def downgrade():
   op.alter_column('custom_attribute_definitions', 'helptext',
                   existing_type=mysql.VARCHAR(length=250),
                   nullable=False)
+  op.drop_column('custom_attribute_definitions', 'multi_choice_mandatory')
   op.drop_column('custom_attribute_definitions', 'definition_id')

--- a/src/ggrc/migrations/versions/20160314155056_39aec99639d5_add_defintion_id_to_ca_definitions.py
+++ b/src/ggrc/migrations/versions/20160314155056_39aec99639d5_add_defintion_id_to_ca_definitions.py
@@ -17,7 +17,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '39aec99639d5'
-down_revision = '204540106539'
+down_revision = '9db8d85e82b'
 
 
 def upgrade():

--- a/src/ggrc/migrations/versions/20160314155056_39aec99639d5_add_defintion_id_to_ca_definitions.py
+++ b/src/ggrc/migrations/versions/20160314155056_39aec99639d5_add_defintion_id_to_ca_definitions.py
@@ -21,30 +21,25 @@ down_revision = '204540106539'
 
 
 def upgrade():
-  """Upgrade database schema and/or data, creating a new revision."""
+  """Add the new id field and fix some indexes/nullable issues."""
   op.add_column('custom_attribute_definitions',
                 sa.Column('definition_id', sa.Integer(), nullable=True))
   op.alter_column('custom_attribute_definitions', 'helptext',
                   existing_type=mysql.VARCHAR(length=250), nullable=True)
-  op.create_index('ix_custom_attributes_definition',
-                  'custom_attribute_definitions',
-                  ['definition_type', 'definition_id'], unique=False)
   op.drop_constraint(u'uq_custom_attribute',
                      'custom_attribute_definitions', type_='unique')
   op.create_unique_constraint('uq_custom_attribute',
                               'custom_attribute_definitions',
-                              ['title', 'definition_type', 'definition_id'])
+                              ['definition_type', 'definition_id', 'title'])
 
 
 def downgrade():
-  """Downgrade database schema and/or data back to the previous revision."""
+  """Remove the new id field and reintroduce some indexes/nullable issues."""
   op.drop_constraint('uq_custom_attribute',
                      'custom_attribute_definitions', type_='unique')
   op.create_unique_constraint(u'uq_custom_attribute',
                               'custom_attribute_definitions',
                               ['title', 'definition_type'])
-  op.drop_index('ix_custom_attributes_definition',
-                table_name='custom_attribute_definitions')
   op.alter_column('custom_attribute_definitions', 'helptext',
                   existing_type=mysql.VARCHAR(length=250),
                   nullable=False)

--- a/src/ggrc/models/custom_attribute_definition.py
+++ b/src/ggrc/models/custom_attribute_definition.py
@@ -14,8 +14,9 @@ from ggrc.models.custom_attribute_value import CustomAttributeValue
 class CustomAttributeDefinition(mixins.Base, mixins.Titled, db.Model):
   __tablename__ = 'custom_attribute_definitions'
 
-  definition_type = db.Column(db.String)
-  attribute_type = db.Column(db.String)
+  definition_type = db.Column(db.String, nullable=False)
+  definition_id = db.Column(db.Integer)
+  attribute_type = db.Column(db.String, nullable=False)
   multi_choice_options = db.Column(db.String)
   mandatory = db.Column(db.Boolean)
   helptext = db.Column(db.String)
@@ -24,11 +25,16 @@ class CustomAttributeDefinition(mixins.Base, mixins.Titled, db.Model):
   attribute_values = db.relationship('CustomAttributeValue',
                                      backref='custom_attribute')
 
-  __table_args__ = (UniqueConstraint(
-      'title', 'definition_type', name='_unique_attribute'),)
+  __table_args__ = (
+      UniqueConstraint('title', 'definition_type', 'definition_id',
+                       name='uq_custom_attribute'),
+      db.Index('ix_custom_attributes_definition',
+               'definition_type', 'definition_id'),
+      db.Index('ix_custom_attributes_title', 'title'))
 
   _publish_attrs = [
       'definition_type',
+      'definition_id',
       'attribute_type',
       'multi_choice_options',
       'mandatory',

--- a/src/ggrc/models/custom_attribute_definition.py
+++ b/src/ggrc/models/custom_attribute_definition.py
@@ -28,8 +28,6 @@ class CustomAttributeDefinition(mixins.Base, mixins.Titled, db.Model):
   __table_args__ = (
       UniqueConstraint('title', 'definition_type', 'definition_id',
                        name='uq_custom_attribute'),
-      db.Index('ix_custom_attributes_definition',
-               'definition_type', 'definition_id'),
       db.Index('ix_custom_attributes_title', 'title'))
 
   _publish_attrs = [

--- a/src/ggrc/models/custom_attribute_definition.py
+++ b/src/ggrc/models/custom_attribute_definition.py
@@ -18,6 +18,7 @@ class CustomAttributeDefinition(mixins.Base, mixins.Titled, db.Model):
   definition_id = db.Column(db.Integer)
   attribute_type = db.Column(db.String, nullable=False)
   multi_choice_options = db.Column(db.String)
+  multi_choice_mandatory = db.Column(db.String)
   mandatory = db.Column(db.Boolean)
   helptext = db.Column(db.String)
   placeholder = db.Column(db.String)
@@ -35,6 +36,7 @@ class CustomAttributeDefinition(mixins.Base, mixins.Titled, db.Model):
       'definition_id',
       'attribute_type',
       'multi_choice_options',
+      'multi_choice_mandatory',
       'mandatory',
       'helptext',
       'placeholder',

--- a/src/ggrc/models/custom_attribute_definition.py
+++ b/src/ggrc/models/custom_attribute_definition.py
@@ -27,7 +27,7 @@ class CustomAttributeDefinition(mixins.Base, mixins.Titled, db.Model):
                                      backref='custom_attribute')
 
   __table_args__ = (
-      UniqueConstraint('title', 'definition_type', 'definition_id',
+      UniqueConstraint('definition_type', 'definition_id', 'title',
                        name='uq_custom_attribute'),
       db.Index('ix_custom_attributes_title', 'title'))
 


### PR DESCRIPTION
This saves custom attribute definitions from assessment template to the database. It should be enough to unblock @hyperNURb's CORE-2966, but editing the assessment template is not yet functional.