### PR TITLE
GGRC-130 Custom serializer for CA dates

### DIFF
--- a/src/ggrc/builder/json.py
+++ b/src/ggrc/builder/json.py
@@ -129,6 +129,10 @@ class UpdateAttrHandler(object):
       # values
       attr_name = attr
       value = json_obj.get(attr_name)
+    elif attr in getattr(obj.__class__, "_custom_update", []):
+      # The attribute has a custom setter
+      attr_name = attr
+      value = obj.__class__._custom_update[attr](obj, json_obj.get(attr_name))
     elif hasattr(attr, '__call__'):
       # The attribute has been decorated with a callable, grab the name and
       # invoke the callable to get the value
@@ -662,6 +666,8 @@ class Builder(AttributeInfo):
             isinstance(class_attr.property, RelationshipProperty):
       return self.publish_relationship(
           obj, attr_name, class_attr, inclusions, include, inclusion_filter)
+    elif attr_name in getattr(obj.__class__, "_custom_publish", []):
+      return obj.__class__._custom_publish[attr_name](obj)
     elif class_attr.__class__.__name__ == 'property':
       if not inclusions or include:
         if getattr(obj, '{0}_id'.format(attr_name)):

--- a/src/ggrc/models/custom_attribute_value.py
+++ b/src/ggrc/models/custom_attribute_value.py
@@ -4,7 +4,6 @@
 """Custom attribute value model"""
 
 from collections import namedtuple
-from datetime import datetime
 
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy import and_
@@ -17,6 +16,7 @@ from ggrc.models.computed_property import computed_property
 from ggrc.models.mixins import Base
 from ggrc.models.reflection import PublishOnly
 from ggrc.models.revision import Revision
+from ggrc import utils
 
 
 class CustomAttributeValue(Base, db.Model):
@@ -390,11 +390,6 @@ class CustomAttributeValue(Base, db.Model):
            for mask in cad.multi_choice_mandatory.split(",")),
       ))
 
-  @staticmethod
-  def _convert_date_format(date, format_from, format_to):
-    """Convert string date format from one to another."""
-    return datetime.strptime(date, format_from).strftime(format_to)
-
   def _publish_attribute_value(self):
     """Return value serialized for JSON.
 
@@ -409,7 +404,7 @@ class CustomAttributeValue(Base, db.Model):
     self_is_date = self.custom_attribute.attribute_type == literal_date
     if self_is_date and self.attribute_value:
       try:
-        result = self._convert_date_format(self.attribute_value,
+        result = utils.convert_date_format(self.attribute_value,
                                            self.DATE_FORMAT_DB,
                                            self.DATE_FORMAT_JSON)
       except ValueError:
@@ -441,7 +436,7 @@ class CustomAttributeValue(Base, db.Model):
     self_is_date = self.custom_attribute.attribute_type == literal_date
     if self_is_date and new_value:
       try:
-        new_value = self._convert_date_format(new_value,
+        new_value = utils.convert_date_format(new_value,
                                               self.DATE_FORMAT_JSON,
                                               self.DATE_FORMAT_DB)
       except ValueError:

--- a/src/ggrc/models/custom_attribute_value.py
+++ b/src/ggrc/models/custom_attribute_value.py
@@ -22,6 +22,15 @@ class CustomAttributeValue(Base, db.Model):
   """Custom attribute value model"""
 
   __tablename__ = 'custom_attribute_values'
+
+  _publish_attrs = [
+      'custom_attribute_id',
+      'attributable_id',
+      'attributable_type',
+      'attribute_value',
+      'attribute_object',
+      PublishOnly('preconditions_failed'),
+  ]
   _fulltext_attrs = ["attribute_value"]
 
   custom_attribute_id = db.Column(
@@ -91,15 +100,6 @@ class CustomAttributeValue(Base, db.Model):
     self.attributable_type = value.__class__.__name__ if value is not None \
         else None
     return setattr(self, self.attributable_attr, value)
-
-  _publish_attrs = [
-      'custom_attribute_id',
-      'attributable_id',
-      'attributable_type',
-      'attribute_value',
-      'attribute_object',
-      PublishOnly('preconditions_failed'),
-  ]
 
   @property
   def attribute_object(self):

--- a/src/ggrc/models/custom_attribute_value.py
+++ b/src/ggrc/models/custom_attribute_value.py
@@ -4,6 +4,7 @@
 """Custom attribute value model"""
 
 from collections import namedtuple
+from datetime import datetime
 
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy import and_
@@ -54,6 +55,17 @@ class CustomAttributeValue(Base, db.Model):
       "Dropdown": lambda self: self._validate_dropdown(),
       "Map:Person": lambda self: self._validate_map_person(),
   }
+
+  _custom_publish = {
+      "attribute_value": lambda self: self._publish_attribute_value(),
+  }
+  _custom_update = {
+      "attribute_value": lambda self, val: self._update_attribute_value(val),
+  }
+
+  # formats to represent Date-type values
+  DATE_FORMAT_DB = "%Y-%m-%d"
+  DATE_FORMAT_JSON = "%m/%d/%Y"
 
   @property
   def latest_revision(self):
@@ -377,3 +389,60 @@ class CustomAttributeValue(Base, db.Model):
           (make_flags(mask)
            for mask in cad.multi_choice_mandatory.split(",")),
       ))
+
+  @staticmethod
+  def _convert_date_format(date, format_from, format_to):
+    """Convert string date format from one to another."""
+    return datetime.strptime(date, format_from).strftime(format_to)
+
+  def _publish_attribute_value(self):
+    """Return value serialized for JSON.
+
+    If self is a Date-type CAV, convert it to MM/DD/YYYY.
+    """
+
+    from ggrc.models import CustomAttributeDefinition
+
+    result = self.attribute_value
+    literal_date = CustomAttributeDefinition.ValidTypes.DATE
+
+    self_is_date = self.custom_attribute.attribute_type == literal_date
+    if self_is_date and self.attribute_value:
+      try:
+        result = self._convert_date_format(self.attribute_value,
+                                           self.DATE_FORMAT_DB,
+                                           self.DATE_FORMAT_JSON)
+      except ValueError:
+        # invalid format or not a date, don't convert
+        pass
+
+    return result
+
+  def _update_attribute_value(self, new_value):
+    """Update value from received JSON.
+
+    If self is a Date-type CAV, convert the received value to YYYY-MM-DD.
+    """
+
+    from ggrc.models import CustomAttributeDefinition
+
+    literal_date = CustomAttributeDefinition.ValidTypes.DATE
+
+    if self.custom_attribute is None:
+      # self is newly created and is not yet flushed to the db
+      # manually store self.custom_attribute because it is cached as None until
+      # flush & expire
+      self.custom_attribute = (db.session.query(CustomAttributeDefinition)
+                               .filter_by(id=self.custom_attribute_id).one())
+
+    self_is_date = self.custom_attribute.attribute_type == literal_date
+    if self_is_date and new_value:
+      try:
+        new_value = self._convert_date_format(new_value,
+                                              self.DATE_FORMAT_JSON,
+                                              self.DATE_FORMAT_DB)
+      except ValueError:
+        # invalid format or not a date, don't convert
+        pass
+
+    self.attribute_value = new_value

--- a/src/ggrc/models/custom_attribute_value.py
+++ b/src/ggrc/models/custom_attribute_value.py
@@ -428,6 +428,9 @@ class CustomAttributeValue(Base, db.Model):
 
     literal_date = CustomAttributeDefinition.ValidTypes.DATE
 
+    # pylint: disable=access-member-before-definition
+    # pylint: disable=attribute-defined-outside-init
+    # false positives on the next block; the author doesn't like that block too
     if self.custom_attribute is None:
       # self is newly created and is not yet flushed to the db
       # manually store self.custom_attribute because it is cached as None until

--- a/src/ggrc/models/mixins/customattributable.py
+++ b/src/ggrc/models/mixins/customattributable.py
@@ -127,6 +127,10 @@ class CustomAttributable(object):
         value.custom_attribute_id or value.custom_attribute.id: value
         for value in self.custom_attribute_values
     }
+    self._definitions_map = {
+        definition.id: definition
+        for definition in self.custom_attribute_definitions
+    }
 
     if isinstance(values[0], dict):
       self._add_ca_value_dicts(values)
@@ -158,6 +162,8 @@ class CustomAttributable(object):
     Args:
       values: List of dictionaries that represent custom attribute values.
     """
