### PR TITLE
GGRC-921 Fix script error on audit summary

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/summary_widget_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/summary_widget_controller.js
@@ -41,7 +41,7 @@
     }
   }, {
     init: function () {
-      var that = this;
+      var frag;
       if (this.element.data('widget-view')) {
         this.options.widget_view = GGRC.mustache_path +
           this.element.data('widget-view');
@@ -61,10 +61,9 @@
           }
         }
       });
-      can.view(this.get_widget_view(this.element),
-        this.options.context, function (frag) {
-          that.element.html(frag);
-        });
+      frag = can.view(this.get_widget_view(this.element),
+                      this.options.context);
+      this.element.html(frag);
       return 0;
     },
     get_widget_view: function (el) {


### PR DESCRIPTION
**"Script error" message is displayed while moving to the audit page**

**Precondition**: 
Log as Global creator, create program, control, audit

**Steps to reproduce**:
1. Go to audit page: confirm an error is displayed

**Actual Result**: "Script error" message is displayed while moving to the audit page

**Expected Result**: no error displayed

**Note**: the issue is reproduced from case to case

![image](https://cloud.githubusercontent.com/assets/567805/22927737/0318c598-f2c4-11e6-8e18-210aa5000af0.png)

To catch the bug it necessary to refresh the page with Audit Summary and quickly switch to another tab in browser (as soon as audit summary page started loading)

![assessment-error](https://cloud.githubusercontent.com/assets/567805/22927775/3213a886-f2c4-11e6-8cb4-2280420e5f95.gif)

