### PR TITLE
GGRC-1359 Add all user-visible searchable fields to the fulltext index

### DIFF
--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -97,7 +97,7 @@
       }, {
         attr_title: 'Audit Lead',
         attr_name: 'audit_lead',
-        attr_sort_field: 'contact.name|email'
+        attr_sort_field: 'contact'
       }, {
         attr_title: 'Code',
         attr_name: 'slug'

--- a/src/ggrc/assets/javascripts/models/cacheable.js
+++ b/src/ggrc/assets/javascripts/models/cacheable.js
@@ -121,7 +121,7 @@
       {
         attr_title: 'Owner',
         attr_name: 'owner',
-        attr_sort_field: 'contact.name|email',
+        attr_sort_field: 'owners',
         order: 20
       },
       {
@@ -137,13 +137,13 @@
       {
         attr_title: 'Primary Contact',
         attr_name: 'contact',
-        attr_sort_field: 'contact.name|email',
+        attr_sort_field: 'contact',
         order: 50
       },
       {
         attr_title: 'Secondary Contact',
         attr_name: 'secondary_contact',
-        attr_sort_field: 'secondary_contact.name|email',
+        attr_sort_field: 'secondary_contact',
         order: 60
       },
       {

--- a/src/ggrc/assets/javascripts/models/control.js
+++ b/src/ggrc/assets/javascripts/models/control.js
@@ -71,9 +71,9 @@
         {attr_title: 'Assertions', attr_name: 'assertions'},
         {attr_title: 'Categories', attr_name: 'categories'},
         {attr_title: 'Principal Assignee', attr_name: 'principal_assessor',
-          attr_sort_field: 'principal_assessor.name|email'},
+          attr_sort_field: 'principal_assessor'},
         {attr_title: 'Secondary Assignee', attr_name: 'secondary_assessor',
-          attr_sort_field: 'secondary_assessor.name|email'}
+          attr_sort_field: 'secondary_assessor'}
       ]),
       display_attr_names: ['title', 'owner', 'status', 'last_assessment_date'],
       add_item_view: GGRC.mustache_path + '/snapshots/tree_add_item.mustache',

--- a/src/ggrc/converters/query_helper.py
+++ b/src/ggrc/converters/query_helper.py
@@ -100,8 +100,9 @@ class QueryHelper(object):
     self._count = 0
     self.getattr_whitelist = {
         "child_type",
+        "contact",
         "is_current",
-        "owners"
+        "secondary_contact",
     }
 
   def _set_attr_name_map(self):

--- a/src/ggrc/fulltext/__init__.py
+++ b/src/ggrc/fulltext/__init__.py
@@ -41,3 +41,44 @@ def resolve_default_text_indexer():
 def get_indexer(indexer=[]):
   return get_extension_instance(
       'FULLTEXT_INDEXER', resolve_default_text_indexer)
+
+
+def get_indexed_model_names():
+  return {
+      "AccessGroup",
+      "Assessment",
+      "AssessmentTemplate",
+      "Audit",
+      "Clause",
+      "Comment",
+      "Contract",
+      "Control",
+      "Cycle",
+      "CycleTaskEntry",
+      "CycleTaskGroup",
+      "CycleTaskGroupObjectTask",
+      "CustomAttributeValue",  # needed because of indexing logic
+      "DataAsset",
+      "Facility",
+      "Issue",
+      "Market",
+      "Objective",
+      "OrgGroup",
+      "Person",
+      "Policy",
+      "Process",
+      "Product",
+      "Program",
+      "Project",
+      "Regulation",
+      "Risk",
+      "RiskAssessment",
+      "Section",
+      "Standard",
+      "System",
+      "TaskGroup",
+      "TaskGroupTask",
+      "Threat",
+      "Vendor",
+      "Workflow",
+  }

--- a/src/ggrc/fulltext/recordbuilder.py
+++ b/src/ggrc/fulltext/recordbuilder.py
@@ -94,11 +94,6 @@ class RecordBuilder(object):
     )
 
 
-def model_is_indexed(tgt_class):
-  fulltext_attrs = AttributeInfo.gather_attrs(tgt_class, '_fulltext_attrs')
-  return len(fulltext_attrs) > 0
-
-
 def get_record_builder(obj, builders={}):
   # pylint: disable=dangerous-default-value
   # This default value is used for simple memoization and should be refactored

