### PR TITLE
CORE-3395 Limit permission scope for GDrive

### DIFF
--- a/src/ggrc_gdrive_integration/assets/javascripts/controllers/gdrive_workflows_controller.js
+++ b/src/ggrc_gdrive_integration/assets/javascripts/controllers/gdrive_workflows_controller.js
@@ -239,7 +239,7 @@
 
       'a[data-toggle=gdrive-picker] click' : function (el, ev) {
 
-        var dfd = GGRC.Controllers.GAPI.authorize(['https://www.googleapis.com/auth/drive']),
+        var dfd = GGRC.Controllers.GAPI.authorize(['https://www.googleapis.com/auth/drive.file']),
           folder_id = el.data('folder-id');
         dfd.then(function () {
           gapi.load('picker', {'callback': createPicker});
@@ -485,7 +485,7 @@
         }
 
         verify_dfd.done(function () {
-          dfd = GGRC.Controllers.GAPI.authorize(['https://www.googleapis.com/auth/drive']);
+          dfd = GGRC.Controllers.GAPI.authorize(['https://www.googleapis.com/auth/drive.file']);
           dfd.then(function () {
             gapi.load('picker', {'callback': createPicker});
           });

--- a/src/ggrc_gdrive_integration/assets/javascripts/models/gdrive_models.js
+++ b/src/ggrc_gdrive_integration/assets/javascripts/models/gdrive_models.js
@@ -7,7 +7,7 @@
 
 (function(can) {
 
-var scopes = ['https://www.googleapis.com/auth/drive', 'https://www.googleapis.com/auth/apps.groups.settings'];
+var scopes = ['https://www.googleapis.com/auth/drive.file', 'https://www.googleapis.com/auth/apps.groups.settings'];
 
 /**
   create a search query that matches the expected format for GDrive API.


### PR DESCRIPTION
Now ggrc will only have access to publicly accessible files
in GDrive and files created or shared with the app. The app
will no longer have full access to user's GDrive.