### PR TITLE
GGRC-171 open view buttons

### DIFF
--- a/src/ggrc/assets/javascripts/components/view-object-button/view-object-button.js
+++ b/src/ggrc/assets/javascripts/components/view-object-button/view-object-button.js
@@ -13,7 +13,22 @@
       '/components/view-object-button/view-object-button.mustache'
     ),
     scope: {
-      instance: null
+      instance: null,
+      define: {
+        maximize: {
+          type: 'boolean',
+          'default': false
+        }
+      },
+      maximizeObject: function (scope, el, ev) {
+        var tree = el.closest('.cms_controllers_tree_view_node');
+        var node = tree.control();
+        ev.preventDefault();
+        ev.stopPropagation();
+        if (node) {
+          node.select('max');
+        }
+      }
     }
   });
 })(window.can);

--- a/src/ggrc/assets/javascripts/controllers/info_pin_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/info_pin_controller.js
@@ -46,6 +46,17 @@ can.Control('CMS.Controllers.InfoPin', {
         }
       });
   },
+  getPinHeight: function (size) {
+    switch (size) {
+      case 'min':
+        return 75;
+      case 'max':
+        return Math.floor($(window).height() * 3 / 4);
+      case 'normal':
+      default:
+        return Math.floor($(window).height() / 3);
+    }
+  },
   hideInstance: function () {
     this.element.stop(true);
     this.element.height(0).html('');
@@ -64,12 +75,13 @@ can.Control('CMS.Controllers.InfoPin', {
       }.bind(this)
     });
   },
