### PR TITLE
GGRC-911 Move details and evidence on assessment page

### DIFF
--- a/src/ggrc/assets/mustache/assessments/info.mustache
+++ b/src/ggrc/assets/mustache/assessments/info.mustache
@@ -25,14 +25,14 @@
                     </assessment-mapped-controls>
                     <div class="assessment-controls">
                         <span class="assessment-controls__note">Input assessment information below:</span>
+                        <div class="assessment-controls__extra-controls">
+                            <assessment-attachments-list class="attachment-list oneline"></assessment-attachments-list>
+                            <assessment-urls-list></assessment-urls-list>
+                        </div>
                         <assessment-custom-attributes instance="instance"
                                                       items="custom_attribute_values"
                                                       class="assessment-custom-attributes flex-box flex-box-multi">
                         </assessment-custom-attributes>
-                        <div class="assessment-controls__extra-controls">
-                            <assessment-attachments-list class="attachment-list"></assessment-attachments-list>
-                            <assessment-urls-list></assessment-urls-list>
-                        </div>
                         <assessment-controls-toolbar class="assessment-controls-toolbar"
                                                      instance="instance"></assessment-controls-toolbar>
                     </div>
@@ -44,76 +44,75 @@
                             scope-object="parentInstance">
                     </assessment-mapped-related-information>
                 </div>
