### PR TITLE
GGRC-1068 Fix shown snapshot objects in tree-view

### DIFF
--- a/src/ggrc/assets/javascripts/components/snapshotter/revisions-comparer.js
+++ b/src/ggrc/assets/javascripts/components/snapshotter/revisions-comparer.js
@@ -19,12 +19,6 @@
         var rightRevisions = scope.rightRevisions;
         var revisionsLength = rightRevisions.length;
         var newRevisionID;
-        if (!currentRevisionID || !rightRevisions || !revisionsLength) {
-          scope.instance.snapshot = scope.instance.snapshot.reify();
-          currentRevisionID = scope.instance.snapshot.revision_id;
-          rightRevisions = scope.instance.snapshot.revisions;
-          revisionsLength = rightRevisions.length;
-        }
         newRevisionID = rightRevisions[revisionsLength - 1].id;
         GGRC.Controllers.Modals.confirm({
           modal_title: 'Compare with the latest version',

--- a/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
+++ b/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
@@ -925,7 +925,7 @@
       var type = model.root_collection;
       content.isLatestRevision = instance.is_latest_revision;
       content.originalLink = '/' + type + '/' + content.id;
-      content.snapshot = new CMS.Models.Snapshot(instance);
+      content.snapshot = new can.Map(instance);
       content.related_sources = [];
       content.related_destinations = [];
       content.viewLink = content.snapshot.viewLink;


### PR DESCRIPTION
**Precondition**:
Created program, regulation, objective, audit
**Steps to reproduce:**
1. Go to audit page
2. Create assessment template
3. Generate assessment based on control and template
4. Map regulation and objective to assessment
5. Go to assessment Info page and open regulation, objective and controls tabs: object is not shown in tree view

_Actual Result:_ Mapped object to assessment is not shown in tree view on Assessment Info page
_Expected Result_: Mapped object to assessment should be shown in tree view on Assessment Info page

**Note**: Object is shown in tree view after refreshing the page several times. But if refresh the page after an object appears the object disappears form tree view again.