### PR TITLE
GGRC-1154 Add empty message in related assessments

### DIFF
--- a/src/ggrc/assets/javascripts/components/object-list/object-list.js
+++ b/src/ggrc/assets/javascripts/components/object-list/object-list.js
@@ -26,6 +26,7 @@
           value: ''
         }
       },
+      emptyMessage: '@',
       isLoading: false,
       selectedItem: {},
       items: [],

--- a/src/ggrc/assets/mustache/assessments/related-assessments-without-reuse.mustache
+++ b/src/ggrc/assets/mustache/assessments/related-assessments-without-reuse.mustache
@@ -30,7 +30,8 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
         </div>
     </div>
     <div class="grid-data-body {{#if isLoading}}loading{{/if}}">
-        <object-list items="relatedObjects" is-loading="isLoading" spinner-css="grid-spinner">
+        <object-list items="relatedObjects" is-loading="isLoading" spinner-css="grid-spinner"
+                     empty-message="No Related Assessments were found">
             <div class="grid-data-row flex-row flex-box">
                 <div class="grid-data-item-index">
                     <state-colors-map state="status"></state-colors-map>

--- a/src/ggrc/assets/mustache/assessments/related-assessments.mustache
+++ b/src/ggrc/assets/mustache/assessments/related-assessments.mustache
@@ -43,7 +43,8 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
         </div>
           <div class="grid-data-body {{#if isLoading}}loading{{/if}}">
             <object-list items="relatedObjects" is-loading="isLoading" spinner-css="grid-spinner" selected-item="selectedItem"
-                         object-list-item-selector="objectSelectorEl">
+                         object-list-item-selector="objectSelectorEl"
+                         empty-message="No Related Assessments were found">
                 <div class="grid-data-row flex-row flex-box">
                     <div class="grid-data-item-index">
                       <state-colors-map state="status"></state-colors-map>

--- a/src/ggrc/assets/mustache/components/object-list/object-list.mustache
+++ b/src/ggrc/assets/mustache/components/object-list/object-list.mustache
@@ -4,6 +4,10 @@
 }}
 {{#if isLoading}}
     <spinner toggle="isLoading" extra-css-class="{{spinnerCss}}" class="spinner-wrapper active"></spinner>
+{{else}}
+    {{#unless items.length}}
+        <span class="empty-message">{{emptyMessage}}</span>
+    {{/unless}}
 {{/if}}
 {{#items}}
   <object-list-item instance="instance" is-selected="isSelected" selection-el="objectListItemSelector">

--- a/src/ggrc/assets/stylesheets/components/object-list/_object-list.scss
+++ b/src/ggrc/assets/stylesheets/components/object-list/_object-list.scss
@@ -43,6 +43,12 @@ object-list {
         }
       }
     }
+
+  }
+
+  & > .empty-message{
+    text-align: center;
+    padding-top: 15px;
   }
 
   object-list-item {


### PR DESCRIPTION
Add "No Related Assessments were found" in Related Assessments window

**Steps to reproduce**:
1. Navigate to assessment's Info panel
2. Open Related Assessments window

**Expected Result**: "No Related Assessments were found" is displayed if there is no related assessments

**On hold** until https://github.com/google/ggrc-core/pull/5146 is merged