### PR TITLE
GGRC-1405 Allow direct filter by id (which is not indexed)

### DIFF
--- a/src/ggrc/converters/query_helper.py
+++ b/src/ggrc/converters/query_helper.py
@@ -100,6 +100,7 @@ class QueryHelper(object):
     self._count = 0
     self.getattr_whitelist = {
         "child_type",
+        "id",
         "is_current",
     }
 

--- a/src/ggrc/converters/query_helper.py
+++ b/src/ggrc/converters/query_helper.py
@@ -102,6 +102,7 @@ class QueryHelper(object):
         "child_type",
         "id",
         "is_current",
+        "program",
     }
 
   def _set_attr_name_map(self):

--- a/test/selenium/src/tests/test_audit_page.py
+++ b/test/selenium/src/tests/test_audit_page.py
@@ -138,7 +138,6 @@ class TestAuditPage(base.Test):
         messages.ERR_MSG_FORMAT.format([expected_control], actual_controls))
 
   @pytest.mark.smoke_tests
-  @pytest.mark.skipif(True, reason="Failed due JS error in app")
   def test_update_snapshotable_ver_of_control(
       self, new_control_rest, new_program_rest, map_control_to_program_rest,
       new_audit_rest, update_control_rest, selenium


### PR DESCRIPTION
Steps to reproduce:
1. Create a Program, map a Control to it.
2. Create an Audit in this Program.
3. Change the base Control.
4. Go to the Control's Snapshot, click "Compare to the latest version".

Expected result: Snapshot comparison window is displayed.
Actual result: The backend doesn't retrieve Revisions as the Query filters them by id (`id = one_id OR id = another_id`).

`critical` as it blocks the following PRs: #5330 #5318 