### PR TITLE
GGRC-456 Fix obsolete link for view audit on LHN

### DIFF
--- a/src/ggrc/assets/mustache/audits/search_result.mustache
+++ b/src/ggrc/assets/mustache/audits/search_result.mustache
@@ -6,7 +6,7 @@
 {{#list}}
 <li class="{{class.category}}" data-model="true" {{data 'model'}}>
   {{#using program=program}}
-  <a href="{{#is_allowed 'view_object_page' 'Program' context=program.context}}{{viewLink}}{{else}}/dashboard#audit_widget/audit/{{id}}{{/is_allowed}}" class="show-extended">
+  <a href="{{viewLink}}" class="show-extended">
       <div>
         <span class="lhs-item lhs-item-medium">
           {{title}}


### PR DESCRIPTION
This PR removes obsolete behavior for opening My Work page on clicking the Audit link in LHN.

Preconditions:
1. Created program, audit, assessment with assignee (progcreator@reciprocitylabs.com)
Steps to reproduce:
1. Log as progcreator@reciprocitylabs.com (engage007)
2. Open LHN and search the created audit
3. Click on the audit in LHN after search: confirm My Work page is displayed
Actual Result: My Work page is displayed after search for an audit in LHN and click on it under GC role
Expected Result: Audit Info page is displayed after search for an audit in LHN and click on it under GC role