### PR TITLE
GGRC-217 Remove hyperlinks from tree view item's fields

### DIFF
--- a/src/ggrc/assets/mustache/base_objects/tree.mustache
+++ b/src/ggrc/assets/mustache/base_objects/tree.mustache
@@ -81,13 +81,7 @@
                               {{/case}}
 
                               {{#default}}
-                                {{#if_helpers '#if_equals' attr_name 'url' 'or #if_equals' attr_name 'reference_url'}}
-                                    <a class="url" href="{{get_url_value attr_name instance}}" target="_blank">
-                                      {{get_default_attr_value attr_name instance}}
-                                    </a>
-                                {{else}}
                                   {{get_default_attr_value attr_name instance}}
-                                {{/if_helpers}}
                               {{/default}}
                             {{/switch}}
                           {{/instance}}


### PR DESCRIPTION
Users encountered a problem when clicking on a tree view item to "select" it and show its info pane.

If an object represented by a tree item had an attribute whose value was rendered with a hyperlink, clicking on that link took the user to different page, even though the intent was to highlight a tree view item. This PR resolves this inconvenience by removing links from tree view items.

To reproduce, open a program and navigate to its Assessments tab. The STATE field showing the Assessment's status is a hyperlink. With the fix applied, you should see that the STATE is not a hyperlink anymore, but instead just a plain text.

P.S.: The issue seems to only affect Assessments, other objects types (e.g. Audits) already had their statuses rendered as plain text.
