### PR TITLE
ISSUE-1.466 Add error handler for incorrect filter

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
@@ -1532,6 +1532,13 @@ CMS.Controllers.TreeLoader('CMS.Controllers.TreeView', {
       .then(this._ifNotRemoved(this.proxy('draw_list')))
       .then(function () {
         this.options.attr('paging.disabled', false);
+      }.bind(this))
+      .fail(function () {
+        this.options.attr('original_list', []);
+        this.element.children('.cms_controllers_tree_view_node').remove();
+        this._loading_finished();
+        GGRC.Errors.notifier('warning',
+          'Filter format is incorrect, data cannot be filtered.')();
       }.bind(this));
   }),
   '{paging} change': _.debounce(


### PR DESCRIPTION
**1.466  Bug (P0)**
**Subject**: Filter is not function for CA with Date type and 400 error is displayed in Console
**Details**: 
Log as Admin
Go to My Work page
Select Sections type in HNB
Try to Filter CA with Date type: error is displayed

_Actual Result_: Filter is not function for CA with Date type and 400 error is displayed in Console
_Expected Result_: error message to user is shown and table is not freezed