### PR TITLE
Revert "Make possibility to search via Query API in unify mapper"

### DIFF
--- a/src/ggrc/assets/javascripts/components/unified_mapper/mapper_results.js
+++ b/src/ggrc/assets/javascripts/components/unified_mapper/mapper_results.js
@@ -173,9 +173,6 @@
       },
       searchFor: function (data) {
         var joinModel;
-        var params = [];
-        var param = {};
-        var relevantObjects = data.options.relevant_objects;
 
         data.options = data.options || {};
 
@@ -196,15 +193,8 @@
           [data.model_name] :
           data.model_name;
 
-        data.model_name.forEach(function (modelName) {
-          param = GGRC.Utils.QueryAPI.buildParam(modelName, {
-            filter: data.term
-          }, relevantObjects, {});
-          param.permissions = data.options.__permission_type;
-          params.push(param);
-        });
-
-        return can.Model.Cacheable.queryAll({data: params});
+        return GGRC.Models.Search.search_for_types(
+          data.term || '', data.model_name, data.options);
       },
 
       getResults: function () {
@@ -250,10 +240,7 @@
           if (!relevant.value || !relevant.filter) {
             return undefined;
           }
-          return {
-            type: relevant.filter.type,
-            id: relevant.filter.id
-          };
+          return relevant.filter.type + ':' + relevant.filter.id;
         }));
 
         if (modelName === 'AllObject') {
@@ -263,7 +250,7 @@
           params.contact_id = contact.id;
         }
         if (!_.isEmpty(filters)) {
-          params.relevant_objects = filters;
+          params.relevant_objects = filters.join(',');
         }
 
         this.scope.attr('mapper.page_loading', true);
@@ -274,7 +261,7 @@
             model_name: modelName,
             options: params
           }).then(function (mappings) {
-            return mappings;
+            return mappings.entries;
           });
         }.bind(this)).attach({});
 

--- a/src/ggrc/assets/javascripts/models/cacheable.js
+++ b/src/ggrc/assets/javascripts/models/cacheable.js
@@ -509,36 +509,6 @@
       return deferred;
     },
 
-    queryAll: function (request) {
-      var deferred = $.Deferred();
-      var self = this;
-
-      GGRC.Utils.QueryAPI.makeRequest(request)
-        .then(function (sourceData) {
-          var values = [];
-          var listDfd = $.Deferred();
-
-          sourceData = sourceData.length ? sourceData : {};
-
-          values = _.map(sourceData, function (object) {
-            return _.compact(_.pluck(object, 'values'));
-          });
-
-          values = Array.prototype.concat.apply([], values);
-          values = Array.prototype.concat.apply([], values);
-
-          self._modelize(values, listDfd);
-
-          listDfd.then(function (list) {
-            deferred.resolve(list);
-          });
-        }, function () {
-          deferred.reject.apply(deferred, arguments);
-        });
-
-      return deferred;
-    },
-
   _modelize: function (sourceData, deferred) {
     var obsList = new this.List([]);
     var index = 0;

--- a/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
+++ b/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
@@ -491,7 +491,7 @@
      * @param {String} page.sortBy - sortBy
      * @param {String} page.sortDirection - sortDirection
      * @param {String} page.filter - Filter string
-     * @param {Object|Object[]} relevant - Information about relevant object
+     * @param {Object} relevant - Information about relevant object
      * @param {Object} relevant.type - Type of relevant object
      * @param {Object} relevant.id - Id of relevant object
      * @param {Object} relevant.operation - Type of operation.
@@ -508,16 +508,10 @@
         return;
       }
 
-      if (relevant) {
-        relevant = _.isArray(relevant) ? relevant : [relevant];
-        relevant.forEach(function (item) {
-          if (item && !item.operation) {
-            item.operation = _getTreeViewOperation(objName);
-          }
-        });
-      }
-
       params.object_name = objName;
+      if (relevant && !relevant.operation) {
+        relevant.operation = _getTreeViewOperation(objName);
+      }
       params.filters = _makeFilter(page.filter, relevant, additionalFilter);
 
       if (page.current && page.pageSize) {
@@ -615,16 +609,14 @@
       var filterList = [];
 
       if (relevant) {
-        relevant.forEach(function (item) {
-          relevantFilter = GGRC.query_parser.parse('#' + item.type + ',' +
-          item.id + '#');
-          filterList.push(relevantFilter);
+        relevantFilter = GGRC.query_parser.parse('#' + relevant.type + ',' +
+                                                 relevant.id + '#');
+        filterList.push(relevantFilter);
 
-          if (item.operation &&
-            item.operation !== relevantFilter.expression.op.name) {
-            relevantFilter.expression.op.name = item.operation;
-          }
-        });
+        if (relevant.operation &&
+            relevant.operation !== relevantFilter.expression.op.name) {
+          relevantFilter.expression.op.name = relevant.operation;
+        }
       }
 
       if (filter) {


### PR DESCRIPTION
This PR is the same as https://github.com/google/ggrc-core/pull/4776 but it targets the release branch instead of the master branch.

This reverts commit 38f2edbd880d9d29a21d7b1df57fdc2cf6ae03d0 from https://github.com/google/ggrc-core/pull/4700.

The commit caused a severe performance degredation in the unified
mapper modal because the /query API is not optimized for returning
non paginated results.

Querying for controls on the grc-test database took more than
1min on my local machine and it executed 42978 sql statements.