### PR TITLE
GGRC-1147 Increase paging description font size

### DIFF
--- a/src/ggrc/assets/stylesheets/components/unified-mapper/_unified-mapper.scss
+++ b/src/ggrc/assets/stylesheets/components/unified-mapper/_unified-mapper.scss
@@ -39,6 +39,10 @@ mapper-results {
       justify-content: flex-end;
       align-items: center;
 
+      .dropdown-toggle {
+        font-size: 12px;
+      }
+
       .dropdown-toggle,
       ::-webkit-input-placeholder {
         color: $gray;


### PR DESCRIPTION
This PR increases paging description font by 1px to match the "Page x of x" label as on the ux screens.

Steps to reproduce:
1. Go to My Work page
2. Open any tab in HNB (e.g. "Controls")
3. Click Map in first tier-> Search any object
4. Look at the count of found items: are too small
Actual Result: Counts are too small in Unified mapper
Expected Result: Improve counts in Unified mapper