### PR TITLE
ISSUE-1.438 Fix mix CA after edit

### DIFF
--- a/src/ggrc/assets/javascripts/apps/custom_attributes.js
+++ b/src/ggrc/assets/javascripts/apps/custom_attributes.js
@@ -12,8 +12,14 @@
     scope: {
       instance: null,
       items: [],
-      setItems: function () {
-        this.attr('items', this.getValues());
+      setItems: function (isReady) {
+        var values = [];
+        if (isReady) {
+          values = this.getValues().sort(function (a, b) {
+            return a.cad.id - b.cad.id;
+          });
+          this.attr('items', values);
+        }
       },
       getValues: function () {
         var result = [];
@@ -42,7 +48,12 @@
       if (this.scope.instance.class.is_custom_attributable) {
         this.scope.instance.setup_custom_attributes();
       }
-      this.scope.setItems();
+      this.scope.setItems(true);
+    },
+    events: {
+      '{scope.instance} isReadyForRender': function (sc, ev, isReady) {
+        this.scope.setItems(isReady);
+      }
     }
   });
 })(window.can, window.GGRC);

--- a/src/ggrc/assets/javascripts/components/inline_edit/inline.js
+++ b/src/ggrc/assets/javascripts/components/inline_edit/inline.js
@@ -83,39 +83,39 @@
 
         this.attr('_value', value);
         this.attr('isSaving', true);
