### PR TITLE
GGRC-114 Fix invalid counts for History and Active Cycles tabs on Workflow page

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
@@ -723,16 +723,17 @@ CMS.Controllers.TreeLoader('CMS.Controllers.TreeView', {
     var self = this;
     var options = this.options;
     var counts;
+    var countsName = options.counts_name || options.model.shortName;
 
     if (this.options.parent_instance && this.options.mapping) {
       counts = GGRC.Utils.QueryAPI.getCounts();
 
       if (self.element) {
         can.trigger(self.element, 'updateCount',
-          [counts.attr(options.model.shortName), self.options.update_count]);
+          [counts.attr(countsName), self.options.update_count]);
       }
 
-      counts.on(options.model.shortName, function (ev, newVal, oldVal) {
+      counts.on(countsName, function (ev, newVal, oldVal) {
         can.trigger(self.element, 'updateCount',
           [newVal, self.options.update_count]);
       });

--- a/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
+++ b/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
@@ -541,22 +541,29 @@
     }
 
     function initCounts(widgets, relevant) {
-      var params = [];
-      var param;
-      var i = 0;
-      var iLen = widgets ? widgets.length : 0;
-      for (; i < iLen; i++) {
-        param = buildParam(widgets[i], {},
-          makeExpression(widgets[i], relevant.type, relevant.id));
+      var params = (widgets ? Array.from(widgets) : []).map(function (widget) {
+        var param;
+        if (typeof widget === 'string') {
+          param = buildParam(widget, {},
+                    makeExpression(widget, relevant.type, relevant.id));
+        } else {
+          param = buildParam(widget.name, {},
+                    makeExpression(widget.name, relevant.type, relevant.id),
+                    null, widget.additionalFilter);
+        }
         param.type = 'count';
-        params.push(param);
-      }
+        return param;
+      });
+
       return makeRequest({
         data: params
       }).then(function (data) {
-        _.each(data, function (info, i) {
-          var name = widgets[i];
-          widgetsCounts.attr(name, info[name].total);
+        data.forEach(function (info, i) {
+          var widget = widgets[i];
+          var name = typeof widget === 'string' ? widget : widget.name;
+          var countsName = typeof widget === 'string' ?
+            widget : (widget.countsName || widget.name);
+          widgetsCounts.attr(countsName, info[name].total);
         });
       });
     }

--- a/src/ggrc_workflows/assets/javascripts/apps/workflows.js
+++ b/src/ggrc_workflows/assets/javascripts/apps/workflows.js
@@ -581,6 +581,7 @@
         draw_children: true,
         parent_instance: object,
         model: 'Cycle',
+        counts_name: 'cycles:history',
         mapping: 'previous_cycles',
         additional_filter: {
           expression: {
@@ -603,6 +604,7 @@
         draw_children: true,
         parent_instance: object,
         model: 'Cycle',
+        counts_name: 'cycles:active',
         mapping: 'current_cycle',
         additional_filter: {
           expression: {
@@ -622,7 +624,24 @@
     newWidgetDescriptors.current = currentWidgetDescriptor;
 
     GGRC.Utils.QueryAPI
-      .initCounts(['Cycle', 'Person', 'TaskGroup'], {
+      .initCounts([
+        {
+          name: 'Cycle',
+          countsName:
+            historyWidgetDescriptor.content_controller_options.counts_name,
+          additionalFilter:
+            historyWidgetDescriptor.content_controller_options.additional_filter
+        },
+        {
+          name: 'Cycle',
+          countsName:
+            currentWidgetDescriptor.content_controller_options.counts_name,
+          additionalFilter:
+            currentWidgetDescriptor.content_controller_options.additional_filter
+        },
+        'Person',
+        'TaskGroup'
+      ], {
         type: object.type,
         id: object.id
       });


### PR DESCRIPTION
Counts for History and Active Cycles tabs should differ, but they are based on the same object name.
This PR adds an ability to specify additional data (custom name for counts map, additional filter) for initCounts function.
It is still possible to use this function in the "old way" passing object names in array.
