### PR TITLE
QUICK-FIX Fix issues with create assessment button on info page

### DIFF
--- a/src/ggrc/assets/javascripts/components/add-object-button/add-object-button.js
+++ b/src/ggrc/assets/javascripts/components/add-object-button/add-object-button.js
@@ -12,13 +12,19 @@
       GGRC.mustache_path +
       '/components/add-object-button/add-object-button.mustache'
     ),
-    scope: {
+    viewModel: {
       instance: null,
       linkclass: '@',
       content: '@',
       text: '@',
       singular: '@',
-      plural: '@'
+      plural: '@',
+      define: {
+        noparams: {
+          type: 'htmlbool',
+          value: false
+        }
+      }
     }
   });
 })(window.can);

--- a/src/ggrc/assets/mustache/audits/summary.mustache
+++ b/src/ggrc/assets/mustache/audits/summary.mustache
@@ -16,7 +16,8 @@
                     content="+ Create assessment"
                     text="Create Assessment"
                     singular="Assessment"
-                    plural="assessments">
+                    plural="assessments"
+                    noparams="true">
                 </add-object-button>
                 <add-object-button
                     instance="instance"

--- a/src/ggrc/assets/mustache/components/add-object-button/add-object-button.mustache
+++ b/src/ggrc/assets/mustache/components/add-object-button/add-object-button.mustache
@@ -7,15 +7,15 @@
     <a href="javascript://" class="{{linkclass}}"
         {{#if text}}
         rel="tooltip"
-        data-placement="bottom"
-        data-original-title="{{text}}"
+        data-placement="left"
+        data-original-title="{{title}}"
         {{/if}}
         data-toggle="modal-ajax-form"
         data-modal-reset="reset"
         data-modal-class="modal-wide"
         data-object-singular="{{singular}}"
         data-object-plural="{{plural}}"
-        data-object-params='{ "{{instance.class.table_singular}}": {"id" : {{instance.id}}, "type" : "{{instance.class.model_singular}}" }, "context": { "id" : {{firstnonempty instance.context.id "null"}}, "href" : "{{instance.context.href}}", "type" : "{{instance.context.type}}" } }'>
+        {{^if noparams}} data-object-params='{ "{{instance.class.table_singular}}": {"id" : {{instance.id}}, "type" : "{{instance.class.model_singular}}" }, "context": { "id" : {{firstnonempty instance.context.id "null"}}, "href" : "{{instance.context.href}}", "type" : "{{instance.context.type}}" } }'{{/if}}>
             {{content}}
     </a>
 {{/is_allowed}}

--- a/src/ggrc/assets/mustache/components/add-object-button/add-object-button.mustache
+++ b/src/ggrc/assets/mustache/components/add-object-button/add-object-button.mustache
@@ -7,8 +7,8 @@
     <a href="javascript://" class="{{linkclass}}"
         {{#if text}}
         rel="tooltip"
-        data-placement="left"
-        data-original-title="{{title}}"
+        data-placement="bottom"
+        data-original-title="{{text}}"
         {{/if}}
         data-toggle="modal-ajax-form"
         data-modal-reset="reset"


### PR DESCRIPTION
Incorrect Data is Passed to Create New Object Modal which case regression:
Steps to reproduce:
- Navigate to Audit Summary Page
- Click on Create Assessment Button 
- Input Some Mandatory fields
- Try to Click Save button
![1487667980](https://cloud.githubusercontent.com/assets/10726105/23161565/b9283716-f83b-11e6-95a5-b36184c73f5d.png)
  