### PR TITLE
[FEATURE/SNAPSHOTS] Core snapshot generator

### DIFF
--- a/src/ggrc/app.py
+++ b/src/ggrc/app.py
@@ -12,7 +12,7 @@ from flask.ext.sqlalchemy import get_debug_queries
 from flask.ext.sqlalchemy import SQLAlchemy
 from tabulate import tabulate
 
-from ggrc import contributions  # noqa: imported so it can be used with getattr
+from ggrc import contributions  # noqa: imported so it can be used with getattr  # pylint: disable=unused-import
 from ggrc import db
 from ggrc import extensions
 from ggrc import notifications

--- a/src/ggrc/app.py
+++ b/src/ggrc/app.py
@@ -101,8 +101,11 @@ def init_permissions_provider():
 
 
 def init_extra_listeners():
+  """Initializes listeners for additional services"""
   from ggrc.automapper import register_automapping_listeners
+  from ggrc.snapshotter.listeners import register_snapshot_listeners
   register_automapping_listeners()
+  register_snapshot_listeners()
 
 
 def _enable_debug_toolbar():

--- a/src/ggrc/models/audit.py
+++ b/src/ggrc/models/audit.py
@@ -18,9 +18,10 @@ from ggrc.models.reflection import AttributeInfo
 from ggrc.models.reflection import PublishOnly
 from ggrc.models.program import Program
 from ggrc.models.person import Person
