### PR TITLE
GGRC-447 Relavant objects for snapshots tests

### DIFF
--- a/src/ggrc/models/mixins/with_similarity_score.py
+++ b/src/ggrc/models/mixins/with_similarity_score.py
@@ -245,6 +245,8 @@ class WithSimilarityScore(object):
             related_to_similar,
             and_(related_id_case == related_to_similar.source_id,
                  related_type_case == related_to_similar.source_type),
+        ).filter(
+            related_to_similar.source_type != "Snapshot"
         ),
         db.session.query(
             related_type_case,
@@ -254,7 +256,9 @@ class WithSimilarityScore(object):
             related_to_similar,
             and_(related_id_case == related_to_similar.destination_id,
                  related_type_case == related_to_similar.destination_type),
-        ),
+        ).filter(
+            related_to_similar.destination_type != "Snapshot"
+        )
     ]
 
   @classmethod

--- a/src/ggrc/models/mixins/with_similarity_score.py
+++ b/src/ggrc/models/mixins/with_similarity_score.py
@@ -74,7 +74,7 @@ class WithSimilarityScore(object):
     # find "similar" objects when Relationship table is not used
     queries_for_union += cls._emulate_relationships(id_, types, relevant_types)
 
-    joined = queries_for_union.pop().union(*queries_for_union).subquery()
+    joined = queries_for_union.pop().union_all(*queries_for_union).subquery()
 
     # define weights for every "related" object type with values from
     # relevant_types dict

--- a/src/ggrc/models/mixins/with_similarity_score.py
+++ b/src/ggrc/models/mixins/with_similarity_score.py
@@ -179,25 +179,29 @@ class WithSimilarityScore(object):
 
     return [
         db.session.query(
-            right_relationship.source_type.label("similar_type"),
+            right_snapshot_join.c.right_snapshot_child_type.label(
+                "related_type"),
             right_relationship.source_id.label("similar_id"),
-            right_snapshot.child_type.label("related_type"),
+            right_relationship.source_type.label("similar_type"),
         ).filter(
             and_(
                 right_relationship.destination_type == "Snapshot",
                 right_relationship.destination_id ==
                 right_snapshot_join.c.right_snapshot_id,
+                right_relationship.source_type == cls.__name__
             )
         ),
         db.session.query(
-            right_relationship.destination_type.label("similar_type"),
+            right_snapshot_join.c.right_snapshot_child_type.label(
+                "related_type"),
             right_relationship.destination_id.label("similar_id"),
-            right_snapshot.child_type.label("related_type"),
+            right_relationship.destination_type.label("similar_type"),
         ).filter(
             and_(
                 right_relationship.source_type == "Snapshot",
                 right_relationship.source_id ==
                 right_snapshot_join.c.right_snapshot_id,
+                right_relationship.destination_type == cls.__name__
             )
         )
     ]

--- a/test/integration/ggrc/models/mixins/test_with_similarity_score.py
+++ b/test/integration/ggrc/models/mixins/test_with_similarity_score.py
@@ -4,36 +4,27 @@
 """Integration tests for WithSimilarityScore logic."""
 
 import json
-from nose.plugins.skip import SkipTest
 
+from ggrc import db
 from ggrc.models import Assessment
 from ggrc.models import Request
+import ggrc.models as models
+from ggrc.snapshotter.rules import Types
+
+
 import integration.ggrc
+import integration.ggrc.generator
 from integration.ggrc.models import factories
 
 
 # pylint: disable=super-on-old-class; TestCase is a new-style class
 class TestWithSimilarityScore(integration.ggrc.TestCase):
   """Integration test suite for WithSimilarityScore functionality."""
-
   def setUp(self):
     super(TestWithSimilarityScore, self).setUp()
+    self.obj_gen = integration.ggrc.generator.ObjectGenerator()
+
     self.client.get("/login")
-
-    self.assessment = factories.AssessmentFactory()
-    self.audit = factories.AuditFactory()
-    self.control = factories.ControlFactory()
-    self.regulation = factories.RegulationFactory()
-
-    self.make_relationships(
-        self.assessment, (
-            self.audit,
-            self.control,
-            self.regulation,
-        ),
-    )
-
-    self.other_assessments, self.id_weight_map = self.make_assessments()
 
   @staticmethod
   def make_relationships(source, destinations):
