### PR TITLE
QUICK-FIX Fix CustomAttributable backref

### DIFF
--- a/src/ggrc/models/custom_attribute_value.py
+++ b/src/ggrc/models/custom_attribute_value.py
@@ -38,7 +38,7 @@ class CustomAttributeValue(Base, db.Model):
 
   @property
   def attributable_attr(self):
-    return '{0}_attributable'.format(self.attributable_type)
+    return '{0}_custom_attributable'.format(self.attributable_type)
 
   @property
   def attributable(self):

--- a/src/ggrc/models/mixins/customattributable.py
+++ b/src/ggrc/models/mixins/customattributable.py
@@ -136,7 +136,8 @@ class CustomAttributable(object):
         existing_value.attribute_object_id = new_value.attribute_object_id
       else:
         new_value.attributable = self
-        self._custom_attribute_values.append(new_value)
+        # new_value is automatically appended to self._custom_attribute_values
+        # on new_value.attributable = self
 
   def _add_ca_value_dicts(self, values):
     """Add CA dict representations to _custom_attributes_values property.
@@ -156,12 +157,14 @@ class CustomAttributable(object):
         attr.attribute_value = value.get("attribute_value")
         attr.attribute_object_id = value.get("attribute_object_id")
       elif "custom_attribute_id" in value:
-        self._custom_attribute_values.append(CustomAttributeValue(
+        # this is automatically appended to self._custom_attribute_values
+        # on attributable=self
+        CustomAttributeValue(
             attributable=self,
             custom_attribute_id=value.get("custom_attribute_id"),
             attribute_value=value.get("attribute_value"),
             attribute_object_id=value.get("attribute_object_id"),
-        ))
+        )
       elif "href" in value:
         # Ignore setting of custom attribute stubs. Getting here means that the
         # front-end is not using the API correctly and needs to be updated.


### PR DESCRIPTION
This PR fixes the problem that `CustomAttributable` mixin defines backrefs `{0}_custom_attributable`, but `CustomAttributeValue` model tries to use the same backrefs under the name `{0}_attributable`, thus making `attributable` property non-functional.

This PR also fixes another problem that appears after fixing this one: the code like `self._custom_attribute_values.append(CustomAttributeValue(attributable=self))` appends the new CAV object to `self._custom_attribute_values` twice: on `append` call and on `attributable=self` assignment.

~~I haven't tested `_add_ca_values` setter; it can possibly have the same issue as `_add_ca_value_dict`.~~
The double-addition problem was fixed in both variants of `custom_attribute_values.setter`.