### PR TITLE
QUICK-FIX Add Save button disabler

### DIFF
--- a/src/ggrc/assets/mustache/modals/save_cancel_delete_buttons.mustache
+++ b/src/ggrc/assets/mustache/modals/save_cancel_delete_buttons.mustache
@@ -53,7 +53,7 @@
           {{^new_object_form}}
             <a
               tabindex="25"
-              class="btn btn-small btn-success preventdoubleclick"
+              class="btn btn-small btn-success preventdoubleclick {{disable_if_errors instance}}"
               data-toggle="modal-submit"
               href="javascript://"
               >Save &amp; Close</a>


### PR DESCRIPTION
Steps to reproduce:
1. Open editing modal of any Assessment.
2. Remove the title, make sure the title field is marked with a red validation box.
Expected result: Save & Close button is grayed out and unclickable.
Actual result: Save & Close button is active and green, but clicking it makes nothing.

This PR just re-adds a conditional "disabled" class of the Save & Close button that has been lost some commits ago accidentally.