### PR TITLE
QUICK-FIX Mitigate rules for date format of imported task

### DIFF
--- a/src/ggrc/converters/errors.py
+++ b/src/ggrc/converters/errors.py
@@ -90,6 +90,10 @@ UNKNOWN_DATE_FORMAT = (u"Line {line}: Field {column_name} contains invalid "
                        u"date format, use YYYY-MM-DD or MM/DD/YYYY. The line "
                        u"will be ignored.")
 
+WRONG_DATE_FORMAT = (u"Line {line}: Field {column_name} contains invalid "
+                     u"date format. Expected MM/DD, but found MM/DD/YYYY, "
+                     u"the YYYY part of the date will be ignored.")
+
 UNSUPPORTED_LIST_ERROR = (u"Line {line}: Field {column_name} does not support "
                           u"{value_type}.")
 

--- a/src/ggrc_workflows/converters/handlers.py
+++ b/src/ggrc_workflows/converters/handlers.py
@@ -167,6 +167,10 @@ class TaskStartColumnHandler(TaskDateColumnHandler):
         return
       self.row_converter.obj.relative_start_day = self.value[0]
     elif freq in ["quarterly", "annually"]:
+      if len(self.value) == 3:
+        self.add_warning(errors.WRONG_DATE_FORMAT,
+                         column_name=self.display_name)
+        self.value = self.value[:2]
       if len(self.value) != 2 or \
          (freq == "quarterly" and not (1 <= self.value[0] <= 3)) or \
          (freq == "annually" and not (1 <= self.value[0] <= 12)) or \
@@ -221,6 +225,10 @@ class TaskEndColumnHandler(TaskDateColumnHandler):
         return
       self.row_converter.obj.relative_end_day = self.value[0]
     elif freq in ["quarterly", "annually"]:
+      if len(self.value) == 3:
+        self.add_warning(errors.WRONG_DATE_FORMAT,
+                         column_name=self.display_name)
+        self.value = self.value[:2]
       if len(self.value) != 2 or \
          (freq == "quarterly" and not (1 <= self.value[0] <= 3)) or \
          (freq == "annually" and not (1 <= self.value[0] <= 12)) or \

--- a/test/integration/ggrc_workflows/converters/test_csvs/workflow_malformed_task_dates.csv
+++ b/test/integration/ggrc_workflows/converters/test_csvs/workflow_malformed_task_dates.csv
@@ -1,0 +1,25 @@
+Object type,,,,,,,,
+Person,name,email,company,role,,,,
+,user 1,user1@ggrc.com,google,Admin ,,,,
+,,,,,,,,
+Object type,,,,,,,,
+Workflow,code*,title*,description ,manager,frequency,force real-time email updates,custom email message,
+,wf-1,wf-1,test,user1@ggrc.com,Annually,no,this is super custom ,
+,,,,,,,,
+Object type,,,,,,,,
+Task Group,code*,Summary*,details,assignee,workflow*,Objects,,
+,tg-1,tg-1,test,user1@ggrc.com,wf-1,"Objective: obj-1
+objective : obj-3",,
+,,,,,,,,
+Object type,,,,,,,,
+Task,code*,Summary*,task group,task description,assignee*,task type,start,end
+,t-1,task for wf-1,tg-1,test,user1@ggrc.com,Rich text,7/10/2015,12/30/2015
+,t-2,task for wf-2,tg-1,test,user1@ggrc.com,Rich text,7/10/15,12/30
+,t-3,checkbox task,tg-1,"ch1, ch2 , some checkbox 3",user1@ggrc.com,Checkboxes,7/10,12/30/17
+,t-4,dropdow task,tg-1,"option 1, another option ,   o3",user1@ggrc.com,Dropdown,7/10,12/30
+,,,,,,,,
+Object type,,,,,,,,
+objective,code*,title*,description,owner,state,notes,,
+,obj-1,obj-1,test,user1@ggrc.com,Draft,this is a note,,
+,obj-2,obj-2,test,user1@ggrc.com,Final,this is a note,,
+,obj-3,obj-3,test,user1@ggrc.com,Effective,this is a note,,


### PR DESCRIPTION
Imported task of quarterly/annually workflow requires dates
to be in format MM/DD, but the most spreadsheet editors
automatically format such dates into MM/DD/YYYY.

The commit mitigate these rules, so dates in format MM/DD/YYYY
will able to be imported without errors, but with only warnings.