### PR TITLE
QUICK-FIX Reset instance after modal close

### DIFF
--- a/src/ggrc/assets/javascripts/bootstrap/modal-form.js
+++ b/src/ggrc/assets/javascripts/bootstrap/modal-form.js
@@ -175,7 +175,7 @@
           return;
         }
         if (instance) {
-          changedInstance = instance.isDirty();
+          changedInstance = instance.isDirty(true);
           hasPending = GGRC.Utils.hasPending(instance);
         }
         if (this.is_form_dirty() || changedInstance || hasPending) {

--- a/src/ggrc/assets/javascripts/components/assessment_attributes.js
+++ b/src/ggrc/assets/javascripts/components/assessment_attributes.js
@@ -10,7 +10,7 @@
    * It collects fields data and it transforms them into appropriate
    * format for saving
    */
-  can.Component.extend({
+  GGRC.Components('templateAttributes', {
     tag: 'assessment-template-attributes',
     template: '<content></content>',
     scope: {
@@ -69,7 +69,7 @@
    *
    * Represents each `field` passed from assessment-template-attributes `fields`
    */
-  can.Component.extend({
+  GGRC.Components('templateAttributesField', {
     tag: 'template-field',
     template: can.view(GGRC.mustache_path +
       '/assessment_templates/attribute_field.mustache'),
@@ -160,6 +160,7 @@
       }
     }
   });
+
   GGRC.Components('addTemplateField', {
     tag: 'add-template-field',
     template: can.view(GGRC.mustache_path +

--- a/src/ggrc/assets/javascripts/controllers/modals_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/modals_controller.js
@@ -979,6 +979,7 @@ can.Control('GGRC.Controllers.Modals', {
           && !this.options.skip_refresh
           && !this.options.instance.isNew()) {
         this.options.instance.refresh();
+        this.options.instance.restore(true);
       }
     }
 


### PR DESCRIPTION
Subject: Deleting Assessment CA fields from Assessment template modal without saving the changes results in weird CA fields behavior on  Assessment template modal

Details: 
Edit the Assessment template 
Delete a CA field from the list but do not save the changes, just close the modal by clickig “X” button or clicking outside the modal

Open Edit Assessment template modal again
Actual Result: the app shows that another field has been removed
Expected Result:  the changes weren’t saved so the app should show all the fields after reopening edit modal
