### PR TITLE
QUICK-FIX Update raspberry version to 0.10.0

### DIFF
--- a/src/ggrc/settings/default.py
+++ b/src/ggrc/settings/default.py
@@ -35,7 +35,7 @@ try:
 except (ImportError):
   pass
 
-VERSION = "0.9.8-Raspberry" + BUILD_NUMBER
+VERSION = "0.10.0-Raspberry" + BUILD_NUMBER
 
 # Google Analytics variables
 GOOGLE_ANALYTICS_ID = os.environ.get('GGRC_GOOGLE_ANALYTICS_ID', '')


### PR DESCRIPTION
When we decided to bump the minor version so that we could update the patch version for our patches we forgot to update the version displayed in the app itself. This PR corrects this.