### PR TITLE
QUICK-FIX Prevent mapping objects to a Person in tree view

### DIFF
--- a/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
+++ b/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
@@ -109,11 +109,14 @@
       var canonical;
       var hasWidget;
       var canonicalMapping;
-      var forbidden = {
+
+      // NOTE: the names in every type pair must be sorted alphabetically!
+      var FORBIDDEN = Object.freeze({
         'audit program': true,
         'audit request': true,
-        'assessmenttemplate cacheable': true
-      };
+        'assessmenttemplate cacheable': true,
+        'cacheable person': true
+      });
 
       if (target instanceof can.Model) {
         targetType = target.constructor.shortName;
@@ -127,7 +130,7 @@
       // - mapping an Audit to a Request is not allowed
       // (and vice versa)
       types = [sourceType.toLowerCase(), targetType.toLowerCase()].sort();
-      if (forbidden[types.join(' ')]) {
+      if (FORBIDDEN[types.join(' ')]) {
         return false;
       }
 

--- a/src/ggrc/assets/javascripts/plugins/tests/ggrc_utils_spec.js
+++ b/src/ggrc/assets/javascripts/plugins/tests/ggrc_utils_spec.js
@@ -1,8 +1,6 @@
 /*!
-  Copyright (C) 2015 Google Inc., authors, and contributors <see AUTHORS file>
+  Copyright (C) 2016 Google Inc.
   Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
-  Created By: peter@reciprocitylabs.com
-  Maintained By: peter@reciprocitylabs.com
 */
 
 describe('GGRC utils allowed_to_map() method', function () {
@@ -13,8 +11,6 @@ describe('GGRC utils allowed_to_map() method', function () {
   var fakeProgram;
   var fakeRequest;
   var fakeAudit;
-  var fakeCA;
-  var fakePersonCreator;
 
   beforeAll(function () {
     allowedToMap = GGRC.Utils.allowed_to_map;
@@ -68,28 +64,27 @@ describe('GGRC utils allowed_to_map() method', function () {
     });
   });
 
-  describe('given a Person and Assessment pair', function () {
+  describe('given a Person instance', function () {
+    var origShortName;
+    var otherInstance;
+    var person;
+
+    beforeAll(function () {
+      origShortName = can.Model.shortName;
+      can.Model.shortName = 'cacheable';
+    });
+
+    afterAll(function () {
+      can.Model.shortName = origShortName;
+    });
+
     beforeEach(function () {
-      fakeCA = new CMS.Models.Assessment({type: 'Assessment'});
-      fakePersonCreator = new CMS.Models.Person({type: 'Person'});
-
-      spyOn(Permission, 'is_allowed_for').and.returnValue(false);
-      spyOn(GGRC.Mappings, 'get_canonical_mapping_name');
+      person = new CMS.Models.Person({type: 'Person'});
+      otherInstance = new can.Model({type: 'Foo'});
     });
 
-    it('returns true for Assessment as source and Person as target', function () {
-      var result;
-      GGRC.Mappings.get_canonical_mapping_name.and.returnValue('people');
-      result = allowedToMap(fakeCA, fakePersonCreator, fakeOptions);
-
-      expect(result).toBe(false);
-    });
-
-    it('returns false for Person as source and as Assessment target', function () {
-      var result;
-      GGRC.Mappings.get_canonical_mapping_name.and.returnValue('related_objects');
-      result = allowedToMap(fakePersonCreator, fakeCA, fakeOptions);
-
+    it('returns false for any object', function () {
+      var result = allowedToMap(otherInstance, person);
       expect(result).toBe(false);
     });
   });


### PR DESCRIPTION
**Issue description:**
> Remove "Map object to this person" (+) button from the first tier of the person on program page

This PR, in fact, removes the said button from all pages where a Person appears in a tree view. This is consistent with the tabs on a Person page, where it is not possible to map any new objects to a person, but just viewing them.