### PR TITLE
GGRC-1249 Fix status color for overdue tasks

### DIFF
--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -2632,7 +2632,11 @@ Mustache.registerHelper("fadeout", function (delay, prop, options) {
     });
 
 Mustache.registerHelper("is_overdue", function (_date, status, options) {
-  var date = moment(resolve_computed(_date));
+  var resolvedDate = resolve_computed(_date);
+  var hashDueDate = resolve_computed(options.hash && options.hash.next_date);
+  var nextDueDate = moment(hashDueDate || resolvedDate);
+  var endDate = moment(resolvedDate);
+  var date = moment.min(nextDueDate, endDate);
   var today = moment().startOf('day');
   var startOfDate = moment(date).startOf('day');
   var isBefore = date && today.diff(startOfDate, 'days') >= 0;

--- a/src/ggrc/assets/mustache/base_objects/open_close.mustache
+++ b/src/ggrc/assets/mustache/base_objects/open_close.mustache
@@ -4,7 +4,7 @@
 }}
 <div class="openclose{{^if draw_children}}__empty{{/if}}" >
   {{#if_instance_of instance "Cycle|CycleTaskGroup|CycleTaskGroupObjectTask"}}
-    <span class="status-label {{#is_overdue instance.end_date instance.status}}status-overdue{{/is_overdue}}" {{addclass "status-" instance.status}} {{addclass "status-" instance.overdue}}></span>
+    <span class="status-label {{#is_overdue instance.end_date instance.status next_date=instance.next_due_date}}status-overdue{{/is_overdue}}" {{addclass "status-" instance.status}} {{addclass "status-" instance.overdue}}></span>
   {{else}}
     {{#if instance.workflow_state}}
       <span class="status-label" {{addclass "status-" instance.workflow_state}}></span>


### PR DESCRIPTION
Overdue tasks has in correct icon color

It is critical for the team to see workflow status, task group status and task status in an easy and intuitive way. Hence status coloring is important to this functionality. ie RED for past due

Task past due (we know that gGRC considers DUE TODAY as past due), but the workflow, task group and task status are all GREY. 

Expected result: color bubbles accurately reflect current task status

Out of scope - due today bugs not to be addressed in this bug

1) if task OVERDUE - dot should be red
2) if task has red date - dot should be red
3) if task is red - task group and cycle should have red dot

![image](https://cloud.githubusercontent.com/assets/567805/23909353/8c221ae0-08e7-11e7-8ac8-96647c0e374f.png)
