### PR TITLE
GGRC-769 Fix enabled checkboxes if WF Task is completed

### DIFF
--- a/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/info.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/info.mustache
@@ -149,7 +149,7 @@
                   <div class="span12">
                     <label><input
                       type="checkbox"
-                      {{^if_can_edit_response instance instance.status}}
+                      {{^if instance.responseOptionsEditable}}
                         disabled="disabled"
                       {{/if}}
                       multiple="multiple"


### PR DESCRIPTION
This PR fixes the "response options" checkboxes being enabled if a WF task is in one of the completed states.

NOTE: The fix in this PR depends on the changes done in #4952, thus it must wait before the latter gets merged.

---

**Precondition:**
Activated one-time WF, a task with checkbox Task type with options

**Steps to reproduce:**
1. Go to Active Cycles tab
1. Navigate to Task's Info pane
1. Select checkbox options: confirm is enabled
4. Verify task
5. Select checkbox options once again: confirm is enabled

**Actual Result:**
Checkbox options are enabled to edit in Task's Info pane if task is verified

**Expected Result:**
Checkbox options should be disabled in Task's Info pane if task is verified (or finished)