### PR TITLE
ISSUE-1.87 Fix collapsing treeview

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
@@ -1512,8 +1512,12 @@ can.Control('CMS.Controllers.TreeViewNode', {
     }.bind(this), 0);
   },
 
-  '{instance} change': function (inst, ev, prop) {
-    if (prop === 'custom_attribute_values') {
+  '{instance} custom_attribute_values': function (object, ev, newVal, oldVal) {
+    function getValues(cav) {
+      return _.pluck(cav.reify(), 'attribute_value');
+    }
+    if (oldVal.length === newVal.length &&
+      _.difference(getValues(oldVal), getValues(newVal)).length) {
       this.draw_node(true);
     }
   },

--- a/src/ggrc/assets/javascripts/plugins/openclose.js
+++ b/src/ggrc/assets/javascripts/plugins/openclose.js
@@ -2,40 +2,42 @@
  Copyright (C) 2016 Google Inc.
  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  */
-(function($) {
+(function ($) {
   function openclose(command) {
-    var $that = $(this),
-      use_slide = $that.length < 100
+    var $that = $(this);
+    var useSlide = $that.length < 100;
 
-    $that.each(function() {
-      var $this = $(this),
-        $main = $this.closest('.item-main'),
-        $li = $main.closest('li'),
-        $content = $li.children('.item-content'),
-        $icon = $main.find('.openclose'),
-        $parentTree = $this.closest('ul.new-tree'),
-        cmd = command;
+    $that.each(function () {
+      var $this = $(this);
+      var $main = $this.closest('.item-main');
+      var $li = $main.closest('li');
+      var $content = $li.children('.item-content');
+      var $icon = $main.find('.openclose');
+      var $parentTree = $this.closest('ul.new-tree');
+      var cmd = command;
 
-      if (typeof cmd !== "string" || cmd === "toggle") {
-        cmd = $icon.hasClass("active") ? "close" : "open";
+      if (typeof cmd !== 'string' || cmd === 'toggle') {
+        cmd = $icon.hasClass('active') ? 'close' : 'open';
       }
 
-      if (cmd === "close") {
-        if (use_slide) {
-          $content.slideUp('fast', callback);
+      if (cmd === 'close') {
+        if (useSlide) {
+          $content.slideUp('fast');
         } else {
-          $content.css("display", "none");
+          $content.css('display', 'none');
         }
         $icon.removeClass('active');
         $li.removeClass('item-open');
         // Only remove tree open if there are no open siblings
-        !$li.siblings('.item-open').length && $parentTree.removeClass('tree-open');
+        if (!$li.siblings('.item-open').length) {
+          $parentTree.removeClass('tree-open');
+        }
         $content.removeClass('content-open');
-      } else if (cmd === "open") {
-        if (use_slide) {
-          $content.slideDown('fast', callback);
+      } else if (cmd === 'open') {
+        if (useSlide) {
+          $content.slideDown('fast');
         } else {
-          $content.css("display", "block");
+          $content.css('display', 'block');
         }
         $icon.addClass('active');
         $li.addClass('item-open');

--- a/src/ggrc/assets/javascripts/plugins/openclose.js
+++ b/src/ggrc/assets/javascripts/plugins/openclose.js
@@ -1,7 +1,7 @@
 /*!
-    Copyright (C) 2016 Google Inc.
-    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
-*/
+ Copyright (C) 2016 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
 (function($) {
   function openclose(command) {
     var $that = $(this),
@@ -14,14 +14,7 @@
         $content = $li.children('.item-content'),
         $icon = $main.find('.openclose'),
         $parentTree = $this.closest('ul.new-tree'),
-        cmd = command,
-        callback
-      ;
-
-      callback = function() {
-        //  Trigger update for sticky headers and footers
-        $this.trigger("updateSticky");
-      };
+        cmd = command;
 
       if (typeof cmd !== "string" || cmd === "toggle") {
         cmd = $icon.hasClass("active") ? "close" : "open";
@@ -32,7 +25,6 @@
           $content.slideUp('fast', callback);
         } else {
           $content.css("display", "none");
-          callback();
         }
         $icon.removeClass('active');
         $li.removeClass('item-open');
@@ -44,7 +36,6 @@
           $content.slideDown('fast', callback);
         } else {
           $content.css("display", "block");
-          callback();
         }
         $icon.addClass('active');
         $li.addClass('item-open');

--- a/src/ggrc/assets/mustache/base_objects/tree.mustache
+++ b/src/ggrc/assets/mustache/base_objects/tree.mustache
@@ -81,9 +81,7 @@
                               {{/case}}
 
                               {{#default}}
-                                {{#if_helpers '\
-                                  #if_equals' attr_name 'url' '\
-                                  or #if_equals' attr_name 'reference_url'}}
+                                {{#if_helpers '#if_equals' attr_name 'url' 'or #if_equals' attr_name 'reference_url'}}
                                     <a class="url" href="{{get_url_value attr_name instance}}" target="_blank">
                                       {{get_default_attr_value attr_name instance}}
                                     </a>


### PR DESCRIPTION
**Subject**: Tree view collapses when opening the 3rd tier of some objects
**Details**: 
Go to https://grc-dev.appspot.com/assessments/13635#audit_widget/audit/1476/assessment_template   as admin and open Audit’s 2nd tier in the tree view so you see the list of the objects mapped to the audit
Now open 3rd tiers for the objects
_Actual Result_: the tree view collapses when opening the 3rd tier for a Template and for the Issue
_Expected Result_: template’s tree view should be empty, Issue’s treeview should show the objects directly mapped to the issue object