### PR TITLE
GGRC-1241 CA with name "type" can not be saved

### DIFF
--- a/src/ggrc/fulltext/__init__.py
+++ b/src/ggrc/fulltext/__init__.py
@@ -24,12 +24,12 @@ class Indexer(object):
 
 class Record(object):
 
-  def __init__(self, key, type, context_id, tags="", **kwargs):
+  def __init__(self, key, rec_type, context_id, properties, tags=""):
     self.key = key
-    self.type = type
+    self.type = rec_type
     self.context_id = context_id
     self.tags = tags
-    self.properties = kwargs
+    self.properties = properties
 
 
 def resolve_default_text_indexer():

--- a/src/ggrc/fulltext/recordbuilder.py
+++ b/src/ggrc/fulltext/recordbuilder.py
@@ -63,7 +63,7 @@ class RecordBuilder(object):
         record_id,
         record_type,
         obj.context_id,
-        **properties
+        properties
     )
 
 

--- a/test/integration/ggrc/fulltext/test_mysql.py
+++ b/test/integration/ggrc/fulltext/test_mysql.py
@@ -36,6 +36,21 @@ class TestCAD(TestCase):
     ).count()
     self.assertEqual(title1_count, 1)
 
+  def test_type_cad(self):
+    """Test CAD with the name 'type' """
+
+    title1 = "type"
+    cad1 = CAD(title=title1, definition_type="market")
+    factory = factories.MarketFactory()
+    CAV(custom_attribute=cad1, attributable=factory, attribute_value="x")
+
+    views.do_reindex()
+
+    title1_count = mysql.MysqlRecordProperty.query.filter(
+        mysql.MysqlRecordProperty.property == title1
+    ).count()
+    self.assertEqual(title1_count, 1)
+
   def test_unique_key(self):
     """Test object property uniqueness."""
     db.session.add(mysql.MysqlRecordProperty(


### PR DESCRIPTION
-	Create a CA with name "type" all lowercase letters not "Type" or anything like that.
-	Try to create an object with value inside the "type" custom attribute
expected: everything works
actual: server error
