### PR TITLE
ISSUE-1.89 Not all optional fields are displayed in New entity modal window by default

### DIFF
--- a/src/ggrc/assets/mustache/access_groups/modal_content.mustache
+++ b/src/ggrc/assets/mustache/access_groups/modal_content.mustache
@@ -101,7 +101,8 @@
           <a data-id="hide_state_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
         </label>
           <dropdown options-list="model.statuses"
-                    name="instance.status">
+                    name="instance.status"
+                    tabindex="23">
           </dropdown>
       </div>
     </div>

--- a/src/ggrc/assets/mustache/assessments/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessments/modal_content.mustache
@@ -60,13 +60,13 @@
     <div class="span6 hide-wrap">
       <div class="row-fluid inner-hide wrap-row">
         <div class="span12">
-          <people-list instance="instance" editable="true" deferred="true" validate="true"></people-list>
+          <people-list tabindex="11" instance="instance" editable="true" deferred="true" validate="true"></people-list>
         </div>
       </div>
 
       <div class="row-fluid inner-hide">
         <div data-id="notifications_hidden" class="span12 hidable">
-          <div class="comment-notification">
+          <div class="comment-notification" tabindex="13">
             <a data-id="hide_notification_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
             <label>
               <input type="checkbox"
@@ -180,7 +180,8 @@
           <dropdown options-list="model.conclusions"
                     no-value="true"
                     no-value-label="---"
-                    name="instance.design">
+                    name="instance.design"
+                    tabindex="23">
           </dropdown>
       </div>
 
@@ -193,7 +194,8 @@
           <dropdown options-list="model.conclusions"
                     no-value="true"
                     no-value-label="---"
-                    name="instance.operationally">
+                    name="instance.operationally"
+                    tabindex="23">
           </dropdown>
       </div>
     </div>

--- a/src/ggrc/assets/mustache/audits/modal_content.mustache
+++ b/src/ggrc/assets/mustache/audits/modal_content.mustache
@@ -65,7 +65,8 @@
         </label>
         <div tabindex="4">
             <dropdown options-list="model.statuses"
-                      name="instance.status">
+                      name="instance.status"
+                      tabindex="23">
             </dropdown>
         </div>
       </div>
@@ -78,6 +79,7 @@
           label="Planned Start Date"
           date="start_date"
           set-max-date="end_date"
+          tabindex="20"
           />
       </div>
       <div data-id="planned_end_date_hidden" class="span3 hidable">
@@ -86,6 +88,7 @@
           label="Planned End Date"
           set-min-date="start_date"
           date="end_date"
+          tabindex="21"
           />
         <label>
       </div>
@@ -99,6 +102,7 @@
             <datepicker
               set-max-date="report_end_date"
               date="report_start_date"
+              tabindex="22"
               />
           </div>
           <div class="span6">

--- a/src/ggrc/assets/mustache/base_templates/effective_dates.mustache
+++ b/src/ggrc/assets/mustache/base_templates/effective_dates.mustache
@@ -12,6 +12,7 @@
       helptext="Enter the date this object becomes effective."
       test-id="startTestId"
       required="required"
+      tabindex="20"
       />
   </div>
   <div data-id="stop_date_hidden" class="span4 hidable">
@@ -23,6 +24,7 @@
       helptext="Enter the date the object stops being effective."
       test-id="endTestId"
       required="required"
+      tabindex="21"
       />
   </div>
 </div>

--- a/src/ggrc/assets/mustache/base_templates/people_list.mustache
+++ b/src/ggrc/assets/mustache/base_templates/people_list.mustache
@@ -23,7 +23,7 @@
         </li>
       {{else}}
         <li class="hidable">
-          <people-group deferred="deferred" editable="editable" instance="instance" mapping="mapping" type="type"></people-group>
+          <people-group deferred="deferred" editable="editable" instance="instance" mapping="mapping" type="type" tabindex="7"></people-group>
         </li>
       {{/if}}
     {{/instance}}

--- a/src/ggrc/assets/mustache/clauses/modal_content.mustache
+++ b/src/ggrc/assets/mustache/clauses/modal_content.mustache
@@ -99,7 +99,8 @@
           <a data-id="hide_state_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
         </label>
           <dropdown options-list="model.statuses"
-                    name="instance.status">
+                    name="instance.status"
+                    tabindex="23">
           </dropdown>
       </div>
     </div>

--- a/src/ggrc/assets/mustache/contracts/modal_content.mustache
+++ b/src/ggrc/assets/mustache/contracts/modal_content.mustache
@@ -101,7 +101,8 @@
           <a data-id="hide_state_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
         </label>
           <dropdown options-list="model.statuses"
