### PR TITLE
GGRC-174 "Uncaught TypeError: Cannot read property 'id' of null" occurs while cllicking on Request log/Related Requests tab

### DIFF
--- a/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
+++ b/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
@@ -164,6 +164,11 @@
       var tablePlural;
       var bindings;
 
+      // Should check all passed arguments are presented
+      if (!target || !destination) {
+        console.error('Incorrect arguments list: ', arguments);
+        return false;
+      }
       if (_.isUndefined(mapping)) {
         tablePlural = CMS.Models[destination.type].table_plural;
         mapping = (target.has_binding(tablePlural) ? '' : 'related_') +

--- a/src/ggrc/assets/mustache/requests/related-requests.mustache
+++ b/src/ggrc/assets/mustache/requests/related-requests.mustache
@@ -71,7 +71,7 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                                 parent-instance="instance"
                                 is-loading="isLoading"
                                 mapping="{{instance.class.info_pane_options.urls.mapping}}">
-                            <reusable-objects-item nstance="instance"
+                            <reusable-objects-item instance="instance"
                                                    is-saving="isSaving"
                                                    base-instance="baseInstance"
                                                    mapping="mapping"


### PR DESCRIPTION
**Subject:** "Uncaught TypeError: Cannot read property 'id' of null" occurs while cllicking on Request log/Related Requests tab
**Details:** 

- Navigate to Request’s Info pane
- Add URL
- Go to Request log/Related Requests tab

**Actual Result:** "Uncaught TypeError: Cannot read property 'id' of null" occurs while clicking on Request log/Related Requests tab
**Expected Result:** No error displayed.
**Workaround:** N/A