### PR TITLE
ISSUE-1.50 CA value isn’t updated in the tree view after editing

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
@@ -1510,19 +1510,18 @@ can.Control('CMS.Controllers.TreeViewNode', {
         this.draw_placeholder();
       }
     }.bind(this), 0);
-
   },
 
   '{instance} change': function (inst, ev, prop) {
     if (prop === 'custom_attribute_values') {
-      this.draw_node();
+      this.draw_node(true);
     }
   },
 
   /**
    * Trigger rendering the tree node in the DOM.
    */
-  draw_node: function () {
+  draw_node: function (force) {
     var isActive;
     var isPlaceholder;
     var lazyLoading = this.options.disable_lazy_loading;
@@ -1532,7 +1531,8 @@ can.Control('CMS.Controllers.TreeViewNode', {
     }
     isPlaceholder = this.element.hasClass('tree-item-placeholder');
 
-    if (this._draw_node_in_progress || !lazyLoading && !isPlaceholder) {
+    if (this._draw_node_in_progress ||
+        !force && (!lazyLoading && !isPlaceholder)) {
       return;
     }
 


### PR DESCRIPTION
Subject: CA value isn’t updated in the tree view after editing

Details: 
Navigate to Program page and open Controls tab in HNB
Click “gear” icon and make the CA field visible in the tree view
Click the 1st tier of a control in the tree view
Edit a CA value via info panel
save

Actual Result: the app confirms that changes are saved but the new CA value isn’t shown in the tree view.

Expected Result: the new CA value should be shown in the tree view right after updating it and saving it in info panel.

Workaround: refresh the page
