### PR TITLE
GGRC-18 Make description of Risk mandatory

### DIFF
--- a/src/ggrc/converters/handlers/handlers.py
+++ b/src/ggrc/converters/handlers/handlers.py
@@ -359,6 +359,9 @@ class TextareaColumnHandler(ColumnHandler):
   def parse_item(self):
     """ Remove multiple spaces and new lines from text """
     if not self.raw_value:
+      if self.mandatory:
+        self.add_error(errors.MISSING_VALUE_ERROR,
+                       column_name=self.display_name)
       return ""
 
     return re.sub(r'\s+', " ", self.raw_value).strip()

--- a/test/integration/ggrc/converters/test_csvs/full_good_import_no_warnings.csv
+++ b/test/integration/ggrc/converters/test_csvs/full_good_import_no_warnings.csv
@@ -564,7 +564,7 @@ Not Launched
 In Scope
 Not in Scope
 Deprecated",MM/DD/YYYY,MM/DD/YYYY,,,,,,,,,,,
-Risk,code*,title*,description,notes,Owner*,Effective date,stop date,,,,,,,,,,,
+Risk,code*,title*,description*,notes,Owner*,Effective date,stop date,,,,,,,,,,,
 ,ra-1,ra-1,test,this is a note,user1@ggrc.com,7/1/2015,7/15/2015,,,,,,,,,,,
 ,ra-2,ra-2,test,this is a note,user1@ggrc.com,7/1/2015,7/15/2015,,,,,,,,,,,
 ,ra-3,ra-3,test,this is a note,user1@ggrc.com,7/1/2015,7/15/2015,,,,,,,,,,,

--- a/test/integration/ggrc/converters/test_csvs/risk_missing_mandatory_description.csv
+++ b/test/integration/ggrc/converters/test_csvs/risk_missing_mandatory_description.csv
@@ -1,0 +1,3 @@
+Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,
+Risk,code*,title*,description*,owner*
+,risk-1,Mandatory description is missing,,user@example.com

--- a/test/integration/ggrc/converters/test_import_comprehensive.py
+++ b/test/integration/ggrc/converters/test_import_comprehensive.py
@@ -313,3 +313,19 @@ class TestComprehensiveSheets(TestCase):
         },
     }
     self._check_csv_response(response, expected_errors)
+
+  def test_missing_rich_text_field(self):
+    """MISSING_VALUE_ERROR is returned on empty mandatory description."""
+    response = self.import_file("risk_missing_mandatory_description.csv")
+
+    expected_errors = {
+        "Risk": {
+            "row_errors": {
+                errors.MISSING_VALUE_ERROR.format(
+                    line="3",
+                    column_name="Description",
+                ),
+            },
+        },
+    }
+    self._check_csv_response(response, expected_errors)

--- a/test/integration/ggrc/converters/test_import_helpers.py
+++ b/test/integration/ggrc/converters/test_import_helpers.py
@@ -10,6 +10,7 @@ from ggrc.converters import import_helper
 from ggrc.converters.import_helper import get_object_column_definitions
 from ggrc.utils import get_mapping_rules
 from ggrc.utils import title_from_camelcase
+from ggrc_risks import models as r_models
 from ggrc_risk_assessments import models as ra_models
 from ggrc_workflows import models as wf_models
 from integration.ggrc import TestCase
@@ -966,6 +967,37 @@ class TestGetObjectColumnDefinitions(TestCase):
         }
     }
     self._test_single_object(models.Request, names, expected_fields)
+
+  def test_risk_definitions(self):
+    """Test default headers for Risk."""
+
+    names = {
+        "Code",
+        "Contact",
+        "Delete",
+        "Description",
+        "Effective Date",
+        "Notes",
+        "Owner",
+        "Reference URL",
+        "State",
+        "Stop Date",
+        "Title",
+        "Url",
+    }
+    expected_fields = {
+        "mandatory": {
+            "Code",
+            "Description",
+            "Owner",
+            "Title",
+        },
+        "unique": {
+            "Code",
+            "Title",
+        },
+    }
+    self._test_single_object(r_models.Risk, names, expected_fields)
 
 
 class TestGetWorkflowObjectColumnDefinitions(TestCase):


### PR DESCRIPTION
Steps to reproduce:

1. Go to import page.
2. Download a template for Risk object.
3. Fill in title and every other mandatory field except Description for a single Risk object.
4. Import that CSV.

Expected result: the CSV template has an asterisk after "Description" column header; the import ignores the CSV line with missing Description; an error message about empty Description column is displayed.
Actual result: the CSV template has no asterisk after "Description" column header; the import ignores the CSV line with missing Description; no error message is shown, just a note that n'th line is ignored.