### PR TITLE
TRL-cRE6rwjY Fix section mixin ordering

### DIFF
--- a/src/ggrc/models/section.py
+++ b/src/ggrc/models/section.py
@@ -26,9 +26,9 @@ from ggrc.models.track_object_state import track_state_for_class
 
 
 class Section(HasObjectState, Hierarchical, Noted, Described, Hyperlinked,
-              WithContact, Titled, Slugged, Stateful, db.Model,
+              WithContact, Titled, Stateful, db.Model,
               CustomAttributable, Documentable, Personable,
-              Ownable, Relatable):
+              Ownable, Relatable, Slugged):
   VALID_STATES = [
       'Draft',
       'Final',


### PR DESCRIPTION
The slugged mixin includes the Base mixin, which must be last. Otherwise
eager queries in the mixins after it are ignored.

This Pr increased get performance for sections by a factor of 3. That is on my local machine with ram database, and we should expect greater performance on deployed instances.