### PR TITLE
ISSUE-1.396 Objects' titles aren't shown immediately after adding them into Controls and  RELATED INFORMATION sections on Assessment's info panel

### DIFF
--- a/src/ggrc/assets/javascripts/components/mapped-objects/mapped-objects.js
+++ b/src/ggrc/assets/javascripts/components/mapped-objects/mapped-objects.js
@@ -51,10 +51,7 @@
       this.scope.setMappedObjects();
     },
     events: {
-      '{scope.parentInstance.related_destinations} length': function () {
-        this.scope.setMappedObjects();
-      },
-      '{scope.parentInstance.related_sources} length': function () {
+      '{scope.parentInstance} change': function () {
         this.scope.setMappedObjects();
       }
     }


### PR DESCRIPTION
1.396  Bug (P1)
Subject: Objects' titles aren't shown immediately after adding them into Controls and 
RELATED INFORMATION sections on Assessment's info panel
Details: 
Navigate to Assessments tab on Audit page
Open assessment’s info panel
Map a control using (+) button in controls section on the info panel (or map any object in 
RELATED INFORMATION via the same (+) button)
Actual Result: Objects' titles aren't shown immediately after adding them
Expected Result: Objects' titles should be shown immediately after adding them
