### PR TITLE
QUICK-FIX Fix error when opening request log with deleted mapped requests

### DIFF
--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -573,16 +573,6 @@
         this._super.apply(this, arguments);
       }
     },
-    display_name: function () {
-      var desc = this.title;
-      var max_len = 20;
-      var out_name = desc;
-      // Truncate if greater than max_len chars
-      if (desc.length > max_len) {
-        out_name = desc.slice(0, max_len) + ' ...';
-      }
-      return 'Request "' + out_name + '"';
-    },
     form_preload: function (new_object_form, object_params) {
       var audit;
       var auditId;

--- a/src/ggrc/assets/javascripts/models/cacheable.js
+++ b/src/ggrc/assets/javascripts/models/cacheable.js
@@ -1106,7 +1106,13 @@ can.Model('can.Model.Cacheable', {
     return serial;
   },
   display_name: function () {
-    return this.title || this.name;
+    var displayName = this.title || this.name;
+
+    if (_.isUndefined(displayName)) {
+      return '"' + this.type + ' ID: ' + this.id + '" (DELETED)';
+    }
+
+    return displayName;
   },
   display_type: function () {
     return this.type;

--- a/src/ggrc/assets/javascripts/models/tests/request_model_spec.js
+++ b/src/ggrc/assets/javascripts/models/tests/request_model_spec.js
@@ -19,7 +19,8 @@ describe('CMS.Models.Request', function () {
     beforeEach(function () {
       instance = new can.Map({
         title: 'Request 18',
-        id: 18
+        id: 18,
+        type: 'Request'
       });
       method = Model.prototype.display_name.bind(instance);
     });
@@ -28,7 +29,7 @@ describe('CMS.Models.Request', function () {
       var result;
       instance.attr('title', undefined);
       result = method();
-      expect(result).toEqual('"Request 18" (DELETED)');
+      expect(result).toEqual('"Request ID: 18" (DELETED)');
     });
   });
 });

--- a/src/ggrc/assets/javascripts/models/tests/request_model_spec.js
+++ b/src/ggrc/assets/javascripts/models/tests/request_model_spec.js
@@ -1,0 +1,34 @@
+/*!
+  Copyright (C) 2016 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+describe('CMS.Models.Request', function () {
+  'use strict';
+
+  var Model;
+
+  beforeAll(function () {
+    Model = CMS.Models.Request;
+  });
+
+  describe('display_name() method', function () {
+    var method;  // the method under test
+    var instance;
+
+    beforeEach(function () {
+      instance = new can.Map({
+        title: 'Request 18',
+        id: 18
+      });
+      method = Model.prototype.display_name.bind(instance);
+    });
+
+    it('returns a generic name for deleted objects', function () {
+      var result;
+      instance.attr('title', undefined);
+      result = method();
+      expect(result).toEqual('"Request 18" (DELETED)');
+    });
+  });
+});


### PR DESCRIPTION
Original error USER-BUG-1.17 was fixed for quince already, however I found another issue with deleted mapped requests.

If a mapped request gets deleted, opening request log for
non-deleted requests throws an error (`.length of undefined`). This
outputs a string with deleted request's ID and a marking that it
was deleted.