### PR TITLE
CORE-3467 Correctly refresh Assessment's custom attributes

### DIFF
--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -942,11 +942,11 @@
         rq.enqueue(cav);
       });
       $.when(
-          instance.refresh('custom_attributes_values'),
+          instance.refresh_all('custom_attributes_values'),
           instance.get_binding('comments').refresh_count(),
           instance.get_binding('all_documents').refresh_count(),
           rq.trigger()
-      ).then(function (assessment, commentCount, attachmentCount, rqRes) {
+      ).then(function (customAttrVals, commentCount, attachmentCount, rqRes) {
         var values = _.map(instance.custom_attribute_values, function (cav) {
           return cav.reify();
         });


### PR DESCRIPTION
This now _really_ fixes the issue, previously the instance itself was refreshed instead of its bindings.