### PR TITLE
CORE-3529 Fix loading subtrees when expanding collapsed node

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/tests/tree_view_node_controller_spec.js
+++ b/src/ggrc/assets/javascripts/controllers/tests/tree_view_node_controller_spec.js
@@ -97,4 +97,54 @@ describe('CMS.Controllers.TreeViewNode', function () {
       }
     );
   });
+
+  describe('expand() method', function () {
+    var ctrlInst;  // fake controller instance
+    var displaySubtreesDfd;
+    var method;
+    var $tree;
+
+    beforeEach(function () {
+      $tree = $([
+        '<li class="tree-item">',
+        '  <div>',
+        '    <div class="openclose"></div>',
+        '  </div>',
+        '</li>'
+      ].join(''));
+
+      displaySubtreesDfd = new can.Deferred();
+
+      ctrlInst = {
+        element: $tree,
+        options: new can.Map({
+          show_view: '/foo/bar.mustache'
+        }),
+        _ifNotRemoved: jasmine.createSpy().and.callFake(function (callback) {
+          return callback;
+        }),
+        display_subtrees:
+          jasmine.createSpy().and.returnValue(displaySubtreesDfd)
+      };
+
+      method = Ctrl.prototype.expand.bind(ctrlInst);
+    });
+
+    it('triggers displaying the subtrees if currently not expanded',
+      function (done) {
+        // the node has been expanded before...
+        ctrlInst._expand_deferred = new can.Deferred();
+
+        // ...but it's currently not expanded
+        $tree.find('.openclose').removeClass('active');
+
+        method();
+
+        setTimeout(function () {
+          expect(ctrlInst.display_subtrees).toHaveBeenCalled();
+          done();
+        }, 10);
+      }
+    );
+  });
 });

--- a/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
@@ -1696,12 +1696,21 @@ can.Control('CMS.Controllers.TreeViewNode', {
     return $.when.apply($, child_tree_dfds);
   },
 
+  /**
+   * Expand the tree node to make its subnodes visible.
+   *
+   * @return {can.Deferred} - a deferred object resolved when all the child
+   *   nodes have been loaded and displayed
+   */
   expand: function () {
     var that = this;
-    if (this._expand_deferred) {
-      //  If we've already expanded, then short-circuit the call.  However,
-      //  we still need to toggle `expanded`, but if it's the first time
-      //  expanding, `this.add_child_lists_to_child` *must* be called first.
+    var $el = this.element;
+
+    if (this._expand_deferred && $el.find('.openclose').is('.active')) {
+      // If we have already expanded and are currently still expanded, then
+      // short-circuit the call. However, we still need to toggle `expanded`,
+      // but if it's the first time expanding, `this.add_child_lists_to_child`
+      // *must* be called first.
       this.options.attr('expanded', true);
       return this._expand_deferred;
     }
@@ -1739,6 +1748,10 @@ can.Control('CMS.Controllers.TreeViewNode', {
    */
   select: function () {
     var $tree = this.element;
+
+    if ($tree.hasClass('active')) {
+      return;  // tree node already selected, no need to activate it again
+    }
 
     $tree.closest('section')
       .find('.cms_controllers_tree_view_node')


### PR DESCRIPTION
The TreeNode controller now correctly determines whether the node is currently expanded or not.

Also, a small improvement has been added, preventing a subtree from being unnecessarily reloaded when selecting an already selected (i.e. active) node.