### PR TITLE
GGRC-1150 Incorrect value in disabled field (Controls -> Asmt tab -> Click map in treeView)

### DIFF
--- a/src/ggrc/assets/javascripts/components/unified-mapper/mapper-results.js
+++ b/src/ggrc/assets/javascripts/components/unified-mapper/mapper-results.js
@@ -32,8 +32,6 @@
       allItems: [],
       allSelected: false,
       baseInstance: null,
-      scopeId: '@',
-      scopeType: '@',
       filter: '',
       selected: [],
       refreshItems: false,
@@ -99,21 +97,12 @@
         this.attr('relatedAssessments.show',
           !!Model.tree_view_options.show_related_assessments);
       },
-      setAdditionalScopeFilter: function () {
-        var id = this.attr('baseInstance.scopeObject.id');
-        var type = this.attr('baseInstance.scopeObject.type');
-        return {
-          type: type,
-          id: id
-        };
-      },
       onSearch: function () {
         this.attr('refreshItems', true);
       },
       prepareRelevantFilters: function () {
         var filters;
         var relevantList = this.attr('mapper.relevant');
-        var useSnapshots = this.useSnapshots();
 
         filters = relevantList.attr()
           .map(function (relevant) {
@@ -122,26 +111,13 @@
             }
             return {
               type: relevant.filter.type,
+              operation: 'relevant',
               id: Number(relevant.filter.id)
             };
           })
           .filter(function (item) {
             return item;
           });
-        // Filter by scope
-        if (useSnapshots) {
-          if (Number(this.attr('scopeId'))) {
-            filters.push({
-              type: this.attr('scopeType'),
-              id: Number(this.attr('scopeId'))
-            });
-          } else {
-            if (this.attr('baseInstance.scopeObject')) {
-              filters.push(this.setAdditionalScopeFilter());
-            }
-            return filters;
-          }
-        }
         return filters;
       },
       prepareBaseQuery: function (modelName, paging, filters, ownedFilter) {
@@ -158,7 +134,8 @@
             filter: this.attr('filter')
           }, {
             type: this.attr('baseInstance.type'),
-            id: this.attr('baseInstance.id')
+            id: this.attr('baseInstance.id'),
+            operation: 'relevant'
           }, [], ownedFilter);
       },
       prepareOwnedFilter: function () {
@@ -332,7 +309,7 @@
           });
         return dfd;
       },
-      setItemsDebounced() {
+      setItemsDebounced: function () {
         clearTimeout(this.attr('_setItemsTimeout'));
         this.attr('_setItemsTimeout', setTimeout(this.setItems.bind(this)));
       },

--- a/src/ggrc/assets/javascripts/components/unified-mapper/mapper.js
+++ b/src/ggrc/assets/javascripts/components/unified-mapper/mapper.js
@@ -68,9 +68,6 @@
     entries: [],
     options: [],
     relevant: [],
-    is_snapshotable: false,
-    snapshot_scope_id: '',
-    snapshot_scope_type: '',
     toolbarSubmitCbs: $.Callbacks(),
     afterSearch: false,
     allowedToCreate: function () {
@@ -224,10 +221,7 @@
           callback: parentScope.attr('callback'),
           useTemplates: parentScope.attr('useTemplates'),
           assessmentGenerator: parentScope.attr('assessmentGenerator'),
-          is_snapshotable: parentScope.attr('is_snapshotable'),
-          is_new: parentScope.attr('is_new'),
-          snapshot_scope_id: parentScope.attr('snapshot_scope_id'),
-          snapshot_scope_type: parentScope.attr('snapshot_scope_type')
+          is_new: parentScope.attr('is_new')
         })),
         template: parentScope.attr('template'),
         draw_children: true

--- a/src/ggrc/assets/javascripts/controllers/tree/tree-view-node.js
+++ b/src/ggrc/assets/javascripts/controllers/tree/tree-view-node.js
@@ -56,8 +56,7 @@
       }
     },
 
