### PR TITLE
FEATURE Mapped objects tabs order

### DIFF
--- a/src/ggrc/assets/javascripts/apps/business_objects.js
+++ b/src/ggrc/assets/javascripts/apps/business_objects.js
@@ -89,7 +89,8 @@
         widget_id: 'info',
         content_controller: GGRC.Controllers.InfoWidget,
         instance: object,
-        widget_view: info_widget_views[object_table]
+        widget_view: info_widget_views[object_table],
+        order: 0
       });
       model_names = can.Map.keys(base_widgets_by_type);
       model_names.sort();
@@ -168,11 +169,82 @@
 
       extra_descriptor_options = {
         all: {
-          Person: {
-            widget_icon: 'fa fa-person'
+          Standard: {
+            order: 10
+          },
+          Regulation: {
+            order: 20
+          },
+          Contract: {
+            order: 30
+          },
+          Section: {
+            order: 40
+          },
+          Objective: {
+            order: 50
+          },
+          Control: {
+            order: 60
+          },
+          AccessGroup: {
+            order: 100
+          },
+          Assessment: {
+            order: 110
+          },
+          Audit: {
+            order: 120
+          },
+          Clause: {
+            order: 130
+          },
+          DataAsset: {
+            order: 140
           },
           Document: {
-            widget_icon: 'fa fa-link'
+            widget_icon: 'fa fa-link',
+            order: 150
+          },
+          Facility: {
+            order: 160
+          },
+          Issue: {
+            order: 170
+          },
+          Market: {
+            order: 180
+          },
+          OrgGroup: {
+            order: 190
+          },
+          Person: {
+            widget_icon: 'fa fa-person',
+            order: 200
+          },
+          Policy: {
+            order: 210
+          },
+          Process: {
+            order: 220
+          },
+          Product: {
+            order: 230
+          },
+          Program: {
+            order: 240
+          },
+          Project: {
+            order: 250
+          },
+          Request: {
+            order: 260
+          },
+          System: {
+            order: 270
+          },
+          Vendor: {
+            order: 280
           }
         },
         Contract: {

--- a/src/ggrc/assets/javascripts/apps/business_objects.js
+++ b/src/ggrc/assets/javascripts/apps/business_objects.js
@@ -167,6 +167,10 @@
         // here we are going to define extra descriptor options, meaning that
         //  these will be used as extra options to create widgets on top of
 
+      // NOTE: By default, widgets are sorted alphabetically (the value of
+      // the order 100+), but the objects with higher importance that should
+      // be  prioritized use order values below 100. An order value of 0 is
+      // reserved for the "info" widget which always comes first.
       extra_descriptor_options = {
         all: {
           Standard: {
@@ -267,26 +271,61 @@
             content_controller: GGRC.Controllers.TreeView
           }
         },
+
+        // An Audit has a different set of object that are more relevant to it,
+        // thus these objects have a customized priority. On the other hand,
+        // the object otherwise prioritized by default (e.g. Regulation) have
+        // their priority lowered so that they fit nicely into the alphabetical
+        // order among the non-prioritized object types.
         Audit: {
-          Person: {
-            widget_id: "person",
-            widget_name: "People",
-            widget_icon: "person",
-            content_controller: GGRC.Controllers.TreeView,
-            content_controller_options: {
-              mapping: "authorized_people",
-              allow_mapping: false,
-              allow_creating: false
-            }
+          Assessment: {
+            order: 10
+          },
+          AssessmentTemplate: {
+            order: 20
+          },
+          Issue: {
+            order: 30
           },
           Request: {
             widget_id: 'Request',
-            widget_name: 'Requests'
+            widget_name: 'Requests',
+            order: 40
+          },
+          Contract: {
+            order: 133  // between default Clause (130) and DataAsset (140)
+          },
+          Control: {
+            order: 137  // between default Clause (130) and DataAsset (140)
+          },
+          Objective: {
+            order: 182  // between default Market (180) and OrgGroup (190)
+          },
+          Regulation: {
+            order: 257  // between default Project (250) and Request (260)
           },
           program: {
-            widget_id: "program",
-            widget_name: "Program",
-            widget_icon: "program"
+            widget_id: 'program',
+            widget_name: 'Program',
+            widget_icon: 'program'
+          },
+          Section: {
+            order: 263  // between default Request (260) and System (270)
+          },
+          Standard: {
+            order: 267  // between default Request (260) and System (270)
+          },
+          Person: {
+            widget_id: 'person',
+            widget_name: 'People',
+            widget_icon: 'person',
+            // NOTE: "order" not overridden
+            content_controller: GGRC.Controllers.TreeView,
+            content_controller_options: {
+              mapping: 'authorized_people',
+              allow_mapping: false,
+              allow_creating: false
+            }
           }
         },
         Control: {

--- a/src/ggrc/assets/javascripts/apps/business_objects.js
+++ b/src/ggrc/assets/javascripts/apps/business_objects.js
@@ -133,12 +133,16 @@
           var final_definition = {};
           if (definition._mixins) {
             can.each(definition._mixins, function (mixin) {
-              if (typeof (mixin) === "string") {
+              if (typeof (mixin) === 'string') {
                 // If string, recursive lookup
-                if (!definitions[mixin])
-                  console.debug("Undefined mixin: " + mixin, definitions);
-                else
-                  can.extend(final_definition, reify_mixins(definitions[mixin]));
+                if (!definitions[mixin]) {
+                  console.debug('Undefined mixin: ' + mixin, definitions);
+                } else {
+                  can.extend(
+                    final_definition,
+                    reify_mixins(definitions[mixin])
+                  );
+                }
               } else if (can.isFunction(mixin)) {
                 // If function, call with current definition state
                 mixin(final_definition);
@@ -254,20 +258,20 @@
         Contract: {
           Clause: {
             widget_name: function () {
-              var $objectArea = $(".object-area");
-              if ($objectArea.hasClass("dashboard-area")) {
-                return "Clauses";
+              var $objectArea = $('.object-area');
+              if ($objectArea.hasClass('dashboard-area')) {
+                return 'Clauses';
               } else {
-                return "Mapped Clauses";
+                return 'Mapped Clauses';
               }
             }
           }
         },
         Program: {
           Person: {
-            widget_id: "person",
-            widget_name: "People",
-            widget_icon: "person",
+            widget_id: 'person',
+            widget_name: 'People',
+            widget_icon: 'person',
             content_controller: GGRC.Controllers.TreeView
           }
         },
@@ -330,14 +334,14 @@
         },
         Control: {
           Request: {
-            widget_id: "Request",
-            widget_name: "Requests"
+            widget_id: 'Request',
+            widget_name: 'Requests'
           }
         },
         Person: {
           Request: {
-            widget_id: "Request",
-            widget_name: "Requests"
+            widget_id: 'Request',
+            widget_name: 'Requests'
           }
         }
       },
@@ -357,22 +361,22 @@
       extra_content_controller_options = apply_mixins({
         objectives: {
           Objective: {
-            mapping: "objectives",
+            mapping: 'objectives',
             child_options: relatedObjectsChildOptions,
             draw_children: true,
-            show_view: path + "/objectives/tree.mustache",
-            footer_view: path + "/objectives/tree_footer.mustache",
-            add_item_view: path + "/objectives/tree_add_item.mustache"
+            show_view: path + '/objectives/tree.mustache',
+            footer_view: path + '/objectives/tree_footer.mustache',
+            add_item_view: path + '/objectives/tree_add_item.mustache'
           }
         },
         controls: {
           Control: {
-            mapping: "controls",
+            mapping: 'controls',
             child_options: relatedObjectsChildOptions,
             draw_children: true,
-            show_view: path + "/controls/tree.mustache",
-            footer_view: path + "/controls/tree_footer.mustache",
-            add_item_view: path + "/controls/tree_add_item.mustache"
+            show_view: path + '/controls/tree.mustache',
+            footer_view: path + '/controls/tree_footer.mustache',
+            add_item_view: path + '/controls/tree_add_item.mustache'
           }
         },
         business_objects: {
@@ -384,81 +388,81 @@
             add_item_view: path + '/audits/tree_add_item.mustache'
           },
           AccessGroup: {
-            mapping: "related_access_groups",
+            mapping: 'related_access_groups',
             child_options: relatedObjectsChildOptions,
             draw_children: true
           },
           DataAsset: {
-            mapping: "related_data_assets",
+            mapping: 'related_data_assets',
             child_options: relatedObjectsChildOptions,
             draw_children: true
           },
           Facility: {
-            mapping: "related_facilities",
+            mapping: 'related_facilities',
             child_options: relatedObjectsChildOptions,
             draw_children: true
           },
           Market: {
-            mapping: "related_markets",
+            mapping: 'related_markets',
             child_options: relatedObjectsChildOptions,
             draw_children: true
           },
           OrgGroup: {
-            mapping: "related_org_groups",
+            mapping: 'related_org_groups',
             child_options: relatedObjectsChildOptions,
             draw_children: true
           },
           Vendor: {
-            mapping: "related_vendors",
+            mapping: 'related_vendors',
             child_options: relatedObjectsChildOptions,
             draw_children: true
           },
           Process: {
-            mapping: "related_processes",
+            mapping: 'related_processes',
             child_options: relatedObjectsChildOptions,
             draw_children: true
           },
           Product: {
-            mapping: "related_products",
+            mapping: 'related_products',
             child_options: relatedObjectsChildOptions,
             draw_children: true
           },
           Project: {
-            mapping: "related_projects",
+            mapping: 'related_projects',
             child_options: relatedObjectsChildOptions,
             draw_children: true
           },
           System: {
-            mapping: "related_systems",
+            mapping: 'related_systems',
             child_options: relatedObjectsChildOptions,
             draw_children: true
           },
           Assessment: {
-            mapping: "related_assessments",
+            mapping: 'related_assessments',
             child_options: relatedObjectsChildOptions,
             draw_children: true
           },
           Request: {
-            mapping: "related_requests",
+            mapping: 'related_requests',
             child_options: [
               _.extend({}, relatedObjectsChildOptions[0], {
-                mapping: "info_related_objects"
+                mapping: 'info_related_objects'
               })
             ],
             draw_children: true
           },
           Document: {
-            mapping: "documents",
+            mapping: 'documents',
             child_options: relatedObjectsChildOptions,
             draw_children: true
           },
           Person: {
-            mapping: "people",
+            mapping: 'people',
             child_options: relatedObjectsChildOptions,
             draw_children: true
           },
           Program: {
-            mapping: "programs",
+            mapping: 'programs',
             child_options: relatedObjectsChildOptions,
             draw_children: true
           }
@@ -484,84 +488,85 @@
         },
         governance_objects: {
           Regulation: {
-            mapping: "regulations",
+            mapping: 'regulations',
             child_options: relatedObjectsChildOptions,
             draw_children: true,
             fetch_post_process: sort_sections,
-            show_view: path + "/directives/tree.mustache",
-            footer_view: path + "/directives/tree_footer.mustache",
-            add_item_view: path + "/directives/tree_add_item.mustache"
+            show_view: path + '/directives/tree.mustache',
+            footer_view: path + '/directives/tree_footer.mustache',
+            add_item_view: path + '/directives/tree_add_item.mustache'
           },
           Contract: {
-            mapping: "contracts",
+            mapping: 'contracts',
             child_options: relatedObjectsChildOptions,
             draw_children: true,
             fetch_post_process: sort_sections,
-            show_view: path + "/directives/tree.mustache",
-            footer_view: path + "/directives/tree_footer.mustache",
+            show_view: path + '/directives/tree.mustache',
+            footer_view: path + '/directives/tree_footer.mustache',
           },
           Policy: {
-            mapping: "policies",
+            mapping: 'policies',
             child_options: relatedObjectsChildOptions,
             draw_children: true,
             fetch_post_process: sort_sections,
-            show_view: path + "/directives/tree.mustache",
-            footer_view: path + "/directives/tree_footer.mustache",
-            add_item_view: path + "/directives/tree_add_item.mustache"
+            show_view: path + '/directives/tree.mustache',
+            footer_view: path + '/directives/tree_footer.mustache',
+            add_item_view: path + '/directives/tree_add_item.mustache'
           },
           Standard: {
-            mapping: "standards",
+            mapping: 'standards',
             child_options: relatedObjectsChildOptions,
             draw_children: true,
             fetch_post_process: sort_sections,
-            show_view: path + "/directives/tree.mustache",
-            footer_view: path + "/directives/tree_footer.mustache",
-            add_item_view: path + "/directives/tree_add_item.mustache"
+            show_view: path + '/directives/tree.mustache',
+            footer_view: path + '/directives/tree_footer.mustache',
+            add_item_view: path + '/directives/tree_add_item.mustache'
           },
           Control: {
-            mapping: "controls",
+            mapping: 'controls',
             child_options: relatedObjectsChildOptions,
             draw_children: true
           },
           Objective: {
-            mapping: "objectives",
+            mapping: 'objectives',
             child_options: relatedObjectsChildOptions,
             draw_children: true
           },
           Section: {
-            mapping: "sections",
+            mapping: 'sections',
             child_options: relatedObjectsChildOptions,
             draw_children: true
           },
           Clause: {
-            mapping: "clauses",
+            mapping: 'clauses',
             child_options: relatedObjectsChildOptions,
             draw_children: true
           }
         },
         Program: {
           _mixins: [
-            "governance_objects", "objectives", "controls", "business_objects", "issues"
+            'governance_objects', 'objectives', 'controls',
+            'business_objects', 'issues'
           ],
           Audit: {
-            mapping: "audits",
+            mapping: 'audits',
             allow_mapping: true,
             child_options: relatedObjectsChildOptions,
             draw_children: true,
-            show_view: path + "/audits/tree.mustache",
-            header_view: path + "/audits/tree_header.mustache",
-            footer_view: path + "/audits/tree_footer.mustache",
-            add_item_view: path + "/audits/tree_add_item.mustache"
+            show_view: path + '/audits/tree.mustache',
+            header_view: path + '/audits/tree_header.mustache',
+            footer_view: path + '/audits/tree_footer.mustache',
+            add_item_view: path + '/audits/tree_add_item.mustache'
           },
           Person: {
-            show_view: path + "/ggrc_basic_permissions/people_roles/authorizations_by_person_tree.mustache",
-            footer_view: path + "/ggrc_basic_permissions/people_roles/authorizations_by_person_tree_footer.mustache",
+            show_view: path + '/ggrc_basic_permissions/people_roles/authorizations_by_person_tree.mustache',
+            footer_view: path + '/ggrc_basic_permissions/people_roles/authorizations_by_person_tree_footer.mustache',
             parent_instance: GGRC.page_instance(),
             allow_reading: true,
             allow_mapping: true,
             allow_creating: true,
             model: CMS.Models.Person,
-            mapping: "mapped_and_or_authorized_people",
+            mapping: 'mapped_and_or_authorized_people',
             child_options: relatedObjectsChildOptions,
             draw_children: true
           }
@@ -569,30 +574,30 @@
         Audit: {
           _mixins: ['issues', 'governance_objects', 'business_objects'],
           Request: {
-            mapping: "active_requests",
+            mapping: 'active_requests',
             child_options: relatedObjectsChildOptions,
             draw_children: true,
-            show_view: path + "/requests/tree.mustache",
-            footer_view: path + "/requests/tree_footer.mustache",
-            add_item_view: path + "/requests/tree_add_item.mustache"
+            show_view: path + '/requests/tree.mustache',
+            footer_view: path + '/requests/tree_footer.mustache',
+            add_item_view: path + '/requests/tree_add_item.mustache'
           },
           Program: {
-            mapping: "_program",
+            mapping: '_program',
             parent_instance: GGRC.page_instance(),
             child_options: relatedObjectsChildOptions,
             draw_children: true,
             model: CMS.Models.Program,
-            show_view: path + "/programs/tree.mustache",
+            show_view: path + '/programs/tree.mustache',
             allow_mapping: false,
             allow_creating: false
           },
           Section: {
-            mapping: "sections",
+            mapping: 'sections',
             child_options: relatedObjectsChildOptions,
             draw_children: true
           },
           Clause: {
-            mapping: "clauses",
+            mapping: 'clauses',
             child_options: relatedObjectsChildOptions,
             draw_children: true
           },
@@ -621,14 +626,14 @@
               '/assessment_templates/tree_add_item.mustache'
           },
           Person: {
-            widget_id: "person",
-            widget_name: "People",
-            widget_icon: "person",
+            widget_id: 'person',
+            widget_name: 'People',
+            widget_icon: 'person',
             child_options: relatedObjectsChildOptions,
             draw_children: true,
             content_controller: GGRC.Controllers.TreeView,
             content_controller_options: {
-              mapping: "authorized_people",
+              mapping: 'authorized_people',
               allow_mapping: false,
               allow_creating: false
             }
@@ -636,15 +641,15 @@
         },
         directive: {
           _mixins: [
-            "objectives", "controls", "business_objects"
+            'objectives', 'controls', 'business_objects'
           ],
           Section: {
-            mapping: "sections",
+            mapping: 'sections',
             child_options: relatedObjectsChildOptions,
             draw_children: true
           },
           Clause: {
-            mapping: "clauses",
+            mapping: 'clauses',
             child_options: relatedObjectsChildOptions,
             draw_children: true
           },
@@ -655,16 +660,16 @@
           }
          },
         Regulation: {
-          _mixins: ["directive", "issues"]
+          _mixins: ['directive', 'issues']
         },
         Standard: {
-          _mixins: ["directive", "issues"]
+          _mixins: ['directive', 'issues']
         },
         Policy: {
-          _mixins: ["directive", "issues"]
+          _mixins: ['directive', 'issues']
         },
         Contract: {
-          _mixins: ["directive", "issues"]
+          _mixins: ['directive', 'issues']
         },
         Clause: {
           _mixins: ['governance_objects', 'business_objects', 'issues'],
@@ -699,51 +704,51 @@
           }
         },
         Request: {
-          _mixins: ["governance_objects", "business_objects", "issues"],
+          _mixins: ['governance_objects', 'business_objects', 'issues'],
           Audit: {
-            mapping: "audits",
+            mapping: 'audits',
             child_options: relatedObjectsChildOptions,
             draw_children: true,
             allow_creating: false,
             allow_mapping: false,
-            show_view: path + "/audits/tree.mustache",
-            add_item_view: path + "/audits/tree_add_item.mustache"
+            show_view: path + '/audits/tree.mustache',
+            add_item_view: path + '/audits/tree_add_item.mustache'
           },
         },
         Assessment: {
-          _mixins: ["governance_objects", "business_objects", "issues"],
+          _mixins: ['governance_objects', 'business_objects', 'issues'],
           Audit: {
-            mapping: "related_audits",
+            mapping: 'related_audits',
             child_options: relatedObjectsChildOptions,
             draw_children: true,
             allow_creating: false,
             allow_mapping: true,
-            show_view: path + "/audits/tree.mustache",
-            add_item_view: path + "/audits/tree_add_item.mustache"
+            show_view: path + '/audits/tree.mustache',
+            add_item_view: path + '/audits/tree_add_item.mustache'
           },
           Section: {
-            mapping: "sections",
+            mapping: 'sections',
             child_options: relatedObjectsChildOptions,
             draw_children: true
           },
           Clause: {
-            mapping: "clauses",
+            mapping: 'clauses',
             child_options: relatedObjectsChildOptions,
             draw_children: true
           },
           Request: {
-            mapping: "related_requests",
+            mapping: 'related_requests',
             child_options: relatedObjectsChildOptions,
             draw_children: true,
-            show_view: path + "/requests/tree.mustache",
-            footer_view: path + "/requests/tree_footer.mustache",
-            add_item_view: path + "/requests/tree_add_item.mustache"
+            show_view: path + '/requests/tree.mustache',
+            footer_view: path + '/requests/tree_footer.mustache',
+            add_item_view: path + '/requests/tree_add_item.mustache'
           }
         },
         Issue: {
           _mixins: ['governance_objects', 'business_objects'],
           Control: {
-            mapping: "related_controls",
+            mapping: 'related_controls',
             child_options: relatedObjectsChildOptions,
             draw_children: true,
             show_view: path + '/controls/tree.mustache',
@@ -756,104 +761,109 @@
             add_item_view: path + '/base_objects/tree_add_item.mustache'
           },
           Audit: {
-            mapping: "related_audits",
+            mapping: 'related_audits',
             child_options: relatedObjectsChildOptions,
             draw_children: true,
-            show_view: GGRC.mustache_path + "/audits/tree.mustache",
-            footer_view: GGRC.mustache_path + "/base_objects/tree_footer.mustache",
-            add_item_view: GGRC.mustache_path + "/base_objects/tree_add_item.mustache"
+            show_view: GGRC.mustache_path + '/audits/tree.mustache',
+            footer_view:
+              GGRC.mustache_path + '/base_objects/tree_footer.mustache',
+            add_item_view:
+              GGRC.mustache_path + '/base_objects/tree_add_item.mustache'
           }
         },
         AccessGroup: {
-          _mixins: ["governance_objects", "business_objects", "issues"]
+          _mixins: ['governance_objects', 'business_objects', 'issues']
         },
         DataAsset: {
-          _mixins: ["governance_objects", "business_objects", "issues"]
+          _mixins: ['governance_objects', 'business_objects', 'issues']
         },
         Facility: {
-          _mixins: ["governance_objects", "business_objects", "issues"]
+          _mixins: ['governance_objects', 'business_objects', 'issues']
         },
         Market: {
-          _mixins: ["governance_objects", "business_objects", "issues"]
+          _mixins: ['governance_objects', 'business_objects', 'issues']
         },
         OrgGroup: {
-          _mixins: ["governance_objects", "business_objects", "issues"]
+          _mixins: ['governance_objects', 'business_objects', 'issues']
         },
         Vendor: {
-          _mixins: ["governance_objects", "business_objects", "issues"]
+          _mixins: ['governance_objects', 'business_objects', 'issues']
         },
         Process: {
-          _mixins: ["governance_objects", "business_objects", "issues"]
+          _mixins: ['governance_objects', 'business_objects', 'issues']
         },
         Product: {
-          _mixins: ["governance_objects", "business_objects", "issues"]
+          _mixins: ['governance_objects', 'business_objects', 'issues']
         },
         Project: {
-          _mixins: ["governance_objects", "business_objects", "issues"]
+          _mixins: ['governance_objects', 'business_objects', 'issues']
         },
         System: {
-          _mixins: ["governance_objects", "business_objects", "issues"]
+          _mixins: ['governance_objects', 'business_objects', 'issues']
         },
         Document: {
-          _mixins: ["governance_objects", "business_objects", "issues"]
+          _mixins: ['governance_objects', 'business_objects', 'issues']
         },
         Person: {
-          _mixins: ["issues"],
+          _mixins: ['issues'],
           Request: {
             mapping: (/^\/objectBrowser\/?$/.test(window.location.pathname)) ?
-              "all_open_audit_requests" : "open_audit_requests",
+              'all_open_audit_requests' : 'open_audit_requests',
             draw_children: true,
             child_options: relatedObjectsChildOptions,
-            show_view: GGRC.mustache_path + "/requests/tree.mustache",
-            footer_view: GGRC.mustache_path + "/requests/tree_footer.mustache",
-            add_item_view: GGRC.mustache_path + "/requests/tree_add_item.mustache"
+            show_view: GGRC.mustache_path + '/requests/tree.mustache',
+            footer_view: GGRC.mustache_path + '/requests/tree_footer.mustache',
+            add_item_view:
+              GGRC.mustache_path + '/requests/tree_add_item.mustache'
           },
           Program: {
-            mapping: "extended_related_programs_via_search",
+            mapping: 'extended_related_programs_via_search',
             child_options: relatedObjectsChildOptions,
             draw_children: true,
             fetch_post_process: sort_sections
           },
           Regulation: {
-            mapping: "extended_related_regulations_via_search",
+            mapping: 'extended_related_regulations_via_search',
             child_options: relatedObjectsChildOptions,
             draw_children: true,
             fetch_post_process: sort_sections,
-            show_view: path + "/directives/tree.mustache"
+            show_view: path + '/directives/tree.mustache'
           },
           Contract: {
-            mapping: "extended_related_contracts_via_search",
+            mapping: 'extended_related_contracts_via_search',
             child_options: relatedObjectsChildOptions,
             draw_children: true,
             fetch_post_process: sort_sections,
-            show_view: path + "/directives/tree.mustache"
+            show_view: path + '/directives/tree.mustache'
           },
           Standard: {
-            mapping: "extended_related_standards_via_search",
+            mapping: 'extended_related_standards_via_search',
             child_options: relatedObjectsChildOptions,
             draw_children: true,
             fetch_post_process: sort_sections,
-            show_view: path + "/directives/tree.mustache"
+            show_view: path + '/directives/tree.mustache'
           },
           Policy: {
-            mapping: "extended_related_policies_via_search",
+            mapping: 'extended_related_policies_via_search',
             child_options: relatedObjectsChildOptions,
             draw_children: true,
             fetch_post_process: sort_sections,
-            show_view: path + "/directives/tree.mustache"
+            show_view: path + '/directives/tree.mustache'
           },
           Audit: {
-            mapping: "extended_related_audits_via_search",
+            mapping: 'extended_related_audits_via_search',
             child_options: relatedObjectsChildOptions,
             draw_children: true,
-            show_view: path + "/audits/tree.mustache"
+            show_view: path + '/audits/tree.mustache'
           },
           Section: {
             model: CMS.Models.Section,
-            mapping: "extended_related_sections_via_search",
-            show_view: GGRC.mustache_path + "/sections/tree.mustache",
-            footer_view: GGRC.mustache_path + "/base_objects/tree_footer.mustache",
-            add_item_view: GGRC.mustache_path + "/base_objects/tree_add_item.mustache",
+            mapping: 'extended_related_sections_via_search',
+            show_view: GGRC.mustache_path + '/sections/tree.mustache',
+            footer_view:
+              GGRC.mustache_path + '/base_objects/tree_footer.mustache',
+            add_item_view:
+              GGRC.mustache_path + '/base_objects/tree_add_item.mustache',
             child_options: relatedObjectsChildOptions,
             draw_children: true
           },
@@ -861,8 +871,10 @@
             model: CMS.Models.Clause,
             mapping: 'extended_related_clauses_via_search',
             show_view: GGRC.mustache_path + '/sections/tree.mustache',
-            footer_view: GGRC.mustache_path + '/base_objects/tree_footer.mustache',
-            add_item_view: GGRC.mustache_path + '/base_objects/tree_add_item.mustache',
+            footer_view:
+              GGRC.mustache_path + '/base_objects/tree_footer.mustache',
+            add_item_view:
+              GGRC.mustache_path + '/base_objects/tree_add_item.mustache',
             child_options: relatedObjectsChildOptions,
             draw_children: true
           },

--- a/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
@@ -145,6 +145,7 @@
           this.inner_nav_controller.update_widget_list(
             this.get_active_widget_elements());
         }
+        this.inner_nav_controller.sortWidgets();
       }
     },
 
@@ -387,6 +388,23 @@
       })[0] || undefined;
     },
 
+    /**
+     * Sort widgets in place by their `order` attribute in ascending order.
+     *
+     * The widgets with non-existing / non-numeric `order` value are placed
+     * at the end of the list.
+     */
+    sortWidgets: function () {
+      function sortByOrderAttr(widget, widget2) {
+        var order = _.isNumber(widget.order) ?
+                                widget.order : Number.MAX_SAFE_INTEGER;
+        var order2 = _.isNumber(widget2.order) ?
+                                 widget2.order : Number.MAX_SAFE_INTEGER;
+        return order - order2;
+      }
+      this.options.widget_list.sort(sortByOrderAttr);
+    },
+
     update_widget_list: function (widget_elements) {
       var widget_list = this.options.widget_list.slice(0);
       var that = this;
@@ -446,7 +464,8 @@
         internav_icon: icon,
         internav_display: title,
         spinner: this.options.spinners['#' + $widget.attr('id')],
-        model: widget_options && widget_options.model
+        model: widget_options && widget_options.model,
+        order: (widget_options || widget).order
       });
 
       index = this.options.widget_list.length;
@@ -464,6 +483,7 @@
           this.options.widget_list.push(widget);
         }
       }
+
       return widget;
     },
 

