### PR TITLE
QUICK-FIX Add ipdbplugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,12 @@ This will run the tests on each file update.
 cd test/unit; sniffer
 ```
 
+You can drop into ipdb debugger on failures by running:
+
+```sh
+run_pytests --ipdb-failures
+```
+
 #### For Selenium tests:
 
 On the host machine in the root of the repository run:

--- a/src/requirements-dev.txt
+++ b/src/requirements-dev.txt
@@ -15,6 +15,7 @@ Flask-Testing==0.4.2
 Flask==0.10.1
 freezegun==0.3.5
 ipdb==0.8.1
+ipdbplugin==1.4.5
 ipython==3.2.0
 itsdangerous==0.24
 Jinja2==2.8


### PR DESCRIPTION
This helps when debugging failures/errors in python unit/integration tests.