### PR TITLE
QUICK-FIX Add validator for status changes

### DIFF
--- a/src/ggrc/converters/column_handlers.py
+++ b/src/ggrc/converters/column_handlers.py
@@ -4,7 +4,7 @@
 """List of all column handlers for objects in the ggrc module."""
 
 from ggrc.converters.handlers import handlers
-from ggrc.converters.handlers import request
+from ggrc.converters.handlers import statusable
 from ggrc.converters.handlers import related_person
 from ggrc.converters.handlers import list_handlers
 from ggrc.converters.handlers import boolean
@@ -49,7 +49,8 @@ GGRC_COLUMN_HANDLERS = {
     "report_start_date": handlers.DateColumnHandler,
     "request": handlers.RequestColumnHandler,
     "request_audit": handlers.RequestAuditColumnHandler,
-    "request_status": request.RequestStatusColumnHandler,
+    "request_status": statusable.StatusableColumnHandler,
+    "assessment_status": statusable.StatusableColumnHandler,
     "request_type": handlers.RequestTypeColumnHandler,
     "requested_on": handlers.DateColumnHandler,
     "secondary_assessor": handlers.UserColumnHandler,

--- a/src/ggrc/converters/errors.py
+++ b/src/ggrc/converters/errors.py
@@ -86,7 +86,7 @@ STATUSABLE_INVALID_STATE = (u"LINE {line}: Can not set {object_type} state to "
 
 STATUSABLE_INVALID_TRANSITION = (u"LINE {line}: Can not transition "
                                  u"{object_type} state from {current_state} to "
-                                 u"{new_state}.")
+                                 u"{new_state} via imports.")
 
 INVALID_START_END_DATES = (u"Line {line}: {start_date} can not be after "
                            u"{end_date}. The line will be ignored.")

--- a/src/ggrc/converters/errors.py
+++ b/src/ggrc/converters/errors.py
@@ -85,8 +85,8 @@ STATUSABLE_INVALID_STATE = (u"LINE {line}: Can not set {object_type} state to "
                             u"imports.")
 
 STATUSABLE_INVALID_TRANSITION = (u"LINE {line}: Can not transition "
-                                 u"{object_type} state from {current_state} to "
-                                 u"{new_state} via imports.")
+                                 u"{object_type} state from {current_state} "
+                                 u"to {new_state} via imports.")
 
 INVALID_START_END_DATES = (u"Line {line}: {start_date} can not be after "
                            u"{end_date}. The line will be ignored.")

--- a/src/ggrc/converters/errors.py
+++ b/src/ggrc/converters/errors.py
@@ -80,8 +80,13 @@ DELETE_CASCADE_ERROR = (u"Line {line}: Cannot delete object {object_type}:"
 
 UNKNOWN_ERROR = u"Line {line}: Import failed due to unknown error."
 
-REQUEST_INVALID_STATE = (u"Line {line}: Can not set Request state to Completed"
-                         u" or Verified via imports.")
+STATUSABLE_INVALID_STATE = (u"LINE {line}: Can not set {object_type} state to "
+                            u"Completed, Ready for Review or Verified via "
+                            u"imports.")
+
+STATUSABLE_INVALID_TRANSITION = (u"LINE {line}: Can not transition "
+                                 u"{object_type} state from {current_state} to "
+                                 u"{new_state}.")
 
 INVALID_START_END_DATES = (u"Line {line}: {start_date} can not be after "
                            u"{end_date}. The line will be ignored.")

--- a/src/ggrc/converters/handlers/handlers.py
+++ b/src/ggrc/converters/handlers/handlers.py
@@ -171,8 +171,14 @@ class StatusColumnHandler(ColumnHandler):
   def __init__(self, row_converter, key, **options):
     self.key = key
     self.valid_states = row_converter.object_class.VALID_STATES
+    self.default_status = self._default_status(row_converter.object_class)
     self.state_mappings = {str(s).lower(): s for s in self.valid_states}
     super(StatusColumnHandler, self).__init__(row_converter, key, **options)
+
+  def _default_status(self, klass):
+    if hasattr(klass, "START_STATE"):
+      return klass.START_STATE
+    return self.valid_states[0]
 
   def parse_item(self):
     value = self.raw_value.lower()
@@ -183,7 +189,7 @@ class StatusColumnHandler(ColumnHandler):
           self.add_warning(errors.WRONG_REQUIRED_VALUE,
                            value=value[:20],
                            column_name=self.display_name)
-          status = self.valid_states[0]
+          status = self.default_status
         else:
           self.add_error(errors.MISSING_VALUE_ERROR,
                          column_name=self.display_name)

--- a/src/ggrc/converters/handlers/statusable.py
+++ b/src/ggrc/converters/handlers/statusable.py
@@ -21,13 +21,13 @@ class StatusableColumnHandler(handlers.StatusColumnHandler):
       if (not obj.status and
          value not in mixins_statusable.Statusable.NOT_DONE_STATES):
         self.add_warning(
-          errors.STATUSABLE_INVALID_STATE,
-          object_type=obj.type)
+            errors.STATUSABLE_INVALID_STATE,
+            object_type=obj.type)
         value = mixins_statusable.Statusable.PROGRESS_STATE
       else:
         self.add_warning(
-          errors.STATUSABLE_INVALID_TRANSITION,
-          object_type=obj.type, current_state=obj.status, new_state=value)
+            errors.STATUSABLE_INVALID_TRANSITION,
+            object_type=obj.type, current_state=obj.status, new_state=value)
         value = mixins_statusable.Statusable.PROGRESS_STATE
 
     return value

