### PR TITLE
QUICK-FIX Fix Audit mappings

### DIFF
--- a/src/ggrc/assets/javascripts/apps/base_widgets.js
+++ b/src/ggrc/assets/javascripts/apps/base_widgets.js
@@ -8,7 +8,7 @@
 (function (GGRC, _) {
   var base_widgets_by_type = {
     AccessGroup: 'Audit Clause Contract Control Assessment DataAsset Facility Issue Market Objective OrgGroup Person Policy Process Product Program Project Regulation Request Section Standard System Vendor',
-    Audit: 'Control Assessment AssessmentTemplate Issue Person Program Request Regulation Policy Standard Contract Section Clause Objective',
+    Audit: 'AccessGroup Clause Contract Control Assessment AssessmentTemplate DataAsset Facility Issue Market Objective OrgGroup Person Policy Process Product Program Project Regulation Request Section Standard System Vendor',
     Clause: 'AccessGroup Audit Contract Control Assessment DataAsset Facility Issue Market Objective OrgGroup Person Policy Process Product Program Project Regulation Request Section Standard System Vendor',
     Contract: 'AccessGroup Audit Clause Control Assessment DataAsset Facility Issue Market Objective OrgGroup Person Process Product Program Project Request Section System Vendor',
     Control: 'AccessGroup Audit Clause Contract Control Assessment DataAsset Facility Issue Market Objective OrgGroup Person Policy Process Product Program Project Regulation Request Request Section Standard System Vendor',

--- a/src/ggrc/assets/javascripts/apps/business_objects.js
+++ b/src/ggrc/assets/javascripts/apps/business_objects.js
@@ -212,11 +212,6 @@
             widget_id: "Request",
             widget_name: "Open Requests"
           },
-          Control: {
-            widget_id: "control",
-            widget_name: "In Scope Controls",
-            widget_icon: "control"
-          },
           program: {
             widget_id: "program",
             widget_name: "Program",
@@ -451,17 +446,6 @@
             show_view: GGRC.mustache_path + "/requests/tree.mustache",
             footer_view: GGRC.mustache_path + "/requests/tree_footer.mustache",
             add_item_view: GGRC.mustache_path + "/requests/tree_add_item.mustache"
-          },
-          Control: {
-            mapping: "program_controls",
-            parent_instance: GGRC.page_instance(),
-            draw_children: true,
-            model: CMS.Models.Control,
-            show_view: GGRC.mustache_path + "/controls/tree.mustache",
-            footer_view: GGRC.mustache_path + "/controls/tree_footer.mustache",
-            add_item_view: GGRC.mustache_path + "/controls/tree_add_item.mustache",
-            allow_mapping: false,
-            allow_creating: false
           },
           Program: {
             mapping: "_program",

--- a/src/ggrc/assets/javascripts/apps/business_objects.js
+++ b/src/ggrc/assets/javascripts/apps/business_objects.js
@@ -439,7 +439,7 @@
           }
         },
         Audit: {
-          _mixins: ['issues', 'governance_objects'],
+          _mixins: ['issues', 'governance_objects', 'business_objects'],
           Request: {
             mapping: "active_requests",
             draw_children: true,
@@ -488,6 +488,17 @@
             add_item_view:
               GGRC.mustache_path + '/base_objects/tree_add_item.mustache'
           },
+          Person: {
+            widget_id: "person",
+            widget_name: "People",
+            widget_icon: "person",
+            content_controller: GGRC.Controllers.TreeView,
+            content_controller_options: {
+              mapping: "authorized_people",
+              allow_mapping: false,
+              allow_creating: false
+            }
+          }
         },
         directive: {
           _mixins: [

--- a/src/ggrc/assets/javascripts/models/mappings.js
+++ b/src/ggrc/assets/javascripts/models/mappings.js
@@ -617,7 +617,7 @@
         requests: 'Request',
         _program: 'Program',
         context: 'Context',
-        related_objects_as_source: ['Assessment', 'AssessmentTemplate', 'Issue']
+
       },
       _mixins: [
         'related_object'

--- a/src/ggrc/assets/javascripts/models/mappings.js
+++ b/src/ggrc/assets/javascripts/models/mappings.js
@@ -619,6 +619,9 @@
         context: 'Context',
         related_objects_as_source: ['Assessment', 'AssessmentTemplate', 'Issue']
       },
+      _mixins: [
+        'related_object'
+      ],
       requests: Direct("Request", "audit", "requests"),
       active_requests: CustomFilter('requests', function (result) {
         return result.instance.status !== 'Accepted';
@@ -632,8 +635,6 @@
       program_issues: Cross('_program', 'related_issues'),
       program_assessments: Cross('_program', 'related_assessments'),
       objects: Proxy(null, 'auditable', 'AuditObject', 'audit', 'audit_objects'),
-      objectives: TypeFilter('objects', 'Objective'),
-      objectives_via_program: Cross('_program', 'objectives'),
       responses_via_requests: Cross('requests', 'related_objects'),
       related_objects_via_requests: Multi(['requests', 'responses_via_requests']),
       context: Direct('Context', 'related_object', 'context'),
@@ -684,30 +685,13 @@
         else
           return false;
       }),
-      //related_mapped_requests: TypeFilter("related_mapped_objects", "Request"),
-      related_requests: TypeFilter("related_objects_via_relationship", "Request"),
       related_mapped_documentation_responses: TypeFilter("related_mapped_objects", "DocumentationResponse"),
       related_mapped_interview_responses: TypeFilter("related_mapped_objects", "InterviewResponse"),
       related_mapped_population_sample_responses: TypeFilter("related_mapped_objects", "PopulationSampleResponse"),
       related_mapped_responses: Multi(["related_mapped_documentation_responses", "related_mapped_interview_responses", "related_mapped_population_sample_responses"]),
       extended_related_objects: Cross("requests", "extended_related_objects"),
-      related_objects_as_source: Proxy(
-        null, "destination", "Relationship", "source", "related_destinations"),
-      related_objects_as_destination: Proxy(
-        null, "source", "Relationship", "destination", "related_sources"),
-      related_objects: Multi(["related_objects_as_source", "related_objects_as_destination"]),
-      related_assessments: TypeFilter("related_objects", "Assessment"),
       related_assessment_templates: TypeFilter(
-        'related_objects', 'AssessmentTemplate'),
-      related_issues: TypeFilter('related_objects', 'Issue'),
-      regulations: TypeFilter('related_objects', 'Regulation'),
-      policies: TypeFilter('related_objects', 'Policy'),
-      standards: TypeFilter('related_objects', 'Standard'),
-      contracts: TypeFilter('related_objects', 'Contract'),
-      sections: TypeFilter('related_objects', 'Section'),
-      clauses: TypeFilter('related_objects', 'Clause'),
-      objectives: TypeFilter('related_objects', 'Objective'),
-      controls: TypeFilter('related_objects', 'Control')
+        'related_objects', 'AssessmentTemplate')
     },
     Assessment: {
       _mixins: [

--- a/src/ggrc/models/hooks/assessment.py
+++ b/src/ggrc/models/hooks/assessment.py
@@ -26,6 +26,9 @@ def init_hook():
     """Apply custom attribute definitions and map people roles
     when generating Assessmet with template"""
 
+    if not src.get("template", None):
+      return
+
     related = {
         "template": get_by_id(src.get("template", None)),
         "obj": get_by_id(src.get("object", None)),

--- a/src/ggrc/utils.py
+++ b/src/ggrc/utils.py
@@ -193,6 +193,7 @@ def get_mapping_rules():
       "Risk": "AccessGroup Clause Contract Assessment Control DataAsset Facility Issue Market Objective OrgGroup Person Policy Process Product Program Project Regulation Request Section Standard System Vendor Threat CycleTaskGroupObjectTask",  # noqa
       "Threat": "AccessGroup Clause Contract Assessment Control DataAsset Facility Issue Market Objective OrgGroup Person Policy Process Product Program Project Regulation Request Section Standard System Vendor Risk CycleTaskGroupObjectTask",  # noqa
       "CycleTaskGroupObjectTask": "AccessGroup Clause Contract Assessment Control DataAsset Facility Issue Market Objective OrgGroup Person Policy Process Product Program Project Regulation Request Section Standard System Vendor Risk Threat",  # noqa
+      "AssessmentTemplate": "Audit",
   }
 
   split_rules = {k: v.split() for k, v in business_object_rules.items()}

--- a/src/ggrc/utils.py
+++ b/src/ggrc/utils.py
@@ -167,7 +167,8 @@ def get_mapping_rules():
   # TODO: Read these rules from different modules and combine them here.
   business_object_rules = {
       "AccessGroup": "Audit Clause Contract Control Assessment DataAsset Facility Issue Market Objective OrgGroup Person Policy Process Product Program Project Regulation Request Section Standard System Vendor Risk Threat CycleTaskGroupObjectTask",  # noqa
-      "Audit": "AccessGroup Clause Contract Control Assessment AssessmentTemplate DataAsset Facility Issue Market Objective OrgGroup Person Policy Process Product Program Project Regulation Request Section Standard System Vendor",  # noqa
+      "Audit": "AccessGroup Clause Contract Control Assessment DataAsset Facility Issue Market Objective OrgGroup Person Policy Process Product Program Project Regulation Request Section Standard System Vendor",  # noqa
+      # "AssessmentTemplate": "Audit", # Uncomment this line when we add support for assessment templates in exports # noqa
       "Clause": "AccessGroup Audit Contract Control Assessment DataAsset Facility Issue Market Objective OrgGroup Person Policy Process Product Program Project Regulation Request Section Standard System Vendor Risk Threat CycleTaskGroupObjectTask",  # noqa
       "Contract": "AccessGroup Audit Clause Control Assessment DataAsset Facility Issue Market Objective OrgGroup Person Process Product Program Project Request Section System Vendor Risk Threat CycleTaskGroupObjectTask",  # noqa
       "Control": "AccessGroup Audit Clause Contract Control Assessment DataAsset Facility Issue Market Objective OrgGroup Person Policy Process Product Program Project Regulation Request Request Section Standard System Vendor Risk Threat CycleTaskGroupObjectTask",  # noqa
@@ -193,7 +194,6 @@ def get_mapping_rules():
       "Risk": "AccessGroup Clause Contract Assessment Control DataAsset Facility Issue Market Objective OrgGroup Person Policy Process Product Program Project Regulation Request Section Standard System Vendor Threat CycleTaskGroupObjectTask",  # noqa
       "Threat": "AccessGroup Clause Contract Assessment Control DataAsset Facility Issue Market Objective OrgGroup Person Policy Process Product Program Project Regulation Request Section Standard System Vendor Risk CycleTaskGroupObjectTask",  # noqa
       "CycleTaskGroupObjectTask": "AccessGroup Clause Contract Assessment Control DataAsset Facility Issue Market Objective OrgGroup Person Policy Process Product Program Project Regulation Request Section Standard System Vendor Risk Threat",  # noqa
-      "AssessmentTemplate": "Audit",
   }
 
   split_rules = {k: v.split() for k, v in business_object_rules.items()}

--- a/src/ggrc/utils.py
+++ b/src/ggrc/utils.py
@@ -167,7 +167,7 @@ def get_mapping_rules():
   # TODO: Read these rules from different modules and combine them here.
   business_object_rules = {
       "AccessGroup": "Audit Clause Contract Control Assessment DataAsset Facility Issue Market Objective OrgGroup Person Policy Process Product Program Project Regulation Request Section Standard System Vendor Risk Threat CycleTaskGroupObjectTask",  # noqa
-      "Audit": "Control Assessment Issue Person Program Request Regulation Policy Standard Contract Section Clause Objective",  # noqa
+      "Audit": "AccessGroup Clause Contract Control Assessment AssessmentTemplate DataAsset Facility Issue Market Objective OrgGroup Person Policy Process Product Program Project Regulation Request Section Standard System Vendor",  # noqa
       "Clause": "AccessGroup Audit Contract Control Assessment DataAsset Facility Issue Market Objective OrgGroup Person Policy Process Product Program Project Regulation Request Section Standard System Vendor Risk Threat CycleTaskGroupObjectTask",  # noqa
       "Contract": "AccessGroup Audit Clause Control Assessment DataAsset Facility Issue Market Objective OrgGroup Person Process Product Program Project Request Section System Vendor Risk Threat CycleTaskGroupObjectTask",  # noqa
       "Control": "AccessGroup Audit Clause Contract Control Assessment DataAsset Facility Issue Market Objective OrgGroup Person Policy Process Product Program Project Regulation Request Request Section Standard System Vendor Risk Threat CycleTaskGroupObjectTask",  # noqa

--- a/test/unit/ggrc/test_utils.py
+++ b/test/unit/ggrc/test_utils.py
@@ -17,19 +17,16 @@ class TestUtilsFunctions(TestCase):
     for object_name, object_mappings in mappings.items():
       for mapping in object_mappings:
         try:
-          # Audits do not have direct mappings and do not have all objects
-          # listed, that is why we don't check both ways.
-          if mapping != "Audit":
-            # If obj A is in obj B mappings, make sure that obj B is also in
-            #obj A mappings
-            self.assertIn(
-                mapping, mappings,
-                "- {} is not in the mappings dict".format(mapping)
-            )
-            self.assertIn(
-                object_name, mappings[mapping],
-                "{} not found in {} mappings".format(object_name, mapping)
-            )
+          # If obj A is in obj B mappings, make sure that obj B is also in
+          # obj A mappings
+          self.assertIn(
+              mapping, mappings,
+              "- {} is not in the mappings dict".format(mapping)
+          )
+          self.assertIn(
+              object_name, mappings[mapping],
+              "{} not found in {} mappings".format(object_name, mapping)
+          )
         except AssertionError as e:
           verificationErrors.append(str(e))
 


### PR DESCRIPTION
As part of CORE-3387 I had to create all possible mappings to Audit and I noticed the app did not allow mapping Directives + Objectives and that creating Assessments without a template failed. 