### PR TITLE
QUICK-FIX Fix save mandatory checkboxes

### DIFF
--- a/src/ggrc/assets/javascripts/pbc/workflow_controller.js
+++ b/src/ggrc/assets/javascripts/pbc/workflow_controller.js
@@ -178,10 +178,8 @@
        * Temporary solution and after updated the backend it need to be deleted
        * Start deprecated block
        */
-      if (cached.id === params.id) {
-        params.mandatory = cached.mandatory;
-        params.multi_choice_mandatory = cached.multi_choice_mandatory;
-      }
+      params.mandatory = cached.mandatory;
+      params.multi_choice_mandatory = cached.multi_choice_mandatory;
       /**
        * End deprecated block
        */


### PR DESCRIPTION
Restore previous functionality that was broken during merge conflict(was already working). As discussed we need to give users an ability to test custom attributes until we prepare BE fix. Discussed with Akhil and @egorhm.