### PR TITLE
GGRC-740 Fix JS error on delete mapped objects

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/tests/tree_view_controller_spec.js
+++ b/src/ggrc/assets/javascripts/controllers/tests/tree_view_controller_spec.js
@@ -81,5 +81,33 @@ describe('CMS.Controllers.TreeView', function () {
 
       expect(result).toBeTruthy();
     });
+
+    it('right relationship without source', function () {
+      var result;
+
+      relationship.destination = {type: 'foo'};
+
+      result = method(relationship, 'foo');
+
+      expect(result).toBeTruthy();
+    });
+
+    it('right relationship without destination', function () {
+      var result;
+
+      relationship.source = {type: 'foo'};
+
+      result = method(relationship, 'foo');
+
+      expect(result).toBeTruthy();
+    });
+
+    it('empty relationship', function () {
+      var result;
+
+      result = method(relationship, 'foo');
+
+      expect(result).toBeFalsy();
+    });
   });
 });

--- a/src/ggrc/assets/javascripts/controllers/tree/tree-view.js
+++ b/src/ggrc/assets/javascripts/controllers/tree/tree-view.js
@@ -904,8 +904,15 @@
       if (!(instance instanceof CMS.Models.Relationship)) {
         return false;
       }
-      return _.includes([instance.destination.type, instance.source.type],
-        shortName);
+      if (instance.destination &&
+        instance.destination.type === shortName) {
+        return true;
+      }
+      if (instance.source &&
+        instance.source.type === shortName) {
+        return true;
+      }
+      return false;
     },
 
     triggerListeners: (function () {
@@ -947,8 +954,10 @@
           // if unmapping e.g. an URL (a "Document") or an assignee from
           // the info pin, refreshing the latter is not needed
           if (instance instanceof CMS.Models.Relationship) {
-            srcType = instance.source.type;
-            destType = instance.destination.type;
+            srcType = instance.source ?
+              instance.source.type : null;
+            destType = instance.destination ?
+              instance.destination.type : null;
             if (srcType === 'Person' || destType === 'Person' ||
               srcType === 'Document' || destType === 'Document') {
               return;


### PR DESCRIPTION
This PR fixes JS error on deleting old mapped objects (not reproduced on freshly created).

Precondition:
Created program, audit
Steps to reproduce:
1. Go to audit page
2. Create Assessment and map several objects to assessment through unified mapper (e.g. Access Group)
3. In Assessment's tab open second tier in tree view and select the mapped object (Access Group)
4. Expand 3 bb's menu in Access Group Info pane
5. Click Delete button: the system freezes
6. Click Delete button once again: "access group not found." error message is displayed
Actual Result: The app freezes if delete mapped object to audit from second tier in Assessment tab
Expected Result: The app should not freeze if delete mapped object to audit from second tier in Assessment tab. The objected is deleted form the tree view.
