### PR TITLE
GGRC-463 Fix server error when clearing person custom attribute

### DIFF
--- a/src/ggrc/assets/javascripts/components/inline_edit/inline.js
+++ b/src/ggrc/assets/javascripts/components/inline_edit/inline.js
@@ -114,7 +114,7 @@
             value = value ? 1 : 0;
           }
           if (type === 'person') {
-            value = value ? ('Person:' + value.id) : value;
+            value = value ? ('Person:' + value.id) : 'Person:None';
           }
           if (type === 'dropdown') {
             if (value && value === '') {

--- a/src/ggrc/assets/javascripts/models/cacheable.js
+++ b/src/ggrc/assets/javascripts/models/cacheable.js
@@ -877,7 +877,7 @@
       if (object) {
         this.custom_attributes.attr(attrId, object.type + ':' + object.id);
       } else {
-        this.custom_attributes.removeAttr(String(attrId));
+        this.custom_attributes.attr(attrId, 'Person:None');
       }
     },
     computed_errors: can.compute(function () {

--- a/src/ggrc/assets/js_specs/models/cacheable_spec.js
+++ b/src/ggrc/assets/js_specs/models/cacheable_spec.js
@@ -630,7 +630,7 @@ describe('can.Model.Cacheable', function () {
       obj._custom_attribute_map(1, 'garbage');
       expect(obj.custom_attributes[1]).toEqual('DummyModel:1');
       obj._custom_attribute_map(1, '');
-      expect(obj.custom_attributes[1]).toEqual(undefined);
+      expect(obj.custom_attributes[1]).toEqual('Person:None');
     });
   });
 });

--- a/src/ggrc/fulltext/recordbuilder.py
+++ b/src/ggrc/fulltext/recordbuilder.py
@@ -30,7 +30,7 @@ class RecordBuilder(object):
 
       properties = {}
       if (obj.custom_attribute.attribute_type == "Map:Person" and
-              obj.attribute_object_id is not None):
+              obj.attribute_object_id):
         # Add both name and email for a Map:Person to the index
         properties[attribute_name + ".name"] = obj.attribute_object.name
         properties[attribute_name + ".email"] = obj.attribute_object.email

--- a/src/ggrc/models/mixins/customattributable.py
+++ b/src/ggrc/models/mixins/customattributable.py
@@ -311,6 +311,8 @@ class CustomAttributable(object):
     # 4) Instantiate custom attribute values for each of the definitions
     #    passed in (keys)
     # pylint: disable=not-an-iterable
+    # filter out attributes like Person:None
+    attributes = {k: v for k, v in attributes.items() if v != "Person:None"}
     definitions = {d.id: d for d in self.get_custom_attribute_definitions()}
     for ad_id in attributes.keys():
       obj_type = self.__class__.__name__


### PR DESCRIPTION
When we clear the custom attribute we set obj.attribute_object_id to 0,
but the check 0 is not None was returning True. If we omit the is not
None part we fix the issue because bool(0) == False and bool(None) ==
False.