### PR TITLE
ISSUE-1.469 Update tree page after update roles

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
@@ -1235,6 +1235,8 @@ CMS.Controllers.TreeLoader('CMS.Controllers.TreeView', {
     CMS.Models[this.options.model.shortName].bind('destroyed',
       this.onDestroyedModel);
 
+    $('body').on('treeupdate', this.refreshList.bind(this));
+
     return false;
   },
 
@@ -1259,6 +1261,10 @@ CMS.Controllers.TreeLoader('CMS.Controllers.TreeView', {
   onCreatedModel: function (ev, instance) {
     if (instance instanceof CMS.Models[this.options.model.shortName]) {
       this.onCreated();
+    }
+
+    if (instance instanceof CMS.Models.UserRole) {
+      this.refreshList();
     }
   },
 

--- a/src/ggrc_basic_permissions/assets/javascripts/controllers/contributions.js
+++ b/src/ggrc_basic_permissions/assets/javascripts/controllers/contributions.js
@@ -415,6 +415,10 @@
             self.element.trigger('relationshipcreated', join);
           });
         });
+      } else {
+        $.when.apply($, deleteDfds).then(function () {
+          $('body').trigger('treeupdate');
+        });
       }
     },
 


### PR DESCRIPTION
**1.469  Bug (P1)**
**Subject**: User roles aren't updated on program page on people tab
**Details**:
Create a program
Go to People tab
Click + to Map Person to this program
Map selected Person
Navigate to Person’s Info pane
Click 3 bb’s button -> Edit Authorizations
Change user role -> Save
Look at Person first tree view:  Authorizations are not updated

_Actual Result_: user roles aren't updated on program page on people tab
_Expected Result:_ user roles should be updated on program page on people tab
_Workaround_: na
Note: refresh can not solve the problem