### PR TITLE
ISSUE-1.505 Allow Assessment assignee to edit own comments

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/comment_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/comment_controller.js
@@ -21,6 +21,7 @@
     },
     '{CMS.Models.Comment} created': function (model, ev, instance) {
       var parentDfd;
+      var permissionRefresh;
       var source;
 
       if (!(instance instanceof CMS.Models.Comment)) {
@@ -29,8 +30,10 @@
 
       source = instance._source_mapping || GGRC.page_instance();
       parentDfd = this._create_relationship(source, instance);
+      permissionRefresh = Permission.refresh();
 
-      instance.delay_resolving_save_until($.when(parentDfd));
+      instance.delay_resolving_save_until(
+        $.when(parentDfd, permissionRefresh));
     }
   });
 


### PR DESCRIPTION
_(don't know the Jira issue number...)_

This PR fixes an issue that prevented a non-admin Assessment assignee from editing his/her own comments without refreshing the page. For that, permissions need to be refreshed for new comments.

Initially I triggered refreshing the permission refresh [here](https://github.com/google/ggrc-core/blob/develop/src/ggrc/assets/javascripts/components/assessment/add_comment.js#L107), but the template already starts rendering the new comment at that point, causing the latter to be briefly uneditable (until the permissions are updated). I thus decided to move refreshing the permissions to an earlier point.

No test, because an integration / end-to-end test would make more sense here, and that is a complex task currently worked on by QA (AFAIK).

---

**Details:**
- Go to Assessment’s Info page
- Add Assessor to People’s list (e.g. progcreator@reciprocitylabs.com)
- Log as Assessor (progcreator@reciprocitylabs.com)
- Navigate to Assessment’s Info pane
- Add comment in Comment tab
- Try to edit the created comment:

**Actual Result:**
Assessor cannot edit own comments in Assessment's Info pane, refreshing the page is required

**Expected Result:**
Assessor should be able to edit own comments in Assessment's Info pane immediately after creating a comment
