### PR TITLE
QUICK-FIX Add tooltip to comma-separated values input field

### DIFF
--- a/src/ggrc/assets/mustache/assessment_templates/attribute_add_field.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/attribute_add_field.mustache
@@ -26,6 +26,7 @@
     <input class="input-block-level"
       can-value="selected.values"
       type="text"
+      title="{{placeholder}}"
       placeholder="{{placeholder}}">
     {{#selected.invalidValues}}
         <label class="warning">Cannot be blank</label>


### PR DESCRIPTION
When defining a dropdown custom attribute field (e.g. in the create AssessmentTemplate modal), its possible values are entered into the provided input field containing instructions as a placeholder text.

Since the input field is too small, the placeholder text does not fit in, thus I added a tooltip displaying the very same text. This seemed a better option than (excessively) extending the input field's size, since the instructions are simply too long for that.