### PR TITLE
GGRC-958 Change a tree view menu option's text

### DIFF
--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -3710,4 +3710,18 @@ Example:
       return options.inverse(options.contexts);
     }
   );
+
+  /**
+   * Return a human friendly name of the object type associated with the
+   * currently active HNB tab.
+   *
+   * Essentially just a wrapper around GGRC.Utils.CurrentPage.activeTabObject.
+   *
+   * @param {Object} options - a CanJS options argument
+   *
+   * @return {String|null} - object type, if any, otherwise null
+   */
+  Mustache.registerHelper('activeTabType', function (options) {
+    return GGRC.Utils.CurrentPage.activeTabObject();
+  });
 })(this, jQuery, can);

--- a/src/ggrc/assets/javascripts/plugins/tests/ggrc_utils_current_page_spec.js
+++ b/src/ggrc/assets/javascripts/plugins/tests/ggrc_utils_current_page_spec.js
@@ -1,0 +1,78 @@
+/*!
+ Copyright (C) 2017 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+describe('GGRC.Utils.CurrentPage', function () {
+  var module = GGRC.Utils.CurrentPage;
+
+  describe('activeTabObject() method', function () {
+    var fakeWindow;
+    var method;  // the method under test
+    var origUtilsWin;
+    var result;
+
+    beforeAll(function () {
+      method = module.activeTabObject;
+
+      fakeWindow = {
+        location: {}
+      };
+
+      origUtilsWin = GGRC.Utils.win;
+      GGRC.Utils.win = fakeWindow;
+    });
+
+    afterAll(function () {
+      GGRC.Utils.win = origUtilsWin;
+    });
+
+    it('returns null if no HNB tab is active', function () {
+      fakeWindow.location.href = 'http://www.foo.bar/baz/123' +
+                                 '?aaa=bbb#audit_widget123';
+      fakeWindow.location.hash = '';
+
+      result = method();
+
+      expect(result).toBe(null);
+    });
+
+    it('returns null if the active tab is not associated with any object tab',
+      function () {
+        var hash = '#info_widget?aaa=bbb#audit_widget123';
+        fakeWindow.location.href = 'http://www.foo.bar/baz/123' + hash;
+        fakeWindow.location.hash = hash;
+
+        result = method();
+
+        expect(result).toBe(null);
+      }
+    );
+
+    it('returns spaced and capitalized object type associated with the ' +
+      'currently active HNB tab',
+      function () {
+        var hash = '#assessment_template_widget?aaa=bbb#audit_widget123';
+        fakeWindow.location.href = 'http://www.foo.bar/baz/123' + hash;
+        fakeWindow.location.hash = hash;
+
+        result = method();
+
+        expect(result).toEqual('Assessment Template');
+      }
+    );
+
+    it('returns spaced and capitalized object type associated with the ' +
+      'currently active HNB tab regardless of the case',
+      function () {
+        var hash = '#aSSessmenT_TEmpLaTe_wiDGet?aaa=bbb#audit_widget123';
+        fakeWindow.location.href = 'http://www.foo.bar/baz/123' + hash;
+        fakeWindow.location.hash = hash;
+
+        result = method();
+
+        expect(result).toEqual('Assessment Template');
+      }
+    );
+  });
+});

--- a/src/ggrc/assets/javascripts/plugins/utils/current-page-utils.js
+++ b/src/ggrc/assets/javascripts/plugins/utils/current-page-utils.js
@@ -5,6 +5,7 @@
 
 (function (GGRC) {
   'use strict';
+
   /**
    * Util methods for work with Current Page.
    */
@@ -41,7 +42,50 @@
       });
     }
 
+    /**
+     * Return a human-friendly name of the object type of the currently
+     * active HNB tab.
+     *
+     * If there is no "active" tab or the tab is not associated with any object
+     * type, null is returned.
+     *
+     * @return {String|null} - a spaced and capizalized object type name
+     */
+    function activeTabObject() {
+      // NOTE: window.CMS might not yed be available when this module is being
+      // defined (in tests at  least), thus we cannot simply pass it in, but
+      // instead reference it only when this function is invoked.
+      var CMS = window.CMS;
+      var PATTERN = /^#(\w+?)_widget.*/gi;
+
+      var modelType;
+      var parts;
+      var tabType;
+
+      var hash = GGRC.Utils.win.location.hash;
+      var matchInfo = PATTERN.exec(hash);
+
+      if (!matchInfo) {
+        return null;
+      }
+
+      tabType = matchInfo[1];  // the content of the first capturing group
+      parts = _.chain(tabType.split('_'))
+                .map(_.method('toLowerCase'))
+                .map(_.capitalize)
+                .value();
+
+      modelType = parts.join('');
+
+      if (!CMS.Models[modelType]) {
+        return null;
+      }
+
+      return parts.join(' ');  // model type with spaces between words
+    }
+
     return {
+      activeTabObject: activeTabObject,
       related: relatedToCurrentInstance,
       initMappedInstances: initMappedInstances
     };

--- a/src/ggrc/assets/mustache/base_objects/sub_tree_expand.mustache
+++ b/src/ggrc/assets/mustache/base_objects/sub_tree_expand.mustache
@@ -9,7 +9,7 @@
       <sub-tree-expander expanded="expanded" display="display">
         <a href="javascript://">
           <i class="fa fa-caret-{{#if expanded}}down{{else}}right{{/if}}"></i>
-          Show mapped to this parent object
+          Show objects not directly related to this {{activeTabType}}
         </a>
       </sub-tree-expander>
     </div>

--- a/src/ggrc/assets/mustache/base_objects/tree_child_show.mustache
+++ b/src/ggrc/assets/mustache/base_objects/tree_child_show.mustache
@@ -8,7 +8,7 @@
                    on-child-show-state-change="@onChildShowStateChange">
     <a href="javascript://">
       <i class="fa fa-fw fa-{{#if isChildShow}}check-{{/if}}square-o"></i>
-      Show mapped to all parents in child tree
+      Objects not directly related to this {{activeTabType}}
     </a>
   </tree-child-show>
 </li>


### PR DESCRIPTION
_(this issue has the priority of "Critical")_

This PR changes the text of one of the options in the tree view's 3BB menu, and the corresponding titles of subtree headers.

NOTE: The change depends on the hash part of the URL to be present when the corresponding tab in HNB is selected. If this is not the case, determining the object type will fail, but IMO this is something that should be fixed in the internal app router or in the URL missing  the tab info, thus the PR does not try to handle such cases (if they can even happen, that is...).

---

Original description;

> Change text for the below:
3BBs
Current: Show mapped to all parents in child tree
New: Objects not directly related to this (object type)
>
> Tree View
Current: Show mapped to this parent object
New: Show objects not directly related to this (object type)

~~It is not entirely clear what "(object type)" should be - a literal text, the type of the current page instance, something else? Maybe the type of the tree item's instance? But that doesn't not make sense for the 3BB menu option, as the latter does not belong to any tree item...~~

~~I opted for the type of the page instance, but please let me know if this should actually be something different.~~

**Update:**
It has been confirmed that using the page instance's type is indeed the way to go. BTW, we need to check how this works on e.g. Dashboard or All Objects page, since the `parent_instance` object might not be available in the templates there.

**Update 2:**
There is no "page" instance on the Dashboard and All Objects pages (it defaults to "Person"), which is probably not what should be shown to the users? What should be shown there, the current "tab" instance type? And how to make that consistent with cases when a "page" instance exists?

**Update 3:** There was a misunderstanding - not the "page instance type", it is the "current tab's object type" that should be used in the message.