### PR TITLE
GGRC-845 Remove the missing object_id issue introduced in PR 4725

### DIFF
--- a/src/ggrc/models/mixins/notifiable.py
+++ b/src/ggrc/models/mixins/notifiable.py
@@ -34,3 +34,21 @@ class Notifiable(object):
         primaryjoin=join_function,
         backref="{}_notifiable".format(self.__name__),
     )
+
+  @declared_attr
+  def _notifications_deletion(self):
+    """Relationship with notifications for self."""
+    from ggrc.models.notification import Notification
+
+    def join_function():
+      """Object and Notification join function."""
+      object_id = sa.orm.foreign(Notification.object_id)
+      object_type = sa.orm.foreign(Notification.object_type)
+      return sa.and_(object_type == self.__name__,
+                     object_id == self.id)
+
+    return sa.orm.relationship(
+        Notification,
+        primaryjoin=join_function,
+        cascade='all, delete-orphan',
+    )


### PR DESCRIPTION
**Precondition:**
Deletion Notifiable instances will not remove related to this instance notifications.

**Steps to reproduce:**
1) create notifiable instance (for example Workflow)
2) create notifications for current instances 
3) delete this instance

**Actual Result:**  
"Warning: Column 'object_id' cannot be null"

**Expected Result:** 
Related notifications should be deleted 