### PR TITLE
CORE-3649 Add hide link for Notifications block

### DIFF
--- a/src/ggrc/assets/mustache/assessments/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessments/modal_content.mustache
@@ -69,6 +69,7 @@
       <div class="row-fluid inner-hide">
         <div class="span12 hidable">
           <div class="comment-notification">
+            <a data-id="hide_notification_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
             <label>
               <input type="checkbox"
                      name="send_by_default"


### PR DESCRIPTION
**Details:**
- start creating a new Assessment via LHN

_Actual Result:_ "Notifications" section on New Assessment modal doesn't have "hide" link
_Expected Result:_ "Notifications" section on New Assessment modal should have "hide" link