### PR TITLE
GGRC-812 Prevent assigning the same Auditor twice

### DIFF
--- a/src/ggrc/assets/javascripts/components/quick_form/quick_add.js
+++ b/src/ggrc/assets/javascripts/components/quick_form/quick_add.js
@@ -85,7 +85,7 @@
           this.scope.attributes.attr($(el).attr("name"), $(el).val());
         }.bind(this));
       },
-      "a[data-toggle=submit]:not(.disabled) click": function (el, ev) {
+      'a[data-toggle=submit]:not(.disabled):not([disabled]) click': function (el, ev) {
         var scope = this.scope;
         var join_model_class;
         var join_object;

--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -3719,7 +3719,42 @@ Example:
       if (modalType === matchingModal) {
         return options.fn(options.contexts);
       }
+      return options.inverse(options.contexts);
+    }
+  );
 
+  /**
+   * Check if a person is contained in the given authorization list and render
+   * the corresponding Mustache block.
+   *
+   * Example usage:
+   *
+   *   {{#isInAuthList assignee approvedEditors}}
+   *     <Edit button here...>
+   *   {{else}}
+   *     Editing not allowed.
+   *   {{/isInAuthList}}
+   *
+   * @param {CMS.Models.Person} person - the user to check for an authorization
+   * @param {Array} authList - the list of authorization grants
+   * @param {Object} options - a CanJS options argument passed to every helper
+   */
+  Mustache.registerHelper(
+    'isInAuthList',
+    function (person, authList, options) {
+      var emails;
+
+      person = Mustache.resolve(person) || {};
+      authList = Mustache.resolve(authList) || [];
+
+      emails = _.map(authList, function (item) {
+        var person = item.instance.person.reify();
+        return person.email;
+      });
+
+      if (_.includes(emails, person.email)) {
+        return options.fn(options.contexts);
+      }
       return options.inverse(options.contexts);
     }
   );

--- a/src/ggrc/assets/js_specs/mustache_helpers/isInAuthList_spec.js
+++ b/src/ggrc/assets/js_specs/mustache_helpers/isInAuthList_spec.js
@@ -1,0 +1,105 @@
+/*!
+  Copyright (C) 2017 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+describe('can.mustache.helper.isInAuthList', function () {
+  'use strict';
+
+  var html;
+  var render; // the rendering function returned by the template compilation
+  var renderedText;
+  var templateContext;
+
+  /**
+   * A factory for creating fake authorization object instances.
+   *
+   * @param {Object} personAttrs - attributes of the person object contained
+   *   within the created authorization object
+   *
+   * @return {can.Map} - authorization object mock
+   */
+  function fakeAuthObj(personAttrs) {
+    var result = new can.Map({
+      instance: {
+        person: personAttrs
+      }
+    });
+
+    spyOn(result.instance.person, 'reify')
+      .and.returnValue(result.instance.person);
+
+    return result;
+  }
+
+  beforeAll(function () {
+    var template = [
+      '<div>',
+      '  {{#isInAuthList person authorizations}}',
+      '    yes',
+      '  {{else}}',
+      '    no',
+      '  {{/isInAuthList}}',
+      '</div>'
+    ].join('');
+
+    render = can.view.mustache(template);
+  });
+
+  it(
+    'renders the falsy block if neither a person nor the authorization list ' +
+    'are given',
+    function () {
+      templateContext = {
+        person: null,
+        authorizations: null
+      };
+
+      html = render(templateContext);
+
+      renderedText = $(html).children('div').text().trim();
+      expect(renderedText).toEqual('no');
+    }
+  );
+
+  it(
+    'renders the truthy block if a person is listed in authorization list',
+    function () {
+      var authList = [
+        fakeAuthObj({id: 15, email: 'person15@foo.bar'}),
+        fakeAuthObj({id: 42, email: 'person42@foo.bar'}),
+        fakeAuthObj({id: 101, email: 'person101@foo.bar'})
+      ];
+
+      templateContext = {
+        person: {id: 42, email: 'person42@foo.bar'},
+        authorizations: authList
+      };
+
+      html = render(templateContext);
+
+      renderedText = $(html).children('div').text().trim();
+      expect(renderedText).toEqual('yes');
+    }
+  );
+
+  it(
+    'renders the falsy block if a person is not listed in authorization list',
+    function () {
+      var authList = [
+        fakeAuthObj({id: 15, email: 'person15@foo.bar'}),
+        fakeAuthObj({id: 101, email: 'person101@foo.bar'})
+      ];
+
+      templateContext = {
+        person: {id: 42, email: 'person42@foo.bar'},
+        authorizations: authList
+      };
+
+      html = render(templateContext);
+
+      renderedText = $(html).children('div').text().trim();
+      expect(renderedText).toEqual('no');
+    }
+  );
+});

--- a/src/ggrc/assets/mustache/audits/info.mustache
+++ b/src/ggrc/assets/mustache/audits/info.mustache
@@ -125,7 +125,17 @@
                 <input tabindex="3" type="text" name="instance" data-lookup="Person" null-if-empty="true" class="search-icon" placeholder="Add Auditor" {{autocomplete_select}} value="{{instance.email}}">
                 <a href="javascript://" {{toggle_button}}><i class="fa fa-trash"></i></a>
 
-                <a href="javascript://" class="btn btn-small btn-success {{^instance}}disabled{{/instance}} no-float" data-toggle="submit" {{toggle_button "modal:success"}}>Add</a>
+                {{#with_mapping 'auditor_authorizations' parent_instance}}
+                  <a
+                    href="javascript://"
+                    class="btn btn-small btn-success {{^instance}}disabled{{/instance}} no-float"
+                    data-toggle="submit" {{toggle_button "modal:success"}}
+                    {{#isInAuthList instance auditor_authorizations}}
+                      disabled
+                      title="User already set as an Auditor"
+                    {{/userExists}}
+                    >Add</a>
+                {{/with_mapping}}
               </div>
               <input type="hidden" name="role_name" value="Auditor" />
               {{/prune_context}}


### PR DESCRIPTION
This PR prevents assigning the same person as an Auditor twice on the same Audit.

The original ticket description (below) required an error message to be improved, but we instead opted to prevent the error from happening in the first place.

---

**Steps to reproduce:**
1. Create a program
2. Create an audit
3. Add a user1 as an Auditor
4. Add a user1 as an Auditor once again

**Actual Result:**
Incorrect message is displayed while adding a user that already exist to an object

**Expected Result:**
"TBD" message is displayed while adding a user that already exist to an object

UPDATE: It has later been decided, that the proper fix would be to prevent a person from being added twice, thus the "Add" button should be disabled in such cases. For user's convenience, a tooltip has been added with an explanation why the button is disabled even though the Person autoselect field contains a value.