### PR TITLE
GGRC-1243 Hide readonly objects from the dropdown in filter by mapping

### DIFF
--- a/src/ggrc/assets/javascripts/components/relevant_filters.js
+++ b/src/ggrc/assets/javascripts/components/relevant_filters.js
@@ -54,6 +54,13 @@
         return _.sortBy(_.compact(_.map(_.keys(mappings), function (mapping) {
           return CMS.Models[mapping];
         })), 'model_singular');
+      },
+      optionHidden: function (option) {
+        var type = option.model_singular;
+        return can.makeArray(this.attr('relevantTo'))
+          .some(function (item) {
+            return item.readOnly && item.type === type;
+          });
       }
     },
     events: {

--- a/src/ggrc/assets/mustache/mapper/relevant_filter.mustache
+++ b/src/ggrc/assets/mustache/mapper/relevant_filter.mustache
@@ -29,7 +29,12 @@
             {{#readOnly}}disabled="disabled"{{/readOnly}}
             can-value="model_name">
       {{#menu}}
-        {{#if model_singular}}<option value="{{model_singular}}" label="{{title_singular}}"></option>{{/if}}
+        {{#if model_singular}}
+          <option value="{{model_singular}}"
+                  label="{{title_singular}}"
+                  {{#optionHidden}}hidden{{/optionHidden}}>
+          </option>
+        {{/if}}
       {{/menu}}
     </select>
     {{#filter}}


### PR DESCRIPTION
This PR hides readonly objects from the dropdown in filter by mapping.

Precondition:
created program, control, audit
Steps to reproduce:
1. Go to audit page-> Assessment's tab
2. Create New 
3. Click map objects button in New Assessment modal
4. Click + Filter by mapping: expand dropdown list
Actual Result: Audit is shown in dropdown list when open Filter by mapping
Expected Result: Audit should not be shown in dropdown list when open Filter by mapping