### PR TITLE
QUICK-FIX Fix mapped objects are not shown

### DIFF
--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -1171,6 +1171,10 @@ class Resource(ModelView):
       with benchmark("Send model POSTed - after commit event"):
         self.model_posted_after_commit.send(obj.__class__, obj=obj,
                                             src=src, service=self)
+      # Note: In model_posted_after_commit necessary mapping and relashionships
+      # are set, so need to commit the changes
+      db.session.commit()
+
       with benchmark("Serialize object"):
         object_for_json = {} if no_result else self.object_for_json(obj)
       with benchmark("Make response"):


### PR DESCRIPTION
BE fix instead of PR #4086 that should be just closed.

Subject: Assessment tab: Mapped objects are not displayed on 2nd tier - user have to refresh page
Details: 
- Create Program
- Create Audit
- Create Assessment object for any control
- Expand to see 2nd tier

Actual Result: Only mapped people are displayed on 2nd tier
Expected Result: All mapped objects should be displayed. In this case Program, Control, Audit
Workaround: Refresh the page