### PR TITLE
ISSUE-1.415 Fix filter on All Objects page

### DIFF
--- a/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
+++ b/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
@@ -566,6 +566,7 @@
       var relevantFilter;
       var filters;
       var left;
+      var right;
 
       if (relevant) {
         relevantFilter = '#' + relevant.type + ',' + relevant.id + '#';
@@ -575,15 +576,22 @@
           relevant.operation !== left.expression.op.name) {
           left.expression.op.name = relevant.operation;
         }
-        if (filter) {
-          filters = GGRC.query_parser.join_queries(left,
-            GGRC.query_parser.parse(filter));
-        } else {
-          filters = left;
-        }
+      }
+
+      if (filter) {
+        right = GGRC.query_parser.parse(filter);
+      }
+
+      if (left && right) {
+        filters = GGRC.query_parser.join_queries(left, right);
+      } else if (left) {
+        filters = left;
+      } else if (right) {
+        filters = right;
       } else {
         filters = {expression: {}};
       }
+
       return filters;
     }
 


### PR DESCRIPTION
**1.415  Bug (P0)**
**Subject**: Filtering doesn’t work at controls tab on the all objects page
**Details**: 
Navigate to Controls tab on All object page 
Filter controls by visible fields (by owner like example) 
Click Filter button
_Actual Result_: the app doesn’t filter records
_Expected Result_: records should be filtered according to filtering criteria correctly
_Workaround_: N/A