### PR TITLE
QUICK-FIX Remove Assessment automapping

### DIFF
--- a/src/ggrc/automapper/rules.py
+++ b/src/ggrc/automapper/rules.py
@@ -12,8 +12,7 @@ Attr = namedtuple('Attr', ['name'])
 
 type_ordering = [['Audit'], ['Program'],
                  ['Regulation', 'Policy', 'Standard', 'Contract'],
-                 ['Section', 'Clause'], ['Objective'], ['Control'],
-                 ['Assessment']]
+                 ['Section', 'Clause'], ['Objective'], ['Control']]
 
 
 # pylint: disable=invalid-name
@@ -133,7 +132,7 @@ class RuleSet(object):
 
 class Types(object):
   all = {'Program', 'Regulation', 'Policy', 'Standard', 'Contract',
-         'Section', 'Clause', 'Objective', 'Control', 'Assessment'}
+         'Section', 'Clause', 'Objective', 'Control'}
   directives = {'Regulation', 'Policy', 'Standard', 'Contract'}
   assets_business = {'System', 'Process', 'DataAsset', 'Product', 'Project',
                      'Facility', 'Market'}

--- a/test/integration/ggrc/automapper/test_automappings.py
+++ b/test/integration/ggrc/automapper/test_automappings.py
@@ -304,34 +304,3 @@ class TestAutomappings(TestCase):
                  (section, regulation),
                  (control, section)],
     )
-
-  def test_automapping_control_assesment(self):
-    program = self.create_object(models.Program, {
-        'title': make_name('Program')
-    })
-    regulation = self.create_object(models.Regulation, {
-        'title': make_name('Test Regulation')
-    })
-    audit = self.create_object(models.Audit, {
-        'title': make_name('Audit'),
-        'program': {'id': program.id},
-        'status': 'Planned',
-    })
-    control = self.create_object(models.Control, {
-        'title': make_name('Test control')
-    })
-    assessment = self.create_object(models.Assessment, {
-        'title': make_name('Test CA'),
-        'audit': {
-            'id': audit.id,
-            'type': audit.type
-        },
-        'object': {
-            'id': control.id,
-            'type': control.type
-        },
-    })
-    self.assert_mapping_implication(
-        to_create=[(program, regulation), (regulation, assessment)],
-        implied=[(program, assessment)]
-    )


### PR DESCRIPTION
This PR removes an Automapping rule that results in Assessment-NonAuditScope direct mappings.