### PR TITLE
GGRC-583 Fix blinking header info panel

### DIFF
--- a/src/ggrc/assets/stylesheets/modules/_file-controls.scss
+++ b/src/ggrc/assets/stylesheets/modules/_file-controls.scss
@@ -7,7 +7,6 @@
   @include border-radius(11px 0 0 11px);
   @include box-shadow(-1px 0 1px rgba(0,0,0, .2));
   @include opacity(0);
-  @include transition(opacity .2s ease, left .2s ease);
   position: absolute;
   top: -2px;
   left: 0;
@@ -18,7 +17,6 @@
   min-width: 20px;
   i {
     @include opacity(.6);
-    @include transition(opacity .2s ease);
   }
   a {
     width: auto !important;


### PR DESCRIPTION
**Steps to reproduce:** 
1. Navigate to Assessment’s Info pane
2. Navigate to any added URL/Evidence: confirm Assessment's title blinks

_Actual Result:_ Assessment's title blinks if navigate to added URL/Evidence in Assessment Info pane
_Expected Result:_ Assessment's title should not blink if navigate to added URL/Evidence in Assessment Info pane