### PR TITLE
Increase BATCH_SIZE for post requests

### DIFF
--- a/src/ggrc/assets/javascripts/models/save_queue.js
+++ b/src/ggrc/assets/javascripts/models/save_queue.js
@@ -22,7 +22,7 @@
 
     DELAY: 100, // Number of ms to wait before the first batch is fired
     BATCH: GGRC.config.MAX_INSTANCES || 3, // Maximum number of POST/PUT requests at any given time
-    BATCH_SIZE: 100,
+    BATCH_SIZE: 1000,
     _queue: [],
     _buckets: {},
     _timeout: null,


### PR DESCRIPTION
Now that we have a better collection_post implementation on the
backend it's safe to increase the number of objects batched.

This will decrease the time needed for creating more than 100
objects since the backend API will not need to load permissions
multiple times.