### PR TITLE
ISSUE-1.473 Change a warning message for Assessments

### DIFF
--- a/src/ggrc/assets/mustache/base_templates/people_list.mustache
+++ b/src/ggrc/assets/mustache/base_templates/people_list.mustache
@@ -9,7 +9,7 @@
     <div class="centered">
       <div class="alert alert-error">
         <p>
-          Assignee and Verifier cannot be the same person!
+          Assessor and Verifier cannot be the same person!
         </p>
       </div>
     </div>


### PR DESCRIPTION
**Subject**: KC: LHN tooltip says "Assignee and Verifier cannot be the same person!" when hovering over an Assessment in LHN though the assessment has Assessor instead of Assignee, error message for blank Assessor (Assignee is required)
**Details**:
- Go to LHN
- Open Assessment’s accordion
- Hover over an Assessment with Assessor such as Verifier: confirm Assignee and Verifier cannot be the same person! message is displayed

**Actual Result**: KC: LHN tooltip says "Assignee and Verifier cannot be the same person!" when hovering over an Assessment in LHN though the assessment has Assessor instead of Assignee, error message for blank Assessor (Assignee is required)
**Expected Result**: Assessor and Verifier cannot be the same person! message is displayed
