### PR TITLE
GGRC-1261 Fix relevant filter is not disabled

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/mapper.js
+++ b/src/ggrc/assets/javascripts/controllers/mapper.js
@@ -85,7 +85,7 @@
           object: data.join_object_type,
           type: data.join_option_type,
           relevantTo: [{
-            eadOnly: true,
+            readOnly: true,
             type: data.snapshot_scope_type,
             id: data.snapshot_scope_id
           }]


### PR DESCRIPTION
This PR fixes a typo in code causing relevant filter to be not disabled.

Precondition:
created program, audit
Steps to reproduce:
1. Go to the audit page-> Assessments tab
2. Click create new
3. Click Map object button in New assessment modal: confirm the field with audit is not disabled
Actual Result: Audit is not disabled by default if map object through New Assessment window
Expected Result: Audit should be disabled by default if map object through New Assessment window