### PR TITLE
GGRC-1126 Fix wrong relevant filter is ignored on search

### DIFF
--- a/src/ggrc/assets/javascripts/components/unified-mapper/mapper-results.js
+++ b/src/ggrc/assets/javascripts/components/unified-mapper/mapper-results.js
@@ -161,16 +161,17 @@
         filters = relevantList.attr()
           .map(function (relevant) {
             if (!relevant.value || !relevant.filter) {
-              return undefined;
+              return {
+                type: relevant.model_name,
+                operation: 'relevant',
+                id: 0
+              };
             }
             return {
               type: relevant.filter.type,
               operation: 'relevant',
               id: Number(relevant.filter.id)
             };
-          })
-          .filter(function (item) {
-            return item;
           });
         return filters;
       },


### PR DESCRIPTION
This PR fixes wrong relevant filter is ignored on search in the unified mapper.

Please see #7 here:
https://github.com/google/ggrc-core/pull/5122#issuecomment-278882297