### PR TITLE
GGRC-1178 Fix search params are not resetted on the next search

### DIFF
--- a/src/ggrc/assets/javascripts/components/unified-mapper/mapper-results.js
+++ b/src/ggrc/assets/javascripts/components/unified-mapper/mapper-results.js
@@ -5,6 +5,9 @@
 (function (can, GGRC, CMS, $) {
   'use strict';
 
+  var DEFAULT_PAGE_SIZE = 5;
+  var DEFAULT_SORT_DIRECTION = 'asc';
+
   can.Component.extend('mapperResults', {
     tag: 'mapper-results',
     template: can.view(
@@ -14,7 +17,7 @@
     viewModel: {
       paging: {
         current: 1,
-        pageSize: 5,
+        pageSize: DEFAULT_PAGE_SIZE,
         filter: '',
         pageSizeSelect: [5, 10, 15]
       },
@@ -24,7 +27,7 @@
       },
       sort: {
         key: '',
-        direction: 'asc'
+        direction: DEFAULT_SORT_DIRECTION
       },
       mapper: null,
       isLoading: false,
@@ -46,7 +49,7 @@
       },
       init: function () {
         var self = this;
-        this.attr('submitCbs').add(this.onSearch.bind(this));
+        this.attr('submitCbs').add(this.onSearch.bind(this, true));
         CMS.Models.DisplayPrefs.getSingleton().then(function (displayPrefs) {
           self.attr('displayPrefs', displayPrefs);
         });
@@ -97,7 +100,16 @@
         this.attr('relatedAssessments.show',
           !!Model.tree_view_options.show_related_assessments);
       },
-      onSearch: function () {
+      resetSearchParams: function () {
+        this.attr('paging.current', 1);
+        this.attr('paging.pageSize', DEFAULT_PAGE_SIZE);
+        this.attr('sort.key', '');
+        this.attr('sort.direction', DEFAULT_SORT_DIRECTION);
+      },
+      onSearch: function (resetParams) {
+        if (resetParams) {
+          this.resetSearchParams();
+        }
         this.attr('refreshItems', true);
       },
       prepareRelevantFilters: function () {
@@ -326,7 +338,7 @@
       },
       '{viewModel} refreshItems': function (scope, ev, refreshItems) {
         if (refreshItems) {
-          this.viewModel.setItems();
+          this.viewModel.setItemsDebounced();
           this.viewModel.attr('refreshItems', false);
         }
       },


### PR DESCRIPTION
This PR fixes search params are not resetted on the next search issue.

Steps to reproduce:
1. Go to My Work page
2. Open object in LHN (e.g. "Regulations")
3. Click map button in the first tier and select object type in Unified mapper (e.g. "Controls"
4. Click Search and go to next page in search results
5. Input filter value (e.g. title) and click Search: no results
Actual Result: Filter doesn't work in Unified mapper if filter and search object on the second and next pages
Expected Result: Filter should work in Unified mapper if filter and search object on the second and next pages
