### PR TITLE
QUICK-FIX Sort urls list by creation date

### DIFF
--- a/src/ggrc/assets/javascripts/components/mapped_tree_view.js
+++ b/src/ggrc/assets/javascripts/components/mapped_tree_view.js
@@ -13,6 +13,7 @@
       reuseMethod: '@',
       treeViewClass: '@',
       expandable: '@',
+      sortField: '@',
       parentInstance: null,
       mappedObjects: [],
       isExpandable: function () {
@@ -39,13 +40,33 @@
       binding = this.scope.parentInstance.get_binding(this.scope.mapping);
 
       binding.refresh_instances().then(function (mappedObjects) {
-        this.scope.attr('mappedObjects').replace(mappedObjects);
+        this.scope.attr('mappedObjects').replace(
+          this._sortObjects(mappedObjects)
+        );
       }.bind(this));
 
       // We are tracking binding changes, so mapped items update accordingly
       binding.list.on('change', function () {
-        this.scope.attr('mappedObjects').replace(binding.list);
+        this.scope.attr('mappedObjects').replace(
+          this._sortObjects(binding.list)
+        );
       }.bind(this));
+    },
+    /**
+      * Sort objects list by this.scope.sortField, if defined
+      *
+      * @param {Array} mappedObjects - the list of objects to be sorted
+      *
+      * @return {Array} - if this.scope.sortField is defined, mappedObjects
+      *                   sorted by field this field;
+      *                   if this.scope.sortField is undefined, unsorted
+      *                   mappedObjects.
+      */
+    _sortObjects: function (mappedObjects) {
+      if (this.scope.attr('sortField')) {
+        return _.sortBy(mappedObjects, this.scope.attr('sortField'));
+      }
+      return mappedObjects;
     },
     events: {
       '[data-toggle=unmap] click': function (el, ev) {

--- a/src/ggrc/assets/javascripts/components/mapped_tree_view.js
+++ b/src/ggrc/assets/javascripts/components/mapped_tree_view.js
@@ -87,7 +87,9 @@
               return mapping.destroy();
             })
             .then(function () {
-              return mapping.documentable.reify();
+              if (mapping.documentable) {
+                return mapping.documentable.reify();
+              }
             });
         });
       }

--- a/src/ggrc/assets/mustache/base_templates/url_list.mustache
+++ b/src/ggrc/assets/mustache/base_templates/url_list.mustache
@@ -7,6 +7,7 @@
   parent-instance="instance"
   mapping="instance.class.info_pane_options.urls.mapping"
   item-template="instance.class.info_pane_options.urls.show_view"
+  sort-field="instance.created_at"
 >
 </mapping-tree-view>
 {{#with_mapping instance.class.info_pane_options.urls.mapping instance}}


### PR DESCRIPTION
The URLs attached to an assessment are not sorted by date added.

Steps to reproduce on localhost:
- Create an assessment.
- Open its details page.
- Add an url with text 'url1' to the assessment.
- Add an url with text 'url2' to the assessment.
- With mysql client, set `creation_date`s in past for url2 and in future for url1 manually.
```sql
update documents set created_at='2000-01-01 00:00:00', updated_at='2000-01-01 00:00:00' where title='url2';
update documents set created_at='2020-01-01 00:00:00', updated_at='2020-01-01 00:00:00' where title='url1';
```
- Refresh the page.
- Add an url with text 'url3' to the assessment.

Expected result: the urls are sorted by creation dates (the order is url2, url3, url1).
Actual result: the urls are sorted by their ids or something (the order is url1, url2, url3).

This PR adds a parameter to sort `mapping-tree-view`s, so the urls list gets sorted before rendering.