### PR TITLE
FEATURE Related assessments on backend

### DIFF
--- a/src/ggrc/models/assessment.py
+++ b/src/ggrc/models/assessment.py
@@ -29,6 +29,7 @@ from ggrc.models.relationship import Relatable
 from ggrc.models.relationship import Relationship
 from ggrc.models.track_object_state import HasObjectState
 from ggrc.models.track_object_state import track_state_for_class
+from ggrc.utils import similarity_options as similarity_options_module
 
 
 class AuditRelationship(object):
@@ -169,14 +170,7 @@ class Assessment(statusable.Statusable, AuditRelationship,
       },
   }
 
-  similarity_options = {
-      "relevant_types": {
-          "Audit": {"weight": 5},
-          "Regulation": {"weight": 3},
-          "Control": {"weight": 10},
-      },
-      "threshold": 5,
-  }
+  similarity_options = similarity_options_module.ASSESSMENT
 
   def validate_conclusion(self, value):
     return value if value in self.VALID_CONCLUSIONS else ""

--- a/src/ggrc/models/assessment.py
+++ b/src/ggrc/models/assessment.py
@@ -20,6 +20,7 @@ from ggrc.models.mixins import statusable
 from ggrc.models.mixins.assignable import Assignable
 from ggrc.models.mixins.autostatuschangeable import AutoStatusChangeable
 from ggrc.models.mixins.validate_on_complete import ValidateOnComplete
+from ggrc.models.mixins.with_similarity_score import WithSimilarityScore
 from ggrc.models.deferred import deferred
 from ggrc.models.object_document import Documentable
 from ggrc.models.object_person import Personable
