### PR TITLE
GGRC-487, GGRC-490 Import revisions fix

### DIFF
--- a/src/ggrc/converters/handlers/custom_attribute.py
+++ b/src/ggrc/converters/handlers/custom_attribute.py
@@ -7,7 +7,6 @@ from dateutil.parser import parse
 
 from sqlalchemy import and_
 
-from ggrc import db
 from ggrc import models
 from ggrc.converters import errors
 from ggrc.converters.handlers import handlers
@@ -37,7 +36,15 @@ class CustomAttributeColumHandler(handlers.TextColumnHandler):
 
     CA values set in insert_object() method.
     """
-    pass
+    if self.value is None:
+      return
+
+    cav = self._get_or_create_ca()
+    cav.attribute_value = self.value
+    if isinstance(cav.attribute_value, models.mixins.Identifiable):
+      obj = cav.attribute_value
+      cav.attribute_value = obj.__class__.__name__
+      cav.attribute_object_id = obj.id
 
   def parse_item(self):
     """Parse raw value from csv file
@@ -97,25 +104,12 @@ class CustomAttributeColumHandler(handlers.TextColumnHandler):
         return ca_value
     ca_value = models.CustomAttributeValue(
         custom_attribute=ca_definition,
-        custom_attribute_id=ca_definition.id,
-        attributable_type=self.row_converter.obj.__class__.__name__,
-        attributable_id=self.row_converter.obj.id,
+        attributable=self.row_converter.obj,
     )
-    db.session.add(ca_value)
     return ca_value
 
   def insert_object(self):
     """Add custom attribute objects to db session."""
-    if self.dry_run or self.value is None:
-      return
-
-    ca = self._get_or_create_ca()
-    ca.attribute_value = self.value
-    if isinstance(ca.attribute_value, models.mixins.Identifiable):
-      obj = ca.attribute_value
-      ca.attribute_value = obj.__class__.__name__
-      ca.attribute_object_id = obj.id
-    self.dry_run = True
 
   def get_date_value(self):
     """Get date value from input string date."""
@@ -209,6 +203,7 @@ class ObjectCaColumnHandler(CustomAttributeColumHandler):
     if self.dry_run:
       return
     self.value = self.parse_item()
+    super(ObjectCaColumnHandler, self).set_obj_attr()
 
   def get_ca_definition(self):
     """Get custom attribute definition for a specific object."""

