### PR TITLE
CORE-3305 Allow picking AssessmentTemplate in multimapper

### DIFF
--- a/src/ggrc/assets/javascripts/models/mappings.js
+++ b/src/ggrc/assets/javascripts/models/mappings.js
@@ -606,7 +606,7 @@
         requests: 'Request',
         _program: 'Program',
         context: 'Context',
-        related_objects_as_source: ['Assessment', 'Issue']
+        related_objects_as_source: ['Assessment', 'AssessmentTemplate', 'Issue']
       },
       requests: Direct("Request", "audit", "requests"),
       active_requests: CustomFilter('requests', function (result) {

--- a/src/ggrc/assets/mustache/modals/mapper/base.mustache
+++ b/src/ggrc/assets/mustache/modals/mapper/base.mustache
@@ -25,18 +25,44 @@
           ^if_equals" mapper.type "AllObject" "\
           and ^if" mapper.search_only}}
           {{#is_allowed 'create' mapper.model.singular context=null}}
-            <a
-               class="btn btn-small btn-draft"
-               href="javascript://"
-               data-toggle="modal-ajax-form"
-               data-modal-class="modal-wide"
-               data-object-singular="{{mapper.model.singular}}"
-               data-object-plural="{{mapper.model.plural}}"
-               data-join-object-id="{{mapper.join_object_id}}"
-            >
-              <i class="fa fa-plus-circle"></i>
-              Create New {{mapper.model.title_singular}}
-            </a>
+
+            {{#if_equals mapper.type 'AssessmentTemplate'}}
+              <a
+                class="btn btn-small btn-draft"
+                href="javascript://"
+                data-toggle="modal-ajax-form"
+                data-modal-class="modal-wide"
+                data-object-singular="{{model_info 'AssessmentTemplate' 'model_singular'}}"
+                data-object-plural="{{model_info 'AssessmentTemplate' 'root_collection'}}"
+                data-object-params='{
+                  "audit": {
+                      "id": {{mapper.get_instance.id}},
+                      "type": "{{mapper.get_instance.type}}"
+                  },
+                  "context": {
+                      "id": {{mapper.get_instance.context.id}},
+                      "type": "{{json_escape mapper.get_instance.context.type}}"
+                  },
+                  "audit_title": "{{json_escape mapper.get_instance.title}}"
+                }'
+                data-join-object-id="{{mapper.join_object_id}}">
+                <i class="fa fa-plus-circle"></i>
+                Create New {{mapper.model.title_singular}}
+              </a>
+            {{else}}
+              <a
+                 class="btn btn-small btn-draft"
+                 href="javascript://"
+                 data-toggle="modal-ajax-form"
+                 data-modal-class="modal-wide"
+                 data-object-singular="{{mapper.model.singular}}"
+                 data-object-plural="{{mapper.model.plural}}"
+                 data-join-object-id="{{mapper.join_object_id}}">
+                <i class="fa fa-plus-circle"></i>
+                Create New {{mapper.model.title_singular}}
+              </a>
+            {{/if_equals}}
+
           {{/is_allowed}}
         {{/if_helpers}}
       </div>


### PR DESCRIPTION
Not the most elegant solution (added a special case for AssessmentTemplates to the base mapper modal template), but according to @hyperNURb the most sensible case to do nevertheless.

There is a slight issue with previewing AssessmentTemplate objects in the modal (sometimes it does not work), but I was told this is outside the scope of this PR, since it seems to be a bug in the multimapper itself - the important thing is that creating new AssessmentTemplates and mapping them to an Audit now works.