### PR TITLE
ISSUE-1.410 Fix modal script error

### DIFF
--- a/src/ggrc/assets/javascripts/bootstrap/modal-ajax.js
+++ b/src/ggrc/assets/javascripts/bootstrap/modal-ajax.js
@@ -254,7 +254,10 @@
       });
 
       $target.on('modal:success', function (e, data, xhr) {
-        var cssSelector;
+        var WARN_MSG = [
+          'The $trigger element was not found in the DOM, thus some',
+          'application events will not be propagated.'
+        ].join(' ');
 
         if (form_target == 'refresh') {
           refresh_page();
@@ -288,8 +291,11 @@
           // element. We thus need to trigger the event on that new element
           // (present in the DOM) if we want event handlers to be invoked.
           if (!document.contains($trigger[0])) {
-            cssSelector = '.' + $trigger.attr('class').replace(/ /g, '.');
-            $trigger = $(cssSelector);
+            $trigger = $('[data-link-purpose="open-edit-modal"]');
+            if (_.isEmpty($trigger)) {
+              console.warn(WARN_MSG);
+              return;
+            }
           }
 
           $trigger.trigger('routeparam', $trigger.data('route'));

--- a/src/ggrc/assets/mustache/base_objects/edit_object_link.mustache
+++ b/src/ggrc/assets/mustache/base_objects/edit_object_link.mustache
@@ -7,6 +7,7 @@
   <li>
     <a data-test-id="dropdown_settings_edit_f4b27aec"
        href="javascript://"
+       data-link-purpose="open-edit-modal"
        data-toggle="modal-ajax-form"
        data-modal-reset="reset"
        data-modal-class="modal-wide"


### PR DESCRIPTION
_(section 2, bug 1.410 - P0)_

This PR fixes a script error that can happen in some cases when saving an object through the add/edit modal. It also adds a "fire alarm" (i.e. a user warning) in case the cause of the issue (changed DOM attributes) happens again.

Sadly, skipping tests here in light of the current situation ( :/  ), as this needs to be merged **today**.

**Steps to reproduce:**
- Log as admin
- Create a program
- Create an Audit > Navigate to Audit page
- Create an Assessment (note: this also applies to other object types)
- Navigate to Assessment’s Info panel->Click 3 bb’s button -> Select Edit Assessment
- Click [x] button-> Click Cancel in Discard Changes window
- Click Save and Close button

**Actual Result:**
_""Uncaught TypeError: Cannot read property 'replace' of undefined""_ error occurs while closing Edit Assessment window without edit

**Expected Result:**
No error displayed. Edit Assessment window should be closed without errors.