### PR TITLE
QUICK-FIX Fix Save & Add Another button

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/modals_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/modals_controller.js
@@ -865,7 +865,7 @@ can.Control('GGRC.Controllers.Modals', {
           var $form = $(this.element).find('form');
           $form.trigger('reset');
         });
-      })
+      }.bind(this))
       .then(this.proxy("apply_object_params"))
       .then(this.proxy("serialize_form"))
       .then(this.proxy("autocomplete"));


### PR DESCRIPTION
**Subject**: Script error “Uncaught TypeError: Cannot read property 'model' of undefined” appears after a try to open assessment template’s 2nd tier on mapping window
**Details**: 
Create a program with an audit
Navigate to audit page → assessment templates tab
Click (+) button in the top of the content area
Click a triangle in one the found assessment templates’ 1st tier
**Actual result**: the script error “Uncaught TypeError: Cannot read property 'model' of undefined” appears 
**Expected result**:  no errors!