@@ -43,7 +34,25 @@ class TestWithSimilarityScore(integration.ggrc.TestCase):
           destination=destination,
       )
 
-  def make_assessments(self):
+  @staticmethod
+  def get_object_snapshot(scope_parent, object_):
+    # pylint: disable=protected-access
+    return db.session.query(models.Snapshot).filter(
+        models.Snapshot.parent_type == scope_parent._inflector.table_singular,
+        models.Snapshot.parent_id == scope_parent.id,
+        models.Snapshot.child_type == object_._inflector.table_singular,
+        models.Snapshot.child_id == object_.id
+    ).one()
+
+  def make_scope_relationships(self, source, scope_parent, objects):
+    """Create relationships between object and snapshots of provided object"""
+    snapshots = []
+    for object_ in objects:
+      snapshot = self.get_object_snapshot(scope_parent, object_)
+      snapshots += [snapshot]
+    self.make_relationships(source, snapshots)
+
+  def make_assessments(self, assessment_mappings):
     """Create six assessments and map them to audit, control, regulation.
 
     Each of the created assessments is mapped to its own subset of {audit,
@@ -52,40 +61,18 @@ class TestWithSimilarityScore(integration.ggrc.TestCase):
     Returns: the six generated assessments and their weights in a dict.
     """
 
-    assessment_mappings = (
-        (self.audit,),
-        (self.control,),
-        (self.regulation,),
-        (self.audit, self.control),
-        (self.audit, self.regulation),
-        (self.control, self.regulation),
-        (self.audit, self.control, self.regulation),
-    )
-    weights = (5, 10, 3, 15, 8, 13, 18)
-
     assessments = [factories.AssessmentFactory()
                    for _ in range(len(assessment_mappings))]
-    for assessment, mappings in zip(assessments, assessment_mappings):
-      self.make_relationships(assessment, mappings)
+    for assessment, all_mappings in zip(assessments, assessment_mappings):
+      audit = [x for x in all_mappings if x.type == "Audit"][0]
+      mappings = all_mappings[1:]
+      ordinary_mappings = [x for x in mappings if x.type not in Types.all]
+      snapshot_mappings = [x for x in mappings if x.type in Types.all]
+      self.make_relationships(assessment, [audit] + ordinary_mappings)
+      self.make_scope_relationships(assessment, audit,
+                                    snapshot_mappings)
 
-    id_weight_map = {assessment.id: weight
-                     for assessment, weight in zip(assessments, weights)}
-
-    return assessments, id_weight_map
-
-  @SkipTest
-  def test_get_similar_objects_weights(self):  # pylint: disable=invalid-name
-    """Check weights counted for similar objects."""
-    similar_objects = Assessment.get_similar_objects_query(
-        id_=self.assessment.id,
-        types=["Assessment"],
-        threshold=0,  # to include low weights too
-    ).all()
-
-    # casting to int from Decimal to prettify the assertion method output
-    id_weight_map = {obj.id: int(obj.weight) for obj in similar_objects}
-
-    self.assertDictEqual(id_weight_map, self.id_weight_map)
+    return assessments
 
   def test_similarity_for_request(self):
     """Check special case for similarity for Request by Audit."""
@@ -132,15 +119,58 @@ class TestWithSimilarityScore(integration.ggrc.TestCase):
         {("Assessment", self.assessment.id, 18)}.union(other_assessments),
     )
 
