### PR TITLE
GGRC-507 Update message for outdated version of snapshot

### DIFF
--- a/src/ggrc/assets/mustache/base_objects/general_info.mustache
+++ b/src/ggrc/assets/mustache/base_objects/general_info.mustache
@@ -27,7 +27,10 @@
           <div class="span12 snapshot">
             <hr class="snapshot">
             <p>
-              A more current version of this {{instance.class.title_singular}} is available. Do you want to <a href="#">update</a>?
+              <snapshot-individual-update instance="instance">
+                  <a href="javascript://" can-click="updateIt">Click here</a>
+                  if you want to check for latest version and update.
+              </snapshot-individual-update>
             </p>
           </div>
         {{/isLatestRevision}}


### PR DESCRIPTION
1. Update message to "click here if you want to check for latest version and update"
2. Word "Click here" is a link that opens "Update to latest version" window