### PR TITLE
GGRG-503 Add version of snapshot in header

### DIFF
--- a/src/ggrc/assets/mustache/base_objects/general_info.mustache
+++ b/src/ggrc/assets/mustache/base_objects/general_info.mustache
@@ -10,6 +10,9 @@
       <div data-test-id="title_0ad9fbaf" class="span9">
         <h6>Title</h6>
         <h3>{{title}}</h3>
+        {{#if snapshot}}
+          <span class="state-value snapshot">{{instance.class.title_singular}} version as at {{date instance.updated_at}}</span>
+        {{/if}}
         {{#if status}}
           <span class="state-value">{{un_camel_case status}}</span>
         {{/if}}

--- a/src/ggrc/assets/stylesheets/_colors.scss
+++ b/src/ggrc/assets/stylesheets/_colors.scss
@@ -153,3 +153,5 @@ $bar-warning: #ffcebe;
 // snapshots
 $snapshotBgnd: #ddf3fd;
 $shapshotBorder: #d9e6ec;
+$snapshotLblBgnd: #6eaacd;
+$snapshotLbl: white;

--- a/src/ggrc/assets/stylesheets/modules/_snapshot.scss
+++ b/src/ggrc/assets/stylesheets/modules/_snapshot.scss
@@ -13,6 +13,12 @@
   margin-left: 0;
 }
 
+.state-value.snapshot {
+  color: $snapshotLbl;
+  background: $snapshotLblBgnd;
+  text-transform: none;
+}
+
 hr.snapshot {
   display: block;
   height: 1px;


### PR DESCRIPTION

1. Open control tabs for snapshoted audit
2. Click snapshoted control in tree view
3. Check header for info page

Expected: version of snapshot should be displayed in header box for info page