### PR TITLE
QUICK-FIX Store updates to comments in memcache

### DIFF
--- a/src/ggrc/cache/cache.py
+++ b/src/ggrc/cache/cache.py
@@ -25,6 +25,7 @@ def all_cache_entries():
       resource('custom_attribute_values', 'CustomAttributeValue'),
       resource('categorizations', 'Categorization'),
       resource('category_bases', 'CategoryBase'),
+      resource('comments', 'Comment'),
       resource('control_categories', 'ControlCategory'),
       resource('control_assertions', 'ControlAssertion'),
       resource('contexts', 'Context'),


### PR DESCRIPTION
This is reproducible only on memcache-enabled instances of our app. Thus, to test it on localhost, run `launch_gae_ggrc`.

Steps to reproduce:
1. Create an Assessment, add yourself as Creator and Assignee.
2. Add a comment to it with text 'Yet unedited text'.
3. Edit the comment to make it 'Edited and saved text', save it, don't refresh the page. It should be saved and rendered correctly ('Edited and saved text').
4. Refresh the page.

Expected result: the comment is loaded as 'Edited and saved text'.
Actual result: the comment is loaded as 'Yet unedited text'.

The problem is that when we PUT the new Comment object, it is not updated in the memcache. This PR registers the model so the update-memcache-after-PUT logic works for the Comment model.