### PR TITLE
GGRC-729 'NoneType' object has no attribute 'type' error is displayed while mapping an object in scope of the audit to Assessment/Issue

### DIFF
--- a/src/ggrc/assets/javascripts/components/unified_mapper/mapper.js
+++ b/src/ggrc/assets/javascripts/components/unified_mapper/mapper.js
@@ -326,12 +326,12 @@
             var isMapped;
             var isAllowed;
             // Use simple Relationship Model to map Snapshot
-            if (GGRC.Utils.Snapshots.isSnapshot(destination)) {
+            if (this.scope.attr('mapper.useSnapshots')) {
               modelInstance = new CMS.Models.Relationship({
                 context: data.context,
                 source: instance,
                 destination: {
-                  href: destination.href,
+                  href: '/api/snapshots/' + destination.id,
                   type: 'Snapshot',
                   id: destination.id
                 }
@@ -357,7 +357,7 @@
             data[mapping.option_attr] = destination;
             modelInstance = new Model(data);
             defer.push(modelInstance.save());
-          });
+          }.bind(this));
 
           $.when.apply($, defer)
             .fail(function (response, message) {


### PR DESCRIPTION
Precondition
Created program, Control, audit
Steps to reproduce:
1. Go to Audit pag
2. Create Assessment
3. Click Map button on the first tier of the tree view
4. Select any object-> Search -> Select an object from the Search List
5. Map Selected: confirm error occurs
Actual Result: 'NoneType' object has no attribute 'type' error is displayed while mapping an object in scope of the audit to Assessment/Issue
Expected Result: no error displayed while mapping
