### PR TITLE
QUICK-FIX Fix getting definitions from values

### DIFF
--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -998,7 +998,7 @@
         commentCount = commentCount();
         attachmentCount = attachmentCount();
         _.each(definitions, function (definition) {
-          var attr = _.result(_.find(definitions, function (cav) {
+          var attr = _.result(_.find(values, function (cav) {
             return cav.custom_attribute_id === definition.id;
           }), 'attribute_value');
 


### PR DESCRIPTION
This PR fixes a problem with CA validation.

Steps to reproduce:
1. Create an Assessment with a mandatory custom attribute, assign GR as a verifier.
2. Login as the GR-verifier, open the quick view pane of the Assessment in the dashboard.
3. Fill in the mandatory custom attribute.

Expected result: the user should have "Complete" (and, if the Assessment is in "Ready for Review" state, "Reject"/"Verify") buttons active and clickable.
Actual result: "Complete" ("Reject", "Verify") buttons are disabled, an error about empty mandatory custom attributes is displayed on hovering over that buttons.