### PR TITLE
GGRC-871 Update related assessments

### DIFF
--- a/src/ggrc/utils/similarity_options.py
+++ b/src/ggrc/utils/similarity_options.py
@@ -5,11 +5,10 @@
 
 ASSESSMENT = {
     "relevant_types": {
-        "Audit": {"weight": 5},
-        "Regulation": {"weight": 3},
-        "Control": {"weight": 10},
+        "Objective": {"weight": 2},
+        "Control": {"weight": 2},
     },
-    "threshold": 5,
+    "threshold": 1,
 }
 
 # similarity_options for assessment and request are the same at the moment

--- a/test/integration/ggrc/models/factories.py
+++ b/test/integration/ggrc/models/factories.py
@@ -259,6 +259,12 @@ class ObjectDocumentFactory(ModelFactory):
     model = models.ObjectDocument
 
 
+class ObjectiveFactory(TitledFactory):
+
+  class Meta:
+    model = models.Objective
+
+
 class RegulationFactory(TitledFactory):
 
   class Meta:

--- a/test/integration/ggrc/models/mixins/test_with_similarity_score.py
+++ b/test/integration/ggrc/models/mixins/test_with_similarity_score.py
@@ -221,7 +221,7 @@ class TestWithSimilarityScore(integration.ggrc.TestCase):
     assessment_mappings = [
         [audit_1, objective_1_program_1, objective_2_program_1],
         [audit_2, objective_1_program_1, objective_2_program_1],
-        [audit_3, objective_1_program_1],
+        [audit_3],
     ]
 
     assessment_1, assessment_2, assessment_3 = self.make_assessments(
@@ -321,12 +321,12 @@ class TestWithSimilarityScore(integration.ggrc.TestCase):
     ]
 
     weights = [
-        [13, 18, 20, 25, 26],
-        [10, 15, 20, 20, 25],
-        [10, 13, 13, 15, 18],
-        [13, 18, 20, 25, 26],
-        [10, 13, 13, 15, 18],
-        [10, 15, 20, 20, 25]
+        [4, 4, 4, 4, 8],
+        [2, 2, 4, 4, 4],
+        [2, 2, 4, 4, 4],
+        [4, 4, 4, 4, 8],
+        [2, 2, 4, 4, 4],
+        [2, 2, 4, 4, 4],
     ]
 
     assessments = self.make_assessments(

--- a/test/integration/ggrc/models/mixins/test_with_similarity_score.py
+++ b/test/integration/ggrc/models/mixins/test_with_similarity_score.py
@@ -18,6 +18,7 @@ from integration.ggrc.models import factories
 # pylint: disable=super-on-old-class; TestCase is a new-style class
 class TestWithSimilarityScore(integration.ggrc.TestCase):
   """Integration test suite for WithSimilarityScore functionality."""
+
   def setUp(self):
     super(TestWithSimilarityScore, self).setUp()
     self.obj_gen = integration.ggrc.generator.ObjectGenerator()
@@ -51,10 +52,10 @@ class TestWithSimilarityScore(integration.ggrc.TestCase):
     self.make_relationships(source, snapshots)
 
   def make_assessments(self, assessment_mappings):
-    """Create six assessments and map them to audit, control, regulation.
+    """Create six assessments and map them to audit, control, objective.
 
     Each of the created assessments is mapped to its own subset of {audit,
-    control, regulation} so each of them has different similarity weight.
+    control, objective} so each of them has different similarity weight.
 
     Returns: the six generated assessments and their weights in a dict.
     """
@@ -154,10 +155,10 @@ class TestWithSimilarityScore(integration.ggrc.TestCase):
   def test_similar_partially_matching(self):
     """Basic check of similar objects manually and via Query API.
 
-    We create three programs, map one them to the two regulations, create two
+    We create three programs, map one them to the two objectives, create two
     audits and verify that we get the same result manually and via Query API.
 
