### PR TITLE
GGRC-1085 Explicitly set default All Objects tab in links

### DIFF
--- a/src/ggrc/assets/mustache/base_objects/page_header.mustache
+++ b/src/ggrc/assets/mustache/base_objects/page_header.mustache
@@ -57,7 +57,7 @@
         </span>
       </a>
     {{else}}
-      <a id="allObjectView" href="/objectBrowser">
+      <a id="allObjectView" href="/objectBrowser#regulation_widget">
         <i class="fa fa-files-o"></i>
         <span>
           All Objects

--- a/src/ggrc/assets/mustache/dashboard/info/get_started.mustache
+++ b/src/ggrc/assets/mustache/dashboard/info/get_started.mustache
@@ -69,7 +69,7 @@
 
   <li class="get-started__list__item get-started__list__item--top-space">
     {{! <a href="javascript://" data-toggle="unified-search" data-original-title="search items" data-join-object-type="MultitypeSearch"> }}
-    <a href="/objectBrowser">
+    <a href="/objectBrowser#regulation_widget">
       <span class="get-started__list__icon-wrap">
         <i class="fa fa-files-o white"></i>
       </span>

--- a/src/ggrc/templates/base_objects/_page_header.haml
+++ b/src/ggrc/templates/base_objects/_page_header.haml
@@ -21,7 +21,7 @@
         My Tasks
         %span.task-count
   %li
-    %a{ 'href': '/objectBrowser' }
+    %a{ 'href': '/objectBrowser#regulation_widget' }
       %i.fa.fa-search
       %span
         All Objects

--- a/test/selenium/src/lib/constants/locator.py
+++ b/test/selenium/src/lib/constants/locator.py
@@ -28,7 +28,7 @@ class PageHeader(object):
   BUTTON_MY_TASKS = (By.CSS_SELECTOR, '.header-content ['
                                       'href="/dashboard#task_widget"]')
   BUTTON_ALL_OBJECTS = (By.CSS_SELECTOR, '.header-content ['
-                                         'href="/objectBrowser"]')
+                                         'href^="/objectBrowser"]')
   TOGGLE_USER_DROPDOWN = (
       By.CSS_SELECTOR, '.header-content .dropdown-toggle')
   BUTTON_HELP = (By.CSS_SELECTOR, '.header-content [id="#page-help"]')
@@ -59,7 +59,7 @@ class Dashboard(object):
   BUTTON_CREATE_NEW_OBJECT = (
       By.CSS_SELECTOR, '.get-started__list [href="#"]')
   BUTTON_ALL_OBJECTS = (By.CSS_SELECTOR, '.get-started__list '
-                                         '[href="/objectBrowser"]')
+                                         '[href^="/objectBrowser"]')
 
 
 class LhnMenu(object):


### PR DESCRIPTION
This PR fixes the issue with the _"Objects not directly related to..."_ option text in the 3bb tree view menu when navigating to the All Objects page directly.

The cause of the issue was a missing hash part of the URL - the latter is used to determine the current tab's object type.

---
**Steps to reproduce:**
  1. Go to the dashboard
  1. Click the "All Objects" link in the page header
  1. When on the (default) Regulations tab, open the 3 dots menu on the right, just above the tree view.

**Expected result:**
The last option's text in the menu says _"Objects not directly related to this Regulation"_

**Actual result:**
The last option's text in the menu says _"Objects not directly related to this"_