### PR TITLE
FEATURE preconditions_failed fields

### DIFF
--- a/src/ggrc/models/custom_attribute_value.py
+++ b/src/ggrc/models/custom_attribute_value.py
@@ -72,6 +72,7 @@ class CustomAttributeValue(Base, db.Model):
     query = super(CustomAttributeValue, cls).eager_query()
     query = query.options(
         orm.subqueryload('_related_revisions'),
+        orm.joinedload('custom_attribute'),
     )
     return query
 

--- a/src/ggrc/models/mixins/customattributable.py
+++ b/src/ggrc/models/mixins/customattributable.py
@@ -365,12 +365,16 @@ class CustomAttributable(object):
         orm.subqueryload('custom_attribute_definitions')
            .undefer_group('CustomAttributeDefinition_complete'),
         orm.subqueryload('_custom_attribute_values')
-           .undefer_group('CustomAttributeValue_complete'),
+           .undefer_group('CustomAttributeValue_complete')
+           .subqueryload('{0}_custom_attributable'.format(cls.__name__)),
+        orm.subqueryload('_custom_attribute_values')
+           .subqueryload('_related_revisions'),
     )
     if hasattr(cls, 'comments'):
       # only for Commentable classess
       query = query.options(
-          orm.subqueryload('comments'),
+          orm.subqueryload('comments')
+             .undefer_group('Comment_complete'),
       )
     return query
 

--- a/src/ggrc/models/mixins/customattributable.py
+++ b/src/ggrc/models/mixins/customattributable.py
@@ -157,6 +157,12 @@ class CustomAttributable(object):
     from ggrc.models.custom_attribute_value import CustomAttributeValue
 
     for value in values:
+      if not value.get("attribute_object_id"):
+        # value.get("attribute_object", {}).get("id") won't help because
+        # value["attribute_object"] can be None
+        value["attribute_object_id"] = (value["attribute_object"].get("id") if
+                                        value.get("attribute_object") else
+                                        None)
       attr = self._values_map.get(value.get("custom_attribute_id"))
       if attr:
         attr.attributable = self

--- a/src/ggrc/models/mixins/customattributable.py
+++ b/src/ggrc/models/mixins/customattributable.py
@@ -352,12 +352,18 @@ class CustomAttributable(object):
   @classmethod
   def eager_query(cls):
     query = super(CustomAttributable, cls).eager_query()
