### PR TITLE
GGRC-515 Fix removing new CA in AT modal

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment_attributes.js
+++ b/src/ggrc/assets/javascripts/components/assessment_attributes.js
@@ -53,8 +53,13 @@
        * @param {jQuery.Event} ev - the onRemove event object
        */
       fieldRemoved: function (instance, $el, ev) {
-        var idx = _.findIndex(this.fields, {id: instance.id});
-        this.fields.splice(idx, 1);
+        var idx = _.findIndex(this.fields, {title: instance.title});
+        if (idx >= 0) {
+          this.fields.splice(idx, 1);
+        } else {
+          console.warn('The list of CAD doesn\'t contain item with "' +
+            instance.title + '" title');
+        }
       }
     },
     events: {

--- a/src/ggrc/assets/javascripts/components/tests/template_attributes_spec.js
+++ b/src/ggrc/assets/javascripts/components/tests/template_attributes_spec.js
@@ -15,19 +15,20 @@ describe('GGRC.Components.templateAttributes', function () {
   describe('fieldRemoved() method', function () {
     var method;  // the method under test
     var scope;
+    var remainingFields;
+    var $el;
+    var eventObj;
 
     beforeEach(function () {
       scope = new can.Map({
         fields: []
       });
       method = Component.prototype.scope.fieldRemoved.bind(scope);
+      $el = $('<p></p>');
+      eventObj = $.Event('on-delete');
     });
 
     it('removes the deleted field from the fields list', function () {
-      var remainingFields;
-      var $el = $('<p></p>');
-      var eventObj = $.Event('on-delete');
-
       var deletedField = new can.Map({id: 4, title: 'bar'});
 
       var currentFields = [
@@ -41,6 +42,41 @@ describe('GGRC.Components.templateAttributes', function () {
 
       remainingFields = _.map(scope.fields, 'title');
       expect(remainingFields).toEqual(['foo', 'baz']);
+    });
+
+    it('removes the field without id from the fields list', function () {
+      var deletedField = new can.Map({title: 'bar'});
+
+      var currentFields = [
+        new can.Map({id: 17, title: 'foo'}),
+        new can.Map({title: 'bar'}),
+        new can.Map({id: 52, title: 'baz'})
+      ];
+      scope.attr('fields').replace(currentFields);
+
+      method(deletedField, $el, eventObj);
+
+      remainingFields = _.map(scope.fields, 'title');
+      expect(remainingFields).toEqual(['foo', 'baz']);
+    });
+
+    it('doesn\'t change the fields list if field doesn\'t match', function () {
+      var deletedField = new can.Map({title: 'barbaz'});
+
+      var currentFields = [
+        new can.Map({id: 17, title: 'foo'}),
+        new can.Map({id: 4, title: 'bar'}),
+        new can.Map({id: 52, title: 'baz'})
+      ];
+      scope.attr('fields').replace(currentFields);
+
+      spyOn(console, 'warn');
+
+      method(deletedField, $el, eventObj);
+
+      remainingFields = _.map(scope.fields, 'title');
+      expect(remainingFields).toEqual(['foo', 'bar', 'baz']);
+      expect(console.warn).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
**Precondition:**
Create GCA with any type for assessment, created program and audit
**Steps to reproduce:**
1. Go to Assessment Template tab on Audit page
2. Add title
3. Add LCA with the title as GCA has from precondition
4. Add LCA with a title that is not exist for assessment
5. Click trash icon to delete GCA: confirm all CA disappear
_Actual Result:_ Additional LCA is deleted while deleting LCA in New Assessment Template modal
_Expected Result:_ Only selected CA for removal should be deleted while clicking on trash icon in New Assessment Template modal

**NOTE**: 
1. You can open any AT modal (create or edit)
2. Add several new CA with any names
3. Remove any of created CA

_Actual_: removed 2 CA instead of 1 selected
_Expected_:  Removed only selected CA
