### PR TITLE
ISSUE-1.100 Hide Map object button on finished tasks

### DIFF
--- a/src/ggrc/assets/mustache/base_templates/mapped_objects.mustache
+++ b/src/ggrc/assets/mustache/base_templates/mapped_objects.mustache
@@ -12,7 +12,27 @@
   tree-view-class="tree-structure new-tree mapped-objects-tree">
 </mapping-tree-view>
 
-{{#is_allowed 'update' instance context='for'}}
+{{#if_equals instance.type 'CycleTaskGroupObjectTask'}}
+  {{^if_in instance.status "Finished,Verified"}}
+    {{#is_allowed 'update' instance context='for'}}
+      <a
+        class="btn btn-draft btn-small"
+        href="javascript://"
+        rel="tooltip"
+        data-type="Program"
+        data-placement="right"
+        data-toggle="unified-mapper"
+        data-join-mapping="related_objects"
+        data-join-option-type="{{model.shortName}}"
+        data-join-object-id="{{instance.id}}"
+        data-join-object-type="{{instance.class.shortName}}"
+        data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty instance.class.title_singular 'Object'}}">
+        Map Objects
+      </a>
+    {{/is_allowed}}
+  {{/if_in}}
+{{else}}
+  {{#is_allowed 'update' instance context='for'}}
   <a
     class="btn btn-draft btn-small"
     href="javascript://"
@@ -27,4 +47,5 @@
     data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty instance.class.title_singular 'Object'}}">
     Map Objects
   </a>
-{{/is_allowed}}
+  {{/is_allowed}}
+{{/if_equals}}

--- a/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/modal_content.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/modal_content.mustache
@@ -99,6 +99,7 @@
         <div class="objective-selector">
           <div style="clear:both">
             <br>
+            {{^if_in instance.status "Finished,Verified"}}
             <a class="section-add section-sticky btn btn-small btn-draft"
               href="javascript://" rel="tooltip"
               {{data "deferred_to"}}
@@ -112,6 +113,7 @@
               data-original-title="Map Object to this {{instance.class.title_singular}}" tabindex="6">
               Map Objects
             </a>
+            {{/if_in}}
           </div>
         </div>
       </ggrc-modal-connector>


### PR DESCRIPTION
**Subject**: “Map Objects” button is active in finished task’s info panel
**Details**: 
Navigate to WF -> Active cycle tab
Finish the task
Open task’s info panel
_Actual Result_: confirm you see active “Map Objects” button and can map an object to finished task
_Expected Result_:  “Map Objects” button shouldn’t be visible or active, it shouldn’t be possible to map objects to the task that is finished