### PR TITLE
CORE-3459 Make default people lists mandatory

### DIFF
--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -1146,12 +1146,26 @@
     },
 
     /**
-     * Initialize the newly created object instance. Essentially just validate
-     * that its title is non-blank.
+     * Initialize the newly created object instance. Validate that its title is
+     * non-blank and its default assessors / verifiers lists are set if
+     * applicable.
      */
     init: function () {
       this._super.apply(this, arguments);
       this.validateNonBlank('title');
+
+      this.validateListNonBlank(
+        'assessorsList',
+        function () {
+          return this.attr('default_people.assessors') === 'other';
+        }
+      );
+      this.validateListNonBlank(
+        'verifiersList',
+        function () {
+          return this.attr('default_people.verifiers') === 'other';
+        }
+      );
     }
   }, {
     // the object types that are not relevant to the AssessmentTemplate,

--- a/src/ggrc/assets/javascripts/plugins/canjs_extensions.js
+++ b/src/ggrc/assets/javascripts/plugins/canjs_extensions.js
@@ -35,6 +35,35 @@
       });
     };
 
+  /**
+   * Validate an autocomplete list field to be not blank.
+   *
+   * It checks in the field contains either a false-value, or a
+   * non-constructor, or a constructor that builds an empty object and if so,
+   * returns a non_blank error message.
+   *
+   * @param {String} listFieldName - the name of the field with the
+   * autocomplete list
+   * @param {Function} condition - a zero-parameter function; the validation
+   * will be fired only if condition returns true or is undefined
+   * @param {Object} options - a CanJS options argument passed to CanJS
+   * validate function
+   *
+   */
+  can.Model.validateListNonBlank =
+    can.Map.validateListNonBlank = function (listFieldName, condition,
+                                             options) {
+      this.validate(listFieldName, options, function (newVal, prop) {
+        if (_.isUndefined(condition) || condition.call(this)) {
+          if (!newVal ||
+              !_.isFunction(newVal.attr) ||
+              _.isEmpty(newVal.attr())) {
+            return this.constructor.validationMessages.non_blank;
+          }
+        }
+      });
+    };
+
   // Adding reduce, a generally useful array comprehension.
   //  Bitovi decided against including it in core CanJS, but
   //  adding it here for easy universal use across can.List

--- a/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
@@ -130,7 +130,7 @@
             ></dropdown>
           </div>
 
