### PR TITLE
QUICK-FIX Update Complete button on verifiers change

### DIFF
--- a/src/ggrc/assets/javascripts/components/people_list.js
+++ b/src/ggrc/assets/javascripts/components/people_list.js
@@ -416,6 +416,7 @@
             return item.what;
           });
         }
+        this.scope.instance.attr('_disabled', 'disabled');
         added = getInstances(added);
         removed = getInstances(removed);
         this.scope.attr('results').replace(
@@ -423,6 +424,7 @@
             return !_.findWhere(removed, {id: item.id});
           }
         ), added));
+        this.scope.instance.attr('_disabled', '');
       },
       '{scope.list_mapped} change': 'updateResult',
       '{scope.list_pending} change': 'updateResult',

--- a/src/ggrc/assets/mustache/assessments/header.mustache
+++ b/src/ggrc/assets/mustache/assessments/header.mustache
@@ -66,29 +66,31 @@ Copyright (C) 2016 Google Inc., authors, and contributors <see AUTHORS file>
               {{#if_in instance.status "Not Started,In Progress"}}
                 {{#is_allowed 'update' instance context='for'}}
                   <li>
-                    {{#if_verifiers_defined instance}}
-                      <reminder
-                        instance="instance"
-                        type="statusToPerson"
-                        modal_title="Reminder for Assessors set"
-                        modal_description="Tomorrow all Assessors will receive a notification to look at this Assessment if they didn't move it to 'Finished' in between."
-                      >
-                        <a href="javascript://" can-click="reminder">
-                          <i class="fa fa-bell-o"></i>
-                          Send reminder to assessors</a>
-                      </reminder>
-                    {{else}}
-                      <reminder
-                        instance="instance"
-                        type="statusToPerson"
-                        modal_title="Reminder for Assessors set"
-                        modal_description="Tomorrow all Assessors will receive a notification to look at this Assessment if they didn't move it to 'Final' in between."
-                      >
-                        <a href="javascript://" can-click="reminder">
-                          <i class="fa fa-bell-o"></i>
-                          Send reminder to assessors</a>
-                      </reminder>
-                    {{/if_verifiers_defined}}
+                    {{#unless instance._disabled}}
+                      {{#if_verifiers_defined instance}}
+                        <reminder
+                            instance="instance"
+                            type="statusToPerson"
+                            modal_title="Reminder for Assessors set"
+                            modal_description="Tomorrow all Assessors will receive a notification to look at this Assessment if they didn't move it to 'Finished' in between."
+                        >
+                          <a href="javascript://" can-click="reminder">
+                            <i class="fa fa-bell-o"></i>
+                            Send reminder to assessors</a>
+                        </reminder>
+                      {{else}}
+                        <reminder
+                            instance="instance"
+                            type="statusToPerson"
+                            modal_title="Reminder for Assessors set"
+                            modal_description="Tomorrow all Assessors will receive a notification to look at this Assessment if they didn't move it to 'Final' in between."
+                        >
+                          <a href="javascript://" can-click="reminder">
+                            <i class="fa fa-bell-o"></i>
+                            Send reminder to assessors</a>
+                        </reminder>
+                      {{/if_verifiers_defined}}
+                    {{/unless}}
                   </li>
                 {{/is_allowed}}
               {{/if_in}}

--- a/src/ggrc/assets/mustache/mixins/stateful.mustache
+++ b/src/ggrc/assets/mustache/mixins/stateful.mustache
@@ -10,17 +10,19 @@
 
   {{#if_in instance.status "Not Started,In Progress"}}
     {{#if_null instance._mandatory_msg}}
-      {{#if_verifiers_defined instance}}
+      {{#unless instance._disabled}}
+        {{#if_verifiers_defined instance}}
           <button class="btn btn-small btn-primary pull-right btn-info-pin-header {{instance._disabled}}"
                   data-name="status"
                   data-value="Ready for Review">
             Complete
           </button>
-      {{else}}
+        {{else}}
           <button class="btn btn-small btn-primary pull-right btn-info-pin-header {{instance._disabled}}"
                   data-name="status"
                   data-value="Completed">Complete</button>
-      {{/if_verifiers_defined}}
+        {{/if_verifiers_defined}}
+      {{/unless}}
     {{else}}
       <button class="btn btn-small btn-primary pull-right btn-info-pin-header disabled"
               title="{{instance._mandatory_msg}}">


### PR DESCRIPTION
Steps to reproduce:

1. Create an assessment, add yourself as Creator and Assessor, but not Verifier.
2. Open Quick view pane for this assessment.
3. Add yourself as Verifier.
4. Click "Complete" button.

Expected result: the assessment is moved into "Ready for review" state, clickable "Verify"/"Reject" buttons are displayed.
Actual result: the assessment is moved into "Completed" state (which is invalid, as the final state in case verifiers are defined is "Verified").