### PR TITLE
QUICK-FIX Add db.Index statements to revisions table

### DIFF
--- a/src/ggrc/models/revision.py
+++ b/src/ggrc/models/revision.py
@@ -28,7 +28,13 @@ class Revision(Base, db.Model):
 
   @staticmethod
   def _extra_table_args(_):
-    return (db.Index('revisions_modified_by', 'modified_by_id'),)
+    return (
+        db.Index("revisions_modified_by", "modified_by_id"),
+        db.Index("fk_revisions_resource", "resource_type", "resource_id"),
+        db.Index("fk_revisions_source", "source_type", "source_id"),
+        db.Index("fk_revisions_destination",
+                 "destination_type", "destination_id"),
+    )
 
   _publish_attrs = [
       'resource_id',


### PR DESCRIPTION
Revisions table has indexes set up correctly (#3537, commit 344e58e198575358ffaccf5bad6997f9b1ba00fd) but the index are not in the
model which can cause issues with alembic (alembic would add
`drop_index` statements to autogenerated migrations).