-                <div class="assessment-summary flex-size-1">
-                    <div class="section-title">Details</div>
-                    <collapsible-panel title-text="Description" collapsed="true" title-icon="fa-list-ol"
-                                       class="details-item">
-                        <read-more text="description"></read-more>
-                    </collapsible-panel>
-                    <collapsible-panel title-text="People" collapsed="true" title-icon="fa-users" class="details-item">
-                        <people-list instance="instance" editable="true" disable-title="true"></people-list>
-                    </collapsible-panel>
-                    <collapsible-panel title-text="Dates" collapsed="true" title-icon="fa-calendar"
-                                       class="details-item">
-                      {{> '/static/mustache/assessments/dates_list.mustache'}}
-                    </collapsible-panel>
-                    <collapsible-panel title-text="Notes" collapsed="true" title-icon="fa-sticky-note-o"
-                                       class="details-item">
-                        <read-more text="notes"></read-more>
-                    </collapsible-panel>
-                    <collapsible-panel title-text="URL" collapsed="true" title-icon="fa-link" class="details-item">
-                      {{> '/static/mustache/assessments/urls.mustache'}}
-                    </collapsible-panel>
-                    <collapsible-panel title-text="Code" collapsed="true" title-icon="fa-code" class="details-item">
-                        <ul class="label-list">
-                            <li>
-                                <h6>Code</h6>
-                                <span>{{instance.slug}}</span>
-                            </li>
-                        </ul>
-                    </collapsible-panel>
-                    <collapsible-panel title-text="Conclusions" collapsed="true" title-icon="fa-gavel"
-                                       class="details-item">
-                        <div class="flex-box flex-col"
-                          {{#instance}}{{data 'model'}}{{/instance}}
-                             data-force-refresh="true"
-                             data-model="true" {{ (el) -> el.ggrc_controllers_quick_form({ instance : el.data('model')}); }}>
-                            <div class="flex-size-1 flex-gutter-2">
-                                <label class="title-text">Conclusion: Design</label>
-                                <p>
-                                    <small><em>Is this control design effective?</em></small>
-                                </p>
-                              {{#is_allowed 'update' instance context='for'}}
-                                  <dropdown options-list="model.conclusions"
-                                            no-value="true"
-                                            no-value-label="---"
-                                            name="instance.design">
-                                  </dropdown>
-                              {{else}}
-                                {{firstnonempty design '--'}}
-                              {{/is_allowed}}
-                            </div>
-                            <div class="flex-size-1 flex-gutter-2">
-                                <label class="title-text">Conclusion: Operation</label>
-                                <p>
-                                    <small><em>Is this control operationally effective?</em></small>
-                                </p>
-                              {{#is_allowed 'update' instance context='for'}}
-                                  <dropdown options-list="model.conclusions"
-                                            no-value="true"
-                                            no-value-label="---"
-                                            name="instance.operationally">
-                                  </dropdown>
-                              {{else}}
-                                {{firstnonempty operationally '--'}}
-                              {{/is_allowed}}
-                            </div>
-                        </div>
-                    </collapsible-panel>
-                </div>
             </div>
             <div class="tabs-wrap">
                 <tabs instance="instance">
+                    <tab-panel panels="panels" title-text="Attributes" instance="instance">
+                      <collapsible-panel title-text="Description" collapsed="true" title-icon="fa-list-ol"
+                                         class="details-item">
+                          <read-more text="description"></read-more>
+                      </collapsible-panel>
+                      <collapsible-panel title-text="People" collapsed="true" title-icon="fa-users" class="details-item">
+                          <people-list instance="instance" editable="true" disable-title="true"></people-list>
+                      </collapsible-panel>
+                      <collapsible-panel title-text="Dates" collapsed="true" title-icon="fa-calendar"
+                                         class="details-item">
+                        {{> '/static/mustache/assessments/dates_list.mustache'}}
+                      </collapsible-panel>
+                      <collapsible-panel title-text="Notes" collapsed="true" title-icon="fa-sticky-note-o"
+                                         class="details-item">
+                          <read-more text="notes"></read-more>
+                      </collapsible-panel>
+                      <collapsible-panel title-text="URL" collapsed="true" title-icon="fa-link" class="details-item">
+                        {{> '/static/mustache/assessments/urls.mustache'}}
+                      </collapsible-panel>
+                      <collapsible-panel title-text="Code" collapsed="true" title-icon="fa-code" class="details-item">
+                          <ul class="label-list">
+                              <li>
+                                  <h6>Code</h6>
+                                  <span>{{instance.slug}}</span>
+                              </li>
+                          </ul>
+                      </collapsible-panel>
+                      <collapsible-panel title-text="Conclusions" collapsed="true" title-icon="fa-gavel"
+                                         class="details-item">
+                          <div class="flex-box flex-col"
+                            {{#instance}}{{data 'model'}}{{/instance}}
+                               data-force-refresh="true"
+                               data-model="true" {{ (el) -> el.ggrc_controllers_quick_form({ instance : el.data('model')}); }}>
+                              <div class="flex-size-1 flex-gutter-2">
+                                  <label class="title-text">Conclusion: Design</label>
+                                  <p>
+                                      <small><em>Is this control design effective?</em></small>
+                                  </p>
+                                {{#is_allowed 'update' instance context='for'}}
+                                    <dropdown options-list="model.conclusions"
+                                              no-value="true"
+                                              no-value-label="---"
+                                              name="instance.design">
+                                    </dropdown>
+                                {{else}}
+                                  {{firstnonempty design '--'}}
+                                {{/is_allowed}}
+                              </div>
+                              <div class="flex-size-1 flex-gutter-2">
+                                  <label class="title-text">Conclusion: Operation</label>
+                                  <p>
+                                      <small><em>Is this control operationally effective?</em></small>
+                                  </p>
+                                {{#is_allowed 'update' instance context='for'}}
+                                    <dropdown options-list="model.conclusions"
+                                              no-value="true"
+                                              no-value-label="---"
+                                              name="instance.operationally">
+                                    </dropdown>
+                                {{else}}
+                                  {{firstnonempty operationally '--'}}
+                                {{/is_allowed}}
+                              </div>
+                          </div>
+                      </collapsible-panel>
+                    </tab-panel>
                     <tab-panel panels="panels" title-text="Comments" instance="instance">
                       {{^if_in instance.status 'Completed,Final'}}
                         {{#is_allowed 'update' instance context='for'}}

--- a/src/ggrc/assets/stylesheets/modules/_assessment.scss
+++ b/src/ggrc/assets/stylesheets/modules/_assessment.scss
@@ -55,7 +55,7 @@
     }
 
     .attach-file-info {
-      margin: -10px 0 10px;
+      margin: -10px 0 16px;
       font-size: 0.9em;
       font-style: italic;
     }


### PR DESCRIPTION
Move attach evidence and url up in a gray box (CA will follow below it).
The whole Details section – whole section GO to inside comments tab, name Attributes