### PR TITLE
GGRC-97 Fix automapper revisions

### DIFF
--- a/test/integration/ggrc/automapper/test_automappings.py
+++ b/test/integration/ggrc/automapper/test_automappings.py
@@ -66,6 +66,11 @@ class TestAutomappings(integration.ggrc.TestCase):
     if not missing:
       self.assertIsNotNone(rel,
                            msg='%s not mapped to %s' % (obj1.type, obj2.type))
+      revisions = models.Revision.query.filter_by(
+          resource_type='Relationship',
+          resource_id=rel.id,
+      ).count()
+      self.assertEqual(revisions, 1)
     else:
       self.assertIsNone(rel,
                         msg='%s mapped to %s' % (obj1.type, obj2.type))


### PR DESCRIPTION
This PR is an update of cherry-picked branch from #4569.

If you map a Section to an Audit (so that a Snapshot is created and mapped to the Audit and the Section is mapped to the Program), not all Relationships are logged yet.