### PR TITLE
QUICK-FIX Fix return type to be a set instead of list

### DIFF
--- a/src/ggrc/models/relationship.py
+++ b/src/ggrc/models/relationship.py
@@ -180,7 +180,7 @@ class Relatable(object):
     Args:
       _types: A set of object types
     Returns:
-      A list (or subset if _types is specified) of related objects.
+      A set (or subset if _types is specified) of related objects.
     """
     # pylint: disable=not-an-iterable
     source_objs = [obj.source for obj in self.related_sources]
@@ -188,7 +188,7 @@ class Relatable(object):
     related = source_objs + dest_objs
 
     if _types:
-      return [obj for obj in related if obj.type in _types]
+      return {obj for obj in related if obj.type in _types}
     return set(related)
 
   _publish_attrs = [


### PR DESCRIPTION
Previously we only returned `set` if no `types_` was specified - this will consolidate return type to a set.