### PR TITLE
ISSUE-1.453 "Uncaught TypeError: Cannot read property 'serialize' of undefined" error occurs while generating Assessment Mapped to Control

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment_generator.js
+++ b/src/ggrc/assets/javascripts/components/assessment_generator.js
@@ -3,12 +3,13 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 */
 
-(function (can, $) {
+(function (_, can, $, GGRC, CMS) {
   'use strict';
 
   GGRC.Components('assessmentGeneratorButton', {
     tag: 'assessment-generator-button',
-    template: '{{{> /static/mustache/base_objects/generate_assessments_button.mustache}}}',
+    template: '{{{> /static/mustache/base_objects/' +
+    'generate_assessments_button.mustache}}}',
     scope: {
       audit: null
     },
@@ -115,8 +116,7 @@
           object: object.stub(),
           context: this.scope.audit.context,
           template: assessmentTemplate && assessmentTemplate.stub(),
-          title: title,
-          owners: [CMS.Models.Person.findInCacheById(GGRC.current_user.id)]
+          title: title
         };
 
         if (assessmentTemplate) {
@@ -167,4 +167,4 @@
       }
     }
   });
-})(window.can, window.can.$);
+})(window._, window.can, window.can.$, window.GGRC, window.CMS);


### PR DESCRIPTION
1.453  Bug (P0)
Subject: "Uncaught TypeError: Cannot read property 'serialize' of undefined" error occurs while generating Assessment Mapped to Control 
Details: 
Create a program
Create an audit
Go to audit page-> Create Control->Create Assessment template 
Go to Assessment tab-> Click Generate Assessment
Select created Assessment template
Select Mapped to Control in FILTER BY MAPPING section
Search-> Select Control from the search list (e.g. 1 test control dfdf)
Click Generate Assessment: an error occurs
The link: https://grc-test.appspot.com/audits/53#assessment_widget
Actual Result: "Uncaught TypeError: Cannot read property 'serialize' of undefined" error occurs while generating Assessment Mapped to Control  
Expected Result: No error displayed. Assessment Mapped to Control should be generated
Workaround: NA
