### PR TITLE
GGRC-749 Fix Risk_personable backref

### DIFF
--- a/src/ggrc_risks/models/risk.py
+++ b/src/ggrc_risks/models/risk.py
@@ -8,13 +8,14 @@ from ggrc.models.associationproxy import association_proxy
 from ggrc.models import mixins
 from ggrc.models.deferred import deferred
 from ggrc.models.object_owner import Ownable
+from ggrc.models.object_person import Personable
 from ggrc.models.reflection import PublishOnly
 from ggrc.models.relationship import Relatable
 from ggrc.models.track_object_state import HasObjectState
 
 
 class Risk(HasObjectState, mixins.CustomAttributable, mixins.Stateful,
-           Relatable, mixins.Described, Ownable,
+           Relatable, mixins.Described, Ownable, Personable,
            mixins.WithContact, mixins.Titled, mixins.Timeboxed,
            mixins.Slugged, mixins.Noted, mixins.Hyperlinked, mixins.Base,
            db.Model):


### PR DESCRIPTION
This PR adds a missing backref that caused `ObjectPerson.log_json()` to log a warning when `ObjectPerson.personable_type == 'Risk'`.