### PR TITLE
GGRC-715 Incorrect message is displayed if Assessment moves from Complete status to In progress

### DIFF
--- a/src/ggrc/assets/javascripts/components/quick_form/quick_add.js
+++ b/src/ggrc/assets/javascripts/components/quick_form/quick_add.js
@@ -93,6 +93,10 @@
         var created_dfd;
         var verify_dfd = $.Deferred();
         scope.attr('disabled', true);
+        scope.attr('modal_description',
+          this.element.context.attributes.modal_description.value);
+        scope.attr('verify_event',
+          !!this.element.context.attributes.verify_event);
 
         if (scope.attr("verify_event")) {
           GGRC.Controllers.Modals.confirm({
@@ -100,7 +104,7 @@
             modal_confirm: scope.attr("modal_button"),
             modal_title: scope.attr("modal_title"),
             button_view: GGRC.mustache_path + "/quick_form/confirm_buttons.mustache"
-          }, verify_dfd.resolve);
+          }, verify_dfd.resolve, verify_dfd.reject);
         } else {
           verify_dfd.resolve();
         }
@@ -187,7 +191,10 @@
           .always(function () {
             scope.attr('disabled', false);
           });
-        }.bind(this));
+        }.bind(this))
+        .fail(function () {
+          scope.attr('disabled', false);
+        });
       },
       // this works like autocomplete_select on all modal forms and
       //  descendant class objects.

--- a/src/ggrc/assets/javascripts/components/quick_form/tests/quick_add_spec.js
+++ b/src/ggrc/assets/javascripts/components/quick_form/tests/quick_add_spec.js
@@ -1,0 +1,83 @@
+/*!
+  Copyright (C) 2017 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+describe('GGRC.Components.quickAdd', function () {
+  'use strict';
+  var Component;
+  var events;
+  var scope;
+
+  beforeAll(function () {
+    Component = GGRC.Components.get('quickAdd');
+    events = Component.prototype.events;
+  });
+
+  describe('"a[data-toggle=submit]:not(.disabled):not([disabled])' +
+  ' click" event', function () {
+    var handler;
+    var element;
+    var expectedParam = {
+      modal_description: 'newDescription',
+      modal_confirm: 'button',
+      modal_title: 'title',
+      button_view: '/static/mustache/quick_form/confirm_buttons.mustache'
+    };
+    var verifyDfd;
+
+    beforeEach(function () {
+      handler =
+        events['a[data-toggle=submit]:not(.disabled):not([disabled]) click'];
+      scope = new can.Map({
+        modal_description: 'oldDescription',
+        verify_event: false,
+        modal_title: 'title',
+        modal_button: 'button'
+      });
+      element = {
+        context: {
+          attributes: {
+            modal_description: {value: 'newDescription'},
+            verify_event: true
+          }
+        }
+      };
+      verifyDfd = $.Deferred();
+      spyOn($, 'Deferred')
+        .and.returnValue(verifyDfd);
+      spyOn(verifyDfd, 'resolve');
+    });
+
+    it('calls confirm panel if verify_event is true', function () {
+      spyOn(GGRC.Controllers.Modals, 'confirm');
+      handler.call({
+        scope: scope,
+        element: element
+      });
+      expect(GGRC.Controllers.Modals.confirm)
+        .toHaveBeenCalledWith(expectedParam,
+          verifyDfd.resolve, verifyDfd.reject);
+    });
+    it('does not call confirm panel if verify_event is false', function () {
+      spyOn(GGRC.Controllers.Modals, 'confirm');
+      element.context.attributes.verify_event = false;
+      handler.call({
+        scope: scope,
+        element: element
+      });
+      expect(GGRC.Controllers.Modals.confirm)
+        .not.toHaveBeenCalled();
+    });
+    it('sets scope.disabled to false after closing confirm panel',
+      function () {
+        spyOn(GGRC.Controllers.Modals, 'confirm')
+          .and.returnValue(verifyDfd.reject());
+        handler.call({
+          scope: scope,
+          element: element
+        });
+        expect(scope.attr('disabled')).toEqual(false);
+      });
+  });
+});

--- a/src/ggrc/assets/mustache/components/assessment/urls-list.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/urls-list.mustache
@@ -18,8 +18,8 @@
       join_model="Relationship"
       quick_create="create_url"
       {{#if_in instance.status 'Completed,Verified,Ready for Review'}}verify_event="true"{{/if_in}}
-      modal_description='You are about to move request from "{{instance.status}}" to "In Progress" - are you sure about that?'
-      modal_title='Confirm moving Request to "In Progress"'
+      modal_description='You are about to move assessment from "{{instance.status}}" to "In Progress" - are you sure about that?'
+      modal_title='Confirm moving Assessment to "In Progress"'
       modal_button='Confirm'
     >
       {{#prune_context}}


### PR DESCRIPTION
Precondition:
Created program, audit
Steps to reproduce:
1. Go to audit page
2. Create assessment
3. Fill mandatory CA if any-> Click complete button
4. Add a Verifier
5. Click Complete and Verify button
6. Add url: confirm incorrect massage is displayed

Actual Result: Incorrect message is displayed if Assessment moves from Complete status to In progress
Expected Result: The following message should be shown: e.g. "You are about to move assessment from "Completed" to "In Progress" - are you sure about that?"