### PR TITLE
CORE-3267 Fix spinner overlapping with the attach evidence button

### DIFF
--- a/src/ggrc_gdrive_integration/assets/mustache/gdrive/gdrive_file.mustache
+++ b/src/ggrc_gdrive_integration/assets/mustache/gdrive/gdrive_file.mustache
@@ -15,6 +15,5 @@
     {{firstexist link_text "Upload Files to GDrive"}}
 </a>
 {{#pending}}
-  <span {{attach_spinner '{ "radius": 3, "length": 2.5, "width": 2 }' 'display:inline-block; top: -5px; left: 12px;' }}>
-  </span>
+  <spinner toggle="pending"></spinner>
 {{/pending}}

--- a/src/ggrc_gdrive_integration/assets/mustache/requests/gdrive_comment_attachment.mustache
+++ b/src/ggrc_gdrive_integration/assets/mustache/requests/gdrive_comment_attachment.mustache
@@ -28,7 +28,8 @@
   {{! This is a failure state for with_mapping, if something in the mapping doesn't refresh properly }}
   {{#if error.errors}}
     <small>
-      You need permission to upload files to the audit folder. <a href="https://drive.google.com/folderview?id={{grdive_msg_to_id error.message}}&usp=sharing#">Request access.</a>
+      You need permission to upload files to the audit folder.
+      <a href="https://drive.google.com/folderview?id={{grdive_msg_to_id error.message}}&amp;usp=sharing#">Request access.</a>
     </small>
   {{else}}
     The GDrive folder for this evidence could not be accessed.


### PR DESCRIPTION
Simply replacing it with the `<spinner>` component did the trick because of a different CSS `display` property (not `fixed` anymore).