-  @SkipTest
-  def test_get_similar_objects(self):
-    """Check similar objects manually and via Query API."""
-    similar_objects = Assessment.get_similar_objects_query(
-        id_=self.assessment.id,
+  def test_get_similar_basic(self):
+    """Basic check of similar objects manually and via Query API.
+
+    We create two programs, map them to the same control, create two audits
+    and verify that we get the same result manually and via Query API.
+    """
+    program_1 = factories.ProgramFactory(title="Program 1")
+    program_2 = factories.ProgramFactory(title="Program 2")
+
+    control_program_1 = factories.ControlFactory(title="Control 1")
+
+    self.make_relationships(
+        program_1, [
+            control_program_1,
+        ],
+    )
+
+    self.make_relationships(
+        program_2, [
+            control_program_1,
+        ],
+    )
+
+    program_1 = models.Program.query.filter_by(title="Program 1").one()
+    program_2 = models.Program.query.filter_by(title="Program 2").one()
+    control_program_1 = models.Control.query.filter_by(title="Control 1").one()
+
+    _, audit_1 = self.obj_gen.generate_object(models.Audit, {
+        "title": "Audit 1",
+        "program": {"id": program_1.id},
+        "status": "Planned"
+    })
+
+    _, audit_2 = self.obj_gen.generate_object(models.Audit, {
+        "title": "Audit 2",
+        "program": {"id": program_2.id},
+        "status": "Planned"
+    })
+
+    assessment_mappings = [
+        [audit_1, control_program_1],
+        [audit_2, control_program_1],
+    ]
+
+    assessment_1, assessment_2 = self.make_assessments(assessment_mappings)
+
+    similar_objects = models.Assessment.get_similar_objects_query(
+        id_=assessment_1.id,
         types=["Assessment"],
     ).all()
-    expected_ids = {id_ for id_, weight in self.id_weight_map.items()
-                    if weight >= Assessment.similarity_options["threshold"]}
+
+    expected_ids = {assessment_2.id}
 
     self.assertSetEqual(
         {obj.id for obj in similar_objects},
@@ -154,7 +184,7 @@ class TestWithSimilarityScore(integration.ggrc.TestCase):
             "expression": {
                 "op": {"name": "similar"},
                 "object_name": "Assessment",
-                "ids": [str(self.assessment.id)],
+                "ids": [str(assessment_1.id)],
             },
         },
     }]
@@ -168,22 +198,102 @@ class TestWithSimilarityScore(integration.ggrc.TestCase):
         expected_ids,
     )
 
-  @SkipTest
-  def test_sort_by_similarity(self):
-    """Check sorting by __similarity__ value with query API."""
-    expected_ids = [id_ for id_, weight in sorted(self.id_weight_map.items(),
-                                                  key=lambda item: item[1])
-                    if weight >= Assessment.similarity_options["threshold"]]
+  def test_similar_partially_matching(self):
+    """Basic check of similar objects manually and via Query API.
+
+    We create three programs, map one them to the two regulations, create two
+    audits and verify that we get the same result manually and via Query API.
+
+    We also ensure that for only single matching regulation we do not
+    fetch that assessment is as related.
+    """
+
+    # pylint: disable=too-many-locals
+
+    program_1 = factories.ProgramFactory(title="Program 1")
+    program_2 = factories.ProgramFactory(title="Program 2")
+    program_3 = factories.ProgramFactory(title="Program 3")
+
+    regulation_1_program_1 = factories.RegulationFactory(title="Regulation 1")
+    regulation_2_program_1 = factories.RegulationFactory(title="Regulation 2")
+
+    self.make_relationships(
+        program_1, [
+            regulation_1_program_1,
+            regulation_2_program_1,
+        ],
+    )
+
+    self.make_relationships(
+        program_2, [
+            regulation_1_program_1,
+            regulation_2_program_1,
+        ],
+    )
+
+    self.make_relationships(
+        program_3, [
+            regulation_1_program_1,
+        ],
+    )
+
+    program_1 = models.Program.query.filter_by(title="Program 1").one()
+    program_2 = models.Program.query.filter_by(title="Program 2").one()
+    program_3 = models.Program.query.filter_by(title="Program 3").one()
+
+    regulation_1_program_1 = models.Regulation.query.filter_by(
+        title="Regulation 1").one()
+    regulation_2_program_1 = models.Regulation.query.filter_by(
+        title="Regulation 2").one()
+
+    _, audit_1 = self.obj_gen.generate_object(models.Audit, {
+        "title": "Audit 1",
+        "program": {"id": program_1.id},
+        "status": "Planned",
+    })
+
+    _, audit_2 = self.obj_gen.generate_object(models.Audit, {
+        "title": "Audit 2",
+        "program": {"id": program_2.id},
+        "status": "Planned",
+    })
+
+    _, audit_3 = self.obj_gen.generate_object(models.Audit, {
+        "title": "Audit 3",
+        "program": {"id": program_3.id},
+        "status": "Planned",
+    })
+
+    assessment_mappings = [
+        [audit_1, regulation_1_program_1, regulation_2_program_1],
+        [audit_2, regulation_1_program_1, regulation_2_program_1],
+        [audit_3, regulation_1_program_1],
+    ]
+
+    assessment_1, assessment_2, assessment_3 = self.make_assessments(
+        assessment_mappings)
+
+    similar_objects = models.Assessment.get_similar_objects_query(
+        id_=assessment_1.id,
+        types=["Assessment"],
+    ).all()
+
+    expected_ids = {assessment_2.id}
+
+    self.assertSetEqual(
+        {obj.id for obj in similar_objects},
+        expected_ids,
+    )
+    self.assertNotIn(assessment_3.id, similar_objects)
 
     query = [{
         "object_name": "Assessment",
         "type": "ids",
-        "order_by": [{"name": "__similarity__"}],
         "filters": {
             "expression": {
                 "op": {"name": "similar"},
                 "object_name": "Assessment",
-                "ids": [str(self.assessment.id)],
+                "ids": [str(assessment_1.id)],
             },
         },
     }]
