### PR TITLE
QUICK-FIX Remove duplicate Google Analytics script config

### DIFF
--- a/src/ggrc/templates/layouts/base.haml
+++ b/src/ggrc/templates/layouts/base.haml
@@ -84,10 +84,7 @@
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-        ga('create', '{{config.get("GOOGLE_ANALYTICS_ID")}}', {
-          cookieDomain: '{{config.get("GOOGLE_ANALYTICS_DOMAIN")}}',
-          siteSpeedSampleRate: 100,
-        });
+        ga('create', '{{config.get("GOOGLE_ANALYTICS_ID")}}', 'auto');
         //  Presence of appName/appVersion seems to prevent 'Real-Time' metrics
         //  https://code.google.com/p/analytics-issues/issues/detail?id=366
         //ga('set', 'appVersion', '{{config.get("VERSION")}}');

--- a/src/ggrc_risks/templates/layouts/base.haml
+++ b/src/ggrc_risks/templates/layouts/base.haml
@@ -70,10 +70,7 @@
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-        ga('create', '{{config.get("GOOGLE_ANALYTICS_ID")}}', {
-          cookieDomain: '{{config.get("GOOGLE_ANALYTICS_DOMAIN")}}',
-          siteSpeedSampleRate: 100,
-        });
+        ga('create', '{{config.get("GOOGLE_ANALYTICS_ID")}}', 'auto');
         //  Presence of appName/appVersion seems to prevent 'Real-Time' metrics
         //  https://code.google.com/p/analytics-issues/issues/detail?id=366
         //ga('set', 'appVersion', '{{config.get("VERSION")}}');


### PR DESCRIPTION
**Update:** The  PR has been rebased onto the develop branch, thus there was nothing left to revert, just the existing GA script templates have been updated (which is the actual net effect of the changes in #4716 and this PR).

---

This PR merges the changes from #4716 with the existing Google Analytics script configuration. It essentially removes most of the #4716, but uses the latter's small change of the GA script template.

To verify the change, one should make sure the `GGRC_GOOGLE_ANALYTICS_ID` environment variable is set (to some Google Analytics ID), and the GA script will appear in the page source. On the other hand, if the variable is not set, the script is not inserted into the page as well.
