### PR TITLE
GGRC-449 Fix values with point in AT CA

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment_attributes.js
+++ b/src/ggrc/assets/javascripts/components/assessment_attributes.js
@@ -81,62 +81,62 @@
           ATTACHMENT: 1
         },
         /*
-         * Removes `field` from `fileds`
+         * Removes `field` from `fields`
          */
         removeField: function (scope, el, ev) {
           ev.preventDefault();
           scope.attr('_pending_delete', true);
         },
         /*
-         * Split field values
-         *
-         * @return {Array} attrs - Returns split values as an array
-         */
-        attrs: function () {
-          if (_.contains(['Person', 'Text'], this.field.attr('type'))) {
-            return [this.attr('field.multi_choice_options')];
-          }
-          return _.splitTrim(this.attr('field.multi_choice_options'), {
-            compact: true
-          });
-        },
-        /*
-         * Denormalize field.multi_choice_mandatory into field.opts
+         * Denormalize field.multi_choice_mandatory into opts
          * "0, 1, 2" is normalized into
-         * { attachment-0: false, comment-0: false,
-         *   attachment-1: false, comment-1: true,
-         *   attachment-2: true, comment-2: false
-         * }
+         * [
+         * {value: 0, attachment: false, comment: false},
+         * {value: 1, attachment: false, comment: true},
+         * {value: 2, attachment: true, comment: false},
+         * ]
          */
         denormalize_mandatory: function (field, pads) {
           var options = _.splitTrim(field.attr('multi_choice_options'));
           var vals = _.splitTrim(field.attr('multi_choice_mandatory'));
-          var mand = new can.Map();
-          _.each(_.zip(options, vals), function (zip) {
-            var option = zip[0];
+          var isEqualLength = options.length === vals.length;
+          var range;
+
+          if (!isEqualLength && options.length < vals.length) {
+            vals.length = options.length;
+          } else if (!isEqualLength && options.length > vals.length) {
+            range = _.range(options.length - vals.length);
+            range = range.map(function () {
+              return '0';
+            });
+            vals = vals.concat(range);
+          }
+
+          return _.zip(options, vals).map(function (zip) {
+            var attr = new can.Map();
             var val = zip[1];
             var attachment = !!(val & 1 << pads.ATTACHMENT);
             var comment = !!(val & 1 << pads.COMMENT);
-            mand.attr('attachment-' + option, attachment);
-            mand.attr('comment-' + option, comment);
+            attr.attr('value', zip[0]);
+            attr.attr('attachment', attachment);
+            attr.attr('comment', comment);
+            return attr;
           });
-          return mand;
         },
         /*
-         * Normalize field.opts into field.multi_choice_mandatory
-         * { attachment-0: true, attachment-1: false,
-         *   attachment-1: true, comment-1: true }
+         * Normalize opts into field.multi_choice_mandatory
+         * [
+         * {value: 0, attachment: true, comment: false},
+         * {value: 1, attachment: true, comment: true},
+         * ]
          * is normalized into "2, 3" (10b, 11b).
          */
-        normalize_mandatory: function (field, pads) {
-          var options = _.splitTrim(field.attr('multi_choice_options'));
-          var opts = field.attr('opts');
-          var mand = $.map(options, function (val) {
-            var attach = opts['attachment-' + val] << pads.ATTACHMENT;
-            var comment = opts['comment-' + val] << pads.COMMENT;
+        normalize_mandatory: function (attrs, pads) {
+          return can.map(attrs, function (attr) {
+            var attach = attr.attr('attachment') << pads.ATTACHMENT;
+            var comment = attr.attr('comment') << pads.COMMENT;
             return attach | comment;
-          });
-          return mand.join(',');
+          }).join(',');
         }
       };
     },
@@ -150,12 +150,12 @@
           return obj.type === field.attr('attribute_type');
         });
         this.scope.field.attr('attribute_name', item.name);
-        this.scope.field.attr('opts', denormalized);
+        this.scope.attr('attrs', denormalized);
       },
-      '{field.opts} change': function (opts) {
-        var field = this.scope.attr('field');
+      '{attrs} change': function () {
+        var attrs = this.scope.attr('attrs');
         var pads = this.scope.attr('pads');
-        var normalized = this.scope.normalize_mandatory(field, pads);
+        var normalized = this.scope.normalize_mandatory(attrs, pads);
         this.scope.field.attr('multi_choice_mandatory', normalized);
       }
     }
