### PR TITLE
GGRC-754, GGRC-769 Fix incorrectly enabled/disabled WF task widgets

### DIFF
--- a/src/ggrc_workflows/assets/javascripts/models/cycle_models.js
+++ b/src/ggrc_workflows/assets/javascripts/models/cycle_models.js
@@ -470,6 +470,22 @@
       ).then(function (object) {
         return object;
       });
+    },
+
+    /**
+     * Determine whether the Task's response options can be edited, taking
+     * the Task and Task's Cycle status into account.
+     *
+     * @return {Boolean} - true if editing response options is allowed,
+     *   false otherwise
+     */
+    responseOptionsEditable: function () {
+      var cycle = this.attr('cycle').reify();
+      var status = this.attr('status');
+
+      var isEditable = cycle.attr('is_current') &&
+                       !_.contains(['Finished', 'Verified'], status);
+      return isEditable;
     }
   });
 })(window.can);

--- a/src/ggrc_workflows/assets/javascripts/models/tests/CycleTaskGroupObjectTask_model_spec.js
+++ b/src/ggrc_workflows/assets/javascripts/models/tests/CycleTaskGroupObjectTask_model_spec.js
@@ -1,0 +1,79 @@
+/*!
+  Copyright (C) 2017 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+describe('CMS.Models.CycleTaskGroupObjectTask', function () {
+  'use strict';
+
+  describe('responseOptionsEditable method', function () {
+    var instance;
+    var method;  // the method under test
+    var Model;
+    var origCycleConfig;
+
+    beforeAll(function () {
+      Model = CMS.Models.CycleTaskGroupObjectTask;
+
+      // override the Task's cycle attribute config to disable the magic that
+      // happens when trying to manually set a mocked Cycle on a Task instance
+      origCycleConfig = Model.attributes.cycle;
+      delete Model.attributes.cycle;
+    });
+
+    afterAll(function () {
+      Model.attributes.cycle = origCycleConfig;
+    });
+
+    beforeEach(function () {
+      instance = new CMS.Models.CycleTaskGroupObjectTask({
+        status: 'Assigned',
+        cycle: {
+          is_current: false
+        }
+      });
+
+      spyOn(instance.cycle, 'reify').and.returnValue(instance.cycle);
+
+      method = Model.prototype.responseOptionsEditable.bind(instance);
+    });
+
+    it('returns false if the Task\'s Cycle is not current for ' +
+      'a non-finished task',
+      function () {
+        var isEditable;
+        instance.attr('status', 'InProgress');
+        instance.cycle.attr('is_current', false);
+
+        isEditable = method();
+
+        expect(isEditable).toBe(false);
+      }
+    );
+
+    it('returns false if a Task in a current cycle is completed', function () {
+      var END_STATES = ['Verified', 'Finished'];
+      var isEditable;
+
+      instance.cycle.attr('is_current', true);
+
+      END_STATES.forEach(function (state) {
+        instance.attr('status', state);
+        isEditable = method();
+        expect(isEditable).toBe(false);
+      });
+    });
+
+    it('returns true if a Task is in a current cycle and not completed',
+      function () {
+        var isEditable;
+        instance.cycle.attr('is_current', true);
+        instance.attr('status', 'InProgress');
+
+        isEditable = method();
+
+        expect(isEditable).toBe(true);
+      }
+    );
+  });
+});

--- a/src/ggrc_workflows/assets/javascripts/workflow_mustache_helpers.js
+++ b/src/ggrc_workflows/assets/javascripts/workflow_mustache_helpers.js
@@ -199,10 +199,4 @@
     }
     return options.inverse(this);
   });
-
-  Mustache.registerHelper('can_edit_response', function (instance, status) {
-    var cycle = Mustache.resolve(instance).cycle.reify();
-    status = Mustache.resolve(status);
-    return cycle.is_current && ['Finished', 'Verified'].indexOf(status) === -1;
-  });
 })(this.can, this.can.$, this.Mustache);

--- a/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/info.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/info.mustache
@@ -149,7 +149,7 @@
                   <div class="span12">
                     <label><input
                       type="checkbox"
-                      {{^if_can_edit_response instance instance.status}}
+                      {{^if instance.responseOptionsEditable}}
                         disabled="disabled"
                       {{/if}}
                       multiple="multiple"

--- a/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/info.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/info.mustache
@@ -137,7 +137,7 @@
               <dropdown
                 name="selected_response_options.0"
                 class-name="noop" {{! to not use default from component}}
-                is-disabled="!{{can_edit_response instance instance.status}}"
+                is-disabled="{{#if instance.responseOptionsEditable}}false{{else}}true{{/if}}"
                 options-list="instance.response_options"></dropdown>
             </ggrc-quick-update>
           {{/if_equals}}


### PR DESCRIPTION
This PR fixes incorrectly enabled/disabled checkboxes and dropdowns for completed Workflow Tasks.

---

**Steps to reproduce GGRC-754:**
- Create a Workflow
- On the Setup tab, define a Task of type Dropdown with a few options
- Activate the workflow, visit the Active Cycles tab
- Select a Task in the tree view (3rd tier) to open its info pane

**Actual result:**
The "response options" dropdown is disabled and its value cannot be modified unless the Task is in Done or Verified state.

**Expected result:**
The "response options" dropdown is enabled and its value can be modified, except if the Task has been completed or verified.

---

**Steps to reproduce GGRC-769:**
- Create a Workflow
- On the Setup tab, define a Task of type Checkbox with a few options
- Activate the workflow, visit the Active Cycles tab
- Select a Task in the tree view (3rd tier) to open its info pane and complete it (i.e. move it to one of the end states, e.g. Finshed)

**Actual result:**
The checkbox options are enabled and can be modified.

**Expected result:**
The checkbox options are disabled and should not be editable if a Task is in one of the end states.