### PR TITLE
QUICK-FIX Fix js error map assessment template modal

### DIFF
--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -248,6 +248,7 @@ dashboard-js-template-files:
   - assessment_templates/attribute_add_field.mustache
   - assessment_templates/modal_content.mustache
   - assessment_templates/info.mustache
+  - assessment_templates/tier2_content.mustache
   - assessments/related_issues.mustache
   - assessments/related_requests.mustache
   - issues/modal_content.mustache

--- a/src/ggrc/assets/javascripts/models/cacheable.js
+++ b/src/ggrc/assets/javascripts/models/cacheable.js
@@ -1438,7 +1438,7 @@ can.Observe.List.prototype.stubs = function() {
   return new can.Observe.List(can.map(this, function(obj) {
     return obj.stub();
   }));
-}
+};
 
 can.Observe.prototype.reify = function() {
   var type, model;
@@ -1455,8 +1455,9 @@ can.Observe.prototype.reify = function() {
 
   if (!model) {
     console.debug("`reify()` called with unrecognized type", this);
+  } else {
+    return model.model(this);
   }
-  return model.model(this);
 };
 
 can.Observe.List.prototype.reify = function() {

--- a/src/ggrc/assets/mustache/assessment_templates/tier2_content.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/tier2_content.mustache
@@ -1,0 +1,13 @@
+{{!
+    Copyright (C) 2016 Google Inc.
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+}}
+
+{{> /static/mustache/base_objects/dropdown_menu_tier2.mustache}}
+
+<div class="tier-content">
+  {{{render '/static/mustache/base_objects/general_info.mustache' instance=instance }}}
+  {{{render '/static/mustache/base_objects/mappings_detail.mustache' result=result parent_instance=parent_instance}}}
+  {{{render '/static/mustache/base_objects/urls.mustache' instance=instance}}}
+  {{{render '/static/mustache/base_objects/notes_and_code.mustache' instance=instance}}}
+</div>


### PR DESCRIPTION
**Subject**: Script error “Uncaught TypeError: Cannot read property 'model' of undefined” appears after a try to open assessment template’s 2nd tier on mapping window
**Details**: 
Create a program with an audit
Navigate to audit page → assessment templates tab
Click (+) button in the top of the content area
Click a triangle in one the found assessment templates’ 1st tier
**Actual result**: the script error “Uncaught TypeError: Cannot read property 'model' of undefined” appears 
**Expected result**:  no errors!