### PR TITLE
GGRC-581 Fix second tier for Active Cycles tab

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
@@ -420,20 +420,19 @@ CMS.Controllers.TreeLoader.extend('CMS.Controllers.TreeView', {
 }, {
   // prototype properties
   setup: function (el, opts) {
-    var defaultOptions = {};
+    var defaultOptions;
     var optionsProperty;
     var defaults = this.constructor.defaults;
     if (typeof this._super === 'function') {
       this._super(el);
     }
-    if (opts.model) {
-      optionsProperty = opts.options_property ||
-       this.constructor.defaults.options_property;
-      defaultOptions = opts.model[optionsProperty] || {};
-    }
+
     if (typeof (opts.model) === 'string') {
       opts.model = CMS.Models[opts.model];
     }
+    optionsProperty = opts.options_property || defaults.options_property;
+    defaultOptions = opts.model[optionsProperty] || {};
+
     this.options = new can.Map(defaults).attr(defaultOptions).attr(opts);
     if (opts instanceof can.Map) {
       this.options = can.extend(this.options, opts);


### PR DESCRIPTION
**Steps to reproduce:**
1. Create wf
2. Go ti Setup tab and create Task
3. Activate WF
4. Go to Active Cycles tab
5. Click on grey triangle on first tier: confirm the second tier is not shown

_Actual Result:_ Second tier is not displayed for Active Cycles on WF page
_Expected Result:_ Second tier should be displayed for Active Cycles on WF page
