### PR TITLE
ISSUE-1.331 JS error is displayed by clicking Select All/None

### DIFF
--- a/src/ggrc/assets/javascripts/components/csv/export.js
+++ b/src/ggrc/assets/javascripts/components/csv/export.js
@@ -151,9 +151,12 @@
               });
               return {
                 object_name: panel.type,
-                fields: _.compact(_.map(Object.keys(panel.selected), function (key) {
-                  return panel.selected[key] === true ? key : null;
-                })),
+                fields: _.compact(_.map(panel.columns(),
+                  function (item, index) {
+                    if (panel.selected[index]) {
+                      return item.key;
+                    }
+                  })),
                 filters: GGRC.query_parser.join_queries(
                   GGRC.query_parser.parse(relevant_filter || ""),
                   GGRC.query_parser.parse(panel.filter || "")
@@ -245,25 +248,27 @@
         }
         this.setSelected();
       },
-      "[data-action=attribute_select_toggle] click": function (el, ev) {
-        var items = GGRC.model_attr_defs[this.scope.attr("item.type")],
-            split_items = {
-              mappings: _.filter(items, function (el) {
-                return el.type === "mapping";
-              }),
-              attributes: _.filter(items, function (el) {
-                return el.type !== "mapping";
-              })
-            };
-        _.map(split_items[el.data("type")], function (attr) {
-          this.scope.attr("item.selected." + attr.key, el.data("value"));
+      '[data-action=attribute_select_toggle] click': function (el, ev) {
+        var items = GGRC.model_attr_defs[this.scope.attr('item.type')];
+        var isMapping = el.data('type') === 'mappings';
+        var value = el.data('value');
+
+        _.each(items, function (item, index) {
+          if (isMapping && item.type === 'mapping') {
+            this.scope.attr('item.selected.' + index, value);
+          }
+          if (!isMapping && item.type !== 'mapping') {
+            this.scope.attr('item.selected.' + index, value);
+          }
         }.bind(this));
       },
-      "setSelected": function () {
-        this.scope.attr("item.selected", _.reduce(this.scope.attr("item").columns(), function (memo, data) {
-          memo[data.key] = true;
-          return memo;
-        }, {}));
+      setSelected: function () {
+        var selected = _.reduce(this.scope.attr('item').columns(),
+          function (memo, data, index) {
+            memo[index] = true;
+            return memo;
+          }, {});
+        this.scope.attr('item.selected', selected);
       },
       "{scope.item} type": function () {
         this.scope.attr("item.selected", {});

--- a/src/ggrc/assets/mustache/import_export/export/attribute_selector.mustache
+++ b/src/ggrc/assets/mustache/import_export/export/attribute_selector.mustache
@@ -17,14 +17,14 @@
     <a data-action="attribute_select_toggle" data-value="false" data-type="mappings" href="javascript://">None</a>
     <div class="attribute-wrap">
       <ul class="attr-list">
-        {{#columns}}
+        {{#each columns}}
         <li>
           <label>
-            <input can-value="selected.{{key}}" type="checkbox" name="{{key}}" checked>
+            <input can-value="selected.{{@index}}" type="checkbox" name="{{key}}" checked>
             {{display_name}}
           </label>
         </li>
-        {{/columns}}
+        {{/each}}
       </ul>
     </div>
   </div>


### PR DESCRIPTION
**Subject**: JS is displayed by clicking Select All/None attributes link at Export Data page
**Details**:   

- Go to Data Export page
- Select Controls in Export Object Types ddl
- Click None link for Attributes

**Actual Result**: JS error appears and not all attributes unchecked
**Expected Result**: all attributes should be unchecked by clicking None for Attributes, all attributes should be checked by clicking Select All for Attributes

**Note**: The roots is that CA attribute could contains "." which is incorrectly used in combination with view bindings.