### PR TITLE
GGRC-438 Rename "Assessor" to "Assignee"

### DIFF
--- a/src/ggrc/assets/javascripts/models/assessment.js
+++ b/src/ggrc/assets/javascripts/models/assessment.js
@@ -164,7 +164,7 @@
         'validate_assessor',
         function () {
           if (!this.validate_assessor) {
-            return 'You need to specify at least one assessor';
+            return 'You need to specify at least one assignee';
           }
         }
       );

--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -674,8 +674,8 @@
         {value: 'Object Owners', title: 'Object Owners'},
         {value: 'Audit Lead', title: 'Audit Lead'},
         {value: 'Auditors', title: 'Auditors'},
-        {value: 'Primary Assessor', title: 'Principal Assessor'},
-        {value: 'Secondary Assessors', title: 'Secondary Assessors'},
+        {value: 'Primary Assessor', title: 'Principal Assignee'},
+        {value: 'Secondary Assessors', title: 'Secondary Assignee'},
         {value: 'Primary Contact', title: 'Primary Contact'},
         {value: 'Secondary Contact', title: 'Secondary Contact'},
         {value: 'other', title: 'Others...'}

--- a/src/ggrc/assets/javascripts/models/control.js
+++ b/src/ggrc/assets/javascripts/models/control.js
@@ -66,9 +66,9 @@
           attr_sort_field: 'frequency.title'},
         {attr_title: 'Assertions', attr_name: 'assertions'},
         {attr_title: 'Categories', attr_name: 'categories'},
-        {attr_title: 'Principal Assessor', attr_name: 'principal_assessor',
+        {attr_title: 'Principal Assignee', attr_name: 'principal_assessor',
           attr_sort_field: 'principal_assessor.name|email'},
-        {attr_title: 'Secondary Assessor', attr_name: 'secondary_assessor',
+        {attr_title: 'Secondary Assignee', attr_name: 'secondary_assessor',
           attr_sort_field: 'secondary_assessor.name|email'}
       ]),
       add_item_view: GGRC.mustache_path + '/controls/tree_add_item.mustache',

--- a/src/ggrc/assets/mustache/assessment_templates/info.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/info.mustache
@@ -56,7 +56,7 @@
 
       <div class="row-fluid wrap-row">
         <div class="span4">
