### PR TITLE
QUICK-FIX Add correct behaviour after adding Related Issues/Requests 

### DIFF
--- a/src/ggrc/assets/javascripts/components/mapped-objects/mapped-objects.js
+++ b/src/ggrc/assets/javascripts/components/mapped-objects/mapped-objects.js
@@ -28,16 +28,27 @@
           GGRC.Utils.filters.applyTypeFilter(items, filterObj.serialize()) :
           items;
       },
+      getBinding: function () {
+        return this.attr('parentInstance').get_binding(this.attr('mapping'));
+      },
       load: function () {
         var dfd = new can.Deferred();
+        var binding = this.getBinding();
+        // Set Loading Status
         this.attr('isLoading', true);
-        this.attr('parentInstance')
-          .get_binding(this.attr('mapping'))
+
+        if (!binding) {
+          dfd.resolve([]);
+          return dfd;
+        }
+        binding
           .refresh_instances()
           .done(function (items) {
-            items = this.filterMappedObjects(items);
-            dfd.resolve(items);
+            dfd.resolve(this.filterMappedObjects(items));
           }.bind(this))
+          .fail(function () {
+            dfd.resolve([]);
+          })
           .always(function () {
             this.attr('isLoading', false);
           }.bind(this));

--- a/src/ggrc/assets/mustache/assessments/related-assessments.mustache
+++ b/src/ggrc/assets/mustache/assessments/related-assessments.mustache
@@ -2,7 +2,7 @@
 Copyright (C) 2016 Google Inc.
 Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
-<related-objects base-instance="instance" related-items-type="Assessment">
+<related-objects base-instance="instance" related-items-type="Assessment" order-by="__similarity__">
     <reusable-objects-list base-instance="instance">
         <div class="grid-data-toolbar flex-box">
             <tree-pagination paging="paging" class="flex-size-1"></tree-pagination>

--- a/src/ggrc/assets/mustache/assessments/related_issues.mustache
+++ b/src/ggrc/assets/mustache/assessments/related_issues.mustache
@@ -3,41 +3,51 @@ Copyright (C) 2016 Google Inc.
 Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 `}}
 
-<div class="row-fluid wrap-row">
-<ul class="past-items-list relatables mapped-list left-spacing">
-  {{#expose reusedObjects=reusedObjects}}
-  {{#defer 'related_issues' instance.related_issues}}
-  {{#related_issues}}
-    <li class="clearfix">
-      <div class="xmedium-col">
-        <a href="{{instance.viewLink}}" target="_blank">
-          {{instance.title}}
-        </a>
-      </div>
-    </li>
-  {{/related_issues}}
-  {{/defer}}
-  {{/expose}}
-</ul>
-</div>
-<div class="row-fluid wrap-row">
-{{#is_allowed 'update' instance context='for'}}
-  {{#with_mapping 'related_audits' instance}}
-    {{#with_mapping 'related_controls' instance}}
-      {{#using control=control}}
-        {{#with_create_issue_json instance}}
-          <a class="btn btn-small btn-danger"
-             href="javascript://"
-             data-toggle="modal-ajax-form"
-             data-modal-class="modal-wide"
-             data-object-singular="Issue"
-             data-object-plural="issues"
-             data-object-params='{{create_issue_json}}'>
-            Raise an Issue
-          </a>
-        {{/with_create_issue_json}}
-      {{/using}}
-    {{/with_mapping}}
-  {{/with_mapping}}
-{{/is_allowed}}
-</div>
+<related-objects base-instance="instance" related-items-type="Issue">
+    <div class="grid-data-toolbar flex-box">
+        <tree-pagination paging="paging" class="flex-size-1"></tree-pagination>
+      {{#is_allowed 'update' baseInstance context='for'}}
+          <div class="grid-data-toolbar-control">
+            {{#with_mapping 'related_audits' baseInstance}}
+              {{#with_mapping 'related_controls' baseInstance}}
+                {{#using control=control}}
+                  {{#with_create_issue_json baseInstance}}
+                      <a class="btn btn-small btn-danger"
+                         href="javascript://"
+                         data-toggle="modal-ajax-form"
+                         data-modal-class="modal-wide"
+                         data-object-singular="Issue"
+                         data-object-plural="issues"
+                         data-object-params='{{create_issue_json}}'>
+                          Raise an Issue
+                      </a>
+                  {{/with_create_issue_json}}
+                {{/using}}
+              {{/with_mapping}}
+            {{/with_mapping}}
+          </div>
+      {{/is_allowed}}
+    </div>
+    <div class="grid-data-header flex-row flex-box">
+        <div class="flex-size-2">
+            Title
+        </div>
+        <div class="flex-size-3">
+            Description
+        </div>
+    </div>
+    <div class="grid-data-body {{#isLoading}}loading{{/isLoading}}">
+        <object-list items="relatedObjects" is-loading="isLoading" spinner-css="grid-spinner">
+            <div class="grid-data-row flex-row flex-box">
+                <div class="flex-size-2">
+                    <a href="{{instance.viewLink}}" target="_blank">
+                      {{instance.title}}
+                    </a>
+                </div>
+                <div class="flex-size-3">
+                    <read-more text="instance.description"></read-more>
+                </div>
+            </div>
+        </object-list>
+    </div>
+</related-objects>

--- a/src/ggrc/assets/mustache/assessments/related_requests.mustache
+++ b/src/ggrc/assets/mustache/assessments/related_requests.mustache
@@ -3,41 +3,51 @@ Copyright (C) 2016 Google Inc.
 Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
 
-<div class="row-fluid wrap-row">
-<ul class="past-items-list relatables">
-  {{#expose reusedObjects=reusedObjects}}
-  {{#defer 'related_requests' instance.related_requests}}
-  {{#related_requests}}
-  <li class="clearfix">
-    <div class="xmedium-col">
-      <a href="{{instance.viewLink}}" target="_blank">
-        {{instance.title}}
-      </a>
+<related-objects base-instance="instance" related-items-type="Request">
+    <div class="grid-data-toolbar flex-box">
+        <tree-pagination paging="paging" class="flex-size-1"></tree-pagination>
+      {{#is_allowed 'update' baseInstance context='for'}}
+          <div class="grid-data-toolbar-control">
+            {{#with_mapping 'related_audits' baseInstance}}
+              {{#with_mapping 'related_controls' baseInstance}}
+                {{#using control=control}}
+                  {{#with_create_issue_json baseInstance}}
+                      <a class="btn btn-small btn-primary"
+                         href="javascript://"
+                         data-toggle="modal-ajax-form"
+                         data-modal-class="modal-wide"
+                         data-object-singular="Request"
+                         data-object-plural="requests"
+                         data-object-params='{{create_issue_json}}'>
+                          Create Request
+                      </a>
+                  {{/with_create_issue_json}}
+                {{/using}}
+              {{/with_mapping}}
+            {{/with_mapping}}
+          </div>
+      {{/is_allowed}}
     </div>
-  </li>
-  {{/related_requests}}
-  {{/defer}}
-  {{/expose}}
-</ul>
-</div>
-<div class="row-fluid wrap-row">
-{{#is_allowed 'update' instance context='for'}}
-  {{#with_mapping 'related_audits' instance}}
-    {{#with_mapping 'related_controls' instance}}
-      {{#using control=control}}
-        {{#with_create_issue_json instance}}
-          <a class="btn btn-small btn-primary"
-             href="javascript://"
-             data-toggle="modal-ajax-form"
-             data-modal-class="modal-wide"
-             data-object-singular="Request"
-             data-object-plural="requests"
-             data-object-params='{{create_issue_json}}'>
-            Create Request
-          </a>
-        {{/with_create_issue_json}}
-      {{/using}}
-    {{/with_mapping}}
-  {{/with_mapping}}
-{{/is_allowed}}
-</div>
+    <div class="grid-data-header flex-row flex-box">
+        <div class="flex-size-2">
+            Title
+        </div>
+        <div class="flex-size-3">
+            Description
+        </div>
+    </div>
+    <div class="grid-data-body {{#isLoading}}loading{{/isLoading}}">
+        <object-list items="relatedObjects" is-loading="isLoading" spinner-css="grid-spinner">
+            <div class="grid-data-row flex-row flex-box">
+                <div class="flex-size-2">
+                    <a href="{{instance.viewLink}}" target="_blank">
+                      {{instance.title}}
+                    </a>
+                </div>
+                <div class="flex-size-3">
+                    <read-more text="instance.description"></read-more>
+                </div>
+            </div>
+        </object-list>
+    </div>
+</related-objects>

--- a/src/ggrc/assets/mustache/requests/related-requests.mustache
+++ b/src/ggrc/assets/mustache/requests/related-requests.mustache
@@ -2,7 +2,7 @@
 Copyright (C) 2016 Google Inc.
 Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
-<related-objects base-instance="instance" related-items-type="Request">
+<related-objects base-instance="instance" related-items-type="Request" order-by="__similarity__">
     <reusable-objects-list parent-instance="instance" base-instance="instance">
         <div class="grid-data-toolbar flex-box">
             <tree-pagination paging="paging" class="flex-size-1"></tree-pagination>

--- a/src/ggrc/assets/stylesheets/components/grid-data/_grid-data.scss
+++ b/src/ggrc/assets/stylesheets/components/grid-data/_grid-data.scss
@@ -3,14 +3,26 @@
  * Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  */
 .grid-data-toolbar {
-  height: 28px;
+  height: 26px;
   margin: 0 0 16px 0;
 
   .grid-data-toolbar-control {
-    width: 85px;
-    height: 28px;
+    display: flex;
+    height: 26px;
     line-height: 26px;
-    margin: 0 0 0 24px;
+    padding: 0 0 0 16px;
+
+    .btn.btn-small {
+      height: 26px;
+      line-height: 26px;
+      box-sizing: border-box;
+      padding: 0 16px;
+    }
+
+    > * {
+      min-width: 86px;
+      margin: 0 0 0 12px;
+    }
   }
 }
 


### PR DESCRIPTION
This PR should fix these 2 bugs: 

1.463  Bug (P2)
Subject: Created Requests are not shown at Related Requests tab in Assessment's Info pane
Details: 
Create a program
Create an Audit
Go to Audit page
Create Assessment
Navigate to Assessment’s Info pane
Go to Related Requests tab
Click Create Request button to Create Request
Look at Related Requests tab: newly created request is not shown
Actual Result: Created Requests after are shown at Related Requests tab in Assessment's Info pane
Expected Result: Requests after creating are shown at Related Requests tab in Assessment's Info pane
Workaround: refresh is needed

1.464  Bug (P2)
Subject: The second and the next created Issues are not shown at Related Issues tab in Assessment's Info pane
Details: 
Create a program
Create an Audit
Go to Audit page
Create Assessment
Navigate to Assessment’s Info pane
Go to Related Requests tab
Click Create Request button to Create Request
Look at Related Requests tab: newly created request is not shown
Actual Result: The second and the next created Issues are not shown at Related Issues tab in Assessment's Info pane
Expected Result: Issues after creating are shown at Related Issues tab in Assessment's Info pane
Workaround: refresh is needed