### PR TITLE
GGRC-614 Assessment generation modal must also show only in scope objects

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment_generator.js
+++ b/src/ggrc/assets/javascripts/components/assessment_generator.js
@@ -114,7 +114,12 @@
         var data = {
           _generated: true,
           audit: this.scope.audit,
-          object: object.stub(),
+          // Provide actual Snapshot Object for Assessment
+          object: {
+            id: object.id,
+            type: 'Snapshot',
+            href: object.selfLink
+          },
           context: this.scope.audit.context,
           template: assessmentTemplate && assessmentTemplate.stub(),
           title: title

--- a/src/ggrc/assets/javascripts/components/unified_mapper/mapper.js
+++ b/src/ggrc/assets/javascripts/components/unified_mapper/mapper.js
@@ -38,8 +38,10 @@
     init: function () {
       this.attr('types', this.initTypes());
       this.attr('parentInstance', this.initInstance());
-      this.attr('isInScopeObject',
-        GGRC.Utils.Snapshots.isInScopeModel(this.attr('object')));
+      this.attr('useSnapshots',
+        GGRC.Utils.Snapshots.isInScopeModel(this.attr('object')) ||
+        // Assessment generation should use Snapshot Objects
+        this.attr('assessmentGenerator'));
     },
     type: 'AllObject', // We set default as All Object
     warningMessage: warningMessage,
@@ -66,7 +68,7 @@
     snapshot_scope_id: '',
     snapshot_scope_type: '',
     parentInstance: null,
-    isInScopeObject: false,
+    useSnapshots: false,
     allowedToCreate: function () {
       var isAllTypeSelected = this.attr('type') === 'AllObject';
       var isSearch = this.attr('search_only');
@@ -76,6 +78,10 @@
       return !isAllTypeSelected && !isSearch && !isInScopeModel;
     },
     showWarning: function () {
+      // In case we generate assessments this should be false no matter what objects should be mapped to assessments
+      if (this.attr('assessmentGenerator')) {
+        return false;
+      }
       return !(GGRC.Mappings
         .canBeMappedDirectly(this.attr('type'), this.attr('object')));
     },

--- a/src/ggrc/assets/mustache/modals/mapper/base.mustache
+++ b/src/ggrc/assets/mustache/modals/mapper/base.mustache
@@ -84,7 +84,7 @@
   {{/if}}
     <search-toolbar class="flex-box search-toolbar flex-box-multi"></search-toolbar>
 </div>
-{{#if mapper.isInScopeObject}}
+{{#if mapper.useSnapshots}}
     <snapshot-loader
             class="snapshot-list"
             base-instance="mapper.parentInstance"

--- a/src/ggrc/models/hooks/assessment.py
+++ b/src/ggrc/models/hooks/assessment.py
@@ -120,14 +120,15 @@ def get_value(people_group, audit, obj, template=None):
     return None
 
   types = {
-      "Object Owners": [
-          owner.person for owner in getattr(obj, 'object_owners', None)
-      ],
+      # Should be updated by someone (hope Miha will assist :)) to setup correct data for generated assessment
+      # "Object Owners": [
+      #    owner.person for owner in getattr(obj, 'object_owners', None)
+      # ],
+      # "Primary Contact": getattr(obj, 'contact', None),
+      # "Secondary Contact": getattr(obj, 'secondary_contact', None),
+      # "Primary Assessor": getattr(obj, 'principal_assessor', None),
+      # "Secondary Assessor": getattr(obj, 'secondary_assessor', None),
       "Audit Lead": getattr(audit, 'contact', None),
-      "Primary Contact": getattr(obj, 'contact', None),
-      "Secondary Contact": getattr(obj, 'secondary_contact', None),
-      "Primary Assessor": getattr(obj, 'principal_assessor', None),
-      "Secondary Assessor": getattr(obj, 'secondary_assessor', None),
   }
   people = template.default_people.get(people_group)
   if not people:


### PR DESCRIPTION
The audit generation modal must only search and display snapshotted objects, in the same way as the mapper modal when trying to map to an assessment.

**Additional modification of back-end is required to correctly generate assessments with snapshots**