### PR TITLE
GGRC-1161 Audit is not shown in Disabled field in Unified mapper - for Risks/THreats

### DIFF
--- a/src/ggrc/assets/javascripts/apps/base_widgets.js
+++ b/src/ggrc/assets/javascripts/apps/base_widgets.js
@@ -95,6 +95,8 @@
     Standard: _.difference(filteredTypes,
       ['Contract', 'Policy', 'Regulation', 'Standard']),
     System: filteredTypes,
+    Risk: _.difference(filteredTypes, ['Risk']),
+    Threat: _.difference(filteredTypes, ['Threat']),
     Vendor: filteredTypes
   };
 

--- a/src/ggrc/assets/javascripts/apps/base_widgets.js
+++ b/src/ggrc/assets/javascripts/apps/base_widgets.js
@@ -29,9 +29,11 @@
     'Program',
     'Project',
     'Regulation',
+    'Risk',
     'Section',
     'Standard',
     'System',
+    'Threat',
     'Vendor'
   ];
   // NOTE: Widgets that have the order value are sorted by an increase values,
@@ -95,8 +97,8 @@
     Standard: _.difference(filteredTypes,
       ['Contract', 'Policy', 'Regulation', 'Standard']),
     System: filteredTypes,
-    Risk: _.difference(filteredTypes, ['Risk']),
-    Threat: _.difference(filteredTypes, ['Threat']),
+    Risk: filteredTypes,
+    Threat: filteredTypes,
     Vendor: filteredTypes
   };
 

--- a/src/ggrc/assets/javascripts/apps/business_objects.js
+++ b/src/ggrc/assets/javascripts/apps/business_objects.js
@@ -45,6 +45,7 @@
         person: CMS.Models.Person,
         role: CMS.Models.Role,
         threat: CMS.Models.Threat,
+        risk: CMS.Models.Risk,
         vulnerability: CMS.Models.Vulnerability,
         template: CMS.Models.Template
       };
@@ -500,6 +501,16 @@
             child_options: relatedObjectsChildOptions,
             draw_children: true
           },
+          Threat: {
+            mapping: 'threat',
+            child_options: relatedObjectsChildOptions,
+            draw_children: true
+          },
+          Risk: {
+            mapping: 'risk',
+            child_options: relatedObjectsChildOptions,
+            draw_children: true
+          },
           Assessment: {
             mapping: 'related_assessments',
             parent_instance: GGRC.page_instance(),
@@ -620,6 +631,22 @@
           },
           Clause: {
             mapping: 'clauses',
+            child_options: relatedObjectsChildOptions,
+            draw_children: true
+          }
+        },
+        Risk: {
+          _mixins: ['governance_objects', 'business_objects', 'issues'],
+          Threat: {
+            mapping: 'threats',
+            child_options: relatedObjectsChildOptions,
+            draw_children: true
+          }
+        },
+        Threat: {
+          _mixins: ['governance_objects', 'business_objects', 'issues'],
+          Risk: {
+            mapping: 'risks',
             child_options: relatedObjectsChildOptions,
             draw_children: true
           }

--- a/src/ggrc/assets/javascripts/apps/business_objects.js
+++ b/src/ggrc/assets/javascripts/apps/business_objects.js
@@ -373,6 +373,16 @@
             mapping: 'programs',
             child_options: relatedObjectsChildOptions,
             draw_children: true
+          },
+          Risk: {
+            mapping: 'risks',
+            child_options: relatedObjectsChildOptions,
+            draw_children: true
+          },
+          Threat: {
+            mapping: 'threats',
+            child_options: relatedObjectsChildOptions,
+            draw_children: true
           }
         },
         issues: {
@@ -502,12 +512,12 @@
             draw_children: true
           },
           Threat: {
-            mapping: 'threat',
+            mapping: 'threats',
             child_options: relatedObjectsChildOptions,
             draw_children: true
           },
           Risk: {
-            mapping: 'risk',
+            mapping: 'risks',
             child_options: relatedObjectsChildOptions,
             draw_children: true
           },
@@ -568,7 +578,7 @@
             child_options: relatedObjectsChildOptions,
             draw_children: true
           }
