### PR TITLE
GGRC-518 Fix error message  after update instance in modal

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/modals_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/modals_controller.js
@@ -993,7 +993,7 @@ can.Control('GGRC.Controllers.Modals', {
       duration: 200,
       complete: function () {
         if (error) {
-          GGRC.Errors.notifierXHR('error')(error);
+          GGRC.Errors.notifier('error', error.responseText);
         }
         delete this.disable_hide;
       }.bind(this)


### PR DESCRIPTION
**Precondition:**
Create GCA with any type for assessment, created program and audit
**Steps to reproduce:**
1. Go to Assessment Template tab on Audit page
2. Add title
3. Add LCA with a title that is not exist for assessment-> Save and Close
5. Open the created Assessment template to edit
6. Add LCA with the title as GCA has from precondition-> Save and Close

_Actual Result:_ "There was an error" occurs in Edit Assessment template modal while saving LCA with the title equal GCA 
_Expected Result:_ no error displayed. A warning that invalid Custom attribute name should be displayed