### PR TITLE
GGRC-12 Auditor isn't able to create an Assessment under an audit

### DIFF
--- a/src/ggrc_basic_permissions/roles/Auditor.py
+++ b/src/ggrc_basic_permissions/roles/Auditor.py
@@ -36,6 +36,7 @@ permissions = {
         "Request",
         "Assessment",
         "Issue",
+        "Audit",
     ],
     "delete": [
         "Request",

--- a/test/integration/ggrc_basic_permissions/test_creator_audit.py
+++ b/test/integration/ggrc_basic_permissions/test_creator_audit.py
@@ -34,13 +34,13 @@ class TestCreatorAudit(TestCase):
             "objects": {
                 "audit": {
                     "get": 200,
-                    "put": 403,
+                    "put": 200,
                     "delete": 403
                 },
                 "mapped_Issue": {
                     "get": 200,
-                    "put": 403,
-                    "delete": 403
+                    "put": 200,
+                    "delete": 200
                 },
                 "unrelated_Issue": {
                     "get": 403,
@@ -50,8 +50,8 @@ class TestCreatorAudit(TestCase):
                 },
                 "mapped_Assessment": {
                     "get": 200,
-                    "put": 403,
-                    "delete": 403
+                    "put": 200,
+                    "delete": 200
                 },
                 "unrelated_Assessment": {
                     "get": 403,


### PR DESCRIPTION
Subject: Auditor isn't able to create an Assessment under an audit
Details: 
- Create a program as Admin
- Create an audit as Admin and assign GC as auditor
- Navigate to Audit page-> Create Assessment and assign Creator as GC  and assessor as GC  -> Save and Close
- Log as GC
- Navigate to audit page-> Try to Create 1 Assessment: an error 403 is displayed in Console
- Create second Assessment: confirm that an error is displayed 