### PR TITLE
GGRC-1229 Update of "bindXHRToButton" function. Unit tests

### DIFF
--- a/src/ggrc/assets/javascripts/plugins/can_control.js
+++ b/src/ggrc/assets/javascripts/plugins/can_control.js
@@ -22,7 +22,7 @@
     bindXHRToButton : function(xhr, el, newtext, disable) {
       // binding of an ajax to a click is something we do manually
       var $el = $(el);
-      var oldtext = $el.text().trim() || $el[0].innerHTML;
+      var oldtext = $el[0].innerHTML;
 
       if(newtext) {
         $el[0].innerHTML = newtext;

--- a/src/ggrc/assets/javascripts/plugins/tests/can_control_spec.js
+++ b/src/ggrc/assets/javascripts/plugins/tests/can_control_spec.js
@@ -1,0 +1,91 @@
+/*!
+  Copyright (C) 2017 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+describe('can.Control', function () {
+  'use strict';
+
+  var Control;
+
+  beforeEach(function () {
+    Control = can.Control.prototype;
+  });
+
+  describe('bindXHRToButton() method', function () {
+    var dfd;
+
+    beforeEach(function () {
+      dfd = new can.Deferred();
+    });
+
+    function callBindXHRToButton(done, actualInnerHtml, newtext, disable) {
+      var element = $('<button>' + actualInnerHtml + '</button>');
+
+      // call bindXHRToButton()
+      Control.bindXHRToButton(dfd, element, newtext, disable);
+
+      // button should have 'disabled' class after call bindXHRToButton
+      expect(element.hasClass('disabled')).toEqual(true);
+
+      if (disable) {
+        // button should have 'disabled' attr after call bindXHRToButton
+        expect(element.attr('disabled')).toEqual('disabled');
+      }
+
+      if (newtext) {
+        // button should have 'newText' before dfd.resolve()
+        expect(element[0].innerHTML).toEqual(newtext);
+      }
+
+      dfd.then(
+        setTimeout(function () {
+          expect(element[0].innerHTML).toEqual(actualInnerHtml);
+
+          // button should not have 'disabled' class after dfd.resolve()
+          expect(element.hasClass('disabled')).toEqual(false);
+
+          if (disable) {
+            // button should not have 'disabled' attr after call bindXHRToButton
+            expect(element.attr('disabled')).toEqual(undefined);
+          }
+          done();
+        }, 3)
+      );
+
+      dfd.resolve();
+    }
+
+    it('bindXHRToButton() should save text of button', function (done) {
+      callBindXHRToButton(done, 'HELLO WORLD');
+    });
+
+    it('bindXHRToButton() should save icon inside button', function (done) {
+      callBindXHRToButton(done, '<i class="fa fa-icon"></i>');
+    });
+
+    it('bindXHRToButton() should save icon and text inside button',
+      function (done) {
+        callBindXHRToButton(done, '<i class="fa fa-icon"></i>My text');
+      }
+    );
+
+    it('bindXHRToButton() should save text of button. Disable button',
+      function (done) {
+        callBindXHRToButton(done, 'HELLO WORLD', '', true);
+      }
+    );
+
+    it('bindXHRToButton() should save icon inside button. New text',
+      function (done) {
+        callBindXHRToButton(done, '<i class="fa fa-icon"></i>', 'My new text');
+      }
+    );
+
+    it('bindXHRToButton() should save text of button. New text. Disable button',
+      function (done) {
+        callBindXHRToButton(done, 'HELLO WORLD', '<i class="fa"></i>', true);
+      }
+    );
+  });
+});


### PR DESCRIPTION
Steps to reproduce:

Create program, audit
On the audit page create assessment
Navigate to assessment's Info pane and click [+] button to attach evidence
Look at Add evidence [+] button: is not shown after adding evidence
Actual Result: Add evidence [+] button disappears after adding evidence
Expected Result: Add evidence [+] button should not disappear after adding evidence

Note: add evidence [+] button is shown after page refresh.