### PR TITLE
QUICK-FIX Lint python files

### DIFF
--- a/src/ggrc_basic_permissions/migrations/versions/20131206002015_c460b4f8cc3_place_all_public_pro.py
+++ b/src/ggrc_basic_permissions/migrations/versions/20131206002015_c460b4f8cc3_place_all_public_pro.py
@@ -1,26 +1,25 @@
 # Copyright (C) 2016 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
-
 """Place all public programs into their own context.
 
-Revision ID: c460b4f8cc3
-Revises: 40a621571ac7
 Create Date: 2013-12-06 00:20:15.108809
-
 """
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+import sqlalchemy as sa
+from alembic import op
+from datetime import datetime
+from sqlalchemy.sql import table, column, select, and_
 
 # revision identifiers, used by Alembic.
 revision = 'c460b4f8cc3'
 down_revision = '40a621571ac7'
 
-import sqlalchemy as sa
-from alembic import op
-from datetime import datetime
-from sqlalchemy.sql import table, column, select, insert, and_
-import json
 
-contexts_table = table('contexts',
+contexts_table = table(
+    'contexts',
     column('id', sa.Integer),
     column('context_id', sa.Integer),
     column('description', sa.Text),
@@ -29,14 +28,16 @@ contexts_table = table('contexts',
     column('modified_by_id', sa.Integer),
     column('created_at', sa.DateTime),
     column('updated_at', sa.DateTime),
-    )
+)
 
-roles_table = table('roles',
+roles_table = table(
+    'roles',
     column('id', sa.Integer),
     column('name', sa.String),
-    )
+)
 
-role_implications_table = table('role_implications',
+role_implications_table = table(
+    'role_implications',
     column('id', sa.Integer),
     column('context_id', sa.Integer),
     column('source_context_id', sa.Integer),
@@ -45,58 +46,66 @@ role_implications_table = table('role_implications',
     column('modified_by_id', sa.Integer),
     column('created_at', sa.DateTime),
     column('updated_at', sa.DateTime),
-    )
+)
 
-programs_table = table('programs',
+programs_table = table(
+    'programs',
     column('id', sa.Integer),
     column('context_id', sa.Integer),
-    )
+)
 
-object_documents_table = table('object_documents',
+object_documents_table = table(
+    'object_documents',
     column('id', sa.Integer),
     column('context_id', sa.Integer),
     column('documentable_id', sa.Integer),
     column('documentable_type', sa.String),
-    )
+)
 
-object_people_table = table('object_people',
+object_people_table = table(
+    'object_people',
     column('id', sa.Integer),
     column('context_id', sa.Integer),
     column('personable_id', sa.Integer),
     column('personable_type', sa.String),
-    )
+)
 
-object_objectives_table = table('object_objectives',
+object_objectives_table = table(
+    'object_objectives',
     column('id', sa.Integer),
     column('context_id', sa.Integer),
     column('objectiveable_id', sa.Integer),
     column('objectiveable_type', sa.String),
-    )
+)
 
-relationships_table = table('relationships',
+relationships_table = table(
+    'relationships',
     column('id', sa.Integer),
     column('context_id', sa.Integer),
     column('source_id', sa.Integer),
     column('source_type', sa.String),
     column('destination_id', sa.Integer),
     column('destination_type', sa.String),
-    )
+)
 
-program_controls_table = table('program_controls',
+program_controls_table = table(
+    'program_controls',
     column('id', sa.Integer),
     column('context_id', sa.Integer),
     column('program_id', sa.Integer),
     column('control_id', sa.String),
-    )
+)
 
-program_directives_table = table('program_directives',
+program_directives_table = table(
+    'program_directives',
     column('id', sa.Integer),
     column('context_id', sa.Integer),
     column('program_id', sa.Integer),
     column('directive_id', sa.String),
-    )
+)
 
-object_owners_table = table('object_owners',
+object_owners_table = table(
+    'object_owners',
     column('id', sa.Integer),
     column('person_id', sa.Integer),
     column('ownable_id', sa.Integer),
@@ -104,9 +113,10 @@ object_owners_table = table('object_owners',
     column('modified_by_id', sa.Integer),
     column('created_at', sa.DateTime),
     column('updated_at', sa.DateTime),
-    )
+)
 
-user_roles_table = table('user_roles',
+user_roles_table = table(
+    'user_roles',
     column('id', sa.Integer),
     column('context_id', sa.Integer),
     column('role_id', sa.Integer),
@@ -114,27 +124,30 @@ user_roles_table = table('user_roles',
     column('modified_by_id', sa.Integer),
     column('created_at', sa.DateTime),
     column('updated_at', sa.DateTime),
-    )
+)
+
 
 def get_role(name):
   connection = op.get_bind()
   return connection.execute(
       select([roles_table.c.id]).where(roles_table.c.name == name)).fetchone()
 
+
 def add_role_implication(
-    context_id, source_context_id, source_role_id, role_id):
+        context_id, source_context_id, source_role_id, role_id):
   current_datetime = datetime.now()
   connection = op.get_bind()
   connection.execute(
       role_implications_table.insert().values(
-        context_id = context_id,
-        source_context_id = source_context_id,
-        source_role_id = source_role_id,
-        role_id = role_id,
-        modified_by_id=1,
-        created_at=current_datetime,
-        updated_at=current_datetime,
-        ))
+          context_id=context_id,
+          source_context_id=source_context_id,
+          source_role_id=source_role_id,
+          role_id=role_id,
+          modified_by_id=1,
+          created_at=current_datetime,
+          updated_at=current_datetime,
+      ))
+
 
 def upgrade():
   reader_role = get_role('Reader')
@@ -145,162 +158,163 @@ def upgrade():
 
   connection = op.get_bind()
   programs = connection.execute(
-      select([programs_table.c.id])\
-          .where(programs_table.c.context_id == None))
+      select([programs_table.c.id])
+      .where(programs_table.c.context_id == None))  # noqa
   current_datetime = datetime.now()
   for program in programs:
-    #Create the program context
-    result = connection.execute(
+    # Create the program context
+    connection.execute(
         contexts_table.insert().values(
-          context_id=1,
-          description='',
-          related_object_id=program.id,
-          related_object_type='Program',
-          modified_by_id=1,
-          created_at=current_datetime,
-          updated_at=current_datetime,
-          ))
+            context_id=1,
+            description='',
+            related_object_id=program.id,
+            related_object_type='Program',
+            modified_by_id=1,
+            created_at=current_datetime,
+            updated_at=current_datetime,
+        ))
     context = connection.execute(
         select([contexts_table.c.id]).where(
-          and_(
-            contexts_table.c.related_object_id == program.id,
-            contexts_table.c.related_object_type == 'Program')
-          )).fetchone()
+            and_(
+                contexts_table.c.related_object_id == program.id,
+                contexts_table.c.related_object_type == 'Program')
+        )).fetchone()
     context_id = context.id
 