-          <div class="span6 {{#instance.computed_errors.assessorsList}}field-failure{{/instance.computed_errors.assessorsList}}">
+          <div class="span6{{#instance.computed_errors.assessorsList}} field-failure{{/instance.computed_errors.assessorsList}}">
             <label>&nbsp;</label>
             {{#if_equals instance.default_people.assessors 'other'}}
               <autocomplete
@@ -169,7 +169,7 @@
             ></dropdown>
           </div>
 
-          <div class="span6 {{#instance.computed_errors.verifiersList}}field-failure{{/instance.computed_errors.verifiersList}}">
+          <div class="span6{{#instance.computed_errors.verifiersList}} field-failure{{/instance.computed_errors.verifiersList}}">
             <label>&nbsp;</label>
 
             {{#if_equals instance.default_people.verifiers 'other'}}

--- a/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
@@ -130,7 +130,7 @@
             ></dropdown>
           </div>
 
-          <div class="span6">
+          <div class="span6 {{#instance.computed_errors.assessorsList}}field-failure{{/instance.computed_errors.assessorsList}}">
             <label>&nbsp;</label>
             {{#if_equals instance.default_people.assessors 'other'}}
               <autocomplete
@@ -139,6 +139,10 @@
                 disable="instance.assessorsListDisable"
                 placeholder="Enter text to search for Assessors"
               ></autocomplete>
+
+              {{#instance.computed_errors.assessorsList}}
+                <label class="help-inline warning">{{this}}</label>
+              {{/instance.computed_errors.assessorsList}}
 
               {{#each instance.assessorsList}}
                 <person
@@ -165,7 +169,7 @@
             ></dropdown>
           </div>
 
-          <div class="span6">
+          <div class="span6 {{#instance.computed_errors.verifiersList}}field-failure{{/instance.computed_errors.verifiersList}}">
             <label>&nbsp;</label>
 
             {{#if_equals instance.default_people.verifiers 'other'}}
@@ -175,6 +179,10 @@
                 disable="instance.verifiersListDisable"
                 placeholder="Enter text to search for Verifiers"
               ></autocomplete>
+
+              {{#instance.computed_errors.verifiersList}}
+                <label class="help-inline warning">{{this}}</label>
+              {{/instance.computed_errors.verifiersList}}
 
               {{#each instance.verifiersList}}
                 <person

--- a/src/ggrc/models/assessment_template.py
+++ b/src/ggrc/models/assessment_template.py
@@ -85,11 +85,14 @@ class AssessmentTemplate(Slugged, Base, Relatable, Titled,
     parsed = json.loads(value)
     for mandatory in self._mandatory_default_people:
       mandatory_value = parsed.get(mandatory)
-      if (not mandatory_value or isinstance(mandatory_value, basestring) and
+      if (not mandatory_value or
+              isinstance(mandatory_value, list) and
+              any(not isinstance(p_id, int) for p_id in mandatory_value) or
+              isinstance(mandatory_value, basestring) and
               mandatory_value not in self.DEFAULT_PEOPLE_LABELS):
         raise ValidationError(
-            'Invalid value for default_people.{field}. Expected a non-empty '
-            'string or a list of people ids, recieved {value}.'
+            'Invalid value for default_people.{field}. Expected a people '
+            'label in string or a list of int people ids, recieved {value}.'
             .format(field=mandatory, value=mandatory_value),
         )
 

--- a/src/ggrc/models/assessment_template.py
+++ b/src/ggrc/models/assessment_template.py
@@ -30,6 +30,7 @@ class AssessmentTemplate(Slugged, Base, Relatable, Titled,
   object.
   """
   __tablename__ = "assessment_templates"
+  _mandatory_default_people = ("assessors", "verifiers")
 
   # the type of the object under assessment
   template_object_type = db.Column(db.String, nullable=True)
@@ -72,17 +73,24 @@ class AssessmentTemplate(Slugged, Base, Relatable, Titled,
 
   @validates('default_people')
   def validate_default_people(self, key, value):
-    """Check that default people lists are not empty."""
-    # pylint: disable=no-self-use
+    """Check that default people lists are not empty.
+
+    Check if the default_people contains both assessors and verifiers. The
+    values of those fields must be thruthy, and if the value is a string it
+    must be a valid default people label. If the value is not a string, it
+    should be a list of valid user ids, but that is too expensive to test in
+    this validator.
+    """
     # pylint: disable=unused-argument
-    if value is not None:
-      parsed = json.loads(value)
-      for field_name, field_value in parsed.iteritems():
-        if not field_value:
-          raise ValidationError(
-              'Invalid value for default_people.{field}. Expected a non-empty '
-              'string or a list of people ids, recieved {value}.'
-              .format(field=field_name, value=field_value),
-          )
+    parsed = json.loads(value)
+    for mandatory in self._mandatory_default_people:
+      mandatory_value = parsed.get(mandatory)
+      if (not mandatory_value or isinstance(mandatory_value, basestring) and
+              mandatory_value not in self.DEFAULT_PEOPLE_LABELS):
+        raise ValidationError(
+            'Invalid value for default_people.{field}. Expected a non-empty '
+            'string or a list of people ids, recieved {value}.'
+            .format(field=mandatory, value=mandatory_value),
+        )
 
     return value

--- a/src/ggrc/models/assessment_template.py
+++ b/src/ggrc/models/assessment_template.py
@@ -5,7 +5,12 @@
 
 """A module containing the implementation of the assessment template entity."""
 
+import json
+
+from sqlalchemy.orm import validates
+
 from ggrc import db
+from ggrc.models.exceptions import ValidationError
 from ggrc.models.mixins import Base
 from ggrc.models.mixins import Slugged
 from ggrc.models.mixins import Titled
@@ -64,3 +69,20 @@ class AssessmentTemplate(Slugged, Base, Relatable, Titled,
   @classmethod
   def generate_slug_prefix_for(cls, obj):
     return "TEMPLATE"
+
+  @validates('default_people')
+  def validate_default_people(self, key, value):
+    """Check that default people lists are not empty."""
+    # pylint: disable=no-self-use
+    # pylint: disable=unused-argument
+    if value is not None:
+      parsed = json.loads(value)
+      for field_name, field_value in parsed.iteritems():
+        if not field_value:
+          raise ValidationError(
+              'Invalid value for default_people.{field}. Expected a non-empty '
+              'string or a list of people ids, recieved {value}.'
+              .format(field=field_name, value=field_value),
+          )
+
+    return value


### PR DESCRIPTION
Add validation to default people lists on assessment template creation form in case the user chooses 'Others' in the default assessors/verifiers dropdowns.