### PR TITLE
GGRC-289: Fix date-related tenses in email digest

### DIFF
--- a/src/ggrc/notifications/data_handlers.py
+++ b/src/ggrc/notifications/data_handlers.py
@@ -57,7 +57,8 @@ def _get_assignable_dict(people, notif):
         notif.notification_type.name: {
             obj.id: {
                 "title": obj.title,
-                "fuzzy_start_date": utils.get_fuzzy_date(start_date),
+                "start_date_statement": utils.get_digest_date_statement(
+                    start_date, "start", True),
                 "url": get_object_url(obj),
             }
         }

--- a/src/ggrc/templates/notifications/email_digest_content.html
+++ b/src/ggrc/templates/notifications/email_digest_content.html
@@ -86,7 +86,7 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                   {% for task in digest['due_soon'].values() %}
                     <li {{ style.list_item() }} >
                       <a href="{{ task['cycle_task_url'] }}" {{ style.link_text() }} >
-                      {{ task['title'] }}</a> due {{ task['fuzzy_due_in'] }}
+                      {{ task['title'] }}</a> {{ task['due_date_statement'] }}
                       <ul>
                       {% for related_object_title in task['related_objects'] %}
                         <li>{{ "%s" % related_object_title if related_object_title }}</li>
@@ -156,7 +156,7 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                       New cycle of
                       <a href="{{ workflow['workflow_url'] }}" {{ style.link_text() }} >
                         {{ workflow['title'] }}</a>
-                      starts {{ workflow['fuzzy_start_date'] }}.
+                      {{ workflow['start_date_statement'] }}.
                     </li>
                   {% endfor %}
                   </ul>
@@ -169,10 +169,9 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                     <li {{ style.list_item() }} >
                       Assessment:
                       <a href="{{ assessment_data['url'] }}" {{ style.link_text() }} >
-                        {{ assessment_data['title'] }}
-                      </a>
-                      {% if assessment_data.get('fuzzy_start_date') %}
-                        starts {{ assessment_data['fuzzy_start_date'] }}.
+                        {{ assessment_data['title'] }}</a>
+                      {% if assessment_data.get('start_date_statement') %}
+                        {{ assessment_data['start_date_statement'] }}.
                       {% endif %}
                     </li>
                   {% endfor %}
@@ -200,10 +199,9 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                     <li {{ style.list_item() }} >
                       Request:
                       <a href="{{ request_data['url'] }}" {{ style.link_text() }} >
-                        {{ request_data['title'] }}
-                      </a>
-                      {% if request_data.get('fuzzy_start_date') %}
-                        starts {{ request_data['fuzzy_start_date'] }}.
+                        {{ request_data['title'] }}</a>
+                      {% if request_data.get('start_date_statement') %}
+                        {{ request_data['start_date_statement'] }}.
                       {% endif %}
                     </li>
                   {% endfor %}

--- a/src/ggrc/utils/__init__.py
+++ b/src/ggrc/utils/__init__.py
@@ -226,6 +226,31 @@ def get_fuzzy_date(delta_date):
   return "in {} day{}".format(delta.days, "s" if delta.days > 1 else "")
 
 
+def get_digest_date_statement(delta_date, word, is_change_tense=False):
+  """Get statement created from word in appropriate tense and readable date.
+
+  This function returns phrase created using concatenation of a word in
+  appropriate tense with human readable date value.
+
+  Args:
+    delta_date (date): Date that we want to show to the user
+    word (str): With which date should be concatenated
+    is_change_tense: Flag which shows is tense of the word should be changed
+
+  Returns:
+    string: A human readable statement, created from word and date
+            concatenation
+  """
+  fuzzy_date = get_fuzzy_date(delta_date)
+  word_end = ''
+  if is_change_tense:
+    if "in" in fuzzy_date:
+      word_end = 's'
+    else:
+      word_end = 'ed'
+  return '{}{} {}'.format(word, word_end, fuzzy_date)
+
+
 # pylint: disable=too-few-public-methods
 # because this is a small context manager
 class QueryCounter(object):

--- a/src/ggrc_workflows/notification/__init__.py
+++ b/src/ggrc_workflows/notification/__init__.py
@@ -82,7 +82,8 @@ All notifications handle the following structure:
                   "workflow_owners":
                       { workflow_owner.id: workflow_owner_info, ...},
                   "start_date": MM/DD/YYYY
-                  "fuzzy_start_date": "in X days/weeks ..."
+                  "start_date_statement": "starts in X day[s]" or
+                                          "started today|X day[s] ago"
               }
               , ...
           }
@@ -95,7 +96,8 @@ All notifications handle the following structure:
                   "workflow_owners":
                       { workflow_owner.id: workflow_owner_info, ...},
                   "start_date": MM/DD/YYYY
-                  "fuzzy_start_date": "in X days/weeks ..."
+                  "start_date_statement": "starts in X day[s]" or
+                                          "started today|X day[s] ago"
               }
               , ...
           }
@@ -150,7 +152,7 @@ Task and cycle_task have the following structure:
       "title": title,
       "object_titles": list of object titles for all related objects
       "end_date": end date in MM/DD/YYYY format
-      "fuzzy_due_in": "today" or "in 1 day"... "in 5 days", "in 1 week" etc.,
+      "due_date_statement": "due today|in X day[s]|X day[s] ago"
       "cycle_task_url" ""
   }
 

--- a/src/ggrc_workflows/notification/data_handler.py
+++ b/src/ggrc_workflows/notification/data_handler.py
@@ -254,8 +254,8 @@ def get_workflow_starts_in_data(notification, workflow):
                 "workflow_owners": workflow_owners,
                 "workflow_url": get_workflow_url(workflow),
                 "start_date": workflow.next_cycle_start_date,
-                "fuzzy_start_date": utils.get_fuzzy_date(
-                    workflow.next_cycle_start_date),
+                "start_date_statement": utils.get_digest_date_statement(
+                    workflow.next_cycle_start_date, "start", True),
                 "custom_message": workflow.notify_custom_message,
                 "title": workflow.title,
             }
@@ -286,8 +286,8 @@ def get_cycle_start_failed_data(notification, workflow):
                 "workflow_owners": workflow_owners,
                 "workflow_url": get_workflow_url(workflow),
                 "start_date": workflow.next_cycle_start_date,
-                "fuzzy_start_date": utils.get_fuzzy_date(
-                    workflow.next_cycle_start_date),
+                "start_date_statement": utils.get_digest_date_statement(
+                    workflow.next_cycle_start_date, "start", True),
                 "custom_message": workflow.notify_custom_message,
                 "title": workflow.title,
             }
@@ -386,7 +386,8 @@ def get_cycle_task_dict(cycle_task):
       "title": cycle_task.title,
       "related_objects": object_titles,
       "end_date": cycle_task.end_date.strftime("%m/%d/%Y"),
-      "fuzzy_due_in": utils.get_fuzzy_date(cycle_task.end_date),
+      "due_date_statement": utils.get_digest_date_statement(
+          cycle_task.end_date, "due"),
       "cycle_task_url": get_cycle_task_url(cycle_task, filter_exp=filter_exp),
   }
 


### PR DESCRIPTION
**Subject:** the daily digest says the request "starts 1 day ago"
**Details:**   
The daily digest sends weirdly formatted message mixing tenses.
**Actual Result:** the daily digest says the request "starts 1 day ago"
**Expected Result:** the daily digest should say the request "started 1 day ago"
**Workaround:** NA