### PR TITLE
GGRC-1205 Add change notification when Assessment CA changes

### DIFF
--- a/test/unit/ggrc/notification/test_notification_handlers.py
+++ b/test/unit/ggrc/notification/test_notification_handlers.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Tests for the ggrc.notifications.notification_handlers module."""
+
+import unittest
+
+from ggrc.notifications.notification_handlers import _align_by_ids, IdValPair
+
+
+class TestAlignByIds(unittest.TestCase):
+  """Tests for the _align_by_ids helper function."""
+  # pylint: disable=invalid-name
+
+  def test_yields_nothing_for_empty_iterables(self):
+    """Giving two empty iterables should result in no pairs yielded."""
+    result = list(_align_by_ids([], []))
+    self.assertFalse(result)
+
+  def test_yields_item_pairs_with_same_ids(self):
+    """Items in yielded pairs shoučld be matched by their IDs."""
+    seq = [
+        IdValPair(8, "foo"),
+        IdValPair(3, "bar"),
+        IdValPair(7, "baz"),
+        IdValPair(9, "qux"),
+    ]
+
+    # values scrambled to test that items are indeed matched by their IDs
+    seq2 = [
+        IdValPair(7, "qux"),
+        IdValPair(3, "bar"),
+        IdValPair(9, "foo"),
+        IdValPair(8, "baz"),
+    ]
+
+    result = list(_align_by_ids(seq, seq2))
+    for item, item2 in result:
+      self.assertEqual(item.id, item2.id)
+
+  def test_pairs_items_with_no_match_with_none(self):
+    """Items without a matching ID are paired with None when yielded."""
+    seq = [
+        IdValPair(9, "bar"),
+    ]
+    seq2 = [
+        IdValPair(5, "foo"),
+        IdValPair(3, "moo"),
+    ]
+
+    result = list(_align_by_ids(seq, seq2))
+    expected = [
+        (IdValPair(9, "bar"), None),
+        (None, IdValPair(5, "foo")),
+        (None, IdValPair(3, "moo")),
+    ]
+
+    self.assertItemsEqual(result, expected)


### PR DESCRIPTION
This PR fixes the issue with detecting CA changes on Assessments.

~~Integration tests are still missing, although there is a separate ticket for that (GGRC-1131) - I can add them in the scope of this PR (for the CA changes), or in a separate PR, it's up to you.
(maybe better to add them separately so that they can be written in parallel while the QA verifies the fix itself?)~~

---

**Precondition:**
created GCA for assessment, program, control, audit, assessment template with LCA

**Steps to reproduce:**
1. Generate Assessment based on Control and assessment template on the audit page and move
  Assessment to In Progress state
2. Add/Update GCA or LCA value
3. Go to https://grc-test.appspot.com/_notifications/show_daily_digest or
https://grc-test.appspot.com/_notifications/show_pending

**Actual Result:**
Notification is not sent to user if update CA's value

**Expected Result:**
Notification should be send to user if update CA's value
(note: unless in the "Not Started" state, of course)