### PR TITLE
GGRC-65 Styling for snapshot info pane

### DIFF
--- a/src/ggrc/assets/mustache/base_objects/general_info.mustache
+++ b/src/ggrc/assets/mustache/base_objects/general_info.mustache
@@ -5,7 +5,7 @@
 
 {{! transcluded via renderLive in, for example, assets/mustache/sections/tier2_content.mustache }}
 {{#instance}}
-  <div class="pane-header">
+  <div class="pane-header {{#if snapshot}}snapshot{{/if}}" >
     <div class="row-fluid wrap-row">
       <div data-test-id="title_0ad9fbaf" class="span9">
         <h6>Title</h6>
@@ -19,6 +19,14 @@
         </p>
         {{/if}}
       </div>
+      {{#if snapshot}}
+        <div class="span12 snapshot">
+          <hr class="snapshot">
+          <p>
+            A more current version of this {{instance.class.title_singular}} is available. Do you want to <a href="#">update</a>?
+          </p>
+        </div>
+      {{/if}}
     </div>
   </div>
   <div data-test-id="title_review_0ad9fbaf" class="row-fluid wrap-row">

--- a/src/ggrc/assets/stylesheets/_colors.scss
+++ b/src/ggrc/assets/stylesheets/_colors.scss
@@ -149,3 +149,7 @@ $bar-base: #fff;
 $bar-success: #d1fcb5;
 $bar-danger: #ffffbe;
 $bar-warning: #ffcebe;
+
+// snapshots
+$snapshotBgnd: #ddf3fd;
+$shapshotBorder: #d9e6ec;

--- a/src/ggrc/assets/stylesheets/_modules.scss
+++ b/src/ggrc/assets/stylesheets/_modules.scss
@@ -44,3 +44,4 @@
 @import "modules/sortable";
 @import "modules/rich-text";
 @import "modules/page-loader";
+@import "modules/snapshot";

--- a/src/ggrc/assets/stylesheets/modules/_snapshot.scss
+++ b/src/ggrc/assets/stylesheets/modules/_snapshot.scss
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2016 Google Inc.
+ * Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+// Common styles
+
+.pane-header.snapshot {
+  background: $snapshotBgnd;
+}
+
+.span12.snapshot {
+  margin-left: 0;
+}
+
+hr.snapshot {
+  display: block;
+  height: 1px;
+  border: 0;
+  border-top: 1px solid $shapshotBorder;
+  margin: 1em 0;
+  padding: 0;
+}
+
+// Info pane
+.sticky-info-panel {
+  .pane-header.snapshot {
+    margin-left: -25px;
+    margin-right: -25px;
+    padding-left: 25px;
+    padding-right: 25px;
+  }
+}
+
+// Info widget
+
+.widget {
+  .pane-header.snapshot {
+    margin-top: -25px;
+    margin-bottom: 20px;
+    padding-bottom: 5px;
+    margin-left: -30px;
+    margin-right: -30px;
+    padding-left: 30px;
+    padding-right: 30px;
+  }
+}


### PR DESCRIPTION
Implemented according to mockups.
It will not be visible until backend (FEATURE/SNAPSHOT) merged.

<img width="1440" alt="screen shot 2016-10-28 at 11 24 54" src="https://cloud.githubusercontent.com/assets/674129/19799999/4784931e-9d02-11e6-8d5f-97352bcaedf3.png">
<img width="1440" alt="screen shot 2016-10-28 at 11 25 08" src="https://cloud.githubusercontent.com/assets/674129/19800000/48e2cbb8-9d02-11e6-85a6-b26bb060b88d.png">
