### PR TITLE
GGRC-575 "Saved" message is shown even if nothing was changed in GCA field

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment/inline.js
+++ b/src/ggrc/assets/javascripts/components/assessment/inline.js
@@ -101,6 +101,12 @@
 
         if (oldValue === value) {
           return;
+        } else if (this.attr('type') === 'person') {
+          if (value && oldValue && oldValue.id === value.id) {
+            // check instances of value and oldValue.
+            // return if instances are exist and ids are equal.
+            return;
+          }
         }
 
         this.attr('_value', value);

--- a/src/ggrc/assets/javascripts/components/inline_edit/inline.js
+++ b/src/ggrc/assets/javascripts/components/inline_edit/inline.js
@@ -104,6 +104,18 @@
         this.attr('context.isEdit', false);
         if (oldValue === value) {
           return;
+        } else if (type === 'checkbox' && Number(oldValue) === Number(value)) {
+          // cast to Number and compare. return if equal.
+          return;
+        } else if (type === 'person') {
+          if (value && oldValue && oldValue.id === value.id) {
+            // check instances of value and oldValue.
+            // return if instances are exist and ids are equal.
+            return;
+          } else if (!value && !oldValue) {
+            // return if instances are not exist.
+            return;
+          }
         }
 
         this.attr('_value', value);
@@ -193,7 +205,7 @@
         if (!isInside &&
             this.scope.attr('context.isEdit')) {
           _.defer(function () {
-            this.scope.onSave(this.scope, this.element, ev);
+            this.scope.onCancel(this.scope, this.element, ev);
           }.bind(this));
         }
       }


### PR DESCRIPTION
Steps to reproduce:
1. Create a program
2. Create a control
3. Navigate to Control's Info pane
4. Select any GCA field to edit and click on outside without any changes: confirm "Save" message is displayed
Actual Result: "Saved" message is shown even if nothing was changed in GCA field
Expected Result: "Saved" message should not appear even if nothing was changed in GCA field

![image](https://cloud.githubusercontent.com/assets/674129/22068428/13623f3e-dda6-11e6-8046-994b70064b52.png)

