### PR TITLE
GGRC-385 Live update Task counter color

### DIFF
--- a/src/ggrc/assets/javascripts/components/object_counter/object_counter.js
+++ b/src/ggrc/assets/javascripts/components/object_counter/object_counter.js
@@ -39,6 +39,7 @@
       '/components/object_counter/object_counter.mustache'),
     scope: {
       counter: '@',
+      counterOverdue: '@',
       modelName: '@',
       searchKeys: '@',
       searchValues: '@',
@@ -48,12 +49,22 @@
         'false': false
       },
       count: null,
+      overdueCount: null,
       initialCount: function () {
         var counter = this.attr('counter');
+        var counterOverdue = this.attr('counterOverdue');
+
         if (_.isUndefined(GGRC.counters[counter])) {
-          throw new Error('Specified counter doesn\'t exist.');
+          throw new Error('Counter ' + counter + ' doesn\'t exist');
         }
         this.attr('count', parseInt(GGRC.counters[counter], 10));
+
+        // the "overdue" counter is optional, thus no error
+        if (!_.isUndefined(GGRC.counters[counterOverdue])) {
+          this.attr(
+            'overdueCount',
+            parseInt(GGRC.counters[counterOverdue], 10));
+        }
       },
       updateCount: _.throttle(function () {
         var searchData = {};
@@ -79,9 +90,27 @@
 
         data = CMS.Models[modelName].findAll(searchData);
         data.done(function (objectList) {
+          var overdue;
+          var utcToday;
+
           this.scope.attr('count', objectList.length);
+
+          // Calculate overdue objects count, assuming UTC time zone and not
+          // taking user's local browser timezone into account.
+          utcToday = moment().tz('UTC');
+
+          overdue = _.filter(objectList, function (item) {
+            var utcDate;
+            if (!item.end_date) {
+              return false;  // no end date --> not considered overdue
+            }
+            utcDate = moment(item.end_date).tz('UTC');
+            return utcToday.isAfter(utcDate, 'day');
+          });
+
+          this.scope.attr('overdueCount', overdue.length);
         }.bind(this));
-      }, 10000) // See component documentation for explanation
+      }, 10000)  // See component documentation for explanation
     },
     init: function () {
       var updateEvents = ['created', 'updated', 'destroyed'];

--- a/src/ggrc/assets/javascripts/components/object_counter/tests/object_counter_spec.js
+++ b/src/ggrc/assets/javascripts/components/object_counter/tests/object_counter_spec.js
@@ -1,0 +1,206 @@
+/*!
+  Copyright (C) 2016 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+describe('GGRC.Components.ObjectCounter', function () {
+  'use strict';
+
+  var Component;  // the component under test
+
+  beforeAll(function () {
+    Component = GGRC.Components.get('ObjectCounter');
+  });
+
+  describe('initializing scope values', function () {
+    var origCounters;
+    var html;
+    var $componentRoot;  // component instance's root element
+
+    beforeEach(function () {
+      var mustacheContext;
+      var renderer;
+      var template;
+      var $body = $('body');
+
+      origCounters = GGRC.counters;
+      GGRC.counters = {
+        user_task_count: 7,
+        user_overdue_task_count: 2
+      };
+
+      template = [
+        '<object-counter',
+        '  counter="user_task_count"',
+        '  counter-overdue="user_overdue_task_count"',
+        '  search-keys="user_id;verbose"',
+        '  search-values="42;true"',
+        '  model-name="CycleTaskGroupObjectTask"',
+        '  >',
+        '</object-counter>'
+      ].join('');
+
+      mustacheContext = {};
+
+      renderer = can.view.mustache(template);
+      html = renderer(mustacheContext);
+      $body.append(html);
+
+      $componentRoot = $body.children('object-counter');
+    });
+
+    afterEach(function () {
+      $componentRoot.remove();
+      GGRC.counters = origCounters;
+    });
+
+    it('sets the task count to the global counter value', function () {
+      var scope = $componentRoot.scope();
+      expect(scope.count).toEqual(7);
+    });
+
+    it('sets the overdue task count to the global counter value', function () {
+      var scope = $componentRoot.scope();
+      expect(scope.overdueCount).toEqual(2);
+    });
+  });
+
+  describe('updateCount() method', function () {
+    var dfdFindAll;
+    var origCurrentUser;
+    var scope;
+    var updateCount;
+
+    beforeAll(function () {
+      origCurrentUser = GGRC.current_user;
+      GGRC.current_user = {
+        id: 117,
+        name: 'John Doe'
+      };
+    });
+
+    afterAll(function () {
+      GGRC.current_user = origCurrentUser;
+    });
+
+    beforeEach(function () {
+      jasmine.clock().install();
+
+      scope = new can.Map({
+        modelName: 'CycleTaskGroupObjectTask',
+        searchKeys: 'user_id;verbose',
+        searchValues: '42;true',
+        _getValue: {}
+      });
+
+      // The updateCount method is throttled, thus we need to cancel any
+      // delayed invocation timers in order to put it into a "fresh" state,
+      // so that its the next call in a test case will be executed immediately.
+      updateCount = Component.prototype.scope.updateCount;
+      updateCount.cancel();
+      updateCount = updateCount.bind({scope: scope});
+
+      dfdFindAll = new can.Deferred();
+      spyOn(CMS.Models.CycleTaskGroupObjectTask, 'findAll')
+        .and.returnValue(dfdFindAll.promise());
+    });
+
+    afterEach(function () {
+      jasmine.clock().uninstall();
+    });
+
+    it('sets overdue tasks counter to zero if no objects retrieved',
+      function () {
+        scope.attr('overdueCount', 99);
+        updateCount();
+        dfdFindAll.resolve([]);
+        expect(scope.overdueCount).toEqual(0);
+      }
+    );
+
+    it('sets the tasks counter to the number of tasks that are overdue',
+      function () {
+        var fetchedObjects;
+        var fakeToday = moment('2016-11-20 10:16:23Z');
+
+        jasmine.clock().mockDate(fakeToday.toDate());
+
+        fetchedObjects = [
+          new can.Map({
+            end_date: new Date('2017-01-15T08:12:00Z')
+          }),
+          new can.Map({
+            end_date: new Date('2016-11-18T19:45:07Z')  // overdue
+          }),
+          new can.Map({
+            end_date: new Date('2018-05-07T12:22:09Z')
+          }),
+          new can.Map({
+            end_date: new Date('2016-09-27T15:00:00Z')  // overdue
+          }),
+          new can.Map({
+            end_date: new Date('2016-12-31T23:59:59Z')
+          })
+        ];
+        scope.attr('overdueCount', 99);
+
+        updateCount();
+        dfdFindAll.resolve(fetchedObjects);
+
+        expect(scope.overdueCount).toEqual(2);
+      }
+    );
+
+    it('considers only the date part when determining if an object is overdue',
+      function () {
+        var fetchedObjects;
+        var fakeToday = moment('2016-11-20 10:16:23.000Z');
+
+        jasmine.clock().mockDate(fakeToday.toDate());
+
+        fetchedObjects = [
+          new can.Map({
+            end_date: new Date('2016-11-20T07:55:35.000Z')
+          }),
+          new can.Map({
+            end_date: new Date('2016-11-20T10:16:22.999Z')
+          }),
+          new can.Map({
+            end_date: new Date('2016-11-20T10:16:23.000Z')
+          }),
+          new can.Map({
+            end_date: new Date('2016-11-20T23:59:59.999Z')
+          }),
+          new can.Map({
+            end_date: new Date('2016-11-19T23:59:59.999Z')  // overdue
+          })
+        ];
+        scope.attr('overdueCount', 99);
+
+        updateCount();
+        dfdFindAll.resolve(fetchedObjects);
+
+        expect(scope.overdueCount).toEqual(1);
+      }
+    );
+
+    it('treats objects with undefined end date as NOT overdue', function () {
+      var fetchedObjects;
+      var fakeToday = moment('2016-11-20 10:16:23.000Z');
+
+      jasmine.clock().mockDate(fakeToday.toDate());
+
+      fetchedObjects = [
+        new can.Map({
+          end_date: undefined
+        })
+      ];
+      scope.attr('overdueCount', 99);
+
+      updateCount();
+      dfdFindAll.resolve(fetchedObjects);
+
+      expect(scope.overdueCount).toEqual(0);
+    });
+  });
+});

--- a/src/ggrc/assets/mustache/base_objects/page_header.mustache
+++ b/src/ggrc/assets/mustache/base_objects/page_header.mustache
@@ -40,7 +40,7 @@
         My Tasks
         <object-counter
           counter="user_task_count"
-          {{#if GGRC.counters.user_overdue_task_count}}class="critical"{{/if}}
+          counter-overdue="user_overdue_task_count"
           model-name="CycleTaskGroupObjectTask"
           search-keys="contact_id;cycle.is_current;status__in"
           search-values="current_user;true;Assigned,InProgress,Finished,Declined"

--- a/src/ggrc/assets/mustache/components/object_counter/object_counter.mustache
+++ b/src/ggrc/assets/mustache/components/object_counter/object_counter.mustache
@@ -3,6 +3,9 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
 
-<small class="count {{^count}}count-zero{{/count}}">
+<small
+  class="count
+        {{^count}}count-zero{{/count}}
+        {{#overdueCount}}critical{{/overdueCount}}">
   {{count}}
 </small>

--- a/src/ggrc/assets/stylesheets/modules/_menu.scss
+++ b/src/ggrc/assets/stylesheets/modules/_menu.scss
@@ -99,7 +99,7 @@ small {
   &.count {
     @include border-radius(4px);
     background: #777;
-    .critical & {
+    &.critical {
       background: $error;
     }
     text-align: center;


### PR DESCRIPTION
This PR fixes live updating of the My Tasks counter color when the number of overdue tasks changes from zero to non-zero (or vice  versa).

---

**Steps to reproduce:**
  1. Go to My work page
  2. Select Tasks tab in HNB
  3. Change one of your own task's task due date, so that an overdue task becomes not overdue (or vice versa - a not overdue task becomes overdue)

**Actual Result:**
My task balloon (in the top navigation bar) doesn't change the color from grey to red and vice versa while changing the task due date

**Expected Result:**
My task balloon should be change the color from red to grey while changing the task due date.
Balloon should be red if at least one of task is overdue, otherwise grey