### PR TITLE
CORE-3205 Update eager_query for Workflows

### DIFF
--- a/src/ggrc_workflows/models/workflow.py
+++ b/src/ggrc_workflows/models/workflow.py
@@ -234,7 +234,8 @@ class Workflow(mixins.CustomAttributable, HasOwnContext, mixins.Timeboxed,
   def eager_query(cls):
     return super(Workflow, cls).eager_query().options(
         orm.subqueryload('cycles').undefer_group('Cycle_complete')
-           .subqueryload("cycle_task_group_object_tasks"),
+           .subqueryload("cycle_task_group_object_tasks")
+           .undefer_group("CycleTaskGroupObjectTask_complete"),
         orm.subqueryload('task_groups'),
         orm.subqueryload('workflow_people'),
     )


### PR DESCRIPTION
Attributes of Cycle Tasks are also needed when doing a collection `GET` to `/api/workflows` so they need to be undeferred (query counting confirms this).