### PR TITLE
Add required flag to task start and end dates

### DIFF
--- a/src/ggrc_workflows/assets/mustache/task_group_tasks/modal_content.mustache
+++ b/src/ggrc_workflows/assets/mustache/task_group_tasks/modal_content.mustache
@@ -77,12 +77,14 @@
           Frequency: One time
           <i class="fa fa-question-circle" rel="tooltip" title="Choose start and end dates"></i>
         </label>
+        <span class="required">*</span>
         <label class="smaller">
            <datepicker set-min-date="instance.minStartDate"
                        date="instance.start_date"
                        required="{{true}}"
                        label="Start Date"></datepicker>
         </label>
+        <span class="required">*</span>
         <label class="smaller">
           <datepicker set-min-date="instance.start_date"
                       date="instance.end_date"


### PR DESCRIPTION
The fields that must be filled in before save button is enabled must
have the proper required red star next to them.