### PR TITLE
QUICK-FIX Refactor collection post checks

### DIFF
--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -1091,11 +1091,7 @@ class Resource(ModelView):
     pass
 
   def _check_contexts_for_post(self, src):
-    if (src.get('private') is True and
-            self.get_context_id_from_json(src) is not None):
-      raise BadRequest(
-          'context MUST be "null" when creating a private resource.')
-    elif 'context' not in src:
+    if 'context' not in src:
       raise BadRequest('context MUST be specified.')
 
   def _try_recover_integrity_error(self, obj, error):


### PR DESCRIPTION
We must split the collection_post_step function into smaller independent
chunks that can be reused once collection_post_step function is removed.