### PR TITLE
QUICK-FIX Render custom attributes on info pane sorted by ID

### DIFF
--- a/src/ggrc/assets/mustache/custom_attributes/info.mustache
+++ b/src/ggrc/assets/mustache/custom_attributes/info.mustache
@@ -6,105 +6,107 @@
 }}
 
 <custom-attributes instance="instance" load="true">
-  {{#if instance.custom_attribute_definitions.length}}
-    {{#iterate_by_two instance.custom_attribute_definitions}}
-      <div class="row-fluid wrap-row">
-      {{#list}}
-        <div class="span6">
-          <div data-custom-attribute="{{id}}" data-type="{{attribute_type}}">
-            {{#with_value_for_id id}}
-              {{#switch attribute_type}}
-              {{#case 'Checkbox'}}
-                <inline-edit
-                  instance="instance"
-                  need-confirm="confirmEdit"
-                  ca-id="id"
-                  value="value"
-                  label="title"
-                  type="checkbox"
-                  mandatory="mandatory"
-                  placeholder="placeholder"
-                  helptext="helptext"
-                ></inline-edit>
-              {{/case}}
-              {{#case 'Rich Text'}}
-                <inline-edit
-                  instance="instance"
-                  need-confirm="confirmEdit"
-                  ca-id="id"
-                  value="value"
-                  label="title"
-                  type="text"
-                  mandatory="mandatory"
-                  placeholder="placeholder"
-                  helptext="helptext"
-                ></inline-edit>
-              {{/case}}
-              {{#case 'Dropdown'}}
-                <inline-edit
-                  instance="instance"
-                  need-confirm="confirmEdit"
-                  ca-id="id"
-                  value="value"
-                  label="title"
-                  type="dropdown"
-                  mandatory="mandatory"
-                  values="multi_choice_options"
-                  placeholder="placeholder"
-                  helptext="helptext"
-                ></inline-edit>
-              {{/case}}
-              {{#case 'Date'}}
-                <inline-edit
-                  instance="instance"
-                  need-confirm="confirmEdit"
-                  ca-id="id"
-                  value="value"
-                  label="title"
-                  type="date"
-                  mandatory="mandatory"
-                  placeholder="placeholder"
-                  helptext="helptext"
-                ></inline-edit>
-              {{/case}}
-              {{#case 'Text'}}
-                <inline-edit
-                  instance="instance"
-                  need-confirm="confirmEdit"
-                  ca-id="id"
-                  value="value"
-                  label="title"
-                  type="input"
-                  mandatory="mandatory"
-                  placeholder="placeholder"
-                  helptext="helptext"
-                ></inline-edit>
-              {{/case}}
-              {{#case 'Map:Person'}}
-                {{#with_object_for_id id}}
+  {{^loading}}
+    {{#if instance.custom_attribute_definitions.length}}
+      {{#iterate_by_two instance.custom_attribute_definitions}}
+        <div class="row-fluid wrap-row">
+        {{#list}}
+          <div class="span6">
+            <div data-custom-attribute="{{id}}" data-type="{{attribute_type}}">
+              {{#with_value_for_id id}}
+                {{#switch attribute_type}}
+                {{#case 'Checkbox'}}
                   <inline-edit
                     instance="instance"
                     need-confirm="confirmEdit"
                     ca-id="id"
-                    value="object"
+                    value="value"
                     label="title"
-                    type="person"
+                    type="checkbox"
                     mandatory="mandatory"
                     placeholder="placeholder"
                     helptext="helptext"
                   ></inline-edit>
-                {{/with_object_for_id}}
-              {{/case}}
-              {{#default}}
-                <h6>{{title}}</h6>
-                {{value}}
-              {{/default}}
-              {{/switch}}
-            {{/with_value_for_id}}
+                {{/case}}
+                {{#case 'Rich Text'}}
+                  <inline-edit
+                    instance="instance"
+                    need-confirm="confirmEdit"
+                    ca-id="id"
+                    value="value"
+                    label="title"
+                    type="text"
+                    mandatory="mandatory"
+                    placeholder="placeholder"
+                    helptext="helptext"
+                  ></inline-edit>
+                {{/case}}
+                {{#case 'Dropdown'}}
+                  <inline-edit
+                    instance="instance"
+                    need-confirm="confirmEdit"
+                    ca-id="id"
+                    value="value"
+                    label="title"
+                    type="dropdown"
+                    mandatory="mandatory"
+                    values="multi_choice_options"
+                    placeholder="placeholder"
+                    helptext="helptext"
+                  ></inline-edit>
+                {{/case}}
+                {{#case 'Date'}}
+                  <inline-edit
+                    instance="instance"
+                    need-confirm="confirmEdit"
+                    ca-id="id"
+                    value="value"
+                    label="title"
+                    type="date"
+                    mandatory="mandatory"
+                    placeholder="placeholder"
+                    helptext="helptext"
+                  ></inline-edit>
+                {{/case}}
+                {{#case 'Text'}}
+                  <inline-edit
+                    instance="instance"
+                    need-confirm="confirmEdit"
+                    ca-id="id"
+                    value="value"
+                    label="title"
+                    type="input"
+                    mandatory="mandatory"
+                    placeholder="placeholder"
+                    helptext="helptext"
+                  ></inline-edit>
+                {{/case}}
+                {{#case 'Map:Person'}}
+                  {{#with_object_for_id id}}
+                    <inline-edit
+                      instance="instance"
+                      need-confirm="confirmEdit"
+                      ca-id="id"
+                      value="object"
+                      label="title"
+                      type="person"
+                      mandatory="mandatory"
+                      placeholder="placeholder"
+                      helptext="helptext"
+                    ></inline-edit>
+                  {{/with_object_for_id}}
+                {{/case}}
+                {{#default}}
+                  <h6>{{title}}</h6>
+                  {{value}}
+                {{/default}}
+                {{/switch}}
+              {{/with_value_for_id}}
+            </div>
           </div>
+        {{/list}}
         </div>
-      {{/list}}
-      </div>
-    {{/iterate_by_two}}
-  {{/if}}
+      {{/iterate_by_two}}
+    {{/if}}
+  {{/loading}}
 </custom-attributes>

--- a/src/ggrc/models/hooks/assessment.py
+++ b/src/ggrc/models/hooks/assessment.py
@@ -235,6 +235,8 @@ def relate_ca(assessment, related):
   ca_definitions = ca_query.filter_by(
       definition_id=related["template"].id,
       definition_type="assessment_template",
+  ).order_by(
+      all_models.CustomAttributeDefinition.id
   )
 
   for definition in ca_definitions:


### PR DESCRIPTION
**Issue description:**
> Generate an Assessment using an Assessment template (the latter should have a few custom attributes defined). The order of custom attributes displayed on the generated Assessment's info pane should be the same as defined in the Assessment Template (currently the custom attributes arr sorted alphabetically).

There were two reasons for an incorrect order:
* When generating an Assessment from an Assessment Template, custom attribute definitions were not stored in the database in the correct order.
* The Mustache template rendering the custom attributes did not wait for the custom attribute sorting to complete - instead, it rendered the (unsorted) Assessment's custom attributes list immediately. This was fixed by wrapping the CA list rendering block into a `{{^loading}}` check, waiting for the `loading` flag  to be cleared.