### PR TITLE
FEATURE Add basic functionality for /query endpoint

### DIFF
--- a/src/ggrc/converters/base_block.py
+++ b/src/ggrc/converters/base_block.py
@@ -27,7 +27,6 @@ from ggrc.converters import pre_commit_checks
 from ggrc.converters.base_row import RowConverter
 from ggrc.converters.import_helper import get_column_order
 from ggrc.converters.import_helper import get_object_column_definitions
-from ggrc.rbac import permissions
 from ggrc.services.common import get_modified_objects
 from ggrc.services.common import update_index
 from ggrc.services.common import update_memcache_after_commit
@@ -272,9 +271,6 @@ class BlockConverter(object):
     self.row_converters = []
     objects = self.object_class.eager_query().filter(
         self.object_class.id.in_(self.object_ids)).all()
-    # TODO: this needs to be moved to query_helper, but it's here for now,
-    # so we don't have to fetch same objects twice from the database.
-    objects = [o for o in objects if permissions.is_allowed_read_for(o)]
     for i, obj in enumerate(objects):
       row = RowConverter(self, self.object_class, obj=obj,
                          headers=self.headers, index=i)

--- a/src/ggrc/converters/base_block.py
+++ b/src/ggrc/converters/base_block.py
@@ -348,7 +348,7 @@ class BlockConverter(object):
     """Add all objects to the database.
 
     This function flushes all objects to the database and if the dry_run flag
-    is not set, the session gets commited and all signals for the imported
+    is not set, the session gets committed and all signals for the imported
     objects get sent.
     """
     if self.ignore:

--- a/src/ggrc/converters/base_row.py
+++ b/src/ggrc/converters/base_row.py
@@ -179,7 +179,7 @@ class RowConverter(object):
   def send_post_commit_signals(self):
     """Send after commit signals for all objects
 
-    This function sends propper signals for all objects depending if the object
+    This function sends proper signals for all objects depending if the object
     was created, updated or deleted.
     Note: signals are only sent for the row objects. Secondary objects such as
     Relationships do not get any signals triggered.
@@ -201,7 +201,7 @@ class RowConverter(object):
   def send_pre_commit_signals(self):
     """Send before commit signals for all objects.
 
-    This function sends propper signals for all objects depending if the object
+    This function sends proper signals for all objects depending if the object
     was created, updated or deleted.
     Note: signals are only sent for the row objects. Secondary objects such as
     Relationships do not get any signals triggered.
@@ -234,7 +234,7 @@ class RowConverter(object):
     """Add additional objects to the current database session.
 
     This is used for adding any extra created objects such as Relationships, to
-    the current session to be commited.
+    the current session to be committed.
     """
     if not self.obj or self.ignore or self.is_delete:
       return

--- a/src/ggrc/converters/query_helper.py
+++ b/src/ggrc/converters/query_helper.py
@@ -108,7 +108,7 @@ class QueryHelper(object):
     return query
 
   def _clean_filters(self, expression):
-    """ prepair the filter expression for building the query """
+    """Prepare the filter expression for building the query."""
     if not expression or type(expression) != dict:
       return
     slugs = expression.get("slugs")

--- a/src/ggrc/converters/query_helper.py
+++ b/src/ggrc/converters/query_helper.py
@@ -9,6 +9,7 @@ from sqlalchemy import and_
 from sqlalchemy import not_
 from sqlalchemy import or_
 
+from ggrc.rbac import permissions
 from ggrc.models.custom_attribute_value import CustomAttributeValue
 from ggrc.models.reflection import AttributeInfo
 from ggrc.models.relationship_helper import RelationshipHelper
@@ -296,7 +297,7 @@ class QueryHelper(object):
     filter_expression = build_expression(expression)
     if filter_expression is not None:
       query = query.filter(filter_expression)
-    object_ids = [o.id for o in query.all()]
+    object_ids = [o.id for o in query if permissions.is_allowed_read_for(o)]
     return object_ids
 
   def _slugs_to_ids(self, object_name, slugs):

--- a/src/ggrc/converters/query_helper.py
+++ b/src/ggrc/converters/query_helper.py
@@ -303,6 +303,13 @@ class QueryHelper(object):
       ids = [o.id for o in query if permissions.is_allowed_update_for(o)]
     else:
       ids = [o.id for o in query if permissions.is_allowed_read_for(o)]
