### PR TITLE
GGRC-576 Update Tree View Controller to correctly render Workflows widgets

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
@@ -425,7 +425,7 @@ CMS.Controllers.TreeLoader('CMS.Controllers.TreeView', {
     if (opts.model) {
       optionsProperty = opts.options_property ||
        this.constructor.defaults.options_property;
-      defaultOptions = opts.model[optionsProperty];
+      defaultOptions = opts.model[optionsProperty] || {};
     }
     if (typeof (opts.model) === 'string') {
       opts.model = CMS.Models[opts.model];


### PR DESCRIPTION
Steps to reproduce:
1. Filter any WF from LHN
2. Click the link to open WF
3. Look at the screen: JS error is displayed
Actual Result: "Uncaught TypeError: (intermediate value).attr(...).attr is not a function" occurs if open WF
Expected Result: no error displayed if open WF

This issue is a regression caused by [PR](https://github.com/google/ggrc-core/pull/4771) - one edge case is missing. Tree View Controller is not initialised correctly.
This modification is only a quick fix - the best solution should be to unify interface for Tree View Controller and pass only well known and defined set of parameters.     
Also in a scope of this PR extra minor improvements were implemented by a separate commit.