### PR TITLE
GGRC-413 DIsplay max Assessment evidence upload batch size

### DIFF
--- a/src/ggrc/assets/mustache/components/assessment/attachments-list.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/attachments-list.mustache
@@ -6,6 +6,7 @@
 <h6>Evidence</h6>
   {{#is_allowed 'update' instance context='for'}}
     {{{render_hooks "Request.gdrive_evidence_storage"}}}
+    <div class="attach-file-info">(you can upload up to 10 files in a single batch)</div>
   {{/is_allowed}}
 {{^if_null instance._mandatory_attachment_msg}}
   <div class="alert alert-info alert-dismissible" role="alert">

--- a/src/ggrc/assets/stylesheets/modules/_assessment.scss
+++ b/src/ggrc/assets/stylesheets/modules/_assessment.scss
@@ -62,6 +62,12 @@ $border-color: #eee;
       flex: 1 1 50%;
       max-width: 50%;
     }
+
+    .attach-file-info {
+      margin: -10px 0 10px;
+      font-size: 0.9em;
+      font-style: italic;
+    }
   }
 }
 


### PR DESCRIPTION
A user reported that when attaching evidence to an Assessment, the upload silently (?) fails if trying to attach more than 10 files at once. This seems to be a GDrive account limitation, as I successfully uploaded 11 files in a batch locally.

Anyway, in order for the users to not be confused, this limitation needs to be presented to them, and @akhilp1 confirmed that displaying an informative text on the form would already suffice. This PR thus adds such text to the Assessment info pane, right under the "Attach Evidence" button.