### PR TITLE
Revert "GGRC-11 Log assessment automappings"

### DIFF
--- a/src/ggrc/models/hooks/assessment.py
+++ b/src/ggrc/models/hooks/assessment.py
@@ -8,8 +8,6 @@
   new relationships and custom attributes
 """
 
-from itertools import izip
-
 from ggrc import db
 from ggrc.login import get_current_user_id
 from ggrc.models import all_models
@@ -22,34 +20,34 @@ from ggrc.services.common import Resource
 def init_hook():
   """ Initialize hooks"""
   # pylint: disable=unused-variable
-  @Resource.collection_posted.connect_via(Assessment)
-  def handle_assessment_post(sender, objects=None, sources=None):
+  @Resource.model_posted_after_commit.connect_via(Assessment)
+  def handle_assessment_post(sender, obj=None, src=None, service=None):
     # pylint: disable=unused-argument
     """Apply custom attribute definitions and map people roles
     when generating Assessmet with template"""
-    for obj, src in izip(objects, sources):
-      src_obj = src.get("object")
-      audit = src.get("audit")
-      program = src.get("program")
-      map_assessment(obj, src_obj)
-      map_assessment(obj, audit)
-      # The program may also be set as the src_obj. If so then it should not be
-      # mapped again.
-      if (src_obj and program and
-          (src_obj["id"] != program["id"] or
-           src_obj["type"] != program["type"])):
-        map_assessment(obj, program)
 
-      if not src.get("_generated"):
-        continue
+    src_obj = src.get("object")
+    audit = src.get("audit")
+    program = src.get("program")
+    map_assessment(obj, src_obj)
+    map_assessment(obj, audit)
+    # The program may also be set as the src_obj. If so then it should not be
+    # mapped again.
+    if (src_obj and program and
+        (src_obj["id"] != program["id"] or
+         src_obj["type"] != program["type"])):
+      map_assessment(obj, program)
 
-      related = {
-          "template": get_by_id(src.get("template")),
-          "obj": get_by_id(src.get("object")),
-          "audit": get_by_id(src.get("audit")),
-      }
-      relate_assignees(obj, related)
-      relate_ca(obj, related)
+    if not src.get("_generated"):
+      return
+
+    related = {
+        "template": get_by_id(src.get("template")),
+        "obj": get_by_id(src.get("object")),
+        "audit": get_by_id(src.get("audit")),
+    }
+    relate_assignees(obj, related)
+    relate_ca(obj, related)
 
 
 def map_assessment(assessment, obj):


### PR DESCRIPTION
This issue caused a regression where assessment generation got broken. I have been working on a fix for this here, but I'm not sure if we want to include this fix in the release branch as well: https://github.com/google/ggrc-core/pull/4553