### PR TITLE
GGRC-452 Add refetch url hash option. Fix assessment templates are not refreshed.

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
@@ -303,18 +303,26 @@
     },
 
     route: function (path) {
+      var refetchMatches;
+      var refetch = false;
       if (path.substr(0, 2) === '#!') {
         path = path.substr(2);
       } else if (path.substr(0, 1) === '#') {
         path = path.substr(1);
       }
+      refetchMatches = path.match(/&refetch|^refetch$/);
+
+      if (refetchMatches && refetchMatches.length === 1) {
+        path = path.replace(refetchMatches[0], '');
+        refetch = true;
+      }
 
       window.location.hash = path;
 
-      this.display_path(path.length ? path : 'Summary_widget');
+      this.display_path(path.length ? path : 'Summary_widget', refetch);
     },
 
-    display_path: function (path) {
+    display_path: function (path, refetch) {
       var step = path.split('/')[0];
       var rest = path.substr(step.length + 1);
       var widgetList = this.options.widget_list;
@@ -327,18 +335,18 @@
       }
       if (widget) {
         this.set_active_widget(widget);
-        return this.display_widget_path(rest);
+        return this.display_widget_path(rest, refetch);
       }
       return new $.Deferred().resolve();
     },
 
-    display_widget_path: function (path) {
+    display_widget_path: function (path, refetch) {
       var activeWidgetSelector = this.options.contexts.active_widget.selector;
       var $activeWidget = $(activeWidgetSelector);
       var widgetController = $activeWidget.control();
 
       if (widgetController && widgetController.display_path) {
-        return widgetController.display_path(path);
+        return widgetController.display_path(path, refetch);
       }
       return new $.Deferred().resolve();
     },

--- a/src/ggrc/assets/javascripts/controllers/dashboard_widgets_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/dashboard_widgets_controller.js
@@ -148,11 +148,11 @@ CMS.Controllers.Filterable("CMS.Controllers.DashboardWidgets", {
     this.options.widget_count.attr("count", "" + count);
   }
 
-  , display_path: function(path) {
+  , display_path: function(path, refetch) {
       var that = this;
       return this.display().then(function() {
         if (that.content_controller && that.content_controller.display_path)
-          return that.content_controller.display_path(path);
+          return that.content_controller.display_path(path, refetch);
       });
     }
 });

--- a/src/ggrc/assets/javascripts/controllers/modals_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/modals_controller.js
@@ -1157,6 +1157,14 @@
         return;
       }
 
+      if (this.options.instance.getHashFragment) {
+        hash = this.options.instance.getHashFragment();
+        if (hash) {
+          window.location.hash = hash;
+          return;
+        }
+      }
+
       hash = window.location.hash.split('/')[0];
       treeController = this.options
         .$trigger

--- a/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/tree_view_controller.js
@@ -162,7 +162,7 @@ can.Control.extend('CMS.Controllers.TreeLoader', {
     }
   },
 
-  display: function () {
+  display: function (refetch) {
     var that = this;
     var tracker_stop = GGRC.Tracker.start(
           'TreeView', 'display', this.options.model.shortName);
@@ -175,6 +175,9 @@ can.Control.extend('CMS.Controllers.TreeLoader', {
         this.fetch_list.bind(this) : this.loadPage.bind(this);
 
     if (this._display_deferred) {
+      if (refetch) {
+        return loader();
+      }
       return this._display_deferred;
     }
 
@@ -803,8 +806,8 @@ CMS.Controllers.TreeLoader.extend('CMS.Controllers.TreeView', {
     return this.find_all_deferred;
   },
 
-  display_path: function (path) {
-    return this.display().then(this._ifNotRemoved(function () {
+  display_path: function (path, refetch) {
+    return this.display(refetch).then(this._ifNotRemoved(function () {
       return _display_tree_subpath(this.element, path);
     }.bind(this)));
   },

--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -453,7 +453,7 @@
 
     after_save: function () {
       if (this.audit) {
-        this.audit.reify().refresh('related_assessment_templates');
+        this.audit.reify().refresh();
       }
     },
 
@@ -641,6 +641,19 @@
       });
 
       return objectTypes;
+    },
+
+    getHashFragment: function () {
+      var widgetName = this.constructor.table_singular;
+      if (window.location.hash
+          .startsWith(['#', widgetName, '_widget'].join(''))) {
+        return;
+      }
+
+      return [widgetName,
+              '_widget/',
+              this.hash_fragment(),
+              '&refetch'].join('');
     },
     ignore_ca_errors: true
   });


### PR DESCRIPTION
This PR adds an ability to re-fetch objects list based on the url hash flag.
This allows to redirect user by url from object creation modal dialogs to the objects list + refreshing it to get actual list state.
Fixes assessment templates are not refreshed after adding assessment template from info widget tab.