### PR TITLE
GGRC-268 Prevent Readers from creating UserRoles

### DIFF
--- a/src/ggrc_basic_permissions/roles/Reader.py
+++ b/src/ggrc_basic_permissions/roles/Reader.py
@@ -140,7 +140,6 @@ permissions = {
         "Person",
         "Program",
         "Role",
-        "UserRole",
         "Context",
         "BackgroundTask",
     ],


### PR DESCRIPTION
Readers should not have the permission to create user roles unless they
get the permission from a different source (e.g. they are program
owners).