### PR TITLE
GGRC-398 Show a zero in a tab if object count not available

### DIFF
--- a/src/ggrc/assets/mustache/dashboard/internav_list.mustache
+++ b/src/ggrc/assets/mustache/dashboard/internav_list.mustache
@@ -18,9 +18,9 @@
         <i class="fa fa-{{ internav_icon }} color"></i>
         {{#if show_title}}
           {{internav_display}}
-          {{#has_count}}({{count}}{{#spinner}}...{{/spinner}}){{/has_count}}
+          {{#has_count}}({{firstnonempty count 0}}){{/has_count}}
         {{else}}
-          {{#has_count}}{{count}}{{#spinner}}...{{/spinner}}{{/has_count}}
+          {{#has_count}}{{firstnonempty count 0}}{{/has_count}}
         {{/if}}
         {{^count}}{{#has_count}}
           {{^instance.constructor.obj_nav_options.show_all_tabs}}


### PR DESCRIPTION
This PR (probably) solves an issue with the object count missing in HNB (i.e. just an empty pair of parentheses is displayed).

The issue is difficult to reproduce, but it seems that it can only occur when the object count is zero, thus we simply display a zero by default. The ellipsis placeholder has been removed, because it seems like it is not used anywhere anymore (at least I haven't seen it for a long  time now).

---

**Steps to reproduce (if lucky :smile: ):**
  1. Create a program
  2. Create an Audit
  3. Go to Audit page
  4. Look at HNB

**Actual Result:**
Objects tabs are displayed without numbers in brackets at Audit tab

**Expected Result:**
Objects tabs are displayed with numbers in brackets at Audit tab
