### PR TITLE
GGRC-640 Exclude not snapshotable objects under assessment

### DIFF
--- a/src/ggrc/assets/javascripts/components/unified_mapper/mapper.js
+++ b/src/ggrc/assets/javascripts/components/unified_mapper/mapper.js
@@ -126,18 +126,19 @@
     getModelNamesList: function (object) {
       var exclude = [];
       var include = [];
+      var snapshots = GGRC.Utils.Snapshots;
       if (this.attr('search_only')) {
         include = ['TaskGroupTask', 'TaskGroup',
           'CycleTaskGroupObjectTask'];
       }
       if (this.attr('assessmentGenerator')) {
-        exclude = GGRC.Utils.Snapshots.inScopeModels;
+        exclude = snapshots.inScopeModels;
       }
       return GGRC.Mappings
         .getMappingList(object, include, exclude);
     },
-    initTypes: function () {
-      var object = this.attr('object');
+    initTypes: function (objectType) {
+      var object = objectType || this.attr('object');
       // Can.JS wrap all objects with can.Map by default
       var groups = this.attr('defaultGroups').attr();
       var list = this.getModelNamesList(object);

--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -900,7 +900,7 @@
         object: 'MultitypeSearch',
         search_only: true
       });
-      objectTypes = mapper.initTypes();
+      objectTypes = mapper.initTypes('AssessmentTemplate');
 
       // the all objects group is not needed
       delete objectTypes.all_objects;

--- a/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
+++ b/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
@@ -876,6 +876,7 @@
 
     return {
       inScopeModels: ['Assessment', 'Issue', 'AssessmentTemplate'],
+      outOfScopeModels: ['Person', 'Program'],
       isSnapshot: isSnapshot,
       isSnapshotScope: isSnapshotScope,
       isSnapshotParent: isSnapshotParent,


### PR DESCRIPTION
Precondition:
Created program, control, audit
1. Go to audit page-> Assessment teplate tab
2. While Assessment teplate creating open dropdown list with Objects under Assessment: confirm the list contains not snapshotable objects (e.g. People, Issues, Programs)

Actual Result: Object under assessment dropdown list contains not snapshotable objects in Assessment template modal window
Expected Result: Object under assessment dropdown list should contains only snapshotable objects in Assessment template modal window