### PR TITLE
GGRC-352 Change styling of info message in people list

### DIFF
--- a/src/ggrc/assets/mustache/base_templates/people_list.mustache
+++ b/src/ggrc/assets/mustache/base_templates/people_list.mustache
@@ -9,9 +9,9 @@
 <div class="side-content">
   {{#instance.roleConflicts}}
     <div class="centered">
-      <div class="alert alert-error">
+      <div class="alert alert-verifier">
         <p>
-            Assignee and Verifier cannot be the same person!
+            Please be informed that Assignee and Verifier are the same person.
         </p>
       </div>
     </div>

--- a/src/ggrc/assets/stylesheets/modules/_label-list.scss
+++ b/src/ggrc/assets/stylesheets/modules/_label-list.scss
@@ -9,6 +9,12 @@
   }
 }
 
+people-list {
+  .alert-verifier {
+    border-width: 2px;
+  }
+}
+
 .person-label {
   @include border-radius(50%);
   width: 35px;


### PR DESCRIPTION
**Subject**: Change a warning message and a style in Info panel for Assessments
**Details**: 
Create a program with audit and map a control to the program
Navigate to audit page and create an assessment template with mandatory fields
Generate assessment using control and the template
Navigate to Info panel for Assessments
Look at the text of the message in red box

_Actual Result:_ The error message occurs in red box if navigate to Info panel for Assessments   
_Expected Result:_ If navigate to Info panel for Assessments the error message should be in yellow box and should contain the text: ”Please be informed that Assignee and Verifier are the same person”    
_Workaround_: NA

![warning_msg](https://cloud.githubusercontent.com/assets/4737102/22153594/032b850a-df39-11e6-96c0-45f82adfe7c2.png)
