### PR TITLE
GGRC-852 Add Assessment state change notifications

### DIFF
--- a/src/ggrc/migrations/versions/20170212143951_1e65abd56ccb_add_notification_types_for_assessment_.py
+++ b/src/ggrc/migrations/versions/20170212143951_1e65abd56ccb_add_notification_types_for_assessment_.py
@@ -1,0 +1,112 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Add notification types for Assessment state transitions.
+
+Create Date: 2017-02-12 14:39:51.734155
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+from datetime import datetime
+
+from alembic import op
+
+from sqlalchemy import Boolean, Date, Integer, String
+from sqlalchemy.sql import column, table
+
+
+# revision identifiers, used by Alembic.
+revision = '1e65abd56ccb'
+down_revision = '57940269e30'
+
+
+_NOTIFICATION_TYPES_TABLE = table(
+    "notification_types",
+    column("name", String),
+    column("description", String),
+    column("template", String),
+    column("advance_notice", Integer),
+    column("instant", Boolean),
+    column("created_at", Date),
+    column("updated_at", Date),
+)
+
+
+_NOW = datetime.utcnow()
+_DESCRIPTION_TPL = \
+    u"Notify Assessors, Creators and Verifiers that an Assessment {}."
+
+_NOTIFICATION_TYPES = [{
+    "name": "assessment_completed",
+    "description": _DESCRIPTION_TPL.format(u"has been completed"),
+    "template": "assessment_completed",
+    "advance_notice": 0,
+    "instant": False,
+    "created_at": _NOW,
+    "updated_at": _NOW,
+}, {
+    "name": "assessment_ready_for_review",
+    "description": _DESCRIPTION_TPL.format(u"is ready for review"),
+    "template": "assessment_ready_for_review",
+    "advance_notice": 0,
+    "instant": False,
+    "created_at": _NOW,
+    "updated_at": _NOW,
+}, {
+    "name": "assessment_verified",
+    "description": _DESCRIPTION_TPL.format(u"has been verified"),
+    "template": "assessment_verified",
+    "advance_notice": 0,
+    "instant": False,
+    "created_at": _NOW,
+    "updated_at": _NOW,
+}, {
+    "name": "assessment_reopened",
+    "description": _DESCRIPTION_TPL.format(u"has been reopened"),
+    "template": "assessment_reopened",
+    "advance_notice": 0,
+    "instant": False,
+    "created_at": _NOW,
+    "updated_at": _NOW,
+}]
+
+
+def upgrade():
+  """Add new notification types for Assessment state transitions.
+
+  The only state transition left out is "Not Started" --> "In Progress",
+  because it has no interest to users.
+  """
+  op.bulk_insert(
+      _NOTIFICATION_TYPES_TABLE,
+      _NOTIFICATION_TYPES
+  )
+
+
+def downgrade():
+  """Remove Assessment state change notification types.
+
+  The only exception is the Assessment declined state transition, i.e. from
+  "Ready for Review" to "In Progress".
+
+  Notifications of the deleted notification types get deleted as well.
+  """
+  notif_type_names = tuple(notif["name"] for notif in _NOTIFICATION_TYPES)
+
+  sql = """
+      DELETE n
+      FROM notifications AS n
+      LEFT JOIN notification_types AS nt ON
+          n.notification_type_id = nt.id
+      WHERE
+          nt.name in {}
+  """.format(notif_type_names)
+
+  op.execute(sql)
+
+  sql = _NOTIFICATION_TYPES_TABLE.delete().where(
+      _NOTIFICATION_TYPES_TABLE.c.name.in_(notif_type_names)
+  )
+  op.execute(sql)

