### PR TITLE
GGRC-568 Object is not shown in Search results in Unified mapper after creation

### DIFF
--- a/src/ggrc/assets/javascripts/components/unified_mapper/mapper.js
+++ b/src/ggrc/assets/javascripts/components/unified_mapper/mapper.js
@@ -231,7 +231,13 @@
         this.setModel();
         this.setBinding();
       },
+      '.add-button modal:added': function (el, ev, model) {
+        this.addNewEntry(model);
+      },
       '.add-button modal:success': function (el, ev, model) {
+        this.addNewEntry(model);
+      },
+      addNewEntry: function (model) {
         // clear
         this.scope.attr('mapper.newEntries').replace([]);
 


### PR DESCRIPTION
Steps to reproduce:
1. Create a program
2. Click Add tab-> Control
3. Click Create New Control in Unified mapper
4. Fill in all the mandatory fields-> Save and Close
5. Look at Search results in Unified mapper: newly created Control is not shown

Actual Result: Object is not shown in Search results in Unified mapper after creation
Expected Result: Object should be shown in Search results in Unified mapper after creation