### PR TITLE
ISSUE-1.172 Cannot read property 'has_binding' of null

### DIFF
--- a/src/ggrc/assets/javascripts/components/unified_mapper/mapper.js
+++ b/src/ggrc/assets/javascripts/components/unified_mapper/mapper.js
@@ -325,14 +325,18 @@
 
       setBinding: function () {
         var binding;
-        var getBindingName = this.scope.attr('mapper').get_binding_name;
-        var selected = this.scope.attr('mapper.get_instance');
-        var tablePlural = getBindingName(
-          selected, this.scope.attr('mapper.model.table_plural'));
+        var getBindingName;
+        var selected;
+        var tablePlural;
 
         if (this.scope.attr('mapper.search_only')) {
           return;
         }
+
+        getBindingName = this.scope.attr('mapper').get_binding_name;
+        selected = this.scope.attr('mapper.get_instance');
+        tablePlural = getBindingName(
+          selected, this.scope.attr('mapper.model.table_plural'));
 
         if (!selected.has_binding(tablePlural)) {
           return;


### PR DESCRIPTION
**Subject**: "Uncaught TypeError: Cannot read property 'has_binding' of null" error appears when click Search in Admin Dashboard page
**Details**:   

- Go to Admin Dashboard page
- Click Search page
- Look at Search page: an error is displayed

**Actual Result**:  "Uncaught TypeError: Cannot read property 'has_binding' of null" error appears when click Search in Admin Dashboard page
**Expected Result**: No error displayed