### PR TITLE
GGRC-307 Prevent info pin from collapsing when removing URL

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
@@ -1004,6 +1004,8 @@ CMS.Controllers.TreeLoader('CMS.Controllers.TreeView', {
 
   '{original_list} remove': function (list, ev, oldVals, index) {
     var remove_marker = {}; // Empty object used as unique marker
+    var removedObjectType;
+    var skipInfoPinRefresh = false;
 
     //  FIXME: This assumes we're replacing the entire list, and corrects for
     //    instances being removed and immediately re-added.  This should be
@@ -1018,6 +1020,18 @@ CMS.Controllers.TreeLoader('CMS.Controllers.TreeView', {
           return v.instance ? v.instance : v;
         }));
 
+    // If a removed object is a Document or a Person, it is likely that it
+    // was removed from the info pin, thus refreshing the latter is not needed.
+    // The check will fail, though, if the info pane was displaying a person
+    // located in a subtree, and we unmapped that person from the object
+    // displayed in the parent tree view node.
+    if (oldVals.length === 1 && oldVals[0].instance) {
+      removedObjectType = oldVals[0].instance.type;
+      if (removedObjectType === 'Person' || removedObjectType === 'Document') {
+        skipInfoPinRefresh = true;
+      }
+    }
+
     // `remove_marker` is to ensure that removals are not attempted until 20ms
     //   after the *last* removal (e.g. for a series of removals)
     this._remove_marker = remove_marker;
@@ -1028,6 +1042,10 @@ CMS.Controllers.TreeLoader('CMS.Controllers.TreeView', {
         }.bind(this));
         this.oldList = null;
         this._remove_marker = null;
+
+        if (skipInfoPinRefresh) {
+          return;
+        }
 
         // TODO: This is a workaround. We need to update communication between
         //       info-pin and tree views through Observer
@@ -1250,6 +1268,9 @@ CMS.Controllers.TreeLoader('CMS.Controllers.TreeView', {
 
     function onDestroyed(ev, instance) {
       var current;
+      var destType;
+      var srcType;
+
       if (self._verifyRelationship(instance, activeTabModel) ||
         instance instanceof CMS.Models[activeTabModel]) {
         if (self.options.attr('original_list').length === 1) {
@@ -1257,7 +1278,20 @@ CMS.Controllers.TreeLoader('CMS.Controllers.TreeView', {
           self.options.attr('paging.current',
             current > 1 ? current - 1 : 1);
         }
+
+        // if unmapping e.g. an URL (a "Document") or an assignee from
+        // the info pin, refreshing the latter is not needed
+        if (instance instanceof CMS.Models.Relationship) {
+          srcType = instance.source.type;
+          destType = instance.destination.type;
+          if (srcType === 'Person' || destType === 'Person' ||
+              srcType === 'Document' || destType === 'Document') {
+            return;
+          }
+        }
+
         _refresh();
+
         // TODO: This is a workaround.We need to update communication between
         //       info-pin and tree views through Observer
         if (!self.element.closest('.cms_controllers_info_pin').length) {


### PR DESCRIPTION
This PR fixes unwanted automatic collapses of info pane.

The cause was the logic in the tree view controller that too eagerly reacted to every remove/unmap event. This fix adds some heuristics to skip refreshing the info pin if an object has been removed  in the latter, and not within the tree view itself.

**Disclaimer:**
Mind that a fix is really not that pretty, and the heuristics might fail in a few cases. Fixing this properly, however, would require to implement a consistent and reliable communication channel between the tree view and the info pane, but paying off that technical debt would be way too big of a task in scope of this fix, the tree view controller is just too patchy.

If anybody know a better solution, please do tell! I would be very happy to hear alternative suggestions.

(also, no tests, because an integration or an end-to-end test would make the most sense here)

---
**Reproducing the issue:**
Open an object (e.g. an Audit), switch to one if its tabs (e.g. Assessments) and select one object in the tree view (top level) to open its info pane.

With info pane open (let's say we are looking at an Assessment), unmap/delete some object from the info pane, e.g. delete an attached URL, or remove a person in the People section on the right (you must make sure that the person removed is removed from _all_ roles assigned to it on the Assessment).

**Expected result:** An object is unmapped from the "main" object, the latter's info pane stays open.
**Actual result:** The info pane is collapsed, and possibly re-opened, but empty.