### PR TITLE
QUICK-FIX Only clear CAD for assessment templates

### DIFF
--- a/src/ggrc/assets/javascripts/pbc/workflow_controller.js
+++ b/src/ggrc/assets/javascripts/pbc/workflow_controller.js
@@ -7,6 +7,9 @@
   can.Control('GGRC.Controllers.PbcWorkflows', {}, {
     '{CMS.Models.AssessmentTemplate} updated': function (model, ev, instance) {
       // Make sure instance.custom_attribute_definitions cache is cleared
+      if (!(instance instanceof CMS.Models.AssessmentTemplate)) {
+        return;
+      }
       instance.custom_attribute_definitions.splice(0,
         instance.custom_attribute_definitions.length);
     },


### PR DESCRIPTION
This fixes a bug where editing an object with custom attribute
definitions removed all custom attribute definitions on that
object until a page refresh.