### PR TITLE
QUICK-FIX Collection post tests

### DIFF
--- a/test/integration/ggrc/services/__init__.py
+++ b/test/integration/ggrc/services/__init__.py
@@ -1,4 +1,85 @@
-
 # Copyright (C) 2016 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
+import ggrc
+import ggrc.builder
+import ggrc.services
+import random
+from ggrc import db
+from ggrc.models.mixins import Base
+from ggrc.services.common import Resource
+from integration.ggrc import TestCase as BaseTestCase
+
+
+class ServicesTestMockModel(Base, ggrc.db.Model):
+  __tablename__ = 'test_model'
+  foo = db.Column(db.String)
+  code = db.Column(db.String, unique=True)
+
+  # REST properties
+  _publish_attrs = ['modified_by_id', 'foo', 'code']
+  _update_attrs = ['foo', 'code']
+
+URL_MOCK_COLLECTION = '/api/mock_resources'
+URL_MOCK_RESOURCE = '/api/mock_resources/{0}'
+Resource.add_to(
+    ggrc.app.app, URL_MOCK_COLLECTION, model_class=ServicesTestMockModel)
+
+
+class TestCase(BaseTestCase):
+
+  def setUp(self):
+    super(TestCase, self).setUp()
+    # Explicitly create test tables
+    if not ServicesTestMockModel.__table__.exists(db.engine):
+      ServicesTestMockModel.__table__.create(db.engine)
+    with self.client.session_transaction() as session:
+      session['permissions'] = {
+          "__GGRC_ADMIN__": {"__GGRC_ALL__": {"contexts": [0]}}
+      }
+
+  def tearDown(self):
+    super(TestCase, self).tearDown()
+    # Explicitly destroy test tables
+    # Note: This must be after the 'super()', because the session is
+    #   closed there.  (And otherwise it might stall due to locks).
+    if ServicesTestMockModel.__table__.exists(db.engine):
+      ServicesTestMockModel.__table__.drop(db.engine)
+
+  def mock_url(self, resource=None):
+    if resource is not None:
+      return URL_MOCK_RESOURCE.format(resource)
+    return URL_MOCK_COLLECTION
+
+  def mock_json(self, model):
+    format = '%Y-%m-%dT%H:%M:%S'
+    updated_at = unicode(model.updated_at.strftime(format))
+    created_at = unicode(model.created_at.strftime(format))
+    return {
+        u'id': int(model.id),
+        u'selfLink': unicode(URL_MOCK_RESOURCE.format(model.id)),
+        u'type': unicode(model.__class__.__name__),
+        u'modified_by': {
+            u'href': u'/api/people/1',
+            u'id': model.modified_by_id,
+            u'type': 'Person',
+            u'context_id': None
+        } if model.modified_by_id is not None else None,
+        u'modified_by_id': int(model.modified_by_id),
+        u'updated_at': updated_at,
+        u'created_at': created_at,
+        u'context':
+            {u'id': model.context_id}
+            if model.context_id is not None else None,
+        u'foo': (unicode(model.foo) if model.foo else None),
+    }
+
+  def mock_model(self, id=None, modified_by_id=1, **kwarg):
+    if 'id' not in kwarg:
+      kwarg['id'] = random.randint(0, 999999999)
+    if 'modified_by_id' not in kwarg:
+      kwarg['modified_by_id'] = 1
+    mock = ServicesTestMockModel(**kwarg)
+    ggrc.db.session.add(mock)
+    ggrc.db.session.commit()
+    return mock

--- a/test/integration/ggrc/services/test_collection_post.py
+++ b/test/integration/ggrc/services/test_collection_post.py
@@ -3,14 +3,8 @@
 
 """Tests for collection post service."""
 
-import ggrc
-import ggrc.builder
-import ggrc.services
 import json
-import time
-from datetime import datetime
-from urlparse import urlparse
-from wsgiref.handlers import format_date_time
+
 from integration.ggrc import services
 
 

