### PR TITLE
CORE-3527 Prepopulate cycletask default dates

### DIFF
--- a/src/ggrc_workflows/assets/javascripts/models/cycle_models.js
+++ b/src/ggrc_workflows/assets/javascripts/models/cycle_models.js
@@ -373,6 +373,10 @@
       var cycle;
 
       if (newObjectForm) {
+        // prepopulate dates with default ones
+        this.attr("start_date", new Date());
+        this.attr("end_date", moment().add({month: 3}).toDate());
+
         if (!form.contact) {
           form.attr("contact", {id: GGRC.current_user.id, type: "Person"});
         }


### PR DESCRIPTION
This PR auto populates the cycle task creation modal with default dates. Currently you can only make a cycle task for one time workflows, that's why logic is done only for this frequency.