### PR TITLE
GGRC-920 [release] "Assessments generation has failed" error is displayed while generating assessments

### DIFF
--- a/src/ggrc/models/hooks/assessment.py
+++ b/src/ggrc/models/hooks/assessment.py
@@ -63,8 +63,8 @@ def init_hook():
         if snapshot:
           parent_title = snapshot.parent.title
           child_revision_title = snapshot.revision.content['title']
-          obj.title = '{} assessment for {}'.format(child_revision_title,
-                                                    parent_title)
+          obj.title = u'{} assessment for {}'.format(child_revision_title,
+                                                     parent_title)
 
 
 def map_assessment(assessment, obj):


### PR DESCRIPTION
GGRC-920: Assessment generation failed cause nonASCII
character appears in control title

**Precondition:**
created program, audit, at least 1 control with nonASCII character in title
**Steps to reproduce:**
1. Go to Audit page
2. Create Assessment template
3. Go to Assessments tab and generate assessment based on the assessment template and 3 controls: confirm an error is displayed

**Actual Result:** "Assessments generation has failed" error is displayed while generating assessments
**Expected Result:** no error displayed. Assessments should be generated and displayed in Assessment tab