### PR TITLE
TEST Add showcase of testing components in CanJS 2.3.x

### DIFF
--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -136,6 +136,7 @@ dashboard-js-files:
   - apps/business_objects.js
   - apps/custom_attributes.js
   # Components
+  - components/click_counter/click_counter.js
   - components/spinner/spinner.js
   - components/modal-connector.js
   - components/collapsible-panel/collapsible-panel.js
@@ -386,6 +387,7 @@ dashboard-js-template-files:
   - components/dropdown/dropdown.mustache
   - components/object_history/object_history.mustache
   - components/person/person.mustache
+  - components/click_counter/click_counter.mustache
   - components/spinner/spinner.mustache
   - components/rich_text/rich_text.mustache
   - components/datepicker/datepicker.mustache

--- a/src/ggrc/assets/javascripts/components/click_counter/click_counter.js
+++ b/src/ggrc/assets/javascripts/components/click_counter/click_counter.js
@@ -1,0 +1,42 @@
+/*!
+    Copyright (C) 2017 Google Inc.
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+(function (can) {
+  'use strict';
+
+  GGRC.Components('clickCounterWrapper', {
+    tag: 'click-counter-wrapper',
+    template: '<content></content>',
+    viewModel: {
+      initialClickCount: 5
+    }
+  });
+
+  GGRC.Components('clickCounter', {
+    tag: 'click-counter',
+    template: can.view(
+      GGRC.mustache_path +
+      '/components/click_counter/click_counter.mustache'
+    ),
+    viewModel: {
+      count: null,
+
+      // fake the stats to show double the amount of actual clicks
+      inflatedStats: function () {
+        return this.attr('count') * 2;
+      },
+
+      _updateCount: function () {
+        this.attr('count', this.count + 1);
+      }
+    },
+
+    events: {
+      '.clickable click': function ($el, ev) {
+        this.viewModel._updateCount();
+      }
+    }
+  });
+})(window.can);

--- a/src/ggrc/assets/javascripts/components/click_counter/tests/click_counter_spec.js
+++ b/src/ggrc/assets/javascripts/components/click_counter/tests/click_counter_spec.js
@@ -1,0 +1,86 @@
+/*!
+  Copyright (C) 2017 Google Inc., authors, and contributors <see AUTHORS file>
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+describe('GGRC.Components.clickCounter', function () {
+  'use strict';
+
+  var Component;  // the component under test
+  var method;  // the method under test
+  var vm;  // fake viewmodel
+  var result;
+
+  beforeAll(function () {
+    Component = GGRC.Components.get('clickCounter');
+  });
+
+  describe('inflatedStats() method', function () {
+    beforeEach(function () {
+      vm = new can.Map({
+        count: 0
+      });
+      method = Component.prototype.viewModel.inflatedStats.bind(vm);
+    });
+
+    it('returns double the amount of actual clicks', function () {
+      vm.attr('count', 7);
+      result = method();
+      expect(result).toEqual(14);
+    });
+  });
+
+  describe('_updateCount() method', function () {
+    beforeEach(function () {
+      vm = new can.Map({
+        count: 0
+      });
+      method = Component.prototype.viewModel._updateCount.bind(vm);
+    });
+
+    it('increments the current click count by one', function () {
+      vm.attr('count', 8);
+      result = method();
+      expect(vm.attr('count')).toEqual(9);
+    });
+  });
+
+  // component "integration" tests
+  describe('DOM interactions', function () {
+    var $rootNode;
+
+    beforeEach(function () {
+      var template = [
+        '<click-counter-wrapper>',
+        '  <click-counter count="initialClickCount"></click-counter>',
+        '</click-counter-wrapper>'
+      ].join('');
+
+      var renderer = can.view.mustache(template);
+      var docFragment = renderer({});
+
+      $rootNode = $(docFragment).find('click-counter-wrapper');
+    });
+
+    afterEach(function () {
+      $rootNode.remove();
+    });
+
+    it('initially displays 5 real clicks', function () {
+      var $label = $rootNode.find('label.real');
+      var text = $label.text();
+      expect(text).toEqual('Total clicks: 5');
+    });
+
+    it('updates the count info labels on button click', function () {
+      var $labelReal = $rootNode.find('label.real');
+      var $labelFake = $rootNode.find('label.fake');
+      var $button = $rootNode.find('.clickable');
+
+      $button.click();
+
+      expect($labelReal.text()).toEqual('Total clicks: 6');
+      expect($labelFake.text()).toEqual('Faked clicks: 12');
+    });
+  });
+});

--- a/src/ggrc/assets/mustache/components/click_counter/click_counter.mustache
+++ b/src/ggrc/assets/mustache/components/click_counter/click_counter.mustache
@@ -1,0 +1,13 @@
+{{!
+  Copyright (C) 2017 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+}}
+
+<span
+  class="clickable"
+  style="cursor: pointer; text-decoration: underline">Click me!</span>
+
+<br><br>
+
+<label class="real">Total clicks: {{count}}</label>
+<label class="fake">Faked clicks: {{inflatedStats}}</label>

--- a/src/ggrc/assets/mustache/dashboard/info/info.mustache
+++ b/src/ggrc/assets/mustache/dashboard/info/info.mustache
@@ -21,4 +21,12 @@
     </div>
     {{/system_role}}
     {{{render_hooks 'Dashboard.Widgets'}}}
+
+    <click-counter-wrapper style="border: 1px solid black;
+                                  min-height: 40px;
+                                  display: block;
+                                  clear: both;
+                                  padding: 20px">
+      <click-counter count="initialClickCount"></click-counter>
+    </click-counter-wrapper>
   </div>


### PR DESCRIPTION
 DO NOT MERGE! JUST A TEST!
---

Following the [discussion](https://github.com/google/ggrc-core/pull/4987#pullrequestreview-17013383) on another PR, this PR tries to test a component defined by using a `viewModel` object (as opposed to a `scope`) to see if there are any significant differences between the CanJS versions 2.3.x and 2.0.6.

The tests contain both the usual tests of viewModel's methods to event handlers. If interested, one can see  the component in action by opening the dashboard page, below the main content.

The [documentation](https://v2.canjs.com/docs/can.Component.prototype.scope.html) suggests that the `scope` property has simply been _renamed_ to "viewModel", and it indeed seems that nothing significantly has changed. Compiling a component is still not  necessary in order to test its `viewModel` methods.

