### PR TITLE
QUICK-FIX Replace hard coded strings with object states

### DIFF
--- a/test/integration/ggrc/notifications/test_assignable_notifications.py
+++ b/test/integration/ggrc/notifications/test_assignable_notifications.py
@@ -101,15 +101,17 @@ class TestAssignableNotification(converters.TestCase):
 
       request = Request.query.get(requests["Request 9"].id)
 
-      self.api_helper.modify_object(request, {"status": "Completed"})
+      self.api_helper.modify_object(request, {"status": Request.FINAL_STATE})
       self.assertEqual(self._get_notifications().count(), 0)
-      self.api_helper.modify_object(request, {"status": "Not Started"})
+      self.api_helper.modify_object(request, {"status": Request.START_STATE})
       self.assertEqual(self._get_notifications().count(), 0)
-      self.api_helper.modify_object(request, {"status": "In Progress"})
+      self.api_helper.modify_object(request,
+                                    {"status": Request.PROGRESS_STATE})
       self.assertEqual(self._get_notifications().count(), 0)
-      self.api_helper.modify_object(request, {"status": "Completed"})
+      self.api_helper.modify_object(request, {"status": Request.FINAL_STATE})
       self.assertEqual(self._get_notifications().count(), 0)
-      self.api_helper.modify_object(request, {"status": "In Progress"})
+      self.api_helper.modify_object(request,
+                                    {"status": Request.PROGRESS_STATE})
       self.assertEqual(self._get_notifications().count(), 0)
 
   @patch("ggrc.notifications.common.send_email")


### PR DESCRIPTION
Fixes #3807 edits to attributes instead of hard coded strings.