### PR TITLE
GGRC-1132 Assessments tree view filter: show special Assessment states instead of Active - Draft - Deprecated

### DIFF
--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -184,6 +184,7 @@ dashboard-js-files:
   - components/show-related-assessments-button/show-related-assessments-button.js
   - components/mapping-controls/mapping-type-selector.js
   - components/dropdown/dropdown.js
+  - components/dropdown/multiselect-dropdown.js
   - components/autocomplete/autocomplete.js
   - components/datepicker/datepicker.js
   - components/person/person.js
@@ -420,6 +421,7 @@ dashboard-js-template-files:
   - components/unified-mapper/mapper-results-columns-configuration.mustache
   - components/assessment_templates/assessment_templates.mustache
   - components/dropdown/dropdown.mustache
+  - components/dropdown/multiselect_dropdown.mustache
   - components/object_history/object_history.mustache
   - components/person/person.mustache
   - components/spinner/spinner.mustache

--- a/src/ggrc/assets/javascripts/components/dropdown/multiselect-dropdown.js
+++ b/src/ggrc/assets/javascripts/components/dropdown/multiselect-dropdown.js
@@ -86,7 +86,7 @@
         this.attr('_stateWasUpdated', false);
         can.trigger(el, 'multiselect:closed', [this.attr('selected')]);
       },
