### PR TITLE
QUICK-FIX Fix reindex logging

### DIFF
--- a/src/ggrc/fulltext/sql.py
+++ b/src/ggrc/fulltext/sql.py
@@ -5,24 +5,22 @@
 
 from ggrc import db
 from ggrc.fulltext import Indexer
-from ggrc.utils import benchmark
 
 
 class SqlIndexer(Indexer):
   def create_record(self, record, commit=True):
-    with benchmark("Add fulltext records: create_record -> submit to db"):
-      for prop, value in record.properties.items():
-        for subproperty, content in value.items():
-          if content:
-            db.session.add(self.record_type(
-                key=record.key,
-                type=record.type,
-                context_id=record.context_id,
-                tags=record.tags,
-                property=prop,
-                subproperty=subproperty,
-                content=content,
-            ))
+    for prop, value in record.properties.items():
+      for subproperty, content in value.items():
+        if content:
+          db.session.add(self.record_type(
+              key=record.key,
+              type=record.type,
+              context_id=record.context_id,
+              tags=record.tags,
+              property=prop,
+              subproperty=subproperty,
+              content=content,
+          ))
     if commit:
       db.session.commit()
 


### PR DESCRIPTION
Reindex logging on grc-test was doing way too many useless log outputs:

![capture 2017-03-03 at 8 54 21](https://cloud.githubusercontent.com/assets/513444/23940498/07a6e8f6-095d-11e7-81da-b1f2693102c8.png)

This PR removes the useless outputs and adds some useful ones.
