### PR TITLE
GGRC-1318 Fix detecting changes on Assessments

### DIFF
--- a/src/ggrc/notifications/notification_handlers.py
+++ b/src/ggrc/notifications/notification_handlers.py
@@ -181,8 +181,8 @@ def handle_assignable_modified(obj):
       u"_notifications", u"comments", u"context", u"context_id", u"created_at",
       u"custom_attribute_definitions", u"custom_attribute_values",
       u"_custom_attribute_values", u"finished_date", u"id", u"modified_by",
-      u"modified_by_id", u"object_level_definitions", u"operationally",
-      u"os_state", u"related_destinations", u"related_sources", u"status",
+      u"modified_by_id", u"object_level_definitions", u"os_state",
+      u"related_destinations", u"related_sources", u"status",
       u"task_group_objects", u"updated_at", u"verified_date",
   ))
 

--- a/src/ggrc/notifications/notification_handlers.py
+++ b/src/ggrc/notifications/notification_handlers.py
@@ -349,11 +349,11 @@ def handle_reminder(obj, reminder_type):
 
 
 def handle_comment_created(obj, src):
-  """Add notification etries for new comments.
+  """Add notification entries for new comments.
 
   Args:
     obj (Comment): New comment.
-    src (dict): Dictionary containing the coment post request data.
+    src (dict): Dictionary containing the comment post request data.
   """
   if src.get("send_notification"):
     notif_type = models.NotificationType.query.filter_by(
@@ -361,11 +361,41 @@ def handle_comment_created(obj, src):
     _add_notification(obj, notif_type)
 
 
-def register_handlers():
+def handle_relationship_altered(rel):
+  """Handle creation or deletion of a relationship between two objects.
+
+  Relationships not involving an Assessment are ignored. For others, if a
+  Person or a Document is assigned/attached (or removed from) an Assessment,
+  that is considered an Assessment modification and hence a notification is
+  created (unless the Assessment has not been started yet, of course).
+
+  Args:
+    rel (Relationship): Created (or deleted) relationship instance.
+  """
+  if rel.source.type != u"Assessment" != rel.destination.type:
+    return
+
+  asmt, other = rel.source, rel.destination
+  if asmt.type != u"Assessment":
+    asmt, other = other, asmt
+
+  if other.type not in (u"Document", u"Person"):
+    return
+
+  if asmt.status != Statusable.START_STATE:
+    _add_assessment_updated_notif(asmt)
+
+  # when modified, a done Assessment gets automatically reopened
+  if asmt.status in Statusable.DONE_STATES:
+    _add_state_change_notif(asmt, Transitions.TO_REOPENED)
+
+
+def register_handlers():  # noqa: C901
   """Register listeners for notification handlers."""
 
   # Variables are used as listeners, and arguments are needed for callback
   # functions.
+  #
   # pylint: disable=unused-argument,unused-variable
 
   @Resource.model_deleted.connect_via(models.Request)
@@ -394,3 +424,15 @@ def register_handlers():
   def comment_created_listener(sender, objects=None, sources=None, **kwargs):
     for obj, src in izip(objects, sources):
       handle_comment_created(obj, src)
+
+  @Resource.model_posted.connect_via(models.Relationship)
+  def relationship_created_listener(sender, obj=None, src=None, service=None):
+    handle_relationship_altered(obj)
+
+  @Resource.model_put.connect_via(models.Relationship)
+  def relationship_updated_listener(sender, obj=None, src=None, service=None):
+    handle_relationship_altered(obj)
+
+  @Resource.model_deleted.connect_via(models.Relationship)
+  def relationship_deleted_listener(sender, obj=None, src=None, service=None):
+    handle_relationship_altered(obj)

--- a/test/integration/ggrc/notifications/test_assignable_notifications.py
+++ b/test/integration/ggrc/notifications/test_assignable_notifications.py
@@ -18,9 +18,12 @@ from ggrc.models import CustomAttributeDefinition
 from ggrc.models import CustomAttributeValue
 from ggrc.models import Notification
 from ggrc.models import NotificationType
+from ggrc.models import ObjectDocument
 from ggrc.models import Revision
+from ggrc.models import Relationship
 from integration.ggrc import TestCase
-from integration.ggrc import api_helper
+from integration.ggrc import api_helper, generator
+from integration.ggrc.models import factories
 
 from integration.ggrc.models.factories import \
     CustomAttributeDefinitionFactory as CAD
@@ -35,6 +38,7 @@ class TestAssignableNotification(TestCase):
     self.client.get("/login")
     self._fix_notification_init()
     self.api_helper = api_helper.Api()
+    self.objgen = generator.ObjectGenerator()
 
   def _fix_notification_init(self):
     """Fix Notification object init function.
