### PR TITLE
GGRC-57 Fix roles on people tab on program

### DIFF
--- a/src/ggrc/assets/javascripts/models/person.js
+++ b/src/ggrc/assets/javascripts/models/person.js
@@ -126,7 +126,7 @@
         });
 
         userRoles = _.filter(person.user_roles, function (item) {
-          return item.getInstance().context_id === instance.context_id;
+          return item.getInstance().context_id === instance.context.id;
         });
 
         relationships = userRoles.concat(objectPeopleFiltered)


### PR DESCRIPTION
Steps:
1.Create a program
2. Go to People tab: confirm No Access role is displayed as default
3. Click + to Map Person to this program
4. Map selected Person
5. Navigate to Person’s Info pane
6. Click 3 bb’s button -> Edit Authorizations
7. Change user role -> Save
8. Look at Person first tree view: Authorizations are not updated
Actual Result: No Role authorization is displayed as default and is not changed to another program roles
Expected Result: Authorization should be displayed according to the program roles