### PR TITLE
GGRC-992 "Uncaught TypeError: Cannot read property 'cache' of undefined" error is displayed while adding a new widget on Assessment Info page

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/mapper.js
+++ b/src/ggrc/assets/javascripts/controllers/mapper.js
@@ -34,7 +34,10 @@
     var type;
     var btn = $(ev.currentTarget);
     var data = {};
+    var joinType;
     var isSearch;
+    var snapshots = GGRC.Utils.Snapshots;
+    var scopeObject = GGRC.page_instance().scopeObject || {};
 
     _.each(btn.data(), function (val, key) {
       data[can.camelCaseToUnderscore(key)] = val;
@@ -47,17 +50,22 @@
       ev.preventDefault();
     }
 
+    joinType = btn.data('join-option-type');
     isSearch = /unified-search/ig.test(data.toggle);
     if (!disableMapper) {
-      if (GGRC.Utils.Snapshots.isInScopeModel(data.join_object_type)) {
+      if (snapshots.isInScopeModel(data.join_object_type)) {
         relevantTo = [{
           readOnly: true,
-          type: data.snapshot_scope_type,
-          id: data.snapshot_scope_id
+          type: scopeObject.type || data.snapshot_scope_type,
+          id: scopeObject.id || data.snapshot_scope_id
         }];
-        type = 'Control';
+        if (data.join_object_type === 'Assessment') {
+          type = !joinType || joinType === 'Assessment' ? 'Control' : joinType;
+        } else {
+          type = joinType;
+        }
       } else {
-        type = btn.data('join-option-type');
+        type = joinType;
       }
       GGRC.Controllers.MapperModal.launch(btn, _.extend({
         object: btn.data('join-object-type'),

--- a/src/ggrc/assets/mustache/assessments/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessments/modal_content.mustache
@@ -112,6 +112,8 @@
         {{^list.length}}
           <span class="gray"><em>No mapped objects</em></span>
         {{/list.length}}
+        {{#if new_object_form}}
+        {{else}}
           <div class="objective-selector">
             <div style="clear:both">
               <br>
@@ -126,14 +128,15 @@
                  data-join-object-id="{{instance.id}}"
                  data-join-object-type="{{instance.class.model_singular}}"
                  data-original-title="Map Object to this {{instance.class.title_singular}}" tabindex="6"
-                {{#instance.audit }}
-                   data-snapshot-scope-id="{{instance.audit.id}}"
-                  data-snapshot-scope-type="{{instance.audit.type}}"
-                {{/instance.audit}}>
+                 {{#instance.audit }}
+                 data-snapshot-scope-id="{{instance.audit.id}}"
+                 data-snapshot-scope-type="{{instance.audit.type}}"
+                 {{/instance.audit}}>
                    Map Objects
               </a>
             </div>
           </div>
+       {{/if}}
       </ggrc-modal-connector>
     </div>
     <div data-id="notifications_hidden" class="span6 hidable">


### PR DESCRIPTION
Precondition:
created program, control, audit
Steps to reproduce:
1. Go to audit page
2. Generate Assessment based on the control from precondition
3. Go to assessment tab and click Open in the first tier
4. Add any widget on Assessment Info page (e.g. "Regulation")

Actual Result: "Uncaught TypeError: Cannot read property 'cache' of undefined" error is displayed while adding a new widget on Assessment Info page
Expected Result: no error displayed while adding 