### PR TITLE
GGRC-363 Close datepicker calendar after choosing a date

### DIFF
--- a/src/ggrc/assets/javascripts/components/datepicker/datepicker.js
+++ b/src/ggrc/assets/javascripts/components/datepicker/datepicker.js
@@ -16,7 +16,6 @@
       date: null,
       format: '@',
       helptext: '@',
-      isShown: false,
       pattern: 'MM/DD/YYYY',
       setMinDate: null,
       setMaxDate: null,
@@ -27,6 +26,10 @@
           type: 'string'
         },
         persistent: {
+          type: 'boolean',
+          'default': false
+        },
+        isShown: {
           type: 'boolean',
           'default': false
         }

--- a/src/ggrc/assets/mustache/components/assessment/inline/date.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/inline/date.mustache
@@ -4,7 +4,7 @@
 }}
 
 {{#if isEdit}}
-  <datepicker persistent="true" date="context.value"></datepicker>
+  <datepicker is-shown="true" date="context.value"></datepicker>
 {{else}}
   <div class="inline-edit__text">
     {{{firstnonempty context.value '<span class="empty-message">None</span>'}}}

--- a/src/ggrc/assets/mustache/components/inline_edit/datepicker.mustache
+++ b/src/ggrc/assets/mustache/components/inline_edit/datepicker.mustache
@@ -4,7 +4,7 @@
 }}
 
 {{#if context.isEdit}}
-  <datepicker persistent="true" date="context.value"></datepicker>
+  <datepicker is-shown="true" date="context.value"></datepicker>
 {{else}}
   <p class="inline-edit__text">
     {{{firstnonempty context.value '<span class="empty-message">None</span>'}}}


### PR DESCRIPTION
This PR assures that the date picker calendar is closed after choosing a date from it.

Note that there are two different inline edit widgets in use, one for Assessments and one for other object types. When verifying, please make sure to check both.

**Steps to reproduce:**
  * Navigate to Assessment with the date field
  * Try to edit date value via info panel

**Actual Result:**
The custom attribute date field shows the date picker after choosing a date

**Expected Result:**
the date picker should disappear after picking a date