### PR TITLE
GGRC-1328 Global creator/reader/editor can not see Raise an Issue button after mapping a control to Assessment

### DIFF
--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -3410,7 +3410,12 @@ Mustache.registerHelper('with_create_issue_json', function (instance, options) {
   if (instance.mappedSnapshots) {
     relatedSnapshots = instance.mappedSnapshots.map(function (item) {
       var instance = item.instance;
-      return {title: instance.title, id: instance.id, type: instance.type};
+      return {
+        title: instance.title,
+        id: instance.id,
+        type: instance.type,
+        context: instance.context
+      };
     });
   }
 

--- a/src/ggrc/assets/javascripts/permission.js
+++ b/src/ggrc/assets/javascripts/permission.js
@@ -134,9 +134,8 @@
       }.bind(this);
 
       var action_obj = permissions[action] || {};
-      var instance_type = instance.constructor ?
-                          instance.constructor.shortName :
-                          instance.type;
+      var shortName = instance.constructor && instance.constructor.shortName;
+      var instance_type = shortName || instance.type;
       var type_obj = action_obj[instance_type] || {};
       var conditions_by_context = type_obj.conditions || {};
       var resources = type_obj.resources || [];


### PR DESCRIPTION
Steps to reproduce:
1. Log as progcreator@reciprocitylabs.com (engage007)
2. Create program, control, audit
3. Go to audit page, create assessment 
4. On assessment's Info pane map control
5. Open Related Issues tab: Raise an Issue button is not shown
Actual Result: There is no Raise an Issue button under Global creator/reader/editor. There is no possibility for users with such roles to raise an issue
Expected Result: Raise an Issue button is displayed under Global creator/reader/editor roles when map control to assessment

The fix does not fix the issue with the auditor role (auditors still won't see the button).