+
+    if "limit" in object_query:
+      try:
+        from_, to_ = object_query["limit"]
+        ids = ids[from_: to_]
+      except:
+        raise BadQueryException("Bad query: Invalid limit operand.")
     return ids
 
   def _slugs_to_ids(self, object_name, slugs):

--- a/src/ggrc/converters/query_helper.py
+++ b/src/ggrc/converters/query_helper.py
@@ -31,10 +31,11 @@ class QueryHelper(object):
   query object = [
     {
       object_name: search class name,
+      permissions: either read or update, if none are given it defaults to read
       filters: {
         relevant_filters:
           these filters will return all ids of the "search class name" object
-          that are mapped to objects defined in the dictionary insde the list.
+          that are mapped to objects defined in the dictionary inside the list.
           [ list of filters joined by OR expression
             [ list of filters joined by AND expression
               {
@@ -297,8 +298,12 @@ class QueryHelper(object):
     filter_expression = build_expression(expression)
     if filter_expression is not None:
       query = query.filter(filter_expression)
-    object_ids = [o.id for o in query if permissions.is_allowed_read_for(o)]
-    return object_ids
+    requested_permissions = object_query.get("permissions", "read")
+    if requested_permissions == "update":
+      ids = [o.id for o in query if permissions.is_allowed_update_for(o)]
+    else:
+      ids = [o.id for o in query if permissions.is_allowed_read_for(o)]
+    return ids
 
   def _slugs_to_ids(self, object_name, slugs):
     object_class = self.object_map.get(object_name)

--- a/src/ggrc/notifications/common.py
+++ b/src/ggrc/notifications/common.py
@@ -206,7 +206,7 @@ def should_receive(notif, user_data):
 
 
 def send_todays_digest_notifications():
-  """Send emails for todays or overdue notifications.
+  """Send emails for today's or overdue notifications.
 
   Returns:
     str: String containing a simple list of who received the notification.
@@ -260,10 +260,10 @@ def show_pending_notifications():
 
 
 def show_todays_digest_notifications():
-  """Get notification html for todays notifications.
+  """Get notification html for today's notifications.
 
   Returns:
-    str: Html containing all todays notifications.
+    str: Html containing all today's notifications.
   """
   # pylint: disable=invalid-name
   if not permissions.is_admin():

--- a/src/ggrc/services/query_helper.py
+++ b/src/ggrc/services/query_helper.py
@@ -12,6 +12,7 @@ from flask import current_app
 
 from ggrc.builder import json
 from ggrc.converters.query_helper import QueryHelper
+from ggrc.login import login_required
 from ggrc.models.inflector import get_model
 from ggrc.services.common import etag
 from ggrc.utils import as_json
@@ -91,3 +92,12 @@ def get_objects_by_query():
       collection,
       get_last_modified(model, objects),
   )
+
+
+def init_query_view(app):
+  # pylint: disable=unused-variable
+  @app.route('/query', methods=['POST'])
+  @login_required
+  def query_objects():
+    """Advanced object collection queries view."""
+    return get_objects_by_query()

--- a/src/ggrc/services/query_helper.py
+++ b/src/ggrc/services/query_helper.py
@@ -1,0 +1,93 @@
+# Copyright (C) 2016 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""This module contains logic to handle '/query' endpoint."""
+
+from datetime import datetime
+import time
+from wsgiref.handlers import format_date_time
+
+from flask import request
+from flask import current_app
+
+from ggrc.builder import json
+from ggrc.converters.query_helper import QueryHelper
+from ggrc.models.inflector import get_model
+from ggrc.services.common import etag
+from ggrc.utils import as_json
+
+
+def build_collection_representation(model, objects):
+  """Enclose objects list into type-describing block."""
+  # pylint: disable=protected-access
+  collection = [{
+      model.__name__: {
+          "count": len(objects),
+          "values": objects,
+      },
+      "selfLink": None,  # not implemented yet
+  }]
+  return collection
+
+
+def get_last_modified(model, objects):
+  """Get last object update time for Last-Modified header."""
+  if hasattr(model, 'updated_at') and objects:
+    last_modified = max(obj.updated_at for obj in objects)
+  else:
+    last_modified = datetime.now()
+  return last_modified
+
+
+def json_success_response(response_object, last_modified, status=200):
+  """Build a 200-response with metadata headers."""
+  headers = [
+      ('Last-Modified', http_timestamp(last_modified)),
+      ('Etag', etag(response_object)),
+      ('Content-Type', 'application/json'),
+  ]
+  return current_app.make_response(
+      (as_json(response_object), status, headers),
+  )
+
+
+def http_timestamp(timestamp):
+  return format_date_time(time.mktime(timestamp.utctimetuple()))
+
+
+def get_objects_by_query():
+  """Return objects corresponding to a POST'ed query."""
+  # Note: only a single query in a single request is supported now. If we get
+  # several queries in a single request, we process only the first one
+  request_json = request.json[0]
+
+  # valid types should be: 'values', 'ids', 'count'
+  query_type = request_json.get('type', 'values')
+  object_type = request_json.get('object_name')
+  query_helper = QueryHelper([request_json])
+
+  result = query_helper.get_ids()[0]
+  if query_type == 'values':
+    ids, object_type = result.get('ids', []), result.get('object_name', '')
+    model = get_model(object_type)
+    query = model.eager_query()
+    if ids:
+      objects = query.filter(model.id.in_(ids)).all()
+    else:
+      # avoid invoking IN-predicate with empty sequence
+      objects = []
+
+    objects_json = [json.publish(obj) for obj in objects]
+    objects_json = json.publish_representation(objects_json)
+
+    if result.get('fields'):
+      objects_json = [{f: o.get(f) for f in result['fields']}
+                      for o in objects_json]
+    collection = build_collection_representation(model, objects_json)
+  else:
+    raise NotImplementedError("Only 'values' queries are supported now")
+
+  return json_success_response(
+      collection,
+      get_last_modified(model, objects),
+  )

--- a/src/ggrc/views/__init__.py
+++ b/src/ggrc/views/__init__.py
@@ -35,7 +35,7 @@ from ggrc.models.reflection import AttributeInfo
 from ggrc.rbac import permissions
 from ggrc.services.common import as_json
 from ggrc.services.common import inclusion_filter
-from ggrc.services.query_helper import get_objects_by_query
+from ggrc.services import query_helper
 from ggrc.views import converters
 from ggrc.views import cron
 from ggrc.views import filters
@@ -346,6 +346,7 @@ def init_extra_views(app_):
   converters.init_converter_views()
   cron.init_cron_views(app_)
   notifications.init_notification_views(app_)
+  query_helper.init_query_view(app_)
 
 
 def init_all_views(app_):
@@ -372,10 +373,3 @@ def user_permissions():
      logged in user
   '''
   return get_permissions_json()
-
-
-@app.route("/query", methods=["POST"])
-@login_required
-def query_objects():
-  """Advanced object collection queries."""
-  return get_objects_by_query()

--- a/src/ggrc/views/__init__.py
+++ b/src/ggrc/views/__init__.py
@@ -35,6 +35,7 @@ from ggrc.models.reflection import AttributeInfo
 from ggrc.rbac import permissions
 from ggrc.services.common import as_json
 from ggrc.services.common import inclusion_filter
+from ggrc.services.query_helper import get_objects_by_query
 from ggrc.views import converters
 from ggrc.views import cron
 from ggrc.views import filters
@@ -371,3 +372,10 @@ def user_permissions():
      logged in user
   '''
   return get_permissions_json()
+
+
+@app.route("/query", methods=["POST"])
+@login_required
+def query_objects():
+  """Advanced object collection queries."""
+  return get_objects_by_query()

--- a/test/unit/ggrc/converters/test_query_helper.py
+++ b/test/unit/ggrc/converters/test_query_helper.py
@@ -18,6 +18,8 @@ class TestQueryHelper(unittest.TestCase):
       complex query
       invalid complex query
     """
+    # pylint: disable=protected-access
+    # needed for testing protected function inside the query helper
     query = mock.MagicMock()
     helper = query_helper.QueryHelper(query)
 
@@ -57,4 +59,4 @@ class TestQueryHelper(unittest.TestCase):
     ]
 
     for expected_result, expression in expressions:
-      self.assertEqual(expected_result, helper.expression_keys(expression))
+      self.assertEqual(expected_result, helper._expression_keys(expression))


### PR DESCRIPTION
This PR contains @zidarsk8's refactorings to `query_helper` module of `converters` and basic functionality for an endpoint for generic object querying. The API mostly conforms to the specification in [advanced query api document](https://github.com/google/ggrc-core/blob/develop/doc/advanced_query_api.md).