### PR TITLE
GGRC-167 Fix regression with adding comments

### DIFF
--- a/src/ggrc/models/hooks/comment.py
+++ b/src/ggrc/models/hooks/comment.py
@@ -21,7 +21,6 @@ def init_hook():
     for obj in objects:
       obj_owner = ObjectOwner(
           person_id=creator_id,
-          ownable_id=obj.id,
-          ownable_type=obj.type,
+          ownable=obj,
       )
       db.session.add(obj_owner)


### PR DESCRIPTION
This PR fixes the regression when adding a comment became non-functional.

Steps to reproduce:

0. Run the app as `launch_gae_ggrc`.
1. Open an Assessment page.
2. Try to add a comment.

Expected result: the comment is added.
Actual result: HTTP500 is returned, the comment is not added.

Marking `please review` as it's a blocking issue (even for the `develop` branch).

**UPD**: added a note to test this with GAE emulation.