### PR TITLE
QUICK-FIX Fix fulltext indexer

### DIFF
--- a/src/ggrc/fulltext/sql.py
+++ b/src/ggrc/fulltext/sql.py
@@ -2,7 +2,7 @@
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
 from ggrc import db
-from . import Indexer
+from ggrc.fulltext import Indexer
 
 
 class SqlIndexer(Indexer):
@@ -21,11 +21,12 @@ class SqlIndexer(Indexer):
 
   def update_record(self, record, commit=True):
     # remove the obsolete index entries
-    db.session.query(self.record_type).filter(
-        self.record_type.key == record.key,
-        self.record_type.type == record.type,
-        self.record_type.property.in_(list(record.properties.keys())),
-    ).delete(synchronize_session="fetch")
+    if record.properties:
+      db.session.query(self.record_type).filter(
+          self.record_type.key == record.key,
+          self.record_type.type == record.type,
+          self.record_type.property.in_(list(record.properties.keys())),
+      ).delete(synchronize_session="fetch")
     # add new index entries
     self.create_record(record, commit=commit)
 


### PR DESCRIPTION
This is a revert and a proper fix for the work done in this PR https://github.com/google/ggrc-core/pull/4524

The PR mentioned above added an sqlalchemy warning and possible performance degradation.
The issue was caused because custom attributes deleted all entries and added just one. The rest of this fix would be to make a unique index over all three columns (including tags) for uniqueness check and referring to all three columns every time we add or delete a record.

To test this PR, test the working of  https://github.com/google/ggrc-core/pull/4524 and make sure no warnings are shown when running python tests.

PS: also have a look if this change could be too risky to put into quince and if it would be more appropriate to merge it to develop instead.
