### PR TITLE
QUICK-FIX Allow Readers to create Assessment Templates

### DIFF
--- a/src/ggrc_basic_permissions/roles/Reader.py
+++ b/src/ggrc_basic_permissions/roles/Reader.py
@@ -89,6 +89,7 @@ permissions = {
         "Control",
         "Comment",
         "Assessment",
+        "AssessmentTemplate",
         "Issue",
         "DataAsset",
         "AccessGroup",


### PR DESCRIPTION
The title says it all.

If I understood correctly, we can safely grant  Readers this permission, because they will still not be allowed to create mappings.