### PR TITLE
GGRC-1358 Display snapshot in second tier of tree view

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/tree/tree-view-node.js
+++ b/src/ggrc/assets/javascripts/controllers/tree/tree-view-node.js
@@ -101,9 +101,11 @@
       var instance = this.options.instance;
       var relatedInstances = GGRC.Utils.CurrentPage.related
         .attr(instance.type);
-
+      var instanceId = GGRC.Utils.Snapshots.isSnapshot(instance) ?
+                        instance.snapshot.child_id :
+                        instance.id;
       if (!relatedInstances || relatedInstances &&
-        !relatedInstances[instance.id]) {
+        !relatedInstances[instanceId]) {
         this.element.addClass('not-directly-related');
       } else {
         this.element.addClass('directly-related');
@@ -158,9 +160,14 @@
         GGRC.mustache_path + '/base_objects/tree_placeholder.mustache',
         this.options,
         this._ifNotRemoved(function (frag) {
+          var snapshots = GGRC.Utils.Snapshots;
+          var model = CMS.Models[this.options.instance.type];
           this.replace_element(frag);
           this._draw_node_deferred.resolve();
           this.options.expanded = false;
+          if (snapshots.isSnapshot(this.options.instance)) {
+            model.removeFromCacheById(this.options.instance.id);
+          }
           delete this._expand_deferred;
         }.bind(this))
       );

