### PR TITLE
QUICK-FIX Add extra computed property to Object List Component to fix rendering issues   

### DIFF
--- a/src/ggrc/assets/javascripts/components/object-list/object-list.js
+++ b/src/ggrc/assets/javascripts/components/object-list/object-list.js
@@ -20,13 +20,21 @@
         objectListItemSelector: {
           type: 'string',
           value: ''
+        },
+        isLoading: {
+          type: 'boolean',
+          value: false
+        },
+        showSpinner: {
+          get: function () {
+            return this.attr('isLoading');
+          }
         }
       },
       emptyMessage: '@',
       spinnerCss: '@',
       selectedItem: {},
       items: [],
-      isLoading: false,
       getEmptyMessage: function () {
         return this.attr('emptyMessage') || 'None';
       },

--- a/src/ggrc/assets/mustache/components/object-list/object-list.mustache
+++ b/src/ggrc/assets/mustache/components/object-list/object-list.mustache
@@ -2,7 +2,7 @@
     Copyright (C) 2017 Google Inc., authors, and contributors
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
-{{#if isLoading}}
+{{#if showSpinner}}
     <spinner {toggle}="isLoading" {extra-css-class}="spinnerCss" class="spinner-wrapper active"></spinner>
 {{else}}
   {{#if items.length}}


### PR DESCRIPTION
Object List Component doesn't update it state in case primitive type is used as rendering flag 