### PR TITLE
QUICK-FIX Fix remove unmap link from mapped tree view

### DIFF
--- a/src/ggrc/assets/mustache/base_templates/subtree.mustache
+++ b/src/ggrc/assets/mustache/base_templates/subtree.mustache
@@ -45,11 +45,6 @@
     <div class="tier-2-info-content">
       <lazy-openclose>
         {{#show}}
-          {{#is_allowed 'update' parentInstance context='for'}}
-            {{#instance}}
-              {{{render '/static/mustache/mapped_objects/dropdown_menu_tier2.mustache' instance=instance}}}
-            {{/instance}}
-          {{/is_allowed}}
           <div class="tier-content">
             {{> /static/mustache/base_objects/title.mustache}}
             {{> /static/mustache/base_objects/description.mustache}}


### PR DESCRIPTION
As discussed remove 3bbs and unmap completely from ui for mapped objects tree view.