### PR TITLE
QUICK-FIX Update api response codes

### DIFF
--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -1274,10 +1274,10 @@ class Resource(ModelView):
 
   @staticmethod
   def _make_error_from_exception(exc):
-    """Return a 403-code with the exception message."""
+    """Return a 400-code with the exception message."""
     message = translate_message(exc)
     current_app.logger.warn(message)
-    return (403, message)
+    return (400, message)
 
   def collection_post(self):  # noqa
     with benchmark("collection post"):
@@ -1312,7 +1312,7 @@ class Resource(ModelView):
       with benchmark("collection post > body loop: {}".format(len(body))):
         try:
           self.collection_post_loop(body, res, no_result, running_async)
-        except (IntegrityError, ValidationError) as e:
+        except (IntegrityError, ValidationError, ValueError) as e:
           res.append(self._make_error_from_exception(e))
           db.session.rollback()
         except Exception as e:

--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -734,10 +734,10 @@ class Resource(ModelView):
             return self.delete(*args, **kwargs)
           else:
             raise NotImplementedError()
-        except (IntegrityError, ValidationError) as err:
+        except (IntegrityError, ValidationError, ValueError) as err:
           message = translate_message(err)
           current_app.logger.warn(message)
-          return (message, 403, [])
+          return (message, 400, [])
         except Exception as err:
           current_app.logger.exception(err)
           raise

--- a/test/integration/ggrc/services/test_collection_post.py
+++ b/test/integration/ggrc/services/test_collection_post.py
@@ -11,18 +11,23 @@ from integration.ggrc import services
 
 
 class TestCollectionPost(services.TestCase):
+  """Test for collection post api calls."""
 
-  def get_location(self, response):
+  @staticmethod
+  def get_location(response):
     """Ignore the `http://localhost` prefix of the Location"""
     return response.headers['Location'][16:]
 
-  def headers(self, *args, **kwargs):
+  @staticmethod
+  def headers(*args, **kwargs):
+    """Get request headers."""
     ret = list(args)
     ret.append(('X-Requested-By', 'Unit Tests'))
     ret.extend(kwargs.items())
     return ret
 
   def test_collection_post_successful(self):
+    """Test normal successful collection post call."""
     data = json.dumps(
         {'services_test_mock_model': {'foo': 'bar', 'context': None}})
     self.client.get("/login")
@@ -50,7 +55,8 @@ class TestCollectionPost(services.TestCase):
     self.assertEqual(
         'bar', response.json['test_model_collection']['test_model'][0]['foo'])
 
-  def test_collection_post_successful_single_array(self):
+  def test_successful_single_array(self):
+    """Test collection post successful single array."""
     data = json.dumps(
         [{'services_test_mock_model': {'foo': 'bar', 'context': None}}])
     self.client.get("/login")
@@ -71,7 +77,8 @@ class TestCollectionPost(services.TestCase):
     self.assertEqual(
         'bar', response.json['test_model_collection']['test_model'][0]['foo'])
 
