### PR TITLE
GGRC-963 Show Advanced to be removed from all panes, Show all the fields & attributes without the expand/collapse

### DIFF
--- a/src/ggrc/assets/mustache/base_objects/info.mustache
+++ b/src/ggrc/assets/mustache/base_objects/info.mustache
@@ -23,7 +23,7 @@
         <div class="row-fluid">
           <div class="span12">
             <div class="info-expand">
-              <a class="show-hidden-fields info-show-hide" href="javascript://">
+              <a class="show-hidden-fields info-show-hide active" href="javascript://">
                 <span class="out">
                   <i class="fa fa-caret-right"></i>
                   Show
@@ -37,7 +37,7 @@
             </div>
           </div>
         </div><!-- row-fluid end -->
-        <div class="hidden-fields-area" style="display:none;">
+        <div class="hidden-fields-area">
           <div class="row-fluid wrap-row">
             <div class="span4">
               <h6>Code</h6>

--- a/src/ggrc/assets/mustache/controls/info.mustache
+++ b/src/ggrc/assets/mustache/controls/info.mustache
@@ -24,7 +24,7 @@
         <div class="row-fluid">
           <div class="span12">
             <div class="info-expand">
-              <a class="show-hidden-fields info-show-hide" href="javascript://">
+              <a class="show-hidden-fields info-show-hide active" href="javascript://">
                 <span class="out">
                   <i class="fa fa-caret-right"></i>
                   Show
@@ -38,7 +38,7 @@
             </div>
           </div>
         </div>
-        <div class="hidden-fields-area" style="display:none;">
+        <div class="hidden-fields-area">
           <div class="row-fluid wrap-row">
             <div class="span3">
               <h6>Code</h6>

--- a/src/ggrc/assets/mustache/issues/info.mustache
+++ b/src/ggrc/assets/mustache/issues/info.mustache
@@ -24,7 +24,7 @@
         <div class="row-fluid">
           <div class="span12">
             <div class="info-expand">
-              <a class="show-hidden-fields info-show-hide" href="javascript://">
+              <a class="show-hidden-fields info-show-hide active" href="javascript://">
                 <span class="out">
                   <i class="fa fa-caret-right"></i>
                   Show
@@ -38,7 +38,7 @@
             </div>
           </div>
         </div><!-- row-fluid end -->
-        <div class="hidden-fields-area" style="display:none;">
+        <div class="hidden-fields-area">
           <div class="row-fluid wrap-row">
             <div class="span4">
               <h6>Code</h6>

--- a/src/ggrc/assets/mustache/policies/info.mustache
+++ b/src/ggrc/assets/mustache/policies/info.mustache
@@ -23,7 +23,7 @@
         <div class="row-fluid">
           <div class="span12">
             <div class="info-expand">
-              <a class="show-hidden-fields info-show-hide" href="javascript://">
+              <a class="show-hidden-fields info-show-hide active" href="javascript://">
                 <span class="out">
                   <i class="fa fa-caret-right"></i>
                   Show
@@ -37,7 +37,7 @@
             </div>
           </div>
         </div><!-- row-fluid end -->
-        <div class="hidden-fields-area" style="display:none;">
+        <div class="hidden-fields-area">
           <div class="row-fluid wrap-row">
             <div class="span3">
               <h6>Code</h6>

--- a/src/ggrc/assets/mustache/processes/info.mustache
+++ b/src/ggrc/assets/mustache/processes/info.mustache
@@ -23,7 +23,7 @@
         <div class="row-fluid">
           <div class="span12">
             <div class="info-expand">
-              <a class="show-hidden-fields info-show-hide" href="javascript://">
+              <a class="show-hidden-fields info-show-hide active" href="javascript://">
                 <span class="out">
                   <i class="fa fa-caret-right"></i>
                   Show
@@ -37,7 +37,7 @@
             </div>
           </div>
         </div>
-        <div class="hidden-fields-area" style="display:none;">
+        <div class="hidden-fields-area">
           <div class="row-fluid wrap-row">
             <div class="span3">
               <h6>Code</h6>

--- a/src/ggrc/assets/mustache/products/info.mustache
+++ b/src/ggrc/assets/mustache/products/info.mustache
@@ -23,7 +23,7 @@
         <div class="row-fluid">
           <div class="span12">
             <div class="info-expand">
-              <a class="show-hidden-fields info-show-hide" href="javascript://">
+              <a class="show-hidden-fields info-show-hide active" href="javascript://">
                 <span class="out">
                   <i class="fa fa-caret-right"></i>
                   Show
@@ -37,7 +37,7 @@
             </div>
           </div>
         </div>
