### PR TITLE
GGRC-1134 Move total objects count next to the Search button

### DIFF
--- a/src/ggrc/assets/javascripts/components/unified-mapper/mapper-results.js
+++ b/src/ggrc/assets/javascripts/components/unified-mapper/mapper-results.js
@@ -394,9 +394,6 @@
       },
       '{viewModel} type': function () {
         this.viewModel.attr('items', []);
-      },
-      '{viewModel.paging} total': function (scope, ev, total) {
-        this.viewModel.attr('objectsPlural', total > 1);
       }
     }
   });

--- a/src/ggrc/assets/javascripts/components/unified-mapper/mapper-toolbar.js
+++ b/src/ggrc/assets/javascripts/components/unified-mapper/mapper-toolbar.js
@@ -17,6 +17,8 @@
       statuses: [],
       mapper: {},
       isLoading: false,
+      totalObjects: 0,
+      objectsPlural: false,
       showStatusFilter: false,
       displayPrefs: null,
       init: function () {
@@ -64,6 +66,14 @@
       }
     },
     events: {
+      '{viewModel} totalObjects': function (scope, ev, totalObjects) {
+        this.viewModel.attr('objectsPlural', totalObjects > 1);
+      },
+      '{viewModel.mapper} afterSearch': function (scope, ev, afterSearch) {
+        if (!afterSearch) {
+          this.viewModel.attr('totalObjects', 0);
+        }
+      },
       '{viewModel.mapper} type': function () {
         this.viewModel.setStatusFilter();
       }

--- a/src/ggrc/assets/mustache/components/unified-mapper/mapper-results.mustache
+++ b/src/ggrc/assets/mustache/components/unified-mapper/mapper-results.mustache
@@ -46,9 +46,13 @@
     </div>
     <tree-pagination paging="paging" class="list-pagination"></tree-pagination>
   {{else}}
-    {{^isLoading}}
+    {{#if isLoading}}
+      <div class="no-items-spinner-wrapper">
+        <spinner toggle="isLoading" extra-css-class="grid-spinner" class="spinner-wrapper active"></spinner>
+      </div>
+    {{else}}
       <div class="well well-small">No {{getDisplayModel.title_plural}} were found</div>
-    {{/isLoading}}
+    {{/if}}
   {{/if}}
 </object-selection>
 {{#relatedAssessments.show}}

--- a/src/ggrc/assets/mustache/components/unified-mapper/mapper-results.mustache
+++ b/src/ggrc/assets/mustache/components/unified-mapper/mapper-results.mustache
@@ -6,9 +6,6 @@
 <object-selection items="items" selected-items="selected" refresh-selection="refreshItems" all-items="allItems"
                   all-selected="allSelected">
   {{#if items.length}}
-    <div class="objects-found">
-      <label>{{paging.total}} {{#objectsPlural}}Objects{{/objectsPlural}} {{^objectsPlural}}Object{{/objectsPlural}} found</label>
-    </div>
     <div class="list-header">
       {{^disableColumnsConfiguration}}
         <mapper-results-columns-configuration

--- a/src/ggrc/assets/mustache/components/unified-mapper/mapper-toolbar.mustache
+++ b/src/ggrc/assets/mustache/components/unified-mapper/mapper-toolbar.mustache
@@ -92,6 +92,14 @@
   ></relevant-filter>
 </div>
 <div class="filter-buttons">
+  {{#mapper.afterSearch}}
+    {{#totalObjects}}
+      <div class="objects-found {{#isLoading}}loading{{/isLoading}}">
+        <label>{{totalObjects}} {{#objectsPlural}}
+          Objects{{/objectsPlural}} {{^objectsPlural}}Object{{/objectsPlural}} found</label>
+      </div>
+    {{/totalObjects}}
+  {{/mapper.afterSearch}}
   <button can-click="onSubmit" class="btn btn-small btn-info" {{#isLoading}}disabled="disabled"{{/isLoading}}>Search
   </button>
 </div>

--- a/src/ggrc/assets/mustache/modals/mapper/base.mustache
+++ b/src/ggrc/assets/mustache/modals/mapper/base.mustache
@@ -26,8 +26,9 @@
                   mapper="mapper"
                   is-loading="mapper.is_loading"
                   {(filter)}="mapper.filter"
-                  {(status-filter)}="mapper.statusFilter"
-                  (submit)="mapper.onToolbarSubmit()">
+                  (submit)="mapper.onToolbarSubmit()"
+                  total-objects="totalObjects"
+                  {(status-filter)}="mapper.statusFilter">
   </mapper-toolbar>
   <hr/>
   <mapper-results
@@ -41,8 +42,11 @@
     selected="mapper.selected"
     contact="mapper.contact"
     filter="mapper.filter"
-    status-filter="mapper.statusFilter"
-    submit-cbs="mapper.toolbarSubmitCbs">
+    scope-id="{{mapper.snapshot_scope_id}}"
+    scope-type="{{mapper.snapshot_scope_type}}"
+    submit-cbs="mapper.toolbarSubmitCbs"
+    {^paging.total}="totalObjects"
+    status-filter="mapper.statusFilter">
   </mapper-results>
   <div class="well well-small
               {{#mapper.afterSearch}}hidden{{/mapper.afterSearch}}">

--- a/src/ggrc/assets/stylesheets/components/unified-mapper/_unified-mapper-toolbar.scss
+++ b/src/ggrc/assets/stylesheets/components/unified-mapper/_unified-mapper-toolbar.scss
@@ -130,11 +130,8 @@ assessment-templates {
   justify-content: flex-end;
 
   button {
-    margin-bottom: 6px;
-
-    &:first-child {
-      margin-right: 10px;
-    }
+    margin-bottom: 0px;
+    margin-right: 10px;
 
     &.btn-draft {
       background-color: white;
@@ -216,6 +213,24 @@ relevant-filter {
       padding-right: 4px;
     }
 
+  }
+}
+
+.objects-found {
+  margin-right: 10px;
+  margin-bottom: 5px;
+  flex: 0 1;
+  white-space: nowrap;
+
+  label {
+    text-transform: uppercase;
+    font-size: 12px !important;
+    margin-bottom: 0 !important;
+    font-weight: 500;
+  }
+
+  &.loading {
+    opacity: .25;
   }
 }
 

--- a/src/ggrc/assets/stylesheets/components/unified-mapper/_unified-mapper.scss
+++ b/src/ggrc/assets/stylesheets/components/unified-mapper/_unified-mapper.scss
@@ -121,9 +121,15 @@ mapper-results {
         color: $black;
         border-bottom: 1px solid $items-separator-color;
 
-        &:first-child {
-          border-top: 1px solid $items-separator-color;
+        object-selection-item {
+          justify-content: flex-end;
+          width: $object-selection-item-width;
         }
+      }
+
+      object-list-item:first-child,
+      spinner + object-list-item {
+        border-top: 1px solid $items-separator-color;
       }
     }
   }
@@ -469,17 +475,6 @@ mapper-results-columns-configuration {
       border: none;
       background: transparent;
     }
-  }
-}
-
-.objects-found {
-  margin-bottom: 20px;
-
-  label {
-    text-transform: uppercase;
-    font-size: 12px !important;
-    margin-bottom: 0 !important;
-    font-weight: 500;
   }
 }
 

--- a/src/ggrc/assets/stylesheets/components/unified-mapper/_unified-mapper.scss
+++ b/src/ggrc/assets/stylesheets/components/unified-mapper/_unified-mapper.scss
@@ -291,6 +291,16 @@ mapper-results {
     }
   }
 
+  .no-items-spinner-wrapper {
+    display: flex;
+    justify-content: center;
+    height: 58px;
+
+    .spinner .fa {
+      font-size: 32px;
+      color: #444;
+    }
+  }
 
   &.snapshot-list {
     .list-object-item {


### PR DESCRIPTION
This PR moves total objects found next to the Search button. That also reduces modal height a bit.
Also fixes spinner issue: #GGRC-1061
And modal height issue: #GGRC-929