### PR TITLE
GGRC-394 Reset comment field on clicking Save & Add Another

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/modals_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/modals_controller.js
@@ -311,6 +311,9 @@
     },
 
     reset_form: function (setFieldsCb) {
+      var $textArea = $('#program_description');
+      var editorData = $textArea.data('wysihtml5');
+
       // If the modal is closed early, the element no longer exists
       if (this.element) {
         // Do the fields (re-)setting
@@ -326,6 +329,12 @@
       if (this.options.instance.form_preload) {
         this.options.instance.form_preload(this.options.new_object_form,
           this.options.object_params);
+      }
+
+      // The rich text editor's content is not a "normal" form field, thus
+      // it needs to be reset manually (if it exists)
+      if (editorData && editorData.editor) {
+        editorData.editor.clear();
       }
     },
 


### PR DESCRIPTION
This PR fixes an issue with the comment rich text box not being cleared after clicking the `"Save & Add Another"` button in the add comment modal.

(no unit tests, because an e2e test would make more sense here, and those are being developed in a separate development path)

---

**Precondition:**
Have an active WF with Task

**Steps to reproduce:**
  1. Navigate to Task’s Info pane at Active Cycles tab
  1. Click Add comment button
  1. Enter comment into comment field
  1. Click Save and Add Another button: confirm Comment field is not cleaned

**Actual Result:**
Comment field in New comment window is not cleaned after clicking Save and Add Another button when add a comment to Task

**Expected Result:**
Comment field in New comment window should be cleaned after clicking Save and Add Another button when add a comment to Task

