### PR TITLE
CORE-3578 Add "Auditors" to the default people option

### DIFF
--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -1098,6 +1098,7 @@
       people_values: [
         {value: 'Object Owners', title: 'Object Owners'},
         {value: 'Audit Lead', title: 'Audit Lead'},
+        {value: 'Auditors', title: 'Auditors'},
         {value: 'Primary Assessor', title: 'Principal Assessor'},
         {value: 'Secondary Assessors', title: 'Secondary Assessors'},
         {value: 'Primary Contact', title: 'Primary Contact'},

--- a/src/ggrc/models/assessment_template.py
+++ b/src/ggrc/models/assessment_template.py
@@ -39,6 +39,7 @@ class AssessmentTemplate(Base, Relatable, Titled, db.Model):
   DEFAULT_PEOPLE_LABELS = {
       "Object Owners": "Object Owners",
       "Audit Lead": "Audit Lead",
+      "Auditors": "Auditors",
       "Primary Assessor": "Principal Assessor",
       "Secondary Assessors": "Secondary Assessors",
       "Primary Contact": "Primary Contact",

--- a/test/unit/ggrc/models/hooks/test_assessment.py
+++ b/test/unit/ggrc/models/hooks/test_assessment.py
@@ -4,6 +4,7 @@
 # Maintained By: peter@reciprocitylabs.com
 
 """A module with tests for the GGRC Workflow package.
+
 It contains unit tests for the package's top level utility functions.
 """
 
@@ -14,12 +15,35 @@ from mock import MagicMock, patch
 from ggrc.models.hooks import assessment
 
 
+@patch("ggrc.models.hooks.assessment.get_current_user_id")
+@patch("ggrc.models.hooks.assessment.Person")
 class GetValueTestCase(unittest.TestCase):
   """Tests for the get_value() function."""
 
+  # pylint: disable=too-many-instance-attributes
+
+  def setUp(self):
+    self.person_1 = MagicMock(name="Person Bob")
+    self.person_2 = MagicMock(name="Person John")
+    self.person_3 = MagicMock(name="Person Mike")
+
+    self.user_role_1 = MagicMock(person=self.person_1, role=MagicMock())
+    self.user_role_1.role.name = u"Auditor"
+
+    self.user_role_2 = MagicMock(person=self.person_2, role=MagicMock())
+    self.user_role_2.role.name = u"Owner"
+
+    self.user_role_3 = MagicMock(person=self.person_3, role=MagicMock())
+    self.user_role_3.role.name = u"Auditor"
+
+    self.audit = MagicMock(name="audit_1")
+    self.audit.context.user_roles = [
+        self.user_role_1, self.user_role_2, self.user_role_3
+    ]
+
+    self.related_object = MagicMock(name="assessment_1")
+
   # pylint: disable=invalid-name
-  @patch("ggrc.models.hooks.assessment.get_current_user_id")
-  @patch("ggrc.models.hooks.assessment.Person")
   def test_returns_auditors_as_default_assessors_when_no_template(
       self, person_class, get_current_user_id
   ):
@@ -28,25 +52,29 @@ class GetValueTestCase(unittest.TestCase):
     person_class.query.get.return_value = MagicMock(name="Person XY")
     get_current_user_id.return_value = 42
 
-    person_1 = MagicMock(name="Person Bob")
-    person_2 = MagicMock(name="Person John")
-    person_3 = MagicMock(name="Person Mike")
+    people = assessment.get_value(
+        "assessors", self.audit, self.related_object, template=None)
 
-    user_role_1 = MagicMock(person=person_1, role=MagicMock())
-    user_role_1.role.name = u"Auditor"
+    self.assertEqual(people, [self.person_1, self.person_3])
 
-    user_role_2 = MagicMock(person=person_2, role=MagicMock())
-    user_role_2.role.name = u"Owner"
+  # pylint: disable=invalid-name
+  def test_returns_auditors_as_default_verifiers_when_set_in_template(
+      self, person_class, get_current_user_id
+  ):
+    """The function should return all Audit's auditors if the template says so.
+    """
+    person_class.query.get.return_value = MagicMock(name="Person XY")
+    get_current_user_id.return_value = 42
 
-    user_role_3 = MagicMock(person=person_3, role=MagicMock())
-    user_role_3.role.name = u"Auditor"
-
-    audit = MagicMock(name="audit_1")
-    audit.context.user_roles = [user_role_1, user_role_2, user_role_3]
-
-    related_object = MagicMock(name="assessment_1")
+    assessment_template = MagicMock(
+        default_people={"assessors": "Object Owners", "verifiers": "Auditors"}
+    )
 
     people = assessment.get_value(
-        "assessors", audit, related_object, template=None)
+        "verifiers",
+        self.audit,
+        self.related_object,
+        template=assessment_template
+    )
 
-    self.assertEqual(people, [person_1, person_3])
+    self.assertEqual(people, [self.person_1, self.person_3])


### PR DESCRIPTION
~~The ticket says to add this option to the Default Verifier dropdown list, but I presume it needs to be added to the Default Assessors dropdown as well (to date both dropdowns have had identical options to select).~~

~~**Update:** There is no business logic for an Assessor to be an auditor, thus this needs to be updated.~~

**Update 2:** The lack of special business logic does not imply that an option should not be present in the dropdown, it was confirmed that it is fine if both dropdowns remain identical.

**Note:** This PR is based on #3861 I suggest to review and merge the latter first.