### PR TITLE
QUICK-FIX Update csv tests

### DIFF
--- a/test/integration/ggrc/__init__.py
+++ b/test/integration/ggrc/__init__.py
@@ -107,6 +107,11 @@ class TestCase(BaseTestCase):
 
     responses = defaultdict(lambda: defaultdict(set))
 
+    # Set default empty sets for non existing error messages in blocks
+    for block in expected_errors.itervalues():
+      for message in messages:
+        block[message] = block.get(message, set())
+
     for block in response:
       for message in messages:
         if message in expected_errors.get(block["name"], {}):

--- a/test/integration/ggrc/__init__.py
+++ b/test/integration/ggrc/__init__.py
@@ -23,7 +23,7 @@ class SetEncoder(json.JSONEncoder):
   def default(self, obj):
     if isinstance(obj, set):
       return sorted(obj)
-    return json.JSONEncoder.default(self, obj)
+    return super(SetEncoder, self).default(obj)
 
 
 class TestCase(BaseTestCase):

--- a/test/integration/ggrc/__init__.py
+++ b/test/integration/ggrc/__init__.py
@@ -103,14 +103,19 @@ class TestCase(BaseTestCase):
     """
 
     messages = ("block_errors", "block_warnings", "row_errors", "row_warnings")
+    counts = ("created", "updated", "rows")
 
     responses = defaultdict(lambda: defaultdict(set))
 
     for block in response:
       for message in messages:
-        if block[message]:
+        if message in expected_errors.get(block["name"], {}):
           responses[block["name"]][message] = \
               responses[block["name"]][message].union(set(block[message]))
+      for count in counts:
+        if count in expected_errors.get(block["name"], {}):
+          responses[block["name"]][count] = \
+              responses[block["name"]].get(count, 0) + int(block[count])
 
     response_str = json.dumps(responses, indent=4, sort_keys=True,
                               cls=SetEncoder)

--- a/test/integration/ggrc/__init__.py
+++ b/test/integration/ggrc/__init__.py
@@ -108,9 +108,11 @@ class TestCase(BaseTestCase):
     responses = defaultdict(lambda: defaultdict(set))
 
     # Set default empty sets for non existing error messages in blocks
-    for block in expected_errors.itervalues():
+    for block in response:
       for message in messages:
-        block[message] = block.get(message, set())
+        error_block = expected_errors.get(block["name"], {})
+        error_block[message] = error_block.get(message, set())
+        expected_errors[block["name"]] = error_block
 
     for block in response:
       for message in messages:

--- a/test/integration/ggrc/__init__.py
+++ b/test/integration/ggrc/__init__.py
@@ -90,12 +90,12 @@ class TestCase(BaseTestCase):
     app.debug = False
     return app
 
-  def _check_csv_response(self, response, expected_errors):
+  def _check_csv_response(self, response, expected_messages):
     """Test that response contains all expected errors and warnigs.
 
     Args:
       response: api response object.
-      expected_errors: dict of all expected errors by object type.
+      expected_messages: dict of all expected errors by object type.
 
     Raises:
       AssertionError if an expected error or warning is not found in the
@@ -110,26 +110,26 @@ class TestCase(BaseTestCase):
     # Set default empty sets for non existing error messages in blocks
     for block in response:
       for message in messages:
-        error_block = expected_errors.get(block["name"], {})
+        error_block = expected_messages.get(block["name"], {})
         error_block[message] = error_block.get(message, set())
-        expected_errors[block["name"]] = error_block
+        expected_messages[block["name"]] = error_block
 
     for block in response:
       for message in messages:
-        if message in expected_errors.get(block["name"], {}):
+        if message in expected_messages.get(block["name"], {}):
           responses[block["name"]][message] = \
               responses[block["name"]][message].union(set(block[message]))
       for count in counts:
-        if count in expected_errors.get(block["name"], {}):
+        if count in expected_messages.get(block["name"], {}):
           responses[block["name"]][count] = \
               responses[block["name"]].get(count, 0) + int(block[count])
 
     response_str = json.dumps(responses, indent=4, sort_keys=True,
                               cls=SetEncoder)
-    expected_str = json.dumps(expected_errors, indent=4, sort_keys=True,
+    expected_str = json.dumps(expected_messages, indent=4, sort_keys=True,
                               cls=SetEncoder)
 
-    self.assertEqual(responses, expected_errors,
+    self.assertEqual(responses, expected_messages,
                      "Expected response does not match received response:\n\n"
                      "EXPECTED:\n{}\n\nRECEIVED:\n{}".format(
                          expected_str, response_str))

--- a/test/integration/ggrc/converters/test_import_comprehensive.py
+++ b/test/integration/ggrc/converters/test_import_comprehensive.py
@@ -258,7 +258,7 @@ class TestComprehensiveSheets(TestCase):
     response = self.import_file("case_sensitive_slugs.csv")
     expected_errors = {
         "Control": {
-            "row_errors": [
+            "row_errors": {
                 errors.DUPLICATE_VALUE_IN_CSV.format(
                     line_list="3, 4",
                     column_name="Code",
@@ -273,7 +273,7 @@ class TestComprehensiveSheets(TestCase):
                     value="a",
                     ignore_lines="4",
                 ),
-            ]
+            }
         }
     }
     self._check_csv_response(response, expected_errors)
@@ -292,7 +292,7 @@ class TestComprehensiveSheets(TestCase):
 
     expected_errors = {
         "Task Group Task": {
-            "row_errors": [
+            "row_errors": {
                 errors.MISSING_VALUE_ERROR.format(
                     line="5",
                     column_name="End",
@@ -309,7 +309,7 @@ class TestComprehensiveSheets(TestCase):
                     line="7",
                     column_name="End",
                 ),
-            ],
+            },
         },
     }
     self._check_csv_response(response, expected_errors)

--- a/test/integration/ggrc_workflows/converters/test_import_workflow_objects.py
+++ b/test/integration/ggrc_workflows/converters/test_import_workflow_objects.py
@@ -57,10 +57,10 @@ class TestWorkflowObjectsImport(TestCase):
 
     expected_errors = {
         "Workflow": {
-            "row_errors": [
+            "row_errors": {
                 errors.MISSING_VALUE_ERROR.format(
                     line=8, column_name="Manager")
-            ],
+            },
         }
     }
     self._check_csv_response(response, expected_errors)


### PR DESCRIPTION
This is prep work for fixing request import warnings.

This pull request will make it easier to have setup objects and the actual test objects in the same csv in different blocks.