### PR TITLE
GGRC-412 Display spinner while tab content is loading

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
@@ -226,9 +226,19 @@ can.Control('CMS.Controllers.TreeLoader', {
   },
 
   _loading_started: function () {
+    var $contentContainer;
+
     if (!this._loading_deferred) {
       this._loading_deferred = new $.Deferred();
-      this.init_spinner();
+
+      // for some reason, .closest(<selector>) does not work, thus need to use
+      // using a bit less roboust .parent()
+      $contentContainer = this.element.parent();
+      $contentContainer
+        .find('spinner[extra-css-class="initial-spinner"]')
+        .remove();
+
+      this.init_spinner();  // the tree view's own items loading spinner
       this.element.trigger('loading');
     }
   },

--- a/src/ggrc/assets/mustache/dashboard/object_widget.mustache
+++ b/src/ggrc/assets/mustache/dashboard/object_widget.mustache
@@ -56,5 +56,13 @@
 
   <section class="content">
     {{{widget_initial_content}}}
+
+    {{#add_to_current_scope showSpinner=true}}
+      <spinner
+        size="large"
+        extra-css-class="initial-spinner"
+        toggle="showSpinner"
+        ></spinner>
+    {{/add_to_current_scope}}
   </section>
 {{!/section}}

--- a/src/ggrc/assets/stylesheets/modules/_spinner.scss
+++ b/src/ggrc/assets/stylesheets/modules/_spinner.scss
@@ -5,6 +5,10 @@
 
 .spinner {
   display: inline-block;
+  &.initial-spinner {
+    position: relative;
+    left: 49%;  // not 50% to roughly compensate for the spinner's own width
+  }
 }
 
 .spinner-size {


### PR DESCRIPTION
This PR displays a spinner when switching to another object tab (using the HNB) until the tree view is actually loaded and starts loading its own data.

This gives users a way to distinguish between the cases when the tab content is still being loaded, and when the tab content has finished loading, but possibly resulting in no content displayed (e.g.  because of no relevant data to display).

Note that the initial spinner looks differently than the tree view's own spinner while loading content, but this PR does not try to address this UI inconsistency, it just uses the standard spinner component we use throughout the app.

No unit tests, because an integration test would make much more sense here, but that is being worked on as a part of a different story.

P.S.: The ticket mentions that _"we must have spinners with an appropriate message"_, but does not specify what that message should be. We might add _"Loading..."_ or something, although the spinners themselves should already be self-explanatory IMO, it's a standard UI thing not specific to our app.