### PR TITLE
GGRC-1097 Newly created issue is not displayed in "Related Issues" tab 

### DIFF
--- a/src/ggrc/assets/javascripts/components/mapped-objects/mapped-objects.js
+++ b/src/ggrc/assets/javascripts/components/mapped-objects/mapped-objects.js
@@ -203,12 +203,28 @@
         var useSnapshots = this.attr('mappedSnapshots');
         var hasMapping = this.attr('mapping');
         var loadFn;
+        var objects;
         if (useSnapshots) {
           loadFn = this.loadSnapshots;
         } else {
           loadFn = hasMapping ? this.load : this.loadObjects;
         }
-        this.attr('mappedItems').replace(loadFn.call(this));
+        objects = loadFn.call(this);
+        this.attr('mappedItems').replace(objects);
+        objects.then(function (data) {
+          if (!this.parentInstance.mappedSnapshots) {
+            this.parentInstance.mappedSnapshots = [];
+          }
+          data.forEach(function (item) {
+            var childIds = this.parentInstance.mappedSnapshots
+              .map(function (i) {
+                return i.instance.child_id;
+              });
+            if (childIds.indexOf(item.instance.child_id) < 0) {
+              this.parentInstance.mappedSnapshots.push(item);
+            }
+          }.bind(this));
+        }.bind(this));
       }
     },
     init: function () {

--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -3412,11 +3412,12 @@ Mustache.registerHelper('with_create_issue_json', function (instance, options) {
   audit = audits[0].instance.reify();
   programs = audit.get_mapping('_program');
   program = programs.length ? programs[0].instance.reify() : {};
-  control = instance.control ? instance.control.reify() : {};
-  relatedControls = instance.get_mapping('related_controls');
+  control = instance.control ? instance.control : {};
+  relatedControls = instance.mappedSnapshots;
 
   if (!control.id && relatedControls.length) {
     control = relatedControls[0].instance;
+    instance.control = control;
   }
   json = {
     audit: {title: audit.title, id: audit.id, type: audit.type},

--- a/src/ggrc/assets/mustache/issues/modal_content.mustache
+++ b/src/ggrc/assets/mustache/issues/modal_content.mustache
@@ -20,7 +20,7 @@
       {{#instance.computed_errors.title}}<label class="help-inline warning">{{this}}</label>{{/instance.computed_errors.title}}
     </div>
     {{#if new_object_form}}
-      <div class="span6">
+      <div class="span3">
         <label>
           Audit
           <span class="required">*</span>
@@ -30,39 +30,19 @@
           <input tabindex="2" class="input-block-level" name="audit.title" data-permission-type="update" data-lookup="Audit" data-template="/directives/autocomplete_result.mustache" placeholder="Choose Audit" type="text" null-if-empty="false" value="{{firstnonempty audit.title ''}}" disabled="disabled" />
         {{/using}}
       </div>
+      {{#assessment}}
+      <div class="span3">
+          <label>
+            Assessment
+            <span class="required">*</span>
+            <i class="fa fa-question-circle" rel="tooltip" title="Assessment for this Issue"></i>
+          </label>
+          <input tabindex="999" readonly="readonly" class="input-block-level" data-lookup="Assessment" type="text" value="{{firstexist title ''}}" />
+      </div>
+      {{/assessment}}
     {{else}}
       <div class="span6"></div>
     {{/if}}
-  </div>
-
-  <div class="row-fluid">
-    {{#control}}
-    <div class="span3">
-        <label>
-          Control
-          <i class="fa fa-question-circle" rel="tooltip" title="Control for this Issue"></i>
-        </label>
-        <input tabindex="999" readonly="readonly" class="input-block-level" type="text" value="{{firstexist title ''}}" />
-    </div>
-    {{/control}}
-    {{#program}}
-    <div class="span3">
-        <label>
-          Program
-          <i class="fa fa-question-circle" rel="tooltip" title="Program for this Issue"></i>
-        </label>
-        <input tabindex="999" readonly="readonly" class="input-block-level" type="text" value="{{firstexist title ''}}" />
-    </div>
-    {{/program}}
-    {{#assessment}}
-    <div class="span3">
-        <label>
-          Assessment
-          <i class="fa fa-question-circle" rel="tooltip" title="Assessment for this Issue"></i>
-        </label>
-        <input tabindex="999" readonly="readonly" class="input-block-level" data-lookup="Assessment" type="text" value="{{firstexist title ''}}" />
-    </div>
-    {{/assessment}}
   </div>
 
   <div class="row-fluid">


### PR DESCRIPTION
**NOTE**: Tests will be implemented in a separate PR - as soon as we will have an answer for GGRC-1206.

GGRC-1097 Newly created issue is not displayed in "Related Issues" tab

Precondition:
created program, audit, assessment on the audit page
Steps to reproduce:
1. Go to Assessment tab on the audit page
2. Navigate to Assessment’s Info panel 
3. Open Related issues tab
4. Create a new issue

Actual Result: Newly created issue is not displayed in "Related Issues" tab
Expected Result: Newly created issue should be listed on Related issues tab immediately

It also will fix:
GGRC-1098 Extra fields appear in New/Edit Issue modal while creating through Related Issues tab

Precondition:
created program, audit, assessment on the audit page
Steps to reproduce:
1. Go to Assessment tab on the audit page
2. Navigate to Assessment’s Info panel 
3. Open Related issues tab
4. Raise an Issue and look at the New Issue modal window

Actual Result: Extra fields appear in New Issue modal while creating through Related Issues tab
Expected Result: TBD