### PR TITLE
CORE-3392 Disable warning when attaching evidence

### DIFF
--- a/src/ggrc/assets/mustache/requests/info.mustache
+++ b/src/ggrc/assets/mustache/requests/info.mustache
@@ -43,7 +43,7 @@
                   parent_instance="instance"
                   join_model="Relationship"
                   quick_create="create_url"
-                  {{#if_in instance.status "Open,Final,Verified"}}
+                  {{#if_in instance.status "Final,Verified"}}
                     verify_event="true"
                     modal_description='You are about to move request from "{{instance.status}}" to "In Progress" - are you sure about that?'
                     modal_title='Confirm moving Request to "In Progress"'

--- a/src/ggrc_gdrive_integration/assets/mustache/requests/gdrive_evidence_storage.mustache
+++ b/src/ggrc_gdrive_integration/assets/mustache/requests/gdrive_evidence_storage.mustache
@@ -7,7 +7,7 @@
 
 {{#with_mapping 'extended_folders' instance}}
   <div class="oneline">
-    {{#if_in instance.status "Open,Final,Verified"}}
+    {{#if_in instance.status "Final,Verified"}}
       {{#if extended_folders.length}}
         <ggrc-gdrive-picker-launcher
           instance="instance"


### PR DESCRIPTION
Disable warning when moving from `Open` to `In Progress` when attaching evidence.