### PR TITLE
CORE-3668 Fix console error after refresh on Audit tab

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/info_pin_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/info_pin_controller.js
@@ -105,7 +105,7 @@ can.Control("CMS.Controllers.InfoPin", {
         $filter = $(".tree-filter:visible"),
         elTop = el.offset().top,
         elBottom = elTop + el.height(),
-        headerTop = $header.offset().top,
+        headerTop = $header.length ? $header.offset().top : 0,
         headerBottom = headerTop + $header.height(),
         infoTop = this.element.offset().top;
 


### PR DESCRIPTION
Fixed console error after refresh on Audit tab, because sometimes took offset from a hidden element