### PR TITLE
GGRC-211 Fix customattributable date setter

### DIFF
--- a/src/ggrc/models/custom_attribute_value.py
+++ b/src/ggrc/models/custom_attribute_value.py
@@ -52,6 +52,7 @@ class CustomAttributeValue(Base, db.Model):
   # This is just a mapping for accessing local functions so protected access
   # warning is a false positive
   _validator_map = {
+      "Date": lambda self: self._validate_date(),
       "Dropdown": lambda self: self._validate_dropdown(),
       "Map:Person": lambda self: self._validate_map_person(),
   }
@@ -254,6 +255,20 @@ class CustomAttributeValue(Base, db.Model):
         raise ValueError("Invalid custom attribute dropdown option: {v}, "
                          "expected one of {l}"
                          .format(v=self.attribute_value, l=valid_options))
+
+  def _validate_date(self):
+    """Convert date format."""
+    from ggrc.models.custom_attribute_definition import (
+        CustomAttributeDefinition)
+    if (self.custom_attribute.attribute_type ==
+            CustomAttributeDefinition.ValidTypes.DATE):
+      # convert the date formats for dates
+      if self.attribute_value:
+        self.attribute_value = utils.convert_date_format(
+            self.attribute_value,
+            CustomAttributeValue.DATE_FORMAT_JSON,
+            CustomAttributeValue.DATE_FORMAT_DB,
+        )
 
   def validate(self):
     """Validate custom attribute value."""

--- a/src/ggrc/models/mixins/customattributable.py
+++ b/src/ggrc/models/mixins/customattributable.py
@@ -162,8 +162,6 @@ class CustomAttributable(object):
     Args:
       values: List of dictionaries that represent custom attribute values.
     """
-    from ggrc.models.custom_attribute_definition import (
-        CustomAttributeDefinition)
     from ggrc.models.custom_attribute_value import CustomAttributeValue
 
     for value in values:
@@ -173,15 +171,6 @@ class CustomAttributable(object):
         value["attribute_object_id"] = (value["attribute_object"].get("id") if
                                         value.get("attribute_object") else
                                         None)
-      if (self._definitions_map[value["custom_attribute_id"]]
-              .attribute_type == CustomAttributeDefinition.ValidTypes.DATE):
-        # convert the date formats for dates
-        if value.get("attribute_value"):
-          value["attribute_value"] = utils.convert_date_format(
-              value["attribute_value"],
-              CustomAttributeValue.DATE_FORMAT_JSON,
-              CustomAttributeValue.DATE_FORMAT_DB,
-          )
 
       attr = self._values_map.get(value.get("custom_attribute_id"))
       if attr:

--- a/src/ggrc/models/mixins/customattributable.py
+++ b/src/ggrc/models/mixins/customattributable.py
@@ -328,7 +328,9 @@ class CustomAttributable(object):
       #    of the custom attributable.
       # TODO: We are ignoring contexts for now
       # new_value.context_id = cls.context_id
-      self.custom_attribute_values.append(new_value)
+
+      # new value is appended to self.custom_attribute_values by the ORM
+      # self.custom_attribute_values.append(new_value)
       if ad_id in last_values:
         _, previous_value = last_values[ad_id]
         if previous_value != attributes[ad_id]:

--- a/src/ggrc/models/mixins/customattributable.py
+++ b/src/ggrc/models/mixins/customattributable.py
@@ -173,21 +173,20 @@ class CustomAttributable(object):
         value["attribute_object_id"] = (value["attribute_object"].get("id") if
                                         value.get("attribute_object") else
                                         None)
+      if (self._definitions_map[value["custom_attribute_id"]]
+              .attribute_type == CustomAttributeDefinition.ValidTypes.DATE):
+        # convert the date formats for dates
+        if value.get("attribute_value"):
+          value["attribute_value"] = utils.convert_date_format(
+              value["attribute_value"],
+              CustomAttributeValue.DATE_FORMAT_JSON,
+              CustomAttributeValue.DATE_FORMAT_DB,
+          )
+
       attr = self._values_map.get(value.get("custom_attribute_id"))
       if attr:
-        attribute_value = value.get("attribute_value")
-        if (self._definitions_map[value["custom_attribute_id"]]
-                .attribute_type == CustomAttributeDefinition.ValidTypes.DATE):
-          # convert the date formats for dates
-          if attribute_value:
-            attribute_value = utils.convert_date_format(
-                attribute_value,
-                CustomAttributeValue.DATE_FORMAT_JSON,
-                CustomAttributeValue.DATE_FORMAT_DB,
-            )
-
         attr.attributable = self
-        attr.attribute_value = attribute_value
+        attr.attribute_value = value.get("attribute_value")
         attr.attribute_object_id = value.get("attribute_object_id")
       elif "custom_attribute_id" in value:
         # this is automatically appended to self._custom_attribute_values


### PR DESCRIPTION
If the CAV is being created in CustomAttributable (no value was ever stored for the CAD for the object), no date formatting is applied and the date is stored into the DB in invalid format (MM/DD/YYYY instead of YYYY-MM-DD) and becomes unsearchable with the filter. If the value is changed (or removed and then filled again), the date is formatted correctly and is searchable.

Steps to reproduce:
1. Create an Assessment (I'm assuming Assessments have at least one global CAD of type Date).
2. Fill in the Date CA for this Assessment.
3. Try to search for this Assessment with Filter by the Date CA (e.g. `"My Date CA" = 11/01/2016` if you set it to 11/01/2016).

Expected result: the Assessment is shown in the result set.
Actual result: the Assessment is not shown in the result set.

This PR moves the date conversion logic to a common place before updating and creation of CAV objects in `CustomAttributable.custom_attribute_values.setter`.