### PR TITLE
QUICK-FIX Enable revisons for imported objects.

### DIFF
--- a/src/ggrc/converters/base_block.py
+++ b/src/ggrc/converters/base_block.py
@@ -31,6 +31,7 @@ from ggrc.services.common import get_modified_objects
 from ggrc.services.common import update_index
 from ggrc.services.common import update_memcache_after_commit
 from ggrc.services.common import update_memcache_before_commit
+from ggrc.services.common import log_event
 
 
 CACHE_EXPIRY_IMPORT = 600
@@ -379,6 +380,7 @@ class BlockConverter(object):
     """Commit all changes in the session and update memcache."""
     try:
       modified_objects = get_modified_objects(db.session)
+      log_event(db.session, None)
       update_memcache_before_commit(
           self, modified_objects, CACHE_EXPIRY_IMPORT)
       db.session.commit()

--- a/src/ggrc/migrations/versions/20160901125710_173b800a28f3_update_event_enum_field.py
+++ b/src/ggrc/migrations/versions/20160901125710_173b800a28f3_update_event_enum_field.py
@@ -1,0 +1,39 @@
+# Copyright (C) 2016 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Update event enum field
+
+Create Date: 2016-09-01 12:57:10.984592
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+import sqlalchemy as sa
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '173b800a28f3'
+down_revision = '31fbfc1bc608'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  op.alter_column(
+      'events', 'action',
+      type_=sa.Enum(u'POST', u'PUT', u'DELETE', u'BULK', u'GET'),
+      existing_type=sa.Enum(u'POST', u'PUT', u'DELETE', u'IMPORT', u'GET'),
+      nullable=False
+  )
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  op.alter_column(
+      'events', 'action',
+      type_=sa.Enum(u'POST', u'PUT', u'DELETE', u'IMPORT', u'GET'),
+      existing_type=sa.Enum(u'POST', u'PUT', u'DELETE', u'BULK', u'GET'),
+      nullable=False
+  )

--- a/src/ggrc/models/event.py
+++ b/src/ggrc/models/event.py
@@ -9,7 +9,7 @@ class Event(Base, db.Model):
   __tablename__ = 'events'
 
   action = db.Column(
-      db.Enum(u'POST', u'PUT', u'DELETE', u'IMPORT', u'GET'),
+      db.Enum(u'POST', u'PUT', u'DELETE', u'BULK', u'GET'),
       nullable=False,
   )
   resource_id = db.Column(db.Integer)

--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -324,15 +324,16 @@ def log_event(session, obj=None, current_user_id=None, flush=True):
   if current_user_id is None:
     current_user_id = get_current_user_id()
   cache = get_cache()
-  for o in cache.dirty:
-    revision = Revision(o, current_user_id, 'modified', o.log_json())
-    revisions.append(revision)
-  for o in cache.deleted:
-    revision = Revision(o, current_user_id, 'deleted', o.log_json())
-    revisions.append(revision)
-  for o in cache.new:
-    revision = Revision(o, current_user_id, 'created', o.log_json())
-    revisions.append(revision)
+  if cache:
+    for obj_ in cache.dirty:
+      revision = Revision(obj_, current_user_id, 'modified', obj_.log_json())
+      revisions.append(revision)
+    for obj_ in cache.deleted:
+      revision = Revision(obj_, current_user_id, 'deleted', obj_.log_json())
+      revisions.append(revision)
+    for obj_ in cache.new:
+      revision = Revision(obj_, current_user_id, 'created', obj_.log_json())
+      revisions.append(revision)
   if obj is None:
     resource_id = 0
     resource_type = None

--- a/test/integration/ggrc/converters/__init__.py
+++ b/test/integration/ggrc/converters/__init__.py
@@ -2,6 +2,7 @@
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
 from flask import json
+from flask import g
 from os.path import abspath
 from os.path import dirname
 from os.path import join
@@ -22,6 +23,8 @@ class TestCase(ggrc.TestCase):
         "X-test-only": "true" if dry_run else "false",
         "X-requested-by": "gGRC",
     }
+    if hasattr(g, "cache"):
+      delattr(g, "cache")
     response = self.client.post("/_service/import_csv",
                                 data=data, headers=headers)
     self.assert200(response)

