### PR TITLE
QUICK-FIX Fix unit tests for ggrc.utils

### DIFF
--- a/test/unit/ggrc/utils/__init__.py
+++ b/test/unit/ggrc/utils/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>

--- a/test/unit/ggrc/utils/test_mapping.py
+++ b/test/unit/ggrc/utils/test_mapping.py
@@ -153,7 +153,7 @@ class TestUnMappingRules(BaseTestMappingRules):
                'Project', 'Regulation', 'Risk', 'Section', 'Standard',
                'System', 'Threat', 'Vendor', ]
   assessment_rules = ['AccessGroup', 'Audit', 'Clause', 'Contract',
-                      'CycleTaskGroupObjectTask', 'DataAsset',
+                      'Control', 'CycleTaskGroupObjectTask', 'DataAsset',
                       'Facility', 'Issue', 'Market', 'Objective', 'OrgGroup',
                       'Person', 'Policy', 'Process', 'Product', 'Program',
                       'Project', 'Regulation', 'Risk', 'Section', 'Standard',
@@ -228,12 +228,6 @@ class TestUnMappingRules(BaseTestMappingRules):
                   'Person', 'Policy', 'Process', 'Product', 'Program',
                   'Project', 'Regulation', 'Risk', 'Section', 'Standard',
                   'System', 'Vendor', ]
-  issue_rules = ['AccessGroup', 'Assessment', 'Audit', 'Clause', 'Contract',
-                 'CycleTaskGroupObjectTask', 'DataAsset',
-                 'Facility', 'Issue', 'Market', 'Objective', 'OrgGroup',
-                 'Person', 'Policy', 'Process', 'Product', 'Program',
-                 'Project', 'Regulation', 'Risk', 'Section', 'Standard',
-                 'System', 'Threat', 'Vendor', ]
 
   @data(("AccessGroup", accessgroup_rules),
         ("Assessment", assessment_rules),
@@ -244,7 +238,7 @@ class TestUnMappingRules(BaseTestMappingRules):
         ("CycleTaskGroupObjectTask", cycletaskgroupobjecttask_rules),
         ("DataAsset", all_rules),
         ("Facility", all_rules),
-        ("Issue", issue_rules),
+        ("Issue", all_rules),
         ("Market", all_rules),
         ("Objective", all_rules),
         ("OrgGroup", all_rules),


### PR DESCRIPTION
`tests.unit.ggrc.utils.*` never got run by `run_unit` because of missing `__init__.py`.

#5197 broke a unit test but it went unnoticed.