### PR TITLE
CORE-3307 Add Persons live search to AssessmentTemplate modal

### DIFF
--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -122,6 +122,7 @@ dashboard-js-files:
   - components/paginate.js
   - components/tabs.js
   - components/assessment_attributes.js
+  - components/autocomplete/autocomplete.js
   - components/object_history/object_history.js
   #- d3.v2.js
   #- related_graph.js
@@ -223,6 +224,7 @@ dashboard-js-template-files:
   - issues/modal_content.mustache
   - issues/info.mustache
   - issues/remediation_plan.mustache
+  - components/autocomplete/autocomplete.mustache
   - components/object_history/object_history.mustache
   - custom_attributes/modal_content.mustache
   - custom_attributes/info.mustache

--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -124,6 +124,7 @@ dashboard-js-files:
   - components/assessment_attributes.js
   - components/autocomplete/autocomplete.js
   - components/object_history/object_history.js
+  - components/person/person.js
   #- d3.v2.js
   #- related_graph.js
 
@@ -226,6 +227,7 @@ dashboard-js-template-files:
   - issues/remediation_plan.mustache
   - components/autocomplete/autocomplete.mustache
   - components/object_history/object_history.mustache
+  - components/person/person.mustache
   - custom_attributes/modal_content.mustache
   - custom_attributes/info.mustache
   - custom_attribute_definitions/modal_content.mustache

--- a/src/ggrc/assets/javascripts/components/autocomplete/autocomplete.js
+++ b/src/ggrc/assets/javascripts/components/autocomplete/autocomplete.js
@@ -1,0 +1,88 @@
+/*!
+  Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+  Created By: peter@reciprocitylabs.com
+  Maintained By: peter@reciprocitylabs.com
+*/
+
+/**
+ * A component that renders an autocomplete text input field.
+ */
+(function (GGRC, can) {
+  'use strict';
+
+  // the component's configuration object (i.e. its constructor's prototype)
+  var component = {
+    tag: 'autocomplete',
+
+    template: can.view(
+      GGRC.mustache_path +
+      '/components/autocomplete/autocomplete.mustache'
+    ),
+
+    scope: {
+      placeholder: '@',
+      searchItemsType: '@',
+
+      // disable automatically mapping the picked item from the live search
+      // results to the instance object of the current context
+      automappingOff: true,
+
+      disable: false
+    },
+
+    _EV_ITEM_SELECTED: 'item-selected',
+
+    /**
+     * The component's entry point. Invoked when a new component instance has
+     * been created.
+     *
+     * @param {Object} element - the (unwrapped) DOM element that triggered the
+     *   creation of the component instance
+     * @param {Object} options - the component instantiation options
+     */
+    init: function (element, options) {
+      var $el = $(element);
+      var attrVal = $el.attr('disable');
+      var disable;
+      var scope = this.scope;
+
+      // By default CanJS evaluates the component element's attribute values in
+      // the current context, but we want to support passing in literal values
+      // as well. We thus inspect some of the directly and override what CanJS
+      // initializes in scope.
+      if (attrVal === '' || attrVal === 'false') {
+        disable = false;
+      } else if (attrVal === 'true') {
+        disable = true;
+      } else {
+        disable = Boolean(scope.attr('disable'));
+      }
+
+      scope.attr('disable', disable);
+    },
+
+    events: {
+      /**
+       * Event handler when an item is selected from the list of autocomplete's
+       * search results.
+       *
+       * @param {jQuery.Element} $el - the source of the event `ev`
+       * @param {jQuery.Event} ev - the event object
+       * @param {Object} data - information about the selected item
+       */
+      'autocomplete:select': function ($el, ev, data) {
+        $el.triggerHandler({
+          type: component._EV_ITEM_SELECTED,
+          selectedItem: data.item
+        });
+        // If the input still has focus after selecting an item, search results
+        // do not appear unless user clicks out and back in the input (or
+        // starts typing). Removing the focus spares one unnecessary click.
+        $el.find('input').blur();
+      }
+    }
+  };
+
+  GGRC.Components('autocomplete', component);
+})(window.GGRC, window.can);

