### PR TITLE
GGRC-1140 Add verified assessments to pie chart

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/summary_widget_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/summary_widget_controller.js
@@ -12,6 +12,7 @@
       isLoading: true,
       colorsMap: {
         Completed: '#8bc34a',
+        Verified: '#333',
         'In Progress': '#ffab40',
         'Not Started': '#bdbdbd',
         'Ready for Review': '#1378bb'
@@ -208,7 +209,13 @@
       }
     },
     parseStatuses: function (data) {
-      var groups = _.groupBy(data.values, 'status');
+      var pregroups = data.values.map(function (item) {
+        if (item.verified) {
+          item.status = 'Verified';
+        }
+        return item;
+      });
+      var groups = _.groupBy(pregroups, 'status');
       var pairs = _.pairs(groups);
       var sorted = _.sortBy(pairs, function (e) {
         return e[0];
@@ -228,7 +235,7 @@
         type,
         {},
         {id: auditId, type: 'Audit'},
-        ['status']);
+        ['status', 'verified']);
       return GGRC.Utils.QueryAPI.makeRequest({data: [query]});
     },
     loadChartLibrary: function (callback) {


### PR DESCRIPTION
**Add verified assessments to pie chart**

**Precondition**:
created program, audit, assessment on the audit page 

**Steps to reproduce**:
1. Navigate to Assessment's Info panel and Verify/Complete Assessment
2. Go to Audit Summary page
3. Look at the legend: assessment in verified state is not increased by one

**Actual Result**: Verified assessment is not shown in Legend on Audit Summary page
**Expected Result**: Verified and Completed assessment should be shown in Legend on Audit Summary page

Note: Legend "Completed" should show Assessments that are in Completed but Not Verified state. E.g. In progress->Completed