--- a/src/ggrc/notifications/data_handlers.py
+++ b/src/ggrc/notifications/data_handlers.py
@@ -224,14 +224,26 @@ def get_assignable_data(notif):
   """
   if notif.object_type not in {"Request", "Assessment"}:
     return {}
-  elif notif.notification_type.name.endswith("_open"):
-    return assignable_open_data(notif)
-  elif notif.notification_type.name.endswith("_updated"):
-    return assignable_updated_data(notif)
-  elif notif.notification_type.name.endswith("_declined"):
-    return assignable_declined_data(notif)
-  elif notif.notification_type.name.endswith("_reminder"):
-    return assignable_reminder(notif)
+
+  # a map of notification type suffixes to functions that fetch data for those
+  # notification types
+  data_handlers = {
+      "_open": assignable_open_data,
+      "_updated": assignable_updated_data,
+      "_completed": assignable_updated_data,
+      "_ready_for_review": assignable_updated_data,
+      "_verified": assignable_updated_data,
+      "_reopened": assignable_updated_data,
+      "_declined": assignable_declined_data,
+      "_reminder": assignable_reminder,
+  }
+
+  notif_type = notif.notification_type.name
+
+  for suffix, data_handler in data_handlers.iteritems():
+    if notif_type.endswith(suffix):
+      return data_handler(notif)
+
   return {}
 
 

--- a/src/ggrc/templates/notifications/email_digest_content.html
+++ b/src/ggrc/templates/notifications/email_digest_content.html
@@ -191,6 +191,45 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                   </ul>
                 {% endif %}
 
+                {% if digest.get('assessment_completed') %}
+                  <h2 {{ style.sub_title() }} >Completed assessments</h2>
+                  <ul {{ style.list_wrap() }} >
+                  {% for assessment_id, assessment_data in digest['assessment_completed'].iteritems() %}
+                    <li {{ style.list_item() }} >
+                      Assessment:
+                      <a href="{{ assessment_data['url'] }}" {{ style.link_text() }} >
+                        {{ assessment_data['title'] }}</a>
+                    </li>
+                  {% endfor %}
+                  </ul>
+                {% endif %}
+
+                {% if digest.get('assessment_ready_for_review') %}
+                  <h2 {{ style.sub_title() }} >Assessments ready for review</h2>
+                  <ul {{ style.list_wrap() }} >
+                  {% for assessment_id, assessment_data in digest['assessment_ready_for_review'].iteritems() %}
+                    <li {{ style.list_item() }} >
+                      Assessment:
+                      <a href="{{ assessment_data['url'] }}" {{ style.link_text() }} >
+                        {{ assessment_data['title'] }}</a>
+                    </li>
+                  {% endfor %}
+                  </ul>
+                {% endif %}
+
+                {% if digest.get('assessment_verified') %}
+                  <h2 {{ style.sub_title() }} >Verified assessments</h2>
+                  <ul {{ style.list_wrap() }} >
+                  {% for assessment_id, assessment_data in digest['assessment_verified'].iteritems() %}
+                    <li {{ style.list_item() }} >
+                      Assessment:
+                      <a href="{{ assessment_data['url'] }}" {{ style.link_text() }} >
+                        {{ assessment_data['title'] }}</a>
+                    </li>
+                  {% endfor %}
+                  </ul>
+                {% endif %}
+
                 {% if digest.get('assessment_declined') %}
                   <h2 {{ style.sub_title() }} >Declined assessments</h2>
                   <ul {{ style.list_wrap() }} >
@@ -200,6 +239,19 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                       <a href="{{ assessment_data['url'] }}" {{ style.link_text() }} >
                         {{ assessment_data['title'] }}
                       </a>
+                    </li>
+                  {% endfor %}
+                  </ul>
+                {% endif %}
+
+                {% if digest.get('assessment_reopened') %}
+                  <h2 {{ style.sub_title() }} >Reopened assessments</h2>
+                  <ul {{ style.list_wrap() }} >
+                  {% for assessment_id, assessment_data in digest['assessment_reopened'].iteritems() %}
+                    <li {{ style.list_item() }} >
+                      Assessment:
+                      <a href="{{ assessment_data['url'] }}" {{ style.link_text() }} >
+                        {{ assessment_data['title'] }}</a>
                     </li>
                   {% endfor %}
                   </ul>

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -12,6 +12,7 @@ babel==1.3
 bleach==1.2.2
 blinker==1.3
 chardet==2.1.1
+enum34==1.1.6
 Flask-Assets==0.8
 Flask-Login==0.2.2
 Flask==0.10.1

--- a/test/integration/ggrc/notifications/test_assignable_notifications.py
+++ b/test/integration/ggrc/notifications/test_assignable_notifications.py
@@ -80,9 +80,6 @@ class TestAssignableNotification(TestCase):
 
     This function tests that each assessment gets an entry in the
     notifications table after it's been created.
-    Second part of the tests is to make sure that assessment status
-    does not add any new notification entries if the assessment
-    does not have a verifier.
     """
 
     with freeze_time("2015-04-01"):
@@ -108,21 +105,6 @@ class TestAssignableNotification(TestCase):
       self.client.get("/_notifications/send_daily_digest")
       self.assertEqual(self._get_notifications().count(), 0)
 
-      asmt = Assessment.query.get(asmts["A 5"].id)
-
-      self.api_helper.modify_object(asmt, {"status": Assessment.FINAL_STATE})
-      self.assertEqual(self._get_notifications().count(), 0)
-      self.api_helper.modify_object(asmt, {"status": Assessment.START_STATE})
-      self.assertEqual(self._get_notifications().count(), 0)
-      self.api_helper.modify_object(asmt,
-                                    {"status": Assessment.PROGRESS_STATE})
-      self.assertEqual(self._get_notifications().count(), 0)
-      self.api_helper.modify_object(asmt, {"status": Assessment.FINAL_STATE})
-      self.assertEqual(self._get_notifications().count(), 0)
-      self.api_helper.modify_object(asmt,
-                                    {"status": Assessment.PROGRESS_STATE})
-      self.assertEqual(self._get_notifications().count(), 0)
-
   @patch("ggrc.notifications.common.send_email")
   def test_assessment_with_verifiers(self, _):
     """Test notifications entries for declined assessments.
@@ -130,9 +112,7 @@ class TestAssignableNotification(TestCase):
     This tests makes sure there are extra notification entries added when a
     assessment has been declined.
     """
