### PR TITLE
Use refresh queue to fetch the user object in person-info 

### DIFF
--- a/src/ggrc/assets/javascripts/components/person/person.js
+++ b/src/ggrc/assets/javascripts/components/person/person.js
@@ -75,8 +75,8 @@
       }
 
       // but if not in cache, we need to fetch the person object...
-      CMS.Models.Person
-        .findOne({id: personId})
+      person = new CMS.Models.Person({id: personId});
+      new RefreshQueue().enqueue(person).trigger()
         .then(function (person) {
           scope.attr('personObj', person);
         }, function () {

--- a/src/ggrc/assets/javascripts/components/person/tests/person_spec.js
+++ b/src/ggrc/assets/javascripts/components/person/tests/person_spec.js
@@ -32,7 +32,7 @@ describe('GGRC.Components.personItem', function () {
 
     beforeEach(function () {
       dfdFindOne = new can.Deferred();
-      spyOn(CMS.Models.Person, 'findOne').and.returnValue(dfdFindOne);
+      spyOn(RefreshQueue.prototype, 'trigger').and.returnValue(dfdFindOne);
     });
 
     afterEach(function () {
@@ -75,7 +75,7 @@ describe('GGRC.Components.personItem', function () {
 
         dfdFindOne.resolve(person123);
 
-        expect(CMS.Models.Person.findOne).toHaveBeenCalledWith({id: 123});
+        expect(RefreshQueue.prototype.trigger).toHaveBeenCalled();
         expect(component.scope.attr('personObj')).toBe(person123);
       }
     );
@@ -99,7 +99,7 @@ describe('GGRC.Components.personItem', function () {
 
         dfdFindOne.resolve(fetchedPerson);
 
-        expect(CMS.Models.Person.findOne).toHaveBeenCalledWith({id: 123});
+        expect(RefreshQueue.prototype.trigger).toHaveBeenCalled();
         expect(component.scope.attr('personObj')).toBe(fetchedPerson);
       }
     );
@@ -113,7 +113,7 @@ describe('GGRC.Components.personItem', function () {
         frag = $(frag);
         component = frag.find('person-info').control();
 
-        expect(CMS.Models.Person.findOne).not.toHaveBeenCalled();
+        expect(RefreshQueue.prototype.trigger).not.toHaveBeenCalled();
         expect(console.warn).toHaveBeenCalled();
       }
     );
@@ -130,7 +130,7 @@ describe('GGRC.Components.personItem', function () {
       frag = $(frag);
       component = frag.find('person-info').control();
 
-      expect(CMS.Models.Person.findOne).toHaveBeenCalledWith({id: 123});
+      expect(RefreshQueue.prototype.trigger).toHaveBeenCalled();
     });
     it('gets person object from and doesn\'t make a request', function () {
       var personObj = new can.Map({
@@ -150,7 +150,7 @@ describe('GGRC.Components.personItem', function () {
 
       expect(component.scope.attr('personObj'))
           .toBe(CMS.Models.Person.cache['123']);
-      expect(CMS.Models.Person.findOne).not.toHaveBeenCalled();
+      expect(RefreshQueue.prototype.trigger).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
When the user object is not in cache we need to user the refresh
queue instead of the findOne call in order to prevent multiple
request being sent to the server.