### PR TITLE
GGRC-473 Move tree header action icons to dropdown menu

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
@@ -1319,7 +1319,7 @@ CMS.Controllers.TreeLoader('CMS.Controllers.TreeView', {
 
   hide_filter: function () {
     var $filter = this.element.parent().find('.tree-filter');
-    var height = $filter.height();
+    var height = $filter.outerHeight(true);
     var margin = $filter.css('margin-bottom').replace('px', '');
 
     $filter
@@ -1333,8 +1333,8 @@ CMS.Controllers.TreeLoader('CMS.Controllers.TreeView', {
 
     this.element.parent().find('.filter-trigger > a')
         .removeClass('active')
-        .find('i')
-        .attr('data-original-title', 'Show filter');
+        .find('span')
+        .text('Show filter');
 
     this.element.parent().find('.sticky.tree-header').addClass('no-filter');
     Stickyfill.rebuild();
@@ -1355,8 +1355,8 @@ CMS.Controllers.TreeLoader('CMS.Controllers.TreeView', {
 
     this.element.parent().find('.filter-trigger > a')
         .addClass('active')
-        .find('i')
-        .attr('data-original-title', 'Hide filter');
+        .find('span')
+        .text('Hide filter');
 
     this.element.parent().find('.sticky.tree-header').removeClass('no-filter');
     Stickyfill.rebuild();
@@ -1976,6 +1976,8 @@ can.Control('CMS.Controllers.TreeViewNode', {
 
       '.set-tree-attrs,.close-dropdown click': function (el, ev) {
         this.scope.$rootEl.removeClass('open');
+        this.scope.$rootEl.parents('.dropdown-menu')
+          .parent().removeClass('open');
       }
     }
   });
@@ -2041,6 +2043,8 @@ can.Control('CMS.Controllers.TreeViewNode', {
 
       '.set-display-object-list,.close-dropdown click': function (el, ev) {
         this.scope.$rootEl.removeClass('open');
+        this.scope.$rootEl.parents('.dropdown-menu')
+          .parent().removeClass('open');
       }
     }
   });

--- a/src/ggrc/assets/javascripts/dashboard.js
+++ b/src/ggrc/assets/javascripts/dashboard.js
@@ -93,6 +93,20 @@ jQuery(function ($) {
       $(target).tmpl_mergeitems([data]);
     }
   });
+
+  $('body').on('click', '[data-toggle="nested-dropdown"]', function (e) {
+    var $parent = $(this).parent();
+    var isActive = $parent.hasClass('open');
+    if (!isActive) {
+      $parent.toggleClass('open');
+    }
+    e.stopPropagation();
+    e.preventDefault();
+  });
+
+  $('html').on('click.dropdown.data-api', function (e) {
+    $('[data-toggle="nested-dropdown"]').parent().removeClass('open');
+  });
 });
 
 // This is only used by import to redirect on successful import

--- a/src/ggrc/assets/mustache/assessments/tree_header.mustache
+++ b/src/ggrc/assets/mustache/assessments/tree_header.mustache
@@ -19,19 +19,29 @@
       {{> '/static/mustache/base_objects/tree_column_names.mustache'}}
 
       <div class="span{{display_options.action_width}}">
-          <ul class="tree-action-list">
-
-          {{> '/static/mustache/import_export/import_export_buttons.mustache'}}
-          <assessment-generator-button
-            audit="parent_instance"></assessment-generator-button>
-          {{> '/static/mustache/base_objects/filter_trigger.mustache'}}
-          {{> '/static/mustache/base_objects/tree_column_selector.mustache'}}
-          {{> '/static/mustache/base_objects/sub_tree_type_selector.mustache'}}
+        <ul class="tree-action-list">
           {{#if add_item_view}}
-           <li>
-               {{{renderLive add_item_view}}}
-           </li>
-         {{/if}}
+          <li>
+            {{{renderLive add_item_view}}}
+          </li>
+          {{/if}}
+          <li>
+            <div class="details-wrap">
+              <a class="btn btn-draft dropdown-toggle" href="#" data-toggle="dropdown">
+                <span class="bubble"></span>
+                <span class="bubble"></span>
+                <span class="bubble"></span>
+              </a>
+              <ul class="dropdown-menu tree-action-list-items" role="menu">
+                {{> '/static/mustache/import_export/import_export_buttons.mustache'}}
+                <assessment-generator-button
+                  audit="parent_instance"></assessment-generator-button>
+                {{> '/static/mustache/base_objects/filter_trigger.mustache'}}
+                {{> '/static/mustache/base_objects/tree_column_selector.mustache'}}
+                {{> '/static/mustache/base_objects/sub_tree_type_selector.mustache'}}
+              </ul>
+            </div>
+          </li>
         </ul>
       </div>
     </div>

--- a/src/ggrc/assets/mustache/audits/tree_header.mustache
+++ b/src/ggrc/assets/mustache/audits/tree_header.mustache
@@ -20,14 +20,25 @@
 
     <div class="span{{display_options.action_width}}">
       <ul class="tree-action-list">
-        {{> '/static/mustache/base_objects/filter_trigger.mustache'}}
-        {{> '/static/mustache/base_objects/tree_column_selector.mustache'}}
-        {{> '/static/mustache/base_objects/sub_tree_type_selector.mustache'}}
         {{#if add_item_view}}
-          <li>
-            {{{renderLive add_item_view}}}
-          </li>
+        <li>
+          {{{renderLive add_item_view}}}
+        </li>
         {{/if}}
+        <li>
+          <div class="details-wrap">
+            <a class="btn btn-draft dropdown-toggle" href="#" data-toggle="dropdown">
+              <span class="bubble"></span>
+              <span class="bubble"></span>
+              <span class="bubble"></span>
+            </a>
+            <ul class="dropdown-menu tree-action-list-items" role="menu">
+              {{> '/static/mustache/base_objects/filter_trigger.mustache'}}
+              {{> '/static/mustache/base_objects/tree_column_selector.mustache'}}
+              {{> '/static/mustache/base_objects/sub_tree_type_selector.mustache'}}
+            </ul>
+          </div>
+        </li>
       </ul>
     </div>
   </div>

--- a/src/ggrc/assets/mustache/base_objects/filter_trigger.mustache
+++ b/src/ggrc/assets/mustache/base_objects/filter_trigger.mustache
@@ -7,15 +7,15 @@
 <li class="filter-trigger">
 {{^filter_is_hidden}}
   <a href="javascript://" class="active">
-     <i class="fa fa-search" rel="tooltip" data-placement="left" title=""
-        data-original-title="Hide Filter"></i>
+    <i class="fa fa-fw fa-search"></i>
+    <span>Hide Filter</span>
   </a>
 {{/filter_is_hidden}}
 
 {{#filter_is_hidden}}
   <a href="javascript://">
-     <i class="fa fa-search" rel="tooltip" data-placement="left" title=""
-        data-original-title="Show Filter"></i>
+    <i class="fa fa-fw fa-search"></i>
+    <span>Show Filter</span>
   </a>
 {{/filter_is_hidden}}
 </li>

--- a/src/ggrc/assets/mustache/base_objects/generate_assessments_button.mustache
+++ b/src/ggrc/assets/mustache/base_objects/generate_assessments_button.mustache
@@ -11,12 +11,9 @@
         <li class="generate-control-assessments">
           <a href="javascript://">
             <i
-              class="fa fa-magic"
-              rel="tooltip"
-              data-placement="left"
-              title=""
-              data-original-title="Generate Assessments"
+              class="fa fa-fw fa-magic"
              ></i>
+            Generate Assessments
           </a>
         </li>
       {{/is_allowed}}

--- a/src/ggrc/assets/mustache/base_objects/sub_tree_type_selector.mustache
+++ b/src/ggrc/assets/mustache/base_objects/sub_tree_type_selector.mustache
@@ -4,8 +4,9 @@
 }}
  <li>
 <tree-type-selector>
-    <a href="#" class="dropdown-toggle tview-type-toggle" data-toggle="dropdown">
-      <i class="fa fa-share-alt" rel="tooltip" data-placement="left" data-original-title="Select Child Tree Object Type"></i>
+    <a href="#" class="dropdown-toggle tview-type-toggle" data-toggle="nested-dropdown">
+      <i class="fa fa-fw fa-share-alt"></i>
+      Select Child Tree Object Type
     </a>
     <div class="dropdown-menu dropdown-menu2 dropdown-menu-form">
       <a class="pull-right close-dropdown"><i class="fa fa-times black"></i></a>

--- a/src/ggrc/assets/mustache/base_objects/tree_column_selector.mustache
+++ b/src/ggrc/assets/mustache/base_objects/tree_column_selector.mustache
@@ -4,8 +4,9 @@
 }}
 <li>
 <tree-header-selector>
-  <a href="#" class="dropdown-toggle tview-dropdown-toggle" data-toggle="dropdown">
-    <i class="fa fa-cog" rel="tooltip" data-placement="left" data-original-title="Set Visible Fields for {{model.title_singular}}"></i>
+  <a href="#" class="dropdown-toggle tview-dropdown-toggle" data-toggle="nested-dropdown">
+    <i class="fa fa-fw fa-cog"></i>
+    Set Visible Fields for {{model.title_singular}}
   </a>
   <div class="dropdown-menu dropdown-menu-form">
     <a class="pull-right close-dropdown"><i class="fa fa-times black"></i></a>

--- a/src/ggrc/assets/mustache/base_objects/tree_header.mustache
+++ b/src/ggrc/assets/mustache/base_objects/tree_header.mustache
@@ -18,18 +18,28 @@
     {{> '/static/mustache/base_objects/tree_column_names.mustache'}}
 
     <div class="span{{display_options.action_width}}">
-        <ul class="tree-action-list">
-
-        {{> '/static/mustache/import_export/import_export_buttons.mustache'}}
-        <assessment-generator-button audit="parent_instance"></assessment-generator-button>
-        {{> '/static/mustache/base_objects/filter_trigger.mustache'}}
-        {{> '/static/mustache/base_objects/tree_column_selector.mustache'}}
-        {{> '/static/mustache/base_objects/sub_tree_type_selector.mustache'}}
+      <ul class="tree-action-list">
         {{#if add_item_view}}
-          <li>
-            {{{renderLive add_item_view}}}
-          </li>
+        <li>
+          {{{renderLive add_item_view}}}
+        </li>
         {{/if}}
+        <li>
+          <div class="details-wrap">
+            <a class="btn btn-draft dropdown-toggle" href="#" data-toggle="dropdown">
+              <span class="bubble"></span>
+              <span class="bubble"></span>
+              <span class="bubble"></span>
+            </a>
+            <ul class="dropdown-menu tree-action-list-items" role="menu">
+              {{> '/static/mustache/import_export/import_export_buttons.mustache'}}
+              <assessment-generator-button audit="parent_instance"></assessment-generator-button>
+              {{> '/static/mustache/base_objects/filter_trigger.mustache'}}
+              {{> '/static/mustache/base_objects/tree_column_selector.mustache'}}
+              {{> '/static/mustache/base_objects/sub_tree_type_selector.mustache'}}
+            </ul>
+          </div>
+        </li>
       </ul>
     </div>
   </div>

--- a/src/ggrc/assets/mustache/import_export/import_export_buttons.mustache
+++ b/src/ggrc/assets/mustache/import_export/import_export_buttons.mustache
@@ -6,17 +6,17 @@
 {{^if_instance_of parent_instance 'Assessment'}}
 <li>
   <a href="/import"
-    class="section-import" rel="tooltip" data-placement="left"
-    title="" data-original-title="Import {{model.model_plural}}">
-    <i class="fa fa-cloud-upload"></i>
+    class="section-import">
+    <i class="fa fa-fw fa-cloud-upload"></i>
+    Import {{model.model_plural}}
   </a>
 </li>
 {{#if list.length}}
   <li>
     <a href="/export?model_type={{model.model_singular}}&relevant_type={{parent_instance.type}}&relevant_id={{parent_instance.id}}"
-      class="section-import" rel="tooltip" data-placement="left"
-      title="" data-original-title="Export {{model.model_plural}}">
-      <i class="fa fa-download"></i>
+      class="section-import">
+      <i class="fa fa-fw fa-download"></i>
+      Export {{model.model_plural}}
     </a>
   </li>
 {{/if}}

--- a/src/ggrc/assets/mustache/people/tree_header.mustache
+++ b/src/ggrc/assets/mustache/people/tree_header.mustache
@@ -30,12 +30,23 @@
     </div>
     <div class="span4">
       <ul class="tree-action-list">
-        {{> '/static/mustache/base_objects/filter_trigger.mustache'}}
         {{#if add_item_view}}
-          <li>
-            {{{renderLive add_item_view}}}
-          </li>
+        <li>
+          {{{renderLive add_item_view}}}
+        </li>
         {{/if}}
+        <li>
+          <div class="details-wrap">
+            <a class="btn btn-draft dropdown-toggle" href="#" data-toggle="dropdown">
+              <span class="bubble"></span>
+              <span class="bubble"></span>
+              <span class="bubble"></span>
+            </a>
+            <ul class="dropdown-menu tree-action-list-items" role="menu">
+              {{> '/static/mustache/base_objects/filter_trigger.mustache'}}
+            </ul>
+          </div>
+        </li>
       </ul>
     </div>
   </div>

--- a/src/ggrc/assets/stylesheets/modules/_tree-header.scss
+++ b/src/ggrc/assets/stylesheets/modules/_tree-header.scss
@@ -85,23 +85,23 @@
           }
         }
 
-          .map-button {
-            line-height: 22px;
-            background: $blue;
+        .map-button {
+          line-height: 22px;
+          background: $blue;
+          color: $white;
+          padding: 0 16px;
+          border: 1px solid transparent;
+
+          &:hover {
+            background: $link;
             color: $white;
-            padding: 0 16px;
-            border: 1px solid transparent;
+            text-decoration: none;
 
-            &:hover {
-              background: $link;
-              color: $white;
-              text-decoration: none;
-
-              &[disabled] {
-                background: $blue;
-              }
+            &[disabled] {
+              background: $blue;
             }
           }
+        }
 
         .fa {
           color: $black;
@@ -110,14 +110,20 @@
           @include transition(opacity 0.2s ease);
           margin-top: 1px;
         }
+
+        .details-wrap {
+          margin-left: 0;
+        }
+
         li {
           position: relative;
           overflow: visible;
           line-height: 32px;
+          vertical-align: top;
           .counter {
             @include opacity(1);
           }
-          .dropdown-menu {
+          .dropdown-menu:not(.tree-action-list-items) {
             @include border-radius(0);
             right: -12px;
             left: auto;
@@ -198,6 +204,8 @@
                 text-transform: none;
                 float: right;
                 width: 15%;
+                clear: none;
+                font-size: 11px;
                 a {
                   margin: 0;
                   text-decoration: underline;
@@ -211,6 +219,69 @@
                 }
               }
             }
+          }
+          .dropdown-menu.tree-action-list-items {
+            & > li,
+            & > * > li{
+              display: list-item;
+              margin-left: 0;
+              text-align: left;
+              position: static;
+              font-size: 13px;
+
+              .dropdown-toggle {
+                height: auto;
+              }
+
+              .dropdown-menu {
+                top: -11px;
+                right: - 14px;
+
+                .btn {
+                  display: inline-block;
+                  text-transform: none;
+                  color: #fff;
+                  font-weight: bold;
+
+                  &.btn-small {
+                    line-height: 18px;
+                    padding: 4px 14px;
+                  }
+                }
+
+                .btn-info {
+                  background: #40c4ff;
+                }
+              }
+
+              a {
+                > i {
+                  color: #999;
+                }
+                &.active > i {
+                  color: #000;
+                }
+                &.close-dropdown {
+                  padding: 0;
+                  line-height: normal;
+
+                  > i {
+                    color: #000;
+                  }
+
+                  &:hover {
+                    background: none;
+                  }
+                }
+              }
+            }
+          }
+          .action-button {
+            vertical-align: top;
+          }
+          .details-wrap > a {
+            padding-top: 8px;
+            padding-bottom: 8px;
           }
           &.filter-trigger {
             .active {

--- a/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/tree_header.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/tree_header.mustache
@@ -20,19 +20,30 @@
 
     <div class="span{{display_options.action_width}}">
       <ul class="tree-action-list">
-        <li class="filter-trigger">
-          <a href="javascript://" {{^filter_is_hidden}}class="active"{{/filter_is_hidden}}>
-            <i class="fa fa-search" rel="tooltip" data-placement="left" title="" data-original-title="Hide Filter"></i>
-          </a>
-        </li>
-        {{{> "/static/mustache/base_objects/tree_column_selector.mustache"}}}
-        {{{> "/static/mustache/base_objects/sub_tree_type_selector.mustache"}}}
-
         {{#if add_item_view}}
-          <li>
-            {{{renderLive add_item_view}}}
-          </li>
+        <li>
+          {{{renderLive add_item_view}}}
+        </li>
         {{/if}}
+        <li>
+          <div class="details-wrap">
+            <a class="btn btn-draft dropdown-toggle" href="#" data-toggle="dropdown">
+              <span class="bubble"></span>
+              <span class="bubble"></span>
+              <span class="bubble"></span>
+            </a>
+            <ul class="dropdown-menu tree-action-list-items" role="menu">
+              <li class="filter-trigger">
+                <a href="javascript://" {{^filter_is_hidden}}class="active"{{/filter_is_hidden}}>
+                  <i class="fa fa-search"></i>
+                  <span>Hide Filter</span>
+                </a>
+              </li>
+              {{{> "/static/mustache/base_objects/tree_column_selector.mustache"}}}
+              {{{> "/static/mustache/base_objects/sub_tree_type_selector.mustache"}}}
+            </ul>
+          </div>
+        </li>
       </ul>
     </div>
   </div>

--- a/src/ggrc_workflows/assets/mustache/cycles/tree_header.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycles/tree_header.mustache
@@ -25,16 +25,28 @@
     </div>
     <div class="span4">
       <ul class="tree-action-list">
-        <li class="filter-trigger">
-          <a href="javascript://" {{^filter_is_hidden}}class="active"{{/filter_is_hidden}}>
-            <i class="fa fa-search" rel="tooltip" data-placement="left" title="" data-original-title="Hide Filter"></i>
-          </a>
-        </li>
         {{#if add_item_view}}
-          <li>
-            {{{renderLive add_item_view}}}
-          </li>
+        <li>
+          {{{renderLive add_item_view}}}
+        </li>
         {{/if}}
+        <li>
+          <div class="details-wrap">
+            <a class="btn btn-draft dropdown-toggle" href="#" data-toggle="dropdown">
+              <span class="bubble"></span>
+              <span class="bubble"></span>
+              <span class="bubble"></span>
+            </a>
+            <ul class="dropdown-menu tree-action-list-items" role="menu">
+              <li class="filter-trigger">
+                <a href="javascript://" {{^filter_is_hidden}}class="active"{{/filter_is_hidden}}>
+                  <i class="fa fa-search"></i>
+                  <span>Hide Filter</span>
+                </a>
+              </li>
+            </ul>
+          </div>
+        </li>
       </ul>
     </div>
   </div>

--- a/src/ggrc_workflows/assets/mustache/task_groups/tree_header.mustache
+++ b/src/ggrc_workflows/assets/mustache/task_groups/tree_header.mustache
@@ -25,18 +25,30 @@
     </div>
     <div class="span4">
       <ul class="tree-action-list">
-        <li class="filter-trigger">
-          <a href="javascript://" {{^filter_is_hidden}}class="active"{{/filter_is_hidden}}>
-            <i class="fa fa-search" rel="tooltip" data-placement="left" title="" data-original-title="Hide Filter"></i>
-          </a>
-        </li>
         {{#if add_item_view}}
         {{^if_equals parent_instance.kind "Backlog"}}
-          <li>
-            {{{renderLive add_item_view}}}
-          </li>
+        <li>
+          {{{renderLive add_item_view}}}
+        </li>
         {{/if_equals}}
         {{/if}}
+        <li>
+          <div class="details-wrap">
+            <a class="btn btn-draft dropdown-toggle" href="#" data-toggle="dropdown">
+              <span class="bubble"></span>
+              <span class="bubble"></span>
+              <span class="bubble"></span>
+            </a>
+            <ul class="dropdown-menu tree-action-list-items" role="menu">
+              <li class="filter-trigger">
+                <a href="javascript://" {{^filter_is_hidden}}class="active"{{/filter_is_hidden}}>
+                  <i class="fa fa-search"></i>
+                  <span>Hide Filter</span>
+                </a>
+              </li>
+            </ul>
+          </div>
+        </li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
This PR moves action icons from the tree view header to the 3-dot dropdown menu.
Design screens are available at jira issue.