### PR TITLE
GGRC-923 Make color for the widgets in HNB in darker fonts

### DIFF
--- a/src/ggrc/assets/stylesheets/modules/_top-nav.scss
+++ b/src/ggrc/assets/stylesheets/modules/_top-nav.scss
@@ -7,7 +7,7 @@
   @include box-shadow(inset 1px 4px 9px -6px rgba(0,0,0,0.4));
   width: 100%;
   top: 48px;
-  background: $tabBgnd;
+  background: $white;
 }
 
 ul.internav {
@@ -26,6 +26,7 @@ ul.internav {
       &.pie-chart, &.info-circle, &.assessment, &.issue, &.assessment_template {
         a {
           color: $blue;
+          @include opacity(1);
           &:hover {
             color: $blue;
           }
@@ -37,7 +38,8 @@ ul.internav {
       &.menu-action {
         float: right;
         display: block !important;
-        margin-top: 2px;
+        margin-top: 7px;
+        margin-left: 3px;
         .hide-menu {
           background: $grayLight;
           &:focus {
@@ -50,7 +52,7 @@ ul.internav {
         float: right;
         position: relative;
         padding-left: 5px;
-        height: 29px;
+        height: 40px;
         &:before {
           content: '';
           border-left: 1px dotted $grayLight;
@@ -91,6 +93,7 @@ ul.internav {
         color: $black;
         font-weight: bold;
         background: $contentBgnd;
+        @include opacity(1);
         i {
           @include opacity(1);
         }
@@ -102,19 +105,18 @@ ul.internav {
   }
   a {
     @include transition(color 0.2s ease);
-    padding: 0 14px 0 10px;
+    padding: 6px 14px 5px 10px;
     display: block;
     line-height: 29px;
     font-size: 13px;
-    color: $gray;
+    color: $black;
+    @include opacity(.7);
     position: relative;
     &:hover {
       color: $black;
       background: none;
       text-decoration: none;
-      i {
-        @include opacity(1);
-      }
+      @include opacity(1);
       .closed {
         display: block;
       }
@@ -143,7 +145,6 @@ ul.internav {
     }
   }
   i {
-    @include opacity(0.4);
     margin-top: 6px;
   }
 }


### PR DESCRIPTION
**Steps to reproduce:**
1. Go to My Work page
2. Look at the widgets in HNB: gray colored

_Actual Result:_ The widgets in HNB are gray and users think this is disabled
_Expected Result:_ Make color for the widgets in HNB in darker fonts. E.g., make them black

UX for Navigation Line: https://drive.google.com/corp/drive/u/1/folders/0B7_NYFVmb896d1ZOMEtqYWZ4Z0k

Navigation line is re-designed.
We still leave opacity 70% for non selected tabs to increase contrast between selected and non-selected.
Heigh is increased to 40px
Background is white
Black Tabs Specs:
«Current» State - #000000, Bold.
«Normal State» - #000000, Opacity 70%, Regular
Blue Tabs Specs:
«Current» State - #0277BD, Bold.
«Normal State» - #0277BD, Regular