-        <div class="hidden-fields-area" style="display:none;">
+        <div class="hidden-fields-area">
           <div class="row-fluid wrap-row">
             <div class="span3">
               <h6>Code</h6>

--- a/src/ggrc/assets/mustache/programs/info.mustache
+++ b/src/ggrc/assets/mustache/programs/info.mustache
@@ -24,7 +24,7 @@
           <div class="span12">
             <div class="info-expand">
               <a data-test-id="button_advanced_cf47bc01"
-                 class="show-hidden-fields info-show-hide" href="javascript://">
+                 class="show-hidden-fields info-show-hide active" href="javascript://">
                 <span class="out">
                   <i class="fa fa-caret-right"></i>
                   Show
@@ -38,7 +38,7 @@
             </div>
           </div>
         </div><!-- row-fluid end -->
-        <div class="hidden-fields-area" style="display:none;">
+        <div class="hidden-fields-area">
           <div class="row-fluid wrap-row">
             <div data-test-id="title_code_cf47bc01" class="span4">
               <h6>Code</h6>

--- a/src/ggrc/assets/mustache/systems/info.mustache
+++ b/src/ggrc/assets/mustache/systems/info.mustache
@@ -23,7 +23,7 @@
         <div class="row-fluid">
           <div class="span12">
             <div class="info-expand">
-              <a class="show-hidden-fields info-show-hide" href="javascript://">
+              <a class="show-hidden-fields info-show-hide active" href="javascript://">
                 <span class="out">
                   <i class="fa fa-caret-right"></i>
                   Show
@@ -37,7 +37,7 @@
             </div>
           </div>
         </div>
-        <div class="hidden-fields-area" style="display:none;">
+        <div class="hidden-fields-area">
           <div class="row-fluid wrap-row">
             <div class="span3">
               <h6>Code</h6>

--- a/src/ggrc_risk_assessments/assets/mustache/risk_assessments/info.mustache
+++ b/src/ggrc_risk_assessments/assets/mustache/risk_assessments/info.mustache
@@ -56,7 +56,7 @@
       <div class="row-fluid">
         <div class="span12">
           <div class="info-expand">
-            <a class="show-hidden-fields info-show-hide" href="javascript://">
+            <a class="show-hidden-fields info-show-hide active" href="javascript://">
               <span class="out">
                 <i class="fa fa-caret-right"></i>
                 Show
@@ -70,7 +70,7 @@
           </div>
         </div>
       </div><!-- row-fluid end -->
-      <div class="hidden-fields-area" style="display:none;">
+      <div class="hidden-fields-area">
         <div class="row-fluid wrap-row">
           <div class="span4">
             <h6>Code</h6>

--- a/src/ggrc_risks/assets/mustache/risks/info.mustache
+++ b/src/ggrc_risks/assets/mustache/risks/info.mustache
@@ -22,7 +22,7 @@
         <div class="row-fluid">
           <div class="span12">
             <div class="info-expand">
-              <a class="show-hidden-fields info-show-hide" href="javascript://">
+              <a class="show-hidden-fields info-show-hide active" href="javascript://">
                 <span class="out">
                   <i class="fa fa-caret-right"></i>
                   Show
@@ -36,7 +36,7 @@
             </div>
           </div>
         </div><!-- row-fluid end -->
-        <div class="hidden-fields-area" style="display:none;">
+        <div class="hidden-fields-area">
           <div class="row-fluid wrap-row">
             <div class="span4">
               <h6>Code</h6>


### PR DESCRIPTION
## Precondition:

1. Open audit;
2. Open Controls widget;
3. Open any item in TreeView;
4. You can see "Show advanced" collapse.

The content of this collapse should be displayed without the expand/collapse.

## **Note:**

The second commit contains a redesign of number of columns on 'Advanced' section.
I think Info pane looks better after this.

Look at following screenshots:
**Risk pane**
_before_
![_001](https://cloud.githubusercontent.com/assets/4204416/22692534/8c0b81c0-ed50-11e6-82df-1287760bf4b7.png)

_after_
![_002](https://cloud.githubusercontent.com/assets/4204416/22692533/8c0b70d6-ed50-11e6-9be2-b2a378a8ac44.png)


**Issue page**
_before_
![_003](https://cloud.githubusercontent.com/assets/4204416/22692626/dfb3aff0-ed50-11e6-842e-888ff810e989.png)

_after_
![_004](https://cloud.githubusercontent.com/assets/4204416/22692625/dfb0bc14-ed50-11e6-8afe-93f57e189870.png)

The second commit could be reverted if that redesign is not valid.
