### PR TITLE
ISSUE-1.465 Index Map:Person CAV

### DIFF
--- a/src/ggrc/fulltext/recordbuilder.py
+++ b/src/ggrc/fulltext/recordbuilder.py
@@ -26,10 +26,20 @@ class RecordBuilder(object):
       record_type = obj.attributable_type
       # The name of the attribute property needs to be unique for each object,
       # the value comes from the custom_attribute_value
-      properties = {
-          "attribute_value_" + str(obj.id): obj.attribute_value,
-          "tags": obj.custom_attribute.title,
-      }
+      attribute_name = "attribute_value_" + str(obj.id)
+
+      properties = {}
+      if (obj.custom_attribute.attribute_type == "Map:Person" and
+              obj.attribute_object_id is not None):
+        # Add both name and email for a Map:Person to the index
+        properties[attribute_name + ".name"] = obj.attribute_object.name
+        properties[attribute_name + ".email"] = obj.attribute_object.email
+      else:
+        properties[attribute_name] = obj.attribute_value
+
+      # Store the title of the CA to enable searching by it
+      properties["tags"] = obj.custom_attribute.title
+
     return Record(
         # This logic saves custom attribute values as attributes of the object
         # that owns the attribute values. When obj is not a

--- a/src/ggrc/fulltext/sql.py
+++ b/src/ggrc/fulltext/sql.py
@@ -4,17 +4,18 @@
 from ggrc import db
 from . import Indexer
 
+
 class SqlIndexer(Indexer):
   def create_record(self, record, commit=True):
-    for k,v in record.properties.items():
+    for k, v in record.properties.items():
       db.session.add(self.record_type(
-        key=record.key,
-        type=record.type,
-        context_id=record.context_id,
-        tags=record.tags,
-        property=k,
-        content=v,
-        ))
+          key=record.key,
+          type=record.type,
+          context_id=record.context_id,
+          tags=record.tags,
+          property=k,
+          content=v,
+      ))
     if commit:
       db.session.commit()
 
@@ -23,7 +24,7 @@ class SqlIndexer(Indexer):
     self.create_record(record, commit=commit)
 
   def delete_record(self, key, type, commit=True):
-    db.session.query(self.record_type).filter(\
+    db.session.query(self.record_type).filter(
         self.record_type.key == key,
         self.record_type.type == type).delete()
     if commit:
@@ -36,6 +37,6 @@ class SqlIndexer(Indexer):
 
   def delete_records_by_type(self, type, commit=True):
     db.session.query(self.record_type).filter(
-      self.record_type.type == type).delete()
+        self.record_type.type == type).delete()
     if commit:
       db.session.commit()


### PR DESCRIPTION
Filtering by Map:Person CAV is not functional.

Steps to reproduce:
1. On the dashboard open a tab with objects that have Person-type CA (you may have to define a new CA).
2. Set that CA value to "user@example.com" in one of the objects.
3. (for a CA titled CA_PERSON): type `CA_PERSON ~ "user@example.com"` into the filter, press enter.

Expected results: the object edited in step 2 is shown.
Actual results: an empty list is shown.

This PR adds the name and the email of a person to the fulltext index that is used to search by CA values. You may need to do a reindex to make these changes work on every Person-type CA in the system.