### PR TITLE
ISSUE-1.208 Use error message from server-side

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment/inline.js
+++ b/src/ggrc/assets/javascripts/components/assessment/inline.js
@@ -188,11 +188,9 @@
               success: 'Saved'
             });
             this.afterSave();
-          }.bind(this)).fail(function () {
+          }.bind(this)).fail(function (instance, err) {
             this.attr('context.value', this.attr('_value'));
-            $(document.body).trigger('ajax:flash', {
-              error: 'There was a problem saving'
-            });
+            GGRC.Errors.notifier()(err);
           }.bind(this)).always(function () {
             this.attr('isSaving', false);
           }.bind(this));

--- a/src/ggrc/assets/javascripts/components/mapped_tree_view.js
+++ b/src/ggrc/assets/javascripts/components/mapped_tree_view.js
@@ -91,17 +91,7 @@
                 return mapping.documentable.reify();
               }
             })
-            .fail(function (err) {
-              var messages = {
-                '403': 'You don\'t have the permission to access the ' +
-                'requested resource. It is either read-protected or not ' +
-                'readable by the server.'
-              };
-              if (messages[err.status]) {
-                $('body').trigger('ajax:flash',
-                  {warning: messages[err.status]});
-              }
-            });
+            .fail(GGRC.Errors.notifier());
         });
       }
     }

--- a/src/ggrc/assets/javascripts/ggrc_base.js
+++ b/src/ggrc/assets/javascripts/ggrc_base.js
@@ -152,6 +152,27 @@
     delay_leaving_page_until: $.proxy(notifier, "queue")
   });
 
+  GGRC.Errors = {
+    messages: {
+      '403': 'You don\'t have the permission to access the ' +
+      'requested resource. It is either read-protected or not ' +
+      'readable by the server.'
+    },
+    notifier: function (type) {
+      if (!type) {
+        type = 'warning';
+      }
+
+      return function (err) {
+        var message = GGRC.Errors.messages[err.status];
+        var props = {};
+
+        props[type] = message ? message : 'There was a server problem';
+        $('body').trigger('ajax:flash', props);
+      };
+    }
+  };
+
   /*
     The GGRC Math library provides basic arithmetic across arbitrary precision numbers represented
     as strings.  We wrote this initially to handle easy re-sorting of items in tree views, since

--- a/src/ggrc/assets/javascripts/models/cacheable.js
+++ b/src/ggrc/assets/javascripts/models/cacheable.js
@@ -1226,7 +1226,7 @@ can.Model('can.Model.Cacheable', {
       })
       .fail(function (response) {
         that.notifier.on_empty(function () {
-          dfd.reject(that, response.responseText);
+          dfd.reject(that, response);
         });
       })
       .done(function () {


### PR DESCRIPTION
**Subject**: User gets non-informative error message when he doesn't have permissions to update the Assessment
**Details**: Create an assessment and assign a Global Reader as an assignee
Make sure GR user is added to the program with Program Reader Role
Log in as GR and remove yourself from assignee
Do not refresh the page
Try inline editing one of the CAs on Assessment’s info pane

_Actual Result:_ the red error message “There was a problem saving” appears
_Expected Result:_ the error should say “you have no permissions to edit the assessment”