### PR TITLE
GGRC-1317 Change tense for "Assessment created" notification

### DIFF
--- a/src/ggrc/templates/notifications/email_digest_content.html
+++ b/src/ggrc/templates/notifications/email_digest_content.html
@@ -163,7 +163,7 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                 {% endif %}
 
                 {% if digest.get('assessment_open') %}
-                  <h2 {{ style.sub_title() }} >New assessments are created</h2>
+                  <h2 {{ style.sub_title() }} >New assessments were created</h2>
                   <ul {{ style.list_wrap() }} >
                   {% for assessment_id, assessment_data in digest['assessment_open'].iteritems() %}
                     <li {{ style.list_item() }} >


### PR DESCRIPTION
~~_(there might have been a Jira ticket opened, but I do not know about it)_~~

This PR implements the proposal by Prasanna to slightly change the email text for the created Assessments notifications, i.e. from present to past tense.