### PR TITLE
QUICK-FIX Prevent multiple redundant permission GETs

### DIFF
--- a/src/ggrc/assets/javascripts/models/save_queue.js
+++ b/src/ggrc/assets/javascripts/models/save_queue.js
@@ -54,7 +54,7 @@
               return;
             }
           }
-          if ("background_task" in data) {
+          if ('background_task' in data) {
             return CMS.Models.BackgroundTask.findOne({
               id: data.background_task.id
             }).then(function (task) {
@@ -101,6 +101,8 @@
           }
         });
       });
+
+      bucket.save_responses.length = 0;
     },
 
     _step: function (elem) {
@@ -123,7 +125,7 @@
       };
       if (obj.isNew()) {
         type = obj.constructor.table_singular;
-        bucketName = type + (obj.run_in_background ? "_bg" : "");
+        bucketName = type + (obj.run_in_background ? '_bg' : '');
         bucket = this._buckets[bucketName];
 
         if (_.isUndefined(bucket)) {

--- a/src/ggrc/assets/javascripts/models/tests/save_queue_spec.js
+++ b/src/ggrc/assets/javascripts/models/tests/save_queue_spec.js
@@ -1,0 +1,58 @@
+/*!
+  Copyright (C) 2016 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+describe('GGRC.SaveQueue', function () {
+  'use strict';
+
+  describe('_process_save_responses() method', function () {
+    var bucket;
+    var method;  // the method under test
+
+    beforeEach(function () {
+      var thisContext = {};
+
+      method = GGRC.SaveQueue._process_save_responses.bind(thisContext);
+
+      bucket = {
+        objs: [],
+        type: 'audit',
+        plural: 'audits',
+        background: false,
+        save_responses: [],
+        in_flight: false
+      };
+    });
+
+    // a helper function for generating fake response objects as stored in
+    // buckets' save_responses list
+    function makeResponse(objType, objId) {
+      var modelInstance = {
+        type: objType,
+        id: objId,
+        _save: jasmine.createSpy('_save'),
+        _dfd: new can.Deferred()
+      };
+
+      var response = [
+        [modelInstance],
+        [
+          [201, {audit: modelInstance}]
+        ]
+      ];
+
+      return response;
+    }
+
+    it('clears the given bucket\'s response list', function () {
+      var resp = makeResponse('Audit', 1);
+      var resp2 = makeResponse('Audit', 2);
+      bucket.save_responses = [resp, resp2];
+
+      method(bucket);
+
+      expect(bucket.save_responses).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
This PR fixes the issue in `SaveQueue` that didn't clear the saved responses in a bucket after processing them. This resulted in unnecessary processing of old responses.

---

**Steps to reproduce:**
- Create a program, visit the Audits tab
- Create a few Audits without refreshing the page

You will notice in browser's Network tab that each created Audit results in several permission GET requests - the N-th created Audits causes the permissions to be fetched N times.

The same issue probably affected other Cacheable models as well, because using the SaveQueue is baked into the `can.Model.Cacheable.save()` method.