### PR TITLE
QUICK-FIX Fix backend rich text cleaner

### DIFF
--- a/src/ggrc/models/__init__.py
+++ b/src/ggrc/models/__init__.py
@@ -174,15 +174,14 @@ def init_sanitization_hooks():
 
     parser = HTMLParser()
     value = unicode(value)
-    lastvalue = value
-    value = parser.unescape(value)
-    while value != lastvalue:
+    while True:
       lastvalue = value
-      value = parser.unescape(value)
-
-    ret = parser.unescape(
-        bleach.clean(value, bleach_tags, bleach_attrs, strip=True))
-    return ret
+      value = parser.unescape(
+          bleach.clean(value, bleach_tags, bleach_attrs, strip=True)
+      )
+      if value == lastvalue:
+        break
+    return value
 
   for model in all_models:
     attr_info = SanitizeHtmlInfo(model)

--- a/src/ggrc/models/__init__.py
+++ b/src/ggrc/models/__init__.py
@@ -4,10 +4,13 @@
 # Maintained By: dan@reciprocitylabs.com
 
 import inspect
+import sqlalchemy as sa
 
-from ggrc.models.all_models import *  # noqa
-from ggrc import settings
 from ggrc import db
+from ggrc import settings
+from ggrc.models.reflection import SanitizeHtmlInfo
+from ggrc.models.all_models import *  # noqa
+from ggrc.utils import html_cleaner
 
 """All gGRC model objects and associated utilities."""
 
@@ -143,51 +146,11 @@ def init_session_monitor_cache():
 
 def init_sanitization_hooks():
   # Register event listener on all String and Text attributes to sanitize them.
-  import bleach
-  from HTMLParser import HTMLParser
-  import sqlalchemy as sa
-  from ggrc.models.reflection import SanitizeHtmlInfo
-  from .all_models import all_models
-
-  # Set up custom tags/attributes for bleach
-  bleach_tags = [
-      'caption', 'strong', 'em', 'b', 'i', 'p', 'code', 'pre', 'tt', 'samp',
-      'kbd', 'var', 'sub', 'sup', 'dfn', 'cite', 'big', 'small', 'address',
-      'hr', 'br', 'div', 'span', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'ul',
-      'ol', 'li', 'dl', 'dt', 'dd', 'abbr', 'acronym', 'a', 'img',
-      'blockquote', 'del', 'ins', 'table', 'tbody', 'tr', 'td', 'th',
-  ] + bleach.ALLOWED_TAGS
-  bleach_attrs = {}
-  attrs = [
-      'href', 'src', 'width', 'height', 'alt', 'cite', 'datetime',
-      'title', 'class', 'name', 'xml:lang', 'abbr'
-  ]
-
-  for tag in bleach_tags:
-    bleach_attrs[tag] = attrs
-
-  def cleaner(target, value, oldvalue, initiator):
-    # Some cases like Request don't use the title value
-    #  and it's nullable, so check for that
-    if value is None:
-      return value
-
-    parser = HTMLParser()
-    value = unicode(value)
-    while True:
-      lastvalue = value
-      value = parser.unescape(
-          bleach.clean(value, bleach_tags, bleach_attrs, strip=True)
-      )
-      if value == lastvalue:
-        break
-    return value
-
-  for model in all_models:
+  for model in all_models.all_models:
     attr_info = SanitizeHtmlInfo(model)
     for attr_name in attr_info._sanitize_html:
       attr = getattr(model, attr_name)
-      sa.event.listen(attr, 'set', cleaner, retval=True)
+      sa.event.listen(attr, 'set', html_cleaner.cleaner, retval=True)
 
 
 def init_app(app):

--- a/src/ggrc/utils/__init__.py
+++ b/src/ggrc/utils/__init__.py
@@ -11,7 +11,7 @@ import sys
 import time
 
 from flask import current_app, request
-from settings import CUSTOM_URL_ROOT
+from ggrc.settings import CUSTOM_URL_ROOT
 
 
 class GrcEncoder(json.JSONEncoder):

