### PR TITLE
ISSUE-1.3 Fix tier info dropdown z-index

### DIFF
--- a/src/ggrc/assets/stylesheets/modules/_object-header.scss
+++ b/src/ggrc/assets/stylesheets/modules/_object-header.scss
@@ -84,6 +84,8 @@
   margin-left: 10px;
   width: 60px;
   position: relative;
+  z-index: zIndex(info-page-dropdown);
+
   .dropdown-toggle {
     @extend %clearfix;
     height: 8px;


### PR DESCRIPTION
Fixes regression from #4407 on Admin panel. Three dot menu couldn't be clicked because of z-index.