### PR TITLE
GGRC-178 Fix unmap controls from Audit

### DIFF
--- a/src/ggrc/assets/javascripts/models/join_models.js
+++ b/src/ggrc/assets/javascripts/models/join_models.js
@@ -191,7 +191,8 @@
         console.warn('Duplicated relationship objects', relationshipIds);
       }
       relationships = can.map(relationshipIds, function (id) {
-        return CMS.Models.Relationship.findInCacheById(id);
+        return CMS.Models.Relationship.findInCacheById(id) ||
+          CMS.Models.get_instance('Relationship', id);
       });
       result.resolve(relationships);
       return result.promise();

--- a/src/ggrc/assets/javascripts/models/tests/join_models_spec.js
+++ b/src/ggrc/assets/javascripts/models/tests/join_models_spec.js
@@ -11,122 +11,175 @@ describe('CMS.Models.Relationship getRelationshipBetweenInstances() method',
     beforeAll(function () {
       method = CMS.Models.Relationship.getRelationshipBetweenInstances;
 
-      spyOn(CMS.Models.Relationship, 'findInCacheById')
-        .and.callFake(function (id) {
-          return {id: id};
-        });
       spyOn(console, 'warn');
     });
 
-    it('return intersecting Relationships', function (done) {
-      var result;
-      instance1 = {
-        related_sources: [{id: 1}, {id: 2}, {id: 3}],
-        related_destinations: [{id: 4}]
-      };
-      instance2 = {
-        related_sources: [{id: 4}, {id: 5}, {id: 6}],
-        related_destinations: [{id: 7}]
-      };
-
-      result = method(instance1, instance2);
-
-      result.then(function (res) {
-        expect(res[0]).toEqual({id: 4});
-        done();
-      });
+    beforeEach(function () {
+      spyOn(CMS.Models, 'get_instance')
+        .and.callFake(function (name, id) {
+          return {id: id};
+        });
     });
 
-    it('returns undefined for not related instances', function (done) {
-      var result;
-
-      instance1 = {
-        related_sources: [{id: 1}, {id: 2}, {id: 3}],
-        related_destinations: [{id: 4}],
-        refresh: function () {
-          return this;
-        }
-      };
-      instance2 = {
-        related_sources: [{id: 7}, {id: 5}, {id: 6}],
-        related_destinations: [{id: 8}],
-        refresh: function () {
-          return this;
-        }
-      };
-
-      result = method(instance1, instance2);
-
-      result.then(function (res) {
-        expect(res).toEqual([]);
-        done();
+    describe('and cache not empty', function () {
+      beforeAll(function () {
+        spyOn(CMS.Models.Relationship, 'findInCacheById')
+          .and.callFake(function (id) {
+            return {id: id};
+          });
       });
-    });
 
-    it('returns undefined for not related instances, without refresh',
-      function (done) {
+      it('return intersecting Relationships', function (done) {
         var result;
         instance1 = {
           related_sources: [{id: 1}, {id: 2}, {id: 3}],
           related_destinations: [{id: 4}]
         };
         instance2 = {
-          related_sources: [{id: 7}, {id: 5}, {id: 6}],
-          related_destinations: [{id: 8}]
+          related_sources: [{id: 4}, {id: 5}, {id: 6}],
+          related_destinations: [{id: 7}]
         };
 
-        result = method(instance1, instance2, true);
+        result = method(instance1, instance2);
 
         result.then(function (res) {
-          expect(res).toEqual([]);
+          expect(res[0]).toEqual({id: 4});
+          expect(CMS.Models.get_instance.calls.count()).toEqual(0);
           done();
         });
       });
 
-    it('returns intersecting RS after refresh instance', function (done) {
-      var result;
-      instance1 = {
-        related_sources: [{id: 1}, {id: 2}, {id: 3}],
-        related_destinations: [{id: 4}],
-        refresh: function () {
-          return this;
-        }
-      };
-      instance2 = {
-        related_sources: [{id: 7}, {id: 5}, {id: 6}],
-        related_destinations: [{id: 8}],
-        refresh: function () {
-          var self = this;
-          self.related_destinations.push({id: 4});
-          return self;
-        }
-      };
+      it('returns undefined for not related instances', function (done) {
+        var result;
 
-      result = method(instance1, instance2);
+        instance1 = {
+          related_sources: [{id: 1}, {id: 2}, {id: 3}],
+          related_destinations: [{id: 4}],
+          refresh: function () {
+            return this;
+          }
+        };
+        instance2 = {
+          related_sources: [{id: 7}, {id: 5}, {id: 6}],
+          related_destinations: [{id: 8}],
+          refresh: function () {
+            return this;
+          }
+        };
 
-      result.then(function (res) {
-        expect(res[0]).toEqual({id: 4});
-        done();
+        result = method(instance1, instance2);
+
+        result.then(function (res) {
+          expect(res).toEqual([]);
+          expect(CMS.Models.get_instance.calls.count()).toEqual(0);
+          done();
+        });
+      });
+
+      it('returns undefined for not related instances, without refresh',
+        function (done) {
+          var result;
+          instance1 = {
+            related_sources: [{id: 1}, {id: 2}, {id: 3}],
+            related_destinations: [{id: 4}]
+          };
+          instance2 = {
+            related_sources: [{id: 7}, {id: 5}, {id: 6}],
+            related_destinations: [{id: 8}]
+          };
+          result = method(instance1, instance2, true);
+
+          result.then(function (res) {
+            expect(res).toEqual([]);
+            expect(CMS.Models.get_instance.calls.count()).toEqual(0);
+            done();
+          });
+        });
+
+      it('returns intersecting RS after refresh instance', function (done) {
+        var result;
+        instance1 = {
+          related_sources: [{id: 1}, {id: 2}, {id: 3}],
+          related_destinations: [{id: 4}],
+          refresh: function () {
+            return this;
+          }
+        };
+        instance2 = {
+          related_sources: [{id: 7}, {id: 5}, {id: 6}],
+          related_destinations: [{id: 8}],
+          refresh: function () {
+            var self = this;
+            self.related_destinations.push({id: 4});
+            return self;
+          }
+        };
+
+        result = method(instance1, instance2);
+
+        result.then(function (res) {
+          expect(res[0]).toEqual({id: 4});
+          expect(CMS.Models.get_instance.calls.count()).toEqual(0);
+          done();
+        });
+      });
+
+      it('returns all RS for multiple intersection', function (done) {
+        var result;
+        instance1 = {
+          related_sources: [{id: 1}, {id: 2}, {id: 3}],
+          related_destinations: [{id: 4}, {id: 5}]
+        };
+        instance2 = {
+          related_sources: [{id: 4}, {id: 7}, {id: 5}, {id: 6}],
+          related_destinations: [{id: 8}]
+        };
+
+        result = method(instance1, instance2);
+
+        result.then(function (res) {
+          expect(res.length).toEqual(2);
+          expect(console.warn.calls.count()).toEqual(1);
+          expect(CMS.Models.get_instance.calls.count()).toEqual(0);
+          done();
+        });
       });
     });
 
-    it('returns all RS for multiple intersection', function (done) {
-      var result;
-      instance1 = {
-        related_sources: [{id: 1}, {id: 2}, {id: 3}],
-        related_destinations: [{id: 4}, {id: 5}]
-      };
-      instance2 = {
-        related_sources: [{id: 4}, {id: 7}, {id: 5}, {id: 6}],
-        related_destinations: [{id: 8}]
-      };
+    describe('and cache is empty', function () {
+      beforeAll(function () {
+        spyOn(CMS.Models.Relationship, 'findInCacheById')
+          .and.callFake(function (id) {
+            return null;
+          });
+      });
 
-      result = method(instance1, instance2);
+      it('returns RS instance', function (done) {
+        var result;
+        instance1 = {
+          related_sources: [{id: 1}, {id: 2}, {id: 3}],
+          related_destinations: [{id: 4}],
+          refresh: function () {
+            return this;
+          }
+        };
+        instance2 = {
+          related_sources: [{id: 7}, {id: 5}, {id: 6}],
+          related_destinations: [{id: 8}],
+          refresh: function () {
+            var self = this;
+            self.related_destinations.push({id: 4});
+            return self;
+          }
+        };
 
-      result.then(function (res) {
-        expect(res.length).toEqual(2);
-        expect(console.warn.calls.count()).toEqual(1);
-        done();
+        result = method(instance1, instance2);
+
+        result.then(function (res) {
+          expect(CMS.Models.get_instance).toHaveBeenCalled();
+          expect(res[0]).toEqual({id: 4});
+          done();
+        });
       });
     });
   });


### PR DESCRIPTION
**Details:**
Create New Program
Create Audit
Go to Audit page
Map several controls to this Audit
Refresh page
Navigate to Control's Info pane in Audit page
Click 3bbs button and select Unmap button

**Actual result:** nothing happens
**Expected result:** Control should be unmaped from Audit and tree view should be refreshed