### PR TITLE
ISSUE-1.195 Uncaught Error: Syntax error, unrecognized expression

### DIFF
--- a/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
+++ b/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
@@ -275,7 +275,7 @@
           return value === '0';
         },
         'Rich Text': function (value) {
-          return _.isEmpty($(value).text());
+          return _.isEmpty($('<span>' + value).text());
         }
       };
       if (types.indexOf(type) >= 0 && options[type]) {


### PR DESCRIPTION
**Subject**: "Uncaught Error: Syntax error, unrecognized expression: fdsfsd<br>ewtretert<br>tretre<br>treter" error is displayed when saving Assessment with multiple text line in Rich Text CA field
**Details**:   

- Create a program
- Go to Assessments tab
- Click + to map assessments
- Click Create new Assessment
- Fill in all required field
- Fill in few lines of text in Rich Text Custom Attribute field
- Click Save button
- Observe browser console

**Actual Result**: `"Uncaught Error: Syntax error, unrecognized expression: fdsfsd<br>ewtretert<br>tretre<br>treter" error is displayed`
**Expected Result**: No errors displayed. 