### PR TITLE
QUICK-FIX Re-enable the majority of frontend tests

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -19,8 +19,7 @@ module.exports = function (config) {
       'src/ggrc/static/dashboard-templates.js',
       'src/ggrc/static/dashboard.js',
       'src/ggrc/static/dashboard-spec-helpers.js',
-      // 'src/**/*_spec.js'
-      'src/ggrc/assets/javascripts/plugins/tests/component_registry_spec.js'
+      'src/**/*_spec.js'
     ],
 
     // list of files to exclude


### PR DESCRIPTION
This fixes a temporarily commented-out setting that slipped through in #4378