### PR TITLE
GGRC-33 Add logic to recreate lost revisions

### DIFF
--- a/src/ggrc/utils/revisions.py
+++ b/src/ggrc/utils/revisions.py
@@ -181,6 +181,13 @@ def do_refresh_revisions():
   # Not storing revisions for RelationshipAttrs (part of Relationships)
   valid_types -= {"RelationshipAttr"}
 
+  # TODO: fix the errors for the next excluded types and remove this block
+  valid_types -= {
+      "BackgroundTask",  # over max content length
+      "Role",  # no FK by modified_by_id to Person
+      "RiskObject",  # does not mix in Relatable, thus fails on eager_query
+  }
+
   for type_ in valid_types:
     logger.info("Updating revisions for: %s", type_)
     _fix_type_revisions(type_, _get_revisions_by_type(type_))


### PR DESCRIPTION
This PR adds logic to insert lost revisions:
1. For a lost object with no "deleted" revision, create a copy of this object's last revision with `action="deleted"`.
2. For an object with no revisions and `created_at == updated_at`, create a new revision with `action="created"` and `content=obj.log_json()`.
3. For an object with no revisions and `created_at != updated_at`, create a new revision with `action="modified"` and `content=obj.log_json()`.
