### PR TITLE
FEATURE Enhanced ordering for Query API

### DIFF
--- a/src/ggrc/converters/query_helper.py
+++ b/src/ggrc/converters/query_helper.py
@@ -280,8 +280,8 @@ class QueryHelper(object):
              objects[from, to]
 
     If order_by["name"] == "__similarity__" (a special non-field value),
-    similarity weights returned by WithSimilarityScore.get_similar_objects are
-    used for sorting.
+    similarity weights returned by get_similar_objects_query are used for
+    sorting.
 
     Returns:
       a sorted and sliced list of objects
@@ -359,14 +359,14 @@ class QueryHelper(object):
     def similar():
       """Filter by relationships similarity."""
       similar_class = self.object_map[exp["object_name"]]
-      if not hasattr(similar_class, "get_similar_objects"):
+      if not hasattr(similar_class, "get_similar_objects_query"):
         return BadQueryException("{} does not define weights to count "
                                  "relationships similarity"
                                  .format(similar_class.__name__))
-      similar_objects = similar_class.get_similar_objects(
+      similar_objects = similar_class.get_similar_objects_query(
           id_=exp["id"],
           types=[object_class.__name__],
-      )
+      ).all()
       flask.g.query_api_similar_objects = similar_objects  # used for sorting
       return object_class.id.in_([obj.id for obj in similar_objects])
 

--- a/src/ggrc/models/mixins/with_similarity_score.py
+++ b/src/ggrc/models/mixins/with_similarity_score.py
@@ -29,8 +29,8 @@ class WithSimilarityScore(object):
   # }
 
   @classmethod
-  def get_similar_objects(cls, id_, types="all", relevant_types=None,
-                          threshold=None):
+  def get_similar_objects_query(cls, id_, types="all", relevant_types=None,
+                                threshold=None):
     """Get objects of types similar to cls instance by their mappings.
 
     Args:
@@ -43,8 +43,8 @@ class WithSimilarityScore(object):
                  cls.similarity_options["threshold"].
 
     Returns:
-      [(similar_object_id, similar_object_type, weight)] - a list of similar
-          objects with respective weights.
+      SQLAlchemy query that yields results with columns [(id, type, weight)] -
+          the id and type of similar objects with respective weights.
     """
     if not types or (not isinstance(types, list) and types != "all"):
       raise ValueError("Expected types = 'all' or a non-empty list of "
@@ -144,4 +144,4 @@ class WithSimilarityScore(object):
         weight_sum >= threshold,
     )
 
-    return result.all()
+    return result

--- a/src/ggrc/services/query.py
+++ b/src/ggrc/services/query.py
@@ -10,6 +10,7 @@ from flask import request
 from flask import current_app
 from werkzeug.exceptions import BadRequest
 
+from ggrc.converters.query_helper import BadQueryException
 from ggrc.services.query_helper import QueryAPIQueryHelper
 from ggrc.login import login_required
 from ggrc.models.inflector import get_model
@@ -95,5 +96,5 @@ def init_query_view(app):
     """Advanced object collection queries view."""
     try:
       return get_objects_by_query()
-    except NotImplementedError as exc:
+    except (NotImplementedError, BadQueryException) as exc:
       raise BadRequest(exc.message)

--- a/src/ggrc/services/query_helper.py
+++ b/src/ggrc/services/query_helper.py
@@ -50,9 +50,8 @@ class QueryAPIQueryHelper(QueryHelper):
       objects = self._get_objects(object_query)
       object_query["total"] = len(objects)
 
-      objects = self._apply_order_by_and_limit(
+      objects = self._apply_limit(
           objects,
-          order_by=object_query.get("order_by"),
           limit=object_query.get("limit"),
       )
       object_query["count"] = len(objects)

--- a/test/integration/ggrc/models/mixins/test_with_similarity_score.py
+++ b/test/integration/ggrc/models/mixins/test_with_similarity_score.py
@@ -73,11 +73,11 @@ class TestWithSimilarityScore(integration.ggrc.TestCase):
 
   def test_get_similar_objects_weights(self):  # pylint: disable=invalid-name
     """Check weights counted for similar objects."""
-    similar_objects = Assessment.get_similar_objects(
+    similar_objects = Assessment.get_similar_objects_query(
         id_=self.assessment.id,
         types=["Assessment"],
         threshold=0,  # to include low weights too
-    )
+    ).all()
 
     # casting to int from Decimal to prettify the assertion method output
     id_weight_map = {obj.id: int(obj.weight) for obj in similar_objects}
@@ -86,10 +86,10 @@ class TestWithSimilarityScore(integration.ggrc.TestCase):
 
   def test_get_similar_objects(self):
     """Check similar objects manually and via Query API."""
-    similar_objects = Assessment.get_similar_objects(
+    similar_objects = Assessment.get_similar_objects_query(
         id_=self.assessment.id,
         types=["Assessment"],
-    )
+    ).all()
     expected_ids = {id_ for id_, weight in self.id_weight_map.items()
                     if weight >= Assessment.similarity_options["threshold"]}
 

--- a/test/integration/ggrc/services/test_query.py
+++ b/test/integration/ggrc/services/test_query.py
@@ -208,10 +208,6 @@ class TestAdvancedQueryAPI(TestCase):
                          text_pattern in regulation.get("notes", ""))
                         for regulation in regulations["values"]))
 
