### PR TITLE
GGRC-450 Make program dates non mandatory

### DIFF
--- a/src/ggrc/assets/javascripts/models/mixins.js
+++ b/src/ggrc/assets/javascripts/models/mixins.js
@@ -324,7 +324,7 @@
     'extend:attributes': {
       start_date: 'date',
       end_date: 'date'
-    },
+    }
   }, {
     // NOTE: when synchronizing mandatory asterisks of dates with backend for
     // all models, please set the default "required" options to false

--- a/src/ggrc/assets/javascripts/models/simple_models.js
+++ b/src/ggrc/assets/javascripts/models/simple_models.js
@@ -90,6 +90,11 @@ can.Model.Cacheable("CMS.Models.Program", {
     this._super.apply(this, arguments);
   }
 }, {
+  init: function () {
+    this._super.apply(this, arguments);
+    this.attr('configStartDate.required', false);
+    this.attr('configEndDate.required', false);
+  }
 });
 
 can.Model.Cacheable("CMS.Models.Option", {


### PR DESCRIPTION
This PR removes the "required" asterisks from Effective Date and Stop Date fields in Program modal.

`On hold` until a tag for PATCH4 is made.