### PR TITLE
ISSUE-1.184 Fix icon in comment from assessor

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment/add_comment.js
+++ b/src/ggrc/assets/javascripts/components/assessment/add_comment.js
@@ -19,7 +19,8 @@
     related_creators: 'creator',
     related_verifiers: 'verifier',
     related_assignees: 'assignee',
-    related_requesters: 'requester'
+    related_requesters: 'requester',
+    related_assessors: 'assessor'
   };
 
   function getAssigneeType(instance) {


### PR DESCRIPTION
**Subject:** Comment from assessor has N icon
**Details:**   

- Create program, audit and assessment by user#1
- Set user#2 as assessor, set user#3 as verifier
- Open assessment page for created as sessment and leave comment by each user

**Actual Result:** Comment from assessor displayed with N icon
**Expected Result:** Comments should have appropriate icon for each assessment role (A - for assessor)
