### PR TITLE
GGRC-1160 Fix JS error on Mapper modal

### DIFF
--- a/src/ggrc/assets/javascripts/components/unified-mapper/mapper-results-columns-configuration.js
+++ b/src/ggrc/assets/javascripts/components/unified-mapper/mapper-results-columns-configuration.js
@@ -30,18 +30,27 @@
       initializeColumns: function () {
         var selectedColumns = can.makeArray(this.attr('selectedColumns'));
         var availableColumns = can.makeArray(this.attr('availableColumns'));
-        var self = this;
-        this.attr('columns', {});
+        var columns = new can.Map();
         availableColumns
           .forEach(function (attr) {
-            if (selectedColumns.some(function (selectedAttr) {
-              return selectedAttr.attr_name === attr.attr_name;
-            })) {
-              self.attr('columns.' + attr.attr_name, true);
-            } else {
-              self.attr('columns.' + attr.attr_name, false);
-            }
+            var value = {};
+            value[attr.attr_name] = selectedColumns
+              .some(function (selectedAttr) {
+                return selectedAttr.attr_name === attr.attr_name;
+              });
+            columns.attr(value);
           });
+        this.attr('columns', columns);
+      },
+      onSelect: function (attr) {
+        var columns = this.columns;
+        var value = {};
+        value[attr.attr_name] = !columns[attr.attr_name];
+        this.columns.attr(value);
+      },
+      isSelected: function (attr) {
+        var columns = this.attr('columns');
+        return columns[attr.attr_name];
       },
       setColumns: function () {
         var selectedNames = [];

--- a/src/ggrc/assets/javascripts/components/unified-mapper/mapper.js
+++ b/src/ggrc/assets/javascripts/components/unified-mapper/mapper.js
@@ -123,8 +123,7 @@
       if (this.attr('search_only')) {
         include = ['TaskGroupTask', 'TaskGroup',
           'CycleTaskGroupObjectTask'];
-      }
-      if (this.attr('assessmentGenerator')) {
+      } else {
         exclude = snapshots.inScopeModels;
       }
       return GGRC.Mappings

--- a/src/ggrc/assets/mustache/assessments/tree_add_item.mustache
+++ b/src/ggrc/assets/mustache/assessments/tree_add_item.mustache
@@ -21,25 +21,5 @@
       </a>
     {{/is_allowed_to_map}}
     {{/if}}
-  {{else}}
-    {{^if_instance_of parent_instance 'Assessment'}}
-      {{#if allow_mapping}}
-      {{#is_allowed_to_map parent_instance model.shortName}}
-        <a
-          class="section-add btn btn-mini action-button map-button"
-          href="javascript://"
-          rel="tooltip"
-          data-placement="left"
-          data-toggle="unified-mapper"
-          data-join-mapping="{{mapping}}"
-          data-join-option-type="{{model.shortName}}"
-          data-join-object-id="{{parent_instance.id}}"
-          data-join-object-type="{{parent_instance.class.shortName}}"
-          data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}>
-         Map
-        </a>
-      {{/is_allowed_to_map}}
-      {{/if}}
-    {{/if_instance_of}}
   {{/if_instance_of}}
 {{/if}}

--- a/src/ggrc/assets/mustache/base_objects/tree_add_item.mustache
+++ b/src/ggrc/assets/mustache/base_objects/tree_add_item.mustache
@@ -6,21 +6,22 @@
 {{#is_allowed_to_map parent_instance model.shortName}}
 {{#if allow_mapping_or_creating}}
   {{#if model.root_object}}
-  <a
-    class="btn btn-mini action-button map-button"
-    href="javascript://"
-    rel="tooltip"
-    data-placement="left"
-    data-toggle="unified-mapper"
-    data-join-mapping="{{mapping}}"
-    data-join-option-type="{{model.shortName}}"
-    data-join-object-id="{{instance.id}}"
-    data-join-object-type="{{parent_instance.class.shortName}}"
-    data-exclude-option-types="{{exclude_option_types}}"
-    data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}"
->
-    Map
-  </a>
+    {{^if_equals model.shortName 'Assessment'}}
+      <a
+        class="btn btn-mini action-button map-button"
+        href="javascript://"
+        rel="tooltip"
+        data-placement="left"
+        data-toggle="unified-mapper"
+        data-join-mapping="{{mapping}}"
+        data-join-option-type="{{model.shortName}}"
+        data-join-object-id="{{instance.id}}"
+        data-join-object-type="{{parent_instance.class.shortName}}"
+        data-exclude-option-types="{{exclude_option_types}}"
+        data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}">
+        Map
+      </a>
+    {{/if_equals}}
   {{#if null}}
   <span class="section-expander">
     <a href="javascript://"

--- a/src/ggrc/assets/mustache/components/unified-mapper/mapper-results-columns-configuration.mustache
+++ b/src/ggrc/assets/mustache/components/unified-mapper/mapper-results-columns-configuration.mustache
@@ -15,7 +15,8 @@
                  title="{{attr_title}}">
             <input type="checkbox"
                    {{#mandatory}}disabled{{/mandatory}}
-                   can-value="columns.{{attr_name}}"
+                   can-change="onSelect"
+                   {{#isSelected}}checked{{/isSelected}}
                    class="notify-wrap attr-checkbox
                    {{#mandatory}}mandatory{{/mandatory}}">
             {{attr_title}}

--- a/src/ggrc/assets/mustache/dashboard/internav_list.mustache
+++ b/src/ggrc/assets/mustache/dashboard/internav_list.mustache
@@ -85,11 +85,13 @@
               {{^is_dashboard_or_all}}
               {{#is_mappable_type instance.type model.shortName}}
               {{#is_allowed_to_map instance model.shortName}}
+              {{^if_equals model.shortName 'Assessment'}}
                 data-clickable="true"
                 data-toggle="unified-mapper"
                 data-join-option-type="{{model.shortName}}"
                 data-join-object-id="{{instance.id}}"
                 data-join-object-type="{{instance.class.shortName}}"
+              {{/if_equals}}
               {{/is_allowed_to_map}}
               {{/is_mappable_type}}
               {{/is_dashboard_or_all}}


### PR DESCRIPTION
**Steps to reproduce:**
1. Created a program
2. Create a control
3. Click map on the Control's first tier
4. Select Assessment in Unified mapper and Search: error is displayed

_Actual Result:_ "Uncaught TypeError: eventName.indexOf is not a function" occurs while Searching Assessments in Unified mapper
_Expected Result:_ no error displayed while searching assessments

**Note:** 
1. "Uncaught Error: can.Map: Object does not exist" if search "Products" in Unified mapper
2. "Uncaught Error: can.Map: Object does not exist" if search "Threats" in Unified mapper

**Result**
 - Assessments are hidden from the Mapper modal.
 - `can.Map: Object does not exist` error was reproduced for objects which have the CA with point in the name. - fixed