-    We also ensure that for only single matching regulation we do not
+    We also ensure that for only single matching objective we do not
     fetch that assessment is as related.
     """
 
@@ -167,26 +168,26 @@ class TestWithSimilarityScore(integration.ggrc.TestCase):
     program_2 = factories.ProgramFactory(title="Program 2")
     program_3 = factories.ProgramFactory(title="Program 3")
 
-    regulation_1_program_1 = factories.RegulationFactory(title="Regulation 1")
-    regulation_2_program_1 = factories.RegulationFactory(title="Regulation 2")
+    objective_1_program_1 = factories.ObjectiveFactory(title="Objective 1")
+    objective_2_program_1 = factories.ObjectiveFactory(title="Objective 2")
 
     self.make_relationships(
         program_1, [
-            regulation_1_program_1,
-            regulation_2_program_1,
+            objective_1_program_1,
+            objective_2_program_1,
         ],
     )
 
     self.make_relationships(
         program_2, [
-            regulation_1_program_1,
-            regulation_2_program_1,
+            objective_1_program_1,
+            objective_2_program_1,
         ],
     )
 
     self.make_relationships(
         program_3, [
-            regulation_1_program_1,
+            objective_1_program_1,
         ],
     )
 
@@ -194,10 +195,10 @@ class TestWithSimilarityScore(integration.ggrc.TestCase):
     program_2 = models.Program.query.filter_by(title="Program 2").one()
     program_3 = models.Program.query.filter_by(title="Program 3").one()
 
-    regulation_1_program_1 = models.Regulation.query.filter_by(
-        title="Regulation 1").one()
-    regulation_2_program_1 = models.Regulation.query.filter_by(
-        title="Regulation 2").one()
+    objective_1_program_1 = models.Objective.query.filter_by(
+        title="Objective 1").one()
+    objective_2_program_1 = models.Objective.query.filter_by(
+        title="Objective 2").one()
 
     _, audit_1 = self.obj_gen.generate_object(models.Audit, {
         "title": "Audit 1",
@@ -218,9 +219,9 @@ class TestWithSimilarityScore(integration.ggrc.TestCase):
     })
 
     assessment_mappings = [
-        [audit_1, regulation_1_program_1, regulation_2_program_1],
-        [audit_2, regulation_1_program_1, regulation_2_program_1],
-        [audit_3, regulation_1_program_1],
+        [audit_1, objective_1_program_1, objective_2_program_1],
+        [audit_2, objective_1_program_1, objective_2_program_1],
+        [audit_3, objective_1_program_1],
     ]
 
     assessment_1, assessment_2, assessment_3 = self.make_assessments(
@@ -267,15 +268,15 @@ class TestWithSimilarityScore(integration.ggrc.TestCase):
 
     program_1 = factories.ProgramFactory(title="Program 1")
 
-    regulation_1_program_1 = factories.RegulationFactory(title="Regulation 1")
-    regulation_2_program_1 = factories.RegulationFactory(title="Regulation 2")
+    objective_1_program_1 = factories.ObjectiveFactory(title="Objective 1")
+    objective_2_program_1 = factories.ObjectiveFactory(title="Objective 2")
     control_1_program_1 = factories.ControlFactory(title="Control 1")
     control_2_program_1 = factories.ControlFactory(title="Control 2")
 
     self.make_relationships(
         program_1, [
-            regulation_1_program_1,
-            regulation_2_program_1,
+            objective_1_program_1,
+            objective_2_program_1,
             control_1_program_1,
             control_2_program_1
         ],
@@ -295,10 +296,10 @@ class TestWithSimilarityScore(integration.ggrc.TestCase):
         "status": "Planned",
     })
 
-    regulation_1_program_1 = models.Regulation.query.filter_by(
-        title="Regulation 1").one()
-    regulation_2_program_1 = models.Regulation.query.filter_by(
-        title="Regulation 2").one()
+    objective_1_program_1 = models.Objective.query.filter_by(
+        title="Objective 1").one()
+    objective_2_program_1 = models.Objective.query.filter_by(
+        title="Objective 2").one()
     control_1_program_1 = models.Control.query.filter_by(
         title="Control 1").one()
     control_2_program_1 = models.Control.query.filter_by(
@@ -306,16 +307,16 @@ class TestWithSimilarityScore(integration.ggrc.TestCase):
 
     assessment_mappings = [
         [audit_1,
-         regulation_1_program_1, regulation_2_program_1,
+         objective_1_program_1, objective_2_program_1,
          control_1_program_1, control_2_program_1],
         [audit_1, control_1_program_1, control_2_program_1],
         [audit_1,
-         regulation_1_program_1, control_1_program_1],
+         objective_1_program_1, control_1_program_1],
         [audit_2,
-         regulation_1_program_1, regulation_2_program_1,
+         objective_1_program_1, objective_2_program_1,
          control_1_program_1, control_2_program_1],
         [audit_2,
-         regulation_1_program_1, control_1_program_1],
+         objective_1_program_1, control_1_program_1],
         [audit_2, control_1_program_1, control_2_program_1],
     ]
 


### PR DESCRIPTION
2. The related assessments popup (and tab) should list all assessment mapped to the same parent control or same parent objective of the snapshots to which the assessment is mapped to. All other related must be removed from the list