### PR TITLE
GGRC-771 Disable editable custom attributes

### DIFF
--- a/src/ggrc/assets/mustache/components/assessment/custom-attributes.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/custom-attributes.mustache
@@ -14,7 +14,7 @@
                         placeholder="input.placeholder"
                         is-saving="isSaving"
                   {{^is_allowed 'update' instance context='for'}}
-                        readonly
+                        readonly="true"
                   {{/is_allowed}}
                   can-before-edit="instance.confirmBeginEdit"
                 ></assessment-inline-edit>

--- a/src/ggrc/assets/mustache/custom_attributes/info.mustache
+++ b/src/ggrc/assets/mustache/custom_attributes/info.mustache
@@ -28,10 +28,10 @@
               {{#if_helpers '\
                 #if' instance.snapshot '\
                 or #if' instance.isRevision }}
-                readonly
+                readonly="true"
               {{else}}
                 {{^is_allowed 'update' instance context='for'}}
-                  readonly
+                  readonly="true"
                 {{/is_allowed}}
               {{/if_helpers}}
             ></inline-edit>


### PR DESCRIPTION
CA are edited in snapshotable objects on audit page

Precondition:
Created any GCA for Control, program, control with the value in GCA, audit

Steps to reproduce:
1. Go to audit page-> Control's tab
2. Edit GCA value in Control's Info pane: confirm GCA value is edited and "There was a problem saving" is displayed
Actual Result: CA are edited in snapshotable objects on audit page
Expected Result: CA should not be edited in snapshotable objects on audit page