### PR TITLE
ISSUE-1.183 Carriage returns removed for Comments

### DIFF
--- a/src/ggrc/assets/javascripts/components/rich_text/rich_text.js
+++ b/src/ggrc/assets/javascripts/components/rich_text/rich_text.js
@@ -16,6 +16,7 @@
       text: null,
       editor: null,
       placeholder: null,
+      disabled: null,
       formats: ['bold', 'italic', 'link', 'underline',
         'list', 'bullet', 'strike'],
       onChange: function (delta, source) {
@@ -42,6 +43,19 @@
         }
         editor.on('text-change', this.scope.onChange.bind(this.scope));
         this.scope.attr('editor', editor);
+      },
+      '{scope} disabled': function (el, ev) {
+        if (this.scope.attr('disabled')) {
+          this.scope.attr('editor').editor.disable();
+        } else {
+          this.scope.attr('editor').editor.enable();
+        }
+      },
+      // if text had been changed to nothing then clear
+      '{scope} text': function (el, ev) {
+        if (!this.scope.attr('text')) {
+          this.scope.attr('editor').setHTML('');
+        }
       }
     }
   });

--- a/src/ggrc/assets/mustache/components/assessment/comment/input.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/comment/input.mustache
@@ -3,5 +3,5 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
 <div class="">
-    <textarea class="input--textarea" {{#isSaving}}disabled="disabled"{{/isSaving}} rows="4" class="" placeholder="{{commentPlaceHolder}}"can-value="comment.value" can-keyup="removeEmptyMark"></textarea>
+    <rich-text class="input--textarea" {{#isSaving}}disabled="disabled"{{/isSaving}} placeholder="{{commentPlaceHolder}}" text="comment.value" can-keyup="removeEmptyMark"></rich-text>
 </div>


### PR DESCRIPTION
**Subject**: Carriage returns removed for Comments
**Details**:   
Create program and audit
Go to audit page and create assessment
Open created assessment in tree info and comments with 2 lines and click Add button
**Actual Result**: 2 lines joined into 1 line
**Expected Result**: Format of lines in view comment control should be the same as in edit comment control. Rich Text should be in all places where comment is entered/ edited.

**Additionaly** in current rich-text component there's no placeholder implementation.