### PR TITLE
GGRC-69 Snapshot In-Scope Mappings

### DIFF
--- a/src/ggrc/assets/javascripts/components/unified_mapper/mapper.js
+++ b/src/ggrc/assets/javascripts/components/unified_mapper/mapper.js
@@ -27,6 +27,7 @@
     entries: new can.List(),
     options: new can.List(),
     relevant: new can.List(),
+    is_snapshotable: false,
     get_instance: can.compute(function () {
       return CMS.Models.get_instance(
         this.attr('object'),
@@ -176,7 +177,8 @@
           callback: parentScope.attr('callback'),
           getList: parentScope.attr('getList'),
           useTemplates: parentScope.attr('useTemplates'),
-          assessmentGenerator: parentScope.attr('assessmentGenerator')
+          assessmentGenerator: parentScope.attr('assessmentGenerator'),
+          is_snapshotable: parentScope.attr('is_snapshotable')
         })),
         template: parentScope.attr('template'),
         draw_children: true

--- a/src/ggrc/assets/javascripts/components/unified_mapper/mapper.js
+++ b/src/ggrc/assets/javascripts/components/unified_mapper/mapper.js
@@ -28,6 +28,8 @@
     options: new can.List(),
     relevant: new can.List(),
     is_snapshotable: false,
+    snapshot_scope_id: '',
+    snapshot_scope_type: '',
     get_instance: can.compute(function () {
       return CMS.Models.get_instance(
         this.attr('object'),
@@ -178,7 +180,9 @@
           getList: parentScope.attr('getList'),
           useTemplates: parentScope.attr('useTemplates'),
           assessmentGenerator: parentScope.attr('assessmentGenerator'),
-          is_snapshotable: parentScope.attr('is_snapshotable')
+          is_snapshotable: parentScope.attr('is_snapshotable'),
+          snapshot_scope_id: parentScope.attr('snapshot_scope_id'),
+          snapshot_scope_type: parentScope.attr('snapshot_scope_type')
         })),
         template: parentScope.attr('template'),
         draw_children: true

--- a/src/ggrc/assets/javascripts/components/unified_mapper/mapper_results.js
+++ b/src/ggrc/assets/javascripts/components/unified_mapper/mapper_results.js
@@ -249,6 +249,16 @@
         if (contact && contactEmail) {
           params.contact_id = contact.id;
         }
+
+        // Filter by scope
+        if (this.scope.attr('mapper.is_snapshotable')) {
+          // We can also display it in UI as disabled filter
+          filters.push(
+            this.scope.attr('mapper.snapshot_scope_type') +
+            ':' +
+            this.scope.attr('mapper.snapshot_scope_id'));
+        }
+
         if (!_.isEmpty(filters)) {
           params.relevant_objects = filters.join(',');
         }

--- a/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
@@ -1575,6 +1575,7 @@ can.Control('CMS.Controllers.TreeViewNode', {
   },
 
   init: function (el, opts) {
+    var parent = opts.parent_instance || {};
     if (this.options.instance && !this.options.show_view) {
       this.options.show_view =
         this.options.instance.constructor[this.options.options_property].show_view ||
@@ -1589,7 +1590,9 @@ can.Control('CMS.Controllers.TreeViewNode', {
           parent: this,
           parent_instance: this.options.instance,
           is_snapshotable:
-            GGRC.Utils.Snapshots.isSnapshotScope(opts.parent_instance)
+            GGRC.Utils.Snapshots.isSnapshotScope(parent),
+          snapshot_scope_id: parent.id,
+          snapshot_scope_type: parent.type
         });
       }.bind(this));
     }

--- a/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
@@ -1587,7 +1587,9 @@ can.Control('CMS.Controllers.TreeViewNode', {
       this.options.child_options.each(function (option) {
         option.attr({
           parent: this,
-          parent_instance: this.options.instance
+          parent_instance: this.options.instance,
+          is_snapshotable:
+            GGRC.Utils.Snapshots.isSnapshotScope(opts.parent_instance)
         });
       }.bind(this));
     }

--- a/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
+++ b/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
@@ -322,6 +322,15 @@
         return false;
       }
 
+      // special check for snapshot:
+      if (options &&
+          options.context &&
+          options.context.parent_instance &&
+          options.context.parent_instance.snapshot) {
+        // Avoid add mapping for snapshot
+        return false;
+      }
+
       canonical = GGRC.Mappings.get_canonical_mapping_name(
         sourceType, targetType);
       canonicalMapping = GGRC.Mappings.get_canonical_mapping(

--- a/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
+++ b/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
@@ -683,4 +683,33 @@
       initCounts: initCounts
     };
   })();
