### PR TITLE
ISSUE-1193 Maximum call stack size exceeded when creating new task

### DIFF
--- a/src/ggrc/assets/javascripts/plugins/component_registry.js
+++ b/src/ggrc/assets/javascripts/plugins/component_registry.js
@@ -72,6 +72,7 @@
       var scope = this.scope;
       var val;
 
+      can.batch.start();
       _.each(definitions, function (obj, key) {
         var prefix = '';
         if (!_.has(scope, key)) {
@@ -85,8 +86,8 @@
           }
           scope.attr(key, val);
         }
-      }, this);
-
+      });
+      can.batch.stop();
       return init.call(this, arguments);
     };
   };

--- a/src/ggrc_workflows/assets/mustache/task_group_tasks/modal_content.mustache
+++ b/src/ggrc_workflows/assets/mustache/task_group_tasks/modal_content.mustache
@@ -75,6 +75,7 @@
       {{#using workflow=task_group.workflow}}
       {{#switch workflow.frequency}}
       {{#case "one_time"}}
+      {{#add_to_current_scope instance=instance}}
       <div id="one-time" class="frequency-wrap" style="display:block">
         <label>
           Frequency: One time
@@ -97,6 +98,7 @@
             />
         </label>
       </div>
+      {{/add_to_current_scope}}
       {{/case}}
       {{#case "weekly"}}
       <div id="weekly" class="frequency-wrap" style="display:block">


### PR DESCRIPTION
Subject: "Maximum call stack size exceeded" error is displayed while creating new task on Workflow's Setup tab
Details:   
Create a one time Workflow
Click + to create new task on Setup tab
Actual Result: "Maximum call stack size exceeded" error is displayed
Expected Result: No errors displayed. Task could be created
Workaround: N/A
