### PR TITLE
GGRC-291 Fix display names of Comment objects

### DIFF
--- a/src/ggrc/assets/javascripts/models/comment.js
+++ b/src/ggrc/assets/javascripts/models/comment.js
@@ -74,6 +74,18 @@
           });
           this.attr('description', ev.oldVal);
         }.bind(this));
+    },
+
+    /**
+     * Return the "name" of the comment as represented to end users.
+     *
+     * If the "value" of the comment (i.e. its description) does not exist,
+     * an empty string is returned.
+     *
+     * @return {String} - an end user-friendly "name" of the comment
+     */
+    display_name: function () {
+      return this.description || '';
     }
   });
 })(window.can, window.GGRC, window.CMS);

--- a/src/ggrc/assets/javascripts/models/tests/comments_model_spec.js
+++ b/src/ggrc/assets/javascripts/models/tests/comments_model_spec.js
@@ -71,4 +71,30 @@ describe('CMS.Models.Comment', function () {
       );
     });
   });
+
+  describe('display_name() method', function () {
+    var fakeComment;
+    var method;
+
+    beforeEach(function () {
+      fakeComment = new can.Map({});
+      method = CMS.Models.Comment.prototype.display_name.bind(fakeComment);
+    });
+
+    it('returns an empty string if comment does not have a description set',
+      function () {
+        var result;
+        fakeComment.attr('description', undefined);
+        result = method();
+        expect(result).toEqual('');
+      }
+    );
+
+    it('returns comment\'s description if the latter exists', function () {
+      var result;
+      fakeComment.attr('description', 'The comment content.');
+      result = method();
+      expect(result).toEqual('The comment content.');
+    });
+  });
 });


### PR DESCRIPTION
This PR fixes the way Comments are displayed in object history logs. The default `display_name()` method as inherited from `can.Model.Cacheable` did not suit them well, thus I overrode it.

Note that there might be a UX problem when displaying lengthy comments in the log, but this is probably out of scope of this PR. We can perhaps open separate ticket to automatically cut off too long texts in the object history log, if we don't already handle such cases.

**Details:**
- Navigate to Assessment tab -> Navigate to Assessment’s Info panel 
- Leave a comment
- Open Assessment Log

**Actual Result:**
comment has (DELETED) status on assessment's log tab after comment's creation (see screenshot)

**Expected Result:**
comment shouldn’t have (deleted) status in log since it wasn't even created yet by that time