### PR TITLE
QUICK-FIX assessment_template import/export

### DIFF
--- a/src/ggrc/converters/handlers/default_people.py
+++ b/src/ggrc/converters/handlers/default_people.py
@@ -8,7 +8,7 @@ These should be used on default verifiers and default assessors.
 
 from flask import json
 
-from ggrc.models import AssessmentTemplate
+from ggrc.models import AssessmentTemplate, Person
 from ggrc.converters import errors
 from ggrc.converters.handlers import handlers
 
@@ -32,9 +32,39 @@ class DefaultPersonColumnHandler(handlers.ColumnHandler):
 
     This is the "other" option in the default assessor dropdown menu.
     """
-    self.add_error(errors.UNSUPPORTED_LIST_ERROR,
-                   column_name=self.display_name,
-                   value_type="email lists")
+    # This is not good and fast, because it executes query for each
+    # field from each row that contains people list.
+    # If the feature is used actively, it should be refactored
+    # and optimized.
+    new_objects = self.row_converter.block_converter.converter.new_objects
+    new_people = new_objects[Person]
+
+    people = []
+    emails = []
+
+    for email in self.raw_value.splitlines():
+      email = email.strip()
+      if not email:
+        continue
+      if email in new_people:
+        # In "dry run" mode person.id is None, so it is replaced by int value
+        # to pass validation.
+        people.append(new_people[email].id or 0)
+      else:
+        emails.append(email)
+
+    if emails:
+      for person in Person.query.filter(Person.email.in_(emails)).all():
+        people.append(person.id)
+        emails.remove(person.email)
+      if emails:
+        for email in emails:
+          self.add_warning(errors.UNKNOWN_USER_WARNING,
+                           column_name=self.display_name,
+                           email=email)
+    if not people:
+      self.add_error(errors.MISSING_VALUE_ERROR, column_name=self.display_name)
+    return people
 
   def _parse_label_values(self):
     """Parse predefined default assessors.
@@ -81,3 +111,18 @@ class DefaultPersonColumnHandler(handlers.ColumnHandler):
               json.dumps(default_people))
     else:
       setattr(self.row_converter.obj, "_default_people", default_people)
+
+  def get_value(self):
+    """Get value from default_people attribute."""
+    value = self.row_converter.obj.default_people.get(
+        self.KEY_MAP[self.key],
+        "ERROR",
+    )
+    if isinstance(value, list):
+      # This is not good and fast, because it executes query for each
+      # field from each row that contains people list.
+      # If the feature is used actively, it should be refactored
+      # and optimized.
+      people = Person.query.filter(Person.id.in_(value)).all()
+      value = "\n".join(p.email for p in people)
+    return value

--- a/test/integration/ggrc/converters/test_csvs/assessment_template_with_warnings_and_errors.csv
+++ b/test/integration/ggrc/converters/test_csvs/assessment_template_with_warnings_and_errors.csv
@@ -1,0 +1,53 @@
+,,,,,,,,,,,,,,,,,
+Object type,,,,,Only works if object under assessment is Control.,,,,"List of custom attributes for the assessment template
+One attribute per line. fields are separated by commas,
+
+<attribute type>, <attribute name>, [<attribute value1>, <attribute value2>, ...]
+
+Valid attribute types: Text, Rich Text, Date, Checkbox, Person, Dropdown.
+attribute name: any single line string without commas. Leading and trailing spaces are ignored.
+list of attribute values: comma separetd list, only used if attribute type is ""Dropdown"".
+
+Limitations: Dropdown values can not start with either ""(a)"" or ""(c)"" and attribute names can not contain commas "","".",,,,,,,,
+Assessment Template,Code,Audit,Title,Object under assessment,Use control test plan,Default Test Plan,Default Assessors,Default Verifier,Custom Attributes,,,,,,,,
+,T-1,Audit,Template 1,Control,yes,this will be ignored,Object owners,Auditors,"Text, my text name
+mandatory Text, Some Other text name
+Rich text, custom description
+Mandatory Date, date of birth
+Checkbox, dashie?
+peRson, santa clause",,,,,,,,
+,T-2,Audit,Template 2,Control,,Some test plan,Audit lead,"user3@a.com
+user1@a.com",,,,,,,,,
+,T-3,Audit,Template 2,Market,,Market test plan,principal assessor,primary contact,"Dropdown, my dropdown, value 1, value 2, value 3
+mandatory dropdown, my second dropdown, value1, value2
+Dropdown, dropdown with mandatory attachemnts and comments, (a) value1, (a)(c) value 2, (c)  (a)  value3, (c) value cc, valueeee",,,,,,,,
+,T-4,Audit,Template 3,Org Group,yes,Control test plan value will be ignored,principal assessor,primary contact,,,,,,,,,
+,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,
+Object type,,,,,,,,,,,,,,,,,
+Audit,Code*,Program*,Title*,Internal Audit Lead*,Status,,,,,,,,,,,,
+,Audit,Program,Audit,user@example.com,Planned,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,
+Object type,,,,,,,,,,,,,,,,,
+Program,Code*,Title*,Manager,,,,,,,,,,,,,,
+,Program,Program,user@example.com,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,
+Object type,,,,,,,,,,,,,,,,,
+control,code*,title*,description,owner,state,notes,primary contact,secondary contact,effective date,stop date,control url,reference url,test plan,principal assessor,,Assertions,Categories
+,control-1,control-1,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,7/1/2015,7/15/2015,google.com,ggrc.com,plan for control 1,user@example.com,,Privacy,Data Centers
+,control-2,control-2,test,user@example.com,Final,this is a note,user@example.com,user@example.com,7/1/2015,7/15/2015,google.com,ggrc.com,plan for control 2,user@example.com,,Security,Disaster Recovery
+,control-3,control 3,test,user@example.com,Effective,this is a note,user@example.com,user@example.com,7/1/2015,7/15/2015,google.com,ggrc.com,plan for control 3,user@example.com,,Availability,Logical Access/ Access Control
+,control-4,control-4,test,user@example.com,Ineffective,this is a note,user@example.com,user@example.com,7/1/2015,7/15/2015,google.com,ggrc.com,plan for control 4,user@example.com,,Integrity,Sites

