### PR TITLE
Fix document and URL exports

### DIFF
--- a/src/ggrc/converters/handlers/document.py
+++ b/src/ggrc/converters/handlers/document.py
@@ -82,8 +82,8 @@ class DocumentEvidenceHandler(DocumentLinkHandler):
     Returns:
       string containing all evidence URLs and titles.
     """
-    return "\n".join(
-        "{} {}".format(document.link, document.title)
+    return u"\n".join(
+        u"{} {}".format(document.link, document.title)
         for document in self.row_converter.obj.documents
     )
 

--- a/src/ggrc/converters/handlers/handlers.py
+++ b/src/ggrc/converters/handlers/handlers.py
@@ -737,9 +737,9 @@ class RequestColumnHandler(ParentColumnHandler):
 class DocumentsColumnHandler(ColumnHandler):
 
   def get_value(self):
-    lines = ["{} {}".format(d.title, d.link)
+    lines = [u"{} {}".format(d.title, d.link)
              for d in self.row_converter.obj.documents]
-    return "\n".join(lines)
+    return u"\n".join(lines)
 
   def parse_item(self):
     lines = [line.rsplit(" ", 1) for line in self.raw_value.splitlines()]

--- a/test/integration/ggrc/converters/test_csvs/request_full_no_warnings.csv
+++ b/test/integration/ggrc/converters/test_csvs/request_full_no_warnings.csv
@@ -4,7 +4,7 @@ Request,Code*,Audit*,Title*,Description,Notes,Status*,Assignee*,Requester*,Verif
 user2@a.com","user2@a.com
 user3@a.com","user3@a.com
 user4@a.com
-user5@a.com",docuMEntation,7/1/2015,5/11/2016,Test text 1,"Verifier, Requester",Yes,http://i.imgur.com/Lppr247.jpg,"http://i.imgur.com/Lppr247.jpg evidence title 1
+user5@a.com",docuMEntation,7/1/2015,5/11/2016,Test text 1,"Verifier, Requester",Yes,http://i.imgur.com/Lppr247.jpg,"http://i.imgur.com/Lppr247.jpg evidence 啕 title 1
 http://i.imgur.com/qA0l5tb.gifv some title 2","proj-1
 proj-2
 proj-3",mkt-1


### PR DESCRIPTION
Exports should support unicode characters for all fields.