### PR TITLE
ISSUE-1.425 Fix issue with empty values for Rich Text and Text Inputs

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment/inline.js
+++ b/src/ggrc/assets/javascripts/components/assessment/inline.js
@@ -65,10 +65,16 @@
         var value = this.attr('context.value');
 
         this.attr('isEdit', false);
+        // In case value is String and consists only of spaces - do nothing
+        if (typeof value === 'string' && !value.trim()) {
+          this.attr('context.value', '');
+          value = null;
+        }
 
         if (oldValue === value) {
           return;
         }
+
         this.attr('_value', oldValue);
         this.attr('value', value);
         this.attr('isSaving', true);

--- a/src/ggrc/assets/javascripts/components/ca-object/ca-object-value-mapper.js
+++ b/src/ggrc/assets/javascripts/components/ca-object/ca-object-value-mapper.js
@@ -47,6 +47,14 @@
         if (type === 'checkbox') {
           return value === '1';
         }
+
+        if (type === 'input') {
+          if (!value) {
+            return null;
+          }
+          return value.trim();
+        }
+
         if (type === 'person') {
           if (valueObj) {
             return valueObj;


### PR DESCRIPTION
1.425  Bug (P1)
Subject: Spaces are considered to be a value in mandatory CA fields
Details: 
Navigate to Assessments tab on audit page
Open Assessment’s info panel and enter spaces into mandatory field
Actual Result: the app accepts spaces as actual value and allows to complete the Assessment
Expected Result: spaces shouldn’t be considered as a value in mandatory text fields
Workaround: na