### PR TITLE
GGRC-607 Make user_role.context_id a FK

### DIFF
--- a/src/ggrc_basic_permissions/migrations/versions/20161209093634_89d8ca4c1267_make_user_roles_context_id_a_fk.py
+++ b/src/ggrc_basic_permissions/migrations/versions/20161209093634_89d8ca4c1267_make_user_roles_context_id_a_fk.py
@@ -1,0 +1,32 @@
+# Copyright (C) 2016 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Make user_roles.context_id a FK
+
+Create Date: 2016-12-09 09:36:34.286793
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "89d8ca4c1267"
+down_revision = "4e105fc39b25"
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  op.execute("""
+      delete from user_roles where context_id not in (select id from contexts)
+  """)
+  op.create_foreign_key("fk_user_roles_contexts", "user_roles", "contexts",
+                        ["context_id"], ["id"])
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  op.drop_constraint("fk_user_roles_contexts", "user_roles",
+                     type_="foreignkey")


### PR DESCRIPTION
This PR removes the context-less roles from the DB (since they can't be reused any more) and adds a FK constraint on `context_id`.

This migration doesn't conflict with Alembic upgrade and migration conflict PRs.