### PR TITLE
GGRC-1057 Backend relationship validation

### DIFF
--- a/src/ggrc/converters/errors.py
+++ b/src/ggrc/converters/errors.py
@@ -122,3 +122,6 @@ ILLEGAL_APPEND_CONTROL_VALUE = ("Line {line}: "
                                 "You can not map {mapped_type} to "
                                 "{object_type}, because this {mapped_type} is "
                                 "not mapped to the related audit.")
+
+INVALID_MAPPING_ERROR = (u"Line {line}: Tried to create an invalid mapping. "
+                         u"{exception}")

--- a/src/ggrc/converters/handlers/handlers.py
+++ b/src/ggrc/converters/handlers/handlers.py
@@ -449,9 +449,14 @@ class MappingColumnHandler(ColumnHandler):
     for obj in self.value:
       mapping = Relationship.find_related(current_obj, obj)
       if not self.unmap and not mapping:
-        mapping = Relationship(source=current_obj, destination=obj)
-        relationships.append(mapping)
-        db.session.add(mapping)
+        try:
+          mapping = Relationship(source=current_obj, destination=obj)
+          relationships.append(mapping)
+          db.session.add(mapping)
+        except Exception as e:
+          self.add_error(errors.INVALID_MAPPING_ERROR,
+                         column_name=self.display_name,
+                         exception=e)
       elif self.unmap and mapping:
         db.session.delete(mapping)
     db.session.flush()

--- a/src/ggrc/utils/rules.py
+++ b/src/ggrc/utils/rules.py
@@ -5,6 +5,8 @@
 
 import copy
 
+from ggrc import extensions
+
 
 def get_mapping_rules():
   """ Get mappings rules as defined in business_object.js
@@ -83,6 +85,21 @@ def get_mapping_validation_rules():
   The rules must be symmetric, i.e. "MyDst" in rules["MySrc"] <=> "MySrc" in
   rules["MyDst"].
   """
+  base_rules = _get_mapping_validation_core_rules()
+  # Note: at some point we may want to contribute an additional blacklist here
+  contributed_whitelists = extensions.get_module_contributions(
+      "MAPPING_VALIDATION_WHITELIST",
+  )
+  for whitelist in contributed_whitelists:
+    for source_type, destination_types in whitelist.iteritems():
+      base_rules[source_type] = (base_rules.get(source_type, set()) |
+                                 destination_types)
+
+  return base_rules
+
+
+def _get_mapping_validation_core_rules():
+  """Get Relationship validation rules in context of the core app."""
   assignable_rules = {"Person"}
   documentable_rules = {"Document"}
   commentable_rules = {"Comment"}

--- a/src/ggrc/utils/rules.py
+++ b/src/ggrc/utils/rules.py
@@ -77,7 +77,75 @@ def get_unmapping_rules():
   return unmapping_rules
 
 
+def get_mapping_validation_rules():
+  """Get mapping rules to validate a new Relationship.
+
+  The rules must be symmetric, i.e. "MyDst" in rules["MySrc"] <=> "MySrc" in
+  rules["MyDst"].
+  """
+  assignable_rules = {"Person"}
+  documentable_rules = {"Document"}
+  commentable_rules = {"Comment"}
+  audit_scope_rules = {"Assessment", "Issue", "Snapshot"}
+  directive_types = {"Contract", "Policy", "Regulation", "Standard"}
+  allow_all = {
+      "AccessGroup",
+      "Clause",
+      "Contract",
+      "Control",
+      "DataAsset",
+      "Facility",
+      "Market",
+      "Objective",
+      "OrgGroup",
+      "Policy",
+      "Process",
+      "Product",
+      "Program",
+      "Project",
+      "Regulation",
+      "Section",
+      "Standard",
+      "System",
+      "Vendor",
+  }
+  validation_rules = {
+      "AccessGroup": allow_all - {"AccessGroup"},
+      "Assessment": ((audit_scope_rules | assignable_rules |
+                      documentable_rules | commentable_rules | {"Audit"}) -
+                     {"Assessment"}),
+      "AssessmentTemplate": {"Audit"},
+      "Audit": audit_scope_rules | {"AssessmentTemplate"},
+      "Clause": allow_all - {"Clause"},
+      "Comment": {"Assessment"},
+      "Contract": allow_all - directive_types,
+      "Control": allow_all,
+      "DataAsset": allow_all,
+      "Document": {"Assessment"},
+      "Facility": allow_all,
+      "Issue": audit_scope_rules | {"Audit"},
+      "Market": allow_all,
+      "Objective": allow_all,
+      "OrgGroup": allow_all,
+      "Person": {"Assessment"},
+      "Policy": allow_all - directive_types,
+      "Process": allow_all,
+      "Product": allow_all,
+      "Program": allow_all - {"Program", "Audit"},
+      "Project": allow_all,
+      "Regulation": allow_all - directive_types,
+      "Section": allow_all,
+      "Snapshot": audit_scope_rules | {"Audit"},
+      "Standard": allow_all - directive_types,
+      "System": allow_all,
+      "Vendor": allow_all,
+  }
+
+  return validation_rules
+
+
 __all__ = [
     "get_mapping_rules",
+    "get_mapping_validation_rules",
     "get_unmapping_rules",
 ]

--- a/src/ggrc_risks/__init__.py
+++ b/src/ggrc_risks/__init__.py
@@ -4,10 +4,11 @@
 from flask import Blueprint
 
 from ggrc.services.registry import service
-import ggrc_risks.models as models
+from ggrc.models import all_models
 from ggrc_basic_permissions.contributed_roles import RoleContributions
 from ggrc_risks.converters import IMPORTABLE
-from ggrc.models import all_models
+import ggrc_risks.models as models
+from ggrc_risks import utils
 import ggrc_risks.views
 
 # Initialize signal handler for status changes
@@ -93,3 +94,4 @@ class RiskRoleContributions(RoleContributions):
 ROLE_CONTRIBUTIONS = RiskRoleContributions()
 
 contributed_importables = IMPORTABLE
+MAPPING_VALIDATION_WHITELIST = [utils.get_mapping_validation_rules()]

--- a/src/ggrc_risks/utils/__init__.py
+++ b/src/ggrc_risks/utils/__init__.py
@@ -1,0 +1,63 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Relationship validation rules for mappings with Risks/Threats."""
+
+
+def get_mapping_validation_rules():
+  """Get module-specific extension to mapping validation rules."""
+  risk_mappings = {
+      "AccessGroup",
+      "Clause",
+      "Contract",
+      "Control",
+      "DataAsset",
+      "Facility",
+      "Market",
+      "Objective",
+      "OrgGroup",
+      "Policy",
+      "Process",
+      "Product",
+      "Program",
+      "Project",
+      "Regulation",
+      "Section",
+      "Standard",
+      "System",
+      "Threat",
+      "Vendor",
+  }
+  threat_mappings = {
+      "AccessGroup",
+      "Clause",
+      "Contract",
+      "Control",
+      "DataAsset",
+      "Facility",
+      "Market",
+      "Objective",
+      "OrgGroup",
+      "Policy",
+      "Process",
+      "Product",
+      "Program",
+      "Project",
+      "Regulation",
+      "Section",
+      "Standard",
+      "System",
+      "Vendor",
+  }
+  validation_rules = {
+      "Risk": risk_mappings,
+      "Threat": threat_mappings,
+  }
+  for mapping in risk_mappings:
+    validation_rules[mapping] = (validation_rules.get(mapping, set()) |
+                                 {"Risk"})
+  for mapping in threat_mappings:
+    validation_rules[mapping] = (validation_rules.get(mapping, set()) |
+                                 {"Threat"})
+
+  return validation_rules

--- a/src/ggrc_workflows/__init__.py
+++ b/src/ggrc_workflows/__init__.py
@@ -22,6 +22,7 @@ from ggrc_workflows.services import workflow_cycle_calculator
 from ggrc_workflows.roles import (
     WorkflowOwner, WorkflowMember, BasicWorkflowReader, WorkflowBasicReader
 )
+from ggrc_workflows import utils
 from ggrc_basic_permissions.models import Role, UserRole, ContextImplication
 from ggrc_basic_permissions.contributed_roles import (
     RoleContributions, RoleDeclarations, DeclarativeRoleImplications
@@ -1017,3 +1018,4 @@ contributed_column_handlers = COLUMN_HANDLERS
 contributed_get_ids_related_to = relationship_helper.get_ids_related_to
 CONTRIBUTED_CRON_JOBS = [start_recurring_cycles]
 NOTIFICATION_LISTENERS = [notification.register_listeners]
+MAPPING_VALIDATION_WHITELIST = [utils.get_mapping_validation_rules()]

--- a/src/ggrc_workflows/utils/__init__.py
+++ b/src/ggrc_workflows/utils/__init__.py
@@ -1,0 +1,38 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Module with Workflow-context Relationship validation rules."""
+
+
+def get_mapping_validation_rules():
+  """Rules to validate Relationships to Workflow-related objects."""
+  ctgot_mappings = {
+      "AccessGroup",
+      "Clause",
+      "Contract",
+      "Control",
+      "DataAsset",
+      "Facility",
+      "Market",
+      "Objective",
+      "OrgGroup",
+      "Policy",
+      "Process",
+      "Product",
+      "Program",
+      "Project",
+      "Regulation",
+      "Section",
+      "Standard",
+      "System",
+      "Threat",
+      "Vendor",
+  }
+  validation_rules = {
+      "CycleTaskGroupObjectTask": ctgot_mappings,
+  }
+  for mapping in ctgot_mappings:
+    validation_rules[mapping] = (validation_rules.get(mapping, set()) |
+                                 {"CycleTaskGroupObjectTask"})
+
+  return validation_rules

