### PR TITLE
ISSUE-1.361 Add description for CA dropdown fields

### DIFF
--- a/src/ggrc/models/reflection.py
+++ b/src/ggrc/models/reflection.py
@@ -288,10 +288,16 @@ class AttributeInfo(object):
     else:
       custom_attributes = object_class.get_custom_attribute_definitions()
     for attr in custom_attributes:
+      description = ""
       if attr.definition_id:
         ca_type = cls.Type.OBJECT_CUSTOM
       else:
         ca_type = cls.Type.CUSTOM
+        if (attr.attribute_type == attr.ValidTypes.DROPDOWN and
+                attr.multi_choice_options):
+          description = "Accepted values are:\n{}".format(
+              attr.multi_choice_options.replace(",", "\n")
+          )
       attr_name = u"{}{}".format(cls.CUSTOM_ATTR_PREFIX, attr.title).lower()
 
       definition_ids = definitions.get(attr_name, {}).get("definition_ids", [])
@@ -302,7 +308,7 @@ class AttributeInfo(object):
           "attr_name": attr.title,
           "mandatory": attr.mandatory,
           "unique": False,
-          "description": "",
+          "description": description,
           "type": ca_type,
           "definition_ids": definition_ids,
       }

--- a/src/ggrc/models/reflection.py
+++ b/src/ggrc/models/reflection.py
@@ -288,14 +288,16 @@ class AttributeInfo(object):
     else:
       custom_attributes = object_class.get_custom_attribute_definitions()
     for attr in custom_attributes:
-      description = ""
+      description = attr.helptext or ""
       if attr.definition_id:
         ca_type = cls.Type.OBJECT_CUSTOM
       else:
         ca_type = cls.Type.CUSTOM
         if (attr.attribute_type == attr.ValidTypes.DROPDOWN and
                 attr.multi_choice_options):
-          description = "Accepted values are:\n{}".format(
+          if description:
+            description += "\n\n"
+          description += "Accepted values are:\n{}".format(
               attr.multi_choice_options.replace(",", "\n")
           )
       attr_name = u"{}{}".format(cls.CUSTOM_ATTR_PREFIX, attr.title).lower()

--- a/test/integration/ggrc/converters/test_ca_import_export.py
+++ b/test/integration/ggrc/converters/test_ca_import_export.py
@@ -174,7 +174,8 @@ class TestCustomAttributeImportExport(TestCase):
                                 headers=self.headers)
 
     self.assert200(response)
-    self.assertEqual(len(response.data.splitlines()), 21)
+    self.assertEqual(len(response.data.splitlines()), 28)
+    self.assertIn("Accepted values are", response.data)
 
   def tests_ca_export_filters(self):
     """Test filtering on custom attribute values."""

--- a/test/integration/ggrc/converters/test_ca_import_export.py
+++ b/test/integration/ggrc/converters/test_ca_import_export.py
@@ -50,11 +50,12 @@ class TestCustomAttributeImportExport(TestCase):
     gen("product", attribute_type="Rich Text", title="normal RT")
     gen("product", attribute_type="Rich Text", title="man RT", mandatory=True)
     gen("product", attribute_type="Date", title="normal Date")
-    gen("product", attribute_type="Date", title="man Date", mandatory=True)
+    gen("product", attribute_type="Date", title="man Date", mandatory=True,
+        helptext="Birthday")
     gen("product", attribute_type="Checkbox", title="normal CH")
     gen("product", attribute_type="Checkbox", title="man CH", mandatory=True)
     gen("product", attribute_type="Dropdown", title="normal select",
-        options="a,b,c,d")
+        options="a,b,c,d", helptext="Your favorite number.")
     gen("product", attribute_type="Dropdown", title="man select",
         options="e,f,g", mandatory=True)
     gen("product", attribute_type="Map:Person", title="normal person")
@@ -174,8 +175,10 @@ class TestCustomAttributeImportExport(TestCase):
                                 headers=self.headers)
 
     self.assert200(response)
-    self.assertEqual(len(response.data.splitlines()), 28)
-    self.assertIn("Accepted values are", response.data)
+    self.assertEqual(len(response.data.splitlines()), 30)
+    self.assertIn("\"Accepted values are", response.data)
+    self.assertIn("number.\n\nAccepted values are", response.data)
+    self.assertIn("Birthday", response.data)
 
   def tests_ca_export_filters(self):
     """Test filtering on custom attribute values."""


### PR DESCRIPTION
The import template should list possible options for dropdown custom
attribute definitions.

bug description:
> Subject: add description for the dropdown CA fields in CSV template (requests and assessments)
> Details: 
> Create a global CA dropdown field for a request / assessment
> Export CSV template
> Actual Result: dropdown field’s title is listed in CSV template but there is no dropdown items listed.
> Expected Result: show dropdown items in CSV template 
> Workaround: NA