### PR TITLE
QUICK-FIX Move deferred wrapper to its own module

### DIFF
--- a/src/ggrc/models/assessment.py
+++ b/src/ggrc/models/assessment.py
@@ -18,7 +18,7 @@ from ggrc.models.mixins import FinishedDate
 from ggrc.models.mixins import TestPlanned
 from ggrc.models.mixins import Timeboxed
 from ggrc.models.mixins import VerifiedDate
-from ggrc.models.mixins import deferred
+from ggrc.models.deferred import deferred
 from ggrc.models.mixins_assignable import Assignable
 from ggrc.models.object_document import Documentable
 from ggrc.models.object_person import Personable

--- a/src/ggrc/models/audit.py
+++ b/src/ggrc/models/audit.py
@@ -4,8 +4,9 @@
 """Audit model."""
 
 from ggrc import db
-from .mixins import (
-    deferred, Timeboxed, Noted, Described, Hyperlinked, WithContact,
+from ggrc.models.deferred import deferred
+from ggrc.models.mixins import (
+    Timeboxed, Noted, Described, Hyperlinked, WithContact,
     Titled, Slugged, CustomAttributable
 )
 

--- a/src/ggrc/models/audit_object.py
+++ b/src/ggrc/models/audit_object.py
@@ -4,8 +4,8 @@
 from ggrc import db
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.ext.declarative import declared_attr
-from .mixins import deferred, Base
-from .reflection import PublishOnly
+from ggrc.models.mixins import Base
+from ggrc.models.reflection import PublishOnly
 
 class AuditObject(Base, db.Model):
   __tablename__ = 'audit_objects'

--- a/src/ggrc/models/audit_object.py
+++ b/src/ggrc/models/audit_object.py
@@ -7,6 +7,7 @@ from sqlalchemy.ext.declarative import declared_attr
 from ggrc.models.mixins import Base
 from ggrc.models.reflection import PublishOnly
 
+
 class AuditObject(Base, db.Model):
   __tablename__ = 'audit_objects'
 
@@ -15,7 +16,7 @@ class AuditObject(Base, db.Model):
   auditable_id = db.Column(db.Integer, nullable=False)
   auditable_type = db.Column(db.String, nullable=False)
   requests = db.relationship(
-     'Request', backref='audit_object')
+      'Request', backref='audit_object')
 
   @property
   def auditable_attr(self):
@@ -36,14 +37,14 @@ class AuditObject(Base, db.Model):
   def _extra_table_args(cls):
     return (
         db.UniqueConstraint(
-          'audit_id', 'auditable_id', 'auditable_type'),
+            'audit_id', 'auditable_id', 'auditable_type'),
         db.Index('ix_audit_id', 'audit_id'),
-        )
+    )
 
   _publish_attrs = [
       'audit',
       'auditable',
-      ]
+  ]
 
   @classmethod
   def eager_query(cls):
@@ -60,32 +61,31 @@ class AuditObject(Base, db.Model):
 
 
 class Auditable(object):
+
   @declared_attr
   def audit_objects(cls):
     cls.audits = association_proxy(
         'audit_objects', 'audit',
         creator=lambda control: AuditObject(
-            audit=audit,
+            audit=audit,  # noqa
             auditable_type=cls.__name__,
-            )
         )
+    )
     joinstr = 'and_(foreign(AuditObject.auditable_id) == {type}.id, '\
-                   'foreign(AuditObject.auditable_type) == "{type}")'
+        'foreign(AuditObject.auditable_type) == "{type}")'
     joinstr = joinstr.format(type=cls.__name__)
     return db.relationship(
         'AuditObject',
         primaryjoin=joinstr,
         backref='{0}_auditable'.format(cls.__name__),
         cascade='all, delete-orphan',
-        )
+    )
 
   _publish_attrs = [
       PublishOnly('audits'),
       'audit_objects',
-      ]
-  _include_links = [
-    #'audit_objects',
-    ]
+  ]
+  _include_links = []
 
   @classmethod
   def eager_query(cls):

--- a/src/ggrc/models/background_task.py
+++ b/src/ggrc/models/background_task.py
@@ -10,7 +10,7 @@ from ggrc import db
 from ggrc import settings
 from ggrc.login import get_current_user
 from ggrc.models.mixins import Base