-    return query.options(
+    query = query.options(
         orm.subqueryload('custom_attribute_definitions')
            .undefer_group('CustomAttributeDefinition_complete'),
         orm.subqueryload('_custom_attribute_values')
            .undefer_group('CustomAttributeValue_complete'),
     )
+    if hasattr(cls, 'comments'):
+      # only for Commentable classess
+      query = query.options(
+          orm.subqueryload('comments'),
+      )
+    return query
 
   def log_json(self):
     """Log custom attribute values."""

--- a/src/ggrc/models/mixins/customattributable.py
+++ b/src/ggrc/models/mixins/customattributable.py
@@ -21,6 +21,7 @@ from ggrc.models.computed_property import computed_property
 from ggrc.models.reflection import AttributeInfo
 
 
+# pylint: disable=attribute-defined-outside-init; CustomAttributable is a mixin
 class CustomAttributable(object):
   """Custom Attributable mixin."""
 
@@ -337,6 +338,7 @@ class CustomAttributable(object):
 
   @classmethod
   def get_custom_attribute_definitions(cls):
+    """Get all applicable CA definitions (even ones without a value yet)."""
     from ggrc.models.custom_attribute_definition import \
         CustomAttributeDefinition as cad
     if cls.__name__ == "Assessment":
@@ -351,6 +353,7 @@ class CustomAttributable(object):
 
   @classmethod
   def eager_query(cls):
+    """Define fields to be loaded eagerly to lower the count of DB queries."""
     query = super(CustomAttributable, cls).eager_query()
     query = query.options(
         orm.subqueryload('custom_attribute_definitions')
@@ -395,6 +398,7 @@ class CustomAttributable(object):
     return res
 
   def validate_custom_attributes(self):
+    # pylint: disable=not-an-iterable; we can iterate over relationships
     map_ = {d.id: d for d in self.custom_attribute_definitions}
     for value in self._custom_attribute_values:
       if not value.custom_attribute and value.custom_attribute_id:
@@ -403,10 +407,12 @@ class CustomAttributable(object):
 
   @computed_property
   def preconditions_failed(self):
+    """Returns True if any mandatory CAV, comment or evidence is missing."""
     values_map = {
         cav.custom_attribute_id or cav.custom_attribute.id: cav
         for cav in self.custom_attribute_values
     }
+    # pylint: disable=not-an-iterable; we can iterate over relationships
     for cad in self.custom_attribute_definitions:
       if cad.mandatory:
         cav = values_map.get(cad.id)

--- a/src/ggrc/models/mixins/validate_on_complete.py
+++ b/src/ggrc/models/mixins/validate_on_complete.py
@@ -7,16 +7,8 @@ This defines a procedure of an object's validation when its status moves from
 one of NOT_DONE_STATES to DONE_STATES.
 """
 
-from collections import namedtuple
-
-from sqlalchemy import case
-from sqlalchemy.ext.declarative import declared_attr
-from sqlalchemy import orm
 from sqlalchemy.orm import validates
 
-from ggrc import db
-from ggrc.models.comment import Comment
-from ggrc.models.custom_attribute_definition import CustomAttributeDefinition
 from ggrc.models.exceptions import ValidationError
 
 
@@ -27,153 +19,17 @@ class ValidateOnComplete(object):
 
   # pylint: disable=too-few-public-methods
 
-  @declared_attr
-  def _related_comments(self):
-    """Comments related to self via Relationship table."""
-    from ggrc.models.relationship import Relationship
-    comment_id = case(
-        [(Relationship.destination_type == "Comment",
-          Relationship.destination_id)],
-        else_=Relationship.source_id,
-    )
-    commentable_id = case(
-        [(Relationship.destination_type == "Comment",
-          Relationship.source_id)],
-        else_=Relationship.destination_id,
-    )
-
-    return db.relationship(
-        Comment,
-        primaryjoin=lambda: self.id == commentable_id,
-        secondary=Relationship.__table__,
-        secondaryjoin=lambda: Comment.id == comment_id,
-        viewonly=True,
-    )
-
-  @classmethod
-  def eager_query(cls):
-    """Special query to fetch all required fields."""
-    query = super(ValidateOnComplete, cls).eager_query()
-    return query.options(
-        orm.subqueryload("_related_comments")
-           .joinedload("revision"),
-    )
-
-  def _get_custom_attributes_comments(self):
-    # pylint: disable=not-an-iterable; self._related_comments is a list-like
-    return [comment for comment in self._related_comments
-            if comment.revision_id]
-
-  @staticmethod
-  def _multi_choice_options_to_flags(cad):
-    """Parse mandatory comment and evidence flags from dropdown CA definition.
-
-    Args:
-      cad - a CA definition object
-
-    Returns:
-      {option_value: Flags} - a dict from dropdown options values to Flags
-                              objects where Flags.comment_required and
-                              Flags.evidence_required correspond to the values
-                              from multi_choice_mandatory bitmasks
-    """
-    flags = namedtuple("Flags", ["comment_required", "evidence_required"])
-
-    def make_flags(multi_choice_mandatory):
-      flags_mask = int(multi_choice_mandatory)
-      return flags(comment_required=flags_mask & (CustomAttributeDefinition
-                                                  .MultiChoiceMandatoryFlags
-                                                  .COMMENT_REQUIRED),
-                   evidence_required=flags_mask & (CustomAttributeDefinition
-                                                   .MultiChoiceMandatoryFlags
-                                                   .EVIDENCE_REQUIRED))
-
-    if not cad.multi_choice_options or not cad.multi_choice_mandatory:
-      return {}
-    else:
-      return dict(zip(
-          cad.multi_choice_options.split(","),
-          (make_flags(mask)
-           for mask in cad.multi_choice_mandatory.split(",")),
-      ))
-
   @validates("status")
   def validate_status(self, key, value):
-    """Check that mandatory fields and CAs are filled in.
-
-    Also checks that comments and evidences required by dropdown CAs present.
-    """
+    """Check that no CA-introduced completion preconditions are missing."""
     # support for multiple validators for status
     if hasattr(super(ValidateOnComplete, self), "validate_status"):
       value = super(ValidateOnComplete, self).validate_status(key, value)
 
-    # pylint: disable=attribute-defined-outside-init ; it's a mixin
-
     if self.status in self.NOT_DONE_STATES and value in self.DONE_STATES:
-      # CA checks
-      errors = []
-      comments = self._get_custom_attributes_comments()
-      self._definition_value_map = {int(cav.custom_attribute_id): cav
-                                    for cav in self.custom_attribute_values}
-      self._ca_comment_map = {
-          int(comment.revision
-              .content["custom_attribute_id"]): comment
-          for comment in comments
-      }
-      for cad in self.custom_attribute_definitions:
-        # find the value for this definition
-        cav = self._definition_value_map.get(cad.id)
-
-        # check mandatory values
-        errors += self._check_mandatory_value(cad, cav)
-
-        # check relevant comments and attachments
-        if cad.attribute_type == CustomAttributeDefinition.ValidTypes.DROPDOWN:
-          errors += self._check_dropdown_requirements(cad, cav)
-
-      if errors:
-        raise ValidationError(". ".join(errors))
+      if hasattr(self, "preconditions_failed") and self.preconditions_failed:
+        raise ValidationError("CA-introduced completion preconditions "
+                              "are not satisfied. Check preconditions_failed "
+                              "of items of self.custom_attribute_values")
 
     return value
-
-  @staticmethod
-  def _check_mandatory_value(cad, cav):
-    if cad.mandatory and (not cav or not cav.attribute_value):
-      return [
-          "Value for definition #{cad.id} is missing or empty"
-          .format(cad=cad),
-      ]
-    else:
-      return []
-
-  def _check_dropdown_requirements(self, cad, cav):
-    """Check mandatory comment and evidence for the CA value."""
-    errors = []
-    options_to_flags = self._multi_choice_options_to_flags(cad)
-    if cav:
-      flags = options_to_flags.get(cav.attribute_value)
-      if flags:
-        if flags.comment_required:
-          # check the presence of a comment mapped to the CA
-          errors += self._check_mandatory_comment(cad, cav)
-        if flags.evidence_required:
-          # check the presence of an evidence
-          errors += self._check_mandatory_evidence(cad, cav)
-    return errors
-
-  def _check_mandatory_comment(self, cad, cav):
-    """Check mandatory comment for the CA value."""
-    if not self._ca_comment_map.get(cad.id):
-      return [
-          "Comment required by {cad.id} on "
-          "value '{cav.attribute_value}'"
-          .format(cad=cad, cav=cav),
-      ]
-    else:
-      return []
-
-  def _check_mandatory_evidence(self, cad, cav):
-    # pylint: disable=no-self-use
-    # pylint: disable=unused-argument
-    # not implemented yet
-    return []

--- a/src/ggrc/models/mixins/validate_on_complete.py
+++ b/src/ggrc/models/mixins/validate_on_complete.py
@@ -32,12 +32,12 @@ class ValidateOnComplete(object):
     """Comments related to self via Relationship table."""
     from ggrc.models.relationship import Relationship
     comment_id = case(
-        [(Relationship.destination_type == 'Comment',
+        [(Relationship.destination_type == "Comment",
           Relationship.destination_id)],
         else_=Relationship.source_id,
     )
     commentable_id = case(
-        [(Relationship.destination_type == 'Comment',
+        [(Relationship.destination_type == "Comment",
           Relationship.source_id)],
         else_=Relationship.destination_id,
     )
@@ -55,8 +55,8 @@ class ValidateOnComplete(object):
     """Special query to fetch all required fields."""
     query = super(ValidateOnComplete, cls).eager_query()
     return query.options(
-        orm.subqueryload('_related_comments')
-           .joinedload('revision'),
+        orm.subqueryload("_related_comments")
+           .joinedload("revision"),
     )
 
   def _get_custom_attributes_comments(self):
@@ -77,7 +77,7 @@ class ValidateOnComplete(object):
                               Flags.evidence_required correspond to the values
                               from multi_choice_mandatory bitmasks
     """
-    flags = namedtuple('Flags', ['comment_required', 'evidence_required'])
+    flags = namedtuple("Flags", ["comment_required", "evidence_required"])
 
     def make_flags(multi_choice_mandatory):
       flags_mask = int(multi_choice_mandatory)
@@ -92,12 +92,12 @@ class ValidateOnComplete(object):
       return {}
     else:
       return dict(zip(
-          cad.multi_choice_options.split(','),
+          cad.multi_choice_options.split(","),
           (make_flags(mask)
-           for mask in cad.multi_choice_mandatory.split(',')),
+           for mask in cad.multi_choice_mandatory.split(",")),
       ))
 
-  @validates('status')
+  @validates("status")
   def validate_status(self, key, value):
     """Check that mandatory fields and CAs are filled in.
 
@@ -117,7 +117,7 @@ class ValidateOnComplete(object):
                                     for cav in self.custom_attribute_values}
       self._ca_comment_map = {
           int(comment.revision
-              .content['custom_attribute_id']): comment
+              .content["custom_attribute_id"]): comment
           for comment in comments
       }
       for cad in self.custom_attribute_definitions:
@@ -132,7 +132,7 @@ class ValidateOnComplete(object):
           errors += self._check_dropdown_requirements(cad, cav)
 
       if errors:
-        raise ValidationError('. '.join(errors))
+        raise ValidationError(". ".join(errors))
 
     return value
 
@@ -140,7 +140,7 @@ class ValidateOnComplete(object):
   def _check_mandatory_value(cad, cav):
     if cad.mandatory and (not cav or not cav.attribute_value):
       return [
-          'Value for definition #{cad.id} is missing or empty'
+          "Value for definition #{cad.id} is missing or empty"
           .format(cad=cad),
       ]
     else:

--- a/test/integration/ggrc/api_helper.py
+++ b/test/integration/ggrc/api_helper.py
@@ -120,6 +120,8 @@ class Api(object):
       response, db.Model: The put response from the server and the modified
         object if the put request was successful.
     """
+    if data is None:
+      data = {}
     obj_dict = builder.json.publish(obj)
     builder.json.publish_representation(obj_dict)
     obj_dict.update(data)

--- a/test/integration/ggrc/converters/test_imported_api_requests.py
+++ b/test/integration/ggrc/converters/test_imported_api_requests.py
@@ -32,7 +32,7 @@ class TestComprehensiveSheets(TestCase):
             if model_name not in WHITELIST]
 
   # limit found by trial and error, may need tweaking if models change
