### PR TITLE
GGRC-417 Remove object type from Title header in tree view

### DIFF
--- a/src/ggrc/assets/mustache/assessments/tree_header.mustache
+++ b/src/ggrc/assets/mustache/assessments/tree_header.mustache
@@ -10,7 +10,7 @@
       <div class="span{{display_options.title_width}}">
         <div class="title-heading oneline">
           <span class="widget-col-title" data-field="title">
-            {{model.title_singular}} Title
+            Title
             <i class="fa fa-caret-up"></i>
           </span>
         </div>

--- a/src/ggrc/assets/mustache/audits/tree_header.mustache
+++ b/src/ggrc/assets/mustache/audits/tree_header.mustache
@@ -10,7 +10,7 @@
     <div class="span{{display_options.title_width}}">
       <div class="title-heading oneline">
         <span class="widget-col-title" data-field="title">
-          {{model.title_singular}} Title
+          Title
           <i class="fa fa-caret-up"></i>
         </span>
       </div>

--- a/src/ggrc/assets/mustache/base_objects/tree_header.mustache
+++ b/src/ggrc/assets/mustache/base_objects/tree_header.mustache
@@ -9,7 +9,7 @@
     <div class="span{{display_options.title_width}}">
       <div class="title-heading oneline">
         <span class="widget-col-title" data-field="title">
-          {{model.title_singular}} Title
+          Title
           <i class="fa fa-caret-up"></i>
         </span>
       </div>

--- a/src/ggrc/assets/mustache/people/tree_header.mustache
+++ b/src/ggrc/assets/mustache/people/tree_header.mustache
@@ -10,7 +10,7 @@
     <div class="span4">
       <div class="title-heading oneline">
         <span class="widget-col-title" data-field="title">
-          {{model.title_singular}} Name
+          Name
           <i class="fa fa-caret-up"></i>
         </span>
       </div>

--- a/src/ggrc/assets/mustache/requests/tree_header.mustache
+++ b/src/ggrc/assets/mustache/requests/tree_header.mustache
@@ -10,7 +10,7 @@
     <div class="span{{display_options.title_width}}">
       <div class="title-heading oneline">
         <span class="widget-col-title" data-field="description">
-          {{model.title_singular}} Title
+          Title
           <i class="fa fa-caret-up"></i>
         </span>
       </div>

--- a/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/tree_header.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/tree_header.mustache
@@ -10,7 +10,7 @@
     <div class="span{{display_options.title_width}}">
       <div class="title-heading oneline">
         <span class="widget-col-title" data-field="title">
-          Task Title
+          Title
           <i class="fa fa-caret-down"></i>
         </span>
       </div>


### PR DESCRIPTION
This PR removes the object type info from the tree view's Title column header, because that was causing a confusion when using a filterr (I presume users were trying to filter by an incorrect column name). The label of the "title" column in tree view is now simply `"TITLE"` instead of `"{object_type} TITLE"`.

The original ticket description:
> Update the title column header without the object name - Assessment Title to Title - Causing confusion in Filter