### PR TITLE
QUICK-FIX Silence a particular warning message in karma test

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment_templates/tests/assessment_templates_spec.js
+++ b/src/ggrc/assets/javascripts/components/assessment_templates/tests/assessment_templates_spec.js
@@ -80,6 +80,7 @@ describe('GGRC.Components.assessmentTemplates', function () {
       function () {
         mapper.attr('assessmentTemplate', 'template-123');
         templates[1].subitems.length = 0;
+        spyOn(console, 'warn');  // just to silence it
 
         method(templates, mapper);
 


### PR DESCRIPTION
This PR silences a warning printed to the console by one of the karma unit tests. I got a feedback that it might look confusing to some people, even though all the tests pass.

With the fix, the following warning no longer show during the karma test run:
> 'GGRC.Components.assessmentTemplates: An empty template group encountered, possible API error'

Thanks @alieh-rymasheuski for the suggestion! :)