### PR TITLE
1.153 Fix erros in data handlers

### DIFF
--- a/src/ggrc/app.py
+++ b/src/ggrc/app.py
@@ -148,7 +148,7 @@ def _display_sql_queries():
       """
       slow_threshold = 0.5  # EXPLAIN queries that ran for more than 0.5s
       queries = get_debug_queries()
-      app.logger.info("Total queries: {}".format(len(queries)))
+      app.logger.info("Total queries: %s", len(queries))
       if report_type == 'count':
         return response
       # We have to copy the queries list below otherwise queries executed
@@ -156,11 +156,12 @@ def _display_sql_queries():
       for query in queries[:]:
         if report_type == 'slow' and query.duration < slow_threshold:
           continue
-        app.logger.info("{:.8f} {}\n{}\n{}".format(
+        app.logger.info(
+            "%.8f %s\n%s\n%s",
             query.duration,
             query.context,
             query.statement,
-            query.parameters))
+            query.parameters)
         is_select = bool(re.match('SELECT', query.statement, re.I))
         if query.duration > slow_threshold and is_select:
           try:
@@ -169,7 +170,7 @@ def _display_sql_queries():
             result = engine.execute(statement, query.parameters)
             app.logger.info(tabulate(result.fetchall(), headers=result.keys()))
           except Exception as err:  # pylint: disable=broad-except
-            app.logger.warning("Statement failed: {}".format(statement))
+            app.logger.warning("Statement failed: %s", statement)
             app.logger.exception(err)
       return response
 

--- a/src/ggrc/converters/base_block.py
+++ b/src/ggrc/converters/base_block.py
@@ -341,7 +341,7 @@ class BlockConverter(object):
         except exc.SQLAlchemyError as err:
           db.session.rollback()
           current_app.logger.error(
-              "Import failed with: {}".format(err.message))
+              "Import failed with: %s", err.message)
           row_converter.add_error(errors.UNKNOWN_ERROR)
       self.save_import()
 
@@ -370,7 +370,7 @@ class BlockConverter(object):
         except exc.SQLAlchemyError as err:
           db.session.rollback()
           current_app.logger.error(
-              "Import failed with: {}".format(err.message))
+              "Import failed with: %s", err.message)
           row_converter.add_error(errors.UNKNOWN_ERROR)
       self.save_import()
       for row_converter in self.row_converters:
@@ -389,7 +389,7 @@ class BlockConverter(object):
     except exc.SQLAlchemyError as err:
       db.session.rollback()
       current_app.logger.error(
-          "Import failed with: {}".format(err.message))
+          "Import failed with: %s", err.message)
       self.add_errors(errors.UNKNOWN_ERROR, line=self.offset + 2)
 
   def add_errors(self, template, **kwargs):

--- a/src/ggrc/models/mixins/__init__.py
+++ b/src/ggrc/models/mixins/__init__.py
@@ -468,7 +468,7 @@ class Base(ChangeTracked, ContextRBAC, Identifiable):
       return self._display_name()
     except:
       current_app.logger.warn(
-          "display_name error in {}".format(type(self)), exc_info=True)
+          "display_name error in %s", type(self), exc_info=True)
       return ""
 
   def _display_name(self):

--- a/src/ggrc/notifications/common.py
+++ b/src/ggrc/notifications/common.py
@@ -299,7 +299,7 @@ def send_email(user_email, subject, body):
   """
   sender = get_app_engine_email()
   if not mail.is_email_valid(user_email):
-    current_app.logger.error("Invalid email recipient: {}".format(user_email))
+    current_app.logger.error("Invalid email recipient: %s", user_email)
     return
   if not sender:
     current_app.logger.error("APPENGINE_EMAIL setting is invalid.")

--- a/src/ggrc/notifications/data_handlers.py
+++ b/src/ggrc/notifications/data_handlers.py
@@ -73,7 +73,8 @@ def assignable_open_data(notif):
   obj = get_notification_object(notif)
   if not obj:
     current_app.logger.warning(
-        '{} for notification {} not found.'.format(notif.object_type, notif.id))
+        '{} for notification {} not found.'.format(
+            notif.object_type, notif.id))
     return {}
   people = [person for person, _ in obj.assignees]
 

--- a/src/ggrc/notifications/data_handlers.py
+++ b/src/ggrc/notifications/data_handlers.py
@@ -73,8 +73,7 @@ def assignable_open_data(notif):
   obj = get_notification_object(notif)
   if not obj:
     current_app.logger.warning(
-        '{} for notification {} not found.'.format(
-            notif.object_type, notif.id))
+        '%s for notification %s not found.', notif.object_type, notif.id)
     return {}
   people = [person for person, _ in obj.assignees]
 
