### PR TITLE
ISSUE-1.369 Workflow should redirect to setup tab after creation

### DIFF
--- a/src/ggrc_workflows/assets/javascripts/models/workflow.js
+++ b/src/ggrc_workflows/assets/javascripts/models/workflow.js
@@ -97,8 +97,8 @@
       dfd = this._super.apply(this, arguments);
       dfd.then(function (instance) {
         redirectLink = instance.viewLink + '#task_group_widget';
+        instance.attr('_redirect', redirectLink);
         if (!taskGroupTitle) {
-          instance.attr('_redirect', redirectLink);
           return instance;
         }
         taskGroup = new CMS.Models.TaskGroup({


### PR DESCRIPTION
Subject: The app doesn't redirect user to Setup tab after WF creation
Details: 
Create a WF via LHN
Actual Result:  The app doesn't redirect user to Setup tab after WF creation
Expected Result:  The app should redirect user to Setup tab after WF creation
Workaround: refresh the page