### PR TITLE
GGRC-709 Restore missing "Add Comment" button for WF Tasks

### DIFF
--- a/src/ggrc_workflows/assets/mustache/cycle_task_entries/tree_footer.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_entries/tree_footer.mustache
@@ -3,8 +3,10 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
 
-{{^if_equals parent_instance.status 'Verified'}}
-  {{#using cycle=parent_instance.cycle}}
+{{#using task=instance}} {{! just a more descriptive alias}}
+
+{{^if_equals task.status 'Verified'}}
+  {{#using cycle=task.cycle}}
     {{#if cycle.is_current}}
     {{#is_allowed 'update' instance context='for'}}
       <li class="tree-footer tree-item-add inner-tree-footer non-stick">
@@ -20,9 +22,9 @@
           data-object-singular="CycleTaskEntry"
           data-object-plural="cycle_task_entries"
           data-object-params='{
-            "cycle_task_group_object_task": {{parent_instance.id}},
-            "cycle": {{parent_instance.cycle.id}},
-            "context": {{parent_instance.context.id}}
+            "cycle_task_group_object_task": {{task.id}},
+            "cycle": {{task.cycle.id}},
+            "context": {{task.context.id}}
           }'>
           Add Comment
         </a>
@@ -31,3 +33,5 @@
     {{/if}}
   {{/using}}
 {{/if_equals}}
+
+{{/using}}


### PR DESCRIPTION
This PR fixes the bug that prevented the Add Comment button from being shown on Task's info pane. Essentially it uses "instance" in the template instead of "parent_instance" that no longer (?) exists.

This issue has the `Blocker` priority, hence the `critical` label.

---

**Precondition:**
Active WF with Task

**Steps to reproduce:**
  - Navigate to Task’s Info pane at Active Cycles tab
  - Look at Add comment button: is not shown

**Actual Result:**
[Add comment] button is not shown in Task's Info pane

**Expected Result:**
[Add comment] button is shown in Task's Info pane