### PR TITLE
CORE-3394 Simplifiy Assessor User Experience

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -46,9 +46,10 @@
       // x, y, z - Point coordinates
       // i, j, k - Loop indexes
       // k, v - Key, Value
+      // a, b - common parameter names in sorting comparison helper functions
       // e - exception
       // $, _ - libraries
-      "exceptions": ["x", "y", "z", "i", "j", "k", "v", "e", "$", "_"]
+      "exceptions": ["x", "y", "z", "i", "j", "k", "v", "a", "b", "e", "$", "_"]
     }],
     "require-jsdoc": 0,
     "space-before-function-paren": [

--- a/src/ggrc/assets/javascripts/apps/business_objects.js
+++ b/src/ggrc/assets/javascripts/apps/business_objects.js
@@ -803,7 +803,9 @@
           Assessment: {
             mapping: 'extended_related_assessment_via_search',
             child_options: [related_objects_child_options],
-            draw_children: true
+            draw_children: true,
+            header_view:
+              GGRC.mustache_path + '/assessments/tree_header.mustache',
           }
         }
       });

--- a/src/ggrc/assets/javascripts/apps/dashboard.js
+++ b/src/ggrc/assets/javascripts/apps/dashboard.js
@@ -159,8 +159,8 @@
   };
 
   object_browser = /^\/objectBrowser\/?$/.test(location);