-      changeOpenCloseState: function (el, ev) {
+      changeOpenCloseState: function () {
         if (!this.attr('isOpen')) {
           if (this.attr('canBeOpen')) {
             this.attr('canBeOpen', false);
@@ -98,7 +98,7 @@
           this.dropdownClosed(this.element);
         }
       },
-      openDropdown: function (el, ev) {
+      openDropdown: function (el) {
         // we should save element of component.
         // it necessary for 'can.trigger'
         if (el && !this.element) {
@@ -124,8 +124,8 @@
 
         this.viewModel.updateSelected(target);
       },
-      '{window} click': function (el, ev) {
-        this.viewModel.changeOpenCloseState('', ev);
+      '{window} click': function () {
+        this.viewModel.changeOpenCloseState();
       }
     }
   });

--- a/src/ggrc/assets/javascripts/components/dropdown/multiselect-dropdown.js
+++ b/src/ggrc/assets/javascripts/components/dropdown/multiselect-dropdown.js
@@ -1,0 +1,132 @@
+/*!
+    Copyright (C) 2017 Google Inc.
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+(function (can, $) {
+  'use strict';
+
+  GGRC.Components('multiselectDropdown', {
+    tag: 'multiselect-dropdown',
+    template: can.view(
+      GGRC.mustache_path +
+      '/components/dropdown/multiselect_dropdown.mustache'
+    ),
+    viewModel: {
+      _stateWasUpdated: '',
+      selected: [],
+      plural: '@',
+      placeholder: '@',
+      element: '',
+      define: {
+        elementWidth: {
+          type: 'number',
+          value: 240
+        },
+        _displayValue: {
+          get: function () {
+            return this.attr('selected').map(function (item) {
+              return item.attr('value');
+            }).join(', ');
+          }
+        },
+        _selectedAll: {
+          type: 'boolean',
+          value: false,
+          get: function () {
+            var options = this.attr('options') || [];
+
+            return Array.prototype.every.call(options, function (item) {
+              return item.attr('checked');
+            });
+          },
+          set: function (value) {
+            var options = this.attr('options') || [];
+
+            options.forEach(function (option) {
+              option.attr('checked', value);
+            });
+
+            return value;
+          }
+        },
+        isOpen: {
+          type: 'boolean',
+          value: false
+        },
+        options: {
+          type: '*'
+        }
+      },
+      updateSelected: function (item) {
+        var selected = this.attr('selected');
+        var index = -1;
+
+        this.attr('_stateWasUpdated', true);
+
+        if (item.checked) {
+          selected.push(item);
+          return;
+        }
+
+        index = selected.map(function (selectedItem) {
+          return selectedItem.value;
+        }).indexOf(item.value);
+
+        if (index > -1) {
+          selected.splice(index, 1);
+        }
+      },
+      dropdownClosed: function (el, ev, scope) {
+        // don't trigger event if state didn't change
+        if (!this.attr('_stateWasUpdated')) {
+          return;
+        }
+
+        this.attr('_stateWasUpdated', false);
+        can.trigger(el, 'multiselect:closed', [this.attr('selected')]);
+      },
+      changeOpenCloseState: function (el, ev) {
+        if (!this.attr('isOpen')) {
+          if (this.attr('canBeOpen')) {
+            this.attr('canBeOpen', false);
+            this.attr('isOpen', true);
+          }
+        } else {
+          this.attr('isOpen', false);
+          this.attr('canBeOpen', false);
+          this.dropdownClosed(this.element);
+        }
+      },
+      openDropdown: function (el, ev) {
+        // we should save element of component.
+        // it necessary for 'can.trigger'
+        if (el && !this.element) {
+          this.element = el;
+        }
+
+        // this attr needed when page has any components
+        this.attr('canBeOpen', true);
+      },
+      dropdownBodyClick: function (ev) {
+        ev.stopPropagation();
+      }
+    },
+    events:
+    {
+      '{options} change': function (scope, ev, propertyName) {
+        var target = ev.target;
+
+        // igore all propetries except 'checked'
+        if (propertyName.indexOf('checked') === -1) {
+          return;
+        }
+
+        this.viewModel.updateSelected(target);
+      },
+      '{window} click': function (el, ev) {
+        this.viewModel.changeOpenCloseState('', ev);
+      }
+    }
+  });
+})(window.can, window.can.$);

--- a/src/ggrc/assets/javascripts/components/tests/multiselect_dropdown_spec.js
+++ b/src/ggrc/assets/javascripts/components/tests/multiselect_dropdown_spec.js
@@ -1,0 +1,196 @@
+/*!
+  Copyright (C) 2017 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+describe('GGRC.Components.multiselectDropdown', function () {
+  'use strict';
+
+  describe('updateSelected() method', function () {
+    var options;
+    var viewModel;
+
+    beforeEach(function () {
+      viewModel = GGRC.Components.getViewModel('multiselectDropdown');
+
+      options = [
+        {
+          value: 'Draft'
+        },
+        {
+          value: 'Active'
+        },
+        {
+          value: 'Open'
+        },
+        {
+          value: 'Deprecated'
+        }
+      ];
+
+      viewModel.attr('options', options);
+    });
+
+    it('updateSelected() should add new item in "selected"',
+      function () {
+        var selected;
+        var item = viewModel.attr('options')[1];
+        item.checked = true;
+
+        viewModel.updateSelected(item);
+        selected = viewModel.attr('selected');
+
+        expect(selected.length).toEqual(1);
+        expect(selected[0].value).toEqual(item.value);
+      }
+    );
+
+    it('updateSelected() should remove item from "selected"',
+      function () {
+        var selected = viewModel.attr('selected');
+        var options = viewModel.attr('options');
+        var item;
+
+        expect(selected.length).toEqual(0);
+
+        options.forEach(function (option) {
+          option.checked = true;
+          viewModel.updateSelected(option);
+        });
+
+        // we added all options in selected
+        expect(selected.length).toEqual(options.length);
+
+        item = viewModel.attr('options')[1];
+        item.checked = false;
+
+        // pass uchecked item
+        viewModel.updateSelected(item);
+
+        expect(selected.length).toEqual(options.length - 1);
+      }
+    );
+  });
+
+  describe('_displayValue attribute', function () {
+    var viewModel;
+    var options;
+    var draftItem;
+    var activeItem;
+    var openItem;
+
+    beforeEach(function () {
+      viewModel = GGRC.Components.getViewModel('multiselectDropdown');
+
+      options = [
+        {
+          value: 'Draft'
+        },
+        {
+          value: 'Active'
+        },
+        {
+          value: 'Open'
+        },
+        {
+          value: 'Deprecated'
+        }
+      ];
+
+      viewModel.attr('options', options);
+
+      draftItem = options[0];
+      activeItem = options[1];
+      openItem = options[2];
+    });
+
+    it('check "_displayValue" after add new "seleted"',
+      function () {
+        draftItem.checked = true;
+        activeItem.checked = true;
+
+        // select items
+        viewModel.updateSelected(draftItem);
+        viewModel.updateSelected(activeItem);
+
+        expect(viewModel.attr('_displayValue'))
+          .toEqual(draftItem.value + ', ' + activeItem.value);
+      }
+    );
+
+    it('check "_displayValue" after remove item from "seleted"',
+      function () {
+        draftItem.checked = true;
+        activeItem.checked = true;
+        openItem.checked = true;
+
+        // select items
+        viewModel.updateSelected(draftItem);
+        viewModel.updateSelected(activeItem);
+        viewModel.updateSelected(openItem);
+
+        // remove activeItem from 'selected' array
+        activeItem.checked = false;
+        viewModel.updateSelected(activeItem);
+
+        // '_displayValue' should contain values of 'draftItem' and 'openItem' items
+        expect(viewModel.attr('_displayValue'))
+          .toEqual(draftItem.value + ', ' + openItem.value);
+      }
+    );
+  });
+
+  describe('"open/close" state of component', function () {
+    var viewModel;
+
+    beforeEach(function () {
+      viewModel = GGRC.Components.getViewModel('multiselectDropdown');
+      viewModel.attr('options', [{value: 'someOption'}]);
+    });
+
+    it('open dropdown',
+      function () {
+        // click on dropdown input
+        viewModel.openDropdown();
+
+        // "window.click" event is triggered after click on dropdown input
+        viewModel.changeOpenCloseState();
+        expect(viewModel.attr('isOpen')).toEqual(true);
+        expect(viewModel.attr('canBeOpen')).toEqual(false);
+      }
+    );
+
+    it('close dropdown without changing of options',
+      function () {
+        spyOn(can, 'trigger');
+        viewModel.attr('isOpen', true);
+
+        // simulate "window.click" event
+        viewModel.changeOpenCloseState();
+
+        expect(viewModel.attr('isOpen')).toEqual(false);
+        expect(viewModel.attr('canBeOpen')).toEqual(false);
+        expect(can.trigger.calls.count()).toEqual(0);
+      }
+    );
+
+    it('close dropdown with changing of options',
+      function () {
+        var item = viewModel.attr('options')[0];
+        spyOn(can, 'trigger');
+        viewModel.attr('isOpen', true);
+
+        // change state of item
+        item.checked = true;
+        viewModel.updateSelected(item);
+
+        // simulate "window.click" event
+        viewModel.changeOpenCloseState();
+
+        expect(viewModel.attr('isOpen')).toEqual(false);
+        expect(viewModel.attr('canBeOpen')).toEqual(false);
+        expect(can.trigger.calls.count()).toEqual(1);
+      }
+    );
+  });
+});

--- a/src/ggrc/assets/javascripts/controllers/tree/tree-view.js
+++ b/src/ggrc/assets/javascripts/controllers/tree/tree-view.js
@@ -30,6 +30,7 @@
         disabled: false
       },
       fields: [],
+      filter_states: [],
       sortable: true,
       start_expanded: false, // true
       draw_children: true,
@@ -260,6 +261,18 @@
     init: function (el, opts) {
       var setAllowMapping;
 
+      this.options.attr('filter_states', [
+        {
+          value: 'Active'
+        },
+        {
+          value: 'Draft'
+        },
+        {
+          value: 'Deprecated'
+        }
+      ]);
+
       this.element.closest('.widget')
         .on('widget_hidden', this.widget_hidden.bind(this));
       this.element.closest('.widget')
@@ -391,19 +404,13 @@
                 .find('.tree-filter__status-wrap');
               // set state filter (checkboxes)
               can.bind.call(statusControl.ready(function () {
-                self.element.parent()
-                  .find('.attr-status').each(function (i, e) {
-                    if (self.options.attr('selectStateList')
-                      .indexOf(e.value) > -1) {
-                      e.checked = true;
-                    }
-                  });
+                self.options.attr('filter_states').forEach(function (item) {
+                  if (self.options.attr('selectStateList')
+                    .indexOf(item.value) > -1) {
+                    item.attr('checked', true);
+                  }
+                });
               }));
-              // listen to changes in the state filter
-              can.bind.call(statusControl.find('input[type=checkbox]'),
-                'click',
-                this.saveTreeStates.bind(this)
-              );
             }.bind(this))));
       }
 
@@ -1152,13 +1159,12 @@
       savedStateList = this.display_prefs.getTreeViewStates(modelName);
       this.options.attr('selectStateList', savedStateList);
     },
-    saveTreeStates: function () {
-      var $checkState = this.element.parent().find('.attr-status');
-      var $selectedState = $checkState.filter(':checked');
+    saveTreeStates: function (selectedStates) {
       var stateToSave = [];
-      $selectedState.each(function () {
-        stateToSave.push(this.value);
+      selectedStates.forEach(function (state) {
+        stateToSave.push(state.value);
       });
+
       this.options.attr('selectStateList', stateToSave);
       this.display_prefs.setTreeViewStates(this.options.model.model_singular,
         stateToSave);
@@ -1266,7 +1272,8 @@
       this.refreshList();
     },
 
-    filter: function (filterString) {
+    filter: function (filterString, selectedStates) {
+      this.saveTreeStates(selectedStates);
       this.options.attr('paging.filter', filterString);
       this.options.attr('paging.current', 1);
       this.refreshList();

--- a/src/ggrc/assets/javascripts/controllers/tree/tree-view.js
+++ b/src/ggrc/assets/javascripts/controllers/tree/tree-view.js
@@ -260,18 +260,14 @@
 
     init: function (el, opts) {
       var setAllowMapping;
+      var states = GGRC.Utils.State
+        .getStatesForModel(this.options.model.shortName);
 
-      this.options.attr('filter_states', [
-        {
-          value: 'Active'
-        },
-        {
-          value: 'Draft'
-        },
-        {
-          value: 'Deprecated'
-        }
-      ]);
+      var filterStates = states.map(function (state) {
+        return {value: state};
+      });
+
+      this.options.attr('filter_states', filterStates);
 
       this.element.closest('.widget')
         .on('widget_hidden', this.widget_hidden.bind(this));
@@ -404,9 +400,13 @@
                 .find('.tree-filter__status-wrap');
               // set state filter (checkboxes)
               can.bind.call(statusControl.ready(function () {
+                var unwrappedStates = self.options.attr('selectStateList')
+                  .map(function (state) {
+                    return state.replace(/"/g, '');
+                  });
+
                 self.options.attr('filter_states').forEach(function (item) {
-                  if (self.options.attr('selectStateList')
-                    .indexOf(item.value) > -1) {
+                  if (unwrappedStates.indexOf(item.value) > -1) {
                     item.attr('checked', true);
                   }
                 });
@@ -1161,8 +1161,13 @@
     },
     saveTreeStates: function (selectedStates) {
       var stateToSave = [];
+
+      selectedStates = selectedStates || [];
+
       selectedStates.forEach(function (state) {
-        stateToSave.push(state.value);
+        // wrap in quotes
+        var value = '"' + state.value + '"';
+        stateToSave.push(value);
       });
 
       this.options.attr('selectStateList', stateToSave);

--- a/src/ggrc/assets/javascripts/controllers/tree/tree_filter_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/tree/tree_filter_controller.js
@@ -59,43 +59,31 @@ can.Control('GGRC.Controllers.TreeFilter', {}, {
     this.element.find('.tree-filter__expression-holder span i')
       .toggleClass('fa-check-circle-o', !isExpression);
   },
-  apply_filter: function (filterString) {
+  apply_filter: function (filterString, selectedStates) {
     var currentFilter = GGRC.query_parser.parse(filterString);
     var parentControl = this.element
       .closest('.cms_controllers_dashboard_widgets')
       .find('.cms_controllers_tree_view').control();
 
     this.toggle_indicator(currentFilter);
-    parentControl.filter(filterString);
+    parentControl.filter(filterString, selectedStates);
   },
   'input[type=reset] click': function (el, ev) {
-    this.element.find('input[type=text]').val('');
+    this.element.find('input[name=filter_query]').val('');
     this.apply_filter('');
   },
   'input[type=submit] click': function (el, ev) {
     this.apply_filter(this.$txtFilter.val());
   },
-  'input[type=checkbox] click': function (el, ev) {
-    this.apply_filter(this.$txtFilter.val());
+  'multiselect-dropdown multiselect:closed': function (el, ev, selectedStates) {
+    this.apply_filter(this.$txtFilter.val(), selectedStates);
+    ev.stopPropagation();
   },
   'input keyup': function (el, ev) {
     this.toggle_indicator(GGRC.query_parser.parse(el.val()));
 
     if (ev.keyCode === 13) {
       this.apply_filter(el.val());
-    }
-    ev.stopPropagation();
-  },
-  'input, select change': function (el, ev) {
-    // this is left from the old filters and should eventually be replaced
-    // Convert '.' to '__' ('.' will cause can.Observe to try to update a path instead of just a key)
-    var name = el.attr('name').replace(/\./g, '__');
-    if (el.is('.hasDatepicker')) {
-      this.options.states.attr(name, moment(el.val(), 'MM/DD/YYYY'));
-    } else if (el.is(':checkbox') && !el.is(':checked')) {
-      this.options.states.removeAttr(name);
-    } else {
-      this.options.states.attr(name, el.val());
     }
     ev.stopPropagation();
   },

--- a/src/ggrc/assets/javascripts/plugins/utils/state-utils.js
+++ b/src/ggrc/assets/javascripts/plugins/utils/state-utils.js
@@ -9,15 +9,32 @@
    * Utils for state.
    */
   GGRC.Utils.State = (function () {
-    var stateModels = ['AccessGroup', 'Clause', 'Contract',
-       'Control', 'DataAsset', 'Facility', 'Issue', 'Market',
-       'Objective', 'OrgGroup', 'Policy', 'Process', 'Product', 'Program',
-       'Project', 'Regulation', 'Risk', 'Section', 'Standard', 'System',
-       'Threat', 'Vendor', 'Issue'];
-    var notFilterableModels = [
-      'Audit', 'Person', 'Assessment',
-      'AssessmentTemplate', 'Workflow',
-      'TaskGroup', 'Cycle', 'CycleTaskGroupObjectTask'
+    var statesModels = [
+      {
+        models: [
+          'AccessGroup', 'Clause', 'Contract',
+          'Control', 'DataAsset', 'Facility', 'Issue', 'Market',
+          'Objective', 'OrgGroup', 'Policy', 'Process', 'Product', 'Program',
+          'Project', 'Regulation', 'Risk', 'Section', 'Standard', 'System',
+          'Threat', 'Vendor', 'Issue'
+        ],
+        states: ['Active', 'Draft', 'Deprecated']
+      },
+      {
+        models: ['Assessment'],
+        states: [
+          'Not Started', 'In Progress', 'Ready for Review',
+          'Verified', 'Completed'
+        ]
+      },
+      {
+        models: [
+          'Audit', 'Person', 'CycleTaskGroupObjectTask',
+          'AssessmentTemplate', 'Workflow',
+          'TaskGroup', 'Cycle'
+        ],
+        states: []
+      }
     ];
 
     /**
@@ -26,7 +43,13 @@
      * @return {Boolean} True or False
      */
     function hasState(model) {
-      return stateModels.indexOf(model) > -1;
+      var pair = getStatesModelsPair(model);
+
+      if (!pair) {
+        return false;
+      }
+
+      return pair.states.length > 0;
     }
 
     /**
@@ -35,7 +58,30 @@
      * @return {Boolean} True or False
      */
     function hasFilter(model) {
-      return notFilterableModels.indexOf(model) < 0;
+      return hasState(model);
+    }
+
+    /**
+     * Get States-Models pair.
+     * @param {String} model - The model name
+     * @return {Object} object with 'models' and 'states' properties
+     */
+    function getStatesModelsPair(model) {
+      var pairs = statesModels.filter(function (item) {
+        return item.models.indexOf(model) > -1;
+      });
+
+      return pairs.length > 0 ? pairs[0] : null;
+    }
+
+     /**
+     * Get states for model.
+     * @param {String} model - The model name
+     * @return {Array} array of strings
+     */
+    function getStatesForModel(model) {
+      var pair = getStatesModelsPair(model);
+      return pair ? pair.states : [];
     }
 
     /**
@@ -64,7 +110,8 @@
     return {
       hasState: hasState,
       hasFilter: hasFilter,
-      statusFilter: statusFilter
+      statusFilter: statusFilter,
+      getStatesForModel: getStatesForModel
     };
   })();
 })(window.GGRC);

--- a/src/ggrc/assets/mustache/base_objects/tree_view_filter.mustache
+++ b/src/ggrc/assets/mustache/base_objects/tree_view_filter.mustache
@@ -30,12 +30,11 @@
           </div>
           <div class="tree-filter__status-wrap">
             {{#if statusFilterVisible}}
-            <input type="checkbox" name="active" id="statusActive-{{model.model_singular}}" value="Active" class="attr-status">
-            <label for="statusActive-{{model.model_singular}}">Active</label>
-            <input type="checkbox" name="draft" id="statusDraft-{{model.model_singular}}" value="Draft" class="attr-status">
-            <label for="statusDraft-{{model.model_singular}}">Draft</label>
-            <input type="checkbox" name="deprecated" id="statusDeprecated-{{model.model_singular}}" value="Deprecated" class="attr-status">
-            <label for="statusDeprecated-{{model.model_singular}}">Deprecated</label>
+            <multiselect-dropdown 
+              {options}="filter_states"
+              placeholder="Filter by State",
+              plural="States">
+            </multiselect-dropdown>
             {{/if}}
           </div>
           <div class="tree-filter__paging-wrap">

--- a/src/ggrc/assets/mustache/components/dropdown/multiselect_dropdown.mustache
+++ b/src/ggrc/assets/mustache/components/dropdown/multiselect_dropdown.mustache
@@ -1,0 +1,46 @@
+{{!
+  Copyright (C) 2017 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+}}
+
+<div class="multiselect-dropdown flex-box flex-col" style="width: {{elementWidth}}px;">
+  <div class="multiselect-dropdown__input-container" ($click)="openDropdown($element, %event)"> 
+    <input 
+      style="width: {{elementWidth}}px;"
+      type="text"
+      readonly="readonly" 
+      class="multiselect-dropdown__input" 
+      placeholder="{{placeholder}}" 
+      value="{{_displayValue}}"/>
+    <span class="multiselect-dropdown__icon">
+      <i class="fa fa-sort"></i>
+    </span>
+  </div>
+  {{#if isOpen}}
+  <div class="dropdown-menu dropdown-menu-form multiselect-dropdown__body" ($click)="dropdownBodyClick(%event)">
+    <ul class="multiselect-dropdown__list">
+      <li class="multiselect-dropdown__element">
+        <label class="multiselect-dropdown__label" >
+          <input type="checkbox" {($checked)}="_selectedAll" class="multiselect-dropdown__checkbox"/>
+          Select all
+        </label>
+      </li>
+      {{#options}}
+      <li class="multiselect-dropdown__element">
+        <label class="multiselect-dropdown__label">
+          <input type="checkbox"
+            {($checked)}="checked"
+            value="{{value}}"
+            name="{{name}}"
+            id="{{id}}"
+            class="multiselect-dropdown__checkbox {{cssClass}}"
+            />
+          {{value}}
+        </label>
+      </li>
+      {{/options}}
+    </ul>
+  </div>
+  {{/if}}
+</div>
+

--- a/src/ggrc/assets/stylesheets/_components.scss
+++ b/src/ggrc/assets/stylesheets/_components.scss
@@ -24,3 +24,4 @@
 @import "components/object-selection/object-selection";
 @import "components/sub-tree-expander/sub-tree-expander";
 @import "components/tree-node-actions/tree-node-actions";
+@import "components/multiselect-dropdown/multiselect-dropdown";

--- a/src/ggrc/assets/stylesheets/components/multiselect-dropdown/_multiselect-dropdown.scss
+++ b/src/ggrc/assets/stylesheets/components/multiselect-dropdown/_multiselect-dropdown.scss
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ * Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+.multiselect-dropdown {
+  input.multiselect-dropdown__input {
+    padding: 4px 24px 4px 8px;
+    margin: 0;
+    box-sizing: border-box;
+    height:28px;
+    line-height: 28px;
+    border-radius: 0;
+    box-shadow: none;
+    cursor: pointer;
+    user-select: none;
+    text-overflow: ellipsis;
+  }
+
+  .multiselect-dropdown {
+    &__body {
+      position: relative;
+      top: -1px !important;
+      z-index: 2000;
+      float: none;
+      display: block;
+      border-radius: 0;
+    }
+
+    &__list {
+      list-style-type: none;
+      margin-left: 0px;
+      margin-bottom: 0px;
+    }
+
+    &__element {
+      &:hover {
+        background-color: $defaultBlue;
+        color: white;
+      }
+    }
+
+    &__icon {
+      position: absolute;
+      width: 24px;
+      height: 28px;
+      line-height: 28px;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      right: 0;
+      top: 0;
+    }
+
+    &__input-container {
+      cursor: pointer;
+      line-height: 28px;
+      position: relative;
+    }
+
+    &__label {
+      width: 96%;
+      margin: 0px 0px 0px 0px;
+      padding: 2px 0px 2px 5px;
+      font-size: 12px;
+      user-select: none;
+    }
+
+    &__checkbox {
+      margin: 0px 3px 0px 3px;
+    }
+  }
+}

--- a/src/ggrc/assets/stylesheets/modules/_filters.scss
+++ b/src/ggrc/assets/stylesheets/modules/_filters.scss
@@ -171,15 +171,15 @@
       &__paging-wrap {
         display: block;
         position: absolute;
-        width: 400px;
+        width: 350px;
         right: 0;
         top: 0;
       }
       &__status-wrap {
-        right: 400px;
+        right: 350px;
         display: block;
         position: absolute;
-        top: 0;
+        top: -2px;
         font-size: 12px;
         label {
           text-transform: none;

--- a/test/selenium/src/lib/base.py
+++ b/test/selenium/src/lib/base.py
@@ -250,7 +250,7 @@ class Button(Element):
 class Checkbox(Element):
   """A generic checkbox element"""
 
-  def __init__(self, driver, locator, is_checked=False):
+  def __init__(self, driver, locator):
     super(Checkbox, self).__init__(driver, locator)
     self.is_checked = self.element.is_selected()
 
@@ -387,9 +387,7 @@ class Modal(Component):
 
 
 class FilterCommon(Component):
-  """A common filter elements for LHN and tree view
-  (without filter checkboxes).
-  """
+  """A common filter elements for LHN and tree view."""
 
   def __init__(self, driver, text_box_locator, bt_submit_locator,
                bt_clear_locator):
@@ -410,38 +408,6 @@ class FilterCommon(Component):
   def clear_query(self):
     """Clear the query that was entered to field."""
     self.button_clear.click()
-
-
-class Filter(FilterCommon):
-  """A filter elements for tree view with filter checkboxes."""
-
-  def __init__(self, driver, text_box_locator, bt_submit_locator,
-               bt_clear_locator, ch_active_locator, ch_draft_locator,
-               ch_deprecated_locator):
-    super(Filter, self).__init__(driver, text_box_locator, bt_submit_locator,
-                                 bt_clear_locator)
-    self.checkbox_active = Checkbox(driver, ch_active_locator)
-    self.checkbox_draft = Checkbox(driver, ch_draft_locator)
-    self.checkbox_deprecated = Checkbox(driver, ch_deprecated_locator)
-
-  def show_active_objs(self):
-    """Select 'Active' checkbox to show all active objects."""
-    self.checkbox_active.check()
-
-  def show_draft_objs(self):
-    """Select 'Draft' checkbox to show all draft objects."""
-    self.checkbox_draft.check()
-
-  def show_deprecated_objs(self):
-    """Select 'Deprecated' checkbox to show all deprecated objects."""
-    self.checkbox_deprecated.check()
-
-  def show_all_objs(self):
-    """Select 'Active', 'Draft', 'Deprecated' checkboxes to show all objects.
-    """
-    self.show_active_objs()
-    self.show_draft_objs()
-    self.show_deprecated_objs()
 
 
 class AbstractPage(Component):

--- a/test/selenium/src/lib/constants/locator.py
+++ b/test/selenium/src/lib/constants/locator.py
@@ -646,6 +646,7 @@ class ObjectWidget(object):
 
 
 class ModalDeleteObject(object):
+  """Locators for the modal of deletion object."""
   MODAL_TITLE = (By.CSS_SELECTOR, '.modal-header>h2')
   CONFIRMATION_TEXT = (By.CSS_SELECTOR, '.modal-body>div>p')
   OBJECT_TITLE = (By.CSS_SELECTOR, '.modal-body>div>p>span')
@@ -882,38 +883,33 @@ class BaseWidgetGeneric(object):
     class should look like. Note that the same functionality can be
     implemented using properties though with more code."""
     def __init__(cls, *args):
+      _FILTER = "#{}_widget .sticky-filter"
+      _FILTER_BUTTON = _FILTER + " .tree-filter__button"
+      _FILTER_DROPDOWN = _FILTER + " .multiselect-dropdown"
+      _FILTER_DROPDOWN_ELEMENTS = \
+          _FILTER_DROPDOWN + " .multiselect-dropdown__element"
       cls.TEXTFIELD_TO_FILTER = (
-          By.CSS_SELECTOR,
-          '#{}_widget .sticky-filter .tree-filter__expression-holder'
+          By.CSS_SELECTOR, str(_FILTER + " .tree-filter__expression-holder")
             .format(cls._object_name))
       cls.BUTTON_FILTER = (
           By.CSS_SELECTOR,
-          '#{}_widget .sticky-filter .tree-filter__button [type="submit"]'
-            .format(cls._object_name))
+          str(_FILTER_BUTTON + ' [type="submit"]').format(cls._object_name))
       cls.BUTTON_RESET = (
           By.CSS_SELECTOR,
-          '#{}_widget .sticky-filter .tree-filter__button [type="reset"]'
-            .format(cls._object_name))
+          str(_FILTER_BUTTON + ' [type="reset"]').format(cls._object_name))
       cls.BUTTON_HELP = (
           By.CSS_SELECTOR,
-          '#{}_widget .sticky-filter .tree-filter__button  #page-help'
+          str(_FILTER_BUTTON + " #page-help").format(cls._object_name))
+      cls.DROPDOWN = (
+          By.CSS_SELECTOR,
+          str(_FILTER_DROPDOWN + " .multiselect-dropdown__input-container")
             .format(cls._object_name))
-      cls.ACTIVE_CHECKBOX = (
+      cls.DROPDOWN_STATES = (
           By.CSS_SELECTOR,
-          '#{}_widget .sticky-filter .tree-filter__status-wrap '
-          '[name="active"]'.format(cls._object_name))
-      cls.DRAFT_CHECKBOX = (
-          By.CSS_SELECTOR,
-          '#{}_widget .sticky-filter .tree-filter__status-wrap '
-          '[name="draft"]'.format(cls._object_name))
-      cls.CHECKBOX_DEPRECATED = (
-          By.CSS_SELECTOR,
-          '#{}_widget .sticky-filter .tree-filter__status-wrap '
-          '[name="deprecated"]'.format(cls._object_name))
-
+          str(_FILTER_DROPDOWN_ELEMENTS).format(cls._object_name))
   FILTER_PANE_COUNTER = (
-      By.CSS_SELECTOR, ".tree-pagination__count "
-                       ".tree-view-pagination__count__title")
+      By.CSS_SELECTOR,
+      ".tree-pagination__count .tree-view-pagination__count__title")
 
 
 class WidgetAssessments(BaseWidgetGeneric):

--- a/test/selenium/src/lib/page/widget/generic_widget.py
+++ b/test/selenium/src/lib/page/widget/generic_widget.py
@@ -25,24 +25,18 @@ class Widget(base.Widget):
 
   def __init__(self, driver):
     self.member_count = None
-    self.classes_of_objs_with_base_filter = (
-        AsmtTmpls.__name__,
-        Asmts.__name__)
+    self.cls_without_state_filtering = (AsmtTmpls,)
+    # Audits, Persons, Workflows, TaskGroups, Cycles, CycleTaskGroupObjectTasks
     self.common_filter_locators = dict(
         text_box_locator=self._locator_filter.TEXTFIELD_TO_FILTER,
         bt_submit_locator=self._locator_filter.BUTTON_FILTER,
         bt_clear_locator=self._locator_filter.BUTTON_RESET)
     self.button_help = base.Button(driver, self._locator_filter.BUTTON_HELP)
-    if self.__class__.__name__ in self.classes_of_objs_with_base_filter:
-      self.filter = base.FilterCommon(driver, **self.common_filter_locators)
-    else:
-      self.filter = base.Filter(
-          driver, ch_active_locator=self._locator_filter.ACTIVE_CHECKBOX,
-          ch_draft_locator=self._locator_filter.DRAFT_CHECKBOX,
-          ch_deprecated_locator=self._locator_filter.CHECKBOX_DEPRECATED,
-          **self.common_filter_locators)
-      self.filter.show_all_objs()
-
+    self.filter = base.FilterCommon(driver, **self.common_filter_locators)
+    if self.__class__ not in self.cls_without_state_filtering:
+      self.dropdown_states = base.DropdownStatic(
+          driver, dropdown_locator=self._locator_filter.DROPDOWN,
+          elements_locator=self._locator_filter.DROPDOWN_STATES)
     super(Widget, self).__init__(driver)
     self._set_members_listed()
 


### PR DESCRIPTION
New approach should be applied to all tables - drop-down with multiselect
By default - None selected
1) Show selected options in "Input" of dropdown
2) Option to select all states

Filter applied after closing the DDL: e.g. click out the filter

![_002](https://cloud.githubusercontent.com/assets/4204416/23259218/1bab7cac-f9dd-11e6-9235-76bb2fea842e.png)

![_003](https://cloud.githubusercontent.com/assets/4204416/23259217/1baa6966-f9dd-11e6-88b9-5d0ffb348dee.png)
