### PR TITLE
GGRC-785 Fix infinite spinner for evidences

### DIFF
--- a/src/ggrc/assets/javascripts/components/object-list/object-list.js
+++ b/src/ggrc/assets/javascripts/components/object-list/object-list.js
@@ -20,6 +20,9 @@
       isLoading: false,
       selectedItem: {},
       items: [],
+      isLoadingInProgress: function () {
+        return this.attr('isLoading');
+      },
       select: function (ctx, el) {
         this.attr('selectedItem.el', el);
         this.attr('selectedItem.data', ctx.instance);

--- a/src/ggrc/assets/mustache/components/object-list/object-list.mustache
+++ b/src/ggrc/assets/mustache/components/object-list/object-list.mustache
@@ -2,7 +2,7 @@
     Copyright (C) 2017 Google Inc., authors, and contributors
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
-<spinner toggle="isLoading" extra-css-class="{{spinnerCss}}" class="spinner-wrapper {{#isLoading}}active{{/isLoading}}"></spinner>
+<spinner toggle="isLoading" extra-css-class="{{spinnerCss}}" class="spinner-wrapper {{#if isLoadingInProgress}}active{{/if}}"></spinner>
 {{#each items}}
   <object-list-item selected-item="selectedItem" index="{{@index}}" can-click="select">
     <content></content>


### PR DESCRIPTION
**Precondition**:
Created program, audit
**Steps to reproduce:**
1. Go to audit page
2. Create or generate at least 10 assessments (in order to have opportunity to follow to the next page in Related Assessments tab)
3. Navigate to Assessment's Info pane -> Related Assessments tab
4. Confirm Related Assessments are displayed and follow to the next page, then return to the 1st page
5. Confirm spinners are circled endlessly

_Actual Result_: Spinners in Related Assessments tab are circled endlessly 
_Expected Result:_ Spinners in Related Assessments tab should not be circled endlessly 
**Note**: For this reason there is no opportunity to reuse evidence/url