### PR TITLE
GGRC-944 GGRC-1050 Filter is not working correctly for CAs for the snapshots

### DIFF
--- a/src/ggrc/fulltext/mysql.py
+++ b/src/ggrc/fulltext/mysql.py
@@ -30,6 +30,7 @@ class MysqlRecordProperty(db.Model):
   context_id = db.Column(db.Integer)
   tags = db.Column(db.String)
   property = db.Column(db.String(64), primary_key=True)
+  subproperty = db.Column(db.String(64), primary_key=True)
   content = db.Column(db.Text)
 
   @declared_attr

--- a/src/ggrc/fulltext/sql.py
+++ b/src/ggrc/fulltext/sql.py
@@ -3,19 +3,23 @@
 
 from ggrc import db
 from ggrc.fulltext import Indexer
+from ggrc.utils import benchmark
 
 
 class SqlIndexer(Indexer):
   def create_record(self, record, commit=True):
-    for k, v in record.properties.items():
-      db.session.add(self.record_type(
-          key=record.key,
-          type=record.type,
-          context_id=record.context_id,
-          tags=record.tags,
-          property=k,
-          content=v,
-      ))
+    with benchmark("Add fulltext records: create_record -> submit to db"):
+      for prop, value in record.properties.items():
+        for subproperty, content in value.items():
+          db.session.add(self.record_type(
+              key=record.key,
+              type=record.type,
+              context_id=record.context_id,
+              tags=record.tags,
+              property=prop,
+              subproperty=subproperty,
+              content=content,
+          ))
     if commit:
       db.session.commit()
 

--- a/src/ggrc/migrations/versions/20170214101700_ff4ebc0d89c_add_column_to_fulltext_records_table.py
+++ b/src/ggrc/migrations/versions/20170214101700_ff4ebc0d89c_add_column_to_fulltext_records_table.py
@@ -1,0 +1,45 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Add 'subproperty' column into 'fulltext_record_properties' table to make
+search by property subtype bypossible.
+
+For example:
+We have two subtypes of the property Person:
+- name
+- email
+
+Create Date: 2017-02-14 10:17:00.155675
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '5335453abae'
+down_revision = '341f8a645b2f'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  op.add_column('fulltext_record_properties',
+                sa.Column('subproperty', mysql.VARCHAR(length=64),
+                          nullable=False, server_default=''))
+  op.execute("""
+      ALTER TABLE fulltext_record_properties
+      DROP PRIMARY KEY,
+      ADD PRIMARY KEY (`key`, `type`, property, subproperty);
+  """)
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  op.execute("""
+      TRUNCATE TABLE fulltext_record_properties;
+  """)
+  op.drop_column('fulltext_record_properties', 'subproperty')

--- a/test/integration/ggrc/services/test_query.py
+++ b/test/integration/ggrc/services/test_query.py
@@ -595,6 +595,11 @@ class TestQueryWithCA(BaseQueryAPITestCase):
         definition_type="program",
         attribute_type="Date",
     )
