### PR TITLE
QUICK-FIX Fix related people for workflows

### DIFF
--- a/src/ggrc/converters/query_helper.py
+++ b/src/ggrc/converters/query_helper.py
@@ -22,7 +22,6 @@ from ggrc.converters import get_exportables
 from ggrc.rbac import context_query_filter
 from ggrc.utils import query_helpers, benchmark
 from ggrc_basic_permissions import UserRole
-from ggrc_workflows.models import relationship_helper as wf_relationship_handler
 
 
 class BadQueryException(Exception):
@@ -650,11 +649,18 @@ class QueryHelper(object):
               ))
           )
       if "Workflow" in (object_class.__name__, related_type):
-        res.extend(wf_relationship_handler.workflow_person(
-            object_class.__name__,
-            related_type,
-            related_ids,
-        ))
+        try:
+          from ggrc_workflows.models import (relationship_helper as
+                                             wf_relationship_handler)
+        except ImportError:
+          # ggrc_workflows module is not enabled
+          return sa.sql.false()
+        else:
+          res.extend(wf_relationship_handler.workflow_person(
+              object_class.__name__,
+              related_type,
+              related_ids,
+          ))
       if res:
         return object_class.id.in_([obj[0] for obj in res])
       return sa.sql.false()

--- a/src/ggrc/converters/query_helper.py
+++ b/src/ggrc/converters/query_helper.py
@@ -22,6 +22,7 @@ from ggrc.converters import get_exportables
 from ggrc.rbac import context_query_filter
 from ggrc.utils import query_helpers, benchmark
 from ggrc_basic_permissions import UserRole
+from ggrc_workflows.models import relationship_helper as wf_relationship_handler
 
 
 class BadQueryException(Exception):
@@ -648,6 +649,12 @@ class QueryHelper(object):
                   model.id.in_(related_ids),
               ))
           )
+      if "Workflow" in (object_class.__name__, related_type):
+        res.extend(wf_relationship_handler.workflow_person(
+            object_class.__name__,
+            related_type,
+            related_ids,
+        ))
       if res:
         return object_class.id.in_([obj[0] for obj in res])
       return sa.sql.false()

--- a/src/ggrc_workflows/models/relationship_helper.py
+++ b/src/ggrc_workflows/models/relationship_helper.py
@@ -10,6 +10,7 @@ from ggrc_workflows.models import TaskGroup
 from ggrc_workflows.models import TaskGroupObject
 from ggrc_workflows.models import TaskGroupTask
 from ggrc_workflows.models import Workflow
+from ggrc_workflows.models import WorkflowPerson
 from ggrc_workflows.models import WORKFLOW_OBJECT_TYPES
 
 
@@ -255,6 +256,27 @@ def wf_ctgo(object_type, related_type, related_ids):
             Relationship.source_type == object_type)
     return join_by_source_id.union(join_by_destination_id)
 
+
+def workflow_person(object_type, related_type, related_ids):
+  """Relationships between Workflows and People."""
+  if object_type == "Workflow" and related_type == "Person":
+    return db.session.query(
+        WorkflowPerson.workflow_id,
+    ).filter(
+        WorkflowPerson.person_id.in_(related_ids),
+    )
+  elif object_type == "Person" and related_type == "Workflow":
+    return db.session.query(
+        WorkflowPerson.person_id,
+    ).filter(
+        WorkflowPerson.workflow_id.in_(related_ids),
+    )
+  else:
+    raise ValueError("Expected (object_type, related_type) to be "
+                     "('Workflow', 'Person') or ('Person', 'Workflow'), "
+                     "got ({!r}, {!r}) instead"
+                     .format(object_type, related_type))
+
 _function_map = {
     ("Cycle", "CycleTaskGroup"): cycle_ctg,
     ("Cycle", "CycleTaskGroupObjectTask"): cycle_ctogt,
@@ -265,6 +287,7 @@ _function_map = {
     ("TaskGroup", "TaskGroupTask"): tg_task,
     ("TaskGroup", "Workflow"): workflow_tg,
     ("TaskGroupTask", "Workflow"): workflow_tgt,
+    ("Person", "Workflow"): workflow_person,
 }
 
 for wot in WORKFLOW_OBJECT_TYPES:


### PR DESCRIPTION
The new `related_people` filter doesn't return people mapped through `workflow_people` table.

Steps to reproduce:
1. Create a workflow.
2. Navigate to its people tab.
3. Map a person.
4. Refresh the page. (this step may be not needed, it is a separate frontend-side issue)

Expected result: the people counter in the tab is incremented by 1, the mapped person is shown in the list.
Actual result: the counter is incremented by 1, the mapped person is not shown in the list.