### PR TITLE
GGRC-205 Fix filter after incorrect query

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
@@ -1520,6 +1520,7 @@ CMS.Controllers.TreeLoader('CMS.Controllers.TreeView', {
         this.options.attr('paging.disabled', false);
       }.bind(this))
       .fail(function () {
+        this.options.attr('paging.disabled', false);
         this.options.attr('original_list', []);
         this.element.children('.cms_controllers_tree_view_node').remove();
         this._loading_finished();


### PR DESCRIPTION
**Details:**
1. Open Section tab at Dashboard page
2. Filter by CA field w/datetime type with incorrect value (like example ca_date>01/01/0001)
3. Click Reset filter or apply new filter

_Actual Result_: app shows empty list
_Expected result_: app should reset filter and display actual list of entities
_Workaround_: reload page