-  @SkipTest
-  def test_basic_query_filter(self):
-    pass
-
   def test_basic_query_pagination(self):
     """Test basic query with pagination info."""
     from_, to_ = 1, 12
@@ -335,18 +331,6 @@ class TestAdvancedQueryAPI(TestCase):
         set(obj.get("id") for obj in programs_values["values"]),
         set(programs_ids["ids"]),
     )
-
-  @SkipTest
-  def test_mapped_query(self):
-    pass
-
-  @SkipTest
-  def test_mapped_query_filter(self):
-    pass
-
-  @SkipTest
-  def test_mapped_query_pagination(self):
-    pass
 
   @SkipTest
   def test_self_link(self):

--- a/test/integration/ggrc/services/test_query.py
+++ b/test/integration/ggrc/services/test_query.py
@@ -13,7 +13,7 @@ from integration.ggrc import TestCase
 
 
 THIS_ABS_PATH = abspath(dirname(__file__))
-CSV_DIR = join(THIS_ABS_PATH, '../converters/test_csvs/')
+CSV_DIR = join(THIS_ABS_PATH, "../converters/test_csvs/")
 
 # to be moved into converters.query_helper
 DATE_FORMAT_REQUEST = "%m/%d/%Y"
@@ -50,7 +50,7 @@ class TestAdvancedQueryAPI(TestCase):
     """Make a POST to /query endpoint."""
     if not isinstance(data, list):
       data = [data]
-    headers = {'Content-Type': 'application/json', }
+    headers = {"Content-Type": "application/json", }
     return self.client.post("/query", data=json.dumps(data), headers=headers)
 
   def test_basic_query_eq(self):

--- a/test/integration/ggrc/services/test_query.py
+++ b/test/integration/ggrc/services/test_query.py
@@ -4,6 +4,7 @@
 """Tests for /query api endpoint."""
 
 from datetime import datetime
+from operator import itemgetter
 from os.path import abspath, dirname, join
 from flask import json
 from nose.plugins.skip import SkipTest
@@ -312,8 +313,8 @@ class TestAdvancedQueryAPI(TestCase):
     self.assertListEqual(
         regulations,
         sorted(sorted(regulations_unsorted,
-                      key=lambda r: r["title"]),
-               key=lambda r: r["notes"],
+                      key=itemgetter("title")),
+               key=itemgetter("notes"),
                reverse=True),
     )
 
@@ -346,7 +347,7 @@ class TestAdvancedQueryAPI(TestCase):
 
     self.assertListEqual(
         audits_title,
-        sorted(sorted(audits_unsorted, key=lambda a: a["id"]),
+        sorted(sorted(audits_unsorted, key=itemgetter("id")),
                key=lambda a: program_id_title[a["program"]["id"]]),
     )
 
@@ -379,7 +380,7 @@ class TestAdvancedQueryAPI(TestCase):
 
     self.assertListEqual(
         clauses_person,
-        sorted(sorted(clauses_unsorted, key=lambda c: c["id"]),
+        sorted(sorted(clauses_unsorted, key=itemgetter("id")),
                key=lambda c: person_id_name[c["contact"]["id"]]),
     )
 


### PR DESCRIPTION
Short description of what was done in scope of this PR:
1. Ordering in query API was moved to the DB side.
2. Ordering by several fields was added.
3. Ordering by mapped-with-foreign-key objects (like `contact` for program, `program` for audit) was implemented (by `title` for `Titled` objects, by name or email for `Person` objects).
4. Ordering by `__similarity__` was moved to the DB side. Now we have same subqueries for filtering and for sorting.

To sort an Audit by its related Program title, pass `"order_by": [{"name": "program"}]` in the query. Ordering by an arbitrary field of a Program was not implemented intentionally but is technically possible.