### PR TITLE
QUICK-FIX Fix custom attribute value filters on export and pagination

### DIFF
--- a/src/ggrc/converters/query_helper.py
+++ b/src/ggrc/converters/query_helper.py
@@ -429,6 +429,23 @@ class QueryHelper(object):
                               .format(exp["op"]["name"]))
 
     def default_filter_by(object_class, key, predicate):
+      """Default filter option that tries to mach predicate in fulltext index.
+
+      This function tries to match the predicate for a give key with entries in
+      the full text index table. The key is matched to record tags and as
+      the tags only contain custom attribute names, so this filter currently
+      only works on custom attributes.
+
+      Args:
+        object_class: class of the object we are querying for.
+        key: string containing attribute name on which we are filtering.
+        predicate: function containing the correct comparison predicate for
+          the attribute value.
+
+      Returs:
+        Query predicate if the given predicate matches a value for the correct
+          custom attribute.
+      """
       return object_class.id.in_(db.session.query(Record.key).filter(
               Record.type == object_class.__name__,
               Record.tags == key,

--- a/src/ggrc/converters/query_helper.py
+++ b/src/ggrc/converters/query_helper.py
@@ -15,6 +15,8 @@ from sqlalchemy import not_
 from sqlalchemy import or_
 from sqlalchemy import orm
 
+from ggrc import db
+from ggrc.fulltext.mysql import MysqlRecordProperty as Record
 from ggrc.rbac import permissions
 from ggrc import models
 from ggrc.models.custom_attribute_value import CustomAttributeValue
@@ -112,31 +114,12 @@ class QueryHelper(object):
           filter_name = value.get("filter_by", None)
           if filter_name is not None:
             filter_by = getattr(object_class, filter_name, None)
-          value = value["display_name"]
-        if value:
-          self.attr_name_map[object_class][value.lower()] = (key.lower(),
-                                                             filter_by)
-      if not self.ca_disabled:
-        custom_attrs = AttributeInfo.get_custom_attr_definitions(
-            object_class)
-      else:
-        custom_attrs = {}
-
-      for key, definition in custom_attrs.items():
-        if not key.startswith("__custom__:") or \
-           "display_name" not in definition:
-          continue
-        try:
-          # Global custom attribute definition can only have a single id on
-          # their name, so it is safe for that. Currently the filters do not
-          # work with object level custom attributes.
-          attr_id = definition["definition_ids"][0]
-        except KeyError:
-          continue
-        filter_by = CustomAttributeValue.mk_filter_by_custom(object_class,
-                                                             attr_id)
-        name = definition["display_name"].lower()
-        self.attr_name_map[object_class][name] = (name, filter_by)
+          name = value["display_name"]
+        else:
+          name = value
+        if name:
+          self.attr_name_map[object_class][name.lower()] = (key.lower(),
+                                                            filter_by)
 
   def _clean_query(self, query):
     """ sanitize the query object """
@@ -445,19 +428,25 @@ class QueryHelper(object):
       raise BadQueryException("Unknown operator \"{}\""
                               .format(exp["op"]["name"]))
 
+    def default_filter_by(object_class, key, predicate):
+      return object_class.id.in_(db.session.query(Record.key).filter(
+              Record.type == object_class.__name__,
+              Record.tags == key,
+              predicate(Record.content)
+          ))
+
     def with_key(key, p):
       key = key.lower()
       key, filter_by = self.attr_name_map[
           object_class].get(key, (key, None))
-      if hasattr(filter_by, "__call__"):
+      if callable(filter_by):
         return filter_by(p)
       else:
         attr = getattr(object_class, key, None)
-        if attr is None:
-          raise BadQueryException("Bad query: object '{}' does "
-                                  "not have attribute '{}'."
-                                  .format(object_class.__name__, key))
-        return p(attr)
+        if attr:
+          return p(attr)
+        else:
+          return default_filter_by(object_class, key, p)
 
     with_left = lambda p: with_key(exp["left"], p)
 

--- a/src/ggrc/fulltext/__init__.py
+++ b/src/ggrc/fulltext/__init__.py
@@ -20,7 +20,7 @@ class Indexer(object):
     raise NotImplementedError()
 
 class Record(object):
-  def __init__(self, key, type, context_id, tags, **kwargs):
+  def __init__(self, key, type, context_id, tags="", **kwargs):
     self.key = key
     self.type = type
     self.context_id = context_id

--- a/src/ggrc/fulltext/__init__.py
+++ b/src/ggrc/fulltext/__init__.py
@@ -3,7 +3,9 @@
 
 from ggrc.extensions import get_extension_instance
 
+
 class Indexer(object):
+
   def __init__(self, settings):
     pass
 
@@ -19,7 +21,9 @@ class Indexer(object):
   def search(self, terms):
     raise NotImplementedError()
 
+
 class Record(object):
+
   def __init__(self, key, type, context_id, tags="", **kwargs):
     self.key = key
     self.type = type
@@ -27,12 +31,13 @@ class Record(object):
     self.tags = tags
     self.properties = kwargs
 
+
 def resolve_default_text_indexer():
   from ggrc import settings
   db_scheme = settings.SQLALCHEMY_DATABASE_URI.split(':')[0].split('+')[0]
   return 'ggrc.fulltext.{db_scheme}.Indexer'.format(db_scheme=db_scheme)
 
+
 def get_indexer(indexer=[]):
   return get_extension_instance(
       'FULLTEXT_INDEXER', resolve_default_text_indexer)
-

--- a/src/ggrc/fulltext/mysql.py
+++ b/src/ggrc/fulltext/mysql.py
@@ -26,7 +26,7 @@ from ggrc_basic_permissions import objects_via_assignable_query
 from ggrc_basic_permissions import program_relationship_query
 from ggrc_basic_permissions import backlog_workflows
 from ggrc.rbac import permissions, context_query_filter
-from .sql import SqlIndexer
+from ggrc.fulltext.sql import SqlIndexer
 
 
 class MysqlRecordProperty(db.Model):

--- a/src/ggrc/fulltext/recordbuilder.py
+++ b/src/ggrc/fulltext/recordbuilder.py
@@ -24,7 +24,10 @@ class RecordBuilder(object):
       record_type = obj.attributable_type
       # The name of the attribute property needs to be unique for each object,
       # the value comes from the custom_attribute_value
-      properties = {"attribute_value_" + str(obj.id): obj.attribute_value}
+      properties = {
+        "attribute_value_" + str(obj.id): obj.attribute_value,
+        "tags": obj.custom_attribute.title,
+      }
     return Record(
         # This logic saves custom attribute values as attributes of the object
         # that owns the attribute values. When obj is not a CustomAttributeValue
@@ -32,7 +35,6 @@ class RecordBuilder(object):
         record_id,
         record_type,
         obj.context_id,
-        '', #FIXME get any qualifying fields to help in search partitioning...
         **properties
         )
 

--- a/src/ggrc/fulltext/recordbuilder.py
+++ b/src/ggrc/fulltext/recordbuilder.py
@@ -5,7 +5,9 @@
 from ggrc.models.reflection import AttributeInfo
 from . import Record
 
+
 class RecordBuilder(object):
+
   def __init__(self, tgt_class):
     self._fulltext_attrs = AttributeInfo.gather_attrs(
         tgt_class, '_fulltext_attrs')
@@ -25,22 +27,24 @@ class RecordBuilder(object):
       # The name of the attribute property needs to be unique for each object,
       # the value comes from the custom_attribute_value
       properties = {
-        "attribute_value_" + str(obj.id): obj.attribute_value,
-        "tags": obj.custom_attribute.title,
+          "attribute_value_" + str(obj.id): obj.attribute_value,
+          "tags": obj.custom_attribute.title,
       }
     return Record(
         # This logic saves custom attribute values as attributes of the object
-        # that owns the attribute values. When obj is not a CustomAttributeValue
-        # the values are saved directly.
+        # that owns the attribute values. When obj is not a
+        # CustomAttributeValue the values are saved directly.
         record_id,
         record_type,
         obj.context_id,
         **properties
-        )
+    )
+
 
 def model_is_indexed(tgt_class):
   fulltext_attrs = AttributeInfo.gather_attrs(tgt_class, '_fulltext_attrs')
   return len(fulltext_attrs) > 0
+
 
 def get_record_builder(obj, builders={}):
   builder = builders.get(obj.__class__.__name__)
@@ -48,6 +52,7 @@ def get_record_builder(obj, builders={}):
     builder = RecordBuilder(obj.__class__)
     builders[obj.__class__.__name__] = builder
   return builder
+
 
 def fts_record_for(obj):
   builder = get_record_builder(obj)

--- a/src/ggrc/models/custom_attribute_value.py
+++ b/src/ggrc/models/custom_attribute_value.py
@@ -22,6 +22,7 @@ class CustomAttributeValue(Base, db.Model):
   """Custom attribute value model"""
 
   __tablename__ = 'custom_attribute_values'
+  _fulltext_attrs = ["attribute_value"]
 
   custom_attribute_id = db.Column(
       db.Integer,

--- a/test/integration/ggrc/converters/test_ca_import_export.py
+++ b/test/integration/ggrc/converters/test_ca_import_export.py
@@ -182,6 +182,11 @@ class TestCustomAttributeImportExport(TestCase):
     filename = "custom_attribute_tests.csv"
     self.import_file(filename)
 
+    # TODO: there is a bug that imports do not index all custom attributes.
+    # After fixing this bug remove the following two lines.
+    from ggrc import views
+    views.do_reindex()
+
     data = [{
         "object_name": "Product",
         "filters": {

--- a/test/integration/ggrc/converters/test_import_assessments.py
+++ b/test/integration/ggrc/converters/test_import_assessments.py
@@ -1,20 +1,21 @@
 # Copyright (C) 2016 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
-# pylint: disable=maybe-no-member
+# pylint: disable=maybe-no-member, invalid-name
 
 """Test request import and updates."""
 
+from ggrc import db
 from ggrc import models
 from integration.ggrc import converters
 
 
-class TestRequestImport(converters.TestCase):
+class TestAssessmentImportExport(converters.TestCase):
+  """Basic Assessment import tests with.
 
-  """Basic Request import tests with.
-
-  This test suite should test new Request imports and updates. The main focus
-  of these tests is checking error messages for invalid state transitions.
+  This test suite should test new Assessment imports, exports, and updates.
+  The main focus of these tests is checking error messages for invalid state
+  transitions.
   """
 
   def setUp(self):
@@ -22,7 +23,7 @@ class TestRequestImport(converters.TestCase):
     converters.TestCase.setUp(self)
     self.client.get("/login")
 
-  def test_assessments_with_templates(self):
+  def test_import_assessments_with_templates(self):
     """Test importing of assessments with templates."""
 
     self.import_file("assessment_template_no_warnings.csv")
@@ -35,3 +36,50 @@ class TestRequestImport(converters.TestCase):
     values = set(v.attribute_value for v in assessment.custom_attribute_values)
     self.assertIn("abc", values)
     self.assertIn("2015-07-15 00:00:00", values)
+
+  def test_export_assessments_with_filters_and_conflicting_ca_names(self):
+    """Test exporting assessments with conflicting custom attribute names."""
+    self.import_file(u"assessment_template_no_warnings.csv")
+    self.import_file(u"assessment_with_templates.csv")
+
+    # also create an object level custom attribute with a name that clashes
+    # with a name of a "regular" attribute
+    assessment = models.Assessment.query.filter(
+        models.Assessment.slug == u"A 2").first()
+    cad = models.CustomAttributeDefinition(
+        attribute_type=u"Text",
+        title=u"title",
+        definition_type=u"assessment",
+        definition_id=assessment.id
+    )
+    db.session.add(cad)
+    db.session.commit()
+
+    data = [{
+        "object_name": "Assessment",
+        "fields": ["slug", "title", "description", "status"],
+        "filters": {
+            "expression": {
+                "left": {
+                    "left": "code",
+                    "op": {"name": "~"},
+                    "right": "A 2"
+                },
+                "op": {"name": "AND"},
+                "right": {
+                    "left": "title",
+                    "op": {"name": "~"},
+                    "right": "no template Assessment"
+                }
+            },
+            "keys": ["code", "title", "status"],
+            "order_by": {
+                "keys": [],
+                "order": "",
+                "compare": None
+            }
+        }
+    }]
+
+    response = self.export_csv(data)
+    self.assertIn(u"No template Assessment 2", response.data)


### PR DESCRIPTION
This PR adds global and object level custom attribute filters to query helper that is used in exports and pagination.

From my inital tests the performance degredation is negligible, but keep an eye out for anomilies.

Note: you will have to reindex the full text table for the filters to work.