### PR TITLE
QUICK-FIX fix people list saving after change

### DIFF
--- a/src/ggrc/assets/javascripts/components/people_list.js
+++ b/src/ggrc/assets/javascripts/components/people_list.js
@@ -104,6 +104,22 @@
         * @param {Object} ev - click event handler
         */
       remove_role: function (parentScope, el, ev) {
+        /* FIXME: The current implementation does not do role reassignment
+         * correctly.
+         *
+         * What needs to happen is we need to look at the diff between the
+         * previous state and the new state and send the requests for each user
+         * (=relationship) based on the following rules:
+         *
+         * For each of user (= each relationship objects) we need to do the
+         * following check:
+         * 1. If the user did not have any roles before the edit, but now has
+         * at least one role, we need to send a POST request
+         * 2. If the user had roles, but the roles have now changed, we need to
+         * send a PUT request
+         * 3. If the user had roles, but now doesn't have them anymore, we need
+         * to send a DELETE request
+         */
         var person = CMS.Models.Person.findInCacheById(el.data('person'));
         var instance = this.instance;
         var type = this.attr('type');

--- a/src/ggrc/assets/javascripts/models/cacheable.js
+++ b/src/ggrc/assets/javascripts/models/cacheable.js
@@ -404,7 +404,7 @@ can.Model("can.Model.Cacheable", {
           var inst
           , binding = obj.get_binding(pj.through)
           , model = CMS.Models[binding.loader.model_name] || GGRC.Models[binding.loader.model_name];
-          // changed iff mark_for_change was called
+          // changed means that mark_for_change was called
           var changed = pj.opts && pj.opts.change;
           if(pj.how === "add") {
             //Don't re-add -- if the object is already mapped (could be direct or through a proxy)

--- a/src/ggrc/assets/javascripts/models/cacheable.js
+++ b/src/ggrc/assets/javascripts/models/cacheable.js
@@ -388,7 +388,10 @@ can.Model("can.Model.Cacheable", {
     }
   }
   , resolve_deferred_bindings : function(obj) {
-    var _pjs, refresh_dfds = [], dfds = [];
+    var _pjs;
+    var refresh_dfds = [];
+    var dfds = [];
+    var dfds_apply;
     if (obj._pending_joins && obj._pending_joins.length) {
       _pjs = obj._pending_joins.slice(0); //refresh of bindings later will muck up the pending joins on the object
       can.each(can.unique(can.map(_pjs, function(pj) { return pj.through; })), function(binding) {
@@ -401,12 +404,13 @@ can.Model("can.Model.Cacheable", {
           var inst
           , binding = obj.get_binding(pj.through)
           , model = CMS.Models[binding.loader.model_name] || GGRC.Models[binding.loader.model_name];
+          // changed iff mark_for_change was called
+          var changed = pj.opts && pj.opts.change;
           if(pj.how === "add") {
             //Don't re-add -- if the object is already mapped (could be direct or through a proxy)
             // move on to the next one
             // Note: if it is marked as 'change' then you must add it regardless if it exists because it will
             // be deleted.
-            var changed = pj.opts && pj.opts.change;
             if(!changed && ~can.inArray(pj.what, can.map(binding.list, function(bo) { return bo.instance; }))
                || (binding.loader.option_attr
                   && ~can.inArray(
@@ -418,6 +422,11 @@ can.Model("can.Model.Cacheable", {
                   )
             )) {
               return;
+            }
+            // make sure the `changed` flag gets posted to the backend
+            // as it matters
+            if (changed) {
+              pj.attr('extra.changed', true);
             }
             inst = pj.what instanceof model
               ? pj.what
@@ -445,7 +454,11 @@ can.Model("can.Model.Cacheable", {
               if(bound_obj.instance === pj.what || bound_obj.instance[binding.loader.option_attr] === pj.what) {
                 can.each(bound_obj.get_mappings(), function(mapping) {
                   dfds.push(mapping.refresh().then(function() {
-                    mapping.destroy();
+                    if (changed) {
+                      mapping.destroyed();
+                    } else {
+                      mapping.destroy();
+                    }
                   }));
                 });
               }
@@ -453,9 +466,12 @@ can.Model("can.Model.Cacheable", {
           }
         });
 
+        dfds_apply = $.when.apply($, dfds);
+
         obj.attr('_pending_joins', []);
-        obj.attr('_pending_joins_dfd', $.when.apply($, dfds));
-        return $.when.apply($, dfds).then(function() {
+        obj.attr('_pending_joins_dfd', dfds_apply);
+
+        return dfds_apply.then(function() {
           can.trigger(this, "resolved");
           return obj.refresh();
         });

--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -1102,6 +1102,15 @@ class Resource(ModelView):
             msg.endswith("'uq_relationships'")):
       db.session.rollback()
       if src.get('changed'):
+        # Note: this is a dirty hack to make the requests currently sent by the
+        # frontend work. Two requests are sent if we need to update a person's
+        # assigned roles: one to delete the old assignment, another to create a
+        # new assignment with a new set of roles. As they are sent
+        # concurrently, there is a race condition that can cause invalid
+        # reassignment (no old role deletion or no new role addition). This
+        # code ensures that the old assignment is deleted prior to adding a new
+        # assignment.
+
         # remove the conflicting relationship
         db.session.delete(obj.__class__.find_related(obj.source,
                                                      obj.destination))

--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -1091,6 +1091,30 @@ class Resource(ModelView):
     elif 'context' not in src:
       raise BadRequest('context MUST be specified.')
 
+  def _try_recover_integrity_error(self, src, obj, error):
+    """Recover and complete the request if possible, return new response.
+
+    Returns (code, object) if recover possible, None elsewise.
+    """
+    msg = error.orig.args[1]
+    if (obj.type == "Relationship" and
+            msg.startswith("Duplicate entry") and
+            msg.endswith("'uq_relationships'")):
+      db.session.rollback()
+      if src.get('changed'):
+        # remove the conflicting relationship
+        db.session.delete(obj.__class__.find_related(obj.source,
+                                                     obj.destination))
+        db.session.flush()
+        db.session.add(obj)
+      else:
+        # just append the new attrs values
+        obj = obj.__class__.update_attributes(obj.source, obj.destination,
+                                              obj.attrs)
+      db.session.flush()
+      object_for_json = self.object_for_json(obj)
+      return (200, object_for_json)
+
   def collection_post_step(self, src, no_result):
     try:
       obj = self.model()
@@ -1143,17 +1167,12 @@ class Resource(ModelView):
       with benchmark("Make response"):
         return (201, object_for_json)
     except IntegrityError as e:
-      msg = e.orig.args[1]
-      if obj.type == "Relationship" and \
-         msg.startswith("Duplicate entry") and \
-         msg.endswith("'uq_relationships'"):
-        db.session.rollback()
-        obj = obj.__class__.update_attributes(obj.source, obj.destination,
-                                              obj.attrs)
-        db.session.flush()
-        object_for_json = self.object_for_json(obj)
-        return (200, object_for_json)
-      return self._make_error_from_exception(e)
+      response_after_recover = self._try_recover_integrity_error(
+          src, obj, e)
+      if response_after_recover:
+        return response_after_recover
+      else:
+        return self._make_error_from_exception(e)
     except ValidationError as e:
       return self._make_error_from_exception(e)
 


### PR DESCRIPTION
Steps to reproduce:
- create a request, make Example User a creator and assignee;
- open this request for editing;
- remove Example User from creators (add new creators as needed);
- add Example User as a verifier;
- save the form.

Expected result: Example User is made assignee and verifier.
Possible actual results: Example User is unassigned from all lists, or Example User is assigned as creator, assignee and verifier (there is a race condition between the addition and deletion).

This fix allows saving such reassignments.