### PR TITLE
QUICK-FIX Change status from Open to Not Started

### DIFF
--- a/test/integration/ggrc/automapper/test_automappings.py
+++ b/test/integration/ggrc/automapper/test_automappings.py
@@ -324,7 +324,7 @@ class TestAutomappings(integration.ggrc.TestCase):
         'title': make_name('Request'),
         'assignee': {'id': creator.id},
         'request_type': 'documentation',
-        'status': 'Open',
+        'status': 'Not Started',
         'requested_on': '1/1/2015',
         'due_on': '1/1/2016',
     })

--- a/test/integration/ggrc/notifications/test_assignable_notifications.py
+++ b/test/integration/ggrc/notifications/test_assignable_notifications.py
@@ -101,13 +101,13 @@ class TestAssignableNotification(converters.TestCase):
 
       request = Request.query.get(requests["Request 9"].id)
 
-      self.api_helper.modify_object(request, {"status": "Final"})
+      self.api_helper.modify_object(request, {"status": "Completed"})
       self.assertEqual(self._get_notifications().count(), 0)
-      self.api_helper.modify_object(request, {"status": "Open"})
+      self.api_helper.modify_object(request, {"status": "Not Started"})
       self.assertEqual(self._get_notifications().count(), 0)
       self.api_helper.modify_object(request, {"status": "In Progress"})
       self.assertEqual(self._get_notifications().count(), 0)
-      self.api_helper.modify_object(request, {"status": "Final"})
+      self.api_helper.modify_object(request, {"status": "Completed"})
       self.assertEqual(self._get_notifications().count(), 0)
       self.api_helper.modify_object(request, {"status": "In Progress"})
       self.assertEqual(self._get_notifications().count(), 0)


### PR DESCRIPTION
The PR https://github.com/google/ggrc-core/pull/3801 was missing this change and it causes warnings to appear in the integration tests. 

See: https://jenkins.reciprocitylabs.com/job/ggrc_integration/1158/console