-  LIMIT = 30
+  LIMIT = 32
 
   def setUp(self):
     TestCase.setUp(self)

--- a/test/integration/ggrc/models/factories.py
+++ b/test/integration/ggrc/models/factories.py
@@ -192,3 +192,9 @@ class PersonFactory(ModelFactory):
 
   class Meta:
     model = models.Person
+
+
+class CommentFactory(ModelFactory):
+
+  class Meta:
+    model = models.Comment

--- a/test/integration/ggrc/models/mixins/test_customattributable_preconditions_failed.py
+++ b/test/integration/ggrc/models/mixins/test_customattributable_preconditions_failed.py
@@ -1,0 +1,174 @@
+# Copyright (C) 2016 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Integration tests for "preconditions_failed" CAV and CAable fields logic."""
+
+from ggrc.models.assessment import Assessment
+from integration.ggrc import TestCase
+from integration.ggrc import generator
+from integration.ggrc.models import factories
+
+GENERATOR = generator.ObjectGenerator()
+
+
+# pylint: disable=too-many-instance-attributes
+class CustomAttributeMock(object):
+  """Defines CustomAttributeDefinition and CustomAttributeValue objects"""
+
+  # pylint: disable=too-many-arguments
+  def __init__(self, attributable, attribute_type="Text", mandatory=False,
+               dropdown_parameters=None, global_=False, value=None):
+    self.attributable = attributable
+    self.attribute_type = attribute_type
+    self.mandatory = mandatory
+    self.dropdown_parameters = dropdown_parameters
+    self.attribute_value = value
+    self.global_ = global_
+    self.definition = self.make_definition()
+    self.value = self.make_value()
+
+  def make_definition(self):
+    """Generate a custom attribute definition."""
+    definition = factories.CustomAttributeDefinitionFactory(
+        attribute_type=self.attribute_type,
+        definition_type=self.attributable.__class__.__name__,
+        definition_id=None if self.global_ else self.attributable.id,
+        mandatory=self.mandatory,
+        multi_choice_options=(self.dropdown_parameters[0]
+                              if self.dropdown_parameters else None),
+        multi_choice_mandatory=(self.dropdown_parameters[1]
+                                if self.dropdown_parameters else None),
+    )
+    return definition
+
+  def make_value(self):
+    """Generate a custom attribute value."""
+    if self.attribute_value is not None:
+      value = factories.CustomAttributeValueFactory(
+          custom_attribute_id=self.definition.id,
+          attributable_type=self.attributable.__class__.__name__,
+          attributable_id=self.attributable.id,
+          attribute_value=self.attribute_value,
+      )
+    else:
+      value = None
+    return value
+
+
+# pylint: disable=super-on-old-class; TestCase is a new-style class
+class TestPreconditionsFailed(TestCase):
+  """Integration tests suite for preconditions_failed fields logic."""
+
+  # pylint: disable=invalid-name
+
+  def setUp(self):
+    super(TestPreconditionsFailed, self).setUp()
+    self.assessment = factories.AssessmentFactory(
+        status=Assessment.PROGRESS_STATE,
+    )
+
+  def test_preconditions_failed_with_no_ca(self):
+    """No preconditions failed with no CA restrictions."""
+    preconditions_failed = self.assessment.preconditions_failed
+
+    self.assertEqual(preconditions_failed, False)
+
+  def test_preconditions_failed_with_no_mandatory_ca(self):
+    """No preconditions failed with no CA-introduced restrictions."""
+    ca_text = CustomAttributeMock(self.assessment, attribute_type="Text",
+                                  value="")
+    ca_cbox = CustomAttributeMock(self.assessment, attribute_type="Checkbox",
+                                  value="")
+
+    preconditions_failed = self.assessment.preconditions_failed
+
+    self.assertEqual(preconditions_failed, False)
+    self.assertFalse(ca_text.value.preconditions_failed)
+    self.assertFalse(ca_cbox.value.preconditions_failed)
+
+  def test_preconditions_failed_with_mandatory_empty_ca(self):
+    """Preconditions failed if mandatory CA is empty."""
+    ca = CustomAttributeMock(self.assessment, mandatory=True, value="")
+
+    preconditions_failed = self.assessment.preconditions_failed
+
+    self.assertEqual(preconditions_failed, True)
+    self.assertEqual(ca.value.preconditions_failed,
+                     ["value"])
+
+  def test_preconditions_failed_with_mandatory_filled_ca(self):
+    """No preconditions failed if mandatory CA is filled."""
+    ca = CustomAttributeMock(self.assessment, mandatory=True, value="Foo")
+
+    preconditions_failed = self.assessment.preconditions_failed
+
+    self.assertEqual(preconditions_failed, False)
+    self.assertFalse(ca.value.preconditions_failed)
+
+  def test_preconditions_failed_with_mandatory_empty_global_ca(self):
+    """Preconditions failed if global mandatory CA is empty."""
+    ca = CustomAttributeMock(self.assessment, mandatory=True, global_=True,
+                             value="")
+
+    preconditions_failed = self.assessment.preconditions_failed
+
+    self.assertEqual(preconditions_failed, True)
+    self.assertEqual(ca.value.preconditions_failed, ["value"])
+
+  def test_preconditions_failed_with_mandatory_filled_global_ca(self):
+    """No preconditions failed if global mandatory CA is filled."""
+    ca = CustomAttributeMock(self.assessment, mandatory=True, global_=True,
+                             value="Foo")
+
+    preconditions_failed = self.assessment.preconditions_failed
+
+    self.assertEqual(preconditions_failed, False)
+    self.assertFalse(ca.value.preconditions_failed)
+
+  def test_preconditions_failed_with_missing_mandatory_comment(self):
+    """Preconditions failed if comment required by CA is missing."""
+    ca = CustomAttributeMock(
+        self.assessment,
+        attribute_type="Dropdown",
+        dropdown_parameters=("foo,comment_required", "0,1"),
+        value="comment_required",
+    )
+
+    preconditions_failed = self.assessment.preconditions_failed
+
+    self.assertEqual(preconditions_failed, True)
+    self.assertEqual(ca.value.preconditions_failed, ["comment"])
+
+  def test_preconditions_failed_with_present_mandatory_comment(self):
+    """No preconditions failed if comment required by CA is present."""
+    ca = CustomAttributeMock(
+        self.assessment,
+        attribute_type="Dropdown",
+        dropdown_parameters=("foo,comment_required", "0,1"),
+        value=None,  # the value is made with generator to store revision too
+    )
+    _, ca.value = GENERATOR.generate_custom_attribute_value(
+        custom_attribute_id=ca.definition.id,
+        attributable=self.assessment,
+        attribute_value="comment_required",
+    )
+    comment = factories.CommentFactory(
+        assignee_type="Assessor",
+        description="Mandatory comment",
+    )
+    comment.custom_attribute_revision_upd({
+        "custom_attribute_revision_upd": {
+            "custom_attribute_value": {
+                "id": ca.value.id,
+            },
+        },
+    })
+    factories.RelationshipFactory(
+        source=self.assessment,
+        destination=comment,
+    )
+
+    preconditions_failed = self.assessment.preconditions_failed
+
+    self.assertEqual(preconditions_failed, False)
+    self.assertFalse(ca.value.preconditions_failed)

