### PR TITLE
GGRC-784 Fix invalid date on related assessments

### DIFF
--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -1433,7 +1433,8 @@ function localizeDate(date, options, tmpl) {
   if (date) {
     if (typeof date === 'string') {
       // string dates are assumed to be in ISO format
-      return moment.utc(date, 'YYYY-MM-DD', true).format(tmpl);
+      return moment.utc(date, ['YYYY-MM-DD', 'YYYY-MM-DDTHH:mm:ss'], true)
+        .format(tmpl);
     }
     return moment(new Date(date)).format(tmpl);
   }

--- a/src/ggrc/assets/js_specs/mustache_helpers/localize_date_spec.js
+++ b/src/ggrc/assets/js_specs/mustache_helpers/localize_date_spec.js
@@ -1,0 +1,36 @@
+/*!
+ Copyright (C) 2017 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+describe('can.mustache.helper.localize_date', function () {
+  'use strict';
+
+  var helper;
+  var testDate;
+  var fakeOptions;
+
+  beforeAll(function () {
+    helper = can.Mustache._helpers.localize_date.fn;
+    fakeOptions = {};
+  });
+
+  it('returns formatted short ISO format', function () {
+    testDate = '2017-01-16';
+    expect(helper(testDate, fakeOptions)).toEqual('01/16/2017');
+  });
+
+  it('returns formatted full ISO format', function () {
+    testDate = '2017-01-16T12:36:20';
+    expect(helper(testDate, fakeOptions)).toEqual('01/16/2017');
+  });
+
+  it('returns Invalid date for incorrect formats', function () {
+    expect(helper('01-01-2017', fakeOptions)).toEqual('Invalid date');
+    expect(helper('2017/01/16', fakeOptions)).toEqual('Invalid date');
+    expect(helper('01/01/2016', fakeOptions)).toEqual('Invalid date');
+    expect(helper('2017-01-16 12:36:20', fakeOptions)).toEqual('Invalid date');
+    expect(helper('2017-20-01', fakeOptions)).toEqual('Invalid date');
+    expect(helper('01.01.2017', fakeOptions)).toEqual('Invalid date');
+  });
+});


### PR DESCRIPTION
**Precondition:**
Created program, audit
**Steps to reproduce:**
1. Go to audit page
2. Create at least 2 assessments
3. Navigate to Assessment's Info pane -> Related Assessments tab
4. Look at Date column: "Invalid" date is displayed

_Actual Result_: "Invalid" date is displayed in Related Assessments tab
_Expected Result_: Date of Assessment's creation should be displayed in Date column