### PR TITLE
ISSUE-1.433 Fix refresh tree view after create/map object

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
@@ -1243,18 +1243,13 @@ CMS.Controllers.TreeLoader('CMS.Controllers.TreeView', {
   onCreatedRS: function (ev, instance) {
     var onCreated = this.onCreated.bind(this);
     var parentInstance = this.options.parent_instance;
-    var props = ['related_destinations', 'related_sources'];
     function callback() {
-      props.forEach(function (prop) {
-        parentInstance[prop].unbind('change', callback);
-      });
+      parentInstance.unbind('change', callback);
       onCreated();
     }
     if (instance instanceof CMS.Models.Relationship &&
       this._verifyRelationship(instance)) {
-      props.forEach(function (prop) {
-        parentInstance[prop].on('change', callback);
-      });
+      parentInstance.on('change', callback);
     }
   },
 


### PR DESCRIPTION
**1.433  Bug (P0)**
**Subject**: KC: Newly mapped/created object aren't shown in the tree view (refresh needed)
**Details**: 
Create a new program object
Open a tab in HNB (eg Controls)
Create a new control
_Actual Result_: Newly mapped/created object aren't shown in the tree view
_Expected Result_: Newly mapped/created object should be shown in the tree view
_Workaround_: refresh the page

**NOTE**: I listen changes on parent instance, because some part of objects after the change it trigger the `change` event on `related_source` and `related_destinations` arrays, and the rest trigger `property name` event, in my opinion that it because of that we recreate arrays, but I need time for investigate this issue and make code analysis. It is fast fix for release and I've created issue in Post Quince part 