--- a/src/ggrc/assets/javascripts/components/autocomplete/tests/autocomplete_spec.js
+++ b/src/ggrc/assets/javascripts/components/autocomplete/tests/autocomplete_spec.js
@@ -1,0 +1,137 @@
+/*!
+  Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+  Created By: peter@reciprocitylabs.com
+  Maintained By: peter@reciprocitylabs.com
+*/
+
+describe('GGRC.Components.autocomplete', function () {
+  'use strict';
+
+  var Component;  // the component under test
+
+  beforeAll(function () {
+    Component = GGRC.Components.get('autocomplete');
+  });
+
+  describe('defining default scope values', function () {
+    var scope;
+
+    beforeAll(function () {
+      scope = Component.prototype.scope;
+    });
+
+    it('sets the automappingOff flag to true', function () {
+      expect(scope.automappingOff).toBe(true);
+    });
+
+    it('sets the disable flag to false', function () {
+      expect(scope.disable).toBe(false);
+    });
+  });
+
+  describe('init() method', function () {
+    var componentInst;  // fake component instance
+    var element;  // the DOM element passed to the component instance
+    var init;  // the method under test
+    var options;
+
+    beforeEach(function () {
+      element = $('<div></div>')[0];
+      options = {};
+      componentInst = {};
+      componentInst.scope = new can.Map();
+      init = Component.prototype.init.bind(componentInst);
+    });
+
+    it('sets the disable flag to false if the element\'s disable attribute ' +
+      'is empty',
+      function () {
+        $(element).attr('disable', '');
+        componentInst.scope.attr('disable', true);
+        init(element, options);
+        expect(componentInst.scope.disable).toBe(false);
+      }
+    );
+
+    it('sets the disable flag to false if the element\'s disable attribute ' +
+      'has a value false',
+      function () {
+        $(element).attr('disable', 'false');
+        componentInst.scope.attr('disable', true);
+        init(element, options);
+        expect(componentInst.scope.attr('disable')).toBe(false);
+      }
+    );
+
+    it('sets the disable flag to true if the element\'s disable attribute ' +
+      'has a value true',
+      function () {
+        $(element).attr('disable', 'true');
+        componentInst.scope.attr('disable', false);
+        init(element, options);
+        expect(componentInst.scope.attr('disable')).toBe(true);
+      }
+    );
+
+    it('leaves the disable flag unchanged if the element\'s disable ' +
+      'attribute is neither empty nor true/false',
+      function () {
+        $(element).attr('disable', 'whatever');
+        componentInst.scope.attr('disable', true);
+        init(element, options);
+        expect(componentInst.scope.attr('disable')).toBe(true);
+      }
+    );
+  });
+
+  describe('item selected event handler', function () {
+    var eventData;
+    var eventObj;
+    var handler;  // the event handler under test
+    var $childInput;
+    var $element;
+
+    beforeAll(function () {
+      handler = Component.prototype.events['autocomplete:select'];
+    });
+
+    beforeEach(function () {
+      eventData = {
+        item: {id: 123, type: 'Foo'}
+      };
+      eventObj = $.Event('autocomplete:select');
+
+      $element = $('<div></div>');
+      spyOn($element, 'triggerHandler');
+
+      $childInput = $('<input></input>');
+      $element.append($childInput);
+
+      // the $element needs to be added to the DOM to test its focus
+      $('body').append($element);
+    });
+
+    afterEach(function () {
+      $element.remove();
+    });
+
+    it('triggers the item-selected event with the selected item object as ' +
+      'the event argument',
+      function () {
+        handler($element, eventObj, eventData);
+
+        expect($element.triggerHandler).toHaveBeenCalledWith({
+          type: Component.prototype._EV_ITEM_SELECTED,
+          selectedItem: {id: 123, type: 'Foo'}
+        });
+      }
+    );
+
+    it('removes focus from the input element', function () {
+      $childInput.focus();
+      handler($element, eventObj, eventData);
+      expect(document.activeElement).not.toBe($childInput[0]);
+    });
+  });
+});

--- a/src/ggrc/assets/javascripts/components/person/person.js
+++ b/src/ggrc/assets/javascripts/components/person/person.js
@@ -1,0 +1,80 @@
+/*!
+  Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+  Created By: peter@reciprocitylabs.com
+  Maintained By: peter@reciprocitylabs.com
+*/
+
+/**
+ * A component that renders a single Person item, fetching the object from the
+ * server if necessary.
+ */
+(function (GGRC, can) {
+  'use strict';
+
+  // the component's configuration object (i.e. its constructor's prototype)
+  var component = {
+    tag: 'person',
+
+    template: can.view(
+      GGRC.mustache_path +
+      '/components/person/person.mustache'
+    ),
+
+    scope: {
+      personObj: null
+    },
+
+    _EV_REMOVE_CLICK: 'person-remove',
+
+    /**
+     * The component's entry point. Invoked when a new component instance has
+     * been created.
+     *
+     * @param {Object} element - the (unwrapped) DOM element that triggered the
+     *   creation of the component instance
+     * @param {Object} options - the component instantiation options
+     */
+    init: function (element, options) {
+      var $el = $(element);
+      var personId = Number($el.attr('person-id'));
+      var personObj = CMS.Models.Person.cache[personId];
+      var scope = this.scope;
+
+      if (personObj) {
+        scope.attr('personObj', personObj);
+        return;
+      }
+
+      // but if not in cache, we need to fetch the person object...
+      CMS.Models.Person
+        .findOne({id: personId})
+        .then(function (person) {
+          scope.attr('personObj', person);
+        }, function () {
+          $el.trigger(
+            'ajax:flash',
+            {error: 'Failed to fetch data for person ' + personId + '.'});
+        });
+    },
+
+    events: {
+      /**
+       * Event handler when a user clicks the trash icon.
+       *
+       * @param {jQuery.Element} $el - the source of the event `ev`
+       * @param {jQuery.Event} ev - the event object
+       */
+      'a.unmap click': function ($el, ev) {
+        // the handler is registered on the component's root element,
+        // thus it needs to be triggered on it (and not on the $el)
+        this.element.triggerHandler({
+          type: component._EV_REMOVE_CLICK,
+          person: this.scope.personObj
+        });
+      }
+    }
+  };
+
+  GGRC.Components('personItem', component);
+})(window.GGRC, window.can);

--- a/src/ggrc/assets/javascripts/components/person/person.js
+++ b/src/ggrc/assets/javascripts/components/person/person.js
@@ -41,7 +41,10 @@
       var personObj = CMS.Models.Person.cache[personId];
       var scope = this.scope;
 
