### PR TITLE
CORE-3546 Hide Documents in Risk Assessment subtree

### DIFF
--- a/src/ggrc_risk_assessments/assets/javascripts/apps/risk_assessments.js
+++ b/src/ggrc_risk_assessments/assets/javascripts/apps/risk_assessments.js
@@ -71,7 +71,7 @@
             parent_instance: page_instance,
             model: CMS.Models.RiskAssessment,
             show_view: GGRC.mustache_path + "/risk_assessments/tree.mustache",
-            draw_children: true,
+            draw_children: false,
           }
         }
       };


### PR DESCRIPTION
Don't show children at all since nothing else can be mapped to Risk Assessments.