### PR TITLE
GGRC-1218 Fix errors on import mappings to audits and assessments

### DIFF
--- a/src/ggrc/converters/handlers/handlers.py
+++ b/src/ggrc/converters/handlers/handlers.py
@@ -382,6 +382,7 @@ class MappingColumnHandler(ColumnHandler):
 
   def __init__(self, row_converter, key, **options):
     self.key = key
+    self.allow = False  # allow mapping in audit scope
     exportable = get_exportables()
     self.attr_name = options.get("attr_name", "")
     self.mapping_object = exportable.get(self.attr_name)
@@ -400,11 +401,14 @@ class MappingColumnHandler(ColumnHandler):
       list of objects. During dry_run, the list can contain a slug instead of
       an actual object if that object will be generated in the current import.
     """
-    from ggrc.snapshotter import rules
-    if self.mapping_object.__name__ in rules.Types.scoped:
-      # TODO add a proper warning here!
-      # This is just a hack to prevent wrong mappings to assessments or issues.
+    # pylint: disable=protected-access
+    from ggrc.snapshotter.rules import Types
+    # TODO add a proper warning here!
+    # This is just a hack to prevent wrong mappings to assessments or issues.
+    if self.mapping_object.__name__ in Types.scoped | Types.parents and \
+       not self.allow:
       return []
+
     class_ = self.mapping_object
     lines = set(self.raw_value.splitlines())
     slugs = set([slug.lower() for slug in lines if slug.strip()])
@@ -604,6 +608,7 @@ class AuditColumnHandler(MappingColumnHandler):
   def __init__(self, row_converter, key, **options):
     key = "{}audit".format(MAPPING_PREFIX)
     super(AuditColumnHandler, self).__init__(row_converter, key, **options)
+    self.allow = True
 
 
 class RequestAuditColumnHandler(ParentColumnHandler):

--- a/src/ggrc/models/reflection.py
+++ b/src/ggrc/models/reflection.py
@@ -241,6 +241,9 @@ class AttributeInfo(object):
   def _generate_mapping_definition(cls, rules, prefix, display_name_tmpl):
     "Generate definition from template"
     definitions = {}
+    from ggrc.snapshotter.rules import Types
+    read_only = Types.parents | Types.scoped
+    read_only_text = "Read only column and will be ignored on import."
     for klass in rules:
       klass_name = title_from_camelcase(klass)
       key = "{}{}".format(prefix, klass_name)
@@ -249,7 +252,7 @@ class AttributeInfo(object):
           "attr_name": klass.lower(),
           "mandatory": False,
           "unique": False,
-          "description": "",
+          "description": read_only_text if klass in read_only else "",
           "type": cls.Type.MAPPING,
       }
     return definitions


### PR DESCRIPTION
This PR adds rules for audit and audit scope object mappings with imports.

Things to check:
- "map: Audit", "map: Issue", "map: Assessment" columns are ignored on any normal object import.
- "map: [anyobject]" should be ignored on audit imports.

known bugs that will be solved in a different ticket (please don't test this):
- multiple audits can be mapped to an assessment (please don't test this or delete the assessment after)
- Issues don't have an audit column and can be imported without an audit mapping