### PR TITLE
GGRC-355 Fix styling buttons for confirm inline edit 

### DIFF
--- a/src/ggrc/assets/stylesheets/modules/_inline-edit.scss
+++ b/src/ggrc/assets/stylesheets/modules/_inline-edit.scss
@@ -45,7 +45,7 @@
       border: 1px solid $warmGray;
       &:hover {
         .inline-edit__controls {
-          height: auto;
+          height: 32px;
         }
       }
     }
@@ -82,6 +82,25 @@
     }
     .inline-edit--active & {
       display: block;
+    }
+
+    &.inline-edit__controls--edit-mode {
+      background: $white;
+      box-sizing: border-box;
+      height: 32px;
+      bottom: -33px;
+      line-height: 32px;
+      margin: 0;
+      padding: 0;
+      width: 70px;
+      z-index: 1;
+
+      li {
+        box-sizing: border-box;
+        float: left;
+        width: 32px;
+        line-height: 31px;
+      }
     }
   }
 }


### PR DESCRIPTION
**Steps to reproduce:**
1. Navigate to audit page and open Assessment’s info panel
2. Add a comment
3. Find your comment in comments list below (page refresh may be needed)
4. Edit your comment inline

![editcomment](https://cloud.githubusercontent.com/assets/4737102/21419859/4546bc62-c83b-11e6-965c-ed889ca42fde.png)


_Actual Result_: accept and close icons are off their places (see the screenshot)
_Expected Result:_ fix the look of the control icons (eg as on the second screenshot)