### PR TITLE
Frontend permission fixes

### DIFF
--- a/src/ggrc/assets/javascripts/permission.js
+++ b/src/ggrc/assets/javascripts/permission.js
@@ -141,8 +141,7 @@
       var conditions_by_context = type_obj.conditions || {};
       var resources = type_obj.resources || [];
       var context = instance.context || {id: null};
-      var conditions = conditions_by_context[context.id];
-      var contexts = type_obj.contexts || [];
+      var conditions = conditions_by_context[context.id] || [];
       var condition;
       var i;
 
@@ -152,9 +151,6 @@
       if (~resources.indexOf(instance.id)) {
         return true;
       }
-      if (!conditions && contexts.indexOf(context.id) > -1) {
-        return true;
-      }
       if (!this._is_allowed(permissions,
           new Permission(action, instance_type, null)) &&
         !this._is_allowed(permissions,
@@ -162,9 +158,6 @@
         return false;
       }
       // Check any conditions applied per instance
-      if (!conditions) {
-        return false;
-      }
       if (conditions.length === 0) {
         return true;
       }

--- a/src/ggrc/assets/mustache/base_objects/dropdown_menu.mustache
+++ b/src/ggrc/assets/mustache/base_objects/dropdown_menu.mustache
@@ -9,7 +9,7 @@
    or #if' is_info_pin '\
    and #if' instance.viewLink '\
    or #is_allowed' 'update' instance '\
-   ' context='for'}}
+   ' _4_context='for'}}
 <div class="details-wrap">
   <a class="btn btn-draft dropdown-toggle" href="#" data-toggle="dropdown">
     <span class="bubble"></span>

--- a/src/ggrc/assets/mustache/sections/dropdown_menu.mustache
+++ b/src/ggrc/assets/mustache/sections/dropdown_menu.mustache
@@ -9,7 +9,7 @@
    or #if' is_info_pin '\
    and #if' instance.viewLink '\
    or #is_allowed' 'update' instance '\
-   ' context='for'}}
+   ' _4_context='for'}}
 <div class="details-wrap">
   <a class="btn btn-small btn-draft dropdown-toggle" href="#" data-toggle="dropdown"><i class="fa fa-cog"></i></a>
   <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">


### PR DESCRIPTION
This issue was caused by PR #3990 which disabled deletion of objects
Person/Cycle objects, but it mishandled permission checks without
conditions.

This commit also reverts the changes made in PR #4233 as the fix is no
longer needed