### PR TITLE
GGRC-128 Add audit lead as assessor for new assessment

### DIFF
--- a/src/ggrc/assets/javascripts/models/assessment.js
+++ b/src/ggrc/assets/javascripts/models/assessment.js
@@ -272,6 +272,7 @@
       var pageInstance = GGRC.page_instance();
       var currentUser = CMS.Models.get_instance('Person',
         GGRC.current_user.id, GGRC.current_user);
+      var auditLead;
 
       if (!newObjectForm) {
         return;
@@ -280,6 +281,18 @@
       if (pageInstance && pageInstance.type === 'Audit' && !this.audit) {
         this.attr('audit', pageInstance);
       }
+
+      if (this.audit) {
+        auditLead = this.audit.contact.reify();
+        // Assign Assessor role
+        this.mark_for_addition('related_objects_as_destination', auditLead, {
+          attrs: {
+            AssigneeType: 'Assessor'
+          }
+        });
+      }
+
+      // Assign Creator role
       this.mark_for_addition('related_objects_as_destination', currentUser, {
         attrs: {
           AssigneeType: 'Creator'


### PR DESCRIPTION
Assessment: Asssesor/Assginee field needs to be autopopulated with Audit Lead value from the audit. This is for assessment without a template.
