### PR TITLE
GGRC-35 HTML sanitation for custom attributes

### DIFF
--- a/src/ggrc/models/custom_attribute_definition.py
+++ b/src/ggrc/models/custom_attribute_definition.py
@@ -55,6 +55,12 @@ class CustomAttributeDefinition(mixins.Base, mixins.Titled, db.Model):
       'placeholder',
   ]
 
+  _sanitize_html = [
+      "multi_choice_options",
+      "helptext",
+      "placeholder",
+  ]
+
   _reserved_names = {}
 
   def _clone(self, target):

--- a/src/ggrc/models/custom_attribute_value.py
+++ b/src/ggrc/models/custom_attribute_value.py
@@ -34,6 +34,10 @@ class CustomAttributeValue(Base, db.Model):
   ]
   _fulltext_attrs = ["attribute_value"]
 
+  _sanitize_html = [
+      "attribute_value",
+  ]
+
   custom_attribute_id = db.Column(
       db.Integer,
       db.ForeignKey('custom_attribute_definitions.id', ondelete="CASCADE")

--- a/src/ggrc/utils/html_cleaner.py
+++ b/src/ggrc/utils/html_cleaner.py
@@ -43,6 +43,9 @@ def cleaner(dummy, value, *_):
   #  and it's nullable, so check for that
   if value is None:
     return value
+  if not isinstance(value, basestring):
+    # no point in sanitizing non-strings
+    return value
 
   parser = HTMLParser()
   value = unicode(value)


### PR DESCRIPTION
This PR adds the following fields for HTML sanitation:
1. CAD - Dropdown options (Assessment Templates and global CAs)
2. CAD - Inline Help (global CAs)
3. CAD - Placeholder (global CAs)
4. CAV - Attribute value (local and global CAs for every type of CAD)

Item 4 could have narrower scope (only values for Text and Rich Text custom attributes), because values with dangerous HTML tags are disallowed for dates and checkboxes and will be disallowed in scope of item 1 for dropdowns. However, I picked a wider scope and chose to sanitize values for every type of definition to be safe if definition types are extended or something changes in non-text CA logic.