### PR TITLE
ISSUE-1.469 Update tree page after update roles 

### DIFF
--- a/src/ggrc/assets/javascripts/models/person.js
+++ b/src/ggrc/assets/javascripts/models/person.js
@@ -105,8 +105,8 @@
 
       refreshQueue.trigger().then(function (roles) {
         userRoles = _.filter(roles, function (role) {
-          return !role.context || (instance.context &&
-            role.context.id === instance.context.id);
+          return instance.context && role.context &&
+            role.context.id === instance.context.id;
         });
         result.resolve(userRoles);
       });

--- a/src/ggrc_basic_permissions/assets/javascripts/controllers/contributions.js
+++ b/src/ggrc_basic_permissions/assets/javascripts/controllers/contributions.js
@@ -394,10 +394,10 @@
           return;
         }
         if (join) {
-          return join.refresh().done(function () {
-            return join.destroy().then(function () {
-              self.element.trigger('relationshipdestroyed', join);
-            });
+          return join.refresh().then(function () {
+            return join.destroy();
+          }).then(function () {
+            self.element.trigger('relationshipdestroyed', join);
           });
         }
       });


### PR DESCRIPTION
**1.469  Bug (P1)**
**Subject**: User roles aren't updated on program page on people tab
**Details**:
Create a program
Go to People tab
Click + to Map Person to this program
Map selected Person
Navigate to Person’s Info pane
Click 3 bb’s button -> Edit Authorizations
Change user role -> Save
Look at Person first tree view:  Authorizations are not updated

_Actual Result_: user roles aren't updated on program page on people tab
_Expected Result:_ user roles should be updated on program page on people tab
_Workaround_: na
Note: refresh can not solve the problem