### PR TITLE
GGRC-199 Show add new modal if adding Section to Regulation

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/modals_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/modals_controller.js
@@ -535,6 +535,8 @@
           value = can.map(item.value, function (id) {
             return CMS.Models.get_instance(model, id);
           });
+        } else if (item.value instanceof Object) {
+          value = CMS.Models.get_instance(model, item.value.id);
         } else {
           value = CMS.Models.get_instance(model, item.value);
         }

--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -3658,6 +3658,7 @@ Example:
       return options.inverse(options.contexts);
     }
   );
+
   Mustache.registerHelper('isNotInScopeModel', function (modelName, options) {
     var isInScopeModel;
     modelName = can.isFunction(modelName) ? modelName() : modelName;
@@ -3667,4 +3668,46 @@ Example:
       isInScopeModel || GGRC.Utils.Snapshots.isSnapshotParent(modelName);
     return isInScopeModel ? options.inverse(this) : options.fn(this);
   });
+
+  /**
+   * Determine whether the target modal for a Model type that should be opened
+   * on a particular page type matches the given modal type.
+   *
+   * This helper is primarily used by the HNB in the "Add Tab" menu to
+   * determine whether to open the "add new" or the unified mapper modal.
+   *
+   * @param {String} modelName - capitalized model name, e.g. "Audit"
+   * @param {String} modalType - must be either "modal-ajax-form" or
+   *   "unified-mapper"
+   * @param {Object} options - a CanJS options argument
+   */
+  Mustache.registerHelper(
+    'if_target_modal_match',
+    function (modelName, modalType, options) {
+      var matchingModal;
+      var pageType = GGRC.Utils.win.location.pathname.split('/')[1];
+
+      // a list of model types for each page object type when the add/edit
+      // modal should be used instead of the default "map to" modal
+      var EDIT_MODAL_PAIRS = Object.freeze({
+        contracts: ['Section'],
+        policies: ['Section'],
+        regulations: ['Section'],
+        standards: ['Section'],
+        programs: ['Audit']
+      });
+
+      modelName = Mustache.resolve(modelName);
+      modalType = Mustache.resolve(modalType);
+
+      matchingModal = _.contains(EDIT_MODAL_PAIRS[pageType], modelName) ?
+                        'modal-ajax-form' : 'unified-mapper';
+
+      if (modalType === matchingModal) {
+        return options.fn(options.contexts);
+      }
+
+      return options.inverse(options.contexts);
+    }
+  );
 })(this, jQuery, can);

