### PR TITLE
GGRC-370: Add "No Role" user filtering into back-end

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/tree/list_view_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/tree/list_view_controller.js
@@ -125,6 +125,9 @@
         if (searchParams.role_id) {
           params['user_roles.role_id'] = searchParams.role_id;
         }
+        if (searchParams.noRole) {
+          params.__no_role = true;
+        }
       }
 
       return this.options.list_loader(this, params)
@@ -227,7 +230,14 @@
     },
 
     '.search-filters select[name=user_role] change': function (el, ev) {
-      this.options.search_params.role_id = el.val();
+      var value = el.val();
+      if (value === 'no-role') {
+        this.options.search_params.noRole = true;
+        this.options.search_params.role_id = undefined;
+      } else {
+        this.options.search_params.noRole = false;
+        this.options.search_params.role_id = value;
+      }
       this.fetch_list().then(this.proxy('draw_list'));
     },
 

--- a/src/ggrc/assets/mustache/people/filters.mustache
+++ b/src/ggrc/assets/mustache/people/filters.mustache
@@ -27,6 +27,7 @@
             </label>
             <select name="user_role">
               <option value="" selected>All Roles</option>
+              <option value="no-role">No Roles</option>
               {{#roles}}
                 <option value="{{id}}">{{name}}</option>
               {{/roles}}


### PR DESCRIPTION
**Steps to reproduce:**
1. Go to Admin Dashboard
2. People's tab
3. Open "By roles" filter  and select no role: confirm admin can't filter user with no-role permissions
**Actual Result:** admin can't filter user with no-role permissions
**Expected Result:** admin should filter user with no-role permissions and No role permission should exist in drop down list in "By roles" filter

Provided solutions is ugly. But it could be improved a little bit with moving hardcoded things into model part. Front-end part should send **GET** request via next link:
http://localhost:8080/api/people?__sort=name%2Cemail&__page=1&__page_size=50&_=1481893854715&__no_role=true

@egorhm already reviewed this PR's solution and proposed to add new user_role: **no_role**.

Highly appreciate any proposals about how to do it in a proper way for our app. Let's discuss it guys.
If current solution is not so ugly because we should refactor all this function in nearest future (using query API maybe) we can use it instead.
