### PR TITLE
QUICK-FIX Add event to signals 

### DIFF
--- a/src/ggrc/automapper/__init__.py
+++ b/src/ggrc/automapper/__init__.py
@@ -256,7 +256,7 @@ def handle_relationship_post(source, destination):
 
 def register_automapping_listeners():
   """Register event listeners for auto mapper."""
-  # pylint: disable=unused-variable
+  # pylint: disable=unused-variable,unused-argument
 
   @Resource.collection_posted.connect_via(Relationship)
   def handle_relationship_collection_post(sender, objects=None, **kwargs):
@@ -277,9 +277,9 @@ def register_automapping_listeners():
 
   @Resource.model_posted_after_commit.connect_via(Request)
   @Resource.model_put_after_commit.connect_via(Request)
-  def handle_request(sender, obj=None, src=None, service=None):
+  def handle_request(sender, obj=None, src=None, service=None, event=None):
     handle_relationship_post(obj, obj.audit)
 
   @Resource.model_posted_after_commit.connect_via(Audit)
-  def handle_audit(sender, obj=None, src=None, service=None):
+  def handle_audit(sender, obj=None, src=None, service=None, event=None):
     handle_relationship_post(obj, obj.program)

--- a/src/ggrc/converters/base_row.py
+++ b/src/ggrc/converters/base_row.py
@@ -178,7 +178,7 @@ class RowConverter(object):
     for item_handler in self.attrs.values():
       item_handler.set_obj_attr()
 
-  def send_post_commit_signals(self):
+  def send_post_commit_signals(self, event=None):
     """Send after commit signals for all objects
 
     This function sends proper signals for all objects depending if the object
@@ -192,13 +192,15 @@ class RowConverter(object):
     service_class.model = self.object_class
     if self.is_delete:
       Resource.model_deleted_after_commit.send(
-          self.object_class, obj=self.obj, service=service_class)
+          self.object_class, obj=self.obj, service=service_class, event=event)
     elif self.is_new:
       Resource.model_posted_after_commit.send(
-          self.object_class, obj=self.obj, src={}, service=service_class)
+          self.object_class, obj=self.obj, src={}, service=service_class,
+          event=event)
     else:
       Resource.model_put_after_commit.send(
-          self.object_class, obj=self.obj, src={}, service=service_class)
+          self.object_class, obj=self.obj, src={}, service=service_class,
+          event=event)
 
   def send_pre_commit_signals(self):
     """Send before commit signals for all objects.

--- a/src/ggrc/notifications/notification_handlers.py
+++ b/src/ggrc/notifications/notification_handlers.py
@@ -142,7 +142,8 @@ def register_handlers():
 
   @Resource.model_posted_after_commit.connect_via(models.Request)
   @Resource.model_posted_after_commit.connect_via(models.Assessment)
-  def assignable_created_listener(sender, obj=None, src=None, service=None):
+  def assignable_created_listener(sender, obj=None, src=None, service=None,
+                                  event=None):
     handle_assignable_created(obj)
 
   @Resource.model_put.connect_via(models.Assessment)
@@ -152,5 +153,6 @@ def register_handlers():
       handle_reminder(obj, reminder_type)
 
   @Resource.model_posted_after_commit.connect_via(models.Comment)
-  def comment_created_listener(sender, obj=None, src=None, service=None):
+  def comment_created_listener(sender, obj=None, src=None, service=None,
+                               event=None):
     handle_comment_created(obj, src)


### PR DESCRIPTION
This pull request adds event to `*_after_commit` signals. This is required for the snapshotter to avoid ugly [`get_event`](https://github.com/google/ggrc-core/pull/4237/files#diff-30b7bbcf03f429d63ac005af5be076c1R108) call to retrieve (likely) event that caused snapshotter to run and create/update snapshots.

For testing: If tests pass this should be good, however, to be double short, the person that merges it should run `git grep` to ensure that all signal senders attach event and all signal receivers expect event. Do note - event only makes sense for `_after_commit` signals since it is only at that point that we actually have event.