### PR TITLE
QUICK-FIX Fix 500 on relationship with attrs creation

### DIFF
--- a/src/ggrc/models/relationship.py
+++ b/src/ggrc/models/relationship.py
@@ -4,10 +4,10 @@
 from ggrc import db
 from ggrc.models.mixins import Identifiable
 from ggrc.models.mixins import Mapping
+from sqlalchemy import event
 from sqlalchemy import or_, and_
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.ext.declarative import declared_attr
-from sqlalchemy.orm import validates
 from sqlalchemy.orm.collections import attribute_mapped_collection
 from werkzeug.exceptions import BadRequest
 import functools
@@ -69,15 +69,19 @@ class Relationship(Mapping, db.Model):
         else None
     return setattr(self, self.destination_attr, value)
 
-  @validates('relationship_attrs')
-  def _validate_attr(self, key, attr):
+  @staticmethod
+  def validate_attrs(mapper, connection, relationship):
     """
       Only white-listed attributes can be stored, so users don't use this
       for storing arbitrary data.
     """
-    RelationshipAttr.validate_attr(self.source, self.destination,
-                                   self.attrs, attr)
-    return attr
+    # pylint: disable=unused-argument
+    for attr_name, attr_value in relationship.attrs.iteritems():
+      attr = RelationshipAttr(attr_name=attr_name, attr_value=attr_value)
+      RelationshipAttr.validate_attr(relationship.source,
+                                     relationship.destination,
+                                     relationship.attrs,
+                                     attr)
 
   @classmethod
   def find_related(cls, object1, object2):
@@ -135,6 +139,9 @@ class Relationship(Mapping, db.Model):
     # manually add attrs since the base log_json only captures table columns
     json["attrs"] = self.attrs.copy()  # copy in order to detach from orm
     return json
+
+event.listen(Relationship, 'before_insert', Relationship.validate_attrs)
+event.listen(Relationship, 'before_update', Relationship.validate_attrs)
 
 
 class Relatable(object):

--- a/src/ggrc/models/relationship.py
+++ b/src/ggrc/models/relationship.py
@@ -1,17 +1,19 @@
 # Copyright (C) 2016 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
-from ggrc import db
-from ggrc.models.mixins import Identifiable
-from ggrc.models.mixins import Mapping
+import functools
+import inspect
+
 from sqlalchemy import event
 from sqlalchemy import or_, and_
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.orm.collections import attribute_mapped_collection
 from werkzeug.exceptions import BadRequest
-import functools
-import inspect
+
+from ggrc import db
+from ggrc.models.mixins import Identifiable
+from ggrc.models.mixins import Mapping
 
 
 class Relationship(Mapping, db.Model):

--- a/test/integration/ggrc/models/test_relationship.py
+++ b/test/integration/ggrc/models/test_relationship.py
@@ -46,6 +46,11 @@ class TestRelationship(TestCase):
           "__GGRC_ADMIN__": {"__GGRC_ALL__": {"contexts": [0]}}
       }
 
+    self.m1 = self.mock_model()
+    self.m2 = self.mock_model()
+    self.rel = Relationship(source=self.m1, destination=self.m2)
+    db.session.add(self.rel)
+
   def mock_model(self, id=None, modified_by_id=1, **kwarg):
     if 'id' not in kwarg:
       kwarg['id'] = random.randint(0, 999999999)
@@ -54,15 +59,22 @@ class TestRelationship(TestCase):
     mock = RelationshipTestMockModel(**kwarg)
     return mock
 
-  def test_attrs_validation(self):
-    m1 = self.mock_model()
-    m2 = self.mock_model()
-    rel = Relationship(source=m1, destination=m2)
+  def test_attrs_validation_ok(self):
+    self.rel.attrs["validated_attr"] = "123"
+
+    db.session.commit()
+
+  def test_attrs_validation_invalid_attr(self):
+    self.rel.attrs["foo"] = "bar"
+
     with self.assertRaises(werkzeug.exceptions.BadRequest):
-      rel.attrs["foo"] = "bar"
+      db.session.commit()
+
+  def test_attrs_validation_invalid_value(self):
+    self.rel.attrs["validated_attr"] = "wrong value"
+
     with self.assertRaises(werkzeug.exceptions.BadRequest):
-      rel.attrs["validated_attr"] = "wrong value"
-    rel.attrs["validated_attr"] = "123"
+      db.session.commit()
 
 
 class TestRelationshipAttr(TestCase):


### PR DESCRIPTION
Note: this was reproduced only on local appengine emulation. However, this error may some day occur on any installation of GGRC. I make this PR into the develop branch because I feel bad about changing the validators for Relationship model on the day of UAT release.

Steps to reproduce:
1. Open Assessment creation modal.
2. Add a user as a Creator and as a Verifier.
3. Click 'save'.

Expected result: the Assessment is created.
Actual result: http 500 is returned from the backend as RelationshipAttr object validation fails.

The reasons behind this error are the following:
- when we assign a person to an object (say, Assessment), we `POST` a `Relationship` with following fields:
1. source == Person
2. destination == Assessment
3. attrs == {'AssignmentType': 'Creator,Assessor'}  (any assigned roles)
- on the backend, when the system gets the json with these fields for `Relationship`, a `Relationship` object is created and the fields are getting stored (in a `for key, value in json.items()` loop, so **no order is guaranteed**)
- when we store `Relationship.attrs` field, a validator in `RelationshipAttrs.validate_attr` is fired
- `RelationshipAttrs.validate_attr` reads `Relationship.source` and `Relationship.destination`; it fails if any of these fields is not stored yet.

My fix postpones the validation to the moment the data is stored into the database. Please review carefully as I may have overlooked some mistakes.