### PR TITLE
GGRC-783 Fix invalid date sending to backend

### DIFF
--- a/src/ggrc/assets/javascripts/components/datepicker/datepicker.js
+++ b/src/ggrc/assets/javascripts/components/datepicker/datepicker.js
@@ -163,6 +163,26 @@
         return date;
       },
 
+      /**
+       * Prepeare date to ISO format.
+       *
+       * @param {Object} scope - scope of the Component
+       * @param {string|null} val - the new value of the date setting.
+       *   If given as string, it must be in ISO date format.
+       * @return {string|null} - the new date value
+       */
+      prepareDate: function (scope, val) {
+        var valISO = null;
+        var valF = null;
+
+        if (val) {
+          val = val.trim();
+          valF = moment.utc(val, scope.MOMENT_DISPLAY_FMT, true);
+          valISO = valF.isValid() ? valF.format(scope.MOMENT_ISO_DATE) : null;
+        }
+        return valISO;
+      },
+
       '{scope} setMinDate': function (scope, ev, date) {
         var currentDateObj = null;
         var updated = this.updateDate('minDate', date);
@@ -182,12 +202,7 @@
       },
 
       '{scope} _date': function (scope, ev, val) {
-        var valISO = null;
-
-        if (val) {
-          valISO = moment.utc(val, scope.MOMENT_DISPLAY_FMT)
-                         .format(scope.MOMENT_ISO_DATE);
-        }
+        var valISO = this.prepareDate(scope, val);
         scope.attr('date', valISO);
         scope.picker.datepicker('setDate', valISO);
       },

--- a/src/ggrc/assets/javascripts/components/tests/datepicker_spec.js
+++ b/src/ggrc/assets/javascripts/components/tests/datepicker_spec.js
@@ -49,4 +49,27 @@ describe('GGRC.Components.datepicker', function () {
       expect(result.getMonth()).toBe(0);
     });
   });
+
+  describe('prepareDate() method', function () {
+    var method;
+    var scope;
+
+    beforeAll(function () {
+      scope = Component.prototype.scope();
+      method = Component.prototype.events.prepareDate.bind(scope);
+    });
+
+    it('returns null for incorrect date', function () {
+      expect(method(scope, 'some string')).toBe(null);
+      expect(method(scope, '11.12.68')).toBe(null);
+      expect(method(scope, '11.12.2017')).toBe(null);
+      expect(method(scope, '')).toBe(null);
+    });
+
+    it('returns ISO date formated for correct date', function () {
+      expect(method(scope, '11/12/2017')).toBe('2017-11-12');
+      expect(method(scope, ' 11/12/2017')).toBe('2017-11-12');
+      expect(method(scope, '11/12/2017 ')).toBe('2017-11-12');
+    });
+  });
 });


### PR DESCRIPTION
**Precondition**:
Created GCA with date type for Assessment, program, audit

**Steps to reproduce**:
1. Go to audit page-> Assessment's tab
2. Create Assessment
3. Navigate to Assessment's Info pane
4. Fill in GCA with date type with incorrect value (e.g. "space", "#$@") and click save

**Actual Result**: "There was an error!" message is displayed while saving CA with date type with incorrect value in Assessment's Info pane

**Expected Result**: no error displayed. Incorrect values should be ignored in GCA or LCA with date types. GCA or LCA fields should not contain "invalid date". "None" is displayed.

![image](https://cloud.githubusercontent.com/assets/567805/22334903/8362b01e-e3ed-11e6-8a9d-b124bf8e978b.png)
![image](https://cloud.githubusercontent.com/assets/567805/22334955/bcd6cf6a-e3ed-11e6-997a-9b6f7bff2810.png)
