### PR TITLE
QUICK-FIX Prevent potential infinite recursion bugs

### DIFF
--- a/src/ggrc/converters/handlers/handlers.py
+++ b/src/ggrc/converters/handlers/handlers.py
@@ -717,14 +717,16 @@ class ControlCategoryColumnHandler(CategoryColumnHandler):
 
   def __init__(self, row_converter, key, **options):
     self.category_base_type = "ControlCategory"
-    super(self.__class__, self).__init__(row_converter, key, **options)
+    super(ControlCategoryColumnHandler, self).__init__(
+        row_converter, key, **options)
 
 
 class ControlAssertionColumnHandler(CategoryColumnHandler):
 
   def __init__(self, row_converter, key, **options):
     self.category_base_type = "ControlAssertion"
-    super(self.__class__, self).__init__(row_converter, key, **options)
+    super(ControlAssertionColumnHandler, self).__init__(
+        row_converter, key, **options)
 
 
 class RequestColumnHandler(ParentColumnHandler):

--- a/src/ggrc/converters/handlers/related_person.py
+++ b/src/ggrc/converters/handlers/related_person.py
@@ -101,18 +101,21 @@ class RelatedAssigneesColumnHandler(RelatedPersonColumnHandler):
 
   def __init__(self, row_converter, key, **options):
     self._assignee_type = "Assignee"
-    super(self.__class__, self).__init__(row_converter, key, **options)
+    super(RelatedAssigneesColumnHandler, self).__init__(
+        row_converter, key, **options)
 
 
 class RelatedRequestersColumnHandler(RelatedPersonColumnHandler):
 
   def __init__(self, row_converter, key, **options):
     self._assignee_type = "Requester"
-    super(self.__class__, self).__init__(row_converter, key, **options)
+    super(RelatedRequestersColumnHandler, self).__init__(
+        row_converter, key, **options)
 
 
 class RelatedVerifiersColumnHandler(RelatedPersonColumnHandler):
 
   def __init__(self, row_converter, key, **options):
     self._assignee_type = "Verifier"
-    super(self.__class__, self).__init__(row_converter, key, **options)
+    super(RelatedVerifiersColumnHandler, self).__init__(
+        row_converter, key, **options)

--- a/src/ggrc_basic_permissions/converters/handlers.py
+++ b/src/ggrc_basic_permissions/converters/handlers.py
@@ -62,35 +62,40 @@ class ProgramOwnerColumnHandler(ObjectRoleColumnHandler):
 
   def __init__(self, row_converter, key, **options):
     self.role = Role.query.filter_by(name="ProgramOwner").one()
-    super(self.__class__, self).__init__(row_converter, key, **options)
+    super(ProgramOwnerColumnHandler, self).__init__(
+        row_converter, key, **options)
 
 
 class ProgramEditorColumnHandler(ObjectRoleColumnHandler):
 
   def __init__(self, row_converter, key, **options):
     self.role = Role.query.filter_by(name="ProgramEditor").one()
-    super(self.__class__, self).__init__(row_converter, key, **options)
+    super(ProgramEditorColumnHandler, self).__init__(
+        row_converter, key, **options)
 
 
 class ProgramReaderColumnHandler(ObjectRoleColumnHandler):
 
   def __init__(self, row_converter, key, **options):
     self.role = Role.query.filter_by(name="ProgramReader").one()
-    super(self.__class__, self).__init__(row_converter, key, **options)
+    super(ProgramReaderColumnHandler, self).__init__(
+        row_converter, key, **options)
 
 
 class WorkflowOwnerColumnHandler(ObjectRoleColumnHandler):
 
   def __init__(self, row_converter, key, **options):
     self.role = Role.query.filter_by(name="WorkflowOwner").one()
-    super(self.__class__, self).__init__(row_converter, key, **options)
+    super(WorkflowOwnerColumnHandler, self).__init__(
+        row_converter, key, **options)
 
 
 class WorkflowMemberColumnHandler(ObjectRoleColumnHandler):
 
   def __init__(self, row_converter, key, **options):
     self.role = Role.query.filter_by(name="WorkflowMember").one()
-    super(self.__class__, self).__init__(row_converter, key, **options)
+    super(WorkflowMemberColumnHandler, self).__init__(
+        row_converter, key, **options)
 
 
 class AuditAuditorColumnHandler(ObjectRoleColumnHandler):
@@ -98,12 +103,13 @@ class AuditAuditorColumnHandler(ObjectRoleColumnHandler):
   def __init__(self, row_converter, key, **options):
     self.role = Role.query.filter_by(name="Auditor").one()
     self.reader = Role.query.filter_by(name="ProgramReader").one()
-    super(self.__class__, self).__init__(row_converter, key, **options)
+    super(AuditAuditorColumnHandler, self).__init__(
+        row_converter, key, **options)
 
   def insert_object(self):
     if self.dry_run or not self.value:
       return
-    super(self.__class__, self).insert_object()
+    super(AuditAuditorColumnHandler, self).insert_object()
     user_roles = set(map(lambda ur: ur.person_id, self.get_program_roles()))
     context = self.row_converter.obj.program.context
     for auditor in self.value:


### PR DESCRIPTION
This fixes incorrect usages of `super()`. If any of the affected classes were subclassed, and their subclass would call `super(ChildClass, self).__init__()`, a _maximum recursion depth exceeded_ error would occur.

The reason is that when invoking `super(self.__class__, self)` in one of these classes, `self` would actually be an instance of `ChildClass`. Python would search for the right class, but starting from `self.__class__`, i.e. the `ChildClass`!

It would found the parent class, invoke its method, encountering and invoking `super(self.__class__, self).__init__()` again, causing an infinite recursion.