### PR TITLE
GGRC-296 Fix Saved message is not displayed after mapping a person

### DIFF
--- a/src/ggrc/assets/javascripts/components/ca-object/ca-object.js
+++ b/src/ggrc/assets/javascripts/components/ca-object/ca-object.js
@@ -44,15 +44,36 @@
       },
       save: function () {
         var value = this.attr('value');
+        var type = this.attr('type');
+        var valueId = Number(this.attr('valueId'));
+        var attributeObjectId;
+        var valueParts;
+        var customAttributeValue;
+        if (type === 'person') {
+          valueParts = value.split(':');
+          attributeObjectId = Number(valueParts[1]);
+          value = valueParts[0];
+        }
         this.setModified();
         this.attr('instance').save()
           .done(function () {
-            // TODO: remove hack for flash message appearance after normal solution will be applied
-            if (String(value) === this.attr('value')) {
-              can.$(document.body).trigger('ajax:flash', {
-                success: 'Saved'
-              });
+            if (type === 'person') {
+              customAttributeValue =
+                can.makeArray(this.attr('instance.custom_attribute_values'))
+                  .find(function (v) {
+                    return v.id === valueId;
+                  });
+              if (customAttributeValue &&
+                  customAttributeValue.attribute_object &&
+                  customAttributeValue.attribute_object.id !==
+                    attributeObjectId) {
+                return;
+              }
             }
+            if (String(value) !== this.attr('value')) {
+              return;
+            }
+            GGRC.Errors.notifier('success', 'Saved');
           }.bind(this))
           .fail(function (inst, err) {
             GGRC.Errors.notifierXHR('error')(err);

--- a/src/ggrc/assets/javascripts/components/tests/ca-object_spec.js
+++ b/src/ggrc/assets/javascripts/components/tests/ca-object_spec.js
@@ -1,0 +1,117 @@
+/*!
+ Copyright (C) 2016 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+describe('GGRC.Components.customAttributesObject', function () {
+  'use strict';
+
+  var Component;  // the component under test
+
+  beforeAll(function () {
+    Component = GGRC.Components.get('customAttributesObject');
+  });
+
+  describe('save() method', function () {
+    var save;  // the method under test
+    var scope;
+    var scope_;
+    var customAttributeValues;
+    var noConflictAssessment;
+    var hasConflictAssessment;
+    var noConflictSave;
+    var hasConflictSave;
+
+    beforeAll(function () {
+      noConflictSave = function () {
+        var deferred = $.Deferred().resolve();
+        this.attr('value', this.attr('value').split(':')[0]);
+        return deferred.promise();
+      };
+
+      hasConflictSave = function () {
+        var deferred = $.Deferred().resolve();
+        this.attr('value', 'changed');
+        return deferred.promise();
+      };
+    });
+
+    beforeEach(function () {
+      scope_ = Component.prototype.scope;
+
+      scope = new can.Map({
+        setModified: scope_.setModified,
+        valueId: '0',
+        def: {
+          id: 0
+        }
+      });
+
+      save = scope_.save.bind(scope);
+
+      spyOn(GGRC.Errors, 'notifier');
+
+      customAttributeValues = [
+        {id: 1},
+        {id: 0, attribute_object: {id: 2}}
+      ];
+
+      noConflictAssessment = {
+        save: noConflictSave.bind(scope),
+        custom_attribute_values: customAttributeValues
+      };
+      hasConflictAssessment = {
+        save: hasConflictSave.bind(scope),
+        custom_attribute_values: customAttributeValues
+      };
+    });
+
+    it('should show success message on no conflict on input fields',
+      function () {
+        scope.attr('instance', noConflictAssessment);
+        scope.attr('type', 'input');
+        scope.attr('value', 'test');
+
+        save();
+
+        expect(GGRC.Errors.notifier).toHaveBeenCalledWith('success', 'Saved');
+      }
+    );
+
+    it('should not show success message on conflict on input fields',
+      function () {
+        scope.attr('instance', hasConflictAssessment);
+        scope.attr('type', 'input');
+        scope.attr('value', 'test');
+
+        save();
+
+        expect(GGRC.Errors.notifier).not.toHaveBeenCalled();
+      }
+    );
+
+    it('should show success message on no conflict on map person fields',
+      function () {
+        scope.attr('instance', noConflictAssessment);
+        scope.attr('type', 'person');
+        scope.attr('value', 'Person:2');
+
+        save();
+
+        expect(GGRC.Errors.notifier).toHaveBeenCalledWith('success', 'Saved');
+      }
+    );
+
+    it('should not show success message on conflict on map person fields',
+      function () {
+        scope.attr('instance', hasConflictAssessment);
+        scope.attr('type', 'person');
+        scope.attr('value', 'Person:1');
+
+        save();
+
+        expect(GGRC.Errors.notifier).not.toHaveBeenCalled();
+      }
+    );
+  });
+});


### PR DESCRIPTION
This PR fixes issue that "Saved" message is not displayed after edit Person CA field in Assessment's Info panel. The problem is that "Map person" CA field type has specific value.