### PR TITLE
GGRC-37 Hide inactive cycles

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
@@ -1490,7 +1490,9 @@ CMS.Controllers.TreeLoader('CMS.Controllers.TreeView', {
         modelName,
         options.paging,
         queryAPI.makeExpression(modelName, options.parent_instance.type,
-          options.parent_instance.id)
+          options.parent_instance.id),
+        undefined,
+        options.additional_filter
       );
 
     this._draw_list_deferred = false;

--- a/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
+++ b/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
@@ -592,35 +592,29 @@
 
     function _makeFilter(filter, relevant) {
       var relevantFilter;
-      var filters;
-      var left;
-      var right;
+      var filterList = [];
 
       if (relevant) {
-        relevantFilter = '#' + relevant.type + ',' + relevant.id + '#';
-        left = GGRC.query_parser.parse(relevantFilter || '');
+        relevantFilter = GGRC.query_parser.parse('#' + relevant.type + ',' +
+                                                 relevant.id + '#');
+        filterList.push(relevantFilter);
 
         if (relevant.operation &&
-          relevant.operation !== left.expression.op.name) {
-          left.expression.op.name = relevant.operation;
+            relevant.operation !== relevantFilter.expression.op.name) {
+          relevantFilter.expression.op.name = relevant.operation;
         }
       }
 
       if (filter) {
-        right = GGRC.query_parser.parse(filter);
+        filterList.push(GGRC.query_parser.parse(filter));
       }
 
-      if (left && right) {
-        filters = GGRC.query_parser.join_queries(left, right);
-      } else if (left) {
-        filters = left;
-      } else if (right) {
-        filters = right;
-      } else {
-        filters = {expression: {}};
+      if (filterList.length) {
+        return filterList.reduce(function (left, right) {
+          return GGRC.query_parser.join_queries(left, right);
+        });
       }
-
-      return filters;
+      return {expression: {}};
     }
 
     function _getTreeViewOperation(objectName) {

--- a/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
+++ b/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
@@ -469,10 +469,11 @@
      * @param {Object} relevant.type - Type of relevant object
      * @param {Object} relevant.id - Id of relevant object
      * @param {Object} relevant.operation - Type of operation.
+     * @param {Object} additionalFilter - An additional filter to be applied
      * @return {QueryAPIRequest} Array of QueryAPIRequest
      */
-    function buildParams(objName, page, relevant) {
-      return [buildParam(objName, page, relevant)];
+    function buildParams(objName, page, relevant, additionalFilter) {
+      return [buildParam(objName, page, relevant, undefined, additionalFilter)];
     }
 
     /**
@@ -490,9 +491,10 @@
      * @param {Object} relevant.id - Id of relevant object
      * @param {Object} relevant.operation - Type of operation.
      * @param {Array} fields - Array of requested fields.
+     * @param {Object} additionalFilter - An additional filter to be applied
      * @return {QueryAPIRequest} Object of QueryAPIRequest
      */
-    function buildParam(objName, page, relevant, fields) {
+    function buildParam(objName, page, relevant, fields, additionalFilter) {
       var first;
       var last;
       var params = {};
@@ -505,7 +507,7 @@
       if (relevant && !relevant.operation) {
         relevant.operation = _getTreeViewOperation(objName);
       }
-      params.filters = _makeFilter(page.filter, relevant);
+      params.filters = _makeFilter(page.filter, relevant, additionalFilter);
 
       if (page.current && page.pageSize) {
         first = (page.current - 1) * page.pageSize;
@@ -590,7 +592,7 @@
       return expression;
     }
 
-    function _makeFilter(filter, relevant) {
+    function _makeFilter(filter, relevant, additionalFilter) {
       var relevantFilter;
       var filterList = [];
 
@@ -607,6 +609,10 @@
 
       if (filter) {
         filterList.push(GGRC.query_parser.parse(filter));
+      }
+
+      if (additionalFilter) {
+        filterList.push(additionalFilter);
       }
 
       if (filterList.length) {

--- a/src/ggrc_workflows/assets/javascripts/apps/workflows.js
+++ b/src/ggrc_workflows/assets/javascripts/apps/workflows.js
@@ -581,7 +581,14 @@
         draw_children: true,
         parent_instance: object,
         model: 'Cycle',
-        mapping: 'previous_cycles'
+        mapping: 'previous_cycles',
+        additional_filter: {
+          expression: {
+            op: {name: '='},
+            left: 'is_current',
+            right: 0
+          }
+        }
       }
     };
 
@@ -597,6 +604,13 @@
         parent_instance: object,
         model: 'Cycle',
         mapping: 'current_cycle',
+        additional_filter: {
+          expression: {
+            op: {name: '='},
+            left: 'is_current',
+            right: 1
+          }
+        },
         header_view: GGRC.mustache_path + '/cycles/tree_header.mustache',
         add_item_view:
           GGRC.mustache_path +


### PR DESCRIPTION
This PR fixes the queries for "Active Cycles" and "History" tabs on Workflow info page.

Steps to reproduce:
1. Open the info page for Workflow with at least one active Cycle and at least one inactive Cycle.
2. Open "Active Cycles" tab.
3. Open "History" tab.

Expected result: "Active Cycles" shows only active Cycles, each row has "End Cycle" button (if the user has permissions to do so). "History" shows only inactive Cycles, no row has "End Cycle" button.
Actual result: both "Active Cycles" and "History" show the same list of Cycles which is a mix of active and inactive Cycles.