### PR TITLE
GGRC-144 Fix updating an AssessmentTemplate with CAs

### DIFF
--- a/src/ggrc/models/mixins/customattributable.py
+++ b/src/ggrc/models/mixins/customattributable.py
@@ -229,7 +229,7 @@ class CustomAttributable(object):
     custom attribute definitions in the order provided.
 
     Args:
-      definitions: Ordered list of custom attribute definitions
+      definitions: Ordered list of (dict) custom attribute definitions
     """
     from ggrc.models.custom_attribute_definition \
         import CustomAttributeDefinition as CADef
@@ -247,6 +247,8 @@ class CustomAttributable(object):
     for definition in definitions:
       if "_pending_delete" in definition and definition["_pending_delete"]:
         continue
+
+      definition['context'] = getattr(self, "context", None)
       self.insert_definition(definition)
 
   def custom_attributes(self, src):


### PR DESCRIPTION
_(don't know the Jira issue number, sorry)_

This PR fixes editing AssessmentTemplates with custom attribute definitions that have an RBAC context. It assures that the context is not just a plain `dict`, but instead a full `Context` instance, preventing the ORM machinery from complaining.

BTW, if you wonder why this has not been handled by the JSON builder - the builder only de-serializes top-level attributes of our ORM models, thus e.g. `Audit.context` does get de-serialized to a `Context` instance. With AssessmentTemplates, however, the `context` is an attribute of elements in the `AssessmentTemplate.custom_attribute_defintiions` list, and the builder can't really know that it needs to de-serialize a specific "deep" attribute.

---

**Details:**
- Open Audit 1422
- Open Assessment Templates tab
- Open editing modal for Assessment Template 18
- Not changing anything, press Save and close

**Actual Result:**
HTTP 500 is returned from the backend, the CADs in the Assessment Template are removed

**Expected Result:**
Assessment Template should be saved without any changes.
Note: Currently the bug was reproduced only on Assessment Template 18

**IMPORTANT:**
If you don't have that object in your local database, use a grc-dev DB dump from e.g. 2016-08-16. Also, once you reproduce the issue, all AssessmentTemplate's custom attribute definitions will be wiped out, making the bug unreproducible. You thus need to assure to have a correct DB state when testing.

You can, however, reproduce the issue multiple times if yo DON'T refresh the page after an error, but simply close and re-open the AssessmentTemplate edit modal.