### PR TITLE
GGRRC-1311 "Uncaught Error: Required Data for In Scope Object is missing - Original Object is mandatory"

### DIFF
--- a/src/ggrc/assets/mustache/base_objects/tree_add_item.mustache
+++ b/src/ggrc/assets/mustache/base_objects/tree_add_item.mustache
@@ -7,6 +7,7 @@
 {{#if allow_mapping_or_creating}}
   {{#if model.root_object}}
     {{^if_equals model.shortName 'Assessment'}}
+    {{^if_equals model.shortName 'Issue'}}
       <a
         class="btn btn-mini action-button map-button"
         href="javascript://"
@@ -15,12 +16,13 @@
         data-toggle="unified-mapper"
         data-join-mapping="{{mapping}}"
         data-join-option-type="{{model.shortName}}"
-        data-join-object-id="{{instance.id}}"
+        data-join-object-id="{{parent_instance.id}}"
         data-join-object-type="{{parent_instance.class.shortName}}"
         data-exclude-option-types="{{exclude_option_types}}"
         data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}">
         Map
       </a>
+    {{/if_equals}}
     {{/if_equals}}
   {{#if null}}
   <span class="section-expander">


### PR DESCRIPTION
Precondition:
created program, control, audit
Steps to reproduce:
1. Go to audit page
2. Create issue
3. Map issue from precondition to issue
4. Go to the issue page > Control's tab > click Map button

Actual Result: "Uncaught Error: Required Data for In Scope Object is missing - Original Object is mandatory" error occurs if Map Controls to Issue on the Issue page
Expected Result: no error displayed if click Map button in Control's tab on the issues page

**Please perform deep regression testing for this issue.**