### PR TITLE
QUICK-FIX Remove handle_relationship_post

### DIFF
--- a/bin/run_integration
+++ b/bin/run_integration
@@ -15,4 +15,4 @@ export GGRC_SETTINGS_MODULE="testing \
 db_migrate
 
 echo -e "\nRunning integration tests"
-nosetests integration --with-xunit --logging-clear-handlers ${@:1}
+nosetests integration --with-xunit --logging-clear-handlers -v ${@:1}

--- a/test/integration/ggrc/automapper/test_automappings.py
+++ b/test/integration/ggrc/automapper/test_automappings.py
@@ -308,33 +308,6 @@ class TestAutomappings(integration.ggrc.TestCase):
                  (control, section)],
     )
 
-  def test_automapping_request_audit(self):
-    _, creator = self.gen.generate_person(user_role="Creator")
-    program = self.create_object(models.Program, {
-        'title': make_name('Program')
-    })
-    audit = self.create_object(models.Audit, {
-        'title': make_name('Audit'),
-        'program': {'id': program.id},
-        'status': 'Planned',
-    })
-    control = self.create_object(models.Control, {
-        'title': make_name('Test control')
-    })
-    self.create_mapping(audit, control)
-    request = self.create_object(models.Request, {
-        'audit': {'id': audit.id},
-        'title': make_name('Request'),
-        'assignee': {'id': creator.id},
-        'request_type': 'documentation',
-        'status': 'Not Started',
-        'start_date': '1/1/2015',
-        'end_date': '1/1/2016',
-    })
-    self.assert_mapping(request, program)
-    self.assert_mapping(request, audit, missing=True)
-    self.assert_mapping(request, control, missing=True)
-
   def test_automapping_control_assesment(self):
     program = self.create_object(models.Program, {
         'title': make_name('Program')


### PR DESCRIPTION
This function was causing a warning in our integration tests.
After some discussion and investigations we concluded that
creating automappings between Audit - Program - Request
is no longer necessary and all handlers need to be removed.

This PR was based on @zidarsk8 comments here https://github.com/google/ggrc-core/pull/4782#issuecomment-265856159.