### PR TITLE
GGRC-1180 Fix error with cache in unified mapper

### DIFF
--- a/src/ggrc/assets/javascripts/components/relevant_filters.js
+++ b/src/ggrc/assets/javascripts/components/relevant_filters.js
@@ -63,7 +63,7 @@
       setRelevant: function () {
         this.scope.attr('relevant').replace([]);
         can.each(this.scope.attr('relevantTo') || [], function (item) {
-          var model = CMS.Models[item.type].cache[item.id];
+          var model = new CMS.Models[item.type](item);
           this.scope.attr('relevant').push({
             readOnly: item.readOnly,
             value: true,


### PR DESCRIPTION
**"Uncaught TypeError: Cannot read property 'constructor' of undefined" error is displayed if click map button on the assessment's first tier** 

**Steps to reproduce**:
1. Go to My Work page
2. Assessments tab
3. Click map button on the first tier: error is displayed

**Actual Result**: "Uncaught TypeError: Cannot read property 'constructor' of undefined" error is displayed if click map button on the assessment's first tier 

**Expected Result**: no error is shown. Unified mapper is displayed.

![image](https://cloud.githubusercontent.com/assets/567805/22974458/76eeebe4-f393-11e6-891c-35af5fb9bdc0.png)
