### PR TITLE
QUICK-FIX Split collection post loop

### DIFF
--- a/src/ggrc/automapper/__init__.py
+++ b/src/ggrc/automapper/__init__.py
@@ -222,7 +222,16 @@ class AutomapperGenerator(object):
 
 
 def register_automapping_listeners():
-  @Resource.model_posted.connect_via(Relationship)
+
+  @Resource.collection_posted.connect_via(Relationship)
+  def handle_relationship_collection_post(sender, objects=None, **kwargs):
+    automapper = AutomapperGenerator()
+    for obj in objects:
+      if obj is None:
+        logging.warning("Automapping listener: no obj, no mappings created")
+        return
+      automapper.generate_automappings(obj)
+
   def handle_relationship_post(sender, obj=None, src=None, service=None):
     if obj is None:
       logging.warning("Automapping listener: no obj, no mappings created")

--- a/src/ggrc/automapper/__init__.py
+++ b/src/ggrc/automapper/__init__.py
@@ -30,6 +30,7 @@ class Stub(collections.namedtuple("Stub", ["type", "id"])):
 
 
 class AutomapperGenerator(object):
+
   def __init__(self, use_benchmark=True):
     self.processed = set()
     self.queue = set()
@@ -221,10 +222,47 @@ class AutomapperGenerator(object):
     return True
 
 
+def handle_relationship_post(source, destination):
+  """Handle posting of special relationships.
+
+  This function handles direct relationships that do not have a relationship
+  object. A fake object is created with source and destination and auto
+  mappings are then generated.
+
+  Args:
+    source: Source model of relationship
+    destination: Destination model of relationship
+
+  """
+  if source is None:
+    logging.warning("Automapping request listener: "
+                    "no source, no mappings created")
+    return
+  if destination is None:
+    logging.warning("Automapping request listener: "
+                    "no destination, no mappings created")
+    return
+  relationship = Relationship(source_type=source.type,
+                              source_id=source.id,
+                              destination_type=destination.type,
+                              destination_id=destination.id)
+  AutomapperGenerator().generate_automappings(relationship)
+
+
 def register_automapping_listeners():
+  """Register event listeners for auto mapper."""
+  # pylint: disable=unused-variable
 
   @Resource.collection_posted.connect_via(Relationship)
   def handle_relationship_collection_post(sender, objects=None, **kwargs):
+    """Handle bulk creation of relationships.
+
+    This handler reuses auto mapper cache and is more efficient than handling
+    one object at a time.
+
+    Args:
+      objects: list of relationship Models.
+    """
     automapper = AutomapperGenerator()
     for obj in objects:
       if obj is None:
@@ -232,43 +270,11 @@ def register_automapping_listeners():
         return
       automapper.generate_automappings(obj)
 
-  def handle_relationship_post(sender, obj=None, src=None, service=None):
-    if obj is None:
-      logging.warning("Automapping listener: no obj, no mappings created")
-      return
-    AutomapperGenerator().generate_automappings(obj)
-
-  # pylint: disable=unused-variable
   @Resource.model_posted_after_commit.connect_via(Request)
   @Resource.model_put_after_commit.connect_via(Request)
   def handle_request(sender, obj=None, src=None, service=None):
-    if obj is None:
-      logging.warning("Automapping request listener: "
-                      "no obj, no mappings created")
-      return
-    if obj.audit is None:
-      logging.warning("Automapping request listener: "
-                      "no audit, no mappings created")
-      return
-    rel = Relationship(source_type=obj.type,
-                       source_id=obj.id,
-                       destination_type=obj.audit.type,
-                       destination_id=obj.audit.id)
-    handle_relationship_post(sender, obj=rel)
+    handle_relationship_post(obj, obj.audit)
 
-  # pylint: disable=unused-variable
   @Resource.model_posted_after_commit.connect_via(Audit)
   def handle_audit(sender, obj=None, src=None, service=None):
