### PR TITLE
GGRC-1118 Fix updating to latest revision

### DIFF
--- a/src/ggrc/assets/javascripts/components/snapshotter/revisions-comparer.js
+++ b/src/ggrc/assets/javascripts/components/snapshotter/revisions-comparer.js
@@ -80,7 +80,7 @@
         });
       },
       updateRevision: function () {
-        var instance = this.instance.snapshot;
+        var instance = new CMS.Models.Snapshot(this.instance.snapshot);
         instance.refresh().then(function () {
           instance.attr('update_revision', 'latest');
           return instance.save();


### PR DESCRIPTION
**Precondition**:
Created program, control, audit

**Steps to reproduce**:
1. Go to audit page
2. Return to the program page and make changes in Control (e.g. change description)
3. Refresh audit page and update Control to the latest version: error is displayed

**Actual Result**: Uncaught TypeError: instance.refresh is not a function error is displayed while updating object to the latest version

**Expected Result**: no error is shown while updating an object to the latest version

![image](https://cloud.githubusercontent.com/assets/567805/22824209/f5a448f8-ef97-11e6-88ab-003099343f4a.png)
