### PR TITLE
QUICK-FIX Update factory methods and docstrings

### DIFF
--- a/test/selenium/src/lib/entities/entities_factory.py
+++ b/test/selenium/src/lib/entities/entities_factory.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2016 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
-"""Module for business entities."""
+"""Module for factories that create business entities."""
 # pylint: disable=too-few-public-methods
 # pylint: disable=too-many-arguments
 # pylint: disable=no-self-use
@@ -21,9 +21,10 @@ class CAFactory(object):
   def create(cls, title=None, ca_type=None, definition_type=None,
              helptext="", placeholder=None, multi_choice_options=None,
              is_mandatory=False, ca_global=True):
-    """"
-    Method for basic CustomAttribute object creation.
-    None type or definition will be filled randomly.
+    """Create CustomAttribute object.
+
+    Random values will be used for title, ca_type, definition_type and
+    multi_choice_options if they are None.
     """
     ca_entity = cls._create_random_ca()
     ca_entity = cls._fill_ca_entity_fields(
@@ -38,7 +39,7 @@ class CAFactory(object):
 
   @classmethod
   def _create_random_ca(cls):
-    """Create random CustomAttribute entity."""
+    """Create CustomAttribute entity with randomly filled fields."""
     random_ca = entity.CustomAttribute()
     random_ca.ca_type = random.choice(AttributesTypes.ALL_TYPES)
     random_ca.title = cls._generate_title(random_ca.ca_type)
@@ -89,10 +90,11 @@ class CAFactory(object):
 
   @classmethod
   def _normalize_ca_definition_type(cls, ca_object):
-    """
-    Get ca_group title from the selected object for further using in UI.
-    For manipulations with object via REST, definition type should be
-    interpreted as objects.get_singular().get_object_name_form().
+    """Transform definition type to title form.
+
+    Title from used for UI operations.
+    For REST operations definition type should be interpreted as
+    objects.get_singular().get_object_name_form().
     """
     ca_object.definition_type = objects.get_normal_form(
         ca_object.definition_type

--- a/test/selenium/src/lib/entities/entities_factory.py
+++ b/test/selenium/src/lib/entities/entities_factory.py
@@ -17,48 +17,48 @@ from lib.utils.test_utils import append_random_string
 class CAFactory(object):
   """Factory class for Custom Attribute entity."""
 
-  @staticmethod
-  def create(title=None, ca_type=None, definition_type=None,
+  @classmethod
+  def create(cls, title=None, ca_type=None, definition_type=None,
              helptext="", placeholder=None, multi_choice_options=None,
              is_mandatory=False, ca_global=True):
     """"
     Method for basic CustomAttribute object creation.
     None type or definition will be filled randomly.
     """
-    ca_entity = CAFactory._create_random_ca()
-    ca_entity = CAFactory._fill_ca_entity_fields(
+    ca_entity = cls._create_random_ca()
+    ca_entity = cls._fill_ca_entity_fields(
         ca_entity, title=title, ca_type=ca_type,
         definition_type=definition_type,
         helptext=helptext, placeholder=placeholder,
         multi_choice_options=multi_choice_options, is_mandatory=is_mandatory,
         ca_global=ca_global
     )
-    ca_entity = CAFactory._normalize_ca_definition_type(ca_entity)
+    ca_entity = cls._normalize_ca_definition_type(ca_entity)
     return ca_entity
 
-  @staticmethod
-  def _create_random_ca():
+  @classmethod
+  def _create_random_ca(cls):
     """Create random CustomAttribute entity."""
     random_ca = entity.CustomAttribute()
     random_ca.ca_type = random.choice(AttributesTypes.ALL_TYPES)
-    random_ca.title = CAFactory._generate_title(random_ca.ca_type)
+    random_ca.title = cls._generate_title(random_ca.ca_type)
     random_ca.definition_type = random.choice(objects.all_objects)
     return random_ca
 
-  @staticmethod
-  def _generate_title(ca_type):
+  @classmethod
+  def _generate_title(cls, ca_type):
     """Generate title according to CustomAttribute type."""
     special_chars = string_utils.SPECIAL
     return append_random_string(
         "{}_{}_".format(ca_type, random_string(
             size=len(special_chars), chars=special_chars)))
 
-  @staticmethod
-  def _fill_ca_entity_fields(ca_object, **ca_object_fields):
+  @classmethod
+  def _fill_ca_entity_fields(cls, ca_object, **ca_object_fields):
     """Set the CustomAttributes object's attributes."""
     if ca_object_fields.get("ca_type"):
       ca_object.ca_type = ca_object_fields["ca_type"]
-      ca_object.title = CAFactory._generate_title(ca_object.ca_type)
+      ca_object.title = cls._generate_title(ca_object.ca_type)
     if ca_object_fields.get("definition_type"):
       ca_object.definition_type = ca_object_fields["definition_type"]
     if ca_object_fields.get("title"):
@@ -87,8 +87,8 @@ class CAFactory(object):
         ca_object.multi_choice_options = random_list_of_strings(list_len=3)
     return ca_object
 
-  @staticmethod
-  def _normalize_ca_definition_type(ca_object):
+  @classmethod
+  def _normalize_ca_definition_type(cls, ca_object):
     """
     Get ca_group title from the selected object for further using in UI.
     For manipulations with object via REST, definition type should be


### PR DESCRIPTION
This PR resolve last comment from @zidarsk8 in [this PR](https://github.com/google/ggrc-core/pull/4690) about improving scalability/extendibility of Custom Attribute factory by replacing `@staticmethod` to `@classmethod`.