### PR TITLE
ISSUE-1.174 Fix Audit Task creation issue with mapped objects

### DIFF
--- a/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/modal_content.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/modal_content.mustache
@@ -72,6 +72,7 @@
       <ggrc-modal-connector
           parent_instance="instance"
           instance="instance"
+          mapping="related_objects_as_source"
           source_mapping="info_related_objects"
           default_mappings="object_params.pre_mapped_objects"
           deferred="true"


### PR DESCRIPTION
_(section 2, bug 1.174)_

This PR fixes an issue with creating a Task for an Audit.

The error was caused by the unspecified `through` property of the relevant pending join object for the Task under creation, thus the name of the mapping is now passed to the `ggrc-modal-connector` component.

If there are any use cases when this name should be dynamic, please let me know to change the fix. So far it seems that creating a new Task and later editing it both work as expected.

**Steps to reproduce:**
- Create a Program
- Create an Audit under that Program
- Navigate to Audit’s Info panel -> Click on 3bb’s button -> Select Create a task
- Map an object or two to the Task, and also make sure to remove the Audit from the "mapped object(s)" list
- Fill in the mandatory fields and click the "Save and Close" button

**Actual Result:**
_"Uncaught TypeError: Cannot read property 'loader' of undefined"_ error occurs while mapping an object in Create New task form

**Expected Result:**
No error occurs, the task is created and the specified objects are mapped to it.  