--- a/src/ggrc/assets/javascripts/controllers/tree/tree-view.js
+++ b/src/ggrc/assets/javascripts/controllers/tree/tree-view.js
@@ -1275,13 +1275,14 @@
     loadSubTree: function () {
       var parent = this.options.parent_instance;
       var queryAPI = GGRC.Utils.QueryAPI;
+      var snapshots = GGRC.Utils.Snapshots;
       var parentCtrl = this.element.closest('section')
         .find('.cms_controllers_tree_view').control();
       var originalOrder =
         can.makeArray(GGRC.tree_view.attr('orderedWidgetsByType')[parent.type]);
       var relevant = {
         type: parent.type,
-        id: parent.id,
+        id: snapshots.isSnapshot(parent) ? parent.snapshot.child_id : parent.id,
         operation: 'relevant'
       };
       var states = parentCtrl.options.attr('selectStateList');
@@ -1295,10 +1296,15 @@
           filter = statesQuery;
         }
         return queryAPI.buildParam(model, {}, relevant, [
+          'child_id',
+          'child_type',
           'context',
           'email',
           'id',
+          'is_latest_revision',
           'name',
+          'revision',
+          'revisions',
           'selfLink',
           'slug',
           'status',

--- a/src/ggrc/assets/javascripts/models/cacheable.js
+++ b/src/ggrc/assets/javascripts/models/cacheable.js
@@ -442,6 +442,10 @@
       return can.getObject('cache', this, true)[id];
     },
 
+    removeFromCacheById: function (key) {
+      return delete this.store[key];
+    },
+
     newInstance: function (args) {
       var cache = can.getObject('cache', this, true);
       var isKeyExists = args && args[this.id];

--- a/src/ggrc/assets/javascripts/models/mappers/sub-tree-loader.js
+++ b/src/ggrc/assets/javascripts/models/mappers/sub-tree-loader.js
@@ -8,13 +8,37 @@
 
   GGRC.ListLoaders.TreeBaseLoader('GGRC.ListLoaders.SubTreeLoader', {}, {
     load: function (params, models) {
+      var snapshots = GGRC.Utils.Snapshots;
+      if (snapshots.isSnapshotScope(this.binding.instance) ||
+          snapshots.isSnapshotParent(this.binding.instance.type)) {
+        params.data = params.data.map(function (item) {
+          if (snapshots.isSnapshotModel(item.object_name)) {
+            item = snapshots.transformQuery(item);
+          }
+          return item;
+        });
+      }
       return GGRC.Utils.QueryAPI.makeRequest(params)
         .then(function (response) {
           var mapped = [];
           models.forEach(function (modelName, idx) {
-            var values = can.makeArray(response[idx][modelName].values);
-            var models = values.map(function (source) {
-              return CMS.Models[modelName].model(source);
+            var values;
+            var models;
+            if (snapshots.isSnapshotModel(modelName) &&
+                                            response[idx].Snapshot) {
+              values = response[idx].Snapshot.values;
+            } else {
+              values = response[idx][modelName].values;
+            }
+            values = can.makeArray(values);
+            models = values.map(function (source) {
+              var result;
+              if (source.type === 'Snapshot') {
+                result = snapshots.toObject(source);
+              } else {
+                result = CMS.Models[modelName].model(source);
+              }
+              return result;
             });
             mapped = mapped.concat(models);
           });
@@ -31,7 +55,10 @@
           if (needToSplit) {
             list.forEach(function (inst) {
               var relates = related.attr(inst.type);
-              if (relates && relates[inst.id]) {
+              var instId = snapshots.isSnapshot(inst) ?
+                inst.snapshot.child_id :
+                inst.id;
+              if (relates && relates[instId]) {
                 directlyRelated.push(inst);
               } else {
                 notRelated.push(inst);

--- a/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
+++ b/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
@@ -1062,6 +1062,7 @@
      * @return {Object} The object
      */
     function toObject(instance) {
+      var object;
       var model = CMS.Models[instance.child_type];
       var content = instance.revision.content;
       var type = model.root_collection;
@@ -1074,7 +1075,9 @@
       content.selfLink = content.snapshot.selfLink;
       content.type = instance.child_type;
       content.id = instance.id;
-      return new model(content);
+      object = new model(content);
+      model.removeFromCacheById(content.id);  /* removes snapshot object from cache */
+      return object;
     }
 
     /**

--- a/src/ggrc/assets/mustache/base_objects/open_close.mustache
+++ b/src/ggrc/assets/mustache/base_objects/open_close.mustache
@@ -2,7 +2,7 @@
     Copyright (C) 2017 Google Inc.
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
-<div class="openclose{{^if draw_children}}__empty{{/if}}" >
+<div class="openclose{{^if draw_children}}__empty{{/if}}{{#if instance.snapshot}}__snapshot{{/if}}">
   {{#if_instance_of instance "Cycle|CycleTaskGroup|CycleTaskGroupObjectTask"}}
     <span class="status-label {{#is_overdue instance.end_date instance.status}}status-overdue{{/is_overdue}}" {{addclass "status-" instance.status}} {{addclass "status-" instance.overdue}}></span>
   {{else}}
@@ -12,7 +12,9 @@
       <span class="status-label"></span>
     {{/if}}
   {{/if_instance_of}}
-  {{#if draw_children}}
+  {{#unless instance.snapshot}}
+    {{#if draw_children}}
     <i class="fa fa-caret-right"></i>
-  {{/if}}
+    {{/if}}
+  {{/unless}}
 </div>

--- a/src/ggrc/assets/mustache/components/tree/tree-node-actions.mustache
+++ b/src/ggrc/assets/mustache/components/tree/tree-node-actions.mustache
@@ -17,7 +17,9 @@
     <div class="show-details">
       {{#childOptions}}
         {{#if add_item_view}}
-          {{{renderLive add_item_view}}}
+          {{#unless instance.snapshot}}
+            {{{renderLive add_item_view}}}
+          {{/unless}}
         {{/if}}
       {{/childOptions}}
         <view-object-buttons instance="instance" open-is-hidden="isSubtree"/>

--- a/src/ggrc/assets/stylesheets/_common.scss
+++ b/src/ggrc/assets/stylesheets/_common.scss
@@ -75,11 +75,14 @@ select {
   .entry-list & {
     margin: 5px 10px 0 4px !important;
   }
-  .openclose__empty & {
+  .openclose__empty &,
+  .openclose__snapshot &,
+  .openclose__empty__snapshot &{
     margin: 16px 10px 0 10px;
   }
   .inner-tree &,
-  .inner-tree .openclose__empty & {
+  .inner-tree .openclose__empty &,
+  .inner-tree .openclose__empty__snapshot &{
     margin: 10px 5px 0 10px;
   }
 

--- a/src/ggrc/assets/stylesheets/modules/_tree-content.scss
+++ b/src/ggrc/assets/stylesheets/modules/_tree-content.scss
@@ -15,6 +15,8 @@ ul.new-tree {
   @extend %reset-list;
   margin-bottom: 40px;
   .openclose__empty,
+  .openclose__empty__snapshot,
+  .openclose__snapshot,
   .openclose {
     float: left;
     &.active {
@@ -47,6 +49,12 @@ ul.new-tree {
     cursor: pointer;
     &__empty {
       width: 35px;
+      &__snapshot {
+        width: 35px;
+      }
+    }
+    &__snapshot {
+      width: 55px;
     }
   }
   .select {


### PR DESCRIPTION
**Fixes GGRC-1117, GGRC-1115, GGRC-625, GGRC-1358**

## GGRC-1358:
**Fix tree view for snapshots**

Tree view for snapshots:
1. for snapshot line -  no Map button
2. snapshot item should NOT be expanded (remove arrow)
3. For Assessment and Issue lines in tree view - when expand - we show original relationships objects (audit program etc) and mapped snapshots (everywhere) (snapshot of control, no original object)

## GGRC-1117: 
**Assessment info page, Control tree view: tree view second tier doesn't show any mappings for a Control snapshot**

**Precondition**:
created program, control, audit

**Steps to reproduce**:
1. Go to audit page and generate assessment based on Control
2. Go to Control page -> Assessment tab
3. Click map and Search for Controls: Controls snapshots are shown in Unified mapper that are not related to the audit 

**Actual Result**: Assessment info page, Control tree view: tree view second tier doesn't show any mappings for a Control snapshot

**Expected Result**: Assessment info page, Control tree view: tree view second tier should show any mappings for a Control snapshot


## GGRC-1115: 
**All objects page, Assessment tree view: tree view second tier for Assessment is empty (should contain Control snapshots)**

**Precondition**:
created program, control, audit

**Steps to reproduce**:
1. Go to audit page and generate assessment based on control
2. Open Controls page that is mapped to Assessment
3. Assessments tab-> expand second tier: no Control's snapshot

**Actual Result**: All objects page, Assessment tree view: tree view second tier for Assessment is empty and no objects snapshots(should contain Control snapshots)

**Expected Result**: Objects page, Assessment tree view: tree view second tier for Assessment should contain snapshots


## GGRC-625: 
**Show relationships in snapshot tree view**

Tree view of snapshotted objects must show related snapshots in the first tier.