### PR TITLE
ISSUE-1.147 Fix empty import error

### DIFF
--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -190,14 +190,15 @@ def update_memcache_before_commit(context, modified_objects, expiry_time):
 
   context.cache_manager = _get_cache_manager()
 
-  if len(modified_objects.new) > 0:
-    memcache_mark_for_deletion(context, modified_objects.new.items())
+  if modified_objects is not None:
+    if len(modified_objects.new) > 0:
+      memcache_mark_for_deletion(context, modified_objects.new.items())
 
-  if len(modified_objects.dirty) > 0:
-    memcache_mark_for_deletion(context, modified_objects.dirty.items())
+    if len(modified_objects.dirty) > 0:
+      memcache_mark_for_deletion(context, modified_objects.dirty.items())
 
-  if len(modified_objects.deleted) > 0:
-    memcache_mark_for_deletion(context, modified_objects.deleted.items())
+    if len(modified_objects.deleted) > 0:
+      memcache_mark_for_deletion(context, modified_objects.deleted.items())
 
   status_entries = {}
   for key in context.cache_manager.marked_for_delete:


### PR DESCRIPTION
### Steps to reproduce

1. Go to Import page.
2. Download assessment csv template.
3. Fill only Audit column.
4. Click Choose CSV file to import button and select this file.
5. Click Import.

Actual result is an error message "Import failed due to server error." and server responses with 400 status code. This fixes the server error.

The bug is not reproduced locally with disabled cache.