### PR TITLE
1.440 Fix unmap person from workflow

### DIFF
--- a/src/ggrc/assets/javascripts/models/cacheable.js
+++ b/src/ggrc/assets/javascripts/models/cacheable.js
@@ -1447,6 +1447,10 @@
         this.__instance = this._model().model(this);
       }
       return this.__instance;
+    },
+
+    getInstance: function () {
+      return this._instance();
     }
   });
 

--- a/src/ggrc/assets/javascripts/models/mappers/tree-page-loader.js
+++ b/src/ggrc/assets/javascripts/models/mappers/tree-page-loader.js
@@ -39,8 +39,15 @@
       return this.makeResult(mapping.reify(), binding);
     },
     makeResult: function (instance, binding) {
-      return CMS.Models.Relationship
-        .getRelationshipBetweenInstances(binding.instance, instance, true)
+      var relationships;
+      if (binding.instance.workflow_people) {
+        relationships = CMS.Models.Relationship
+          .getWorkflowPersonRelationship(binding.instance, instance);
+      } else {
+        relationships = CMS.Models.Relationship
+          .getRelationshipBetweenInstances(binding.instance, instance, true);
+      }
+      return relationships
         .then(function (relationships) {
           return new GGRC.ListLoaders.MappingResult(
             instance, can.map(relationships, function (relationship) {


### PR DESCRIPTION
**Subject:** URBAN: cannot unmap a person from WF
**Details:** 

- Create Workflow
- Go to People tab at Workflow Info page
- Click + to map Person to this WF (e.g. reader@reciprocitylabs.com)
- Navigate to Person’s Info panel> Click 3 bb’s button
- Click Unmap: Person is not unmapped

**Actual Result:** cannot unmap a person from WF
**Expected Result:** person should be unmapped from WF
