### PR TITLE
GGRC-1158  Auditor (Global Creator) cannot see the file in the assessment by assessor

### DIFF
--- a/src/ggrc/assets/javascripts/models/assessment.js
+++ b/src/ggrc/assets/javascripts/models/assessment.js
@@ -255,11 +255,15 @@
         this._super.apply(this, arguments);
       }
     },
-    save: function () {
-      if (!this.attr('program')) {
-        this.attr('program', this.attr('audit.program'));
+    before_create: function (dfd) {
+      if (!this.audit) {
+        throw new Error('Cannot save assessment, audit not set.');
+      } else if (!this.audit.program || !this.audit.context) {
+        throw new Error(
+          'Cannot save assessment, audit context or program not set.');
       }
-      return this._super.apply(this, arguments);
+      this.attr('program', this.attr('audit.program'));
+      this.attr('context', this.attr('audit.context'));
     },
     after_save: function () {
       this.updateValidation();

--- a/src/ggrc/assets/javascripts/models/tests/assessment_model_spec.js
+++ b/src/ggrc/assets/javascripts/models/tests/assessment_model_spec.js
@@ -1,0 +1,45 @@
+/*!
+  Copyright (C) 2017 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+describe('CMS.Models.Assessment', function () {
+  'use strict';
+
+  describe('before_create() method', function () {
+    var assessment;
+    var audit;
+    var auditWithoutContext;
+    var context;
+    var program;
+
+    beforeEach(function () {
+      assessment = new CMS.Models.Assessment();
+      context = new CMS.Models.Context({id: 42});
+      program = new CMS.Models.Program({id: 54});
+      audit = new CMS.Models.Audit({context: context, program: program});
+      auditWithoutContext = new CMS.Models.Audit({program: program});
+    });
+
+    it('sets the program and context properties', function () {
+      assessment.attr('audit', audit);
+      assessment.before_create();
+      expect(assessment.context.id).toEqual(context.id);
+      expect(assessment.program.id).toEqual(program.id);
+    });
+
+    it('throws an error if audit is not defined', function () {
+      expect(function () {
+        assessment.before_create();
+      }).toThrow(new Error('Cannot save assessment, audit not set.'));
+    });
+
+    it('throws an error if audit program/context are not defined', function () {
+      assessment.attr('audit', auditWithoutContext);
+      expect(function () {
+        assessment.before_create();
+      }).toThrow(new Error(
+        'Cannot save assessment, audit context or program not set.'));
+    });
+  });
+});

--- a/src/ggrc/migrations/versions/20170219221807_4e7fda17abc7_fix_assessment_contexts.py
+++ b/src/ggrc/migrations/versions/20170219221807_4e7fda17abc7_fix_assessment_contexts.py
@@ -1,0 +1,69 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Fix Assessment contexts
+
+Create Date: 2017-02-19 22:18:07.518997
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '4e7fda17abc7'
+down_revision = '2f1cee67a8f3'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  # Fixes assessments without audit context
+  # SELECT COUNT(*) FROM assessments
+  #  WHERE context_id is NULL;
+  sql = """
+  UPDATE assessments as a
+    JOIN relationships AS r ON r.source_id = a.id
+     AND r.source_type = 'Assessment' AND r.destination_type = 'Audit'
+    JOIN audits AS au ON r.destination_id = au.id
+     SET a.context_id = au.context_id
+   WHERE a.context_id is NULL;
+  """
+  op.execute(sql)
+  sql = """
+  UPDATE assessments as a
+    JOIN relationships AS r ON r.destination_id = a.id
+     AND r.destination_type = 'Assessment' AND r.source_type = 'Audit'
+    JOIN audits AS au ON r.source_id = au.id
+     SET a.context_id = au.context_id
+   WHERE a.context_id is NULL;
+  """
+  op.execute(sql)
+  # Fixes object_documents mapped to assessments without audit context
+  # SELECT COUNT(*) FROM object_documents
+  #  WHERE documentable_type = 'Assessment' AND context_id IS NULL;
+  sql = """
+  UPDATE object_documents AS od
+    JOIN assessments AS a ON od.documentable_id = a.id
+     SET od.context_id = a.context_id
+   WHERE documentable_type = 'Assessment' AND od.context_id IS NULL;
+  """
+  op.execute(sql)
+  # Fixes documents attached to assessments without audit context
+  # SELECT count(*)
+  #   FROM documents AS d
+  #   JOIN object_documents AS od ON d.id = od.document_id
+  #  WHERE od.documentable_type = 'Assessment' AND d.context_id IS NULL;
+  sql = """
+  UPDATE documents AS d
+    JOIN object_documents AS od ON od.document_id = d.id
+     AND od.documentable_type = 'Assessment'
+     SET d.context_id = od.context_id
+   WHERE d.context_id IS NULL
+  """
+  op.execute(sql)
+
+
+def downgrade():
+  """Nothing to do here."""
+  pass


### PR DESCRIPTION
Steps to reproduce:

1. Create a new assessment via the create new dialog (this issue is not reproducible when generating assessments) as an admin.
2. Attach evidence.
3. Add a global creator user as an Auditor to the Assessment's aduit
4. Login as the creator user and see if see the evidence list.

Expected: The attached file from step 2 should be there
Actual: The attached file is missing