### PR TITLE
ISS-2-141 Fix script error when ending a Workflow Cycle

### DIFF
--- a/src/ggrc_workflows/assets/javascripts/components/end_cycle.js
+++ b/src/ggrc_workflows/assets/javascripts/components/end_cycle.js
@@ -3,28 +3,46 @@
   Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 */
 
+/**
+ * A component that wraps a button for ending a Workflow cycle, and
+ * automatically handles a click on it.
+ *
+ * As a result, the Cycle instance passed to the component is ended, and
+ * a couple of affected objects are refreshed in the process.
+ *
+ * Usage example (state and permission checks not included):
+ *
+ *   <cycle-end-cycle cycle="instance">
+ *       <button>Click to end a Cycle</button>
+ *   </cycle-end-cycle>
+ *
+ */
 (function (GGRC, can) {
   'use strict';
 
-  can.Component.extend({
-    tag: "cycle-end-cycle",
-    template: "<content/>",
+  GGRC.Components('endCycleButtonWrap', {
+    tag: 'cycle-end-cycle',
+    template: '<content/>',
     events: {
-      click: function() {
-        this.scope.cycle.refresh().then(function(cycle) {
-          cycle.attr('is_current', false).save().then(function() {
+      click: function () {
+        this.scope.cycle
+          .refresh()
+          .then(function (cycle) {
+            return cycle.attr('is_current', false).save();
+          })
+          .then(function () {
             return GGRC.page_instance().refresh();
-          }).then(function(){
+          })
+          .then(function () {
             // We need to update person's assigned_tasks mapping manually
-            var person_id = GGRC.current_user.id,
-                person = CMS.Models.Person.cache[person_id];
-                binding = person.get_binding('assigned_tasks');
+            var person = CMS.Models.Person.cache[GGRC.current_user.id];
+            var binding = person.get_binding('assigned_tasks');
 
-            // FIXME: Find a better way of removing stagnant items from the list.
+            // FIXME: Find a better way of removing stagnant
+            // items from the list.
             binding.list.splice(0, binding.list.length);
             return binding.loader.refresh_list(binding);
           });
-        });
       }
     }
   });


### PR DESCRIPTION
_(bug 1.141, section 2)_

The issue was caused by adding the `'use strict'`directive during  refactoring, causing the browser to strictly complain about the variable `binding` (it was declared without the `var` keyword due to a semicolon instead of a comma in the preceding line).

**Steps to reproduce:**
- Create a one time workflow under admin
- Create a task
- Activate workflow
- Click “End Cycle” button on the Active Cycles tab

**Actual result:**
_"Uncaught ReferenceError: binding is not defined"_ error is displayed.

**Expected result:**
No error occurs.

