### PR TITLE
QUICK-FIX Disallow create WF from new Task modal

### DIFF
--- a/src/ggrc/assets/mustache/base_objects/autocomplete_result.mustache
+++ b/src/ggrc/assets/mustache/base_objects/autocomplete_result.mustache
@@ -24,10 +24,18 @@
 {{/if}}
 {{#if model}}
 {{#is_allowed "create" model.shortName context=null}}
-<li class="ui-menu-item add-new oneline" data-ui-autocomplete-item="">
-  <a data-object-plural="{{model.table_plural}}" data-modal-class="modal-wide" href="javascript://" data-object-singular="{{model.model_singular}}" data-toggle="modal-ajax-form" data-modal-reset="reset" data-mapping="{{mapping}}">
-    + Create New
-  </a>
-</li>
+    {{^if_equals model.shortName "Workflow"}}
+        <li class="ui-menu-item add-new oneline" data-ui-autocomplete-item="">
+          <a data-object-plural="{{model.table_plural}}"
+             data-modal-class="modal-wide"
+             href="javascript://"
+             data-object-singular="{{model.model_singular}}"
+             data-toggle="modal-ajax-form"
+             data-modal-reset="reset"
+             data-mapping="{{mapping}}">
+            + Create New
+          </a>
+        </li>
+    {{/if_equals}}
 {{/is_allowed}}
 {{/if}}

--- a/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/modal_content.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/modal_content.mustache
@@ -48,7 +48,9 @@
       <br>
       <div class="{{#instance.computed_errors.workflow}}field-failure{{/instance.computed_errors.workflow}} {{#instance.computed_errors.cycle}}field-failure{{/instance.computed_errors.cycle}}">
         {{#using workflow=instance.workflow}}
-          <h6>Workflow <span class="required">*</span></h6>
+          <h6 title="An active workflow should be created in advance">
+            Active Workflow <span class="required">*</span>
+          </h6>
           <input
             class="input-block-level required"
             name="workflow."


### PR DESCRIPTION
PR applies temporary workaround for workflow as discussed with @akhilp1.
1) remove "create new" for workflow field
2) label "Active Workflow" + tooltip for the user "An active workflow should be created in advance."