### PR TITLE
CORE-3684 Clean docker, part 1

### DIFF
--- a/Dockerfile-clean
+++ b/Dockerfile-clean
@@ -1,0 +1,43 @@
+FROM phusion/baseimage
+
+RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \
+  && apt-get update \
+  && apt-get install -y \
+    curl \
+    fabric \
+    git-core \
+    make \
+    mysql-client \
+    nodejs \
+    python-imaging \
+    python-mysqldb \
+    python-pip \
+    python-pycurl \
+    python-virtualenv \
+    sqlite3 \
+    unzip \
+    vim \
+    wget \
+    zip \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY ./provision/docker/vagrant.bashrc /root/.bashrc
+WORKDIR /vagrant
+
+# Javascript dependencies
+COPY ./package.json ./bower.json /vagrant-dev/
+RUN cd /vagrant-dev \
+  && npm install \
+  && node_modules/.bin/bower --allow-root install
+
+# Python packages
+COPY ./Makefile /vagrant/
+COPY ./src/requirements*.txt /vagrant/src/
+COPY ./bin/init_env ./bin/setup_linked_packages.py /vagrant/bin/
+COPY ./extras /vagrant/extras
+RUN make setup_dev DEV_PREFIX=/vagrant-dev \
+  && make appengine_sdk DEV_PREFIX=/vagrant-dev \
+  && make appengine_packages DEV_PREFIX=/vagrant-dev \
+  && rm /vagrant-dev/opt/google_appengine_1.9.3.zip
+
+CMD bash -c 'tail -f bin/init_env'

--- a/bin/db_reset
+++ b/bin/db_reset
@@ -13,6 +13,7 @@ TEST_DB_NAME="ggrcdevtest"
 SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
 ROOT_PATH="${SCRIPTPATH}/../"
 DUMP_FILE=${1:-}
+HOST=${GGRC_DATABASE_HOST-"127.0.0.1"}
 
 if [[ "$DUMP_FILE" == "-h" || "$DUMP_FILE" == "--help" ]] ; then
   echo "Usage: $(basename $0) [sql_dump_file.sql]"
@@ -32,14 +33,16 @@ if [[ -f "$DUMP_FILE" ]] && grep "^USE " $DUMP_FILE; then
   exit 1
 fi
 
-mysql -uroot -proot -e "drop database if exists $DB_NAME"
-mysql -uroot -proot -e "create database $DB_NAME character set utf8"
-mysql -uroot -proot -e "drop database if exists $TEST_DB_NAME"
-mysql -uroot -proot -e "create database $TEST_DB_NAME character set utf8"
+
+
+mysql -uroot -proot -h$HOST -e "drop database if exists $DB_NAME"
+mysql -uroot -proot -h$HOST -e "create database $DB_NAME character set utf8"
+mysql -uroot -proot -h$HOST -e "drop database if exists $TEST_DB_NAME"
+mysql -uroot -proot -h$HOST -e "create database $TEST_DB_NAME character set utf8"
 
 if [[ -f "$DUMP_FILE" ]]; then
   echo "Importing: $DUMP_FILE"
-  mysql -uroot -proot $DB_NAME < $DUMP_FILE
+  mysql -uroot -proot -h$HOST $DB_NAME < $DUMP_FILE
 fi
 
 db_migrate

--- a/docker-compose-clean.yml
+++ b/docker-compose-clean.yml
@@ -1,0 +1,20 @@
+cleandev:
+  build: .
+  dockerfile: Dockerfile-clean
+  ports:
+   - "8000:8000"
+   - "8080:8080"
+   - "9876:9876"
+  volumes:
+   - ".:/vagrant"
+  environment:
+   - PYTHONDONTWRITEBYTECODE=true
+   - NODE_PATH=/vagrant-dev/node_modules/
+   - GGRC_DATABASE_URI=mysql+mysqldb://root:root@db/ggrcdev?charset=utf8
+   - GGRC_DATABASE_HOST=db
+  links:
+   - db
+db:
+  image: mysql:5.5
+  environment:
+  - MYSQL_ROOT_PASSWORD=root

--- a/src/ggrc/settings/development.py
+++ b/src/ggrc/settings/development.py
@@ -10,14 +10,16 @@ TESTING = True
 PRODUCTION = False
 FLASK_DEBUGTOOLBAR = False
 HOST = '0.0.0.0'
-SQLALCHEMY_DATABASE_URI = 'mysql+mysqldb://root:root@127.0.0.1/ggrcdev?charset=utf8'
+SQLALCHEMY_DATABASE_URI = os.environ.get(
+    'GGRC_DATABASE_URI',
+    'mysql+mysqldb://root:root@127.0.0.1/ggrcdev?charset=utf8')
 FULLTEXT_INDEXER = 'ggrc.fulltext.mysql.MysqlIndexer'
 LOGIN_MANAGER = 'ggrc.login.noop'
-#SQLALCHEMY_ECHO = True
-#SQLALCHEMY_RECORD_QUERIES = True
+# SQLALCHEMY_ECHO = True
+# SQLALCHEMY_RECORD_QUERIES = True
 AUTOBUILD_ASSETS = True
 ENABLE_JASMINE = True
-#DEBUG_ASSETS = True
+# DEBUG_ASSETS = True
 USE_APP_ENGINE_ASSETS_SUBDOMAIN = False
 MEMCACHE_MECHANISM = False
 APPENGINE_EMAIL = "user@example.com"


### PR DESCRIPTION
This adds new Dockerfile and docker-compose files to build a thiner ggrc container. It's not quite ready for prime time yet, but it should unblock @akhilp1.

To use the new Dockerfile use:

```
docker-compose -f docker-compose-clean.yml up
docker exec -it ggrccore_cleandev_1 bash
```

In part 2, we'll replace the default current Dockerfile if everyone agrees. 

ps: @edofic can you let me know how much slower the default mysql container is compared to the in memory fat container?