### PR TITLE
ISSUE-1.455 Fix control export

### DIFF
--- a/src/ggrc/converters/handlers/boolean.py
+++ b/src/ggrc/converters/handlers/boolean.py
@@ -30,7 +30,7 @@ class CheckboxColumnHandler(handlers.ColumnHandler):
     if self.raw_value == "":
       return False
     value = self.raw_value.lower() in self.TRUE_VALUES
-    if self.raw_value == self.NONE_VALUES:
+    if self.raw_value in self.NONE_VALUES:
       value = None
     if self.raw_value.lower() not in self.ALLOWED_VALUES:
       self.add_warning(errors.WRONG_VALUE, column_name=self.display_name)
@@ -65,6 +65,5 @@ class KeyControlColumnHandler(CheckboxColumnHandler):
 
   ALLOWED_VALUES = {"key", "non-key", "--", "---"}
   TRUE_VALUES = {"key"}
-  NONE_VALUES = {"--", "---"}
   _true = "key"
   _false = "non-key"

--- a/src/ggrc/converters/handlers/boolean.py
+++ b/src/ggrc/converters/handlers/boolean.py
@@ -22,6 +22,8 @@ class CheckboxColumnHandler(handlers.ColumnHandler):
   ALLOWED_VALUES = {"yes", "true", "no", "false", "--", "---"}
   TRUE_VALUES = {"yes", "true"}
   NONE_VALUES = {"--", "---"}
+  _true = "yes"
+  _false = "no"
 
   def parse_item(self):
     """ mandatory checkboxes will get evelauted to false on empty value """
@@ -38,7 +40,7 @@ class CheckboxColumnHandler(handlers.ColumnHandler):
     val = getattr(self.row_converter.obj, self.key, False)
     if val is None:
       return "--"
-    return "true" if val else "false"
+    return self._true if val else self._false
 
   def set_obj_attr(self):
     """ handle set object for boolean values
@@ -64,3 +66,5 @@ class KeyControlColumnHandler(CheckboxColumnHandler):
   ALLOWED_VALUES = {"key", "non-key", "--", "---"}
   TRUE_VALUES = {"key"}
   NONE_VALUES = {"--", "---"}
+  _true = "key"
+  _false = "non-key"

--- a/src/ggrc/converters/handlers/handlers.py
+++ b/src/ggrc/converters/handlers/handlers.py
@@ -476,7 +476,7 @@ class OptionColumnHandler(ColumnHandler):
   def get_value(self):
     option = getattr(self.row_converter.obj, self.key, None)
     if option is None:
-      return ""
+      return "--"
     if callable(option.title):
       return option.title()
     return option.title

--- a/src/ggrc/models/control.py
+++ b/src/ggrc/models/control.py
@@ -205,7 +205,10 @@ class Control(HasObjectState, Relatable, CustomAttributable, Documentable,
           "display_name": "Secondary Assessor",
           "filter_by": "_filter_by_secondary_assessor",
       },
-      "key_control": "Significance",
+      "key_control": {
+          "display_name": "Significance",
+          "description": "Allowed values are:\nkey\nnon-key\n---",
+      }
   }
 
   @validates('kind', 'means', 'verify_frequency')


### PR DESCRIPTION
**P0 for V4**

bug description:

> Subject: the app says that Significance column contains invalid data if "True" and "False" is used though the app exports values "True" and "False" for existing controls objects
> Details: 
> Navigate to export page
> Export 3 controls with different values for Significance field
> Reimport csv file you’ve just exported
> Actual Result: the app says that Significance column contains invalid data
> Expected Result: data should be ok, we’ve just exported them
> Workaround: NA
> 