### PR TITLE
GGRC-1184 Fix mapping snapshots for the new objects

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/mapper.js
+++ b/src/ggrc/assets/javascripts/controllers/mapper.js
@@ -8,17 +8,23 @@
     .map(function (val) {
       return '[data-toggle="' + val + '"]';
     });
-  var dataCorruptionMessage = 'Some Data is corrupted! ' +
+  var DATA_CORRUPTION_MESSAGE = 'Some Data is corrupted! ' +
               'Missing Scope Object';
+  var OBJECT_REQUIRED_MESSAGE = 'Required Data for In Scope Object is missing' +
+    ' - Original Object is mandatory';
 
   can.Control.extend('GGRC.Controllers.MapperModal', {
     defaults: {
       component: GGRC.mustache_path + '/modals/mapper/component.mustache'
     },
     launch: function ($trigger, options) {
-      var href = $trigger.attr('data-href') || $trigger.attr('href');
-      var modalId = 'ajax-modal-' + (href || '').replace(/[\/\?=\&#%]/g, '-').replace(/^-/, '');
-      var $target = $('<div id="' + modalId + '" class="modal modal-selector hide"></div>');
+      var href = $trigger.attr('data-href') ||
+        $trigger.attr('href');
+      var modalId = 'ajax-modal-' + (href || '')
+          .replace(/[\/\?=\&#%]/g, '-')
+          .replace(/^-/, '');
+      var $target =
+        $('<div id="' + modalId + '" class="modal modal-selector hide"></div>');
 
       $target.modal_form({}, $trigger);
       this.newInstance($target[0], can.extend({
@@ -38,16 +44,9 @@
   });
 
   $('body').on('click', selectors.join(', '), function (ev, disableMapper) {
-    var relevantTo = null;
-    var type;
     var btn = $(ev.currentTarget);
     var data = {};
-    var joinType = btn.data('join-option-type');
     var isSearch;
-    var snapshots = GGRC.Utils.Snapshots;
-    var id = btn.data('join-object-id');
-    var objectType = btn.data('join-object-type');
-    var inScopeObject;
 
     can.each(btn.data(), function (val, key) {
       data[can.camelCaseToUnderscore(key)] = val;
@@ -62,50 +61,84 @@
 
     isSearch = /unified-search/ig.test(data.toggle);
 
-    if (!disableMapper) {
-      if (snapshots.isInScopeModel(objectType) && !isSearch) {
-        /* if no id or object type is provided we shouldn't allow mapping */
-        if (!id || !objectType) {
-          return new Error('Required Data for In Scope Object is missing' +
-            ' - Original Object is mandatory');
+    if (disableMapper) {
+      return;
+    }
+
+    if (!data.join_object_type) {
+      throw new Error(OBJECT_REQUIRED_MESSAGE);
+    }
+
+    if (GGRC.Utils.Snapshots
+        .isInScopeModel(data.join_object_type) && !isSearch) {
+      openForSnapshots(btn, data);
+    } else {
+      openForCommonObjects(btn, data, isSearch);
+    }
+
+    function openForSnapshots(btn, data) {
+      var config;
+      var inScopeObject;
+
+      if (data.is_new) {
+        config = {
+          object: data.join_object_type,
+          type: data.join_option_type,
+          relevantTo: [{
+            eadOnly: true,
+            type: data.snapshot_scope_type,
+            id: data.snapshot_scope_id
+          }]
+        };
+        GGRC.Controllers.MapperModal.launch(btn, can.extend(config, data));
+        return;
+      }
+
+      if (!data.join_object_id) {
+        throw new Error(OBJECT_REQUIRED_MESSAGE);
+      }
+
+      inScopeObject =
+        CMS.Models[data.join_object_type].store[data.join_object_id];
+
+      inScopeObject.updateScopeObject().then(function () {
+        var scopeObject = inScopeObject.attr('scopeObject');
+
+        if (!scopeObject.id) {
+          GGRC.Errors.notifier('error', DATA_CORRUPTION_MESSAGE);
+          setTimeout(function () {
+            window.location.assign(location.origin + '/dashboard');
+          }, 3000);
+          return;
         }
-        inScopeObject = CMS.Models[objectType].store[id];
-        inScopeObject.updateScopeObject().then(function () {
-          var scopeObject = inScopeObject.attr('scopeObject');
-          if (!scopeObject.id) {
-            GGRC.Errors.notifier('error', dataCorruptionMessage);
-            setTimeout(function () {
-              window.location.assign(location.origin + '/dashboard');
-            }, 3000);
-            return;
-          }
-          relevantTo = [{
+
+        config = {
+          object: data.join_object_type,
+          'join-object-id': data.join_object_id,
+          type: data.join_option_type,
+          relevantTo: [{
             readOnly: true,
             type: scopeObject.type,
             id: scopeObject.id
-          }];
-          // Default Mapping Type should be Control
-          type = joinType || 'Control';
-          GGRC.Controllers.MapperModal.launch(btn, can.extend({
-            object: objectType,
-            'join-object-id': id,
-            type: type,
-            relevantTo: relevantTo
-          }, data));
-        });
-      } else {
-        type = joinType;
-        GGRC.Controllers.MapperModal.launch(btn, can.extend({
-          object: objectType,
-          type: type,
-          'join-object-id': id,
-          'search-only': isSearch,
-          template: {
-            title: isSearch ?
-              '/static/mustache/base_objects/modal/search_title.mustache' : ''
-          }
-        }, data));
-      }
+          }]
+        };
+
+        GGRC.Controllers.MapperModal.launch(btn, can.extend(config, data));
+      });
+    }
+
+    function openForCommonObjects(btn, data, isSearch) {
+      var config = {
+        object: data.join_object_type,
+        type: data.join_option_type,
+        'join-object-id': data.join_object_id,
+        'search-only': isSearch,
+        template: {
+          title: isSearch ?
+            '/static/mustache/base_objects/modal/search_title.mustache' : ''
+        }
+      };
+      GGRC.Controllers.MapperModal.launch(btn, can.extend(config, data));
     }
   });
 })(window.can, window.can.$);


### PR DESCRIPTION
This PR fixes mapping snapshots on the create object popup.

Steps to reproduce:
1. On the audit page go to Assessments tab
2. Click Create New and look at the Map button: is disabled
Actual Result: Map button doesn't open Unified mapper in New Assessment modal
Expected Result: Map button should open Unified mapper in New Assessment modal and should be the possibility to map objects from the audit scope to Assessment
