### PR TITLE
GGRC-811 Fix displaying of missing fields in revision diff

### DIFF
--- a/src/ggrc/assets/javascripts/apps/custom_attributes.js
+++ b/src/ggrc/assets/javascripts/apps/custom_attributes.js
@@ -28,10 +28,9 @@
           function (cad) {
             var cav;
             var type = cad.attribute_type;
-            var instance = this.attr('instance');
             can.each(this.attr('instance.custom_attribute_values'),
               function (val) {
-                val = val.isStub || instance.isRevision ? val : val.reify();
+                val = val.isStub ? val : val.reify();
                 if (val.custom_attribute_id === cad.id) {
                   cav = val;
                 }

--- a/src/ggrc/assets/javascripts/components/snapshotter/revisions-comparer.js
+++ b/src/ggrc/assets/javascripts/components/snapshotter/revisions-comparer.js
@@ -109,7 +109,8 @@
        * @return {Object} - jQuery object
        */
       getAttributes: function ($infoPanes, index) {
-        return $($infoPanes[index]).find('.row-fluid h6 + *');
+        var selector = '.row-fluid h6 + *, .row-fluid .state-value';
+        return $($infoPanes[index]).find(selector);
       },
 
       /**

--- a/src/ggrc/assets/javascripts/components/snapshotter/revisions-comparer.js
+++ b/src/ggrc/assets/javascripts/components/snapshotter/revisions-comparer.js
@@ -77,11 +77,10 @@
       prepareInstances: function (data) {
         return data.Revision.values.map(function (value) {
           var content = value.content;
+          var model = CMS.Models[value.resource_type];
           content.isRevision = true;
-          content.class = {
-            is_custom_attributable: false
-          };
-          return {instance: content};
+          content.type = value.resource_type;
+          return {instance: new model(content)};
         });
       },
       updateRevision: function () {

--- a/src/ggrc/assets/javascripts/components/snapshotter/tests/revisions-comparer_spec.js
+++ b/src/ggrc/assets/javascripts/components/snapshotter/tests/revisions-comparer_spec.js
@@ -22,20 +22,22 @@ describe('GGRC.Components.revisionsComparer', function () {
         Revision: {
           values: [{
             id: 1,
-            content: {id: 1}
+            content: {id: 1},
+            resource_type: 'Control'
           }, {
             id: 2,
-            content: {id: 1}
+            content: {id: 1},
+            resource_type: 'Control'
           }]
         }
       };
     });
 
-    it('returns instances with isRevision and class properties', function () {
+    it('returns instances of necessary type and with isRevision', function () {
       var result = method(fakeData);
       result.forEach(function (item) {
-        expect(typeof item.instance.class).toEqual('object');
-        expect(item.instance.class.is_custom_attributable).toBe(false);
+        expect(item.instance instanceof CMS.Models.Control).toBeTruthy();
+        expect(item.instance.type).toBe('Control');
         expect(item.instance.isRevision).toBe(true);
       });
     });

--- a/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
+++ b/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
@@ -866,7 +866,7 @@
      * @return {Boolean} True or False
      */
     function isSnapshot(instance) {
-      return instance && instance.snapshot;
+      return instance && (instance.snapshot || instance.isRevision);
     }
 
     /**

--- a/src/ggrc/assets/stylesheets/modules/_modal.scss
+++ b/src/ggrc/assets/stylesheets/modules/_modal.scss
@@ -744,6 +744,7 @@
          .row-fluid{
            margin-bottom: 0;
            .span3,
+           .span4,
            .span6,
            .span9,
            .span12{

--- a/src/ggrc/assets/stylesheets/modules/_modal.scss
+++ b/src/ggrc/assets/stylesheets/modules/_modal.scss
@@ -736,8 +736,8 @@
        .info-pane-utility{
          display: none;
        }
-       .state-value{
-         display: none;
+       .pane-header h3{
+         float: none;
        }
        .tier-content,
        custom-attributes{


### PR DESCRIPTION
Precondition:
created program, control, audit

Steps to reproduce:
1. Go to the audit page
2. Return to the program page and make changes in Control (e.g. change the values in "Principal Assignee", "Secondary Assignee", "KIND/NATURE", "EFFECTIVE DATE", "STOP DATE", "ASSERTIONS", "FREQUENCY", "CATEGORIES", "TYPE/MEANS", “STATE”, “OBJECT REVIEW”)
3. Return to the audit page and refresh the page
4. Navigate to Control's Info pane and click on the "Compare with the latest version" link
5. Look at the comparison window: confirm that the updates are not shown

Actual Result: Comparison window doesn't contain the updates for the fields
Expected Result: Comparison window should contain the updates for the fields
