### PR TITLE
ISSUE-139 CA has no definition and no value

### DIFF
--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -984,13 +984,13 @@
           instance.get_binding('all_documents').refresh_count(),
           rq.trigger()
       ).then(function (customAttrVals, commentCount, attachmentCount, rqRes) {
-        var values = _.map(instance.custom_attribute_values, function (cav) {
-          return cav.reify();
-        });
+        var values = instance.custom_attribute_values.reify();
+        var definitions = instance.custom_attribute_definitions.reify();
+
         commentCount = commentCount();
         attachmentCount = attachmentCount();
-        _.each(instance.custom_attribute_definitions, function (definition) {
-          var attr = _.result(_.find(values, function (cav) {
+        _.each(definitions, function (definition) {
+          var attr = _.result(_.find(definitions, function (cav) {
             return cav.custom_attribute_id === definition.id;
           }), 'attribute_value');
 
@@ -1003,10 +1003,14 @@
           var definition;
           var i;
           var mandatory;
-          definition = _.find(instance.custom_attribute_definitions, {
+          definition = _.find(definitions, {
             id: cav.custom_attribute_id
           });
-          if (!definition.multi_choice_options ||
+          if (!definition) {
+            console.warn('CAV id %d is not reified properly.', cav.id);
+          }
+          if (!definition ||
+              !definition.multi_choice_options ||
               !definition.multi_choice_mandatory) {
             return;
           }


### PR DESCRIPTION
### Subject:
Script error "Uncaught TypeError: Cannot read property 'multi_choice_options' of undefined" appears when updating Assessment status for the other user

### Details: 

as GE user: 
- Create a program
- Create an audit
- Assign the GC user as the auditor
- Create an Assessment 
- Set GE user as the assessor and leave Verifier blanc
- Log in as GC user and navigate to Audit page -> Assessments tab
- Confirm you see the same status under both users
As GE user complete the assessment
- As GC user click the 1st tier of the assessment in the tree view list

### Actual Result:
Script error "Uncaught TypeError: Cannot read property 'multi_choice_options' of undefined" appears

### Expected Result:
No errors should appear
