### PR TITLE
QUICK-FIX Add logging warnings for missing revisions

### DIFF
--- a/src/ggrc/snapshotter/__init__.py
+++ b/src/ggrc/snapshotter/__init__.py
@@ -8,6 +8,7 @@ snapshot object represent a join between parent object (Audit),
 child object (e.g. Control, Regulation, ...) and a particular revision.
 """
 
+from logging import getLogger
 
 from sqlalchemy.sql.expression import tuple_
 from sqlalchemy.sql.expression import bindparam
@@ -31,6 +32,8 @@ from ggrc.snapshotter.helpers import get_snapshots
 from ggrc.snapshotter.indexer import reindex_pairs
 
 from ggrc.snapshotter.rules import get_rules
+
+logger = getLogger(__name__)  # pylint: disable=invalid-name
 
 
 class SnapshotGenerator(object):
@@ -213,6 +216,11 @@ class SnapshotGenerator(object):
           else:
             missed_keys.add(key)
 
+      if missed_keys:
+        logger.warning(
+            "Tried to update snapshots for the following objects but "
+            "found no revisions: %s", missed_keys)
+
       if not modified_snapshot_keys:
         return OperationResponse("update", True, set(), response_data)
 
@@ -372,6 +380,11 @@ class SnapshotGenerator(object):
             data_payload += [data]
           else:
             missed_keys.add(pair)
+
+      if missed_keys:
+        logger.warning(
+            "Tried to create snapshots for the following objects but "
+            "found no revisions: %s", missed_keys)
 
       with benchmark("Snapshot._create.write to database"):
         self._execute(

--- a/src/ggrc/snapshotter/helpers.py
+++ b/src/ggrc/snapshotter/helpers.py
@@ -20,6 +20,9 @@ logger = getLogger(__name__)  # pylint: disable=invalid-name
 def get_revisions(pairs, revisions, filters=None):
   """Retrieve revision ids for pairs
 
+  If revisions dictionary is provided it will validate that the selected
+  revision exists in the objects revision history.
+
   Args:
     pairs: set([(parent_1, child_1), (parent_2, child_2), ...])
     revisions: dict({(parent, child): revision_id, ...})

--- a/src/ggrc/snapshotter/helpers.py
+++ b/src/ggrc/snapshotter/helpers.py
@@ -4,7 +4,7 @@
 """Various simple helper functions for snapshot generator"""
 
 import collections
-
+from logging import getLogger
 
 from sqlalchemy.sql.expression import tuple_
 
@@ -13,6 +13,8 @@ from ggrc import models
 from ggrc.snapshotter.datastructures import Stub
 from ggrc.snapshotter.datastructures import Pair
 from ggrc.utils import benchmark
+
+logger = getLogger(__name__)  # pylint: disable=invalid-name
 
 
 def get_revisions(pairs, revisions, filters=None):
@@ -56,6 +58,10 @@ def get_revisions(pairs, revisions, filters=None):
             if key in revisions:
               if revid == revisions[key]:
                 revision_id_cache[key] = revid
+              else:
+                logger.warning(
+                    "Specified revision for object %s but couldn't find the"
+                    "revision '%s' in object history", key, revisions[key])
             else:
               if key not in revision_id_cache:
                 revision_id_cache[key] = revid


### PR DESCRIPTION
A bit overdue task from my TODO - marking as `critical` because it would be really nice to know when there are missing revisions in production.