### PR TITLE
ISSUE-1.116 Reader with Assessor permissions can attach evidence

### DIFF
--- a/src/ggrc_basic_permissions/roles/Reader.py
+++ b/src/ggrc_basic_permissions/roles/Reader.py
@@ -109,7 +109,6 @@ permissions = {
             },
             "condition": "relationship",
         },
-        "ObjectFile",
         "ObjectPerson",
         "Option",
         "OrgGroup",

--- a/src/ggrc_basic_permissions/roles/Reader.py
+++ b/src/ggrc_basic_permissions/roles/Reader.py
@@ -104,11 +104,12 @@ permissions = {
         {
             "type": "ObjectDocument",
             "terms": {
-                "property_name": "document,documentable",
+                "property_name": "documentable",
                 "action": "update",
             },
             "condition": "relationship",
         },
+        "ObjectFile",
         "ObjectPerson",
         "Option",
         "OrgGroup",

--- a/src/ggrc_gdrive_integration/assets/javascripts/apps/gdrive.js
+++ b/src/ggrc_gdrive_integration/assets/javascripts/apps/gdrive.js
@@ -17,13 +17,6 @@
       folders: new GGRC.ListLoaders.ProxyListLoader("ObjectFolder", "folderable", "folder", "object_folders", "GDriveFolder")
     },
 
-    fileable : {
-      _canonical : {
-        files : "GDriveFile"
-      },
-      files : new GGRC.ListLoaders.ProxyListLoader("ObjectFile", "fileable", "file", "object_files", "GDriveFile")
-    },
-
     revisionable : {
       _canonical : {
         revisions : "GDriveFileRevision"
@@ -108,11 +101,6 @@
   GGRC.register_hook("Audit.storage_folder_picker", GGRC.mustache_path + "/audits/gdrive_folder_picker.mustache");
 
 
-  $.extend(true, CMS.Models.Document.attributes, {
-    "object_files": "CMS.Models.ObjectFile.stubs",
-    "files": "CMS.Models.GDriveFile.stubs"
-  });
-
   can.view.mustache("picker-tag-readonly", "<ggrc-gdrive-folder-picker instance='instance' readonly='true'/>");
     //We are no longer mapping GDrive files directly to responses.  It makes it difficult to figure out which GDrive file is which
   // document when we go to present. however, this functionality is still supported.
@@ -120,7 +108,7 @@
 
   // GGRC.JoinDescriptor.from_arguments_list([
   //   [["Program", "Audit", "Request"], "GDriveFolder", "ObjectFolder", "folder", "folderable"]
-  //   , ["GDriveFile", "ObjectFile", "file", "fileable"]
+  //   , ["GDriveFile", "§", "file", "fileable"]
   // ]);
 
   $.extend(true, CMS.Models.Meeting.attributes, {

--- a/src/ggrc_gdrive_integration/assets/javascripts/components/gdrive_folder_picker.js
+++ b/src/ggrc_gdrive_integration/assets/javascripts/components/gdrive_folder_picker.js
@@ -38,11 +38,6 @@
                   context: object.context || {id: null},
                   documentable: object,
                   document: doc
-                }).save(),
-                new CMS.Models.ObjectFile({
-                  context: object.context || {id: null},
-                  file: file,
-                  fileable: doc
                 }).save()
               ]);
             });

--- a/src/ggrc_gdrive_integration/assets/javascripts/components/gdrive_picker_launcher.js
+++ b/src/ggrc_gdrive_integration/assets/javascripts/components/gdrive_picker_launcher.js
@@ -271,9 +271,6 @@
               }
 
               return $.when(
-                CMS.Models.ObjectFile.findAll({
-                  file_id: file.id, fileable_id: docs[0].id
-                }),
                 objectDoc
               ).then(function (ofs) {
                 if (ofs.length < 1) {
@@ -281,12 +278,6 @@
                     doc.mark_for_addition('files', file, {
                       context: that.instance.context || {id: null}
                     });
-                  } else {
-                    return new CMS.Models.ObjectFile({
-                      context: that.instance.context || {id: null},
-                      file: file,
-                      fileable: doc
-                    }).save();
                   }
                 }})
               .then(function () {

--- a/src/ggrc_gdrive_integration/assets/javascripts/models/gdrive_models.js
+++ b/src/ggrc_gdrive_integration/assets/javascripts/models/gdrive_models.js
@@ -485,47 +485,6 @@
     }
   });
 
-  can.Model.Join('CMS.Models.ObjectFile', {
-    root_object: 'object_file',
-    root_collection: 'object_files',
-    findAll: 'GET /api/object_files',
-    create: 'POST /api/object_files',
-    update: 'PUT /api/object_files/{id}',
-    destroy: 'DELETE /api/object_files/{id}',
-    join_keys: {
-      fileable: can.Model.Cacheable,
-      file: CMS.Models.GDriveFile
-    },
-    attributes: {
-      modified_by: 'CMS.Models.Person.stub',
-      file: 'CMS.Models.GDriveFile.stub',
-      fileable: 'CMS.Models.get_stub'
-    },
-    model: function (params) {
-      if (typeof params === 'object' && params.file_id) {
-        params.file = new CMS.Models.GDriveFile({
-          id: params.file_id,
-          href: '/drive/v2/files/' + params.file_id
-        }).stub();
-      }
-      return this._super(params);
-    }
-  }, {
-    serialize: function (attr) {
-      var serial;
-      if (!attr) {
-        serial = this._super.apply(this, arguments);
-        serial.file_id = serial.file ? serial.file.id : serial.file_id;
-        delete serial.file;
-        return serial;
-      }
-      if (attr === 'file_id') {
-        return this.file_id || this.file.id;
-      }
-      return this._super.apply(this, arguments);
-    }
-  });
-
   $(document).ready(function () {
     gapi_request_with_auth = GGRC.gapi_request_with_auth;
   });


### PR DESCRIPTION
Subject: GReader is not able to Attach evidence - message no folder for Audit is displayed even if folder is assigned to Audit and Reader have edit rights on it

Details: 
Create Program
Create Audit
Create  Assessment object with GReader as assessor 
As Reader, navigate to page of newly created assessment
Open info tab 
Confirm red alert triangle is displayed next to the Attach evidence button
Click attach evidence button
Select and upload any file

Actual Result:  Attached file is not displayed, several error messages are displayed on JS console