### PR TITLE
QUICK-FIX Fire validation on every editing modal open

### DIFF
--- a/src/ggrc/assets/javascripts/bootstrap/modal-form.js
+++ b/src/ggrc/assets/javascripts/bootstrap/modal-form.js
@@ -153,33 +153,36 @@
   }
 
   , hide: function (e) {
-    var that = this,
-      control = this.$element.control(),
-      options = control && control.options;
+    var that = this;
+    var control = this.$element.control();
+    var options = control && control.options;
 
-      // If the hide was initiated by the backdrop, check for dirty form data before continuing
+    // If the hide was initiated by the backdrop, check for dirty form data
+    // before continuing
     if (e && $(e.target).is('.modal-backdrop')) {
-
-      if ($(e.target).is(".disabled")) {
-          // In the case of a disabled modal backdrop, treat it like any other disabled data-dismiss,
-          //  i.e. do nothing.
+      if ($(e.target).is('.disabled')) {
+        // In the case of a disabled modal backdrop, treat it like any other disabled data-dismiss,
+        //  i.e. do nothing.
         e.stopPropagation();
         return;
       }
       if (this.is_form_dirty()) {
-          // Confirm that the user wants to lose the data prior to hiding
+        // Confirm that the user wants to lose the data prior to hiding
         GGRC.Controllers.Modals.confirm({
-          modal_title : "Discard Changes"
-            , modal_description : "Are you sure that you want to discard your changes?"
-            , modal_confirm : "Discard"
-            , instance : options.instance
-            , model : options.model
-            , skip_refresh : true
+          modal_title: 'Discard Changes',
+          modal_description:
+            'Are you sure that you want to discard your changes?',
+          modal_confirm: 'Discard',
+          instance: options.instance,
+          model: options.model,
+          skip_refresh: true
         }, function () {
           $.when((function () {
-            can.trigger(options.instance, "modal:dismiss");
+            can.trigger(options.instance, 'modal:dismiss');
           })()).then(function () {
-            that.$element.find("[data-dismiss='modal'], [data-dismiss='modal-reset']").trigger("click");
+            that.$element.find(
+              "[data-dismiss='modal'], [data-dismiss='modal-reset']"
+            ).trigger('click');
             that.hide();
           });
         });
@@ -187,10 +190,10 @@
       }
     }
 
-      // Hide the modal like normal
+    // Hide the modal like normal
     $.when((function () {
       if (options) {
-        return can.trigger(options.instance, "modal:dismiss");
+        return can.trigger(options.instance, 'modal:dismiss');
       }
       return;
     })()).then(function () {

--- a/src/ggrc/assets/javascripts/bootstrap/modal-form.js
+++ b/src/ggrc/assets/javascripts/bootstrap/modal-form.js
@@ -177,29 +177,22 @@
           model: options.model,
           skip_refresh: true
         }, function () {
-          $.when((function () {
-            can.trigger(options.instance, 'modal:dismiss');
-          })()).then(function () {
-            that.$element.find(
-              "[data-dismiss='modal'], [data-dismiss='modal-reset']"
-            ).trigger('click');
-            that.hide();
-          });
+          can.trigger(options.instance, 'modal:dismiss');
+          that.$element.find(
+            "[data-dismiss='modal'], [data-dismiss='modal-reset']"
+          ).trigger('click');
+          that.hide();
         });
         return;
       }
     }
 
     // Hide the modal like normal
