### PR TITLE
ISSUE-1.56 Add Control description in the preview window

### DIFF
--- a/src/ggrc/assets/mustache/controls/tier2_content.mustache
+++ b/src/ggrc/assets/mustache/controls/tier2_content.mustache
@@ -7,6 +7,7 @@
 
 <div class="tier-content">
   {{{render '/static/mustache/base_objects/general_info.mustache' instance=instance }}}
+  {{{render '/static/mustache/base_objects/description.mustache' instance=instance}}}
   {{{renderLive '/static/mustache/base_objects/notes_and_code.mustache' instance=instance}}}
   {{{renderLive '/static/mustache/base_objects/mappings_detail.mustache' result=result parent_instance=parent_instance}}}
   {{{renderLive '/static/mustache/base_objects/contacts.mustache' instance=instance}}}

--- a/src/ggrc/assets/mustache/directives/tier2_content.mustache
+++ b/src/ggrc/assets/mustache/directives/tier2_content.mustache
@@ -7,6 +7,7 @@
 
 <div class="tier-content">
   {{{render '/static/mustache/base_objects/general_info.mustache' instance=instance }}}
+  {{{render '/static/mustache/base_objects/description.mustache' instance=instance}}}
   {{{renderLive '/static/mustache/base_objects/mappings_detail.mustache' result=result parent_instance=parent_instance}}}
   {{{renderLive '/static/mustache/base_objects/contacts.mustache' instance=instance}}}
   {{#instance.url}}

--- a/src/ggrc/assets/mustache/objectives/tier2_content.mustache
+++ b/src/ggrc/assets/mustache/objectives/tier2_content.mustache
@@ -7,6 +7,7 @@
 
 <div class="tier-content">
   {{{render '/static/mustache/base_objects/general_info.mustache' instance=instance }}}
+  {{{render '/static/mustache/base_objects/description.mustache' instance=instance}}}
   {{{renderLive '/static/mustache/base_objects/notes_and_code.mustache' instance=instance}}}
   {{{renderLive '/static/mustache/base_objects/mappings_detail.mustache' result=result parent_instance=parent_instance}}}
   {{{renderLive '/static/mustache/base_objects/contacts.mustache' instance=instance}}}

--- a/src/ggrc/assets/mustache/programs/tier2_content.mustache
+++ b/src/ggrc/assets/mustache/programs/tier2_content.mustache
@@ -7,6 +7,7 @@
 
 <div class="tier-content">
   {{{render '/static/mustache/base_objects/general_info.mustache' instance=instance }}}
+  {{{render '/static/mustache/base_objects/description.mustache' instance=instance}}}
   {{{renderLive '/static/mustache/base_objects/notes_and_code.mustache' instance=instance}}}
   {{{renderLive '/static/mustache/base_objects/mappings_detail.mustache' result=result parent_instance=parent_instance}}}
   {{^if_equals instance.class.table_singular 'person'}}

--- a/src/ggrc/assets/mustache/requests/tier2_content.mustache
+++ b/src/ggrc/assets/mustache/requests/tier2_content.mustache
@@ -7,6 +7,7 @@
 
 <div class="tier-content">
   {{{render '/static/mustache/requests/general_info.mustache' instance=instance }}}
+  {{{render '/static/mustache/base_objects/description.mustache' instance=instance}}}
   {{{renderLive '/static/mustache/base_objects/mappings_detail.mustache' result=result parent_instance=parent_instance}}}
   {{{renderLive '/static/mustache/base_objects/urls.mustache' instance=instance}}}
   {{{renderLive '/static/mustache/base_objects/notes_and_code.mustache' instance=instance}}}

--- a/src/ggrc/assets/mustache/sections/tier2_content.mustache
+++ b/src/ggrc/assets/mustache/sections/tier2_content.mustache
@@ -81,6 +81,7 @@
 
 <div class="tier-content">
   {{{render '/static/mustache/base_objects/general_info.mustache' instance=instance }}}
+  {{{render '/static/mustache/base_objects/description.mustache' instance=instance}}}
   <div class="row-fluid wrap-row">
     <div class="span12">
       <h6>

--- a/src/ggrc_workflows/assets/mustache/workflows/tier2_content.mustache
+++ b/src/ggrc_workflows/assets/mustache/workflows/tier2_content.mustache
@@ -7,6 +7,7 @@
 
 <div class="tier-content">
   {{{render '/static/mustache/base_objects/general_info.mustache' instance=instance }}}
+  {{{render '/static/mustache/base_objects/description.mustache' instance=instance}}}
 
   <div class="row-fluid wrap-row">
     <div class="span6">


### PR DESCRIPTION
**Subject**: Add Control description in the preview window (unified mapping modal)
**Details**: 

-  go to Program page and open Controls tab
-  click Search button to see the controls in OBJECTS FOUND section
- Click grey triangle in a Control’s first tier in OBJECTS FOUND section

**Actual Result**: the app doesn’t show description in Control’s 2nd tier on unified mapping modal window
**Expected Result**: Add the control description to the unified mapper modal window
**Notes**: Description field should be visible for all types of objects