### PR TITLE
ISSUE-1.3

### DIFF
--- a/src/ggrc/assets/stylesheets/modules/_assessment.scss
+++ b/src/ggrc/assets/stylesheets/modules/_assessment.scss
@@ -116,7 +116,7 @@ $border-color: #eee;
         .state-value {
           padding: 0 8px;
           box-sizing: border-box;
-          height: 22px;
+          min-height: 22px;
           margin: 0 16px 0 0;
           line-height: 22px;
           align-self: center;

--- a/src/ggrc/assets/stylesheets/modules/_object-header.scss
+++ b/src/ggrc/assets/stylesheets/modules/_object-header.scss
@@ -5,9 +5,6 @@
 
 .pane-header {
   h3 {
-    overflow: hidden !important;
-    white-space: nowrap;
-    text-overflow: ellipsis;
     max-width: 80%;
     float: left;
     margin-right: 10px;
@@ -16,7 +13,7 @@
     position: fixed;
     left: 52px;
     right: 52px;
-    height: 52px;
+    min-height: 52px;
     background: $white;
     border-bottom: 1px solid $lightGray;
     padding-top: 15px;


### PR DESCRIPTION
Subject:
Object title is not fully displayed at object info page

Details:
- Go to audit with long name https://grc-dev.appspot.com/programs/4386#audit_widget/audit/1830
- Check title

Actual Result:
Long object title is cutted

Expected Result:
User should be able to see full title
