### PR TITLE
GGRC-787 Improve performance of Audit snapshots migration.

### DIFF
--- a/src/ggrc/migrations/versions/20161117114904_142272c4a0b6_migrate_audits_for_snapshots.py
+++ b/src/ggrc/migrations/versions/20161117114904_142272c4a0b6_migrate_audits_for_snapshots.py
@@ -19,7 +19,6 @@ from sqlalchemy.sql import table
 from sqlalchemy.sql import tuple_
 
 from ggrc.models.event import Event
-from ggrc.models.relationship import Relationship
 from ggrc.models.revision import Revision
 from ggrc.models.snapshot import Snapshot
 from ggrc.models.assessment import Assessment
@@ -43,7 +42,6 @@ logger = getLogger(__name__)  # pylint: disable=invalid-name
 revision = '142272c4a0b6'
 down_revision = '579239d161e1'
 
-relationships_table = Relationship.__table__
 events_table = Event.__table__
 snapshots_table = Snapshot.__table__
 revisions_table = Revision.__table__
@@ -157,10 +155,7 @@ def process_audits(connection, user_id, caches, audits):
           "context_id": snapshot_cache[snapshot][1],
       }]
 
-    if relationships_payload:
-      connection.execute(
-          relationships_table.insert().prefix_with("IGNORE"),
-          relationships_payload)
+    insert_payloads(connection, relationships=relationships_payload)
 
 
 def upgrade():

--- a/src/ggrc/migrations/versions/20161220161315_275cd0dcaea_migrate_assessments_issues_data.py
+++ b/src/ggrc/migrations/versions/20161220161315_275cd0dcaea_migrate_assessments_issues_data.py
@@ -23,7 +23,6 @@ from ggrc.models.assessment import Assessment
 from ggrc.models.event import Event
 from ggrc.models.request import Request
 from ggrc.models.issue import Issue
-from ggrc.models.relationship import Relationship
 from ggrc.models.revision import Revision
 from ggrc.models.snapshot import Snapshot
 
@@ -48,7 +47,6 @@ requests_table = Request.__table__
 issues_table = Issue.__table__
 snapshots_table = Snapshot.__table__
 revisions_table = Revision.__table__
-relationships_table = Relationship.__table__
 events_table = Event.__table__
 
 audits_table = table(
@@ -245,10 +243,7 @@ def link_snapshots_to_objects(connection, user_id,
                 object_klass, object_.id, obj_.type, obj_.id
             )
 
-  if relationships_payload:
-    connection.execute(
-        relationships_table.insert().prefix_with("IGNORE"),
-        relationships_payload)
+  insert_payloads(connection, relationships=relationships_payload)
 
 
 def get_scope_snapshots(connection):

--- a/src/ggrc/migrations/versions/20161221084829_1aa39778da75_migrate_requests_to_assessments.py
+++ b/src/ggrc/migrations/versions/20161221084829_1aa39778da75_migrate_requests_to_assessments.py
@@ -327,13 +327,13 @@ def upgrade():
 
   if attr_delete_ids:
     connection.execute(
-      "delete from relationship_attrs where id in ({})".format(
-        ",".join(str(id_) for id_ in attr_delete_ids)
-      )
+        "delete from relationship_attrs where id in ({})".format(
+            ",".join(str(id_) for id_ in attr_delete_ids)
+        )
     )
   if attr_update_val:
     connection.execute(text(
-      """
+        """
         REPLACE INTO relationship_attrs (
             id,
             relationship_id,
@@ -342,8 +342,8 @@ def upgrade():
         )
         VALUES
         {}
-      """.format(", ".join(attr_update_str))),
-      **attr_update_val
+        """.format(", ".join(attr_update_str))),
+        **attr_update_val
     )
 
   # The following block logically belongs to ggrc_workflows but is included

--- a/src/ggrc/migrations/versions/20161221084829_1aa39778da75_migrate_requests_to_assessments.py
+++ b/src/ggrc/migrations/versions/20161221084829_1aa39778da75_migrate_requests_to_assessments.py
@@ -293,10 +293,13 @@ def upgrade():
       "Requester": "Creator",
       "Assignee": "Assessor",
   }
-  for attr_id, assignees in connection.execute("""
+
+  assignee_type_query = connection.execute("""
       select id, attr_value from relationship_attrs
       where attr_name = 'AssigneeType'
-  """):
+  """)
+
+  for attr_id, assignees in assignee_type_query:
     # Split the assignees csv; replace every Request-specific assignee with its
     # Assessment variant; discard empty assignees
     new_assignees = ",".join(sorted({


### PR DESCRIPTION
Join multiple insert statements into one

We want to manually create a single big insert statement for migrations
because the biggest bottleneck is database latency. This is the best way
of reducing the time needed for the migrations.

There is no user defined data in the relationships and all types can
only contain valid model names, thus reducing the danger of a possible
sql injection enough that we don't have to worry.


Before: 2+ hours - DNF
After: real	1m51.905s

Note: before merging this, you should revert grc-dev database to a version without this migrations run.