### PR TITLE
GGRC-1084 Add notification about changed Assessments

### DIFF
--- a/src/ggrc/migrations/versions/20170207134238_562ec606ff7c_add_assessment_updated_notification_type.py
+++ b/src/ggrc/migrations/versions/20170207134238_562ec606ff7c_add_assessment_updated_notification_type.py
@@ -1,0 +1,75 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Add Assessment updated notification type
+
+Create Date: 2017-02-07 13:42:38.921370
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+from datetime import datetime
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '562ec606ff7c'
+down_revision = '6e9a3ed063d2'
+
+
+def upgrade():
+  """Add new notification type: Assessment updated."""
+  description = (
+      "Send an Assessment updated notification to "
+      "Assessors, Creators and Verifiers."
+  )
+
+  now = datetime.utcnow().strftime("%Y-%m-%d %H-%M-%S")
+
+  sql = """
+    INSERT INTO notification_types (
+        name,
+        description,
+        template,
+        advance_notice,
+        instant,
+        created_at,
+        updated_at
+    )
+    VALUES (
+        "assessment_updated",
+        "{description}",
+        "assessment_updated",
+        0,
+        FALSE,
+        '{now}',
+        '{now}'
+    )
+  """.format(description=description, now=now)
+
+  op.execute(sql)
+
+
+def downgrade():
+  """Remove the "Assessment updated" notification type.
+
+  Also delete all notifications of that type.
+  """
+  sql = """
+    DELETE n
+    FROM notifications AS n
+    LEFT JOIN notification_types AS nt ON
+        n.notification_type_id = nt.id
+    WHERE
+        nt.name = "assessment_updated"
+  """
+  op.execute(sql)
+
+  sql = """
+    DELETE
+    FROM notification_types
+    WHERE name = "assessment_updated"
+  """
+  op.execute(sql)

--- a/src/ggrc/models/assessment.py
+++ b/src/ggrc/models/assessment.py
@@ -187,7 +187,7 @@ class Assessment(statusable.Statusable, AuditRelationship,
   similarity_options = similarity_options_module.ASSESSMENT
 
   def validate_conclusion(self, value):
-    return value if value in self.VALID_CONCLUSIONS else ""
+    return value if value in self.VALID_CONCLUSIONS else None
 
   @validates("operationally")
   def validate_opperationally(self, key, value):

--- a/src/ggrc/models/comment.py
+++ b/src/ggrc/models/comment.py
@@ -59,7 +59,7 @@ class Commentable(object):
       # given data - this is intended.
       return ",".join(value)
     elif not value:
-      return ""
+      return None
     else:
       raise ValueError(value,
                        'Value should be either empty ' +

--- a/src/ggrc/notifications/data_handlers.py
+++ b/src/ggrc/notifications/data_handlers.py
@@ -87,6 +87,27 @@ def assignable_open_data(notif):
   return _get_assignable_dict(people, notif)
 
 
+def assignable_updated_data(notif):
+  """Get data for updated assignable object.
+
+  Args:
+    notif (Notification): Notification entry for an open assignable object.
+
+  Returns:
+    A dict containing all notification data for the given notification.
+  """
+  obj = get_notification_object(notif)
+  if not obj:
+    logger.warning(
+        '%s for notification %s not found.',
+        notif.object_type, notif.id,
+    )
+    return {}
+  people = [person for person, _ in obj.assignees]
+
+  return _get_assignable_dict(people, notif)
+
+
 def _get_declined_people(obj):
   """Get a list of people for declined notifications.
 
@@ -205,6 +226,8 @@ def get_assignable_data(notif):
     return {}
   elif notif.notification_type.name.endswith("_open"):
     return assignable_open_data(notif)
+  elif notif.notification_type.name.endswith("_updated"):
+    return assignable_updated_data(notif)
   elif notif.notification_type.name.endswith("_declined"):
     return assignable_declined_data(notif)
   elif notif.notification_type.name.endswith("_reminder"):

--- a/src/ggrc/templates/notifications/email_digest_content.html
+++ b/src/ggrc/templates/notifications/email_digest_content.html
@@ -178,6 +178,19 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                   </ul>
                 {% endif %}
 
+                {% if digest.get('assessment_updated') %}
+                  <h2 {{ style.sub_title() }} >Assessments have been updated</h2>
+                  <ul {{ style.list_wrap() }} >
+                  {% for assessment_id, assessment_data in digest['assessment_updated'].iteritems() %}
+                    <li {{ style.list_item() }} >
+                      Assessment:
+                      <a href="{{ assessment_data['url'] }}" {{ style.link_text() }} >
+                        {{ assessment_data['title'] }}</a>
+                    </li>
+                  {% endfor %}
+                  </ul>
+                {% endif %}
+
                 {% if digest.get('assessment_declined') %}
                   <h2 {{ style.sub_title() }} >Declined assessments</h2>
                   <ul {{ style.list_wrap() }} >


### PR DESCRIPTION
_(a V2 release ticket, hence a higher priority)_

This PR adds a notification record when an (active) Assessment is modified, and includes it into the daily digest email.

When reviewing, please especially mind / focus on the following:
 - Is the list of attributes to ignore, when deciding whether there was a change or not, correct?
 - The exact notification content has not been defined yet, thus I opted for a generic message for the time being.
 - No (integration) tests yet, I would first like to check whether the overall structure and logic of the change is sound. We might also have to postpone them until the exact notification content is known (to have a clearly defined "output") - we might want to create a separate subtask for that in order to not block the main development of the new notifications feature (tests can be written in parallel with other work.
 - (this behavior has been confirmed by @akhilp1 in an offline) ~~Notifications are not sent if an Assessment has not been started yet, since that probably doesn't make sense IMO -the creator of an Assessment might e.g. subsequently do some additional minor edits which are not all that interesting, we have an "Assessment opened" notification for that~~


---

**Steps to verify:**
  - create an Assessment (or open an existing one) and make sure several different people are assigned to it (Verifier, Assignee, etc.)
  - make a change to an Assessment (e.g. edit one of its attributes)
  - look at the daily digest email preview at `<host>/_notifications/show_daily_digest`

**Expected result:**
There should be an "Assessment modified" paragraph in the daily digest email for every person assigned to the modified assessment.