### PR TITLE
CORE-3652 change active cycles page

### DIFF
--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -147,6 +147,7 @@ dashboard-js-files:
   - components/add_comment/add_comment.js
   - components/object_cloner/object_cloner.js
   - components/object_counter/object_counter.js
+  - components/treeview/treeview.js
   #- d3.v2.js
   #- related_graph.js
 
@@ -271,6 +272,7 @@ dashboard-js-template-files:
   - components/rich_text/rich_text.mustache
   - components/datepicker/datepicker.mustache
   - components/object_counter/object_counter.mustache
+  - treeview/treeview.mustache
   - custom_attributes/modal_content.mustache
   - custom_attributes/info.mustache
   - custom_attribute_definitions/modal_content.mustache
@@ -441,6 +443,7 @@ dashboard-js-template-files:
   - import_export/export/filter_query.mustache
   - mapper/relevant_filter.mustache
   - quick_form/confirm_buttons.mustache
+  - treeview/treeview.mustache
 
 dashboard-css-files:
   - dashboard.css

--- a/src/ggrc/assets/javascripts/components/treeview/treeview.js
+++ b/src/ggrc/assets/javascripts/components/treeview/treeview.js
@@ -1,0 +1,60 @@
+/*!
+    Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+    Created By: tomaz@reciprocitylabs.com
+    Maintained By: tomaz@reciprocitylabs.com
+*/
+
+(function (can, $) {
+  'use strict';
+  /**
+   *  Treeview component which renders a treeview with given options
+   *
+   *  @param {JSON} treeViewOptions - options for the treeview eg.
+   *   {
+   *     draw_children: true,
+   *     parent_instance: object,
+   *     model: CMS.Models.CycleTaskGroupObjectTask,
+   *     mapping: 'cycle_task_group_object_tasks',
+   *     header_view: GGRC.mustache_path +
+            '/cycle_task_group_object_tasks/tree_header.mustache',
+   *     add_item_view: GGRC.mustache_path +
+   *       '/cycle_task_group_object_tasks/tree_add_item.mustache'
+   *   }
+   *  @param {can.Model} instance - instance that will act as
+   *    parent_instance for the treeview (mapping will be applied on it)
+   */
+
+  GGRC.Components('treeview', {
+    tag: 'tree-view',
+    template: can.view(GGRC.mustache_path +
+      '/treeview/treeview.mustache'),
+    scope: {
+      treeViewOptions: undefined,
+      instance: undefined
+    },
+    events: {
+      '{scope} instance': function () {
+        // Sets treeview options and recreates treeview
+        var options = this.scope.attr('treeViewOptions');
+        if (this.scope.instance) {
+          options.attr('parent_instance', this.scope.attr('instance'));
+        }
+        if (this.scope._treeView) {
+          // Empty and destroy treeview
+          this.scope._treeView.element.empty();
+          this.scope._treeView.custom_destroy();
+        }
+        // NOTE: even though you kill stickies in custom_destroy this component
+        // could get rerendered with a new scope, meaning that the previous one
+        // didn't get destroyed with custom_destroy
+        Stickyfill.kill();
+        // Create a new treeview and display it
+        this.scope._treeView = new CMS.Controllers.TreeView(
+          this.element.find('.tree-structure'), options);
+        // Display treeview
+        this.scope._treeView.display();
+      }
+    }
+  });
+})(window.can, window.can.$);

