### PR TITLE
QUICK-FIX Make _title_uniqueness false on Assessments

### DIFF
--- a/src/ggrc/models/assessment.py
+++ b/src/ggrc/models/assessment.py
@@ -46,6 +46,7 @@ class Assessment(mixins_statusable.Statusable,
   """
 
   __tablename__ = 'assessments'
+  _title_uniqueness = False
 
   ASSIGNEE_TYPES = (u"Creator", u"Assessor", u"Verifier")
 

--- a/test/integration/ggrc/converters/test_import_helpers.py
+++ b/test/integration/ggrc/converters/test_import_helpers.py
@@ -343,7 +343,6 @@ class TestGetObjectColumnDefinitions(TestCase):
     vals = {val["display_name"]: val for val in definitions.values()}
     self.assertTrue(vals["Title"]["mandatory"])
     self.assertTrue(vals["Owner"]["mandatory"])
-    self.assertTrue(vals["Title"]["unique"])
     self.assertTrue(vals["Audit"]["mandatory"])
 
   def test_issue_definitions(self):


### PR DESCRIPTION
The Assessments model should match the actual table in the database.
Since the title is not a unique field, the model itself should reflect
that.

This a part of CORE-3391. I am breaking that ticket up into smaller logical chunks so it can be reviewed and merged faster.