### PR TITLE
QUICK-FIX Remove legacy code

### DIFF
--- a/src/ggrc/assets/javascripts/models/assessment.js
+++ b/src/ggrc/assets/javascripts/models/assessment.js
@@ -46,14 +46,6 @@
     defaults: {
       status: 'Not Started'
     },
-    filter_keys: ['title', 'status', 'operationally', 'operational', 'design',
-      'finished_date', 'verified_date', 'verified'],
-    filter_mappings: {
-      state: 'status',
-      operational: 'operationally',
-      'verified date': 'verified_date',
-      'finished date': 'finished_date'
-    },
     tree_view_options: {
       add_item_view: GGRC.mustache_path +
         '/base_objects/tree_add_item.mustache',

--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -347,21 +347,6 @@
 
   can.Model.Cacheable('CMS.Models.Request', {
     root_object: 'request',
-    filter_keys: ['assignee', 'audit', 'code', 'company', 'control', 'due on',
-      'due', 'name', 'notes', 'request', 'starts', 'starts on', 'status',
-      'test', 'title', 'request_type', 'type', 'request type',
-      'request_object', 'request object', 'request title',
-      'verified', 'verified_date', 'finished_date'
-    ],
-    filter_mappings: {
-      type: 'request_type',
-      'request title': 'title',
-      'request description': 'description',
-      'request type': 'request_type',
-      'verified date': 'verified_date',
-      'finished date': 'finished_date',
-      'request date': 'requested_on'
-    },
     root_collection: 'requests',
     findAll: 'GET /api/requests',
     findOne: 'GET /api/requests/{id}',

--- a/src/ggrc/assets/javascripts/models/cacheable.js
+++ b/src/ggrc/assets/javascripts/models/cacheable.js
@@ -112,28 +112,6 @@
 
   can.Model('can.Model.Cacheable', {
     root_object: '',
-    filter_keys: ['assignee', 'company', 'contact', 'description',
-                'email', 'end_date', 'kind', 'name', 'notes',
-                'owners', 'reference_url', 'slug', 'status',
-                'start_date', 'test', 'title', 'updated_at', 'created_at',
-                'due_on'
-  ],
-    filter_mappings: {
-    // 'search term', 'actual value in the object'
-      'owner': 'owners',
-      'workflow': 'workflows',
-      'due date': 'end_date',
-      'end date': 'end_date',
-      'stop date': 'end_date',
-      'effective date': 'start_date',
-      'start date': 'start_date',
-      'created date': 'created_at',
-      'updated date': 'updated_at',
-      'modified date': 'updated_at',
-      'code': 'slug',
-      'state': 'status'
-    },
-
     attr_list: [
     {attr_title: 'Title', attr_name: 'title'},
     {attr_title: 'Owner', attr_name: 'owner', attr_sort_field: 'contact.name|email'},


### PR DESCRIPTION
The filter keys and mappings were used for accessing object properties
on the frontend by the Javascript filters. Since these filters are now
done with the query API, these variables aren't used anymore. The code
that used them was removed in one of the previous commits but these were
forgotten.


This is cleaning up dead code after this PR: https://github.com/google/ggrc-core/pull/4505
