### PR TITLE
QUICK FIX permissions after assessment creation

### DIFF
--- a/src/ggrc/assets/javascripts/pbc/workflow_controller.js
+++ b/src/ggrc/assets/javascripts/pbc/workflow_controller.js
@@ -5,7 +5,7 @@
  * Maintained By: brad@reciprocitylabs.com
  */
 
-(function (can, $) {
+(function (can, $, Permission) {
   can.Control('GGRC.Controllers.PbcWorkflows', {}, {
     '{CMS.Models.AssessmentTemplate} updated': function (model, ev, instance) {
       var attrDfd;
@@ -138,6 +138,13 @@
       });
       instance.delay_resolving_save_until(dfd);
     },
+    '{CMS.Models.Assessment} created': function (model, ev, instance) {
+      if (!(instance instanceof CMS.Models.Assessment)) {
+        return;
+      }
+
+      instance.delay_resolving_save_until(Permission.refresh());
+    },
     _after_pending_joins: function (instance, callback) {
       var dfd = instance.attr('_pending_joins_dfd');
       if (!dfd) {
@@ -163,4 +170,4 @@
   $(function () {
     $(document.body).ggrc_controllers_pbc_workflows();
   });
-})(this.can, this.can.$);
+})(this.can, this.can.$, window.Permission);


### PR DESCRIPTION
Subject: Reader cannot see "Edit", "Unmap", “Delete” options under 3bbs button in Assessment’s info pane right after creating an Assessment. Only after page refresh.
Details: 
Log in as GR create a program and an audit
Create new Assessment on audit page (do not reload the page)
Click 3bbs button
Actual Result:  Assessment state is changed to “IN PROGRESS”
Expected Result: User should not be able to reuse evidence for other user’s object.
Additional info: The same happens to the Request - delete item misses in the dropdown
Workaround: N/A