### PR TITLE
GGRC-624 Unify date string representations on frontend

### DIFF
--- a/src/ggrc/assets/javascripts/components/datepicker/datepicker.js
+++ b/src/ggrc/assets/javascripts/components/datepicker/datepicker.js
@@ -16,10 +16,9 @@
       date: null,
       format: '@',
       helptext: '@',
-      pattern: 'MM/DD/YYYY',
       setMinDate: null,
       setMaxDate: null,
-      _date: null,
+      _date: null,  // the internal value of the text input field
       required: '@',
       define: {
         label: {
@@ -35,7 +34,7 @@
         }
       },
       onSelect: function (val, ev) {
-        this.attr('_date', val);
+        this.attr('date', val);
         this.attr('isShown', false);
       },
       onFocus: function (el, ev) {
@@ -45,45 +44,93 @@
         if (!GGRC.Utils.inViewport(this.picker)) {
           this.attr('showTop', true);
         }
-      }
+      },
+
+      // Date formats for the actual selected value, and for the date as
+      // displayed to the user. The Moment.js library and the jQuery datepicker
+      // use different format notation, thus separate settings for each.
+      // IMPORTANT: The pair of settings for each "type" of value (i.e. actual
+      // value / display value) must be consistent across both libraries!
+      MOMENT_ISO_DATE: 'YYYY-MM-DD',
+      MOMENT_DISPLAY_FMT: 'MM/DD/YYYY',
+      PICKER_ISO_DATE: 'yy-mm-dd',
+      PICKER_DISPLAY_FMT: 'mm/dd/yy'
     },
