### PR TITLE
GGRC-215 Improve performance of /query count queries

### DIFF
--- a/src/ggrc/converters/query_helper.py
+++ b/src/ggrc/converters/query_helper.py
@@ -10,6 +10,7 @@ import collections
 
 import flask
 import sqlalchemy as sa
+from sqlalchemy.orm import undefer
 
 from ggrc import db
 from ggrc import models
@@ -257,6 +258,7 @@ class QueryHelper(object):
       return set()
     object_class = self.object_map[object_name]
     query = object_class.query
+    query = query.options(undefer('updated_at'))
 
     requested_permissions = object_query.get("permissions", "read")
     with benchmark("Get permissions: _get_objects > _get_type_query"):


### PR DESCRIPTION
_get_last_modified function in services/query_helper was fetching the
updated_at column from the database for every object in the loop. For
the object count query on all objects page on grc-test this resulted in
over 14k queries to the database just to fetch the updated_at column
for every object.

I believe this simple code change will reduce the request time for
fetching object counts from minutes to just a couple of seconds at most.

Some quick benchmarks:

In my local env it took 20.12s to load the counts:
![screen shot 2016-11-11 at 13 40 10](https://cloud.githubusercontent.com/assets/513444/20215437/96a1d354-a814-11e6-8088-3a0d82551a06.png)
After the change:
![screen shot 2016-11-11 at 13 39 18](https://cloud.githubusercontent.com/assets/513444/20215464/b7d5f99c-a814-11e6-92b0-b1e3079645e2.png)

grc-test is even worse, it's currently taking 1.7minutes to load the all object page:
![screen shot 2016-11-11 at 13 45 47](https://cloud.githubusercontent.com/assets/513444/20215539/39a72018-a815-11e6-97fc-bd498f31dd5e.png)

I'll post a benchmark for grc-test after this is merged.