--- a/src/ggrc/utils/html_cleaner.py
+++ b/src/ggrc/utils/html_cleaner.py
@@ -1,0 +1,47 @@
+# Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+# Created By: andraz@reciprocitylabs.com
+# Maintained By: andraz@reciprocitylabs.com
+
+
+import bleach
+
+from HTMLParser import HTMLParser
+
+
+# Set up custom tags/attributes for bleach
+bleach_tags = [
+    'caption', 'strong', 'em', 'b', 'i', 'p', 'code', 'pre', 'tt', 'samp',
+    'kbd', 'var', 'sub', 'sup', 'dfn', 'cite', 'big', 'small', 'address',
+    'hr', 'br', 'div', 'span', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'ul',
+    'ol', 'li', 'dl', 'dt', 'dd', 'abbr', 'acronym', 'a', 'img',
+    'blockquote', 'del', 'ins', 'table', 'tbody', 'tr', 'td', 'th',
+] + bleach.ALLOWED_TAGS
+
+bleach_attrs = {}
+
+attrs = [
+    'href', 'src', 'width', 'height', 'alt', 'cite', 'datetime',
+    'title', 'class', 'name', 'xml:lang', 'abbr'
+]
+
+for tag in bleach_tags:
+  bleach_attrs[tag] = attrs
+
+
+def cleaner(target, value, oldvalue, initiator):
+  # Some cases like Request don't use the title value
+  #  and it's nullable, so check for that
+  if value is None:
+    return value
+
+  parser = HTMLParser()
+  value = unicode(value)
+  while True:
+    lastvalue = value
+    value = parser.unescape(
+        bleach.clean(value, bleach_tags, bleach_attrs, strip=True)
+    )
+    if value == lastvalue:
+      break
+  return value

--- a/src/ggrc/utils/html_cleaner.py
+++ b/src/ggrc/utils/html_cleaner.py
@@ -3,14 +3,15 @@
 # Created By: andraz@reciprocitylabs.com
 # Maintained By: andraz@reciprocitylabs.com
 
-
-import bleach
+"""Provides an HTML cleaner function with sqalchemy compatible API"""
 
 from HTMLParser import HTMLParser
 
+import bleach
+
 
 # Set up custom tags/attributes for bleach
-bleach_tags = [
+BLEACH_TAGS = [
     'caption', 'strong', 'em', 'b', 'i', 'p', 'code', 'pre', 'tt', 'samp',
     'kbd', 'var', 'sub', 'sup', 'dfn', 'cite', 'big', 'small', 'address',
     'hr', 'br', 'div', 'span', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'ul',
@@ -18,18 +19,28 @@ bleach_tags = [
     'blockquote', 'del', 'ins', 'table', 'tbody', 'tr', 'td', 'th',
 ] + bleach.ALLOWED_TAGS
 
-bleach_attrs = {}
+BLEACH_ATTRS = {}
 
-attrs = [
+ATTRS = [
     'href', 'src', 'width', 'height', 'alt', 'cite', 'datetime',
     'title', 'class', 'name', 'xml:lang', 'abbr'
 ]
 
-for tag in bleach_tags:
-  bleach_attrs[tag] = attrs
+for tag in BLEACH_TAGS:
+  BLEACH_ATTRS[tag] = ATTRS
 
 
-def cleaner(target, value, oldvalue, initiator):
+def cleaner(dummy, value, *_):
+  """Cleans out unsafe HTML tags.
+
+  Uses bleach and unescape until it reaches a fix point.
+
+  Args:
+    dummy: unused, sqalchemy will pass in the model class
+    value: html (string) to be cleaned
+  Returns:
+    Html (string) without unsafe tags.
+  """
   # Some cases like Request don't use the title value
   #  and it's nullable, so check for that
   if value is None:
@@ -40,7 +51,7 @@ def cleaner(target, value, oldvalue, initiator):
   while True:
     lastvalue = value
     value = parser.unescape(
-        bleach.clean(value, bleach_tags, bleach_attrs, strip=True)
+        bleach.clean(value, BLEACH_TAGS, BLEACH_ATTRS, strip=True)
     )
     if value == lastvalue:
       break

--- a/test/unit/ggrc/test_utils.py
+++ b/test/unit/ggrc/test_utils.py
@@ -135,3 +135,14 @@ class TestUtilsFunctions(TestCase):
     }
     expected_result = utils.merge_dicts(dict1, dict2, dict3)
     self.assertEqual(result, expected_result)
+
+  def test_html_cleaner(self):
+    def clean(value):
+      return utils.html_cleaner.cleaner(None, value, None, None)
+
+    self.assertEqual(clean("<script>alert(1)</script>"), "alert(1)")
+
+    nested = ("<<script>s<script>c<script>r<script>i<script>p<script>t"
+              "<script>>alert(2)<<script>/<script>s<script>c<script>r<script>"
+              "i<script>p<script>t<script>>")
+    self.assertEqual(clean(nested), "alert(2)")


### PR DESCRIPTION
This now also handles cases with nested script tags, for example
```
<<script>s<script>c<script>r<script>i<script>p<script>t<script>>alert(1)<script>/<script>s<script>c<script>r<script>i<script>p<script>t<script>>
```