### PR TITLE
CORE-3124 Fix rerender tree view on admin dashboard

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
@@ -222,20 +222,13 @@ can.Control('CMS.Controllers.TreeLoader', {
     this.on();
 
     temp_list = [];
-    if (!is_reload) {
-      list.each(function (v) {
-        var item = that.prepare_child_options(v, force_prepare_children);
-        temp_list.push(item);
-        if (!item.instance.selfLink) {
-          refresh_queue.enqueue(v.instance);
-        }
-      });
-    } else {
-      list.each(function (v) {
-        temp_list.push(v);
-      });
-    }
-
+    list.each(function (v) {
+      var item = that.prepare_child_options(v, force_prepare_children);
+      temp_list.push(item);
+      if (!is_reload && !item.instance.selfLink) {
+        refresh_queue.enqueue(v.instance);
+      }
+    });
     if (this.options.sort_property || this.options.sort_function) {
       original_function = this.options.sort_function ||
                           this._sort_property_comparator(this.options.sort_property);


### PR DESCRIPTION
Subject: Custom Attributes tab is empty after switching back to it from Event tab on admin dashboard page.
Description:
- Navigate to Admin dashboard
- Open Custom Attributes tab
- Open Events tab
- Switch back to Custom Attributes

Actual Result: Custom Attributes tab has no content
Expected Result: Custom Attributes should show the tree view with the items
Workaround: Refresh the page