### PR TITLE
QUICK-FIX Fix selection last item in the dropdowns

### DIFF
--- a/src/ggrc/assets/javascripts/components/dropdown/dropdown.js
+++ b/src/ggrc/assets/javascripts/components/dropdown/dropdown.js
@@ -23,6 +23,7 @@
       className: '@',
       onChange: $.noop,
       noValue: '@',
+      noValueLabel: '@',
       /*
         Options list should be an `array` of object containing `title` and `value`
         [{
@@ -33,7 +34,7 @@
       optionsList: null,
       options: function () {
         var none = [{
-          title: 'None',
+          title: this.attr('noValueLabel') || 'None',
           value: ''
         }];
         var list = can.map(this.attr('optionsList') || [], function (option) {

--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -87,6 +87,8 @@
       status: 'Draft',
       object_type: 'Assessment'
     },
+    statuses: ['Planned', 'In Progress', 'Manager Review',
+      'Ready for External Review', 'Completed'],
     obj_nav_options: {
       show_all_tabs: false,
       force_show_list: ['In Scope Controls', 'Requests',
@@ -897,6 +899,8 @@
     conflicts: [
       ['assessor', 'verifier']
     ],
+    conclusions: ['Effective', 'Ineffective', 'Needs improvement',
+      'Not Applicable'],
     init: function () {
       if (this._super) {
         this._super.apply(this, arguments);

--- a/src/ggrc/assets/javascripts/models/business_object_models.js
+++ b/src/ggrc/assets/javascripts/models/business_object_models.js
@@ -80,8 +80,10 @@ can.Model.Cacheable("CMS.Models.OrgGroup", {
     , "DataAsset" : {}
     , "AccessGroup" : {}
     , "Market" : {}
-    }
-  , init : function() {
+    },
+  statuses: ['Draft', 'Final', 'Effective', 'Ineffective', 'Launched',
+      'Not Launched', 'In Scope', 'Not in Scope', 'Deprecated'],
+  init: function () {
     var that = this;
     this._super && this._super.apply(this, arguments);
     $(function(){
@@ -154,8 +156,10 @@ can.Model.Cacheable("CMS.Models.Project", {
     , "DataAsset" : {}
     , "AccessGroup" : {}
     , "Market" : {}
-    }
-  , init : function() {
+    },
+  statuses: ['Draft', 'Final', 'Effective', 'Ineffective', 'Launched',
+      'Not Launched', 'In Scope', 'Not in Scope', 'Deprecated'],
+  init: function () {
     var that = this;
     this._super && this._super.apply(this, arguments);
     $(function(){
@@ -241,9 +245,11 @@ can.Model.Cacheable("CMS.Models.Facility", {
     , "DataAsset" : {}
     , "AccessGroup" : {}
     , "Market" : {}
-    }
-  , init : function() {
-    var that = this
+    },
+  statuses: ['Draft', 'Final', 'Effective', 'Ineffective', 'Launched',
+      'Not Launched', 'In Scope', 'Not in Scope', 'Deprecated'],
+  init: function () {
+    var that = this;
     this._super && this._super.apply(this, arguments);
     $(function(){
       that.tree_view_options.child_options[0].model = CMS.Models.Process;
@@ -332,9 +338,11 @@ can.Model.Cacheable("CMS.Models.Product", {
     , "DataAsset" : {}
     , "AccessGroup" : {}
     , "Market" : {}
-    }
-  , init : function() {
-    var that = this
+    },
+  statuses: ['Draft', 'Final', 'Effective', 'Ineffective', 'Launched',
+      'Not Launched', 'In Scope', 'Not in Scope', 'Deprecated'],
+  init: function () {
+    var that = this;
     this._super && this._super.apply(this, arguments);
     $(function(){
       that.tree_view_options.child_options[0].model = CMS.Models.Process;
@@ -421,8 +429,10 @@ can.Model.Cacheable("CMS.Models.DataAsset", {
     , "DataAsset" : {}
     , "AccessGroup" : {}
     , "Market" : {}
-    }
-  , init : function() {
+    },
+  statuses: ['Draft', 'Final', 'Effective', 'Ineffective', 'Launched',
+      'Not Launched', 'In Scope', 'Not in Scope', 'Deprecated'],
+  init: function () {
     var that = this;
     this._super && this._super.apply(this, arguments);
     $(function(){
@@ -509,8 +519,10 @@ can.Model.Cacheable("CMS.Models.AccessGroup", {
     , "DataAsset" : {}
     , "AccessGroup" : {}
     , "Market" : {}
-    }
-  , init : function() {
+    },
+  statuses: ['Draft', 'Final', 'Effective', 'Ineffective', 'Launched',
+    'Not Launched', 'In Scope', 'Not in Scope', 'Deprecated'],
+  init: function () {
     var that = this;
     this._super && this._super.apply(this, arguments);
     $(function(){
@@ -583,8 +595,10 @@ can.Model.Cacheable("CMS.Models.Market", {
     , "DataAsset" : {}
     , "AccessGroup" : {}
     , "Market" : {}
-    }
-  , init : function() {
+    },
+  statuses: ['Draft', 'Final', 'Effective', 'Ineffective', 'Launched',
+      'Not Launched', 'In Scope', 'Not in Scope', 'Deprecated'],
+  init: function () {
     var that = this;
     this._super && this._super.apply(this, arguments);
     $(function(){
@@ -670,8 +684,10 @@ can.Model.Cacheable("CMS.Models.Vendor", {
     , "DataAsset" : {}
     , "AccessGroup" : {}
     , "Market" : {}
-    }
-  , init : function() {
+    },
+  statuses: ['Draft', 'Final', 'Effective', 'Ineffective', 'Launched',
+      'Not Launched', 'In Scope', 'Not in Scope', 'Deprecated'],
+  init: function () {
     var that = this;
     this._super && this._super.apply(this, arguments);
     $(function(){

--- a/src/ggrc/assets/javascripts/models/control.js
+++ b/src/ggrc/assets/javascripts/models/control.js
@@ -77,9 +77,10 @@ can.Model.Cacheable("CMS.Models.Control", {
       , title_plural : "Business Objects"
       , draw_children : false
     }]
-  }
-
-  , init : function() {
+  },
+  statuses: ['Draft', 'Final', 'Effective', 'Ineffective', 'Launched',
+      'Not Launched', 'In Scope', 'Not in Scope', 'Deprecated'],
+  init: function () {
     this.validateNonBlank("title");
     this._super.apply(this, arguments);
   }

--- a/src/ggrc/assets/javascripts/models/control.js
+++ b/src/ggrc/assets/javascripts/models/control.js
@@ -5,103 +5,105 @@
 
 //= require can.jquery-all
 //= require models/cacheable
-(function(namespace, $){
-can.Model.Cacheable("CMS.Models.Control", {
+(function (namespace, $) {
+  can.Model.Cacheable('CMS.Models.Control', {
   // static properties
-    root_object : "control"
-  , root_collection : "controls"
-  , category : "governance"
-  , findAll : "GET /api/controls"
-  , findOne : "GET /api/controls/{id}"
-  , create : "POST /api/controls"
-  , update : "PUT /api/controls/{id}"
-  , destroy : "DELETE /api/controls/{id}"
-  , mixins : ["ownable", "contactable", "unique_title"]
-  , is_custom_attributable: true
-  , attributes : {
-      context : "CMS.Models.Context.stub"
-    , owners : "CMS.Models.Person.stubs"
-    , modified_by : "CMS.Models.Person.stub"
-    , object_people : "CMS.Models.ObjectPerson.stubs"
-    , people : "CMS.Models.Person.stubs"
-    , object_documents : "CMS.Models.ObjectDocument.stubs"
-    , documents : "CMS.Models.Document.stubs"
-    , categories : "CMS.Models.ControlCategory.stubs"
-    , assertions : "CMS.Models.ControlAssertion.stubs"
-    , objectives : "CMS.Models.Objective.stubs"
-    , directive : "CMS.Models.Directive.stub"
-    , audit_objects : "CMS.Models.AuditObject.stubs"
-    , sections : "CMS.Models.get_stubs"
-    , programs : "CMS.Models.Program.stubs"
-    , kind : "CMS.Models.Option.stub"
-    , means : "CMS.Models.Option.stub"
-    , verify_frequency : "CMS.Models.Option.stub"
-    , principal_assessor : "CMS.Models.Person.stub"
-    , secondary_assessor : "CMS.Models.Person.stub"
-    , custom_attribute_values : "CMS.Models.CustomAttributeValue.stubs"
-  }
-  , links_to : {}
-  , defaults : {
-      "selected" : false
-    , "title" : ""
-    , "slug" : ""
-    , "description" : ""
-    , "url" : ""
-  }
-
-  , tree_view_options : {
-      show_view : GGRC.mustache_path + "/controls/tree.mustache"
-    , footer_view : GGRC.mustache_path + "/controls/tree_footer.mustache"
-    , attr_list : can.Model.Cacheable.attr_list.concat([
-      {attr_title: 'URL', attr_name: 'url'},
-      {attr_title: 'Reference URL', attr_name: 'reference_url'},
-      {attr_title: 'Effective Date', attr_name: 'start_date'},
-      {attr_title: 'Stop Date', attr_name: 'end_date'},
-      {attr_title: 'Kind/Nature', attr_name: 'kind', attr_sort_field: 'kind.title'},
-      {attr_title: 'Fraud Related ', attr_name: 'fraud_related'},
-      {attr_title: 'Significance', attr_name: 'significance'},
-      {attr_title: 'Type/Means', attr_name: 'means', attr_sort_field: 'means.title'},
-      {attr_title: 'Frequency', attr_name: 'frequency', attr_sort_field: 'frequency.title'},
-      {attr_title: 'Assertions', attr_name: 'assertions'},
-      {attr_title: 'Categories', attr_name: 'categories'},
-      {attr_title: 'Principal Assessor', attr_name: 'principal_assessor', attr_sort_field: 'principal_assessor.name|email'},
-      {attr_title: 'Secondary Assessor', attr_name: 'secondary_assessor', attr_sort_field: 'secondary_assessor.name|email'}
-    ])
-    , add_item_view : GGRC.mustache_path + "/controls/tree_add_item.mustache"
-    , draw_children : true
-    , child_options : [{
-        model : can.Model.Cacheable
-      , mapping : "related_objects" //"related_and_able_objects"
-      , footer_view : GGRC.mustache_path + "/base_objects/tree_footer.mustache"
-      , add_item_view : GGRC.mustache_path + "/base_objects/tree_add_item.mustache"
-      , title_plural : "Business Objects"
-      , draw_children : false
-    }]
-  },
-  statuses: ['Draft', 'Final', 'Effective', 'Ineffective', 'Launched',
+    root_object: 'control',
+    root_collection: 'controls',
+    category: 'governance',
+    findAll: 'GET /api/controls',
+    findOne: 'GET /api/controls/{id}',
+    create: 'POST /api/controls',
+    update: 'PUT /api/controls/{id}',
+    destroy: 'DELETE /api/controls/{id}',
+    mixins: ['ownable', 'contactable', 'unique_title'],
+    is_custom_attributable: true,
+    attributes: {
+      context: 'CMS.Models.Context.stub',
+      owners: 'CMS.Models.Person.stubs',
+      modified_by: 'CMS.Models.Person.stub',
+      object_people: 'CMS.Models.ObjectPerson.stubs',
+      people: 'CMS.Models.Person.stubs',
+      object_documents: 'CMS.Models.ObjectDocument.stubs',
+      documents: 'CMS.Models.Document.stubs',
+      categories: 'CMS.Models.ControlCategory.stubs',
+      assertions: 'CMS.Models.ControlAssertion.stubs',
+      objectives: 'CMS.Models.Objective.stubs',
+      directive: 'CMS.Models.Directive.stub',
+      audit_objects: 'CMS.Models.AuditObject.stubs',
+      sections: 'CMS.Models.get_stubs',
+      programs: 'CMS.Models.Program.stubs',
+      kind: 'CMS.Models.Option.stub',
+      means: 'CMS.Models.Option.stub',
+      verify_frequency: 'CMS.Models.Option.stub',
+      principal_assessor: 'CMS.Models.Person.stub',
+      secondary_assessor: 'CMS.Models.Person.stub',
+      custom_attribute_values: 'CMS.Models.CustomAttributeValue.stubs'
+    },
+    links_to: {},
+    defaults: {
+      selected: false,
+      title: '',
+      slug: '',
+      description: '',
+      url: ''
+    },
+    tree_view_options: {
+      show_view: GGRC.mustache_path + '/controls/tree.mustache',
+      footer_view: GGRC.mustache_path + '/controls/tree_footer.mustache',
+      attr_list: can.Model.Cacheable.attr_list.concat([
+        {attr_title: 'URL', attr_name: 'url'},
+        {attr_title: 'Reference URL', attr_name: 'reference_url'},
+        {attr_title: 'Effective Date', attr_name: 'start_date'},
+        {attr_title: 'Stop Date', attr_name: 'end_date'},
+        {attr_title: 'Kind/Nature', attr_name: 'kind',
+          attr_sort_field: 'kind.title'},
+        {attr_title: 'Fraud Related ', attr_name: 'fraud_related'},
+        {attr_title: 'Significance', attr_name: 'significance'},
+        {attr_title: 'Type/Means', attr_name: 'means',
+          attr_sort_field: 'means.title'},
+        {attr_title: 'Frequency', attr_name: 'frequency',
+          attr_sort_field: 'frequency.title'},
+        {attr_title: 'Assertions', attr_name: 'assertions'},
+        {attr_title: 'Categories', attr_name: 'categories'},
+        {attr_title: 'Principal Assessor', attr_name: 'principal_assessor',
+          attr_sort_field: 'principal_assessor.name|email'},
+        {attr_title: 'Secondary Assessor', attr_name: 'secondary_assessor',
+          attr_sort_field: 'secondary_assessor.name|email'}
+      ]),
+      add_item_view: GGRC.mustache_path + '/controls/tree_add_item.mustache',
+      draw_children: true,
+      child_options: [{
+        model: can.Model.Cacheable,
+        mapping: 'related_objects', // 'related_and_able_objects'
+        footer_view: GGRC.mustache_path + '/base_objects/tree_footer.mustache',
+        add_item_view: GGRC.mustache_path +
+        '/base_objects/tree_add_item.mustache',
+        title_plural: 'Business Objects',
+        draw_children: false
+      }]
+    },
+    statuses: ['Draft', 'Final', 'Effective', 'Ineffective', 'Launched',
       'Not Launched', 'In Scope', 'Not in Scope', 'Deprecated'],
-  init: function () {
-    this.validateNonBlank("title");
-    this._super.apply(this, arguments);
-  }
-}
-, {
-  init : function() {
-    var that = this;
-    this._super.apply(this, arguments);
-
-    this.bind("change", function(ev, attr, how, newVal, oldVal) {
-      // Emit the "orphaned" event when the directive attribute is removed
-      if (attr === "directive" && how === "remove" && oldVal && newVal === undefined) {
-        // It is necessary to temporarily add the attribute back for orphaned
-        // processing to work properly.
-        that.directive = oldVal;
-        can.trigger(that.constructor, 'orphaned', that);
-        delete that.directive;
-      }
-    });
-  }
-
-});
-
+    init: function () {
+      this.validateNonBlank('title');
+      this._super.apply(this, arguments);
+    }
+  }, {
+    init: function () {
+      var that = this;
+      this._super.apply(this, arguments);
+      this.bind('change', function (ev, attr, how, newVal, oldVal) {
+        // Emit the 'orphaned' event when the directive attribute is removed
+        if (attr === 'directive' && how === 'remove' && oldVal &&
+          newVal === undefined) {
+          // It is necessary to temporarily add the attribute back for orphaned
+          // processing to work properly.
+          that.directive = oldVal;
+          can.trigger(that.constructor, 'orphaned', that);
+          delete that.directive;
+        }
+      });
+    }
+  });
 })(this, can.$);

--- a/src/ggrc/assets/javascripts/models/custom_attributes.js
+++ b/src/ggrc/assets/javascripts/models/custom_attributes.js
@@ -63,6 +63,8 @@
     defaults: {
       "title": ""
     },
+    attributeTypes: ['Text', 'Rich Text', 'Date', 'Checkbox', 'Dropdown',
+      'Map:Person'],
     init: function() {
       this.validateNonBlank("title");
       this._super.apply(this, arguments);

--- a/src/ggrc/assets/javascripts/models/custom_attributes.js
+++ b/src/ggrc/assets/javascripts/models/custom_attributes.js
@@ -5,8 +5,7 @@
 
 //= require can.jquery-all
 //= require models/cacheable
-(function(namespace, $) {
-
+(function (namespace, $) {
   /* function sortCustomAttributables
    *
    * Groups custom attributes by category.
@@ -29,80 +28,77 @@
    * CustomAttributeDefinitions as children
    *
    */
