### PR TITLE
ISSUE-1.423 Uncaught TypeError: Cannot read property 'findInCacheById' of undefined

### DIFF
--- a/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
+++ b/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
@@ -277,7 +277,9 @@
         'audit request': true,
         'program riskassessment': true,
         'assessmenttemplate cacheable': true,
-        'cacheable person': true
+        'cacheable person': true,
+        'person risk': true,
+        'person threat': true
       });
 
       if (target instanceof can.Model) {


### PR DESCRIPTION
**Subject**: "Uncaught TypeError: Cannot read property 'findInCacheById' of undefined" error occurs while clicking Create new Risk/Threats in unified mapper window at My Work page
**Details**: 

- Log as admin
- Go to My work page
- Go to Risk/Threats tab
- Click + to map Risk/Threats to person
- Click +Create New: confirm that an error is displayed

**Actual Result**: "Uncaught TypeError: Cannot read property 'findInCacheById' of undefined" error occurs while clicking Create new Risk/Threats in unified mapper window at My Work page

**Notes**: Related issues: 424, 430. 
Expected result: [+ Map Risks/Threats to this person] buttons should not exist at Risks/Threats tabs at My Work page
