### PR TITLE
GGRC-1383 Fix audit contexts

### DIFF
--- a/src/ggrc/converters/handlers/handlers.py
+++ b/src/ggrc/converters/handlers/handlers.py
@@ -561,10 +561,10 @@ class ParentColumnHandler(ColumnHandler):
     obj = self.row_converter.obj
     parent = getattr(obj, self.key, None)
     if parent is not None and \
-       hasattr(obj, "context_id") and \
-       hasattr(parent, "context_id") and \
-       parent.context_id is not None:
-      obj.context_id = parent.context_id
+       hasattr(obj, "context") and \
+       hasattr(parent, "context") and \
+       parent.context is not None:
+      obj.context = parent.context
 
   def get_value(self):
     value = getattr(self.row_converter.obj, self.key, self.value)
@@ -574,10 +574,15 @@ class ParentColumnHandler(ColumnHandler):
 
 
 class ProgramColumnHandler(ParentColumnHandler):
+  """Handler for program column on audit imports."""
 
   def __init__(self, row_converter, key, **options):
     self.parent = Program
     super(ProgramColumnHandler, self).__init__(row_converter, key, **options)
+
+  def set_obj_attr(self):
+    if self.row_converter.is_new:
+      super(ProgramColumnHandler, self).set_obj_attr()
 
 
 class SectionDirectiveColumnHandler(MappingColumnHandler):

