### PR TITLE
GGRC-1109 Extra evidence appears in Assessment's Info panel after refreshing the page and delete the evidence

### DIFF
--- a/src/ggrc/assets/javascripts/helpers/mapping_helpers.js
+++ b/src/ggrc/assets/javascripts/helpers/mapping_helpers.js
@@ -6,10 +6,15 @@
 (function () {
   Mustache.registerHelper('if_mapping_ready',
     function (mappingName, instance, options) {
-      var mappingDeferred = Mustache.resolve(instance)
-        .get_mapping_deferred(mappingName);
-
+      var mappingDeferred;
       var dfd = new $.Deferred();
+
+      if (typeof mappingName !== 'string') {
+        mappingName = Mustache.resolve(mappingName);
+      }
+
+      mappingDeferred = Mustache.resolve(instance)
+        .get_mapping_deferred(mappingName);
 
       mappingDeferred.then(function (mapping) {
         var resolveDfd = function () {

--- a/src/ggrc/assets/mustache/components/assessment/attachments-list.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/attachments-list.mustache
@@ -14,10 +14,13 @@
     <button type="button" class="close" data-dismiss="alert" aria-label="Close">&times;</button>
   </div>
 {{/if_null}}
-<mapping-tree-view
-  parent-instance="instance"
-  mapping="instance.class.info_pane_options.evidence.mapping"
-  item-template="instance.class.info_pane_options.evidence.show_view"
-  empty-text="None"
->
-</mapping-tree-view>
+
+{{#if_mapping_ready instance.class.info_pane_options.evidence.mapping instance}}
+  <mapping-tree-view
+    parent-instance="instance"
+    mapping="instance.class.info_pane_options.evidence.mapping"
+    item-template="instance.class.info_pane_options.evidence.show_view"
+    empty-text="None"
+  >
+  </mapping-tree-view>
+{{/if_mapping_ready}}


### PR DESCRIPTION
**Precondition**:
Created program, audit, assessment on the audit page

**Steps to reproduce**:
1. Navigate to Assessment's Info panel on the audit page 
2. Attach at least two evidences and refresh the page
3. Click trash icon to delete evidence: extra evidence appears

_Actual Result_: Extra evidence appears in Assessment's Info panel after refreshing the page and delete the evidence
_Expected Result_: Extra evidence should not appear in Assessment's Info panel after refreshing the page and delete the evidence

_Note_: to delete all the evidences after the steps mentioned above refresh the page is needed

![89c9f417b37aa8eb5a8d9671b095e6cbd55f639fd1e2533f8e pimgpsh_thumbnail_win_distr](https://cloud.githubusercontent.com/assets/4204416/23556741/ad8273da-003e-11e7-83c4-f024f3b6cb37.jpg)
