### PR TITLE
QUICK-FIX Save Audit -> object relationships

### DIFF
--- a/src/ggrc/snapshotter/__init__.py
+++ b/src/ggrc/snapshotter/__init__.py
@@ -112,12 +112,19 @@ class SnapshotGenerator(object):
   def _get_snapshottable_objects(self, obj):
     """Get snapshottable objects from parent object's neighborhood."""
     with benchmark("Snapshot._get_snapshotable_objects"):
+      related_mappings = set()
       object_rules = self.rules.rules[obj.type]
 
       with benchmark("Snapshot._get_snapshotable_objects.related_mappings"):
-        related_mappings = obj.related_objects({
+        relatable_rules = {
             rule for rule in object_rules["fst"]
-            if isinstance(rule, basestring)})
+            if isinstance(rule, basestring)
+        }
+
+        if relatable_rules:
+          related_mappings = obj.related_objects({
+              rule for rule in object_rules["fst"]
+              if isinstance(rule, basestring)})
 
       with benchmark("Snapshot._get_snapshotable_objects.direct mappings"):
         direct_mappings = {getattr(obj, rule.name)

--- a/src/ggrc/snapshotter/__init__.py
+++ b/src/ggrc/snapshotter/__init__.py
@@ -236,7 +236,7 @@ class SnapshotGenerator(object):
 
       with benchmark("Snapshot._update.create snapshots revision payload"):
         for snapshot in snapshots:
-          parent = Stub.from_tuple(snapshot, 4, 5)
+          parent = Stub(snapshot.parent_type, snapshot.parent_id)
           context_id = self.context_cache[parent]
           data = create_snapshot_revision_dict("modified", event_id, snapshot,
                                                user_id, context_id)
@@ -416,7 +416,7 @@ class SnapshotGenerator(object):
       with benchmark("Snapshot._create.create revision payload"):
         with benchmark("Snapshot._create.create snapshots revision payload"):
           for snapshot in snapshots:
-            parent = Stub.from_tuple(snapshot, 4, 5)
+            parent = Stub(snapshot.parent_type, snapshot.parent_id)
             context_id = self.context_cache[parent]
             data = create_snapshot_revision_dict("created", event_id, snapshot,
                                                  user_id, context_id)

--- a/test/integration/ggrc/snapshotter/test_snapshoting.py
+++ b/test/integration/ggrc/snapshotter/test_snapshoting.py
@@ -452,7 +452,7 @@ class TestSnapshoting(SnapshotterBaseTestCase):
     self.create_audit(program)
 
     audit = db.session.query(models.Audit).filter(
-        models.Audit.title.like("%Snapshotable audit%")).first()
+        models.Audit.title == "Snapshotable audit").one()
 
     snapshots = db.session.query(models.Snapshot).filter(
         models.Snapshot.parent_type == "Audit",

--- a/test/integration/ggrc/snapshotter/test_snapshoting.py
+++ b/test/integration/ggrc/snapshotter/test_snapshoting.py
@@ -48,10 +48,8 @@ class TestSnapshoting(SnapshotterBaseTestCase):
         }
     })
 
-    self.assertEqual(
-        db.session.query(models.Audit).filter(
-            models.Audit.title.like(
-                "%Snapshotable audit%")).count(), 1)
+    audit = db.session.query(models.Audit).filter(
+        models.Audit.title == "Snapshotable audit").one()
 
     snapshot = db.session.query(models.Snapshot).filter(
         models.Snapshot.child_id == control.id,
@@ -79,16 +77,16 @@ class TestSnapshoting(SnapshotterBaseTestCase):
 
     relationship_columns = db.session.query(models.Relationship)
     relationship = relationship_columns.filter(
-        models.Relationship.source_type == "Control",
-        models.Relationship.source_id == control.id,
-        models.Relationship.destination_type == "Snapshot",
-        models.Relationship.destination_id == snapshot.first().id
+        models.Relationship.source_type == "Audit",
+        models.Relationship.source_id == audit.id,
+        models.Relationship.destination_type == "Control",
+        models.Relationship.destination_id == control.id
     ).union(
         relationship_columns.filter(
-            models.Relationship.source_type == "Snapshot",
-            models.Relationship.source_id == snapshot.first().id,
-            models.Relationship.destination_type == "Control",
-            models.Relationship.destination_id == control.id
+            models.Relationship.source_type == "Control",
+            models.Relationship.source_id == control.id,
+            models.Relationship.destination_type == "Audit",
+            models.Relationship.destination_id == audit.id
         )
     )
     self.assertEqual(relationship.count(), 1)

--- a/test/integration/ggrc_basic_permissions/test_creator_program.py
+++ b/test/integration/ggrc_basic_permissions/test_creator_program.py
@@ -5,6 +5,8 @@
 Test Creator role with Program scoped roles
 """
 
+import unittest
+
 from ggrc import db
 from ggrc.models import all_models
 from integration.ggrc import TestCase
@@ -293,6 +295,7 @@ class TestCreatorProgram(TestCase):
       # Try mapping
     self.assertEqual(errors, [])
 
+  @unittest.skip("Test for request object, not important anymore")
   def test_creator_audit_request_creation(self):
     self.init_objects("ProgramOwner")
     program = self.objects.get("program")


### PR DESCRIPTION
_Adding `needs work` since I want to see all tests will die because of this_

Replace base object -> snapshot mappings with audit -> base object since original was just data duplication that will be removed in the near future.