### PR TITLE
ISSUE-1.372 Change exported checkbox CA values format

### DIFF
--- a/src/ggrc/converters/handlers/custom_attribute.py
+++ b/src/ggrc/converters/handlers/custom_attribute.py
@@ -57,12 +57,19 @@ class CustomAttributeColumHandler(handlers.TextColumnHandler):
     definition = self.get_ca_definition()
     if not definition:
       return ""
+
     for value in self.row_converter.obj.custom_attribute_values:
       if value.custom_attribute_id == definition.id:
         if value.custom_attribute.attribute_type.startswith("Map:"):
           obj = value.attribute_object
           return getattr(obj, "email", getattr(obj, "slug", None))
+        elif value.custom_attribute.attribute_type == _types.CHECKBOX:
+          attr_val = value.attribute_value if value.attribute_value else u"0"
+          attr_val = int(attr_val)
+          return str(bool(attr_val)).upper()
+
         return value.attribute_value
+
     return None
 
   def _get_or_create_ca(self):

--- a/test/unit/ggrc/converters/handlers/__init__.py
+++ b/test/unit/ggrc/converters/handlers/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2016 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>

--- a/test/unit/ggrc/converters/handlers/test_custom_attribute.py
+++ b/test/unit/ggrc/converters/handlers/test_custom_attribute.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2016 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Tests for the CustomAttributeColumHandler class"""
+
+import unittest
+
+from mock import MagicMock, patch
+
+from ggrc.converters.handlers.custom_attribute import (
+    CustomAttributeColumHandler
+)
+from ggrc.models import CustomAttributeDefinition
+
+
+CA_TYPES = CustomAttributeDefinition.ValidTypes  # pylint: disable=invalid-name
+
+
+class CustomAttributeColumHandlerTestCase(unittest.TestCase):
+  """Base class for CustomAttributeColumHandler tests"""
+  def setUp(self):
+    row_converter = MagicMock(name=u"row_converter")
+    key = u"a_checkbox_field"
+    self.handler = CustomAttributeColumHandler(row_converter, key)
+
+
+@patch.object(CustomAttributeColumHandler, u"get_ca_definition")
+class GetValueTestCase(CustomAttributeColumHandlerTestCase):
+  """Tests for the get_value() method"""
+  # pylint: disable=invalid-name
+
+  def setUp(self):
+    super(GetValueTestCase, self).setUp()
+    self.handler.row_converter.obj.custom_attribute_values = []
+
+  @staticmethod
+  def _ca_value_factory(id_, type_, value):
+    """Create a mocked custom attribute value object"""
+    mock_config = {
+        u"custom_attribute_id": id_,
+        u"custom_attribute.attribute_type": type_,
+        u"attribute_object": MagicMock(name=u"attribute_object"),
+        u"attribute_value": value,
+    }
+    return MagicMock(**mock_config)
+
+  def test_returns_string_true_for_truthy_checkbox(self, get_ca_definition):
+    """The method should return "TRUE" for checked checkbox CAs."""
+    get_ca_definition.return_value = MagicMock(id=117)
+
+    ca_value = self._ca_value_factory(
+        id_=117, type_=CA_TYPES.CHECKBOX, value=u"1")
+    self.handler.row_converter.obj.custom_attribute_values.append(ca_value)
+
+    result = self.handler.get_value()
+    self.assertEqual(result, u"TRUE")
+
+  def test_returns_string_false_for_falsy_checkbox(self, get_ca_definition):
+    """The method should return "FALSE" for unchecked checkbox CAs."""
+    get_ca_definition.return_value = MagicMock(id=117)
+
+    ca_value = self._ca_value_factory(
+        id_=117, type_=CA_TYPES.CHECKBOX, value=u"0")
+    self.handler.row_converter.obj.custom_attribute_values.append(ca_value)
+
+    result = self.handler.get_value()
+    self.assertEqual(result, u"FALSE")
+
+  def test_returns_string_false_for_missing_checkbox_value(
+      self, get_ca_definition
+  ):
+    """The method should return "FALSE" for checkbox CAs with no value."""
+    get_ca_definition.return_value = MagicMock(id=117)
+
+    ca_value = self._ca_value_factory(
+        id_=117, type_=CA_TYPES.CHECKBOX, value=None)
+    self.handler.row_converter.obj.custom_attribute_values.append(ca_value)
+
+    result = self.handler.get_value()
+    self.assertEqual(result, u"FALSE")


### PR DESCRIPTION
_(section 2, issue 1.372 - P1)_

This PR assures that exporting and re-importing the same object works as expected. It changes the format of the exported values for checkbox custom attributes to match what the import expects (literal strings 
_"FALSE"_ and _"TRUE"_ instead of numeric `0` and `1`, respectively).


**Steps to reproduce:**
- Navigate to export page and export an Assessment with checkbox CA
- During the export, the checked checkbox CAs are exported with a value 1
- Try to import the same CSV file

**Actual Result:**
the import expects a string TRUE, thus ignoring the record previously exported.

**Expected Result:**
The import should either support few values (eg True, 1, yes etc) and clearly specified to the user in the column title cell or there should be only one allowed value (eg True) which should be also specified in csv file.