### PR TITLE
QUICK-FIX Fix Assessment creation

### DIFF
--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -868,7 +868,8 @@
   }, {
     form_preload: function (newObjectForm) {
       var pageInstance = GGRC.page_instance();
-      var currentUser = CMS.Models.get_instance("Person", GGRC.current_user);
+      var currentUser = CMS.Models.get_instance('Person',
+        GGRC.current_user.id, GGRC.current_user);
       this._set_recipients(this.attr('recipients'));
 
       if (!newObjectForm) {


### PR DESCRIPTION
This actually fetches Person instance instead of malformed object that `get_instance` returns if you put in wrong types of parameters.