### PR TITLE
GGRC-672 Fix js error on people tab

### DIFF
--- a/src/ggrc/assets/javascripts/models/person.js
+++ b/src/ggrc/assets/javascripts/models/person.js
@@ -115,13 +115,14 @@
     getPersonMappings: function (instance, person, specificOject) {
       var result = $.Deferred();
       var mappingObject = instance[specificOject];
-      var refreshQueue = new RefreshQueue();
+      var mappingsRQ = new RefreshQueue();
+      var userRolesRQ = new RefreshQueue();
 
       can.each(mappingObject, function (obj) {
-        refreshQueue.enqueue(obj);
+        mappingsRQ.enqueue(obj);
       });
 
-      refreshQueue.trigger().then(function (objects) {
+      mappingsRQ.trigger().then(function (objects) {
         var userRoles;
         var objectPeopleFiltered = _.filter(objects, function (item) {
           return item.person && item.person.id === person.id;
@@ -136,6 +137,12 @@
 
         userRoles = userRoles.concat(objectPeopleFiltered);
 
+        can.each(userRoles, function (obj) {
+          userRolesRQ.enqueue(obj);
+        });
+
+        return userRolesRQ.trigger();
+      }).then(function (userRoles) {
         result.resolve(userRoles);
       });
       return result.promise();


### PR DESCRIPTION
**Steps to reproduce:**
1. Create a new program
2. Got to people tab, click map and click search in the Unified mapper
3. Map a new person to the program
4. Refresh the page: a script error appears

_Actual Result_: "Uncaught TypeError: Cannot read property 'reify' of undefined" error occurs if refresh the page after mapping a current user to program
_Expected Result_: no error displayed after refreshing a page

**NOTE**: I couldn't reproduce this issue locally. Only on grc-epic-1 server 