### PR TITLE
QUICK-FIX Test snapshotable control after delete original

### DIFF
--- a/test/selenium/src/lib/base.py
+++ b/test/selenium/src/lib/base.py
@@ -465,14 +465,15 @@ class Widget(AbstractPage):
     Args: driver (CustomDriver)
     """
     super(Widget, self).__init__(driver)
-    object_name, id_, widget_name = re.search(
+    matched_url_parts = re.search(
         constants.regex.URL_WIDGET_INFO, self.url).groups()
-    self.object_id = id_
-    self.name_from_url = widget_name.split("_")[0] or \
-        constants.element.WidgetBar.INFO
-    self.object_name = object_name
-    self.is_under_audit = (
-        self.object_name == objects.AUDITS and self.name_from_url != "info")
+    source_obj_plural, source_obj_id, widget = matched_url_parts
+    self.source_obj_from_url = source_obj_plural
+    self.source_obj_id_from_url = source_obj_id
+    self.widget_name_from_url = (widget.split("_")[0] or
+                                 constants.element.WidgetBar.INFO)
+    self.is_under_audit = (self.source_obj_from_url == objects.AUDITS and
+                           self.widget_name_from_url != "info")
 
 
 class TreeView(Component):

--- a/test/selenium/src/lib/page/widget/generic_widget.py
+++ b/test/selenium/src/lib/page/widget/generic_widget.py
@@ -304,11 +304,6 @@ class Controls(Widget):
 
   def __init__(self, driver,):
     super(Controls, self).__init__(driver)
-    self.label_title = base.Label(driver, locator.ObjectWidget.HEADER_TITLE)
-    self.label_owner = base.Label(driver, locator.ObjectWidget.HEADER_OWNER)
-    self.label_state = base.Label(driver, locator.ObjectWidget.HEADER_STATE)
-    self.label_last_asmt_date = base.Label(
-        driver, locator.ObjectWidget.HEADER_LAST_ASSESSMENT_DATE)
     self.tree_view = TreeView(
         driver, widget_name=self._locator_filter.widget_name)
 
@@ -326,6 +321,18 @@ class Controls(Widget):
     self.tree_view.select_member_by_title(obj_title)
     info_panel = self.info_widget_cls(self._driver)
     return info_panel.open_info_3bbs().is_edit_exist()
+
+  def is_openable(self, obj_title):
+    """Check Control is openable via Info panel from Tree View."""
+    self.tree_view.select_member_by_title(obj_title)
+    info_panel = self.info_widget_cls(self._driver)
+    return info_panel.open_info_3bbs().is_open_exist()
+
+  def is_updateble(self, obj_title):
+    """Check Control is updateble via Info panel from Tree View."""
+    self.tree_view.select_member_by_title(obj_title)
+    info_panel = self.info_widget_cls(self._driver)
+    return info_panel.is_link_get_latest_ver_exist()
 
   def set_visible_fields(self):
     """Set visible fields for display Controls on Tree View."""

--- a/test/selenium/src/lib/service/rest/client.py
+++ b/test/selenium/src/lib/service/rest/client.py
@@ -52,7 +52,7 @@ class RestClient(object):
     return req_headers
 
   def create_object(self, type, **kwargs):
-    """Create an object or make other operations used POST request and
+    """Create object or make other operations used POST request and
     return raw response.
     """
     if type == self._count:
@@ -63,8 +63,7 @@ class RestClient(object):
     return resp
 
   def update_object(self, href, **kwargs):
-    """Update an object used GET, POST requests and return raw response.
-    """
+    """Update object used GET, POST requests and return raw response."""
     obj_url = urlparse.urljoin(environment.APP_URL, href)
     obj_resp_headers = self.get_object(obj_url)["resp_headers"]
     obj_resp_body = self.get_object(obj_url)["resp_body"]
@@ -75,8 +74,17 @@ class RestClient(object):
                                 headers=new_obj_req_headers)
     return new_obj_resp
 
+  def delete_object(self, href):
+    """Delete object used GET, POST requests and return raw response."""
+    obj_url = urlparse.urljoin(environment.APP_URL, href)
+    obj_resp_headers = self.get_object(obj_url)["resp_headers"]
+    del_obj_req_headers = self.generate_req_headers(
+        resp_headers=obj_resp_headers)
+    del_obj_resp = requests.delete(url=obj_url, headers=del_obj_req_headers)
+    return del_obj_resp
+
   def get_object(self, obj_url):
