### PR TITLE
QUICK-FIX Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/doc/developer_guide.md
+++ b/doc/developer_guide.md
@@ -171,7 +171,7 @@ Full text search is enabled for certain models. It is enabled by a class attribu
 
 #### Database Migrations
 
-Migrations are implemented and executed via [alembic](http://alembic.readthedocs.org/en/latest/), augmented to support extension modules in ggrc.migrate.  (The standard `alembic` command will *not* do the right thing.)
+Migrations are implemented and executed via [alembic](http://alembic.zzzcomputing.com/en/latest/), augmented to support extension modules in ggrc.migrate.  (The standard `alembic` command will *not* do the right thing.)
 
 Migration scripts are written in Python and live in [`src/<module>/migrations/versions`](/src/ggrc/migrations/versions).
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.