### PR TITLE
ISSUE-1.366 Fix URL to attached evidence files

### DIFF
--- a/src/ggrc/assets/mustache/base_templates/attachment.mustache
+++ b/src/ggrc/assets/mustache/base_templates/attachment.mustache
@@ -23,7 +23,7 @@
     {{^if reusable}}
     <span class="date">{{date instance.created_at true}}</span>
     {{/if}}
-    <a href="{{schemed_url instance.link}}" href="{{schemed_url instance.link}}" target="_blank">
+    <a href="{{schemed_url instance.link}}" target="_blank">
       <span>{{firstnonempty instance.title instance.link}}</span>
     </a>
 


### PR DESCRIPTION
_(section 2, issue 1.366 - P1)_

This PR fixes links to attached evidence files.

**Steps to reproduce:**
- Attach an evidence to a Request via import (NOTE: simply uploading the evidence through the application seems to work as well)
- open Request info panel on Audit page
- Click the evidence link

**Actual Result:**
the browser cannot reach the evidence file because file address is duplicated (see the screenshot)

**Expected Result:**
the link to the file should be correct