--- a/src/ggrc/assets/javascripts/components/treeview/treeview.js
+++ b/src/ggrc/assets/javascripts/components/treeview/treeview.js
@@ -1,8 +1,6 @@
 /*!
-    Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+    Copyright (C) 2016 Google Inc.
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
-    Created By: tomaz@reciprocitylabs.com
-    Maintained By: tomaz@reciprocitylabs.com
 */
 
 (function (can, $) {

--- a/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
@@ -730,7 +730,8 @@ CMS.Controllers.TreeLoader('CMS.Controllers.TreeView', {
   bind_header_events: function () {
     // Bind events for header elements
     var parent = this.element.parent();
-    // TODO: This is a workaround so we can toggle filter. We should refactor this ASAP.
+    // This is a workaround so we can toggle filter.
+    // We should refactor this ASAP.
     can.bind.call(
         parent.find('.filter-trigger > a'),
         'click',

--- a/src/ggrc/assets/mustache/treeview/treeview.mustache
+++ b/src/ggrc/assets/mustache/treeview/treeview.mustache
@@ -1,0 +1,10 @@
+{{!
+    Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+    Created By: tomaz@reciprocitylabs.com
+    Maintained By: tomaz@reciprocitylabs.com
+}}
+
+<div>
+  <ul class='tree-structure new-tree'></ul>
+</div>

--- a/src/ggrc/assets/mustache/treeview/treeview.mustache
+++ b/src/ggrc/assets/mustache/treeview/treeview.mustache
@@ -1,8 +1,6 @@
 {{!
-    Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
-    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
-    Created By: tomaz@reciprocitylabs.com
-    Maintained By: tomaz@reciprocitylabs.com
+  Copyright (C) 2016 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
 
 <div>

--- a/src/ggrc_workflows/assets/assets.yaml
+++ b/src/ggrc_workflows/assets/assets.yaml
@@ -14,6 +14,9 @@ dashboard-js-files:
   - components/end_cycle.js
   - components/workflow_active.js
   - components/workflow_deactivate.js
+  - controllers/sprints_controller.js
+  - components/dropdown_mapping.js
+  - components/sprints_observer.js
 
 dashboard-js-spec-files:
 
@@ -91,3 +94,5 @@ dashboard-js-template-files:
   - cycle_task_group_object_tasks/current_tg_tree_footer.mustache
   - workflows/clone_modal_content.mustache
   - task_groups/clone_modal_content.mustache
+  - workflows/dropdown_mapping.mustache
+  - workflows/sprints.mustache

--- a/src/ggrc_workflows/assets/javascripts/apps/workflows.js
+++ b/src/ggrc_workflows/assets/javascripts/apps/workflows.js
@@ -142,7 +142,9 @@
         cycle_task_groups: Direct(
           'CycleTaskGroup', 'cycle', 'cycle_task_groups'),
         reify_cycle_task_groups: Reify('cycle_task_groups'),
-        workflow: Direct('Workflow', 'cycles', 'workflow')
+        workflow: Direct('Workflow', 'cycles', 'workflow'),
+        cycle_task_group_object_tasks: Cross('cycle_task_groups',
+          'cycle_task_group_tasks')
       },
 
       CycleTaskGroup: {
@@ -561,18 +563,18 @@
     };
 
     currentWidgetDescriptor = {
-      content_controller: CMS.Controllers.TreeView,
-      content_controller_selector: 'ul',
-      widget_initial_content: '<ul class="tree-structure new-tree"></ul>',
+      content_controller: CMS.Controllers.Sprints,
       widget_id: 'current',
-      widget_name: 'Active Cycles',
+      widget_name: 'Sprints',
       widget_icon: 'cycle',
       content_controller_options: {
         draw_children: true,
         parent_instance: object,
-        model: 'Cycle',
-        mapping: 'current_cycle',
-        header_view: GGRC.mustache_path + '/cycles/tree_header.mustache',
+        model: CMS.Models.CycleTaskGroupObjectTask,
+        mapping: 'cycle_task_group_object_tasks',
+        header_view:
+          GGRC.mustache_path +
+          '/cycle_task_group_object_tasks/tree_header.mustache',
         add_item_view:
           GGRC.mustache_path +
           '/cycle_task_group_object_tasks/tree_add_item.mustache'

--- a/src/ggrc_workflows/assets/javascripts/components/dropdown_mapping.js
+++ b/src/ggrc_workflows/assets/javascripts/components/dropdown_mapping.js
@@ -1,0 +1,17 @@
+/*!
+    Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+    Created By: tomaz@reciprocitylabs.com
+    Maintained By: tomaz@reciprocitylabs.com
+*/
+
+// Component with dropdown mapping
+GGRC.Components('dropdown-mapping', {
+  tag: 'dropdown-mapping',
+  template: can.view(GGRC.mustache_path +
+    '/workflows/dropdown_mapping.mustache'),
+  scope: {
+    instances: [],
+    selectedId: undefined
+  }
+});

--- a/src/ggrc_workflows/assets/javascripts/components/dropdown_mapping.js
+++ b/src/ggrc_workflows/assets/javascripts/components/dropdown_mapping.js
@@ -1,8 +1,6 @@
 /*!
-    Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+    Copyright (C) 2016 Google Inc.
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
-    Created By: tomaz@reciprocitylabs.com
-    Maintained By: tomaz@reciprocitylabs.com
 */
 
 // Component with dropdown mapping

--- a/src/ggrc_workflows/assets/javascripts/components/sprints_observer.js
+++ b/src/ggrc_workflows/assets/javascripts/components/sprints_observer.js
@@ -1,8 +1,6 @@
 /*!
-    Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+    Copyright (C) 2016 Google Inc.
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
-    Created By: tomaz@reciprocitylabs.com
-    Maintained By: tomaz@reciprocitylabs.com
 */
 
 /**

--- a/src/ggrc_workflows/assets/javascripts/components/sprints_observer.js
+++ b/src/ggrc_workflows/assets/javascripts/components/sprints_observer.js
@@ -1,0 +1,34 @@
+/*!
+    Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+    Created By: tomaz@reciprocitylabs.com
+    Maintained By: tomaz@reciprocitylabs.com
+*/
+
+/**
+ * This component listens for changes on selectedId so it can changes
+ * the selectedInstance which is needed by some of it's child elements
+ */
+GGRC.Components('sprints-observer', {
+  tag: 'sprints-observer',
+  template: '<content/>',
+  scope: {
+    instances: null,
+    selectedId: null,
+    selectedInstance: null
+  },
+  init: function () {
+    var active = _.first(this.scope.instances);
+    if (active && active.id) {
+      this.scope.attr('selectedId', active.id);
+    }
+  },
+  events: {
+    '{scope} selectedId': function () {
+      var selected = _.find(this.scope.instances, function (inst) {
+        return inst.id === Number(this.scope.selectedId);
+      }.bind(this))
+      this.scope.attr('selectedInstance', selected);
+    }
+  }
+});

--- a/src/ggrc_workflows/assets/javascripts/components/workflow_active.js
+++ b/src/ggrc_workflows/assets/javascripts/components/workflow_active.js
@@ -48,7 +48,10 @@
     tag: 'workflow-start-cycle',
     content: '<content/>',
     events: {
-      click: _generate_cycle
+      click: function () {
+        Stickyfill.kill();
+        _generate_cycle();
+      }
     }
   });
 
@@ -109,6 +112,11 @@
             workflow.attr('status', 'Active');
             return workflow.save();
           }, restore_button).then(function (workflow) {
+            if (workflow.cycles.length > 0) {
+              setTimeout(function () {
+                window.location.hash = 'current_widget';
+              }, 250);
+            }
             if (moment(workflow.next_cycle_start_date).isSame(moment(), 'day')) {
               return new CMS.Models.Cycle({
                 context: workflow.context.stub(),

--- a/src/ggrc_workflows/assets/javascripts/controllers/sprints_controller.js
+++ b/src/ggrc_workflows/assets/javascripts/controllers/sprints_controller.js
@@ -1,0 +1,48 @@
+/*!
+    Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+    Created By: tomaz@reciprocitylabs.com
+    Maintained By: tomaz@reciprocitylabs.com
+*/
+
+can.Control('CMS.Controllers.Sprints', {
+  defaults: {
+    view: GGRC.mustache_path + '/workflows/sprints.mustache',
+    workflow: GGRC.page_instance()
+  }
+}, {
+  init: function (el, options) {
+    this.renderPage(el, options);
+  },
+  renderPage: function (el, options) {
+    // set filter hidden on this page by default
+    CMS.Models.DisplayPrefs.getSingleton().then(function (display_prefs) {
+      display_prefs.setFilterHidden(true);
+    }).then(function () {
+      // Get workflow cycles and sort them by created_at
+      options.workflow.refresh_all('cycles').then(function (cycles) {
+        var sortedCycles = _.sortBy(cycles, function (cycle) {
+          return -cycle.created_at;
+        });
+
+        var view = can.view(
+          this.options.view,
+          {
+            treeViewOptions: options,
+            workflow: GGRC.page_instance(),
+            cycles: sortedCycles
+          });
+        this.element.html(view);
+      }.bind(this));
+    }.bind(this));
+  },
+  '{workflow} next_cycle_start_date': function () {
+    // If cycle gets added you need to rerender Sprints tab
+    this.renderPage(this.element, this.options);
+  },
+  '{workflow} status': function () {
+    // If the cycle is activated on one-time workflow you need
+    // to rerender Sprints tab
+    this.renderPage(this.element, this.options);
+  }
+});

--- a/src/ggrc_workflows/assets/javascripts/controllers/sprints_controller.js
+++ b/src/ggrc_workflows/assets/javascripts/controllers/sprints_controller.js
@@ -1,8 +1,6 @@
 /*!
-    Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+    Copyright (C) 2016 Google Inc.
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
-    Created By: tomaz@reciprocitylabs.com
-    Maintained By: tomaz@reciprocitylabs.com
 */
 
 can.Control('CMS.Controllers.Sprints', {

--- a/src/ggrc_workflows/assets/javascripts/models/cycle_models.js
+++ b/src/ggrc_workflows/assets/javascripts/models/cycle_models.js
@@ -48,7 +48,7 @@
     }
     if (typeof workflow.cycles === undefined || !workflow.cycles) {
       $(document.body).trigger(
-        'ajax:flash', 
+        'ajax:flash',
         {warning: 'No cycles in the workflow!'}
       );
       return;
@@ -60,14 +60,20 @@
 
       if (!activeCycleList.length) {
         $(document.body).trigger(
-          'ajax:flash', 
+          'ajax:flash',
           {warning: 'No active cycles in the workflow!'}
         );
         return;
       }
       activeCycleList = _.sortByOrder(
         activeCycleList, ['start_date'], ['desc']);
-      activeCycle = activeCycleList[0];
+      if (form.fromCycle) {
+        activeCycle = _.find(activeCycleList, function (cycle) {
+          return cycle.id === form.fromCycle.id;
+        });
+      } else {
+        activeCycle = activeCycleList[0];
+      }
       form.attr('workflow', {id: workflow.id, type: 'Workflow'});
       form.attr('context', {id: workflow.context.id, type: 'Context'});
       form.attr('cycle', {id: activeCycle.id, type: 'Cycle'});
@@ -150,7 +156,36 @@
         }
       });
     },
-    overdue: overdue_compute
+    overdue: overdue_compute,
+    dropdownName: function (index, ctx) {
+      var frequency;
+      var sprintNr;
+      var extra = '';
+      var workflow;
+      var dropdownTemplate = _.template(
+        '<%= frequency %> Sprint ' +
+        '<%= sprintNr %> ENDS ON: <%= endDate %> <%= extra %>'
+      );
+      if (_.isUndefined(this.workflow)) {
+        return '';
+      }
+      if (_.isFunction(index)) {
+        index = index();
+      }
+      workflow = this.workflow.reify();
+      sprintNr = workflow.cycles.length - index;
+      frequency = _.capitalize(workflow.frequency).replace('_', ' ');
+      if (!this.is_current) {
+        extra = 'ARCHIVED';
+      }
+      // return rendered template
+      return dropdownTemplate({
+        frequency: frequency,
+        sprintNr: sprintNr,
+        endDate: this.end_date,
+        extra: extra
+      });
+    }
   });
 
   _mustache_path = GGRC.mustache_path + '/cycle_task_entries';

--- a/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/tree_add_item.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/tree_add_item.mustache
@@ -4,7 +4,14 @@
 }}
 
 {{#is_allowed 'create' 'CycleTaskGroupObjectTask' context=null}}
-  {{^if_recurring_workflow parent_instance}}
+  {{! Possible scenarios:
+    - on Sprints page with parent_instance Cycle
+    - on Dashboard MyTasks with parent_instance Person
+    - on some object page
+  }}
+  {{^if_helpers '\
+    #if_equals' parent_instance.type "Cycle" '\
+    and ^if' parent_instance.is_current}}
     <a
       class="section-add"
       href="javascript://"
@@ -17,19 +24,22 @@
       data-toggle="modal-ajax-form"
       data-modal-reset="reset"
       data-object-params='{
-        {{^if_instance_of parent_instance 'Person|Workflow'}}
+        {{#if_equals parent_instance.type 'Cycle'}}
+          {{#if parent_instance.is_current}}
+            "workflow":{"id":{{parent_instance.workflow.id}},"type":"Workflow"},
+            "fromCycle":{"id":{{parent_instance.id}},"type":"Cycle"},
+          {{/if}}
+        {{/if_equals}}
+        {{^if_instance_of parent_instance 'Person|Cycle'}}
           "pre_mapped_objects": [{
             "type": "{{ parent_instance.type }}",
             "id": {{ parent_instance.id }}
           }],
         {{/if_instance_of}}
         "modal_title": "Create New Cycle Task"
-        {{#if_equals parent_instance.type 'Workflow'}}
-          ,"workflow":{"id":{{parent_instance.id}},"type":"Workflow"}
-        {{/if_equals}}
         }'>
 
       <i class="fa fa-plus-circle"></i>
     </a>
-  {{/if_recurring_workflow}}
+  {{/if_helpers}}
 {{/is_allowed}}

--- a/src/ggrc_workflows/assets/mustache/workflows/dropdown_mapping.mustache
+++ b/src/ggrc_workflows/assets/mustache/workflows/dropdown_mapping.mustache
@@ -1,8 +1,6 @@
 {{!
-  Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+  Copyright (C) 2016 Google Inc.
   Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
-  Created By: tomaz@reciprocitylabs.com
-  Maintained By: tomaz@reciprocitylabs.com
 }}
 
 

--- a/src/ggrc_workflows/assets/mustache/workflows/dropdown_mapping.mustache
+++ b/src/ggrc_workflows/assets/mustache/workflows/dropdown_mapping.mustache
@@ -1,0 +1,15 @@
+{{!
+  Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+  Created By: tomaz@reciprocitylabs.com
+  Maintained By: tomaz@reciprocitylabs.com
+}}
+
+
+<select can-value='selectedId' class='input-block-level'>
+  {{#each instances}}
+    <option value='{{id}}'>
+      {{dropdownName @index}}
+    </option>
+  {{/each}}
+</select>

--- a/src/ggrc_workflows/assets/mustache/workflows/sprints.mustache
+++ b/src/ggrc_workflows/assets/mustache/workflows/sprints.mustache
@@ -1,8 +1,6 @@
 {{!
-  Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+  Copyright (C) 2016 Google Inc.
   Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
-  Created By: tomaz@reciprocitylabs.com
-  Maintained By: tomaz@reciprocitylabs.com
 }}
 
 <sprints-observer instances='cycles'>

--- a/src/ggrc_workflows/assets/mustache/workflows/sprints.mustache
+++ b/src/ggrc_workflows/assets/mustache/workflows/sprints.mustache
@@ -1,0 +1,45 @@
+{{!
+  Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+  Created By: tomaz@reciprocitylabs.com
+  Maintained By: tomaz@reciprocitylabs.com
+}}
+
+<sprints-observer instances='cycles'>
+
+  {{#if instances.length}}
+    <div class='row-fluid'>
+      <div data-id='state_hidden' class='span12 hidable'>
+
+        {{! render instances dropdown }}
+        <div data-id='state_hidden' class='span4 hidable'>
+          <dropdown-mapping
+            instances='instances'
+            selected-id='selectedId'>
+          </dropdown-mapping>
+        </div>
+
+        {{! render end-cycle button }}
+        <div data-id='state_hidden' class='span8 hidable'>
+          <cycle-end-cycle cycle='selectedInstance'>
+            {{#is_allowed 'update' cycle.workflow.reify}}
+              {{#if cycle.is_current}}
+                <button class='btn btn-draft btn-small end-cycle pull-right inline-block'>
+                  End Sprint
+                </button>
+              {{/if}}
+            {{/is_allowed}}
+          </cycle-end-cycle>
+        </div>
+
+      </div>
+    </div>
+
+    <tree-view tree-view-options='treeViewOptions' instance='selectedInstance'>
+    </tree-view>
+
+  {{else}}
+    There are no active Sprints.
+  {{/if}}
+
+</sprints-observer>


### PR DESCRIPTION
Reopened on develop but with a change - the filter on sprints page can be opened now but is closed by default. There are also some other minor changes for instance treeview component kills stickies.