### PR TITLE
ISSUE-115 Fix showing duplicate objects in mapper modal

### DIFF
--- a/src/ggrc/assets/javascripts/components/unified_mapper/mapper_results.js
+++ b/src/ggrc/assets/javascripts/components/unified_mapper/mapper_results.js
@@ -71,6 +71,7 @@
     events: {
       inserted: function () {
         this.scope.attr('entries', []);
+        this.scope.attr('options', []);
         this.element.find('.results-wrap').cms_controllers_infinite_scroll();
       },
       '.modalSearchButton click': 'getResults',

--- a/src/ggrc/assets/javascripts/components/unified_mapper/mapper_results.js
+++ b/src/ggrc/assets/javascripts/components/unified_mapper/mapper_results.js
@@ -6,7 +6,7 @@
 (function (can, $) {
   'use strict';
 
-  can.Component.extend({
+  GGRC.Components('mapperResults', {
     tag: 'mapper-results',
     template: can.view(
       GGRC.mustache_path +
@@ -70,6 +70,7 @@
     },
     events: {
       inserted: function () {
+        this.scope.attr('entries', []);
         this.element.find('.results-wrap').cms_controllers_infinite_scroll();
       },
       '.modalSearchButton click': 'getResults',

--- a/src/ggrc/assets/javascripts/components/unified_mapper/tests/mapper_results_spec.js
+++ b/src/ggrc/assets/javascripts/components/unified_mapper/tests/mapper_results_spec.js
@@ -1,0 +1,33 @@
+/*!
+  Copyright (C) 2016 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+describe('GGRC.Components.mapperResults', function () {
+  'use strict';
+
+  describe('on inserted event', function () {
+    var scope;
+    var $body;
+    var $root;  // the component's root DOM element
+
+    beforeEach(function () {
+      var renderer = can.view.mustache('<mapper-results></mapper-results>');
+
+      $body = $('body');
+      $body.append(renderer());
+      $root = $body.find('mapper-results');
+
+      scope = $root.scope();
+    });
+
+    afterEach(function () {
+      $root.remove();
+    });
+
+    it('initializes the list of entries to an empty list', function () {
+      expect(scope.entries).toBeDefined();
+      expect(scope.entries.attr()).toEqual([]);
+    });
+  });
+});

--- a/src/ggrc/assets/javascripts/components/unified_mapper/tests/mapper_results_spec.js
+++ b/src/ggrc/assets/javascripts/components/unified_mapper/tests/mapper_results_spec.js
@@ -29,5 +29,10 @@ describe('GGRC.Components.mapperResults', function () {
       expect(scope.entries).toBeDefined();
       expect(scope.entries.attr()).toEqual([]);
     });
+
+    it('initializes the options to an empty list', function () {
+      expect(scope.options).toBeDefined();
+      expect(scope.options.attr()).toEqual([]);
+    });
   });
 });


### PR DESCRIPTION
_(bug 1.34 under Section 2)_

This fixes the issue in the unified mapping modal where the same mapped object can be shown multiple times. This occurs because the `entries` list is not initialized upon component instantiation, causing the `{scope.entries} add` event handler to be invoked multiple times. On the other hand, properly initializing the list assures that it is free of any existing event handlers.

**Steps to reproduce:**
- Navigate to a Program page
- Open controls tab in horizontal menu and click (+) button
- Create a new Control via unified mapping modal and map it to the program
- Open mapping modal window again by clicking (+) button and create another Control from within it

**Actual Result:**
The Control’s title is shown multiple times in the OBJECTS FOUND section (once for every time the modal has been opened)
**Expected Result:**
The newly created control is displayed only once