### PR TITLE
QUICK-FIX Prevent casting scope values to parent scope

### DIFF
--- a/src/ggrc/assets/javascripts/components/autocomplete/tests/autocomplete_spec.js
+++ b/src/ggrc/assets/javascripts/components/autocomplete/tests/autocomplete_spec.js
@@ -20,7 +20,7 @@ describe('GGRC.Components.autocomplete', function () {
     });
 
     it('sets the automappingOff flag to true', function () {
-      expect(scope.automappingOff).toBe(true);
+      expect(scope().automappingOff).toBe(true);
     });
   });
 

--- a/src/ggrc/assets/javascripts/components/person/tests/person_spec.js
+++ b/src/ggrc/assets/javascripts/components/person/tests/person_spec.js
@@ -20,7 +20,7 @@ describe('GGRC.Components.personItem', function () {
     });
 
     it('sets the personObj to null', function () {
-      expect(scope.personObj).toBeNull();
+      expect(scope().personObj).toBeNull();
     });
   });
 

--- a/src/ggrc/assets/javascripts/plugins/component_registry.js
+++ b/src/ggrc/assets/javascripts/plugins/component_registry.js
@@ -48,7 +48,7 @@
     }
 
     if (definitions) {
-      config.init = Components._extendInit(config.init, definitions);
+      config.scope = Components._extendScope(config.scope, definitions);
     }
 
     constructor = can.Component.extend(config);
@@ -58,37 +58,33 @@
   }
 
   /**
-   * Wrap component init function
+   * Wrap component scope function
    *
-   * @param {Function} init - Component init function
+   * @param {Function} originalScope - Component original scope
    * @param {Object} definitions - Type definitions and their defaults
    *
-   * @return {Function} - Returns wrapped init function
+   * @return {Function} - Scope wrapped init function
    */
-  Components._extendInit = function (init, definitions) {
-    init = init || $.noop;
-
-    return function (element, options) {
-      var scope = this.scope;
+  Components._extendScope = function (originalScope, definitions) {
+    return function (scope, parentScope, element) {
       var val;
-
-      can.batch.start();
+      scope = scope || {};
+      parentScope = parentScope || {};
+      element = element instanceof jQuery ? element : $(element);
       _.each(definitions, function (obj, key) {
         var prefix = '';
-        if (!_.has(scope, key)) {
-          if (obj.type === 'function') {
-            prefix = 'can-';
-          }
-          val = element.getAttribute(prefix + can.camelCaseToDashCase(key));
-          val = Components._castValue(val, obj.type, options);
-          if (_.isUndefined(val) && _.has(obj, 'default')) {
-            val = obj.default;
-          }
-          scope.attr(key, val);
+        if (obj.type === 'function') {
+          prefix = 'can-';
         }
+        val = element.attr(prefix + can.camelCaseToDashCase(key));
+        val = Components._castValue(val, obj.type, parentScope);
+        if (_.isUndefined(val) && _.has(obj, 'default')) {
+          val = obj.default;
+        }
+        scope[key] = val;
       });
-      can.batch.stop();
-      return init.call(this, arguments);
+
+      return new can.Map(_.extend({}, originalScope, scope));
     };
   };
 
@@ -97,11 +93,11 @@
    *
    * @param {String} val - Value we get from element attribute
    * @param {String} type - Type for the value we need to get
-   * @param {object} options - init function options
+   * @param {object} parentScope - Parent scope
    *
    * @return {Any} - Returns casted types
    */
-  Components._castValue = function (val, type, options) {
+  Components._castValue = function (val, type, parentScope) {
     var types = {
       'boolean': function (bool) {
         if (_.isBoolean(bool)) {
@@ -128,23 +124,24 @@
         }
         return num;
       },
-      'function': function (fn, options) {
-        if (!fn || !options.scope.attr(fn)) {
+      'function': function (fn) {
+        if (!fn || !parentScope.attr(fn)) {
           return;
         }
-        return options.scope.attr(fn);
+        return parentScope.attr(fn);
       }
     };
     if (!types[type]) {
       console.warn('Cast value for `' + type + '` is not defined');
       return undefined;
     }
+
     if (val &&
         type !== 'function' &&
-        options.scope.attr(val)) {
-      val = options.scope.attr(val);
+        parentScope.attr(val)) {
+      val = parentScope.attr(val);
     }
-    return types[type](val, options);
+    return types[type](val);
   };
 
   // the internal storage of the registered components


### PR DESCRIPTION
I found out that using `scope.attr` in init function propagates attribute to parent scope and causes problem. This should fix that issue.