### PR TITLE
QUICK-FIX Fix close tab regression

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
@@ -555,7 +555,8 @@
     }, 100),
     '.closed click': function (el, ev) {
       var $link = el.closest('a');
-      var widget = this.widget_by_selector($link.attr('href'));
+      var widget = this.widget_by_selector('#' + $link.attr('href')
+                                                      .split('#')[1]);
       var widgets = this.options.widget_list;
 
       widget.attr('force_show', false);


### PR DESCRIPTION
This PR fixes the regression with being unable to close HNB tabs.

Steps to reproduce:
1. Go to dashboard.
2. Click "Add tab", add a tab.
3. Click the close button to delete the added tab.

Expected result: the tab is closed.
Actual result: a JS error is raised, the tab is not closed.