### PR TITLE
ISSUE-1.182 Task Due today but listed as overdue

### DIFF
--- a/src/ggrc/assets/js_specs/mustache_helpers/localize_date_today_spec.js
+++ b/src/ggrc/assets/js_specs/mustache_helpers/localize_date_today_spec.js
@@ -1,0 +1,44 @@
+/*!
+ Copyright (C) 2016 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+describe('can.mustache.helper.localize_date_today', function () {
+  'use strict';
+
+  var helper;
+  var testDate;
+
+  beforeAll(function () {
+    helper = can.Mustache._helpers.localize_date_today.fn;
+  });
+
+  it('returns "Today" for today', function () {
+    testDate = new Date();
+    expect(helper(testDate)).toEqual('Today');
+  });
+
+  it('returns date for tomorrow', function () {
+    var today = new Date();
+    var tomorrow = today.getDate() + 1;
+    var expected = moment(tomorrow).format('MM/DD/YYYY');
+    expect(helper(tomorrow)).toEqual(expected);
+  });
+
+  it('returns date for yesterday', function () {
+    var yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    var expected = moment(yesterday).format('MM/DD/YYYY');
+    expect(helper(yesterday)).toEqual(expected);
+  });
+
+  it('returns date string when date is passed in', function () {
+    testDate = new Date(2000, 2, 2);
+    expect(helper(testDate)).toEqual('03/02/2000');
+  });
+
+  it('returns "Today" for falsey', function () {
+    expect(helper(null)).toEqual('Today');
+    expect(helper()).toEqual('Today');
+  });
+});

--- a/src/ggrc_workflows/assets/javascripts/controllers/dashboard_page.js
+++ b/src/ggrc_workflows/assets/javascripts/controllers/dashboard_page.js
@@ -12,6 +12,7 @@
     //Any task that is not finished or verified are subject to overdue
     if (task.instance.status === "Finished" || task.instance.status === "Verified")
       return false;
+    // TODO: [Overdue] Move this logic to helper.
     else if (end_date.getTime() < today.getTime())
       return true;
   }
@@ -138,6 +139,7 @@
             if (data.status === 'Verified')
               verified++;
             else {
+              // TODO: [Overdue] Move this logic to helper.
               if (end_date.getTime() < today.getTime()) {
                 over_due++;
                 $('dashboard-errors').control().scope.attr('error_msg', 'Some tasks are overdue!');

--- a/src/ggrc_workflows/assets/javascripts/models/cycle_models.js
+++ b/src/ggrc_workflows/assets/javascripts/models/cycle_models.js
@@ -9,14 +9,18 @@
 
   overdueCompute = can.compute(function (val) {
     var date;
+    var today = moment().startOf('day');
+    var startOfDate;
     if (this.attr('status') === 'Verified') {
       return '';
     }
     date = moment(this.attr('next_due_date') || this.attr('end_date'));
-    if (date && date.isBefore(new Date())) {
-      return 'overdue';
+    startOfDate = moment(date).startOf('day');
+    // TODO: [Overdue] Move this logic to helper.
+    if (date && today.diff(startOfDate, 'days') <= 0) {
+      return '';
     }
-    return '';
+    return 'overdue';
   });
 
   function refreshAttr(instance, attr) {

--- a/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/tree.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/tree.mustache
@@ -69,7 +69,7 @@
                 <li>
                   <div class="date">
                     <span rel="tooltip" data-placement="top" {{#is_overdue instance.end_date instance.status}}class="error"{{/is_overdue}} data-original-title="Due On">
-                      <i class="fa fa-clock-o {{#is_overdue instance.end_date instance.status}}red{{else}}color{{/is_overdue}}"></i> {{localize_date instance.end_date}}
+                      <i class="fa fa-clock-o {{#is_overdue instance.end_date instance.status}}red{{else}}color{{/is_overdue}}"></i> {{localize_date_today instance.end_date}}
                     </span>
                   </div>
                 </li>

--- a/src/ggrc_workflows/models/workflow.py
+++ b/src/ggrc_workflows/models/workflow.py
@@ -375,7 +375,7 @@ class WorkflowState(object):
 
     today = date.today()
     overdue_tasks = any(task.end_date and
-                        task.end_date <= today and
+                        task.end_date < today and
                         task.status != "Verified"
                         for task in current_tasks)
 
@@ -408,7 +408,7 @@ class WorkflowState(object):
     for cycle in current_cycles:
       for task in cycle.cycle_task_group_object_tasks:
         if (task.status != "Verified" and
-           task.end_date is not None and task.end_date <= today):
+           task.end_date is not None and task.end_date < today):
           return "Overdue"
 
     return cls._get_state(current_cycles)


### PR DESCRIPTION
**Subject**: Workflow: Task Due today but listed as overdue
**Details**:   

- Create workflow
- Create task w/due date today
- Activate workflow and go to active cycles tab

**Actual Result**: task with due date equals today is displayed as overdue
**Expected Result**: task should be displayed “Today” text. Task and Workflow shouldn’t be marked as overdue (red colour)

**Notes**: I also introduced some ToDo's to refactor 'overdue detection' in the future.
Please also note that changes in Python code were discussed with @alieh-rymasheuski .