### PR TITLE
ISSUE-1.107 Add description field in unified mapper tree view

### DIFF
--- a/src/ggrc/assets/mustache/base_objects/tier2_content.mustache
+++ b/src/ggrc/assets/mustache/base_objects/tier2_content.mustache
@@ -6,11 +6,12 @@
 {{> /static/mustache/base_objects/dropdown_menu_tier2.mustache}}
 
 <div class="tier-content">
-  {{{render '/static/mustache/base_objects/general_info.mustache' instance=instance }}}
-  {{{renderLive '/static/mustache/base_objects/mappings_detail.mustache' result=result parent_instance=parent_instance}}}
+  {{> /static/mustache/base_objects/general_info.mustache}}
+  {{> /static/mustache/base_objects/mappings_detail.mustache}}
+  {{> /static/mustache/base_objects/description.mustache'}}
   {{^if_equals instance.class.table_singular 'person'}}
-    {{{renderLive '/static/mustache/base_objects/contacts.mustache' instance=instance}}}
+    {{> /static/mustache/base_objects/contacts.mustache}}
   {{/if_equals}}
-  {{{renderLive '/static/mustache/base_objects/urls.mustache' instance=instance}}}
-  {{{renderLive '/static/mustache/base_objects/notes_and_code.mustache' instance=instance}}}
+  {{> /static/mustache/base_objects/urls.mustache}}
+  {{> /static/mustache/base_objects/notes_and_code.mustache}}
 </div>


### PR DESCRIPTION
Subject: "Map Access Group to Assessment" inified mapper: add description into object info when you expand the line in search result list.
Details: 
Create an Audit
Display Assessments tab
Create  Assessment object
Click + icon to map objects (Unified mapper is displayed with list of available Access Groups)
Click triangle icon before access group title to expand the object’s details
Observe Description field
Actual Result:  Description field is missing on the expanded Access Group object.
Expected Result: Description field is available on the unified mapper. 
Workaround: Edit the object from unified mapper to see the Description field.