-      if (personObj) {
+      // For some reason the cache sometimes contains partially loaded objects,
+      // thus we also need to check if "email" (a required field) is present.
+      // If it is, we can be certain that we can use the object from the cache.
+      if (personObj && personObj.attr('email')) {
         scope.attr('personObj', personObj);
         return;
       }

--- a/src/ggrc/assets/javascripts/components/person/tests/person_spec.js
+++ b/src/ggrc/assets/javascripts/components/person/tests/person_spec.js
@@ -60,7 +60,9 @@ describe('GGRC.Components.personItem', function () {
     it('sets the personObj in scope to the cached Person object ' +
       'if found there',
       function () {
-        var person42 = new can.Map({id: 42, name: 'John'});
+        var person42 = new can.Map({
+          id: 42, name: 'John', email: 'john@doe.com'
+        });
         CMS.Models.Person.cache[42] = person42;
         $(element).attr('person-id', 42);
 
@@ -73,7 +75,9 @@ describe('GGRC.Components.personItem', function () {
     it('sets the personObj in scope to the fetched Person object ' +
       'if not found in cache',
       function () {
-        var person123 = new can.Map({id: 123, name: 'Mike'});
+        var person123 = new can.Map({
+          id: 123, name: 'Mike', email: 'mike@mike.com'
+        });
 
         delete CMS.Models.Person.cache[123];
         $(element).attr('person-id', 123);
@@ -83,6 +87,25 @@ describe('GGRC.Components.personItem', function () {
 
         expect(CMS.Models.Person.findOne).toHaveBeenCalledWith({id: 123});
         expect(componentInst.scope.attr('personObj')).toBe(person123);
+      }
+    );
+
+    it('sets the personObj in scope to the fetched Person object ' +
+      'for partially loaded objects in cache',
+      function () {
+        var person123 = new can.Map({id: 123, name: '', email: ''});
+        var fetchedPerson = new can.Map({
+          id: 123, name: 'John', email: 'john@doe.com'
+        });
+
+        CMS.Models.Person.cache[123] = person123;
+        $(element).attr('person-id', 123);
+
+        init(element, options);
+        dfdFindOne.resolve(fetchedPerson);
+
+        expect(CMS.Models.Person.findOne).toHaveBeenCalledWith({id: 123});
+        expect(componentInst.scope.attr('personObj')).toBe(fetchedPerson);
       }
     );
 

--- a/src/ggrc/assets/javascripts/components/person/tests/person_spec.js
+++ b/src/ggrc/assets/javascripts/components/person/tests/person_spec.js
@@ -1,0 +1,143 @@
+/*!
+  Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+  Created By: peter@reciprocitylabs.com
+  Maintained By: peter@reciprocitylabs.com
+*/
+
+describe('GGRC.Components.personItem', function () {
+  'use strict';
+
+  var Component;  // the component under test
+
+  beforeAll(function () {
+    Component = GGRC.Components.get('personItem');
+  });
+
+  describe('defining default scope values', function () {
+    var scope;
+
+    beforeAll(function () {
+      scope = Component.prototype.scope;
+    });
+
+    it('sets the personObj to null', function () {
+      expect(scope.personObj).toBeNull();
+    });
+  });
+
+  describe('init() method', function () {
+    var componentInst;  // fake component instance
+    var dfdFindOne;
+    var element;  // the DOM element passed to the component instance
+    var init;  // the method under test
+    var options;
+    var origPersonCache;
+
+    beforeAll(function () {
+      componentInst = {};
+
+      init = Component.prototype.init.bind(componentInst);
+    });
+
+    beforeEach(function () {
+      element = $('<div></div>')[0];
+      options = {};
+
+      dfdFindOne = new can.Deferred();
+      spyOn(CMS.Models.Person, 'findOne').and.returnValue(dfdFindOne);
+
+      origPersonCache = CMS.Models.Person.cache;
+      CMS.Models.Person.cache = {};
+
+      componentInst.scope = new can.Map({});
+    });
+
+    afterEach(function () {
+      CMS.Models.Person.cache = origPersonCache;
+    });
+
+    it('sets the personObj in scope to the cached Person object ' +
+      'if found there',
+      function () {
+        var person42 = new can.Map({id: 42, name: 'John'});
+        CMS.Models.Person.cache[42] = person42;
+        $(element).attr('person-id', 42);
+
+        init(element, options);
+
+        expect(componentInst.scope.attr('personObj')).toBe(person42);
+      }
+    );
+
+    it('sets the personObj in scope to the fetched Person object ' +
+      'if not found in cache',
+      function () {
+        var person123 = new can.Map({id: 123, name: 'Mike'});
+
+        delete CMS.Models.Person.cache[123];
+        $(element).attr('person-id', 123);
+
+        init(element, options);
+        dfdFindOne.resolve(person123);
+
+        expect(CMS.Models.Person.findOne).toHaveBeenCalledWith({id: 123});
+        expect(componentInst.scope.attr('personObj')).toBe(person123);
+      }
+    );
+
+    it('displays a toaster error if fetching the Person object fails',
+      function () {
+        var $fakeElement = $('<div person-id="123"></div>');
+        spyOn($fakeElement, 'trigger');
+        spyOn(window, '$').and.returnValue($fakeElement);
+        delete CMS.Models.Person.cache[123];
+
+        init(element, options);
+        dfdFindOne.reject('Server error');
+
+        expect(window.$).toHaveBeenCalledWith(element);
+        expect($fakeElement.trigger).toHaveBeenCalledWith(
+          'ajax:flash',
+          {error: 'Failed to fetch data for person 123.'}
+        );
+      }
+    );
+  });
+
+  describe('unmap person click event handler', function () {
+    var handler;  // the event handler under test
+    var componentInst;  // fake component instance
+
+    beforeAll(function () {
+      handler = Component.prototype.events['a.unmap click'];
+    });
+
+    beforeEach(function () {
+      componentInst = {
+        element: {
+          triggerHandler: jasmine.createSpy()
+        },
+        scope: new can.Map()
+      };
+
+      handler = handler.bind(componentInst);
+    });
+
+    it('triggers the person-remove event with the person object as the ' +
+      'event argument',
+      function () {
+        var call;
+        componentInst.scope.attr('personObj', {id: 123, name: 'John'});
+
+        handler();
+
+        expect(componentInst.element.triggerHandler).toHaveBeenCalled();
+        call = componentInst.element.triggerHandler.calls.mostRecent();
+        expect(call.args[0].type).toEqual(
+          Component.prototype._EV_REMOVE_CLICK);
+        expect(call.args[0].person.attr()).toEqual({id: 123, name: 'John'});
+      }
+    );
+  });
+});

--- a/src/ggrc/assets/javascripts/controllers/modals_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/modals_controller.js
@@ -91,37 +91,56 @@ can.Control("GGRC.Controllers.Modals", {
         .then(this.proxy("autocomplete"));
       this.restore_ui_status_from_storage();
     }.bind(this));
-  }
+  },
 
-  , apply_object_params: function () {
+  apply_object_params: function () {
     if (!this.options.object_params) {
       return;
     }
-    this.options.object_params.each(function(value, key) {
-      this.set_value({ name: key, value: value });
+    this.options.object_params.each(function (value, key) {
+      this.set_value({name: key, value: value});
     }, this);
   },
-  "input[data-lookup] focus": function (el, ev) {
+
+  'input[data-lookup] focus': function (el, ev) {
     this.autocomplete(el);
   },
-  "input[data-lookup] keyup": function (el, ev) {
+
+  'input[data-lookup] keyup': function (el, ev) {
     // Set the transient field for validation
-    var name = el.attr('name').split('.'),
-        instance = this.options.instance,
-        value = el.val();
+    var name;
+    var instance;
+    var value;
 
-    name.pop(); //set the owner to null, not the email
-    instance._transient || instance.attr("_transient", new can.Observe({}));
+    // in some cases we want to disable automapping the selected item to the
+    // modal's underlying object (e.g. we don't want to map the picked Persons
+    // to an AssessmentTemplates object)
+    if (el.data('no-automap')) {
+      return;
+    }
 
-    can.reduce(name.slice(0, -1), function(current, next) {
-      current = current + "." + next;
-      instance.attr(current) || instance.attr(current, new can.Observe({}));
+    name = el.attr('name').split('.');
+    instance = this.options.instance;
+    value = el.val();
+
+    name.pop(); // set the owner to null, not the email
+
+    if (!instance._transient) {
+      instance.attr('_transient', new can.Observe({}));
+    }
+
+    can.reduce(name.slice(0, -1), function (current, next) {
+      current = current + '.' + next;
+      if (!instance.attr(current)) {
+        instance.attr(current, new can.Observe({}));
+      }
       return current;
-    }, "_transient");
+    }, '_transient');
 
-    instance.attr(["_transient"].concat(name).join("."), value);
+    instance.attr(['_transient'].concat(name).join('.'), value);
   },
-  autocomplete: function(el) {
+
+  autocomplete: function (el) {
     $.cms_autocomplete.call(this, el);
   },
   autocomplete_select: function (el, event, ui) {

--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -1267,7 +1267,7 @@
      * @param {jQuery.Element} $el - the source of the event `ev`
      * @param {jQuery.Event} ev - the event that was triggered
      */
-    ddAssessorsChanged: function (context, $el, ev) {
+    defaultAssesorsChanged: function (context, $el, ev) {
       this._updateDropdownEnabled('assessors');
     },
 
@@ -1278,7 +1278,7 @@
      * @param {jQuery.Element} $el - the source of the event `ev`
      * @param {jQuery.Event} ev - the event that was triggered
      */
-    ddVerifiersChanged: function (context, $el, ev) {
+    defaultVerifiersChanged: function (context, $el, ev) {
       this._updateDropdownEnabled('verifiers');
     },
 

--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -1192,7 +1192,6 @@
       this.attr('_objectTypes', this._choosableObjectTypes());
       this._unpackPeopleData();
 
-      // TODO: tests for this!
       this._updateDropdownEnabled('assessors');
       this._updateDropdownEnabled('verifiers');
     },
@@ -1223,6 +1222,19 @@
     },
 
     /**
+     * Event handler when a user clicks to remove an assessor from the
+     * assessors list. It removes the corresponding assessor ID from the list.
+     *
+     * @param {can.Map} context - the Mustache context of the `$el`
+     * @param {jQuery.Element} $el - the source of the event `ev`
+     * @param {jQuery.Event} ev - the event that was triggered
+     */
+    assessorRemoved: function (context, $el, ev) {
+      var user = ev.person;
+      this.assessorsList.removeAttr(String(user.id));
+    },
+
+    /**
      * Event handler when a verifier is picked in an autocomplete form field.
      * It adds the picked verifier's ID to the verifiers list.
      *
@@ -1235,22 +1247,51 @@
       this.verifiersList.attr(user.id, true);
     },
 
-    // TODO: docstring, tests
+    /**
+     * Event handler when a user clicks to remove a verifier from the verifiers
+     * list. It removes the corresponding verifier ID from the list.
+     *
+     * @param {can.Map} context - the Mustache context of the `$el`
+     * @param {jQuery.Element} $el - the source of the event `ev`
+     * @param {jQuery.Event} ev - the event that was triggered
+     */
+    verifierRemoved: function (context, $el, ev) {
+      var user = ev.person;
+      this.verifiersList.removeAttr(String(user.id));
+    },
+
+    /**
+     * Event handler when a user changes the default assessors option.
+     *
+     * @param {can.Map} context - the Mustache context of the `$el`
+     * @param {jQuery.Element} $el - the source of the event `ev`
+     * @param {jQuery.Event} ev - the event that was triggered
+     */
     ddAssessorsChanged: function (context, $el, ev) {
       this._updateDropdownEnabled('assessors');
-      // TODO: clear selected assessors as well? prob. better to preserve them
     },
 
-    // TODO: docstring, tests
+    /**
+     * Event handler when a user changes the default verifiers option.
+     *
+     * @param {can.Map} context - the Mustache context of the `$el`
+     * @param {jQuery.Element} $el - the source of the event `ev`
+     * @param {jQuery.Event} ev - the event that was triggered
+     */
     ddVerifiersChanged: function (context, $el, ev) {
       this._updateDropdownEnabled('verifiers');
-      // TODO: clear selected verifiers as well? prob. better to preserve them
     },
 
-    // TODO: test, docstrings... rename.... verifiers/assessors
+    /**
+     * Update the autocomplete field's disabled flag based on the current value
+     * of the corresponding dropdown.
+     *
+     * @param {String} name - the value to inspect, must be either "assessors"
+     *   or "verifiers"
+     */
     _updateDropdownEnabled: function (name) {
       var disable = this.attr('default_people.' + name) !== 'other';
-      this.attr(name + 'DropdownDisable', disable);
+      this.attr(name + 'ListDisable', disable);
     },
 
     /**

--- a/src/ggrc/assets/js_specs/models/assessment_template_spec.js
+++ b/src/ggrc/assets/js_specs/models/assessment_template_spec.js
@@ -425,7 +425,7 @@ describe('can.Model.AssessmentTemplate', function () {
     });
   });
 
-  describe('ddAssessorsChanged() method', function () {
+  describe('defaultAssesorsChanged() method', function () {
     var context;
     var $element;
     var eventObj;
@@ -442,7 +442,7 @@ describe('can.Model.AssessmentTemplate', function () {
         instance.attr('assessorsListDisable', false);
         instance.attr('default_people.assessors', 'Object Owners');
 
-        instance.ddAssessorsChanged(context, $element, eventObj);
+        instance.defaultAssesorsChanged(context, $element, eventObj);
 
         expect(instance.attr('assessorsListDisable')).toBe(true);
       }
@@ -454,14 +454,14 @@ describe('can.Model.AssessmentTemplate', function () {
         instance.attr('assessorsListDisable', true);
         instance.attr('default_people.assessors', 'other');
 
-        instance.ddAssessorsChanged(context, $element, eventObj);
+        instance.defaultAssesorsChanged(context, $element, eventObj);
 
         expect(instance.attr('assessorsListDisable')).toBe(false);
       }
     );
   });
 
-  describe('ddVerifiersChanged() method', function () {
+  describe('defaultVerifiersChanged() method', function () {
     var context;
     var $element;
     var eventObj;
@@ -478,7 +478,7 @@ describe('can.Model.AssessmentTemplate', function () {
         instance.attr('verifiersListDisable', false);
         instance.attr('default_people.verifiers', 'Object Owners');
 
-        instance.ddVerifiersChanged(context, $element, eventObj);
+        instance.defaultVerifiersChanged(context, $element, eventObj);
 
         expect(instance.attr('verifiersListDisable')).toBe(true);
       }
@@ -490,7 +490,7 @@ describe('can.Model.AssessmentTemplate', function () {
         instance.attr('verifiersListDisable', true);
         instance.attr('default_people.verifiers', 'other');
 
-        instance.ddVerifiersChanged(context, $element, eventObj);
+        instance.defaultVerifiersChanged(context, $element, eventObj);
 
         expect(instance.attr('verifiersListDisable')).toBe(false);
       }

--- a/src/ggrc/assets/js_specs/models/assessment_template_spec.js
+++ b/src/ggrc/assets/js_specs/models/assessment_template_spec.js
@@ -326,6 +326,39 @@ describe('can.Model.AssessmentTemplate', function () {
     });
   });
 
+  describe('assessorRemoved() method', function () {
+    var context;
+    var $element;
+    var eventObj;
+
+    beforeEach(function () {
+      context = {};
+      $element = $('<div></div>');
+      eventObj = $.Event();
+    });
+
+    it('removes the new assessor\'s ID from the assessors list', function () {
+      instance.attr('assessorsList', {'7': true, '42': true, '3': true});
+      eventObj.person = {id: 42};
+
+      instance.assessorRemoved(context, $element, eventObj);
+
+      expect(
+        instance.attr('assessorsList').attr()
+      ).toEqual({'7': true, '3': true});
+    });
+
+    it('silently ignores removing non-existing entries', function () {
+      instance.attr('assessorsList', {'7': true});
+      eventObj.person = {id: 50};
+
+      instance.assessorRemoved(context, $element, eventObj);
+      // there should have been no error
+
+      expect(instance.attr('assessorsList').attr()).toEqual({'7': true});
+    });
+  });
+
   describe('verifierAdded() method', function () {
     var context;
     var $element;
@@ -357,5 +390,110 @@ describe('can.Model.AssessmentTemplate', function () {
 
       expect(instance.attr('verifiersList').attr()).toEqual({'7': true});
     });
+  });
+
+  describe('verifierRemoved() method', function () {
+    var context;
+    var $element;
+    var eventObj;
+
+    beforeEach(function () {
+      context = {};
+      $element = $('<div></div>');
+      eventObj = $.Event();
+    });
+
+    it('removes the new verifier\'s ID from the verifiers list', function () {
+      instance.attr('verifiersList', {'7': true, '42': true, '3': true});
+      eventObj.person = {id: 42};
+
+      instance.verifierRemoved(context, $element, eventObj);
+
+      expect(
+        instance.attr('verifiersList').attr()
+      ).toEqual({'7': true, '3': true});
+    });
+
+    it('silently ignores removing non-existing entries', function () {
+      instance.attr('verifiersList', {'7': true});
+      eventObj.person = {id: 50};
+
+      instance.verifierRemoved(context, $element, eventObj);
+      // there should have been no error
+
+      expect(instance.attr('verifiersList').attr()).toEqual({'7': true});
+    });
+  });
+
+  describe('ddAssessorsChanged() method', function () {
+    var context;
+    var $element;
+    var eventObj;
+
+    beforeEach(function () {
+      context = {};
+      $element = $('<div></div>');
+      eventObj = $.Event();
+    });
+
+    it('sets the assessorsListDisable flag if the corresponding ' +
+      'selected option is different from "other"',
+      function () {
+        instance.attr('assessorsListDisable', false);
+        instance.attr('default_people.assessors', 'Object Owners');
+
+        instance.ddAssessorsChanged(context, $element, eventObj);
+
+        expect(instance.attr('assessorsListDisable')).toBe(true);
+      }
+    );
+
+    it('clears the assessorsListDisable flag if the corresponding ' +
+      'selected option is "other"',
+      function () {
+        instance.attr('assessorsListDisable', true);
+        instance.attr('default_people.assessors', 'other');
+
+        instance.ddAssessorsChanged(context, $element, eventObj);
+
+        expect(instance.attr('assessorsListDisable')).toBe(false);
+      }
+    );
+  });
+
+  describe('ddVerifiersChanged() method', function () {
+    var context;
+    var $element;
+    var eventObj;
+
+    beforeEach(function () {
+      context = {};
+      $element = $('<div></div>');
+      eventObj = $.Event();
+    });
+
+    it('sets the verifiersListDisable flag if the corresponding ' +
+      'selected option is different from "other"',
+      function () {
+        instance.attr('verifiersListDisable', false);
+        instance.attr('default_people.verifiers', 'Object Owners');
+
+        instance.ddVerifiersChanged(context, $element, eventObj);
+
+        expect(instance.attr('verifiersListDisable')).toBe(true);
+      }
+    );
+
+    it('clears the verifiersListDisable flag if the corresponding ' +
+      'selected option is "other"',
+      function () {
+        instance.attr('verifiersListDisable', true);
+        instance.attr('default_people.verifiers', 'other');
+
+        instance.ddVerifiersChanged(context, $element, eventObj);
+
+        expect(instance.attr('verifiersListDisable')).toBe(false);
+      }
+    );
   });
 });

--- a/src/ggrc/assets/js_specs/models/assessment_template_spec.js
+++ b/src/ggrc/assets/js_specs/models/assessment_template_spec.js
@@ -168,64 +168,76 @@ describe('can.Model.AssessmentTemplate', function () {
       });
     });
 
-    it('uses the user-provided list if assessors set to "other"', function () {
-      var result;
+    it('uses the list of chosen assessor IDs if default assessors are set ' +
+      'to "other"',
+      function () {
+        var assessorIds;
+        var result;
 
-      instance.attr('default_people', {
-        assessors: 'other',
-        verifiers: 'Whatever'
-      });
+        instance.attr('default_people', {
+          assessors: 'other',
+          verifiers: 'Whatever'
+        });
 
-      instance.attr('assessors_list', '  John,, Jack Mac,John,  Jill,  , ');
+        assessorIds = new can.Map({'17': true, '2': true, '9': true});
+        instance.attr('assessorsList', assessorIds);
 
-      result = instance._packPeopleData();
+        result = instance._packPeopleData();
 
-      expect(typeof result).toEqual('string');
-      result = JSON.parse(result);
-      expect(result).toEqual({
-        assessors: ['John', 'Jack Mac', 'Jill'],
-        verifiers: 'Whatever'
-      });
-    });
+        expect(typeof result).toEqual('string');
+        result = JSON.parse(result);
+        expect(result).toEqual({
+          assessors: [2, 9, 17],
+          verifiers: 'Whatever'
+        });
+      }
+    );
 
-    it('uses the user-provided list if verifiers set to "other"', function () {
-      var result;
+    it('uses the list of chosen verifier IDs if default verifiers are set ' +
+      'to "other"',
+      function () {
+        var verifierIds;
+        var result;
 
-      instance.attr('default_people', {
-        assessors: 'Whatever',
-        verifiers: 'other'
-      });
+        instance.attr('default_people', {
+          assessors: 'Whatever',
+          verifiers: 'other'
+        });
 
-      instance.attr('verifiers_list', '  First, ,, Sec ond   ,First, Third ');
+        verifierIds = new can.Map({'12': true, '6': true, '11': true});
+        instance.attr('verifiersList', verifierIds);
 
-      result = instance._packPeopleData();
+        result = instance._packPeopleData();
 
-      expect(typeof result).toEqual('string');
-      result = JSON.parse(result);
-      expect(result).toEqual({
-        assessors: 'Whatever',
-        verifiers: ['First', 'Sec ond', 'Third']
-      });
-    });
+        expect(typeof result).toEqual('string');
+        result = JSON.parse(result);
+        expect(result).toEqual({
+          assessors: 'Whatever',
+          verifiers: [6, 11, 12]
+        });
+      }
+    );
   });
 
   describe('_unpackPeopleData() method', function () {
-    it('converts the default assessors list to a string', function () {
+    it('builds an IDs dict from the default assessors list', function () {
       instance.attr('default_people', {
-        assessors: new can.List([12, 5, 7])
+        assessors: new can.List([5, 7, 12])
       });
-      instance.attr('assessors_list', '');
+      instance.attr('assessorsList', {});
 
       instance._unpackPeopleData();
 
-      expect(instance.assessors_list).toEqual('12, 5, 7');
+      expect(
+        instance.assessorsList.attr()
+      ).toEqual({'5': true, '7': true, '12': true});
     });
 
     it('sets the default assessors option to "other" if needed', function () {
       // this is needed when the default assessors setting is actually
       // a list of User IDs...
       instance.attr('default_people', {
-        assessors: new can.List([12, 5, 7])
+        assessors: new can.List([5, 7, 12])
       });
 
       instance._unpackPeopleData();
@@ -233,27 +245,117 @@ describe('can.Model.AssessmentTemplate', function () {
       expect(instance.default_people.assessors).toEqual('other');
     });
 
-    it('converts the default verifiers list to a string', function () {
+    it('clears the assessors IDs dict if needed', function () {
+      instance.attr('assessorsList', {'42': true});
       instance.attr('default_people', {
-        verifiers: new can.List([12, 5, 7])
+        assessors: 'Some User Group'  // not a list of IDs
       });
-      instance.attr('verifiers_list', '');
 
       instance._unpackPeopleData();
 
-      expect(instance.verifiers_list).toEqual('12, 5, 7');
+      expect(instance.assessorsList.attr()).toEqual({});
+    });
+
+    it('builds an IDs dict from the default verifiers list', function () {
+      instance.attr('default_people', {
+        verifiers: new can.List([5, 7, 12])
+      });
+      instance.attr('verifiersList', {});
+
+      instance._unpackPeopleData();
+
+      expect(
+        instance.verifiersList.attr()
+      ).toEqual({'5': true, '7': true, '12': true});
     });
 
     it('sets the default verifiers option to "other" if needed', function () {
       // this is needed when the default verifiers setting is actually
       // a list of User IDs...
       instance.attr('default_people', {
-        verifiers: new can.List([12, 5, 7])
+        verifiers: new can.List([5, 7, 12])
       });
 
       instance._unpackPeopleData();
 
       expect(instance.default_people.verifiers).toEqual('other');
+    });
+
+    it('clears the verifiers IDs dict if needed', function () {
+      instance.attr('verifiersList', {'42': true});
+      instance.attr('default_people', {
+        verifiers: 'Some User Group'  // not a list of IDs
+      });
+
+      instance._unpackPeopleData();
+
+      expect(instance.verifiersList.attr()).toEqual({});
+    });
+  });
+
+  describe('assessorAdded() method', function () {
+    var context;
+    var $element;
+    var eventObj;
+
+    beforeEach(function () {
+      context = {};
+      $element = $('<div></div>');
+      eventObj = $.Event();
+    });
+
+    it('adds the new assessor\'s ID to the assessors list', function () {
+      instance.attr('assessorsList', {'7': true});
+      eventObj.selectedItem = {id: 42};
+
+      instance.assessorAdded(context, $element, eventObj);
+
+      expect(
+        instance.attr('assessorsList').attr()
+      ).toEqual({'7': true, '42': true});
+    });
+
+    it('silently ignores duplicate entries', function () {
+      instance.attr('assessorsList', {'7': true});
+      eventObj.selectedItem = {id: 7};
+
+      instance.assessorAdded(context, $element, eventObj);
+      // there should have been no error
+
+      expect(instance.attr('assessorsList').attr()).toEqual({'7': true});
+    });
+  });
+
+  describe('verifierAdded() method', function () {
+    var context;
+    var $element;
+    var eventObj;
+
+    beforeEach(function () {
+      context = {};
+      $element = $('<div></div>');
+      eventObj = $.Event();
+    });
+
+    it('adds the new verifier\'s ID to the assessors list', function () {
+      instance.attr('verifiersList', {'7': true});
+      eventObj.selectedItem = {id: 42};
+
+      instance.verifierAdded(context, $element, eventObj);
+
+      expect(
+        instance.attr('verifiersList').attr()
+      ).toEqual({'7': true, '42': true});
+    });
+
+    it('silently ignores duplicate entries', function () {
+      instance.attr('verifiersList', {'7': true});
+      eventObj.selectedItem = {id: 7};
+
+      instance.verifierAdded(context, $element, eventObj);
+      // there should have been no error
+
+      expect(instance.attr('verifiersList').attr()).toEqual({'7': true});
     });
   });
 });

--- a/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
@@ -110,7 +110,7 @@
 
             <select
               can-value="instance.default_people.assessors"
-              can-change="instance.ddAssessorsChanged"
+              can-change="instance.defaultAssesorsChanged"
               class="input-block-level js-toggle-field">
               <option value="Object Owners">Object Owners</option>
               <option value="Audit Lead">Audit Lead</option>
@@ -149,7 +149,7 @@
 
             <select
               can-value="instance.default_people.verifiers"
-              can-change="instance.ddVerifiersChanged"
+              can-change="instance.defaultVerifiersChanged"
               class="input-block-level js-toggle-field">
               <option value="Object Owners">Object Owners</option>
               <option value="Audit Lead">Audit Lead</option>

--- a/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
@@ -110,6 +110,7 @@
 
             <select
               can-value="instance.default_people.assessors"
+              can-change="instance.ddAssessorsChanged"
               class="input-block-level js-toggle-field">
               <option value="Object Owners">Object Owners</option>
               <option value="Audit Lead">Audit Lead</option>
@@ -122,10 +123,14 @@
 
           <div class="span6">
             <label>&nbsp;</label>
-            <input type="text"
-              can-value="instance.assessors_list"
-              class="input-block-level choose-input choose-assessor"
-              placeholder="Add person 1, Add person 2...">
+            <autocomplete
+              search-items-type="Person"
+              can-item-selected="instance.assessorAdded"
+              disable="instance.assessorsDropdownDisable"
+              placeholder="Enter text to search for Assessors"></autocomplete>
+
+            Default assessors:
+            {{#each instance.assessorsList}}Assessor {{@key}}, {{/each}}
           </div>
         </div>
 
@@ -138,6 +143,7 @@
 
             <select
               can-value="instance.default_people.verifiers"
+              can-change="instance.ddVerifiersChanged"
               class="input-block-level js-toggle-field">
               <option value="Object Owners">Object Owners</option>
               <option value="Audit Lead">Audit Lead</option>
@@ -150,10 +156,14 @@
 
           <div class="span6">
             <label>&nbsp;</label>
-            <input type="text"
-              can-value="instance.verifiers_list"
-              class="input-block-level choose-input choose-verifier"
-              placeholder="Add person 1, Add person 2...">
+            <autocomplete
+              search-items-type="Person"
+              can-item-selected="instance.verifierAdded"
+              disable="instance.verifiersDropdownDisable"
+              placeholder="Enter text to search for Verifiers"></autocomplete>
+
+              Default verifiers:
+              {{#each instance.verifiersList}}Verifier {{@key}}, {{/each}}
           </div>
         </div>
       </div>

--- a/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
@@ -123,20 +123,20 @@
 
           <div class="span6">
             <label>&nbsp;</label>
-            <autocomplete
-              search-items-type="Person"
-              can-item-selected="instance.assessorAdded"
-              disable="instance.assessorsListDisable"
-              placeholder="Enter text to search for Assessors"></autocomplete>
+            {{#if_equals instance.default_people.assessors 'other'}}
+              <autocomplete
+                search-items-type="Person"
+                can-item-selected="instance.assessorAdded"
+                disable="instance.assessorsListDisable"
+                placeholder="Enter text to search for Assessors"
+              ></autocomplete>
 
-              {{#if_equals instance.default_people.assessors 'other'}}
-                Default assessors:
-                {{#each instance.assessorsList}}
-                  <person
-                    person-id="{{@key}}"
-                    can-person-remove="instance.assessorRemoved"></person>
-                {{/each}}
-              {{/if}}
+              {{#each instance.assessorsList}}
+                <person
+                  person-id="{{@key}}"
+                  can-person-remove="instance.assessorRemoved"></person>
+              {{/each}}
+            {{/if}}
           </div>
         </div>
 
@@ -162,20 +162,21 @@
 
           <div class="span6">
             <label>&nbsp;</label>
-            <autocomplete
-              search-items-type="Person"
-              can-item-selected="instance.verifierAdded"
-              disable="instance.verifiersListDisable"
-              placeholder="Enter text to search for Verifiers"></autocomplete>
 
-              {{#if_equals instance.default_people.verifiers 'other'}}
-                Default verifiers:
-                {{#each instance.verifiersList}}
-                  <person
-                    person-id="{{@key}}"
-                    can-person-remove="instance.verifierRemoved"></person>
-                {{/each}}
-              {{/if}}
+            {{#if_equals instance.default_people.verifiers 'other'}}
+              <autocomplete
+                search-items-type="Person"
+                can-item-selected="instance.verifierAdded"
+                disable="instance.verifiersListDisable"
+                placeholder="Enter text to search for Verifiers"
+              ></autocomplete>
+
+              {{#each instance.verifiersList}}
+                <person
+                  person-id="{{@key}}"
+                  can-person-remove="instance.verifierRemoved"></person>
+              {{/each}}
+            {{/if}}
           </div>
         </div>
       </div>

--- a/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
@@ -126,11 +126,17 @@
             <autocomplete
               search-items-type="Person"
               can-item-selected="instance.assessorAdded"
-              disable="instance.assessorsDropdownDisable"
+              disable="instance.assessorsListDisable"
               placeholder="Enter text to search for Assessors"></autocomplete>
 
-            Default assessors:
-            {{#each instance.assessorsList}}Assessor {{@key}}, {{/each}}
+              {{#if_equals instance.default_people.assessors 'other'}}
+                Default assessors:
+                {{#each instance.assessorsList}}
+                  <person
+                    person-id="{{@key}}"
+                    can-person-remove="instance.assessorRemoved"></person>
+                {{/each}}
+              {{/if}}
           </div>
         </div>
 
@@ -159,11 +165,17 @@
             <autocomplete
               search-items-type="Person"
               can-item-selected="instance.verifierAdded"
-              disable="instance.verifiersDropdownDisable"
+              disable="instance.verifiersListDisable"
               placeholder="Enter text to search for Verifiers"></autocomplete>
 
-              Default verifiers:
-              {{#each instance.verifiersList}}Verifier {{@key}}, {{/each}}
+              {{#if_equals instance.default_people.verifiers 'other'}}
+                Default verifiers:
+                {{#each instance.verifiersList}}
+                  <person
+                    person-id="{{@key}}"
+                    can-person-remove="instance.verifierRemoved"></person>
+                {{/each}}
+              {{/if}}
           </div>
         </div>
       </div>

--- a/src/ggrc/assets/mustache/components/autocomplete/autocomplete.mustache
+++ b/src/ggrc/assets/mustache/components/autocomplete/autocomplete.mustache
@@ -1,0 +1,17 @@
+{{!
+  Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+  Created By: peter@reciprocitylabs.com
+  Maintained By: peter@reciprocitylabs.com
+}}
+
+<div class="span12 objective-selector field-wrap">
+  <input type="text"
+    data-lookup="{{searchItemsType}}"
+    null-if-empty="true"
+    {{#if disable}}disabled{{/if}}
+    {{autocomplete_select}}
+    data-no-automap="{{automappingOff}}"
+    class="search-icon"
+    placeholder="{{placeholder}}">
+</div>

--- a/src/ggrc/assets/mustache/components/person/person.mustache
+++ b/src/ggrc/assets/mustache/components/person/person.mustache
@@ -12,7 +12,5 @@
     <a href="javascript://" class="unmap" title="Remove">
       <i class="fa fa-trash"></i>
     </a>
-  {{else}}
-    Error: no Person data
   {{/if}}
 </div>

--- a/src/ggrc/assets/mustache/components/person/person.mustache
+++ b/src/ggrc/assets/mustache/components/person/person.mustache
@@ -1,0 +1,18 @@
+{{!
+  Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+  Created By: peter@reciprocitylabs.com
+  Maintained By: peter@reciprocitylabs.com
+}}
+
+<div class="person">
+  {{#if personObj}}
+    {{{renderLive '/static/mustache/people/popover.mustache' person=personObj}}}
+
+    <a href="javascript://" class="unmap" title="Remove">
+      <i class="fa fa-trash"></i>
+    </a>
+  {{else}}
+    Error: no Person data
+  {{/if}}
+</div>

--- a/src/ggrc/assets/stylesheets/modules/_modal.scss
+++ b/src/ggrc/assets/stylesheets/modules/_modal.scss
@@ -775,6 +775,10 @@
   }
 }
 
+.person a.unmap {
+  margin-left: 0.4em;
+}
+
 // Mockups Assessment Page V1.0
 .note {
   font-size: $f-medium;


### PR DESCRIPTION
This PR adds the `autocomplete` and `personItem` components, because the existing autocomplete widgets found in other modals were not useful, unfortunately - they want to do too much magic behind the scenes, e.g. mapping the picked item to the modal's underlying instance, but we don't want that for Assessment Templates, those Person items shouldn't be mapped to them.

The `autocomplete` component uses the existing autocomplete internally, but with an added hack to the `modals_controller` which breaks the `autocomplete`'s tight coupling with the latter.