### PR TITLE
CORE-3481 Make the "relevant to" UI texts consistent

### DIFF
--- a/src/ggrc/assets/mustache/base_objects/extended_info.mustache
+++ b/src/ggrc/assets/mustache/base_objects/extended_info.mustache
@@ -113,7 +113,7 @@
                   <span class="primary"
                         data-test-id="extended_info_object_already_mapped">
                     <i class="fa fa-check-square-o"></i>
-                    Relevant to this {{#page_instance.class.title_singular}}
+                    Mapped to this {{#page_instance.class.title_singular}}
                       {{toLowerCase}}{{/page_instance.class.title_singular}}
                   </span>
                 {{else}}

--- a/src/ggrc/assets/mustache/base_objects/filters/filter_by_relevance.mustache
+++ b/src/ggrc/assets/mustache/base_objects/filters/filter_by_relevance.mustache
@@ -8,14 +8,14 @@
 <div class="relevance-filters">
   <div class="row-fluid">
     <div class="span12">
-      <h6>Filter by mapping relevance</h6>
+      <h6>Filter by mapping</h6>
       {{#each filter_list}}
       <div class="single-line-filter">
         <button type="submit" data-index="{{@index}}" class="remove_filter">
           <i class="fa fa-trash"></i>
         </button>
         <label>
-          {{#if @index}}AND {{/if}}Relevant to:
+          {{#if @index}}AND {{/if}}Mapped to:
         </label>
         <select class="input-small filter-type-selector select-filter{{@index}}" can-value="model_name">
           {{#option_type_menu_2}}

--- a/src/ggrc/assets/mustache/mapper/relevant_filter.mustache
+++ b/src/ggrc/assets/mustache/mapper/relevant_filter.mustache
@@ -5,14 +5,14 @@
     Maintained By: ivan@reciprocitylabs.com
 }}
 
-<h6>Filter by mapping relevance</h6>
+<h6>Filter by mapping</h6>
 {{#each relevant}}
   <div class="single-line-filter">
     <button type="submit" data-index="{{@index}}" class="remove_filter">
       <i class="fa fa-trash"></i>
     </button>
     <label>
-      {{#if @index}}AND {{/if}}Relevant to:
+      {{#if @index}}AND {{/if}}Mapped to:
     </label>
     <select class="input-small filter-type-selector select-filter{{@index}}" can-value="model_name">
       {{#menu}}

--- a/src/ggrc/assets/mustache/programs/extended_info.mustache
+++ b/src/ggrc/assets/mustache/programs/extended_info.mustache
@@ -78,7 +78,7 @@
                 {{#if mappings.length}}
                   <span class="primary">
                     <i class="fa fa-check-square-o"></i>
-                    Relevant to this {{#page_instance.class.title_singular}}{{toLowerCase}}{{/page_instance.class.title_singular}}
+                    Mapped to this {{#page_instance.class.title_singular}}{{toLowerCase}}{{/page_instance.class.title_singular}}
                   </span>
                 {{else}}
                   {{#is_allowed_to_map page_instance instance join=true}}

--- a/src/ggrc_workflows/assets/mustache/tasks/extended_info.mustache
+++ b/src/ggrc_workflows/assets/mustache/tasks/extended_info.mustache
@@ -57,7 +57,7 @@
             {{#if mappings.length}}
               <span class="primary">
                 <i class="fa fa-check-square-o"></i>
-                Relevant to this {{#page_instance.class.title_singular}}{{toLowerCase}}{{/page_instance.class.title_singular}}
+                Mapped to this {{#page_instance.class.title_singular}}{{toLowerCase}}{{/page_instance.class.title_singular}}
               </span>
             {{else}}
               {{#is_allowed_to_map page_instance instance join=true}}
@@ -74,7 +74,4 @@
     </div>
   </div>
 
-
-
-{{!/div}}
 {{/instance}}


### PR DESCRIPTION
This PR renames a few things in the UI to make them consistent throughout the app, namely:
* FILTER BY MAPPING RELEVANCE --> FILTER BY MAPPING
* Relevant to --> Mapped to