-  def test_collection_post_successful_multiple(self):
+  def test_successful_multiple(self):
+    """Test collection post successful multiple."""
     data = json.dumps([
         {'services_test_mock_model': {'foo': 'bar1', 'context': None}},
         {'services_test_mock_model': {'foo': 'bar2', 'context': None}},
@@ -95,7 +102,8 @@ class TestCollectionPost(services.TestCase):
     self.assertEqual(
         2, len(response.json['test_model_collection']['test_model']))
 
-  def test_collection_post_successful_multiple_with_errors(self):
+  def test_multiple_with_errors(self):
+    """Test collection post successful multiple with errors."""
     data = json.dumps([
         {'services_test_mock_model':
          {'foo': 'bar1', 'code': 'f1', 'context': None}},
@@ -121,7 +129,8 @@ class TestCollectionPost(services.TestCase):
     self.assertEqual(
         0, len(response.json['test_model_collection']['test_model']))
 
-  def test_collection_post_bad_request(self):
+  def test_post_bad_request(self):
+    """Test collection post with invalid content."""
     response = self.client.post(
         self.mock_url(),
         content_type='application/json',
@@ -130,7 +139,8 @@ class TestCollectionPost(services.TestCase):
     )
     self.assert400(response)
 
-  def test_collection_post_bad_content_type(self):
+  def test_bad_content_type(self):
+    """Test post with bad content type."""
     response = self.client.post(
         self.mock_url(),
         content_type='text/plain',
@@ -139,7 +149,7 @@ class TestCollectionPost(services.TestCase):
     )
     self.assertStatus(response, 415)
 
-  def test_collection_post_relationship(self):
+  def test_post_relationship(self):
     """Test integrity error on relationship collection post.
 
     Posting duplicate relationships should have a mechanism for removing

--- a/test/integration/ggrc/services/test_collection_post.py
+++ b/test/integration/ggrc/services/test_collection_post.py
@@ -114,8 +114,8 @@ class TestCollectionPost(services.TestCase):
         headers=self.headers(),
     )
 
-    self.assertEqual(403, response.status_code)
-    self.assertEqual([403], [i[0] for i in response.json])
+    self.assertEqual(400, response.status_code)
+    self.assertEqual([400], [i[0] for i in response.json])
     response = self.client.get(self.mock_url(), headers=self.headers())
     self.assert200(response)
     self.assertEqual(

--- a/test/integration/ggrc/services/test_common.py
+++ b/test/integration/ggrc/services/test_common.py
@@ -98,6 +98,25 @@ class TestServices(services.TestCase):
         original_headers['Etag'], response.headers['Etag'])
     self.assertEqual('baz', response.json['services_test_mock_model']['foo'])
 
+  def test_put_value_error(self):
+    """Test response code for put request with value errors."""
+    mock = self.mock_model(foo='buzz')
+    response = self.client.get(self.mock_url(mock.id), headers=self.headers())
+    obj = response.json
+    obj['services_test_mock_model']['validated'] = 'Value Error'
+    url = urlparse(obj['services_test_mock_model']['selfLink']).path
+    original_headers = dict(response.headers)
+    response = self.client.put(
+        url,
+        data=json.dumps(obj),
+        headers=self.headers(
+            ('If-Unmodified-Since', original_headers['Last-Modified']),
+            ('If-Match', original_headers['Etag']),
+        ),
+        content_type='application/json',
+    )
+    self.assertEqual(response.status_code, 400)
+
   def test_put_bad_request(self):
     mock = self.mock_model(foo='tough')
     response = self.client.get(self.mock_url(mock.id), headers=self.headers())

--- a/test/integration/ggrc/services/test_response_codes.py
+++ b/test/integration/ggrc/services/test_response_codes.py
@@ -1,0 +1,80 @@
+# Copyright (C) 2016 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Tests API response codes."""
+
+import json
+from mock import patch
+
+from integration.ggrc import services
+
+
+class TestCollectionPost(services.TestCase):
+  """Test response codes for post requests."""
+
+  def setUp(self):
+    super(TestCollectionPost, self).setUp()
+    self.client.get("/login")
+
+  def _post(self, data):
+    return self.client.post(
+        self.mock_url(),
+        content_type='application/json',
+        data=data,
+        headers=[('X-Requested-By', 'Unit Tests')],
+    )
+
+  def test_post_successful_response(self):
+    """Test successful model post call."""
+    data = json.dumps({
+        'services_test_mock_model': {
+            'foo': 'bar',
+            'code': '1',
+            'validated': 'good',
+            'context': None
+        }}
+    )
+    response = self._post(data)
+    self.assertStatus(response, 201)
+
+  def test_post_bad_request(self):
+    """Test all bad request calls."""
+    data = json.dumps({
+        'services_test_mock_model': {
+            'foo': 'bar',
+            'code': '1',
+            'validated': 'Value Error',
+            'context': None
+        }}
+    )
+    response = self._post(data)
+    self.assertStatus(response, 400)
+
+    data = json.dumps({
+        'services_test_mock_model': {
+            'foo': 'bar',
+            'code': '1',
+            'validated': 'Validation Error',
+            'context': None
+        }}
+    )
+    response = self._post(data)
+    self.assertStatus(response, 400)
+
+    response = self._post("what")
+    self.assertStatus(response, 400)
+
+  @patch("ggrc.rbac.permissions.is_allowed_create_for")
+  def test_post_forbidden(self, is_allowed):
+    """Test posting a forbidden model."""
+    is_allowed.return_value = False
+    data = json.dumps({
+        'services_test_mock_model': {
+            'foo': 'bar',
+            'code': '1',
+            'validated': 'good',
+            'context': None
+        }}
+    )
+    response = self._post(data)
+    self.assertStatus(response, 403)


### PR DESCRIPTION
This PR makes sure that we don't return 403 (Forbidden) for invalid requests and such.

The PR  is build on top of https://github.com/google/ggrc-core/pull/4212 and will be rebased once that one is merged.