### PR TITLE
GGRC-804 Fix duplication of comparer on double click

### DIFF
--- a/src/ggrc/assets/javascripts/components/snapshotter/revisions-comparer.js
+++ b/src/ggrc/assets/javascripts/components/snapshotter/revisions-comparer.js
@@ -17,29 +17,29 @@
         var revisionsLength = scope.rightRevisions.length;
         var newRevisionID = scope.rightRevisions[revisionsLength - 1].id;
         var view = scope.instance.view;
-        this.getRevisions(currentRevisionID, newRevisionID)
-          .then(function (data) {
-            var revisions = this.prepareInstances(data);
-            var that = this;
-
-            GGRC.Controllers.Modals.confirm({
-              modal_title: 'Compare with the latest version',
-              header_view: GGRC.mustache_path +
-                            '/modals/modal_compare_header.mustache',
-              modal_confirm: 'Update',
-              skip_refresh: true,
-              extraCssClass: 'compare-modal',
-              button_view: GGRC.mustache_path +
-                            '/modals/prompt_buttons.mustache',
-              afterFetch: function (target) {
+        var that = this;
+        GGRC.Controllers.Modals.confirm({
+          modal_title: 'Compare with the latest version',
+          modal_description: 'Loading...',
+          header_view: GGRC.mustache_path +
+                        '/modals/modal_compare_header.mustache',
+          modal_confirm: 'Update',
+          skip_refresh: true,
+          extraCssClass: 'compare-modal',
+          button_view: GGRC.mustache_path +
+                        '/modals/prompt_buttons.mustache',
+          afterFetch: function (target) {
+            that.getRevisions(currentRevisionID, newRevisionID)
+              .then(function (data) {
+                var revisions = that.prepareInstances(data);
                 var fragLeft = can.view(view, revisions[0]);
                 var fragRight = can.view(view, revisions[1]);
                 fragLeft.appendChild(fragRight);
                 target.find('.modal-body').html(fragLeft);
                 that.highlightDifference(target);
-              }
-            }, this.updateRevision.bind(this));
-          }.bind(this));
+              });
+          }
+        }, this.updateRevision.bind(this));
       },
       getRevisions: function (currentRevisionID, newRevisionID) {
         var additionalFilter = {


### PR DESCRIPTION
Precondition:
Created program, control, audit
Steps to reproduce:
1. Go to the audit page
2. Return to the program page and make changes in Control (e.g. change the title)
3. Return to the audit page and refresh the page
4. Navigate to Control's Info pane and click on the "Compare with the latest version" link: confirm several windows are displayed

Actual Result: "Compare with the latest version" window is duplicated if click twice on the "Compare with the latest version" link
Expected Result: "Compare with the latest version" window should not duplicated if click twice on the "Compare with the latest version" link