-from ggrc.models.mixins import deferred
+from ggrc.models.deferred import deferred
 from ggrc.models.mixins import Stateful
 from ggrc.models.types import CompressedType
 

--- a/src/ggrc/models/category.py
+++ b/src/ggrc/models/category.py
@@ -6,7 +6,8 @@ from ggrc import db
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.orm import validates
 from .categorization import Categorization
-from .mixins import deferred, Base, Hierarchical
+from ggrc.models.deferred import deferred
+from ggrc.models.mixins import Base, Hierarchical
 
 
 class CategorizedPublishable(object):
@@ -41,7 +42,7 @@ class CategoryBase(Hierarchical, Base, db.Model):
 
   categorizations = db.relationship(
       'ggrc.models.categorization.Categorization',
-      backref='category', 
+      backref='category',
       cascade='all, delete-orphan',
       )
 

--- a/src/ggrc/models/category.py
+++ b/src/ggrc/models/category.py
@@ -3,14 +3,13 @@
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
 from ggrc import db
-from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.orm import validates
-from .categorization import Categorization
 from ggrc.models.deferred import deferred
 from ggrc.models.mixins import Base, Hierarchical
 
 
 class CategorizedPublishable(object):
+
   def __init__(self, attr_name, type_name):
     self.attr_name = attr_name
     self.type_name = type_name
@@ -38,13 +37,13 @@ class CategoryBase(Hierarchical, Base, db.Model):
 
   __mapper_args__ = {
       'polymorphic_on': type
-      }
+  }
 
   categorizations = db.relationship(
       'ggrc.models.categorization.Categorization',
       backref='category',
       cascade='all, delete-orphan',
-      )
+  )
 
   @validates('type')
   def validates_type(self, key, value):
@@ -55,14 +54,12 @@ class CategoryBase(Hierarchical, Base, db.Model):
       'name',
       'type',
       'required',
-      #'scope_id',
-      ]
+  ]
   _sanitize_html = [
       'name',
-      ]
+  ]
 
   @classmethod
   def eager_query(cls):
-    from sqlalchemy import orm
     query = super(CategoryBase, cls).eager_query()
     return query.options()

--- a/src/ggrc/models/clause.py
+++ b/src/ggrc/models/clause.py
@@ -5,7 +5,7 @@
 
 from ggrc import db
 from ggrc.models.mixins import CustomAttributable
-from ggrc.models.mixins import deferred
+from ggrc.models.deferred import deferred
 from ggrc.models.mixins import Described
 from ggrc.models.mixins import Hierarchical
 from ggrc.models.mixins import Hyperlinked

--- a/src/ggrc/models/context.py
+++ b/src/ggrc/models/context.py
@@ -4,7 +4,8 @@
 import datetime
 from sqlalchemy.ext.declarative import declared_attr
 from ggrc import db
-from ggrc.models.mixins import deferred, Base
+from ggrc.models.deferred import deferred
+from ggrc.models.mixins import  Base
 
 
 class Context(Base, db.Model):

--- a/src/ggrc/models/context.py
+++ b/src/ggrc/models/context.py
@@ -5,7 +5,7 @@ import datetime
 from sqlalchemy.ext.declarative import declared_attr
 from ggrc import db
 from ggrc.models.deferred import deferred
-from ggrc.models.mixins import  Base
+from ggrc.models.mixins import Base
 
 
 class Context(Base, db.Model):

--- a/src/ggrc/models/control.py
+++ b/src/ggrc/models/control.py
@@ -15,7 +15,7 @@ from ggrc.models.mixins import CustomAttributable
 from ggrc.models.mixins import Hierarchical
 from ggrc.models.mixins import TestPlanned
 from ggrc.models.mixins import Timeboxed
-from ggrc.models.mixins import deferred
+from ggrc.models.deferred import deferred
 from ggrc.models.object_document import Documentable
 from ggrc.models.object_owner import Ownable
 from ggrc.models.object_person import Personable

