### PR TITLE
QUICK-FIX Search by Enter key in Unified Mapper

### DIFF
--- a/src/ggrc/assets/javascripts/components/unified_mapper/mapper.js
+++ b/src/ggrc/assets/javascripts/components/unified_mapper/mapper.js
@@ -385,6 +385,7 @@
 
       '#search keyup': function (el, ev) {
         if (ev.keyCode === 13) {
+          this.scope.attr('mapper.term', el.val());
           this.element.find('mapper-results').control().getResults();
         }
       },


### PR DESCRIPTION
This PR fixes bug in Unified Mapper when hitting enter key doesn't search with matching term correctly.