### PR TITLE
GGRC-1025 Refresh tree view after mapping of snapshot

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/tests/tree_view_controller_spec.js
+++ b/src/ggrc/assets/javascripts/controllers/tests/tree_view_controller_spec.js
@@ -82,6 +82,17 @@ describe('CMS.Controllers.TreeView', function () {
       expect(result).toBeTruthy();
     });
 
+    it('right relationship for Snapshot', function () {
+      var result;
+
+      relationship.source = {type: 'bar'};
+      relationship.destination = {type: 'Snapshot'};
+
+      result = method(relationship, 'foo');
+
+      expect(result).toBeTruthy();
+    });
+
     it('right relationship without source', function () {
       var result;
 

--- a/src/ggrc/assets/javascripts/controllers/tree/tree-view.js
+++ b/src/ggrc/assets/javascripts/controllers/tree/tree-view.js
@@ -984,11 +984,13 @@
         return false;
       }
       if (instance.destination &&
-        instance.destination.type === shortName) {
+        (instance.destination.type === shortName ||
+         instance.destination.type === 'Snapshot')) {
         return true;
       }
       if (instance.source &&
-        instance.source.type === shortName) {
+        (instance.source.type === shortName ||
+         instance.source.type === 'Snapshot')) {
         return true;
       }
       return false;


### PR DESCRIPTION
Mapped object is not shown in tree view and tab is not increased by one after mapping on Assessment Info page

**Precondition**:
Created program, at least 2 controls, audit

**Steps to reproduce**:
1. Go to audit page
2. Create assessment and go to assessment Info page
3. Open Controls tab and click Map in tree view
4. Select one control that is mapped to audit and map: confirm the selected control is not displayed in tree view

**Actual Result**: Mapped object is not shown in tree view after mapping on Assessment Info page. Refresh is needed

**Expected Result**: Mapped object should be shown in tree view after mapping on Assessment Info page and tab should increase by one

![image](https://cloud.githubusercontent.com/assets/567805/23306769/fcc478e6-fab5-11e6-99da-c5d8fa51cb43.png)
![image](https://cloud.githubusercontent.com/assets/567805/23306903/7e32b532-fab6-11e6-97ce-6e443021c6ff.png)
