### PR TITLE
QUICK-FIX Enable auto state transition for all DONE states

### DIFF
--- a/src/ggrc/models/mixins/autostatuschangeable.py
+++ b/src/ggrc/models/mixins/autostatuschangeable.py
@@ -29,7 +29,7 @@ class AutoStatusChangeable(object):
   _tracked_attrs = set()
 
   FIRST_CLASS_EDIT = ({statusable.Statusable.START_STATE} |
-                      statusable.Statusable.END_STATES)
+                      statusable.Statusable.DONE_STATES)
   ASSIGNABLE_EDIT = statusable.Statusable.END_STATES
 
   @staticmethod

--- a/test/integration/ggrc/models/mixins/test_autostatuschangable.py
+++ b/test/integration/ggrc/models/mixins/test_autostatuschangable.py
@@ -107,7 +107,7 @@ class TestMixinAutoStatusChangeable(integration.ggrc.TestCase):
     self.assertEqual(assessment.title.endswith("modified, change #2"),
                      True)
     self.assertEqual(assessment.status,
-                     models.Assessment.DONE_STATE)
+                     models.Assessment.PROGRESS_STATE)
 
     assessment = self.change_status(assessment,
                                     assessment.VERIFIED_STATE,


### PR DESCRIPTION
This makes the objects like Assessment to automatically transition to the "In Progress" state on edit even when they are in a DONE state (or in any of the FINAL states, as before).

This PR is closely related to the [other PR](https://github.com/google/ggrc-core/pull/4473) that adresses automatic state transitioning, but it fixes a different cause of the problem.

To reproduce, open a Statusable object (e.g. an Assessment), put it into a DONE (but not FINAL) state, e.g. the "Ready to Review" state. Then modify a custom attribute on that Assessment's info panel, and the Assessment does not go into the "In Progress" state automatically (and does after the fix).

The test will be added in a follow-up pull request that will also add the state transition confirmation dialog. 

**Edit:** Well, it  turned out that the test was already in place, I just needed to modify one of its assertions.