### PR TITLE
QUICK-FIX Undo the CA refresh fix

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
@@ -1515,7 +1515,6 @@ can.Control('CMS.Controllers.TreeViewNode', {
 
   '{instance} change': function (inst, ev, prop) {
     if (prop === 'custom_attribute_values') {
-      this.draw_placeholder();
       this.draw_node();
     }
   },


### PR DESCRIPTION
This pull request reverts the PR #4202 that caused problems with opening tree view subtiers.

**Steps to reproduce:**
- Open a tree view, e.g. the Audits tab on the Dashboard.
- Expand the top-tier audit.
- Expand that Audit's sub-tier
- Expand another Audit's sub-tier

**Expected result:** The sub-tier is expanded
**Actual result:** The while top tier gets collapsed

Note that this PR will re-introduce the issue fixed in #4202, i.e. the CA values do not get refreshed in tree view when editing then in the tree view's item info panel. In an offline discussion we concluded that it's best to wait for the CA backend changes before solving any of the issues related to them - if they still happen to exist at that point.

@hyperNURb When this gets merged, can you just please mark the issue fixed by #4202 as reopened? Thanks.

