### PR TITLE
QUICK-FIX Background task improvements

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment_generator.js
+++ b/src/ggrc/assets/javascripts/components/assessment_generator.js
@@ -58,6 +58,25 @@
         flash[type] = messages[type];
         $('body').trigger('ajax:flash', flash);
       },
+      updateStatus: function (ids, count) {
+        var wait = [2, 4, 8, 16, 32, 64];
+        if (count >= wait.length) {
+          count = wait.length - 1;
+        }
+        CMS.Models.BackgroundTask.findAll({
+          id__in: ids.join(',')
+        }).then(function (tasks) {
+          var statuses = _.countBy(tasks, function (task) {
+            return task.status;
+          });
+          this.showFlash(statuses);
+          if (statuses.Pending || statuses.Running) {
+            setTimeout(function () {
+              this.updateStatus(ids, ++count);
+            }.bind(this), wait[count] * 1000);
+          }
+        }.bind(this));
+      },
       generateAssessments: function (list, options) {
         var que = new RefreshQueue();
 
@@ -72,7 +91,6 @@
             .then(function () {
               var tasks = arguments;
               var ids;
-              var interval;
               this.showFlash({Pending: 1});
               options.context.closeModal();
               if (!tasks.length || tasks[0] instanceof CMS.Models.Assessment) {
@@ -83,19 +101,7 @@
               ids = _.uniq(_.map(arguments, function (task) {
                 return task.id;
               }));
-              interval = setInterval(function () {
-                CMS.Models.BackgroundTask.findAll({
-                  id__in: ids.join(',')
-                }).then(function (tasks) {
-                  var statuses = _.countBy(tasks, function (task) {
-                    return task.status;
-                  });
-                  if (!statuses.Pending && !statuses.Running) {
-                    clearInterval(interval);
-                  }
-                  this.showFlash(statuses);
-                }.bind(this));
-              }.bind(this), 2000);
+              this.updateStatus(ids, 0);
             }.bind(this));
         }.bind(this));
       },

--- a/src/ggrc/assets/javascripts/models/save_queue.js
+++ b/src/ggrc/assets/javascripts/models/save_queue.js
@@ -32,7 +32,8 @@
     _enqueue_bucket: function (bucket) {
       var that = this;
       return function () {
-        var objs = bucket.objs.splice(0, that.BATCH_SIZE);
+        var size = bucket.background ? bucket.objs.length : that.BATCH_SIZE;
+        var objs = bucket.objs.splice(0, size);
         var body = _.map(objs, function (obj) {
           var list = {};
           list[bucket.type] = obj.serialize();


### PR DESCRIPTION
- [x] Improves background task polling by increasing wait time between consecutive requests (starts with a 2s wait and can get up to 64s wait between requests).
- [x] Prevents batching of objects into multiple requests. This makes sure that the generation dialog is closed sooner - without having to wait for multiple POST requests to resolve.