### PR TITLE
QUICK-FIX Fix removing person from two people lists

### DIFF
--- a/src/ggrc/assets/javascripts/components/people_list.js
+++ b/src/ggrc/assets/javascripts/components/people_list.js
@@ -230,7 +230,9 @@
           this.instance.remove_duplicate_pending_joins(person);
         } else {
           // convert roles list to a string
-          roles = operation.roles.join(',');
+          if (_.isArray(operation.roles)) {
+            roles = operation.roles.join(',');
+          }
           if (operation.how === 'add') {
             this.instance.mark_for_addition(
               'related_objects_as_destination',


### PR DESCRIPTION
Steps to reproduce:
1. Open modal to edit Assessment.
2. Add Example User as a Creator and as an Assessor.
3. Remove Example User from Assessors.
4. Remove Example User from Creators.

Expected result: Example User is removed from Creators and Assessors.
Actual result: A js error 'Cannot read property 'join' of undefined' is shown.