-         },
+        },
         Regulation: {
           _mixins: ['directive', 'issues']
         },
@@ -857,6 +867,16 @@
             add_item_view: null,
             header_view: path + '/assessments/tree_header.mustache',
             footer_view: path + '/base_objects/tree_footer.mustache'
+          },
+          Risk: {
+            mapping: 'extended_related_risks_via_search',
+            child_options: relatedObjectsChildOptions,
+            draw_children: true
+          },
+          Threat: {
+            mapping: 'extended_related_threats_via_search',
+            child_options: relatedObjectsChildOptions,
+            draw_children: true
           }
         }
       });

--- a/src/ggrc/assets/javascripts/components/tests/mapper-model_spec.js
+++ b/src/ggrc/assets/javascripts/components/tests/mapper-model_spec.js
@@ -35,17 +35,15 @@ describe('GGRC.Models.MapperModel', function () {
         'Section',
         'Standard',
         'System',
-        'Vendor'
+        'Vendor',
+        'Risk',
+        'Threat'
       ],
       notMappable: ['Assessment', 'Issue', 'AssessmentTemplate']
     },
     risk_assessments: {
       models: ['RiskAssessment'],
       notMappable: ['RiskAssessment']
-    },
-    risks: {
-      models: ['Risk', 'Threat'],
-      notMappable: []
     },
     workflows: {
       models: [
@@ -98,8 +96,8 @@ describe('GGRC.Models.MapperModel', function () {
     Clause: _.difference(filtered, ['Clause']),
     Contract: _.difference(filtered, directives),
     Control: filtered,
-    CycleTaskGroupObjectTask: _.difference(filtered, ['Person', 'Risk',
-      'TaskGroup', 'Threat', 'Workflow']),
+    CycleTaskGroupObjectTask: _.difference(filtered, ['Person',
+      'TaskGroup', 'Workflow']),
     DataAsset: filtered,
     Facility: filtered,
     Issue: _.difference(filtered, ['Audit', 'Person', 'Program', 'Project',
@@ -116,14 +114,14 @@ describe('GGRC.Models.MapperModel', function () {
       modules.workflows.notMappable)),
     Project: filtered,
     Regulation: _.difference(filtered, directives),
-    Risk: _.difference(filtered, ['Audit', 'Risk']),
+    Risk: filtered,
     RiskAssessment: [],
     Section: filtered,
     Standard: _.difference(filtered, directives),
     System: filtered,
-    TaskGroup: _.difference(filtered, ['Audit', 'Person', 'Risk', 'TaskGroup',
-      'Threat', 'Workflow']),
-    Threat: _.difference(filtered, ['Audit', 'Threat']),
+    TaskGroup: _.difference(filtered, ['Audit', 'Person',
+      'TaskGroup', 'Workflow']),
+    Threat: filtered,
     Vendor: filtered
   };
 

--- a/src/ggrc/assets/javascripts/models/mappers/mappings-ggrc.js
+++ b/src/ggrc/assets/javascripts/models/mappers/mappings-ggrc.js
@@ -118,6 +118,8 @@
       related_audits: TypeFilter('related_objects', 'Audit'),
       related_controls: TypeFilter('related_objects', 'Control'),
       related_assessments: TypeFilter('related_objects', 'Assessment'),
+      related_risks: TypeFilter('related_objects', 'Risk'),
+      related_threats: TypeFilter('related_objects', 'Threat'),
       regulations: TypeFilter('related_objects', 'Regulation'),
       contracts: TypeFilter('related_objects', 'Contract'),
       policies: TypeFilter('related_objects', 'Policy'),
@@ -128,9 +130,7 @@
       clauses: TypeFilter('related_objects', 'Clause'),
       objectives: TypeFilter('related_objects', 'Objective'),
       risks: TypeFilter('related_objects', 'Risk'),
-      related_risks: TypeFilter('related_objects', 'Risk'),
-      threats: TypeFilter('related_objects', 'Threat'),
-      related_threats: TypeFilter('related_objects', 'Threat')
+      threats: TypeFilter('related_objects', 'Threat')
     },
     // Program
     Program: {
@@ -267,6 +267,8 @@
       owned_products: Indirect('Product', 'contact'),
       owned_projects: Indirect('Project', 'contact'),
       owned_systems: Indirect('System', 'contact'),
+      owned_risks: Indirect('Risk', 'contact'),
+      owned_threats: Indirect('Threat', 'contact'),
       related_objects: Proxy(
         null, 'personable', 'ObjectPerson', 'person', 'object_people'),
       related_programs: TypeFilter('related_objects', 'Program'),
@@ -289,6 +291,8 @@
       related_projects: TypeFilter('related_objects', 'Project'),
       related_systems: TypeFilter('related_objects', 'System'),
       related_issues: TypeFilter('related_objects', 'Issue'),
+      related_risks: TypeFilter('related_objects', 'Risk'),
+      related_threats: TypeFilter('related_objects', 'Threat'),
       authorizations: Direct('UserRole', 'person', 'user_roles'),
       programs_via_authorizations:
         Cross('authorizations', 'program_via_context'),
@@ -334,7 +338,8 @@
         });
       }, 'Program,Regulation,Contract,Policy,Standard,Section,Clause,' +
         'Objective,Control,System,Process,DataAsset,AccessGroup,Product,' +
-        'Project,Facility,Market,OrgGroup,Vendor,Audit,Assessment,Issue'),
+        'Project,Facility,Market,OrgGroup,Vendor,' +
+        'Audit,Assessment,Issue,Risk,Threat'),
       extended_related_programs_via_search:
         TypeFilter('related_objects_via_search', 'Program'),
       extended_related_regulations_via_search:
