### PR TITLE
GGRC-393 Fix task comments' context menu positionig

### DIFF
--- a/src/ggrc/assets/stylesheets/modules/_comments.scss
+++ b/src/ggrc/assets/stylesheets/modules/_comments.scss
@@ -119,7 +119,6 @@
             color: $gray;
             i {
               @include opacity(0.4);
-              @include transition(opacity 0.2s ease);
               margin: 7px 4px 0 0;
             }
             &:hover {

--- a/src/ggrc/assets/stylesheets/modules/_tree-content.scss
+++ b/src/ggrc/assets/stylesheets/modules/_tree-content.scss
@@ -417,6 +417,10 @@ ul.new-tree {
     margin-bottom: 0;
     max-height: 240px;
     overflow-y: auto;
+    .task-comments & {
+      max-height: none;
+      overflow-y: visible;
+    }
     & .tier-2-info {
       padding: 14px 10px 0 10px;
       .tier-2-info-content {

--- a/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/info.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/info.mustache
@@ -199,7 +199,8 @@
                 parent-instance="instance"
                 mapping="instance.class.info_pane_options.comments.mapping"
                 item-template="instance.class.info_pane_options.comments.show_view"
-                tree-view-class="tree-structure new-tree mapped-objects-tree">
+                tree-view-class="tree-structure new-tree mapped-objects-tree entry-list"
+                class="task-comments">
               </mapping-tree-view>
             {{/count}}
             {{^count}}


### PR DESCRIPTION
This PR fixes a displaced "comment actions" menu for Cycle Task comments. This was caused by a missing CSS class that prevented for some necessary styles to be applied.

One thing that I noticed is that if a context menu is opened for the last comment (need to have at least 3 of them, I think), a vertical scroll bar appears because the context menu expands the comment list `<div>`, and the latter's height is restricted to 240 px (the context menu is a part of that div).

One way around it would be to lift the height restriction and set the `overflow-y` property to `auto`, but that causes other issues, namely the height of the info pane's contents to explode if there are too many comments and/or objects mapped to the Task.

The latter seemed like a worse option, thus I did not opt for it, and significantly refactoring entries lists / tree views and their styles was IMO way out of scope of this ticket.

(suggestions of course welcome, if this scroll bar is not desired and if there exists a sensible fix, otherwise a UX person will probably need to have a look at that)

---

**Precondition:**
Have an active Workflow with at least one Task.

**Steps to reproduce:**
- Navigate to Task’s Info pane at Active Cycles tab
- Add at least 2 comments
- Click on gear icon to edit or delete the (first?) comment: Edit/Delete buttons appear randomly

**Expected Result:**
Edit/Delete menu should appear opposite or under the gear icon.

**Actual Result:**
Edit/Delete menu appearx randomly while clicking on gear icon in Task's Info pane.


