### PR TITLE
GGRC-614 Assessment generation with inscope objects

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment_generator.js
+++ b/src/ggrc/assets/javascripts/components/assessment_generator.js
@@ -114,7 +114,12 @@
         var data = {
           _generated: true,
           audit: this.scope.audit,
-          object: object.stub(),
+          // Provide actual Snapshot Object for Assessment
+          object: {
+            id: object.id,
+            type: 'Snapshot',
+            href: object.selfLink
+          },
           context: this.scope.audit.context,
           template: assessmentTemplate && assessmentTemplate.stub(),
           title: title

--- a/src/ggrc/assets/javascripts/components/assessment_generator.js
+++ b/src/ggrc/assets/javascripts/components/assessment_generator.js
@@ -27,6 +27,7 @@
           useTemplates: true,
           assessmentGenerator: true,
           relevantTo: [{
+            readOnly: true,
             type: instance.type,
             id: instance.id
           }],

--- a/src/ggrc/assets/javascripts/components/relevant_filters.js
+++ b/src/ggrc/assets/javascripts/components/relevant_filters.js
@@ -69,6 +69,7 @@
         can.each(this.scope.attr('relevantTo') || [], function (item) {
           var model = CMS.Models[item.type].cache[item.id];
           this.scope.attr('relevant').push({
+            readOnly: item.readOnly,
             value: true,
             filter: model,
             menu: this.scope.attr('menu'),

--- a/src/ggrc/assets/javascripts/components/unified_mapper/mapper.js
+++ b/src/ggrc/assets/javascripts/components/unified_mapper/mapper.js
@@ -38,8 +38,10 @@
     init: function () {
       this.attr('types', this.initTypes());
       this.attr('parentInstance', this.initInstance());
-      this.attr('isInScopeObject',
-        GGRC.Utils.Snapshots.isInScopeModel(this.attr('object')));
+      this.attr('useSnapshots',
+        GGRC.Utils.Snapshots.isInScopeModel(this.attr('object')) ||
+        // Assessment generation should use Snapshot Objects
+        this.attr('assessmentGenerator'));
     },
     type: 'AllObject', // We set default as All Object
     warningMessage: warningMessage,
@@ -66,7 +68,7 @@
     snapshot_scope_id: '',
     snapshot_scope_type: '',
     parentInstance: null,
-    isInScopeObject: false,
+    useSnapshots: false,
     allowedToCreate: function () {
       var isAllTypeSelected = this.attr('type') === 'AllObject';
       var isSearch = this.attr('search_only');
@@ -76,6 +78,10 @@
       return !isAllTypeSelected && !isSearch && !isInScopeModel;
     },
     showWarning: function () {
+      // In case we generate assessments this should be false no matter what objects should be mapped to assessments
+      if (this.attr('assessmentGenerator')) {
+        return false;
+      }
       return !(GGRC.Mappings
         .canBeMappedDirectly(this.attr('type'), this.attr('object')));
     },

--- a/src/ggrc/assets/mustache/mapper/relevant_filter.mustache
+++ b/src/ggrc/assets/mustache/mapper/relevant_filter.mustache
@@ -6,13 +6,17 @@
 <h6>Filter by mapping</h6>
 {{#each relevant}}
   <div class="single-line-filter">
-    <button type="submit" data-index="{{@index}}" class="remove_filter">
-      <i class="fa fa-trash"></i>
-    </button>
+    {{^readOnly}}
+      <button type="submit" data-index="{{@index}}" class="remove_filter">
+        <i class="fa fa-trash"></i>
+      </button>
+    {{/readOnly}}
     <label>
       {{#if @index}}AND {{/if}}Mapped to:
     </label>
-    <select class="input-small filter-type-selector select-filter{{@index}}" can-value="model_name">
+    <select class="input-small filter-type-selector select-filter{{@index}}"
+            {{#readOnly}}disabled="disabled"{{/readOnly}}
+            can-value="model_name">
       {{#menu}}
         {{#if model_singular}}<option value="{{model_singular}}" label="{{title_singular}}"></option>{{/if}}
       {{/menu}}
@@ -24,6 +28,7 @@
         {{#model_name}}
         <div class="modal-search objective-selector">
           <input
+            {{#readOnly}}disabled="disabled"{{/readOnly}}
             class="input-large search-icon search-filter-{{@index}}"
             placeholder="Enter text to search for {{model_name}}"
             type="text"
@@ -41,5 +46,7 @@
   </div>
 {{/each}}
 <div class="add-rule">
-  <a href="javascript://" can-click="addFilter" class="add-filter-rule">+ Add New Rule</a>
+  {{^readOnly}}
+     <a href="javascript://" can-click="addFilter" class="add-filter-rule">+ Add New Rule</a>
+  {{/readOnly}}
 </div>

--- a/src/ggrc/assets/mustache/modals/mapper/base.mustache
+++ b/src/ggrc/assets/mustache/modals/mapper/base.mustache
@@ -84,7 +84,7 @@
   {{/if}}
     <search-toolbar class="flex-box search-toolbar flex-box-multi"></search-toolbar>
 </div>
-{{#if mapper.isInScopeObject}}
+{{#if mapper.useSnapshots}}
     <snapshot-loader
             class="snapshot-list"
             base-instance="mapper.parentInstance"

--- a/src/ggrc/models/hooks/assessment.py
+++ b/src/ggrc/models/hooks/assessment.py
@@ -121,13 +121,17 @@ def get_value(people_group, audit, obj, template=None):
 
   types = {
       "Object Owners": [
-          owner.person for owner in getattr(obj, 'object_owners', None)
+          get_by_id(owner)
+          for owner in obj.revision.content.get("owners", [])
       ],
-      "Audit Lead": getattr(audit, 'contact', None),
-      "Primary Contact": getattr(obj, 'contact', None),
-      "Secondary Contact": getattr(obj, 'secondary_contact', None),
-      "Primary Assessor": getattr(obj, 'principal_assessor', None),
-      "Secondary Assessor": getattr(obj, 'secondary_assessor', None),
+      "Audit Lead": getattr(audit, "contact", None),
+      "Primary Contact": get_by_id(obj.revision.content.get("contact")),
+      "Secondary Contact": get_by_id(
+          obj.revision.content.get("secondary_contact")),
+      "Primary Assessor": get_by_id(
+          obj.revision.content.get("principal_assessor")),
+      "Secondary Assessor": get_by_id(
+          obj.revision.content.get("secondary_assessor")),
   }
   people = template.default_people.get(people_group)
   if not people:

--- a/test/unit/ggrc/models/hooks/test_assessment.py
+++ b/test/unit/ggrc/models/hooks/test_assessment.py
@@ -40,6 +40,7 @@ class GetValueTestCase(unittest.TestCase):
     ]
 
     self.related_object = MagicMock(name="assessment_1")
+    self.related_object.revision.content = {}
 
   # pylint: disable=invalid-name
   def test_returns_auditors_as_default_assessors_when_no_template(


### PR DESCRIPTION
This is an expension of https://github.com/google/ggrc-core/pull/4838.

This PR makes the audit relevant filter read only, because removing the relevant filter makes no sense and it actualy causes the fronend to send an invalid query.
The frontend creates an invalid query if there is no additional filter specified (text filter or relevant filter) so making the relevant filter as read only is the best quick fix for that since we already discussed this with the UX people.

Second thing this PR does is fixing the default people lists specified in the template. Please note that if the values are missing in the snapshot, they will also be missing here, but that might be a bug in the revisions code and not in the setter for default people.

@andrei-karalionak I have cherry-picked your commit into this PR  rather than merging your PR and continuing here, because your last commit does not pass the lint tests. If you wish you can close your pr (https://github.com/google/ggrc-core/pull/4838) and we'll have someone merge this, or you can remove the last commit from your PR, I'll merge it and then I'll rebase these three commits.