### PR TITLE
GGRC-191 Preselect the First Assessment Template when generating Assessments

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment_templates/assessment_templates.js
+++ b/src/ggrc/assets/javascripts/components/assessment_templates/assessment_templates.js
@@ -16,6 +16,8 @@
       binding: '@',
       responses: [],
       instance: null,
+      mapper: null,  // a shared object representing the mapper modal's state
+
       templates: function () {
         var result = {};
         var responses = this.attr('responses');
@@ -44,15 +46,57 @@
           });
         });
         return [noValue].concat(_.toArray(result));
+      },
+
+      /**
+       * Set the initial Assessment Template to be selected in the relevant
+       * dropdown menu.
+       *
+       * By default, the first option from the first option group is selected,
+       * unless such option does not exist, or if the mapper instance is not
+       * given. In that case this method has no effect.
+       *
+       * @param {Array} templates - a list of possible options for the dropdown
+       * @param {GGRC.Models.MapperModel} mapper - the shared object holding
+       *   the state of the mapper modal
+       */
+      _selectInitialTemplate: function (templates, mapper) {
+        var initialTemplate;
+        var nonDummyItem;
+
+        if (!mapper) {
+          return;
+        }
+
+        // The first element is a dummy option, thus if there are no other
+        // elements, simply don't pick anything.
+        if (templates.length < 2) {
+          return;
+        }
+
+        nonDummyItem = templates[1];  // a single item or an object group
+
+        if (!nonDummyItem.group) {  // a single item
+          initialTemplate = nonDummyItem.value;
+        } else {
+          if (!nonDummyItem.subitems || nonDummyItem.subitems.length === 0) {
+            return;  // an empty group, no option to pick from it
+          }
+          initialTemplate = nonDummyItem.subitems[0].value;
+        }
+
+        mapper.attr('assessmentTemplate', initialTemplate);
       }
     },
     init: function () {
-      var instance = this.scope.attr('instance');
-      var binding = instance.get_binding(this.scope.attr('binding'));
+      var scope = this.scope;
+      var instance = scope.attr('instance');
+      var binding = instance.get_binding(scope.attr('binding'));
 
       binding.refresh_instances().done(function (response) {
-        this.scope.attr('responses', response);
-      }.bind(this));
+        scope.attr('responses', response);
+        scope._selectInitialTemplate(scope.templates(), scope.mapper);
+      });
     }
   });
 })(window.can, window.can.$);

