### PR TITLE
GGRC-185 Fix JS error in AT modal

### DIFF
--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -878,7 +878,7 @@
         data.verifiers = makeList(this.attr('verifiersList'));
       }
 
-      return JSON.stringify(data);
+      return data;
     },
 
     /**

--- a/src/ggrc/assets/js_specs/models/assessment_template_spec.js
+++ b/src/ggrc/assets/js_specs/models/assessment_template_spec.js
@@ -158,8 +158,6 @@ describe('can.Model.AssessmentTemplate', function () {
 
       result = instance._packPeopleData();
 
-      expect(typeof result).toEqual('string');
-      result = JSON.parse(result);
       expect(result).toEqual({
         assessors: 'Rabbits',
         verifiers: 'Turtles'
@@ -182,8 +180,6 @@ describe('can.Model.AssessmentTemplate', function () {
 
         result = instance._packPeopleData();
 
-        expect(typeof result).toEqual('string');
-        result = JSON.parse(result);
         expect(result).toEqual({
           assessors: [2, 9, 17],
           verifiers: 'Whatever'
@@ -207,8 +203,6 @@ describe('can.Model.AssessmentTemplate', function () {
 
         result = instance._packPeopleData();
 
-        expect(typeof result).toEqual('string');
-        result = JSON.parse(result);
         expect(result).toEqual({
           assessors: 'Whatever',
           verifiers: [6, 11, 12]

--- a/src/ggrc/converters/handlers/default_people.py
+++ b/src/ggrc/converters/handlers/default_people.py
@@ -6,8 +6,6 @@
 These should be used on default verifiers and default assessors.
 """
 
-from flask import json
-
 from ggrc.models import AssessmentTemplate, Person
 from ggrc.converters import errors
 from ggrc.converters.handlers import handlers
@@ -107,8 +105,7 @@ class DefaultPersonColumnHandler(handlers.ColumnHandler):
 
     if _default_people:
       default_people.update(_default_people)
-      setattr(self.row_converter.obj, "default_people",
-              json.dumps(default_people))
+      setattr(self.row_converter.obj, "default_people", default_people)
     else:
       setattr(self.row_converter.obj, "_default_people", default_people)
 

--- a/src/ggrc/models/assessment_template.py
+++ b/src/ggrc/models/assessment_template.py
@@ -4,8 +4,6 @@
 
 """A module containing the implementation of the assessment template entity."""
 
-import json
-
 from sqlalchemy.orm import validates
 
 from ggrc import db
@@ -141,7 +139,7 @@ class AssessmentTemplate(assessment.AuditRelationship, relationship.Relatable,
         "template_object_type": self.template_object_type,
         "test_plan_procedure": self.test_plan_procedure,
         "procedure_description": self.procedure_description,
-        "default_people": json.dumps(self.default_people),
+        "default_people": self.default_people,
     }
     assessment_template_copy = AssessmentTemplate(**data)
     db.session.add(assessment_template_copy)
@@ -175,12 +173,12 @@ class AssessmentTemplate(assessment.AuditRelationship, relationship.Relatable,
     this validator.
     """
     # pylint: disable=unused-argument
-    parsed = json.loads(value)
     for mandatory in self._mandatory_default_people:
-      mandatory_value = parsed.get(mandatory)
+      mandatory_value = value.get(mandatory)
       if (not mandatory_value or
               isinstance(mandatory_value, list) and
-              any(not isinstance(p_id, int) for p_id in mandatory_value) or
+              any(not isinstance(p_id, (int, long))
+                  for p_id in mandatory_value) or
               isinstance(mandatory_value, basestring) and
               mandatory_value not in self.DEFAULT_PEOPLE_LABELS):
         raise ValidationError(

--- a/test/integration/ggrc/models/factories.py
+++ b/test/integration/ggrc/models/factories.py
@@ -153,8 +153,8 @@ class AssessmentTemplateFactory(ModelFactory):
   test_plan_procedure = False
   procedure_description = factory.LazyAttribute(
       lambda _: random_string("lorem ipsum description"))
-  default_people = \
-      "{\"assessors\":\"Object Owners\",\"verifiers\":\"Object Owners\"}"
+  default_people = {"assessors": "Object Owners",
+                    "verifiers": "Object Owners"}
 
 
 class ContractFactory(ModelFactory):


### PR DESCRIPTION
Steps to reproduce:
1. Open an Audit page.
2. Open new Assessment Template definition modal.
3. Type in a title.
4. Add a CA with title "CA3" (or the title of any other global Assessment CA present in the system).
5. Click "Save & Close". An error "Invalid Custom attribute name" should be displayed.
6. Click "Save & Close" once again (without any changes).
Expected result: the POST request is sent again, the error "Invalid Custom attribute name" is displayed again.
Actual result: error "Uncaught TypeError: current._get is not a function" is displayed in the console, no request is sent.
