### PR TITLE
QUICK-FIX Freeze docker base image to use ubuntu 14.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/baseimage
+FROM phusion/baseimage:0.9.15
 
 RUN rm /usr/sbin/policy-rc.d \
   && curl -sL https://deb.nodesource.com/setup_5.x | sudo -E bash \


### PR DESCRIPTION
The phusion:baseimage has changed to ubuntu 16:04 even though the doc on
docker hub says otherwise. This breaks our build and the develop
environment.

see: https://github.com/phusion/baseimage-docker/blob/rel-0.9.19/image/Dockerfile

PS: we should really fix/freeze most of our deps, and update them manually to avoid weird bugs.