--- a/test/integration/ggrc/converters/test_import_assessment_templates.py
+++ b/test/integration/ggrc/converters/test_import_assessment_templates.py
@@ -1,0 +1,74 @@
+# Copyright (C) 2016 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+# pylint: disable=maybe-no-member
+
+"""Test Assessment Template import."""
+
+from ggrc import models
+from ggrc.converters import errors
+from integration.ggrc import converters
+
+
+class TestAssessmentTemplatesImport(converters.TestCase):
+  """Assessment Template import tests."""
+
+  def setUp(self):
+    """Set up for Request test cases."""
+    converters.TestCase.setUp(self)
+    self.client.get("/login")
+
+  def test_valid_import(self):
+    """Test valid import."""
+    response = self.import_file("assessment_template_no_warnings.csv")
+    response = next(r for r in response if r["name"] == "Assessment Template")
+
+    self.assertEqual(response["rows"], 4)
+    self.assertEqual(response["updated"], 0)
+    self.assertEqual(response["created"], 4)
+    self.assertEqual(response["row_errors"], [])
+    self.assertEqual(response["row_warnings"], [])
+    self.assertEqual(response["block_errors"], [])
+    self.assertEqual(response["block_warnings"], [])
+
+    people = {p.email: p.id for p in models.Person.query.all()}
+    template = models.AssessmentTemplate.query \
+        .filter(models.AssessmentTemplate.slug == "T-2") \
+        .first()
+
+    self.assertEqual(
+        template.default_people["verifiers"],
+        [people["user3@a.com"], people["user1@a.com"]],
+    )
+
+  def test_invalid_import(self):
+    """Test invalid import."""
+    data = "assessment_template_with_warnings_and_errors.csv"
+    response = self.import_file(data)
+    response = next(r for r in response if r["name"] == "Assessment Template")
+
+    expected_errors = [
+        errors.MISSING_VALUE_ERROR.format(
+            line=5,
+            column_name="Default Verifier",
+        )
+    ]
+    expected_warnings = [
+        errors.UNKNOWN_USER_WARNING.format(
+            line=5,
+            column_name="Default Verifier",
+            email="user3@a.com",
+        ),
+        errors.UNKNOWN_USER_WARNING.format(
+            line=5,
+            column_name="Default Verifier",
+            email="user1@a.com"
+        ),
+    ]
+    self.assertEqual(response["rows"], 4)
+    self.assertEqual(response["updated"], 0)
+    self.assertEqual(response["created"], 3)
+    self.assertEqual(response["row_errors"], expected_errors)
+    self.assertEqual(response["row_warnings"], expected_warnings)
+    self.assertEqual(response["block_errors"], [])
+    self.assertEqual(response["block_warnings"], [])


### PR DESCRIPTION
It fixes exporting values of "Default Assessors" and "Default Verifier" from Assessment Template, that does not work at all. It also fixes import of the same fields in case them contain list of user emails.