### PR TITLE
GGRC-311 Refresh user role after update in /admin

### DIFF
--- a/src/ggrc_basic_permissions/assets/javascripts/controllers/contributions.js
+++ b/src/ggrc_basic_permissions/assets/javascripts/controllers/contributions.js
@@ -397,6 +397,7 @@
           return join.refresh().then(function () {
             return join.destroy();
           }).then(function () {
+            self.refresh_object_list();
             self.element.trigger('relationshipdestroyed', join);
           });
         }
@@ -413,6 +414,7 @@
           join.save().then(function () {
             self.join_list.push(join);
             self.refresh_option_list();
+            self.refresh_object_list();
             self.element.trigger('relationshipcreated', join);
           });
         });


### PR DESCRIPTION
Steps to reproduce:
1. Log as Admin
2. Go to Admin Dashboard-> People’s tab
3. Click grey triangle on the first tier
4. Click 3 bb’s button in Info pane
5. Select Edit Authorizations
6. Change user role for the selected person-> Save

Actual Result: User role is not changed in the tree view.
Expected Result: User role should be changed.
