### PR TITLE
ISSUE-1.171 Fix mapping new Assessments in mapper modal

### DIFF
--- a/src/ggrc/assets/javascripts/bootstrap/modal-ajax.js
+++ b/src/ggrc/assets/javascripts/bootstrap/modal-ajax.js
@@ -254,6 +254,8 @@
       });
 
       $target.on('modal:success', function (e, data, xhr) {
+        var cssSelector;
+
         if (form_target == 'refresh') {
           refresh_page();
         } else if (form_target == 'redirect') {
@@ -280,6 +282,16 @@
             $active.closest('.active').removeClass('active');
             $active.click();
           }
+
+          // For some reason it can happen that the original $trigger element
+          // is removed from the DOM and replaced with another identical
+          // element. We thus need to trigger the event on that new element
+          // (present in the DOM) if we want event handlers to be invoked.
+          if (!document.contains($trigger[0])) {
+            cssSelector = '.' + $trigger.attr('class').replace(/ /g, '.');
+            $trigger = $(cssSelector);
+          }
+
           $trigger.trigger('routeparam', $trigger.data('route'));
           $trigger.trigger('modal:success', Array.prototype.slice.call(arguments, 1));
         }


### PR DESCRIPTION
_(section 2, bug 1.171)_

In the mapper modal, a newly created Assessment did not appear in the list of objects to select and map to the target object, and this PR fixes that.

A test turned out to be a bit too complicated to write with the current state of the code, the  `form` method of `ajax-modal` would need to be refactored into smaller composable parts for that. :/

**Steps to reproduce:**
- Create a program under GE role
- Click Add-> Assessments-> Click [Create New Assessments] button in Unified mapper window
- Fill in the obligatory fields->Save and Close

**Actual Result:**
The created Assessment does not appear in the list of "results" in the mapper modal while adding through Unified mapper window  
**Expected Result:**
The created Assessment is displayed in the list of "results" in the mapper modal while adding through Unified mapper window