@@ -192,13 +302,121 @@ class TestWithSimilarityScore(integration.ggrc.TestCase):
         data=json.dumps(query),
         headers={"Content-Type": "application/json"},
     )
-
-    # note that in our test data every similar object has a different weight;
-    # the order of objects with same weight is undefined after sorting
-    self.assertListEqual(
-        json.loads(response.data)[0]["Assessment"]["ids"],
+    self.assertSetEqual(
+        set(json.loads(response.data)[0]["Assessment"]["ids"]),
         expected_ids,
     )
+
+  def test_sort_by_similarity(self):
+    """Check sorting by __similarity__ value with query API."""
+
+    # pylint: disable=too-many-locals
+
+    program_1 = factories.ProgramFactory(title="Program 1")
+
+    regulation_1_program_1 = factories.RegulationFactory(title="Regulation 1")
+    regulation_2_program_1 = factories.RegulationFactory(title="Regulation 2")
+    control_1_program_1 = factories.ControlFactory(title="Control 1")
+    control_2_program_1 = factories.ControlFactory(title="Control 2")
+
+    self.make_relationships(
+        program_1, [
+            regulation_1_program_1,
+            regulation_2_program_1,
+            control_1_program_1,
+            control_2_program_1
+        ],
+    )
+
+    program_1 = models.Program.query.filter_by(title="Program 1").one()
+
+    _, audit_1 = self.obj_gen.generate_object(models.Audit, {
+        "title": "Audit 1",
+        "program": {"id": program_1.id},
+        "status": "Planned",
+    })
+
+    _, audit_2 = self.obj_gen.generate_object(models.Audit, {
+        "title": "Audit 2",
+        "program": {"id": program_1.id},
+        "status": "Planned",
+    })
+
+    regulation_1_program_1 = models.Regulation.query.filter_by(
+        title="Regulation 1").one()
+    regulation_2_program_1 = models.Regulation.query.filter_by(
+        title="Regulation 2").one()
+    control_1_program_1 = models.Control.query.filter_by(
+        title="Control 1").one()
+    control_2_program_1 = models.Control.query.filter_by(
+        title="Control 2").one()
+
+    assessment_mappings = [
+        [audit_1,
+         regulation_1_program_1, regulation_2_program_1,
+         control_1_program_1, control_2_program_1],
+        [audit_1, control_1_program_1, control_2_program_1],
+        [audit_1,
+         regulation_1_program_1, control_1_program_1],
+        [audit_2,
+         regulation_1_program_1, regulation_2_program_1,
+         control_1_program_1, control_2_program_1],
+        [audit_2,
+         regulation_1_program_1, control_1_program_1],
+        [audit_2, control_1_program_1, control_2_program_1],
+    ]
+
+    weights = [
+        [13, 18, 20, 25, 26],
+        [10, 15, 20, 20, 25],
+        [10, 13, 13, 15, 18],
+        [13, 18, 20, 25, 26],
+        [10, 13, 13, 15, 18],
+        [10, 15, 20, 20, 25]
+    ]
+
+    assessments = self.make_assessments(
+        assessment_mappings)
+    assessment_ids = [ass.id for ass in assessments]
+
+    for aid, weight_defs in zip(assessment_ids, weights):
+      similar_objects = models.Assessment.get_similar_objects_query(
+          id_=aid,
+          types=["Assessment"],
+      ).all()
+
+      sorted_similar = sorted(similar_objects,
+                              key=lambda x: x.weight)
+
+      self.assertEqual(
+          weight_defs,
+          [x.weight for x in sorted_similar]
+      )
+
+      query = [{
+          "object_name": "Assessment",
+          "type": "ids",
+          "order_by": [{"name": "__similarity__"}],
+          "filters": {
+              "expression": {
+                  "op": {"name": "similar"},
+                  "object_name": "Assessment",
+                  "ids": [str(aid)],
+              },
+          },
+      }]
+      response = self.client.post(
+          "/query",
+          data=json.dumps(query),
+          headers={"Content-Type": "application/json"},
+      )
+
+      # note that in our test data every similar object has a different weight;
+      # the order of objects with same weight is undefined after sorting
+      self.assertListEqual(
+          json.loads(response.data)[0]["Assessment"]["ids"],
+          [obj.id for obj in sorted_similar],
+      )
 
   def test_empty_similar_results(self):
     """Check empty similarity result."""

--- a/test/integration/ggrc/models/mixins/test_with_similarity_score.py
+++ b/test/integration/ggrc/models/mixins/test_with_similarity_score.py
@@ -6,8 +6,6 @@
 import json
 
 from ggrc import db
-from ggrc.models import Assessment
-from ggrc.models import Request
 import ggrc.models as models
 from ggrc.snapshotter.rules import Types
 
@@ -73,51 +71,6 @@ class TestWithSimilarityScore(integration.ggrc.TestCase):
                                     snapshot_mappings)
 
     return assessments
