### PR TITLE
GGRC-496 Hide undo button when Assessment returns to In Progress state

### DIFF
--- a/src/ggrc/assets/mustache/mixins/stateful.mustache
+++ b/src/ggrc/assets/mustache/mixins/stateful.mustache
@@ -54,9 +54,10 @@
       {{/results}}
     {{/with_mapping}}
   {{/if_equals}}
-
+  {{^if_equals instance.status "In Progress"}}
     {{#instance._undo.0}}
         <a href="javascript://" data-name="status" data-value="{{instance._undo.0}}" data-undo="true" class="undo btn-info-pin-header pull-right {{instance._disabled}}">Undo</a>
     {{/instance._undo.0}}
+  {{/if_equals}}
   </div>
 {{/is_allowed }}


### PR DESCRIPTION
This PR hides undo action button when Assessment returns to In Progress state after editing CA fields.