+
+  /**
+   * Util methods for work with Snapshots.
+   */
+  GGRC.Utils.Snapshots = (function () {
+    /**
+     * Check whether object is snapshot
+     * @param {Object} instance - Object instance
+     * @return {Boolean} True or False.
+     */
+    function isSnapshot(instance) {
+      return instance.snapshot;
+    }
+
+    /**
+     * Check whether object is in spanshot scope
+     * @param {Object} parentInstance - Object (parent) instance
+     * @return {Boolean} True or False.
+     */
+    function isSnapshotScope(parentInstance) {
+      var instance = parentInstance || GGRC.page_instance();
+      return instance ? instance.is_snapshotable : false;
+    }
+
+    return {
+      isSnapshot: isSnapshot,
+      isSnapshotScope: isSnapshotScope
+    };
+  })();
 })(jQuery, window.GGRC = window.GGRC || {}, window.moment, window.Permission);

--- a/src/ggrc/assets/mustache/assessments/tree_add_item.mustache
+++ b/src/ggrc/assets/mustache/assessments/tree_add_item.mustache
@@ -36,7 +36,9 @@
           data-join-object-id="{{parent_instance.id}}"
           data-join-object-type="{{parent_instance.class.shortName}}"
           data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}"
-          data-is-snapshotable="{{is_snapshotable}}">
+          data-is-snapshotable="{{is_snapshotable}}"
+          data-snapshot-scope-id="{{snapshot_scope_id}}"
+          data-snapshot-scope-type="{{snapshot_scope_type}}">
          Map
         </a>
       {{/is_allowed_to_map}}

--- a/src/ggrc/assets/mustache/assessments/tree_add_item.mustache
+++ b/src/ggrc/assets/mustache/assessments/tree_add_item.mustache
@@ -35,7 +35,8 @@
           data-join-option-type="{{model.shortName}}"
           data-join-object-id="{{parent_instance.id}}"
           data-join-object-type="{{parent_instance.class.shortName}}"
-          data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}">
+          data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}"
+          data-is-snapshotable="{{is_snapshotable}}">
          Map
         </a>
       {{/is_allowed_to_map}}

--- a/src/ggrc/assets/mustache/audits/tree_add_item.mustache
+++ b/src/ggrc/assets/mustache/audits/tree_add_item.mustache
@@ -34,7 +34,9 @@
         data-join-object-id="{{parent_instance.id}}"
         data-join-object-type="{{parent_instance.class.shortName}}"
         data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}"
-        data-is-snapshotable="{{is_snapshotable}}">
+        data-is-snapshotable="{{is_snapshotable}}"
+        data-snapshot-scope-id="{{snapshot_scope_id}}"
+        data-snapshot-scope-type="{{snapshot_scope_type}}">
         Map
       </a>
     {{/if}}

--- a/src/ggrc/assets/mustache/audits/tree_add_item.mustache
+++ b/src/ggrc/assets/mustache/audits/tree_add_item.mustache
@@ -33,7 +33,8 @@
         data-join-option-type="{{model.shortName}}"
         data-join-object-id="{{parent_instance.id}}"
         data-join-object-type="{{parent_instance.class.shortName}}"
-        data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}">
+        data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}"
+        data-is-snapshotable="{{is_snapshotable}}">
         Map
       </a>
     {{/if}}

--- a/src/ggrc/assets/mustache/base_objects/tree_add_item.mustache
+++ b/src/ggrc/assets/mustache/base_objects/tree_add_item.mustache
@@ -18,7 +18,9 @@
     data-join-object-type="{{parent_instance.class.shortName}}"
     data-exclude-option-types="{{exclude_option_types}}"
     data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}"
-    data-is-snapshotable="{{parent_instance.is_snapshotable}}">
+    data-is-snapshotable="{{parent_instance.is_snapshotable}}"
+    data-snapshot-scope-id="{{parent_instance.snapshot_scope_id}}"
+    data-snapshot-scope-type="{{parent_instance.snapshot_scope_type}}">
     Map
   </a>
   {{#if null}}
@@ -51,7 +53,9 @@
     data-exclude-option-types="{{exclude_option_types}}"
     data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}"
     data-object-params='{ "section": { "id": {{parent_instance.id}}, "title": "{{json_escape parent_instance.title}}", "description": "{{json_escape parent_instance.description}}" } }'
-    data-is-snapshotable="{{is_snapshotable}}">
+    data-is-snapshotable="{{is_snapshotable}}"
+    data-snapshot-scope-id="{{snapshot_scope_id}}"
+    data-snapshot-scope-type="{{snapshot_scope_type}}">
     Map
   </a>
   {{else}}
@@ -66,7 +70,9 @@
     data-join-object-type="{{parent_instance.class.shortName}}"
     data-exclude-option-types="{{exclude_option_types}}"
     data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}"