@@ -378,7 +383,11 @@
       extended_related_issues_via_search:
         TypeFilter('related_objects_via_search', 'Issue'),
       extended_related_assessment_via_search:
-        TypeFilter('related_objects_via_search', 'Assessment')
+        TypeFilter('related_objects_via_search', 'Assessment'),
+      extended_related_risks_via_search:
+        TypeFilter('related_objects_via_search', 'Risk'),
+      extended_related_threats_via_search:
+        TypeFilter('related_objects_via_search', 'Threat')
     },
     Context: {
       _canonical: {
@@ -488,14 +497,10 @@
       }, 'CustomAttributeDefinition')
     },
     Risk: {
-      _mixins: [
-        'related_object', 'ownable'
-      ]
+      _mixins: ['directive_object']
     },
     Threat: {
-      _mixins: [
-        'related_object', 'ownable'
-      ]
+      _mixins: ['directive_object']
     }
   });
 })(window.GGRC, window.can);

--- a/src/ggrc/assets/javascripts/models/mappers/mappings-ggrc.js
+++ b/src/ggrc/assets/javascripts/models/mappers/mappings-ggrc.js
@@ -92,7 +92,7 @@
           'Product', 'Project', 'System', 'Regulation', 'Policy', 'Contract',
           'Standard', 'Program', 'Issue', 'Control', 'Section', 'Clause',
           'Objective', 'Audit', 'Assessment', 'AssessmentTemplate',
-          'AccessGroup', 'Document'
+          'AccessGroup', 'Document', 'Risk', 'Threat'
         ]
       },
       related_objects_as_source: Proxy(
@@ -126,7 +126,11 @@
       controls: TypeFilter('related_objects', 'Control'),
       sections: TypeFilter('related_objects', 'Section'),
       clauses: TypeFilter('related_objects', 'Clause'),
-      objectives: TypeFilter('related_objects', 'Objective')
+      objectives: TypeFilter('related_objects', 'Objective'),
+      risks: TypeFilter('related_objects', 'Risk'),
+      related_risks: TypeFilter('related_objects', 'Risk'),
+      threats: TypeFilter('related_objects', 'Threat'),
+      related_threats: TypeFilter('related_objects', 'Threat')
     },
     // Program
     Program: {
@@ -241,7 +245,7 @@
           'Program', 'Regulation', 'Contract', 'Policy', 'Standard',
           'AccessGroup', 'Objective', 'Control', 'Section', 'Clause',
           'DataAsset', 'Facility', 'Market', 'OrgGroup', 'Vendor', 'Process',
-          'Product', 'Project', 'System', 'Issue'],
+          'Product', 'Project', 'System', 'Issue', 'Risk', 'Threat'],
         authorizations: 'UserRole'
       },
       owned_programs: Indirect('Program', 'contact'),
