### PR TITLE
QUICK-FIX Assessment's state "Complete" isn't shown in info panel

### DIFF
--- a/src/ggrc/assets/mustache/assessments/header.mustache
+++ b/src/ggrc/assets/mustache/assessments/header.mustache
@@ -9,15 +9,13 @@ Copyright (C) 2016 Google Inc.
             <h6>title</h6>
             <div class="pane-header__title">
                 <h3>{{title}}</h3>
-              {{^if_in instance.status 'Verified, Completed'}}
                   <span class="state-value">{{status}}</span>
-              {{/if_in}}
-              {{#if verified}}
-                  <i class="fa fa-check-circle green"
-                     rel="tooltip"
-                     title="Verified on {{localize_date verified_date}}">
-                  </i>
-              {{/if}}
+                  {{#if verified}}
+                    <i class="fa fa-check-circle green"
+                      rel="tooltip"
+                      title="Verified on {{localize_date verified_date}}">
+                    </i>
+                  {{/if}}
             </div>
         </div>
         <div class="span3">


### PR DESCRIPTION
1.353  Bug (P1)
Subject: Assessment's state "Complete" isn't shown in info panel
Details: 
Log in as auditor and navigate to an audit page with assessments
Assessment shouldn’t have Verifiers
Complete the assessment clicking “complete” button
Actual Result: Assessment's state "Complete" isn't shown in info panel
Expected Result: Assessment's state "Complete" should be shown in info panel