### PR TITLE
GGRC-814 Add default Mapping type for Assessment Edit Modal

### DIFF
--- a/src/ggrc/assets/javascripts/components/modal-connector.js
+++ b/src/ggrc/assets/javascripts/components/modal-connector.js
@@ -37,7 +37,6 @@
       init: function () {
         var that = this;
         var key;
-
         this.scope.attr('controller', this);
         if (!this.scope.instance) {
           this.scope.attr('deferred', true);
@@ -116,11 +115,12 @@
         }
         this.scope.attr('instance', this.scope.attr('parent_instance')
           .attr(this.scope.instance_attr).reify());
+        // Add pending operations
         can.each(changes, function (item) {
           var mapping = this.scope.mapping ||
-            GGRC.Mappings.get_canonical_mapping_name(
-              this.scope.instance.constructor.shortName,
-              item.what.constructor.shortName);
+              GGRC.Mappings.get_canonical_mapping_name(
+                this.scope.instance.constructor.shortName,
+                item.what.constructor.shortName);
           if (item.how === 'add') {
             this.scope.instance
               .mark_for_addition(mapping, item.what, item.extra);

--- a/src/ggrc/assets/javascripts/components/unified_mapper/mapper.js
+++ b/src/ggrc/assets/javascripts/components/unified_mapper/mapper.js
@@ -238,29 +238,36 @@
       deferredSave: function () {
         var source = this.scope.attr('deferred_to').instance ||
           this.scope.attr('mapper.object');
+        var data = {};
 
-        var data = {
-          multi_map: true,
-          arr: _.compact(_.map(
-            this.scope.attr('mapper.selected'),
-            function (desination) {
-              var isAllowed = GGRC.Utils.allowed_to_map(source, desination);
-              var instance =
-                can.makeArray(this.scope.attr('mapper.entries'))
-                  .map(function (entry) {
-                    return entry.instance || entry;
-                  })
-                  .find(function (instance) {
-                    return instance.id === desination.id &&
-                      instance.type === desination.type;
-                  });
-              if (instance && isAllowed) {
-                return instance;
-              }
-            }.bind(this)
-          ))
-        };
-
+        if (this.scope.attr('mapper.useSnapshots')) {
+          data = {
+            multi_map: true,
+            arr: this.scope.attr('mapper.selected')
+          };
+        } else {
+          data = {
+            multi_map: true,
+            arr: _.compact(_.map(
+              this.scope.attr('mapper.selected'),
+              function (desination) {
+                var isAllowed = GGRC.Utils.allowed_to_map(source, desination);
+                var instance =
+                  can.makeArray(this.scope.attr('mapper.entries'))
+                    .map(function (entry) {
+                      return entry.instance || entry;
+                    })
+                    .find(function (instance) {
+                      return instance.id === desination.id &&
+                        instance.type === desination.type;
+                    });
+                if (instance && isAllowed) {
+                  return instance;
+                }
+              }.bind(this)
+            ))
+          };
+        }
         this.scope.attr('deferred_to').controller.element.trigger(
           'defer:add', [data, {map_and_save: true}]);
         this.closeModal();

--- a/src/ggrc/assets/mustache/assessments/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessments/modal_content.mustache
@@ -7,7 +7,7 @@
 <div class="hideable-holder">
 {{#instance}}
 <form action="javascript://">
-  {{> /static/mustache/base_objects/form_restore.mustache}}
+  {{> '/static/mustache/base_objects/form_restore.mustache'}}
 
   {{^if new_object_form}}
     {{#if_in instance.status "Not Started,Completed,Verified"}}
@@ -65,7 +65,7 @@
       <ggrc-modal-connector
               parent_instance="instance"
               instance="instance"
-              source_mapping="info_related_objects"
+              mapping="related_objects_as_source"
               deferred="true">
         <label class="border-l">
           Mapped Objects
@@ -122,7 +122,6 @@
                  data-toggle="unified-mapper"
                  data-deferred="true"
                  data-object-source="true"
-                 data-join-mapping="business_objects"
                  data-join-object-id="{{instance.id}}"
                  data-join-object-type="{{instance.class.model_singular}}"
                  data-original-title="Map Object to this {{instance.class.title_singular}}" tabindex="6"
@@ -186,7 +185,7 @@
 
 
     <div class="span6 hide-wrap hidable">
-      {{> /static/mustache/base_objects/modal_contact_fields.mustache}}
+      {{> '/static/mustache/base_objects/modal_contact_fields.mustache'}}
     </div>
     </div>
 


### PR DESCRIPTION
Precondition:
created program, control, audit
Steps to reproduce:
1. Go to audit page
2. Create assessment 
3. Open Edit Assessments modal window
4. Click Map object button and map Control to assessment: confirm the selected Control is not shown in modal window
Actual Result: Objects are not mapped to Assessment in Edit Assessment modal window
Expected Result: Objects should be mapped to Assessment in Edit Assessment modal window and a message is shown that <object> is mapped to assessment
