### PR TITLE
CORE-3062 Remove "No Access" requirement for unmapping people from programs

### DIFF
--- a/src/ggrc_basic_permissions/assets/mustache/ggrc_basic_permissions/people_roles/info.mustache
+++ b/src/ggrc_basic_permissions/assets/mustache/ggrc_basic_permissions/people_roles/info.mustache
@@ -40,7 +40,6 @@
         {{#with_program_roles_as "roles" result}}
           {{#if_helpers '\
             #if_equals' roles.length 1 '\
-            and #if_equals' roles.0.role.permission_summary "Mapped" '\
             and #if' result.mappings '\
             and #is_allowed_all' 'delete' result.mappings}}
             <li class="border">

--- a/src/ggrc_basic_permissions/assets/mustache/ggrc_basic_permissions/people_roles/info.mustache
+++ b/src/ggrc_basic_permissions/assets/mustache/ggrc_basic_permissions/people_roles/info.mustache
@@ -38,17 +38,17 @@
           <clipboard-link title="Get permalink" notify="true" text="{{get_permalink_for_object instance}}" />
         </li>
         {{#with_program_roles_as "roles" result}}
-          {{#if_helpers '\
-            #if' result.mappings '\
-            and #is_allowed_all' 'delete' result.mappings}}
-            <li class="border">
-              <a href="javascript://" class="unmap" data-toggle="unmap">
-                {{#result}}<span class="result" {{data 'result'}}></span>{{/result}}
-                <i class="fa fa-ban"></i>
-                Unmap
-              </a>
-            </li>
-          {{/if_helpers}}
+          {{#if result.mappings}}
+            {{#is_allowed_all 'delete' result.mappings}}
+              <li class="border">
+                <a href="javascript://" class="unmap" data-toggle="unmap">
+                  {{#result}}<span class="result" {{data 'result'}}></span>{{/result}}
+                  <i class="fa fa-ban"></i>
+                  Unmap
+                </a>
+              </li>
+            {{/is_allowed_all}}
+          {{/result.mappings}}
         {{/with_program_roles_as}}
         <li>
           <a href="/people/{{instance.id}}">

--- a/src/ggrc_basic_permissions/assets/mustache/ggrc_basic_permissions/people_roles/info.mustache
+++ b/src/ggrc_basic_permissions/assets/mustache/ggrc_basic_permissions/people_roles/info.mustache
@@ -39,8 +39,7 @@
         </li>
         {{#with_program_roles_as "roles" result}}
           {{#if_helpers '\
-            #if_equals' roles.length 1 '\
-            and #if' result.mappings '\
+            #if' result.mappings '\
             and #is_allowed_all' 'delete' result.mappings}}
             <li class="border">
               <a href="javascript://" class="unmap" data-toggle="unmap">


### PR DESCRIPTION
Previously you needed to edit authorizations and change it to "No Access" for any user. This is now no longer required.

@Smotko Do you know of any reasons why this was needed? Per my testing it didn't cause issues. Even if you unmap all managers, admin can still visit program and promote someone to a manager.