### PR TITLE
GGRC-805 Add waiting for owners refresh before highlight

### DIFF
--- a/src/ggrc/assets/javascripts/components/snapshotter/revisions-comparer.js
+++ b/src/ggrc/assets/javascripts/components/snapshotter/revisions-comparer.js
@@ -43,8 +43,10 @@
                 var fragLeft = can.view(view, revisions[0]);
                 var fragRight = can.view(view, revisions[1]);
                 fragLeft.appendChild(fragRight);
-                target.find('.modal-body').html(fragLeft);
-                that.highlightDifference(target);
+                revisions[1].instance.refresh_all('owners').then(function () {
+                  target.find('.modal-body').html(fragLeft);
+                  that.highlightDifference(target);
+                });
               });
           }
         }, this.updateRevision.bind(this));


### PR DESCRIPTION
GCA fields are shown as not in line in the "Compare with the latest version" window after updates

**Precondition**:
Created program, control, audit

**Steps to reproduce**:
1. Go to the audit page
2. Return to the program page and make changes in Control (e.g. add several owners)
3. Return to the audit page and refresh the page
4. Navigate to Control's Info pane and click on the "Compare with the latest version" link
5. Look at the window: confirm GCA are displayed randomly

**Actual Result**: GCA fields are shown as not in line in the "Compare with the latest version" window after updates

**Expected Result**: GCA fields are displayed in line in the "Compare with the latest version" window after updates

![image](https://cloud.githubusercontent.com/assets/567805/22460761/717689b6-e7b7-11e6-8351-e637a5b0478e.png)
