### PR TITLE
QUICK-FIX Add Creator assignee type to comments

### DIFF
--- a/src/ggrc/assets/javascripts/components/add_comment/add_comment.js
+++ b/src/ggrc/assets/javascripts/components/add_comment/add_comment.js
@@ -32,6 +32,7 @@
       get_assignee_type: can.compute(function () {
         // TODO: We prioritize order V > A > R
         var types = {
+          related_creators: 'creator',
           related_verifiers: 'verifier',
           related_assignees: 'assignee',
           related_requesters: 'requester'


### PR DESCRIPTION
When adding a comment on an Assessment where the user is the creator, the comment would have a type label 'none'.