### PR TITLE
ISSUE-1.395 Fix info panel flickering when hovering over CAs

### DIFF
--- a/src/ggrc/assets/stylesheets/components/object-list/_object-list.scss
+++ b/src/ggrc/assets/stylesheets/components/object-list/_object-list.scss
@@ -4,7 +4,6 @@
  */
 
 object-list {
-  display: flex;
   box-sizing: border-box;
   width: 100%;
   align-self: stretch;


### PR DESCRIPTION
_(section 2, bug 1.395 - P1)_

This PR fixes the jumpy UI behavior which can be very distracting for the users. The issue seems to be caused by the `display: flex` CSS styling of the mapped objects list container. The behaviour was first observed [here](https://github.com/google/ggrc-core/commit/9650baa7b8539cfcc634eafee395166a2b9cd916).

@andrei-karalionak - the fix seems to work fine, but are there any additional implications of removing  the `flex` display rule?

**Steps to reproduce:**
- Navigate to Assessments tab on Audit page
- Open Assessment’s info panel
- Change the size of the info panel
- Hover few times over any CA fields in the info panel (make sure that the info panel's vertical scrollbar is _not_ position at the very top.

**Actual Result:**
the whole info panel flicks (see the screen cast [here](https://drive.google.com/open?id=0B_yi_GigOIL5TVM0ZzVDN1FVR1E))

**Expected Result:**
no flickering!