### PR TITLE
GGRC-136 Update 3bbs menu items for snapshot panel

### DIFF
--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -288,6 +288,7 @@ dashboard-js-template-files:
   - base_objects/states.mustache
   - base_objects/form_restore.mustache
   - base_objects/info-pin.mustache
+  - base_objects/info-pane-utility.mustache
   - base_objects/info_header.mustache
   - base_objects/filters/advanced_search_filter_actions.mustache
   - base_objects/filters/modal_filter_actions.mustache
@@ -532,6 +533,7 @@ dashboard-js-template-files:
   - import_export/export/filter_query.mustache
   - mapper/relevant_filter.mustache
   - quick_form/confirm_buttons.mustache
+  - snapshots/dropdown_menu.mustache
 
 dashboard-css-files:
   - dashboard.css

--- a/src/ggrc/assets/mustache/assessment_templates/info.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/info.mustache
@@ -10,9 +10,7 @@
       {{{render '/static/mustache/base_objects/info-pin.mustache'}}}
     {{/is_info_pin}}
 
-    <div class="info-pane-utility">
-      {{> /static/mustache/base_objects/dropdown_menu.mustache}}
-    </div>
+    {{> /static/mustache/base_objects/info-pane-utility.mustache}}
 
     <div class="tier-content">
 

--- a/src/ggrc/assets/mustache/audits/info.mustache
+++ b/src/ggrc/assets/mustache/audits/info.mustache
@@ -10,9 +10,7 @@
       {{{render '/static/mustache/base_objects/info-pin.mustache'}}}
     {{/is_info_pin}}
 
-    <div class="info-pane-utility">
-      {{> /static/mustache/base_objects/dropdown_menu.mustache}}
-    </div>
+    {{> /static/mustache/base_objects/info-pane-utility.mustache}}
 
     <div class="tier-content">
       <div class="pane-header">

