### PR TITLE
QUICK-FIX Merge release/0.10-Raspberry into develop

### DIFF
--- a/src/ggrc/migrations/versions/20170104100418_4aa9f2ee7969_reattach_urls_evidences_from_comments_.py
+++ b/src/ggrc/migrations/versions/20170104100418_4aa9f2ee7969_reattach_urls_evidences_from_comments_.py
@@ -13,7 +13,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '4aa9f2ee7969'
-down_revision = '562ec606ff7c'
+down_revision = '57940269e30'
 
 
 def upgrade():

--- a/src/ggrc/migrations/versions/20170130060409_57940269e30_migrate_requests_change_logs.py
+++ b/src/ggrc/migrations/versions/20170130060409_57940269e30_migrate_requests_change_logs.py
@@ -1,0 +1,34 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Migrate requests change logs
+
+Create Date: 2017-01-30 06:04:09.538516
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '57940269e30'
+down_revision = '562ec606ff7c'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  op.execute("""
+      update revisions
+             join requests on revisions.resource_type = 'Request' and
+                              revisions.resource_id = requests.id
+             join assessments on requests.slug = assessments.slug
+      set resource_type = 'Assessment',
+          resource_id = assessments.id
+  """)
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  pass


### PR DESCRIPTION
Since merged release branch into develop, all migrations that were added
to develop branch must now be applied on top of any migration in the
release branch.

**Note: before merging this into develop!**
The grc-dev database needs to be reverted to the state before the
"reattach urls evidences from comments" migration was run.