### PR TITLE
GGRC-45 UX changes in people list

### DIFF
--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -1536,13 +1536,16 @@ Mustache.registerHelper("lowercase", function (value, options) {
   return value.toLowerCase();
 });
 
-Mustache.registerHelper("assignee_types", function (value, options) {
-  value = resolve_computed(value) || "";
-  value = _.first(_.map(value.split(","), function (type) {
-    return _.trim(type).toLowerCase();
-  }));
-  return _.isEmpty(value) ? "none" : value;
-});
+  Mustache.registerHelper('assignee_types', function (value, options) {
+    function capitalizeFirst(string) {
+      return string.charAt(0).toUpperCase() + string.slice(1);
+    }
+    value = resolve_computed(value) || '';
+    value = _.first(_.map(value.split(','), function (type) {
+      return _.trim(type).toLowerCase();
+    }));
+    return _.isEmpty(value) ? '' : '(' + capitalizeFirst(value) + ')';
+  });
 
 Mustache.registerHelper("local_time_range", function (value, start, end, options) {
   var tokens = [];

--- a/src/ggrc/assets/js_specs/mustache_helpers/assignee_types_spec.js
+++ b/src/ggrc/assets/js_specs/mustache_helpers/assignee_types_spec.js
@@ -1,0 +1,57 @@
+/*!
+ Copyright (C) 2016 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+describe('can.mustache.helper.assignee_types', function () {
+  'use strict';
+
+  var helper;
+
+  beforeAll(function () {
+    helper = can.Mustache._helpers.assignee_types.fn;
+  });
+
+  describe('expected assignee type with a capital letter in brackets,' +
+    'when the input: ', function () {
+    it('type in lower case', function () {
+      expect(helper('foo')).toEqual('(Foo)');
+    });
+
+    it('type in upper case', function () {
+      expect(helper('BAR')).toEqual('(Bar)');
+    });
+
+    it('type\'s letters in different cases', function () {
+      expect(helper('bAz')).toEqual('(Baz)');
+    });
+  });
+
+  describe('expected empty string ', function () {
+    it('if input empty string', function () {
+      expect(helper('')).toEqual('');
+    });
+
+    it('if input undefined', function () {
+      expect(helper(undefined)).toEqual('');
+    });
+
+    it('if input null', function () {
+      expect(helper(null)).toEqual('');
+    });
+  });
+
+  describe('expected error for incorrect input types:', function () {
+    it('number', function () {
+      expect(function () {
+        helper(123);
+      }).toThrow();
+    });
+
+    it('array', function () {
+      expect(function () {
+        helper([1, 2, 3]);
+      }).toThrow();
+    });
+  });
+});

--- a/src/ggrc/assets/mustache/assessments/dates_list.mustache
+++ b/src/ggrc/assets/mustache/assessments/dates_list.mustache
@@ -7,16 +7,16 @@
     <ul class="label-list dates">
       {{#if created_at}}
         <li class="gray">
-          <label>
+          <h6>
             Created on
-          </label>
+          </h6>
           <span name="created_at">{{localize_date created_at}}</span>
         </li>
       {{/if}}
       {{#if due_on}}
         <li>
           {{#toggle change_due_date}}
-            <label>Due on</label>
+            <h6>Due on</h6>
             <div class="input-group">
               <span class="input-group-addon"><i class="fa fa-calendar"></i></span>
               <input tabindex="5" class="span8 input-block-level date" name="due_on" data-toggle="datepicker" data-after="created_at" placeholder="MM/DD/YYYY" type="text" value="{{localize_date due_on}}">
@@ -29,9 +29,9 @@
                 </span>
               {{/if_in}}
             {{/is_allowed}}
-            <label>
+            <h6>
               Due on
-            </label>
+            </h6>
             {{#if_null instance.due_on}}
               defined
             {{/if_null}}
@@ -41,7 +41,7 @@
       {{/if}}
       {{#if_helpers '#if' instance.finished_date 'or #if_null' instance.finished_date}}
         <li>
-          <label>Finished</label>
+          <h6>Finished</h6>
           {{#if instance.finished_date}}
             <span>{{localize_date instance.finished_date}}</span>
           {{else}}
@@ -51,7 +51,7 @@
       {{/if_helpers}}
       {{#if_helpers '#if' instance.verified_date 'or #if_null' instance.verified_date}}
         <li>
-          <label>Verified</label>
+          <h6>Verified</h6>
           {{#if instance.verified_date}}
             <span>{{localize_date instance.verified_date}}</span>
           {{else}}

--- a/src/ggrc/assets/mustache/assessments/urls.mustache
+++ b/src/ggrc/assets/mustache/assessments/urls.mustache
@@ -3,24 +3,26 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
 
-<h6>{{firstnonempty constructor.title_singular}}&nbsp;URL</h6>
-<div>
-  {{#if url}}
-      <a data-test-id="text_program_url_aa7d1a65" class="url" href="{{schemed_url url}}" target="_blank">
-        {{url}}
-      </a>
-  {{else}}
-      <span class="empty-message">None</span>
-  {{/if}}
-</div>
-<h6>Reference URL</h6>
-<div>
-  {{#if reference_url}}
-      <a data-test-id="text_reference_url_aa7d1a65" class="url" href="{{schemed_url reference_url}}"
-         target="_blank">
-        {{reference_url}}
-      </a>
-  {{else}}
-      <span class="empty-message">None</span>
-  {{/if}}
-</div>
+<ul class="label-list">
+    <li>
+        <h6>{{firstnonempty constructor.title_singular}}&nbsp;URL</h6>
+        {{#if url}}
+            <a data-test-id="text_program_url_aa7d1a65" class="url" href="{{schemed_url url}}" target="_blank">
+              {{url}}
+            </a>
+        {{else}}
+            <span class="empty-message">None</span>
+        {{/if}}
+    </li>
+    <li>
+        <h6>Reference URL</h6>
+        {{#if reference_url}}
+            <a data-test-id="text_reference_url_aa7d1a65" class="url" href="{{schemed_url reference_url}}"
+               target="_blank">
+              {{reference_url}}
+            </a>
+        {{else}}
+            <span class="empty-message">None</span>
+        {{/if}}
+    </li>
+</ul>

--- a/src/ggrc/assets/mustache/base_templates/comment_subtree.mustache
+++ b/src/ggrc/assets/mustache/base_templates/comment_subtree.mustache
@@ -5,13 +5,12 @@
 
 {{#instance}}
 <li>
-  <span class="person-label {{assignee_types assignee_type}}"></span>
   <div class="w-status">
     <span class="entry-author">
       {{#using person=modified_by}}
         {{{render '/static/mustache/people/popover.mustache' person=person}}}
       {{/using}}
-      added a response - {{date created_at}}
+      {{assignee_types assignee_type}} added a response - {{date created_at}}
     </span>
     {{#instance.custom_attribute_revision}}
         <h6 class="comment-list__ca-description">{{instance.custom_attribute_revision.custom_attribute.title}}: {{instance.custom_attribute_revision.custom_attribute_stored_value}}</h6>

--- a/src/ggrc/assets/stylesheets/components/collapsible-panel/_collapsible-panel.scss
+++ b/src/ggrc/assets/stylesheets/components/collapsible-panel/_collapsible-panel.scss
@@ -18,6 +18,11 @@ collapsible-panel {
         padding: 0;
       }
     }
+
+    h6 {
+      float: left;
+      width: 50%;
+    }
   }
 
   &.details-item {
@@ -26,11 +31,10 @@ collapsible-panel {
     .collapsible-panel-body {
       > .body-inner {
         padding: 0;
-        border-top: 1px solid #ccc;
+        border-bottom: 1px solid #ccc;
 
         &.is-expanded {
           padding: 4px 8px 4px 24px;
-          border-top: 1px solid transparent;
         }
       }
     }

--- a/src/ggrc/assets/stylesheets/modules/_label-list.scss
+++ b/src/ggrc/assets/stylesheets/modules/_label-list.scss
@@ -107,6 +107,11 @@
           left: -25px;
         }
       }
+      &.gray {
+        h6 {
+          color: $gray;
+        }
+      }
     }
   }
   i {
@@ -145,6 +150,9 @@
       width: auto;
       .people-group_title {
         font-weight: bold;
+      }
+      .person-add {
+        padding-left: 16px;
       }
     }
     .modal-body & {


### PR DESCRIPTION
Comments from UX Designer:
We already show labels in People section (Verifier, Creator etc). No need for additional icons as we do not show them for other labels /categories. 
Comments section: it's quite unclear what icons mean (a letter means a role). Instead, I would suggest using Role after a person name 
![ggrc-45_comment_icons](https://cloud.githubusercontent.com/assets/4737102/20347915/4389498c-ac14-11e6-9803-b065bc7bbaf5.png)

Delete icon:
Currently, this icon appears with a delay and at the left - what is not common behavior. I'd suggest showing "trash" icon on mouse hover at the right. On hover - in order not to "promote" delete action in People section.
![ggrc-45_delete](https://cloud.githubusercontent.com/assets/4737102/20347955/67c27e2c-ac14-11e6-8a2a-9240fcf0c2d5.png)

Some more UI issues for this page:

- Control to add URL and People are different
<img width="1380" alt="ggrc_asmt_ui_1" src="https://cloud.githubusercontent.com/assets/4737102/20348017/a81e8e16-ac14-11e6-94f6-0e22e1106f52.png">
- different paddings after a category label and  icon
- icons have different colors: e.g. for  and  icons
- different label format
<img width="1416" alt="ggrc_asmt_ui_2" src="https://cloud.githubusercontent.com/assets/4737102/20348034/b9fa995e-ac14-11e6-8420-602e273fe2fb.png">
- separator between section disappears when one section is open
