### PR TITLE
GGRC-1240 Fix changing status on tab switching in assessment

### DIFF
--- a/src/ggrc/assets/mustache/components/object-state-toolbar/object-state-toolbar.mustache
+++ b/src/ggrc/assets/mustache/components/object-state-toolbar/object-state-toolbar.mustache
@@ -4,9 +4,9 @@
 }}
 
 <div {{#instance}}{{data 'model'}}{{/instance}} {{ (el) -> el.ggrc_controllers_quick_form({instance : el.data('model') }) }}>
-  {{#if isInProgressOrNotStarted}}
-    {{^if hasErrors}}
-      {{#unless isDisabled}}
+  {{#unless isDisabled}}
+    {{#if isInProgressOrNotStarted}}
+      {{^if hasErrors}}
         {{#if hasVerifiers}}
             <button class="btn btn-small btn-primary pull-right btn-info-pin-header"
                     data-name="status"
@@ -17,40 +17,40 @@
                     data-name="status"
                     data-value="Completed">Complete</button>
         {{/if}}
-      {{/unless}}
-    {{else}}
-        <button class="btn btn-small btn-primary pull-right btn-info-pin-header disabled" {{#if errorMsg }}title="{{errorMsg}}"{{/if}}>Complete</button>
-    {{/if}}
-  {{/if}}
-  {{#if isInReview}}
-    {{#if isCurrentUserVerifier}}
-      {{#unless hasErrors}}
-          <button class="btn btn-small btn-success pull-right btn-info-pin-header"
-                  data-name="status"
-                  data-value="Verified">Verify
-          </button>
-          <button class="btn btn-small btn-danger pull-right btn-info-pin-header"
-                  data-name="status"
-                  data-value="In Progress">Reject
-          </button>
       {{else}}
-          <button class="btn btn-small btn-success pull-right btn-info-pin-header disabled"
-                  data-name="status"
-                  data-value="Verified"
-                  title="{{errorMsg}}">Verify
-          </button>
-          <button class="btn btn-small btn-danger pull-right btn-info-pin-header disabled"
-                  data-name="status"
-                  data-value="In Progress"
-                  title="{{errorMsg}}">Reject
-          </button>
-      {{/unless}}
+          <button class="btn btn-small btn-primary pull-right btn-info-pin-header disabled" {{#if errorMsg }}title="{{errorMsg}}"{{/if}}>Complete</button>
+      {{/if}}
     {{/if}}
-  {{/if}}
-  {{#unless isInProgress}}
-    {{#instance._undo.0}}
-        <a data-name="status" data-value="{{instance._undo.0}}" data-undo="true"
-           class="undo btn btn-small btn-link btn-info-pin-header pull-right {{#if isDisabled}}disabled{{/if}}">Undo</a>
-    {{/instance._undo.0}}
+    {{#if isInReview}}
+      {{#if isCurrentUserVerifier}}
+        {{#unless hasErrors}}
+            <button class="btn btn-small btn-success pull-right btn-info-pin-header"
+                    data-name="status"
+                    data-value="Verified">Verify
+            </button>
+            <button class="btn btn-small btn-danger pull-right btn-info-pin-header"
+                    data-name="status"
+                    data-value="In Progress">Reject
+            </button>
+        {{else}}
+            <button class="btn btn-small btn-success pull-right btn-info-pin-header disabled"
+                    data-name="status"
+                    data-value="Verified"
+                    title="{{errorMsg}}">Verify
+            </button>
+            <button class="btn btn-small btn-danger pull-right btn-info-pin-header disabled"
+                    data-name="status"
+                    data-value="In Progress"
+                    title="{{errorMsg}}">Reject
+            </button>
+        {{/unless}}
+      {{/if}}
+    {{/if}}
+    {{#unless isInProgress}}
+      {{#instance._undo.0}}
+          <a data-name="status" data-value="{{instance._undo.0}}" data-undo="true"
+             class="undo btn btn-small btn-link btn-info-pin-header pull-right {{#if isDisabled}}disabled{{/if}}">Undo</a>
+      {{/instance._undo.0}}
+    {{/unless}}
   {{/unless}}
 </div>


### PR DESCRIPTION
**Precondition**:
created program, control, audit

**Steps to reproduce**:
1. Generate assessment on the audit page based on control
2. Navigate to assessments Info pane and add verifier (progcreator@reciprocitylabs.com (engage007) in People list
3. Log as verifier (progcreator@reciprocitylabs.com (engage007)
4. Fill in mandatory CA fields if any and Complete/verify assessment
5. Click on Related Assessment/Issues/Assessment Log tabs: confirm assessment changes status from Completed/Verified Assessment to In progress

**Actual Result**: Completed/Verified Assessment moves to In progress state if press Related Assessment/Issues/Assessment Log tabs

**Expected Result**: Completed/Verified Assessment should not move to In progress state if press Related Assessment/Issues/Assessment Log tabs

