### PR TITLE
QUICK-FIX Simplify CA rendering

### DIFF
--- a/src/ggrc/assets/javascripts/components/datepicker/datepicker.js
+++ b/src/ggrc/assets/javascripts/components/datepicker/datepicker.js
@@ -16,7 +16,6 @@
       date: null,
       format: '@',
       helptext: '@',
-      testId: '@',
       isShown: false,
       pattern: 'MM/DD/YYYY',
       setMinDate: null,

--- a/src/ggrc/assets/javascripts/components/datepicker/datepicker.js
+++ b/src/ggrc/assets/javascripts/components/datepicker/datepicker.js
@@ -15,7 +15,6 @@
     scope: {
       date: null,
       format: '@',
-      label: '@',
       helptext: '@',
       testId: '@',
       isShown: false,
@@ -24,6 +23,9 @@
       setMaxDate: null,
       _date: null,
       define: {
+        label: {
+          type: 'string'
+        },
         required: {
           type: 'boolean',
           'default': false

--- a/src/ggrc/assets/javascripts/components/inline_edit/inline.js
+++ b/src/ggrc/assets/javascripts/components/inline_edit/inline.js
@@ -13,7 +13,6 @@
     ),
     scope: {
       instance: null,
-      type: '@',
       caId: null,
       property: '@',
       value: null,
@@ -26,11 +25,13 @@
         value: null,
         values: null
       },
-
       emptyText: '@',
-
       $rootEl: null,
-
+      define: {
+        type: {
+          type: 'string'
+        }
+      },
       _EV_INSTANCE_SAVE: 'on-save',
 
       /**
@@ -108,7 +109,6 @@
           } else {
             instance.attr(property, value);
           }
-
           instance.save()
             .done(function () {
               $(document.body).trigger('ajax:flash', {

--- a/src/ggrc/assets/javascripts/components/inline_edit/tests/inline_edit_spec.js
+++ b/src/ggrc/assets/javascripts/components/inline_edit/tests/inline_edit_spec.js
@@ -88,8 +88,11 @@ describe('GGRC.Components.inlineEdit', function () {
     var instance;
     var method;
     var componentInst;
+    var el;
+    var options = {};
 
     beforeAll(function () {
+      el = document.createElement('DIV');
       method = Component.prototype.init;
     });
     beforeEach(function () {
@@ -98,6 +101,7 @@ describe('GGRC.Components.inlineEdit', function () {
         toggle: true,
         dropdown: ''
       });
+
       scope = new can.Map({
         instance: instance,
         context: {
@@ -116,12 +120,12 @@ describe('GGRC.Components.inlineEdit', function () {
       });
       it('context.value should be false for 0', function () {
         scope.attr('value', '0');
-        method.call(componentInst);
+        method.call(componentInst, el, options);
         expect(scope.attr('context.value')).toEqual(false);
       });
       it('context.value should be true for 1', function () {
         scope.attr('value', '1');
-        method.call(componentInst);
+        method.call(componentInst, el, options);
         expect(scope.attr('context.value')).toEqual(true);
       });
     });
@@ -132,12 +136,12 @@ describe('GGRC.Components.inlineEdit', function () {
       });
       it('context.value should be false', function () {
         scope.attr('instance.toggle', false);
-        method.call(componentInst);
+        method.call(componentInst, el, options);
         expect(scope.attr('context.value')).toEqual(false);
       });
       it('context.value should be true', function () {
         scope.attr('instance.toggle', true);
-        method.call(componentInst);
+        method.call(componentInst, el, options);
         expect(scope.attr('context.value')).toEqual(true);
       });
     });
@@ -148,14 +152,14 @@ describe('GGRC.Components.inlineEdit', function () {
       it('context.values should be list when string', function () {
         var options = 'a,b,c,d';
         scope.attr('values', options);
-        method.call(componentInst);
+        method.call(componentInst, el, options);
         expect(scope.attr('context.values').serialize())
           .toEqual(['a', 'b', 'c', 'd']);
       });
       it('context.values should be list when string', function () {
         var options = ['a', 'b', 'c', 'd'];
         scope.attr('values', options);
-        method.call(componentInst);
+        method.call(componentInst, el, options);
 
         expect(scope.attr('context.values').serialize())
           .toEqual(['a', 'b', 'c', 'd']);

--- a/src/ggrc/assets/javascripts/plugins/component_registry.js
+++ b/src/ggrc/assets/javascripts/plugins/component_registry.js
@@ -83,8 +83,7 @@
           if (_.isUndefined(val) && _.has(obj, 'default')) {
             val = obj.default;
           }
-          scope[key] = val;
-          scope._data[key] = val;
+          scope.attr(key, val);
         }
       }, this);
 

--- a/src/ggrc/assets/mustache/base_templates/effective_dates.mustache
+++ b/src/ggrc/assets/mustache/base_templates/effective_dates.mustache
@@ -10,12 +10,8 @@
       date="instance.start_date"
       set-max-date="instance.end_date"
       helptext="Enter the date this object becomes effective."
-      {{#startTestId}}
-      test-id="{{startTestId}}"
-      {{/startTestId}}
-      {{#required}}
-      required="true"
-      {{/required}}
+      test-id="startTestId"
+      required="required"
       />
   </div>
   <div data-id="stop_date_hidden" class="span4 hidable">
@@ -25,10 +21,8 @@
       set-min-date="instance.start_date"
       date="instance.end_date"
       helptext="Enter the date the object stops being effective."
-      {{#endTestId}}
-      test-id="{{endTestId}}"
-      {{/endTestId}}
-      {{#required}}required="true"{{/required}}
+      test-id="endTestId"
+      required="required"
       />
   </div>
 </div>

--- a/src/ggrc/assets/mustache/components/datepicker/datepicker.mustache
+++ b/src/ggrc/assets/mustache/components/datepicker/datepicker.mustache
@@ -2,7 +2,7 @@
   Copyright (C) 2016 Google Inc.
   Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
-<div class="datepicker__wrapper" {{#testId}}data-test-id="{{testId}}"{{/testId}}>
+<div class="datepicker__wrapper">
   {{#if label}}
     <label>
       {{label}}

--- a/src/ggrc/assets/mustache/controls/modal_content.mustache
+++ b/src/ggrc/assets/mustache/controls/modal_content.mustache
@@ -153,10 +153,8 @@
         </div>
       </div>
     </div>
-    <div class="row-fluid">
-      {{#expose startTestId="control_effective_date_0376cf90" endTestId="control_end_date_91ec027a"}}
-        {{> /static/mustache/base_templates/effective_dates.mustache}}
-      {{/expose}}
+    <div class="row-fluid" test-id="control_effective_dates_0376cf90">
+      {{> /static/mustache/base_templates/effective_dates.mustache}}
     </div>
 
     <div class="row-fluid">

--- a/src/ggrc/assets/mustache/custom_attributes/info.mustache
+++ b/src/ggrc/assets/mustache/custom_attributes/info.mustache
@@ -3,126 +3,37 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
 
-<custom-attributes instance="instance" load="true">
+<custom-attributes instance="instance">
   {{^loading}}
     {{#if instance.custom_attribute_definitions.length}}
-      {{#iterate_by_two instance.custom_attribute_definitions}}
-        <div class="row-fluid wrap-row">
-        {{#list}}
-          <div class="span6">
-            <div data-custom-attribute="{{id}}" data-type="{{attribute_type}}">
-              {{#with_value_for_id id}}
-                {{#switch attribute_type}}
-                {{#case 'Checkbox'}}
-                  <inline-edit
-                    instance="instance"
-                    need-confirm="confirmEdit"
-                    ca-id="id"
-                    value="value"
-                    label="title"
-                    type="checkbox"
-                    mandatory="mandatory"
-                    placeholder="placeholder"
-                    helptext="helptext"
-                    {{^is_allowed 'update' instance context='for'}}
-                      readonly
-                    {{/is_allowed}}
-                  ></inline-edit>
-                {{/case}}
-                {{#case 'Rich Text'}}
-                  <inline-edit
-                    instance="instance"
-                    need-confirm="confirmEdit"
-                    ca-id="id"
-                    value="value"
-                    label="title"
-                    type="text"
-                    mandatory="mandatory"
-                    placeholder="placeholder"
-                    helptext="helptext"
-                    {{^is_allowed 'update' instance context='for'}}
-                      readonly
-                    {{/is_allowed}}
-                  ></inline-edit>
-                {{/case}}
-                {{#case 'Dropdown'}}
-                  <inline-edit
-                    instance="instance"
-                    need-confirm="confirmEdit"
-                    ca-id="id"
-                    value="value"
-                    label="title"
-                    type="dropdown"
-                    mandatory="mandatory"
-                    values="multi_choice_options"
-                    placeholder="placeholder"
-                    helptext="helptext"
-                    {{^is_allowed 'update' instance context='for'}}
-                      readonly
-                    {{/is_allowed}}
-                  ></inline-edit>
-                {{/case}}
-                {{#case 'Date'}}
-                  <inline-edit
-                    instance="instance"
-                    need-confirm="confirmEdit"
-                    ca-id="id"
-                    value="value"
-                    label="title"
-                    type="date"
-                    mandatory="mandatory"
-                    placeholder="placeholder"
-                    helptext="helptext"
-                    {{^is_allowed 'update' instance context='for'}}
-                      readonly
-                    {{/is_allowed}}
-                  ></inline-edit>
-                {{/case}}
-                {{#case 'Text'}}
-                  <inline-edit
-                    instance="instance"
-                    need-confirm="confirmEdit"
-                    ca-id="id"
-                    value="value"
-                    label="title"
-                    type="input"
-                    mandatory="mandatory"
-                    placeholder="placeholder"
-                    helptext="helptext"
-                    {{^is_allowed 'update' instance context='for'}}
-                      readonly
-                    {{/is_allowed}}
-                  ></inline-edit>
-                {{/case}}
-                {{#case 'Map:Person'}}
-                  {{#with_object_for_id id}}
-                    <inline-edit
-                      instance="instance"
-                      need-confirm="confirmEdit"
-                      ca-id="id"
-                      value="object"
-                      label="title"
-                      type="person"
-                      mandatory="mandatory"
-                      placeholder="placeholder"
-                      helptext="helptext"
-                      {{^is_allowed 'update' instance context='for'}}
-                        readonly
-                      {{/is_allowed}}
-                    ></inline-edit>
-                  {{/with_object_for_id}}
-                {{/case}}
-                {{#default}}
-                  <h6>{{title}}</h6>
-                  {{value}}
-                {{/default}}
-                {{/switch}}
-              {{/with_value_for_id}}
-            </div>
+      <div class="row-fluid wrap-row">
+      {{#getValues}}
+        <div class="span6">
+          <div data-custom-attribute="{{id}}" data-type="{{attribute_type}}">
+            <inline-edit
+              instance="instance"
+              need-confirm="confirmEdit"
+              ca-id="cad.id"
+              {{#if cav.attribute_object}}
+              value="cav.attribute_object"
+              {{else}}
+              value="cav.attribute_value"
+              {{/if}}
+              values="cad.values"
+              title="cad.title"
+              label="cad.label"
+              type="type"
+              mandatory="cad.mandatory"
+              placeholder="cad.placeholder"
+              helptext="cad.helptext"
+              {{^is_allowed 'update' instance context='for'}}
+                readonly
+              {{/is_allowed}}
+            ></inline-edit>
           </div>
-        {{/list}}
         </div>
-      {{/iterate_by_two}}
+      {{/getValues}}
+      </div>
     {{/if}}
   {{/loading}}
 </custom-attributes>

--- a/src/ggrc/assets/mustache/custom_attributes/modal_content.mustache
+++ b/src/ggrc/assets/mustache/custom_attributes/modal_content.mustache
@@ -8,43 +8,42 @@
 <custom-attributes instance="instance">
   <div class="hideable-holder bare">
     <div class="row-fluid">
-      {{#each instance.custom_attribute_definitions}}
-      {{#with_value_for_id id}}
+      {{#getValues}}
+        <div class="{{^cad.mandatory}}hidable{{/cad.mandatory}} span6
+          {{#ca_validation_error instance.computed_errors id}}field-failure{{/ca_validation_error}}">
 
-      <div class="{{^mandatory}}hidable{{/mandatory}} span6
-                  {{#ca_validation_error instance.computed_errors id}}field-failure{{/ca_validation_error}}">
-        {{#switch attribute_type}}
+        {{#switch cad.attribute_type}}
         {{#case 'Text'}}
           <label>
-            {{title}}
-            {{#mandatory}}<span class="required">*</span>{{/mandatory}}
-            {{#helptext}}<i class="fa fa-question-circle" rel="tooltip" title="{{helptext}}"></i>{{/helptext}}
+            {{cad.title}}
+            {{#cad.mandatory}}<span class="required">*</span>{{/cad.mandatory}}
+            {{#cad.helptext}}<i class="fa fa-question-circle" rel="tooltip" title="{{cad.helptext}}"></i>{{/cad.helptext}}
             <a href="javascript://" class="field-hide" tabindex="-1">hide</a>
           </label>
-          <input tabindex="{{add_index 20 @index}}" data-ram="{{@index}}" class="input-block-level" value="{{value}}" placeholder="{{placeholder}}" name="custom_attributes.{{id}}" type="text">
+          <input tabindex="{{add_index 20 @index}}" data-ram="{{@index}}" class="input-block-level" value="{{cav.attribute_value}}" placeholder="{{cad.placeholder}}" name="custom_attributes.{{cad.id}}" type="text">
         {{/case}}
         {{#case 'Rich Text'}}
           <label>
-            {{title}}
-            {{#mandatory}}<span class="required">*</span>{{/mandatory}}
-            {{#helptext}}<i class="fa fa-question-circle" rel="tooltip" title="{{helptext}}"></i>{{/helptext}}
+            {{cad.title}}
+            {{#cad.mandatory}}<span class="required">*</span>{{/cad.mandatory}}
+            {{#cad.helptext}}<i class="fa fa-question-circle" rel="tooltip" title="{{cad.helptext}}"></i>{{/cad.helptext}}
             <a href="javascript://" class="field-hide" tabindex="-1">hide</a>
           </label>
           <div class="wysiwyg-area">
-            <textarea tabindex="{{add_index 20 @index}}" id="{{title}}" class="span12 double wysihtml5" name="custom_attributes.{{id}}" placeholder="{{placeholder}}">{{{value}}}</textarea>
+            <textarea tabindex="{{add_index 20 @index}}" id="{{cad.title}}" class="span12 double wysihtml5" name="custom_attributes.{{cad.id}}" placeholder="{{cad.placeholder}}">{{{cav.attribute_value}}}</textarea>
           </div>
         {{/case}}
         {{#case 'Dropdown'}}
           <label>
-            {{title}}
-            {{#mandatory}}<span class="required">*</span>{{/mandatory}}
-            {{#helptext}}<i class="fa fa-question-circle" rel="tooltip" title="{{helptext}}"></i>{{/helptext}}
+            {{cad.title}}
+            {{#cad.mandatory}}<span class="required">*</span>{{/cad.mandatory}}
+            {{#cad.helptext}}<i class="fa fa-question-circle" rel="tooltip" title="{{cad.helptext}}"></i>{{/cad.helptext}}
             <a href="javascript://" class="field-hide" tabindex="-1">hide</a>
           </label>
-          <select class="input-block-level" name="custom_attributes.{{id}}" null-if-empty="null-if-empty" tabindex="20">
-            <option value="" {{#if_equals "" value}}selected="true"{{/if_equals}}>---</option>
-            {{#iterate_string multi_choice_options ','}}
-              <option {{#if_equals iterator value}}selected="true"{{/if_equals}}>{{iterator}}</option>
+          <select class="input-block-level" name="custom_attributes.{{cad.id}}" null-if-empty="null-if-empty" tabindex="20">
+            <option value="" {{#if_equals "" cav.attribute_value}}selected="true"{{/if_equals}}>---</option>
+            {{#iterate_string cad.multi_choice_options ','}}
+              <option {{#if_equals iterator cav.attribute_value}}selected="true"{{/if_equals}}>{{iterator}}</option>
             {{/iterate}}
           </select>
         {{/case}}
@@ -52,10 +51,10 @@
           <label>&nbsp;</label>
           <div class="checkbox-area">
             <label>
-              <input tabindex="{{add_index 20 @index}}" name="custom_attributes.{{id}}" type="checkbox"  {{#if_equals value "1"}}checked="checked"{{/if_equals}}>
-              {{title}}
-              {{#mandatory}}<span class="required">*</span>{{/mandatory}}
-              {{#helptext}}<i class="fa fa-question-circle" rel="tooltip" title="{{helptext}}"></i>{{/helptext}}
+              <input tabindex="{{add_index 20 @index}}" name="custom_attributes.{{cad.id}}" type="checkbox"  {{#if_equals cav.attribute_value "1"}}checked="checked"{{/if_equals}}>
+              {{cad.title}}
+              {{#cad.mandatory}}<span class="required">*</span>{{/cad.mandatory}}
+              {{#cad.helptext}}<i class="fa fa-question-circle" rel="tooltip" title="{{cad.helptext}}"></i>{{/cad.helptext}}
               <a href="javascript://" class="field-hide" tabindex="-1">hide</a>
             </label>
           </div>
@@ -63,28 +62,28 @@
         {{#case 'Date'}}
         <a href="javascript://" class="field-hide" tabindex="-1">hide</a>
         <datepicker
-          label="{{title}}"
-          date="instance.custom_attributes.{{id}}"
-          required="{{mandatory}}"
-          helptext="{{helptext}}"
+          label="cad.title"
+          date="instance.custom_attributes.{{cad.id}}"
+          required="cad.mandatory"
+          helptext="cad.helptext"
           />
         {{/case}}
         {{#case 'Map:Person'}}
         <label>
-          {{title}}
-          {{#mandatory}}<span class="required">*</span>{{/mandatory}}
-          {{#helptext}}<i class="fa fa-question-circle" rel="tooltip" title="{{helptext}}"></i>{{/helptext}}
+          {{cad.title}}
+          {{#cad.mandatory}}<span class="required">*</span>{{/cad.mandatory}}
+          {{#cad.helptext}}<i class="fa fa-question-circle" rel="tooltip" title="{{cad.helptext}}"></i>{{/cad.helptext}}
           <a href="javascript://" class="field-hide" tabindex="-1">hide</a>
         </label>
-        {{#with_object_for_id id}}
+          {{#using person=cav.attribute_object}}
           <input class="input-block-level"
-                 name="_custom_attribute_mappings.{{id}}.email"
+                 name="_custom_attribute_mappings.{{cad.id}}.email"
                  data-lookup="Person" placeholder="Enter email address"
-                 data-lookup-cb="_custom_attribute_map {{id}}"
+                 data-lookup-cb="_custom_attribute_map {{cad.id}}"
                  null-if-empty="null-if-empty"
                  type="text"
-                 value="{{object.email}}" />
-        {{/with_object_for_id}}
+                 value="{{person.email}}" />
+          {{/using}}
         {{/case}}
         {{/switch}}
 
@@ -92,9 +91,7 @@
           <label class="help-inline warning">{{errors.0}}</label>
         {{/ca_validation_error}}
       </div>
-
-      {{/with_value_for_id}}
-      {{/instance.custom_attribute_definitions}}
+      {{/getValues}}
     </div>
   </div>
 </custom-attributes>

--- a/src/ggrc/assets/mustache/programs/modal_content.mustache
+++ b/src/ggrc/assets/mustache/programs/modal_content.mustache
@@ -119,9 +119,9 @@
              tabindex="9"
              class="input-block-level" name="slug" placeholder="PROGRAM-XXX" type="text" value="{{slug}}">
     </div>
-    {{#expose startTestId="new_program_field_effective_date_f2783a28" endTestId="new_program_field_stop_date_f2783a28"}}
+    <div test-id="new_program_field_effective_date_f2783a28">
       {{> '/static/mustache/base_templates/effective_dates.mustache'}}
-    {{/expose}}
+    </div>
   </div>
   <div class="row-fluid">
     <div class="span4 hidable">

--- a/test/selenium/src/lib/constants/locator.py
+++ b/test/selenium/src/lib/constants/locator.py
@@ -204,20 +204,24 @@ class ModalCreateNewProgram(BaseModalCreateNew):
 
   UI_EFFECTIVE_DATE = (
       By.CSS_SELECTOR,
-      '[data-test-id="new_program_field_effective_date_f2783a28"] '
+      '[test-id="new_program_field_effective_date_f2783a28"] '
+      '[data-id="effective_date_hidden"] '
       '.datepicker__input')
   EFFECTIVE_DATE_DATEPICKER = (
       By.CSS_SELECTOR,
       '[test-id="new_program_field_effective_date_f2783a28"] '
+      '[data-id="effective_date_hidden"] '
       '[data-handler="selectDay"]')
 
   UI_STOP_DATE = (
       By.CSS_SELECTOR,
-      '[data-test-id="new_program_field_stop_date_f2783a28"] '
+      '[test-id="new_program_field_effective_date_f2783a28"] '
+      '[data-id="stop_date_hidden"] '
       '.datepicker__input')
   STOP_DATE_DATEPICKER = (
       By.CSS_SELECTOR,
-      '[test-id="new_program_field_stop_date_f2783a28"] '
+      '[test-id="new_program_field_effective_date_f2783a28"] '
+      '[data-id="stop_date_hidden"] '
       '[data-handler="selectDay"]')
 
   TITLE = (By.CSS_SELECTOR, '[data-test-id="label_title_2c925d94"]')
@@ -414,20 +418,24 @@ class ModalCreateNewControl(BaseModalCreateNew):
 
   EFFECTIVE_DATE = (
       By.CSS_SELECTOR,
-      '[data-test-id="control_effective_date_0376cf90"] '
+      '[test-id="control_effective_dates_0376cf90"] '
+      '[data-id="effective_date_hidden"] '
       '.datepicker__input')
   DATEPICKER_EFFECTIVE_DATE = (
       By.CSS_SELECTOR,
-      '[data-test-id="control_effective_date_0376cf90"] '
+      '[test-id="control_effective_dates_0376cf90"] '
+      '[data-id="effective_date_hidden"] '
       '[data-handler="selectDay"]')
 
   STOP_DATE = (
       By.CSS_SELECTOR,
-      '[data-test-id="control_end_date_91ec027a"] '
+      '[test-id="control_effective_dates_0376cf90"] '
+      '[data-id="stop_date_hidden"] '
       '.datepicker__input')
   DATEPICKER_STOP_DATE = (
       By.CSS_SELECTOR,
-      '[data-test-id="control_end_date_91ec027a"] '
+      '[test-id="control_effective_dates_0376cf90"] '
+      '[data-id="stop_date_hidden"] '
       '[data-handler="selectDay"]')
 
   # buttons


### PR DESCRIPTION
So overall problem is following:
- If I fix how we set attributes on scope d8d279654e8f1380b3463093cc575dfa21423b98 and we have old CA rendering logic, we will get an stack overflow. With this fix our Unified mapper and all components get events triggered properly
- I've used this opportunity to clear CA logic a bit, because with old logic all inner components break due to scope visibility

I can probably split this into two separate PR's.
I need some feedback on this, prolly @Smotko the most

P.S. Kudos to @zidarsk8 for all the answers and simplifying our life with new CA
P.P.S. @zidar I couldn't find any regressions related to CA