### PR TITLE
GGRC-737 Fix script error when commenting on Dropdown Task

### DIFF
--- a/src/ggrc/assets/javascripts/models/cacheable.js
+++ b/src/ggrc/assets/javascripts/models/cacheable.js
@@ -1144,8 +1144,8 @@
           serial[name] = can.map(val, function (v) {
             var isModel = v && typeof v.save === 'function';
             return isModel ?
-            v.stub().serialize() :
-            v.serialize ? v.serialize() : v;
+                   v.stub().serialize() :
+                   (v && v.serialize) ? v.serialize() : v;
           });
         } else if (typeof val !== 'function') {
           if (that[name] && that[name].isComputed) {


### PR DESCRIPTION
This PR fixes an error when serializing a Task object of type "dropdown" that has not response option selected. It was caused by a bug in the generic model serializer when serializing Array elements that are `undefined` or `null`.

No unit tests, because refactoring the `serialize()` method should probably be done first, i.e. splitting it into multiple smaller methods, as an already existing code comment suggests.

NOTE:
If any (?) of the workflow's Task Groups contains more than one task, you might not  be able to review this PR due to another issue in the `tasksSortList` component (sorting by dates that are ISO strings. This will be handled in a separate PR.

---

**Precondition:**
Activated annually WF with at least one Task of type "dropdown"

**Steps to reproduce:**
  1. Go to Active Cycles tab
  1. Select a "dropdown" task and click the Add Comment button in Task's info pane: confirm JS error is displayed

**Actual Result:**
_"Uncaught TypeError: Cannot read property 'serialize' of undefined"_ error occurs while clicking Add Comment button in Task's Info pane

**Expected Result:**
no error is displayed while adding a comment, the add comment modal opens normally