### PR TITLE
QUICK-FIX Turn off popover for the removed person

### DIFF
--- a/src/ggrc/assets/javascripts/components/people_list.js
+++ b/src/ggrc/assets/javascripts/components/people_list.js
@@ -304,6 +304,10 @@
         var roleToRemove = can.capitalize(this.attr('type'));
         var deferred = this.attr('deferred');
 
+        // Turn off popover for the removed person
+        $(el).closest('li').find('.person-tooltip-trigger')
+          .removeClass('person-tooltip-trigger');
+
         if (deferred) {
           this.deferred_remove_role(person, roleToRemove);
         } else {


### PR DESCRIPTION
**Subject: Hard to reproduce:** Tree view glitch is back: after editing Assessment the tree view is messed up
**Details:** 
- Create an assessment
- Click add a verifier
- Click trash can icon next to verifier’s email and hover his email while the app removing the email.

_Actual Result:_  User info tooltip stays after user email is removed
_Expected Result:_ Tooltip should be removed together with user’s email

_PS: Reproduced if configure a slow connection in Network conditions(Chrome DevTool)_