### PR TITLE
QUICK-FIX Enable CanJS stache plugin

### DIFF
--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -27,6 +27,7 @@ dashboard-js-files:
   - canjs/can.map.attributes.js
   - canjs/can.map.backup.js
   - canjs/can.map.define.js
+  - canjs/can.stache.js
   - wysihtml5/advanced.js
   - wysihtml5/wysihtml5-0.4.0pre.js
   - wysihtml5/bootstrap-wysihtml5-0.0.2.js

--- a/src/ggrc_risks/assets/javascripts/apps/risks.js
+++ b/src/ggrc_risks/assets/javascripts/apps/risks.js
@@ -317,7 +317,9 @@
 
 
 
-  GGRC.register_hook("LHN.Sections_risk", GGRC.mustache_path + "/dashboard/lhn_risks");
+  GGRC.register_hook(
+    'LHN.Sections_risk',
+    GGRC.mustache_path + '/dashboard/lhn_risks.mustache');
 
   RisksExtension.init_mappings();
 

--- a/src/ggrc_workflows/assets/javascripts/apps/workflows.js
+++ b/src/ggrc_workflows/assets/javascripts/apps/workflows.js
@@ -518,7 +518,7 @@
 
     GGRC.register_hook(
         'ObjectNav.Actions',
-        GGRC.mustache_path + '/dashboard/object_nav_actions');
+        GGRC.mustache_path + '/dashboard/object_nav_actions.mustache');
 
     $.extend(
       true,
@@ -716,10 +716,12 @@
   };
 
   GGRC.register_hook(
-      'Dashboard.Widgets', GGRC.mustache_path + '/dashboard/widgets');
+      'Dashboard.Widgets',
+      GGRC.mustache_path + '/dashboard/widgets.mustache');
 
   GGRC.register_hook(
-      'Dashboard.Errors', GGRC.mustache_path + '/dashboard/info/errors');
+      'Dashboard.Errors',
+      GGRC.mustache_path + '/dashboard/info/errors.mustache');
 
   WorkflowExtension.init_mappings();
 


### PR DESCRIPTION
This PR enables CanJS stache plugin that will allow us to start using stache templates (default in CanJS 3.x) and replace the deprecated mustache templates.

The commits were cherry picked from #4979 which is unfortunately `on hold` for the time being (waiting for spinner UI mockups).

The exact strategy of migrating from mustache to stache is yet to be discussed, but preliminary findings show that we can already start using stache for self-contained application building blocks, e.g. Components or independently compiled internal templates of Controls (#4979 contains one such example).

---

Requested a review from @andrei-karalionak since he was the one who proposed to enable stache without (unnecessarily) waiting for the spinners PR - which makes sense IMO, too.