### PR TITLE
BUG-29927456 Show My Tasks count in red only when overdue tasks

### DIFF
--- a/src/ggrc/assets/javascripts/apps/dashboard.js
+++ b/src/ggrc/assets/javascripts/apps/dashboard.js
@@ -208,6 +208,7 @@
       default_widgets: defaults || GGRC.default_widgets || [],
       instance: GGRC.page_instance(),
       header_view: GGRC.mustache_path + '/base_objects/page_header.mustache',
+      GGRC: GGRC,  // make the global object available in Mustache templates
       page_title: function (controller) {
         return controller.options.instance.title;
       },

--- a/src/ggrc/assets/mustache/base_objects/page_header.mustache
+++ b/src/ggrc/assets/mustache/base_objects/page_header.mustache
@@ -40,6 +40,7 @@
         My Tasks
         <object-counter
           counter="user_task_count"
+          {{#if GGRC.counters.user_overdue_task_count}}class="critical"{{/if}}
           model-name="CycleTaskGroupObjectTask"
           search-keys="contact_id;cycle.is_current;status__in"
           search-values="current_user;true;Assigned,InProgress,Finished,Declined"

--- a/src/ggrc/assets/stylesheets/modules/_menu.scss
+++ b/src/ggrc/assets/stylesheets/modules/_menu.scss
@@ -99,14 +99,14 @@
 small {
   &.count {
     @include border-radius(4px);
-    background: $error;
+    background: #777;
+    .critical & {
+      background: $error;
+    }
     text-align: center;
     text-shadow: none;
     color: $white;
     padding: 0 0 0 1px;
-    &.count-zero {
-      background:#777;
-    }
   }
 }
 

--- a/src/ggrc/templates/base_objects/show.haml
+++ b/src/ggrc/templates/base_objects/show.haml
@@ -14,6 +14,16 @@
 -block extra_javascript
   =super()
   GGRC.page_object = ={ instance_json()|safe };
-  GGRC.counters = { "user_task_count": ={ user_task_count()|safe } };
+
+  -# Since it is expensive (issues a DB query), only invoke user_task_count()
+  -# once and use the resulting list. An auxiliary property is used to store
+  -# the result, because there are no other better ways (?) to do that in HAML
+  GGRC.counters = {
+    "_task_counts": ={ user_task_count()|safe }
+  }
+  GGRC.counters = {
+    "user_task_count": GGRC.counters._task_counts[0],
+    "user_overdue_task_count": GGRC.counters._task_counts[1]
+  };
 
 -block widget_area

--- a/src/ggrc/templates/dashboard/index.haml
+++ b/src/ggrc/templates/dashboard/index.haml
@@ -11,7 +11,17 @@
 -block extra_javascript
   =super()
   GGRC.page_object = { "person": ={ full_user_json()|safe } };
-  GGRC.counters = { "user_task_count": ={ user_task_count()|safe } };
+
+  -# Since it is expensive (issues a DB query), only invoke user_task_count()
+  -# once and use the resulting list. An auxiliary property is used to store
+  -# the result, because there are no other better ways (?) to do that in HAML
+  GGRC.counters = {
+    "_task_counts": ={ user_task_count()|safe }
+  }
+  GGRC.counters = {
+    "user_task_count": GGRC.counters._task_counts[0],
+    "user_overdue_task_count": GGRC.counters._task_counts[1]
+  };
 
 
 -block widget_area


### PR DESCRIPTION
_(buganizer issue 29927456, P1)_

This PR changes the way the My Tasks count is displayed.

**Description:**
_"The task count in the header should be gray if there are no overdue tasks. Currently it's red if there is more than one task. It should be red only if at least one task is overdue."_

Note that the task count color is not updated automatically when the "overdue" condition changes, a page refresh is needed. @Smotko said that that's fine for the time being, and thus I just opened a post-release issue for it.

During the testing you might notice that when you add a new task (under the Tasks tab), it does not appear immediately in the tree view, a page refresh is needed. This issue is unrelated to this PR, it already exists in the current develop branch.