### PR TITLE
QUICK-FIX Change object titles to links in related objects lists

### DIFF
--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -837,6 +837,54 @@ Mustache.registerHelper("get_view_link", function (instance, options) {
   return defer_render("a", finish, instance.get_permalink());
 });
 
+  /**
+   * Generate an anchor element that opens the instance's view page in a
+   * new browser tab/window.
+   *
+   * If the instance does not have such a page, an empty string is returned.
+   * The inner content of the tag is used as the text for the link.
+   *
+   * This helper is a modification of the `get_view_link` helper - the latter
+   * generates a link with an arrow icon instead of the text.
+   *
+   * Example usage:
+   *
+   *   {{{#view_object_link instance}}}
+   *     Open {{firstexist instance.name instance.title}}
+   *   {{{/view_object_link}}}
+   *
+   * NOTE: Since an HTML snippet is generated, the helper should be used with
+   * an unescaping block (tripple braces).
+   *
+   * @param {can.Model} instance - the object to generate the link for
+   * @param {Object} options - a CanJS options argument passed to every helper
+   * @return {String} - the link HTML snippet
+   */
+  Mustache.registerHelper('view_object_link', function (instance, options) {
+    var linkText;
+
+    function onRenderComplete(link) {
+      var html = [
+        '<a ',
+        '  href="' + link + '"',
+        '  target="_blank"',
+        '  class="view-link">',
+        linkText,
+        '</a>'
+      ].join('');
+      return html;
+    }
+
+    instance = resolve_computed(instance);
+    if (!instance.viewLink && !instance.get_permalink) {
+      return '';
+    }
+
+    linkText = options.fn(options.contexts);
+
+    return defer_render('a', onRenderComplete, instance.get_permalink());
+  });
+
 Mustache.registerHelper("schemed_url", function (url) {
   var domain, max_label, url_split;
 

--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -824,18 +824,18 @@ Mustache.registerHelper("get_permalink_for_object", function (instance, options)
   return window.location.origin + instance.viewLink;
 });
 
-Mustache.registerHelper("get_view_link", function (instance, options) {
-  function finish(link) {
-    return "<a href=" + link + " target=\"_blank\" class=\"view-link\">" +
-           "  <i class=\"fa fa-long-arrow-right\"></i>" +
-           "</a>";
-  }
-  instance = resolve_computed(instance);
-  if (!instance.viewLink && !instance.get_permalink) {
-    return "";
-  }
-  return defer_render("a", finish, instance.get_permalink());
-});
+  Mustache.registerHelper('get_view_link', function (instance, options) {
+    function finish(link) {
+      return '<a href=' + link + ' target="_blank" class="view-link">' +
+             '  <i class="fa fa-long-arrow-right"></i>' +
+             '</a>';
+    }
+    instance = resolve_computed(instance);
+    if (!instance.viewLink && !instance.get_permalink) {
+      return '';
+    }
+    return defer_render('a', finish, instance.get_permalink());
+  });
 
   /**
    * Generate an anchor element that opens the instance's view page in a

--- a/src/ggrc/assets/mustache/base_templates/subtree.mustache
+++ b/src/ggrc/assets/mustache/base_templates/subtree.mustache
@@ -21,17 +21,16 @@
             <div class="span8">
               <div class="tree-title-area">
                 <i class="fa fa-{{instance.class.table_singular}} color"></i>
-                {{firstexist instance.name instance.title instance.description}}
+
+                {{{#view_object_link instance}}}
+                  {{firstexist instance.name instance.title instance.description}}
+                {{{/view_object_link}}}
+
                 <span class="url-link">
                   {{firstexist instance.email instance.link}}
                 </span>
               </div>
             </div> <!-- span8 end -->
-            <div class="span4">
-              <div class="show-details">
-                  {{{get_view_link instance}}}
-              </div>
-            </div>
           </div> <!-- row-fluid end -->
         </div> <!-- item-data end -->
       </div> <!-- select end -->

--- a/src/ggrc_workflows/assets/javascripts/models/cycle_models.js
+++ b/src/ggrc_workflows/assets/javascripts/models/cycle_models.js
@@ -48,7 +48,7 @@
     }
     if (typeof workflow.cycles === undefined || !workflow.cycles) {
       $(document.body).trigger(
-        'ajax:flash', 
+        'ajax:flash',
         {warning: 'No cycles in the workflow!'}
       );
       return;
@@ -60,7 +60,7 @@
 
       if (!activeCycleList.length) {
         $(document.body).trigger(
-          'ajax:flash', 
+          'ajax:flash',
           {warning: 'No active cycles in the workflow!'}
         );
         return;


### PR DESCRIPTION
This PR replaces the "arrow" links to the object view page by changing the objects' titles themselves into links.

> **Details:**
 - Navigate to the audit page -> Assessments tab
 - Click the assessment’s 1st tier
 - Open Related Assessments tab in info panel

> **Actual Result:** the arrows are shown for the related objects
> **Expected Result:** Remove the arrows and make the object titles hyperlinks

This is issue in `1.24` under `Section 2` in the bug description document.

NOTE:
For consistency, the links are changed everywhere where the template `base_objects/subtree.mustache` is used to render the list of related objects.
If this behavior is not desired, a new specialized template should be created, and used only at specific places (perhaps in a separate PR?).

P.S.: The helper is essentially just a modified version of the existing helper `get_view_link`, and the docstring explains the difference between the two to avoid confusion.
