### PR TITLE
GGRC-506 Show second level of treeView for snapshots

### DIFF
--- a/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
+++ b/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
@@ -762,6 +762,8 @@
       content.isLatestRevision = instance.is_latest_revision;
       content.originalLink = '/' + type + '/' + content.id;
       content.snapshot = new CMS.Models.Snapshot(instance);
+      content.related_sources = instance.related_sources;
+      content.related_destinations = instance.related_destinations;
       content.custom_attribute_values = content.custom_attributes;
       content.viewLink = content.snapshot.viewLink;
       content.selfLink = content.snapshot.selfLink;


### PR DESCRIPTION
Precondition:
1. Created program, control, audit, snapshotable object (e.g. Access Group)
Steps to reproduce:
1. Go to  Access Group tab on Audit page
2. Click gray triangle on the first tree view: confirm the second tree view is not displayed

Actual Result: Snapshotable object's second tree view is not displayed on Audit page
Expected Result: Snapshotable object's second tree view should be shown on Audit page

**NOTE:** This fix will show parent object (on the second level) of snapshot, then objects that are mapped to parent object (third level). It should be confirmed by @akhilp1 .

**NOTE2:** We can proceed and show it next Monday to Akhill, and fix if any change will be requested.

I hope that this behavior is more logical, because user can't change mappings for snapshot but only for parent object.

<img width="1440" alt="screen shot 2016-11-24 at 13 04 15" src="https://cloud.githubusercontent.com/assets/674129/20595283/675d5d58-b24a-11e6-925f-1a00d86a6ef9.png">