### PR TITLE
GGRC-469 Unmark Assignee field as optional in Task modal

### DIFF
--- a/src/ggrc_workflows/assets/mustache/task_group_tasks/modal_content.mustache
+++ b/src/ggrc_workflows/assets/mustache/task_group_tasks/modal_content.mustache
@@ -15,7 +15,7 @@
       </label>
       <input class="input-block-level required" id="task-title" placeholder="Enter Title" name="title" type="text" value="{{instance.title}}" tabindex="1" autofocus>
     </div>
-    <div class="span4 hidable">
+    <div class="span4">
       {{#using contact=instance.contact model_singular=model.model_singular}}
       <label>
         Assignee


### PR DESCRIPTION
This PR fixes the issue of a required field becoming hidden in the create Task modal when clicking the _"Hide all optional fields"_ button.

**Steps to reproduce:**
  1. Create one time WF
  2. Navigate to Task's Group Info pane on Setup tab
  3. Click + to create task
  4. Click [Hide all optional fields] button: confirm that mandatory "Assignee" field is hidden

**Actual Result:**
Mandatory "Assignee" field hides while clicking [Hide all optional fields] button in Create New Task modal

**Expected Result:**
Mandatory "Assignee" field is not hidden while clicking [Hide all optional fields] button in Create New Task modal