### PR TITLE
GGRC-806 Fix highlighting of unchanged attributes in diff

### DIFF
--- a/src/ggrc/assets/javascripts/components/snapshotter/revisions-comparer.js
+++ b/src/ggrc/assets/javascripts/components/snapshotter/revisions-comparer.js
@@ -252,7 +252,7 @@
               }
             });
             if ($sameCA.length) {
-              highlightProperty('title', $sameCA, $caOld, titleSelector);
+              highlightProperty('titleText', $sameCA, $caOld, titleSelector);
               highlightProperty('value', $sameCA, $caOld, valueSelector);
               equalCAHeight($caOld, $sameCA);
             } else {
@@ -271,7 +271,9 @@
         function highlightProperty(name, $caFirst, $caLast, selector) {
           var caFirstScope = $caFirst.viewModel();
           var caLastScope = $caLast.viewModel();
-          if (caFirstScope[name] !== caLastScope[name]) {
+          var firstProp = caFirstScope[name].id || caFirstScope[name];
+          var lastProp = caLastScope[name].id || caLastScope[name];
+          if (firstProp !== lastProp) {
             if (caFirstScope[name]) {
               $caFirst.find(selector).addClass(highlightClass);
             }

--- a/src/ggrc/assets/javascripts/plugins/wysiwyg.js
+++ b/src/ggrc/assets/javascripts/plugins/wysiwyg.js
@@ -8,6 +8,8 @@
       return;
     }
 
+    wysihtml5ParserRules.cleanUp = false;
+
     $(this).data('_wysihtml5_initialized', true);
     this.wysihtml5({
       link: true,

--- a/third_party/wysihtml5/wysihtml5-0.4.0pre.js
+++ b/third_party/wysihtml5/wysihtml5-0.4.0pre.js
@@ -9457,7 +9457,11 @@ wysihtml5.views.Textarea = wysihtml5.views.View.extend(
     autoLink:             true,
     // Object which includes parser rules to apply when html gets inserted via copy & paste
     // See parser_rules/*.js for examples
-    parserRules:          { tags: { br: {}, span: {}, div: {}, p: {} }, classes: {} },
+    parserRules:          {
+                            tags: { br: {}, span: {}, div: {}, p: {} },
+                            classes: {},
+                            cleanUp: true
+                          },
     // Parser method to use when the user inserts content via copy & paste
     parser:               wysihtml5.dom.parse,
     // Class name which should be set on the contentEditable element in the created sandbox iframe, can be styled via the 'stylesheets' option
@@ -9562,7 +9566,10 @@ wysihtml5.views.Textarea = wysihtml5.views.View.extend(
     },
     
     parse: function(htmlOrElement) {
-      var returnValue = this.config.parser(htmlOrElement, this.config.parserRules, this.composer.sandbox.getDocument(), true);
+      var returnValue = this.config.parser(htmlOrElement,
+                                          this.config.parserRules,
+                                          this.composer.sandbox.getDocument(),
+                                          this.config.parserRules.cleanUp);
       if (typeof(htmlOrElement) === "object") {
         wysihtml5.quirks.redraw(htmlOrElement);
       }


### PR DESCRIPTION
Precondition:
Created GCA with Person type for Control, program, control with the value in GCA, audit

Steps to reproduce:
1. Go to the audit page
2. Return to the program page and make changes in Control (e.g. change the title, description, the value in any GCA except Person type)
3. Return to the audit page and refresh the page
4. Navigate to Control's Info pane and click on the "Compare with the latest version" link
5. Look at the GCA with Person type: confirm Person is marked as updated

Actual Result: The values in GCA that were not updated are shown as updated in the "Compare with the latest version" window
Expected Result: The values in GCA that were not updated should not be marked as updated in the "Compare with the latest version" window (e.g. marked with a color)

Note: the issue is related not only for GCA but for other object's fields 