### PR TITLE
QUICK-FIX Only use config if it's available

### DIFF
--- a/src/ggrc/assets/javascripts/apps/base_widgets.js
+++ b/src/ggrc/assets/javascripts/apps/base_widgets.js
@@ -8,7 +8,7 @@
    * Tree View Widgets Configuration module
    */
   // Items allowed for mapping via snapshot.
-  var snapshotWidgetsConfig = GGRC.config.snapshotable_objects;
+  var snapshotWidgetsConfig = GGRC.config.snapshotable_objects || [];
   // Items allowed for relationship mapping
   var directMappingConfig = [
     'Assessment',

--- a/src/ggrc/templates/layouts/base.haml
+++ b/src/ggrc/templates/layouts/base.haml
@@ -32,6 +32,7 @@
       GGRC = window.GGRC || {};
       GGRC.Settings = {};
       GGRC.Bootstrap = {};
+      GGRC.config = {};
       -include "scripts/tracker-prefix.js"
       window.st=Date.now();
       -block extra_javascript


### PR DESCRIPTION
Make sure to use GGRC.config object only if it was loaded. The index page does not load all configs and causes a script error before it could load.

This PR removes the blocker caused by https://github.com/google/ggrc-core/pull/4701/files#diff-9642b862bb4f2f86483c36f4b95fb62eR11 

~I have checked and could not find any negative side effects of this change, but I would like to get at least 2 confirmations that this can not cause any blockers in the future. If there is any issue found in this fix we will fix issue linked above with a static list copy pasted from the backend before a proper solution is found.~

PS: we should also investigate why Selenium tests did not find the original issue.