-    if obj is None:
-      logging.warning("Automapping audit listener: "
-                      "no obj, no mappings created")
-      return
-    if obj.program is None:
-      logging.warning("Automapping audit listener: "
-                      "no program, no mappings created")
-      return
-    rel = Relationship(source_type=obj.type,
-                       source_id=obj.id,
-                       destination_type=obj.program.type,
-                       destination_id=obj.program.id)
-    handle_relationship_post(sender, obj=rel)
+    handle_relationship_post(obj, obj.program)

--- a/src/ggrc/models/revision.py
+++ b/src/ggrc/models/revision.py
@@ -108,6 +108,6 @@ class Revision(Base, db.Model):
       else:
         # otherwise, it's a normal creation event
         result = u"{0} {1}".format(display_name, self.action)
-    if self.event.action == "IMPORT":
-      result += ", via spreadsheet import"
+    if self.event.action == "BULK":
+      result += ", via bulk action"
     return result

--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -1211,12 +1211,8 @@ class Resource(ModelView):
     with benchmark("Get modified objects"):
       modified_objects = get_modified_objects(db.session)
 
-
-    with benchmark("Pre collection post log flush"):
-      db.session.flush()
     with benchmark("Log event for all objects"):
-      for obj in objects:
-        log_event(db.session, obj, flush=False)
+      log_event(db.session, obj, flush=False)
 
     with benchmark("Update memcache before commit for collection POST"):
       update_memcache_before_commit(

--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -332,7 +332,7 @@ def log_event(session, obj=None, current_user_id=None, flush=True):
   if obj is None:
     resource_id = 0
     resource_type = None
-    action = 'IMPORT'
+    action = 'BULK'
     context_id = 0
   else:
     resource_id = obj.id

--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -1181,6 +1181,14 @@ class Resource(ModelView):
         raise Forbidden()
 
   def collection_post_loop(self, body, res, no_result, running_async):
+    """Handle all posted objects.
+
+    Args:
+      body: list of dictionaries containing json object representations.
+      res: List that will get responses appended to it.
+      no_result: Flag for suppressing results.
+      running_async: Flag for async jobs.
+    """
 
     with benchmark("Generate objects"):
       objects = []
@@ -1199,7 +1207,7 @@ class Resource(ModelView):
         obj.modified_by = get_current_user()
         objects.append(obj)
 
-    with benchmark("Send model POSTed event"):
+    with benchmark("Send collection POSTed event"):
       self.collection_posted.send(obj.__class__, objects=objects)
     with benchmark("Check create permissions"):
       self._check_post_permissions(objects)

--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -124,6 +124,8 @@ def set_ids_for_new_custom_attributes(objects, parent_obj):
   Returns:
     None
   """
+  if not hasattr(parent_obj, "PER_OBJECT_CUSTOM_ATTRIBUTABLE"):
+    return
 
   object_attrs = {
       "CustomAttributeValue": "attributable_id",
@@ -131,8 +133,7 @@ def set_ids_for_new_custom_attributes(objects, parent_obj):
   }
 
   for obj in objects:
-    if (obj.type not in object_attrs or
-            not hasattr(parent_obj, "PER_OBJECT_CUSTOM_ATTRIBUTABLE")):
+    if obj.type not in object_attrs:
       continue
 
     attr = object_attrs[obj.type]

--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -1220,8 +1220,6 @@ class Resource(ModelView):
     with benchmark("Generate objects"):
       objects = []
       for wrapped_src in body:
-        if running_async:
-          time.sleep(settings.BACKGROUND_COLLECTION_POST_SLEEP)
         src = self._unwrap_collection_post_src(wrapped_src)
         obj = self._get_model_instance(src, body)
         with benchmark("Deserialize object"):

--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -1181,14 +1181,14 @@ class Resource(ModelView):
       with benchmark("Send model POSTed event"):
         self.model_posted.send(obj.__class__, obj=obj, src=src, service=self)
 
-      self._check_post_permissions([obj])
-
       obj.modified_by = get_current_user()
+      with benchmark("Update custom attribute values"):
+        set_ids_for_new_custom_attributes(obj)
+
+      self._check_post_permissions([obj])
 
       with benchmark("Get modified objects"):
         modified_objects = get_modified_objects(db.session)
-      with benchmark("Update custom attribute values"):
-        set_ids_for_new_custom_attributes(obj)
 
       with benchmark("Log event"):
         log_event(db.session, obj)

--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -637,6 +637,18 @@ class Resource(ModelView):
         :src: The original POSTed JSON dictionary.
         :service: The instance of Resource handling the POST request.
       """,)
