### PR TITLE
ISSUE: 1.90/1.385: Fix memcache issue with assessment generation

### DIFF
--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -235,6 +235,13 @@ def update_memcache_after_commit(context):
 
   cache_manager = context.cache_manager
 
+  related_objs = list()
+  for val in getattr(g, "referenced_objects", {}).itervalues():
+    obj_list = val.values()
+    if obj_list:
+      related_objs.append((obj_list[0], None))
+  memcache_mark_for_deletion(context, related_objs)
+
   # TODO(dan): check for duplicates in marked_for_delete
   if len(cache_manager.marked_for_delete) > 0:
     delete_result = cache_manager.bulk_delete(


### PR DESCRIPTION
It fixes 1.90 and 1.385 bugs. They are about cache with people doesn't
update when new assessment generates.

**1.90  Bug (P1)**
**Subject:** Single Creator and Assessor are deleted from Assessment from Assessment Edit modal window by deleting Verifier
**Details:**
- Login as admin
- Create control from LHN menu
- Create program from LHN menu
- Open program page, click at Control tab and map created control to program
- Click at Audit tab and create Audit for program
- Open Audit page
- Click at ASMT template tab and create ASMT template based on control
- Click at Assessment tab and Generate assessment based on created control and asmt template
- Open Edit Assessment modal window and hover mouse over Verifier and delete current logged user

**Actual Result:** User was deleted from Creator and Assessor too
**Expected Result:** Verifier should be deleted only.



**1.385  Bug (P0)**
**Subject:** "Uncaught TypeError: Cannot read property 'destroy' of undefined" error is displayed while clicking a trash icon to delete a Verifier
**Details:**
- Login as admin
- Create control from LHN menu
- Create program from LHN menu
- Open program page, click at Control tab and map created control to program
- Click at Audit tab and create Audit for program
- Open Audit page
- Click at ASMT template tab and create ASMT template based on control
- Click at Assessment tab and Generate assessment based on created control and asmt template
- Navigate to Assessment’s Info panel-> Open People list
- Click trash icon to delete a Verifier

**Actual Result:**  "Uncaught TypeError: Cannot read property 'destroy' of undefined" error is displayed while clicking a trash icon to delete a Verifier
**Expected Result:** No error displayed. Verifier should be deleted after clicking a trash icon.