--- a/src/ggrc/models/deferred.py
+++ b/src/ggrc/models/deferred.py
@@ -1,0 +1,23 @@
+# Copyright (C) 2016 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Custom deferred wrapper.
+
+This deferred wrapper automatically adds the group name to a deferred object
+according to the current class.
+"""
+
+from ggrc import db
+
+
+def deferred(column, classname):
+  """Defer column loading for basic properties, such as boolean or string, so
+  that they are not loaded on joins. However, Identifiable provides an
+  eager_query implementation that will specify undefer in the options so that
+  when the resource is loaded itself, rather than through a join, it is
+  completely loaded.
+
+  In join tables, this function should not wrap foreign keys nor should it wrap
+  type properties for polymorphic relations.
+  """
+  return db.deferred(column, group=classname + '_complete')

--- a/src/ggrc/models/directive.py
+++ b/src/ggrc/models/directive.py
@@ -2,7 +2,8 @@
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
 from ggrc import db
-from .mixins import deferred, BusinessObject, Timeboxed, CustomAttributable
+from ggrc.models.deferred import deferred
+from ggrc.models.mixins import BusinessObject, Timeboxed, CustomAttributable
 from .object_document import Documentable
 from .object_person import Personable
 from .object_owner import Ownable

--- a/src/ggrc/models/document.py
+++ b/src/ggrc/models/document.py
@@ -4,7 +4,7 @@
 from sqlalchemy.orm import validates
 
 from ggrc import db
-from ggrc.models.mixins import deferred
+from ggrc.models.deferred import deferred
 from ggrc.models.mixins import Base
 from ggrc.models.relationship import Relatable
 from ggrc.models.object_owner import Ownable

--- a/src/ggrc/models/help.py
+++ b/src/ggrc/models/help.py
@@ -5,6 +5,7 @@ from ggrc import db
 from ggrc.models.deferred import deferred
 from ggrc.models.mixins import Titled, Slugged
 
+
 class Help(Titled, Slugged, db.Model):
   __tablename__ = 'helps'
   _title_uniqueness = False
@@ -13,10 +14,10 @@ class Help(Titled, Slugged, db.Model):
 
   _fulltext_attrs = [
       'content',
-      ]
+  ]
   _publish_attrs = [
       'content',
-      ]
+  ]
   _sanitize_html = [
       'content',
-      ]
+  ]

--- a/src/ggrc/models/help.py
+++ b/src/ggrc/models/help.py
@@ -2,7 +2,8 @@
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
 from ggrc import db
-from .mixins import deferred, Titled, Slugged
+from ggrc.models.deferred import deferred
+from ggrc.models.mixins import Titled, Slugged
 
 class Help(Titled, Slugged, db.Model):
   __tablename__ = 'helps'

--- a/src/ggrc/models/mixins.py
+++ b/src/ggrc/models/mixins.py
@@ -22,6 +22,7 @@ from sqlalchemy.orm.session import Session
 from ggrc import db
 from ggrc.models import reflection
 from ggrc.models.computed_property import computed_property
+from ggrc.models.deferred import deferred
 from ggrc.models.inflector import ModelInflectorDescriptor
 from ggrc.models.reflection import AttributeInfo
 from ggrc.utils import underscore_from_camelcase
@@ -35,19 +36,6 @@ must also inherit from ``db.Model``. For example:
        __tablename__ = 'markets'
 
 """
-
-
-def deferred(column, classname):
-  """Defer column loading for basic properties, such as boolean or string, so
-  that they are not loaded on joins. However, Identifiable provides an
-  eager_query implementation that will specify undefer in the options so that
-  when the resource is loaded itself, rather than through a join, it is
-  completely loaded.
-
-  In join tables, this function should not wrap foreign keys nor should it wrap
-  type properties for polymorphic relations.
-  """
-  return db.deferred(column, group=classname + '_complete')
 
 
 class Identifiable(object):

--- a/src/ggrc/models/object_document.py
+++ b/src/ggrc/models/object_document.py
@@ -4,7 +4,8 @@
 from ggrc import db
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.ext.declarative import declared_attr
-from ggrc.models.mixins import deferred, Mapping, Timeboxed
+from ggrc.models.deferred import deferred
+from ggrc.models.mixins import Mapping, Timeboxed
 from ggrc.models.reflection import PublishOnly
 
 

