### PR TITLE
GGRC-584 Add relationships between snapshots

### DIFF
--- a/src/ggrc/models/snapshot.py
+++ b/src/ggrc/models/snapshot.py
@@ -153,7 +153,7 @@ class Snapshot(relationship.Relatable, mixins.Base, db.Model):
         with benchmark("Snapshot post api set revisions"):
           cls._set_revisions(new_snapshots)
         with benchmark("Snapshot post api ensure relationships"):
-          cls._ensure_relationships(new_snapshots)
+          cls._ensure_program_relationships(new_snapshots)
 
   @classmethod
   def _revert_attrs(cls, objects):
@@ -171,7 +171,7 @@ class Snapshot(relationship.Relatable, mixins.Base, db.Model):
           setattr(snapshot, attr, deleted[0])
 
   @classmethod
-  def _ensure_relationships(cls, objects):
+  def _ensure_program_relationships(cls, objects):
     """Ensure that snapshotted object is related to audit program.
 
     This function is made to handle multiple snapshots for a single audit.

--- a/src/ggrc/models/snapshot.py
+++ b/src/ggrc/models/snapshot.py
@@ -106,7 +106,7 @@ class Snapshot(relationship.Relatable, mixins.Base, db.Model):
   def update_revision(self, value):
     self._update_revision = value
     if value == "latest":
-      self._set_revisions([self])
+      _set_latest_revisions([self])
 
   @property
   def parent_attr(self):
@@ -131,136 +131,6 @@ class Snapshot(relationship.Relatable, mixins.Base, db.Model):
         db.Index("ix_snapshots_parent", "parent_type", "parent_id"),
         db.Index("ix_snapshots_child", "child_type", "child_id"),
     )
-
-  @classmethod
-  def handle_post_flush(cls, session, flush_context, instances):
-    """Handle snapshot objects on api post requests."""
-    # pylint: disable=unused-argument
-    # Arguments here are set in the event listener and are mandatory.
-
-    with benchmark("Snapshot pre flush handler"):
-
-      snapshots = [o for o in session if isinstance(o, cls)]
-      if not snapshots:
-        return
-
-      with benchmark("Snapshot revert attrs"):
-        cls._revert_attrs(snapshots)
-
-      new_snapshots = [o for o in snapshots
-                       if getattr(o, "_update_revision", "") == "new"]
-      if new_snapshots:
-        with benchmark("Snapshot post api set revisions"):
-          cls._set_revisions(new_snapshots)
-        with benchmark("Snapshot post api ensure relationships"):
-          cls._ensure_program_relationships(new_snapshots)
-
-  @classmethod
-  def _revert_attrs(cls, objects):
-    """Revert any modified attributes on snapshot.
-
-    All snapshot attributes that are updatable with API calls should only be
-    settable and not editable. This function reverts any possible edits to
-    existing values.
-    """
-    attrs = ["parent_id", "parent_type", "child_id", "child_type"]
-    for snapshot in objects:
-      for attr in attrs:
-        deleted = inspect(snapshot).attrs[attr].history.deleted
-        if deleted:
-          setattr(snapshot, attr, deleted[0])
-
-  @classmethod
-  def _ensure_program_relationships(cls, objects):
-    """Ensure that snapshotted object is related to audit program.
-
-    This function is made to handle multiple snapshots for a single audit.
-    Args:
-      objects: list of snapshot objects with child_id and child_type set.
-    """
-    pairs = [(o.child_type, o.child_id) for o in objects]
-    assert len({o.parent.id for o in objects}) == 1  # fail on multiple audits
-    program = ("Program", objects[0].parent.program_id)
-    rel = relationship.Relationship
-    columns = db.session.query(
-        rel.destination_type,
-        rel.destination_id,
-        rel.source_type,
-        rel.source_id,
-    )
-    query = columns.filter(
-        tuple_(rel.destination_type, rel.destination_id) == (program),
-        tuple_(rel.source_type, rel.source_id).in_(pairs)
-    ).union(
-        columns.filter(
-            tuple_(rel.source_type, rel.source_id) == (program),
-            tuple_(rel.destination_type, rel.destination_id).in_(pairs)
-        )
-    )
-    existing_pairs = set(sum([
-        [(r.destination_type, r.destination_id), (r.source_type, r.source_id)]
-        for r in query
-    ], []))  # build a set of all found type-id pairs
-    missing_pairs = set(pairs).difference(existing_pairs)
-    cls._insert_relationships(program, missing_pairs)
-
-  @classmethod
-  def _insert_relationships(cls, program, missing_pairs):
-    """Insert missing obj-program relationships."""
-    if not missing_pairs:
-      return
-    current_user_id = get_current_user_id()
-    now = datetime.now()
-    # We are doing an INSERT IGNORE INTO here to mitigate a race condition
-    # that happens when multiple simultaneous requests create the same
-    # automapping. If a relationship object fails our unique constraint
-    # it means that the mapping was already created by another request
-    # and we can safely ignore it.
-    inserter = relationship.Relationship.__table__.insert().prefix_with(
-        "IGNORE")
-    db.session.execute(
-        inserter.values([
-            {
-                "id": None,
-                "modified_by_id": current_user_id,
-                "created_at": now,
-                "updated_at": now,
-                "source_type": program[0],
-                "source_id": program[1],
-                "destination_type": dst_type,
-                "destination_id": dst_id,
-                "context_id": None,
-                "status": None,
-                "automapping_id": None
-            }
-            for dst_type, dst_id in missing_pairs
-        ])
-    )
-
-  @classmethod
-  def _set_revisions(cls, objects):
-    """Set latest revision_id for given child_type.
-
-    Args:
-      objects: list of snapshot objects with child_id and child_type set.
-    """
-    pairs = [(o.child_type, o.child_id) for o in objects]
-    query = db.session.query(
-        func.max(revision.Revision.id, name="id", identifier="id"),
-        revision.Revision.resource_type,
-        revision.Revision.resource_id,
-    ).filter(
-        tuple_(
-            revision.Revision.resource_type,
-            revision.Revision.resource_id,
-        ).in_(pairs)
-    ).group_by(
-        revision.Revision.resource_type,
-        revision.Revision.resource_id,
-    )
-    id_map = {(r_type, r_id): id_ for id_, r_type, r_id in query}
-    for o in objects:
-      o.revision_id = id_map.get((o.child_type, o.child_id))
 
 
 class Snapshotable(object):
@@ -293,4 +163,134 @@ class Snapshotable(object):
     )
 
 
-event.listen(Session, 'before_flush', Snapshot.handle_post_flush)
+def handle_post_flush(session, flush_context, instances):
+  """Handle snapshot objects on api post requests."""
+  # pylint: disable=unused-argument
+  # Arguments here are set in the event listener and are mandatory.
+
+  with benchmark("Snapshot pre flush handler"):
+
+    snapshots = [o for o in session if isinstance(o, Snapshot)]
+    if not snapshots:
+      return
+
+    with benchmark("Snapshot revert attrs"):
+      _revert_attrs(snapshots)
+
+    new_snapshots = [o for o in snapshots
+                     if getattr(o, "_update_revision", "") == "new"]
+    if new_snapshots:
+      with benchmark("Snapshot post api set revisions"):
+        _set_latest_revisions(new_snapshots)
+      with benchmark("Snapshot post api ensure relationships"):
+        _ensure_program_relationships(new_snapshots)
+
+
+def _revert_attrs(objects):
+  """Revert any modified attributes on snapshot.
+
+  All snapshot attributes that are updatable with API calls should only be
+  settable and not editable. This function reverts any possible edits to
+  existing values.
+  """
+  attrs = ["parent_id", "parent_type", "child_id", "child_type"]
+  for snapshot in objects:
+    for attr in attrs:
+      deleted = inspect(snapshot).attrs[attr].history.deleted
+      if deleted:
+        setattr(snapshot, attr, deleted[0])
+
+
+def _ensure_program_relationships(objects):
+  """Ensure that snapshotted object is related to audit program.
+
+  This function is made to handle multiple snapshots for a single audit.
+  Args:
+    objects: list of snapshot objects with child_id and child_type set.
+  """
+  pairs = [(o.child_type, o.child_id) for o in objects]
+  assert len({o.parent.id for o in objects}) == 1  # fail on multiple audits
+  program = ("Program", objects[0].parent.program_id)
+  rel = relationship.Relationship
+  columns = db.session.query(
+      rel.destination_type,
+      rel.destination_id,
+      rel.source_type,
+      rel.source_id,
+  )
+  query = columns.filter(
+      tuple_(rel.destination_type, rel.destination_id) == (program),
+      tuple_(rel.source_type, rel.source_id).in_(pairs)
+  ).union(
+      columns.filter(
+          tuple_(rel.source_type, rel.source_id) == (program),
+          tuple_(rel.destination_type, rel.destination_id).in_(pairs)
+      )
+  )
+  existing_pairs = set(sum([
+      [(r.destination_type, r.destination_id), (r.source_type, r.source_id)]
+      for r in query
+  ], []))  # build a set of all found type-id pairs
+  missing_pairs = set(pairs).difference(existing_pairs)
+  _insert_program_relationships(program, missing_pairs)
+
+
+def _insert_program_relationships(program, missing_pairs):
+  """Insert missing obj-program relationships."""
+  if not missing_pairs:
+    return
+  current_user_id = get_current_user_id()
+  now = datetime.now()
+  # We are doing an INSERT IGNORE INTO here to mitigate a race condition
+  # that happens when multiple simultaneous requests create the same
+  # automapping. If a relationship object fails our unique constraint
+  # it means that the mapping was already created by another request
+  # and we can safely ignore it.
+  inserter = relationship.Relationship.__table__.insert().prefix_with(
+      "IGNORE")
+  db.session.execute(
+      inserter.values([
+          {
+              "id": None,
+              "modified_by_id": current_user_id,
+              "created_at": now,
+              "updated_at": now,
+              "source_type": program[0],
+              "source_id": program[1],
+              "destination_type": dst_type,
+              "destination_id": dst_id,
+              "context_id": None,
+              "status": None,
+              "automapping_id": None
+          }
+          for dst_type, dst_id in missing_pairs
+      ])
+  )
+
+
+def _set_latest_revisions(objects):
+  """Set latest revision_id for given child_type.
+
+  Args:
+    objects: list of snapshot objects with child_id and child_type set.
+  """
+  pairs = [(o.child_type, o.child_id) for o in objects]
+  query = db.session.query(
+      func.max(revision.Revision.id, name="id", identifier="id"),
+      revision.Revision.resource_type,
+      revision.Revision.resource_id,
+  ).filter(
+      tuple_(
+          revision.Revision.resource_type,
+          revision.Revision.resource_id,
+      ).in_(pairs)
+  ).group_by(
+      revision.Revision.resource_type,
+      revision.Revision.resource_id,
+  )
+  id_map = {(r_type, r_id): id_ for id_, r_type, r_id in query}
+  for o in objects:
+    o.revision_id = id_map.get((o.child_type, o.child_id))
+
+
+event.listen(Session, 'before_flush', handle_post_flush)

--- a/src/ggrc/models/snapshot.py
+++ b/src/ggrc/models/snapshot.py
@@ -25,22 +25,6 @@ from ggrc.models.deferred import deferred
 from ggrc.models.computed_property import computed_property
 
 
-def get_latest_revision_id(snapshot):
-  """Retrieve last revision saved for snapshots
-
-  Args:
-    snapshot: Instance of models.Snapshot
-  Returns:
-    ID of the latest revision or None otherwise
-  """
-  from ggrc.snapshotter.helpers import get_revisions
-  from ggrc.snapshotter.datastructures import Pair
-  pair = Pair.from_snapshot(snapshot)
-  revisions = get_revisions({pair}, revisions=set())
-  if pair in revisions and revisions[pair]:
-    return revisions[pair]
-
-
 class Snapshot(relationship.Relatable, mixins.Base, db.Model):
   """Snapshot object that holds a join of parent object, revision, child object
   and parent object's context.
@@ -122,9 +106,7 @@ class Snapshot(relationship.Relatable, mixins.Base, db.Model):
   def update_revision(self, value):
     self._update_revision = value
     if value == "latest":
-      latest_revision_id = get_latest_revision_id(self)
-      if latest_revision_id:
-        self.revision_id = latest_revision_id
+      self._set_revisions([self])
 
   @property
   def parent_attr(self):


### PR DESCRIPTION
Relationships between snapshots must match relationships between the parent objects that were snapshotted.

Currently this is only visible in the database.