### PR TITLE
QUICK-FIX Assessment Log tabs hangs in case of incorrect related persons data 

### DIFF
--- a/src/ggrc/assets/javascripts/components/object_history/object_history.js
+++ b/src/ggrc/assets/javascripts/components/object_history/object_history.js
@@ -521,7 +521,8 @@
 
       perPersonMappings = _(mappings)
         .filter(function (rev) {
-          if (rev.source_type === 'Person' || rev.destination_type === 'Person') {
+          if (rev.source_type === 'Person' ||
+            rev.destination_type === 'Person') {
             return rev;
           }
         })
@@ -535,7 +536,8 @@
       perPersonRoleHistory = _.zipObject(
         _.map(perPersonMappings, function (revisions, pid) {
           var history = _.map(revisions, function (rev) {
-            if (rev.action === 'deleted') {
+            // Add extra check to fix possible issue with inconsistent data
+            if (rev.action === 'deleted' || !rev.content.attrs.AssigneeType) {
               return {
                 updated_at: rev.updated_at,
                 role: 'none'

--- a/src/ggrc/assets/javascripts/components/object_history/tests/object_history_spec.js
+++ b/src/ggrc/assets/javascripts/components/object_history/tests/object_history_spec.js
@@ -777,6 +777,34 @@ describe('GGRC.Components.objectHistory', function () {
   describe('_computeRoleChanges method', function () {
     var componentInst;  // fake component instance
     var method;  // the method under test
+    var corruptedRevision = new can.Map({
+      object: new can.List([
+        {
+          id: 10,
+          modified_by: {
+            id: 166
+          }
+        }
+      ]),
+      mappings: new can.List([
+        {
+          id: 1,
+          modified_by: {
+            id: 166
+          },
+          action: 'created',
+          source_type: 'Person',
+          source_id: 166,
+          destination_type: 'ObjectFoo',
+          destination_id: 123,
+          updated_at: new Date(2016, 0, 1),
+          type: 'Revision',
+          content: {
+            attrs: {}
+          }
+        }
+      ])
+    });
     var revisions = new can.Map({
       object: new can.List([
         {
@@ -968,6 +996,20 @@ describe('GGRC.Components.objectHistory', function () {
           },
           {
             updated_at: new Date(2016, 0, 5),
+            role: 'none'
+          }
+        ]
+      });
+    });
+
+    it('builds correct history when data is corrupted', function () {
+      var roleHistory;
+
+      roleHistory = method(corruptedRevision);
+      expect(roleHistory).toEqual({
+        '166': [
+          {
+            updated_at: new Date(2016, 0, 1),
             role: 'none'
           }
         ]


### PR DESCRIPTION
This issue can be reproduced on dev: [assessment](http://localhost:8080/audits/1477#assessment_widget/assessment/13639)