--- a/src/ggrc/models/object_person.py
+++ b/src/ggrc/models/object_person.py
@@ -6,7 +6,8 @@ from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy import orm
 
 from ggrc import db
-from ggrc.models.mixins import deferred, Mapping, Timeboxed
+from ggrc.models.deferred import deferred
+from ggrc.models.mixins import Mapping, Timeboxed
 from ggrc.models.reflection import PublishOnly
 
 

--- a/src/ggrc/models/option.py
+++ b/src/ggrc/models/option.py
@@ -2,7 +2,8 @@
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
 from ggrc import db
-from .mixins import deferred, Base, Described
+from ggrc.models.deferred import deferred
+from ggrc.models.mixins import Base, Described
 
 class Option(Described, Base, db.Model):
   __tablename__ = 'options'

--- a/src/ggrc/models/option.py
+++ b/src/ggrc/models/option.py
@@ -5,6 +5,7 @@ from ggrc import db
 from ggrc.models.deferred import deferred
 from ggrc.models.mixins import Base, Described
 
+
 class Option(Described, Base, db.Model):
   __tablename__ = 'options'
 
@@ -16,13 +17,13 @@ class Option(Described, Base, db.Model):
   def _extra_table_args(cls):
     return (
         db.Index('ix_options_role', 'role'),
-        )
+    )
 
   _publish_attrs = [
       'role',
       'title',
       'required',
-      ]
+  ]
   _sanitize_html = [
       'title',
-      ]
+  ]

--- a/src/ggrc/models/person.py
+++ b/src/ggrc/models/person.py
@@ -9,7 +9,8 @@ from ggrc import settings
 from ggrc.models.computed_property import computed_property
 from ggrc.models.context import HasOwnContext
 from ggrc.models.exceptions import ValidationError
-from ggrc.models.mixins import deferred, Base, CustomAttributable
+from ggrc.models.deferred import deferred
+from ggrc.models.mixins import Base, CustomAttributable
 from ggrc.models.custom_attribute_definition import CustomAttributeMapable
 from ggrc.models.reflection import PublishOnly
 from ggrc.models.relationship import Relatable

--- a/src/ggrc/models/product.py
+++ b/src/ggrc/models/product.py
@@ -5,13 +5,14 @@ from ggrc import db
 from sqlalchemy.orm import validates
 from ggrc.models.deferred import deferred
 from ggrc.models.mixins import BusinessObject, Timeboxed, CustomAttributable
