### PR TITLE
GGRC-353 Fix the size of the circle for the number of tasks

### DIFF
--- a/src/ggrc/assets/stylesheets/modules/_menu.scss
+++ b/src/ggrc/assets/stylesheets/modules/_menu.scss
@@ -20,9 +20,8 @@
       font-weight: bold;
       line-height: 16px;
       text-align: center;
-      width: 14px;
       height: 16px;
-      padding: 0 2px 0 1px;
+      padding: 0 5px;
       display: inline-block;
     }
     &.user {


### PR DESCRIPTION
**Steps to reproduce:**
See attached screenshots
_Actual Result:_ The red circle in My tasks section in top nav bar is too small, the third digit is not visible
_Expected Result:_ all 3 (or more) digits should be visible

![image](https://cloud.githubusercontent.com/assets/4737102/20786246/db338976-b7b5-11e6-9702-094dc5f2e754.png)
