### PR TITLE
QUICK-FIX Exclude Role from reindex

### DIFF
--- a/src/ggrc/views/__init__.py
+++ b/src/ggrc/views/__init__.py
@@ -75,7 +75,8 @@ def do_reindex():
   excluded_models = {
       all_models.Directive,
       all_models.Option,
-      all_models.SystemOrProcess
+      all_models.SystemOrProcess,
+      all_models.Role,
   }
   indexed_models = {model for model in all_models.all_models
                     if model_is_indexed(model)}


### PR DESCRIPTION
The Role object is not searchable and is also not indexed by default
when a new application instance is created. That is why the reindexer
should also ignore this object.