-from .object_document import Documentable
-from .object_owner import Ownable
-from .object_person import Personable
-from .option import Option
-from .relationship import Relatable
-from .utils import validate_option
-from .track_object_state import HasObjectState, track_state_for_class
+from ggrc.models.object_document import Documentable
+from ggrc.models.object_owner import Ownable
+from ggrc.models.object_person import Personable
+from ggrc.models.option import Option
+from ggrc.models.relationship import Relatable
+from ggrc.models.utils import validate_option
+from ggrc.models.track_object_state import HasObjectState
+from ggrc.models.track_object_state import track_state_for_class
 
 
 class Product(HasObjectState, CustomAttributable, Documentable, Personable,
@@ -23,8 +24,8 @@ class Product(HasObjectState, CustomAttributable, Documentable, Personable,
 
   kind = db.relationship(
       'Option',
-      primaryjoin='and_(foreign(Product.kind_id) == Option.id, '\
-                       'Option.role == "product_type")',
+      primaryjoin='and_(foreign(Product.kind_id) == Option.id, '
+      'Option.role == "product_type")',
       uselist=False,
   )
 
@@ -32,13 +33,13 @@ class Product(HasObjectState, CustomAttributable, Documentable, Personable,
       'kind',
       'version',
   ]
-  _sanitize_html = ['version',]
+  _sanitize_html = ['version', ]
   _aliases = {
-    "url": "Product URL",
-    "kind": {
-      "display_name": "Kind/Type",
-      "filter_by": "_filter_by_kind",
-    },
+      "url": "Product URL",
+      "kind": {
+          "display_name": "Kind/Type",
+          "filter_by": "_filter_by_kind",
+      },
   }
 
   @validates('kind')

--- a/src/ggrc/models/product.py
+++ b/src/ggrc/models/product.py
@@ -3,7 +3,8 @@
 
 from ggrc import db
 from sqlalchemy.orm import validates
-from .mixins import deferred, BusinessObject, Timeboxed, CustomAttributable
+from ggrc.models.deferred import deferred
+from ggrc.models.mixins import BusinessObject, Timeboxed, CustomAttributable
 from .object_document import Documentable
 from .object_owner import Ownable
 from .object_person import Personable

--- a/src/ggrc/models/program.py
+++ b/src/ggrc/models/program.py
@@ -6,7 +6,7 @@ from ggrc.models.context import HasOwnContext
 from ggrc.models.mixins import BusinessObject
 from ggrc.models.mixins import CustomAttributable
 from ggrc.models.mixins import Timeboxed
-from ggrc.models.mixins import deferred
+from ggrc.models.deferred import deferred
 from ggrc.models.object_document import Documentable
 from ggrc.models.object_owner import Ownable
 from ggrc.models.object_person import ObjectPerson

--- a/src/ggrc/models/request.py
+++ b/src/ggrc/models/request.py
@@ -21,7 +21,7 @@ from ggrc.models.mixins import FinishedDate
 from ggrc.models.mixins import Slugged
 from ggrc.models.mixins import Titled
 from ggrc.models.mixins import VerifiedDate
-from ggrc.models.mixins import deferred
+from ggrc.models.deferred import deferred
 from ggrc.models.mixins_assignable import Assignable
 from ggrc.models.object_document import Documentable
 from ggrc.models.object_person import Personable

--- a/src/ggrc/models/section.py
+++ b/src/ggrc/models/section.py
@@ -12,7 +12,7 @@ from ggrc.models.mixins import Slugged
 from ggrc.models.mixins import Stateful
 from ggrc.models.mixins import Titled
 from ggrc.models.mixins import WithContact
-from ggrc.models.mixins import deferred
+from ggrc.models.deferred import deferred
 from ggrc.models.object_document import Documentable
 from ggrc.models.object_owner import Ownable
 from ggrc.models.object_person import Personable

--- a/src/ggrc/models/system.py
+++ b/src/ggrc/models/system.py
@@ -4,7 +4,8 @@
 from sqlalchemy.orm import validates
 
 from ggrc import db
-from .mixins import deferred, BusinessObject, Timeboxed, CustomAttributable
+from ggrc.models.deferred import deferred
+from ggrc.models.mixins import BusinessObject, Timeboxed, CustomAttributable
 from .object_document import Documentable
 from .object_owner import Ownable
 from .object_person import Personable

--- a/src/ggrc/models/system.py
+++ b/src/ggrc/models/system.py
@@ -6,16 +6,17 @@ from sqlalchemy.orm import validates
 from ggrc import db
 from ggrc.models.deferred import deferred
 from ggrc.models.mixins import BusinessObject, Timeboxed, CustomAttributable
-from .object_document import Documentable
-from .object_owner import Ownable
-from .object_person import Personable
-from .option import Option
-from .relationship import Relatable
-from .utils import validate_option
-from .track_object_state import HasObjectState, track_state_for_class
+from ggrc.models.object_document import Documentable
+from ggrc.models.object_owner import Ownable
+from ggrc.models.object_person import Personable
+from ggrc.models.option import Option
+from ggrc.models.relationship import Relatable
+from ggrc.models.utils import validate_option
+from ggrc.models import track_object_state
 
 
-class SystemOrProcess(HasObjectState, Timeboxed, BusinessObject, db.Model):
+class SystemOrProcess(track_object_state.HasObjectState, Timeboxed,
+                      BusinessObject, db.Model):
   # Override model_inflector
   _table_plural = 'systems_or_processes'
   __tablename__ = 'systems'
@@ -26,8 +27,8 @@ class SystemOrProcess(HasObjectState, Timeboxed, BusinessObject, db.Model):
   network_zone_id = deferred(db.Column(db.Integer), 'SystemOrProcess')
   network_zone = db.relationship(
       'Option',
-      primaryjoin='and_(foreign(SystemOrProcess.network_zone_id) == Option.id, '\
-                       'Option.role == "network_zone")',
+      primaryjoin='and_(foreign(SystemOrProcess.network_zone_id) == Option.id,'
+      ' Option.role == "network_zone")',
       uselist=False,
   )
 
@@ -50,8 +51,8 @@ class SystemOrProcess(HasObjectState, Timeboxed, BusinessObject, db.Model):
   _sanitize_html = ['version']
   _aliases = {
       "network_zone": {
-        "display_name": "Network Zone",
-        "filter_by": "_filter_by_network_zone",
+          "display_name": "Network Zone",
+          "filter_by": "_filter_by_network_zone",
       },
   }
 
@@ -81,7 +82,7 @@ class SystemOrProcess(HasObjectState, Timeboxed, BusinessObject, db.Model):
                  'is_biz_process'),
     )
 