@@ -248,7 +247,7 @@ def get_comment_data(notif):
                    rel.Assessment_destination or rel.Assessment_source)
   if not comment_obj:
     current_app.logger.warning(
-        'Comment object not found for notification {}'.format(notif.id))
+        'Comment object not found for notification %s', notif.id)
     return {}
 
   if comment_obj.recipients:

--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -205,14 +205,13 @@ def update_memcache_before_commit(context, modified_objects, expiry_time):
     build_cache_status(status_entries, 'DeleteOp:' + key,
                        expiry_time, 'InProgress')
   if len(status_entries) > 0:
-    current_app.logger.info("CACHE: status entries: " + str(status_entries))
+    current_app.logger.info("CACHE: status entries: %s", str(status_entries))
     ret = context.cache_manager.bulk_add(status_entries, expiry_time)
     if ret is not None and len(ret) == 0:
       pass
     else:
       current_app.logger.error(
-          'CACHE: Unable to add status for newly created entries ' +
-          str(ret))
+          'CACHE: Unable to add status for newly created entries %s', str(ret))
 
 
 def update_memcache_after_commit(context):

--- a/src/ggrc/services/log_event.py
+++ b/src/ggrc/services/log_event.py
@@ -3,13 +3,15 @@
 
 from flask import request, current_app
 
+
 def log_event():
   '''Log javascript client errors to syslog via application logger.'''
   method = request.method.lower()
   if method == 'post':
     severity = request.json['log_event']['severity']
     description = request.json['log_event']['description']
-    current_app.logger.error('Javascript Client: %s %s',
+    current_app.logger.error(
+        'Javascript Client: %s %s',
         severity, description)
     return current_app.make_response(('', 200, []))
   raise NotImplementedError()

--- a/src/ggrc/services/log_event.py
+++ b/src/ggrc/services/log_event.py
@@ -9,8 +9,7 @@ def log_event():
   if method == 'post':
     severity = request.json['log_event']['severity']
     description = request.json['log_event']['description']
-    current_app.logger.error('Javascript Client: {0} {1}'.format(
-      severity, description))
+    current_app.logger.error('Javascript Client: %s %s',
+        severity, description)
     return current_app.make_response(('', 200, []))
   raise NotImplementedError()
-

--- a/src/ggrc/utils/benchmarks.py
+++ b/src/ggrc/utils/benchmarks.py
@@ -31,7 +31,7 @@ class BenchmarkContextManager(object):
 
   def __exit__(self, exc_type, exc_value, exc_trace):
     end = time.time()
-    current_app.logger.info("{:.4f} {}".format(end - self.start, self.message))
+    current_app.logger.info("%.4f %s", end - self.start, self.message)
 
 
 class WithNop(object):

--- a/src/ggrc_workflows/notification/data_handler.py
+++ b/src/ggrc_workflows/notification/data_handler.py
@@ -99,6 +99,10 @@ def get_cycle_task_due(notification):
     current_app.logger.warning(
         '{} for notification {} not found.'.format(notif.object_type, notif.id))
     return {}
+  if not cycle_task.contact:
+    current_app.logger.warning(
+        'Contact for cycle task {} not found.'.format(notification.object_id))
+    return {}
 
   notif_name = notification.notification_type.name
   due = "due_today" if notif_name == "cycle_task_due_today" else "due_in"
@@ -174,6 +178,10 @@ def get_cycle_data(notification):
 def get_cycle_task_declined_data(notification):
   cycle_task = get_object(CycleTaskGroupObjectTask, notification.object_id)
   if not cycle_task:
+    current_app.logger.warning(
+        '{} for notification {} not found.'.format(notif.object_type, notif.id))
+    return {}
+  if not cycle_task.contact:
     current_app.logger.warning(
         '{} for notification {} not found.'.format(notif.object_type, notif.id))
     return {}

--- a/src/ggrc_workflows/notification/data_handler.py
+++ b/src/ggrc_workflows/notification/data_handler.py
@@ -3,6 +3,7 @@
 
 from copy import deepcopy
 from datetime import date
+from flask import current_app
 from sqlalchemy import and_
 from urlparse import urljoin
 
@@ -28,6 +29,8 @@ exposed functions
 def get_cycle_created_task_data(notification):
   cycle_task = get_object(CycleTaskGroupObjectTask, notification.object_id)
   if not cycle_task:
+    current_app.logger.warning(
+        '{} for notification {} not found.'.format(notif.object_type, notif.id))
     return {}
 
   cycle_task_group = cycle_task.cycle_task_group
@@ -93,6 +96,8 @@ def get_cycle_created_task_data(notification):
 def get_cycle_task_due(notification):
   cycle_task = get_object(CycleTaskGroupObjectTask, notification.object_id)
   if not cycle_task:
+    current_app.logger.warning(
+        '{} for notification {} not found.'.format(notif.object_type, notif.id))
     return {}
 
   notif_name = notification.notification_type.name
@@ -169,6 +174,8 @@ def get_cycle_data(notification):
 def get_cycle_task_declined_data(notification):
   cycle_task = get_object(CycleTaskGroupObjectTask, notification.object_id)
   if not cycle_task:
+    current_app.logger.warning(
+        '{} for notification {} not found.'.format(notif.object_type, notif.id))
     return {}
 
   force = cycle_task.cycle_task_group.cycle.workflow.notify_on_change

--- a/src/ggrc_workflows/notification/data_handler.py
+++ b/src/ggrc_workflows/notification/data_handler.py
@@ -30,8 +30,8 @@ def get_cycle_created_task_data(notification):
   cycle_task = get_object(CycleTaskGroupObjectTask, notification.object_id)
   if not cycle_task:
     current_app.logger.warning(
-        '{} for notification {} not found.'.format(
-            notification.object_type, notification.id))
+        '%s for notification %s not found.',
+        notification.object_type, notification.id)
     return {}
 
   cycle_task_group = cycle_task.cycle_task_group
