### PR TITLE
QUICK-FIX Clear similarity filter query

### DIFF
--- a/src/ggrc/converters/query_helper.py
+++ b/src/ggrc/converters/query_helper.py
@@ -282,6 +282,11 @@ class QueryHelper(object):
         total = len(matches)
       object_query["total"] = total
 
+    if hasattr(flask.g, "similar_objects_query"):
+      # delete similar_objects_query for the case when several queries are
+      # POSTed in one request, the first one filters by similarity and the
+      # second one doesn't but tries to sort by __similarity__
+      delattr(flask.g, "similar_objects_query")
     return matches
 
   @staticmethod

--- a/test/integration/ggrc/models/mixins/test_with_similarity_score.py
+++ b/test/integration/ggrc/models/mixins/test_with_similarity_score.py
@@ -173,3 +173,44 @@ class TestWithSimilarityScore(integration.ggrc.TestCase):
         response.json[0]["Assessment"]["ids"],
         [],
     )
+
+  def test_invalid_sort_by_similarity(self):
+    """Check sorting by __similarity__ with query API when it is impossible."""
+
+    # no filter by similarity but order by similarity
+    query = [{
+        "object_name": "Assessment",
+        "order_by": [{"name": "__similarity__"}],
+        "filters": {"expression": {}},
+    }]
+
+    self.assert400(self.client.post(
+        "/query",
+        data=json.dumps(query),
+        headers={"Content-Type": "application/json"},
+    ))
+
+    # filter by similarity in one query and order by similarity in another
+    query = [
+        {
+            "object_name": "Assessment",
+            "filters": {
+                "expression": {
+                    "op": {"name": "similar"},
+                    "object_name": "Assessment",
+                    "ids": [1],
+                },
+            },
+        },
+        {
+            "object_name": "Assessment",
+            "order_by": [{"name": "__similarity__"}],
+            "filters": {"expression": {}},
+        },
+    ]
+
+    self.assert400(self.client.post(
+        "/query",
+        data=json.dumps(query),
+        headers={"Content-Type": "application/json"},
+    ))


### PR DESCRIPTION
This PR fixes a minor issue with the similarity mechanism in Query API.

Steps to reproduce:
1. POST two queries in a single request: the first of query does a filter by similarity, the second one does sorting by similarity without filtering.

Expected result: HTTP 400 should be returned (as the second query is invalid).
Actual result: Two result sets are returned, the second one can have some sorting applied.

This case is covered in an integration test in this PR.