### PR TITLE
GGRC-397 Allow picking past dates for Tasks in date picker

### DIFF
--- a/src/ggrc_workflows/assets/mustache/task_group_tasks/modal_content.mustache
+++ b/src/ggrc_workflows/assets/mustache/task_group_tasks/modal_content.mustache
@@ -78,8 +78,7 @@
           <i class="fa fa-question-circle" rel="tooltip" title="Choose start and end dates"></i>
         </label>
         <label class="smaller">
-           <datepicker set-min-date="instance.minStartDate"
-                       date="instance.start_date"
+           <datepicker date="instance.start_date"
                        required="{{true}}"
                        label="Start Date"></datepicker>
         </label>


### PR DESCRIPTION
This PR removes the minimum date restriction when selecting Workflow Task dates from the date picker widget.

**Steps to reproduce:**
  1. Create a one time WF
  2. Select a Task Group, click the `(+)` button in its info pane to create a new Task
  3. Try to select Start date in the past - can only be done by manually changing the filed contents

**Actual Result:**
Start/End Dates can be changed only manually in Task modal window, if the dates are related to past/present period

**Expected Result:**
Start/End Dates can be selected from the calendar in Task modal window if the dates are related to past/present period