### PR TITLE
ISSUE-1.216 Make sure that new comments' text gets displayed

### DIFF
--- a/src/ggrc/assets/mustache/base_templates/comment_subtree.mustache
+++ b/src/ggrc/assets/mustache/base_templates/comment_subtree.mustache
@@ -17,15 +17,23 @@
         <h6 class="comment-list__ca-description">{{instance.custom_attribute_revision.custom_attribute.title}}: {{instance.custom_attribute_revision.custom_attribute_stored_value}}</h6>
     {{/instance.custom_attribute_revision}}
     <div class="rtf-block">
-      <inline-edit
-        type="text"
-        instance="instance"
-        property="description"
-        value="description"
-        {{^canEditComment instance parentInstance}}readonly{{/canEditComment}}
-        can-on-save="instance.updateDescription"
-        empty-text="No comment was entered"
-      ></inline-edit>
+      {{!
+        The inlineEdit component parses and updates the "type" attribute too
+        late (after its template has been parsed), sometimes causing the inline
+        edit widget not to be rendered at all. We thus need to explicitly set
+        the said attribute to "text" before using  the component.
+      }}
+      {{#add_to_current_scope type="text"}}
+        <inline-edit
+          type="text"
+          instance="instance"
+          property="description"
+          value="description"
+          {{^canEditComment instance parentInstance}}readonly{{/canEditComment}}
+          can-on-save="instance.updateDescription"
+          empty-text="No comment was entered"
+        ></inline-edit>
+      {{/add_to_current_scope}}
     </div>
     <mapping-tree-view
       parent-instance="instance"


### PR DESCRIPTION
_(section 2, bug 1.216)_

This PR fixes an issue that prevented the newly added comments' text to be displayed immediately (a page reload or adding another comment was required).

The issue was caused by the known order of parsing the components' templates - first the template is parsed, and only _then_ the component's _init()_ method is invoked. Updating the `type` attribute in the latter did not make the template to re-render itself, thus I had to add a workaround.

BTW, if there is a better canonical way to deal with this, please let me know, and I will apply a different fix.

**Steps to reproduce:**
- Navigate to audit page and open Assessment’s info panel
- Click icon next to a CA field title to add the comment (see the [screencast](https://drive.google.com/open?id=0B_yi_GigOIL5S3BtcmVVZERQekk))
- Add a comment

  (BTW, you can also add a comment directly using the form at the bottom of the Assessment's info pane,   under the Comments tab)
- See the Comments tab below

**Actual Result:**
The text of the newly added comment isn’t shown

**Expected Result:**
Text of the comment should be shown along with the user name and date stamp