--- a/test/integration/ggrc/converters/test_import_csv.py
+++ b/test/integration/ggrc/converters/test_import_csv.py
@@ -28,7 +28,14 @@ class TestBasicCsvImport(converters.TestCase):
   def test_policy_basic_import(self):
     filename = "policy_basic_import.csv"
     self.import_file(filename)
-    self.assertEqual(models.Policy.query.count(), 3)
+    policies = models.Policy.query.all()
+    policy_ids = [policy.id for policy in policies]
+    self.assertEqual(len(policies), 3)
+    revisions = models.Revision.query.filter(
+        models.Revision.resource_type == "Policy",
+        models.Revision.resource_id.in_(policy_ids)
+    ).all()
+    self.assertEqual(len(revisions), 3)
 
   def test_policy_import_working_with_warnings(self):
     def test_owners(policy):

--- a/test/integration/ggrc/converters/test_import_update.py
+++ b/test/integration/ggrc/converters/test_import_update.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2016 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
+"""Tests for bulk updates with CSV import."""
+
 from integration.ggrc.converters import TestCase
 
 from ggrc import models
@@ -24,6 +26,11 @@ class TestImportUpdates(TestCase):
 
     policy = models.Policy.query.filter_by(slug="p1").first()
     self.assertEqual(policy.title, "some weird policy")
+    revision_count = models.Revision.query.filter(
+        models.Revision.resource_type == "Policy",
+        models.Revision.resource_id == policy.id
+    ).count()
+    self.assertEqual(revision_count, 1)
 
     filename = "policy_basic_import_update.csv"
     response = self.import_file(filename)
@@ -31,3 +38,8 @@ class TestImportUpdates(TestCase):
 
     policy = models.Policy.query.filter_by(slug="p1").first()
     self.assertEqual(policy.title, "Edited policy")
+    revision_count = models.Revision.query.filter(
+        models.Revision.resource_type == "Policy",
+        models.Revision.resource_id == policy.id
+    ).count()
+    self.assertEqual(revision_count, 2)

--- a/test/integration/ggrc/converters/test_import_update.py
+++ b/test/integration/ggrc/converters/test_import_update.py
@@ -17,22 +17,17 @@ class TestImportUpdates(TestCase):
   def test_policy_basic_update(self):
     """ Test simple policy title update """
 
-    messages = ("block_errors", "block_warnings", "row_errors", "row_warnings")
-
     filename = "policy_basic_import.csv"
     response = self.import_file(filename)
-    for block in response:
-      for message in messages:
-        self.assertEqual(set(), set(block[message]))
+
+    self._check_response(response, {})
 
     policy = models.Policy.query.filter_by(slug="p1").first()
     self.assertEqual(policy.title, "some weird policy")
 
     filename = "policy_basic_import_update.csv"
     response = self.import_file(filename)
-    for block in response:
-      for message in messages:
-        self.assertEqual(set(), set(block[message]))
+    self._check_response(response, {})
 
     policy = models.Policy.query.filter_by(slug="p1").first()
     self.assertEqual(policy.title, "Edited policy")

--- a/test/integration/ggrc/converters/test_import_update.py
+++ b/test/integration/ggrc/converters/test_import_update.py
@@ -3,6 +3,7 @@
 
 from integration.ggrc.converters import TestCase
 
+from ggrc import models
 
 class TestImportUpdates(TestCase):
 
@@ -23,8 +24,14 @@ class TestImportUpdates(TestCase):
       for message in messages:
         self.assertEqual(set(), set(block[message]))
 
+    policy = models.Policy.query.filter_by(slug="p1").first()
+    self.assertEqual(policy.title, "some weird policy")
+
     filename = "policy_basic_import_update.csv"
     response = self.import_file(filename)
     for block in response:
       for message in messages:
         self.assertEqual(set(), set(block[message]))
+
+    policy = models.Policy.query.filter_by(slug="p1").first()
+    self.assertEqual(policy.title, "Edited policy")

--- a/test/integration/ggrc/converters/test_import_update.py
+++ b/test/integration/ggrc/converters/test_import_update.py
@@ -5,6 +5,7 @@ from integration.ggrc.converters import TestCase
 
 from ggrc import models
 
+
 class TestImportUpdates(TestCase):
 
   """ Test importing of already existing objects """


### PR DESCRIPTION
This PR makes sure that all new import objects have their own entry in the revisions table. Fix for existing objects without revisions will come at a later point.

This PR also causes some performance degredation on imports, but that will be fix with imporved logging in the future.