### PR TITLE
QUICK-FIX Fix Access Group's Mapper modal

### DIFF
--- a/src/ggrc/assets/javascripts/components/mapping-controls/mapping-type-selector.js
+++ b/src/ggrc/assets/javascripts/components/mapping-controls/mapping-type-selector.js
@@ -12,15 +12,24 @@
       GGRC.mustache_path +
       '/components/mapping-controls/mapping-type-selector.mustache'
     ),
-    scope: {
+    viewModel: {
       disabled: false,
       readonly: false,
       types: [],
       selectedType: ''
     },
-    events: {
-      init: function () {
-        // We might need to add some specific logic for disabled/enable DropDown items
+    init: function () {
+      var selectedType = this.viewModel.selectedType;
+      var types = this.viewModel.types;
+      var groups = ['business', 'entities', 'governance'];
+      var values = [];
+
+      groups.forEach(function (name) {
+        var groupItems = types.attr(name + '.items');
+        values = values.concat(_.pluck(groupItems, 'value'));
+      });
+      if (values.indexOf(selectedType) < 0) {
+        this.viewModel.attr('selectedType', values[0]);
       }
     }
   });


### PR DESCRIPTION
**Steps for reproduce:**
 - open Access Group tab
 - click `Map` button in tree view
 - make sure that Object Type dropdown is empty
 - click on `Search` or `Create` button

_Actual result:_ JS error
_Expected result:_ Object Type dropdown shouldn't be empty