### PR TITLE
QUICK-FIX Remove unicode dict wrapper

### DIFF
--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -27,7 +27,7 @@ import ggrc.builder.json
 import ggrc.models
 from flask.ext.sqlalchemy import Pagination
 from ggrc import db, utils
-from ggrc.utils import as_json, UnicodeSafeJsonWrapper, benchmark
+from ggrc.utils import as_json, benchmark
 from ggrc.fulltext import get_indexer
 from ggrc.fulltext.recordbuilder import fts_record_for
 from ggrc.login import get_current_user_id, get_current_user
@@ -796,7 +796,7 @@ class Resource(ModelView):
       obj = self.get_object(id)
     if obj is None:
       return self.not_found_response()
-    src = UnicodeSafeJsonWrapper(self.request.json)
+    src = self.request.json
     with benchmark("Query update permissions"):
       if not permissions.is_allowed_update(
           self.model.__name__, obj.id, obj.context_id)\
@@ -1220,8 +1220,7 @@ class Resource(ModelView):
         for src in body:
           try:
             src_res = None
-            src_res = self.collection_post_step(
-                UnicodeSafeJsonWrapper(src), no_result)
+            src_res = self.collection_post_step(src, no_result)
             db.session.commit()
             if running_async:
               time.sleep(settings.BACKGROUND_COLLECTION_POST_SLEEP)

--- a/src/ggrc/utils/__init__.py
+++ b/src/ggrc/utils/__init__.py
@@ -35,22 +35,6 @@ class GrcEncoder(json.JSONEncoder):
       return super(GrcEncoder, self).default(obj)
 
 
-class UnicodeSafeJsonWrapper(dict):
-
-  """JSON received via POST has keys as unicode. This makes get work with plain
-  `str` keys.
-  """
-
-  def __getitem__(self, key):
-    ret = self.get(key)
-    if ret is None:
-      raise KeyError(key)
-    return ret
-
-  def get(self, key, default=None):
-    return super(UnicodeSafeJsonWrapper, self).get(unicode(key), default)  # noqa
-
-
 def as_json(obj, **kwargs):
   return json.dumps(obj, cls=GrcEncoder, **kwargs)
 


### PR DESCRIPTION
Current versions of python work normally weather the key is a unicode
string or not, so the wrapper to convert all keys to unicode is
redundant.