### PR TITLE
GGRC-1465 Add Option stubs to Revision content

### DIFF
--- a/src/ggrc/utils/__init__.py
+++ b/src/ggrc/utils/__init__.py
@@ -306,3 +306,27 @@ def generate_query_chunks(query, chunk_size=1000):
   count = query.count()
   for offset in range(0, count, chunk_size):
     yield query.order_by('id').limit(chunk_size).offset(offset).all()
+
+
+def create_stub(object_, context_id=None):
+  """Create stub from model attribute
+
+  Args:
+    object_: Object instance
+  Returns:
+    Dict representation of stub
+  """
+  import ggrc.models as models
+
+  if object_:
+    id_ = object_.id
+    type_ = object_.type
+
+    model = getattr(models.all_models, type_)
+    return {
+        'type': type_,
+        'id': id_,
+        'context_id': context_id,
+        'href': u"/api/{}/{}".format(model._inflector.table_plural, id_),  # noqa # pylint: disable=protected-access
+    }
+  return None

--- a/test/integration/ggrc/models/test_snapshot.py
+++ b/test/integration/ggrc/models/test_snapshot.py
@@ -28,10 +28,8 @@ class TestSnapshot(TestCase):
       "directive",
       "directive_id",
 
-      "kind",
       "kind_id",
 
-      "means",
       "means_id",
 
       "meta_kind",
@@ -39,7 +37,6 @@ class TestSnapshot(TestCase):
       "network_zone",
       "network_zone_id",
 
-      "verify_frequency",
       "verify_frequency_id",
 
       "assertions",


### PR DESCRIPTION
This fixes snapshot rendering of `kind`, `means` and `verified_frequency`, however it doesn't address `Categories` and `Assertions` because those two create separate revisions. That will probably require refactoring of control type to convert to option attribute or move it to class which is probably outside of scope of this ticket.