### PR TITLE
QUICK-FIX mapping permissions for Creator/Reader

### DIFF
--- a/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
+++ b/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
@@ -135,7 +135,9 @@
 
       canMap = Permission.is_allowed_for('update', source) ||
         sourceType === 'Person' ||
-        _.contains(createContexts, sourceContext);
+        _.contains(createContexts, sourceContext) ||
+        // Also allow mapping to source if the source is about to be created.
+        _.isUndefined(source.created_at);
 
       if (target instanceof can.Model) {
         canMap = canMap &&


### PR DESCRIPTION
If you create an object (DataAsset for instance) with a creator and then go to create Request modal window and try to map it you will not be allowed to map that DataAsset. The same thing happens when trying to map objects on cycletask create modal.
Also do you guys think it would be safer to check if ```source.type``` is undefined? Does anyone know of a case where sourceContext would be undefined and you would not be on create modal window?