### PR TITLE
GGRC-465 Create snapshots for existing audits and assessments and issues

### DIFF
--- a/src/ggrc/migrations/env.py
+++ b/src/ggrc/migrations/env.py
@@ -22,14 +22,14 @@ target_metadata = db.metadata
 
 
 def include_symbol(tablename, schema=None):
-    """Exclude some tables from consideration by alembic's 'autogenerate'.
-    """
-    # Exclude `*_alembic_version` tables
-    if re.match(r'.*_alembic_version$', tablename):
-        return False
+  """Exclude some tables from consideration by alembic's 'autogenerate'.
+  """
+  # Exclude `*_alembic_version` tables
+  if re.match(r'.*_alembic_version$', tablename):
+    return False
 
-    # If the tablename didn't match any exclusion cases, return True
-    return True
+  # If the tablename didn't match any exclusion cases, return True
+  return True
 
 
 def run_migrations_offline():

--- a/src/ggrc/migrations/utils/__init__.py
+++ b/src/ggrc/migrations/utils/__init__.py
@@ -7,3 +7,133 @@ Migrations Utility Module.
 Place here your migration helpers that is shared among number of migrations.
 
 """
+
+from collections import namedtuple
+from logging import getLogger
+
+from sqlalchemy.sql import and_
+from sqlalchemy.sql import func
+from sqlalchemy.sql import select
+from sqlalchemy.sql import tuple_
+
+from ggrc.models.relationship import Relationship
+from ggrc.models.revision import Revision
+from ggrc.models.snapshot import Snapshot
+
+
+relationships_table = Relationship.__table__  # pylint: disable=invalid-name
+revisions_table = Revision.__table__  # pylint: disable=invalid-name
+snapshots_table = Snapshot.__table__  # pylint: disable=invalid-name
+
+
+Stub = namedtuple("Stub", ["type", "id"])
+
+logger = getLogger(__name__)  # pylint: disable=invalid-name
+
+
+def get_relationships(connection, type_, id_, filter_types=None):
+  """Get all relationships of individual object"""
+  if not filter_types:
+    relationships = select([relationships_table]).where(and_(
+        relationships_table.c.source_type == type_,
+        relationships_table.c.source_id == id_,
+    )).union(
+        select([relationships_table]).where(and_(
+            relationships_table.c.destination_type == type_,
+            relationships_table.c.destination_id == id_,
+        ))
+    )
+  else:
+    relationships = select([relationships_table]).where(and_(
+        relationships_table.c.source_type == type_,
+        relationships_table.c.source_id == id_,
+        relationships_table.c.destination_type.in_(filter_types)
+    )
+    ).union(
+        select([relationships_table]).where(and_(
+            relationships_table.c.destination_type == type_,
+            relationships_table.c.destination_id == id_,
+            relationships_table.c.source_type.in_(filter_types)
+        ))
+    )
+
+  relationships_ = connection.execute(relationships)
+  related = set()
+  for obj in relationships_:
+    if obj.source_type == type_ and obj.source_id == id_:
+      child = Stub(obj.destination_type, obj.destination_id)
+    else:
+      child = Stub(obj.source_type, obj.source_id)
+    related.add(child)
+  return related
+
+
+def get_relationship_cache(connection, type_, filter_types=None):
+  """Get all relationships of specified object type.
+
+  For "Program", it will build a cache of all relationships of all
+  programs."""
+  if not filter_types:
+    relationships = select([relationships_table]).where(and_(
+        relationships_table.c.source_type == type_,
+    )).union(
+        select([relationships_table]).where(and_(
+            relationships_table.c.destination_type == type_,
+        ))
+    )
+  else:
+    relationships = select([relationships_table]).where(and_(
+        relationships_table.c.source_type == type_,
+        relationships_table.c.destination_type.in_(filter_types)
+    )
+    ).union(
+        select([relationships_table]).where(and_(
+            relationships_table.c.destination_type == type_,
+            relationships_table.c.source_type.in_(filter_types)
+        ))
+    )
+
+  relationships_ = connection.execute(relationships)
+  from collections import defaultdict
+  cache = defaultdict(set)
+  for obj in relationships_:
+    if obj.source_type == type_:
+      source = Stub(obj.source_type, obj.source_id)
+      target = Stub(obj.destination_type, obj.destination_id)
+    else:
+      source = Stub(obj.destination_type, obj.destination_id)
+      target = Stub(obj.source_type, obj.source_id)
+    cache[source].add(target)
+  return cache
+
+
+def get_revisions(connection, objects):
+  """Get latest revisions of provided objects."""
+  revisions = select([
+      func.max(revisions_table.c.id),
+      revisions_table.c.resource_type,
+      revisions_table.c.resource_id,
+  ]).where(
+      tuple_(
+          revisions_table.c.resource_type,
+          revisions_table.c.resource_id).in_(objects)
+  ).group_by(revisions_table.c.resource_type, revisions_table.c.resource_id)
+  revisions_ = {
+      Stub(rtype, rid): id_ for id_, rtype, rid in
+      connection.execute(revisions).fetchall()
+  }
+  return revisions_
+
+
+def insert_payloads(connection, snapshots_payload, relationships_payload):
+  """Bulk insert snapshot and relationship payloads and create applicable
+  revisions."""
+
+  if snapshots_payload:
+    connection.execute(
+        snapshots_table.insert().prefix_with("IGNORE"), snapshots_payload)
+
+  if relationships_payload:
+    connection.execute(
+        relationships_table.insert().prefix_with("IGNORE"),
+        relationships_payload)

--- a/src/ggrc/migrations/utils/resolve_duplicates.py
+++ b/src/ggrc/migrations/utils/resolve_duplicates.py
@@ -18,6 +18,16 @@ from ggrc import db
 
 
 def resolve_duplicates(model, attr, separator=u"-"):
+  """Resolve duplicates on a model property
+
+  Check and remove by renaming duplicate attribute for values.
+
+  Args:
+    model: model that will be checked
+    attr: attribute that will be checked
+    separator: (default -) Separator between old attr value and integer
+  """
+  # pylint: disable=invalid-name
   v0, v1 = aliased(model, name="v0"), aliased(model, name="v1")
   query = db.session.query(v0).join(v1, and_(
       getattr(v0, attr) == getattr(v1, attr),

--- a/src/ggrc/migrations/versions/20161117114904_142272c4a0b6_migrate_audits_for_snapshots.py
+++ b/src/ggrc/migrations/versions/20161117114904_142272c4a0b6_migrate_audits_for_snapshots.py
@@ -1,0 +1,299 @@
+# Copyright (C) 2016 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Migrate audits for snapshots
+
+Create Date: 2016-11-17 11:49:04.547216
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+from logging import getLogger
+
+from alembic import op
+
+from sqlalchemy.sql import and_
+from sqlalchemy.sql import column
+from sqlalchemy.sql import func
+from sqlalchemy.sql import select
+from sqlalchemy.sql import table
+from sqlalchemy.sql import tuple_
+
+from ggrc.models.event import Event
+from ggrc.models.relationship import Relationship
+from ggrc.models.revision import Revision
+from ggrc.models.snapshot import Snapshot
+from ggrc.models.assessment import Assessment
+from ggrc.models.issue import Issue
+
+from ggrc.migrations.utils import get_relationship_cache
+from ggrc.migrations.utils import get_revisions
+from ggrc.migrations.utils import insert_payloads
+from ggrc.migrations.utils import Stub
+
+from ggrc.migrations.utils.migrator import get_migration_user_id
+
+from ggrc.snapshotter.rules import Types
+
+
+logger = getLogger(__name__)  # pylint: disable=invalid-name
+
+
+# revision identifiers, used by Alembic.
+revision = '142272c4a0b6'
+down_revision = '579239d161e1'
+
+relationships_table = Relationship.__table__
+events_table = Event.__table__
+snapshots_table = Snapshot.__table__
+revisions_table = Revision.__table__
+
+assessments_table = Assessment.__table__
+issues_table = Issue.__table__
+
+audits_table = table(
+    "audits",
+    column("id"),
+    column("context_id"),
+    column("program_id"),
+)
+
+programs_table = table(
+    "programs",
+    column("id"),
+    column("context_id")
+)
+
+
+def create_snapshots(connection, user_id, caches, audits):
+  """Create snapshots and relationships to programs"""
+  # pylint: disable=too-many-locals
+  relationships_payload = []
+  snapshots_payload = []
+  snapshot_quads = set()
+
+  program_relationships = caches["program_rels"]
+  audit_relationships = caches["audit_rels"]
+  program_contexts = caches["program_contexts"]
+  revisions_cache = caches["revisions"]
+
+  for audit in audits:
+    parent_key = Stub("Audit", audit.id)
+    program_key = Stub("Program", audit.program_id)
+    audit_scope_objects = audit_relationships[parent_key]
+    program_scope_objects = program_relationships[program_key]
+    missing_in_program_scope = audit_scope_objects - program_scope_objects
+
+    if missing_in_program_scope:
+      for obj_ in missing_in_program_scope:
+        if obj_ in revisions_cache:
+          relationships_payload += [{
+              "source_type": "Program",
+              "source_id": audit.program_id,
+              "destination_type": obj_.type,
+              "destination_id": obj_.id,
+              "modified_by_id": user_id,
+              "context_id": program_contexts[audit.program_id],
+          }]
+
+    if audit_scope_objects:
+      for obj_ in audit_scope_objects:
+        if obj_ in revisions_cache:
+          quad = ("Audit", audit.id, obj_.type, obj_.id)
+          snapshot_quads.add(quad)
+          snapshots_payload += [{
+              "parent_type": "Audit",
+              "parent_id": audit.id,
+              "child_type": obj_.type,
+              "child_id": obj_.id,
+              "revision_id": revisions_cache[obj_],
+              "context_id": audit.context_id,
+              "modified_by_id": user_id,
+          }]
+          # this is because of our hack where we rely on relationships
+          # to actually show objects
+          relationships_payload += [{
+              "source_type": "Audit",
+              "source_id": audit.id,
+              "destination_type": obj_.type,
+              "destination_id": obj_.id,
+              "modified_by_id": user_id,
+              "context_id": audit.context_id,
+          }]
+        else:
+          logger.warning(
+              "Missing revision for object %s-%s", obj_.type, obj_.id)
+
+  insert_payloads(connection, snapshots_payload, relationships_payload)
+  return snapshot_quads
+
+
+def process_audits(connection, user_id, caches, audits):
+  """Process audits"""
+  snapshot_quads = create_snapshots(connection, user_id, caches, audits)
+
+  relationships_payload = []
+  if snapshot_quads:
+    snapshots = connection.execute(select([snapshots_table]).where(
+        tuple_(
+            Snapshot.parent_type,
+            Snapshot.parent_id,
+            Snapshot.child_type,
+            Snapshot.child_id,
+        ).in_(snapshot_quads)
+    )).fetchall()
+    snapshot_cache = {
+        (obj_.parent_type, obj_.parent_id,
+         obj_.child_type, obj_.child_id): (obj_.id, obj_.context_id)
+        for obj_ in snapshots
+    }
+    for snapshot in snapshot_quads:
+      relationships_payload += [{
+          "source_type": snapshot[2],
+          "source_id": snapshot[3],
+          "destination_type": "Snapshot",
+          "destination_id": snapshot_cache[snapshot][0],
+          "modified_by_id": user_id,
+          "context_id": snapshot_cache[snapshot][1],
+      }]
+
+    if relationships_payload:
+      connection.execute(
+          relationships_table.insert().prefix_with("IGNORE"),
+          relationships_payload)
+
+
+def validate_database(connection):
+  """Validate that there are no invalid objects in the database before performing
+  any operations"""
+  # pylint: disable=too-many-locals
+  audits_more = []
+  ghost_objects = []
+
+  tables = [
+      ("Assessment", assessments_table),
+      ("Issue", issues_table),
+  ]
+
+  for (klass_name, table_) in tables:
+    sql_base_left = select([
+        func.count(relationships_table.c.id).label("relcount"),
+        relationships_table.c.source_id.label("object_id"),
+    ]).where(
+        and_(
+            relationships_table.c.source_type == klass_name,
+            relationships_table.c.destination_type == "Audit"
+        )
+    ).group_by(relationships_table.c.source_id)
+
+    sql_base_right = select([
+        func.count(relationships_table.c.id).label("relcount"),
+        relationships_table.c.destination_id.label("object_id"),
+    ]).where(
+        and_(
+            relationships_table.c.destination_type == klass_name,
+            relationships_table.c.source_type == "Audit"
+        )
+    ).group_by(relationships_table.c.destination_id)
+
+    sql_left_more = sql_base_left.having(sql_base_left.c.relcount > 1)
+    sql_right_more = sql_base_right.having(sql_base_right.c.relcount > 1)
+    sql_left_one = sql_base_left.having(sql_base_left.c.relcount == 1)
+    sql_right_one = sql_base_right.having(sql_base_right.c.relcount == 1)
+
+    result_left_more = connection.execute(sql_left_more).fetchall()
+    result_right_more = connection.execute(sql_right_more).fetchall()
+    result_more = result_left_more + result_right_more
+
+    result_left_one = connection.execute(sql_left_one).fetchall()
+    result_right_one = connection.execute(sql_right_one).fetchall()
+    result_one = result_left_one + result_right_one
+
+    all_object_ids = {
+        x.id for x in connection.execute(select([table_.c.id])).fetchall()
+    }
+    to_audit_mapped_ids = {
+        x.object_id for x in result_more + result_one
+    }
+
+    result_zero = all_object_ids - to_audit_mapped_ids
+
+    if result_more:
+      audits_more += [(klass_name, result_more)]
+    if result_zero:
+      ghost_objects += [(klass_name, result_zero)]
+  return audits_more, ghost_objects
+
+
+def upgrade():
+  """Migrate audit-related data and concepts to audit snapshots"""
+  # pylint: disable=too-many-locals
+
+  connection = op.get_bind()
+
+  audits_more, ghost_objects = validate_database(connection)
+
+  if audits_more or ghost_objects:
+    if audits_more:
+      for klass_name, result in audits_more:
+        ids = [id_ for _, id_ in result]
+        logger.warning(
+            "The following %s have more than one Audit: %s",
+            klass_name,
+            ",".join(map(str, ids))  # pylint: disable=bad-builtin
+        )
+    if ghost_objects:
+      for klass_name, result in ghost_objects:
+        logger.warning(
+            "The following %s have no Audits mapped to them: %s",
+            klass_name,
+            ",".join(map(str, result))  # pylint: disable=bad-builtin
+        )
+    raise Exception("Cannot perform migration. Check logger warnings.")
+
+  audits = connection.execute(audits_table.select()).fetchall()
+  if audits:
+    program_ids = {audit.program_id for audit in audits}
+
+    program_sql = select([programs_table]).where(
+        programs_table.c.id.in_(program_ids)
+    )
+    programs = connection.execute(program_sql)
+    program_contexts = {program.id: program.context_id for program in programs}
+
+    program_relationships = get_relationship_cache(
+        connection, "Program", Types.all)
+    audit_relationships = get_relationship_cache(
+        connection, "Audit", Types.all)
+
+    all_objects = (program_relationships.values() +
+                   audit_relationships.values())
+    revisionable_objects = set()
+    revisionable_objects = revisionable_objects.union(*all_objects)
+    revision_cache = get_revisions(connection, revisionable_objects)
+
+    objects_missing_revision = (revisionable_objects -
+                                set(revision_cache.keys()))
+    if objects_missing_revision:
+      missing = ",".join(
+          ["{obj.type}-{obj.id}".format(obj=obj)
+           for obj in objects_missing_revision])
+      logger.warning(
+          "The following objects are missing revisions: %s", missing)
+      raise Exception("There are still objects with missing revisions!")
+
+    caches = {
+        "program_contexts": program_contexts,
+        "program_rels": program_relationships,
+        "audit_rels": audit_relationships,
+        "revisions": revision_cache
+    }
+
+    user_id = get_migration_user_id(connection)
+
+    process_audits(connection, user_id, caches, audits)
+
+
+def downgrade():
+  pass

--- a/src/ggrc/migrations/versions/20161220161315_275cd0dcaea_migrate_assessments_issues_data.py
+++ b/src/ggrc/migrations/versions/20161220161315_275cd0dcaea_migrate_assessments_issues_data.py
@@ -1,0 +1,334 @@
+# Copyright (C) 2016 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+migrate-assessments-issues-data
+
+Create Date: 2016-12-20 16:13:15.208946
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+from collections import defaultdict
+from logging import getLogger
+
+from alembic import op
+
+from sqlalchemy.sql import column
+from sqlalchemy.sql import select
+from sqlalchemy.sql import table
+from sqlalchemy.sql import tuple_
+
+from ggrc.models.assessment import Assessment
+from ggrc.models.event import Event
+from ggrc.models.request import Request
+from ggrc.models.issue import Issue
+from ggrc.models.relationship import Relationship
+from ggrc.models.revision import Revision
+from ggrc.models.snapshot import Snapshot
+
+from ggrc.snapshotter.rules import Types
+
+from ggrc.migrations.utils import get_relationship_cache
+from ggrc.migrations.utils import get_revisions
+from ggrc.migrations.utils import insert_payloads
+from ggrc.migrations.utils import Stub
+from ggrc.migrations.utils.migrator import get_migration_user_id
+
+
+logger = getLogger(__name__)  # pylint: disable=invalid-name
+
+
+# revision identifiers, used by Alembic.
+revision = '275cd0dcaea'
+down_revision = '142272c4a0b6'
+
+assessments_table = Assessment.__table__
+requests_table = Request.__table__
+issues_table = Issue.__table__
+snapshots_table = Snapshot.__table__
+revisions_table = Revision.__table__
+relationships_table = Relationship.__table__
+events_table = Event.__table__
+
+audits_table = table(
+    "audits",
+    column("id"),
+    column("context_id"),
+    column("program_id"),
+)
+
+programs_table = table(
+    "programs",
+    column("id"),
+    column("context_id")
+)
+
+
+def process_objects(connection, user_id, caches, object_settings):
+  """Process objects
+
+  Used for processing of Assessments and Issues
+  """
+  # pylint: disable=too-many-locals
+
+  snapshot_quads = get_or_create_snapshots(connection, user_id,
+                                           caches, object_settings)
+
+  link_snapshots_to_objects(connection, user_id, caches, object_settings,
+                            snapshot_quads)
+
+
+def get_or_create_snapshots(connection, user_id,
+                            caches, object_settings):
+  """Get or create snapshots for specific object type"""
+  # pylint: disable=too-many-locals
+  relationships_payload = []
+  snapshots_payload = []
+  snapshot_quads = set()
+
+  program_relationships = caches["program_rels"]
+  parent_snapshot_cache = caches["snapshots"]
+  program_contexts = caches["program_contexts"]
+  audit_programs = caches["audit_programs"]
+  audit_contexts = caches["audit_contexts"]
+  revisions_cache = caches["revisions"]
+
+  object_klass = object_settings["type"]
+  object_relationships = object_settings["object_relationships"]
+  object_select = object_settings["select_all"]
+
+  all_objects = connection.execute(object_select).fetchall()
+
+  for object_ in all_objects:
+    key = Stub(object_klass, object_.id)
+    objects = object_relationships[key]
+    audit = [x for x in objects if x.type == "Audit"]
+    others = [x for x in objects if x.type in Types.all]
+
+    if len(audit) != 1:
+      continue
+
+    if audit:
+      audit = audit[0]
+      others = set(others)
+
+      quads = {
+          ("Audit", audit.id, obj_.type, obj_.id)
+          for obj_ in others
+      }
+      snapshot_quads.update(quads)
+
+      program_id = audit_programs[audit.id]
+      program_ctx_id = program_contexts[program_id]
+
+      existing_snapshots = parent_snapshot_cache[audit]
+      missing_snapshots = others - existing_snapshots
+
+      if missing_snapshots:
+        audit_context_id = audit_contexts[audit.id]
+
+        for obj_ in missing_snapshots:
+          if obj_ in revisions_cache:
+            snapshots_payload += [{
+                "parent_type": "Audit",
+                "parent_id": audit.id,
+                "child_type": obj_.type,
+                "child_id": obj_.id,
+                "revision_id": revisions_cache[obj_],
+                "context_id": audit_context_id,
+                "modified_by_id": user_id,
+            }]
+            relationships_payload += [{
+                "source_type": "Program",
+                "source_id": program_id,
+                "destination_type": obj_.type,
+                "destination_id": obj_.id,
+                "modified_by_id": user_id,
+                "context_id": program_ctx_id,
+            }, {
+                # this is because of our hack where we rely on
+                # relationships
+                "source_type": "Audit",
+                "source_id": audit.id,
+                "destination_type": obj_.type,
+                "destination_id": obj_.id,
+                "modified_by_id": user_id,
+                "context_id": audit_context_id,
+            }]
+          else:
+            logger.warning(
+                "Missing revision for object %s-%s", obj_.type, obj_.id)
+
+        missing_from_program_scope = (program_relationships[program_id] -
+                                      existing_snapshots)
+        if missing_from_program_scope:
+          for obj_ in missing_from_program_scope:
+            relationships_payload += [{
+                "source_type": "Program",
+                "source_id": program_id,
+                "destination_type": obj_.type,
+                "destination_id": obj_.id,
+                "modified_by_id": user_id,
+                "context_id": program_ctx_id,
+            }]
+
+  insert_payloads(connection, snapshots_payload, relationships_payload)
+  return snapshot_quads
+
+
+def link_snapshots_to_objects(connection, user_id,
+                              caches, object_settings, snapshot_quads):
+  """Create relationships between snapshots and objects"""
+  # pylint: disable=too-many-locals
+  relationships_payload = []
+
+  audit_contexts = caches["audit_contexts"]
+
+  object_klass = object_settings["type"]
+  object_relationships = object_settings["object_relationships"]
+  object_select = object_settings["select_all"]
+
+  all_objects = connection.execute(object_select).fetchall()
+
+  if snapshot_quads:
+    snapshots = connection.execute(select([snapshots_table]).where(
+        tuple_(
+            Snapshot.parent_type,
+            Snapshot.parent_id,
+            Snapshot.child_type,
+            Snapshot.child_id,
+        ).in_(snapshot_quads)
+    )).fetchall()
+    snapshot_cache = {
+        (obj_.parent_type, obj_.parent_id,
+         obj_.child_type, obj_.child_id): obj_.id
+        for obj_ in snapshots
+    }
+
+    for object_ in all_objects:
+      key = Stub(object_klass, object_.id)
+      objects = object_relationships[key]
+      audit = [x for x in objects if x.type == "Audit"]
+      others = [x for x in objects if x.type in Types.all]
+
+      if len(audit) != 1:
+        continue
+
+      if audit:
+        audit = audit[0]
+        audit_context_id = audit_contexts[audit.id]
+        others = set(others)
+
+        for obj_ in others:
+          quad = ("Audit", audit.id, obj_.type, obj_.id)
+          if quad in snapshot_cache:
+            relationships_payload += [{
+                "source_type": object_klass,
+                "source_id": object_.id,
+                "destination_type": "Snapshot",
+                "destination_id": snapshot_cache[quad],
+                "modified_by_id": user_id,
+                "context_id": audit_context_id,
+            }, {
+                "source_type": obj_.type,
+                "source_id": obj_.id,
+                "destination_type": "Snapshot",
+                "destination_id": snapshot_cache[quad],
+                "modified_by_id": user_id,
+                "context_id": audit_context_id,
+            }]
+          else:
+            logger.warning(
+                "Couldn't map %s-%s to Snapshot of object %s-%s because it "
+                "doesn't exist due to missing revision.",
+                object_klass, object_.id, obj_.type, obj_.id
+            )
+
+  if relationships_payload:
+    connection.execute(
+        relationships_table.insert().prefix_with("IGNORE"),
+        relationships_payload)
+
+
+def get_scope_snapshots(connection):
+  """Create cache of audit snapshots
+
+  Create cache (defaultdict) of audits mapping from audit stub to set of
+  children stubs.
+  """
+  cache = defaultdict(set)
+
+  query = select([snapshots_table])
+  result = connection.execute(query)
+  for snapshot in result:
+    parent = Stub(snapshot.parent_type, snapshot.parent_id)
+    child = Stub(snapshot.child_type, snapshot.child_id)
+    cache[parent].add(child)
+  return cache
+
+
+def upgrade():
+  """Primary upgrade function for upgrading assessments and issues
+
+  Primarily used for building various caches et al."""
+  # pylint: disable=too-many-locals
+  connection = op.get_bind()
+
+  program_sql = select([programs_table])
+  programs = connection.execute(program_sql)
+  program_contexts = {program.id: program.context_id for program in programs}
+
+  audit_sql = select([audits_table])
+  audits = connection.execute(audit_sql).fetchall()
+  if audits:
+    audit_contexts = {audit.id: audit.context_id for audit in audits}
+    audit_programs = {audit.id: audit.program_id for audit in audits}
+
+    program_cache = get_relationship_cache(connection, "Program", Types.all)
+    audit_cache = get_relationship_cache(connection, "Audit", Types.all)
+    parent_snapshot_cache = get_scope_snapshots(connection)
+    assessments_cache = get_relationship_cache(connection, "Assessment",
+                                               Types.all | {"Audit"})
+    issues_cache = get_relationship_cache(connection, "Issue",
+                                          Types.all | {"Audit"})
+
+    all_objects = (program_cache.values() + audit_cache.values() +
+                   assessments_cache.values() + issues_cache.values())
+
+    revisionable_objects = set()
+    revisionable_objects = revisionable_objects.union(*all_objects)
+    revision_cache = get_revisions(connection, revisionable_objects)
+
+    caches = {
+        "program_rels": program_cache,
+        "audit_rels": audit_cache,
+        "snapshots": parent_snapshot_cache,
+        "program_contexts": program_contexts,
+        "audit_programs": audit_programs,
+        "audit_contexts": audit_contexts,
+        "revisions": revision_cache
+    }
+
+    objects = [
+        {
+            "type": "Assessment",
+            "select_all": assessments_table.select(),
+            "object_relationships": assessments_cache
+        },
+        {
+            "type": "Issue",
+            "select_all": issues_table.select(),
+            "object_relationships": issues_cache
+        },
+    ]
+
+    if assessments_cache or issues_cache:
+      user_id = get_migration_user_id(connection)
+
+      for object_settings in objects:
+        process_objects(connection, user_id, caches, object_settings)
+
+
+def downgrade():
+  pass


### PR DESCRIPTION
Test cases that **_have_** to be performed by the reviewer (if more, the merrier):

* usual and correct program and audit with some snapshottable objects
* getting warnings if assessments/issues are mapped to multiple audits
* getting warnings if assessments/issues are orphaned (mapped to 0 audits)
* if assessment/issue is mapped to snapshottable objects that ARE NOT in program scope - ensure object is mapped to program after migration and that snapshot of that object exists
* if assessment/issue is mapped to snapshottable objects that ARE NOT in audit scope - ensure object is snapshotted and relationship between object and program exists after migration and that snapshot of that object exists
* if assessment/issue is mapped to snapshottable objects that ARE NOT in BOTH audit AND program scope - ensure object is snapshotted and relationship between object and program exists after migration and that snapshot of that object exists.

All snapshot relations must also be duplicated via relationship table because we are currently rely on a hack (also verify).

Currently all invalid behavior only issues warnings and does not raises Exceptions:
* https://github.com/google/ggrc-core/pull/4938/files#diff-5faf31cc6bb8b6579bf9aabdf0ee8076R254
* https://github.com/google/ggrc-core/pull/4938/files#diff-5faf31cc6bb8b6579bf9aabdf0ee8076R285