### PR TITLE
GGRC-153 Add configurable Google Analytics script

### DIFF
--- a/src/ggrc/settings/default.py
+++ b/src/ggrc/settings/default.py
@@ -41,6 +41,23 @@ VERSION = "0.9.7-Quince" + BUILD_NUMBER
 GOOGLE_ANALYTICS_ID = os.environ.get('GGRC_GOOGLE_ANALYTICS_ID', '')
 GOOGLE_ANALYTICS_DOMAIN = os.environ.get('GGRC_GOOGLE_ANALYTICS_DOMAIN', '')
 
+ANALYTICS_TEMPLATE = """
+<script type="text/javascript">
+(function (i,s,o,g,r,a,m) {i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+ga('create', '%s', 'auto');
+ga('send', 'pageview');
+</script>
+"""
+
+if GOOGLE_ANALYTICS_ID:
+  GOOGLE_ANALYTICS_SCRIPT = ANALYTICS_TEMPLATE % GOOGLE_ANALYTICS_ID
+else:
+  GOOGLE_ANALYTICS_SCRIPT = ""
+
 # Initialize from environment if present
 SQLALCHEMY_DATABASE_URI = os.environ.get('GGRC_DATABASE_URI', '')
 SECRET_KEY = os.environ.get('GGRC_SECRET_KEY', 'Replace-with-something-secret')

--- a/src/ggrc/templates/assessments_view/index.haml
+++ b/src/ggrc/templates/assessments_view/index.haml
@@ -74,3 +74,5 @@
             =config.get('COMPANY')
             Version
             =config.get('VERSION')
+      .analytics
+        ={config.get('GOOGLE_ANALYTICS_SCRIPT') | safe}

--- a/src/ggrc/templates/layouts/dashboard.haml
+++ b/src/ggrc/templates/layouts/dashboard.haml
@@ -78,6 +78,8 @@
             =config.get('COMPANY')
             Version
             =config.get('VERSION')
+      .analytics
+        ={config.get('GOOGLE_ANALYTICS_SCRIPT') | safe}
 
   #lhn
     #lhs.lhs.accordion{ 'data-template': '/dashboard/lhn.mustache' }


### PR DESCRIPTION
In order for the analytics script to appear in the page, the `GGRC_GOOGLE_ANALYTICS_ID` environment variable must be set.

This PR can be verified by inspecting the page footer, i.e. the part where the copyright and version info is.

(added the `on hold` label due to code freeze)