### PR TITLE
QUICK-FIX Upgrade momentjs

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,7 @@
     "jquery": "1.11.3",
     "lodash": "3.10.1",
     "mousetrap": "1.5.3",
-    "moment": "2.10.6",
+    "moment": "2.15.0",
     "moment-timezone": "0.5.0",
     "jasmine-fixture": "1.3.3",
     "spinjs": "1.3.3",

--- a/src/ggrc/assets/javascripts/components/datepicker/datepicker.js
+++ b/src/ggrc/assets/javascripts/components/datepicker/datepicker.js
@@ -88,7 +88,6 @@
             date.subtract(1, 'day');
           }
         };
-        date = this.getDate(date);
         date = moment(date);
 
         if (types[type]) {


### PR DESCRIPTION
This fixes a deprecation warning and upgrades moment.js to the latest version. We need to upgrade moment because 2.10 has a known vulnerability.