### PR TITLE
ISSUE-1.177 Checkboxes are filled while Selecting None

### DIFF
--- a/src/ggrc/assets/javascripts/components/unified_mapper/mapper_checkbox.js
+++ b/src/ggrc/assets/javascripts/components/unified_mapper/mapper_checkbox.js
@@ -46,14 +46,16 @@
     },
     events: {
       '{scope} selected': function () {
+        var checked = _.findWhere(this.scope.attr('selected'), {
+          id: Number(this.scope.attr('instance').id)
+        });
+        // Avoid null and undefined
+        if (!checked) {
+          checked = false;
+        }
         this.element
           .find('.object-check-single')
-          .prop(
-            'checked',
-            _.findWhere(this.scope.attr('selected'), {
-              id: Number(this.scope.attr('instance').id)
-            })
-          );
+          .prop('checked', checked);
       },
       '.object-check-single change': function (el, ev) {
         var scope = this.scope;

--- a/src/ggrc/assets/javascripts/components/unified_mapper/mapper_results.js
+++ b/src/ggrc/assets/javascripts/components/unified_mapper/mapper_results.js
@@ -36,6 +36,7 @@
         this.attr('mapper.all_selected', false);
         this.attr('select_state', false);
         scope.attr('selected').replace([]);
+        this.attr('selected', []);
       },
       selectAll: function (scope, el, ev) {
         var entries;


### PR DESCRIPTION
**Subject**: Checkboxes are filled while Selecting None in Generate Assessment window
**Details**:   

- Create a program
- Create an Audit
- Map several new Controls to Audit 
- Navigate to Assessments tab and Click to Generate Assessments
- Select Object type “Controls” mapped to the created Audit->Click on Search button
- Select All objects
- Select None: checkboxes are still filled

**Actual Result**: Checkboxes are filled while Selecting None in Generate Assessment window
**Expected Result**: Checkboxes should not be filled while Selecting None in Generate