### PR TITLE
GGRC-823 Assessment Info Pane is not refreshed properly

### DIFF
--- a/src/ggrc/assets/javascripts/components/mapped_tree_view.js
+++ b/src/ggrc/assets/javascripts/components/mapped_tree_view.js
@@ -76,7 +76,8 @@
         var binding;
 
         ev.stopPropagation();
-
+        // Refactor and show spinner instead (for all lists)
+        el.hide();
         binding = _.find(mappings, function (mapping) {
           return mapping.instance.id === instance.id &&
             mapping.instance.type === instance.type;


### PR DESCRIPTION
UI issue.

Steps to reproduce:
1) Create Assessment from Admin user.
2) Add new URL on Info Pane.
3) Delete URL on Info Pane.

Expected Result: list of URLs should be cleaned.
Actual Result: URL left in list. If try to delete it once again user will see JS error about 'mapping'.
Workaround: refresh the page, deleted URL disappear.

![image](https://cloud.githubusercontent.com/assets/674129/22643379/452db84a-ec6f-11e6-968a-e83f4465adfc.png)