--- a/src/ggrc/converters/handlers/statusable.py
+++ b/src/ggrc/converters/handlers/statusable.py
@@ -5,10 +5,10 @@
 
 from ggrc.converters.handlers import handlers
 from ggrc.converters import errors
-from ggrc import models
+from ggrc.models import mixins_statusable
 
 
-class RequestStatusColumnHandler(handlers.StatusColumnHandler):
+class StatusableColumnHandler(handlers.StatusColumnHandler):
   """Handler for request status."""
 
   def parse_item(self):

--- a/src/ggrc/models/assessment.py
+++ b/src/ggrc/models/assessment.py
@@ -12,12 +12,17 @@ from ggrc.models import reflection
 from ggrc.models.audit import Audit
 from ggrc.models.comment import Commentable
 from ggrc.models.mixin_autostatuschangable import AutoStatusChangable
-from ggrc.models.mixins import BusinessObject
 from ggrc.models.mixins import CustomAttributable
+from ggrc.models.mixins import Described
 from ggrc.models.mixins import FinishedDate
+from ggrc.models.mixins import Hyperlinked
+from ggrc.models.mixins import Noted
+from ggrc.models.mixins import Slugged
 from ggrc.models.mixins import TestPlanned
 from ggrc.models.mixins import Timeboxed
+from ggrc.models.mixins import Titled
 from ggrc.models.mixins import VerifiedDate
+from ggrc.models.mixins import WithContact
 from ggrc.models.mixins import deferred
 from ggrc.models.mixins_assignable import Assignable
 from ggrc.models.object_document import Documentable
