### PR TITLE
GGRC-856 Creator Program Editor gets a permission error trying to save an Assessment Template

### DIFF
--- a/src/ggrc_basic_permissions/roles/ProgramAuditEditor.py
+++ b/src/ggrc_basic_permissions/roles/ProgramAuditEditor.py
@@ -30,6 +30,7 @@ permissions = {
         "Request",
         "Comment",
         "Assessment",
+        "AssessmentTemplate",
         "Issue",
         "Meeting",
         "ObjectControl",


### PR DESCRIPTION
**GGRC-856:** get request to '/permissions' endpoint caches
permissions. Assessment Template cannot be POSTed after it
because permissions are come from cache. Cache should be
cleared out before performing checks for POST operation or it should contain appropriate context for new AssessmentTemplate.

**Steps to reproduce:**
1. Create a program and map GC (progcreator@reciprocitylabs.com (engage007) as Program Editor
2. Create an audit
3. Log as Program Editor (progcreator@reciprocitylabs.com (engage007)
4. Go to audit and create Assessment template: confirm Program Editor gets a permission error

**Actual Result:** Creator Program Editor gets a permission error trying to save an Assessment Template
**Expected Result:** Creator Program Editor should be able to create an Assessment Template

This PR should be merged before: #5232 and #5301.