### PR TITLE
QUICK FIX exception displayed while mapping Access Group to Assessment object

### DIFF
--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -2797,11 +2797,14 @@ Mustache.registerHelper("fadeout", function (delay, prop, options) {
 
   Mustache.registerHelper('current_cycle_assignee',
     function (instance, options) {
-      var mapping = instance.get_mapping('current_approval_cycles');
+      var mapping;
       var approvalCycle;
       var binding;
       var finish;
       var progress;
+
+      instance = Mustache.resolve(instance);
+      mapping = instance.get_mapping('current_approval_cycles');
 
       if (!mapping || !mapping.length) {
         return options.inverse();
@@ -2824,6 +2827,7 @@ Mustache.registerHelper("fadeout", function (delay, prop, options) {
     });
 
 Mustache.registerHelper("with_mapping_count", function (instance, mapping_names, options) {
+  
   var args = can.makeArray(arguments)
     , options = args[args.length-1]  // FIXME duplicate declaration
     , mapping_name

--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -2826,8 +2826,8 @@ Mustache.registerHelper("fadeout", function (delay, prop, options) {
       }, binding.refresh_instances());
     });
 
-Mustache.registerHelper("with_mapping_count", function (instance, mapping_names, options) {
-  
+Mustache.registerHelper('with_mapping_count', function (instance, mapping_names, options) {
+
   var args = can.makeArray(arguments)
     , options = args[args.length-1]  // FIXME duplicate declaration
     , mapping_name


### PR DESCRIPTION
**Subject:** "Uncaught TypeError: instance.get_mapping is not a function" error is displayed while mapping Access Group to Assessment object
**Details:** 
- Create an audit
- Create assessment object
- Click + to map objects
- Select Access Groups in dropdown
- Click Search button -> about 10 objects are found
- Expand each object (click triangle before title)

**Actual Result:** While expanding the objects details following error is displayed: "Uncaught **TypeError:** instance.get_mapping is not a function". Error is not displayed for all found objects.
**Expected Result:** No errors displayed.
**Workaround:** N/A
