### PR TITLE
QUICK-FIX: python requirements

### DIFF
--- a/src/requirements-dev.txt
+++ b/src/requirements-dev.txt
@@ -35,6 +35,5 @@ sniffer==0.3.5
 webob==1.4.1
 Werkzeug==0.11
 wsgiref==0.1.2
-cached-property==1.3.0
 Mako==1.0.4
 Sphinx==1.4.6

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -31,5 +31,6 @@ tabulate==0.7.5
 webassets==0.8
 Werkzeug==0.9.3
 colorlog==2.7.0
+cached-property==1.3.0
 # Flask-SQLAlchemy must be last - it somehow mangles `distribute` / `setuptools`
 Flask-SQLAlchemy==1.0


### PR DESCRIPTION
add cached-property==1.3.0 to prod requirements
and remove it from dev requirements 