### PR TITLE
GGRC-510 Fix empty filter on export page

### DIFF
--- a/src/ggrc/assets/javascripts/components/csv/export.js
+++ b/src/ggrc/assets/javascripts/components/csv/export.js
@@ -130,7 +130,7 @@
                   predicates;
               predicates = _.map(panel.attr("relevant"), function (el) {
                 var id = el.model_name === "__previous__" ? index - 1 : el.filter.id;
-                return "#" + el.model_name + "," + id + "#";
+                return id ? '#' + el.model_name + ',' + id + '#' : null;
               });
               relevant_filter = _.reduce(predicates, function (p1, p2) {
                 return p1 + " AND " + p2;

--- a/src/ggrc/assets/javascripts/components/csv/export.js
+++ b/src/ggrc/assets/javascripts/components/csv/export.js
@@ -3,48 +3,48 @@
   Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 */
 
-(function(can, $) {
-  var url = can.route.deparam(window.location.search.substr(1)),
-      filterModel = can.Map({
-        model_name: "Program",
-        value: "",
-        filter: {}
-      }),
-      panelModel = can.Map({
-        selected: {},
-        models: null,
-        type: "Program",
-        filter: "",
-        relevant: can.compute(function () {
-          return new can.List();
-        }),
-        columns: [],
-      }),
-      panelsModel = can.Map({
-        items: new can.List()
-      }),
-      exportModel = can.Map({
-        panels: new panelsModel(),
-        loading: false,
-        url: "/_service/export_csv",
-        type: url.model_type || "Program",
-        only_relevant: false,
-        filename: "export_objects.csv"
-      });
-
+(function (can, $) {
+  var url = can.route.deparam(window.location.search.substr(1));
+  var filterModel = can.Map({
+    model_name: 'Program',
+    value: '',
+    filter: {}
+  });
+  var panelModel = can.Map({
+    selected: {},
+    models: null,
+    type: 'Program',
+    filter: '',
+    relevant: can.compute(function () {
+      return new can.List();
+    }),
+    columns: []
+  });
+  var panelsModel = can.Map({
+    items: new can.List()
+  });
+  var exportModel = can.Map({
+    panels: new panelsModel(),
+    loading: false,
+    url: '/_service/export_csv',
+    type: url.model_type || 'Program',
+    only_relevant: false,
+    filename: 'export_objects.csv'
+  });
+  var csvExport;
 
   can.Component.extend({
-    tag: "csv-template",
-    template: "<content></content>",
+    tag: 'csv-template',
+    template: '<content></content>',
     scope: {
-      url: "/_service/export_csv",
+      url: '/_service/export_csv',
       selected: [],
-      importable: GGRC.Bootstrap.importable,
+      importable: GGRC.Bootstrap.importable
     },
     events: {
-      "#importSelect change": function (el, ev) {
-        var $items = el.find(":selected"),
-            selected = this.scope.attr("selected");
+      '#importSelect change': function (el, ev) {
+        var $items = el.find(':selected');
+        var selected = this.scope.attr('selected');
 
         $items.each(function () {
           var $item = $(this);
@@ -52,19 +52,20 @@
             return;
           }
           return selected.push({
-            name: $item.attr("label"),
+            name: $item.attr('label'),
             value: $item.val()
           });
         });
       },
-      ".import-button click": function (el, ev) {
+      '.import-button click': function (el, ev) {
+        var data;
         ev.preventDefault();
-        var data = _.map(this.scope.attr("selected"), function (el) {
-              return {
-                object_name: el.value,
-                fields: "all"
-              };
-            });
+        data = _.map(this.scope.attr('selected'), function (el) {
+          return {
+            object_name: el.value,
+            fields: 'all'
+          };
+        });
         if (!data.length) {
           return;
         }
@@ -72,24 +73,24 @@
         GGRC.Utils.export_request({
           data: data
         }).then(function (data) {
-          GGRC.Utils.download("import_template.csv", data);
-        }.bind(this))
+          GGRC.Utils.download('import_template.csv', data);
+        })
         .fail(function (data) {
-          $("body").trigger("ajax:flash", {
-            "error": $(data.responseText.split("\n")[3]).text()
+          $('body').trigger('ajax:flash', {
+            error: $(data.responseText.split('\n')[3]).text()
           });
-        }.bind(this));
+        });
       },
-      ".import-list a click": function (el, ev) {
+      '.import-list a click': function (el, ev) {
+        var index = el.data('index');
+        var item = this.scope.attr('selected').splice(index, 1)[0];
+
         ev.preventDefault();
 
-        var index = el.data("index"),
-            item = this.scope.attr("selected").splice(index, 1)[0];
-
-        this.element.find("#importSelect option:selected").each(function () {
+        this.element.find('#importSelect option:selected').each(function () {
           var $item = $(this);
           if ($item.val() === item.value) {
-            $item.prop("selected", false);
+            $item.prop('selected', false);
           }
         });
       }
@@ -97,12 +98,12 @@
   });
 
   can.Component.extend({
-    tag: "csv-export",
-    template: "<content></content>",
+    tag: 'csv-export',
+    template: '<content></content>',
     scope: function () {
       return {
         isFilterActive: false,
-        export: new exportModel()
+        'export': new exportModel()
       };
     },
     events: {
@@ -120,94 +121,102 @@
       '.option-type-selector change': function (el, ev) {
         this.scope.attr('isFilterActive', false);
       },
-      "#export-csv-button click": function (el, ev) {
+      '#export-csv-button click': function (el, ev) {
+        var panels;
+        var query;
+
         ev.preventDefault();
-        this.scope.attr("export.loading", true);
-        var panels = this.scope.attr("export.panels.items"),
-            only_relevant = this.scope.attr("export.only_relevant"),
-            query = _.map(panels, function (panel, index) {
-              var relevant_filter = "",
-                  predicates;
-              predicates = _.map(panel.attr("relevant"), function (el) {
-                var id = el.model_name === "__previous__" ? index - 1 : el.filter.id;
-                return id ? '#' + el.model_name + ',' + id + '#' : null;
-              });
-              relevant_filter = _.reduce(predicates, function (p1, p2) {
-                return p1 + " AND " + p2;
-              });
-              return {
-                object_name: panel.type,
-                fields: _.compact(_.map(panel.columns(),
-                  function (item, index) {
-                    if (panel.selected[index]) {
-                      return item.key;
-                    }
-                  })),
-                filters: GGRC.query_parser.join_queries(
-                  GGRC.query_parser.parse(relevant_filter || ""),
-                  GGRC.query_parser.parse(panel.filter || "")
-                )
-              };
-            });
+        this.scope.attr('export.loading', true);
+
+        panels = this.scope.attr('export.panels.items');
+        query = _.map(panels, function (panel, index) {
+          var relevantFilter;
+          var predicates;
+          predicates = _.map(panel.attr('relevant'), function (el) {
+            var id = el.model_name === '__previous__' ?
+              index - 1 : el.filter.id;
+            return id ? '#' + el.model_name + ',' + id + '#' : null;
+          });
+          relevantFilter = _.reduce(predicates, function (p1, p2) {
+            return p1 + ' AND ' + p2;
+          });
+          return {
+            object_name: panel.type,
+            fields: _.compact(_.map(panel.columns(),
+              function (item, index) {
+                if (panel.selected[index]) {
+                  return item.key;
+                }
+              })),
+            filters: GGRC.query_parser.join_queries(
+              GGRC.query_parser.parse(relevantFilter || ''),
+              GGRC.query_parser.parse(panel.filter || '')
+            )
+          };
+        });
 
         GGRC.Utils.export_request({
           data: query
         }).then(function (data) {
-          GGRC.Utils.download(this.scope.attr("export.filename"), data);
+          GGRC.Utils.download(this.scope.attr('export.filename'), data);
         }.bind(this))
         .fail(function (data) {
-          $("body").trigger("ajax:flash", {
-            "error": $(data.responseText.split("\n")[3]).text()
+          $('body').trigger('ajax:flash', {
+            error: $(data.responseText.split('\n')[3]).text()
           });
-        }.bind(this))
+        })
         .always(function () {
-          this.scope.attr("export.loading", false);
+          this.scope.attr('export.loading', false);
         }.bind(this));
       }
     }
   });
 
-
   can.Component.extend({
-    tag: "export-group",
-    template: "<content></content>",
+    tag: 'export-group',
+    template: '<content></content>',
     scope: {
       _index: 0
     },
     events: {
-      "inserted": function () {
+      inserted: function () {
         this.addPanel({
-          type: url.model_type || "Program"
+          type: url.model_type || 'Program'
         });
       },
       addPanel: function (data) {
+        var index = this.scope.attr('_index') + 1;
+        var pm;
+
         data = data || {};
-        var index = this.scope.attr("_index") + 1;
         if (!data.type) {
-          data.type = "Program";
+          data.type = 'Program';
         }
 
-        this.scope.attr("_index", index);
-        var pm = new panelModel(data);
-        pm.attr('columns', can.compute(function() {
+        this.scope.attr('_index', index);
+        pm = new panelModel(data);
+        pm.attr('columns', can.compute(function () {
           var definitions = GGRC.model_attr_defs[pm.attr('type')];
           return _.filter(definitions, function (el) {
             return (!el.import_only) &&
-                   (el.display_name.indexOf("unmap:") === -1);
+                   (el.display_name.indexOf('unmap:') === -1);
           });
         }));
-        return this.scope.attr("panels.items").push(pm);
+        return this.scope.attr('panels.items').push(pm);
       },
       getIndex: function (el) {
-        return +el.closest("export-panel").control().scope.attr("item.index");
+        return Number(el.closest('export-panel')
+          .control().scope.attr('item.index'));
       },
-      ".remove_filter_group click": function (el, ev) {
+      '.remove_filter_group click': function (el, ev) {
+        var elIndex = this.getIndex(el);
+        var index = _.pluck(this.scope.attr('panels.items'), 'index')
+            .indexOf(elIndex);
+
         ev.preventDefault();
-        var elIndex = this.getIndex(el),
-            index = _.pluck(this.scope.attr("panels.items"), "index").indexOf(elIndex);
-        this.scope.attr("panels.items").splice(index, 1);
+        this.scope.attr('panels.items').splice(index, 1);
       },
-      "#addAnotherObjectType click": function (el, ev) {
+      '#addAnotherObjectType click': function (el, ev) {
         ev.preventDefault();
         this.addPanel();
       }
@@ -215,16 +224,16 @@
   });
 
   can.Component.extend({
-    tag: "export-panel",
-    template: "<content></content>",
+    tag: 'export-panel',
+    template: '<content></content>',
     scope: {
       exportable: GGRC.Bootstrap.exportable,
-      panel_number: "@",
+      panel_number: '@',
       has_parent: false,
       fetch_relevant_data: function (id, type) {
         var dfd = CMS.Models[type].findOne({id: id});
         dfd.then(function (result) {
-          this.attr("item.relevant").push(new filterModel({
+          this.attr('item.relevant').push(new filterModel({
             model_name: url.relevant_type,
             value: url.relevant_id,
             filter: result
@@ -234,9 +243,9 @@
     },
     events: {
       inserted: function () {
-        var panel_number = +this.scope.attr("panel_number");
+        var panelNumber = Number(this.scope.attr('panel_number'));
 
-        if (!panel_number && url.relevant_id && url.relevant_type) {
+        if (!panelNumber && url.relevant_id && url.relevant_type) {
           this.scope.fetch_relevant_data(url.relevant_id, url.relevant_type);
         }
         this.setSelected();
@@ -263,27 +272,29 @@
           }, {});
         this.scope.attr('item.selected', selected);
       },
-      "{scope.item} type": function () {
-        this.scope.attr("item.selected", {});
-        this.scope.attr("item.relevant", []);
-        this.scope.attr("item.filter", "");
-        this.scope.attr("item.has_parent", false);
+      '{scope.item} type': function () {
+        this.scope.attr('item.selected', {});
+        this.scope.attr('item.relevant', []);
+        this.scope.attr('item.filter', '');
+        this.scope.attr('item.has_parent', false);
 
         this.setSelected();
       }
     },
     helpers: {
       first_panel: function (options) {
-        if (+this.attr("panel_number") > 0) {
+        if (Number(this.attr('panel_number')) > 0) {
           return options.fn();
         }
         return options.inverse();
       }
     }
   });
-  var csvExport = $("#csv_export");
-  if (csvExport.length) {
-    csvExport.html(can.view(GGRC.mustache_path + "/import_export/export.mustache", {}));
-  }
 
+  csvExport = $('#csv_export');
+  if (csvExport.length) {
+    csvExport.html(
+      can.view(GGRC.mustache_path + '/import_export/export.mustache', {})
+    );
+  }
 })(window.can, window.can.$);


### PR DESCRIPTION
**Steps to reproduce:**
1. Go to Admin Dashboard
2. Data Export
3. Select any object type for export (e.g. Programs)
4. Select mapped to any Object (e.g. Access Group) and don't select the title of the Access Group (but dropdown list is shown)
5. Click on Export Objects button: confirm JS error displayed

_Actual Result_: an error occurs while clicking Export Objects button if the object's title is not selected from dropdown list
_Expected Result_: no error displayed
_Tech details_: The server returns HTTP400 with the error because the "relevant" object is not chosen in the search field. The UI should either forbid clicking "export objects" when no "relevant" object is chosen, or not include the "relevant" filter for this type in the request to the server.