### PR TITLE
GGRC-726 Fix setting GCA value on Regulations

### DIFF
--- a/src/ggrc/assets/javascripts/models/directive_models.js
+++ b/src/ggrc/assets/javascripts/models/directive_models.js
@@ -13,7 +13,9 @@ can.Model.Cacheable("CMS.Models.Directive", {
   , root_model : "Directive"
   , findAll : "/api/directives"
   , findOne : "/api/directives/{id}"
-  , mixins : ["ownable", "contactable", "unique_title", 'timeboxed']
+  , mixins : [
+    'ownable', 'contactable', 'unique_title', 'timeboxed', 'ca_update'
+  ]
   , tree_view_options : {
       list_view : GGRC.mustache_path + "/directives/tree.mustache"
     , footer_view : GGRC.mustache_path + "/base_objects/tree_footer.mustache"
@@ -94,7 +96,6 @@ CMS.Models.Directive("CMS.Models.Standard", {
   , attributes : {}
   , meta_kinds : [ "Standard" ]
   , cache : can.getObject("cache", CMS.Models.Directive, true),
-  mixins: ['ca_update'],
   defaults: {
     status: 'Draft',
     kind: 'Standard'
@@ -125,7 +126,6 @@ CMS.Models.Directive("CMS.Models.Regulation", {
   , attributes : {}
   , meta_kinds : [ "Regulation" ]
   , cache : can.getObject("cache", CMS.Models.Directive, true),
-  mixins: ['ca_update'],
   defaults: {
     status: 'Draft',
     kind: 'Regulation'
@@ -157,7 +157,6 @@ CMS.Models.Directive("CMS.Models.Policy", {
   , attributes : {}
   , meta_kinds : [  "Company Policy", "Org Group Policy", "Data Asset Policy", "Product Policy", "Contract-Related Policy", "Company Controls Policy" ]
   , cache : can.getObject("cache", CMS.Models.Directive, true),
-  mixins: ['ca_update'],
   defaults: {
     status: 'Draft',
     kind: null
@@ -197,7 +196,6 @@ CMS.Models.Directive("CMS.Models.Contract", {
   }
   , meta_kinds : [ "Contract" ]
   , cache : can.getObject("cache", CMS.Models.Directive, true),
-  mixins: ['ca_update'],
   defaults: {
     status: 'Draft',
     kind: 'Contract'


### PR DESCRIPTION
This PR fixes GCA field update on Regulation entities.

Precondition:
1. Created GCA with e.g. rich text type, checkbox for Regulation, created program, Regulation and audit
Steps to reproduce:
1. Navigate to Regulation's Info pane on Program page
2. Fill in GCA field from precondition: confirm the error occurs
3. Refresh the page and look at GCA: the values are not saved
Actual result: "There was a problem saving" error occurs while filling GCA field in Regulation's Info pane
Expected Result: no error displayed. The value in GCA field is saved