-    """Get an object used GET request and return dictionary:
+    """Get object used GET request and return dictionary:
     {"resp_body": resp.text, "resp_headers": resp.headers}.
     """
     req_headers = self.generate_req_headers()

--- a/test/selenium/src/lib/service/rest_service.py
+++ b/test/selenium/src/lib/service/rest_service.py
@@ -12,6 +12,7 @@ from lib.entities.entities_factory import (
   ProgramsFactory, AuditsFactory, AssessmentTemplatesFactory,
   AssessmentsFactory, ControlsFactory, IssuesFactory, PersonsFactory)
 from lib.service.rest.client import RestClient
+from lib.utils import string_utils
 
 
 class BaseService(object):
@@ -114,9 +115,15 @@ class ControlsService(BaseService):
     return self.create_list_objs(factory=ControlsFactory(), count=count)
 
   def update(self, objs):
-    """Update an existing Controls objects via REST API and return updated."""
+    """Update existing Controls objects via REST API and return updated."""
     return self.update_list_objs(
-        list_old_objs=[objs], factory=ControlsFactory())
+        list_old_objs=string_utils.convert_to_list(objs),
+        factory=ControlsFactory())
+
+  def delete(self, objs):
+    """Delete existing Controls objects via REST API."""
+    return [self.client.delete_object(href=obj.href) for obj
+            in string_utils.convert_to_list(objs)]
 
 
 class ProgramsService(BaseService):
@@ -179,15 +186,10 @@ class RelationshipsService(BaseService):
     """Create relationship from source to destination objects and
     return created.
     """
-    if isinstance(dest_objs, list):
-      return [
-          self.client.create_object(
-              type=self._relationship, source=src_obj.__dict__,
-              destination=dest_obj.__dict__) for dest_obj in dest_objs]
-    else:
-      return self.client.create_object(
-          type=self._relationship, source=src_obj.__dict__,
-          destination=dest_objs.__dict__)
+    return [self.client.create_object(
+        type=self._relationship, source=src_obj.__dict__,
+        destination=dest_obj.__dict__) for dest_obj in
+            string_utils.convert_to_list(dest_objs)]
 
 
 class ObjectsOwnersService(BaseService):
@@ -196,15 +198,9 @@ class ObjectsOwnersService(BaseService):
 
   def create(self, objs, owner=PersonsFactory().default()):
     """Assign of an owner to objects."""
-    if isinstance(objs, list):
-      return [
-          self.client.create_object(
-              type=self._object_owner, ownable=obj.__dict__,
-              person=owner.__dict__) for obj in objs]
-    else:
-      return self.client.create_object(
-          type=self._object_owner, ownable=objs.__dict__,
-          person=owner.__dict__)
+    return [self.client.create_object(
+        type=self._object_owner, ownable=obj.__dict__,
+        person=owner.__dict__) for obj in string_utils.convert_to_list(objs)]
 
 
 class ObjectsInfoService(BaseService):

--- a/test/selenium/src/lib/service/webui_service.py
+++ b/test/selenium/src/lib/service/webui_service.py
@@ -91,6 +91,14 @@ class BaseWebUiService(object):
     objs_widget = gen_widget(self.driver)
     return objs_widget.is_editable(obj_title=obj.title)
 
+  def is_obj_open_via_info_panel(self, widget_url, gen_widget, obj):
+    """Navigate to widget URL, select object from Tree View by title and
+    check via Info panel that object is openable.
+    """
+    selenium_utils.open_url(self.driver, widget_url)
+    objs_widget = gen_widget(self.driver)
+    return objs_widget.is_openable(obj_title=obj.title)
+
 
 class AuditsService(BaseWebUiService):
   """Service for working with entity Audits entities."""
@@ -145,6 +153,14 @@ class AuditsService(BaseWebUiService):
     audit_info_page = Audits.info_widget_cls(self.driver)
     (audit_info_page.
      open_info_3bbs().select_update_objs().confirm_update())
+
+  def is_obj_update_via_info_panel(self, widget_url, gen_widget, obj):
+    """Navigate to widget URL, select object from Tree View by title and
+    check via Info panel that object is updateble.
+    """
+    selenium_utils.open_url(self.driver, widget_url)
+    objs_widget = gen_widget(self.driver)
+    return objs_widget.is_updateble(obj_title=obj.title)
 
   def get_obj_from_info_widget(self, audit_obj):
     """Get and return Audit object from Info widget."""
@@ -251,6 +267,20 @@ class ControlsService(BaseWebUiService):
     """Check that Control object is editable via Info panel from Tree View.
     If editable then return 'True' if no editable then return 'False'."""
     return self.is_obj_editable_via_info_panel(
+        widget_url=Controls.URL.format(source_obj_url=source_obj.url),
+        gen_widget=Controls, obj=control_obj)
+
+  def is_update_via_info_panel(self, source_obj, control_obj):
+    """Check that Control object is updateble via Info panel from Tree View.
+    If updateble then return 'True' if no updateble then return 'False'."""
+    return AuditsService(self.driver).is_obj_update_via_info_panel(
+        widget_url=Controls.URL.format(source_obj_url=source_obj.url),
+        gen_widget=Controls, obj=control_obj)
+
+  def is_open_via_info_panel(self, source_obj, control_obj):
+    """Check that Control object is openable via Info panel from Tree View.
+    If openable then return 'True' if no openable then return 'False'."""
+    return self.is_obj_open_via_info_panel(
         widget_url=Controls.URL.format(source_obj_url=source_obj.url),
         gen_widget=Controls, obj=control_obj)
 

--- a/test/selenium/src/lib/service/webui_service.py
+++ b/test/selenium/src/lib/service/webui_service.py
@@ -91,10 +91,11 @@ class BaseWebUiService(object):
     objs_widget = gen_widget(self.driver)
     return objs_widget.is_editable(obj_title=obj.title)
 
-  def is_obj_open_via_info_panel(self, widget_url, gen_widget, obj):
+  def is_obj_page_exist_via_info_panel(self, widget_url, gen_widget, obj):
     """Navigate to widget URL, select object from Tree View by title and
