### PR TITLE
ISSUE-1.447 Program page is displayed after edit Assessment

### DIFF
--- a/src/ggrc/assets/javascripts/bootstrap/modal-form.js
+++ b/src/ggrc/assets/javascripts/bootstrap/modal-form.js
@@ -166,6 +166,10 @@
       var hasPending;
       var changedInstance;
 
+      if (e) {
+        e.preventDefault();
+      }
+
       // If the hide was initiated by the backdrop, check for dirty form data before continuing
       if (e && $(e.target).is('.modal-backdrop,.fa-times')) {
         if ($(e.target).is('.disabled')) {


### PR DESCRIPTION
**1.447  Bug (P2)**
Subject: Program page is displayed after edit Assessment in Audit tab
**Details:** 
Create a Program
Create an audit
Go to Audit page and create an Assessment
Go to Program page-> Audit page
Navigate to first tree vier tier-> Click grey triangle
Select Assessment-> Navigate to Assessment’s Info pane-> click 3 bb’s button->Edit Assessment
Click [x] in Edit Assessment’s window-> Click Discard: confirm that the app. redirects to Program tab
**Actual Result:** Program page is displayed after edit Assessment in Audit tab
**Expected Result:** Audit tab should be displayed after adit Assessment  