### PR TITLE
ISSUE-1.335 Fix Assessment related objects creation

### DIFF
--- a/src/ggrc/assets/javascripts/models/assessment.js
+++ b/src/ggrc/assets/javascripts/models/assessment.js
@@ -34,7 +34,6 @@
     },
     is_custom_attributable: true,
     attributes: {
-      control: 'CMS.Models.Control.stub',
       context: 'CMS.Models.Context.stub',
       modified_by: 'CMS.Models.Person.stub',
       start_date: 'date',

--- a/src/ggrc/assets/javascripts/models/assessment.js
+++ b/src/ggrc/assets/javascripts/models/assessment.js
@@ -34,6 +34,8 @@
     },
     is_custom_attributable: true,
     attributes: {
+      related_sources: 'CMS.Models.Relationship.stubs',
+      related_destinations: 'CMS.Models.Relationship.stubs',
       context: 'CMS.Models.Context.stub',
       modified_by: 'CMS.Models.Person.stub',
       start_date: 'date',


### PR DESCRIPTION
*Subject:*
the Control isn't show in the Assessment's info tab after Assessment creation

*Details:*
- Navigate to audit page
- Create an assessment manually
- Open Assessment’s info panel

*Actual Result:*
the Control isn't show in the Assessment's info tab after Assessment creation

*Expected Result:*
the Control should be show in the Assessment's info tab after Assessment creation

*Workaround:*
page refresh