### PR TITLE
QUICK-FIX Add stable sort for similarity

### DIFF
--- a/src/ggrc/converters/query_helper.py
+++ b/src/ggrc/converters/query_helper.py
@@ -406,7 +406,8 @@ class QueryHelper(object):
         join_target = flask.g.similar_objects_query.subquery()
         join_condition = model.id == join_target.c.id
         joins = [(join_target, join_condition)]
-        order = join_target.c.weight
+        order = "weight, {model._inflector.table_plural}_id".format(
+            model=model)
         return joins, order
 
       def by_ca():

--- a/test/integration/ggrc/models/mixins/test_with_similarity_score.py
+++ b/test/integration/ggrc/models/mixins/test_with_similarity_score.py
@@ -364,15 +364,9 @@ class TestWithSimilarityScore(integration.ggrc.TestCase):
           headers={"Content-Type": "application/json"},
       )
 
-      # our sorted results are only unstably sorted. As such we verify that
-      # weights match and not actual object ids
-      obj_weight = {so.id: so.weight for so in similar_objects}
-      response_ids = json.loads(response.data)[0]["Assessment"]["ids"]
-      response_weights = [obj_weight[rid] for rid in response_ids]
-
       self.assertListEqual(
-          response_weights,
-          [obj.weight for obj in sorted_similar],
+          json.loads(response.data)[0]["Assessment"]["ids"],
+          [obj.id for obj in sorted_similar]
       )
 
   def test_empty_similar_results(self):


### PR DESCRIPTION
Currently similarity query is performing unstable sort - this should sort by weight first and ID second and as such should return the same results always.

Not critical since we have a fix for test that performs comparison by weight but this is the proper solution so I'm opening PR nonetheless.