--- a/test/integration/ggrc/models/mixins/test_validate_on_complete.py
+++ b/test/integration/ggrc/models/mixins/test_validate_on_complete.py
@@ -18,7 +18,7 @@ class CustomAttributeMock(object):
   """Defines CustomAttributeDefinition and CustomAttributeValue objects"""
 
   # pylint: disable=too-many-arguments
-  def __init__(self, attributable, attribute_type='Text', mandatory=False,
+  def __init__(self, attributable, attribute_type="Text", mandatory=False,
                dropdown_parameters=None, global_=False, value=None):
     self.attributable = attributable
     self.attribute_type = attribute_type
@@ -67,7 +67,7 @@ class TestValidateOnComplete(TestCase):
     _, assessment = GENERATOR.generate_object(
         Assessment,
         data={
-            'status': Assessment.PROGRESS_STATE,
+            "status": Assessment.PROGRESS_STATE,
         },
     )
     return assessment
@@ -89,8 +89,8 @@ class TestValidateOnComplete(TestCase):
 
   def test_validates_with_no_mandatory_ca(self):
     """Validation ok with no CA-introduced restrictions."""
-    CustomAttributeMock(self.assessment, attribute_type='Text')
-    CustomAttributeMock(self.assessment, attribute_type='Checkbox')
+    CustomAttributeMock(self.assessment, attribute_type="Text")
+    CustomAttributeMock(self.assessment, attribute_type="Checkbox")
     self.refresh(self.assessment)
 
     self.assessment.status = self.assessment.FINAL_STATE
@@ -109,7 +109,7 @@ class TestValidateOnComplete(TestCase):
 
   def test_validates_with_mandatory_filled_ca(self):
     """Validation ok if mandatory CA is filled."""
-    CustomAttributeMock(self.assessment, mandatory=True, value='Foo')
+    CustomAttributeMock(self.assessment, mandatory=True, value="Foo")
     self.refresh(self.assessment)
 
     self.assessment.status = self.assessment.FINAL_STATE
@@ -129,7 +129,7 @@ class TestValidateOnComplete(TestCase):
   def test_validates_with_mandatory_filled_global_ca(self):
     """Validation ok if global mandatory CA is filled."""
     CustomAttributeMock(self.assessment, mandatory=True, global_=True,
-                        value='Foo')
+                        value="Foo")
     self.refresh(self.assessment)
 
     self.assessment.status = self.assessment.FINAL_STATE
