### PR TITLE
ISSUE-1.190 Cannot read property 'model_singular' of undefined

### DIFF
--- a/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
+++ b/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
@@ -131,7 +131,7 @@
       var list = GGRC.tree_view.base_widgets_by_type[type];
       var forbidden;
       var forbiddenList = {
-        Program: ['Audit'],
+        Program: ['Audit', 'RiskAssessment'],
         Audit: ['Assessment', 'Program', 'Request'],
         Assessment: [],
         Request: ['Workflow', 'TaskGroup', 'Person', 'Audit'],
@@ -209,6 +209,7 @@
       var FORBIDDEN = Object.freeze({
         'audit program': true,
         'audit request': true,
+        'program riskassessment': true,
         'assessmenttemplate cacheable': true,
         'cacheable person': true
       });

--- a/src/ggrc_risk_assessments/assets/javascripts/apps/risk_assessments.js
+++ b/src/ggrc_risk_assessments/assets/javascripts/apps/risk_assessments.js
@@ -81,6 +81,8 @@
           widget_name: 'Risk Assessments',
           content_controller: GGRC.Controllers.TreeView,
           content_controller_options: {
+            add_item_view: GGRC.mustache_path +
+              '/risk_assessments/tree_add_item.mustache',
             mapping: 'risk_assessments',
             parent_instance: page_instance,
             model: CMS.Models.RiskAssessment,

--- a/src/ggrc_risk_assessments/assets/mustache/risk_assessments/tree_add_item.mustache
+++ b/src/ggrc_risk_assessments/assets/mustache/risk_assessments/tree_add_item.mustache
@@ -5,19 +5,40 @@
 
 
 {{#if allow_mapping_or_creating}}
-{{#is_allowed_to_map parent_instance model.shortName}}
-  <a
-    href="javascript://"
-    rel="tooltip"
-    data-toggle="modal-ajax-form"
-    data-modal-reset="reset"
-    data-modal-class="modal-wide"
-    data-object-singular="RiskAssessment"
-    data-object-plural="risk_assessments"
-    data-object-params='{ "{{parent_instance.class.table_singular}}": { "id" : {{parent_instance.id}}, "title" : "{{parent_instance.title}}" }, "context": { "id" : {{firstnonempty parent_instance.context.id "null"}}, "href" : "{{parent_instance.context.href}}", "type" : "{{parent_instance.context.type}}" } }'
-    data-placement="right"
-    data-original-title="Create {{model.title_singular}}">
-    <i class="fa fa-plus-circle"></i>
-  </a>
-{{/is_allowed_to_map}}
+{{#if_instance_of parent_instance 'Program'}}
+    {{#if allow_creating}}
+    {{#is_allowed 'update' parent_instance}}
+      <a 
+        href="javascript://"
+        rel="tooltip"
+        class="section-create"
+        data-placement="left"
+        data-original-title="Create {{model.title_singular}}"
+        data-toggle="modal-ajax-form"
+        data-modal-reset="reset"
+        data-modal-class="modal-wide"
+        data-object-singular="RiskAssessment"
+        data-object-plural="risk_assessments"
+        data-object-params='{ "{{parent_instance.class.table_singular}}": { "id" : {{parent_instance.id}}, "title" : "{{parent_instance.title}}" }, "context": { "id" : {{firstnonempty parent_instance.context.id "null"}}, "href" : "{{parent_instance.context.href}}", "type" : "{{parent_instance.context.type}}" } }'>
+        <i class="fa fa-plus-circle"></i>
+      </a>
+    {{/is_allowed}}
+    {{/if}}
+{{else}}
+    {{#is_allowed_to_map parent_instance model.shortName}}
+      <a
+        href="javascript://"
+        rel="tooltip"
+        data-toggle="modal-ajax-form"
+        data-modal-reset="reset"
+        data-modal-class="modal-wide"
+        data-object-singular="RiskAssessment"
+        data-object-plural="risk_assessments"
+        data-object-params='{ "{{parent_instance.class.table_singular}}": { "id" : {{parent_instance.id}}, "title" : "{{parent_instance.title}}" }, "context": { "id" : {{firstnonempty parent_instance.context.id "null"}}, "href" : "{{parent_instance.context.href}}", "type" : "{{parent_instance.context.type}}" } }'
+        data-placement="right"
+        data-original-title="Create {{model.title_singular}}">
+        <i class="fa fa-plus-circle"></i>
+      </a>
+    {{/is_allowed_to_map}}
+{{/if_instance_of}}
 {{/if}}


### PR DESCRIPTION
**Subject**: "Cannot read property 'model_singular' of undefined" error is displayed while mapping Risk Assessment to program
**Details**:   

- Create a program
- Click Add+ >Select Risk Assessments
- Click + Add New Rule

**Actual Result**: "Cannot read property 'model_singular' of undefined" error is displayed
**Expected Result**: No error displayed.

**Notes**: 

- @Smotko noted that adding Risk Assessments to Program should behave as Audits (Add instead of Map). This fix also enables this behaviour.
- Well known issue: Risk Assessment could not be saved (button is disabled). We agreed with QA team that it will be fixed in scope of another issue.