### PR TITLE
ISSUE-1.223 Show task entry mapped documents

### DIFF
--- a/src/ggrc_workflows/assets/javascripts/models/cycle_models.js
+++ b/src/ggrc_workflows/assets/javascripts/models/cycle_models.js
@@ -172,7 +172,12 @@
     create: 'POST /api/cycle_task_entries',
     update: 'PUT /api/cycle_task_entries/{id}',
     destroy: 'DELETE /api/cycle_task_entries/{id}',
-
+    info_pane_options: {
+      attachments: {
+        mapping: 'documents',
+        show_view: GGRC.mustache_path + '/base_templates/attachment.mustache'
+      }
+    },
     attributes: {
       cycle_task_group_object_task: 'CMS.Models.CycleTaskGroupObjectTask.stub',
       modified_by: 'CMS.Models.Person.stub',

--- a/src/ggrc_workflows/assets/mustache/cycle_task_entries/tree.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_entries/tree.mustache
@@ -11,13 +11,12 @@
   <span class="status-label status-"></span>
   <div class="w-status">
     {{{instance.description}}}
-    {{#prune_context}}
-    {{#child_options.0}}
-      <ul class="attachment-list" {{data 'options'}} {{ (el) -> el.cms_controllers_tree_view(el.data('options')).control("tree_view").display() }}>
-      </ul>
-    {{/child_options.0}}
-    {{/prune_context}}
 
+    <mapping-tree-view
+      parent-instance="instance"
+      mapping="instance.class.info_pane_options.attachments.mapping"
+      item-template="instance.class.info_pane_options.attachments.show_view"
+    />
     {{^if_equals parent_instance.status 'Verified'}}
     {{#with_mapping 'folders' instance}} {{! dummy to ensure the child content always updates}}
     {{#defer 'workflowFolder' instance.workflowFolder allow_fail=true}}
@@ -48,6 +47,7 @@
       {{#if instance.created_at}}on {{date instance.created_at}}{{/if}}
     </span>
   </div>
+
   <div class="entry-actions pull-right">
     <a class="dropdown-toggle" href="#" data-toggle="dropdown"><i class="fa fa-cog"></i></a>
     <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">


### PR DESCRIPTION
*Subject:*
attachments not showing up if added to cycle task comment

*Details:*
- Create an active cycle under a WF
- Add a gDrive folder to the WF
- Leave a comment under the task on Active cycle task
- Upload a file to the comment

*Actual Result:*
attached to the comment file isn’t show

*Expected Result:*
attached to the comment file should be show instantly after attaching it
