### PR TITLE
QUICK-FIX Fix script error in ObjectCounter if no user

### DIFF
--- a/src/ggrc/assets/javascripts/components/object_counter/object_counter.js
+++ b/src/ggrc/assets/javascripts/components/object_counter/object_counter.js
@@ -1,6 +1,6 @@
 /*!
- Copyright (C) 2016 Google Inc., authors, and contributors
- Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+   Copyright (C) 2016 Google Inc.
+   Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  */
 
 (function (can, $) {
@@ -43,7 +43,7 @@
       searchKeys: '@',
       searchValues: '@',
       _getValue: {
-        current_user: GGRC.current_user.id,
+        current_user: GGRC.current_user ? GGRC.current_user.id : -1,
         'true': true,
         'false': false
       },


### PR DESCRIPTION
If you logout (or visit the login screen directly), a script error occurs in the ObjectCounter component's definition, because there is no current user available to read his/her id.

This is the issue #95 in the bug spreadsheet, under the _Quince_ tab.

No test, unfortunately, because all components get registered before the tests run. Changing this and loading components conditionally would most likely require way too much refactoring at this point.