### PR TITLE
QUICK-FIX Fix storing empty values for Map:Person

### DIFF
--- a/src/ggrc/models/custom_attribute_value.py
+++ b/src/ggrc/models/custom_attribute_value.py
@@ -227,7 +227,7 @@ class CustomAttributeValue(Base, db.Model):
 
     Note: this validator does not check if id is a proper person id.
     """
-    if ":" in self.attribute_value:
+    if self.attribute_value and ":" in self.attribute_value:
       value, id_ = self.attribute_value.split(":")
       self.attribute_value = value
       self.attribute_object_id = id_


### PR DESCRIPTION
This PR fixes storing empty Map:Person CAVs.

Steps to reproduce: make a PUT request for an Assessment with Person CAD with `custom_attribute_values = [{"custom_attribute_id": "<CAD_id>", "attribute_value": null, "attribute_object": null}]`.

Expected results: the empty value is stored and is returned in response with `"attribute_value": null, "attribute_object": null`.
Actual results: error 500 is returned because of an uncaught `AttributeError`.