### PR TITLE
QUICK-FIX: Add cycle task to subtrees only if they are defined

### DIFF
--- a/src/ggrc_workflows/assets/javascripts/apps/workflows.js
+++ b/src/ggrc_workflows/assets/javascripts/apps/workflows.js
@@ -293,12 +293,14 @@
       treeWidgets[type] = treeWidgets[type].concat(['TaskGroup', 'Workflow',
         'CycleTaskEntry', 'CycleTaskGroupObjectTask', 'CycleTaskGroupObject',
         'CycleTaskGroup']);
-      subTrees[type].display_list = subTrees[type].display_list
-        .concat(['CycleTaskGroupObjectTask']);
-      subTrees[type].model_list = subTrees[type].model_list.concat({
-        display_name: CMS.Models.CycleTaskGroupObjectTask.title_singular,
-        display_status: true,
-        model_name: 'CycleTaskGroupObjectTask'});
+      if (!_.isEmpty(subTrees)) {
+        subTrees[type].display_list = subTrees[type].display_list
+          .concat(['CycleTaskGroupObjectTask']);
+        subTrees[type].model_list = subTrees[type].model_list.concat({
+          display_name: CMS.Models.CycleTaskGroupObjectTask.title_singular,
+          display_status: true,
+          model_name: 'CycleTaskGroupObjectTask'});
+      }
     });
 
     if (pageInstance instanceof CMS.Models.Workflow) {


### PR DESCRIPTION
There was an issue on the export page, where it didn't break anything, but it produced a console error. This fixes the console error.