### PR TITLE
GGRC-1216 Add import warning for some mapping columns

### DIFF
--- a/src/ggrc/converters/errors.py
+++ b/src/ggrc/converters/errors.py
@@ -115,8 +115,12 @@ ONLY_IMPORTABLE_COLUMNS_WARNING = (u"Line {line}: Only the following "
                                    u"attributes are importable: {columns}. "
                                    u"All other columns will be ignored.")
 
+EXPORT_ONLY_WARNING = (u"Line {line}: Field '{column_name}' "
+                       u"can not be imported. The value will be ignored.")
+
 ILLIGAL_REMOVE_CONTROL_VALUE = ("Line {line}: "
                                 "System does not allow to unmap control")
+
 ILLIGAL_APPEND_CONTROL_VALUE = ("Line {line}: "
                                 "System does not allow to map control to "
                                 "{object_type}, because this control is not "

--- a/src/ggrc/converters/handlers/handlers.py
+++ b/src/ggrc/converters/handlers/handlers.py
@@ -407,6 +407,9 @@ class MappingColumnHandler(ColumnHandler):
     # This is just a hack to prevent wrong mappings to assessments or issues.
     if self.mapping_object.__name__ in Types.scoped | Types.parents and \
        not self.allow:
+      if self.raw_value:
+        self.add_warning(errors.EXPORT_ONLY_WARNING,
+                         column_name=self.display_name)
       return []
 
     class_ = self.mapping_object

--- a/test/integration/ggrc/converters/test_import_csv.py
+++ b/test/integration/ggrc/converters/test_import_csv.py
@@ -131,14 +131,22 @@ class TestBasicCsvImport(TestCase):
 
     Checks for fields being updarted correctly
     """
-    messages = ("block_errors", "block_warnings", "row_errors", "row_warnings")
 
     filename = "pci_program.csv"
     response = self.import_file(filename)
 
-    for response_block in response:
-      for message in messages:
-        self.assertEqual(set(), set(response_block[message]))
+    self._check_csv_response(response, {
+        "Control": {
+            "row_warnings": {
+                errors.EXPORT_ONLY_WARNING.format(
+                    line=9, column_name="map:audit"),
+                errors.EXPORT_ONLY_WARNING.format(
+                    line=10, column_name="map:audit"),
+                errors.EXPORT_ONLY_WARNING.format(
+                    line=11, column_name="map:audit"),
+            }
+        }
+    })
 
     assessment = models.Assessment.query.filter_by(slug="CA.PCI 1.1").first()
     audit = models.Audit.query.filter_by(slug="AUDIT-Consolidated").first()
@@ -150,9 +158,7 @@ class TestBasicCsvImport(TestCase):
     filename = "pci_program_update.csv"
     response = self.import_file(filename)
 
-    for response_block in response:
-      for message in messages:
-        self.assertEqual(set(), set(response_block[message]))
+    self._check_csv_response(response, {})
 
     assessment = models.Assessment.query.filter_by(slug="CA.PCI 1.1").first()
     audit = models.Audit.query.filter_by(slug="AUDIT-Consolidated").first()


### PR DESCRIPTION
The columns for mapping audit, issue, and assessments are not importable
and the user should see a warning that those will be ignored.