### PR TITLE
QUICK-FIX Save CA values on AT

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/modals_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/modals_controller.js
@@ -894,6 +894,22 @@ can.Control('GGRC.Controllers.Modals', {
       }
 
       this.disable_hide = true;
+    /**
+     * Temporary solution and after updated the backend it need to be deleted
+     * Start deprecated block
+     */
+    instance._cachedCADefinitions = [];
+
+    _.forEach(instance.custom_attribute_definitions, function (attr, i) {
+      instance._cachedCADefinitions[i] = {
+        id: attr.id,
+        multi_choice_mandatory: attr.multi_choice_mandatory || '',
+        mandatory: !!attr.mandatory
+      };
+    });
+    /**
+     * End deprecated block
+     */
       ajd = instance.save();
       ajd.fail(this.save_error.bind(this))
         .done(function (obj) {


### PR DESCRIPTION
Assessment Template: When we edit custom attribute with dropdown type, the checkboxes for Attachment, Comment, Mandatory are not saved.