### PR TITLE
GGRC-919 Fix model inflector registration

### DIFF
--- a/src/ggrc/models/__init__.py
+++ b/src/ggrc/models/__init__.py
@@ -6,6 +6,7 @@ import sqlalchemy as sa
 
 from ggrc import db
 from ggrc import settings
+from ggrc.models import inflector
 from ggrc.models.reflection import SanitizeHtmlInfo
 from ggrc.models.all_models import *  # noqa
 from ggrc.utils import html_cleaner
@@ -78,7 +79,8 @@ def drop_db(use_migrations=False, quiet=False):
 
 def init_models(app):
   from ggrc.models.all_models import all_models  # noqa
-  [model._inflector for model in all_models]
+  for model in all_models:
+    inflector.register_inflections(model._inflector)
 
 
 def init_hooks():

--- a/src/ggrc/models/all_models.py
+++ b/src/ggrc/models/all_models.py
@@ -126,6 +126,7 @@ def register_model(model):
   """
   current_module = sys.modules[__name__]
   setattr(current_module, model.__name__, model)
+  model._inflector
   all_models.append(model)
   __all__.append(model.__name__)
 

--- a/src/ggrc/models/all_models.py
+++ b/src/ggrc/models/all_models.py
@@ -126,7 +126,7 @@ def register_model(model):
   """
   current_module = sys.modules[__name__]
   setattr(current_module, model.__name__, model)
-  model._inflector
+  inflector.register_inflections(model._inflector)
   all_models.append(model)
   __all__.append(model.__name__)
 

--- a/src/ggrc/models/inflector.py
+++ b/src/ggrc/models/inflector.py
@@ -8,13 +8,17 @@
 
 from ggrc import utils
 
+
 def with_model_override(func):
   model_property_name = "_{0}".format(func.__name__)
+
   def wrapped(self):
     return getattr(self.model, model_property_name, func(self))
   return wrapped
 
+
 class ModelInflector(object):
+  """Several forms of human-readable model name."""
   def __new__(cls, model):
     try:
       return _inflectors[model]
@@ -28,15 +32,15 @@ class ModelInflector(object):
 
   def all_inflections(self):
     return {
-      'model_singular': self.model_singular,
-      'model_plural': self.model_plural,
-      'table_singular': self.table_singular,
-      'table_plural': self.table_plural,
-      'human_singular': self.human_singular,
-      'human_plural': self.human_plural,
-      'title_singular': self.title_singular,
-      'title_plural': self.title_plural,
-      }
+        'model_singular': self.model_singular,
+        'model_plural': self.model_plural,
+        'table_singular': self.table_singular,
+        'table_plural': self.table_plural,
+        'human_singular': self.human_singular,
+        'human_plural': self.human_plural,
+        'title_singular': self.title_singular,
+        'title_plural': self.title_plural,
+    }
 
   @property
   def table_name(self):
@@ -77,14 +81,16 @@ class ModelInflector(object):
 
   def __repr__(self):
     return (
-      'ModelInflector({model}):\n'
-      '  model: {model_singular} {model_plural}\n'
-      '  table: {table_singular} {table_plural}\n'
-      '  human: {human_singular} {human_plural}\n'
-      '  title: {title_singular} {title_plural}\n')\
-      .format(model=self.model, **self.all_inflections())
+        'ModelInflector({model}):\n'
+        '  model: {model_singular} {model_plural}\n'
+        '  table: {table_singular} {table_plural}\n'
+        '  human: {human_singular} {human_plural}\n'
+        '  title: {title_singular} {title_plural}\n'
+        .format(model=self.model, **self.all_inflections()))
+
 
 class ModelInflectorDescriptor(object):
+  """Caching descriptor to hold model inflector."""
   cache_attribute = '_cached_inflector'
 
   def __get__(self, obj, cls):
@@ -101,20 +107,23 @@ _inflectors = {}
 # { <inflection>: <model class> }
 _inflection_to_model = {}
 
+
 def register_inflections(inflector):
-  for mode, value in inflector.all_inflections().items():
-    if value in _inflection_to_model \
-        and _inflection_to_model[value] is not inflector.model:
+  """Register model inflector."""
+  for value in inflector.all_inflections().itervalues():
+    if (value in _inflection_to_model and
+            _inflection_to_model[value] is not inflector.model):
       print("Overriding inflection:\n"
             "    {0} => {1}\n"
             "  with\n"
             "    {2} => {3}".format(
-              value, _inflection_to_model[value],
-              value, inflector.model))
+                value, _inflection_to_model[value],
+                value, inflector.model))
     _inflection_to_model[value] = inflector.model
 
 
 def unregister_inflector(inflector):
+  """Unregister model inflector."""
   for mode, value in inflector.all_inflections().items():
     if value in _inflection_to_model:
       del _inflection_to_model[value]
@@ -122,5 +131,5 @@ def unregister_inflector(inflector):
     del _inflectors[inflector.model]
 
 
-def get_model(s):
-  return _inflection_to_model.get(s, None)
+def get_model(inflection):
+  return _inflection_to_model.get(inflection, None)

--- a/src/ggrc/models/inflector.py
+++ b/src/ggrc/models/inflector.py
@@ -25,7 +25,6 @@ class ModelInflector(object):
 
   def __init__(self, model):
     self.model = model
-    register_inflections(self)
 
   def all_inflections(self):
     return {

--- a/src/ggrc_basic_permissions/models.py
+++ b/src/ggrc_basic_permissions/models.py
@@ -205,14 +205,9 @@ class ContextImplication(Base, db.Model):
     )
 
 
-all_models.Role = Role
-all_models.UserRole = UserRole
-all_models.ContextImplication = ContextImplication
-all_models.Role._inflector
-all_models.UserRole._inflector
-all_models.ContextImplication._inflector
-all_models.all_models.extend([Role, UserRole, ContextImplication])
-all_models.__all__.extend(["Role", "UserRole", "ContextImplication"])
+all_models.register_model(Role)
+all_models.register_model(UserRole)
+all_models.register_model(ContextImplication)
 
 
 def get_ids_related_to_user_role(object_type, related_type, related_ids):


### PR DESCRIPTION
This PR reverts a commit that introduced a regression with model_name -> model data not available for some models for some requests.

Steps to reproduce:
1. Open the dashboard.

Expected result: no HTTP500 received.
Actual result: HTTP500 received.

This is a good example of why side effects and lazy computation blow up sometimes when mixed.

Description of GGRC-919:
Steps to reproduce:
1. Create a program
2. Add tab (e.g. Controls)
3. Click Search in Unified Mapper: confirm 500 error is displayed in console
Actual Result: 500 error is displayed in console while searching an object in Unified mapper
Expected Result: no error displayed. Objects are displayed in Search list if exist