### PR TITLE
GGRC-1287 Fix evidence button color

### DIFF
--- a/src/ggrc/assets/stylesheets/modules/_assessment.scss
+++ b/src/ggrc/assets/stylesheets/modules/_assessment.scss
@@ -119,13 +119,6 @@
     ggrc-gdrive-picker-launcher {
       display: inline-block;
       margin: 0;
-
-      a.btn {
-        background: rgba(0, 0, 0, 0.15);
-        &:hover {
-          background: rgba(0, 0, 0, 0.175);
-        }
-      }
     }
 
     h6 {


### PR DESCRIPTION
**Steps to reproduce**:
1. Navigate to Assessment's Info pane 
2. Look at the + Add evidence button: in gray rectangle

**Actual Result**: Add evidence button is shown with a gray color
**Expected Result**: Add evidence button should be green

![image](https://cloud.githubusercontent.com/assets/567805/23301399/cad39454-fa9a-11e6-8722-113975623c07.png)
