### PR TITLE
ISSUE-1.364 Add URL and evidence descriptions to CSV templates

### DIFF
--- a/src/ggrc/models/assessment.py
+++ b/src/ggrc/models/assessment.py
@@ -22,7 +22,7 @@ from ggrc.models.mixins.autostatuschangeable import AutoStatusChangeable
 from ggrc.models.mixins.validate_on_complete import ValidateOnComplete
 from ggrc.models.mixins.with_similarity_score import WithSimilarityScore
 from ggrc.models.deferred import deferred
-from ggrc.models.object_document import Documentable
+from ggrc.models.object_document import EvidenceURL
 from ggrc.models.object_person import Personable
 from ggrc.models.reflection import PublishOnly
 from ggrc.models.relationship import Relatable
@@ -66,7 +66,7 @@ class AuditRelationship(object):
 
 class Assessment(statusable.Statusable, AuditRelationship,
                  AutoStatusChangeable, Assignable, HasObjectState, TestPlanned,
-                 CustomAttributable, Documentable, Commentable, Personable,
+                 CustomAttributable, EvidenceURL, Commentable, Personable,
                  reminderable.Reminderable, Timeboxed, Relatable,
                  WithSimilarityScore, FinishedDate, VerifiedDate,
                  ValidateOnComplete, BusinessObject, db.Model):
@@ -167,16 +167,6 @@ class Assessment(statusable.Statusable, AuditRelationship,
           "display_name": "Verifier",
           "filter_by": "_filter_by_related_verifiers",
           "type": reflection.AttributeInfo.Type.MAPPING,
-      },
-      "document_url": {
-          "display_name": "Url",
-          "filter_by": "_ignore_filter",
-          "type": reflection.AttributeInfo.Type.SPECIAL_MAPPING,
-      },
-      "document_evidence": {
-          "display_name": "Evidence",
-          "filter_by": "_ignore_filter",
-          "type": reflection.AttributeInfo.Type.SPECIAL_MAPPING,
       },
   }
 

--- a/src/ggrc/models/object_document.py
+++ b/src/ggrc/models/object_document.py
@@ -1,12 +1,15 @@
 # Copyright (C) 2016 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
-from ggrc import db
+from sqlalchemy import orm
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.ext.declarative import declared_attr
+
+
+from ggrc import db
+from ggrc.models import reflection
 from ggrc.models.deferred import deferred
 from ggrc.models.mixins import Mapping, Timeboxed
-from ggrc.models.reflection import PublishOnly
 
 
 class ObjectDocument(Timeboxed, Mapping, db.Model):
@@ -72,8 +75,6 @@ class ObjectDocument(Timeboxed, Mapping, db.Model):
 
   @classmethod
   def eager_query(cls):
-    from sqlalchemy import orm
-
     query = super(ObjectDocument, cls).eager_query()
     return query.options(
         orm.subqueryload('document'))
@@ -103,7 +104,7 @@ class Documentable(object):
     )
 
   _publish_attrs = [
-      PublishOnly('documents'),
+      reflection.PublishOnly('documents'),
       'object_documents',
   ]
 
@@ -113,8 +114,30 @@ class Documentable(object):
 
   @classmethod
   def eager_query(cls):
-    from sqlalchemy import orm
-
     query = super(Documentable, cls).eager_query()
     return cls.eager_inclusions(query, Documentable._include_links).options(
         orm.subqueryload('object_documents'))
+
+class EvidenceURL(Documentable):
+  """Documentable mixin for evidence and URL documents."""
+
+  _aliases = {
+      "document_url": {
+          "display_name": "Url",
+          "filter_by": "_filter_by_url",
+          "type": reflection.AttributeInfo.Type.SPECIAL_MAPPING,
+      },
+      "document_evidence": {
+          "display_name": "Evidence",
+          "filter_by": "_filter_by_evidence",
+          "type": reflection.AttributeInfo.Type.SPECIAL_MAPPING,
+      },
+  }
+
+  @classmethod
+  def _filter_by_url(cls, _):
+    return None
+
+  @classmethod
+  def _filter_by_evidence(cls, _):
+    return None

--- a/src/ggrc/models/object_document.py
+++ b/src/ggrc/models/object_document.py
@@ -118,6 +118,7 @@ class Documentable(object):
     return cls.eager_inclusions(query, Documentable._include_links).options(
         orm.subqueryload('object_documents'))
 
+
 class EvidenceURL(Documentable):
   """Documentable mixin for evidence and URL documents."""
 
@@ -126,11 +127,15 @@ class EvidenceURL(Documentable):
           "display_name": "Url",
           "filter_by": "_filter_by_url",
           "type": reflection.AttributeInfo.Type.SPECIAL_MAPPING,
+          "description": "New line separated list of URLs.",
       },
       "document_evidence": {
           "display_name": "Evidence",
           "filter_by": "_filter_by_evidence",
           "type": reflection.AttributeInfo.Type.SPECIAL_MAPPING,
+          "description": ("New line separated list of evidence links and "
+                          "titles.\nExample:\n\nhttp://my.gdrive.link/file "
+                          "Title of the evidence link"),
       },
   }
 

--- a/src/ggrc/models/request.py
+++ b/src/ggrc/models/request.py
@@ -26,13 +26,13 @@ from ggrc.models.mixins.with_similarity_score import WithSimilarityScore
 from ggrc.models.mixins.autostatuschangeable import AutoStatusChangeable
 from ggrc.models.deferred import deferred
 from ggrc.models.mixins.assignable import Assignable
-from ggrc.models.object_document import Documentable
+from ggrc.models.object_document import EvidenceURL
 from ggrc.models.object_person import Personable
 from ggrc.utils import similarity_options as similarity_options_module
 
 
 class Request(statusable.Statusable, AutoStatusChangeable, Assignable,
-              Documentable, Personable, CustomAttributable,
+              EvidenceURL, Personable, CustomAttributable,
               relationship.Relatable, WithSimilarityScore, Titled, Slugged,
               Described, Commentable, FinishedDate, VerifiedDate, Base,
               db.Model):
@@ -141,16 +141,6 @@ class Request(statusable.Statusable, AutoStatusChangeable, Assignable,
           "filter_by": "_filter_by_related_verifiers",
           "type": reflection.AttributeInfo.Type.MAPPING,
       },
-      "document_url": {
-          "display_name": "Url",
-          "filter_by": "_filter_by_url",
-          "type": reflection.AttributeInfo.Type.SPECIAL_MAPPING,
-      },
-      "document_evidence": {
-          "display_name": "Evidence",
-          "filter_by": "_filter_by_evidence",
-          "type": reflection.AttributeInfo.Type.SPECIAL_MAPPING,
-      },
   }
 
   def _display_name(self):
@@ -186,14 +176,6 @@ class Request(statusable.Statusable, AutoStatusChangeable, Assignable,
   @classmethod
   def _filter_by_related_verifiers(cls, predicate):
     return cls._get_relate_filter(predicate, "Verifier")
-
-  @classmethod
-  def _filter_by_url(cls, _):
-    return None
-
-  @classmethod
-  def _filter_by_evidence(cls, _):
-    return None
 
   @classmethod
   def _filter_by_request_audit(cls, predicate):


### PR DESCRIPTION
Bug description:
> Subject: add the hint explaining what should be put into Evidence column in CSV Request/Assessment template
> Details: 
> Download CSV import template
> Actual Result: Evidence column title doesn’t contain explanation what should be 
> Expected Result: users should have the hint how to field fields properly

These descriptions are duplicated because of improper use of
documentable mixin, where the descriptions would otherwise belong.