@@ -98,12 +98,12 @@ def get_cycle_task_due(notification):
   cycle_task = get_object(CycleTaskGroupObjectTask, notification.object_id)
   if not cycle_task:
     current_app.logger.warning(
-        '{} for notification {} not found.'.format(
-            notification.object_type, notification.id))
+        '%s for notification %s not found.',
+        notification.object_type, notification.id)
     return {}
   if not cycle_task.contact:
     current_app.logger.warning(
-        'Contact for cycle task {} not found.'.format(notification.object_id))
+        'Contact for cycle task %s not found.', notification.object_id)
     return {}
 
   notif_name = notification.notification_type.name

--- a/src/ggrc_workflows/notification/data_handler.py
+++ b/src/ggrc_workflows/notification/data_handler.py
@@ -179,15 +179,10 @@ def get_cycle_data(notification):
 
 def get_cycle_task_declined_data(notification):
   cycle_task = get_object(CycleTaskGroupObjectTask, notification.object_id)
-  if not cycle_task:
+  if not cycle_task or not cycle_task.contact:
     current_app.logger.warning(
-        '{} for notification {} not found.'.format(
-            notification.object_type, notification.id))
-    return {}
-  if not cycle_task.contact:
-    current_app.logger.warning(
-        '{} for notification {} not found.'.format(
-            notification.object_type, notification.id))
+        '%s for notification %s not found.',
+        notification.object_type, notification.id)
     return {}
 
   force = cycle_task.cycle_task_group.cycle.workflow.notify_on_change

--- a/src/ggrc_workflows/notification/data_handler.py
+++ b/src/ggrc_workflows/notification/data_handler.py
@@ -30,7 +30,8 @@ def get_cycle_created_task_data(notification):
   cycle_task = get_object(CycleTaskGroupObjectTask, notification.object_id)
   if not cycle_task:
     current_app.logger.warning(
-        '{} for notification {} not found.'.format(notif.object_type, notif.id))
+        '{} for notification {} not found.'.format(
+            notification.object_type, notification.id))
     return {}
 
   cycle_task_group = cycle_task.cycle_task_group
@@ -97,7 +98,8 @@ def get_cycle_task_due(notification):
   cycle_task = get_object(CycleTaskGroupObjectTask, notification.object_id)
   if not cycle_task:
     current_app.logger.warning(
-        '{} for notification {} not found.'.format(notif.object_type, notif.id))
+        '{} for notification {} not found.'.format(
+            notification.object_type, notification.id))
     return {}
   if not cycle_task.contact:
     current_app.logger.warning(
@@ -179,11 +181,13 @@ def get_cycle_task_declined_data(notification):
   cycle_task = get_object(CycleTaskGroupObjectTask, notification.object_id)
   if not cycle_task:
     current_app.logger.warning(
-        '{} for notification {} not found.'.format(notif.object_type, notif.id))
+        '{} for notification {} not found.'.format(
+            notification.object_type, notification.id))
     return {}
   if not cycle_task.contact:
     current_app.logger.warning(
-        '{} for notification {} not found.'.format(notif.object_type, notif.id))
+        '{} for notification {} not found.'.format(
+            notification.object_type, notification.id))
     return {}
 
   force = cycle_task.cycle_task_group.cycle.workflow.notify_on_change


### PR DESCRIPTION
I have found multiple issues:

1. Deleted requests were not deleted from the notifications table (isn't reproducible) and there are no app engine logs from the date when the Request was deleted.
2. Cycle tasks can have a NULL contact_id in the database so we can't assume the contact will always be there.
3. Comment might not be mapped to an Assignable object.

I have created post quince tasks for all of these cases, but for now I think this PR should unblock people trying to test notifications. 