### PR TITLE
QUICK-FIX Fix import signals

### DIFF
--- a/src/ggrc/converters/base_block.py
+++ b/src/ggrc/converters/base_block.py
@@ -366,6 +366,7 @@ class BlockConverter(object):
     if not self.converter.dry_run:
       for row_converter in self.row_converters:
         row_converter.send_pre_commit_signals()
+      for row_converter in self.row_converters:
         try:
           row_converter.insert_object()
           db.session.flush()

--- a/src/ggrc_workflows/__init__.py
+++ b/src/ggrc_workflows/__init__.py
@@ -408,10 +408,13 @@ def ensure_assignee_is_workflow_member(workflow, assignee):
   if not assignee:
     return
 
+  if any(assignee == wp.person for wp in workflow.workflow_people):
+    return
+
   # Check if assignee is mapped to the Workflow
   workflow_people = models.WorkflowPerson.query.filter(
       models.WorkflowPerson.workflow_id == workflow.id,
-      models.WorkflowPerson.person_id == assignee.id).all()
+      models.WorkflowPerson.person_id == assignee.id).count()
   if not workflow_people:
     workflow_person = models.WorkflowPerson(
         person=assignee,
@@ -424,7 +427,7 @@ def ensure_assignee_is_workflow_member(workflow, assignee):
   from ggrc_basic_permissions.models import UserRole
   user_roles = UserRole.query.filter(
       UserRole.context_id == workflow.context_id,
-      UserRole.person_id == assignee.id).all()
+      UserRole.person_id == assignee.id).count()
   if not user_roles:
     workflow_member_role = _find_role('WorkflowMember')
     user_role = UserRole(


### PR DESCRIPTION
This pull request is prep work for making cycle tasks editable via imports.

The thing is for cycle tasks to be properly importable, the pre commit signals have to work properly and all have to be called before the first flush statement.