-  can.Model.Cacheable("CMS.Models.CustomAttributable", {
-    findAll: function() {
+  can.Model.Cacheable('CMS.Models.CustomAttributable', {
+    findAll: function () {
       var types;
       types = GGRC.custom_attributable_types.sort(sortCustomAttributables);
-      return $.when(can.map(types, function(m, i) {
-        return new CMS.Models.CustomAttributable($.extend(m, {
+      return $.when(can.map(types, function (type, i) {
+        return new CMS.Models.CustomAttributable($.extend(type, {
           id: i
         }));
       }));
     }
   }, {
     // Cacheable checks if selfLink is set when the findAll deferred is done
-    selfLink: "/custom_attribute_list"
+    selfLink: '/custom_attribute_list'
   });
 
-  can.Model.Cacheable("CMS.Models.CustomAttributeDefinition", {
+  can.Model.Cacheable('CMS.Models.CustomAttributeDefinition', {
     // static properties
-    root_object: "custom_attribute_definition",
-    root_collection: "custom_attribute_definitions",
-    category: "custom_attribute_definitions",
-    findAll: "GET /api/custom_attribute_definitions",
-    findOne: "GET /api/custom_attribute_definitions/{id}",
-    create: "POST /api/custom_attribute_definitions",
-    update: "PUT /api/custom_attribute_definitions/{id}",
-    destroy: "DELETE /api/custom_attribute_definitions/{id}",
+    root_object: 'custom_attribute_definition',
+    root_collection: 'custom_attribute_definitions',
+    category: 'custom_attribute_definitions',
+    findAll: 'GET /api/custom_attribute_definitions',
+    findOne: 'GET /api/custom_attribute_definitions/{id}',
+    create: 'POST /api/custom_attribute_definitions',
+    update: 'PUT /api/custom_attribute_definitions/{id}',
+    destroy: 'DELETE /api/custom_attribute_definitions/{id}',
     mixins: [],
     attributes: {
-      values: "CMS.Models.CustomAttributeValue.stubs",
-      modified_by: "CMS.Models.Person.stub"
+      values: 'CMS.Models.CustomAttributeValue.stubs',
+      modified_by: 'CMS.Models.Person.stub'
     },
     links_to: {},
     defaults: {
-      "title": ""
+      title: ''
     },
     attributeTypes: ['Text', 'Rich Text', 'Date', 'Checkbox', 'Dropdown',
       'Map:Person'],
-    init: function() {
-      this.validateNonBlank("title");
+    init: function () {
+      this.validateNonBlank('title');
       this._super.apply(this, arguments);
     }
   }, {
-    init: function() {
-      var that = this;
+    init: function () {
       this._super.apply(this, arguments);
     }
   });
 
-  can.Model.Cacheable("CMS.Models.CustomAttributeValue", {
+  can.Model.Cacheable('CMS.Models.CustomAttributeValue', {
     // static properties
-    root_object: "custom_attribute_value",
-    root_collection: "custom_attribute_values",
-    category: "custom_attribute_values",
-    findAll: "GET /api/custom_attribute_values",
-    findOne: "GET /api/custom_attribute_values/{id}",
-    create: "POST /api/custom_attribute_values",
-    update: "PUT /api/custom_attribute_values/{id}",
-    destroy: "DELETE /api/custom_attribute_values/{id}",
+    root_object: 'custom_attribute_value',
+    root_collection: 'custom_attribute_values',
+    category: 'custom_attribute_values',
+    findAll: 'GET /api/custom_attribute_values',
+    findOne: 'GET /api/custom_attribute_values/{id}',
+    create: 'POST /api/custom_attribute_values',
+    update: 'PUT /api/custom_attribute_values/{id}',
+    destroy: 'DELETE /api/custom_attribute_values/{id}',
     mixins: [],
     attributes: {
-      definition: "CMS.Models.CustomAttributeDefinition.stub",
-      modified_by: "CMS.Models.Person.stub"
+      definition: 'CMS.Models.CustomAttributeDefinition.stub',
+      modified_by: 'CMS.Models.Person.stub'
     },
     links_to: {},
     defaults: {
-      "title": ""
+      title: ''
     },
-    init: function() {
+    init: function () {
       this._super.apply(this, arguments);
     }
   }, {
-    init: function() {
-      var that = this;
+    init: function () {
       this._super.apply(this, arguments);
     }
   });
-
 })(this, can.$);

--- a/src/ggrc/assets/javascripts/models/directive_models.js
+++ b/src/ggrc/assets/javascripts/models/directive_models.js
@@ -99,8 +99,10 @@ CMS.Models.Directive("CMS.Models.Standard", {
   , is_custom_attributable: true
   , attributes : {}
   , meta_kinds : [ "Standard" ]
-  , cache : can.getObject("cache", CMS.Models.Directive, true)
-  , init : function() {
+  , cache : can.getObject("cache", CMS.Models.Directive, true),
+  statuses: ['Draft', 'Final', 'Effective', 'Ineffective', 'Launched',
+      'Not Launched', 'In Scope', 'Not in Scope', 'Deprecated'],
+  init: function () {
     can.extend(this.attributes, CMS.Models.Directive.attributes);
     this._super.apply(this, arguments);
   }
@@ -126,8 +128,10 @@ CMS.Models.Directive("CMS.Models.Regulation", {
   , is_custom_attributable: true
   , attributes : {}
   , meta_kinds : [ "Regulation" ]
-  , cache : can.getObject("cache", CMS.Models.Directive, true)
-  , init : function() {
+  , cache : can.getObject("cache", CMS.Models.Directive, true),
+  statuses: ['Draft', 'Final', 'Effective', 'Ineffective', 'Launched',
+      'Not Launched', 'In Scope', 'Not in Scope', 'Deprecated'],
+  init: function () {
     can.extend(this.attributes, CMS.Models.Directive.attributes);
     this._super.apply(this, arguments);
   }
@@ -154,8 +158,10 @@ CMS.Models.Directive("CMS.Models.Policy", {
   , is_custom_attributable: true
   , attributes : {}
   , meta_kinds : [  "Company Policy", "Org Group Policy", "Data Asset Policy", "Product Policy", "Contract-Related Policy", "Company Controls Policy" ]
-  , cache : can.getObject("cache", CMS.Models.Directive, true)
-  , init : function() {
+  , cache : can.getObject("cache", CMS.Models.Directive, true),
+  statuses: ['Draft', 'Final', 'Effective', 'Ineffective', 'Launched',
+      'Not Launched', 'In Scope', 'Not in Scope', 'Deprecated'],
+  init: function () {
     can.extend(this.attributes, CMS.Models.Directive.attributes);
     can.extend(this.tree_view_options, CMS.Models.Directive.tree_view_options);
     this.tree_view_options.attr_list = can.Model.Cacheable.attr_list.concat([
@@ -190,8 +196,10 @@ CMS.Models.Directive("CMS.Models.Contract", {
   , attributes : {
   }
   , meta_kinds : [ "Contract" ]
-  , cache : can.getObject("cache", CMS.Models.Directive, true)
-  , init : function() {
+  , cache : can.getObject("cache", CMS.Models.Directive, true),
+  statuses: ['Draft', 'Final', 'Effective', 'Ineffective', 'Launched',
+      'Not Launched', 'In Scope', 'Not in Scope', 'Deprecated'],
+  init: function () {
     can.extend(this.attributes, CMS.Models.Directive.attributes);
     this._super.apply(this, arguments);
   }

--- a/src/ggrc/assets/javascripts/models/issue.js
+++ b/src/ggrc/assets/javascripts/models/issue.js
@@ -27,14 +27,16 @@
         {attr_title: 'Reference URL', attr_name: 'reference_url'}
       ])
     },
-    init : function() {
+    statuses: ['Draft', 'Final', 'Effective', 'Ineffective', 'Launched',
+      'Not Launched', 'In Scope', 'Not in Scope', 'Deprecated'],
+    init: function () {
       this._super && this._super.apply(this, arguments);
       this.validateNonBlank("title");
     }
   }, {
     object_model: can.compute(function() {
       return CMS.Models[this.attr("object_type")];
-    }),
+    })
   });
 
 })(this.can);

--- a/src/ggrc/assets/javascripts/models/issue.js
+++ b/src/ggrc/assets/javascripts/models/issue.js
@@ -2,27 +2,26 @@
     Copyright (C) 2016 Google Inc.
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 */
-;(function(can) {
-
-  can.Model.Cacheable("CMS.Models.Issue", {
-    root_object : "issue",
-    root_collection : "issues",
-    findOne : "GET /api/issues/{id}",
-    findAll : "GET /api/issues",
-    update : "PUT /api/issues/{id}",
-    destroy : "DELETE /api/issues/{id}",
-    create : "POST /api/issues",
-    mixins : ["ownable", "contactable"],
+;(function (can) {
+  can.Model.Cacheable('CMS.Models.Issue', {
+    root_object: 'issue',
+    root_collection: 'issues',
+    findOne: 'GET /api/issues/{id}',
+    findAll: 'GET /api/issues',
+    update: 'PUT /api/issues/{id}',
+    destroy: 'DELETE /api/issues/{id}',
+    create: 'POST /api/issues',
+    mixins: ['ownable', 'contactable'],
     is_custom_attributable: true,
-    attributes : {
-      context : "CMS.Models.Context.stub",
-      modified_by : "CMS.Models.Person.stub",
-      custom_attribute_values : "CMS.Models.CustomAttributeValue.stubs",
-      start_date: "date",
-      end_date: "date"
+    attributes: {
+      context: 'CMS.Models.Context.stub',
+      modified_by: 'CMS.Models.Person.stub',
+      custom_attribute_values: 'CMS.Models.CustomAttributeValue.stubs',
+      start_date: 'date',
+      end_date: 'date'
     },
-    tree_view_options : {
-      attr_list : can.Model.Cacheable.attr_list.concat([
+    tree_view_options: {
+      attr_list: can.Model.Cacheable.attr_list.concat([
         {attr_title: 'URL', attr_name: 'url'},
         {attr_title: 'Reference URL', attr_name: 'reference_url'}
       ])
@@ -31,12 +30,11 @@
       'Not Launched', 'In Scope', 'Not in Scope', 'Deprecated'],
     init: function () {
       this._super && this._super.apply(this, arguments);
-      this.validateNonBlank("title");
+      this.validateNonBlank('title');
     }
   }, {
-    object_model: can.compute(function() {
-      return CMS.Models[this.attr("object_type")];
+    object_model: can.compute(function () {
+      return CMS.Models[this.attr('object_type')];
     })
   });
-
 })(this.can);

--- a/src/ggrc/assets/javascripts/models/section.js
+++ b/src/ggrc/assets/javascripts/models/section.js
@@ -8,139 +8,141 @@
 //= require models/cacheable
 
 // this model doesn't exist anymore, can we get rid of it?
-can.Model.Cacheable("CMS.Models.Section", {
-  root_object : "section"
-  , root_collection : "sections"
-  , model_plural : "Sections"
-  , table_plural : "sections"
-  , title_plural : "Sections"
-  , model_singular : "Section"
-  , title_singular : "Section"
-  , table_singular : "section"
-  , category : "governance"
-  , root_model : "Section"
-  , findAll : "GET /api/sections"
-  , findOne : "GET /api/sections/{id}"
-  , create : "POST /api/sections"
-  , update : "PUT /api/sections/{id}"
-  , destroy : "DELETE /api/sections/{id}"
-  , is_custom_attributable: true
-  , mixins : ["ownable", "contactable", "unique_title"]
-  , attributes : {
-      context : "CMS.Models.Context.stub"
-    , owners: "CMS.Models.Person.stubs"
-    , modified_by: "CMS.Models.Person.stub"
-    , object_people: "CMS.Models.ObjectPerson.stubs"
-    , people: "CMS.Models.Person.stubs"
-    , object_documents: "CMS.Models.ObjectDocument.stubs"
-    , documents: "CMS.Models.Document.stubs"
-    , directive: "CMS.Models.get_stub"
-    , children: "CMS.Models.get_stubs"
-    , directive_sections: "CMS.Models.DirectiveSection.stubs"
-    , directives: "CMS.Models.get_stubs"
-    , objectives: "CMS.Models.Objective.stubs"
-    , custom_attribute_values : "CMS.Models.CustomAttributeValue.stubs"
-  }
-  , tree_view_options : {
-      show_view : "/static/mustache/sections/tree.mustache"
-    , footer_view : GGRC.mustache_path + "/sections/tree_footer.mustache"
-    , attr_list : can.Model.Cacheable.attr_list.concat([
+can.Model.Cacheable('CMS.Models.Section', {
+  root_object: 'section',
+  root_collection: 'sections',
+  model_plural: 'Sections',
+  table_plural: 'sections',
+  title_plural: 'Sections',
+  model_singular: 'Section',
+  title_singular: 'Section',
+  table_singular: 'section',
+  category: 'governance',
+  root_model: 'Section',
+  findAll: 'GET /api/sections',
+  findOne: 'GET /api/sections/{id}',
+  create: 'POST /api/sections',
+  update: 'PUT /api/sections/{id}',
+  destroy: 'DELETE /api/sections/{id}',
+  is_custom_attributable: true,
+  mixins: ['ownable', 'contactable', 'unique_title'],
+  attributes: {
+    context: 'CMS.Models.Context.stub',
+    owners: 'CMS.Models.Person.stubs',
+    modified_by: 'CMS.Models.Person.stub',
+    object_people: 'CMS.Models.ObjectPerson.stubs',
+    people: 'CMS.Models.Person.stubs',
+    object_documents: 'CMS.Models.ObjectDocument.stubs',
+    documents: 'CMS.Models.Document.stubs',
+    directive: 'CMS.Models.get_stub',
+    children: 'CMS.Models.get_stubs',
+    directive_sections: 'CMS.Models.DirectiveSection.stubs',
+    directives: 'CMS.Models.get_stubs',
+    objectives: 'CMS.Models.Objective.stubs',
+    custom_attribute_values: 'CMS.Models.CustomAttributeValue.stubs'
+  },
+  tree_view_options: {
+    show_view: '/static/mustache/sections/tree.mustache',
+    footer_view: GGRC.mustache_path + '/sections/tree_footer.mustache',
+    attr_list: can.Model.Cacheable.attr_list.concat([
       {attr_title: 'URL', attr_name: 'url'},
       {attr_title: 'Reference URL', attr_name: 'reference_url'}
-    ])
-    , add_item_view : GGRC.mustache_path + "/sections/tree_add_item.mustache"
-    , child_options : [{
-        model : can.Model.Cacheable
-      , mapping : "related_objects"
-      , title_plural : "Business Objects"
-      , draw_children : function() {
-          return this.instance.type === "Objective";
-      }
-      , footer_view : GGRC.mustache_path + "/base_objects/tree_footer.mustache"
-      , add_item_view : GGRC.mustache_path + "/base_objects/tree_add_item.mustache"
-      , child_options : [{
-            model: CMS.Models.Control
-          , title_plural: "Controls"
-          , mapping: "controls"
-          , draw_children: false
-          , footer_view: GGRC.mustache_path + "/controls/tree_footer.mustache"
-          , add_item_view : GGRC.mustache_path + "/controls/tree_add_item.mustache"
-          }]
+    ]),
+    add_item_view: GGRC.mustache_path + '/sections/tree_add_item.mustache',
+    child_options: [{
+      model: can.Model.Cacheable,
+      mapping: 'related_objects',
+      title_plural: 'Business Objects',
+      draw_children: function () {
+        return this.instance.type === 'Objective';
+      },
+      footer_view: GGRC.mustache_path + '/base_objects/tree_footer.mustache',
+      add_item_view: GGRC.mustache_path +
+      '/base_objects/tree_add_item.mustache',
+      child_options: [{
+        model: CMS.Models.Control,
+        title_plural: 'Controls',
+        mapping: 'controls',
+        draw_children: false,
+        footer_view: GGRC.mustache_path + '/controls/tree_footer.mustache',
+        add_item_view: GGRC.mustache_path + '/controls/tree_add_item.mustache'
       }]
-    }
-
-  , init : function() {
+    }]
+  },
+  statuses: ['Draft', 'Final', 'Effective', 'Ineffective', 'Launched',
+    'Not Launched', 'In Scope', 'Not in Scope', 'Deprecated'],
+  init: function () {
     this._super.apply(this, arguments);
-    this.validateNonBlank("title");
+    this.validateNonBlank('title');
   }
 }, {
 });
 
-
-can.Model.Cacheable("CMS.Models.Clause", {
-    root_object: "clause"
-  , root_collection: "clauses"
-  , model_plural: "Clauses"
-  , table_plural: "clauses"
-  , title_plural: "Clauses"
-  , model_singular: "Clause"
-  , title_singular: "Clause"
-  , table_singular: "clause"
-  , category: "governance"
-  , root_model: "Clause"
-  , findAll: "GET /api/clauses"
-  , findOne: "GET /api/clauses/{id}"
-  , create: "POST /api/clauses"
-  , update: "PUT /api/clauses/{id}"
-  , destroy: "DELETE /api/clauses/{id}"
-  , is_custom_attributable: true
-  , mixins : ["ownable", "contactable", "unique_title"]
-  , attributes : {
-      context : "CMS.Models.Context.stub"
-    , owners: "CMS.Models.Person.stubs"
-    , modified_by: "CMS.Models.Person.stub"
-    , object_people: "CMS.Models.ObjectPerson.stubs"
-    , people: "CMS.Models.Person.stubs"
-    , object_documents: "CMS.Models.ObjectDocument.stubs"
-    , documents: "CMS.Models.Document.stubs"
-    , directive: "CMS.Models.get_stub"
-    , children: "CMS.Models.get_stubs"
-    , directive_sections: "CMS.Models.DirectiveSection.stubs"
-    , directives: "CMS.Models.get_stubs"
-    , objectives: "CMS.Models.Objective.stubs"
-    , custom_attribute_values : "CMS.Models.CustomAttributeValue.stubs"
-  }
-
-  , tree_view_options: {
-      show_view: "/static/mustache/sections/tree.mustache"
-    , footer_view: GGRC.mustache_path + "/sections/tree_footer.mustache"
-    , attr_list : can.Model.Cacheable.attr_list.concat([
+can.Model.Cacheable('CMS.Models.Clause', {
+  root_object: 'clause',
+  root_collection: 'clauses',
+  model_plural: 'Clauses',
+  table_plural: 'clauses',
+  title_plural: 'Clauses',
+  model_singular: 'Clause',
+  title_singular: 'Clause',
+  table_singular: 'clause',
+  category: 'governance',
+  root_model: 'Clause',
+  findAll: 'GET /api/clauses',
+  findOne: 'GET /api/clauses/{id}',
+  create: 'POST /api/clauses',
+  update: 'PUT /api/clauses/{id}',
+  destroy: 'DELETE /api/clauses/{id}',
+  is_custom_attributable: true,
+  mixins: ['ownable', 'contactable', 'unique_title'],
+  attributes: {
+    context: 'CMS.Models.Context.stub',
+    owners: 'CMS.Models.Person.stubs',
+    modified_by: 'CMS.Models.Person.stub',
+    object_people: 'CMS.Models.ObjectPerson.stubs',
+    people: 'CMS.Models.Person.stubs',
+    object_documents: 'CMS.Models.ObjectDocument.stubs',
+    documents: 'CMS.Models.Document.stubs',
+    directive: 'CMS.Models.get_stub',
+    children: 'CMS.Models.get_stubs',
+    directive_sections: 'CMS.Models.DirectiveSection.stubs',
+    directives: 'CMS.Models.get_stubs',
+    objectives: 'CMS.Models.Objective.stubs',
+    custom_attribute_values: 'CMS.Models.CustomAttributeValue.stubs'
+  },
+  tree_view_options: {
+    show_view: '/static/mustache/sections/tree.mustache',
+    footer_view: GGRC.mustache_path + '/sections/tree_footer.mustache',
+    attr_list: can.Model.Cacheable.attr_list.concat([
       {attr_title: 'URL', attr_name: 'url'},
       {attr_title: 'Reference URL', attr_name: 'reference_url'}
-    ])
-    , add_item_view : GGRC.mustache_path + "/sections/tree_add_item.mustache"
-    , child_options: [{
-        model: can.Model.Cacheable
-      , mapping: "related_objects" //"related_and_able_objects"
-      , title_plural: "Business Objects"
-      , draw_children: function(){
-          return this.instance.type === "Objective";
-        }
-      , footer_view: GGRC.mustache_path + "/base_objects/tree_footer.mustache"
-      , add_item_view : GGRC.mustache_path + "/base_objects/tree_add_item.mustache"
-      , child_options: [{
-            model: CMS.Models.Control
-          , title_plural: "Controls"
-          , mapping: "controls"
-          , draw_children: false
-          , footer_view: GGRC.mustache_path + "/controls/tree_footer.mustache"
-          , add_item_view : GGRC.mustache_path + "/controls/tree_add_item.mustache"
-          }]
+    ]),
+    add_item_view: GGRC.mustache_path + '/sections/tree_add_item.mustache',
+    child_options: [{
+      model: can.Model.Cacheable,
+      mapping: 'related_objects', // 'related_and_able_objects'
+      title_plural: 'Business Objects',
+      draw_children: function () {
+        return this.instance.type === 'Objective';
+      },
+      footer_view: GGRC.mustache_path + '/base_objects/tree_footer.mustache',
+      add_item_view: GGRC.mustache_path +
+      '/base_objects/tree_add_item.mustache',
+      child_options: [{
+        model: CMS.Models.Control,
+        title_plural: 'Controls',
+        mapping: 'controls',
+        draw_children: false,
+        footer_view: GGRC.mustache_path + '/controls/tree_footer.mustache',
+        add_item_view: GGRC.mustache_path + '/controls/tree_add_item.mustache'
       }]
-    }
-  , init : function() {
+    }]
+  },
+  statuses: ['Draft', 'Final', 'Effective', 'Ineffective', 'Launched',
+    'Not Launched', 'In Scope', 'Not in Scope', 'Deprecated'],
+  init: function () {
     this._super.apply(this, arguments);
-    this.validateNonBlank("title");
+    this.validateNonBlank('title');
   }
-}, {
-});
+}, {});

--- a/src/ggrc/assets/javascripts/models/simple_models.js
+++ b/src/ggrc/assets/javascripts/models/simple_models.js
@@ -79,9 +79,10 @@ can.Model.Cacheable("CMS.Models.Program", {
     , "AccessGroup" : {}
     , "Product" : {}
     , "Market" : {}
-  }
-  , init : function() {
-    var that = this;
+  },
+  statuses: ['Draft', 'Final', 'Effective', 'Ineffective', 'Launched',
+      'Not Launched', 'In Scope', 'Not in Scope', 'Deprecated'],
+  init: function () {
     this.validateNonBlank("title");
     this._super.apply(this, arguments);
   }
@@ -161,9 +162,10 @@ can.Model.Cacheable("CMS.Models.Objective", {
       , title_plural : "Business Objects"
       , draw_children : false
     }]
-  }
-
-  , init : function() {
+  },
+  statuses: ['Draft', 'Final', 'Effective', 'Ineffective', 'Launched',
+      'Not Launched', 'In Scope', 'Not in Scope', 'Deprecated'],
+  init: function () {
     this.validateNonBlank("title");
     this._super.apply(this, arguments);
   }

--- a/src/ggrc/assets/javascripts/models/system.js
+++ b/src/ggrc/assets/javascripts/models/system.js
@@ -1,168 +1,174 @@
 /*!
-    Copyright (C) 2016 Google Inc.
-    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
-*/
+ Copyright (C) 2016 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
 
-can.Model.Cacheable("CMS.Models.SystemOrProcess", {
-    root_object : "system_or_process"
-    , root_collection : "systems_or_processes"
-    , title_plural : "Systems/Processes"
-    , category : "business"
-    , findAll : "GET /api/systems_or_processes"
-
-    , model : function(params) {
-        if (this.shortName !== 'SystemOrProcess')
-          return this._super(params);
-        if (!params)
-          return params;
-        params = this.object_from_resource(params);
-        if (!params.selfLink) {
-          if (params.type !== 'SystemOrProcess')
-            return CMS.Models[params.type].model(params);
-        } else {
-          if (params.is_biz_process)
-            return CMS.Models.Process.model(params);
-          else
-            return CMS.Models.System.model(params);
-        }
-      }
-
-    , mixins : ["ownable", "contactable", "unique_title"]
-    , attributes : {
-        context : "CMS.Models.Context.stub"
-      , owners : "CMS.Models.Person.stubs"
-      , modified_by : "CMS.Models.Person.stub"
-      , object_people : "CMS.Models.ObjectPerson.stubs"
-      , people : "CMS.Models.Person.stubs"
-      , object_documents : "CMS.Models.ObjectDocument.stubs"
-      , documents : "CMS.Models.Document.stubs"
-      , related_sources : "CMS.Models.Relationship.stubs"
-      , related_destinations : "CMS.Models.Relationship.stubs"
-      , objectives : "CMS.Models.Objective.stubs"
-      , controls : "CMS.Models.Control.stubs"
-      , sections : "CMS.Models.get_stubs"
-      , network_zone : "CMS.Models.Option.stub"
-      , custom_attribute_values : "CMS.Models.CustomAttributeValue.stubs"
+can.Model.Cacheable('CMS.Models.SystemOrProcess', {
+  root_object: 'system_or_process',
+  root_collection: 'systems_or_processes',
+  title_plural: 'Systems/Processes',
+  category: 'business',
+  findAll: 'GET /api/systems_or_processes',
+  model: function (params) {
+    if (this.shortName !== 'SystemOrProcess')
+      return this._super(params);
+    if (!params)
+      return params;
+    params = this.object_from_resource(params);
+    if (!params.selfLink) {
+      if (params.type !== 'SystemOrProcess')
+        return CMS.Models[params.type].model(params);
+    } else if (params.is_biz_process) {
+      return CMS.Models.Process.model(params);
+    } else {
+      return CMS.Models.System.model(params);
     }
-    , tree_view_options : {
-      show_view : "/static/mustache/base_objects/tree.mustache"
-      , footer_view : GGRC.mustache_path + "/base_objects/tree_footer.mustache"
-      , attr_list : can.Model.Cacheable.attr_list.concat([
-        {attr_title: 'Network Zone', attr_name: 'network_zone', attr_sort_field: 'network_zone.title'},
-        {attr_title: 'Effective Date', attr_name: 'start_date'},
-        {attr_title: 'Stop Date', attr_name: 'end_date'},
-        {attr_title: 'URL', attr_name: 'url'},
-        {attr_title: 'Reference URL', attr_name: 'reference_url'}
-      ])
-      , add_item_view : GGRC.mustache_path + "/base_objects/tree_add_item.mustache"
-      , link_buttons : true
-      , child_options : []
-    }
-    , links_to : {
-        "System" : {}
-      , "Process" : {}
-      , "Control" : {}
-      , "Product" : {}
-      , "Facility" : {}
-      , "OrgGroup" : {}
-      , "Vendor" : {}
-      , "Project" : {}
-      , "DataAsset" : {}
-      , "AccessGroup" : {}
-      , "Program" : {}
-      , "Market" : {}
-      , "Regulation" : {}
-      , "Policy" : {}
-      , "Standard" : {}
-      , "Contract" : {}
-      , "Objective" : {}
-      }
+  },
+  mixins: ['ownable', 'contactable', 'unique_title'],
+  attributes: {
+    context: 'CMS.Models.Context.stub',
+    owners: 'CMS.Models.Person.stubs',
+    modified_by: 'CMS.Models.Person.stub',
+    object_people: 'CMS.Models.ObjectPerson.stubs',
+    people: 'CMS.Models.Person.stubs',
+    object_documents: 'CMS.Models.ObjectDocument.stubs',
+    documents: 'CMS.Models.Document.stubs',
+    related_sources: 'CMS.Models.Relationship.stubs',
+    related_destinations: 'CMS.Models.Relationship.stubs',
+    objectives: 'CMS.Models.Objective.stubs',
+    controls: 'CMS.Models.Control.stubs',
+    sections: 'CMS.Models.get_stubs',
+    network_zone: 'CMS.Models.Option.stub',
+    custom_attribute_values: 'CMS.Models.CustomAttributeValue.stubs'
+  },
+  tree_view_options: {
+    show_view: '/static/mustache/base_objects/tree.mustache',
+    footer_view: GGRC.mustache_path + '/base_objects/tree_footer.mustache',
+    attr_list: can.Model.Cacheable.attr_list.concat([
+      {
+        attr_title: 'Network Zone',
+        attr_name: 'network_zone',
+        attr_sort_field: 'network_zone.title'
+      },
+      {attr_title: 'Effective Date', attr_name: 'start_date'},
+      {attr_title: 'Stop Date', attr_name: 'end_date'},
+      {attr_title: 'URL', attr_name: 'url'},
+      {attr_title: 'Reference URL', attr_name: 'reference_url'}
+    ]),
+    add_item_view: GGRC.mustache_path + '/base_objects/tree_add_item.mustache',
+    link_buttons: true,
+    child_options: []
+  },
+  links_to: {
+    System: {},
+    Process: {},
+    Control: {},
+    Product: {},
+    Facility: {},
+    OrgGroup: {},
+    Vendor: {},
+    Project: {},
+    DataAsset: {},
+    AccessGroup: {},
+    Program: {},
+    Market: {},
+    Regulation: {},
+    Policy: {},
+    Standard: {},
+    Contract: {},
+    Objective: {}
+  }
 }, {
-    system_or_process: function() {
-      if (this.attr('is_biz_process'))
-        return 'process';
-      else
-        return 'system';
+  system_or_process: function () {
+    var result;
+    if (this.attr('is_biz_process')) {
+      result = 'process';
+    } else {
+      result = 'system';
     }
-    , system_or_process_capitalized: function() {
-      var str = this.system_or_process();
-      return str.charAt(0).toUpperCase() + str.slice(1);
-    }
+    return result;
+  },
+  system_or_process_capitalized: function () {
+    var str = this.system_or_process();
+    return str.charAt(0).toUpperCase() + str.slice(1);
+  }
 });
 
-CMS.Models.SystemOrProcess("CMS.Models.System", {
-    root_object : "system"
-  , root_collection : "systems"
-  , findAll : "GET /api/systems"
-  , findOne : "GET /api/systems/{id}"
-  , create : "POST /api/systems"
-  , update : "PUT /api/systems/{id}"
-  , destroy : "DELETE /api/systems/{id}"
+CMS.Models.SystemOrProcess('CMS.Models.System', {
+  root_object: 'system',
+  root_collection: 'systems',
+  findAll: 'GET /api/systems',
+  findOne: 'GET /api/systems/{id}',
+  create: 'POST /api/systems',
+  update: 'PUT /api/systems/{id}',
+  destroy: 'DELETE /api/systems/{id}',
 
-  , cache : can.getObject("cache", CMS.Models.SystemOrProcess, true)
-  , is_custom_attributable: true
-  , attributes: {}
-  , defaults : {
-      title : ""
-    , url : ""
-    },
+  cache: can.getObject('cache', CMS.Models.SystemOrProcess, true),
+  is_custom_attributable: true,
+  attributes: {},
+  defaults: {
+    title: '',
+    url: ''
+  },
   statuses: ['Draft', 'Final', 'Effective', 'Ineffective', 'Launched',
-      'Not Launched', 'In Scope', 'Not in Scope', 'Deprecated'],
+    'Not Launched', 'In Scope', 'Not in Scope', 'Deprecated'],
   init: function () {
     can.extend(this.attributes, CMS.Models.SystemOrProcess.attributes);
     this._super && this._super.apply(this, arguments);
-    this.tree_view_options = $.extend({}, CMS.Models.SystemOrProcess.tree_view_options, {
-      // systems is a special case; can be imported to programs
-      footer_view: GGRC.mustache_path +
-          (GGRC.infer_object_type(GGRC.page_object) === CMS.Models.Program ?
-            "/systems/tree_footer.mustache" :
-             "/base_objects/tree_footer.mustache"),
+    this.tree_view_options = $.extend({},
+      CMS.Models.SystemOrProcess.tree_view_options, {
+        // systems is a special case; can be imported to programs
+        footer_view: GGRC.mustache_path +
+        (GGRC.infer_object_type(GGRC.page_object) === CMS.Models.Program ?
+          '/systems/tree_footer.mustache' :
+          '/base_objects/tree_footer.mustache'),
         add_item_view: GGRC.mustache_path +
-            (GGRC.infer_object_type(GGRC.page_object) === CMS.Models.Program ?
-              "/systems/tree_add_item.mustache"
-            : "/base_objects/tree_add_item.mustache")
-    });
-    this.validateNonBlank("title");
-  } //don't rebind the ObjectDocument/ObjectPerson events.
+        (GGRC.infer_object_type(GGRC.page_object) === CMS.Models.Program ?
+          '/systems/tree_add_item.mustache' :
+          '/base_objects/tree_add_item.mustache')
+      });
+    this.validateNonBlank('title');
+  } // don't rebind the ObjectDocument/ObjectPerson events.
 }, {
-    init : function() {
-      this._super && this._super.apply(this, arguments);
-      this.attr('is_biz_process', false);
-    }
+  init: function () {
+    this._super && this._super.apply(this, arguments);
+    this.attr('is_biz_process', false);
+  }
 });
 
-CMS.Models.SystemOrProcess("CMS.Models.Process", {
-    root_object : "process"
-  , root_collection : "processes"
-  , model_plural : "Processes"
-  , table_plural : "processes"
-  , title_plural : "Processes"
-  , model_singular : "Process"
-  , title_singular : "Process"
-  , table_singular : "process"
-  , findAll : "GET /api/processes"
-  , findOne : "GET /api/processes/{id}"
-  , create : "POST /api/processes"
-  , update : "PUT /api/processes/{id}"
-  , destroy : "DELETE /api/processes/{id}"
-  , cache : can.getObject("cache", CMS.Models.SystemOrProcess, true)
-  , is_custom_attributable: true
-  , attributes : {}
-  , defaults : {
-      title : ""
-    , url : ""
-    },
+CMS.Models.SystemOrProcess('CMS.Models.Process', {
+  root_object: 'process',
+  root_collection: 'processes',
+  model_plural: 'Processes',
+  table_plural: 'processes',
+  title_plural: 'Processes',
+  model_singular: 'Process',
+  title_singular: 'Process',
+  table_singular: 'process',
+  findAll: 'GET /api/processes',
+  findOne: 'GET /api/processes/{id}',
+  create: 'POST /api/processes',
+  update: 'PUT /api/processes/{id}',
+  destroy: 'DELETE /api/processes/{id}',
+  cache: can.getObject('cache', CMS.Models.SystemOrProcess, true),
+  is_custom_attributable: true,
+  attributes: {},
+  defaults: {
+    title: '',
+    url: ''
+  },
   statuses: ['Draft', 'Final', 'Effective', 'Ineffective', 'Launched',
-      'Not Launched', 'In Scope', 'Not in Scope', 'Deprecated'],
+    'Not Launched', 'In Scope', 'Not in Scope', 'Deprecated'],
   init: function () {
     can.extend(this.attributes, CMS.Models.SystemOrProcess.attributes);
     this._super && this._super.apply(this, arguments);
-    this.tree_view_options = $.extend({}, CMS.Models.SystemOrProcess.tree_view_options);
-    this.validateNonBlank("title");
-  } //don't rebind the ObjectDocument/ObjectPerson events.
+    this.tree_view_options = $.extend({},
+      CMS.Models.SystemOrProcess.tree_view_options);
+    this.validateNonBlank('title');
+  } // don't rebind the ObjectDocument/ObjectPerson events.
 }, {
-    init : function() {
-      this._super && this._super.apply(this, arguments);
-      this.attr('is_biz_process', true);
-    }
+  init: function () {
+    this._super && this._super.apply(this, arguments);
+    this.attr('is_biz_process', true);
+  }
 });

--- a/src/ggrc/assets/javascripts/models/system.js
+++ b/src/ggrc/assets/javascripts/models/system.js
@@ -105,8 +105,10 @@ CMS.Models.SystemOrProcess("CMS.Models.System", {
   , defaults : {
       title : ""
     , url : ""
-    }
-  , init : function() {
+    },
+  statuses: ['Draft', 'Final', 'Effective', 'Ineffective', 'Launched',
+      'Not Launched', 'In Scope', 'Not in Scope', 'Deprecated'],
+  init: function () {
     can.extend(this.attributes, CMS.Models.SystemOrProcess.attributes);
     this._super && this._super.apply(this, arguments);
     this.tree_view_options = $.extend({}, CMS.Models.SystemOrProcess.tree_view_options, {
@@ -149,8 +151,10 @@ CMS.Models.SystemOrProcess("CMS.Models.Process", {
   , defaults : {
       title : ""
     , url : ""
-    }
-  , init : function() {
+    },
+  statuses: ['Draft', 'Final', 'Effective', 'Ineffective', 'Launched',
+      'Not Launched', 'In Scope', 'Not in Scope', 'Deprecated'],
+  init: function () {
     can.extend(this.attributes, CMS.Models.SystemOrProcess.attributes);
     this._super && this._super.apply(this, arguments);
     this.tree_view_options = $.extend({}, CMS.Models.SystemOrProcess.tree_view_options);

--- a/src/ggrc/assets/mustache/access_groups/modal_content.mustache
+++ b/src/ggrc/assets/mustache/access_groups/modal_content.mustache
@@ -121,11 +121,9 @@
           <i class="fa fa-question-circle" rel="tooltip" title="Indicates the status of this object."></i>
           <a data-id="hide_state_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
         </label>
-        <select data-id="state_dd" class="input-block-level" name="status" null-if-empty="null-if-empty" tabindex="11">
-          {{#iterate 'Draft', 'Final', 'Effective', 'Ineffective', 'Launched', 'Not Launched', 'In Scope', 'Not in Scope', 'Deprecated'}}
-            <option {{#if_equals iterator status}}selected="true"{{/if_equals}}>{{iterator}}</option>
-          {{/iterate}}
-        </select>
+          <dropdown options-list="model.statuses"
+                    name="status">
+          </dropdown>
       </div>
     </div>
   </div>

--- a/src/ggrc/assets/mustache/assessments/info.mustache
+++ b/src/ggrc/assets/mustache/assessments/info.mustache
@@ -60,6 +60,7 @@
               {{#is_allowed 'update' instance context='for'}}
                   <dropdown options-list="model.conclusions"
                             no-value="true"
+                            no-value-label="---"
                             name="design">
                   </dropdown>
               {{else}}
@@ -72,6 +73,7 @@
               {{#is_allowed 'update' instance context='for'}}
                   <dropdown options-list="model.conclusions"
                             no-value="true"
+                            no-value-label="---"
                             name="operationally">
                   </dropdown>
               {{else}}

--- a/src/ggrc/assets/mustache/assessments/info.mustache
+++ b/src/ggrc/assets/mustache/assessments/info.mustache
@@ -58,12 +58,10 @@
               <h6>Conclusion: Design</h6>
               <p><small><em>Is this control design effective?</em></small></p>
               {{#is_allowed 'update' instance context='for'}}
-                <select class="input-medium visual-selector" name="design">
-                  <option value="" {{#if_equals design ""}}selected{{/if_equals}}>---</option>
-                  {{#iterate 'Effective' 'Ineffective' 'Needs improvement' 'Not Applicable'}}
-                    <option {{#if_equals iterator design}}selected="true"{{/if_equals}}>{{iterator}}</option>
-                  {{/iterate}}
-                </select>
+                  <dropdown options-list="model.conclusions"
+                            no-value="true"
+                            name="design">
+                  </dropdown>
               {{else}}
                 {{firstnonempty design '--'}}
               {{/is_allowed}}
@@ -72,12 +70,10 @@
               <h6>Conclusion: Operation</h6>
               <p><small><em>Is this control operationally effective?</em></small></p>
               {{#is_allowed 'update' instance context='for'}}
-                <select class="input-medium visual-selector" name="operationally">
-                  <option value="" {{#if_equals operationally ""}}selected{{/if_equals}}>---</option>
-                  {{#iterate 'Effective' 'Ineffective' 'Needs improvement' 'Not Applicable'}}
-                    <option {{#if_equals iterator operationally}}selected="true"{{/if_equals}}>{{iterator}}</option>
-                  {{/iterate}}
-                </select>
+                  <dropdown options-list="model.conclusions"
+                            no-value="true"
+                            name="operationally">
+                  </dropdown>
               {{else}}
                 {{firstnonempty operationally '--'}}
               {{/is_allowed}}

--- a/src/ggrc/assets/mustache/assessments/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessments/modal_content.mustache
@@ -198,12 +198,10 @@
           <i class="fa fa-question-circle" rel="tooltip" title="Is this control design effective?"></i>
           <a data-id="hide_state_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
         </label>
-        <select class="input-block-level" name="design" null-if-empty="null-if-empty" tabindex="7">
-          <option value="" {{#if_equals design ""}}selected{{/if_equals}}>---</option>
-          {{#iterate 'Effective' 'Ineffective' 'Needs improvement' 'Not Applicable'}}
-            <option {{#if_equals iterator design}}selected="true"{{/if_equals}}>{{iterator}}</option>
-          {{/iterate}}
-        </select>
+          <dropdown options-list="model.conclusions"
+                    no-value="true"
+                    name="design">
+          </dropdown>
       </div>
 
       <div class="span6 hidable">
@@ -212,12 +210,10 @@
           <i class="fa fa-question-circle" rel="tooltip" title="Is this control operationally effective?"></i>
           <a data-id="hide_state_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
         </label>
-        <select class="input-block-level" name="operationally" null-if-empty="null-if-empty" tabindex="8">
-          <option value="" {{#if_equals operationally ""}}selected{{/if_equals}}>---</option>
-          {{#iterate 'Effective' 'Ineffective' 'Needs improvement' 'Not Applicable'}}
-            <option {{#if_equals iterator operationally}}selected="true"{{/if_equals}}>{{iterator}}</option>
-          {{/iterate}}
-        </select>
+          <dropdown options-list="model.conclusions"
+                    no-value="true"
+                    name="operationally">
+          </dropdown>
       </div>
     </div>
   </div>

--- a/src/ggrc/assets/mustache/assessments/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessments/modal_content.mustache
@@ -200,6 +200,7 @@
         </label>
           <dropdown options-list="model.conclusions"
                     no-value="true"
+                    no-value-label="---"
                     name="design">
           </dropdown>
       </div>
@@ -212,6 +213,7 @@
         </label>
           <dropdown options-list="model.conclusions"
                     no-value="true"
+                    no-value-label="---"
                     name="operationally">
           </dropdown>
       </div>

--- a/src/ggrc/assets/mustache/audits/modal_content.mustache
+++ b/src/ggrc/assets/mustache/audits/modal_content.mustache
@@ -64,11 +64,9 @@
           <a data-id="hide_status_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
         </label>
         <div tabindex="4">
-          <select data-id="status_dd" class="input-block-level" name="status" {{#new_object_form}}disabled="true"{{/new_object_form}}>
-            {{#iterate 'Planned' 'In Progress' 'Manager Review' 'Ready for External Review' 'Completed'}}
-            <option {{#if_equals iterator instance.status}}selected="true"{{/if_equals}}>{{iterator}}</option>
-            {{/iterate}}
-          </select>
+            <dropdown options-list="model.statuses"
+                      name="instance.status">
+            </dropdown>
         </div>
       </div>
     </div>

--- a/src/ggrc/assets/mustache/audits/modal_content.mustache
+++ b/src/ggrc/assets/mustache/audits/modal_content.mustache
@@ -65,7 +65,7 @@
         </label>
         <div tabindex="4">
             <dropdown options-list="model.statuses"
-                      name="instance.status">
+                      name="status">
             </dropdown>
         </div>
       </div>

--- a/src/ggrc/assets/mustache/clauses/modal_content.mustache
+++ b/src/ggrc/assets/mustache/clauses/modal_content.mustache
@@ -120,12 +120,9 @@
           <i class="fa fa-question-circle" rel="tooltip" title="Indicates the status of this object."></i>
           <a data-id="hide_state_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
         </label>
-        <select data-id="state_dd" class="input-block-level" name="status" null-if-empty="null-if-empty" tabindex="8">
-          <option value="Draft" {{#if_equals status ""}}selected{{/if_equals}}>Draft</option>
-          {{#iterate 'Final', 'Effective', 'Ineffective', 'Launched', 'Not Launched', 'In Scope', 'Not in Scope', 'Deprecated'}}
-            <option {{#if_equals iterator status}}selected="true"{{/if_equals}}>{{iterator}}</option>
-          {{/iterate}}
-        </select>
+          <dropdown options-list="model.statuses"
+                    name="status">
+          </dropdown>
       </div>
     </div>
   </div>

--- a/src/ggrc/assets/mustache/components/dropdown/dropdown.mustache
+++ b/src/ggrc/assets/mustache/components/dropdown/dropdown.mustache
@@ -6,6 +6,8 @@
 <select
   class="{{firstnonempty className 'input-block-level'}}"
   can-value="{{name}}"
+  name="{{name}}"
+  null-if-empty="null-if-empty"
   can-change="onChange"
   {{#isDisabled}}disabled="disabled"{{/isDisabled}}
   >

--- a/src/ggrc/assets/mustache/contracts/modal_content.mustache
+++ b/src/ggrc/assets/mustache/contracts/modal_content.mustache
@@ -121,11 +121,9 @@
           <i class="fa fa-question-circle" rel="tooltip" title="Indicates the status of this object."></i>
           <a data-id="hide_state_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
         </label>
-        <select data-id="state_dd" class="input-block-level" name="status" null-if-empty="null-if-empty" tabindex="11">
-          {{#iterate 'Draft', 'Final', 'Effective', 'Ineffective', 'Launched', 'Not Launched', 'In Scope', 'Not in Scope', 'Deprecated'}}
-            <option {{#if_equals iterator status}}selected="true"{{/if_equals}}>{{iterator}}</option>
-          {{/iterate}}
-        </select>
+          <dropdown options-list="model.statuses"
+                    name="status">
+          </dropdown>
       </div>
     </div>
   </div>

--- a/src/ggrc/assets/mustache/controls/modal_content.mustache
+++ b/src/ggrc/assets/mustache/controls/modal_content.mustache
@@ -243,11 +243,9 @@
           <i class="fa fa-question-circle" rel="tooltip" title="Indicates the status of this object."></i>
           <a data-id="hide_state_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
         </label>
-        <select data-id="state_dd" class="input-block-level" name="status" null-if-empty="null-if-empty" tabindex="20">
-          {{#iterate 'Draft', 'Final', 'Effective', 'Ineffective', 'Launched', 'Not Launched', 'In Scope', 'Not in Scope', 'Deprecated'}}
-            <option {{#if_equals iterator status}}selected="true"{{/if_equals}}>{{iterator}}</option>
-          {{/iterate}}
-        </select>
+          <dropdown options-list="model.statuses"
+                    name="status">
+          </dropdown>
       </div>
     </div>
   </div>

--- a/src/ggrc/assets/mustache/custom_attribute_definitions/modal_content.mustache
+++ b/src/ggrc/assets/mustache/custom_attribute_definitions/modal_content.mustache
@@ -21,11 +21,9 @@
         <span class="required">*</span>
         <i class="fa fa-question-circle" rel="tooltip" title="Choose the type of attribute to create."></i>
       </label>
-      <select name="attribute_type" tabindex="2">
-        {{#iterate 'Text', 'Rich Text', 'Date', 'Checkbox' 'Dropdown' 'Map:Person'}} {{! 'File upload' }}
-        <option {{#if_equals iterator attribute_type}}selected="true"{{/if_equals}}>{{iterator}}</option>
-        {{/iterate}}
-      </select>
+        <dropdown options-list="model.attributeTypes"
+                  name="attribute_type">
+        </dropdown>
     </div>
     <div class="span2">
       <label>

--- a/src/ggrc/assets/mustache/data_assets/modal_content.mustache
+++ b/src/ggrc/assets/mustache/data_assets/modal_content.mustache
@@ -121,11 +121,9 @@
           <i class="fa fa-question-circle" rel="tooltip" title="Indicates the status of this object."></i>
           <a data-id="hide_state_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
         </label>
-        <select data-id="state_dd" class="input-block-level" name="status" null-if-empty="null-if-empty" tabindex="11">
-          {{#iterate 'Draft', 'Final', 'Effective', 'Ineffective', 'Launched', 'Not Launched', 'In Scope', 'Not in Scope', 'Deprecated'}}
-            <option {{#if_equals iterator status}}selected="true"{{/if_equals}}>{{iterator}}</option>
-          {{/iterate}}
-        </select>
+          <dropdown options-list="model.statuses"
+                    name="status">
+          </dropdown>
       </div>
     </div>
   </div>

--- a/src/ggrc/assets/mustache/facilities/modal_content.mustache
+++ b/src/ggrc/assets/mustache/facilities/modal_content.mustache
@@ -121,11 +121,9 @@
           <i class="fa fa-question-circle" rel="tooltip" title="Indicates the status of this object."></i>
           <a data-id="hide_state_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
         </label>
-        <select data-id="state_dd" class="input-block-level" name="status" null-if-empty="null-if-empty" tabindex="11">
-          {{#iterate 'Draft', 'Final', 'Effective', 'Ineffective', 'Launched', 'Not Launched', 'In Scope', 'Not in Scope', 'Deprecated'}}
-            <option {{#if_equals iterator status}}selected="true"{{/if_equals}}>{{iterator}}</option>
-          {{/iterate}}
-        </select>
+          <dropdown options-list="model.statuses"
+                    name="status">
+          </dropdown>
       </div>
     </div>
   </div>

--- a/src/ggrc/assets/mustache/issues/modal_content.mustache
+++ b/src/ggrc/assets/mustache/issues/modal_content.mustache
@@ -175,12 +175,10 @@
           <i class="fa fa-question-circle" rel="tooltip" title="Indicates the status of this object."></i>
           <a data-id="hide_state_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
         </label>
-        <select data-id="state_dd" class="input-block-level" name="status" null-if-empty="null-if-empty" tabindex="6">
-          <option value="" {{#if_equals status ""}}selected{{/if_equals}}>---</option>
-          {{#iterate 'Draft', 'Final', 'Effective', 'Ineffective', 'Launched', 'Not Launched', 'In Scope', 'Not in Scope', 'Deprecated'}}
-            <option {{#if_equals iterator status}}selected="true"{{/if_equals}}>{{iterator}}</option>
-          {{/iterate}}
-        </select>
+          <dropdown options-list="model.statuses"
+                    no-value="true"
+                    name="status">
+          </dropdown>
       </div>
     </div>
   </div>

--- a/src/ggrc/assets/mustache/issues/modal_content.mustache
+++ b/src/ggrc/assets/mustache/issues/modal_content.mustache
@@ -177,6 +177,7 @@
         </label>
           <dropdown options-list="model.statuses"
                     no-value="true"
+                    no-value-label="---"
                     name="status">
           </dropdown>
       </div>

--- a/src/ggrc/assets/mustache/markets/modal_content.mustache
+++ b/src/ggrc/assets/mustache/markets/modal_content.mustache
@@ -121,11 +121,9 @@
           <i class="fa fa-question-circle" rel="tooltip" title="Indicates the status of this object."></i>
           <a data-id="hide_state_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
         </label>
-        <select data-id="state_dd" class="input-block-level" name="status" null-if-empty="null-if-empty" tabindex="11">
-          {{#iterate 'Draft', 'Final', 'Effective', 'Ineffective', 'Launched', 'Not Launched', 'In Scope', 'Not in Scope', 'Deprecated'}}
-            <option {{#if_equals iterator status}}selected="true"{{/if_equals}}>{{iterator}}</option>
-          {{/iterate}}
-        </select>
+          <dropdown options-list="model.statuses"
+                    name="status">
+          </dropdown>
       </div>
     </div>
   </div>

--- a/src/ggrc/assets/mustache/objectives/modal_content.mustache
+++ b/src/ggrc/assets/mustache/objectives/modal_content.mustache
@@ -94,11 +94,9 @@
           <i class="fa fa-question-circle" rel="tooltip" title="Indicates the status of this object."></i>
           <a data-id="hide_state_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
         </label>
-        <select data-id="state_dd" class="input-block-level" name="status" null-if-empty="null-if-empty" tabindex="9">
-          {{#iterate 'Draft', 'Final', 'Effective', 'Ineffective', 'Launched', 'Not Launched', 'In Scope', 'Not in Scope', 'Deprecated'}}
-            <option {{#if_equals iterator status}}selected="true"{{/if_equals}}>{{iterator}}</option>
-          {{/iterate}}
-        </select>
+          <dropdown options-list="model.statuses"
+                    name="status">
+          </dropdown>
       </div>
     </div>
   </div>

--- a/src/ggrc/assets/mustache/org_groups/modal_content.mustache
+++ b/src/ggrc/assets/mustache/org_groups/modal_content.mustache
@@ -119,11 +119,9 @@
           <i class="fa fa-question-circle" rel="tooltip" title="Indicates the status of this object."></i>
           <a data-id="hide_state_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
         </label>
-        <select data-id="state_dd" class="input-block-level" name="status" null-if-empty="null-if-empty" tabindex="11">
-          {{#iterate 'Draft', 'Final', 'Effective', 'Ineffective', 'Launched', 'Not Launched', 'In Scope', 'Not in Scope', 'Deprecated'}}
-            <option {{#if_equals iterator status}}selected="true"{{/if_equals}}>{{iterator}}</option>
-          {{/iterate}}
-        </select>
+          <dropdown options-list="model.statuses"
+                    name="status">
+          </dropdown>
       </div>
     </div>
   </div>

--- a/src/ggrc/assets/mustache/policies/modal_content.mustache
+++ b/src/ggrc/assets/mustache/policies/modal_content.mustache
@@ -137,11 +137,9 @@
         <i class="fa fa-question-circle" rel="tooltip" title="Indicates the status of this object."></i>
         <a data-id="hide_state_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
       </label>
-      <select data-id="state_dd" class="input-block-level" name="status" null-if-empty="null-if-empty" tabindex="12">
-        {{#iterate 'Draft', 'Final', 'Effective', 'Ineffective', 'Launched', 'Not Launched', 'In Scope', 'Not in Scope', 'Deprecated'}}
-          <option {{#if_equals iterator status}}selected="true"{{/if_equals}}>{{iterator}}</option>
-        {{/iterate}}
-      </select>
+        <dropdown options-list="model.statuses"
+                  name="status">
+        </dropdown>
     </div>
   </div>
 </form>

--- a/src/ggrc/assets/mustache/processes/modal_content.mustache
+++ b/src/ggrc/assets/mustache/processes/modal_content.mustache
@@ -134,6 +134,7 @@
       </label>
         <dropdown options-list="model.statuses"
                   no-value="true"
+                  no-value-label="---"
                   name="status">
         </dropdown>
     </div>

--- a/src/ggrc/assets/mustache/processes/modal_content.mustache
+++ b/src/ggrc/assets/mustache/processes/modal_content.mustache
@@ -132,12 +132,10 @@
         <i class="fa fa-question-circle" rel="tooltip" title="Indicates the status of this object."></i>
         <a data-id="hide_state_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
       </label>
-      <select data-id="state_dd" class="input-block-level" name="status" null-if-empty="null-if-empty" tabindex="12">
-        <option value="" {{#if_equals status ""}}selected{{/if_equals}}>---</option>
-        {{#iterate 'Draft', 'Final', 'Effective', 'Ineffective', 'Launched', 'Not Launched', 'In Scope', 'Not in Scope', 'Deprecated'}}
-          <option {{#if_equals iterator status}}selected="true"{{/if_equals}}>{{iterator}}</option>
-        {{/iterate}}
-      </select>
+        <dropdown options-list="model.statuses"
+                  no-value="true"
+                  name="status">
+        </dropdown>
     </div>
   </div>
 </form>

--- a/src/ggrc/assets/mustache/products/modal_content.mustache
+++ b/src/ggrc/assets/mustache/products/modal_content.mustache
@@ -128,11 +128,9 @@
           <i class="fa fa-question-circle" rel="tooltip" title="Indicates the status of this object."></i>
           <a data-id="hide_state_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
         </label>
-        <select data-id="state_dd" class="input-block-level" name="status" null-if-empty="null-if-empty" tabindex="12">
-          {{#iterate 'Draft', 'Final', 'Effective', 'Ineffective', 'Launched', 'Not Launched', 'In Scope', 'Not in Scope', 'Deprecated'}}
-            <option {{#if_equals iterator status}}selected="true"{{/if_equals}}>{{iterator}}</option>
-          {{/iterate}}
-        </select>
+          <dropdown options-list="model.statuses"
+                    name="status">
+          </dropdown>
       </div>
     </div>
   </div>

--- a/src/ggrc/assets/mustache/programs/modal_content.mustache
+++ b/src/ggrc/assets/mustache/programs/modal_content.mustache
@@ -152,13 +152,9 @@
         <i class="fa fa-question-circle" rel="tooltip" title="Indicates the status of this object."></i>
         <a href="javascript://" class="field-hide" tabindex="-1">hide</a>
       </label>
-      <select data-test-id="new_program_dropdown_state_036a1fa6"
-              class="input-block-level"
-              name="status" null-if-empty="null-if-empty" tabindex="12">
-        {{#iterate 'Draft', 'Final', 'Effective', 'Ineffective', 'Launched', 'Not Launched', 'In Scope', 'Not in Scope', 'Deprecated'}}
-          <option {{#if_equals iterator status}}selected="true"{{/if_equals}}>{{iterator}}</option>
-        {{/iterate}}
-      </select>
+        <dropdown options-list="model.statuses"
+                  name="status">
+        </dropdown>
     </div>
   </div>
 

--- a/src/ggrc/assets/mustache/programs/modal_content.mustache
+++ b/src/ggrc/assets/mustache/programs/modal_content.mustache
@@ -152,7 +152,8 @@
         <i class="fa fa-question-circle" rel="tooltip" title="Indicates the status of this object."></i>
         <a href="javascript://" class="field-hide" tabindex="-1">hide</a>
       </label>
-        <dropdown options-list="model.statuses"
+        <dropdown data-test-id="new_program_dropdown_state_036a1fa6"
+                  options-list="model.statuses"
                   name="status">
         </dropdown>
     </div>

--- a/src/ggrc/assets/mustache/projects/modal_content.mustache
+++ b/src/ggrc/assets/mustache/projects/modal_content.mustache
@@ -121,11 +121,9 @@
           <i class="fa fa-question-circle" rel="tooltip" title="Indicates the status of this object."></i>
           <a data-id="hide_state_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
         </label>
-        <select data-id="state_dd" class="input-block-level" name="status" null-if-empty="null-if-empty" tabindex="11">
-          {{#iterate 'Draft', 'Final', 'Effective', 'Ineffective', 'Launched', 'Not Launched', 'In Scope', 'Not in Scope', 'Deprecated'}}
-            <option {{#if_equals iterator status}}selected="true"{{/if_equals}}>{{iterator}}</option>
-          {{/iterate}}
-        </select>
+          <dropdown options-list="model.statuses"
+                    name="status">
+          </dropdown>
       </div>
     </div>
   </div>

--- a/src/ggrc/assets/mustache/regulations/modal_content.mustache
+++ b/src/ggrc/assets/mustache/regulations/modal_content.mustache
@@ -120,11 +120,9 @@
           <i class="fa fa-question-circle" rel="tooltip" title="Indicates the status of this object."></i>
           <a data-id="hide_state_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
         </label>
-        <select data-id="state_dd" class="input-block-level" name="status" null-if-empty="null-if-empty" tabindex="11">
-          {{#iterate 'Draft', 'Final', 'Effective', 'Ineffective', 'Launched', 'Not Launched', 'In Scope', 'Not in Scope', 'Deprecated'}}
-            <option {{#if_equals iterator status}}selected="true"{{/if_equals}}>{{iterator}}</option>
-          {{/iterate}}
-        </select>
+          <dropdown options-list="model.statuses"
+                    name="status">
+          </dropdown>
       </div>
     </div>
   </div>

--- a/src/ggrc/assets/mustache/sections/modal_content.mustache
+++ b/src/ggrc/assets/mustache/sections/modal_content.mustache
@@ -111,12 +111,9 @@
           <i class="fa fa-question-circle" rel="tooltip" title="Indicates the status of this object."></i>
           <a data-id="hide_state_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
         </label>
-        <select data-id="state_dd" class="input-block-level" name="status" null-if-empty="null-if-empty" tabindex="9">
-          <option value="Draft" {{#if_equals status ""}}selected{{/if_equals}}>Draft</option>
-          {{#iterate 'Final', 'Effective', 'Ineffective', 'Launched', 'Not Launched', 'In Scope', 'Not in Scope', 'Deprecated'}}
-            <option {{#if_equals iterator status}}selected="true"{{/if_equals}}>{{iterator}}</option>
-          {{/iterate}}
-        </select>
+          <dropdown options-list="model.statuses"
+                    name="status">
+          </dropdown>
       </div>
     </div>
   </div>

--- a/src/ggrc/assets/mustache/standards/modal_content.mustache
+++ b/src/ggrc/assets/mustache/standards/modal_content.mustache
@@ -121,11 +121,9 @@
           <i class="fa fa-question-circle" rel="tooltip" title="Indicates the status of this object."></i>
           <a data-id="hide_state_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
         </label>
-        <select data-id="state_dd" class="input-block-level" name="status" null-if-empty="null-if-empty" tabindex="11">
-          {{#iterate 'Draft', 'Final', 'Effective', 'Ineffective', 'Launched', 'Not Launched', 'In Scope', 'Not in Scope', 'Deprecated'}}
-            <option {{#if_equals iterator status}}selected="true"{{/if_equals}}>{{iterator}}</option>
-          {{/iterate}}
-        </select>
+          <dropdown options-list="model.statuses"
+                    name="status">
+          </dropdown>
       </div>
     </div>
   </div>

--- a/src/ggrc/assets/mustache/systems/modal_content.mustache
+++ b/src/ggrc/assets/mustache/systems/modal_content.mustache
@@ -132,11 +132,9 @@
         <i class="fa fa-question-circle" rel="tooltip" title="Indicates the status of this object."></i>
         <a data-id="hide_state_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
       </label>
-      <select data-id="state_dd" class="input-block-level" name="status" null-if-empty="null-if-empty" tabindex="12">
-        {{#iterate 'Draft', 'Final', 'Effective', 'Ineffective', 'Launched', 'Not Launched', 'In Scope', 'Not in Scope', 'Deprecated'}}
-          <option {{#if_equals iterator status}}selected="true"{{/if_equals}}>{{iterator}}</option>
-        {{/iterate}}
-      </select>
+        <dropdown options-list="model.statuses"
+                  name="status">
+        </dropdown>
     </div>
   </div>
 </form>

--- a/src/ggrc/assets/mustache/vendors/modal_content.mustache
+++ b/src/ggrc/assets/mustache/vendors/modal_content.mustache
@@ -119,11 +119,9 @@
           <i class="fa fa-question-circle" rel="tooltip" title="Indicates the status of this object."></i>
           <a data-id="hide_state_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
         </label>
-        <select data-id="state_dd" class="input-block-level" name="status" null-if-empty="null-if-empty" tabindex="10">
-          {{#iterate 'Draft', 'Final', 'Effective', 'Ineffective', 'Launched', 'Not Launched', 'In Scope', 'Not in Scope', 'Deprecated'}}
-            <option {{#if_equals iterator status}}selected="true"{{/if_equals}}>{{iterator}}</option>
-          {{/iterate}}
-        </select>
+          <dropdown options-list="model.statuses"
+                    name="status">
+          </dropdown>
       </div>
     </div>
 </form>

--- a/src/ggrc_risks/assets/javascripts/models/risk.js
+++ b/src/ggrc_risks/assets/javascripts/models/risk.js
@@ -28,8 +28,9 @@
     tree_view_options: {
       add_item_view : GGRC.mustache_path + "/base_objects/tree_add_item.mustache"
     },
-
-    init: function() {
+    statuses: ['Draft', 'Final', 'Effective', 'Ineffective', 'Launched',
+      'Not Launched', 'In Scope', 'Not in Scope', 'Deprecated'],
+    init: function () {
       this._super && this._super.apply(this, arguments);
       var req_fields = ["title", "description", "contact"];
       for (var i = 0; i < req_fields.length; i++) {

--- a/src/ggrc_risks/assets/javascripts/models/threat.js
+++ b/src/ggrc_risks/assets/javascripts/models/threat.js
@@ -41,6 +41,8 @@
         {attr_title: 'Reference URL', attr_name: 'reference_url'}
       ])
     },
+    statuses: ['Draft', 'Final', 'Effective', 'Ineffective', 'Launched',
+      'Not Launched', 'In Scope', 'Not in Scope', 'Deprecated'],
     init: function () {
       this._super && this._super.apply(this, arguments);
       this.validatePresenceOf("title");

--- a/src/ggrc_risks/assets/mustache/risks/modal_content.mustache
+++ b/src/ggrc_risks/assets/mustache/risks/modal_content.mustache
@@ -171,6 +171,7 @@
       </label>
         <dropdown options-list="model.statuses"
                   no-value="true"
+                  no-value-label="---"
                   name="status">
         </dropdown>
     </div>

--- a/src/ggrc_risks/assets/mustache/risks/modal_content.mustache
+++ b/src/ggrc_risks/assets/mustache/risks/modal_content.mustache
@@ -169,13 +169,10 @@
            title="Indicates the status of this object."></i>
         <a href="javascript://" class="field-hide" tabindex="-1">hide</a>
       </label>
-      <select class="input-block-level"
-              name="status" null-if-empty="null-if-empty" tabindex="8">
-        <option value="" {{#if_equals status ""}}selected{{/if_equals}}>---</option>
-        {{#iterate 'Draft', 'Final', 'Effective', 'Ineffective', 'Launched', 'Not Launched', 'In Scope', 'Not in Scope', 'Deprecated'}}
-          <option {{#if_equals iterator status}}selected="true"{{/if_equals}}>{{iterator}}</option>
-        {{/iterate}}
-      </select>
+        <dropdown options-list="model.statuses"
+                  no-value="true"
+                  name="status">
+        </dropdown>
     </div>
   </div>
 

--- a/src/ggrc_risks/assets/mustache/threats/modal_content.mustache
+++ b/src/ggrc_risks/assets/mustache/threats/modal_content.mustache
@@ -121,6 +121,7 @@
       </label>
         <dropdown options-list="model.statuses"
                   no-value="true"
+                  no-value-label="---"
                   name="status">
         </dropdown>
     </div>

--- a/src/ggrc_risks/assets/mustache/threats/modal_content.mustache
+++ b/src/ggrc_risks/assets/mustache/threats/modal_content.mustache
@@ -119,12 +119,10 @@
         <i class="fa fa-question-circle" rel="tooltip" title="Indicates the status of this object."></i>
         <a href="javascript://" class="field-hide" tabindex="-1">hide</a>
       </label>
-      <select class="input-block-level" name="status" null-if-empty="null-if-empty" tabindex="10">
-        <option value="" {{#if_equals status ""}}selected{{/if_equals}}>---</option>
-        {{#iterate 'Draft', 'Final', 'Effective', 'Ineffective', 'Launched', 'Not Launched', 'In Scope', 'Not in Scope', 'Deprecated'}}
-          <option {{#if_equals iterator status}}selected="true"{{/if_equals}}>{{iterator}}</option>
-        {{/iterate}}
-      </select>
+        <dropdown options-list="model.statuses"
+                  no-value="true"
+                  name="status">
+        </dropdown>
     </div>
   </div>
 </form>


### PR DESCRIPTION
**Subject:** Cannot select Audit state "Completed" in the audit status dropdown from the first try
**Details:**
- edit an audit
- select "Completed" in the Status dropdown

_Actual Result:_  the value “Ready for review” is selected instead
_Expected Result:_ status "Completed" should be selected from the first try
_Workaround:_ select "Completed" status once again

This issue is relevant to all dropdowns in the application when you choose the last item.