### PR TITLE
GGRC-714 Fix js error on annual tasks

### DIFF
--- a/src/ggrc_workflows/assets/mustache/task_group_tasks/modal_content.mustache
+++ b/src/ggrc_workflows/assets/mustache/task_group_tasks/modal_content.mustache
@@ -207,7 +207,7 @@
               <option value="{{iterator_0}}">{{iterator_1}}</option>
             {{/iterate}}
           </select>
-          <select name="relative_start_day" class="input-mini" can-value="instance.instance.relative_start_day" tabindex="5">
+          <select name="relative_start_day" class="input-mini" can-value="instance.relative_start_day" tabindex="5">
             {{#iterate 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31}}
             <option value="{{iterator}}">{{iterator}}</option>
             {{/iterate}}


### PR DESCRIPTION
Steps to reproduce:
1. Create annual WF
2. Click = to create a task in Task's group Info pane: confirm JS error is displayed
Actual Result: "Uncaught TypeError: Cannot read property 'relative_start_day' of undefined" error is displayed while creating a task for annual WF
Expected Result: no error is displayed while creating a task