### PR TITLE
QUICK-FIX Improve flash messages visibility 

### DIFF
--- a/src/ggrc/assets/javascripts/application.js
+++ b/src/ggrc/assets/javascripts/application.js
@@ -62,16 +62,17 @@
 
   $doc.ready(function () {
     // monitor target, where flash messages are added
+    var AUTOHIDE_TIMEOUT = 10000;
     var target = $('section.content div.flash')[0];
     var observer = new MutationObserver(function (mutations) {
       mutations.forEach(function (mutation) {
         // check for new nodes
         if (mutation.addedNodes !== null) {
           // remove the success message from non-expandable
-          // flash success messages after five seconds
+          // flash success messages after timeout
           setTimeout(function () {
             $('.flash .alert-autohide').remove();
-          }, 5000);
+          }, AUTOHIDE_TIMEOUT);
         }
       });
     });

--- a/src/ggrc/assets/stylesheets/modules/_notifications.scss
+++ b/src/ggrc/assets/stylesheets/modules/_notifications.scss
@@ -13,6 +13,7 @@
   margin-left: 25%;
   z-index: zIndex(flash);
   font-size: 11px;
+
   .notice {
     background-color: $messageGreen;
     p {
@@ -59,8 +60,8 @@
 }
 
 .alert {
-  @include border-radius(0);
-  border: none;
+  @include border-radius(2px);
+  border: 1px solid;
   margin-bottom: 20px;
   p {
     margin-bottom: 0;


### PR DESCRIPTION
We use flash messages all over the app to deliver message of fail, success and notifications. Unfortunately sometimes it's not obvious they appeared.
I asked Dragan how can we improve it and he came up with this temporary solution until we handle it properly for next release.
