### PR TITLE
QUICK-FIX Add type check for spaceCamelCase

### DIFF
--- a/src/ggrc/assets/javascripts/plugins/canjs_extensions.js
+++ b/src/ggrc/assets/javascripts/plugins/canjs_extensions.js
@@ -79,6 +79,10 @@
 
   // Turn camelSpace strings into Camel Space strings
   can.spaceCamelCase = function (string) {
+    if (!_.isString(string)) {
+      throw new TypeError('Invalid type, string required.');
+    }
+
     return can.underscore(string)
       .split('_')
       .map(can.capitalize)

--- a/src/ggrc/assets/javascripts/plugins/canjs_extensions.js
+++ b/src/ggrc/assets/javascripts/plugins/canjs_extensions.js
@@ -77,7 +77,7 @@
     };
   }
 
-  // Turn camelSpace strings into Camel Space strings
+  // Turn camelCase or snake-case strings into Camel Space strings
   can.spaceCamelCase = function (string) {
     if (!_.isString(string)) {
       throw new TypeError('Invalid type, string required.');

--- a/src/ggrc/assets/javascripts/plugins/tests/canjs_extensions_spec.js
+++ b/src/ggrc/assets/javascripts/plugins/tests/canjs_extensions_spec.js
@@ -61,4 +61,35 @@ describe('CanJS extensions', function () {
       }).toThrow(new TypeError('Invalid type, string required.'));
     });
   });
+
+  describe('using spaceCamelCase', function () {
+    var method;
+
+    beforeEach(function () {
+      method = can.spaceCamelCase;
+    });
+
+    it('should return camel case from space case', function () {
+      expect(method('hello_world')).toBe('Hello World');
+      expect(method('hello_world_hi_there')).toBe('Hello World Hi There');
+      expect(method('my_number_4_and_number_5')).toBe(
+        'My Number 4 And Number 5');
+    });
+    it('should return same value for one word', function () {
+      expect(method('hello')).toBe('Hello');
+      expect(method('Hello')).toBe('Hello');
+    });
+    it('should return properly capitalized for camelCase input', function () {
+      expect(method('helloWorld')).toBe('Hello World');
+      expect(method('helloWorldHiThere')).toBe('Hello World Hi There');
+    });
+    it('should throw a type error in case of non string', function () {
+      expect(function () {
+        method(42);
+      }).toThrow(new TypeError('Invalid type, string required.'));
+      expect(function () {
+        method({a: 1});
+      }).toThrow(new TypeError('Invalid type, string required.'));
+    });
+  });
 });


### PR DESCRIPTION
@hyperNURb If you believe tests should behave differently or that I shouldn't throw type error but silently convert to string or return `''` let me know.