### PR TITLE
GGRC-211 Fix customattributable date setter

### DIFF
--- a/src/ggrc/models/custom_attribute_value.py
+++ b/src/ggrc/models/custom_attribute_value.py
@@ -52,6 +52,7 @@ class CustomAttributeValue(Base, db.Model):
   # This is just a mapping for accessing local functions so protected access
   # warning is a false positive
   _validator_map = {
+      "Date": lambda self: self._validate_date(),
       "Dropdown": lambda self: self._validate_dropdown(),
       "Map:Person": lambda self: self._validate_map_person(),
   }
@@ -254,6 +255,20 @@ class CustomAttributeValue(Base, db.Model):
         raise ValueError("Invalid custom attribute dropdown option: {v}, "
                          "expected one of {l}"
                          .format(v=self.attribute_value, l=valid_options))
+
+  def _validate_date(self):
+    """Convert date format."""
+    from ggrc.models.custom_attribute_definition import (
+        CustomAttributeDefinition)
+    if (self.custom_attribute.attribute_type ==
+            CustomAttributeDefinition.ValidTypes.DATE):
+      # convert the date formats for dates
+      if self.attribute_value:
+        self.attribute_value = utils.convert_date_format(
+            self.attribute_value,
+            CustomAttributeValue.DATE_FORMAT_JSON,
+            CustomAttributeValue.DATE_FORMAT_DB,
+        )
 
   def validate(self):
     """Validate custom attribute value."""

--- a/src/ggrc/models/mixins/customattributable.py
+++ b/src/ggrc/models/mixins/customattributable.py
@@ -162,8 +162,6 @@ class CustomAttributable(object):
     Args:
       values: List of dictionaries that represent custom attribute values.
     """
-    from ggrc.models.custom_attribute_definition import (
-        CustomAttributeDefinition)
     from ggrc.models.custom_attribute_value import CustomAttributeValue
 
     for value in values:
@@ -173,21 +171,11 @@ class CustomAttributable(object):
         value["attribute_object_id"] = (value["attribute_object"].get("id") if
                                         value.get("attribute_object") else
                                         None)
+
       attr = self._values_map.get(value.get("custom_attribute_id"))
       if attr:
-        attribute_value = value.get("attribute_value")
-        if (self._definitions_map[value["custom_attribute_id"]]
-                .attribute_type == CustomAttributeDefinition.ValidTypes.DATE):
-          # convert the date formats for dates
-          if attribute_value:
-            attribute_value = utils.convert_date_format(
-                attribute_value,
-                CustomAttributeValue.DATE_FORMAT_JSON,
-                CustomAttributeValue.DATE_FORMAT_DB,
-            )
-
         attr.attributable = self
-        attr.attribute_value = attribute_value
+        attr.attribute_value = value.get("attribute_value")
         attr.attribute_object_id = value.get("attribute_object_id")
       elif "custom_attribute_id" in value:
         # this is automatically appended to self._custom_attribute_values
@@ -340,7 +328,9 @@ class CustomAttributable(object):
       #    of the custom attributable.
       # TODO: We are ignoring contexts for now
       # new_value.context_id = cls.context_id
-      self.custom_attribute_values.append(new_value)
+
+      # new value is appended to self.custom_attribute_values by the ORM
+      # self.custom_attribute_values.append(new_value)
       if ad_id in last_values:
         _, previous_value = last_values[ad_id]
         if previous_value != attributes[ad_id]:

--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -871,11 +871,11 @@ class Resource(ModelView):
       self.json_update(obj, src)
     obj.modified_by_id = get_current_user_id()
     db.session.add(obj)
-    with benchmark("Send PUTed event"):
-      self.model_put.send(obj.__class__, obj=obj, src=src, service=self)
     with benchmark("Validate custom attributes"):
       if hasattr(obj, "validate_custom_attributes"):
         obj.validate_custom_attributes()
+    with benchmark("Send PUT event"):
+      self.model_put.send(obj.__class__, obj=obj, src=src, service=self)
     with benchmark("Get modified objects"):
       modified_objects = get_modified_objects(db.session)
     with benchmark("Update custom attribute values"):


### PR DESCRIPTION
This PR reverts #4621 and adds a fix to the blocker issue about being unable to complete an Assessment.

Steps to reproduce:
1. Create an Assessment with Date-type CA.
2. Fill in the CA with some date.
3. Click "Complete" button.

Expected result: the Assessment is completed.
Actual result: the Assessment remains In Progress.