-  if (/^\/\w+\/\d+($|\?|\#)/.test(location) || /^\/dashboard/.test(location)
-      || object_browser) {
+  if (/^\/\w+\/\d+($|\?|\#)/.test(location) || /^\/dashboard/.test(location) ||
+      /^\/assessments_view/.test(location) || object_browser) {
     instance = GGRC.page_instance();
     model_name = instance.constructor.shortName;
     init_widgets();

--- a/src/ggrc/assets/javascripts/apps/dashboard.js
+++ b/src/ggrc/assets/javascripts/apps/dashboard.js
@@ -138,6 +138,8 @@
       location = window.location.pathname,
       instance, model_name, extra_page_options, defaults, object_browser;
 
+  var isAssessmentsView = /^\/assessments_view/.test(location);
+
   extra_page_options = {
       Program: {
           header_view: GGRC.mustache_path + "/base_objects/page_header.mustache"
@@ -160,11 +162,19 @@
 
   object_browser = /^\/objectBrowser\/?$/.test(location);
   if (/^\/\w+\/\d+($|\?|\#)/.test(location) || /^\/dashboard/.test(location) ||
-      /^\/assessments_view/.test(location) || object_browser) {
+      isAssessmentsView || object_browser) {
     instance = GGRC.page_instance();
     model_name = instance.constructor.shortName;
     init_widgets();
-    defaults = Object.keys(GGRC.WidgetList.get_widget_list_for(model_name));
+
+    var widgetList = GGRC.WidgetList.get_widget_list_for(model_name);
+
+    // the assessments_view only needs the Assessments widget
+    if (isAssessmentsView) {
+      widgetList = {assessment: widgetList.assessment};
+    }
+
+    defaults = Object.keys(widgetList);
 
     //Remove info and task tabs from object-browser list of tabs
     if (object_browser) {
@@ -173,8 +183,7 @@
     }
 
     $area.cms_controllers_page_object($.extend({
-      //model_descriptors: model_descriptors,
-      widget_descriptors: GGRC.WidgetList.get_widget_list_for(model_name)
+      widget_descriptors: widgetList
       , default_widgets: defaults || GGRC.default_widgets || []
       , instance: GGRC.page_instance()
       , header_view: GGRC.mustache_path + "/base_objects/page_header.mustache"

--- a/src/ggrc/assets/javascripts/apps/dashboard.js
+++ b/src/ggrc/assets/javascripts/apps/dashboard.js
@@ -1,70 +1,88 @@
 /*!
-    Copyright (C) 2013 Google Inc., authors, and contributors <see AUTHORS file>
-    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
-    Created By: brad@reciprocitylabs.com
-    Maintained By: brad@reciprocitylabs.com
+  Copyright (C) 2013 Google Inc., authors, and contributors <see AUTHORS file>
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+  Created By: brad@reciprocitylabs.com
+  Maintained By: peter@reciprocitylabs.com
 */
 
-//= require controllers/resize_widgets_controller
-//= require controllers/dashboard_widgets
-//= require models/simple_models
-//= require controls/control
-//= require sections/section
-//= require pbc/system
+(function (namespace, $) {
+  var $area = $('.area').first();
+  var defaults;
+  var extraPageOptions;
+  var instance;
+  var location = window.location.pathname;
+  var isAssessmentsView;
+  var isObjectBrowser;
+  var modelName;
+  var widgetList;
 
-(function(namespace, $) {
-  var sort_by_name_email = function(list) {
-    return new list.constructor(can.makeArray(list).sort(function(a,b) {
+  var sortByNameEmail = function (list) {
+    return new list.constructor(can.makeArray(list).sort(function (a, b) {
       a = a.person || a;
       b = b.person || b;
       a = (can.trim(a.name) || can.trim(a.email)).toLowerCase();
       b = (can.trim(b.name) || can.trim(b.email)).toLowerCase();
-      if (a > b) return 1;
-      if (a < b) return -1;
+      if (a > b) {
+        return 1;
+      }
+      if (a < b) {
+        return -1;
+      }
       return 0;
     }));
   };
-  var init_widgets = function () {
+
+  var initWidgets = function () {
     // Ensure each extension has had a chance to initialize widgets
     _.each(GGRC.extensions, function (extension) {
-      extension.init_widgets && extension.init_widgets();
+      if (extension.init_widgets) {
+        extension.init_widgets();
+      }
     });
   };
-  var admin_list_descriptors = {
-    "people" : {
-        model : CMS.Models.Person
-      , roles: new can.Observe.List()
-      , init : function() {
-          var self = this;
-          CMS.Models.Role.findAll({ scope__in: "System,Admin" }).done(function(roles) {
-            self.roles.replace(sort_by_name_email(roles));
+
+  var adminListDescriptors = {
+    people: {
+      model: CMS.Models.Person,
+      roles: new can.Observe.List(),
+      init: function () {
+        var self = this;
+        CMS.Models.Role
+          .findAll({scope__in: 'System,Admin'})
+          .done(function (roles) {
+            self.roles.replace(sortByNameEmail(roles));
           });
-        }
-      , object_display : "People"
-      , tooltip_view : "/static/mustache/people/object_tooltip.mustache"
-      , header_view : "/static/mustache/people/filters.mustache"  // includes only the filter, not the column headers
-      , list_view : "/static/mustache/people/object_list.mustache"
-      , fetch_post_process : sort_by_name_email
-    }
-    , "roles" : {
-        model : CMS.Models.Role
-      , extra_params : { scope__in: "System,Admin,Private Program,Workflow" }
-      , object_category : "governance"
-      , object_display : "Roles"
-      , list_view : "/static/mustache/roles/object_list.mustache"
-      , fetch_post_process : sort_by_name_email
-    }
-    , "events" : {
-        model : CMS.Models.Event
-      , object_category : "governance"
-      , object_display : "Events"
-      , list_view : "/static/mustache/events/object_list.mustache"
-    }
-    , "custom_attributes" : {
+      },
+      object_display: 'People',
+      tooltip_view: '/static/mustache/people/object_tooltip.mustache',
+      header_view:
+        // includes only the filter, not the column headers
+        '/static/mustache/people/filters.mustache',
+      list_view: '/static/mustache/people/object_list.mustache',
+      fetch_post_process: sortByNameEmail
+    },
+    roles: {
+      model: CMS.Models.Role,
+      extra_params: {scope__in: 'System,Admin,Private Program,Workflow'},
+      object_category: 'governance',
+      object_display: 'Roles',
+      list_view: '/static/mustache/roles/object_list.mustache',
+      fetch_post_process: sortByNameEmail
+    },
+    events: {
+      model: CMS.Models.Event,
+      object_category: 'governance',
+      object_display: 'Events',
+      list_view: '/static/mustache/events/object_list.mustache'
+    },
+    custom_attributes: {
       parent_instance: CMS.Models.CustomAttributable,
       model: CMS.Models.CustomAttributable,
-      header_view: GGRC.mustache_path + "/custom_attribute_definitions/tree_header.mustache",
-      show_view: GGRC.mustache_path + "/custom_attribute_definitions/tree.mustache",
+      header_view:
+        GGRC.mustache_path +
+        '/custom_attribute_definitions/tree_header.mustache',
+      show_view:
+        GGRC.mustache_path + '/custom_attribute_definitions/tree.mustache',
       sortable: false,
       list_loader: function () {
         return CMS.Models.CustomAttributable.findAll();
@@ -72,102 +90,106 @@
       draw_children: true,
       child_options: [{
         model: CMS.Models.CustomAttributeDefinition,
-        mapping: "custom_attribute_definitions",
-        show_view: GGRC.mustache_path + "/custom_attribute_definitions/subtree.mustache",
+        mapping: 'custom_attribute_definitions',
+        show_view:
+          GGRC.mustache_path +
+          '/custom_attribute_definitions/subtree.mustache',
         footer_view: null,
         add_item_view: null
       }]
     }
   };
-  var admin_widgets = new GGRC.WidgetList("ggrc_admin", {
-      admin : {
-        "people" : {
-            "model" : CMS.Models.Person
-          , "content_controller": GGRC.Controllers.ListView
-          , "content_controller_options": admin_list_descriptors["people"]
-          , "widget_id" : "people_list"
-          , "widget_icon" : "person"
-          , "show_filter" : false
-          , widget_name: function() {
-            return "People";
-          }
-          , widget_info : function() {
-            return "";
-          }
+
+  new GGRC.WidgetList('ggrc_admin', {
+    admin: {
+      people: {
+        model: CMS.Models.Person,
+        content_controller: GGRC.Controllers.ListView,
+        content_controller_options: adminListDescriptors.people,
+        widget_id: 'people_list',
+        widget_icon: 'person',
+        show_filter: false,
+        widget_name: function () {
+          return 'People';
+        },
+        widget_info: function () {
+          return '';
         }
-        , "roles" : {
-            "model" : CMS.Models.Role
-          , "content_controller": GGRC.Controllers.ListView
-          , "content_controller_options": admin_list_descriptors["roles"]
-          , "widget_id" : "roles_list"
-          , "widget_icon" : "role"
-          , "show_filter" : false
-          , widget_name: function() {
-            return "Roles";
-          }
-          , widget_info : function() {
-            return "";
-          }
+      },
+      roles: {
+        model: CMS.Models.Role,
+        content_controller: GGRC.Controllers.ListView,
+        content_controller_options: adminListDescriptors.roles,
+        widget_id: 'roles_list',
+        widget_icon: 'role',
+        show_filter: false,
+        widget_name: function () {
+          return 'Roles';
+        },
+        widget_info: function () {
+          return '';
         }
-        , "events" : {
-            "model" : CMS.Models.Event
-          , "content_controller": GGRC.Controllers.ListView
-          , "content_controller_options": admin_list_descriptors["events"]
-          , "widget_id" : "events_list"
-          , "widget_icon" : "event"
-          , widget_name: function() {
-            return "Events";
-          }
-          , widget_info : function() {
-            return "";
-          }
+      },
+      events: {
+        model: CMS.Models.Event,
+        content_controller: GGRC.Controllers.ListView,
+        content_controller_options: adminListDescriptors.events,
+        widget_id: 'events_list',
+        widget_icon: 'event',
+        widget_name: function () {
+          return 'Events';
+        },
+        widget_info: function () {
+          return '';
         }
-        , custom_attributes : {
-          widget_id: "custom_attribute",
-          widget_name: "Custom Attributes",
-          widget_icon: "workflow",
-          content_controller: CMS.Controllers.TreeView,
-          content_controller_selector: "ul",
-          model: CMS.Models.CustomAttributable,
-          widget_initial_content: '<ul class="tree-structure new-tree colored-list" data-no-pin="true"></ul>',
-          content_controller_options: admin_list_descriptors["custom_attributes"]
-        }
+      },
+      custom_attributes: {
+        widget_id: 'custom_attribute',
+        widget_name: 'Custom Attributes',
+        widget_icon: 'workflow',
+        content_controller: CMS.Controllers.TreeView,
+        content_controller_selector: 'ul',
+        model: CMS.Models.CustomAttributable,
+        widget_initial_content:
+          '<ul' +
+          '  class="tree-structure new-tree colored-list"' +
+          '  data-no-pin="true"' +
+          '></ul>',
+        content_controller_options: adminListDescriptors.custom_attributes
       }
+    }
   });
-  var $area = $('.area').first(),
-      location = window.location.pathname,
-      instance, model_name, extra_page_options, defaults, object_browser;
 
-  var isAssessmentsView = /^\/assessments_view/.test(location);
-
-  extra_page_options = {
-      Program: {
-          header_view: GGRC.mustache_path + "/base_objects/page_header.mustache"
-        , page_title: function(controller) {
-            return "GRC Program: " + controller.options.instance.title;
-          }
-
+  extraPageOptions = {
+    Program: {
+      header_view: GGRC.mustache_path + '/base_objects/page_header.mustache',
+      page_title: function (controller) {
+        return 'GRC Program: ' + controller.options.instance.title;
       }
-    , Person: {
-          header_view: GGRC.mustache_path + "/base_objects/page_header.mustache"
-        , page_title: function(controller) {
-            var instance = controller.options.instance;
-            return /dashboard/.test(window.location)
-              ? "GRC: My Work"
-              : "GRC Profile: " + (instance.name && instance.name.trim()) || (instance.email && instance.email.trim());
-          }
-
+    },
+    Person: {
+      header_view: GGRC.mustache_path + '/base_objects/page_header.mustache',
+      page_title: function (controller) {
+        var instance = controller.options.instance;
+        return /dashboard/.test(window.location) ?
+          'GRC: My Work' :
+          'GRC Profile: ' +
+              (instance.name && instance.name.trim()) ||
+              (instance.email && instance.email.trim());
       }
+    }
   };
 
-  object_browser = /^\/objectBrowser\/?$/.test(location);
-  if (/^\/\w+\/\d+($|\?|\#)/.test(location) || /^\/dashboard/.test(location) ||
-      isAssessmentsView || object_browser) {
-    instance = GGRC.page_instance();
-    model_name = instance.constructor.shortName;
-    init_widgets();
+  isAssessmentsView = /^\/assessments_view/.test(location);
+  isObjectBrowser = /^\/objectBrowser\/?$/.test(location);
 
-    var widgetList = GGRC.WidgetList.get_widget_list_for(model_name);
+  if (/^\/\w+\/\d+($|\?|\#)/.test(location) || /^\/dashboard/.test(location) ||
+      isAssessmentsView || isObjectBrowser) {
+    instance = GGRC.page_instance();
+    modelName = instance.constructor.shortName;
+    initWidgets();
+
+    widgetList = GGRC.WidgetList.get_widget_list_for(modelName);
 
     // the assessments_view only needs the Assessments widget
     if (isAssessmentsView) {
@@ -176,51 +198,52 @@
 
     defaults = Object.keys(widgetList);
 
-    //Remove info and task tabs from object-browser list of tabs
-    if (object_browser) {
+    // Remove info and task tabs from object-browser list of tabs
+    if (isObjectBrowser) {
       defaults.splice(defaults.indexOf('info'), 1);
       defaults.splice(defaults.indexOf('task'), 1);
     }
 
     $area.cms_controllers_page_object($.extend({
-      widget_descriptors: widgetList
-      , default_widgets: defaults || GGRC.default_widgets || []
-      , instance: GGRC.page_instance()
-      , header_view: GGRC.mustache_path + "/base_objects/page_header.mustache"
-      , page_title: function(controller) {
-          return controller.options.instance.title;
-        }
-      , page_help: function(controller) {
-          return controller.options.instance.constructor.table_singular;
-        }
-      , current_user: GGRC.current_user
-      }, extra_page_options[model_name]));
+      widget_descriptors: widgetList,
+      default_widgets: defaults || GGRC.default_widgets || [],
+      instance: GGRC.page_instance(),
+      header_view: GGRC.mustache_path + '/base_objects/page_header.mustache',
+      page_title: function (controller) {
+        return controller.options.instance.title;
+      },
+      page_help: function (controller) {
+        return controller.options.instance.constructor.table_singular;
+      },
+      current_user: GGRC.current_user
+    }, extraPageOptions[modelName]));
   } else if (/^\/admin\/?$/.test(location)) {
     $area.cms_controllers_dashboard({
-        widget_descriptors: GGRC.WidgetList.get_widget_list_for("admin")
-      , menu_tree_spec: GGRC.admin_menu_spec
-      , default_widgets : ["people", "roles", "events", "custom_attributes"]
+      widget_descriptors: GGRC.WidgetList.get_widget_list_for('admin'),
+      menu_tree_spec: GGRC.admin_menu_spec,
+      default_widgets: ['people', 'roles', 'events', 'custom_attributes']
     });
-    init_widgets();
+    initWidgets();
   } else if (/^\/import|export/i.test(location)) {
-    init_widgets();
+    initWidgets();
   } else {
     $area.cms_controllers_dashboard({
       widget_descriptors: GGRC.widget_descriptors,
-      default_widgets : GGRC.default_widgets
+      default_widgets: GGRC.default_widgets
     });
   }
 
-  $("body").on("click", ".note-trigger, .edit-notes", function(ev) {
-    ev.stopPropagation();
-    var $object = $(ev.target).closest("[data-object-id]")
-    , type = $object.data("object-type")
-    , notes_model = widget_descriptors[type].model
-    , sec;
+  $('body').on('click', '.note-trigger, .edit-notes', function (ev) {
+    var $object = $(ev.target).closest('[data-object-id]');
+    var type = $object.data('object-type');
+    var notesModel = GGRC.widget_descriptors[type].model;
 
-    $(ev.target).closest(".note").cms_controllers_section_notes({
-      section_id : $object.data("object-id") || (/\d+$/.exec(window.location.pathname) || [null])[0]
-      , model_class : notes_model
+    ev.stopPropagation();
+
+    $(ev.target).closest('.note').cms_controllers_section_notes({
+      section_id: $object.data('object-id') ||
+                  (/\d+$/.exec(window.location.pathname) || [null])[0],
+      model_class: notesModel
     });
   });
 })(this, jQuery);

--- a/src/ggrc/assets/mustache/assessments/tree_header.mustache
+++ b/src/ggrc/assets/mustache/assessments/tree_header.mustache
@@ -1,70 +1,59 @@
 {{!
-    Copyright (C) 2015 Google Inc., authors, and contributors <see AUTHORS file>
-    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
-    Created By: anze@reciprocitylabs.com
-    Maintained By: anze@reciprocitylabs.com
+  Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+  Created By: anze@reciprocitylabs.com
+  Maintained By: peter@reciprocitylabs.com
 }}
 
-{{{> "/static/mustache/base_objects/tree_view_filter.mustache"}}}
-
-<header class="header sticky sticky-header tree-header {{#filter_is_hidden}}no-filter{{/filter_is_hidden}}">
-  <div class="row-fluid">
-    <div class="span4">
+{{#if_equals original_list.length 0}}
+  <div class="zero-state">
+    <h2>
+      {{#is_profile}}
+        You have
+      {{else}}
+        {{#with_page_object_as 'page_object'}}
+          {{page_object.type}} has
+        {{/with_page_object_as}}
+      {{/is_profile}}
+      no assigned tasks
+    </h2>
+  </div>
+{{else}}
+  {{{> "/static/mustache/base_objects/tree_view_filter.mustache"}}}
+  <header
+    class="header sticky sticky-header tree-header
+          {{#filter_is_hidden}}no-filter{{/filter_is_hidden}}">
+    <div class="row-fluid">
+      <div class="span{{display_options.title_width}}">
         <div class="title-heading oneline">
           <span class="widget-col-title" data-field="title|description_inline|name|email">
             {{model.title_singular}} Title
             <i class="fa fa-caret-up"></i>
           </span>
-      </div>
-    </div>
-    <div class="span1">
-      <div class="oneline">
-        <span class="widget-col-title" data-field="owners.0.name|email">
-          Owner
-          <i class="fa fa-caret-up"></i>
-        </span>
-      </div>
-    </div>
-    <div class="span2">
-      <div class="row-fluid">
-        <div class="span6">
-          <div class="oneline centered">
-            <span class="widget-col-title" data-field="design">
-              Design
-              <i class="fa fa-caret-up"></i>
-            </span>
-          </div>
-        </div>
-        <div class="span6">
-          <div class="oneline centered">
-            <span class="widget-col-title" data-field="operationally">
-              Operational
-              <i class="fa fa-caret-up"></i>
-            </span>
-          </div>
         </div>
       </div>
-    </div>
-    <div class="span1">
-      <div class="oneline">
-        <span class="widget-col-title" data-field="status">
-          State
-          <i class="fa fa-caret-up"></i>
-        </span>
+
+      {{{> "/static/mustache/base_objects/tree_column_names.mustache"}}}
+
+      <div class="span{{display_options.action_width}}">
+          <ul class="tree-action-list">
+
+          {{{> "/static/mustache/import_export/import_export_buttons.mustache}}}
+          <assessment-generator-button
+            audit="parent_instance"></assessment-generator-button>
+          {{{> "/static/mustache/base_objects/filter_trigger.mustache}}}
+          {{{> "/static/mustache/base_objects/tree_column_selector.mustache"}}}
+          {{{> "/static/mustache/base_objects/sub_tree_type_selector.mustache"}}}
+
+          {{#if add_item_view}}
+            <li>
+              {{{renderLive add_item_view}}}
+            </li>
+          {{/if}}
+        </ul>
       </div>
     </div>
-    <div class="span4">
-        <ul class="tree-action-list">
-        {{{> "/static/mustache/import_export/import_export_buttons.mustache}}}
-        <assessment-generator-button audit="parent_instance"></assessment-generator-button>
-        {{{> "/static/mustache/base_objects/filter_trigger.mustache}}}
-        {{#if add_item_view}}
-          <li>
-            {{{renderLive add_item_view}}}
-          </li>
-        {{/if}}
-      </ul>
-    </div>
-  </div>
-</header>
+  </header>
+{{/if_equals}}
+
 <div class="clearfix"></div>

--- a/src/ggrc/templates/assessments_view/index.haml
+++ b/src/ggrc/templates/assessments_view/index.haml
@@ -22,4 +22,69 @@
   My Assessments
 
 -block body
-  TODO: put some content in here
+  -# TODO: this <header> needed?
+  %header.header.main
+
+  .area{ 'class': '={ model_display_class }' }
+    .header-content
+      %h2.logo-wrap{ 'class': '={ logo_wrap_class }' }
+        %a{ 'class': 'to-my-work', 'href': '/dashboard' }
+          -set logo_url = config.get("COMPANY_LOGO")
+          -if logo_url
+            %img{ "src" : "#{logo_url}", 'alt' : 'GRC', 'title' : 'GRC'}
+
+      -# TODO: something injects menu into the header black, we need
+      -# to remove it
+      #page-header
+        -block header
+
+    -# TODO: remove this and make sure thereis no script error
+    -# to remove it
+    -block nav
+      .top-inner-nav
+        .object-nav
+          %ul.nav{ 'class': "internav" }
+
+    %section.content
+      .flash
+        -with messages = get_flashed_messages(with_categories=True)
+          -if messages
+            -for category, message in messages
+              %div{ 'class': "{{category}}" }
+                %a.close{'href': "#", 'data-dismiss': "alert" }
+                  x
+                %p
+                  {{message}}
+        -#FIXME: Flash messages
+        -#flash.each do |type, value|
+          -value = [value] unless value.is_a?(Array)
+          -value = value.map(:presence).compact
+          -if value.size > 0
+            %div{ 'class': type }
+              %a.close{'href': "#{}", :'data-dismiss': "alert"}
+                &times;
+              -value.each do |message|
+                %p=message
+      -block main
+        .clearfix
+          //.objnav.bar-v
+          //.inner-nav
+            .object-nav
+              %ul.nav{ 'class': "internav ={ model_display_class }" }
+          .object-area
+            #show_columns.column-set{ 'data-resize': "true" }
+              #middle_column
+                .row-fluid
+                  .span12.full-width
+                    .inner-content.widget-area
+                      -block widget_area
+          .pin-content
+
+    %section.footer
+      .row-fluid
+        .span12
+          %p
+            =config.get('COPYRIGHT')
+            =config.get('COMPANY')
+            Version
+            =config.get('VERSION')

--- a/src/ggrc/templates/assessments_view/index.haml
+++ b/src/ggrc/templates/assessments_view/index.haml
@@ -11,20 +11,12 @@
   GGRC.config = ={ config_json()|safe };
   GGRC.custom_attr_defs =  ={ attributes_json()|safe }
   GGRC.model_attr_defs =  ={ all_attributes_json()|safe }
-
-  // TODO: should probably be something else?
   GGRC.page_object = { "person": ={ current_user_json()|safe } };
 
 -block page_help scoped
   dashboard
 
--block title
-  My Assessments
-
 -block body
-  -# TODO: this <header> needed?
-  %header.header.main
-
   .area{ 'class': '={ model_display_class }' }
     .header-content
       %h2.logo-wrap{ 'class': '={ logo_wrap_class }' }
@@ -33,13 +25,10 @@
           -if logo_url
             %img{ "src" : "#{logo_url}", 'alt' : 'GRC', 'title' : 'GRC'}
 
-      -# TODO: something injects menu into the header black, we need
-      -# to remove it
-      #page-header
-        -block header
+      %h1.entities
+        %span.title-content
+          My Assessments
 
-    -# TODO: remove this and make sure thereis no script error
-    -# to remove it
     -block nav
       .top-inner-nav
         .object-nav
@@ -67,10 +56,9 @@
                 %p=message
       -block main
         .clearfix
-          //.objnav.bar-v
-          //.inner-nav
-            .object-nav
-              %ul.nav{ 'class': "internav ={ model_display_class }" }
+          .object-nav
+            %ul.nav{ 'class': "internav ={ model_display_class }" }
+
           .object-area
             #show_columns.column-set{ 'data-resize': "true" }
               #middle_column

--- a/src/ggrc/templates/assessments_view/index.haml
+++ b/src/ggrc/templates/assessments_view/index.haml
@@ -1,0 +1,25 @@
+-# Copyright (C) 2013 Google Inc., authors, and contributors <see AUTHORS file>
+-# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+-# Created By: peter@reciprocitylabs.com
+-# Maintained By: peter@reciprocitylabs.com
+
+-extends 'layouts/base.haml'
+
+-block extra_javascript
+  GGRC.permissions = ={ permissions_json()|safe };
+  GGRC.current_user = ={ current_user_json()|safe };
+  GGRC.config = ={ config_json()|safe };
+  GGRC.custom_attr_defs =  ={ attributes_json()|safe }
+  GGRC.model_attr_defs =  ={ all_attributes_json()|safe }
+
+  // TODO: should probably be something else?
+  GGRC.page_object = { "person": ={ current_user_json()|safe } };
+
+-block page_help scoped
+  dashboard
+
+-block title
+  My Assessments
+
+-block body
+  TODO: put some content in here

--- a/src/ggrc/views/__init__.py
+++ b/src/ggrc/views/__init__.py
@@ -242,6 +242,13 @@ def admin():
   return render_template("admin/index.haml")
 
 
+@app.route("/assessments_view")
+@login_required
+def assessments_view():
+  """The clutter-free list of all Person's Assessments"""
+  return render_template("assessments_view/index.haml")
+
+
 @app.route("/background_task/<id_task>", methods=['GET'])
 def get_task_response(id_task):
   """Gets the status of a background task"""


### PR DESCRIPTION
This PR adds a new and distraction-free `/assessments_view` view that only displays thel Assessments assigned to the current user's, without any other unnecessary page elements such as LHN, the widgets bar etc.

The PR also lints the `apps/dashboard.js` file, thus I recommend reviewing this on a commit-to-commit basis to see what has changed in there in terms of business logic.