-  setInstance: function (instance, el) {
+  setInstance: function (instance, el, size) {
     var options = this.findOptions(el);
     var view = this.findView(instance);
-    var panelHeight = $(window).height() / 3;
+    var panelHeight = this.getPinHeight(size);
     var confirmEdit = instance.class.confirmEditModal ?
       instance.class.confirmEditModal : {};
+    var currentPanelHeight;
 
     if (!_.isEmpty(confirmEdit)) {
       confirmEdit.confirm = this.confirmEdit;
@@ -93,7 +105,8 @@ can.Control('CMS.Controllers.InfoPin', {
     this.loadChildTrees();
 
     // Make sure pin is visible
-    if (!this.element.height()) {
+    currentPanelHeight = this.element.height();
+    if (!currentPanelHeight || currentPanelHeight !== panelHeight) {
       this.element.animate({
         height: panelHeight
       }, {
@@ -158,19 +171,15 @@ can.Control('CMS.Controllers.InfoPin', {
   },
   '.pin-action a click': function (el) {
     var $win = $(window);
-    var winHeight = $win.height();
     var options = {
       duration: 800,
       easing: 'easeOutExpo'
     };
-    var targetHeight = {
-      min: 75,
-      normal: (winHeight / 3),
-      max: (winHeight * 3 / 4)
-    };
     var $info = this.element.find('.info');
     var type = el.data('size');
-    var size = targetHeight[type];
+    var size = this.getPinHeight(type);
+    var infoPinSizeClass = type ?
+      type + '-pin-size' : 'normal-pin-size';
 
     if (type === 'deselect') {
       // TODO: Make some direct communication between the components
@@ -195,6 +204,11 @@ can.Control('CMS.Controllers.InfoPin', {
 
     this.element.animate({height: size}, options);
     el.find('i').css({opacity: 1});
+    $('.cms_controllers_tree_view_node.active')
+      .removeClass(function (index, css) {
+        return (css.match(/\w+-pin-size/g) || []).join(' ');
+      })
+      .addClass(infoPinSizeClass);
   },
   ' scroll': function (el, ev) {
     var header = this.element.find('.pane-header');

--- a/src/ggrc/assets/mustache/assessments/header.mustache
+++ b/src/ggrc/assets/mustache/assessments/header.mustache
@@ -46,7 +46,7 @@ Copyright (C) 2016 Google Inc.
                               <li>
                                   <a href="{{instance.viewLink}}">
                                       <i class="fa fa-long-arrow-right"></i>
-                                      View {{instance.class.title_singular}}
+                                      Open {{instance.class.title_singular}}
                                   </a>
                               </li>
                           {{/is_allowed}}

--- a/src/ggrc/assets/mustache/base_objects/dropdown_menu.mustache
+++ b/src/ggrc/assets/mustache/base_objects/dropdown_menu.mustache
@@ -111,7 +111,7 @@
           <li>
             <a href="{{instance.viewLink}}">
               <i class="fa fa-long-arrow-right"></i>
-              View {{instance.class.title_singular}}
+              Open {{instance.class.title_singular}}
             </a>
           </li>
         {{/is_allowed}}

--- a/src/ggrc/assets/mustache/base_objects/dropdown_menu_tier2.mustache
+++ b/src/ggrc/assets/mustache/base_objects/dropdown_menu_tier2.mustache
@@ -55,7 +55,7 @@
         <li>
           <a href="{{instance.viewLink}}">
             <i class="fa fa-long-arrow-right"></i>
-            View {{instance.class.title_singular}}
+            Open {{instance.class.title_singular}}
           </a>
         </li>
       {{/is_allowed}}

--- a/src/ggrc/assets/mustache/base_objects/info_header.mustache
+++ b/src/ggrc/assets/mustache/base_objects/info_header.mustache
@@ -37,7 +37,7 @@
                   <li>
                     <a href="{{instance.viewLink}}">
                       <i class="fa fa-long-arrow-right"></i>
-                      View {{instance.class.title_singular}}
+                      Open {{instance.class.title_singular}}
                     </a>
                   </li>
                 {{/is_allowed}}

--- a/src/ggrc/assets/mustache/base_objects/states.mustache
+++ b/src/ggrc/assets/mustache/base_objects/states.mustache
@@ -67,7 +67,7 @@
                 </li>
               {{/object_tasks}}
             </ul>
-            <a class="info-action" href="{{instance.viewLink}}#task_widget"><i class="fa fa-long-arrow-right"></i> View tasks</a>
+            <a class="info-action" href="{{instance.viewLink}}#task_widget"><i class="fa fa-long-arrow-right"></i> Open tasks</a>
           </div>
         </div>
       </div>

--- a/src/ggrc/assets/mustache/base_objects/tree.mustache
+++ b/src/ggrc/assets/mustache/base_objects/tree.mustache
@@ -99,7 +99,10 @@
                       {{{renderLive add_item_view}}}
                     {{/if}}
                   {{/child_options}}
-                  <view-object-button instance="instance" />
+                  {{^is_subtree}}
+                      <view-object-button instance="instance" />
+                  {{/is_subtree}}
+                  <view-object-button instance="instance" maximize="true" />
                 </div>
                 <ul class="tree-action-list">
                   {{#infer_roles instance}}

--- a/src/ggrc/assets/mustache/base_objects/view_link.mustache
+++ b/src/ggrc/assets/mustache/base_objects/view_link.mustache
@@ -7,7 +7,7 @@
   <li>
     <a href="{{instance.viewLink}}">
       <i class="fa fa-long-arrow-right"></i>
-      View {{instance.class.title_singular}}
+      Open {{instance.class.title_singular}}
     </a>
   </li>
 {{/if}}

--- a/src/ggrc/assets/mustache/base_templates/header.mustache
+++ b/src/ggrc/assets/mustache/base_templates/header.mustache
@@ -79,7 +79,7 @@
                   <li>
                     <a href="{{instance.viewLink}}">
                       <i class="fa fa-long-arrow-right"></i>
-                      View {{instance.class.title_singular}}
+                      Open {{instance.class.title_singular}}
                     </a>
                   </li>
                 {{/is_allowed}}

--- a/src/ggrc/assets/mustache/components/view-object-button/view-object-button.mustache
+++ b/src/ggrc/assets/mustache/components/view-object-button/view-object-button.mustache
@@ -4,9 +4,16 @@
 }}
 
 {{#if instance.viewLink}}
-    {{#is_allowed "view_object_page" instance}}
-        <a href="{{instance.viewLink}}" target="_blank" class="btn btn-mini btn-outline">
-            Open
-        </a>          
-    {{/is_allowed}}
+  {{#is_allowed "view_object_page" instance}}
+    {{^maximize}}
+    <a href="{{instance.viewLink}}" target="_blank" class="btn btn-mini btn-outline">
+      Open
+    </a>
+    {{/maximize}}
+    {{#maximize}}
+    <a href="#" class="btn btn-mini btn-outline" can-click="maximizeObject">
+      View
+    </a>
+    {{/maximize}}
+  {{/is_allowed}}
 {{/if}}

--- a/src/ggrc/assets/mustache/controls/object_list.mustache
+++ b/src/ggrc/assets/mustache/controls/object_list.mustache
@@ -36,7 +36,7 @@
           <div class="span6">
             <a href="{{viewLink}}" class="info-action">
               <i class="fa fa-long-arrow-right"></i>
-              View {{class.title_singular}}
+              Open {{class.title_singular}}
             </a>
           </div>
 

--- a/src/ggrc/assets/mustache/dashboard/object_list.mustache
+++ b/src/ggrc/assets/mustache/dashboard/object_list.mustache
@@ -36,7 +36,7 @@
           <div class="span6">
             <a href="{{viewLink}}" class="info-action">
               <i class="fa fa-long-arrow-right"></i>
-              View {{class.title_singular}}
+              Open {{class.title_singular}}
             </a>
           </div>
         </div>

--- a/src/ggrc/assets/mustache/people/object_list.mustache
+++ b/src/ggrc/assets/mustache/people/object_list.mustache
@@ -75,7 +75,7 @@
               <li>
                 <a href="/people/{{id}}">
                   <i class="fa fa-long-arrow-right"></i>
-                  View Profile Page
+                  Open Profile Page
                 </a>
               </li>
               {{#is_allowed 'create' 'delete' 'UserRole' context=parent_instance.context.id}}

--- a/src/ggrc/assets/mustache/sections/dropdown_menu.mustache
+++ b/src/ggrc/assets/mustache/sections/dropdown_menu.mustache
@@ -30,7 +30,7 @@
           <li>
             <a href="{{instance.viewLink}}">
               <i class="fa fa-long-arrow-right"></i>
-              View {{instance.class.title_singular}}
+              Open {{instance.class.title_singular}}
             </a>
           </li>
         {{/is_allowed}}

--- a/src/ggrc/assets/mustache/sections/tier2_content.mustache
+++ b/src/ggrc/assets/mustache/sections/tier2_content.mustache
@@ -15,7 +15,7 @@
         <li>
           <a href="{{instance.viewLink}}">
             <i class="fa fa-long-arrow-right"></i>
-            View {{instance.class.title_singular}}
+            Open {{instance.class.title_singular}}
           </a>
         </li>
       {{/is_allowed}}

--- a/src/ggrc_basic_permissions/assets/mustache/ggrc_basic_permissions/people_roles/authorizations_by_person_list.mustache
+++ b/src/ggrc_basic_permissions/assets/mustache/ggrc_basic_permissions/people_roles/authorizations_by_person_list.mustache
@@ -147,7 +147,7 @@
               <div>
                 <a href="/people/{{id}}" class="info-action">
                   <i class="fa fa-long-arrow-right"></i>
-                  View Profile Page
+                  Open Profile Page
                 </a>
               </div>
             </div>

--- a/src/ggrc_basic_permissions/assets/mustache/ggrc_basic_permissions/people_roles/info.mustache
+++ b/src/ggrc_basic_permissions/assets/mustache/ggrc_basic_permissions/people_roles/info.mustache
@@ -55,7 +55,7 @@
         <li>
           <a href="/people/{{instance.id}}">
             <i class="fa fa-long-arrow-right"></i>
-            View Profile Page
+            Open Profile Page
           </a>
         </li>
       </ul>

--- a/src/ggrc_workflows/assets/mustache/cycle_task_group_objects/info.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_group_objects/info.mustache
@@ -36,7 +36,7 @@
                   <li>
                     <a href="{{object.viewLink}}">
                       <i class="fa fa-long-arrow-right"></i>
-                      View {{object.class.title_singular}}
+                      Open {{object.class.title_singular}}
                     </a>
                   </li>
                 {{/is_allowed}}

--- a/src/ggrc_workflows/assets/mustache/cycles/info.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycles/info.mustache
@@ -24,7 +24,7 @@
               <li>
                 <a href="{{workflow.viewLink}}">
                   <i class="fa fa-long-arrow-right"></i>
-                  View {{workflow.class.title_singular}}
+                  Open {{workflow.class.title_singular}}
                 </a>
               </li>
             {{!/is_allowed}}

--- a/src/ggrc_workflows/assets/mustache/workflows/info.mustache
+++ b/src/ggrc_workflows/assets/mustache/workflows/info.mustache
@@ -84,7 +84,7 @@
                 <li>
                   <a href="{{instance.viewLink}}">
                     <i class="fa fa-long-arrow-right"></i>
-                    View {{instance.class.title_singular}}
+                    Open {{instance.class.title_singular}}
                   </a>
                 </li>
               {{/is_allowed}}


### PR DESCRIPTION
This PR adds view button that opens assessments in maximized mode. It also hides open buttons in subtree items and changes wording of "View" menu items across the project.

From Jira description:
On the assessment tree view, the user prefer not clicking the open button, rather maximizing the modal, however maximizing is not clear as the open button. UX suggestions are needed to making maximizing more prominent.
To implement the following:
1. Add new button "View" to open modal window. 
2. Remove "Open" button for rows in the tree; View is more popular action; a user still can open an object via [...] 3dot menu.
3. Rename action in the 3dot menu from View to Open. 