### PR TITLE
GGRC-406 Close a tag in base add comment template

### DIFF
--- a/src/ggrc/assets/mustache/base_templates/add_comment.mustache
+++ b/src/ggrc/assets/mustache/base_templates/add_comment.mustache
@@ -72,7 +72,7 @@
           >Add</a>
 
         <label class="input--inline pull-left">
-          <input type="checkbox" can-value="sendNotification"
+          <input type="checkbox" can-value="sendNotification">
           Send Notifications
         </label>
         {{/if}}


### PR DESCRIPTION
~~Just discovered this while fixing some issue. Created a separate PR, because it turned out that this change will not be included in the PR with an actual fix, and I don't want to bloat the latter.~~

UPDATE: There was an issue discovered, causes by fixing the markup. It seems that some functionality relies on the old broken markup. Details below (thanks @alieh-rymasheuski for providing them, and opening the ticket)

---

**Title:**
GGRC-406 Add Comment form lacks a label for the Send Notifications checkbox at Request page

**Steps to reproduce:**
1. Go to a Request page.
2. Scroll to the Add Comment form.

**Expected result:** there is a labeled checkbox to Send Notifications at the bottom of the form.
**Actual result:** there is a checkbox without a label at the bottom of the form.