### PR TITLE
GGRC-1024/1045/1171 - Changes for HBN

### DIFF
--- a/src/ggrc/assets/javascripts/apps/base_widgets.js
+++ b/src/ggrc/assets/javascripts/apps/base_widgets.js
@@ -34,10 +34,8 @@
     'System',
     'Vendor'
   ];
-    // NOTE: By default, widgets are sorted alphabetically (the value of
-    // the order 100+), but the objects with higher importance that should
-    // be  prioritized use order values below 100. An order value of 0 is
-    // reserved for the "info" widget which always comes first.
+  // NOTE: Widgets that have the order value are sorted by an increase values,
+  // the rest of widgets are sorted alphabetically
   var defaultOrderTypes = {
     Standard: 10,
     Regulation: 20,

--- a/src/ggrc/assets/javascripts/apps/base_widgets.js
+++ b/src/ggrc/assets/javascripts/apps/base_widgets.js
@@ -8,36 +8,48 @@
   /**
    * Tree View Widgets Configuration module
    */
+  var allCoreTypes = [
+    'AccessGroup',
+    'Assessment',
+    'AssessmentTemplate',
+    'Audit',
+    'Clause',
+    'Contract',
+    'Control',
+    'DataAsset',
+    'Facility',
+    'Issue',
+    'Market',
+    'Objective',
+    'OrgGroup',
+    'Person',
+    'Policy',
+    'Process',
+    'Product',
+    'Program',
+    'Project',
+    'Regulation',
+    'Section',
+    'Standard',
+    'System',
+    'Vendor'
+  ];
     // NOTE: By default, widgets are sorted alphabetically (the value of
     // the order 100+), but the objects with higher importance that should
     // be  prioritized use order values below 100. An order value of 0 is
     // reserved for the "info" widget which always comes first.
   var defaultOrderTypes = {
-    Assessment: 8,
+    Standard: 10,
     Regulation: 20,
-    Contract: 30,
-    Section: 40,
-    Objective: 50,
-    Control: 60,
-    AccessGroup: 100,
-    Audit: 120,
-    Clause: 130,
-    DataAsset: 140,
-    Facility: 160,
-    Issue: 170,
-    Market: 180,
-    OrgGroup: 190,
-    Person: 200,
-    Policy: 210,
-    Process: 220,
-    Product: 230,
-    Program: 240,
-    Project: 250,
-    Standard: 260,
-    System: 270,
-    Vendor: 280
+    Section: 30,
+    Objective: 40,
+    Control: 50,
+    Product: 60,
+    System: 70,
+    Process: 80,
+    Audit: 90,
+    Person: 100
   };
-  var allTypes = Object.keys(defaultOrderTypes).sort();
   // Items allowed for mapping via snapshot.
   var snapshotWidgetsConfig = GGRC.config.snapshotable_objects || [];
   // Items allowed for relationship mapping
@@ -54,7 +66,7 @@
   var baseWidgetsByType;
   var orderedWidgetsByType = {};
 
-  var filteredTypes = _.difference(allTypes, excludeMappingConfig);
+  var filteredTypes = _.difference(allCoreTypes, excludeMappingConfig);
   // Audit is excluded and created a separate logic for it
   baseWidgetsByType = {
     AccessGroup: _.difference(filteredTypes, ['AccessGroup']),
@@ -65,6 +77,7 @@
       ['Contract', 'Policy', 'Regulation', 'Standard']),
     Control: filteredTypes,
     Assessment: snapshotWidgetsConfig.concat('Audit').sort(),
+    AssessmentTemplate: [],
     DataAsset: filteredTypes,
     Facility: filteredTypes,
     Issue: snapshotWidgetsConfig.concat('Audit').sort(),
@@ -87,11 +100,19 @@
     Vendor: filteredTypes
   };
 
