### PR TITLE
GGRC-147 Fix auto-tab switch when dismissing CA changes

### DIFF
--- a/src/ggrc/assets/javascripts/bootstrap/modal-form.js
+++ b/src/ggrc/assets/javascripts/bootstrap/modal-form.js
@@ -164,6 +164,10 @@
       var hasPending;
       var changedInstance;
 
+      if (e) {
+        e.preventDefault();
+      }
+
       // If the hide was initiated by the backdrop, check for dirty form data before continuing
       if (e && $(e.target).is('.modal-backdrop,.fa-times')) {
         if ($(e.target).is('.disabled')) {


### PR DESCRIPTION
This PR cherry-picks the fix done in #4478 to apply it to the Quince branch. Thanks @Smotko for the hint that this issue has already been fixed in `develop` branch!

**Steps to reproduce:**
- Log as Admin
- Go to Admin Dashboard-> Custom Attributes
- Click on grey triangle on the first tier
- Select GCA and click on Edit icon
- Make changes (e.g. in Attribute title field)
- Click on x button to close-> Discard

**Actual Result:**
Redirecting to People's tab after making changes in CA on Admin Dashboard

**Expected Result:**
Should not be redirecting to People's tab after making changes in CA on Admin Dashboard