--- a/test/integration/ggrc/converters/test_csvs/all_snapshottable_objects.csv
+++ b/test/integration/ggrc/converters/test_csvs/all_snapshottable_objects.csv
@@ -1,0 +1,105 @@
+Object type,"Use this db for custom attribute definitions
+https://gist.github.com/zidarsk8/c6335d961a7004b9f896a3e4b1db8a8b",,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Access Group,Code*,Title*,Description,Notes,,Owner*,Effective Date,Stop Date,State,Primary Contact,Secondary Contact,Access Group URL,Reference URL,,,,,,,,,,,,,Delete,,,,,map:assessment,map:audit,map:clause,map:contract,map:control,map:cycle task group object task,map:data asset,map:facility,map:issue,map:market,map:objective,map:org group,map:person,map:policy,map:process,map:product,map:program,map:project,map:regulation,map:request,map:risk,map:section,map:standard,map:system,map:threat,map:vendor
+,Access Group code,Access Group title,Access Group description,Access Group notes,,"user@example.com
+user1@example.com",20/2/2020,22/2/2022,Draft,user2@example.com,user3@example.com,http://url.example.zzz,reference.example.zzz,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Object type,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Clause,Code*,Title*,Text of Clause,Notes,,Owner*,Effective Date,Stop Date,State,Primary Contact,Secondary Contact,Clause URL,Reference URL,,,,,,,,,,,,,Delete,,,,map:access group,map:assessment,map:audit,,map:contract,map:control,map:cycle task group object task,map:data asset,map:facility,map:issue,map:market,map:objective,map:org group,map:person,map:policy,map:process,map:product,map:program,map:project,map:regulation,map:request,map:risk,map:section,map:standard,map:system,map:threat,map:vendor
+,Clause code,Clause title,Clause description,Clause notes,,"user@example.com
+user1@example.com",20/2/2020,22/2/2022,Draft,user2@example.com,user3@example.com,http://url.example.zzz,reference.example.zzz,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Object type,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Contract,Code*,Title*,Description,Notes,,Owner*,Effective Date,Stop Date,State,Primary Contact,Secondary Contact,Contract URL,Reference URL,,,,,,,,,,,,,Delete,,,,map:access group,map:assessment,map:audit,map:clause,,map:control,map:cycle task group object task,map:data asset,map:facility,map:issue,map:market,map:objective,map:org group,map:person,,map:process,map:product,map:program,map:project,,map:request,map:risk,map:section,,map:system,map:threat,map:vendor
+,Contract code,Contract title,Contract description,Contract notes,,"user@example.com
+user1@example.com",20/2/2020,22/2/2022,Draft,user2@example.com,user3@example.com,http://url.example.zzz,reference.example.zzz,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Object type,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Control,Code*,Title*,Description,Notes,Test Plan,Owner*,Effective Date,Stop Date,State,Primary Contact,Secondary Contact,Control URL,Reference URL,Assertions,Categories,Fraud Related,Significance,Kind/Nature,Type/Means,Principal Assessor,Secondary Assessor,Frequency,,,,Delete,CA date,CA dropdown,CA text,map:access group,map:assessment,map:audit,map:clause,map:contract,map:control,map:cycle task group object task,map:data asset,map:facility,map:issue,map:market,map:objective,map:org group,map:person,map:policy,map:process,map:product,map:program,map:project,map:regulation,map:request,map:risk,map:section,map:standard,map:system,map:threat,map:vendor
+,Control code,Control title,Control description,Control notes,Control test plan,"user@example.com
+user1@example.com",20/2/2020,22/2/2022,Draft,user2@example.com,user3@example.com,http://url.example.zzz,reference.example.zzz,"Privacy
+Integrity","Sites
+Data Centers",yes,non-key,corrective,physical,user3@example.com,user4@example.com,daily,,,,,22/2/2022,one,Control ca text,,,,,,,,,,,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Object type,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Data Asset,Code*,Title*,Description,Notes,,Owner*,Effective Date,Stop Date,State,Primary Contact,Secondary Contact,Data Asset URL,Reference URL,,,,,,,,,,,,,Delete,,,,map:access group,map:assessment,map:audit,map:clause,map:contract,map:control,map:cycle task group object task,map:data asset,map:facility,map:issue,map:market,map:objective,map:org group,map:person,map:policy,map:process,map:product,map:program,map:project,map:regulation,map:request,map:risk,map:section,map:standard,map:system,map:threat,map:vendor
+,Data Assest code,Data Assest title,Data Assest description,Data Assest notes,,"user@example.com
+user1@example.com",20/2/2020,22/2/2022,Draft,user2@example.com,user3@example.com,http://url.example.zzz,reference.example.zzz,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Object type,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Facility,Code*,Title*,Description,Notes,,Owner*,Effective Date,Stop Date,State,Primary Contact,Secondary Contact,Facility URL,Reference URL,,,,,,,,,,,,,Delete,CA date,CA dropdown,CA text,map:access group,map:assessment,map:audit,map:clause,map:contract,map:control,map:cycle task group object task,map:data asset,map:facility,map:issue,map:market,map:objective,map:org group,map:person,map:policy,map:process,map:product,map:program,map:project,map:regulation,map:request,map:risk,map:section,map:standard,map:system,map:threat,map:vendor
+,Facility code,Facility title,Facility description,Facility notes,,"user@example.com
+user1@example.com",20/2/2020,22/2/2022,Draft,user2@example.com,user3@example.com,http://url.example.zzz,reference.example.zzz,,,,,,,,,,,,,,22/2/2022,TWO,Facility ca text,,,,,,,,,,,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Object type,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Market,Code*,Title*,Description,Notes,,Owner*,Effective Date,Stop Date,State,Primary Contact,Secondary Contact,Market URL,Reference URL,,,,,,,,,,,,,Delete,CA date,CA dropdown,CA text,map:access group,map:assessment,map:audit,map:clause,map:contract,map:control,map:cycle task group object task,map:data asset,map:facility,map:issue,map:market,map:objective,map:org group,map:person,map:policy,map:process,map:product,map:program,map:project,map:regulation,map:request,map:risk,map:section,map:standard,map:system,map:threat,map:vendor
+,Market code,Market title,Market description,Market notes,,"user@example.com
+user1@example.com",20/2/2020,22/2/2022,Draft,user2@example.com,user3@example.com,http://url.example.zzz,reference.example.zzz,,,,,,,,,,,,,,22/2/2022,three,Market ca text,,,,,,,,,,,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Object type,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Objective,Code*,Title*,Description,Notes,,Owner*,,,State,Primary Contact,Secondary Contact,Objective URL,Reference URL,,,,,,,,,,,,,Delete,,,,map:access group,map:assessment,map:audit,map:clause,map:contract,map:control,map:cycle task group object task,map:data asset,map:facility,map:issue,map:market,map:objective,map:org group,map:person,map:policy,map:process,map:product,map:program,map:project,map:regulation,map:request,map:risk,map:section,map:standard,map:system,map:threat,map:vendor
+,Objective code,Objective title,Objective description,Objective notes,,"user@example.com
+user1@example.com",,,Draft,user2@example.com,user3@example.com,http://url.example.zzz,reference.example.zzz,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Object type,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Org Group,Code*,Title*,Description,Notes,,Owner*,Effective Date,Stop Date,State,Primary Contact,Secondary Contact,Org Group URL,Reference URL,,,,,,,,,,,,,Delete,,,,map:access group,map:assessment,map:audit,map:clause,map:contract,map:control,map:cycle task group object task,map:data asset,map:facility,map:issue,map:market,map:objective,map:org group,map:person,map:policy,map:process,map:product,map:program,map:project,map:regulation,map:request,map:risk,map:section,map:standard,map:system,map:threat,map:vendor
+,Org Group code,Org Group title,Org Group description,Org Group notes,,"user@example.com
+user1@example.com",20/2/2020,22/2/2022,Draft,user2@example.com,user3@example.com,http://url.example.zzz,reference.example.zzz,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Object type,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Policy,Code*,Title*,Description,Notes,,Owner*,Effective Date,Stop Date,State,Primary Contact,Secondary Contact,Policy URL,Reference URL,,,,,,,,,,,,Kind/Type,Delete,,,,map:access group,map:assessment,map:audit,map:clause,,map:control,map:cycle task group object task,map:data asset,map:facility,map:issue,map:market,map:objective,map:org group,map:person,,map:process,map:product,map:program,map:project,,map:request,map:risk,map:section,,map:system,map:threat,map:vendor
+,Policy code,Policy title,Policy description,Policy notes,,"user@example.com
+user1@example.com",20/2/2020,22/2/2022,Draft,user2@example.com,user3@example.com,http://url.example.zzz,reference.example.zzz,,,,,,,,,,,,company policy,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Object type,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Process,Code*,Title*,Description,Notes,,Owner*,Effective Date,Stop Date,State,Primary Contact,Secondary Contact,Process URL,Reference URL,,,,,,,,,,,Network Zone,,Delete,,,,map:access group,map:assessment,map:audit,map:clause,map:contract,map:control,map:cycle task group object task,map:data asset,map:facility,map:issue,map:market,map:objective,map:org group,map:person,map:policy,map:process,map:product,map:program,map:project,map:regulation,map:request,map:risk,map:section,map:standard,map:system,map:threat,map:vendor
+,Process code,Process title,Process description,Process notes,,"user@example.com
+user1@example.com",20/2/2020,22/2/2022,Draft,user2@example.com,user3@example.com,http://url.example.zzz,reference.example.zzz,,,,,,,,,,,prod,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Object type,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Product,Code*,Title*,Description,Notes,,Owner*,Effective Date,Stop Date,State,Primary Contact,Secondary Contact,Product URL,Reference URL,,,,,,,,,,,,Kind/Type,Delete,,,,map:access group,map:assessment,map:audit,map:clause,map:contract,map:control,map:cycle task group object task,map:data asset,map:facility,map:issue,map:market,map:objective,map:org group,map:person,map:policy,map:process,map:product,map:program,map:project,map:regulation,map:request,map:risk,map:section,map:standard,map:system,map:threat,map:vendor
+,Product code,Product title,Product description,Product notes,,"user@example.com
+user1@example.com",20/2/2020,22/2/2022,Draft,user2@example.com,user3@example.com,http://url.example.zzz,reference.example.zzz,,,,,,,,,,,,saas,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Object type,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Regulation,Code*,Title*,Description,Notes,,Owner*,Effective Date,Stop Date,State,Primary Contact,Secondary Contact,Regulation URL,Reference URL,,,,,,,,,,,,,Delete,,,,map:access group,map:assessment,map:audit,map:clause,,map:control,map:cycle task group object task,map:data asset,map:facility,map:issue,map:market,map:objective,map:org group,map:person,,map:process,map:product,map:program,map:project,,map:request,map:risk,map:section,,map:system,map:threat,map:vendor
+,Regulation code,Regulation title,Regulation description,Regulation notes,,"user@example.com
+user1@example.com",20/2/2020,22/2/2022,Draft,user2@example.com,user3@example.com,http://url.example.zzz,reference.example.zzz,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Object type,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Risk,Code*,Title*,Description*,Notes,,Owner*,Effective Date,Stop Date,State,Contact,,Url,Reference URL,,,,,,,,,,,,,Delete,,,,map:access group,map:assessment,,map:clause,map:contract,map:control,map:cycle task group object task,map:data asset,map:facility,map:issue,map:market,map:objective,map:org group,map:person,map:policy,map:process,map:product,map:program,map:project,map:regulation,map:request,,map:section,map:standard,map:system,map:threat,map:vendor
+,Risk code,Risk title,Risk description,Risk notes,,"user@example.com
+user1@example.com",20/2/2020,22/2/2022,Draft,user2@example.com,,http://url.example.zzz,reference.example.zzz,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Object type,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Section,Code*,Title*,Text of Section,Notes,,Owner*,,,State,Primary Contact,Secondary Contact,Section URL,Reference URL,,,,,,,,,,Policy / Regulation / Standard / Contract,,,Delete,CA date,CA dropdown,CA text,map:access group,map:assessment,map:audit,map:clause,map:contract,map:control,map:cycle task group object task,map:data asset,map:facility,map:issue,map:market,map:objective,map:org group,map:person,map:policy,map:process,map:product,map:program,map:project,map:regulation,map:request,map:risk,map:section,map:standard,map:system,map:threat,map:vendor
+,Section code,Section title,Section description,Section notes,,"user@example.com
+user1@example.com",,,Draft,user2@example.com,user3@example.com,http://url.example.zzz,reference.example.zzz,,,,,,,,,,policy code,,,,22/2/2022,four,Section ca text,,,,,,,,,,,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Object type,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Standard,Code*,Title*,Description,Notes,,Owner*,Effective Date,Stop Date,State,Primary Contact,Secondary Contact,Standard URL,Reference URL,,,,,,,,,,,,,Delete,,,,map:access group,map:assessment,map:audit,map:clause,,map:control,map:cycle task group object task,map:data asset,map:facility,map:issue,map:market,map:objective,map:org group,map:person,,map:process,map:product,map:program,map:project,,map:request,map:risk,map:section,,map:system,map:threat,map:vendor
+,Standard code,Standard title,Standard description,Standard notes,,"user@example.com
+user1@example.com",20/2/2020,22/2/2022,Draft,user2@example.com,user3@example.com,http://url.example.zzz,reference.example.zzz,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Object type,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+System,Code*,Title*,Description,Notes,,Owner*,Effective Date,Stop Date,State,Primary Contact,Secondary Contact,System URL,Reference URL,,,,,,,,,,,Network Zone,,Delete,,,,map:access group,map:assessment,map:audit,map:clause,map:contract,map:control,map:cycle task group object task,map:data asset,map:facility,map:issue,map:market,map:objective,map:org group,map:person,map:policy,map:process,map:product,map:program,map:project,map:regulation,map:request,map:risk,map:section,map:standard,map:system,map:threat,map:vendor
+,System code,System title,System description,System notes,,"user@example.com
+user1@example.com",20/2/2020,22/2/2022,Draft,user2@example.com,user3@example.com,http://url.example.zzz,reference.example.zzz,,,,,,,,,,,core,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Object type,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Threat,Code*,Title*,Description,Notes,,Owner*,Effective Date,Stop Date,State,Contact,,Threat URL,Reference URL,,,,,,,,,,,,,Delete,,,,map:access group,map:assessment,,map:clause,map:contract,map:control,map:cycle task group object task,map:data asset,map:facility,map:issue,map:market,map:objective,map:org group,map:person,map:policy,map:process,map:product,map:program,map:project,map:regulation,map:request,map:risk,map:section,map:standard,map:system,map:vendor,
+,Threat code,Threat title,Threat description,Threat notes,,"user@example.com
+user1@example.com",20/2/2020,22/2/2022,Draft,user2@example.com,,http://url.example.zzz,reference.example.zzz,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Object type,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Vendor,Code*,Title*,Description,Notes,,Owner*,Effective Date,Stop Date,State,Primary Contact,Secondary Contact,Vendor URL,Reference URL,,,,,,,,,,,,,Delete,,,,map:access group,map:assessment,map:audit,map:clause,map:contract,map:control,map:cycle task group object task,map:data asset,map:facility,map:issue,map:market,map:objective,map:org group,map:person,map:policy,map:process,map:product,map:program,map:project,map:regulation,map:request,map:risk,map:section,map:standard,map:system,map:threat,map:vendor
+,Vendor code,Vendor title,Vendor description,Vendor notes,,"user@example.com
+user1@example.com",20/2/2020,22/2/2022,Draft,user2@example.com,user3@example.com,http://url.example.zzz,reference.example.zzz,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Object type,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Person,name,email,company,role,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+,user 1,user1@example.com,google,Admin,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+,user 2,user2@example.com,google,gGRC Admin,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+,user 3,user3@example.com,google,creator,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+,user 4,user4@example.com,google,reader,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,