--- a/src/ggrc/assets/js_specs/mustache_helpers/if_target_modal_match_spec.js
+++ b/src/ggrc/assets/js_specs/mustache_helpers/if_target_modal_match_spec.js
@@ -1,0 +1,137 @@
+/*!
+  Copyright (C) 2017 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+describe('can.mustache.helper.if_target_modal_match', function () {
+  'use strict';
+
+  var fakeOptions;  // fake mustache options object passed to the helper
+  var helper;
+  var fakeWindow;
+  var origWinObject;
+  var templateContext;
+
+  beforeAll(function () {
+    helper = can.Mustache._helpers.if_target_modal_match.fn;
+
+    fakeWindow = {
+      location: {
+        pathname: '/foo'
+      }
+    };
+
+    origWinObject = GGRC.Utils.win;
+    GGRC.Utils.win = fakeWindow;
+  });
+
+  afterAll(function () {
+    GGRC.Utils.win = origWinObject;
+  });
+
+  beforeEach(function () {
+    templateContext = {foo: 'bar'};
+
+    fakeOptions = {
+      fn: jasmine.createSpy(),
+      inverse: jasmine.createSpy(),
+      contexts: templateContext
+    };
+  });
+
+  it('matches the "create new" modal for Audit on Program page', function () {
+    var callArgs;
+    var expectedArgs = [templateContext];
+
+    fakeWindow.location.pathname = '/programs/123';
+    helper('Audit', 'modal-ajax-form', fakeOptions);
+
+    expect(fakeOptions.fn.calls.count()).toEqual(1);
+    callArgs = fakeOptions.fn.calls.mostRecent().args;
+    expect(callArgs).toEqual(expectedArgs);
+  });
+
+  it('matches the "create new" modal for Section on Contract page',
+    function () {
+      var callArgs;
+      var expectedArgs = [templateContext];
+
+      fakeWindow.location.pathname = '/contracts/123';
+      helper('Section', 'modal-ajax-form', fakeOptions);
+
+      expect(fakeOptions.fn.calls.count()).toEqual(1);
+      callArgs = fakeOptions.fn.calls.mostRecent().args;
+      expect(callArgs).toEqual(expectedArgs);
+    }
+  );
+
+  it('does not match the "create new" modal for Section on Program page',
+    function () {
+      var callArgs;
+      var expectedArgs = [templateContext];
+
+      fakeWindow.location.pathname = '/programs/123';
+      helper('Section', 'modal-ajax-form', fakeOptions);
+
+      expect(fakeOptions.inverse.calls.count()).toEqual(1);
+      callArgs = fakeOptions.inverse.calls.mostRecent().args;
+      expect(callArgs).toEqual(expectedArgs);
+    }
+  );
+
+  it('matches the "create new" modal for Section on Policy page',
+    function () {
+      var callArgs;
+      var expectedArgs = [templateContext];
+
+      fakeWindow.location.pathname = '/policies/123';
+      helper('Section', 'modal-ajax-form', fakeOptions);
+
+      expect(fakeOptions.fn.calls.count()).toEqual(1);
+      callArgs = fakeOptions.fn.calls.mostRecent().args;
+      expect(callArgs).toEqual(expectedArgs);
+    }
+  );
+
+  it('matches the "create new" modal for Section on Regulation page',
+    function () {
+      var callArgs;
+      var expectedArgs = [templateContext];
+
+      fakeWindow.location.pathname = '/regulations/123';
+      helper('Section', 'modal-ajax-form', fakeOptions);
+
+      expect(fakeOptions.fn.calls.count()).toEqual(1);
+      callArgs = fakeOptions.fn.calls.mostRecent().args;
+      expect(callArgs).toEqual(expectedArgs);
+    }
+  );
+
+  it('matches the "create new" modal for Section on Standard page',
+    function () {
+      var callArgs;
+      var expectedArgs = [templateContext];
+
+      fakeWindow.location.pathname = '/standards/123';
+      helper('Section', 'modal-ajax-form', fakeOptions);
+
+      expect(fakeOptions.fn.calls.count()).toEqual(1);
+      callArgs = fakeOptions.fn.calls.mostRecent().args;
+      expect(callArgs).toEqual(expectedArgs);
+    }
+  );
+
+  it('does not match the "create new" modal for Audit on non-Program page',
+    function () {
+      var callArgs;
+      var expectedArgs = [templateContext];
+
+      fakeWindow.location.pathname = '/assessments/123';
+      helper('Audit', 'modal-ajax-form', fakeOptions);
+
+      expect(fakeOptions.inverse.calls.count()).toEqual(1);
+      callArgs = fakeOptions.inverse.calls.mostRecent().args;
+      expect(callArgs).toEqual(expectedArgs);
+    }
+  );
+});

--- a/src/ggrc/assets/mustache/assessment_templates/tree_add_item.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/tree_add_item.mustache
@@ -26,7 +26,7 @@
       "audit_title": "{{json_escape parent_instance.title}}"
     }'
   >
-    Create New
+    Create
   </a>
 {{/is_allowed}}
 

--- a/src/ggrc/assets/mustache/assessments/tree_add_item.mustache
+++ b/src/ggrc/assets/mustache/assessments/tree_add_item.mustache
@@ -17,7 +17,7 @@
          data-modal-class="modal-wide"
          data-object-singular="{{model.model_singular}}"
          data-object-plural="{{model.table_plural}}">
-        Create New
+        Create
       </a>
     {{/is_allowed_to_map}}
     {{/if}}

--- a/src/ggrc/assets/mustache/audits/tree_add_item.mustache
+++ b/src/ggrc/assets/mustache/audits/tree_add_item.mustache
@@ -16,7 +16,7 @@
          data-object-singular="Audit"
          data-object-plural="audits"
          data-object-params='{ "{{parent_instance.class.table_singular}}": { "id" : {{parent_instance.id}}, "title" : "{{parent_instance.title}}" }, "context": { "id" : {{firstnonempty parent_instance.context.id "null"}}, "href" : "{{parent_instance.context.href}}", "type" : "{{parent_instance.context.type}}" } }'>
-        Create New
+        Create
       </a>
     {{/is_allowed}}
     {{/if}}

--- a/src/ggrc/assets/mustache/base_objects/autocomplete_result.mustache
+++ b/src/ggrc/assets/mustache/base_objects/autocomplete_result.mustache
@@ -32,7 +32,7 @@
              data-toggle="modal-ajax-form"
              data-modal-reset="reset"
              data-mapping="{{mapping}}">
-            + Create New
+            + Create
           </a>
         </li>
       {{/if_equals}}

--- a/src/ggrc/assets/mustache/base_objects/search_actions.mustache
+++ b/src/ggrc/assets/mustache/base_objects/search_actions.mustache
@@ -6,7 +6,7 @@
 {{#is_allowed 'create' model.shortName context='any'}}
 <li class="add-new oneline" data-ui-autocomplete-item="">
   <a data-object-plural="{{model.table_plural}}" data-test-id="button_lhn_create_new_program_522c563f" data-form-target="redirect" data-modal-class="modal-wide" href="javascript://" data-object-singular="{{model.model_singular}}" data-toggle="modal-ajax-form" data-modal-reset="reset">
-    + Create New
+    + Create
   </a>
 </li>
 {{/is_allowed}}

--- a/src/ggrc/assets/mustache/base_objects/tree_add_item.mustache
+++ b/src/ggrc/assets/mustache/base_objects/tree_add_item.mustache
@@ -35,7 +35,7 @@
        data-modal-class="modal-wide"
        data-object-singular="{{parent_instance.class.model_singular}}"
        data-object-plural="{{parent_instance.class.table_plural}}">
-      Create New
+      Create
     </a>
   </span>
   {{/if}}

--- a/src/ggrc/assets/mustache/dashboard/info/get_started.mustache
+++ b/src/ggrc/assets/mustache/dashboard/info/get_started.mustache
@@ -46,7 +46,7 @@
         <span class="get-started__list__icon-wrap">
           <i class="fa fa-plus-circle white"></i>
         </span>
-        Create new object
+        Create object
       </a>
       <div class="dropdown-menu" role="menu">
         {{#object_menu}}

--- a/src/ggrc/assets/mustache/dashboard/internav_list.mustache
+++ b/src/ggrc/assets/mustache/dashboard/internav_list.mustache
@@ -50,9 +50,7 @@
           or #if' instance.constructor.obj_nav_options.show_all_tabs '\
           or #in_array' internav_display instance.constructor.obj_nav_options.force_show_list}}
 
-          {{#if_helpers '\
-            #if_page_type' 'programs' '\
-            and #if_equals' model.shortName 'Audit'}}
+          {{#if_target_modal_match model.shortName 'modal-ajax-form'}}
             <a
               href="{{urlPath}}{{selector}}"
               rel="tooltip"

--- a/src/ggrc/assets/mustache/documents/autocomplete_result.mustache
+++ b/src/ggrc/assets/mustache/documents/autocomplete_result.mustache
@@ -23,7 +23,7 @@
 {{#is_allowed "create" "OrgGroup" context=null}}
 <li class="ui-menu-item add-new oneline" data-ui-autocomplete-item="">
   <a data-object-plural="documents" data-modal-class="modal-wide" href="javascript://" data-object-singular="{{model_class}}" data-toggle="modal-ajax-form" data-modal-reset="reset">
-    + Create New
+    + Create
   </a>
 </li>
 {{/is_allowed}}

--- a/src/ggrc/assets/mustache/issues/tree_add_item.mustache
+++ b/src/ggrc/assets/mustache/issues/tree_add_item.mustache
@@ -26,6 +26,6 @@
       "audit_title": "{{json_escape parent_instance.title}}"
     }'
   >
-    Create New
+    Create
   </a>
 {{/is_allowed}}

--- a/src/ggrc/assets/mustache/meetings/tree_add_item.mustache
+++ b/src/ggrc/assets/mustache/meetings/tree_add_item.mustache
@@ -16,6 +16,6 @@
      data-object-singular="Meeting"
      data-object-plural="meetings"
      data-object-params='{ "{{parent_instance.class.table_singular}}": {"id" : {{parent_instance.id}}, "type" : "{{parent_instance.class.model_singular}}" }, "context": { "id" : {{firstnonempty parent_instance.context.id "null"}}, "href" : "{{parent_instance.context.href}}", "type" : "{{parent_instance.context.type}}" }, "modal_title" : "Schedule a Meeting" }'>
-    Create New
+    Create
   </a>
 {{/allow_creating}}

--- a/src/ggrc/assets/mustache/modals/mapper/base.mustache
+++ b/src/ggrc/assets/mustache/modals/mapper/base.mustache
@@ -56,7 +56,7 @@
                 }'
                             data-join-object-id="{{mapper.join_object_id}}">
                         <i class="fa fa-plus-circle"></i>
-                        Create New {{mapper.model.title_singular}}
+                        Create {{mapper.model.title_singular}}
                     </a>
                 </div>
             </div>
@@ -73,7 +73,7 @@
                               data-object-plural="{{mapper.model.plural}}"
                               data-join-object-id="{{mapper.join_object_id}}">
                           <i class="fa fa-plus-circle"></i>
-                          Create New {{mapper.model.title_singular}}
+                          Create {{mapper.model.title_singular}}
                       </a>
                   </div>
               </div>

--- a/src/ggrc/assets/mustache/objectives/autocomplete_result.mustache
+++ b/src/ggrc/assets/mustache/objectives/autocomplete_result.mustache
@@ -23,7 +23,7 @@
 {{#is_allowed "create" "Objective" context=null}}
 <li class="ui-menu-item add-new oneline" data-ui-autocomplete-item="">
   <a data-object-plural="objectives" data-modal-class="modal-wide" href="javascript://" data-object-singular="Objective" data-toggle="modal-ajax-form" data-modal-reset="reset">
-    + Create New
+    + Create
   </a>
 </li>
 {{/is_allowed}}

--- a/src/ggrc/assets/mustache/org_groups/autocomplete_result.mustache
+++ b/src/ggrc/assets/mustache/org_groups/autocomplete_result.mustache
@@ -23,7 +23,7 @@
 {{#is_allowed "create" "OrgGroup" context=null}}
 <li class="ui-menu-item add-new oneline" data-ui-autocomplete-item="">
   <a data-object-plural="org_groups" data-modal-class="modal-wide" href="javascript://" data-object-singular="OrgGroup" data-toggle="modal-ajax-form" data-modal-reset="reset">
-    + Create New
+    + Create
   </a>
 </li>
 {{/is_allowed}}

--- a/src/ggrc/assets/mustache/people/autocomplete_result.mustache
+++ b/src/ggrc/assets/mustache/people/autocomplete_result.mustache
@@ -28,7 +28,7 @@
 {{#is_allowed "create" "Person" context=null}}
 <li class="ui-menu-item add-new oneline" data-ui-autocomplete-item="">
   <a data-object-plural="people" data-modal-class="modal-wide" href="javascript://" data-object-singular="Person" data-toggle="modal-ajax-form" data-modal-reset="reset">
-    + Create New
+    + Create
   </a>
 </li>
 {{/is_allowed}}

--- a/src/ggrc/assets/mustache/people/filters.mustache
+++ b/src/ggrc/assets/mustache/people/filters.mustache
@@ -70,7 +70,7 @@
              data-modal-class="modal-wide"
              data-object-singular="Person"
              data-object-plural="people">
-            Create New
+            Create
           </a>
         </li>
 

--- a/src/ggrc/assets/mustache/sections/tree_add_item.mustache
+++ b/src/ggrc/assets/mustache/sections/tree_add_item.mustache
@@ -18,16 +18,16 @@
         data-object-singular="{{model.model_singular}}"
         data-object-plural="{{model.root_collection}}"
         data-object-params='{
-          "{{parent_instance.class.table_singular}}": {
-              "id" : {{parent_instance.id}},
-              "title" : "{{parent_instance.title}}" },
-              "context": {
-                  "id" : {{firstnonempty parent_instance.context.id "null"}},
-                  "href" : "{{parent_instance.context.href}}",
-                  "type" : "{{parent_instance.context.type}}"
-              }
-          }'
-        >
+          "directive": {
+              "id": {{parent_instance.id}},
+              "title": "{{parent_instance.title}}"
+          },
+          "context": {
+              "id": {{firstnonempty parent_instance.context.id "null"}},
+              "href": "{{parent_instance.context.href}}",
+              "type": "{{parent_instance.context.type}}"
+          }
+        }'>
           Create New
       </a>
     {{/is_allowed}}
@@ -53,5 +53,5 @@
       </a>
     {{/is_allowed_to_map}}
     {{/if}}
-  {{/if}}
+  {{/if_instance_of}}
 {{/if}}

--- a/src/ggrc/assets/mustache/sections/tree_add_item.mustache
+++ b/src/ggrc/assets/mustache/sections/tree_add_item.mustache
@@ -4,7 +4,36 @@
 }}
 
 {{#if allow_mapping_or_creating}}
-  {{#if allow_mapping}}
+  {{#if_instance_of parent_instance 'Contract|Policy|Regulation|Standard'}}
+    {{#if allow_creating}}
+    {{#is_allowed 'update' parent_instance}}
+      <a
+        href="javascript://"
+        class="section-create action-button create-button"
+        rel="tooltip" data-placement="left"
+        data-original-title="Create {{model.title_singular}}"
+        data-toggle="modal-ajax-form"
+        data-modal-reset="reset"
+        data-modal-class="modal-wide"
+        data-object-singular="{{model.model_singular}}"
+        data-object-plural="{{model.root_collection}}"
+        data-object-params='{
+          "{{parent_instance.class.table_singular}}": {
+              "id" : {{parent_instance.id}},
+              "title" : "{{parent_instance.title}}" },
+              "context": {
+                  "id" : {{firstnonempty parent_instance.context.id "null"}},
+                  "href" : "{{parent_instance.context.href}}",
+                  "type" : "{{parent_instance.context.type}}"
+              }
+          }'
+        >
+          Create New
+      </a>
+    {{/is_allowed}}
+    {{/if}}
+  {{else}}
+    {{#if allow_mapping}}
     {{#is_allowed_to_map parent_instance model.shortName}}
       <a
         class="section-add btn btn-mini action-button map-button"
@@ -23,5 +52,6 @@
           Map
       </a>
     {{/is_allowed_to_map}}
+    {{/if}}
   {{/if}}
 {{/if}}

--- a/src/ggrc/assets/mustache/sections/tree_add_item.mustache
+++ b/src/ggrc/assets/mustache/sections/tree_add_item.mustache
@@ -28,7 +28,7 @@
               "type": "{{parent_instance.context.type}}"
           }
         }'>
-          Create New
+          Create
       </a>
     {{/is_allowed}}
     {{/if}}

--- a/src/ggrc/assets/mustache/vendors/autocomplete_result.mustache
+++ b/src/ggrc/assets/mustache/vendors/autocomplete_result.mustache
@@ -23,7 +23,7 @@
 {{#is_allowed "create" "Vendor" context=null}}
 <li class="ui-menu-item add-new oneline" data-ui-autocomplete-item="">
   <a data-object-plural="vendors" data-modal-class="modal-wide" href="javascript://" data-object-singular="Vendor" data-toggle="modal-ajax-form" data-modal-reset="reset">
-    + Create New
+    + Create
   </a>
 </li>
 {{/is_allowed}}

--- a/src/ggrc_gdrive_integration/assets/mustache/people/gplus_actions.mustache
+++ b/src/ggrc_gdrive_integration/assets/mustache/people/gplus_actions.mustache
@@ -31,7 +31,7 @@
               </li>
               {{/circles}}
               <li class="create">
-                <a href="javascript://">Create new circle</a>
+                <a href="javascript://">Create circle</a>
               </li>
             </ul>
           </div>

--- a/src/ggrc_risk_assessments/assets/mustache/dashboard/lhn_search_actions_risk_assessments.mustache
+++ b/src/ggrc_risk_assessments/assets/mustache/dashboard/lhn_search_actions_risk_assessments.mustache
@@ -6,7 +6,7 @@
 {{#is_allowed 'create' model.shortName context='any'}}
 <li class="add-new" data-ui-autocomplete-item="">
   <a data-object-plural="{{model.table_plural}}" data-form-target="redirect" data-modal-class="modal-wide" href="javascript://" data-object-singular="{{model.model_singular}}" data-toggle="modal-ajax-form" data-modal-reset="reset" >
-    + Create New
+    + Create
   </a>
 </li>
 {{/is_allowed}}

--- a/src/ggrc_risk_assessments/assets/mustache/risk_assessments/tree_add_item.mustache
+++ b/src/ggrc_risk_assessments/assets/mustache/risk_assessments/tree_add_item.mustache
@@ -20,7 +20,7 @@
         data-object-singular="RiskAssessment"
         data-object-plural="risk_assessments"
         data-object-params='{ "{{parent_instance.class.table_singular}}": { "id" : {{parent_instance.id}}, "title" : "{{parent_instance.title}}" }, "context": { "id" : {{firstnonempty parent_instance.context.id "null"}}, "href" : "{{parent_instance.context.href}}", "type" : "{{parent_instance.context.type}}" } }'>
-        Create New
+        Create
       </a>
     {{/is_allowed}}
     {{/if}}
@@ -38,7 +38,7 @@
         data-object-params='{ "{{parent_instance.class.table_singular}}": { "id" : {{parent_instance.id}}, "title" : "{{parent_instance.title}}" }, "context": { "id" : {{firstnonempty parent_instance.context.id "null"}}, "href" : "{{parent_instance.context.href}}", "type" : "{{parent_instance.context.type}}" } }'
         data-placement="right"
         data-original-title="Create {{model.title_singular}}">
-        Create New
+        Create
       </a>
     {{/is_allowed_to_map}}
 {{/if_instance_of}}

--- a/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/tree_add_item.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/tree_add_item.mustache
@@ -23,13 +23,13 @@
             "id": {{ parent_instance.id }}
           }],
         {{/if_instance_of}}
-        "modal_title": "Create New Cycle Task"
+        "modal_title": "Create Cycle Task"
         {{#if_equals parent_instance.type 'Workflow'}}
           ,"workflow":{"id":{{parent_instance.id}},"type":"Workflow"}
         {{/if_equals}}
         }'>
 
-      Create New
+      Create
     </a>
   {{/if_recurring_workflow}}
 {{/is_allowed}}

--- a/src/ggrc_workflows/assets/mustache/selectors/multitype_multiselect_base_modal.mustache
+++ b/src/ggrc_workflows/assets/mustache/selectors/multitype_multiselect_base_modal.mustache
@@ -30,9 +30,9 @@
         >
           <i class="fa fa-plus-circle"></i>
           {{#if_equals new_object_title 'Person'}}
-            Add New
+            Add
           {{else}}
-            Create New
+            Create
           {{/#if_equals}}
           {{ new_object_title }}
         </a>

--- a/src/ggrc_workflows/assets/mustache/task_groups/tree_add_item.mustache
+++ b/src/ggrc_workflows/assets/mustache/task_groups/tree_add_item.mustache
@@ -18,7 +18,7 @@
      data-object-plural="task_groups"
      data-form-target="refresh_page_instance"
      data-object-params='{ "workflow": {{parent_instance.id}}, "context": {{parent_instance.context.id}}, "modal_title": "Create Task Group" }'>
-    Create New
+    Create
   </a>
 {{/if_equals}}
 {{/is_allowed}}


### PR DESCRIPTION
<sup>_(this issue has the "critical" priority)_</sup>

This PR changes the type of modal displayed when adding the Sections tab from the Regulations page.

Unit tests for the fix in the modals controller were omitted, because that method is convoluted beyond any reasonable threshold and would have to be significantly refactored first.

---

**Steps to reproduce:**
- Create Regulation
- Click (+) Add Tab buton in HNB and select Sections

**Actual Result:**
Unified mapper window is displayed after clicking Add and selecting Section on Regulation page

**Expected Result:**
New Section modal window is displayed after clicking Add and selecting Section on Regulation page
UPDATE: And  the same for the following objects - Policy / Regulation / Standard / Contract
UPDATE 2: Also, the "Map" buttons (above the tree view) must be changed to "Create New" buttons where applicable.
UPDATE 2a: When a "Create New" button is used, the corresponding form field in the modal must be pre-filled with the correct model instance.
UPDATE 3: The button text should say "Create" instead of "Create New". Applies to all such buttons in the app.