### PR TITLE
QUICK-FIX fix showing risk assessments

### DIFF
--- a/src/ggrc_risk_assessments/assets/mustache/risk_assessments/info.mustache
+++ b/src/ggrc_risk_assessments/assets/mustache/risk_assessments/info.mustache
@@ -42,11 +42,15 @@
       </div>
       <div class="span4">
         <h6>Risk Manager</h6>
-        <person person-obj="instance.ra_manager"></person>
+        {{#using person=instance.ra_manager}}
+          {{{render '/static/mustache/people/popover.mustache'}}}
+        {{/using}}
       </div>
       <div class="span4">
         <h6>Risk Counsel</h6>
-        <person person-obj="instance.ra_counsel"></person>
+        {{#using person=instance.ra_counsel}}
+          {{{render '/static/mustache/people/popover.mustache'}}}
+        {{/using}}
       </div>
     </div>
 


### PR DESCRIPTION
This reverts commit ca620e8e05d1b8da843f41b446cda4099ce84282 since person
component was having issues:
- errors when rendering without a person
- sometimes not updating after an edit