### PR TITLE
CORE-3639 Make validate recipients to ignore empty values

### DIFF
--- a/src/ggrc/models/comment.py
+++ b/src/ggrc/models/comment.py
@@ -24,6 +24,8 @@ class Commentable(object):
   send_by_default should be used for setting the "send notification" flag in
     the comment modal.
   """
+  # pylint: disable=too-few-public-methods
+
   VALID_RECIPIENTS = frozenset([
       "Assessor",
       "Assignee",
@@ -42,8 +44,13 @@ class Commentable(object):
                         list of comma separated `VALID_RECIPIENTS`
     """
     # pylint: disable=unused-argument
-    if value and set(value.split(',')).issubset(self.VALID_RECIPIENTS):
-      return value
+    if value:
+      value = set(name for name in value.split(",") if name)
+
+    if value and value.issubset(self.VALID_RECIPIENTS):
+      # The validator is a bit more smart and also makes some filtering of the
+      # given data - this is intended.
+      return ",".join(value)
     elif not value:
       return ""
     else:


### PR DESCRIPTION
The validator was too eager and complained when it got empty role names. Note that the validator will still complain about strings containing whitespace only, because that might indicate a different problem (e.g. incorrect role values set), but if that is not desired, I can change its behavior.

Of course the question remains why some Assessments ended up having their `recipients` DB field set to `",,"` in the first place, but this PR does not attempt to resolve that.

