### PR TITLE
GGRC-468 Remove asterisks from effective/stop dates

### DIFF
--- a/src/ggrc/assets/javascripts/components/effective-dates/effective-dates.js
+++ b/src/ggrc/assets/javascripts/components/effective-dates/effective-dates.js
@@ -14,6 +14,16 @@
     ),
     scope: {
       instance: null,
+      configStartDate: {
+        label: 'Effective Date',
+        helpText: 'Enter the date this object becomes effective.',
+        required: false
+      },
+      configEndDate: {
+        label: 'Stop Date',
+        helpText: 'Enter the date this object stops being effective.',
+        required: false
+      }
     }
   });
 })(window.can, window.GGRC);

--- a/src/ggrc/assets/javascripts/models/control.js
+++ b/src/ggrc/assets/javascripts/models/control.js
@@ -104,8 +104,6 @@
           delete that.directive;
         }
       });
-      this.attr('configStartDate.required', false);
-      this.attr('configEndDate.required', false);
     }
   });
 })(this, can.$);

--- a/src/ggrc/assets/javascripts/models/mixins.js
+++ b/src/ggrc/assets/javascripts/models/mixins.js
@@ -326,17 +326,15 @@
       end_date: 'date'
     }
   }, {
-    // NOTE: when synchronizing mandatory asterisks of dates with backend for
-    // all models, please set the default "required" options to false
     configStartDate: {
       label: 'Effective Date',
       helpText: 'Enter the date this object becomes effective.',
-      required: true
+      required: false
     },
     configEndDate: {
       label: 'Stop Date',
       helpText: 'Enter the date this object stops being effective.',
-      required: true
+      required: false
     }
   });
 })(this.can);

--- a/src/ggrc/assets/javascripts/models/mixins.js
+++ b/src/ggrc/assets/javascripts/models/mixins.js
@@ -326,15 +326,5 @@
       end_date: 'date'
     }
   }, {
-    configStartDate: {
-      label: 'Effective Date',
-      helpText: 'Enter the date this object becomes effective.',
-      required: false
-    },
-    configEndDate: {
-      label: 'Stop Date',
-      helpText: 'Enter the date this object stops being effective.',
-      required: false
-    }
   });
 })(this.can);

--- a/src/ggrc/assets/javascripts/models/simple_models.js
+++ b/src/ggrc/assets/javascripts/models/simple_models.js
@@ -90,11 +90,6 @@ can.Model.Cacheable("CMS.Models.Program", {
     this._super.apply(this, arguments);
   }
 }, {
-  init: function () {
-    this._super.apply(this, arguments);
-    this.attr('configStartDate.required', false);
-    this.attr('configEndDate.required', false);
-  }
 });
 
 can.Model.Cacheable("CMS.Models.Option", {

--- a/src/ggrc/assets/mustache/components/effective-dates/effective-dates.mustache
+++ b/src/ggrc/assets/mustache/components/effective-dates/effective-dates.mustache
@@ -6,23 +6,23 @@
 <div data-id="effective_date_hidden" class="span4 hidable">
   <a data-id="hide_effective_date_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
   <datepicker
-      label="instance.configStartDate.label"
+      label="configStartDate.label"
       date="instance.start_date"
       set-max-date="instance.end_date"
-      helptext="instance.configStartDate.helpText"
+      helptext="configStartDate.helpText"
       test-id="startTestId"
-      {{#instance.configStartDate.required}}required="required"{{/instance.configStartDate.required}}
+      {{#configStartDate.required}}required="required"{{/configStartDate.required}}
   />
 </div>
 
 <div data-id="stop_date_hidden" class="span4 hidable">
   <a data-id="hide_stop_date_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
   <datepicker
-      label="instance.configEndDate.label"
+      label="configEndDate.label"
       date="instance.end_date"
       set-min-date="instance.start_date"
-      helptext="instance.configEndDate.helpText"
+      helptext="configEndDate.helpText"
       test-id="endTestId"
-      {{#instance.configEndDate.required}}required="required"{{/instance.configEndDate.required}}
+      {{#configEndDate.required}}required="required"{{/configEndDate.required}}
   />
 </div>


### PR DESCRIPTION
This PR removes unnecessary "required" asterisks from "Effective date" and "Stop date" fields from all objects' modals.

This PR also removes the per-model configuration mechanism for "Effective date" and "Stop date" fields in the modals since no model that uses `<effective-dates>` component has custom labels/mandatory options for these fields.

The per-model configuration mechanism required that the config objects were stored for each instance of the models, and these config objects just increased memory usage for no functional difference.

`On hold` due to the code freeze.