### PR TITLE
GGRC-778 Fix default dropdown's value in AT modal

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment_attributes.js
+++ b/src/ggrc/assets/javascripts/components/assessment_attributes.js
@@ -287,7 +287,7 @@
       /*
        * Set default dropdown type on init
        */
-      inserted: function () {
+      init: function () {
         var types = this.scope.attr('types');
         if (!this.scope.attr('selected.type')) {
           this.scope.attr('selected.type', _.first(types).attr('type'));


### PR DESCRIPTION
**Precondition**:
Created program, audit
**Steps to reproduce:**
1. Go to audit page->Assessment template tab
2. While assessment template creation add attribute title and do not select attribute type
3. Click Add field

_Actual Result_: Uncaught TypeError: Cannot read property 'name' of undefined error is displayed while adding LCA without type in New AT modal window
_Expected Result_: no error displayed. Attribute type should be selected by default.