-track_state_for_class(SystemOrProcess)
+track_object_state.track_state_for_class(SystemOrProcess)
 
 
 class System(CustomAttributable, Documentable, Personable,

--- a/src/ggrc/models/track_object_state.py
+++ b/src/ggrc/models/track_object_state.py
@@ -6,7 +6,7 @@ from sqlalchemy import event
 from datetime import datetime
 from ggrc import db
 from sqlalchemy.ext.declarative import declared_attr
-from .mixins import deferred
+from ggrc.models.deferred import deferred
 from ggrc.login import get_current_user_id
 from .reflection import PublishOnly
 

--- a/src/ggrc_gdrive_integration/models/object_event.py
+++ b/src/ggrc_gdrive_integration/models/object_event.py
@@ -1,12 +1,11 @@
 # Copyright (C) 2016 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
+from sqlalchemy import orm
+
 from ggrc import db
-from sqlalchemy.ext.associationproxy import association_proxy
-from sqlalchemy.ext.declarative import declared_attr
-from ggrc.models.deferred import deferred
 from ggrc.models.mixins import Base
-from ggrc.models.reflection import PublishOnly
+
 
 class ObjectEvent(Base, db.Model):
   __tablename__ = 'object_events'
@@ -31,51 +30,43 @@ class ObjectEvent(Base, db.Model):
         else None
     return setattr(self, self.eventable_attr, value)
 
-  @staticmethod
-  def _extra_table_args(cls):
-    return (
-        #db.UniqueConstraint('event_id', 'eventable_id', 'eventable_type'),
-        )
-
   _publish_attrs = [
       'event_id',
       'calendar_id',
       'eventable',
-      ]
+  ]
 
   @classmethod
   def eager_query(cls):
-    from sqlalchemy import orm
-
     query = super(ObjectEvent, cls).eager_query()
     return query.options()
 
   def _display_name(self):
     return self.eventable.display_name + '<-> gdrive event' + self.event_id
 
+
 class Eventable(object):
+
   @classmethod
   def late_init_eventable(cls):
     def make_object_events(cls):
       joinstr = 'and_(foreign(ObjectEvent.eventable_id) == {type}.id, '\
-                     'foreign(ObjectEvent.eventable_type) == "{type}")'
+          'foreign(ObjectEvent.eventable_type) == "{type}")'
       joinstr = joinstr.format(type=cls.__name__)
       return db.relationship(
           'ObjectEvent',
           primaryjoin=joinstr,
           backref='{0}_eventable'.format(cls.__name__),
           cascade='all, delete-orphan',
-          )
+      )
     cls.object_events = make_object_events(cls)
 
   _publish_attrs = [
       'object_events',
-      ]
+  ]
 
   @classmethod
   def eager_query(cls):
-    from sqlalchemy import orm
-
     query = super(Eventable, cls).eager_query()
     return query.options(
         orm.subqueryload('object_events'))

--- a/src/ggrc_gdrive_integration/models/object_event.py
+++ b/src/ggrc_gdrive_integration/models/object_event.py
@@ -4,7 +4,8 @@
 from ggrc import db
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.ext.declarative import declared_attr
-from ggrc.models.mixins import deferred, Base
+from ggrc.models.deferred import deferred
+from ggrc.models.mixins import Base
 from ggrc.models.reflection import PublishOnly
 
 class ObjectEvent(Base, db.Model):

