### PR TITLE
GGRC-388 Fix selecting Assignee in New Task modal

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/modals_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/modals_controller.js
@@ -172,21 +172,20 @@ can.Control('GGRC.Controllers.Modals', {
     if (/^\d+$/.test(path[path.length - 1])) {
       index = parseInt(path.pop(), 10);
       path = path.join('.');
-      if (!this.options.instance.attr(path)) {
-        this.options.instance.attr(path, []);
+      if (!instance.attr(path)) {
+        instance.attr(path, []);
       }
-      this.options.instance.attr(path).splice(index, 1, ui.item.stub());
+      instance.attr(path).splice(index, 1, ui.item.stub());
     } else {
       path = path.join('.');
       setTimeout(function () {
         el.val(ui.item.name || ui.item.email || ui.item.title, ui.item);
       }, 0);
-
-      this.options.instance.attr(path, ui.item);
-      if (!this.options.instance._transient) {
-        this.options.instance.attr('_transient', can.Map());
+      instance.attr(path, null).attr(path, ui.item);
+      if (!instance._transient) {
+        instance.attr('_transient', can.Map());
       }
-      this.options.instance.attr('_transient.' + path, ui.item);
+      instance.attr('_transient.' + path, ui.item);
     }
   },
   immediate_find_or_create: function(el, ev, data) {


### PR DESCRIPTION
**Subject**: Assignee is not selected on the first try from the dropdown list in New task window 
**Details**: 
Create WF
Go to setup tab
Navigate to Task’s group Info pane
Click + to Create New Task
Delete a default value in Assignee field
Select Assignee from drop down list: Assignee is not selected on the first try 

_Actual Result_: Assignee is not selected on the first try from the dropdown list in New task window 
_Expected Result:_ Assignee should be selected on the first try from the dropdown list in New task window 
_Workaround_: NA