### PR TITLE
ISSUE-1.26 Dynamically check for related verifiers

### DIFF
--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -3506,6 +3506,42 @@ Mustache.registerHelper("pretty_role_name", function (name) {
   return name;
 });
 
+   /**
+   * Check if provided user is current user
+   *
+   * Example usage:
+   *
+   *   {{#if_current_user person}}
+   *     ...
+   *   {{/if_current_user}}
+   *
+   * or:
+   *
+   *   {{#if_current_user email}}
+   *     ...
+   *   {{/if_current_user}}
+   *
+   * @param {Object|String} person - Person object or email
+   * @param {Object} options - a CanJS options argument passed to every helper
+   *
+   */
+  Mustache.registerHelper('if_current_user', function (person, options) {
+    var email;
+    person = Mustache.resolve(person);
+
+    if (_.isString(person)) {
+      email = person;
+    } else if (person && person.email) {
+      email = person.email;
+    } else {
+      console.warn('You should pass in either email or person object');
+    }
+
+    if (GGRC.current_user.email === email) {
+      return options.fn(options.context);
+    }
+    return options.inverse();
+  });
 
 /*
 Add new variables to current scope. This is useful for passing variables

--- a/src/ggrc/assets/js_specs/mustache_helpers/if_current_user_spec.js
+++ b/src/ggrc/assets/js_specs/mustache_helpers/if_current_user_spec.js
@@ -1,0 +1,92 @@
+/*!
+  Copyright (C) 2016 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+describe('can.mustache.helper.if_current_user', function () {
+  'use strict';
+
+  var fakeOptions;  // fake mustache options object passed to the helper
+  var helper;
+  var person;
+  var originalUser;
+
+  beforeAll(function () {
+    originalUser = GGRC.current_user;
+    person = new CMS.Models.Person({
+      name: 'Ivan',
+      email: 'ivan@example.com',
+      type: 'Person',
+      id: 42
+    });
+    GGRC.current_user = person;
+    helper = can.Mustache._helpers.if_current_user.fn;
+  });
+
+  afterAll(function () {
+    GGRC.current_user = originalUser;
+  });
+
+  beforeEach(function () {
+    fakeOptions = {
+      fn: jasmine.createSpy(),
+      inverse: jasmine.createSpy(),
+      context: {}
+    };
+  });
+
+  it('triggers rendering of the "truthy" block for value person string',
+    function () {
+      helper('ivan@example.com', fakeOptions);
+
+      expect(fakeOptions.fn.calls.count()).toEqual(1);
+    });
+
+  it('triggers rendering of the "falsy" block for invalid person string',
+    function () {
+      helper('john@example.com', fakeOptions);
+
+      expect(fakeOptions.inverse.calls.count()).toEqual(1);
+    });
+
+  it('triggers rendering of the "truthy" block for person object',
+    function () {
+      helper(person, fakeOptions);
+
+      expect(fakeOptions.fn.calls.count()).toEqual(1);
+    });
+
+  it('triggers rendering of the "falsy" block for empty string',
+    function () {
+      helper('', fakeOptions);
+
+      expect(fakeOptions.inverse.calls.count()).toEqual(1);
+    });
+
+  it('triggers rendering of the "falsy" block for empty object',
+    function () {
+      spyOn(console, 'warn');
+      helper({}, fakeOptions);
+
+      expect(fakeOptions.inverse.calls.count()).toEqual(1);
+      expect(console.warn).toHaveBeenCalled();
+    });
+
+  it('triggers rendering of the "falsy" block for undefined',
+    function () {
+      spyOn(console, 'warn');
+      helper(undefined, fakeOptions);
+
+      expect(fakeOptions.inverse.calls.count()).toEqual(1);
+      expect(console.warn).toHaveBeenCalled();
+    });
+
+  it('triggers rendering of the "falsy" block for null',
+    function () {
+      spyOn(console, 'warn');
+      helper(null, fakeOptions);
+
+      expect(fakeOptions.inverse.calls.count()).toEqual(1);
+      expect(console.warn).toHaveBeenCalled();
+    });
+});

--- a/src/ggrc/assets/mustache/mixins/stateful.mustache
+++ b/src/ggrc/assets/mustache/mixins/stateful.mustache
@@ -30,27 +30,29 @@
   {{/if_in}}
 
   {{#if_equals instance.status "Ready for Review"}}
-      {{#if_null instance._mandatory_msg}}
-          {{#if_verifier instance}}
-              <button class="btn btn-small btn-success pull-right btn-info-pin-header {{instance._disabled}}"
-                      data-name="status"
-                      data-value="Verified">Verify</button>
-              <button class="btn btn-small btn-danger pull-right btn-info-pin-header {{instance._disabled}}"
-                      data-name="status"
-                      data-value="In Progress">Reject</button>
-          {{/if_verifier}}
-      {{else}}
-          {{#if_verifier instance}}
-              <button class="btn btn-small btn-success pull-right btn-info-pin-header disabled"
-                      data-name="status"
-                      data-value="Verified"
-                      title="{{instance._mandatory_msg}}">Verify</button>
-              <button class="btn btn-small btn-danger pull-right btn-info-pin-header disabled"
-                      data-name="status"
-                      data-value="In Progress"
-                      title="{{instance._mandatory_msg}}">Reject</button>
-          {{/if_verifier}}
-      {{/if_null}}
+    {{#with_mapping 'related_verifiers' instance}}
+      {{#results}}
+        {{#if_current_user instance}}
+          {{#if_null instance._mandatory_msg}}
+            <button class="btn btn-small btn-success pull-right btn-info-pin-header {{instance._disabled}}"
+                    data-name="status"
+                    data-value="Verified">Verify</button>
+            <button class="btn btn-small btn-danger pull-right btn-info-pin-header {{instance._disabled}}"
+                    data-name="status"
+                    data-value="In Progress">Reject</button>
+          {{else}}
+            <button class="btn btn-small btn-success pull-right btn-info-pin-header disabled"
+                    data-name="status"
+                    data-value="Verified"
+                    title="{{instance._mandatory_msg}}">Verify</button>
+            <button class="btn btn-small btn-danger pull-right btn-info-pin-header disabled"
+                    data-name="status"
+                    data-value="In Progress"
+                    title="{{instance._mandatory_msg}}">Reject</button>
+          {{/if_null}}
+        {{/if_current_user}}
+      {{/results}}
+    {{/with_mapping}}
   {{/if_equals}}
 
     {{#instance._undo.0}}


### PR DESCRIPTION
Subject: Verifier doesn't see "Reject" / "Verify" buttons if he just added himself a verifier role under an Assessment
Details: 
Create an Assessments and make yourself an Assessor
Assign another user as the verifier
Click complete button
Now add yourself to the verifiers
Actual Result: "Reject" / "Verify" buttons aren’t visible immediately
Expected Result: "Reject" / "Verify" buttons should appear right after user became a verifier
Workaround: N/A
Screenshot: N/A