### PR TITLE
GGRC-443, GGRC-467 Fix close button in visible fields dialog

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
@@ -1989,8 +1989,9 @@ can.Control('CMS.Controllers.TreeViewNode', {
     template: '<content/>',
     scope: {},
     events: {
-      init: function () {
+      init: function (element, options) {
         this.scope.attr('controller', this);
+        this.scope.attr('$rootEl', $(element));
       },
 
       'input.model-checkbox click': function (el, ev) {
@@ -2039,7 +2040,7 @@ can.Control('CMS.Controllers.TreeViewNode', {
       },
 
       '.set-display-object-list,.close-dropdown click': function (el, ev) {
-        this.element.find('.dropdown-menu').closest('li').removeClass('open');
+        this.scope.$rootEl.removeClass('open');
       }
     }
   });

--- a/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
@@ -1937,8 +1937,9 @@ can.Control('CMS.Controllers.TreeViewNode', {
     template: '<content/>',
     scope: {},
     events: {
-      init: function () {
+      init: function (element, options) {
         this.scope.attr('controller', this);
+        this.scope.attr('$rootEl', $(element));
       },
 
       disable_attrs: function (el, ev) {
@@ -1974,7 +1975,7 @@ can.Control('CMS.Controllers.TreeViewNode', {
       },
 
       '.set-tree-attrs,.close-dropdown click': function (el, ev) {
-        this.element.find('.dropdown-menu').closest('li').removeClass('open');
+        this.scope.$rootEl.removeClass('open');
       }
     }
   });


### PR DESCRIPTION
This PR fixes the button for closing the "visible fields" dialog used with tree views.

It turned out that the fix also fixes the issue GGRC-467.

(tests skipped, b/c an end-to-end Selenium test would make the most sense, and that is being worked on as a part of a different issue)

---

**Steps to reproduce (GGRC-443):**
  1. Go to Assessment tab (or any tab where Set Visible fields/Select child tree dialogs exist)
  2. Click on Set Visible fields icon/Select child tree icon
  3. Click on [x] to close the dialog

**Actual result:**
close [x] button is disabled on Set Visible fields/Select child tree dialogs

**Expected result:**
close [x] button should close the Set Visible fields/Select child tree dialogs

---

**Steps to reproduce (GGRC-467):**
  1. Go to My Work Page
  2. Select any tab from HNB (e.g. "Audits")
  3. Click gear icon in tree view tool bar
  4. Select checkbox to set visible field
  5. Click on Set fields button: confirm Set visible fields dialog isn't closed

**Actual Result:**
[Set fields] button doesn't close Set visible fields dialog

**Expected Result:**
[Set fields] button should close Set visible fields dialog