@@ -65,9 +66,9 @@ class AuditRelationship(object):
 class Assessment(statusable.Statusable, AuditRelationship,
                  AutoStatusChangeable, Assignable, HasObjectState, TestPlanned,
                  CustomAttributable, Documentable, Commentable, Personable,
-                 reminderable.Reminderable, Timeboxed,
-                 Relatable, FinishedDate, VerifiedDate, ValidateOnComplete,
-                 BusinessObject, db.Model):
+                 reminderable.Reminderable, Timeboxed, Relatable,
+                 WithSimilarityScore, FinishedDate, VerifiedDate,
+                 ValidateOnComplete, BusinessObject, db.Model):
   """Class representing Assessment.
 
   Assessment is an object representing an individual assessment performed on
@@ -166,6 +167,15 @@ class Assessment(statusable.Statusable, AuditRelationship,
           "filter_by": "_filter_by_related_verifiers",
           "type": reflection.AttributeInfo.Type.MAPPING,
       },
+  }
+
+  similarity_options = {
+      "relevant_types": {
+          "Audit": {"weight": 5},
+          "Regulation": {"weight": 3},
+          "Control": {"weight": 10},
+      },
+      "threshold": 5,
   }
 
   def validate_conclusion(self, value):

--- a/src/ggrc/models/mixins/with_similarity_score.py
+++ b/src/ggrc/models/mixins/with_similarity_score.py
@@ -1,0 +1,147 @@
+# Copyright (C) 2016 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Contains WithSimilarityScore mixin.
+
+This defines a procedure of getting "similar" objects which have similar
+relationships.
+"""
+
+from sqlalchemy import and_
+from sqlalchemy import case
+from sqlalchemy import or_
+from sqlalchemy.orm import aliased
+from sqlalchemy.sql import func
+
+from ggrc import db
+from ggrc.models.relationship import Relationship
+
+
+class WithSimilarityScore(object):
+  """Defines a routine to get similar object with mappings to same objects."""
+
+  # pylint: disable=too-few-public-methods
+
+  # example of similarity_options:
+  # similarity_options = {
+  #     "relevant_types": {"Audit": {"weight": 5}, type: {"weight": w}},
+  #     "threshold": 10,
+  # }
+
+  @classmethod
+  def get_similar_objects(cls, id_, types="all", relevant_types=None,
+                          threshold=None):
+    """Get objects of types similar to cls instance by their mappings.
+
+    Args:
+      id_: the id of the object to which the search will be applied;
+      types: a list of types of relevant objects (or "all" if you need to find
+             objects of any type);
+      relevant_types: use this parameter to override parameters from
+                      cls.similarity_options["relevant_types"];
+      threshold: use this parameter to override
+                 cls.similarity_options["threshold"].
+
+    Returns:
+      [(similar_object_id, similar_object_type, weight)] - a list of similar
+          objects with respective weights.
+    """
+    if not types or (not isinstance(types, list) and types != "all"):
+      raise ValueError("Expected types = 'all' or a non-empty list of "
+                       "requested types, got {!r} instead.".format(types))
+    if not hasattr(cls, "similarity_options"):
+      raise AttributeError("Expected 'similarity_options' defined for "
+                           "'{c.__name__}' model.".format(c=cls))
+    if relevant_types is None:
+      relevant_types = cls.similarity_options["relevant_types"]
+    if threshold is None:
+      threshold = cls.similarity_options["threshold"]
+
+    # naming: self is "object", the object mapped to it is "related",
+    # the object mapped to "related" is "similar"
+
+    # get all Relationships for self
+    object_to_related = db.session.query(Relationship).filter(
+        or_(and_(Relationship.source_type == cls.__name__,
+                 Relationship.source_id == id_),
+            and_(Relationship.destination_type == cls.__name__,
+                 Relationship.destination_id == id_))).subquery()
+
+    # define how to get id and type of "related" objects
+    related_id_case = (case([(and_(object_to_related.c.source_id == id_,
+                                   object_to_related.c.source_type ==
+                                   cls.__name__),
+                              object_to_related.c.destination_id)],
+                            else_=object_to_related.c.source_id)
+                       .label("related_id"))
+    related_type_case = (case([(and_(object_to_related.c.source_id == id_,
+                                     object_to_related.c.source_type ==
+                                     cls.__name__),
+                                object_to_related.c.destination_type)],
+                              else_=object_to_related.c.source_type)
+                         .label("related_type"))
+
+    related_to_similar = aliased(Relationship, name="related_to_similar")
+
+    # self-join Relationships to get "similar" id and type; save "related" type
+    # to get the weight of this relationship later
+    joined = db.session.query(
+        related_type_case,
+        related_to_similar.destination_id.label("similar_id"),
+        related_to_similar.destination_type.label("similar_type"),
+    ).join(
+        related_to_similar,
+        and_(related_id_case == related_to_similar.source_id,
+             related_type_case == related_to_similar.source_type),
+    ).union(db.session.query(
+        related_type_case,
+        related_to_similar.source_id.label("similar_id"),
+        related_to_similar.source_type.label("similar_type"),
+    ).join(
+        related_to_similar,
+        and_(related_id_case == related_to_similar.destination_id,
+             related_type_case == related_to_similar.destination_type),
+    )).subquery()
+
+    # define weights for every "related" object type with values from
+    # relevant_types dict
+    weight_case = case(
+        [(joined.c.related_type == type_, parameters["weight"])
+         for type_, parameters in relevant_types.items()],
+        else_=0)
+    weight_sum = func.sum(weight_case).label("weight")
+
+    # return the id and type of "similar" object together with its measure of
+    # similarity
+    result = db.session.query(
+        joined.c.similar_id.label("id"),
+        joined.c.similar_type.label("type"),
+        weight_sum,
+    ).filter(or_(
+        # filter out self
+        joined.c.similar_id != id_,
+        joined.c.similar_type != cls.__name__,
+    ))
+
+    # do the filtering by "similar" object types
+    if types is not None:
+      if not types:
+        # types is provided but is empty
+        return []
+      elif types == "all":
+        # any type will pass, no filtering applied
+        pass
+      else:
+        # retain only types from the provided list
+        result = result.filter(joined.c.similar_type.in_(types))
+
+    # group by "similar" objects to sum up weights correctly
+    result = result.group_by(
+        joined.c.similar_type,
+        joined.c.similar_id,
+    ).having(
+        # filter out "similar" objects that have insufficient similarity
+        weight_sum >= threshold,
+    )
+
+    return result.all()

--- a/src/ggrc/models/request.py
+++ b/src/ggrc/models/request.py
@@ -26,6 +26,7 @@ from ggrc.models.deferred import deferred
 from ggrc.models.mixins.assignable import Assignable
 from ggrc.models.object_document import Documentable
 from ggrc.models.object_person import Personable
