### PR TITLE
GGRC-139 Hide mapper modal if needed on opening People tab

### DIFF
--- a/src/ggrc/assets/javascripts/bootstrap/modal-ajax.js
+++ b/src/ggrc/assets/javascripts/bootstrap/modal-ajax.js
@@ -500,7 +500,7 @@
         function (e) {
 
           var $this = $(this)
-          , toggle_type = $(this).data('toggle')
+          , toggle_type = $(this).data('toggle'), loadHref
           , modal_id, target, $target, option, href, new_target, modal_type;
 
 
@@ -512,6 +512,8 @@
           }
 
           href = $this.attr('data-href') || $this.attr('href');
+          loadHref = !$this.data().noHrefLoad;
+
           modal_id = 'ajax-modal-' + href.replace(/[\/\?=\&#%]/g, '-').replace(/^-/, '');
           target = $this.attr('data-target') || $('#' + modal_id);
 
@@ -531,8 +533,8 @@
 
           if (new_target || $this.data('modal-reset') === 'reset') {
             $target.html(preload_content());
-            if ($this.prop('protocol') === window.location.protocol) {
-              $target.load(href, emit_loaded);
+            if ($this.prop('protocol') === window.location.protocol && loadHref) {
+                  $target.load(href, emit_loaded);
             }
           }
 

--- a/src/ggrc/assets/javascripts/bootstrap/modal-ajax.js
+++ b/src/ggrc/assets/javascripts/bootstrap/modal-ajax.js
@@ -498,11 +498,14 @@
         'click.modal-ajax.data-api keydown.modal-ajax.data-api',
         toggle ? '[data-toggle=modal-ajax-' + toggle + ']' : '[data-toggle=modal-ajax]',
         function (e) {
-
-          var $this = $(this)
-          , toggle_type = $(this).data('toggle'), loadHref
-          , modal_id, target, $target, option, href, new_target, modal_type;
-
+          var $this = $(this);
+          var loadHref;
+          var modalId;
+          var target;
+          var $target;
+          var option;
+          var href;
+          var newTarget;
 
           if ($this.hasClass('disabled')) {
             return;
@@ -514,31 +517,37 @@
           href = $this.attr('data-href') || $this.attr('href');
           loadHref = !$this.data().noHrefLoad;
 
-          modal_id = 'ajax-modal-' + href.replace(/[\/\?=\&#%]/g, '-').replace(/^-/, '');
-          target = $this.attr('data-target') || $('#' + modal_id);
+          modalId = 'ajax-modal-' +
+                     href.replace(/[\/\?=\&#%]/g, '-').replace(/^-/, '');
+          target = $this.attr('data-target') || $('#' + modalId);
 
           $target = $(target);
-          new_target = $target.length === 0;
+          newTarget = $target.length === 0;
 
-          if (new_target) {
-            $target = $('<div id="' + modal_id + '" class="modal hide"></div>');
+          if (newTarget) {
+            $target = $('<div id="' + modalId + '" class="modal hide"></div>');
             $target.addClass($this.attr('data-modal-class'));
-            $this.attr('data-target', '#' + modal_id);
+            $this.attr('data-target', '#' + modalId);
           }
 
           $target.on('hidden', function (ev) {
-            if (ev.target === ev.currentTarget)
+            if (ev.target === ev.currentTarget) {
               $target.remove();
+            }
           });
 
-          if (new_target || $this.data('modal-reset') === 'reset') {
+          if (newTarget || $this.data('modal-reset') === 'reset') {
             $target.html(preload_content());
-            if ($this.prop('protocol') === window.location.protocol && loadHref) {
-                  $target.load(href, emit_loaded);
+            if (
+              $this.prop('protocol') === window.location.protocol &&
+              loadHref
+            ) {
+              $target.load(href, emit_loaded);
             }
           }
 
-          option = $target.data('modal-help') ? 'toggle' : $.extend({}, $target.data(), $this.data());
+          option = $target.data('modal-help') ?
+                   'toggle' : $.extend({}, $target.data(), $this.data());
 
           launch_fn.apply($target, [$target, $this, option]);
         });

--- a/src/ggrc/assets/mustache/dashboard/internav_list.mustache
+++ b/src/ggrc/assets/mustache/dashboard/internav_list.mustache
@@ -49,23 +49,60 @@
           or #if' force_show '\
           or #if' instance.constructor.obj_nav_options.show_all_tabs '\
           or #in_array' internav_display instance.constructor.obj_nav_options.force_show_list}}
-        <a
-          href="{{ selector }}"
-          {{#is_mappable_type instance.type model.shortName}}
-          {{#is_allowed_to_map instance model.shortName}}
-            data-clickable="true"
-            data-toggle="unified-mapper"
-            data-join-option-type="{{model.shortName}}"
-            data-join-object-id="{{instance.id}}"
-            data-join-object-type="{{instance.class.shortName}}"
-          {{/is_allowed_to_map}}
-          {{/is_mappable_type}}
-        >
-          <div class="oneline">
-            <i class="fa fa-{{ internav_icon }} color"></i>
-            {{internav_display}}
-          </div>
-        </a>
+
+          {{#if_helpers '\
+            #if_page_type' 'programs' '\
+            and #if_equals' model.shortName 'Audit'}}
+            <a
+              href="{{selector}}"
+              rel="tooltip"
+              data-placement="left"
+              data-original-title="Create {{model.title_singular}}"
+              data-toggle="modal-ajax-form"
+              data-modal-reset="reset"
+              data-no-href-load="true"
+              data-modal-class="modal-wide"
+              data-object-singular="{{model.title_singular}}"
+              data-object-plural="{{model.table_plural}}"
+              data-object-params='{
+                  "{{instance.class.table_singular}}": {
+                      "id": {{instance.id}},
+                      "title": "{{instance.title}}"
+                  },
+                  "context": {
+                      "id": {{firstnonempty instance.context.id "null"}},
+                      "href": "{{instance.context.href}}",
+                      "type": "{{instance.context.type}}"
+                  }
+              }'
+            >
+              <div class="oneline">
+                <i class="fa fa-{{ internav_icon }} color"></i>
+                {{internav_display}}
+              </div>
+            </a>
+          {{else}}
+            <a
+              href="{{ selector }}"
+              {{^is_dashboard_or_all}}
+              {{#is_mappable_type instance.type model.shortName}}
+              {{#is_allowed_to_map instance model.shortName}}
+                data-clickable="true"
+                data-toggle="unified-mapper"
+                data-join-option-type="{{model.shortName}}"
+                data-join-object-id="{{instance.id}}"
+                data-join-object-type="{{instance.class.shortName}}"
+              {{/is_allowed_to_map}}
+              {{/is_mappable_type}}
+              {{/is_dashboard_or_all}}
+            >
+              <div class="oneline">
+                <i class="fa fa-{{ internav_icon }} color"></i>
+                {{internav_display}}
+              </div>
+            </a>
+          {{/if_helpers}}
+
         {{/if_helpers}}
       </div>
     {{/widget_list}}

--- a/src/ggrc/assets/mustache/dashboard/internav_list.mustache
+++ b/src/ggrc/assets/mustache/dashboard/internav_list.mustache
@@ -52,11 +52,13 @@
         <a
           href="{{ selector }}"
           {{#is_mappable_type instance.type model.shortName}}
+          {{#is_allowed_to_map instance model.shortName}}
             data-clickable="true"
             data-toggle="unified-mapper"
             data-join-option-type="{{model.shortName}}"
             data-join-object-id="{{instance.id}}"
             data-join-object-type="{{instance.class.shortName}}"
+          {{/is_allowed_to_map}}
           {{/is_mappable_type}}
         >
           <div class="oneline">


### PR DESCRIPTION
_(I do not have access to Jira yet, thus don't know the exact ticket number... but it's 1.506 in the old bug list document, P2)_

This PR is the same as  #4586, just opened against a correct branch. It fixes unwanted mapper modal being displayed when opening new tabs, even when the target object type is not allowed to be mapped to the current page instance(meaning, among other things, that there is also no `(+)` button in the corresponding tree view's header).

It also fixes a related issue, i.e. the 1st issue @Smotko mentioned in his [comment](https://github.com/google/ggrc-core/pull/4586#issuecomment-256341257). Now, when clicking Add... Audits in LHN on Program page, the Add Audit modal is automatically displayed.

(BTW, the `GGRC.register_modal_hook()` method had to be linted for the build to pass, since the changes required for the fix introduced additional ESLint issues)

**Steps to reproduce (the main issue):**
- Go to Assessment’s Info page
- Click +Add widget-> People

**Actual Result:**
Unified mapper is automatically displayed while adding People's widget in Assessment's Info page

**Expected Result:**
Unified mapper should not displayed while adding People's widget in Assessment's Info page
---
