### PR TITLE
GGRC-402 Fix blinking header of info-pin

### DIFF
--- a/src/ggrc/assets/stylesheets/modules/_inline-edit.scss
+++ b/src/ggrc/assets/stylesheets/modules/_inline-edit.scss
@@ -66,7 +66,6 @@
     }
     a {
       @include opacity(0.6);
-      @include transition(opacity 0.2s ease);
       &:hover {
         @include opacity(1);
       }


### PR DESCRIPTION
**Steps to reproduce:** 
Navigate to Assessment’s Info pane
Navigate to any CA field to edit: confirm Assessment's title blinks

_Actual Result_: Assessment's title blinks if navigate to CA field in Assessment Info pane
_Expected Result_: Assessment's title should not blink if navigate to CA field in Assessment Info pane
_Workaround_: na