### PR TITLE
GGRC-1074 Enable Assessment comment notifications by default

### DIFF
--- a/src/ggrc/assets/javascripts/models/assessment.js
+++ b/src/ggrc/assets/javascripts/models/assessment.js
@@ -28,7 +28,9 @@
       verified_date: 'date'
     },
     defaults: {
-      status: 'Not Started'
+      status: 'Not Started',
+      send_by_default: true,  // notifications when a comment is added
+      recipients: 'Assessor,Creator,Verifier'  // user roles to be notified
     },
     statuses: ['Not Started', 'In Progress', 'Ready for Review',
         'Verified', 'Completed'],


### PR DESCRIPTION
~~_(not sure whether the related Jira issue has been created yet)_~~

Comment notifications for Assessments should be enabled by default, which is governed by the relevant setting on the Assessment object. This PR makes sure that this setting is enabled by default when creating a new Assessment.

---

**Steps to reproduce:**
  1. Go to Audit's summary tab
  1. Click the "create assessment" button (a modal opens - look at the _"Enable notifications on comments"_ checkbox group)
  1. Fill in the required fields and click Save
  1. On the created Assessment's info pane look at the RESPONSE COMMENTS column on the right.
  

**Expected result:**
- The "send notifications" checkbox under the comment rich text field is checked by default.
- The aforementioned checkboxes on the modal form are all checked by default

**Actual result:**
- The "send notifications" checkbox under the comment rich text field is _not_ checked by default.
- The aforementioned checkboxes on the modal form are _not_ checked by default