### PR TITLE
QUICK-FIX-1.437 "Uncaught can.Map: Object does not exist"

### DIFF
--- a/src/ggrc/assets/javascripts/bootstrap/modal-form.js
+++ b/src/ggrc/assets/javascripts/bootstrap/modal-form.js
@@ -159,8 +159,6 @@
     },
 
     hide: function (e) {
-      var control = this.control;
-      var options = control && control.options;
       var instance = this.instance;
       var pending;
       var hasPending;
@@ -184,11 +182,8 @@
             modal_title: 'Discard Changes',
             modal_description: 'Are you sure that you want to discard your changes?',
             modal_confirm: 'Discard',
-            instance: instance,
-            model: options.model,
             skip_refresh: true
           }, function () {
-            instance.restore(true);
             can.trigger(instance, 'modal:dismiss');
             this.$element
               .find("[data-dismiss='modal'], [data-dismiss='modal-reset']")


### PR DESCRIPTION
**1.437  Bug (P0)**
**Subject:** "Uncaught can.Map: Object does not exist" occurs after saving an Objective with the already existent title 
**Details:** 
Log as Admin
Go to LHN
Create an Objective
Navigate to Objective’s Info pane> Click 3 bb’s button to Edit objective.
Enter description
Click [x] button to close the window
Click  Discard
Enter already existent title > Save and Close
**Actual Result**: "Uncaught can.Map: Object does not exist" occurs after saving an Objective with the already existent title 
**Expected Result**: No error displayed. “The value 'no xxxx' is already used for another title; title values must be unique” message should be exist (as example).