### PR TITLE
QUICK-FIX Fix update snapshots

### DIFF
--- a/src/ggrc/assets/javascripts/components/snapshotter/individual-update.js
+++ b/src/ggrc/assets/javascripts/components/snapshotter/individual-update.js
@@ -24,10 +24,7 @@
         }, function () {
           var instance = this.instance.snapshot;
           instance.refresh().then(function () {
-            var data = {
-              operation: 'update'
-            };
-            instance.attr('individual-update', data);
+            instance.attr('update_revision', 'latest');
             return instance.save();
           }).then(function () {
             window.location.reload();

--- a/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
+++ b/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
@@ -744,12 +744,12 @@
       var model = CMS.Models[instance.child_type];
       var content = instance.revision.content;
       var type = model.root_collection;
-      content.type = instance.child_type;
-      content.snapshot = new CMS.Models.Snapshot(content);
-      content.selfLink = instance.selfLink.replace('snapshots', type);
-      content.snapshot.selfLink = content.selfLink;
-      content.viewLink = '/' + type + '/' + content.id;
-      content.originalLink = content.viewLink;
+      content.originalLink = '/' + type + '/' + content.id;
+      content.snapshot = new CMS.Models.Snapshot(instance);
+      content.viewLink = content.snapshot.viewLink;
+      content.selfLink = content.snapshot.selfLink;
+      content.type = content.snapshot.type;
+      content.id = content.snapshot.id;
       return content;
     }
 


### PR DESCRIPTION
- Update the PUT request call for snapshots to match what the
backend expects.

- The content of the snapshot model should never refer to the original
objects. This causes problems when refreshing a snapshot of the object
that was already deleted.

- The other fix here is to always use correct links and not mix up ids of
the original objects and snapshots, which will create invalid links.


This fixes all script errors when navigating the tree views for snapshotted objects and when trying to update a single snapshot instance.
Marking this as please review because it's needed for the demo.