### PR TITLE
QUICK-FIX Hide 'Update Scope' menu item if object not is_snapshotable

### DIFF
--- a/src/ggrc/assets/mustache/base_objects/dropdown_menu.mustache
+++ b/src/ggrc/assets/mustache/base_objects/dropdown_menu.mustache
@@ -18,15 +18,15 @@
   </a>
   <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
     {{#is_allowed 'update' instance context='for'}}    
-      
-      <li>
-        <snapshot-scope-update instance="instance">
-          <a href="javascript://" can-click="upsertIt">
-            <i class="fa fa-refresh"></i>
-            Update objects to latest version</a>
-        </snapshot-scope-update>
-      </li>
-
+      {{#if instance.is_snapshotable}}
+        <li>
+          <snapshot-scope-update instance="instance">
+            <a href="javascript://" can-click="upsertIt">
+              <i class="fa fa-refresh"></i>
+              Update objects to latest version</a>
+          </snapshot-scope-update>
+        </li>
+      {{/if}}
       {{> /static/mustache/base_objects/edit_object_link.mustache}}
     {{/is_allowed}}
 


### PR DESCRIPTION
Regression issue, this menu item still should not be visible for Audit (without snapshot backend).