-                    name="instance.status">
+                    name="instance.status"
+                    tabindex="23">
           </dropdown>
       </div>
     </div>

--- a/src/ggrc/assets/mustache/controls/modal_content.mustache
+++ b/src/ggrc/assets/mustache/controls/modal_content.mustache
@@ -223,7 +223,8 @@
           <a data-id="hide_state_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
         </label>
           <dropdown options-list="model.statuses"
-                    name="instance.status">
+                    name="instance.status"
+                    tabindex="23">
           </dropdown>
       </div>
     </div>

--- a/src/ggrc/assets/mustache/data_assets/modal_content.mustache
+++ b/src/ggrc/assets/mustache/data_assets/modal_content.mustache
@@ -101,7 +101,8 @@
           <a data-id="hide_state_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
         </label>
           <dropdown options-list="model.statuses"
-                    name="instance.status">
+                    name="instance.status"
+                    tabindex="23">
           </dropdown>
       </div>
     </div>

--- a/src/ggrc/assets/mustache/facilities/modal_content.mustache
+++ b/src/ggrc/assets/mustache/facilities/modal_content.mustache
@@ -101,7 +101,8 @@
           <a data-id="hide_state_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
         </label>
           <dropdown options-list="model.statuses"
-                    name="instance.status">
+                    name="instance.status"
+                    tabindex="23">
           </dropdown>
       </div>
     </div>

--- a/src/ggrc/assets/mustache/issues/modal_content.mustache
+++ b/src/ggrc/assets/mustache/issues/modal_content.mustache
@@ -157,7 +157,8 @@
           <dropdown options-list="model.statuses"
                     no-value="true"
                     no-value-label="---"
-                    name="instance.status">
+                    name="instance.status"
+                    tabindex="23">
           </dropdown>
       </div>
     </div>

--- a/src/ggrc/assets/mustache/markets/modal_content.mustache
+++ b/src/ggrc/assets/mustache/markets/modal_content.mustache
@@ -101,7 +101,8 @@
           <a data-id="hide_state_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
         </label>
           <dropdown options-list="model.statuses"
-                    name="instance.status">
+                    name="instance.status"
+                    tabindex="23">
           </dropdown>
       </div>
     </div>

--- a/src/ggrc/assets/mustache/objectives/modal_content.mustache
+++ b/src/ggrc/assets/mustache/objectives/modal_content.mustache
@@ -95,7 +95,8 @@
           <a data-id="hide_state_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
         </label>
           <dropdown options-list="model.statuses"
-                    name="instance.status">
+                    name="instance.status"
+                    tabindex="23">
           </dropdown>
       </div>
     </div>

--- a/src/ggrc/assets/mustache/org_groups/modal_content.mustache
+++ b/src/ggrc/assets/mustache/org_groups/modal_content.mustache
@@ -99,7 +99,8 @@
           <a data-id="hide_state_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
         </label>
           <dropdown options-list="model.statuses"
-                    name="instance.status">
+                    name="instance.status"
+                    tabindex="23">
           </dropdown>
       </div>
     </div>

--- a/src/ggrc/assets/mustache/policies/modal_content.mustache
+++ b/src/ggrc/assets/mustache/policies/modal_content.mustache
@@ -117,7 +117,8 @@
         <a data-id="hide_state_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
       </label>
         <dropdown options-list="model.statuses"
-                  name="instance.status">
+                  name="instance.status"
+                  tabindex="23">
         </dropdown>
     </div>
   </div>

--- a/src/ggrc/assets/mustache/processes/modal_content.mustache
+++ b/src/ggrc/assets/mustache/processes/modal_content.mustache
@@ -114,7 +114,8 @@
         <dropdown options-list="model.statuses"
                   no-value="true"
                   no-value-label="---"
-                  name="instance.status">
+                  name="instance.status"
+                  tabindex="23">
         </dropdown>
     </div>
   </div>

--- a/src/ggrc/assets/mustache/products/modal_content.mustache
+++ b/src/ggrc/assets/mustache/products/modal_content.mustache
@@ -108,7 +108,8 @@
           <a data-id="hide_state_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
         </label>
           <dropdown options-list="model.statuses"
-                    name="instance.status">
+                    name="instance.status"
+                    tabindex="23">
           </dropdown>
       </div>
     </div>

--- a/src/ggrc/assets/mustache/programs/modal_content.mustache
+++ b/src/ggrc/assets/mustache/programs/modal_content.mustache
@@ -132,7 +132,8 @@
       </label>
         <dropdown data-test-id="new_program_dropdown_state_036a1fa6"
                   options-list="model.statuses"