--- a/test/integration/ggrc/services/test_collection_post.py
+++ b/test/integration/ggrc/services/test_collection_post.py
@@ -1,0 +1,148 @@
+# Copyright (C) 2016 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Tests for collection post service."""
+
+import ggrc
+import ggrc.builder
+import ggrc.services
+import json
+import time
+from datetime import datetime
+from urlparse import urlparse
+from wsgiref.handlers import format_date_time
+from integration.ggrc import services
+
+
+class TestCollectionPost(services.TestCase):
+
+  def get_location(self, response):
+    """Ignore the `http://localhost` prefix of the Location"""
+    return response.headers['Location'][16:]
+
+  def headers(self, *args, **kwargs):
+    ret = list(args)
+    ret.append(('X-Requested-By', 'Unit Tests'))
+    ret.extend(kwargs.items())
+    return ret
+
+  def test_collection_post_successful(self):
+    data = json.dumps(
+        {'services_test_mock_model': {'foo': 'bar', 'context': None}})
+    self.client.get("/login")
+    response = self.client.post(
+        self.mock_url(),
+        content_type='application/json',
+        data=data,
+        headers=self.headers(),
+    )
+    self.assertStatus(response, 201)
+    self.assertIn('Location', response.headers)
+    response = self.client.get(
+        self.get_location(response), headers=self.headers())
+    self.assert200(response)
+    self.assertIn('Content-Type', response.headers)
+    self.assertEqual('application/json', response.headers['Content-Type'])
+    self.assertIn('services_test_mock_model', response.json)
+    self.assertIn('foo', response.json['services_test_mock_model'])
+    self.assertEqual('bar', response.json['services_test_mock_model']['foo'])
+    # check the collection, too
+    response = self.client.get(self.mock_url(), headers=self.headers())
+    self.assert200(response)
+    self.assertEqual(
+        1, len(response.json['test_model_collection']['test_model']))
+    self.assertEqual(
+        'bar', response.json['test_model_collection']['test_model'][0]['foo'])
+
+  def test_collection_post_successful_single_array(self):
+    data = json.dumps(
+        [{'services_test_mock_model': {'foo': 'bar', 'context': None}}])
+    self.client.get("/login")
+    response = self.client.post(
+        self.mock_url(),
+        content_type='application/json',
+        data=data,
+        headers=self.headers(),
+    )
+    self.assert200(response)
+    self.assertEqual(type(response.json), list)
+    self.assertEqual(len(response.json), 1)
+
+    response = self.client.get(self.mock_url(), headers=self.headers())
+    self.assert200(response)
+    self.assertEqual(
+        1, len(response.json['test_model_collection']['test_model']))
+    self.assertEqual(
+        'bar', response.json['test_model_collection']['test_model'][0]['foo'])
+
+  def test_collection_post_successful_multiple(self):
+    data = json.dumps([
+        {'services_test_mock_model': {'foo': 'bar1', 'context': None}},
+        {'services_test_mock_model': {'foo': 'bar2', 'context': None}},
+    ])
+    self.client.get("/login")
+    response = self.client.post(
+        self.mock_url(),
+        content_type='application/json',
+        data=data,
+        headers=self.headers(),
+    )
+    self.assert200(response)
+    self.assertEqual(type(response.json), list)
+    self.assertEqual(len(response.json), 2)
+    self.assertEqual(
+        'bar1', response.json[0][1]['services_test_mock_model']['foo'])
+    self.assertEqual(
+        'bar2', response.json[1][1]['services_test_mock_model']['foo'])
+    response = self.client.get(self.mock_url(), headers=self.headers())
+    self.assert200(response)
+    self.assertEqual(
+        2, len(response.json['test_model_collection']['test_model']))
+
+  def test_collection_post_successful_multiple_with_errors(self):
+    data = json.dumps([
+        {'services_test_mock_model':
+         {'foo': 'bar1', 'code': 'f1', 'context': None}},
+        {'services_test_mock_model':
+            {'foo': 'bar1', 'code': 'f1', 'context': None}},
+        {'services_test_mock_model':
+            {'foo': 'bar2', 'code': 'f2', 'context': None}},
+        {'services_test_mock_model':
+            {'foo': 'bar2', 'code': 'f2', 'context': None}},
+    ])
+    self.client.get("/login")
+    response = self.client.post(
+        self.mock_url(),
+        content_type='application/json',
+        data=data,
+        headers=self.headers(),
+    )
+
+    self.assertEqual(403, response.status_code)
+    self.assertEqual([201, 403, 201, 403], [i[0] for i in response.json])
+    self.assertEqual(
+        'bar1', response.json[0][1]['services_test_mock_model']['foo'])
+    self.assertEqual(
+        'bar2', response.json[2][1]['services_test_mock_model']['foo'])
+    response = self.client.get(self.mock_url(), headers=self.headers())
+    self.assert200(response)
+    self.assertEqual(
+        2, len(response.json['test_model_collection']['test_model']))
+
+  def test_collection_post_bad_request(self):
+    response = self.client.post(
+        self.mock_url(),
+        content_type='application/json',
+        data='This is most definitely not valid content.',
+        headers=self.headers(),
+    )
+    self.assert400(response)
+
+  def test_collection_post_bad_content_type(self):
+    response = self.client.post(
+        self.mock_url(),
+        content_type='text/plain',
+        data="Doesn't matter, now does it?",
+        headers=self.headers(),
+    )
+    self.assertStatus(response, 415)

