### PR TITLE
ISSUE-1.339 Make the list of values for Dropdown CAs mandatory

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/modals_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/modals_controller.js
@@ -384,6 +384,23 @@ can.Control('GGRC.Controllers.Modals', {
       this.set_value_from_element(el);
     }
   },
+
+  /**
+   * The onChange handler for the custom attribute type dropdown.
+   *
+   * This handler is specific to the Custom Attribute Edit modal.
+   *
+   * @param {jQuery} $el - the dropdown DOM element
+   * @param {$.Event} ev - the event object
+   */
+  'dropdown[data-purpose="ca-type"] change': function ($el, ev) {
+    var instance = this.options.instance;
+
+    if (instance.attribute_type !== 'Dropdown') {
+      instance.attr('multi_choice_options', undefined);
+    }
+  },
+
   serialize_form: function () {
     var $form = this.options.$content.find("form");
     var $elements = $form.find(":input:not(isolate-form *)");

--- a/src/ggrc/assets/javascripts/models/custom_attributes.js
+++ b/src/ggrc/assets/javascripts/models/custom_attributes.js
@@ -63,8 +63,69 @@
     },
     attributeTypes: ['Text', 'Rich Text', 'Date', 'Checkbox', 'Dropdown',
       'Map:Person'],
+
+    _customValidators: {
+      /**
+       * Validate a comma-separated list of possible values defined by the
+       * custom attribute definition.
+       *
+       * This validation is only applicable to multi-choice CA types such as
+       * Dropdown, and does not do anything for other CA types.
+       *
+       * There must be at most one empty value defined (whitespace trimmed),
+       * and the values must be unique.
+       *
+       * @param {*} newVal - the new value of the property
+       * @param {String} propName - the instance property to validate
+       *
+       * @return {String} - A validation error message, if any. An empty string
+       *   is returned if the validation passes.
+       */
+      multiChoiceOptions: function (newVal, propName) {
+        var choices;
+        var nonBlanks;
+        var uniques;
+
+        if (propName !== 'multi_choice_options') {
+          return '';  // nothing  to validate here
+        }
+
+        if (this.attribute_type !== 'Dropdown') {
+          return '';  // all ok, the value of multi_choice_options not needed
+        }
+
+        choices = _.splitTrim(newVal, ',');
+
+        if (!choices.length) {
+          return 'At least one possible value required.';
+        }
+
+        nonBlanks = _.compact(choices);
+        if (nonBlanks.length < choices.length) {
+          return 'Blank values not allowed.';
+        }
+
+        uniques = _.unique(nonBlanks);
+        if (uniques.length < nonBlanks.length) {
+          return 'Duplicate values found.';
+        }
+
+        return '';  // no errors
+      }
+    },
+
     init: function () {
       this.validateNonBlank('title');
+
+      // Besides multi_choice_options we need toset the validation on the
+      // attribute_type field as well, even though its validation always
+      // succeeds. For some reson this is required for the modal UI buttons to
+      // properly update themselves when choosing a different attribute type.
+      this.validate(
+        ['multi_choice_options', 'attribute_type'],
+        this._customValidators.multiChoiceOptions
+      );
+
       this._super.apply(this, arguments);
     }
   }, {

--- a/src/ggrc/assets/javascripts/models/tests/custom_attribute_definition_model_spec.js
+++ b/src/ggrc/assets/javascripts/models/tests/custom_attribute_definition_model_spec.js
@@ -1,0 +1,72 @@
+/*!
+  Copyright (C) 2016 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+describe('CMS.Models.CustomAttributeDefinition', function () {
+  'use strict';
+
+  var Model;
+
+  beforeAll(function () {
+    Model = CMS.Models.CustomAttributeDefinition;
+  });
+
+  describe('multiChoiceOptions custom validator', function () {
+    var validator;
+    var instance;
+
+    beforeEach(function () {
+      instance = new can.Map({
+        attribute_type: 'Dropdown'
+      });
+      validator = Model._customValidators.multiChoiceOptions.bind(instance);
+    });
+
+    it('returns an empty message for properties other ' +
+      'than multi_choice_options',
+      function () {
+        ['foo', 'bar', 'baz'].forEach(function (propName) {
+          var msg = validator(',,,', propName);
+          expect(msg).toEqual('');
+        });
+      }
+    );
+
+    it('returns an empty message for non-dropdown types', function () {
+      Model.attributeTypes.forEach(function (attrType) {
+        var msg;
+
+        if (attrType === 'Dropdown') {
+          return;
+        }
+
+        instance.attr('attribute_type', attrType);
+
+        msg = validator(',,,', 'multi_choice_options');
+        expect(msg).toEqual('');
+      });
+    });
+
+    it('returns an error when no values defined', function () {
+      var msg = validator('', 'multi_choice_options');
+      expect(msg).toEqual('At least one possible value required.');
+    });
+
+    it('returns an error when blank values defined', function () {
+      // NOTE: the empty value is the one after the last comma
+      var msg = validator('foo  ,  bar ,', 'multi_choice_options');
+      expect(msg).toEqual('Blank values not allowed.');
+    });
+
+    it('returns an error when duplicate values values defined', function () {
+      var msg = validator('foo, bar, baz, foo  , gox', 'multi_choice_options');
+      expect(msg).toEqual('Duplicate values found.');
+    });
+
+    it('returns an empty message if validation succeeds', function () {
+      var msg = validator('  one  two, three,four   ', 'multi_choice_options');
+      expect(msg).toEqual('');
+    });
+  });
+});

--- a/src/ggrc/assets/mustache/custom_attribute_definitions/modal_content.mustache
+++ b/src/ggrc/assets/mustache/custom_attribute_definitions/modal_content.mustache
@@ -22,7 +22,8 @@
         <i class="fa fa-question-circle" rel="tooltip" title="Choose the type of attribute to create."></i>
       </label>
         <dropdown options-list="model.attributeTypes"
-                  name="instance.attribute_type">
+                  name="instance.attribute_type"
+                  data-purpose="ca-type">
         </dropdown>
     </div>
     <div class="span2">
@@ -73,15 +74,31 @@
       </div>
     </div>
   {{/case}}
+
   {{#case "Dropdown"}}
     <div class='row-fluid'>
-      <div class="span12">
+      <div
+        class="span12 {{#if instance.computed_errors.multi_choice_options}}field-failure{{/if}}">
         <label>
           Possible values (separated by comma ",")
+          <span class="required">*</span>
           <i class="fa fa-question-circle" rel="tooltip"
             title="Provide a list of values from which users will be able to choose."></i>
         </label>
-        <input tabindex="4" class="input-block-level" placeholder="Enter possible values" name="multi_choice_options" type="text" value="{{multi_choice_options}}">
+
+        {{#instance.computed_errors.multi_choice_options}}
+           <label class="help-inline warning">
+               {{this}}
+           </label>
+         {{/instance.computed_errors.multi_choice_options}}
+
+        <input
+          tabindex="4"
+          class="input-block-level"
+          placeholder="Enter possible values"
+          name="multi_choice_options"
+          type="text"
+          value="{{multi_choice_options}}">
       </div>
     </div>
     <div class='row-fluid'>
@@ -95,6 +112,7 @@
       </div>
     </div>
   {{/case}}
+
   {{#case "Checkbox"}}
   <div class='row-fluid'>
     <div class="span6">


### PR DESCRIPTION
_(section 2, issue 1.339 - P2)_

This PR prevents creating a Dropdown custom attribute without specifying at least one possible value to choose from.

**Steps to reproduce:**
- Open Custom Attribute tab at Admin Dashboard page
- Open Any attribute section and click Add Attribute button
- Fill Attribute title and select attribute type as Dropdown
- Leave possible values empty or fill spaces and click Save & Close button

**Actual Result:**
Attribute was saved

**Expected Result:**
field with possible values should have mandatory mark and Save & Close button should be disabled until valid values will be provided into possible values field