### PR TITLE
QUICK-FIX Cycle revisions

### DIFF
--- a/src/ggrc_workflows/__init__.py
+++ b/src/ggrc_workflows/__init__.py
@@ -10,7 +10,7 @@ from ggrc.login import get_current_user
 from ggrc.models import all_models
 from ggrc.models.relationship import Relationship
 from ggrc.rbac.permissions import is_allowed_update
-from ggrc.services.common import Resource
+from ggrc.services.common import Resource, log_event
 from ggrc.services.registry import service
 from ggrc_workflows import models, notification
 from ggrc_workflows.models import relationship_helper
@@ -882,8 +882,8 @@ def start_recurring_cycles():
     notification.handle_workflow_modify(None, workflow)
     notification.handle_cycle_created(None, obj=cycle)
 
+  log_event(db.session)
   db.session.commit()
-  db.session.flush()
 
 
 def get_cycles(workflow):

--- a/src/ggrc_workflows/views/__init__.py
+++ b/src/ggrc_workflows/views/__init__.py
@@ -71,7 +71,7 @@ def _get_unstarted_workflows():
   """
   return db.session.query(Workflow).filter(
       Workflow.next_cycle_start_date < date.today(),
-      Workflow.recurrences.is_(True),
+      Workflow.recurrences == 1,
       Workflow.status == 'Active',
   ).all()
 

--- a/test/integration/ggrc_workflows/test_workflow_revisions.py
+++ b/test/integration/ggrc_workflows/test_workflow_revisions.py
@@ -1,0 +1,98 @@
+# Copyright (C) 2016 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+# pylint: disable=missing-docstring
+
+from freezegun import freeze_time
+from mock import patch
+
+from ggrc.models import Revision, Event
+from ggrc_workflows import start_recurring_cycles
+from integration.ggrc_workflows.generator import WorkflowsGenerator
+from integration.ggrc.generator import ObjectGenerator
+from integration.ggrc import TestCase
+
+
+class TestRecurringWorkflowRevisions(TestCase):
+  """Starting start recurring cycle should generate revisions."""
+
+  def setUp(self):
+    TestCase.setUp(self)
+    self.wf_generator = WorkflowsGenerator()
+    self.object_generator = ObjectGenerator()
+
+    self.random_objects = self.object_generator.generate_random_objects()
+    _, self.person_1 = self.object_generator.generate_person(
+        user_role="Administrator")
+    _, self.person_2 = self.object_generator.generate_person(
+        user_role="Administrator")
+    self._create_test_cases()
+
+  @patch("ggrc.notifications.common.send_email")
+  def test_revisions(self, mock_mail):  # pylint: disable=unused-argument
+    with freeze_time("2015-04-01"):
+      _, workflow = self.wf_generator.generate_workflow(self.monthly_workflow)
+      self.wf_generator.activate_workflow(workflow)
+
+    event_count = Event.query.count()
+    revision_query = Revision.query.filter_by(
+        resource_type='CycleTaskGroupObjectTask',
+    )
+    revision_count = revision_query.count()
+    # cycle starts on monday - 6th, and not on 5th
+    with freeze_time("2015-04-03"):
+      start_recurring_cycles()
+
+    self.assertEqual(event_count + 1, Event.query.count())
+    self.assertNotEqual(revision_count, revision_query.count())
+
+  def _create_test_cases(self):
+    def person_dict(person_id):
+      return {
+          "href": "/api/people/%d" % person_id,
+          "id": person_id,
+          "type": "Person"
+      }
+
+    self.monthly_workflow = {
+        "title": "test monthly wf notifications",
+        "notify_on_change": True,
+        "description": "some test workflow",
+        "owners": [person_dict(self.person_2.id)],
+        "frequency": "monthly",
+        "task_groups": [{
+            "title": "one time task group",
+            "contact": person_dict(self.person_1.id),
+            "task_group_tasks": [{
+                "title": "task 1",
+                "description": "some task",
+                "contact": person_dict(self.person_1.id),
+                "relative_start_day": 5,
+                "relative_end_day": 25,
+            }, {
+                "title": "task 2",
+                "description": "some task",
+                "contact": person_dict(self.person_1.id),
+                "relative_start_day": 10,
+                "relative_end_day": 21,
+            }],
+            "task_group_objects": self.random_objects[:2]
+        }, {
+            "title": "another one time task group",
+            "contact": person_dict(self.person_1.id),
+            "task_group_tasks": [{
+                "title": "task 1 in tg 2",
+                "description": "some task",
+                "contact": person_dict(self.person_1.id),
+                "relative_start_day": 15,
+                "relative_end_day": 15,
+            }, {
+                "title": "task 2 in tg 2",
+                "description": "some task",
+                "contact": person_dict(self.person_2.id),
+                "relative_start_day": 15,
+                "relative_end_day": 28,
+            }],
+            "task_group_objects": []
+        }]
+    }


### PR DESCRIPTION
It fixes creating revisions for cycle tasks and related objects.

This how to reproduce the bug on local dev machine:
1. Create a weekly workflow.
2. Create a task that should start tomorrow.
3. Activate workflow.
4. Change system time on tomorrow.
5. Touch [CRON endpoint](http://localhost:8080/nightly_cron_endpoint)
6. Go to workflow active cycles - new cycle should be activated
7. Go to [event list](http://localhost:8080/admin#events_list_widget) on admin dashboard - there is no event about new cycle.
8. Execute the following query in MySQL console:

```sql
select * from revisions where resource_type = 'CycleTaskGroupObjectTask' \G
```

There is no revision for newly created cycle task.

It is also fixed SQL error in [start unstarted cycles endpoint](http://localhost:8080/admin/unstarted_cycles).

This PR blocks #4374 