### PR TITLE
GGRC-349 Change attribute name to avoid collision

### DIFF
--- a/src/ggrc/assets/mustache/components/inline_edit/inline.mustache
+++ b/src/ggrc/assets/mustache/components/inline_edit/inline.mustache
@@ -7,7 +7,7 @@
             {{#if context.isEdit}}inline-edit--active{{/if}}
             {{#if readonly}}inline-edit--readonly{{/if}}">
   <h6 class="inline-edit__title">
-    {{firstnonempty title label}}
+    {{firstnonempty titleText label}}
     {{#mandatory}}<span class="required">*</span>{{/mandatory}}
     {{#helptext}}<i class="fa fa-question-circle" rel="tooltip" title="{{helptext}}"></i>{{/helptext}}
   </h6>

--- a/src/ggrc/assets/mustache/custom_attributes/info.mustache
+++ b/src/ggrc/assets/mustache/custom_attributes/info.mustache
@@ -19,7 +19,7 @@
               value="cav.attribute_value"
               {{/if}}
               values="cad.multi_choice_options"
-              title="cad.title"
+              title-text="cad.title"
               label="cad.label"
               type="{{type}}"
               mandatory="cad.mandatory"


### PR DESCRIPTION
This PR changes inline edit title attribute name to avoid collision with html tag attribute.

Steps to reproduce:
1. Navigate to admin dashboard => people tab
2. Open user’s 2nd tier by clicking grey triangle in the 1st tier
3. Hover over the editing CA field on object’s info panel

Actual Result: weird global CA field title “cad.title” is shown when hovering mouse over CA field editing field on info panel
Expected Result: either it should show CA’s title (eg label) or show nothing