### PR TITLE
GGRC-256 Add slug on Assessment info pane

### DIFF
--- a/src/ggrc/assets/mustache/assessments/info.mustache
+++ b/src/ggrc/assets/mustache/assessments/info.mustache
@@ -63,6 +63,14 @@
                     <collapsible-panel title-text="URL" collapsed="true" title-icon="fa-link" class="details-item">
                       {{> '/static/mustache/assessments/urls.mustache'}}
                     </collapsible-panel>
+                    <collapsible-panel title-text="Code" collapsed="true" title-icon="fa-code" class="details-item">
+                        <ul class="label-list">
+                            <li>
+                                <h6>Code</h6>
+                                <span>{{instance.slug}}</span>
+                            </li>
+                        </ul>
+                    </collapsible-panel>
                     <collapsible-panel title-text="Conclusions" collapsed="true" title-icon="fa-gavel"
                                        class="details-item">
                         <div class="flex-box flex-col"

--- a/src/ggrc/assets/stylesheets/modules/_assessment.scss
+++ b/src/ggrc/assets/stylesheets/modules/_assessment.scss
@@ -177,6 +177,8 @@ $border-color: #eee;
     h6 {
       margin: 0;
       padding: 0 0 8px;
+      float: left;
+      width: 32%;
     }
   }
 }


### PR DESCRIPTION
**Details**: 
Create an assessment under an audit
Open assessment’s info panel

_Actual Result_: there is no Assessment's slug (code) in assessment's info panel on audit page
_Expected Result:_ please confirm that slug (code) should be visible on assessment info panel on audit page (we are still able to see slug when editing assessment)
_Workaround_: na
![ggrc-256_code_1](https://cloud.githubusercontent.com/assets/4737102/20384307/604101e0-acc4-11e6-900e-b965cef682ed.png)
![ggrc-256_code_2](https://cloud.githubusercontent.com/assets/4737102/20384314/64bd55de-acc4-11e6-9f63-2f13d62ad3ec.png)