--- a/test/integration/ggrc/services/test_common.py
+++ b/test/integration/ggrc/services/test_common.py
@@ -1,12 +1,8 @@
 # Copyright (C) 2016 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
-import ggrc
-import ggrc.builder
-import ggrc.services
 import json
 import time
-from datetime import datetime
 from urlparse import urlparse
 from wsgiref.handlers import format_date_time
 from integration.ggrc import services
@@ -16,9 +12,6 @@ RESOURCE_ALLOWED = ['HEAD', 'GET', 'PUT', 'DELETE', 'OPTIONS']
 
 
 class TestServices(services.TestCase):
-
-  def http_timestamp(self, timestamp):
-    return format_date_time(time.mktime(timestamp.utctimetuple()))
 
   def get_location(self, response):
     """Ignore the `http://localhost` prefix of the Location"""
@@ -73,127 +66,6 @@ class TestServices(services.TestCase):
     self.assertAllow(
         self.client.delete(self.mock_url(), headers=self.headers()),
         COLLECTION_ALLOWED)
-
-  def test_collection_post_successful(self):
-    data = json.dumps(
-        {'services_test_mock_model': {'foo': 'bar', 'context': None}})
-    self.client.get("/login")
-    response = self.client.post(
-        self.mock_url(),
-        content_type='application/json',
-        data=data,
-        headers=self.headers(),
-    )
-    self.assertStatus(response, 201)
-    self.assertIn('Location', response.headers)
-    response = self.client.get(
-        self.get_location(response), headers=self.headers())
-    self.assert200(response)
-    self.assertIn('Content-Type', response.headers)
-    self.assertEqual('application/json', response.headers['Content-Type'])
-    self.assertIn('services_test_mock_model', response.json)
-    self.assertIn('foo', response.json['services_test_mock_model'])
-    self.assertEqual('bar', response.json['services_test_mock_model']['foo'])
-    # check the collection, too
-    response = self.client.get(self.mock_url(), headers=self.headers())
-    self.assert200(response)
-    self.assertEqual(
-        1, len(response.json['test_model_collection']['test_model']))
-    self.assertEqual(
-        'bar', response.json['test_model_collection']['test_model'][0]['foo'])
-
-  def test_collection_post_successful_single_array(self):
-    data = json.dumps(
-        [{'services_test_mock_model': {'foo': 'bar', 'context': None}}])
-    self.client.get("/login")
-    response = self.client.post(
-        self.mock_url(),
-        content_type='application/json',
-        data=data,
-        headers=self.headers(),
-    )
-    self.assert200(response)
-    self.assertEqual(type(response.json), list)
-    self.assertEqual(len(response.json), 1)
-
-    response = self.client.get(self.mock_url(), headers=self.headers())
-    self.assert200(response)
-    self.assertEqual(
-        1, len(response.json['test_model_collection']['test_model']))
-    self.assertEqual(
-        'bar', response.json['test_model_collection']['test_model'][0]['foo'])
-
-  def test_collection_post_successful_multiple(self):
-    data = json.dumps([
-        {'services_test_mock_model': {'foo': 'bar1', 'context': None}},
-        {'services_test_mock_model': {'foo': 'bar2', 'context': None}},
-    ])
-    self.client.get("/login")
-    response = self.client.post(
-        self.mock_url(),
-        content_type='application/json',
-        data=data,
-        headers=self.headers(),
-    )
-    self.assert200(response)
-    self.assertEqual(type(response.json), list)
-    self.assertEqual(len(response.json), 2)
-    self.assertEqual(
-        'bar1', response.json[0][1]['services_test_mock_model']['foo'])
-    self.assertEqual(
-        'bar2', response.json[1][1]['services_test_mock_model']['foo'])
-    response = self.client.get(self.mock_url(), headers=self.headers())
-    self.assert200(response)
-    self.assertEqual(
-        2, len(response.json['test_model_collection']['test_model']))
-
-  def test_collection_post_successful_multiple_with_errors(self):
-    data = json.dumps([
-        {'services_test_mock_model':
-         {'foo': 'bar1', 'code': 'f1', 'context': None}},
-        {'services_test_mock_model':
-            {'foo': 'bar1', 'code': 'f1', 'context': None}},
-        {'services_test_mock_model':
-            {'foo': 'bar2', 'code': 'f2', 'context': None}},
-        {'services_test_mock_model':
-            {'foo': 'bar2', 'code': 'f2', 'context': None}},
-    ])
-    self.client.get("/login")
-    response = self.client.post(
-        self.mock_url(),
-        content_type='application/json',
-        data=data,
-        headers=self.headers(),
-    )
-
-    self.assertEqual(403, response.status_code)
-    self.assertEqual([201, 403, 201, 403], [i[0] for i in response.json])
-    self.assertEqual(
-        'bar1', response.json[0][1]['services_test_mock_model']['foo'])
-    self.assertEqual(
-        'bar2', response.json[2][1]['services_test_mock_model']['foo'])
-    response = self.client.get(self.mock_url(), headers=self.headers())
-    self.assert200(response)
-    self.assertEqual(
-        2, len(response.json['test_model_collection']['test_model']))
-
-  def test_collection_post_bad_request(self):
-    response = self.client.post(
-        self.mock_url(),
-        content_type='application/json',
-        data='This is most definitely not valid content.',
-        headers=self.headers(),
-    )
-    self.assert400(response)
-
-  def test_collection_post_bad_content_type(self):
-    response = self.client.post(
-        self.mock_url(),
-        content_type='text/plain',
-        data="Doesn't matter, now does it?",
-        headers=self.headers(),
-    )
-    self.assertStatus(response, 415)
 
   def test_put_successful(self):
     mock = self.mock_model(foo='buzz')

--- a/test/integration/ggrc/services/test_common.py
+++ b/test/integration/ggrc/services/test_common.py
@@ -4,7 +4,6 @@
 import json
 import time
 from urlparse import urlparse
-from wsgiref.handlers import format_date_time
 from integration.ggrc import services
 
 COLLECTION_ALLOWED = ['HEAD', 'GET', 'POST', 'OPTIONS']


### PR DESCRIPTION
This is a refactor of collection post test to better cover all use cases needed for the rafactor.

In this PR the only new test is for duplicate relatioships posted. See https://github.com/google/ggrc-core/pull/4194/commits/67c4b8140bd8db337ce572eea5ebfc7d00e8cebb

Note: The whole collection post refactor will be split into several smaller PRs for easier PR review process. In the pull requests that update and add tests, please make sure that we actually test what we want the end behaviour to be and that the tests themself actually fail when needed. 