### PR TITLE
1.179 Fix raise issue button

### DIFF
--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -3411,25 +3411,30 @@ Mustache.registerHelper('get_custom_attr_value', function (attr, instance, optio
   return value;
 });
 
-Mustache.registerHelper("with_create_issue_json", function (instance, options) {
-  instance = Mustache.resolve(instance);
-
-  var audits = instance.get_mapping("related_audits"),
-      audit, programs, program, control, json, related_controls;
+Mustache.registerHelper('with_create_issue_json', function (instance, options) {
+  var audits;
+  var audit;
+  var programs;
+  var program;
+  var control;
+  var json;
+  var relatedControls;
   var canMap;
 
+  instance = Mustache.resolve(instance);
+  audits = instance.get_mapping('related_audits');
   if (!audits.length) {
-    return "";
+    return options.inverse(options.contexts);
   }
 
   audit = audits[0].instance.reify();
-  programs = audit.get_mapping("_program");
+  programs = audit.get_mapping('_program');
   program = programs.length ? programs[0].instance.reify() : {};
   control = instance.control ? instance.control.reify() : {};
-  related_controls = instance.get_mapping('related_controls');
+  relatedControls = instance.get_mapping('related_controls');
 
-  if (!control.id && related_controls.length) {
-    control = related_controls[0].instance;
+  if (!control.id && relatedControls.length) {
+    control = relatedControls[0].instance;
   }
   json = {
     audit: {title: audit.title, id: audit.id, type: audit.type},
@@ -3453,7 +3458,7 @@ Mustache.registerHelper("with_create_issue_json", function (instance, options) {
   }).indexOf(false) === -1;
   if (canMap) {
     return options.fn(options.contexts.add(
-        {'create_issue_json': JSON.stringify(json)}));
+        {create_issue_json: JSON.stringify(json)}));
   }
   return options.inverse(options.contexts);
 });

--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -3450,12 +3450,12 @@ Mustache.registerHelper('with_create_issue_json', function (instance, options) {
     }
   };
   // Check permissions
-  canMap = can.map([audit, program, control, instance], function (obj) {
+  canMap = [audit, program, control, instance].every(function (obj) {
     if (_.isEmpty(obj)) {
       return true;
     }
     return Permission.is_allowed_for('update', obj);
-  }).indexOf(false) === -1;
+  });
   if (canMap) {
     return options.fn(options.contexts.add(
         {create_issue_json: JSON.stringify(json)}));


### PR DESCRIPTION
This prevents `"Uncaught TypeError: Cannot read property '0' of undefined" occurs while Raising an Issue in Assessment's Info panel under GC role` from happening by disabling the create request/raise an issue button from showing if the the user doesn't have permission to map all objects.