+from ggrc.utils import similarity_options as similarity_options_module
 
 
 class Request(statusable.Statusable, AutoStatusChangeable, Assignable,
@@ -47,14 +48,7 @@ class Request(statusable.Statusable, AutoStatusChangeable, Assignable,
 
   ASSIGNEE_TYPES = (u'Assignee', u'Requester', u'Verifier')
 
-  similarity_options = {
-      "relevant_types": {
-          "Audit": {"weight": 5},
-          "Regulation": {"weight": 3},
-          "Control": {"weight": 10},
-      },
-      "threshold": 5,
-  }
+  similarity_options = similarity_options_module.REQUEST
 
   # TODO Remove requestor and requestor_id on database cleanup
   requestor_id = db.Column(db.Integer, db.ForeignKey('people.id'))

--- a/src/ggrc/models/request.py
+++ b/src/ggrc/models/request.py
@@ -20,6 +20,7 @@ from ggrc.models.mixins import Slugged
 from ggrc.models.mixins import Titled
 from ggrc.models.mixins import VerifiedDate
 from ggrc.models.mixins import statusable
+from ggrc.models.mixins.with_similarity_score import WithSimilarityScore
 from ggrc.models.mixins.autostatuschangeable import AutoStatusChangeable
 from ggrc.models.deferred import deferred
 from ggrc.models.mixins.assignable import Assignable
@@ -27,9 +28,9 @@ from ggrc.models.object_document import Documentable
 from ggrc.models.object_person import Personable
 
 
-class Request(statusable.Statusable,
-              AutoStatusChangeable, Assignable, Documentable, Personable,
-              CustomAttributable, relationship.Relatable, Titled, Slugged,
+class Request(statusable.Statusable, AutoStatusChangeable, Assignable,
+              Documentable, Personable, CustomAttributable,
+              relationship.Relatable, WithSimilarityScore, Titled, Slugged,
               Described, Commentable, FinishedDate, VerifiedDate, Base,
               db.Model):
   """Class representing Requests.
@@ -45,6 +46,15 @@ class Request(statusable.Statusable,
   VALID_TYPES = (u'documentation', u'interview')
 
   ASSIGNEE_TYPES = (u'Assignee', u'Requester', u'Verifier')
+
+  similarity_options = {
+      "relevant_types": {
+          "Audit": {"weight": 5},
+          "Regulation": {"weight": 3},
+          "Control": {"weight": 10},
+      },
+      "threshold": 5,
+  }
 
   # TODO Remove requestor and requestor_id on database cleanup
   requestor_id = db.Column(db.Integer, db.ForeignKey('people.id'))

--- a/src/ggrc/utils/similarity_options.py
+++ b/src/ggrc/utils/similarity_options.py
@@ -1,0 +1,16 @@
+# Copyright (C) 2016 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Defines similarity_options for classes implementing WithSimilarityScore."""
+
+ASSESSMENT = {
+    "relevant_types": {
+        "Audit": {"weight": 5},
+        "Regulation": {"weight": 3},
+        "Control": {"weight": 10},
+    },
+    "threshold": 5,
+}
+
+# similarity_options for assessment and request are the same at the moment
+REQUEST = ASSESSMENT

--- a/test/integration/ggrc/models/factories.py
+++ b/test/integration/ggrc/models/factories.py
@@ -210,3 +210,9 @@ class ObjectDocumentFactory(ModelFactory):
 
   class Meta:
     model = models.ObjectDocument
+
+
+class RegulationFactory(ModelFactory, TitledFactory):
+
+  class Meta:
+    model = models.Regulation

--- a/test/integration/ggrc/models/mixins/test_with_similarity_score.py
+++ b/test/integration/ggrc/models/mixins/test_with_similarity_score.py
@@ -1,0 +1,151 @@
+# Copyright (C) 2016 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Integration tests for WithSimilarityScore logic."""
+
+import json
+
+from ggrc.models import Assessment
+import integration.ggrc
+from integration.ggrc.models import factories
+
+
+# pylint: disable=super-on-old-class; TestCase is a new-style class
+class TestWithSimilarityScore(integration.ggrc.TestCase):
+  """Integration test suite for WithSimilarityScore functionality."""
+
+  def setUp(self):
+    super(TestWithSimilarityScore, self).setUp()
+    self.client.get("/login")
+
+    self.assessment = factories.AssessmentFactory()
+    self.audit = factories.AuditFactory()
+    self.control = factories.ControlFactory()
+    self.regulation = factories.RegulationFactory()
+
+    self.make_relationships(
+        self.assessment, (
+            self.audit,
+            self.control,
+            self.regulation,
+        ),
+    )
+
+    self.other_assessments, self.id_weight_map = self.make_assessments()
+
+  @staticmethod
+  def make_relationships(source, destinations):
+    for destination in destinations:
+      factories.RelationshipFactory(
+          source=source,
+          destination=destination,
+      )
+
+  def make_assessments(self):
+    """Create six assessments and map them to audit, control, regulation.
+
+    Each of the created assessments is mapped to its own subset of {audit,
+    control, regulation} so each of them has different similarity weight.
+
+    Returns: the six generated assessments and their weights in a dict.
+    """
+
+    assessment_mappings = (
+        (self.audit,),
+        (self.control,),
+        (self.regulation,),
+        (self.audit, self.control),
+        (self.audit, self.regulation),
+        (self.control, self.regulation),
+        (self.audit, self.control, self.regulation),
+    )
+    weights = (5, 10, 3, 15, 8, 13, 18)
+
+    assessments = [factories.AssessmentFactory()
+                   for _ in range(len(assessment_mappings))]
+    for assessment, mappings in zip(assessments, assessment_mappings):
+      self.make_relationships(assessment, mappings)
+
+    id_weight_map = {assessment.id: weight
+                     for assessment, weight in zip(assessments, weights)}
+
+    return assessments, id_weight_map
+
+  def test_get_similar_objects_weights(self):  # pylint: disable=invalid-name
+    """Check weights counted for similar objects."""
+    similar_objects = Assessment.get_similar_objects(
+        id_=self.assessment.id,
+        types=["Assessment"],
+        threshold=0,  # to include low weights too
+    )
+
+    # casting to int from Decimal to prettify the assertion method output
+    id_weight_map = {obj.id: int(obj.weight) for obj in similar_objects}
+
+    self.assertDictEqual(id_weight_map, self.id_weight_map)
+
+  def test_get_similar_objects(self):
+    """Check similar objects manually and via Query API."""
+    similar_objects = Assessment.get_similar_objects(
+        id_=self.assessment.id,
+        types=["Assessment"],
+    )
+    expected_ids = {id_ for id_, weight in self.id_weight_map.items()
+                    if weight >= Assessment.similarity_options["threshold"]}
+
+    self.assertSetEqual(
+        {obj.id for obj in similar_objects},
+        expected_ids,
+    )
+
+    query = [{
+        "object_name": "Assessment",
+        "type": "ids",
+        "filters": {
+            "expression": {
+                "op": {"name": "similar"},
+                "object_name": "Assessment",
+                "id": self.assessment.id,
+            },
+        },
+    }]
+    response = self.client.post(
+        "/query",
+        data=json.dumps(query),
+        headers={"Content-Type": "application/json"},
+    )
+    self.assertSetEqual(
+        set(json.loads(response.data)[0]["Assessment"]["ids"]),
+        expected_ids,
+    )
+
+  def test_sort_by_similarity(self):
+    """Check sorting by __similarity__ value with query API."""
+    expected_ids = [id_ for id_, weight in sorted(self.id_weight_map.items(),
+                                                  key=lambda item: item[1])
+                    if weight >= Assessment.similarity_options["threshold"]]
+
+    query = [{
+        "object_name": "Assessment",
+        "type": "ids",
+        "order_by": [{"name": "__similarity__"}],
+        "filters": {
+            "expression": {
+                "op": {"name": "similar"},
+                "object_name": "Assessment",
+                "id": self.assessment.id,
+            },
+        },
+    }]
+    response = self.client.post(
+        "/query",
+        data=json.dumps(query),
+        headers={"Content-Type": "application/json"},
+    )
+
+    # note that in our test data every similar object has a different weight;
+    # the order of objects with same weight is undefined after sorting
+    self.assertListEqual(
+        json.loads(response.data)[0]["Assessment"]["ids"],
+        expected_ids,
+    )


### PR DESCRIPTION
This PR adds logic to determine "related Assessments/Requests" (renamed to "similar Assessments/Requests" to avoid confusion with objects being related via Relationship object) to the backend.

This feature can be invoked through Query API by adding a special filter: `{"op": {"name": "similar"}, "object_name": "Assessment", "id": 42}`, which will return all objects of requested type (not necessarily Assessments) that have mappings similar to Assessment with id = 42.

The only types allowed in `"object_name"` here are Assessment and Request.

To sort by the measure of similarity you should provide `"order_by": ["name": "__similarity__"]` with optional `"desc": true` (to get most similar objects returned first, as the current implementation on the frontend does). This ordering is a special case and should be used only in simple queries. The ordering can be undefined of the similarity filter is combined with other filters by "or" operator (as some of the returned objects won't have the similarity measured).