### PR TITLE
GGRC-724, GGRC-487 Revert amend last revision with owners

### DIFF
--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -341,9 +341,12 @@ def _get_log_revisions(current_user_id, obj=None, force_obj=False):
       for obj_ in objects:
         revision = Revision(obj_, current_user_id, action, obj_.log_json())
         revisions.append(revision)
-        if obj_.type == "ObjectOwner":
-          from ggrc.utils import revisions as revision_utils
-          revision_utils.refresh_single_revison(obj_.ownable)
+        if obj_.type == "ObjectOwner" and obj_.ownable:
+          # any change (create/delete/modify) of the owners is an edit on the
+          # original object. That is why the action is always set to modified.
+          revision = Revision(obj_.ownable, current_user_id, "modified",
+                              obj_.ownable.log_json())
+          revisions.append(revision)
 
     if force_obj and obj is not None and obj not in cache.dirty:
       # If the ``obj`` has been updated, but only its custom attributes have

--- a/src/ggrc/utils/revisions.py
+++ b/src/ggrc/utils/revisions.py
@@ -88,18 +88,3 @@ def do_refresh_revisions():
   for type_, rows in rows_by_type.iteritems():
     logger.info("Updating revisions for: %s", type_)
     _fix_type_revisions(type_, rows)
-
-
-def refresh_single_revison(obj):
-  """Refresh last revision of a given object."""
-  if not obj or not obj.id:
-    logger.warning("Can not refresh revisions of new objects.")
-    return
-  revision = all_models.Revision.query.filter(
-      all_models.Revision.resource_id == obj.id,
-      all_models.Revision.resource_type == obj.type,
-  ).order_by(all_models.Revision.id.desc()).first()
-  if revision and revision.action in {"created", "modified"}:
-    new_content = obj.log_json()
-    if revision.content != new_content:
-      revision.content = new_content

--- a/test/integration/ggrc/converters/test_import_csv.py
+++ b/test/integration/ggrc/converters/test_import_csv.py
@@ -33,7 +33,7 @@ class TestBasicCsvImport(converters.TestCase):
     revisions = models.Revision.query.filter(
         models.Revision.resource_type == "Policy"
     ).count()
-    self.assertEqual(revisions, 3)
+    self.assertEqual(revisions, 6)
     policy = models.Policy.eager_query().first()
     self.assertEqual(policy.modified_by.email, "user@example.com")
 

--- a/test/integration/ggrc/converters/test_import_update.py
+++ b/test/integration/ggrc/converters/test_import_update.py
@@ -30,7 +30,7 @@ class TestImportUpdates(TestCase):
         models.Revision.resource_type == "Policy",
         models.Revision.resource_id == policy.id
     ).count()
-    self.assertEqual(revision_count, 1)
+    self.assertEqual(revision_count, 2)
 
     filename = "policy_basic_import_update.csv"
     response = self.import_file(filename)
@@ -42,5 +42,5 @@ class TestImportUpdates(TestCase):
         models.Revision.resource_type == "Policy",
         models.Revision.resource_id == policy.id
     ).count()
-    self.assertEqual(revision_count, 2)
+    self.assertEqual(revision_count, 4)
     self.assertEqual(policy.owners[0].email, "user1@example.com")

--- a/test/integration/ggrc/snapshotter/test_snapshoting.py
+++ b/test/integration/ggrc/snapshotter/test_snapshoting.py
@@ -177,9 +177,8 @@ class TestSnapshoting(SnapshotterBaseTestCase):
     control_revisions = db.session.query(models.Revision).filter(
         models.Revision.resource_type == control.type,
         models.Revision.resource_id == control.id)
-    self.assertEqual(
-        control_revisions.count(), 3,
-        "There were 3 edits made at the time")
+    # 2 revisions are from the initial creation, and 2 are from edits.
+    self.assertEqual(control_revisions.count(), 4)
 
     self.assertEqual(
         control_revisions.order_by(models.Revision.id.desc()).first().id,
@@ -581,7 +580,7 @@ class TestSnapshoting(SnapshotterBaseTestCase):
     objective_revision = db.session.query(models.Revision).filter(
         models.Revision.resource_type == "Objective",
         models.Revision.resource_id == objective.id
-    ).one()
+    ).all()[-1]
 
     self.assertEquals(objective_snapshot.count(), 1)
     self.assertEquals(objective_snapshot.first().revision_id,
@@ -621,7 +620,7 @@ class TestSnapshoting(SnapshotterBaseTestCase):
     objective_revision = db.session.query(models.Revision).filter(
         models.Revision.resource_type == "Objective",
         models.Revision.resource_id == objective.id
-    ).one()
+    ).all()[-1]
 
     self.assertEquals(objective_snapshot.count(), 1)
     self.assertEquals(objective_snapshot.first().revision_id,

--- a/test/integration/ggrc_basic_permissions/test_creator.py
+++ b/test/integration/ggrc_basic_permissions/test_creator.py
@@ -242,4 +242,4 @@ class TestCreator(TestCase):
 
     self.api.set_user(self.users["creator"])
     check(obj_1, 0)
-    check(obj_2, 1)
+    check(obj_2, 2)


### PR DESCRIPTION
This commit reverts the functionality from https://github.com/google/ggrc-core/pull/4893/commits/c5c610f87a3de8843ed46d7682c2f9d43ff97913


The reverted commit caused a regression where editing object owners via
import would also edit other values in the revision, and with that break
our snapshots functionality. The result of this commit is that on object
owner edits there is an extra event logged for original object
modification.

The difference in the log can be seen here:
![capture 2016-12-05 at 14 23 42](https://cloud.githubusercontent.com/assets/566311/21565783/4e4f438a-ce9c-11e6-9919-6052c5f73bd3.png)

To test this PR you should verify the ticket GGRC-487
- make sure object owners appear in snapshots for new object, that are created via web UI or with imports.
- make sure correct object owners are displayed after editing the object (ui and imports)
