### PR TITLE
GGRC-1135 Tooltip that don’t go away

### DIFF
--- a/src/ggrc/assets/javascripts/plugins/tooltip.js
+++ b/src/ggrc/assets/javascripts/plugins/tooltip.js
@@ -81,6 +81,10 @@
 
       monitorTimeoutId = setTimeout(monitorFn, monitorPeriod);
       $currentTarget.data('tooltip-monitor', true);
+      // Hide tooltip when target clicked
+      $currentTarget.on('click', function () {
+        $('.tooltip').hide();
+      });
     }
   }
   ;


### PR DESCRIPTION
Steps:
1. Open any page with treeview
2. Open info pane
3. Play with "Maximize/Minimize" button (click 5, 10, 20 ... times; try to click in 500ms when hovering target element)

Actual: Sometimes tooltip becomes frozen (and not hidden)