### PR TITLE
QUICK-FIX Fix expand control visibility

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/info_pin_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/info_pin_controller.js
@@ -121,6 +121,10 @@ can.Control('CMS.Controllers.InfoPin', {
     $header = $('.tree-header:visible');
     $filter = $('.tree-filter:visible');
 
+    if (_.isEmpty(el) || _.isEmpty($header)) {
+      return;
+    }
+
     elTop = el.offset().top;
     elBottom = elTop + el.height();
 

--- a/src/ggrc/assets/javascripts/controllers/info_pin_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/info_pin_controller.js
@@ -107,23 +107,33 @@ can.Control('CMS.Controllers.InfoPin', {
     }
   },
   ensureElementVisible: function (el) {
-    var $objectArea = $('.object-area');
-    var $header = $('.tree-header:visible');
-    var $filter = $('.tree-filter:visible');
-    var elTop = el.offset().top;
-    var elBottom = elTop + el.height();
-    var headerTop = $header.length ? $header.offset().top : 0;
-    var headerBottom = headerTop + $header.height();
-    var infoTop = this.element.offset().top;
+    var $objectArea;
+    var $header;
+    var $filter;
+    var elTop;
+    var elBottom;
+    var headerTop;
+    var headerBottom;
+    var infoTop;
 
     $(window).trigger('resize');
+    $objectArea = $('.object-area');
+    $header = $('.tree-header:visible');
+    $filter = $('.tree-filter:visible');
+
+    elTop = el.offset().top;
+    elBottom = elTop + el.height();
+
+    headerTop = $header.offset().top;
+    headerBottom = headerTop + $header.height();
+    infoTop = this.element.offset().top;
 
     if (elTop < headerBottom || elBottom > infoTop) {
       el[0].scrollIntoView(false);
       if (elTop < headerBottom) {
         el[0].scrollIntoView(true);
-        $objectArea.scrollTop($objectArea.scrollTop() - $header.height() -
-          $filter.height());
+        $objectArea.scrollTop(
+          $objectArea.scrollTop() - $header.height() - $filter.height());
       } else {
         el[0].scrollIntoView(false);
       }


### PR DESCRIPTION
Add check if element and header are present

In hard-to-reproduce and quite rare cases (but quite often encountered when editing files) header is not present when executing `ensureElementVisible` on page load, in which case there is an error thrown:

````
"cannot access top of undefined” on headerTop = $header.offset().top 
````
call. After that error infopin expansion dies.

This silently ignores that and just skips the execution on page load (no noticeable issues with that) while still allowing info pin expansion for later use.