### PR TITLE
GGRC-723 Evidence is not shown in Related Assessments tab in Assessment's Info pane

### DIFF
--- a/src/ggrc/assets/javascripts/components/mapped-objects/mapped-objects.js
+++ b/src/ggrc/assets/javascripts/components/mapped-objects/mapped-objects.js
@@ -27,10 +27,12 @@
         exclude: []
       },
       filterMappedObjects: function (items) {
-        var filterObj = this.attr('filter');
-        return filterObj ?
-          GGRC.Utils.filters.applyTypeFilter(items, filterObj.attr()) :
-          items;
+        function getTypeFromInstance(item) {
+          return item.instance.type;
+        }
+        return GGRC.Utils.filters
+          .applyTypeFilter(items,
+            this.attr('filter').attr(), getTypeFromInstance);
       },
       getBinding: function () {
         return this.attr('parentInstance').get_binding(this.attr('mapping'));

--- a/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
+++ b/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
@@ -36,19 +36,22 @@
        * @return {Function} - filtering function
        */
       makeTypeFilter: function (filterObj) {
+        function checkIsNotEmptyArray(arr) {
+          return arr && Array.isArray(arr) && arr.length;
+        }
         return function (item) {
           var type = item.instance.type.toString().toLowerCase();
           if (!filterObj) {
             return true;
           }
-          if (filterObj.only && Array.isArray(filterObj.only)) {
+          if (checkIsNotEmptyArray(filterObj.only)) {
             // Do sanity transformation
             filterObj.only = filterObj.only.map(function (item) {
               return item.toString().toLowerCase();
             });
             return filterObj.only.indexOf(type) > -1;
           }
-          if (filterObj.exclude && Array.isArray(filterObj.exclude)) {
+          if (checkIsNotEmptyArray(filterObj.exclude)) {
             // Do sanity transformation
             filterObj.exclude = filterObj.exclude.map(function (item) {
               return item.toString().toLowerCase();

--- a/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
+++ b/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
@@ -25,10 +25,17 @@
        * Performs filtering on provided array like instances
        * @param {Array} items - array like instance
        * @param {Function} filter - filtering function
+       * @param {Function} selectFn - function to select proper attributes
        * @return {Array} - filtered array
        */
-      applyFilter: function (items, filter) {
-        return Array.prototype.filter.call(items, filter);
+      applyFilter: function (items, filter, selectFn) {
+        selectFn = selectFn ||
+          function (x) {
+            return x;
+          };
+        return Array.prototype.filter.call(items, function (item) {
+          return filter(selectFn(item));
+        });
       },
       /**
        * Helper function to create a filtering function
@@ -39,8 +46,8 @@
         function checkIsNotEmptyArray(arr) {
           return arr && Array.isArray(arr) && arr.length;
         }
-        return function (item) {
-          var type = item.instance.type.toString().toLowerCase();
+        return function (type) {
+          type = type.toString().toLowerCase();
           if (!filterObj) {
             return true;
           }
@@ -60,9 +67,9 @@
           }
         };
       },
-      applyTypeFilter: function (items, filterObj) {
+      applyTypeFilter: function (items, filterObj, getTypeSelectFn) {
         var filter = GGRC.Utils.filters.makeTypeFilter(filterObj);
-        return GGRC.Utils.filters.applyFilter(items, filter);
+        return GGRC.Utils.filters.applyFilter(items, filter, getTypeSelectFn);
       }
     },
     sortingHelpers: {


### PR DESCRIPTION
Precondition:
Created program, audit
Steps to reproduce:
1. Go to audit page
2. Create at least 2 Assessments
3. Add URL in Assessment's Info pane one of the Assessments 
4. Navigate to Assessment's info pane of second Assessment-> Related Assessments tab
5. Look at Evidence column: URL is not displayed
Actual Result: Evidence is not shown in Related Assessments tab in Assessment's Info pane
Expected Result: Evidence should be shown in Related Assessments tab in Assessment's Info pane
