### PR TITLE
QUICK-FIX Update pylint

### DIFF
--- a/bin/check
+++ b/bin/check
@@ -7,7 +7,6 @@
 set -o nounset
 set -o errexit
 
-TEMPLATE="{msg_id}:{line:3d},{column}: {obj}: {msg}"
 SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
 
 cd "${SCRIPTPATH}/../"
@@ -17,9 +16,7 @@ function py_files() {
 }
 
 if [[ $(py_files) ]]; then
-  py_files | xargs pylint --msg-template="$TEMPLATE"
+  py_files | xargs pylint
 else
   echo "No python files changed."
 fi
-
-# TODO: add jshint and jscs checks.

--- a/bin/check_pylint_diff
+++ b/bin/check_pylint_diff
@@ -40,13 +40,13 @@ git clean -xdfq
 git reset --hard HEAD
 
 if [[ "$ARG1" != "" ]]; then
-  TEST_COMMIT=$ARG1
+  TEST_COMMIT=$(git rev-parse HEAD)
+  PARENT_1=$ARG1
 else
   TEST_COMMIT=$(git rev-parse HEAD)
+  PARENT_1=$(git show --pretty=raw $TEST_COMMIT | grep parent | head -1 | grep -oE "[^ ]*$")
 fi
 
-CURRENT_COMMIT=$(git rev-parse HEAD)
-PARENT_1=$(git show --pretty=raw $TEST_COMMIT | grep parent | head -1 | grep -oE "[^ ]*$")
 
 echo "Comparing commits $TEST_COMMIT and $PARENT_1."
 

--- a/pylintrc
+++ b/pylintrc
@@ -90,7 +90,7 @@ evaluation=2 * error + warning + refactor + convention
 
 # Template used to display messages. This is a python new-style format string
 # used to format the message information. See doc for all details
-#msg-template=
+msg-template={msg_id}:{line:4d},{column}: {obj}: {msg} ({symbol})
 
 
 [BASIC]


### PR DESCRIPTION
The check_pylint_diff script used wrong commits while running
'check_pylint_diff develop' on a feature branch. This fix makes sure
that running that on a feature branch works as the help suggests and is
the same as running 'check_pylint_diff' on a merge commit from that
branch. And we want all pylint checks to display the same message template with
error codes.