### PR TITLE
GGRC-798 Fix revisions for assessments

### DIFF
--- a/src/ggrc/utils/revisions.py
+++ b/src/ggrc/utils/revisions.py
@@ -176,6 +176,6 @@ def do_refresh_revisions():
   # TODO: Improve performance/memory consumption so that we can run
   # _fix_type_revisions for all objects and not just the objects that are
   # snapshottable
-  for type_ in sorted(Types.all):
+  for type_ in sorted(Types.all | {"Assessment"}):
     logger.info("Updating revisions for: %s", type_)
     _fix_type_revisions(event, type_, _get_revisions_by_type(type_))


### PR DESCRIPTION
Because we create new assessments from requests we also need to create
new revisions for those assessments.

PS: Memory footprint did not go up a lot. Testing on the grc-test database, processing 6k assessments did not push virtual memory above 600MB, maybe around 50MB more than without processing assessments.