### PR TITLE
CORE-3491 Fix broken display of relevant assessments

### DIFF
--- a/src/ggrc/assets/javascripts/components/mapped_tree_view.js
+++ b/src/ggrc/assets/javascripts/components/mapped_tree_view.js
@@ -12,7 +12,17 @@
     scope: {
       reusable: '@',
       reuseMethod: '@',
-      treeViewClass: '@'
+      treeViewClass: '@',
+      expandable: '@',
+      isExpandable: function () {
+        var expandable = this.attr('expandable');
+        if (expandable === null || expandable === undefined) {
+          return true;
+        } else if (typeof expandable === 'string') {
+          return expandable === 'true';
+        }
+        return expandable;
+      }
     },
     events: {
       '[data-toggle=unmap] click': function (el, ev) {

--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -828,7 +828,9 @@ Mustache.registerHelper("get_permalink_for_object", function (instance, options)
 
 Mustache.registerHelper("get_view_link", function (instance, options) {
   function finish(link) {
-    return "<a href=" + link + " target=\"_blank\"><i class=\"fa fa-long-arrow-right\"></i></a>";
+    return "<a href=" + link + " target=\"_blank\" class=\"view-link\">" +
+           "  <i class=\"fa fa-long-arrow-right\"></i>" +
+           "</a>";
   }
   instance = resolve_computed(instance);
   if (!instance.viewLink && !instance.get_permalink) {

--- a/src/ggrc/assets/mustache/assessments/reusable_objects.mustache
+++ b/src/ggrc/assets/mustache/assessments/reusable_objects.mustache
@@ -48,6 +48,7 @@ Maintained By: urban@reciprocitylabs.com
             is-loading="isLoading"
             mapping="instance.class.info_pane_options.mapped_objects.mapping"
             item-template="instance.class.info_pane_options.mapped_objects.show_view"
+            expandable="false"
             >
           </mapping-tree-view>
         </ul>

--- a/src/ggrc/assets/mustache/base_templates/mapping_tree_view.mustache
+++ b/src/ggrc/assets/mustache/base_templates/mapping_tree_view.mustache
@@ -6,10 +6,10 @@
 }}
 
 <ul class="{{#if treeViewClass}}{{treeViewClass}}{{else}}attachment-list{{/if}}">
-  {{#expose reusable=reusable reusedObjects=reusedObjects reuseMethod=reuseMethod mapping=mapping baseInstance=baseInstance isLoading=isLoading}}
+  {{#expose reusable=reusable reusedObjects=reusedObjects reuseMethod=reuseMethod mapping=mapping baseInstance=baseInstance isLoading=isLoading isExpandable=isExpandable boom=boom}}
   {{#with_mapping mapping parentInstance}}
     {{#results}}
-      {{{render itemTemplate baseInstance=baseInstance parentInstance=parentInstance reusable=reusable reusedObjects=reusedObjects reuseMethod=reuseMethod mapping=mapping isLoading=isLoading}}}
+      {{{render itemTemplate baseInstance=baseInstance parentInstance=parentInstance reusable=reusable reusedObjects=reusedObjects reuseMethod=reuseMethod mapping=mapping isLoading=isLoading isExpandable=isExpandable}}}
     {{/results}}
   {{/with_mapping}}
   {{/expose}}

--- a/src/ggrc/assets/mustache/base_templates/mapping_tree_view.mustache
+++ b/src/ggrc/assets/mustache/base_templates/mapping_tree_view.mustache
@@ -6,7 +6,7 @@
 }}
 
 <ul class="{{#if treeViewClass}}{{treeViewClass}}{{else}}attachment-list{{/if}}">
-  {{#expose reusable=reusable reusedObjects=reusedObjects reuseMethod=reuseMethod mapping=mapping baseInstance=baseInstance isLoading=isLoading isExpandable=isExpandable boom=boom}}
+  {{#expose reusable=reusable reusedObjects=reusedObjects reuseMethod=reuseMethod mapping=mapping baseInstance=baseInstance isLoading=isLoading isExpandable=isExpandable}}
   {{#with_mapping mapping parentInstance}}
     {{#results}}
       {{{render itemTemplate baseInstance=baseInstance parentInstance=parentInstance reusable=reusable reusedObjects=reusedObjects reuseMethod=reuseMethod mapping=mapping isLoading=isLoading isExpandable=isExpandable}}}

--- a/src/ggrc/assets/mustache/base_templates/subtree.mustache
+++ b/src/ggrc/assets/mustache/base_templates/subtree.mustache
@@ -11,9 +11,11 @@
     data-id="{{ instance.id }}">
   <div class="item-main">
     <div class="item-wrap">
-      <div class="openclose" {{data 'expandable'}}>
+      <div class="openclose">
         <span class="status-label status-draft"></span>
+        {{#if isExpandable}}
         <i class="fa fa-caret-right"></i>
+        {{/id}}
       </div>
       <div class="select">
         <div class="item-data">
@@ -40,7 +42,7 @@
     </div> <!-- item-wrap end -->
   </div> <!-- item-main end -->
 
-
+  {{#if isExpandable}}
   <div class="tier-2-info item-content">
     <div class="tier-2-info-content">
       <lazy-openclose>
@@ -59,5 +61,6 @@
       </lazy-openclose>
     </div>
   </div>
+  {{/if}}
 
 </li>

--- a/src/ggrc/assets/mustache/base_templates/subtree.mustache
+++ b/src/ggrc/assets/mustache/base_templates/subtree.mustache
@@ -31,9 +31,7 @@
             </div> <!-- span8 end -->
             <div class="span4">
               <div class="show-details">
-                {{#is_allowed "view_object_page" instance}}
                   {{{get_view_link instance}}}
-                {{/is_allowed}}
               </div>
             </div>
           </div> <!-- row-fluid end -->

--- a/src/ggrc/assets/mustache/requests/reusable_objects.mustache
+++ b/src/ggrc/assets/mustache/requests/reusable_objects.mustache
@@ -43,12 +43,12 @@ Maintained By: urban@reciprocitylabs.com
           reusable="true"
           reusable-objects="reusedObjects"
           reuse-method="createRelationship"
-          tree-view-class="mapped-list"
           parent-instance="instance"
           base-instance="baseInstance"
           is-loading="isLoading"
           mapping="instance.class.info_pane_options.mapped_objects.mapping"
           item-template="instance.class.info_pane_options.mapped_objects.show_view"
+          expandable="false"
           >
         </mapping-tree-view>
       </div>

--- a/src/ggrc/assets/stylesheets/modules/_attachment-list.scss
+++ b/src/ggrc/assets/stylesheets/modules/_attachment-list.scss
@@ -30,12 +30,16 @@
     }
     a {
       @extend %oneline;
+      width: 68%;
       display: inline-block;
-      margin-top: 5px;
       &.more {
         display: inline;
         width: auto;
       }
+    }
+    a.view-link {
+      margin-top: 5px;
+      width: 100%;
     }
     .tree-title-area {
       margin-top: 5px;

--- a/src/ggrc/assets/stylesheets/modules/_attachment-list.scss
+++ b/src/ggrc/assets/stylesheets/modules/_attachment-list.scss
@@ -30,12 +30,15 @@
     }
     a {
       @extend %oneline;
-      width: 68%;
       display: inline-block;
+      margin-top: 5px;
       &.more {
         display: inline;
         width: auto;
       }
+    }
+    .tree-title-area {
+      margin-top: 5px;
     }
   }
   .past-items-list & {


### PR DESCRIPTION
List of mapped objects is now displayed like:
![urq7ic14d0c](https://cloud.githubusercontent.com/assets/347547/15179247/75db2996-1772-11e6-905b-ef4e83fcbe7d.png)