-    check via Info panel that object is openable.
+    check via Info panel that object page is exist.
     """
+    # pylint: disable=invalid-name
     selenium_utils.open_url(self.driver, widget_url)
     objs_widget = gen_widget(self.driver)
     return objs_widget.is_openable(obj_title=obj.title)
@@ -154,7 +155,7 @@ class AuditsService(BaseWebUiService):
     (audit_info_page.
      open_info_3bbs().select_update_objs().confirm_update())
 
-  def is_obj_update_via_info_panel(self, widget_url, gen_widget, obj):
+  def is_obj_updateble_via_info_panel(self, widget_url, gen_widget, obj):
     """Navigate to widget URL, select object from Tree View by title and
     check via Info panel that object is updateble.
     """
@@ -270,17 +271,17 @@ class ControlsService(BaseWebUiService):
         widget_url=Controls.URL.format(source_obj_url=source_obj.url),
         gen_widget=Controls, obj=control_obj)
 
-  def is_update_via_info_panel(self, source_obj, control_obj):
+  def is_updateble_via_info_panel(self, source_obj, control_obj):
     """Check that Control object is updateble via Info panel from Tree View.
     If updateble then return 'True' if no updateble then return 'False'."""
-    return AuditsService(self.driver).is_obj_update_via_info_panel(
+    return AuditsService(self.driver).is_obj_updateble_via_info_panel(
         widget_url=Controls.URL.format(source_obj_url=source_obj.url),
         gen_widget=Controls, obj=control_obj)
 
-  def is_open_via_info_panel(self, source_obj, control_obj):
+  def is_openable_via_info_panel(self, source_obj, control_obj):
     """Check that Control object is openable via Info panel from Tree View.
     If openable then return 'True' if no openable then return 'False'."""
-    return self.is_obj_open_via_info_panel(
+    return self.is_obj_page_exist_via_info_panel(
         widget_url=Controls.URL.format(source_obj_url=source_obj.url),
         gen_widget=Controls, obj=control_obj)
 

--- a/test/selenium/src/lib/utils/string_utils.py
+++ b/test/selenium/src/lib/utils/string_utils.py
@@ -50,3 +50,11 @@ def remap_keys_for_list_dicts(dict_transformation_keys, list_dicts):
  """
   return [{dict_transformation_keys[key]: value for key, value
            in dic.iteritems()} for dic in list_dicts]
+
+
+def convert_to_list(items):
+  """Converts items to list items:
+  - if items are already list items then skip;
+  - if are not list items then convert to list items."""
+  list_items = items if isinstance(items, list) else [items, ]
+  return list_items

--- a/test/selenium/src/tests/conftest.py
+++ b/test/selenium/src/tests/conftest.py
@@ -231,6 +231,14 @@ def update_control_rest(new_control_rest):
 
 
 @pytest.yield_fixture(scope="function")
