### PR TITLE
GGRC-458 Remove duplicate of Map button in tree view

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
@@ -416,32 +416,23 @@ CMS.Controllers.TreeLoader('CMS.Controllers.TreeView', {
 }, {
   // prototype properties
   setup: function (el, opts) {
-    var that = this;
+    var defaultOptions = {};
+    var optionsProperty;
+    var defaults = this.constructor.defaults;
     if (typeof this._super === 'function') {
       this._super(el);
     }
+    if (opts.model) {
+      optionsProperty = opts.options_property ||
+       this.constructor.defaults.options_property;
+      defaultOptions = opts.model[optionsProperty];
+    }
+    if (typeof (opts.model) === 'string') {
+      opts.model = CMS.Models[opts.model];
+    }
+    this.options = new can.Observe(defaults).attr(defaultOptions).attr(opts);
     if (opts instanceof can.Observe) {
-      this.options = opts;
-      if (typeof (this.options.model) === 'string') {
-        this.options.attr('model', CMS.Models[this.options.model]);
-      }
-      if (this.options.model) {
-        can.each(this.options.model[opts.options_property || this.constructor.defaults.options_property], function (v, k) {
-          if (!that.options.hasOwnProperty(k)) {
-            that.options.attr(k, v);
-          }
-        });
-      }
-      can.each(this.constructor.defaults, function (v, k) {
-        if (!that.options.hasOwnProperty(k)) {
-          that.options.attr(k, v);
-        }
-      });
-    } else {
-      if (typeof (opts.model) === 'string') {
-        opts.model = CMS.Models[opts.model];
-      }
-      this.options = new can.Observe(this.constructor.defaults).attr(opts.model ? opts.model[opts.options_property || this.constructor.defaults.options_property] : {}).attr(opts);
+      this.options = can.extend({}, this.options, opts);
     }
   },
   deselect: function () {

--- a/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
@@ -430,9 +430,9 @@ CMS.Controllers.TreeLoader('CMS.Controllers.TreeView', {
     if (typeof (opts.model) === 'string') {
       opts.model = CMS.Models[opts.model];
     }
-    this.options = new can.Observe(defaults).attr(defaultOptions).attr(opts);
+    this.options = new can.Map(defaults).attr(defaultOptions).attr(opts);
     if (opts instanceof can.Observe) {
-      this.options = can.extend({}, this.options, opts);
+      this.options = can.extend(this.options, opts);
     }
   },
   deselect: function () {


### PR DESCRIPTION
Steps to reproduce:
1. Log as admin
2. Go to My Work or All objects page
3. Select e.g. Access Groups tab from HNB
4. Click on gray triangle in the first tree view: confirm extra [Map] button appears

Actual Result: extra [Map] button is displayed after opening the second tree view on My Work/All objects pages
Expected Result: Extra [Map] button should not be shown after opening the second tree view on My Work/All objects pages