### PR TITLE
QUICK-FIX Correct check for undefined variable

### DIFF
--- a/src/ggrc/assets/javascripts/client_record_replay.js
+++ b/src/ggrc/assets/javascripts/client_record_replay.js
@@ -21,8 +21,8 @@
  */
 GGRC.RequestStore = function() {
   // From https://www.artandlogic.com/blog/2013/06/ajax-caching-transports-compatible-with-jquery-deferred/
-  var storage = (typeof(sessionStorage) == undefined) ?
-      (typeof(localStorage) == undefined) ? {
+  var storage = (typeof sessionStorage === 'undefined') ?
+      (typeof localStorage === 'undefined') ? {
           getItem: function(key){
               return this.store[key];
           },


### PR DESCRIPTION
The code was comparing the result of `typeof` with a variable named `undefined`.

As typeof returns a string it should compare to `'undefined'`