### PR TITLE
GGRC-740 Fix app freeze on delete mapped object

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/tree/tree-view.js
+++ b/src/ggrc/assets/javascripts/controllers/tree/tree-view.js
@@ -701,7 +701,7 @@
       setTimeout(this._ifNotRemoved(function () {
         if (this._remove_marker === removeMarker) {
           can.each(this.oldList, function (v) {
-            this.element.trigger('removeChild', v);
+            this.element.trigger('removeChildNode', v);
           }.bind(this));
           this.oldList = null;
           this._remove_marker = null;
@@ -837,7 +837,7 @@
       return res;
     },
 
-    ' removeChild': function (el, ev, data) { // eslint-disable-line quote-props
+    ' removeChildNode': function (el, ev, data) { // eslint-disable-line quote-props
       var that = this;
       var instance;
 

--- a/src/ggrc/assets/javascripts/models/cacheable.js
+++ b/src/ggrc/assets/javascripts/models/cacheable.js
@@ -759,23 +759,6 @@
       if (!this._pending_joins) {
         this.attr('_pending_joins', []);
       }
-
-    // Listen for `stub_destroyed` change events and nullify or remove the
-    // corresponding property or list item.
-      this.bind('change', function (ev, path, how, newVal, oldVal) {
-        var m, n;
-        m = path.match(/(.*?)\.stub_destroyed$/);
-        if (m) {
-          n = m[1].match(/^([^.]+)\.(\d+)$/);
-          if (n) {
-            that.attr(n[1]).splice(parseInt(n[2], 10), 1);
-          } else {
-            n = m[1].match(/^([^.]+)$/);
-            if (n)
-              that.removeAttr(n[1]);
-          }
-        }
-      });
     },
     load_custom_attribute_definitions: function () {
       var definitions;


### PR DESCRIPTION
This PR fixes app freeze on delete mapped object.

Precondition:
Created program, audit
Steps to reproduce:
1. Go to audit page
2. Create Assessment and map several objects to assessment through unified mapper (e.g. Access Group)
3. In Assessment's tab open second tier in tree view and select the mapped object (Access Group)
4. Expand 3 bb's menu in Access Group Info pane
5. Click Delete button: the system freezes
6. Click Delete button once again: "access group not found." error message is displayed
Actual Result: The app freezes if delete mapped object to audit from second tier in Assessment tab
Expected Result: The app should not freeze if delete mapped object to audit from second tier in Assessment tab. The objected is deleted form the tree view.
