### PR TITLE
QUICK-FIX CA drag exception

### DIFF
--- a/src/ggrc/assets/javascripts/bootstrap/modal-ajax.js
+++ b/src/ggrc/assets/javascripts/bootstrap/modal-ajax.js
@@ -249,16 +249,16 @@
       $target
       .modal_form(option, $trigger)
       .ggrc_controllers_modals({
-          new_object_form : !$trigger.attr('data-object-id')
-        , object_params : object_params
-        , button_view : GGRC.Controllers.Modals.BUTTON_VIEW_SAVE_CANCEL_DELETE
-        , model : model
-        , current_user : GGRC.current_user
-        , instance : instance
-        , modal_title : object_params.modal_title || modal_title
-        , content_view : content_view
-        , mapping : mapping
-        , $trigger: $trigger
+        new_object_form : !$trigger.attr('data-object-id'),
+        object_params : object_params,
+        button_view : GGRC.Controllers.Modals.BUTTON_VIEW_SAVE_CANCEL_DELETE,
+        model : model,
+        current_user : GGRC.current_user,
+        instance : instance,
+        modal_title : object_params.modal_title || modal_title,
+        content_view : content_view,
+        mapping : mapping,
+        $trigger: $trigger
       });
 
       $target.on('modal:success', function(e, data, xhr) {

--- a/src/ggrc/assets/javascripts/components/assessment_attributes.js
+++ b/src/ggrc/assets/javascripts/components/assessment_attributes.js
@@ -59,9 +59,10 @@
         // It's not nice way to rely on DOM for sorting,
         // but it was easiest for implementation
         this.scope.fields.replace(_.map(sortables,
-          function (item) {
-            return $(item).data('field');
-          }));
+           function (item) {
+             return $(item).data('field');
+           }
+        ));
       }
     }
   });
@@ -74,7 +75,7 @@
     tag: 'template-field',
     template: can.view(GGRC.mustache_path +
       '/assessment_templates/attribute_field.mustache'),
-    scope: function (attrs, parentScope) {
+    scope: function (attrs, parentScope, element) {
       return {
         types: parentScope.attr('types'),
         pads: {

--- a/src/ggrc/assets/mustache/assessment_templates/attribute_field.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/attribute_field.mustache
@@ -6,33 +6,31 @@
 }}
 
 {{^field._pending_delete}}
-<li {{data 'field'}} class="row-fluid sortable-item">
   <div class="span-custom2-and-half">{{field.title}}</div>
-    <div class="span-custom1-and-half">{{field.attribute_name}}</div>
-    <div class="span2">
-      {{#attrs}}
-        <span class="block single-line" title="{{.}}">{{.}}</span>
-      {{/attrs}}
+  <div class="span-custom1-and-half">{{field.attribute_name}}</div>
+  <div class="span2">
+    {{#attrs}}
+      <span class="block single-line" title="{{.}}">{{.}}</span>
+    {{/attrs}}
+  </div>
+  <div class="span2 centered checkbox-wrap">
+    {{#attrs}}
+      <input can-value="field.opts.attachment-{{.}}" type="checkbox">
+    {{/attrs}}
+  </div>
+  <div class="span1 centered checkbox-wrap">
+    {{#attrs}}
+      <input can-value="field.opts.comment-{{.}}" type="checkbox">
+    {{/attrs}}
+  </div>
+  <div class="span1 centered checkbox-wrap">
+    <input type="checkbox" can-value="field.mandatory">
+  </div>
+  <div class="span2">
+    <div class="pull-right">
+      {{#field}}
+        <a can-click="removeField" href="#"><i class="fa fa-trash"></i></a>
+      {{/field}}
     </div>
-    <div class="span2 centered checkbox-wrap">
-      {{#attrs}}
-        <input can-value="field.opts.attachment-{{.}}" type="checkbox">
-      {{/attrs}}
-    </div>
-    <div class="span1 centered checkbox-wrap">
-      {{#attrs}}
-        <input can-value="field.opts.comment-{{.}}" type="checkbox">
-      {{/attrs}}
-    </div>
-    <div class="span1 centered checkbox-wrap">
-      <input type="checkbox" can-value="field.mandatory">
-    </div>
-    <div class="span2">
-      <div class="pull-right">
-        {{#field}}
-          <a can-click="removeField" href="#"><i class="fa fa-trash"></i></a>
-        {{/field}}
-      </div>
-    </div>
-  </li>
+  </div>
 {{/field._pending_delete}}

--- a/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
@@ -248,7 +248,11 @@
                       </add-template-field>
                     </li>
                     {{#fields}}
-                      <template-field field="." fields="fields"></template-field>
+                      {{^if _pending_delete}}
+                          <li class="row-fluid{{#new_object_form}} sortable-item{{/new_object_form}}" {{data 'field'}}>
+                              <template-field field="." fields="fields"></template-field>
+                          </li>
+                      {{/if _pending_delete}}
                     {{/fields}}
                   </ul>
                 </div>


### PR DESCRIPTION
Script error: Uncaught TypeError: Cannot read property 'name' of undefined appears when trying to change the order of custom attributes when creating a new Assessment Template