### PR TITLE
ISSUE-1.138 Fix cached permissions for audit create

### DIFF
--- a/src/ggrc/converters/base_row.py
+++ b/src/ggrc/converters/base_row.py
@@ -216,6 +216,8 @@ class RowConverter(object):
     elif self.is_new:
       Resource.model_posted.send(
           self.object_class, obj=self.obj, src={}, service=service_class)
+      Resource.collection_posted.send(
+          self.object_class, objects=[self.obj], sources=[{}])
     else:
       Resource.model_put.send(
           self.object_class, obj=self.obj, src={}, service=service_class)

--- a/src/ggrc_basic_permissions/__init__.py
+++ b/src/ggrc_basic_permissions/__init__.py
@@ -4,6 +4,8 @@
 """Initialize RBAC"""
 
 import datetime
+import itertools
+
 import sqlalchemy.orm
 from sqlalchemy import and_
 from sqlalchemy import case
@@ -12,6 +14,7 @@ from sqlalchemy import or_
 from sqlalchemy.orm import aliased
 from flask import Blueprint
 from flask import g
+
 from ggrc import db
 from ggrc import settings
 from ggrc.app import app
@@ -935,11 +938,12 @@ def create_audit_context(audit):
   audit.context = context
 
 
-@Resource.model_posted.connect_via(Audit)
-def handle_audit_post(sender, obj=None, src=None, service=None):
-  if not src.get("operation", None):
-    db.session.flush()
-    create_audit_context(obj)
+@Resource.collection_posted.connect_via(Audit)
+def handle_audit_post(sender, objects=None, sources=None):
+  for obj, src in itertools.izip(objects, sources):
+    if not src.get("operation", None):
+      db.session.flush()
+      create_audit_context(obj)
 
 
 @Resource.model_deleted.connect


### PR DESCRIPTION
**Steps to reproduce:** 
* Log as Global Reader
* Create a program -> Create an audit -> Save
* Look at the console (F12)

**Actual Result:** Error "Failed to load resource: the server responded with a status of 403" in the console occurs while creating an audit under GR role

**Expected Result:** No error. An audit is created under GR role.

The bug is not reproduced in development environment without cache.