### PR TITLE
ISSUE-1.382 Fix setting and getting values from textarea

### DIFF
--- a/src/ggrc/assets/javascripts/components/add_comment/add_comment.js
+++ b/src/ggrc/assets/javascripts/components/add_comment/add_comment.js
@@ -84,8 +84,10 @@
       },
       newInstance: function () {
         var instance = CMS.Models.Comment();
-        instance._source_mapping = this.scope.attr('source_mapping');
-        instance.attr('context', this.scope.attr('parent_instance.context'));
+        instance.attr({
+          _source_mapping: this.scope.attr('source_mapping'),
+          context: this.scope.attr('parent_instance.context')
+        });
         this.scope.attr('instance', instance);
       },
       cleanPanel: function () {

--- a/src/ggrc/assets/javascripts/components/add_comment/add_comment.js
+++ b/src/ggrc/assets/javascripts/components/add_comment/add_comment.js
@@ -27,6 +27,7 @@
       list: [],
       // the following are just for the case when we have no object to start with,
       changes: [],
+      description: null,
       removePending: function (scope, el, ev) {
         var joins = this.instance._pending_joins;
         var model = scope.what;
@@ -86,15 +87,14 @@
       },
       cleanPanel: function () {
         this.scope.attachments.replace([]);
-        this.element.find('textarea').val('');
+        this.scope.attr('description', null);
       },
       /**
        * The component's click event (happens when the user clicks add comment),
        * takes care of saving the comment with appended evidence.
        */
       '.btn-success click': function (el, ev) {
-        var $textarea = this.element.find('.add-comment textarea');
-        var description = $.trim($textarea.val());
+        var description = $.trim(this.scope.description);
         var attachments = this.scope.attachments;
         var source = this.scope.source_mapping;
         var instance = this.scope.instance;

--- a/src/ggrc/assets/javascripts/components/add_comment/add_comment.js
+++ b/src/ggrc/assets/javascripts/components/add_comment/add_comment.js
@@ -28,6 +28,7 @@
       // the following are just for the case when we have no object to start with,
       changes: [],
       description: null,
+      sendNotification: false,
       removePending: function (scope, el, ev) {
         var joins = this.instance._pending_joins;
         var model = scope.what;
@@ -73,10 +74,12 @@
       })
     },
     events: {
-      init: function () {
+      inserted: function () {
         if (!this.scope.attr('source_mapping')) {
           this.scope.attr('source_mapping', GGRC.page_instance());
         }
+        this.scope.attr('sendNotification',
+          this.scope.attr('parent_instance.send_by_default'));
         this.newInstance();
       },
       newInstance: function () {
@@ -99,15 +102,13 @@
         var source = this.scope.source_mapping;
         var instance = this.scope.instance;
         var data;
-        var $sendNotification = this.element.find('[name=send_notification]');
-        var sendNotification = $sendNotification[0].checked;
 
         if (!description.length && !attachments.length) {
           return;
         }
         data = {
           description: description,
-          send_notification: sendNotification,
+          send_notification: this.scope.attr('sendNotification'),
           context: source.context,
           assignee_type: this.scope.attr('get_assignee_type')
         };

--- a/src/ggrc/assets/mustache/base_templates/add_comment.mustache
+++ b/src/ggrc/assets/mustache/base_templates/add_comment.mustache
@@ -39,7 +39,14 @@
         {{/is_allowed}}
       </div>
       <div class="wysiwyg-area">
-        <textarea {{#isSaving}}disabled="disabled"{{/isSaving}} rows="4" class="span12 triple wysihtml5" name="comment-description" id="comment-description" placeholder="Enter comment (optional)"></textarea>
+        <textarea {{#isSaving}}disabled="disabled"{{/isSaving}}
+          rows="4"
+          class="span12 triple wysihtml5"
+          name="comment-description"
+          id="comment-description"
+          placeholder="Enter comment (optional)"
+          can-value="description"
+        ></textarea>
       </div>
       <div class="attachments-preview">
         <ul>

--- a/src/ggrc/assets/mustache/base_templates/add_comment.mustache
+++ b/src/ggrc/assets/mustache/base_templates/add_comment.mustache
@@ -72,8 +72,7 @@
           >Add</a>
 
         <label class="input--inline pull-left">
-          <input type="checkbox" name="send_notification"
-            {{#parent_instance.send_by_default}}checked{{/send_by_default}}>
+          <input type="checkbox" can-value="sendNotification"
           Send Notifications
         </label>
         {{/if}}


### PR DESCRIPTION
Subject: "Uncaught TypeError: Cannot read property 'find' of null" error is displayed while navigating to Request Log in Request's Info panel

Details: 
Navigate to Request’s Info panel
Go to Comments and Responses tab
Enter comment and while comment is saving click on Request Log tab: an error is displayed 

Actual Result: "Uncaught TypeError: Cannot read property 'find' of null" error is displayed while navigating to Request Log in Request's Info panel

Expected Result: No error displayed. 
Workaround: N/A