### PR TITLE
GGRC-114 Fix counts are not refreshed after starting the workflow

### DIFF
--- a/src/ggrc_workflows/assets/javascripts/components/end_cycle.js
+++ b/src/ggrc_workflows/assets/javascripts/components/end_cycle.js
@@ -24,7 +24,9 @@
     tag: 'cycle-end-cycle',
     template: '<content/>',
     events: {
-      click: function () {
+      click: function (el, ev) {
+        ev.stopPropagation();
+
         this.scope.cycle
           .refresh()
           .then(function (cycle) {

--- a/src/ggrc_workflows/assets/javascripts/components/workflow_active.js
+++ b/src/ggrc_workflows/assets/javascripts/components/workflow_active.js
@@ -109,13 +109,28 @@
             workflow.attr('status', 'Active');
             return workflow.save();
           }, restore_button).then(function (workflow) {
-            if (moment(workflow.next_cycle_start_date).isSame(moment(), 'day')) {
+            if (moment(workflow.next_cycle_start_date)
+                .isSame(moment(), 'day')) {
               return new CMS.Models.Cycle({
                 context: workflow.context.stub(),
                 workflow: {id: workflow.id, type: 'Workflow'},
                 autogenerate: true
               }).save();
             }
+          }, restore_button).then(function () {
+            var WorkflowExtension =
+              GGRC.extensions.find(function (extension) {
+                return extension.name === 'workflows';
+              });
+
+            $('body').trigger('treeupdate');
+            return GGRC.Utils.QueryAPI
+              .initCounts([
+                WorkflowExtension.countsMap.activeCycles
+              ], {
+                type: workflow.type,
+                id: workflow.id
+              });
           }, restore_button).then(restore_button);
         } else {
           _generate_cycle().then(function () {


### PR DESCRIPTION
This PR fixes active cycles count is not refreshed when starting the workflow from other tabs. It also fixes issue for active cycles tree is not updated.