### PR TITLE
GGRC-1220 Assessment's Info pane: link in Control's pop up doesn't work

### DIFF
--- a/src/ggrc/assets/javascripts/components/object-list-item/detailed-business-object-list-item.js
+++ b/src/ggrc/assets/javascripts/components/object-list-item/detailed-business-object-list-item.js
@@ -32,7 +32,8 @@
         },
         objectLink: {
           get: function () {
-            return this.attr('itemData.viewLink');
+            return this.attr('itemData.viewLink') ||
+              this.buildObjectLink(this.attr('instance'));
           }
         },
         objectTitle: {
@@ -43,6 +44,15 @@
               this.attr('itemData.email') || false;
           }
         }
+      },
+      buildObjectLink: function (instance) {
+        var model = instance.child_type ?
+          CMS.Models[instance.child_type] :
+          CMS.Models[instance.type];
+
+        var type = model.root_collection;
+        var link = '/' + type + '/' + instance.child_id || instance.id;
+        return link;
       }
     }
   });

--- a/src/ggrc/assets/javascripts/components/object-list-item/detailed-business-object-list-item.js
+++ b/src/ggrc/assets/javascripts/components/object-list-item/detailed-business-object-list-item.js
@@ -12,7 +12,7 @@
   /**
    * Assessment specific mapped objects popover view component
    */
-  can.Component.extend({
+  GGRC.Components('detailedBusinessObjectListItem', {
     tag: tag,
     template: tpl,
     viewModel: {
@@ -32,8 +32,9 @@
         },
         objectLink: {
           get: function () {
-            return this.attr('itemData.viewLink') ||
-              this.buildObjectLink(this.attr('instance'));
+            return this.attr('isSnapshot') ?
+              GGRC.Utils.Snapshots.getParentUrl(this.attr('instance')) :
+              this.attr('itemData.viewLink');
           }
         },
         objectTitle: {
@@ -44,15 +45,6 @@
               this.attr('itemData.email') || false;
           }
         }
-      },
-      buildObjectLink: function (instance) {
-        var model = instance.child_type ?
-          CMS.Models[instance.child_type] :
-          CMS.Models[instance.type];
-
-        var type = model.root_collection;
-        var link = '/' + type + '/' + instance.child_id || instance.id;
-        return link;
       }
     }
   });

--- a/src/ggrc/assets/javascripts/components/tests/detailed_business_object_list_item_spec.js
+++ b/src/ggrc/assets/javascripts/components/tests/detailed_business_object_list_item_spec.js
@@ -1,0 +1,72 @@
+/*!
+ Copyright (C) 2017 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+describe('GGRC.Components.detailedBusinessObjectListItem', function () {
+  'use strict';
+
+  var snapshotParentTitle = 'Control title #1';
+  var snapshotParentUrl = '/controls/55';
+  var vendorObjectTitle = 'Vendor title 123';
+  var vendorObjectLink = '/vendors/33';
+
+  var snapshotObject = {
+    selfLink: '/api/snapshots/123',
+    viewLink: '/snapshots/123',
+    type: 'Snapshot',
+    child_id: 55,
+    child_type: 'Control',
+    revision: {
+      content: {
+        title: snapshotParentTitle
+      }
+    }
+  };
+
+  var vendorObject = {
+    selfLink: '/api/vendors/33',
+    viewLink: vendorObjectLink,
+    type: 'Vendor',
+    title: vendorObjectTitle,
+    id: 33
+  };
+
+  describe('objectLink property', function () {
+    var viewModel;
+
+    beforeEach(function () {
+      viewModel = GGRC.Components
+        .getViewModel('detailedBusinessObjectListItem');
+    });
+
+    it('check objectLink of Vendor object', function () {
+      viewModel.attr('instance', vendorObject);
+      expect(viewModel.attr('objectLink')).toEqual(vendorObjectLink);
+    });
+
+    it('check objectLink of Snapshot object', function () {
+      viewModel.attr('instance', snapshotObject);
+      expect(viewModel.attr('objectLink')).toEqual(snapshotParentUrl);
+    });
+  });
+
+  describe('objectTitle property', function () {
+    var viewModel;
+
+    beforeEach(function () {
+      viewModel = GGRC.Components
+        .getViewModel('detailedBusinessObjectListItem');
+    });
+
+    it('check objectTitle of Vendor object', function () {
+      viewModel.attr('instance', vendorObject);
+      expect(viewModel.attr('objectTitle')).toEqual(vendorObjectTitle);
+    });
+
+    it('check objectTitle of Snapshot object', function () {
+      viewModel.attr('instance', snapshotObject);
+      expect(viewModel.attr('objectTitle')).toEqual(snapshotParentTitle);
+    });
+  });
+});

--- a/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
+++ b/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
@@ -1077,6 +1077,19 @@
     }
 
     /**
+     * Build url for snapshot's parent
+     * @param {Object} instance - Snapshot instance
+     * @return {String} Url
+     */
+    function getParentUrl(instance) {
+      var model = CMS.Models[instance.child_type];
+      var plural = model.table_plural;
+      var link = '/' + plural + '/' + instance.child_id;
+
+      return link;
+    }
+
+    /**
      * Convert array of snapshots to array of object
      * @param {Object} values - array of snapshots
      * @return {Object} The array of objects
@@ -1162,7 +1175,8 @@
       transformQuery: transformQuery,
       setAttrs: setAttrs,
       getSnapshotItemQuery: getSnapshotItemQuery,
-      isSnapshotType: isSnapshotType
+      isSnapshotType: isSnapshotType,
+      getParentUrl: getParentUrl
     };
   })();
 })(jQuery, window.GGRC = window.GGRC || {}, window.moment, window.Permission);


### PR DESCRIPTION
**Precondition**: 
created program, control, audit 

**Steps to reproduce** :
1. Generate assessment based on control on the audit page 
2. Navigate to assessment's Info pane and click on control mapped to assessment 
3. Click on Control's link: confirm the link doesn't redirect to original control 

_Actual Result_: Assessment's Info pane: link in Control's pop up doesn't work
_Expected Result_: Link in Control's pop up should redirect to original control page

![1220](https://cloud.githubusercontent.com/assets/4204416/23847701/b588dae4-07e4-11e7-9f76-0b5a5cf67748.png)