### PR TITLE
GGRC-1368 Fix status filter is not applied on search after opening the mapper

### DIFF
--- a/src/ggrc/assets/javascripts/components/unified-mapper/mapper-toolbar.js
+++ b/src/ggrc/assets/javascripts/components/unified-mapper/mapper-toolbar.js
@@ -13,7 +13,7 @@
     ),
     viewModel: {
       filter: '',
-      statusFilter: null,
+      statusFilter: '',
       dropdown_options: [],
       statuses: [],
       mapper: {},
@@ -26,13 +26,12 @@
         var self = this;
         CMS.Models.DisplayPrefs.getSingleton().then(function (displayPrefs) {
           self.attr('displayPrefs', displayPrefs);
-          self.setStatusFilter();
+          setTimeout(self.setStatusFilter.bind(self));
         });
       },
       onSubmit: function () {
         this.dispatch('submit');
         if (this.attr('showStatusFilter')) {
-          this.attr('mapper.statusFilter', this.attr('statusFilter'));
           this.saveStatusFilter();
         }
       },

--- a/src/ggrc/assets/javascripts/components/unified-mapper/mapper.js
+++ b/src/ggrc/assets/javascripts/components/unified-mapper/mapper.js
@@ -82,9 +82,9 @@
     relevant: [],
     submitCbs: $.Callbacks(),
     afterSearch: false,
-    init: function () {
+    afterShown: function () {
       if (!this.attr('search_only')) {
-        setTimeout(this.onToolbarSubmit.bind(this));
+        this.onToolbarSubmit();
       }
     },
     allowedToCreate: function () {
@@ -271,11 +271,16 @@
         }
       },
       inserted: function () {
+        var self = this;
         this.scope.attr('mapper.selected').replace([]);
         this.scope.attr('mapper.entries').replace([]);
 
         this.setModel();
         this.setBinding();
+
+        setTimeout(function () {
+          self.scope.attr('mapper').afterShown();
+        });
       },
       closeModal: function () {
         this.scope.attr('mapper.is_saving', false);


### PR DESCRIPTION
Steps to reproduce:
1. Select Regulations widget on My work page
1. Click Map on the first tree view
3. In unified mapper set "Active" in dropdown filter> Click Search
3. Close unified mapper then click map again
Actual: "Active" state is displayed in multi select dropdown filter by no applied
Expected: "Active" state is displayed in multi select dropdown filter by should be applied in Unified mapper