### PR TITLE
ISSUE-1.345 Display mandatory notification if no files attached

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment/attachments-list.js
+++ b/src/ggrc/assets/javascripts/components/assessment/attachments-list.js
@@ -19,6 +19,18 @@
     scope: {
       instance: null
     },
+    helpers: {
+      showNotification: function (options) {
+        var instance = this.instance;
+        var binding = instance.class.info_pane_options.evidence.mapping;
+        var mapping = instance.get_mapping(binding);
+
+        if (instance._mandatory_attachment_msg &&
+            mapping.length < instance._mandatory_attachment_count) {
+          return options.fn(options.contexts);
+        }
+        return options.inverse();
+      }
     }
   });
 })(window.GGRC, window.can);

--- a/src/ggrc/assets/javascripts/components/assessment/attachments-list.js
+++ b/src/ggrc/assets/javascripts/components/assessment/attachments-list.js
@@ -16,9 +16,9 @@
   GGRC.Components('assessmentAttachmentsList', {
     tag: tag,
     template: template,
-    scope: {},
-    events: {
-      init: function () {}
+    scope: {
+      instance: null
+    },
     }
   });
 })(window.GGRC, window.can);

--- a/src/ggrc/assets/javascripts/components/ca-object/ca-object-modal-content.js
+++ b/src/ggrc/assets/javascripts/components/ca-object/ca-object-modal-content.js
@@ -23,7 +23,7 @@
     },
     helpers: {
       renderFieldValue: function (value) {
-        value = value();
+        value = Mustache.resolve(value);
         return value || '<span class="empty-message">None</span>';
       }
     }

