### PR TITLE
GGRC-405 Fix error on admin dashboard page

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
@@ -36,7 +36,7 @@
     init_tree_view_settings: function () {
       var validModels;
       var savedChildTreeDisplayList;
-      if (!GGRC.page_object) { // Admin dashboard
+      if (GGRC.pageType && GGRC.pageType === 'admin') { // Admin dashboard
         return;
       }
 

--- a/src/ggrc/templates/admin/index.haml
+++ b/src/ggrc/templates/admin/index.haml
@@ -10,6 +10,8 @@
   =super()
   GGRC.page_object = { "person": ={ full_user_json()|safe } };
 
+  GGRC.pageType = "admin";
+
 -block header
   -include 'base_objects/_page_header.haml'
 


### PR DESCRIPTION
**Steps**:
1. Open Assessment tab at Audit page
2. Click Select Child Tree Object Type and select any checkboxes
3. Go to Admin dashboard page

_Expected results_: the admin dashboard is shown.
_Actual results_: the page freezes with spinner, no controls are shown, JS error "Uncaught can.Map: Object does not exist" is reported in the console.

Workaround (to make admin dashboard working):
1. With the app opened, open Developer tools
2. Go to Application tab
3. Choose Local Storage -> the server you encountered this problem on (for instance, grc-test.appspot.com)
4. Delete every line with "display prefs" prefix.