@@ -35,7 +40,8 @@ class Assessment(mixins_statusable.Statusable,
                  CustomAttributable, Documentable, Commentable, Personable,
                  mixins_reminderable.Reminderable, Timeboxed,
                  Ownable, Relatable, FinishedDate, VerifiedDate,
-                 BusinessObject, db.Model):
+                 Noted, Described, Hyperlinked, WithContact,
+                 Titled, Slugged, db.Model):
   """Class representing Assessment.
 
   Assessment is an object representing an individual assessment performed on

--- a/src/ggrc/models/assessment.py
+++ b/src/ggrc/models/assessment.py
@@ -128,6 +128,7 @@ class Assessment(mixins_statusable.Statusable,
           "filter_by": "_filter_by_related_verifiers",
           "type": reflection.AttributeInfo.Type.MAPPING,
       },
+      "status": "State"
   }
 
   def validate_conclusion(self, value):

--- a/src/ggrc/models/mixins.py
+++ b/src/ggrc/models/mixins.py
@@ -355,7 +355,7 @@ class FinishedDate(object):
     )
 
   _publish_attrs = [
-      reflection.PublishOnly('finished_date')
+      reflection.PublishOnly("finished_date")
   ]
 
   _aliases = {
@@ -408,8 +408,8 @@ class VerifiedDate(object):
     return self.verified_date != None  # noqa
 
   _publish_attrs = [
-      reflection.PublishOnly('verified'),
-      reflection.PublishOnly('verified_date'),
+      reflection.PublishOnly("verified"),
+      reflection.PublishOnly("verified_date"),
   ]
 
   _aliases = {

--- a/src/ggrc/models/mixins_statusable.py
+++ b/src/ggrc/models/mixins_statusable.py
@@ -26,7 +26,14 @@ class Statusable(object):
 
   NOT_DONE_STATES = {START_STATE, PROGRESS_STATE}
   DONE_STATES = {DONE_STATE} | END_STATES
-  VALID_STATES = tuple(NOT_DONE_STATES | DONE_STATES)
+
+  VALID_STATES = (
+      START_STATE,
+      PROGRESS_STATE,
+      DONE_STATE,
+      VERIFIED_STATE,
+      FINAL_STATE
+  )
 
   status = db.Column(
       db.Enum(*VALID_STATES),
@@ -76,10 +83,8 @@ class Statusable(object):
     if self.status == value:
       return value
 
-    verifiers = any(True for _, roles in self.assignees
-                    if "Verifier" in roles)
-
-    valid_transitions = self.STATE_MACHINE[verifiers]
+    has_verifiers = any(self.get_assignees("Verifier"))
+    valid_transitions = self.STATE_MACHINE[has_verifiers]
 
     if (self.status, value) in valid_transitions:
       return value

--- a/src/ggrc/models/mixins_statusable.py
+++ b/src/ggrc/models/mixins_statusable.py
@@ -57,6 +57,7 @@ class Statusable(object):
           (None, START_STATE),
           # None to PROGRESS_STATE needed because of imports
           (None, PROGRESS_STATE),
+          (START_STATE, PROGRESS_STATE),
           (PROGRESS_STATE, DONE_STATE),
           (DONE_STATE, PROGRESS_STATE),
           (START_STATE, DONE_STATE),

--- a/src/ggrc/models/mixins_statusable.py
+++ b/src/ggrc/models/mixins_statusable.py
@@ -76,24 +76,20 @@ class Statusable(object):
   }
 
   IMPORT_STATE_MACHINE = {
-    (None, START_STATE),
-    (None, PROGRESS_STATE),
-    (START_STATE, PROGRESS_STATE),
-    (START_STATE, START_STATE),
-    (PROGRESS_STATE, PROGRESS_STATE),
+      (None, START_STATE),
+      (None, PROGRESS_STATE),
+      (START_STATE, PROGRESS_STATE),
+      (START_STATE, START_STATE),
+      (PROGRESS_STATE, PROGRESS_STATE),
   }
 
   @classmethod
   def valid_transition(cls, old, new, has_verifiers):
-    if (old, new) in cls.STATE_MACHINE[has_verifiers]:
-      return True
-    return False
+    return (old, new) in cls.STATE_MACHINE[has_verifiers]
 
   @classmethod
   def valid_import_transition(cls, old, new):
-    if (old, new) in cls.IMPORT_STATE_MACHINE:
-      return True
-    return False
+    return (old, new) in cls.IMPORT_STATE_MACHINE
 
   @validates("status")
   def validate_status(self, key, value):

--- a/src/ggrc/models/mixins_statusable.py
+++ b/src/ggrc/models/mixins_statusable.py
@@ -27,13 +27,13 @@ class Statusable(object):
   NOT_DONE_STATES = {START_STATE, PROGRESS_STATE}
   DONE_STATES = {DONE_STATE} | END_STATES
 
-  VALID_STATES = (
+  VALID_STATES = {
       START_STATE,
       PROGRESS_STATE,
       DONE_STATE,
       VERIFIED_STATE,
       FINAL_STATE
-  )
+  }
 
   status = db.Column(
       db.Enum(*VALID_STATES),

--- a/src/ggrc/models/mixins_statusable.py
+++ b/src/ggrc/models/mixins_statusable.py
@@ -3,6 +3,11 @@
 
 """A mixin for objects with statuses"""
 
+from sqlalchemy.orm import validates
+
+from werkzeug.exceptions import BadRequest
+
+
 from ggrc import db
 
 
@@ -27,3 +32,59 @@ class Statusable(object):
       db.Enum(*VALID_STATES),
       nullable=False,
       default=START_STATE)
+
+  # State machine for all allowed transitions depending on whether verifiers
+  # are defined or not.
+  STATE_MACHINE = {
+      False: {
+          (None, START_STATE),
+          (START_STATE, PROGRESS_STATE),
+          (PROGRESS_STATE, FINAL_STATE),
+          (FINAL_STATE, PROGRESS_STATE),
+          (START_STATE, FINAL_STATE),
+          (FINAL_STATE, START_STATE),
+      },
+      True: {
+          (None, START_STATE),
+          (START_STATE, PROGRESS_STATE),
+          (PROGRESS_STATE, DONE_STATE),
+          (DONE_STATE, PROGRESS_STATE),
+          (START_STATE, DONE_STATE),
+          (DONE_STATE, START_STATE),
+          (DONE_STATE, VERIFIED_STATE),
+          # All objects are in FINAL_STATE and not in VERIFIED_STATE
+          (FINAL_STATE, DONE_STATE),
+          (FINAL_STATE, PROGRESS_STATE),
+          # The following is a hack for automatic conversion from
+          # VERIFIED_STATE to FINAL_STATE
+          (DONE_STATE, FINAL_STATE),
+          # THe following is a hack for transition from FINAL_STATE to
+          # PROGRESS_STATE
+          (FINAL_STATE, PROGRESS_STATE)
+      }
+  }
+
+  @validates("status")
+  def validate_status(self, key, value):
+    """Validate status transitions"""
+
+    # Sqlalchemy only uses one validator per status (not neccessarily the
+    # first) and ignores others. This enables cooperation between validators.
+    if hasattr(super(Statusable, self), "validate_status"):
+      value = super(Statusable, self).validate_status(key, value)
+
+    if self.status == value:
+      return value
+
+    verifiers = any(True for _, roles in self.assignees
+                    if "Verifier" in roles)
+
+    valid_transitions = self.STATE_MACHINE[verifiers]
+
+    if (self.status, value) in valid_transitions:
+      return value
+
+    message = ("Transition from \"{}\" to \"{}\" is not allowed.".format(
+        self.status, value))
+
+    raise BadRequest(message)

--- a/test/integration/ggrc/converters/test_csvs/request_full_no_warnings.csv
+++ b/test/integration/ggrc/converters/test_csvs/request_full_no_warnings.csv
@@ -15,7 +15,7 @@ proj-3",mkt-1
 ,Request 7,Audit,Request title 3,,,not started,user1@a.com,user2@a.com,,Interview,7/7/2015,5/17/2016,,,,,
 ,Request 8,Audit,Request title 4,,,not started,user1@a.com,user2@a.com,user@example.com,Interview,7/8/2015,5/18/2016,,,,,
 ,Request 9,Audit,Request title 5,,,not started,user1@a.com,user2@a.com,,Interview,7/9/2015,5/19/2016,,,,,
-,Request 10,Audit,Request title 6,,,Ready for Review,user1@a.com,user2@a.com,user@example.com,Interview,7/10/2015,5/20/2016,,,,,
+,Request 10,Audit,Request title 6,,,In Progress,user1@a.com,user2@a.com,user@example.com,Interview,7/10/2015,5/20/2016,,,,,
 ,Request 11,Audit,Request title 7,,,In PROGRESS,user1@a.com,user2@a.com,user@example.com,Interview,7/11/2015,5/21/2016,,,,,
 ,Request 12,Audit,Request title 8,,,Not Started,user1@a.com,user2@a.com,user@example.com,Interview,7/12/2015,5/22/2016,,,,,
 ,,,,,,,,,,,,,,,,,

--- a/test/integration/ggrc/converters/test_import_requests.py
+++ b/test/integration/ggrc/converters/test_import_requests.py
@@ -103,8 +103,11 @@ class TestRequestImport(converters.TestCase):
     These tests are an intermediate part for zucchini release and will be
     updated in the next release.
 
-    CSV sheet:
-      https://docs.google.com/spreadsheets/d/1Jg8jum2eQfvR3kZNVYbVKizWIGZXvfqv3yQpo2rIiD8/edit#gid=299569476
+    CSV sheets:
+      * request_full_no_warnings.csv:
+          https://docs.google.com/spreadsheets/d/1Jg8jum2eQfvR3kZNVYbVKizWIGZXvfqv3yQpo2rIiD8/edit#gid=704933240
+      * request_update_intermediate.csv:
+          https://docs.google.com/spreadsheets/d/1Jg8jum2eQfvR3kZNVYbVKizWIGZXvfqv3yQpo2rIiD8/edit#gid=299569476
     """
     self.import_file("request_full_no_warnings.csv")
     response = self.import_file("request_update_intermediate.csv")
