### PR TITLE
GGRC-529 Unify main spinners

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
@@ -80,51 +80,46 @@ can.Control.extend('CMS.Controllers.TreeLoader', {
   defaults: {}
 }, {
   init_spinner: function () {
+    var renderer;
     var spinner;
-    var $spinner;
     var $footer;
     var $wrapper;
-    var spinnerTopOffset = '40%';
-    var elementOffset = $(window).height() - this.element.offset().top;
 
     if (this.element) {
       $footer = this.element.children('.tree-item-add').first();
-      spinner = new Spinner({
-        radius: 4,
-        length: 4,
-        width: 2
-      }).spin();
-      $spinner = $(spinner.el);
+
       if (this.options.is_subtree) {
         $wrapper = $('<li class="tree-item tree-spinner"/>');
       } else {
         $wrapper = $('<div class="tree-spinner"/>');
       }
+
       if (!this.options.is_subtree && !this.element.next().length) {
         $wrapper.css('height', '40px');
       }
 
-      if (this.element.height() > elementOffset) {
-        spinnerTopOffset = Math.floor(elementOffset / 2) + 'px';
-      }
-
-      $wrapper.append($spinner);
-      $spinner.css({
-        display: 'absolute',
-        left: '50%',
-        top: spinnerTopOffset
-      });
+      spinner = [
+        '<spinner toggle="showMe"',
+        '  size="large"',
+        '  extra-css-class="tree-items"',
+        '>',
+        '</spinner>'
+      ].join('');
+      renderer = can.view.mustache(spinner);
+      spinner = renderer({showMe: true});
 
       // Admin dashboard
       if ($footer.length === 0 &&
-        this.element.children('.tree-structure').length > 0) {
+          this.element.children('.tree-structure').length > 0) {
         this.element.children('.tree-structure')
           .addClass('new-tree_loading').append($wrapper);
-      } else if ($footer.length === 0) { // My work
+      } else if ($footer.length === 0) {  // My work
         this.element.addClass('new-tree_loading').append($wrapper);
       } else {
         $footer.before($wrapper);
       }
+
+      $wrapper.append(spinner);
     }
   },
   prepare: function () {
@@ -243,14 +238,17 @@ can.Control.extend('CMS.Controllers.TreeLoader', {
 
   _loading_finished: function () {
     var loading_deferred;
+
     if (this._loading_deferred) {
       this.element.trigger('loaded');
       this.element.find('.tree-spinner').remove();
+
       if (this.element.hasClass('new-tree_loading')) {
         this.element.removeClass('new-tree_loading');
       } else {
         this.element.find('.new-tree_loading').removeClass('new-tree_loading');
       }
+
       loading_deferred = this._loading_deferred;
       this._loading_deferred = null;
       loading_deferred.resolve();

--- a/src/ggrc/assets/mustache/audits/search_result.mustache
+++ b/src/ggrc/assets/mustache/audits/search_result.mustache
@@ -18,6 +18,7 @@
 {{/list}}
 
 {{#list.is_loading}}
-  <li class="spinny"  {{attach_spinner '{ "radius": 4, "length": 7, "width": 2 }' }}>
+  <li class="spinny">
+    <spinner toggle="list.is_loading"></spinner>
   </li>
 {{/list.is_loading}}

--- a/src/ggrc/assets/mustache/base_objects/search_result.mustache
+++ b/src/ggrc/assets/mustache/base_objects/search_result.mustache
@@ -23,6 +23,7 @@
 {{/list}}
 
 {{#list.is_loading}}
-  <li class="spinny"  {{attach_spinner '{ "radius": 4, "length": 7, "width": 2 }' }}>
+  <li class="spinny">
+    <spinner toggle="list.is_loading"></spinner>
   </li>
 {{/list.is_loading}}

--- a/src/ggrc/assets/mustache/people/search_result.mustache
+++ b/src/ggrc/assets/mustache/people/search_result.mustache
@@ -18,6 +18,7 @@
 {{/list}}
 
 {{#list.is_loading}}
-  <li class="spinny"  {{attach_spinner '{ "radius": 4, "length": 7, "width": 2 }' }}>
+  <li class="spinny">
+    <spinner toggle="list.is_loading"></spinner>
   </li>
 {{/list.is_loading}}

--- a/src/ggrc/assets/mustache/programs/search_result.mustache
+++ b/src/ggrc/assets/mustache/programs/search_result.mustache
@@ -23,6 +23,7 @@
 {{/list}}
 
 {{#list.is_loading}}
-  <li class="spinny"  {{attach_spinner '{ "radius": 4, "length": 7, "width": 2 }' }}>
+  <li class="spinny">
+    <spinner toggle="list.is_loading"></spinner>
   </li>
 {{/list.is_loading}}

--- a/src/ggrc/assets/stylesheets/modules/_spinner.scss
+++ b/src/ggrc/assets/stylesheets/modules/_spinner.scss
@@ -17,6 +17,9 @@
     top: 10px;
     left: 49%;
   }
+  #lhn .spinny & {
+    margin-left: 20%;
+  }
 }
 
 .spinner-size {

--- a/src/ggrc/assets/stylesheets/modules/_spinner.scss
+++ b/src/ggrc/assets/stylesheets/modules/_spinner.scss
@@ -6,8 +6,16 @@
 .spinner {
   display: inline-block;
   &.initial-spinner {
-    position: relative;
+    position: absolute;
     left: 49%;  // not 50% to roughly compensate for the spinner's own width
+    top: 205px;
+    color: gray;
+  }
+  &.tree-items {
+    position: absolute;
+    z-index: 1000001 !important;
+    top: 10px;
+    left: 49%;
   }
 }
 

--- a/src/ggrc/templates/layouts/base.haml
+++ b/src/ggrc/templates/layouts/base.haml
@@ -23,7 +23,8 @@
   %body
     %div{ 'class': 'page-loader'}
       %div{ 'class': 'page-loader__wrapper'}
-        %span{ 'class': 'page-loader__icon' }
+        %i{'class': 'spinner-icon spinner-size__large fa fa-spinner fa-pulse',
+           'aria-hidden': 'true'}
         %span{ 'class': 'page-loader__text' } Page is loading, please wait...
 
     -block body

--- a/src/ggrc_workflows/assets/mustache/workflows/search_result.mustache
+++ b/src/ggrc_workflows/assets/mustache/workflows/search_result.mustache
@@ -32,6 +32,7 @@
   {{/list}}
 
   {{#list.is_loading}}
-    <li class="spinny"  {{attach_spinner '{ "radius": 4, "length": 7, "width": 2 }' }}>
+    <li class="spinny">
+      <spinner toggle="list.is_loading"></spinner>
     </li>
   {{/list.is_loading}}


### PR DESCRIPTION
This PR fixes a UX inconvenience that caused users to see two spinners while waiting for the tab content to load.

The fix, however, does not remove the existing tree items loading spinner, because the latter is still useful for pagination, etc. Instead, it styles it along the tab content spinner, so that both look like a single spinner to end user.

Also, the main tree loading spinners in LHN have been updated as well, although the PR does not attempt to update each and every spinner in the app (the ticket does not mention it, nor was this mentioned in the updates). But if unifying just about every spinner out there is in scope of this PR (please confirm with somebody), then please let me know, and also update the time estimate on the ticket. Or, alternatively, make sure a separate ticket is opened for that.

---

**Precondition:**
Created program, controls, audit

**Steps to reproduce:**
  1. Go to Controls tab on audit page: confirm that created controls from precondition are displayed
  2. Refresh the page

**Actual Result:**
several different spinners are displayed while page is loading ([screencast](https://drive.google.com/file/d/0B96BGW1_MO8AcXhQeTd1cmdsY28/view))

**Expected Result:**
one spinner should be displayed while page is loading 

**Additional comment(s) on the issue:**

> Consulted with UX person - the bigger spinner should be shown - as in attach, and it should be only one - no two spinners should be shown.
Also lets change and have the same spinner on the begining when the app is loading to have the same consitent spinner.