### PR TITLE
GGRC-817 Update Mapper Model to fix duplication issue

### DIFF
--- a/src/ggrc/assets/javascripts/components/unified_mapper/mapper.js
+++ b/src/ggrc/assets/javascripts/components/unified_mapper/mapper.js
@@ -29,7 +29,7 @@
       },
       types: {
         get: function () {
-          return this.initTypes(this.attr('object'));
+          return this.initTypes();
         }
       },
       parentInstance: {
@@ -133,7 +133,7 @@
     initTypes: function (objectType) {
       var object = objectType || this.attr('object');
       // Can.JS wrap all objects with can.Map by default
-      var groups = this.attr('typeGroups');
+      var groups = this.attr('typeGroups').attr();
       var list = this.getModelNamesList(object);
 
       list.forEach(function (modelName) {
@@ -153,7 +153,7 @@
     },
     modelFromType: function (type) {
       var types = _.reduce(_.values(
-        this.attr('types').attr()), function (memo, val) {
+        this.attr('types')), function (memo, val) {
         if (val.items) {
           return memo.concat(val.items);
         }


### PR DESCRIPTION
Precondition:
- Created program, audit
Steps to reproduce:
1. Go to audit page
2. Create Assessment
3. Click Map in tree view in Assessment's tab
4. Select different objects types from Object type dropdown list and click Search: confirm the selected objects are duplicated and the list icreases
Actual Result: When using a mapper modal and clicking Search for several different object types, the list of Object Type dropdown options increases and duplicates entries appear in it
Expected Result: When using a mapper modal and clicking Search for several different object types, the list of Object Type dropdown options should not increase and duplicate entries appear in it