### PR TITLE
GGRC-1119 Fix duplicating of url on double click Add button

### DIFF
--- a/src/ggrc/assets/javascripts/components/quick_form/quick_add.js
+++ b/src/ggrc/assets/javascripts/components/quick_form/quick_add.js
@@ -92,6 +92,7 @@
         var quick_create;
         var created_dfd;
         var verify_dfd = $.Deferred();
+        scope.attr('disabled', true);
 
         if (scope.attr("verify_event")) {
           GGRC.Controllers.Modals.confirm({
@@ -118,7 +119,10 @@
                   })
                   .done(function (data) {
                     this.scope.attr('instance', data);
-                  }.bind(this));
+                  }.bind(this))
+                  .always(function () {
+                    scope.attr('disabled', false);
+                  });
               }
             }
           }
@@ -179,7 +183,10 @@
               }),
               el
               );
-          }.bind(this));
+          }.bind(this))
+          .always(function () {
+            scope.attr('disabled', false);
+          });
         }.bind(this));
       },
       // this works like autocomplete_select on all modal forms and

--- a/src/ggrc/assets/mustache/components/assessment/urls-list.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/urls-list.mustache
@@ -18,7 +18,7 @@
             <div class="objective-selector field-wrap">
                 <input tabindex="3" type="text" name="instance" placeholder="Add URL">
                 <a href="javascript://" {{toggle_button}}><i class="fa fa-trash"></i></a>
-                <a href="javascript://" class="btn btn-small btn-success no-float" data-toggle="submit" {{toggle_button 'modal:success'}}>Add</a>
+                <a href="javascript://" class="btn btn-small btn-success no-float {{#if disabled}}disabled{{/disabled}}" data-toggle="submit" {{toggle_button 'modal:success'}}>Add</a>
             </div>
             <input type="hidden" name="role_name" value="Auditor" />
         {{/prune_context}}


### PR DESCRIPTION
**URL duplicates if click Add button twice**

**Precondition**:
created program, audit

**Steps to reproduce**:
1. Go to audit page and create assessment
2. Navigate to assessment's info pane
3. Click + to add URL
4. Fill url and click twice on Add button: URL duplicates

**Actual Result**: URL duplicates if click Add button twice
**Expected Result**: URL should not be duplicated if click Add button twice

![image](https://cloud.githubusercontent.com/assets/567805/23452993/8ebcda30-fe77-11e6-9b85-4838de960d0c.png)

