### PR TITLE
GGRC-502 Show snapshots in blue color in treeView

### DIFF
--- a/src/ggrc/assets/stylesheets/_colors.scss
+++ b/src/ggrc/assets/stylesheets/_colors.scss
@@ -152,6 +152,7 @@ $bar-warning: #ffcebe;
 
 // snapshots
 $snapshotBgnd: #ddf3fd;
+$snapshotBgndActive: darken($snapshotBgnd, 10%);
 $shapshotBorder: #d9e6ec;
 $snapshotLblBgnd: #6eaacd;
 $snapshotLbl: white;

--- a/src/ggrc/assets/stylesheets/modules/_snapshot.scss
+++ b/src/ggrc/assets/stylesheets/modules/_snapshot.scss
@@ -60,10 +60,17 @@ a.disabled {
 // Tree view
 ul.new-tree {
   li.tree-item {
-    &.active.snapshot {
+    &.snapshot {
       > .item-main {
         > .item-wrap {
           background: $snapshotBgnd;
+        }
+      }
+    }
+    &.active.snapshot {
+      > .item-main {
+        > .item-wrap {
+          background: $snapshotBgndActive;
         }
       }
     }


### PR DESCRIPTION
1. Create Audit and map control
2. Change control title and go to Control tab at Audit page
3. Snapshoted control displayed in blue color in tree-view (for first level of tree-view)
4. If tree view is selected the blue color should be deeper