### PR TITLE
GGRC-53 Do not send email notification if user has No Role on workflow

### DIFF
--- a/src/ggrc/notifications/common.py
+++ b/src/ggrc/notifications/common.py
@@ -200,7 +200,7 @@ def should_receive(notif, user_data, people_cache):
   if person.system_wide_role == "No Access":
     return False
 
-  def is_enabled(notif_type):
+  def is_enabled(notif_type, person):
     """Check user notification settings.
 
     Args:
@@ -211,16 +211,16 @@ def should_receive(notif, user_data, people_cache):
       Boolean based on what settings users has stored or what the default
       setting is for the given notification.
     """
-    result = NotificationConfig.query.filter(
-        and_(NotificationConfig.person_id == person_id,
-             NotificationConfig.notif_type == notif_type))
-    if result.count() == 0:
+
+    notification_configs = [nc for nc in person.notification_configs
+                               if nc.notif_type == notif_type]
+    if len(notification_configs) == 0:
       # If we have no results, we need to use the default value, which is
       # true for digest emails.
       return notif_type == "Email_Digest"
-    return result.one().enable_flag
+    return notification_configs[0].enable_flag
 
-  has_digest = force_notif or is_enabled("Email_Digest")
+  has_digest = force_notif or is_enabled("Email_Digest", person)
 
   return has_digest
 

--- a/src/ggrc/notifications/common.py
+++ b/src/ggrc/notifications/common.py
@@ -23,7 +23,6 @@ from ggrc import extensions
 from ggrc import settings
 from ggrc.models import Person
 from ggrc.models import Notification
-from ggrc.models import NotificationConfig
 from ggrc.rbac import permissions
 from ggrc.utils import merge_dict
 
@@ -190,10 +189,9 @@ def should_receive(notif, user_data, people_cache):
     person = people_cache[person_id]
   else:
     person = db.session.query(Person).options(
-      joinedload('user_roles').joinedload('role'),
-      joinedload('notification_configs')).filter(
-        Person.id == person_id
-      ).first()
+        joinedload('user_roles').joinedload('role'),
+        joinedload('notification_configs')
+    ).filter(Person.id == person_id).first()
     people_cache[person_id] = person
 
   # If the user has no access we should not send any emails
