### PR TITLE
GGRC-1149 Fix fields order in columns config

### DIFF
--- a/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
+++ b/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
@@ -884,6 +884,13 @@
             attr.attr_sort_field = attr.attr_name;
           }
           return attr;
+        }).sort(function (a, b) {
+          if (a.order && !b.order) {
+            return -1;
+          } else if (!a.order && b.order) {
+            return 1;
+          }
+          return a.order - b.order;
         });
 
       var customAttrs =


### PR DESCRIPTION
This PR fixes fields order was not applied in columns configuration of the unified mapper.

Steps to reproduce:
1. Go to My Work page
2. Regulations tab
3. Click map in the first tier and select Controls/Objectives object type
4. Open Config for Search results: look at the Set visible fields dialog
Actual Result: Make Last assessment date field after State field in Set visible fields dialog
Expected Result: "Last assessment date" field should be after "State" field in Set visible fields dialog