### PR TITLE
GGRC-1048 Additional UX styling in Assessment page

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment/attachments-list.js
+++ b/src/ggrc/assets/javascripts/components/assessment/attachments-list.js
@@ -16,10 +16,12 @@
   GGRC.Components('assessmentAttachmentsList', {
     tag: tag,
     template: template,
-    scope: {},
+    scope: {
+      title: '@',
+      tooltip: '@'
+    },
     events: {
       init: function () {}
     }
   });
 })(window.GGRC, window.can);
-

--- a/src/ggrc/assets/javascripts/components/ca-object/ca-object.js
+++ b/src/ggrc/assets/javascripts/components/ca-object/ca-object.js
@@ -6,9 +6,58 @@
 (function (can) {
   'use strict';
 
+  var icons = {
+    noValidation: 'fa-check-circle',
+    empty: 'fa-times-circle validation-icon-empty',
+    valid: 'fa-check-circle validation-icon-valid',
+    invalid: 'fa-times-circle validation-icon-invalid'
+  };
+
+  var titles = {
+    noValidation: ' ',
+    empty: 'validation-title-empty',
+    valid: 'validation-title-valid',
+    invalid: 'validation-title-invalid'
+  };
+
   can.Component.extend({
     tag: 'ca-object',
     viewModel: {
+      define: {
+        validation: {},
+        iconCls: {
+          value: icons.noValidation,
+          get: function () {
+            var icon = icons.noValidation;
+
+            if (this.attr('validation.mandatory')) {
+              icon = this.attr('validation.empty') ? icons.empty : icons.valid;
+            }
+            /* This validation is required for DropDowns with required attachments */
+            if (!this.attr('validation.valid')) {
+              icon = icons.invalid;
+            }
+            return icon;
+          }
+        },
+        titleCls: {
+          value: titles.noValidation,
+          get: function () {
+            var icon = titles.noValidation;
+
+            if (this.attr('validation.mandatory')) {
+              icon = this.attr('validation.empty') ?
+                                      titles.empty :
+                                      titles.valid;
+            }
+            /* This validation is required for DropDowns with required attachments */
+            if (!this.attr('validation.valid')) {
+              icon = titles.invalid;
+            }
+            return icon;
+          }
+        }
+      },
       valueId: null,
       value: null,
       type: null,

--- a/src/ggrc/assets/javascripts/components/mapped_tree_view.js
+++ b/src/ggrc/assets/javascripts/components/mapped_tree_view.js
@@ -14,6 +14,7 @@
       treeViewClass: '@',
       expandable: '@',
       sortField: '@',
+      emptyText: '@',
       parentInstance: null,
       mappedObjects: [],
       isExpandable: function () {

--- a/src/ggrc/assets/mustache/assessments/info.mustache
+++ b/src/ggrc/assets/mustache/assessments/info.mustache
@@ -58,71 +58,76 @@
             </div>
             <div class="tabs-wrap">
                 <tabs instance="instance">
-                    <tab-panel panels="panels" title-text="Attributes" instance="instance">
-                      <collapsible-panel title-text="Description" collapsed="true" title-icon="fa-list-ol"
-                                         class="details-item">
-                          <read-more text="description"></read-more>
-                      </collapsible-panel>
-                      <collapsible-panel title-text="People" collapsed="true" title-icon="fa-users" class="details-item">
-                          <people-list instance="instance" editable="true" disable-title="true"></people-list>
-                      </collapsible-panel>
-                      <collapsible-panel title-text="Dates" collapsed="true" title-icon="fa-calendar"
-                                         class="details-item">
-                        {{> '/static/mustache/assessments/dates_list.mustache'}}
-                      </collapsible-panel>
-                      <collapsible-panel title-text="Notes" collapsed="true" title-icon="fa-sticky-note-o"
-                                         class="details-item">
-                          <read-more text="notes"></read-more>
-                      </collapsible-panel>
-                      <collapsible-panel title-text="URL" collapsed="true" title-icon="fa-link" class="details-item">
-                        {{> '/static/mustache/assessments/urls.mustache'}}
-                      </collapsible-panel>
-                      <collapsible-panel title-text="Code" collapsed="true" title-icon="fa-code" class="details-item">
-                          <ul class="label-list">
-                              <li>
-                                  <h6>Code</h6>
-                                  <span>{{instance.slug}}</span>
-                              </li>
-                          </ul>
-                      </collapsible-panel>
-                      <collapsible-panel title-text="Conclusions" collapsed="true" title-icon="fa-gavel"
-                                         class="details-item">
-                          <div class="flex-box flex-col"
-                            {{#instance}}{{data 'model'}}{{/instance}}
-                               data-force-refresh="true"
-                               data-model="true" {{ (el) -> el.ggrc_controllers_quick_form({ instance : el.data('model')}); }}>
-                              <div class="flex-size-1 flex-gutter-2">
-                                  <label class="title-text">Conclusion: Design</label>
-                                  <p>
-                                      <small><em>Is this control design effective?</em></small>
-                                  </p>
-                                {{#is_allowed 'update' instance context='for'}}
-                                    <dropdown options-list="model.conclusions"
-                                              no-value="true"
-                                              no-value-label="---"
-                                              name="instance.design">
-                                    </dropdown>
-                                {{else}}
-                                  {{firstnonempty design '--'}}
-                                {{/is_allowed}}
+                    <tab-panel panels="panels" title-text="Assessment Attributes" instance="instance">
+                        <div class="atrribute-tab-panel-column">
+                            <collapsible-panel title-text="Description" collapsed="true" title-icon="fa-list-ol"
+                                               class="details-item">
+                                <read-more text="description"></read-more>
+                            </collapsible-panel>
+                            <collapsible-panel title-text="People" collapsed="true" title-icon="fa-users" class="details-item">
+                                <people-list instance="instance" editable="true" disable-title="true"></people-list>
+                            </collapsible-panel>
+                            <collapsible-panel title-text="Dates" collapsed="true" title-icon="fa-calendar"
+                                               class="details-item">
+                              {{> '/static/mustache/assessments/dates_list.mustache'}}
+                            </collapsible-panel>
+                            <collapsible-panel title-text="Notes" collapsed="true" title-icon="fa-sticky-note-o"
+                                               class="details-item">
+                                <read-more text="notes"></read-more>
+                            </collapsible-panel>
+                        </div>
+
+                        <div class="atrribute-tab-panel-column">
+                          <collapsible-panel title-text="URL" collapsed="true" title-icon="fa-link" class="details-item">
+                            {{> '/static/mustache/assessments/urls.mustache'}}
+                          </collapsible-panel>
+                          <collapsible-panel title-text="Code" collapsed="true" title-icon="fa-code" class="details-item">
+                              <ul class="label-list">
+                                  <li>
+                                      <h6>Code</h6>
+                                      <span>{{instance.slug}}</span>
+                                  </li>
+                              </ul>
+                          </collapsible-panel>
+                          <collapsible-panel title-text="Conclusions" collapsed="true" title-icon="fa-gavel"
+                                             class="details-item">
+                              <div class="flex-box flex-col"
+                                {{#instance}}{{data 'model'}}{{/instance}}
+                                   data-force-refresh="true"
+                                   data-model="true" {{ (el) -> el.ggrc_controllers_quick_form({ instance : el.data('model')}); }}>
+                                  <div class="flex-size-1 flex-gutter-2">
+                                      <label class="title-text">Conclusion: Design</label>
+                                      <p>
+                                          <small><em>Is this control design effective?</em></small>
+                                      </p>
+                                    {{#is_allowed 'update' instance context='for'}}
+                                        <dropdown options-list="model.conclusions"
+                                                  no-value="true"
+                                                  no-value-label="---"
+                                                  name="instance.design">
+                                        </dropdown>
+                                    {{else}}
+                                      {{firstnonempty design '--'}}
+                                    {{/is_allowed}}
+                                  </div>
+                                  <div class="flex-size-1 flex-gutter-2">
+                                      <label class="title-text">Conclusion: Operation</label>
+                                      <p>
+                                          <small><em>Is this control operationally effective?</em></small>
+                                      </p>
+                                    {{#is_allowed 'update' instance context='for'}}
+                                        <dropdown options-list="model.conclusions"
+                                                  no-value="true"
+                                                  no-value-label="---"
+                                                  name="instance.operationally">
+                                        </dropdown>
+                                    {{else}}
+                                      {{firstnonempty operationally '--'}}
+                                    {{/is_allowed}}
+                                  </div>
                               </div>
-                              <div class="flex-size-1 flex-gutter-2">
-                                  <label class="title-text">Conclusion: Operation</label>
-                                  <p>
-                                      <small><em>Is this control operationally effective?</em></small>
-                                  </p>
-                                {{#is_allowed 'update' instance context='for'}}
-                                    <dropdown options-list="model.conclusions"
-                                              no-value="true"
-                                              no-value-label="---"
-                                              name="instance.operationally">
-                                    </dropdown>
-                                {{else}}
-                                  {{firstnonempty operationally '--'}}
-                                {{/is_allowed}}
-                              </div>
-                          </div>
-                      </collapsible-panel>
+                          </collapsible-panel>
+                        </div>
                     </tab-panel>
                     <tab-panel panels="panels" title-text="Assessment Log" instance="instance">
                         <revision-log instance="instance"></revision-log>

--- a/src/ggrc/assets/mustache/assessments/info.mustache
+++ b/src/ggrc/assets/mustache/assessments/info.mustache
@@ -28,7 +28,10 @@
                             <i class="fa fa-question-circle" rel="tooltip" data-original-title="Respond to assessment here. Use comments on the right for free text responses."></i>
                         </div>
                         <div class="assessment-controls__extra-controls">
-                            <assessment-attachments-list class="attachment-list oneline"></assessment-attachments-list>
+                            <assessment-attachments-list class="assesment-attachment-list"
+                                                         title="Evidence"
+                                                         tooltip="You can upload up to 10 files in a single batch">
+                            </assessment-attachments-list>
                             <assessment-urls-list></assessment-urls-list>
                         </div>
                         <assessment-custom-attributes instance="instance"

--- a/src/ggrc/assets/mustache/assessments/info.mustache
+++ b/src/ggrc/assets/mustache/assessments/info.mustache
@@ -50,7 +50,7 @@
                     </assessment-mapped-related-information>
                 </div>
                 <div class="assessment-comments flex-size-1">
-                    <div class="section-title">Responses/ Comments</div>
+                    <div class="section-title">Responses/Comments</div>
                     {{^if_in instance.status 'Completed,Final'}}
                       {{#is_allowed 'update' instance context='for'}}
                           <assessment-add-comment class="assessment-comments-add" instance="instance"></assessment-add-comment>

--- a/src/ggrc/assets/mustache/assessments/info.mustache
+++ b/src/ggrc/assets/mustache/assessments/info.mustache
@@ -47,7 +47,7 @@
                     </assessment-mapped-related-information>
                 </div>
                 <div class="assessment-comments flex-size-1">
-                    <div class="section-title">Response Comments</div>
+                    <div class="section-title">Responses/ Comments</div>
                     {{^if_in instance.status 'Completed,Final'}}
                       {{#is_allowed 'update' instance context='for'}}
                           <assessment-add-comment class="assessment-comments-add" instance="instance"></assessment-add-comment>

--- a/src/ggrc/assets/mustache/base_templates/mapping_tree_view.mustache
+++ b/src/ggrc/assets/mustache/base_templates/mapping_tree_view.mustache
@@ -4,9 +4,15 @@
 }}
 
 <ul class="{{#if treeViewClass}}{{treeViewClass}}{{else}}attachment-list{{/if}}">
-  {{#mappedObjects}}
-    {{#using instance=instance}}
-      {{{render itemTemplate instance=instance baseInstance=baseInstance parentInstance=parentInstance reusable=reusable reusedObjects=reusedObjects reuseMethod=reuseMethod mapping=mapping isLoading=isLoading isExpandable=isExpandable}}}
-    {{/using}}
-  {{/mappedObjects}}
+  {{#if mappedObjects.length}}
+    {{#mappedObjects}}
+      {{#using instance=instance}}
+        {{{render itemTemplate instance=instance baseInstance=baseInstance parentInstance=parentInstance reusable=reusable reusedObjects=reusedObjects reuseMethod=reuseMethod mapping=mapping isLoading=isLoading isExpandable=isExpandable}}}
+      {{/using}}
+    {{/mappedObjects}}
+  {{else}}
+    {{#if emptyText}}
+      <li class="empty-message">{{emptyText}}</li>
+    {{/if}}
+  {{/if}}
 </ul>

--- a/src/ggrc/assets/mustache/components/assessment/attachments-list.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/attachments-list.mustache
@@ -3,13 +3,11 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
 
-<h6>Evidence</h6>
-  {{#if_mapping_ready "audits" instance}}
-    {{#is_allowed 'update' instance context='for'}}
-      {{{render_hooks "Request.gdrive_evidence_storage"}}}
-      <div class="attach-file-info">(you can upload up to 10 files in a single batch)</div>
-    {{/is_allowed}}
-  {{/if_mapping_ready}}
+{{#if_mapping_ready "audits" instance}}
+  {{#is_allowed 'update' instance context='for'}}
+    {{{render_hooks "Request.gdrive_evidence_storage"}}}
+  {{/is_allowed}}
+{{/if_mapping_ready}}
 {{^if_null instance._mandatory_attachment_msg}}
   <div class="alert alert-info alert-dismissible" role="alert">
     {{instance._mandatory_attachment_msg}}
@@ -20,5 +18,6 @@
   parent-instance="instance"
   mapping="instance.class.info_pane_options.evidence.mapping"
   item-template="instance.class.info_pane_options.evidence.show_view"
+  empty-text="None"
 >
 </mapping-tree-view>

--- a/src/ggrc/assets/mustache/components/assessment/custom-attributes.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/custom-attributes.mustache
@@ -4,11 +4,11 @@
 }}
 {{#items}}
     <ca-object class="flex-box flex-row" value-id="id" def="def" value="attribute_value"
-               modal="modal" type="attributeType">
-        <ca-object-validation-icon validation="validation"></ca-object-validation-icon>
+               modal="modal" type="attributeType" validation="validation">
+        <i class="fa validation-icon {{iconCls}}"></i>
         <div class="flex-box flex-col">
             <h6 class="inline-edit__title">
-          <span class="inline-edit__title-body">
+          <span class="inline-edit__title-body {{titleCls}}">
             {{def.title}}
             {{#if def.helptext}}
                 <i class="fa fa-question-circle" rel="tooltip" title="{{def.helptext}}"></i>

--- a/src/ggrc/assets/stylesheets/_colors.scss
+++ b/src/ggrc/assets/stylesheets/_colors.scss
@@ -114,6 +114,7 @@ $messageGreen: #bbffb6;
 $messageRed: #ffdddd;
 $messageYellow: #ffffcc;
 $messagePurple: #ddddff;
+$btnPriority: #4B898B;
 
 // compliance
 $defaultWidget: #444;

--- a/src/ggrc/assets/stylesheets/components/ca-object/_ca-object.scss
+++ b/src/ggrc/assets/stylesheets/components/ca-object/_ca-object.scss
@@ -10,6 +10,33 @@
     box-sizing: border-box;
   }
 
+  .validation-title-empty {
+    color: $icon-color-empty;
+  }
+
+  .validation-title-invalid {
+    color: $icon-color-invalid;
+  }
+
+  .validation-icon {
+    text-align: center;
+    color: transparent;
+    width: 24px;
+    height: 24px;
+    line-height: 24px;
+    display: block;
+
+    &.validation-icon-empty {
+      color: $icon-color-empty;
+    }
+    &.validation-icon-invalid {
+      color: $icon-color-invalid;
+    }
+    &.validation-icon-valid {
+      color: $icon-color-valid;
+    }
+  }
+
   ca-object-validation-icon {
     display: flex;
     width: 24px;

--- a/src/ggrc/assets/stylesheets/modules/_assessment.scss
+++ b/src/ggrc/assets/stylesheets/modules/_assessment.scss
@@ -13,6 +13,18 @@
     margin-right: 30%;
     padding-right: 12px;
     padding-bottom: 28px;
+
+    assessment-mapped-controls,
+    collapsible-panel-header {
+      .fa-plus-circle {
+        opacity: 1;
+        color: $btnGreen;
+
+        &:hover {
+          color: $icon-color-hover;
+        }
+      }
+    }
   }
 
   .section-title {
@@ -71,7 +83,13 @@
 
     .attachments-list-alert {
       float: left;
-      margin: 6px 0 0 -20px;
+      margin: 6px 0 0 -24px;
+
+      & + .attachments-list-control {
+        .attachments-list-title {
+          color: #ce3e3e;
+        }
+      }
     }
 
     .assesment-attachment-list {
@@ -88,6 +106,10 @@
           .fa {
             opacity: 1;
             color: $btnGreen;
+
+            &:hover {
+              color: $icon-color-hover;
+            }
           }
         }
       }
@@ -172,15 +194,17 @@
         }
       }
       .assessment-controls-toolbar {
-        margin: 8px 6px 0;
+        margin: 8px 6px 0 28px;
         display: flex;
-        justify-content: flex-end;
+        justify-content: flex-start;
 
         .btn-extra-gray {
-          background: rgba(0, 0, 0, 0.15);
+          background: $btnPriority;
+          color: $white;
+          font-weight: normal;
 
           &:hover {
-            background: rgba(0, 0, 0, 0.175);
+            background: lighten($btnPriority, 10%);
           }
         }
 
@@ -209,12 +233,24 @@
     flex-direction: column;
     border-left: 1px solid $border-color;
 
+    &:after {
+      content: '';
+      width: 100%;
+      bottom: 0;
+      left: 0;
+      height: 50px;
+      display: block;
+      position: absolute;
+      background: linear-gradient(to bottom, transparent, white 70%);
+    }
+
     .assessment-comments-add {
       display: block;
     }
 
     mapping-tree-view {
       overflow-y: auto;
+      padding-bottom: 45px;
     }
 
     .side-content {
@@ -260,7 +296,7 @@
   left: 57px;
 
   .fa {
-    color: $icon-color-dark;
+    color: $btnGreen;
 
     &:hover {
       color: $icon-color-hover;

--- a/src/ggrc/assets/stylesheets/modules/_assessment.scss
+++ b/src/ggrc/assets/stylesheets/modules/_assessment.scss
@@ -69,6 +69,30 @@
       max-width: 50%;
     }
 
+    .attachments-list-alert {
+      float: left;
+      margin: 6px 0 0 -20px;
+    }
+
+    .assesment-attachment-list {
+      display: block;
+      margin-bottom: 10px;
+    }
+
+    .attachments-list-control {
+      .attachments-list-action {
+        .btn {
+          background: none;
+          padding: 0 0 0 8px;
+
+          .fa {
+            opacity: 1;
+            color: $btnGreen;
+          }
+        }
+      }
+    }
+
     .attach-file-info {
       margin: -10px 0 16px;
       font-size: 0.9em;

--- a/src/ggrc/assets/stylesheets/modules/_assessment.scss
+++ b/src/ggrc/assets/stylesheets/modules/_assessment.scss
@@ -201,6 +201,21 @@
   .tabs-wrap {
     margin-top: -28px;
     position: relative;
+
+    .atrribute-tab-panel-column {
+      display: inline-block;
+      width: 32%;
+      vertical-align: top;
+    }
+
+    collapsible-panel.details-item {
+
+      .collapsible-panel-body {
+        .body-inner {
+          border-bottom: 0;
+        }
+      }
+    }
   }
 }
 

--- a/src/ggrc_gdrive_integration/assets/mustache/requests/gdrive_evidence_storage.mustache
+++ b/src/ggrc_gdrive_integration/assets/mustache/requests/gdrive_evidence_storage.mustache
@@ -4,51 +4,59 @@
 }}
 
 {{#with_mapping 'extended_folders' instance}}
-  <div class="oneline">
-    {{#if_in instance.status "Completed,Verified"}}
-      {{#if extended_folders.length}}
-        <ggrc-gdrive-picker-launcher
-          instance="instance"
-          link_text="Attach evidence"
-          click_event="trigger_upload_parent"
-          verify_event="true"
-          modal_description='You are about to move request from "{{instance.status}}" to "In Progress" - are you sure about that?'
-          modal_title='Confirm moving Request to "In Progress"'
-          modal_button='Confirm'
-          >
-        </ggrc-gdrive-picker-launcher>
+  {{^if extended_folders.length}}
+    <i class="fa fa-exclamation-triangle red attachments-list-alert" rel="tooltip" data-placement="bottom" data-original-title="Audit folder not set. Files will be uploaded to your GDrive root folder."></i>
+  {{/if}}
+  <h6 class="attachments-list-control">
+    <span class="attachments-list-title">
+      {{title}}
+    </span>
+    <span class="attachments-list-action" rel="tooltip" data-original-title="{{tooltip}}">
+      {{#if_in instance.status "Completed,Verified"}}
+        {{#if extended_folders.length}}
+          <ggrc-gdrive-picker-launcher
+            instance="instance"
+            icon="plus-circle"
+            link_text=" "
+            click_event="trigger_upload_parent"
+            verify_event="true"
+            modal_description='You are about to move request from "{{instance.status}}" to "In Progress" - are you sure about that?'
+            modal_title='Confirm moving Request to "In Progress"'
+            modal_button='Confirm'
+            >
+          </ggrc-gdrive-picker-launcher>
+        {{else}}
+          <ggrc-gdrive-picker-launcher
+            instance="instance"
+            icon="plus-circle"
+            link_text=" "
+            click_event="trigger_upload"
+            verify_event="true"
+            modal_description='You are about to move request from "{{instance.status}}" to "In Progress" - are you sure about that?'
+            modal_title='Confirm moving Request to "In Progress"'
+            modal_button='Confirm'
+            >
+          </ggrc-gdrive-picker-launcher>
+        {{/if}}
       {{else}}
-        <ggrc-gdrive-picker-launcher
-          instance="instance"
-          link_text="Attach evidence"
-          click_event="trigger_upload"
-          verify_event="true"
-          modal_description='You are about to move request from "{{instance.status}}" to "In Progress" - are you sure about that?'
-          modal_title='Confirm moving Request to "In Progress"'
-          modal_button='Confirm'
-          >
-        </ggrc-gdrive-picker-launcher>
-        <i class="fa fa-exclamation-triangle red" style="margin-top:4px" rel="tooltip" data-placement="bottom" data-original-title="Audit folder not set. Files will be uploaded to your GDrive root folder."></i>
-      {{/if}}
-    {{else}}
-      {{#if extended_folders.length}}
-        <ggrc-gdrive-picker-launcher
-          icon="paperclip"
-          instance="instance"
-          link_text="Attach evidence"
-          click_event="trigger_upload_parent">
-        </ggrc-gdrive-picker-launcher>
-      {{else}}
-        <ggrc-gdrive-picker-launcher
-          icon="paperclip"
-          instance="instance"
-          link_text="Attach evidence"
-          click_event="trigger_upload">
-        </ggrc-gdrive-picker-launcher>
-        <i class="fa fa-exclamation-triangle red" style="margin-top:4px" rel="tooltip" data-placement="bottom" data-original-title="Audit folder not set. Files will be uploaded to your GDrive root folder."></i>
-      {{/if}}
-    {{/if_in}}
-  </div>
+        {{#if extended_folders.length}}
+          <ggrc-gdrive-picker-launcher
+            icon="plus-circle"
+            instance="instance"
+            link_text=" "
+            click_event="trigger_upload_parent">
+          </ggrc-gdrive-picker-launcher>
+        {{else}}
+          <ggrc-gdrive-picker-launcher
+            icon="plus-circle"
+            instance="instance"
+            link_text=" "
+            click_event="trigger_upload">
+          </ggrc-gdrive-picker-launcher>
+        {{/if}}
+      {{/if_in}}
+    </span>
+  </h6>
 {{else}}
   {{! This is a failure state for with_mapping, if something in the mapping doesn't refresh properly }}
   {{#if error.errors}}


### PR DESCRIPTION
Style assessment page component according to mockup
- Attributes tab styling (two columns)
- buttons styling 
       ("Prior Audit Responses" button must be actually the color `#4B898B` instead of color on the mockup)
- Evidence styling
- Responses/ Comments (change title from response comments)
- Assessment Attributes (change title from attributes)
- Comments bottom fadeout (not like on the screenshot)

![image](https://cloud.githubusercontent.com/assets/567805/22691281/c2af96f4-ed4a-11e6-8df9-782d4621478a.png)
