### PR TITLE
CORE-3440 Display full usernames on AssessmentTemplate info

### DIFF
--- a/src/ggrc/assets/mustache/assessment_templates/info.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/info.mustache
@@ -66,7 +66,9 @@
               {{#if default_people.assessors.length}}
                 <ul>
                   {{#each default_people.assessors}}
-                    <li>User {{.}}</li>  {{!TODO: get the actual User object}}
+                    <li>
+                      <person person-id="{{.}}"></person>
+                    </li>
                   {{/each}}
                 </ul>
               {{else}}
@@ -87,7 +89,9 @@
               {{#if default_people.verifiers.length}}
                 <ul>
                   {{#each default_people.verifiers}}
-                    <li>User {{.}}</li>  {{!TODO: get the actual User object}}
+                    <li>
+                      <person person-id="{{.}}"></person>
+                    </li>
                   {{/each}}
                 </ul>
               {{else}}


### PR DESCRIPTION
**Note:** the trash icon (i.e. the Delete button) is still being displayed next to the user name, but that will change when @hyperNURb finishes the ticket he is currently working on - that ticket will alter the behavior of the `<person>` component, hiding the Delete button by default unless an `on-delete` handler is provided. I thus didn't address that in this PR.