### PR TITLE
GGRC-103 Grey out unrelated mapped objects in child tree

### DIFF
--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -43,6 +43,7 @@ dashboard-js-files:
   - plugins/persistent_notifier.js
   - ggrc_base.js
   - plugins/ggrc_utils.js
+  - plugins/utils/current-page-utils.js
   - plugins/datepicker.js
   - plugins/can_control.js
   - plugins/wysiwyg.js

--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -214,6 +214,7 @@ dashboard-js-files:
   - components/tree/tree-header-selector.js
   - components/tree/tree-type-selector.js
   - components/tree/tree-child-show.js
+  - components/tree/sub-tree-expander.js
   - components/view-object-buttons/view-object-buttons.js
   - components/add-object-button/add-object-button.js
   - components/effective-dates/effective-dates.js
@@ -311,6 +312,7 @@ dashboard-js-template-files:
   - base_objects/tree_column_selector.mustache
   - base_objects/tree_column_names.mustache
   - base_objects/tree_child_show.mustache
+  - base_objects/sub_tree_expand.mustache
   - base_objects/filter_trigger.mustache
   - base_objects/generate_assessments_button.mustache
   - base_objects/states.mustache

--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -79,6 +79,7 @@ dashboard-js-files:
   - models/mappers/reifying-list-loader.js
   - models/mappers/tree-base-loader.js
   - models/mappers/tree-page-loader.js
+  - models/mappers/sub-tree-loader.js
   - models/mappers/mapper-helpers.js
   - models/mappers/mappings.js
   - models/mappers/mappings-ggrc.js

--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -213,6 +213,7 @@ dashboard-js-files:
   - components/tree_pagination/tree_pagination.js
   - components/tree/tree-header-selector.js
   - components/tree/tree-type-selector.js
+  - components/tree/tree-child-show.js
   - components/view-object-buttons/view-object-buttons.js
   - components/add-object-button/add-object-button.js
   - components/effective-dates/effective-dates.js
@@ -309,6 +310,7 @@ dashboard-js-template-files:
   - base_objects/tree_view_filter.mustache
   - base_objects/tree_column_selector.mustache
   - base_objects/tree_column_names.mustache
+  - base_objects/tree_child_show.mustache
   - base_objects/filter_trigger.mustache
   - base_objects/generate_assessments_button.mustache
   - base_objects/states.mustache

--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -77,6 +77,7 @@ dashboard-js-files:
   - models/mappers/indirect-list-loader.js
   - models/mappers/search-list-loader.js
   - models/mappers/reifying-list-loader.js
+  - models/mappers/tree-base-loader.js
   - models/mappers/tree-page-loader.js
   - models/mappers/mapper-helpers.js
   - models/mappers/mappings.js

--- a/src/ggrc/assets/javascripts/apps/base_widgets.js
+++ b/src/ggrc/assets/javascripts/apps/base_widgets.js
@@ -8,12 +8,36 @@
   /**
    * Tree View Widgets Configuration module
    */
-  var allTypes = [
-    'AccessGroup', 'Audit', 'Clause', 'Contract', 'Control', 'Assessment',
-    'DataAsset', 'Facility', 'Issue', 'Market', 'Objective', 'OrgGroup',
-    'Person', 'Policy', 'Process', 'Product', 'Program', 'Project',
-    'Regulation', 'Section', 'Standard', 'System', 'Vendor'
-  ];
+    // NOTE: By default, widgets are sorted alphabetically (the value of
+    // the order 100+), but the objects with higher importance that should
+    // be  prioritized use order values below 100. An order value of 0 is
+    // reserved for the "info" widget which always comes first.
+  var defaultOrderTypes = {
+    Assessment: 8,
+    Regulation: 20,
+    Contract: 30,
+    Section: 40,
+    Objective: 50,
+    Control: 60,
+    AccessGroup: 100,
+    Audit: 120,
+    Clause: 130,
+    DataAsset: 140,
+    Facility: 160,
+    Issue: 170,
+    Market: 180,
+    OrgGroup: 190,
+    Person: 200,
+    Policy: 210,
+    Process: 220,
+    Product: 230,
+    Program: 240,
+    Project: 250,
+    Standard: 260,
+    System: 270,
+    Vendor: 280
+  };
+  var allTypes = Object.keys(defaultOrderTypes).sort();
   // Items allowed for mapping via snapshot.
   var snapshotWidgetsConfig = GGRC.config.snapshotable_objects || [];
   // Items allowed for relationship mapping
@@ -28,6 +52,7 @@
     'Program'
   ];
   var baseWidgetsByType;
+  var orderedWidgetsByType = {};
 
   var filteredTypes = _.difference(allTypes, excludeMappingConfig);
   // Audit is excluded and created a separate logic for it
@@ -62,6 +87,15 @@
     Vendor: filteredTypes
   };
 
+  allTypes.forEach(function (type) {
+    var related = baseWidgetsByType[type].slice(0);
+    orderedWidgetsByType[type] = related.sort(function (a, b) {
+      return defaultOrderTypes[a] - defaultOrderTypes[b];
+    });
+  });
+
   GGRC.tree_view = GGRC.tree_view || new can.Map();
   GGRC.tree_view.attr('base_widgets_by_type', baseWidgetsByType);
+  GGRC.tree_view.attr('orderedWidgetsByType', orderedWidgetsByType);
+  GGRC.tree_view.attr('defaultOrderTypes', defaultOrderTypes);
 })(window.GGRC, window._);

