### PR TITLE
CORE-3405 Fix finishing particular workflow cycles

### DIFF
--- a/src/ggrc_workflows/__init__.py
+++ b/src/ggrc_workflows/__init__.py
@@ -954,12 +954,14 @@ def adjust_next_cycle_start_date(
       if last_cycle_start_date >= first_task_reified:
         last_cycle_start_date = last_cycle_start_date + calculator.time_delta
 
-      workflow.non_adjusted_next_cycle_start_date = \
-          calculator.relative_day_to_date(
-              relative_day=first_task.relative_start_day,
-              relative_month=first_task.relative_start_month,
-              base_date=last_cycle_start_date
-          )
+      result = calculator.relative_day_to_date(
+          relative_day=first_task.relative_start_day,
+          relative_month=first_task.relative_start_month,
+          base_date=last_cycle_start_date
+      )
+      if isinstance(result, datetime):
+        result = result.date()
+      workflow.non_adjusted_next_cycle_start_date = result
 
   # Unless we are moving forward one interval we just want to recalculate
   # the next_cycle_start_date to reflect the latest changes to the

--- a/src/ggrc_workflows/services/workflow_cycle_calculator/cycle_calculator.py
+++ b/src/ggrc_workflows/services/workflow_cycle_calculator/cycle_calculator.py
@@ -241,7 +241,8 @@ class CycleCalculator(object):
     Usually this is first element of self.tasks,
 
     Args:
-      base_date: The start date of the time unit we are operating on.
+      base_date: (datetime.date) The start date of the time unit we are
+        operating on.
     Returns:
       datetime.date: Adjusted date when the next cycle is going to be
                      generated.

--- a/src/ggrc_workflows/services/workflow_cycle_calculator/cycle_calculator.py
+++ b/src/ggrc_workflows/services/workflow_cycle_calculator/cycle_calculator.py
@@ -4,17 +4,23 @@
 # Maintained By: urban@reciprocitylabs.com
 
 import datetime
+
 from abc import ABCMeta, abstractmethod
 
-from ggrc_workflows.services.workflow_cycle_calculator.google_holidays import GoogleHolidays
+from ggrc_workflows.services.workflow_cycle_calculator.google_holidays import (
+    GoogleHolidays
+)
+
 
 @property
 def NotImplementedProperty(self):
   raise NotImplementedError
 
+
 @property
 def NotImpementedMethod(self):
   raise NotImplementedError
+
 
 class CycleCalculator(object):
   """Cycle calculation for all workflow frequencies with the exception of
@@ -33,8 +39,8 @@ class CycleCalculator(object):
   Attributes:
     date_domain: Class implementation's domain in which values passed to it are
                  to be found
-    time_delta: Class implementation's atomic unit by which addition/subtraction
-                will take place during calculations.
+    time_delta: Class implementation's atomic unit by which
+                addition/subtraction will take place during calculations.
     HOLIDAYS: Official holidays with the addition of several days that Google
               observes. See file google_holidays.py for details.
   """
@@ -50,7 +56,6 @@ class CycleCalculator(object):
                            base_date=None):
     raise NotImplementedError("Converting from relative to real date"
                               "must be done on an instance.")
