### PR TITLE
QUICK-FIX Person model should always be set

### DIFF
--- a/src/ggrc/assets/javascripts/components/person/person.js
+++ b/src/ggrc/assets/javascripts/components/person/person.js
@@ -61,6 +61,8 @@
         if (personModel) {
           personModel = personModel.reify();
         }
+      } else if (person) {
+        personModel = person;
       }
       // For some reason the cache sometimes contains partially loaded objects,
       // thus we also need to check if "email" (a required field) is present.

--- a/src/ggrc/assets/javascripts/components/person/tests/person_spec.js
+++ b/src/ggrc/assets/javascripts/components/person/tests/person_spec.js
@@ -152,6 +152,24 @@ describe('GGRC.Components.personItem', function () {
           .toBe(CMS.Models.Person.cache['123']);
       expect(RefreshQueue.prototype.trigger).not.toHaveBeenCalled();
     });
+    it('gets person object from context and it doesn\'t trigger ' +
+       'the RefreshQueue', function () {
+      var personObj = new CMS.Models.Person({
+        id: 123, name: 'Ivan', email: 'ivan@google.com', type: 'Person'
+      });
+
+      template = can.view
+        .mustache('<person-info person-obj="person"></person-info>');
+      frag = template({
+        person: personObj
+      });
+      frag = $(frag);
+      component = frag.find('person-info').control();
+
+      expect(component.scope.attr('personObj'))
+          .toBe(CMS.Models.Person.cache['123']);
+      expect(RefreshQueue.prototype.trigger).not.toHaveBeenCalled();
+    });
   });
 
   describe('unmap person click event handler', function () {


### PR DESCRIPTION
I've figured out I've missed this case. Easiest way to reproduce it to provide person object with fully data and watch refresh que get triggered.