### PR TITLE
GGRC-137 Hide unmap button from People tab of Audit page

### DIFF
--- a/src/ggrc/assets/stylesheets/modules/_object-header.scss
+++ b/src/ggrc/assets/stylesheets/modules/_object-header.scss
@@ -169,6 +169,11 @@
         padding-top: 5px;
         margin-top: 5px;
       }
+      &.border-bottom {
+        border-bottom: 1px solid $headerBgnd;
+        padding-bottom: 5px;
+        margin-bottom: 5px;
+      }
     }
   }
   &.status-wrap {

--- a/src/ggrc_basic_permissions/assets/mustache/ggrc_basic_permissions/people_roles/info.mustache
+++ b/src/ggrc_basic_permissions/assets/mustache/ggrc_basic_permissions/people_roles/info.mustache
@@ -34,21 +34,23 @@
         {{/options.mapped_and_or_authorized_people}}
         {{/is_info_pin}}
         {{/is_allowed}}
-        <li>
+        <li class="border-bottom">
           <clipboard-link title="Get permalink" notify="true" text="{{get_permalink_for_object instance}}" />
         </li>
-        {{#with_program_roles_as "roles" result}}
-          {{#if result.mappings}}
-            {{#is_allowed_all 'delete' result.mappings}}
-              <li class="border">
-                <a href="javascript://" class="unmap" data-toggle="unmap">
-                  {{#result}}<span class="result" {{data 'result'}}></span>{{/result}}
-                  <i class="fa fa-ban"></i>
-                  Unmap
-                </a>
-              </li>
-            {{/is_allowed_all}}
-          {{/result.mappings}}
+        {{^if_instance_of options.parent_instance 'Audit'}}
+          {{#with_program_roles_as "roles" result}}
+            {{#if result.mappings}}
+              {{#is_allowed_all 'delete' result.mappings}}
+                <li>
+                  <a href="javascript://" class="unmap" data-toggle="unmap">
+                    {{#result}}<span class="result" {{data 'result'}}></span>{{/result}}
+                    <i class="fa fa-ban"></i>
+                    Unmap
+                  </a>
+                </li>
+              {{/is_allowed_all}}
+            {{/if}}
+          {{/if_instance_of}}
         {{/with_program_roles_as}}
         <li>
           <a href="/people/{{instance.id}}">


### PR DESCRIPTION
**Subject:** Unmap button is available for unmapping a person in People’s tab of Audit page that was added at Program page
**Details:** 

- Create a program
- Go to People’ s tab
- Map a person to the program with Program Reader role
- Create an audit
- Go to Audit page -> People’s tab
- Navigate to the first tree veiw of the added person 
- Click on 3 bb’s button in Person’s Info pane

**Select Unmap:** Unmap button is available for unmapping
**Actual Result:** Unmap button is available for unmapping a person in People’s tab of Audit page that was added at Program page
**Expected Result:** There is the possibility to unmap the person only in Program page. In this case unmap button should not exist.
**Workaround:** NA
