### PR TITLE
GGRC-652 Fix js error on generate assessment modal

### DIFF
--- a/src/ggrc/assets/javascripts/components/unified_mapper/mapper.js
+++ b/src/ggrc/assets/javascripts/components/unified_mapper/mapper.js
@@ -459,7 +459,11 @@
       '#search keyup': function (el, ev) {
         if (ev.keyCode === 13) {
           this.scope.attr('mapper.term', el.val());
-          this.element.find('mapper-results').control().getResults();
+          if (this.scope.attr('mapper.useSnapshots')) {
+            this.element.find('snapshot-loader').scope().setItems();
+          } else {
+            this.element.find('mapper-results').control().getResults();
+          }
         }
       },
 


### PR DESCRIPTION
**Precondition**:
Created program, control, audit
1. Go to audit page
2. Click Autogenerate button in Audit summary page
3. Click Enter 

_Actual Result_: "Uncaught TypeError: Cannot read property 'getResults' of undefined" error occurs while clicking enter in Unified mapper
_Expected Result_: no error displayed