### PR TITLE
ISSUE-1.443 Uncaught TypeError: Cannot read property 'appendChild' of null

### DIFF
--- a/src/ggrc/assets/javascripts/plugins/autocomplete.js
+++ b/src/ggrc/assets/javascripts/plugins/autocomplete.js
@@ -284,6 +284,7 @@
 
       $ul.unbind('scrollNext')
         .bind('scrollNext', function (ev, data) {
+          var listItems;
           if (context.attr('scroll_op_in_progress') ||
               context.attr('oldLen') === context.attr('items').length) {
             return;
@@ -295,11 +296,19 @@
           context.attr('scroll_op_in_progress', true);
           context.attr('items_loading', true);
           this.source(this.last_request, function (items) {
-            var listItems = context.attr('items');
-            context.attr('oldLen', listItems.length);
-            listItems.push.apply(listItems, can.map(items, function (item) {
-              return item.item;
-            }));
+            try {
+              listItems = context.attr('items');
+              listItems.push.apply(listItems, can.map(items, function (item) {
+                return item.item;
+              }));
+              context.attr('oldLen', listItems.length);
+            } catch (error) {
+              // Really ugly way to hide canjs exception during scrolling.
+              // Please note that it occurs in really rear cases.
+              // Better solution is needed.
+              console.warn(error);
+            }
+
             context.removeAttr('items_loading');
             _.defer(function () {
               context.attr('scroll_op_in_progress', false);


### PR DESCRIPTION
**Subject**: "Uncaught TypeError: Cannot read property 'appendChild' of null" error occurs when scrolling objects in drop down menu at Export Objects page 
**Details**: 

- Log as Admin 
- Go to Data Export page
- Click “+ Add New Rule” in FILTER BY MAPPING section
- Select an object (e.g. Assessment, Workflow, Access Group) in the dropdown menu
- Type in field the first letter and scroll the created objects: error occurs

**Actual Result**: "Uncaught TypeError: Cannot read property 'appendChild' of null" error occurs when scrolling objects in drop down menu at Export Objects page 
**Expected Result**: No error displayed. 
**Note**: bug is reproduced temporary

**Trace**:
```
dashboard.js:26043 TypeError: Cannot read property 'appendChild' of null
    at Object.can.appendChild (http://localhost:8080/static/dashboard.js:2539:15)
    at Object.after (http://localhost:8080/static/dashboard.js:6082:25)
    at Constructor.add (http://localhost:8080/static/dashboard.js:7393:38)
    at Constructor.can.dispatch (http://localhost:8080/static/dashboard.js:2377:37)
    at Object.trigger (http://localhost:8080/static/dashboard.js:2578:38)
    at Object.trigger (http://localhost:8080/static/dashboard.js:4201:36)
    at Constructor._triggerChange (http://localhost:8080/static/dashboard.js:4873:39)
    at Constructor.list.(anonymous function) (http://localhost:8080/static/dashboard.js:5030:30)
    at Constructor.proto.(anonymous function) [as push] (http://localhost:8080/static/dashboard.js:11036:35)
    at http://localhost:8080/static/dashboard.js:26038:28
```
**Hints**: In order to reproduce it you should scroll up and down at the page when the list is loading (spinner is visible). You should perform 5-10 scrolls in a second 😄
I've also found that the error often occurs after this warning message:
```
dashboard.js:183 Handling of 'mousewheel' input event was delayed for 249 ms due to main thread being busy. Consider marking event handler as 'passive' to make the page more responive.
```

**Please also note that this is a quite ugly fix, but if you have any ideas or suggestions - you're welcome.**

PS: It will not affect user experience as far as only 1 portion of items will skipped (in case of exception) and when user will scroll down again it will be again requested and then added to the list.