### PR TITLE
CORE-3515 Fix highlighting of the active tree view node

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/tests/tree_view_controller_spec.js
+++ b/src/ggrc/assets/javascripts/controllers/tests/tree_view_controller_spec.js
@@ -1,0 +1,45 @@
+/*!
+  Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+  Created By: peter@reciprocitylabs.com
+  Maintained By: peter@reciprocitylabs.com
+*/
+
+describe('CMS.Controllers.TreeView', function () {
+  'use strict';
+
+  var Ctrl;  // the controller under test
+
+  beforeAll(function () {
+    Ctrl = CMS.Controllers.TreeView;
+  });
+
+  describe('init() method', function () {
+    var ctrlInst;  // fake controller instance
+    var dfdSingleton;
+    var method;
+    var options;
+    var $element;
+
+    beforeEach(function () {
+      options = {};
+      $element = $('<div></div>');
+
+      ctrlInst = {
+        element: $element,
+        widget_hidden: jasmine.createSpy('widget_hidden'),
+        widget_shown: jasmine.createSpy('widget_shown'),
+        options: new can.Map(options)
+      };
+
+      method = Ctrl.prototype.init.bind(ctrlInst);
+
+      dfdSingleton = new can.Deferred();
+      spyOn(
+        CMS.Models.DisplayPrefs, 'getSingleton'
+      ).and.returnValue(dfdSingleton);
+    });
+
+    // test cases here...
+  });
+});

--- a/src/ggrc/assets/javascripts/controllers/tests/tree_view_node_controller_spec.js
+++ b/src/ggrc/assets/javascripts/controllers/tests/tree_view_node_controller_spec.js
@@ -1,0 +1,100 @@
+/*!
+  Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+  Created By: peter@reciprocitylabs.com
+  Maintained By: peter@reciprocitylabs.com
+*/
+
+describe('CMS.Controllers.TreeViewNode', function () {
+  'use strict';
+
+  var Ctrl;  // the controller under test
+
+  beforeAll(function () {
+    Ctrl = CMS.Controllers.TreeViewNode;
+  });
+
+  describe('draw_node() method', function () {
+    var ctrlInst;  // fake controller instance
+    var ifNotRemovedResult;  // fake return value of the _ifNotRemoved() method
+    var method;
+    var $element;
+
+    beforeEach(function () {
+      ifNotRemovedResult = {};
+      $element = $('<div></div>');
+
+      ctrlInst = {
+        options: new can.Map({
+          show_view: '/foo/bar.mustache'
+        }),
+        element: $element,
+        _draw_node_in_progress: false,
+        _draw_node_deferred: new can.Deferred(),
+        add_child_lists_to_child: jasmine.createSpy(),
+        _ifNotRemoved: jasmine.createSpy().and.returnValue(ifNotRemovedResult),
+        replace_element: jasmine.createSpy()
+      };
+
+      method = Ctrl.prototype.draw_node.bind(ctrlInst);
+
+      spyOn(can, 'view');
+    });
+
+    it('renders the DOM element with the "active" CSS class if node active',
+      function () {
+        var callArgs;
+        var callback;
+
+        ctrlInst.options.attr('isActive', false);
+        $element.addClass('active');
+
+        method();
+
+        expect(can.view).toHaveBeenCalledWith(
+          '/foo/bar.mustache',
+          ctrlInst.options,
+          ifNotRemovedResult
+        );
+
+        expect(ctrlInst._ifNotRemoved).toHaveBeenCalled();
+        callArgs = ctrlInst._ifNotRemoved.calls.mostRecent().args;
+        callback = callArgs[0];
+
+        // simulate invoking the callback and observe the effect
+        $element.removeClass('active');
+        callback();
+
+        expect(ctrlInst.element.hasClass('active')).toBe(true);
+      }
+    );
+
+    it('renders the DOM element without the "active" CSS class if ' +
+      'node not active',
+      function () {
+        var callArgs;
+        var callback;
+
+        ctrlInst.options.attr('isActive', false);
+        $element.removeClass('active');  // make sure it is indeed inactive
+
+        method();
+
+        expect(can.view).toHaveBeenCalledWith(
+          '/foo/bar.mustache',
+          ctrlInst.options,
+          ifNotRemovedResult
+        );
+
+        expect(ctrlInst._ifNotRemoved).toHaveBeenCalled();
+        callArgs = ctrlInst._ifNotRemoved.calls.mostRecent().args;
+        callback = callArgs[0];
+
+        // simulate invoking the callback and observe the effect
+        callback();
+
+        expect(ctrlInst.element.hasClass('active')).toBe(false);
+      }
+    );
+  });
+});