+
     events: {
       inserted: function () {
+        var scope = this.scope;
         var element = this.element.find('.datepicker__calendar');
-        var date = this.getDate(this.scope.date);
+        var minDate;
+        var maxDate;
+        var date;
 
         element.datepicker({
+          dateFormat: scope.PICKER_ISO_DATE,
           altField: this.element.find('.datepicker__input'),
+          altFormat: scope.PICKER_DISPLAY_FMT,
           onSelect: this.scope.onSelect.bind(this.scope)
         });
+        scope.attr('picker', element);
 
-        this.scope.attr('picker', element);
+        date = this.getDate(scope.date);
+        scope.picker.datepicker('setDate', date);
 
-        this.scope.picker.datepicker('setDate', date);
-        if (this.scope.setMinDate) {
-          this.updateDate('minDate', this.scope.setMinDate);
+        // set the boundaries of the dates that user is allowed to select
+        minDate = this.getDate(scope.setMinDate);
+        maxDate = this.getDate(scope.setMaxDate);
+        scope.attr('setMinDate', minDate);
+        scope.attr('setMaxDate', maxDate);
+
+        if (scope.setMinDate) {
+          this.updateDate('minDate', scope.setMinDate);
         }
-        if (this.scope.setMaxDate) {
-          this.updateDate('maxDate', this.scope.setMaxDate);
+        if (scope.setMaxDate) {
+          this.updateDate('maxDate', scope.setMaxDate);
         }
-        this.scope._date = date;
       },
+
+      /**
+       * Convert given date to an ISO date string.
+       *
+       * @param {Date|string|null} date - the date to convert
+       * @return {string|null} - date in ISO format or null if empty or invalid
+       */
       getDate: function (date) {
+        var scope = this.scope;
+
         if (date instanceof Date) {
-          return moment(date).format(this.scope.pattern);
-        }
-        if (moment(date, 'YYYY-MM-DD').isValid()) {
-          return moment(date).format(this.scope.pattern);
-        }
-        if (this.isValidDate(date)) {
+          // NOTE: Not using moment.utc(), because if a Date instance is given,
+          // it is in the browser's local timezone, thus we need to take that
+          // into account to not end up with a different date. Ideally this
+          // should never happen, but that would require refactoring the way
+          // Date objects are created throughout the app.
+          return moment(date).format(scope.MOMENT_ISO_DATE);
+        } else if (this.isValidDate(date)) {
           return date;
         }
+
         return null;
       },
+
       isValidDate: function (date) {
-        return moment(date, this.scope.pattern, true).isValid();
+        var scope = this.scope;
+        return moment(date, scope.MOMENT_ISO_DATE, true).isValid();
       },
+
+      /**
+       * Change the min/max date allowed to be picked.
+       *
+       * @param {string} type - the setting to change ("minDate" or "maxDate").
+       *   The value given is automatically adjusted for a day as business
+       *   rules dictate.
+       * @param {Date|string|null} date - the new value of the `type` setting.
+       *   If given as string, it must be in ISO date format.
+       * @return {Date|null} - the new date value
+       */
       updateDate: function (type, date) {
+        var scope = this.scope;
+
         var types = {
           minDate: function () {
             date.add(1, 'day');
@@ -92,32 +139,59 @@
             date.subtract(1, 'day');
           }
         };
+
         if (!date) {
-          this.scope.picker.datepicker('option', type, null);
-          return;
+          scope.picker.datepicker('option', type, null);
+          return null;
         }
-        date = moment(date, "MM/DD/YYYY");
+
+        if (date instanceof Date) {
+          // NOTE: Not using moment.utc(), because if a Date instance is given,
+          // it is in the browser's local timezone, thus we need to take that
+          // into account to not end up with a different date. Ideally this
+          // should never happen, but that would require refactoring the way
+          // Date objects are created throughout the app.
+          date = moment(date).format(scope.MOMENT_ISO_DATE);
+        }
+        date = moment.utc(date);
 
         if (types[type]) {
           types[type]();
         }
         date = date.toDate();
-        this.scope.picker.datepicker('option', type, date);
+        scope.picker.datepicker('option', type, date);
         return date;
       },
+
       '{scope} setMinDate': function (scope, ev, date) {
+        var currentDateObj = null;
         var updated = this.updateDate('minDate', date);
-        if (this.scope.attr('date') < updated) {
-          this.scope.attr('_date', moment(updated).format(this.scope.pattern));
+
+        if (scope.date) {
+          currentDateObj = moment.utc(scope.date).toDate();
+          if (currentDateObj < updated) {
+            this.scope.attr(
+              '_date',
+              moment.utc(updated).format(scope.MOMENT_DISPLAY_FMT));
+          }
         }
       },
+
       '{scope} setMaxDate': function (scope, ev, date) {
         this.updateDate('maxDate', date);
       },
+
       '{scope} _date': function (scope, ev, val) {
-        scope.attr('date', val);
-        scope.picker.datepicker('setDate', val);
+        var valISO = null;
+
+        if (val) {
+          valISO = moment.utc(val, scope.MOMENT_DISPLAY_FMT)
+                         .format(scope.MOMENT_ISO_DATE);
+        }
+        scope.attr('date', valISO);
+        scope.picker.datepicker('setDate', valISO);
       },
+
       '{window} mousedown': function (el, ev) {
         var isInside;
 

--- a/src/ggrc/assets/javascripts/components/inline_edit/inline_datepicker.js
+++ b/src/ggrc/assets/javascripts/components/inline_edit/inline_datepicker.js
@@ -20,7 +20,7 @@
         if (_.isEmpty(val)) {
           return;
         }
-        if (!moment(val, 'MM/DD/YYYY', true).isValid()) {
+        if (!moment(val, 'YYYY-MM-DD', true).isValid()) {
           this.scope.attr('context.value', undefined);
         }
       }

--- a/src/ggrc/assets/javascripts/components/tests/datepicker_spec.js
+++ b/src/ggrc/assets/javascripts/components/tests/datepicker_spec.js
@@ -28,12 +28,12 @@ describe('GGRC.Components.datepicker', function () {
     });
 
     it('returns undefined for empty date', function () {
-      expect(method('maxDate')).toBe(undefined);
-      expect(method('maxDate', null)).toBe(undefined);
-      expect(method('minDate', '')).toBe(undefined);
+      expect(method('maxDate')).toBe(null);
+      expect(method('maxDate', null)).toBe(null);
+      expect(method('minDate', '')).toBe(null);
     });
 
-    it('returns increment date', function () {
+    it('returns a date incremented by a day for maxDate', function () {
       var result = method('maxDate', new Date(2017, 0, 1));
 
       expect(result.getDate()).toBe(31);
@@ -41,7 +41,7 @@ describe('GGRC.Components.datepicker', function () {
       expect(result.getMonth()).toBe(11);
     });
 
-    it('returns decrement date', function () {
+    it('returns a date decremented by a day for minDate', function () {
       var result = method('minDate', new Date(2017, 0, 1));
 
       expect(result.getDate()).toBe(2);

--- a/src/ggrc/assets/javascripts/models/mixins.js
+++ b/src/ggrc/assets/javascripts/models/mixins.js
@@ -349,10 +349,31 @@
     }
   });
 
+  /**
+   * A mixin to use for objects that can have a time limit imposed on them.
+   *
+   * @class CMS.Models.Mixins.timeboxed
+   */
   can.Model.Mixin('timeboxed', {
     'extend:attributes': {
       start_date: 'date',
       end_date: 'date'
+    },
+
+    // Override default CanJS's conversion/serialization of dates, because
+    // that takes the browser's local timezone into account, which we do not
+    // want with our UTC dates. Having plain UTC-formatted date strings is
+    // more suitable for the current structure of the app.
+    serialize: {
+      date: function (val, type) {
+        return val;
+      }
+    },
+
+    convert: {
+      date: function (val, oldVal, fn, type) {
+        return val;
+      }
     }
   }, {
   });

--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -1206,6 +1206,7 @@ Mustache.registerHelper("link_to_tree", function () {
  *    * datetime (MM/DD/YYYY hh:mm:ss [PM|AM] [local timezone])
  */
 Mustache.registerHelper('date', function (date, hideTime) {
+  date = Mustache.resolve(date);
   return GGRC.Utils.formatDate(date, hideTime);
 });
 
@@ -1430,6 +1431,10 @@ function localizeDate(date, options, tmpl) {
   }
   date = resolve_computed(date);
   if (date) {
+    if (typeof date === 'string') {
+      // string dates are assumed to be in ISO format
+      return moment.utc(date, 'YYYY-MM-DD', true).format(tmpl);
+    }
     return moment(new Date(date)).format(tmpl);
   }
   return '';

--- a/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
+++ b/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
@@ -117,6 +117,11 @@
         return '';
       }
 
+      if (typeof date === 'string') {
+        // string dates are assumed to be in ISO format
+        return moment.utc(date, 'YYYY-MM-DD', true).format('MM/DD/YYYY');
+      }
+
       inst = moment(new Date(date.isComputed ? date() : date));
       if (hideTime === true) {
         return inst.format('MM/DD/YYYY');

--- a/src/ggrc/assets/mustache/components/assessment/inline/date.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/inline/date.mustache
@@ -7,6 +7,10 @@
   <datepicker is-shown="true" date="context.value"></datepicker>
 {{else}}
   <div class="inline-edit__text">
-    {{{firstnonempty context.value '<span class="empty-message">None</span>'}}}
+    {{#if context.value}}
+      {{date context.value true}}
+    {{else}}
+      <span class="empty-message">None</span>
+    {{/if}}
   </div>
 {{/if}}

--- a/src/ggrc/assets/mustache/components/datepicker/datepicker.mustache
+++ b/src/ggrc/assets/mustache/components/datepicker/datepicker.mustache
@@ -17,7 +17,7 @@
   <div class="datepicker__input-wrapper">
     <i class="fa fa-calendar"></i>
     <input
-      placeholder="{{pattern}}"
+      placeholder="{{MOMENT_DISPLAY_FMT}}"
       type="text"
       class="datepicker__input date"
       can-value="_date"

--- a/src/ggrc/assets/mustache/components/inline_edit/datepicker.mustache
+++ b/src/ggrc/assets/mustache/components/inline_edit/datepicker.mustache
@@ -7,6 +7,10 @@
   <datepicker is-shown="true" date="context.value"></datepicker>
 {{else}}
   <p class="inline-edit__text">
-    {{{firstnonempty context.value '<span class="empty-message">None</span>'}}}
+    {{#if context.value}}
+      {{date context.value true}}
+    {{else}}
+      <span class="empty-message">None</span>
+    {{/if}}
   </p>
 {{/if}}

--- a/src/ggrc/builder/json.py
+++ b/src/ggrc/builder/json.py
@@ -118,10 +118,6 @@ class UpdateAttrHandler(object):
       # values
       attr_name = attr
       value = json_obj.get(attr_name)
-    elif attr in getattr(obj.__class__, "_custom_update", []):
-      # The attribute has a custom setter
-      attr_name = attr
-      value = obj.__class__._custom_update[attr](obj, json_obj.get(attr_name))
     elif hasattr(attr, '__call__'):
       # The attribute has been decorated with a callable, grab the name and
       # invoke the callable to get the value
@@ -659,8 +655,6 @@ class Builder(AttributeInfo):
             isinstance(class_attr.property, RelationshipProperty):
       result = self.publish_relationship(
           obj, attr_name, class_attr, inclusions, include, inclusion_filter)
-    elif attr_name in getattr(obj.__class__, "_custom_publish", []):
-      result = obj.__class__._custom_publish[attr_name](obj)
     elif class_attr.__class__.__name__ == 'property':
       if not inclusions or include:
         if getattr(obj, '{0}_id'.format(attr_name)):

--- a/src/ggrc/converters/handlers/custom_attribute.py
+++ b/src/ggrc/converters/handlers/custom_attribute.py
@@ -118,7 +118,7 @@ class CustomAttributeColumHandler(handlers.TextColumnHandler):
     value = None
     try:
       value = parse(self.raw_value).strftime(
-          models.CustomAttributeValue.DATE_FORMAT_DB,
+          models.CustomAttributeValue.DATE_FORMAT_ISO,
       )
     except (TypeError, ValueError):
       self.add_warning(errors.WRONG_VALUE, column_name=self.display_name)

--- a/src/ggrc/converters/query_helper.py
+++ b/src/ggrc/converters/query_helper.py
@@ -579,8 +579,8 @@ class QueryHelper(object):
         try:
           converted_date = convert_date_format(
               value,
-              CustomAttributeValue.DATE_FORMAT_JSON,
-              CustomAttributeValue.DATE_FORMAT_DB,
+              CustomAttributeValue.DATE_FORMAT_US,
+              CustomAttributeValue.DATE_FORMAT_ISO,
           )
         except (TypeError, ValueError):
           # wrong format or not a date
@@ -589,7 +589,7 @@ class QueryHelper(object):
             raise BadQueryException(u"Field '{}' expects a '{}' date"
                                     .format(
                                         o_key,
-                                        CustomAttributeValue.DATE_FORMAT_JSON,
+                                        CustomAttributeValue.DATE_FORMAT_US,
                                     ))
 
 

--- a/src/ggrc/models/custom_attribute_value.py
+++ b/src/ggrc/models/custom_attribute_value.py
@@ -62,8 +62,8 @@ class CustomAttributeValue(Base, db.Model):
   }
 
   # formats to represent Date-type values
-  DATE_FORMAT_DB = "%Y-%m-%d"
-  DATE_FORMAT_JSON = "%m/%d/%Y"
+  DATE_FORMAT_ISO = "%Y-%m-%d"
+  DATE_FORMAT_US = "%m/%d/%Y"
 
   @property
   def latest_revision(self):
@@ -263,8 +263,8 @@ class CustomAttributeValue(Base, db.Model):
         # Validate the date format by trying to parse it
         self.attribute_value = utils.convert_date_format(
             self.attribute_value,
-            CustomAttributeValue.DATE_FORMAT_DB,
-            CustomAttributeValue.DATE_FORMAT_DB,
+            CustomAttributeValue.DATE_FORMAT_ISO,
+            CustomAttributeValue.DATE_FORMAT_ISO,
         )
 
   def validate(self):

--- a/src/ggrc/models/custom_attribute_value.py
+++ b/src/ggrc/models/custom_attribute_value.py
@@ -255,17 +255,13 @@ class CustomAttributeValue(Base, db.Model):
 
   def _validate_date(self):
     """Convert date format."""
-    from ggrc.models.custom_attribute_definition import (
-        CustomAttributeDefinition)
-    if (self.custom_attribute.attribute_type ==
-            CustomAttributeDefinition.ValidTypes.DATE):
-      if self.attribute_value:
-        # Validate the date format by trying to parse it
-        self.attribute_value = utils.convert_date_format(
-            self.attribute_value,
-            CustomAttributeValue.DATE_FORMAT_ISO,
-            CustomAttributeValue.DATE_FORMAT_ISO,
-        )
+    if self.attribute_value:
+      # Validate the date format by trying to parse it
+      self.attribute_value = utils.convert_date_format(
+          self.attribute_value,
+          CustomAttributeValue.DATE_FORMAT_ISO,
+          CustomAttributeValue.DATE_FORMAT_ISO,
+      )
 
   def validate(self):
     """Validate custom attribute value."""

--- a/test/integration/ggrc/models/test_snapshot.py
+++ b/test/integration/ggrc/models/test_snapshot.py
@@ -128,7 +128,7 @@ class TestSnapshot(TestCase):
     ca_args = [
         {"title": "CA text", "attribute_type": "Text"},
         {"title": "CA rich text", "attribute_type": "Rich Text"},
-        {"title": "CA date", "attribute_type": "Text"},  # Change this to date!
+        {"title": "CA date", "attribute_type": "Date"},
         {"title": "CA checkbox", "attribute_type": "Checkbox"},
         {"title": "CA person", "attribute_type": "Map:Person"},
         {"title": "CA dropdown", "attribute_type": "Dropdown",
@@ -206,5 +206,4 @@ class TestSnapshot(TestCase):
       obj = model.eager_query().first()
       generated_json = self._clean_json(obj.log_json())
       expected_json = self._clean_json(self._get_object(obj))
-      self.assertEqual(expected_json, generated_json)
       self.assertEqual(expected_json, generated_json)


### PR DESCRIPTION
This PR that attempts to unify the date formats used on the frontend.

Date strings must now be in ISO format and are assumed to be in UTC timezone (just like on the server), and are transparently converted to a different format only when and where required for presentation purposes. Also, the backend now only accepts ISO dates only (workarounds for date CustomAttributeValues have been removed) - need at least @zidarsk8 (or his drop-in replacement) to review that part, and maybe to advise on updating the integration tests as well, since I do not know exactly what parts of the code are just a temporary CA Date value workarounds.

The two main sources where string <---> Date conversions happen on the frontend (often incorrectly because of local time zones) are date pickers and serialization of CanJS models, and this PR addresses them. There might still be some other places where this happens, but the initial testing on info panes and edit modals succeeded.

The PR does not try to address any existing issues that are not directly to the change, namely:
* Having at least two different inline edit widgets (Assessments have their own version of it),
* Unifying the way Custom Attributes are submitted to the server, i.e. the `custom_attribute_values` attribute vs.  the old `custom_attributes`,
* Missing (?) datepicker validation, datepicker UI glitches, etc.

For the time being, there are no additional tests for the datepicker component, I would first like a confirmation that this is indeed a fix that we want and would consider as "proper".

P.S.: Yeah, for sure it would be better to have the date values available as Date (or Moment) objects, tried it, but that opens another set of problems with `CustomAttributeValue` instances and thus decided to skip that part for awhile, as it is not strictly necessary for achieving the goal (unified date format that is sent to the bakcend).