### PR TITLE
GGRC-805 Fix mismatch of lines of CA in revision diff

### DIFF
--- a/src/ggrc/assets/javascripts/components/snapshotter/revisions-comparer.js
+++ b/src/ggrc/assets/javascripts/components/snapshotter/revisions-comparer.js
@@ -248,6 +248,7 @@
          * @param {Object} caLast - jQuery object
          */
         function compareCA(caFirst, caLast) {
+          var prevIndex = -1;
           caFirst.each(function (i, caOld) {
             var $sameCA = [];
             var $caOld = $(caOld);
@@ -257,6 +258,7 @@
               var caNewScope = $caNew.viewModel();
               if (caNewScope.caId === caOldScope.caId) {
                 $sameCA = $caNew;
+                prevIndex = j;
               }
             });
             if ($sameCA.length) {
@@ -264,7 +266,7 @@
               highlightProperty('value', $sameCA, $caOld, valueSelector);
               equalCAHeight($caOld, $sameCA);
             } else {
-              fillEmptyCA(caLast, $caOld, i);
+              fillEmptyCA(caLast, $caOld, prevIndex);
             }
           });
         }
@@ -308,19 +310,20 @@
          * Fill empty space when CA is not existing
          * @param {Object} caList - List of CA
          * @param {Object} $ca - jQuery object Current attribute
-         * @param {Number} index - Index of current attribute
+         * @param {Number} index - Index of previous the same attribute
          */
         function fillEmptyCA(caList, $ca, index) {
-          var i = 1;
-          var caOldHeight = $ca
-                              .closest(caWrapperSelector)
-                              .outerHeight(true);
-          while (!$(caList[index - i]).length && i < index) {
-            i++;
+          var caOldHeight;
+          caOldHeight = $ca
+                          .closest(caWrapperSelector)
+                          .outerHeight(true);
+          if (index === -1) {
+            $(caList.context).css('padding-top', '+=' + caOldHeight);
+          } else {
+            $(caList[index])
+                    .closest(caWrapperSelector)
+                    .css('margin-bottom', '+=' + caOldHeight);
           }
-          $(caList[index - i])
-                  .closest(caWrapperSelector)
-                  .css('margin-bottom', '+=' + caOldHeight);
           $ca.closest(caSelector).addClass(highlightClass);
         }
       }

--- a/src/ggrc/assets/stylesheets/modules/_modal.scss
+++ b/src/ggrc/assets/stylesheets/modules/_modal.scss
@@ -741,6 +741,7 @@
        }
        .tier-content,
        custom-attributes{
+         display: block;
          .row-fluid{
            margin-bottom: 0;
            .span3,


### PR DESCRIPTION
Precondition:
Created program, control, audit

Steps to reproduce:
1. Go to the audit page
2. Return to the program page and make changes in Control (e.g. change the title, description, the value in GCA)
3. Return to the audit page and refresh the page
4. Navigate to Control's Info pane and click on the "Compare with the latest version" link
5. Look at the window: confirm GCA are displayed randomly

Actual Result: GCA fields are shown as not in line in the "Compare with the latest version" window after updates
Expected Result: GCA fields are displayed in line in the "Compare with the latest version" window after updates

![image](https://cloud.githubusercontent.com/assets/567805/22201327/20231d5c-e174-11e6-8f3b-ab5c1144d03e.png)

