### PR TITLE
ISSUE-1.198 Strip spaces from CAD dropdown options

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -219,7 +219,7 @@ logging-modules=logging
 [MISCELLANEOUS]
 
 # List of note tags to take in consideration, separated by a comma.
-notes=FIXME,XXX,TODO
+notes=FIXME,XXX
 
 
 [SIMILARITIES]

--- a/src/ggrc/migrations/versions/20160824005517_31fbfc1bc608_strip_spaces_around_old_cad_dropdown_.py
+++ b/src/ggrc/migrations/versions/20160824005517_31fbfc1bc608_strip_spaces_around_old_cad_dropdown_.py
@@ -1,0 +1,139 @@
+# Copyright (C) 2016 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Strip spaces around old CAD dropdown parameters
+
+Create Date: 2016-08-24 00:55:17.547549
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+from alembic import op
+from sqlalchemy.sql import text
+
+
+# revision identifiers, used by Alembic.
+revision = "31fbfc1bc608"
+down_revision = "24296c08e80"
+
+
+def _strip_and_zip_options_and_bitmaps(cad):
+  """Get dropdown info from cad, strip options and zip them with bitmaps.
+
+  Args:
+    cad: named tuple like (cad.id, cad.multi_choice_options,
+                           cad.multi_choice_mandatory).
+
+  Returns:
+    [(dropdown_option, mandatory_bitmap), ...] for every option in dropdown cad
+  """
+  options = [opt.strip() for opt in cad.multi_choice_options.split(",")]
+  if cad.multi_choice_mandatory is None:
+    bitmaps = [None] * len(options)
+  else:
+    bitmaps = [bitmap.strip() for bitmap in
+               cad.multi_choice_mandatory.split(",")]
+  return zip(options, bitmaps)
+
+
+def _deduplicate_and_remove_empty_options(zipped):
+  """Remove option-bitmap pairs where option is duplicate or empty.
+
+  Args:
+    zipped: list of tuples [(option, bitmap), ...].
+
+  Returns:
+    `zipped` without such elements where `option` is duplicate in the list or
+    is empty.
+  """
+  stored_options = set()
+  zipped_unique = []
+  for (option, bitmap) in zipped:
+    # remove empty options and duplicate options at once
+    if option and option not in stored_options:
+      zipped_unique.append((option, bitmap))
+      stored_options.add(option)
+  return zipped_unique
+
+
+def _unzip_and_make_csv(zipped):
+  """Unzip options and bitmaps and make comma-separated strings from them.
+
+  Args:
+    zipped: list of tuples [(options, bitmap), ...].
+
+  Returns:
+    (options, bitmaps) - a tuple of strings or a tuple of string and None.
+
+  bitmaps is None if every bitmap in zipped is None (meaning no bitmap was
+  stored in the db) or zipped has zero length.
+  """
+  options_new, bitmaps_new = zip(*zipped) if zipped else ([], [])
+
+  options_new = ",".join(options_new)
+  if not bitmaps_new or not any(bitmaps_new):
+    # no bitmaps were defined
+    bitmaps_new = None
+  else:
+    bitmaps_new = ",".join(bitmaps_new)
+  return options_new, bitmaps_new
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision.
+
+  1. Strip every dropdown option of leading and trailing whitespace.
+  2. Remove duplicate dropdown options in every CAD.
+  3. Remove empty dropdown options in every CAD (leave one empty dropdown
+  option if there are no non-empty options).
+  4. Strip every value of CAV for Dropdown-type CAD of leading and trailing
+  whitespace.
+  """
+  connection = op.get_bind()
+
+  cads = connection.execute("""
+      SELECT id, multi_choice_options, multi_choice_mandatory
+      FROM custom_attribute_definitions
+      WHERE attribute_type = 'Dropdown' AND
+            multi_choice_options IS NOT NULL
+  """).fetchall()
+  for cad in cads:
+    zipped = _strip_and_zip_options_and_bitmaps(cad)
+    zipped_unique = _deduplicate_and_remove_empty_options(zipped)
+    options_new, bitmaps_new = _unzip_and_make_csv(zipped_unique)
+
+    if (cad.multi_choice_options != options_new or
+            cad.multi_choice_mandatory != bitmaps_new):
+      connection.execute(text("""
+          UPDATE custom_attribute_definitions SET
+              multi_choice_options = :mco,
+              multi_choice_mandatory = :mcm
+          WHERE id = :id
+      """), mco=options_new, mcm=bitmaps_new, id=cad.id)
+
+  cavs = connection.execute("""
+      SELECT cavs.id as id, attribute_value
+      FROM custom_attribute_values as cavs JOIN
+           custom_attribute_definitions as cads ON
+               cads.id = cavs.custom_attribute_id
+      WHERE cads.attribute_type = 'Dropdown'
+  """)
+  for cav in cavs:
+    if cav.attribute_value is None:
+      new_attribute_value = None
+    else:
+      new_attribute_value = cav.attribute_value.strip()
+
+    if cav.attribute_value != new_attribute_value:
+      connection.execute(text("""
+          UPDATE custom_attribute_values SET
+              attribute_value = :av
+          WHERE id = :id
+      """), av=new_attribute_value, id=cav.id)
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  # it is not possible to add the removed spaces and items back to the values
+  pass

--- a/src/ggrc/models/custom_attribute_definition.py
+++ b/src/ggrc/models/custom_attribute_definition.py
@@ -111,7 +111,8 @@ class CustomAttributeDefinition(mixins.Base, mixins.Titled, db.Model):
   def validate_multi_choice_options(self, _, value):
     """Strip spaces around options in dropdown options."""
     # pylint: disable=no-self-use
-    if value is not None:
+    # TODO: this should be "if value is not None" to disallow value == ""
+    if value:
       value_list = [part.strip() for part in value.split(",")]
       value_set = set(value_list)
       if len(value_set) != len(value_list):

--- a/src/ggrc/models/custom_attribute_definition.py
+++ b/src/ggrc/models/custom_attribute_definition.py
@@ -4,11 +4,13 @@
 """Custom attribute definition module"""
 
 from sqlalchemy.ext.declarative import declared_attr
+from sqlalchemy.orm import validates
 from sqlalchemy.sql.schema import UniqueConstraint
 
 from ggrc import db
 from ggrc.models import mixins
 from ggrc.models.custom_attribute_value import CustomAttributeValue
+from ggrc.models.exceptions import ValidationError
 
 
 class CustomAttributeDefinition(mixins.Base, mixins.Titled, db.Model):
@@ -94,6 +96,42 @@ class CustomAttributeDefinition(mixins.Base, mixins.Titled, db.Model):
       "Date": "Date",
       "Person": "Map:Person",
   }
+
+  @validates("attribute_type")
+  def validate_attribute_type(self, _, value):
+    """Check that provided attribute_type is allowed."""
+    if value not in self.VALID_TYPES.values():
+      raise ValidationError("Invalid attribute_type: got {v}, "
+                            "expected one of {l}"
+                            .format(v=value,
+                                    l=list(self.VALID_TYPES.values())))
+    return value
+
+  @validates("multi_choice_options")
+  def validate_multi_choice_options(self, _, value):
+    """Strip spaces around options in dropdown options."""
+    # pylint: disable=no-self-use
+    if value is not None:
+      value_list = [part.strip() for part in value.split(",")]
+      value_set = set(value_list)
+      if len(value_set) != len(value_list):
+        raise ValidationError("Duplicate dropdown options are not allowed: "
+                              "'{}'".format(value))
+      if "" in value_set:
+        raise ValidationError("Empty dropdown options are not allowed: '{}'"
+                              .format(value))
+      value = ",".join(value_list)
+
+    return value
+
+  @validates("multi_choice_mandatory")
+  def validate_multi_choice_mandatory(self, _, value):
+    """Strip spaces around bitmas in dropdown options."""
+    # pylint: disable=no-self-use
+    if value:
+      value = ",".join(part.strip() for part in value.split(","))
+
+    return value
 
 
 class CustomAttributeMapable(object):

--- a/src/ggrc/models/custom_attribute_value.py
+++ b/src/ggrc/models/custom_attribute_value.py
@@ -234,9 +234,13 @@ class CustomAttributeValue(Base, db.Model):
 
   def _validate_dropdown(self):
     """Validate dropdown opiton."""
-    valid_options = self.custom_attribute.multi_choice_options.split(",")
-    if self.attribute_value and self.attribute_value not in valid_options:
-      raise ValueError("Invalid custom attribute dropdown option")
+    valid_options = set(self.custom_attribute.multi_choice_options.split(","))
+    if self.attribute_value:
+      self.attribute_value = self.attribute_value.strip()
+      if self.attribute_value not in valid_options:
+        raise ValueError("Invalid custom attribute dropdown option: {v}, "
+                         "expected one of {l}"
+                         .format(v=self.attribute_value, l=valid_options))
 
   def validate(self):
     """Validate custom attribute value."""

--- a/test/integration/ggrc/generator.py
+++ b/test/integration/ggrc/generator.py
@@ -245,10 +245,10 @@ class ObjectGenerator(Generator):
             "modal_title": kwargs.get("modal_title", self.random_str()),
             "attribute_type": kwargs.get("attribute_type", "Text"),
             "mandatory": kwargs.get("mandatory", False),
-            "helptext": kwargs.get("helptext", False),
-            "placeholder": kwargs.get("placeholder", False),
+            "helptext": kwargs.get("helptext", None),
+            "placeholder": kwargs.get("placeholder", None),
             "context": {"id": None},
-            "multi_choice_options": kwargs.get("options", False),
+            "multi_choice_options": kwargs.get("options", None),
         }
     }
     data[obj_name].update(kwargs)


### PR DESCRIPTION
While the frontend code strips the spaces around options of new dropdown CADs, the CADs already stored in the DB can have `multi_choice_options = "one, two , three"` (and the new CAVs can have `attribute_value = "two"`, without spaces, which will be diagnosed as an invalid dropdown value). This PR has a migration that strips the enclosing spaces of options in `multi_choice_options`. There are also SQLAlchemy-level validators that strip the spaces from `CAD.multi_choice_options` and `CAD.multi_choice_mandatory` stored into the DB and `CAV.attribute_value` stored through `CustomAttributable` objects.

Steps to reproduce:
1. Create an Assessment with CAD with `multi_choice_options = "one, two , three"` (you should do it manually with SQL or use a CAD defined before a PR that started stripping spaces around CA values).
2. Open Edit Assessment modal for this Assessment, set the corresponding CA value to "two" or "three".
3. Click Save.

Expected result: the value is stored.
Actual result: HTTP 400 is returned from the server as "two" (or "three") is considered an invalid dropdown value.

The user is still able to add values with spaces to `CAD.multi_choice.options` and `CAV.attribute_value` manually with an SQL query or POST/PUT `CAV.attribute_value` with spaces to `/api/custom_attribute_values` endpoint.