### PR TITLE
QUICK-FIX Prevent dropdown custom attribute's options wrap

### DIFF
--- a/src/ggrc/assets/mustache/assessment_templates/attribute_field.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/attribute_field.mustache
@@ -11,7 +11,7 @@
     <div class="span-custom1-and-half">{{field.attribute_name}}</div>
     <div class="span2">
       {{#attrs}}
-        <span class="block">{{.}}</span>
+        <span class="block single-line" title="{{.}}">{{.}}</span>
       {{/attrs}}
     </div>
     <div class="span2 centered checkbox-wrap">

--- a/src/ggrc/assets/stylesheets/_common.scss
+++ b/src/ggrc/assets/stylesheets/_common.scss
@@ -771,6 +771,11 @@ p {
   .block {
     display: block;
   }
+  .single-line {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
   .attr-titles {
     @extend %clearfix;
     ul {


### PR DESCRIPTION
This fixes the vertical alignment issue with the dropdown's list of options on the edit AssessmentTemplate modal (the custom attributes section).

If the possible choices for a custom attribute of type dropdown have looooong naaaaames, their text was wrapped into multiple lines, causing a vertical alignment mismatch with the checkboxes in the next two columns (they all fit into a single line) - it became difficult for the users to see which checkbox corresponds to a particular dropdown's option.