### PR TITLE
GGRC-249 Fix UI update on CA definition deletion

### DIFF
--- a/src/ggrc/assets/mustache/custom_attribute_definitions/subtree.mustache
+++ b/src/ggrc/assets/mustache/custom_attribute_definitions/subtree.mustache
@@ -4,7 +4,10 @@
 }}
 
 
-<tr>
+<tr
+  data-object-id="{{instance.id}}"
+  data-object-type="{{instance.constructor.table_singular}}"
+>
   {{#instance}}
   <td>{{title}}</td>
   <td>{{attribute_type}}</td>


### PR DESCRIPTION
This PR fixes the UI glitch that did not remove a (sub)tree item when a Custom Attribute Definition was deleted (putting `on hold`, please remove the label once the QA testing  of the release branch finishes).

The issue was caused by the subtree DOM items missing essential `data-*` attributes that the tree view controller uses for locating and removing elements from the DOM (the internal state of the tree view controller and the database were fine, it was just the DOM element that wasn't removed).


**Details:**
- Open Admin Dashboard
- Navigate to Custom Attributes tab
- Select object type (e.g. Audit) and expand it
- Add a new custom attribute definition to that type
- Click Edit next  to the Custom Attribute Definition
- Click Delete button
- Look at Custom Attributes tab

**Actual Result:**
attribute isn't removed from Custom Attributes tab, a page refresh is needed for the effect to be visible

**Expected Result:**
attribute should be removed from Custom Attributes tab

