### PR TITLE
GGRC-1186 Remove empty in_ query

### DIFF
--- a/src/ggrc/converters/handlers/snapshot_instance_column_handler.py
+++ b/src/ggrc/converters/handlers/snapshot_instance_column_handler.py
@@ -56,8 +56,9 @@ class SnapshotInstanceColumnHandler(MappingColumnHandler):
 
     It should be related to row instance over snapshot relation"""
     if self.row_converter.obj.id is None:
-        # For new object query should be empty
-        return self.mapping_object.query.filter(self.mapping_object.id.in_([]))
+      # For new object query should be empty
+      return self.mapping_object.query.filter(
+          self.mapping_object.id.is_(None))
     rel_snapshots = models.Relationship.get_related_query(
         self.row_converter.obj, models.Snapshot(),
     ).subquery("snapshot_rel")


### PR DESCRIPTION
This removes the sqlalchemy warning for the empty in statement that can
be a potential performance regression.

This is a fix for the integration tests warning that was introduced in https://github.com/google/ggrc-core/pull/5100#issuecomment-279669965