### PR TITLE
QUICK-FIX Reset assessment status after change CA

### DIFF
--- a/src/ggrc/assets/javascripts/components/inline_edit/inline.js
+++ b/src/ggrc/assets/javascripts/components/inline_edit/inline.js
@@ -11,8 +11,7 @@
   GGRC.Components('inlineEdit', {
     tag: 'inline-edit',
     template: can.view(
-      GGRC.mustache_path +
-      '/components/inline_edit/inline.mustache'
+      GGRC.mustache_path + '/components/inline_edit/inline.mustache'
     ),
     scope: {
       instance: null,
@@ -45,12 +44,15 @@
        */
       enableEdit: function (scope, $el, ev) {
         ev.preventDefault();
-
-        if (!this.attr('readonly')) {
+        if (!this.attr('readonly') && scope.needConfirm) {
+          scope.needConfirm.confirm(scope.instance, scope.needConfirm)
+            .done(function () {
+              this.attr('context.isEdit', true);
+            }.bind(this));
+        } else if (!this.attr('readonly')) {
           this.attr('context.isEdit', true);
         }
       },
-
       onCancel: function (ctx, el, ev) {
         ev.preventDefault();
         this.attr('context.isEdit', false);

--- a/src/ggrc/assets/javascripts/components/inline_edit/tests/inline_edit_spec.js
+++ b/src/ggrc/assets/javascripts/components/inline_edit/tests/inline_edit_spec.js
@@ -44,7 +44,8 @@ describe('GGRC.Components.inlineEdit', function () {
         preventDefault: jasmine.createSpy()
       };
       scope = new can.Map({
-        context: {}
+        context: {},
+        instance: {}
       });
     });
 
@@ -58,6 +59,7 @@ describe('GGRC.Components.inlineEdit', function () {
 
       it('enters the edit mode if editing allowed', function () {
         scope.attr('context.isEdit', false);
+        scope.attr('instance.status', 'In Progress');
         scope.attr('readonly', false);
 
         enableEdit(scope, $el, ev);
@@ -66,6 +68,7 @@ describe('GGRC.Components.inlineEdit', function () {
 
       it('does not enter the edit mode if editing not allowed', function () {
         scope.attr('context.isEdit', false);
+        scope.attr('instance.status', 'In Progress');
         scope.attr('readonly', true);
 
         enableEdit(scope, $el, ev);

--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -872,6 +872,12 @@
         show_view: GGRC.mustache_path + '/base_templates/urls.mustache'
       }
     },
+    confirmEditModal: {
+      title: 'Confirm moving Request to "In Progress"',
+      description: 'You are about to move request from ' +
+      '"{{status}}" to "In Progress" - are you sure about that?',
+      button: 'Confirm'
+    },
     assignable_list: [{
       type: 'creator',
       mapping: 'related_creators',

--- a/src/ggrc/assets/mustache/assessments/info.mustache
+++ b/src/ggrc/assets/mustache/assessments/info.mustache
@@ -47,7 +47,12 @@
           </div>
 
           {{{render '/static/mustache/base_objects/urls.mustache' is_program=true instance=instance}}}
-          {{{render '/static/mustache/custom_attributes/info.mustache' instance=instance}}}
+
+          {{#if_in instance.status "Completed,Verified"}}
+            {{{render '/static/mustache/custom_attributes/info.mustache' instance=instance confirmEdit=confirmEdit}}}
+          {{else}}
+            {{{render '/static/mustache/custom_attributes/info.mustache' instance=instance}}}
+          {{/if_in}}
 
           <div class="row-fluid wrap-row" {{#instance}}{{data 'model'}}{{/instance}} data-force-refresh="true"
             data-model="true" {{ (el) -> el.ggrc_controllers_quick_form({ instance : el.data('model')}); }}>

--- a/src/ggrc/assets/mustache/base_templates/people_list.mustache
+++ b/src/ggrc/assets/mustache/base_templates/people_list.mustache
@@ -19,4 +19,5 @@
         </li>
       {{/if}}
     {{/instance}}
-</ul>
+  </ul>
+</div>

--- a/src/ggrc/assets/mustache/custom_attributes/info.mustache
+++ b/src/ggrc/assets/mustache/custom_attributes/info.mustache
@@ -17,6 +17,7 @@
               {{#case 'Checkbox'}}
                 <inline-edit
                   instance="instance"
+                  need-confirm="confirmEdit"
                   ca-id="id"
                   value="value"
                   label="title"
@@ -29,6 +30,7 @@
               {{#case 'Rich Text'}}
                 <inline-edit
                   instance="instance"
+                  need-confirm="confirmEdit"
                   ca-id="id"
                   value="value"
                   label="title"
@@ -41,6 +43,7 @@
               {{#case 'Dropdown'}}
                 <inline-edit
                   instance="instance"
+                  need-confirm="confirmEdit"
                   ca-id="id"
                   value="value"
                   label="title"
@@ -54,6 +57,7 @@
               {{#case 'Date'}}
                 <inline-edit
                   instance="instance"
+                  need-confirm="confirmEdit"
                   ca-id="id"
                   value="value"
                   label="title"
@@ -66,6 +70,7 @@
               {{#case 'Text'}}
                 <inline-edit
                   instance="instance"
+                  need-confirm="confirmEdit"
                   ca-id="id"
                   value="value"
                   label="title"
@@ -79,6 +84,7 @@
                 {{#with_object_for_id id}}
                   <inline-edit
                     instance="instance"
+                    need-confirm="confirmEdit"
                     ca-id="id"
                     value="object"
                     label="title"
@@ -99,6 +105,6 @@
         </div>
       {{/list}}
       </div>
-    {{/instance.custom_attribute_definitions}}
+    {{/iterate_by_two}}
   {{/if}}
 </custom-attributes>

--- a/src/ggrc/models/mixin_autostatuschangable.py
+++ b/src/ggrc/models/mixin_autostatuschangable.py
@@ -280,5 +280,8 @@ class AutoStatusChangable(object):
       if obj.documentable.type == model.__name__:
         cls.handle_first_class_edit(model, obj.documentable)
 
+# pylint: disable=fixme
+# TODO: find a way to listen for updates only for classes that use
+# AutoStatusChangable, not for every flush event for every session
 event.listen(Session, 'before_flush',
              AutoStatusChangable.adjust_status_before_flush)

--- a/src/ggrc/models/mixin_autostatuschangable.py
+++ b/src/ggrc/models/mixin_autostatuschangable.py
@@ -7,7 +7,9 @@
 
 import datetime
 
+from sqlalchemy import event
 from sqlalchemy import inspect
+from sqlalchemy.orm.session import Session
 
 from ggrc import db
 from ggrc.models import relationship
@@ -109,9 +111,10 @@ class AutoStatusChangable(object):
   def handle_first_class_edit(cls, model, obj, rel=None, method=None):
     """Handles first class edit
 
-    Performs check whether object received first class edit (ordinary edit
+    Performs check whether object received first class edit (ordinary edit)
     that should transition object to PROGRESS_STATE from either: START_STATE
-    or one of END_STATES.
+    or one of END_STATES and sets obj._need_status_reset to True if the state
+    transition is needed.
 
     Args:
       model: (db.Model class) Class from which to read FIRST_CLASS_EDIT
@@ -122,10 +125,25 @@ class AutoStatusChangable(object):
       method: (string) HTTP method used that triggered signal
     """
 
-    # pylint: disable=unused-argument,unused-variable
+    # pylint: disable=unused-argument,protected-access
 
     if obj.status in model.FIRST_CLASS_EDIT:
-      cls.adjust_status(model, obj)
+      obj._need_status_reset = True
+
+  @classmethod
+  def adjust_status_before_flush(cls, session, flush_context, instances):
+    """Reset status of AutoStatusChangable objects with _need_status_reset.
+
+    Is registered to listen for 'before_flush' events on a later stage.
+    """
+
+    # pylint: disable=unused-argument
+
+    for obj in session.identity_map.values():
+      if (isinstance(obj, AutoStatusChangable) and
+              getattr(obj, '_need_status_reset', False)):
+        cls.adjust_status(type(obj), obj)
+        delattr(obj, '_need_status_reset')
 
   @classmethod
   def handle_person_edit(cls, model, obj, rel, method):
@@ -261,3 +279,6 @@ class AutoStatusChangable(object):
 
       if obj.documentable.type == model.__name__:
         cls.handle_first_class_edit(model, obj.documentable)
+
+event.listen(Session, 'before_flush',
+             AutoStatusChangable.adjust_status_before_flush)

--- a/src/ggrc_gdrive_integration/assets/mustache/requests/gdrive_evidence_storage.mustache
+++ b/src/ggrc_gdrive_integration/assets/mustache/requests/gdrive_evidence_storage.mustache
@@ -31,7 +31,7 @@
           >
         </ggrc-gdrive-picker-launcher>
         <i class="fa fa-exclamation-triangle red" style="margin-top:4px" rel="tooltip" data-placement="bottom" data-original-title="Audit folder not set. Files will be uploaded to your GDrive root folder."></i>
-      {{/if_in}}
+      {{/if}}
     {{else}}
       {{#if extended_folders.length}}
         <ggrc-gdrive-picker-launcher
@@ -48,8 +48,8 @@
           click_event="trigger_upload">
         </ggrc-gdrive-picker-launcher>
         <i class="fa fa-exclamation-triangle red" style="margin-top:4px" rel="tooltip" data-placement="bottom" data-original-title="Audit folder not set. Files will be uploaded to your GDrive root folder."></i>
-      {{/if_in}}
-    {{/if}}
+      {{/if}}
+    {{/if_in}}
   </div>
 {{else}}
   {{! This is a failure state for with_mapping, if something in the mapping doesn't refresh properly }}


### PR DESCRIPTION
**Subject:** In Completed assessment, if user modifies any attribute (except comment), assessment status should change to "In Progress". 
**Details:** 
Create  Assessment under the Audit using an Assessment Template with some CA fields
Complete the Assessment
Change Assessment’s CA field value in Assessment’s info panel

_Actual Result:_  Assessment’s status remains “Completed”
_Expected Result:_ Assessment’s status should be changed to “In Progress” (Need to add the same popup warning message, as we do when user adds an evidence attachment.)