### PR TITLE
GGRC-277 Fix odd behavior in edit modal when removing a CA without saving

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment_attributes.js
+++ b/src/ggrc/assets/javascripts/components/assessment_attributes.js
@@ -80,11 +80,22 @@
           COMMENT: 0,
           ATTACHMENT: 1
         },
+
+        _EV_FIELD_REMOVED: 'on-remove',
+
         /*
          * Removes `field` from `fields`
          */
         removeField: function (scope, el, ev) {
           ev.preventDefault();
+
+          // CAUTION: In order for the event to not get lost, triggering it
+          // must happen before changing any of the scope attributes that
+          // cause changes in the template.
+          this.$rootEl.triggerHandler({
+            type: this._EV_FIELD_REMOVED
+          });
+
           scope.attr('_pending_delete', true);
         },
         /*
@@ -141,7 +152,14 @@
       };
     },
     events: {
-      init: function () {
+      /**
+       * The component's entry point.
+       *
+       * @param {Object} element - the (unwrapped) DOM element that triggered
+       *   creating the component instance
+       * @param {Object} options - the component instantiation options
+       */
+      init: function (element, options) {
         var field = this.scope.attr('field');
         var pads = this.scope.attr('pads');
         var denormalized = this.scope.denormalize_mandatory(field, pads);
@@ -151,6 +169,8 @@
         });
         this.scope.field.attr('attribute_name', item.name);
         this.scope.attr('attrs', denormalized);
+
+        this.scope.attr('$rootEl', $(element));
       },
       '{attrs} change': function () {
         var attrs = this.scope.attr('attrs');

--- a/src/ggrc/assets/javascripts/components/assessment_attributes.js
+++ b/src/ggrc/assets/javascripts/components/assessment_attributes.js
@@ -39,7 +39,23 @@
         type: 'Map:Person',
         name: 'Person',
         text: ''
-      }])
+      }]),
+
+      /**
+       * A handler for when a user removes a Custom Attribute Definition.
+       *
+       * It removes the corresponding CA definition object from the list to
+       * keep it in sync with the definitions listed in DOM.
+       *
+       * @param {CMS.Models.CustomAttributeDefinition} instance -
+       *   the definition that was removed
+       * @param {jQuery.Element} $el - the source of the event `ev`
+       * @param {jQuery.Event} ev - the onRemove event object
+       */
+      fieldRemoved: function (instance, $el, ev) {
+        var idx = _.findIndex(this.fields, {id: instance.id});
+        this.fields.splice(idx, 1);
+      }
     },
     events: {
       inserted: function () {

--- a/src/ggrc/assets/javascripts/components/tests/template_attributes_field_spec.js
+++ b/src/ggrc/assets/javascripts/components/tests/template_attributes_field_spec.js
@@ -1,7 +1,7 @@
 /*!
- Copyright (C) 2016 Google Inc.
- Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
- */
+  Copyright (C) 2016 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
 
 describe('GGRC.Components.templateAttributesField', function () {
   'use strict';
@@ -106,6 +106,60 @@ describe('GGRC.Components.templateAttributesField', function () {
       var result = normalizeMandatory(attrs, pads);
 
       expect(result).toEqual('0,2,1,3');
+    });
+  });
+
+  describe('emitting events', function () {
+    describe('on-remove event', function () {
+      var $root;  // the component's root DOM element
+      var onRemoveCallback;
+
+      beforeEach(function () {
+        var $body = $('body');
+        var docFragment;
+        var htmlSnippet;
+        var renderer;
+        var templateContext;
+
+        onRemoveCallback = jasmine.createSpy('onRemoveCallback');
+
+        htmlSnippet = [
+          '<template-field ',
+          '  field="fieldDefinition"',
+          '  can-on-remove="callMeOnRemove">',
+          '</template-field>'
+        ].join('');
+
+        templateContext = new can.Map({
+          types: new can.List([
+            {
+              type: 'Text',
+              name: 'Text',
+              text: 'Enter description'
+            }
+          ]),
+          fieldDefinition: {
+            attribute_type: 'Text'
+          },
+          callMeOnRemove: onRemoveCallback
+        });
+
+        renderer = can.view.mustache(htmlSnippet);
+        docFragment = renderer(templateContext);
+        $body.append(docFragment);
+
+        $root = $body.find('template-field');
+      });
+
+      afterEach(function () {
+        $root.remove();
+      });
+
+      it('invokes the provided handler when element is removed', function () {
+        var $btnDelete = $root.find('.fa-trash').closest('a');
+        $btnDelete.click();
+        expect(onRemoveCallback).toHaveBeenCalled();
+      });
     });
   });
 });

--- a/src/ggrc/assets/javascripts/components/tests/template_attributes_spec.js
+++ b/src/ggrc/assets/javascripts/components/tests/template_attributes_spec.js
@@ -1,0 +1,46 @@
+/*!
+  Copyright (C) 2016 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+describe('GGRC.Components.templateAttributes', function () {
+  'use strict';
+
+  var Component;  // the component under test
+
+  beforeAll(function () {
+    Component = GGRC.Components.get('templateAttributes');
+  });
+
+  describe('fieldRemoved() method', function () {
+    var method;  // the method under test
+    var scope;
+
+    beforeEach(function () {
+      scope = new can.Map({
+        fields: []
+      });
+      method = Component.prototype.scope.fieldRemoved.bind(scope);
+    });
+
+    it('removes the deleted field from the fields list', function () {
+      var remainingFields;
+      var $el = $('<p></p>');
+      var eventObj = $.Event('on-delete');
+
+      var deletedField = new can.Map({id: 4, title: 'bar'});
+
+      var currentFields = [
+        new can.Map({id: 17, title: 'foo'}),
+        new can.Map({id: 4, title: 'bar'}),
+        new can.Map({id: 52, title: 'baz'})
+      ];
+      scope.attr('fields').replace(currentFields);
+
+      method(deletedField, $el, eventObj);
+
+      remainingFields = _.map(scope.fields, 'title');
+      expect(remainingFields).toEqual(['foo', 'baz']);
+    });
+  });
+});

--- a/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
@@ -248,7 +248,10 @@
                     {{#fields}}
                       {{^if _pending_delete}}
                           <li class="row-fluid sortable-item" {{data 'field'}}>
-                              <template-field field="." fields="fields"></template-field>
+                              <template-field
+                                field="."
+                                fields="fields"
+                                can-on-remove="fieldRemoved"></template-field>
                           </li>
                       {{/if _pending_delete}}
                     {{/fields}}


### PR DESCRIPTION
This PR fixes the issue in the Assessment Template edit modal that caused the lists of Custom Attribute Definitions in the DOM and in the code out of sync, which resulted in an odd behavior.

**Details:**
- Edit the Assessment template 
- Delete a CA field from the list but do not save the changes, just close the modal by clickig “X” button or clicking outside the modal
- Open Edit Assessment template modal again

**Actual Result:**
the app shows that another field has been removed

**Expected Result:**
the changes weren’t saved so the app should show all the fields after reopening edit modal
