### PR TITLE
GGRC-462 Reset not saved CAD in AT

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/modals_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/modals_controller.js
@@ -1005,6 +1005,7 @@ can.Control('GGRC.Controllers.Modals', {
   '{instance} destroyed': ' hide',
 
   ' hide': function (el, ev) {
+    var cad;
     if (this.disable_hide) {
       ev.stopImmediatePropagation();
       ev.stopPropagation();
@@ -1015,6 +1016,13 @@ can.Control('GGRC.Controllers.Modals', {
       // Ensure that this modal was hidden and not a child modal
       this.element && ev.target === this.element[0] &&
       !this.options.skip_refresh && !this.options.instance.isNew()) {
+      if (this.options.instance.type === 'AssessmentTemplate') {
+        cad = this.options.instance.attr('custom_attribute_definitions');
+        cad = _.filter(cad, function (attr) {
+          return attr.id;
+        });
+        this.options.instance.attr('custom_attribute_definitions', cad);
+      }
       this.options.instance.refresh();
     }
   },


### PR DESCRIPTION
**Steps to reproduce:**
1. Create an Assessment Template with CA "one".
2. Open the editing modal for this Assessment Template.
3. Add a CA "two", don't save.
4. Close the modal, click "discard".
5. Open the editing modal for this Assessment Template again.

_Expected result:_ only CA "one" is displayed.
_Actual result:_ CAs "one" and "two" are displayed (note that "two" doesn't exist in the DB).