### PR TITLE
GGRC-412 Add missing spinners when content is being loaded

### DIFF
--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -112,6 +112,7 @@ dashboard-js-files:
   - models/system.js
   - models/join_models.js
   # Controllers
+  - controllers/spinner_injector_controller.js
   - controllers/filterable_controller.js
   - controllers/dashboard_widgets_controller.js
   - controllers/info_widget_controller.js

--- a/src/ggrc/assets/javascripts/components/people_list.js
+++ b/src/ggrc/assets/javascripts/components/people_list.js
@@ -83,6 +83,7 @@
       results: [],
       list_pending: [],
       list_mapped: [],
+      fetchingData: false,  // fetching data currently in progress or not
       computed_mapping: false,
       forbiddenForUnmap: [],
       /**
@@ -405,8 +406,13 @@
       }
     },
     events: {
-      inserted: function () {
-        this.scope.get_mapped_deferred().then(function (data) {
+      init: function () {
+        // NOTE: If the logic below is executed was inserted() instead, the
+        // view might initially not update itself correctly (i.e. the
+        // fetchingData flag) due to race conditions.
+        this.scope.attr('fetchingData', true);
+
+        this.scope.get_mapped_deferred().done(function (data) {
           this.scope.attr('list_pending', this.scope.get_pending());
           this.scope.attr('list_mapped', data);
           this.updateMappedResult(data);
@@ -417,6 +423,9 @@
           if (this.scope.instance.isNew() && this.scope.validate) {
             this.validate();
           }
+        }.bind(this))
+        .always(function () {
+          this.scope.attr('fetchingData', false);
         }.bind(this));
       },
       validate: function () {

--- a/src/ggrc/assets/javascripts/components/snapshotter/scope-update.js
+++ b/src/ggrc/assets/javascripts/components/snapshotter/scope-update.js
@@ -22,6 +22,12 @@
           skip_refresh: true
         }, function () {
           var instance = this.instance;
+
+          var notificationSettings = {
+            progress: 'Updating objects to the latest version in progress.'
+          };
+          $('body').trigger('ajax:flash', notificationSettings);
+
           instance.refresh().then(function () {
             var data = {
               operation: 'upsert'

--- a/src/ggrc/assets/javascripts/components/tests/people_list_spec.js
+++ b/src/ggrc/assets/javascripts/components/tests/people_list_spec.js
@@ -12,6 +12,53 @@ describe('GGRC.Components.peopleGroup', function () {
     Component = GGRC.Components.get('peopleGroup');
   });
 
+  describe('init() method', function () {
+    var dfdFetchData;
+    var init;  // the method under test
+    var context;
+
+    beforeEach(function () {
+      dfdFetchData = new can.Deferred();
+
+      context = new can.Map({
+        updateMappedResult: jasmine.createSpy(),
+        scope: {
+          get_mapped_deferred:
+            jasmine.createSpy().and.returnValue(dfdFetchData),
+          get_pending: jasmine.createSpy(),
+          validate: jasmine.createSpy(),
+          instance: {
+            isNew: jasmine.createSpy()
+          }
+        }
+      });
+      init = Component.prototype.events.init.bind(context);
+    });
+
+    it('initially sets the fetchingData flag', function () {
+      var scope = context.scope;
+      scope.attr('fetchingData', false);
+      init();
+      expect(scope.attr('fetchingData')).toBe(true);
+    });
+
+    it('clears the fetchingData flag when data has been fetched', function () {
+      var scope = context.scope;
+      scope.attr('fetchingData', true);
+      init();
+      dfdFetchData.resolve();
+      expect(scope.attr('fetchingData')).toBe(false);
+    });
+
+    it('clears the fetchingData flag if fetching data fails', function () {
+      var scope = context.scope;
+      context.scope.attr('fetchingData', true);
+      init();
+      dfdFetchData.reject();
+      expect(scope.attr('fetchingData')).toBe(false);
+    });
+  });
+
   describe('get_pending() method', function () {
     var getPending;  // the method under test
     var scope;

--- a/src/ggrc/assets/javascripts/components/unified-mapper/mapper.js
+++ b/src/ggrc/assets/javascripts/components/unified-mapper/mapper.js
@@ -239,7 +239,8 @@
           newEntries: parentScope.attr('newEntries')
         })),
         template: parentScope.attr('template'),
-        draw_children: true
+        draw_children: true,
+        $opener: attrs['%root'].$trigger  // the button used to open the modal
       };
     },
 
@@ -396,6 +397,7 @@
           }.bind(this));
 
           $.when.apply($, defer)
+            .done(this._handleSuccessfulMap.bind(this))
             .fail(function (response, message) {
               $('body').trigger('ajax:flash', {error: message});
             })
@@ -404,6 +406,25 @@
               this.closeModal();
             }.bind(this));
         }.bind(this));
+      },
+
+      /**
+       * A callback for when objects have been successfully mapped to another
+       * object.
+       *
+       * @param {...CMS.Models.Relationship} relationship - one or more
+       *   Relationship instances that were created
+       */
+      _handleSuccessfulMap: function () {
+        var $container;
+
+        // Inject the spinner only when using the "main" Map button, i.e. the
+        // one not specific to any tree items.
+        if (!this.scope.joinObjectId) {
+          $container = this.scope.$opener.closest('section.content');
+          GGRC.spinnerInjector.inject(
+            $container, 'large', 'initial-spinner refreshing');
+        }
       },
 
       setBinding: function () {

--- a/src/ggrc/assets/javascripts/controllers/spinner_injector_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/spinner_injector_controller.js
@@ -1,0 +1,70 @@
+/*!
+    Copyright (C) 2017 Google Inc.
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+(function (can, $) {
+  'use strict';
+
+  /**
+   * A Control for dynamically injecting (and removing) spinners into the page.
+   *
+   * By design, only one spinner can be active at a time (per each Control
+   * instance... although it is primarily meant to be used as a singleton).
+   *
+   * @class GGRC.Controllers.SpinnerInjector
+   */
+  var Ctrl = can.Control.extend('GGRC.Controllers.SpinnerInjector', {
+    SPINNER_TEMPLATE: [
+      '<spinner',
+      '  size="{spinnerSize}"',
+      '  extra-css-class="{extraCssClass}"',
+      '  toggle="{visible}"',
+      '  data-marker="SpinnerInjector"',
+      '></spinner>'
+    ].join('')
+  }, {
+    init: function ($el, options) {
+      this.$spinner = null;
+    },
+
+    /**
+     * Inject a spinner into the given container.
+     *
+     * If there exists another previously injected spinner, it is removed in
+     * the process, even if located in a different container.
+     *
+     * @param {Object} $container - a jQuery-wrapped DOM element to inject the
+     *   spinner into
+     * @param {string} size - the size of the spinner as expected by the
+     *  underlying spinner component
+     * @param {string} extraCssClass - additional CSS class(es) to apply to the
+     *   injected spinner as expected by the underlying spinner component
+     */
+    inject: function ($container, size, extraCssClass) {
+      var renderer = can.stache(this.constructor.SPINNER_TEMPLATE);
+      var fragment = renderer({
+        spinnerSize: size,
+        extraCssClass: extraCssClass,
+        visible: true
+      });
+
+      this.remove();
+      $container.append(fragment);
+
+      this.$spinner = $container.find('[data-marker="SpinnerInjector"]');
+    },
+
+    /**
+     * Remove the previously injected spinner from the DOM, if it exists.
+     */
+    remove: function () {
+      if (this.$spinner) {
+        this.$spinner.remove();
+        this.$spinner = null;
+      }
+    }
+  });
+
+  GGRC.spinnerInjector = new Ctrl('body');
+})(window.can, window.$);