--- a/src/ggrc/assets/mustache/base_objects/info-pane-utility.mustache
+++ b/src/ggrc/assets/mustache/base_objects/info-pane-utility.mustache
@@ -1,0 +1,12 @@
+{{!
+    Copyright (C) 2016 Google Inc.
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+}}
+
+<div class="info-pane-utility">
+    {{#if instance.snapshot}}
+        {{> /static/mustache/snapshots/dropdown_menu.mustache}}
+    {{else}}
+        {{> /static/mustache/base_objects/dropdown_menu.mustache}}
+    {{/if}}
+</div>

--- a/src/ggrc/assets/mustache/base_objects/info.mustache
+++ b/src/ggrc/assets/mustache/base_objects/info.mustache
@@ -10,9 +10,7 @@
       {{{render '/static/mustache/base_objects/info-pin.mustache'}}}
     {{/is_info_pin}}
 
-    <div class="info-pane-utility">
-      {{> /static/mustache/base_objects/dropdown_menu.mustache}}
-    </div>
+    {{> /static/mustache/base_objects/info-pane-utility.mustache}}
 
     <div class="tier-content">
       {{{render '/static/mustache/base_objects/general_info.mustache' instance=instance}}}

--- a/src/ggrc/assets/mustache/controls/info.mustache
+++ b/src/ggrc/assets/mustache/controls/info.mustache
@@ -10,9 +10,7 @@
       {{{render '/static/mustache/base_objects/info-pin.mustache'}}}
     {{/is_info_pin}}
 
-    <div class="info-pane-utility">
-      {{> /static/mustache/base_objects/dropdown_menu.mustache}}
-    </div>
+    {{> /static/mustache/base_objects/info-pane-utility.mustache}}
 
     <div class="tier-content">
       {{{render '/static/mustache/base_objects/general_info.mustache' instance=instance}}}

--- a/src/ggrc/assets/mustache/issues/info.mustache
+++ b/src/ggrc/assets/mustache/issues/info.mustache
@@ -10,9 +10,7 @@
       {{{render '/static/mustache/base_objects/info-pin.mustache'}}}
     {{/is_info_pin}}
 
-    <div class="info-pane-utility">
-      {{> /static/mustache/base_objects/dropdown_menu.mustache}}
-    </div>
+    {{> /static/mustache/base_objects/info-pane-utility.mustache}}
 
     <div class="tier-content">
       {{{render '/static/mustache/base_objects/general_info.mustache' instance=instance}}}

--- a/src/ggrc/assets/mustache/objectives/info.mustache
+++ b/src/ggrc/assets/mustache/objectives/info.mustache
@@ -10,9 +10,7 @@
       {{{render '/static/mustache/base_objects/info-pin.mustache'}}}
     {{/is_info_pin}}
 
-    <div class="info-pane-utility">
-      {{> /static/mustache/base_objects/dropdown_menu.mustache}}
-    </div>
+    {{> /static/mustache/base_objects/info-pane-utility.mustache}}
 
     <div class="tier-content">
       {{{render '/static/mustache/base_objects/general_info.mustache' instance=instance}}}

--- a/src/ggrc/assets/mustache/policies/info.mustache
+++ b/src/ggrc/assets/mustache/policies/info.mustache
@@ -10,9 +10,7 @@
       {{{render '/static/mustache/base_objects/info-pin.mustache'}}}
     {{/is_info_pin}}
 
-    <div class="info-pane-utility">
-      {{> /static/mustache/base_objects/dropdown_menu.mustache}}
-    </div>
+    {{> /static/mustache/base_objects/info-pane-utility.mustache}}
 
     <div class="tier-content">
       {{{render '/static/mustache/base_objects/general_info.mustache' instance=instance}}}

--- a/src/ggrc/assets/mustache/processes/info.mustache
+++ b/src/ggrc/assets/mustache/processes/info.mustache
@@ -10,9 +10,7 @@
       {{{render '/static/mustache/base_objects/info-pin.mustache'}}}
     {{/is_info_pin}}
 
-    <div class="info-pane-utility">
-      {{> /static/mustache/base_objects/dropdown_menu.mustache}}
-    </div>
+    {{> /static/mustache/base_objects/info-pane-utility.mustache}}
 
     <div class="tier-content">
       {{{render '/static/mustache/base_objects/general_info.mustache' instance=instance}}}

--- a/src/ggrc/assets/mustache/products/info.mustache
+++ b/src/ggrc/assets/mustache/products/info.mustache
@@ -10,9 +10,7 @@
       {{{render '/static/mustache/base_objects/info-pin.mustache'}}}
     {{/is_info_pin}}
 
-    <div class="info-pane-utility">
-      {{> /static/mustache/base_objects/dropdown_menu.mustache}}
-    </div>
+    {{> /static/mustache/base_objects/info-pane-utility.mustache}}
 
     <div class="tier-content">
       {{{render '/static/mustache/base_objects/general_info.mustache' instance=instance}}}

--- a/src/ggrc/assets/mustache/programs/info.mustache
+++ b/src/ggrc/assets/mustache/programs/info.mustache
@@ -10,9 +10,7 @@
       {{{render '/static/mustache/base_objects/info-pin.mustache'}}}
     {{/is_info_pin}}
 
-    <div class="info-pane-utility">
-      {{> /static/mustache/base_objects/dropdown_menu.mustache}}
-    </div>
+    {{> /static/mustache/base_objects/info-pane-utility.mustache}}
 
     <div class="tier-content">
       {{{render '/static/mustache/base_objects/general_info.mustache' instance=instance}}}

--- a/src/ggrc/assets/mustache/snapshots/dropdown_menu.mustache
+++ b/src/ggrc/assets/mustache/snapshots/dropdown_menu.mustache
@@ -1,0 +1,52 @@
+{{!
+    Copyright (C) 2016 Google Inc.
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+}}
+
+
+{{#if_helpers '\
+#if' is_info_pin '\
+and #is_allowed_to_map' page_instance instance '\
+or #if' is_info_pin '\
+and #if' instance.viewLink '\
+or #is_allowed' 'update' instance '\
+' _4_context='for'}}
+    <div class="details-wrap">
+        <a class="btn btn-draft dropdown-toggle" href="#" data-toggle="dropdown">
+            <span class="bubble"></span>
+            <span class="bubble"></span>
+            <span class="bubble"></span>
+        </a>
+        <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
+
+            {{#is_info_pin}}
+                {{#if instance.viewLink}}
+                    {{#is_allowed "view_object_page" instance}}
+                        <li>
+                            <a href="{{instance.viewLink}}">
+                            <i class="fa fa-long-arrow-right"></i>
+                            View {{instance.class.title_singular}}
+                            </a>
+                        </li>
+                    {{/is_allowed}}
+                {{/if}}
+            {{/is_info_pin}}
+
+            <li>
+                <clipboard-link
+                    data-test-id="dropdown_settings_get_permalink_75e3bf91"
+                    title="Get permalink"
+                    notify="true"
+                    text="{{get_permalink_for_object instance}}" />
+            </li>
+
+            <li>
+                <a href="{{instance.originalLink}}">
+                    <i class="fa fa-long-arrow-right"></i>
+                    View original {{instance.class.title_singular}}
+                </a>
+            </li>
+
+        </ul>
+    </div>
+{{/if_helpers}}

--- a/src/ggrc/assets/mustache/systems/info.mustache
+++ b/src/ggrc/assets/mustache/systems/info.mustache
@@ -10,9 +10,7 @@
       {{{render '/static/mustache/base_objects/info-pin.mustache'}}}
     {{/is_info_pin}}
 
-    <div class="info-pane-utility">
-      {{> /static/mustache/base_objects/dropdown_menu.mustache}}
-    </div>
+    {{> /static/mustache/base_objects/info-pane-utility.mustache}}
 
     <div class="tier-content">
       {{{render '/static/mustache/base_objects/general_info.mustache' instance=instance}}}

--- a/src/ggrc_risk_assessments/assets/mustache/risk_assessments/info.mustache
+++ b/src/ggrc_risk_assessments/assets/mustache/risk_assessments/info.mustache
@@ -9,9 +9,7 @@
     {{{render '/static/mustache/base_objects/info-pin.mustache'}}}
   {{/is_info_pin}}
 
-  <div class="info-pane-utility">
-    {{> /static/mustache/base_objects/dropdown_menu.mustache}}
-  </div>
+  {{> /static/mustache/base_objects/info-pane-utility.mustache}}
 
   <div class="tier-content">
     {{{render '/static/mustache/base_objects/general_info.mustache' instance=instance}}}

--- a/src/ggrc_risks/assets/mustache/risks/info.mustache
+++ b/src/ggrc_risks/assets/mustache/risks/info.mustache
@@ -10,9 +10,7 @@
       {{{render '/static/mustache/base_objects/info-pin.mustache'}}}
     {{/is_info_pin}}
 
-    <div class="info-pane-utility">
-      {{> /static/mustache/base_objects/dropdown_menu.mustache}}
-    </div>
+    {{> /static/mustache/base_objects/info-pane-utility.mustache}}
 
     <div class="tier-content">
       {{{render '/static/mustache/base_objects/general_info.mustache' instance=instance}}}


### PR DESCRIPTION
Implemented according to mockups.
It will not be visible until backend (FEATURE/SNAPSHOT) merged.
(Please note 'Update snapshot' menu item is not in scope of this PR)
<img width="1440" alt="screen shot 2016-11-02 at 11 59 03" src="https://cloud.githubusercontent.com/assets/674129/19922462/cdb08a3e-a0f3-11e6-814a-06ca7f9c65fa.png">
