### PR TITLE
GGRC-1139 Tree view filter: show special object states instead of Active - Draft - Deprecated for Audits

### DIFF
--- a/src/ggrc/assets/javascripts/plugins/utils/state-utils.js
+++ b/src/ggrc/assets/javascripts/plugins/utils/state-utils.js
@@ -28,8 +28,15 @@
         ]
       },
       {
+        models: ['Audit'],
+        states: [
+          'Planned', 'In Progress', 'Manager Review',
+          'Ready for External Review', 'Completed'
+        ]
+      },
+      {
         models: [
-          'Audit', 'Person', 'CycleTaskGroupObjectTask',
+          'Person', 'CycleTaskGroupObjectTask',
           'AssessmentTemplate', 'Workflow',
           'TaskGroup', 'Cycle'
         ],


### PR DESCRIPTION
User can filter an Audits by Status

![_001](https://cloud.githubusercontent.com/assets/4204416/23363348/4dbcb84c-fd0b-11e6-998b-0cfec5ae5d9a.png)