@@ -120,10 +123,13 @@ class TestRequestImport(converters.TestCase):
         "block_warnings": set(),
         "row_errors": set(),
         "row_warnings": set([
-            errors.REQUEST_INVALID_STATE.format(line=5),
-            errors.REQUEST_INVALID_STATE.format(line=6),
-            errors.REQUEST_INVALID_STATE.format(line=11),
-            errors.REQUEST_INVALID_STATE.format(line=12),
+            errors.STATUSABLE_INVALID_TRANSITION.format(line=4, object_type="Request", current_state=models.Request.PROGRESS_STATE, new_state=models.Request.DONE_STATE),
+            errors.STATUSABLE_INVALID_TRANSITION.format(line=5, object_type="Request", current_state=models.Request.START_STATE, new_state=models.Request.FINAL_STATE),
+            errors.STATUSABLE_INVALID_TRANSITION.format(line=6, object_type="Request", current_state=models.Request.PROGRESS_STATE, new_state=models.Request.VERIFIED_STATE),
+            errors.STATUSABLE_INVALID_TRANSITION.format(line=7, object_type="Request", current_state=models.Request.START_STATE, new_state=models.Request.DONE_STATE),
+            errors.STATUSABLE_INVALID_STATE.format(line=10, object_type="Request"),
+            errors.STATUSABLE_INVALID_STATE.format(line=11, object_type="Request"),
+            errors.STATUSABLE_INVALID_STATE.format(line=12, object_type="Request"),
         ]),
     }
 
