### PR TITLE
GGRC-495 Hide import and export buttons for snapshots

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
@@ -461,6 +461,11 @@ CMS.Controllers.TreeLoader('CMS.Controllers.TreeView', {
   // When user selects 3 middle selectable attribute, title width is reduced to span3
   // and when user selects 4 attributes, the action column is also reduced to span3
   setup_column_width: function () {
+    // Special case when import and export buttons should not be wisible for snapshots
+    var snapshots = GGRC.Utils.Snapshots;
+    var hideImportExport =
+        snapshots.isSnapshotScope(this.options.parent_instance) &&
+        snapshots.isSnapshotModel(this.options.model.model_singular);
     var display_options;
     var display_width = 12;
     var attr_count = this.options.display_attr_list.length;
@@ -482,7 +487,8 @@ CMS.Controllers.TreeLoader('CMS.Controllers.TreeView', {
       title_width: selected_widths[0],
       selectable_width: selected_widths[1],
       action_width: selected_widths[2],
-      selectable_attr_width: display_width / Math.max(attr_count, 1)
+      selectable_attr_width: display_width / Math.max(attr_count, 1),
+      hideImportExport: hideImportExport
     };
     this.options.attr('display_options', display_options);
   },

--- a/src/ggrc/assets/mustache/import_export/import_export_buttons.mustache
+++ b/src/ggrc/assets/mustache/import_export/import_export_buttons.mustache
@@ -3,21 +3,25 @@
   Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
 
-{{^if_instance_of parent_instance 'Assessment'}}
-<li>
-  <a href="/import"
-    class="section-import" rel="tooltip" data-placement="left"
-    title="" data-original-title="Import {{model.model_plural}}">
-    <i class="fa fa-cloud-upload"></i>
-  </a>
-</li>
-{{#if list.length}}
+{{#if display_options.hideImportExport}}
+
+{{else}}
+  {{^if_instance_of parent_instance 'Assessment'}}
   <li>
-    <a href="/export?model_type={{model.model_singular}}&relevant_type={{parent_instance.type}}&relevant_id={{parent_instance.id}}"
+    <a href="/import"
       class="section-import" rel="tooltip" data-placement="left"
-      title="" data-original-title="Export {{model.model_plural}}">
-      <i class="fa fa-download"></i>
+      title="" data-original-title="Import {{model.model_plural}}">
+      <i class="fa fa-cloud-upload"></i>
     </a>
   </li>
+  {{#if list.length}}
+    <li>
+      <a href="/export?model_type={{model.model_singular}}&relevant_type={{parent_instance.type}}&relevant_id={{parent_instance.id}}"
+        class="section-import" rel="tooltip" data-placement="left"
+        title="" data-original-title="Export {{model.model_plural}}">
+        <i class="fa fa-download"></i>
+      </a>
+    </li>
+  {{/if}}
+  {{/if_instance_of}}
 {{/if}}
-{{/if_instance_of}}


### PR DESCRIPTION
Precondition:
1. Created program, control, snapshotable object (e.g. Access group), audit
Steps to reproduce:
1. Go to Access Group tab on Audit page
2. Look at tree view tool bar: confirm export/import icon is not hidden 

Actual Result: export/import button is not hidden in tree view tool bar
Expected Result: export/import button should be hidden in tree view tool bar