### PR TITLE
QUICK-FIX Disable AutomapperGenerator on Audit edit

### DIFF
--- a/src/ggrc/automapper/__init__.py
+++ b/src/ggrc/automapper/__init__.py
@@ -254,7 +254,6 @@ def register_automapping_listeners():
 
   # pylint: disable=unused-variable
   @Resource.model_posted_after_commit.connect_via(Audit)
-  @Resource.model_put_after_commit.connect_via(Audit)
   def handle_audit(sender, obj=None, src=None, service=None):
     if obj is None:
       logging.warning("Automapping audit listener: "


### PR DESCRIPTION
Removed the hook that fires on Audit PUT event since we are not supporting
editing of the program anyway (not even via the API) so this will not introduce
any consistency issues.

This makes Audit editing fast even if the underlying program has many mapped objects.