### PR TITLE
GGRC-1179 Sorting by ASSESSMENT CREATE DATE is not working in Related assessments

### DIFF
--- a/src/ggrc/assets/javascripts/components/related-objects/related-objects.js
+++ b/src/ggrc/assets/javascripts/components/related-objects/related-objects.js
@@ -51,7 +51,9 @@
         params.data = [{
           limit: [first, last],
           object_name: relatedType,
-          order_by: [{name: orderBy, desc: true}],
+          order_by: orderBy.split(',').map(function (field) {
+            return {name: field, desc: true};
+          }),
           filters: {
             expression: {
               object_name: type,

--- a/src/ggrc/assets/mustache/assessments/related-assessments-without-reuse.mustache
+++ b/src/ggrc/assets/mustache/assessments/related-assessments-without-reuse.mustache
@@ -2,7 +2,7 @@
 Copyright (C) 2017 Google Inc.
 Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
-<related-objects base-instance="instance" related-items-type="Assessment" order-by="finished_date">
+<related-objects base-instance="instance" related-items-type="Assessment" order-by="finished_date,created_at">
     <div class="grid-data-toolbar flex-box">
         <tree-pagination paging="paging"></tree-pagination>
     </div>

--- a/src/ggrc/assets/mustache/assessments/related-assessments.mustache
+++ b/src/ggrc/assets/mustache/assessments/related-assessments.mustache
@@ -2,7 +2,7 @@
 Copyright (C) 2017 Google Inc.
 Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
-<related-objects base-instance="instance" related-items-type="Assessment" order-by="finished_date">
+<related-objects base-instance="instance" related-items-type="Assessment" order-by="finished_date,created_at">
     <reusable-objects-list base-instance="instance">
         <div class="grid-data-toolbar flex-box">
             <tree-pagination paging="paging"></tree-pagination>


### PR DESCRIPTION
Precondition:
Created program, control, audit, at least 10 generated assessments based on control with different Finish/Create dates
Steps to reproduce:
1. Navigate to Assessment's Info panel on the audit page
2. Open Related assessments window
3. Look at the sorting by ASSESSMENT CREATE DATE: is not sorted in descending order
Actual Result: Sorting by ASSESSMENT CREATE DATE is not working in Related assessments  
Expected Result: Sorting by ASSESSMENT CREATE DATE should work in descending order in Related assessments  

Note: First sort by finish date if not exist then sort by create date.Finished Dated and Created Date in descending order.
