### PR TITLE
CORE-3708 Improve custom attribute values help's visibility

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment_attributes.js
+++ b/src/ggrc/assets/javascripts/components/assessment_attributes.js
@@ -20,11 +20,11 @@
       types: new can.List([{
         type: 'Text',
         name: 'Text',
-        text: 'Type description'
+        text: 'Enter description'
       }, {
         type: 'Rich Text',
         name: 'Rich Text',
-        text: 'Type description'
+        text: 'Enter description'
       }, {
         type: 'Date',
         name: 'Date',
@@ -36,7 +36,7 @@
       }, {
         type: 'Dropdown',
         name: 'Dropdown',
-        text: 'Type values separated by comma'
+        text: 'Enter values separated by comma'
       }, {
         type: 'Map:Person',
         name: 'Person',

--- a/src/ggrc/assets/mustache/assessment_templates/attribute_add_field.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/attribute_add_field.mustache
@@ -21,13 +21,15 @@
     {{/types}}
   </select>
 </div>
-<div class="span2{{#selected.invalidValues}} field-failure{{/selected.invalidValues}}">
+<div class="span2{{#selected.invalidValues}}
+            field-failure{{/selected.invalidValues}}
+            ca-values">
   {{#in_array selected.type valueAttrs}}
     <input class="input-block-level"
       can-value="selected.values"
       type="text"
-      title="{{placeholder}}"
       placeholder="{{placeholder}}">
+      <i class="fa fa-question-circle" rel="tooltip" title="{{placeholder}}"></i>
     {{#selected.invalidValues}}
         <label class="warning">Cannot be blank</label>
     {{/selected.invalidValues}}

--- a/src/ggrc/assets/stylesheets/_common.scss
+++ b/src/ggrc/assets/stylesheets/_common.scss
@@ -794,6 +794,20 @@ p {
       select {
         margin-bottom: 0;
       }
+      .ca-values {
+        input {
+          float: left;
+          width: 80%;
+        }
+        i.fa {
+          float: left;
+          margin: 6px 0 0 6px;
+          opacity: 0.2;
+          &:hover {
+            opacity: 0.7;
+          };
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
**Ticket description:**


> When defining a new custom attribute of type Dropdown, the tooltip help over the possible values input field appears only after some delay. It is thus not obvious to the user that such help exist.
> 
> An icon should be added next to the input field, and the tooltip should be triggered by hovering over it.
> 
> The existing input field tooltip should be removed.
