### PR TITLE
CORE-3710 Fix custom attribute duplicate values

### DIFF
--- a/src/ggrc/migrations/versions/20160707132122_1269660b288b_remove_ca_duplicate_values.py
+++ b/src/ggrc/migrations/versions/20160707132122_1269660b288b_remove_ca_duplicate_values.py
@@ -1,0 +1,60 @@
+# Copyright (C) 2016 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+remove ca duplicate values
+
+Create Date: 2016-07-07 13:21:22.732299
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '1269660b288b'
+down_revision = '3a0c977a9cb8'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+
+  # Remove duplicate lines and include only the newest ones.
+  # This relies on the newest lines having the biggest id.
+
+  op.execute(
+      """
+      CREATE TEMPORARY TABLE latest_cav AS (
+          SELECT MAX(id) AS id
+          FROM custom_attribute_values
+          GROUP BY custom_attribute_id, attributable_id
+      )
+      """
+  )
+  op.execute(
+      """
+      DELETE FROM custom_attribute_values
+      WHERE id NOT IN (SELECT id FROM latest_cav)
+      """
+  )
+  op.execute("DROP TEMPORARY TABLE latest_cav")
+
+  # The unique constraint does not include the attributable_type since that is
+  # already specified in the custom attribute definition (custom_attribute_id)
+  # and we should avoid adding string values to indexes.
+  op.create_unique_constraint(
+      "uq_custom_attribute_value",
+      "custom_attribute_values",
+      ["custom_attribute_id", "attributable_id"]
+  )
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  op.drop_constraint(
+      "uq_custom_attribute_value",
+      "custom_attribute_values",
+      type_="unique"
+  )

--- a/src/ggrc/models/custom_attribute_value.py
+++ b/src/ggrc/models/custom_attribute_value.py
@@ -98,6 +98,17 @@ class CustomAttributeValue(Base, db.Model):
 
   @classmethod
   def mk_filter_by_custom(cls, obj_class, custom_attribute_id):
+    """Get filter for custom attributable object.
+
+    This returns an exists filter for the given predicate, matching it to
+    either a custom attribute value, or a value of the matched object.
+
+    Args:
+      obj_class: Class of the attributable object.
+      custom_attribute_id: Id of the attribute definition.
+    Returns:
+      A function that will generate a filter for a given predicate.
+    """
     from ggrc.models import all_models
     attr_def = all_models.CustomAttributeDefinition.query.filter_by(
         id=custom_attribute_id
@@ -110,7 +121,7 @@ class CustomAttributeValue(Base, db.Model):
                   for name in ["email", "title", "slug"]]
         fields = [field for field in fields if field is not None]
 
-        def filter_by(predicate):
+        def filter_by_mapping(predicate):
           return cls.query.filter(
               (cls.custom_attribute_id == custom_attribute_id) &
               (cls.attributable_type == obj_class.__name__) &
@@ -119,16 +130,16 @@ class CustomAttributeValue(Base, db.Model):
                   (map_class.id == cls.attribute_object_id) &
                   or_(*[predicate(f) for f in fields])).exists())
           ).exists()
-        return filter_by
+        return filter_by_mapping
 
-    def filter_by(predicate):
+    def filter_by_custom(predicate):
       return cls.query.filter(
           (cls.custom_attribute_id == custom_attribute_id) &
           (cls.attributable_type == obj_class.__name__) &
           (cls.attributable_id == obj_class.id) &
           predicate(cls.attribute_value)
       ).exists()
-    return filter_by
+    return filter_by_custom
 
   def _clone(self, obj):
     """Clone a custom value to a new object."""
@@ -145,7 +156,7 @@ class CustomAttributeValue(Base, db.Model):
     return ca_value
 
   @staticmethod
-  def _extra_table_args(cls):
+  def _extra_table_args(_):
     return (
         db.UniqueConstraint('attributable_id', 'custom_attribute_id'),
     )

--- a/src/ggrc/models/custom_attribute_value.py
+++ b/src/ggrc/models/custom_attribute_value.py
@@ -143,3 +143,9 @@ class CustomAttributeValue(Base, db.Model):
     db.session.add(ca_value)
     db.session.flush()
     return ca_value
+
+  @staticmethod
+  def _extra_table_args(cls):
+    return (
+        db.UniqueConstraint('attributable_id', 'custom_attribute_id'),
+    )


### PR DESCRIPTION
This is just the first part of refactors to backend code, before we can start working on propper post collection requests.

PS: this PR breaks imports that try to update custom attributes (no warning is shown, but they silently fail and are not updated). Fix for this is waiting on PJ merge. see: https://reciprocitylabs.atlassian.net/browse/CORE-3711