--- a/src/ggrc_gdrive_integration/models/object_file.py
+++ b/src/ggrc_gdrive_integration/models/object_file.py
@@ -4,7 +4,8 @@
 from ggrc import db
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.ext.declarative import declared_attr
-from ggrc.models.mixins import deferred, Base
+from ggrc.models.deferred import deferred
+from ggrc.models.mixins import Base
 from ggrc.models.reflection import PublishOnly
 
 class ObjectFile(Base, db.Model):

--- a/src/ggrc_gdrive_integration/models/object_folder.py
+++ b/src/ggrc_gdrive_integration/models/object_folder.py
@@ -4,7 +4,8 @@
 from ggrc import db
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.ext.declarative import declared_attr
-from ggrc.models.mixins import deferred, Base
+from ggrc.models.deferred import deferred
+from ggrc.models.mixins import Base
 from ggrc.models.reflection import PublishOnly
 
 class ObjectFolder(Base, db.Model):

--- a/src/ggrc_gdrive_integration/models/object_folder.py
+++ b/src/ggrc_gdrive_integration/models/object_folder.py
@@ -2,11 +2,8 @@
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
 from ggrc import db
-from sqlalchemy.ext.associationproxy import association_proxy
-from sqlalchemy.ext.declarative import declared_attr
-from ggrc.models.deferred import deferred
 from ggrc.models.mixins import Base
-from ggrc.models.reflection import PublishOnly
+
 
 class ObjectFolder(Base, db.Model):
   __tablename__ = 'object_folders'
@@ -34,44 +31,43 @@ class ObjectFolder(Base, db.Model):
   @staticmethod
   def _extra_table_args(cls):
     return (
-        #db.UniqueConstraint('folder_id', 'folderable_id', 'folderable_type'),
         db.Index('ix_folderable_id_type', 'folderable_id', 'folderable_type'),
-        )
+    )
 
   _publish_attrs = [
       'folder_id',
       'parent_folder_id',
       'folderable',
-      ]
+  ]
 
   @classmethod
   def eager_query(cls):
-    from sqlalchemy import orm
-
     query = super(ObjectFolder, cls).eager_query()
     return query.options()
 
   def _display_name(self):
     return self.folderable.display_name + '<-> gdrive folder ' + self.folder_id
 
+
 class Folderable(object):
+
   @classmethod
   def late_init_folderable(cls):
     def make_object_folders(cls):
       joinstr = 'and_(foreign(ObjectFolder.folderable_id) == {type}.id, '\
-                     'foreign(ObjectFolder.folderable_type) == "{type}")'
+          'foreign(ObjectFolder.folderable_type) == "{type}")'
       joinstr = joinstr.format(type=cls.__name__)
       return db.relationship(
           'ObjectFolder',
           primaryjoin=joinstr,
           backref='{0}_folderable'.format(cls.__name__),
           cascade='all, delete-orphan',
-          )
+      )
     cls.object_folders = make_object_folders(cls)
 
   _publish_attrs = [
       'object_folders',
-      ]
+  ]
 
   @classmethod
   def eager_query(cls):

--- a/src/ggrc_risk_assessments/models/risk_assessment.py
+++ b/src/ggrc_risk_assessments/models/risk_assessment.py
@@ -9,7 +9,7 @@ from ggrc.models.mixins import Noted
 from ggrc.models.mixins import Slugged
 from ggrc.models.mixins import Timeboxed
 from ggrc.models.mixins import Titled
-from ggrc.models.mixins import deferred
+from ggrc.models.deferred import deferred
 from ggrc.models.object_document import Documentable
 from ggrc.models.person import Person
 from ggrc.models.program import Program

--- a/src/ggrc_risks/models/risk.py
+++ b/src/ggrc_risks/models/risk.py
@@ -6,6 +6,7 @@ from sqlalchemy.ext.declarative import declared_attr
 from ggrc import db
 from ggrc.models.associationproxy import association_proxy
 from ggrc.models import mixins
