### PR TITLE
QUICK-FIX view log data in Request log tab

### DIFF
--- a/src/ggrc/assets/javascripts/components/object_history/object_history.js
+++ b/src/ggrc/assets/javascripts/components/object_history/object_history.js
@@ -24,9 +24,6 @@
       isLoading: true
     },
 
-    // the type of the object the component is operating on
-    _INSTANCE_TYPE: null,
-
     _DATE_FIELDS: Object.freeze({
       created_at: 1,
       updated_at: 1,
@@ -57,8 +54,6 @@
      */
     init: function (element, options) {
       var setUp = function () {
-        this._INSTANCE_TYPE = this.scope.instance.type;
-
         this._fetchRevisionsData(
           this.scope.instance
         ).then(
@@ -441,14 +436,20 @@
      *         - newVal: the attribute's new (modified) value
      */
     _mappingChange: function (revision, chain) {
-      var object = revision.destination_type === this._INSTANCE_TYPE ?
-                   revision.source : revision.destination;
+      var object;
       var displayName;
       var displayType;
       var fieldName;
       var origVal;
       var newVal;
       var previous;
+
+      if (revision.destination_type === this.scope.instance.type &&
+        revision.destination_id === this.scope.instance.id) {
+        object = revision.source;
+      } else {
+        object = revision.destination;
+      }
 
       if (object instanceof can.Stub) {
         object = object.reify();

--- a/src/ggrc/assets/javascripts/components/object_history/tests/object_history_spec.js
+++ b/src/ggrc/assets/javascripts/components/object_history/tests/object_history_spec.js
@@ -82,12 +82,6 @@ describe('GGRC.Components.objectHistory', function () {
       }
     );
 
-    it('stores the correct instance type', function () {
-      instance.attr('type', 'ObjectFoo');
-      method(element);
-      expect(componentInst._INSTANCE_TYPE).toEqual('ObjectFoo');
-    });
-
     it('fetches history data for the correct object instance', function () {
       method(element);
       expect(componentInst._fetchRevisionsData).toHaveBeenCalledWith(instance);
@@ -541,7 +535,6 @@ describe('GGRC.Components.objectHistory', function () {
       // obtain a reference to the method under test, and bind it to a fake
       // instance context
       var componentInst = {
-        _INSTANCE_TYPE: 'ObjectFoo',
         scope: new can.Map({
           instance: {
             id: 123,
@@ -698,10 +691,15 @@ describe('GGRC.Components.objectHistory', function () {
 
     beforeAll(function () {
       componentInst = {
-        _INSTANCE_TYPE: 'ObjectFoo',
         _getRoleAtTime: function () {
           return 'none';
-        }
+        },
+        scope: new can.Map({
+          instance: {
+            id: 123,
+            type: 'ObjectFoo'
+          }
+        })
       };
 
       method = Component.prototype._mappingChange.bind(componentInst);
@@ -866,7 +864,6 @@ describe('GGRC.Components.objectHistory', function () {
 
     beforeAll(function () {
       componentInst = {
-        _INSTANCE_TYPE: 'ObjectFoo',
         scope: new can.Map({
           instance: {
             id: 123,


### PR DESCRIPTION
Subject: “Uncaught TypeError: Cannot read property 'display_name' of undefined” error is displayed while trying to display Request Log tab on request page
Details: 
Create a program
Create an audit for that program
Create request. While creating request map all available Requests in the system.
Save the Request
Click Request Log tab
Actual Result:  “Uncaught TypeError: Cannot read property 'display_name' of undefined” error is displayed.
Expected Result: Request log contains corresponding information.
Workaround: N/A
