### PR TITLE
GGRC-1022 Add last-assessment-date component to Control's treeview

### DIFF
--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -226,6 +226,7 @@ dashboard-js-files:
   - components/textarea-array/textarea-array.js
   - components/object-selection/object-selection.js
   - components/object-selection/object-selection-item.js
+  - components/last-assessment-date/last-assessment-date.js
   #- d3.v2.js
   #- related_graph.js
 

--- a/src/ggrc/assets/javascripts/components/last-assessment-date/last-assessment-date.js
+++ b/src/ggrc/assets/javascripts/components/last-assessment-date/last-assessment-date.js
@@ -1,0 +1,46 @@
+/*!
+ Copyright (C) 2017 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+(function (can, GGRC) {
+  'use strict';
+
+  var queryAPI = GGRC.Utils.QueryAPI;
+  var REQUESTED_TYPE = 'Assessment';
+  var FILTER_OPTIONS = Object.freeze({
+    current: 1,
+    pageSize: 1,
+    sortBy: 'finished_date',
+    sortDirection: 'desc'
+  });
+  var REQUIRED_FIELDS = Object.freeze(['finished_date']);
+
+  can.Component.extend({
+    tag: 'last-assessment-date',
+    template: '<content/>',
+    viewModel: {
+      controlId: null,
+      lastAssessmentDate: null
+    },
+    init: function () {
+      this.loadLastAssessment(this.viewModel.controlId);
+    },
+    loadLastAssessment: function (id) {
+      var viewModel = this.viewModel;
+      var params = queryAPI.buildParam(REQUESTED_TYPE, FILTER_OPTIONS, {
+        type: 'Control',
+        id: id
+      }, REQUIRED_FIELDS);
+
+      queryAPI.makeRequest({data: [params]}).then(function (response) {
+        var assessment = response[0][REQUESTED_TYPE].values[0];
+        var finishedDate;
+        if (assessment) {
+          finishedDate = assessment.finished_date;
+        }
+        viewModel.attr('lastAssessmentDate', finishedDate);
+      });
+    }
+  });
+})(window.can, window.GGRC);

--- a/src/ggrc/assets/javascripts/models/control.js
+++ b/src/ggrc/assets/javascripts/models/control.js
@@ -67,7 +67,8 @@
         {attr_title: 'Principal Assignee', attr_name: 'principal_assessor',
           attr_sort_field: 'principal_assessor.name|email'},
         {attr_title: 'Secondary Assignee', attr_name: 'secondary_assessor',
-          attr_sort_field: 'secondary_assessor.name|email'}
+          attr_sort_field: 'secondary_assessor.name|email'},
+        {attr_title: 'Last Assessment Date', attr_name: 'last_assessment_date'}
       ]),
       add_item_view: GGRC.mustache_path + '/snapshots/tree_add_item.mustache',
       draw_children: true,

--- a/src/ggrc/assets/mustache/controls/tree.mustache
+++ b/src/ggrc/assets/mustache/controls/tree.mustache
@@ -120,6 +120,11 @@
                                   {{/items}}
                                 {{/using}}
                               {{/case}}
+                              {{#case 'last_assessment_date'}}
+                                  <last-assessment-date control-id="instance.id">
+                                    {{localize_date lastAssessmentDate}}
+                                  </last-assessment-date>
+                              {{/case}}
 
                               {{#default}}
                                 {{#if_helpers '\


### PR DESCRIPTION
![5 set visible fields for control_05](https://cloud.githubusercontent.com/assets/4737102/22585002/9869b286-ea06-11e6-8840-1dbccf231455.png)
![controls_new column_most recent assessment date_06](https://cloud.githubusercontent.com/assets/4737102/22585003/986ba85c-ea06-11e6-8810-f64cf8ca6cb1.png)
