### PR TITLE
GGRC-287 Fix audit folder is not refreshed after edit

### DIFF
--- a/src/ggrc_gdrive_integration/assets/javascripts/components/gdrive_folder_picker.js
+++ b/src/ggrc_gdrive_integration/assets/javascripts/components/gdrive_folder_picker.js
@@ -93,6 +93,14 @@
         });
 
         return deleteDeferred;
+      },
+      _updateCurrentFolder: function () {
+        var item = this.instance.get_binding('folders').list[0];
+        if (!item && this.instance.get_binding('extended_folders')) {
+          item = this.instance.get_binding('extended_folders').list[0];
+        }
+
+        this.attr('current_folder', item ? item.instance : null);
       }
     },
     events: {
@@ -149,12 +157,8 @@
       },
       '{scope.folder_list} change': function () {
         var pjlength;
-        var item = this.scope.instance.get_binding('folders').list[0];
-        if (!item && this.scope.instance.get_binding('extended_folders')) {
-          item = this.scope.instance.get_binding('extended_folders').list[0];
-        }
 
-        this.scope.attr('current_folder', item ? item.instance : null);
+        this.scope._updateCurrentFolder();
         if (this.scope.deferred && this.scope.instance._pending_joins) {
           pjlength = this.scope.instance._pending_joins.length;
           can.each(this.scope.instance._pending_joins.slice(0).reverse(), function (pj, i) {
@@ -163,6 +167,10 @@
             }
           }, this);
         }
+      },
+
+      '{scope.instance} object_folders': function () {
+        this.scope._updateCurrentFolder();
       },
 
       /**


### PR DESCRIPTION
This PR fixes audit is not refreshed on the info panel after editing it in edit modal.

Ticket description:
Subject: Audit folder is not removed from Audit's Info panel after Edit Audit
Details:   
Create program
Create an Audit> Assign folder while creating an Audit> Save and Close
Navigate to Audit’s Info panel> Click 3 bb’s button> Edit Audit
Click trash icon to delete folder> Save and Close
Look at Audit’s Info panel: Audit folder is not removed from Audit's Info panel
Actual Result: Audit folder is not removed from Audit's Info panel after Edit Audit
Expected Result: Audit folder should be removed from Audit's Info panel after Edit Audit
Workaround: Refresh the page