### PR TITLE
QUICK-FIX Model cleanup

### DIFF
--- a/src/ggrc/models/all_models.py
+++ b/src/ggrc/models/all_models.py
@@ -126,7 +126,6 @@ def register_model(model):
   """
   current_module = sys.modules[__name__]
   setattr(current_module, model.__name__, model)
-  model._inflector
   all_models.append(model)
   __all__.append(model.__name__)
 

--- a/src/ggrc/models/assessment_template.py
+++ b/src/ggrc/models/assessment_template.py
@@ -20,7 +20,7 @@ from ggrc.services import common
 
 class AssessmentTemplate(assessment.AuditRelationship, relationship.Relatable,
                          mixins.Titled, mixins.CustomAttributable,
-                         mixins.Slugged, mixins.Base, db.Model):
+                         mixins.Slugged, db.Model):
   """A class representing the assessment template entity.
 
   An Assessment Template is a template that allows users for easier creation of

--- a/src/ggrc/models/event.py
+++ b/src/ggrc/models/event.py
@@ -36,10 +36,6 @@ class Event(Base, db.Model):
   def _extra_table_args(class_):
     return (
         db.Index('events_modified_by', 'modified_by_id'),
-        db.Index(
-            'ix_{}_updated_at'.format(class_.__tablename__),
-            'updated_at',
-        ),
     )
 
   @classmethod

--- a/src/ggrc_risk_assessments/models/risk_assessment.py
+++ b/src/ggrc_risk_assessments/models/risk_assessment.py
@@ -2,7 +2,6 @@
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
 from ggrc import db
-from ggrc.models.mixins import Base
 from ggrc.models.mixins import CustomAttributable
 from ggrc.models.mixins import Described
 from ggrc.models.mixins import Noted
@@ -16,8 +15,8 @@ from ggrc.models.program import Program
 from ggrc.models.relationship import Relatable
 
 
-class RiskAssessment(Documentable, Slugged, Timeboxed, Noted, Described,
-                     CustomAttributable, Titled, Relatable, Base, db.Model):
+class RiskAssessment(Documentable, Timeboxed, Noted, Described,
+                     CustomAttributable, Titled, Relatable, Slugged, db.Model):
   __tablename__ = 'risk_assessments'
   _title_uniqueness = False
 

--- a/src/ggrc_risks/models/risk.py
+++ b/src/ggrc_risks/models/risk.py
@@ -17,7 +17,7 @@ from ggrc.models.track_object_state import HasObjectState
 class Risk(HasObjectState, mixins.CustomAttributable, mixins.Stateful,
            Relatable, mixins.Described, Ownable, Personable,
            mixins.WithContact, mixins.Titled, mixins.Timeboxed,
-           mixins.Slugged, mixins.Noted, mixins.Hyperlinked, mixins.Base,
+           mixins.Noted, mixins.Hyperlinked, mixins.Slugged,
            db.Model):
   __tablename__ = 'risks'
 

--- a/src/ggrc_workflows/models/cycle_task_group.py
+++ b/src/ggrc_workflows/models/cycle_task_group.py
@@ -7,7 +7,6 @@
 from sqlalchemy import orm
 
 from ggrc import db
-from ggrc.models.mixins import Base
 from ggrc.models.mixins import Described
 from ggrc.models.mixins import Slugged
 from ggrc.models.mixins import Stateful
@@ -17,8 +16,8 @@ from ggrc.models.mixins import WithContact
 from ggrc_workflows.models.cycle import Cycle
 
 
-class CycleTaskGroup(WithContact, Stateful, Slugged, Timeboxed, Described,
-                     Titled, Base, db.Model):
+class CycleTaskGroup(WithContact, Stateful, Timeboxed, Described,
+                     Titled, Slugged, db.Model):
   """Cycle Task Group model.
   """
   __tablename__ = 'cycle_task_groups'

--- a/src/ggrc_workflows/models/cycle_task_group_object_task.py
+++ b/src/ggrc_workflows/models/cycle_task_group_object_task.py
@@ -9,7 +9,6 @@ from sqlalchemy.ext.associationproxy import association_proxy
 
 from ggrc import db
 from ggrc.models.computed_property import computed_property
-from ggrc.models.mixins import Base
 from ggrc.models.mixins import Described
 from ggrc.models.mixins import Notifiable
 from ggrc.models.mixins import Slugged
@@ -25,8 +24,8 @@ from ggrc_workflows.models.cycle_task_group import CycleTaskGroup
 
 
 class CycleTaskGroupObjectTask(
-        WithContact, Stateful, Slugged, Timeboxed, Relatable, Notifiable,
-        Described, Titled, Base, db.Model):
+        WithContact, Stateful, Timeboxed, Relatable, Notifiable,
+        Described, Titled, Slugged, db.Model):
   """Cycle task model
   """
   __tablename__ = 'cycle_task_group_object_tasks'

--- a/src/ggrc_workflows/models/task_group_task.py
+++ b/src/ggrc_workflows/models/task_group_task.py
@@ -11,14 +11,14 @@ from sqlalchemy import schema
 
 from ggrc import db
 from ggrc.login import get_current_user
-from ggrc.models.mixins import Base, Slugged, Titled, Described, WithContact
+from ggrc.models.mixins import Slugged, Titled, Described, WithContact
 from ggrc.models.types import JsonType
 from ggrc_workflows.models.mixins import RelativeTimeboxed
 from ggrc_workflows.models.task_group import TaskGroup
 
 
-class TaskGroupTask(WithContact, Slugged, Titled, Described, RelativeTimeboxed,
-                    Base, db.Model):
+class TaskGroupTask(WithContact, Titled, Described, RelativeTimeboxed,
+                    Slugged, db.Model):
   """Workflow TaskGroupTask model."""
 
   __tablename__ = 'task_group_tasks'

--- a/src/ggrc_workflows/models/workflow.py
+++ b/src/ggrc_workflows/models/workflow.py
@@ -26,8 +26,8 @@ from ggrc_workflows.models import cycle_task_group
 
 
 class Workflow(mixins.CustomAttributable, HasOwnContext, mixins.Timeboxed,
-               mixins.Described, mixins.Titled, mixins.Slugged,
-               mixins.Notifiable, mixins.Stateful, mixins.Base, db.Model):
+               mixins.Described, mixins.Titled,
+               mixins.Notifiable, mixins.Stateful, mixins.Slugged, db.Model):
   """Basic Workflow first class object.
   """
   __tablename__ = 'workflows'


### PR DESCRIPTION
This is a cleanup of our models to better match the database.

Simple way to test these changes is to check the differences between the autogenerated alembic migrations and by running:
```python
from ggrc import app, db
db.Model.metadata.create_all(db.engine)
```