### PR TITLE
GGRC-853 Hide create and import buttons if user doesn't have permissions

### DIFF
--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -1216,90 +1216,85 @@ Mustache.registerHelper('date', function (date, hideTime) {
  *  {{#is_allowed ACTION [ACTION2 ACTION3...] RESOURCE_TYPE_STRING context=CONTEXT_ID}} content {{/is_allowed}}
  *  {{#is_allowed ACTION RESOURCE_INSTANCE}} content {{/is_allowed}}
  */
-var allowed_actions = ["create", "read", "update", "delete", "view_object_page", "__GGRC_ADMIN__"];
-Mustache.registerHelper("is_allowed", function () {
-  var args = Array.prototype.slice.call(arguments, 0)
-    , actions = []
-    , resource
-    , resource_type
-    , context_unset = {}
-    , context_id = context_unset
-    , context_override
-    , options = args[args.length-1]
-    , passed = true
-    ;
+  var allowedActions = ['create', 'read', 'update', 'delete',
+    'view_object_page', '__GGRC_ADMIN__'];
+  Mustache.registerHelper('is_allowed', function () {
+    var args = Array.prototype.slice.call(arguments, 0);
+    var actions = [];
+    var resource;
+    var resourceType;
+    var contextUnset = {};
+    var contextId = contextUnset;
+    var contextOverride;
+    var options = args[args.length - 1];
+    var passed = true;
 
-  // Resolve arguments
-  can.each(args, function (arg, i) {
-    while (typeof arg === 'function' && arg.isComputed) {
-      arg = arg();
+    // Resolve arguments
+    can.each(args, function (arg, i) {
+      while (typeof arg === 'function' && arg.isComputed) {
+        arg = arg();
+      }
+
+      if (typeof arg === 'string' && can.inArray(arg, allowedActions) > -1) {
+        actions.push(arg);
+      } else if (typeof arg === 'string') {
+        resourceType = arg;
+      } else if (typeof arg === 'object' && arg instanceof can.Model) {
+        resource = arg;
+      }
+    });
+    if (options.hash && options.hash.hasOwnProperty('context')) {
+      contextId = options.hash.context;
+      if (typeof contextId === 'function' && contextId.isComputed) {
+        contextId = contextId();
+      }
+      if (contextId && typeof contextId === 'object' && contextId.id) {
+        // Passed in the context object instead of the context ID, so use the ID
+        contextId = contextId.id;
+      }
+      //  Using `context=null` in Mustache templates, when `null` is not defined,
+      //  causes `context_id` to be `""`.
+      if (contextId === '' || contextId === undefined) {
+        contextId = null;
+      } else if (contextId === 'for' || contextId === 'any') {
+        contextOverride = contextId;
+        contextId = undefined;
+      }
     }
 
-    if (typeof arg === 'string' && can.inArray(arg, allowed_actions) > -1) {
-      actions.push(arg);
+    if (resourceType && contextId === contextUnset) {
+      throw new Error(
+        'If `resource_type` is a string, `context` must be explicit');
     }
-    else if (typeof arg === 'string') {
-      resource_type = arg;
+    if (actions.length === 0) {
+      throw new Error('Must specify at least one action');
     }
-    else if (typeof arg === 'object' && arg instanceof can.Model) {
-      resource = arg;
+
+    if (resource) {
+      resourceType = resource.constructor.shortName;
+      contextId = resource.context ? resource.context.id : null;
     }
+
+    // Check permissions
+    can.each(actions, function (action) {
+      if (resource && Permission.is_allowed_for(action, resource)) {
+        passed = true;
+        return;
+      }
+      if (contextId !== undefined) {
+        passed = passed && Permission.is_allowed(action, resourceType,
+            contextId);
+      }
+      if (passed && contextOverride === 'for' && resource) {
+        passed = passed && Permission.is_allowed_for(action, resource);
+      } else if (passed && contextOverride === 'any' && resourceType) {
+        passed = passed && Permission.is_allowed_any(action, resourceType);
+      }
+    });
+
+    return passed ? options.fn(options.contexts || this) :
+      options.inverse(options.contexts || this);
   });
-  if (options.hash && options.hash.hasOwnProperty("context")) {
-    context_id = options.hash.context;
-    if (typeof context_id === 'function' && context_id.isComputed) {
-      context_id = context_id();
-    }
-    if (context_id && typeof context_id === "object" && context_id.id) {
-      // Passed in the context object instead of the context ID, so use the ID
-      context_id = context_id.id;
-    }
-    //  Using `context=null` in Mustache templates, when `null` is not defined,
-    //  causes `context_id` to be `""`.
-    if (context_id === "" || context_id === undefined) {
-      context_id = null;
-    } else if (context_id === 'for' || context_id === 'any') {
-      context_override = context_id;
-      context_id = undefined;
-    }
-  }
-
-  if (resource_type && context_id === context_unset) {
-    throw new Error(
-        "If `resource_type` is a string, `context` must be explicit");
-  }
-  if (actions.length === 0) {
-    throw new Error(
-        "Must specify at least one action");
-  }
-
-  if (resource) {
-    resource_type = resource.constructor.shortName;
-    context_id = resource.context ? resource.context.id : null;
-  }
-
-  // Check permissions
-  can.each(actions, function (action) {
-    if (resource && Permission.is_allowed_for(action, resource)) {
-      passed = true;
-      return;
-    }
-    if (context_id !== undefined) {
-      passed = passed && Permission.is_allowed(action, resource_type, context_id);
-    }
-    if (passed && context_override === 'for' && resource) {
-      passed = passed && Permission.is_allowed_for(action, resource);
-    }
-    else if (passed && context_override === 'any' && resource_type) {
-      passed = passed && Permission.is_allowed_any(action, resource_type);
-    }
-  });
-
-  return passed
-    ? options.fn(options.contexts || this)
-    : options.inverse(options.contexts || this)
-    ;
-});
 
 Mustache.registerHelper('any_allowed', function (action, data, options) {
   var passed = [],

--- a/src/ggrc/assets/mustache/audits/summary.mustache
+++ b/src/ggrc/assets/mustache/audits/summary.mustache
@@ -8,8 +8,8 @@
 
     <div class="span12">
         <section class="info audit-summary">
-
             <div class="info-pane-utility">
+              {{#is_allowed 'update' instance context='for'}}
                 <add-object-button
                     instance="instance"
                     linkclass="btn btn-small btn-draft"
@@ -28,6 +28,7 @@
                     plural="assessment_templates">
                 </add-object-button>
                 <assessment-generator-button audit="instance" button='true'></assessment-generator-button>
+                {{/is_allowed}}
             </div>
 
             <div class="tier-content">

--- a/src/ggrc/assets/mustache/components/add-object-button/add-object-button.mustache
+++ b/src/ggrc/assets/mustache/components/add-object-button/add-object-button.mustache
@@ -3,7 +3,7 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
 
-{{#is_allowed 'create' singular context=instance.context}}
+{{#is_allowed 'update' instance context='for'}}
     <a href="javascript://" class="{{linkclass}}"
         {{#if text}}
         rel="tooltip"

--- a/src/ggrc/assets/mustache/import_export/import_export_buttons.mustache
+++ b/src/ggrc/assets/mustache/import_export/import_export_buttons.mustache
@@ -3,10 +3,9 @@
   Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
 
-{{#if display_options.hideImportExport}}
-{{else}}
-
+{{^if display_options.hideImportExport}}
 {{^if_instance_of parent_instance 'Assessment'}}
+{{#is_allowed 'update' model.shortName context=parent_instance.context}}
 <li>
   <a href="/import"
     target="_blank"
@@ -15,6 +14,7 @@
     Import {{model.model_plural}}
   </a>
 </li>
+{{/is_allowed}}
 {{#if list.length}}
   <li>
     <a href="/export?model_type={{model.model_singular}}&relevant_type={{parent_instance.type}}&relevant_id={{parent_instance.id}}"
@@ -26,5 +26,4 @@
   </li>
 {{/if}}
 {{/if_instance_of}}
-
 {{/if}}


### PR DESCRIPTION
**Steps to reproduce:**
1. Create a program and add GC (progcreator@reciprocitylabs.com (engage007) as a program reader to the program
2. Create an audit
3. Log as a program reader (progcreator@reciprocitylabs.com (engage007)
4. Go to Audit summary page: confirm Create Assessment and Autogenerate buttons are present and there is a possibility to create and generate assessment
5. Go to Assessment tab-> Open 3 bb's menu: confirm import button is shown

_Actual Result:_ Global Creator as Program Reader/Global Reader can create/generate/import objects and map it to the Audit
_Expected Result:_ Global Creator as Program Reader/Global Reader cannot create/generate/import objects and map it to the Audit.