### PR TITLE
ISSUE-1.194 Fix error when checking a checkbox in mapper modal

### DIFF
--- a/src/ggrc_workflows/assets/mustache/selectors/object_selector_option_items.mustache
+++ b/src/ggrc_workflows/assets/mustache/selectors/object_selector_option_items.mustache
@@ -24,9 +24,7 @@
                 <div class="object-check" align="left">
 
                   <mapper-checkbox
-                    {{#is_allowed_to_map selected_object instance}}
-                      allowed-to-map="true"
-                    {{/is_allowed_to_map}}
+                    {{#is_allowed_to_map selected_object instance}}allowed-to-map="true"{{/is_allowed_to_map}}
                     appended="appended"
                     instance="instance"
                     instance_id="{{instance.id}}"


### PR DESCRIPTION
_(section 2, bug 1.194)_

This fixes an issue with automatically selecting a checkbox in the mapper modal after creating a new object in it.

The problem is that if there is a conditional block in a Mustache template that conditionally creates an attribute, and that block contains whitespace, that is parsed by CanJS just by splitting the block at `=` character, resulting in e.g. the following (note the leading/trailing whitespace:
- Attribute name: `'  attr-foo'`
- Attribute value: `'bar  '`

CanJS then internally tries to set an attribute with a name `' attr-foo'` on a DOM element, which browser refuses because of an invalid attribute name (it must not contain whitespace).

**Lesson:** Be very careful when using Mustache blocks for managing DOM elements' attributes, it can easily result in unintuitive errors.

---

**Steps to reproduce:**
- Log Global Creator
- Create control from LHN menu
- Click Add+ > Select Audit
- Click Create new Audit in Unified mapper > Select create new program in Program field of New Audit window>Fill the title > Save and Close
- Click Save and Close New Audit window

**Actual Result:**
_"Uncaught InvalidCharacterError: Failed to execute 'setAttribute' on 'Element': ' allowed-to-map' is not a valid attribute name"_ error occurs while mapping Adit to Control under GC role

**Expected Result:**
No errors displayed.  