### PR TITLE
ISSUE-1.365 Reset entries and selected items in unified mapper

### DIFF
--- a/src/ggrc/assets/javascripts/components/unified_mapper/mapper.js
+++ b/src/ggrc/assets/javascripts/components/unified_mapper/mapper.js
@@ -185,6 +185,9 @@
 
     events: {
       inserted: function () {
+        this.scope.attr('mapper.selected').replace([]);
+        this.scope.attr('mapper.entries').replace([]);
+
         this.setModel();
         this.setBinding();
       },


### PR DESCRIPTION
*Subject:*
Extra Control mapped while creating and mapping a new Control via unified mapper window

*Details:*
- Create/Go to Audit
- Go to Control tab-> Map Control to this Audit: confirm that 1 object selected for mapping is displayed in Unified mapper window 
- Click Create New Control-> Fill the mandatory fields-> Save and Close: confirm that 2 objects selected for mapping is displayed in Unified mapper window
- Click [x] to Close Unified mapper window
- Open Unified mapper window to Map Control to this Audit once again
- Create New Control-> Fill the mandatory fields-> Save and Close: confirm that 3 objects selected for mapping is displayed in Unified mapper window 
- Click Map selected: extra Control mapped while creating and mapping a new Control

*Actual Result:* Extra Control mapped while creating and mapping a new Control via unified mapper window

*Expected Result:* Extra Control should not be mapped while creating and mapping a new Control via unified mapper window

*Workaround:* NA
