### PR TITLE
QUICK FK Fix export with empty person CA

### DIFF
--- a/src/ggrc/converters/handlers/custom_attribute.py
+++ b/src/ggrc/converters/handlers/custom_attribute.py
@@ -61,14 +61,15 @@ class CustomAttributeColumHandler(handlers.TextColumnHandler):
     for value in self.row_converter.obj.custom_attribute_values:
       if value.custom_attribute_id == definition.id:
         if value.custom_attribute.attribute_type.startswith("Map:"):
-          obj = value.attribute_object
-          return getattr(obj, "email", getattr(obj, "slug", None))
+          if value.attribute_object_id:
+            obj = value.attribute_object
+            return getattr(obj, "email", getattr(obj, "slug", None))
         elif value.custom_attribute.attribute_type == _types.CHECKBOX:
           attr_val = value.attribute_value if value.attribute_value else u"0"
           attr_val = int(attr_val)
           return str(bool(attr_val)).upper()
-
-        return value.attribute_value
+        else:
+          return value.attribute_value
 
     return None
 


### PR DESCRIPTION
Since we're storing CA values for all definitions even if the value has
not been set, we should support exporting empty person CA.

This is a data issue and not a filter issue as the bug description says.
P0 issue not in issue finder:
> Error appeared after a try to export all assessments using "GLOBAL CA"= 3 as a filter

Please note that this is just a bugfix and the whole get_value needs to be refactored as part of performance tickets for raspberry. 
