### PR TITLE
ISSUE-1.180 "Uncaught TypeError: Cannot read property 'id' of undefined"

### DIFF
--- a/src/ggrc/templates/admin/index.haml
+++ b/src/ggrc/templates/admin/index.haml
@@ -8,6 +8,7 @@
 
 -block extra_javascript
   =super()
+  GGRC.page_object = { "person": ={ full_user_json()|safe } };
 
 -block header
   -include 'base_objects/_page_header.haml'


### PR DESCRIPTION
**Subject**: "Uncaught TypeError: Cannot read property 'id' of undefined" error occurs while maping an object to task in Admin Dashboard
**Details**:   

- Go to Admin Dashboard
- Click Search
- Select Object type “Program”> Search program (e.g. prog562)
- Click triangle near the program in Objects found list
- Click 3 bb’s button>Create a task
- Fill TASK SUMMARY and ACTIVE WORKFLOW
- Click Map Objects button  

**Actual Result**: "Uncaught TypeError: Cannot read property 'id' of undefined" error occurs while maping an object to task in Admin Dashboard
**Expected Result**: No error. Objects should be mapped to the task