### PR TITLE
GGRC-596 Fix save input data on cancel

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment/inline.js
+++ b/src/ggrc/assets/javascripts/components/assessment/inline.js
@@ -96,7 +96,7 @@
           return;
         }
 
-        this.attr('_value', oldValue);
+        this.attr('_value', value);
         this.attr('value', value);
         this.attr('isSaving', true);
       }
@@ -118,7 +118,7 @@
 
         if (!isInside && scope.attr('isEdit')) {
           _.defer(function () {
-            scope.onSave();
+            scope.onCancel(scope);
           });
         }
       }


### PR DESCRIPTION
Steps to reproduce:

1. Navigate to Assessment Info pane in audit page
2. Change the value in GCA field with Person type from precondition: confirm Assessment changes the status to In progress
3. Click Complete button
4. Click Verify button
5. Change the value in GCA field 

**Actual**: Saved message and spinner are displayed if edit and don't save the changes in GCA field with Person type in Assessment's Info pane
**Expected**: Saved message and spinner should not displayed if edit and don't save the changes in GCA field with Person type in Assessment's Info pane