@@ -136,7 +142,8 @@ class TestRequestImport(converters.TestCase):
     self.assertEqual(requests["Request 60"].status, models.Request.START_STATE)
     self.assertEqual(requests["Request 61"].status,
                      models.Request.PROGRESS_STATE)
-    self.assertEqual(requests["Request 62"].status, models.Request.DONE_STATE)
+    self.assertEqual(requests["Request 62"].status,
+                     models.Request.PROGRESS_STATE)
     self.assertEqual(requests["Request 63"].status,
                      models.Request.PROGRESS_STATE)
     self.assertEqual(requests["Request 64"].status,

--- a/test/integration/ggrc/converters/test_import_requests.py
+++ b/test/integration/ggrc/converters/test_import_requests.py
@@ -123,13 +123,32 @@ class TestRequestImport(converters.TestCase):
         "block_warnings": set(),
         "row_errors": set(),
         "row_warnings": set([
-            errors.STATUSABLE_INVALID_TRANSITION.format(line=4, object_type="Request", current_state=models.Request.PROGRESS_STATE, new_state=models.Request.DONE_STATE),
-            errors.STATUSABLE_INVALID_TRANSITION.format(line=5, object_type="Request", current_state=models.Request.START_STATE, new_state=models.Request.FINAL_STATE),
-            errors.STATUSABLE_INVALID_TRANSITION.format(line=6, object_type="Request", current_state=models.Request.PROGRESS_STATE, new_state=models.Request.VERIFIED_STATE),
-            errors.STATUSABLE_INVALID_TRANSITION.format(line=7, object_type="Request", current_state=models.Request.START_STATE, new_state=models.Request.DONE_STATE),
-            errors.STATUSABLE_INVALID_STATE.format(line=10, object_type="Request"),
-            errors.STATUSABLE_INVALID_STATE.format(line=11, object_type="Request"),
-            errors.STATUSABLE_INVALID_STATE.format(line=12, object_type="Request"),
+            errors.STATUSABLE_INVALID_TRANSITION.format(
+                line=4,
+                object_type="Request",
+                current_state=models.Request.PROGRESS_STATE,
+                new_state=models.Request.DONE_STATE),
+            errors.STATUSABLE_INVALID_TRANSITION.format(
+                line=5,
+                object_type="Request",
+                current_state=models.Request.START_STATE,
+                new_state=models.Request.FINAL_STATE),
+            errors.STATUSABLE_INVALID_TRANSITION.format(
+                line=6,
+                object_type="Request",
+                current_state=models.Request.PROGRESS_STATE,
+                new_state=models.Request.VERIFIED_STATE),
+            errors.STATUSABLE_INVALID_TRANSITION.format(
+                line=7,
+                object_type="Request",
+                current_state=models.Request.START_STATE,
+                new_state=models.Request.DONE_STATE),
+            errors.STATUSABLE_INVALID_STATE.format(
+                line=10, object_type="Request"),
+            errors.STATUSABLE_INVALID_STATE.format(
+                line=11, object_type="Request"),
+            errors.STATUSABLE_INVALID_STATE.format(
+                line=12, object_type="Request"),
         ]),
     }
 

