### PR TITLE
CORE-2508 Adjust AssessmentTemplate's custom attribute types

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment_attributes.js
+++ b/src/ggrc/assets/javascripts/components/assessment_attributes.js
@@ -117,24 +117,27 @@
     scope: {
       selected: new can.Map(),
       types: [{
-        type: 'Dropdown',
-        text: 'Type values separated by comma'
+        type: 'Text',
+        text: 'Type description'
+      }, {
+        type: 'Rich Text',
+        text: 'Type description'
+      }, {
+        type: 'Date',
+        text: 'MM/DD/YYYY'
       }, {
         type: 'Checkbox',
         text: 'Type label'
       }, {
-        type: 'Radio',
+        type: 'Dropdown',
         text: 'Type values separated by comma'
-      }, {
-        type: 'Text',
-        text: 'Type description'
       }, {
         type: 'Map:Person',
         text: ''  // not used
       }],
 
       // the field types that require a list of possible values to be defined
-      valueAttrs: ['Dropdown', 'Checkbox', 'Radio'],
+      valueAttrs: ['Dropdown', 'Checkbox'],
 
       /*
        * Create a new field.


### PR DESCRIPTION
The list of possible choices is now in line with the similar list on the Admin panel's custom attribute definitions page.

**Note:** A few things from the ticket that need additional clarification, such as maybe adding the Radio type and changing how Checkbox type behaves, are intentionally omitted from this PR. I will open separate tickets for these as discussed with @Smotko 