### PR TITLE
QUICK-FIX Use flask's static file handler

### DIFF
--- a/src/app.yaml.dist
+++ b/src/app.yaml.dist
@@ -15,11 +15,6 @@ manual_scaling:
   instances: {MAX_INSTANCES}
 
 handlers:
-  - url: /static
-    static_dir: ggrc/static
-    http_headers:
-      Access-Control-Allow-Origin: '*'
-
   - url: /login
     script: ggrc.app.app.wsgi_app
     login: required

--- a/src/ggrc/settings/default.py
+++ b/src/ggrc/settings/default.py
@@ -67,3 +67,5 @@ JINJA2 = jinja2.Environment(loader=jinja2.PackageLoader('ggrc', 'templates'))
 EMAIL_DIGEST = JINJA2.get_template("notifications/email_digest.html")
 EMAIL_TODAYS = JINJA2.get_template("notifications/view_todays_digest.html")
 EMAIL_PENDING = JINJA2.get_template("notifications/view_pending_digest.html")
+
+USE_APP_ENGINE_ASSETS_SUBDOMAIN = False


### PR DESCRIPTION
In production the fonts are not loading (chrome is canceling the request). This is a potential fix for the problem.

Deployed here: https://nostatic-dot-grc-dev.appspot.com/