### PR TITLE
QUICK-FIX Assessment is not shown up after creation on audit page

### DIFF
--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -948,6 +948,7 @@
     },
     after_save: function () {
       this._set_mandatory_msgs();
+      this.audit.refresh();
     },
     _set_mandatory_msgs: function () {
       var instance = this;


### PR DESCRIPTION
**Details**: 
Create a program with audit 
Navigate to audit page and create an assessment 

*Actual Result:* Tree view doesn’t show created assessment on Assessments tab on audit page. Page refresh is needed.
*Expected Result:* Assessment should be shown on Assessments tab on audit page without page refresh.
