### PR TITLE
CORE-3201 Show users with popover in request log

### DIFF
--- a/src/ggrc/assets/mustache/components/object_history/object_history.mustache
+++ b/src/ggrc/assets/mustache/components/object_history/object_history.mustache
@@ -14,7 +14,7 @@
 
           <div class="w-status">
             <span class="entry-author">
-              <a href="javascript://">{{madeBy}}</a>
+              {{{render '/static/mustache/people/popover.mustache' person=madeBy}}
               made changes &mdash; {{date updatedAt}}
             </span>
             <div class="clearfix">


### PR DESCRIPTION
I also refactored the history component to use plain JS objects and arrays
insted of the CanJS counterparts since some CanJS magic was modifying the data
and I don't think CanJS wrappers are needed here.