### PR TITLE
QUICK-FIX Vertically align items in related objects lists

### DIFF
--- a/src/ggrc/assets/stylesheets/modules/_attachment-list.scss
+++ b/src/ggrc/assets/stylesheets/modules/_attachment-list.scss
@@ -5,6 +5,9 @@
 
 .attachment-list {
   @extend %reset-list;
+  .fa {
+    vertical-align: bottom;
+  }
   .date {
     color: $gray;
     font-size: 11px;
@@ -38,9 +41,10 @@
     a.view-link {
       margin-top: 5px;
       width: 100%;
+      vertical-align: bottom;
     }
     .tree-title-area {
-      margin-top: 5px;
+      margin-top: 0px;
     }
   }
   .past-items-list & {


### PR DESCRIPTION
This is a follow up on #4177, it fixes the vertical alignment of the items in related objects lists to match the alignment of the list's bullet.

/cc @zidarsk8 