-    #Add the role implications that makes the program public
+    # Add the role implications that makes the program public
     for role in [reader_role, object_editor_role, program_creator_role]:
       add_role_implication(context_id, None, role.id, program_reader_role.id)
 
-    #Move the program into the program context
-    op.execute(programs_table.update().values(context_id=context_id)\
-        .where(programs_table.c.id == program.id))
+    # Move the program into the program context
+    op.execute(programs_table.update().values(context_id=context_id)
+               .where(programs_table.c.id == program.id))
 
-    #Add role assignments for owners and delete the object_owner relationships
+    # Add role assignments for owners and delete the object_owner relationships
     owners = connection.execute(
-        select([object_owners_table.c.id, object_owners_table.c.person_id])\
-            .where(
-              and_(
+        select([object_owners_table.c.id, object_owners_table.c.person_id])
+        .where(
+            and_(
                 object_owners_table.c.ownable_id == program.id,
                 object_owners_table.c.ownable_type == 'Program')
-              )).fetchall()
+        )).fetchall()
     for owner in owners:
       connection.execute(
-        user_roles_table.insert().values(
-          context_id = context_id,
-          role_id = program_owner_role.id,
-          person_id = owner.person_id,
-          modified_by_id = 1,
-          created_at = current_datetime,
-          updated_at = current_datetime,
+          user_roles_table.insert().values(
+              context_id=context_id,
+              role_id=program_owner_role.id,
+              person_id=owner.person_id,
+              modified_by_id=1,
+              created_at=current_datetime,
+              updated_at=current_datetime,
           ))
       connection.execute(
-        object_owners_table.delete().where(
-          object_owners_table.c.id == owner.id))
+          object_owners_table.delete().where(
+              object_owners_table.c.id == owner.id))
 