--- a/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
@@ -1458,7 +1458,6 @@ CMS.Controllers.TreeLoader('CMS.Controllers.TreeView', {
       }
     }
   }
-
 });
 
 can.Control('CMS.Controllers.TreeViewNode', {
@@ -1522,16 +1521,38 @@ can.Control('CMS.Controllers.TreeViewNode', {
       this.draw_node();
     }
   },
+
+  /**
+   * Trigger rendering the tree node in the DOM.
+   */
   draw_node: function () {
+    var isActive;
+
     if (this._draw_node_in_progress) {
       return;
     }
+
     this._draw_node_in_progress = true;
     this.add_child_lists_to_child();
-    can.view(this.options.show_view, this.options, this._ifNotRemoved(function (frag) {
-      this.replace_element(frag);
-      this._draw_node_deferred.resolve();
-    }.bind(this)));
+
+    // the node's isActive state is not stored anywhere, thus we need to
+    // determine it from the presemce of the corresponding CSS class
+    isActive = this.element.hasClass('active');
+
+    can.view(
+      this.options.show_view,
+      this.options,
+      this._ifNotRemoved(function (frag) {
+        this.replace_element(frag);
+
+        if (isActive) {
+          this.element.addClass('active');
+        }
+
+        this._draw_node_deferred.resolve();
+      }.bind(this))
+    );
+
     this._draw_node_in_progress = false;
     this.options.attr('is_subtree',
         this.element && this.element.closest('.inner-tree').length > 0);
@@ -1713,10 +1734,16 @@ can.Control('CMS.Controllers.TreeViewNode', {
     }
   },
 
+  /**
+   * Mark the tree node as active (and all other tree nodes as inactive).
+   */
   select: function () {
     var $tree = this.element;
 
-    $tree.closest('section').find('.cms_controllers_tree_view_node').removeClass('active');
+    $tree.closest('section')
+      .find('.cms_controllers_tree_view_node')
+      .removeClass('active');
+
     $tree.addClass('active');
 
     this.update_hash_fragment();

--- a/src/ggrc/assets/mustache/base_objects/tree.mustache
+++ b/src/ggrc/assets/mustache/base_objects/tree.mustache
@@ -5,7 +5,11 @@
     Maintained By: brad@reciprocitylabs.com
 }}
 
-  <li class="tree-item" data-object-id="{{instance.id}}" data-object-type="{{instance.class.table_singular}}" {{addclass "t-" instance.workflow_state}}>
+  <li class="tree-item "
+    data-object-id="{{instance.id}}"
+    data-object-type="{{instance.class.table_singular}}"
+    {{addclass "t-" instance.workflow_state}}>
+
     <div class="item-main" {{#instance}}{{data 'model'}}{{/instance}}>
       <div class="item-wrap">
         {{{render '/static/mustache/base_objects/open_close.mustache' instance=instance}}}


### PR DESCRIPTION
The issue was caused if something triggered a refresh of the active tree node, causing it to render itself with the vanilla template, but there was nothing that applied the `active` CSS class to it.

This fix computes the `isActive` flag upon rendering, sending it to the tree node template's scope, allowing it to render itself properly.