### PR TITLE
CORE-3499: Error message on request creation from assessment

### DIFF
--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -617,18 +617,13 @@
       return this._super.apply(this, arguments);
     },
     after_save: function () {
-      // Create a relationship between request & assessment & control
-      var dfds = can.map(['assessment'], function (obj) {
-        if (!(this.attr(obj) && this.attr(obj).stub)) {
-          return undefined;
-        }
-        return new CMS.Models.Relationship({
-          source: this.attr(obj).stub(),
-          destination: this.stub(),
-          context: this.context.stub()
-        }).save();
-      }.bind(this));
-      GGRC.delay_leaving_page_until($.when.apply($, dfds));
+      // Create a relationship between request & assessment
+      var dfd = new CMS.Models.Relationship({
+        source: this.attr('assessment').stub(),
+        destination: this.stub(),
+        context: this.context.stub()
+      }).save();
+      GGRC.delay_leaving_page_until($.when(dfd));
     },
     _refresh: function (bindings) {
       var refresh_queue = new RefreshQueue();

--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -618,6 +618,10 @@
     },
     after_save: function () {
       // Create a relationship between request & assessment
+      // if the request is created from the assessment view page
+      if (!(this.attr('assessment') && this.attr('assessment').stub)) {
+        return;
+      }
       var dfd = new CMS.Models.Relationship({
         source: this.attr('assessment').stub(),
         destination: this.stub(),

--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -628,7 +628,7 @@
         destination: this.stub(),
         context: this.context.stub()
       }).save();
-      GGRC.delay_leaving_page_until($.when(dfd));
+      GGRC.delay_leaving_page_until(dfd);
     },
     _refresh: function (bindings) {
       var refresh_queue = new RefreshQueue();

--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -618,7 +618,7 @@
     },
     after_save: function () {
       // Create a relationship between request & assessment & control
-      var dfds = can.map(['control', 'assessment'], function (obj) {
+      var dfds = can.map(['assessment'], function (obj) {
         if (!(this.attr(obj) && this.attr(obj).stub)) {
           return undefined;
         }

--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -619,10 +619,11 @@
     after_save: function () {
       // Create a relationship between request & assessment
       // if the request is created from the assessment view page
+      var dfd;
       if (!(this.attr('assessment') && this.attr('assessment').stub)) {
         return;
       }
-      var dfd = new CMS.Models.Relationship({
+      dfd = new CMS.Models.Relationship({
         source: this.attr('assessment').stub(),
         destination: this.stub(),
         context: this.context.stub()


### PR DESCRIPTION
When you create a request from the assessment info page, there is an internal server error because the frontend tries to add a relationship: Control <--> Requests. Because Control is not mapped to the Assessment, the source in the relationship is `null`. Which crashes a subscriber to the POST Relationship event at the backend.