### PR TITLE
QUICK-FIX Enable CAD ordering in edit AT modal

### DIFF
--- a/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
@@ -247,7 +247,7 @@
                     </li>
                     {{#fields}}
                       {{^if _pending_delete}}
-                          <li class="row-fluid{{#new_object_form}} sortable-item{{/new_object_form}}" {{data 'field'}}>
+                          <li class="row-fluid sortable-item" {{data 'field'}}>
                               <template-field field="." fields="fields"></template-field>
                           </li>
                       {{/if _pending_delete}}


### PR DESCRIPTION
Now that saving is all done on the backend we can enable ordering of custom attribute definitions in the edit assessment template modal.