### PR TITLE
GGRC-670 Remove obsolete attribute from revision content

### DIFF
--- a/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
+++ b/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
@@ -836,7 +836,6 @@
       content.snapshot = new CMS.Models.Snapshot(instance);
       content.related_sources = [];
       content.related_destinations = [];
-      content.custom_attribute_values = content.custom_attributes;
       content.viewLink = content.snapshot.viewLink;
       content.selfLink = content.snapshot.selfLink;
       content.type = instance.child_type;


### PR DESCRIPTION
The custom_attributes field has been replaced with
custom_attribute_values to better match the actual response content that
the front-end should receive.

For verification:
Check that custom attribute values are correct on snapshots (Ignore the date value).

after merging, wait for deployment and then run 
```javascript
$.post('/admin/refresh_revisions')
```