-  allTypes.forEach(function (type) {
+  allCoreTypes.forEach(function (type) {
     var related = baseWidgetsByType[type].slice(0);
-    orderedWidgetsByType[type] = related.sort(function (a, b) {
-      return defaultOrderTypes[a] - defaultOrderTypes[b];
-    });
+
+    orderedWidgetsByType[type] = _.chain(related)
+      .map(function (type) {
+        return {
+          name: type,
+          order: defaultOrderTypes[type]
+        };
+      })
+      .sortByAll(['order', 'name'])
+      .map('name')
+      .value();
   });
 
   GGRC.tree_view = GGRC.tree_view || new can.Map();

--- a/src/ggrc/assets/javascripts/apps/business_objects.js
+++ b/src/ggrc/assets/javascripts/apps/business_objects.js
@@ -233,36 +233,18 @@
         // order among the non-prioritized object types.
         Audit: {
           Assessment: {
-            order: 10
+            order: 6
           },
           Issue: {
-            order: 30
+            order: 7
           },
-          AssessmentTemplate: {
-            order: 40
-          },
-          Contract: {
-            order: 133  // between default Clause (130) and DataAsset (140)
-          },
-          Control: {
-            order: 137  // between default Clause (130) and DataAsset (140)
-          },
-          Objective: {
-            order: 182  // between default Market (180) and OrgGroup (190)
-          },
-          Regulation: {
-            order: 257  // between default Project (250) and Request (260)
+          Program: {
+            order: 8
           },
           program: {
             widget_id: 'program',
             widget_name: 'Program',
             widget_icon: 'program'
-          },
-          Section: {
-            order: 263  // between default Request (260) and System (270)
-          },
-          Standard: {
-            order: 267  // between default Request (260) and System (270)
           },
           Person: {
             widget_id: 'person',

--- a/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
@@ -283,6 +283,7 @@
       instance: null,
       isMenuVisible: true,
       addTabTitle: 'Add Tab',
+      hideTabTitle: 'Hide',
       dividedTabsMode: false,
       priorityTabs: null
     }
@@ -312,6 +313,7 @@
             if (isAuditScope) {
               this.element.addClass(this.options.instance.type.toLowerCase());
               this.options.attr('addTabTitle', 'Add Scope');
+              this.options.attr('hideTabTitle', 'Show Audit Scope');
               this.options.attr('dividedTabsMode', true);
               this.options.attr('priorityTabs', 4);
             }
@@ -648,9 +650,11 @@
         $dropdown.removeClass('one-item');
       }
     },
-    '.hide-menu click': function (el) {
-      var $hiddenArea = this.element
-        .find('li:nth-child(n+5):not(:last-child)');
+    '.not-priority-hide click': function (el) {
+      var count = this.options.attr('priorityTabs') + 1;
+      var hiddenAreaSelector = 'li:nth-child(n+' + count + '):not(:last-child)';
+      var $hiddenArea = this.element.find(hiddenAreaSelector);
+
       this.options.attr('isMenuVisible', !this.options.isMenuVisible);
       if (this.options.isMenuVisible) {
         $hiddenArea.show();

--- a/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
@@ -228,8 +228,6 @@
       }
 
       $element
-        .trigger('sortreceive')
-        .trigger('section_created')
         .trigger('widgets_updated', $element);
 
       return control;
@@ -437,14 +435,8 @@
      * at the end of the list.
      */
     sortWidgets: function () {
-      function sortByOrderAttr(widget, widget2) {
-        var order = _.isNumber(widget.order) ?
-                                widget.order : Number.MAX_SAFE_INTEGER;
-        var order2 = _.isNumber(widget2.order) ?
-                                 widget2.order : Number.MAX_SAFE_INTEGER;
-        return order - order2;
-      }
-      this.options.widget_list.sort(sortByOrderAttr);
+      this.options.attr('widget_list',
+        _.sortByAll(this.options.widget_list, ['order', 'internav_display']));
     },
 
     update_widget_list: function (widgetElements) {

--- a/src/ggrc/assets/javascripts/controllers/tests/inner_navigation_controller_spec.js
+++ b/src/ggrc/assets/javascripts/controllers/tests/inner_navigation_controller_spec.js
@@ -32,35 +32,142 @@ describe('CMS.Controllers.InnerNav', function () {
     it('sorts widgets by their "order" attribute', function () {
       var widgetOrder;
       var widgets = [
-        {widget_id: 'aaa', order: 40},
-        {widget_id: 'bbb', order: 20},
-        {widget_id: 'ccc', order: 50},
-        {widget_id: 'ddd', order: 10},
-        {widget_id: 'eee', order: 30}
+        {internav_display: 'aaa', order: 40},
+        {internav_display: 'bbb', order: 20},
+        {internav_display: 'ccc', order: 50},
+        {internav_display: 'ddd', order: 10},
+        {internav_display: 'eee', order: 30}
       ];
       options.widget_list.replace(widgets);
 
       sortWidgets();
 
-      widgetOrder = _.map(ctrlInst.options.widget_list, 'widget_id');
+      widgetOrder = _.map(ctrlInst.options.widget_list, 'internav_display');
       expect(widgetOrder).toEqual(['ddd', 'bbb', 'eee', 'aaa', 'ccc']);
     });
 
-    it('places widgets with unknown "order" at the end', function () {
-      var lastWidget;
+    it('places widgets with unknown "order" at the end and sort them in alphabetical order', function () {
+      var widgetOrder;
       var widgets = [
-        {widget_id: 'aaa', order: 40},
-        {widget_id: 'bbb', order: undefined},
-        {widget_id: 'ccc', order: 50},
-        {widget_id: 'ddd', order: 10},
-        {widget_id: 'eee', order: 30}
+        {internav_display: 'abc'},
+        {internav_display: 'aaa', order: 40},
+        {internav_display: 'cba'},
+        {internav_display: 'ccc', order: 50},
+        {internav_display: 'qwerty'},
+        {internav_display: 'ddd', order: 10},
+        {internav_display: 'xyz'},
+        {internav_display: 'eee', order: 30}
       ];
       options.widget_list.replace(widgets);
 
       sortWidgets();
 
-      lastWidget = ctrlInst.options.widget_list[4];
-      expect(lastWidget.widget_id).toEqual('bbb');
+      widgetOrder = _.map(ctrlInst.options.widget_list, 'internav_display');
+      expect(widgetOrder)
+        .toEqual(['ddd', 'eee', 'aaa', 'ccc', 'abc', 'cba', 'qwerty', 'xyz']);
+    });
+  });
+
+  describe('show_hide_titles() method', function () {
+    var DISPLAY_WIDTH = 1920;
+    var ctrlInst;  // fake controller instance
+    var showHideTitles;
+    var options;
+
+    function createWidgets(titlesStatus) {
+      var widgets = [
+        {name: 'aaa', show_title: titlesStatus},
+        {name: 'bbb', show_title: titlesStatus},
+        {name: 'ccc', show_title: titlesStatus},
+        {name: 'ddd', show_title: titlesStatus},
+        {name: 'eee', show_title: titlesStatus},
+        {name: 'fff', show_title: titlesStatus}
+      ];
+      options.attr('widget_list', widgets);
+      return widgets;
+    }
+
+    function setWidgetsWidth(first, second) {
+      spyOn(Array.prototype, 'reduce').and.returnValues(first, second);
+    }
+
+    beforeEach(function () {
+      options = new can.Map({
+        widget_list: new can.Observe.List([]),
+        dividedTabsMode: false,
+        priorityTabs: null
+      });
+
+      ctrlInst = {
+        element: {
+          children: jasmine.createSpy(),
+          width: jasmine.createSpy().and.returnValue(DISPLAY_WIDTH)
+        },
+        options: options
+      };
+
+      spyOn(_, 'map')
+        .and
+        .returnValue([]);
+
+      showHideTitles = Ctrl.prototype.show_hide_titles.bind(ctrlInst);
+    });
+
+    afterEach(function () {
+      Array.prototype.reduce.calls.reset();
+    });
+
+    it('doesnt hide titles if the width is enough', function () {
+      createWidgets(false);
+
+      setWidgetsWidth(1500);
+
+      showHideTitles();
+
+      expect(_.every(options.attr('widget_list'), 'show_title')).toBeTruthy();
+    });
+
+    it('hides titles if the width isnt enough', function () {
+      createWidgets(true);
+
+      setWidgetsWidth(2500);
+
+      showHideTitles();
+
+      expect(_.every(options.widget_list, 'show_title', false)).toBeTruthy();
+    });
+
+    it('hides not priority titles if the width isnt enough', function () {
+      var widgetList;
+      createWidgets(true);
+
+      options.attr('dividedTabsMode', true);
+      options.attr('priorityTabs', 3);
+
+      setWidgetsWidth(2500, 1500);
+
+      showHideTitles();
+
+      widgetList = options.attr('widget_list');
+
+      expect(_.every(widgetList.slice(0, 3), 'show_title')).toBeTruthy();
+      expect(_.every(widgetList.slice(3), 'show_title', false)).toBeTruthy();
+    });
+
+    it('hides all titles if the width isnt enough', function () {
+      var widgetList;
+      createWidgets(true);
+
+      options.attr('dividedTabsMode', true);
+      options.attr('priorityTabs', 3);
+
+      setWidgetsWidth(3000, 2000);
+
+      showHideTitles();
+
+      widgetList = options.attr('widget_list');
+
+      expect(_.every(widgetList, 'show_title', false)).toBeTruthy();
     });
   });
 });

--- a/src/ggrc/assets/mustache/dashboard/internav_list.mustache
+++ b/src/ggrc/assets/mustache/dashboard/internav_list.mustache
@@ -38,7 +38,7 @@
 {{#is_allowed 'update' instance}}
 {{#if widget_list.length}}
 <li data-test-id="button_widget_add_2c925d94" class="hidden-widgets-list">
-  <a href="{{urlPath}}#dropdown-widgets" class="dropdown-toggle" data-toggle="dropdown" rel="tooltip" data-placement="bottom" title="Add Tab"><i class="fa fa-plus-circle"></i> Add Tab</a>
+  <a href="{{urlPath}}#dropdown-widgets" class="dropdown-toggle" data-toggle="dropdown" rel="tooltip" data-placement="bottom" title="{{addTabTitle}}"><i class="fa fa-plus-circle"></i> {{addTabTitle}}</a>
   <div class="dropdown-menu" role="menu">
     {{#widget_list}}
       <div class="inner-nav-item">
@@ -114,7 +114,10 @@
 {{{render_hooks 'ObjectNav.Actions'}}}
 
 {{#if_page_type 'audits'}}
-  <li class="menu-action">
-    <input type="button" class="btn btn-small hide-menu" value="Hide">
+  <li class="hide-menu {{#if isMenuVisible}}visible{{/if}}">
+      <i class="fa fa-angle-{{#if isMenuVisible}}right{{else}}left{{/if}}"></i>
+      {{^if isMenuVisible}}
+      <span>Show Audit Scope</span>
+      {{/if}}
   </li>
 {{/if_page_type}}

--- a/src/ggrc/assets/mustache/dashboard/internav_list.mustache
+++ b/src/ggrc/assets/mustache/dashboard/internav_list.mustache
@@ -113,11 +113,11 @@
 
 {{{render_hooks 'ObjectNav.Actions'}}}
 
-{{#if_page_type 'audits'}}
-  <li class="hide-menu {{#if isMenuVisible}}visible{{/if}}">
+{{#if dividedTabsMode}}
+  <li class="not-priority-hide {{#if isMenuVisible}}visible{{/if}}">
       <i class="fa fa-angle-{{#if isMenuVisible}}right{{else}}left{{/if}}"></i>
       {{^if isMenuVisible}}
-      <span>Show Audit Scope</span>
+      <span>{{hideTabTitle}}</span>
       {{/if}}
   </li>
-{{/if_page_type}}
+{{/if}}

--- a/src/ggrc/assets/stylesheets/modules/_top-nav.scss
+++ b/src/ggrc/assets/stylesheets/modules/_top-nav.scss
@@ -43,18 +43,6 @@ ul.internav {
       &:nth-child(n+5) {
         order: 20;
       }
-      &.hide-menu {
-        order: 15;
-        display: flex;
-        align-items: center;
-        &.visible {
-          border-left: 1px dotted;
-          border-right: 1px dotted;
-        }
-        i {
-          margin: auto 5px;
-        }
-      }
     }
   }
   li {
@@ -98,6 +86,18 @@ ul.internav {
         }
       }
     }
+    &.not-priority-hide {
+      order: 15 !important;
+      display: flex;
+      align-items: center;
+      &.visible {
+        border-left: 1px dotted;
+        border-right: 1px dotted;
+      }
+      i {
+        margin: auto 5px;
+      }
+    }
     .dropdown-menu {
       a {
         padding-top: 0;
@@ -105,6 +105,7 @@ ul.internav {
       }
     }
   }
+
   a {
     @include transition(color 0.2s ease);
     padding: 6px 14px 5px 10px;

--- a/src/ggrc/assets/stylesheets/modules/_top-nav.scss
+++ b/src/ggrc/assets/stylesheets/modules/_top-nav.scss
@@ -14,16 +14,14 @@ ul.internav {
   @extend %reset-list;
   @extend %clearfix;
   margin-left: 28px;
+  display: flex;
+  flex-flow: row wrap;
   &.audit {
     margin-right: 40px;
-    .left-menu {
-      float: left;
-    }
-    .right-menu {
-      float: right;
-    }
     li {
-      &.pie-chart, &.info-circle, &.assessment, &.issue, &.assessment_template {
+      &.access_group, &.clause, &.contract, &.control, &.data_asset, &.facility,
+      &.market, &.objective, &.org_group, &.policy, &.process, &.product,
+      &.regulation, &.section, &.standard, &.system, &.vendor {
         a {
           color: $blue;
           @include opacity(1);
@@ -35,41 +33,35 @@ ul.internav {
           }
         }
       }
-      &.menu-action {
-        float: right;
-        display: block !important;
-        margin-top: 7px;
-        margin-left: 3px;
-        .hide-menu {
-          background: $grayLight;
-          &:focus {
-            outline: none;
-          }
-        }
+      &:nth-child(4) {
+        margin-left: 0;
+        margin-right: auto;
       }
-      &.hidden-widgets-list {
-        border-left: 1px dotted $grayLight;
-        float: right;
-        position: relative;
-        padding-left: 5px;
-        height: 40px;
-        &:before {
-          content: '';
-          border-left: 1px dotted $grayLight;
-          position: absolute;
-          left: -3px;
-          height: 100%;
+      &:nth-child(-n+4) {
+        order: 10;
+      }
+      &:nth-child(n+5) {
+        order: 20;
+      }
+      &.hide-menu {
+        order: 15;
+        display: flex;
+        align-items: center;
+        &.visible {
+          border-left: 1px dotted;
+          border-right: 1px dotted;
+        }
+        i {
+          margin: auto 5px;
         }
       }
     }
   }
   li {
-    position: relative;
-    float: left;
     &.inner-nav-button {
-      text-align: center;
-      padding: 1px 40px 0 10px;
-      float: right;
+      margin-left: auto;
+      align-self: center;
+      padding-right: 40px;
       .message {
         color: $green;
       }
@@ -82,9 +74,13 @@ ul.internav {
       }
     }
     &.hidden-widgets-list {
-      a.dropdown-toggle {
-        &:hover {
-          background: none;
+      position: relative;
+      a {
+        white-space:nowrap;
+        &.dropdown-toggle {
+          &:hover {
+            background: none;
+          }
         }
       }
     }
@@ -100,6 +96,12 @@ ul.internav {
         &:hover {
           color: $black;
         }
+      }
+    }
+    .dropdown-menu {
+      a {
+        padding-top: 0;
+        padding-bottom: 0;
       }
     }
   }

--- a/src/ggrc_risks/assets/javascripts/apps/risks.js
+++ b/src/ggrc_risks/assets/javascripts/apps/risks.js
@@ -225,7 +225,6 @@
       widget_id: CMS.Models.Threat.table_singular,
       widget_name: CMS.Models.Threat.title_plural,
       widget_icon: CMS.Models.Threat.table_singular,
-      order: 275,
       content_controller_options: {
         child_options: relatedObjectsChildOptions,
         draw_children: true,
@@ -242,7 +241,7 @@
       widget_id: CMS.Models.Risk.table_singular,
       widget_name: CMS.Models.Risk.title_plural,
       widget_icon: CMS.Models.Risk.table_singular,
-      order: 265,
+      order: 45, // between default Objective (40) and Control (50)
       content_controller_options: {
         child_options: relatedObjectsChildOptions,
         draw_children: true,

--- a/src/ggrc_risks/assets/javascripts/apps/risks.js
+++ b/src/ggrc_risks/assets/javascripts/apps/risks.js
@@ -3,99 +3,112 @@
  * Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  */
 
-
 (function ($, CMS, GGRC) {
   var RisksExtension = {};
 
   // Insert risk mappings to all gov/business object types
-  var _risk_object_types = [
-      "Program", "Regulation", "Standard", "Policy", "Contract",
-      "Objective", "Control", "Section", "Clause", "System", "Process",
-      "DataAsset", "Facility", "Market", "Product", "Project",
-      "MultitypeSearch", "Issue", "Assessment", "AccessGroup",
-      "Person", "OrgGroup", "Vendor"
-    ],
-    related_object_descriptors = {},
-    threat_descriptor, risk_descriptor;
+  var riskObjectTypes = [
+    'AccessGroup',
+    'Assessment',
+    'Clause',
+    'Contract',
+    'Control',
+    'DataAsset',
+    'Facility',
+    'Issue',
+    'Market',
+    'MultitypeSearch',
+    'Objective',
+    'OrgGroup',
+    'Person',
+    'Policy',
+    'Process',
+    'Product',
+    'Program',
+    'Project',
+    'Regulation',
+    'Section',
+    'Standard',
+    'System',
+    'Vendor'
+  ];
+  var relatedObjectDescriptors = {};
+  var threatDescriptor;
+  var riskDescriptor;
 
   // Register `risks` extension with GGRC
   GGRC.extensions.push(RisksExtension);
 
-  RisksExtension.name = "risks";
+  RisksExtension.name = 'risks';
 
   // Register Risk Assessment models for use with `infer_object_type`
   RisksExtension.object_type_decision_tree = function () {
     return {
-      "risk": CMS.Models.Risk,
-      "threat": CMS.Models.Threat
+      risk: CMS.Models.Risk,
+      threat: CMS.Models.Threat
     };
   };
 
   // Configure mapping extensions for ggrc_risks
-  RisksExtension.init_mappings = function init_mappings() {
-    var Proxy = GGRC.MapperHelpers.Proxy,
-      Direct = GGRC.MapperHelpers.Direct,
-      Cross = GGRC.MapperHelpers.Cross,
-      CustomFilter = GGRC.MapperHelpers.CustomFilter,
-      Reify = GGRC.MapperHelpers.Reify,
-      Search = GGRC.MapperHelpers.Search,
-      TypeFilter = GGRC.MapperHelpers.TypeFilter,
-      Multi = GGRC.MapperHelpers.Multi,
-      Indirect = GGRC.MapperHelpers.Indirect;
+  RisksExtension.init_mappings = function () {
+    var Proxy = GGRC.MapperHelpers.Proxy;
+    var Search = GGRC.MapperHelpers.Search;
+    var TypeFilter = GGRC.MapperHelpers.TypeFilter;
+    var Multi = GGRC.MapperHelpers.Multi;
 
     // Add mappings for risk objects
     var mappings = {
-
       related: {
-        related_objects_as_source: Proxy(
-          null, "destination", "Relationship", "source", "related_destinations"),
+        related_objects_as_source: Proxy(null, 'destination', 'Relationship',
+          'source', 'related_destinations'),
         related_objects_as_destination: Proxy(
-          null, "source", "Relationship", "destination", "related_sources"),
-        related_objects: Multi(["related_objects_as_source", "related_objects_as_destination"]),
+          null, 'source', 'Relationship', 'destination', 'related_sources'),
+        related_objects:
+          Multi(['related_objects_as_source', 'related_objects_as_destination'])
       },
       related_objects: {
         _canonical: {
-          "related_objects_as_source": _risk_object_types,
+          related_objects_as_source: riskObjectTypes
         },
-        related_programs: TypeFilter("related_objects", "Program"),
-        related_data_assets: TypeFilter("related_objects", "DataAsset"),
-        related_access_groups: TypeFilter("related_objects", "AccessGroup"),
-        related_facilities: TypeFilter("related_objects", "Facility"),
-        related_markets: TypeFilter("related_objects", "Market"),
-        related_processes: TypeFilter("related_objects", "Process"),
-        related_products: TypeFilter("related_objects", "Product"),
-        related_projects: TypeFilter("related_objects", "Project"),
-        related_systems: TypeFilter("related_objects", "System"),
-        related_controls: TypeFilter("related_objects", "Control"),
-        related_clauses: TypeFilter("related_objects", "Clause"),
-        related_sections: TypeFilter("related_objects", "Section"),
-        related_regulations: TypeFilter("related_objects", "Regulation"),
-        related_contracts: TypeFilter("related_objects", "Contract"),
-        related_policies: TypeFilter("related_objects", "Policy"),
-        related_standards: TypeFilter("related_objects", "Standard"),
-        related_objectives: TypeFilter("related_objects", "Objective"),
-        related_issues: TypeFilter("related_objects", "Issue"),
-        related_assessments: TypeFilter("related_objects", "Assessment"),
-        related_people: TypeFilter("related_objects", "Person"),
-        related_org_groups: TypeFilter("related_objects", "OrgGroup"),
-        related_vendors: TypeFilter("related_objects", "Vendor")
+        related_programs: TypeFilter('related_objects', 'Program'),
+        related_data_assets: TypeFilter('related_objects', 'DataAsset'),
+        related_access_groups: TypeFilter('related_objects', 'AccessGroup'),
+        related_facilities: TypeFilter('related_objects', 'Facility'),
+        related_markets: TypeFilter('related_objects', 'Market'),
+        related_processes: TypeFilter('related_objects', 'Process'),
+        related_products: TypeFilter('related_objects', 'Product'),
+        related_projects: TypeFilter('related_objects', 'Project'),
+        related_systems: TypeFilter('related_objects', 'System'),
+        related_controls: TypeFilter('related_objects', 'Control'),
+        related_clauses: TypeFilter('related_objects', 'Clause'),
+        related_sections: TypeFilter('related_objects', 'Section'),
+        related_regulations: TypeFilter('related_objects', 'Regulation'),
+        related_contracts: TypeFilter('related_objects', 'Contract'),
+        related_policies: TypeFilter('related_objects', 'Policy'),
+        related_standards: TypeFilter('related_objects', 'Standard'),
+        related_objectives: TypeFilter('related_objects', 'Objective'),
+        related_issues: TypeFilter('related_objects', 'Issue'),
+        related_assessments: TypeFilter('related_objects', 'Assessment'),
+        related_people: TypeFilter('related_objects', 'Person'),
+        related_org_groups: TypeFilter('related_objects', 'OrgGroup'),
+        related_vendors: TypeFilter('related_objects', 'Vendor')
 
       },
       related_risk: {
         _canonical: {
-          "related_objects_as_source": ['Risk'].concat(_risk_object_types)
+          related_objects_as_source: ['Risk'].concat(riskObjectTypes)
         },
-        related_risks: TypeFilter("related_objects", "Risk")
+        related_risks: TypeFilter('related_objects', 'Risk')
       },
       related_threat: {
         _canonical: {
-          "related_objects_as_source": ['Threat'].concat(_risk_object_types)
+          related_objects_as_source: ['Threat'].concat(riskObjectTypes)
         },
-        related_threats: TypeFilter("related_objects", "Threat")
+        related_threats: TypeFilter('related_objects', 'Threat')
       },
       ownable: {
         owners: Proxy(
-          "Person", "person", "ObjectOwner", "ownable", "object_owners")
+          'Person', 'person', 'ObjectOwner', 'ownable', 'object_owners')
       },
       Risk: {
         _mixins: ['related', 'related_objects', 'related_threat', 'ownable'],
@@ -120,69 +133,71 @@
     // patch Person to extend query for dashboard
     GGRC.Mappings.modules.ggrc_core
       .Person.related_objects_via_search
-      .observe_types.push("Risk", "Threat");
+      .observe_types.push('Risk', 'Threat');
 
-    can.each(_risk_object_types, function (type) {
-        mappings[type] = _.extend(mappings[type] || {}, {
-          _canonical: {
-            "related_objects_as_source": ["Risk", "Threat"]
-          },
-          _mixins: ["related", "related_risk", "related_threat"],
-        });
+    can.each(riskObjectTypes, function (type) {
+      mappings[type] = _.extend(mappings[type] || {}, {
+        _canonical: {
+          related_objects_as_source: ['Risk', 'Threat']
+        },
+        _mixins: ['related', 'related_risk', 'related_threat']
+      });
     });
-    new GGRC.Mappings("ggrc_risks", mappings);
+    new GGRC.Mappings('ggrc_risks', mappings);
   };
 
   // Override GGRC.extra_widget_descriptors and GGRC.extra_default_widgets
   // Initialize widgets for risk page
-  RisksExtension.init_widgets = function init_widgets() {
+  RisksExtension.init_widgets = function () {
     var treeViewDepth = 2;
-    var relatedObjectsChildOptions = [GGRC.Utils.getRelatedObjects(treeViewDepth)];
-    var page_instance = GGRC.page_instance();
-    var is_my_work = function () {
-      return page_instance && page_instance.type === 'Person';
+    var relatedObjChildOpts =
+      [GGRC.Utils.getRelatedObjects(treeViewDepth)];
+    var pageInstance = GGRC.page_instance();
+    var isMyWork = function () {
+      return pageInstance && pageInstance.type === 'Person';
     };
 
-    var related_or_owned = is_my_work() ? 'owned_' : 'related_';
-    var sorted_widget_types = _.sortBy(_risk_object_types, function (type) {
+    var relatedOrOwned = isMyWork() ? 'owned_' : 'related_';
+    var sortedWidgetTypes = _.sortBy(riskObjectTypes, function (type) {
       var model = CMS.Models[type] || {};
       return model.title_plural || type;
     });
     var baseWidgetsByType = GGRC.tree_view.base_widgets_by_type;
     var moduleObjectNames = ['Risk', 'Threat'];
-    var extendedModuleTypes = _risk_object_types.concat(moduleObjectNames);
+    var extendedModuleTypes = riskObjectTypes.concat(moduleObjectNames);
     var subTrees = GGRC.tree_view.sub_tree_for;
 
     if (/^\/objectBrowser\/?$/.test(window.location.pathname)) {
-      related_or_owned = 'all_';
+      relatedOrOwned = 'all_';
     }
     // Init widget descriptors:
-    can.each(sorted_widget_types, function (model_name) {
+    can.each(sortedWidgetTypes, function (modelName) {
       var model;
 
-      if (model_name === "MultitypeSearch" || !baseWidgetsByType[model_name]) {
+      if (modelName === 'MultitypeSearch' || !baseWidgetsByType[modelName]) {
         return;
       }
-      model = CMS.Models[model_name];
+      model = CMS.Models[modelName];
 
       // First we add Risk and Threat to other object's maps
-      baseWidgetsByType[model_name] = baseWidgetsByType[model_name].concat(
+      baseWidgetsByType[modelName] = baseWidgetsByType[modelName].concat(
         moduleObjectNames);
 
-      related_object_descriptors[model_name] = {
+      relatedObjectDescriptors[modelName] = {
         content_controller: CMS.Controllers.TreeView,
-        content_controller_selector: "ul",
+        content_controller_selector: 'ul',
         widget_initial_content: '<ul class="tree-structure new-tree"></ul>',
         widget_id: model.table_singular,
         widget_name: model.model_plural,
         widget_icon: model.table_singular,
         content_controller_options: {
-          add_item_view: GGRC.mustache_path + "/base_objects/tree_add_item.mustache",
-          child_options: relatedObjectsChildOptions,
+          add_item_view: GGRC.mustache_path +
+          '/base_objects/tree_add_item.mustache',
+          child_options: relatedObjChildOpts,
           draw_children: true,
-          parent_instance: page_instance,
+          parent_instance: pageInstance,
           model: model,
-          mapping: "related_" + model.table_plural
+          mapping: 'related_' + model.table_plural
         }
       };
     });
@@ -191,10 +206,10 @@
     // tree_view.basic_model_list and tree_view.sub_tree_for for risk module
     // objects
     can.each(moduleObjectNames, function (name) {
-      baseWidgetsByType[name] = extendedModuleTypes;
-
       var widgetList = baseWidgetsByType[name];
-      var child_model_list = [];
+      var childModelList = [];
+
+      baseWidgetsByType[name] = extendedModuleTypes;
 
       GGRC.tree_view.basic_model_list.push({
         model_name: name,
@@ -203,7 +218,7 @@
 
       can.each(widgetList, function (item) {
         if (extendedModuleTypes.indexOf(item) !== -1) {
-          child_model_list.push({
+          childModelList.push({
             model_name: item,
             display_name: CMS.Models[item].title_singular
           });
@@ -212,112 +227,108 @@
 
       if (!_.isEmpty(subTrees.serialize())) {
         subTrees.attr(name, {
-          model_list: child_model_list,
-          display_list: CMS.Models[name].tree_view_options.child_tree_display_list || widgetList
+          model_list: childModelList,
+          display_list:
+          CMS.Models[name].tree_view_options.child_tree_display_list ||
+          widgetList
         });
       }
     });
 
-    threat_descriptor = {
+    threatDescriptor = {
       content_controller: CMS.Controllers.TreeView,
-      content_controller_selector: "ul",
+      content_controller_selector: 'ul',
       widget_initial_content: '<ul class="tree-structure new-tree"></ul>',
       widget_id: CMS.Models.Threat.table_singular,
       widget_name: CMS.Models.Threat.title_plural,
       widget_icon: CMS.Models.Threat.table_singular,
       content_controller_options: {
-        child_options: relatedObjectsChildOptions,
+        child_options: relatedObjChildOpts,
         draw_children: true,
-        parent_instance: page_instance,
+        parent_instance: pageInstance,
         model: CMS.Models.Threat,
-        mapping: related_or_owned + CMS.Models.Threat.table_plural,
+        mapping: relatedOrOwned + CMS.Models.Threat.table_plural,
         footer_view: GGRC.mustache_path + '/base_objects/tree_footer.mustache'
       }
     };
-    risk_descriptor = {
+    riskDescriptor = {
       content_controller: CMS.Controllers.TreeView,
-      content_controller_selector: "ul",
+      content_controller_selector: 'ul',
       widget_initial_content: '<ul class="tree-structure new-tree"></ul>',
       widget_id: CMS.Models.Risk.table_singular,
       widget_name: CMS.Models.Risk.title_plural,
       widget_icon: CMS.Models.Risk.table_singular,
       order: 45, // between default Objective (40) and Control (50)
       content_controller_options: {
-        child_options: relatedObjectsChildOptions,
+        child_options: relatedObjChildOpts,
         draw_children: true,
-        parent_instance: page_instance,
+        parent_instance: pageInstance,
         model: CMS.Models.Risk,
-        mapping: related_or_owned + CMS.Models.Risk.table_plural,
+        mapping: relatedOrOwned + CMS.Models.Risk.table_plural,
         footer_view: GGRC.mustache_path + '/base_objects/tree_footer.mustache'
       }
     };
 
-    if (page_instance instanceof CMS.Models.Risk) {
+    if (pageInstance instanceof CMS.Models.Risk) {
       RisksExtension.init_widgets_for_risk_page();
-    } else if (page_instance instanceof CMS.Models.Threat) {
+    } else if (pageInstance instanceof CMS.Models.Threat) {
       RisksExtension.init_widgets_for_threat_page();
-    } else if (page_instance instanceof CMS.Models.Person) {
+    } else if (pageInstance instanceof CMS.Models.Person) {
       RisksExtension.init_widgets_for_person_page();
     } else {
       RisksExtension.init_widgets_for_other_pages();
     }
   };
 
-  RisksExtension.init_widgets_for_risk_page =
-    function init_widgets_for_risk_page() {
-      var risk_descriptors = $.extend({},
-        related_object_descriptors, {
-          Threat: threat_descriptor
-        }
-      );
-      new GGRC.WidgetList("ggrc_risks", {
-        Risk: risk_descriptors
-      });
-  };
-
-  RisksExtension.init_widgets_for_threat_page =
-    function init_widgets_for_threat_page() {
-      var threat_descriptors = $.extend({},
-        related_object_descriptors, {
-          Risk: risk_descriptor
-        }
-      );
-      new GGRC.WidgetList("ggrc_risks", {
-        Threat: threat_descriptors
-      });
-  };
-
-  RisksExtension.init_widgets_for_person_page =
-    function init_widgets_for_person_page() {
-      var people_widgets = $.extend({}, {
-          Threat: threat_descriptor
-        }, {
-          Risk: risk_descriptor
-        }
-      );
-
-      new GGRC.WidgetList("ggrc_risks", {
-        Person: people_widgets
-      });
-  };
-
-  RisksExtension.init_widgets_for_other_pages =
-    function init_widgets_for_other_pages() {
-      var descriptor = {},
-          page_instance = GGRC.page_instance();
-      if (page_instance && ~can.inArray(page_instance.constructor.shortName, _risk_object_types)) {
-        descriptor[page_instance.constructor.shortName] = {
-          risk: risk_descriptor,
-          threat: threat_descriptor
-        };
+  RisksExtension.init_widgets_for_risk_page = function () {
+    var riskDescriptors = $.extend({},
+      relatedObjectDescriptors, {
+        Threat: threatDescriptor
       }
-      new GGRC.WidgetList("ggrc_risks", descriptor);
+    );
+    new GGRC.WidgetList('ggrc_risks', {
+      Risk: riskDescriptors
+    });
   };
 
+  RisksExtension.init_widgets_for_threat_page = function () {
+    var threatDescriptors = $.extend({},
+      relatedObjectDescriptors, {
+        Risk: riskDescriptor
+      }
+    );
+    new GGRC.WidgetList('ggrc_risks', {
+      Threat: threatDescriptors
+    });
+  };
 
+  RisksExtension.init_widgets_for_person_page = function () {
+    var peopleWidgets = $.extend({}, {
+      Threat: threatDescriptor
+    }, {
+      Risk: riskDescriptor
+    });
 
-  GGRC.register_hook("LHN.Sections_risk", GGRC.mustache_path + "/dashboard/lhn_risks");
+    new GGRC.WidgetList('ggrc_risks', {
+      Person: peopleWidgets
+    });
+  };
+
+  RisksExtension.init_widgets_for_other_pages = function () {
+    var descriptor = {};
+    var pageInstance = GGRC.page_instance();
+    if (pageInstance &&
+      ~can.inArray(pageInstance.constructor.shortName, riskObjectTypes)) {
+      descriptor[pageInstance.constructor.shortName] = {
+        risk: riskDescriptor,
+        threat: threatDescriptor
+      };
+    }
+    new GGRC.WidgetList('ggrc_risks', descriptor);
+  };
+
+  GGRC.register_hook('LHN.Sections_risk',
+    GGRC.mustache_path + '/dashboard/lhn_risks');
 
   RisksExtension.init_mappings();
-
 })(this.can.$, this.CMS, this.GGRC);

--- a/src/ggrc_risks/assets/javascripts/models/risk.js
+++ b/src/ggrc_risks/assets/javascripts/models/risk.js
@@ -3,30 +3,29 @@
  * Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  */
 
-
-(function(can) {
-
-  can.Model.Cacheable("CMS.Models.Risk", {
-    root_object: "risk",
-    root_collection: "risks",
-    category: "risk",
-    findAll: "GET /api/risks",
-    findOne: "GET /api/risks/{id}",
-    create: "POST /api/risks",
-    update: "PUT /api/risks/{id}",
-    destroy: "DELETE /api/risks/{id}",
+(function (can) {
+  can.Model.Cacheable('CMS.Models.Risk', {
+    root_object: 'risk',
+    root_collection: 'risks',
+    category: 'risk',
+    findAll: 'GET /api/risks',
+    findOne: 'GET /api/risks/{id}',
+    create: 'POST /api/risks',
+    update: 'PUT /api/risks/{id}',
+    destroy: 'DELETE /api/risks/{id}',
     mixins: ['ownable', 'contactable', 'unique_title', 'ca_update'],
     is_custom_attributable: true,
-    attributes : {
-      context : "CMS.Models.Context.stub",
-      contact : "CMS.Models.Person.stub",
-      owners : "CMS.Models.Person.stubs",
-      modified_by : "CMS.Models.Person.stub",
-      objects : "CMS.Models.get_stubs",
-      risk_objects: "CMS.Models.RiskObject.stubs"
+    attributes: {
+      context: 'CMS.Models.Context.stub',
+      contact: 'CMS.Models.Person.stub',
+      owners: 'CMS.Models.Person.stubs',
+      modified_by: 'CMS.Models.Person.stub',
+      objects: 'CMS.Models.get_stubs',
+      risk_objects: 'CMS.Models.RiskObject.stubs'
     },
     tree_view_options: {
-      add_item_view : GGRC.mustache_path + "/base_objects/tree_add_item.mustache",
+      add_item_view: GGRC.mustache_path +
+      '/base_objects/tree_add_item.mustache',
       attr_view: GGRC.mustache_path + '/base_objects/tree-item-attr.mustache'
     },
     defaults: {
@@ -34,12 +33,15 @@
     },
     statuses: ['Draft', 'Deprecated', 'Active'],
     init: function () {
-      this._super && this._super.apply(this, arguments);
-      var req_fields = ["title", "description", "contact"];
-      for (var i = 0; i < req_fields.length; i++) {
-        this.validatePresenceOf(req_fields[i]);
+      var reqFields = ['title', 'description', 'contact'];
+      var i = 0;
+      if (this._super) {
+        this._super.apply(this, arguments);
+      }
+
+      for (i; i < reqFields.length; i++) {
+        this.validatePresenceOf(reqFields[i]);
       }
     }
   }, {});
-
 })(window.can);

--- a/src/ggrc_risks/assets/javascripts/models/risk_join_models.js
+++ b/src/ggrc_risks/assets/javascripts/models/risk_join_models.js
@@ -3,26 +3,23 @@
  * Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  */
 
-
-(function(can) {
-
-  can.Model.Join("CMS.Models.RiskObject", {
-    root_object: "risk_object",
-    root_collection: "risk_objects",
+(function (can) {
+  can.Model.Join('CMS.Models.RiskObject', {
+    root_object: 'risk_object',
+    root_collection: 'risk_objects',
     join_keys: {
-      "risk": CMS.Models.Risk,
-      "object": can.Model.Cacheable,
+      risk: CMS.Models.Risk,
+      object: can.Model.Cacheable
     },
     attributes: {
-      context: "CMS.Models.Context.stub",
-      modified_by: "CMS.Models.Person.stub",
-      risk: "CMS.Models.Risk.stub",
-      object: "CMS.Models.get_stub",
+      context: 'CMS.Models.Context.stub',
+      modified_by: 'CMS.Models.Person.stub',
+      risk: 'CMS.Models.Risk.stub',
+      object: 'CMS.Models.get_stub'
     },
-    findAll: "GET /api/risk_objects",
-    create: "POST /api/risk_objects",
-    destroy: "DELETE /api/risk_objects/{id}"
+    findAll: 'GET /api/risk_objects',
+    create: 'POST /api/risk_objects',
+    destroy: 'DELETE /api/risk_objects/{id}'
   }, {
   });
-
 })(window.can);

--- a/src/ggrc_risks/assets/javascripts/models/threat.js
+++ b/src/ggrc_risks/assets/javascripts/models/threat.js
@@ -3,37 +3,37 @@
  * Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  */
 
-
 (function (can) {
-  can.Model.Cacheable("CMS.Models.Threat", {
-    root_object: "threat",
-    root_collection: "threats",
-    category: "risk",
-    findAll: "GET /api/threats",
-    findOne: "GET /api/threats/{id}",
-    create: "POST /api/threats",
-    update: "PUT /api/threats/{id}",
-    destroy: "DELETE /api/threats/{id}",
+  can.Model.Cacheable('CMS.Models.Threat', {
+    root_object: 'threat',
+    root_collection: 'threats',
+    category: 'risk',
+    findAll: 'GET /api/threats',
+    findOne: 'GET /api/threats/{id}',
+    create: 'POST /api/threats',
+    update: 'PUT /api/threats/{id}',
+    destroy: 'DELETE /api/threats/{id}',
     mixins: ['ownable', 'contactable', 'unique_title', 'ca_update'],
     is_custom_attributable: true,
     attributes: {
-      context: "CMS.Models.Context.stub",
-      contact: "CMS.Models.Person.stub",
-      owners: "CMS.Models.Person.stubs",
-      modified_by: "CMS.Models.Person.stub",
-      object_people: "CMS.Models.ObjectPerson.stubs",
-      people: "CMS.Models.Person.stubs",
-      related_sources: "CMS.Models.Relationship.stubs",
-      related_destinations: "CMS.Models.Relationship.stubs",
-      object_objectives: "CMS.Models.ObjectObjective.stubs",
-      objectives: "CMS.Models.Objective.stubs",
-      object_controls: "CMS.Models.ObjectControl.stubs",
-      controls: "CMS.Models.Control.stubs",
-      object_sections: "CMS.Models.ObjectSection.stubs",
-      sections: "CMS.Models.get_stubs"
+      context: 'CMS.Models.Context.stub',
+      contact: 'CMS.Models.Person.stub',
+      owners: 'CMS.Models.Person.stubs',
+      modified_by: 'CMS.Models.Person.stub',
+      object_people: 'CMS.Models.ObjectPerson.stubs',
+      people: 'CMS.Models.Person.stubs',
+      related_sources: 'CMS.Models.Relationship.stubs',
+      related_destinations: 'CMS.Models.Relationship.stubs',
+      object_objectives: 'CMS.Models.ObjectObjective.stubs',
+      objectives: 'CMS.Models.Objective.stubs',
+      object_controls: 'CMS.Models.ObjectControl.stubs',
+      controls: 'CMS.Models.Control.stubs',
+      object_sections: 'CMS.Models.ObjectSection.stubs',
+      sections: 'CMS.Models.get_stubs'
     },
     tree_view_options: {
-      add_item_view : GGRC.mustache_path + "/base_objects/tree_add_item.mustache",
+      add_item_view: GGRC.mustache_path +
+      '/base_objects/tree_add_item.mustache',
       attr_view: GGRC.mustache_path + '/base_objects/tree-item-attr.mustache',
       attr_list: can.Model.Cacheable.attr_list.concat([
         {attr_title: 'URL', attr_name: 'url'},
@@ -45,8 +45,10 @@
     },
     statuses: ['Draft', 'Deprecated', 'Active'],
     init: function () {
-      this._super && this._super.apply(this, arguments);
-      this.validatePresenceOf("title");
+      if (this._super) {
+        this._super.apply(this, arguments);
+      }
+      this.validatePresenceOf('title');
     }
   }, {});
 })(window.can);

--- a/src/ggrc_workflows/assets/javascripts/apps/workflows.js
+++ b/src/ggrc_workflows/assets/javascripts/apps/workflows.js
@@ -430,7 +430,6 @@
         workflow: {
           widget_id: 'workflow',
           widget_name: 'Workflows',
-          order: 400,
           content_controller: GGRC.Controllers.TreeView,
           content_controller_options: {
             mapping: 'workflows',
@@ -443,7 +442,6 @@
         task: {
           widget_id: 'task',
           widget_name: 'Workflow Tasks',
-          order: 410,
           content_controller: GGRC.Controllers.TreeView,
           content_controller_options: {
             mapping: 'object_tasks',


### PR DESCRIPTION
**GGRC-1024**
Fix tab order for non-audit related objects for audit page according to changes in GGRC-1171, but Assessment, Issue, Program should be at first

**GGRC-1045**
Tabs color: change blue to snapshots on the right and grey fro objects on left
Left tabs should not collapse if not enough space for it, only right part should collapse

Mockups: https://goo.gl/BR0hVV

**GGRC-1171**
Scenario:

The screenshot shows standards after products tab. Hierarchy in program is:
Standards,Regulations,Sections,Objectives,Risks,Controls, Products, Systems,Process,Audit,People, AND (alphabetical order after this)

