### PR TITLE
GGRC-500 Replace bulk of warnings with only one

### DIFF
--- a/src/ggrc/converters/base_block.py
+++ b/src/ggrc/converters/base_block.py
@@ -107,6 +107,7 @@ class BlockConverter(object):
     self.row_warnings = []
     self.row_converters = []
     self.ignore = False
+    self._has_non_importable_columns = False
     # For import contains model name from csv file.
     # For export contains 'Model.__name__' value.
     self.class_name = options.get("class_name", "")
@@ -137,6 +138,16 @@ class BlockConverter(object):
       self.add_errors(errors.PERMISSION_ERROR, line=self.offset + 2)
       logger.error("Import failed with: Only admin can update existing "
                    "cycle-tasks via import")
+    if self._has_non_importable_columns:
+      importable_column_names = []
+      for field_name in self.object_class.IMPORTABLE_FIELDS:
+        if field_name == 'slug':
+          continue
+        importable_column_names.append(
+            self.headers[field_name]["display_name"])
+      self.add_warning(errors.ONLY_IMPORTABLE_COLUMNS_WARNING,
+                       line=self.offset + 2,
+                       columns=", ".join(importable_column_names))
 
   def _create_ca_definitions_cache(self):
     """Create dict cache for custom attribute definitions.
@@ -266,9 +277,7 @@ class BlockConverter(object):
         if (self.operation == 'import' and
                 hasattr(self.object_class, "IMPORTABLE_FIELDS") and
                 field_name not in self.object_class.IMPORTABLE_FIELDS):
-          self.add_warning(errors.NON_IMPORTABLE_COLUMN_WARNING,
-                           line=self.offset + 2,
-                           column_name=header)
+          self._has_non_importable_columns = True
           self.remove_column(index - removed_count)
           removed_count += 1
           continue

--- a/src/ggrc/converters/errors.py
+++ b/src/ggrc/converters/errors.py
@@ -107,5 +107,6 @@ INVALID_STATUS_DATE_CORRELATION = (u"Line {line}: Cannot change {date} for "
                                    u"task which status is {status}. "
                                    u"The line will be ignored.")
 
-NON_IMPORTABLE_COLUMN_WARNING = (u"Line {line}: Attribute '{column_name}' "
-                                 u"is non-importable. Column will be ignored.")
+ONLY_IMPORTABLE_COLUMNS_WARNING = (u"Line {line}: Only the following "
+                                   u"attributes are importable: {columns}. "
+                                   u"All other columns will be ignored.")

--- a/src/ggrc_workflows/models/cycle_task_group_object_task.py
+++ b/src/ggrc_workflows/models/cycle_task_group_object_task.py
@@ -31,8 +31,8 @@ class CycleTaskGroupObjectTask(
   __tablename__ = 'cycle_task_group_object_tasks'
   _title_uniqueness = False
 
-  IMPORTABLE_FIELDS = ('description', 'end_date', 'finished_date',
-                       'slug', 'start_date', 'title', 'verified_date')
+  IMPORTABLE_FIELDS = ('slug', 'title', 'description', 'start_date',
+                       'end_date', 'finished_date', 'verified_date')
 
   @classmethod
   def generate_slug_prefix_for(cls, obj):

--- a/test/integration/ggrc_workflows/converters/test_cycle_task_import_update.py
+++ b/test/integration/ggrc_workflows/converters/test_cycle_task_import_update.py
@@ -455,31 +455,25 @@ class TestCycleTaskImportUpdate(TestCase):
         }
     }
 
-    # Below is description of warnings for non-importable columns. It is needed
+    # Below is description of warning for non-importable columns. It is needed
     # for test_cycle_task_warnings.
-    warning_columns = (
-        'assignee', 'cycle', 'delete', 'map:access group', 'map:assessment',
-        'map:clause', 'map:contract', 'map:control', 'map:data asset',
-        'map:facility', 'map:issue', 'map:market', 'map:objective',
-        'map:org group', 'map:person', 'map:policy', 'map:process',
-        'map:product', 'map:program', 'map:project', 'map:regulation',
-        'map:risk', 'map:section', 'map:standard', 'map:system',
-        'map:threat', 'map:vendor', 'state', 'task group', 'task type'
-    )
+    importable_column_names = []
+    for field_name in CycleTaskGroupObjectTask.IMPORTABLE_FIELDS:
+      if field_name == 'slug':
+        continue
+      # pylint: disable=protected-access
+      importable_column_names.append(
+          CycleTaskGroupObjectTask._aliases.get(field_name, field_name))
     self.expected_warnings = {
         'Cycle Task Group Object Task': {
-            'block_warnings': set(),
+            'block_warnings': {
+                errors.ONLY_IMPORTABLE_COLUMNS_WARNING.format(
+                    line=2,
+                    columns=", ".join(importable_column_names)
+                )
+            },
         }
     }
-    for column_name in warning_columns:
-      self.expected_warnings[
-          'Cycle Task Group Object Task'
-      ]['block_warnings'].add(
-          errors.NON_IMPORTABLE_COLUMN_WARNING.format(
-              line=2,
-              column_name=column_name,
-          )
-      )
 
     # This is an error message which should be shown during
     # test_cycle_task_create_error test


### PR DESCRIPTION
**GGRC-500** Show warning for all values that can't be changed during import by user

- Prepare 2 historical tasks and 2 active tasks
- Add non importable columns and import updated csv file
- Check that only one warning message is displayed for all restricted columns

**Example:** csv file w/cycle tasks contains non importable fields (e.g. status, delete, map: program)
During import the next warning should be shown: "Only next columns are importable: title, description, start/end/finish/verified dates. All the others columns will be ignored"

---

**How to reproduce the issue:**

  1.  Create Workflow/Task Group/Tasks.
  1. Activate workflow. (Wait until new cycle-tasks will be created.)
  1. Export existing cycle-tasks. Choose any non-importable fields for cycle-tasks. This is any other except that in next list:
    `IMPORTABLE_FIELDS = ('description', 'end_date', 'finished_date', 'slug', 'start_date', 'title', 'verified_date')`
    Only `IMPORTABLE_FIELDS` can be updated during cycle-tasks import. So this is the reason while warning should appear.
   1. Re-import exported **csv** file. (Shouldn't change `slug` there cause new-cycle-tasks creation is forbidden.)
   1.  Check that appropriate warning message appears. Any other field except that in `IMPORTABLE_FIELDS` list will be ignored.
