### PR TITLE
QUICK-FIX Fix custom attributue definitions cache

### DIFF
--- a/src/ggrc/assets/javascripts/pbc/workflow_controller.js
+++ b/src/ggrc/assets/javascripts/pbc/workflow_controller.js
@@ -50,6 +50,10 @@
           }).value();
 
         return $.when.apply($, attrDfd);
+      }).then(function () {
+        // Make sure instance.custom_attribute_definitions cache is cleared
+        instance.custom_attribute_definitions.splice(0,
+            instance.custom_attribute_definitions.length);
       });
 
       instance.delay_resolving_save_until(resolveDfd);


### PR DESCRIPTION
custom_attribute_definitions list contained old values that were
not getting refreshed when the save modal was opened after a save.