### PR TITLE
QUICK-FIX Fix mapping programs to controls

### DIFF
--- a/src/ggrc/automapper/__init__.py
+++ b/src/ggrc/automapper/__init__.py
@@ -81,7 +81,7 @@ class AutomapperGenerator(object):
         self.cache[dst].add(src)
 
     for type_, ids in batch_requests.iteritems():
-      model = getattr(models, type_)
+      model = getattr(models.all_models, type_)
       instances = model.query.filter(model.id.in_(ids))
       for instance in instances:
         self.instance_cache[Stub(type_, instance.id)] = instance
@@ -177,12 +177,12 @@ class AutomapperGenerator(object):
           self.queue.add(entry)
 
   def _step_implicit(self, src, dst, implicit):
-    if not hasattr(models, src.type):
+    if not hasattr(models.all_models, src.type):
       logging.warning('Automapping by attr: cannot find model %s', src.type)
       return
     instance = self.instance_cache.get(src)
     if instance is None:
-      model = getattr(models, src.type)
+      model = getattr(models.all_models, src.type)
       instance = model.query.filter(model.id == src.id).first()
       self.instance_cache[src] = instance
     if instance is None:

--- a/src/ggrc_basic_permissions/__init__.py
+++ b/src/ggrc_basic_permissions/__init__.py
@@ -30,7 +30,6 @@ from ggrc.login import get_current_user
 from ggrc.models import all_models
 from ggrc.models.audit import Audit
 from ggrc.models.program import Program
-from ggrc.models.relationship import Relationship
 from ggrc.rbac import permissions
 from ggrc.rbac.permissions_provider import DefaultUserPermissions
 from ggrc.services.common import _get_cache_manager
@@ -684,76 +683,6 @@ def add_public_program_context_implication(context, check_exists=False):
       context_scope='Program',
       modified_by=get_current_user(),
   ))
-
-
-# When adding a private program to an Audit Response, ensure Auditors
-#  can read it
-@Resource.model_posted.connect_via(Relationship)
-def handle_relationship_post(sender, obj=None, src=None, service=None):
-  db.session.flush()
-  db.session.add(obj)
-  db.session.flush()
-
-  if isinstance(obj.destination, Program) \
-     and obj.destination.private \
-     and db.session.query(ContextImplication) \
-     .filter(
-          and_(ContextImplication.context_id == obj.destination.context.id,
-               ContextImplication.source_context_id == obj.source.context.id))\
-     .count() < 1:
-    # Create the audit -> program implication for the
-    # Program added to the Response
-    parent_program = obj.source.request.audit.program
-    if parent_program != obj.destination:
-      db.session.add(ContextImplication(
-          source_context=obj.source.context,
-          context=obj.destination.context,
-          source_context_scope='Audit',
-          context_scope='Program',
-          modified_by=get_current_user(),
-      ))
-
-      db.session.add(ContextImplication(
-          source_context=parent_program.context,
-          context=obj.destination.context,
-          source_context_scope='Program',
-          context_scope='Program',
-          modified_by=get_current_user(),
-      ))
-
-
-# When adding a private program to an Audit Response, ensure Auditors
-#  can read it
-@Resource.model_deleted.connect_via(Relationship)
-def handle_relationship_delete(sender, obj=None, src=None, service=None):
-  db.session.flush()
-
-  if isinstance(obj.destination, Program) \
-     and obj.destination.private:
-
-    # figure out if any other responses in this audit
-    # are still mapped to the same prog
-    responses = [r for req in obj.source.request.audit.requests
-                 for r in req.responses]
-    relationships = [rel for resp in responses for rel in
-                     resp.related_destinations
-                     if rel != obj.destination]
-    matching_programs = [p.destination for p in relationships
-                         if p.destination == obj.destination]
-
-    # Delete the audit -> program implication for the Program removed from
-    # the Response
-    if len(matching_programs) < 1:
-      db.session.query(ContextImplication)\
-          .filter(
-              ContextImplication.context_id == obj.destination.context_id,
-              ContextImplication.source_context_id == obj.source.context_id)\
-          .delete()
-      db.session.query(ContextImplication)\
-          .filter(
-              ContextImplication.context_id == obj.destination.context_id,
-              ContextImplication.source_context_id == obj.source.context_id)\
-          .delete()
 
 
 @Resource.model_put.connect_via(Program)

--- a/src/ggrc_workflows/models/workflow.py
+++ b/src/ggrc_workflows/models/workflow.py
@@ -405,7 +405,8 @@ class WorkflowState(object):
     today = date.today()
     for cycle in current_cycles:
       for task in cycle.cycle_task_group_object_tasks:
-        if task.status != "Verified" and task.end_date <= today:
+        if (task.status != "Verified" and
+           task.end_date is not None and task.end_date <= today):
           return "Overdue"
 
     return cls._get_state(current_cycles)


### PR DESCRIPTION
With some data sets it's impossible to map existing programs to existing controls (from the control info page, program widget). Could not reproduce with clean db but easily with grc-dev dump.

This fixes multiple issues and unblocks the mapping.