### PR TITLE
GGRC-1144 Show LAST ASSESSMENT DATE column for snapshots

### DIFF
--- a/src/ggrc/assets/javascripts/components/last-assessment-date/last-assessment-date.js
+++ b/src/ggrc/assets/javascripts/components/last-assessment-date/last-assessment-date.js
@@ -35,6 +35,7 @@
       var viewModel = this.viewModel;
       var params = queryAPI.buildParam(REQUESTED_TYPE, FILTER_OPTIONS, {
         type: type,
+        operation: 'relevant',
         id: id
       }, REQUIRED_FIELDS);
 

--- a/src/ggrc/assets/javascripts/components/last-assessment-date/last-assessment-date.js
+++ b/src/ggrc/assets/javascripts/components/last-assessment-date/last-assessment-date.js
@@ -15,6 +15,7 @@
     sortDirection: 'desc'
   });
   var REQUIRED_FIELDS = Object.freeze(['finished_date']);
+  var ALLOWED_TYPES = Object.freeze(['Control', 'Objective']);
 
   can.Component.extend({
     tag: 'last-assessment-date',
@@ -27,7 +28,7 @@
     init: function () {
       var id = this.viewModel.instanceId;
       var type = this.viewModel.instanceType;
-      if (id && type) {
+      if (id && type && ALLOWED_TYPES.indexOf(type) > -1) {
         this.loadLastAssessment(type, id);
       }
     },

--- a/src/ggrc/assets/javascripts/components/last-assessment-date/last-assessment-date.js
+++ b/src/ggrc/assets/javascripts/components/last-assessment-date/last-assessment-date.js
@@ -17,17 +17,31 @@
   var REQUIRED_FIELDS = Object.freeze(['finished_date']);
   var ALLOWED_TYPES = Object.freeze(['Control', 'Objective']);
 
-  can.Component.extend({
+  GGRC.Components('lastAssessmentDate', {
     tag: 'last-assessment-date',
-    template: '<content/>',
+    template: '{{localize_date lastAssessmentDate}}',
     viewModel: {
-      instanceId: null,
-      instanceType: null,
+      instance: null,
       lastAssessmentDate: null
     },
     init: function () {
-      var id = this.viewModel.instanceId;
-      var type = this.viewModel.instanceType;
+      var instance = this.viewModel.instance;
+      var isSnapshot;
+      var id;
+      var type;
+
+      if (!instance) {
+        return;
+      }
+
+      isSnapshot = !!this.viewModel.instance.snapshot;
+      if (isSnapshot) {
+        id = instance.snapshot.child_id;
+        type = instance.snapshot.child_type;
+      } else {
+        id = instance.id;
+        type = instance.type;
+      }
       if (id && type && ALLOWED_TYPES.indexOf(type) > -1) {
         this.loadLastAssessment(type, id);
       }

--- a/src/ggrc/assets/javascripts/components/last-assessment-date/last-assessment-date_spec.js
+++ b/src/ggrc/assets/javascripts/components/last-assessment-date/last-assessment-date_spec.js
@@ -1,0 +1,190 @@
+/*!
+ Copyright (C) 2017 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+describe('GGRC.Components.lastAssessmentDate', function () {
+  'use strict';
+
+  var Component;  // the component under test
+
+  beforeAll(function () {
+    Component = GGRC.Components.get('lastAssessmentDate');
+  });
+
+  describe('init() method', function () {
+    var componentInst;
+    var method;
+
+    describe('for not Snapshot object', function () {
+      beforeEach(function () {
+        componentInst = {
+          viewModel: new can.Map(),
+          loadLastAssessment: jasmine.createSpy()
+        };
+        method = Component.prototype.init.bind(componentInst);
+      });
+
+      it('works correct for Control type', function () {
+        componentInst.viewModel.attr('instance', {
+          type: 'Control',
+          id: 123
+        });
+        method();
+
+        expect(componentInst.loadLastAssessment).toHaveBeenCalled();
+      });
+
+      it('works correct for Objective type', function () {
+        componentInst.viewModel.attr('instance', {
+          type: 'Objective',
+          id: 321
+        });
+        method();
+
+        expect(componentInst.loadLastAssessment).toHaveBeenCalled();
+      });
+
+      it('doesn\'t work if instance is empty', function () {
+        method();
+
+        expect(componentInst.loadLastAssessment).not.toHaveBeenCalled();
+      });
+
+      it('doesn\'t work if type is empty', function () {
+        componentInst.viewModel.attr('instance', {
+          id: 321
+        });
+        method();
+
+        expect(componentInst.loadLastAssessment).not.toHaveBeenCalled();
+      });
+
+      it('doesn\'t work if id is empty', function () {
+        componentInst.viewModel.attr('instance', {
+          type: 'Control'
+        });
+        method();
+
+        expect(componentInst.loadLastAssessment).not.toHaveBeenCalled();
+      });
+
+      it('doesn\'t work for not allowed types', function () {
+        componentInst.viewModel.attr('instance', {
+          type: 'Foo',
+          id: 321
+        });
+        method();
+
+        expect(componentInst.loadLastAssessment).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('for Snapshot object', function () {
+      beforeEach(function () {
+        componentInst = {
+          viewModel: new can.Map(),
+          loadLastAssessment: jasmine.createSpy()
+        };
+        method = Component.prototype.init.bind(componentInst);
+      });
+
+      it('works correct for Control type', function () {
+        componentInst.viewModel.attr('instance', {
+          snapshot: {
+            child_type: 'Control',
+            child_id: 123
+          }
+        });
+        method();
+
+        expect(componentInst.loadLastAssessment).toHaveBeenCalled();
+      });
+
+      it('works correct for Objective type', function () {
+        componentInst.viewModel.attr('instance', {
+          snapshot: {
+            child_type: 'Objective',
+            child_id: 321
+          }
+        });
+        method();
+
+        expect(componentInst.loadLastAssessment).toHaveBeenCalled();
+      });
+
+      it('doesn\'t work if instance is empty', function () {
+        method();
+
+        expect(componentInst.loadLastAssessment).not.toHaveBeenCalled();
+      });
+
+      it('doesn\'t work if type is empty', function () {
+        componentInst.viewModel.attr('instance', {
+          snapshot: {
+            child_id: 321
+          }
+        });
+        method();
+
+        expect(componentInst.loadLastAssessment).not.toHaveBeenCalled();
+      });
+
+      it('doesn\'t work for not allowed types', function () {
+        componentInst.viewModel.attr('instance', {
+          snapshot: {
+            child_type: 'Foo',
+            child_id: 321
+          }
+        });
+        method();
+
+        expect(componentInst.loadLastAssessment).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('loadLastAssessment() method', function () {
+    var loadLastAssessment;
+    var REQUESTED_TYPE = 'Assessment';
+    var FILTER_OPTIONS = Object.freeze({
+      current: 1,
+      pageSize: 1,
+      sortBy: 'finished_date',
+      sortDirection: 'desc'
+    });
+    var REQUIRED_FIELDS = Object.freeze(['finished_date']);
+
+    beforeAll(function () {
+      spyOn(GGRC.Utils.QueryAPI, 'buildParam');
+      spyOn(GGRC.Utils.QueryAPI, 'makeRequest').and.returnValue({
+        then: jasmine.createSpy()
+      });
+    });
+
+    beforeEach(function () {
+      var componentInst = {
+        viewModel: new can.Map()
+      };
+
+      loadLastAssessment = Component.prototype.loadLastAssessment
+        .bind(componentInst);
+    });
+
+    it('requesting the correct parameters', function () {
+      loadLastAssessment('Foo', 123);
+
+      expect(GGRC.Utils.QueryAPI.buildParam)
+        .toHaveBeenCalledWith(
+          REQUESTED_TYPE,
+          FILTER_OPTIONS, {
+            type: 'Foo',
+            operation: 'relevant',
+            id: 123
+          },
+          REQUIRED_FIELDS);
+
+      expect(GGRC.Utils.QueryAPI.makeRequest).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/ggrc/assets/mustache/controls/tree-item-attr.mustache
+++ b/src/ggrc/assets/mustache/controls/tree-item-attr.mustache
@@ -88,9 +88,7 @@
     {{/using}}
   {{/case}}
   {{#case 'last_assessment_date'}}
-    <last-assessment-date instance-id="instance.id" instance-type="instance.type">
-      {{localize_date lastAssessmentDate}}
-    </last-assessment-date>
+    <last-assessment-date instance="instance"/>
   {{/case}}
 
   {{#default}}

--- a/src/ggrc/assets/mustache/objectives/tree-item-attr.mustache
+++ b/src/ggrc/assets/mustache/objectives/tree-item-attr.mustache
@@ -28,9 +28,7 @@
     </span>
   {{/case}}
   {{#case 'last_assessment_date'}}
-    <last-assessment-date instance-id="instance.id" instance-type="instance.type">
-      {{localize_date lastAssessmentDate}}
-    </last-assessment-date>
+    <last-assessment-date instance="instance"/>
   {{/case}}
 
   {{#default}}


### PR DESCRIPTION
**Precondition**:
created program, control, objective, audit, assessment on the audit page
**Steps to reproduce:**
1. Navigate to assessment's Info pane on the audit page and Complete assessment
2. Go to Controls/Objectives tabs
3. Look at LAST ASSESSMENT DATE column: assessment's finish date empty

_Actual Result_: LAST ASSESSMENT DATE column for snapshots: Controls/Objectives is empty
_Expected Result_: Hide LAST ASSESSMENT DATE column for snapshots.