### PR TITLE
QUICK-FIX Fix getting object state for invalid objects

### DIFF
--- a/src/ggrc_workflows/models/workflow.py
+++ b/src/ggrc_workflows/models/workflow.py
@@ -375,9 +375,12 @@ class WorkflowState(object):
     if not current_tasks:
       return None
 
-    overdue_tasks = [task for task in current_tasks
-                     if task.status != "Verified" and
-                     task.end_date <= date.today()]
+    today = date.today()
+    overdue_tasks = any(task.end_date and
+                        task.end_date <= today and
+                        task.status != "Verified"
+                        for task in current_tasks)
+
     if overdue_tasks:
       return "Overdue"
 


### PR DESCRIPTION
The database can contain some cycle tasks without an end_date. That
causes api calls for any object on that task to fail. The main
difference in the code here is the check if task.end_date is None right
before the date < today check. The rest is just a trivial performance
improvement since we only need to check if any such task exists.

The underlying problem for this will need to be found and solved in a
different PR. The point if this commit is to make sure invalid database
state does not break the app.

See:
https://grc-dev.appspot.com/workflows/316#current_widget/cycle/280/cycle_task_group/313/cycle_task_group_object_task/699

To reproduce the bug, just select all sections in the unified mapper modal. When the request gets to the section mapped to the above task, server returns a 500 and the app hangs.