-    #Move all relationships for the program into the program context
-    op.execute(object_documents_table.update().values(context_id=context_id)\
-        .where(
-          and_(
+    # Move all relationships for the program into the program context
+    op.execute(object_documents_table.update().values(context_id=context_id)
+               .where(
+        and_(
             object_documents_table.c.documentable_id == program.id,
             object_documents_table.c.documentable_type == 'Program')))
 
-    op.execute(object_people_table.update().values(context_id=context_id)\
-        .where(
-          and_(
+    op.execute(object_people_table.update().values(context_id=context_id)
+               .where(
+        and_(
             object_people_table.c.personable_id == program.id,
             object_people_table.c.personable_type == 'Program')))
 
-    op.execute(object_objectives_table.update().values(context_id=context_id)\
-        .where(
-          and_(
+    op.execute(object_objectives_table.update().values(context_id=context_id)
+               .where(
+        and_(
             object_objectives_table.c.objectiveable_id == program.id,
             object_objectives_table.c.objectiveable_type == 'Program')))
 
-    op.execute(relationships_table.update().values(context_id=context_id)\
-        .where(
-          and_(
+    op.execute(relationships_table.update().values(context_id=context_id)
+               .where(
+        and_(
             relationships_table.c.source_id == program.id,
             relationships_table.c.source_type == 'Program')))
 
-    op.execute(relationships_table.update().values(context_id=context_id)\
-        .where(
-          and_(
+    op.execute(relationships_table.update().values(context_id=context_id)
+               .where(
+        and_(
             relationships_table.c.destination_id == program.id,
             relationships_table.c.destination_type == 'Program')))
 
-    op.execute(program_controls_table.update().values(context_id=context_id)\
-        .where(program_controls_table.c.program_id == program.id))
+    op.execute(program_controls_table.update().values(context_id=context_id)
+               .where(program_controls_table.c.program_id == program.id))
 
-    op.execute(program_directives_table.update().values(context_id=context_id)\
-        .where(program_directives_table.c.program_id == program.id))
+    op.execute(program_directives_table.update().values(context_id=context_id)
+               .where(program_directives_table.c.program_id == program.id))
+
 
 def downgrade():
   reader_role = get_role('Reader')
   program_owner_role = get_role('ProgramOwner')
   connection = op.get_bind()
-  #Find public programs by finding a public role implication
+  # Find public programs by finding a public role implication
   reader_implications = connection.execute(
-      select([role_implications_table.c.context_id])\
-          .where(role_implications_table.c.source_role_id == reader_role.id))
+      select([role_implications_table.c.context_id])
+      .where(role_implications_table.c.source_role_id == reader_role.id))
   current_datetime = datetime.now()
   for public_implication in reader_implications:
     context_id = public_implication.context_id
 
-    #Move all relationships back to the NULL context
-    op.execute(object_documents_table.update().values(context_id=None)\
-        .where(object_documents_table.c.context_id == context_id))
+    # Move all relationships back to the NULL context
+    op.execute(object_documents_table.update().values(context_id=None)
+               .where(object_documents_table.c.context_id == context_id))
 
-    op.execute(object_people_table.update().values(context_id=None)\
-        .where(object_people_table.c.context_id == context_id))
+    op.execute(object_people_table.update().values(context_id=None)
+               .where(object_people_table.c.context_id == context_id))
 
-    op.execute(object_objectives_table.update().values(context_id=None)\
-        .where(object_objectives_table.c.context_id == context_id))
+    op.execute(object_objectives_table.update().values(context_id=None)
+               .where(object_objectives_table.c.context_id == context_id))
 
-    op.execute(relationships_table.update().values(context_id=None)\
-        .where(relationships_table.c.context_id == context_id))
+    op.execute(relationships_table.update().values(context_id=None)
+               .where(relationships_table.c.context_id == context_id))
 
-    op.execute(program_controls_table.update().values(context_id=None)\
-        .where(program_controls_table.c.context_id == context_id))
+    op.execute(program_controls_table.update().values(context_id=None)
+               .where(program_controls_table.c.context_id == context_id))
 
-    op.execute(program_directives_table.update().values(context_id=None)\
-        .where(program_directives_table.c.context_id == context_id))
+    op.execute(program_directives_table.update().values(context_id=None)
+               .where(program_directives_table.c.context_id == context_id))
 
-    #Remove the role implications that made the program public
+    # Remove the role implications that made the program public
     op.execute(role_implications_table.delete().where(
-      role_implications_table.c.context_id == context_id))
+        role_implications_table.c.context_id == context_id))
 
-    #Create ObjectOwner rows for each ProgramOwner role assignment, delete
-    #the now defunct ProgramOwner assignments
+    # Create ObjectOwner rows for each ProgramOwner role assignment, delete
+    # the now defunct ProgramOwner assignments
     program = connection.execute(
-        select([programs_table.c.id])\
-            .where(programs_table.c.context_id == context_id)).fetchone()
+        select([programs_table.c.id])
+        .where(programs_table.c.context_id == context_id)).fetchone()
     program_owners = connection.execute(
-        select([user_roles_table.c.id, user_roles_table.c.person_id])\
-            .where(
-              and_(
+        select([user_roles_table.c.id, user_roles_table.c.person_id])
+        .where(
+            and_(
                 user_roles_table.c.context_id == context_id,
                 user_roles_table.c.role_id == program_owner_role.id)))
     for program_owner in program_owners:
       connection.execute(
           object_owners_table.insert().values(
-            person_id = program_owner.person_id,
-            ownable_id = program.id,
-            ownable_type = 'Program',
-            modified_by_id = 1,
-            created_at = current_datetime,
-            updated_at = current_datetime,
-            ))
+              person_id=program_owner.person_id,
+              ownable_id=program.id,
+              ownable_type='Program',
+              modified_by_id=1,
+              created_at=current_datetime,
+              updated_at=current_datetime,
+          ))
 
-    #Delete defunct role assignments
+    # Delete defunct role assignments
     connection.execute(
         user_roles_table.delete().where(
-          user_roles_table.c.context_id == context_id))
+            user_roles_table.c.context_id == context_id))
 
-    #Move the program back into the NULL context
-    op.execute(programs_table.update().values(context_id=None)\
-        .where(programs_table.c.context_id == context_id))
+    # Move the program back into the NULL context
+    op.execute(programs_table.update().values(context_id=None)
+               .where(programs_table.c.context_id == context_id))
 
-    #Remove the defunct context
-    op.execute(contexts_table.delete()\
-        .where(contexts_table.c.id == context_id))
+    # Remove the defunct context
+    op.execute(contexts_table.delete()
+               .where(contexts_table.c.id == context_id))

--- a/src/ggrc_workflows/migrations/versions/20140722203407_4b3316aa1acf_move_existing_workflows_to_new_contexts.py
+++ b/src/ggrc_workflows/migrations/versions/20140722203407_4b3316aa1acf_move_existing_workflows_to_new_contexts.py
@@ -1,27 +1,25 @@
 # Copyright (C) 2016 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
-
 """Move existing Workflows to new contexts
 
-Revision ID: 4b3316aa1acf
-Revises: 292222c25829
 Create Date: 2014-07-22 20:34:07.052212
-
 """
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+from alembic import op
+import sqlalchemy as sa
+from datetime import datetime
+from sqlalchemy.sql import table, column, select, and_
 
 # revision identifiers, used by Alembic.
 revision = '4b3316aa1acf'
 down_revision = '292222c25829'
 
 
-from alembic import op
-import sqlalchemy as sa
-from datetime import datetime
-from sqlalchemy.sql import table, column, select, insert, and_
-
-
-contexts_table = table('contexts',
+contexts_table = table(
+    'contexts',
     column('id', sa.Integer),
     column('context_id', sa.Integer),
     column('description', sa.Text),
@@ -30,14 +28,16 @@ contexts_table = table('contexts',
     column('modified_by_id', sa.Integer),
     column('created_at', sa.DateTime),
     column('updated_at', sa.DateTime),
-    )
+)
 
-roles_table = table('roles',
+roles_table = table(
+    'roles',
     column('id', sa.Integer),
     column('name', sa.String),
-    )
+)
 
-user_roles_table = table('user_roles',
+user_roles_table = table(
+    'user_roles',
     column('id', sa.Integer),
     column('context_id', sa.Integer),
     column('role_id', sa.Integer),
@@ -45,9 +45,10 @@ user_roles_table = table('user_roles',
     column('modified_by_id', sa.Integer),
     column('created_at', sa.DateTime),
     column('updated_at', sa.DateTime),
-    )
+)
 
-context_implications_table = table('context_implications',
+context_implications_table = table(
+    'context_implications',
     column('id', sa.Integer),
     column('context_id', sa.Integer),
     column('source_context_id', sa.Integer),
@@ -56,104 +57,119 @@ context_implications_table = table('context_implications',
     column('modified_by_id', sa.Integer),
     column('created_at', sa.DateTime),
     column('updated_at', sa.DateTime),
-    )
+)
 
 
-workflows_table = table('workflows',
+workflows_table = table(
+    'workflows',
     column('id', sa.Integer),
     column('context_id', sa.Integer),
-    )
+)
 
-workflow_objects_table = table('workflow_objects',
+workflow_objects_table = table(
+    'workflow_objects',
     column('id', sa.Integer),
     column('context_id', sa.Integer),
     column('workflow_id', sa.Integer),
-    )
+)
 
-workflow_people_table = table('workflow_people',
+workflow_people_table = table(
+    'workflow_people',
     column('id', sa.Integer),
     column('context_id', sa.Integer),
     column('workflow_id', sa.Integer),
     column('person_id', sa.Integer),
-    )
+)
 
-workflow_tasks_table = table('workflow_tasks',
+workflow_tasks_table = table(
+    'workflow_tasks',
     column('id', sa.Integer),
     column('context_id', sa.Integer),
     column('workflow_id', sa.Integer),
-    )
+)
 
-task_groups_table = table('task_groups',
+task_groups_table = table(
+    'task_groups',
     column('id', sa.Integer),
     column('context_id', sa.Integer),
     column('workflow_id', sa.Integer),
-    )
+)
 
-task_group_objects_table = table('task_group_objects',
+task_group_objects_table = table(
+    'task_group_objects',
     column('id', sa.Integer),
     column('context_id', sa.Integer),
     column('task_group_id', sa.Integer),
-    )
+)
 
-task_group_tasks_table = table('task_group_tasks',
+task_group_tasks_table = table(
+    'task_group_tasks',
     column('id', sa.Integer),
     column('context_id', sa.Integer),
     column('task_group_id', sa.Integer),
-    )
+)
 
 
-cycles_table = table('cycles',
+cycles_table = table(
+    'cycles',
     column('id', sa.Integer),
     column('context_id', sa.Integer),
     column('workflow_id', sa.Integer),
-    )
+)
 
-cycle_task_groups_table = table('cycle_task_groups',
+cycle_task_groups_table = table(
+    'cycle_task_groups',
     column('id', sa.Integer),
     column('context_id', sa.Integer),
     column('cycle_id', sa.Integer),
-    )
+)
 
-cycle_task_entries_table = table('cycle_task_entries',
+cycle_task_entries_table = table(
+    'cycle_task_entries',
     column('id', sa.Integer),
     column('context_id', sa.Integer),
     column('cycle_id', sa.Integer),
-    )
+)
 
-cycle_task_group_objects_table = table('cycle_task_group_objects',
+cycle_task_group_objects_table = table(
+    'cycle_task_group_objects',
     column('id', sa.Integer),
     column('context_id', sa.Integer),
     column('cycle_id', sa.Integer),
-    )
+)
 
-cycle_task_group_object_tasks_table = table('cycle_task_group_object_tasks',
+cycle_task_group_object_tasks_table = table(
+    'cycle_task_group_object_tasks',
     column('id', sa.Integer),
     column('context_id', sa.Integer),
     column('cycle_id', sa.Integer),
-    )
+)
 
 
-object_files_table = table('object_files',
+object_files_table = table(
+    'object_files',
     column('id', sa.Integer),
     column('context_id', sa.Integer),
     column('fileable_id', sa.Integer),
     column('fileable_type', sa.String),
-    )
+)
 
-object_folders_table = table('object_folders',
+object_folders_table = table(
+    'object_folders',
     column('id', sa.Integer),
     column('context_id', sa.Integer),
     column('folderable_id', sa.Integer),
     column('folderable_type', sa.String),
-    )
+)
 
-object_owners_table = table('object_owners',
+object_owners_table = table(
+    'object_owners',
     column('id', sa.Integer),
     column('context_id', sa.Integer),
     column('person_id', sa.Integer),
     column('ownable_id', sa.Integer),
     column('ownable_type', sa.String),
-    )
+)
 
 
 def get_role(name):
@@ -168,42 +184,40 @@ def upgrade():
   # Get the roles we'll need later
   workflow_owner_role = get_role('WorkflowOwner')
   workflow_member_role = get_role('WorkflowMember')
-  basic_workflow_reader_role = get_role('BasicWorkflowReader')
-  workflow_basic_reader_role = get_role('WorkflowBasicReader')
 
   # Get all current workflows
   connection = op.get_bind()
   workflows = connection.execute(
-      select([workflows_table.c.id])\
-          .where(workflows_table.c.context_id == None))
+      select([workflows_table.c.id])
+      .where(workflows_table.c.context_id == None))  # noqa
 
   for workflow in workflows:
     workflow_id = workflow.id
 
     # Create the Workflow context
-    result = connection.execute(
+    connection.execute(
         contexts_table.insert().values(
-          context_id=None,
-          description='',
-          related_object_id=workflow_id,
-          related_object_type='Workflow',
-          modified_by_id=1,
-          created_at=current_datetime,
-          updated_at=current_datetime,
-          ))
+            context_id=None,
+            description='',
+            related_object_id=workflow_id,
+            related_object_type='Workflow',
+            modified_by_id=1,
+            created_at=current_datetime,
+            updated_at=current_datetime,
+        ))
 
     # Get the context id
     context = connection.execute(
         select([contexts_table.c.id]).where(
-          and_(
-            contexts_table.c.related_object_id == workflow_id,
-            contexts_table.c.related_object_type == 'Workflow')
-          )).fetchone()
+            and_(
+                contexts_table.c.related_object_id == workflow_id,
+                contexts_table.c.related_object_type == 'Workflow')
+        )).fetchone()
     context_id = context.id
 
     # Move the Workflow into the new context
-    op.execute(workflows_table.update().values(context_id=context_id)\
-        .where(workflows_table.c.id == workflow_id))
+    op.execute(workflows_table.update().values(context_id=context_id)
+               .where(workflows_table.c.id == workflow_id))
 
   # Now, select *all* workflows, since the rest applies to all equally
   workflows = connection.execute(
@@ -215,64 +229,63 @@ def upgrade():
 
     # Create the Context Implications to/from the Workflow context
     op.execute(context_implications_table.insert().values(
-      source_context_id=context_id,
-      source_context_scope='Workflow',
-      context_id=None,
-      context_scope=None,
-      modified_by_id=1,
-      created_at=current_datetime,
-      updated_at=current_datetime
-      ))
+        source_context_id=context_id,
+        source_context_scope='Workflow',
+        context_id=None,
+        context_scope=None,
+        modified_by_id=1,
+        created_at=current_datetime,
+        updated_at=current_datetime
+    ))
 
     op.execute(context_implications_table.insert().values(
-      source_context_id=None,
-      source_context_scope=None,
-      context_id=context_id,
-      context_scope='Workflow',
-      modified_by_id=1,
-      created_at=current_datetime,
-      updated_at=current_datetime
-      ))
-
+        source_context_id=None,
+        source_context_scope=None,
+        context_id=context_id,
+        context_scope='Workflow',
+        modified_by_id=1,
+        created_at=current_datetime,
+        updated_at=current_datetime
+    ))
 
     # Add role assignments for owners and delete the object_owner relationships
     owners = connection.execute(
-        select([object_owners_table.c.id, object_owners_table.c.person_id])\
-            .where(
-              and_(
+        select([object_owners_table.c.id, object_owners_table.c.person_id])
+        .where(
+            and_(
                 object_owners_table.c.ownable_id == workflow_id,
                 object_owners_table.c.ownable_type == 'Workflow')
-              )).fetchall()
+        )).fetchall()
 
     for owner in owners:
       connection.execute(
-        user_roles_table.insert().values(
-          context_id = context_id,
-          role_id = workflow_owner_role.id,
-          person_id = owner.person_id,
-          modified_by_id = 1,
-          created_at = current_datetime,
-          updated_at = current_datetime,
+          user_roles_table.insert().values(
+              context_id=context_id,
+              role_id=workflow_owner_role.id,
+              person_id=owner.person_id,
+              modified_by_id=1,
+              created_at=current_datetime,
+              updated_at=current_datetime,
           ))
       connection.execute(
-        object_owners_table.delete().where(
-          object_owners_table.c.id == owner.id))
+          object_owners_table.delete().where(
+              object_owners_table.c.id == owner.id))
 
     # Add role assignments for WorkflowPerson objects
     members = connection.execute(
-        select([workflow_people_table.c.person_id])\
-            .where(workflow_people_table.c.workflow_id == workflow_id)
-            ).fetchall()
+        select([workflow_people_table.c.person_id])
+        .where(workflow_people_table.c.workflow_id == workflow_id)
+    ).fetchall()
 
     for member in members:
       connection.execute(
-        user_roles_table.insert().values(
-          context_id = context_id,
-          role_id = workflow_member_role.id,
-          person_id = member.person_id,
-          modified_by_id = 1,
-          created_at = current_datetime,
-          updated_at = current_datetime,
+          user_roles_table.insert().values(
+              context_id=context_id,
+              role_id=workflow_member_role.id,
+              person_id=member.person_id,
+              modified_by_id=1,
+              created_at=current_datetime,
+              updated_at=current_datetime,
           ))
 
     '''
@@ -299,76 +312,76 @@ def upgrade():
     '''
 
     # Update rows for directly-connected tables
-    op.execute(workflow_objects_table.update().values(context_id=context_id)\
-        .where(workflow_objects_table.c.workflow_id == workflow_id))
+    op.execute(workflow_objects_table.update().values(context_id=context_id)
+               .where(workflow_objects_table.c.workflow_id == workflow_id))
 
-    op.execute(workflow_people_table.update().values(context_id=context_id)\
-        .where(workflow_people_table.c.workflow_id == workflow_id))
+    op.execute(workflow_people_table.update().values(context_id=context_id)
+               .where(workflow_people_table.c.workflow_id == workflow_id))
 
-    op.execute(workflow_tasks_table.update().values(context_id=context_id)\
-        .where(workflow_tasks_table.c.workflow_id == workflow_id))
+    op.execute(workflow_tasks_table.update().values(context_id=context_id)
+               .where(workflow_tasks_table.c.workflow_id == workflow_id))
 
-    op.execute(task_groups_table.update().values(context_id=context_id)\
-        .where(task_groups_table.c.workflow_id == workflow_id))
-
-    op.execute(
-        task_group_objects_table.update()\
-            .values(context_id=context_id)\
-            .where(task_group_objects_table.c.task_group_id.in_(
-              select([task_groups_table.c.id])\
-                  .where(task_groups_table.c.workflow_id == workflow_id))))
+    op.execute(task_groups_table.update().values(context_id=context_id)
+               .where(task_groups_table.c.workflow_id == workflow_id))
 
     op.execute(
-        task_group_tasks_table.update()\
-            .values(context_id=context_id)\
-            .where(task_group_tasks_table.c.task_group_id.in_(
-              select([task_groups_table.c.id])\
-                  .where(task_groups_table.c.workflow_id == workflow_id))))
+        task_group_objects_table.update()
+        .values(context_id=context_id)
+        .where(task_group_objects_table.c.task_group_id.in_(
+            select([task_groups_table.c.id])
+            .where(task_groups_table.c.workflow_id == workflow_id))))
 
-    op.execute(cycles_table.update().values(context_id=context_id)\
-        .where(cycles_table.c.workflow_id == workflow_id))
+    op.execute(
+        task_group_tasks_table.update()
+        .values(context_id=context_id)
+        .where(task_group_tasks_table.c.task_group_id.in_(
+            select([task_groups_table.c.id])
+            .where(task_groups_table.c.workflow_id == workflow_id))))
+
+    op.execute(cycles_table.update().values(context_id=context_id)
+               .where(cycles_table.c.workflow_id == workflow_id))
 
     # Update rows for polymorphically-connected tables
-    op.execute(object_files_table.update().values(context_id=context_id)\
-        .where(
-          and_(
+    op.execute(object_files_table.update().values(context_id=context_id)
+               .where(
+        and_(
             object_files_table.c.fileable_id == workflow_id,
             object_files_table.c.fileable_type == 'Workflow')))
 
-    op.execute(object_folders_table.update().values(context_id=context_id)\
-        .where(
-          and_(
+    op.execute(object_folders_table.update().values(context_id=context_id)
+               .where(
+        and_(
             object_folders_table.c.folderable_id == workflow_id,
             object_folders_table.c.folderable_type == 'Workflow')))
 
     # Update rows for cycle-connected tables
     op.execute(
-        cycle_task_entries_table.update()\
-            .values(context_id=context_id)\
-            .where(cycle_task_entries_table.c.cycle_id.in_(
-              select([cycles_table.c.id])\
-                  .where(cycles_table.c.workflow_id == workflow_id))))
+        cycle_task_entries_table.update()
+        .values(context_id=context_id)
+        .where(cycle_task_entries_table.c.cycle_id.in_(
+            select([cycles_table.c.id])
+            .where(cycles_table.c.workflow_id == workflow_id))))
 
     op.execute(
-        cycle_task_groups_table.update()\
-            .values(context_id=context_id)\
-            .where(cycle_task_groups_table.c.cycle_id.in_(
-              select([cycles_table.c.id])\
-                  .where(cycles_table.c.workflow_id == workflow_id))))
+        cycle_task_groups_table.update()
+        .values(context_id=context_id)
+        .where(cycle_task_groups_table.c.cycle_id.in_(
+            select([cycles_table.c.id])
+            .where(cycles_table.c.workflow_id == workflow_id))))
 
     op.execute(
-        cycle_task_group_objects_table.update()\
-            .values(context_id=context_id)\
-            .where(cycle_task_group_objects_table.c.cycle_id.in_(
-              select([cycles_table.c.id])\
-                  .where(cycles_table.c.workflow_id == workflow_id))))
+        cycle_task_group_objects_table.update()
+        .values(context_id=context_id)
+        .where(cycle_task_group_objects_table.c.cycle_id.in_(
+            select([cycles_table.c.id])
+            .where(cycles_table.c.workflow_id == workflow_id))))
 
     op.execute(
-        cycle_task_group_object_tasks_table.update()\
-            .values(context_id=context_id)\
-            .where(cycle_task_group_object_tasks_table.c.cycle_id.in_(
-              select([cycles_table.c.id])\
-                  .where(cycles_table.c.workflow_id == workflow_id))))
+        cycle_task_group_object_tasks_table.update()
+        .values(context_id=context_id)
+        .where(cycle_task_group_object_tasks_table.c.cycle_id.in_(
+            select([cycles_table.c.id])
+            .where(cycles_table.c.workflow_id == workflow_id))))
 
 
 def downgrade():

--- a/test/integration/ggrc/memcache/benchmark_concurrent.py
+++ b/test/integration/ggrc/memcache/benchmark_concurrent.py
@@ -18,140 +18,188 @@ from datetime import datetime
 from copy import deepcopy
 import threading
 
-localhost_headers={
-  'Accept': 'application/json',
-  'Content-Type': 'application/json',
-  'x-requested-by' :'gGRC',
-  'Cookie': 'Please enter cookie'
+localhost_headers = {
+    'Accept': 'application/json',
+    'Content-Type': 'application/json',
+    'x-requested-by': 'gGRC',
+    'Cookie': 'Please enter cookie'
 }
 
-ggrcdev_headers={
-  'Accept': 'application/json',
-  'Content-Type': 'application/json',
-  'x-requested-by' :'gGRC',
-  'Cookie': 'Please enter cookie'
+ggrcdev_headers = {
+    'Accept': 'application/json',
+    'Content-Type': 'application/json',
+    'x-requested-by': 'gGRC',
+    'Cookie': 'Please enter cookie'
 }
 
-appspot_headers={
-  'Accept': 'application/json',
-  'Content-Type': 'application/json',
-  'x-requested-by' :'gGRC',
-  'Cookie': 'Please enter cookie'
+appspot_headers = {
+    'Accept': 'application/json',
+    'Content-Type': 'application/json',
+    'x-requested-by': 'gGRC',
+    'Cookie': 'Please enter cookie'
 }
 
 create_resources = {
- 'regulations': '{"regulation":{"kind":"Regulation","contact":{"id":1260,"type":"Person"},"title":"Benchmark Regulation","description":"Benchmark Regulation","notes":"Benchmark Regulation CREATED","url":"","reference_url":"","slug":"","start_date":"","end_date":"","status":null,"context":{"id":null},"owners":[{"id":1260,"href":"/api/people/1260","type":"Person"}],"provisional_id":"provisional_6741102"}}'
+    'regulations': '{"regulation":{"kind":"Regulation","contact":{"id":1260,"t'
+    'ype":"Person"},"title":"Benchmark Regulation","description":"Benchmark Re'
+    'gulation","notes":"Benchmark Regulation CREATED","url":"","reference_url"'
+    ':"","slug":"","start_date":"","end_date":"","status":null,"context":{"id"'
+    ':null},"owners":[{"id":1260,"href":"/api/people/1260","type":"Person"}],"'
+    'provisional_id":"provisional_6741102"}}'
 }
 
 update_resources = {
- 'regulations': '{"regulation":{"kind":"Regulation","contact":{"id":1260,"href":"/api/people/1260","type":"Person"},"description":"Benchmark Regulation","object_people":[],"program_directives":[],"controls":[],"url":"","type":"Regulation","status":"Draft","owners":[{"id":1260,"href":"/api/people/1260","type":"Person"}],"scope":"","directive_controls":[],"sections":[],"selfLink":"/api/regulations/71","programs":[],"created_at":"2014-03-20T22:09:24Z","updated_at":"2014-03-20T22:09:24Z","object_owners":[{"status":"Draft","modified_by":{"href":"/api/people/1260","id":1260,"type":"Person"},"id":1083,"selfLink":"/api/object_owners/1083","person":{"href":"/api/people/1260","id":1260,"type":"Person"},"context":null,"created_at":"2014-03-20T22:09:24","updated_at":"2014-03-20T22:09:24","type":"ObjectOwner","ownable":{"href":"/api/regulations/71","id":71,"type":"Regulation"}}],"reference_url":"","organization":"","documents":[],"title":"Benchmark Regulation","objectives":[],"modified_by":{"id":1260,"href":"/api/people/1260","type":"Person"},"people":[],"id":71,"notes":"Benchmark Regulation UPDATED 1","version":"","viewLink":"/regulations/71","object_documents":[],"related_sources":[],"related_destinations":[], "slug": "REGULATION-101", "start_date":"","end_date":"","context":{"id":null}}}'
+    'regulations': '{"regulation":{"kind":"Regulation","contact":{"id":1260,"h'
+    'ref":"/api/people/1260","type":"Person"},"description":"Benchmark Regulat'
+    'ion","object_people":[],"program_directives":[],"controls":[],"url":"","t'
+    'ype":"Regulation","status":"Draft","owners":[{"id":1260,"href":"/api/peop'
+    'le/1260","type":"Person"}],"scope":"","directive_controls":[],"sections":'
+    '[],"selfLink":"/api/regulations/71","programs":[],"created_at":"2014-03-2'
+    '0T22:09:24Z","updated_at":"2014-03-20T22:09:24Z","object_owners":[{"statu'
+    's":"Draft","modified_by":{"href":"/api/people/1260","id":1260,"type":"Per'
+    'son"},"id":1083,"selfLink":"/api/object_owners/1083","person":{"href":"/a'
+    'pi/people/1260","id":1260,"type":"Person"},"context":null,"created_at":"2'
+    '014-03-20T22:09:24","updated_at":"2014-03-20T22:09:24","type":"ObjectOwne'
+    'r","ownable":{"href":"/api/regulations/71","id":71,"type":"Regulation"}}]'
+    ',"reference_url":"","organization":"","documents":[],"title":"Benchmark R'
+    'egulation","objectives":[],"modified_by":{"id":1260,"href":"/api/people/1'
+    '260","type":"Person"},"people":[],"id":71,"notes":"Benchmark Regulation U'
+    'PDATED 1","version":"","viewLink":"/regulations/71","object_documents":[]'
+    ',"related_sources":[],"related_destinations":[], "slug": "REGULATION-101"'
+    ', "start_date":"","end_date":"","context":{"id":null}}}'
 }
 
 update_resources2 = {
- 'regulations': '{"regulation":{"kind":"Regulation","contact":{"id":1260,"href":"/api/people/1260","type":"Person"},"description":"Benchmark Regulation","object_people":[],"program_directives":[],"controls":[],"url":"","type":"Regulation","status":"Draft","owners":[{"id":1260,"href":"/api/people/1260","type":"Person"}],"scope":"","directive_controls":[],"sections":[],"selfLink":"/api/regulations/71","programs":[],"created_at":"2014-03-20T22:09:24Z","updated_at":"2014-03-20T22:09:24Z","object_owners":[{"status":"Draft","modified_by":{"href":"/api/people/1260","id":1260,"type":"Person"},"id":1083,"selfLink":"/api/object_owners/1083","person":{"href":"/api/people/1260","id":1260,"type":"Person"},"context":null,"created_at":"2014-03-20T22:09:24","updated_at":"2014-03-20T22:09:24","type":"ObjectOwner","ownable":{"href":"/api/regulations/71","id":71,"type":"Regulation"}}],"reference_url":"","organization":"","documents":[],"title":"Benchmark Regulation","objectives":[],"modified_by":{"id":1260,"href":"/api/people/1260","type":"Person"},"people":[],"id":71,"notes":"Benchmark Regulation UPDATED 2","version":"","viewLink":"/regulations/71","object_documents":[],"related_sources":[],"related_destinations":[],"slug": "REGULATION-101", "start_date":"","end_date":"","context":{"id":null}}}'
+    'regulations': '{"regulation":{"kind":"Regulation","contact":{"id":1260,"h'
+    'ref":"/api/people/1260","type":"Person"},"description":"Benchmark Regulat'
+    'ion","object_people":[],"program_directives":[],"controls":[],"url":"","t'
+    'ype":"Regulation","status":"Draft","owners":[{"id":1260,"href":"/api/peop'
+    'le/1260","type":"Person"}],"scope":"","directive_controls":[],"sections":'
+    '[],"selfLink":"/api/regulations/71","programs":[],"created_at":"2014-03-2'
+    '0T22:09:24Z","updated_at":"2014-03-20T22:09:24Z","object_owners":[{"statu'
+    's":"Draft","modified_by":{"href":"/api/people/1260","id":1260,"type":"Per'
+    'son"},"id":1083,"selfLink":"/api/object_owners/1083","person":{"href":"/a'
+    'pi/people/1260","id":1260,"type":"Person"},"context":null,"created_at":"2'
+    '014-03-20T22:09:24","updated_at":"2014-03-20T22:09:24","type":"ObjectOwne'
+    'r","ownable":{"href":"/api/regulations/71","id":71,"type":"Regulation"}}]'
+    ',"reference_url":"","organization":"","documents":[],"title":"Benchmark R'
+    'egulation","objectives":[],"modified_by":{"id":1260,"href":"/api/people/1'
+    '260","type":"Person"},"people":[],"id":71,"notes":"Benchmark Regulation U'
+    'PDATED 2","version":"","viewLink":"/regulations/71","object_documents":[]'
+    ',"related_sources":[],"related_destinations":[],"slug": "REGULATION-101",'
+    '"start_date":"","end_date":"","context":{"id":null}}}'
 }
 
 mapping_resource = {
- 'regulations' : 'regulation'
+    'regulations': 'regulation'
 }
 
+
 class TestGetThread(threading.Thread):
+
   def __init__(self, name, data, loop_cnt):
     super(TestGetThread, self).__init__()
     self.name = name
     self.data = data
-    self.starttime=None
-    self.endtime=None
+    self.starttime = None
+    self.endtime = None
     self.loop_cnt = loop_cnt
 
   def run(self):
-    self.starttime=datetime.now()
+    self.starttime = datetime.now()
     for cnt in range(self.loop_cnt):
-      #print "Running GET Thread: " + self.name + " Iteration " + str(cnt+1)
+      # print "Running GET Thread: " + self.name + " Iteration " + str(cnt+1)
       if not cnt % 100:
-        print "GET Iteration " + str(cnt+1)  + " of " + str(self.loop_cnt)
+        print "GET Iteration " + str(cnt + 1) + " of " + str(self.loop_cnt)
       benchmark_get(self.data, 1, "Concurrency Test")
-    self.endtime=datetime.now()
+    self.endtime = datetime.now()
+
 
 class TestPutThread(threading.Thread):
+
   def __init__(self, name, put_data, get_data, loop_cnt):
     super(TestPutThread, self).__init__()
     self.name = name
     self.get_data = get_data
     self.put_data = put_data
-    self.starttime=None
-    self.endtime=None
+    self.starttime = None
+    self.endtime = None
     self.loop_cnt = loop_cnt
 
   def run(self):
-    self.starttime=datetime.now()
+    self.starttime = datetime.now()
     for cnt in range(self.loop_cnt):
-      #print "Running PUT/GET Thread: " + self.name + " Iteration " + str(cnt+1)
+      # print "Running PUT/GET Thread: " + self.name + " Iteration " +
+      # str(cnt+1)
       if not cnt % 100:
-        print "PUT/GET Iteration " + str(cnt+1)  + " of " + str(self.loop_cnt)
+        print "PUT/GET Iteration " + str(cnt + 1) + " of " + str(self.loop_cnt)
       for resource, payload in self.put_data.items():
-       json_payload = json.loads(payload)
-       updated_notes = "Benchmark Regulation UPDATED#" + str(cnt+1)
-       json_payload[mapping_resource[resource]]['notes'] = updated_notes
-       self.put_data[resource] = json.dumps(json_payload)
+        json_payload = json.loads(payload)
+        updated_notes = "Benchmark Regulation UPDATED#" + str(cnt + 1)
+        json_payload[mapping_resource[resource]]['notes'] = updated_notes
+        self.put_data[resource] = json.dumps(json_payload)
       benchmark_update(self.put_data, self.get_data, 1)
       benchmark_get(self.get_data, 1, "Concurrency GET Test", updated_notes)
-    self.endtime=datetime.now()
+    self.endtime = datetime.now()
+
 
 def invoke_url(op, prefix, host, url, payload, headers, count):
-  response=None
+  response = None
   for cnt in range(count):
     testurl = prefix + "://" + host + url
-    starttime=datetime.now()
     if op == 'post':
       response = requests.post(testurl, data=payload, headers=headers)
-    elif op =='get':
+    elif op == 'get':
       response = requests.get(testurl, headers=headers, params=payload)
-    elif op =='put':
+    elif op == 'put':
       response = requests.put(testurl, data=payload, headers=headers)
     else:
       response = requests.delete(testurl, headers=headers)
-    endtime=datetime.now()
-    #print "Test Iteration #: " + str(cnt+1) +  " url: " + testurl + " time: " + str(endtime-starttime) + "..."
     time.sleep(1)
   return response
 
-localhost_url="localhost:8080"
-ggrcdev_url="ggrc-dev.googleplex.com"
-appspot_url="grc-audit.appspot.com"
+localhost_url = "localhost:8080"
+ggrcdev_url = "ggrc-dev.googleplex.com"
+appspot_url = "grc-audit.appspot.com"
 
-#headers=appspot_headers
-#targethost=appspot_url
-targethost=localhost_url
-headers=localhost_headers
-num_iterations=1
-etag=10023
-#prefix="https"
-prefix="http"
+# headers=appspot_headers
+# targethost=appspot_url
+targethost = localhost_url
+headers = localhost_headers
+num_iterations = 1
+etag = 10023
+# prefix="https"
+prefix = "http"
+
 
 def benchmark_delete(resource_data, num_iterations):
-  payload=None
+  payload = None
   for resource, data in resource_data.items():
-    #print "Test DELETE for resource: " + resource + " with ids " + str(data['ids'])
+    # print "Test DELETE for resource: " + resource + " with ids " +
+    # str(data['ids'])
     testurl = "/api/" + resource
     ids = data['ids']
-    etags= data['etag']
+    etags = data['etag']
     last_modified_items = data['last-modified']
     for cnt in range(len(ids)):
       id = ids[cnt]
-      delete_headers=deepcopy(headers)
+      delete_headers = deepcopy(headers)
       delete_headers['If-Match'] = etags[cnt]
       delete_headers['If-Unmodified-Since'] = last_modified_items[cnt]
-      response = invoke_url('delete', prefix, targethost, testurl+ "/" + str(id), payload, delete_headers, num_iterations)
+      response = invoke_url('delete', prefix, targethost, testurl +
+                            "/" + str(id), payload, delete_headers,
+                            num_iterations)
       if response.status_code != 200:
         print "DELETE Failed: " + str(response.status_code)
 
+
 def benchmark_get(resource_data, num_iterations, name, verify_notes=None):
   for resource, data in resource_data.items():
-    #print "Test GET for owner: " + name + " resource: " + resource + " with ids " + str(data['ids'])
+    # print "Test GET for owner: " + name + " resource: " + resource + " with
+    # ids " + str(data['ids'])
     testurl = "/api/" + resource
     ids = ""
-    idslen= len(data['ids'])
+    idslen = len(data['ids'])
     cnt = 0
     for id in data['ids']:
       cnt = cnt + 1
@@ -159,76 +207,79 @@ def benchmark_get(resource_data, num_iterations, name, verify_notes=None):
         ids = ids + str(id)
       else:
         ids = ids + str(id) + ","
-    payload = {'id__in': ids, '_': str(etag) }
-    response = invoke_url('get', prefix, targethost, testurl, payload, headers, num_iterations)
+    payload = {'id__in': ids, '_': str(etag)}
+    response = invoke_url('get', prefix, targethost,
+                          testurl, payload, headers, num_iterations)
     if response.status_code != 200:
       print "GET Failed: " + str(response.status_code)
     else:
-      #print "GET Successful: " + str(response.status_code)
-      #print "Cache Hit/Miss: " + response.headers['X-GGRC-Cache']
       json_response = json.loads(response.text)
-      #print "Regulation etag: " + str(response.headers['etag'])
-      #print "Regulation last-modified: " + str(response.headers['last-modified'])
-      #resource_data[resource]['last-modified']=[]
-      #resource_data[resource]['etag']=[]
       responses = json_response[resource + '_collection'][resource]
       for item in responses:
         if verify_notes is not None:
-          #print "UPDATE Notes: " + verify_notes
+          # print "UPDATE Notes: " + verify_notes
           if item["notes"] != verify_notes:
-            print "[WARN]: UPDATE Notes: " + verify_notes + "GET Notes: " + item["notes"]
-        #resource_data[resource]['last-modified'].append(response.headers['last-modified'])
-        #resource_data[resource]['etag'].append(response.headers['etag'])
+            print "[WARN]: UPDATE Notes: " + verify_notes + "GET Notes: " + \
+                item["notes"]
+
 
 def benchmark_create(resource_data, resource_cnt, num_iterations):
-  resource_dict={}
+  resource_dict = {}
   for resource, payload in resource_data.items():
     testurl = "/api/" + resource
-    resource_dict[resource]={}
-    resource_dict[resource]['ids']=[]
-    resource_dict[resource]['etag']=[]
-    resource_dict[resource]['last-modified']=[]
-    resource_dict[resource]['json-response']=[]
+    resource_dict[resource] = {}
+    resource_dict[resource]['ids'] = []
+    resource_dict[resource]['etag'] = []
+    resource_dict[resource]['last-modified'] = []
+    resource_dict[resource]['json-response'] = []
     for cnt in range(resource_cnt):
-      response = invoke_url('post', prefix, targethost, testurl, payload, headers, num_iterations)
+      response = invoke_url('post', prefix, targethost,
+                            testurl, payload, headers, num_iterations)
       if response.status_code == 201:
         json_response = json.loads(response.text)
         for key, value in json_response.items():
           resource_dict[resource]['ids'].append(value['id'])
           resource_dict[resource]['etag'].append(response.headers['etag'])
-          resource_dict[resource]['last-modified'].append(response.headers['last-modified'])
-          #print "Test CREATE for resource: " + resource + " with id " + str(value[u'id'])
+          resource_dict[resource][
+              'last-modified'].append(response.headers['last-modified'])
+          # print "Test CREATE for resource: " + resource + " with id " +
+          # str(value[u'id'])
       else:
         print "CREATE Failed: " + str(response.status_code)
         return None
   return resource_dict
 
+
 def benchmark_update(resource_data, resource_dict, num_iterations):
   for resource, payload in resource_data.items():
     testurl = "/api/" + resource
     ids = resource_dict[resource]['ids']
-    #print "Test UPDATE for resource: " + resource + " with ids " + str(ids)
-    etags= resource_dict[resource]['etag']
+    # print "Test UPDATE for resource: " + resource + " with ids " + str(ids)
+    etags = resource_dict[resource]['etag']
     last_modified_items = resource_dict[resource]['last-modified']
     for cnt in range(len(ids)):
-      #print etags
-      #print last_modified_items
+      # print etags
+      # print last_modified_items
       id = ids[cnt]
-      update_headers=deepcopy(headers)
+      update_headers = deepcopy(headers)
       update_headers['If-Match'] = etags[cnt]
       update_headers['If-Unmodified-Since'] = str(last_modified_items[cnt])
-      response = invoke_url('put', prefix, targethost, testurl + '/' + str(id), payload, update_headers, num_iterations)
+      response = invoke_url('put', prefix, targethost, testurl +
+                            '/' + str(id), payload, update_headers,
+                            num_iterations)
       if response.status_code != 200:
         print "UPDATE Failed: " + str(response.status_code)
       else:
         resource_dict[resource]['etag'][cnt] = response.headers['etag']
-        resource_dict[resource]['last-modified'][cnt] = response.headers['last-modified']
-        #print response.headers['etag']
-        #print response.headers['last-modified']
+        resource_dict[resource][
+            'last-modified'][cnt] = response.headers['last-modified']
+        # print response.headers['etag']
+        # print response.headers['last-modified']
+
 
 def run_singlethreaded_tests():
-  print "Running single threaded benchmark tests (create, GET, PUT, GET, DELETE) ..."
-  resource_dict=benchmark_create(create_resources, 1, 1)
+  print "Running single threaded benchmark tests create, GET, PUT, GET, DELETE"
+  resource_dict = benchmark_create(create_resources, 1, 1)
   if resource_dict is not None:
     benchmark_get(resource_dict, 1, "Single Threaded GET Test")
     benchmark_update(update_resources, resource_dict, 1)
@@ -239,25 +290,33 @@ def run_singlethreaded_tests():
   else:
     print "ERROR: Unable to run benchmark tests"
 
+
 def run_concurrent_tests(loop_cnt):
   print "Running Benchmark Concurrent tests PUT/GET and GET..."
-  resource_dict=benchmark_create(create_resources, 1, 1)
+  resource_dict = benchmark_create(create_resources, 1, 1)
   if resource_dict is not None:
-    get_threads=[]
-    put_threads=[]
+    get_threads = []
+    put_threads = []
     for cnt in range(1):
-     get_threads.append(TestGetThread("GET Thread" + str(cnt+1), resource_dict, loop_cnt+20))
-     put_threads.append(TestPutThread("PUT Thread" + str(cnt+1), update_resources, resource_dict, loop_cnt))
+      get_threads.append(TestGetThread(
+          "GET Thread" + str(cnt + 1), resource_dict, loop_cnt + 20))
+      put_threads.append(TestPutThread(
+          "PUT Thread" + str(cnt + 1), update_resources, resource_dict,
+          loop_cnt))
     for cnt in range(1):
-     get_threads[cnt].start()
-     put_threads[cnt].start()
+      get_threads[cnt].start()
+      put_threads[cnt].start()
     for cnt in range(1):
-     get_threads[cnt].join()
-     put_threads[cnt].join()
-     benchmark_delete(resource_dict, 1)
+      get_threads[cnt].join()
+      put_threads[cnt].join()
+      benchmark_delete(resource_dict, 1)
     for cnt in range(1):
-      print get_threads[cnt].name + " starttime: " + str(get_threads[cnt].starttime) + " endtime: " + str(get_threads[cnt].endtime)
-      print put_threads[cnt].name + " starttime: " + str(put_threads[cnt].starttime) + " endtime: " + str(put_threads[cnt].endtime)
+      print get_threads[cnt].name + " starttime: " + str(
+          get_threads[cnt].starttime) + " endtime: " + str(
+          get_threads[cnt].endtime)
+      print put_threads[cnt].name + " starttime: " + str(
+          put_threads[cnt].starttime) + " endtime: " + str(
+          put_threads[cnt].endtime)
 
 if __name__ == '__main__':
   run_singlethreaded_tests()


### PR DESCRIPTION
This just clears all pep8 errors from worst offending files.

The only code changes in these files are not used vars removed and a few print statemens removed. Other than that, all changes are pure PEP8 compatibility changes.