### PR TITLE
GGRC-1171 Reorder navigation tabs on Program page

### DIFF
--- a/src/ggrc/assets/javascripts/apps/base_widgets.js
+++ b/src/ggrc/assets/javascripts/apps/base_widgets.js
@@ -13,30 +13,31 @@
     // be  prioritized use order values below 100. An order value of 0 is
     // reserved for the "info" widget which always comes first.
   var defaultOrderTypes = {
-    Assessment: 8,
-    Regulation: 20,
-    Contract: 30,
-    Section: 40,
-    Objective: 50,
-    Control: 60,
+    Standard: 7,
+    Regulation: 10,
+    Section: 15,
+    Objective: 20,
+    Control: 30,
+    Product: 35,
+    System: 40,
+    Process: 45,
+    Audit: 50,
+    Person: 55,
     AccessGroup: 100,
-    Audit: 120,
-    Clause: 130,
+    Assessment: 110,
+    Clause: 120,
+    Contract: 130,
     DataAsset: 140,
     Facility: 160,
     Issue: 170,
     Market: 180,
     OrgGroup: 190,
-    Person: 200,
     Policy: 210,
-    Process: 220,
-    Product: 230,
     Program: 240,
     Project: 250,
-    Standard: 260,
-    System: 270,
     Vendor: 280
   };
+
   var allTypes = Object.keys(defaultOrderTypes).sort();
   // Items allowed for mapping via snapshot.
   var snapshotWidgetsConfig = GGRC.config.snapshotable_objects || [];

--- a/src/ggrc/assets/javascripts/apps/business_objects.js
+++ b/src/ggrc/assets/javascripts/apps/business_objects.js
@@ -241,40 +241,49 @@
           AssessmentTemplate: {
             order: 40
           },
-          Contract: {
-            order: 133  // between default Clause (130) and DataAsset (140)
-          },
+
+          // other widgets are sorted alphabetically, some of them need their
+          // default value reset
           Control: {
-            order: 137  // between default Clause (130) and DataAsset (140)
+            order: 135  // between default Contract (130) and DataAsset (140)
           },
           Objective: {
-            order: 182  // between default Market (180) and OrgGroup (190)
-          },
-          Regulation: {
-            order: 257  // between default Project (250) and Request (260)
-          },
-          program: {
-            widget_id: 'program',
-            widget_name: 'Program',
-            widget_icon: 'program'
-          },
-          Section: {
-            order: 263  // between default Request (260) and System (270)
-          },
-          Standard: {
-            order: 267  // between default Request (260) and System (270)
+            order: 185  // between default Market (180) and OrgGroup (190)
           },
           Person: {
             widget_id: 'person',
             widget_name: 'People',
             widget_icon: 'person',
-            // NOTE: "order" not overridden
+            order: 195,  // between default OrgGroup (190) and Policy (210)
             content_controller: GGRC.Controllers.TreeView,
             content_controller_options: {
               mapping: 'authorized_people',
               allow_mapping: false,
               allow_creating: false
             }
+          },
+          Process: {
+            order: 215  // between default Policy (210) and Program (240)
+          },
+          Product: {
+            order: 220  // between default Policy (210) and Program (240)
+          },
+          Regulation: {
+            order: 255  // between default Project (250) and Vendor (280)
+          },
+          Section: {
+            order: 260  // between default Project (250) and Vendor (280)
+          },
+          Standard: {
+            order: 265  // between default Project (250) and Vendor (280)
+          },
+          System: {
+            order: 270  // between default Project (250) and Vendor (280)
+          },
+          program: {
+            widget_id: 'program',
+            widget_name: 'Program',
+            widget_icon: 'program'
           }
         }
       };

--- a/src/ggrc_risk_assessments/assets/javascripts/apps/risk_assessments.js
+++ b/src/ggrc_risk_assessments/assets/javascripts/apps/risk_assessments.js
@@ -79,6 +79,7 @@
         risk_assessments: {
           widget_id: 'risk_assessments',
           widget_name: 'Risk Assessments',
+          order: 257,
           content_controller: GGRC.Controllers.TreeView,
           content_controller_options: {
             add_item_view: GGRC.mustache_path +

--- a/src/ggrc_risks/assets/javascripts/apps/risks.js
+++ b/src/ggrc_risks/assets/javascripts/apps/risks.js
@@ -242,7 +242,7 @@
       widget_id: CMS.Models.Risk.table_singular,
       widget_name: CMS.Models.Risk.title_plural,
       widget_icon: CMS.Models.Risk.table_singular,
-      order: 265,
+      order: 25,
       content_controller_options: {
         child_options: relatedObjectsChildOptions,
         draw_children: true,


### PR DESCRIPTION
This PR customizes the order of the HNB tabs for ~~Program~~ all objects (retaining the existing exception for Audit). The new order should be, quoting:

> Standards,Regulations,Sections,Objectives,Risks,Controls, Products, Systems,Process,
Audit,People, AND (alphabetical order after this)

To verify the change, open e.g. a Program page and open all the tabs for it (using the HNB `Add Tab` button), possibly mapping some objects of different types to the Program if necessary.

**Update:** Based on the discussion, the order should apply to _all_ object types, not just the Program, but with retaining the existing exception for Audits.