### PR TITLE
QUICK-FIX Fix delete assessment on My Work page

### DIFF
--- a/src/ggrc/assets/mustache/assessments/tree_header.mustache
+++ b/src/ggrc/assets/mustache/assessments/tree_header.mustache
@@ -5,24 +5,9 @@
   Maintained By: peter@reciprocitylabs.com
 }}
 
-{{#if_equals original_list.length 0}}
-  <div class="zero-state">
-    <h2>
-      {{#is_profile}}
-        You have
-      {{else}}
-        {{#with_page_object_as 'page_object'}}
-          {{page_object.type}} has
-        {{/with_page_object_as}}
-      {{/is_profile}}
-      no assigned tasks
-    </h2>
-  </div>
-{{else}}
   {{{> "/static/mustache/base_objects/tree_view_filter.mustache"}}}
   <header
-    class="header sticky sticky-header tree-header
-          {{#filter_is_hidden}}no-filter{{/filter_is_hidden}}">
+    class="header sticky sticky-header tree-header {{#filter_is_hidden}}no-filter{{/filter_is_hidden}}">
     <div class="row-fluid">
       <div class="span{{display_options.title_width}}">
         <div class="title-heading oneline">
@@ -54,6 +39,5 @@
       </div>
     </div>
   </header>
-{{/if_equals}}
 
 <div class="clearfix"></div>

--- a/src/ggrc/assets/mustache/base_objects/tree_view_filter.mustache
+++ b/src/ggrc/assets/mustache/base_objects/tree_view_filter.mustache
@@ -5,7 +5,10 @@
     Maintained By: vladan@reciprocitylabs.com
 }}
 
-  <div class="sticky sticky-header tree-filter" {{#filter_is_hidden}}style="height: 0px; margin-bottom: 0px;"{{/filter_is_hidden}} data-height="42" data-margin-bottom="25">
+  <div class="sticky sticky-header tree-filter"
+       {{#filter_is_hidden}}style="height: 0; margin-bottom: 0;"{{/filter_is_hidden}}
+       data-height="42"
+       data-margin-bottom="25">
     <div class="sticky-filter inner-filter-sticky">
       <div class="tree-filter__inline-filtering clearfix" {{ (el) -> el.ggrc_controllers_tree_filter() }} >
 

--- a/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/tree_footer.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/tree_footer.mustache
@@ -19,4 +19,4 @@
     {{/is_profile}} no assigned tasks</h2>
   </div>
 </li>
-{{/if _equals}}
+{{/if_equals}}


### PR DESCRIPTION
**Subject:** Delete assessment from My Work dashboard gives an error: Uncaught TypeError: Failed to execute 'getComputedStyle' on 'Window': parameter 1 is not of type 'Element'.
**Details:** 
Ensure one assessment is assigned to current user
Navigate to My work page > Assessment tab
Open info panel >3dots button 
Click delete item

_Actual Result:_ Error message is displayed: Uncaught TypeError: Failed to execute 'getComputedStyle' on 'Window': parameter 1 is not of type 'Element'.
_Expected Result:_ Error message should not be displayed, assessment should be deleted.
_Workaround:_ click one of the tabs