### PR TITLE
GGRC-1071 Fix ordering of snapshots

### DIFF
--- a/src/ggrc/converters/query_helper.py
+++ b/src/ggrc/converters/query_helper.py
@@ -514,10 +514,11 @@ class QueryHelper(object):
           raise BadQueryException("Can't order by '__similarity__' when no ",
                                   "'similar' filter was applied.")
       else:
-        key, _ = self.attr_name_map[model].get(key, (key, None))
-        attr = getattr(model, key.encode('utf-8'), None)
-        if attr is None:
-          # non object attributes are treated as custom attributes
+        if model.__name__ != "Snapshot":
+          key, _ = self.attr_name_map[model].get(key, (key, None))
+          attr = getattr(model, key.encode('utf-8'), None)
+        if model.__name__ == "Snapshot" or attr is None:
+          # Snapshot or non object attributes are treated as custom attributes
           self._count += 1
           joins, order = by_ca()
         elif (isinstance(attr, sa.orm.attributes.InstrumentedAttribute) and


### PR DESCRIPTION
Steps to reproduce (from Jira):
1. Go to audit page
2. Click Map in Control's tab and map one more Control to audit
Actual Result: HTTP500 is returned, the mapped object is not shown in tree view
Expected Result: The mapped object is shown in tree view

Second case (more general):
1. Go to any tree view with Snapshots (for instance, Control tab on Assessment page).
2. Try to sort by any column.
Expected result: the data is sorted (note: sorting by owner doesn't work yet, see GGRC-587)
Actual result: HTTP500 is returned, the tree view is empty.