### PR TITLE
ISSUE-1.165 Fix HTTP 428 error on sending Assessment reminders

### DIFF
--- a/src/ggrc/assets/javascripts/components/reminder.js
+++ b/src/ggrc/assets/javascripts/components/reminder.js
@@ -3,6 +3,8 @@
  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  */
 (function (can, $) {
+  'use strict';
+
   GGRC.Components('reminder', {
     tag: 'reminder',
     template: '<content/>',
@@ -11,19 +13,31 @@
       type: '@',
       modal_title: '@',
       modal_description: '@',
-      reminder: function (scope, el, ev) {
+
+      /**
+       * Create reminder notifications for all assessors of an Assessment.
+       *
+       * @param {can.Map} scope - the component's scope
+       * @param {jQuery.Object} $el - the DOM element that triggered the action
+       * @param {jQuery.Event} ev - the event object
+       */
+      reminder: function (scope, $el, ev) {
         var instance = scope.instance;
 
-        instance.refresh();
-        instance.attr('reminderType', scope.type);
-
-        $.when(instance.save()).then(function () {
-          GGRC.Controllers.Modals.confirm({
-            modal_title: scope.attr('modal_title'),
-            modal_description: scope.attr('modal_description'),
-            button_view: GGRC.mustache_path + '/modals/close_buttons.mustache'
+        instance
+          .refresh()
+          .then(function () {
+            instance.attr('reminderType', scope.type);
+            return $.when(instance.save());
+          })
+          .then(function () {
+            GGRC.Controllers.Modals.confirm({
+              modal_title: scope.attr('modal_title'),
+              modal_description: scope.attr('modal_description'),
+              button_view:
+                GGRC.mustache_path + '/modals/close_buttons.mustache'
+            });
           });
-        });
       }
     }
   });

--- a/src/ggrc/assets/javascripts/components/tests/reminder_spec.js
+++ b/src/ggrc/assets/javascripts/components/tests/reminder_spec.js
@@ -1,0 +1,52 @@
+/*!
+  Copyright (C) 2016 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+describe('GGRC.Components.reminder', function () {
+  'use strict';
+
+  var Component;  // the component under test
+
+  beforeAll(function () {
+    Component = GGRC.Components.get('reminder');
+  });
+
+  describe('reminder() method', function () {
+    var eventObj;
+    var instance;
+    var method;  // the method under test
+    var pendingRefresh;
+    var pendingSave;
+    var scope;
+    var $element;
+
+    beforeEach(function () {
+      pendingRefresh = new can.Deferred();
+      pendingSave = new can.Deferred();
+
+      instance = new can.Map({
+        refresh: jasmine.createSpy('refresh')
+                        .and.returnValue(pendingRefresh.promise()),
+        save: jasmine.createSpy('save')
+                     .and.returnValue(pendingSave.promise())
+      });
+
+      scope = new can.Map({
+        instance: instance
+      });
+      eventObj = $.Event();
+      $element = $('<div></div>');
+
+      method = Component.prototype.scope.reminder.bind(scope);
+    });
+
+    it('saves the instance only after it has been refreshed', function () {
+      method(scope, $element, eventObj);
+
+      expect(instance.save).not.toHaveBeenCalled();
+      pendingRefresh.resolve(instance);
+      expect(instance.save).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
_(section 2, bug 1.165 - P0)_

This PR fixes an error when trying to send reminders to Assessment's assessors.

**Steps to reproduce:**
- Create an Audit
- Create assessment object/Define assessment template->generate assessment
- Navigate to Assessment Info/navigate to generated assessment
- Click 3bbs button and click _"Send reminder to assessors"_

**Actual Result:**
_"PUT https://grc-dev.appspot.com/api/assessments/13846 428 ()"_ is displayed in console. Modal window is not displayed.

**Expected Result:**
Notifications are created, the PUT request succeeds.