### PR TITLE
QUICK-FIX Remove libreoffice lock file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ test/selenium/asseluser
 
 # Karma runner's default coverage report directory
 coverage
+
+# LibreOffice locks
+.~lock.*#

--- a/test/integration/ggrc/test_csvs/.~lock.pci_program.csv#
+++ b/test/integration/ggrc/test_csvs/.~lock.pci_program.csv#
@@ -1,1 +1,0 @@
-,zidar,dashie,16.02.2017 23:38,file:///home/zidar/.config/libreoffice/4;


### PR DESCRIPTION
A [LibreOffice lock file](https://github.com/google/ggrc-core/pull/5197/files/4d50524b18b6073b314b77532b0a1565dd407df4#diff-1044ef177a2e71200e763767a80c09d6) slipped past our code review recently. This PR removes the lock file and updates `.gitignore` to prevent adding lock files in future.