-    $.when((function () {
-      if (options) {
-        return can.trigger(options.instance, 'modal:dismiss');
-      }
-      return;
-    })()).then(function () {
-      $.fn.modal.Constructor.prototype.hide.apply(this, [e]);
-      this.$element.off('modal_form');
-    }.bind(this));
+    if (options) {
+      can.trigger(options.instance, 'modal:dismiss');
+    }
+    $.fn.modal.Constructor.prototype.hide.apply(this, [e]);
+    this.$element.off('modal_form');
   }
 
   , focus_first_input: function (ev) {

--- a/src/ggrc/assets/javascripts/bootstrap/modal-form.js
+++ b/src/ggrc/assets/javascripts/bootstrap/modal-form.js
@@ -176,9 +176,9 @@
             , model : options.model
             , skip_refresh : true
         }, function () {
-          $.when(function () {
+          $.when((function () {
             can.trigger(options.instance, "modal:dismiss");
-          }).then(function () {
+          })()).then(function () {
             that.$element.find("[data-dismiss='modal'], [data-dismiss='modal-reset']").trigger("click");
             that.hide();
           });
@@ -188,12 +188,12 @@
     }
 
       // Hide the modal like normal
-    $.when(function () {
+    $.when((function () {
       if (options) {
         return can.trigger(options.instance, "modal:dismiss");
       }
       return;
-    }).then(function () {
+    })()).then(function () {
       $.fn.modal.Constructor.prototype.hide.apply(this, [e]);
       this.$element.off('modal_form');
     }.bind(this));

--- a/src/ggrc/assets/javascripts/controllers/modals_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/modals_controller.js
@@ -270,9 +270,14 @@ can.Control('GGRC.Controllers.Modals', {
     }
     return dfd.done(function () {
       this.reset_form(function () {
-        // Make sure custom attr validations/values are set
-        if (instance && instance.setup_custom_attributes) {
-          instance.setup_custom_attributes();
+        if (instance) {
+          // Make sure custom attr validations/values are reset
+          if (instance.custom_attributes) {
+            instance.custom_attributes = undefined;
+          }
+          if (instance.setup_custom_attributes) {
+            instance.setup_custom_attributes();
+          }
         }
       });
     }.bind(that));

--- a/src/ggrc/assets/javascripts/controllers/modals_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/modals_controller.js
@@ -276,9 +276,7 @@ can.Control('GGRC.Controllers.Modals', {
       this.reset_form(function () {
         if (instance) {
           // Make sure custom attr validations/values are reset
-          if (instance.custom_attributes) {
-            instance.custom_attributes = undefined;
-          }
+          instance.custom_attributes = undefined;
           if (instance.setup_custom_attributes) {
             instance.setup_custom_attributes();
           }

--- a/src/ggrc/assets/javascripts/controllers/modals_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/modals_controller.js
@@ -222,49 +222,53 @@ can.Control('GGRC.Controllers.Modals', {
     ).done(this.proxy('draw'));
   }
 
-  , fetch_data : function(params) {
-    var that = this,
-        dfd,
-        instance;
+  , fetch_data: function (params) {
+    var that = this;
+    var dfd;
+    var instance;
     params = params || this.find_params();
     params = params && params.serialize ? params.serialize() : params;
     if (this.options.skip_refresh && this.options.instance) {
       return new $.Deferred().resolve(this.options.instance);
-    }
-    else if (this.options.instance) {
+    } else if (this.options.instance) {
       dfd = this.options.instance.refresh();
-    }
-    else if (this.options.model) {
-      dfd = this.options.new_object_form
-          ? $.when(this.options.attr("instance", new this.options.model(params).attr("_suppress_errors", true)))
-          : this.options.model.findAll(params).then(function(data) {
-            var h;
-            if(data.length) {
-              that.options.attr("instance", data[0]);
-              return data[0].refresh(); //have to refresh (get ETag) to be editable.
-            } else {
-              that.options.attr("new_object_form", true);
-              that.options.attr("instance", new that.options.model(params));
-              return that.options.instance;
-            }
-          }).done(function() {
-            // Check if modal was closed
-            if(that.element !== null)
-              that.on(); //listen to instance.
-          });
-    }
-    else {
-      this.options.attr("instance", new can.Observe(params));
+    } else if (this.options.model) {
+      if (this.options.new_object_form) {
+        dfd = $.when(this.options.attr(
+          'instance',
+          new this.options.model(params).attr('_suppress_errors', true)
+        ));
+      } else {
+        dfd = this.options.model.findAll(params).then(function (data) {
+          if (data.length) {
+            that.options.attr('instance', data[0]);
+            return data[0].refresh(); // have to refresh (get ETag) to be editable.
+          }
+          that.options.attr('new_object_form', true);
+          that.options.attr('instance', new that.options.model(params));
+          return that.options.instance;
+        }).done(function () {
+          // Check if modal was closed
+          if (that.element !== null) {
+            that.on(); // listen to instance.
+          }
+        });
+      }
+    } else {
+      this.options.attr('instance', new can.Observe(params));
       that.on();
       dfd = new $.Deferred().resolve(this.options.instance);
     }
     instance = this.options.instance;
     if (instance) {
       // Make sure custom attributes are preloaded:
-      dfd = dfd.then(function(){
+      dfd = dfd.then(function () {
         return $.when(
-          instance.load_custom_attribute_definitions && instance.load_custom_attribute_definitions(),
-          instance.custom_attribute_values ? instance.refresh_all('custom_attribute_values') : []
+          instance.load_custom_attribute_definitions &&
+            instance.load_custom_attribute_definitions(),
+          instance.custom_attribute_values ?
+            instance.refresh_all('custom_attribute_values') :
+            []
         );
       });
     }

--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -528,8 +528,6 @@
       this.validateNonBlank('title');
       this.validateNonBlank('end_date');
       this.validateNonBlank('start_date');
-      this.validatePresenceOf('validate_assignee');
-      this.validatePresenceOf('validate_requester');
       this.validatePresenceOf('audit');
 
       this.validate(['start_date', 'end_date'], function (newVal, prop) {
@@ -544,11 +542,17 @@
         }
       });
 
-      this.validate(['validate_assignee', 'validate_requester'],
+      this.validate(
+        'validate_assignee',
         function (newVal, prop) {
           if (!this.validate_assignee) {
             return 'You need to specify at least one assignee';
           }
+        }
+      );
+      this.validate(
+        'validate_requester',
+        function (newVal, prop) {
           if (!this.validate_requester) {
             return 'You need to specify at least one requester';
           }
@@ -897,15 +901,19 @@
       }
       this.validatePresenceOf('object');
       this.validatePresenceOf('audit');
-      this.validatePresenceOf('validate_creator');
-      this.validatePresenceOf('validate_assessor');
       this.validateNonBlank('title');
 
-      this.validate(['validate_creator', 'validate_assessor'],
+      this.validate(
+        'validate_creator',
         function (newVal, prop) {
           if (!this.validate_creator) {
             return 'You need to specify at least one creator';
           }
+        }
+      );
+      this.validate(
+        'validate_assessor',
+        function (newVal, prop) {
           if (!this.validate_assessor) {
             return 'You need to specify at least one assessor';
           }


### PR DESCRIPTION
Steps to reproduce:
- generate an assessment with a mandatory text CA
- open a modal to edit it (the mandatory CA is highlighted red by the validators)
- enter something into that CA (the mandatory CA red box disappears)
- close the modal without saving
- open a modal to edit the same assessment.
Expected result: the mandatory CA field is highlighted red, "save" button is disabled.
Actual result: the mandatory CA field is not highlighted red, "save" button is not disabled.

This PR also fixes the same issue with empty mandatory people lists (assessors, creators, requesters, assignees), to test this case you need to manually remove the relationship between the only creator (assessor, or any mandatory role) and the assessment.