### PR TITLE
ISSUE-1.116 "Audit" is missing in object type dropdown on Export page

### DIFF
--- a/src/ggrc/assets/javascripts/components/relevant_filters.js
+++ b/src/ggrc/assets/javascripts/components/relevant_filters.js
@@ -42,9 +42,7 @@
         if (/true/i.test(this.attr('show_all'))) {
           // find all widget types and manually add Cycle since it's missing
           // convert names to CMS models and prune invalid (undefined)
-          models = ['Cycle'];
-          models = Array.prototype.concat.apply(models,
-              _.values(GGRC.tree_view.base_widgets_by_type));
+          models = can.Map.keys(GGRC.tree_view.base_widgets_by_type);
           models = _.difference(_.unique(models),
                                ['CycleTaskEntry', 'CycleTaskGroupObject']);
           models = _.map(models, function (mapping) {


### PR DESCRIPTION
P2
**Subject**: "Audit" is missing in object type dropdown on Export page
**Details**: 
Create an audit
Create assessment object
Click icon to export assessments
**Actual Result**: "Audit” is missing in object type dropdown on Export page
**Expected Result**: Object type dropdown should contain “Audit”
**Workaround**: N/A
