### PR TITLE
QUICK-FIX Ignore Assessment CA changes for notifications

### DIFF
--- a/src/ggrc/notifications/notification_handlers.py
+++ b/src/ggrc/notifications/notification_handlers.py
@@ -169,11 +169,12 @@ def handle_assignable_modified(obj):
   # covered by other event types such as "comment created"
   # pylint: disable=invalid-name
   IGNORE_ATTRS = frozenset((
-      u'_notifications', u'comments', u'context', u'context_id', u'created_at',
-      u'custom_attribute_definitions', u"finished_date", u'id', u'modified_by',
-      u'modified_by_id', u'object_level_definitions', u'operationally',
-      u'os_state', u'related_destinations', u'related_sources', u'status',
-      u'task_group_objects', u'updated_at', u"verified_date"
+      u"_notifications", u"comments", u"context", u"context_id", u"created_at",
+      u"custom_attribute_definitions", u"_custom_attribute_values",
+      u"finished_date", u"id", u"modified_by", u"modified_by_id",
+      u"object_level_definitions", u"operationally", u"os_state",
+      u"related_destinations", u"related_sources", u"status",
+      u"task_group_objects", u"updated_at", u"verified_date",
   ))
 
   for attr_name, val in attrs.items():


### PR DESCRIPTION
This PR disables checking for custom attributes changes on Assessments for the time being.

Detecting CA changes by using SQL ALchemy's attribute history is unreliable and  can lead to false positives / false negatives.

Since CA changes on Assessments are already not detected, adding the `_custom_attribute_values` attribute to the ignore list will not cause additional issues.

---

**Steps to reproduce:**
 - Go to the admin panel and make sure there are no required Custom Attributes defined for Assessments (but there should still be a few CAs defined)
- Go to the Audit page, Assessments tab and create an Assessment
- On the Assessment's info pane, click the COMPLETE button, directly completing an Assessment from the "Not Started" state

**Expected result:**
An "Assessment completed" (or "is Ready to Review", depending on whether a Verifier role is set) notification is created.

**Actual result:**
The abovementioned notification is created + two additional (incorrect) notifications, i.e. "Assessment updated" and "Assessment reopened".

