### PR TITLE
GGRC-844 Fix disabled Save button on create Audit form

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/modals_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/modals_controller.js
@@ -69,6 +69,8 @@
     }
   }, {
     init: function () {
+      var currentUser;
+
       if (!(this.options instanceof can.Observe)) {
         this.options = new can.Observe(this.options);
       }
@@ -76,9 +78,25 @@
       if (!this.element.find('.modal-body').length) {
         can.view(this.options.preload_view, {}, this.proxy('after_preload'));
       } else {
+        // Make sure that the current user object, if it exists, is fully
+        // loaded before rendering the form, otherwise initial validation can
+        // incorrectly fail for form fields whose values rely on current user's
+        // attributes.
+        if (GGRC.current_user) {
+          currentUser = CMS.Models.Person.cache[GGRC.current_user.id].reify();
+        }
+
+        if (currentUser && !currentUser.email) {
+          // If email - a required attribute - is missing, the user object is
+          // not fully loaded and we need to force-fetch it first.
+          currentUser.refresh().then(function () {
+            this.after_preload();
+          }.bind(this));
+          return;
+        }
+
         this.after_preload();
       }
-      // this.options.attr("mapping", !!this.options.mapping);
     },
 
     after_preload: function (content) {


### PR DESCRIPTION
This PR makes sure that before the form is rendered, the current Person object data is fully loaded so that the initial for validation passes (it used to fail because of the incomplete data of the default Audit lead, i.e. empty email address).

No tests, because and end-to-end Selenium test would make more sense... a unit test would just test an implementation detail (partially undecided on this, though... if deemed needed, I will add such test).

The downside might be that a Person object is fetched unnecessarily if the modal form does not use it, but I could not find other good ways to fix it, e.g. by hooking on some _"autocomplete field initial value loaded"_ event or something, and trigger manual form re-validation there.

NOTE: The PR does not try to handle the case when `GGRC.current_user` does not exist - if that happens, something else is seriously wrong (the modal should never open if a user has not been authenticated).

NOTE 2: The PR does not try to fix a similar bug that sometimes occur when the Audit title field is not automatically pre-filled and/or the form validation machinery misses that event - I was not able to reproduce that issue locally.

---

**Steps to reproduce:**
1. Create a program
2. Add Audit Widget, the Create New Audit modal opens
3. Look at Save and Close/ Save and Add Another buttons in the Audit modal window: are disabled

**Actual Result:**
Save button is disabled in New Audit modal window

**Expected Result:**
Saved button should not be disabled in New Audit modal window

NOTE: I was told this issue might not be reproducible on some systems... maybe depending on the OS/browser version, or the machine speed. I was able to consistently reproduce it locally on Chrome 55.0.2883.87 (64-bit), Ubuntu 16.04.