-
 
   def __init__(self, workflow, holidays=HOLIDAYS):
     """Initializes calculator based on the workflow and holidays.
@@ -78,8 +83,10 @@ class CycleCalculator(object):
     self.workflow = workflow
     self.holidays = holidays
     self.tasks = [
-      task for task_group in self.workflow.task_groups
-           for task in task_group.task_group_tasks]
+        task
+        for task_group in self.workflow.task_groups
+        for task in task_group.task_group_tasks
+    ]
     self.tasks.sort(key=lambda t: (t.relative_start_month,
                                    t.relative_start_day))
 
@@ -98,8 +105,8 @@ class CycleCalculator(object):
 
     Calculates the first workday by going backwards by either subtracting
     appropriate number of days (if ddate is during weekend) or substracting
-    by one day if it's a holiday. In case we still aren't on a workday we repeat
-    the process recursively until we find the first workday.
+    by one day if it's a holiday. In case we still aren't on a workday we
+    repeat the process recursively until we find the first workday.
 
     Args:
       date: datetime object
@@ -132,22 +139,24 @@ class CycleCalculator(object):
       base_date = datetime.date.today()
 
     return datetime.date(
-      base_date.year,
-      base_date.month,
-      min([t.relative_start_day for t in self.tasks] + [base_date.day]))
+        base_date.year,
+        base_date.month,
+        min([t.relative_start_day for t in self.tasks] + [base_date.day]))
 
   def get_first_task_relative(self):
     tasks_start_dates = [
-      (v['start_date'], v['relative_start'])
-      for v in self.reified_tasks.values()]
+        (v['start_date'], v['relative_start'])
+        for v in self.reified_tasks.values()
+    ]
     tasks_start_dates.sort(key=lambda x: x[0])
     _, first_relative_pair = tasks_start_dates[0]
     return first_relative_pair
 
   def get_last_task_relative(self):
     tasks_end_dates = [
-      (v['end_date'], v['relative_end'])
-      for v in self.reified_tasks.values()]
+        (v['end_date'], v['relative_end'])
+        for v in self.reified_tasks.values()
+    ]
     tasks_end_dates.sort(key=lambda x: x[0], reverse=True)
     _, last_relative_pair = tasks_end_dates[0]
     return last_relative_pair
@@ -177,7 +186,9 @@ class CycleCalculator(object):
     start_date, end_date = self.non_adjusted_task_date_range(task, base_date)
     return self.adjust_date(start_date), self.adjust_date(end_date)
 
-  def non_adjusted_task_date_range(self, task, base_date=None, initialisation=False):
+  def non_adjusted_task_date_range(
+      self, task, base_date=None, initialisation=False
+  ):
     """Calculates individual task's start and end date based on base_date.
 
     Taking base_date into account calculates individual task's start and
@@ -196,24 +207,24 @@ class CycleCalculator(object):
       base_date = datetime.date.today()
 
     start_date = self.relative_day_to_date(
-      task.relative_start_day,
-      relative_month=task.relative_start_month,
-      base_date=base_date)
+        task.relative_start_day,
+        relative_month=task.relative_start_month,
+        base_date=base_date)
 
     end_date = self.relative_day_to_date(
-      task.relative_end_day,
-      relative_month=task.relative_end_month,
-      base_date=base_date)
+        task.relative_end_day,
+        relative_month=task.relative_end_month,
+        base_date=base_date)
 
     # On initialisation `reified_tasks` haven't been initialised yet, making
     # this check unnecessary (and impossible).
     if not initialisation:
       min_rsm, min_rsd = self.get_month_day_pair_from_relative(
-        self.get_first_task_relative())
+          self.get_first_task_relative())
 
       min_start = self.relative_day_to_date(
-        relative_day=min_rsd, relative_month=min_rsm,
-        base_date=base_date)
+          relative_day=min_rsd, relative_month=min_rsm,
+          base_date=base_date)
 
       # In certain cases (e.g. quarterly) the calculation of correct time unit
       # in which we operate can actually put start date of a specific task
@@ -252,17 +263,17 @@ class CycleCalculator(object):
       base_date = today
 
     min_rsm, min_rsd = self.get_month_day_pair_from_relative(
-      self.get_first_task_relative())
+        self.get_first_task_relative())
     max_rem, max_red = self.get_month_day_pair_from_relative(
-      self.get_last_task_relative())
+        self.get_last_task_relative())
 
     min_start = self.relative_day_to_date(
-      relative_day=min_rsd, relative_month=min_rsm,
-      base_date=base_date)
+        relative_day=min_rsd, relative_month=min_rsm,
+        base_date=base_date)
 
     max_end = self.relative_day_to_date(
-      relative_day=max_red, relative_month=max_rem,
-      base_date=base_date)
+        relative_day=max_red, relative_month=max_rem,
+        base_date=base_date)
 
     if max_end < min_start:
       max_end = max_end + self.time_delta
