### PR TITLE
GGRC-431 Remove bad data form object_people table

### DIFF
--- a/src/ggrc/migrations/versions/20161109010604_4afe69ce3c38_remove_invalid_person_objects.py
+++ b/src/ggrc/migrations/versions/20161109010604_4afe69ce3c38_remove_invalid_person_objects.py
@@ -1,0 +1,31 @@
+# Copyright (C) 2016 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Remove invalid person objects
+
+Create Date: 2016-11-09 01:06:04.745331
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '4afe69ce3c38'
+down_revision = '2105a9db99fc'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  op.execute(
+      """DELETE FROM object_people WHERE personable_type IN (
+          'InterviewResponse',
+          'DocumentationResponse'
+      )"""
+  )
+
+
+def downgrade():
+  """Nothing to be done about removed data."""


### PR DESCRIPTION
The InterviewResponse object was not properly removed from all tables
when the model was deleted. Memcache then tried to remove this non
existent model, which resulted in an exception. This migration makes
sure that such bad data is properly purged from our database.


To reproduce this issue, try to create an assessment on the audit 503 from the grc-test database.
Expected: you should be able to make an assessment
Actual result: You get a script error for non existent type "InterviewResponse"


PS: this commit is a monkey patch for Qunice-PATCH3 so the head commit is the one from the patch3 tag.