### PR TITLE
GGRC-1306 Cannot map issue to audit

### DIFF
--- a/src/ggrc/assets/javascripts/pbc/workflow_controller.js
+++ b/src/ggrc/assets/javascripts/pbc/workflow_controller.js
@@ -21,9 +21,11 @@
       }
 
       this._after_pending_joins(instance, function () {
-        dfd = instance.relatedSnapshots.map(function (item) {
-          return this._create_relationship(instance, item);
-        }.bind(this));
+        dfd = instance.relatedSnapshots ?
+          instance.relatedSnapshots.map(function (item) {
+            return this._create_relationship(instance, item);
+          }.bind(this)) :
+          [];
         dfd.push(this._create_relationship(instance, instance.audit));
         dfd.push(this._create_relationship(instance, instance.assessment));
         instance.delay_resolving_save_until($.when.apply($, dfd));


### PR DESCRIPTION
Precondition:
created program, control, audit
Steps to reproduce:
1. Go to audit page
2. Issues tab-> Create an issue

Actual Result: Cannot map issue to audit: "Uncaught TypeError: Cannot read property 'map' of undefined" occurs in console
Expected Result: no error displayed. Issue should be mapped to audit.

NOTE: There are no mapped snapshots when creating an Issue outside Assessment.