### PR TITLE
GGRC-750 Complete button is not disabled in Assessment's Info pane if mandatory GCA is not filled in

### DIFF
--- a/src/ggrc/assets/javascripts/models/assessment.js
+++ b/src/ggrc/assets/javascripts/models/assessment.js
@@ -189,7 +189,7 @@
           }
         });
         if (cad.mandatory &&
-            GGRC.Utils.isEmptyCA(value, cad.attribute_type)) {
+            GGRC.Utils.isEmptyCA(value, cad.attribute_type, cav)) {
           // If Custom Attribute is mandatory and empty
           errorsList.value.push(cad.title);
         } else if (cav) {

--- a/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
+++ b/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
@@ -406,7 +406,7 @@
     mapCAType: function (type) {
       return customAttributesType[type] || 'input';
     },
-    isEmptyCA: function (value, type) {
+    isEmptyCA: function (value, type, cav) {
       var result = false;
       var types = ['Text', 'Rich Text', 'Date', 'Checkbox', 'Dropdown',
         'Map:Person'];
@@ -417,10 +417,17 @@
         'Rich Text': function (value) {
           value = GGRC.Utils.getPlainText(value);
           return _.isEmpty(value);
+        },
+        'Map:Person': function (value, cav) {
+          // Special case, Map:Person has 'Person' value by default
+          if (cav) {
+            return !cav.attribute_object;
+          }
+          return _.isEmpty(value);
         }
       };
       if (types.indexOf(type) > -1 && options[type]) {
-        result = options[type](value);
+        result = options[type](value, cav);
       } else if (types.indexOf(type) > -1) {
         result = _.isEmpty(value);
       }

--- a/src/ggrc/assets/javascripts/plugins/tests/ggrc_utils_spec.js
+++ b/src/ggrc/assets/javascripts/plugins/tests/ggrc_utils_spec.js
@@ -142,6 +142,16 @@ describe('GGRC utils isEmptyCA() method', function () {
       var result = isEmptyCA('', 'Map:Person');
       expect(result).toBe(true);
     });
+
+    it('returns true for not selected cav', function () {
+      var result = isEmptyCA('', 'Map:Person', {attribute_object: null});
+      expect(result).toBe(true);
+    });
+
+    it('returns false for selected cav', function () {
+      var result = isEmptyCA('', 'Map:Person', {attribute_object: 'Person'});
+      expect(result).toBe(false);
+    });
   });
 
   describe('check Date type', function () {


### PR DESCRIPTION
Precondition:
Created mandatory GCA with person type for assessment, program, audit
Steps to reproduce:
1. Go to audit page-> Assessment's Info pane
2. Create assessment and add a Verifier
3. Fill in all GCA in Assessment's Info pane->Click Complete button
4. Remove a person from mandatory GCA with person type: confirm Complete button is not disabled

Actual Result: Complete button is not disabled in Assessment's Info pane if mandatory GCA is not filled in
Expected Result: Complete button should be disabled in Assessment's Info pane if mandatory GCA is not filled in