--- a/src/ggrc/fulltext/recordbuilder.py
+++ b/src/ggrc/fulltext/recordbuilder.py
@@ -88,6 +88,8 @@ class RecordBuilder(object):
     Its content is :-separated sorted list of (name or email) of the people in
     list.
     """
+    if not people:
+      return {"__sort__": ""}
     _, names, emails = zip(*(cls.get_person_id_name_email(p) for p in people))
     sort_values = (name or email for (name, email) in zip(names, emails))
     content = ":".join(sorted(sort_values))

--- a/src/ggrc/fulltext/recordbuilder.py
+++ b/src/ggrc/fulltext/recordbuilder.py
@@ -6,7 +6,6 @@
 from collections import defaultdict
 
 import flask
-from sqlalchemy.ext.associationproxy import _AssociationList
 
 from ggrc import db
 import ggrc.models.all_models
@@ -111,7 +110,7 @@ class RecordBuilder(object):
       properties[attribute_name] = {"": obj.attribute_value}
     return properties
 
-  def as_record(self, obj):
+  def as_record(self, obj):  # noqa  # pylint:disable=too-many-branches
     """Generate record representation for an object.
 
     Properties should be returned in the following format:

--- a/src/ggrc/fulltext/sql.py
+++ b/src/ggrc/fulltext/sql.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2017 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
+"""SQL routines for full-text indexing."""
+
 from ggrc import db
 from ggrc.fulltext import Indexer
 from ggrc.utils import benchmark
@@ -11,15 +13,16 @@ class SqlIndexer(Indexer):
     with benchmark("Add fulltext records: create_record -> submit to db"):
       for prop, value in record.properties.items():
         for subproperty, content in value.items():
-          db.session.add(self.record_type(
-              key=record.key,
-              type=record.type,
-              context_id=record.context_id,
-              tags=record.tags,
-              property=prop,
-              subproperty=subproperty,
-              content=content,
-          ))
+          if content:
+            db.session.add(self.record_type(
+                key=record.key,
+                type=record.type,
+                context_id=record.context_id,
+                tags=record.tags,
+                property=prop,
+                subproperty=subproperty,
+                content=content,
+            ))
     if commit:
       db.session.commit()
 

--- a/src/ggrc/models/assessment.py
+++ b/src/ggrc/models/assessment.py
@@ -106,6 +106,11 @@ class Assessment(statusable.Statusable, AuditRelationship,
       PublishOnly('object')
   ]
 
+  _fulltext_attrs = [
+      'design',
+      'operationally',
+  ]
+
   _tracked_attrs = {
       'contact_id',
       'description',

--- a/src/ggrc/models/audit.py
+++ b/src/ggrc/models/audit.py
@@ -65,6 +65,14 @@ class Audit(Snapshotable, clonable.Clonable,
       PublishOnly('audit_objects')
   ]
 
+  _fulltext_attrs = [
+      'report_start_date',
+      'report_end_date',
+      'audit_firm',
+      'status',
+      'gdrive_evidence_folder',
+  ]
+
   _sanitize_html = [
       'gdrive_evidence_folder',
       'description',

--- a/src/ggrc/models/clause.py
+++ b/src/ggrc/models/clause.py
@@ -35,5 +35,9 @@ class Clause(HasObjectState, Hierarchical, CustomAttributable, Personable,
       'na',
       'notes',
   ]
+  _fulltext_attrs = [
+      'na',
+      'notes',
+  ]
   _sanitize_html = ['notes']
   _include_links = []

--- a/src/ggrc/models/control.py
+++ b/src/ggrc/models/control.py
@@ -173,6 +173,21 @@ class Control(HasObjectState, Relatable, CustomAttributable,
       'secondary_assessor',
   ]
 
+  _fulltext_attrs = [
+      'active',
+      'company_control',
+      'directive',
+      'documentation_description',
+      'fraud_related',
+      'key_control',
+      'kind',
+      'means',
+      'verify_frequency',
+      'version',
+      'principal_assessor',
+      'secondary_assessor',
+  ]
+
   _sanitize_html = [
       'documentation_description',
       'version',

--- a/src/ggrc/models/directive.py
+++ b/src/ggrc/models/directive.py
@@ -60,6 +60,17 @@ class Directive(HasObjectState, Timeboxed, BusinessObject, db.Model):
       'version',
   ]
 
+  _fulltext_attrs = [
+      'audit_start_date',
+      'audit_frequency',
+      'audit_duration',
+      'controls',
+      'kind',
+      'organization',
+      'scope',
+      'version',
+  ]
+
   _sanitize_html = [
       'organization',
       'scope',

--- a/src/ggrc/models/mixins/__init__.py
+++ b/src/ggrc/models/mixins/__init__.py
@@ -150,6 +150,12 @@ class ChangeTracked(object):
       'created_at',
       'updated_at',
   ]
+  _fulltext_attrs = [
+      'created_at',
+      'updated_at',
+      'modified_by'
+  ]
+
   _update_attrs = []
 
 
@@ -224,6 +230,10 @@ class Hyperlinked(object):
       "url": "Url",
       "reference_url": "Reference URL",
   }
+  _fulltext_index = [
+      'url',
+      'reference_url',
+  ]
 
 
 class Hierarchical(object):
@@ -244,6 +254,10 @@ class Hierarchical(object):
 
   # REST properties
   _publish_attrs = [
+      'children',
+      'parent',
+  ]
+  _fulltext_attrs = [
       'children',
       'parent',
   ]
@@ -346,6 +360,10 @@ class FinishedDate(object):
       "finished_date": "Finished Date"
   }
 