+def delete_control_rest(new_control_rest):
+  """Delete existing Control object via REST API.
+  Return: lib.entities.entity.Control
+  """
+  yield ControlsService().delete(objs=new_control_rest)
+
+
+@pytest.yield_fixture(scope="function")
 def map_controls_to_program_rest(new_program_rest, new_controls_rest):
   """Create new Program, Controls objects via REST API and map created
   Controls to Program via REST API.

--- a/test/selenium/src/tests/test_audit_page.py
+++ b/test/selenium/src/tests/test_audit_page.py
@@ -105,7 +105,6 @@ class TestAuditPage(base.Test):
         "updated_control": audit_with_one_control["updated_control"],
         "second_control": second_control}
 
-  # Tests of creation and generation objects under audit.
   @pytest.mark.smoke_tests
   def test_asmt_tmpl_creation(self, new_audit_rest, selenium):
     """Check if Assessment Template can be created from Audit page via
@@ -171,31 +170,6 @@ class TestAuditPage(base.Test):
     assert expected_asmts == actual_asmts, (
         messages.ERR_MSG_FORMAT.format(expected_asmts, actual_asmts))
 
-  # Tests of audit snapshots.
-  @pytest.mark.smoke_tests
-  def test_audit_contains_snapshotable_ver_of_control(
-      self, new_control_rest, new_program_rest, map_control_to_program_rest,
-      new_audit_rest, update_control_rest, selenium
-  ):
-    """Check via UI that Audit contains snapshotable Control that equal to
-    original Control under Program
-    after updated original Control via REST API.
-    Preconditions:
-    - Program, Control created via REST API.
-    - Control mapped to Program via REST API.
-    - Audit created under Program via REST API.
-    - Original Control updated via REST API.
-    """
-    audit, _ = new_audit_rest
-    expected_control = new_control_rest
-    actual_controls_tab_count = (webui_service.ControlsService(selenium).
-                                 get_count_from_tab(source_obj=audit))
-    assert len([expected_control]) == actual_controls_tab_count
-    actual_controls = (webui_service.ControlsService(selenium).
-                       get_objs_from_tree_view(source_obj=audit))
-    assert [expected_control] == actual_controls, (
-        messages.ERR_MSG_FORMAT.format([expected_control], actual_controls))
-
   @pytest.mark.smoke_tests
   def test_audit_contains_readonly_ver_of_control(
       self, new_control_rest, new_program_rest, map_control_to_program_rest,
@@ -221,12 +195,11 @@ class TestAuditPage(base.Test):
     assert is_control_editable is False
 
   @pytest.mark.smoke_tests
-  def test_audit_contains_snapshotable_control_after_update_original_control(
+  def test_audit_contains_snapshotable_control_after_updating_control(
       self, create_audit_and_update_original_control, selenium
   ):
-    """Check via UI that Audit contains snapshotable Control
-    that equal to original Control under Program after updated original
-    Control via REST API.
+    """Check via UI that Audit contains snapshotable Control that does not
+    equal updated version Control without version updating Control.
     Preconditions:
     - Execution and return of fixture
       'create_audit_and_update_original_control'.
@@ -243,12 +216,12 @@ class TestAuditPage(base.Test):
         messages.ERR_MSG_FORMAT.format([expected_control], actual_controls))
 
   @pytest.mark.smoke_tests
-  def test_update_audit_snapshotable_control_after_update_original_control(
+  def test_update_snapshotable_ver_after_updating_original_control(
       self, create_audit_and_update_original_control, selenium
   ):
     """Check via UI that Audit contains snapshotable Control that up-to-date
-    with it actual state after updated snapshotable Control to latest
-    version via UI.
+    with it actual state of original control after updating snapshot to latest
+    version.
     Preconditions:
     - Execution and return of fixture
       'create_audit_and_update_original_control'.
@@ -269,13 +242,13 @@ class TestAuditPage(base.Test):
 
   @pytest.mark.smoke_tests
   @pytest.mark.skipif(True, reason="Issue in app GGRC-1196")
-  def test_audit_contains_snapshotable_control_after_delete_original_control(
+  def test_audit_contains_snapshotable_control_after_deleting_original_control(
       self, create_audit_and_delete_original_control, selenium
   ):
-    """Check via UI that Audit contains snapshotable Control that:
-    - equal to original Control under Program;
-    - is not have links to update version to latest state and
-      to view original Control under Program.
+    """Check via UI that Audit contains snapshotable Control even after
+    deleting original control.
+    Snapshot does not have links to update version to latest state
+    and to view original Control under Program.
     Preconditions:
     - Execution and return of fixture
       'create_audit_and_delete_original_control'.
@@ -290,26 +263,22 @@ class TestAuditPage(base.Test):
                        get_objs_from_tree_view(source_obj=audit))
     assert [expected_control] == actual_controls, (
         messages.ERR_MSG_FORMAT.format([expected_control], actual_controls))
-
-    control_is_updateable = (
-        webui_service.ControlsService(selenium).
-        is_update_via_info_panel(source_obj=audit,
-                                 control_obj=expected_control))
-    control_is_openable = (
-        webui_service.ControlsService(selenium).
-        is_open_via_info_panel(source_obj=audit,
-                               control_obj=expected_control))
-    assert control_is_updateable is False
-    assert control_is_openable is False
+    is_control_updateable = (
+        webui_service.ControlsService(selenium).is_updateble_via_info_panel(
+            source_obj=audit, control_obj=expected_control))
+    is_control_openable = (
+        webui_service.ControlsService(selenium).is_openable_via_info_panel(
+            source_obj=audit, control_obj=expected_control))
+    assert is_control_updateable is False
+    assert is_control_openable is False
 
   @pytest.mark.smoke_tests
-  def test_audit_contains_snapshotable_control_after_change_original_controls(
+  def test_mapped_to_program_controls_does_not_added_to_existing_audit(
       self, create_audit_and_update_first_of_two_original_controls, selenium
   ):
-    """Check via UI that Audit contains snapshotable Control
-    that equal to original Control under Program after updated original
-    Control via REST API and created second Control and mapped it to
-    Program via REST API.
+    """Check via UI that Audit contains snapshotable Control that equal to
+    original Control does not contain Control that was mapped to
+    Program after Audit creation.
     Preconditions:
     - Execution and return of fixture
       'create_audit_and_update_first_of_two_original_controls'.
@@ -331,7 +300,8 @@ class TestAuditPage(base.Test):
       self, create_audit_and_update_first_of_two_original_controls, selenium
   ):
     """Check via UI that Audit contains snapshotable Controls that up-to-date
-    with their actual states after bulk updated audit objects to latest ver.
+    with their actual states after bulk updated audit objects
+    to latest version.
     Preconditions:
     - Execution and return of fixture
       'create_audit_and_update_first_of_two_original_controls'.
@@ -351,7 +321,6 @@ class TestAuditPage(base.Test):
     assert expected_controls == actual_controls, (
         messages.ERR_MSG_FORMAT.format(expected_controls, actual_controls))
 
-  # Tests of audit clones.
   @pytest.mark.smoke_tests
   def test_cloned_audit_contains_new_attrs(self, create_and_clone_audit,
                                            selenium):

--- a/test/selenium/src/tests/test_people_groups_page.py
+++ b/test/selenium/src/tests/test_people_groups_page.py
@@ -22,5 +22,5 @@ class TestOrgGroupPage(base.Test):
     and closing lhn_modal we're redirected to an url that contains an
     object id.
     """
-    assert (url.ORG_GROUPS + "/" + new_org_group_ui.object_id in
+    assert (url.ORG_GROUPS + "/" + new_org_group_ui.source_obj_id_from_url in
             new_org_group_ui.url)

--- a/test/selenium/src/tests/test_program_page.py
+++ b/test/selenium/src/tests/test_program_page.py
@@ -25,7 +25,7 @@ class TestProgramPage(base.Test):
     _, program_info_page = new_program_ui
     lhn_menu = dashboard.Header(selenium).open_lhn_menu().select_my_objects()
     assert (lhn_menu.toggle_programs.members_count >=
-            int(program_info_page.object_id))
+            int(program_info_page.source_obj_id_from_url))
 
   @pytest.mark.smoke_tests
   def test_modal_redirects(self, new_program_ui):
@@ -36,7 +36,7 @@ class TestProgramPage(base.Test):
     object id.
     """
     _, program_info_page = new_program_ui
-    assert (url.PROGRAMS + "/" + program_info_page.object_id in
+    assert (url.PROGRAMS + "/" + program_info_page.source_obj_id_from_url in
             program_info_page.url)
 
   @pytest.mark.smoke_tests

--- a/test/selenium/src/tests/test_risk_threats_page.py
+++ b/test/selenium/src/tests/test_risk_threats_page.py
@@ -22,5 +22,5 @@ class TestRiskThreatPage(base.Test):
     and closing lhn_modal we're redirected to an url that contains an
     object id.
     """
-    assert (
-        url.RISKS + "/" + new_risk_ui.object_id in new_risk_ui.url)
+    assert (url.RISKS + "/" + new_risk_ui.source_obj_id_from_url in
+            new_risk_ui.url)


### PR DESCRIPTION
This PR ~depends on #5348~ and add 1 test case:
Check that audit contains snapshotable control after delete original control.