### PR TITLE
QUICK-FIX Add Wrap Behavior for Custom Attributes Titles

### DIFF
--- a/src/ggrc/assets/stylesheets/components/custom-attributes/_custom-attributes.scss
+++ b/src/ggrc/assets/stylesheets/components/custom-attributes/_custom-attributes.scss
@@ -6,11 +6,12 @@
 ca-object-validation {
   display: flex;
   flex-direction: row;
-  flex: 1;
-  min-width: 50%;
+  flex: 1 1 50%;
+  max-width: 50%;
   box-sizing: border-box;
 }
 ca-object {
+  max-width: calc(100% - 24px);
   display: flex;
   flex-direction: column;
   box-sizing: border-box;

--- a/src/ggrc/assets/stylesheets/modules/_assessment.scss
+++ b/src/ggrc/assets/stylesheets/modules/_assessment.scss
@@ -198,11 +198,10 @@ $border-color: #eee;
   .inline-edit__title {
     line-height: 22px;
     margin: 0;
-    height: 22px;
     box-sizing: border-box;
     padding: 0 48px 0 4px;
     position: relative;
-    display: block;
+    display: flex;
 
     .fa {
       width: 24px;
@@ -211,14 +210,12 @@ $border-color: #eee;
     }
 
     .inline-edit__title-body {
-      display: inline-block;
+      display: flex;
       max-width: 100%;
       overflow: hidden;
       line-height: 22px;
       box-sizing: border-box;
       padding: 0 24px 0 0;
-      text-overflow: ellipsis;
-      white-space: nowrap;
       position: relative;
 
       .fa {


### PR DESCRIPTION
1.409  Bug (P0)
Subject: Long CA fields' labels should be wrapped on info panels
Details: 
Give a long title to a CA field (eg 50-70 characters)
Create an object with this CA
Open object’s info panel
Actual Result: long CA fields titles overlap
Expected Result: titles shouldn’t overlap
