### PR TITLE
FEATURE Extend query api with "ids" and "count"

### DIFF
--- a/test/integration/ggrc/services/test_query.py
+++ b/test/integration/ggrc/services/test_query.py
@@ -144,6 +144,77 @@ class TestAdvancedQueryAPI(TestCase):
 
     self.assertEqual(programs_limit["total"], programs_no_limit["total"])
 
+  def test_query_count(self):
+    """The value of "count" is same for "values" and "count" queries."""
+    data_values = {
+        "object_name": "Program",
+        "type": "values",
+        "filters": {
+            "expression": {
+                "left": "title",
+                "op": {"name": "~"},
+                "right": "Cat ipsum",
+            },
+        },
+    }
+    response_values = json.loads(self._post(data_values).data)[0]
+    programs_values = response_values.get("Program")
+    self.assertIsNot(programs_values, None)
+
+    data_count = {
+        "object_name": "Program",
+        "type": "count",
+        "filters": {
+            "expression": {
+                "left": "title",
+                "op": {"name": "~"},
+                "right": "Cat ipsum",
+            },
+        },
+    }
+    response_count = json.loads(self._post(data_count).data)[0]
+    programs_count = response_count.get("Program")
+    self.assertIsNot(programs_count, None)
+
+    self.assertEqual(programs_values["count"], programs_count["count"])
+
+  def test_query_ids(self):
+    """The ids are the same for "values" and "ids" queries."""
+    data_values = {
+        "object_name": "Program",
+        "type": "values",
+        "filters": {
+            "expression": {
+                "left": "title",
+                "op": {"name": "~"},
+                "right": "Cat ipsum",
+            },
+        },
+    }
+    response_values = json.loads(self._post(data_values).data)[0]
+    programs_values = response_values.get("Program")
+    self.assertIsNot(programs_values, None)
+
+    data_ids = {
+        "object_name": "Program",
+        "type": "ids",
+        "filters": {
+            "expression": {
+                "left": "title",
+                "op": {"name": "~"},
+                "right": "Cat ipsum",
+            },
+        },
+    }
+    response_ids = json.loads(self._post(data_ids).data)[0]
+    programs_ids = response_ids.get("Program")
+    self.assertIsNot(programs_ids, None)
+
+    self.assertEqual(
+        set(obj.get("id") for obj in programs_values["values"]),
+        set(programs_ids["ids"]),
+    )
+
   @SkipTest
   def test_mapped_query(self):
     pass

--- a/test/integration/ggrc/services/test_query.py
+++ b/test/integration/ggrc/services/test_query.py
@@ -357,3 +357,131 @@ class TestAdvancedQueryAPI(TestCase):
     # In the end, instead of returning mapped object stubs like we do now, we'd
     # just return a self link for fetching those objects.
     pass
+
+  def test_multiple_queries(self):
+    """Multiple queries POST is identical to multiple single-query POSTs."""
+    data_list = [
+        {
+            "object_name": "Program",
+            "order_by": [{
+                "name": "title",
+            }],
+            "limit": [1, 12],
+            "filters": {
+                "expression": {
+                    "left": "title",
+                    "op": {"name": "~"},
+                    "right": "Cat ipsum",
+                },
+            },
+        },
+        {
+            "object_name": "Program",
+            "type": "values",
+            "filters": {
+                "expression": {
+                    "left": "title",
+                    "op": {"name": "~"},
+                    "right": "Cat ipsum",
+                },
+            },
+        },
+        {
+            "object_name": "Program",
+            "type": "count",
+            "filters": {
+                "expression": {
+                    "left": "title",
+                    "op": {"name": "~"},
+                    "right": "Cat ipsum",
+                },
+            },
+        },
+        {
+            "object_name": "Program",
+            "type": "ids",
+            "filters": {
+                "expression": {
+                    "left": "title",
+                    "op": {"name": "~"},
+                    "right": "Cat ipsum",
+                },
+            },
+        },
+        {
+            "object_name": "Program",
+            "filters": {
+                "expression": {
+                    "left": "title",
+                    "op": {"name": "="},
+                    "right": "Cat ipsum 1",
+                },
+            },
+        },
+        {
+            "object_name": "Program",
+            "filters": {
+                "expression": {
+                    "left": "title",
+                    "op": {"name": "~"},
+                    "right": "1",
+                },
+            },
+        },
+        {
+            "object_name": "Program",
+            "filters": {
+                "expression": {
+                    "left": "title",
+                    "op": {"name": "!="},
+                    "right": "Cat ipsum 1",
+                },
+            },
+        },
+        {
+            "object_name": "Program",
+            "filters": {
+                "expression": {
+                    "left": "title",
+                    "op": {"name": "!~"},
+                    "right": "`",
+                },
+            },
+        },
+        {
+            "object_name": "Program",
+            "filters": {
+                "expression": {
+                    "left": "effective date",
+                    "op": {"name": "<"},
+                    "right": "05/18/2015",
+                },
+            },
+        },
+        {
+            "object_name": "Program",
+            "filters": {
+                "expression": {
+                    "left": "effective date",
+                    "op": {"name": ">"},
+                    "right": "05/18/2015",
+                },
+            },
+        },
+        {
+            "object_name": "Regulation",
+            "fields": ["description", "notes"],
+            "filters": {
+                "expression": {
+                    "op": {"name": "text_search"},
+                    "text": "ea",
+                },
+            },
+        },
+    ]
+
+    response_multiple_posts = [json.loads(self._post(data).data)[0]
+                               for data in data_list]
+    response_single_post = json.loads(self._post(data_list).data)
+
+    self.assertEqual(response_multiple_posts, response_single_post)


### PR DESCRIPTION
This PR adds two features to the query api:
- Support for "ids" and "count" query types (the query should contain a field `"type": "ids"` or `"type": "count"` to use it):

  - if type is `"ids"`, the result won't contain `"values"`, but instead will contain a list of object ids in `"ids"`;
  - if type is `"count"`, the result won't contain `"values"` or `"ids"`, but will contain only the `"count"` of filtered objects;

- Support for multiple query objects in a single POST request as per the advanced query api spec.

This PR also fixes a regression with unavailable text_search that appeared after my refactoring of `converters.query_helper`.

There are tests included for most of the current functionality of the query API.