### PR TITLE
GGRC-421 Auto-select correct WF Cycle when using email links

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
@@ -365,7 +365,7 @@
         dashboardCtr.show_widget_area();
         widget.siblings().addClass('hidden').trigger('widget_hidden');
         widget.removeClass('hidden').trigger('widget_shown');
-        $('[href=' + panel + ']')
+        $('[href$=' + panel + ']')
         .closest('li').addClass('active')
         .siblings().removeClass('active');
       }

--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -2121,6 +2121,10 @@ Mustache.registerHelper('param_current_location', function () {
   return GGRC.current_url_compute();
 });
 
+  Mustache.registerHelper('urlPath', function () {
+    return window.location.pathname;
+  });
+
 Mustache.registerHelper("sum", function () {
   var sum = 0;
   for (var i = 0; i < arguments.length - 1; i++) {

--- a/src/ggrc/assets/mustache/dashboard/internav_list.mustache
+++ b/src/ggrc/assets/mustache/dashboard/internav_list.mustache
@@ -13,7 +13,7 @@
       or #if' instance.constructor.obj_nav_options.show_all_tabs '\
       or #in_array' internav_display instance.constructor.obj_nav_options.force_show_list}}
 
-    <a href="{{ selector }}" rel="tooltip" data-placement="bottom" title="{{ internav_display }}">
+    <a href="{{urlPath}}{{ selector }}" rel="tooltip" data-placement="bottom" title="{{ internav_display }}">
       <div class="oneline">
         <i class="fa fa-{{ internav_icon }} color"></i>
         {{#if show_title}}
@@ -38,7 +38,7 @@
 {{#is_allowed 'update' instance}}
 {{#if widget_list.length}}
 <li data-test-id="button_widget_add_2c925d94" class="hidden-widgets-list">
-  <a href="#dropdown-widgets" class="dropdown-toggle" data-toggle="dropdown" rel="tooltip" data-placement="bottom" title="Add Tab"><i class="fa fa-plus-circle"></i> Add Tab</a>
+  <a href="{{urlPath}}#dropdown-widgets" class="dropdown-toggle" data-toggle="dropdown" rel="tooltip" data-placement="bottom" title="Add Tab"><i class="fa fa-plus-circle"></i> Add Tab</a>
   <div class="dropdown-menu" role="menu">
     {{#widget_list}}
       <div class="inner-nav-item">
@@ -54,7 +54,7 @@
             #if_page_type' 'programs' '\
             and #if_equals' model.shortName 'Audit'}}
             <a
-              href="{{selector}}"
+              href="{{urlPath}}{{selector}}"
               rel="tooltip"
               data-placement="left"
               data-original-title="Create {{model.title_singular}}"
@@ -83,7 +83,7 @@
             </a>
           {{else}}
             <a
-              href="{{ selector }}"
+              href="{{urlPath}}{{ selector }}"
               {{^is_dashboard_or_all}}
               {{#is_mappable_type instance.type model.shortName}}
               {{#is_allowed_to_map instance model.shortName}}

--- a/test/selenium/src/lib/constants/locator.py
+++ b/test/selenium/src/lib/constants/locator.py
@@ -502,7 +502,10 @@ class WidgetBar(object):
   class _Locator(object):
     @staticmethod
     def get_widget(object_name):
-      return (By.CSS_SELECTOR, '[href="#{}_widget"]'.format(object_name))
+      return (
+          By.CSS_SELECTOR,
+          '.object-nav [href$="#{}_widget"]'.format(object_name)
+      )
 
   class __metaclass__(type):
     def __init__(cls, *args):
@@ -532,8 +535,11 @@ class WidgetBarButtonAddDropdown(object):
   class _Locator(object):
     @staticmethod
     def get_dropdown_item(object_name):
-      return (By.CSS_SELECTOR, '[data-test-id="button_widget_add_2c925d94"] '
-                               '[href="#{}_widget"]'.format(object_name))
+      return (
+          By.CSS_SELECTOR,
+          '[data-test-id="button_widget_add_2c925d94"] '
+          '.object-nav [href$="#{}_widget"]'.format(object_name)
+      )
 
   class __metaclass__(type):
     def __init__(cls, *args):

--- a/test/unit/ggrc_workflows/notification/__init__.py
+++ b/test/unit/ggrc_workflows/notification/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (C) 2016 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>

--- a/test/unit/ggrc_workflows/notification/test_data_handler.py
+++ b/test/unit/ggrc_workflows/notification/test_data_handler.py
@@ -1,0 +1,62 @@
+# Copyright (C) 2016 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""A module with tests for the GGRC Workflow's data_handler module."""
+
+import unittest
+
+from mock import MagicMock, patch
+
+from ggrc_workflows.notification.data_handler import get_cycle_task_url
+
+
+class GetCycleTaskUrlTestCase(unittest.TestCase):
+  """Tests for the get_cycle_task_url() function."""
+
+  # pylint: disable=invalid-name, unused-argument
+  @patch(
+      u"ggrc_workflows.notification.data_handler.get_url_root",
+      return_value=u"http://www.foo.com/")
+  def test_generates_correct_url_for_task(self, *mocks):
+    """The method should return a correct URL for the given Task."""
+    task = MagicMock()
+    task.id = 15
+    task.cycle_task_group.id = 6
+    task.cycle_task_group.cycle.id = 77
+    task.cycle_task_group.cycle.workflow.id = 9
+
+    result = get_cycle_task_url(task)
+
+    expected_url = (
+        u"http://www.foo.com/"
+        u"workflows/9#current_widget"
+        u"/cycle/77"
+        u"/cycle_task_group/6"
+        u"/cycle_task_group_object_task/15"
+    )
+    self.assertEqual(result, expected_url)
+
+  # pylint: disable=invalid-name, unused-argument
+  @patch(
+      u"ggrc_workflows.notification.data_handler.get_url_root",
+      return_value=u"http://www.foo.com/")
+  def test_generates_correct_url_with_filter_if_given(self, *mocks):
+    """The method should return a correct URL for the given Task."""
+    task = MagicMock()
+    task.id = 15
+    task.cycle_task_group.id = 6
+    task.cycle_task_group.cycle.id = 77
+    task.cycle_task_group.cycle.workflow.id = 9
+
+    cycle_filter = u"id=77"
+
+    result = get_cycle_task_url(task, filter_exp=cycle_filter)
+
+    expected_url = (
+        u"http://www.foo.com/"
+        u"workflows/9?filter=id%3D77#current_widget"
+        u"/cycle/77"
+        u"/cycle_task_group/6"
+        u"/cycle_task_group_object_task/15"
+    )
+    self.assertEqual(result, expected_url)


### PR DESCRIPTION
This PR improves the links to users' tasks in daily digest emails. It adds a filter query to the URLs, so that only the relevant WF Cycle is displayed in the tree view, making it much easier for the user to find the actual task linked from the email.

One way to test this is to create some WF tasks for various people and then preview the daily digest email (hint: URL path `/_notifications/show_daily_digest`). These links now automatically apply a tree view filter, as mentioned above.

**NOTE:**
Adding a query parameter to the URL introduced an inconvenience when switching between tabs in HNB, the filter tended to stick around and filtering tree views on other tabs, because only the hash part of the URL was changed.

To avoid this, this PR also prepends the `href` attributes of the tabs with the current URL path. The downside is that on the first tab switch (after following a link from the email) a full page reload happens, but I hope this this does not represent too big of an inconvenience.

_(another alternative would perhaps be to somehow add the filter parameter to the hash portion of the URL, but that would require changing the way we parse and route, and I did not want to touch that, too risky a change to make for this fix IMO)_

**NOTE 2:**
It was quite tricky to get the automatic filters working due to the order different controllers are initialized on the frontend. I found the way around it, but it might not be ideal, as mentioned in a comment in the source (there might still be some race conditions). Suggestions welcome, although it seems that it already works fine enough.