### PR TITLE
QUICK-FIX Fix similar requests query

### DIFF
--- a/src/ggrc/models/mixins/with_similarity_score.py
+++ b/src/ggrc/models/mixins/with_similarity_score.py
@@ -9,6 +9,7 @@ relationships.
 
 from sqlalchemy import and_
 from sqlalchemy import case
+from sqlalchemy import literal
 from sqlalchemy import or_
 from sqlalchemy.orm import aliased
 from sqlalchemy.sql import func
@@ -106,6 +107,8 @@ class WithSimilarityScore(object):
         ),
     ]
 
+    queries_for_union += cls._emulate_relationships(id_, types, relevant_types)
+
     joined = queries_for_union.pop().union(*queries_for_union).subquery()
 
     # define weights for every "related" object type with values from
@@ -148,5 +151,90 @@ class WithSimilarityScore(object):
         # filter out "similar" objects that have insufficient similarity
         weight_sum >= threshold,
     )
+
+    return result
+
+  @classmethod
+  def _emulate_relationships(cls, id_, types, relevant_types):
+    """Get a list of queries for second-tier objects mapped via foreign key.
+
+    This is used primarily to determine Requests mapped to Audits (Request
+    model has a foreign key to Audit model and is not mapped with a
+    Relationship object).
+
+    Each query returns results compliant with the results of
+    get_similar_objects_query as they get UNIONed in that method.
+    """
+
+    # Note: this is a hack that can go away only when Request-Audit mapping
+    # will be implemented in Relationships table
+
+    from ggrc.models import Audit, Request
+
+    result = []
+    if Audit.__name__ in relevant_types:
+      # Note: this code assumes that `types` is a single-element list
+      if cls is Request and Request.__name__ in types:
+        similar_requests = aliased(cls, name="similar_requests")
+        result.append(db.session.query(
+            literal(Audit.__name__).label("related_type"),
+            similar_requests.id.label("similar_id"),
+            literal(Request.__name__).label("similar_type"),
+        ).select_from(
+            similar_requests,
+        ).join(
+            cls,
+            similar_requests.audit_id == cls.audit_id,
+        ).filter(
+            and_(cls.id == id_,
+                 cls.id != similar_requests.id),
+        ))
+      elif cls is Request and Request.__name__ not in types:
+        audit_to_similar = aliased(Relationship, name="audit_to_similar")
+        result.append(db.session.query(
+            literal(Audit.__name__).label("related_type"),
+            audit_to_similar.source_id.label("similar_id"),
+            audit_to_similar.source_type.label("similar_type"),
+        ).select_from(
+            audit_to_similar,
+        ).join(
+            cls,
+            and_(audit_to_similar.destination_id == cls.audit_id,
+                 audit_to_similar.destination_type == Audit.__name__),
+        ))
+        result.append(db.session.query(
+            literal(Audit.__name__).label("related_type"),
+            audit_to_similar.destination_id.label("similar_id"),
+            audit_to_similar.destination_type.label("similar_type"),
+        ).select_from(
+            audit_to_similar,
+        ).join(
+            cls,
+            and_(audit_to_similar.source_id == cls.audit_id,
+                 audit_to_similar.source_type == Audit.__name__),
+        ))
+      elif cls is not Request and Request.__name__ in types:
+        self_to_audit = aliased(Relationship, name="self_to_audit")
+        request = aliased(Request)
+
+        result.append(db.session.query(
+            literal(Audit.__name__).label("related_type"),
+            request.id.label("similar_id"),
+            literal(Request.__name__).label("similar_type"),
+        ).select_from(
+            request,
+        ).join(
+            self_to_audit,
+            or_(
+                and_(self_to_audit.source_id == id_,
+                     self_to_audit.source_type == cls.__name__,
+                     self_to_audit.destination_id == request.audit_id,
+                     self_to_audit.destination_type == Audit.__name__),
+                and_(self_to_audit.destination_id == id_,
+                     self_to_audit.destination_type == cls.__name__,
+                     self_to_audit.source_id == request.audit_id,
+                     self_to_audit.source_type == Audit.__name__),
+            ),
+        ))
 
     return result

--- a/test/integration/ggrc/models/factories.py
+++ b/test/integration/ggrc/models/factories.py
@@ -216,3 +216,11 @@ class RegulationFactory(ModelFactory, TitledFactory):
 
   class Meta:
     model = models.Regulation
+
+
+class RequestFactory(ModelFactory, TitledFactory):
+
+  class Meta:
+    model = models.Request
+
+  request_type = "documentation"

--- a/test/integration/ggrc/models/mixins/test_with_similarity_score.py
+++ b/test/integration/ggrc/models/mixins/test_with_similarity_score.py
@@ -6,6 +6,7 @@
 import json
 
 from ggrc.models import Assessment
+from ggrc.models import Request
 import integration.ggrc
 from integration.ggrc.models import factories
 
@@ -83,6 +84,51 @@ class TestWithSimilarityScore(integration.ggrc.TestCase):
     id_weight_map = {obj.id: int(obj.weight) for obj in similar_objects}
 
     self.assertDictEqual(id_weight_map, self.id_weight_map)
+
+  def test_similarity_for_request(self):
+    """Check special case for similarity for Request by Audit."""
+    request1 = factories.RequestFactory(audit_id=self.audit.id)
+    request2 = factories.RequestFactory(audit_id=self.audit.id)
+
+    self.make_relationships(request1, [self.control, self.regulation])
+
+    requests_by_request = Request.get_similar_objects_query(
+        id_=request1.id,
+        types=["Request"],
+        threshold=0,
+    ).all()
+
+    self.assertSetEqual(
+        {(obj.type, obj.id, obj.weight) for obj in requests_by_request},
+        {("Request", request2.id, 5)},
+    )
+
+    requests_by_assessment = Assessment.get_similar_objects_query(
+        id_=self.assessment.id,
+        types=["Request"],
+        threshold=0,
+    ).all()
+
+    self.assertSetEqual(
+        {(obj.type, obj.id, obj.weight) for obj in requests_by_assessment},
+        {("Request", request1.id, 18),
+         ("Request", request2.id, 5)},
+    )
+
+    assessments_by_request = Request.get_similar_objects_query(
+        id_=request1.id,
+        types=["Assessment"],
+        threshold=0,
+    ).all()
+
+    other_assessments = {
+        ("Assessment", assessment.id, self.id_weight_map[assessment.id])
+        for assessment in self.other_assessments
+    }
+    self.assertSetEqual(
+        {(obj.type, obj.id, obj.weight) for obj in assessments_by_request},
+        {("Assessment", self.assessment.id, 18)}.union(other_assessments),
+    )
 
   def test_get_similar_objects(self):
     """Check similar objects manually and via Query API."""


### PR DESCRIPTION
This PR adds a special case to the similarity computation code for Requests as the Request model is mapped to Audit model with a foreign key, not through Relationship objects.