### PR TITLE
QUICK-FIX Cache objects on request

### DIFF
--- a/src/ggrc/builder/json.py
+++ b/src/ggrc/builder/json.py
@@ -10,6 +10,7 @@ from datetime import datetime
 
 import iso8601
 import sqlalchemy
+from flask import g
 from sqlalchemy.ext.associationproxy import AssociationProxy
 from sqlalchemy.orm.attributes import InstrumentedAttribute
 from sqlalchemy.orm.properties import RelationshipProperty
@@ -252,7 +253,9 @@ class UpdateAttrHandler(object):
       rel_obj = json_obj.get(attr_name)
       if rel_obj:
         try:
-          # FIXME: Should this be .one() instead of .first() ?
+          cache = getattr(g, "referenced_objects", {})
+          if rel_class in cache:
+            return cache.get(rel_class, {}).get(rel_obj[u'id'])
           return db.session.query(rel_class).filter(
               rel_class.id == rel_obj[u'id']).first()
         except TypeError:

--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -20,7 +20,6 @@ from urllib import urlencode
 from blinker import Namespace
 from flask import url_for, request, current_app, g, has_request_context
 from flask.views import View
-from flask import g
 from sqlalchemy import and_, or_
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.sql.expression import tuple_

--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -365,6 +365,9 @@ def clear_permission_cache():
 
 
 class ModelView(View):
+  """Basic view handler for all models"""
+  # pylint: disable=protected-access
+  # access to _sa_class_manager is needed for fetching the right mapper
   DEFAULT_PAGE_SIZE = 20
   MAX_PAGE_SIZE = 100
   pk = 'id'
@@ -1341,13 +1344,13 @@ class Resource(ModelView):
           self._build_request_stub_cache(body)
         try:
           self.collection_post_loop(body, res, no_result, running_async)
-        except (IntegrityError, ValidationError, ValueError) as e:
-          res.append(self._make_error_from_exception(e))
+        except (IntegrityError, ValidationError, ValueError) as error:
+          res.append(self._make_error_from_exception(error))
           db.session.rollback()
-        except Exception as e:
-          res.append((getattr(e, "code", 500), e.message))
+        except Exception as error:
+          res.append((getattr(error, "code", 500), error.message))
           current_app.logger.warn("Collection POST commit failed:")
-          current_app.logger.exception(e)
+          current_app.logger.exception(error)
           db.session.rollback()
         if hasattr(g, "referenced_objects"):
           delattr(g, "referenced_objects")


### PR DESCRIPTION
This Pr removes all queries for deserializing reltionship object in collection post.

Query count for colleciton post with 90 object:
before: 1275
after: 1097