@@ -175,7 +175,7 @@
         /*
          * Create a new field.
          *
-         * Field must contain value title, type, values and opts.
+         * Field must contain value title, type, values.
          * Opts are populated, once we start changing checkbox values
          *
          * @param {can.Map} scope - the current (add-template-field) scope
@@ -213,8 +213,7 @@
               id: scope.attr('id'),
               title: title,
               attribute_type: type,
-              multi_choice_options: values,
-              opts: new can.Map()
+              multi_choice_options: values
             });
             _.each(['title', 'values', 'multi_choice_options'],
               function (type) {

--- a/src/ggrc/assets/javascripts/components/tests/template_attributes_field_spec.js
+++ b/src/ggrc/assets/javascripts/components/tests/template_attributes_field_spec.js
@@ -1,0 +1,111 @@
+/*!
+ Copyright (C) 2016 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+describe('GGRC.Components.templateAttributesField', function () {
+  'use strict';
+
+  var Component;  // the component under test
+  var scope;
+  var pads = new can.Map({
+    COMMENT: 0,
+    ATTACHMENT: 1
+  });
+  var parentScope;
+
+  beforeAll(function () {
+    parentScope = new can.Map({
+      attr: function () {
+        return {};
+      }
+    });
+    Component = GGRC.Components.get('templateAttributesField');
+  });
+
+  describe('denormalize_mandatory() method', function () {
+    var denormalizeMandatory;
+
+    beforeAll(function () {
+      scope = Component.prototype.scope({}, parentScope);
+      denormalizeMandatory = scope.denormalize_mandatory;
+    });
+
+    it('returns correct denormalized field', function () {
+      var field = new can.Map({
+        multi_choice_options: 'foo,bar,baz,bam',
+        multi_choice_mandatory: '0,1,2,3'
+      });
+      var result = denormalizeMandatory(field, pads);
+
+      expect(result.length).toEqual(4);
+      expect(result[0].attachment).toEqual(false);
+      expect(result[0].comment).toEqual(false);
+      expect(result[1].attachment).toEqual(false);
+      expect(result[1].comment).toEqual(true);
+      expect(result[2].attachment).toEqual(true);
+      expect(result[2].comment).toEqual(false);
+      expect(result[3].attachment).toEqual(true);
+      expect(result[3].comment).toEqual(true);
+    });
+
+    it('returns false for attachment and comment for missing mandatory',
+      function () {
+        var field = new can.Map({
+          multi_choice_options: 'one,two,three,four,five',
+          multi_choice_mandatory: '0,1,2'
+        });
+        var result = denormalizeMandatory(field, pads);
+
+        expect(result.length).toEqual(5);
+        expect(result[0].attachment).toEqual(false);
+        expect(result[0].comment).toEqual(false);
+        expect(result[1].attachment).toEqual(false);
+        expect(result[1].comment).toEqual(true);
+        expect(result[2].attachment).toEqual(true);
+        expect(result[2].comment).toEqual(false);
+
+        expect(result[3].attachment).toEqual(false);
+        expect(result[3].comment).toEqual(false);
+        expect(result[4].attachment).toEqual(false);
+        expect(result[4].comment).toEqual(false);
+      });
+
+    it('returns values only for defined options', function () {
+      var field = new can.Map({
+        multi_choice_options: 'one,two,three',
+        multi_choice_mandatory: '0,1,2,2,0'
+      });
+      var result = denormalizeMandatory(field, pads);
+
+      expect(result.length).toEqual(3);
+      expect(result[0].attachment).toEqual(false);
+      expect(result[0].comment).toEqual(false);
+      expect(result[1].attachment).toEqual(false);
+      expect(result[1].comment).toEqual(true);
+      expect(result[2].attachment).toEqual(true);
+      expect(result[2].comment).toEqual(false);
+    });
+  });
+
+  describe('normalize_mandatory() method', function () {
+    var normalizeMandatory;
+
+    beforeAll(function () {
+      scope = Component.prototype.scope({}, parentScope);
+      normalizeMandatory = scope.normalize_mandatory;
+    });
+
+    it('returns correct normalized attrs', function () {
+      var attrs = new can.List([
+        {attachment: false, comment: false},
+        {attachment: true, comment: false},
+        {attachment: false, comment: true},
+        {attachment: true, comment: true}
+      ]);
+      var result = normalizeMandatory(attrs, pads);
+
+      expect(result).toEqual('0,2,1,3');
+    });
+  });
+});

--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -734,7 +734,9 @@
       if (!this.custom_attribute_definitions) {
         this.attr('custom_attribute_definitions', new can.List());
       }
-      this.attr('_objectTypes', this._choosableObjectTypes());
+      if (!this.attr('_objectTypes')) {
+        this.attr('_objectTypes', this._choosableObjectTypes());
+      }
       this._unpackPeopleData();
 
       this._updateDropdownEnabled('assessors');
@@ -752,6 +754,11 @@
 
       return this._super.apply(this, arguments);
     },
+
+    before_save: function () {
+      this.attr('_objectTypes', undefined);
+    },
+
     after_save: function () {
       if (this.audit) {
         this.audit.reify().refresh('related_assessment_templates');

--- a/src/ggrc/assets/mustache/assessment_templates/attribute_field.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/attribute_field.mustache
@@ -6,21 +6,22 @@
 {{^field._pending_delete}}
   <div class="span-custom2-and-half">{{field.title}}</div>
   <div class="span-custom1-and-half">{{field.attribute_name}}</div>
-  <div class="span2">
+  <div class="span5">
     {{#attrs}}
-      <span class="block single-line" title="{{.}}">{{.}}</span>
+        <div class="row">
+            <div class="span5">
+                <span class="block single-line" title="{{value}}">{{value}}</span>
+            </div>
+            <div class="span5 centered checkbox-wrap">
+                <input can-value="attachment" type="checkbox">
+            </div>
+            <div class="span2 centered checkbox-wrap">
+                <input can-value="comment" type="checkbox">
+            </div>
+        </div>
     {{/attrs}}
   </div>
-  <div class="span2 centered checkbox-wrap">
-    {{#attrs}}
-      <input can-value="field.opts.attachment-{{.}}" type="checkbox">
-    {{/attrs}}
-  </div>
-  <div class="span1 centered checkbox-wrap">
-    {{#attrs}}
-      <input can-value="field.opts.comment-{{.}}" type="checkbox">
-    {{/attrs}}
-  </div>
+
   <div class="span1 centered checkbox-wrap">
     <input type="checkbox" can-value="field.mandatory">
   </div>


### PR DESCRIPTION
**Steps to reproduce:**
**Precondition**: 
1. Created program and audit

**Steps to reproduce:**
1. Go to Audit page
2. Add Tab-> Assessment template
3. During Assessment template creating add LCA with dropdown type and attribute values that contain points
3. Click Save and Close button: confirm error is displayed

_Actual result:_ "Uncaught can.Map: Object does not exist" error message occurs while creating Assessment template with dropdown LCA with dots in options
_Expected result:_ no error displayed. Should be the possibility to have dots in LCA dropdown options.