### PR TITLE
CORE-3262 Fully set up Risk and Threat objects

### DIFF
--- a/src/ggrc_risks/assets/javascripts/apps/risks.js
+++ b/src/ggrc_risks/assets/javascripts/apps/risks.js
@@ -188,13 +188,12 @@
       };
     });
 
-    // Add risk and Threat to base widget types
-    can.each(moduleObjectNames, function (obj) {
-      GGRC.tree_view.base_widgets_by_type[obj] = extendedModuleTypes;
-    });
-
-    // Set up tree_view.basic_model_list and tree_view.sub_tree_for
+    // Add risk and Threat to base widget types and set up
+    // tree_view.basic_model_list and tree_view.sub_tree_for for risk module
+    // objects
     can.each(moduleObjectNames, function (name) {
+      baseWidgetsByType[name] = extendedModuleTypes;
+
       var widgetList = baseWidgetsByType[name].sort();
       var child_model_list = [];
 

--- a/src/ggrc_risks/assets/javascripts/apps/risks.js
+++ b/src/ggrc_risks/assets/javascripts/apps/risks.js
@@ -153,6 +153,7 @@
     var baseWidgetsByType = GGRC.tree_view.base_widgets_by_type;
     var moduleObjectNames = ['Risk', 'Threat'];
     var extendedModuleTypes = _risk_object_types.concat(moduleObjectNames);
+    var subTrees = GGRC.tree_view.sub_tree_for;
 
     if (/^\/objectBrowser\/?$/.test(window.location.pathname)) {
       related_or_owned = 'all_';
@@ -211,10 +212,12 @@
         }
       });
 
-      GGRC.tree_view.sub_tree_for[name] = {
-        model_list: child_model_list,
-        display_list: CMS.Models[name].tree_view_options.child_tree_display_list || widgetList
-      };
+      if (!_.isEmpty(subTrees)) {
+        subTrees[name] = {
+          model_list: child_model_list,
+          display_list: CMS.Models[name].tree_view_options.child_tree_display_list || widgetList
+        };
+      }
     });
 
     threat_descriptor = {


### PR DESCRIPTION
Risk and Threat objects haven’t been fully initialised, with this we 
1) Add them to `GGRC.tree_view.base_widgets_by_type`
2) Create Risk and Threat entries with mappable values in 
`GGRC.tree_view.base_widgets_by_type`
3) Set up `GGRC.tree_view.basic_model_list`
4) Set up `GGRC.tree_view.sub_tree_for`

This allows GGRC.Utils.allowed_to_map to recognise the existence of 
widgets (`hasWidget`’s _.contains check).

Setting up just base_widgets_by_type is not enough because `ggrc_workflows` extension [fails here](https://github.com/google/ggrc-core/blob/develop/src/ggrc_workflows/assets/javascripts/apps/workflows.js#L349).