### PR TITLE
CORE-3705 Improve related objects permission query

### DIFF
--- a/test/integration/ggrc_basic_permissions/test_creator_audit.py
+++ b/test/integration/ggrc_basic_permissions/test_creator_audit.py
@@ -50,8 +50,8 @@ class TestCreatorAudit(TestCase):
                 },
                 "mapped_Assessment": {
                     "get": 200,
-                    "put": 200,
-                    "delete": 200
+                    "put": 403,
+                    "delete": 403
                 },
                 "unrelated_Assessment": {
                     "get": 403,


### PR DESCRIPTION
Instead of querying all the contexts based on roles and implications we
use the context data we have already fetched and stored in the
permissions object.

The new query propagates permissions of the current object context to
all the objects mapped via the relationships table.

The only side effect of this is that the Auditor role which used to
have read permission on all the mapped objects and update/delete
permission on assessments, requests, issues no longer automatically
have update/delete permissions because their audit context scope is
read only.

I have discussed this use case with prasanna & akhil and they agreed
that is an acceptable compromise for better performance. Auditor can
still get update/delete permissions by becoming assignees/verifiers.

Note: I still need to remove the `program_relationship_query` function,
but because it's used inside `fulltext/mysql.py` I'll remove this in a
separate pull request.