### PR TITLE
ISSUE-1.374 Remove fileable deferred

### DIFF
--- a/src/ggrc_gdrive_integration/assets/javascripts/components/gdrive_picker_launcher.js
+++ b/src/ggrc_gdrive_integration/assets/javascripts/components/gdrive_picker_launcher.js
@@ -270,19 +270,7 @@
                 }).save();
               }
 
-              return $.when(
-                objectDoc
-              ).then(function (ofs) {
-                if (ofs.length < 1) {
-                  if (that.deferred) {
-                    doc.mark_for_addition('files', file, {
-                      context: that.instance.context || {id: null}
-                    });
-                  }
-                }})
-              .then(function () {
-                return doc;
-              });
+              return objectDoc;
             });
             return dfdDoc;
           });


### PR DESCRIPTION
Subject: Script error "Uncaught TypeError: Cannot read property 'length' of undefined" appears when adding a comment with the attachment under a request https://grc-test.appspot.com/admin/unstarted_cycles url

Details: 
Navigate to request tab on audit page
Open request’s info panel
Add a comment with attachment

Actual Result: script error appears upon adding a comment

Expected Result: No error displayed. 


This is a leftover from #4309 and #4365 