### PR TITLE
ISSUE-1.149 Script error occurs when adding new auditor

### DIFF
--- a/src/ggrc/assets/javascripts/models/join_models.js
+++ b/src/ggrc/assets/javascripts/models/join_models.js
@@ -196,23 +196,27 @@
   }, {
     save: function () {
       var role;
-      if (!this.role && this.role_name) {
-        role = _.find(CMS.Models.Role.cache, {name: this.role_name});
-        if (role) {
-          this.attr('role', role.stub());
-          return this._super.apply(this, arguments);
-        }
-        return CMS.Models.Role.findAll({
-          name__in: this.role_name
-        }).then(function (roles) {
-          if (roles.length < 1) {
-            return new $.Deferred().reject('Role not found');
-          }
-          this.attr('role', roles[0].stub());
-          return this._super.apply(this, arguments);
-        }.bind(this));
+      var _super = this._super;
+
+      if (this.role && !this.role_name) {
+        return _super.apply(this, arguments);
       }
-      return this._super.apply(this, arguments);
+
+      role = _.find(CMS.Models.Role.cache, {name: this.role_name});
+      if (role) {
+        this.attr('role', role.stub());
+        return _super.apply(this, arguments);
+      }
+      return CMS.Models.Role.findAll({
+        name__in: this.role_name
+      }).then(function (role) {
+        if (!role.length) {
+          return new $.Deferred().reject('Role not found');
+        }
+        role = role[0];
+        this.attr('role', role.stub());
+        return _super.apply(this, arguments);
+      }.bind(this));
     }
   });
 

--- a/src/ggrc/assets/javascripts/models/simple_models.js
+++ b/src/ggrc/assets/javascripts/models/simple_models.js
@@ -194,27 +194,27 @@ can.Model.Cacheable("CMS.Models.Event", {
     }
 }, {});
 
-can.Model.Cacheable("CMS.Models.Role", {
-  root_object : "role"
-  , root_collection : "roles"
-  , findAll : "GET /api/roles"
-  , findOne : "GET /api/roles/{id}"
-  , update : "PUT /api/roles/{id}"
-  , destroy : "DELETE /api/roles/{id}"
-  , create : "POST /api/roles"
-  , scopes : [
-        "Private Program",
-        "Workflow",
-        "System"
-    ]
-  , defaults : {
-      permissions: {
-          read: []
-        , update: []
-        , create: []
-        , "delete": []
-      }
+can.Model.Cacheable('CMS.Models.Role', {
+  root_object: 'role',
+  root_collection: 'roles',
+  findAll: 'GET /api/roles',
+  findOne: 'GET /api/roles/{id}',
+  update: 'PUT /api/roles/{id}',
+  destroy: 'DELETE /api/roles/{id}',
+  create: 'POST /api/roles',
+  scopes: [
+    'Private Program',
+    'Workflow',
+    'System'
+  ],
+  defaults: {
+    permissions: {
+      read: [],
+      update: [],
+      create: [],
+      delete: []
     }
+  }
 }, {
 
   allowed : function(operation, object_or_class) {


### PR DESCRIPTION
Subject:
Script error "Uncaught TypeError: Cannot read property 'apply' of undefined" occurs while adding an auditor in Audit's Info panel

Details: 
Create a program
Create an audit
Navigate to Audit’s Info panel -> Add Editor -> click on Add

Actual Result:
Script error "Uncaught TypeError: Cannot read property 'apply' of undefined" occurs while adding an auditor in Audit's Info panel

Expected Result:
No error. An auditor should be added in Audit's Info panel


**Note:** It's add _Auditor_, not _Editor_