### PR TITLE
Make sure confirmBeginEdit event is only fired for Requests

### DIFF
--- a/src/ggrc/assets/mustache/custom_attributes/info.mustache
+++ b/src/ggrc/assets/mustache/custom_attributes/info.mustache
@@ -28,7 +28,9 @@
               {{^is_allowed 'update' instance context='for'}}
                 readonly
               {{/is_allowed}}
-              can-before-edit="instance.confirmBeginEdit"
+              {{#if_instance_of instance 'Request'}}
+                can-before-edit="instance.confirmBeginEdit"
+              {{/if_instance_of}}
             ></inline-edit>
           </div>
         </div>


### PR DESCRIPTION
Other objects don't have the needed handler which resulted
in a script error. We ignore assessments here because those
are handled by assessment/custom-attributes.mustache.