-    data-is-snapshotable="{{is_snapshotable}}">
+    data-is-snapshotable="{{is_snapshotable}}"
+    data-snapshot-scope-id="{{snapshot_scope_id}}"
+    data-snapshot-scope-type="{{snapshot_scope_type}}">
     Map
   </a>
   {{/if_instance_of}}

--- a/src/ggrc/assets/mustache/base_objects/tree_add_item.mustache
+++ b/src/ggrc/assets/mustache/base_objects/tree_add_item.mustache
@@ -17,7 +17,8 @@
     data-join-object-id="{{instance.id}}"
     data-join-object-type="{{parent_instance.class.shortName}}"
     data-exclude-option-types="{{exclude_option_types}}"
-    data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}">
+    data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}"
+    data-is-snapshotable="{{parent_instance.is_snapshotable}}">
     Map
   </a>
   {{#if null}}
@@ -31,7 +32,7 @@
        data-modal-reset="reset"
        data-modal-class="modal-wide"
        data-object-singular="{{parent_instance.class.model_singular}}"
-       data-object-plural="{{parent_instance.class.table_plural}}" >
+       data-object-plural="{{parent_instance.class.table_plural}}">
       Create New
     </a>
   </span>
@@ -50,7 +51,7 @@
     data-exclude-option-types="{{exclude_option_types}}"
     data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}"
     data-object-params='{ "section": { "id": {{parent_instance.id}}, "title": "{{json_escape parent_instance.title}}", "description": "{{json_escape parent_instance.description}}" } }'
-    >
+    data-is-snapshotable="{{is_snapshotable}}">
     Map
   </a>
   {{else}}
@@ -65,7 +66,7 @@
     data-join-object-type="{{parent_instance.class.shortName}}"
     data-exclude-option-types="{{exclude_option_types}}"
     data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}"
-    >
+    data-is-snapshotable="{{is_snapshotable}}">
     Map
   </a>
   {{/if_instance_of}}

--- a/src/ggrc/assets/mustache/modals/mapper/base.mustache
+++ b/src/ggrc/assets/mustache/modals/mapper/base.mustache
@@ -144,7 +144,8 @@
     contact="mapper.contact"
     term="mapper.term"
     options="mapper.options"
-    items-per-page="20">
+    items-per-page="20"
+    is_snapshotable="mapper.is_snapshotable">
 </mapper-results>
 <div class="modal-footer">
   {{^if mapper.search_only}}

--- a/src/ggrc/assets/mustache/modals/mapper/base.mustache
+++ b/src/ggrc/assets/mustache/modals/mapper/base.mustache
@@ -145,7 +145,9 @@
     term="mapper.term"
     options="mapper.options"
     items-per-page="20"
-    is_snapshotable="mapper.is_snapshotable">
+    is_snapshotable="mapper.is_snapshotable"
+    snapshot_scope_id="{{mapper.snapshot_scope_id}}"
+    snapshot_scope_type="{{mapper.snapshot_scope_type}}">
 </mapper-results>
 <div class="modal-footer">
   {{^if mapper.search_only}}

--- a/src/ggrc/assets/mustache/modals/mapper/component.mustache
+++ b/src/ggrc/assets/mustache/modals/mapper/component.mustache
@@ -12,5 +12,7 @@
     type="{{type}}"
     join-object-id="{{join-object-id}}"
     is_snapshotable="{{is_snapshotable}}"
+    snapshot_scope_id="{{snapshot_scope_id}}"
+    snapshot_scope_type="{{snapshot_scope_type}}"
 >
 </modal-mapper>

--- a/src/ggrc/assets/mustache/modals/mapper/component.mustache
+++ b/src/ggrc/assets/mustache/modals/mapper/component.mustache
@@ -11,5 +11,6 @@
     object="{{object}}"
     type="{{type}}"
     join-object-id="{{join-object-id}}"
+    is_snapshotable="{{is_snapshotable}}"
 >
 </modal-mapper>


### PR DESCRIPTION
- Hide map button for snapshots;
- Unified mapper search results contains only 'in-scope' objects;

It will not be visible until backend (FEATURE/SNAPSHOT) merged.