### PR TITLE
ISSUE-1.157 Cannot read property 'editor' of undefined"

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/modals_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/modals_controller.js
@@ -844,6 +844,7 @@ can.Control('GGRC.Controllers.Modals', {
   }
 
   , new_instance: function (data) {
+    var wysihtml5;
     var params = this.find_params(),
         new_instance;
     new_instance = new this.options.model(params);
@@ -857,7 +858,13 @@ can.Control('GGRC.Controllers.Modals', {
       if (definition.attribute_type === 'Checkbox') {
         element.attr('checked', false);
       } else if (definition.attribute_type === 'Rich Text') {
-        element.data("wysihtml5").editor.clear();
+        // Check that wysihtml5 is still alive, otherwise just clean textarea
+        wysihtml5 = element.data("wysihtml5");
+        if (wysihtml5) {
+          wysihtml5.editor.clear();
+        } else {
+          element.val('');
+        }
       } else if (definition.attribute_type === 'Map:Person') {
         element = this.element.find('[name="_custom_attribute_mappings.' +
                                     definition.id + '.email"]');


### PR DESCRIPTION
**Subject**: Script error "Uncaught TypeError: Cannot read property 'editor' of undefined" appears if Save & Add Another button is clicked when creating Control on program page
**Details**: 

- Create a program
- Add Controls tab
- Click + to map Controls
- Click Create new Control
- Fill in title and click Save & Add another

**Actual Result**: Script error "Uncaught TypeError: Cannot read property 'editor' of undefined" appears
**Expected Result**: Control is saved.

Notes: Please try to reproduce it for Control with custom attribute type:RichText.