### PR TITLE
GGRC-794 Update revision content lenght

### DIFF
--- a/src/ggrc/migrations/versions/20170112112254_177a979b230a_update_revision_content_field.py
+++ b/src/ggrc/migrations/versions/20170112112254_177a979b230a_update_revision_content_field.py
@@ -1,0 +1,40 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Update revision content field.
+
+Create Date: 2017-01-12 11:22:54.998164
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '177a979b230a'
+down_revision = '275cd0dcaea'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  op.alter_column(
+      "revisions",
+      "content",
+      existing_type=sa.Text(),
+      type_=mysql.LONGTEXT,
+      nullable=False
+  )
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  op.alter_column(
+      "revisions",
+      "content",
+      existing_type=mysql.LONGTEXT,
+      type_=sa.Text(),
+      nullable=False
+  )

--- a/src/ggrc/models/revision.py
+++ b/src/ggrc/models/revision.py
@@ -6,7 +6,7 @@
 from ggrc import db
 from ggrc.models.computed_property import computed_property
 from ggrc.models.mixins import Base
-from ggrc.models.types import JsonType
+from ggrc.models.types import LongJsonType
 
 
 class Revision(Base, db.Model):
@@ -19,7 +19,7 @@ class Revision(Base, db.Model):
   event_id = db.Column(db.Integer, db.ForeignKey('events.id'), nullable=False)
   action = db.Column(db.Enum(u'created', u'modified', u'deleted'),
                      nullable=False)
-  content = db.Column(JsonType, nullable=False)
+  content = db.Column(LongJsonType, nullable=False)
 
   source_type = db.Column(db.String, nullable=True)
   source_id = db.Column(db.Integer, nullable=True)

--- a/test/integration/ggrc/models/test_revision.py
+++ b/test/integration/ggrc/models/test_revision.py
@@ -3,9 +3,11 @@
 
 """ Tests for ggrc.models.Revision """
 
+import ggrc.models
 import integration.ggrc
 import integration.ggrc.generator
-import ggrc.models
+
+from integration.ggrc.models import factories
 
 
 def _get_revisions(obj, field="resource"):
@@ -108,3 +110,18 @@ class TestRevisions(integration.ggrc.TestCase):
     actual = [(r.action, _project_content(r.content))
               for r in revisions_source]
     self.assertEqual(sorted(actual), sorted(expected))
+
+  def test_content_length(self):
+    """Test revision content length restrictions."""
+    process = factories.ProcessFactory(
+        title="a" * 200,
+        description="b" * 65000,
+        notes="c" * 65000,
+    )
+    revision = ggrc.models.Revision.query.filter(
+        ggrc.models.Revision.resource_id == process.id,
+        ggrc.models.Revision.resource_type == process.type,
+    ).first()
+    self.assertIsNotNone(revision)
+    self.assertEqual(revision.content["title"], process.title)
+    self.assertEqual(revision.content["description"], process.description)


### PR DESCRIPTION
Ticket description

> Precondition:
> Created GCA for Assessment with e.g. "Rich text" type, program, audit
> Steps to reproduce:
> 1. Go to audit page-> Assessments tab
> 2. Create Assessment-> Navigate to Info pane
> 3. Fill in the value into GCA from precondition
> 4. Confirm "There was an error" message is displayed and 500 error in console
> Actual Result: "There was an error" message is displayed while saving the value in CA in Assessment's Info pane and CA is not saved
> Expected Result: no error displayed. The value in CA is saved
> 
> Link to assessment: https://grc-test.appspot.com/audits/722#assessment_widget/assessment/11227
> Note: max length of json request is 65534 bytes
> 
> 
> note this will happen if create any object with 65534 characters long description.