### PR TITLE
GGRC-727 Custom attributes for two word objects

### DIFF
--- a/src/ggrc/models/mixins/customattributable.py
+++ b/src/ggrc/models/mixins/customattributable.py
@@ -419,7 +419,7 @@ class CustomAttributable(object):
       # fetch definitions form database because `self.custom_attribute`
       # may not be populated
       defs = CustomAttributeDefinition.query.filter(
-          CustomAttributeDefinition.definition_type == self.type,
+          CustomAttributeDefinition.definition_type == self._inflector.table_singular,  # noqa # pylint: disable=protected-access
           CustomAttributeDefinition.id.in_([
               value.custom_attribute_id
               for value in self.custom_attribute_values

--- a/test/integration/ggrc/models/test_snapshot.py
+++ b/test/integration/ggrc/models/test_snapshot.py
@@ -107,7 +107,15 @@ class TestSnapshot(TestCase):
   @staticmethod
   def _create_cas():
     """Create custom attribute definitions."""
-    ca_model_names = ["facility", "control", "market", "section", "threat"]
+    ca_model_names = [
+        "facility",
+        "control",
+        "market",
+        "section",
+        "threat",
+        "access_group",
+        "data_asset"
+    ]
     ca_args = [
         {"title": "CA text", "attribute_type": "Text"},
         {"title": "CA rich text", "attribute_type": "Rich Text"},

--- a/test/integration/ggrc/models/test_snapshot.py
+++ b/test/integration/ggrc/models/test_snapshot.py
@@ -5,30 +5,13 @@
 
 from ggrc.app import app
 from ggrc.models import all_models
+from ggrc.snapshotter.rules import Types
 from integration.ggrc import TestCase
 from integration.ggrc.models import factories
 
-TEST_MODELS = [
-    all_models.Facility,
-    all_models.AccessGroup,
-    all_models.Clause,
-    all_models.Contract,
-    all_models.Control,
-    all_models.DataAsset,
-    all_models.Market,
-    all_models.Objective,
-    all_models.OrgGroup,
-    all_models.Policy,
-    all_models.Process,
-    all_models.Product,
-    all_models.Regulation,
-    all_models.Risk,
-    all_models.Section,
-    all_models.Standard,
-    all_models.System,
-    all_models.Threat,
-    all_models.Vendor,
-]
+
+def get_snapshottable_models():
+  return {getattr(all_models, stype) for stype in Types.all}
 
 
 class TestSnapshot(TestCase):
@@ -202,7 +185,8 @@ class TestSnapshot(TestCase):
     created from a snapshot on the fronend, it will have all the needed fields.
     """
     self.client.get("/login")
-    for model in TEST_MODELS:
+    test_models = get_snapshottable_models()
+    for model in test_models:
       obj = model.eager_query().first()
       generated_json = self._clean_json(obj.log_json())
       expected_json = self._clean_json(self._get_object(obj))

--- a/test/integration/ggrc/models/test_snapshot.py
+++ b/test/integration/ggrc/models/test_snapshot.py
@@ -138,8 +138,8 @@ class TestSnapshot(TestCase):
 
   def _get_object(self, obj):
     return self.client.get(
-        "/api/{}/{}".format(obj._inflector.table_plural, obj.id)
-    ).json[obj._inflector.table_singular]
+        "/api/{}/{}".format(obj._inflector.table_plural, obj.id)  # noqa # pylint: disable=protected-access
+    ).json[obj._inflector.table_singular]  # noqa # pylint: disable=protected-access
 
   def _clean_json(self, content):
     """Remove ignored items from JSON content.

--- a/test/integration/ggrc/test_csvs/all_snapshottable_objects.csv
+++ b/test/integration/ggrc/test_csvs/all_snapshottable_objects.csv
@@ -1,8 +1,9 @@
 Object type,"Use this db for custom attribute definitions
 https://gist.github.com/zidarsk8/c6335d961a7004b9f896a3e4b1db8a8b",,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Access Group,Code*,Title*,Description,Notes,,Owner*,Effective Date,Stop Date,State,Primary Contact,Secondary Contact,Access Group URL,Reference URL,,,,,,,,,,,,,Delete,,,,,,,,map:assessment,map:audit,map:clause,map:contract,map:control,map:cycle task group object task,map:data asset,map:facility,map:issue,map:market,map:objective,map:org group,map:person,map:policy,map:process,map:product,map:program,map:project,map:regulation,map:risk,map:section,map:standard,map:system,map:threat,map:vendor
+Access Group,Code*,Title*,Description,Notes,,Owner*,Effective Date,Stop Date,State,Primary Contact,Secondary Contact,Access Group URL,Reference URL,,,,,,,,,,,,,Delete,CA date,CA dropdown,CA text,CA rich text,CA checkbox,CA person,,map:assessment,map:audit,map:clause,map:contract,map:control,map:cycle task group object task,map:data asset,map:facility,map:issue,map:market,map:objective,map:org group,map:person,map:policy,map:process,map:product,map:program,map:project,map:regulation,map:risk,map:section,map:standard,map:system,map:threat,map:vendor
 ,Access Group code,Access Group title,Access Group description,Access Group notes,,"user@example.com
-user1@example.com",20/2/2020,22/2/2022,Draft,user2@example.com,user3@example.com,http://url.example.zzz,reference.example.zzz,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+user1@example.com",20/2/2020,22/2/2022,Draft,user2@example.com,user3@example.com,http://url.example.zzz,reference.example.zzz,,,,,,,,,,,,,,22/2/2022,thREE,Access group ca text,"access group<br><br>
+rich text",yes,user4@example.com,,,,,,,,,,,,,,,,,,,,,,,,,,
 ,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Object type,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Clause,Code*,Title*,Text of Clause,Notes,,Owner*,Effective Date,Stop Date,State,Primary Contact,Secondary Contact,Clause URL,Reference URL,,,,,,,,,,,,,Delete,,,,,,,map:access group,map:assessment,map:audit,,map:contract,map:control,map:cycle task group object task,map:data asset,map:facility,map:issue,map:market,map:objective,map:org group,map:person,map:policy,map:process,map:product,map:program,map:project,map:regulation,map:risk,map:section,map:standard,map:system,map:threat,map:vendor
@@ -23,9 +24,10 @@ Data Centers",yes,non-key,corrective,physical,user3@example.com,user4@example.co
 rich text",yes,user4@example.com,,,,,,,,,,,,,,,,,,,,,,,,,,
 ,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Object type,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Data Asset,Code*,Title*,Description,Notes,,Owner*,Effective Date,Stop Date,State,Primary Contact,Secondary Contact,Data Asset URL,Reference URL,,,,,,,,,,,,,Delete,,,,,,,map:access group,map:assessment,map:audit,map:clause,map:contract,map:control,map:cycle task group object task,map:data asset,map:facility,map:issue,map:market,map:objective,map:org group,map:person,map:policy,map:process,map:product,map:program,map:project,map:regulation,map:risk,map:section,map:standard,map:system,map:threat,map:vendor
+Data Asset,Code*,Title*,Description,Notes,,Owner*,Effective Date,Stop Date,State,Primary Contact,Secondary Contact,Data Asset URL,Reference URL,,,,,,,,,,,,,Delete,CA date,CA dropdown,CA text,CA rich text,CA checkbox,CA person,map:access group,map:assessment,map:audit,map:clause,map:contract,map:control,map:cycle task group object task,map:data asset,map:facility,map:issue,map:market,map:objective,map:org group,map:person,map:policy,map:process,map:product,map:program,map:project,map:regulation,map:risk,map:section,map:standard,map:system,map:threat,map:vendor
 ,Data Assest code,Data Assest title,Data Assest description,Data Assest notes,,"user@example.com
-user1@example.com",20/2/2020,22/2/2022,Draft,user2@example.com,user3@example.com,http://url.example.zzz,reference.example.zzz,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+user1@example.com",20/2/2020,22/2/2022,Draft,user2@example.com,user3@example.com,http://url.example.zzz,reference.example.zzz,,,,,,,,,,,,,,22/2/2022,tWo,DATA ASSET ca text,"data asset<br><br>
+rich text",yes,user4@example.com,,,,,,,,,,,,,,,,,,,,,,,,,,
 ,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Object type,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Facility,Code*,Title*,Description,Notes,,Owner*,Effective Date,Stop Date,State,Primary Contact,Secondary Contact,Facility URL,Reference URL,,,,,,,,,,,,,Delete,CA date,CA dropdown,CA text,CA rich text,CA checkbox,CA person,map:access group,map:assessment,map:audit,map:clause,map:contract,map:control,map:cycle task group object task,map:data asset,map:facility,map:issue,map:market,map:objective,map:org group,map:person,map:policy,map:process,map:product,map:program,map:project,map:regulation,map:risk,map:section,map:standard,map:system,map:threat,map:vendor


### PR DESCRIPTION
We didn't properly store custom attribute definitions in revisions of two-word objects (Access Groups and Data Assets) which resulted in snapshots not showing any custom attributes for those objects.

To reproduce: have custom attributes on two-word objects, create program with those objects in program scope, create audit, visit snapshots of two-word objects.

To see changes you will have to re-index revisions (run `$.post("/admin/refresh_revisions");` in console).