### PR TITLE
GGRC-70 Disable editing for snapshots

### DIFF
--- a/src/ggrc/assets/stylesheets/modules/_snapshot.scss
+++ b/src/ggrc/assets/stylesheets/modules/_snapshot.scss
@@ -22,6 +22,12 @@ hr.snapshot {
   padding: 0;
 }
 
+a.disabled {
+  pointer-events: none !important;
+  cursor: default;
+  color: $disabled;
+}
+
 // Info pane
 .sticky-info-panel {
   .pane-header.snapshot {

--- a/src/ggrc_workflows/assets/mustache/base_objects/approval_link.mustache
+++ b/src/ggrc_workflows/assets/mustache/base_objects/approval_link.mustache
@@ -38,9 +38,9 @@
               {{/with_most_recent_declining_task_entry}}
             {{/if_equals}}
             <div {{#review_task}}{{data 'model'}}{{/review_task}} {{ (el) -> el.ggrc_controllers_quick_form({instance : el.data("model") }) }}>
-              <button class="btn btn-mini btn-success change-task-status {{instance._disabled}}" data-name="status" data-value="Verified">Approve</button>
+              <button class="btn btn-mini btn-success change-task-status {{instance._disabled}} {{#if instance.snapshot}}disabled{{/if}}" data-name="status" data-value="Verified">Approve</button>
               <a href="javascript://"
-                class="undoable btn btn-mini btn-danger change-task-status {{instance._disabled}}"
+                class="undoable btn btn-mini btn-danger change-task-status {{instance._disabled}} {{#if instance.snapshot}}disabled{{/if}}"
                 data-toggle="modal-ajax-form"
                 data-object-singular="CycleTaskEntry"
                 data-object-params='{\
@@ -65,7 +65,7 @@
                 {{#with_mapping 'object_tasks' instance}}
                 <p>
                   If you wish to change the current reviewer, please click
-                  <a href="#task_widget/cycle_task_group_object_task/{{object_tasks.0.instance.id}}">here</a>
+                  <a href="#task_widget/cycle_task_group_object_task/{{object_tasks.0.instance.id}}" class="{{#if instance.snapshot}}disabled{{/if}}">here</a>
                   and change the assignee.
                 </p>
                 {{/with_mapping}}
@@ -76,9 +76,9 @@
               {{#with_mapping_count instance 'current_approval_cycles'}}
                 {{#if_equals count 0}}
                   {{#is_allowed "update" instance}}
-                    <a href="javascript://" class="non-transparent" data-toggle="modal-ajax-approvalform" data-object-singular="{{instance.class.model_singular}}" data-object-id="{{instance.id}}">
+                    <a href="javascript://" class="non-transparent {{#if instance.snapshot}}disabled{{/if}}" data-toggle="modal-ajax-approvalform" data-object-singular="{{instance.class.model_singular}}" data-object-id="{{instance.id}}">
                       <i class="fa fa-check-square-o gray"></i>
-                      Submit For Review
+                      Submit For Review 
                     </a>
                   {{else}}
                     <i>No review in progress</i>


### PR DESCRIPTION
Implemented according to requirements (disable edit functionality for snapshots).
It will not be visible until backend (FEATURE/SNAPSHOT) merged.
<img width="1440" alt="screen shot 2016-11-09 at 15 56 23" src="https://cloud.githubusercontent.com/assets/674129/20139032/246195de-a695-11e6-9164-918d760e2277.png">
