### PR TITLE
QUICK-FIX Rename deprecated ESLint config file

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -35,7 +35,7 @@
     "google": false,
     "st": false,
     "wysihtml5ParserRules": false,
-    "wysihtml5": false,
+    "wysihtml5": false
   },
 
   "rules": {
@@ -59,7 +59,7 @@
       "ignoreComments": true,
       "ignoreUrls": true
     }],
-    "quotes": [2, "single", {
+    "quotes": [1, "single", {
       "avoidEscape": true
     }],
     "no-implicit-coercion": [2, {"boolean": false}],
@@ -81,8 +81,8 @@
     // party libraries' APIs might expect object arguments with properties
     // following a different naming conventions, and trying to work around
     // that just to make the linter happy is simply not worth it.
-    "camelcase":  [1, {properties: "never"}],
+    "camelcase":  [1, {"properties": "never"}],
     "new-cap": 0,
-    "no-new": 0,
+    "no-new": 0
   }
 }


### PR DESCRIPTION
I noticed that having the ESLint config in the `.eslintrc` file (without the config format suffix) is [deprecated](http://eslint.org/docs/user-guide/configuring#configuration-file-formats), thus I renamed it.

I also cleaned up the JSON a bit to make it valid, and reverted the change made in #3931 because that turned out to not be the cause of the observed issue.