### PR TITLE
QUICK-FIX Force rebuilding of bower components

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ directory
     git submodule update --init
     docker-compose up -d
     docker exec -it ggrccore_dev_1 su vagrant
-    make bower_components
+    make -B bower_components
     build_css
     build_assets
     db_reset


### PR DESCRIPTION
This fixes the fonts when creating a fresh container. Since the fix for
missing system links, bower components does not run as soon as you login
to the container. With -B flag, we force bower_components to rebuild
even if the link already exists.