### PR TITLE
GGRC-1274/1275/1276 Unified mapper people improvements

### DIFF
--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -485,6 +485,7 @@ dashboard-js-template-files:
   - pbc/iframe_tooltip.mustache
   - people/active_column.mustache
   - people/autocomplete_result.mustache
+  - people/dropdown_menu.mustache
   - people/filters.mustache
   - people/info.mustache
   - people/list.mustache

--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -346,6 +346,7 @@ dashboard-js-template-files:
   - base_objects/open_close.mustache
   - base_objects/sub_tree_type_selector.mustache
   - base_objects/modal/search_title.mustache
+  - base_objects/mapper-item-description.mustache
   - base_templates/add_comment.mustache
   - base_templates/objects_tooltip.mustache
   - base_templates/attachment_list.mustache
@@ -503,6 +504,7 @@ dashboard-js-template-files:
   - people/tree_add_item.mustache
   - people/tree_header.mustache
   - people/search_result.mustache
+  - people/mapper-item-description.mustache
   - policies/info.mustache
   - policies/modal_content.mustache
   - processes/info.mustache

--- a/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
+++ b/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
@@ -893,7 +893,8 @@
           return a.order - b.order;
         });
 
-      var customAttrs =
+      var customAttrs = disableConfiguration ?
+        [] :
         GGRC.custom_attr_defs
           .filter(function (def) {
             return def.definition_type === modelDefinition &&

--- a/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
+++ b/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
@@ -869,7 +869,7 @@
           (Model.tree_view_options.display_attr_names ||
           Cacheable.tree_view_options.display_attr_names);
       var disableConfiguration =
-        !!Model.tree_view_options.disable_columns_configuration
+        !!Model.tree_view_options.disable_columns_configuration;
       var mandatoryColumns;
       var displayColumns;
 

--- a/src/ggrc/assets/mustache/base_objects/mapper-item-description.mustache
+++ b/src/ggrc/assets/mustache/base_objects/mapper-item-description.mustache
@@ -1,0 +1,35 @@
+{{!
+  Copyright (C) 2017 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+}}
+
+<div class="col-container">
+  <div class="attr-container title">
+    <h6>Owner</h6>
+    {{#if item.owners.length}}
+      <ul class="inner-count-list">
+        {{#each item.owners}}
+          <li>
+            <person-info person-id="{{id}}"></person-info>
+          </li>
+        {{/each}}
+      </ul>
+    {{else}}
+      <span class="empty-message">None</span>
+    {{/if}}
+  </div>
+  <div class="attr-container notes">
+    <h6>Notes</h6>
+    <div class="attr-value ">
+      {{item.notes}}
+    </div>
+  </div>
+</div>
+<div class="col-container">
+  <div class="attr-container description">
+    <h6>Description</h6>
+    <div class="attr-value">
+      {{item.description}}
+    </div>
+  </div>
+</div>

--- a/src/ggrc/assets/mustache/components/unified-mapper/mapper-results-item-details.mustache
+++ b/src/ggrc/assets/mustache/components/unified-mapper/mapper-results-item-details.mustache
@@ -15,36 +15,11 @@
   {{/if}}
 </div>
 <div class="flex-box">
-  <div class="col-container">
-    <div class="attr-container title">
-      <h6>Owner</h6>
-      {{#if item.owners.length}}
-        <ul class="inner-count-list">
-          {{#each item.owners}}
-            <li>
-              <person-info person-id="{{id}}"></person-info>
-            </li>
-          {{/each}}
-        </ul>
-      {{else}}
-        <span class="empty-message">None</span>
-      {{/if}}
-    </div>
-    <div class="attr-container notes">
-      <h6>Notes</h6>
-      <div class="attr-value ">
-        {{item.notes}}
-      </div>
-    </div>
-  </div>
-  <div class="col-container">
-    <div class="attr-container description">
-      <h6>Description</h6>
-      <div class="attr-value">
-        {{item.description}}
-      </div>
-    </div>
-  </div>
+  {{#if_equals instance.type "Person"}}
+    {{> '/static/mustache/people/mapper-item-description.mustache'}}
+  {{else}}
+    {{> '/static/mustache/base_objects/mapper-item-description.mustache'}}
+  {{/if_equals}}
 </div>
 <div class="open-link-container">
   <a href="{{firstnonempty instance.originalLink item.viewLink}}" target="_blank">

--- a/src/ggrc/assets/mustache/components/unified-mapper/mapper-results-item-details.mustache
+++ b/src/ggrc/assets/mustache/components/unified-mapper/mapper-results-item-details.mustache
@@ -7,7 +7,11 @@
   {{#if instance.snapshot}}
     {{> '/static/mustache/snapshots/dropdown_menu.mustache'}}
   {{else}}
-    {{> '/static/mustache/base_objects/dropdown_menu.mustache'}}
+    {{#if_equals instance.type "Person"}}
+      {{> '/static/mustache/people/dropdown_menu.mustache'}}
+    {{else}}
+      {{> '/static/mustache/base_objects/dropdown_menu.mustache'}}
+    {{/if_equals}}
   {{/if}}
 </div>
 <div class="flex-box">

--- a/src/ggrc/assets/mustache/people/dropdown_menu.mustache
+++ b/src/ggrc/assets/mustache/people/dropdown_menu.mustache
@@ -1,0 +1,23 @@
+{{!
+    Copyright (C) 2017 Google Inc.
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+}}
+
+<div class="details-wrap">
+  <a class="btn btn-draft dropdown-toggle" href="#" data-toggle="dropdown">
+    <span class="bubble"></span>
+    <span class="bubble"></span>
+    <span class="bubble"></span>
+  </a>
+  <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
+    <li class="border-bottom">
+      <clipboard-link title="Get permalink" notify="true" text="{{get_permalink_for_object instance}}" />
+    </li>
+    <li>
+      <a href="/people/{{instance.id}}" target="_blank">
+        <i class="fa fa-long-arrow-right"></i>
+        Open Profile Page
+      </a>
+    </li>
+  </ul>
+</div>

--- a/src/ggrc/assets/mustache/people/mapper-item-description.mustache
+++ b/src/ggrc/assets/mustache/people/mapper-item-description.mustache
@@ -1,0 +1,13 @@
+{{!
+  Copyright (C) 2017 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+}}
+
+<div class="col-container">
+  <div class="attr-container description">
+    <h6>Company</h6>
+    <div class="attr-value">
+      {{item.company}}
+    </div>
+  </div>
+</div>

--- a/src/ggrc_basic_permissions/assets/mustache/ggrc_basic_permissions/people_roles/info.mustache
+++ b/src/ggrc_basic_permissions/assets/mustache/ggrc_basic_permissions/people_roles/info.mustache
@@ -53,7 +53,7 @@
           {{/if_instance_of}}
         {{/with_program_roles_as}}
         <li>
-          <a href="/people/{{instance.id}}">
+          <a href="/people/{{instance.id}}" target="_blank">
             <i class="fa fa-long-arrow-right"></i>
             Open Profile Page
           </a>


### PR DESCRIPTION
This PR improves people result grid in the unified mapper.

GGRC-1274:
Confirmed with NK: hide CA columns for people

GGRC-1275:
Confirmed with NK: make Company the only field in Person's description for the mapper

GGRC-1276:
Confirmed with NK: the dropdown should be the same as in the Info pane