### PR TITLE
GGRC-169 Query API CA date conversion

### DIFF
--- a/test/integration/ggrc/converters/test_csvs/sorting_with_ca_setup.csv
+++ b/test/integration/ggrc/converters/test_csvs/sorting_with_ca_setup.csv
@@ -1,61 +1,61 @@
-Object type,,,,,,,,,,,,,,
-program,code*,title*,description ,Manager,state,primary contact,effective date,stop date,notes,program url,reference url,editor,CA text,CA dropdown
+Object type,,,,,,,,,,,,,,,
+program,code*,title*,description ,Manager,state,primary contact,effective date,stop date,notes,program url,reference url,editor,CA text,CA date,CA dropdown
 ,prog-1,F,2,"anze@example.com
 albert@example.com
 tommy@example.com",Draft,anze@example.com,1/6/2016,1/19/2016,3,http://google.com/_1,http://google.com/_2,"anze@example.com
 albert@example.com
-tommy@example.com",B,one
+tommy@example.com",B,05/18/2015,one
 ,prog-2,G,2,"miha@example.com
 rob@example.com
 ken@example.com",Final,albert@example.com,1/7/2016,1/18/2016,2,http://google.com/_2,http://google.com/_3,"miha@example.com
 rob@example.com
-ken@example.com",B,two
+ken@example.com",B,05/17/2015,two
 ,prog-3,H,2,"user@example.com
 anze@example.com
 miha@example.com",Effective,tommy@example.com,1/8/2016,1/17/2016,1,http://google.com/_3,http://google.com/_4,"user@example.com
 anze@example.com
-miha@example.com",A,two
+miha@example.com",A,05/18/2015,two
 ,prog-4,I,3,"anze@example.com
 albert@example.com
 tommy@example.com",Ineffective,miha@example.com,1/9/2016,1/16/2016,2,http://google.com/_4,http://google.com/_5,"anze@example.com
 albert@example.com
-tommy@example.com",A,one
+tommy@example.com",A,12/31/2014,one
 ,prog-5,J,3,"miha@example.com
 rob@example.com
 ken@example.com",Launched,anze@example.com,1/10/2016,1/15/2016,1,http://google.com/_5,http://google.com/_6,"miha@example.com
 rob@example.com
-ken@example.com",D,three
+ken@example.com",D,05/18/2015,three
 ,prog-6,A,3,"user@example.com
 anze@example.com
 miha@example.com",Not Launched,albert@example.com,1/1/2016,1/14/2016,5,http://google.com/_6,http://google.com/_7,"user@example.com
 anze@example.com
-miha@example.com",D,four
+miha@example.com",D,01/01/2016,four
 ,prog-7,B,1,"anze@example.com
 albert@example.com
 tommy@example.com",In Scope,tommy@example.com,1/2/2016,1/13/2016,5,http://google.com/_7,http://google.com/_8,"anze@example.com
 albert@example.com
-tommy@example.com",E,one
+tommy@example.com",E,05/18/2015,one
 ,prog-8,C,1,"miha@example.com
 rob@example.com
 ken@example.com",Not in Scope,miha@example.com,1/3/2016,1/12/2016,3,http://google.com/_8,http://google.com/_9,"miha@example.com
 rob@example.com
-ken@example.com",E,two
+ken@example.com",E,10/18/2015,two
 ,prog-9,D,1,"user@example.com
 anze@example.com
 miha@example.com",Deprecated,rob@example.com,1/4/2016,1/11/2016,1,http://google.com/_9,http://google.com/_10,"user@example.com
 anze@example.com
-miha@example.com",A,four
+miha@example.com",A,05/18/2015,four
 ,prog-10,E,1,"anze@example.com
 albert@example.com
 tommy@example.com",Draft,ken@example.com,1/5/2016,1/10/2016,2,http://google.com/_10,http://google.com/_11,"anze@example.com
 albert@example.com
-tommy@example.com",J,five
-,,,,,,,,,,,,,,
-Object type,,,,,,,,,,,,,,
-Person,Name,Email*,Company,Role,,,,,,,,,,
-,three,anze@example.com,,Admin,,,,,,,,,,
-,four,albert@example.com,,Admin,,,,,,,,,,
-,five,tommy@example.com,,Admin,,,,,,,,,,
-,eleven,miha@example.com,,Admin,,,,,,,,,,
-,nine,rob@example.com,,Admin,,,,,,,,,,
-,twelwe,ken@example.com,,Admin,,,,,,,,,,
+tommy@example.com",J,05/19/2015,five
+,,,,,,,,,,,,,,,
+Object type,,,,,,,,,,,,,,,
+Person,Name,Email*,Company,Role,,,,,,,,,,,
+,three,anze@example.com,,Admin,,,,,,,,,,,
+,four,albert@example.com,,Admin,,,,,,,,,,,
+,five,tommy@example.com,,Admin,,,,,,,,,,,
+,eleven,miha@example.com,,Admin,,,,,,,,,,,
+,nine,rob@example.com,,Admin,,,,,,,,,,,
+,twelwe,ken@example.com,,Admin,,,,,,,,,,,


### PR DESCRIPTION
This PR is a trimmed down version of #4535 and features just Query API specific logic for filtering by CA dates.

Steps to test:
0. Make sure you performed reindex after running the migration in #4564.
1. Open a tree view of Assessments. They should have at least one Date-type CA.
2. Try typing this into the filter (`ca_field` is the name of your Date-type CA):
- `ca_field = 2016-10-24`
- `ca_field < 2016-10-24`
- `ca_field > 2016-10-24`
- `created_at = 2016-10-24` (won't be effective as `created_at` is a datetime field, most probably nothing will match)
- `created_at < 2016-10-24`
- `created_at > 2016-10-24`

`ca_field ~ 2016` and `created_at ~ 2016` are not implemented. There is no valid case why it should be allowed (the user can do `ca_field > 12/31/2015 AND ca_field < 1/1/2017` instead, for instance).

On hold until #4579, #4566, #4564 are merged because the logic in this PR relies on the format of the data in the database. It can be tested on synthetic data, but the listed PRs provide a way to test this on real data.
Includes commits from #4579 and #4566.