### PR TITLE
ISSUE-1.99: Assign assignee to cloned WF TG

### DIFF
--- a/src/ggrc_workflows/models/task_group.py
+++ b/src/ggrc_workflows/models/task_group.py
@@ -7,6 +7,7 @@
 from sqlalchemy import or_
 
 from ggrc import db
+from ggrc.login import get_current_user
 from ggrc.models.associationproxy import association_proxy
 from ggrc.models.mixins import (
     Titled, Slugged, Described, Timeboxed, WithContact
@@ -86,8 +87,10 @@ class TaskGroup(
         'context'
     ]
 
-    if kwargs.get('clone_people', False):
-      columns.append('contact')
+    if kwargs.get('clone_people', False) and getattr(self, "contact"):
+      columns.append("contact")
+    else:
+      kwargs["contact"] = get_current_user()
 
     target = self.copy_into(_other, columns, **kwargs)
 

--- a/test/unit/ggrc_workflows/models/test_task_group.py
+++ b/test/unit/ggrc_workflows/models/test_task_group.py
@@ -1,0 +1,79 @@
+# Copyright (C) 2016 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""A module with unit tests for the Task Group model."""
+
+import unittest
+from mock import MagicMock, patch
+
+from ggrc_workflows.models import task_group
+
+
+class TestTaskGroupTask(unittest.TestCase):
+  """Consists of Task Group model unittests."""
+
+  def setUp(self):
+    """Setup Task Group model tests.
+    :return: None
+    """
+    task_group.db = MagicMock()
+
+  # pylint: disable=invalid-name
+  def test_copy_when_clone_people_is_true_and_contact_is_not_none(self):
+    """ Test copy() method with next parameters:
+    clone_people: True
+    self.contact: not None
+    :return: None
+    """
+    taskgroup = task_group.TaskGroup()
+    taskgroup.contact = 'Person id=0x0000AABBCCDDEEFF'
+    result = taskgroup.copy(clone_people=True)
+    self.assertEqual(result.contact, taskgroup.contact)
+
+  @patch("ggrc_workflows.models.task_group.get_current_user",
+         return_value="Current user person id=0x0011223344556677")
+  # pylint: disable=invalid-name
+  def test_copy_when_clone_people_is_false_and_contact_is_not_none(
+      self, get_current_user,
+  ):
+    """ Test copy() method with next parameters:
+        clone_people: False
+        self.contact: not None
+        :return: None
+        """
+    taskgroup = task_group.TaskGroup()
+    taskgroup.contact = 'Person id=0x0000AABBCCDDEEFF'
+    result = taskgroup.copy(clone_people=False)
+    self.assertEqual(result.contact, get_current_user())
+
+  @patch("ggrc_workflows.models.task_group.get_current_user",
+         return_value="Current user person id=0x0011223344556677")
+  # pylint: disable=invalid-name
+  def test_copy_when_clone_people_is_true_and_contact_is_none(
+      self, get_current_user
+  ):
+    """ Test copy() method with next parameters:
+        clone_people: True
+        self.contact: None
+        :return: None
+        """
+    taskgroup = task_group.TaskGroup()
+    taskgroup.contact = None
+    result = taskgroup.copy(clone_people=True)
+    self.assertEqual(result.contact, get_current_user())
+
+  @patch("ggrc_workflows.models.task_group.get_current_user",
+         return_value="Current user person id=0x0011223344556677")
+  # pylint: disable=invalid-name
+  def test_copy_when_clone_people_is_false_and_contact_is_none(
+      self, get_current_user
+  ):
+    """ Test copy() method with next parameters:
+        clone_people: False
+        self.contact: None
+        :return: None
+        """
+    taskgroup = task_group.TaskGroup()
+    taskgroup.contact = None
+    result = taskgroup.copy(clone_people=False)
+    self.assertEqual(result.contact, get_current_user())


### PR DESCRIPTION
**Bug 1.99:** Cloned WF TG doesn't have assignee assigned after cloning
**Details:**
•	Create a WF with the task group (TG)
•	Click 3bbs button in TG’s info panel
•	Select clone
•	Uncheck “Also clone the People in this Task Group”
•	Click “Proceed”
**Actual Result:** the task group is created without an assignee.
**Expected Result:**  the task groups should be cloned with WF manager as assignee
**Workaround:** n/a
