### PR TITLE
GGRC-1475 Fix empty status in is_overdue

### DIFF
--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -2631,25 +2631,25 @@ Mustache.registerHelper("fadeout", function (delay, prop, options) {
       );
     });
 
-Mustache.registerHelper("is_overdue", function (_date, status, options) {
-  var resolvedDate = resolve_computed(_date);
-  var hashDueDate = resolve_computed(options.hash && options.hash.next_date);
-  var nextDueDate = moment(hashDueDate || resolvedDate);
-  var endDate = moment(resolvedDate);
-  var date = moment.min(nextDueDate, endDate);
-  var today = moment().startOf('day');
-  var startOfDate = moment(date).startOf('day');
-  var isBefore = date && today.diff(startOfDate, 'days') >= 0;
-  options = arguments.length === 2 ? arguments[1] : options;
-  status = arguments.length === 2 ? "" : resolve_computed(status);
-  // TODO: [Overdue] Move this logic to helper.
-  if (status !== 'Verified' && isBefore) {
-    return options.fn(options.contexts);
-  }
-  else {
-    return options.inverse(options.contexts);
-  }
-});
+  Mustache.registerHelper('is_overdue', function (_date, status, options) {
+    var resolvedDate = resolve_computed(_date);
+    var opts = arguments[arguments.length - 1];
+    var hashDueDate = resolve_computed(opts.hash && opts.hash.next_date);
+    var nextDueDate = moment(hashDueDate || resolvedDate);
+    var endDate = moment(resolvedDate);
+    var date = moment.min(nextDueDate, endDate);
+    var today = moment().startOf('day');
+    var startOfDate = moment(date).startOf('day');
+    var isBefore = date && today.diff(startOfDate, 'days') >= 0;
+    var result;
+    status = arguments.length === 2 ? '' : resolve_computed(status);
+    if (status !== 'Verified' && isBefore) {
+      result = opts.fn(opts.contexts);
+    } else {
+      result = opts.inverse(opts.contexts);
+    }
+    return result;
+  });
 
 Mustache.registerHelper("with_mappable_instances_as", function (name, list, options) {
   var ctx = new can.Observe()

--- a/src/ggrc/assets/js_specs/mustache_helpers/is_overdue_spec.js
+++ b/src/ggrc/assets/js_specs/mustache_helpers/is_overdue_spec.js
@@ -1,0 +1,74 @@
+/*!
+  Copyright (C) 2017 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+describe('can.mustache.helper.is_overdue', function () {
+  'use strict';
+
+  var fakeOptions;  // fake mustache options object passed to the helper
+  var helper;
+  var templateContext;
+
+  beforeAll(function () {
+    helper = can.Mustache._helpers.is_overdue.fn;
+  });
+
+  beforeEach(function () {
+    templateContext = {foo: 'bar'};
+
+    fakeOptions = {
+      fn: jasmine.createSpy(),
+      inverse: jasmine.createSpy(),
+      contexts: templateContext,
+      hash: {
+        next_date: '2010-04-02'
+      }
+    };
+  });
+
+  it('triggers rendering of "truthy" block when status is passed', function () {
+    var callArgs;
+    var expectedArgs = [templateContext];
+
+    helper('2010-01-01', 'Fake Status', fakeOptions);
+
+    expect(fakeOptions.fn.calls.count()).toEqual(1);
+    callArgs = fakeOptions.fn.calls.mostRecent().args;
+    expect(callArgs).toEqual(expectedArgs);
+  });
+
+  it('triggers rendering of "falsy" block when status is passed', function () {
+    var callArgs;
+    var expectedArgs = [templateContext];
+    fakeOptions.hash = undefined;
+
+    helper('2030-01-01', 'Fake Status', fakeOptions);
+
+    expect(fakeOptions.inverse.calls.count()).toEqual(1);
+    callArgs = fakeOptions.inverse.calls.mostRecent().args;
+    expect(callArgs).toEqual(expectedArgs);
+  });
+
+  it('triggers "truthy" block rendering when no status passed', function () {
+    var callArgs;
+    var expectedArgs = [templateContext];
+
+    helper('2010-01-01', fakeOptions);
+
+    expect(fakeOptions.fn.calls.count()).toEqual(1);
+    callArgs = fakeOptions.fn.calls.mostRecent().args;
+    expect(callArgs).toEqual(expectedArgs);
+  });
+
+  it('triggers "falsy" block rendering when status is "Verified"', function () {
+    var callArgs;
+    var expectedArgs = [templateContext];
+
+    helper('2010-01-01', 'Verified', fakeOptions);
+
+    expect(fakeOptions.inverse.calls.count()).toEqual(1);
+    callArgs = fakeOptions.inverse.calls.mostRecent().args;
+    expect(callArgs).toEqual(expectedArgs);
+  });
+});


### PR DESCRIPTION
**"Uncaught TypeError: Cannot read property 'hash' of undefined" error is displayed if open any widget with overdue object in tree view**

**Steps to reproduce**:
1. Go to All objects/ My objects page
2. Open e.g. "Objectives" widget in HNB

**Actual Result**: "Uncaught TypeError: Cannot read property 'hash' of undefined" error is displayed
**Expected Result**: No error displayed

![image](https://cloud.githubusercontent.com/assets/567805/23987493/eb53cff0-0a3a-11e7-9c2e-c845536cd314.png)
