### PR TITLE
QUICK-FIX Update docker provisioning in the project readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,11 @@ vagrant up
 
 To reprovision a docker container run the following:
 
+Remove files that are not in the repository e.g. python cache:
+```sh
+git clean -df
+```
+Start reprovisioning:
 ```sh
 docker-compose build --pull --no-cache
 ```


### PR DESCRIPTION
Python cache breaks building packages installed by pip so reprovisioning doesn't work if the repo isn't clean.