### PR TITLE
QUICK-FIX Component should create its own map object

### DIFF
--- a/src/ggrc/assets/javascripts/plugins/component_registry.js
+++ b/src/ggrc/assets/javascripts/plugins/component_registry.js
@@ -84,7 +84,7 @@
         scope[key] = val;
       });
 
-      return new can.Map(_.extend({}, originalScope, scope));
+      return _.extend({}, originalScope, scope);
     };
   };
 


### PR DESCRIPTION
If we return new can.Map, can.compute doesn't get bind to the map object itself and it throws an error - this PR fixes this issue.