### PR TITLE
QUICK-FIX Repeat CA date formatting migration

### DIFF
--- a/src/ggrc/migrations/utils/fix_dates.py
+++ b/src/ggrc/migrations/utils/fix_dates.py
@@ -4,70 +4,67 @@
 """Convert date formats in CAV table."""
 
 
-def fix_single_digit_month(connection):
-  """Change M/DD/YYYY (M/D/YYYY) into MM/DD/YYYY (MM/D/YYYY) correspondigly."""
-  connection.execute("""
+def _update_date_by_regexp(connection, regexp, new_value):
+  """Run an UPDATE cavs SET value = new_value WHERE value REGEXP regexp.
+
+  WARNING: Function arguments are directly passed to the expression, no
+  escaping is performed! This function should not be called with arguments from
+  an untrusted source!
+  """
+
+  request_skeleton = """
       UPDATE custom_attribute_values AS cav JOIN
              custom_attribute_definitions AS cad ON
                  cav.custom_attribute_id = cad.id
-      SET cav.attribute_value = CONCAT('0', cav.attribute_value)
+      SET cav.attribute_value = {new_value}
       WHERE cad.attribute_type = 'Date' AND
-            cav.attribute_value REGEXP '^[0-9]{1}/[0-9]{1,2}/[0-9]{4}$'
-  """)
+            cav.attribute_value REGEXP '{regexp}'
+  """
+  connection.execute(request_skeleton.format(new_value=new_value,
+                                             regexp=regexp))
+
+
+def fix_single_digit_month(connection):
+  """Change M/DD/YYYY (M/D/YYYY) into MM/DD/YYYY (MM/D/YYYY) correspondigly."""
+  _update_date_by_regexp(connection=connection,
+                         regexp="^[0-9]{1}/[0-9]{1,2}/[0-9]{4}$",
+                         new_value="CONCAT('0', cav.attribute_value)")
 
 
 def fix_single_digit_day(connection):
   """Change MM/D/YYYY into MM/DD/YYYY."""
-  connection.execute("""
-      UPDATE custom_attribute_values AS cav JOIN
-             custom_attribute_definitions AS cad ON
-                 cav.custom_attribute_id = cad.id
-      SET cav.attribute_value = CONCAT(SUBSTR(cav.attribute_value, 1, 3),
-                                       '0',
-                                       SUBSTR(cav.attribute_value, 4, 9))
-      WHERE cad.attribute_type = 'Date' AND
-            cav.attribute_value REGEXP '^[0-9]{2}/[0-9]{1}/[0-9]{4}$'
-  """)
+  _update_date_by_regexp(connection=connection,
+                         regexp="^[0-9]{2}/[0-9]{1}/[0-9]{4}$",
+                         new_value="""CONCAT(SUBSTR(cav.attribute_value, 1, 3),
+                                             '0',
+                                             SUBSTR(cav.attribute_value, 4, 9))
+                         """)
 
 
 def american_date_to_iso(connection):
   """Change MM/DD/YYYY into YYYY-MM-DD."""
-  connection.execute("""
-      UPDATE custom_attribute_values AS cav JOIN
-             custom_attribute_definitions AS cad ON
-                 cav.custom_attribute_id = cad.id
-      SET cav.attribute_value = CONCAT_WS('-',
+  _update_date_by_regexp(connection=connection,
+                         regexp="^[0-9]{2}/[0-9]{2}/[0-9]{4}$",
+                         new_value="""CONCAT_WS('-',
                                           SUBSTR(cav.attribute_value, 7, 4),
                                           SUBSTR(cav.attribute_value, 1, 2),
                                           SUBSTR(cav.attribute_value, 4, 2))
-      WHERE cad.attribute_type = 'Date' AND
-            cav.attribute_value REGEXP '^[0-9]{2}/[0-9]{2}/[0-9]{4}$'
-  """)
+                         """)
 
 
 def strip_trailing_zero_time(connection):
   """Change YYYY-MM-DD 00:00:00 to YYYY-MM-DD."""
-  connection.execute("""
-      UPDATE custom_attribute_values AS cav JOIN
-             custom_attribute_definitions AS cad ON
-                 cav.custom_attribute_id = cad.id
-      SET cav.attribute_value = SUBSTR(cav.attribute_value, 1, 10)
-      WHERE cad.attribute_type = 'Date' AND
-            cav.attribute_value REGEXP
-                '^[0-9]{4}-[0-9]{2}-[0-9]{2} 00:00:00$'
-  """)
+  _update_date_by_regexp(connection=connection,
+                         regexp="^[0-9]{4}-[0-9]{2}-[0-9]{2} 00:00:00$",
+                         new_value="SUBSTR(cav.attribute_value, 1, 10)")
 
 
 def iso_date_to_american(connection):
   """Change YYYY-MM-DD into MM/DD/YYYY."""
-  connection.execute("""
-      UPDATE custom_attribute_values AS cav JOIN
-             custom_attribute_definitions AS cad ON
-                 cav.custom_attribute_id = cad.id
-      SET cav.attribute_value = CONCAT_WS('/',
+  _update_date_by_regexp(connection=connection,
+                         regexp="^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+                         new_value="""CONCAT_WS('/',
                                           SUBSTR(cav.attribute_value, 6, 2),
                                           SUBSTR(cav.attribute_value, 9, 2),
                                           SUBSTR(cav.attribute_value, 1, 4))
-      WHERE cad.attribute_type = 'Date' AND
-            cav.attribute_value REGEXP '^[0-9]{4}-[0-9]{2}-[0-9]{2}$'
-  """)
+                         """)

--- a/src/ggrc/migrations/utils/fix_dates.py
+++ b/src/ggrc/migrations/utils/fix_dates.py
@@ -1,0 +1,73 @@
+# Copyright (C) 2016 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Convert date formats in CAV table."""
+
+
+def fix_single_digit_month(connection):
+  """Change M/DD/YYYY (M/D/YYYY) into MM/DD/YYYY (MM/D/YYYY) correspondigly."""
+  connection.execute("""
+      UPDATE custom_attribute_values AS cav JOIN
+             custom_attribute_definitions AS cad ON
+                 cav.custom_attribute_id = cad.id
+      SET cav.attribute_value = CONCAT('0', cav.attribute_value)
+      WHERE cad.attribute_type = 'Date' AND
+            cav.attribute_value REGEXP '^[0-9]{1}/[0-9]{1,2}/[0-9]{4}$'
+  """)
+
+
+def fix_single_digit_day(connection):
+  """Change MM/D/YYYY into MM/DD/YYYY."""
+  connection.execute("""
+      UPDATE custom_attribute_values AS cav JOIN
+             custom_attribute_definitions AS cad ON
+                 cav.custom_attribute_id = cad.id
+      SET cav.attribute_value = CONCAT(SUBSTR(cav.attribute_value, 1, 3),
+                                       '0',
+                                       SUBSTR(cav.attribute_value, 4, 9))
+      WHERE cad.attribute_type = 'Date' AND
+            cav.attribute_value REGEXP '^[0-9]{2}/[0-9]{1}/[0-9]{4}$'
+  """)
+
+
+def american_date_to_iso(connection):
+  """Change MM/DD/YYYY into YYYY-MM-DD."""
+  connection.execute("""
+      UPDATE custom_attribute_values AS cav JOIN
+             custom_attribute_definitions AS cad ON
+                 cav.custom_attribute_id = cad.id
+      SET cav.attribute_value = CONCAT_WS('-',
+                                          SUBSTR(cav.attribute_value, 7, 4),
+                                          SUBSTR(cav.attribute_value, 1, 2),
+                                          SUBSTR(cav.attribute_value, 4, 2))
+      WHERE cad.attribute_type = 'Date' AND
+            cav.attribute_value REGEXP '^[0-9]{2}/[0-9]{2}/[0-9]{4}$'
+  """)
+
+
+def strip_trailing_zero_time(connection):
+  """Change YYYY-MM-DD 00:00:00 to YYYY-MM-DD."""
+  connection.execute("""
+      UPDATE custom_attribute_values AS cav JOIN
+             custom_attribute_definitions AS cad ON
+                 cav.custom_attribute_id = cad.id
+      SET cav.attribute_value = SUBSTR(cav.attribute_value, 1, 10)
+      WHERE cad.attribute_type = 'Date' AND
+            cav.attribute_value REGEXP
+                '^[0-9]{4}-[0-9]{2}-[0-9]{2} 00:00:00$'
+  """)
+
+
+def iso_date_to_american(connection):
+  """Change YYYY-MM-DD into MM/DD/YYYY."""
+  connection.execute("""
+      UPDATE custom_attribute_values AS cav JOIN
+             custom_attribute_definitions AS cad ON
+                 cav.custom_attribute_id = cad.id
+      SET cav.attribute_value = CONCAT_WS('/',
+                                          SUBSTR(cav.attribute_value, 6, 2),
+                                          SUBSTR(cav.attribute_value, 9, 2),
+                                          SUBSTR(cav.attribute_value, 1, 4))
+      WHERE cad.attribute_type = 'Date' AND
+            cav.attribute_value REGEXP '^[0-9]{4}-[0-9]{2}-[0-9]{2}$'
+  """)

--- a/src/ggrc/migrations/versions/20161020082501_53206b20c12b_unify_ca_date_format.py
+++ b/src/ggrc/migrations/versions/20161020082501_53206b20c12b_unify_ca_date_format.py
@@ -12,6 +12,8 @@ Create Date: 2016-10-20 08:25:01.140510
 from alembic import op
 from sqlalchemy.sql import text
 
+from ggrc.migrations.utils import fix_dates
+
 
 # revision identifiers, used by Alembic.
 revision = '53206b20c12b'
@@ -42,91 +44,21 @@ def _strip_whitespace_around_dates(connection):
       """), val=new_value, id=date.id)
 
 
-def _fix_single_digit_month(connection):
-  """Change M/DD/YYYY (M/D/YYYY) into MM/DD/YYYY (MM/D/YYYY) correspondigly."""
-  connection.execute("""
-      UPDATE custom_attribute_values AS cav JOIN
-             custom_attribute_definitions AS cad ON
-                 cav.custom_attribute_id = cad.id
-      SET cav.attribute_value = CONCAT('0', cav.attribute_value)
-      WHERE cad.attribute_type = 'Date' AND
-            cav.attribute_value REGEXP '^[0-9]{1}/[0-9]{1,2}/[0-9]{4}$'
-  """)
-
-
-def _fix_single_digit_day(connection):
-  """Change MM/D/YYYY into MM/DD/YYYY."""
-  connection.execute("""
-      UPDATE custom_attribute_values AS cav JOIN
-             custom_attribute_definitions AS cad ON
-                 cav.custom_attribute_id = cad.id
-      SET cav.attribute_value = CONCAT(SUBSTR(cav.attribute_value, 1, 3),
-                                       '0',
-                                       SUBSTR(cav.attribute_value, 4, 9))
-      WHERE cad.attribute_type = 'Date' AND
-            cav.attribute_value REGEXP '^[0-9]{2}/[0-9]{1}/[0-9]{4}$'
-  """)
-
-
-def _american_date_to_iso(connection):
-  """Change MM/DD/YYYY into YYYY-MM-DD."""
-  connection.execute("""
-      UPDATE custom_attribute_values AS cav JOIN
-             custom_attribute_definitions AS cad ON
-                 cav.custom_attribute_id = cad.id
-      SET cav.attribute_value = CONCAT_WS('-',
-                                          SUBSTR(cav.attribute_value, 7, 4),
-                                          SUBSTR(cav.attribute_value, 1, 2),
-                                          SUBSTR(cav.attribute_value, 4, 2))
-      WHERE cad.attribute_type = 'Date' AND
-            cav.attribute_value REGEXP '^[0-9]{2}/[0-9]{2}/[0-9]{4}$'
-  """)
-
-
-def _strip_trailing_zero_time(connection):
-  """Change YYYY-MM-DD 00:00:00 to YYYY-MM-DD."""
-  connection.execute("""
-      UPDATE custom_attribute_values AS cav JOIN
-             custom_attribute_definitions AS cad ON
-                 cav.custom_attribute_id = cad.id
-      SET cav.attribute_value = SUBSTR(cav.attribute_value, 1, 10)
-      WHERE cad.attribute_type = 'Date' AND
-            cav.attribute_value REGEXP
-                '^[0-9]{4}-[0-9]{2}-[0-9]{2} 00:00:00$'
-  """)
-
-
 def upgrade():
   """Upgrade database schema and/or data, creating a new revision."""
   connection = op.get_bind()
 
   _strip_whitespace_around_dates(connection)
 
-  _fix_single_digit_month(connection)
-  _fix_single_digit_day(connection)
-  _american_date_to_iso(connection)
+  fix_dates.fix_single_digit_month(connection)
+  fix_dates.fix_single_digit_day(connection)
+  fix_dates.american_date_to_iso(connection)
 
-  _strip_trailing_zero_time(connection)
-
-
-def _iso_date_to_american(connection):
-  """Change YYYY-MM-DD into MM/DD/YYYY."""
-  connection.execute("""
-      UPDATE custom_attribute_values AS cav JOIN
-             custom_attribute_definitions AS cad ON
-                 cav.custom_attribute_id = cad.id
-      SET cav.attribute_value = CONCAT_WS('/',
-                                          SUBSTR(cav.attribute_value, 6, 2),
-                                          SUBSTR(cav.attribute_value, 9, 2),
-                                          SUBSTR(cav.attribute_value, 1, 4))
-      WHERE cad.attribute_type = 'Date' AND
-            cav.attribute_value REGEXP '^[0-9]{4}-[0-9]{2}-[0-9]{2}$'
-  """)
+  fix_dates.strip_trailing_zero_time(connection)
 
 
 def downgrade():
   """Downgrade database schema and/or data back to the previous revision."""
   connection = op.get_bind()
 
-  _iso_date_to_american(connection)
-
+  fix_dates.iso_date_to_american(connection)

--- a/src/ggrc/migrations/versions/20161104072614_2105a9db99fc_redo_ca_date_formatting.py
+++ b/src/ggrc/migrations/versions/20161104072614_2105a9db99fc_redo_ca_date_formatting.py
@@ -1,0 +1,38 @@
+# Copyright (C) 2016 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Redo CA date formatting.
+
+This migration is a partial duplicate of 53206b20c12b. The formatting is
+performed again because not every source of invalid dates was fixed prior to
+53206b20c12b.
+
+Create Date: 2016-11-04 07:26:14.880610
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+from alembic import op
+
+from ggrc.migrations.utils import fix_dates
+
+
+# revision identifiers, used by Alembic.
+revision = '2105a9db99fc'
+down_revision = '1db61b597d2d'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  connection = op.get_bind()
+
+  # only format MM/DD/YYYY with variations
+  fix_dates.fix_single_digit_month(connection)
+  fix_dates.fix_single_digit_day(connection)
+  fix_dates.american_date_to_iso(connection)
+
+
+def downgrade():
+  """Do nothing."""
+  # no formating required, every formatting downgrade is done in 53206b20c12b
+  pass


### PR DESCRIPTION
This PR duplicates the migration to format CA date values because not every source of invalid date formats was fixed previously.