### PR TITLE
GGRC-1295 Set Controls to be default object for assessments mapping

### DIFF
--- a/src/ggrc/assets/javascripts/components/unified-mapper/mapper.js
+++ b/src/ggrc/assets/javascripts/components/unified-mapper/mapper.js
@@ -10,6 +10,7 @@
     'and system will create snapshots of selected objects for this Audit';
 
   var DEFAULT_OBJECT_MAP = {
+    Assessment: 'Control',
     Objective: 'Control',
     Section: 'Objective',
     Regulation: 'Section',


### PR DESCRIPTION
This PR sets Controls to be default object for assessments mapping.

By default when map objects to assessment is invoked, object type should be pre-selected to control. 
Steps to reproduce:
1. Create control, program and map them
2. Create audit
3. Open new asmt modal window and click map object button
4. Check mapper window: Control is not selected by default
5. Create assessment and click Map button in first tier
6. Check mapper window: Control is not selected by default
Actual: Access group is selected by default
Excepted: Controls is selected by default and non-edible mapping filter to this audit is applied
Note: this is expected behavior for all mapper windows from assessment page/modal window/info pane
