### PR TITLE
GGRC-1066 Related Assessments popup: minor updates

### DIFF
--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -142,6 +142,7 @@ dashboard-js-files:
   - apps/business_objects.js
   - apps/custom_attributes.js
   # Components
+  - components/state-colors-map/state-colors-map.js
   - components/spinner/spinner.js
   - components/modal-connector.js
   - components/collapsible-panel/collapsible-panel.js

--- a/src/ggrc/assets/javascripts/components/assessment/controls-toolbar/controls-toolbar.js
+++ b/src/ggrc/assets/javascripts/components/assessment/controls-toolbar/controls-toolbar.js
@@ -16,7 +16,7 @@
       state: {
         open: false
       },
-      modalTitle: 'Prior Audit Responses',
+      modalTitle: 'Related Assessments',
       showRelatedResponses: function () {
         this.attr('state.open', true);
       }

--- a/src/ggrc/assets/javascripts/components/state-colors-map/state-colors-map.js
+++ b/src/ggrc/assets/javascripts/components/state-colors-map/state-colors-map.js
@@ -1,0 +1,38 @@
+/*!
+    Copyright (C) 2017 Google Inc.
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+(function (can) {
+  'use strict';
+
+  can.Component.extend('stateColorsMap', {
+    tag: 'state-colors-map',
+    template: '<span style="color: {{color}};">{{state}}</span>',
+    viewModel: {
+      define: {
+        state: {
+          type: String,
+          value: 'Not Started'
+        },
+        color: {
+          get: function () {
+            return this.attr('colorsMap')[this.attr('state')];
+          }
+        },
+        colorsMap: {
+          type: '*',
+          value: function () {
+            return {
+              'Not Started': '#bdbdbd',
+              'In Progress': '#ffab40',
+              'Ready for Review': '#1378bb',
+              Verified: '#333',
+              Completed: '#8bc34a'
+            };
+          }
+        }
+      }
+    }
+  });
+})(window.can);

--- a/src/ggrc/assets/javascripts/components/state-colors-map/state-colors-map.js
+++ b/src/ggrc/assets/javascripts/components/state-colors-map/state-colors-map.js
@@ -5,7 +5,11 @@
 
 (function (can) {
   'use strict';
-
+  /* Default Sate for Assessment should be 'Not Started' */
+  var defaultState = 'Not Started';
+  /**
+   * Simple Component to add color indication for Assessment State Name
+   */
   can.Component.extend('stateColorsMap', {
     tag: 'state-colors-map',
     template: '<span style="color: {{color}};">{{state}}</span>',
@@ -13,11 +17,17 @@
       define: {
         state: {
           type: String,
-          value: 'Not Started'
+          value: defaultState
         },
         color: {
           get: function () {
-            return this.attr('colorsMap')[this.attr('state')];
+            var color = this.attr('colorsMap')[this.attr('state')];
+            if (!color) {
+              console.warn('State of the Object is not defined in Color Map: ',
+                this.attr('state'));
+            }
+            /* Set default 'Not Started' State Color in case incorrect state is provided */
+            return color || this.attr('colorsMap')[defaultState];
           }
         },
         colorsMap: {

--- a/src/ggrc/assets/mustache/assessments/related-assessments.mustache
+++ b/src/ggrc/assets/mustache/assessments/related-assessments.mustache
@@ -18,13 +18,13 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
         </div>
         <div class="grid-data-header flex-row flex-box">
             <div class="grid-data-item-index">
-                Assessment Create Date
+                Assessment State
             </div>
             <div class="grid-data-item-index">
                 Assessment Finish Date
             </div>
             <div class="grid-data-item-index">
-                State
+                Assessment Create Date
             </div>
             <div class="flex-size-3">
                 Related Controls / Objectives
@@ -43,13 +43,13 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
             <object-list items="relatedObjects" is-loading="isLoading" spinner-css="grid-spinner">
                 <div class="grid-data-row flex-row flex-box">
                     <div class="grid-data-item-index">
-                      {{localize_date created_at}}
+                      {{status}}
                     </div>
                     <div class="grid-data-item-index">
                       {{localize_date finished_date}}
                     </div>
                     <div class="grid-data-item-index">
-                      {{status}}
+                      {{localize_date created_at}}
                     </div>
                     <div class="flex-size-3">
                         <related-controls-objectives parent-instance="instance">

--- a/src/ggrc/assets/mustache/assessments/related-assessments.mustache
+++ b/src/ggrc/assets/mustache/assessments/related-assessments.mustache
@@ -43,7 +43,7 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
             <object-list items="relatedObjects" is-loading="isLoading" spinner-css="grid-spinner">
                 <div class="grid-data-row flex-row flex-box">
                     <div class="grid-data-item-index">
-                      {{status}}
+                      <state-colors-map state="status"></state-colors-map>
                     </div>
                     <div class="grid-data-item-index">
                       {{localize_date finished_date}}

--- a/src/ggrc/assets/mustache/assessments/related-assessments.mustache
+++ b/src/ggrc/assets/mustache/assessments/related-assessments.mustache
@@ -5,7 +5,7 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 <related-objects base-instance="instance" related-items-type="Assessment" order-by="finished_date">
     <reusable-objects-list base-instance="instance">
         <div class="grid-data-toolbar flex-box">
-            <tree-pagination paging="paging" class="flex-size-1"></tree-pagination>
+            <tree-pagination paging="paging"></tree-pagination>
             {{#is_allowed 'update' baseInstance context='for'}}
                 <div class="grid-data-toolbar-control">
                     <button {{^hasSelected}}disabled{{/hasSelected}}

--- a/src/ggrc/assets/mustache/assessments/related-assessments.mustache
+++ b/src/ggrc/assets/mustache/assessments/related-assessments.mustache
@@ -39,7 +39,7 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                 Urls
             </div>
         </div>
-        <div class="grid-data-body {{#if isLoading}}loading{{/if}}">
+          <div class="grid-data-body {{#if isLoading}}loading{{/if}}">
             <object-list items="relatedObjects" is-loading="isLoading" spinner-css="grid-spinner">
                 <div class="grid-data-row flex-row flex-box">
                     <div class="grid-data-item-index">
@@ -66,7 +66,7 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                             <mapped-objects
                                 parent-instance="parentInstance"
                                 related-types="relatedTypes">
-                                <a href="{{instance.selfLink}}" target="_blank">{{instance.title}}</a>
+                                <a href="{{instance.viewLink}}" target="_blank">{{instance.title}}</a>
                             </mapped-objects>
                         </related-audits>
                     </div>
@@ -100,6 +100,6 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                     </div>
                 </div>
             </object-list>
-        </div>
+          </div>
     </reusable-objects-list>
 </related-objects>

--- a/src/ggrc/assets/mustache/components/assessment/controls-toolbar/controls-toolbar.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/controls-toolbar/controls-toolbar.mustache
@@ -2,7 +2,7 @@
     Copyright (C) 2017 Google Inc.
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
-<button class="btn btn-small btn-draft btn-extra-gray" can-click="showRelatedResponses" title="Show Prior Audit Responses">Prior Audit Responses</button>
+<button class="btn btn-small btn-draft btn-extra-gray" can-click="showRelatedResponses" title="Show Related Assessments">Related Assessments</button>
 {{#is_allowed 'update' instance context='for'}}
     <object-state-toolbar instance="instance"></object-state-toolbar>
 {{/is_allowed}}

--- a/src/ggrc/assets/mustache/components/tree_pagination/tree_pagination.mustache
+++ b/src/ggrc/assets/mustache/components/tree_pagination/tree_pagination.mustache
@@ -1,8 +1,8 @@
-<div class="tree-pagination">
+<div class="tree-pagination flex-box">
   <div class="tree-pagination__count">
     <div class="dropdown">
-      <h6 class="dropdown-toggle tree-view-pagination__count__title"
-          data-toggle="dropdown">{{paginationInfo paging.current paging.pageSize paging.total}}</h6>
+      <div class="dropdown-toggle tree-view-pagination__count__title"
+          data-toggle="dropdown">{{paginationInfo paging.current paging.pageSize paging.total}}</div>
       <div class="dropdown-menu">
         <span>Items per page:</span>
         <div class="btn-group">
@@ -14,14 +14,14 @@
       </div>
     </div>
   </div>
-  <ul class="pagination pull-right">
+  <ul class="pagination">
     <li class="{{#if_equals paging.current 1}} disabled{{/if_equals}}">
-      <a href="javascript://" can-click="setFirstPage">
+      <a can-click="setFirstPage">
         <i class="fa fa-angle-double-left" aria-hidden="true"></i>
       </a>
     </li>
     <li class="{{#if_equals paging.current 1}} disabled{{/if_equals}}">
-      <a href="javascript://" can-click="setPrevPage">
+      <a can-click="setPrevPage">
         <i class="fa fa-angle-left" aria-hidden="true"></i>
       </a>
     </li>
@@ -30,15 +30,14 @@
                placeholder="{{paginationPlaceholder paging.current paging.count}}" >
     </li>
     <li class="{{#if_equals paging.current paging.count}} disabled{{/if_equals}}">
-      <a href="javascript://" can-click="setNextPage">
+      <a can-click="setNextPage">
         <i class="fa fa-angle-right" aria-hidden="true"></i>
       </a>
     </li>
     <li class="{{#if_equals paging.current paging.count}} disabled{{/if_equals}}">
-      <a href="javascript://" can-click="setLastPage">
+      <a can-click="setLastPage">
         <i class="fa fa-angle-double-right" aria-hidden="true"></i>
       </a>
     </li>
   </ul>
-  <div class="clearfix"></div>
 </div>

--- a/src/ggrc/assets/stylesheets/components/grid-data/_grid-data.scss
+++ b/src/ggrc/assets/stylesheets/components/grid-data/_grid-data.scss
@@ -5,6 +5,7 @@
 .grid-data-toolbar {
   height: 26px;
   margin: 0 0 16px 0;
+  justify-content: flex-end;
 
   .grid-data-toolbar-control {
     display: flex;

--- a/src/ggrc/assets/stylesheets/components/tree_pagination/_tree_pagination.scss
+++ b/src/ggrc/assets/stylesheets/components/tree_pagination/_tree_pagination.scss
@@ -3,33 +3,36 @@
  * Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  */
 
-.footer-wrapper {
-  padding: 0 16px;
-}
-
 .tree-pagination {
+  line-height: 26px;
+  font-size: 12px;
+
   &__count {
-    display: inline-block;
     width: 130px;
-    margin-right: 20px;
+    margin-right: 16px;
+    line-height: 26px;
     cursor: pointer;
+
     button {
       line-height: 26px;
       padding-top: 0;
       padding-bottom: 0;
     }
-    h6 {
+    .tree-view-pagination__count__title {
       font-weight: normal;
       text-transform: none;
-      font-size: 12px;
+      font-size: 11px;
+      line-height: 26px;
       text-align: right;
-      display: block;
+      margin: 0;
+      padding: 0;
     }
   }
   .dropdown-menu {
-    padding: 10px;
-    line-height: 39px;
+    padding: 8px;
+    line-height: 38px;
     min-width: 140px;
+
     .btn-group {
       .btn {
         color: $black;
@@ -46,9 +49,10 @@
   }
   .pagination {
     margin: 0;
-    display: inline-block;
+    height: 26px;
+
     ul {
-      margin-left: 10px;
+      margin-left: 8px;
     }
     li {
       &:first-child {
@@ -81,6 +85,7 @@
         vertical-align: top;
         border-radius: 0;
         height: 16px;
+        font-size: 12px;
         margin-bottom: 0;
         background-color: $white;
         border-top: 1px solid $widgetBorder;

--- a/src/ggrc/assets/stylesheets/modules/_filters.scss
+++ b/src/ggrc/assets/stylesheets/modules/_filters.scss
@@ -19,9 +19,11 @@
     line-height: 26px;
     height: 26px;
     background: $white;
-    border-bottom: 3px solid $warmGray;
+    box-shadow: 0 3px 4px 2px $warmGray;
     padding: 7px 16px 6px 10px;
     margin-bottom: 8px;
+    border-radius: 2px;
+
     &--transparent {
       line-height: 26px;
       height: 26px;
@@ -79,14 +81,14 @@
   &__expression-holder {
     position: relative;
     &__is-expression {
-      @include opacity(0.25);
+      opacity: 0.25;
       position: absolute;
       right: 6px;
       top: 1px;
     }
     &--active {
       .tree-filter__expression-holder__is-expression {
-        @include opacity(1);
+        opacity: 1;
         i {
           background-position: -246px -176px;
         }
@@ -138,11 +140,11 @@
       font-weight: normal;
     }
     i {
-      @include opacity(0.25);
-      @include transition(opacity 0.2s ease);
+      opacity: 0.25;
+      transition: opacity 0.2s ease;
       color: $black;
       &:hover {
-        @include opacity(1);
+        opacity: 1;
       }
     }
   }


### PR DESCRIPTION
Some short list of improvements:
 - Assessment State Column at the beginning + color indication for state (with the same colors as on pie chart on Audit Summary)
- put Assessment Finish Date to the second column
- update title (button also) - "Related Assessments"
- Put Paging Info Closer to paging control