### PR TITLE
QUICK-FIX Duplicate item in unified mapper

### DIFF
--- a/src/ggrc/assets/javascripts/components/unified_mapper/mapper_results.js
+++ b/src/ggrc/assets/javascripts/components/unified_mapper/mapper_results.js
@@ -95,6 +95,11 @@
           type: instance.type,
           href: instance.href
         });
+        if (this.scope.attr('page') === 0) {
+          // if the added item is the first one rendered, update the page
+          // counter manually not to confuse drawPage method
+          this.scope.attr('page', 1);
+        }
       },
       '.results-wrap scrollNext': 'drawPage',
       getItem: function (model) {


### PR DESCRIPTION
Steps to reproduce:
1. Navigate to a program page.
2. Open "Controls" tab.
3. Click "map" plus button if the mapper does not open automatically.
4. In the mapper, click "Create new control".
5. Fill in the form, click "save". (the new control is displayed in the result list)
6. Scroll the list down.

Expected result: Nothing happens as there is only one item in the list, there is nowhere to scroll.
Actual result: The new control is duplicated.

The bug occures because the method `drawPage` that is triggered on scrolling event tries to refresh items in `this.scope.entries[this.scope.page*20, (this.scope.page+1)*20]` and append them to the list that is rendered. Since `this.scope.page` is initialized to `0` and is not updated on new control creation, items from `this.scope.entries[0, 20]` are appended to the list that is rendered, thus duplicating the new control that is `this.scope.entries[0]`.

**On hold** since this fix is scheduled to go to V4.