### PR TITLE
CORE-3461 Refresh page after generating assessments

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment_generator.js
+++ b/src/ggrc/assets/javascripts/components/assessment_generator.js
@@ -48,9 +48,11 @@
           this._results = results;
 
           $.when.apply($, results)
-            .always(options.context.closeModal.bind(options.context))
             .done(this.notify.bind(this))
-            .fail(this.notify.bind(this));
+            .fail(this.notify.bind(this))
+            .always(function() {
+              window.location.reload();
+            });
         }.bind(this));
       },
       generateModel: function (object, template) {


### PR DESCRIPTION
This is a workaround for reloading custom attribute definitions.