### PR TITLE
GGRC-1074 Add default Assessment notification settings

### DIFF
--- a/src/ggrc/migrations/versions/20170215144723_2f1cee67a8f3_add_default_assessment_notifications_.py
+++ b/src/ggrc/migrations/versions/20170215144723_2f1cee67a8f3_add_default_assessment_notifications_.py
@@ -1,0 +1,68 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Add default Assessment notifications settings.
+
+Create Date: 2017-02-15 14:47:23.772467
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+from alembic import op
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+
+# revision identifiers, used by Alembic.
+revision = "2f1cee67a8f3"
+down_revision = "1e65abd56ccb"
+
+
+def upgrade():
+  """Enable sending Assessment comment notifications by default.
+
+  The notifications should (by default) be sent to all people roles assigned
+  to a particular Assessment.
+  """
+  sql = """
+    UPDATE assessments
+    SET send_by_default = 1
+    WHERE send_by_default IS NULL
+  """
+  op.execute(sql)
+
+  sql = """
+    UPDATE assessments
+    SET recipients = "Assessor,Creator,Verifier"
+    WHERE recipients IS NULL
+  """
+  op.execute(sql)
+
+  op.alter_column(
+      "assessments", "send_by_default",
+      server_default=u"1",
+      existing_type=sa.Integer(),
+      existing_nullable=True)
+
+  op.alter_column(
+      "assessments", "recipients",
+      server_default=u"Assessor,Creator,Verifier",
+      existing_type=mysql.VARCHAR(length=250),
+      existing_nullable=True)
+
+
+def downgrade():
+  """Remove default settings for Assessment comment notifications."""
+  op.alter_column(
+      "assessments", "send_by_default",
+      server_default=None,
+      existing_type=sa.Integer(),
+      existing_nullable=True)
+
+  op.alter_column(
+      "assessments", "recipients",
+      server_default=None,
+      existing_type=mysql.VARCHAR(length=250),
+      existing_nullable=True)

--- a/src/ggrc/models/comment.py
+++ b/src/ggrc/models/comment.py
@@ -67,8 +67,12 @@ class Commentable(object):
                        ', '.join(sorted(self.VALID_RECIPIENTS))
                        )
 
-  recipients = db.Column(db.String, nullable=True)
-  send_by_default = db.Column(db.Boolean)
+  recipients = db.Column(
+      db.String,
+      nullable=True,
+      default=u"Assessor,Creator,Verifier")
+
+  send_by_default = db.Column(db.Boolean, nullable=True, default=True)
 
   _publish_attrs = [
       "recipients",

--- a/test/integration/ggrc/converters/test_import_assessments.py
+++ b/test/integration/ggrc/converters/test_import_assessments.py
@@ -4,7 +4,12 @@
 # pylint: disable=maybe-no-member, invalid-name
 
 """Test request import and updates."""
+
+import csv
+
 from collections import OrderedDict
+from cStringIO import StringIO
+from itertools import izip
 
 from flask.json import dumps
 
@@ -326,9 +331,12 @@ class TestAssessmentExport(TestCase):
         },
     }]
     response = self.export_csv(data)
-    raw_data = response.data.strip().split("\n")[4:6]
-    keys, vals = raw_data
-    instance_dict = dict(zip(keys.split(","), vals.split(",")))
+
+    keys, vals = response.data.strip().split("\n")[4:6]
+    keys = next(csv.reader(StringIO(keys), delimiter=","), [])
+    vals = next(csv.reader(StringIO(vals), delimiter=","), [])
+    instance_dict = dict(izip(keys, vals))
+
     self.assertEqual(value, instance_dict[column])
 
   def test_export_assesments_without_map_control(self):

--- a/test/integration/ggrc/models/test_assessment.py
+++ b/test/integration/ggrc/models/test_assessment.py
@@ -8,9 +8,21 @@ from integration.ggrc.models.factories import AssessmentFactory
 
 
 class TestAssessment(TestCase):
+  # pylint: disable=invalid-name
 
   def test_auto_slug_generation(self):
     AssessmentFactory(title="Some title")
     db.session.commit()
     ca = Assessment.query.first()
     self.assertEqual("ASSESSMENT-{}".format(ca.id), ca.slug)
+
+  def test_enabling_comment_notifications_by_default(self):
+    """New Assessments should have comment notifications enabled by default."""
+    AssessmentFactory()
+    db.session.commit()
+
+    asmt = Assessment.query.first()
+
+    self.assertTrue(asmt.send_by_default)
+    recipients = asmt.recipients.split(",") if asmt.recipients else []
+    self.assertEqual(sorted(recipients), ["Assessor", "Creator", "Verifier"])


### PR DESCRIPTION
This is a follow-up to #5107 that synchronizes the default Assessment notification settings when using imports with how the Assessment's "Create new" modal behaves.

**Steps to verify:**
 - Go to the `/import` page and download the Assessment import template (or use an existing one)
 - Fill in the required fields in the downloaded template, make sure to leave the `Code`, `Recipients`, and `Send by default` columns blank.
 - Import the template, a new Assessment should get created
 - Open the created Assessment in the application, open a modal to edit it

**Expected result:**
Look at the "Enable notifications on comments" checkbox group - all checkboxes should be checked, just like they are checked when opening a modal to create a new Assessment.
Also, on that Assessment's info pane, the "Send Notifications" checkbox under the Add Comment rich text area should be checked.

