### PR TITLE
GGRC-525 Return JSON in HTTP400

### DIFF
--- a/src/ggrc/app.py
+++ b/src/ggrc/app.py
@@ -49,6 +49,11 @@ def _ensure_session_teardown():
     db.session.remove()
 
 
+def setup_error_handlers(app_):
+  from ggrc.utils import error_handlers
+  error_handlers.register_handlers(app_)
+
+
 def init_models(app_):
   import ggrc.models
   ggrc.models.init_app(app_)
@@ -185,6 +190,8 @@ def _display_sql_queries():
             logger.warning("Statement failed: %s", statement, exc_info=True)
       return response
 
+
+setup_error_handlers(app)
 init_models(app)
 configure_flask_login(app)
 configure_webassets(app)

--- a/src/ggrc/converters/query_helper.py
+++ b/src/ggrc/converters/query_helper.py
@@ -481,7 +481,7 @@ class QueryHelper(object):
         if hasattr(flask.g, "similar_objects_query"):
           joins, order = by_similarity()
         else:
-          raise BadQueryException("Can't order by '__similarity__' when no ",
+          raise BadQueryException("Can't order by '__similarity__' when no "
                                   "'similar' filter was applied.")
       else:
         key, _ = self.attr_name_map[model].get(key, (key, None))

--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -825,7 +825,7 @@ class Resource(ModelView):
         except (IntegrityError, ValidationError, ValueError) as err:
           message = translate_message(err)
           logger.warning(message)
-          return (message, 400, [])
+          raise BadRequest(message)
         except Exception as err:
           logger.exception(err)
           raise
@@ -936,9 +936,8 @@ class Resource(ModelView):
     try:
       src = src[root_attribute]
     except KeyError:
-      return current_app.make_response((
-          'Required attribute "{0}" not found'.format(
-              root_attribute), 400, []))
+      raise BadRequest('Required attribute "{0}" not found'.format(
+          root_attribute))
     with benchmark("Deserialize object"):
       self.json_update(obj, src)
     obj.modified_by_id = get_current_user_id()

--- a/src/ggrc/services/search.py
+++ b/src/ggrc/services/search.py
@@ -4,6 +4,7 @@
 import json
 
 from flask import request, current_app
+from werkzeug.exceptions import BadRequest
 
 import ggrc.models.relationship
 
@@ -17,11 +18,8 @@ def search():
   permission_type = request.args.get('__permission_type', 'read')
   permission_model = request.args.get('__permission_model', None)
   if terms is None:
-    return current_app.make_response((
-        'Query parameter "q" specifying search terms must be provided.',
-        400,
-        [('Content-Type', 'text/plain')],
-    ))
+    raise BadRequest('Query parameter "q" specifying search '
+                     'terms must be provided.')
 
   should_group_by_type = request.args.get('group_by_type', '')
   should_group_by_type = should_group_by_type.lower() == 'true'

--- a/src/ggrc/utils/error_handlers.py
+++ b/src/ggrc/utils/error_handlers.py
@@ -1,0 +1,25 @@
+# Copyright (C) 2016 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Custom HTTP error handlers.
+
+Setup is done in ggrc/app.py
+"""
+
+from flask import current_app
+
+from ggrc.utils import as_json
+
+
+def register_handlers(app):
+  # pylint: disable=unused-variable; we use bad_request in the decorator
+  @app.errorhandler(400)
+  def bad_request(err):
+    """Custom handler for BadRequest error
+
+    Returns JSON object with error code and message in response body.
+    """
+    resp = {"code": 400,
+            "message": err.description}
+    headers = [('Content-Type', 'application/json'), ]
+    return current_app.make_response((as_json(resp), 400, headers),)

--- a/test/integration/ggrc/models/mixins/test_with_similarity_score.py
+++ b/test/integration/ggrc/models/mixins/test_with_similarity_score.py
@@ -409,11 +409,15 @@ class TestWithSimilarityScore(integration.ggrc.TestCase):
         "filters": {"expression": {}},
     }]
 
-    self.assert400(self.client.post(
+    response = self.client.post(
         "/query",
         data=json.dumps(query),
         headers={"Content-Type": "application/json"},
-    ))
+    )
+    self.assert400(response)
+    self.assertEqual(response.json["message"],
+                     "Can't order by '__similarity__' when no 'similar' "
+                     "filter was applied.")
 
     # filter by similarity in one query and order by similarity in another
     query = [
@@ -434,8 +438,9 @@ class TestWithSimilarityScore(integration.ggrc.TestCase):
         },
     ]
 
-    self.assert400(self.client.post(
+    response = self.client.post(
         "/query",
         data=json.dumps(query),
         headers={"Content-Type": "application/json"},
-    ))
+    )
+    self.assert400(response)

--- a/test/integration/ggrc/services/test_collection_post.py
+++ b/test/integration/ggrc/services/test_collection_post.py
@@ -138,6 +138,11 @@ class TestCollectionPost(services.TestCase):
         headers=self.headers(),
     )
     self.assert400(response)
+    self.assertEqual(
+        response.json['message'],
+        "The browser (or proxy) sent a request that this server "
+        "could not understand.",
+    )
 
   def test_bad_content_type(self):
     """Test post with bad content type."""

--- a/test/integration/ggrc/services/test_common.py
+++ b/test/integration/ggrc/services/test_common.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2017 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
+"""Tests for /api/<model> endpoints."""
+
 import json
 import time
 from urlparse import urlparse
@@ -19,36 +21,41 @@ RESOURCE_ALLOWED = ["HEAD", "GET", "PUT", "DELETE", "OPTIONS"]
 
 
 class TestServices(services.TestCase):
+  """Integration tests suite for /api/<model> endpoints common logic."""
 
-  def get_location(self, response):
+  @staticmethod
+  def get_location(response):
     """Ignore the `http://localhost` prefix of the Location"""
     return response.headers["Location"][16:]
 
-  def assertRequiredHeaders(self, response,
-                            headers={"Content-Type": "application/json"}):
+  def assert_required_headers(self, response, headers=None):
+    """Check if response has the provided list of headers."""
+    if headers is None:
+      headers = {"Content-Type": "application/json"}
     self.assertIn("Etag", response.headers)
     self.assertIn("Last-Modified", response.headers)
     self.assertIn("Content-Type", response.headers)
-    for k, v in headers.items():
-      self.assertEqual(v, response.headers.get(k))
+    for header, value in headers.items():
+      self.assertEqual(value, response.headers.get(header))
 
-  def assertAllow(self, response, allowed=None):
+  def assert_allow(self, response, allowed=None):
     self.assert405(response)
     self.assertIn("Allow", response.headers)
     if allowed:
       self.assertItemsEqual(allowed, response.headers["Allow"].split(", "))
 
-  def assertOptions(self, response, allowed):
+  def assert_options(self, response, allowed):
     self.assertIn("Allow", response.headers)
     self.assertItemsEqual(allowed, response.headers["Allow"].split(", "))
 
-  def headers(self, *args, **kwargs):
+  @staticmethod
+  def headers(*args, **kwargs):
     ret = list(args)
     ret.append(("X-Requested-By", "Unit Tests"))
     ret.extend(kwargs.items())
     return ret
 
-  def test_X_Requested_By_required(self):
+  def test_x_requested_by_required(self):
     response = self.client.post(self.mock_url())
     self.assert400(response)
     self.assertEqual(response.json['message'],
@@ -71,12 +78,12 @@ class TestServices(services.TestCase):
     self.assert404(response)
 
   def test_collection_put(self):
-    self.assertAllow(
+    self.assert_allow(
         self.client.put(self.mock_url(), headers=self.headers()),
         COLLECTION_ALLOWED)
 
   def test_collection_delete(self):
-    self.assertAllow(
+    self.assert_allow(
         self.client.delete(self.mock_url(), headers=self.headers()),
         COLLECTION_ALLOWED)
 
@@ -85,7 +92,7 @@ class TestServices(services.TestCase):
     mock = self.mock_model(foo=foo_param)
     response = self.client.get(self.mock_url(mock.id), headers=self.headers())
     self.assert200(response)
-    self.assertRequiredHeaders(response)
+    self.assert_required_headers(response)
     return response
 
   def test_put_successful(self):
@@ -271,12 +278,12 @@ class TestServices(services.TestCase):
     mock = self.mock_model()
     response = self.client.open(
         self.mock_url(mock.id), method="OPTIONS", headers=self.headers())
-    self.assertOptions(response, RESOURCE_ALLOWED)
+    self.assert_options(response, RESOURCE_ALLOWED)
 
   def test_collection_options(self):
     response = self.client.open(
         self.mock_url(), method="OPTIONS", headers=self.headers())
-    self.assertOptions(response, COLLECTION_ALLOWED)
+    self.assert_options(response, COLLECTION_ALLOWED)
 
   def test_get_bad_accept(self):
     mock1 = self.mock_model(foo="baz")

--- a/test/integration/ggrc/services/test_query.py
+++ b/test/integration/ggrc/services/test_query.py
@@ -194,6 +194,8 @@ class TestAdvancedQueryAPI(BaseQueryAPITestCase):
     )
     response = self._post(data)
     self.assert400(response)
+    self.assertEqual(response.json['message'],
+                     "Field 'effective date' expects a '%m/%d/%Y' date")
 
   def test_basic_query_text_search(self):
     """Filter by fulltext search."""
@@ -306,29 +308,44 @@ class TestAdvancedQueryAPI(BaseQueryAPITestCase):
     """Invalid limit parameters are handled properly."""
 
     # invalid "from"
-    self.assert400(self._post(
+    response = self._post(
         self._make_query_dict("Program", limit=["invalid", 12]),
-    ))
+    )
+    self.assert400(response)
+    self.assertEqual(response.json['message'],
+                     "Invalid limit operator. Integers expected.")
 
     # invalid "to"
-    self.assert400(self._post(
+    response = self._post(
         self._make_query_dict("Program", limit=[0, "invalid"]),
-    ))
+    )
+    self.assert400(response)
+    self.assertEqual(response.json['message'],
+                     "Invalid limit operator. Integers expected.")
 
     # "from" >= "to"
-    self.assert400(self._post(
+    response = self._post(
         self._make_query_dict("Program", limit=[12, 0]),
-    ))
+    )
+    self.assert400(response)
+    self.assertEqual(response.json['message'],
+                     "Limit start should be smaller than end.")
 
     # negative "from"
-    self.assert400(self._post(
+    response = self._post(
         self._make_query_dict("Program", limit=[-2, 10]),
-    ))
+    )
+    self.assert400(response)
+    self.assertEqual(response.json['message'],
+                     "Limit cannot contain negative numbers.")
 
     # negative "to"
-    self.assert400(self._post(
+    response = self._post(
         self._make_query_dict("Program", limit=[2, -10]),
-    ))
+    )
+    self.assert400(response)
+    self.assertEqual(response.json['message'],
+                     "Limit cannot contain negative numbers.")
 
   def test_query_order_by(self):
     """Results get sorted by own field."""
@@ -729,6 +746,8 @@ class TestQueryWithCA(BaseQueryAPITestCase):
     )
     response = self._post(data)
     self.assert400(response)
+    self.assertEqual(response.json['message'],
+                     "Field 'ca date' expects a '%m/%d/%Y' date")
 
   def test_ca_query_different_types_local_ca(self):
     """Filter by local CAs with same title and different types."""

--- a/test/integration/ggrc/services/test_response_codes.py
+++ b/test/integration/ggrc/services/test_response_codes.py
@@ -48,7 +48,9 @@ class TestCollectionPost(services.TestCase):
         }}
     )
     response = self._post(data)
-    self.assertStatus(response, 400)
+    self.assert400(response)
+    # TODO: check why response.json contains unwrapped string
+    self.assertEqual(response.json, "raised Value Error")
 
     data = json.dumps({
         'services_test_mock_model': {
@@ -59,10 +61,15 @@ class TestCollectionPost(services.TestCase):
         }}
     )
     response = self._post(data)
-    self.assertStatus(response, 400)
+    self.assert400(response)
+    # TODO: check why response.json contains unwrapped string
+    self.assertEqual(response.json, "raised Validation Error")
 
     response = self._post("what")
-    self.assertStatus(response, 400)
+    self.assert400(response)
+    self.assertEqual(response.json["message"],
+                     "The browser (or proxy) sent a request that this server "
+                     "could not understand.")
 
   @patch("ggrc.rbac.permissions.is_allowed_create_for")
   def test_post_forbidden(self, is_allowed):

--- a/test/integration/ggrc/services/test_search.py
+++ b/test/integration/ggrc/services/test_search.py
@@ -70,3 +70,11 @@ class TestResource(TestCase):
     entries = self.search("Control", relevant_objects=ids)
     self.assertEqual({entry["id"] for entry in entries},
                      {self.objects[2].id})
+
+  def test_search_fail_with_terms_none(self):
+    """Test search to fail with BadRequest (400 Error) when terms are None."""
+    query = '/search?types={}&counts_only={}'.format("Control", False)
+    response = self.api.tc.get(query)
+    self.assert400(response)
+    self.assertEqual(response.json['message'], 'Query parameter "q" '
+                     'specifying search terms must be provided.')

--- a/test/integration/ggrc_workflows/test_api_calls.py
+++ b/test/integration/ggrc_workflows/test_api_calls.py
@@ -24,6 +24,7 @@ class TestWorkflowsApiPost(TestCase):
     del data["workflow"]["context"]
     response = self.api.post(Workflow, data)
     self.assert400(response)
+    # TODO: check why response.json["message"] is empty
 
   def test_create_one_time_workflows(self):
     data = self.get_workflow_dict()


### PR DESCRIPTION
The frontend guys requested JSON values to be returned for HTTP400 errors to be able to parse the error messages easily. This PR defines basic JSON error logic: return `{"code": 400, "message": exc.message}` in the body of HTTP400.

This PR enables some frontend enhancements, so I'm marking it with `please review`.