### PR TITLE
GGRC-878 Change styling of tabs on Audit page

### DIFF
--- a/src/ggrc/assets/javascripts/apps/business_objects.js
+++ b/src/ggrc/assets/javascripts/apps/business_objects.js
@@ -205,7 +205,7 @@
             widget_icon: 'fa fa-link!',
             order: 150
           };
-          all.Person.widget_icon = 'fa fa-person';
+          all.Person.widget_icon = 'person';
           return all;
         })(),
         Contract: {

--- a/src/ggrc/assets/mustache/dashboard/internav_list.mustache
+++ b/src/ggrc/assets/mustache/dashboard/internav_list.mustache
@@ -4,7 +4,7 @@
 }}
 
 {{#widget_list}}
-  <li>
+  <li class="{{internav_icon}}">
     {{#if_helpers '\
       #if' has_count '\
       and #if' count '\
@@ -110,3 +110,9 @@
 {{/is_allowed}}
 
 {{{render_hooks 'ObjectNav.Actions'}}}
+
+{{#if_page_type 'audits'}}
+  <li class="menu-action">
+    <input type="button" class="btn btn-small hide-menu" value="Hide">
+  </li>
+{{/if_page_type}}

--- a/src/ggrc/assets/stylesheets/modules/_top-nav.scss
+++ b/src/ggrc/assets/stylesheets/modules/_top-nav.scss
@@ -14,6 +14,48 @@ ul.internav {
   @extend %reset-list;
   @extend %clearfix;
   margin-left: 28px;
+  &.audit {
+    margin-right: 40px;
+    .left-menu {
+      float: left;
+    }
+    .right-menu {
+      border-left: 1px dotted $grayLight;
+      float: right;
+      position: relative;
+      padding-left: 5px;
+      &:before {
+        content: '';
+        border-left: 1px dotted $grayLight;
+        position: absolute;
+        left: -3px;
+        height: 100%;
+      }
+      .menu-action {
+        display: block !important;
+        margin-top: 2px;
+        .hide-menu {
+          background: $grayLight;
+          &:focus {
+            outline: none;
+          }
+        }
+      }
+    }
+    li {
+      &.pie-chart, &.info-circle, &.assessment, &.issue, &.assessment_template {
+        a {
+          color: $blue;
+          &:hover {
+            color: $blue;
+          }
+          i {
+            color: $blue;
+          }
+        }
+      }
+    }
+  }
   li {
     position: relative;
     float: left;


### PR DESCRIPTION
Separate tabs for audit summary, info and assessments with a different color and the rest scoping and other information towards the right with different color (Note: Mockup was created for this in the past)

UX mockups: https://drive.google.com/corp/drive/u/1/folders/0BxUZsNDMuM58MWgtSVVOMHlUY00