### PR TITLE
QUICK-FIX Reduce # of sql queries in automapper

### DIFF
--- a/src/ggrc/automapper/__init__.py
+++ b/src/ggrc/automapper/__init__.py
@@ -213,17 +213,14 @@ class AutomapperGenerator(object):
     if src in self.cache.get(dst, []):
       return False
 
-    created = False
-    if Relationship.find_related(src, dst) is None:
-      self.auto_mappings.add((src, dst))
-      created = True
+    self.auto_mappings.add((src, dst))
 
     if src in self.cache:
       self.cache[src].add(dst)
     if dst in self.cache:
       self.cache[dst].add(src)
 
-    return created
+    return True
 
 
 def register_automapping_listeners():


### PR DESCRIPTION
This makes the check more pessimistic but it turns out that a bigger `INSERT IGNORE` + more python run time is much cheaper than a large number of SQL queries.

This is critical because this has a big impact on Audit creation times.

Also see CORE-2546 - I noticed about 25% improvements (on my machine) in that case as well.