### PR TITLE
GGRC-530 Disable changing url hash on opening object in a new tab

### DIFF
--- a/src/ggrc/assets/javascripts/components/view-object-buttons/view-object-buttons.js
+++ b/src/ggrc/assets/javascripts/components/view-object-buttons/view-object-buttons.js
@@ -23,6 +23,9 @@
         if (node) {
           node.select(true);
         }
+      },
+      openObject(scope, el, ev) {
+        ev.stopPropagation();
       }
     }
   });

--- a/src/ggrc/assets/mustache/components/view-object-buttons/view-object-buttons.mustache
+++ b/src/ggrc/assets/mustache/components/view-object-buttons/view-object-buttons.mustache
@@ -7,7 +7,9 @@
   {{#is_allowed "view_object_page" instance}}
     {{^openIsHidden}}
     {{^instance.snapshot}}
-    <a href="{{instance.viewLink}}" target="_blank" class="btn btn-mini btn-outline">
+    <a href="{{instance.viewLink}}" target="_blank"
+       class="btn btn-mini btn-outline"
+       can-click="openObject">
       Open
     </a>
     {{/instance.snapshot}}


### PR DESCRIPTION
This PR disabled opening info pane and changing url hash when opening objects with open button in a new tab.