### PR TITLE
ISSUE-1.210 Save and Close buttons are disabled for New Risk Assessment

### DIFF
--- a/src/ggrc_risk_assessments/assets/javascripts/models/risk_assessment.js
+++ b/src/ggrc_risk_assessments/assets/javascripts/models/risk_assessment.js
@@ -28,6 +28,8 @@
       modified_by: "CMS.Models.Person.stub",
       object_documents: "CMS.Models.ObjectDocument.stubs",
       custom_attribute_values : "CMS.Models.CustomAttributeValue.stubs",
+      start_date: 'date',
+      end_date: 'date'
     },
     tree_view_options: {
       attr_list: [

--- a/src/ggrc_risk_assessments/assets/mustache/risk_assessments/modal_content.mustache
+++ b/src/ggrc_risk_assessments/assets/mustache/risk_assessments/modal_content.mustache
@@ -21,8 +21,8 @@
       <a data-id="hide_effective_date_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
       <datepicker
         label="Effective Date"
-        date="start_date"
-        set-max-date="end_date"
+        date="instance.start_date"
+        set-max-date="instance.end_date"
         required="true"
         />
     </div>
@@ -30,7 +30,7 @@
       <a data-id="hide_stop_date_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
       <datepicker
         label="End Date"
-        date="end_date"
+        date="instance.end_date"
         required="true"
         />
     </div>


### PR DESCRIPTION
**Subject**: Save and Close button/ Save and Add Another button are disabled after filling all the mandatory fields in New Risk Assessment window  
**Details**: 

- Create a program
- Click Add -> Select Risk Assessments
- Click Create New Risk Assessment in unified mapper
- Fill all the mandatory fields
- Click Save and Close button/ Save and Add Another button: are disabled   

**Actual Result**: Save and Close button/ Save and Add Another button are disabled after filling all the mandatory fields in New Risk Assessment window  
**Expected Result**: Save and Close button/ Save and Add Another button should be enabled after filling all the mandatory fields in New Risk Assessment window 

**NOTES**: This fix for 1.210 & 1.91