### PR TITLE
GGRC-390 Fix counters and tree are not refreshed after workflow actions

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
@@ -1494,13 +1494,14 @@ CMS.Controllers.TreeLoader('CMS.Controllers.TreeView', {
     return this.page_loader.load({data: [params]})
       .then(function (data) {
         var total = data.total;
+        var countsName = this.options.counts_name || params.object_name;
         this.options.attr('paging.total', total);
         this.options.attr('paging.count',
           Math.ceil(data.total / this.options.paging.pageSize));
 
-        if (!params.filters.expression.right &&
-          total !== queryAPI.getCounts().attr(params.object_name)) {
-          queryAPI.getCounts().attr(params.object_name, total);
+        if (!this.options.paging.filter &&
+          total !== queryAPI.getCounts().attr(countsName)) {
+          queryAPI.getCounts().attr(countsName, total);
         }
         return data.values;
       }.bind(this));

--- a/src/ggrc_workflows/assets/javascripts/apps/workflows.js
+++ b/src/ggrc_workflows/assets/javascripts/apps/workflows.js
@@ -32,10 +32,44 @@
 
   var draftOnUpdateMixin;
 
+  var historyWidgetCountsName = 'cycles:history';
+  var currentWidgetCountsName = 'cycles:active';
+
+  var historyWidgetFilter = {
+    expression: {
+      op: {name: '='},
+      left: 'is_current',
+      right: 0
+    }
+  };
+
+  var currentWidgetFilter = {
+    expression: {
+      op: {name: '='},
+      left: 'is_current',
+      right: 1
+    }
+  };
+
   // Register `workflows` extension with GGRC
   GGRC.extensions.push(WorkflowExtension);
 
   WorkflowExtension.name = 'workflows';
+
+  WorkflowExtension.countsMap = {
+    history: {
+      name: 'Cycle',
+      countsName: historyWidgetCountsName,
+      additionalFilter: historyWidgetFilter
+    },
+    activeCycles: {
+      name: 'Cycle',
+      countsName: currentWidgetCountsName,
+      additionalFilter: currentWidgetFilter
+    },
+    person: 'Person',
+    taskGroup: 'TaskGroup'
+  };
 
   // Register Workflow models for use with `infer_object_type`
   WorkflowExtension.object_type_decision_tree = function () {
@@ -581,15 +615,9 @@
         draw_children: true,
         parent_instance: object,
         model: 'Cycle',
-        counts_name: 'cycles:history',
+        counts_name: historyWidgetCountsName,
         mapping: 'previous_cycles',
-        additional_filter: {
-          expression: {
-            op: {name: '='},
-            left: 'is_current',
-            right: 0
-          }
-        }
+        additional_filter: historyWidgetFilter
       }
     };
 
@@ -604,15 +632,9 @@
         draw_children: true,
         parent_instance: object,
         model: 'Cycle',
-        counts_name: 'cycles:active',
+        counts_name: currentWidgetCountsName,
         mapping: 'current_cycle',
-        additional_filter: {
-          expression: {
-            op: {name: '='},
-            left: 'is_current',
-            right: 1
-          }
-        },
+        additional_filter: currentWidgetFilter,
         header_view: GGRC.mustache_path + '/cycles/tree_header.mustache',
         add_item_view:
           GGRC.mustache_path +
@@ -625,22 +647,10 @@
 
     GGRC.Utils.QueryAPI
       .initCounts([
-        {
-          name: 'Cycle',
-          countsName:
-            historyWidgetDescriptor.content_controller_options.counts_name,
-          additionalFilter:
-            historyWidgetDescriptor.content_controller_options.additional_filter
-        },
-        {
-          name: 'Cycle',
-          countsName:
-            currentWidgetDescriptor.content_controller_options.counts_name,
-          additionalFilter:
-            currentWidgetDescriptor.content_controller_options.additional_filter
-        },
-        'Person',
-        'TaskGroup'
+        WorkflowExtension.countsMap.history,
+        WorkflowExtension.countsMap.activeCycles,
+        WorkflowExtension.countsMap.person,
+        WorkflowExtension.countsMap.taskGroup
       ], {
         type: object.type,
         id: object.id

--- a/src/ggrc_workflows/assets/javascripts/components/end_cycle.js
+++ b/src/ggrc_workflows/assets/javascripts/components/end_cycle.js
@@ -42,6 +42,22 @@
             // items from the list.
             binding.list.splice(0, binding.list.length);
             return binding.loader.refresh_list(binding);
+          })
+          .then(function () {
+            var pageInstance = GGRC.page_instance();
+            var WorkflowExtension =
+              GGRC.extensions.find(function (extension) {
+                return extension.name === 'workflows';
+              });
+
+            $('body').trigger('treeupdate');
+            return GGRC.Utils.QueryAPI
+              .initCounts([
+                WorkflowExtension.countsMap.history
+              ], {
+                type: pageInstance.type,
+                id: pageInstance.id
+              });
           });
       }
     }


### PR DESCRIPTION
This PR fixes issue about widget counters that are not updated after workflow actions: activate workflow, end cycle.
It also fixes issue about active cycles tree is not updated after ending cycle .