### PR TITLE
ISSUE-1.446 Change sort rule for list of tasks

### DIFF
--- a/src/ggrc/assets/javascripts/components/sort_by_sort_index/sort_by_sort_index.js
+++ b/src/ggrc/assets/javascripts/components/sort_by_sort_index/sort_by_sort_index.js
@@ -6,8 +6,8 @@
 (function (can, $) {
   'use strict';
 
-  GGRC.Components('sortBySortIndex', {
-    tag: 'sort-by-sort-index',
+  GGRC.Components('tasksSortList', {
+    tag: 'tasks-sort-list',
     scope: {
       sorted: null,
       mapping: null,
@@ -16,17 +16,36 @@
 
     init: function () {
       var mapping = this.scope.attr('mapping');
+      var getTaskDate = function (instance, type) {
+        var date = new Date();
+        var month = instance['relative_' + type + '_month'];
+        var day = instance['relative_' + type + '_day'];
+
+        if (instance[type + '_date']) {
+          return instance[type + '_date'];
+        }
+        date.setHours(0, 0, 0, 0);
+        date.setDate(day);
+        if (month) {
+          date.setMonth(month - 1);
+        }
+        return date;
+      };
       var sort = function () {
         var arr = _.toArray(mapping);
         var last;
         var lastIndex;
         arr.sort(function (a, b) {
-          a = a.instance.sort_index;
-          b = b.instance.sort_index;
-          if (a === b) {
-            return 0;
+          var ad = getTaskDate(a.instance, 'start');
+          var bd = getTaskDate(b.instance, 'start');
+          var result = ad.getTime() - bd.getTime();
+
+          if (!result) {
+            ad = getTaskDate(a.instance, 'end');
+            bd = getTaskDate(b.instance, 'end');
+            result = ad - bd;
           }
-          return GGRC.Math.string_less_than(a, b) ? -1 : 1;
+          return result;
         });
         this.scope.attr('sorted', arr);
         last = arr[arr.length - 1];

--- a/src/ggrc_workflows/assets/mustache/task_groups/info.mustache
+++ b/src/ggrc_workflows/assets/mustache/task_groups/info.mustache
@@ -62,7 +62,7 @@
           {{#with_mapping 'task_group_tasks' instance}}
             <h3>Tasks (<span>{{task_group_tasks.length}}</span>)</h3>
             <h4 class="inline-explanation">Define tasks</h4>
-            <sort-by-sort-index mapping="task_group_tasks">
+            <tasks-sort-list mapping="task_group_tasks">
               <ul class="tree-structure new-tree"
                   {{sortable_if instance.lock_task_order '{ "items": "li:not(.tree-footer)", "handle": ".drag" }' inverse=true}}>
                 {{#each sorted}}
@@ -70,7 +70,7 @@
                 {{/each}}
                 {{>'/static/mustache/task_group_tasks/task_group_subtree_footer.mustache'}}
               </ul>
-            </sort-by-sort-index>
+            </tasks-sort-list>
           {{/with_mapping}}
         </div>
 


### PR DESCRIPTION
**1.446  Bug (P1)**
**Subject**: Tasks are not ordered by date in Task Group Info pane
**Details**: 
Create WF
Go to Setup tab
Create Task Group
Navigate to Task Group Info pane
Create Tasks with different titles, assignees and dates (e.g. 10 tasks)
Go to another tab and return to Task Group Info pane once again
Look at the created tasks: confirm tasks are not sorted alphabetically
_Actual Result_: Tasks are not ordered by date in Task Group Info pane
_Expected Result_: Tasks should be ordered by date in Task Group Info pane