@@ -285,5 +296,5 @@ class CycleCalculator(object):
       base_date = base_date + self.time_delta
 
     return self.relative_day_to_date(
-      relative_day=min_rsd, relative_month=min_rsm,
-      base_date=base_date)
+        relative_day=min_rsd, relative_month=min_rsm,
+        base_date=base_date)

--- a/src/requirements-dev.txt
+++ b/src/requirements-dev.txt
@@ -22,7 +22,7 @@ ipython==3.2.0
 itsdangerous==0.24
 Jinja2==2.8
 MarkupSafe==0.23
-mock==1.0.1
+mock==2.0.0
 MonthDelta==0.9.1
 names==0.3.0
 nose-progressive==1.5.1

--- a/test/unit/ggrc_workflows/test_ggrc_workflows.py
+++ b/test/unit/ggrc_workflows/test_ggrc_workflows.py
@@ -1,0 +1,57 @@
+# Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+# Created By: peter@reciprocitylabs.com
+# Maintained By: peter@reciprocitylabs.com
+
+"""A module with tests for the GGRC Workflow package.
+
+It contains unit tests for the package's top level utility functions.
+"""
+
+import unittest
+
+from datetime import datetime, timedelta
+
+from mock import MagicMock, patch
+
+from freezegun import freeze_time
+from ggrc_workflows import adjust_next_cycle_start_date
+
+
+class AdjustNextCycleStartDateTestCase(unittest.TestCase):
+  """Tests for the adjust_next_cycle_start_date() function."""
+
+  def setUp(self):
+    self.workflow = MagicMock(name="workflow")
+    self.wf_calculator = MagicMock(name="workflow_calculator")
+
+    self.wf_calculator.time_delta = timedelta(weeks=1)
+    self.wf_calculator.non_adjusted_next_cycle_start_date = \
+        lambda base_date: base_date + self.wf_calculator.time_delta
+
+  # pylint: disable=invalid-name
+  @patch("ggrc_workflows.get_cycles")
+  def test_handling_datetime_objects(self, get_cycles):
+    """The method should know how to handle datetime.datetime objects.
+
+    The reason is that workflow cycle calculator does not always return
+    datetime.date objects if passed a datetime.datetime argument.
+    """
+    cycle_task = MagicMock(name="cycle_task")
+    cycle_task.start_date = datetime(2016, 02, 21)
+    get_cycles.return_value = [cycle_task]
+
+    self.workflow.recurrences = True
+    self.workflow.non_adjusted_next_cycle_start_date = None
+
+    self.wf_calculator.tasks = [MagicMock(name="task_1")]
+    self.wf_calculator.relative_day_to_date.side_effect = [
+        datetime(2016, 3, 15),
+        datetime(2016, 6, 6),
+    ]
+
+    try:
+      with freeze_time("2016-05-10 14:26:18"):
+        adjust_next_cycle_start_date(self.wf_calculator, self.workflow)
+    except TypeError:
+      self.fail("The method should handle datetime.datetime without errors.")


### PR DESCRIPTION
The cause of the bug was an attempt to compare a `date` object with a `datetime` object, because somewhere in the code a workflow's `non_adjusted_next_cycle_start_date` was was set to a `datetime` instance (instead of the expected `date`).

The easiest way to verify this is to try to finish a workflow with a `NULL` `non_adjusted_next_cycle_start_date` column before and after the fix.

Alternatively, one can use the ggrc-dev server's DB dump and try to finish the active cycle of the workflow 1259, just as described in the ticket.

<sub>No unit tests, sadly, because it is likely that some non-trivial refactoring would have to take place to avoid disproportionally large fixtures. :/</sub>