### PR TITLE
QUICK-FIX Fix SQLAlchemy warning in similar filter

### DIFF
--- a/src/ggrc/converters/query_helper.py
+++ b/src/ggrc/converters/query_helper.py
@@ -529,8 +529,10 @@ class QueryHelper(object):
           types=[object_class.__name__],
       )
       flask.g.similar_objects_query = similar_objects_query
-      similar_objects = similar_objects_query.all()
-      return object_class.id.in_([obj.id for obj in similar_objects])
+      similar_objects_ids = [obj.id for obj in similar_objects_query]
+      if similar_objects_ids:
+        return object_class.id.in_(similar_objects_ids)
+      return sa.sql.false()
 
     def unknown():
       raise BadQueryException("Unknown operator \"{}\""

--- a/test/integration/ggrc/models/mixins/test_with_similarity_score.py
+++ b/test/integration/ggrc/models/mixins/test_with_similarity_score.py
@@ -149,3 +149,27 @@ class TestWithSimilarityScore(integration.ggrc.TestCase):
         json.loads(response.data)[0]["Assessment"]["ids"],
         expected_ids,
     )
+
+  def test_empty_similar_results(self):
+    """Check empty similarity result."""
+    query = [{
+        "object_name": "Assessment",
+        "type": "ids",
+        "filters": {
+            "expression": {
+                "op": {"name": "similar"},
+                "object_name": "Assessment",
+                "ids": ["-1"],
+            },
+        },
+    }]
+    response = self.client.post(
+        "/query",
+        data=json.dumps(query),
+        headers={"Content-Type": "application/json"},
+    )
+
+    self.assertListEqual(
+        response.json[0]["Assessment"]["ids"],
+        [],
+    )


### PR DESCRIPTION
This PR fixes the code so that a warning from SQLAlchemy "IN-predicate was called with an empty sequence" mentioned in #4455 that is raised in case when the filter should return an empty result set no longer appears.

Doing the filter like `ids = query_for_ids.all() ; id.in_(ids)` is slightly faster than doing it like `id.in_(query_for_ids)`. This difference increases with the size of the result set.