### PR TITLE
QUICK-FIX Add permissions check for remind assessors link

### DIFF
--- a/src/ggrc/assets/mustache/assessments/header.mustache
+++ b/src/ggrc/assets/mustache/assessments/header.mustache
@@ -64,31 +64,33 @@ Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
               {{/is_info_pin}}
 
               {{#if_in instance.status "Not Started,In Progress"}}
-              <li>
-                {{#if_verifiers_defined instance}}
-                  <reminder
-                    instance="instance"
-                    type="statusToPerson"
-                    modal_title="Reminder for Assessors set"
-                    modal_description="Tomorrow all Assessors will receive a notification to look at this Assessment if they didn't move it to 'Finished' in between."
-                  >
-                    <a href="javascript://" can-click="reminder">
-                      <i class="fa fa-bell-o"></i>
-                      Send reminder to assessors</a>
-                  </reminder>
-                {{else}}
-                  <reminder
-                    instance="instance"
-                    type="statusToPerson"
-                    modal_title="Reminder for Assessors set"
-                    modal_description="Tomorrow all Assessors will receive a notification to look at this Assessment if they didn't move it to 'Final' in between."
-                  >
-                    <a href="javascript://" can-click="reminder">
-                      <i class="fa fa-bell-o"></i>
-                      Send reminder to assessors</a>
-                  </reminder>
-                {{/if_verifiers_defined}}
-              </li>
+                {{#is_allowed 'update' instance context='for'}}
+                  <li>
+                    {{#if_verifiers_defined instance}}
+                      <reminder
+                        instance="instance"
+                        type="statusToPerson"
+                        modal_title="Reminder for Assessors set"
+                        modal_description="Tomorrow all Assessors will receive a notification to look at this Assessment if they didn't move it to 'Finished' in between."
+                      >
+                        <a href="javascript://" can-click="reminder">
+                          <i class="fa fa-bell-o"></i>
+                          Send reminder to assessors</a>
+                      </reminder>
+                    {{else}}
+                      <reminder
+                        instance="instance"
+                        type="statusToPerson"
+                        modal_title="Reminder for Assessors set"
+                        modal_description="Tomorrow all Assessors will receive a notification to look at this Assessment if they didn't move it to 'Final' in between."
+                      >
+                        <a href="javascript://" can-click="reminder">
+                          <i class="fa fa-bell-o"></i>
+                          Send reminder to assessors</a>
+                      </reminder>
+                    {{/if_verifiers_defined}}
+                  </li>
+                {{/is_allowed}}
               {{/if_in}}
 
               {{#is_allowed 'delete' instance}}


### PR DESCRIPTION
This PR removes the _"send reminder to Assessors"_ link from the Assessment's ellipsis menu if the user doesn't have permissions to do so (having resulted in an HTTP 403 error before the fix).

This is issue 150 in the part A bug list.