### PR TITLE
QUICK-FIX: Check if we don't get the full workflow instance on form populate

### DIFF
--- a/src/ggrc_workflows/assets/javascripts/models/cycle_models.js
+++ b/src/ggrc_workflows/assets/javascripts/models/cycle_models.js
@@ -42,8 +42,11 @@
       form.removeAttr('workflow');
       return;
     }
-    if (workflow instanceof can.Stub) {
+    if (workflow.reify) {
       workflow = workflow.reify();
+    } else {
+      console.log("Can't reify workflow");
+      return;
     }
     if (typeof workflow.cycles === undefined || !workflow.cycles) {
       $(document.body).trigger(


### PR DESCRIPTION
What we get when creating a new task is not always a proper stub, but just id and Type and maybe something else, so we can't always check it with can.Stub 