### PR TITLE
GGRC-491 Fix updating CAs with the old API

### DIFF
--- a/src/ggrc/models/mixins/customattributable.py
+++ b/src/ggrc/models/mixins/customattributable.py
@@ -278,8 +278,7 @@ class CustomAttributable(object):
         CustomAttributeValue.attributable_id == self.id)).all()
 
     attr_value_ids = [value.id for value in attr_values]
-    ftrp_properties = [
-        "attribute_value_{id}".format(id=_id) for _id in attr_value_ids]
+    ftrp_properties = [val.custom_attribute.title for val in attr_values]
 
     # Save previous value of custom attribute. This is a bit complicated by
     # the fact that imports can save multiple values at the time of writing.


### PR DESCRIPTION
This commit fixes the regression caused by https://github.com/google/ggrc-core/pull/4683/commits/7b69a5a54c0ab709ba001492ab44e7e30127578e because we did
not change the fulltext property name everywhere. This fixes the invalid
property name is used for custom attribute values.

To test this just try to set and then edit any custom attribute value on any object that still uses the old custom attribute API. (anything that's not assessments)

The real fix would be to remove the old CA API and just update the entire froned, but this is good enough for now, and we already have a ticket for that.