### PR TITLE
QUICK-FIX Update git management doc

### DIFF
--- a/doc/git_management.md
+++ b/doc/git_management.md
@@ -39,7 +39,7 @@ pushes to google/ggrc-core.
 
 4. prevent pushing to upstream.
 
-        git remote set-url --push upstream git@github.com:<nick>/ggrc-core.git
+        git remote set-url --push upstream $(git remote get-url --push origin)
 
         git fetch upstream
 


### PR DESCRIPTION
This change just makes it easier for users to properly set their
upstream push url. Now copy paste should work without having to change
the <nick> placeholder.