@@ -279,3 +283,252 @@ class TestAssignableNotification(TestCase):
     self.api_helper.modify_object(asmt5,
                                   {"status": Assessment.FINAL_STATE})
     self.assertEqual(self._get_notifications().count(), 1)
+
+  @patch("ggrc.notifications.common.send_email")
+  def test_changing_assigned_people_triggers_notifications(self, _):
+    """Test that changing Assessment people results in change notification.
+
+    Adding (removing) a person to (from) Assessment should be detected and
+    considered an Assessment change.
+    """
+    self.import_file("assessment_with_templates.csv")
+    asmts = {asmt.slug: asmt for asmt in Assessment.query}
+
+    self.client.get("/_notifications/send_daily_digest")
+    self.assertEqual(self._get_notifications().count(), 0)
+
+    asmt = Assessment.query.get(asmts["A 5"].id)
+
+    # add an Assessor, there should be no notifications because the Assessment
+    # has not been started yet
+    person = factories.PersonFactory()
+    response, relationship = self.objgen.generate_relationship(
+        person, asmt, attrs={"AssigneeType": "Assessor"})
+    self.assertEqual(response.status_code, 201)
+
+    change_notifs = self._get_notifications(notif_type="assessment_updated")
+    self.assertEqual(change_notifs.count(), 0)
+    asmt = Assessment.query.get(asmts["A 5"].id)
+
+    # move Assessment to to "In Progress" state and clear notifications
+    self.api_helper.modify_object(
+        asmt, {"status": Assessment.PROGRESS_STATE})
+
+    self.client.get("/_notifications/send_daily_digest")
+    self.assertEqual(self._get_notifications().count(), 0)
+    asmt = Assessment.query.get(asmts["A 5"].id)
+
+    # assign another Assignee, change notification should be created
+    person2 = factories.PersonFactory()
+    response, relationship2 = self.objgen.generate_relationship(
+        person2, asmt, attrs={"AssigneeType": "Assessor"})
+    self.assertEqual(response.status_code, 201)
+    rel2_id = relationship2.id
+
+    change_notifs = self._get_notifications(notif_type="assessment_updated")
+    self.assertEqual(change_notifs.count(), 1)
+
+    # clear notifications, assign the same person as Verfier, check for
+    # change notification
+    self.client.get("/_notifications/send_daily_digest")
+    self.assertEqual(change_notifs.count(), 0)
+    asmt = Assessment.query.get(asmts["A 5"].id)
+    relationship2 = Relationship.query.get(rel2_id)
+
+    self.api_helper.modify_object(
+        relationship2, {"AssigneeType": "Assessor,Verifier"})
+
+    change_notifs = self._get_notifications(notif_type="assessment_updated")
+    self.assertEqual(change_notifs.count(), 1)
+
+    # clear notifications, delete an Assignee, test for change notification
+    self.client.get("/_notifications/send_daily_digest")
+    self.assertEqual(change_notifs.count(), 0)
+    asmt = Assessment.query.get(asmts["A 5"].id)
+
+    self.api_helper.delete(relationship)
+
+    change_notifs = self._get_notifications(notif_type="assessment_updated")
+    self.assertEqual(change_notifs.count(), 1)
+
+    # clear notifications, delete one of the person's roles, test for
+    # change notification
+    self.client.get("/_notifications/send_daily_digest")
+    self.assertEqual(change_notifs.count(), 0)
+    asmt = Assessment.query.get(asmts["A 5"].id)
+    relationship2 = Relationship.query.get(rel2_id)
+
+    self.api_helper.modify_object(
+        relationship2, {"AssigneeType": "Assessor"})  # not Verifier anymore
+
+    change_notifs = self._get_notifications(notif_type="assessment_updated")
+    self.assertEqual(change_notifs.count(), 1)
+
+    # changing people if completed should result in "reopened" notification
+
+    # TODO: contrary to how relations to Documents behave, assigning a Person
+    # to an Assessment causes the latter to be immediately moved to the
+    # "In Progress" state, making the relationship change handler to think that
+    # the Assessment was modified in the "In Progress" state, resulting in
+    # a missing assessment_reopened notification. We thus skip this check for
+    # the time being.
+
+    # asmt = Assessment.query.get(asmts["A 5"].id)
+    # self.api_helper.modify_object(
+    #     asmt, {"status": Assessment.FINAL_STATE})
+    # self.client.get("/_notifications/send_daily_digest")
+    # self.assertEqual(self._get_notifications().count(), 0)
+    # asmt = Assessment.query.get(asmts["A 5"].id)
+
+    # person = factories.PersonFactory()
+    # response, relationship = self.objgen.generate_relationship(
+    #     person, asmt, attrs={"AssigneeType": "Assessor"})
+    # self.assertEqual(response.status_code, 201)
+
+    # reopened_notifs = self._get_notifications(
+    #     notif_type="assessment_reopened")
+    # self.assertEqual(reopened_notifs.count(), 1)
+
+  @patch("ggrc.notifications.common.send_email")
+  def test_changing_assessment_urls_triggers_notifications(self, _):
+    """Test that changing Assessment URLs results in change notification.
+
+    Adding (removing) a URL to (from) Assessment should be detected and
+    considered an Assessment change.
+    """
+    self.import_file("assessment_with_templates.csv")
+    asmts = {asmt.slug: asmt for asmt in Assessment.query}
+
+    self.client.get("/_notifications/send_daily_digest")
+    self.assertEqual(self._get_notifications().count(), 0)
+
+    asmt = Assessment.query.get(asmts["A 5"].id)
+
+    # add a URL, there should be no notifications because the Assessment
+    # has not been started yet
+    url = factories.DocumentFactory(link="www.foo.com")
+    response, relationship = self.objgen.generate_relationship(url, asmt)
+    self.assertEqual(response.status_code, 201)
+
+    change_notifs = self._get_notifications(notif_type="assessment_updated")
+    self.assertEqual(change_notifs.count(), 0)
+    asmt = Assessment.query.get(asmts["A 5"].id)
+
+    # move Assessment to to "In Progress" state and clear notifications
+    self.api_helper.modify_object(
+        asmt, {"status": Assessment.PROGRESS_STATE})
+
+    self.client.get("/_notifications/send_daily_digest")
+    self.assertEqual(self._get_notifications().count(), 0)
+    asmt = Assessment.query.get(asmts["A 5"].id)
+
+    # add another URL, change notification should be created
+    url2 = factories.DocumentFactory(link="www.bar.com")
+    response, _ = self.objgen.generate_relationship(url2, asmt)
+    self.assertEqual(response.status_code, 201)
+
+    change_notifs = self._get_notifications(notif_type="assessment_updated")
+    self.assertEqual(change_notifs.count(), 1)
+
+    # clear notifications, delete a URL, test for change notification
+    self.client.get("/_notifications/send_daily_digest")
+    self.assertEqual(change_notifs.count(), 0)
+    asmt = Assessment.query.get(asmts["A 5"].id)
+
+    self.api_helper.delete(relationship)
+
+    change_notifs = self._get_notifications(notif_type="assessment_updated")
+    self.assertEqual(change_notifs.count(), 1)
+
+    # changing URLs if completed should result in "reopened" notification
+    asmt = Assessment.query.get(asmts["A 5"].id)
+    self.api_helper.modify_object(
+        asmt, {"status": Assessment.FINAL_STATE})
+    self.client.get("/_notifications/send_daily_digest")
+    self.assertEqual(self._get_notifications().count(), 0)
+    asmt = Assessment.query.get(asmts["A 5"].id)
+
+    url = factories.DocumentFactory(link="www.abc.com")
+    response, relationship = self.objgen.generate_relationship(url, asmt)
+    self.assertEqual(response.status_code, 201)
+
+    reopened_notifs = self._get_notifications(notif_type="assessment_reopened")
+    self.assertEqual(reopened_notifs.count(), 1)
+
+  @patch("ggrc.notifications.common.send_email")
+  def test_changing_assessment_attachment_triggers_notifications(self, _):
+    """Test that changing Assessment attachment results in change notification.
+
+    Adding (removing) an attachment to (from) Assessment should be detected and
+    considered an Assessment change.
+    """
+    self.import_file("assessment_with_templates.csv")
+    asmts = {asmt.slug: asmt for asmt in Assessment.query}
+
+    self.client.get("/_notifications/send_daily_digest")
+    self.assertEqual(self._get_notifications().count(), 0)
+
+    asmt = Assessment.query.get(asmts["A 5"].id)
+
+    # add an attachment, there should be no notifications because the
+    # Assessment has not been started yet
+    pdf_doc = factories.DocumentFactory(title="foo.pdf")
+    data = {
+        "document": {"type": pdf_doc.type, "id": pdf_doc.id},
+        "documentable": {"type": asmt.type, "id": asmt.id}
+    }
+    response, obj_doc = self.objgen.generate_object(ObjectDocument, data=data)
+    self.assertEqual(response.status_code, 201)
+
+    change_notifs = self._get_notifications(notif_type="assessment_updated")
+    self.assertEqual(change_notifs.count(), 0)
+    asmt = Assessment.query.get(asmts["A 5"].id)
+
+    # move Assessment to to "In Progress" state and clear notifications
+    self.api_helper.modify_object(
+        asmt, {"status": Assessment.PROGRESS_STATE})
+
+    self.client.get("/_notifications/send_daily_digest")
+    self.assertEqual(self._get_notifications().count(), 0)
+    asmt = Assessment.query.get(asmts["A 5"].id)
+
+    # attach another document, change notification should be created
+    image = factories.DocumentFactory(link="foobar.png")
+    data = {
+        "document": {"type": image.type, "id": image.id},
+        "documentable": {"type": asmt.type, "id": asmt.id}
+    }
+    response, _ = self.objgen.generate_object(ObjectDocument, data=data)
+    self.assertEqual(response.status_code, 201)
+
+    change_notifs = self._get_notifications(notif_type="assessment_updated")
+    self.assertEqual(change_notifs.count(), 1)
+
+    # clear notifications, remove an attachment, test for change notification
+    self.client.get("/_notifications/send_daily_digest")
+    self.assertEqual(change_notifs.count(), 0)
+    asmt = Assessment.query.get(asmts["A 5"].id)
+
+    self.api_helper.delete(obj_doc)
+
+    change_notifs = self._get_notifications(notif_type="assessment_updated")
+    self.assertEqual(change_notifs.count(), 1)
+
+    # changing attachments completed should result in "reopened" notification
+    asmt = Assessment.query.get(asmts["A 5"].id)
+    self.api_helper.modify_object(
+        asmt, {"status": Assessment.FINAL_STATE})
+    self.client.get("/_notifications/send_daily_digest")
+    self.assertEqual(self._get_notifications().count(), 0)
+    asmt = Assessment.query.get(asmts["A 5"].id)
+
+    file_foo = factories.DocumentFactory(link="foo.txt")
+    data = {
+        "document": {"type": file_foo.type, "id": file_foo.id},
+        "documentable": {"type": asmt.type, "id": asmt.id}
+    }
+    response, _ = self.objgen.generate_object(ObjectDocument, data=data)
+    self.assertEqual(response.status_code, 201)
+
+    reopened_notifs = self._get_notifications(notif_type="assessment_reopened")
+    self.assertEqual(reopened_notifs.count(), 1)


### PR DESCRIPTION
This PR fixes detecting changes to an Assessment in the following cases:

- [x] Changing People assigned to an Assessment (adding/removing user roles),
- [x] Adding/removing Assessment URLs,
- [x] Adding/removing Assessment attachemnts,
- [x] Modifying the `Conclusion: operation` field.

~~Writing integration tests is in progress and will later update the PR with them.~~

---
**Steps to reproduce:**
  1. Create assessment on the audit page
  1. Complete assessment
  1. Do one of the following:
      - Add/Remove Verifier (or Assignee) to assessment
      - Add/remove Assessment URL
      - Add/remove Assessment evidence
      - Modify the  `Conclusion: operation` field (under  the `Conclusions` collapsible section)

**Expected Result:**
Assessment change notification to be added when a change is made to an Assessment
(best to check the daily digest email - `<host>/_notifications/show_daily_digest`, all people assigned to the Assessment should have it)

**Actual Result:**
Assessment change notification is not added.