### PR TITLE
GGRC-1269 Avoid creating a Relationship on Snapshottable-Audit mapping

### DIFF
--- a/src/ggrc/automapper/__init__.py
+++ b/src/ggrc/automapper/__init__.py
@@ -239,41 +239,6 @@ class AutomapperGenerator(object):
     return True
 
 
-def generate_relationship_snapshots(obj):
-  """Generate needed snapshots for a given relationship.
-
-  If we post a relationship for a snapshotable object and an Audit, we will map
-  that object to audits program, make a snapshot for it and map the snapshot to
-  the Audit.
-
-  NOTE: this function will be deprecated soon.
-
-  Args:
-    obj: Relationship object.
-  """
-
-  from ggrc.snapshotter import rules as snapshot_rules
-
-  parent = None
-  child = None
-  if "Audit" in obj.source_type:
-    parent = obj.source
-    child = obj.destination
-  elif "Audit" in obj.destination_type:
-    parent = obj.destination
-    child = obj.source
-
-  if parent and child.type in snapshot_rules.Types.all:
-    db.session.add(models.Snapshot(
-        parent=parent,
-        child_id=child.id,
-        child_type=child.type,
-        update_revision="new",
-        context=parent.context,
-        modified_by=get_current_user()
-    ))
-
-
 def register_automapping_listeners():
   """Register event listeners for auto mapper."""
   # pylint: disable=unused-variable,unused-argument
@@ -293,5 +258,4 @@ def register_automapping_listeners():
       if obj is None:
         logger.warning("Automapping listener: no obj, no mappings created")
         return
-      generate_relationship_snapshots(obj)
       automapper.generate_automappings(obj)

--- a/src/ggrc/services/__init__.py
+++ b/src/ggrc/services/__init__.py
@@ -12,6 +12,7 @@ def contributed_services():
   (url, ModelClass) tuples.
   """
   import ggrc.models.all_models as models
+  from ggrc.services.relationship_resource import RelationshipResource
 
   return [
       service('background_tasks', models.BackgroundTask),
@@ -53,7 +54,7 @@ def contributed_services():
       service('products', models.Product),
       service('projects', models.Project),
       service('programs', models.Program),
-      service('relationships', models.Relationship),
+      service('relationships', models.Relationship, RelationshipResource),
       service('requests', models.Request),
       service('revisions', models.Revision, ReadOnlyResource),
       service('sections', models.Section),

--- a/src/ggrc/services/relationship_resource.py
+++ b/src/ggrc/services/relationship_resource.py
@@ -1,0 +1,73 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Custom Resource for Relationship that creates Snapshots when needed.
+
+When Audit-Snapshottable Relationship is POSTed, a Snapshot should be created
+instead.
+"""
+
+from ggrc.builder import json as json_builder
+from ggrc import db
+import ggrc.services.common
+from ggrc.models.snapshot import Snapshot
+from ggrc.login import get_current_user
+
+
+class RelationshipResource(ggrc.services.common.Resource):
+  """Custom Resource that transforms Relationships to Snapshots on un-json."""
+
+  # pylint: disable=abstract-method
+
+  @staticmethod
+  def _parse_snapshot_data(src):
+    """Try to find parent-child pair from src.
+
+    Args:
+      src: source JSON from which a Relationship would have been created.
+
+    Returns:
+      (parent, child, is_snapshot):
+          (source, destination, True) if source is a Parent and destination is
+          a Snapshottable;
+          (destination, source, True) if source is a Snapshottable and
+          destination is a Parent;
+          (None, None, False) otherwise.
+    """
+    from ggrc.snapshotter import rules as snapshot_rules
+    parent, child = None, None
+    if src["source"]["type"] in snapshot_rules.Types.parents:
+      parent, child = src["source"], src["destination"]
+    elif src["destination"]["type"] in snapshot_rules.Types.parents:
+      parent, child = src["source"], src["destination"]
+
+    is_snapshot = bool(parent) and child["type"] in snapshot_rules.Types.all
+    return parent, child, is_snapshot
+
+  def _get_model_instance(self, src=None, body=None):
+    """For Parent and Snapshottable src and dst, create an empty Snapshot."""
+    _, _, is_snapshot = self._parse_snapshot_data(src)
+
+    if is_snapshot:
+      obj = Snapshot()
+      db.session.add(obj)
+      return obj
+    else:
+      return super(RelationshipResource, self)._get_model_instance(src, body)
+
+  def json_create(self, obj, src):
+    """For Parent and Snapshottable src and dst, fill in the Snapshot obj."""
+    parent, child, is_snapshot = self._parse_snapshot_data(src)
+
+    if is_snapshot:
+      snapshot_data = {
+          "parent": parent,
+          "child_type": child["type"],
+          "child_id": child["id"],
+          "update_revision": "new",
+      }
+      json_builder.create(obj, snapshot_data)
+      obj.modified_by = get_current_user()
+      obj.context = obj.parent.context
+    else:
+      return super(RelationshipResource, self).json_create(obj, src)


### PR DESCRIPTION
The old hack to create Snapshots by POSTing to `/api/relationships` created a Relationship and Snapshot for requests to map Audits to Snapshottables.

The new hack just creates Snapshots on JSON deserialization.