### PR TITLE
Store current user as owner of newly created URL

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/quick_form_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/quick_form_controller.js
@@ -194,6 +194,7 @@ can.Component.extend({
         link: value,
         title: value,
         context: this.scope.parent_instance.context || new CMS.Models.Context({id : null}),
+        owners: [CMS.Models.Person.findInCacheById(GGRC.current_user.id)],
       });
     },
   },


### PR DESCRIPTION
This fixes an issue about a Global Reader who is an Assignee (creator, assessor, verifier) of an Assessment, but can't add an URL to it.

Steps to reproduce:
1. Create an Assessment, assign GR as an assessor.
2. Log in as GR.
3. Click "Add URL"  on the Assessment quick view pane
4. Type in some url
5. Click "Add".

Expected result: an URL object is created and mapped to the Assessment, the url is listed in the "URL" section.
Actual result: an URL object is created but is not mapped, FORBIDDEN error is printed, the url is not listed in the "URL" section.