### PR TITLE
QUICK-FIX Fix a typo in Assessment's binding name

### DIFF
--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -942,7 +942,7 @@
         rq.enqueue(cav);
       });
       $.when(
-          instance.refresh_all('custom_attributes_values'),
+          instance.refresh_all('custom_attribute_values'),
           instance.get_binding('comments').refresh_count(),
           instance.get_binding('all_documents').refresh_count(),
           rq.trigger()


### PR DESCRIPTION
This is a follow-up on #3901 