### PR TITLE
GGRC-184 Add more descriptive messages on CA name clash

### DIFF
--- a/src/ggrc/models/custom_attribute_definition.py
+++ b/src/ggrc/models/custom_attribute_definition.py
@@ -214,7 +214,9 @@ class CustomAttributeDefinition(mixins.Base, mixins.Titled, db.Model):
       flask.g.template_cad_names = {cad.title.lower() for cad in query}
 
     if name in flask.g.template_cad_names:
-      raise ValueError("Invalid Custom attribute name.")
+      raise ValueError(u"Local custom attribute '{}' "
+                       u"already exists for this object type."
+                       .format(name))
 
   @validates("title", "definition_type")
   def validate_title(self, key, value):
@@ -254,11 +256,14 @@ class CustomAttributeDefinition(mixins.Base, mixins.Titled, db.Model):
       return value
 
     if name in self._get_reserved_names(definition_type):
-      raise ValueError("Invalid Custom attribute name.")
+      raise ValueError(u"Attribute '{}' is reserved for this object type."
+                       .format(name))
 
     if (self._get_global_cad_names(definition_type).get(name) is not None and
             self._get_global_cad_names(definition_type).get(name) != self.id):
-      raise ValueError("Invalid Custom attribute name.")
+      raise ValueError(u"Global custom attribute '{}' "
+                       u"already exists for this object type"
+                       .format(name))
 
     if definition_type == "assessment":
       self.validate_assessment_title(name)


### PR DESCRIPTION
This PR changes text for error messages returned on CAD name conflict.

Preparation:
1. Go to Admin panel, add a global CA for Assessment with title "Global".
2. Go to an Audit, define an Assessment Template with CA titled "Local".

Cases:
1. In Admin panel, try to add a global CA for Assessment with title "Global".
2. In Admin panel, try to add a global CA for Assessment with title "Local".
3. In Admin panel, try to add a global CA for Assessment with title "Title".
4. In an Audit, try to save an Assessment Template with CA with title "Global".
5. In an Audit, try to save an Assessment Template with CA with title "Local". (this is the only case that should succeed)
6. In an Audit, try to save an Assessment Template with CA with title "Title".

For every case, check that the error message:
1. Features the title of the Custom Attribute that was not created.
2. Precisely describes the reason of inability to create the Custom Attribute definition.