### PR TITLE
CORE-3521 Remove the "References" option from the unified mapper modal

### DIFF
--- a/src/ggrc/assets/javascripts/components/unified_mapper/mapper.js
+++ b/src/ggrc/assets/javascripts/components/unified_mapper/mapper.js
@@ -151,7 +151,11 @@
     })
   });
 
-  can.Component.extend({
+  /**
+   * A component implementing a modal for mapping objects to other objects,
+   * taking the object type mapping constraints into account.
+   */
+  GGRC.Components('modalMapper', {
     tag: 'modal-mapper',
     template: can.view(GGRC.mustache_path + '/modals/mapper/base.mustache'),
     scope: function (attrs, parentScope, el) {

--- a/src/ggrc/assets/javascripts/components/unified_mapper/mapper.js
+++ b/src/ggrc/assets/javascripts/components/unified_mapper/mapper.js
@@ -133,6 +133,10 @@
         cmsModel = CMS.Models[modelName];
         group = !groups[cmsModel.category] ? 'governance' : cmsModel.category;
 
+        if (cmsModel.title_singular === 'Reference') {
+          return;
+        }
+
         groups[group].items.push({
           name: cmsModel.title_plural,
           value: cmsModel.shortName,

--- a/src/ggrc/assets/javascripts/components/unified_mapper/tests/mapper_model_spec.js
+++ b/src/ggrc/assets/javascripts/components/unified_mapper/tests/mapper_model_spec.js
@@ -1,0 +1,58 @@
+/*!
+  Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+  Created By: peter@reciprocitylabs.com
+  Maintained By: peter@reciprocitylabs.com
+*/
+
+describe('GGRC.Models.MapperModel', function () {
+  'use strict';
+
+  var mapper;
+
+  beforeEach(function () {
+    mapper = new GGRC.Models.MapperModel();
+  });
+
+  describe('types() method', function () {
+    var canonicalMappings;  // a fake return value for a Spy
+
+    beforeAll(function () {
+      var OBJECT_TYPES = [
+        'DataAsset', 'Facility', 'Market', 'OrgGroup', 'Vendor', 'Process',
+        'Product', 'Project', 'System', 'Regulation', 'Policy', 'Contract',
+        'Standard', 'Program', 'Issue', 'Control', 'Section', 'Clause',
+        'Objective', 'Audit', 'Assessment', 'AccessGroup', 'Request',
+        'Document', 'Risk', 'Threat'
+      ];
+
+      canonicalMappings = {};
+
+      OBJECT_TYPES.forEach(function (item) {
+        canonicalMappings[item] = {};
+      });
+    });
+
+    beforeEach(function () {
+      spyOn(mapper, 'get_forbidden').and.returnValue([]);
+      spyOn(mapper, 'get_whitelist').and.returnValue([]);
+      spyOn(GGRC.Mappings, 'get_canonical_mappings_for')
+        .and.returnValue(canonicalMappings);
+    });
+
+    it('excludes the References type from the result', function () {
+      var modelNames;
+
+      var result = mapper.types();
+
+      _.forOwn(result, function (groupInfo, groupName) {
+        if (groupName === 'all_objects') {
+          modelNames = groupInfo.models;
+        } else {
+          modelNames = _.map(groupInfo.items, 'title_singular');
+        }
+        expect(_.contains(modelNames, 'Reference')).toBe(false);
+      });
+    });
+  });
+});


### PR DESCRIPTION
NOTE: The Reference type is still available when defining object filters, it has only been removed from the "main" object type dropdown.