### PR TITLE
GGRC-382 Fix required label in datepicker

### DIFF
--- a/src/ggrc/assets/javascripts/components/datepicker/datepicker.js
+++ b/src/ggrc/assets/javascripts/components/datepicker/datepicker.js
@@ -19,8 +19,11 @@
       setMinDate: null,
       setMaxDate: null,
       _date: null,  // the internal value of the text input field
-      required: '@',
       define: {
+        required: {
+          type: 'boolean',
+          'default': false
+        },
         label: {
           type: 'string'
         },


### PR DESCRIPTION
**Subject**: Optional fields are marked as mandatory fields in New Workflow window
**Details**: 
Open New Workflow window
Click Hide all optional fields -> Show optional fields
Look at optional field (e.g.”date-1” ): is marked as mandatory field 

_Actual Result:_ Optional fields are marked as mandatory fields in New Workflow window
_Expected Result:_ Optional fields are not marked as mandatory fields in New Workflow window
**Note**: Check the asterisks in all the modal windows
Workaround: NA