### PR TITLE
QUICK-FIX Fix getting reified instances in mapping treeview

### DIFF
--- a/src/ggrc/assets/javascripts/components/mapped_tree_view.js
+++ b/src/ggrc/assets/javascripts/components/mapped_tree_view.js
@@ -38,7 +38,7 @@
 
       binding = this.scope.parentInstance.get_binding(this.scope.mapping);
 
-      binding.refresh_instances().then(function (mappedObjects) {
+      binding.refresh_list().then(function (mappedObjects) {
         this.scope.attr('mappedObjects').replace(mappedObjects);
       }.bind(this));
 

--- a/src/ggrc/assets/mustache/base_templates/mapping_tree_view.mustache
+++ b/src/ggrc/assets/mustache/base_templates/mapping_tree_view.mustache
@@ -6,9 +6,7 @@
 }}
 
 <ul class="{{#if treeViewClass}}{{treeViewClass}}{{else}}attachment-list{{/if}}">
-  {{#expose reusable=reusable reusedObjects=reusedObjects reuseMethod=reuseMethod mapping=mapping baseInstance=baseInstance isLoading=isLoading isExpandable=isExpandable}}
-    {{#mappedObjects}}
-      {{{render itemTemplate baseInstance=baseInstance parentInstance=parentInstance reusable=reusable reusedObjects=reusedObjects reuseMethod=reuseMethod mapping=mapping isLoading=isLoading isExpandable=isExpandable}}}
-    {{/mappedObjects}}
-  {{/expose}}
+  {{#mappedObjects}}
+    {{{render itemTemplate instance=instance baseInstance=baseInstance parentInstance=parentInstance reusable=reusable reusedObjects=reusedObjects reuseMethod=reuseMethod mapping=mapping isLoading=isLoading isExpandable=isExpandable}}}
+  {{/mappedObjects}}
 </ul>


### PR DESCRIPTION
Steps to reproduce:
- Add a comment with URL on Assessment
- Refresh the page
- Check mapped URL's showing _Invalid date_