### PR TITLE
QUICK-FIX Remove html tags from flash messages

### DIFF
--- a/src/ggrc/assets/javascripts/components/csv/export.js
+++ b/src/ggrc/assets/javascripts/components/csv/export.js
@@ -86,7 +86,9 @@
           GGRC.Utils.download("import_template.csv", data);
         }.bind(this))
         .fail(function (data) {
-          $("body").trigger("ajax:flash", {"error": data.responseText.split("\n")[3]});
+          $("body").trigger("ajax:flash", {
+            "error": $(data.responseText.split("\n")[3]).text()
+          });
         }.bind(this));
       },
       ".import-list a click": function (el, ev) {
@@ -167,7 +169,9 @@
           GGRC.Utils.download(this.scope.attr("export.get_filename"), data);
         }.bind(this))
         .fail(function (data) {
-          $("body").trigger("ajax:flash", {"error": data.responseText.split("\n")[3]});
+          $("body").trigger("ajax:flash", {
+            "error": $(data.responseText.split("\n")[3]).text()
+          });
         }.bind(this))
         .always(function () {
           this.scope.attr("export.loading", false);

--- a/src/ggrc/assets/javascripts/components/csv/import.js
+++ b/src/ggrc/assets/javascripts/components/csv/import.js
@@ -63,7 +63,9 @@
         }.bind(this))
         .fail(function (data) {
           this.scope.attr("state", "select");
-          $("body").trigger("ajax:flash", {"error": data.responseText.split("\n")[3]});
+          $("body").trigger("ajax:flash", {
+            "error": $(data.responseText.split("\n")[3]).text()
+          });
         }.bind(this))
         .always(function () {
           this.scope.attr("isLoading", false);
@@ -113,7 +115,9 @@
         }.bind(this))
         .fail(function (data) {
           this.scope.attr("state", "select");
-          $("body").trigger("ajax:flash", {"error": data.responseText.split("\n")[3]});
+          $("body").trigger("ajax:flash", {
+            "error": $(data.responseText.split("\n")[3]).text()
+          });
         }.bind(this))
         .always(function () {
           this.scope.attr("isLoading", false);


### PR DESCRIPTION
The flash errors and warnings have their own formatting and should only
display clear text.

To reproduce this, just try to import a jpeg file and look at the flash message.