### PR TITLE
QUICK-FIX Remove issue stats label from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@ Governance, Risk and Compliance (GGRC)
 =========
 
 [![Build Status](https://jenkins.reciprocitylabs.com/job/ggrc_develop_build/badge/icon)](https://jenkins.reciprocitylabs.com/job/ggrc_develop_build/)
-[![Issue Stats](http://www.issuestats.com/github/google/ggrc-core/badge/pr?style=flat)](http://www.issuestats.com/github/google/ggrc-core)
 
 Governance, Risk Management, and Compliance are activities necessary for any organization with regulatory or contractual obligations.
 


### PR DESCRIPTION
The issue stats label is usually out of sync and the like is broken most of the time, so it's better to just remove it.