### PR TITLE
GGRC-93 Add a migration to unify CA dates format

### DIFF
--- a/src/ggrc/migrations/versions/20161020082501_53206b20c12b_unify_ca_date_format.py
+++ b/src/ggrc/migrations/versions/20161020082501_53206b20c12b_unify_ca_date_format.py
@@ -1,0 +1,86 @@
+# Copyright (C) 2016 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Unify CA date format
+
+Create Date: 2016-10-20 08:25:01.140510
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '53206b20c12b'
+down_revision = 'bb6fe8e14bb'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  connection = op.get_bind()
+
+  # change M/DD/YYYY or M/D/YYYY into MM/DD/YYYY or MM/D/YYYY correspondigly
+  connection.execute("""
+      UPDATE custom_attribute_values AS cav JOIN
+             custom_attribute_definitions AS cad ON
+                 cav.custom_attribute_id = cad.id
+      SET cav.attribute_value = CONCAT('0', cav.attribute_value)
+      WHERE cad.attribute_type = 'Date' AND
+            cav.attribute_value REGEXP '^[0-9]{1}/[0-9]{1,2}/[0-9]{4}$'
+  """)
+
+  # change MM/D/YYYY into MM/DD/YYYY
+  connection.execute("""
+      UPDATE custom_attribute_values AS cav JOIN
+             custom_attribute_definitions AS cad ON
+                 cav.custom_attribute_id = cad.id
+      SET cav.attribute_value = CONCAT(SUBSTR(cav.attribute_value, 1, 3),
+                                       '0',
+                                       SUBSTR(cav.attribute_value, 4, 9))
+      WHERE cad.attribute_type = 'Date' AND
+            cav.attribute_value REGEXP '^[0-9]{2}/[0-9]{1}/[0-9]{4}$'
+  """)
+
+  # change MM/DD/YYYY into YYYY-MM-DD
+  connection.execute("""
+      UPDATE custom_attribute_values AS cav JOIN
+             custom_attribute_definitions AS cad ON
+                 cav.custom_attribute_id = cad.id
+      SET cav.attribute_value = CONCAT_WS('-',
+                                          SUBSTR(cav.attribute_value, 7, 4),
+                                          SUBSTR(cav.attribute_value, 1, 2),
+                                          SUBSTR(cav.attribute_value, 4, 2))
+      WHERE cad.attribute_type = 'Date' AND
+            cav.attribute_value REGEXP '^[0-9]{2}/[0-9]{2}/[0-9]{4}$'
+  """)
+
+  # change YYYY-MM-DD 00:00:00 to YYYY-MM-DD
+  connection.execute("""
+      UPDATE custom_attribute_values AS cav JOIN
+             custom_attribute_definitions AS cad ON
+                 cav.custom_attribute_id = cad.id
+      SET cav.attribute_value = SUBSTR(cav.attribute_value, 1, 10)
+      WHERE cad.attribute_type = 'Date' AND
+            cav.attribute_value REGEXP
+                '^[0-9]{4}-[0-9]{2}-[0-9]{2} 00:00:00$'
+  """)
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  connection = op.get_bind()
+
+  # change YYYY-MM-DD into MM/DD/YYYY
+  connection.execute("""
+      UPDATE custom_attribute_values AS cav JOIN
+             custom_attribute_definitions AS cad ON
+                 cav.custom_attribute_id = cad.id
+      SET cav.attribute_value = CONCAT_WS('/',
+                                          SUBSTR(cav.attribute_value, 6, 2),
+                                          SUBSTR(cav.attribute_value, 9, 2),
+                                          SUBSTR(cav.attribute_value, 1, 4))
+      WHERE cad.attribute_type = 'Date' AND
+            cav.attribute_value REGEXP '^[0-9]{4}-[0-9]{2}-[0-9]{2}$'
+  """)

--- a/src/ggrc/migrations/versions/20161020082501_53206b20c12b_unify_ca_date_format.py
+++ b/src/ggrc/migrations/versions/20161020082501_53206b20c12b_unify_ca_date_format.py
@@ -10,6 +10,7 @@ Create Date: 2016-10-20 08:25:01.140510
 # pylint: disable=invalid-name
 
 from alembic import op
+from sqlalchemy.sql import text
 
 
 # revision identifiers, used by Alembic.
@@ -17,9 +18,35 @@ revision = '53206b20c12b'
 down_revision = 'bb6fe8e14bb'
 
 
+def _strip_whitespace_around_dates(connection):
+  """Fix possibly existing dates prefixed with spaces in the DB."""
+
+  dates = connection.execute("""
+      SELECT cavs.id as id, attribute_value as value
+      FROM custom_attribute_values AS cavs JOIN
+           custom_attribute_definitions as cads ON
+               cads.id = cavs.custom_attribute_id
+      WHERE attribute_type = 'Date'
+  """)
+
+  for date in dates:
+    if date.value is None:
+      new_value = None
+    else:
+      new_value = date.value.strip()
+    if date.value != new_value:
+      connection.execute(text("""
+          UPDATE custom_attribute_values SET
+              attribute_value = :val
+          WHERE id = :id
+      """), val=new_value, id=date.id)
+
+
 def upgrade():
   """Upgrade database schema and/or data, creating a new revision."""
   connection = op.get_bind()
+
+  _strip_whitespace_around_dates(connection)
 
   # change M/DD/YYYY or M/D/YYYY into MM/DD/YYYY or MM/D/YYYY correspondigly
   connection.execute("""


### PR DESCRIPTION
This PR fixes the format of Date-type CAVs in the DB. At the moment the formats are `MM/DD/YYYY` (set by the frontend) and `YYYY-MM-DD 00:00:00` (set by the imports some time ago).

The migration in this PR makes every date formatted as `YYYY-MM-DD`. The downgrading part of the migration reverts the formats to `MM/DD/YYYY`.

~~On hold until every other part of GGRC-34 is ready.~~

On hold until #4566 and #4579 are merged because until they are merged there is a possibility to store the data in the format this migration gets rid of.