### PR TITLE
QUICK-FIX Disallow GR reuse evidences

### DIFF
--- a/src/ggrc/assets/mustache/assessments/reusable_objects.mustache
+++ b/src/ggrc/assets/mustache/assessments/reusable_objects.mustache
@@ -20,9 +20,11 @@ Maintained By: urban@reciprocitylabs.com
       <div class="medium-col">
         <h6>Evidence</h6>
       </div>
-      <div class="mini-col">
-        <a href="javascript://" can-click="reuseIt" class="btn {{#disableReuse}}disabled{{/disableReuse}} btn-small btn-full btn-draft js-trigger-reuse">Reuse</a>
-      </div>
+      {{#is_allowed 'update' parentInstance context='for'}}
+        <div class="mini-col">
+          <a href="javascript://" can-click="reuseIt" class="btn {{#disableReuse}}disabled{{/disableReuse}} btn-small btn-full btn-draft js-trigger-reuse">Reuse</a>
+        </div>
+      {{/is_allowed}}
     </li>
   </ul>
   <ul class="past-items-list relatables">

--- a/src/ggrc/assets/mustache/base_templates/attachment.mustache
+++ b/src/ggrc/assets/mustache/base_templates/attachment.mustache
@@ -30,12 +30,16 @@
     </a>
 
     {{#if reusable}}
-      {{#isDisabled instance}}
-        <input type="checkbox" checked disabled />
-      {{/isDisabled}}
-      {{^isDisabled instance}}
-        <input type="checkbox" {{#isLoading}}disabled{{/isLoading}} can-value="list.{{method}}-{{instance.type}}-{{instance.id}}" />
-      {{/isDisabled}}
+      {{#is_allowed 'update' baseInstance context='for'}}
+        {{#is_allowed 'update' instance context='for'}}
+          {{#isDisabled instance}}
+            <input type="checkbox" checked disabled />
+          {{/isDisabled}}
+          {{^isDisabled instance}}
+            <input type="checkbox" {{#isLoading}}disabled{{/isLoading}} can-value="list.{{method}}-{{instance.type}}-{{instance.id}}" />
+          {{/isDisabled}}
+        {{/is_allowed}}
+      {{/is_allowed}}
     {{/if}}
   </li>
 </reusable-object>

--- a/src/ggrc/assets/mustache/base_templates/urls.mustache
+++ b/src/ggrc/assets/mustache/base_templates/urls.mustache
@@ -25,12 +25,16 @@
     </a>
 
     {{#if reusable}}
-      {{#isDisabled instance}}
-        <input type="checkbox" checked disabled />
-      {{/isDisabled}}
-      {{^isDisabled instance}}
-        <input type="checkbox" {{#isLoading}}disabled{{/isLoading}} can-value="list.{{method}}-{{instance.type}}-{{instance.id}}" />
-      {{/isDisabled}}
+      {{#is_allowed 'update' baseInstance context='for'}}
+        {{#is_allowed 'update' instance context='for'}}
+          {{#isDisabled instance}}
+            <input type="checkbox" checked disabled />
+          {{/isDisabled}}
+          {{^isDisabled instance}}
+            <input type="checkbox" {{#isLoading}}disabled{{/isLoading}} can-value="list.{{method}}-{{instance.type}}-{{instance.id}}" />
+          {{/isDisabled}}
+        {{/is_allowed}}
+      {{/is_allowed}}
     {{/if}}
   </li>
 </reusable-object>

--- a/src/ggrc/assets/mustache/requests/reusable_objects.mustache
+++ b/src/ggrc/assets/mustache/requests/reusable_objects.mustache
@@ -20,9 +20,11 @@ Maintained By: urban@reciprocitylabs.com
       <div class="medium-col">
         <h6>Evidence</h6>
       </div>
-      <div class="mini-col">
-        <a href="javascript://" can-click="reuseIt" class="btn {{#disableReuse}}disabled{{/disableReuse}} btn-small btn-full btn-draft js-trigger-reuse">Reuse</a>
-      </div>
+      {{#is_allowed 'update' parentInstance context='for'}}
+        <div class="mini-col">
+          <a href="javascript://" can-click="reuseIt" class="btn {{#disableReuse}}disabled{{/disableReuse}} btn-small btn-full btn-draft js-trigger-reuse">Reuse</a>
+        </div>
+      {{/is_allowed}}
     </li>
   </ul>
   <ul class="past-items-list relatables">

--- a/src/ggrc_basic_permissions/roles/Reader.py
+++ b/src/ggrc_basic_permissions/roles/Reader.py
@@ -102,7 +102,14 @@ permissions = {
         "Help",
         "Market",
         "Objective",
-        "ObjectDocument",
+        {
+            "type": "ObjectDocument",
+            "terms": {
+                "property_name": "document,documentable",
+                "action": "update",
+            },
+            "condition": "relationship",
+        },
         "ObjectPerson",
         "Option",
         "OrgGroup",


### PR DESCRIPTION
This disallows GR to map evidences to an object he doesn't have permissions to edit.

Steps to reproduce:
1. Create an Assessment A1 with GR as Assessor.
2. Create an Assessment A2 without GR assigned.
3. Map a common control to both A1 and A2. (needed to make A1 and A2 related)
4. Log in as GR.
5. Attach an evidence to A1. (or you can add an URL, they are processed the same way)
6. Navigate to A2, open "Related Assessments" tab.
7. Check the evidence from A1 to reuse, click "Reuse".

Expected results: GR shouldn't map an evidence (URL) to an Assessment he doesn't have permission to edit.
Actual results: the evidence (URL) is mapped successfully.

This PR both forbids the mapping on the backend, and disables the checkboxes to reuse the evidences on the frontend.