### PR TITLE
QUICK-FIX Fix Person type custom attr in assessment template

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment_attributes.js
+++ b/src/ggrc/assets/javascripts/components/assessment_attributes.js
@@ -129,7 +129,7 @@
         type: 'Text',
         text: 'Type description'
       }, {
-        type: 'Person',
+        type: 'Map:Person',
         text: ''  // not used
       }],
 


### PR DESCRIPTION
This is relevant to #3709 since wrong CA type causes it to not render in the generated assessment edit modal.