--- a/src/ggrc/assets/javascripts/controllers/tests/inner_navigation_controller_spec.js
+++ b/src/ggrc/assets/javascripts/controllers/tests/inner_navigation_controller_spec.js
@@ -1,0 +1,66 @@
+/*!
+  Copyright (C) 2016 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+describe('CMS.Controllers.InnerNav', function () {
+  'use strict';
+
+  var Ctrl;  // the controller under test
+
+  beforeAll(function () {
+    Ctrl = CMS.Controllers.InnerNav;
+  });
+
+  describe('sortWidgets() method', function () {
+    var ctrlInst;  // fake controller instance
+    var sortWidgets;
+    var options;
+
+    beforeEach(function () {
+      options = {
+        widget_list: new can.Observe.List([])
+      };
+
+      ctrlInst = {
+        options: new can.Map(options)
+      };
+
+      sortWidgets = Ctrl.prototype.sortWidgets.bind(ctrlInst);
+    });
+
+    it('sorts widgets by their "order" attribute', function () {
+      var widgetOrder;
+      var widgets = [
+        {widget_id: 'aaa', order: 40},
+        {widget_id: 'bbb', order: 20},
+        {widget_id: 'ccc', order: 50},
+        {widget_id: 'ddd', order: 10},
+        {widget_id: 'eee', order: 30}
+      ];
+      options.widget_list.replace(widgets);
+
+      sortWidgets();
+
+      widgetOrder = _.map(ctrlInst.options.widget_list, 'widget_id');
+      expect(widgetOrder).toEqual(['ddd', 'bbb', 'eee', 'aaa', 'ccc']);
+    });
+
+    it('places widgets with unknown "order" at the end', function () {
+      var lastWidget;
+      var widgets = [
+        {widget_id: 'aaa', order: 40},
+        {widget_id: 'bbb', order: undefined},
+        {widget_id: 'ccc', order: 50},
+        {widget_id: 'ddd', order: 10},
+        {widget_id: 'eee', order: 30}
+      ];
+      options.widget_list.replace(widgets);
+
+      sortWidgets();
+
+      lastWidget = ctrlInst.options.widget_list[4];
+      expect(lastWidget.widget_id).toEqual('bbb');
+    });
+  });
+});

--- a/src/ggrc/assets/javascripts/modules/widget_descriptor.js
+++ b/src/ggrc/assets/javascripts/modules/widget_descriptor.js
@@ -4,7 +4,7 @@
 */
 
 (function ($, CMS, GGRC) {
-  //A widget descriptor has the minimum five properties:
+  // A widget descriptor has the minimum five properties:
   // widget_id:  the unique ID string for the widget
   // widget_name: the display title for the widget in the UI
   // widget_icon: the CSS class for the widget in the UI
@@ -12,30 +12,31 @@
   // content_controller_options: options passed directly to the content controller; the
   //   precise options depend on the controller itself.  They usually require instance
   //   and/or model and some view.
-  can.Construct("GGRC.WidgetDescriptor", {
+  can.Construct('GGRC.WidgetDescriptor', {
     /*
       make an info widget descriptor for a GGRC object
       You must provide:
       instance - an instance that is a subclass of can.Model.Cacheable
-      widget_view [optional] - a template for rendering the info.
+      widgetView [optional] - a template for rendering the info.
     */
-    make_info_widget: function (instance, widget_view) {
-      var default_info_widget_view = GGRC.mustache_path + "/base_objects/info.mustache";
+    make_info_widget: function (instance, widgetView) {
+      var defaultInfoWidgetView = GGRC.mustache_path +
+                                     '/base_objects/info.mustache';
       return new this(
-        instance.constructor.shortName + ":info", {
-          widget_id: "info",
+        instance.constructor.shortName + ':info', {
+          widget_id: 'info',
           widget_name: function () {
-            if (instance.constructor.title_singular === 'Person')
+            if (instance.constructor.title_singular === 'Person') {
               return 'Info';
-            else
-              return instance.constructor.title_singular + " Info";
+            }
+            return instance.constructor.title_singular + ' Info';
           },
-          widget_icon: "info-circle",
+          widget_icon: 'info-circle',
           content_controller: GGRC.Controllers.InfoWidget,
           content_controller_options: {
             instance: instance,
             model: instance.constructor,
-            widget_view: widget_view || default_info_widget_view
+            widget_view: widgetView || defaultInfoWidgetView
           },
           order: 0
         });
@@ -44,44 +45,51 @@
       make a tree view widget descriptor with mostly default-for-GGRC settings.
       You must provide:
       instance - an instance that is a subclass of can.Model.Cacheable
-      far_model - a can.Model.Cacheable class
+      farModel - a can.Model.Cacheable class
       mapping - a mapping object taken from the instance
       extenders [optional] - an array of objects that will extend the default widget config.
     */
-    make_tree_view: function (instance, far_model, mapping, extenders) {
+    make_tree_view: function (instance, farModel, mapping, extenders) {
       var descriptor = {
         content_controller: CMS.Controllers.TreeView,
-        content_controller_selector: "ul",
+        content_controller_selector: 'ul',
         widget_initial_content: '<ul class="tree-structure new-tree"></ul>',
-        widget_id: far_model.table_singular,
+        widget_id: farModel.table_singular,
         widget_guard: function () {
-          if (far_model.title_plural === "Audits" && instance instanceof CMS.Models.Program) {
-            return "context" in instance && !!(instance.context.id);
+          if (
+            farModel.title_plural === 'Audits' &&
+            instance instanceof CMS.Models.Program
+          ) {
+            return 'context' in instance && !!(instance.context.id);
           }
           return true;
         },
         widget_name: function () {
-          var $objectArea = $(".object-area");
-          if ($objectArea.hasClass("dashboard-area") || instance.constructor.title_singular === "Person") {
+          var $objectArea = $('.object-area');
+          if (
+            $objectArea.hasClass('dashboard-area') ||
+            instance.constructor.title_singular === 'Person'
+          ) {
             if (/dashboard/.test(window.location)) {
-              return "My " + far_model.title_plural;
-            } else {
-              return far_model.title_plural;
+              return 'My ' + farModel.title_plural;
             }
-          } else if (far_model.title_plural === "Audits") {
-            return "Mapped Audits";
-          } else {
-            return (far_model.title_plural === "References" ? "Linked " : "Mapped ") + far_model.title_plural;
+            return farModel.title_plural;
+          } else if (farModel.title_plural === 'Audits') {
+            return 'Mapped Audits';
           }
+          return (
+            farModel.title_plural === 'References' ?
+                                         'Linked ' : 'Mapped '
+          ) + farModel.title_plural;
         },
-        widget_icon: far_model.table_singular,
-        object_category: far_model.category || 'default',
-        model: far_model,
+        widget_icon: farModel.table_singular,
+        object_category: farModel.category || 'default',
+        model: farModel,
         content_controller_options: {
           child_options: [],
           draw_children: true,
           parent_instance: instance,
-          model: far_model,
+          model: farModel,
           list_loader: function () {
             return mapping.refresh_list();
           }
@@ -90,11 +98,14 @@
 
       $.extend.apply($, [true, descriptor].concat(extenders || []));
 
-      return new this(instance.constructor.shortName + ":" + far_model.table_singular, descriptor);
+      return new this(
+        instance.constructor.shortName + ':' + farModel.table_singular,
+        descriptor
+      );
     },
     newInstance: function (id, opts) {
       var ret;
-      if (!opts && typeof id === "object") {
+      if (!opts && typeof id === 'object') {
         opts = id;
         id = opts.widget_id;
       }
@@ -108,12 +119,12 @@
           GGRC.widget_descriptors[id] = ret;
         }
         return GGRC.widget_descriptors[id];
-      } else {
-        ret = this._super.apply(this, arguments);
-        $.extend(ret, opts);
-        GGRC.widget_descriptors[id] = ret;
-        return ret;
       }
+
+      ret = this._super.apply(this, arguments);
+      $.extend(ret, opts);
+      GGRC.widget_descriptors[id] = ret;
+      return ret;
     }
   }, {});
 })(this.can.$, this.CMS, this.GGRC);

--- a/src/ggrc/assets/javascripts/modules/widget_descriptor.js
+++ b/src/ggrc/assets/javascripts/modules/widget_descriptor.js
@@ -36,7 +36,8 @@
             instance: instance,
             model: instance.constructor,
             widget_view: widget_view || default_info_widget_view
-          }
+          },
+          order: 0
         });
     },
     /*

--- a/src/ggrc/assets/javascripts/modules/widget_list.js
+++ b/src/ggrc/assets/javascripts/modules/widget_list.js
@@ -17,20 +17,22 @@
     See the comments for GGRC.WidgetDescriptor for details in what is necessary to define
     a widget descriptor.
   */
-  can.Construct("GGRC.WidgetList", {
+  can.Construct('GGRC.WidgetList', {
     modules: {},
     /*
       get_widget_list_for: return a keyed object of widget descriptors for the specified page type.
 
-      page_type - one of a GGRC object model's shortName, or "admin"
+      pageType - one of a GGRC object model's shortName, or "admin"
 
       The widget descriptors are built on the first call of this function; subsequently they are retrieved from the
        widget descriptor cache.
     */
-    get_widget_list_for: function (page_type) {
+    get_widget_list_for: function (pageType) {
       var widgets = {};
+      var descriptors = {};
+
       can.each(this.modules, function (module) {
-        can.each(module[page_type], function (descriptor, id) {
+        can.each(module[pageType], function (descriptor, id) {
           if (!widgets[id]) {
             widgets[id] = descriptor;
           } else {
@@ -38,43 +40,47 @@
           }
         });
       });
-      var descriptors = {};
-      can.each(widgets, function (widget, widget_id) {
+
+      can.each(widgets, function (widget, widgetId) {
         switch (widget.content_controller) {
-        case GGRC.Controllers.InfoWidget:
-          descriptors[widget_id] = GGRC.WidgetDescriptor.make_info_widget(
-            widget.content_controller_options && widget.content_controller_options.instance || widget.instance,
-            widget.content_controller_options && widget.content_controller_options.widget_view || widget.widget_view
-          );
-          break;
-        case GGRC.Controllers.TreeView:
-          descriptors[widget_id] = GGRC.WidgetDescriptor.make_tree_view(
-            widget.content_controller_options && (widget.content_controller_options.instance || widget.content_controller_options.parent_instance) || widget.instance,
-            widget.content_controller_options && widget.content_controller_options.model || widget.far_model || widget.model,
-            widget.content_controller_options && widget.content_controller_options.mapping || widget.mapping,
-            widget
-          );
-          break;
-        default:
-          descriptors[widget_id] = new GGRC.WidgetDescriptor(page_type + ":" + widget_id, widget);
+          case GGRC.Controllers.InfoWidget:
+            descriptors[widgetId] = GGRC.WidgetDescriptor.make_info_widget(
+              widget.content_controller_options && widget.content_controller_options.instance || widget.instance,
+              widget.content_controller_options && widget.content_controller_options.widget_view || widget.widget_view
+            );
+            break;
+          case GGRC.Controllers.TreeView:
+            descriptors[widgetId] = GGRC.WidgetDescriptor.make_tree_view(
+              widget.content_controller_options && (widget.content_controller_options.instance || widget.content_controller_options.parent_instance) || widget.instance,
+              widget.content_controller_options && widget.content_controller_options.model || widget.far_model || widget.model,
+              widget.content_controller_options && widget.content_controller_options.mapping || widget.mapping,
+              widget
+            );
+            break;
+          default:
+            descriptors[widgetId] = new GGRC.WidgetDescriptor(
+                pageType + ':' + widgetId, widget);
         }
       });
+
       can.each(descriptors, function (descriptor, id) {
         if (descriptor.suppressed) {
           delete descriptors[id];
         }
       });
+
       return descriptors;
     },
     /*
       returns a keyed object of widget descriptors that represents the current page.
     */
     get_current_page_widgets: function () {
-      return this.get_widget_list_for(GGRC.page_instance().constructor.shortName);
+      return this.get_widget_list_for(
+        GGRC.page_instance().constructor.shortName);
     },
     get_default_widget_sort: function () {
       return this.sort;
-    },
+    }
   }, {
     init: function (name, opts, sort) {
       this.constructor.modules[name] = this;
@@ -87,27 +93,27 @@
       Here instead of using the object format described in the class comments, you may instead
       add widgets to the WidgetList by using add_widget.
 
-      page_type - the shortName of a GGRC object class, or "admin"
+      pageType - the shortName of a GGRC object class, or "admin"
       id - the desired widget's id.
       descriptor - a widget descriptor appropriate for the widget type. FIXME - the descriptor's
         widget_id value must match the value passed as "id"
     */
-    add_widget: function (page_type, id, descriptor) {
-      this[page_type] = this[page_type] || {};
-      if (this[page_type][id]) {
-        can.extend(true, this[page_type][id], descriptor);
+    add_widget: function (pageType, id, descriptor) {
+      this[pageType] = this[pageType] || {};
+      if (this[pageType][id]) {
+        can.extend(true, this[pageType][id], descriptor);
       } else {
-        this[page_type][id] = descriptor;
+        this[pageType][id] = descriptor;
       }
     },
-    suppress_widget: function (page_type, id) {
-      this[page_type] = this[page_type] || {};
-      if (this[page_type][id]) {
-        can.extend(true, this[page_type][id], {
+    suppress_widget: function (pageType, id) {
+      this[pageType] = this[pageType] || {};
+      if (this[pageType][id]) {
+        can.extend(true, this[pageType][id], {
           suppressed: true
         });
       } else {
-        this[page_type][id] = {
+        this[pageType][id] = {
           suppressed: true
         };
       }

--- a/src/ggrc/assets/mustache/dashboard/internav_list.mustache
+++ b/src/ggrc/assets/mustache/dashboard/internav_list.mustache
@@ -3,7 +3,7 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
 
-{{#each widget_list}}
+{{#widget_list}}
   <li>
     {{#if_helpers '\
       #if' has_count '\
@@ -33,13 +33,14 @@
     </a>
     {{/if_helpers}}
   </li>
-{{/each}}
+{{/widget_list}}
+
 {{#is_allowed 'update' instance}}
 {{#if widget_list.length}}
 <li data-test-id="button_widget_add_2c925d94" class="hidden-widgets-list">
   <a href="#dropdown-widgets" class="dropdown-toggle" data-toggle="dropdown" rel="tooltip" data-placement="bottom" title="Add widget"><i class="fa fa-plus-circle"></i> Add...</a>
   <div class="dropdown-menu" role="menu">
-    {{#each widget_list}}
+    {{#widget_list}}
       <div class="inner-nav-item">
         {{^if_helpers '\
           #if' has_count '\
@@ -65,9 +66,10 @@
         </a>
         {{/if_helpers}}
       </div>
-    {{/each}}
+    {{/widget_list}}
   </div>
 </li>
 {{/if}}
 {{/is_allowed}}
+
 {{{render_hooks 'ObjectNav.Actions'}}}

--- a/src/ggrc_risks/assets/javascripts/apps/risks.js
+++ b/src/ggrc_risks/assets/javascripts/apps/risks.js
@@ -226,6 +226,7 @@
       widget_id: CMS.Models.Threat.table_singular,
       widget_name: CMS.Models.Threat.title_plural,
       widget_icon: CMS.Models.Threat.table_singular,
+      order: 275,
       content_controller_options: {
         child_options: relatedObjectsChildOptions,
         draw_children: true,
@@ -242,6 +243,7 @@
       widget_id: CMS.Models.Risk.table_singular,
       widget_name: CMS.Models.Risk.title_plural,
       widget_icon: CMS.Models.Risk.table_singular,
+      order: 265,
       content_controller_options: {
         child_options: relatedObjectsChildOptions,
         draw_children: true,

--- a/src/ggrc_workflows/assets/javascripts/apps/workflows.js
+++ b/src/ggrc_workflows/assets/javascripts/apps/workflows.js
@@ -397,6 +397,7 @@
         workflow: {
           widget_id: 'workflow',
           widget_name: 'Workflows',
+          order: 400,
           content_controller: GGRC.Controllers.TreeView,
           content_controller_options: {
             mapping: 'workflows',
@@ -409,6 +410,7 @@
         task: {
           widget_id: 'task',
           widget_name: 'Workflow Tasks',
+          order: 410,
           content_controller: GGRC.Controllers.TreeView,
           content_controller_options: {
             mapping: 'object_tasks',


### PR DESCRIPTION
_(Buganizer issue 28426058, for those with access)_

The user wanted a modified order of the tabs in the horizontal navigation bar (currently sorted alphabetically). The new order of the mapped object types should be as follows:

- Standard
- Regulation
- Contract
- Section
- Objective
- Control
- everything else (opted to keep that in alphabetical order)

BTW, this new order does not apply to Workflows AFAIK - please let me know in case this assumption is incorrect.

BTW 2, this change also affect the order of the items in the HNB's "Add..." menu (it uses the same collection for rendering), but when discussed with @Smotko we concluded that this is probably just fine and a different (read: alphabetical) order is not required there.