### PR TITLE
QUICK-FIX Disable db validator

### DIFF
--- a/bin/db_migrate
+++ b/bin/db_migrate
@@ -9,10 +9,6 @@ SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
 
 cd "${SCRIPTPATH}/../src"
 
-# Database validation is only needed for Audit snapshots migration.
-# Remove the next line if Raspberry has already been released.
-python /vagrant/bin/validate_database.py
-
 python -c "\
 import ggrc.migrate
 import sys, os


### PR DESCRIPTION
validate_database.py regularly blocks grc-test deployment because of Assessment-Issue mappings that are in fact allowed. I disabled it until the time when it is updated.