### PR TITLE
GGRC-256 Update to Fix Layout issue of Assessment Info Pane

### DIFF
--- a/src/ggrc/assets/mustache/assessments/info.mustache
+++ b/src/ggrc/assets/mustache/assessments/info.mustache
@@ -11,10 +11,10 @@
 
         <div class="tier-content">
           {{> '/static/mustache/assessments/header.mustache' }}
-            <div class="assessment-info-pane">
-                <div class="assessment-attributes">
+            <div class="assessment-info-pane flex-box">
+                <div class="assessment-attributes flex-size-2">
                     <div class="assessment-description">
-                        <h6>Test Plan</h6>
+                        <div class="section-title">Test Plan</div>
                         <read-more text="test_plan"></read-more>
                     </div>
                     <assessment-mapped-controls instance="instance"
@@ -27,7 +27,7 @@
                         <assessment-custom-attributes instance="instance"
                                                       definitions="custom_attribute_definitions"
                                                       values="custom_attribute_values"
-                                                      class="assessment-custom-attributes">
+                                                      class="assessment-custom-attributes flex-box flex-box-multi">
                         </assessment-custom-attributes>
                         <div class="assessment-controls__extra-controls">
                             <assessment-attachments-list class="attachment-list"></assessment-attachments-list>
@@ -43,8 +43,8 @@
                             mapping="info_related_objects">
                     </assessment-mapped-related-information>
                 </div>
-                <div class="assessment-summary">
-                    <h6>Details</h6>
+                <div class="assessment-summary flex-size-1">
+                    <div class="section-title">Details</div>
                     <collapsible-panel title-text="Description" collapsed="true" title-icon="fa-list-ol"
                                        class="details-item">
                         <read-more text="description"></read-more>

--- a/src/ggrc/assets/mustache/components/assessment/custom-attributes.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/custom-attributes.mustache
@@ -3,8 +3,8 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
 {{#items}}
-    <ca-object-validation class="flex-box flex-row flex-size-1" def="def" value-id="{{id}}" errors="preconditions_failed" value="attribute_value" modal="modal" is-modified="isModified">
-        <ca-object class="flex-box flex-col flex-size-1" instance="instance" value-id="{{id}}" def="def" value="attribute_value" modal="modal" type="attributeType" is-modified="isModified">
+    <ca-object-validation class="flex-box flex-row" def="def" value-id="{{id}}" errors="preconditions_failed" value="attribute_value" modal="modal" is-modified="isModified">
+        <ca-object class="flex-box flex-col" instance="instance" value-id="{{id}}" def="def" value="attribute_value" modal="modal" type="attributeType" is-modified="isModified">
             <ca-object-value-mapper value="attribute_value" type="type" value-obj="attribute_object" def="def">
                 <assessment-inline-edit
                         value="input.value"

--- a/src/ggrc/assets/stylesheets/components/custom-attributes/_custom-attributes.scss
+++ b/src/ggrc/assets/stylesheets/components/custom-attributes/_custom-attributes.scss
@@ -4,9 +4,7 @@
  */
 
 ca-object-validation {
-  display: flex;
-  flex-basis: 50%;
-  max-width: 50%;
+  width: 50%;
   box-sizing: border-box;
 }
 

--- a/src/ggrc/assets/stylesheets/modules/_assessment.scss
+++ b/src/ggrc/assets/stylesheets/modules/_assessment.scss
@@ -17,20 +17,16 @@ $border-color: #eee;
   align-items: stretch;
   flex-wrap: wrap;
 
-  .assessment-attributes {
-    flex: 2 2 66%;
-    margin: 8px 22px 8px 0;
-    max-width: 66%;
+  .section-title {
+    font-size: 11px;
+    text-transform: uppercase;
+    font-weight: bold;
+    line-height: 24px;
+    margin: 0 0 4px;
   }
 
   .assessment-description {
-    margin: 8px 0 16px;
-  }
-
-  .assessment-control-item {
-    flex: 1 1 50%;
-    max-width: 50%;
-    min-height: 72px;
+    margin: 0 0 12px;
   }
 
   .assessment-controls {
@@ -38,7 +34,7 @@ $border-color: #eee;
     padding: 12px 12px 24px;
     box-sizing: border-box;
     border-radius: 2px;
-    margin-bottom: 20px;
+    margin-bottom: 16px;
 
     .assessment-controls__note {
       display: block;
@@ -167,18 +163,10 @@ $border-color: #eee;
   }
 
   .assessment-summary {
-    flex: 1;
-    margin: 0 0 28px;
+    margin: 0 0 28px 24px;
 
     .side-content {
       margin: 0;
-    }
-
-    h6 {
-      margin: 0;
-      padding: 0 0 8px;
-      float: left;
-      width: 32%;
     }
   }
 }


### PR DESCRIPTION
Fix Invalid positioning of Description list and URL list in Assessment's Info pane
Steps to reproduce:
1. Navigate to Assessment's Info pane
2. Look at Description list and open URL list


![image](https://cloud.githubusercontent.com/assets/10726105/20483744/bcac3ef2-b004-11e6-9b8a-aa075ec8bebf.png)
