### PR TITLE
GGRC-909 Move comments to the right side in assessments

### DIFF
--- a/src/ggrc/assets/mustache/assessments/info.mustache
+++ b/src/ggrc/assets/mustache/assessments/info.mustache
@@ -44,6 +44,15 @@
                             scope-object="parentInstance">
                     </assessment-mapped-related-information>
                 </div>
+                <div class="assessment-comments flex-size-1">
+                    <div class="section-title">Response Comments</div>
+                    {{^if_in instance.status 'Completed,Final'}}
+                      {{#is_allowed 'update' instance context='for'}}
+                          <assessment-add-comment class="assessment-comments-add" instance="instance"></assessment-add-comment>
+                      {{/is_allowed}}
+                    {{/if_in}}
+                    {{> '/static/mustache/base_templates/comment_list.mustache' }}
+                </div>
             </div>
             <div class="tabs-wrap">
                 <tabs instance="instance">
@@ -112,14 +121,6 @@
                               </div>
                           </div>
                       </collapsible-panel>
-                    </tab-panel>
-                    <tab-panel panels="panels" title-text="Comments" instance="instance">
-                      {{^if_in instance.status 'Completed,Final'}}
-                        {{#is_allowed 'update' instance context='for'}}
-                            <assessment-add-comment class="width-70 flex-box flex-col" instance="instance"></assessment-add-comment>
-                        {{/is_allowed}}
-                      {{/if_in}}
-                      {{> '/static/mustache/base_templates/comment_list.mustache' }}
                     </tab-panel>
                     <tab-panel panels="panels" title-text="Assessment Log" instance="instance">
                         <revision-log instance="instance"></revision-log>

--- a/src/ggrc/assets/stylesheets/modules/_assessment.scss
+++ b/src/ggrc/assets/stylesheets/modules/_assessment.scss
@@ -7,6 +7,13 @@
   display: flex;
   align-items: stretch;
   flex-wrap: wrap;
+  position: relative;
+
+  .assessment-attributes {
+    margin-right: 30%;
+    padding-right: 12px;
+    padding-bottom: 28px;
+  }
 
   .section-title {
     font-size: 11px;
@@ -159,12 +166,32 @@
     }
   }
 
-  .assessment-summary {
-    margin: 0 0 28px 24px;
+  .assessment-comments {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    padding-left: 12px;
+    width: 30%;
+    display: flex;
+    flex-direction: column;
+    border-left: 1px solid $border-color;
+
+    .assessment-comments-add {
+      display: block;
+    }
+
+    mapping-tree-view {
+      overflow-y: auto;
+    }
 
     .side-content {
       margin: 0;
     }
+  }
+
+  .tabs-wrap {
+    margin-top: -28px;
   }
 }
 


### PR DESCRIPTION
Improvements to Assessment Page.
Place and Style Comment Stream to the right

Instead of Details section - we move section named "Response Comments" to the right panel

![image](https://cloud.githubusercontent.com/assets/567805/22555625/56013a86-e975-11e6-9a49-312d02f71227.png)
