### PR TITLE
GGRC-5 Fix is_authenticated in person class

### DIFF
--- a/src/ggrc/models/person.py
+++ b/src/ggrc/models/person.py
@@ -89,7 +89,7 @@ class Person(CustomAttributable, CustomAttributeMapable, HasOwnContext,
   # Methods required by Flask-Login
     # pylint: disable=no-self-use
   def is_authenticated(self):
-    return True
+    return self.system_wide_role != 'No Access'
 
   def is_active(self):
     # pylint: disable=no-self-use


### PR DESCRIPTION
This makes sure that the user is logged out when they loose a system
wide role. Before this change the user was still able to access the app
until they manually logged out.