--- a/src/ggrc/assets/javascripts/controllers/tests/spinner_injector_controller_spec.js
+++ b/src/ggrc/assets/javascripts/controllers/tests/spinner_injector_controller_spec.js
@@ -1,0 +1,76 @@
+/*!
+  Copyright (C) 2017 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+describe('GGRC.Controllers.SpinnerInjector', function () {
+  'use strict';
+
+  var Ctrl;  // the control under test
+
+  beforeAll(function () {
+    Ctrl = GGRC.Controllers.SpinnerInjector;
+  });
+
+  describe('inject() method', function () {
+    var ctrlInst;  // fake control instance
+    var inject;
+    var $container;
+
+    beforeEach(function () {
+      function CtrlMock() {}
+
+      CtrlMock.prototype.remove = jasmine.createSpy();
+      CtrlMock.SPINNER_TEMPLATE = '<div id="fakeSpinner"></div>';
+
+      ctrlInst = new CtrlMock();
+      inject = Ctrl.prototype.inject.bind(ctrlInst);
+
+      $container = $('<div id="contaner"></div>');
+    });
+
+    it('inserts spinner into the given container', function () {
+      inject($container);
+      expect($container.find('#fakeSpinner').length).toEqual(1);
+    });
+
+    it('removes previously inserted spinner from the DOM', function () {
+      var $anotherContainer = $('<div id="anotherContaner"></div>');
+      var $existingSpinner = $('<div id="existingSpinner"></div>');
+
+      $anotherContainer.append($existingSpinner);
+      ctrlInst.$spinner = $existingSpinner;
+
+      ctrlInst.remove.and.callFake(function () {
+        $existingSpinner.remove();
+      });
+
+      inject($container);
+
+      expect($anotherContainer.find('#existingSpinner').length).toEqual(0);
+    });
+  });
+
+  describe('remove() method', function () {
+    var ctrlInst;  // fake control instance
+    var remove;
+    var $container;
+    var $spinner;
+
+    beforeEach(function () {
+      ctrlInst = {};
+      remove = Ctrl.prototype.remove.bind(ctrlInst);
+
+      $container = $('<div id="contaner"></div>');
+      $spinner = $('<div id="spinner"></div>');
+      $container.append($spinner);
+    });
+
+    it('removes the existing spinner from the DOM', function () {
+      ctrlInst.$spinner = $spinner;
+      remove();
+      expect($container.find('#spinner').length).toEqual(0);
+      expect(ctrlInst.$spinner).toBeFalsy();
+    });
+  });
+});

--- a/src/ggrc/assets/javascripts/controllers/tree/tree-loader.js
+++ b/src/ggrc/assets/javascripts/controllers/tree/tree-loader.js
@@ -195,6 +195,8 @@
           .find('spinner[extra-css-class="initial-spinner"]')
           .remove();
 
+        GGRC.spinnerInjector.remove();
+
         this.init_spinner();  // the tree view's own items loading spinner
         this.element.trigger('loading');
       }

--- a/src/ggrc/assets/mustache/base_templates/people_group.mustache
+++ b/src/ggrc/assets/mustache/base_templates/people_group.mustache
@@ -3,7 +3,6 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
 
-
 <label class="people-group">
     <span {{#boldTitle}}class="people-group_title"{{/boldTitle}}>
       {{heading}}
@@ -25,6 +24,9 @@
       {{/has_permissions}}
     {{/editable}}
 </label>
+
+<spinner toggle="fetchingData" size="normal"></spinner>
+
 <ul class="inner-count-list">
   {{^if results.length}}
     <li><i> No {{type}}s</i></li>

--- a/src/ggrc/assets/stylesheets/modules/_spinner.scss
+++ b/src/ggrc/assets/stylesheets/modules/_spinner.scss
@@ -10,6 +10,9 @@
     left: 49%;  // not 50% to roughly compensate for the spinner's own width
     top: 205px;
     color: gray;
+    &.refreshing {  // when refreshing an already loaded LHN tab content
+      top: 110px;
+    }
   }
   &.tree-items {
     position: absolute;


### PR DESCRIPTION
**Update:** Since this will not go into release and is thus, presumably, not urgent, I will wait for a bit more for the list of missing  spinners to be compiled, and will then address all of them in a batch (thus also changed the `needs work` label to `question` so that people will actually have a look at this PR).

---

This PR adds spinners where the content is still being loaded, but there is no visual indication for the user to know this.

Tests cover only the new can.Control, while the UI is not tested, since a Selenium would make more sense for that.

---

The issue itself is quite broad and has partially already been done. This PR adds the following missing spinners:
* [x] When an object is mapped in any of the LHN tabs using the mapper modal that was opened with the "main" Map button, i.e. the blue one above the tree view. There was a gap between the time the modal was closed, and the time the tree view started displaying its own internal spinner while refreshing itself.

* [x] Update snapshots to latest version on 3 dots menu on audits takes a while and is missing a spinner.
  (solved by displaying a notification bar, similar to the one used when generating Assessments)

* [x] Loading assignees on the Assessment info pane - especially Verifier takes some time to load.

Please add more items to the list above, if necessary (the ticket description is not detailed enough), and if that should be done in scope of this PR. Thanks!