### PR TITLE
FEATURE Mandatory evidence check

### DIFF
--- a/src/ggrc/models/custom_attribute_value.py
+++ b/src/ggrc/models/custom_attribute_value.py
@@ -320,9 +320,25 @@ class CustomAttributeValue(Base, db.Model):
 
   def _check_mandatory_evidence(self):
     """Check presence of mandatory evidence."""
-    # pylint: disable=no-self-use
-    # not implemented yet
-    return []
+    if hasattr(self.attributable, "object_documents"):
+      # Note: this is a suboptimal implementation of mandatory evidence check;
+      # it should be refactored once Evicence-CA mapping is introduced
+      def evidence_required(cav):
+        """Return True if an evidence is required for this `cav`."""
+        flags = (self._multi_choice_options_to_flags(cav.custom_attribute)
+                 .get(cav.attribute_value))
+        return flags and flags.evidence_required
+      evidence_found = (len(self.attributable.object_documents) >=
+                        len([cav
+                             for cav in self.attributable
+                                            .custom_attribute_values
+                             if evidence_required(cav)]))
+    else:
+      evidence_found = False
+    if not evidence_found:
+      return ["evidence"]
+    else:
+      return []
 
   @staticmethod
   def _multi_choice_options_to_flags(cad):

--- a/test/integration/ggrc/models/factories.py
+++ b/test/integration/ggrc/models/factories.py
@@ -198,3 +198,15 @@ class CommentFactory(ModelFactory):
 
   class Meta:
     model = models.Comment
+
+
+class DocumentFactory(ModelFactory):
+
+  class Meta:
+    model = models.Document
+
+
+class ObjectDocumentFactory(ModelFactory):
+
+  class Meta:
+    model = models.ObjectDocument


### PR DESCRIPTION
~~This PR depends on #4275 and can't be merged before it.~~

This PR enables mandatory evidence check on the backend and makes preconditions check on the frontend unneeded.

The logic of mandatory evidence check is the same as it used to be on the frontend: mandatory evidence preconditions fails for every CAV requiring evidence if the number of evidences required is greater than the number of evidences provided. This is a temporary solution until we make a decision on how Evidence - CA mapping should behave, what can be mapped to what and how will evidence reuse work in this case.