### PR TITLE
GGRC-715 Incorrect message is displayed if Assessment moves from Complete status to In progress

### DIFF
--- a/src/ggrc/assets/mustache/components/assessment/urls-list.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/urls-list.mustache
@@ -10,8 +10,8 @@
               join_model="Relationship"
               quick_create="create_url"
               {{#if_in instance.status 'Completed,Verified,Ready for Review'}}verify_event="true"{{/if_in}}
-              modal_description='You are about to move request from "{{instance.status}}" to "In Progress" - are you sure about that?'
-              modal_title='Confirm moving Request to "In Progress"'
+              modal_description='You are about to move assessment from "{{instance.status}}" to "In Progress" - are you sure about that?'
+              modal_title='Confirm moving Assessment to "In Progress"'
               modal_button='Confirm'
       >
         {{#prune_context}}


### PR DESCRIPTION
Precondition:
Created program, audit
Steps to reproduce:
1. Go to audit page
2. Create assessment
3. Fill mandatory CA if any-> Click complete button
4. Add a Verifier
5. Click Complete and Verify button
6. Add url: confirm incorrect message is displayed

Actual Result: Incorrect message is displayed if Assessment moves from Complete status to In progress
Expected Result: The following message should be shown: e.g. "You are about to move assessment from "Completed" to "In Progress" - are you sure about that?"

![image](https://cloud.githubusercontent.com/assets/674129/22153667/43bf539e-df39-11e6-9d94-66abab289634.png)
