### PR TITLE
FEATURE Add "ready_for_completion" field

### DIFF
--- a/src/ggrc/builder/json.py
+++ b/src/ggrc/builder/json.py
@@ -645,7 +645,12 @@ class Builder(AttributeInfo):
   def publish_attr(
           self, obj, attr_name, inclusions, include, inclusion_filter):
     class_attr = getattr(obj.__class__, attr_name)
-    if isinstance(class_attr, AssociationProxy):
+    publish_raw = attr_name in getattr(obj.__class__, "_publish_raw", [])
+    if publish_raw:
+      # The attribute provides a raw value that requires no special processing.
+      # This is used for special mapings such as custom attribute values.
+      return getattr(obj, attr_name)
+    elif isinstance(class_attr, AssociationProxy):
       if getattr(class_attr, 'publish_raw', False):
         published_attr = getattr(obj, attr_name)
         if hasattr(published_attr, "copy"):

--- a/src/ggrc/models/comment.py
+++ b/src/ggrc/models/comment.py
@@ -98,6 +98,7 @@ class Comment(Relatable, Described, Documentable, Ownable, Base, db.Model):
   custom_attribute_definition = db.relationship(
       'CustomAttributeDefinition',
       uselist=False,
+      backref='associated_comments',
   )
 
   # REST properties

