### PR TITLE
QUICK-FIX Hide Save & Add Another button from AT modal

### DIFF
--- a/src/ggrc/assets/mustache/modals/save_cancel_delete_buttons.mustache
+++ b/src/ggrc/assets/mustache/modals/save_cancel_delete_buttons.mustache
@@ -59,12 +59,14 @@
               >Save &amp; Close</a>
           {{/new_object_form}}
           {{#new_object_form}}
+            {{^if_equals model.shortName "AssessmentTemplate"}}
             <a
               tabindex="24"
               class="btn btn-small btn-info preventdoubleclick {{disable_if_errors instance}}"
               data-toggle="modal-submit-addmore"
               href="javascript://"
               >Save &amp; Add Another</a>
+            {{/if_equals}}
             <a
               tabindex="25"
               class="btn btn-small btn-success preventdoubleclick {{disable_if_errors instance}}"


### PR DESCRIPTION
**Subject:** Script error "Uncaught TypeError: Cannot read property 'editor' of undefined" appears if  Save & Add Another button is clicked when creating a template with all types of fields
**Details:** 
Start creating an Assessment Template on audit page
Add all the types of CA fields to the template
Click Save & Add another button

_Actual result:_ Script Error "Uncaught TypeError: Cannot read property 'editor' of undefined" appears