### PR TITLE
ISSUE1.445: Fix multibyte characters error message

### DIFF
--- a/src/ggrc/converters/base_block.py
+++ b/src/ggrc/converters/base_block.py
@@ -243,6 +243,16 @@ class BlockConverter(object):
     for index, header in enumerate(headers):
       if header in header_names:
         field_name = header_names[header]
+        field_multibyte_err = False
+        try:
+          if len(field_name) != len(field_name.encode("utf-8")):
+            field_multibyte_err = True
+        except UnicodeDecodeError:
+          field_multibyte_err = True
+        if field_multibyte_err:
+          self.add_errors(errors.MULTIBYTE_ATTRIBUTE_ERROR,
+                          column_name=header, line=self.offset + 2)
+          return
         clean_headers[field_name] = self.object_headers[field_name]
       else:
         self.add_warning(errors.UNKNOWN_COLUMN,

--- a/src/ggrc/converters/errors.py
+++ b/src/ggrc/converters/errors.py
@@ -102,3 +102,8 @@ UNSUPPORTED_OPERATION_ERROR = (u"Line {line}: {operation} is not supported. "
 
 INVALID_ATTRIBUTE_WARNING = (u"Line {line}: Object does not contain attribute "
                              u"'{column_name}'. The value will be ignored.")
+
+MULTIBYTE_ATTRIBUTE_ERROR = (u"Line {line}: Cannot import objects with "
+                             u"an attribute name that contains multi-byte "
+                             u"characters: '{column_name}'. "
+                             u"The whole block will be ignored.")


### PR DESCRIPTION
Issue 1.445 is hot fix for Quince v3. In Raspberry app should
support import objects with multibyte custom attributes titles.
As we discussed with @akhilp1 on 09/28/2016 evening offline.

**1.445  Bug (P2)**
**Subject:** Incorrect error message occurs while importing an object with CA title that contains non ASCII characters
**Details:** 
- Log in as Admin 
- Go to Admin Dashboard-> Custom Attributes 
- Create CA for WF with Non ASCII characters in title
- Create WF1
- Export the created WF
- Edit CSV file: remove CODE and rename WF1 (e.g. WF2)
- Import CSV file

**Actual Result:** Incorrect error message occurs while importing an object with CA title that contains non ASCII characters
**Expected Result:** Correct error message occurs (e.g.): “Non ASCII characters forbidden while importing”