### PR TITLE
GGRC-362 Audit with no status exists on DEV

### DIFF
--- a/src/ggrc/migrations/versions/20170103101308_42b22b9ca859__fix_audit_empty_status.py
+++ b/src/ggrc/migrations/versions/20170103101308_42b22b9ca859__fix_audit_empty_status.py
@@ -1,0 +1,38 @@
+# Copyright (C) 2016 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Fix audit empty status
+
+Create Date: 2016-12-22 13:53:24.497701
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+import sqlalchemy as sa
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '42b22b9ca859'
+down_revision = '4fcaef05479f'
+
+
+VALID_STATES = (
+    u'Planned', u'In Progress', u'Manager Review',
+    u'Ready for External Review', u'Completed'
+)
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  op.execute("UPDATE audits SET status='Planned' WHERE status=0")
+  op.alter_column('audits', 'status', nullable=True, type_=sa.String(250),
+                  existing_type=sa.Enum(*VALID_STATES))
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  op.alter_column('audits', 'status', nullable=False,
+                  type_=sa.Enum(*VALID_STATES), existing_type=sa.String)

--- a/src/ggrc/models/audit.py
+++ b/src/ggrc/models/audit.py
@@ -7,7 +7,7 @@ from ggrc import db
 from ggrc.models.deferred import deferred
 from ggrc.models.mixins import (
     Timeboxed, Noted, Described, Hyperlinked, WithContact,
-    Titled, Slugged, CustomAttributable
+    Titled, Slugged, CustomAttributable, Stateful
 )
 
 from ggrc.models.mixins import clonable
@@ -24,7 +24,7 @@ from ggrc.models.snapshot import Snapshotable
 class Audit(Snapshotable, clonable.Clonable,
             CustomAttributable, Personable, HasOwnContext, Relatable,
             Timeboxed, Noted, Described, Hyperlinked, WithContact, Titled,
-            Slugged, db.Model):
+            Stateful, Slugged, db.Model):
   """Audit model."""
 
   __tablename__ = 'audits'
@@ -42,9 +42,6 @@ class Audit(Snapshotable, clonable.Clonable,
   audit_firm_id = deferred(
       db.Column(db.Integer, db.ForeignKey('org_groups.id')), 'Audit')
   audit_firm = db.relationship('OrgGroup', uselist=False)
-  # TODO: this should be stateful mixin
-  status = deferred(db.Column(db.Enum(*VALID_STATES), nullable=False),
-                    'Audit')
   gdrive_evidence_folder = deferred(db.Column(db.String), 'Audit')
   program_id = deferred(
       db.Column(db.Integer, db.ForeignKey('programs.id'), nullable=False),
@@ -86,7 +83,10 @@ class Audit(Snapshotable, clonable.Clonable,
           "type": AttributeInfo.Type.USER_ROLE,
           "filter_by": "_filter_by_auditor",
       },
-      "status": "Status",
+      "status": {
+          "display_name": "Status",
+          "mandatory": True,
+      },
       "start_date": "Planned Start Date",
       "end_date": "Planned End Date",
       "report_start_date": "Planned Report Period from",


### PR DESCRIPTION
**Details:** 
Navigate to https://grc-dev.appspot.com/programs/4051#audit_widget/audit/1477 
**Actual Result:** one of the audits has no status
**Expected Result:** all the audits should have the status
**Workaround:** change the status manually
**Additional info:** most likely this audit was created during the time when we had the issue with status dropdown but we need to check it one time more to make sure the issue like this won’t leak to UAT.