### PR TITLE
CORE-3399 Show custom attributes in the change log

### DIFF
--- a/src/ggrc/assets/javascripts/components/object_history/object_history.js
+++ b/src/ggrc/assets/javascripts/components/object_history/object_history.js
@@ -54,34 +54,38 @@
      * @param {Object} options - the component instantiation options
      */
     init: function (element, options) {
+      var setUp = function () {
+        this._INSTANCE_TYPE = this.scope.instance.type;
+
+        this._fetchRevisionsData(
+          this.scope.instance
+        ).then(
+          function success(revisions) {
+            // combine all the changes and sort them by date descending
+            var changeHistory = _([]).concat(
+                _.toArray(this._computeObjectChanges(revisions.object)),
+                _.toArray(this._computeMappingChanges(revisions.mappings))
+            ).sortBy('updatedAt').reverse().value();
+            this.scope.attr('changeHistory', changeHistory);
+          }.bind(this),
+
+          function error() {
+            $(element).trigger(
+              'ajax:flash',
+              {error: 'Failed to fetch revision history data.'});
+          }
+        ).always(function () {
+          this.scope.attr('isLoading', false);
+        }.bind(this));
+      }.bind(this);
+
       if (this.scope.instance === null) {
         throw new Error('Instance not passed through the HTML element.');
       }
-
-      this._INSTANCE_TYPE = this.scope.instance.type;
-
-      this._fetchRevisionsData(
-        this.scope.instance
-      ).then(
-        function success(revisions) {
-          var changeHistory;
-          var mappingsChanges = this._computeMappingChanges(revisions.mappings);
-          var objChanges = this._computeObjectChanges(revisions.object);
-
-          // combine all the changes and sort them by date descending
-          changeHistory = objChanges.concat(mappingsChanges);
-          changeHistory = _.sortBy(changeHistory, 'updatedAt').reverse();
-          this.scope.attr('changeHistory', changeHistory);
-        }.bind(this),
-
-        function error() {
-          $(element).trigger(
-            'ajax:flash',
-            {error: 'Failed to fetch revision history data.'});
-        }
-      ).always(function () {
-        this.scope.attr('isLoading', false);
-      }.bind(this));
+      this.scope.instance.on('updated', function () {
+        setUp();
+      });
+      setUp();
     },
 
     /**

--- a/src/ggrc/assets/javascripts/components/object_history/tests/object_history_spec.js
+++ b/src/ggrc/assets/javascripts/components/object_history/tests/object_history_spec.js
@@ -245,7 +245,12 @@ describe('GGRC.Components.objectHistory', function () {
     var origModelAttrDefs;  // original user-friendly attribute name settings
 
     beforeAll(function () {
-      method = Component.prototype._objectChangeDiff;
+      method = Component.prototype._objectChangeDiff.bind({
+        _DATE_FIELDS: {},
+        _objectCADiff: function () {
+          return [];
+        }
+      });
     });
 
     beforeEach(function () {
@@ -329,7 +334,7 @@ describe('GGRC.Components.objectHistory', function () {
           }
         };
 
-        var result = method.call({_DATE_FIELDS: {}}, rev1, rev2);
+        var result = method(rev1, rev2);
 
         expectedChangeList = [{
           fieldName: 'Object Name',
@@ -374,6 +379,105 @@ describe('GGRC.Components.objectHistory', function () {
           expect(result.changes.length).toEqual(0);
         }
       );
+    });
+  });
+
+  describe('_objectCADiff() method', function () {
+    var method;  // the method under test
+
+    beforeAll(function () {
+      method = Component.prototype._objectCADiff;
+    });
+
+    it('detects set attributes', function () {
+      var oldValues = [];
+      var oldDefs = [];
+      var newValues = [{
+        custom_attribute_id: 1,
+        attribute_value: 'custom value'
+      }];
+      var newDefs = [{
+        id: 1,
+        title: 'CA',
+        attribute_type: 'text'
+      }];
+      var result = method(oldValues, oldDefs, newValues, newDefs);
+      expect(result).toEqual([{
+        fieldName: 'CA',
+        origVal: '—',
+        newVal: 'custom value'
+      }]);
+    });
+
+    it('detects unset attributes', function () {
+      var oldValues = [{
+        custom_attribute_id: 1,
+        attribute_value: 'custom value'
+      }];
+      var oldDefs = [{
+        id: 1,
+        title: 'CA',
+        attribute_type: 'text'
+      }];
+      var newValues = [];
+      var newDefs = [];
+      var result = method(oldValues, oldDefs, newValues, newDefs);
+      expect(result).toEqual([{
+        fieldName: 'CA',
+        origVal: 'custom value',
+        newVal: '—'
+      }]);
+    });
+
+    it('detects multiple changed attributes', function () {
+      var oldValues = [{
+        custom_attribute_id: 1,
+        attribute_value: 'v1'
+      }, {
+        custom_attribute_id: 2,
+        attribute_value: 'v2'
+      }, {
+        custom_attribute_id: 3,
+        attribute_value: 'v3'
+      }];
+
+      var oldDefs = [{
+        id: 1,
+        title: 'CA1',
+        attribute_type: 'text'
+      }, {
+        id: 2,
+        title: 'CA2',
+        attribute_type: 'text'
+      }, {
+        id: 3,
+        title: 'CA3',
+        attribute_type: 'text'
+      }];
+
+      var newValues = [{
+        custom_attribute_id: 1,
+        attribute_value: 'v3'
+      }, {
+        custom_attribute_id: 2,
+        attribute_value: 'v4'
+      }, {
+        custom_attribute_id: 3,
+        attribute_value: 'v3'
+      }];
+
+      var newDefs = oldDefs;
+
+      var result = method(oldValues, oldDefs, newValues, newDefs);
+      expect(result).toEqual([{
+        fieldName: 'CA1',
+        origVal: 'v1',
+        newVal: 'v3'
+      }, {
+        fieldName: 'CA2',
+        origVal: 'v2',
+        newVal: 'v4'
+      }]);
     });
   });
 


### PR DESCRIPTION
This does multiple changes
- update custom attribute saving backend logic to use the ORM and not directly create objects (enables next step)
- store custom attribute values as part of revisions
- store custom attribute definitions as part of revisions (to freeze field names & types in time)
- wires up auto refresh of the change log on instance update to better integrate with inline edits