### PR TITLE
CORE-3400 Hide empty diff entries in request log

### DIFF
--- a/src/ggrc/assets/javascripts/components/object_history/object_history.js
+++ b/src/ggrc/assets/javascripts/components/object_history/object_history.js
@@ -252,11 +252,13 @@
               origVal = GGRC.Utils.formatDate(origVal, true);
             }
           }
-          diff.changes.push({
-            fieldName: displayName,
-            origVal: origVal || "—",
-            newVal: value || "—"
-          });
+          if (origVal || value) {
+            diff.changes.push({
+              fieldName: displayName,
+              origVal: origVal || "—",
+              newVal: value || "—"
+            });
+          }
         }
       }.bind(this));
 


### PR DESCRIPTION
A change between `undefined` and `null` should not be shown as a change since
both is `—` for the user.