### PR TITLE
QUICK-FIX Limit import file dialog to *.csv files

### DIFF
--- a/src/ggrc/assets/mustache/import_export/import.mustache
+++ b/src/ggrc/assets/mustache/import_export/import.mustache
@@ -13,7 +13,9 @@
           download one of the predefined templates.
         </p>
         <div class="clearfix">
-          <input type="file" data-file-upload class="csv-upload" name="upload" style="visibility: hidden; width: 1px; height: 1px" />
+          <input type="file" accept=".csv"
+                 data-file-upload class="csv-upload" name="upload"
+                 style="visibility: hidden; width: 1px; height: 1px" />
           {{#states}}
             <button id="import_btn" {{#isDisabled}}disabled{{/isDisabled}} class="btn btn-large btn-fixed state-{{state}} {{class}}">{{{text}}}</button>
             {{^if_equals state "select"}}


### PR DESCRIPTION
This fix makes picking a CSV file for import more user friendly, because it automatically sets the filter on the browser's select file dialog to `*.csv` files.

Note that this is just a convenience for the user, nothing is enforced on the server, and the user can even select a different file type in the dialog (although I'm not sure if there is a use case for that, but anyway...).