-          <h6>Default Assessors</h6>
+          <h6>Default Assignees</h6>
           {{#if default_people.assessors}}
             {{#if_string default_people.assessors}}
               {{get_item DEFAULT_PEOPLE_LABELS default_people.assessors}}

--- a/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
@@ -117,7 +117,7 @@
         <div class="row-fluid choose-from-select">
           <div class="span6 bottom-spacing">
             <label>
-              Default Assessors
+              Default Assignees
               <span class="required">*</span>
             </label>
             <dropdown
@@ -135,7 +135,7 @@
                 search-items-type="Person"
                 can-item-selected="instance.assessorAdded"
                 disable="instance.assessorsListDisable"
-                placeholder="Enter text to search for Assessors"
+                placeholder="Enter text to search for Assignees"
               ></autocomplete>
 
               {{#instance.computed_errors.assessorsList}}

--- a/src/ggrc/assets/mustache/assessments/header.mustache
+++ b/src/ggrc/assets/mustache/assessments/header.mustache
@@ -61,23 +61,23 @@ Copyright (C) 2016 Google Inc.
                                     <reminder
                                             instance="instance"
                                             type="statusToPerson"
-                                            modal_title="Reminder for Assessors set"
-                                            modal_description="Tomorrow all Assessors will receive a notification to look at this Assessment if they didn't move it to 'Finished' in between."
+                                            modal_title="Reminder for Assignees set"
+                                            modal_description="Tomorrow all Assignees will receive a notification to look at this Assessment if they didn't move it to 'Finished' in between."
                                     >
                                         <a href="javascript://" can-click="reminder">
                                             <i class="fa fa-bell-o"></i>
-                                            Send reminder to assessors</a>
+                                            Send reminder to assignees</a>
                                     </reminder>
                                 {{else}}
                                     <reminder
                                             instance="instance"
                                             type="statusToPerson"
-                                            modal_title="Reminder for Assessors set"
-                                            modal_description="Tomorrow all Assessors will receive a notification to look at this Assessment if they didn't move it to 'Final' in between."
+                                            modal_title="Reminder for Assignees set"
+                                            modal_description="Tomorrow all Assignees will receive a notification to look at this Assessment if they didn't move it to 'Final' in between."
                                     >
                                         <a href="javascript://" can-click="reminder">
                                             <i class="fa fa-bell-o"></i>
-                                            Send reminder to assessors</a>
+                                            Send reminder to assignees</a>
                                     </reminder>
                                 {{/if_verifiers_defined}}
                               {{/unless}}

--- a/src/ggrc/assets/mustache/assessments/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessments/modal_content.mustache
@@ -151,7 +151,7 @@
             <li>
               <label class="input--inline">
                   <input type="checkbox" can-value="values.Assessor">
-                  Notify assessor(s)
+                  Notify assignee(s)
               </label>
             </li>
             <li>

--- a/src/ggrc/assets/mustache/controls/info.mustache
+++ b/src/ggrc/assets/mustache/controls/info.mustache
@@ -49,7 +49,7 @@
               </p>
             </div>
             <div class="span3">
-              <h6>Principal Assessor</h6>
+              <h6>Principal Assignee</h6>
               {{#using assessor=instance.principal_assessor}}
               {{#if instance.principal_assessor}}
                 <p>
@@ -61,7 +61,7 @@
               {{/using}}
             </div>
             <div class="span3">
-              <h6>Secondary Assessor</h6>
+              <h6>Secondary Assignee</h6>
               {{#using assessor=instance.secondary_assessor}}
               {{#if instance.secondary_assessor}}
                 <p>

--- a/src/ggrc/assets/mustache/controls/modal_content.mustache
+++ b/src/ggrc/assets/mustache/controls/modal_content.mustache
@@ -192,27 +192,27 @@
     <div class="row-fluid">
       <div data-test-id="control_primary_assessor_f7379330" data-id="principal_assessor_hidden" class="span4 hidable">
         <label>
-          Principal Assessor
+          Principal Assignee
           <i class="fa fa-question-circle" rel="tooltip" title="Select primary person who is responsible for assessing this control."></i>
           <a data-id="hide_principal_assessor_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
         </label>
         <i class="fa fa-person green pull-left icon-field"></i>
         <div class="objective-selector">
           {{#using assessor=instance.principal_assessor}}
-          <input data-id="principal_assessor_txtbx"  tabindex="18" type="text" name="principal_assessor.email" data-lookup="Person" class="span11 audit-selector search-icon" placeholder="Enter text to search for Principal Assessor" value="{{firstnonempty assessor.email ''}}">
+          <input data-id="principal_assessor_txtbx"  tabindex="18" type="text" name="principal_assessor.email" data-lookup="Person" class="span11 audit-selector search-icon" placeholder="Enter text to search for Principal Assignee" value="{{firstnonempty assessor.email ''}}">
           {{/using}}
         </div>
       </div>
       <div data-test-id="control_secondary_assessor_b9439af6"  data-id="secondary_assessor_hidden" class="span4 hidable">
         <label>
-          Secondary Assessor
+          Secondary Assignee
           <i class="fa fa-question-circle" rel="tooltip" title="Select secondary person who is responsible for assessing this control."></i>
           <a data-id="hide_secondary_assessor_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
         </label>
         <i class="fa fa-person green pull-left icon-field"></i>
         <div class="objective-selector">
           {{#using assessor=instance.secondary_assessor}}
-          <input data-id="secondary_assessor_txtbx" tabindex="19" type="text" name="secondary_assessor.email" data-lookup="Person" class="span11 audit-selector search-icon" placeholder="Enter text to search for Secondary Assessor" value="{{firstnonempty assessor.email ''}}">
+          <input data-id="secondary_assessor_txtbx" tabindex="19" type="text" name="secondary_assessor.email" data-lookup="Person" class="span11 audit-selector search-icon" placeholder="Enter text to search for Secondary Assignee" value="{{firstnonempty assessor.email ''}}">
           {{/using}}
         </div>
       </div>


### PR DESCRIPTION
There were still some places in the app where the obsolete _"Assessor"_ term was used instead of the _"Assignee"_.

The change can be seen (at least) at the following places, mostly form labels and input field placeholder texts:
 - Control's edit modal and info pane (check the Advanced section)
 - Assessment Template's edit modal and info pane
 - Assessment's info pane - the "remind people" link and the text in the notification dialog that appears.

I have noticed that there are some texts in the `notification_types` table, too, but it was not clear what should be changed there, if anything. For example, the record with the ID 22 contains both the `"Assessor"` and the `"Assignee"` words, thus I was not sure what the semantics of an `"Assessor"` are in that context, and decided to not change that for the time being.

```console 
mysql> SELECT id, name, description FROM notification_types WHERE description LIKE "%assessor%";
```

| id | name | description |
|---|---|---|
| 22 | assessment_open | Send an open assessment notification to Assessors, Assignees and Verifiers. |
| 23 | assessment_declined | Notify Assessor that an assessment was declined. |
| 25 | assessment_assessor_reminder | Notify all Assessors that they should take a look at the assessment. |

---

NOTE:
I did not change any of the labels on the backend (i.e. in Python) in order to not break users' existing import files that still use old column labels. If this PR should change that, too, on top of the frontend labels, please let me know.
