### PR TITLE
CORE-3693 Fix import CSV error

### DIFF
--- a/src/ggrc/converters/base_block.py
+++ b/src/ggrc/converters/base_block.py
@@ -259,7 +259,6 @@ class BlockConverter(object):
       for row_converter in self.row_converters:
         try:
           row_converter.insert_secondary_objects()
-          db.session.flush()
         except exc.SQLAlchemyError as err:
           db.session.rollback()
           current_app.logger.error(

--- a/src/ggrc/converters/base_block.py
+++ b/src/ggrc/converters/base_block.py
@@ -214,13 +214,13 @@ class BlockConverter(object):
       row_converter.handle_row_data(field_list)
     if field_list is None:
       self.check_mandatory_fields()
-      self.check_uniq_columns()
+      self.check_unique_columns()
 
   def check_mandatory_fields(self):
     for row_converter in self.row_converters:
-      row_converter.chect_mandatory_fields()
+      row_converter.check_mandatory_fields()
 
-  def check_uniq_columns(self, counts=None):
+  def check_unique_columns(self, counts=None):
     self.generate_unique_counts()
     for key, counts in self.unique_counts.items():
       self.remove_duplicate_keys(key, counts)

--- a/src/ggrc/converters/base_row.py
+++ b/src/ggrc/converters/base_row.py
@@ -87,7 +87,7 @@ class RowConverter(object):
     else:
       self.handle_csv_row_data(field_list)
 
-  def chect_mandatory_fields(self):
+  def check_mandatory_fields(self):
     if not self.is_new or self.is_delete:
       return
     headers = self.block_converter.object_headers

--- a/src/ggrc/converters/base_row.py
+++ b/src/ggrc/converters/base_row.py
@@ -213,7 +213,7 @@ class RowConverter(object):
     for handler in self.attrs.values():
       handler.insert_object()
 
-  def insert_secondary_objecs(self):
+  def insert_secondary_objects(self):
     """Add additional objects to the current database session.
 
     This is used for adding any extra created objects such as Relationships, to

--- a/src/ggrc/converters/handlers/handlers.py
+++ b/src/ggrc/converters/handlers/handlers.py
@@ -620,6 +620,7 @@ class ObjectPersonColumnHandler(UserColumnHandler):
           context=self.row_converter.obj.context
       )
       db.session.add(object_person)
+      db.session.flush()
     self.dry_run = True
 
 

--- a/test/integration/ggrc/converters/test_csvs/duplicate_object_person.csv
+++ b/test/integration/ggrc/converters/test_csvs/duplicate_object_person.csv
@@ -1,0 +1,4 @@
+Object type,,,,,,,,
+Program,Code*,Title*,No Access,Manager,map:person,editor,reader
+,p1,p 2,user@example.com,user@example.com,user@example.com,,
+,p2,p 1,user@example.com,user@example.com,user@example.com,,

--- a/test/integration/ggrc/converters/test_csvs/duplicate_object_person_objective_error.csv
+++ b/test/integration/ggrc/converters/test_csvs/duplicate_object_person_objective_error.csv
@@ -1,0 +1,4 @@
+Object type,,,,,,,,
+Program,Code*,Title*,No Access,Manager,map:objective,map:person,editor,reader
+,p1,p 2,user@example.com,user@example.com,,user@example.com,,
+,p2,p 1,user@example.com,user@example.com,objective1,user@example.com,,

--- a/test/integration/ggrc/converters/test_import_csv.py
+++ b/test/integration/ggrc/converters/test_import_csv.py
@@ -171,8 +171,16 @@ class TestBasicCsvImport(converters.TestCase):
 
   def test_duplicate_people(self):
     """Test adding two of the same object people objects in the same row."""
-    self.generator.generate_object(models.Objective, {"slug": "objective1"})
     filename = "duplicate_object_person.csv"
+    response = self.import_file(filename)[0]
+
+    self.assertEqual(0, len(response["row_warnings"]))
+    self.assertEqual(0, len(response["row_errors"]))
+
+  def test_duplicate_people_objective_error(self):
+    """Test duplicate error that causes request to fail."""
+    self.generator.generate_object(models.Objective, {"slug": "objective1"})
+    filename = "duplicate_object_person_objective_error.csv"
     response = self.import_file(filename)[0]
 
     self.assertEqual(0, len(response["row_warnings"]))

--- a/test/integration/ggrc/converters/test_import_csv.py
+++ b/test/integration/ggrc/converters/test_import_csv.py
@@ -168,3 +168,12 @@ class TestBasicCsvImport(converters.TestCase):
 
     self.assertEqual(expected_errors, set(response["row_errors"]))
     self.assertEqual(0, models.Person.query.filter_by(email=None).count())
+
+  def test_duplicate_people(self):
+    """Test adding two of the same object people objects in the same row."""
+    self.generator.generate_object(models.Objective, {"slug": "objective1"})
+    filename = "duplicate_object_person.csv"
+    response = self.import_file(filename)[0]
+
+    self.assertEqual(0, len(response["row_warnings"]))
+    self.assertEqual(0, len(response["row_errors"]))


### PR DESCRIPTION
Two ObjectPerson objects were being created in the same row converter and the session wasn't being flush in-between which resulted in an integrity error.

I resized the original test file to make testing the error easier. See the Jira ticket to get the smaller file.