### PR TITLE
GGRC-685 Snapshots of mapped to Assessment objects are not shown in Related Assessments tab in Info pane

### DIFF
--- a/src/ggrc/assets/javascripts/components/mapped-objects/mapped-objects.js
+++ b/src/ggrc/assets/javascripts/components/mapped-objects/mapped-objects.js
@@ -22,7 +22,10 @@
       parentInstance: null,
       selectedItem: {},
       mappedItems: [],
-      filter: null,
+      filter: {
+        only: [],
+        exclude: []
+      },
       filterMappedObjects: function (items) {
         var filterObj = this.attr('filter');
         return filterObj ?
@@ -56,13 +59,13 @@
         return [].concat(includeFilters, excludeFilters);
       },
       getSnapshotQuery: function () {
-        var relavantFilters = [{
+        var relevantFilters = [{
           type: this.attr('parentInstance.type'),
           id: this.attr('parentInstance.id')
         }];
         var filters = this.getSnapshotQueryFilters();
         var query = GGRC.Utils.QueryAPI
-          .buildParam('Snapshot', {}, relavantFilters, [], filters);
+          .buildParam('Snapshot', {}, relevantFilters, [], filters);
         return {data: [query]};
       },
       loadSnapshots: function () {

--- a/src/ggrc/assets/mustache/assessments/related-assessments.mustache
+++ b/src/ggrc/assets/mustache/assessments/related-assessments.mustache
@@ -43,6 +43,7 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                     </div>
                     <div class="flex-size-1">
                         <mapped-objects
+                                mapped-snapshots="instance"
                                 parent-instance="instance"
                                 mapping="{{instance.class.info_pane_options.mapped_objects.mapping}}">
                           {{> '/static/mustache/components/assessment/mapped-objects/mapped-related-information-item.mustache' }}


### PR DESCRIPTION
Created Program, Control, at least 2 Regulations, Audit
Steps to reproduce:
1. Go to the audit page->Assessment's tab
2. Generate at least 2 Assessments based on Control
3. Generate at least 2 Assessments based on 2 Regulation
4. Navigate to Assessment's Info pane one of the generated Assessments-> Related Assessments tab
5. Look at the list: real objects are shown (e.g. Program, Audit)
Actual Result: Snapshots of mapped to Assessment objects are not shown in Related Assessments tab in Info pane
Expected Result: Snapshots of mapped to Assessment objects should be shown in Related Assessments tab in Info pane
