### PR TITLE
GGRC-488 Disable editing GCA for snapshots

### DIFF
--- a/src/ggrc/assets/mustache/custom_attributes/info.mustache
+++ b/src/ggrc/assets/mustache/custom_attributes/info.mustache
@@ -25,9 +25,13 @@
               mandatory="cad.mandatory"
               placeholder="cad.placeholder"
               helptext="cad.helptext"
-              {{^is_allowed 'update' instance context='for'}}
+              {{#if instance.snapshot}}
                 readonly
-              {{/is_allowed}}
+              {{else}}
+                {{^is_allowed 'update' instance context='for'}}
+                  readonly
+                {{/is_allowed}}
+              {{/if}}
               {{#if_instance_of instance 'Request'}}
                 can-before-edit="instance.confirmBeginEdit"
               {{/if_instance_of}}


### PR DESCRIPTION
Steps to reproduce:
1. Create GCA for an object (e.g. Regulations)
2. Create program
3. Create Control
4. Create Regulations-> Enter the value into the created CA field in Regulations Info pane
5. Create Audit
6. Go to Audit page-> Regulations tab-> Navigate to Regulations Info pane
7. Try to edit CA field: confirm the field is editable

Actual Result: CA field is editable after snapshot
Expected Result: CA field should not be editable after snapshot