### PR TITLE
CORE-3560 Bring back task reordering

### DIFF
--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -147,6 +147,7 @@ dashboard-js-files:
   - components/add_comment/add_comment.js
   - components/object_cloner/object_cloner.js
   - components/object_counter/object_counter.js
+  - components/sort_by_sort_index/sort_by_sort_index.js
   #- d3.v2.js
   #- related_graph.js
 

--- a/src/ggrc/assets/javascripts/components/sort_by_sort_index/sort_by_sort_index.js
+++ b/src/ggrc/assets/javascripts/components/sort_by_sort_index/sort_by_sort_index.js
@@ -1,0 +1,94 @@
+/*!
+    Copyright (C) 2016 Google Inc.
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+(function (can, $) {
+  'use strict';
+
+  GGRC.Components('sortBySortIndex', {
+    tag: 'sort-by-sort-index',
+    scope: {
+      sorted: null,
+      mapping: null,
+      next_sort_index: null
+    },
+
+    init: function () {
+      var mapping = this.scope.attr('mapping');
+      var sort = function () {
+        var arr = _.toArray(mapping);
+        var last;
+        var lastIndex;
+        arr.sort(function (a, b) {
+          a = a.instance.sort_index;
+          b = b.instance.sort_index;
+          if (a === b) {
+            return 0;
+          }
+          return GGRC.Math.string_less_than(a, b) ? -1 : 1;
+        });
+        this.scope.attr('sorted', arr);
+        last = arr[arr.length - 1];
+        lastIndex = (last !== -Infinity) ? last.instance.sort_index : '0';
+        this.scope.attr('next_sort_index',
+            GGRC.Math.string_half(
+                GGRC.Math.string_add(
+                    Number.MAX_SAFE_INTEGER.toString(), lastIndex
+                )
+            )
+        );
+      }.bind(this);
+      sort();
+      mapping.bind('change', sort);
+    },
+
+    events: {
+      ' sortupdate': function (el, ev, ui) {
+        var mapping = this.scope.attr('mapping');
+        var instanceIndex = _.indexBy(_.pluck(mapping, 'instance'), 'id');
+
+        var instances = _.map(ui.item.parent().children('li'), function (el) {
+          return instanceIndex[$(el).data('object-id')];
+        });
+
+        var targetIndex = _.findIndex(instances, {
+          id: ui.item.data('object-id')
+        });
+
+        var nexts = []; // index for constant time next element lookup
+        var dirty = []; // instances to be saved
+        instances[targetIndex].attr('sort_index', null);
+        nexts[instances.length] = Number.MAX_SAFE_INTEGER.toString();
+        _.eachRight(instances, function (instance, index) {
+          nexts[index] = instance.sort_index || nexts[index + 1];
+        });
+
+        // in most cases this will only update sort_index for targetIndex
+        // but will also correctly resolve missing or duplicate sort_index-es
+        _.each(instances, function (instance, index) {
+          var prev;
+          var next;
+          if (instance.sort_index &&
+              instance.sort_index !== nexts[index + 1]) {
+            return;
+          }
+          prev = (instances[index - 1] || {sort_index: '0'}).sort_index;
+          next = nexts[index + 1];
+          instance.attr('sort_index', GGRC.Math.string_half(
+                GGRC.Math.string_add(prev, next)
+          ));
+          dirty.push(instance);
+        });
+
+        _.each(dirty, function (instance) {
+          var index = instance.sort_index;
+          return instance.refresh().then(function (instance) {
+            instance.attr('sort_index', index);
+            instance.save();
+          });
+        });
+      }
+    }
+  });
+})(window.can, window.can.$);

--- a/src/ggrc_workflows/assets/mustache/task_group_tasks/task_group_subtree.mustache
+++ b/src/ggrc_workflows/assets/mustache/task_group_tasks/task_group_subtree.mustache
@@ -3,12 +3,19 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
 
-  <li data-object-id="{{instance.id}}" data-object-type="{{instance.class.table_singular}}">
+  <li data-object-id="{{instance.id}}"
+      data-object-type="{{instance.class.table_singular}}">
     <div class="objective-selector field-wrap task-wrap" data-model="true" {{#instance}}{{data "model"}}{{/instance}}>
       <div class="row-fluid">
         <div class="span4">
           <div class="oneline">
-            <i class="fa fa-{{instance.class.table_singular}} color"></i>
+            {{#is_allowed 'update' instance}}
+            {{^if_equals instanceworkflow.reify.status 'Inactive'}}
+            <a class="drag {{#parent_instance.lock_task_order}}disabled{{/parent_instance.lock_task_order}}" href="javascript://">
+              <i class="fa fa-arrows-v"></i>
+            </a>
+            {{/if_equals}}
+            {{/is_allowed}}
             <span class="inline-data-content">{{instance.title}}</span>
           </div>
         </div>

--- a/src/ggrc_workflows/assets/mustache/task_group_tasks/task_group_subtree_footer.mustache
+++ b/src/ggrc_workflows/assets/mustache/task_group_tasks/task_group_subtree_footer.mustache
@@ -17,7 +17,7 @@
     data-object-singular="TaskGroupTask"
     data-toggle="modal-ajax-form"
     data-modal-reset="reset"
-    data-object-params='{ "task_group": {{instance.id}}, "context": {{instance.context.id}}, "modal_title": "Create New Task" }'>
+    data-object-params='{ "task_group": {{instance.id}}, "context": {{instance.context.id}}, "sort_index": "{{next_sort_index}}", "modal_title": "Create New Task" }'>
     <i class="fa fa-plus-circle"></i>
   </a>
 </div>

--- a/src/ggrc_workflows/assets/mustache/task_groups/info.mustache
+++ b/src/ggrc_workflows/assets/mustache/task_groups/info.mustache
@@ -62,12 +62,15 @@
           {{#with_mapping 'task_group_tasks' instance}}
             <h3>Tasks (<span>{{task_group_tasks.length}}</span>)</h3>
             <h4 class="inline-explanation">Define tasks</h4>
-            <ul class="tree-structure new-tree">
-              {{#each task_group_tasks}}
-                {{>'/static/mustache/task_group_tasks/task_group_subtree.mustache'}}
-              {{/each}}
-              {{>'/static/mustache/task_group_tasks/task_group_subtree_footer.mustache'}}
-            </ul>
+            <sort-by-sort-index mapping="task_group_tasks">
+              <ul class="tree-structure new-tree"
+                  {{sortable_if instance.lock_task_order '{ "items": "li:not(.tree-footer)", "handle": ".drag" }' inverse=true}}>
+                {{#each sorted}}
+                  {{>'/static/mustache/task_group_tasks/task_group_subtree.mustache'}}
+                {{/each}}
+                {{>'/static/mustache/task_group_tasks/task_group_subtree_footer.mustache'}}
+              </ul>
+            </sort-by-sort-index>
           {{/with_mapping}}
         </div>
 


### PR DESCRIPTION
This re-implements reordering outside tree view. 
Sadly I couldn't remove the reordering code from tree view since it's still used for task groups and I don't know how to ingrate it there - suggestions welcome.