### PR TITLE
GGRC-1297 Default State filters for assessments

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/tree/tree-view.js
+++ b/src/ggrc/assets/javascripts/controllers/tree/tree-view.js
@@ -1148,8 +1148,8 @@
       savedStateList = this.display_prefs.getTreeViewStates(modelName);
 
       if (savedStateList.length === 0 &&
-        this.options.model.model_singular === 'Assessment') {
-        // default states for "Assessment" widget
+          GGRC.Utils.CurrentPage.isMyAssessments()) {
+        // default states for "My Assessments" page
         this.options.attr('selectStateList',
           ['"Not Started"', '"In Progress"']);
       } else {

--- a/src/ggrc/assets/javascripts/controllers/tree/tree-view.js
+++ b/src/ggrc/assets/javascripts/controllers/tree/tree-view.js
@@ -401,8 +401,9 @@
                     return state.replace(/"/g, '');
                   });
 
+                var checkAll = unwrappedStates.length === 0;
                 self.options.attr('filter_states').forEach(function (item) {
-                  if (unwrappedStates.indexOf(item.value) > -1) {
+                  if (checkAll || unwrappedStates.indexOf(item.value) > -1) {
                     item.attr('checked', true);
                   }
                 });
@@ -1145,7 +1146,15 @@
       // Get the status list from local storage
       var savedStateList;
       savedStateList = this.display_prefs.getTreeViewStates(modelName);
-      this.options.attr('selectStateList', savedStateList);
+
+      if (savedStateList.length === 0 &&
+        this.options.model.model_singular === 'Assessment') {
+        // default states for "Assessment" widget
+        this.options.attr('selectStateList',
+          ['"Not Started"', '"In Progress"']);
+      } else {
+        this.options.attr('selectStateList', savedStateList);
+      }
     },
     saveTreeStates: function (selectedStates) {
       var stateToSave = [];

--- a/src/ggrc/assets/javascripts/controllers/tree/tree-view.js
+++ b/src/ggrc/assets/javascripts/controllers/tree/tree-view.js
@@ -1147,14 +1147,12 @@
       var savedStateList;
       savedStateList = this.display_prefs.getTreeViewStates(modelName);
 
-      if (savedStateList.length === 0 &&
-          GGRC.Utils.CurrentPage.isMyAssessments()) {
-        // default states for "My Assessments" page
-        this.options.attr('selectStateList',
-          ['"Not Started"', '"In Progress"']);
-      } else {
-        this.options.attr('selectStateList', savedStateList);
+      if (savedStateList.length === 0) {
+        savedStateList = GGRC.Utils
+          .State.getDefaultStatesForModel(this.options.model.shortName);
       }
+
+      this.options.attr('selectStateList', savedStateList);
     },
     saveTreeStates: function (selectedStates) {
       var stateToSave = [];

--- a/src/ggrc/assets/javascripts/plugins/utils/state-utils.js
+++ b/src/ggrc/assets/javascripts/plugins/utils/state-utils.js
@@ -114,11 +114,27 @@
       return filterString;
     }
 
+    /**
+     * Get default states for model.
+     * @param {String} model - The model name
+     * @return {Array} List of default states for model
+     */
+    function getDefaultStatesForModel(model) {
+      var states = [];
+
+      if (GGRC.Utils.CurrentPage.isMyAssessments()) {
+        states = ['"Not Started"', '"In Progress"'];
+      }
+
+      return states;
+    }
+
     return {
       hasState: hasState,
       hasFilter: hasFilter,
       statusFilter: statusFilter,
-      getStatesForModel: getStatesForModel
+      getStatesForModel: getStatesForModel,
+      getDefaultStatesForModel: getDefaultStatesForModel
     };
   })();
 })(window.GGRC);


### PR DESCRIPTION
Default value in assessments page should be filtered on "**Not Started**" and "**In Progress**"  (for "**My Assessments**" and "**Assessments**" page).

Comment from @xferra :
1. For the rest - "Select ALL" checkbox should be selected by default (Now it's empty). 
2. When entering custom filter - behave as AND with State filter
3. Consistent behavior with Audit Summary numbers
3* Verify all combinations of filters


Note: Second point (_When entering custom filter - behave as AND with State filter_) has already fixed in PR #5294 
