### PR TITLE
QUICK-FIX Remove delete column from Person csv template

### DIFF
--- a/src/ggrc/models/reflection.py
+++ b/src/ggrc/models/reflection.py
@@ -334,7 +334,7 @@ class AttributeInfo(object):
     filtered_aliases = [(k, v) for k, v in aliases.items() if v is not None]
 
     # push the extra delete column at the end to override any custom behavior
-    if hasattr(object_class, "slug") or hasattr(object_class, "email"):
+    if hasattr(object_class, "slug"):
       filtered_aliases.append(("delete", {
           "display_name": "Delete",
           "description": "",

--- a/test/integration/ggrc/converters/test_import_helpers.py
+++ b/test/integration/ggrc/converters/test_import_helpers.py
@@ -644,7 +644,6 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Email",
         "Company",
         "Role",
-        "Delete",
     }
     expected_names = element_names.union(mapping_names)
     self.assertEqual(expected_names, display_names)


### PR DESCRIPTION
We do not support deleting of users and that column should not exist in
the csv template.

Issue 449 on MIT.