### PR TITLE
QUICK-FIX Fix migration chain on develop

### DIFF
--- a/src/ggrc/migrations/versions/20160728140921_2a5a39600741_add_snapshot_model.py
+++ b/src/ggrc/migrations/versions/20160728140921_2a5a39600741_add_snapshot_model.py
@@ -15,7 +15,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "2a5a39600741"
-down_revision = "4afe69ce3c38"
+down_revision = "1f5c3e0025da"
 
 
 def upgrade():

--- a/src/ggrc/migrations/versions/20161123124848_1f5c3e0025da_remove_control_id_column_from_.py
+++ b/src/ggrc/migrations/versions/20161123124848_1f5c3e0025da_remove_control_id_column_from_.py
@@ -17,7 +17,7 @@ from sqlalchemy.sql import table, column
 
 # revision identifiers, used by Alembic.
 revision = '1f5c3e0025da'
-down_revision = '2a5a39600741'
+down_revision = '4afe69ce3c38'
 
 
 def upgrade():


### PR DESCRIPTION
The develop branch should only add migrations on top of any chain that
has already been deployed.