### PR TITLE
CORE-3493 Remove "Owner" column from Assessment's tree view

### DIFF
--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -768,10 +768,6 @@
         attr_title: 'Title',
         attr_name: 'title'
       }, {
-        attr_title: 'Owner',
-        attr_name: 'owner',
-        attr_sort_field: 'contact.name|email'
-      }, {
         attr_title: 'Code',
         attr_name: 'slug'
       }, {


### PR DESCRIPTION
The title says it all...