--- a/test/integration/ggrc/generator.py
+++ b/test/integration/ggrc/generator.py
@@ -20,8 +20,10 @@ from integration.ggrc.models import factories
 class Generator(object):
   """Generator base class."""
 
-  def __init__(self):
-    self.api = api_helper.Api()
+  def __init__(self, api=None):
+    if api is None:
+      api = api_helper.Api()
+    self.api = api
     self.resource = common.Resource()
 
   @staticmethod

--- a/test/integration/ggrc/services/test_collection_post.py
+++ b/test/integration/ggrc/services/test_collection_post.py
@@ -156,15 +156,15 @@ class TestCollectionPost(TestCase):
     duplicates from the post request and fixing unique integrity errors.
     """
     db.session.add(models.Policy(id=144, title="hello"))
-    db.session.add(models.Policy(id=233, title="world"))
-    db.session.add(models.Policy(id=377, title="bye"))
+    db.session.add(models.Control(id=233, title="world"))
+    db.session.add(models.Objective(id=377, title="bye"))
     db.session.commit()
 
     self.client.get("/login")
     data = json.dumps([{
         "relationship": {
             "source": {"id": 144, "type": "Policy"},
-            "destination": {"id": 233, "type": "Policy"},
+            "destination": {"id": 233, "type": "Control"},
             "context": None,
         },
     }])
@@ -184,19 +184,19 @@ class TestCollectionPost(TestCase):
     data = json.dumps([{
         "relationship": {  # this should be ignored
             "source": {"id": 144, "type": "Policy"},
-            "destination": {"id": 233, "type": "Policy"},
+            "destination": {"id": 233, "type": "Control"},
             "context": None,
         },
     }, {
         "relationship": {
-            "source": {"id": 377, "type": "Policy"},
+            "source": {"id": 377, "type": "Objective"},
             "destination": {"id": 144, "type": "Policy"},
             "context": None,
         },
     }, {
         "relationship": {  # Refactored api will ignore this
             "source": {"id": 144, "type": "Policy"},
-            "destination": {"id": 377, "type": "Policy"},
+            "destination": {"id": 377, "type": "Objective"},
             "context": None,
         },
     }])

--- a/test/integration/ggrc/snapshotter/test_snapshoting.py
+++ b/test/integration/ggrc/snapshotter/test_snapshoting.py
@@ -28,12 +28,7 @@ class TestSnapshoting(SnapshotterBaseTestCase):
     control = self.create_object(models.Control, {
         "title": "Test Control Snapshot 1"
     })
-    assessment = self.create_object(models.Assessment, {
-        "title": "Test Assessment Snapshot 1"
-    })
-
     self.create_mapping(program, control)
-    self.create_mapping(program, assessment)
 
     control = self.refresh_object(control)
 
@@ -52,6 +47,10 @@ class TestSnapshoting(SnapshotterBaseTestCase):
 
     audit = db.session.query(models.Audit).filter(
         models.Audit.title == "Snapshotable audit").one()
+    assessment = self.create_object(models.Assessment, {
+        "title": "Test Assessment Snapshot 1"
+    })
+    self.create_mapping(audit, assessment)
 
     snapshot = db.session.query(models.Snapshot).filter(
         models.Snapshot.child_id == control.id,

--- a/test/integration/ggrc/test_csvs/case_sensitive_slugs.csv
+++ b/test/integration/ggrc/test_csvs/case_sensitive_slugs.csv
@@ -1,9 +1,9 @@
-Object type,Test duplicate column error.,,,,
-Control,Code*,Title*,Owner*,,
-,a,a,user@example.com,,
-,A,A,user@example.com,,
-,,,,,
-Object type,,,,,
-Person,Name,Email*,Company,Role,map: Control
-,Person,person@gmail.com,no company,reader,"a
+Object type,Test duplicate column error.,,,
+Control,Code*,Title*,Owner*,
+,a,a,user@example.com,
+,A,A,user@example.com,
+,,,,
+Object type,,,,
+Objective,Code*,Title*,Owner*,map:control
+,,Objective mapped to "A" and "a" controls,user@example.com,"a
 A"

--- a/test/integration/ggrc_basic_permissions/test_creator.py
+++ b/test/integration/ggrc_basic_permissions/test_creator.py
@@ -184,8 +184,8 @@ class TestCreator(TestCase):
     _, obj_0 = self.generator.generate(all_models.Regulation, "regulation", {
         "regulation": {"title": "Test regulation", "context": None},
     })
-    _, obj_1 = self.generator.generate(all_models.Regulation, "regulation", {
-        "regulation": {"title": "Test regulation 2", "context": None},
+    _, obj_1 = self.generator.generate(all_models.Objective, "objective", {
+        "objective": {"title": "Test objective", "context": None},
     })
     response, rel = self.generator.generate(
         all_models.Relationship, "relationship", {
@@ -194,7 +194,7 @@ class TestCreator(TestCase):
                 "type": "Regulation"
             }, "destination": {
                 "id": obj_1.id,
-                "type": "Regulation"
+                "type": "Objective"
             }, "context": None},
         }
     )

--- a/test/integration/ggrc_basic_permissions/test_csvs/audit_rbac.csv
+++ b/test/integration/ggrc_basic_permissions/test_csvs/audit_rbac.csv
@@ -1,5 +1,5 @@
 Object type,"Must be unique. Can be left empty for autogeneration. If updating or deleting, code is required",,,,,,,,,,,,,,,,,,,,,,
-Program,Code*,Title*,Description,Notes,Manager*,Editor,Reader,Effective Date,Stop Date,State,Primary Contact,Secondary Contact,Program URL,Reference URL,map:control,map:person,,,,,,,
+Program,Code*,Title*,Description,Notes,Manager*,Editor,Reader,Effective Date,Stop Date,State,Primary Contact,Secondary Contact,Program URL,Reference URL,map:control,,,,,,,,
 ,PMRBACPROGRAM-1,Program Manager Audit RBAC Test,,,"user@example.com
 creatorpm@test.com
 readerpm@test.com
@@ -10,18 +10,7 @@ Editorpe@test.com
 adminpe@test.com","creatorpr@test.com
 readerpr@test.com
 editorpr@test.com
-Adminpr@test.com",,,Draft,user@example.com,,,,PMRBACCONTROL-1,"creatorpm@test.com
-readerpm@test.com
-editorpm@test.com
-adminpm@test.com
-creatorpe@test.com
-readerpe@test.com
-editorpe@test.com
-Adminpe@test.com
-Creatorpr@test.com
-readerpr@test.com
-Editorpr@test.com
-adminpr@test.com",,,,,,,
+Adminpr@test.com",,,Draft,user@example.com,,,,PMRBACCONTROL-1,,,,,,,,
 ,,,,,,,,,,,,,,,,,,,,,,,
 ,,,,,,,,,,,,,,,,,,,,,,,
 Object type,"Must be unique. Can be left empty for autogeneration. If updating or deleting, code is required",,,,,,,,,,,,,,,,,,,,,,
@@ -30,24 +19,24 @@ Audit,Code*,Program*,Title*,Description,Planned Start Date,Planned End Date,Plan
 ,,,,,,,,,,,,,,,,,,,,,,,
 ,,,,,,,,,,,,,,,,,,,,,,,
 Object type,,,,,,,,,,,,,,,,,,,,,,,
-Person,Name,Email*,Company,Role,map:clause,map:contract,map:control,map:objective,map:policy,map:program,map:section,map:standard,,,,,,,,,,,
-,user@example.com,user@example.com,,Administrator,PMRBACCLAUSE-1,PMRBACCONTRACT-1,PMRBACCONTROL-1,PMRBACOBJECTIVE-1,PMRBACPOLICY-1,PMRBACPROGRAM-1,PMRBACSECTION-1,PMRBACSTANDARD-1,,,,,,,,,,,
+Person,Name,Email*,Company,Role,,,,,,,,,,,,,,,,,,,
+,user@example.com,user@example.com,,Administrator,,,,,,,,,,,,,,,,,,,
 ,Admin,admin@test.com,,Administrator,,,,,,,,,,,,,,,,,,,
-,Creator PM,creatorpm@test.com,,Creator,,,,,,PMRBACPROGRAM-1,,,,,,,,,,,,,
+,Creator PM,creatorpm@test.com,,Creator,,,,,,,,,,,,,,,,,,,
 ,Creator,creator@test.com,,Creator,,,,,,,,,,,,,,,,,,,
-,Reader PM,readerpm@test.com,,Reader,,,,,,PMRBACPROGRAM-1,,,,,,,,,,,,,
+,Reader PM,readerpm@test.com,,Reader,,,,,,,,,,,,,,,,,,,
 ,Reader,reader@test.com,,Reader,,,,,,,,,,,,,,,,,,,
-,Editor PM,editorpm@test.com,,Editor,,,,,,PMRBACPROGRAM-1,,,,,,,,,,,,,
+,Editor PM,editorpm@test.com,,Editor,,,,,,,,,,,,,,,,,,,
 ,Editor,editor@test.com,,Editor,,,,,,,,,,,,,,,,,,,
-,Admin PM,adminpm@test.com,,Administrator,,,,,,PMRBACPROGRAM-1,,,,,,,,,,,,,
-,Creator PR,creatorpr@test.com,,Creator,,,,,,PMRBACPROGRAM-1,,,,,,,,,,,,,
-,Reader PR,readerpr@test.com,,Reader,,,,,,PMRBACPROGRAM-1,,,,,,,,,,,,,
-,Editor PR,editorpr@test.com,,Editor,,,,,,PMRBACPROGRAM-1,,,,,,,,,,,,,
-,Admin PR,adminpr@test.com,,Administrator,,,,,,PMRBACPROGRAM-1,,,,,,,,,,,,,
-,Creator PE,creatorpe@test.com,,Creator,,,,,,PMRBACPROGRAM-1,,,,,,,,,,,,,
-,Reader PE,readerpe@test.com,,Reader,,,,,,PMRBACPROGRAM-1,,,,,,,,,,,,,
-,Editor PE,editorpe@test.com,,Editor,,,,,,PMRBACPROGRAM-1,,,,,,,,,,,,,
-,Admin PE,adminpe@test.com,,Administrator,,,,,,PMRBACPROGRAM-1,,,,,,,,,,,,,
+,Admin PM,adminpm@test.com,,Administrator,,,,,,,,,,,,,,,,,,,
+,Creator PR,creatorpr@test.com,,Creator,,,,,,,,,,,,,,,,,,,
+,Reader PR,readerpr@test.com,,Reader,,,,,,,,,,,,,,,,,,,
+,Editor PR,editorpr@test.com,,Editor,,,,,,,,,,,,,,,,,,,
+,Admin PR,adminpr@test.com,,Administrator,,,,,,,,,,,,,,,,,,,
+,Creator PE,creatorpe@test.com,,Creator,,,,,,,,,,,,,,,,,,,
+,Reader PE,readerpe@test.com,,Reader,,,,,,,,,,,,,,,,,,,
+,Editor PE,editorpe@test.com,,Editor,,,,,,,,,,,,,,,,,,,
+,Admin PE,adminpe@test.com,,Administrator,,,,,,,,,,,,,,,,,,,
 ,,,,,,,,,,,,,,,,,,,,,,,
 ,,,,,,,,,,,,,,,,,,,,,,,
 Object type,"Must be unique. Can be left empty for autogeneration. If updating or deleting, code is required", ,,,,,,,,,,,,,,,,,,,,,

--- a/test/integration/ggrc_basic_permissions/test_csvs/audit_rbac_snapshot_create.csv
+++ b/test/integration/ggrc_basic_permissions/test_csvs/audit_rbac_snapshot_create.csv
@@ -1,5 +1,5 @@
-Object type,"Must be unique. Can be left empty for autogeneration. If updating or deleting, code is required",,,,,,,,,,,,,,,
-Program,Code*,Title*,Description,Notes,Manager*,Editor,Reader,Effective Date,Stop Date,State,Primary Contact,Secondary Contact,Program URL,Reference URL,map:control,map:person
+Object type,"Must be unique. Can be left empty for autogeneration. If updating or deleting, code is required",,,,,,,,,,,,,,
+Program,Code*,Title*,Description,Notes,Manager*,Editor,Reader,Effective Date,Stop Date,State,Primary Contact,Secondary Contact,Program URL,Reference URL,map:control
 ,PMRBACPROGRAM-1,Program Manager Audit RBAC Test,,,"user@example.com
 creatorpm@test.com
 readerpm@test.com
@@ -10,90 +10,75 @@ Editorpe@test.com
 adminpe@test.com","creatorpr@test.com
 readerpr@test.com
 editorpr@test.com
-Adminpr@test.com",,,Draft,user@example.com,,,,PMRBACCONTROL-1,"creatorpm@test.com
-readerpm@test.com
-editorpm@test.com
-adminpm@test.com
-creatorpe@test.com
-readerpe@test.com
-editorpe@test.com
-Adminpe@test.com
-Creatorpr@test.com
-readerpr@test.com
-Editorpr@test.com
-adminpr@test.com
-readerauditor@test.com
-creatorauditor@test.com
-editorauditor@test.com
-adminauditor@test.com"
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-Object type,,,,,,,,,,,,,,,,
-Person,Name,Email*,Company,Role,map:clause,map:contract,map:control,map:objective,map:policy,map:program,map:regulation,map:section,map:standard,,,
-,user@example.com,user@example.com,,Administrator,PMRBACCLAUSE-1,PMRBACCONTRACT-1,PMRBACCONTROL-1,PMRBACOBJECTIVE-1,PMRBACPOLICY-1,PMRBACPROGRAM-1,PMRBACREGULATION-1,PMRBACSECTION-1,PMRBACSTANDARD-1,,,
-,Admin,admin@test.com,,Administrator,,,,,,,,,,,,
-,Creator PM,creatorpm@test.com,,Creator,,,,,,PMRBACPROGRAM-1,,,,,,
-,Creator,creator@test.com,,Creator,,,,,,,,,,,,
-,Reader PM,readerpm@test.com,,Reader,,,,,,PMRBACPROGRAM-1,,,,,,
-,Reader,reader@test.com,,Reader,,,,,,,,,,,,
-,Editor PM,editorpm@test.com,,Editor,,,,,,PMRBACPROGRAM-1,,,,,,
-,Editor,editor@test.com,,Editor,,,,,,,,,,,,
-,Admin PM,adminpm@test.com,,Administrator,,,,,,PMRBACPROGRAM-1,,,,,,
-,Creator PR,creatorpr@test.com,,Creator,,,,,,PMRBACPROGRAM-1,,,,,,
-,Reader PR,readerpr@test.com,,Reader,,,,,,PMRBACPROGRAM-1,,,,,,
-,Editor PR,editorpr@test.com,,Editor,,,,,,PMRBACPROGRAM-1,,,,,,
-,Admin PR,adminpr@test.com,,Administrator,,,,,,PMRBACPROGRAM-1,,,,,,
-,Creator PE,creatorpe@test.com,,Creator,,,,,,PMRBACPROGRAM-1,,,,,,
-,Reader PE,readerpe@test.com,,Reader,,,,,,PMRBACPROGRAM-1,,,,,,
-,Editor PE,editorpe@test.com,,Editor,,,,,,PMRBACPROGRAM-1,,,,,,
-,Admin PE,adminpe@test.com,,Administrator,,,,,,PMRBACPROGRAM-1,,,,,,
-,Reader Auditor,readerauditor@test.com,,Reader,,,,,,,,,,,,
-,Creator Auditor,creatorauditor@test.com,,Creator,,,,,,,,,,,,
-,Editor Auditor,editorauditor@test.com,,Editor,,,,,,,,,,,,
-,Admin Auditor,adminauditor@test.com,,Administrator,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-Object type,,,,,,,,,,,,,,,,
-Access Group,code*,title*,description,owner,state,map:program,,,,,,,,,,
-,ag-1,ag-1,test,user@example.com,Draft,PMRBACPROGRAM-1,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-Object type,,,,,,,,,,,,,,,,
-Clause,code*,title*,text of clause,owner,state,map:program,,,,,,,,,,
-,Pmrbacclause-1,cl-1,test,user@example.com,Draft,PMRBACPROGRAM-1,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-Object type,,,,,,,,,,,,,,,,
-control,code*,title*,description,owner,state,map:program,,,,,,,,,,
-,Pmrbaccontrol-1,control-1,test,user@example.com,Draft,PMRBACPROGRAM-1,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-Object type,,,,,,,,,,,,,,,,
-Contract,code*,title*,description,owner,state,map:program,,,,,,,,,,
-,Pmrbaccontract-1,contract-1,test,user@example.com,Draft,PMRBACPROGRAM-1,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-Object type,,,,,,,,,,,,,,,,
-Data Asset,code*,title*,description,owner,state,map:program,,,,,,,,,,
-,da-1,da-1,test,user@example.com,Draft,PMRBACPROGRAM-1,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
+Adminpr@test.com",,,Draft,user@example.com,,,,PMRBACCONTROL-1
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+Object type,,,,,,,,,,,,,,,
+Person,Name,Email*,Company,Role,,,,,,,,,,,
+,user@example.com,user@example.com,,Administrator,,,,,,,,,,,
+,Admin,admin@test.com,,Administrator,,,,,,,,,,,
+,Creator PM,creatorpm@test.com,,Creator,,,,,,,,,,,
+,Creator,creator@test.com,,Creator,,,,,,,,,,,
+,Reader PM,readerpm@test.com,,Reader,,,,,,,,,,,
+,Reader,reader@test.com,,Reader,,,,,,,,,,,
+,Editor PM,editorpm@test.com,,Editor,,,,,,,,,,,
+,Editor,editor@test.com,,Editor,,,,,,,,,,,
+,Admin PM,adminpm@test.com,,Administrator,,,,,,,,,,,
+,Creator PR,creatorpr@test.com,,Creator,,,,,,,,,,,
+,Reader PR,readerpr@test.com,,Reader,,,,,,,,,,,
+,Editor PR,editorpr@test.com,,Editor,,,,,,,,,,,
+,Admin PR,adminpr@test.com,,Administrator,,,,,,,,,,,
+,Creator PE,creatorpe@test.com,,Creator,,,,,,,,,,,
+,Reader PE,readerpe@test.com,,Reader,,,,,,,,,,,
+,Editor PE,editorpe@test.com,,Editor,,,,,,,,,,,
+,Admin PE,adminpe@test.com,,Administrator,,,,,,,,,,,
+,Reader Auditor,readerauditor@test.com,,Reader,,,,,,,,,,,
+,Creator Auditor,creatorauditor@test.com,,Creator,,,,,,,,,,,
+,Editor Auditor,editorauditor@test.com,,Editor,,,,,,,,,,,
+,Admin Auditor,adminauditor@test.com,,Administrator,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+Object type,,,,,,,,,,,,,,,
+Access Group,code*,title*,description,owner,state,map:program,,,,,,,,,
+,ag-1,ag-1,test,user@example.com,Draft,PMRBACPROGRAM-1,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+Object type,,,,,,,,,,,,,,,
+Clause,code*,title*,text of clause,owner,state,map:program,,,,,,,,,
+,Pmrbacclause-1,cl-1,test,user@example.com,Draft,PMRBACPROGRAM-1,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+Object type,,,,,,,,,,,,,,,
+control,code*,title*,description,owner,state,map:program,,,,,,,,,
+,Pmrbaccontrol-1,control-1,test,user@example.com,Draft,PMRBACPROGRAM-1,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+Object type,,,,,,,,,,,,,,,
+Contract,code*,title*,description,owner,state,map:program,,,,,,,,,
+,Pmrbaccontract-1,contract-1,test,user@example.com,Draft,PMRBACPROGRAM-1,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+Object type,,,,,,,,,,,,,,,
+Data Asset,code*,title*,description,owner,state,map:program,,,,,,,,,
+,da-1,da-1,test,user@example.com,Draft,PMRBACPROGRAM-1,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
 Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
 Other values are:
 Final
@@ -103,13 +88,13 @@ Launched
 Not Launched
 In Scope
 Not in Scope
-Deprecated",,,,,,MM/DD/YYYY,MM/DD/YYYY,,,,
-Facility,code*,title*,description,owner,state,notes,primary contact,secondary contact,facility url,reference url,effective date,stop date,map:program,,,
-,fac-1,fac-1,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,google.com,ggrc.com,7/1/2015,7/15/2015,PMRBACPROGRAM-1,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
+Deprecated",,,,,,MM/DD/YYYY,MM/DD/YYYY,,,
+Facility,code*,title*,description,owner,state,notes,primary contact,secondary contact,facility url,reference url,effective date,stop date,map:program,,
+,fac-1,fac-1,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,google.com,ggrc.com,7/1/2015,7/15/2015,PMRBACPROGRAM-1,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
 Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
 Other values are:
 Final
@@ -119,13 +104,13 @@ Launched
 Not Launched
 In Scope
 Not in Scope
-Deprecated",,,,,,MM/DD/YYYY,MM/DD/YYYY,,,,
-Market,code*,title*,description,owner,state,notes,primary contact,secondary contact,market url,reference url,effective date,stop date,map:program,,,
-,mkt-1,mkt-1,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,google.com,ggrc.com,7/1/2015,7/15/2015,PMRBACPROGRAM-1,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
+Deprecated",,,,,,MM/DD/YYYY,MM/DD/YYYY,,,
+Market,code*,title*,description,owner,state,notes,primary contact,secondary contact,market url,reference url,effective date,stop date,map:program,,
+,mkt-1,mkt-1,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,google.com,ggrc.com,7/1/2015,7/15/2015,PMRBACPROGRAM-1,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
 Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
 Other values are:
 Final
@@ -135,13 +120,13 @@ Launched
 Not Launched
 In Scope
 Not in Scope
-Deprecated",,,,,,,,,,,
-objective,code*,title*,description,owner,state,notes,primary contact,secondary contact,objective url,reference url,map:program,,,,,
-,Pmrbacobjective-1,obj-1,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,google.com,ggrc.com,PMRBACPROGRAM-1,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
+Deprecated",,,,,,,,,,
+objective,code*,title*,description,owner,state,notes,primary contact,secondary contact,objective url,reference url,map:program,,,,
+,Pmrbacobjective-1,obj-1,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,google.com,ggrc.com,PMRBACPROGRAM-1,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
 Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
 Other values are:
 Final
@@ -151,13 +136,13 @@ Launched
 Not Launched
 In Scope
 Not in Scope
-Deprecated",,,,,,,,,,,
-OrgGroup,code*,title*,description,owner,state,notes,primary contact,secondary contact,reference url,map:program,,,,,,
-,orggroup-1,orggroup-1,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,ggrc.com,PMRBACPROGRAM-1,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
+Deprecated",,,,,,,,,,
+OrgGroup,code*,title*,description,owner,state,notes,primary contact,secondary contact,reference url,map:program,,,,,
+,orggroup-1,orggroup-1,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,ggrc.com,PMRBACPROGRAM-1,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
 Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
 Other values are:
 Final
@@ -173,13 +158,13 @@ Org Group Policy
 Data Asset Policy
 Product Policy
 Contract-Related Policy
-Company Controls Policy",,,
-Policy,code*,title*,description,owner,state,notes,primary contact,secondary contact,effective date,stop date,policy url,reference url,Kind/Type,map:program,,
-,Pmrbacpolicy-1,policy 1,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,7/1/2015,7/15/2015,google.com,ggrc.com,Company Policy,PMRBACPROGRAM-1,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
+Company Controls Policy",,
+Policy,code*,title*,description,owner,state,notes,primary contact,secondary contact,effective date,stop date,policy url,reference url,Kind/Type,map:program,
+,Pmrbacpolicy-1,policy 1,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,7/1/2015,7/15/2015,google.com,ggrc.com,Company Policy,PMRBACPROGRAM-1,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
 Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
 Other values are:
 Final
@@ -194,12 +179,12 @@ Prod
 Corp
 Service
 Core
-3rd Party",,,
-Process,code*,title*,description,owner,state,notes,primary contact,secondary contact,process url,reference url,effective date,stop date,network zone,map:program,,
-,proc-1,proc-1,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,google.com,ggrc.com,7/1/2015,7/15/2015,prod,PMRBACPROGRAM-1,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
+3rd Party",,
+Process,code*,title*,description,owner,state,notes,primary contact,secondary contact,process url,reference url,effective date,stop date,network zone,map:program,
+,proc-1,proc-1,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,google.com,ggrc.com,7/1/2015,7/15/2015,prod,PMRBACPROGRAM-1,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
 Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
 Other values are:
 Final
@@ -212,13 +197,13 @@ Not in Scope
 Deprecated",,,,,,MM/DD/YYYY,MM/DD/YYYY,"Options are:
 Saas
 Desktop Software
-Appliance",,,
-Product,code*,title*,description,owner,state,notes,primary contact,secondary contact,product url,reference url,effective date,stop date,Kind/Type,map:program,,
-,prod-1,prod-1,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,google.com,ggrc.com,7/1/2015,7/15/2015,Saas,PMRBACPROGRAM-1,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
+Appliance",,
+Product,code*,title*,description,owner,state,notes,primary contact,secondary contact,product url,reference url,effective date,stop date,Kind/Type,map:program,
+,prod-1,prod-1,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,google.com,ggrc.com,7/1/2015,7/15/2015,Saas,PMRBACPROGRAM-1,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
 Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
 Other values are:
 Final
@@ -228,12 +213,12 @@ Launched
 Not Launched
 In Scope
 Not in Scope
-Deprecated",,,,MM/DD/YYYY,MM/DD/YYYY,,,,,,
-Regulation,code*,title*,description,owner,state,notes,primary contact,secondary contact,effective date,stop date,regulation url,reference url,map:program,,,
-,Pmrbacregulation-1,reg 1,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,7/1/2015,7/15/2015,google.com,ggrc.com,PMRBACPROGRAM-1,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
+Deprecated",,,,MM/DD/YYYY,MM/DD/YYYY,,,,,
+Regulation,code*,title*,description,owner,state,notes,primary contact,secondary contact,effective date,stop date,regulation url,reference url,map:program,,
+,Pmrbacregulation-1,reg 1,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,7/1/2015,7/15/2015,google.com,ggrc.com,PMRBACPROGRAM-1,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
 Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
 Other values are:
 Final
@@ -243,13 +228,13 @@ Launched
 Not Launched
 In Scope
 Not in Scope
-Deprecated",,,,,,,,"either of the mappings (policy, regulation, standard) is mandatory for a section to be imported",,,
-Section,code*,title*,text of section,owner,state,notes,primary contact,secondary contact,,,section url,reference url,Policy / Regulation / Standard / Contract,map:program,,
-,Pmrbacsection-1,sec-1,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,,,google.com,ggrc.com,Pmrbacpolicy-1,PMRBACPROGRAM-1,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
+Deprecated",,,,,,,,"either of the mappings (policy, regulation, standard) is mandatory for a section to be imported",,
+Section,code*,title*,text of section,owner,state,notes,primary contact,secondary contact,,,section url,reference url,Policy / Regulation / Standard / Contract,map:program,
+,Pmrbacsection-1,sec-1,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,,,google.com,ggrc.com,Pmrbacpolicy-1,PMRBACPROGRAM-1,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
 Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
 Other values are:
 Final
@@ -259,13 +244,13 @@ Launched
 Not Launched
 In Scope
 Not in Scope
-Deprecated",,,,MM/DD/YYYY,MM/DD/YYYY,,,,,,
-Standard,code*,title*,description,owner,state,notes,primary contact,secondary contact,effective date,stop date,standard url,reference url,map:program,,,
-,Pmrbacstandard-1,std 1,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,7/1/2015,7/15/2015,google.com,ggrc.com,PMRBACPROGRAM-1,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
+Deprecated",,,,MM/DD/YYYY,MM/DD/YYYY,,,,,
+Standard,code*,title*,description,owner,state,notes,primary contact,secondary contact,effective date,stop date,standard url,reference url,map:program,,
+,Pmrbacstandard-1,std 1,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,7/1/2015,7/15/2015,google.com,ggrc.com,PMRBACPROGRAM-1,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
 Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
 Other values are:
 Final
@@ -280,13 +265,13 @@ Prod
 Corp
 Service
 Core
-3rd Party",,,
-System,code*,title*,description,owner,state,notes,primary contact,secondary contact,system url,reference url,effective date,stop date,network zone,map:program,,
-,sys-1,sys-1,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,google.com,ggrc.com,7/1/2015,7/15/2015,prod,PMRBACPROGRAM-1,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
+3rd Party",,
+System,code*,title*,description,owner,state,notes,primary contact,secondary contact,system url,reference url,effective date,stop date,network zone,map:program,
+,sys-1,sys-1,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,google.com,ggrc.com,7/1/2015,7/15/2015,prod,PMRBACPROGRAM-1,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
 Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",Mandatory field,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
 Other values are:
 Final
@@ -296,14 +281,14 @@ Launched
 Not Launched
 In Scope
 Not in Scope
-Deprecated",,,,MM/DD/YYYY,MM/DD/YYYY,,,,,,
-Vendor,code*,title*,description,owner,state,notes,primary contact,secondary contact,effective date,stop date,vendor url,reference url,map:program,,,
-,ven-1,ven-1,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,7/1/2015,7/15/2015,google.com,ggrc.com,PMRBACPROGRAM-1,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
+Deprecated",,,,MM/DD/YYYY,MM/DD/YYYY,,,,,
+Vendor,code*,title*,description,owner,state,notes,primary contact,secondary contact,effective date,stop date,vendor url,reference url,map:program,,
+,ven-1,ven-1,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,7/1/2015,7/15/2015,google.com,ggrc.com,PMRBACPROGRAM-1,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
 Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
 Other values are:
 Final
@@ -313,13 +298,13 @@ Launched
 Not Launched
 In Scope
 Not in Scope
-Deprecated",MM/DD/YYYY,MM/DD/YYYY,,,,,,,,,
-Risk,code*,title*,description,notes,Owner*,Effective date,stop date,map:program,,,,,,,,
-,ra-1,ra-1,test,this is a note,user@example.com,7/1/2015,7/15/2015,PMRBACPROGRAM-1,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
+Deprecated",MM/DD/YYYY,MM/DD/YYYY,,,,,,,,
+Risk,code*,title*,description,notes,Owner*,Effective date,stop date,map:program,,,,,,,
+,ra-1,ra-1,test,this is a note,user@example.com,7/1/2015,7/15/2015,PMRBACPROGRAM-1,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
 Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
 Other values are:
 Final
@@ -329,6 +314,6 @@ Launched
 Not Launched
 In Scope
 Not in Scope
-Deprecated",MM/DD/YYYY,MM/DD/YYYY,,,,,,,,,
-Threat,code*,title*,description,notes,Owner*,Effective date,stop date,map:program,,,,,,,,
-,threat-1,threat-1,test,this is a note,user@example.com,7/1/2015,7/15/2015,PMRBACPROGRAM-1,,,,,,,,
+Deprecated",MM/DD/YYYY,MM/DD/YYYY,,,,,,,,
+Threat,code*,title*,description,notes,Owner*,Effective date,stop date,map:program,,,,,,,
+,threat-1,threat-1,test,this is a note,user@example.com,7/1/2015,7/15/2015,PMRBACPROGRAM-1,,,,,,,

--- a/test/integration/ggrc_basic_permissions/test_csvs/audit_rbac_snapshot_update.csv
+++ b/test/integration/ggrc_basic_permissions/test_csvs/audit_rbac_snapshot_update.csv
@@ -1,5 +1,5 @@
-Object type,"Must be unique. Can be left empty for autogeneration. If updating or deleting, code is required",,,,,,,,,,,,,,,
-Program,Code*,Title*,Description,Notes,Manager*,Editor,Reader,Effective Date,Stop Date,State,Primary Contact,Secondary Contact,Program URL,Reference URL,map:control,map:person
+Object type,"Must be unique. Can be left empty for autogeneration. If updating or deleting, code is required",,,,,,,,,,,,,,
+Program,Code*,Title*,Description,Notes,Manager*,Editor,Reader,Effective Date,Stop Date,State,Primary Contact,Secondary Contact,Program URL,Reference URL,map:control
 ,PMRBACPROGRAM-1,Program Manager Audit RBAC Test,,,"user@example.com
 creatorpm@test.com
 readerpm@test.com
@@ -10,94 +10,79 @@ Editorpe@test.com
 adminpe@test.com","creatorpr@test.com
 readerpr@test.com
 editorpr@test.com
-Adminpr@test.com",,,Draft,user@example.com,,,,PMRBACCONTROL-1,"creatorpm@test.com
-readerpm@test.com
-editorpm@test.com
-adminpm@test.com
-creatorpe@test.com
-readerpe@test.com
-editorpe@test.com
-Adminpe@test.com
-Creatorpr@test.com
-readerpr@test.com
-Editorpr@test.com
-adminpr@test.com
-readerauditor@test.com
-creatorauditor@test.com
-editorauditor@test.com
-adminauditor@test.com"
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-Object type,,,,,,,,,,,,,,,,
-Person,Name,Email*,Company,Role,map:clause,map:contract,map:control,map:objective,map:policy,map:program,map:regulation,map:section,map:standard,,,
-,user@example.com,user@example.com,,Administrator,PMRBACCLAUSE-1,PMRBACCONTRACT-1,PMRBACCONTROL-1,PMRBACOBJECTIVE-1,PMRBACPOLICY-1,PMRBACPROGRAM-1,PMRBACREGULATION-1,PMRBACSECTION-1,PMRBACSTANDARD-1,,,
-,Admin,admin@test.com,,Administrator,,,,,,,,,,,,
-,Creator PM,creatorpm@test.com,,Creator,,,,,,PMRBACPROGRAM-1,,,,,,
-,Creator,creator@test.com,,Creator,,,,,,,,,,,,
-,Reader PM,readerpm@test.com,,Reader,,,,,,PMRBACPROGRAM-1,,,,,,
-,Reader,reader@test.com,,Reader,,,,,,,,,,,,
-,Editor PM,editorpm@test.com,,Editor,,,,,,PMRBACPROGRAM-1,,,,,,
-,Editor,editor@test.com,,Editor,,,,,,,,,,,,
-,Admin PM,adminpm@test.com,,Administrator,,,,,,PMRBACPROGRAM-1,,,,,,
-,Creator PR,creatorpr@test.com,,Creator,,,,,,PMRBACPROGRAM-1,,,,,,
-,Reader PR,readerpr@test.com,,Reader,,,,,,PMRBACPROGRAM-1,,,,,,
-,Editor PR,editorpr@test.com,,Editor,,,,,,PMRBACPROGRAM-1,,,,,,
-,Admin PR,adminpr@test.com,,Administrator,,,,,,PMRBACPROGRAM-1,,,,,,
-,Creator PE,creatorpe@test.com,,Creator,,,,,,PMRBACPROGRAM-1,,,,,,
-,Reader PE,readerpe@test.com,,Reader,,,,,,PMRBACPROGRAM-1,,,,,,
-,Editor PE,editorpe@test.com,,Editor,,,,,,PMRBACPROGRAM-1,,,,,,
-,Admin PE,adminpe@test.com,,Administrator,,,,,,PMRBACPROGRAM-1,,,,,,
-,Reader Auditor,readerauditor@test.com,,Reader,,,,,,,,,,,,
-,Creator Auditor,creatorauditor@test.com,,Creator,,,,,,,,,,,,
-,Editor Auditor,editorauditor@test.com,,Editor,,,,,,,,,,,,
-,Admin Auditor,adminauditor@test.com,,Administrator,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-Object type,,,,,,,,,,,,,,,,
-Access Group,code*,title*,description,owner,state,map:program,,,,,,,,,,
-,ag-1,ag-1 EDIT,test,user@example.com,Draft,PMRBACPROGRAM-1,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-Object type,,,,,,,,,,,,,,,,
-Clause,code*,title*,text of clause,owner,state,map:program,,,,,,,,,,
-,Pmrbacclause-1,cl-1 EDIT,test,user@example.com,Draft,PMRBACPROGRAM-1,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-Object type,,,,,,,,,,,,,,,,
-control,code*,title*,description,owner,state,map:program,,,,,,,,,,
-,Pmrbaccontrol-1,control-1 EDIT,test,user@example.com,Draft,PMRBACPROGRAM-1,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-Object type,,,,,,,,,,,,,,,,
-Contract,code*,title*,description,owner,state,map:program,,,,,,,,,,
-,Pmrbaccontract-1,contract-1 EDIT,test,user@example.com,Draft,PMRBACPROGRAM-1,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-Object type,,,,,,,,,,,,,,,,
-Data Asset,code*,title*,description,owner,state,map:program,,,,,,,,,,
-,da-1,da-1 EDIT,test,user@example.com,Draft,PMRBACPROGRAM-1,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
+Adminpr@test.com",,,Draft,user@example.com,,,,PMRBACCONTROL-1
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+Object type,,,,,,,,,,,,,,,
+Person,Name,Email*,Company,Role,,,,,,,,,,,
+,user@example.com,user@example.com,,Administrator,,,,,,,,,,,
+,Admin,admin@test.com,,Administrator,,,,,,,,,,,
+,Creator PM,creatorpm@test.com,,Creator,,,,,,,,,,,
+,Creator,creator@test.com,,Creator,,,,,,,,,,,
+,Reader PM,readerpm@test.com,,Reader,,,,,,,,,,,
+,Reader,reader@test.com,,Reader,,,,,,,,,,,
+,Editor PM,editorpm@test.com,,Editor,,,,,,,,,,,
+,Editor,editor@test.com,,Editor,,,,,,,,,,,
+,Admin PM,adminpm@test.com,,Administrator,,,,,,,,,,,
+,Creator PR,creatorpr@test.com,,Creator,,,,,,,,,,,
+,Reader PR,readerpr@test.com,,Reader,,,,,,,,,,,
+,Editor PR,editorpr@test.com,,Editor,,,,,,,,,,,
+,Admin PR,adminpr@test.com,,Administrator,,,,,,,,,,,
+,Creator PE,creatorpe@test.com,,Creator,,,,,,,,,,,
+,Reader PE,readerpe@test.com,,Reader,,,,,,,,,,,
+,Editor PE,editorpe@test.com,,Editor,,,,,,,,,,,
+,Admin PE,adminpe@test.com,,Administrator,,,,,,,,,,,
+,Reader Auditor,readerauditor@test.com,,Reader,,,,,,,,,,,
+,Creator Auditor,creatorauditor@test.com,,Creator,,,,,,,,,,,
+,Editor Auditor,editorauditor@test.com,,Editor,,,,,,,,,,,
+,Admin Auditor,adminauditor@test.com,,Administrator,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+Object type,,,,,,,,,,,,,,,
+Access Group,code*,title*,description,owner,state,map:program,,,,,,,,,
+,ag-1,ag-1 EDIT,test,user@example.com,Draft,PMRBACPROGRAM-1,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+Object type,,,,,,,,,,,,,,,
+Clause,code*,title*,text of clause,owner,state,map:program,,,,,,,,,
+,Pmrbacclause-1,cl-1 EDIT,test,user@example.com,Draft,PMRBACPROGRAM-1,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+Object type,,,,,,,,,,,,,,,
+control,code*,title*,description,owner,state,map:program,,,,,,,,,
+,Pmrbaccontrol-1,control-1 EDIT,test,user@example.com,Draft,PMRBACPROGRAM-1,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+Object type,,,,,,,,,,,,,,,
+Contract,code*,title*,description,owner,state,map:program,,,,,,,,,
+,Pmrbaccontract-1,contract-1 EDIT,test,user@example.com,Draft,PMRBACPROGRAM-1,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+Object type,,,,,,,,,,,,,,,
+Data Asset,code*,title*,description,owner,state,map:program,,,,,,,,,
+,da-1,da-1 EDIT,test,user@example.com,Draft,PMRBACPROGRAM-1,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
 Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
 Other values are:
 Final
@@ -107,13 +92,13 @@ Launched
 Not Launched
 In Scope
 Not in Scope
-Deprecated",,,,,,MM/DD/YYYY,MM/DD/YYYY,,,,
-Facility,code*,title*,description,owner,state,notes,primary contact,secondary contact,facility url,reference url,effective date,stop date,map:program,,,
-,fac-1,fac-1 EDIT,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,google.com,ggrc.com,7/1/2015,7/15/2015,PMRBACPROGRAM-1,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
+Deprecated",,,,,,MM/DD/YYYY,MM/DD/YYYY,,,
+Facility,code*,title*,description,owner,state,notes,primary contact,secondary contact,facility url,reference url,effective date,stop date,map:program,,
+,fac-1,fac-1 EDIT,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,google.com,ggrc.com,7/1/2015,7/15/2015,PMRBACPROGRAM-1,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
 Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
 Other values are:
 Final
@@ -123,13 +108,13 @@ Launched
 Not Launched
 In Scope
 Not in Scope
-Deprecated",,,,,,MM/DD/YYYY,MM/DD/YYYY,,,,
-Market,code*,title*,description,owner,state,notes,primary contact,secondary contact,market url,reference url,effective date,stop date,map:program,,,
-,mkt-1,mkt-1 EDIT,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,google.com,ggrc.com,7/1/2015,7/15/2015,PMRBACPROGRAM-1,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
+Deprecated",,,,,,MM/DD/YYYY,MM/DD/YYYY,,,
+Market,code*,title*,description,owner,state,notes,primary contact,secondary contact,market url,reference url,effective date,stop date,map:program,,
+,mkt-1,mkt-1 EDIT,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,google.com,ggrc.com,7/1/2015,7/15/2015,PMRBACPROGRAM-1,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
 Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
 Other values are:
 Final
@@ -139,13 +124,13 @@ Launched
 Not Launched
 In Scope
 Not in Scope
-Deprecated",,,,,,,,,,,
-objective,code*,title*,description,owner,state,notes,primary contact,secondary contact,objective url,reference url,map:program,,,,,
-,Pmrbacobjective-1,obj-1 EDIT,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,google.com,ggrc.com,PMRBACPROGRAM-1,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
+Deprecated",,,,,,,,,,
+objective,code*,title*,description,owner,state,notes,primary contact,secondary contact,objective url,reference url,map:program,,,,
+,Pmrbacobjective-1,obj-1 EDIT,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,google.com,ggrc.com,PMRBACPROGRAM-1,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
 Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
 Other values are:
 Final
@@ -155,13 +140,13 @@ Launched
 Not Launched
 In Scope
 Not in Scope
-Deprecated",,,,,,,,,,,
-OrgGroup,code*,title*,description,owner,state,notes,primary contact,secondary contact,reference url,map:program,,,,,,
-,orggroup-1,orggroup-1 EDIT,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,ggrc.com,PMRBACPROGRAM-1,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
+Deprecated",,,,,,,,,,
+OrgGroup,code*,title*,description,owner,state,notes,primary contact,secondary contact,reference url,map:program,,,,,
+,orggroup-1,orggroup-1 EDIT,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,ggrc.com,PMRBACPROGRAM-1,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
 Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
 Other values are:
 Final
@@ -177,13 +162,13 @@ Org Group Policy
 Data Asset Policy
 Product Policy
 Contract-Related Policy
-Company Controls Policy",,,
-Policy,code*,title*,description,owner,state,notes,primary contact,secondary contact,effective date,stop date,policy url,reference url,Kind/Type,map:program,,
-,Pmrbacpolicy-1,policy 1 EDIT,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,7/1/2015,7/15/2015,google.com,ggrc.com,Company Policy,PMRBACPROGRAM-1,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
+Company Controls Policy",,
+Policy,code*,title*,description,owner,state,notes,primary contact,secondary contact,effective date,stop date,policy url,reference url,Kind/Type,map:program,
+,Pmrbacpolicy-1,policy 1 EDIT,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,7/1/2015,7/15/2015,google.com,ggrc.com,Company Policy,PMRBACPROGRAM-1,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
 Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
 Other values are:
 Final
@@ -198,12 +183,12 @@ Prod
 Corp
 Service
 Core
-3rd Party",,,
-Process,code*,title*,description,owner,state,notes,primary contact,secondary contact,process url,reference url,effective date,stop date,network zone,map:program,,
-,proc-1,proc-1 EDIT,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,google.com,ggrc.com,7/1/2015,7/15/2015,prod,PMRBACPROGRAM-1,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
+3rd Party",,
+Process,code*,title*,description,owner,state,notes,primary contact,secondary contact,process url,reference url,effective date,stop date,network zone,map:program,
+,proc-1,proc-1 EDIT,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,google.com,ggrc.com,7/1/2015,7/15/2015,prod,PMRBACPROGRAM-1,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
 Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
 Other values are:
 Final
@@ -216,13 +201,13 @@ Not in Scope
 Deprecated",,,,,,MM/DD/YYYY,MM/DD/YYYY,"Options are:
 Saas
 Desktop Software
-Appliance",,,
-Product,code*,title*,description,owner,state,notes,primary contact,secondary contact,product url,reference url,effective date,stop date,Kind/Type,map:program,,
-,prod-1,prod-1 EDIT,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,google.com,ggrc.com,7/1/2015,7/15/2015,Saas,PMRBACPROGRAM-1,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
+Appliance",,
+Product,code*,title*,description,owner,state,notes,primary contact,secondary contact,product url,reference url,effective date,stop date,Kind/Type,map:program,
+,prod-1,prod-1 EDIT,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,google.com,ggrc.com,7/1/2015,7/15/2015,Saas,PMRBACPROGRAM-1,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
 Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
 Other values are:
 Final
@@ -232,12 +217,12 @@ Launched
 Not Launched
 In Scope
 Not in Scope
-Deprecated",,,,MM/DD/YYYY,MM/DD/YYYY,,,,,,
-Regulation,code*,title*,description,owner,state,notes,primary contact,secondary contact,effective date,stop date,regulation url,reference url,map:program,,,
-,Pmrbacregulation-1,reg 1 EDIT,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,7/1/2015,7/15/2015,google.com,ggrc.com,PMRBACPROGRAM-1,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
+Deprecated",,,,MM/DD/YYYY,MM/DD/YYYY,,,,,
+Regulation,code*,title*,description,owner,state,notes,primary contact,secondary contact,effective date,stop date,regulation url,reference url,map:program,,
+,Pmrbacregulation-1,reg 1 EDIT,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,7/1/2015,7/15/2015,google.com,ggrc.com,PMRBACPROGRAM-1,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
 Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
 Other values are:
 Final
@@ -247,13 +232,13 @@ Launched
 Not Launched
 In Scope
 Not in Scope
-Deprecated",,,,,,,,"either of the mappings (policy, regulation, standard) is mandatory for a section to be imported",,,
-Section,code*,title*,text of section,owner,state,notes,primary contact,secondary contact,,,section url,reference url,Policy / Regulation / Standard / Contract,map:program,,
-,Pmrbacsection-1,sec-1 EDIT,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,,,google.com,ggrc.com,Pmrbacpolicy-1,PMRBACPROGRAM-1,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
+Deprecated",,,,,,,,"either of the mappings (policy, regulation, standard) is mandatory for a section to be imported",,
+Section,code*,title*,text of section,owner,state,notes,primary contact,secondary contact,,,section url,reference url,Policy / Regulation / Standard / Contract,map:program,
+,Pmrbacsection-1,sec-1 EDIT,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,,,google.com,ggrc.com,Pmrbacpolicy-1,PMRBACPROGRAM-1,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
 Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
 Other values are:
 Final
@@ -263,13 +248,13 @@ Launched
 Not Launched
 In Scope
 Not in Scope
-Deprecated",,,,MM/DD/YYYY,MM/DD/YYYY,,,,,,
-Standard,code*,title*,description,owner,state,notes,primary contact,secondary contact,effective date,stop date,standard url,reference url,map:program,,,
-,Pmrbacstandard-1,std 1 EDIT,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,7/1/2015,7/15/2015,google.com,ggrc.com,PMRBACPROGRAM-1,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
+Deprecated",,,,MM/DD/YYYY,MM/DD/YYYY,,,,,
+Standard,code*,title*,description,owner,state,notes,primary contact,secondary contact,effective date,stop date,standard url,reference url,map:program,,
+,Pmrbacstandard-1,std 1 EDIT,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,7/1/2015,7/15/2015,google.com,ggrc.com,PMRBACPROGRAM-1,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
 Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
 Other values are:
 Final
@@ -284,13 +269,13 @@ Prod
 Corp
 Service
 Core
-3rd Party",,,
-System,code*,title*,description,owner,state,notes,primary contact,secondary contact,system url,reference url,effective date,stop date,network zone,map:program,,
-,sys-1,sys-1 EDIT,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,google.com,ggrc.com,7/1/2015,7/15/2015,prod,PMRBACPROGRAM-1,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
+3rd Party",,
+System,code*,title*,description,owner,state,notes,primary contact,secondary contact,system url,reference url,effective date,stop date,network zone,map:program,
+,sys-1,sys-1 EDIT,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,google.com,ggrc.com,7/1/2015,7/15/2015,prod,PMRBACPROGRAM-1,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
 Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",Mandatory field,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
 Other values are:
 Final
@@ -300,14 +285,14 @@ Launched
 Not Launched
 In Scope
 Not in Scope
-Deprecated",,,,MM/DD/YYYY,MM/DD/YYYY,,,,,,
-Vendor,code*,title*,description,owner,state,notes,primary contact,secondary contact,effective date,stop date,vendor url,reference url,map:program,,,
-,ven-1,ven-1 EDIT,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,7/1/2015,7/15/2015,google.com,ggrc.com,PMRBACPROGRAM-1,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
+Deprecated",,,,MM/DD/YYYY,MM/DD/YYYY,,,,,
+Vendor,code*,title*,description,owner,state,notes,primary contact,secondary contact,effective date,stop date,vendor url,reference url,map:program,,
+,ven-1,ven-1 EDIT,test,user@example.com,Draft,this is a note,user@example.com,user@example.com,7/1/2015,7/15/2015,google.com,ggrc.com,PMRBACPROGRAM-1,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
 Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
 Other values are:
 Final
@@ -317,13 +302,13 @@ Launched
 Not Launched
 In Scope
 Not in Scope
-Deprecated",MM/DD/YYYY,MM/DD/YYYY,,,,,,,,,
-Risk,code*,title*,description,notes,Owner*,Effective date,stop date,map:program,,,,,,,,
-,ra-1,ra-1 EDIT,test,this is a note,user@example.com,7/1/2015,7/15/2015,PMRBACPROGRAM-1,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,
+Deprecated",MM/DD/YYYY,MM/DD/YYYY,,,,,,,,
+Risk,code*,title*,description,notes,Owner*,Effective date,stop date,map:program,,,,,,,
+,ra-1,ra-1 EDIT,test,this is a note,user@example.com,7/1/2015,7/15/2015,PMRBACPROGRAM-1,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,
 Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",,,"if owner is not provided, current user will be reated as owner of the object","Default value 'draft' is selected
 Other values are:
 Final
@@ -333,6 +318,6 @@ Launched
 Not Launched
 In Scope
 Not in Scope
-Deprecated",MM/DD/YYYY,MM/DD/YYYY,,,,,,,,,
-Threat,code*,title*,description,notes,Owner*,Effective date,stop date,map:program,,,,,,,,
-,threat-1,threat-1 EDIT,test,this is a note,user@example.com,7/1/2015,7/15/2015,PMRBACPROGRAM-1,,,,,,,,
+Deprecated",MM/DD/YYYY,MM/DD/YYYY,,,,,,,,
+Threat,code*,title*,description,notes,Owner*,Effective date,stop date,map:program,,,,,,,
+,threat-1,threat-1 EDIT,test,this is a note,user@example.com,7/1/2015,7/15/2015,PMRBACPROGRAM-1,,,,,,,

--- a/test/integration/ggrc_basic_permissions/test_reader.py
+++ b/test/integration/ggrc_basic_permissions/test_reader.py
@@ -158,8 +158,8 @@ class TestReader(TestCase):
     _, obj_0 = self.generator.generate(all_models.Regulation, "regulation", {
         "regulation": {"title": "Test regulation", "context": None},
     })
-    _, obj_1 = self.generator.generate(all_models.Regulation, "regulation", {
-        "regulation": {"title": "Test regulation 2", "context": None},
+    _, obj_1 = self.generator.generate(all_models.Objective, "objective", {
+        "objective": {"title": "Test objective", "context": None},
     })
     response, rel = self.generator.generate(
         all_models.Relationship, "relationship", {
@@ -168,7 +168,7 @@ class TestReader(TestCase):
                 "type": "Regulation"
             }, "destination": {
                 "id": obj_1.id,
-                "type": "Regulation"
+                "type": "Objective"
             }, "context": None},
         }
     )

--- a/test/unit/ggrc/models/test_relationship.py
+++ b/test/unit/ggrc/models/test_relationship.py
@@ -1,0 +1,55 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Module for unit test suite for Relationship model."""
+
+import unittest
+
+import mock
+
+import ggrc
+from ggrc.models.exceptions import ValidationError
+from ggrc.models.mixins import Base
+from ggrc.models.relationship import Relationship
+
+
+class MockModelA(Base, ggrc.db.Model):
+  __tablename__ = "mock_model_a"
+
+
+class MockModelB(Base, ggrc.db.Model):
+  __tablename__ = "mock_model_b"
+
+
+@mock.patch("ggrc.utils.rules.get_mapping_validation_rules")
+class TestRelationship(unittest.TestCase):
+  """Unit test suite for Relationship model."""
+
+  def test_relationship_validation_ok(self, get_rules_mock):
+    """Mapping of allowed source_type and destination_type is OK."""
+    get_rules_mock.return_value = {
+        "MockModelA": {"MockModelA", "MockModelB"},
+        "MockModelB": {"MockModelA", "MockModelB"},
+    }
+    # nothing raises ValidationError
+    for src, dst in [(MockModelA(), MockModelA()),
+                     (MockModelA(), MockModelB()),
+                     (MockModelB(), MockModelA()),
+                     (MockModelB(), MockModelB())]:
+      rel = Relationship(source=src, destination=dst)
+      self.assertIs(rel.source, src)
+      self.assertIs(rel.destination, dst)
+
+  # pylint: disable=invalid-name
+  def test_relationship_validation_disallowed_type(self, get_rules_mock):
+    """Validation fails when source-destination types pair disallowed."""
+    get_rules_mock.return_value = {
+        "MockModelA": {"MockModelA"},
+    }
+    Relationship(source=MockModelA(), destination=MockModelA())
+    with self.assertRaises(ValidationError):
+      Relationship(source=MockModelA(), destination=MockModelB())
+    with self.assertRaises(ValidationError):
+      Relationship(source=MockModelB(), destination=MockModelA())
+    with self.assertRaises(ValidationError):
+      Relationship(source=MockModelB(), destination=MockModelB())

