### PR TITLE
ISSUE-1.90  Single Creator and Assessor are deleted by deleting Verifier

### DIFF
--- a/src/ggrc/assets/javascripts/components/people_list.js
+++ b/src/ggrc/assets/javascripts/components/people_list.js
@@ -97,17 +97,21 @@
       /**
         * Get people mapped to this instance
         *
-        * @return {Array} - the list of current mapped people
+        * @return {Promise} - a promise that returns the list of current mapped people
         */
-      get_mapped: function () {
+      get_mapped_deferred: function () {
         // We call get_mapping only once because canjs events can get caught in a loop
         // computed_mapping needs to be in scope so its separated from other people lists
         if (!this.computed_mapping) {
-          this.attr('list_mapped',
-                    this.attr('instance').get_mapping(this.attr('mapping')));
-          this.computed_mapping = true;
+          return this.attr('instance')
+            .get_mapping_deferred(this.attr('mapping'))
+            .then(function (data) {
+              this.attr('list_mapped', data);
+              this.computed_mapping = true;
+              return data;
+            }.bind(this));
         }
-        return this.attr('list_mapped');
+        return $.when(this.attr('list_mapped'));
       },
       /**
         * Get the first (or only) pending join for a person
@@ -405,16 +409,18 @@
     },
     events: {
       inserted: function () {
-        this.scope.attr('list_pending', this.scope.get_pending());
-        this.scope.attr('list_mapped', this.scope.get_mapped());
-        this.updateResult();
-        if (!this.scope.attr('required')) {
-          return;
-        }
-        this.scope.attr('mapped_people', this.scope.get_mapped());
-        if (this.scope.instance.isNew() && this.scope.validate) {
-          this.validate();
-        }
+        this.scope.get_mapped_deferred().then(function (data) {
+          this.scope.attr('list_pending', this.scope.get_pending());
+          this.scope.attr('list_mapped', data);
+          this.updateMappedResult(data);
+          if (!this.scope.attr('required')) {
+            return;
+          }
+          this.scope.attr('mapped_people', data);
+          if (this.scope.instance.isNew() && this.scope.validate) {
+            this.validate();
+          }
+        }.bind(this));
       },
       validate: function () {
         if (!(this.scope.required && this.scope.validate)) {
@@ -424,8 +430,13 @@
           this.scope.attr('type'), !!this.scope.results.length);
       },
       updateResult: function () {
+        this.scope.get_mapped_deferred().then(function (data) {
+          this.updateMappedResult(data);
+        }.bind(this));
+      },
+      updateMappedResult: function (data) {
         var type = can.capitalize(this.scope.type);
-        var mapped = _.map(this.scope.get_mapped(), function (item) {
+        var mapped = _.map(data, function (item) {
           return item.instance;
         });
         var pending = _.filter(this.scope.get_pending(), function (item) {

--- a/src/ggrc/assets/javascripts/components/tests/people_list_spec.js
+++ b/src/ggrc/assets/javascripts/components/tests/people_list_spec.js
@@ -49,42 +49,45 @@ describe('GGRC.Components.peopleGroup', function () {
     var getMapped;  // the method under test
     var scope;
     var mappingsList = [{}, {}];  // some arbitrary values
-    var result;
+    var deferred = $.Deferred();
 
     beforeEach(function () {
       scope = new can.Map({
         computed_mapping: false,
         mapping: 'some mapping',
         instance: new can.Map({
-          get_mapping: function () {}
+          get_mapping_deferred: function () {}
         })
       });
       mappingsList = scope.attr('mappingsList', mappingsList);
 
-      spyOn(scope.instance, 'get_mapping').and.returnValue(mappingsList);
+      spyOn(scope.instance, 'get_mapping_deferred')
+        .and
+        .returnValue(deferred.resolve(mappingsList));
 
-      getMapped = Component.prototype.scope.get_mapped.bind(scope);
+      getMapped = Component.prototype.scope.get_mapped_deferred.bind(scope);
     });
 
     it('returns mappings and sets "computed_mapping" to true',
        function () {
-         result = getMapped();
-
-         expect(result).toEqual(mappingsList);
-         expect(scope.attr('list_mapped')).toEqual(mappingsList);
-         expect(scope.computed_mapping).toEqual(true);
-         expect(scope.instance.get_mapping).toHaveBeenCalledWith(scope.mapping);
+         getMapped().then(function (data) {
+           expect(data).toEqual(mappingsList);
+           expect(scope.attr('list_mapped')).toEqual(mappingsList);
+           expect(scope.computed_mapping).toEqual(true);
+           expect(scope.instance.get_mapping_deferred)
+             .toHaveBeenCalledWith(scope.mapping);
+         });
        });
 
-    it('does not call instance.get_mapping if "computed_mapping" is true',
+    it('does not call instance.get_mapping_deferred if "computed_mapping"',
        function () {
          scope.computed_mapping = true;
          scope.attr('list_mapped', mappingsList);
 
-         result = getMapped();
-
-         expect(result).toEqual(scope.attr('list_mapped'));
-         expect(scope.instance.get_mapping).not.toHaveBeenCalled();
+         getMapped().then(function (data) {
+           expect(data).toEqual(scope.attr('list_mapped'));
+           expect(scope.instance.get_mapping_deferred).not.toHaveBeenCalled();
+         });
        });
   });
 

--- a/src/ggrc/assets/javascripts/models/cacheable.js
+++ b/src/ggrc/assets/javascripts/models/cacheable.js
@@ -868,6 +868,10 @@
       return [];
     },
 
+    get_mapping_deferred: function (name) {
+      return this.get_binding(name).refresh_list();
+    },
+
   // This retrieves the potential orphan stats for a given instance
   // Example: "This may also delete 3 Sections, 2 Controls, and 4 object mappings."
     get_orphaned_count: function () {


### PR DESCRIPTION
**Subject**: Single Creator and Assessor are deleted from Assessment from Assessment Edit modal window by deleting Verifier
**Details**: 

- Login as admin
- Create control from LHN menu
- Create program from LHN menu
- Open program page, click at Control tab and map created control to program
- Click at Audit tab and create Audit for program
- Open Audit page
- Click at ASMT template tab and create ASMT template based on control
- Click at Assessment tab and Generate assessment based on created control and asmt template
- Open Edit Assessment modal window and hover mouse over Verifier and delete current logged user

**Actual Result**: User was deleted from Creator and Assessor too
**Expected Result**: Verifier should be deleted only.

**Notes**: Sometimes it's really hard to reproduce this issue. Please enable network throttling or emulate 'slow backend' somehow.