--- a/test/integration/ggrc/models/test_mixin_autostatuschangable.py
+++ b/test/integration/ggrc/models/test_mixin_autostatuschangable.py
@@ -35,6 +35,38 @@ class TestMixinAutoStatusChangable(integration.ggrc.TestCase):
     assessment = self.refresh_object(assessment)
     self.assertEqual(assessment.status, models.Assessment.PROGRESS_STATE)
 
+  def test_sending_assessment_no_verifiers_wrong_state(self):
+    """Test that no verifier scenario doesn't save correct value"""
+    people = [
+        ("creator@example.com", "Creator"),
+        ("assessor_1@example.com", "Assessor"),
+        ("assessor_2@example.com", "Assessor"),
+    ]
+
+    assessment = self.create_assessment(people)
+
+    self.assertEqual(assessment.status,
+                     models.Assessment.START_STATE)
+
+    assessment = self.refresh_object(assessment)
+
+    self.api_helper.modify_object(assessment, {
+        "title": assessment.title + " modified, change #1"
+    })
+
+    assessment = self.refresh_object(assessment)
+
+    self.assertEqual(assessment.status,
+                     models.Assessment.PROGRESS_STATE)
+
+    response = self.api_helper.modify_object(assessment, {
+        "status": assessment.DONE_STATE,
+    })
+    self.assertEqual(response.status_code, 400, "Status shouldn't be adjusted")
+
+    assessment = self.refresh_object(assessment)
+    self.assertEqual(assessment.status, models.Assessment.PROGRESS_STATE)
+
   def test_chaning_assignees_when_open_should_not_change_status(self):
     """Adding/chaning/removing assignees shouldn't change status when open"""
     people = [

--- a/test/integration/ggrc_basic_permissions/test_creator_program.py
+++ b/test/integration/ggrc_basic_permissions/test_creator_program.py
@@ -323,7 +323,7 @@ class TestCreatorProgram(TestCase):
     response = self.api.post(all_models.Request, {
         "request": {
             "title": "Request for audit",
-            "status": "In Progress",
+            "status": "Not Started",
             "context": {
                 "id": audit_context_id,
                 "type": "Context"

--- a/test/unit/ggrc/models/test_assessement.py
+++ b/test/unit/ggrc/models/test_assessement.py
@@ -26,7 +26,6 @@ class TestAssessmentMixins(test_mixins_base.TestMixinsBase):
     self.model = Assessment
     self.included_mixins = [
         mixins_assignable.Assignable,
-        mixins.BusinessObject,
         mixins.CustomAttributable,
         db.Model,
         object_document.Documentable,
@@ -36,6 +35,14 @@ class TestAssessmentMixins(test_mixins_base.TestMixinsBase):
         object_owner.Ownable,
         object_person.Personable,
         relationship.Relatable,
+        mixins.Described,
+        mixins.FinishedDate,
+        mixins.Hyperlinked,
+        mixins.Noted,
+        mixins.Slugged,
+        mixins.Titled,
+        mixins.VerifiedDate,
+        mixins.WithContact,
     ]
 
     self.attributes_introduced = [


### PR DESCRIPTION
This PR is waiting for #3915 to be reviewed and merged.

This adds a check to ensure that all assignable objects pass through review stage. Previously you could end up with request in Completed (and not verified) state without going through review if user did some assignee changes and hasn't refreshed frontend.

This doesn't fix the frontend issue but it does ensure that customer data isn't in wrong state.