### PR TITLE
GGRC-908 Remove Controls expander icon in Assessment

### DIFF
--- a/src/ggrc/assets/mustache/components/assessment/mapped-objects/mapped-controls.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/mapped-objects/mapped-controls.mustache
@@ -2,7 +2,8 @@
     Copyright (C) 2017 Google Inc., authors, and contributors
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
-<collapsible-panel-header title-text="titleText" expanded="expanded">
+<div class="section-title">
+  {{titleText}}
   {{#is_allowed 'update' instance context='for'}}
       <i class="fa fa-plus-circle"
          rel="tooltip"
@@ -19,16 +20,14 @@
          data-snapshot-scope-type="{{scopeObject.type}}">
       </i>
   {{/is_allowed}}
-</collapsible-panel-header>
-<collapsible-panel-body expanded="expanded" class="collapsible-panel-body">
-    <mapped-objects selected-item="selectedItem" parent-instance="instance" filter="filter" mapped-snapshots="mappedSnapshots">
-       <business-object-list-item instance="instance">
-          <div class="description">
-            <read-more text="itemData.description" max-text-length="90"></read-more>
-          </div>
-       </business-object-list-item>
-    </mapped-objects>
-    <object-popover class="object-popover" item="selectedItem">
-        <assessment-mapped-controls-popover class="assessment-mapped-controls-popover" item="item" expanded="expanded"></assessment-mapped-controls-popover>
-    </object-popover>
-</collapsible-panel-body>
+</div>
+<mapped-objects selected-item="selectedItem" parent-instance="instance" filter="filter" mapped-snapshots="mappedSnapshots">
+   <business-object-list-item instance="instance">
+      <div class="description">
+        <read-more text="itemData.description" max-text-length="90"></read-more>
+      </div>
+   </business-object-list-item>
+</mapped-objects>
+<object-popover class="object-popover" item="selectedItem">
+    <assessment-mapped-controls-popover class="assessment-mapped-controls-popover" item="item" expanded="expanded"></assessment-mapped-controls-popover>
+</object-popover>

--- a/src/ggrc/assets/mustache/components/mapped-objects/mapped-objects.mustache
+++ b/src/ggrc/assets/mustache/components/mapped-objects/mapped-objects.mustache
@@ -2,9 +2,13 @@
     Copyright (C) 2017 Google Inc., authors, and contributors
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
-<object-list items="showItems" selected-item="selectedItem" is-loading="isLoading">
-    <content></content>
-</object-list>
-{{#if requireLimit}}
-  <button class="btn btn-small btn-link" can-click="toggleShowAll">{{showAllButtonText}}</button>
+{{#if mappedItems.length}}
+  <object-list items="showItems" selected-item="selectedItem" is-loading="isLoading">
+      <content></content>
+  </object-list>
+  {{#if requireLimit}}
+    <button class="btn btn-small btn-link" can-click="toggleShowAll">{{showAllButtonText}}</button>
+  {{/if}}
+{{else}}
+  <span class="empty-message">None</span>
 {{/if}}

--- a/src/ggrc/assets/stylesheets/modules/_assessment.scss
+++ b/src/ggrc/assets/stylesheets/modules/_assessment.scss
@@ -21,6 +21,20 @@
     font-weight: bold;
     line-height: 24px;
     margin: 0 0 4px;
+
+    .fa {
+      color: $icon-color-dark;
+      width: 32px;
+      height: 24px;
+      line-height: 24px;
+      text-align: center;
+      cursor: pointer;
+      margin-left: 8px;
+
+      &:hover {
+        color: $icon-color-hover;
+      }
+    }
   }
 
   .assessment-description {


### PR DESCRIPTION
Hide Controls expander icon and add "None" text in case no mapped controls

![image](https://cloud.githubusercontent.com/assets/567805/22595947/90b5ec1a-ea3a-11e6-8bbd-f0f67f09ae49.png)
