### PR TITLE
GGRC-457 Restore modal state after save

### DIFF
--- a/src/ggrc/assets/mustache/assessments/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessments/modal_content.mustache
@@ -134,7 +134,7 @@
       <div class="comment-notification">
         <a data-id="hide_notification_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
         <label>
-          <input type="checkbox"
+          <input tabindex="11" type="checkbox"
                  name="send_by_default"
                  {{# send_by_default}}checked{{/send_by_default}}>
           Enable notifications on comments
@@ -144,19 +144,19 @@
           <ul class="comment-notification__list">
             <li>
               <label class="input--inline">
-                  <input type="checkbox" can-value="values.Creator">
+                  <input tabindex="12" type="checkbox" can-value="values.Creator">
                   Notify creator(s)
               </label>
             </li>
             <li>
               <label class="input--inline">
-                  <input type="checkbox" can-value="values.Assessor">
+                  <input tabindex="13" type="checkbox" can-value="values.Assessor">
                   Notify assignee(s)
               </label>
             </li>
             <li>
               <label class="input--inline">
-                  <input type="checkbox" can-value="values.Verifier">
+                  <input tabindex="14" type="checkbox" can-value="values.Verifier">
                   Notify verifier(s)
               </label>
             </li>
@@ -239,7 +239,8 @@
           <i class="fa fa-question-circle" rel="tooltip" title="Is this control design effective?"></i>
           <a data-id="hide_state_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
         </label>
-          <dropdown options-list="model.conclusions"
+          <dropdown tabindex="9"
+                    options-list="model.conclusions"
                     no-value="true"
                     no-value-label="---"
                     name="instance.design">
@@ -252,7 +253,8 @@
           <i class="fa fa-question-circle" rel="tooltip" title="Is this control operationally effective?"></i>
           <a data-id="hide_state_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
         </label>
-          <dropdown options-list="model.conclusions"
+          <dropdown tabindex="10"
+                    options-list="model.conclusions"
                     no-value="true"
                     no-value-label="---"
                     name="instance.operationally">

--- a/src/ggrc/assets/mustache/components/effective-dates/effective-dates.mustache
+++ b/src/ggrc/assets/mustache/components/effective-dates/effective-dates.mustache
@@ -6,6 +6,7 @@
 <div data-id="effective_date_hidden" class="span4 hidable">
   <a data-id="hide_effective_date_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
   <datepicker
+      tabindex="20"
       label="configStartDate.label"
       date="instance.start_date"
       set-max-date="instance.end_date"
@@ -18,6 +19,7 @@
 <div data-id="stop_date_hidden" class="span4 hidable">
   <a data-id="hide_stop_date_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
   <datepicker
+      tabindex="21"
       label="configEndDate.label"
       date="instance.end_date"
       set-min-date="instance.start_date"


### PR DESCRIPTION
**Preconditions**:
1. Created program and audit

**Steps to reproduce:**
1. Go to audit page
2. Add tab->Assessment
3. During Assessment creation click on [Hide all optional fields button]-> Save and Add Another
4. Look at New Assessment modal: additional optional fields are displayed

_Actual Result:_ Additional optional fields are displayed in New Assessment modal after click Save and Add Another button
_Expected Result:_ Additional optional fields should not displayed in New Assessment modal after click Save and Add Another button
