### PR TITLE
GGRC-487 Display object owners in snapshots

### DIFF
--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -343,7 +343,7 @@ def _get_log_revisions(current_user_id, obj=None, force_obj=False):
         revisions.append(revision)
         if obj_.type == "ObjectOwner":
           from ggrc.utils import revisions as revision_utils
-          revision_utils.regfresh_single_revison(obj.ownable)
+          revision_utils.regfresh_single_revison(obj_.ownable)
 
     if force_obj and obj is not None and obj not in cache.dirty:
       # If the ``obj`` has been updated, but only its custom attributes have

--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -347,15 +347,16 @@ def log_event(session, obj=None, current_user_id=None, flush=True,
     current_user_id = get_current_user_id()
   cache = get_cache()
   if cache:
-    for obj_ in cache.dirty:
-      revision = Revision(obj_, current_user_id, 'modified', obj_.log_json())
-      revisions.append(revision)
-    for obj_ in cache.deleted:
-      revision = Revision(obj_, current_user_id, 'deleted', obj_.log_json())
-      revisions.append(revision)
-    for obj_ in cache.new:
-      revision = Revision(obj_, current_user_id, 'created', obj_.log_json())
-      revisions.append(revision)
+    cached_objects = {
+      "modified": cache.dirty,
+      "deleted": cache.deleted,
+      "created": cache.new,
+    }
+    for action, objects in cached_objects.iteritems():
+      for obj_ in objects:
+        revision = Revision(obj_, current_user_id, action, obj_.log_json())
+        revisions.append(revision)
+
     if force_obj and obj is not None and obj not in cache.dirty:
       # If the ``obj`` has been updated, but only its custom attributes have
       # been changed, then this object will not be added into

--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -343,7 +343,7 @@ def _get_log_revisions(current_user_id, obj=None, force_obj=False):
         revisions.append(revision)
         if obj_.type == "ObjectOwner":
           from ggrc.utils import revisions as revision_utils
-          revision_utils.regfresh_single_revison(obj_.ownable)
+          revision_utils.refresh_single_revison(obj_.ownable)
 
     if force_obj and obj is not None and obj not in cache.dirty:
       # If the ``obj`` has been updated, but only its custom attributes have

--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -357,11 +357,8 @@ def log_event(session, obj=None, current_user_id=None, flush=True,
         revision = Revision(obj_, current_user_id, action, obj_.log_json())
         revisions.append(revision)
         if obj_.type == "ObjectOwner":
-          # any change (create/delete/modify) of the owners is an edit on the
-          # original object. That is why the action is always set to modified.
-          revision = Revision(obj_.ownable, current_user_id, "modified",
-                              obj_.ownable.log_json())
-          revisions.append(revision)
+          import ggrc.utils.revisions
+          ggrc.utils.revisions.regfresh_single_revison(obj.ownable)
 
     if force_obj and obj is not None and obj not in cache.dirty:
       # If the ``obj`` has been updated, but only its custom attributes have

--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -333,9 +333,9 @@ def _get_log_revisions(current_user_id, obj=None, force_obj=False):
   cache = get_cache()
   if cache:
     cached_objects = {
-      "modified": cache.dirty,
-      "deleted": cache.deleted,
-      "created": cache.new,
+        "modified": cache.dirty,
+        "deleted": cache.deleted,
+        "created": cache.new,
     }
     for action, objects in cached_objects.iteritems():
       for obj_ in objects:

--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -356,6 +356,12 @@ def log_event(session, obj=None, current_user_id=None, flush=True,
       for obj_ in objects:
         revision = Revision(obj_, current_user_id, action, obj_.log_json())
         revisions.append(revision)
+        if obj_.type == "ObjectOwner":
+          # any change (create/delete/modify) of the owners is an edit on the
+          # original object. That is why the action is always set to modified.
+          revision = Revision(obj_.ownable, current_user_id, "modified",
+                              obj_.ownable.log_json())
+          revisions.append(revision)
 
     if force_obj and obj is not None and obj not in cache.dirty:
       # If the ``obj`` has been updated, but only its custom attributes have

--- a/src/ggrc/utils/revisions.py
+++ b/src/ggrc/utils/revisions.py
@@ -89,6 +89,7 @@ def do_refresh_revisions():
     logger.info("Updating revisions for: %s", type_)
     _fix_type_revisions(type_, rows)
 
+
 def regfresh_single_revison(obj):
   """Refresh last revision of a given object."""
   if not obj.id:

--- a/src/ggrc/utils/revisions.py
+++ b/src/ggrc/utils/revisions.py
@@ -88,3 +88,17 @@ def do_refresh_revisions():
   for type_, rows in rows_by_type.iteritems():
     logger.info("Updating revisions for: %s", type_)
     _fix_type_revisions(type_, rows)
+
+def regfresh_single_revison(obj):
+  """Refresh last revision of a given object."""
+  if not obj.id:
+    logger.warning("Can not refresh revisions of new objects.")
+    return
+  revision = all_models.Revision.query.filter(
+      all_models.Revision.resource_id == obj.id,
+      all_models.Revision.resource_type == obj.type,
+  ).order_by(all_models.Revision.id.desc()).first()
+  if revision and revision.action in {"created", "modified"}:
+    new_content = obj.log_json()
+    if revision.content != new_content:
+      revision.content = new_content

--- a/src/ggrc/utils/revisions.py
+++ b/src/ggrc/utils/revisions.py
@@ -92,7 +92,7 @@ def do_refresh_revisions():
 
 def regfresh_single_revison(obj):
   """Refresh last revision of a given object."""
-  if not obj.id:
+  if not obj or not obj.id:
     logger.warning("Can not refresh revisions of new objects.")
     return
   revision = all_models.Revision.query.filter(

--- a/src/ggrc/utils/revisions.py
+++ b/src/ggrc/utils/revisions.py
@@ -90,7 +90,7 @@ def do_refresh_revisions():
     _fix_type_revisions(type_, rows)
 
 
-def regfresh_single_revison(obj):
+def refresh_single_revison(obj):
   """Refresh last revision of a given object."""
   if not obj or not obj.id:
     logger.warning("Can not refresh revisions of new objects.")

--- a/test/integration/ggrc/converters/test_csvs/policy_basic_import.csv
+++ b/test/integration/ggrc/converters/test_csvs/policy_basic_import.csv
@@ -3,3 +3,8 @@ policy,code,title,owner,state
 ,"p1",some weird policy,user@example.com,Draft
 ,p2,another weird policy,user@example.com,Draft
 ,,Who let the dogs out,user@example.com,Draft
+,,,,
+Object type,,,,
+Person,name,email,company,role
+,user 1,user1@example.com,google,Admin 
+,user 2,user2@example.com,google,gGRC Admin

--- a/test/integration/ggrc/converters/test_csvs/policy_basic_import_update.csv
+++ b/test/integration/ggrc/converters/test_csvs/policy_basic_import_update.csv
@@ -1,4 +1,4 @@
 Object type,required,required,required,required
 policy,code,title,owner,state
-,"p1",Edited policy,user@example.com,Draft
-,p2,another Edited y,user@example.com,Draft
+,"p1",Edited policy,user1@example.com,Draft
+,p2,another Edited y,user2@example.com,Draft

--- a/test/integration/ggrc/converters/test_import_update.py
+++ b/test/integration/ggrc/converters/test_import_update.py
@@ -43,3 +43,4 @@ class TestImportUpdates(TestCase):
         models.Revision.resource_id == policy.id
     ).count()
     self.assertEqual(revision_count, 2)
+    self.assertEqual(policy.owners[0].email, "user1@example.com")


### PR DESCRIPTION
Note: This is not a nice solution so I am open for any suggestions of a better implementations. 

This PR fixes object owners on snapshots of newly created objects. The owners will now appear in the tree view and in the snapshots info pin.