--- a/src/ggrc/migrations/versions/20170307131717_1a5ec1ed04af_fix_audit_context.py
+++ b/src/ggrc/migrations/versions/20170307131717_1a5ec1ed04af_fix_audit_context.py
@@ -1,0 +1,308 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Fix audit context
+
+Create Date: 2017-03-07 13:17:17.472314
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '1a5ec1ed04af'
+down_revision = '3f615f3b5192'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+
+  # clear bad audit ids, clearing instead of just fixing the bad audit ids will
+  # make it easier to propagate this change to all of its related objects that
+  # also have an invalid context id.
+
+  # Clear audit_
+  sql = """
+    UPDATE audits AS au
+    LEFT JOIN contexts AS c ON
+      au.context_id = c.id
+    SET au.context_id = NULL
+    WHERE c.related_object_type != "Audit"
+  """
+  op.execute(sql)
+
+  # Clear all bad contexts from any audit related object.
+
+  # Clear snapshot_
+  sql = """
+    UPDATE snapshots AS s
+    JOIN audits AS au ON
+      s.parent_id = au.id AND
+      s.parent_type = "Audit"
+    SET s.context_id = NULL
+    WHERE au.context_id IS NULL
+  """
+  op.execute(sql)
+
+  # Clear issue_
+  sql = """
+  UPDATE issues AS i
+    JOIN relationships AS r ON r.source_id = i.id
+     AND r.source_type = 'Issue' AND r.destination_type = 'Audit'
+    JOIN audits AS au ON r.destination_id = au.id
+     SET i.context_id = NULL
+   WHERE au.context_id is NULL;
+  """
+  op.execute(sql)
+
+  sql = """
+  UPDATE issues AS i
+    JOIN relationships AS r ON r.destination_id = i.id
+     AND r.destination_type = 'Issue' AND r.source_type = 'Audit'
+    JOIN audits AS au ON r.source_id = au.id
+     SET i.context_id = NULL
+   WHERE au.context_id is NULL
+  """
+  op.execute(sql)
+
+  # Clear assessment_
+  sql = """
+  UPDATE assessments AS a
+    JOIN relationships AS r ON r.source_id = a.id
+     AND r.source_type = 'Assessment' AND r.destination_type = 'Audit'
+    JOIN audits AS au ON r.destination_id = au.id
+     SET a.context_id = NULL
+   WHERE au.context_id is NULL;
+  """
+  op.execute(sql)
+
+  sql = """
+  UPDATE assessments AS a
+    JOIN relationships AS r ON r.destination_id = a.id
+     AND r.destination_type = 'Assessment' AND r.source_type = 'Audit'
+    JOIN audits AS au ON r.source_id = au.id
+     SET a.context_id = NULL
+   WHERE au.context_id is NULL
+  """
+  op.execute(sql)
+
+  # Clear object_document
+  sql = """
+  UPDATE object_documents AS od
+    JOIN assessments AS a ON od.documentable_id = a.id
+     SET od.context_id = NULL
+   WHERE documentable_type = 'Assessment' AND a.context_id IS NULL;
+  """
+  op.execute(sql)
+
+  # Clear document_
+  sql = """
+  UPDATE documents AS d
+    JOIN object_documents AS od ON od.document_id = d.id
+     AND od.documentable_type = 'Assessment'
+     SET d.context_id = NULL
+   WHERE od.context_id IS NULL
+  """
+  op.execute(sql)
+
+  sql = """
+  UPDATE documents AS d
+    JOIN relationships AS r ON
+        r.source_id = d.id AND
+        r.source_type = "Document" AND
+        r.destination_type = "Assessment"
+    JOIN assessments AS a ON
+        r.destination_id = a.id
+     SET d.context_id = NULL
+   WHERE a.context_id IS NULL
+  """
+  op.execute(sql)
+
+  sql = """
+  UPDATE documents AS d
+    JOIN relationships AS r ON
+        r.destination_id = d.id AND
+        r.destination_type = "Document" AND
+        r.source_type = "Assessment"
+    JOIN assessments AS a ON
+        r.source_id = a.id
+     SET d.context_id = NULL
+   WHERE a.context_id IS NULL
+  """
+  op.execute(sql)
+
+  # Clear assessment_template
+  sql = """
+  UPDATE assessment_templates AS at
+    JOIN relationships AS r ON
+        r.source_id = at.id AND
+        r.source_type = "AssessmentTemplate" AND
+        r.destination_type = "Audit"
+    JOIN audits AS au ON
+        r.destination_id = au.id
+     SET at.context_id = NULL
+   WHERE au.context_id IS NULL
+  """
+  op.execute(sql)
+
+  sql = """
+  UPDATE assessment_templates AS at
+    JOIN relationships AS r ON
+        r.destination_id = at.id AND
+        r.destination_type = "AssessmentTemplate" AND
+        r.source_type = "Audit"
+    JOIN audits AS au ON
+        r.source_id = au.id
+     SET at.context_id = NULL
+   WHERE au.context_id IS NULL
+  """
+  op.execute(sql)
+
+  #############################################################################
+  # Now we will apply the audit context fix and propagate the change to all of
+  # its related objects
+  #############################################################################
+
+  # Set audit_
+  sql = """
+    UPDATE audits AS au
+    JOIN contexts AS c ON
+      au.id = c.related_object_id AND
+      c.related_object_type = "Audit"
+    SET au.context_id = c.id
+    where au.context_id is NULL
+  """
+  op.execute(sql)
+
+  # Set snapshot_
+  sql = """
+    UPDATE snapshots AS s
+      JOIN audits AS au ON
+           s.parent_id = au.id AND
+           s.parent_type = "Audit"
+       SET s.context_id = au.context_id
+     WHERE s.context_id IS NULL
+  """
+  op.execute(sql)
+
+  # Set issue_
+  sql = """
+  UPDATE issues AS i
+    JOIN relationships AS r ON r.source_id = i.id
+     AND r.source_type = 'Issue' AND r.destination_type = 'Audit'
+    JOIN audits AS au ON r.destination_id = au.id
+     SET i.context_id = au.context_id
+   WHERE i.context_id is NULL;
+  """
+  op.execute(sql)
+
+  sql = """
+  UPDATE issues AS i
+    JOIN relationships AS r ON r.destination_id = i.id
+     AND r.destination_type = 'Issue' AND r.source_type = 'Audit'
+    JOIN audits AS au ON r.source_id = au.id
+     SET i.context_id = au.context_id
+   WHERE i.context_id is NULL;
+  """
+  op.execute(sql)
+
+  # Set assessment_
+  sql = """
+  UPDATE assessments AS a
+    JOIN relationships AS r ON r.source_id = a.id
+     AND r.source_type = 'Assessment' AND r.destination_type = 'Audit'
+    JOIN audits AS au ON r.destination_id = au.id
+     SET a.context_id = au.context_id
+   WHERE a.context_id is NULL;
+  """
+  op.execute(sql)
+
+  sql = """
+  UPDATE assessments AS a
+    JOIN relationships AS r ON r.destination_id = a.id
+     AND r.destination_type = 'Assessment' AND r.source_type = 'Audit'
+    JOIN audits AS au ON r.source_id = au.id
+     SET a.context_id = au.context_id
+   WHERE a.context_id is NULL;
+  """
+  op.execute(sql)
+
+  # Set object_document
+  sql = """
+  UPDATE object_documents AS od
+    JOIN assessments AS a ON od.documentable_id = a.id
+     SET od.context_id = a.context_id
+   WHERE documentable_type = 'Assessment' AND od.context_id IS NULL;
+  """
+  op.execute(sql)
+
+  # Set document_
+  sql = """
+  UPDATE documents AS d
+    JOIN object_documents AS od ON od.document_id = d.id
+     AND od.documentable_type = 'Assessment'
+     SET d.context_id = od.context_id
+   WHERE d.context_id IS NULL
+  """
+  op.execute(sql)
+
+  sql = """
+  UPDATE documents AS d
+    JOIN relationships AS r ON
+        r.source_id = d.id AND
+        r.source_type = "Document" AND
+        r.destination_type = "Assessment"
+    JOIN assessments AS a ON
+        r.destination_id = a.id
+     SET d.context_id = a.context_id
+   WHERE d.context_id IS NULL
+  """
+  op.execute(sql)
+
+  sql = """
+  UPDATE documents AS d
+    JOIN relationships AS r ON
+        r.destination_id = d.id AND
+        r.destination_type = "Document" AND
+        r.source_type = "Assessment"
+    JOIN assessments AS a ON
+        r.source_id = a.id
+     SET d.context_id = a.context_id
+   WHERE d.context_id IS NULL
+  """
+  op.execute(sql)
+
+  # Set assessment_template
+  sql = """
+  UPDATE assessment_templates AS at
+    JOIN relationships AS r ON
+        r.source_id = at.id AND
+        r.source_type = "AssessmentTemplate" AND
+        r.destination_type = "Audit"
+    JOIN audits AS au ON
+        r.destination_id = au.id
+     SET at.context_id = au.context_id
+   WHERE at.context_id IS NULL
+  """
+  op.execute(sql)
+
+  sql = """
+  UPDATE assessment_templates AS at
+    JOIN relationships AS r ON
+        r.destination_id = at.id AND
+        r.destination_type = "AssessmentTemplate" AND
+        r.source_type = "Audit"
+    JOIN audits AS au ON
+        r.source_id = au.id
+     SET at.context_id = au.context_id
+   WHERE at.context_id IS NULL
+  """
+  op.execute(sql)
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  pass

