### PR TITLE
QUICK-FIX Confirm status change on edit

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment/inline.js
+++ b/src/ggrc/assets/javascripts/components/assessment/inline.js
@@ -30,6 +30,9 @@
         value: null,
         options: null
       },
+
+      _EV_BEFORE_EDIT: 'before-edit',  // before entering the edit mode
+
       setPerson: function (scope, el, ev) {
         this.attr('context.value', ev.selectedItem.serialize());
       },
@@ -37,25 +40,43 @@
         ev.preventDefault();
         this.attr('context.value', undefined);
       },
+
       /**
        * Enter the edit mode if editing is allowed (i.e. the readonly option is
-       * not set). If the readonly option is enabled, do not do anything.
+       * not set).
+       *
+       * If the readonly option is enabled, do not do anything. The same if the
+       * beforeEdit handler is not defined, or if the promise it returns is not
+       * resolved.
        *
        * @param {can.Map} scope - the scope object itself (this)
+       * @param {jQuery.Element} $el - the DOM element that triggered the event
+       * @param {jQuery.Event} ev - the event object
        */
-      enableEdit: function (scope) {
-        if (scope.attr('readonly')) {
+      enableEdit: function (scope, $el, ev) {
+        var confirmation;
+        var onBeforeEdit = this.$rootEl.attr('can-' + scope._EV_BEFORE_EDIT);
+
+        ev.preventDefault();
+
+        if (this.attr('readonly')) {
           return;
         }
-        if (scope.needConfirm) {
-          scope.confirmEdit.confirm(scope.instance,
-            scope.confirmEdit).done(function () {
-              scope.attr('isEdit', true);
-            });
-        } else {
-          scope.attr('isEdit', true);
+
+        if (!onBeforeEdit) {
+          this.attr('isEdit', true);
+          return;
         }
+
+        confirmation = this.$rootEl.triggerHandler({
+          type: this._EV_BEFORE_EDIT
+        });
+
+        confirmation.done(function () {
+          this.attr('isEdit', true);
+        }.bind(this));   // and do nothing if no confirmation by the user
       },
+
       onCancel: function (scope) {
         scope.attr('isEdit', false);
         scope.attr('context.value', scope.attr('_value'));
@@ -74,12 +95,14 @@
         this.attr('isSaving', true);
       }
     },
-    init: function () {
+    init: function (element, options) {
       var scope = this.scope;
       var value = scope.attr('value');
 
       scope.attr('_value', value);
       scope.attr('context.value', value);
+
+      scope.attr('$rootEl', $(element));
     },
     events: {
       '{window} mousedown': function (el, ev) {

--- a/src/ggrc/assets/javascripts/components/inline_edit/inline.js
+++ b/src/ggrc/assets/javascripts/components/inline_edit/inline.js
@@ -28,22 +28,47 @@
       emptyText: '@',
       $rootEl: null,
       type: '@',
-      _EV_INSTANCE_SAVE: 'on-save',
+
+      // event names definitions
+      _EV_INSTANCE_SAVE: 'on-save',  // "save" button is clicked
+      _EV_BEFORE_EDIT: 'before-edit',  // before entering the edit mode
 
       /**
        * Enter the edit mode if editing is allowed (i.e. the readonly option is
-       * not set). If the readonly option is enabled, do not do anything.
+       * not set).
+       *
+       * If the readonly option is enabled, do not do anything. The same if the
+       * beforeEdit handler is not defined, or if the promise it returns is not
+       * resolved.
        *
        * @param {can.Map} scope - the scope object itself (this)
        * @param {jQuery.Element} $el - the DOM element that triggered the event
        * @param {jQuery.Event} ev - the event object
        */
       enableEdit: function (scope, $el, ev) {
+        var confirmation;
+        var onBeforeEdit = this.$rootEl.attr('can-' + scope._EV_BEFORE_EDIT);
+
         ev.preventDefault();
-        if (!this.attr('readonly')) {
-          this.attr('context.isEdit', true);
+
+        if (this.attr('readonly')) {
+          return;
         }
+
+        if (!onBeforeEdit) {
+          this.attr('context.isEdit', true);
+          return;
+        }
+
+        confirmation = this.$rootEl.triggerHandler({
+          type: this._EV_BEFORE_EDIT
+        });
+
+        confirmation.done(function () {
+          this.attr('context.isEdit', true);
+        }.bind(this));   // and do nothing if no confirmation by the user
       },
+
       onCancel: function (ctx, el, ev) {
         ev.preventDefault();
         this.attr('context.isEdit', false);

--- a/src/ggrc/assets/javascripts/models/assessment.js
+++ b/src/ggrc/assets/javascripts/models/assessment.js
@@ -11,7 +11,10 @@
     update: 'PUT /api/assessments/{id}',
     destroy: 'DELETE /api/assessments/{id}',
     create: 'POST /api/assessments',
-    mixins: ['ownable', 'contactable', 'unique_title', 'relatable'],
+    mixins: [
+      'ownable', 'contactable', 'unique_title', 'relatable',
+      'autoStatusChangeable'
+    ],
     relatable_options: {
       relevantTypes: {
         Audit: {

--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -368,7 +368,7 @@
     create: 'POST /api/requests',
     update: 'PUT /api/requests/{id}',
     destroy: 'DELETE /api/requests/{id}',
-    mixins: ['unique_title', 'relatable', 'ca_update'],
+    mixins: ['unique_title', 'relatable', 'ca_update', 'autoStatusChangeable'],
     relatable_options: {
       relevantTypes: {
         Audit: {

--- a/src/ggrc/assets/javascripts/models/mixins.js
+++ b/src/ggrc/assets/javascripts/models/mixins.js
@@ -151,6 +151,52 @@
     }
   });
 
+  /**
+   * A mixin to use for objects that can have their status automatically
+   * changed when they are edited.
+   *
+   * @class CMS.Models.Mixins.autoStatusChangeable
+   */
+  can.Model.Mixin('autoStatusChangeable', {}, {
+
+    /**
+     * Display a confirmation dialog before starting to edit the instance.
+     *
+     * The dialog is not shown only if the instance is in the "In Progress"
+     * state - in that case an already resolved promise is returned.
+     *
+     * @return {Promise} A promise resolved/rejected if the user chooses to
+     *   confirm/reject the dialog.
+     */
+    confirmBeginEdit: function () {
+      var STATUS_IN_PROGRESS = 'In Progress';
+
+      var TITLE = [
+        'Confirm moving ', this.type, ' to "', STATUS_IN_PROGRESS, '"'
+      ].join('');
+
+      var DESCRIPTION = [
+        'If you modify a value, the status of the ', this.type,
+        ' will move from "', this.status, '" to "',
+        STATUS_IN_PROGRESS, '" - are you sure about that?'
+      ].join('');
+
+      var confirmation = $.Deferred();
+
+      if (this.status === STATUS_IN_PROGRESS) {
+        confirmation.resolve();
+      } else {
+        GGRC.Controllers.Modals.confirm({
+          modal_description: DESCRIPTION,
+          modal_title: TITLE,
+          button_view: GGRC.mustache_path + '/gdrive/confirm_buttons.mustache'
+        }, confirmation.resolve, confirmation.reject);
+      }
+
+      return confirmation.promise();
+    }
+  });
+
   can.Model.Mixin('unique_title', {
     'after:init': function () {
       this.validate(['title', '_transient.title'], function (newVal, prop) {

--- a/src/ggrc/assets/javascripts/models/tests/autoStatusChangeable_mixin_spec.js
+++ b/src/ggrc/assets/javascripts/models/tests/autoStatusChangeable_mixin_spec.js
@@ -1,0 +1,109 @@
+/*!
+  Copyright (C) 2016 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+describe('CMS.Models.Mixins.autoStatusChangeable', function () {
+  'use strict';
+
+  var Mixin;
+
+  beforeAll(function () {
+    Mixin = CMS.Models.Mixins.autoStatusChangeable;
+  });
+
+  describe('confirmBeginEdit() method', function () {
+    var instance;
+    var method;
+
+    beforeEach(function () {
+      instance = new can.Map({
+        type: 'MyModel',
+        status: 'Not Started'
+      });
+      method = Mixin.prototype.confirmBeginEdit.bind(instance);
+
+      spyOn(GGRC.Controllers.Modals, 'confirm');
+    });
+
+    it('displays a confirmation dialog with correct texts', function () {
+      var callArgs;
+      var expectedBodyText;
+      var expectedTitle;
+      var modalOptions;
+      var spy;
+
+      instance.attr('type', 'MagicType');
+      instance.attr('status', 'In Limbo');
+
+      method();
+
+      spy = GGRC.Controllers.Modals.confirm;
+      expect(spy).toHaveBeenCalled();
+
+      callArgs = spy.calls.first().args;
+      modalOptions = callArgs[0];
+
+      expectedTitle = 'Confirm moving MagicType to "In Progress"';
+      expect(modalOptions.modal_title).toEqual(expectedTitle);
+
+      expectedBodyText = [
+        'If you modify a value, the status of the MagicType will move',
+        'from "In Limbo" to "In Progress" - are you sure about that?'
+      ].join(' ');
+      expect(modalOptions.modal_description).toEqual(expectedBodyText);
+    });
+
+    it('resolves the given promise if the dialog gets confimred', function () {
+      var callArgs;
+      var confirmCallback;
+      var promise;
+      var spy;
+
+      promise = method();
+
+      spy = GGRC.Controllers.Modals.confirm;
+      expect(spy).toHaveBeenCalled();
+
+      callArgs = spy.calls.first().args;
+      confirmCallback = callArgs[1];
+
+      expect(promise.state()).not.toEqual(
+        'resolved',
+        'The promise was resolved too early.'
+      );
+      confirmCallback();
+      expect(promise.state()).toEqual('resolved');
+    });
+
+    it('rejects the given promise if the dialog gets cancelled', function () {
+      var callArgs;
+      var rejectCallback;
+      var promise;
+      var spy;
+
+      promise = method();
+
+      spy = GGRC.Controllers.Modals.confirm;
+      expect(spy).toHaveBeenCalled();
+
+      callArgs = spy.calls.first().args;
+      rejectCallback = callArgs[2];
+
+      expect(promise.state()).not.toEqual(
+        'rejected',
+        'The promise was rejected too early.'
+      );
+      rejectCallback();
+      expect(promise.state()).toEqual('rejected');
+    });
+
+    it('returns a resolved promise if "In Progress" state', function () {
+      var promise;
+
+      instance.attr('status', 'In Progress');
+      promise = method();
+      expect(promise.state()).toEqual('resolved');
+    });
+  });
+});

--- a/src/ggrc/assets/mustache/components/assessment/custom-attributes.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/custom-attributes.mustache
@@ -16,6 +16,7 @@
                   {{^is_allowed 'update' instance context='for'}}
                         readonly
                   {{/is_allowed}}
+                  can-before-edit="instance.confirmBeginEdit"
                 ></assessment-inline-edit>
             </ca-object-value-mapper>
         </ca-object>

--- a/src/ggrc/assets/mustache/custom_attributes/info.mustache
+++ b/src/ggrc/assets/mustache/custom_attributes/info.mustache
@@ -28,6 +28,7 @@
               {{^is_allowed 'update' instance context='for'}}
                 readonly
               {{/is_allowed}}
+              can-before-edit="instance.confirmBeginEdit"
             ></inline-edit>
           </div>
         </div>


### PR DESCRIPTION
This is a follow-up on #4473. It adds a confirmation dialog about automatic state transition when editing a custom attribute on Assessment's/Request's info pane (note - to see it in action, the Assessment/Request object must **not** be in the _"In Progress"_ state).

If you can, please review this with a bit higher priority, I only have time to apply any needed changes tomorrow (but even that is not guaranteed).

A couple of notes:
- We have two separate implementations of the inline-edit widget component (Assessments use their own implementation). I did not have time to refactor and unify these two components, thus duplicating the `enableEdit()` method. We should nevertheless make the unification after the release.
- In the modal dialog, the Confirm/Cancel buttons are colored red and green, respectively. At least to me this is a bit counter-intuitive, the colors should IMO be reversed, but I left this behavior as is. If needed, this can subsequently easily be changed  by swapping the classes in the relevant modal buttons template.
- The `beforeEdit()` callback is defined on a model. It belongs more to a controller (the model itself should not really know anything about modals), but I didn't find a good CanJS-ish way to use a controller's method in a template. On the other hand, this is quite a common pattern in the app, the models already contain quite a few such "controller" methods, thus I did not try to address this here.