### PR TITLE
[Feature/Snapshotter] Remove Program - Audit - Program Objects automappings

### DIFF
--- a/src/ggrc/automapper/__init__.py
+++ b/src/ggrc/automapper/__init__.py
@@ -11,7 +11,6 @@ from ggrc import db
 from ggrc import models
 from ggrc.automapper.rules import rules
 from ggrc.login import get_current_user
-from ggrc.models.audit import Audit
 from ggrc.models.relationship import Relationship
 from ggrc.models.request import Request
 from ggrc.rbac.permissions import is_allowed_update
@@ -279,7 +278,3 @@ def register_automapping_listeners():
   @Resource.model_put_after_commit.connect_via(Request)
   def handle_request(sender, obj=None, src=None, service=None, event=None):
     handle_relationship_post(obj, obj.audit)
-
-  @Resource.model_posted_after_commit.connect_via(Audit)
-  def handle_audit(sender, obj=None, src=None, service=None, event=None):
-    handle_relationship_post(obj, obj.program)

--- a/src/ggrc/automapper/rules.py
+++ b/src/ggrc/automapper/rules.py
@@ -176,11 +176,4 @@ rules = RuleSet(count_limit=10000, rule_list=[
         {'Request'},
     ),
 
-    Rule(
-        'mapping program objects to audit',
-        {Attr('audits'), 'Audit'},
-        {'Program'},
-        {'Regulation', 'Policy', 'Standard', 'Contract',
-         'Section', 'Clause', 'Objective', 'Control'}
-    ),
 ])

--- a/test/integration/ggrc/automapper/test_automappings.py
+++ b/test/integration/ggrc/automapper/test_automappings.py
@@ -360,35 +360,3 @@ class TestAutomappings(integration.ggrc.TestCase):
         to_create=[(program, regulation), (regulation, assessment)],
         implied=[(program, assessment)]
     )
-
-  def test_automapping_audit_program_object(self):
-    """Test rule 'mapping program objects to audit'."""
-    program = self.create_object(models.Program, {
-        'title': make_name('Program')
-    })
-    audit = self.create_object(models.Audit, {
-        'title': make_name('Audit'),
-        'program': {'id': program.id},
-        'status': 'Planned',
-    })
-    regulation = self.create_object(models.Regulation, {
-        'title': make_name('Test PD Regulation')
-    })
-    section = self.create_object(models.Section, {
-        'title': make_name('Test section'),
-        'directive': {'id': regulation.id},
-    })
-
-    self.assert_mapping_implication(
-        to_create=[(program, regulation), (program, section)],
-        implied=[(regulation, audit), (section, audit)]
-    )
-
-    audit_new = self.create_object(models.Audit, {
-        'title': make_name('Audit'),
-        'program': {'id': program.id},
-        'status': 'Planned',
-    })
-    self.assert_mapping(audit_new, regulation)
-    self.assert_mapping(audit_new, section)
-    self.assert_mapping(audit_new, program, missing=True)


### PR DESCRIPTION
We are beginning our transition to snapshots and no longer need
Audit - Program automappings.