--- a/test/unit/ggrc/models/test_relationship_attr.py
+++ b/test/unit/ggrc/models/test_relationship_attr.py
@@ -34,10 +34,20 @@ class TestRelationshipAttr(unittest.TestCase):
 
     m1 = RelationshipAttrTestMockModel()
     m2 = RelationshipAttrTestMockModel()
+    self.rules_patcher = mock.patch("ggrc.utils.rules."
+                                    "get_mapping_validation_rules")
+    self.rules_mock = self.rules_patcher.start()
+    self.rules_mock.return_value = {
+        "RelationshipAttrTestMockModel": "RelationshipAttrTestMockModel",
+    }
     self.rel = Relationship(source=m1, destination=m2)
 
     self.mapper_mock = mock.Mock(name='mapper')
     self.connection_mock = mock.Mock(name='connection')
+
+  def tearDown(self):
+    self.rules_patcher.stop()
+    super(TestRelationshipAttr, self).tearDown()
 
   def test_attrs_validation_ok(self):
     self.rel.attrs["validated_attr"] = "123"

--- a/test/unit/ggrc/utils/test_rules.py
+++ b/test/unit/ggrc/utils/test_rules.py
@@ -233,3 +233,18 @@ class TestUnMappingRules(BaseTestMappingRules):
   @unpack
   def test_field(self, field, rules):
     self.assertRules(field, *rules)
+
+
+class TestMappingValidationRules(unittest.TestCase):
+  """Test suite for mapping validation rules."""
+
+  def test_rules_symmetry(self):
+    """Mapping validation rules are symmetric."""
+    base_rules = ggrc.utils.rules.get_mapping_validation_rules()
+    mirrored_rules = dict()
+    for source_type, destination_types in base_rules.iteritems():
+      for destination_type in destination_types:
+        mirrored_rules[destination_type] = (
+            mirrored_rules.get(destination_type, set()) | {source_type}
+        )
+    self.assertDictEqual(mirrored_rules, base_rules)


### PR DESCRIPTION
This PR adds a validator to check `source_type, destination_type` pairs for `Relationship` objects by a whitelist.

~This PR is currently WIP as many tests fail and the validation rules set is incomplete for models from extensions.~

Depends on:
- [x] #5247 
- [x] #5252 
- [x] #5286 
- [x] #5313 

Waiting for approve from Prasanna.