### PR TITLE
QUICK-FIX Stop request spam from people list

### DIFF
--- a/src/ggrc/assets/javascripts/components/people_list.js
+++ b/src/ggrc/assets/javascripts/components/people_list.js
@@ -32,12 +32,22 @@
       list_pending: [],
       list_mapped: [],
       computed_mapping: false,
+      /**
+        * Get pending joins for current instance
+        *
+        * @return {Array} - the list of current pending joins
+        */
       get_pending: function () {
         if (!this.attr('deferred')) {
           return [];
         }
         return this.attr('instance._pending_joins');
       },
+      /**
+        * Get people mapped to this instance
+        *
+        * @return {Array} - the list of current mapped people
+        */
       get_mapped: function () {
         // We call get_mapping only once because canjs events can get caught in a loop
         // computed_mapping needs to be in scope so its separated from other people lists
@@ -48,6 +58,15 @@
         }
         return this.attr('list_mapped');
       },
+      /**
+        * Remove a person's role from current pending joins list
+        *
+        * Removes the role that is stated in `this.type`
+        *
+        * @param {Person} person - a person whose role should be removed
+        *
+        * @return {Array} - a new pending joins list
+        */
       remove_pending: function (person) {
         var results = this.attr('results');
         var list = this.attr('list_pending');
@@ -75,6 +94,15 @@
         index = _.findIndex(list, findInList);
         return list.splice(index, 1);
       },
+      /**
+        * Remove a role assignment from a person
+        *
+        * Called with a role removal button
+        *
+        * @param {Object} parentScope - current page context
+        * @param {jQuery.Object} el - clicked element
+        * @param {Object} ev - click event handler
+        */
       remove_role: function (parentScope, el, ev) {
         var person = CMS.Models.Person.findInCacheById(el.data('person'));
         var instance = this.instance;
@@ -116,6 +144,14 @@
           }
         });
       },
+      /**
+        * Get saved roles list for a person
+        *
+        * @param {Person} person - the person whose roles to get
+        * @param {Object} instance - the object to which the person is assigned
+        *
+        * @return {jQuery.Deferred} - a promise with the role list
+        */
       get_roles: function (person, instance) {
         var rel = function (obj) {
           return _.map(_.union(obj.related_sources, obj.related_destinations),

--- a/src/ggrc/assets/javascripts/components/people_list.js
+++ b/src/ggrc/assets/javascripts/components/people_list.js
@@ -31,6 +31,7 @@
       results: [],
       list_pending: [],
       list_mapped: [],
+      computed_mapping: false,
       get_pending: function () {
         if (!this.attr('deferred')) {
           return [];
@@ -38,14 +39,22 @@
         return this.attr('instance._pending_joins');
       },
       get_mapped: function () {
-        return this.attr('instance').get_mapping(this.attr('mapping'));
+        // We call get_mapping only once because canjs events can get caught in a loop
+        // computed_mapping needs to be in scope so its separated from other people lists
+        if (!this.computed_mapping) {
+          this.attr('list_mapped',
+                    this.attr('instance').get_mapping(this.attr('mapping')));
+          this.computed_mapping = true;
+        }
+        return this.attr('list_mapped');
       },
       remove_pending: function (person) {
         var results = this.attr('results');
         var list = this.attr('list_pending');
         var listPerson = _.find(list, findInList);
         var personRoles = can.getObject('extra.attrs.AssigneeType',
-          listPerson).split(',');
+                                        listPerson)
+                             .split(',');
         var type = this.type;
         var index;
 
@@ -68,55 +77,74 @@
       },
       remove_role: function (parentScope, el, ev) {
         var person = CMS.Models.Person.findInCacheById(el.data('person'));
+        var instance = this.instance;
+        var type = this.attr('type');
+        var that = this;
+
+        this.get_roles(person, instance).then(function (result) {
+          var roles = result.roles;
+          var ids = result.ids;
+          var rel = result.relationship;
+
+          if (!ids.length && that.attr('deferred')) {
+            return that.remove_pending(person);
+          }
+
+          roles = _.filter(roles, function (role) {
+            return role && (role.toLowerCase() !== type);
+          });
+
+          if (that.attr('deferred') === 'true') {
+            el.closest('li').remove();
+            if (!roles.length) {
+              instance.mark_for_deletion('related_objects_as_destination',
+                person);
+            } else {
+              instance.mark_for_change('related_objects_as_destination',
+                person, {
+                  attrs: {
+                    AssigneeType: roles.join(',')
+                  }
+                }
+              );
+            }
+          } else if (roles.length) {
+            rel.attrs.attr('AssigneeType', roles.join(','));
+            rel.save();
+          } else {
+            rel.destroy();
+          }
+        });
+      },
+      get_roles: function (person, instance) {
         var rel = function (obj) {
           return _.map(_.union(obj.related_sources, obj.related_destinations),
             function (relationship) {
               return relationship.id;
-            }
-          );
+            });
         };
-        var instance = this.instance;
-        var ids = _.intersection(rel(person), rel(this.instance));
-        var type = this.attr('type');
-
-        if (!ids.length && this.attr('deferred')) {
-          return this.remove_pending(person);
-        }
+        var rolesDfd = $.Deferred();
+        var ids = _.intersection(rel(person), rel(instance));
+        var found = false;
         _.each(ids, function (id) {
           var rel = CMS.Models.Relationship.findInCacheById(id);
-          if (rel.attrs && rel.attrs.AssigneeType) {
+          if (rel && rel.attrs && rel.attrs.AssigneeType) {
+            found = true;
             rel.refresh().then(function (rel) {
               var roles = rel.attrs.AssigneeType.split(',');
-              roles = _.filter(roles, function (role) {
-                return role && (role.toLowerCase() !== type);
-              });
-              if (this.attr('deferred') === 'true') {
-                el.closest('li').remove();
-                if (roles.length) {
-                  instance.mark_for_deletion('related_objects_as_destination',
-                    person);
-                } else {
-                  instance.mark_for_change('related_objects_as_destination',
-                    person, {
-                      attrs: {
-                        AssigneeType: roles.join(',')
-                      }
-                    }
-                  );
-                }
-              } else if (roles.length) {
-                rel.attrs.attr('AssigneeType', roles.join(','));
-                rel.save().then(function () {
-                  return instance.refresh();
-                });
-              } else {
-                rel.destroy().then(function () {
-                  return instance.refresh();
-                });
-              }
-            }.bind(this));
+              var result = {roles: roles,
+                            relationship: rel,
+                            ids: ids};
+              rolesDfd.resolve(result);
+            });
           }
-        }, this);
+        });
+        // If the person has no assigneeType relationshipAttr for this instance
+        // then he has no roles
+        if (!found) {
+          rolesDfd.resolve({roles: [], ids: ids});
+        }
+        return rolesDfd;
       }
     },
     events: {
@@ -202,14 +230,31 @@
               }
             });
           }
