### PR TITLE
ISSUE-1.416 Checkbox for Reuse evidences is still available for already reused evidences at Related Assessment tab in Assessment's Info panel

### DIFF
--- a/src/ggrc/assets/javascripts/components/reusable-objects/reusable-objects-item.js
+++ b/src/ggrc/assets/javascripts/components/reusable-objects/reusable-objects-item.js
@@ -14,21 +14,24 @@
     template: tpl,
     scope: {
       isSaving: false,
+      instance: null,
+      checkReusedStatus: false,
       selectedList: new can.List(),
       disabled: false,
       isDisabled: function () {
         return this.attr('disabled');
       },
       setDisabled: function () {
-        this.attr('disabled', GGRC.Utils.is_mapped(
+        var isDisabled = GGRC.Utils.is_mapped(
           this.attr('baseInstance'),
           this.attr('instance'),
-          this.attr('mapping')));
+          this.attr('mapping'));
+        this.attr('disabled', isDisabled);
       },
-      toggleSelection: function (val) {
+      toggleSelection: function (isChecked) {
         var list = this.attr('selectedList');
         var index;
-        if (val) {
+        if (isChecked) {
           list.push(this.attr('instance'));
         } else {
           index = list.indexOf(this.attr('instance'));
@@ -43,11 +46,10 @@
       'input[type="checkbox"] change': function (el) {
         this.scope.toggleSelection(el.is(':checked'));
       },
-      '{scope.baseInstance.object_documents} length': function () {
-        this.scope.setDisabled();
-      },
-      '{scope.baseInstance.related_destinations} length': function () {
-        this.scope.setDisabled();
+      '{scope} checkReusedStatus': function (scope, ev, performCheck) {
+        if (performCheck) {
+          this.scope.setDisabled();
+        }
       }
     }
   });

--- a/src/ggrc/assets/javascripts/components/reusable-objects/reusable-objects-item.js
+++ b/src/ggrc/assets/javascripts/components/reusable-objects/reusable-objects-item.js
@@ -22,10 +22,6 @@
       isDisabled: function () {
         return this.attr('disabled');
       },
-      setReuseMapperType: function () {
-        // Add extra attribute to the instance property to setup exact mapper type
-        this.attr('instance.reuseMapperType', this.attr('mapping'));
-      },
       setDisabled: function () {
         var isDisabled = GGRC.Utils.is_mapped(
           this.attr('baseInstance'),
@@ -45,7 +41,6 @@
       }
     },
     init: function () {
-      this.scope.setReuseMapperType();
       this.scope.setDisabled();
     },
     events: {

--- a/src/ggrc/assets/javascripts/components/reusable-objects/reusable-objects-item.js
+++ b/src/ggrc/assets/javascripts/components/reusable-objects/reusable-objects-item.js
@@ -16,10 +16,15 @@
       isSaving: false,
       instance: null,
       checkReusedStatus: false,
-      selectedList: new can.List(),
+      selectedList: [],
       disabled: false,
+      mapping: null,
       isDisabled: function () {
         return this.attr('disabled');
+      },
+      setReuseMapperType: function () {
+        // Add extra attribute to the instance property to setup exact mapper type
+        this.attr('instance.reuseMapperType', this.attr('mapping'));
       },
       setDisabled: function () {
         var isDisabled = GGRC.Utils.is_mapped(
@@ -40,6 +45,7 @@
       }
     },
     init: function () {
+      this.scope.setReuseMapperType();
       this.scope.setDisabled();
     },
     events: {

--- a/src/ggrc/assets/javascripts/components/reusable-objects/reusable-objects-list.js
+++ b/src/ggrc/assets/javascripts/components/reusable-objects/reusable-objects-list.js
@@ -21,9 +21,16 @@
         document: destination
       });
     },
-    // TODO: need to add a more reliable check
     isObjectDocument: function (object) {
-      return object.object_documents && object.object_documents.length;
+      var isObjectDocument;
+      if (object.attr('reuseMapperType')) {
+        isObjectDocument =
+          object.attr('reuseMapperType') === 'all_documents';
+      } else {
+        isObjectDocument =
+          object.object_documents && object.object_documents.length;
+      }
+      return isObjectDocument;
     },
     mapObjects: function (source, destination) {
       return this.isObjectDocument(destination) ?
@@ -37,7 +44,7 @@
     scope: {
       baseInstance: null,
       checkReusedStatus: false,
-      selectedList: new can.List(),
+      selectedList: [],
       isSaving: false,
       reuseSelected: function () {
         var reusedList = this.attr('selectedList');

--- a/src/ggrc/assets/mustache/assessments/related-assessments.mustache
+++ b/src/ggrc/assets/mustache/assessments/related-assessments.mustache
@@ -58,6 +58,7 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                                                    is-saving="isSaving"
                                                    base-instance="baseInstance"
                                                    mapping="mapping"
+                                                   check-reused-status="checkReusedStatus"
                                                    selected-list="selectedList">
                                 <span class="date">{{date instance.created_at true}}</span>
                                 <a href="{{schemed_url instance.link}}" target="_blank">
@@ -73,6 +74,7 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                                                    is-saving="isSaving"
                                                    base-instance="baseInstance"
                                                    mapping="mapping"
+                                                   check-reused-status="checkReusedStatus"
                                                    selected-list="selectedList">
                                 <span class="date">{{date instance.created_at true}}</span>
                                 <a href="{{schemed_url instance.link}}" target="_blank">

--- a/src/ggrc/assets/mustache/assessments/related-assessments.mustache
+++ b/src/ggrc/assets/mustache/assessments/related-assessments.mustache
@@ -44,22 +44,20 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                     <div class="flex-size-1">
                         <mapped-objects
                                 parent-instance="instance"
-                                mapping="{{instance.class.info_pane_options.mapped_objects.mapping}}"
-                        >
+                                mapping="{{instance.class.info_pane_options.mapped_objects.mapping}}">
                           {{> '/static/mustache/components/assessment/mapped-objects/mapped-related-information-item.mustache' }}
                         </mapped-objects>
                     </div>
                     <div class="flex-size-1">
                         <mapped-objects
                                 parent-instance="instance"
-                                mapping="{{instance.class.info_pane_options.evidence.mapping}}"
-                        >
+                                mapping="{{instance.class.info_pane_options.evidence.mapping}}">
                             <reusable-objects-item instance="instance"
                                                    is-saving="isSaving"
                                                    base-instance="baseInstance"
                                                    mapping="mapping"
                                                    check-reused-status="checkReusedStatus"
-                                                   selected-list="selectedList">
+                                                   selected-list="evidenceList">
                                 <span class="date">{{date instance.created_at true}}</span>
                                 <a href="{{schemed_url instance.link}}" target="_blank">
                                     <span>{{firstnonempty instance.title instance.link}}</span>
@@ -68,14 +66,13 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                         </mapped-objects>
                         <mapped-objects
                                 parent-instance="instance"
-                                mapping="{{instance.class.info_pane_options.urls.mapping}}"
-                        >
+                                mapping="{{instance.class.info_pane_options.urls.mapping}}">
                             <reusable-objects-item instance="instance"
                                                    is-saving="isSaving"
                                                    base-instance="baseInstance"
                                                    mapping="mapping"
                                                    check-reused-status="checkReusedStatus"
-                                                   selected-list="selectedList">
+                                                   selected-list="urlList">
                                 <span class="date">{{date instance.created_at true}}</span>
                                 <a href="{{schemed_url instance.link}}" target="_blank">
                                     <span>{{firstnonempty instance.title instance.link}}</span>

--- a/src/ggrc/assets/mustache/components/reusable-objects/reusable-objects-item.mustache
+++ b/src/ggrc/assets/mustache/components/reusable-objects/reusable-objects-item.mustache
@@ -6,8 +6,8 @@
 <reusable-objets-item-control>
   {{#is_allowed 'update' baseInstance context='for'}}
     {{#is_allowed 'update' instance context='for'}}
-      {{#if isDisabled}}
-          <input type="checkbox" checked disabled/>
+      {{#if disabled}}
+          <input type="checkbox" checked="checked" disabled/>
       {{else}}
           <input type="checkbox" {{#isSaving}}disabled{{/isSaving}}/>
       {{/if}}

--- a/src/ggrc/assets/mustache/requests/related-requests.mustache
+++ b/src/ggrc/assets/mustache/requests/related-requests.mustache
@@ -60,6 +60,7 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                             <reusable-objects-item instance="instance"
                                                    base-instance="baseInstance"
                                                    mapping="mapping"
+                                                   check-reused-status="checkReusedStatus"
                                                    selected-list="selectedList">
                                 <span class="date">{{date instance.created_at true}}</span>
                                 <a href="{{schemed_url instance.link}}" target="_blank">
@@ -75,6 +76,7 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                             <reusable-objects-item instance="instance"
                                                    base-instance="baseInstance"
                                                    mapping="mapping"
+                                                   check-reused-status="checkReusedStatus"
                                                    selected-list="selectedList">
                                 <span class="date">{{date instance.created_at true}}</span>
                                 <a href="{{schemed_url instance.link}}" target="_blank">

--- a/src/ggrc/assets/mustache/requests/related-requests.mustache
+++ b/src/ggrc/assets/mustache/requests/related-requests.mustache
@@ -46,8 +46,7 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                         <mapped-objects
                                 parent-instance="instance"
                                 is-loading="isLoading"
-                                mapping="{{instance.class.info_pane_options.mapped_objects.mapping}}"
-                        >
+                                mapping="{{instance.class.info_pane_options.mapped_objects.mapping}}">
                           {{> '/static/mustache/components/assessment/mapped-objects/mapped-related-information-item.mustache' }}
                         </mapped-objects>
                     </div>
@@ -55,13 +54,13 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                         <mapped-objects
                                 parent-instance="instance"
                                 is-loading="isLoading"
-                                mapping="{{instance.class.info_pane_options.evidence.mapping}}"
-                        >
+                                mapping="{{instance.class.info_pane_options.evidence.mapping}}">
                             <reusable-objects-item instance="instance"
+                                                   is-saving="isSaving"
                                                    base-instance="baseInstance"
                                                    mapping="mapping"
                                                    check-reused-status="checkReusedStatus"
-                                                   selected-list="selectedList">
+                                                   selected-list="evidenceList">
                                 <span class="date">{{date instance.created_at true}}</span>
                                 <a href="{{schemed_url instance.link}}" target="_blank">
                                     <span>{{firstnonempty instance.title instance.link}}</span>
@@ -71,13 +70,13 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                         <mapped-objects
                                 parent-instance="instance"
                                 is-loading="isLoading"
-                                mapping="{{instance.class.info_pane_options.urls.mapping}}"
-                        >
-                            <reusable-objects-item instance="instance"
+                                mapping="{{instance.class.info_pane_options.urls.mapping}}">
+                            <reusable-objects-item nstance="instance"
+                                                   is-saving="isSaving"
                                                    base-instance="baseInstance"
                                                    mapping="mapping"
                                                    check-reused-status="checkReusedStatus"
-                                                   selected-list="selectedList">
+                                                   selected-list="urlList">
                                 <span class="date">{{date instance.created_at true}}</span>
                                 <a href="{{schemed_url instance.link}}" target="_blank">
                                     <span>{{firstnonempty instance.title instance.link}}</span>


### PR DESCRIPTION
1.416  Bug (P1)
Subject: Checkbox for Reuse evidences is still available for already reused evidences at Related Assessment tab in Assessment's Info panel 
Details: 
Create a program
Create an audit
Go to audit page
Create Assessment > Navigate to Info panel and attach an evidence
Create second Assessment> Navigate to Info panel>go to Related assessments tab> Reuse the above mentioned evidence to Assessment
Create third Assessment-> Navigate to Info panel-> Go to Related assessments tab> Reuse the above mentioned evidence to Assessment
Actual Result: Checkbox for Reuse evidences is still available for already reused evidences at Related Assessment tab in Assessment's Info panel 
Expected Result: Checkbox for Reuse evidences should be disabled for already reused evidences at Related Assessment tab in Assessment's Info panel 
Workaround: N/A
