### PR TITLE
GGRC-474 Snapshot post api

### DIFF
--- a/src/ggrc/automapper/__init__.py
+++ b/src/ggrc/automapper/__init__.py
@@ -253,6 +253,39 @@ def handle_relationship_post(source, destination):
   AutomapperGenerator().generate_automappings(relationship)
 
 
+def generate_relationship_snapshots(obj):
+  """Generate needed snapshots for a given relationship.
+
+  If we post a relationship for a snapshotable object and an Audit, we will map
+  that object to audits program, make a snapshot for it and map the snapshot to
+  the Audit.
+
+  NOTE: this function will be deprecated soon.
+
+  Args:
+    obj: Relationship object.
+  """
+
+  from ggrc.snapshotter import rules as snapshot_rules
+
+  parent = None
+  child = None
+  if "Audit" in obj.source_type:
+    parent = obj.source
+    child = obj.destination
+  elif "Audit" in obj.destination_type:
+    parent = obj.destination
+    child = obj.source
+
+  if parent and child.type in snapshot_rules.Types.all:
+    db.session.add(models.Snapshot(
+        parent=parent,
+        child_id=child.id,
+        child_type=child.type,
+        update_revision="new",
+    ))
+
+
 def register_automapping_listeners():
   """Register event listeners for auto mapper."""
   # pylint: disable=unused-variable,unused-argument
@@ -272,6 +305,7 @@ def register_automapping_listeners():
       if obj is None:
         logger.warning("Automapping listener: no obj, no mappings created")
         return
+      generate_relationship_snapshots(obj)
       automapper.generate_automappings(obj)
 
   @Resource.model_posted_after_commit.connect_via(Request)

--- a/src/ggrc/automapper/__init__.py
+++ b/src/ggrc/automapper/__init__.py
@@ -283,6 +283,8 @@ def generate_relationship_snapshots(obj):
         child_id=child.id,
         child_type=child.type,
         update_revision="new",
+        context=parent.context,
+        modified_by=get_current_user()
     ))
 
 

--- a/src/ggrc/models/snapshot.py
+++ b/src/ggrc/models/snapshot.py
@@ -89,6 +89,7 @@ class Snapshot(relationship.Relatable, mixins.Base, db.Model):
   revision = db.relationship(
       "Revision",
   )
+  _update_revision = None
 
   @classmethod
   def eager_query(cls):
@@ -139,6 +140,9 @@ class Snapshot(relationship.Relatable, mixins.Base, db.Model):
 
   @classmethod
   def handle_post_flush(cls, session, flush_context, instances):
+    """Handle snapshot objects on api post requests."""
+    # pylint: disable=unused-argument
+    # Arguments here are set in the event listener and are mandatory.
     objects = [
         o for o in session.new
         if isinstance(o, cls) and getattr(o, "_update_revision", "") == "new"
@@ -158,7 +162,7 @@ class Snapshot(relationship.Relatable, mixins.Base, db.Model):
     """
     pairs = [(o.child_type, o.child_id) for o in objects]
     assert len({o.parent.id for o in objects}) == 1  # fail on multiple audits
-    program = ("Program", o.parent.program_id)
+    program = ("Program", objects[0].parent.program_id)
     rel = relationship.Relationship
     columns = db.session.query(
         rel.destination_type,

--- a/test/integration/ggrc/snapshotter/test_snapshoting.py
+++ b/test/integration/ggrc/snapshotter/test_snapshoting.py
@@ -517,3 +517,77 @@ class TestSnapshoting(SnapshotterBaseTestCase):
     )
 
     self.assertEqual(snapshots.count(), 0)
+
+  def test_snapshot_post_api(self):
+    """Test snapshot creation when object is in program scope already"""
+    program = self.create_object(models.Program, {
+        "title": "Test Program Snapshot 1"
+    })
+
+    control = self.create_object(models.Control, {
+        "title": "Test Control Snapshot 1"
+    })
+
+    self.create_audit(program)
+
+    objective = self.create_object(models.Objective, {
+        "title": "Test Objective Snapshot UNEDITED"
+    })
+    self.create_mapping(program, objective)
+
+    audit = db.session.query(models.Audit).filter(
+        models.Audit.title.like("%Snapshotable audit%")).one()
+
+    self.api.post(models.Snapshot, [
+        {
+            "snapshot": {
+                "parent": {
+                    "id": audit.id,
+                    "type": "Audit",
+                    "href": "/api/audits/{}".format(audit.id)
+                },
+                "child_type": "Objective",
+                "child_id": objective.id,
+                "update_revision": "new",
+                "context": {
+                    "id": audit.context_id,
+                    "type": "Context",
+                    "href": "/api/contexts/{}".format(audit.context_id)
+                }
+            }
+        },
+        {
+            "snapshot": {
+                "parent": {
+                    "id": audit.id,
+                    "type": "Audit",
+                    "href": "/api/audits/{}".format(audit.id)
+                },
+                "child_type": "Control",
+                "child_id": control.id,
+                "update_revision": "new",
+                "context": {
+                    "id": audit.context_id,
+                    "type": "Context",
+                    "href": "/api/contexts/{}".format(audit.context_id)
+                }
+            }
+        }
+    ])
+
+    objective_snapshot = db.session.query(models.Snapshot).filter(
+        models.Snapshot.child_type == "Objective",
+        models.Snapshot.child_id == objective.id
+    )
+
+    objective_revision = db.session.query(models.Revision).filter(
+        models.Revision.resource_type == "Objective",
+        models.Revision.resource_id == objective.id
+    ).one()
+
+    self.assertEquals(objective_snapshot.count(), 1)
+    self.assertEquals(objective_snapshot.first().revision_id,
+                      objective_revision.id)
+
+    self.assertIsNotNone(models.Relationship.find_related(program, objective))
+    self.assertIsNotNone(models.Relationship.find_related(program, control))


### PR DESCRIPTION
This adds support for creating snapshots from the unified mapper.

For the api request specs, please take a look at the added integration test.