### PR TITLE
ISSUE-1.127 Can not read property 'destroy' of undefined

### DIFF
--- a/src/ggrc/assets/javascripts/components/people_list.js
+++ b/src/ggrc/assets/javascripts/components/people_list.js
@@ -75,6 +75,7 @@
       limit: '@',
       mapping: null,
       required: '@',
+      deferred: '@',
       type: null,
       toggle_add: false,
       mapped_people: [],


### PR DESCRIPTION
"deferred" property wasn't set properly from mustache templates

**Details:**
- Create a program -> Create Audit -> Create Assessment
- Navigate to Assessment's info panel
- Click + to add a Verifier/Assessor
- Click a trash can icon to delete a Verifier/Assessor->Add a Verifier/Assessor
- Click a trash can icon to delete a Verifier/Assessor

**Actual Result:** Script error "Uncaught TypeError: Cannot read property 'destroy' of undefined" occurs when removing a Verifier/Assessor from Assessment's info panel

**Expected Result:** No error. A Verifier/Assessor should be removed without error.