### PR TITLE
GGRC-366 Fix min/max date after change value in datepicker

### DIFF
--- a/src/ggrc/assets/javascripts/components/datepicker/datepicker.js
+++ b/src/ggrc/assets/javascripts/components/datepicker/datepicker.js
@@ -86,6 +86,7 @@
           }
         };
         if (!date) {
+          this.scope.picker.datepicker('option', type, null);
           return;
         }
         date = moment(date);
@@ -108,6 +109,7 @@
       },
       '{scope} _date': function (scope, ev, val) {
         scope.attr('date', val);
+        scope.picker.datepicker('setDate', val);
       },
       '{window} mousedown': function (el, ev) {
         var isInside;


### PR DESCRIPTION
**Details**: 
Click +Create New to create new program
Select Effective date and then Stop date
Delete value from Effective date field
Click on Stop Date field

_Actual Result_: We still have the restriction in 'minDate'
_Expected Result_: We shouldn't have the restriction  in 'minDate' or 'maxDate' if sibling field is empty