### PR TITLE
ISSUE-1.420 Fix error notification

### DIFF
--- a/src/ggrc/assets/javascripts/components/people_list.js
+++ b/src/ggrc/assets/javascripts/components/people_list.js
@@ -377,7 +377,7 @@
         var rolesDfd = $.Deferred();
 
         CMS.Models.Relationship
-          .getRelationshipBetweenInstances(person, instance)
+          .getRelationshipBetweenInstances(person, instance, instance.isNew())
           .done(function (relationships) {
             var found = false;
             _.map(relationships, function (relationship) {
@@ -396,7 +396,6 @@
             }
           })
           .fail(function (e) {
-            GGRC.Errors.notifier('error')(e);
             rolesDfd.resolve({roles: []});
           });
 

--- a/src/ggrc/assets/javascripts/ggrc_base.js
+++ b/src/ggrc/assets/javascripts/ggrc_base.js
@@ -166,8 +166,10 @@
       return function (err) {
         var props = {};
 
-        message = message || GGRC.Errors.messages[err.status];
-        props[type] = message || 'There was a server problem';
+        if (!message && err && err.status) {
+          message = GGRC.Errors.messages[err.status];
+        }
+        props[type] = message || 'There was an error!';
         $('body').trigger('ajax:flash', props);
       };
     }

--- a/src/ggrc/assets/javascripts/models/join_models.js
+++ b/src/ggrc/assets/javascripts/models/join_models.js
@@ -183,6 +183,8 @@
         return $.when(first.refresh(), second.refresh())
           .then(function (fObj, sObj) {
             return rec(fObj, sObj, true);
+          }).fail(function (e) {
+            result.resolve([]);
           });
       }
       if (relationshipIds.length > 1) {

--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -2848,39 +2848,37 @@ Mustache.registerHelper("fadeout", function (delay, prop, options) {
       }, binding.refresh_instances());
     });
 
-Mustache.registerHelper('with_mapping_count', function (instance, mapping_names, options) {
+  Mustache.registerHelper('with_mapping_count',
+    function (instance, mappingNames, options) {
+      var args = can.makeArray(arguments);
+      var mappingName;
+      var i;
 
-  var args = can.makeArray(arguments)
-    , options = args[args.length-1]  // FIXME duplicate declaration
-    , mapping_name
-    ;
+      options = args[args.length - 1];  // FIXME duplicate declaration
 
-  mapping_names = args.slice(1, args.length - 1);
+      mappingNames = args.slice(1, args.length - 1);
 
-  instance = Mustache.resolve(instance);
+      instance = Mustache.resolve(instance);
 
-  // Find the most appropriate mapping
-  for (var i = 0; i < mapping_names.length; i++) {
-    mapping_name = Mustache.resolve(mapping_names[i]);
-    if (instance.has_binding(mapping_name)) {
-      break;
-    }
-  }
+      // Find the most appropriate mapping
+      for (i = 0; i < mappingNames.length; i++) {
+        mappingName = Mustache.resolve(mappingNames[i]);
+        if (instance.has_binding(mappingName)) {
+          break;
+        }
+      }
 
-  var finish = function (count) {
-    return options.fn(options.contexts.add({ count: count }));
-  };
-
-  var progress = function () {
-    return options.inverse(options.contexts);
-  };
-
-  return defer_render(
-    "span",
-    { done: finish, progress: progress },
-    instance.get_list_counter(mapping_name)
-  );
-});
+      return defer_render('span', {
+        done: function (count) {
+          return options.fn(options.contexts.add({count: count}));
+        },
+        progress: function () {
+          return options.inverse(options.contexts);
+        }
+      },
+        instance.get_list_counter(mappingName)
+      );
+    });
 
 Mustache.registerHelper("is_overdue", function (_date, status, options) {
   var date = moment(resolve_computed(_date));

--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -2862,7 +2862,7 @@ Mustache.registerHelper('with_mapping_count', function (instance, mapping_names,
   // Find the most appropriate mapping
   for (var i = 0; i < mapping_names.length; i++) {
     mapping_name = Mustache.resolve(mapping_names[i]);
-    if (instance.get_binding(mapping_name)) {
+    if (instance.has_binding(mapping_name)) {
       break;
     }
   }


### PR DESCRIPTION
**1.420  Bug (P0)**
**Subject**: "Uncaught TypeError: Cannot read property 'status' of undefined" occurs while adding Assessor in New Assessment window 
**Details**: 
Create a program
Create  an Audit
Go to Audit page
While Creating Assessment select Assessor (other than Creator) from drop down list: confirm that JS error occurs in console
_Actual Result_: "Uncaught TypeError: Cannot read property 'status' of undefined" occurs while adding Assessor in New Assessment window 
_Expected Result_: No error displayed. Assessor should be added to Assessment.
