### PR TITLE
QUICK-FIX Update integration test framework

### DIFF
--- a/test/integration/ggrc/__init__.py
+++ b/test/integration/ggrc/__init__.py
@@ -60,6 +60,7 @@ class TestCase(BaseTestCase):
         "roles",
         "test_model",
         "contexts",
+        "people",
     )
     tables = set(db.metadata.tables).difference(ignore_tables)
     for _ in range(len(tables)):
@@ -74,6 +75,8 @@ class TestCase(BaseTestCase):
             pass
     contexts = db.metadata.tables["contexts"]
     db.engine.execute(contexts.delete(contexts.c.id > 1))
+    people = db.metadata.tables["people"]
+    db.engine.execute(people.delete(people.c.email != "user@example.com"))
     db.session.commit()
 
   def setUp(self):

--- a/test/integration/ggrc/generator.py
+++ b/test/integration/ggrc/generator.py
@@ -5,7 +5,6 @@
 
 import datetime
 import random
-import string
 
 import names
 
@@ -15,6 +14,7 @@ from ggrc.app import app
 from ggrc.services import common
 from ggrc_basic_permissions import models as permissions_models
 from integration.ggrc import api_helper
+from integration.ggrc.models import factories
 
 
 class Generator(object):
@@ -23,11 +23,6 @@ class Generator(object):
   def __init__(self):
     self.api = api_helper.Api()
     self.resource = common.Resource()
-
-  @staticmethod
-  def random_str(length=8,
-                 chars=string.ascii_uppercase + string.digits + "  _.-"):
-    return ''.join(random.choice(chars) for _ in range(length))
 
   @staticmethod
   def random_date(start=datetime.date.today(), end=None):
@@ -112,7 +107,7 @@ class ObjectGenerator(Generator):
     if add_fields:
       obj_dict[obj_name].update({
           "owners": [self.create_stub(models.Person.query.first())],
-          "title": self.random_str(),
+          "title": factories.random_str(),
       })
     obj_dict[obj_name].update(data)
     return self.generate(obj_class, obj_name, obj_dict)