--- a/src/ggrc/models/mixins/validate_on_complete.py
+++ b/src/ggrc/models/mixins/validate_on_complete.py
@@ -32,12 +32,12 @@ class ValidateOnComplete(object):
     """Comments related to self via Relationship table."""
     from ggrc.models.relationship import Relationship
     comment_id = case(
-        [(Relationship.destination_type == 'Comment',
+        [(Relationship.destination_type == "Comment",
           Relationship.destination_id)],
         else_=Relationship.source_id,
     )
     commentable_id = case(
-        [(Relationship.destination_type == 'Comment',
+        [(Relationship.destination_type == "Comment",
           Relationship.source_id)],
         else_=Relationship.destination_id,
     )
@@ -55,8 +55,8 @@ class ValidateOnComplete(object):
     """Special query to fetch all required fields."""
     query = super(ValidateOnComplete, cls).eager_query()
     return query.options(
-        orm.subqueryload('_related_comments')
-           .joinedload('revision'),
+        orm.subqueryload("_related_comments")
+           .joinedload("revision"),
     )
 
   def _get_custom_attributes_comments(self):
@@ -77,7 +77,7 @@ class ValidateOnComplete(object):
                               Flags.evidence_required correspond to the values
                               from multi_choice_mandatory bitmasks
     """
-    flags = namedtuple('Flags', ['comment_required', 'evidence_required'])
+    flags = namedtuple("Flags", ["comment_required", "evidence_required"])
 
     def make_flags(multi_choice_mandatory):
       flags_mask = int(multi_choice_mandatory)
@@ -92,12 +92,12 @@ class ValidateOnComplete(object):
       return {}
     else:
       return dict(zip(
-          cad.multi_choice_options.split(','),
+          cad.multi_choice_options.split(","),
           (make_flags(mask)
-           for mask in cad.multi_choice_mandatory.split(',')),
+           for mask in cad.multi_choice_mandatory.split(",")),
       ))
 
-  @validates('status')
+  @validates("status")
   def validate_status(self, key, value):
     """Check that mandatory fields and CAs are filled in.
 
@@ -117,7 +117,7 @@ class ValidateOnComplete(object):
                                     for cav in self.custom_attribute_values}
       self._ca_comment_map = {
           int(comment.revision
-              .content['custom_attribute_id']): comment
+              .content["custom_attribute_id"]): comment
           for comment in comments
       }
       for cad in self.custom_attribute_definitions:
@@ -132,7 +132,7 @@ class ValidateOnComplete(object):
           errors += self._check_dropdown_requirements(cad, cav)
 
       if errors:
-        raise ValidationError('. '.join(errors))
+        raise ValidationError(". ".join(errors))
 
     return value
 
@@ -140,7 +140,7 @@ class ValidateOnComplete(object):
   def _check_mandatory_value(cad, cav):
     if cad.mandatory and (not cav or not cav.attribute_value):
       return [
-          'Value for definition #{cad.id} is missing or empty'
+          "Value for definition #{cad.id} is missing or empty"
           .format(cad=cad),
       ]
     else:

--- a/test/integration/ggrc/models/mixins/test_validate_on_complete.py
+++ b/test/integration/ggrc/models/mixins/test_validate_on_complete.py
@@ -18,7 +18,7 @@ class CustomAttributeMock(object):
   """Defines CustomAttributeDefinition and CustomAttributeValue objects"""
 
   # pylint: disable=too-many-arguments
-  def __init__(self, attributable, attribute_type='Text', mandatory=False,
+  def __init__(self, attributable, attribute_type="Text", mandatory=False,
                dropdown_parameters=None, global_=False, value=None):
     self.attributable = attributable
     self.attribute_type = attribute_type
@@ -67,7 +67,7 @@ class TestValidateOnComplete(TestCase):
     _, assessment = GENERATOR.generate_object(
         Assessment,
         data={
-            'status': Assessment.PROGRESS_STATE,
+            "status": Assessment.PROGRESS_STATE,
         },
     )
     return assessment
@@ -89,8 +89,8 @@ class TestValidateOnComplete(TestCase):
 
   def test_validates_with_no_mandatory_ca(self):
     """Validation ok with no CA-introduced restrictions."""
-    CustomAttributeMock(self.assessment, attribute_type='Text')
-    CustomAttributeMock(self.assessment, attribute_type='Checkbox')
+    CustomAttributeMock(self.assessment, attribute_type="Text")
+    CustomAttributeMock(self.assessment, attribute_type="Checkbox")
     self.refresh(self.assessment)
 
     self.assessment.status = self.assessment.FINAL_STATE
@@ -109,7 +109,7 @@ class TestValidateOnComplete(TestCase):
 
   def test_validates_with_mandatory_filled_ca(self):
     """Validation ok if mandatory CA is filled."""
-    CustomAttributeMock(self.assessment, mandatory=True, value='Foo')
+    CustomAttributeMock(self.assessment, mandatory=True, value="Foo")
     self.refresh(self.assessment)
 
     self.assessment.status = self.assessment.FINAL_STATE
@@ -129,7 +129,7 @@ class TestValidateOnComplete(TestCase):
   def test_validates_with_mandatory_filled_global_ca(self):
     """Validation ok if global mandatory CA is filled."""
     CustomAttributeMock(self.assessment, mandatory=True, global_=True,
-                        value='Foo')
+                        value="Foo")
     self.refresh(self.assessment)
 
     self.assessment.status = self.assessment.FINAL_STATE
@@ -140,9 +140,9 @@ class TestValidateOnComplete(TestCase):
     """Validation fails if comment required by CA is missing."""
     CustomAttributeMock(
         self.assessment,
-        attribute_type='Dropdown',
-        dropdown_parameters=('foo,comment_required', '0,1'),
-        value='comment_required',
+        attribute_type="Dropdown",
+        dropdown_parameters=("foo,comment_required", "0,1"),
+        value="comment_required",
     )
     self.refresh(self.assessment)
 
@@ -155,17 +155,17 @@ class TestValidateOnComplete(TestCase):
     """Validation ok if comment required by CA is present."""
     ca = CustomAttributeMock(
         self.assessment,
-        attribute_type='Dropdown',
-        dropdown_parameters=('foo,comment_required', '0,1'),
-        value='comment_required',
+        attribute_type="Dropdown",
+        dropdown_parameters=("foo,comment_required", "0,1"),
+        value="comment_required",
     )
     _, comment = GENERATOR.generate_comment(
         commentable=self.assessment,
-        assignee_type='Assessor',
-        description='Mandatory comment',
+        assignee_type="Assessor",
+        description="Mandatory comment",
         custom_attribute_revision_upd={
-            'custom_attribute_value': {
-                'id': ca.value.id,
+            "custom_attribute_value": {
+                "id": ca.value.id,
             },
         },
     )

--- a/test/integration/ggrc/models/mixins/test_validate_on_complete.py
+++ b/test/integration/ggrc/models/mixins/test_validate_on_complete.py
@@ -176,69 +176,63 @@ class TestValidateOnComplete(TestCase):
 
     self.assertEqual(self.assessment.status, self.assessment.FINAL_STATE)
 
-  def test_ready_for_completion_with_no_ca(self):
-    """Ready for completion with no CA restrictions."""
-    ready_for_completion = self.assessment.ready_for_completion
+  def test_preconditions_failed_with_no_ca(self):
+    """No preconditions failed with no CA restrictions."""
+    preconditions_failed = self.assessment.preconditions_failed
 
-    self.assertEqual(ready_for_completion["ready"], True)
-    self.assertFalse(ready_for_completion.get("invalid_attributes"))
+    self.assertFalse(preconditions_failed)
 
-  def test_ready_for_completion_with_no_mandatory_ca(self):
-    """Ready for completion with no CA-introduced restrictions."""
+  def test_preconditions_failed_with_no_mandatory_ca(self):
+    """No preconditions failed with no CA-introduced restrictions."""
     CustomAttributeMock(self.assessment, attribute_type="Text")
     CustomAttributeMock(self.assessment, attribute_type="Checkbox")
     self.refresh(self.assessment)
 
-    ready_for_completion = self.assessment.ready_for_completion
+    preconditions_failed = self.assessment.preconditions_failed
 
-    self.assertEqual(ready_for_completion["ready"], True)
-    self.assertFalse(ready_for_completion.get("invalid_attributes"))
+    self.assertFalse(preconditions_failed)
 
-  def test_ready_for_completion_with_mandatory_empty_ca(self):
-    """Not ready for completion if mandatory CA is empty."""
+  def test_preconditions_failed_with_mandatory_empty_ca(self):
+    """Some preconditions failed if mandatory CA is empty."""
     ca = CustomAttributeMock(self.assessment, mandatory=True)
     self.refresh(self.assessment)
 
-    ready_for_completion = self.assessment.ready_for_completion
+    preconditions_failed = self.assessment.preconditions_failed
 
-    self.assertEqual(ready_for_completion["ready"], False)
-    self.assertEqual(ready_for_completion["invalid_attributes"],
-                     [{"id": ca.definition.id, "errors": ["value"]}])
+    self.assertEqual(preconditions_failed,
+                     {ca.definition.id: ["value"]})
 
-  def test_ready_for_completion_with_mandatory_filled_ca(self):
-    """Ready for completion if mandatory CA is filled."""
+  def test_preconditions_failed_with_mandatory_filled_ca(self):
+    """No preconditions failed if mandatory CA is filled."""
     CustomAttributeMock(self.assessment, mandatory=True, value="Foo")
     self.refresh(self.assessment)
 
-    ready_for_completion = self.assessment.ready_for_completion
+    preconditions_failed = self.assessment.preconditions_failed
 
-    self.assertEqual(ready_for_completion["ready"], True)
-    self.assertFalse(ready_for_completion.get("invalid_attributes"))
+    self.assertFalse(preconditions_failed)
 
-  def test_ready_for_completion_with_mandatory_empty_global_ca(self):
-    """Not ready for completion if global mandatory CA is empty."""
+  def test_preconditions_failed_with_mandatory_empty_global_ca(self):
+    """Some preconditions failed if global mandatory CA is empty."""
     ca = CustomAttributeMock(self.assessment, mandatory=True, global_=True)
     self.refresh(self.assessment)
 
-    ready_for_completion = self.assessment.ready_for_completion
+    preconditions_failed = self.assessment.preconditions_failed
 
-    self.assertEqual(ready_for_completion["ready"], False)
-    self.assertEqual(ready_for_completion["invalid_attributes"],
-                     [{"id": ca.definition.id, "errors": ["value"]}])
+    self.assertEqual(preconditions_failed,
+                     {ca.definition.id: ["value"]})
 
-  def test_ready_for_completion_with_mandatory_filled_global_ca(self):
-    """Ready for completion if global mandatory CA is filled."""
+  def test_preconditions_failed_with_mandatory_filled_global_ca(self):
+    """No preconditions failed if global mandatory CA is filled."""
     CustomAttributeMock(self.assessment, mandatory=True, global_=True,
                         value="Foo")
     self.refresh(self.assessment)
 
-    ready_for_completion = self.assessment.ready_for_completion
+    preconditions_failed = self.assessment.preconditions_failed
 
-    self.assertEqual(ready_for_completion["ready"], True)
-    self.assertFalse(ready_for_completion.get("invalid_attributes"))
+    self.assertFalse(preconditions_failed)
 
-  def test_ready_for_completion_with_missing_mandatory_comment(self):
-    """Not ready for completion if comment required by CA is missing."""
+  def test_preconditions_failed_with_missing_mandatory_comment(self):
+    """Some preconditions failed if comment required by CA is missing."""
     ca = CustomAttributeMock(
         self.assessment,
         attribute_type="Dropdown",
@@ -247,14 +241,13 @@ class TestValidateOnComplete(TestCase):
     )
     self.refresh(self.assessment)
 
-    ready_for_completion = self.assessment.ready_for_completion
+    preconditions_failed = self.assessment.preconditions_failed
 
-    self.assertEqual(ready_for_completion["ready"], False)
-    self.assertEqual(ready_for_completion["invalid_attributes"],
-                     [{"id": ca.definition.id, "errors": ["comment"]}])
+    self.assertEqual(preconditions_failed,
+                     {ca.definition.id: ["comment"]})
 
-  def test_ready_for_completion_with_present_mandatory_comment(self):
-    """Ready for completion if comment required by CA is present."""
+  def test_preconditions_failed_with_present_mandatory_comment(self):
+    """No preconditions failed if comment required by CA is present."""
     ca = CustomAttributeMock(
         self.assessment,
         attribute_type="Dropdown",
@@ -274,7 +267,6 @@ class TestValidateOnComplete(TestCase):
     GENERATOR.generate_relationship(self.assessment, comment)
     self.refresh(self.assessment)
 
-    ready_for_completion = self.assessment.ready_for_completion
+    preconditions_failed = self.assessment.preconditions_failed
 
-    self.assertEqual(ready_for_completion["ready"], True)
-    self.assertFalse(ready_for_completion.get("invalid_attributes"))
+    self.assertFalse(preconditions_failed)


### PR DESCRIPTION
~~Depends on #4196 and can't be merged before it.~~

This PR adds a field that can be used to disable "Complete" button on Assessment page on the frontend. This field is filled in with the same logic that is used to validate if Assessment can be moved into "Completed" state.

The syntax of the field is as follows:
```js
"ready_for_completion": {
    "ready": bool,  // true if the Assessment can be completed, false otherwise
    "invalid_attributes": [{"id": int /* the id of a CA definition that blocks the completion */,
                            "errors": [str] /* a list of unsatisfied requirements */}],
}
```

Possible values for `errors` are: `"mandatory"` (missing mandatory value), `"comment"` (missing mandatory comment), `"evidence"` (missing mandatory evidence, not implemented yet).