--- a/src/ggrc/assets/javascripts/components/ca-object/ca-object-modal-content.js
+++ b/src/ggrc/assets/javascripts/components/ca-object/ca-object-modal-content.js
@@ -13,6 +13,7 @@
     tag: 'ca-object-modal-content',
     template: tpl,
     scope: {
+      instance: null,
       content: {
         title: null,
         value: null,

--- a/src/ggrc/assets/javascripts/models/assessment.js
+++ b/src/ggrc/assets/javascripts/models/assessment.js
@@ -237,12 +237,15 @@
       } else {
         this.removeAttr('_mandatory_comment_msg');
       }
-
       if (needed.attachment.length) {
-        this.attr('_mandatory_attachment_msg',
-          'Evidence required by: ' + needed.attachment.join(', '));
+        this.attr({
+          _mandatory_attachment_msg: 'Evidence required by: ' +
+            needed.attachment.join(', '),
+          _mandatory_attachment_count: needed.attachment.length
+        });
       } else {
         this.removeAttr('_mandatory_attachment_msg');
+        this.removeAttr('_mandatory_attachment_count');
       }
 
       if (needed.value.length) {

--- a/src/ggrc/assets/mustache/assessments/info.mustache
+++ b/src/ggrc/assets/mustache/assessments/info.mustache
@@ -32,7 +32,7 @@
                                                       class="assessment-custom-attributes">
                         </assessment-custom-attributes>
                         <div class="assessment-controls__extra-controls">
-                            <assessment-attachments-list class="attachment-list"></assessment-attachments-list>
+                            <assessment-attachments-list instance='instance' class="attachment-list" />
                             <assessment-urls-list></assessment-urls-list>
                         </div>
                         <assessment-controls-toolbar class="assessment-controls-toolbar"

--- a/src/ggrc/assets/mustache/components/assessment/attachments-list.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/attachments-list.mustache
@@ -7,12 +7,12 @@
   {{#is_allowed 'update' instance context='for'}}
     {{{render_hooks "Request.gdrive_evidence_storage"}}}
   {{/is_allowed}}
-{{^if_null instance._mandatory_attachment_msg}}
+{{#showNotification}}
   <div class="alert alert-info alert-dismissible" role="alert">
     {{instance._mandatory_attachment_msg}}
     <button type="button" class="close" data-dismiss="alert" aria-label="Close">&times;</button>
   </div>
-{{/if_null}}
+{{/showNotification}}
 <mapping-tree-view
   parent-instance="instance"
   mapping="instance.class.info_pane_options.evidence.mapping"

--- a/src/ggrc/assets/mustache/components/ca-object/ca-object-modal-content.mustache
+++ b/src/ggrc/assets/mustache/components/ca-object/ca-object-modal-content.mustache
@@ -18,8 +18,7 @@
           <assessment-add-comment instance="instance" state="state" ca-ids="caIds" comment-place-holder="Enter comment"></assessment-add-comment>
       {{/comment}}
       {{#evidence}}
-          <assessment-attachments-list class="attachment-list" source_mapping="instance"
-                                       parent_instance="instance"></assessment-attachments-list>
+          <assessment-attachments-list class="attachment-list" />
       {{/evidence}}
     </div>
 </form>

--- a/src/ggrc/assets/mustache/components/ca-object/ca-object-modal-content.mustache
+++ b/src/ggrc/assets/mustache/components/ca-object/ca-object-modal-content.mustache
@@ -18,6 +18,7 @@
       <assessment-add-comment instance="instance" state="state" ca-ids="caIds" comment-place-holder="Enter comment"></assessment-add-comment>
     {{/comment}}
     {{#evidence}}
+      <assessment-attachments-list instance="instance" class="attachment-list" />
     {{/evidence}}
   </div>
 </form>

--- a/src/ggrc/assets/mustache/components/ca-object/ca-object-modal-content.mustache
+++ b/src/ggrc/assets/mustache/components/ca-object/ca-object-modal-content.mustache
@@ -3,22 +3,21 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
 <form class="modal-body attachment-modal__body">
-    <div class="attachment-modal__field">
-        <h6 class="attachment-modal__field-title">{{content.title}}</h6>
-        <div class="attachment-modal__field-value">
-          {{#if isPerson}}
-              <person-info person-obj="content.value"></person-info>
-          {{else}}
-              <read-more text="content.value"></read-more>
-          {{/if}}
-        </div>
+  <div class="attachment-modal__field">
+    <h6 class="attachment-modal__field-title">{{content.title}}</h6>
+    <div class="attachment-modal__field-value">
+      {{#if isPerson}}
+        <person-info person-obj="content.value"></person-info>
+      {{else}}
+        <read-more text="content.value"></read-more>
+      {{/if}}
     </div>
-    <div class="attachment-modal__controls">
-      {{#comment}}
-          <assessment-add-comment instance="instance" state="state" ca-ids="caIds" comment-place-holder="Enter comment"></assessment-add-comment>
-      {{/comment}}
-      {{#evidence}}
-          <assessment-attachments-list class="attachment-list" />
-      {{/evidence}}
-    </div>
+  </div>
+  <div class="attachment-modal__controls">
+    {{#comment}}
+      <assessment-add-comment instance="instance" state="state" ca-ids="caIds" comment-place-holder="Enter comment"></assessment-add-comment>
+    {{/comment}}
+    {{#evidence}}
+    {{/evidence}}
+  </div>
 </form>

--- a/src/ggrc/assets/mustache/components/ca-object/ca-object-modal.mustache
+++ b/src/ggrc/assets/mustache/components/ca-object/ca-object-modal.mustache
@@ -9,7 +9,7 @@
             <i class="fa fa-times black"></i>
         </a>
     </div>
-    <ca-object-modal-content content="modal.content" ca-ids="modal.caIds"></ca-object-modal-content>
+    <ca-object-modal-content instance='instance' content="modal.content" ca-ids="modal.caIds"></ca-object-modal-content>
     <div class="modal-footer">
         <div class="row-fluid">
             <div class="confirm-buttons">


### PR DESCRIPTION
Subject: "Evidence required by" message is displayed after uploading evidence in pop up window in Assessment's Info panel  
Details:  
Create a program
Create an audit>Navigate to audit tab
Create Assessment with CA dropdown field (e.g. “Comment and Evidence”)
Navigate to Assessment’s Info panel-> Select the value “Comment and Evidence” in CA dropdown field
Add comment
Click Attach evidence button to upload a file: confirm "Evidence required by" message is displayed after uploading evidence
Actual Result:  "Evidence required by" message is displayed after uploading evidence in pop up window in Assessment's Info panel   
Expected Result: "Evidence required by" message is not displayed after uploading evidence in pop up window in Assessment's Info panel   