### PR TITLE
QUICK-FIX Fix js error while selecting object on New Assessment modal

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/modals_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/modals_controller.js
@@ -139,7 +139,9 @@ can.Control('GGRC.Controllers.Modals', {
       return current;
     }, '_transient');
 
-    instance.attr(['_transient'].concat(name).join('.'), value);
+    if (name.length) {
+      instance.attr(['_transient'].concat(name).join('.'), value);
+    }
   },
 
   autocomplete: function (el) {


### PR DESCRIPTION
**Subject**: "Uncaught can.Map: Object does not exist" error is displayed while selecting object on New Assessment modal window
**Description**:
Create a program.
Create an audit for that program.
Navigate to newly created audit and display Assessments tab.
Display browser's console.
*Note:* Next 2 steps should be performed quickly WHILE CREATING the Assessment.
You need to enter a value in the new assessor input  for the contextual search and select the user as assessor.
Click into Object field and select any object.
**Actual Result:** "Uncaught can.Map: Object does not exist" error is displayed while selecting object on New Assessment modal window
**Expected Result:** No errors displayed
**Workaround:** Wait before step 6.
