### PR TITLE
GGRC-1093 Improve Active - Deprecated - Draft filter for assignable objects

### DIFF
--- a/src/ggrc/assets/javascripts/models/display_prefs.js
+++ b/src/ggrc/assets/javascripts/models/display_prefs.js
@@ -232,6 +232,12 @@ can.Model.LocalStorage("CMS.Models.DisplayPrefs", {
       return [];
     }
 
+    // Avoid User bugs:
+    // User may have wrong config in local storage
+    if (!GGRC.Utils.State.hasFilter(model_name)) {
+      return [];
+    }
+
     return value[model_name].status_list;
   },
 

--- a/src/ggrc/assets/javascripts/plugins/utils/state-utils.js
+++ b/src/ggrc/assets/javascripts/plugins/utils/state-utils.js
@@ -14,8 +14,11 @@
        'Objective', 'OrgGroup', 'Policy', 'Process', 'Product', 'Program',
        'Project', 'Regulation', 'Risk', 'Section', 'Standard', 'System',
        'Threat', 'Vendor'];
-    var notFilterableModels = ['Person', 'AssessmentTemplate', 'Workflow',
-        'TaskGroup', 'Cycle', 'CycleTaskGroupObjectTask'];
+    var notFilterableModels = [
+      'Person', 'Assessment', 'Issue',
+      'AssessmentTemplate', 'Workflow',
+      'TaskGroup', 'Cycle', 'CycleTaskGroupObjectTask'
+    ];
 
     /**
      * Check if model has state.


### PR DESCRIPTION
Steps to reproduce:
1. Go to My Work page and open Audit tab
2. Look at Audit statuses: differ from Active - Deprecated - Draft 
Actual Result: States for assignable objects are differ from Active - Deprecated - Draft states
Expected result: Remove filter from assignable objects: Assessments, Issues, Workflow, Tasks, Cycle Tasks + Person and Asmt template