### PR TITLE
QUICK-FIX Fix regression on mapping modal close

### DIFF
--- a/src/ggrc/assets/javascripts/bootstrap/modal-form.js
+++ b/src/ggrc/assets/javascripts/bootstrap/modal-form.js
@@ -188,7 +188,7 @@
     }
 
     // Hide the modal like normal
-    if (options) {
+    if (options && options.instance) {
       can.trigger(options.instance, 'modal:dismiss');
     }
     $.fn.modal.Constructor.prototype.hide.apply(this, [e]);


### PR DESCRIPTION
This fixes the regression that makes it impossible to close a mapping modal.