+from ggrc.models.deferred import deferred
 from ggrc.models.object_document import Documentable
 from ggrc.models.object_owner import Ownable
 from ggrc.models.reflection import PublishOnly
@@ -35,7 +36,7 @@ class Risk(HasObjectState, mixins.CustomAttributable, mixins.Stateful,
   # Overriding mixin to make mandatory
   @declared_attr
   def description(cls):
-    return mixins.deferred(db.Column(db.Text, nullable=False), cls.__name__)
+    return deferred(db.Column(db.Text, nullable=False), cls.__name__)
 
   risk_objects = db.relationship(
       'RiskObject', backref='risk', cascade='all, delete-orphan')

--- a/src/ggrc_risks/models/risk_object.py
+++ b/src/ggrc_risks/models/risk_object.py
@@ -6,7 +6,8 @@
 from ggrc import db
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.ext.declarative import declared_attr
-from ggrc.models.mixins import deferred, Mapping
+from ggrc.models.deferred import deferred
+from ggrc.models.mixins import Mapping
 from ggrc.models.reflection import PublishOnly
 
 

--- a/src/ggrc_risks/models/risk_object.py
+++ b/src/ggrc_risks/models/risk_object.py
@@ -5,8 +5,6 @@
 
 from ggrc import db
 from sqlalchemy.ext.associationproxy import association_proxy
-from sqlalchemy.ext.declarative import declared_attr
-from ggrc.models.deferred import deferred
 from ggrc.models.mixins import Mapping
 from ggrc.models.reflection import PublishOnly
 
@@ -39,14 +37,14 @@ class RiskObject(Mapping, db.Model):
     return (
         db.UniqueConstraint('risk_id', 'object_id', 'object_type'),
         db.Index('ix_risk_id', 'risk_id'),
-        )
+    )
 
   _publish_attrs = [
       'risk',
       'object',
-      ]
+  ]
   _sanitize_html = [
-      ]
+  ]
 
   @classmethod
   def eager_query(cls):
@@ -61,6 +59,7 @@ class RiskObject(Mapping, db.Model):
 
 
 class Riskable(object):
+
   @classmethod
   def late_init_riskable(cls):
     def make_risk_objects(cls):
@@ -69,26 +68,26 @@ class Riskable(object):
           creator=lambda risk: RiskObject(
               risk=risk,
               object_type=cls.__name__,
-              )
           )
+      )
       joinstr = 'and_(foreign(RiskObject.object_id) == {type}.id, '\
-                     'foreign(RiskObject.object_type) == "{type}")'
+          'foreign(RiskObject.object_type) == "{type}")'
       joinstr = joinstr.format(type=cls.__name__)
       return db.relationship(
           'RiskObject',
           primaryjoin=joinstr,
           backref='{0}_object'.format(cls.__name__),
           cascade='all, delete-orphan',
-          )
+      )
     cls.risk_objects = make_risk_objects(cls)
 
   _publish_attrs = [
       PublishOnly('risks'),
       'risk_objects',
-      ]
+  ]
 
   _include_links = [
-      ]
+  ]
 
   @classmethod
   def eager_query(cls):
@@ -97,4 +96,3 @@ class Riskable(object):
     query = super(Riskable, cls).eager_query()
     return cls.eager_inclusions(query, Riskable._include_links).options(
         orm.subqueryload('risk_objects'))
-

--- a/src/ggrc_workflows/models/workflow.py
+++ b/src/ggrc_workflows/models/workflow.py
@@ -21,7 +21,7 @@ from ggrc.models import reflection
 from ggrc.models.associationproxy import association_proxy
 from ggrc.models.computed_property import computed_property
 from ggrc.models.context import HasOwnContext
-from ggrc.models.mixins import deferred
+from ggrc.models.deferred import deferred
 from ggrc.models.person import Person
 from ggrc_basic_permissions.models import UserRole
 from ggrc_workflows.models import cycle


### PR DESCRIPTION
The deferred wrapper is used in all our models and mixins and having it
in the mixins.py file causes circular imports which are resolved by
having import statements inside functions. We should avoid that and this
is a step to moving all of our import statements to the top of python
files.

This is a side product of my work for custom attribute value fixes needed for collection post refactor.