### PR TITLE
GGRC-128 Fix adding current user as assignee

### DIFF
--- a/src/ggrc/assets/javascripts/models/assessment.js
+++ b/src/ggrc/assets/javascripts/models/assessment.js
@@ -282,20 +282,23 @@
 
       if (this.audit) {
         auditLead = this.audit.contact.reify();
-        // Assign Assessor role
-        this.mark_for_addition('related_objects_as_destination', auditLead, {
+        if (currentUser === auditLead) {
+          markForAddition(this, auditLead, 'Creator,Assessor');
+        } else {
+          markForAddition(this, auditLead, 'Assessor');
+          markForAddition(this, currentUser, 'Creator');
+        }
+      } else {
+        markForAddition(this, currentUser, 'Creator');
+      }
+
+      function markForAddition(instance, user, type) {
+        instance.mark_for_addition('related_objects_as_destination', user, {
           attrs: {
-            AssigneeType: 'Assessor'
+            AssigneeType: type
           }
         });
       }
-
-      // Assign Creator role
-      this.mark_for_addition('related_objects_as_destination', currentUser, {
-        attrs: {
-          AssigneeType: 'Creator'
-        }
-      });
     },
     refreshInstance: function () {
       return this.refresh().then(function () {

--- a/src/ggrc/assets/javascripts/models/cacheable.js
+++ b/src/ggrc/assets/javascripts/models/cacheable.js
@@ -1193,12 +1193,18 @@
   /**
    Set up a deferred join object creation when this object is updated.
   */
-    mark_for_addition: function (join_attr, obj, extra_attrs, options) {
+    mark_for_addition: function (joinAttr, obj, extraAttrs, options) {
       obj = obj.reify ? obj.reify() : obj;
-      extra_attrs = _.isEmpty(extra_attrs) ? undefined : extra_attrs;
+      extraAttrs = _.isEmpty(extraAttrs) ? undefined : extraAttrs;
 
       this.remove_duplicate_pending_joins(obj);
-      this._pending_joins.push({how: 'add', what: obj, through: join_attr, extra: extra_attrs, opts: options});
+      this._pending_joins.push({
+        how: 'add',
+        what: obj,
+        through: joinAttr,
+        extra: extraAttrs,
+        opts: options
+      });
     },
 
     remove_duplicate_pending_joins: function (obj) {
@@ -1210,7 +1216,8 @@
       len = this._pending_joins.length;
       joins = _.filter(this._pending_joins, function (val) {
         return val.what !== obj;
-      }.bind(this));
+      });
+
       if (len !== joins.length) {
         this.attr('_pending_joins').replace(joins);
       }


### PR DESCRIPTION
**Previous:** Assessor/Assignee field is not auto populated with Audit Lead value if Audit Lead equals assessment creator
**Issue**: If Current User is audit lead so he isn't populating as Assessor/Assignee
**Fix**: Now he populated as Assessor/Assignee