### PR TITLE
GGRC-1195 Add notification if skipping "In Progress" state

### DIFF
--- a/src/ggrc/notifications/notification_handlers.py
+++ b/src/ggrc/notifications/notification_handlers.py
@@ -140,6 +140,10 @@ def handle_assignable_modified(obj):
     _add_assignable_declined_notif(obj)
 
   transitions_map = {
+      (Statusable.START_STATE, Statusable.FINAL_STATE):
+          Transitions.TO_COMPLETED,
+      (Statusable.START_STATE, Statusable.DONE_STATE):
+          Transitions.TO_REVIEW,
       (Statusable.PROGRESS_STATE, Statusable.FINAL_STATE):
           Transitions.TO_COMPLETED,
       (Statusable.PROGRESS_STATE, Statusable.DONE_STATE):

--- a/test/integration/ggrc/models/test_assessment.py
+++ b/test/integration/ggrc/models/test_assessment.py
@@ -1,7 +1,6 @@
 # Copyright (C) 2017 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
-from ggrc import db
 from ggrc.models import Assessment
 from integration.ggrc import TestCase
 from integration.ggrc.models.factories import AssessmentFactory
@@ -12,15 +11,12 @@ class TestAssessment(TestCase):
 
   def test_auto_slug_generation(self):
     AssessmentFactory(title="Some title")
-    db.session.commit()
     ca = Assessment.query.first()
     self.assertEqual("ASSESSMENT-{}".format(ca.id), ca.slug)
 
   def test_enabling_comment_notifications_by_default(self):
     """New Assessments should have comment notifications enabled by default."""
     AssessmentFactory()
-    db.session.commit()
-
     asmt = Assessment.query.first()
 
     self.assertTrue(asmt.send_by_default)


### PR DESCRIPTION
This PR fixes a missing state transition notification when an Assessment is completed / sent to review directly from the "Not Started" state, skipping the "In Progress" state.

---

**Steps to reproduce:**
 1. Create assessment on the audit page
 1. Make sure that there is no required fields in Assessment's Info pane (best to create a fresh Assessment  without any custom attributes defined for Assessments)
 1. Complete Assessment: assessment moves from Not Started state to Completed without In progress state

**Expected Result:**
Notification should be sent in daily digest to Creator, Assignee, Verifier in a daily digest

**Actual Result:**
Notification is not sent if Assessment moves from Not Started to Completed directly

NOTE:
The PR also fixes the case when an Assessment is sent from Not Started to Ready for Review directly - all the steps are the same, just make sure that in step 1, an Assessment is created with a Verifier assigned to it.