-
-  def test_similarity_for_request(self):
-    """Check special case for similarity for Request by Audit."""
-    request1 = factories.RequestFactory(audit_id=self.audit.id)
-    request2 = factories.RequestFactory(audit_id=self.audit.id)
-
-    self.make_relationships(request1, [self.control, self.regulation])
-
-    requests_by_request = Request.get_similar_objects_query(
-        id_=request1.id,
-        types=["Request"],
-        threshold=0,
-    ).all()
-
-    self.assertSetEqual(
-        {(obj.type, obj.id, obj.weight) for obj in requests_by_request},
-        {("Request", request2.id, 5)},
-    )
-
-    requests_by_assessment = Assessment.get_similar_objects_query(
-        id_=self.assessment.id,
-        types=["Request"],
-        threshold=0,
-    ).all()
-
-    self.assertSetEqual(
-        {(obj.type, obj.id, obj.weight) for obj in requests_by_assessment},
-        {("Request", request1.id, 18),
-         ("Request", request2.id, 5)},
-    )
-
-    assessments_by_request = Request.get_similar_objects_query(
-        id_=request1.id,
-        types=["Assessment"],
-        threshold=0,
-    ).all()
-
-    other_assessments = {
-        ("Assessment", assessment.id, self.id_weight_map[assessment.id])
-        for assessment in self.other_assessments
-    }
-    self.assertSetEqual(
-        {(obj.type, obj.id, obj.weight) for obj in assessments_by_request},
-        {("Assessment", self.assessment.id, 18)}.union(other_assessments),
-    )
 
   def test_get_similar_basic(self):
     """Basic check of similar objects manually and via Query API.


### PR DESCRIPTION
This fixes the issue with join where wrong table was being references, adds support weighting by object instead of weighting by type and adds tests that were missing from #4833 .