### PR TITLE
CORE-3370 Fix starting particular Workflow tasks

### DIFF
--- a/src/ggrc_workflows/__init__.py
+++ b/src/ggrc_workflows/__init__.py
@@ -540,7 +540,7 @@ def handle_cycle_task_group_object_task_put(
   # Doing this regardless of status.history.has_changes() is important in order
   # to update objects that have been declined. It updates the os_last_updated
   # date and last_updated_by via the call to set_internal_object_state.
-  if obj.task_group_task.object_approval:
+  if getattr(obj.task_group_task, 'object_approval', None):
     os_state = None
     status = None
     if obj.status == 'Verified':


### PR DESCRIPTION
The issue was caused by `task_group_task` being `None`, added additional check for that case.

(without a test, same reason as in #3789 :/ )
