### PR TITLE
GGRC-801 - Fix undefined id of Data Asstes in revision diff

### DIFF
--- a/src/ggrc/assets/javascripts/components/snapshotter/revisions-comparer.js
+++ b/src/ggrc/assets/javascripts/components/snapshotter/revisions-comparer.js
@@ -13,11 +13,19 @@
       leftRevisionId: null,
       rightRevisions: [],
       compareIt: function (scope, el, ev) {
-        var currentRevisionID = scope.leftRevisionId;
-        var revisionsLength = scope.rightRevisions.length;
-        var newRevisionID = scope.rightRevisions[revisionsLength - 1].id;
         var view = scope.instance.view;
         var that = this;
+        var currentRevisionID = scope.leftRevisionId;
+        var rightRevisions = scope.rightRevisions;
+        var revisionsLength = rightRevisions.length;
+        var newRevisionID;
+        if (!currentRevisionID || !rightRevisions || !revisionsLength) {
+          scope.instance.snapshot = scope.instance.snapshot.reify();
+          currentRevisionID = scope.instance.snapshot.revision_id;
+          rightRevisions = scope.instance.snapshot.revisions;
+          revisionsLength = rightRevisions.length;
+        }
+        newRevisionID = rightRevisions[revisionsLength - 1].id;
         GGRC.Controllers.Modals.confirm({
           modal_title: 'Compare with the latest version',
           modal_description: 'Loading...',


### PR DESCRIPTION
"Uncaught TypeError: Cannot read property 'id' of undefined" error is displayed while clicking on "Compare with the latest version" link

Precondition:
created program, object (e.g. "Data Assets"), audit

Steps to reproduce:
1. Go to audit page: confirm that "Data Assets" is displayed in HNB
2. Return to program page and make changes in "Data Assets" (e.g. change title, description)
3. Return to audit page
4. Refresh the page
5. Navigate to "Data Assets" Info pane and click on "Compare with the latest version"

Actual Result: "Uncaught TypeError: Cannot read property 'id' of undefined" error is displayed while clicking on "Compare with the latest version" link
Expected Result: no error displayed. "Compare with the latest version" dialog appears

![image](https://cloud.githubusercontent.com/assets/567805/22201408/7e203926-e174-11e6-8cb0-2f67667a7a31.png)
