### PR TITLE
CORE-3367 Show object display names in request log mappings

### DIFF
--- a/src/ggrc/assets/javascripts/components/object_history/object_history.js
+++ b/src/ggrc/assets/javascripts/components/object_history/object_history.js
@@ -295,11 +295,21 @@
     _mappingChange: function (revision, chain) {
       var object = revision.destination_type === this._INSTANCE_TYPE ?
                    revision.source : revision.destination;
-      var fieldName = ('Mapping to ' + object.type + ': ' +
-                                       object.display_name());
-      var origVal = '—';
-      var newVal = _.capitalize(revision.action);
-      var previous = chain[_.findIndex(chain, revision) - 1];
+      var displayName;
+      var fieldName;
+      var origVal;
+      var newVal;
+      var previous;
+
+      if (object instanceof can.Stub) {
+        object = object.reify();
+      }
+
+      displayName = object.display_name() || object.description;
+      fieldName = 'Mapping to ' + object.type + ': ' + displayName;
+      origVal = '—';
+      newVal = _.capitalize(revision.action);
+      previous = chain[_.findIndex(chain, revision) - 1];
       if (revision.action !== 'deleted' &&
           _.exists(revision.content, 'attrs.AssigneeType')) {
         newVal = revision.content.attrs.AssigneeType;

--- a/src/ggrc/assets/javascripts/components/object_history/tests/object_history_spec.js
+++ b/src/ggrc/assets/javascripts/components/object_history/tests/object_history_spec.js
@@ -553,21 +553,25 @@ describe('GGRC.Components.objectHistory', function () {
           modified_by: 'User 17',
           updated_at: new Date('2015-05-17 17:24:01'),
           action: 'created',
-          source_id: 123,
-          source_type: 'ObjectFoo',
-          destination_id: 99,
-          destination_type: 'OtherObject'
+          destination: {
+            type: 'Other',
+            display_name: function () {
+              return 'OtherObject';
+            }
+          },
+          source_id: 99,
+          source_type: 'OtherObject'
         };
 
-        var result = method(revision);
+        var result = method(revision, [revision]);
 
         expect(result).toEqual({
           madeBy: "User 17",
           updatedAt: new Date('2015-05-17 17:24:01'),
-          mapping: {
-            action: 'Created',
-            relatedObjId: 99,
-            relatedObjType: 'OtherObject'
+          changes: {
+            origVal: '—',
+            newVal: 'Created',
+            fieldName: 'Mapping to Other: OtherObject'
           }
         });
       }
@@ -580,21 +584,25 @@ describe('GGRC.Components.objectHistory', function () {
           modified_by: 'User 17',
           updated_at: new Date('2015-05-17 17:24:01'),
           action: 'deleted',
-          source_id: 99,
-          source_type: 'OtherObject',
+          source: {
+            type: 'Other',
+            display_name: function () {
+              return 'OtherObject';
+            }
+          },
           destination_id: 123,
           destination_type: 'ObjectFoo'
         };
 
-        var result = method(revision);
+        var result = method(revision, [revision]);
 
         expect(result).toEqual({
-          madeBy: 'User 17',
+          madeBy: "User 17",
           updatedAt: new Date('2015-05-17 17:24:01'),
-          mapping: {
-            action: 'Deleted',
-            relatedObjId: 99,
-            relatedObjType: 'OtherObject'
+          changes: {
+            origVal: '—',
+            newVal: 'Deleted',
+            fieldName: 'Mapping to Other: OtherObject'
           }
         });
       }

--- a/src/ggrc/assets/mustache/components/object_history/object_history.mustache
+++ b/src/ggrc/assets/mustache/components/object_history/object_history.mustache
@@ -50,7 +50,7 @@
                   that the entry is about a change of an instance's mapping }}
               <div class="clearfix">
                 <div class="third-col">
-                  Mapping to {{relatedObjType}} {{relatedObjId}}
+                  Mapping to {{object.type}}: {{object.display_name}}
                 </div>
                 <div class="third-col">
                   &mdash;

--- a/src/ggrc/assets/mustache/components/object_history/object_history.mustache
+++ b/src/ggrc/assets/mustache/components/object_history/object_history.mustache
@@ -30,8 +30,6 @@
             </div>
 
             {{#changes}}
-              {{! the presence of the "changes" list indicates that the
-                  entry is about the change to the instance itself }}
               <div class="clearfix">
                 <div class="third-col">
                   {{fieldName}}
@@ -45,21 +43,6 @@
               </div>
             {{/changes}}
 
-            {{#mapping}}
-              {{! alternatively, the presence of the "mapping" object indicates
-                  that the entry is about a change of an instance's mapping }}
-              <div class="clearfix">
-                <div class="third-col">
-                  Mapping to {{object.type}}: {{object.display_name}}
-                </div>
-                <div class="third-col">
-                  &mdash;
-                </div>
-                <div class="third-col">
-                  {{action}}
-                </div>
-              </div>
-            {{/mapping}}
           </div>
         </li>
       {{/entries}}

--- a/src/ggrc/models/relationship.py
+++ b/src/ggrc/models/relationship.py
@@ -4,11 +4,8 @@
 # Maintained By: david@reciprocitylabs.com
 
 from ggrc import db
-from ggrc.models.mixins import Base
-from ggrc.models.mixins import Described
 from ggrc.models.mixins import Identifiable
 from ggrc.models.mixins import Mapping
-from ggrc.models.mixins import deferred
 from sqlalchemy import or_, and_
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.ext.declarative import declared_attr
@@ -134,6 +131,12 @@ class Relationship(Mapping, db.Model):
   def _display_name(self):
     return "{}:{} <-> {}:{}".format(self.source_type, self.source_id,
                                     self.destination_type, self.destination_id)
+
+  def log_json(self):
+    json = super(Relationship, self).log_json()
+    # manually add attrs since the base log_json only captures table columns
+    json["attrs"] = self.attrs.copy()  # copy in order to detach from orm
+    return json
 
 
 class Relatable(object):


### PR DESCRIPTION
In this PR:
- fetch mapped objects and use `display_name`s for human-friendlines
- fix `Relationship` to store `attrs` in `Revision`
- unify `change` format between fields and mappings (for more flexibility and cleaner template)
- display assignee roles in mappings history
- access mapping history (already fetched) to show original value for assignee roles