### PR TITLE
GGRC-436 [Create new object] button disappears on My Work page under GR/GE roles

### DIFF
--- a/src/ggrc/assets/mustache/dashboard/info/get_started.mustache
+++ b/src/ggrc/assets/mustache/dashboard/info/get_started.mustache
@@ -41,7 +41,7 @@
   {{/is_allowed}}
 
   {{#any_allowed 'create' object_menu context='any'}}
-    <li class="get-started__list__item get-started__list__item--top-space hidden-widgets-list">
+    <li class="get-started__list__item get-started__list__item--top-space hidden-widgets-list top-space">
       <a href="#" class="dropdown-toggle" data-toggle="dropdown">
         <span class="get-started__list__icon-wrap">
           <i class="fa fa-plus-circle white"></i>


### PR DESCRIPTION
Steps to reproduce:
1. Log as GR/GE
2. Look at [Create new object] button at My Work page: disappears while My Work page is loading

Actual result: [Create new object] button disappears on My Work page under GR/GE roles
Expected result: [Create new object] button should exist on My Work page


![image](https://cloud.githubusercontent.com/assets/674129/22201211/b041937e-e173-11e6-9f41-8c7c7b4c3c3b.png)
