### PR TITLE
GGRC-110 Assessment cad uniqueness

### DIFF
--- a/src/ggrc/models/custom_attribute_definition.py
+++ b/src/ggrc/models/custom_attribute_definition.py
@@ -171,9 +171,12 @@ class CustomAttributeDefinition(mixins.Base, mixins.Titled, db.Model):
   @classmethod
   def _get_global_cad_names(cls, definition_type):
     """Get names of global cad for a given object."""
+    definition_types = [definition_type]
+    if definition_type == "assessment_template":
+      definition_types.append("assessment")
     if not getattr(flask.g, "_global_cad_names", set()):
       query = db.session.query(cls.title, cls.id).filter(
-          cls.definition_type == definition_type,
+          cls.definition_type.in_(definition_types),
           cls.definition_id.is_(None)
       )
       flask.g._global_cad_names = {name.lower(): id_ for name, id_ in query}

--- a/src/ggrc/models/custom_attribute_definition.py
+++ b/src/ggrc/models/custom_attribute_definition.py
@@ -152,6 +152,8 @@ class CustomAttributeDefinition(mixins.Base, mixins.Titled, db.Model):
       frozen set containing all reserved attribute names for the current
       object.
     """
+    # pylint: disable=protected-access
+    # The _inflector is a false positive in our app.
     with benchmark("Generate a list of all reserved attribute names"):
       if not cls._reserved_names.get(definition_type):
         definition_map = {model._inflector.table_singular: model
@@ -174,13 +176,13 @@ class CustomAttributeDefinition(mixins.Base, mixins.Titled, db.Model):
     definition_types = [definition_type]
     if definition_type == "assessment_template":
       definition_types.append("assessment")
-    if not getattr(flask.g, "_global_cad_names", set()):
+    if not getattr(flask.g, "global_cad_names", set()):
       query = db.session.query(cls.title, cls.id).filter(
           cls.definition_type.in_(definition_types),
           cls.definition_id.is_(None)
       )
-      flask.g._global_cad_names = {name.lower(): id_ for name, id_ in query}
-    return flask.g._global_cad_names
+      flask.g.global_cad_names = {name.lower(): id_ for name, id_ in query}
+    return flask.g.global_cad_names
 
   def validate_assessment_title(self, name):
     """Check assessment title uniqueness.
@@ -205,13 +207,13 @@ class CustomAttributeDefinition(mixins.Base, mixins.Titled, db.Model):
       # then title then definition_id, this check would fail.
       return
 
-    if not getattr(flask.g, "_at_cad_names", set()):
+    if not getattr(flask.g, "template_cad_names", set()):
       query = db.session.query(self.__class__.title).filter(
           self.__class__.definition_type == "assessment_template"
       )
-      flask.g._at_cad_names = {cad.title.lower() for cad in query}
+      flask.g.template_cad_names = {cad.title.lower() for cad in query}
 
-    if name in flask.g._at_cad_names:
+    if name in flask.g.template_cad_names:
       raise ValueError("Invalid Custom attribute name.")
 
   @validates("title", "definition_type")

--- a/test/integration/ggrc/models/test_cad.py
+++ b/test/integration/ggrc/models/test_cad.py
@@ -154,3 +154,36 @@ class TestCAD(TestCase):
             title="assessment CAD",
             definition_type="assessment",
         )
+
+  def test_assessment_template(self):
+    """Test collisions between assessment template and assessments.
+
+    Assessment template is not allowed to have local CAD that match Assessment
+    global CAD, because that will cause collisions when assessments are
+    generated when using the mentioned template.
+    """
+    CAD = factories.CustomAttributeDefinitionFactory
+    with app.app_context():
+      CAD(
+          title="global title",
+          definition_type="assessment",
+      )
+      CAD(
+          title="local title",
+          definition_type="assessment",
+          definition_id=1,
+      )
+    with app.app_context():
+      # check that assessment template CAD can match an assessment local CAD.
+      CAD(
+          title="local title",
+          definition_type="assessment_template",
+          definition_id=1,
+      )
+    with app.app_context():
+      with self.assertRaises(ValueError):
+        CAD(
+            title="global title",
+            definition_type="assessment_template",
+            definition_id=1,
+        )

--- a/test/integration/ggrc/models/test_cad.py
+++ b/test/integration/ggrc/models/test_cad.py
@@ -3,7 +3,6 @@
 
 """Integration tests for custom attribute definitions model."""
 
-from flask import g
 from sqlalchemy.exc import IntegrityError
 
 from ggrc import db
@@ -11,6 +10,8 @@ from ggrc import models
 from ggrc.app import app
 from integration.ggrc import TestCase
 from integration.ggrc.models import factories
+
+CAD = factories.CustomAttributeDefinitionFactory
 
 
 class TestCAD(TestCase):
@@ -133,7 +134,6 @@ class TestCAD(TestCase):
     global CAD, because that will cause collisions when assessments are
     generated when using the mentioned template.
     """
-    CAD = factories.CustomAttributeDefinitionFactory
     with app.app_context():
       CAD(
           title="assessment CAD",
@@ -162,7 +162,6 @@ class TestCAD(TestCase):
     global CAD, because that will cause collisions when assessments are
     generated when using the mentioned template.
     """
-    CAD = factories.CustomAttributeDefinitionFactory
     with app.app_context():
       CAD(
           title="global title",


### PR DESCRIPTION
Assessment template custom attribute names must not match assessment custom attribute names because it causes conflicts when generating assessments.

Create global assessment custom attribute with name "gca"
create assessment template with custom attribute named "gca"
try to create assessment using the previous template.