--- a/src/ggrc/migrations/versions/20170307131717_1a5ec1ed04af_fix_audit_context.py
+++ b/src/ggrc/migrations/versions/20170307131717_1a5ec1ed04af_fix_audit_context.py
@@ -19,6 +19,7 @@ down_revision = '3f615f3b5192'
 
 def upgrade():
   """Upgrade database schema and/or data, creating a new revision."""
+  # pylint: disable=too-many-statements
 
   # clear bad audit ids, clearing instead of just fixing the bad audit ids will
   # make it easier to propagate this change to all of its related objects that
@@ -95,6 +96,14 @@ def upgrade():
     JOIN assessments AS a ON od.documentable_id = a.id
      SET od.context_id = NULL
    WHERE documentable_type = 'Assessment' AND a.context_id IS NULL;
+  """
+  op.execute(sql)
+
+  sql = """
+  UPDATE object_documents AS od
+    JOIN issues AS i ON od.documentable_id = i.id
+     SET od.context_id = NULL
+   WHERE documentable_type = 'Issue' AND i.context_id IS NULL;
   """
   op.execute(sql)
 
@@ -236,6 +245,14 @@ def upgrade():
     JOIN assessments AS a ON od.documentable_id = a.id
      SET od.context_id = a.context_id
    WHERE documentable_type = 'Assessment' AND od.context_id IS NULL;
+  """
+  op.execute(sql)
+
+  sql = """
+  UPDATE object_documents AS od
+    JOIN issues AS i ON od.documentable_id = i.id
+     SET od.context_id = i.context_id
+   WHERE documentable_type = 'Issue' AND od.context_id IS NULL;
   """
   op.execute(sql)
 

