### PR TITLE
GGRC-1365 Fix mapper error on “select all” action for new objects

### DIFF
--- a/src/ggrc/assets/javascripts/components/unified-mapper/mapper-results.js
+++ b/src/ggrc/assets/javascripts/components/unified-mapper/mapper-results.js
@@ -339,7 +339,7 @@
           .makeRequest(query)
           .done(function (responseArr) {
             var data = responseArr[0];
-            var filters = responseArr[1][modelKey].ids;
+            var relatedData = responseArr[1];
             var values = data[modelKey][queryType];
             var result = values.map(function (item) {
               return {
@@ -348,9 +348,9 @@
               };
             });
             // Do not perform extra mapping validation in case Assessment generation
-            if (!this.attr('mapper.assessmentGenerator')) {
+            if (!this.attr('mapper.assessmentGenerator') && relatedData) {
               result = result.filter(function (item) {
-                return filters.indexOf(item.id) < 0;
+                return relatedData[modelKey].ids.indexOf(item.id) < 0;
               });
             }
             dfd.resolve(result);


### PR DESCRIPTION
Steps to reproduce:
1. On the Audit page invoke new Assessment modal window
2. Click Map object button
3. Click Select all in Unified mapper
Actual Result: "Uncaught TypeError: Cannot read property 'Snapshot' of undefined" error occurs if Select all in Unified mapper 
Expected Result: no error displayed after click select all in Unified mapper