--- a/test/integration/ggrc/models/test_snapshot.py
+++ b/test/integration/ggrc/models/test_snapshot.py
@@ -1,0 +1,54 @@
+# Copyright (C) 2016 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Tests for snapshot model."""
+
+from ggrc import db
+from ggrc.app import app
+from ggrc.services import common
+from ggrc.models import all_models
+from integration.ggrc.converters import TestCase
+from integration.ggrc.models import factories
+
+
+class TestSnapshot(TestCase):
+  """Basic tests for /query api."""
+
+  def setUp(self):
+    """Set up test cases for all tests."""
+    TestCase.clear_data()
+    self._create_cas()
+    self._import_file("all_snapshottable_objects.csv")
+
+  @staticmethod
+  def _create_cas():
+    """Create custom attribute definitions."""
+    for type_ in ["facility", "control", "market", "section"]:
+      with app.app_context():
+        factories.CustomAttributeDefinitionFactory(
+            title="CA dropdown",
+            definition_type=type_,
+            attribute_type="Dropdown",
+            multi_choice_options="one,two,three,four,five",
+        )
+        factories.CustomAttributeDefinitionFactory(
+            title="CA text",
+            definition_type=type_,
+            attribute_type="Text",
+        )
+        factories.CustomAttributeDefinitionFactory(
+            title="CA date",
+            definition_type=type_,
+            attribute_type="Date",
+        )
+
+  def test_revision_conent(self):
+    """Test that revision contains all content needed."""
+
+    facility_revision = all_models.Revision.query.filter(
+        all_models.Revision.resource_type == "Facility").order_by(
+        all_models.Revision.id.desc()).first()
+
+    self.assertIn("custom_attributes", facility_revision.content)
+    self.assertNotEqual(facility_revision.content["custom_attributes"], [])
+

--- a/test/integration/ggrc/models/test_snapshot.py
+++ b/test/integration/ggrc/models/test_snapshot.py
@@ -3,9 +3,7 @@
 
 """Tests for snapshot model."""
 
-from ggrc import db
 from ggrc.app import app
-from ggrc.services import common
 from ggrc.models import all_models
 from integration.ggrc.converters import TestCase
 from integration.ggrc.models import factories
@@ -51,4 +49,3 @@ class TestSnapshot(TestCase):
 
     self.assertIn("custom_attributes", facility_revision.content)
     self.assertNotEqual(facility_revision.content["custom_attributes"], [])
-


### PR DESCRIPTION
This is prep work for snapshot content fixes. Because we're using imports for set up stage for tests, we must make sure that they set all the revision content properly.

Adding please review, because this is needed for the tuesdays pilot release.

To test this: 
- import an new object that has custom attributes. 
- check that the custom attribute values are stored in the content of the revisions table (you have to check manually)