+from ggrc.models.snapshot import Snapshotable
 
 
-class Audit(clonable.Clonable,
+class Audit(Snapshotable, clonable.Clonable,
             CustomAttributable, Personable, HasOwnContext, Relatable,
             Timeboxed, Noted, Described, Hyperlinked, WithContact, Titled,
             Slugged, db.Model):

--- a/src/ggrc/snapshotter/__init__.py
+++ b/src/ggrc/snapshotter/__init__.py
@@ -1,2 +1,458 @@
 # Copyright (C) 2016 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Main snapshotter module
+
+Snapshotter creates an immutable scope around an object (e.g. Audit) where
+snapshot object represent a join between parent object (Audit),
+child object (e.g. Control, Regulation, ...) and a particular revision.
+"""
+
+
+from sqlalchemy.sql.expression import tuple_
+from sqlalchemy.sql.expression import bindparam
+
+from ggrc import db
+from ggrc import models
+from ggrc.login import get_current_user_id
+from ggrc.utils import benchmark
+
+from ggrc.snapshotter.datastructures import Attr
+from ggrc.snapshotter.datastructures import Pair
+from ggrc.snapshotter.datastructures import Stub
+from ggrc.snapshotter.datastructures import OperationResponse
+from ggrc.snapshotter.helpers import create_relationship_dict
+from ggrc.snapshotter.helpers import create_relationship_revision_dict
+from ggrc.snapshotter.helpers import create_snapshot_dict
+from ggrc.snapshotter.helpers import create_snapshot_revision_dict
+from ggrc.snapshotter.helpers import get_relationships
+from ggrc.snapshotter.helpers import get_revisions
+from ggrc.snapshotter.helpers import get_snapshots
+from ggrc.snapshotter.indexer import reindex_pairs
+
+from ggrc.snapshotter.rules import get_rules
+
+
+class SnapshotGenerator(object):
+  """Geneate snapshots per rules of all connected objects"""
+
+  def __init__(self, dry_run):
+    self.rules = get_rules()
+
+    self.parents = set()
+    self.children = set()
+    self.snapshots = dict()
+    self.context_cache = dict()
+    self.dry_run = dry_run
+
+  def add_parent(self, obj):
+    """Add parent object and automatically scan neighborhood for snapshottable
+    objects."""
+    with benchmark("Snapshot.add_parent_object"):
+      key = Stub.from_object(obj)
+      if key not in self.parents:
+        with benchmark("Snapshot.add_parent_object.add object"):
+          objs = self._get_snapshottable_objects(obj)
+          self.parents.add(key)
+          self.context_cache[key] = obj.context_id
+          self.children = self.children | objs
+          self.snapshots[key] = objs
+      return self.parents
+
+  def add_family(self, parent, children):
+    """Directly add parent object and children that should be snapshotted."""
+    _type, _id = parent
+    model = getattr(models, _type)
+    parent_object = db.session.query(model).filter(model.id == _id).one()
+    self.parents.add(parent)
+    self.snapshots[parent] = children
+    self.children = children
+    self.context_cache[parent] = parent_object.context_id
+
+  def _fetch_neighborhood(self, parent_object, objects):
+    with benchmark("Snapshot._fetch_object_neighborhood"):
+      query_pairs = set()
+
+      for obj in objects:
+        for snd_obj in self.rules.rules[parent_object.type]["snd"]:
+          query_pairs.add((obj.type, obj.id, snd_obj))
+
+      columns = db.session.query(
+          models.Relationship.source_type,
+          models.Relationship.source_id,
+          models.Relationship.destination_type,
+          models.Relationship.destination_id)
+
+      relationships = columns.filter(
+          tuple_(
+              models.Relationship.destination_type,
+              models.Relationship.destination_id,
+              models.Relationship.source_type,
+          ).in_(query_pairs)).union(
+          columns.filter(tuple_(
+              models.Relationship.source_type,
+              models.Relationship.source_id,
+              models.Relationship.destination_type,
+          ).in_(query_pairs)))
+
+      neighborhood = set()
+      for (stype, sid, dtype, did) in relationships:
+        source = Stub(stype, sid)
+        destination = Stub(dtype, did)
+
+        if source in objects:
+          neighborhood.add(destination)
+        else:
+          neighborhood.add(source)
+      return neighborhood
+
+  def _get_snapshottable_objects(self, obj):
+    """Get snapshottable objects from parent object's neighborhood."""
+    with benchmark("Snapshot._get_snapshotable_objects"):
+      object_rules = self.rules.rules[obj.type]
+
+      with benchmark("Snapshot._get_snapshotable_objects.related_mappings"):
+        related_mappings = obj.related_objects({
+            rule for rule in object_rules["fst"]
+            if isinstance(rule, basestring)})
+
+      with benchmark("Snapshot._get_snapshotable_objects.direct mappings"):
+        direct_mappings = {getattr(obj, rule.name)
+                           for rule in object_rules["fst"]
+                           if isinstance(rule, Attr)}
+
+      related_objects = {Stub.from_object(obj)
+                         for obj in related_mappings | direct_mappings}
+
+      with benchmark("Snapshot._get_snapshotable_objects.fetch neighborhood"):
+        return self._fetch_neighborhood(obj, related_objects)
+
+  def update(self, event, revisions, _filter=None):
+    """Update parent object's snapshots."""
+    _, for_update = self.analyze()
+    result = self._update(for_update=for_update, event=event,
+                          revisions=revisions, _filter=_filter)
+    updated = result.response
+    if not self.dry_run:
+      reindex_pairs(updated)
+    return result
+
+  def _update(self, for_update, event, revisions, _filter):
+    """Update (or create) parent objects' snapshots and create revisions for
+    them.
+
+    Args:
+      event: A ggrc.models.Event instance
+      revisions: A set of tuples of pairs with revisions to which it should
+        either create or update a snapshot of that particular audit
+      _filter: Callable that should return True if it should be updated
+    Returns:
+      OperationResponse
+    """
+    # pylint: disable=too-many-locals
+    with benchmark("Snapshot._update"):
+      user_id = get_current_user_id()
+      missed_keys = set()
+      snapshot_cache = dict()
+      modified_snapshot_keys = set()
+      data_payload_update = list()
+      revision_payload = list()
+      response_data = dict()
+
+      if self.dry_run and event is None:
+        event_id = 0
+      else:
+        event_id = event.id
+
+      with benchmark("Snapshot._update.filter"):
+        if _filter:
+          for_update = {elem for elem in for_update if _filter(elem)}
+
+      with benchmark("Snapshot._update.get existing snapshots"):
+        existing_snapshots = db.session.query(
+            models.Snapshot.id,
+            models.Snapshot.revision_id,
+            models.Snapshot.parent_type,
+            models.Snapshot.parent_id,
+            models.Snapshot.child_type,
+            models.Snapshot.child_id,
+        ).filter(tuple_(
+            models.Snapshot.parent_type, models.Snapshot.parent_id,
+            models.Snapshot.child_type, models.Snapshot.child_id
+        ).in_({pair.to_4tuple() for pair in for_update}))
+
+        for esnap in existing_snapshots:
+          sid, rev_id, pair_tuple = esnap[0], esnap[1], esnap[2:]
+          pair = Pair.from_4tuple(pair_tuple)
+          snapshot_cache[pair] = (sid, rev_id)
+
+      with benchmark("Snapshot._update.retrieve latest revisions"):
+        revision_id_cache = get_revisions(
+            for_update,
+            filters=[models.Revision.action.in_(["created", "modified"])],
+            revisions=revisions)
+
+      response_data["revisions"] = {
+          "old": {pair: values[1] for pair, values in snapshot_cache.items()},
+          "new": revision_id_cache
+      }
+
+      with benchmark("Snapshot._update.build snapshot payload"):
+        for key in for_update:
+          if key in revision_id_cache:
+            sid, rev_id = snapshot_cache[key]
+            latest_rev = revision_id_cache[key]
+            if rev_id != latest_rev:
+              modified_snapshot_keys.add(key)
+              data_payload_update += [{
+                  "_id": sid,
+                  "_revision_id": latest_rev,
+                  "_modified_by_id": user_id
+              }]
+          else:
+            missed_keys.add(key)
+
+      if not modified_snapshot_keys:
+        return OperationResponse("update", True, set(), response_data)
+
+      with benchmark("Snapshot._update.write snapshots to database"):
+        update_sql = models.Snapshot.__table__.update().where(
+            models.Snapshot.id == bindparam("_id")).values(
+            revision_id=bindparam("_revision_id"),
+            modified_by_id=bindparam("_modified_by_id"))
+        self._execute(update_sql, data_payload_update)
+
+      with benchmark("Snapshot._update.retrieve inserted snapshots"):
+        snapshots = get_snapshots(modified_snapshot_keys)
+
+      with benchmark("Snapshot._update.create snapshots revision payload"):
+        for snapshot in snapshots:
+          parent = Stub.from_tuple(snapshot, 4, 5)
+          context_id = self.context_cache[parent]
+          data = create_snapshot_revision_dict("modified", event_id, snapshot,
+                                               user_id, context_id)
+          revision_payload += [data]
+
+      with benchmark("Insert Snapshot entries into Revision"):
+        self._execute(models.Revision.__table__.insert(), revision_payload)
+      return OperationResponse("update", True, for_update, response_data)
+
+  def analyze(self):
+    """Analyze which snapshots need to be updated and which created"""
+    query = set(db.session.query(
+        models.Snapshot.parent_type,
+        models.Snapshot.parent_id,
+        models.Snapshot.child_type,
+        models.Snapshot.child_id,
+    ).filter(tuple_(
+        models.Snapshot.parent_type, models.Snapshot.parent_id
+    ).in_(self.parents)))
+
+    existing_scope = {Pair.from_4tuple(fields) for fields in query}
+
+    full_scope = {Pair(parent, child)
+                  for parent, children in self.snapshots.items()
+                  for child in children}
+
+    for_update = existing_scope
+    for_create = full_scope - existing_scope
+
+    return for_create, for_update
+
+  def upsert(self, event, revisions, _filter):
+    return self._upsert(event=event, revisions=revisions, _filter=_filter)
+
+  def _upsert(self, event, revisions, _filter):
+    """Update and (if needed) create snapshots
+
+    Args:
+      event: A ggrc.models.Event instance
+      revisions: A set of tuples of pairs with revisions to which it should
+        either create or update a snapshot of that particular audit
+      _filter: Callable that should return True if it should be updated
+    Returns:
+      OperationResponse
+    """
+    for_create, for_update = self.analyze()
+    create, update = None, None
+    created, updated = set(), set()
+
+    if for_update:
+      update = self._update(
+          for_update=for_update, event=event, revisions=revisions,
+          _filter=_filter)
+      updated = update.response
+    if for_create:
+      create = self._create(for_create=for_create, event=event,
+                            revisions=revisions, _filter=_filter)
+      created = create.response
+
+    to_reindex = updated | created
+    if not self.dry_run:
+      reindex_pairs(to_reindex)
+    return OperationResponse("upsert", True, {
+        "create": create,
+        "update": update
+    }, {
+        "dry-run": self.dry_run
+    })
+
+  def _execute(self, operation, data):
+    """Execute bulk operation on data if not in dry mode
+
+    Args:
+      operation: sqlalchemy operation
+      data: a list of dictionaries with keys representing column names and
+        values to insert with operation
+    Returns:
+      True if successful.
+    """
+    if data and not self.dry_run:
+      engine = db.engine
+      engine.execute(operation, data)
+      db.session.commit()
+
+  def create(self, event, revisions, _filter=None):
+    """Create snapshots of parent object's neighborhood per provided rules
+    and split in chuncks if there are too many snapshottable objects."""
+    for_create, _ = self.analyze()
+    result = self._create(
+        for_create=for_create, event=event,
+        revisions=revisions, _filter=_filter)
+    created = result.response
+    if not self.dry_run:
+      reindex_pairs(created)
+    return result
+
+  def _create(self, for_create, event, revisions, _filter):
+    """Create snapshots of parent objects neighhood and create revisions for
+    snapshots.
+
+    Args:
+      event: A ggrc.models.Event instance
+      revisions: A set of tuples of pairs with revisions to which it should
+        either create or update a snapshot of that particular audit
+      _filter: Callable that should return True if it should be updated
+    Returns:
+      OperationResponse
+    """
+    # pylint: disable=too-many-locals,too-many-statements
+    with benchmark("Snapshot._create"):
+      with benchmark("Snapshot._create init"):
+        user_id = get_current_user_id()
+        missed_keys = set()
+        data_payload = list()
+        revision_payload = list()
+        relationship_payload = list()
+        response_data = dict()
+
+        if self.dry_run and event is None:
+          event_id = 0
+        else:
+          event_id = event.id
+
+      with benchmark("Snapshot._create.filter"):
+        if _filter:
+          for_create = {elem for elem in for_create if _filter(elem)}
+
+      with benchmark("Snapshot._create._get_revisions"):
+        revision_id_cache = get_revisions(for_create, revisions)
+
+      response_data["revisions"] = revision_id_cache
+
+      with benchmark("Snapshot._create.create payload"):
+        for pair in for_create:
+          if pair in revision_id_cache:
+            revision_id = revision_id_cache[pair]
+            context_id = self.context_cache[pair.parent]
+            data = create_snapshot_dict(pair, revision_id, user_id, context_id)
+            data_payload += [data]
+          else:
+            missed_keys.add(pair)
+
+      with benchmark("Snapshot._create.write to database"):
+        self._execute(
+            models.Snapshot.__table__.insert(),
+            data_payload)
+
+      with benchmark("Snapshot._create.retrieve inserted snapshots"):
+        snapshots = get_snapshots(for_create)
+
+      with benchmark("Snapshot._create.create base object -> snapshot rels"):
+        for snapshot in snapshots:
+          base_object = Stub.from_tuple(snapshot, 6, 7)
+          snapshot_object = Stub("Snapshot", snapshot[0])
+          relationship = create_relationship_dict(base_object, snapshot_object,
+                                                  user_id, snapshot[1])
+          relationship_payload += [relationship]
+
+      with benchmark("Snapshot._create.write relationships to database"):
+        self._execute(models.Relationship.__table__.insert(),
+                      relationship_payload)
+
+      with benchmark("Snapshot._create.get created relationships"):
+        created_relationships = {
+            (rel["source_type"], rel["source_id"],
+             rel["destination_type"], rel["destination_id"])
+            for rel in relationship_payload}
+        relationships = get_relationships(created_relationships)
+
+      with benchmark("Snapshot._create.create revision payload"):
+        with benchmark("Snapshot._create.create snapshots revision payload"):
+          for snapshot in snapshots:
+            parent = Stub.from_tuple(snapshot, 4, 5)
+            context_id = self.context_cache[parent]
+            data = create_snapshot_revision_dict("created", event_id, snapshot,
+                                                 user_id, context_id)
+            revision_payload += [data]
+
+        with benchmark("Snapshot._create.create rel revision payload"):
+          snapshot_parents = {pair.child: pair.parent for pair in for_create}
+          for relationship in relationships:
+            obj = Stub.from_tuple(relationship, 4, 5)
+            parent = snapshot_parents[obj]
+            context_id = self.context_cache[parent]
+            data = create_relationship_revision_dict(
+                "created", event_id, relationship, user_id, context_id)
+            revision_payload += [data]
+
+      with benchmark("Snapshot._create.write revisions to database"):
+        self._execute(models.Revision.__table__.insert(), revision_payload)
+      return OperationResponse("create", True, for_create, response_data)
+
+
+def create_snapshots(objs, event, revisions=None, _filter=None, dry_run=False):
+  """Create snapshots of parent objects."""
+  # pylint: disable=unused-argument
+  if not revisions:
+    revisions = set()
+
+  with benchmark("Snapshot.create_snapshots"):
+    with benchmark("Snapshot.create_snapshots.init"):
+      generator = SnapshotGenerator(dry_run)
+      if not isinstance(objs, set):
+        objs = {objs}
+      for obj in objs:
+        db.session.add(obj)
+        with benchmark("Snapshot.create_snapshots.add_parent_objects"):
+          generator.add_parent(obj)
+    with benchmark("Snapshot.create_snapshots.create"):
+      return generator.create(event=event,
+                              revisions=revisions,
+                              _filter=_filter)
+
+
+def upsert_snapshots(objs, event, revisions=None, _filter=None, dry_run=False):
+  """Update (and create if needed) snapshots of parent objects."""
+  # pylint: disable=unused-argument
+  if not revisions:
+    revisions = set()
+
+  with benchmark("Snapshot.update_snapshots"):
+    generator = SnapshotGenerator(dry_run)
+    if not isinstance(objs, set):
+      objs = {objs}
+    for obj in objs:
+      db.session.add(obj)
+      generator.add_parent(obj)
+    return generator.upsert(event=event, revisions=revisions, _filter=_filter)

--- a/src/ggrc/snapshotter/datastructures.py
+++ b/src/ggrc/snapshotter/datastructures.py
@@ -44,6 +44,13 @@ class Pair(collections.namedtuple("Pair", ["parent", "child"])):
     return cls(Stub(_tuple[parent_type], _tuple[parent_id]),
                Stub(_tuple[child_type], _tuple[child_id]))
 
+  @classmethod
+  def from_snapshot(cls, snapshot):
+    return cls(
+        Stub.from_object(snapshot.parent),
+        Stub(snapshot.child_type, snapshot.child_id)
+    )
+
   def to_4tuple(self):
     return self.parent.type, self.parent.id, self.child.type, self.child.id
 

--- a/src/ggrc/snapshotter/helpers.py
+++ b/src/ggrc/snapshotter/helpers.py
@@ -1,0 +1,203 @@
+# Copyright (C) 2016 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Various simple helper functions for snapshot generator"""
+
+import collections
+
+
+from sqlalchemy.sql.expression import tuple_
+
+from ggrc import db
+from ggrc import models
+from ggrc.snapshotter.datastructures import Stub
+from ggrc.snapshotter.datastructures import Pair
+from ggrc.utils import benchmark
+
+
+def get_revisions(pairs, revisions, filters=None):
+  """Retrieve revision ids for pairs
+
+  Args:
+    pairs: set([(parent_1, child_1), (parent_2, child_2), ...])
+    revisions: dict({(parent, child): revision_id, ...})
+    filters: predicate
+  """
+  with benchmark("snapshotter.helpers.get_revisions"):
+    revision_id_cache = dict()
+
+    if pairs:
+      with benchmark("get_revisions.create caches"):
+        child_stubs = {pair.child for pair in pairs}
+
+        with benchmark("get_revisions.create child -> parents cache"):
+          parents_cache = collections.defaultdict(set)
+          for parent, child in pairs:
+            parents_cache[child].add(parent)
+
+      with benchmark("get_revisions.retrieve revisions"):
+        query = db.session.query(
+            models.Revision.id,
+            models.Revision.resource_type,
+            models.Revision.resource_id).filter(
+            tuple_(
+                models.Revision.resource_type,
+                models.Revision.resource_id).in_(child_stubs)
+        ).order_by(models.Revision.id.desc())
+        if filters:
+          for _filter in filters:
+            query = query.filter(_filter)
+
+      with benchmark("get_revisions.create revision_id cache"):
+        for revid, restype, resid in query:
+          child = Stub(restype, resid)
+          for parent in parents_cache[child]:
+            key = Pair(parent, child)
+            if key in revisions:
+              if revid == revisions[key]:
+                revision_id_cache[key] = revid
+            else:
+              if key not in revision_id_cache:
+                revision_id_cache[key] = revid
+    return revision_id_cache
+
+
+def get_relationships(relationships):
+  """Retrieve relationships
+
+  Args:
+    relationships:
+  """
+  with benchmark("snapshotter.helpers.get_relationships"):
+    if relationships:
+      relationship_columns = db.session.query(
+          models.Relationship.id,
+          models.Relationship.modified_by_id,
+          models.Relationship.created_at,
+          models.Relationship.updated_at,
+          models.Relationship.source_type,
+          models.Relationship.source_id,
+          models.Relationship.destination_type,
+          models.Relationship.destination_id,
+          models.Relationship.context_id,
+      )
+
+      return relationship_columns.filter(
+          tuple_(
+              models.Relationship.source_type,
+              models.Relationship.source_id,
+              models.Relationship.destination_type,
+              models.Relationship.destination_id,
+          ).in_(relationships)
+      ).union(
+          relationship_columns.filter(
+              tuple_(
+                  models.Relationship.destination_type,
+                  models.Relationship.destination_id,
+                  models.Relationship.source_type,
+                  models.Relationship.source_id
+              ).in_(relationships)
+          )
+      )
+    else:
+      return set()
+
+
+def get_snapshots(objects=None, ids=None):
+  with benchmark("snapshotter.helpers.get_snapshots"):
+    if objects and ids:
+      raise Exception(
+          "Insert only iterable of (parent, child) tuples or set of IDS")
+    columns = db.session.query(
+        models.Snapshot.id,
+        models.Snapshot.context_id,
+        models.Snapshot.created_at,
+        models.Snapshot.updated_at,
+        models.Snapshot.parent_type,
+        models.Snapshot.parent_id,
+        models.Snapshot.child_type,
+        models.Snapshot.child_id,
+        models.Snapshot.revision_id,
+        models.Snapshot.modified_by_id,
+    )
+    if objects:
+      return columns.filter(
+          tuple_(
+              models.Snapshot.parent_type,
+              models.Snapshot.parent_id,
+              models.Snapshot.child_type,
+              models.Snapshot.child_id
+          ).in_({(parent.type, parent.id, child.type, child.id)
+                 for parent, child in objects}))
+    if ids:
+      return columns.filter(
+          models.Snapshot.id.in_(ids))
+    return set()
+
+
+def create_snapshot_dict(pair, revision_id, user_id, context_id):
+  """Create dictionary representation of snapshot"""
+  parent, child = pair.to_2tuple()
+  return {
+      "parent_type": parent.type,
+      "parent_id": parent.id,
+      "child_type": child.type,
+      "child_id": child.id,
+      "revision_id": revision_id,
+      "modified_by_id": user_id,
+      "context_id": context_id
+  }
+
+
+def create_snapshot_revision_dict(action, event_id, snapshot,
+                                  user_id, context_id):
+  """Create dictionary representation of snapshot revision"""
+  return {
+      "action": action,
+      "event_id": event_id,
+      "content": snapshot._asdict(),
+      "modified_by_id": user_id,
+      "resource_id": snapshot[0],
+      "resource_type": "Snapshot",
+      "context_id": context_id
+  }
+
+
+def create_relationship_dict(source, destination, user_id, context_id):
+  """Create dictionary representation of relationship"""
+  return {
+      "source_type": source.type,
+      "source_id": source.id,
+      "destination_type": destination.type,
+      "destination_id": destination.id,
+      "modified_by_id": user_id,
+      "context_id": context_id,
+  }
+
+
+def create_relationship_revision_dict(action, event_id, relationship,  # noqa # pylint: disable=invalid-name
+                                      user_id, context_id):
+  """Create dictionary representation of relationship revision"""
+  return {
+      "action": action,
+      "event_id": event_id,
+      "content": relationship._asdict(),
+      "modified_by_id": user_id,
+      "resource_id": relationship.id,
+      "resource_type": "Relationship",
+      "context_id": context_id
+  }
+
+
+def create_dry_run_response(pairs, old_revisions, new_revisions):
+  with benchmark("create_dry_run_response"):
+    response = dict()
+    for pair in pairs:
+      if pair.parent not in response:
+        response[pair.parent] = {}
+
+      old_revision_id = old_revisions.get(pair)
+      new_revision_id = new_revisions.get(pair)
+      if old_revision_id != new_revision_id:
+        response[pair.parent][pair.child] = (old_revision_id, new_revision_id)
+    return response

--- a/src/ggrc/snapshotter/listeners.py
+++ b/src/ggrc/snapshotter/listeners.py
@@ -1,0 +1,45 @@
+# Copyright (C) 2016 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Register various listeners needed for snapshot operation"""
+
+from ggrc.services.common import Resource
+
+from ggrc import models
+
+
+from ggrc.snapshotter import create_snapshots
+from ggrc.snapshotter import upsert_snapshots
+from ggrc.snapshotter.datastructures import Stub
+from ggrc.snapshotter.rules import get_rules
+
+
+def create_all(sender, obj=None, src=None, service=None, event=None):  # noqa  # pylint: disable=unused-argument
+  """Create snapshots"""
+  # We use "operation" for non-standard operations (e.g. cloning)
+  if not src.get("operation"):
+    create_snapshots(obj, event)
+
+
+def upsert_all(sender, obj=None, src=None, service=None, event=None):  # noqa  # pylint: disable=unused-argument
+  """Update snapshots globally"""
+  snapshot_settings = src.get("snapshots")
+  if snapshot_settings:
+    if snapshot_settings["operation"] == "upsert":
+      revisions = {
+          (Stub.from_dict(revision["parent"]),
+           Stub.from_dict(revision["child"])): revision["revision_id"]
+          for revision in snapshot_settings.get("revisions", {})}
+      upsert_snapshots(obj, event, revisions=revisions)
+
+
+def register_snapshot_listeners():
+  """Attach listeners to various models"""
+
+  rules = get_rules()
+
+  # Initialize listening on parent objects
+  for type_ in rules.rules.keys():
+    model = getattr(models.all_models, type_)
+    Resource.model_posted_after_commit.connect(create_all, model, weak=False)
+    Resource.model_put_after_commit.connect(upsert_all, model, weak=False)

--- a/src/ggrc/views/__init__.py
+++ b/src/ggrc/views/__init__.py
@@ -332,6 +332,7 @@ def contributed_object_views():
       object_view(models.Person),
       object_view(models.Vendor),
       object_view(models.Issue),
+      object_view(models.Snapshot),
   ]
 
 

