### PR TITLE
ISSUE-1.200 Fix request start and end date

### DIFF
--- a/src/ggrc/assets/javascripts/components/datepicker/datepicker.js
+++ b/src/ggrc/assets/javascripts/components/datepicker/datepicker.js
@@ -80,8 +80,21 @@
         return moment(date, this.scope.pattern, true).isValid();
       },
       setDate: function (type, date) {
+        var types = {
+          minDate: function () {
+            date.add(1, 'day');
+          },
+          maxDate: function () {
+            date.subtract(1, 'day');
+          }
+        };
         date = this.getDate(date);
-        this.scope.picker.datepicker('option', type, date);
+        date = moment(date);
+
+        if (types[type]) {
+          types[type]();
+        }
+        this.scope.picker.datepicker('option', type, date.toDate());
       },
       '{scope} setMinDate': function (scope, ev, date) {
         this.setDate('minDate', date);

--- a/src/ggrc/assets/mustache/requests/modal_content.mustache
+++ b/src/ggrc/assets/mustache/requests/modal_content.mustache
@@ -68,16 +68,16 @@
       <div class="row-fluid">
         <div class="span6">
           <datepicker
-            set-min-date="report_end_date"
-            date="report_start_date"
+            set-max-date="end_date"
+            date="start_date"
             required="true"
             label="Starts On"
             />
         </div>
         <div class="span6">
           <datepicker
-            set-min-date="report_end_date"
-            date="report_start_date"
+            set-min-date="start_date"
+            date="end_date"
             required="true"
             label="Due On"
             />


### PR DESCRIPTION
*Subject:*
"Starts On" and "Due On" mandatory date pickers are not validated when creating a request

*Details:*
Start reating a Request under an audit

*Actual Result:*
the save buttons are active though mandatory "Starts On" and "Due On" date pickers aren’t filled in

*Expected Result:*
the save buttons should be inactive until all mandatory fields are filled in