### PR TITLE
ISSUE-1.435: Add custom attribute's nonASCII characters support

### DIFF
--- a/src/ggrc/models/reflection.py
+++ b/src/ggrc/models/reflection.py
@@ -292,7 +292,7 @@ class AttributeInfo(object):
         ca_type = cls.Type.OBJECT_CUSTOM
       else:
         ca_type = cls.Type.CUSTOM
-      attr_name = "{}{}".format(cls.CUSTOM_ATTR_PREFIX, attr.title).lower()
+      attr_name = u"{}{}".format(cls.CUSTOM_ATTR_PREFIX, attr.title).lower()
 
       definition_ids = definitions.get(attr_name, {}).get("definition_ids", [])
       definition_ids.append(attr.id)


### PR DESCRIPTION
**1.435  Issue (P1)**
**Subject:** AR: custom attribute with a non ascii character causes an data issue
**Details:** 
- Create custom attribute with non ASCII character in title
- Click on Data export menu item

**Actual result:** Stack trace on the screen and in console.
**Expected result:** Export page should be opened.