@@ -140,9 +140,9 @@ class TestValidateOnComplete(TestCase):
     """Validation fails if comment required by CA is missing."""
     CustomAttributeMock(
         self.assessment,
-        attribute_type='Dropdown',
-        dropdown_parameters=('foo,comment_required', '0,1'),
-        value='comment_required',
+        attribute_type="Dropdown",
+        dropdown_parameters=("foo,comment_required", "0,1"),
+        value="comment_required",
     )
     self.refresh(self.assessment)
 
@@ -155,17 +155,17 @@ class TestValidateOnComplete(TestCase):
     """Validation ok if comment required by CA is present."""
     ca = CustomAttributeMock(
         self.assessment,
-        attribute_type='Dropdown',
-        dropdown_parameters=('foo,comment_required', '0,1'),
-        value='comment_required',
+        attribute_type="Dropdown",
+        dropdown_parameters=("foo,comment_required", "0,1"),
+        value="comment_required",
     )
     _, comment = GENERATOR.generate_comment(
         commentable=self.assessment,
-        assignee_type='Assessor',
-        description='Mandatory comment',
+        assignee_type="Assessor",
+        description="Mandatory comment",
         custom_attribute_revision_upd={
-            'custom_attribute_value': {
-                'id': ca.value.id,
+            "custom_attribute_value": {
+                "id": ca.value.id,
             },
         },
     )

--- a/test/integration/ggrc/models/mixins/test_validate_on_complete.py
+++ b/test/integration/ggrc/models/mixins/test_validate_on_complete.py
@@ -3,95 +3,35 @@
 
 """Integration tests for ValidateOnComplete mixin"""
 
-from ggrc import db
 from ggrc.models.assessment import Assessment
 from ggrc.models.exceptions import ValidationError
-from integration.ggrc import generator
 from integration.ggrc import TestCase
+from integration.ggrc.models import factories
 
 
-GENERATOR = generator.ObjectGenerator()
-
-
-# pylint: disable=too-many-instance-attributes
-class CustomAttributeMock(object):
-  """Defines CustomAttributeDefinition and CustomAttributeValue objects"""
-
-  # pylint: disable=too-many-arguments
-  def __init__(self, attributable, attribute_type="Text", mandatory=False,
-               dropdown_parameters=None, global_=False, value=None):
-    self.attributable = attributable
-    self.attribute_type = attribute_type
-    self.mandatory = mandatory
-    self.dropdown_parameters = dropdown_parameters
-    self.attribute_value = value
-    self.global_ = global_
-    self.definition = self.make_definition()
-    self.value = self.make_value()
-
-  def make_definition(self):
-    """Generate a custom attribute definition."""
-    _, definition = GENERATOR.generate_custom_attribute(
-        attribute_type=self.attribute_type,
-        definition_type=self.attributable.__class__.__name__,
-        definition_id=None if self.global_ else self.attributable.id,
-        mandatory=self.mandatory,
-        multi_choice_options=(self.dropdown_parameters[0]
-                              if self.dropdown_parameters else None),
-        multi_choice_mandatory=(self.dropdown_parameters[1]
-                                if self.dropdown_parameters else None),
-    )
-    return definition
-
-  def make_value(self):
-    """Generate a custom attribute value."""
-    if self.attribute_value is not None:
-      _, value = GENERATOR.generate_custom_attribute_value(
-          custom_attribute_id=self.definition.id,
-          attributable=self.attributable,
-          attribute_value=self.attribute_value,
-      )
-    else:
-      value = None
-    return value
-
-
+# pylint: disable=super-on-old-class; TestCase is a new-style class
 class TestValidateOnComplete(TestCase):
   """Integration tests suite for ValidateOnComplete mixin"""
 
   # pylint: disable=invalid-name
 
-  @staticmethod
-  def create_assessment():
-    """Generate an assessment with mapped custom attributes."""
-    _, assessment = GENERATOR.generate_object(
-        Assessment,
-        data={
-            "status": Assessment.PROGRESS_STATE,
-        },
-    )
-    return assessment
-
-  @staticmethod
-  def refresh(obj):
-    db.session.add(obj)
-    db.session.refresh(obj)
-
   def setUp(self):
     super(TestValidateOnComplete, self).setUp()
-    self.assessment = self.create_assessment()
+    self.assessment = factories.AssessmentFactory(
+        status=Assessment.PROGRESS_STATE,
+    )
 
-  def test_validates_with_no_ca(self):
-    """Validation ok with no CA restrictions."""
-    self.assessment.status = self.assessment.FINAL_STATE
-
-    self.assertEqual(self.assessment.status, self.assessment.FINAL_STATE)
+  def make_custom_attribute_definition(self, mandatory):
+    return factories.CustomAttributeDefinitionFactory(
+        attribute_type="Text",
+        definition_type="Assessment",
+        definition_id=self.assessment.id,
+        mandatory=mandatory
+    )
 
   def test_validates_with_no_mandatory_ca(self):
     """Validation ok with no CA-introduced restrictions."""
-    CustomAttributeMock(self.assessment, attribute_type="Text")
-    CustomAttributeMock(self.assessment, attribute_type="Checkbox")
-    self.refresh(self.assessment)
+    self.make_custom_attribute_definition(mandatory=False)
 
     self.assessment.status = self.assessment.FINAL_STATE
 
@@ -99,79 +39,12 @@ class TestValidateOnComplete(TestCase):
 
   def test_validates_with_mandatory_empty_ca(self):
     """Validation fails if mandatory CA is empty."""
-    CustomAttributeMock(self.assessment, mandatory=True)
-    self.refresh(self.assessment)
+    self.make_custom_attribute_definition(mandatory=True)
 
     with self.assertRaises(ValidationError):
       self.assessment.status = self.assessment.FINAL_STATE
 
     self.assertEqual(self.assessment.status, self.assessment.PROGRESS_STATE)
 
-  def test_validates_with_mandatory_filled_ca(self):
-    """Validation ok if mandatory CA is filled."""
-    CustomAttributeMock(self.assessment, mandatory=True, value="Foo")
-    self.refresh(self.assessment)
-
-    self.assessment.status = self.assessment.FINAL_STATE
-
-    self.assertEqual(self.assessment.status, self.assessment.FINAL_STATE)
-
-  def test_validates_with_mandatory_empty_global_ca(self):
-    """Validation fails if global mandatory CA is empty."""
-    CustomAttributeMock(self.assessment, mandatory=True, global_=True)
-    self.refresh(self.assessment)
-
-    with self.assertRaises(ValidationError):
-      self.assessment.status = self.assessment.FINAL_STATE
-
-    self.assertEqual(self.assessment.status, self.assessment.PROGRESS_STATE)
-
-  def test_validates_with_mandatory_filled_global_ca(self):
-    """Validation ok if global mandatory CA is filled."""
-    CustomAttributeMock(self.assessment, mandatory=True, global_=True,
-                        value="Foo")
-    self.refresh(self.assessment)
-
-    self.assessment.status = self.assessment.FINAL_STATE
-
-    self.assertEqual(self.assessment.status, self.assessment.FINAL_STATE)
-
-  def test_validates_with_missing_mandatory_comment(self):
-    """Validation fails if comment required by CA is missing."""
-    CustomAttributeMock(
-        self.assessment,
-        attribute_type="Dropdown",
-        dropdown_parameters=("foo,comment_required", "0,1"),
-        value="comment_required",
-    )
-    self.refresh(self.assessment)
-
-    with self.assertRaises(ValidationError):
-      self.assessment.status = self.assessment.FINAL_STATE
-
-    self.assertEqual(self.assessment.status, self.assessment.PROGRESS_STATE)
-
-  def test_validates_with_present_mandatory_comment(self):
-    """Validation ok if comment required by CA is present."""
-    ca = CustomAttributeMock(
-        self.assessment,
-        attribute_type="Dropdown",
-        dropdown_parameters=("foo,comment_required", "0,1"),
-        value="comment_required",
-    )
-    _, comment = GENERATOR.generate_comment(
-        commentable=self.assessment,
-        assignee_type="Assessor",
-        description="Mandatory comment",
-        custom_attribute_revision_upd={
-            "custom_attribute_value": {
-                "id": ca.value.id,
-            },
-        },
-    )
-    GENERATOR.generate_relationship(self.assessment, comment)
-    self.refresh(self.assessment)
-
-    self.assessment.status = self.assessment.FINAL_STATE
-
-    self.assertEqual(self.assessment.status, self.assessment.FINAL_STATE)
+  # most of the test cases were moved to TestPreconditionsFailed since
+  # ValidateOnComplete logic depends on preconditions_failed flags


### PR DESCRIPTION
~~This PR depends on #4270 that fixes a related bug and is not functional without that bug fix.~~

This PR introduces fields that can be used to disable "Complete" button on Assessment page on the frontend.

The new JSON representation of an Assessment with several CA values with the new fields is as follows:
```js
"assessment": {
  "custom_attribute_values": [
    {
      // a dropdown with missing mandatory comment
      "attribute_value": "some value that requires a mandatory comment",
      "preconditions_failed": ["comment"],  // this list contains every failed precondition; its items can be "comment", "evidence" and "value"
      // other CAV fields
    }
  ],
  "preconditions_failed": true,  // this field is true if any precondition of any CA value failed
  // other Assessment fields
}
```

`Assessment.preconditions_failed` is `true` even in the case when a mandatory CAD has a missing associated CAV and that CAV is not listed in `custom_attribute_values` list.