### PR TITLE
GGRC-597 Blank fields are displayed after adding a comment in Assessment's Info pane

### DIFF
--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -150,6 +150,7 @@ dashboard-js-files:
   - components/assessment/inline.js
   - components/assessment/add_comment.js
   - components/comment/comment-input.js
+  - components/comment/comment-list-helper.js
   - components/assessment/controls-toolbar/controls-toolbar.js
   - components/mapped-objects/mapped-objects.js
   - components/object-list/object-list.js

--- a/src/ggrc/assets/javascripts/components/comment/comment-list-helper.js
+++ b/src/ggrc/assets/javascripts/components/comment/comment-list-helper.js
@@ -1,0 +1,25 @@
+/*!
+ Copyright (C) 2017 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+(function () {
+  Mustache.registerHelper('if_comment_list_ready',
+    function (instance, options) {
+      var commentsMapping = Mustache.resolve(instance)
+        .get_mapping('comments');
+
+      var commentsDfd = new $.Deferred();
+
+      var resolveCommentsDfd = function () {
+        commentsDfd.resolve();
+        commentsMapping.unbind('length', resolveCommentsDfd);
+      };
+
+      commentsMapping.bind('length', resolveCommentsDfd);
+
+      return Mustache.defer_render('span', function () {
+        return options.fn(options.contexts);
+      }, commentsDfd);
+    });
+})();

--- a/src/ggrc/assets/mustache/base_templates/comment_list.mustache
+++ b/src/ggrc/assets/mustache/base_templates/comment_list.mustache
@@ -5,6 +5,7 @@
 
 {{#instance.class.info_pane_options.comments}}
 {{#add_to_current_scope parent_instance=instance}}
+{{#if_comment_list_ready instance}}
   <mapping-tree-view
     parent-instance="instance"
     is-loading="isLoading"
@@ -13,5 +14,6 @@
     item-template="/static/mustache/base_templates/comment_subtree.mustache"
     >
   </mapping-tree-view>
+{{/if_comment_list_ready instance}}
 {{/add_to_current_scope}}
 {{/instance}}


### PR DESCRIPTION
Steps to reproduce:
1. Navigate to Assessment's Info pane on audit page
2. Go to comment tab and add comment-> Save
3. Look at the added comment: comment displayed with blank field above

Actual Result: blank fields are displayed after adding a comment in Assessment's Info pane
Expected Result: a comment without additional records is displayed in Assessment's Info pane

**NOTE**: It's really hard to reproduce. This PR will also fix comments duplications.

![image](https://cloud.githubusercontent.com/assets/674129/21610945/c991eb6e-d1db-11e6-811b-7157eb7402a3.png)
