### PR TITLE
CORE-3624 Mapping a control to the Audit duplicates the control's title in the tree view

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
@@ -187,7 +187,7 @@ can.Control('CMS.Controllers.TreeLoader', {
     return this._display_deferred;
   },
 
-  draw_list: function (list, is_reload, force_prepare_chilren) {
+  draw_list: function (list, is_reload, force_prepare_children) {
     var that = this;
     var refresh_queue = new RefreshQueue();
     var sort_function;
@@ -226,7 +226,7 @@ can.Control('CMS.Controllers.TreeLoader', {
     temp_list = [];
     if (!is_reload) {
       list.each(function (v) {
-        var item = that.prepare_child_options(v, force_prepare_chilren);
+        var item = that.prepare_child_options(v, force_prepare_children);
         temp_list.push(item);
         if (!item.instance.selfLink) {
           refresh_queue.enqueue(v.instance);
@@ -264,7 +264,7 @@ can.Control('CMS.Controllers.TreeLoader', {
         return o;
       }
     });
-    this._draw_list_deferred = this.enqueue_items(temp_list, is_reload, force_prepare_chilren);
+    this._draw_list_deferred = this.enqueue_items(temp_list, is_reload, force_prepare_children);
     return this._draw_list_deferred;
   },
 
@@ -301,7 +301,7 @@ can.Control('CMS.Controllers.TreeLoader', {
     };
   },
 
-  enqueue_items: function (items, is_reload, force_prepare_chilren) {
+  enqueue_items: function (items, is_reload, force_prepare_children) {
     var child_tree_display_list = [];
     var filtered_items = [];
     var i;
@@ -366,18 +366,28 @@ can.Control('CMS.Controllers.TreeLoader', {
       refreshed_deferred = new $.Deferred().resolve();
     }
     refreshed_deferred.then(function () {
-      that.insert_items(filtered_items, force_prepare_chilren);
+      that.insert_items(filtered_items, force_prepare_children);
       that._ifNotRemoved(that._loading_finished).call(that);
     });
     return this._loading_deferred;
   },
 
-  insert_items: function (items, force_prepare_chilren) {
+  insert_items: function (items, force_prepare_children) {
     var that = this;
     var prepped_items = [];
+    var id_map = {};
+    var to_insert;
 
-    can.each(items, function (item) {
-      var prepped = that.prepare_child_options(item, force_prepare_chilren);
+    // Check the list of items to be inserted for any duplicate items.
+    can.each(this.options.list || [], function (item) {
+      id_map[item.instance.type + item.instance.id] = true;
+    });
+    to_insert = _.filter(items, function (item) {
+      return !id_map[item.instance.type + item.instance.id];
+    });
+
+    can.each(to_insert, function (item) {
+      var prepped = that.prepare_child_options(item, force_prepare_children);
       if (prepped.instance.selfLink) {
         prepped_items.push(prepped);
       }

--- a/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
@@ -374,28 +374,28 @@ can.Control('CMS.Controllers.TreeLoader', {
 
   insert_items: function (items, force_prepare_children) {
     var that = this;
-    var prepped_items = [];
-    var id_map = {};
-    var to_insert;
+    var preppedItems = [];
+    var idMap = {};
+    var toInsert;
 
     // Check the list of items to be inserted for any duplicate items.
     can.each(this.options.list || [], function (item) {
-      id_map[item.instance.type + item.instance.id] = true;
+      idMap[item.instance.type + item.instance.id] = true;
     });
-    to_insert = _.filter(items, function (item) {
-      return !id_map[item.instance.type + item.instance.id];
+    toInsert = _.filter(items, function (item) {
+      return !idMap[item.instance.type + item.instance.id];
     });
 
-    can.each(to_insert, function (item) {
+    can.each(toInsert, function (item) {
       var prepped = that.prepare_child_options(item, force_prepare_children);
       if (prepped.instance.selfLink) {
-        prepped_items.push(prepped);
+        preppedItems.push(prepped);
       }
     });
 
-    if (prepped_items.length > 0) {
-      this.options.list.push.apply(this.options.list, prepped_items);
-      this.add_child_lists(prepped_items);
+    if (preppedItems.length > 0) {
+      this.options.list.push.apply(this.options.list, preppedItems);
+      this.add_child_lists(preppedItems);
     }
   }
 });


### PR DESCRIPTION
The issue is caused by [enqueue_items](https://github.com/google/ggrc-core/blob/320985733edf31f3daf08e6cc2a2afd43d3b53fc/src/ggrc/assets/javascripts/controllers/tree_view_controller.js#L304) and then [insert_items](https://github.com/google/ggrc-core/blob/320985733edf31f3daf08e6cc2a2afd43d3b53fc/src/ggrc/assets/javascripts/controllers/tree_view_controller.js#L375) being triggered twice. The first happens when the mapper save queue [adds a new item](https://github.com/google/ggrc-core/blob/320985733edf31f3daf08e6cc2a2afd43d3b53fc/src/ggrc/assets/javascripts/controllers/tree_view_controller.js#L1002) to the original list and the second happens when the mapper modal [triggers a refresh](https://github.com/google/ggrc-core/blob/70953a2d810acc087a91ce4098136b14810b8b77/src/ggrc/assets/javascripts/components/unified_mapper/mapper.js#L216) on the tree view.

Normally the full refresh of the tree view happens after the first insert_items call and clears the list of items but when a control has at least 1 custom_attribute_value the controls custom attributes [are refreshed](https://github.com/google/ggrc-core/blob/320985733edf31f3daf08e6cc2a2afd43d3b53fc/src/ggrc/assets/javascripts/controllers/tree_view_controller.js#L352) which delays the first insert_items call until after the full refresh starts thus insert_items is called twice and the duplicate item is added to the list.

Once the tree view re-write is finished I'm guessing this manual tree view refresh will not be needed so the easiest solution for now is to check for duplicates when the new items are added to the tree view.