@@ -252,11 +247,11 @@ class ObjectGenerator(Generator):
     obj_name = "custom_attribute_definition"
     data = {
         obj_name: {
-            "title": kwargs.get("title", self.random_str()),
+            "title": kwargs.get("title", factories.random_str()),
             "custom_attribute_definitions": [],
             "custom_attributes": {},
             "definition_type": definition_type,
-            "modal_title": kwargs.get("modal_title", self.random_str()),
+            "modal_title": kwargs.get("modal_title", factories.random_str()),
             "attribute_type": kwargs.get("attribute_type", "Text"),
             "mandatory": kwargs.get("mandatory", False),
             "helptext": kwargs.get("helptext", None),
@@ -274,7 +269,7 @@ class ObjectGenerator(Generator):
     obj_name = "custom_attribute_value"
     data = {
         obj_name: {
-            "title": kwargs.get("title", self.random_str()),
+            "title": kwargs.get("title", factories.random_str()),
             "custom_attribute_id": custom_attribute_id,
             "attributable_type": attributable.__class__.__name__,
             "attributable_id": attributable.id,

--- a/test/integration/ggrc/models/factories.py
+++ b/test/integration/ggrc/models/factories.py
@@ -13,6 +13,7 @@ use the object generator in the ggrc.generator module.
 # pylint: disable=no-init
 
 import random
+import string
 
 import factory
 
@@ -23,11 +24,9 @@ from ggrc.fulltext import get_indexer
 from ggrc.fulltext.recordbuilder import fts_record_for
 
 
-def random_string(prefix=''):
-  return '{prefix}{suffix}'.format(
-      prefix=prefix,
-      suffix=random.randint(0, 9999999999),
-  )
+def random_str(length=8, prefix="", chars=None):
+  chars = chars or string.ascii_uppercase + string.digits + "  _.-"
+  return prefix + "".join(random.choice(chars) for _ in range(length))
 
 
 class ModelFactory(factory.Factory):
@@ -69,7 +68,7 @@ class ModelFactory(factory.Factory):
 
 
 class TitledFactory(factory.Factory):
-  title = factory.LazyAttribute(lambda m: random_string('title'))
+  title = factory.LazyAttribute(lambda m: random_str(prefix='title'))
 
 
 class CustomAttributeDefinitionFactory(ModelFactory, TitledFactory):
@@ -128,7 +127,7 @@ class ControlCategoryFactory(ModelFactory):
   class Meta:
     model = models.ControlCategory
 
-  name = factory.LazyAttribute(lambda m: random_string('name'))
+  name = factory.LazyAttribute(lambda m: random_str(prefix='name'))
   lft = None
   rgt = None
   scope_id = None
@@ -154,7 +153,7 @@ class ContextFactory(ModelFactory):
     model = models.Context
 
   name = factory.LazyAttribute(
-      lambda obj: random_string("SomeObjectType Context"))
+      lambda obj: random_str(prefix="SomeObjectType Context"))
   related_object = None
 
 
@@ -163,8 +162,8 @@ class ProgramFactory(ModelFactory):
   class Meta:
     model = models.Program
 
-  title = factory.LazyAttribute(lambda _: random_string("program_title"))
-  slug = factory.LazyAttribute(lambda _: random_string(""))
+  title = factory.LazyAttribute(lambda _: random_str(prefix="program_title"))
+  slug = factory.LazyAttribute(lambda _: random_str())
 
 
 class AuditFactory(ModelFactory):
@@ -172,8 +171,8 @@ class AuditFactory(ModelFactory):
   class Meta:
     model = models.Audit
 
-  title = factory.LazyAttribute(lambda _: random_string("audit title "))
-  slug = factory.LazyAttribute(lambda _: random_string(""))
+  title = factory.LazyAttribute(lambda _: random_str(prefix="audit title "))
+  slug = factory.LazyAttribute(lambda _: random_str())
   status = "Planned"
   program_id = factory.LazyAttribute(lambda _: ProgramFactory().id)
   context_id = factory.LazyAttribute(lambda _: ContextFactory().id)
@@ -196,11 +195,11 @@ class AssessmentTemplateFactory(ModelFactory):
     model = models.AssessmentTemplate
 
   title = factory.LazyAttribute(
-      lambda _: random_string("assessment template title"))
+      lambda _: random_str(prefix="assessment template title"))
   template_object_type = None
   test_plan_procedure = False
   procedure_description = factory.LazyAttribute(
-      lambda _: random_string("lorem ipsum description"))
+      lambda _: random_str(length=100))
   default_people = {"assessors": "Object Owners",
                     "verifiers": "Object Owners"}
 

--- a/test/integration/ggrc/models/factories.py
+++ b/test/integration/ggrc/models/factories.py
@@ -47,27 +47,27 @@ class ModelFactory(factory.Factory):
     indexer = get_indexer()
     db.session.flush()
     user = cls._get_user()
-    revision = models.Revision(instance, user.id, 'created', instance.log_json())
+    revision = models.Revision(
+        instance, user.id, 'created', instance.log_json())
     event = models.Event(
         modified_by=user,
         action="POST",
         resource_id=instance.id,
         resource_type=instance.type,
         context=instance.context,
-        revisions = [revision],
+        revisions=[revision],
     )
     db.session.add(revision)
     db.session.add(event)
     indexer.update_record(fts_record_for(instance), commit=False)
-
 
   @staticmethod
   def _get_user():
     user = models.Person.query.first()
     if not user:
       user = models.Person(
-        name=noop.default_user_name,
-        email=noop.default_user_email,
+          name=noop.default_user_name,
+          email=noop.default_user_email,
       )
       db.session.add(user)
       db.session.flush()

--- a/test/integration/ggrc/models/factories.py
+++ b/test/integration/ggrc/models/factories.py
@@ -67,11 +67,11 @@ class ModelFactory(factory.Factory):
     return user
 
 
-class TitledFactory(factory.Factory):
-  title = factory.LazyAttribute(lambda m: random_str(prefix='title'))
+class TitledFactory(ModelFactory):
+  title = factory.LazyAttribute(lambda m: random_str(prefix='title '))
 
 
-class CustomAttributeDefinitionFactory(ModelFactory, TitledFactory):
+class CustomAttributeDefinitionFactory(TitledFactory):
 
   class Meta:
     model = models.CustomAttributeDefinition
@@ -94,13 +94,13 @@ class CustomAttributeValueFactory(ModelFactory):
   attribute_object_id = None
 
 
-class DirectiveFactory(ModelFactory, TitledFactory):
+class DirectiveFactory(TitledFactory):
 
   class Meta:
     model = models.Directive
 
 
-class ControlFactory(ModelFactory, TitledFactory):
+class ControlFactory(TitledFactory):
 
   class Meta:
     model = models.Control
@@ -116,7 +116,7 @@ class ControlFactory(ModelFactory, TitledFactory):
   notes = None
 
 
-class AssessmentFactory(ModelFactory, TitledFactory):
+class AssessmentFactory(TitledFactory):
 
   class Meta:
     model = models.Assessment
@@ -157,25 +157,20 @@ class ContextFactory(ModelFactory):
   related_object = None
 
 
-class ProgramFactory(ModelFactory):
+class ProgramFactory(TitledFactory):
 
   class Meta:
     model = models.Program
 
-  title = factory.LazyAttribute(lambda _: random_str(prefix="program_title"))
-  slug = factory.LazyAttribute(lambda _: random_str())
 
-
-class AuditFactory(ModelFactory):
+class AuditFactory(TitledFactory):
 
   class Meta:
     model = models.Audit
 
-  title = factory.LazyAttribute(lambda _: random_str(prefix="audit title "))
-  slug = factory.LazyAttribute(lambda _: random_str())
   status = "Planned"
-  program_id = factory.LazyAttribute(lambda _: ProgramFactory().id)
-  context_id = factory.LazyAttribute(lambda _: ContextFactory().id)
+  program = factory.LazyAttribute(lambda _: ProgramFactory())
+  context = factory.LazyAttribute(lambda _: ContextFactory())
 
 
 class SnapshotFactory(ModelFactory):
@@ -189,13 +184,11 @@ class SnapshotFactory(ModelFactory):
   revision_id = 0
 
 
-class AssessmentTemplateFactory(ModelFactory):
+class AssessmentTemplateFactory(TitledFactory):
 
   class Meta:
     model = models.AssessmentTemplate
 
-  title = factory.LazyAttribute(
-      lambda _: random_str(prefix="assessment template title"))
   template_object_type = None
   test_plan_procedure = False
   procedure_description = factory.LazyAttribute(
@@ -259,13 +252,13 @@ class ObjectDocumentFactory(ModelFactory):
     model = models.ObjectDocument
 
 
-class RegulationFactory(ModelFactory, TitledFactory):
+class RegulationFactory(TitledFactory):
 
   class Meta:
     model = models.Regulation
 
 
-class RequestFactory(ModelFactory, TitledFactory):
+class RequestFactory(TitledFactory):
 
   class Meta:
     model = models.Request
@@ -273,25 +266,25 @@ class RequestFactory(ModelFactory, TitledFactory):
   request_type = "documentation"
 
 
-class OrgGroupFactory(ModelFactory, TitledFactory):
+class OrgGroupFactory(TitledFactory):
 
   class Meta:
-    model = models.Regulation
+    model = models.OrgGroup
 
 
-class ProcessFactory(ModelFactory, TitledFactory):
-
-  class Meta:
-    model = models.Regulation
-
-
-class PolicyFactory(ModelFactory, TitledFactory):
+class ProcessFactory(TitledFactory):
 
   class Meta:
-    model = models.Regulation
+    model = models.Process
 
 
-class MarketFactory(ModelFactory, TitledFactory):
+class PolicyFactory(TitledFactory):
 
   class Meta:
-    model = models.Regulation
+    model = models.Policy
+
+
+class MarketFactory(TitledFactory):
+
+  class Meta:
+    model = models.Market

--- a/test/integration/ggrc_basic_permissions/test_creator_audit.py
+++ b/test/integration/ggrc_basic_permissions/test_creator_audit.py
@@ -11,6 +11,7 @@ from integration.ggrc import TestCase
 from integration.ggrc.api_helper import Api
 from integration.ggrc.generator import Generator
 from integration.ggrc.generator import ObjectGenerator
+from integration.ggrc.models import factories
 
 
 class TestCreatorAudit(TestCase):
@@ -145,7 +146,7 @@ class TestCreatorAudit(TestCase):
     test_case = self.test_cases[test_case_name]
     editor = self.people.get('editor')
     self.api.set_user(editor)
-    random_title = self.object_generator.random_str()
+    random_title = factories.random_str()
     response = self.api.post(all_models.Program, {
         "program": {"title": random_title, "context": None},
     })
@@ -166,7 +167,7 @@ class TestCreatorAudit(TestCase):
     self.objects["audit"] = all_models.Audit.query.get(audit_id)
 
     for prefix in ("mapped", "unrelated"):
-      random_title = self.object_generator.random_str()
+      random_title = factories.random_str()
 
       response = self.api.post(all_models.Issue, {
           "issue": {"title": random_title, "context": None},

--- a/test/integration/ggrc_basic_permissions/test_creator_program.py
+++ b/test/integration/ggrc_basic_permissions/test_creator_program.py
@@ -5,12 +5,13 @@
 Test Creator role with Program scoped roles
 """
 
-from integration.ggrc import TestCase
+from ggrc import db
 from ggrc.models import all_models
+from integration.ggrc import TestCase
 from integration.ggrc.api_helper import Api
 from integration.ggrc.generator import Generator
 from integration.ggrc.generator import ObjectGenerator
-from ggrc import db
+from integration.ggrc.models import factories
 
 
 class TestCreatorProgram(TestCase):
@@ -191,7 +192,7 @@ class TestCreatorProgram(TestCase):
     test_case = self.test_cases[test_case_name]
     creator = self.people.get('creator')
     self.api.set_user(creator)
-    random_title = self.object_generator.random_str()
+    random_title = factories.random_str()
     response = self.api.post(all_models.Program, {
         "program": {"title": random_title, "context": None},
     })
@@ -201,7 +202,7 @@ class TestCreatorProgram(TestCase):
     self.objects["program"] = all_models.Program.query.get(program_id)
     # Create an object:
     for obj in ("mapped_object", "unrelated"):
-      random_title = self.object_generator.random_str()
+      random_title = factories.random_str()
       response = self.api.post(all_models.System, {
           "system": {"title": random_title, "context": None},
       })

--- a/test/integration/ggrc_workflows/generator.py
+++ b/test/integration/ggrc_workflows/generator.py
@@ -1,14 +1,20 @@
 # Copyright (C) 2016 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
-from datetime import date
-from ggrc import db
-from ggrc import builder
-from ggrc_workflows.models import (Workflow, TaskGroup, TaskGroupTask,
-                                   TaskGroupObject, Cycle)
-from integration.ggrc.generator import Generator
 import random
 import copy
+
+from datetime import date
+
+from ggrc import db
+from ggrc import builder
+from ggrc_workflows.models import Cycle
+from ggrc_workflows.models import TaskGroup
+from ggrc_workflows.models import TaskGroupObject
+from ggrc_workflows.models import TaskGroupTask
+from ggrc_workflows.models import Workflow
+from integration.ggrc.generator import Generator
+from integration.ggrc.models import factories
 
 
 class WorkflowsGenerator(Generator):
@@ -22,7 +28,7 @@ class WorkflowsGenerator(Generator):
 
     tgs = data.pop("task_groups", [])
 
-    wf = Workflow(title="wf " + self.random_str())
+    wf = Workflow(title="wf " + factories.random_str())
     obj_dict = self.obj_to_dict(wf, obj_name)
     obj_dict[obj_name].update(data)
 
@@ -45,7 +51,7 @@ class WorkflowsGenerator(Generator):
     workflow = self._session_add(workflow)
 
     tg = TaskGroup(
-      title="tg " + self.random_str(),
+      title="tg " + factories.random_str(),
       workflow_id=workflow.id,
       context_id=workflow.context.id,
       contact_id=1
@@ -76,7 +82,7 @@ class WorkflowsGenerator(Generator):
     tgt = TaskGroupTask(
       task_group_id=task_group.id,
       context_id=task_group.context.id,
-      title="tgt " + self.random_str(),
+      title="tgt " + factories.random_str(),
       start_date=default_start,
       end_date=default_end,
       relative_start_day=random.randrange(1, day_range),

--- a/test/integration/ggrc_workflows/generator.py
+++ b/test/integration/ggrc_workflows/generator.py
@@ -51,10 +51,10 @@ class WorkflowsGenerator(Generator):
     workflow = self._session_add(workflow)
 
     tg = TaskGroup(
-      title="tg " + factories.random_str(),
-      workflow_id=workflow.id,
-      context_id=workflow.context.id,
-      contact_id=1
+        title="tg " + factories.random_str(),
+        workflow_id=workflow.id,
+        context_id=workflow.context.id,
+        contact_id=1
     )
     obj_dict = self.obj_to_dict(tg, obj_name)
     obj_dict[obj_name].update(data)
@@ -80,16 +80,16 @@ class WorkflowsGenerator(Generator):
     obj_name = "task_group_task"
 
     tgt = TaskGroupTask(
-      task_group_id=task_group.id,
-      context_id=task_group.context.id,
-      title="tgt " + factories.random_str(),
-      start_date=default_start,
-      end_date=default_end,
-      relative_start_day=random.randrange(1, day_range),
-      relative_start_month=random.randrange(1, 12),
-      relative_end_day=random.randrange(1, day_range),
-      relative_end_month=random.randrange(1, 12),
-      contact_id=1
+        task_group_id=task_group.id,
+        context_id=task_group.context.id,
+        title="tgt " + factories.random_str(),
+        start_date=default_start,
+        end_date=default_end,
+        relative_start_day=random.randrange(1, day_range),
+        relative_start_month=random.randrange(1, 12),
+        relative_end_day=random.randrange(1, day_range),
+        relative_end_month=random.randrange(1, 12),
+        contact_id=1
     )
     obj_dict = self.obj_to_dict(tgt, obj_name)
     obj_dict[obj_name].update(data)
@@ -105,10 +105,10 @@ class WorkflowsGenerator(Generator):
     obj_name = "task_group_object"
 
     tgo = TaskGroupObject(
-      object_id=obj.id,
-      object=obj,
-      task_group_id=task_group.id,
-      context_id=task_group.context.id
+        object_id=obj.id,
+        object=obj,
+        task_group_id=task_group.id,
+        context_id=task_group.context.id
     )
     obj_dict = self.obj_to_dict(tgo, obj_name)
 
@@ -123,19 +123,19 @@ class WorkflowsGenerator(Generator):
     obj_name = "cycle"
 
     obj_dict = {
-      obj_name: {
-        "workflow": {
-          "id": workflow.id,
-          "type": workflow.__class__.__name__,
-          "href": "/api/workflows/%d" % workflow.id
-        },
-        "context": {
-          "id": workflow.context.id,
-          "type": workflow.context.__class__.__name__,
-          "href": "/api/workflows/%d" % workflow.context.id
-        },
-        "autogenerate": "true"
-      }
+        obj_name: {
+            "workflow": {
+                "id": workflow.id,
+                "type": workflow.__class__.__name__,
+                "href": "/api/workflows/%d" % workflow.id
+            },
+            "context": {
+                "id": workflow.context.id,
+                "type": workflow.context.__class__.__name__,
+                "href": "/api/workflows/%d" % workflow.context.id
+            },
+            "autogenerate": "true"
+        }
     }
 
     return self.generate(Cycle, obj_name, obj_dict)
@@ -143,8 +143,8 @@ class WorkflowsGenerator(Generator):
   def activate_workflow(self, workflow):
     workflow = self._session_add(workflow)
     return self.modify_workflow(workflow, {
-      "status": "Active",
-      "recurrences": workflow.frequency != "one_time"
+        "status": "Active",
+        "recurrences": workflow.frequency != "one_time"
     })
 
   def modify_workflow(self, wf=None, data={}):

--- a/test/integration/ggrc_workflows/models/factories.py
+++ b/test/integration/ggrc_workflows/models/factories.py
@@ -10,7 +10,7 @@ from integration.ggrc.models.factories import ModelFactory
 from integration.ggrc.models.factories import TitledFactory
 
 
-class WorkflowFactory(ModelFactory, TitledFactory):
+class WorkflowFactory(TitledFactory):
 
   class Meta:
     model = models.Workflow
@@ -18,7 +18,7 @@ class WorkflowFactory(ModelFactory, TitledFactory):
   frequency = "one_time"
 
 
-class TaskGroupFactory(ModelFactory, TitledFactory):
+class TaskGroupFactory(TitledFactory):
 
   class Meta:
     model = models.TaskGroup
@@ -36,7 +36,7 @@ class TaskGroupObjectFactory(ModelFactory):
   object_type = ""
 
 
-class TaskGroupTaskFactory(ModelFactory, TitledFactory):
+class TaskGroupTaskFactory(TitledFactory):
 
   class Meta:
     model = models.TaskGroupTask
@@ -45,7 +45,7 @@ class TaskGroupTaskFactory(ModelFactory, TitledFactory):
   task_type = "text"
 
 
-class CycleFactory(ModelFactory, TitledFactory):
+class CycleFactory(TitledFactory):
 
   class Meta:
     model = models.Cycle
@@ -53,7 +53,7 @@ class CycleFactory(ModelFactory, TitledFactory):
   workflow = factory.SubFactory(WorkflowFactory)
 
 
-class CycleTaskGroupFactory(ModelFactory, TitledFactory):
+class CycleTaskGroupFactory(TitledFactory):
 
   class Meta:
     model = models.CycleTaskGroup
@@ -61,7 +61,7 @@ class CycleTaskGroupFactory(ModelFactory, TitledFactory):
   cycle = factory.SubFactory(CycleFactory)
 
 
-class CycleTaskFactory(ModelFactory, TitledFactory):
+class CycleTaskFactory(TitledFactory):
 
   class Meta:
     model = models.CycleTaskGroupObjectTask

--- a/test/integration/ggrc_workflows/notifications/test_cycle_start_failed_notifications.py
+++ b/test/integration/ggrc_workflows/notifications/test_cycle_start_failed_notifications.py
@@ -11,6 +11,7 @@ from ggrc.models import Notification
 from integration.ggrc_workflows.generator import WorkflowsGenerator
 from integration.ggrc.api_helper import Api
 from integration.ggrc.generator import ObjectGenerator
+from integration.ggrc.models import factories
 
 
 class TestCycleStartFailed(TestCase):
@@ -168,7 +169,7 @@ class TestCycleStartFailed(TestCase):
             "contact": person_dict(self.user.id),
             "task_group_tasks": [{
                 "contact": person_dict(self.user.id),
-                "description": self.wf_generator.random_str(100),
+                "description": factories.random_str(100),
                 "relative_start_day": 5,
                 "relative_start_month": 2,
                 "relative_end_day": 25,
@@ -189,7 +190,7 @@ class TestCycleStartFailed(TestCase):
             "contact": person_dict(self.user.id),
             "task_group_tasks": [{
                 "contact": person_dict(self.user.id),
-                "description": self.wf_generator.random_str(100),
+                "description": factories.random_str(100),
                 "relative_start_day": 14,
                 "relative_end_day": 25,
             },

--- a/test/integration/ggrc_workflows/notifications/test_deleted_objects.py
+++ b/test/integration/ggrc_workflows/notifications/test_deleted_objects.py
@@ -12,6 +12,7 @@ from ggrc_workflows.models import Workflow
 from integration.ggrc_workflows.generator import WorkflowsGenerator
 from integration.ggrc.api_helper import Api
 from integration.ggrc.generator import ObjectGenerator
+from integration.ggrc.models import factories
 
 
 class TestNotificationsForDeletedObjects(TestCase):
@@ -90,7 +91,7 @@ class TestNotificationsForDeletedObjects(TestCase):
             "contact": person_dict(self.user.id),
             "task_group_tasks": [{
                 "contact": person_dict(self.user.id),
-                "description": self.wf_generator.random_str(100),
+                "description": factories.random_str(100),
                 "relative_start_day": 5,
                 "relative_start_month": 2,
                 "relative_end_day": 25,

--- a/test/integration/ggrc_workflows/notifications/test_enable_disable_notifications.py
+++ b/test/integration/ggrc_workflows/notifications/test_enable_disable_notifications.py
@@ -11,6 +11,7 @@ from ggrc import models
 from integration.ggrc_workflows.generator import WorkflowsGenerator
 from integration.ggrc.api_helper import Api
 from integration.ggrc.generator import ObjectGenerator
+from integration.ggrc.models import factories
 
 
 class TestEnableAndDisableNotifications(TestCase):
@@ -173,7 +174,7 @@ class TestEnableAndDisableNotifications(TestCase):
             "contact": person_dict(self.user.id),
             "task_group_tasks": [{
                 "contact": person_dict(self.user.id),
-                "description": self.wf_generator.random_str(100),
+                "description": factories.random_str(100),
                 "relative_start_day": 5,
                 "relative_start_month": 2,
                 "relative_end_day": 25,
@@ -194,7 +195,7 @@ class TestEnableAndDisableNotifications(TestCase):
             "contact": person_dict(self.user.id),
             "task_group_tasks": [{
                 "contact": person_dict(self.user.id),
-                "description": self.wf_generator.random_str(100),
+                "description": factories.random_str(100),
                 "relative_start_day": 5,
                 "relative_start_month": 2,
                 "relative_end_day": 25,

--- a/test/integration/ggrc_workflows/notifications/test_recurring_cycles.py
+++ b/test/integration/ggrc_workflows/notifications/test_recurring_cycles.py
@@ -11,6 +11,7 @@ from ggrc.models import Person
 from integration.ggrc_workflows.generator import WorkflowsGenerator
 from integration.ggrc.api_helper import Api
 from integration.ggrc.generator import ObjectGenerator
+from integration.ggrc.models import factories
 
 
 class TestRecurringCycleNotifications(TestCase):
@@ -96,7 +97,7 @@ class TestRecurringCycleNotifications(TestCase):
             "contact": person_dict(self.assignee.id),
             "task_group_tasks": [{
                 "contact": person_dict(self.assignee.id),
-                "description": self.generator.random_str(100),
+                "description": factories.random_str(100),
                 "relative_start_day": 5,
                 "relative_start_month": 2,
                 "relative_end_day": 25,

--- a/test/integration/ggrc_workflows/test_basic_workflow_actions.py
+++ b/test/integration/ggrc_workflows/test_basic_workflow_actions.py
@@ -13,6 +13,7 @@ from integration.ggrc import TestCase
 from integration.ggrc_workflows.generator import WorkflowsGenerator
 from integration.ggrc.api_helper import Api
 from integration.ggrc.generator import ObjectGenerator
+from integration.ggrc.models import factories
 
 
 class TestBasicWorkflowActions(TestCase):
@@ -131,19 +132,19 @@ class TestBasicWorkflowActions(TestCase):
         "task_groups": [{
             "title": "tg_1",
             "task_group_tasks": [{
-                "description": self.generator.random_str(100),
+                "description": factories.random_str(100),
                 "relative_start_day": 5,
                 "relative_start_month": 1,
                 "relative_end_day": 25,
                 "relative_end_month": 2,
             }, {
-                "description": self.generator.random_str(100),
+                "description": factories.random_str(100),
                 "relative_start_day": 15,
                 "relative_start_month": 2,
                 "relative_end_day": 28,
                 "relative_end_month": 2,
             }, {
-                "description": self.generator.random_str(100),
+                "description": factories.random_str(100),
                 "relative_start_day": 1,
                 "relative_start_month": 1,
                 "relative_end_day": 1,
@@ -161,7 +162,7 @@ class TestBasicWorkflowActions(TestCase):
         "task_groups": [{
             "title": "tg_2",
             "task_group_tasks": [{
-                "description": self.generator.random_str(100),
+                "description": factories.random_str(100),
                 "relative_end_day": 1,
                 "relative_end_month": None,
                 "relative_start_day": 5,
@@ -194,7 +195,7 @@ class TestBasicWorkflowActions(TestCase):
         }, {
             "title": "tg_2",
             "task_group_tasks": [{
-                "description": self.generator.random_str(100)
+                "description": factories.random_str(100)
             }, {}
             ],
             "task_group_objects": self.random_objects[:2]
@@ -202,13 +203,13 @@ class TestBasicWorkflowActions(TestCase):
             "title": "tg_3",
             "task_group_tasks": [{
                 "title": "simple task 1",
-                "description": self.generator.random_str(100)
+                "description": factories.random_str(100)
             }, {
-                "title": self.generator.random_str(),
-                "description": self.generator.random_str(100)
+                "title": factories.random_str(),
+                "description": factories.random_str(100)
             }, {
-                "title": self.generator.random_str(),
-                "description": self.generator.random_str(100)
+                "title": factories.random_str(),
+                "description": factories.random_str(100)
             }
             ],
             "task_group_objects": self.random_objects
@@ -226,7 +227,7 @@ class TestBasicWorkflowActions(TestCase):
             {
                 "title": "tg_2",
                 "task_group_tasks": [{
-                    "description": self.generator.random_str(100)
+                    "description": factories.random_str(100)
                 }, {}],
                 "task_group_objects": self.random_objects[:2]
             },
@@ -234,13 +235,13 @@ class TestBasicWorkflowActions(TestCase):
                 "title": "tg_3",
                 "task_group_tasks": [{
                     "title": "simple task 1",
-                    "description": self.generator.random_str(100)
+                    "description": factories.random_str(100)
                 }, {
-                    "title": self.generator.random_str(),
-                    "description": self.generator.random_str(100)
+                    "title": factories.random_str(),
+                    "description": factories.random_str(100)
                 }, {
-                    "title": self.generator.random_str(),
-                    "description": self.generator.random_str(100)
+                    "title": factories.random_str(),
+                    "description": factories.random_str(100)
                 }],
                 "task_group_objects": []
             }
@@ -255,7 +256,7 @@ class TestBasicWorkflowActions(TestCase):
             {
                 "title": "tg_2",
                 "task_group_tasks": [{
-                     "description": self.generator.random_str(100),
+                     "description": factories.random_str(100),
                      "relative_end_day": 1,
                      "relative_end_month": None,
                      "relative_start_day": 5,


### PR DESCRIPTION
The object generator for testing added a default owners and title fields
to posted data. On objects that do not have these fields such as
Comments and Relationships this caused an error. The second bug that hid
that error was that owners contained invalid data unless the test was
run on a clean database with a person with id 1.

The first commit fixes both of the above issues.
To test this issue just run the following commands on develop and on this PR.
```bash
$ cd test/
$ db_reset 
$ nosetests integration.ggrc.notifications.test_comment_notifications:TestCommentNotification.test_notification_entries
```

The rest of the commits just organize and clean up the testing code.