### PR TITLE
GGRC-930 add custom filter for cycle tasks 

### DIFF
--- a/src/ggrc/fulltext/recordbuilder.py
+++ b/src/ggrc/fulltext/recordbuilder.py
@@ -11,7 +11,7 @@ from ggrc import db
 import ggrc.models.all_models
 from ggrc.models.reflection import AttributeInfo
 from ggrc.models.person import Person
-from ggrc.fulltext import Record
+from ggrc.fulltext import Record, FullTextAttr
 
 
 class RecordBuilder(object):
@@ -47,7 +47,13 @@ class RecordBuilder(object):
       attrs = AttributeInfo.gather_attrs(tgt_class, '_fulltext_attrs')
       return {attr: {"": obj.revision.content.get(attr)} for attr in attrs}
 
-    return {attr: {"": getattr(obj, attr)} for attr in self._fulltext_attrs}
+    properties = {}
+    for attr in self._fulltext_attrs:
+      if isinstance(attr, basestring):
+        properties[attr] = {"": getattr(obj, attr)}
+      elif isinstance(attr, FullTextAttr):
+        properties[attr.alias] = attr.get_property_for(obj)
+    return properties
 
   @staticmethod
   def get_person_id_name_email(person):

--- a/test/integration/ggrc_workflows/converters/test_export_cycle_tasks.py
+++ b/test/integration/ggrc_workflows/converters/test_export_cycle_tasks.py
@@ -1,0 +1,197 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+
+"""Tests for task group task specific export."""
+
+from collections import defaultdict
+
+from ddt import data, unpack, ddt
+
+from integration.ggrc_workflows.models import factories
+from integration.ggrc import TestCase
+
+from ggrc.models.all_models import CycleTaskGroupObjectTask
+
+
+@ddt
+class TestExportTasks(TestCase):
+  """Test imports for basic workflow objects."""
+
+  def setUp(self):
+    super(TestExportTasks, self).setUp()
+    self.client.get("/login")
+    self.headers = {
+        'Content-Type': 'application/json',
+        "X-Requested-By": "GGRC",
+        "X-export-view": "blocks",
+    }
+
+  @staticmethod
+  def generate_tasks_for_cycle(cycle_count, task_count):
+    """generate seceted number of cycles and tasks"""
+    results = {}
+    for _ in range(cycle_count):
+      workflow = factories.WorkflowFactory()
+      cycle = factories.CycleFactory(workflow=workflow)
+      person = factories.PersonFactory(
+          name="user for cycle {}".format(cycle.id))
+      task_group = factories.TaskGroupFactory(workflow=workflow)
+      for _ in range(task_count):
+        task_group_task = factories.TaskGroupTaskFactory(
+            task_group=task_group, contact=person)
+        cycle_task_group = factories.CycleTaskGroupFactory(
+            cycle=cycle, contact=person)
+        task = factories.CycleTaskFactory(cycle=cycle,
+                                          cycle_task_group=cycle_task_group,
+                                          contact=person,
+                                          task_group_task=task_group_task)
+        results[task.id] = cycle.slug
+    return results
+
+  # pylint: disable=invalid-name
+  def assertCycles(self, field, value, cycle_slugs):
+    """assertion for search cycles for selected fields and values"""
+    search_request = [{
+        "object_name": "Cycle",
+        "filters": {
+            "expression": {
+                "left": field,
+                "op": {"name": "="},
+                "right": value,
+            },
+        },
+        "fields": ["slug"],
+    }]
+    parsed_data = self.export_parsed_csv(search_request)["Cycle"]
+    self.assertEqual(sorted(cycle_slugs),
+                     sorted([i["Code*"] for i in parsed_data]))
+    self.assertEqual(len(cycle_slugs), len(parsed_data))
+
+  @data(
+      #  (Cycle count, tasks in cycle)
+      (0, 0),
+      (1, 1),
+      (2, 1),
+      (2, 1),
+      (2, 2),
+  )
+  @unpack
+  def test_filter_by_task_slug(self, cycle_count, task_count):
+    """Test filter cycles by task slug and title"""
+    task_cycle_filter = self.generate_tasks_for_cycle(cycle_count, task_count)
+    self.assertEqual(bool(cycle_count), bool(task_cycle_filter))
+    for task_id, slug in task_cycle_filter.iteritems():
+      task = CycleTaskGroupObjectTask.query.filter(
+          CycleTaskGroupObjectTask.id == task_id
+      ).one()
+      self.assertCycles("task", task.slug, [slug])
+      self.assertCycles("task", task.title, [slug])
+
+  @data(
+      #  (Cycle count, tasks in cycle)
+      (0, 0),
+      (1, 1),
+      (2, 1),
+      (2, 1),
+      (2, 2),
+  )
+  @unpack
+  def test_filter_group_slug(self, cycle_count, task_count):
+    """Test filter cycles by group slug and title"""
+    task_cycle_filter = self.generate_tasks_for_cycle(cycle_count, task_count)
+    self.assertEqual(bool(cycle_count), bool(task_cycle_filter))
+    for task_id, slug in task_cycle_filter.iteritems():
+      task = CycleTaskGroupObjectTask.query.filter(
+          CycleTaskGroupObjectTask.id == task_id
+      ).one()
+      self.assertCycles("group", task.cycle_task_group.slug, [slug])
+      self.assertCycles("group", task.cycle_task_group.title, [slug])
+
+  @data(
+      #  (Cycle count, tasks in cycle)
+      (0, 0),
+      (1, 1),
+      (2, 1),
+      (2, 1),
+      (2, 2),
+  )
+  @unpack
+  def test_filter_by_task_due_date(self, cycle_count, task_count):
+    """Test filter cycles by task due date"""
+    task_cycle_filter = self.generate_tasks_for_cycle(cycle_count, task_count)
+    self.assertEqual(bool(cycle_count), bool(task_cycle_filter))
+    due_date_dict = defaultdict(set)
+    for task_id, slug in task_cycle_filter.iteritems():
+      task = CycleTaskGroupObjectTask.query.filter(
+          CycleTaskGroupObjectTask.id == task_id
+      ).one()
+      due_date_dict[str(task.end_date)].add(slug)
+
+    for due_date, cycle_slugs in due_date_dict.iteritems():
+      self.assertCycles("task_due_date", due_date, list(cycle_slugs))
+
+  @data(
+      #  (Cycle count, tasks in cycle)
+      (0, 0),
+      (1, 1),
+      (2, 1),
+      (2, 1),
+      (2, 2),
+  )
+  @unpack
+  def test_filter_by_group_due_date(self, cycle_count, task_count):
+    """Test filter cycles by group due date"""
+    task_cycle_filter = self.generate_tasks_for_cycle(cycle_count, task_count)
+    self.assertEqual(bool(cycle_count), bool(task_cycle_filter))
+    due_date_dict = defaultdict(set)
+    for task_id, slug in task_cycle_filter.iteritems():
+      task = CycleTaskGroupObjectTask.query.filter(
+          CycleTaskGroupObjectTask.id == task_id
+      ).one()
+      due_date_dict[str(task.cycle_task_group.next_due_date)].add(slug)
+
+    for due_date, cycle_slugs in due_date_dict.iteritems():
+      self.assertCycles("group_due_date", due_date, list(cycle_slugs))
+
+  @data(
+      #  (Cycle count, tasks in cycle)
+      (0, 0),
+      (1, 1),
+      (2, 1),
+      (2, 1),
+      (2, 2),
+  )
+  @unpack
+  def test_filter_by_group_assignee(self, cycle_count, task_count):
+    """Test filter cycles by group assignee name or email"""
+    task_cycle_filter = self.generate_tasks_for_cycle(cycle_count, task_count)
+    self.assertEqual(bool(cycle_count), bool(task_cycle_filter))
+    for task_id, slug in task_cycle_filter.iteritems():
+      task = CycleTaskGroupObjectTask.query.filter(
+          CycleTaskGroupObjectTask.id == task_id
+      ).one()
+      self.assertCycles(
+          "group_assignee", task.cycle_task_group.contact.email, [slug])
+      self.assertCycles(
+          "group_assignee", task.cycle_task_group.contact.name, [slug])
+
+  @data(
+      #  (Cycle count, tasks in cycle)
+      (0, 0),
+      (1, 1),
+      (2, 1),
+      (2, 1),
+      (2, 2),
+  )
+  @unpack
+  def test_filter_by_task_assignee(self, cycle_count, task_count):
+    """Test filter cycles by task assignee name or email"""
+    task_cycle_filter = self.generate_tasks_for_cycle(cycle_count, task_count)
+    self.assertEqual(bool(cycle_count), bool(task_cycle_filter))
+    for task_id, slug in task_cycle_filter.iteritems():
+      task = CycleTaskGroupObjectTask.query.filter(
+          CycleTaskGroupObjectTask.id == task_id
+      ).one()
+      self.assertCycles("task_assignee", task.contact.email, [slug])
+      self.assertCycles("task_assignee", task.contact.name, [slug])

