### PR TITLE
GGRC-8 Fix displaying delete button for comments for tasks

### DIFF
--- a/src/ggrc_workflows/assets/mustache/cycle_task_entries/tree.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_entries/tree.mustache
@@ -61,15 +61,12 @@
       </li>
       <li>
         {{^if_equals parent_instance.status 'Verified'}}
-          {{#if mappings}}
-          {{#is_allowed_all 'delete' mappings}}
-            <a href="javascript://" data-toggle="unmap">
-              {{#result}}<span class="result" {{data 'result'}}></span>{{/result}}
+            {{#is_allowed 'delete' instance}}
+            <a data-toggle="modal-ajax-deleteform" data-object-plural="{{instance.class.table_plural}}" data-object-singular="CycleTaskEntry" data-modal-reset="reset" data-modal-class="modal" data-object-id="{{instance.id}}" href="javascript://">
               <i class="fa fa-trash"></i>
               Delete Comment
             </a>
           {{/is_allowed_all}}
-          {{/if}}
         {{/if_equals}}
       </li>
     </ul>


### PR DESCRIPTION
**Subject:** [Delete comment] button is absent in Task's Info pane at Active Cycles tab
**Details:**

- Create WF
- Go to setup tab
- Navigate to Task Group’s Info pane
- Create Task
- Click Activate Workflow button
- Go to Active Cycles tab
- Click grey triangle to Navigate to second tree view-> Task’s Info pane
- Add comment
- Click gear icon to delete comment: Delete button is absent

**Actual Result:** [Delete comment] button is absent in Task's Info pane at Active Cycles tab
**Expected Result:** [Delete comment] button should be in Task's Info pane at Active Cycles tab 
Workaround: NA
