### PR TITLE
QUICK-FIX Rename Person component

### DIFF
--- a/src/ggrc/assets/javascripts/components/person/person.js
+++ b/src/ggrc/assets/javascripts/components/person/person.js
@@ -12,7 +12,7 @@
 
   // the component's configuration object (i.e. its constructor's prototype)
   var component = {
-    tag: 'person',
+    tag: 'person-info',
 
     template: can.view(
       GGRC.mustache_path +

--- a/src/ggrc/assets/javascripts/components/person/tests/person_spec.js
+++ b/src/ggrc/assets/javascripts/components/person/tests/person_spec.js
@@ -51,10 +51,11 @@ describe('GGRC.Components.personItem', function () {
         });
         CMS.Models.Person.cache[42] = person42;
 
-        template = can.view.mustache('<person person-id="42"></person>');
+        template = can.view
+          .mustache('<person-info person-id="42"></person-info>');
         frag = template();
         frag = $(frag);
-        component = frag.find('person').control();
+        component = frag.find('person-info').control();
 
         expect(component.scope.attr('personObj')).toBe(person42);
       }
@@ -67,11 +68,12 @@ describe('GGRC.Components.personItem', function () {
           id: 123, name: 'Mike', email: 'mike@mike.com'
         });
 
-        template = can.view.mustache('<person person-id="123"></person>');
+        template = can.view
+          .mustache('<person-info person-id="123"></person-info>');
         frag = template();
 
         frag = $(frag);
-        component = frag.find('person').control();
+        component = frag.find('person-info').control();
 
         delete CMS.Models.Person.cache[123];
 
@@ -90,13 +92,14 @@ describe('GGRC.Components.personItem', function () {
           id: 123, name: 'John', email: 'john@doe.com'
         });
 
-        template = can.view.mustache('<person person-id="123"></person>');
+        template = can.view
+          .mustache('<person-info person-id="123"></person-info>');
         frag = template();
 
         CMS.Models.Person.cache[123] = person123;
 
         frag = $(frag);
-        component = frag.find('person').control();
+        component = frag.find('person-info').control();
 
         dfdFindOne.resolve(fetchedPerson);
 

--- a/src/ggrc/assets/javascripts/models/person.js
+++ b/src/ggrc/assets/javascripts/models/person.js
@@ -1,104 +1,106 @@
 /*!
-    Copyright (C) 2016 Google Inc.
-    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
-*/
+ Copyright (C) 2016 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
 
-//= require can.jquery-all
-//= require models/cacheable
+// require can.jquery-all
+// require models/cacheable
 
-(function(ns, can) {
-
-can.Model.Cacheable("CMS.Models.Person", {
-  root_object : "person"
-  , root_collection : "people"
-  , category : "entities"
-  , findAll : "GET /api/people"
-  , findOne : "GET /api/people/{id}"
-  , create : "POST /api/people"
-  , update : "PUT /api/people/{id}"
-  , destroy : "DELETE /api/people/{id}"
-  , search : function(request, response) {
-    return $.ajax({
-      type : "get"
-      , url : "/api/people"
-      , dataType : "json"
-      , data : {s : request.term}
-      , success : function(data) {
-        response($.map( data, function( item ) {
-          return can.extend({}, item.person, {
-            label: item.person.email
-            , value: item.person.id
-          });
-        }));
-      }
-    });
-  }
-  , is_custom_attributable: true
-  , attributes : {
-      context : "CMS.Models.Context.stub"
-    , modified_by : "CMS.Models.Person.stub"
-    , object_people : "CMS.Models.ObjectPerson.stubs"
-    , language : "CMS.Models.Option.stub"
-    , user_roles : "CMS.Models.UserRole.stubs"
-    , name : "trimmed"
-    , email : "trimmedLower"
-    , custom_attribute_values : "CMS.Models.CustomAttributeValue.stubs"
-  }
-  , defaults : {
-    name : ""
-    , email : ""
-    , contact : null
-    , owners : null
-  }
-  , convert : {
-    trimmed : function (val) {
-      return (val && val.trim) ? val.trim() : val;
+(function (ns, can) {
+  can.Model.Cacheable('CMS.Models.Person', {
+    root_object: 'person',
+    root_collection: 'people',
+    category: 'entities',
+    findAll: 'GET /api/people',
+    findOne: 'GET /api/people/{id}',
+    create: 'POST /api/people',
+    update: 'PUT /api/people/{id}',
+    destroy: 'DELETE /api/people/{id}',
+    search: function (request, response) {
+      return can.ajax({
+        type: 'get',
+        url: '/api/people',
+        dataType: 'json',
+        data: {s: request.term},
+        success: function (data) {
+          response(can.$.map(data, function (item) {
+            return can.extend({}, item.person, {
+              label: item.person.email,
+              value: item.person.id
+            });
+          }));
+        }
+      });
     },
-    trimmedLower : function (val) {
-      return ((val && val.trim) ? val.trim() : val).toLowerCase();
-    }
-  }
-  , serialize : {
-    trimmed : function (val) {
-      return (val && val.trim) ? val.trim() : val;
+    is_custom_attributable: true,
+    attributes: {
+      context: 'CMS.Models.Context.stub',
+      modified_by: 'CMS.Models.Person.stub',
+      object_people: 'CMS.Models.ObjectPerson.stubs',
+      language: 'CMS.Models.Option.stub',
+      user_roles: 'CMS.Models.UserRole.stubs',
+      name: 'trimmed',
+      email: 'trimmedLower',
+      custom_attribute_values: 'CMS.Models.CustomAttributeValue.stubs'
     },
-    trimmedLower : function (val) {
-      return ((val && val.trim) ? val.trim() : val).toLowerCase();
-    }
-  }
-  , findInCacheByEmail : function(email) {
-    var result = null, that = this;
-    can.each(Object.keys(this.cache || {}), function(k) {
-      if (that.cache[k].email === email) {
-        result = that.cache[k];
-        return false;
+    defaults: {
+      name: '',
+      email: '',
+      contact: null,
+      owners: null
+    },
+    convert: {
+      trimmed: function (val) {
+        return (val && val.trim) ? val.trim() : val;
+      },
+      trimmedLower: function (val) {
+        return ((val && val.trim) ? val.trim() : val).toLowerCase();
       }
-    });
-    return result;
-  }
-  , tree_view_options: {
-      show_view: GGRC.mustache_path + "/people/tree.mustache"
-    , header_view : GGRC.mustache_path + "/people/tree_header.mustache"
-    , footer_view : GGRC.mustache_path + "/people/tree_footer.mustache"
-    , add_item_view : GGRC.mustache_path + "/people/tree_add_item.mustache"
-    }
-  , list_view_options: {
-      find_params: { "__sort": "name,email" }
-    }
-  , init : function() {
-    var rEmail = /^[-!#$%&\'*+\\.\/0-9=?A-Z^_`{|}~]+@([-0-9A-Z]+\.)+([0-9A-Z]){2,4}$/i;
-    this._super.apply(this, arguments);
+    },
+    serialize: {
+      trimmed: function (val) {
+        return (val && val.trim) ? val.trim() : val;
+      },
+      trimmedLower: function (val) {
+        return ((val && val.trim) ? val.trim() : val).toLowerCase();
+      }
+    },
+    findInCacheByEmail: function (email) {
+      var result = null;
+      var that = this;
+      can.each(Object.keys(this.cache || {}), function (k) {
+        if (that.cache[k].email === email) {
+          result = that.cache[k];
+          return false;
+        }
+      });
+      return result;
+    },
+    tree_view_options: {
+      show_view: GGRC.mustache_path + '/people/tree.mustache',
+      header_view: GGRC.mustache_path + '/people/tree_header.mustache',
+      footer_view: GGRC.mustache_path + '/people/tree_footer.mustache',
+      add_item_view: GGRC.mustache_path + '/people/tree_add_item.mustache'
+    },
+    list_view_options: {
+      find_params: {__sort: 'name,email'}
+    },
+    init: function () {
+      var rEmail =
+        /^[-!#$%&*+\\.\/0-9=?A-Z^_`{|}~]+@([-0-9A-Z]+\.)+([0-9A-Z]){2,4}$/i;
+      this._super.apply(this, arguments);
 
-    this.validateNonBlank('email');
-    this.validateFormatOf('email', rEmail);
-  }
-}, {
-  display_name : function() {
-    return this.email;
-  }
-  , autocomplete_label : function() {
-    return this.name ? this.name + " <span class=\"url-link\">" + this.email + "</span>" : this.email;
-  }
-});
-
-})(this, can);
+      this.validateNonBlank('email');
+      this.validateFormatOf('email', rEmail);
+    }
+  }, {
+    display_name: function () {
+      return this.email;
+    },
+    autocomplete_label: function () {
+      return this.name ?
+      this.name + '<span class="url-link">' + this.email + '</span>' :
+        this.email;
+    }
+  });
+})(window, can);

--- a/src/ggrc/assets/mustache/assessment_templates/info.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/info.mustache
@@ -65,7 +65,7 @@
                 <ul>
                   {{#each default_people.assessors}}
                     <li>
-                      <person editable="true" person-id="{{.}}"></person>
+                      <person-info editable="true" person-id="{{.}}"></person-info>
                     </li>
                   {{/each}}
                 </ul>
@@ -88,7 +88,7 @@
                 <ul>
                   {{#each default_people.verifiers}}
                     <li>
-                      <person editable="true" person-id="{{.}}"></person>
+                      <person-info editable="true" person-id="{{.}}"></person-info>
                     </li>
                   {{/each}}
                 </ul>

--- a/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
@@ -143,10 +143,10 @@
               {{/instance.computed_errors.assessorsList}}
 
               {{#each instance.assessorsList}}
-                <person
+                <person-info
                   editable="true"
                   person-id="{{@key}}"
-                  can-person-remove="instance.assessorRemoved"></person>
+                  can-person-remove="instance.assessorRemoved"></person-info>
               {{/each}}
             {{/if}}
           </div>
@@ -183,10 +183,10 @@
               {{/instance.computed_errors.verifiersList}}
 
               {{#each instance.verifiersList}}
-                <person
+                <person-info
                   editable="true"
                   person-id="{{@key}}"
-                  can-person-remove="instance.verifierRemoved"></person>
+                  can-person-remove="instance.verifierRemoved"></person-info>
               {{/each}}
             {{/if}}
           </div>

--- a/src/ggrc/assets/mustache/audits/extended_info.mustache
+++ b/src/ggrc/assets/mustache/audits/extended_info.mustache
@@ -30,7 +30,7 @@
     <div class="span12">
       <h6>Audit Lead</h6>
       <p class="oneline">
-        <person empty-text="Not assigned" person-obj="instance.contact"></person>
+        <person-info empty-text="Not assigned" person-obj="instance.contact"></person-info>
       </p>
     </div>
   </div>
@@ -85,7 +85,7 @@
               {{#each authorizations}}
                 <li>
                   {{#using auditor=auditors.0.person}}
-                    <person empty-text="Not assigned" person-obj="instance.person"></person>
+                    <person-info empty-text="Not assigned" person-obj="instance.person"></person-info>
                   {{/using}}
                 </li>
               {{/each}}

--- a/src/ggrc/assets/mustache/components/inline_edit/person.mustache
+++ b/src/ggrc/assets/mustache/components/inline_edit/person.mustache
@@ -8,7 +8,7 @@
     <a href="#" can-click="unsetPerson" class="inline-block">
       <i class="fa fa-times" aria-hidden="true"></i>
     </a>
-    <person class="inline-block" person-obj="context.value"></person>
+    <person-info class="inline-block" person-obj="context.value"></person-info>
   {{/if}}
   <autocomplete
     search-items-type="Person"
@@ -18,7 +18,7 @@
   ></autocomplete>
 {{else}}
   {{#if context.value}}
-    <person person-obj="context.value"></person>
+    <person-info person-obj="context.value"></person-info>
   {{else}}
     <span class="empty-message">No person</span>
   {{/if}}

--- a/src/ggrc_workflows/assets/mustache/base_objects/approval_link.mustache
+++ b/src/ggrc_workflows/assets/mustache/base_objects/approval_link.mustache
@@ -88,7 +88,7 @@
                   <span class="setup-link">
                     Review in progress
                     {{#current_cycle_assignee instance}}
-                      by <person class="inline-block" person-obj="person"></person>
+                      by <person-info class="inline-block" person-obj="person"></person-info>
                     {{/current_cycle_assignee}}
                   </span>
                 {{/if_equals}}


### PR DESCRIPTION
Can JS has a known issue with components named with a single word - they might not be rendered and initialised correctly.    