### PR TITLE
CORE-3204 Format date fields in request log 

### DIFF
--- a/src/ggrc/assets/javascripts/components/object_history/object_history.js
+++ b/src/ggrc/assets/javascripts/components/object_history/object_history.js
@@ -225,10 +225,10 @@
           // format date fields
           if (this._DATE_FIELDS[fieldName]) {
             if (value) {
-              value = Mustache._helpers.date.fn(value);
+              value = GGRC.Utils.formatDate(value);
             }
             if (origVal) {
-              origVal = Mustache._helpers.date.fn(origVal);
+              origVal = GGRC.Utils.formatDate(origVal);
             }
           }
           diff.changes.push({

--- a/src/ggrc/assets/javascripts/components/object_history/object_history.js
+++ b/src/ggrc/assets/javascripts/components/object_history/object_history.js
@@ -225,10 +225,10 @@
           // format date fields
           if (this._DATE_FIELDS[fieldName]) {
             if (value) {
-              value = GGRC.Utils.formatDate(value);
+              value = GGRC.Utils.formatDate(value, true);
             }
             if (origVal) {
-              origVal = GGRC.Utils.formatDate(origVal);
+              origVal = GGRC.Utils.formatDate(origVal, true);
             }
           }
           diff.changes.push({

--- a/src/ggrc/assets/javascripts/components/object_history/object_history.js
+++ b/src/ggrc/assets/javascripts/components/object_history/object_history.js
@@ -29,6 +29,17 @@
     // the type of the object the component is operating on
     _INSTANCE_TYPE: null,
 
+    _DATE_FIELDS: Object.freeze({
+      created_at: 1,
+      updated_at: 1,
+      start_date: 1,
+      end_date: 1,
+      requested_on: 1,
+      due_on: 1,
+      finished_date: 1,
+      verified_date: 1
+    }),
+
     /**
      * The component's entry point. Invoked when a new component instance has
      * been created.
@@ -211,13 +222,22 @@
         }
 
         if (displayName && value !== origVal) {
+          // format date fields
+          if (this._DATE_FIELDS[fieldName]) {
+            if (value) {
+              value = Mustache._helpers.date.fn(value);
+            }
+            if (origVal) {
+              origVal = Mustache._helpers.date.fn(origVal);
+            }
+          }
           diff.changes.push({
             fieldName: displayName,
             origVal: origVal,
             newVal: value
           });
         }
-      });
+      }.bind(this));
 
       return diff;
     },

--- a/src/ggrc/assets/javascripts/components/object_history/tests/object_history_spec.js
+++ b/src/ggrc/assets/javascripts/components/object_history/tests/object_history_spec.js
@@ -328,7 +328,7 @@ describe('GGRC.Components.objectHistory', function () {
           }
         };
 
-        var result = method(rev1, rev2);
+        var result = method.call({_DATE_FIELDS: {}}, rev1, rev2);
 
         expectedChangeList = [{
           fieldName: 'Object Name',

--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -1214,18 +1214,7 @@ Mustache.registerHelper("link_to_tree", function () {
  *    * datetime (MM/DD/YYYY hh:mm:ss [PM|AM] [local timezone])
  */
 Mustache.registerHelper('date', function (date, hideTime) {
-  var currentTimezone = moment.tz.guess();
-  var m;
-
-  if (date === undefined || date === null) {
-    return '';
-  }
-
-  m = moment(new Date(date.isComputed ? date() : date));
-  if (hideTime === true) {
-    return m.format('MM/DD/YYYY');
-  }
-  return m.tz(currentTimezone).format('MM/DD/YYYY hh:mm:ss A z');
+  return GGRC.Utils.formatDate(date, hideTime);
 });
 
 /**

--- a/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
+++ b/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
@@ -18,6 +18,20 @@
       }
       return date.toDate();
     },
+    formatDate: function (date, hideTime) {
+      var currentTimezone = moment.tz.guess();
+      var m;
+
+      if (date === undefined || date === null) {
+        return '';
+      }
+
+      m = moment(new Date(date.isComputed ? date() : date));
+      if (hideTime === true) {
+        return m.format('MM/DD/YYYY');
+      }
+      return m.tz(currentTimezone).format('MM/DD/YYYY hh:mm:ss A z');
+    },
     getPickerElement: function (picker) {
       return _.find(_.values(picker), function (val) {
         if (val instanceof Node) {


### PR DESCRIPTION
Using `date` mustache helper to be consistent with other dates.

I listed other date fields that are not (yet!) present on the Request object to catch future use cases.