### PR TITLE
GGRC-16 Display user's email even if name is not empty

### DIFF
--- a/src/ggrc/assets/mustache/people/object_list.mustache
+++ b/src/ggrc/assets/mustache/people/object_list.mustache
@@ -20,11 +20,7 @@
                 </div>
                 <div class="span4">
                   <div class="email tree-title-area">
-                    {{#if_match name '\\\\S'}}
-                      {{#name}}
-                        <span class="email">{{email}}</span>
-                      {{/name}}
-                    {{/if_match}}
+                    <span class="email">{{email}}</span>
                   </div>
                 </div>
                 <div class="span2">

--- a/src/ggrc/assets/mustache/people/tree.mustache
+++ b/src/ggrc/assets/mustache/people/tree.mustache
@@ -21,16 +21,12 @@
 
               <div class="span2">
                 <div class="email tree-title-area">
-                  {{#if_match instance.name '\\\\S'}}
-                    {{#instance.name}}
-                      <span class="email">{{instance.email}}</span>
-                      {{#if_equals system_wide_role 'No Role'}}
-                        <span class="user-disabled">
-                          (Inactive user)
-                        </span>
-                      {{/if_equals}}
-                    {{/instance.name}}
-                  {{/if_match}}
+                  <span class="email">{{instance.email}}</span>
+                  {{#if_equals system_wide_role 'No Role'}}
+                    <span class="user-disabled">
+                      (Inactive user)
+                    </span>
+                  {{/if_equals}}
                 </div>
               </div>
 

--- a/src/ggrc/assets/mustache/search/advanced_search_option_items.mustache
+++ b/src/ggrc/assets/mustache/search/advanced_search_option_items.mustache
@@ -17,7 +17,7 @@
             <div class="span8">
               <div class="tree-title-area">
                 <i class="fa fa-{{instance.class.table_singular}} color"></i>
-                {{firstexist instance.name instance.title instance.description}}
+                {{firstexist instance.name instance.email instance.title instance.description}}
                 <span class="url-link">
                 {{firstexist instance.email instance.link}}
                 </span>

--- a/src/ggrc_basic_permissions/assets/mustache/ggrc_basic_permissions/people_roles/authorizations_by_person_list.mustache
+++ b/src/ggrc_basic_permissions/assets/mustache/ggrc_basic_permissions/people_roles/authorizations_by_person_list.mustache
@@ -54,11 +54,7 @@
               <div class="item-data">
                 <div class="tree-title-area">
                   {{{render '/static/mustache/people/popover.mustache' person=this}}}
-                  {{#if_match name '\\\\S'}}
-                    {{#name}}
-                      <span class="email">{{email}}</span>
-                    {{/name}}
-                  {{/if_match}}
+                    <span class="email">{{email}}</span>
                 </div>
               </div>
 

--- a/src/ggrc_basic_permissions/assets/mustache/ggrc_basic_permissions/people_roles/authorizations_by_person_tree.mustache
+++ b/src/ggrc_basic_permissions/assets/mustache/ggrc_basic_permissions/people_roles/authorizations_by_person_tree.mustache
@@ -17,11 +17,7 @@
                 </div>
                 <div class="span2">
                   <div class="email tree-title-area">
-                    {{#if_match instance.name '\\\\S'}}
-                      {{#instance.name}}
-                        <span class="email">{{instance.email}}</span>
-                      {{/instance.name}}
-                    {{/if_match}}
+                    <span class="email">{{instance.email}}</span>
                   </div>
                 </div>
                 <div class="span2">

--- a/src/ggrc_workflows/assets/mustache/selectors/object_selector_option_items.mustache
+++ b/src/ggrc_workflows/assets/mustache/selectors/object_selector_option_items.mustache
@@ -13,7 +13,7 @@
             <div class="row-fluid">
               <div class="span11">
                 <div class="tree-title-area">
-                  {{firstexist instance.name instance.title instance.link instance.description}}
+                  {{firstexist instance.name instance.email instance.title instance.link instance.description}}
                   <span class="url-link">
                     {{firstexist instance.email instance.link}}
                   </span>


### PR DESCRIPTION
**1.399  Bug (P1)**
**Subject**: Item is not displayed in the first tier in People tab while adding a person without Name
**Details**: 
Navigate to Admin Dashboard
Click to People tab
Click + to Add person
Enter Email in New Person window> Save and Close
Find the created person via filter
Look at tree view

_Actual Result_:  Item is not displayed in the first tier in People tab while adding a person without Name
_Expected Result_: Item should be displayed in the first tier in People tab