### PR TITLE
Improve page load performance

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/dashboard_widgets_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/dashboard_widgets_controller.js
@@ -66,7 +66,6 @@ CMS.Controllers.Filterable("CMS.Controllers.DashboardWidgets", {
   , draw_widget : function(frag, prefs) {
 
     this.element.html(frag[0]);
-    this.element.trigger("widgets_updated", this.element);
 
     var content = this.element
       , controller_content = null;


### PR DESCRIPTION
There is no reason to trigger widgets_updated event in the draw_widget
function. This improves performance of the initial page load by 10s in
some cases.

Regulation page load time BEFORE:
![screen shot 2016-09-15 at 02 02 12](https://cloud.githubusercontent.com/assets/513444/18534155/a494c6aa-7ae8-11e6-852a-30ae8a236a67.png)

Regulation page load time AFTER:
![screen shot 2016-09-15 at 02 00 47](https://cloud.githubusercontent.com/assets/513444/18534160/adee0658-7ae8-11e6-9aa5-b1722a173b23.png)

