### PR TITLE
GGRC-713 Filled mandatory CA is marked as unfilled in Assessment's Info pane

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment/inline.js
+++ b/src/ggrc/assets/javascripts/components/assessment/inline.js
@@ -76,10 +76,17 @@
           this.attr('isEdit', true);
         }.bind(this));   // and do nothing if no confirmation by the user
       },
-
+      updateValidation: function (value) {
+        if (this.objectValidation) {
+          this.objectValidation.attr('empty', GGRC.Utils.isEmptyCA(value));
+        }
+      },
       onCancel: function (scope) {
+        var value = scope.attr('_value');
         scope.attr('isEdit', false);
-        scope.attr('context.value', scope.attr('_value'));
+        scope.attr('context.value', value);
+
+        this.updateValidation(value);
       },
       onSave: function () {
         var oldValue = this.attr('value');
@@ -99,6 +106,8 @@
         this.attr('_value', value);
         this.attr('value', value);
         this.attr('isSaving', true);
+
+        this.updateValidation(value);
       }
     },
     init: function (element, options) {

--- a/src/ggrc/assets/javascripts/components/ca-object/ca-object-validation-icon.js
+++ b/src/ggrc/assets/javascripts/components/ca-object/ca-object-validation-icon.js
@@ -44,7 +44,13 @@
     },
     events: {
       init: function () {
+        var self = this;
         this.scope.applyState();
+        this.scope.validation.bind('change', function (event, propertyName) {
+          if (propertyName === 'empty') {
+            self.scope.applyState();
+          }
+        });
       },
       '{scope} validation': function () {
         this.scope.applyState();

--- a/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
+++ b/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
@@ -419,6 +419,9 @@
           return _.isEmpty(value);
         }
       };
+      if (value === undefined) {
+        return true;
+      }
       if (types.indexOf(type) > -1 && options[type]) {
         result = options[type](value);
       } else if (types.indexOf(type) > -1) {

--- a/src/ggrc/assets/javascripts/plugins/tests/ggrc_utils_spec.js
+++ b/src/ggrc/assets/javascripts/plugins/tests/ggrc_utils_spec.js
@@ -75,6 +75,13 @@ describe('GGRC utils isEmptyCA() method', function () {
     isEmptyCA = GGRC.Utils.isEmptyCA;
   });
 
+  describe('check undefined value', function () {
+    it('returns true for undefined', function () {
+      var result = isEmptyCA(undefined);
+      expect(result).toBe(true);
+    });
+  });
+
   describe('check Rich Text value', function () {
     it('returns true for empty div', function () {
       var result = isEmptyCA('<div></div>', 'Rich Text');

--- a/src/ggrc/assets/mustache/components/assessment/custom-attributes.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/custom-attributes.mustache
@@ -13,6 +13,7 @@
                         title-text="input.title"
                         placeholder="input.placeholder"
                         is-saving="isSaving"
+                        object-validation="validation"
                   {{^is_allowed 'update' instance context='for'}}
                         readonly="true"
                   {{/is_allowed}}


### PR DESCRIPTION
Precondition:
Created mandatory GCA for assessment, program, audit
Steps to reproduce:
1. Go to audit page
2. Create Assessment-> Navigate to Info pane
3. Fill in the GCA field form precondition: confirm is marked as unfilled

Actual Result: Filled mandatory CA is marked as unfilled in Assessment's Info pane. Refresh is needed.
Expected Result: Filled mandatory CA should be marked as filled (e.g. [^Filled mandatory CA field.png]) in Assessment's Info pane