### PR TITLE
GGRC-11 Events list doesn't show automapping of newly created/generated assessment to the Audit

### DIFF
--- a/src/ggrc/models/assessment.py
+++ b/src/ggrc/models/assessment.py
@@ -102,7 +102,7 @@ class Assessment(statusable.Statusable, AuditRelationship,
   operationally = deferred(db.Column(db.String), "Assessment")
 
   @declared_attr
-  def object_level_definitions(cls):
+  def object_level_definitions(self):
     """Set up a backref so that we can create an object level custom
        attribute definition without the need to do a flush to get the
        assessment id.
@@ -232,7 +232,7 @@ class Assessment(statusable.Statusable, AuditRelationship,
     return cls._get_relate_filter(predicate, "Verifier")
 
   @classmethod
-  def _ignore_filter(cls, predicate):
+  def _ignore_filter(cls, _):
     return None
 
 

--- a/src/ggrc/models/custom_attribute_definition.py
+++ b/src/ggrc/models/custom_attribute_definition.py
@@ -50,7 +50,10 @@ class CustomAttributeDefinition(mixins.Base, mixins.Titled, db.Model):
   @definition.setter
   def definition(self, value):
     self.definition_id = getattr(value, 'id', None)
-    self.definition_type = getattr(value, 'type', "").lower()
+    if hasattr(value, '_inflector'):
+      self.definition_type = value._inflector.table_singular
+    else:
+      self.definition_type = ''
     return setattr(self, self.definition_attr, value)
 
   _extra_table_args = (

--- a/src/ggrc/models/custom_attribute_definition.py
+++ b/src/ggrc/models/custom_attribute_definition.py
@@ -39,6 +39,20 @@ class CustomAttributeDefinition(mixins.Base, mixins.Titled, db.Model):
   attribute_values = db.relationship('CustomAttributeValue',
                                      backref='custom_attribute')
 
+  @property
+  def definition_attr(self):
+    return '{0}_definition'.format(self.definition_type)
+
+  @property
+  def definition(self):
+    return getattr(self, self.definition_attr)
+
+  @definition.setter
+  def definition(self, value):
+    self.definition_id = getattr(value, 'id', None)
+    self.definition_type = getattr(value, 'type', "").lower()
+    return setattr(self, self.definition_attr, value)
+
   _extra_table_args = (
       UniqueConstraint('definition_type', 'definition_id', 'title',
                        name='uq_custom_attribute'),

--- a/src/ggrc/models/hooks/assessment.py
+++ b/src/ggrc/models/hooks/assessment.py
@@ -238,8 +238,14 @@ def relate_ca(assessment, related):
   )
 
   for definition in ca_definitions:
-    db.make_transient(definition)
-    definition.id = None
-    definition.definition_id = assessment.id
-    definition.definition_type = assessment._inflector.table_singular
-    db.session.add(definition)
+    cad = all_models.CustomAttributeDefinition(
+        title=definition.title,
+        definition=assessment,
+        attribute_type=definition.attribute_type,
+        multi_choice_options=definition.multi_choice_options,
+        multi_choice_mandatory=definition.multi_choice_mandatory,
+        mandatory=definition.mandatory,
+        helptext=definition.helptext,
+        placeholder=definition.placeholder,
+    )
+    db.session.add(cad)

--- a/src/ggrc/models/relationship.py
+++ b/src/ggrc/models/relationship.py
@@ -52,8 +52,8 @@ class Relationship(Mapping, db.Model):
 
   @source.setter
   def source(self, value):
-    self.source_id = value.id if value is not None else None
-    self.source_type = value.__class__.__name__ if value is not None else None
+    self.source_id = getattr(value, 'id', None)
+    self.source_type = getattr(value, 'type', None)
     return setattr(self, self.source_attr, value)
 
   @property
@@ -66,9 +66,8 @@ class Relationship(Mapping, db.Model):
 
   @destination.setter
   def destination(self, value):
-    self.destination_id = value.id if value is not None else None
-    self.destination_type = value.__class__.__name__ if value is not None \
-        else None
+    self.destination_id = getattr(value, 'id', None)
+    self.destination_type = getattr(value, 'type', None)
     return setattr(self, self.destination_attr, value)
 
   @staticmethod


### PR DESCRIPTION
This PR was cherry-picked from develop: https://github.com/google/ggrc-core/pull/4553

Please double and triple check everything so that we don't have to revert it the same way as we had to last time... 
