### PR TITLE
ISSUE-1.175 Fix mapping to Person

### DIFF
--- a/src/ggrc/assets/javascripts/apps/business_objects.js
+++ b/src/ggrc/assets/javascripts/apps/business_objects.js
@@ -833,6 +833,7 @@
             mapping: 'extended_related_assessment_via_search',
             child_options: relatedObjectsChildOptions,
             draw_children: true,
+            add_item_view: null,
             header_view:
               path + '/assessments/tree_header.mustache'
           }


### PR DESCRIPTION
**Subject:** "Uncaught TypeError: Cannot read property 'findInCacheById' of undefined" error occurs when create an assessment in dashboard
**Details:**   Go to dashboard
Click on assessments icon
Click [+] to map Assessment->Click on Create New
**Actual Result:** "Uncaught TypeError: Cannot read property 'findInCacheById' of undefined" error occurs while mapping an object in Create New task form
**Expected Result:** No error. Assessment should be created. 

UPDATE:
Need remove [+] button from Assessment tab on My Page