### PR TITLE
QUICK-FIX Turn on ESLint warnings for quote styles

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -59,6 +59,9 @@
       "ignoreComments": true,
       "ignoreUrls": true
     }],
+    "quotes": [
+        1, "single", {"avoidEscape": true}
+    ],
     "no-implicit-coercion": [2, {"boolean": false}],
     "no-inline-comments": 0,
     "no-negated-condition": 0,


### PR DESCRIPTION
**Note:** this will increase the reported number of ESLint issues.

**Note 2:** I added an exception to allow using double quotes to avoid quotes escaping, so that strings like _"Arnold said: I'll be back"_ are permitted. If this is not desirable, I will change the config.
