### PR TITLE
CORE-3509 Remove tooltips when hovering tree view title bars

### DIFF
--- a/src/ggrc/assets/mustache/base_objects/tree.mustache
+++ b/src/ggrc/assets/mustache/base_objects/tree.mustache
@@ -13,7 +13,7 @@
           <div class="item-data">
             <div class="row-fluid">
               <div class="span{{display_options.title_width}}">
-                <div class="title tree-title-area" rel="tooltip" data-placement="left" title="" data-original-title="{{instance.title}}">
+                <div class="title tree-title-area" title="{{instance.title}}">
                   {{#is_subtree}}
                     <i class="fa fa-{{instance.class.table_singular}} color"></i>
                   {{/is_subtree}}


### PR DESCRIPTION
This removes the tooltips as suggested in a [comment](https://reciprocitylabs.atlassian.net/browse/CORE-3509?focusedCommentId=26444&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-26444) under the ticket.

The other issue (highlighting the clicked tree item) will be dealt with in a [separate ticket](https://reciprocitylabs.atlassian.net/browse/CORE-3515).