### PR TITLE
QUICK-FIX Add a special case for total

### DIFF
--- a/src/ggrc/converters/query_helper.py
+++ b/src/ggrc/converters/query_helper.py
@@ -313,10 +313,13 @@ class QueryHelper(object):
         # offset from 0 as the offset of the initial row for sql is 0 (not 1).
         matches = query.limit(page_size).offset(first).all()
       with benchmark("Apply limit: _apply_limit > query_count"):
-        # Note: using func.count() as query.count() is generating additional
-        # subquery
-        count_q = query.statement.with_only_columns([sa.func.count()])
-        total = db.session.execute(count_q).scalar()
+        if len(matches) < page_size:
+          total = len(matches) + first
+        else:
+          # Note: using func.count() as query.count() is generating additional
+          # subquery
+          count_q = query.statement.with_only_columns([sa.func.count()])
+          total = db.session.execute(count_q).scalar()
 
     return matches, total
 


### PR DESCRIPTION
This PR adds a special case for counting `total` without a DB query if fetched result set is smaller than `page_size` (@egorhm already tried to implement this optimization in #4440).