### PR TITLE
CORE-3276 Fix __table_args__ definitions

### DIFF
--- a/src/ggrc/models/custom_attribute_definition.py
+++ b/src/ggrc/models/custom_attribute_definition.py
@@ -26,7 +26,7 @@ class CustomAttributeDefinition(mixins.Base, mixins.Titled, db.Model):
   attribute_values = db.relationship('CustomAttributeValue',
                                      backref='custom_attribute')
 
-  __table_args__ = (
+  _extra_table_args = (
       UniqueConstraint('definition_type', 'definition_id', 'title',
                        name='uq_custom_attribute'),
       db.Index('ix_custom_attributes_title', 'title'))

--- a/src/ggrc_workflows/models/task_group_task.py
+++ b/src/ggrc_workflows/models/task_group_task.py
@@ -24,7 +24,7 @@ class TaskGroupTask(WithContact, Slugged, Titled, Described, RelativeTimeboxed,
   """Workflow TaskGroupTask model."""
 
   __tablename__ = 'task_group_tasks'
-  __table_args__ = (
+  _extra_table_args = (
       schema.CheckConstraint('start_date <= end_date'),
   )
   _title_uniqueness = False

--- a/test/unit/ggrc/models/test_table_args.py
+++ b/test/unit/ggrc/models/test_table_args.py
@@ -1,0 +1,38 @@
+# Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+# Created By: andraz@reciprocitylabs.com
+# Maintained By: andraz@reciprocitylabs.com
+
+"""Tests for overriden __table_args__."""
+
+import unittest
+
+from ggrc.models.all_models import all_models
+from ggrc.models.mixins import Identifiable
+
+
+class TestTableArgs(unittest.TestCase):
+
+  def test_extra_args_included(self):
+    """Table args for all models should contain extra args.
+
+    This can be violated if you inherit Identifiable but then also define
+    constraints via __table_args__ instead of _extra_table_args.
+    """
+    for model in all_models:
+      self.assertTrue(issubclass(model, Identifiable))
+
+      extras = getattr(model, "_extra_table_args", None)
+      if not extras:
+        continue
+      if callable(extras):
+        extras = extras(model)
+
+      # Doing only constraint name checking because equality doen't work here
+      extra_names = {e.name for e in extras}
+      args_names = {a.name for a in model.__table_args__}
+      self.assertTrue(
+          extra_names.issubset(args_names),
+          "_extra_table_args for {} are not present in __table_args__"
+          .format(model.__name__)
+      )


### PR DESCRIPTION
Every database model that is `Identifiable` should use `_extra_table_args`
instead of `__table_args__` so it can be extended through mixins.