### PR TITLE
GGRC-858 - Apply default setting for mapper modal window when it is invoked from assessment page

### DIFF
--- a/src/ggrc/assets/javascripts/components/unified_mapper/mapper.js
+++ b/src/ggrc/assets/javascripts/components/unified_mapper/mapper.js
@@ -393,8 +393,12 @@
         this.scope.attr('mapper.contact', null);
         this.scope.attr('mapper.contactEmail', null);
         // Edge case for Assessment Generation
+        // and objects that are not in Snapshot scope
         if (!this.scope.attr('mapper.assessmentGenerator')) {
-          this.scope.attr('mapper.relevant').replace([]);
+          if (!GGRC.Utils.Snapshots.isInScopeModel(
+            this.scope.attr('mapper.object'))) {
+            this.scope.attr('mapper.relevant').replace([]);
+          }
         }
         this.setModel();
         this.setBinding();

--- a/src/ggrc/assets/javascripts/controllers/mapper.js
+++ b/src/ggrc/assets/javascripts/controllers/mapper.js
@@ -30,6 +30,8 @@
   });
 
   $('body').on('click', selectors.join(', '), function (ev, disableMapper) {
+    var relevantTo = null;
+    var type;
     var btn = $(ev.currentTarget);
     var data = {};
     var isSearch;
@@ -47,11 +49,22 @@
 
     isSearch = /unified-search/ig.test(data.toggle);
     if (!disableMapper) {
+      if (GGRC.Utils.Snapshots.isInScopeModel(data.join_object_type)) {
+        relevantTo = [{
+          readOnly: true,
+          type: data.snapshot_scope_type,
+          id: data.snapshot_scope_id
+        }];
+        type = 'Control';
+      } else {
+        type = btn.data('join-option-type');
+      }
       GGRC.Controllers.MapperModal.launch(btn, _.extend({
         object: btn.data('join-object-type'),
-        type: btn.data('join-option-type'),
+        type: type,
         'join-object-id': btn.data('join-object-id'),
         'search-only': isSearch,
+        relevantTo: relevantTo,
         template: {
           title: isSearch ?
             '/static/mustache/base_objects/modal/search_title.mustache' : ''

--- a/src/ggrc/assets/javascripts/models/assessment.js
+++ b/src/ggrc/assets/javascripts/models/assessment.js
@@ -340,12 +340,16 @@
         GGRC.current_user.id, GGRC.current_user);
       var auditLead;
 
-      if (!newObjectForm) {
-        return;
+      if (pageInstance && (!this.audit || !this.audit.id || !this.audit.type)) {
+        if (pageInstance.type === 'Audit') {
+          this.attr('audit', pageInstance);
+        } else if (this.scopeObject) {
+          this.audit = this.scopeObject;
+        }
       }
 
-      if (pageInstance && pageInstance.type === 'Audit' && !this.audit) {
-        this.attr('audit', pageInstance);
+      if (!newObjectForm) {
+        return;
       }
 
       if (this.audit) {

--- a/src/ggrc/assets/javascripts/models/mixins.js
+++ b/src/ggrc/assets/javascripts/models/mixins.js
@@ -183,11 +183,12 @@
       return GGRC.Utils.QueryAPI
         .makeRequest({data: [query]})
         .done(function (idsArr) {
-          this.attr('scopeObject',
-            {
-              id: idsArr[0][objType][queryType][0],
-              type: 'Audit'
-            });
+          var audit = {
+            id: idsArr[0][objType][queryType][0],
+            type: 'Audit'
+          };
+          this.attr('scopeObject', audit);
+          this.attr('audit', audit);
         }.bind(this));
     }
   });

--- a/src/ggrc/assets/mustache/assessments/info.mustache
+++ b/src/ggrc/assets/mustache/assessments/info.mustache
@@ -39,7 +39,7 @@
                     <assessment-mapped-related-information
                             instance="instance"
                             title-text="Related Information"
-                            mapping-type=""
+                            mapping-type="Control"
                             mapping="info_related_objects"
                             scope-object="parentInstance">
                     </assessment-mapped-related-information>


### PR DESCRIPTION
Description
by default when map objects to assessment is invoked, object type should be pre-selected to control. There should also be a filter preset that shows only the objects related to the current audit. This visually is important for the user understanding

- Create control and program and map them 
- Create audit
- Open new asmt modal window and click map object button 
- Check mapper window

Actual: Access group is selected by default and mapping filter is empty 
Excepted: Controls is selected by default and non-edible mapping filter to this audit is applied
**Note**: 

- this is expected behavior for all mapper windows from assessment page/modal window/info pane (view/create/edit modes)
- Risks and Threats breaks the default (disabled) filter - it will be fixed in scope of another issue
