### PR TITLE
GGRC-471 Unify icon colors on info pane

### DIFF
--- a/src/ggrc/assets/stylesheets/modules/_assessment.scss
+++ b/src/ggrc/assets/stylesheets/modules/_assessment.scss
@@ -212,6 +212,9 @@ $border-color: #eee;
         position: absolute;
         right: 0;
         top: 0;
+        &.fa-question-circle {
+          color: $icon-color-dark;
+        }
       }
     }
 


### PR DESCRIPTION
This PR adjusts the color of the `(?)` icon to match the color of other icons.

To see the change in action, open an object, switch to one of the object tabs that have Custom Attributes (e.g. Assessments), and select one of the Assessments in the tree view (create one if necessary).

You will see that on the info pane, the formerly black `(?)` icons next to (some) custom attributes now match the color of e.g. the `(+)` icon for adding an URL (at the bottom of the info pane's gray area).

You also check the following [screenshot](https://lh3.googleusercontent.com/-z8YutKRjoBs/WDV55LX3GVI/AAAAAAAAAUk/-0WLvzTUlusFW2v2s9nybCkUbtE7JtHZQCL0B/h1572/2016-11-23.png) for a better picture.