--- a/src/ggrc/migrations/versions/20170307131717_1a5ec1ed04af_fix_audit_context.py
+++ b/src/ggrc/migrations/versions/20170307131717_1a5ec1ed04af_fix_audit_context.py
@@ -111,7 +111,7 @@ def upgrade():
   sql = """
   UPDATE documents AS d
     JOIN object_documents AS od ON od.document_id = d.id
-     AND od.documentable_type = 'Assessment'
+     AND od.documentable_type in ("Assessment", "Issue")
      SET d.context_id = NULL
    WHERE od.context_id IS NULL
   """
@@ -260,7 +260,7 @@ def upgrade():
   sql = """
   UPDATE documents AS d
     JOIN object_documents AS od ON od.document_id = d.id
-     AND od.documentable_type = 'Assessment'
+     AND od.documentable_type in ("Assessment", "Issue")
      SET d.context_id = od.context_id
    WHERE d.context_id IS NULL
   """

--- a/src/ggrc_basic_permissions/migrations/versions/20170311142655_3ab8b37b04_clear_user_roles_with_invalid_context.py
+++ b/src/ggrc_basic_permissions/migrations/versions/20170311142655_3ab8b37b04_clear_user_roles_with_invalid_context.py
@@ -1,0 +1,42 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Clear user roles with invalid context
+
+Create Date: 2017-03-11 14:26:55.133169
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '3ab8b37b04'
+down_revision = '53831d153d8e'
+
+
+def upgrade():
+  """Delete audit user roles from bad audits.
+
+  This will remove all auditors from audits that had the program context
+  instead of their own context. In that case there is no way of knowing t
+  which audit the any given auditor belonged to in the first place, so from
+  security standpoint it is safer to remove those roles and manually add them
+  back if needed.
+  """
+  sql = """
+  DELETE user_roles
+  FROM user_roles
+  JOIN roles as r on user_roles.role_id = r.id
+  JOIN contexts as c on user_roles.context_id = c.id
+  WHERE
+    r.name = "Auditor" AND
+    c.related_object_type = "Program"
+  """
+  op.execute(sql)
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""

--- a/src/ggrc_gdrive_integration/migrations/versions/20170311201102_5405cc1ae721_fix_audit_context_on_folders.py
+++ b/src/ggrc_gdrive_integration/migrations/versions/20170311201102_5405cc1ae721_fix_audit_context_on_folders.py
@@ -1,0 +1,36 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Fix audit context on folders
+
+Create Date: 2017-03-11 20:11:02.652252
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '5405cc1ae721'
+down_revision = '395186a2d8'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+
+  # Clear object_folder
+  sql = """
+    UPDATE object_folders AS of
+    JOIN audits AS au ON
+      of.folderable_id = au.id AND
+      of.folderable_type = "Audit"
+    SET of.context_id = au.context_id
+  """
+  op.execute(sql)
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  pass


### PR DESCRIPTION
When importing an audit, it will get the program context_id instead of it's own context_id. This Id then propagates through to any audit related object and thus we must fix that.

To verify the RBAC bug, we can import an audit, and then any auditor will get edit access to the parent program (which should not happen)

Objects that still have program context:

- [x] Snapshots
- [x] relationships
- [x] documents (urls mapped via relationships tabel)
- [x] user_roles with for auditor role
- [x] assessment templates