--- a/src/ggrc/views/__init__.py
+++ b/src/ggrc/views/__init__.py
@@ -85,6 +85,7 @@ def do_reindex():
   indexed_models -= excluded_models
 
   for model in indexed_models:
+    # pylint: disable=protected-access
     mapper_class = model._sa_class_manager.mapper.base_mapper.class_
     query = model.query.options(
         db.undefer_group(mapper_class.__name__ + '_complete'),

--- a/src/ggrc/views/__init__.py
+++ b/src/ggrc/views/__init__.py
@@ -158,6 +158,15 @@ def get_attributes_json():
 
 
 def get_import_types(export_only=False):
+  """Returns types that can be imported (and exported) or exported only.
+
+  Args:
+    export_only (default False): If set to true, return objects that can only
+        be exported and not imported.
+  Returns:
+    A list of models with model_singular and title_plural as keys.
+  """
+  # pylint: disable=protected-access
   types = get_exportables if export_only else get_importables
   data = []
   for model in set(types().values()):

--- a/src/ggrc/views/__init__.py
+++ b/src/ggrc/views/__init__.py
@@ -261,7 +261,7 @@ def dashboard():
 
 @app.route("/objectBrowser")
 @login_required
-def objectBrowser():
+def object_browser():
   """The object Browser page
   """
   return render_template("dashboard/index.haml")

--- a/test/integration/ggrc/converters/test_csvs/snapshotter_create.csv
+++ b/test/integration/ggrc/converters/test_csvs/snapshotter_create.csv
@@ -1,0 +1,286 @@
+Object type,,,,,,,,,,,,,,
+program,code*,title*,Manager,state,,,,,,,,,,
+,Prog-13211,Program with 3 of everything snapshotable,user@example.com,Draft,,,,,,,,,,
+,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,
+Object type,,,,,,,,,,,,,,
+Access Group,code*,title*,description,owner,state,map:program,,,,,,,,
+,ag-1,ag-1,test,user@example.com,Draft,Prog-13211,,,,,,,,
+,ag-2,ag-2,test,user@example.com,Final,Prog-13211,,,,,,,,
+,ag-3,ag-3,test,user@example.com,Draft,Prog-13211,,,,,,,,
+,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,
+Object type,,,,,,,,,,,,,,
+Clause,code*,title*,text of clause,owner,state,map:program,,,,,,,,
+,cl-1,cl-1,test,user@example.com,Draft,Prog-13211,,,,,,,,
+,cl-2,cl-2,test,user@example.com,Final,Prog-13211,,,,,,,,
+,cl-3,cl-3,test,user@example.com,Draft,Prog-13211,,,,,,,,
+,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,
+Object type,,,,,,,,,,,,,,
+control,code*,title*,description,owner,state,map:program,,,,,,,,
+,control-1,control-1,test,user@example.com,Draft,Prog-13211,,,,,,,,
+,control-2,control-2,test,user@example.com,Final,Prog-13211,,,,,,,,
+,control-3,control-3,test,user@example.com,Draft,Prog-13211,,,,,,,,
+,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,
+Object type,,,,,,,,,,,,,,
+Contract,code*,title*,description,owner,state,map:program,,,,,,,,
+,contract-1,contract-1,test,user@example.com,Draft,Prog-13211,,,,,,,,
+,Contract-2,Contract-2,test,user@example.com,Final,Prog-13211,,,,,,,,
+,Contract-3,Contract-3,test,user@example.com,Draft,Prog-13211,,,,,,,,
+,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,
+Object type,,,,,,,,,,,,,,
+Data Asset,code*,title*,description,owner,state,map:program,,,,,,,,
+,da-1,da-1,test,user@example.com,Draft,Prog-13211,,,,,,,,
+,da-2,da-2,test,user@example.com,Final,Prog-13211,,,,,,,,
+,da-3,da-3,test,user@example.com,Draft,Prog-13211,,,,,,,,
+,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,
+Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
+Other values are:
+Final
+Effective
+Ineffective
+Launched
+Not Launched
+In Scope
+Not in Scope
+Deprecated",,,,,,MM/DD/YYYY,MM/DD/YYYY,,
+Facility,code*,title*,description,owner,state,notes,primary contact,secondary contact,facility url,reference url,effective date,stop date,map:program,
+,fac-1,fac-1,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,google.com,ggrc.com,7/1/2015,7/15/2015,Prog-13211,
+,fac-2,fac-2,test,user@example.com,Final,this is a note,user@example.com,user@example.com,google.com,ggrc.com,7/1/2015,7/15/2015,Prog-13211,
+,fac-3,fac-3,test,user@example.com,Effective,this is a note,user@example.com,user@example.com,google.com,ggrc.com,7/1/2015,7/15/2015,Prog-13211,
+,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,
+Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
+Other values are:
+Final
+Effective
+Ineffective
+Launched
+Not Launched
+In Scope
+Not in Scope
+Deprecated",,,,,,MM/DD/YYYY,MM/DD/YYYY,,
+Market,code*,title*,description,owner,state,notes,primary contact,secondary contact,market url,reference url,effective date,stop date,map:program,
+,mkt-1,mkt-1,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,google.com,ggrc.com,7/1/2015,7/15/2015,Prog-13211,
+,mkt-2,mkt-2,test,user@example.com,Final,this is a note,user@example.com,user@example.com,google.com,ggrc.com,7/1/2015,7/15/2015,Prog-13211,
+,mkt-3,mkt-3,test,user@example.com,Effective,this is a note,user@example.com,user@example.com,google.com,ggrc.com,7/1/2015,7/15/2015,Prog-13211,
+,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,
+Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
+Other values are:
+Final
+Effective
+Ineffective
+Launched
+Not Launched
+In Scope
+Not in Scope
+Deprecated",,,,,,,,,
+objective,code*,title*,description,owner,state,notes,primary contact,secondary contact,objective url,reference url,map:program,,,
+,obj-1,obj-1,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,google.com,ggrc.com,Prog-13211,,,
+,obj-2,obj-2,test,user@example.com,Final,this is a note,user@example.com,user@example.com,google.com,ggrc.com,Prog-13211,,,
+,obj-3,obj-3,test,user@example.com,Effective,this is a note,user@example.com,user@example.com,google.com,ggrc.com,Prog-13211,,,
+,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,
+Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
+Other values are:
+Final
+Effective
+Ineffective
+Launched
+Not Launched
+In Scope
+Not in Scope
+Deprecated",,,,,,,,,
+OrgGroup,code*,title*,description,owner,state,notes,primary contact,secondary contact,reference url,map:program,,,,
+,orggroup-1,orggroup-1,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,ggrc.com,Prog-13211,,,,
+,Orggroup-2,Orggroup-2,test,user@example.com,Final,this is a note,user@example.com,user@example.com,ggrc.com,Prog-13211,,,,
+,Orggroup-3,Orggroup-3,test,user@example.com,Effective,this is a note,user@example.com,user@example.com,ggrc.com,Prog-13211,,,,
+,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,
+Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
+Other values are:
+Final
+Effective
+Ineffective
+Launched
+Not Launched
+In Scope
+Not in Scope
+Deprecated",,,,MM/DD/YYYY,MM/DD/YYYY,,,"Options are:
+Company Policy
+Org Group Policy
+Data Asset Policy
+Product Policy
+Contract-Related Policy
+Company Controls Policy",
+Policy,code*,title*,description,owner,state,notes,primary contact,secondary contact,effective date,stop date,policy url,reference url,Kind/Type,map:program
+,p1,policy 1,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,7/1/2015,7/15/2015,google.com,ggrc.com,Company Policy,Prog-13211
+,p2,policy 2,test,user@example.com,Final,this is a note,user@example.com,user@example.com,7/1/2015,7/15/2015,google.com,ggrc.com,Org Group Policy,Prog-13211
+,p3,policy 3,test,user@example.com,Effective,this is a note,user@example.com,user@example.com,7/1/2015,7/15/2015,google.com,ggrc.com,Data Asset Policy,Prog-13211
+,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,
+Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
+Other values are:
+Final
+Effective
+Ineffective
+Launched
+Not Launched
+In Scope
+Not in Scope
+Deprecated",,,,,,MM/DD/YYYY,MM/DD/YYYY,"Options are:
+Prod
+Corp
+Service
+Core
+3rd Party",
+Process,code*,title*,description,owner,state,notes,primary contact,secondary contact,process url,reference url,effective date,stop date,network zone,map:program
+,proc-1,proc-1,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,google.com,ggrc.com,7/1/2015,7/15/2015,prod,Prog-13211
+,proc-2,proc-2,test,user@example.com,Final,this is a note,user@example.com,user@example.com,google.com,ggrc.com,7/1/2015,7/15/2015,corp,Prog-13211
+,proc-3,proc-3,test,user@example.com,Effective,this is a note,user@example.com,user@example.com,google.com,ggrc.com,7/1/2015,7/15/2015,service,Prog-13211
+,,,,,,,,,,,,,,
+Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
+Other values are:
+Final
+Effective
+Ineffective
+Launched
+Not Launched
+In Scope
+Not in Scope
+Deprecated",,,,,,MM/DD/YYYY,MM/DD/YYYY,"Options are:
+Saas
+Desktop Software
+Appliance",
+Product,code*,title*,description,owner,state,notes,primary contact,secondary contact,product url,reference url,effective date,stop date,Kind/Type,map:program
+,prod-1,prod-1,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,google.com,ggrc.com,7/1/2015,7/15/2015,Saas,Prog-13211
+,prod-2,prod-2,test,user@example.com,Final,this is a note,user@example.com,user@example.com,google.com,ggrc.com,7/1/2015,7/15/2015,Desktop Software,Prog-13211
+,prod-3,prod-3,test,user@example.com,Effective,this is a note,user@example.com,user@example.com,google.com,ggrc.com,7/1/2015,7/15/2015,Appliance,Prog-13211
+,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,
+Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
+Other values are:
+Final
+Effective
+Ineffective
+Launched
+Not Launched
+In Scope
+Not in Scope
+Deprecated",,,,MM/DD/YYYY,MM/DD/YYYY,,,,
+Regulation,code*,title*,description,owner,state,notes,primary contact,secondary contact,effective date,stop date,regulation url,reference url,map:program,
+,reg-1,reg 1,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,7/1/2015,7/15/2015,google.com,ggrc.com,Prog-13211,
+,reg-2,reg 2,test,user@example.com,Final,this is a note,user@example.com,user@example.com,7/1/2015,7/15/2015,google.com,ggrc.com,Prog-13211,
+,reg-3,reg 3,test,user@example.com,Effective,this is a note,user@example.com,user@example.com,7/1/2015,7/15/2015,google.com,ggrc.com,Prog-13211,
+,,,,,,,,,,,,,,
+Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
+Other values are:
+Final
+Effective
+Ineffective
+Launched
+Not Launched
+In Scope
+Not in Scope
+Deprecated",,,,,,,,"either of the mappings (policy, regulation, standard) is mandatory for a section to be imported",
+Section,code*,title*,text of section,owner,state,notes,primary contact,secondary contact,,,section url,reference url,Policy / Regulation / Standard / Contract,map:program
+,sec-1,sec-1,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,,,google.com,ggrc.com,p1,Prog-13211
+,sec-2,sec-2,test,user@example.com,Final,this is a note,user@example.com,user@example.com,,,google.com,ggrc.com,p2,Prog-13211
+,sec-3,sec-3,test,user@example.com,Effective,this is a note,user@example.com,user@example.com,,,google.com,ggrc.com,p3,Prog-13211
+,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,
+Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
+Other values are:
+Final
+Effective
+Ineffective
+Launched
+Not Launched
+In Scope
+Not in Scope
+Deprecated",,,,MM/DD/YYYY,MM/DD/YYYY,,,,
+Standard,code*,title*,description,owner,state,notes,primary contact,secondary contact,effective date,stop date,standard url,reference url,map:program,
+,std-1,std 1,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,7/1/2015,7/15/2015,google.com,ggrc.com,Prog-13211,
+,std-2,std 2,test,user@example.com,Final,this is a note,user@example.com,user@example.com,7/1/2015,7/15/2015,google.com,ggrc.com,Prog-13211,
+,std-3,std 3,test,user@example.com,Effective,this is a note,user@example.com,user@example.com,7/1/2015,7/15/2015,google.com,ggrc.com,Prog-13211,
+,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,
+Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
+Other values are:
+Final
+Effective
+Ineffective
+Launched
+Not Launched
+In Scope
+Not in Scope
+Deprecated",,,,,,MM/DD/YYYY,MM/DD/YYYY,"Options are:
+Prod
+Corp
+Service
+Core
+3rd Party",
+System,code*,title*,description,owner,state,notes,primary contact,secondary contact,system url,reference url,effective date,stop date,network zone,map:program
+,sys-1,sys-1,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,google.com,ggrc.com,7/1/2015,7/15/2015,prod,Prog-13211
+,sys-2,sys-2,test,user@example.com,Final,this is a note,user@example.com,user@example.com,google.com,ggrc.com,7/1/2015,7/15/2015,corp,Prog-13211
+,sys-3,sys-3,test,user@example.com,Effective,this is a note,user@example.com,user@example.com,google.com,ggrc.com,7/1/2015,7/15/2015,service,Prog-13211
+,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,
+Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",Mandatory field,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
+Other values are:
+Final
+Effective
+Ineffective
+Launched
+Not Launched
+In Scope
+Not in Scope
+Deprecated",,,,MM/DD/YYYY,MM/DD/YYYY,,,,
+Vendor,code*,title*,description,owner,state,notes,primary contact,secondary contact,effective date,stop date,vendor url,reference url,map:program,
+,ven-1,ven-1,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,7/1/2015,7/15/2015,google.com,ggrc.com,Prog-13211,
+,ven-2,ven-2,test,user@example.com,Final,this is a note,user@example.com,user@example.com,7/1/2015,7/15/2015,google.com,ggrc.com,Prog-13211,
+,ven-3,ven-3,test,user@example.com,Effective,this is a note,user@example.com,user@example.com,7/1/2015,7/15/2015,google.com,ggrc.com,Prog-13211,
+,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,
+Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
+Other values are:
+Final
+Effective
+Ineffective
+Launched
+Not Launched
+In Scope
+Not in Scope
+Deprecated",MM/DD/YYYY,MM/DD/YYYY,,,,,,,
+Risk,code*,title*,description,notes,Owner*,Effective date,stop date,map:program,,,,,,
+,ra-1,ra-1,test,this is a note,user@example.com,7/1/2015,7/15/2015,Prog-13211,,,,,,
+,ra-2,ra-2,test,this is a note,user@example.com,7/1/2015,7/15/2015,Prog-13211,,,,,,
+,ra-3,ra-3,test,this is a note,user@example.com,7/1/2015,7/15/2015,Prog-13211,,,,,,
+,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,
+Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
+Other values are:
+Final
+Effective
+Ineffective
+Launched
+Not Launched
+In Scope
+Not in Scope
+Deprecated",MM/DD/YYYY,MM/DD/YYYY,,,,,,,
+Threat,code*,title*,description,notes,Owner*,Effective date,stop date,map:program,,,,,,
+,threat-1,threat-1,test,this is a note,user@example.com,7/1/2015,7/15/2015,Prog-13211,,,,,,
+,Threat-2,Threat-2,test,this is a note,user@example.com,7/1/2015,7/15/2015,Prog-13211,,,,,,
+,Threat-3,Threat-3,test,this is a note,user@example.com,7/1/2015,7/15/2015,Prog-13211,,,,,,

--- a/test/integration/ggrc/converters/test_csvs/snapshotter_update.csv
+++ b/test/integration/ggrc/converters/test_csvs/snapshotter_update.csv
@@ -1,0 +1,286 @@
+Object type,,,,,,,,,,,,,,
+program,code*,title*,Manager,state,,,,,,,,,,
+,Prog-13211,Program with 3 of everything snapshotable,user@example.com,Draft,,,,,,,,,,
+,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,
+Object type,,,,,,,,,,,,,,
+Access Group,code*,title*,description,owner,state,map:program,,,,,,,,
+,ag-1,ag-1 EDIT,test,user@example.com,Draft,Prog-13211,,,,,,,,
+,ag-2,ag-2 EDIT,test,user@example.com,Final,Prog-13211,,,,,,,,
+,ag-3,ag-3 EDIT,test,user@example.com,Draft,Prog-13211,,,,,,,,
+,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,
+Object type,,,,,,,,,,,,,,
+Clause,code*,title*,text of clause,owner,state,map:program,,,,,,,,
+,cl-1,cl-1 EDIT,test,user@example.com,Draft,Prog-13211,,,,,,,,
+,cl-2,cl-2 EDIT,test,user@example.com,Final,Prog-13211,,,,,,,,
+,cl-3,cl-3 EDIT,test,user@example.com,Draft,Prog-13211,,,,,,,,
+,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,
+Object type,,,,,,,,,,,,,,
+control,code*,title*,description,owner,state,map:program,,,,,,,,
+,control-1,control-1 EDIT,test,user@example.com,Draft,Prog-13211,,,,,,,,
+,control-2,control-2 EDIT,test,user@example.com,Final,Prog-13211,,,,,,,,
+,control-3,control-3 EDIT,test,user@example.com,Draft,Prog-13211,,,,,,,,
+,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,
+Object type,,,,,,,,,,,,,,
+Contract,code*,title*,description,owner,state,map:program,,,,,,,,
+,contract-1,Contract-1 EDIT,test,user@example.com,Draft,Prog-13211,,,,,,,,
+,Contract-2,Contract-2 EDIT,test,user@example.com,Final,Prog-13211,,,,,,,,
+,Contract-3,Contract-3 EDIT,test,user@example.com,Draft,Prog-13211,,,,,,,,
+,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,
+Object type,,,,,,,,,,,,,,
+Data Asset,code*,title*,description,owner,state,map:program,,,,,,,,
+,da-1,da-1 EDIT,test,user@example.com,Draft,Prog-13211,,,,,,,,
+,da-2,da-2 EDIT,test,user@example.com,Final,Prog-13211,,,,,,,,
+,da-3,da-3 EDIT,test,user@example.com,Draft,Prog-13211,,,,,,,,
+,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,
+Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
+Other values are:
+Final
+Effective
+Ineffective
+Launched
+Not Launched
+In Scope
+Not in Scope
+Deprecated",,,,,,MM/DD/YYYY,MM/DD/YYYY,,
+Facility,code*,title*,description,owner,state,notes,primary contact,secondary contact,facility url,reference url,effective date,stop date,map:program,
+,fac-1,Fac-1 EDIT,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,google.com,ggrc.com,7/1/2015,7/15/2015,Prog-13211,
+,fac-2,Fac-2 EDIT,test,user@example.com,Final,this is a note,user@example.com,user@example.com,google.com,ggrc.com,7/1/2015,7/15/2015,Prog-13211,
+,fac-3,Fac-3 EDIT,test,user@example.com,Effective,this is a note,user@example.com,user@example.com,google.com,ggrc.com,7/1/2015,7/15/2015,Prog-13211,
+,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,
+Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
+Other values are:
+Final
+Effective
+Ineffective
+Launched
+Not Launched
+In Scope
+Not in Scope
+Deprecated",,,,,,MM/DD/YYYY,MM/DD/YYYY,,
+Market,code*,title*,description,owner,state,notes,primary contact,secondary contact,market url,reference url,effective date,stop date,map:program,
+,mkt-1,Mkt-1 EDIT,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,google.com,ggrc.com,7/1/2015,7/15/2015,Prog-13211,
+,mkt-2,mkt-2 EDIT,test,user@example.com,Final,this is a note,user@example.com,user@example.com,google.com,ggrc.com,7/1/2015,7/15/2015,Prog-13211,
+,mkt-3,mkt-3 EDIT,test,user@example.com,Effective,this is a note,user@example.com,user@example.com,google.com,ggrc.com,7/1/2015,7/15/2015,Prog-13211,
+,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,
+Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
+Other values are:
+Final
+Effective
+Ineffective
+Launched
+Not Launched
+In Scope
+Not in Scope
+Deprecated",,,,,,,,,
+objective,code*,title*,description,owner,state,notes,primary contact,secondary contact,objective url,reference url,map:program,,,
+,obj-1,obj-1 EDIT,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,google.com,ggrc.com,Prog-13211,,,
+,obj-2,obj-2 EDIT,test,user@example.com,Final,this is a note,user@example.com,user@example.com,google.com,ggrc.com,Prog-13211,,,
+,obj-3,obj-3 EDIT,test,user@example.com,Effective,this is a note,user@example.com,user@example.com,google.com,ggrc.com,Prog-13211,,,
+,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,
+Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
+Other values are:
+Final
+Effective
+Ineffective
+Launched
+Not Launched
+In Scope
+Not in Scope
+Deprecated",,,,,,,,,
+OrgGroup,code*,title*,description,owner,state,notes,primary contact,secondary contact,reference url,map:program,,,,
+,orggroup-1,orggroup-1 EDIT,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,ggrc.com,Prog-13211,,,,
+,Orggroup-2,Orggroup-2 EDIT,test,user@example.com,Final,this is a note,user@example.com,user@example.com,ggrc.com,Prog-13211,,,,
+,Orggroup-3,Orggroup-3 EDIT,test,user@example.com,Effective,this is a note,user@example.com,user@example.com,ggrc.com,Prog-13211,,,,
+,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,
+Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
+Other values are:
+Final
+Effective
+Ineffective
+Launched
+Not Launched
+In Scope
+Not in Scope
+Deprecated",,,,MM/DD/YYYY,MM/DD/YYYY,,,"Options are:
+Company Policy
+Org Group Policy
+Data Asset Policy
+Product Policy
+Contract-Related Policy
+Company Controls Policy",
+Policy,code*,title*,description,owner,state,notes,primary contact,secondary contact,effective date,stop date,policy url,reference url,Kind/Type,map:program
+,p1,policy 1 EDIT,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,7/1/2015,7/15/2015,google.com,ggrc.com,Company Policy,Prog-13211
+,p2,policy 2 EDIT,test,user@example.com,Final,this is a note,user@example.com,user@example.com,7/1/2015,7/15/2015,google.com,ggrc.com,Org Group Policy,Prog-13211
+,p3,policy 3 EDIT,test,user@example.com,Effective,this is a note,user@example.com,user@example.com,7/1/2015,7/15/2015,google.com,ggrc.com,Data Asset Policy,Prog-13211
+,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,
+Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
+Other values are:
+Final
+Effective
+Ineffective
+Launched
+Not Launched
+In Scope
+Not in Scope
+Deprecated",,,,,,MM/DD/YYYY,MM/DD/YYYY,"Options are:
+Prod
+Corp
+Service
+Core
+3rd Party",
+Process,code*,title*,description,owner,state,notes,primary contact,secondary contact,process url,reference url,effective date,stop date,network zone,map:program
+,proc-1,proc-1 EDIT,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,google.com,ggrc.com,7/1/2015,7/15/2015,prod,Prog-13211
+,proc-2,proc-2 EDIT,test,user@example.com,Final,this is a note,user@example.com,user@example.com,google.com,ggrc.com,7/1/2015,7/15/2015,corp,Prog-13211
+,proc-3,proc-3 EDIT,test,user@example.com,Effective,this is a note,user@example.com,user@example.com,google.com,ggrc.com,7/1/2015,7/15/2015,service,Prog-13211
+,,,,,,,,,,,,,,
+Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
+Other values are:
+Final
+Effective
+Ineffective
+Launched
+Not Launched
+In Scope
+Not in Scope
+Deprecated",,,,,,MM/DD/YYYY,MM/DD/YYYY,"Options are:
+Saas
+Desktop Software
+Appliance",
+Product,code*,title*,description,owner,state,notes,primary contact,secondary contact,product url,reference url,effective date,stop date,Kind/Type,map:program
+,prod-1,prod-1 EDIT,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,google.com,ggrc.com,7/1/2015,7/15/2015,Saas,Prog-13211
+,prod-2,prod-2 EDIT,test,user@example.com,Final,this is a note,user@example.com,user@example.com,google.com,ggrc.com,7/1/2015,7/15/2015,Desktop Software,Prog-13211
+,prod-3,prod-3 EDIT,test,user@example.com,Effective,this is a note,user@example.com,user@example.com,google.com,ggrc.com,7/1/2015,7/15/2015,Appliance,Prog-13211
+,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,
+Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
+Other values are:
+Final
+Effective
+Ineffective
+Launched
+Not Launched
+In Scope
+Not in Scope
+Deprecated",,,,MM/DD/YYYY,MM/DD/YYYY,,,,
+Regulation,code*,title*,description,owner,state,notes,primary contact,secondary contact,effective date,stop date,regulation url,reference url,map:program,
+,reg-1,reg 1 EDIT,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,7/1/2015,7/15/2015,google.com,ggrc.com,Prog-13211,
+,reg-2,reg 2 EDIT,test,user@example.com,Final,this is a note,user@example.com,user@example.com,7/1/2015,7/15/2015,google.com,ggrc.com,Prog-13211,
+,reg-3,reg 3 EDIT,test,user@example.com,Effective,this is a note,user@example.com,user@example.com,7/1/2015,7/15/2015,google.com,ggrc.com,Prog-13211,
+,,,,,,,,,,,,,,
+Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
+Other values are:
+Final
+Effective
+Ineffective
+Launched
+Not Launched
+In Scope
+Not in Scope
+Deprecated",,,,,,,,"either of the mappings (policy, regulation, standard) is mandatory for a section to be imported",
+Section,code*,title*,text of section,owner,state,notes,primary contact,secondary contact,,,section url,reference url,Policy / Regulation / Standard / Contract,map:program
+,sec-1,sec-1 EDIT,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,,,google.com,ggrc.com,p1,Prog-13211
+,sec-2,sec-2 EDIT,test,user@example.com,Final,this is a note,user@example.com,user@example.com,,,google.com,ggrc.com,p2,Prog-13211
+,sec-3,sec-3 EDIT,test,user@example.com,Effective,this is a note,user@example.com,user@example.com,,,google.com,ggrc.com,p3,Prog-13211
+,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,
+Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
+Other values are:
+Final
+Effective
+Ineffective
+Launched
+Not Launched
+In Scope
+Not in Scope
+Deprecated",,,,MM/DD/YYYY,MM/DD/YYYY,,,,
+Standard,code*,title*,description,owner,state,notes,primary contact,secondary contact,effective date,stop date,standard url,reference url,map:program,
+,std-1,std 1 EDIT,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,7/1/2015,7/15/2015,google.com,ggrc.com,Prog-13211,
+,std-2,std 2 EDIT,test,user@example.com,Final,this is a note,user@example.com,user@example.com,7/1/2015,7/15/2015,google.com,ggrc.com,Prog-13211,
+,std-3,std 3 EDIT,test,user@example.com,Effective,this is a note,user@example.com,user@example.com,7/1/2015,7/15/2015,google.com,ggrc.com,Prog-13211,
+,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,
+Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
+Other values are:
+Final
+Effective
+Ineffective
+Launched
+Not Launched
+In Scope
+Not in Scope
+Deprecated",,,,,,MM/DD/YYYY,MM/DD/YYYY,"Options are:
+Prod
+Corp
+Service
+Core
+3rd Party",
+System,code*,title*,description,owner,state,notes,primary contact,secondary contact,system url,reference url,effective date,stop date,network zone,map:program
+,sys-1,sys-1 EDIT,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,google.com,ggrc.com,7/1/2015,7/15/2015,prod,Prog-13211
+,sys-2,sys-2 EDIT,test,user@example.com,Final,this is a note,user@example.com,user@example.com,google.com,ggrc.com,7/1/2015,7/15/2015,corp,Prog-13211
+,sys-3,sys-3 EDIT,test,user@example.com,Effective,this is a note,user@example.com,user@example.com,google.com,ggrc.com,7/1/2015,7/15/2015,service,Prog-13211
+,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,
+Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",Mandatory field,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
+Other values are:
+Final
+Effective
+Ineffective
+Launched
+Not Launched
+In Scope
+Not in Scope
+Deprecated",,,,MM/DD/YYYY,MM/DD/YYYY,,,,
+Vendor,code*,title*,description,owner,state,notes,primary contact,secondary contact,effective date,stop date,vendor url,reference url,map:program,
+,ven-1,ven-1 EDIT,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,7/1/2015,7/15/2015,google.com,ggrc.com,Prog-13211,
+,ven-2,ven-2 EDIT,test,user@example.com,Final,this is a note,user@example.com,user@example.com,7/1/2015,7/15/2015,google.com,ggrc.com,Prog-13211,
+,ven-3,ven-3 EDIT,test,user@example.com,Effective,this is a note,user@example.com,user@example.com,7/1/2015,7/15/2015,google.com,ggrc.com,Prog-13211,
+,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,
+Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
+Other values are:
+Final
+Effective
+Ineffective
+Launched
+Not Launched
+In Scope
+Not in Scope
+Deprecated",MM/DD/YYYY,MM/DD/YYYY,,,,,,,
+Risk,code*,title*,description,notes,Owner*,Effective date,stop date,map:program,,,,,,
+,ra-1,ra-1 EDIT,test,this is a note,user@example.com,7/1/2015,7/15/2015,Prog-13211,,,,,,
+,ra-2,ra-2 EDIT,test,this is a note,user@example.com,7/1/2015,7/15/2015,Prog-13211,,,,,,
+,ra-3,ra-3 EDIT,test,this is a note,user@example.com,7/1/2015,7/15/2015,Prog-13211,,,,,,
+,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,
+Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
+Other values are:
+Final
+Effective
+Ineffective
+Launched
+Not Launched
+In Scope
+Not in Scope
+Deprecated",MM/DD/YYYY,MM/DD/YYYY,,,,,,,
+Threat,code*,title*,description,notes,Owner*,Effective date,stop date,map:program,,,,,,
+,threat-1,threat-1 EDIT,test,this is a note,user@example.com,7/1/2015,7/15/2015,Prog-13211,,,,,,
+,Threat-2,Threat-2 EDIT,test,this is a note,user@example.com,7/1/2015,7/15/2015,Prog-13211,,,,,,
+,Threat-3,Threat-3 EDIT,test,this is a note,user@example.com,7/1/2015,7/15/2015,Prog-13211,,,,,,

--- a/test/integration/ggrc/snapshotter/__init__.py
+++ b/test/integration/ggrc/snapshotter/__init__.py
@@ -1,0 +1,99 @@
+# Copyright (C) 2016 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Base test case for testing snapshotter"""
+
+from collections import defaultdict
+from os.path import abspath, dirname, join
+
+import ggrc.models as models
+
+import integration.ggrc
+from integration.ggrc import api_helper
+from integration.ggrc.converters import TestCase
+import integration.ggrc.generator
+from integration.ggrc.models import factories
+
+
+THIS_ABS_PATH = abspath(dirname(__file__))
+CSV_DIR = join(THIS_ABS_PATH, "../converters/test_csvs/")
+
+
+def snapshot_identity(s_1, s_2):
+  return (s_1.id == s_2.id and
+          s_1.updated_at == s_2.updated_at and
+          s_1.child_id == s_2.child_id and
+          s_1.child_type == s_2.child_type and
+          s_1.revision_id == s_2.revision_id)
+
+
+class SnapshotterBaseTestCase(TestCase):
+  """Test cases for Snapshoter module"""
+
+  # pylint: disable=invalid-name
+
+  def setUp(self):
+    integration.ggrc.TestCase.setUp(self)
+    self.objgen = integration.ggrc.generator.ObjectGenerator()
+    self.api = api_helper.Api()
+
+  def tearDown(self):
+    integration.ggrc.TestCase.tearDown(self)
+
+  def create_object(self, cls, data):
+    _, obj = self.objgen.generate_object(cls, data)
+    return obj
+
+  def create_mapping(self, src, dst):
+    _, obj = self.objgen.generate_relationship(src, dst)
+    return obj
+
+  def create_audit(self, program):
+    self.create_object(models.Audit, {
+        "title": "Snapshotable audit",
+        "program": {"id": program.id},
+        "status": "Planned",
+        "snapshots": {
+            "operation": "create",
+        }
+    })
+
+  @classmethod
+  def refresh_object(cls, obj):
+    """Returns a new instance of a model, fresh and warm from the database."""
+    return obj.query.filter_by(id=obj.id).one()
+
+  @staticmethod
+  def create_custom_attribute_definitions(cad_definitions=None):
+    """Create custom attribute definitions used throughout snapshotter tests"""
+    custom_attribute_definitions = defaultdict(list)
+
+    if not cad_definitions:
+      cad_definitions = [
+          {
+              "definition_type": "control",
+              "title": "control text field 1",
+              "attribute_type": "Text",
+          },
+          {
+              "definition_type": "objective",
+              "title": "objective rich field 1",
+              "attribute_type": "Rich Text",
+          },
+          {
+              "definition_type": "process",
+              "title": "process date field 1",
+              "attribute_type": "Date",
+          },
+          {
+              "definition_type": "access_group",
+              "title": "access group text field 2",
+              "attribute_type": "Text",
+          },
+      ]
+
+    for cad in cad_definitions:
+      attr = factories.CustomAttributeDefinitionFactory(**cad)
+      custom_attribute_definitions[cad["definition_type"]] = attr
+
+    return custom_attribute_definitions

--- a/test/integration/ggrc/snapshotter/test_indexing.py
+++ b/test/integration/ggrc/snapshotter/test_indexing.py
@@ -1,0 +1,341 @@
+# Copyright (C) 2016 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Test for indexing of snapshotted objects"""
+
+from sqlalchemy.sql.expression import tuple_
+
+from ggrc import db
+from ggrc import models
+from ggrc.views import do_reindex
+from ggrc.fulltext.mysql import MysqlRecordProperty as Record
+from ggrc.snapshotter.indexer import delete_records
+
+from integration.ggrc.snapshotter import SnapshotterBaseTestCase
+from integration.ggrc.models import factories
+
+
+def get_records(_audit, _snapshots):
+  return db.session.query(Record).filter(
+      tuple_(
+          Record.type,
+          Record.key,
+          Record.property,
+          Record.content
+      ).in_(
+          {("Snapshot", s.id, "parent", "Audit-{}".format(_audit.id))
+           for s in _snapshots}
+      ))
+
+
+class TestSnapshotIndexing(SnapshotterBaseTestCase):
+  """Test cases for Snapshoter module"""
+
+  # pylint: disable=invalid-name,too-many-locals
+
+  def setUp(self):
+    SnapshotterBaseTestCase.setUp(self)
+
+    self.client.get("/login")
+    self.headers = {
+        'Content-Type': 'application/json',
+        "X-Requested-By": "gGRC",
+    }
+
+  def test_create_indexing(self):
+    """Test that creating objects results in full index"""
+    custom_attribute_defs = self.create_custom_attribute_definitions()
+
+    self._import_file("snapshotter_create.csv")
+
+    control = db.session.query(models.Control).filter(
+        models.Control.slug == "control-3"
+    ).one()
+    access_group = db.session.query(models.AccessGroup).filter(
+        models.AccessGroup.slug == "ag-2"
+    ).one()
+    objective = db.session.query(models.Objective).filter(
+        models.Objective.slug == "obj-1"
+    ).one()
+    process = db.session.query(models.Process).filter(
+        models.Process.slug == "proc-2"
+    ).one()
+    custom_attribute_values = [
+        {
+            "custom_attribute": custom_attribute_defs["control"],
+            "attributable": control,
+            "attribute_value": "control value 1",
+        },
+        {
+            "custom_attribute": custom_attribute_defs["objective"],
+            "attributable": objective,
+            "attribute_value": "objective value 1",
+        },
+        {
+            "custom_attribute": custom_attribute_defs["process"],
+            "attributable": process,
+            "attribute_value": "07/12/2016",
+        },
+        {
+            "custom_attribute": custom_attribute_defs["access_group"],
+            "attributable": access_group,
+            "attribute_value": "access_group text value 1",
+        },
+    ]
+
+    for value in custom_attribute_values:
+      factories.CustomAttributeValueFactory(**value)
+
+    # Add custom attribute values via factory doesn't create revisions, so
+    # we modify all the objects via import, which saves the full object
+    # state in revisions table (including custom attribute values).
+    self._import_file("snapshotter_update.csv")
+
+    program = db.session.query(models.Program).filter(
+        models.Program.slug == "Prog-13211"
+    ).one()
+
+    self.create_audit(program)
+
+    audit = db.session.query(models.Audit).filter(
+        models.Audit.title.like("%Snapshotable audit%")).first()
+
+    snapshots = db.session.query(models.Snapshot).all()
+
+    records = db.session.query(Record).filter(
+        tuple_(
+            Record.type,
+            Record.key,
+            Record.property,
+            Record.content
+        ).in_(
+            {("Snapshot", s.id, "parent", "Audit-{}".format(audit.id))
+             for s in snapshots}
+        ))
+
+    self.assertEqual(records.count(), 57)
+
+    # At this point all objects are no longer in the session and we have to
+    # manually refresh them from the database
+    control = db.session.query(models.Control).filter(
+        models.Control.slug == "control-3"
+    ).one()
+    access_group = db.session.query(models.AccessGroup).filter(
+        models.AccessGroup.slug == "ag-2"
+    ).one()
+    objective = db.session.query(models.Objective).filter(
+        models.Objective.slug == "obj-1"
+    ).one()
+    process = db.session.query(models.Process).filter(
+        models.Process.slug == "proc-2"
+    ).one()
+
+    custom_attributes = [
+        (control, "control text field 1", "control value 1"),
+        (objective, "objective rich field 1", "objective value 1"),
+        (process, "process date field 1", "07/12/2016"),
+        (access_group, "access group text field 2",
+         "access_group text value 1")
+    ]
+
+    for obj, definition, value in custom_attributes:
+      snapshot = db.session.query(models.Snapshot).filter(
+          models.Snapshot.child_type == obj.type,
+          models.Snapshot.child_id == obj.id,
+      ).one()
+
+      _cav = db.session.query(Record).filter(
+          Record.key == snapshot.id,
+          Record.type == "Snapshot",
+          Record.property == definition,
+          Record.content == value
+      )
+      _title = db.session.query(Record).filter(
+          Record.key == snapshot.id,
+          Record.type == "Snapshot",
+          Record.property == "title",
+          Record.content == obj.title
+      )
+      _desc = db.session.query(Record).filter(
+          Record.key == snapshot.id,
+          Record.type == "Snapshot",
+          Record.property == "description",
+          Record.content == obj.description
+      )
+      self.assertEqual(_cav.count(), 1)
+      self.assertEqual(_title.count(), 1)
+      self.assertEqual(_desc.count(), 1)
+
+  def test_update_indexing(self):
+    """Test that creating objects results in full index"""
+    custom_attribute_defs = self.create_custom_attribute_definitions()
+
+    self._import_file("snapshotter_create.csv")
+
+    access_group = db.session.query(models.AccessGroup).filter(
+        models.AccessGroup.title == "ag-2"
+    ).one()
+    objective = db.session.query(models.Objective).filter(
+        models.Objective.title == "obj-1"
+    ).one()
+    custom_attribute_values = [
+        {
+            "custom_attribute": custom_attribute_defs["objective"],
+            "attributable": objective,
+            "attribute_value": "objective value 1",
+        },
+        {
+            "custom_attribute": custom_attribute_defs["access_group"],
+            "attributable": access_group,
+            "attribute_value": "access_group text value 1",
+        },
+    ]
+
+    for value in custom_attribute_values:
+      factories.CustomAttributeValueFactory(**value)
+
+    # Add custom attribute values via factory doesn't create revisions, so
+    # we modify all the objects via import, which saves the full object
+    # state in revisions table (including custom attribute values).
+    self._import_file("snapshotter_update.csv")
+
+    program = db.session.query(models.Program).filter(
+        models.Program.slug == "Prog-13211"
+    ).one()
+
+    self.create_audit(program)
+
+    objective_cav = db.session.query(models.CustomAttributeValue).filter(
+        models.CustomAttributeValue.attribute_value == "objective value 1"
+    ).one()
+
+    access_group_cav = db.session.query(models.CustomAttributeValue).filter(
+        models.CustomAttributeValue.attribute_value ==
+        "access_group text value 1"
+    ).one()
+
+    cavs = [
+        (objective_cav, "objective CA value edited after initial index"),
+        (access_group_cav, "access_group CA value edited after initial index"),
+    ]
+
+    # This is not a correct way to update CAVs but PUT request on CAV
+    # doesn't work and attaching full custom attribute signature
+    # (custom_attribute_definitions, custom_attribute_values and
+    # custom_attributes) is out of scope for this.
+    for obj, val in cavs:
+      obj.attribute_value = val
+      db.session.add(obj)
+    db.session.commit()
+
+    access_group = db.session.query(models.AccessGroup).filter(
+        models.AccessGroup.slug == "ag-2"
+    ).one()
+    objective = db.session.query(models.Objective).filter(
+        models.Objective.slug == "obj-1"
+    ).one()
+
+    obj_edits = [
+        (objective, "objective title edited after initial index"),
+        (access_group, "access group title edited after initial index")
+    ]
+
+    for obj, title in obj_edits:
+      obj = self.refresh_object(obj)
+      self.api.modify_object(obj, {
+          "title": title
+      })
+
+    audit = db.session.query(models.Audit).filter(
+        models.Audit.title.like("%Snapshotable audit%")).one()
+    # Initiate update operation
+    self.api.modify_object(audit, {
+        "snapshots": {
+            "operation": "upsert"
+        }
+    })
+
+    snapshots = db.session.query(models.Snapshot).all()
+
+    records = db.session.query(Record).filter(
+        tuple_(
+            Record.type,
+            Record.key,
+            Record.property,
+            Record.content
+        ).in_(
+            {("Snapshot", s.id, "parent", "Audit-{}".format(s.parent_id))
+             for s in snapshots}
+        ))
+
+    self.assertEqual(records.count(), 57)
+
+    custom_attributes = [
+        (objective,
+         "objective title edited after initial index",
+         "objective rich field 1",
+         "objective CA value edited after initial index"),
+        (access_group,
+         "access group title edited after initial index",
+         "access group text field 2",
+         "access_group CA value edited after initial index")
+    ]
+
+    for obj, title, definition, value in custom_attributes:
+      obj = self.refresh_object(obj)
+      snapshot = db.session.query(models.Snapshot).filter(
+          models.Snapshot.child_type == obj.type,
+          models.Snapshot.child_id == obj.id,
+      ).one()
+
+      _cav = db.session.query(Record).filter(
+          Record.key == snapshot.id,
+          Record.type == "Snapshot",
+          Record.property == definition,
+          Record.content == value
+      )
+      _title = db.session.query(Record).filter(
+          Record.key == snapshot.id,
+          Record.type == "Snapshot",
+          Record.property == "title",
+          Record.content == title
+      )
+      _desc = db.session.query(Record).filter(
+          Record.key == snapshot.id,
+          Record.type == "Snapshot",
+          Record.property == "description",
+          Record.content == obj.description
+      )
+      self.assertEqual(_cav.count(), 1)
+      self.assertEqual(_title.count(), 1)
+      self.assertEqual(_desc.count(), 1)
+
+  def test_full_reindex(self):
+    """Test full reindex of all snapshots"""
+    self._import_file("snapshotter_create.csv")
+
+    program = db.session.query(models.Program).filter(
+        models.Program.slug == "Prog-13211"
+    ).one()
+
+    self.create_audit(program)
+
+    audit = db.session.query(models.Audit).filter(
+        models.Audit.title.like("%Snapshotable audit%")).first()
+
+    snapshots = db.session.query(models.Snapshot).all()
+
+    records = get_records(audit, snapshots)
+
+    self.assertEqual(records.count(), 57)
+
+    delete_records({s.id for s in snapshots})
+
+    records = get_records(audit, snapshots)
+    self.assertEqual(records.count(), 0)
+
+    do_reindex()
+
+    records = get_records(audit, snapshots)
+
+    self.assertEqual(records.count(), 57)

--- a/test/integration/ggrc/snapshotter/test_snapshoting.py
+++ b/test/integration/ggrc/snapshotter/test_snapshoting.py
@@ -1,0 +1,519 @@
+# Copyright (C) 2016 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Test for snapshoter"""
+
+import collections
+
+from ggrc import db
+import ggrc.models as models
+from ggrc.snapshotter.rules import Types
+
+from integration.ggrc.snapshotter import SnapshotterBaseTestCase
+from integration.ggrc.snapshotter import snapshot_identity
+
+
+class TestSnapshoting(SnapshotterBaseTestCase):
+  """Test cases for Snapshoter module"""
+
+  # pylint: disable=invalid-name
+
+  def test_snapshot_create(self):
+    """Test simple snapshot creation with a simple change"""
+    program = self.create_object(models.Program, {
+        "title": "Test Program Snapshot 1"
+    })
+    control = self.create_object(models.Control, {
+        "title": "Test Control Snapshot 1"
+    })
+    assessment = self.create_object(models.Assessment, {
+        "title": "Test Assessment Snapshot 1"
+    })
+
+    self.create_mapping(program, control)
+    self.create_mapping(program, assessment)
+
+    control = self.refresh_object(control)
+
+    self.api.modify_object(control, {
+        "title": "Test Control Snapshot 1 EDIT 1"
+    })
+
+    self.create_object(models.Audit, {
+        "title": "Snapshotable audit",
+        "program": {"id": program.id},
+        "status": "Planned",
+        "snapshots": {
+            "operation": "create"
+        }
+    })
+
+    self.assertEqual(
+        db.session.query(models.Audit).filter(
+            models.Audit.title.like(
+                "%Snapshotable audit%")).count(), 1)
+
+    snapshot = db.session.query(models.Snapshot).filter(
+        models.Snapshot.child_id == control.id,
+        models.Snapshot.child_type == "Control",
+    )
+
+    self.assertEqual(snapshot.count(), 1)
+    self.assertEqual(
+        snapshot.first().revision.content["title"],
+        "Test Control Snapshot 1 EDIT 1")
+
+    snapshot_revision = db.session.query(
+        models.Revision.resource_type,
+        models.Revision.resource_id,
+        models.Revision.content
+    ).filter(
+        models.Revision.resource_type == "Snapshot",
+        models.Revision.resource_id == snapshot.first().id,
+    )
+
+    self.assertEqual(snapshot_revision.count(), 1)
+    snapshot_revision_content = snapshot_revision.first()[2]
+    self.assertEqual(snapshot_revision_content["child_type"], "Control")
+    self.assertEqual(snapshot_revision_content["child_id"], control.id)
+
+    relationship_columns = db.session.query(models.Relationship)
+    relationship = relationship_columns.filter(
+        models.Relationship.source_type == "Control",
+        models.Relationship.source_id == control.id,
+        models.Relationship.destination_type == "Snapshot",
+        models.Relationship.destination_id == snapshot.first().id
+    ).union(
+        relationship_columns.filter(
+            models.Relationship.source_type == "Snapshot",
+            models.Relationship.source_id == snapshot.first().id,
+            models.Relationship.destination_type == "Control",
+            models.Relationship.destination_id == control.id
+        )
+    )
+    self.assertEqual(relationship.count(), 1)
+
+    relationship_revision = db.session.query(
+        models.Revision.resource_type,
+        models.Revision.resource_id,
+        models.Revision.content,
+    ).filter(
+        models.Revision.resource_type == "Relationship",
+        models.Revision.resource_id == relationship.first().id,
+    )
+    self.assertEqual(relationship_revision.count(), 1)
+
+  def test_snapshot_update(self):
+    """Test simple snapshot creation with a simple change"""
+    program = self.create_object(models.Program, {
+        "title": "Test Program Snapshot 1"
+    })
+    control = self.create_object(models.Control, {
+        "title": "Test Control Snapshot 1"
+    })
+
+    self.create_mapping(program, control)
+
+    control = self.refresh_object(control)
+
+    self.api.modify_object(control, {
+        "title": "Test Control Snapshot 1 EDIT 1"
+    })
+
+    self.create_audit(program)
+
+    audit = db.session.query(models.Audit).filter(
+        models.Audit.title.like("%Snapshotable audit%")).one()
+
+    control_snapshot = db.session.query(models.Snapshot).filter(
+        models.Snapshot.child_id == control.id,
+        models.Snapshot.child_type == "Control",
+        models.Snapshot.parent_type == "Audit",
+        models.Snapshot.parent_id == audit.id)
+
+    self.assertEqual(control_snapshot.count(), 1)
+    self.assertEqual(control_snapshot.first().revision.content["title"],
+                     "Test Control Snapshot 1 EDIT 1")
+
+    # Create a new objective, add it to program and edit control to detect
+    # update.
+
+    objective = self.create_object(models.Objective, {
+        "title": "Test Objective Snapshot UNEDITED"
+    })
+    self.create_mapping(program, objective)
+
+    self.api.modify_object(control, {
+        "title": "Test Control Snapshot 1 Edit 2 AFTER initial snapshot"
+    })
+
+    audit = self.refresh_object(audit)
+    # Initiate update operation
+    self.api.modify_object(audit, {
+        "snapshots": {
+            "operation": "upsert"
+        }
+    })
+
+    objective_snapshot = db.session.query(models.Snapshot).filter(
+        models.Snapshot.child_type == "Objective",
+        models.Snapshot.child_id == objective.id,
+        models.Snapshot.parent_type == "Audit",
+        models.Snapshot.parent_id == audit.id
+    )
+    self.assertEqual(objective_snapshot.count(), 1)
+    self.assertEqual(
+        objective_snapshot.first().revision.content["title"],
+        "Test Objective Snapshot UNEDITED")
+
+    control_snapshot = db.session.query(models.Snapshot).filter(
+        models.Snapshot.child_type == "Control",
+        models.Snapshot.child_id == control.id,
+        models.Snapshot.parent_type == "Audit",
+        models.Snapshot.parent_id == audit.id
+    )
+    self.assertEqual(control_snapshot.count(), 1)
+    self.assertEqual(control_snapshot.first().revision.content["title"],
+                     "Test Control Snapshot 1 Edit 2 AFTER initial snapshot")
+
+    control_revisions = db.session.query(models.Revision).filter(
+        models.Revision.resource_type == control.type,
+        models.Revision.resource_id == control.id)
+    self.assertEqual(
+        control_revisions.count(), 3,
+        "There were 3 edits made at the time")
+
+    self.assertEqual(
+        control_revisions.order_by(models.Revision.id.desc()).first().id,
+        control_snapshot.one().revision_id)
+
+  def test_update_to_specific_version(self):
+    """Test global update and selecting a specific revision for one object"""
+    program = self.create_object(models.Program, {
+        "title": "Test Program Snapshot 1"
+    })
+    control = self.create_object(models.Control, {
+        "title": "Test Control Snapshot 1"
+    })
+
+    objective = self.create_object(models.Objective, {
+        "title": "Test Objective Snapshot 1"
+    })
+
+    self.create_mapping(program, control)
+    self.create_mapping(program, objective)
+
+    control = self.refresh_object(control)
+    for x in xrange(1, 4):
+      self.api.modify_object(control, {
+          "title": "Test Control Snapshot 1 EDIT {}".format(x)
+      })
+
+    self.create_object(models.Audit, {
+        "title": "Snapshotable audit",
+        "program": {"id": program.id},
+        "status": "Planned",
+        "snapshots": {
+            "operation": "create"
+        }
+    })
+
+    audit = db.session.query(models.Audit).filter(
+        models.Audit.title.like("%Snapshotable audit%")).one()
+
+    revision = db.session.query(
+        models.Revision.id,
+        models.Revision.resource_type,
+        models.Revision.resource_id,
+        models.Revision.content,
+    ).filter(
+        models.Revision.resource_type == control.type,
+        models.Revision.resource_id == control.id,
+        models.Revision.content.like("%Test Control Snapshot 1 EDIT 2%"),
+    ).one()
+
+    audit = self.refresh_object(audit)
+    self.api.modify_object(audit, {
+        "snapshots": {
+            "operation": "upsert",
+            "revisions": [{
+                "parent": self.objgen.create_stub(audit),
+                "child": self.objgen.create_stub(control),
+                "revision_id": revision[0]
+            }]
+        }
+    })
+
+    control_snapshot = db.session.query(models.Snapshot).filter(
+        models.Snapshot.child_type == control.type,
+        models.Snapshot.child_id == control.id,
+        models.Snapshot.parent_type == "Audit",
+        models.Snapshot.parent_id == audit.id
+    )
+    self.assertEqual(control_snapshot.count(), 1)
+    self.assertEqual(control_snapshot.first().revision.content["title"],
+                     "Test Control Snapshot 1 EDIT 2")
+
+  def test_snapshot_creation_with_custom_attribute_values(self):
+    pass
+
+  def test_creation_of_snapshots_for_multiple_parent_objects(self):
+    pass
+
+  def test_individual_update(self):
+    """Test update of individual snapshot
+
+    1. Create program with mapped control and data asset.
+    2. Create audit, verify there are snapshot for control and data asset
+    3. Update control and data asset title
+    4. Run refresh on control's snapshot object
+    5. Verify control's title is changed and data assets NOT
+    """
+
+    program = self.create_object(models.Program, {
+        "title": "Test Program Snapshot 1"
+    })
+
+    control = self.create_object(models.Control, {
+        "title": "Test Control Snapshot 1"
+    })
+    data_asset = self.create_object(models.DataAsset, {
+        "title": "Test DataAsset Snapshot 1"
+    })
+
+    self.create_mapping(program, control)
+    self.create_mapping(program, data_asset)
+
+    control = self.refresh_object(control)
+    data_asset = self.refresh_object(data_asset)
+
+    self.create_audit(program)
+
+    audit = db.session.query(models.Audit).filter(
+        models.Audit.title.like("%Snapshotable audit%")).one()
+
+    self.assertEqual(
+        db.session.query(models.Snapshot).filter(
+            models.Snapshot.parent_type == "Audit",
+            models.Snapshot.parent_id == audit.id).count(),
+        2)
+
+    control = self.refresh_object(control)
+    self.api.modify_object(control, {
+        "title": "Test Control Snapshot 1 EDIT 1"
+    })
+
+    data_asset = self.refresh_object(data_asset)
+    self.api.modify_object(data_asset, {
+        "title": "Test Data Asset Snapshot 1 EDIT 1"
+    })
+
+    control_snapshot = db.session.query(models.Snapshot).filter(
+        models.Snapshot.child_type == "Control",
+        models.Snapshot.child_id == control.id).first()
+
+    self.assertEqual(
+        control_snapshot.revision.content["title"],
+        "Test Control Snapshot 1")
+
+    self.api.modify_object(control_snapshot, {
+        "update_revision": "latest"
+    })
+
+    expected = [
+        (control, "Test Control Snapshot 1 EDIT 1"),
+        (data_asset, "Test DataAsset Snapshot 1"),
+    ]
+    for obj, expected_title in expected:
+      snapshot = db.session.query(models.Snapshot).filter(
+          models.Snapshot.child_type == obj.__class__.__name__,
+          models.Snapshot.child_id == obj.id).first()
+      self.assertEquals(
+          snapshot.revision.content["title"],
+          expected_title)
+
+    control_snapshot_event = db.session.query(models.Event).filter(
+        models.Event.resource_type == "Snapshot",
+        models.Event.resource_id == control_snapshot.id,
+        models.Event.action == "PUT"
+    )
+    self.assertEqual(control_snapshot_event.count(), 1)
+
+    control_snapshot_revisions = db.session.query(models.Revision).filter(
+        models.Revision.resource_type == "Snapshot",
+        models.Revision.resource_id == control_snapshot.id
+    )
+    self.assertEqual(control_snapshot_revisions.count(), 2)
+
+  def test_snapshot_put_operation(self):
+    """Test that performing PUT operation on snapshot does not change any values
+    """
+
+    program = self.create_object(models.Program, {
+        "title": "Test Program Snapshot 1"
+    })
+
+    control = self.create_object(models.Control, {
+        "title": "Test Control Snapshot 1"
+    })
+
+    self.create_mapping(program, control)
+
+    control = self.refresh_object(control)
+
+    self.create_audit(program)
+
+    control = self.refresh_object(control)
+    self.api.modify_object(control, {
+        "title": "Test Control Snapshot 1 EDIT 1"
+    })
+
+    control_snapshot = db.session.query(models.Snapshot).filter(
+        models.Snapshot.child_type == "Control",
+        models.Snapshot.child_id == control.id).first()
+
+    self.assertEqual(
+        control_snapshot.revision.content["title"],
+        "Test Control Snapshot 1")
+
+    audit = db.session.query(models.Audit).filter(
+        models.Audit.title.like("%Snapshotable audit%")).one()
+
+    update_data = {
+        "parent_id": audit.id + 123,
+        "parent_type": "DataAsset",
+        "child_id": control_snapshot.id + 123,
+        "child_type": "Regulation",
+        "revision_id": control_snapshot.revision_id + 123,
+    }
+    self.api.modify_object(control_snapshot, update_data)
+
+    control_snapshot_updated = db.session.query(models.Snapshot).filter(
+        models.Snapshot.child_type == control.__class__.__name__,
+        models.Snapshot.child_id == control.id).one()
+
+    for field in update_data.keys():
+      self.assertEqual(
+          getattr(control_snapshot, field),
+          getattr(control_snapshot_updated, field)
+      )
+
+  def test_update_when_mapped_objects_are_deleted(self):
+    """Test global update when object got deleted or unmapped"""
+    pass
+
+  def test_snapshoting_of_objects(self):
+    """Test that all object types that should be snapshotted are snapshotted
+
+    It is expected that all objects will be triplets.
+    """
+
+    self._import_file("snapshotter_create.csv")
+
+    # Verify that all objects got imported correctly.
+    for _type in Types.all:
+      self.assertEqual(
+          db.session.query(getattr(models.all_models, _type)).count(),
+          3)
+
+    program = db.session.query(models.Program).filter(
+        models.Program.slug == "Prog-13211"
+    ).one()
+
+    self.create_audit(program)
+
+    audit = db.session.query(models.Audit).filter(
+        models.Audit.title.like("%Snapshotable audit%")).first()
+
+    snapshots = db.session.query(models.Snapshot).filter(
+        models.Snapshot.parent_type == "Audit",
+        models.Snapshot.parent_id == audit.id,
+    )
+
+    self.assertEqual(snapshots.count(), len(Types.all) * 3)
+
+    type_count = collections.defaultdict(int)
+    for snapshot in snapshots:
+      type_count[snapshot.child_type] += 1
+
+    missing_types = set()
+    for snapshottable_type in Types.all:
+      if type_count[snapshottable_type] != 3:
+        missing_types.add(snapshottable_type)
+
+    self.assertEqual(missing_types, set())
+
+  def test_snapshot_update_is_idempotent(self):
+    """Test that nothing has changed if there's nothing to update"""
+    self._import_file("snapshotter_create.csv")
+
+    program = db.session.query(models.Program).filter(
+        models.Program.slug == "Prog-13211"
+    ).one()
+
+    self.create_audit(program)
+
+    audit = db.session.query(models.Audit).filter(
+        models.Audit.title.like("%Snapshotable audit%")).first()
+
+    snapshots = db.session.query(models.Snapshot).filter(
+        models.Snapshot.parent_type == "Audit",
+        models.Snapshot.parent_id == audit.id,
+    )
+
+    self.assertEqual(snapshots.count(), len(Types.all) * 3)
+
+    audit = self.refresh_object(audit)
+    self.api.modify_object(audit, {
+        "snapshots": {
+            "operation": "upsert"
+        }
+    })
+
+    old_snapshots = {s.id: s for s in snapshots}
+
+    snapshots = db.session.query(models.Snapshot).filter(
+        models.Snapshot.parent_type == "Audit",
+        models.Snapshot.parent_id == audit.id,
+    )
+
+    new_snapshots = {s.id: s for s in snapshots}
+
+    for _id, snapshot in new_snapshots.items():
+      self.assertEqual(snapshot_identity(old_snapshots[_id], snapshot), True)
+
+  def test_audit_creation_if_nothing_in_program_scope(self):
+    """Test audit creation if there's nothing in prog scope"""
+    program_title = "empty program"
+    audit_title = "Audit for empty program"
+
+    self.create_object(models.Program, {
+        "title": program_title,
+    })
+
+    program = db.session.query(models.Program).filter(
+        models.Program.title == "empty program"
+    ).one()
+
+    self.create_object(models.Audit, {
+        "title": "Audit for empty program",
+        "program": {"id": program.id},
+        "status": "Planned",
+        "snapshots": {
+            "operation": "create",
+        }
+    })
+
+    audit = db.session.query(models.Audit).filter(
+        models.Audit.title == audit_title).one()
+
+    self.assertEqual(
+        db.session.query(models.Audit).filter(
+            models.Audit.title == audit_title).count(), 1)
+
+    snapshots = db.session.query(models.Snapshot).filter(
+        models.Snapshot.parent_type == "Audit",
+        models.Snapshot.parent_id == audit.id,
+    )
+
+    self.assertEqual(snapshots.count(), 0)


### PR DESCRIPTION
This adds snapshot generator and adds tests for core generator and for indexing that was left missing from #4654.

To test you should verify all the object that should be snapshotted (per rules) are actually snapshotted and set to correct (latest) revision. You can also perform various PUT to audit/snapshot to verify what bulk/individual updates have gone through. See tests for examples. If you believe there is a missing test scenario, please point it out.

All of aforementioned verification will have to be performed in database since frontend cannot properly fetch snapshots until @zidarsk8 finishes his Query API work.