--- a/src/ggrc/assets/javascripts/apps/business_objects.js
+++ b/src/ggrc/assets/javascripts/apps/business_objects.js
@@ -50,16 +50,16 @@
       };
     },
     init_widgets: function () {
-      var base_widgets_by_type = GGRC.tree_view.base_widgets_by_type;
-      var widget_list = new GGRC.WidgetList('ggrc_core');
-      var object_class = GGRC.infer_object_type(GGRC.page_object);
-      var object_table = object_class && object_class.table_plural;
+      var baseWidgetsByType = GGRC.tree_view.base_widgets_by_type;
+      var widgetList = new GGRC.WidgetList('ggrc_core');
+      var objectClass = GGRC.infer_object_type(GGRC.page_object);
+      var objectTable = objectClass && objectClass.table_plural;
       var object = GGRC.page_instance();
       var path = GGRC.mustache_path;
-      var info_widget_views;
+      var infoWidgetViews;
       var summaryWidgetViews;
-      var model_names;
-      var possible_model_type;
+      var modelNames;
+      var possibleModelType;
       var treeViewDepth = 2;
       var relatedObjectsChildOptions =
         [GGRC.Utils.getRelatedObjects(treeViewDepth)];
@@ -67,6 +67,7 @@
       var extraDescriptorOptions;
       var overriddenModels;
       var extraContentControllerOptions;
+
       // TODO: Really ugly way to avoid executing IIFE - needs cleanup
       if (!GGRC.page_object) {
         return;
@@ -76,16 +77,16 @@
       summaryWidgetViews = {
         audits: path + '/audits/summary.mustache'
       };
-      if (summaryWidgetViews[object_table]) {
-        widget_list.add_widget(object.constructor.shortName, 'summary', {
+      if (summaryWidgetViews[objectTable]) {
+        widgetList.add_widget(object.constructor.shortName, 'summary', {
           widget_id: 'summary',
           content_controller: GGRC.Controllers.SummaryWidget,
           instance: object,
-          widget_view: summaryWidgetViews[object_table],
+          widget_view: summaryWidgetViews[objectTable],
           order: 3
         });
       }
-      info_widget_views = {
+      infoWidgetViews = {
         programs: path + '/programs/info.mustache',
         audits: path + '/audits/info.mustache',
         people: path + '/people/info.mustache',
@@ -100,17 +101,17 @@
           path + '/assessment_templates/info.mustache',
         issues: path + '/issues/info.mustache'
       };
-      widget_list.add_widget(object.constructor.shortName, 'info', {
+      widgetList.add_widget(object.constructor.shortName, 'info', {
         widget_id: 'info',
         content_controller: GGRC.Controllers.InfoWidget,
         instance: object,
-        widget_view: info_widget_views[object_table],
+        widget_view: infoWidgetViews[objectTable],
         order: 5
       });
-      model_names = can.Map.keys(base_widgets_by_type);
-      model_names.sort();
-      possible_model_type = model_names.slice();
-      can.each(model_names, function (name) {
+      modelNames = can.Map.keys(baseWidgetsByType);
+      modelNames.sort();
+      possibleModelType = modelNames.slice();
+      can.each(modelNames, function (name) {
         var w_list;
         var child_model_list = [];
 
@@ -119,10 +120,10 @@
           display_name: CMS.Models[name].title_singular
         });
         // Initialize child_model_list, and child_display_list each model_type
-        w_list = base_widgets_by_type[name];
+        w_list = baseWidgetsByType[name];
 
         can.each(w_list, function (item) {
-          if (possible_model_type.indexOf(item) !== -1) {
+          if (possibleModelType.indexOf(item) !== -1) {
             child_model_list.push({
               model_name: item,
               display_name: CMS.Models[item].title_singular
@@ -184,7 +185,7 @@
       if (/^\/assessments_view/.test(window.location.pathname)) {
         farModels = ['Assessment'];
       } else {
-        farModels = base_widgets_by_type[object.constructor.shortName];
+        farModels = baseWidgetsByType[object.constructor.shortName];
       }
 
         // here we are going to define extra descriptor options, meaning that
@@ -202,7 +203,7 @@
 
           all.Document = {
             widget_icon: 'fa fa-link!',
-              order: 150
+            order: 150
           };
           all.Person.widget_icon = 'fa fa-person';
           return all;
@@ -211,11 +212,8 @@
           Clause: {
             widget_name: function () {
               var $objectArea = $('.object-area');
-              if ($objectArea.hasClass('dashboard-area')) {
-                return 'Clauses';
-              } else {
-                return 'Mapped Clauses';
-              }
+              return $objectArea.hasClass('dashboard-area') ?
+                'Clauses' : 'Mapped Clauses';
             }
           }
         },
@@ -906,7 +904,7 @@
             content_controller_options: extraContentControllerOptions[object.constructor.shortName][model_name]
           });
         }
-        widget_list.add_widget(object.constructor.shortName, widget_id, descriptor);
+        widgetList.add_widget(object.constructor.shortName, widget_id, descriptor);
       });
     }
   });

--- a/src/ggrc/assets/javascripts/apps/business_objects.js
+++ b/src/ggrc/assets/javascripts/apps/business_objects.js
@@ -61,12 +61,12 @@
       var model_names;
       var possible_model_type;
       var treeViewDepth = 2;
-      var relatedObjectsChildOptions = [GGRC.Utils.getRelatedObjects(treeViewDepth)];
+      var relatedObjectsChildOptions =
+        [GGRC.Utils.getRelatedObjects(treeViewDepth)];
       var farModels;
       var extraDescriptorOptions;
       var overriddenModels;
       var extraContentControllerOptions;
-
       // TODO: Really ugly way to avoid executing IIFE - needs cleanup
       if (!GGRC.page_object) {
         return;
@@ -190,87 +190,23 @@
         // here we are going to define extra descriptor options, meaning that
         //  these will be used as extra options to create widgets on top of
 
-      // NOTE: By default, widgets are sorted alphabetically (the value of
-      // the order 100+), but the objects with higher importance that should
-      // be  prioritized use order values below 100. An order value of 0 is
-      // reserved for the "info" widget which always comes first.
       extraDescriptorOptions = {
-        all: {
-          Standard: {
-            order: 10
-          },
-          Regulation: {
-            order: 20
-          },
-          Contract: {
-            order: 30
-          },
-          Section: {
-            order: 40
-          },
-          Objective: {
-            order: 50
-          },
-          Control: {
-            order: 60
-          },
-          AccessGroup: {
-            order: 100
-          },
-          Assessment: {
-            order: 110
-          },
-          Audit: {
-            order: 120
-          },
-          Clause: {
-            order: 130
-          },
-          DataAsset: {
-            order: 140
-          },
-          Document: {
-            widget_icon: 'fa fa-link',
-            order: 150
-          },
-          Facility: {
-            order: 160
-          },
-          Issue: {
-            order: 170
-          },
-          Market: {
-            order: 180
-          },
-          OrgGroup: {
-            order: 190
-          },
-          Person: {
-            widget_icon: 'fa fa-person',
-            order: 200
-          },
-          Policy: {
-            order: 210
-          },
-          Process: {
-            order: 220
-          },
-          Product: {
-            order: 230
-          },
-          Program: {
-            order: 240
-          },
-          Project: {
-            order: 250
-          },
-          System: {
-            order: 270
-          },
-          Vendor: {
-            order: 280
-          }
-        },
+        all: (function () {
+          var defOrder = GGRC.tree_view.attr('defaultOrderTypes');
+          var all = {};
+          Object.keys(defOrder).forEach(function (type) {
+            all[type] = {
+              order: defOrder[type]
+            };
+          });
+
+          all.Document = {
+            widget_icon: 'fa fa-link!',
+              order: 150
+          };
+          all.Person.widget_icon = 'fa fa-person';
+          return all;
+        })(),
         Contract: {
           Clause: {
             widget_name: function () {

--- a/src/ggrc/assets/javascripts/components/tree/sub-tree-expander.js
+++ b/src/ggrc/assets/javascripts/components/tree/sub-tree-expander.js
@@ -1,5 +1,5 @@
 /*!
- Copyright (C) 2016 Google Inc.
+ Copyright (C) 2017 Google Inc.
  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  */
 

--- a/src/ggrc/assets/javascripts/components/tree/sub-tree-expander.js
+++ b/src/ggrc/assets/javascripts/components/tree/sub-tree-expander.js
@@ -14,13 +14,13 @@
     },
     events: {
       'a click': function () {
-        var treeViewEl = this.element.closest('.cms_controllers_tree_view');
+        var treeViewEl = this.element.closest('.cms_controllers_tree_view_node');
         var ctrl = treeViewEl.control();
 
         if (this.scope.expanded) {
           treeViewEl.find('.parent-related').hide();
         } else {
-          ctrl.display(true);
+          ctrl.display_subtrees(true);
         }
 
         this.scope.attr('expanded', !this.scope.attr('expanded'));

--- a/src/ggrc/assets/javascripts/components/tree/sub-tree-expander.js
+++ b/src/ggrc/assets/javascripts/components/tree/sub-tree-expander.js
@@ -1,0 +1,30 @@
+/*!
+ Copyright (C) 2016 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+(function (can) {
+  'use strict';
+
+  GGRC.Components('subTreeExpander', {
+    tag: 'sub-tree-expander',
+    template: '<content/>',
+    scope: {
+      expanded: null
+    },
+    events: {
+      'a click': function () {
+        var treeViewEl = this.element.closest('.cms_controllers_tree_view');
+        var ctrl = treeViewEl.control();
+
+        if (this.scope.expanded) {
+          treeViewEl.find('.parent-related').hide();
+        } else {
+          ctrl.display(true);
+        }
+
+        this.scope.attr('expanded', !this.scope.attr('expanded'));
+      }
+    }
+  });
+})(window.can);

--- a/src/ggrc/assets/javascripts/components/tree/tree-child-show.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-child-show.js
@@ -1,5 +1,5 @@
 /*!
- Copyright (C) 2016 Google Inc.
+ Copyright (C) 2017 Google Inc.
  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  */
 

--- a/src/ggrc/assets/javascripts/components/tree/tree-child-show.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-child-show.js
@@ -7,19 +7,19 @@
   GGRC.Components('treeChildShow', {
     tag: 'tree-child-show',
     template: '<content/>',
-    scope: {},
+    viewModel: {
+      onChildShowStateChange: null,
+      isChildShow: null
+    },
     events: {
       init: function (element, options) {
-        this.scope.attr('controller', this);
-        this.scope.attr('$rootEl', $(element));
       },
       'a click': function () {
-        var sec_el = this.element.closest('section');
-        var tree_view_el = sec_el.find('.cms_controllers_tree_view');
-        var control = tree_view_el.control();
-        var cur = control.options.attr('showMappedToAllParents');
+        var isChildShow = this.viewModel.attr('isChildShow');
+        var onChildShowStateChange = this.viewModel.onChildShowStateChange;
 
-        control.options.attr('showMappedToAllParents', !cur);
+        this.viewModel.attr('isChildShow', !isChildShow);
+        onChildShowStateChange(!isChildShow);
       }
     }
   });

--- a/src/ggrc/assets/javascripts/components/tree/tree-child-show.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-child-show.js
@@ -1,0 +1,26 @@
+/*!
+ Copyright (C) 2016 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+(function (can, $) {
+  GGRC.Components('treeChildShow', {
+    tag: 'tree-child-show',
+    template: '<content/>',
+    scope: {},
+    events: {
+      init: function (element, options) {
+        this.scope.attr('controller', this);
+        this.scope.attr('$rootEl', $(element));
+      },
+      'a click': function () {
+        var sec_el = this.element.closest('section');
+        var tree_view_el = sec_el.find('.cms_controllers_tree_view');
+        var control = tree_view_el.control();
+        var cur = control.options.attr('showMappedToAllParents');
+
+        control.options.attr('showMappedToAllParents', !cur);
+      }
+    }
+  });
+})(window.can, window.can.$);

--- a/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
@@ -55,14 +55,14 @@
 
     initCurrentRelatedInstanses: function () {
       var instance;
-      if (GGRC.pageType && GGRC.pageType === 'admin') { // Admin dashboard
+      if (GGRC.pageType === 'admin') { // Admin dashboard
         return;
       }
 
       instance = this.options.instance;
 
-      GGRC.Utils.CurrentPage.initMappedInstanses(
-        GGRC.tree_view.base_widgets_by_type[instance.type], {
+      GGRC.Utils.CurrentPage.initMappedInstances(
+        GGRC.tree_view.attr('orderedWidgetsByType')[instance.type], {
           type: instance.type,
           id: instance.id
         });

--- a/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
@@ -15,6 +15,7 @@
         this.display_prefs = prefs;
 
         this.init_tree_view_settings();
+        this.initCurrentRelatedInstanses();
         this.init_page_title();
         this.init_page_help();
         this.init_page_header();
@@ -50,6 +51,21 @@
             savedChildTreeDisplayList);
         }
       }.bind(this));
+    },
+
+    initCurrentRelatedInstanses: function () {
+      var instance;
+      if (GGRC.pageType && GGRC.pageType === 'admin') { // Admin dashboard
+        return;
+      }
+
+      instance = this.options.instance;
+
+      GGRC.Utils.CurrentPage.initMappedInstanses(
+        GGRC.tree_view.base_widgets_by_type[instance.type], {
+          type: instance.type,
+          id: instance.id
+        });
     },
 
     init_page_title: function () {

--- a/src/ggrc/assets/javascripts/controllers/tree/tree-view-node.js
+++ b/src/ggrc/assets/javascripts/controllers/tree/tree-view-node.js
@@ -101,6 +101,19 @@
         }
       },
 
+    markNotRelatedItem: function () {
+      var instance = this.options.instance;
+      var relatedInstances = GGRC.Utils.CurrentPage.related
+        .attr(instance.type);
+
+      if (!relatedInstances || relatedInstances &&
+        !relatedInstances[instance.id]) {
+        this.element.addClass('parent-related');
+      } else {
+        this.element.addClass('current-instance-related');
+      }
+    },
+
     /**
      * Trigger rendering the tree node in the DOM.
      * @param {Boolean} force - indicates redraw is/is not mandatory
@@ -139,6 +152,7 @@
           this._draw_node_deferred.resolve();
         }.bind(this))
       );
+
       this.options.attr('isPlaceholder', false);
       this._draw_node_in_progress = false;
     },
@@ -257,6 +271,10 @@
       oldEl.replaceWith(el);
       this.element = firstchild.addClass(this.constructor._fullName)
         .data(oldData);
+
+      if (this.options.is_subtree) {
+        this.markNotRelatedItem();
+      }
       this.on();
     },
 

--- a/src/ggrc/assets/javascripts/controllers/tree/tree-view-node.js
+++ b/src/ggrc/assets/javascripts/controllers/tree/tree-view-node.js
@@ -25,6 +25,7 @@
       options_property: 'tree_view_options',
       show_view: null,
       expanded: false,
+      subTreeLoading: false,
       draw_children: true,
       child_options: []
     }
@@ -288,7 +289,7 @@
       }.bind(this)));
     },
 
-    display_subtrees: function () {
+    display_subtrees: function (refetch) {
       var childTreeDfds = [];
       var that = this;
 
@@ -301,7 +302,11 @@
           if ($el.closest('.' + that.constructor._fullName).is(that.element)) {
             childTreeControl = $el.control();
             if (childTreeControl) {
-              childTreeDfds.push(childTreeControl.display());
+              that.options.attr('subTreeLoading', true);
+              childTreeDfds.push(childTreeControl.display(refetch)
+                .then(function () {
+                  that.options.attr('subTreeLoading', false);
+                }));
             }
           }
         });

--- a/src/ggrc/assets/javascripts/controllers/tree/tree-view.js
+++ b/src/ggrc/assets/javascripts/controllers/tree/tree-view.js
@@ -342,6 +342,7 @@
 
       if (this.options.header_view && this.options.show_header) {
         optionsDfd = $.when(this.options).then(function (options) {
+          options.onChildShowStateChange = self.childShowStateChange.bind(self);
           options.onChildModelsChange = self.set_tree_display_list.bind(self);
           return options;
         });
@@ -857,15 +858,16 @@
       var options;
       var expander;
 
-      if (!showMappedToAllParents) {
-        return;
-      }
       element = this.element.find('.parent-related:first');
       options = {
         expanded: !!element.length && showMappedToAllParents
       };
       expander = can.view(GGRC.mustache_path +
         '/base_objects/sub_tree_expand.mustache', options);
+
+      if (!showMappedToAllParents) {
+        $(expander.firstElementChild).hide();
+      }
 
       if (element.length) {
         $(expander).insertBefore(element);
@@ -1312,6 +1314,20 @@
         if (oldVal !== newVal && _.contains(['current', 'pageSize'], type)) {
           this.refreshList();
         }
-      })
+      }),
+    childShowStateChange: function (childShowState) {
+      var expanderEls = this.element.find('.sub-tree-expander');
+
+      if (!_.isBoolean(childShowState)) {
+        return;
+      }
+      if (childShowState) {
+        expanderEls.show();
+      } else {
+        expanderEls.hide();
+      }
+
+      this.options.attr('showMappedToAllParents', !!childShowState);
+    }
   });
 })(window.can, window.$);

--- a/src/ggrc/assets/javascripts/controllers/tree/tree-view.js
+++ b/src/ggrc/assets/javascripts/controllers/tree/tree-view.js
@@ -43,7 +43,8 @@
       // { property: "controls", model: CMS.Models.Control, }
       // { parent_find_param: "system_id" ... }
       scroll_page_count: 1, // pages above and below viewport
-      is_subtree: false
+      is_subtree: false,
+      showMappedToAllParents: false
     },
     do_not_propagate: [
       'header_view',
@@ -268,6 +269,10 @@
           this.page_loader = new GGRC.ListLoaders.TreePageLoader(
             this.options.model, this.options.parent_instance,
             this.options.mapping);
+        } else if (this.options.attr('is_subtree')) {
+          this.page_loader = new GGRC.ListLoaders.SubTreeLoader(
+            this.options.model, this.options.parent_instance,
+            this.options.mapping);
         }
 
         if ('parent_instance' in opts && 'status' in opts.parent_instance) {
@@ -379,7 +384,9 @@
             }.bind(this))
           ));
       }
-      return $.when.apply($.when, dfds);
+
+      this._init_view_deferred = $.when.apply($.when, dfds);
+      return this._init_view_deferred;
     },
 
     init_count: function () {
@@ -833,9 +840,38 @@
       res = $.when.apply($, drawItemsDfds);
 
       res.then(function () {
+        if (this.options.is_subtree) {
+          this.addSubTreeExpander(items);
+        }
         _.defer(this.draw_visible.bind(this));
       }.bind(this));
       return res;
+    },
+
+    addSubTreeExpander: function () {
+      var parentCtrl = this.element.closest('section')
+        .find('.cms_controllers_tree_view').control();
+      var showMappedToAllParents = parentCtrl.options
+        .attr('showMappedToAllParents');
+      var element;
+      var options;
+      var expander;
+
+      if (!showMappedToAllParents) {
+        return;
+      }
+      element = this.element.find('.parent-related:first');
+      options = {
+        expanded: !!element.length && showMappedToAllParents
+      };
+      expander = can.view(GGRC.mustache_path +
+        '/base_objects/sub_tree_expand.mustache', options);
+
+      if (element.length) {
+        $(expander).insertBefore(element);
+      } else {
+        this.element.append(expander);
+      }
     },
 
     ' removeChildNode': function (el, ev, data) { // eslint-disable-line quote-props
@@ -1173,6 +1209,41 @@
       this.options.attr('paging.filter', filterString);
       this.options.attr('paging.current', 1);
       this.refreshList();
+    },
+
+    loadSubTree: function (allRelatedToParent) {
+      var parent = this.options.parent_instance;
+      var queryAPI = GGRC.Utils.QueryAPI;
+      var parentCtrl = this.element.closest('section')
+        .find('.cms_controllers_tree_view').control();
+      var displayModels = can.makeArray(
+        parentCtrl.options.attr('selected_child_tree_model_list'));
+      var relevant = {
+        type: parent.type,
+        id: parent.id,
+        operation: 'relevant'
+      };
+      var current = GGRC.page_instance();
+      var addFilter;
+      var reqParams;
+
+      if (!allRelatedToParent) {
+        addFilter = {
+          expression: {
+            object_name: current.type,
+            op: {
+              name: 'relevant'
+            },
+            ids: [current.id]
+          }
+        };
+      }
+      displayModels = _.map(displayModels, 'model_name');
+      reqParams = displayModels.map(function (model) {
+        return queryAPI.buildParam(model, {}, relevant, null, addFilter);
+      });
+
+      return this.page_loader.load({data: reqParams}, displayModels);
     },
 
     loadPage: function () {

--- a/src/ggrc/assets/javascripts/controllers/tree/tree-view.js
+++ b/src/ggrc/assets/javascripts/controllers/tree/tree-view.js
@@ -1218,6 +1218,8 @@
         .find('.cms_controllers_tree_view').control();
       var displayModels = can.makeArray(
         parentCtrl.options.attr('selected_child_tree_model_list'));
+      var originalOrder =
+        GGRC.tree_view.attr('orderedWidgetsByType')[parent.type];
       var relevant = {
         type: parent.type,
         id: parent.id,
@@ -1239,6 +1241,7 @@
         };
       }
       displayModels = _.map(displayModels, 'model_name');
+      displayModels = _.intersection(originalOrder, displayModels);
       reqParams = displayModels.map(function (model) {
         return queryAPI.buildParam(model, {}, relevant, null, addFilter);
       });

--- a/src/ggrc/assets/javascripts/models/mappers/sub-tree-loader.js
+++ b/src/ggrc/assets/javascripts/models/mappers/sub-tree-loader.js
@@ -1,5 +1,5 @@
 /*!
- Copyright (C) 2016 Google Inc.
+ Copyright (C) 2017 Google Inc.
  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  */
 

--- a/src/ggrc/assets/javascripts/models/mappers/sub-tree-loader.js
+++ b/src/ggrc/assets/javascripts/models/mappers/sub-tree-loader.js
@@ -1,0 +1,41 @@
+/*!
+ Copyright (C) 2016 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+(function (GGRC, can) {
+  'use strict';
+
+  GGRC.ListLoaders.TreeBaseLoader('GGRC.ListLoaders.SubTreeLoader', {}, {
+    load: function (params, models) {
+      return GGRC.Utils.QueryAPI.makeRequest(params)
+        .then(function (response) {
+          var mapped = [];
+          models.forEach(function (modelName, idx) {
+            var values = can.makeArray(response[idx][modelName].values);
+            var models = values.map(function (source) {
+              return CMS.Models[modelName].model(source);
+            });
+            mapped = mapped.concat(models);
+          });
+          return mapped;
+        })
+        .then(function (list) {
+          var mappedToCurrent = [];
+          var rest = [];
+          var related = GGRC.Utils.CurrentPage.related;
+
+          list.forEach(function (inst) {
+            var relates = related.attr(inst.type);
+            if (relates && relates[inst.id]) {
+              mappedToCurrent.push(inst);
+            } else {
+              rest.push(inst);
+            }
+          });
+          mappedToCurrent = mappedToCurrent.concat(rest);
+          return this.insertInstancesFromMappings(mappedToCurrent);
+        }.bind(this));
+    }
+  });
+})(GGRC, can);

--- a/src/ggrc/assets/javascripts/models/mappers/tree-base-loader.js
+++ b/src/ggrc/assets/javascripts/models/mappers/tree-base-loader.js
@@ -1,5 +1,5 @@
 /*!
- Copyright (C) 2016 Google Inc.
+ Copyright (C) 2017 Google Inc.
  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  */
 

--- a/src/ggrc/assets/javascripts/models/mappers/tree-base-loader.js
+++ b/src/ggrc/assets/javascripts/models/mappers/tree-base-loader.js
@@ -1,0 +1,63 @@
+/*!
+ Copyright (C) 2016 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+(function (GGRC, can) {
+  'use strict';
+
+  GGRC.ListLoaders.BaseListLoader('GGRC.ListLoaders.TreeBaseLoader', {}, {
+    init: function (model, instance, mapping) {
+      this.model = model;
+      this.binding = instance.get_binding(mapping);
+    },
+    insertInstancesFromMappings: function (mappings) {
+      var self = this;
+      var result;
+
+      result = can.map(can.makeArray(mappings), function (mapping) {
+        return self.getResultFromMapping(mapping);
+      });
+      return $.when.apply($, result).then(function () {
+        return new can.List(Array.prototype.slice.call(arguments));
+      });
+    },
+    getResultFromMapping: function (mapping) {
+      var binding = this.binding;
+      return this.makeResult(mapping.reify(), binding);
+    },
+    makeResult: function (instance, binding) {
+      var result;
+      if (instance instanceof CMS.Models.Person) {
+        if (binding.instance.workflow_people) {
+          result = CMS.Models.Person
+            .getPersonMappings(binding.instance, instance, 'workflow_people');
+        } else if (binding.instance.object_people.length) {
+          result = CMS.Models.Person
+            .getPersonMappings(binding.instance, instance, 'object_people');
+        } else {
+          result = CMS.Models.Person
+            .getUserRoles(binding.instance, instance);
+        }
+      } else {
+        result = CMS.Models.Relationship
+          .getRelationshipBetweenInstances(binding.instance, instance, true);
+      }
+      return result
+        .then(function (relationships) {
+          return new GGRC.ListLoaders.MappingResult(
+            instance, can.map(relationships, function (relationship) {
+              return {
+                binding: binding,
+                instance: relationship,
+                mappings: [{
+                  instance: true,
+                  mappings: [],
+                  binding: binding
+                }]
+              };
+            }), binding);
+        });
+    }
+  });
+})(GGRC, can);

--- a/src/ggrc/assets/javascripts/models/mappers/tree-base-loader.js
+++ b/src/ggrc/assets/javascripts/models/mappers/tree-base-loader.js
@@ -8,6 +8,7 @@
 
   GGRC.ListLoaders.BaseListLoader('GGRC.ListLoaders.TreeBaseLoader', {}, {
     init: function (model, instance, mapping) {
+      mapping = mapping || 'related_objects';
       this.model = model;
       this.binding = instance.get_binding(mapping);
     },

--- a/src/ggrc/assets/javascripts/models/mappers/tree-page-loader.js
+++ b/src/ggrc/assets/javascripts/models/mappers/tree-page-loader.js
@@ -6,11 +6,7 @@
 (function (GGRC, can) {
   'use strict';
 
-  GGRC.ListLoaders.BaseListLoader('GGRC.ListLoaders.TreePageLoader', {}, {
-    init: function (model, instance, mapping) {
-      this.model = model;
-      this.binding = instance.get_binding(mapping);
-    },
+  GGRC.ListLoaders.TreeBaseLoader('GGRC.ListLoaders.TreePageLoader', {}, {
     load: function (params) {
       var snapshots = GGRC.Utils.Snapshots;
       var queryParams = params;
@@ -28,54 +24,6 @@
         .then(function (values) {
           result.values = values;
           return result;
-        });
-    },
-    insertInstancesFromMappings: function (mappings) {
-      var self = this;
-      var result;
-
-      result = can.map(can.makeArray(mappings), function (mapping) {
-        return self.getResultFromMapping(mapping);
-      });
-      return $.when.apply($, result).then(function () {
-        return new can.List(Array.prototype.slice.call(arguments));
-      });
-    },
-    getResultFromMapping: function (mapping) {
-      var binding = this.binding;
-      return this.makeResult(mapping.reify(), binding);
-    },
-    makeResult: function (instance, binding) {
-      var result;
-      if (instance instanceof CMS.Models.Person) {
-        if (binding.instance.workflow_people) {
-          result = CMS.Models.Person
-            .getPersonMappings(binding.instance, instance, 'workflow_people');
-        } else if (binding.instance.object_people.length) {
-          result = CMS.Models.Person
-            .getPersonMappings(binding.instance, instance, 'object_people');
-        } else {
-          result = CMS.Models.Person
-            .getUserRoles(binding.instance, instance);
-        }
-      } else {
-        result = CMS.Models.Relationship
-          .getRelationshipBetweenInstances(binding.instance, instance, true);
-      }
-      return result
-        .then(function (relationships) {
-          return new GGRC.ListLoaders.MappingResult(
-            instance, can.map(relationships, function (relationship) {
-              return {
-                binding: binding,
-                instance: relationship,
-                mappings: [{
-                  instance: true,
-                  mappings: [],
-                  binding: binding
-                }]
-              };
-            }), binding);
         });
     }
   });

--- a/src/ggrc/assets/javascripts/plugins/utils/current-page-utils.js
+++ b/src/ggrc/assets/javascripts/plugins/utils/current-page-utils.js
@@ -1,0 +1,49 @@
+/*!
+ Copyright (C) 2017 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+(function (GGRC) {
+  'use strict';
+  /**
+   * Util methods for work with Current Page.
+   */
+  GGRC.Utils.CurrentPage = (function () {
+    var queryAPI = GGRC.Utils.QueryAPI;
+    var relatedToCurrentInstance = new can.Map({});
+
+    function initMappedInstances(dependentModels, current) {
+      var models = can.makeArray(dependentModels);
+      var reqParams = [];
+
+      models.forEach(function (model) {
+        reqParams.push(queryAPI.buildParam(
+          model,
+          {},
+          {
+            type: current.type,
+            id: current.id,
+            operation: 'relevant'
+          },
+          ['id']));
+      });
+
+      return queryAPI.makeRequest({data: reqParams}).then(function (response) {
+        models.forEach(function (model, idx) {
+          var values = can.makeArray(response[idx][model].values);
+          var map = values.reduce(function (mapped, obj) {
+            mapped[obj.id] = true;
+            return mapped;
+          }, {});
+          relatedToCurrentInstance.attr(model, map);
+        });
+        return relatedToCurrentInstance;
+      });
+    }
+
+    return {
+      related: relatedToCurrentInstance,
+      initMappedInstances: initMappedInstances
+    };
+  })();
+})(window.GGRC);

--- a/src/ggrc/assets/mustache/assessments/tree.mustache
+++ b/src/ggrc/assets/mustache/assessments/tree.mustache
@@ -81,6 +81,7 @@
           {{#prune_context}} {{! this line is just chopping the context stack down to one element}}
               {{#child_options}}
                 <div class="inner-tree">
+                  <spinner toggle="subTreeLoading"></spinner>
                   <ul class="tree-structure new-tree" {{data 'options'}} {{ (el) -> el.cms_controllers_tree_view(el.data("options")) }}></ul>
                 </div>
               {{/child_options}}

--- a/src/ggrc/assets/mustache/assessments/tree_header.mustache
+++ b/src/ggrc/assets/mustache/assessments/tree_header.mustache
@@ -39,6 +39,7 @@
                 {{> '/static/mustache/base_objects/filter_trigger.mustache'}}
                 {{> '/static/mustache/base_objects/tree_column_selector.mustache'}}
                 {{> '/static/mustache/base_objects/sub_tree_type_selector.mustache'}}
+                {{> '/static/mustache/base_objects/tree_child_show.mustache'}}
               </ul>
             </div>
           </li>

--- a/src/ggrc/assets/mustache/audits/tree.mustache
+++ b/src/ggrc/assets/mustache/audits/tree.mustache
@@ -134,6 +134,7 @@
       {{#if draw_children}}
         {{#child_options.0}}
           <div class="inner-tree">
+            <spinner toggle="subTreeLoading"></spinner>
             <ul class="tree-structure new-tree" {{data 'options'}} {{ (el) -> el.cms_controllers_tree_view(el.data("options")).control("tree_view").display() }}>
             </ul>
           </div>

--- a/src/ggrc/assets/mustache/audits/tree_header.mustache
+++ b/src/ggrc/assets/mustache/audits/tree_header.mustache
@@ -36,6 +36,7 @@
               {{> '/static/mustache/base_objects/filter_trigger.mustache'}}
               {{> '/static/mustache/base_objects/tree_column_selector.mustache'}}
               {{> '/static/mustache/base_objects/sub_tree_type_selector.mustache'}}
+              {{> '/static/mustache/base_objects/tree_child_show.mustache'}}
             </ul>
           </div>
         </li>

--- a/src/ggrc/assets/mustache/base_objects/sub_tree_expand.mustache
+++ b/src/ggrc/assets/mustache/base_objects/sub_tree_expand.mustache
@@ -1,0 +1,17 @@
+{{!
+    Copyright (C) 2017 Google Inc.
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+}}
+
+<li class="tree-item  cms_controllers_tree_view_node">
+  <div class="item-main">
+    <div class="item-wrap">
+      <sub-tree-expander expanded="expanded" display="display">
+        <a href="javascript://">
+          <i class="fa fa-caret-{{#if expanded}}down{{else}}right{{/if}}"></i>
+          Show mapped to this parent object
+        </a>
+      </sub-tree-expander>
+    </div>
+  </div>
+</li>

--- a/src/ggrc/assets/mustache/base_objects/sub_tree_expand.mustache
+++ b/src/ggrc/assets/mustache/base_objects/sub_tree_expand.mustache
@@ -3,7 +3,7 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
 
-<li class="tree-item  cms_controllers_tree_view_node">
+<li class="tree-item cms_controllers_tree_view_node sub-tree-expander">
   <div class="item-main">
     <div class="item-wrap">
       <sub-tree-expander expanded="expanded" display="display">

--- a/src/ggrc/assets/mustache/base_objects/sub_tree_expand.mustache
+++ b/src/ggrc/assets/mustache/base_objects/sub_tree_expand.mustache
@@ -3,7 +3,7 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
 
-<li class="tree-item cms_controllers_tree_view_node sub-tree-expander">
+<li class="tree-item sub-tree-expander">
   <div class="item-main">
     <div class="item-wrap">
       <sub-tree-expander expanded="expanded" display="display">

--- a/src/ggrc/assets/mustache/base_objects/tree.mustache
+++ b/src/ggrc/assets/mustache/base_objects/tree.mustache
@@ -125,6 +125,7 @@
           {{#prune_context}} {{! this line is just chopping the context stack down to one element}}
             {{#child_options.0}}
                 <div class="inner-tree">
+                  <spinner toggle="subTreeLoading"></spinner>
                   <ul class="tree-structure new-tree" {{data 'options'}} {{ (el) -> el.cms_controllers_tree_view(el.data("options")) }}></ul>
                 </div>
               {{/child_options.0}}

--- a/src/ggrc/assets/mustache/base_objects/tree.mustache
+++ b/src/ggrc/assets/mustache/base_objects/tree.mustache
@@ -123,11 +123,11 @@
       <div class="tier-2-info-content">
         {{#if draw_children}}
           {{#prune_context}} {{! this line is just chopping the context stack down to one element}}
-              {{#child_options}}
+            {{#child_options.0}}
                 <div class="inner-tree">
                   <ul class="tree-structure new-tree" {{data 'options'}} {{ (el) -> el.cms_controllers_tree_view(el.data("options")) }}></ul>
                 </div>
-              {{/child_options}}
+              {{/child_options.0}}
           {{/prune_context}}
         {{/if}}
       </div>

--- a/src/ggrc/assets/mustache/base_objects/tree_child_show.mustache
+++ b/src/ggrc/assets/mustache/base_objects/tree_child_show.mustache
@@ -1,0 +1,7 @@
+<li class="tree-child-show">
+  <tree-child-show>
+    <input type="checkbox"
+           {{#if showMappedToAllParents}}checked="checked"{{/if}}
+           value="Show only mapped to all parents in child tree">
+  </tree-child-show>
+</li>

--- a/src/ggrc/assets/mustache/base_objects/tree_child_show.mustache
+++ b/src/ggrc/assets/mustache/base_objects/tree_child_show.mustache
@@ -1,7 +1,8 @@
 <li class="tree-child-show">
   <tree-child-show>
-    <input type="checkbox"
-           {{#if showMappedToAllParents}}checked="checked"{{/if}}
-           value="Show only mapped to all parents in child tree">
+    <a href="javascript://">
+      <i class="fa fa-fw fa-{{#if showMappedToAllParents}}check-{{/if}}square-o"></i>
+      Show mapped to all parents in child tree
+    </a>
   </tree-child-show>
 </li>

--- a/src/ggrc/assets/mustache/base_objects/tree_child_show.mustache
+++ b/src/ggrc/assets/mustache/base_objects/tree_child_show.mustache
@@ -1,3 +1,8 @@
+{{!
+    Copyright (C) 2017 Google Inc.
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+}}
+
 <li class="tree-child-show">
   <tree-child-show>
     <a href="javascript://">

--- a/src/ggrc/assets/mustache/base_objects/tree_child_show.mustache
+++ b/src/ggrc/assets/mustache/base_objects/tree_child_show.mustache
@@ -4,9 +4,10 @@
 }}
 
 <li class="tree-child-show">
-  <tree-child-show>
+  <tree-child-show is-child-show="showMappedToAllParents"
+                   on-child-show-state-change="@onChildShowStateChange">
     <a href="javascript://">
-      <i class="fa fa-fw fa-{{#if showMappedToAllParents}}check-{{/if}}square-o"></i>
+      <i class="fa fa-fw fa-{{#if isChildShow}}check-{{/if}}square-o"></i>
       Show mapped to all parents in child tree
     </a>
   </tree-child-show>

--- a/src/ggrc/assets/mustache/base_objects/tree_header.mustache
+++ b/src/ggrc/assets/mustache/base_objects/tree_header.mustache
@@ -37,6 +37,7 @@
               {{> '/static/mustache/base_objects/filter_trigger.mustache'}}
               {{> '/static/mustache/base_objects/tree_column_selector.mustache'}}
               {{> '/static/mustache/base_objects/sub_tree_type_selector.mustache'}}
+              {{> '/static/mustache/base_objects/tree_child_show.mustache'}}
             </ul>
           </div>
         </li>

--- a/src/ggrc/assets/mustache/controls/tree.mustache
+++ b/src/ggrc/assets/mustache/controls/tree.mustache
@@ -175,6 +175,7 @@
           {{#prune_context}} {{! this line is just chopping the context stack down to one element}}
             {{#child_options}}
               <div class="inner-tree">
+                <spinner toggle="subTreeLoading"></spinner>
                 <ul class="tree-structure new-tree" {{data 'options'}} {{ (el) -> el.cms_controllers_tree_view(el.data("options")) }}></ul>
               </div>
             {{/child_options}}

--- a/src/ggrc/assets/mustache/directives/tree.mustache
+++ b/src/ggrc/assets/mustache/directives/tree.mustache
@@ -135,6 +135,7 @@
           {{#prune_context}} {{! this line is just chopping the context stack down to one element}}
             {{#child_options}}
               <div class="inner-tree">
+                  <spinner toggle="subTreeLoading"></spinner>
                   <ul class="tree-structure new-tree" {{data 'options'}} {{ (el) -> el.cms_controllers_tree_view(el.data("options")) }}></ul>
               </div>
             {{/child_options}}

--- a/src/ggrc/assets/mustache/objectives/tree.mustache
+++ b/src/ggrc/assets/mustache/objectives/tree.mustache
@@ -115,6 +115,7 @@
           {{#prune_context}} {{! this line is just chopping the context stack down to one element}}
             {{#child_options}}
               <div class="inner-tree">
+                <spinner toggle="subTreeLoading"></spinner>
                 <ul class="tree-structure new-tree" {{data 'options'}} {{ (el) -> el.cms_controllers_tree_view(el.data("options")) }}></ul>
               </div>
             {{/child_options}}

--- a/src/ggrc/assets/mustache/people/tree.mustache
+++ b/src/ggrc/assets/mustache/people/tree.mustache
@@ -87,6 +87,7 @@
             {{#prune_context}} {{! this line is just chopping the context stack down to one element}}
               {{#child_options}}
                 <div class="inner-tree">
+                  <spinner toggle="subTreeLoading"></spinner>
                   <ul class="tree-structure new-tree" {{data 'options'}} {{ (el) -> el.cms_controllers_tree_view(el.data("options")) }}></ul>
                 </div>
               {{/child_options}}

--- a/src/ggrc/assets/mustache/programs/tree.mustache
+++ b/src/ggrc/assets/mustache/programs/tree.mustache
@@ -124,6 +124,7 @@
           {{#prune_context}} {{! this line is just chopping the context stack down to one element}}
               {{#child_options}}
                 <div class="inner-tree">
+                  <spinner toggle="subTreeLoading"></spinner>
                   <ul class="tree-structure new-tree" {{data 'options'}} {{ (el) -> el.cms_controllers_tree_view(el.data("options")) }}></ul>
                 </div>
               {{/child_options}}

--- a/src/ggrc/assets/mustache/sections/tree.mustache
+++ b/src/ggrc/assets/mustache/sections/tree.mustache
@@ -152,6 +152,7 @@
           {{#prune_context}} {{! this line is just chopping the context stack down to one element}}
             {{#child_options}}
               <div class="inner-tree">
+                  <spinner toggle="subTreeLoading"></spinner>
                   <ul class="tree-structure new-tree colored-list" {{data 'options'}} {{ (el) -> el.cms_controllers_tree_view(el.data("options")) }}></ul>
               </div>
             {{/child_options}}

--- a/src/ggrc/assets/stylesheets/_components.scss
+++ b/src/ggrc/assets/stylesheets/_components.scss
@@ -23,3 +23,4 @@
 @import "components/search-toolbar/search-toolbar";
 @import "components/snapshot-list/snapshot-list";
 @import "components/object-selection/object-selection";
+@import "components/sub-tree-expander/sub-tree-expander";

--- a/src/ggrc/assets/stylesheets/components/sub-tree-expander/_sub-tree-expander.scss
+++ b/src/ggrc/assets/stylesheets/components/sub-tree-expander/_sub-tree-expander.scss
@@ -1,0 +1,10 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ * Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+sub-tree-expander {
+  i {
+    margin: 0 10px;
+  }
+}

--- a/src/ggrc/assets/stylesheets/modules/_tree-content.scss
+++ b/src/ggrc/assets/stylesheets/modules/_tree-content.scss
@@ -209,6 +209,12 @@ ul.new-tree {
         color: $gray;
       }
     }
+    &.current-instance-related {
+      color: $darkText;
+      .fa {
+        color: $darkText;
+      }
+    }
     .black-font {
       color: $black;
     }

--- a/src/ggrc/assets/stylesheets/modules/_tree-content.scss
+++ b/src/ggrc/assets/stylesheets/modules/_tree-content.scss
@@ -203,6 +203,12 @@ ul.new-tree {
         color: $black;
       }
     }
+    &.parent-related {
+      color: $gray;
+      .fa {
+        color: $gray;
+      }
+    }
     .black-font {
       color: $black;
     }

--- a/src/ggrc/assets/stylesheets/modules/_tree-header.scss
+++ b/src/ggrc/assets/stylesheets/modules/_tree-header.scss
@@ -254,6 +254,10 @@
                 }
               }
 
+              &.tree-child-show {
+                border-top: 1px solid $sidenavBorder;
+              }
+
               a {
                 > i {
                   color: #999;

--- a/src/ggrc_risk_assessments/assets/mustache/risk_assessments/tree.mustache
+++ b/src/ggrc_risk_assessments/assets/mustache/risk_assessments/tree.mustache
@@ -109,6 +109,7 @@
           {{#prune_context}} {{! this line is just chopping the context stack down to one element}}
               {{#child_options}}
                 <div class="inner-tree">
+                  <spinner toggle="subTreeLoading"></spinner>
                   <ul class="tree-structure new-tree" {{data 'options'}} {{ (el) -> el.cms_controllers_tree_view(el.data("options")) }}></ul>
                 </div>
               {{/child_options}}


### PR DESCRIPTION
1) Second level to be always pre-sorted in display by object type. The sort order of types should be similar to the standard sort order
2) By default, the second level should only show the objects that are relevant to the current object open. There needs to be a selector that the user can select to show all objects. There already is a selector box available on top to select what related objects are shown at the second level. This can be leveraged for designing some kind of a show all selector. Need UX input here.
If all objects is selected, the objects that are not related to the current object open should be shown visually separately (probably grey font or different font color)
Example - Let us say we open the program, click on the objectives tab and expand the second level on objectives.
Currently all objects that are mapped to the objective expanded are shown, regardless of whether or not it is mapped to the current program open. In the new design the following will occur -
1) The objects in second level will be sorted by type - (standards, sections, objectives, controls, systems, products, audits etc.. see standard order already implemented else where within the application)
2) The second level by default will show only objects that are mapped to the current program. If however a show all option is clicked, all objects relating to the objective will be shown. The objects that are not mapped to the program will be visually presented differently. Also note that the sort order by type will still be maintained.

![mappedobject_expand_1](https://cloud.githubusercontent.com/assets/4737102/21639387/cbed43a4-d280-11e6-8116-e0ecaf3250e5.png)
![righttopmenu](https://cloud.githubusercontent.com/assets/4737102/21639390/d1b3a3b4-d280-11e6-86cb-9f17c55385c9.png)
