### PR TITLE
ISSUE-1.485 Program Info page: Assessments are shown at Related Requests/Related Issues tab in Assessment's Info pane

### DIFF
--- a/src/ggrc/assets/javascripts/components/mapped-objects/mapped-objects.js
+++ b/src/ggrc/assets/javascripts/components/mapped-objects/mapped-objects.js
@@ -34,13 +34,13 @@
       load: function () {
         var dfd = new can.Deferred();
         var binding = this.getBinding();
-        // Set Loading Status
-        this.attr('isLoading', true);
 
         if (!binding) {
           dfd.resolve([]);
           return dfd;
         }
+        // Set Loading Status
+        this.attr('isLoading', true);
         binding
           .refresh_instances()
           .done(function (items) {

--- a/src/ggrc/assets/javascripts/components/related-objects/related-objects.js
+++ b/src/ggrc/assets/javascripts/components/related-objects/related-objects.js
@@ -65,7 +65,8 @@
             var data = responseArr[0];
             var values = data[relatedType].values;
             var result = values.map(function (item) {
-              return {instance: new CMS.Models[relatedType](item)};
+              item.instance = new CMS.Models[relatedType](item);
+              return item;
             });
             // Update paging object
             this.updatePaging(data[relatedType].total);

--- a/src/ggrc/assets/mustache/assessments/related-assessments.mustache
+++ b/src/ggrc/assets/mustache/assessments/related-assessments.mustache
@@ -34,11 +34,11 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
             <object-list items="relatedObjects" is-loading="isLoading" spinner-css="grid-spinner">
                 <div class="grid-data-row flex-row flex-box">
                     <div class="grid-data-item-index">
-                      {{localize_date instance.created_at}}
+                      {{localize_date created_at}}
                     </div>
                     <div class="flex-size-1">
-                        <a href="{{instance.viewLink}}" target="_blank">
-                          {{instance.title}}
+                        <a href="{{viewLink}}" target="_blank">
+                          {{title}}
                         </a>
                     </div>
                     <div class="flex-size-1">

--- a/src/ggrc/assets/mustache/assessments/related_issues.mustache
+++ b/src/ggrc/assets/mustache/assessments/related_issues.mustache
@@ -40,12 +40,12 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
         <object-list items="relatedObjects" is-loading="isLoading" spinner-css="grid-spinner">
             <div class="grid-data-row flex-row flex-box">
                 <div class="flex-size-2">
-                    <a href="{{instance.viewLink}}" target="_blank">
-                      {{instance.title}}
+                    <a href="{{viewLink}}" target="_blank">
+                      {{title}}
                     </a>
                 </div>
                 <div class="flex-size-3">
-                    <read-more text="instance.description"></read-more>
+                    <read-more text="description"></read-more>
                 </div>
             </div>
         </object-list>

--- a/src/ggrc/assets/mustache/assessments/related_requests.mustache
+++ b/src/ggrc/assets/mustache/assessments/related_requests.mustache
@@ -40,12 +40,12 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
         <object-list items="relatedObjects" is-loading="isLoading" spinner-css="grid-spinner">
             <div class="grid-data-row flex-row flex-box">
                 <div class="flex-size-2">
-                    <a href="{{instance.viewLink}}" target="_blank">
-                      {{instance.title}}
+                    <a href="{{viewLink}}" target="_blank">
+                      {{title}}
                     </a>
                 </div>
                 <div class="flex-size-3">
-                    <read-more text="instance.description"></read-more>
+                    <read-more text="description"></read-more>
                 </div>
             </div>
         </object-list>


### PR DESCRIPTION
1.485  Bug (P1)
Subject: Program Info page: Assessments are shown at Related Requests/Related Issues tab in Assessment's Info pane
Details:
Create a program
Create an Audit
Go to Audit page
Create at least 2 Assessments
Create at least 2 Requests
Go to Program Info page
Open Assessment’s tab
Navigate to Assessment’s Info pane
Open Related Request tab: confirm Assessments are shown
Actual Result: Program Info page: Assessments are shown at Related Requests/Related Issues tab in Assessment's Info pane
Expected Result: Program Info page: Requests/Issues are shown at Related Requests/Related Issues tab in Assessment's Info pane
Workaround: NA
Note: Check for Related Issues tab following the above mentioned steps too under admin and GR roles
