### PR TITLE
QUICK-FIX Fix CA preconditions tests

### DIFF
--- a/test/integration/ggrc/models/mixins/test_customattributable_preconditions_failed.py
+++ b/test/integration/ggrc/models/mixins/test_customattributable_preconditions_failed.py
@@ -45,9 +45,8 @@ class CustomAttributeMock(object):
     """Generate a custom attribute value."""
     if self.attribute_value is not None:
       value = factories.CustomAttributeValueFactory(
-          custom_attribute_id=self.definition.id,
-          attributable_type=self.attributable.__class__.__name__,
-          attributable_id=self.attributable.id,
+          custom_attribute=self.definition,
+          attributable=self.attributable,
           attribute_value=self.attribute_value,
       )
     else:

--- a/test/integration/ggrc/models/test_clonable.py
+++ b/test/integration/ggrc/models/test_clonable.py
@@ -333,9 +333,8 @@ class TestClonable(integration.ggrc.TestCase):
         attribute_type="Text"
     )
     factories.CustomAttributeValueFactory(
-        custom_attribute_id=ca_def_text.id,
-        attributable_id=audit.id,
-        attributable_type="Audit",
+        custom_attribute=ca_def_text,
+        attributable=audit,
         attribute_value="CA 1 value"
     )
 


### PR DESCRIPTION
Setting related attributes should be done with objects as the ORM
expects. This fixes errors when upgrading to sqlalchemy to 1.0.1.