### PR TITLE
ISS-117 Hide generate assessments icon for Readers

### DIFF
--- a/src/ggrc/assets/mustache/base_objects/generate_assessments_button.mustache
+++ b/src/ggrc/assets/mustache/base_objects/generate_assessments_button.mustache
@@ -7,10 +7,18 @@
   {{#if_helpers '\
     #if_equals' model.shortName 'Control' '\
     or #if_equals' model.shortName 'Assessment'}}
-    <li class="generate-control-assessments">
-      <a href="javascript://">
-        <i class="fa fa-magic" rel="tooltip" data-placement="left" title="" data-original-title="Generate Assessments"></i>
-      </a>
-    </li>
+      {{#is_allowed 'update' parent_instance context="for"}}
+        <li class="generate-control-assessments">
+          <a href="javascript://">
+            <i
+              class="fa fa-magic"
+              rel="tooltip"
+              data-placement="left"
+              title=""
+              data-original-title="Generate Assessments"
+             ></i>
+          </a>
+        </li>
+      {{/is_allowed}}
   {{/if_helpers}}
 {{/if_instance_of}}


### PR DESCRIPTION
_(Section 2, bug 1.42)_

This PR makes sure that the generate assessments magic wand icon is now shown if the user doesn't have permissions for the action.

**Steps to reproduce:**
- Create an Audit.
- Create assessment and set Global Reader as assessor. Use reader@reciprocitylabs.com. 
- Login under Global Reader 
- Display Audit -> Assessments tab

**Actual Result:** “Generate Assessments” icon is available under Assessor (Global Reader)
**Expected Result:** “Generate Assessments” icon is not available under Assessor (Global Reader)