+  collection_posted = signals.signal(
+      "Collection POSTed",
+      """
+      Indicates that a list of models was received via POST and will be
+      committed to the database. The sender in the signal will be the model
+      class of the POSTed resource. The following arguments will be sent along
+      with the signal:
+
+        :objects: The model instance created from the POSTed JSON.
+        :src: The original POSTed JSON dictionary.
+        :service: The instance of Resource handling the POST request.
+      """,)
   model_posted_after_commit = signals.signal(
       "Model POSTed - after",
       """
@@ -1187,6 +1199,9 @@ class Resource(ModelView):
         set_ids_for_new_custom_attributes(obj)
 
       objects.append(obj)
+
+    with benchmark("Send model POSTed event"):
+      self.collection_posted.send(obj.__class__, objects=objects)
 
     self._check_post_permissions(objects)
 

--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -1222,13 +1222,13 @@ class Resource(ModelView):
     with benchmark("Update memcache after commit for collection POST"):
       update_memcache_after_commit(self.request)
 
-    for obj in objects:
-      with benchmark("Send model POSTed - after commit event"):
+    with benchmark("Send model POSTed - after commit event"):
+      for obj in objects:
         self.model_posted_after_commit.send(obj.__class__, obj=obj,
                                             src=src, service=self)
         # Note: In model_posted_after_commit necessary mapping and
         # relationships are set, so need to commit the changes
-        db.session.commit()
+      db.session.commit()
 
     with benchmark("Serialize objects"):
       for obj in objects:

--- a/test/integration/ggrc/services/test_collection_post.py
+++ b/test/integration/ggrc/services/test_collection_post.py
@@ -115,13 +115,11 @@ class TestCollectionPost(services.TestCase):
     )
 
     self.assertEqual(403, response.status_code)
-    self.assertEqual([201, 403], [i[0] for i in response.json])
-    self.assertEqual(
-        'bar1', response.json[0][1]['services_test_mock_model']['foo'])
+    self.assertEqual([403], [i[0] for i in response.json])
     response = self.client.get(self.mock_url(), headers=self.headers())
     self.assert200(response)
     self.assertEqual(
-        1, len(response.json['test_model_collection']['test_model']))
+        0, len(response.json['test_model_collection']['test_model']))
 
   def test_collection_post_bad_request(self):
     response = self.client.post(


### PR DESCRIPTION
~~This is continuation of https://github.com/google/ggrc-core/pull/4209 and will be rebased once that PR is merged.~~
~~When reviewing just checks commits from "Change CA set_ids return condition" on.~~
~~PS: this PR should improve collection post performance when batching multiple objects~~

Most notable change in this PR is that collection post no longer fails on single bad object and adds all the good ones, but rather if any object in the collection is bad, none of them get inserted. This is the main source of the performance improvements, by batching multiple operations and queries.

Please pay attention to all object generatios, revision generation (on admin panel), lhn entries, and anything else you can think of.

Testing this is mostly, creating a lot of objects and checking that they appear where they should, Try special objects such as custom attributes, objects with custom attributes, people, and so on.

Also pay attention on performance, if it seems slower than on develop, you should make a comment and the issues should be investigated.