### PR TITLE
GGRC-470 Unify trash icon, evidence and controls in order to add URL, People and Evidance

### DIFF
--- a/src/ggrc/assets/javascripts/components/mapped_tree_view.js
+++ b/src/ggrc/assets/javascripts/components/mapped_tree_view.js
@@ -9,8 +9,6 @@
     template: can.view(GGRC.mustache_path +
       '/base_templates/mapping_tree_view.mustache'),
     scope: {
-      reusable: '@',
-      reuseMethod: '@',
       treeViewClass: '@',
       expandable: '@',
       sortField: '@',

--- a/src/ggrc/assets/mustache/base_templates/attachment.mustache
+++ b/src/ggrc/assets/mustache/base_templates/attachment.mustache
@@ -5,25 +5,25 @@
 
 <reusable-object list="reusedObjects" parent-instance="parentInstance" base-instance="baseInstance" mapping="mapping" isLoading="isLoading">
   <li data-object-id="{{instance.id}}" data-object-type="{{instance.class.table_singular}}">
-    {{#is_allowed 'update' parentInstance context='for'}}
-    {{#instance}}
-      <span class="file-controls">
-        <a href="javascript://" class="info-action unmap" data-toggle="unmap">
-          <span class="result" {{data 'result'}}></span>
-          <i class="fa fa-trash"></i>
-        </a>
-      </span>
-    {{/instance}}
-    {{/is_allowed}}
-
     {{#instance.selfLink}}
       <i class="fa fa-file-{{file_type instance}}-o"></i>
     {{/instance.selfLink}}
 
     <span class="date">{{date instance.created_at true}}</span>
 
-    <a href="{{schemed_url instance.link}}" target="_blank">
+    <a href="{{schemed_url instance.link}}" class="title" target="_blank">
       <span>{{firstnonempty instance.title instance.link}}</span>
     </a>
+
+    {{#is_allowed 'update' parentInstance context='for'}}
+      {{#instance}}
+        <span class="trash-control">
+          <a href="javascript://" class="info-action unmap" data-toggle="unmap">
+            <span class="result" {{data 'result'}}></span>
+            <i class="fa fa-trash"></i>
+          </a>
+        </span>
+      {{/instance}}
+    {{/is_allowed}}
   </li>
 </reusable-object>

--- a/src/ggrc/assets/mustache/base_templates/attachment.mustache
+++ b/src/ggrc/assets/mustache/base_templates/attachment.mustache
@@ -3,44 +3,27 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
 
-<reusable-object reusable="reusable" method="reuseMethod" list="reusedObjects" parent-instance="parentInstance" base-instance="baseInstance" mapping="mapping" isLoading="isLoading">
+<reusable-object list="reusedObjects" parent-instance="parentInstance" base-instance="baseInstance" mapping="mapping" isLoading="isLoading">
   <li data-object-id="{{instance.id}}" data-object-type="{{instance.class.table_singular}}">
-    {{^if reusable}}
-      {{#is_allowed 'update' parentInstance context='for'}}
-      {{#instance}}
-        <span class="file-controls">
-          <a href="javascript://" class="info-action unmap" data-toggle="unmap">
-            <span class="result" {{data 'result'}}></span>
-            <i class="fa fa-trash"></i>
-          </a>
-        </span>
-      {{/instance}}
-      {{/is_allowed}}
-    {{/if}}
+    {{#is_allowed 'update' parentInstance context='for'}}
+    {{#instance}}
+      <span class="file-controls">
+        <a href="javascript://" class="info-action unmap" data-toggle="unmap">
+          <span class="result" {{data 'result'}}></span>
+          <i class="fa fa-trash"></i>
+        </a>
+      </span>
+    {{/instance}}
+    {{/is_allowed}}
 
     {{#instance.selfLink}}
       <i class="fa fa-file-{{file_type instance}}-o"></i>
     {{/instance.selfLink}}
 
-    {{^if reusable}}
     <span class="date">{{date instance.created_at true}}</span>
-    {{/if}}
 
     <a href="{{schemed_url instance.link}}" target="_blank">
       <span>{{firstnonempty instance.title instance.link}}</span>
     </a>
-
-    {{#if reusable}}
-      {{#is_allowed 'update' baseInstance context='for'}}
-        {{#is_allowed 'update' instance context='for'}}
-          {{#isDisabled instance}}
-            <input type="checkbox" checked disabled />
-          {{/isDisabled}}
-          {{^isDisabled instance}}
-            <input type="checkbox" {{#isLoading}}disabled{{/isLoading}} can-value="list.{{method}}-{{instance.type}}-{{instance.id}}" />
-          {{/isDisabled}}
-        {{/is_allowed}}
-      {{/is_allowed}}
-    {{/if}}
   </li>
 </reusable-object>

--- a/src/ggrc/assets/mustache/base_templates/mapping_tree_view.mustache
+++ b/src/ggrc/assets/mustache/base_templates/mapping_tree_view.mustache
@@ -7,7 +7,7 @@
   {{#if mappedObjects.length}}
     {{#mappedObjects}}
       {{#using instance=instance}}
-        {{{render itemTemplate instance=instance baseInstance=baseInstance parentInstance=parentInstance reusable=reusable reusedObjects=reusedObjects reuseMethod=reuseMethod mapping=mapping isLoading=isLoading isExpandable=isExpandable}}}
+        {{{render itemTemplate instance=instance baseInstance=baseInstance parentInstance=parentInstance reusedObjects=reusedObjects mapping=mapping isLoading=isLoading isExpandable=isExpandable}}}
       {{/using}}
     {{/mappedObjects}}
   {{else}}

--- a/src/ggrc/assets/mustache/base_templates/people_group.mustache
+++ b/src/ggrc/assets/mustache/base_templates/people_group.mustache
@@ -31,17 +31,18 @@
   {{/if}}
   {{#results}}
     <li>
-      {{#has_permissions}}
-        {{#can_unmap}}
-        <span class="file-controls">
-          <a href="javascript://" class="info-action unmap" can-click="remove_role" data-person={{id}}>
-            <span class="result" {{data 'result'}}></span>
-            <i class="fa fa-trash"></i>
-          </a>
-        </span>
-        {{/can_unmap}}
-      {{/has_permissions}}
-      <person-info person-obj="." />
+      <person-info person-obj=".">
+        {{#has_permissions}}
+          {{#can_unmap}}
+            <span class="trash-control">
+              <a href="javascript://" class="info-action unmap" can-click="remove_role" data-person={{id}}>
+                <span class="result" {{data 'result'}}></span>
+                <i class="fa fa-trash"></i>
+              </a>
+            </span>
+          {{/can_unmap}}
+        {{/has_permissions}}
+      </person-info>
     </li>
   {{/results}}
   <li class="person-add">
@@ -52,7 +53,7 @@
           <div class="person-selector">
             <input tabindex="7" type="text" name="" class="search-icon" data-lookup="Person" placeholder="Search for {{type}}" null-if-empty="false" value="" {{autocomplete_select}} />
             <a href="javascript://" {{toggle_button}}>
-              <i class="fa fa-times"></i>
+              <i class="fa fa-trash"></i>
             </a>
           </div>
         {{/toggle}}

--- a/src/ggrc/assets/mustache/base_templates/urls.mustache
+++ b/src/ggrc/assets/mustache/base_templates/urls.mustache
@@ -5,19 +5,20 @@
 
 <reusable-object list="reusedObjects" parent-instance="parentInstance" base-instance="baseInstance" mapping="mapping" isLoading="isLoading">
   <li data-object-id="{{instance.id}}" data-object-type="{{instance.class.table_singular}}">
-    {{#is_allowed 'update' parentInstance context='for'}}
-    {{#instance}}
-      <span class="file-controls">
-        <a href="javascript://" class="info-action unmap" data-toggle="unmap">
-          <span class="result" {{data 'result'}}></span>
-          <i class="fa fa-trash"></i>
-        </a>
-      </span>
-    {{/instance}}
-    {{/is_allowed}}
     <span class="date">{{date instance.created_at true}}</span>
-    <a href="{{schemed_url instance.link}}" target="_blank">
+    <a href="{{schemed_url instance.link}}" class="title" target="_blank">
       <span>{{firstnonempty instance.title instance.link}}</span>
     </a>
+
+    {{#is_allowed 'update' parentInstance context='for'}}
+      {{#instance}}
+        <span class="trash-control">
+          <a href="javascript://" class="info-action unmap" data-toggle="unmap">
+            <span class="result" {{data 'result'}}></span>
+            <i class="fa fa-trash"></i>
+          </a>
+        </span>
+      {{/instance}}
+    {{/is_allowed}}
   </li>
 </reusable-object>

--- a/src/ggrc/assets/mustache/base_templates/urls.mustache
+++ b/src/ggrc/assets/mustache/base_templates/urls.mustache
@@ -3,9 +3,8 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
 
-<reusable-object reusable="reusable" method="reuseMethod" list="reusedObjects" parent-instance="parentInstance" base-instance="baseInstance" mapping="mapping" isLoading="isLoading">
+<reusable-object list="reusedObjects" parent-instance="parentInstance" base-instance="baseInstance" mapping="mapping" isLoading="isLoading">
   <li data-object-id="{{instance.id}}" data-object-type="{{instance.class.table_singular}}">
-    {{^if reusable}}
     {{#is_allowed 'update' parentInstance context='for'}}
     {{#instance}}
       <span class="file-controls">
@@ -16,23 +15,9 @@
       </span>
     {{/instance}}
     {{/is_allowed}}
-    {{/if}}
     <span class="date">{{date instance.created_at true}}</span>
     <a href="{{schemed_url instance.link}}" target="_blank">
       <span>{{firstnonempty instance.title instance.link}}</span>
     </a>
-
-    {{#if reusable}}
-      {{#is_allowed 'update' baseInstance context='for'}}
-        {{#is_allowed 'update' instance context='for'}}
-          {{#isDisabled instance}}
-            <input type="checkbox" checked disabled />
-          {{/isDisabled}}
-          {{^isDisabled instance}}
-            <input type="checkbox" {{#isLoading}}disabled{{/isLoading}} can-value="list.{{method}}-{{instance.type}}-{{instance.id}}" />
-          {{/isDisabled}}
-        {{/is_allowed}}
-      {{/is_allowed}}
-    {{/if}}
   </li>
 </reusable-object>

--- a/src/ggrc/assets/mustache/components/assessment/urls-list.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/urls-list.mustache
@@ -3,30 +3,6 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
 <h6>URL</h6>
-{{#is_allowed 'update' instance context='for'}}
-  {{#toggle show_new_object_form}}
-    <ggrc-quick-add
-              parent_instance="instance"
-              join_model="Relationship"
-              quick_create="create_url"
-              {{#if_in instance.status 'Completed,Verified,Ready for Review'}}verify_event="true"{{/if_in}}
-              modal_description='You are about to move request from "{{instance.status}}" to "In Progress" - are you sure about that?'
-              modal_title='Confirm moving Request to "In Progress"'
-              modal_button='Confirm'
-      >
-        {{#prune_context}}
-            <div class="objective-selector field-wrap">
-                <input tabindex="3" type="text" name="instance" placeholder="Add URL">
-                <a href="javascript://" {{toggle_button}}><i class="fa fa-trash"></i></a>
-                <a href="javascript://" class="btn btn-small btn-success no-float {{#if disabled}}disabled{{/disabled}}" data-toggle="submit" {{toggle_button 'modal:success'}}>Add</a>
-            </div>
-            <input type="hidden" name="role_name" value="Auditor" />
-        {{/prune_context}}
-      </ggrc-quick-add>
-  {{else}}
-      <a class="assessment-url-list__add-btn" {{toggle_button}}><i class="fa fa-plus-circle"></i></a>
-  {{/toggle}}
-{{/is_allowed}}
 {{#if_mapping_ready "urls" instance}}
   <mapping-tree-view
     parent-instance="instance"
@@ -35,6 +11,42 @@
   >
   </mapping-tree-view>
 {{/if_mapping_ready}}
+{{#is_allowed 'update' instance context='for'}}
+  {{#toggle show_new_object_form}}
+    <ggrc-quick-add
+      parent_instance="instance"
+      join_model="Relationship"
+      quick_create="create_url"
+      {{#if_in instance.status 'Completed,Verified,Ready for Review'}}verify_event="true"{{/if_in}}
+      modal_description='You are about to move request from "{{instance.status}}" to "In Progress" - are you sure about that?'
+      modal_title='Confirm moving Request to "In Progress"'
+      modal_button='Confirm'
+    >
+      {{#prune_context}}
+        <div class="inline-edit inline-edit--active">
+          <div class="inline-edit__content">
+            <input tabindex="3" type="text" name="instance" placeholder="Add URL">
+            <input type="hidden" name="role_name" value="Auditor" />
+            <ul class="inline-edit__controls inline-edit__controls--edit-mode">
+              <li>
+                <a href="javascript://" class="{{#if disabled}}disabled{{/disabled}}" data-toggle="submit" {{toggle_button 'modal:success'}}>
+                  <i class="fa fa-check"></i>
+                </a>
+              </li>
+              <li>
+                <a href="javascript://" {{toggle_button}}>
+                  <i class="fa fa-times"></i>
+                </a>
+              </li>
+            </ul>
+          </div>
+        </div>
+      {{/prune_context}}
+    </ggrc-quick-add>
+  {{else}}
+    <a class="assessment-url-list__add-btn" {{toggle_button}}><i class="fa fa-plus-circle"></i></a>
+  {{/toggle}}
+{{/is_allowed}}
 {{#with_mapping instance.class.info_pane_options.urls.mapping instance}}
   {{#info_related_objects}}
     {{{render parent_instance.class.info_pane_options.urls.show_view instance=instance}}}

--- a/src/ggrc/assets/mustache/components/person/person.mustache
+++ b/src/ggrc/assets/mustache/components/person/person.mustache
@@ -7,6 +7,8 @@
   {{#if personObj}}
     {{{renderLive '/static/mustache/people/popover.mustache' person=personObj}}}
 
+    <content/>
+
     {{#if editable}}
     <a href="javascript://" class="unmap" title="Remove">
       <i class="fa fa-trash"></i>

--- a/src/ggrc/assets/stylesheets/modules/_attachment-list.scss
+++ b/src/ggrc/assets/stylesheets/modules/_attachment-list.scss
@@ -34,6 +34,8 @@
 
 .attachment-list {
   @extend %reset-list;
+  display: flex;
+  flex-direction: column;
   .fa {
     vertical-align: bottom;
   }
@@ -41,7 +43,6 @@
     color: $gray;
     font-size: 11px;
     font-style: italic;
-    display: inline-block;
     margin-right: 4px;
     line-height: 18px;
     vertical-align: top;
@@ -50,21 +51,26 @@
     margin: 5px 0 10px;
   }
   li {
+    display: flex;
     margin-bottom: 5px;
-    position: relative;
+    a.title {
+      overflow: hidden !important;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      max-width: 70%;
+      display: inline-block;
+    }
+    .trash-control {
+      padding-left: 16px;
+      display: none;
+    }
+
     &:hover {
-      .file-controls {
-        @include opacity(1);
-        left: -25px;
+      .trash-control {
+        display: inherit;
       }
     }
-    [class*="fa-file-"] {
-      vertical-align: top;
-    }
     a {
-      @extend %oneline;
-      width: 68%;
-      display: inline-block;
       &.more {
         display: inline;
         width: auto;
@@ -76,23 +82,10 @@
       vertical-align: bottom;
     }
     .tree-title-area {
-      margin-top: 0px;
+      margin-top: 0;
     }
   }
-  .past-items-list & {
-    width: 92%;
-    li {
-      margin-bottom: 0;
-    }
-    label {
-      display: inline-block;
-      @extend %oneline;
-      width: 95%;
-    }
-    input[type="checkbox"] {
-      float: right;
-    }
-  }
+
   .entry-list & {
     padding: 4px 0 0 0;
     li {

--- a/src/ggrc/assets/stylesheets/modules/_label-list.scss
+++ b/src/ggrc/assets/stylesheets/modules/_label-list.scss
@@ -122,7 +122,6 @@ people-list {
   }
   i {
     @include opacity(.6);
-    @include transition(opacity .2s ease);
   }
   a {
     &:hover {

--- a/src/ggrc/assets/stylesheets/modules/_modal.scss
+++ b/src/ggrc/assets/stylesheets/modules/_modal.scss
@@ -874,8 +874,21 @@
   }
 }
 
-.person a.unmap {
-  margin-left: 0.4em;
+.person {
+  display: flex;
+  .trash-control {
+    padding-left: 16px;
+    display: none;
+  }
+
+  &:hover {
+    .trash-control {
+      display: inherit;
+    }
+  }
+  a.unmap {
+    margin-left: 0.4em;
+  }
 }
 
 // Mockups Assessment Page V1.0


### PR DESCRIPTION
1. Unify controls in order to add URL and People
2. Trash icon behavior according to the future design  

![03_asmt_trash_icons](https://cloud.githubusercontent.com/assets/4737102/22294955/43b42398-e326-11e6-8411-4907ef4b3aa2.png)
