### PR TITLE
QUICK-FIX Fix people list in admin panel

### DIFF
--- a/src/ggrc/assets/javascripts/application.js
+++ b/src/ggrc/assets/javascripts/application.js
@@ -140,7 +140,7 @@
         $('.header-content').next('.content').removeClass('affixed');
       }
     });
-    $body.on('click', 'ul.tree-structure .item-main .grcobject, ul.tree-structure .item-main .openclose .fa-caret-right', function (evnt) {
+    $body.on('click', 'ul.tree-structure .item-main .grcobject, ul.tree-structure .item-main .openclose', function (evnt) {
       evnt.stopPropagation();
       $(this).openclose();
     });

--- a/src/ggrc/assets/javascripts/apps/dashboard.js
+++ b/src/ggrc/assets/javascripts/apps/dashboard.js
@@ -59,6 +59,7 @@
         // includes only the filter, not the column headers
         '/static/mustache/people/filters.mustache',
       list_view: '/static/mustache/people/object_list.mustache',
+      draw_children: true,
       fetch_post_process: sortByNameEmail
     },
     roles: {

--- a/src/ggrc/assets/stylesheets/modules/_tree-content.scss
+++ b/src/ggrc/assets/stylesheets/modules/_tree-content.scss
@@ -25,7 +25,6 @@ ul.new-tree {
       }
     }
     .fa-caret-right {
-      cursor: pointer;
       display: inline-block;
       width: 20px;
       @include opacity(0.25);
@@ -44,6 +43,7 @@ ul.new-tree {
   }
   .openclose {
     width: 55px;
+    cursor: pointer;
     &__empty {
       width: 35px;
     }


### PR DESCRIPTION
This fixes the blocker issue on admin dashboard and I have also made a quick ninja UX improvement to restore the click area to the whole `.openclose` element. The caret icon was way too narrow to comfortably click and it would frustrate users.