### PR TITLE
GGRC-946, GGRC-1086 Add status field to full text search properties

### DIFF
--- a/src/ggrc/models/mixins/__init__.py
+++ b/src/ggrc/models/mixins/__init__.py
@@ -284,6 +284,7 @@ class Stateful(object):
         db.String, default=cls.default_status, nullable=False), cls.__name__)
 
   _publish_attrs = ['status']
+  _fulltext_attrs = ['status']
   _aliases = {
       "status": {
           "display_name": "State",


### PR DESCRIPTION
_I **think** this was discussed as a blocker so I'm adding `critical` - if I'm mistaken, somebody please remove it (but verify in Jira first)._

Add status field to full text search properties. In order to see the changes you will have to run `$.post("/admin/reindex");` from console to issue reindex command.