### PR TITLE
ISSUE-1.449 "Uncaught TypeError: Cannot read property 'top' of undefined"

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
@@ -855,6 +855,9 @@ CMS.Controllers.TreeLoader('CMS.Controllers.TreeView', {
     if (!(el instanceof jQuery)) {
       el = $(el);
     }
+    if (!el.offset()) {
+      return 0;
+    }
     el_o = el.offset().top;
     el_h = el.outerHeight();
     above_top = (el_o + el_h - se_o) / se_h;


### PR DESCRIPTION
**Subject**: Script error "Uncaught TypeError: Cannot read property 'top' of undefined" appears after deleting an object that is mapped to an Assessment
**Details**: 

- Navigate to assessments tab on audit page 
- Open assessment’s 2nd tier with mapped objects
- Click on mapped object’s 1st tier to open its info panel
- Click 3bbs button and select delete button
- Confirm deletion

**Actual Result**: Script error "Uncaught TypeError: Cannot read property 'top' of undefined" appears after deleting an object that is mapped to an Assessment
**Expected Result**: no errors!
