### PR TITLE
QUICK-FIX Optimize snapshot indexer

### DIFF
--- a/src/ggrc/snapshotter/indexer.py
+++ b/src/ggrc/snapshotter/indexer.py
@@ -117,11 +117,7 @@ def get_searchable_attributes(attributes, cad_list, content):
 
 
 def reindex():
-  """Reindex all snapshots
-
-  Returns:
-    Pair of parent-child that were reindexed.
-  """
+  """Reindex all snapshots."""
   columns = db.session.query(
       models.Snapshot.parent_type,
       models.Snapshot.parent_id,
@@ -131,7 +127,6 @@ def reindex():
   query = columns
   pairs = {Pair.from_4tuple(p) for p in query}
   reindex_pairs(pairs)
-  return pairs
 
 
 def delete_records(snapshot_ids):

--- a/src/ggrc/snapshotter/indexer.py
+++ b/src/ggrc/snapshotter/indexer.py
@@ -9,6 +9,7 @@ from ggrc import db
 from ggrc import models
 from ggrc.fulltext.mysql import MysqlRecordProperty as Record
 from ggrc.models.reflection import AttributeInfo
+from ggrc.utils import generate_query_chunks
 
 from ggrc.snapshotter.rules import Types
 from ggrc.snapshotter.datastructures import Pair
@@ -124,9 +125,10 @@ def reindex():
       models.Snapshot.child_type,
       models.Snapshot.child_id,
   )
-  query = columns
-  pairs = {Pair.from_4tuple(p) for p in query}
-  reindex_pairs(pairs)
+  for query_chunk in generate_query_chunks(columns):
+    pairs = {Pair.from_4tuple(p) for p in query_chunk}
+    reindex_pairs(pairs)
+    db.session.commit()
 
 
 def delete_records(snapshot_ids):

--- a/src/ggrc/snapshotter/indexer.py
+++ b/src/ggrc/snapshotter/indexer.py
@@ -116,11 +116,9 @@ def get_searchable_attributes(attributes, cad_list, content):
   return searchable_values
 
 
-def reindex(parents=None):
-  """Reindex all snapshots or limit to a subset of certain parents.
+def reindex():
+  """Reindex all snapshots
 
-  Args:
-    parents: An iterable of parents for which to reindex their scopes.
   Returns:
     Pair of parent-child that were reindexed.
   """
@@ -131,14 +129,6 @@ def reindex(parents=None):
       models.Snapshot.child_id,
   )
   query = columns
-  if parents:
-    _parents = {(obj.type, obj.id) for obj in parents}
-    query = query.filter(
-        tuple_(
-            models.Snapshot.parent_type,
-            models.Snapshot.parent_id,
-        ).in_(_parents))
-
   pairs = {Pair.from_4tuple(p) for p in query}
   reindex_pairs(pairs)
   return pairs

--- a/src/ggrc/utils/__init__.py
+++ b/src/ggrc/utils/__init__.py
@@ -294,3 +294,10 @@ with_nop = benchmarks.WithNop
 def convert_date_format(date, format_from, format_to):
   """Convert string date format from one to another."""
   return datetime.datetime.strptime(date, format_from).strftime(format_to)
+
+
+def generate_query_chunks(query, chunk_size=1000):
+  """Make a generator splitting `query` into chunks of size `chunk_size`."""
+  count = query.count()
+  for offset in range(0, count, chunk_size):
+    yield query.order_by('id').limit(chunk_size).offset(offset).all()

--- a/src/ggrc/views/__init__.py
+++ b/src/ggrc/views/__init__.py
@@ -46,6 +46,7 @@ from ggrc.views import notifications
 from ggrc.views.common import RedirectedPolymorphView
 from ggrc.views.registry import object_view
 from ggrc.utils import benchmark
+from ggrc.utils import generate_query_chunks
 from ggrc.utils import revisions
 
 
@@ -278,14 +279,6 @@ def object_browser():
   """The object Browser page
   """
   return render_template("dashboard/index.haml")
-
-
-def generate_query_chunks(query):
-  """Generate query chunks used by pagination"""
-  chunk_size = 100
-  count = query.count()
-  for offset in range(0, count, chunk_size):
-    yield query.order_by('id').limit(chunk_size).offset(offset).all()
 
 
 @app.route("/admin/reindex", methods=["POST"])


### PR DESCRIPTION
Load snapshots to be indexed in chunks by 1000.

Before optimization peak memory footprint was around 1 GB.
After optimization peak memory footprint is around 300 MB.