### PR TITLE
GGRC-1310 Fix mapper formatting

### DIFF
--- a/src/ggrc/assets/stylesheets/components/unified-mapper/_unified-mapper.scss
+++ b/src/ggrc/assets/stylesheets/components/unified-mapper/_unified-mapper.scss
@@ -358,7 +358,7 @@ mapper-results-item {
   &.has-related-assessments {
 
     object-selection-item {
-      width: $object-selection-item-with-related-assessments-width;
+      width: $object-selection-item-with-related-assessments-width !important;
     }
   }
 }


### PR DESCRIPTION
This PR fixes mapper grid formatting issue.

Precondition:
created program, control, audit
Steps to reproduce:
1. Go to audit page
2. Add objectives
3. Click search in Unified mapper
4. Look at the results list: confirm formatting is broken
Actual Result: Formatting is broken in Unified mapper
Expected Result: Formatting should nor be broken in Unified mapper