### PR TITLE
GGRC-170 Disable status change popup for Not Started state

### DIFF
--- a/src/ggrc/assets/javascripts/models/mixins.js
+++ b/src/ggrc/assets/javascripts/models/mixins.js
@@ -162,14 +162,17 @@
     /**
      * Display a confirmation dialog before starting to edit the instance.
      *
-     * The dialog is not shown only if the instance is in the "In Progress"
-     * state - in that case an already resolved promise is returned.
+     * The dialog is not shown if the instance is either in the "Not Started",
+     * or the "In Progress" state - in that case an already resolved promise is
+     * returned.
      *
      * @return {Promise} A promise resolved/rejected if the user chooses to
      *   confirm/reject the dialog.
      */
     confirmBeginEdit: function () {
+      var STATUS_NOT_STARTED = 'Not Started';
       var STATUS_IN_PROGRESS = 'In Progress';
+      var IGNORED_STATES = [STATUS_NOT_STARTED, STATUS_IN_PROGRESS];
 
       var TITLE = [
         'Confirm moving ', this.type, ' to "', STATUS_IN_PROGRESS, '"'
@@ -183,7 +186,7 @@
 
       var confirmation = $.Deferred();
 
-      if (this.status === STATUS_IN_PROGRESS) {
+      if (_.includes(IGNORED_STATES, this.status)) {
         confirmation.resolve();
       } else {
         GGRC.Controllers.Modals.confirm({

--- a/src/ggrc/assets/javascripts/models/tests/autoStatusChangeable_mixin_spec.js
+++ b/src/ggrc/assets/javascripts/models/tests/autoStatusChangeable_mixin_spec.js
@@ -60,6 +60,8 @@ describe('CMS.Models.Mixins.autoStatusChangeable', function () {
       var promise;
       var spy;
 
+      instance.attr('status', 'In Limbo');
+
       promise = method();
 
       spy = GGRC.Controllers.Modals.confirm;
@@ -82,6 +84,8 @@ describe('CMS.Models.Mixins.autoStatusChangeable', function () {
       var promise;
       var spy;
 
+      instance.attr('status', 'In Limbo');
+
       promise = method();
 
       spy = GGRC.Controllers.Modals.confirm;
@@ -98,12 +102,32 @@ describe('CMS.Models.Mixins.autoStatusChangeable', function () {
       expect(promise.state()).toEqual('rejected');
     });
 
-    it('returns a resolved promise if "In Progress" state', function () {
-      var promise;
+    it('returns a resolved promise if in "In Progress" state without ' +
+      'opening the modal',
+      function () {
+        var promise;
+        var spy = GGRC.Controllers.Modals.confirm;
 
-      instance.attr('status', 'In Progress');
-      promise = method();
-      expect(promise.state()).toEqual('resolved');
-    });
+        instance.attr('status', 'In Progress');
+        promise = method();
+
+        expect(promise.state()).toEqual('resolved');
+        expect(spy).not.toHaveBeenCalled();
+      }
+    );
+
+    it('returns a resolved promise if in "Not Started" state without ' +
+      'opening the modal',
+      function () {
+        var promise;
+        var spy = GGRC.Controllers.Modals.confirm;
+
+        instance.attr('status', 'Not Started');
+        promise = method();
+
+        expect(promise.state()).toEqual('resolved');
+        expect(spy).not.toHaveBeenCalled();
+      }
+    );
   });
 });


### PR DESCRIPTION
When editing a custom attribute on a `Not Started` object, the automatic status change confirmation dialog is not wanted, and this PR fixes that.

**Steps to reproduce:**
- Create a new Assessment or Request (make sure that at least one custom attribute is defined for that object type). The object's state will be set to _"Not Started"_.
- Try to inline edit a custom attrbute on that object's info panel.

**Expected result:**
The custom attribute can be edited without any distractions.

**Actual result:**
A dialog appears asking  the user to confirm automatic status change if the CA value gets modified. 