### PR TITLE
ISSUE-1.192 Cannot read property 'sort' of undefined"

### DIFF
--- a/src/ggrc/assets/javascripts/models/cacheable.js
+++ b/src/ggrc/assets/javascripts/models/cacheable.js
@@ -840,7 +840,10 @@ can.Model('can.Model.Cacheable', {
     function sortById(a, b) {
       return a.id - b.id;
     }
-    this.attr('custom_attribute_definitions').sort(sortById);
+    // Sort only if definitions were attached.
+    if (this.attr('custom_attribute_definitions')) {
+      this.attr('custom_attribute_definitions').sort(sortById);
+    }
   },
 
   _custom_attribute_map: function (attrId, object) {

--- a/src/ggrc/assets/javascripts/models/tests/cacheable_model_spec.js
+++ b/src/ggrc/assets/javascripts/models/tests/cacheable_model_spec.js
@@ -40,5 +40,13 @@ describe('CMS.Models.Cacheable', function () {
       expectedIdOrder = _.map(instance.custom_attribute_definitions, 'id');
       expect(expectedIdOrder).toEqual([1, 2, 3, 4, 5]);
     });
+
+    it('skips sorting if no custom attribute definitions', function () {
+      var actualOrder;
+      instance.attr('custom_attribute_definitions', undefined);
+      instance.setup_custom_attributes();
+      actualOrder = _.map(instance.custom_attribute_definitions, 'id');
+      expect(actualOrder).toEqual([]);
+    });
   });
 });


### PR DESCRIPTION
**Subject**: "Uncaught TypeError: Cannot read property 'sort' of undefined" error is displayed on Workflow's Active Cycle tab
**Details**:   

- Open any activated Workflow (https://grc-dev.appspot.com/workflows/689#current_widget/cycle/976)
- Display Active cycles tab
- Click on active cycle 1st tier

**Actual Result**: "Uncaught TypeError: Cannot read property 'sort' of undefined" error is displayed
**Expected Result**: No errors displayed. Info pane is displayed