### PR TITLE
ISSUE-1.406 GCA Dropdowns lost their values on info panels/tabs

### DIFF
--- a/src/ggrc/assets/mustache/custom_attributes/info.mustache
+++ b/src/ggrc/assets/mustache/custom_attributes/info.mustache
@@ -17,7 +17,7 @@
               {{else}}
               value="cav.attribute_value"
               {{/if}}
-              values="cad.values"
+              values="cad.multi_choice_options"
               title="cad.title"
               label="cad.label"
               type="{{type}}"


### PR DESCRIPTION
**Subject**: GCA Dropdowns lost their values on info panels/tabs
**Details**: 

- Create a GCA dropdown field with values for regulation object type
- Create a regulation and navigate to its page
- Click edit icon next to dropdown CA field

**Actual Result**: dropdown field has no values
**Expected Result**: values should be present in the dropdown