@@ -482,6 +486,16 @@
           definition_id: null
         });
       }, 'CustomAttributeDefinition')
+    },
+    Risk: {
+      _mixins: [
+        'related_object', 'ownable'
+      ]
+    },
+    Threat: {
+      _mixins: [
+        'related_object', 'ownable'
+      ]
     }
   });
 })(window.GGRC, window.can);

--- a/src/ggrc/assets/stylesheets/modules/_top-nav.scss
+++ b/src/ggrc/assets/stylesheets/modules/_top-nav.scss
@@ -21,10 +21,10 @@ ul.internav {
     li {
       &.access_group, &.clause, &.contract, &.control, &.data_asset, &.facility,
       &.market, &.objective, &.org_group, &.policy, &.process, &.product,
-      &.regulation, &.section, &.standard, &.system, &.vendor {
+      &.regulation, &.section, &.standard, &.system, &.vendor, &.risk, &.threat {
         a {
           color: $blue;
-          @include opacity(1);
+          opacity: 1;
           &:hover {
             color: $blue;
           }
@@ -77,9 +77,9 @@ ul.internav {
         color: $black;
         font-weight: bold;
         background: $contentBgnd;
-        @include opacity(1);
+        opacity: 1;
         i {
-          @include opacity(1);
+          opacity: 1;
         }
         &:hover {
           color: $black;

--- a/src/ggrc_risks/assets/javascripts/apps/risks.js
+++ b/src/ggrc_risks/assets/javascripts/apps/risks.js
@@ -331,4 +331,4 @@
     GGRC.mustache_path + '/dashboard/lhn_risks');
 
   RisksExtension.init_mappings();
-})(this.can.$, this.CMS, this.GGRC);
+})(window.can.$, window.CMS, window.GGRC);

--- a/src/ggrc_risks/assets/javascripts/models/risk.js
+++ b/src/ggrc_risks/assets/javascripts/models/risk.js
@@ -4,6 +4,8 @@
  */
 
 (function (can) {
+  'use strict';
+
   can.Model.Cacheable('CMS.Models.Risk', {
     root_object: 'risk',
     root_collection: 'risks',
@@ -24,8 +26,8 @@
       risk_objects: 'CMS.Models.RiskObject.stubs'
     },
     tree_view_options: {
-      add_item_view: GGRC.mustache_path +
-      '/base_objects/tree_add_item.mustache',
+      add_item_view:
+        GGRC.mustache_path + '/base_objects/tree_add_item.mustache',
       attr_view: GGRC.mustache_path + '/base_objects/tree-item-attr.mustache'
     },
     defaults: {
@@ -34,14 +36,12 @@
     statuses: ['Draft', 'Deprecated', 'Active'],
     init: function () {
       var reqFields = ['title', 'description', 'contact'];
-      var i = 0;
       if (this._super) {
         this._super.apply(this, arguments);
       }
-
-      for (i; i < reqFields.length; i++) {
-        this.validatePresenceOf(reqFields[i]);
-      }
+      reqFields.forEach(function (reqField) {
+        this.validatePresenceOf(reqField);
+      }.bind(this));
     }
   }, {});
 })(window.can);

--- a/src/ggrc_risks/assets/javascripts/models/threat.js
+++ b/src/ggrc_risks/assets/javascripts/models/threat.js
@@ -4,6 +4,8 @@
  */
 
 (function (can) {
+  'use strict';
+
   can.Model.Cacheable('CMS.Models.Threat', {
     root_object: 'threat',
     root_collection: 'threats',


### PR DESCRIPTION
This PR also fixes [GGRC-1181](https://gojira.corp.google.com/browse/GGRC-1181)

Precondition:
created program, control, audit
Steps to reproduce:
1. Go to Assessment tab on the audit page
2. Select Generate assessment in 3 bb's menu
3. Select "Threats" Object type: confirm audit is not appear by default
4. Select "Controls": confirm audit is not appear by default as well
Actual Result: Audit is not shown in Disabled field in Unified mapper 
Expected Result: Audit should be shown in Disabled field in Unified mapper
