### PR TITLE
ISSUE-1.63 Allow GE to edit owned objects

### DIFF
--- a/src/ggrc/assets/javascripts/permission.js
+++ b/src/ggrc/assets/javascripts/permission.js
@@ -142,6 +142,7 @@
       var resources = type_obj.resources || [];
       var context = instance.context || {id: null};
       var conditions = conditions_by_context[context.id];
+      var contexts_by_type = type_obj.contexts || [];
       var condition;
       var i;
 
@@ -152,7 +153,7 @@
       if (~resources.indexOf(instance.id)) {
         return true;
       }
-      
+
       if (!conditions && contexts_by_type.indexOf(context.id) > -1) {
         return true;
       }

--- a/src/ggrc/assets/javascripts/permission.js
+++ b/src/ggrc/assets/javascripts/permission.js
@@ -142,22 +142,19 @@
       var resources = type_obj.resources || [];
       var context = instance.context || {id: null};
       var conditions = conditions_by_context[context.id];
-      var contexts_by_type = type_obj.contexts || [];
+      var contexts = type_obj.contexts || [];
       var condition;
       var i;
 
       if (checkAdmin(0) || checkAdmin(null)) {
         return true;
       }
-
       if (~resources.indexOf(instance.id)) {
         return true;
       }
-
-      if (!conditions && contexts_by_type.indexOf(context.id) > -1) {
+      if (!conditions && contexts.indexOf(context.id) > -1) {
         return true;
       }
-      
       if (!this._is_allowed(permissions,
           new Permission(action, instance_type, null)) &&
         !this._is_allowed(permissions,

--- a/src/ggrc/assets/javascripts/permission.js
+++ b/src/ggrc/assets/javascripts/permission.js
@@ -152,6 +152,11 @@
       if (~resources.indexOf(instance.id)) {
         return true;
       }
+      
+      if (!conditions && contexts_by_type.indexOf(context.id) > -1) {
+        return true;
+      }
+      
       if (!this._is_allowed(permissions,
           new Permission(action, instance_type, null)) &&
         !this._is_allowed(permissions,


### PR DESCRIPTION
Please confirm that if GGRC.permissions.[action].[object_type].conditions are not specified we can check permissions based on GGRC.permissions.[action].[object_type].contexts and current object.context.id.