### PR TITLE
GGRC-387 Fix blank info pane after deleting object

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/info_pin_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/info_pin_controller.js
@@ -68,7 +68,7 @@ can.Control('CMS.Controllers.InfoPin', {
         $(window).trigger('resize', 0);
       },
       complete: function () {
-        this.element.html('');
+        this.element.height(0).html('');
         $('.cms_controllers_tree_view_node').removeClass('active');
       }.bind(this)
     });


### PR DESCRIPTION
This PR fixes blank info pane after deleting object from 3bb dropdown menu.

Steps to reproduce: 
1. Navigate to assessments tab on audit page 
2. Open assessment’s 2nd tier with mapped objects
3. Click on mapped object’s 1st tier to open its info panel
4. Click 3bbs button and select delete button
5. Confirm deletion: Blank Info panel is displayed

Actual Result: Blank Info pane is displayed in Assessment tab after deleting an object that is mapped to an Assessment
Expected Result: Blank Info pane should not displayed in Assessment tab after deleting an object that is mapped to an Assessment