### PR TITLE
GGRC-793 Disable the pop up that shows objectives/regulations in Assessment's Info pane

### DIFF
--- a/src/ggrc/assets/mustache/components/assessment/mapped-objects/mapped-controls-popover.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/mapped-objects/mapped-controls-popover.mustache
@@ -3,6 +3,7 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
 <!-- Objectives and Regulations Grids -->
+<!--
 <collapsible-panel title-text="Show Related Objectives and Regulations" collapsed="true" expanded="expanded"
                    extra-css-class="no-padding">
     <div class="grid-data-simple">
@@ -69,3 +70,4 @@
         </div>
     </div>
 </collapsible-panel>
+-->


### PR DESCRIPTION
Precondition:
Created program, control, regulations/objectives that are mapped to control audit
Steps to reproduce:
1. Go to audit page
2. Generate assessment based on control from precondition
3. Navigate to Assessment's Info pane
4. Click on mapped control in Info pane
Expected Result: Disable the pop up that shows objectives/regulations in Assessment's Info pane
