### PR TITLE
CORE-3709 Fix bad object ca imports

### DIFF
--- a/src/ggrc/converters/errors.py
+++ b/src/ggrc/converters/errors.py
@@ -94,3 +94,6 @@ UNSUPPORTED_LIST_ERROR = (u"Line {line}: Field {column_name} does not support "
 
 UNSUPPORTED_OPERATION_ERROR = (u"Line {line}: {operation} is not supported. "
                                u"The line will be ignored.")
+
+INVALID_ATTRIBUTE_WARNING = (u"Line {line}: Object does not contain attribute "
+                             u"'{column_name}'. The value will be ignored.")

--- a/src/ggrc/converters/handlers/custom_attribute.py
+++ b/src/ggrc/converters/handlers/custom_attribute.py
@@ -41,6 +41,10 @@ class CustomAttributeColumHandler(handlers.TextColumnHandler):
       CustomAttributeValue with the correct definition type and value.
     """
     self.definition = self.get_ca_definition()
+    if self.definition is None:
+      self.add_warning(errors.INVALID_ATTRIBUTE_WARNING,
+                       column_name=self.display_name)
+      return None
     value = models.CustomAttributeValue(custom_attribute_id=self.definition.id)
     typ = self.definition.attribute_type.split(":")[0]
     value_handler = self._type_handlers[typ]


### PR DESCRIPTION
If an object level CA exists and does not belong to the current object,
we ignore the value and show a warning.

Please note that this does not fix the import warnings when doing the import tests. It may say that everything is fine, and then give a bigger number of ignored objects