@@ -213,8 +211,8 @@ def should_receive(notif, user_data, people_cache):
     """
 
     notification_configs = [nc for nc in person.notification_configs
-                               if nc.notif_type == notif_type]
-    if len(notification_configs) == 0:
+                            if nc.notif_type == notif_type]
+    if not notification_configs:
       # If we have no results, we need to use the default value, which is
       # true for digest emails.
       return notif_type == "Email_Digest"

--- a/src/ggrc/notifications/common.py
+++ b/src/ggrc/notifications/common.py
@@ -340,8 +340,8 @@ def modify_data(data):
 
   # combine "my_tasks" from multiple cycles
   data["cycle_started_tasks"] = {}
-  if "cycle_started" in data:
-    for cycle in data["cycle_started"].values():
+  if "cycle_data" in data:
+    for cycle in data["cycle_data"].values():
       if "my_tasks" in cycle:
         data["cycle_started_tasks"].update(cycle["my_tasks"])
 

--- a/src/ggrc_workflows/notification/__init__.py
+++ b/src/ggrc_workflows/notification/__init__.py
@@ -99,31 +99,29 @@ All notifications handle the following structure:
               }
               , ...
           }
-
-          "cycle_started": {
+          "cycle_data": {
               cycle.id: {
-                  # manually started cycles have instant notification
-                  "manually": False
-
-                  "custom_message": ""
-                  "cycle_title": ""
-                  "cycle_url": ""
-                  "workflow_owners":
-                      { workflow_owner.id: workflow_owner_info, ...},
-
                   "my_tasks" : # list of all tasks assigned to the user
-                      { cycle_task.id: { task_info }, ...}
-
+                      { cycle_task.id: { task_info }, ...},
                   # list of all task groups assigned to the user, including
                   # tasks
                   "my_task_groups" :
                       { task_group.id:
                           { cycle_task.id: { task_info }, ... }, ...
-                      }
-
+                      },
                   "cycle_tasks" : # list of all tasks in the workflow
                       { cycle_task.id: { task_info }, ...}
-
+              }
+          }
+          "cycle_started": {
+              cycle.id: {
+                  # manually started cycles have instant notification
+                  "manually": False,
+                  "custom_message": "",
+                  "cycle_title": "",
+                  "cycle_url": "",
+                  "workflow_owners":
+                      { workflow_owner.id: workflow_owner_info, ...}
               }
               , ...
           }

--- a/src/ggrc_workflows/notification/data_handler.py
+++ b/src/ggrc_workflows/notification/data_handler.py
@@ -59,7 +59,7 @@ def get_cycle_created_task_data(notification):
           "force_notifications": {
               notification.id: force
           },
-          "cycle_started": {
+          "cycle_data": {
               cycle.id: {
                   "my_tasks": deepcopy(task)
               }
@@ -72,7 +72,7 @@ def get_cycle_created_task_data(notification):
           "force_notifications": {
               notification.id: force
           },
-          "cycle_started": {
+          "cycle_data": {
               cycle.id: {
                   "my_task_groups": {
                       cycle_task_group.id: deepcopy(task)
@@ -88,7 +88,7 @@ def get_cycle_created_task_data(notification):
             "force_notifications": {
                 notification.id: force
             },
-            "cycle_started": {
+            "cycle_data": {
                 cycle.id: {
                     "cycle_tasks": deepcopy(task)
                 }

--- a/src/ggrc_workflows/notification/data_handler.py
+++ b/src/ggrc_workflows/notification/data_handler.py
@@ -156,7 +156,8 @@ def get_cycle_created_data(notification, cycle):
   force = cycle.workflow.notify_on_change
   result = {}
 
-  for person in cycle.workflow.people:
+  for user_role in cycle.workflow.context.user_roles:
+    person = user_role.person
     result[person.email] = {
         "user": data_handlers.get_person_dict(person),
         "force_notifications": {
@@ -239,9 +240,10 @@ def get_workflow_starts_in_data(notification, workflow):
   workflow_owners = get_workflow_owners_dict(workflow.context_id)
   force = workflow.notify_on_change
 
-  for wf_person in workflow.workflow_people:
-    result[wf_person.person.email] = {
-        "user": data_handlers.get_person_dict(wf_person.person),
+  for user_roles in workflow.context.user_roles:
+    wf_person = user_roles.person
+    result[wf_person.email] = {
+        "user": data_handlers.get_person_dict(wf_person),
         "force_notifications": {
             notification.id: force
         },

--- a/test/integration/ggrc_workflows/notifications/test_one_time_wf.py
+++ b/test/integration/ggrc_workflows/notifications/test_one_time_wf.py
@@ -61,7 +61,7 @@ class TestOneTimeWorkflowNotification(TestCase):
       self.assertIn("cycle_started", notif_data[person_1.email])
       self.assertIn(cycle.id, notif_data[person_1.email]["cycle_started"])
       self.assertIn("my_tasks",
-                    notif_data[person_1.email]["cycle_started"][cycle.id])
+                    notif_data[person_1.email]["cycle_data"][cycle.id])
 
     with freeze_time("2015-05-03"):  # two days befor due date
       _, notif_data = common.get_daily_notifications()
@@ -92,14 +92,14 @@ class TestOneTimeWorkflowNotification(TestCase):
       _, notif_data = common.get_daily_notifications()
       self.assertIn("cycle_started", notif_data[user])
       self.assertIn(cycle.id, notif_data[user]["cycle_started"])
-      self.assertIn("my_tasks", notif_data[user]["cycle_started"][cycle.id])
-      self.assertIn("cycle_tasks", notif_data[user]["cycle_started"][cycle.id])
+      self.assertIn("my_tasks", notif_data[user]["cycle_data"][cycle.id])
+      self.assertIn("cycle_tasks", notif_data[user]["cycle_data"][cycle.id])
       self.assertIn(
-          "my_task_groups", notif_data[user]["cycle_started"][cycle.id])
+          "my_task_groups", notif_data[user]["cycle_data"][cycle.id])
       self.assertIn("cycle_url", notif_data[user]["cycle_started"][cycle.id])
 
       cycle = Cycle.query.get(cycle.id)
-      cycle_data = notif_data[user]["cycle_started"][cycle.id]
+      cycle_data = notif_data[user]["cycle_data"][cycle.id]
       for task in cycle.cycle_task_group_object_tasks:
         self.assertIn(task.id, cycle_data["my_tasks"])
         self.assertIn(task.id, cycle_data["cycle_tasks"])


### PR DESCRIPTION
Users do not want to receive cycle notifications when they are assigned as No Role on the workflow tab.

I'm adding a question label as I'm not 100% sure how we should handle No Role people that are also assignees on a cycle task. Currently we send an email notification about the task being overdue/decline, but I need to check with akhil if No Role should mute those as well.