### PR TITLE
CORE-3382 show evidence in the change log

### DIFF
--- a/src/ggrc/assets/javascripts/components/object_history/object_history.js
+++ b/src/ggrc/assets/javascripts/components/object_history/object_history.js
@@ -100,42 +100,25 @@
      *      mappings
      */
     _fetchRevisionsData: function () {
-      var Revision = CMS.Models.Revision;
-
-      var instance = this.scope.instance;
-
-      var dfd = Revision.findAll({
-        resource_type: this._INSTANCE_TYPE,
-        resource_id: instance.id,
-        __sort: 'updated_at'
-      });
-
-      var dfd2 = Revision.findAll({
-        source_type: this._INSTANCE_TYPE,
-        source_id: instance.id,
-        __sort: 'updated_at'
-      });
-
-      var dfd3 = Revision.findAll({
-        destination_type: this._INSTANCE_TYPE,
-        destination_id: instance.id,
-        __sort: 'updated_at'
-      });
+      var findAll = function (attr) {
+        var query = {__sort: 'updated_at'};
+        query[attr + '_type'] = this.scope.instance.type;
+        query[attr + '_id'] = this.scope.instance.id;
+        return CMS.Models.Revision.findAll(query);
+      }.bind(this);
 
       return can.when(
-        dfd, dfd2, dfd3
+        findAll('resource'), findAll('source'), findAll('destination')
       ).then(function (objRevisions, mappingsSrc, mappingsDest) {
         // manually include people for modified_by since using __include would
         // result in a lot of duplication
         var rq = new RefreshQueue();
-        var enqueue = function (revision) {
-          if (revision.modified_by) {
-            rq.enqueue(revision.modified_by);
-          }
-        };
-        _.each(objRevisions, enqueue);
-        _.each(mappingsSrc, enqueue);
-        _.each(mappingsDest, enqueue);
+        _.each(objRevisions.concat(mappingsSrc, mappingsDest),
+            function (revision) {
+              if (revision.modified_by) {
+                rq.enqueue(revision.modified_by);
+              }
+            });
         _.each(mappingsSrc, function (revision) {
           if (revision.destination_type && revision.destination_id) {
             revision.destination = can.Stub.get_or_create({
@@ -158,15 +141,12 @@
           .then(function (embedded) {
             return rq.trigger().then(function () {
               var reify = function (revision) {
-                if (revision.modified_by && revision.modified_by.reify) {
-                  revision.attr('modified_by', revision.modified_by.reify());
-                }
-                if (revision.destination && revision.destination.reify) {
-                  revision.attr('destination', revision.destination.reify());
-                }
-                if (revision.source && revision.source.reify()) {
-                  revision.attr('source', revision.source.reify());
-                }
+                _.each(['modified_by', 'source', 'destination'],
+                    function (field) {
+                      if (revision[field] && revision[field].reify) {
+                        revision.attr(field, revision[field].reify());
+                      }
+                    });
                 return revision;
               };
               var mappings = mappingsSrc.concat(mappingsDest, embedded);
@@ -192,57 +172,64 @@
      *   revisons of the indirect mappings.
      */
     _fetchEmbeddedRevisionData: function (mappedObjects, rq) {
-      var dfds = _.chain(mappedObjects)
-        .filter(function (obj) {
-          return _.contains(this._EMBED_MAPPINGS[this.scope.instance.type],
-                            obj.type);
-        }.bind(this))
-        .map(function (obj) {
-          return [
-            CMS.Models.Revision.findAll({
-              source_type: obj.type,
-              source_id: obj.id,
-              __sort: 'updated_at'
-            }).then(function (revisions) {
-              return _.map(revisions, function (revision) {
-                revision = new can.Map(revision.serialize());
-                revision.attr('updated_at', new Date(revision.updated_at));
-                revision.attr('source_type', this.scope.instance.type);
-                revision.attr('source_id', this.scope.instance.id);
-                revision.attr('source', this.scope.instance);
-                revision.attr('destination', can.Stub.get_or_create({
+      var filterElegible = function (obj) {
+        return _.contains(this._EMBED_MAPPINGS[this.scope.instance.type],
+                          obj.type);
+      }.bind(this);
+      var fetchRevisions = function (obj) {
+        return [
+          CMS.Models.Revision.findAll({
+            source_type: obj.type,
+            source_id: obj.id,
+            __sort: 'updated_at'
+          }).then(function (revisions) {
+            return _.map(revisions, function (revision) {
+              revision = new can.Map(revision.serialize());
+              revision.attr({
+                updated_at: new Date(revision.updated_at),
+                source_type: this.scope.instance.type,
+                source_id: this.scope.instance.id,
+                source: this.scope.instance,
+                destination: can.Stub.get_or_create({
                   type: revision.destination_type,
                   id: revision.destination_id
-                }));
-                rq.enqueue(revision.destination);
-                return revision;
-              }.bind(this));
-            }.bind(this)),
-            CMS.Models.Revision.findAll({
-              destination_type: obj.type,
-              destination_id: obj.id,
-              __sort: 'updated_at'
-            }).then(function (revisions) {
-              return _.map(revisions, function (revision) {
-                revision = new can.Map(revision.serialize());
-                revision.attr('updated_at', new Date(revision.updated_at));
-                revision.attr('destination_type', this.scope.instance.type);
-                revision.attr('destination_id', this.scope.instance.id);
-                revision.attr('destination', this.scope.instance);
-                revision.attr('source', can.Stub.get_or_create({
+                })
+              });
+              rq.enqueue(revision.destination);
+              return revision;
+            }.bind(this));
+          }.bind(this)),
+          CMS.Models.Revision.findAll({
+            destination_type: obj.type,
+            destination_id: obj.id,
+            __sort: 'updated_at'
+          }).then(function (revisions) {
+            return _.map(revisions, function (revision) {
+              revision = new can.Map(revision.serialize());
+              revision.attr({
+                updated_at: new Date(revision.updated_at),
+                destination_type: this.scope.instance.type,
+                destination_id: this.scope.instance.id,
+                destination: this.scope.instance,
+                source: can.Stub.get_or_create({
                   type: revision.source_type,
                   id: revision.source_id
-                }));
-                rq.enqueue(revision.source);
-                return revision;
-              }.bind(this));
-            }.bind(this))
-          ];
-        }.bind(this))
-        .flatten()
-        .value();
+                })
+              });
+              rq.enqueue(revision.source);
+              return revision;
+            }.bind(this));
+          }.bind(this))
+        ];
+      }.bind(this);
+      var dfds = _.chain(mappedObjects).filter(filterElegible)
+                                       .map(fetchRevisions)
+                                       .flatten()
+                                       .value();
       return $.when.apply($, dfds).then(function () {
         return _.filter(_.flatten(arguments), function (revision) {
+          // revisions where source == desitnation will be introduced when
+          // spoofing the obj <-> instance mapping
           return revision.source.href !== revision.destination.href;
         });
       });

--- a/src/ggrc/assets/javascripts/components/object_history/tests/object_history_spec.js
+++ b/src/ggrc/assets/javascripts/components/object_history/tests/object_history_spec.js
@@ -396,7 +396,10 @@ describe('GGRC.Components.objectHistory', function () {
             id: 123,
             type: 'ObjectFoo'
           }
-        })
+        }),
+        _fetchEmbeddedRevisionData: function () {
+          return new can.Deferred().resolve([]);
+        }
       };
 
       method = Component.prototype._fetchRevisionsData.bind(componentInst);

--- a/src/ggrc/assets/javascripts/components/tabs.js
+++ b/src/ggrc/assets/javascripts/components/tabs.js
@@ -5,7 +5,7 @@
     Maintained By: ivan@reciprocitylabs.com
 */
 
-(function (can, $) {
+(function (GGRC, can, $) {
   can.Component.extend({
     tag: 'tabs',
     template: can.view(GGRC.mustache_path + '/base_objects/tabs.mustache'),
@@ -51,7 +51,7 @@
     }
   });
 
-  can.Component.extend({
+  GGRC.Components("tabPanel", {
     tag: 'tab-panel',
     template: can.view(GGRC.mustache_path + '/base_objects/tab_panel.mustache'),
     scope: {
@@ -88,7 +88,12 @@
         var index;
         var panel;
 
-        item.split('.');
+        item = item.split('.');
+        if (item.length !== 3 || item[1] !== "panel" || item[2] !== "active") {
+          // if this is a change to a scope in a different panel we should
+          // not switch tabs
+          return;
+        }
         index = Number(item[0]);
         panel = list[index].panel;
         if (status && this.scope !== panel) {
@@ -97,4 +102,4 @@
       }
     }
   });
-})(window.can, window.can.$);
+})(window.GGRC, window.can, window.can.$);

--- a/src/ggrc/assets/javascripts/components/tabs_spec.js
+++ b/src/ggrc/assets/javascripts/components/tabs_spec.js
@@ -1,0 +1,34 @@
+/*!
+  Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+  Created By: andraz@reciprocitylabs.com
+  Maintained By: andraz@reciprocitylabs.com
+*/
+
+describe('GGRC.Components.tabPanel', function () {
+  'use strict';
+
+  var instance;
+  var scope;
+
+  beforeAll(function () {
+    instance = $(can.view.mustache('<tab-panel></tab-panel>')().children[0]);
+    scope = instance.scope();
+  });
+
+  it('doesn\'t switch tabs when internal scope changes', function () {
+    scope.attr("panels", new can.List([
+      new can.Map(),
+      new can.Map({
+        panel: new can.Map()
+      })
+    ]));
+    scope.attr("active", true);
+
+    scope.attr("panels.0.foo", "bar");
+    expect(scope.active).toEqual(true);
+
+    scope.attr("panels.1.panel.active", true);
+    expect(scope.active).toEqual(false);
+  });
+});

--- a/src/ggrc/models/object_document.py
+++ b/src/ggrc/models/object_document.py
@@ -33,6 +33,24 @@ class ObjectDocument(Timeboxed, Mapping, db.Model):
         else None
     return setattr(self, self.documentable_attr, value)
 
+
+  # properties to integrate into revision indexing
+  @property
+  def source_type(self):
+    return "Document"
+
+  @property
+  def source_id(self):
+    return self.document_id
+
+  @property
+  def destination_type(self):
+    return self.documentable_type
+
+  @property
+  def destination_id(self):
+    return self.documentable_id
+
   @staticmethod
   def _extra_table_args(cls):
     return (


### PR DESCRIPTION
This does multiple things:
- enables fetching of indirect mappings (currently coded here, not exploring mappings.js)
- enables indexing of `ObjectDocument` join objects
- fixes a bug in the tab switches
- introduces tests for the tab switcher