-                  name="instance.status">
+                  name="instance.status"
+                  tabindex="23">
         </dropdown>
     </div>
   </div>

--- a/src/ggrc/assets/mustache/projects/modal_content.mustache
+++ b/src/ggrc/assets/mustache/projects/modal_content.mustache
@@ -101,7 +101,8 @@
           <a data-id="hide_state_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
         </label>
           <dropdown options-list="model.statuses"
-                    name="instance.status">
+                    name="instance.status"
+                    tabindex="23">
           </dropdown>
       </div>
     </div>

--- a/src/ggrc/assets/mustache/regulations/modal_content.mustache
+++ b/src/ggrc/assets/mustache/regulations/modal_content.mustache
@@ -100,7 +100,8 @@
           <a data-id="hide_state_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
         </label>
           <dropdown options-list="model.statuses"
-                    name="instance.status">
+                    name="instance.status"
+                    tabindex="23">
           </dropdown>
       </div>
     </div>

--- a/src/ggrc/assets/mustache/sections/modal_content.mustache
+++ b/src/ggrc/assets/mustache/sections/modal_content.mustache
@@ -112,7 +112,8 @@
           <a data-id="hide_state_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
         </label>
           <dropdown options-list="model.statuses"
-                    name="instance.status">
+                    name="instance.status"
+                    tabindex="23">
           </dropdown>
       </div>
     </div>

--- a/src/ggrc/assets/mustache/standards/modal_content.mustache
+++ b/src/ggrc/assets/mustache/standards/modal_content.mustache
@@ -101,7 +101,8 @@
           <a data-id="hide_state_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
         </label>
           <dropdown options-list="model.statuses"
-                    name="instance.status">
+                    name="instance.status"
+                    tabindex="23">
           </dropdown>
       </div>
     </div>

--- a/src/ggrc/assets/mustache/systems/modal_content.mustache
+++ b/src/ggrc/assets/mustache/systems/modal_content.mustache
@@ -112,7 +112,8 @@
         <a data-id="hide_state_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
       </label>
         <dropdown options-list="model.statuses"
-                  name="instance.status">
+                  name="instance.status"
+                  tabindex="23">
         </dropdown>
     </div>
   </div>

--- a/src/ggrc/assets/mustache/vendors/modal_content.mustache
+++ b/src/ggrc/assets/mustache/vendors/modal_content.mustache
@@ -99,7 +99,8 @@
           <a data-id="hide_state_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
         </label>
           <dropdown options-list="model.statuses"
-                    name="instance.status">
+                    name="instance.status"
+                    tabindex="23">
           </dropdown>
       </div>
     </div>

--- a/src/ggrc_gdrive_integration/assets/mustache/gdrive/gdrive_folder.mustache
+++ b/src/ggrc_gdrive_integration/assets/mustache/gdrive/gdrive_folder.mustache
@@ -54,7 +54,7 @@
           </span>
           {{^if readonly}}
           <a href="javascript://"
-            tabindex="{{firsnonempty tabindex '0'}}"
+            tabindex="{{firstnonempty tabindex '0'}}"
             class="entry-attachment tree-item-add"
             data-toggle="gdrive-picker"
             data-model="{{instance.class.model_singular}}"

--- a/src/ggrc_risks/assets/mustache/risks/modal_content.mustache
+++ b/src/ggrc_risks/assets/mustache/risks/modal_content.mustache
@@ -136,7 +136,8 @@
         <dropdown options-list="model.statuses"
                   no-value="true"
                   no-value-label="---"
-                  name="instance.status">
+                  name="instance.status"
+                  tabindex="23">
         </dropdown>
     </div>
   </div>

--- a/src/ggrc_risks/assets/mustache/threats/modal_content.mustache
+++ b/src/ggrc_risks/assets/mustache/threats/modal_content.mustache
@@ -101,7 +101,8 @@
         <dropdown options-list="model.statuses"
                   no-value="true"
                   no-value-label="---"
-                  name="instance.status">
+                  name="instance.status"
+                  tabindex="23">
         </dropdown>
     </div>
   </div>


### PR DESCRIPTION
**Subject:** Not all optional fields are displayed New Audit modal window by default
**Details:** 
Login under your account
Open New Modal window for program/audit/etc. from LHN menu
Click Hide all optional fields
Enter required data and save modal window
Open New Modal window once again and check displayed fields
**Actual Result:** Not all fields are displayed in modal window.
**Expected Result:** By default all fields (required and optional) should be displayed or application should remember user choices and display only required fields only
**Workaround:** click show all optional fields