+          // If user already has a role then we change relationshipattr else
+          // we add it.
           if (pending) {
-            instance.mark_for_addition('related_objects_as_destination',
-              person, {
-                attrs: {
-                  AssigneeType: role
-                },
-                context: instance.context
-              });
+            this.scope.get_roles(person, instance).then(function (result) {
+              var roles = result.roles || [];
+              if (roles.length) {
+                roles.push(role);
+                instance.mark_for_change('related_objects_as_destination',
+                    person, {
+                      attrs: {
+                        AssigneeType: roles.join(',')
+                      },
+                      context: instance.context
+                    }
+                  );
+              } else {
+                instance.mark_for_addition('related_objects_as_destination',
+                  person, {
+                    attrs: {
+                      AssigneeType: role
+                    },
+                    context: instance.context
+                  });
+              }
+            });
           }
         } else {
           model = CMS.Models.Relationship.get_relationship(person, instance);

--- a/src/ggrc/assets/javascripts/models/cacheable.js
+++ b/src/ggrc/assets/javascripts/models/cacheable.js
@@ -404,7 +404,10 @@ can.Model("can.Model.Cacheable", {
           if(pj.how === "add") {
             //Don't re-add -- if the object is already mapped (could be direct or through a proxy)
             // move on to the next one
-            if(~can.inArray(pj.what, can.map(binding.list, function(bo) { return bo.instance; }))
+            // Note: if it is marked as 'change' then you must add it regardless if it exists because it will
+            // be deleted.
+            var changed = pj.opts && pj.opts.change;
+            if(!changed && ~can.inArray(pj.what, can.map(binding.list, function(bo) { return bo.instance; }))
                || (binding.loader.option_attr
                   && ~can.inArray(
                     pj.what
@@ -437,10 +440,13 @@ can.Model("can.Model.Cacheable", {
               })
             );
           } else if(pj.how === "remove") {
+
             can.map(binding.list, function(bound_obj) {
               if(bound_obj.instance === pj.what || bound_obj.instance[binding.loader.option_attr] === pj.what) {
                 can.each(bound_obj.get_mappings(), function(mapping) {
-                  dfds.push(mapping.refresh().then(function() { mapping.destroy(); }));
+                  dfds.push(mapping.refresh().then(function() {
+                    mapping.destroy();
+                  }));
                 });
               }
             });


### PR DESCRIPTION
Steps to reproduce:
- create an assessment, add some users as creators, assessors and verifiers
- open a modal to edit this assessment
- open Network tab in developer tools
- add a user as a creator, verifier or assignee
- remove one of the creators, verifiers or assignees
(possibly you need to continue adding and deleting people until the bug takes effect)

Bug behavior: the application starts sending requests on `api/people?id__in=...` for every person present in people lists in a loop, redrawing every people list several times a second.

This fix adds a way to break the `update list_mapped` - `callback on list_mapped update` - `update list_mapped` loop.