### PR TITLE
GGRC-1103 Fix "Update all snapshots in the audit" feature

### DIFF
--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -964,6 +964,9 @@ class Resource(ModelView):
     with benchmark("Send PUT - after commit event"):
       self.model_put_after_commit.send(obj.__class__, obj=obj,
                                        src=src, service=self, event=event)
+      # Note: Some data is created in listeners for model_put_after_commit
+      # (like updates to snapshots), so we need to commit the changes
+      db.session.commit()
     with benchmark("Serialize collection"):
       object_for_json = self.object_for_json(obj)
     with benchmark("Make response"):


### PR DESCRIPTION
This PR adds a COMMIT after calling `_copy_snapshot_relationships` via sending `model_put_after_commit` event.

Steps to reproduce:
1. Create a program.
2. Create a control, map it to the program.
3. Create an audit for the program.
4. Create an assessment in the audit, map it to the control's snapshot.
5. Create an objective, map it to the control **and to the program** (it's not automapped!).
6. Open assessment info page, click on the control snapshot preview, open "related objectives and regulations": it should be empty (same as objective tab in the audit, the objective is not snapshotted yet).
7. Open audit info page, click "Update objects to latest version" in the dropdown menu.
8. Open assessment info page, click on the control snapshot preview, open "related objectives and regulations".

Expected result: the objective snapshot is displayed in objectives section.
Actual result: the objectives section is empty (although the objective is snapshotted).