### PR TITLE
CORE-3571 Speed up tree view item rendering

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
@@ -967,7 +967,7 @@ CMS.Controllers.TreeLoader('CMS.Controllers.TreeView', {
     // Increment call ID so that all previous draw_node calls will be skipped.
     this.draw_visible_call_id++;
     _.each(toRender, function (step) {
-      callId = this.draw_visible_call_id;
+      var callId = this.draw_visible_call_id;
       setTimeout(function () {
         if (this.draw_visible_call_id === callId) {
           step.draw_node();

--- a/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
@@ -881,7 +881,7 @@ CMS.Controllers.TreeLoader('CMS.Controllers.TreeView', {
     }
     return 0;
   },
-  draw_visible_call_id: 0,
+  draw_visible_call_count: 0,
   draw_visible: _.debounce(function () {
     var MAX_STEPS = 100;
     var elPosition;
@@ -904,7 +904,6 @@ CMS.Controllers.TreeLoader('CMS.Controllers.TreeView', {
     }
     elPosition = this.el_position.bind(this);
     children = this.element.children();
-
     lo = 0;
     hi = children.length - 1;
     max = hi;
@@ -943,8 +942,13 @@ CMS.Controllers.TreeLoader('CMS.Controllers.TreeView', {
 
     _.each(alreadyVisible, function (visible_element) {
       control = $(visible_element).control();
-      if (control && Math.abs(elPosition(control.element)) <= pageCount) {
+      if (!control) {
+        return;
+      }
+      if (Math.abs(elPosition(control.element)) <= pageCount) {
         visible.push(control);
+      } else {
+        control.draw_placeholder();
       }
     });
 
@@ -963,19 +967,19 @@ CMS.Controllers.TreeLoader('CMS.Controllers.TreeView', {
         toRender.push(control);
       }
     }
-
-    // Increment call ID so that all previous draw_node calls will be skipped.
-    this.draw_visible_call_id++;
-    _.each(toRender, function (step) {
-      var callId = this.draw_visible_call_id;
-      setTimeout(function () {
-        if (this.draw_visible_call_id === callId) {
-          step.draw_node();
-        }
-      }.bind(this), 0);
-    }.bind(this));
-  }, 30, {leading: true}),
-
+    this.renderStep(toRender, ++this.draw_visible_call_count);
+  }, 100, {leading: true}),
+  renderStep: function renderStep(toRender, count) {
+    // If there is nothing left to render or if draw_visible was run while
+    // rendering we simply terminate.
+    if (toRender.length === 0 || this.draw_visible_call_count > count) {
+      return;
+    }
+    toRender[0].draw_node();
+    setTimeout(function () {
+      this.renderStep(toRender.slice(1), count);
+    }.bind(this), 0);
+  },
   _last_scroll_top: 0,
 
   _is_scrolling_up: false,

--- a/src/ggrc/assets/mustache/assessments/tree.mustache
+++ b/src/ggrc/assets/mustache/assessments/tree.mustache
@@ -9,7 +9,7 @@
   <li class="tree-item" data-object-id="{{instance.id}}" data-object-type="{{instance.class.table_singular}}" {{addclass "t-" instance.workflow_state}}>
     <div class="item-main" {{#instance}}{{data 'model'}}{{/instance}}>
       <div class="item-wrap">
-        {{{render '/static/mustache/base_objects/open_close.mustache' instance=instance}}}
+        {{> '/static/mustache/base_objects/open_close.mustache'}}
         <div class="select">
           <div class="item-data">
             <div class="row-fluid">

--- a/src/ggrc/assets/mustache/audits/tree.mustache
+++ b/src/ggrc/assets/mustache/audits/tree.mustache
@@ -10,7 +10,7 @@
 <li class="tree-item" data-object-id="{{instance.id}}" data-object-type="{{instance.class.table_singular}}">
   <div class="item-main" data-model="true" {{#instance}}{{data 'model'}}{{/instance}}>
     <div class="item-wrap">
-      {{{render '/static/mustache/base_objects/open_close.mustache' instance=instance}}}
+      {{> '/static/mustache/base_objects/open_close.mustache'}}
       <div class="select">
         <div class="item-data">
           <div class="row-fluid">

--- a/src/ggrc/assets/mustache/base_objects/open_close.mustache
+++ b/src/ggrc/assets/mustache/base_objects/open_close.mustache
@@ -12,7 +12,7 @@
       <span class="status-label" {{addclass "status-" instance.workflow_state}}></span>
     {{else}}
       <span class="status-label"></span>
-    {{/instance}}
+    {{/if}}
   {{/if_instance_of}}
   <i class="fa fa-caret-right"></i>
 </div>

--- a/src/ggrc/assets/mustache/base_objects/tree.mustache
+++ b/src/ggrc/assets/mustache/base_objects/tree.mustache
@@ -12,7 +12,9 @@
 
     <div class="item-main" {{#instance}}{{data 'model'}}{{/instance}}>
       <div class="item-wrap">
-        {{{render '/static/mustache/base_objects/open_close.mustache' instance=instance}}}
+      {{#instance}}
+        {{{renderLive '/static/mustache/base_objects/open_close.mustache' instance=this}}}
+      {{/instance}}
         <div class="select">
           <div class="item-data">
             <div class="row-fluid">

--- a/src/ggrc/assets/mustache/base_objects/tree.mustache
+++ b/src/ggrc/assets/mustache/base_objects/tree.mustache
@@ -12,9 +12,7 @@
 
     <div class="item-main" {{#instance}}{{data 'model'}}{{/instance}}>
       <div class="item-wrap">
-      {{#instance}}
-        {{{renderLive '/static/mustache/base_objects/open_close.mustache' instance=this}}}
-      {{/instance}}
+       {{> '/static/mustache/base_objects/open_close.mustache'}}
         <div class="select">
           <div class="item-data">
             <div class="row-fluid">

--- a/src/ggrc/assets/mustache/controls/tree.mustache
+++ b/src/ggrc/assets/mustache/controls/tree.mustache
@@ -9,7 +9,7 @@
   <li class="tree-item" data-object-id="{{instance.id}}" data-object-type="control" {{addclass "t-" instance.workflow_state}}>
     <div class="item-main" {{#instance}}{{data 'model'}}{{/instance}}>
       <div class="item-wrap">
-        {{{render '/static/mustache/base_objects/open_close.mustache' instance=instance}}}
+        {{> '/static/mustache/base_objects/open_close.mustache'}}
         <div class="select">
           <div class="item-data">
             <div class="row-fluid">

--- a/src/ggrc/assets/mustache/custom_attribute_definitions/tree.mustache
+++ b/src/ggrc/assets/mustache/custom_attribute_definitions/tree.mustache
@@ -9,7 +9,7 @@
 <li class="tree-item" data-model="true">
   <div class="item-main" {{data 'model'}}>
     <div class="item-wrap">
-      {{> '/static/mustache/base_objects/open_close.mustache' }}
+      {{> '/static/mustache/base_objects/open_close.mustache'}}
       <div class="select disabled">
         <div class="item-data">
           <div class="row-fluid">

--- a/src/ggrc/assets/mustache/directives/tree.mustache
+++ b/src/ggrc/assets/mustache/directives/tree.mustache
@@ -8,7 +8,7 @@
   <li class="tree-item" data-object-id="{{instance.id}}" data-object-type="{{instance.class.table_singular}}" {{addclass "t-" instance.workflow_state}}>
     <div class="item-main" {{#instance}}{{data 'model'}}{{/instance}}>
       <div class="item-wrap">
-        {{{render '/static/mustache/base_objects/open_close.mustache' instance=instance}}}
+        {{> '/static/mustache/base_objects/open_close.mustache'}}
         <div class="select">
           <div class="item-data">
             <div class="row-fluid">

--- a/src/ggrc/assets/mustache/documents/tree.mustache
+++ b/src/ggrc/assets/mustache/documents/tree.mustache
@@ -9,7 +9,7 @@
   <li class="tree-item" data-object-id="{{instance.id}}" data-object-type="{{instance.class.table_singular}}">
     <div class="item-main" {{#instance}}{{data 'model'}}{{/instance}}>
       <div class="item-wrap">
-        {{{render '/static/mustache/base_objects/open_close.mustache' instance=instance}}}
+        {{> '/static/mustache/base_objects/open_close.mustache'}}
         <div class="select">
           <div class="item-data">
             <div class="row-fluid">

--- a/src/ggrc/assets/mustache/objectives/tree.mustache
+++ b/src/ggrc/assets/mustache/objectives/tree.mustache
@@ -9,7 +9,7 @@
   <li class="tree-item" data-object-id="{{instance.id}}" data-object-type="objective" {{addclass "t-" instance.workflow_state}}>
     <div class="item-main" {{#instance}}{{data 'model'}}{{/instance}}>
       <div class="item-wrap">
-        {{{render '/static/mustache/base_objects/open_close.mustache' instance=instance}}}
+        {{> '/static/mustache/base_objects/open_close.mustache'}}
         <div class="select">
           <div class="item-data">
             <div class="row-fluid">

--- a/src/ggrc/assets/mustache/people/object_list.mustache
+++ b/src/ggrc/assets/mustache/people/object_list.mustache
@@ -11,7 +11,7 @@
     <li class="tree-item role" data-model="true" {{data 'model'}}>
       <div class="item-main">
         <div class="item-wrap">
-          {{{render '/static/mustache/base_objects/open_close.mustache' instance=instance}}}
+          {{> '/static/mustache/base_objects/open_close.mustache'}}
           <div class="select">
             <div class="item-data">
               <div class="row-fluid">

--- a/src/ggrc/assets/mustache/people/tree.mustache
+++ b/src/ggrc/assets/mustache/people/tree.mustache
@@ -8,7 +8,7 @@
   <li class="tree-item" data-object-id="{{instance.id}}" data-object-type="{{instance.class.table_singular}}">
     <div class="item-main" {{#instance}}{{data 'model'}}{{/instance}}>
       <div class="item-wrap">
-        {{{render '/static/mustache/base_objects/open_close.mustache' instance=instance}}}
+        {{> '/static/mustache/base_objects/open_close.mustache'}}
         <div class="select">
           <div class="item-data">
             <div class="row-fluid">

--- a/src/ggrc/assets/mustache/programs/tree.mustache
+++ b/src/ggrc/assets/mustache/programs/tree.mustache
@@ -9,7 +9,7 @@
   <li class="tree-item" data-object-id="{{instance.id}}" data-object-type="{{instance.class.table_singular}}" {{addclass "t-" instance.workflow_state}}>
     <div class="item-main" {{#instance}}{{data 'model'}}{{/instance}}>
       <div class="item-wrap">
-        {{{render '/static/mustache/base_objects/open_close.mustache' instance=instance}}}
+        {{> '/static/mustache/base_objects/open_close.mustache'}}
         <div class="select">
           <div class="item-data">
             <div class="row-fluid">

--- a/src/ggrc/assets/mustache/requests/tree.mustache
+++ b/src/ggrc/assets/mustache/requests/tree.mustache
@@ -8,7 +8,7 @@
 <li class="tree-item requests" data-object-id="{{instance.id}}" data-object-type="{{instance.class.table_singular}}" {{addclass "rq-" instance.status}}>
   <div class="item-main" {{#instance}}{{data 'model'}}{{/instance}} data-model="true">
     <div class="item-wrap">
-      {{{render '/static/mustache/base_objects/open_close.mustache' instance=instance}}}
+      {{> '/static/mustache/base_objects/open_close.mustache'}}
       <div class="select">
         <div class="item-data">
           <div class="row-fluid">

--- a/src/ggrc/assets/mustache/search/advanced_search_people_items.mustache
+++ b/src/ggrc/assets/mustache/search/advanced_search_people_items.mustache
@@ -13,7 +13,7 @@
   data-id="{{ instance.id }}">
     <div class="item-main">
       <div class="item-wrap">
-        {{{render '/static/mustache/base_objects/open_close.mustache' instance=instance}}}
+        {{> '/static/mustache/base_objects/open_close.mustache'}}
         <div class="select">
           <div class="item-data">
             <div class="row-fluid">

--- a/src/ggrc/assets/mustache/sections/tree.mustache
+++ b/src/ggrc/assets/mustache/sections/tree.mustache
@@ -9,7 +9,7 @@
   <li class="tree-item" data-object-id="{{instance.id}}" data-object-type="{{instance.class.table_singular}}" {{addclass "t-" instance.workflow_state}}>
     <div class="item-main" {{#instance}}{{data 'model'}}{{/instance}}>
       <div class="item-wrap">
-        {{{render '/static/mustache/base_objects/open_close.mustache' instance=instance}}}
+        {{> '/static/mustache/base_objects/open_close.mustache'}}
         <div class="select">
           <div class="item-data">
             <div class="row-fluid">

--- a/src/ggrc_basic_permissions/assets/mustache/ggrc_basic_permissions/people_roles/authorizations_by_person_tree.mustache
+++ b/src/ggrc_basic_permissions/assets/mustache/ggrc_basic_permissions/people_roles/authorizations_by_person_tree.mustache
@@ -8,7 +8,7 @@
     <li class="tree-item" data-object-id="{{instance.id}}" data-object-type="{{instance.class.table_singular}}">
       <div class="item-main" {{#instance}}{{data 'person'}}{{/instance}}>
         <div class="item-wrap">
-          {{{render '/static/mustache/base_objects/open_close.mustache' instance=instance}}}
+          {{> '/static/mustache/base_objects/open_close.mustache'}}
           <div class="select">
             <div class="item-data">
               <div class="row-fluid">

--- a/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/tree.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/tree.mustache
@@ -11,7 +11,7 @@
   >
   <div class="item-main" {{data 'model'}}>
     <div class="item-wrap">
-      {{{render '/static/mustache/base_objects/open_close.mustache' instance=instance}}}
+      {{> '/static/mustache/base_objects/open_close.mustache'}}
       <div class="select">
         <div class="item-data">
           <div class="row-fluid">

--- a/src/ggrc_workflows/assets/mustache/cycle_task_group_objects/tree.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_group_objects/tree.mustache
@@ -9,7 +9,7 @@
 <li class="tree-item t-assigned" {{addclass "t-" instance.status}} {{addclass "t-" instance.overdue}} data-object-id="{{instance.id}}" data-object-type="{{instance.class.table_singular}}">
   <div class="item-main" {{#instance}}{{data 'model'}}{{/instance}}>
     <div class="item-wrap">
-      {{{render '/static/mustache/base_objects/open_close.mustache' instance=instance}}}
+      {{> '/static/mustache/base_objects/open_close.mustache'}}
       <div class="select">
         <div class="item-data">
           <div class="row-fluid">

--- a/src/ggrc_workflows/assets/mustache/cycle_task_groups/tree.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_groups/tree.mustache
@@ -9,7 +9,7 @@
 <li class="tree-item task-item t-assigned" data-object-id="{{instance.id}}" data-object-type="{{instance.class.table_singular}}" {{addclass "t-" instance.status}} {{addclass "t-" instance.overdue}}>
   <div class="item-main" {{#instance}}{{data 'model'}}{{/instance}}>
     <div class="item-wrap">
-      {{{render '/static/mustache/base_objects/open_close.mustache' instance=instance}}}
+      {{> '/static/mustache/base_objects/open_close.mustache'}}
       <div class="select">
         <div class="item-data">
           <div class="row-fluid">

--- a/src/ggrc_workflows/assets/mustache/cycles/tree.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycles/tree.mustache
@@ -8,7 +8,7 @@
 <li class="tree-item" {{addclass "t-" instance.status}} {{addclass "t-" instance.overdue}} data-object-id="{{instance.id}}" data-object-type="{{instance.class.table_singular}}">
   <div class="item-main" {{#instance}}{{data 'model'}}{{/instance}}>
     <div class="item-wrap">
-      {{{render '/static/mustache/base_objects/open_close.mustache' instance=instance}}}
+      {{> '/static/mustache/base_objects/open_close.mustache'}}
       <div class="select">
         <div class="item-data">
           <div class="row-fluid">

--- a/src/ggrc_workflows/assets/mustache/selectors/multitype_multiselect_option_items.mustache
+++ b/src/ggrc_workflows/assets/mustache/selectors/multitype_multiselect_option_items.mustache
@@ -13,7 +13,7 @@
 
   <div class="item-main">
     <div class="item-wrap">
-      {{{render '/static/mustache/base_objects/open_close.mustache' instance=instance}}}
+      {{> '/static/mustache/base_objects/open_close.mustache'}}
       <div class="select">
         <div class="item-data">
           <div class="row-fluid">

--- a/src/ggrc_workflows/assets/mustache/selectors/object_selector_option_items.mustache
+++ b/src/ggrc_workflows/assets/mustache/selectors/object_selector_option_items.mustache
@@ -9,7 +9,7 @@
   <li class="tree-item task-item" data-object-type="{{instance.class.table_singular}}"{{#instance}}{{ data 'option' }}{{/instance}} data-id="{{ instance.id }}">
     <div class="item-main">
       <div class="item-wrap">
-        {{{render '/static/mustache/base_objects/open_close.mustache' instance=instance}}}
+        {{> '/static/mustache/base_objects/open_close.mustache'}}
         <div class="select">
           <div class="item-data">
             <div class="row-fluid">

--- a/src/ggrc_workflows/assets/mustache/workflows/tree.mustache
+++ b/src/ggrc_workflows/assets/mustache/workflows/tree.mustache
@@ -9,7 +9,7 @@
   <li class="tree-item" data-object-id="{{instance.id}}" data-object-type="{{instance.class.table_singular}}" {{addclass "t-" instance.workflow_state}}>
     <div class="item-main" {{#instance}}{{data 'model'}}{{/instance}}>
       <div class="item-wrap">
-        {{{render '/static/mustache/base_objects/open_close.mustache' instance=instance}}}
+        {{> '/static/mustache/base_objects/open_close.mustache'}}
         <div class="select">
           <div class="item-data">
             <div class="row-fluid">


### PR DESCRIPTION
Changed the way items are scheduled for rendering by scheduling them all
upfront instead of chaining them. This makes them render faster but isn't as
smooth.

Stopped replacing a rendered item with a placeholder when it is no
longer visible. This decreases the amount of re-rendering for the browser
but risks increasing the memory use. This seemed to not affect performance
for ~750 objects but needs some more testing.

Decreased the delay between the user stopping scrolling and the item
rendering starting.

Sped up template rendering of each item by switching open_close
template to use 'renderLive' instead of 'render'. Serializing the
context in the 'render' function was taking about 40% of the rendering
time. It is still taking ~30ms to draw each item.