### PR TITLE
ISSUE-1.428 Fix get_custom_attr_value helper

### DIFF
--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -3403,42 +3403,43 @@ Mustache.registerHelper('get_url_value', function (attr_name, instance) {
 /*
   Used to get the string value for custom attributes
 */
-Mustache.registerHelper('get_custom_attr_value', function (attr, instance, options) {
-  var value = '';
-  var definition;
+  Mustache.registerHelper('get_custom_attr_value',
+    function (attr, instance, options) {
+      var value = '';
+      var definition;
 
-  attr = Mustache.resolve(attr);
-  instance = Mustache.resolve(instance);
+      attr = Mustache.resolve(attr);
+      instance = Mustache.resolve(instance);
 
-  can.each(GGRC.custom_attr_defs, function (item) {
-    if (item.definition_type === instance.class.table_singular &&
-        item.title === attr.attr_name) {
-      definition = item;
-    }
-  });
-
-  if (definition) {
-    can.each(instance.custom_attribute_values, function (item) {
-      if (!(instance instanceof CMS.Models.Assessment)) {
-        // reify all models with the exception of the Assessment,
-        // because it has a different logic of work with the CA
-        item = item.reify();
-      }
-      if (item.custom_attribute_id === definition.id) {
-        if (definition.attribute_type.startsWith('Map:')) {
-          value = options.fn(options.contexts.add({
-            object: item.attribute_object ?
-              item.attribute_object.reify() : null
-          }));
-        } else {
-          value = item.attribute_value;
+      can.each(GGRC.custom_attr_defs, function (item) {
+        if (item.definition_type === instance.class.table_singular &&
+          item.title === attr.attr_name) {
+          definition = item;
         }
-      }
-    });
-  }
+      });
 
-  return value;
-});
+      if (definition) {
+        can.each(instance.custom_attribute_values, function (item) {
+          if (!(instance instanceof CMS.Models.Assessment)) {
+            // reify all models with the exception of the Assessment,
+            // because it has a different logic of work with the CA
+            item = item.reify();
+          }
+          if (item.custom_attribute_id === definition.id) {
+            if (definition.attribute_type.startsWith('Map:')) {
+              value = options.fn(options.contexts.add({
+                object: item.attribute_object ?
+                  item.attribute_object.reify() : null
+              }));
+            } else {
+              value = item.attribute_value;
+            }
+          }
+        });
+      }
+
+      return value;
+    });
 
 Mustache.registerHelper('with_create_issue_json', function (instance, options) {
   var audits;

--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -3419,11 +3419,16 @@ Mustache.registerHelper('get_custom_attr_value', function (attr, instance, optio
 
   if (definition) {
     can.each(instance.custom_attribute_values, function (item) {
-      item = item.reify();
+      if (!(instance instanceof CMS.Models.Assessment)) {
+        // reify all models with the exception of the Assessment,
+        // because it has a different logic of work with the CA
+        item = item.reify();
+      }
       if (item.custom_attribute_id === definition.id) {
         if (definition.attribute_type.startsWith('Map:')) {
           value = options.fn(options.contexts.add({
-            object: item.attribute_object.reify()
+            object: item.attribute_object ?
+              item.attribute_object.reify() : null
           }));
         } else {
           value = item.attribute_value;


### PR DESCRIPTION
**1.428  Bug (P0)**
**Subject**: "Uncaught TypeError: Cannot read property 'custom_attribute_id' of undefined" error occurs while setting visible fields for Assessment 
**Details**: 
Log as Admin
Go to Admin Dashboard -> CA
Go to Assessments-> Create several Global CA (e.g. first: “name” - Rich text type, second: “name1” - dropdown type with values)
Create a program
Create an Audit> Go to Audit page
Create Assessment
Select Global CA fields in Set visible fields for Assessment widow> Set fields
_Actual Result_: "Uncaught TypeError: Cannot read property 'custom_attribute_id' of undefined" error occurs while setting visible fields for Assessment 
_Expected Result_: No error displayed. Should be the possibility to set visible fields. The title of Visible fields are displayed above Assessment’s first tier. 
_Workaround_: na