### PR TITLE
CORE-3467 Wait for Assessment custom attributes data to load

### DIFF
--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -942,10 +942,11 @@
         rq.enqueue(cav);
       });
       $.when(
+          instance.refresh('custom_attributes_values'),
           instance.get_binding('comments').refresh_count(),
           instance.get_binding('all_documents').refresh_count(),
           rq.trigger()
-      ).then(function (commentCount, attachmentCount, rqRes) {
+      ).then(function (assessment, commentCount, attachmentCount, rqRes) {
         var values = _.map(instance.custom_attribute_values, function (cav) {
           return cav.reify();
         });
@@ -964,8 +965,7 @@
           definition = _.find(instance.custom_attribute_definitions, {
             id: cav.custom_attribute_id
           });
-          if (!definition ||
-              !definition.multi_choice_options ||
+          if (!definition.multi_choice_options ||
               !definition.multi_choice_mandatory) {
             return;
           }


### PR DESCRIPTION
This changes the way the issue was resolved in #3890 - the latter PR only fixed the symptom, but no the cause itself, which was that custom attributes data has not been loaded yet when needed.

This PR also reverts the fix done in #3890 because if there happens to be another bug, we want to make it loud and explicit, thus the `!definition` condition has been removed (that just fixed the symptom, but then the checks for mandatory stuff would not  work).