-
     with freeze_time("2015-04-01"):
-
       self.assertEqual(self._get_notifications().count(), 0)
       self.import_file("assessment_with_templates.csv")
       asmts = {asmt.slug: asmt for asmt in Assessment.query}
@@ -154,30 +134,31 @@ class TestAssignableNotification(TestCase):
       self.api_helper.modify_object(asmt1,
                                     {"status": Assessment.PROGRESS_STATE})
       self.assertEqual(self._get_notifications().count(), 0)
+
       self.api_helper.modify_object(asmt1, {"status": Assessment.DONE_STATE})
-      self.assertEqual(self._get_notifications().count(), 0)
+      self.assertEqual(self._get_notifications().count(), 1)
       # decline assessment 1
       self.api_helper.modify_object(asmt1,
                                     {"status": Assessment.PROGRESS_STATE})
-      self.assertEqual(self._get_notifications().count(), 1)
+      self.assertEqual(self._get_notifications().count(), 3)
       self.api_helper.modify_object(asmt1, {"status": Assessment.DONE_STATE})
-      self.assertEqual(self._get_notifications().count(), 1)
+      self.assertEqual(self._get_notifications().count(), 3)
       # decline assessment 1 the second time
       self.api_helper.modify_object(asmt1,
                                     {"status": Assessment.PROGRESS_STATE})
-      self.assertEqual(self._get_notifications().count(), 1)
+      self.assertEqual(self._get_notifications().count(), 3)
 
       asmt6 = Assessment.query.get(asmts["A 6"].id)
       # start and finish assessment 6
       self.api_helper.modify_object(asmt6,
                                     {"status": Assessment.PROGRESS_STATE})
-      self.assertEqual(self._get_notifications().count(), 1)
+      self.assertEqual(self._get_notifications().count(), 3)
       self.api_helper.modify_object(asmt6, {"status": Assessment.DONE_STATE})
-      self.assertEqual(self._get_notifications().count(), 1)
+      self.assertEqual(self._get_notifications().count(), 4)
       # decline assessment 6
       self.api_helper.modify_object(asmt6,
                                     {"status": Assessment.PROGRESS_STATE})
-      self.assertEqual(self._get_notifications().count(), 2)
+      self.assertEqual(self._get_notifications().count(), 6)
 
       # send all notifications
       self.client.get("/_notifications/send_daily_digest")
@@ -190,16 +171,16 @@ class TestAssignableNotification(TestCase):
       self.assertEqual(self._get_notifications().count(), 0)
       self.api_helper.modify_object(asmt6,
                                     {"status": Assessment.DONE_STATE})
-      self.assertEqual(self._get_notifications().count(), 0)
+      self.assertEqual(self._get_notifications().count(), 1)
       self.api_helper.modify_object(asmt6,
                                     {"status": Assessment.VERIFIED_STATE})
-      self.assertEqual(self._get_notifications().count(), 0)
+      self.assertEqual(self._get_notifications().count(), 2)
       self.api_helper.modify_object(asmt6,
                                     {"status": Assessment.PROGRESS_STATE})
-      self.assertEqual(self._get_notifications().count(), 0)
+      self.assertEqual(self._get_notifications().count(), 3)
       # decline assessment 6
       self.api_helper.modify_object(asmt6, {"status": Assessment.DONE_STATE})
-      self.assertEqual(self._get_notifications().count(), 0)
+      self.assertEqual(self._get_notifications().count(), 3)
       self.api_helper.modify_object(asmt6,
                                     {"status": Assessment.PROGRESS_STATE})
-      self.assertEqual(self._get_notifications().count(), 1)
+      self.assertEqual(self._get_notifications().count(), 4)


### PR DESCRIPTION
This PR adds notifications to daily digest email if Assessment's status is changed. All user roles assigned to the Assessment (Creator, Assignees, Verifiers) get notified.

This can probably be considered as a "beta PR", thus adding the `needs work` label. The code should be probably be refactored a bit, and there is a state transition clash between two notification types, namely "Assessment declined" and "Assessment reopened". Plus more thorough testing needs to be done.

**Edit:**
The notification email templates used are generic for now. Some modest changes need to be done, which is covered by a different subtask.