### PR TITLE
ISSUE-1.394 Wrong validation message when hovering Complete button

### DIFF
--- a/src/ggrc/assets/javascripts/models/assessment.js
+++ b/src/ggrc/assets/javascripts/models/assessment.js
@@ -212,21 +212,19 @@
             value = cav.attribute_value;
           }
         });
-        // If Custom Attribute Value is presented - do all required checks
-        if (cav) {
-          cav.preconditions_failed = cav.preconditions_failed || [];
-          if (cad.mandatory &&
+        if (cad.mandatory &&
             GGRC.Utils.isEmptyCA(value, cad.attribute_type)) {
-            errorsList.value.push(cad.title);
-          }
+          // If Custom Attribute is mandatory and empty
+          errorsList.value.push(cad.title);
+        } else if (cav) {
+          // If Custom Attribute Value is presented - do all required checks
+          cav.preconditions_failed = cav.preconditions_failed || [];
           if (cav.preconditions_failed.indexOf('comment') > -1) {
             errorsList.comment.push(cad.title + ': ' + value);
           }
           if (cav.preconditions_failed.indexOf('evidence') > -1) {
             errorsList.attachment.push(cad.title + ': ' + value);
           }
-        } else {
-          errorsList.value.push(cad.title);
         }
       });
     },

--- a/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
+++ b/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
@@ -304,7 +304,7 @@
         'Map:Person'];
       var options = {
         Checkbox: function (value) {
-          return value === '0';
+          return !value || value === '0';
         },
         'Rich Text': function (value) {
           value = GGRC.Utils.getPlainText(value);


### PR DESCRIPTION
**Subject**: wrong validation message when hovering Complete button on Assessment info panel
**Details**: 

- Navigate to Assessment with mandatory and empty CA  
- Hover over Complete button

**Actual Result**: The message says there are many fields mentioned in the tooltip though the assessment has only 3 CA fields marked as mandatory on info panel
**Expected Result**: EITHER only mandatory fields should be shown in the tooltip message upon hovering the Complete button OR the fields should be marked as mandatory in Info panel