### PR TITLE
QUICK-FIX Fix dev environment

### DIFF
--- a/provision/docker/vagrant.bashrc
+++ b/provision/docker/vagrant.bashrc
@@ -114,3 +114,6 @@ source /vagrant/bin/init_vagrant_env
 export TERM=xterm-color
 export EDITOR=vim
 PS1='\[\033[01;35m\]\u@\h\[\033[01;34m\] \w \n\$\[\033[00m\] '
+
+ln -sf /vagrant-dev/node_modules /vagrant/node_modules
+ln -sf /vagrant-dev/bower_components /vagrant/bower_components


### PR DESCRIPTION
Provisioning steps do not create the proper symbolic links needed for
the dev environment to work. This also applies after cleaning the repo
and reprovisioning or if a user manually deletes these links. This fix
makes sure that once a user enters the dev environment it works as
expected.

This is a fix for the issue https://github.com/google/ggrc-core/issues/3838.