-        instance.refresh().then(function () {
-          if (this.attr('caId')) {
-            if (type === 'checkbox') {
-              value = value ? 1 : 0;
-            }
-            if (type === 'person') {
-              value = value ? ('Person:' + value.id) : value;
-            }
-            if (type === 'dropdown') {
-              if (value && value === '') {
-                value = undefined;
-              }
-            }
-            instance.attr('custom_attributes.' + caid, value);
-          } else {
-            instance.attr(property, value);
+
+        if (this.attr('caId')) {
+          if (type === 'checkbox') {
+            value = value ? 1 : 0;
           }
-          instance.save()
-            .done(function () {
-              $(document.body).trigger('ajax:flash', {
-                success: 'Saved'
-              });
-            })
-            .fail(function () {
-              this.attr('context.value', this.attr('_value'));
-              $(document.body).trigger('ajax:flash', {
-                error: 'There was a problem saving'
-              });
-            }.bind(this))
-            .always(function () {
-              this.attr('isSaving', false);
-            }.bind(this));
-        }.bind(this));
+          if (type === 'person') {
+            value = value ? ('Person:' + value.id) : value;
+          }
+          if (type === 'dropdown') {
+            if (value && value === '') {
+              value = undefined;
+            }
+          }
+          instance.attr('custom_attributes.' + caid, value);
+        } else {
+          instance.attr(property, value);
+        }
+        instance.attr('isReadyForRender', false);
+        instance.save()
+          .done(function () {
+            $(document.body).trigger('ajax:flash', {
+              success: 'Saved'
+            });
+          })
+          .fail(function () {
+            this.attr('context.value', this.attr('_value'));
+            $(document.body).trigger('ajax:flash', {
+              error: 'There was a problem saving'
+            });
+          }.bind(this))
+          .always(function () {
+            this.attr('isSaving', false);
+          }.bind(this));
       }
     },
     init: function (element, options) {

--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -56,7 +56,7 @@
     update: 'PUT /api/audits/{id}',
     destroy: 'DELETE /api/audits/{id}',
     create: 'POST /api/audits',
-    mixins: ['contactable', 'unique_title'],
+    mixins: ['contactable', 'unique_title', 'ca_update'],
     is_custom_attributable: true,
     is_clonable: true,
     attributes: {
@@ -389,7 +389,7 @@
     create: 'POST /api/requests',
     update: 'PUT /api/requests/{id}',
     destroy: 'DELETE /api/requests/{id}',
-    mixins: ['unique_title', 'relatable'],
+    mixins: ['unique_title', 'relatable', 'ca_update'],
     relatable_options: {
       relevantTypes: {
         Audit: {

--- a/src/ggrc/assets/javascripts/models/business_object_models.js
+++ b/src/ggrc/assets/javascripts/models/business_object_models.js
@@ -14,7 +14,7 @@ can.Model.Cacheable("CMS.Models.OrgGroup", {
   , create : "POST /api/org_groups"
   , update : "PUT /api/org_groups/{id}"
   , destroy : "DELETE /api/org_groups/{id}"
-  , mixins : ["ownable", "contactable", "unique_title"]
+  , mixins : ['ownable', 'contactable', 'unique_title', 'ca_update']
   , is_custom_attributable: true
   , attributes : {
       context: 'CMS.Models.Context.stub',
@@ -109,7 +109,7 @@ can.Model.Cacheable("CMS.Models.Project", {
   , create : "POST /api/projects"
   , update : "PUT /api/projects/{id}"
   , destroy : "DELETE /api/projects/{id}"
-  , mixins : ["ownable", "contactable", "unique_title"]
+  , mixins : ['ownable', 'contactable', 'unique_title', 'ca_update']
   , is_custom_attributable: true
   , attributes : {
       context: 'CMS.Models.Context.stub',
@@ -189,7 +189,7 @@ can.Model.Cacheable("CMS.Models.Facility", {
   , create : "POST /api/facilities"
   , update : "PUT /api/facilities/{id}"
   , destroy : "DELETE /api/facilities/{id}"
-  , mixins : ["ownable", "contactable", "unique_title"]
+  , mixins : ['ownable', 'contactable', 'unique_title', 'ca_update']
   , is_custom_attributable: true
   , attributes : {
       context: 'CMS.Models.Context.stub',
@@ -284,7 +284,7 @@ can.Model.Cacheable("CMS.Models.Product", {
   , create : "POST /api/products"
   , update : "PUT /api/products/{id}"
   , destroy : "DELETE /api/products/{id}"
-  , mixins : ["ownable", "contactable", "unique_title"]
+  , mixins : ['ownable', 'contactable', 'unique_title', 'ca_update']
   , is_custom_attributable: true
   , attributes : {
       context: 'CMS.Models.Context.stub',
@@ -383,7 +383,7 @@ can.Model.Cacheable("CMS.Models.DataAsset", {
   , create : "POST /api/data_assets"
   , update : "PUT /api/data_assets/{id}"
   , destroy : "DELETE /api/data_assets/{id}"
-  , mixins : ["ownable", "contactable", "unique_title"]
+  , mixins : ['ownable', 'contactable', 'unique_title', 'ca_update']
   , is_custom_attributable: true
   , attributes : {
       context: 'CMS.Models.Context.stub',
@@ -478,7 +478,7 @@ can.Model.Cacheable("CMS.Models.AccessGroup", {
   , create : "POST /api/access_groups"
   , update : "PUT /api/access_groups/{id}"
   , destroy : "DELETE /api/access_groups/{id}"
-  , mixins : ["ownable", "contactable", "unique_title"]
+  , mixins : ['ownable', 'contactable', 'unique_title', 'ca_update']
   , is_custom_attributable: true
   , attributes : {
       context : "CMS.Models.Context.stub"
@@ -571,7 +571,7 @@ can.Model.Cacheable("CMS.Models.AccessGroup", {
     create: 'POST /api/markets',
     update: 'PUT /api/markets/{id}',
     destroy: 'DELETE /api/markets/{id}',
-    mixins: ['ownable', 'contactable', 'unique_title'],
+    mixins: ['ownable', 'contactable', 'unique_title', 'ca_update'],
     is_custom_attributable: true,
     attributes: {
       context: 'CMS.Models.Context.stub',
@@ -654,7 +654,7 @@ can.Model.Cacheable("CMS.Models.Vendor", {
   , create : "POST /api/vendors"
   , update : "PUT /api/vendors/{id}"
   , destroy : "DELETE /api/vendors/{id}"
-  , mixins : ["ownable", "contactable", "unique_title"]
+  , mixins : ['ownable', 'contactable', 'unique_title', 'ca_update']
   , is_custom_attributable: true
   , attributes : {
       context: 'CMS.Models.Context.stub',

--- a/src/ggrc/assets/javascripts/models/control.js
+++ b/src/ggrc/assets/javascripts/models/control.js
@@ -14,7 +14,7 @@
     create: 'POST /api/controls',
     update: 'PUT /api/controls/{id}',
     destroy: 'DELETE /api/controls/{id}',
-    mixins: ['ownable', 'contactable', 'unique_title'],
+    mixins: ['ownable', 'contactable', 'unique_title', 'ca_update'],
     is_custom_attributable: true,
     attributes: {
       context: 'CMS.Models.Context.stub',

--- a/src/ggrc/assets/javascripts/models/directive_models.js
+++ b/src/ggrc/assets/javascripts/models/directive_models.js
@@ -98,6 +98,7 @@ CMS.Models.Directive("CMS.Models.Standard", {
   , attributes : {}
   , meta_kinds : [ "Standard" ]
   , cache : can.getObject("cache", CMS.Models.Directive, true),
+  mixins: ['ca_update'],
   defaults: {
     status: 'Draft',
     kind: 'Standard'
@@ -128,6 +129,7 @@ CMS.Models.Directive("CMS.Models.Regulation", {
   , attributes : {}
   , meta_kinds : [ "Regulation" ]
   , cache : can.getObject("cache", CMS.Models.Directive, true),
+  mixins: ['ca_update'],
   defaults: {
     status: 'Draft',
     kind: 'Regulation'
@@ -159,6 +161,7 @@ CMS.Models.Directive("CMS.Models.Policy", {
   , attributes : {}
   , meta_kinds : [  "Company Policy", "Org Group Policy", "Data Asset Policy", "Product Policy", "Contract-Related Policy", "Company Controls Policy" ]
   , cache : can.getObject("cache", CMS.Models.Directive, true),
+  mixins: ['ca_update'],
   defaults: {
     status: 'Draft',
     kind: null
@@ -198,6 +201,7 @@ CMS.Models.Directive("CMS.Models.Contract", {
   }
   , meta_kinds : [ "Contract" ]
   , cache : can.getObject("cache", CMS.Models.Directive, true),
+  mixins: ['ca_update'],
   defaults: {
     status: 'Draft',
     kind: 'Contract'

--- a/src/ggrc/assets/javascripts/models/issue.js
+++ b/src/ggrc/assets/javascripts/models/issue.js
@@ -11,7 +11,7 @@
     update: 'PUT /api/issues/{id}',
     destroy: 'DELETE /api/issues/{id}',
     create: 'POST /api/issues',
-    mixins: ['ownable', 'contactable'],
+    mixins: ['ownable', 'contactable', 'ca_update'],
     is_custom_attributable: true,
     attributes: {
       context: 'CMS.Models.Context.stub',

--- a/src/ggrc/assets/javascripts/models/mixins.js
+++ b/src/ggrc/assets/javascripts/models/mixins.js
@@ -142,6 +142,15 @@
     }
   });
 
+  can.Model.Mixin('ca_update', {}, {
+    after_save: function () {
+      this.attr('isReadyForRender', true);
+    },
+    info_pane_preload: function () {
+      this.refresh();
+    }
+  });
+
   can.Model.Mixin('unique_title', {
     'after:init': function () {
       this.validate(['title', '_transient.title'], function (newVal, prop) {

--- a/src/ggrc/assets/javascripts/models/person.js
+++ b/src/ggrc/assets/javascripts/models/person.js
@@ -43,6 +43,7 @@
       email: 'trimmedLower',
       custom_attribute_values: 'CMS.Models.CustomAttributeValue.stubs'
     },
+    mixins: ['ca_update'],
     defaults: {
       name: '',
       email: '',

--- a/src/ggrc/assets/javascripts/models/section.js
+++ b/src/ggrc/assets/javascripts/models/section.js
@@ -22,7 +22,7 @@ can.Model.Cacheable('CMS.Models.Section', {
   update: 'PUT /api/sections/{id}',
   destroy: 'DELETE /api/sections/{id}',
   is_custom_attributable: true,
-  mixins: ['ownable', 'contactable', 'unique_title'],
+  mixins: ['ownable', 'contactable', 'unique_title', 'ca_update'],
   attributes: {
     context: 'CMS.Models.Context.stub',
     owners: 'CMS.Models.Person.stubs',
@@ -95,7 +95,7 @@ can.Model.Cacheable('CMS.Models.Clause', {
   update: 'PUT /api/clauses/{id}',
   destroy: 'DELETE /api/clauses/{id}',
   is_custom_attributable: true,
-  mixins: ['ownable', 'contactable', 'unique_title'],
+  mixins: ['ownable', 'contactable', 'unique_title', 'ca_update'],
   attributes: {
     context: 'CMS.Models.Context.stub',
     owners: 'CMS.Models.Person.stubs',

--- a/src/ggrc/assets/javascripts/models/simple_models.js
+++ b/src/ggrc/assets/javascripts/models/simple_models.js
@@ -33,7 +33,7 @@ can.Model.Cacheable("CMS.Models.Program", {
   , create : "POST /api/programs"
   , update : "PUT /api/programs/{id}"
   , destroy : "DELETE /api/programs/{id}"
-  , mixins : ["contactable", "unique_title"]
+  , mixins : ['contactable', 'unique_title', 'ca_update']
   , is_custom_attributable: true
   , attributes : {
       context: 'CMS.Models.Context.stub',
@@ -127,7 +127,7 @@ can.Model.Cacheable("CMS.Models.Objective", {
   , create : "POST /api/objectives"
   , update : "PUT /api/objectives/{id}"
   , destroy : "DELETE /api/objectives/{id}"
-  , mixins : ["ownable", "contactable", "unique_title"]
+  , mixins : ['ownable', 'contactable', 'unique_title', 'ca_update']
   , is_custom_attributable: true
   , attributes : {
       context : "CMS.Models.Context.stub"

--- a/src/ggrc/assets/javascripts/models/system.js
+++ b/src/ggrc/assets/javascripts/models/system.js
@@ -107,7 +107,7 @@ CMS.Models.SystemOrProcess('CMS.Models.System', {
   create: 'POST /api/systems',
   update: 'PUT /api/systems/{id}',
   destroy: 'DELETE /api/systems/{id}',
-
+  mixins: ['ca_update'],
   cache: can.getObject('cache', CMS.Models.SystemOrProcess, true),
   is_custom_attributable: true,
   attributes: {},
@@ -161,6 +161,7 @@ CMS.Models.SystemOrProcess('CMS.Models.Process', {
     url: '',
     status: 'Draft'
   },
+  mixins: ['ca_update'],
   statuses: ['Draft', 'Final', 'Effective', 'Ineffective', 'Launched',
     'Not Launched', 'In Scope', 'Not in Scope', 'Deprecated'],
   init: function () {

--- a/src/ggrc/assets/mustache/custom_attributes/info.mustache
+++ b/src/ggrc/assets/mustache/custom_attributes/info.mustache
@@ -5,8 +5,9 @@
 
 <custom-attributes instance="instance">
     {{#if instance.custom_attribute_definitions.length}}
+      {{#iterate_by_two items}}
       <div class="row-fluid wrap-row">
-      {{#items}}
+      {{#list}}
         <div class="span6">
           <div data-custom-attribute="{{id}}" data-type="{{attribute_type}}">
             <inline-edit
@@ -30,7 +31,8 @@
             ></inline-edit>
           </div>
         </div>
-      {{/items}}
+      {{/list}}
       </div>
+      {{/iterate_by_two}}
     {{/if}}
 </custom-attributes>

--- a/src/ggrc_risk_assessments/assets/javascripts/models/risk_assessment.js
+++ b/src/ggrc_risk_assessments/assets/javascripts/models/risk_assessment.js
@@ -13,6 +13,7 @@
     root_object: "risk_assessment",
     root_collection: "risk_assessments",
     category: "risk_assessment",
+    mixins: ['ca_update'],
     findAll: "GET /api/risk_assessments",
     findOne: "GET /api/risk_assessments/{id}",
     create: "POST /api/risk_assessments",

--- a/src/ggrc_risks/assets/javascripts/models/risk.js
+++ b/src/ggrc_risks/assets/javascripts/models/risk.js
@@ -15,7 +15,7 @@
     create: "POST /api/risks",
     update: "PUT /api/risks/{id}",
     destroy: "DELETE /api/risks/{id}",
-    mixins: ["ownable", "contactable", "unique_title"],
+    mixins: ['ownable', 'contactable', 'unique_title', 'ca_update'],
     is_custom_attributable: true,
     attributes : {
       context : "CMS.Models.Context.stub",

--- a/src/ggrc_risks/assets/javascripts/models/threat.js
+++ b/src/ggrc_risks/assets/javascripts/models/threat.js
@@ -14,7 +14,7 @@
     create: "POST /api/threats",
     update: "PUT /api/threats/{id}",
     destroy: "DELETE /api/threats/{id}",
-    mixins: ["ownable", "contactable", "unique_title"],
+    mixins: ['ownable', 'contactable', 'unique_title', 'ca_update'],
     is_custom_attributable: true,
     attributes: {
       context: "CMS.Models.Context.stub",

--- a/src/ggrc_workflows/assets/javascripts/models/workflow.js
+++ b/src/ggrc_workflows/assets/javascripts/models/workflow.js
@@ -10,7 +10,7 @@
     root_object: "workflow",
     root_collection: "workflows",
     category: "workflow",
-    mixins: [],
+    mixins: ['ca_update'],
     findAll: "GET /api/workflows",
     findOne: "GET /api/workflows/{id}",
     create: "POST /api/workflows",


### PR DESCRIPTION
**1.438  Bug (P0)**
**Subject**: CA field with dropdown type is shown as rich text and CA filed with rich text is shown as dropdown in Workflow's Info pane after edit   
**Details**: 
Create a Workflow
Go to Workflow Info page
Navigate to Workflow's Info pane
Edit any CA (e.g. MY_TITLE4 ): CA looks like rich text instead of chekbox. 
_Actual Result_: Mandatory CA field with dropdown type is shown as rich text and CA filed with rich text is shown as dropdown in Workflow's Info pane  
_Expected Result_: CA fields are displayed according to Attribute type  
_Workaround_: NA
**Note**: check all the CA fields according to Attribute type 