### PR TITLE
GGRC-1304 Verifier should default to auditor

### DIFF
--- a/src/ggrc/assets/javascripts/models/assessment.js
+++ b/src/ggrc/assets/javascripts/models/assessment.js
@@ -348,6 +348,7 @@
       var currentUser = CMS.Models.get_instance('Person',
         GGRC.current_user.id, GGRC.current_user);
       var auditLead;
+      var self = this;
 
       if (pageInstance && (!this.audit || !this.audit.id || !this.audit.type)) {
         if (pageInstance.type === 'Audit') {
@@ -372,6 +373,12 @@
           markForAddition(this, auditLead, 'Assessor');
           markForAddition(this, currentUser, 'Creator');
         }
+
+        this.audit.findAuditors().then(function (list) {
+          list.forEach(function (item) {
+            markForAddition(self, item.person, 'Verifier');
+          });
+        });
       } else {
         markForAddition(this, currentUser, 'Creator');
       }

--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -336,8 +336,8 @@
       test_plan_procedure: false,
       template_object_type: 'Control',
       default_people: {
-        assessors: 'Object Owners',
-        verifiers: 'Object Owners'
+        assessors: 'Audit Lead',
+        verifiers: 'Auditors'
       },
       // the custom lists of assessor / verifier IDs if "other" is selected for
       // the corresponding default_people setting


### PR DESCRIPTION
_Steps to reproduce:_ 
1. Create a program
 2. Create an audit and grand Auditor to audit (e.g. "user1")
 3. Go to audit page 
4. Invoke New assessment modal window: "user1" should be displayed as verifier 

_Expected Result_: If user is added to Audit as Auditor such user should be displayed as verifier in New Assessment modal window

_Clarified and confirmed questions by Prasanna_: 
1. If added two auditors to audit, two Verifiers should be shown in New Assessment modal. 
2. If a user as Auditor has been deleted from Audit such user should not be deleted as Verifier from created assessment. If a user as Auditor has been added to Audit such user should not be added as Verifier to created assessment. This is a one time behavior. 
3. In New Assessment template modal window make default values for the following fields: Default Assignees - "Audit Lead", Default Verifier - "Auditors". 
4. If a user imports csv file with filled Assignee, Creator, Auditor, so Verifier should not be taken by default as Auditor.