--- a/src/ggrc/assets/javascripts/components/assessment_templates/assessment_templates.js
+++ b/src/ggrc/assets/javascripts/components/assessment_templates/assessment_templates.js
@@ -61,6 +61,11 @@
        *   the state of the mapper modal
        */
       _selectInitialTemplate: function (templates, mapper) {
+        var WARN_EMPTY_GROUP = [
+          'GGRC.Components.assessmentTemplates: ',
+          'An empty template group encountered, possible API error'
+        ].join('');
+
         var initialTemplate;
         var nonDummyItem;
 
@@ -80,6 +85,7 @@
           initialTemplate = nonDummyItem.value;
         } else {
           if (!nonDummyItem.subitems || nonDummyItem.subitems.length === 0) {
+            console.warn(WARN_EMPTY_GROUP);
             return;  // an empty group, no option to pick from it
           }
           initialTemplate = nonDummyItem.subitems[0].value;

--- a/src/ggrc/assets/javascripts/components/assessment_templates/tests/assessment_templates_spec.js
+++ b/src/ggrc/assets/javascripts/components/assessment_templates/tests/assessment_templates_spec.js
@@ -87,6 +87,20 @@ describe('GGRC.Components.assessmentTemplates', function () {
       }
     );
 
+    it('issues a warning if an empty group is encountered', function () {
+      var expectedMsg = [
+        'GGRC.Components.assessmentTemplates: ',
+        'An empty template group encountered, possible API error'
+      ].join('');
+
+      spyOn(console, 'warn');
+      templates[1].subitems.length = 0;
+
+      method(templates, mapper);
+
+      expect(console.warn).toHaveBeenCalledWith(expectedMsg);
+    });
+
     it('selects the first non-dummy value if it precedes all object groups',
       function () {
         mapper.attr('assessmentTemplate', 'template-123');

--- a/src/ggrc/assets/javascripts/components/assessment_templates/tests/assessment_templates_spec.js
+++ b/src/ggrc/assets/javascripts/components/assessment_templates/tests/assessment_templates_spec.js
@@ -1,0 +1,101 @@
+/*!
+  Copyright (C) 2016 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+describe('GGRC.Components.assessmentTemplates', function () {
+  'use strict';
+
+  var Component;  // the component under test
+
+  beforeAll(function () {
+    Component = GGRC.Components.get('assessmentTemplates');
+  });
+
+  describe('_selectInitialTemplate() method', function () {
+    var mapper;
+    var method;  // the method under test
+    var templates;
+
+    beforeAll(function () {
+      method = Component.prototype.scope._selectInitialTemplate;
+    });
+
+    beforeEach(function () {
+      mapper = new can.Map({
+        assessmentTemplate: ''
+      });
+
+      templates = [
+        {
+          title: 'No Template',
+          value: ''
+        },
+        {
+          group: 'FooBarBaz objects',
+          subitems: [
+            {title: 'object Foo', value: 'foo'},
+            {title: 'object Bar', value: 'bar'},
+            {title: 'object Baz', value: 'baz'}
+          ]
+        },
+        {
+          group: 'Animal objects',
+          subitems: [
+            {title: 'Elephant Dumbo', value: 'elephant'},
+            {title: 'Flying Pig', value: 'pig'},
+            {title: 'Tiny Mouse', value: 'mouse'}
+          ]
+        }
+      ];
+    });
+
+    it('gracefully handles a missing mapper object', function () {
+      try {
+        method(templates, null);
+      } catch (err) {
+        fail('Handling a non-existing mapper object failed: ' + err.msg);
+      }
+    });
+
+    it('selects the first item from the first option group', function () {
+      mapper.attr('assessmentTemplate', 'template-123');
+      method(templates, mapper);
+      expect(mapper.assessmentTemplate).toEqual('foo');
+    });
+
+    it('leaves the current template unchanged if only a dummy value in ' +
+      'the templates list',
+      function () {
+        mapper.attr('assessmentTemplate', 'template-123');
+        templates.splice(1);  // keep only the 1st (dummy) option
+
+        method(templates, mapper);
+
+        expect(mapper.assessmentTemplate).toEqual('template-123');
+      }
+    );
+
+    it('leaves the current template unchanged if first object group empty',
+      function () {
+        mapper.attr('assessmentTemplate', 'template-123');
+        templates[1].subitems.length = 0;
+
+        method(templates, mapper);
+
+        expect(mapper.assessmentTemplate).toEqual('template-123');
+      }
+    );
+
+    it('selects the first non-dummy value if it precedes all object groups',
+      function () {
+        mapper.attr('assessmentTemplate', 'template-123');
+        templates.splice(1, 0, {title: 'No Group Template', value: 'single'});
+
+        method(templates, mapper);
+
+        expect(mapper.assessmentTemplate).toEqual('single');
+      }
+    );
+  });
+});

--- a/src/ggrc/assets/mustache/modals/mapper/base.mustache
+++ b/src/ggrc/assets/mustache/modals/mapper/base.mustache
@@ -73,6 +73,7 @@
     type="mapper.type"
     binding="related_assessment_templates"
     assessment-template="mapper.assessmentTemplate"
+    mapper="mapper"
   >
   </assessment-templates>
   {{/if}}


### PR DESCRIPTION
This PR changes the generate Assessments modal, so that by default, the first available AssessmentTemplate is selected in the corresponding dropdown.

**Details:**
- Open an Audit, go to the Assessment Templates tab.
- If needed, define a couple of Assessment Templates for different object types (some of the ATs should have the same object type set).
- Go to  the Assessments tab and click the magic wand icon (just above the tree view, on the right).

**Expected result:**
In the modal, the first available Assessment Template should be preselected in the corresponding dropdown (if such template exists, of course)

**Actual result:**
No Assessment Template is selected in the dropdown by default.

P.S.: The branch name is incorrect, the issue number is indeed GGRC-191.