### PR TITLE
GGRC-380 Fix label on checkboxes

### DIFF
--- a/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/info.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/info.mustache
@@ -147,7 +147,7 @@
               {{#each instance.response_options}}
                 <div class="row-fluid wrap-row">
                   <div class="span12">
-                    <input
+                    <label><input
                       type="checkbox"
                       {{^if_can_edit_response instance instance.status}}
                         disabled="disabled"
@@ -159,6 +159,7 @@
                         checked="checked"
                       {{/in_array}}>
                     {{.}}
+                    </label>
                   </div>
                 </div>
               {{/each}}


### PR DESCRIPTION
when creating a task with checkboxes, the checkboxes on cycle tasks are not label-clickable