### PR TITLE
GGRC-789 Remove missing revisions exception

### DIFF
--- a/src/ggrc/migrations/versions/20161117114904_142272c4a0b6_migrate_audits_for_snapshots.py
+++ b/src/ggrc/migrations/versions/20161117114904_142272c4a0b6_migrate_audits_for_snapshots.py
@@ -211,8 +211,7 @@ def upgrade():
           ["{obj.type}-{obj.id}".format(obj=obj)
            for obj in objects_missing_revision])
       logger.warning(
-          "The following objects are missing revisions: %s", missing)
-      raise Exception("There are still objects with missing revisions!")
+          "Phantom objects mapped to program or audit: %s", missing)
 
     caches = {
         "program_contexts": program_contexts,


### PR DESCRIPTION
Because we restore snapshots for every object one migration before this
one, the error thrown here is only because of phantom objects ->
objects that were deleted from the database, but still have left over
relationships.

We will remove such relationships in a separate PR.