### PR TITLE
GGRC-1296 Mapper search on open

### DIFF
--- a/src/ggrc/assets/javascripts/components/unified-mapper/mapper.js
+++ b/src/ggrc/assets/javascripts/components/unified-mapper/mapper.js
@@ -80,8 +80,13 @@
     options: [],
     newEntries: [],
     relevant: [],
-    toolbarSubmitCbs: $.Callbacks(),
+    submitCbs: $.Callbacks(),
     afterSearch: false,
+    init: function () {
+      if (!this.attr('search_only')) {
+        setTimeout(this.onToolbarSubmit.bind(this));
+      }
+    },
     allowedToCreate: function () {
       var isSearch = this.attr('search_only');
       // Don't allow to create new instances for "In Scope" Objects
@@ -175,7 +180,7 @@
       return _.findWhere(types, {value: type});
     },
     onToolbarSubmit: function () {
-      this.attr('toolbarSubmitCbs').fire();
+      this.attr('submitCbs').fire();
       this.attr('afterSearch', true);
     }
   });

--- a/src/ggrc/assets/mustache/modals/mapper/base.mustache
+++ b/src/ggrc/assets/mustache/modals/mapper/base.mustache
@@ -44,7 +44,7 @@
     filter="mapper.filter"
     scope-id="{{mapper.snapshot_scope_id}}"
     scope-type="{{mapper.snapshot_scope_type}}"
-    submit-cbs="mapper.toolbarSubmitCbs"
+    submit-cbs="mapper.submitCbs"
     {^paging.total}="totalObjects"
     status-filter="mapper.statusFilter">
   </mapper-results>


### PR DESCRIPTION
This PR adds search-on-open behavior for mapping actions to the mapper.

From jira issue:
...first page should get loaded asynchronously in mapping modal from assessment.