### PR TITLE
GGRC-661 Fix default values of response options

### DIFF
--- a/src/ggrc_workflows/models/cycle_task_group_object_task.py
+++ b/src/ggrc_workflows/models/cycle_task_group_object_task.py
@@ -65,9 +65,9 @@ class CycleTaskGroupObjectTask(
   task_type = db.Column(
       db.String(length=250), nullable=False)
   response_options = db.Column(
-      JsonType(), nullable=False, default='[]')
+      JsonType(), nullable=False, default=[])
   selected_response_options = db.Column(
-      JsonType(), nullable=False, default='[]')
+      JsonType(), nullable=False, default=[])
 
   sort_index = db.Column(
       db.String(length=250), default="", nullable=False)

--- a/src/ggrc_workflows/models/task_group_task.py
+++ b/src/ggrc_workflows/models/task_group_task.py
@@ -51,7 +51,7 @@ class TaskGroupTask(WithContact, Slugged, Titled, Described, RelativeTimeboxed,
       db.String(length=250), default=default_task_type, nullable=False)
 
   response_options = db.Column(
-      JsonType(), nullable=False, default='[]')
+      JsonType(), nullable=False, default=[])
 
   VALID_TASK_TYPES = ['text', 'menu', 'checkbox']
 


### PR DESCRIPTION
Steps to reproduce:
1. Create a one-time Workflow.
2. Go to Active Cycles tab.
3. Click "Create New".
4. Select "Dropdown" (or "Checkbox") in task type dropdown, leave "Selection Response Options" textarea empty.
5. Click "Save & Close".

Expected result: the task is created, no errors occur.
Actual result: the task is created, JS error `(this.attr(...) || []).join is not a function` occurs.