### PR TITLE
GGRC-366 Fix auto insert date in Effective date

### DIFF
--- a/src/ggrc/assets/javascripts/components/datepicker/datepicker.js
+++ b/src/ggrc/assets/javascripts/components/datepicker/datepicker.js
@@ -85,6 +85,9 @@
             date.subtract(1, 'day');
           }
         };
+        if (!date) {
+          return;
+        }
         date = moment(date);
 
         if (types[type]) {

--- a/src/ggrc/assets/javascripts/components/tests/datepicker_spec.js
+++ b/src/ggrc/assets/javascripts/components/tests/datepicker_spec.js
@@ -1,0 +1,52 @@
+/*!
+ Copyright (C) 2016 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+describe('GGRC.Components.datepicker', function () {
+  'use strict';
+
+  var Component;  // the component under test
+
+  beforeAll(function () {
+    Component = GGRC.Components.get('datepicker');
+  });
+
+  describe('updateDate() method', function () {
+    var method;
+    var scope;
+
+    beforeAll(function () {
+      scope = new can.Map({
+        scope: {
+          picker: {
+            datepicker: jasmine.createSpy()
+          }
+        }
+      });
+      method = Component.prototype.events.updateDate.bind(scope);
+    });
+
+    it('returns undefined for empty date', function () {
+      expect(method('maxDate')).toBe(undefined);
+      expect(method('maxDate', null)).toBe(undefined);
+      expect(method('minDate', '')).toBe(undefined);
+    });
+
+    it('returns increment date', function () {
+      var result = method('maxDate', new Date(2017, 0, 1));
+
+      expect(result.getDate()).toBe(31);
+      expect(result.getFullYear()).toBe(2016);
+      expect(result.getMonth()).toBe(11);
+    });
+
+    it('returns decrement date', function () {
+      var result = method('minDate', new Date(2017, 0, 1));
+
+      expect(result.getDate()).toBe(2);
+      expect(result.getFullYear()).toBe(2017);
+      expect(result.getMonth()).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
**Subject**: Effective Date and Stop Date fields automatically insert previously deleted values
**Details**: 
Click +Create New to create new program
Select Effective date and then Stop date
Delete value from Effective date field
Delete value from Stop date
Click outside of the date fields (anywhere on the modal window)

_Actual Result:_ Effective date is automatically filled with previously deleted value
_Expected Result:_ Effective date is not selected automatically
_Workaround_: NA