### PR TITLE
ISSUE-1.357 Do not set current date as default on import

### DIFF
--- a/src/ggrc/converters/handlers/handlers.py
+++ b/src/ggrc/converters/handlers/handlers.py
@@ -295,7 +295,7 @@ class DateColumnHandler(ColumnHandler):
       return
 
     try:
-      return parse(self.raw_value)
+      return parse(value) if value else None
     except:
       self.add_error(errors.WRONG_VALUE_ERROR, column_name=self.display_name)
 

--- a/src/ggrc/models/request.py
+++ b/src/ggrc/models/request.py
@@ -5,6 +5,8 @@
 
 # pylint: disable=fixme
 
+from datetime import date, timedelta
+
 from sqlalchemy import orm
 
 from ggrc import db
@@ -58,8 +60,19 @@ class Request(statusable.Statusable, AutoStatusChangeable, Assignable,
   request_type = deferred(db.Column(db.Enum(*VALID_TYPES), nullable=False),
                           'Request')
 
-  start_date = deferred(db.Column(db.Date, nullable=False), 'Request')
-  end_date = deferred(db.Column(db.Date, nullable=False), 'Request')
+  start_date = deferred(
+      db.Column(db.Date, nullable=False, default=date.today),
+      'Request'
+  )
+
+  end_date = deferred(
+      db.Column(
+          db.Date,
+          nullable=False,
+          default=lambda: date.today() + timedelta(7)
+      ),
+      'Request'
+  )
 
   # TODO Remove audit_id audit_object_id on database cleanup
   audit_id = db.Column(db.Integer, db.ForeignKey('audits.id'), nullable=False)

--- a/test/integration/ggrc/converters/test_csvs/request_with_warnings_and_errors.csv
+++ b/test/integration/ggrc/converters/test_csvs/request_with_warnings_and_errors.csv
@@ -14,13 +14,14 @@ be done only upon re-importing this csv", ,changed notes,In Progress,user1@a.com
 ,Request 10,Audit,Request title 6,"This works because the change is removing verifier, and state does not change",,,In Progress,user1@a.com,user2@a.com,,Interview,7/10/2015,5/20/2016,,,,
 ,Request 11,Audit,Request title 7,State can not transition back to open,,,In Progress,user1@a.com,user2@a.com,user@example.com,Interview,7/11/2015,5/21/2016,,,,
 ,Request 12,Audit,Request title 8,"State will be changed to in-progress, because of the updates to request.",,changes,In Progress,user1@a.com,user2@a.com,user@example.com,Interview,7/12/2015,5/22/2016,,,,
-,Request 17,Audit,Request title 1,"proj-55 does not exist
+,Request 16,Audit,Request title 1,"proj-55 does not exist
 non_existing@a.com does not exist ", --- already exists ---,notes 1,In Progress,"user1@a.com
 user2@a.com","user2@a.com
 user3@a.com","user3@a.com
 non_existing@a.com",docuMEntation,7/1/2015,5/11/2016,Test text 1,proj-55,mkt-1,
-,Request 18,Audit,Request title 2,Missing requested on date - will default to today,,notes 2,In Progress,user1@a.com,user2@a.com,user3@a.com,interviEW,,5/12/2016,Test text 2,proj-1,mkt-2,
-,Request 19,Audit,Request title 3,"Missing requested on and due on dates, default today",,notes 3,In Progress,user1@a.com,user2@a.com,user3@a.com,interviEW,,,Test text 3,,,
+,Request 17,Audit,Request title 2,Missing Due On date - will default to today + 7 days,,notes 2,In Progress,user1@a.com,user2@a.com,user3@a.com,interviEW,5/11/2016,,Test text 2,proj-1,mkt-2,
+,Request 18,Audit,Request title 2,Missing Starts On on date - will default to today,,notes 2,In Progress,user1@a.com,user2@a.com,user3@a.com,interviEW,,5/12/2016,Test text 2,proj-1,mkt-2,
+,Request 19,Audit,Request title 3,"Missing Starts On on and Due On dates, default today / today + 7 days",,notes 3,In Progress,user1@a.com,user2@a.com,user3@a.com,interviEW,,,Test text 3,,,
 ,Request 20,Audit,Request title 4,Missing request type - will take default , --- already exists ---,notes 4,In Progress,user1@a.com,user2@a.com,user3@a.com,,7/4/2015,5/14/2016,Test text 4,,,
 ,Request 21,not existing,Request title 5,Not existing audit does not exist, --- already exists ---,notes 5,In Progress,user1@a.com,user2@a.com,user3@a.com,interviEW,7/5/2015,5/15/2016,Test text 5,,,
 ,Request 22,Audit,same title no warning,"Can not set a state of a new request to verified or finished, because adding a new 

--- a/test/unit/ggrc/converters/handlers/test_date_column_handler.py
+++ b/test/unit/ggrc/converters/handlers/test_date_column_handler.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2016 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Tests for the DateColumnHandler class"""
+
+import unittest
+from mock import MagicMock
+
+from ggrc.converters.handlers.handlers import DateColumnHandler
+
+
+class DateColumnHandlerTestCase(unittest.TestCase):
+  """Base class for DateColumnHandler tests"""
+  def setUp(self):
+    row_converter = MagicMock(name=u"row_converter")
+    key = u"field_foo"
+    self.handler = DateColumnHandler(row_converter, key)
+
+
+class ParseItemTestCase(DateColumnHandlerTestCase):
+  """Tests for the parse_item() method"""
+  # pylint: disable=invalid-name
+
+  def test_returns_none_for_empty_strings(self):
+    """The method should return None if given an empty string."""
+    self.handler.raw_value = u""
+    result = self.handler.parse_item()
+    self.assertIsNone(result)
+
+  def test_returns_none_for_whitespace_only_strings(self):
+    """The method should return None if given a whitespace-only string."""
+    self.handler.raw_value = u" \t\n  \n\t \r\n \t  "
+    result = self.handler.parse_item()
+    self.assertIsNone(result)


### PR DESCRIPTION
_(section 2, issue 1.357  - P1)_

This PR changes the way the empty dates are interpreted by default on import (no longer converted to the current date) in  order to make them consistent with the Assessment add/edit modal.

It does, on the other hand, set default values for the required date fields on the `Request` model. As per an offline discussion, setting them independently from each other is fine, even though the result might not be what the user might expect - but that is considered a user error, and it is his/her responsibility to provide values for those required fields in the first place.

**Details:**
 - Create assessment
 - Export it to CSV file
 - Ensure that Due On date is empty
 - Import CSV file

**Actual Result:**
Finished, Verified, Due On dates are populated with current date

**Expected Result:**
Empty dates are NOT populated with current date