### PR TITLE
GGRC-207 Fix tooltip in people list

### DIFF
--- a/src/ggrc/assets/javascripts/components/people_list.js
+++ b/src/ggrc/assets/javascripts/components/people_list.js
@@ -77,7 +77,7 @@
       mapping: null,
       required: '@',
       type: null,
-      title: null,
+      heading: null,
       toggle_add: false,
       mapped_people: [],
       results: [],

--- a/src/ggrc/assets/mustache/base_templates/people_group.mustache
+++ b/src/ggrc/assets/mustache/base_templates/people_group.mustache
@@ -6,7 +6,7 @@
 
 <label class="people-group">
     <span {{#boldTitle}}class="people-group_title"{{/boldTitle}}>
-      {{title}}
+      {{heading}}
     </span>
     {{#if editable}}
       {{#if required}}

--- a/src/ggrc/assets/mustache/base_templates/people_list.mustache
+++ b/src/ggrc/assets/mustache/base_templates/people_list.mustache
@@ -26,7 +26,7 @@
                   instance="instance"
                   mapping="mapping"
                   type="type"
-                  title="title"
+                  heading="title"
                   bold-title="disableTitle"
                   {{#if required}}
                   required="true"


### PR DESCRIPTION
1. Go to Assessment Modal window or Assessment info page
2. Hover mouse over plus button for creator/verifier/assignee
3. Hover mouse over delete button for creator/verifier/assignee
4. Hover mouse over entered person for for creator/verifier/assignee
5. Click plus button and hover mouse over close button
Expected results: tooltip should display corresponding info message not the word "title" only