### PR TITLE
CORE-3702 Fix GC cannot create new Request

### DIFF
--- a/src/ggrc/assets/mustache/modals/mapper/base.mustache
+++ b/src/ggrc/assets/mustache/modals/mapper/base.mustache
@@ -25,7 +25,7 @@
         {{#if_helpers "\
           ^if_equals" mapper.type "AllObject" "\
           and ^if" mapper.search_only}}
-          {{#is_allowed 'create' mapper.model.singular context=null}}
+          {{#is_allowed 'create' mapper.model.singular context='any'}}
 
             {{#if_equals mapper.type 'AssessmentTemplate'}}
               <a


### PR DESCRIPTION
GC should be allowed to create new objects if he has any of the Audit contexts already available. The same as the logic for LHN menu (e.g. 'Create New Request' button should be available when any of  audits were created).