### PR TITLE
ISS-2-1.142 Fix temporarily displaying "invalid date" under comments

### DIFF
--- a/src/ggrc_workflows/assets/mustache/cycle_task_entries/tree.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_entries/tree.mustache
@@ -42,7 +42,11 @@
     {{/defer}}
     {{/with_mapping}}
     {{/if_equals}}
-    <span class="entry-author">Modified by {{#using person=instance.modified_by}}{{{render '/static/mustache/people/popover.mustache' person=person}}}{{/using}} on {{date instance.created_at}}</span>
+    <span class="entry-author">
+      Modified by
+      {{#using person=instance.modified_by}}{{{render '/static/mustache/people/popover.mustache' person=person}}}{{/using}}
+      {{#if instance.created_at}}on {{date instance.created_at}}{{/if}}
+    </span>
   </div>
   <div class="entry-actions pull-right">
     <a class="dropdown-toggle" href="#" data-toggle="dropdown"><i class="fa fa-cog"></i></a>


### PR DESCRIPTION
This fixes a temporary rendering glitch when the comment's `created_at` field is not available yet due to the comment still being fetched from the server.

**Steps to reproduce:** 
- Create a one time workflow under admin
- Create a task
- Activate workflow
- Add a comment to the task

**Actual Result:** _"Modified by on Invalid date"_ is briefly displayed after adding a comment (in the comments section)
**Expected Result:** A correct time stamp is displayed.