### PR TITLE
ISSUE-1.379 Add status change warning

### DIFF
--- a/src/ggrc/assets/mustache/assessments/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessments/modal_content.mustache
@@ -9,6 +9,15 @@
 <form action="javascript://">
   {{> /static/mustache/base_objects/form_restore.mustache}}
 
+  {{^if new_object_form}}
+    {{#if_in instance.status "Not Started,Completed,Verified"}}
+      <div class="alert warning">
+        <i class="fa fa-exclamation-triangle red"></i>
+        You are about to move assessment from "{{instance.status}}" to "In Progress".
+      </div>
+    {{/if_in}}
+  {{/if}}
+
   <div class="row-fluid">
     <div class="span6 {{#instance.computed_errors.title}}field-failure{{/instance.computed_errors.title}}">
       <label>


### PR DESCRIPTION
Subject: There is no a message about changing Assessment's status when editing it

Details: 
Navigate to an Assessment in Not Started state
Edit it

Actual Result: There is no a message about changing Assessment's status when editing it

Expected Result: the message should warn the user that Assessment's state will be changed upon saving