### PR TITLE
GGRC-499 Change order of warnings and errors in /import

### DIFF
--- a/src/ggrc/assets/javascripts/components/csv/import.js
+++ b/src/ggrc/assets/javascripts/components/csv/import.js
@@ -132,16 +132,16 @@
         .done(function (data) {
           this.scope.attr("import", _.map(data, function (element) {
             element.data = [];
-            if (element.block_warnings.concat(element.row_warnings).length) {
-              element.data.push({
-                status: "warnings",
-                messages: element.block_warnings.concat(element.row_warnings)
-              });
-            }
             if (element.block_errors.concat(element.row_errors).length) {
               element.data.push({
                 status: "errors",
                 messages: element.block_errors.concat(element.row_errors)
+              });
+            }
+            if (element.block_warnings.concat(element.row_warnings).length) {
+              element.data.push({
+                status: "warnings",
+                messages: element.block_warnings.concat(element.row_warnings)
               });
             }
             return element;


### PR DESCRIPTION
Errors should be before warnings during file importing

1. Export active WF w/tasks
2. Change for assignee for 1 task
3. Add new task
4. Login as GC and try to import this file

Expected results: Error is displayed on top, warning is displayed below error message