### PR TITLE
QUICK-FIX GR is able to Add comment without PE role in Assessment's Info panel

### DIFF
--- a/src/ggrc/assets/mustache/components/ca-object/ca-object-title.mustache
+++ b/src/ggrc/assets/mustache/components/ca-object/ca-object-title.mustache
@@ -6,7 +6,9 @@
     <span class="inline-edit__title-body">{{titleText}}
       {{#def.helptext}}<i class="fa fa-question-circle" rel="tooltip" title="{{def.helptext}}"></i>{{/def.helptext}}
       </span>
-    <span class="inline-edit__extra-controls">
-      {{#value}}<i can-click="addComment" class="fa fa-edit" rel="tooltip" title="Add comment"></i>{{/value}}
-    </span>
+      {{#is_allowed 'update' instance context='for'}}
+        <span class="inline-edit__extra-controls">
+          {{#value}}<i can-click="addComment" class="fa fa-edit" rel="tooltip" title="Add comment"></i>{{/value}}
+        </span>
+      {{/is_allowed}}
 </h6>

--- a/src/ggrc/assets/mustache/components/ca-object/ca-object.mustache
+++ b/src/ggrc/assets/mustache/components/ca-object/ca-object.mustache
@@ -2,5 +2,5 @@
     Copyright (C) 2016 Google Inc.
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
-<ca-object-title title-text="def.title"></ca-object-title>
+<ca-object-title title-text="def.title" instance="instance"></ca-object-title>
 <content></content>


### PR DESCRIPTION
1.344  Bug (P1) 
Subject: GR is able to Add comment without PE role in Assessment's Info panel  
Details:  
Create a program
Create an audit>Navigate to audit tab
Create Assessment with CA fields
Log as Global Reader
Open the created Assessment
Navigate to Assessment’s Info panel-> Add comment into CA field: pop up window is displayed for adding a comment
Actual Result:  GR is able to Add comment without PE role in Assessment's Info panel  
Expected Result: GR is not able to Add comment without PE role in Assessment's Info panel  