### PR TITLE
GGRC-1229 Add evidence [+] button disappears after adding evidence

### DIFF
--- a/src/ggrc/assets/javascripts/plugins/can_control.js
+++ b/src/ggrc/assets/javascripts/plugins/can_control.js
@@ -21,8 +21,8 @@
     //make buttons non-clickable when saving
     bindXHRToButton : function(xhr, el, newtext, disable) {
       // binding of an ajax to a click is something we do manually
-      var $el = $(el)
-      , oldtext = $el.text();
+      var $el = $(el);
+      var oldtext = $el.text().trim() || $el[0].innerHTML;
 
       if(newtext) {
         $el[0].innerHTML = newtext;


### PR DESCRIPTION
**Steps to reproduce:**
1. Create program, audit
2. On the audit page create assessment
3. Navigate to assessment's Info pane and click [+] button to attach evidence
4. Look at Add evidence [+] button: is not shown after adding evidence

_Actual Result_: Add evidence [+] button disappears after adding evidence
_Expected Result_: Add evidence [+] button should not disappear after adding evidence

_Note_: add evidence [+] button is shown after page refresh.