### PR TITLE
GGRC-459 Fix Assessment status change on Person CA edit

### DIFF
--- a/src/ggrc/models/mixins/autostatuschangeable.py
+++ b/src/ggrc/models/mixins/autostatuschangeable.py
@@ -208,8 +208,9 @@ class AutoStatusChangeable(object):
       return False  # also exits if obj itself is None
 
     histories = (
-        inspect(value).attrs.get("attribute_value").history
+        inspect(value).attrs.get(attr_name).history
         for value in obj.custom_attribute_values
+        for attr_name in ("attribute_value", "attribute_object_id")
     )
 
     for attr_history in histories:

--- a/test/integration/ggrc/models/mixins/test_autostatuschangable.py
+++ b/test/integration/ggrc/models/mixins/test_autostatuschangable.py
@@ -160,6 +160,44 @@ class TestMixinAutoStatusChangeable(integration.ggrc.TestCase):
     self.assertEqual(assessment.status,
                      models.Assessment.PROGRESS_STATE)
 
+  def test_modifying_person_custom_attribute_changes_status(self):
+    """Test that changing a Person CA changes the status to in progress."""
+    person_id = models.Person.query.first().id
+    _, another_person = self.objgen.generate_person()
+
+    # define a Custom Attribute of type Person...
+    _, ca_def = self.objgen.generate_custom_attribute(
+        definition_type="assessment",
+        attribute_type="Map:Person",
+        title="best employee")
+
+    # create assessment with a Person Custom Attribute set, make sure the
+    # state is set to final
+    assessment = self.create_simple_assessment()
+
+    custom_attribute_values = [{
+        "custom_attribute_id": ca_def.id,
+        "attribute_value": "Person:" + str(person_id),
+    }]
+    self.api_helper.modify_object(assessment, {
+        "custom_attribute_values": custom_attribute_values
+    })
+
+    assessment = self.change_status(assessment, assessment.FINAL_STATE)
+    assessment = self.refresh_object(assessment)
+
+    # now change the Person CA and check what happens with the status
+    custom_attribute_values = [{
+        "custom_attribute_id": ca_def.id,
+        "attribute_value": "Person:" + str(another_person.id),  # make a change
+    }]
+    self.api_helper.modify_object(assessment, {
+        "custom_attribute_values": custom_attribute_values
+    })
+
+    assessment = self.refresh_object(assessment)
+    self.assertEqual(assessment.status, models.Assessment.PROGRESS_STATE)
+
   @classmethod
   def create_assignees(cls, obj, persons):
     """Create assignees for object.


### PR DESCRIPTION
This PR fixes automatic transitions to "In Progress" state for Assessments (and other AutoStatusChangeable objects) upon editing a Person CA.

---

**Steps to reproduce:**
  * Create GCA type Person for Assessment
  * Create Assessment
  * Change status to "Ready for Review" or "Verified"
  * Open inline edit for GCA (press confirm in modal), change value and Save

**Actual result:**
Assessment Status not changed

**Expected result:**
Assessment's status should be changed

(screencast: http://www.screencast.com/t/gmkMPnEUVWHI)