### PR TITLE
QUICK-FIX Temp fix for  program audit owner to create CAD

### DIFF
--- a/src/ggrc_basic_permissions/roles/ProgramAuditOwner.py
+++ b/src/ggrc_basic_permissions/roles/ProgramAuditOwner.py
@@ -30,6 +30,8 @@ permissions = {
         "Document",
         "Meeting",
         "Context",
+        "CustomAttributeDefinition",
+        "CustomAttributeValue",
     ],
     "create": [
         "Request",
@@ -45,7 +47,9 @@ permissions = {
         "ObjectPerson",
         "Relationship",
         "Document",
-        "Meeting"
+        "Meeting",
+        "CustomAttributeDefinition",
+        "CustomAttributeValue",
     ],
     "view_object_page": [
         "__GGRC_ALL__"
@@ -64,7 +68,9 @@ permissions = {
         "ObjectPerson",
         "Relationship",
         "Document",
-        "Meeting"
+        "Meeting",
+        "CustomAttributeDefinition",
+        "CustomAttributeValue",
     ],
     "delete": [
         "UserRole",
@@ -79,6 +85,8 @@ permissions = {
         "Document",
         "Meeting"
         "AuditObject",
-        "Audit"
+        "Audit",
+        "CustomAttributeDefinition",
+        "CustomAttributeValue",
     ]
 }


### PR DESCRIPTION
As agreed with @Smotko just a temporary solution to let users test CAD under GR/GC roles. 