### PR TITLE
Change status text color in workflow

### DIFF
--- a/src/ggrc/assets/mustache/base_objects/states.mustache
+++ b/src/ggrc/assets/mustache/base_objects/states.mustache
@@ -17,7 +17,7 @@
           <span class="gray"><em>Finished</em></span>
         {{/case}}
         {{#case 'InProgress'}}
-          <span class="yellow"><em>In progress</em></span>
+          <span class="orange"><em>In progress</em></span>
         {{/case}}
         {{#case 'Overdue'}}
             <span class="error"><em>Overdue</em></span>
@@ -55,7 +55,7 @@
                           <span class="blue"><em>Finished</em></span>
                         {{/case}}
                         {{#case 'InProgress'}}
-                          <span class="yellow"><em>In progress</em></span>
+                          <span class="orange"><em>In progress</em></span>
                         {{/case}}
                       {{/switch}}
                       {{^if_equals instance.status 'Verified'}}{{#is_overdue instance.end_date}}

--- a/src/ggrc/assets/stylesheets/_helpers.scss
+++ b/src/ggrc/assets/stylesheets/_helpers.scss
@@ -111,6 +111,10 @@ small {
   color: $yellow;
 }
 
+.orange {
+  color: $orange;
+}
+
 .divider {
   width: 100%;
   height: 1px;

--- a/src/ggrc/assets/stylesheets/modules/_tree-content.scss
+++ b/src/ggrc/assets/stylesheets/modules/_tree-content.scss
@@ -646,6 +646,9 @@ ul.new-tree {
     @include opacity(1);
     text-decoration:none;
   }
+  &.person-tooltip-trigger {
+    @include opacity(1);
+  }
   &.relevant-action {
     @include opacity(0.5);
     padding-right: 20px;


### PR DESCRIPTION
Change text color to `#ffab40` according to ticket 35380747 in Buganizer

![image](https://cloud.githubusercontent.com/assets/567805/23123532/ca3f47dc-f779-11e6-8aaa-dea2cc311906.png)
