### PR TITLE
QUICK-FIX: Add quarterly to list of ignored workflows for add task button

### DIFF
--- a/src/ggrc_workflows/assets/javascripts/workflow_mustache_helpers.js
+++ b/src/ggrc_workflows/assets/javascripts/workflow_mustache_helpers.js
@@ -208,7 +208,8 @@
   Mustache.registerHelper("if_recurring_workflow", function (object, options) {
     object = Mustache.resolve(object);
     if (object.type === 'Workflow' &&
-        ['weekly', 'monthly', 'annually'].indexOf(object.frequency) >= 0) {
+        _.includes(['weekly', 'monthly', 'quarterly', 'annually'],
+                   object.frequency)) {
       return options.fn(this);
     } else {
       return options.inverse(this);


### PR DESCRIPTION
This hides the add new cycle task button in the cycle view also on quarterly workflows.