### PR TITLE
QUICK FIX scope.needConfirm.confirm exception

### DIFF
--- a/src/ggrc/assets/javascripts/components/inline_edit/inline.js
+++ b/src/ggrc/assets/javascripts/components/inline_edit/inline.js
@@ -44,12 +44,7 @@
        */
       enableEdit: function (scope, $el, ev) {
         ev.preventDefault();
-        if (!this.attr('readonly') && scope.needConfirm) {
-          scope.needConfirm.confirm(scope.instance, scope.needConfirm)
-            .done(function () {
-              this.attr('context.isEdit', true);
-            }.bind(this));
-        } else if (!this.attr('readonly')) {
+        if (!this.attr('readonly')) {
           this.attr('context.isEdit', true);
         }
       },

--- a/src/ggrc/assets/mustache/custom_attributes/info.mustache
+++ b/src/ggrc/assets/mustache/custom_attributes/info.mustache
@@ -12,7 +12,6 @@
           <div data-custom-attribute="{{id}}" data-type="{{attribute_type}}">
             <inline-edit
               instance="instance"
-              need-confirm="confirmEdit"
               ca-id="cad.id"
               {{#if cav.attribute_object}}
               value="cav.attribute_object"


### PR DESCRIPTION
**Subject:** "Uncaught TypeError: scope.needConfirm.confirm is not a function" error occurs while edit in People's Info panel 
**Details:**   
- Create a program
- Navigate to People tab
- Navigate to People’s Info panel
- Edit a value in any editable field

**Actual Result:**  "Uncaught TypeError: scope.needConfirm.confirm is not a function" error occurs while edit in People's Info panel 
**Expected Result:** No errors displayed/ Should be the possibility to edit editable fields. 
**Workaround:** Navigate to People’s Info page and edit.
