### PR TITLE
QUICK-FIX Add error messages for required custom attributes

### DIFF
--- a/src/ggrc/assets/javascripts/models/cacheable.js
+++ b/src/ggrc/assets/javascripts/models/cacheable.js
@@ -775,7 +775,8 @@ can.Model("can.Model.Cacheable", {
         if (definition.attribute_type === 'Checkbox') {
           self.class.validate('custom_attributes.' + definition.id,
               function (val) {
-                return !val;
+                var msg = val ? '' : 'must be checked';
+                return msg;
               });
         } else {
           self.class.validateNonBlank('custom_attributes.' + definition.id);

--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -3442,4 +3442,44 @@ Example:
       return options.inverse(options.context);
     }
   );
+
+  /**
+   * Check if Custom Atttribute's value did not pass validation, and render the
+   * corresponding block in the template. The error messages, if any, are
+   * available in the "error" variable within the "truthy" block.
+   *
+   * Example usage:
+   *
+   *   {{#ca_validation_error validationErrors customAttrId}}
+   *     Invalid value for the Custom Attribute {{customAttrId}}: {{errors.0}}
+   *   {{else}}
+   *     Hooray, no errors, a correct value is set!
+   *   {{/ca_validation_error}}
+   *
+   * @param {Object} validationErrors - an object containing validation results
+   *   of a can.Model instance
+   * @param {Number} customAttrId - ID of the Custom Attribute to check for
+   *   validation errors
+   * @param {Object} options - a CanJS options argument passed to every helper
+   */
+  Mustache.registerHelper(
+    'ca_validation_error',
+    function (validationErrors, customAttrId, options) {
+      var errors;
+      var contextStack;
+      var property;
+
+      validationErrors = Mustache.resolve(validationErrors) || {};
+      customAttrId = Mustache.resolve(customAttrId);
+
+      property = 'custom_attributes.' + customAttrId;
+      errors = validationErrors[property] || [];
+
+      if (errors.length > 0) {
+        contextStack = options.contexts.add({errors: errors});
+        return options.fn(contextStack);
+      }
+      return options.inverse(options.contexts);
+    }
+  );
 })(this, jQuery, can);

--- a/src/ggrc/assets/js_specs/mustache_helpers/ca_validation_error_spec.js
+++ b/src/ggrc/assets/js_specs/mustache_helpers/ca_validation_error_spec.js
@@ -1,0 +1,61 @@
+/*!
+  Copyright (C) 2016 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+describe('can.mustache.helper.ca_validation_error', function () {
+  'use strict';
+
+  var helper;
+  var fakeOptions;
+
+  beforeAll(function () {
+    helper = can.Mustache._helpers.ca_validation_error.fn;
+  });
+
+  beforeEach(function () {
+    fakeOptions = {
+      fn: jasmine.createSpy('options.fn'),
+      inverse: jasmine.createSpy('options.inverse'),
+      contexts: {
+        add: jasmine.createSpy('contexts.add')
+      }
+    };
+  });
+
+  it('renders the "truthy" block if there are validation errors for the ' +
+    'custom attribute',
+    function () {
+      var validationErrors = {
+        'custom_attributes.4': ['invalid value']
+      };
+      helper(validationErrors, 4, fakeOptions);
+      expect(fakeOptions.fn).toHaveBeenCalled();
+    }
+  );
+
+  it('adds the errors list to the scope if there are validation errors for ' +
+    'the custom attribute',
+    function () {
+      var validationErrors = {
+        'custom_attributes.1': ['invalid  date format'],
+        'custom_attributes.4': ['value is too short', 'not a number']
+      };
+      helper(validationErrors, 4, fakeOptions);
+      expect(fakeOptions.contexts.add).toHaveBeenCalledWith(
+        {errors: ['value is too short', 'not a number']}
+      );
+    }
+  );
+
+  it('renders the "falsy" block if there are no validation errors for the ' +
+    'custom attribute',
+    function () {
+      var validationErrors = {
+        'custom_attributes.4': ['invalid value']
+      };
+      helper(validationErrors, 8, fakeOptions);
+      expect(fakeOptions.inverse).toHaveBeenCalled();
+    }
+  );
+});

--- a/src/ggrc/assets/mustache/custom_attributes/modal_content.mustache
+++ b/src/ggrc/assets/mustache/custom_attributes/modal_content.mustache
@@ -13,7 +13,8 @@
       {{#each instance.custom_attribute_definitions}}
       {{#with_value_for_id id}}
 
-      <div class="{{^mandatory}}hidable{{/mandatory}} span6">
+      <div class="{{^mandatory}}hidable{{/mandatory}} span6
+                  {{#ca_validation_error instance.computed_errors id}}field-failure{{/ca_validation_error}}">
         {{#switch attribute_type}}
         {{#case 'Text'}}
           <label>
@@ -93,7 +94,12 @@
         {{/with_object_for_id}}
         {{/case}}
         {{/switch}}
+
+        {{#ca_validation_error instance.computed_errors id}}
+          <label class="help-inline warning">{{errors.0}}</label>
+        {{/ca_validation_error}}
       </div>
+
       {{/with_value_for_id}}
       {{/instance.custom_attribute_definitions}}
     </div>


### PR DESCRIPTION
Ticket description:

> Add validation message for mandatory Custom Attribute in Assessment (now when you do not fill it and press Save, nothing is showed to the user, no reaction)

**Notes:**
* There are some minor styling issues like spacing between the error message and the corresponding UI widget, but since they do not represent a blocker in any way, this PR does not try to address them. If needed, this can probably be delegated to Vladan (can be done independently from the other tasks).
* If there multiple validation errors for a single field, only the first one is shown - showing all of them would clutter the form.