-    init: function (el, opts) {
-      var parent = opts.parent_instance || {};
+    init: function () {
       var options = this.options;
       if (options.instance && !options.show_view) {
         options.show_view =
@@ -71,11 +70,7 @@
         this.options.child_options.each(function (option) {
           option.attr({
             parent: this,
-            parent_instance: this.options.instance,
-            is_snapshotable:
-              GGRC.Utils.Snapshots.isSnapshotScope(parent),
-            snapshot_scope_id: parent.id,
-            snapshot_scope_type: parent.type
+            parent_instance: this.options.instance
           });
         }.bind(this));
       }

--- a/src/ggrc/assets/javascripts/models/mixins.js
+++ b/src/ggrc/assets/javascripts/models/mixins.js
@@ -173,11 +173,15 @@
 
   can.Model.Mixin('inScopeObjects', {}, {
     'after:info_pane_preload': function () {
+      return this.updateScopeObject();
+    },
+    updateScopeObject: function () {
       var objType = 'Audit';
       var queryType = 'ids';
       var query = GGRC.Utils.QueryAPI
         .buildRelevantIdsQuery(objType, {}, {
           type: this.attr('type'),
+          operation: 'relevant',
           id: this.attr('id')
         }, null);
       return GGRC.Utils.QueryAPI

--- a/src/ggrc/assets/mustache/assessments/tree_add_item.mustache
+++ b/src/ggrc/assets/mustache/assessments/tree_add_item.mustache
@@ -35,10 +35,7 @@
           data-join-option-type="{{model.shortName}}"
           data-join-object-id="{{parent_instance.id}}"
           data-join-object-type="{{parent_instance.class.shortName}}"
-          data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}"
-          data-is-snapshotable="{{is_snapshotable}}"
-          data-snapshot-scope-id="{{snapshot_scope_id}}"
-          data-snapshot-scope-type="{{snapshot_scope_type}}">
+          data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}>
          Map
         </a>
       {{/is_allowed_to_map}}

--- a/src/ggrc/assets/mustache/audits/tree_add_item.mustache
+++ b/src/ggrc/assets/mustache/audits/tree_add_item.mustache
@@ -34,9 +34,7 @@
         data-join-object-id="{{parent_instance.id}}"
         data-join-object-type="{{parent_instance.class.shortName}}"
         data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}"
-        data-is-snapshotable="{{is_snapshotable}}"
-        data-snapshot-scope-id="{{snapshot_scope_id}}"
-        data-snapshot-scope-type="{{snapshot_scope_type}}">
+      >
         Map
       </a>
     {{/if}}

--- a/src/ggrc/assets/mustache/base_objects/tree_add_item.mustache
+++ b/src/ggrc/assets/mustache/base_objects/tree_add_item.mustache
@@ -18,9 +18,7 @@
     data-join-object-type="{{parent_instance.class.shortName}}"
     data-exclude-option-types="{{exclude_option_types}}"
     data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}"
-    data-is-snapshotable="{{parent_instance.is_snapshotable}}"
-    data-snapshot-scope-id="{{parent_instance.scopeObject.id}}"
-    data-snapshot-scope-type="{{parent_instance.scopeObject.type}}">
+>
     Map
   </a>
   {{#if null}}
@@ -53,9 +51,7 @@
     data-exclude-option-types="{{exclude_option_types}}"
     data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}"
     data-object-params='{ "section": { "id": {{parent_instance.id}}, "title": "{{json_escape parent_instance.title}}", "description": "{{json_escape parent_instance.description}}" } }'
-    data-is-snapshotable="{{parent_instance.is_snapshotable}}"
-    data-snapshot-scope-id="{{parent_instance.scopeObject.id}}"
-    data-snapshot-scope-type="{{parent_instance.scopeObject.type}}">
+>
     Map
   </a>
   {{else}}
@@ -70,9 +66,7 @@
     data-join-object-type="{{parent_instance.class.shortName}}"
     data-exclude-option-types="{{exclude_option_types}}"
     data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}"
-    data-is-snapshotable="{{is_snapshotable}}"
-    data-snapshot-scope-id="{{snapshot_scope_id}}"
-    data-snapshot-scope-type="{{snapshot_scope_type}}">
+>
     Map
   </a>
   {{/if_instance_of}}

--- a/src/ggrc/assets/mustache/components/assessment/mapped-objects/mapped-controls.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/mapped-objects/mapped-controls.mustache
@@ -15,9 +15,7 @@
          data-join-object-id="{{instance.id}}"
          data-join-object-type="{{instance.class.shortName}}"
          data-original-title="Map {{firstnonempty mappingType 'Object'}} to this {{firstnonempty instance.class.title_singular 'Object'}}"
-         data-is-snapshotable="{{scopeObject.is_snapshotable}}"
-         data-snapshot-scope-id="{{scopeObject.id}}"
-         data-snapshot-scope-type="{{scopeObject.type}}">
+ >
       </i>
   {{/is_allowed}}
 </div>

--- a/src/ggrc/assets/mustache/components/assessment/mapped-objects/mapped-related-information.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/mapped-objects/mapped-related-information.mustache
@@ -14,9 +14,7 @@
          data-join-object-id="{{instance.id}}"
          data-join-object-type="{{instance.class.shortName}}"
          data-original-title="Map {{firstnonempty mappingType 'Object'}} to this {{firstnonempty instance.class.title_singular 'Object'}}"
-         data-is-snapshotable="{{scopeObject.is_snapshotable}}"
-         data-snapshot-scope-id="{{scopeObject.id}}"
-         data-snapshot-scope-type="{{scopeObject.type}}">
+ >
       </i>
   {{/is_allowed}}
 </collapsible-panel-header>

--- a/src/ggrc/assets/mustache/documents/tree_add_item.mustache
+++ b/src/ggrc/assets/mustache/documents/tree_add_item.mustache
@@ -16,9 +16,7 @@
     data-join-object-id="{{parent_instance.id}}"
     data-join-object-type="{{parent_instance.class.shortName}}"
     data-original-title="{{#if_equals model.title_singular 'Reference'}}Link non-GGRC URLs as References{{else}}Map {{firstnonempty title_singular model.title_singular 'Object'}}{{/if_equals}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}"
-    data-is-snapshotable="{{parent_instance.is_snapshotable}}"
-    data-snapshot-scope-id="{{parent_instance.scopeObject.id}}"
-    data-snapshot-scope-type="{{parent_instance.scopeObject.type}}">
+>
       Map
   </a>
 {{/is_allowed_to_map}}

--- a/src/ggrc/assets/mustache/modals/mapper/base.mustache
+++ b/src/ggrc/assets/mustache/modals/mapper/base.mustache
@@ -40,8 +40,6 @@
     selected="mapper.selected"
     contact="mapper.contact"
     filter="mapper.filter"
-    scope-id="{{mapper.snapshot_scope_id}}"
-    scope-type="{{mapper.snapshot_scope_type}}"
     submit-cbs="mapper.toolbarSubmitCbs">
   </mapper-results>
   <div class="well well-small

--- a/src/ggrc/assets/mustache/modals/mapper/component.mustache
+++ b/src/ggrc/assets/mustache/modals/mapper/component.mustache
@@ -11,8 +11,5 @@
     object="{{object}}"
     type="{{type}}"
     join-object-id="{{join-object-id}}"
-    is_snapshotable="{{is_snapshotable}}"
-    snapshot_scope_id="{{snapshot_scope_id}}"
-    snapshot_scope_type="{{snapshot_scope_type}}"
 >
 </modal-mapper>

--- a/src/ggrc/assets/mustache/snapshots/tree_add_item.mustache
+++ b/src/ggrc/assets/mustache/snapshots/tree_add_item.mustache
@@ -16,10 +16,7 @@
     data-join-object-id="{{parent_instance.id}}"
     data-join-object-type="{{parent_instance.class.shortName}}"
     data-exclude-option-types="{{exclude_option_types}}"
-    data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}"
-    data-is-snapshotable="{{parent_instance.is_snapshotable}}"
-    data-snapshot-scope-id="{{parent_instance.scopeObject.id}}"
-    data-snapshot-scope-type="{{parent_instance.scopeObject.type}}">
+    data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}">
       Map
   </a>
 {{/if}}


### PR DESCRIPTION
As right now we use default `relevantTo` read-only property to define Snapshot Scope Object it causes regressions still using this references in the Unified Mapper Component and Tree View