### PR TITLE
GGRC-1120 Fix styles in assessment with long attributes

### DIFF
--- a/src/ggrc/assets/mustache/components/assessment/custom-attributes.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/custom-attributes.mustache
@@ -6,7 +6,7 @@
     <ca-object class="flex-box flex-row" value-id="id" def="def" value="attribute_value"
                modal="modal" type="attributeType" validation="validation">
         <i class="fa validation-icon {{iconCls}}"></i>
-        <div class="flex-box flex-col">
+        <div class="flex-box flex-col custom-attribute__body">
             <h6 class="inline-edit__title">
           <span class="inline-edit__title-body {{titleCls}}">
             {{def.title}}

--- a/src/ggrc/assets/stylesheets/components/ca-object/_ca-object.scss
+++ b/src/ggrc/assets/stylesheets/components/ca-object/_ca-object.scss
@@ -22,6 +22,7 @@
     text-align: center;
     color: transparent;
     width: 24px;
+    min-width: 24px;
     height: 24px;
     line-height: 24px;
     display: block;
@@ -40,6 +41,7 @@
   ca-object-validation-icon {
     display: flex;
     width: 24px;
+    min-width: 24px;
     line-height: 24px;
     height: 24px;
     color: transparent;
@@ -62,6 +64,10 @@
         color: $icon-color-valid;
       }
     }
+  }
+
+  .custom-attribute__body {
+    min-width: 0; /* fixes known issue with flexbox and text-overflow */
   }
 
   .inline-edit {
@@ -169,6 +175,10 @@
 
     &:hover {
       background: #fff;
+    }
+
+    .inline-edit__text {
+      overflow: auto;
     }
 
     input[type="checkbox"] {

--- a/src/ggrc/assets/stylesheets/modules/_assessment.scss
+++ b/src/ggrc/assets/stylesheets/modules/_assessment.scss
@@ -13,6 +13,7 @@
     margin-right: 30%;
     padding-right: 12px;
     padding-bottom: 28px;
+    min-width: 0; /* fixes known issue with flexboxes and text-overflow */
 
     assessment-mapped-controls,
     collapsible-panel-header {
@@ -86,6 +87,7 @@
     display: flex;
     align-items: stretch;
     flex-wrap: wrap;
+    margin-bottom: 10px;
 
     > * {
       position: relative;
@@ -97,7 +99,7 @@
 
     .attachments-list-alert {
       float: left;
-      margin: 6px 0 0 -24px;
+      margin: 1px 0 0 -24px;
 
       & + .attachments-list-control {
         .attachments-list-title {
@@ -145,7 +147,7 @@
 
     ggrc-gdrive-picker-launcher {
       display: inline-block;
-      margin: 4px 0;
+      margin: 0;
 
       a.btn {
         background: rgba(0, 0, 0, 0.15);


### PR DESCRIPTION
**Formating is broken if attach evidence/URL with a long title**

**Precondition**:
created program, control, audit

**Steps to reproduce**:
1. Go to audit page
2. Generate assessment based on control
3. Navigate to Assessments Info panel
4. Add evidence/URL with a long title

**Actual Result**: Formating is broken if attach evidence/URL with a long title

**Expected Result**: Formating should not be broken if attach evidence/URL with a long title

![image](https://cloud.githubusercontent.com/assets/567805/22829022/640c0f56-efb1-11e6-9e29-ef7918815620.png)
