### PR TITLE
GGRC-244 Fix checked reused evidence after change page

### DIFF
--- a/src/ggrc/assets/javascripts/components/reusable-objects/reusable-objects-item.js
+++ b/src/ggrc/assets/javascripts/components/reusable-objects/reusable-objects-item.js
@@ -31,15 +31,22 @@
             this.attr('mapping'));
         this.attr('disabled', isDisabled);
       },
+      isSelected: function () {
+        var instanceId = this.attr('instance.id');
+
+        return _.some(this.attr('selectedList'), function (item) {
+          return item.id === instanceId;
+        });
+      },
       toggleSelection: function (isChecked) {
         var list = this.attr('selectedList');
         var index = -1;
-        if (isChecked) {
+        if (isChecked && !this.isSelected()) {
           list.push({
             id: this.attr('instance.id'),
             type: this.attr('instance.type')
           });
-        } else {
+        } else if (!isChecked) {
           list.forEach(function (item, i) {
             var type = this.attr('instance.snapshot') ?
               'Snapshot' :
@@ -57,6 +64,9 @@
     },
     init: function () {
       this.scope.setDisabled();
+      if (this.scope.isSelected()) {
+        this.scope.attr('isChecked', true);
+      }
     },
     events: {
       '{scope} isChecked': function (scope, ev, isChecked) {


### PR DESCRIPTION
**Subject**: Checkbox for Reuse evidence is unchecked while following to the next page at Related Assessment tab in Assessment's Info panel 
**Details**: 
Create a program
Create an audit
Go to audit page
Create Assessment > Navigate to Info panel and attach an evidence
Create Assessments > Navigate to Info panel>go to Related assessments tab> Select checkbox to Reuse evidence and follow to the next page
Return to the previous page

_Actual Result_: Checkbox for Reuse evidence is unchecked while following to the next page at Related Assessment tab in Assessment's Info panel 
_Expected Result_: Checkbox for Reuse evidence should be checked while following to the next page
_Workaround_: N/A