### PR TITLE
Fix comment required dialog

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment/add_comment.js
+++ b/src/ggrc/assets/javascripts/components/assessment/add_comment.js
@@ -80,7 +80,7 @@
         this.attr('comment.value', null);
       },
       removeEmptyMark: function (scope, el) {
-        this.attr('state.empty', !el.val().length);
+        this.attr('state.empty', !el.text().length);
       },
       getCommentData: function () {
         var source = this.attr('instance');


### PR DESCRIPTION
When we changed the textarea into a rich text field we also changed how
we get value from the element. The rich text field requires the text()
function instead of the val().