### PR TITLE
QUICK-FIX Get Search API benchmark data

### DIFF
--- a/src/ggrc/fulltext/mysql.py
+++ b/src/ggrc/fulltext/mysql.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2017 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
+"""MySql indexer"""
+
 from sqlalchemy import and_
 from sqlalchemy import case
 from sqlalchemy import distinct
@@ -20,9 +22,11 @@ from ggrc.models import all_models
 from ggrc.utils import query_helpers
 from ggrc.rbac import context_query_filter
 from ggrc.fulltext.sql import SqlIndexer
+from ggrc.utils import benchmark
 
 
 class MysqlRecordProperty(db.Model):
+  """MySQL index table"""
   __tablename__ = 'fulltext_record_properties'
 
   key = db.Column(db.Integer, primary_key=True)
@@ -58,6 +62,7 @@ event.listen(
 
 
 class MysqlIndexer(SqlIndexer):
+  """Provides indexing functionality"""
   record_type = MysqlRecordProperty
 
   def _get_filter_query(self, terms):
@@ -75,32 +80,34 @@ class MysqlIndexer(SqlIndexer):
     """Prepare the query based on the allowed contexts and resources for
      each of the required objects(models).
     """
-    type_queries = []
-    for model_name in model_names:
-      contexts, resources = query_helpers.get_context_resource(
-          model_name=model_name,
-          permission_type=permission_type,
-          permission_model=permission_model
-      )
-      if contexts is not None:
-        if resources:
-          resource_sql = and_(
-              MysqlRecordProperty.type == model_name,
-              MysqlRecordProperty.key.in_(resources))
-        else:
-          resource_sql = false()
-
-        type_query = or_(
-            and_(
+    with benchmark("mysql.py:MysqlIndexer.get_permissions_query"):
+      type_queries = []
+      for model_name in model_names:
+        contexts, resources = query_helpers.get_context_resource(
+            model_name=model_name,
+            permission_type=permission_type,
+            permission_model=permission_model
+        )
+        if contexts is not None:
+          if resources:
+            resource_sql = and_(
                 MysqlRecordProperty.type == model_name,
-                context_query_filter(MysqlRecordProperty.context_id, contexts)
-            ),
-            resource_sql)
-        type_queries.append(type_query)
+                MysqlRecordProperty.key.in_(resources))
+          else:
+            resource_sql = false()
 
-    return and_(
-        MysqlRecordProperty.type.in_(model_names),
-        or_(*type_queries))
+          type_query = or_(
+              and_(
+                  MysqlRecordProperty.type == model_name,
+                  context_query_filter(MysqlRecordProperty.context_id,
+                                       contexts)
+              ),
+              resource_sql)
+          type_queries.append(type_query)
+
+      return and_(
+          MysqlRecordProperty.type.in_(model_names),
+          or_(*type_queries))
 
   def search_get_owner_query(self, query, types=None, contact_id=None):
     """Prepare the search query based on the contact_id to return my
@@ -141,85 +148,93 @@ class MysqlIndexer(SqlIndexer):
     ))
 
   def _get_grouped_types(self, types, extra_params=None):
-    model_names = [model.__name__ for model in all_models.all_models]
-    if types is not None:
-      model_names = [m for m in model_names if m in types]
+    with benchmark("mysql.py:MysqlIndexer._get_grouped_types"):
+      model_names = [model.__name__ for model in all_models.all_models]
+      if types is not None:
+        model_names = [m for m in model_names if m in types]
 
-    if extra_params is not None:
-      model_names = [m for m in model_names if m not in extra_params]
-    return model_names
+      if extra_params is not None:
+        model_names = [m for m in model_names if m not in extra_params]
+      return model_names
 
   def search(self, terms, types=None, permission_type='read',
              permission_model=None, contact_id=None, extra_params={}):
     """Prepare the search query and return the results set based on the
     full text table."""
-    model_names = self._get_grouped_types(types, extra_params)
-    columns = (
-        self.record_type.key.label('key'),
-        self.record_type.type.label('type'),
-        self.record_type.property.label('property'),
-        self.record_type.content.label('content'),
-        case(
-            [(self.record_type.property == 'title', literal(0))],
-            else_=literal(1)).label('sort_key'))
+    with benchmark("mysql.py:MysqlIndexer.search"):
+      model_names = self._get_grouped_types(types, extra_params)
+      columns = (
+          self.record_type.key.label('key'),
+          self.record_type.type.label('type'),
+          self.record_type.property.label('property'),
+          self.record_type.content.label('content'),
+          case(
+              [(self.record_type.property == 'title', literal(0))],
+              else_=literal(1)).label('sort_key'))
 
-    query = db.session.query(*columns)
-    query = query.filter(self.get_permissions_query(
-        model_names, permission_type, permission_model))
-    query = query.filter(self._get_filter_query(terms))
-    query = self.search_get_owner_query(query, types, contact_id)
+      with benchmark("get permissions"):
+        query = db.session.query(*columns)
+        query = query.filter(self.get_permissions_query(
+            model_names, permission_type, permission_model))
+        query = query.filter(self._get_filter_query(terms))
+        query = self.search_get_owner_query(query, types, contact_id)
 
-    model_names = [model.__name__ for model in all_models.all_models]
-    if types is not None:
-      model_names = [m for m in model_names if m in types]
+      model_names = [model.__name__ for model in all_models.all_models]
+      if types is not None:
+        model_names = [m for m in model_names if m in types]
 
-    unions = [query]
-    # Add extra_params and extra_colums:
-    for k, v in extra_params.iteritems():
-      if k not in model_names:
-        continue
-      q = db.session.query(*columns)
-      q = q.filter(
-          self.get_permissions_query([k], permission_type, permission_model))
-      q = q.filter(self._get_filter_query(terms))
-      q = self.search_get_owner_query(q, [k], contact_id)
-      q = self._add_extra_params_query(q, k, v)
-      unions.append(q)
-    all_queries = union(*unions)
-    all_queries = aliased(all_queries.order_by(
-        all_queries.c.sort_key, all_queries.c.content))
-    return db.session.execute(
-        select([all_queries.c.key, all_queries.c.type]).distinct())
+      unions = [query]
+      # Add extra_params and extra_colums:
+      for k, v in extra_params.iteritems():
+        if k not in model_names:
+          continue
+        q = db.session.query(*columns)
+        q = q.filter(
+            self.get_permissions_query([k], permission_type, permission_model))
+        q = q.filter(self._get_filter_query(terms))
+        q = self.search_get_owner_query(q, [k], contact_id)
+        q = self._add_extra_params_query(q, k, v)
+        unions.append(q)
+
+      with benchmark("mysql.py:MysqlIndexer.search.perform union"):
+        all_queries = union(*unions)
+        all_queries = aliased(all_queries.order_by(
+            all_queries.c.sort_key, all_queries.c.content))
+
+      with benchmark("mysql.py:MysqlIndexer.search.execute result"):
+        return db.session.execute(
+            select([all_queries.c.key, all_queries.c.type]).distinct())
 
   def counts(self, terms, types=None, contact_id=None,
              extra_params={}, extra_columns={}):
     """Prepare the search query, but return only count for each of
      the requested objects."""
-    model_names = self._get_grouped_types(types, extra_params)
-    query = db.session.query(
-        self.record_type.type, func.count(distinct(
-            self.record_type.key)), literal(""))
-    query = query.filter(self.get_permissions_query(model_names))
-    query = query.filter(self._get_filter_query(terms))
-    query = self.search_get_owner_query(query, types, contact_id)
-    query = query.group_by(self.record_type.type)
-    all_extra_columns = dict(extra_columns.items() +
-                             [(p, p) for p in extra_params
-                              if p not in extra_columns])
-    if not all_extra_columns:
-      return query.all()
+    with benchmark("mysql.py:MysqlIndexer.counts"):
+      model_names = self._get_grouped_types(types, extra_params)
+      query = db.session.query(
+          self.record_type.type, func.count(distinct(
+              self.record_type.key)), literal(""))
+      query = query.filter(self.get_permissions_query(model_names))
+      query = query.filter(self._get_filter_query(terms))
+      query = self.search_get_owner_query(query, types, contact_id)
+      query = query.group_by(self.record_type.type)
+      all_extra_columns = dict(extra_columns.items() +
+                               [(p, p) for p in extra_params
+                                if p not in extra_columns])
+      if not all_extra_columns:
+        return query.all()
 
-    # Add extra_params and extra_colums:
-    for k, v in all_extra_columns.iteritems():
-      q = db.session.query(
-          self.record_type.type, func.count(
-              distinct(self.record_type.key)), literal(k))
-      q = q.filter(self.get_permissions_query([v]))
-      q = q.filter(self._get_filter_query(terms))
-      q = self.search_get_owner_query(q, [v], contact_id)
-      q = self._add_extra_params_query(q, v, extra_params.get(k, None))
-      q = q.group_by(self.record_type.type)
-      query = query.union(q)
-    return query.all()
+      # Add extra_params and extra_colums:
+      for k, v in all_extra_columns.iteritems():
+        q = db.session.query(
+            self.record_type.type, func.count(
+                distinct(self.record_type.key)), literal(k))
+        q = q.filter(self.get_permissions_query([v]))
+        q = q.filter(self._get_filter_query(terms))
+        q = self.search_get_owner_query(q, [v], contact_id)
+        q = self._add_extra_params_query(q, v, extra_params.get(k, None))
+        q = q.group_by(self.record_type.type)
+        query = query.union(q)
+      return query.all()
 
 Indexer = MysqlIndexer

--- a/src/ggrc/services/__init__.py
+++ b/src/ggrc/services/__init__.py
@@ -85,11 +85,11 @@ def all_services():
 def init_extra_services(app):
   from ggrc.login import login_required
 
-  from .search import search
+  from ggrc.services.search import search
   app.add_url_rule(
       '/search', 'search', login_required(search))
 
-  from .description import ServiceDescription
+  from ggrc.services.description import ServiceDescription
   app.add_url_rule(
       '/api', view_func=ServiceDescription.as_view('ServiceDescription'))
 

--- a/src/ggrc/services/search.py
+++ b/src/ggrc/services/search.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2017 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
+"""Services for Search API"""
+
 import json
 
 from flask import request, current_app
@@ -13,64 +15,65 @@ from ggrc import db
 
 
 def search():
-  terms = request.args.get('q')
-  permission_type = request.args.get('__permission_type', 'read')
-  permission_model = request.args.get('__permission_model', None)
-  if terms is None:
-    return current_app.make_response((
-        'Query parameter "q" specifying search terms must be provided.',
-        400,
-        [('Content-Type', 'text/plain')],
-    ))
+  with benchmark("search.py:search"):
+    terms = request.args.get('q')
+    permission_type = request.args.get('__permission_type', 'read')
+    permission_model = request.args.get('__permission_model', None)
+    if terms is None:
+      return current_app.make_response((
+          'Query parameter "q" specifying search terms must be provided.',
+          400,
+          [('Content-Type', 'text/plain')],
+      ))
 
-  should_group_by_type = request.args.get('group_by_type', '')
-  should_group_by_type = should_group_by_type.lower() == 'true'
-  should_just_count = request.args.get('counts_only', '')
-  should_just_count = should_just_count.lower() == 'true'
+    should_group_by_type = request.args.get('group_by_type', '')
+    should_group_by_type = should_group_by_type.lower() == 'true'
+    should_just_count = request.args.get('counts_only', '')
+    should_just_count = should_just_count.lower() == 'true'
 
-  types = request.args.get('types', '')
-  types = [t.strip() for t in types.split(',') if len(t.strip()) > 0]
-  if len(types) == 0:
-    types = None
+    types = request.args.get('types', '')
+    types = [t.strip() for t in types.split(',') if len(t.strip()) > 0]
+    if len(types) == 0:
+      types = None
 
-  contact_id = request.args.get('contact_id')
-  extra_params = request.args.get('extra_params', {})
-  extra_columns = request.args.get('extra_columns', {})
+    contact_id = request.args.get('contact_id')
+    extra_params = request.args.get('extra_params', {})
+    extra_columns = request.args.get('extra_columns', {})
 
-  relevant_objects = request.args.get('relevant_objects', None)
+    relevant_objects = request.args.get('relevant_objects', None)
 
-  if extra_params:
-    # Parse t1:a=b,c=d;t2:e=f into dict {t1:{a:b,c:d},t2:{e:f}}
-    extra_params = {
-        k: {
-            kk: vv for kk, vv in (x.split('=') for x in v.split(','))
-        } for k, v in (x.split(':') for x in extra_params.split(';'))
-    }
-  else:
-    extra_params = {}
+    if extra_params:
+      # Parse t1:a=b,c=d;t2:e=f into dict {t1:{a:b,c:d},t2:{e:f}}
+      extra_params = {
+          k: {
+              kk: vv for kk, vv in (x.split('=') for x in v.split(','))
+          } for k, v in (x.split(':') for x in extra_params.split(';'))
+      }
+    else:
+      extra_params = {}
 
-  if extra_columns:
-    # Parse a=b,c=d into dict {a:b,c:d}
-    extra_columns = {k: v for k, v in
-                     (x.split('=') for x in extra_columns.split(','))}
+    if extra_columns:
+      # Parse a=b,c=d into dict {a:b,c:d}
+      extra_columns = {k: v for k, v in
+                       (x.split('=') for x in extra_columns.split(','))}
 
-  else:
-    extra_columns = {}
+    else:
+      extra_columns = {}
 
-  if relevant_objects is not None:
-    relevant_objects = [tuple(obj.split(':'))
-                        for obj in relevant_objects.split(',')]
+    if relevant_objects is not None:
+      relevant_objects = [tuple(obj.split(':'))
+                          for obj in relevant_objects.split(',')]
 
-  if should_just_count:
-    return do_counts(terms, types, contact_id, extra_params, extra_columns)
-  if should_group_by_type:
-    return group_by_type_search(terms, types, contact_id, extra_params,
-                                relevant_objects)
-  return basic_search(
-      terms, types,
-      permission_type, permission_model,
-      contact_id, extra_params, relevant_objects
-  )
+    if should_just_count:
+      return do_counts(terms, types, contact_id, extra_params, extra_columns)
+    if should_group_by_type:
+      return group_by_type_search(terms, types, contact_id, extra_params,
+                                  relevant_objects)
+    return basic_search(
+        terms, types,
+        permission_type, permission_model,
+        contact_id, extra_params, relevant_objects
+    )
 
 
 def do_counts(terms, types=None, contact_id=None,
@@ -80,114 +83,120 @@ def do_counts(terms, types=None, contact_id=None,
   # Remove types that the user can't read
   # types = [type for type in types if permissions.is_allowed_read(type, None)]
 
-  indexer = get_indexer()
-  with benchmark("Counts"):
-    results = indexer.counts(terms, types=types, contact_id=contact_id,
-                             extra_params=extra_params,
-                             extra_columns=extra_columns)
+  with benchmark("search.py:do_counts"):
+    indexer = get_indexer()
+    with benchmark("Counts"):
+      results = indexer.counts(terms, types=types, contact_id=contact_id,
+                               extra_params=extra_params,
+                               extra_columns=extra_columns)
 
-  results = [(r[2] if r[2] != "" else r[0], r[1]) for r in results]
-  return current_app.make_response((
-      json.dumps({
-          'results': {
-              'selfLink': request.url,
-              'counts': dict(results)
-          }
-      }, cls=GrcEncoder),
-      200,
-      [('Content-Type', 'application/json')],
-  ))
+    results = [(r[2] if r[2] != "" else r[0], r[1]) for r in results]
+    return current_app.make_response((
+        json.dumps({
+            'results': {
+                'selfLink': request.url,
+                'counts': dict(results)
+            }
+        }, cls=GrcEncoder),
+        200,
+        [('Content-Type', 'application/json')],
+    ))
 
 
 def _build_relevant_filter(types, relevant_objects):
-  if relevant_objects is None:
-    relevant_objects = []
-  filters = []
-  for relevant_type, relevant_id in relevant_objects:
-    relationship = ggrc.models.relationship.Relationship
-    src_query = db.session.query(
-        relationship.source_type, relationship.source_id
-    ).filter(
-        relationship.source_type.in_(types) | (types is None),
-        relationship.destination_type == relevant_type,
-        relationship.destination_id == relevant_id
-    )
-    dst_query = db.session.query(
-        relationship.destination_type, relationship.destination_id
-    ).filter(
-        relationship.destination_type.in_(types) | (types is None),
-        relationship.source_type == relevant_type,
-        relationship.source_id == relevant_id
-    )
-    filters.append(set(src_query.union(dst_query)))
+  with benchmark("search.py:_build_relevant_filter"):
+    if relevant_objects is None:
+      relevant_objects = []
+    filters = []
+    for relevant_type, relevant_id in relevant_objects:
+      relationship = ggrc.models.relationship.Relationship
+      src_query = db.session.query(
+          relationship.source_type, relationship.source_id
+      ).filter(
+          relationship.source_type.in_(types) | (types is None),
+          relationship.destination_type == relevant_type,
+          relationship.destination_id == relevant_id
+      )
+      dst_query = db.session.query(
+          relationship.destination_type, relationship.destination_id
+      ).filter(
+          relationship.destination_type.in_(types) | (types is None),
+          relationship.source_type == relevant_type,
+          relationship.source_id == relevant_id
+      )
+      filters.append(set(src_query.union(dst_query)))
 
-  def check(result_pair):
-    return all(result_pair in bucket for bucket in filters)
+    def check(result_pair):
+      return all(result_pair in bucket for bucket in filters)
 
-  return check
+    return check
 
 
 def do_search(terms, list_for_type, types=None, permission_type='read',
               permission_model=None, contact_id=None, extra_params=None,
               relevant_objects=None):
-  indexer = get_indexer()
-  with benchmark("Search"):
+  with benchmark("search.py:do_search"):
+    indexer = get_indexer()
     results = indexer.search(
         terms, types=types, permission_type=permission_type,
         permission_model=permission_model, contact_id=contact_id,
         extra_params=extra_params
     )
 
-  related_filter = _build_relevant_filter(types, relevant_objects)
-  seen_results = {}
+    related_filter = _build_relevant_filter(types, relevant_objects)
+    seen_results = {}
 
-  for result in results:
-    id = result.key
-    model_type = result.type
-    result_pair = (model_type, id)
-    if result_pair not in seen_results and related_filter(result_pair):
-      seen_results[result_pair] = True
-      entries_list = list_for_type(model_type)
-      entries_list.append({
-          'id': id,
-          'type': model_type,
-          'href': url_for(model_type, id=id),
-      })
+    with benchmark("build_results"):
+      for result in results:
+        id = result.key
+        model_type = result.type
+        result_pair = (model_type, id)
+        if result_pair not in seen_results and related_filter(result_pair):
+          seen_results[result_pair] = True
+          entries_list = list_for_type(model_type)
+          entries_list.append({
+              'id': id,
+              'type': model_type,
+              'href': url_for(model_type, id=id),
+          })
 
 
 def make_search_result(entries):
-  return current_app.make_response((
-      json.dumps({
-          'results': {
-              'selfLink': request.url,
-              'entries': entries,
-          }
-      }, cls=GrcEncoder),
-      200,
-      [('Content-Type', 'application/json')],
-  ))
+  with benchmark("search.py:make_search_result"):
+    return current_app.make_response((
+        json.dumps({
+            'results': {
+                'selfLink': request.url,
+                'entries': entries,
+            }
+        }, cls=GrcEncoder),
+        200,
+        [('Content-Type', 'application/json')],
+    ))
 
 
 def basic_search(terms, types=None,
                  permission_type='read', permission_model=None,
                  contact_id=None, extra_params=None, relevant_objects=None):
-  entries = []
+  with benchmark("search.py:basic_search"):
+    entries = []
 
-  def list_for_type(_):
-    return entries
+    def list_for_type(_):
+      return entries
 
-  do_search(terms, list_for_type, types, permission_type, permission_model,
-            contact_id, extra_params, relevant_objects)
-  return make_search_result(entries)
+    do_search(terms, list_for_type, types, permission_type, permission_model,
+              contact_id, extra_params, relevant_objects)
+    return make_search_result(entries)
 
 
 def group_by_type_search(terms, types=None, contact_id=None, extra_params={},
                          relevant_objects=None):
-  entries = {}
+  with benchmark("search.py:group_by_type_search"):
+    entries = {}
 
-  def list_for_type(t):
-    return entries[t] if t in entries else entries.setdefault(t, [])
+    def list_for_type(t):
+      return entries[t] if t in entries else entries.setdefault(t, [])
 
-  do_search(terms, list_for_type, types, contact_id=contact_id,
-            extra_params=extra_params, relevant_objects=relevant_objects)
-  return make_search_result(entries)
+    do_search(terms, list_for_type, types, contact_id=contact_id,
+              extra_params=extra_params, relevant_objects=relevant_objects)
+    return make_search_result(entries)

--- a/src/ggrc/utils/debug_query.py
+++ b/src/ggrc/utils/debug_query.py
@@ -1,0 +1,52 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Helper functions for debugging queries"""
+
+from sqlalchemy.sql import compiler
+from MySQLdb.converters import conversions, escape
+
+
+def compile_query(session, query):
+  """Compile query for MySQL.
+
+  Compile query for current session and return a string representation of
+  SQLAlchemy's Query object with filled in parameters.
+
+  The usual `compile_kwargs={"literal_binds": True}` approach suggested by
+  SQLALchemy doc (http://docs.sqlalchemy.org/en/latest/faq/sqlexpressions.html#how-do-i-render-sql-expressions-as-strings-possibly-with-bound-parameters-inlined)  # noqa
+  doesn't include the backtick characters needed for copy-pasting to console,
+  this performs the necessary encoding and escaping.
+
+  Based on http://stackoverflow.com/a/4618647.
+
+  Args:
+    session: SQLAlchemy session object
+    query: SQLAlchemy Query objects
+  Returns:
+    Full string representation of SQLAlchemy query
+  """
+  dialect = session.bind.dialect
+  statement = query
+  comp = compiler.SQLCompiler(dialect, statement)
+  comp.compile()
+  enc = dialect.encoding
+  params = []
+  for key in comp.positiontup:
+    value = comp.params[key]
+    if isinstance(value, unicode):
+      value = value.encode(enc)
+    params.append(escape(value, conversions))
+  return (comp.string.encode(enc) % tuple(params)).decode(enc)
+
+
+def explain_query(session, query):
+  """Print full EXPLAIN query for SQLAlchemy's Query object
+
+  Args:
+    session: SQLAlchemy session object
+    query: SQLAlchemy Query objects
+  Returns:
+    EXPLAIN statement for a given query.
+  """
+  return "EXPLAIN " + compile_query(session, query)


### PR DESCRIPTION
This is a preparation ticket for GGRC-966 ("LHN for Assessments needs refreshes since objects don't show at times").

Current best guess is that due to large number of assessments Search API buckles under the load. To get better insight into what exactly is happening we need `benchmark` statements in Search API and MySQL search functions.