### PR TITLE
GGRC-809 Pagination doesn’t work in Assessment Log in Assessment's Info pane

### DIFF
--- a/src/ggrc/assets/javascripts/components/paginate.js
+++ b/src/ggrc/assets/javascripts/components/paginate.js
@@ -18,9 +18,9 @@
         *
         * @return {Number} - Number of current page
         */
-      currentPage: function () {
+      currentPage: can.compute(function () {
         return this.attr('current') + 1;
-      },
+      }),
       /**
         * Sets previous page
         *
@@ -76,12 +76,12 @@
         *                     pageNum: `True page number that gets passed to setPage function`
         *                   }
         */
-      totalPages: function () {
+      totalPages: can.compute(function () {
         var list = this.attr('list');
         var perPage = Number(this.attr('perPage'));
 
         return Math.ceil(list.length / perPage);
-      }
+      })
     }
   });
 })(window.can, window.can.$);

--- a/src/ggrc/assets/mustache/base_objects/paginate.mustache
+++ b/src/ggrc/assets/mustache/base_objects/paginate.mustache
@@ -7,7 +7,7 @@
 
 {{#if totalPages}}
 <ul class="pagination">
-  <li {{#if_equals currentPage 1}}class="disabled"{{/if_equals}}>
+  <li {{#if_match currentPage 1}}class="disabled"{{/if_equals}}>
     <a can-click="setPrevious" href="#">Previous</a>
   </li>
   <li>
@@ -15,7 +15,7 @@
       <span>{{currentPage}} of {{totalPages}}</span>
     </span>
   </li>
-  <li {{#if_equals currentPage totalPages}}class="disabled"{{/if_equals}}>
+  <li {{#if_match currentPage totalPages}}class="disabled"{{/if_equals}}>
     <a can-click="setNext" href="#">Next</a>
   </li>
 </ul>


### PR DESCRIPTION
Precondition:
- created program, audit

Steps to reproduce:
1. Go to audit page
2. Create Assessment
3. Make changes for Assessment: e.g. fill values in GCA if any, complete assessment, map any objects to Assessment, attach evidence/urls
4. Go to Assessment Log and ensure that log contains at least two pages
5. Click "Next" link: confirm is not followed to the next page

Actual Result: Pagination doesn’t work in Assessment Log in Assessment's Info pane
Expected Result: Pagination should work in Assessment Log in Assessment's Info pane if click on "Next" and "Previous" links