### PR TITLE
GGRC-1337 Fix inefficient query for ids on all pages

### DIFF
--- a/src/ggrc/assets/javascripts/plugins/utils/current-page-utils.js
+++ b/src/ggrc/assets/javascripts/plugins/utils/current-page-utils.js
@@ -18,22 +18,21 @@
       var reqParams = [];
 
       models.forEach(function (model) {
-        reqParams.push(queryAPI.buildParam(
+        reqParams.push(queryAPI.buildRelevantIdsQuery(
           model,
           {},
           {
             type: current.type,
             id: current.id,
             operation: 'relevant'
-          },
-          ['id']));
+          }));
       });
 
       return queryAPI.makeRequest({data: reqParams}).then(function (response) {
         models.forEach(function (model, idx) {
-          var values = can.makeArray(response[idx][model].values);
-          var map = values.reduce(function (mapped, obj) {
-            mapped[obj.id] = true;
+          var ids = response[idx][model].ids;
+          var map = ids.reduce(function (mapped, id) {
+            mapped[id] = true;
             return mapped;
           }, {});
           relatedToCurrentInstance.attr(model, map);


### PR DESCRIPTION
We have a query to QueryAPI on all pages that is used to hide objects not directly mapped to the current context from the second tier of tree views.

The query is done like this:
[{"object_name": "AccessGroup", "fields": ["id"], "filter": {...}}, {"object_name": "Control", "fields": ["id"], ...}, ...]

The correct form of this query is:
[{"object_name": "AccessGroup", "type": "ids", "filter": {...}}, {"object_name": "Control", "type": "ids", ...}, ...]

The reason behind the bad performance of the first format of the query for ids is that when we perform a query with "type": "values" (default), we query whole objects from the database, serialize them and leave only fields specified in "fields" list before sending them to the frontend. When we perform a query with "type": "ids", we query only ids from the database, and it is over an order of magnitude more efficient.

We won't optimize the logic behind "fields" list yet as it's not critical for our current functionality and it will take significant amount of work to do.