### PR TITLE
ISSUE-1.432 Fix loading Cycles in tree view with deleted Tasks

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
@@ -1837,7 +1837,9 @@ can.Control('CMS.Controllers.TreeViewNode', {
         .then(this._ifNotRemoved(function () {
           this.element.trigger('subtree_loaded');
           this.element.trigger('loaded');
-          this._expand_deferred.resolve();
+          if (this._expand_deferred) {
+            this._expand_deferred.resolve();
+          }
         }.bind(this)));
     }.bind(this)), 0);
     return this._expand_deferred;


### PR DESCRIPTION
_(section 2, bug 1.432 - P0)_

This PR fixes a script error that occurs in the tree view when loading Workflow Task Groups that had a task deleted from them.

The cause was that that in these cases [resolving a deferred](https://github.com/google/ggrc-core/blob/develop/src/ggrc/assets/javascripts/controllers/tree_view_controller.js#L1840) failed because the deferred is, for some reason, [deleted first](https://github.com/google/ggrc-core/blob/develop/src/ggrc/assets/javascripts/controllers/tree_view_controller.js#L1675). Adding a simple check like the one just a [few lines above](https://github.com/google/ggrc-core/blob/develop/src/ggrc/assets/javascripts/controllers/tree_view_controller.js#L1823) did the trick.

I noticed that it is not possible to end a cycle without any tasks (the button is missing), but that's probably a separate issue.

No tests, sadly, because that  would require quite some refactoring of the nested callbacks. :/

**Steps to reproduce:**
- Create Workflow
- Add a task into task group
- Activate workflow
- Start new cycle (if it doesn't start automatically)
- Go to Active Cycle tab
- Delete a task from active cycle
- Reload page

**Actual Result:**
At the top you see an error message _"Uncaught TypeError: Cannot read property 'resolve' of undefined"_

**Expected Result:**
no errors