### PR TITLE
QUICK-FIX Remove Assessment<->Program mapping

### DIFF
--- a/src/ggrc/models/hooks/assessment.py
+++ b/src/ggrc/models/hooks/assessment.py
@@ -37,15 +37,8 @@ def init_hook():
     for obj, src in izip(objects, sources):
       src_obj = src.get("object")
       audit = src.get("audit")
-      program = src.get("program")
       map_assessment(obj, src_obj)
       map_assessment(obj, audit)
-      # The program may also be set as the src_obj. If so then it should not be
-      # mapped again.
-      if (src_obj and program and
-          (src_obj["id"] != program["id"] or
-           src_obj["type"] != program["type"])):
-        map_assessment(obj, program)
 
       if not src.get("_generated"):
         continue


### PR DESCRIPTION
This PR removes backend code that creates a mapping to Program on Assessment creation.

`critical` as it is related to data corruption that breaks grc-test deployment.