--- a/test/integration/ggrc_workflows/models/factories.py
+++ b/test/integration/ggrc_workflows/models/factories.py
@@ -8,6 +8,7 @@ from datetime import date
 from ggrc_workflows import models
 from integration.ggrc.models.factories import ModelFactory
 from integration.ggrc.models.factories import TitledFactory
+from integration.ggrc.models.factories import PersonFactory
 
 
 class WorkflowFactory(TitledFactory):
@@ -59,6 +60,8 @@ class CycleTaskGroupFactory(TitledFactory):
     model = models.CycleTaskGroup
 
   cycle = factory.SubFactory(CycleFactory)
+  contact = factory.SubFactory(PersonFactory)
+  next_due_date = date(2015, 12, 4)
 
 
 class CycleTaskFactory(TitledFactory):
@@ -73,3 +76,4 @@ class CycleTaskFactory(TitledFactory):
   task_type = "text"
   start_date = date(2015, 12, 4)
   end_date = date(2015, 12, 27)
+  contact = factory.SubFactory(PersonFactory)


### PR DESCRIPTION
Add custom filters by workflow and is_current in CycleTaskGroupObjectTask. 
It's filter instances by cycle workflow id and cycle is_current values. 
This is required for add filter action on the frontend. Also it allows to filter tasks on export and using that custom filters in python code. 

Note:
is_current == True returns tasks only for active cycles
is_current == False returns tasks only for history cycles