### PR TITLE
CORE-3312 Add title field to the AssessmentTemplate object

### DIFF
--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -1089,6 +1089,7 @@
      */
     init: function () {
       this._super.apply(this, arguments);
+      this.validateNonBlank('title');
     }
   }, {
     // the object types that are not relevant to the AssessmentTemplate,

--- a/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
@@ -10,6 +10,32 @@
     {{> /static/mustache/base_objects/form_restore.mustache}}
 
     <div class="row-fluid">
+      <div class="span6 {{#instance.computed_errors.title}}field-failure{{/instance.computed_errors.title}}">
+        <label>
+          Title
+          <span class="required">*</span>
+          <i
+            class="fa fa-question-circle"
+            rel="tooltip"
+            title="Give new {{model.model_plural}} a name that's easy to search for and indicates the main goals of this {{model.model_singular}}."
+            ></i>
+        </label>
+
+        <input
+          data-id="title_txtbx" tabindex="1" class="input-block-level"
+          placeholder="Enter Title"
+          name="title"
+          type="text"
+          can-value="instance.title"
+          autofocus>
+
+        {{#instance.computed_errors.title}}
+          <label class="help-inline warning">{{this}}</label>
+        {{/instance.computed_errors.title}}
+      </div>
+    </div>
+
+    <div class="row-fluid">
       <div class="span6">
         <label>Audit</label>
         <strong>{{object_params.audit_title}}</strong>

--- a/src/ggrc/migrations/versions/20160322211955_9db8d85e82b_add_title_to_assessmenttemplate.py
+++ b/src/ggrc/migrations/versions/20160322211955_9db8d85e82b_add_title_to_assessmenttemplate.py
@@ -1,0 +1,40 @@
+# Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+# Created By: peter@reciprocitylabs.com
+# Maintained By: peter@reciprocitylabs.com
+
+"""
+Add title to AssessmentTemplate
+
+Create Date: 2016-03-22 21:19:55.013833
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+import sqlalchemy as sa
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '9db8d85e82b'
+down_revision = '204540106539'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision.
+
+  The function adds the title column to the assessment_templates table.
+  """
+  op.add_column(
+      "assessment_templates",
+      sa.Column("title", sa.String(length=250), nullable=False, unique=False)
+  )
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision.
+
+  The function drops the assessment_template table's title column.
+  """
+  op.drop_column("assessment_templates", "title")

--- a/src/ggrc/models/assessment_template.py
+++ b/src/ggrc/models/assessment_template.py
@@ -6,12 +6,12 @@
 """A module containing the implementation of the assessment template entity."""
 
 from ggrc import db
-from ggrc.models.mixins import Base
+from ggrc.models.mixins import Base, Titled
 from ggrc.models.relationship import Relatable
 from ggrc.models.types import JsonType
 
 
-class AssessmentTemplate(Base, Relatable, db.Model):
+class AssessmentTemplate(Base, Relatable, Titled, db.Model):
   """A class representing the assessment template entity.
 
   An Assessment Template is a template that allows users for easier creation of
@@ -34,10 +34,12 @@ class AssessmentTemplate(Base, Relatable, db.Model):
   # within the releated audit
   default_people = db.Column(JsonType, nullable=False)
 
+  _title_uniqueness = False
+
   # REST properties
   _publish_attrs = [
-      'template_object_type',
-      'test_plan_procedure',
-      'procedure_description',
-      'default_people',
+      "template_object_type",
+      "test_plan_procedure",
+      "procedure_description",
+      "default_people",
   ]


### PR DESCRIPTION
The title says it all.

The title is not  required to be unique, because users might not even know what other AssessmentTemplates exist when creating their owns for their Audits, thus they probably shouldn't guess which AssessmentTemplate titles are already taken (makes sense?).