### PR TITLE
GGRC-708 Fix js error after changing date on wf create task

### DIFF
--- a/src/ggrc_workflows/assets/mustache/task_group_tasks/modal_content.mustache
+++ b/src/ggrc_workflows/assets/mustache/task_group_tasks/modal_content.mustache
@@ -71,7 +71,6 @@
       {{#using workflow=task_group.workflow}}
       {{#switch workflow.frequency}}
       {{#case "one_time"}}
-      {{#add_to_current_scope instance=instance}}
       <div id="one-time" class="frequency-wrap" style="display:block">
         <label>
           Frequency: One time
@@ -89,7 +88,6 @@
                       label="Due Date"></datepicker>
         </label>
       </div>
-      {{/add_to_current_scope}}
       {{/case}}
       {{#case "weekly"}}
       <div id="weekly" class="frequency-wrap" style="display:block">


### PR DESCRIPTION
This PR fixes js error after changing date on wf create task modal.

Steps to reproduce:
1. Create one-time WF
2. Go to Setup tab
3. While creating a task change start date to date later (e.g. yesterday)-> Save and Close
Actual Result: "Uncaught TypeError: instance.errors is not a function" error is displayed while creating a task in WF
Expected Result: no error displayed. A task is created and displayed in Task's Group Info pane