### PR TITLE
CORE-3309 Trigger discarding changes confirmation when closing a modal

### DIFF
--- a/src/ggrc/assets/javascripts/bootstrap/modal-ajax.js
+++ b/src/ggrc/assets/javascripts/bootstrap/modal-ajax.js
@@ -5,18 +5,12 @@
     Maintained By: brad@reciprocitylabs.com
 */
 
-//= require bootstrap-modal
-//= require can.jquery-all
-//= require jquery-migrate
-//= require jquery-ui
-
-!function($) {
-
-  "use strict"; // jshint ;_;
+(function ($) {
+  'use strict';
 
   function preload_content() {
     var template =
-      [ '<div class="modal-header">'
+      ['<div class="modal-header">'
       , '  <a class="pull-right modal-dismiss" href="#" data-dismiss="modal">'
       , '    <i class="fa fa-times black"></i>'
       , '  </a>'
@@ -33,7 +27,7 @@
             .css({
               width: '100px', height: '100px',
               left: '50%', top: '50%',
-              zIndex : calculate_spinner_z_index
+              zIndex: calculate_spinner_z_index
             })
         ).end();
   }
@@ -42,7 +36,7 @@
     if (xhr.status == 403) {
       // For now, only inject the response HTML in the case
       // of an authorization error
-      $(this).html(responseText)
+      $(this).html(responseText);
     }
     $(this).trigger('loaded');
   }
@@ -52,16 +46,16 @@
   }
 
   var handlers = {
-    'modal': function($target, $trigger, option) {
-      $target.modal(option).draggable({ handle: '.modal-header' });
+    'modal': function ($target, $trigger, option) {
+      $target.modal(option).draggable({handle: '.modal-header'});
     },
 
-    'listform': function($target, $trigger, option) {
+    'listform': function ($target, $trigger, option) {
       var list_target = $trigger.data('list-target');
       $target.modal_relationship_selector(option, $trigger);
 
       // Close the modal and rewrite the target list
-      $target.on('ajax:json', function(e, data, xhr) {
+      $target.on('ajax:json', function (e, data, xhr) {
         if (data.errors) {
         } else if (list_target == 'refresh') {
           refresh_page();
@@ -72,36 +66,36 @@
       });
     },
 
-    'listnewform': function($target, $trigger, option) {
+    'listnewform': function ($target, $trigger, option) {
       $target.modal_form(option, $trigger);
       var list_target = $trigger.data('list-target')
         , selector_target = $trigger.data('selector-target')
         ;
 
       // Close the modal and append to the target list
-      $target.on('ajax:json', function(e, data, xhr) {
+      $target.on('ajax:json', function (e, data, xhr) {
         if (data.errors) {
         } else {
           if (list_target) {
-            $(list_target).tmpl_additem(data)
+            $(list_target).tmpl_additem(data);
           }
           if (selector_target) {
             $(selector_target).trigger('list-add-item', data);
           }
-          //$(tablist_target).trigger('list-add-item', data);
+          // $(tablist_target).trigger('list-add-item', data);
           $target.modal_form('hide');
         }
       });
     },
 
-    'listeditform': function($target, $trigger, option) {
+    'listeditform': function ($target, $trigger, option) {
       $target.modal_form(option, $trigger);
       var list_target = $trigger.data('list-target')
         , selector_target = $trigger.data('selector-target')
         ;
 
       // Close the modal and append to the target list
-      $target.on('ajax:json', function(e, data, xhr) {
+      $target.on('ajax:json', function (e, data, xhr) {
         if (data.errors) {
         } else {
           if (list_target) {
@@ -116,46 +110,46 @@
       });
     },
 
-    'deleteform': function($target, $trigger, option) {
+    'deleteform': function ($target, $trigger, option) {
       var form_target = $trigger.data('form-target')
-        , model = CMS.Models[$trigger.attr("data-object-singular")]
+        , model = CMS.Models[$trigger.attr('data-object-singular')]
         , instance
-        , delete_counts = new can.Observe({loading: true, counts: ""})
+        , delete_counts = new can.Observe({loading: true, counts: ''})
         ;
 
-      if($trigger.attr('data-object-id') === "page") {
+      if ($trigger.attr('data-object-id') === 'page') {
         instance = GGRC.page_instance();
       } else {
         instance = model.findInCacheById($trigger.attr('data-object-id'));
       }
 
-      instance.get_orphaned_count().done(function(counts){
-          delete_counts.attr('loading', false);
-          delete_counts.attr('counts', counts);
-        }).fail(function(){
-          delete_counts.attr('loading', false);
+      instance.get_orphaned_count().done(function (counts) {
+        delete_counts.attr('loading', false);
+        delete_counts.attr('counts', counts);
+      }).fail(function () {
+        delete_counts.attr('loading', false);
       });
 
       $target
       .modal_form(option, $trigger)
       .ggrc_controllers_delete({
-          $trigger : $trigger
-        , skip_refresh : !$trigger.data("refresh")
-        , new_object_form : false
-        , button_view : GGRC.mustache_path + "/modals/delete_cancel_buttons.mustache"
-        , model : model
-        , instance : instance
-        , delete_counts : delete_counts
-        , modal_title : "Delete " + $trigger.attr("data-object-singular")
-        , content_view : GGRC.mustache_path + "/base_objects/confirm_delete.mustache"
+        $trigger: $trigger
+        , skip_refresh: !$trigger.data('refresh')
+        , new_object_form: false
+        , button_view: GGRC.mustache_path + '/modals/delete_cancel_buttons.mustache'
+        , model: model
+        , instance: instance
+        , delete_counts: delete_counts
+        , modal_title: 'Delete ' + $trigger.attr('data-object-singular')
+        , content_view: GGRC.mustache_path + '/base_objects/confirm_delete.mustache'
       });
 
-      $target.on('modal:success', function(e, data) {
-        var model_name = $trigger.attr("data-object-plural").toLowerCase();
-        if($trigger.attr('data-object-id') === "page" || (instance === GGRC.page_instance())) {
+      $target.on('modal:success', function (e, data) {
+        var model_name = $trigger.attr('data-object-plural').toLowerCase();
+        if ($trigger.attr('data-object-id') === 'page' || (instance === GGRC.page_instance())) {
           GGRC.navigate('/dashboard');
-        } else if (model_name  == 'people' || model_name  == 'roles') {
-          window.location.assign('/admin#' + model_name + "_list_widget");
+        } else if (model_name == 'people' || model_name == 'roles') {
+          window.location.assign('/admin#' + model_name + '_list_widget');
           GGRC.navigate();
         } else {
           $trigger.trigger('modal:success', data);
@@ -164,18 +158,18 @@
       });
     },
 
-    'unmapform': function($target, $trigger, option) {
+    'unmapform': function ($target, $trigger, option) {
       var form_target = $trigger.data('form-target')
       , object_params = $trigger.attr('data-object-params')
-      , model = CMS.Models[$trigger.attr("data-object-singular")]
+      , model = CMS.Models[$trigger.attr('data-object-singular')]
       , instance;
-      if($trigger.attr('data-object-id') === "page") {
+      if ($trigger.attr('data-object-id') === 'page') {
         instance = GGRC.page_instance();
       } else {
         instance = model.findInCacheById($trigger.attr('data-object-id'));
       }
       if (object_params) {
-        object_params = JSON.parse(object_params.replace(/\\n/g, "\n"));
+        object_params = JSON.parse(object_params.replace(/\\n/g, '\n'));
       } else {
         object_params = {};
       }
@@ -183,26 +177,26 @@
       $target
       .modal_form(option, $trigger)
       .ggrc_controllers_unmap({
-          $trigger : $trigger
-        , new_object_form : false
-        , button_view : GGRC.mustache_path + "/modals/unmap_cancel_buttons.mustache"
-        , model : model
-        , instance : instance
-        , object_params : object_params
-        , modal_title : $trigger.attr("data-modal-title") || ("Delete " + $trigger.attr("data-object-singular"))
-        , content_view : $trigger.attr('data-content-view') || (GGRC.mustache_path + "/base_objects/confirm_unmap.mustache")
+        $trigger: $trigger
+        , new_object_form: false
+        , button_view: GGRC.mustache_path + '/modals/unmap_cancel_buttons.mustache'
+        , model: model
+        , instance: instance
+        , object_params: object_params
+        , modal_title: $trigger.attr('data-modal-title') || ('Delete ' + $trigger.attr('data-object-singular'))
+        , content_view: $trigger.attr('data-content-view') || (GGRC.mustache_path + '/base_objects/confirm_unmap.mustache')
       });
 
-      $target.on('modal:success', function(e, data) {
-        $trigger.children(".result").each(function(i, result_el) {
+      $target.on('modal:success', function (e, data) {
+        $trigger.children('.result').each(function (i, result_el) {
           var $result_el = $(result_el)
             , result = $result_el.data('result')
             , mappings = result && result.get_mappings()
             , i
             ;
 
-          can.each(mappings, function(mapping) {
-            mapping.refresh().done(function() {
+          can.each(mappings, function (mapping) {
+            mapping.refresh().done(function () {
               if (mapping instanceof CMS.Models.Control) {
                 mapping.removeAttr('directive');
                 mapping.save();
@@ -216,216 +210,216 @@
       });
     },
 
-    'form': function($target, $trigger, option) {
+    'form': function ($target, $trigger, option) {
       var form_target = $trigger.data('form-target')
       , object_params = $trigger.attr('data-object-params')
-      , model = CMS.Models[$trigger.attr("data-object-singular")] || CMS.ModelHelpers[$trigger.attr("data-object-singular")]
+      , model = CMS.Models[$trigger.attr('data-object-singular')] || CMS.ModelHelpers[$trigger.attr('data-object-singular')]
       , mapping = $trigger.data('mapping')
       , instance;
 
-      if($trigger.attr('data-object-id') === "page") {
+      if ($trigger.attr('data-object-id') === 'page') {
         instance = GGRC.page_instance();
       } else {
         instance = model.findInCacheById($trigger.attr('data-object-id'));
       }
       if (object_params) {
-        object_params = JSON.parse(object_params.replace(/\\n/g, "\n"));
+        object_params = JSON.parse(object_params.replace(/\\n/g, '\n'));
       } else {
         object_params = {};
       }
 
-      var modal_title = (instance ? "Edit " : "New ") + ($trigger.attr("data-object-singular-override") || model.title_singular || $trigger.attr("data-object-singular"));
+      var modal_title = (instance ? 'Edit ' : 'New ') + ($trigger.attr('data-object-singular-override') || model.title_singular || $trigger.attr('data-object-singular'));
       // If this was initiated via quick join link
       if (object_params.section) {
-        modal_title = "Map " + modal_title + " to " + object_params.section.title;
+        modal_title = 'Map ' + modal_title + ' to ' + object_params.section.title;
       }
-      var title_override = $trigger.attr("data-modal-title-override");
+      var title_override = $trigger.attr('data-modal-title-override');
       if (title_override) {
         modal_title = title_override;
       }
 
-      var content_view = $trigger.data('template') || GGRC.mustache_path + "/" + $trigger.attr("data-object-plural") + "/modal_content.mustache";
+      var content_view = $trigger.data('template') || GGRC.mustache_path + '/' + $trigger.attr('data-object-plural') + '/modal_content.mustache';
 
       $target
       .modal_form(option, $trigger)
       .ggrc_controllers_modals({
-          new_object_form : !$trigger.attr('data-object-id')
-        , object_params : object_params
-        , button_view : GGRC.Controllers.Modals.BUTTON_VIEW_SAVE_CANCEL_DELETE
-        , model : model
-        , current_user : GGRC.current_user
-        , instance : instance
-        , modal_title : object_params.modal_title || modal_title
-        , content_view : content_view
-        , mapping : mapping
+        new_object_form: !$trigger.attr('data-object-id')
+        , object_params: object_params
+        , button_view: GGRC.Controllers.Modals.BUTTON_VIEW_SAVE_CANCEL_DELETE
+        , model: model
+        , current_user: GGRC.current_user
+        , instance: instance
+        , modal_title: object_params.modal_title || modal_title
+        , content_view: content_view
+        , mapping: mapping
         , $trigger: $trigger
       });
 
-      $target.on('modal:success', function(e, data, xhr) {
+      $target.on('modal:success', function (e, data, xhr) {
         if (form_target == 'refresh') {
           refresh_page();
         } else if (form_target == 'redirect') {
-          if (typeof xhr !== 'undefined' && "getResponseHeader" in xhr) {
+          if (typeof xhr !== 'undefined' && 'getResponseHeader' in xhr) {
             GGRC.navigate(xhr.getResponseHeader('location'));
-          } else if(data._redirect) {
+          } else if (data._redirect) {
             GGRC.navigate(data._redirect);
           } else {
             GGRC.navigate(data.selfLink.replace('/api', ''));
           }
-        } else if (form_target == 'refresh_page_instance'){
+        } else if (form_target == 'refresh_page_instance') {
           GGRC.page_instance().refresh();
         } else {
           var dirty;
           $target.modal_form('hide');
-          if($trigger.data("dirty")) {
-            dirty = $($trigger.data("dirty").split(",")).map(function(i, val) {
+          if ($trigger.data('dirty')) {
+            dirty = $($trigger.data('dirty').split(',')).map(function (i, val) {
               return '[href="' + val.trim() + '"]';
-            }).get().join(",");
+            }).get().join(',');
             $(dirty).data('tab-loaded', false);
           }
-          if(dirty) {
-            var $active = $(dirty).filter(".active [href]");
-            $active.closest(".active").removeClass("active");
+          if (dirty) {
+            var $active = $(dirty).filter('.active [href]');
+            $active.closest('.active').removeClass('active');
             $active.click();
           }
-          $trigger.trigger("routeparam", $trigger.data("route"));
+          $trigger.trigger('routeparam', $trigger.data('route'));
           $trigger.trigger('modal:success', Array.prototype.slice.call(arguments, 1));
         }
       });
     },
 
-    'helpform' : function($target, $trigger, option) {
-      $target.modal_form(option, $trigger).ggrc_controllers_help({ slug : $trigger.attr('data-help-slug') });
+    'helpform': function ($target, $trigger, option) {
+      $target.modal_form(option, $trigger).ggrc_controllers_help({slug: $trigger.attr('data-help-slug')});
     }
 
   };
 
 
-  var arrangeBackgroundModals = function(modals, referenceModal) {
+  var arrangeBackgroundModals = function (modals, referenceModal) {
     modals = $(modals).not(referenceModal);
-    if(modals.length < 1) return;
+    if (modals.length < 1) return;
 
-    var $header = referenceModal.find(".modal-header");
-    var header_height = $header.height() + parseInt($header.css("padding-top")) + parseInt($header.css("padding-bottom"));
+    var $header = referenceModal.find('.modal-header');
+    var header_height = $header.height() + parseInt($header.css('padding-top')) + parseInt($header.css('padding-bottom'));
     var _top = parseInt($(referenceModal).offset().top);
 
     modals.css({
-        "overflow" : "hidden"
-      , "height" : function() {
-          return header_height;
-        }
-      , "top" : function(i) {
+      'overflow': 'hidden'
+      , 'height': function () {
+        return header_height;
+      }
+      , 'top': function (i) {
         return _top - (modals.length - i) * (header_height);
       }
-      , "margin-top" : 0
-      , 'position' : "absolute"
-    })
-    modals.off("scroll.modalajax");
-    modals.on("scroll.modalajax", function() {
-        $(this).scrollTop(0); //fix for Chrome rendering bug when resizing block elements containing CSS sprites.
+      , 'margin-top': 0
+      , 'position': 'absolute'
     });
-  }
+    modals.off('scroll.modalajax');
+    modals.on('scroll.modalajax', function () {
+      $(this).scrollTop(0); // fix for Chrome rendering bug when resizing block elements containing CSS sprites.
+    });
+  };
 
-  var arrangeTopModal = function(modals, modal) {
-    if(!modal || !modal.length)
+  var arrangeTopModal = function (modals, modal) {
+    if (!modal || !modal.length)
       return;
 
-    var $header = modal.find(".modal-header:first");
-    var header_height = $header.height() + parseInt($header.css("padding-top")) + parseInt($header.css("padding-bottom"));
+    var $header = modal.find('.modal-header:first');
+    var header_height = $header.height() + parseInt($header.css('padding-top')) + parseInt($header.css('padding-bottom'));
 
     var offsetParent = modal.offsetParent();
     var _scrollY = 0;
     var _top = 0;
     var _left = modal.position().left;
-    if(!offsetParent.length || offsetParent.is("html, body")) {
+    if (!offsetParent.length || offsetParent.is('html, body')) {
       offsetParent = $(window);
       _scrollY = window.scrollY;
       _top = _scrollY
         + (offsetParent.height()
           - modal.height()) / 5
-        + header_height / 5
+        + header_height / 5;
 
-        window.scrollY + ($(window).height() - modal.height()) / 2 + (modals.length - 1) * parseInt(modal.find(".modal-header").height())
+      window.scrollY + ($(window).height() - modal.height()) / 2 + (modals.length - 1) * parseInt(modal.find('.modal-header').height());
     } else {
-      _top = offsetParent.closest(".modal").offset().top - offsetParent.offset().top + header_height;
-      _left = offsetParent.closest(".modal").offset().left + offsetParent.closest(".modal").width() / 2 - offsetParent.offset().left;
+      _top = offsetParent.closest('.modal').offset().top - offsetParent.offset().top + header_height;
+      _left = offsetParent.closest('.modal').offset().left + offsetParent.closest('.modal').width() / 2 - offsetParent.offset().left;
     }
     if (_top < 0) {
       _top = 0;
     }
     modal
-    .css("top", _top + "px")
-    .css({"position" : "absolute", "margin-top" : 0, "left" : _left});
-  }
+    .css('top', _top + 'px')
+    .css({'position': 'absolute', 'margin-top': 0, 'left': _left});
+  };
 
   var _modal_show = $.fn.modal.Constructor.prototype.show;
-  $.fn.modal.Constructor.prototype.show = function() {
+  $.fn.modal.Constructor.prototype.show = function () {
     var that = this;
     var $el = this.$element;
     var shownevents, keyevents;
-    if(!(shownevents = $._data($el[0], "events").shown)
-        || $(shownevents).filter(function() {
-            return $.inArray("arrange", this.namespace.split(".")) > -1;
+    if (!(shownevents = $._data($el[0], 'events').shown)
+        || $(shownevents).filter(function () {
+          return $.inArray('arrange', this.namespace.split('.')) > -1;
         }).length < 1) {
-          $el.on("shown.arrange, loaded.arrange", function(ev) {
-            if(ev.target === ev.currentTarget)
-                reconfigureModals.call(that);
-          });
+      $el.on('shown.arrange, loaded.arrange', function (ev) {
+        if (ev.target === ev.currentTarget)
+          reconfigureModals.call(that);
+      });
     }
 
-    if($el.is("body > * *")) {
-      this.$cloneEl = $("<div>").appendTo($el.parent());
-      can.each($el[0].attributes, function(attr) {
+    if ($el.is('body > * *')) {
+      this.$cloneEl = $('<div>').appendTo($el.parent());
+      can.each($el[0].attributes, function (attr) {
         that.$cloneEl.attr(attr.name, attr.value);
       });
-      $el.find("*").uniqueId();
+      $el.find('*').uniqueId();
       this.$cloneEl.html($el.html());
       $el.detach().appendTo(document.body);
-      this.$cloneEl.removeAttr("id").find("*").attr("data-original-id", function() {
+      this.$cloneEl.removeAttr('id').find('*').attr('data-original-id', function () {
         return this.id;
-      }).removeAttr("id");
+      }).removeAttr('id');
 
-      $el.on(["click", "mouseup", "keypress", "keydown", "keyup", "show", "shown", "hide", "hidden"].join(".clone ") + ".clone", function(e) {
+      $el.on(['click', 'mouseup', 'keypress', 'keydown', 'keyup', 'show', 'shown', 'hide', 'hidden'].join('.clone ') + '.clone', function (e) {
         that.$cloneEl
         ? that.$cloneEl.find("[data-original-id='" + e.target.id + "']").trigger(new $.Event(e))
-        : $el.off(".clone");
+        : $el.off('.clone');
       });
     }
 
 
     // prevent form submissions when descendant elements are also modals.
-    if(!(keyevents = $._data($el[0], "events").keypress)
-        || $(keyevents).filter(function() {
-            return $.inArray("preventdoublesubmit", this.namespace.split(".")) > -1;
-          }).length < 1) {
-      $el.on('keypress.preventdoublesubmit', function(ev) {
-        if(ev.which === 13 && !$(document.activeElement).hasClass('wysihtml5')) {
+    if (!(keyevents = $._data($el[0], 'events').keypress)
+        || $(keyevents).filter(function () {
+          return $.inArray('preventdoublesubmit', this.namespace.split('.')) > -1;
+        }).length < 1) {
+      $el.on('keypress.preventdoublesubmit', function (ev) {
+        if (ev.which === 13 && !$(document.activeElement).hasClass('wysihtml5')) {
           ev.preventDefault();
-          if(ev.originalEvent) {
+          if (ev.originalEvent) {
             ev.originalEvent.preventDefault();
           }
           return false;
         }
       });
     }
-    if(!(keyevents = $._data($el[0], "events").keyup)
-        || $(keyevents).filter(function() {
-            return $.inArray("preventdoubleescape", this.namespace.split(".")) > -1;
-          }).length < 1) {
-      $el.on('keyup.preventdoubleescape', function(ev) {
-       if(ev.which === 27 && $(ev.target).closest(".modal").length) {
-          $(ev.target).closest(".modal").attr("tabindex", -1).focus();
+    if (!(keyevents = $._data($el[0], 'events').keyup)
+        || $(keyevents).filter(function () {
+          return $.inArray('preventdoubleescape', this.namespace.split('.')) > -1;
+        }).length < 1) {
+      $el.on('keyup.preventdoubleescape', function (ev) {
+        if (ev.which === 27 && $(ev.target).closest('.modal').length) {
+          $(ev.target).closest('.modal').attr('tabindex', -1).focus();
           ev.stopPropagation();
           ev.originalEvent && ev.originalEvent.stopPropagation();
           that.hide();
         }
       });
-      $el.attr("tabindex") || $el.attr("tabindex", -1);
-      setTimeout(function() { $el.focus(); }, 1);
+      $el.attr('tabindex') || $el.attr('tabindex', -1);
+      setTimeout(function () { $el.focus(); }, 1);
     }
 
     _modal_show.apply(this, arguments);
-    //reconfigureModals.call(this);   //handled by modal shown event firing.
+    // reconfigureModals.call(this);   //handled by modal shown event firing.
   };
 
   var reconfigureModals = function () {
@@ -455,97 +449,97 @@
   };
 
   var _modal_hide = $.fn.modal.Constructor.prototype.hide;
-  $.fn.modal.Constructor.prototype.hide = function(ev) {
-    if(ev && (ev.modalHidden))
-        return;  //We already hid one
+  $.fn.modal.Constructor.prototype.hide = function (ev) {
+    if (ev && (ev.modalHidden))
+      return;  // We already hid one
 
-    if(this.$cloneEl) {
+    if (this.$cloneEl) {
       this.$element.detach().appendTo(this.$cloneEl.parent());
       this.$cloneEl.remove();
       this.$cloneEl = null;
-      this.$element.off(".clone")
+      this.$element.off('.clone');
     }
 
     _modal_hide.apply(this, arguments);
 
     var animated =
-        $(".modal").filter(":animated");
-    if(animated.length) {
-        animated.stop(true, true);
+        $('.modal').filter(':animated');
+    if (animated.length) {
+      animated.stop(true, true);
     }
 
-    var modals = $(".modal:visible");
+    var modals = $('.modal:visible');
     var lastModal = modals.last();
-    lastModal.css({"height" : "", "overflow" : "", top : "", "margin-top" : ""});
+    lastModal.css({'height': '', 'overflow': '', top: '', 'margin-top': ''});
     arrangeTopModal(modals, lastModal);
     arrangeBackgroundModals(modals, lastModal);
-    if(ev) ev.modal_hidden = true; //mark that we've hidden one
+    if (ev) ev.modal_hidden = true; // mark that we've hidden one
   };
 
-  GGRC.register_modal_hook = function(toggle, launch_fn) {
-    $(function() {
+  GGRC.register_modal_hook = function (toggle, launch_fn) {
+    $(function () {
       $('body').on(
         'click.modal-ajax.data-api keydown.modal-ajax.data-api',
-        toggle ? "[data-toggle=modal-ajax-" + toggle + "]" : "[data-toggle=modal-ajax]",
-        function(e) {
+        toggle ? '[data-toggle=modal-ajax-' + toggle + ']' : '[data-toggle=modal-ajax]',
+        function (e) {
 
-        var $this = $(this)
+          var $this = $(this)
           , toggle_type = $(this).data('toggle')
           , modal_id, target, $target, option, href, new_target, modal_type;
 
 
-        if ($this.hasClass("disabled")) {
-          return;
-        }
-        if (e.type === "keydown" && e.which !== 13) {
-          return;  //activate for keydown on Enter/Return only.
-        }
-
-        href = $this.attr('data-href') || $this.attr('href');
-        modal_id = 'ajax-modal-' + href.replace(/[\/\?=\&#%]/g, '-').replace(/^-/, '');
-        target = $this.attr('data-target') || $('#' + modal_id);
-
-        $target = $(target);
-        new_target = $target.length === 0;
-
-        if (new_target) {
-          $target = $('<div id="' + modal_id + '" class="modal hide"></div>');
-          $target.addClass($this.attr('data-modal-class'));
-          $this.attr('data-target', '#' + modal_id);
-        }
-
-        $target.on('hidden', function(ev) {
-          if(ev.target === ev.currentTarget)
-              $target.remove();
-        });
-
-        if (new_target || $this.data('modal-reset') === 'reset') {
-          $target.html(preload_content());
-          if($this.prop("protocol") === window.location.protocol) {
-            $target.load(href, emit_loaded);
+          if ($this.hasClass('disabled')) {
+            return;
           }
-        }
+          if (e.type === 'keydown' && e.which !== 13) {
+            return;  // activate for keydown on Enter/Return only.
+          }
 
-        option = $target.data('modal-help') ? 'toggle' : $.extend({}, $target.data(), $this.data());
+          href = $this.attr('data-href') || $this.attr('href');
+          modal_id = 'ajax-modal-' + href.replace(/[\/\?=\&#%]/g, '-').replace(/^-/, '');
+          target = $this.attr('data-target') || $('#' + modal_id);
 
-        launch_fn.apply($target, [$target, $this, option]);
-      });
+          $target = $(target);
+          new_target = $target.length === 0;
+
+          if (new_target) {
+            $target = $('<div id="' + modal_id + '" class="modal hide"></div>');
+            $target.addClass($this.attr('data-modal-class'));
+            $this.attr('data-target', '#' + modal_id);
+          }
+
+          $target.on('hidden', function (ev) {
+            if (ev.target === ev.currentTarget)
+              $target.remove();
+          });
+
+          if (new_target || $this.data('modal-reset') === 'reset') {
+            $target.html(preload_content());
+            if ($this.prop('protocol') === window.location.protocol) {
+              $target.load(href, emit_loaded);
+            }
+          }
+
+          option = $target.data('modal-help') ? 'toggle' : $.extend({}, $target.data(), $this.data());
+
+          launch_fn.apply($target, [$target, $this, option]);
+        });
     });
   };
-  $(function() {
+  $(function () {
     can.each({
-        "": handlers["modal"],
-        "form": handlers["form"],
-        "helpform": handlers["helpform"],
-        "listform": handlers["listform"],
-        "listnewform": handlers["listnewform"],
-        "listeditform": handlers["listeditform"],
-        "deleteform": handlers["deleteform"],
-        "unmapform": handlers["unmapform"],
-      },
-      function(launch_fn, toggle) {
+      '': handlers['modal'],
+      'form': handlers['form'],
+      'helpform': handlers['helpform'],
+      'listform': handlers['listform'],
+      'listnewform': handlers['listnewform'],
+      'listeditform': handlers['listeditform'],
+      'deleteform': handlers['deleteform'],
+      'unmapform': handlers['unmapform']
+    },
+      function (launch_fn, toggle) {
         GGRC.register_modal_hook(toggle, launch_fn);
       }
     );
   });
-}(window.jQuery);
+})(window.jQuery);

--- a/src/ggrc/assets/javascripts/bootstrap/modal-form.js
+++ b/src/ggrc/assets/javascripts/bootstrap/modal-form.js
@@ -164,6 +164,9 @@
       var that = this;
       var control = this.control;
       var options = control && control.options;
+      var instance = this.instance;
+      var hasPending;
+      var changedInstance;
 
       // If the hide was initiated by the backdrop, check for dirty form data before continuing
       if (e && $(e.target).is('.modal-backdrop')) {
@@ -173,7 +176,11 @@
           e.stopPropagation();
           return;
         }
-        if (this.is_form_dirty() || this.instance && this.instance.isDirty()) {
+        if (instance) {
+          changedInstance = instance.isDirty();
+          hasPending = GGRC.Utils.hasPending(instance);
+        }
+        if (this.is_form_dirty() || changedInstance || hasPending) {
             // Confirm that the user wants to lose the data prior to hiding
           GGRC.Controllers.Modals.confirm({
             modal_title: 'Discard Changes',

--- a/src/ggrc/assets/javascripts/bootstrap/modal-form.js
+++ b/src/ggrc/assets/javascripts/bootstrap/modal-form.js
@@ -161,10 +161,10 @@
     },
 
     hide: function (e) {
-      var that = this;
       var control = this.control;
       var options = control && control.options;
       var instance = this.instance;
+      var pending;
       var hasPending;
       var changedInstance;
 
@@ -186,31 +186,30 @@
             modal_title: 'Discard Changes',
             modal_description: 'Are you sure that you want to discard your changes?',
             modal_confirm: 'Discard',
-            instance: options.instance,
+            instance: instance,
             model: options.model,
             skip_refresh: true
           }, function () {
-            $.when(function () {
-              can.trigger(options.instance, 'modal:dismiss');
-            }).then(function () {
-              that.$element.find("[data-dismiss='modal'], [data-dismiss='modal-reset']").trigger('click');
-              that.hide();
-            });
-          });
+            can.trigger(instance, 'modal:dismiss');
+            this.$element
+              .find("[data-dismiss='modal'], [data-dismiss='modal-reset']")
+              .trigger('click');
+            this.hide();
+          }.bind(this));
           return;
         }
       }
 
-        // Hide the modal like normal
-      $.when(function () {
-        if (options) {
-          return can.trigger(options.instance, 'modal:dismiss');
+      // Hide the modal like normal
+      if (instance) {
+        pending = instance.attr('_pending_joins');
+        if (pending && pending.length) {
+          instance.attr('_pending_joins', []);
         }
-        return;
-      }).then(function () {
-        $.fn.modal.Constructor.prototype.hide.apply(this, [e]);
-        this.$element.off('modal_form');
-      }.bind(this));
+        can.trigger(instance, 'modal:dismiss');
+      }
+      $.fn.modal.Constructor.prototype.hide.apply(this, [e]);
+      this.$element.off('modal_form');
     },
 
     focus_first_input: function (ev) {

--- a/src/ggrc/assets/javascripts/bootstrap/modal-form.js
+++ b/src/ggrc/assets/javascripts/bootstrap/modal-form.js
@@ -5,15 +5,13 @@
     Maintained By: brad@reciprocitylabs.com
 */
 
-!function ($) {
-
-  "use strict"; // jshint ;_;
+(function ($) {
+  'use strict';
 
   /* MODAL_FORM PUBLIC CLASS DEFINITION
    * =============================== */
 
   var ModalForm = function (element, options, trigger) {
-
     this.options = options;
     this.$element = $(element);
     this.$trigger = $(trigger);
@@ -24,13 +22,13 @@
   /* NOTE: MODAL_FORM EXTENDS BOOTSTRAP-MODAL.js
    * ========================================== */
 
-  ModalForm.prototype = new $.fn.modal.Constructor(null, {remote : false});
+  ModalForm.prototype = new $.fn.modal.Constructor(null, {remote: false});
 
   $.extend(ModalForm.prototype, {
 
     init: function () {
-      var that = this
-        , $form;
+      var that = this;
+
       this.$element
         .on('preload', function () {
           that.is_form_dirty(true);
@@ -43,195 +41,206 @@
         .on('shown.modal-form', $.proxy(this.focus_first_input, this))
         .on('loaded.modal-form', $.proxy(this.focus_first_input, this))
         .on('loaded.modal-form', function (ev) {
-          $("a[data-wysihtml5-command], a[data-wysihtml5-action]", ev.target).attr('tabindex', "-1");
-          $form = that.$form();
-          $(this).trigger("shown"); // this will reposition the modal stack
+          $('a[data-wysihtml5-command], a[data-wysihtml5-action]', ev.target).attr('tabindex', '-1');
+          $(this).trigger('shown'); // this will reposition the modal stack
         })
         .on('delete-object', $.proxy(this.delete_object, this))
         .draggable({handle: '.modal-header'});
+    },
 
-    }
+    doNothing: function (e) {
+      e.stopImmediatePropagation();
+      e.stopPropagation();
+      e.preventDefault();
+    },
+    delete_object: function (e, data, xhr) {
+        // If this modal is contained within another modal, pass the event onward
+      var $trigger_modal = this.$trigger.closest('.modal');
+      var delete_target;
 
-  , doNothing: function (e) {
-    e.stopImmediatePropagation();
-    e.stopPropagation();
-    e.preventDefault();
-  }
-
-  , delete_object: function (e, data, xhr) {
-      // If this modal is contained within another modal, pass the event onward
-    var $trigger_modal = this.$trigger.closest('.modal')
-        , delete_target
-        ;
-
-    if ($trigger_modal.length > 0) {
-      $trigger_modal.trigger('delete-object', [data, xhr]);
-    } else {
-      delete_target = this.$trigger.data('delete-target');
-      if (delete_target == 'refresh') {
-          // Refresh the page
-        GGRC.navigate(window.location.href.replace(/#.*/, ''));
-      } else if (xhr && xhr.getResponseHeader('location')) {
-          // Otherwise redirect if possible
-        GGRC.navigate(xhr.getResponseHeader('location'));
+      if ($trigger_modal.length > 0) {
+        $trigger_modal.trigger('delete-object', [data, xhr]);
       } else {
-          // Otherwise refresh the page
-        GGRC.navigate(window.location.href.replace(/#.*/, ''));
+        delete_target = this.$trigger.data('delete-target');
+        if (delete_target === 'refresh') {
+            // Refresh the page
+          GGRC.navigate(window.location.href.replace(/#.*/, ''));
+        } else if (xhr && xhr.getResponseHeader('location')) {
+            // Otherwise redirect if possible
+          GGRC.navigate(xhr.getResponseHeader('location'));
+        } else {
+            // Otherwise refresh the page
+          GGRC.navigate(window.location.href.replace(/#.*/, ''));
+        }
       }
-    }
-  }
+    },
+    $form: function () {
+      return this.$element.find('form').first();
+    },
 
-  , $form: function () {
-    return this.$element.find('form').first();
-  }
-
-  , is_form_dirty: function (cache_values) {
-    var that = this
-        , cache = {}
-        , dirty = false
-        ;
+    is_form_dirty: function (cache_values) {
+      var that = this;
+      var cache = {};
+      var dirty = false;
 
       // Generate a hash of the form values
-    can.each(this.$form().serializeArray(), function (field) {
-      cache[field.name] = cache[field.name] ? cache[field.name] + ',' + field.value : field.value;
-    });
-
-      // Cache the initial form values as requested
-    if (cache_values || !this._cached_values) {
-      this._cached_values = cache;
-    }
-      // Otherwise compute a diff to determine whether the form is dirty
-    else {
-      can.each(cache, function (value, key) {
-        dirty = dirty || (value !== that._cached_values[key] && (!!value || that._cached_values[key] !== undefined));
+      can.each(this.$form().serializeArray(), function (field) {
+        var val;
+        if (cache[field.name]) {
+          val = cache[field.name] + ',' + field.value;
+        } else {
+          val = field.value;
+        }
+        cache[field.name] = val;
       });
-    }
 
-    return dirty;
-  }
-
-  , submit: function (e) {
-    var $form = this.$form()
-      , that = this;
-
-    if (!$form.data("submitpending")) {
-      $("[data-toggle=modal-submit]", $form)
-          .each(function () { $(this).data("origText", $(this).text()); })
-          .addClass("disabled pending-ajax")
-          .attr("disabled", true);
-
-      $form.data("submitpending", true)
-        .one("ajax:beforeSend", function (ev, _xhr) {
-          that.xhr = _xhr;
-        })
-        .submit();
-    }
-    if (e.type == 'click')
-      e.preventDefault();
-  }
-
-  , keypress_submit: function (e) {
-    if (e.which == 13 && !$(e.target).is('textarea')) {
-      if (!e.isDefaultPrevented()) {
-        e.preventDefault();
-        this.$form().submit();
-      }
-    }
-  }
-
-  , keyup_escape : function (e) {
-    if ($(document.activeElement).is("select, [data-toggle=datepicker]") && e.which === 27) {
-      this.$element.attr("tabindex", -1).focus();
-      e.stopPropagation();
-    }
-  }
-
-  , reset: function (e) {
-    var form = this.$form()[0];
-    form && form.reset();
-    this.hide(e);
-  }
-
-  , hide: function (e) {
-    var that = this,
-      control = this.$element.control(),
-      options = control && control.options;
-
-      // If the hide was initiated by the backdrop, check for dirty form data before continuing
-    if (e && $(e.target).is('.modal-backdrop')) {
-
-      if ($(e.target).is(".disabled")) {
-          // In the case of a disabled modal backdrop, treat it like any other disabled data-dismiss,
-          //  i.e. do nothing.
-        e.stopPropagation();
-        return;
-      }
-      if (this.is_form_dirty()) {
-          // Confirm that the user wants to lose the data prior to hiding
-        GGRC.Controllers.Modals.confirm({
-          modal_title : "Discard Changes"
-            , modal_description : "Are you sure that you want to discard your changes?"
-            , modal_confirm : "Discard"
-            , instance : options.instance
-            , model : options.model
-            , skip_refresh : true
-        }, function () {
-          $.when(function () {
-            can.trigger(options.instance, "modal:dismiss");
-          }).then(function () {
-            that.$element.find("[data-dismiss='modal'], [data-dismiss='modal-reset']").trigger("click");
-            that.hide();
-          });
+      if (cache_values || !this._cached_values) {
+        // Cache the initial form values as requested
+        this._cached_values = cache;
+      } else {
+        // Otherwise compute a diff to determine whether the form is dirty
+        can.each(cache, function (value, key) {
+          if (!dirty) {
+            dirty = (value !== that._cached_values[key] &&
+              (!!value || that._cached_values[key] !== undefined));
+          }
         });
+      }
+
+      return dirty;
+    },
+
+    submit: function (e) {
+      var $form = this.$form();
+      var that = this;
+
+      if (!$form.data('submitpending')) {
+        $('[data-toggle=modal-submit]', $form)
+            .each(function () {
+              $(this).data('origText', $(this).text());
+            })
+            .addClass('disabled pending-ajax')
+            .attr('disabled', true);
+
+        $form.data('submitpending', true)
+          .one('ajax:beforeSend', function (ev, _xhr) {
+            that.xhr = _xhr;
+          })
+          .submit();
+      }
+      if (e.type === 'click') {
+        e.preventDefault();
+      }
+    },
+
+    keypress_submit: function (e) {
+      if (e.which === 13 && !$(e.target).is('textarea')) {
+        if (!e.isDefaultPrevented()) {
+          e.preventDefault();
+          this.$form().submit();
+        }
+      }
+    },
+
+    keyup_escape: function (e) {
+      if ($(document.activeElement).is('select, [data-toggle=datepicker]') && e.which === 27) {
+        this.$element.attr('tabindex', -1).focus();
+        e.stopPropagation();
+      }
+    },
+
+    reset: function (e) {
+      var form = this.$form()[0];
+      if (form) {
+        form.reset();
+      }
+      this.hide(e);
+    },
+
+    hide: function (e) {
+      var that = this;
+      var control = this.$element.control();
+      var options = control && control.options;
+
+        // If the hide was initiated by the backdrop, check for dirty form data before continuing
+      if (e && $(e.target).is('.modal-backdrop')) {
+        if ($(e.target).is('.disabled')) {
+            // In the case of a disabled modal backdrop, treat it like any other disabled data-dismiss,
+            //  i.e. do nothing.
+          e.stopPropagation();
+          return;
+        }
+        if (this.is_form_dirty()) {
+            // Confirm that the user wants to lose the data prior to hiding
+          GGRC.Controllers.Modals.confirm({
+            modal_title: 'Discard Changes',
+            modal_description: 'Are you sure that you want to discard your changes?',
+            modal_confirm: 'Discard',
+            instance: options.instance,
+            model: options.model,
+            skip_refresh: true
+          }, function () {
+            $.when(function () {
+              can.trigger(options.instance, 'modal:dismiss');
+            }).then(function () {
+              that.$element.find("[data-dismiss='modal'], [data-dismiss='modal-reset']").trigger('click');
+              that.hide();
+            });
+          });
+          return;
+        }
+      }
+
+        // Hide the modal like normal
+      $.when(function () {
+        if (options) {
+          return can.trigger(options.instance, 'modal:dismiss');
+        }
         return;
-      }
+      }).then(function () {
+        $.fn.modal.Constructor.prototype.hide.apply(this, [e]);
+        this.$element.off('modal_form');
+      }.bind(this));
+    },
+
+    focus_first_input: function (ev) {
+      var that = this;
+      setTimeout(function () {
+        var $first_input;
+        $first_input = that.$element.find('*[autofocus]');
+        if (!$first_input.length) {
+          $first_input = that.$element
+              .find('input[type="text"], input[type="checkbox"], select, textarea')
+              .not('[placeholder*=autofill], label:contains(autofill) + *, [disabled]')
+              .first();
+        }
+        if ($first_input.length && (!ev || that.$element.is(ev.target))) {
+          $first_input.get(0).focus();
+        }
+      }, 100);
     }
-
-      // Hide the modal like normal
-    $.when(function () {
-      if (options) {
-        return can.trigger(options.instance, "modal:dismiss");
-      }
-      return;
-    }).then(function () {
-      $.fn.modal.Constructor.prototype.hide.apply(this, [e]);
-      this.$element.off('modal_form');
-    }.bind(this));
-  }
-
-  , focus_first_input: function (ev) {
-    var that = this;
-    setTimeout(function () {
-      var $first_input;
-      $first_input = that.$element.find('*[autofocus]');
-      if ($first_input.length == 0) {
-        $first_input = that.$element
-            .find('input[type="text"], input[type="checkbox"], select, textarea')
-            .not('[placeholder*=autofill], label:contains(autofill) + *, [disabled]')
-            .first();
-      }
-      if ($first_input.length > 0 && (!ev || that.$element.is(ev.target))) {
-        $first_input.get(0).focus();
-      }
-    }, 100);
-  }
   });
 
   $.fn.modal_form = function (option, trigger) {
     return this.each(function () {
-      var $this = $(this)
-        , data = $this.data('modal_form')
-        , options = $.extend({}, $.fn.modal_form.defaults, $this.data(), typeof option == 'object' && option);
-      if (!data) $this.data('modal_form', (data = new ModalForm(this, options, trigger)));
-      if (typeof option == 'string') data[option]();
-      else if (options.show) data.show();
+      var $this = $(this);
+      var data = $this.data('modal_form');
+      var options = $.extend({}, $.fn.modal_form.defaults,
+        $this.data(), typeof option === 'object' && option);
+
+      if (!data) {
+        $this.data('modal_form', (data = new ModalForm(this, options, trigger)));
+      }
+      if (typeof option === 'string') {
+        data[option]();
+      } else if (options.show) {
+        data.show();
+      }
     });
   };
 
   $.fn.modal_form.Constructor = ModalForm;
-
   $.fn.modal_form.defaults = $.extend({}, $.fn.modal.defaults, {
-
   });
 
   /* MODAL-FORM DATA-API
@@ -239,9 +248,10 @@
 
   $(function () {
     $('body').on('click.modal-form.data-api', '[data-toggle="modal-form"]', function (e) {
-      var $this = $(this), href
-        , $target = $($this.attr('data-target') || (href = $this.attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '')) // strip for ie7
-        , option = $target.data('modal-form') ? 'toggle' : $.extend({}, $target.data(), $this.data());
+      var $this = $(this);
+      var href;
+      var $target = $($this.attr('data-target') || (href = $this.attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '')); // strip for ie7
+      var option = $target.data('modal-form') ? 'toggle' : $.extend({}, $target.data(), $this.data());
 
       e.preventDefault();
       $target.modal_form(option);
@@ -253,6 +263,12 @@
     // Default form complete handler
     $('body').on('ajax:complete', function (e, xhr, status) {
       var data = null;
+      var modal_form;
+      var flash_types;
+      var type_i;
+      var message;
+      var flash;
+
       try {
         data = JSON.parse(xhr.responseText);
       } catch (exc) {
@@ -261,24 +277,23 @@
 
       if (!e.stopRedirect) {
         // Maybe handle AJAX/JSON redirect or refresh
-        if (xhr.status == 278) {
+        if (xhr.status === 278) {
           // Handle 278 redirect (AJAX redirect)
           GGRC.navigate(xhr.getResponseHeader('location'));
-        } else if (xhr.status == 279) {
+        } else if (xhr.status === 279) {
           // Handle 279 page refresh
           GGRC.navigate(window.location.href.replace(/#.*/, ''));
-        }
-        else {
-          var modal_form = $(".modal:visible:last").data("modal_form");
+        } else {
+          modal_form = $('.modal:visible:last').data('modal_form');
           if (modal_form && xhr === modal_form.xhr) {
             delete modal_form.xhr;
-            $("[data-toggle=modal-submit]", modal_form.$element)
-            .removeAttr("disabled")
-            .removeClass("disabled pending-ajax")
+            $('[data-toggle=modal-submit]', modal_form.$element)
+            .removeAttr('disabled')
+            .removeClass('disabled pending-ajax')
             .each(function () {
-              $(this).text($(this).data("origText"));
+              $(this).text($(this).data('origText'));
             });
-            $("form", modal_form.$element).data("submitpending", false);
+            $('form', modal_form.$element).data('submitpending', false);
           }
         }
       }
@@ -293,20 +308,21 @@
 
       if (!e.stopFlash) {
         // Maybe handle AJAX flash messages
-        var flash_types = ["error", "alert", "notice", "warning"]
-          , type_i, message
-          , flash;
+        flash_types = ['error', 'alert', 'notice', 'warning'];
 
         for (type_i in flash_types) {
+          if (!flash_types.hasOwnProperty(type_i)) {
+            continue;
+          }
           message = xhr.getResponseHeader('x-flash-' + flash_types[type_i]);
           message = JSON.parse(message);
           if (message) {
-            if (!flash)
+            if (!flash) {
               flash = {};
+            }
             flash[flash_types[type_i]] = message;
           }
         }
-
         if (flash) {
           $(document.body).trigger('ajax:flash', flash);
         }
@@ -367,6 +383,9 @@
           $html.append('<a href="#" class="close" data-dismiss="alert">x</a>');
 
           for (messageI in flash[type]) {
+            if (!flash[type].hasOwnProperty(messageI)) {
+              continue;
+            }
             message = flash[type][messageI];
             // Skip error codes. To force display use String(...) when
             // triggering the flash.
@@ -398,6 +417,5 @@
       });
       $(this).find('.modal-body').html($frag);
     });
-
   });
-}(window.jQuery);
+})(window.jQuery);

--- a/src/ggrc/assets/javascripts/controllers/modals_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/modals_controller.js
@@ -952,14 +952,11 @@ can.Control('GGRC.Controllers.Modals', {
   , "{instance} destroyed" : " hide"
 
   , " hide" : function(el, ev) {
-      if(this.disable_hide) {
+      if (this.disable_hide) {
         ev.stopImmediatePropagation();
         ev.stopPropagation();
         ev.preventDefault();
         return false;
-      }
-      if (this.options.instance) {
-        this.options.instance.attr("_pending_joins", []);
       }
       if (this.options.instance instanceof can.Model
           // Ensure that this modal was hidden and not a child modal

--- a/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
+++ b/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
@@ -73,8 +73,13 @@
       if (list instanceof can.List) {
         list = list.serialize();
       }
+
       return _.find(list, function (pending) {
-        return pending.how === how && pending.what === instance;
+        var method = pending.how === how;
+        if (!instance) {
+          return method;
+        }
+        return method && pending.what === instance;
       });
     },
     is_mapped: function (target, destination, mapping) {


### PR DESCRIPTION
Closing the modal window after filling in assessor and/or verifier fields doesn't trigger discarding changes confirmation modal.

Please note that this works only if we click on backdrop (overlay). If we directly click on `x` this won't work