### PR TITLE
ISSUE-1.426 Remove creation new item in list in export page

### DIFF
--- a/src/ggrc/assets/javascripts/components/relevant_filters.js
+++ b/src/ggrc/assets/javascripts/components/relevant_filters.js
@@ -3,11 +3,17 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 */
 
-(function (can, $) {
-  can.Component.extend({
+(function (can, $, GGRC) {
+  GGRC.Components('relevantFilter', {
     tag: 'relevant-filter',
     template: can.view(GGRC.mustache_path + '/mapper/relevant_filter.mustache'),
     scope: {
+      define: {
+        disableCreate: {
+          type: 'boolean',
+          'default': false
+        }
+      },
       relevant_menu_item: '@',
       show_all: '@',
       addFilter: function () {
@@ -94,4 +100,4 @@
       }
     }
   });
-})(window.can, window.can.$);
+})(window.can, window.can.$, window.GGRC);

--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -2997,19 +2997,26 @@ Mustache.registerHelper("log", function () {
   })));
 });
 
-Mustache.registerHelper("autocomplete_select", function (options) {
+Mustache.registerHelper('autocomplete_select', function (disableCreate, opt) {
   var cls;
+  var options = arguments[arguments.length - 1];
+  var _disableCreate = Mustache.resolve(disableCreate);
+
+  if (typeof (_disableCreate) !== 'boolean') {
+    _disableCreate = false;
+  }
   if (options.hash && options.hash.controller) {
     cls = Mustache.resolve(cls);
-    if (typeof cls === "string") {
+    if (typeof cls === 'string') {
       cls = can.getObject(cls);
     }
   }
   return function (el) {
-    $(el).bind("inserted", function () {
-      var $ctl = $(this).parents(":data(controls)");
+    $(el).bind('inserted', function () {
+      var $ctl = $(this).parents(':data(controls)');
       $(this).ggrc_autocomplete($.extend({}, options.hash, {
-        controller : cls ? $ctl.control(cls) : $ctl.control()
+        controller: cls ? $ctl.control(cls) : $ctl.control(),
+        disableCreate: _disableCreate
       }));
     });
   };

--- a/src/ggrc/assets/javascripts/plugins/autocomplete.js
+++ b/src/ggrc/assets/javascripts/plugins/autocomplete.js
@@ -280,6 +280,8 @@
         }
       }
 
+      context.attr('disableCreate', this.options.disableCreate);
+
       $ul.unbind('scrollNext')
         .bind('scrollNext', function (ev, data) {
           if (context.attr('scroll_op_in_progress') ||

--- a/src/ggrc/assets/mustache/base_objects/autocomplete_result.mustache
+++ b/src/ggrc/assets/mustache/base_objects/autocomplete_result.mustache
@@ -22,7 +22,8 @@
 {{/if}}
 {{#if model}}
 {{#is_allowed "create" model.shortName context=null}}
-    {{^if_equals model.shortName "Workflow"}}
+    {{^if disableCreate}}
+      {{^if_equals model.shortName "Workflow"}}
         <li class="ui-menu-item add-new oneline" data-ui-autocomplete-item="">
           <a data-object-plural="{{model.table_plural}}"
              data-modal-class="modal-wide"
@@ -34,6 +35,7 @@
             + Create New
           </a>
         </li>
-    {{/if_equals}}
+      {{/if_equals}}
+    {{/if}}
 {{/is_allowed}}
 {{/if}}

--- a/src/ggrc/assets/mustache/import_export/export.mustache
+++ b/src/ggrc/assets/mustache/import_export/export.mustache
@@ -49,7 +49,7 @@
               {{> /static/mustache/import_export/export/attribute_selector.mustache}}
               {{> /static/mustache/import_export/export/filter_query.mustache}}
 
-              <relevant-filter show_all="true" has_parent="item.has_parent" relevant_menu_item="parent" type="export.type" panel_number="panel_number" relevant="item.relevant"></relevant-filter>
+              <relevant-filter show_all="true" has_parent="item.has_parent" relevant_menu_item="parent" type="export.type" panel_number="panel_number" relevant="item.relevant" disable-create="true"></relevant-filter>
             </export-panel>
           </div>
         {{/each}}

--- a/src/ggrc/assets/mustache/mapper/relevant_filter.mustache
+++ b/src/ggrc/assets/mustache/mapper/relevant_filter.mustache
@@ -32,7 +32,7 @@
             value="{{firstnonempty filter.name filter.email filter.title}}"
             data-lookup="{{this}}"
             data-template="/{{#if_equals model_name 'Person'}}people{{else}}base_objects{{/if_equals}}/autocomplete_result.mustache"
-            {{ autocomplete_select }}
+            {{ autocomplete_select disableCreate }}
             >
         </div>
         {{/model_name}}


### PR DESCRIPTION
**Subject:** Script error "Uncaught can.view: No template or empty template:/static/mustache/cycles/modal_content.mustache" appears when creating a new cycle while exporting data from the app
**Details:** 

- Log as Admin
- Navigate to Export page
- Click “+ Add New Rule” in FILTER BY MAPPING section
- Select Cycle in the dropdown
- at the bottom of the autocompletion list click “Create new” 

**Actual Result:** Script error "Uncaught can.view: No template or empty template:/static/mustache/cycles/modal_content.mustache" appears 
**Expected Result:** no errors should appear. I believe the  “Create new” option should be removed from the export page for all types of the objects, since there is no need in object creation when exporting.
**Workaround:** na