### PR TITLE
GGRC-1059: Impossible to add new attribute to existing WF model

### DIFF
--- a/src/ggrc_workflows/migrations/versions/20150707143127_44047daa31a9_add_non_adjusted_next_cycle_start_date.py
+++ b/src/ggrc_workflows/migrations/versions/20150707143127_44047daa31a9_add_non_adjusted_next_cycle_start_date.py
@@ -8,6 +8,10 @@ Revises: 1431e7094e26
 Create Date: 2015-07-07 14:31:27.780564
 
 """
+# Workaround legacy code which blocks Workflow new attribute addition
+
+# flake8: noqa
+# pylint: skip-file
 
 # revision identifiers, used by Alembic.
 revision = '44047daa31a9'
@@ -15,21 +19,23 @@ down_revision = '4840f4760f4b'
 
 from alembic import op
 import sqlalchemy as sa
-from sqlalchemy.dialects import mysql
+# from sqlalchemy.dialects import mysql
 
-from datetime import date
-from ggrc.app import app
-from ggrc import settings, db
-import ggrc_workflows.models as models
-from ggrc_workflows import adjust_next_cycle_start_date
-from ggrc_workflows.services.workflow_cycle_calculator import \
-    get_cycle_calculator
+# from datetime import date
+# from ggrc.app import app
+# from ggrc import settings, db
+# import ggrc_workflows.models as models
+# from ggrc_workflows import adjust_next_cycle_start_date
+# from ggrc_workflows.services.workflow_cycle_calculator import \
+#     get_cycle_calculator
 
 
 def upgrade():
     op.add_column('workflows',
                   sa.Column('non_adjusted_next_cycle_start_date',
                   sa.Date(), nullable=True))
+    # Workaround legacy code which blocks Workflow new attribute addition
+    return
 
     # If somebody deleted all the tasks we must clear the next cycle start
     # date


### PR DESCRIPTION
After new attributes addition to WF model, found that migration failed cause old migration imports WF model from GGRC sources: 20150707143127_44047daa31a9_add_non_adjusted_next_cycle_start_date.py
