### PR TITLE
GGRC-761 Fix select child tree dialog

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/tree/tree-view.js
+++ b/src/ggrc/assets/javascripts/controllers/tree/tree-view.js
@@ -331,11 +331,17 @@
     },
 
     init_view: function () {
+      var self = this;
       var dfds = [];
+      var optionsDfd;
 
       if (this.options.header_view && this.options.show_header) {
+        optionsDfd = $.when(this.options).then(function (options) {
+          options.onChildModelsChange = self.set_tree_display_list.bind(self);
+          return options;
+        });
         dfds.push(
-          can.view(this.options.header_view, $.when(this.options)).then(
+          can.view(this.options.header_view, optionsDfd).then(
             this._ifNotRemoved(function (frag) {
               this.element.before(frag);
               // TODO: This is a workaround so we can toggle filter. We should refactor this ASAP.
@@ -359,11 +365,6 @@
               can.bind.call(this.element.parent().find('.set-tree-attrs'),
                 'click',
                 this.set_tree_attrs.bind(this)
-              );
-              can.bind.call(this.element.parent()
-                  .find('.set-display-object-list'),
-                'click',
-                this.set_tree_display_list.bind(this)
               );
             }.bind(this))));
       }
@@ -1108,23 +1109,17 @@
         'click', this.sort.bind(this));
     },
 
-    set_tree_display_list: function (ev) {
-      var modelName; // = this.options.model.model_singular,
-      var $check = this.element.parent().find('.model-checkbox');
-      var $selected = $check.filter(':checked');
-      var selectedItems = [];
+    set_tree_display_list: function (modelName, selectedItems) {
       var i;
       var el;
       var openItems;
       var control;
       var tviewEl;
 
-      modelName = this.element.parent().find('.object-type-selector').val();
+      if (!modelName) {
+        return;
+      }
 
-      // save the list
-      $selected.each(function (index) {
-        selectedItems.push(this.value);
-      });
       // update GGRC.tree_view
       GGRC.tree_view.sub_tree_for.attr(modelName + '.display_list',
         selectedItems);

--- a/src/ggrc/assets/mustache/base_objects/sub_tree_type_selector.mustache
+++ b/src/ggrc/assets/mustache/base_objects/sub_tree_type_selector.mustache
@@ -3,7 +3,11 @@
   Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
  <li>
-<tree-type-selector>
+<tree-type-selector
+  active-model="selected_model_name"
+  selected-child-models="selected_child_tree_model_list"
+  models-list="select_model_list"
+  on-child-models-change="@onChildModelsChange">
     <a href="#" class="dropdown-toggle tview-type-toggle" data-toggle="nested-dropdown">
       <i class="fa fa-fw fa-share-alt"></i>
       Select Child Tree Object Type
@@ -13,14 +17,14 @@
       <h5>
         Select child tree object type for:
         <select class="input-medium object-type-selector">
-          {{#select_model_list}}
+          {{#modelsList}}
           <option
             value="{{model_name}}"
             label="{{display_name}}"
-            {{#if_equals model_name selected_model_name}}selected="selected"
+            {{#if_equals model_name activeModel}}selected="selected"
             {{/if_equals}}>
           </option>
-          {{/select_model_list}}
+          {{/modelsList}}
         </select>
       </h5>
 
@@ -34,7 +38,7 @@
       </ul>
 
       <ul class="model-list">
-        {{#selected_child_tree_model_list}}
+        {{#selectedChildModels}}
         <li>
           <label class="checkbox-inline" title="{{display_name}}">
             <input type="checkbox"
@@ -46,7 +50,7 @@
             {{display_name}}
           </label>
         </li>
-        {{/selected_child_tree_model_list}}
+        {{/selectedChildModels}}
       </ul>
 
       <a class="btn btn-small btn-info set-display-object-list" href="javascript://">Set Visibility</a>


### PR DESCRIPTION
Steps to reproduce:
1. From My Work page open any tab
2. On Tree-View press 3bb's -> Select Child Tree Object Type
3. Look at "Select child tree object type for" field: is empty
Actual Result: Widget title is not selected by default in Select child tree dialog
Expected Result: Widget title should be selected by default in Select child tree dialog

Note: if "Select child tree object type for" field is not selected and click on Select all -> Set Visibility -> "Uncaught Error: can.Map: Object does not exist" error is displayed