### PR TITLE
CORE-3635 Fix assessment generation redirect

### DIFF
--- a/src/ggrc/assets/javascripts/bootstrap/modal-form.js
+++ b/src/ggrc/assets/javascripts/bootstrap/modal-form.js
@@ -313,7 +313,7 @@
       }
     });
 
-    $('body').on('ajax:flash', function (e, flash) {
+    $('body').on('ajax:flash', function (e, flash, redirectLink) {
       var $target;
       var $flashHolder;
       var type;
@@ -378,6 +378,10 @@
                 $html.removeClass('alert-autohide');
                 $link = $('<a href="javascript://">Show results</a>');
                 $link.on('click', function () {
+                  if (redirectLink) {
+                    $('html').addClass('no-js');
+                    window.location.href = redirectLink;
+                  }
                   window.location.reload();
                 });
                 $html.append($link);

--- a/src/ggrc/assets/javascripts/components/assessment_generator.js
+++ b/src/ggrc/assets/javascripts/components/assessment_generator.js
@@ -41,6 +41,7 @@
       showFlash: function (statuses) {
         var flash = {};
         var type;
+        var redirectLink;
         var messages = {
           error: 'Assessment generation has failed.',
           progress: 'Assessment generation is in process. This may take ' +
@@ -53,10 +54,11 @@
           type = 'progress';
         } else {
           type = 'success';
+          redirectLink = window.location.pathname + '#assessment_widget';
         }
 
         flash[type] = messages[type];
-        $('body').trigger('ajax:flash', flash);
+        $('body').trigger('ajax:flash', [flash, redirectLink]);
       },
       updateStatus: function (ids, count) {
         var wait = [2, 4, 8, 16, 32, 64];


### PR DESCRIPTION
The app doesn't redirect user to the assessments tab after generating assessments from controls tab on audit page. 

Steps:
- create a program and map a control to the program
- create an audit under the program and navigate to the audit page
- go to Controls tab on audit page
- click magic wand icon and generate the assessment
- click "See results" when the assessment is generated

*Actual Result:* the app shows controls tab instead of redirecting you to Assessments tab after the click

*Expected Result:* the app should redirect you to Assessments tab after the click

