### PR TITLE
HOT-FIX Fix assessment context

### DIFF
--- a/src/ggrc/assets/javascripts/models/assessment.js
+++ b/src/ggrc/assets/javascripts/models/assessment.js
@@ -361,6 +361,9 @@
         return;
       }
 
+      // Make sure before create is called before save
+      this.before_create();
+
       if (this.audit) {
         auditLead = this.audit.contact.reify();
         if (currentUser === auditLead) {

--- a/src/ggrc/migrations/versions/20170219221807_4e7fda17abc7_fix_assessment_contexts.py
+++ b/src/ggrc/migrations/versions/20170219221807_4e7fda17abc7_fix_assessment_contexts.py
@@ -9,8 +9,6 @@ Create Date: 2017-02-19 22:18:07.518997
 # disable Invalid constant name pylint warning for mandatory Alembic variables.
 # pylint: disable=invalid-name
 
-from alembic import op
-
 # revision identifiers, used by Alembic.
 revision = '4e7fda17abc7'
 down_revision = '2f1cee67a8f3'
@@ -18,50 +16,7 @@ down_revision = '2f1cee67a8f3'
 
 def upgrade():
   """Upgrade database schema and/or data, creating a new revision."""
-  # Fixes assessments without audit context
-  # SELECT COUNT(*) FROM assessments
-  #  WHERE context_id is NULL;
-  sql = """
-  UPDATE assessments as a
-    JOIN relationships AS r ON r.source_id = a.id
-     AND r.source_type = 'Assessment' AND r.destination_type = 'Audit'
-    JOIN audits AS au ON r.destination_id = au.id
-     SET a.context_id = au.context_id
-   WHERE a.context_id is NULL;
-  """
-  op.execute(sql)
-  sql = """
-  UPDATE assessments as a
-    JOIN relationships AS r ON r.destination_id = a.id
-     AND r.destination_type = 'Assessment' AND r.source_type = 'Audit'
-    JOIN audits AS au ON r.source_id = au.id
-     SET a.context_id = au.context_id
-   WHERE a.context_id is NULL;
-  """
-  op.execute(sql)
-  # Fixes object_documents mapped to assessments without audit context
-  # SELECT COUNT(*) FROM object_documents
-  #  WHERE documentable_type = 'Assessment' AND context_id IS NULL;
-  sql = """
-  UPDATE object_documents AS od
-    JOIN assessments AS a ON od.documentable_id = a.id
-     SET od.context_id = a.context_id
-   WHERE documentable_type = 'Assessment' AND od.context_id IS NULL;
-  """
-  op.execute(sql)
-  # Fixes documents attached to assessments without audit context
-  # SELECT count(*)
-  #   FROM documents AS d
-  #   JOIN object_documents AS od ON d.id = od.document_id
-  #  WHERE od.documentable_type = 'Assessment' AND d.context_id IS NULL;
-  sql = """
-  UPDATE documents AS d
-    JOIN object_documents AS od ON od.document_id = d.id
-     AND od.documentable_type = 'Assessment'
-     SET d.context_id = od.context_id
-   WHERE d.context_id IS NULL
-  """
-  op.execute(sql)
+  pass
 
 
 def downgrade():

--- a/src/ggrc/migrations/versions/20170224202800_341f8a645b2f_fix_assessment_contexts_again.py
+++ b/src/ggrc/migrations/versions/20170224202800_341f8a645b2f_fix_assessment_contexts_again.py
@@ -1,0 +1,69 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Fix Assessment contexts again
+
+Create Date: 2017-02-24 20:28:00.507631
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '341f8a645b2f'
+down_revision = '4e7fda17abc7'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  # Fixes assessments without audit context
+  # SELECT COUNT(*) FROM assessments
+  #  WHERE context_id is NULL;
+  sql = """
+  UPDATE assessments as a
+    JOIN relationships AS r ON r.source_id = a.id
+     AND r.source_type = 'Assessment' AND r.destination_type = 'Audit'
+    JOIN audits AS au ON r.destination_id = au.id
+     SET a.context_id = au.context_id
+   WHERE a.context_id is NULL;
+  """
+  op.execute(sql)
+  sql = """
+  UPDATE assessments as a
+    JOIN relationships AS r ON r.destination_id = a.id
+     AND r.destination_type = 'Assessment' AND r.source_type = 'Audit'
+    JOIN audits AS au ON r.source_id = au.id
+     SET a.context_id = au.context_id
+   WHERE a.context_id is NULL;
+  """
+  op.execute(sql)
+  # Fixes object_documents mapped to assessments without audit context
+  # SELECT COUNT(*) FROM object_documents
+  #  WHERE documentable_type = 'Assessment' AND context_id IS NULL;
+  sql = """
+  UPDATE object_documents AS od
+    JOIN assessments AS a ON od.documentable_id = a.id
+     SET od.context_id = a.context_id
+   WHERE documentable_type = 'Assessment' AND od.context_id IS NULL;
+  """
+  op.execute(sql)
+  # Fixes documents attached to assessments without audit context
+  # SELECT count(*)
+  #   FROM documents AS d
+  #   JOIN object_documents AS od ON d.id = od.document_id
+  #  WHERE od.documentable_type = 'Assessment' AND d.context_id IS NULL;
+  sql = """
+  UPDATE documents AS d
+    JOIN object_documents AS od ON od.document_id = d.id
+     AND od.documentable_type = 'Assessment'
+     SET d.context_id = od.context_id
+   WHERE d.context_id IS NULL
+  """
+  op.execute(sql)
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  pass


### PR DESCRIPTION
Our javascript model callbacks are broken, before_create/before_save gets called after the POST is already made. 

As a temporary solution I am adding the call to before_create into assessment's form_preload.

Because this is a production issue I have made sure the migrations are also rerun.

This fixes https://github.com/google/ggrc-core/pull/5194