### PR TITLE
CORE-3467 Fix script error when loading an Assessment

### DIFF
--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -964,7 +964,8 @@
           definition = _.find(instance.custom_attribute_definitions, {
             id: cav.custom_attribute_id
           });
-          if (!definition.multi_choice_options ||
+          if (!definition ||
+              !definition.multi_choice_options ||
               !definition.multi_choice_mandatory) {
             return;
           }


### PR DESCRIPTION
I was not able to reproduce this issue locally, even after discussing it with Kostya yet again, but by seeing it on the test server I was able to create the fix.

See the comments under the ticket for the link to an Assessment where the issue can be observed.