### PR TITLE
CORE-2964 Handling mandatory comments and attachments

### DIFF
--- a/src/ggrc/assets/javascripts/models/cacheable.js
+++ b/src/ggrc/assets/javascripts/models/cacheable.js
@@ -739,6 +739,10 @@ can.Model("can.Model.Cacheable", {
     if (this.attr('custom_attribute_definitions')) {
       return;
     }
+    if (GGRC.custom_attr_defs === undefined) {
+      GGRC.custom_attr_defs = {};
+      console.warn("Missing injected custom attribute definitions");
+    }
     definitions = can.map(GGRC.custom_attr_defs, function (def) {
       var idCheck = !def.definition_id || def.definition_id === this.id;
       if (idCheck && def.definition_type === this.constructor.table_singular) {

--- a/src/ggrc/assets/mustache/assessments/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessments/modal_content.mustache
@@ -150,21 +150,6 @@
         </div>
       </div>
     </div>
-    <div class="row-fluid">
-      <div data-id="state_hidden" class="span4 hidable">
-        <label>
-          State
-          <i class="fa fa-question-circle" rel="tooltip" title="Indicates the status of this object."></i>
-          <a data-id="hide_state_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
-        </label>
-        <select data-id="state_dd" class="input-block-level" name="status" null-if-empty="null-if-empty" tabindex="6">
-          <option value="" {{#if_equals status ""}}selected{{/if_equals}}>---</option>
-          {{#iterate 'Open', 'In Progress', 'Finished', 'Verified', 'Final'}}
-            <option {{#if_equals iterator status}}selected="true"{{/if_equals}}>{{iterator}}</option>
-          {{/iterate}}
-        </select>
-      </div>
-    </div>
 
     <div class="row-fluid">
       <div class="span6 hidable">

--- a/src/ggrc/assets/mustache/base_templates/add_comment.mustache
+++ b/src/ggrc/assets/mustache/base_templates/add_comment.mustache
@@ -5,6 +5,16 @@
     Maintained By: ivan@reciprocitylabs.com
 }}
 <div class="add-comment">
+  {{^if_null parent_instance._mandatory_comment_msg}}
+    <div class="row-fluid">
+      <div class="span8">
+        <div class="alert alert-info alert-dismissible" role="alert">
+          {{parent_instance._mandatory_comment_msg}}
+          <button type="button" class="close" data-dismiss="alert" aria-label="Close">&times;</button>
+        </div>
+      </div>
+    </div>
+  {{/if_null}}
   <div class="row-fluid">
     <div class="span8">
       <div class="controls top">

--- a/src/ggrc/assets/mustache/base_templates/attachment_list.mustache
+++ b/src/ggrc/assets/mustache/base_templates/attachment_list.mustache
@@ -5,6 +5,14 @@
     Maintained By: ivan@reciprocitylabs.com
 }}
 
+
+{{^if_null instance._mandatory_attachment_msg}}
+  <div class="alert alert-info alert-dismissible" role="alert">
+    {{instance._mandatory_attachment_msg}}
+    <button type="button" class="close" data-dismiss="alert" aria-label="Close">&times;</button>
+  </div>
+{{/if_null}}
+
 <mapping-tree-view
   parent-instance="instance"
   mapping="instance.class.info_pane_options.evidence.mapping"

--- a/src/ggrc/assets/mustache/mixins/stateful.mustache
+++ b/src/ggrc/assets/mustache/mixins/stateful.mustache
@@ -9,11 +9,34 @@
   <div {{#instance}}{{data 'model'}}{{/instance}} {{ (el) -> el.ggrc_controllers_quick_form({instance : el.data("model") }) }}>
 
   {{#if_in instance.status "Open,In Progress"}}
-    {{#if_verifiers_defined instance}}
-        <button href="javascript://" class="btn btn-small btn-primary pull-right btn-info-pin-header {{instance._disabled}}" data-name="status" data-value="Finished">Finish</button>
+    {{#if_helpers '\
+      #if_null' instance._mandatory_comment_msg '\
+      and #if_null' instance._mandatory_attachment_msg}}
+      {{#if_verifiers_defined instance}}
+          <button href="javascript://"
+                  class="btn btn-small btn-primary pull-right btn-info-pin-header {{instance._disabled}}"
+                  data-name="status"
+                  data-value="Finished">
+            Finish
+          </button>
+      {{else}}
+          <button href="javascript://"
+                  class="btn btn-small btn-primary pull-right btn-info-pin-header {{instance._disabled}}"
+                  data-name="status"
+                  data-value="Final">
+            Finish
+          </button>
+      {{/if_verifiers_defined}}
     {{else}}
-        <button href="javascript://" class="btn btn-small btn-primary pull-right btn-info-pin-header {{instance._disabled}}" data-name="status" data-value="Final">Finish</button>
-    {{/if_verifiers_defined}}
+      <button href="javascript://"
+              class="btn btn-small btn-primary pull-right btn-info-pin-header disabled"
+              rel="tooltip"
+              title="{{instance._mandatory_comment_msg}}
+                     {{^if_null instance._mandatory_comment_msg}} | {{/if}}
+                     {{instance._mandatory_attachment_msg}}">
+        Finish
+      </button>
+    {{/if_helpers}}
   {{/if_in}}
 
   {{#if_equals instance.status "Finished"}}


### PR DESCRIPTION
**depends on** #3709

Implements handling of mandatory comments and attachments on assessments:
- disable finish button
- show notifications that you should make a comment or attach evidence

Still needs polishing (and is blocked by #3709 merge)