### PR TITLE
CORE-3593 Fix access to UserRole objects for Editors

### DIFF
--- a/src/ggrc_basic_permissions/roles/Editor.py
+++ b/src/ggrc_basic_permissions/roles/Editor.py
@@ -54,6 +54,7 @@ permissions = {
         "Role",
         "Request",
         "Context",
+        "UserRole",
         {
             "type": "BackgroundTask",
             "terms": {


### PR DESCRIPTION
This allows Global Editors to access UserRole objects. This
allows access to e.g. Auditors on Audit objects.