### PR TITLE
ISSUE-1.375 Fix the rendering of uploaded Request evidence

### DIFF
--- a/src/ggrc/assets/mustache/base_templates/attachment.mustache
+++ b/src/ggrc/assets/mustache/base_templates/attachment.mustache
@@ -17,12 +17,15 @@
       {{/instance}}
       {{/is_allowed}}
     {{/if}}
+
     {{#instance.selfLink}}
       <i class="fa fa-file-{{file_type instance}}-o"></i>
     {{/instance.selfLink}}
+
     {{^if reusable}}
     <span class="date">{{date instance.created_at true}}</span>
     {{/if}}
+
     <a href="{{schemed_url instance.link}}" target="_blank">
       <span>{{firstnonempty instance.title instance.link}}</span>
     </a>

--- a/src/ggrc/assets/mustache/base_templates/mapping_tree_view.mustache
+++ b/src/ggrc/assets/mustache/base_templates/mapping_tree_view.mustache
@@ -5,6 +5,8 @@
 
 <ul class="{{#if treeViewClass}}{{treeViewClass}}{{else}}attachment-list{{/if}}">
   {{#mappedObjects}}
-    {{{render itemTemplate instance=instance baseInstance=baseInstance parentInstance=parentInstance reusable=reusable reusedObjects=reusedObjects reuseMethod=reuseMethod mapping=mapping isLoading=isLoading isExpandable=isExpandable}}}
+    {{#using instance=instance}}
+      {{{render itemTemplate instance=instance baseInstance=baseInstance parentInstance=parentInstance reusable=reusable reusedObjects=reusedObjects reuseMethod=reuseMethod mapping=mapping isLoading=isLoading isExpandable=isExpandable}}}
+    {{/using}}
   {{/mappedObjects}}
 </ul>


### PR DESCRIPTION
_(section 2, issue 1.375 - P1)_

This PR fixes displaying the attached evidence info - the problem was that the Document instance was not properly refreshed in the template, thus the latter did not have all the data available.

NOTE: The changes in `attachment.mustache` were made during the debugging, but ultimately turned out to be unnecessary - I nevertheless kept them in for better template readability, but if somebody really doesn't like it, I can kick that out. :smile: 

**Details:**
- Navigate to request tab on audit page
- Open Request’s info panel
- Add a comment with attachment
- Add another comment with the attachment
- Reload the page

**Actual Result:**
""Invalid date"" is shown instead of the 2nd file name on Request's info panel

**Expected Result:**
the file title should be mentioned 2 times (+ the correct creation date displayed)