### PR TITLE
GGRC-959 Ungrey the 3bbs menu options

### DIFF
--- a/src/ggrc/assets/mockups/mockup_base_templates/info_panel/info_panel_utility.mustache
+++ b/src/ggrc/assets/mockups/mockup_base_templates/info_panel/info_panel_utility.mustache
@@ -10,7 +10,7 @@
       <span class="bubble"></span>
       <span class="bubble"></span>
     </a>
-    <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
+    <ul class="dropdown-menu three-dots-list" aria-labelledby="drop1" role="menu">
       {{#is_allowed 'update' instance context='for'}}
         <li>
           <a href="#WorkflowSetup" data-toggle="modal">

--- a/src/ggrc/assets/mockups/quick-workflow/info.mustache
+++ b/src/ggrc/assets/mockups/quick-workflow/info.mustache
@@ -42,7 +42,7 @@
                 <span class="bubble"></span>
                 <span class="bubble"></span>
               </a>
-              <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
+              <ul class="dropdown-menu three-dots-list" aria-labelledby="drop1" role="menu">
                 {{#is_allowed 'update' instance context='for'}}
                   {{> /static/mustache/base_objects/edit_object_link.mustache}}
                 {{/is_allowed}}

--- a/src/ggrc/assets/mockups/request/info.mustache
+++ b/src/ggrc/assets/mockups/request/info.mustache
@@ -42,7 +42,7 @@
                 <span class="bubble"></span>
                 <span class="bubble"></span>
               </a>
-              <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
+              <ul class="dropdown-menu three-dots-list" aria-labelledby="drop1" role="menu">
                 <li>
                   <a href="#AssessmentDefineTemplate" data-toggle="modal">
                     <i class="grcicon-add-black"></i>

--- a/src/ggrc/assets/mustache/assessments/header.mustache
+++ b/src/ggrc/assets/mustache/assessments/header.mustache
@@ -26,7 +26,7 @@ Copyright (C) 2017 Google Inc.
                         <span class="bubble"></span>
                         <span class="bubble"></span>
                     </a>
-                    <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
+                    <ul class="dropdown-menu three-dots-list" aria-labelledby="drop1" role="menu">
                       {{#is_allowed 'update' instance context='for'}}
                         {{> '/static/mustache/base_objects/edit_object_link.mustache'}}
                       {{/is_allowed}}

--- a/src/ggrc/assets/mustache/base_objects/dropdown_menu.mustache
+++ b/src/ggrc/assets/mustache/base_objects/dropdown_menu.mustache
@@ -16,7 +16,7 @@
     <span class="bubble"></span>
     <span class="bubble"></span>
   </a>
-  <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
+  <ul class="dropdown-menu three-dots-list" aria-labelledby="drop1" role="menu">
     {{#is_allowed 'update' instance context='for'}}
       {{#if instance.is_snapshotable}}
         <li>

--- a/src/ggrc/assets/mustache/base_objects/dropdown_menu_tier2.mustache
+++ b/src/ggrc/assets/mustache/base_objects/dropdown_menu_tier2.mustache
@@ -16,7 +16,7 @@
        <span class="bubble"></span>
   </a>
 
-  <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
+  <ul class="dropdown-menu three-dots-list" aria-labelledby="drop1" role="menu">
 
     {{> /static/mustache/base_objects/edit_object_link.mustache}}
 

--- a/src/ggrc/assets/mustache/base_templates/header.mustache
+++ b/src/ggrc/assets/mustache/base_templates/header.mustache
@@ -34,7 +34,7 @@
             <span class="bubble"></span>
             <span class="bubble"></span>
           </a>
-          <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
+          <ul class="dropdown-menu three-dots-list" aria-labelledby="drop1" role="menu">
             {{#is_allowed 'update' instance context='for'}}
               {{> '/static/mustache/base_objects/edit_object_link.mustache'}}
             {{/is_allowed}}

--- a/src/ggrc/assets/mustache/mapped_objects/dropdown_menu_tier2.mustache
+++ b/src/ggrc/assets/mustache/mapped_objects/dropdown_menu_tier2.mustache
@@ -12,7 +12,7 @@
     <span class="bubble"></span>
   </a>
 
-  <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
+  <ul class="dropdown-menu three-dots-list" aria-labelledby="drop1" role="menu">
 
     <li>
       <a href="javascript://" class="unmap" data-toggle="unmap">

--- a/src/ggrc/assets/mustache/people/dropdown_menu.mustache
+++ b/src/ggrc/assets/mustache/people/dropdown_menu.mustache
@@ -9,7 +9,7 @@
     <span class="bubble"></span>
     <span class="bubble"></span>
   </a>
-  <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
+  <ul class="dropdown-menu three-dots-list" aria-labelledby="drop1" role="menu">
     <li class="border-bottom">
       <clipboard-link title="Get permalink" notify="true" text="{{get_permalink_for_object instance}}" />
     </li>

--- a/src/ggrc/assets/mustache/people/object_list.mustache
+++ b/src/ggrc/assets/mustache/people/object_list.mustache
@@ -71,7 +71,7 @@
               <span class="bubble"></span>
               <span class="bubble"></span>
             </a>
-            <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
+            <ul class="dropdown-menu three-dots-list" aria-labelledby="drop1" role="menu">
               <li>
                 <a href="/people/{{id}}">
                   <i class="fa fa-long-arrow-right"></i>

--- a/src/ggrc/assets/mustache/snapshots/dropdown_menu.mustache
+++ b/src/ggrc/assets/mustache/snapshots/dropdown_menu.mustache
@@ -17,7 +17,7 @@ or #is_allowed' 'update' instance '\
             <span class="bubble"></span>
             <span class="bubble"></span>
         </a>
-        <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
+        <ul class="dropdown-menu three-dots-list" aria-labelledby="drop1" role="menu">
 
 <!--
 TODO: Temporary disabled until snapshot view is added.

--- a/src/ggrc/assets/stylesheets/_common.scss
+++ b/src/ggrc/assets/stylesheets/_common.scss
@@ -908,3 +908,16 @@ p {
     width: 70%;
   }
 }
+
+.three-dots-list {
+  & > li {
+    a {
+      color: #000 !important;
+    }
+
+    .fa {
+      color: #000 !important;
+      opacity: 0.7 !important;
+    }
+  }
+}

--- a/src/ggrc_basic_permissions/assets/mustache/ggrc_basic_permissions/people_roles/info.mustache
+++ b/src/ggrc_basic_permissions/assets/mustache/ggrc_basic_permissions/people_roles/info.mustache
@@ -16,7 +16,7 @@
         <span class="bubble"></span>
         <span class="bubble"></span>
       </a>
-      <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
+      <ul class="dropdown-menu three-dots-list" aria-labelledby="drop1" role="menu">
         {{#is_allowed 'create' 'delete' 'UserRole' context=options.parent_instance.context.id}}
         {{#is_info_pin}}
         {{#if_equals options.mapping "mapped_and_or_authorized_people"}}

--- a/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/info.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/info.mustache
@@ -19,7 +19,7 @@
             <span class="bubble"></span>
             <span class="bubble"></span>
           </a>
-          <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
+          <ul class="dropdown-menu three-dots-list" aria-labelledby="drop1" role="menu">
             <li>
               <a href="javascript://" data-object-singular-override="Task for current Workflow Cycle" data-toggle="modal-ajax-form" data-modal-reset="reset" data-modal-class="modal-wide" data-object-singular="{{instance.class.model_singular}}" data-object-plural="{{instance.class.table_plural}}" data-object-id="{{instance.id}}">
                 <i class="fa fa-pencil-square-o"></i>

--- a/src/ggrc_workflows/assets/mustache/cycle_task_group_objects/info.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_group_objects/info.mustache
@@ -19,7 +19,7 @@
               <span class="bubble"></span>
               <span class="bubble"></span>
             </a>
-            <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
+            <ul class="dropdown-menu three-dots-list" aria-labelledby="drop1" role="menu">
               {{#is_allowed 'update' object context='for'}}
                 <li>
                   <a href="javascript://" data-toggle="modal-ajax-form" data-modal-reset="reset" data-modal-class="modal-wide" data-object-singular="{{object.class.model_singular}}" data-object-plural="{{object.class.table_plural}}" data-object-id="{{object.id}}">

--- a/src/ggrc_workflows/assets/mustache/cycles/info.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycles/info.mustache
@@ -18,7 +18,7 @@
           <span class="bubble"></span>
           <span class="bubble"></span>
         </a>
-        <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
+        <ul class="dropdown-menu three-dots-list" aria-labelledby="drop1" role="menu">
           {{#if workflow.viewLink}}
             {{!#is_allowed "view_object_page" instance}}
               <li>

--- a/src/ggrc_workflows/assets/mustache/task_groups/info.mustache
+++ b/src/ggrc_workflows/assets/mustache/task_groups/info.mustache
@@ -19,7 +19,7 @@
             <span class="bubble"></span>
             <span class="bubble"></span>
           </a>
-          <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
+          <ul class="dropdown-menu three-dots-list" aria-labelledby="drop1" role="menu">
             {{#using workflow=instance.workflow}}
               {{^if_equals workflow.status 'Inactive'}}
                 {{> /static/mustache/base_objects/edit_object_link.mustache}}

--- a/src/ggrc_workflows/assets/mustache/workflows/info.mustache
+++ b/src/ggrc_workflows/assets/mustache/workflows/info.mustache
@@ -18,7 +18,7 @@
           <span class="bubble"></span>
           <span class="bubble"></span>
         </a>
-        <ul class="dropdown-menu" aria-labelledby="drop1" role="menu">
+        <ul class="dropdown-menu three-dots-list" aria-labelledby="drop1" role="menu">
           {{^is_info_pin}}
             {{{render_hooks instance.class.shortName 'info_widget_actions'}}}
             {{^if_equals instance.kind "Backlog"}}


### PR DESCRIPTION
**Steps to reproduce:**
1. Go to My Work page
2. Select any object's tab from HNB (e.g. Controls)
3. Click on 3 dots menu: confirm Hide Filter is not grayed

_Actual Result_: Hide Filter is not grayed in 3 dots menu
_Expected Result_: Tree view tools should be one color in 3 dots menu. So it should be grayed

_need to implement_: remove show/hide filter option at all.

![123](https://cloud.githubusercontent.com/assets/4204416/23368107/c14d460c-fd1d-11e6-8a70-0a4319462d97.png)
