### PR TITLE
GGRC-1143 Fix script error in certain tree views

### DIFF
--- a/src/ggrc_risk_assessments/assets/mustache/risk_assessments/tree.mustache
+++ b/src/ggrc_risk_assessments/assets/mustache/risk_assessments/tree.mustache
@@ -40,7 +40,7 @@
                       {{else}}
                         <div class="owner tree-title-area">
                           {{#instance}}
-                            {{>'/static/mustache/ggrc_risk_assessments/risk_assessments/tree-item-attr.mustache'}}
+                            {{>'/static/mustache/risk_assessments/tree-item-attr.mustache'}}
                           {{/instance}}
                         </div>
                       {{/if_equals}}

--- a/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/tree.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/tree.mustache
@@ -27,7 +27,7 @@
                     <div class="span{{display_options.selectable_attr_width}}">
                       <div class="owner tree-title-area">
                         {{#instance}}
-                          {{> '/static/mustache/ggrc_workflows/cycle_task_group_object_tasks/tree-item-attr.mustache'}}
+                          {{> '/static/mustache/cycle_task_group_object_tasks/tree-item-attr.mustache'}}
                         {{/instance}}
                       </div>
                     </div>

--- a/src/ggrc_workflows/assets/mustache/workflows/tree.mustache
+++ b/src/ggrc_workflows/assets/mustache/workflows/tree.mustache
@@ -28,7 +28,7 @@
                       {{else}}
                         <div class="owner tree-title-area">
                           {{#instance}}
-                            {{> '/static/mustache/ggrc_workflows/workflows/tree-item-attr.mustache'}}
+                            {{> '/static/mustache/workflows/tree-item-attr.mustache'}}
                           {{/instance}}
                         </div>
                       {{/if_equals}}


### PR DESCRIPTION
This fixes regressions caused by 232a726 that was part of #5122.

Steps to reproduce:
1. Create one time WF
2. Create task to Task Group and Activate WF
3. Open Active Cycles tab and expand sub level for Task Group
Actual Result: JS error occurs in WF while expanding tasks in Active Cycles tab
Expected Result: No error displayed

Same error was also present on two other pages:

1. Workflow tree view on any object page with an active workflow attached (care the initial count on object page will be zero, even though workflows are mapped)
2. Risk Assessment tree view on Program page