+  _fulltext_attrs = [
+      'finished_date',
+  ]
+
   @validates('status')
   def validate_status(self, key, value):
     """Update finished_date given the right status change."""
@@ -399,6 +417,10 @@ class VerifiedDate(object):
   _aliases = {
       "verified_date": "Verified Date"
   }
+
+  _fulltext_attrs = [
+      "verified_date",
+  ]
 
   @validates('status')
   def validate_status(self, key, value):
@@ -645,6 +667,7 @@ class WithContact(object):
     )
 
   _publish_attrs = ['contact', 'secondary_contact']
+  _fulltext_attrs = ['contact', 'secondary_contact']
   _aliases = {
       "contact": {
           "display_name": "Primary Contact",

--- a/src/ggrc/models/mixins/assignable.py
+++ b/src/ggrc/models/mixins/assignable.py
@@ -28,13 +28,16 @@ class Assignable(object):
     Returns:
         A set of assignees.
     """
-
-    assignees = [(r.source, tuple(r.attrs["AssigneeType"].split(",")))
-                 for r in self.related_sources
-                 if "AssigneeType" in r.attrs]
-    assignees += [(r.destination, tuple(r.attrs["AssigneeType"].split(",")))
-                  for r in self.related_destinations
-                  if "AssigneeType" in r.attrs]
+    assignees = [
+        (r.source, tuple(set(r.attrs["AssigneeType"].split(","))))
+        for r in self.related_sources
+        if "AssigneeType" in r.attrs
+    ]
+    assignees += [
+        (r.destination, tuple(set(r.attrs["AssigneeType"].split(","))))
+        for r in self.related_destinations
+        if "AssigneeType" in r.attrs
+    ]
     return assignees
 
   def get_assignees(self, filter_=None):

--- a/src/ggrc/models/mixins/assignable.py
+++ b/src/ggrc/models/mixins/assignable.py
@@ -19,6 +19,8 @@ class Assignable(object):
 
   ASSIGNEE_TYPES = set(["Assignee"])
 
+  _fulltext_attrs = ['assignees']
+
   @property
   def assignees(self):
     """Property that returns assignees

--- a/src/ggrc/models/object_owner.py
+++ b/src/ggrc/models/object_owner.py
@@ -83,6 +83,9 @@ class Ownable(object):
       PublishOnly('object_owners'),
   ]
   _include_links = []
+  _fulltext_attrs = [
+      'owners',
+  ]
   _aliases = {
       "owners": {
           "display_name": "Owner",

--- a/src/ggrc/models/option.py
+++ b/src/ggrc/models/option.py
@@ -14,6 +14,9 @@ class Option(Described, Base, db.Model):
   title = deferred(db.Column(db.String), 'Option')
   required = deferred(db.Column(db.Boolean), 'Option')
 
+  def __str__(self):
+    return self.title
+
   @staticmethod
   def _extra_table_args(cls):
     return (

--- a/src/ggrc/models/org_group.py
+++ b/src/ggrc/models/org_group.py
@@ -14,3 +14,6 @@ class OrgGroup(HasObjectState, CustomAttributable,
                Ownable, BusinessObject, db.Model):
   __tablename__ = 'org_groups'
   _aliases = {"url": "Org Group URL"}
+
+  def __str__(self):
+    return self.title

--- a/src/ggrc/models/track_object_state.py
+++ b/src/ggrc/models/track_object_state.py
@@ -18,6 +18,7 @@ class HasObjectState(object):
   _publish_attrs = [
       PublishOnly('os_state'),
   ]
+  _fulltext_attrs = ["os_state"]
   _aliases = {
       "os_state": {
           "display_name": "Review State",

--- a/src/ggrc/snapshotter/indexer.py
+++ b/src/ggrc/snapshotter/indexer.py
@@ -3,10 +3,13 @@
 
 """Manage indexing for snapshotter service"""
 
+import flask
+from sqlalchemy.ext.associationproxy import _AssociationList
 from sqlalchemy.sql.expression import tuple_
 
 from ggrc import db
 from ggrc import models
+from ggrc.models import all_models
 from ggrc.fulltext.mysql import MysqlRecordProperty as Record
 from ggrc.models.reflection import AttributeInfo
 from ggrc.utils import generate_query_chunks
@@ -155,6 +158,32 @@ def insert_records(payload):
   db.session.commit()
 
 
+def get_person_data(rec, person):
+  """Get list of Person properties for fulltext indexing
+  """
+  subprops = {}
+  if hasattr(flask.g, "people_map"):
+    if isinstance(person, dict):
+      person_id = person.get("id")
+    else:
+      person_id = person.id
+    person_name, person_email = flask.g.people_map[person_id]
+  else:
+    if isinstance(person, dict):
+      person_id = person.get("id")
+      person = (db.session.query(all_models.Person).filter_by(id=person_id)
+                .one())
+    person_name, person_email = person.name, person.email
+  subprops["{}-name".format(person_id)] = person_name
+  subprops["{}-email".format(person_id)] = person_email
+  data = []
+  for key, val in subprops.items():
+    newrec = rec.copy()
+    newrec.update({"subproperty": key, "content": val})
+    data += [newrec]
+  return data
+
+
 def reindex_pairs(pairs):
   """Reindex selected snapshots.
 
@@ -209,17 +238,37 @@ def reindex_pairs(pairs):
           "child_id": pair.child.id
       })
 
+      assignees = properties.pop("assignees", None)
+      if assignees:
+        for person, roles in assignees:
+          if person:
+            for role in roles:
+              properties[role] = [person]
+
+      person_properties = {"modified_by", "owners", "principal_assessor",
+                           "secondary_assessor", "contact",
+                           "secondary_contact"}
       for prop, val in properties.items():
         if prop and val:
-          data = {
+          # record stub
+          rec = {
               "key": snapshot_id,
               "type": "Snapshot",
               "context_id": ctx_id,
               "tags": _get_tag(pair),
               "property": prop,
+              "subproperty": "",
               "content": val,
           }
-          search_payload += [data]
+          if prop in person_properties:
+            if not (isinstance(val, list) or
+                    isinstance(val, _AssociationList)):
+              val = [val]
+            for person in val:
+              if person:
+                search_payload += get_person_data(rec, person)
+          else:
+            search_payload += [rec]
 
     delete_records(snapshot_ids)
     insert_records(search_payload)

--- a/src/ggrc/snapshotter/indexer.py
+++ b/src/ggrc/snapshotter/indexer.py
@@ -3,7 +3,6 @@
 
 """Manage indexing for snapshotter service"""
 
-from sqlalchemy.ext.associationproxy import _AssociationList
 from sqlalchemy.sql.expression import tuple_
 
 from ggrc import db
@@ -72,7 +71,6 @@ def _get_model_properties():
         attribute definition attributes.
   """
   # pylint: disable=protected-access
-  from ggrc.models import all_models
   class_properties = dict()
   klass_names = Types.all
 
@@ -182,7 +180,7 @@ def get_person_sort_subprop(rec, people):
   return data
 
 
-def reindex_pairs(pairs):
+def reindex_pairs(pairs):  # noqa  # pylint:disable=too-many-branches
   """Reindex selected snapshots.
 
   Args:
@@ -201,7 +199,7 @@ def reindex_pairs(pairs):
   snapshot_columns, revision_columns = _get_columns()
 
   snapshot_query = snapshot_columns
-  if pairs:
+  if pairs:  # pylint:disable=too-many-nested-blocks
     pairs_filter = tuple_(
         models.Snapshot.parent_type,
         models.Snapshot.parent_id,

--- a/src/ggrc/views/__init__.py
+++ b/src/ggrc/views/__init__.py
@@ -76,6 +76,10 @@ def do_reindex():
 
   indexed_models = get_indexed_model_names()
 
+  people = db.session.query(all_models.Person.id, all_models.Person.name,
+                            all_models.Person.email)
+  g.people_map = {p.id: (p.name, p.email) for p in people}
+
   for model in indexed_models:
     # pylint: disable=protected-access
     model = get_model(model)
@@ -89,6 +93,8 @@ def do_reindex():
       db.session.commit()
 
   reindex_snapshots()
+
+  delattr(g, "people_map")
 
 
 def get_permissions_json():

--- a/src/ggrc/views/__init__.py
+++ b/src/ggrc/views/__init__.py
@@ -22,15 +22,15 @@ from ggrc.builder.json import publish
 from ggrc.builder.json import publish_representation
 from ggrc.converters import get_importables, get_exportables
 from ggrc.extensions import get_extension_modules
-from ggrc.fulltext import get_indexer
+from ggrc.fulltext import get_indexer, get_indexed_model_names
 from ggrc.fulltext.recordbuilder import fts_record_for
-from ggrc.fulltext.recordbuilder import model_is_indexed
 from ggrc.login import get_current_user
 from ggrc.login import login_required
 from ggrc.models import all_models
 from ggrc.models.background_task import create_task
 from ggrc.models.background_task import make_task_response
 from ggrc.models.background_task import queued_task
+from ggrc.models.inflector import get_model
 from ggrc.models.reflection import AttributeInfo
 from ggrc.rbac import permissions
 from ggrc.services.common import as_json
@@ -74,20 +74,11 @@ def do_reindex():
   indexer = get_indexer()
   indexer.delete_all_records(False)
 
-  # Remove model base classes and non searchable objects
-  excluded_models = {
-      all_models.Directive,
-      all_models.Option,
-      all_models.SystemOrProcess,
-      all_models.Role,
-  }
-  indexed_models = {model for model in all_models.all_models
-                    if model_is_indexed(model)}
-
-  indexed_models -= excluded_models
+  indexed_models = get_indexed_model_names()
 
   for model in indexed_models:
     # pylint: disable=protected-access
+    model = get_model(model)
     mapper_class = model._sa_class_manager.mapper.base_mapper.class_
     query = model.query.options(
         db.undefer_group(mapper_class.__name__ + '_complete'),

--- a/src/ggrc_risk_assessments/assets/javascripts/models/risk_assessment.js
+++ b/src/ggrc_risk_assessments/assets/javascripts/models/risk_assessment.js
@@ -39,12 +39,12 @@
         {
           attr_title: 'Risk Manager',
           attr_name: 'ra_manager',
-          attr_sort_field: 'ra_manager.name|email'
+          attr_sort_field: 'ra_manager'
         },
         {
           attr_title: 'Risk Counsel',
           attr_name: 'ra_counsel',
-          attr_sort_field: 'ra_counsel.name|email'
+          attr_sort_field: 'ra_counsel'
         }
       ],
       add_item_view: path + '/tree_add_item.mustache',

--- a/src/ggrc_workflows/assets/javascripts/models/cycle_models.js
+++ b/src/ggrc_workflows/assets/javascripts/models/cycle_models.js
@@ -347,7 +347,7 @@
         {
           attr_title: 'Assignee',
           attr_name: 'assignee',
-          attr_sort_field: 'contact.name|email'
+          attr_sort_field: 'contact'
         },
         {
           attr_title: 'Start Date',

--- a/src/ggrc_workflows/assets/javascripts/models/task_group.js
+++ b/src/ggrc_workflows/assets/javascripts/models/task_group.js
@@ -42,7 +42,7 @@
       mapper_attr_list: [
         {attr_title: 'Title', attr_name: 'title'},
         {attr_title: 'Assignee', attr_name: 'assignee',
-          attr_sort_field: 'contact.name|email'}
+          attr_sort_field: 'contact'}
       ],
       disable_columns_configuration: true
     },
@@ -108,7 +108,7 @@
       mapper_attr_list: [
         {attr_title: 'Title', attr_name: 'title'},
         {attr_title: 'Assignee', attr_name: 'assignee',
-          attr_sort_field: 'contact.name|email'}
+          attr_sort_field: 'contact'}
       ],
       disable_columns_configuration: true
     },

--- a/src/ggrc_workflows/assets/mustache/task_groups/tree_header.mustache
+++ b/src/ggrc_workflows/assets/mustache/task_groups/tree_header.mustache
@@ -18,7 +18,7 @@
       </div>
       <div class="span2">
         <div class="oneline">
-          <span class="widget-col-title" data-field="contact.name|email">
+          <span class="widget-col-title" data-field="contact">
             Assignee
             <i class="fa fa-caret-down"></i>
           </span>

--- a/test/integration/ggrc/services/test_query.py
+++ b/test/integration/ggrc/services/test_query.py
@@ -442,6 +442,7 @@ class TestAdvancedQueryAPI(BaseQueryAPITestCase):
                key=lambda c: person_id_name[c["contact"]["id"]]),
     )
 
+  @unittest.skip("Order by owners with fulltext not implemented.")
   def test_query_order_by_owners(self):
     """Results get sorted by name or email of the (first) owner."""
     # TODO: the test data set lacks objects with several owners

--- a/test/integration/ggrc/services/test_query.py
+++ b/test/integration/ggrc/services/test_query.py
@@ -442,7 +442,6 @@ class TestAdvancedQueryAPI(BaseQueryAPITestCase):
                key=lambda c: person_id_name[c["contact"]["id"]]),
     )
 
-  @unittest.skip("Order by owners with fulltext not implemented.")
   def test_query_order_by_owners(self):
     """Results get sorted by name or email of the (first) owner."""
     # TODO: the test data set lacks objects with several owners

--- a/test/integration/ggrc_workflows/notifications/test_middle_level_one_time_wf.py
+++ b/test/integration/ggrc_workflows/notifications/test_middle_level_one_time_wf.py
@@ -90,10 +90,6 @@ class TestOneTimeWorkflowNotification(TestCase):
       cycle_response, cycle = self.wf_generator.generate_cycle(wf)
       self.wf_generator.activate_workflow(wf)
 
-      db.session.add(self.owner1)
-      db.session.add(self.tgassignee1)
-      db.session.add(self.member1)
-
       common.get_daily_notifications()
 
   def create_test_cases(self):

--- a/test/integration/ggrc_workflows/notifications/test_middle_level_one_time_wf.py
+++ b/test/integration/ggrc_workflows/notifications/test_middle_level_one_time_wf.py
@@ -2,13 +2,13 @@
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
 import textwrap
-from integration.ggrc import TestCase
-from freezegun import freeze_time
 from datetime import date, datetime
+from freezegun import freeze_time
 
 from ggrc import db
 from ggrc.notifications import common
 from ggrc.models import Notification
+from integration.ggrc import TestCase
 from integration.ggrc_workflows.generator import WorkflowsGenerator
 from integration.ggrc.api_helper import Api
 from integration.ggrc.generator import ObjectGenerator

--- a/test/selenium/src/lib/constants/locator.py
+++ b/test/selenium/src/lib/constants/locator.py
@@ -537,7 +537,7 @@ class ObjectWidget(object):
   _HEADER = '.header [class^="span"]'
   HEADER_TITLE = (By.CSS_SELECTOR, _HEADER + ' [data-field="title"]')
   HEADER_OWNER = (
-      By.CSS_SELECTOR, _HEADER + ' [data-field="contact.name|email"]')
+      By.CSS_SELECTOR, _HEADER + ' [data-field="owners"]')
   HEADER_STATE = (By.CSS_SELECTOR, _HEADER + ' [data-field="status"]')
   HEADER_LAST_ASSESSMENT_DATE = (
       By.CSS_SELECTOR, _HEADER + ' [data-field="last_assessment_date"]')


### PR DESCRIPTION
At the moment we can't use fulltext index to search for everything typed into "Filter" field by the user.
We should index every user-searchable field.

UPD (Aleh): every field that has multiple subproperties (any person and any list field) has an additional `__sort__` subproperty in the index; it is used only for sorting by that field.