### PR TITLE
QUICK-FIX Fix updating fulltext index for CA

### DIFF
--- a/src/ggrc/fulltext/sql.py
+++ b/src/ggrc/fulltext/sql.py
@@ -20,7 +20,13 @@ class SqlIndexer(Indexer):
       db.session.commit()
 
   def update_record(self, record, commit=True):
-    self.delete_record(record.key, record.type, commit=False)
+    # remove the obsolete index entries
+    db.session.query(self.record_type).filter(
+        self.record_type.key == record.key,
+        self.record_type.type == record.type,
+        self.record_type.property.in_(list(record.properties.keys())),
+    ).delete(synchronize_session="fetch")
+    # add new index entries
     self.create_record(record, commit=commit)
 
   def delete_record(self, key, type, commit=True):


### PR DESCRIPTION
This PR fixes an issue where every fulltext index entry for an objects gets removed on a CA update.

Steps to reproduce:
1. Open info pane of an object with at least two CA defined (say, text fields CA1 and CA2, but their names and values do not matter).
2. Set CA1 to "hello".
3. Enter `CA1 = "hello"` in the filter, press enter. The edited object should be shown in the tree view.
4. Set CA2 to "break the index".
5. Enter `CA1 = "hello"` again in the filter, press enter.

Expected result: the same edited object is shown in the tree view.
Actual result: the edited object is not shown (but CA1 has still value "hello" stored).

You may need to force reindex to make sure the broken index records are recreated.