### PR TITLE
IMPROVEMENT Add Spinner on Loading of Related Requests   

### DIFF
--- a/src/ggrc/assets/javascripts/components/mapped-objects/mapped-objects.js
+++ b/src/ggrc/assets/javascripts/components/mapped-objects/mapped-objects.js
@@ -16,13 +16,16 @@
     tag: tag,
     template: tpl,
     scope: {
+      isLoading: false,
       mapping: '@',
       parentInstance: null,
       mappedItems: [],
       setMappedObjects: function (items) {
+        this.attr('isLoading', false);
         this.attr('mappedItems').replace(items);
       },
       load: function () {
+        this.attr('isLoading', true);
         this.attr('parentInstance')
           .get_binding(this.attr('mapping'))
           .refresh_instances()

--- a/src/ggrc/assets/javascripts/components/object-list/object-list.js
+++ b/src/ggrc/assets/javascripts/components/object-list/object-list.js
@@ -12,10 +12,12 @@
   /**
    * Object List component
    */
-  GGRC.Components('objectList', {
+  can.Component.extend({
     tag: tag,
     template: tpl,
     scope: {
+      spinnerCss: '@',
+      isLoading: false,
       selectedItem: null,
       items: [],
       select: function (ctx, el) {

--- a/src/ggrc/assets/javascripts/components/object-list/object-list.js
+++ b/src/ggrc/assets/javascripts/components/object-list/object-list.js
@@ -12,7 +12,7 @@
   /**
    * Object List component
    */
-  can.Component.extend({
+  GGRC.Components('objectList', {
     tag: tag,
     template: tpl,
     scope: {

--- a/src/ggrc/assets/javascripts/components/related-objects/related-objects.js
+++ b/src/ggrc/assets/javascripts/components/related-objects/related-objects.js
@@ -9,9 +9,8 @@
   can.Component.extend({
     tag: 'related-objects',
     scope: {
-      parentInstance: null,
       baseInstance: null,
-      relatedItemsType: 'Assessment',
+      relatedItemsType: '@',
       relatedObjects: new can.List(),
       paging: {
         current: 1,

--- a/src/ggrc/assets/javascripts/components/reusable-objects/reusable-objects-item.js
+++ b/src/ggrc/assets/javascripts/components/reusable-objects/reusable-objects-item.js
@@ -13,6 +13,7 @@
     tag: 'reusable-objects-item',
     template: tpl,
     scope: {
+      isSaving: false,
       selectedList: new can.List(),
       disabled: false,
       isDisabled: function () {

--- a/src/ggrc/assets/javascripts/components/reusable-objects/reusable-objects-list.js
+++ b/src/ggrc/assets/javascripts/components/reusable-objects/reusable-objects-list.js
@@ -35,23 +35,23 @@
   can.Component.extend({
     tag: 'reusable-objects-list',
     scope: {
-      parentInstance: null,
+      baseInstance: null,
       selectedList: new can.List(),
-      isLoading: false,
+      isSaving: false,
       reuseSelected: function () {
         var reusedList = this.attr('selectedList');
-        var source = this.attr('parentInstance');
+        var source = this.attr('baseInstance');
         var models = can.map(reusedList, function (destination) {
           var relationship = mapper.map(source, destination);
           return relationship.save();
         });
-        this.attr('isLoading', true);
+        this.attr('isSaving', true);
         can.when.apply(can, models).then(function () {
           can.$(document.body).trigger('ajax:flash', {
             success: 'Selected evidences are reused'
           });
           reusedList.replace([]);
-          this.attr('isLoading', false);
+          this.attr('isSaving', false);
         }.bind(this));
       }
     },

--- a/src/ggrc/assets/javascripts/components/simple-modal/simple-modal.js
+++ b/src/ggrc/assets/javascripts/components/simple-modal/simple-modal.js
@@ -24,7 +24,7 @@
     tag: 'simple-modal',
     template: tpl,
     scope: {
-      extraCssCls: '@',
+      extraCssClass: '@',
       instance: null,
       modalEl: null,
       state: {

--- a/src/ggrc/assets/javascripts/components/spinner/spinner.js
+++ b/src/ggrc/assets/javascripts/components/spinner/spinner.js
@@ -3,7 +3,7 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 */
 
-(function (can, $) {
+(function (can) {
   'use strict';
 
   GGRC.Components('spinner', {
@@ -13,8 +13,9 @@
       '/components/spinner/spinner.mustache'
     ),
     scope: {
+      extraCssCls: '@',
       size: '@',
       toggle: null
     }
   });
-})(window.can, window.can.$);
+})(window.can);

--- a/src/ggrc/assets/javascripts/components/spinner/spinner.js
+++ b/src/ggrc/assets/javascripts/components/spinner/spinner.js
@@ -13,7 +13,7 @@
       '/components/spinner/spinner.mustache'
     ),
     scope: {
-      extraCssCls: '@',
+      extraCssClass: '@',
       size: '@',
       toggle: null
     }

--- a/src/ggrc/assets/mustache/assessments/related-assessments.mustache
+++ b/src/ggrc/assets/mustache/assessments/related-assessments.mustache
@@ -2,8 +2,8 @@
 Copyright (C) 2016 Google Inc.
 Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
-<related-objects base-instance="instance" relatedItemsType="Assessment">
-    <reusable-objects-list parent-instance="instance" base-instance="instance">
+<related-objects base-instance="instance" related-items-type="Assessment">
+    <reusable-objects-list base-instance="instance">
         <div class="grid-data-toolbar flex-box">
             <tree-pagination paging="paging" class="flex-size-1"></tree-pagination>
             {{#is_allowed 'update' baseInstance context='for'}}
@@ -17,7 +17,6 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
             {{/is_allowed}}
         </div>
         <div class="grid-data-header flex-row flex-box">
-
             <div class="grid-data-item-index">
                 Date
             </div>
@@ -32,7 +31,7 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
             </div>
         </div>
         <div class="grid-data-body {{#isLoading}}loading{{/isLoading}}">
-            <object-list items="relatedObjects">
+            <object-list items="relatedObjects" is-loading="isLoading" spinner-css="grid-spinner">
                 <div class="grid-data-row flex-row flex-box">
                     <div class="grid-data-item-index">
                       {{localize_date instance.created_at}}
@@ -45,7 +44,6 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                     <div class="flex-size-1">
                         <mapped-objects
                                 parent-instance="instance"
-                                is-loading="isLoading"
                                 mapping="{{instance.class.info_pane_options.mapped_objects.mapping}}"
                         >
                           {{> '/static/mustache/components/assessment/mapped-objects/item-templates/title.mustache' }}
@@ -54,10 +52,10 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                     <div class="flex-size-1">
                         <mapped-objects
                                 parent-instance="instance"
-                                is-loading="isLoading"
                                 mapping="{{instance.class.info_pane_options.evidence.mapping}}"
                         >
                             <reusable-objects-item instance="instance"
+                                                   is-saving="isSaving"
                                                    base-instance="baseInstance"
                                                    mapping="mapping"
                                                    selected-list="selectedList">
@@ -69,10 +67,10 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                         </mapped-objects>
                         <mapped-objects
                                 parent-instance="instance"
-                                is-loading="isLoading"
                                 mapping="{{instance.class.info_pane_options.urls.mapping}}"
                         >
                             <reusable-objects-item instance="instance"
+                                                   is-saving="isSaving"
                                                    base-instance="baseInstance"
                                                    mapping="mapping"
                                                    selected-list="selectedList">

--- a/src/ggrc/assets/mustache/components/assessment/controls-toolbar/controls-toolbar.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/controls-toolbar/controls-toolbar.mustache
@@ -4,6 +4,6 @@
 }}
 <button class="btn btn-small btn-draft btn-extra-gray" can-click="showRelatedResponses" title="Show Related Responses">Prior Responses</button>
  {{> '/static/mustache/mixins/stateful.mustache' }}
-<simple-modal instance="instance" state="modal" extra-css-cls="related-assessments">
+<simple-modal instance="instance" state="modal" extra-css-class="related-assessments">
     {{> '/static/mustache/assessments/related-assessments.mustache' }}
 </simple-modal>

--- a/src/ggrc/assets/mustache/components/mapped-objects/mapped-objects.mustache
+++ b/src/ggrc/assets/mustache/components/mapped-objects/mapped-objects.mustache
@@ -2,6 +2,6 @@
     Copyright (C) 2016 Google Inc., authors, and contributors
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
-<object-list items="mappedItems" selected-item="selectedItem">
+<object-list items="mappedItems" selected-item="selectedItem" is-loading="isLoading">
   <content></content>
 </object-list>

--- a/src/ggrc/assets/mustache/components/object-list/object-list.mustache
+++ b/src/ggrc/assets/mustache/components/object-list/object-list.mustache
@@ -2,7 +2,7 @@
     Copyright (C) 2016 Google Inc., authors, and contributors
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
-<spinner toggle="isLoading" extra-css-cls="{{spinnerCss}}" class="{{#isLoading}}active{{/isLoading}}"></spinner>
+<spinner toggle="isLoading" extra-css-class="{{spinnerCss}}" class="{{#isLoading}}active{{/isLoading}}"></spinner>
 {{#each items}}
   <object-list-item selected-item="selectedItem" index="{{@index}}" can-click="select">
     <content></content>

--- a/src/ggrc/assets/mustache/components/object-list/object-list.mustache
+++ b/src/ggrc/assets/mustache/components/object-list/object-list.mustache
@@ -2,7 +2,7 @@
     Copyright (C) 2016 Google Inc., authors, and contributors
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
-
+<spinner toggle="isLoading" extra-css-cls="{{spinnerCss}}" class="{{#isLoading}}active{{/isLoading}}"></spinner>
 {{#each items}}
   <object-list-item selected-item="selectedItem" index="{{@index}}" can-click="select">
     <content></content>

--- a/src/ggrc/assets/mustache/components/reusable-objects/reusable-objects-item.mustache
+++ b/src/ggrc/assets/mustache/components/reusable-objects/reusable-objects-item.mustache
@@ -9,7 +9,7 @@
       {{#if isDisabled}}
           <input type="checkbox" checked disabled/>
       {{else}}
-          <input type="checkbox" {{#isLoading}}disabled{{/isLoading}}/>
+          <input type="checkbox" {{#isSaving}}disabled{{/isSaving}}/>
       {{/if}}
     {{/is_allowed}}
   {{/is_allowed}}

--- a/src/ggrc/assets/mustache/components/simple-modal/simple-modal.mustache
+++ b/src/ggrc/assets/mustache/components/simple-modal/simple-modal.mustache
@@ -2,7 +2,7 @@
     Copyright (C) 2016 Google Inc.
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
-<div class="simple-modal {{extraCssCls}} {{modalCls}}">
+<div class="simple-modal {{extraCssClass}} {{modalCls}}">
     <div class="modal-header">
         <h4>Prior Responses</h4>
         <a class="modal-dismiss" can-click="hide">

--- a/src/ggrc/assets/mustache/components/spinner/spinner.mustache
+++ b/src/ggrc/assets/mustache/components/spinner/spinner.mustache
@@ -4,7 +4,7 @@
 }}
 
 {{#toggle}}
-<div class="spinner {{extraCssCls}}">
+<div class="spinner {{extraCssClass}}">
   <i class="spinner-icon {{#size}}spinner-size__{{size}}{{/size}} fa fa-spinner fa-pulse" aria-hidden="true"></i>
 </div>
 {{/toggle}}

--- a/src/ggrc/assets/mustache/components/spinner/spinner.mustache
+++ b/src/ggrc/assets/mustache/components/spinner/spinner.mustache
@@ -4,7 +4,7 @@
 }}
 
 {{#toggle}}
-<div class="spinner">
+<div class="spinner {{extraCssCls}}">
   <i class="spinner-icon {{#size}}spinner-size__{{size}}{{/size}} fa fa-spinner fa-pulse" aria-hidden="true"></i>
 </div>
 {{/toggle}}

--- a/src/ggrc/assets/stylesheets/components/grid-data/_grid-data.scss
+++ b/src/ggrc/assets/stylesheets/components/grid-data/_grid-data.scss
@@ -13,6 +13,7 @@
     margin: 0 0 0 24px;
   }
 }
+
 .grid-data-header {
   padding: 8px 0;
   border: 1px solid #ccc;
@@ -30,25 +31,29 @@
     font-weight: bold;
   }
 }
+
 .grid-data-body {
-  min-height: 300px;
-  max-height: 500px;
+  display: flex;
+  height: 400px;
   box-sizing: border-box;
   overflow: auto;
+  position: relative;
 
   &.loading {
     opacity: 0.5;
-    background: #fcfcfc;
   }
 }
+
 // Extra style for the first index/order column
 .grid-data-item-index {
   width: 100px;
 }
+
 .grid-data-row {
   overflow: hidden;
   padding: 8px 0;
   border-bottom: 1px solid #ccc;
+  cursor: default;
   // Extra style for columns
   > * {
     overflow: hidden;

--- a/src/ggrc/assets/stylesheets/components/object-list/_object-list.scss
+++ b/src/ggrc/assets/stylesheets/components/object-list/_object-list.scss
@@ -5,14 +5,46 @@
 
 object-list {
   display: flex;
+  box-sizing: border-box;
+  width: 100%;
+  align-self: stretch;
   flex-direction: column;
   position: relative;
   list-style: none;
   padding: 0;
   margin: 0;
+  min-height: 24px;
+  // Should affect only direct children
+  > spinner {
+    display: flex;
+    z-index: -1;
+
+    &.active {
+      z-index: 9999;
+    }
+
+    .spinner {
+      position: absolute;
+      right: 0;
+      left: 0;
+      top: 0;
+      bottom: 0;
+      display: flex;
+      align-items: center;
+      font-size: 18px;
+      // Bigger spinner with separate color for the grid
+      &.grid-spinner {
+        justify-content: center;
+
+        .fa {
+          color: $defaultWidget;
+          font-size: 32px;
+        }
+      }
+    }
+  }
 
   object-list-item {
-    background: $white;
     line-height: 24px;
     box-sizing: border-box;
     margin: 0;

--- a/src/ggrc/assets/stylesheets/components/reusable-objects/_reusable-objects.scss
+++ b/src/ggrc/assets/stylesheets/components/reusable-objects/_reusable-objects.scss
@@ -6,21 +6,28 @@ reusable-objects-item {
   display: flex;
   position: relative;
   line-height: 24px;
-  padding-right: 38px;
+  padding-right: 42px;
 
   > .date {
     width: 72px;
     margin: 0 8px 0 0;
   }
 }
+
 reusable-objets-item-control {
-  display: flex;
   position: absolute;
+  display: flex;
+  align-items: center;
   top: 0;
   right: 0;
   line-height: 24px;
   height: 24px;
   width: 38px;
+  box-sizing: border-box;
   text-align: center;
-  vertical-align: baseline;
+
+  input[type="checkbox"] {
+    margin: 0;
+    padding: 0;
+  }
 }


### PR DESCRIPTION
1.387  Bug (P1)
Subject: There are no spinners or loading animation so the users see this for the first 5-10s while related objects are loading
Details: 
Go to assessment page and open Related assessments tab on info panel
Actual Result:  There are no spinners or loading animation so the users see this for the first 5-10s while related objects are loading
Workaround: N/A