### PR TITLE
QUICK-FIX Improve the AutoStatusChangeable mixin's docstring

### DIFF
--- a/src/ggrc/models/mixins/autostatuschangeable.py
+++ b/src/ggrc/models/mixins/autostatuschangeable.py
@@ -18,11 +18,10 @@ from ggrc.models.mixins import statusable
 
 
 class AutoStatusChangeable(object):
-  """
-  Mixin for automatic status changes
+  """A mixin for automatic status changes.
 
-  Enables automatic transitioning of objects on any edit in cases where object
-  has reached one of end states.
+  Enables automatic transitioning of objects on any edit in cases when an
+  object is in one of the DONE states, or in the START state.
   """
 
   __lazy_init__ = True


### PR DESCRIPTION
This is a follow-up on #4483, updating the docstring to more accurately reflect what the `AutoStatusChangeable` mixin does.