### PR TITLE
QUICK-FIX Remove tooltip when hovering over tab contents

### DIFF
--- a/src/ggrc/assets/javascripts/components/tabs.js
+++ b/src/ggrc/assets/javascripts/components/tabs.js
@@ -1,8 +1,6 @@
 /*!
-    Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
-    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
-    Created By: ivan@reciprocitylabs.com
-    Maintained By: ivan@reciprocitylabs.com
+  Copyright (C) 2016 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 */
 
 (function (GGRC, can, $) {
@@ -67,12 +65,14 @@
     }
   });
 
-  GGRC.Components("tabPanel", {
+  GGRC.Components('tabPanel', {
     tag: 'tab-panel',
-    template: can.view(GGRC.mustache_path + '/base_objects/tab_panel.mustache'),
+    template: can.view(
+      GGRC.mustache_path + '/base_objects/tab_panel.mustache'
+    ),
     scope: {
       active: false,
-      title: '@',
+      titleText: '@',
       panels: null
     },
     events: {
@@ -86,10 +86,11 @@
       inserted: function () {
         var panels = this.scope.attr('panels');
         panels.push({
-          title: this.scope.attr('title'),
+          title: this.scope.attr('titleText'),
           panel: this.scope
         });
       },
+
       /**
        * Check if other tabs are active and deactivate them
        *
@@ -97,15 +98,15 @@
        * @param {Object} ev - event triggered on change
        * @param {String} item - item that got changed
        * @param {String} action - what got changed on the object
-       * @param {String} status - status of changed item, we are looking for `active`
-       *                          property change to either `true` or `false`
+       * @param {String} status - status of changed item, we are looking for
+       *   `active` property change to either `true` or `false`
        */
       '{scope.panels} change': function (list, ev, item, action, status) {
         var index;
         var panel;
 
         item = item.split('.');
-        if (item.length !== 3 || item[1] !== "panel" || item[2] !== "active") {
+        if (item.length !== 3 || item[1] !== 'panel' || item[2] !== 'active') {
           // if this is a change to a scope in a different panel we should
           // not switch tabs
           return;

--- a/src/ggrc/assets/mustache/assessments/info.mustache
+++ b/src/ggrc/assets/mustache/assessments/info.mustache
@@ -99,7 +99,7 @@
 
       <div class="tabs-wrap">
         <tabs instance="instance">
-          <tab-panel panels="panels" title="Comments" instance="instance">
+          <tab-panel panels="panels" title-text="Comments" instance="instance">
             {{#if_helpers '\
               ^if_equals' status 'Verified' '\
               and ^if_equals' status 'Final' }}
@@ -111,16 +111,16 @@
             {{/if_equals}}
             {{{render "/static/mustache/base_templates/comment_list.mustache" instance=instance update_count="false"}}}
           </tab-panel>
-          <tab-panel panels="panels" title="Assessment Log" instance="instance">
+          <tab-panel panels="panels" title-text="Assessment Log" instance="instance">
             <revision-log instance="instance"></revision-log>
           </tab-panel>
-          <tab-panel panels="panels" title="Related Assessments" instance="instance">
+          <tab-panel panels="panels" title-text="Related Assessments" instance="instance">
             {{{render "/static/mustache/assessments/reusable_objects.mustache" instance=instance}}}
           </tab-panel>
-          <tab-panel panels="panels" title="Related Requests" instance="instance">
+          <tab-panel panels="panels" title-text="Related Requests" instance="instance">
             {{{render "/static/mustache/assessments/related_requests.mustache" instance=instance}}}
           </tab-panel>
-          <tab-panel panels="panels" title="Related Issues" instance="instance">
+          <tab-panel panels="panels" title-text="Related Issues" instance="instance">
             {{{render "/static/mustache/assessments/related_issues.mustache" instance=instance}}}
           </tab-panel>
         </tabs>

--- a/src/ggrc/assets/mustache/requests/info.mustache
+++ b/src/ggrc/assets/mustache/requests/info.mustache
@@ -80,7 +80,7 @@
 
       <div class="tabs-wrap">
         <tabs instance=".">
-          <tab-panel panels="panels" title="Comments and Responses" instance="instance">
+          <tab-panel panels="panels" title-text="Comments and Responses" instance="instance">
             {{#if_helpers '\
               ^if_equals' status 'Verified' '\
               and ^if_equals' status 'Final' }}
@@ -92,10 +92,10 @@
             {{/if_equals}}
             {{{render "/static/mustache/base_templates/comment_list.mustache" instance=instance update_count="false"}}}
           </tab-panel>
-          <tab-panel panels="panels" title="Request Log" instance="instance">
+          <tab-panel panels="panels" title-text="Request Log" instance="instance">
             <revision-log instance="instance"></revision-log>
           </tab-panel>
-          <tab-panel panels="panels" title="Related Requests" instance="instance">
+          <tab-panel panels="panels" title-text="Related Requests" instance="instance">
             {{{render "/static/mustache/requests/reusable_objects.mustache" instance=instance}}}
           </tab-panel>
         </tabs>


### PR DESCRIPTION
The issue was caused because the `title`attribute the tab component used is also used by browsers. The fix was to simply use a different attribute name for the tab title.