### PR TITLE
GGRC-629 Fix assessment generation with templates

### DIFF
--- a/src/ggrc/models/hooks/assessment.py
+++ b/src/ggrc/models/hooks/assessment.py
@@ -27,6 +27,7 @@ def init_hook():
     # pylint: disable=unused-argument
     """Apply custom attribute definitions and map people roles
     when generating Assessmet with template"""
+    db.session.flush()
     for obj, src in izip(objects, sources):
       src_obj = src.get("object")
       audit = src.get("audit")


### PR DESCRIPTION
The validator for custom attribute names needs to have the link between
the assessment and the custom attribute definition to work properly.
This is done by sqlalchemy on flush. In some cases the flush gets called
in the check_permissions step, but this ensures we have all the data
flushed before generating the needed links for assessments.


Ticked description:

> Precondition:
> Created program, control, audit
> 1. Go to audit page
> 2. Create Assessment template with custom attributes
> 3. Create assessment
> 4. Select Generate Assessments in 3 dots menu
> 5. Select Assessment template and Control for generation: Assessment generation failed
> Actual Result: Assessment generation failed if select Assessment template for generation
> Expected Result: Assessment should be generated if select Assessment template for generation
> Note: 
> To reproduce this you have to use launch_gae_ggrc instead of launch_ggrc because permissions work in a different way.