### PR TITLE
QUICK-FIX Fix custom attribute loading

### DIFF
--- a/src/ggrc/models/assessment_template.py
+++ b/src/ggrc/models/assessment_template.py
@@ -6,13 +6,14 @@
 """A module containing the implementation of the assessment template entity."""
 
 from ggrc import db
-from ggrc.models.mixins import Base, Titled
+from ggrc.models.mixins import Base, Titled, CustomAttributable
 from ggrc.models.reflection import PublishOnly
 from ggrc.models.relationship import Relatable
 from ggrc.models.types import JsonType
 
 
-class AssessmentTemplate(Base, Relatable, Titled, db.Model):
+class AssessmentTemplate(Base, Relatable, Titled,
+                         CustomAttributable, db.Model):
   """A class representing the assessment template entity.
 
   An Assessment Template is a template that allows users for easier creation of

--- a/src/ggrc/models/custom_attribute_definition.py
+++ b/src/ggrc/models/custom_attribute_definition.py
@@ -31,7 +31,7 @@ class CustomAttributeDefinition(mixins.Base, mixins.Titled, db.Model):
                        name='uq_custom_attribute'),
       db.Index('ix_custom_attributes_title', 'title'))
 
-  _publish_attrs = [
+  _include_links = _publish_attrs = [
       'definition_type',
       'definition_id',
       'attribute_type',

--- a/src/ggrc/models/mixins.py
+++ b/src/ggrc/models/mixins.py
@@ -665,35 +665,37 @@ class BusinessObject(Stateful, Noted, Described, Hyperlinked, WithContact,
 class CustomAttributable(object):
 
   @declared_attr
-  def custom_attribute_values(cls):
+  def custom_attribute_values(self):
+    """Load custom attribute values"""
     from ggrc.models.custom_attribute_value import CustomAttributeValue
 
     def join_function():
       return and_(
-          foreign(CustomAttributeValue.attributable_id) == cls.id,
-          foreign(CustomAttributeValue.attributable_type) == cls.__name__)
+          foreign(CustomAttributeValue.attributable_id) == self.id,
+          foreign(CustomAttributeValue.attributable_type) == self.__name__)
     return relationship(
         "CustomAttributeValue",
         primaryjoin=join_function,
-        backref='{0}_custom_attributable'.format(cls.__name__),
+        backref='{0}_custom_attributable'.format(self.__name__),
         cascade='all, delete-orphan',
     )
 
   @declared_attr
-  def custom_attribute_definitions(cls):
+  def custom_attribute_definitions(self):
+    """Load custom attribute definitions"""
     from ggrc.models.custom_attribute_definition\
         import CustomAttributeDefinition
 
     def join_function():
       definition_id = foreign(CustomAttributeDefinition.definition_id)
       definition_type = foreign(CustomAttributeDefinition.definition_type)
-      return and_(or_(definition_id == cls.id, definition_id == None),  # noqa
-                  definition_type == cls._inflector.table_singular)
+      return and_(or_(definition_id == self.id, definition_id.is_(None)),
+                  definition_type == self._inflector.table_singular)
 
     return relationship(
         "CustomAttributeDefinition",
         primaryjoin=join_function,
-        backref='{0}_custom_attributable_definition'.format(cls.__name__),
+        backref='{0}_custom_attributable_definition'.format(self.__name__),
         cascade='all, delete-orphan',
     )
 

--- a/src/ggrc/views/__init__.py
+++ b/src/ggrc/views/__init__.py
@@ -116,7 +116,7 @@ def get_current_user_json():
 def get_attributes_json():
   """Get a list of all custom attribute definitions"""
   attrs = models.CustomAttributeDefinition.eager_query().filter(
-      models.CustomAttributeDefinition.definition_id == None  # noqa
+      models.CustomAttributeDefinition.definition_id.is_(None)
   )
   published = []
   for attr in attrs:

--- a/src/ggrc/views/__init__.py
+++ b/src/ggrc/views/__init__.py
@@ -115,7 +115,9 @@ def get_current_user_json():
 
 def get_attributes_json():
   """Get a list of all custom attribute definitions"""
-  attrs = models.CustomAttributeDefinition.eager_query().all()
+  attrs = models.CustomAttributeDefinition.eager_query().filter(
+      models.CustomAttributeDefinition.definition_id == None  # noqa
+  )
   published = []
   for attr in attrs:
     published.append(publish(attr))


### PR DESCRIPTION
Having 2000+ custom attribute definitions injected into the base
template increased the page load by multiple seconds. This fix should
greatly increase page load times on system with a big amount of custom
attribute definitions on the object level.