+    factories.CustomAttributeDefinitionFactory(
+        title="CA person",
+        definition_type="program",
+        attribute_type="Map:Person",
+    )
     # local CADs for the Assessments
     for title in ["Date or arbitrary text", "Date or text styled as date"]:
       factories.CustomAttributeDefinitionFactory(
@@ -694,6 +699,17 @@ class TestQueryWithCA(BaseQueryAPITestCase):
     titles = [prog["title"] for prog in programs]
     self.assertItemsEqual(titles, ("F", "H", "J", "B", "D"))
     self.assertEqual(len(programs), 5)
+
+  def test_ca_filter_by_person(self):
+    """Test CA person fields filtering by = operator."""
+    programs = self._get_first_result_set(
+        self._make_query_dict("Program",
+                              expression=["ca person", "=", "three"]),
+        "Program", "values",
+    )
+    titles = [prog["title"] for prog in programs]
+    self.assertItemsEqual(titles, ("F",))
+    self.assertEqual(len(programs), 1)
 
   def test_ca_query_lt(self):
     """Test CA date fields filtering by < operator."""

--- a/test/integration/ggrc/test_csvs/sorting_with_ca_setup.csv
+++ b/test/integration/ggrc/test_csvs/sorting_with_ca_setup.csv
@@ -1,55 +1,55 @@
-Object type,,,,,,,,,,,,,,,
-program,code*,title*,description ,Manager,state,primary contact,effective date,stop date,notes,program url,reference url,editor,CA text,CA date,CA dropdown
+Object type,,,,,,,,,,,,,,,,
+program,code*,title*,description ,Manager,state,primary contact,effective date,stop date,notes,program url,reference url,editor,CA text,CA date,CA dropdown,CA person
 ,prog-1,F,2,"anze@example.com
 albert@example.com
 tommy@example.com",Draft,anze@example.com,1/6/2016,1/19/2016,3,http://google.com/_1,http://google.com/_2,"anze@example.com
 albert@example.com
-tommy@example.com",B,05/18/2015,one
+tommy@example.com",B,05/18/2015,one,anze@example.com
 ,prog-2,G,2,"miha@example.com
 rob@example.com
 ken@example.com",Active,albert@example.com,1/7/2016,1/18/2016,2,http://google.com/_2,http://google.com/_3,"miha@example.com
 rob@example.com
-ken@example.com",B,05/17/2015,two
+ken@example.com",B,05/17/2015,two,albert@example.com
 ,prog-3,H,2,"user@example.com
 anze@example.com
 miha@example.com",Active,tommy@example.com,1/8/2016,1/17/2016,1,http://google.com/_3,http://google.com/_4,"user@example.com
 anze@example.com
-miha@example.com",A,05/18/2015,two
+miha@example.com",A,05/18/2015,two,tommy@example.com
 ,prog-4,I,3,"anze@example.com
 albert@example.com
 tommy@example.com",Active,miha@example.com,1/9/2016,1/16/2016,2,http://google.com/_4,http://google.com/_5,"anze@example.com
 albert@example.com
-tommy@example.com",A,12/31/2014,one
+tommy@example.com",A,12/31/2014,one,
 ,prog-5,J,3,"miha@example.com
 rob@example.com
 ken@example.com",Active,anze@example.com,1/10/2016,1/15/2016,1,http://google.com/_5,http://google.com/_6,"miha@example.com
 rob@example.com
-ken@example.com",D,05/18/2015,three
+ken@example.com",D,05/18/2015,three,
 ,prog-6,A,3,"user@example.com
 anze@example.com
 miha@example.com",Draft,albert@example.com,1/1/2016,1/14/2016,5,http://google.com/_6,http://google.com/_7,"user@example.com
 anze@example.com
-miha@example.com",D,01/01/2016,four
+miha@example.com",D,01/01/2016,four,
 ,prog-7,B,1,"anze@example.com
 albert@example.com
 tommy@example.com",Active,tommy@example.com,1/2/2016,1/13/2016,5,http://google.com/_7,http://google.com/_8,"anze@example.com
 albert@example.com
-tommy@example.com",E,05/18/2015,one
+tommy@example.com",E,05/18/2015,one,
 ,prog-8,C,1,"miha@example.com
 rob@example.com
 ken@example.com",Draft,miha@example.com,1/3/2016,1/12/2016,3,http://google.com/_8,http://google.com/_9,"miha@example.com
 rob@example.com
-ken@example.com",E,10/18/2015,two
+ken@example.com",E,10/18/2015,two,
 ,prog-9,D,1,"user@example.com
 anze@example.com
 miha@example.com",Deprecated,rob@example.com,1/4/2016,1/11/2016,1,http://google.com/_9,http://google.com/_10,"user@example.com
 anze@example.com
-miha@example.com",A,05/18/2015,four
+miha@example.com",A,05/18/2015,four,
 ,prog-10,E,1,"anze@example.com
 albert@example.com
 tommy@example.com",Draft,ken@example.com,1/5/2016,1/10/2016,2,http://google.com/_10,http://google.com/_11,"anze@example.com
 albert@example.com
-tommy@example.com",J,05/19/2015,five
+tommy@example.com",J,05/19/2015,five,
 ,,,,,,,,,,,,,,,
 Object type,,,,,,,,,,,,,,,
 Assessment,audit*,code*,Date or arbitrary text,Date or text styled as date,,,,,,,,,,,


### PR DESCRIPTION
This PS covers also GGRC-1050 "Filter doesn't work for "Person" GCA"

Precondition:
Created GCA field for control (e.g. person, date, text, dropdown types), program, at least two controls with the value in GCA field with date type, audit
Steps to reproduce:
1. Go to audit page-> Control's tab
2. Filter control by the value in GCA field from precondition (e.g. GCA = "1/27/2017"): no result
3. Create Assessment template with LCA (e.g. Person type) and Generate Assessment based on the control and Assessment template
4. Go to Assessment and try to filter by the value in LCA (Person type): no result
Actual Result: Filter is not working correctly for CAs for the snapshots
Expected Result: Filter is working correctly for snapshots on Audit page (by values in GCA, dates, person and etc. using <,>,,=, !=, !)