+    from ggrc.models.custom_attribute_definition import (
+        CustomAttributeDefinition)
     from ggrc.models.custom_attribute_value import CustomAttributeValue
 
     for value in values:
@@ -169,8 +175,19 @@ class CustomAttributable(object):
                                         None)
       attr = self._values_map.get(value.get("custom_attribute_id"))
       if attr:
+        attribute_value = value.get("attribute_value")
+        if (self._definitions_map[value["custom_attribute_id"]]
+                .attribute_type == CustomAttributeDefinition.ValidTypes.DATE):
+          # convert the date formats for dates
+          if attribute_value:
+            attribute_value = CustomAttributeValue._convert_date_format(
+                attribute_value,
+                CustomAttributeValue.DATE_FORMAT_JSON,
+                CustomAttributeValue.DATE_FORMAT_DB,
+            )
+
         attr.attributable = self
-        attr.attribute_value = value.get("attribute_value")
+        attr.attribute_value = attribute_value
         attr.attribute_object_id = value.get("attribute_object_id")
       elif "custom_attribute_id" in value:
         # this is automatically appended to self._custom_attribute_values

--- a/src/ggrc/models/mixins/customattributable.py
+++ b/src/ggrc/models/mixins/customattributable.py
@@ -180,7 +180,7 @@ class CustomAttributable(object):
                 .attribute_type == CustomAttributeDefinition.ValidTypes.DATE):
           # convert the date formats for dates
           if attribute_value:
-            attribute_value = CustomAttributeValue._convert_date_format(
+            attribute_value = utils.convert_date_format(
                 attribute_value,
                 CustomAttributeValue.DATE_FORMAT_JSON,
                 CustomAttributeValue.DATE_FORMAT_DB,

--- a/src/ggrc/utils/__init__.py
+++ b/src/ggrc/utils/__init__.py
@@ -261,3 +261,8 @@ class QueryCounter(object):
 
 benchmark = benchmarks.get_benchmark()
 with_nop = benchmarks.WithNop
+
+
+def convert_date_format(date, format_from, format_to):
+  """Convert string date format from one to another."""
+  return datetime.datetime.strptime(date, format_from).strftime(format_to)


### PR DESCRIPTION
This PR enables date format conversion for custom attributes: the values are stored in `YYYY-MM-DD` format in the DB, but are sent to the frontend and received back in `MM-DD-YYYY` format. It is done to avoid changes to Date CA logic on the frontend.