### PR TITLE
GGRC-791 GGRC-792 Index fixes for custom attributes with long names

### DIFF
--- a/src/ggrc/migrations/versions/20170112013716_421b2179c02e_update_fulltext_index.py
+++ b/src/ggrc/migrations/versions/20170112013716_421b2179c02e_update_fulltext_index.py
@@ -1,0 +1,39 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Update fulltext index.
+
+Create Date: 2017-01-12 01:37:16.801973
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '421b2179c02e'
+down_revision = '177a979b230a'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  op.alter_column(
+      "fulltext_record_properties",
+      "property",
+      existing_type=sa.String(length=64),
+      type_=sa.String(length=250),
+      nullable=False
+  )
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  op.alter_column(
+      "fulltext_record_properties",
+      "property",
+      existing_type=sa.String(length=250),
+      type_=sa.String(length=64),
+      nullable=False
+  )

--- a/test/integration/ggrc/converters/test_csvs/querying_with_unicode.csv
+++ b/test/integration/ggrc/converters/test_csvs/querying_with_unicode.csv
@@ -1,5 +1,5 @@
 Object type,,,,,,,,,,,,,,
-program,code*,title*,description ,Manager,state,primary contact,effective date,stop date,notes,program url,reference url,editor,CA текст,CA список
+program,code*,title*,description ,Manager,state,primary contact,effective date,stop date,notes,program url,reference url,editor,CA текстXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX,CA списокXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 ,prog-1,программа F,2,"anze@example.com
 albert@example.com
 tommy@example.com",Draft,anze@example.com,1/6/2016,1/19/2016,3,http://google.com/_1,http://google.com/_2,"anze@example.com

--- a/test/integration/ggrc/fulltext/__init__.py
+++ b/test/integration/ggrc/fulltext/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>

--- a/test/integration/ggrc/fulltext/test_mysql.py
+++ b/test/integration/ggrc/fulltext/test_mysql.py
@@ -1,0 +1,60 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Integration tests for custom attribute definitions model."""
+
+import sqlalchemy.exc
+
+from ggrc import db
+from ggrc import views
+from ggrc.fulltext import mysql
+from integration.ggrc import TestCase
+from integration.ggrc.models import factories
+
+CAD = factories.CustomAttributeDefinitionFactory
+CAV = factories.CustomAttributeValueFactory
+
+
+class TestCAD(TestCase):
+  """Tests for basic functionality of cad model."""
+
+  def test_cad_length(self):
+    """Custom attribute titles must support all lengths that can be stored."""
+
+    title1 = "a" * 200 + "1"
+    title2 = "a" * 200 + "2"
+    cad1 = CAD(title=title1, definition_type="market")
+    cad2 = CAD(title=title2, definition_type="market",)
+    factory = factories.MarketFactory()
+    CAV(custom_attribute=cad1, attributable=factory, attribute_value="x")
+    CAV(custom_attribute=cad2, attributable=factory, attribute_value="x")
+
+    views.do_reindex()
+
+    title1_count = mysql.MysqlRecordProperty.query.filter(
+        mysql.MysqlRecordProperty.property == title1
+    ).count()
+    self.assertEqual(title1_count, 1)
+
+  def test_unique_key(self):
+    """Test object property uniqueness."""
+    db.session.add(mysql.MysqlRecordProperty(
+        key=1,
+        type="my_type",
+        property=u"\u5555" * 240 + u"1",
+    ))
+    db.session.add(mysql.MysqlRecordProperty(
+        key=1,
+        type="my_type",
+        property=u"\u5555" * 240 + u"2",
+    ))
+    db.session.commit()
+    self.assertEqual(mysql.MysqlRecordProperty.query.count(), 2)
+
+    with self.assertRaises(sqlalchemy.exc.IntegrityError):
+      db.session.add(mysql.MysqlRecordProperty(
+          key=1,
+          type="my_type",
+          property=u"\u5555" * 240 + u"2",
+      ))
+      db.session.commit()

--- a/test/integration/ggrc/services/test_query.py
+++ b/test/integration/ggrc/services/test_query.py
@@ -791,16 +791,19 @@ class TestQueryWithUnicode(BaseQueryAPITestCase):
     self._import_file("querying_with_unicode.csv")
     self.client.get("/login")
 
-  @staticmethod
-  def _generate_cad():
+  CAD_TITLE1 = u"CA список" + "X" * 200
+  CAD_TITLE2 = u"CA текст" + "X" * 200
+
+  @classmethod
+  def _generate_cad(cls):
     """Generate custom attribute definitions."""
     factories.CustomAttributeDefinitionFactory(
-        title=u"CA список",
+        title=cls.CAD_TITLE1,
         definition_type="program",
         multi_choice_options=u"один,два,три,четыре,пять",
     )
     factories.CustomAttributeDefinitionFactory(
-        title=u"CA текст",
+        title=cls.CAD_TITLE2,
         definition_type="program",
     )
 
@@ -830,11 +833,12 @@ class TestQueryWithUnicode(BaseQueryAPITestCase):
     programs = self._flatten_cav(
         self._get_first_result_set(
             self._make_query_dict("Program",
-                                  order_by=[{"name": u"CA текст"},
-                                            {"name": u"CA список"}]),
+                                  order_by=[{"name": self.CAD_TITLE2},
+                                            {"name": self.CAD_TITLE1}]),
             "Program", "values",
         )
     )
 
-    keys = [(prog[u"CA текст"], prog[u"CA список"]) for prog in programs]
+    keys = [(prog[self.CAD_TITLE2], prog[self.CAD_TITLE1])
+            for prog in programs]
     self.assertEqual(keys, sorted(keys))


### PR DESCRIPTION
This ticket covers 2 different cases when custom attribute name is too long.

searching and sorting on custom attributes with too long names

- create CA for any object with name: (could be any name longer than 66 characters)
"abcd abcd abcd abcd abcd abcd abcd abcd abcd abcd abcd abcd 1"
- create an object with some value in that CA and try to filter on it.
Expected: filter should work
Actual: filter acts as if that CA name does not exist


Second part of this is if we create another long CA with the same prefix:

- create second ca:
"abcd abcd abcd abcd abcd abcd abcd abcd abcd abcd abcd abcd 2"
- try to create an object with values in both CA fields
Expected: object should be created without an error
Actual: object is created but error shows up, The object itself exists, but does not show up in LHN or in any search using fulltext table.