### PR TITLE
QUICK-FIX: Make sure tasks stay ordered after sort

### DIFF
--- a/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
+++ b/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
@@ -163,6 +163,24 @@
            _.contains(createContexts, targetContext));
       }
       return canMap;
+    },
+    get_last_index: function (taskList) {
+      var maxInt = Number.MAX_SAFE_INTEGER.toString(10);
+      var listMax = "0";
+      can.each(taskList, function (item) {
+        if (item.reify) {
+          item = item.reify();
+        }
+        var idx = item.attr
+          ? (item.attr("sort_index") || item.attr("instance.sort_index"))
+          : item.sort_index || item.instance && (item.instance.attr
+          ? item.instance.attr("sort_index")
+          : item.instance.sort_index);
+        if (typeof idx !== "undefined") {
+          listMax = _.max([idx, listMax]);
+        }
+      });
+      return GGRC.Math.string_half(GGRC.Math.string_add(listMax, maxInt));
     }
   };
 })(jQuery, window.GGRC = window.GGRC || {}, window.moment, window.Permission);

--- a/src/ggrc_workflows/assets/javascripts/models/task_group.js
+++ b/src/ggrc_workflows/assets/javascripts/models/task_group.js
@@ -148,22 +148,30 @@
       });
     }
   }, {
-    init : function() {
+    init: function () {
       this._super && this._super.apply(this, arguments);
       this.bind('task_group', function (ev, newTask) {
+        var afterLastIndex;
+        var task;
+        var taskGroup;
+        var taskGroupTasks;
+
         if (!newTask) {
           return;
         }
         newTask = newTask.reify();
-        var task,
-            taskGroup = newTask.get_mapping('task_group_tasks').slice(0);
-
+        taskGroup = newTask.get_mapping('task_group_tasks').slice(0);
+        taskGroupTasks = newTask.get_mapping('task_group_tasks');
+        // find last created task
         do {
           task = taskGroup.splice(-1)[0];
           task = task && task.instance;
         } while (task === this);
 
+        // if there was no task found populate dates with default values
+        // and set the sort_index to a start value
         if (!task) {
+          this.attr('sort_index', GGRC.Utils.get_last_index());
           return;
         }
         can.each('relative_start_day relative_start_month relative_end_day relative_end_month start_date end_date'.split(' '),
@@ -171,7 +179,10 @@
             if (task[prop] && !this[prop]) {
               this.attr(prop, task.attr(prop) instanceof Date ? new Date(task[prop]) : task[prop]);
             }
-        }, this);
+          }, this);
+        // populate sort_index
+        afterLastIndex = GGRC.Utils.get_last_index(taskGroupTasks);
+        this.attr('sort_index', afterLastIndex);
       });
     },
 

--- a/src/ggrc_workflows/assets/javascripts/workflow_mustache_helpers.js
+++ b/src/ggrc_workflows/assets/javascripts/workflow_mustache_helpers.js
@@ -19,28 +19,9 @@
 
    @param list a list of objects or bindings
    */
-  Mustache.registerHelper("sort_index_at_end", function(list, options) {
-    var max_int = Number.MAX_SAFE_INTEGER.toString(10);
-    var list_max = "0";
-
-    list = Mustache.resolve(list);
-    can.each(list, function(item) {
-      if (item.reify) {
-        item = item.reify();
-      }
-      var idx = item.attr
-        ? (item.attr("sort_index") || item.attr("instance.sort_index"))
-        : item.sort_index || item.instance && (item.instance.attr
-        ? item.instance.attr("sort_index")
-        : item.instance.sort_index);
-      if (typeof idx !== "undefined") {
-        list_max = GGRC.Math.string_max(idx, list_max);
-      }
-    });
-
-    return GGRC.Math.string_half(GGRC.Math.string_add(list_max, max_int));
+  Mustache.registerHelper("sort_index_at_end", function (list, options) {
+    return GGRC.Utils.get_last_index(list);
   });
-
 
   /*
    sortable_if mustache helper

--- a/src/ggrc_workflows/assets/mustache/task_group_tasks/modal_content.mustache
+++ b/src/ggrc_workflows/assets/mustache/task_group_tasks/modal_content.mustache
@@ -250,7 +250,9 @@
     </div>
     <input type="hidden" name="task_group" model="TaskGroup" value="{{firstnonempty object_params.task_group instance.task_group.id}}" />
     <input type="hidden" name="context" model="Context" value="{{firstnonempty object_params.context instance.context.id}}" />
-    <input type="hidden" name="sort_index" value="{{firstnonempty object_params.sort_index instance.sort_index}}" />
+    <!-- we use this instead of type="hidden" because otherwise canjs will not populate the value using
+    instance.attr('sort_index', 666) -->
+    <input type="text" style="display:none" name="sort_index" value="{{instance.sort_index}}" />
   </div>
   <div class="row-fluid">
     <div data-id="code_hidden" class="span4 hidable">

--- a/src/ggrc_workflows/assets/mustache/task_group_tasks/task_group_subtree_footer.mustache
+++ b/src/ggrc_workflows/assets/mustache/task_group_tasks/task_group_subtree_footer.mustache
@@ -20,7 +20,7 @@
     data-object-singular="TaskGroupTask"
     data-toggle="modal-ajax-form"
     data-modal-reset="reset"
-    data-object-params='{ "task_group": {{parent_instance.id}}, "context": {{parent_instance.context.id}}, "sort_index": "{{sort_index_at_end original_list}}", "modal_title": "Create New Task" }'>
+    data-object-params='{ "task_group": {{parent_instance.id}}, "context": {{parent_instance.context.id}}, "modal_title": "Create New Task" }'>
     <i class="fa fa-plus-circle"></i>
   </a>
 </div>


### PR DESCRIPTION
When creating a workflow, on the setup page, when you are creating the tasks, if you tried to reorder them and then refresh the page, they would not be reordered.
The only way this used to work if you dragged a task to the top or bottom of the list. Then the sort started working.
If you clicked save&add another, the sort_index did not get updated as well, so I moved it to the init and removed from the template.