### PR TITLE
ISS-2-1.48 Remove filtering from custom attributes list

### DIFF
--- a/src/ggrc/assets/mustache/custom_attribute_definitions/tree_header.mustache
+++ b/src/ggrc/assets/mustache/custom_attribute_definitions/tree_header.mustache
@@ -3,26 +3,12 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
 
-{{{> "/static/mustache/base_objects/tree_view_filter.mustache"}}}
-<header class="header sticky sticky-header tree-header {{#filter_is_hidden}}no-filter{{/filter_is_hidden}}">
+<header class="header tree-header no-filter">
   <div class="row-fluid">
     <div class="span{{display_options.title_width}}">
       <div class="title-heading oneline">
-        <span class="widget-col-title" data-field="title|description_inline|name|email">
           Object Type
-          <i class="fa fa-caret-up"></i>
-        </span>
       </div>
-    </div>
-
-    <div class="span{{display_options.selectable_width}}">
-      &nbsp;
-    </div>
-
-    <div class="span{{display_options.action_width}}">
-      <ul class="tree-action-list">
-        {{{> "/static/mustache/base_objects/filter_trigger.mustache}}}
-      </ul>
     </div>
   </div>
 </header>


### PR DESCRIPTION
_(issue 1.48, section 2)_

This fixes the issue with filtering under the admin panel's custom attributes tab.

Since fixing the filtering functionality would be time-consuming, and because the list of custom attributes is relatively short, it was decided that simply removing the filtering functionality would be the best option.

---

**Steps to reproduce:**
- Go to Admin Dashboard
- Open Custom Attributes tab HNB
- Type “co” into filter textbox and click Filter button

**Actual Result:** Script error _"Uncaught TypeError: Cannot read property 'toLowerCase' of undefined"_ appears.

**Expected Result:**  Inform user properly that user use incorrect values in filter textbox or disable filter button till user fix existing filter criteria (the same as we use for mandatory fields validation)
_NOTE: obsolete, please the the explanation above)_