### PR TITLE
QUICK-FIX Fix selenium tests

### DIFF
--- a/src/ggrc/assets/javascripts/models/join_models.js
+++ b/src/ggrc/assets/javascripts/models/join_models.js
@@ -248,8 +248,8 @@ can.Model.Join("CMS.Models.ObjectOwner", {
   update: 'PUT /api/object_owners/{id}',
   destroy: 'DELETE /api/object_owners/{id}',
   join_keys: {
-    ownable: 'can.Model.Cacheable',
-    person: 'CMS.Models.Person'
+    ownable: can.Model.Cacheable,
+    person: CMS.Models.Person
   },
   attributes: {
     context: 'CMS.Models.Context.stub',

--- a/test/selenium/src/lib/constants/locator.py
+++ b/test/selenium/src/lib/constants/locator.py
@@ -802,7 +802,7 @@ class AdminCustomAttributes(object):
   class _Locator(object):
     @staticmethod
     def get_toggle(child_id):
-      return (By.CSS_SELECTOR, '.tree-structure li:nth-child({}) div '
+      return (By.CSS_SELECTOR, '#custom_attribute_widget li:nth-child({}) '
               '.openclose'.format(child_id))
 
     @staticmethod


### PR DESCRIPTION
- [x] The old selector was also matching the .openclose element in the
`people_list_widget` which was not visible and therefore not clickable
causing the selenium test to fail.

  This should make the custom attributes test pass, but I expect the selenium tests to fail because of   another issue (waiting for redirect when clicking save & add another).

-  [x] Fix creation of objects (this was not a Selenium test issue, but an issue introduced by 5ecef933e400fafa8234d778cb92a86590eccc7c

- [x] random ERROR:

```
request = <SubRequest 'selenium' for <Function 'test_app_redirects_to_new_risk_page'>>
capabilities = {'browserName': 'Chrome', 'platform': 'Any'}

    @pytest.fixture
    def selenium(request, capabilities):
        """Returns a WebDriver instance based on options and capabilities"""
        from .driver import start_driver
>       driver = start_driver(request.node, capabilities)

/usr/local/lib/python2.7/dist-packages/pytest_selenium/pytest_selenium.py:75: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/usr/local/lib/python2.7/dist-packages/pytest_selenium/driver.py:26: in start_driver
    options.driver.lower()))(item, _capabilities)
/usr/local/lib/python2.7/dist-packages/pytest_selenium/driver.py:51: in chrome_driver
    return webdriver.Chrome(**kwargs)
/usr/local/lib/python2.7/dist-packages/selenium/webdriver/chrome/webdriver.py:67: in __init__
    desired_capabilities=desired_capabilities)
/usr/local/lib/python2.7/dist-packages/selenium/webdriver/remote/webdriver.py:87: in __init__
    self.start_session(desired_capabilities, browser_profile)
/usr/local/lib/python2.7/dist-packages/selenium/webdriver/remote/webdriver.py:141: in start_session
    'desiredCapabilities': desired_capabilities,
/usr/local/lib/python2.7/dist-packages/selenium/webdriver/remote/webdriver.py:199: in execute
    response = self.command_executor.execute(driver_command, params)
/usr/local/lib/python2.7/dist-packages/selenium/webdriver/remote/remote_connection.py:395: in execute
    return self._request(command_info[0], url, body=data)
/usr/local/lib/python2.7/dist-packages/selenium/webdriver/remote/remote_connection.py:426: in _request
    resp = self._conn.getresponse()
/usr/lib/python2.7/httplib.py:1127: in getresponse
    response.begin()
/usr/lib/python2.7/httplib.py:453: in begin
    version, status, reason = self._read_status()
/usr/lib/python2.7/httplib.py:409: in _read_status
    line = self.fp.readline(_MAXLINE + 1)
```