### PR TITLE
GGRC-634 Fix search key deletion of custom attribute values

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,10 @@
+# Deployment instructions
+=========================
+
+Document describing version-specific steps that need to happen before or after
+deployment of specific version to production.
+
+## 0.10.5-Raspberry
+
+* Run `$.post("/admin/reindex");`
+

--- a/src/ggrc/models/mixins/customattributable.py
+++ b/src/ggrc/models/mixins/customattributable.py
@@ -256,6 +256,7 @@ class CustomAttributable(object):
     db.session.query(MysqlRecordProperty)\
         .filter(
             and_(
+                MysqlRecordProperty.key == self.id,
                 MysqlRecordProperty.type == self.__class__.__name__,
                 MysqlRecordProperty.property.in_(ftrp_properties)))\
         .delete(synchronize_session='fetch')


### PR DESCRIPTION
Previouly all custom attribute values in full text search table
of certain type were deleted - this should limit the deletion
query to affected objects only.

To the best of my testing this happens if you edit two objects of the same type (via e.g. inline edit) - only the last one has the custom attribute values saved in full text search table. This should prevent this from happening again. We should also run `$.post("/admin/reindex");` on deployment.

Steps to reproduce:
- create two objects of the same type with custom attributes (e.g. date custom attribute)
- set custom attribute to whatever (e.g. `date-1 = 2/13/2017`)
- edit both of the objects via inline edit, set custom attribute to the same value (e.g. `date-1 = 2/14/2017`)
- start mapping them to another object
- open mapper model
- search by custom attribute that will match both of those objects (`date-1 = 2/14/2017`)

Expected results: both objects are found
Actual result: only the object that was edited last is found