### PR TITLE
GGRC-1483 GGRC-1468 GGRC-1480 Fix index of Options in Snapshots

### DIFF
--- a/src/ggrc/models/mixins/__init__.py
+++ b/src/ggrc/models/mixins/__init__.py
@@ -532,7 +532,11 @@ class Base(ChangeTracked, ContextRBAC, Identifiable):
     for attr_name in self._publish_attrs:
       if is_attr_of_type(self, attr_name, models.Option):
         attr = getattr(self, attr_name)
-        stub = create_stub(attr)
+        if attr:
+          stub = create_stub(attr)
+          stub["title"] = attr.title
+        else:
+          stub = None
         res[attr_name] = stub
     return res
 

--- a/src/ggrc/snapshotter/indexer.py
+++ b/src/ggrc/snapshotter/indexer.py
@@ -272,6 +272,9 @@ def reindex_pairs(pairs):  # noqa  # pylint:disable=too-many-branches
             for person in val:
               search_payload += get_person_data(rec, person)
             search_payload += get_person_sort_subprop(rec, val)
+          elif isinstance(val, dict) and "title" in val:
+            rec["content"] = val["title"]
+            search_payload += [rec]
           else:
             if isinstance(rec["content"], basestring):
               search_payload += [rec]

--- a/src/ggrc/snapshotter/indexer.py
+++ b/src/ggrc/snapshotter/indexer.py
@@ -3,6 +3,8 @@
 
 """Manage indexing for snapshotter service"""
 
+import logging
+
 from sqlalchemy.sql.expression import tuple_
 
 from ggrc import db
@@ -15,6 +17,9 @@ from ggrc.utils import generate_query_chunks
 
 from ggrc.snapshotter.rules import Types
 from ggrc.snapshotter.datastructures import Pair
+
+
+logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
 def _get_tag(pair):
@@ -268,7 +273,12 @@ def reindex_pairs(pairs):  # noqa  # pylint:disable=too-many-branches
               search_payload += get_person_data(rec, person)
             search_payload += get_person_sort_subprop(rec, val)
           else:
-            search_payload += [rec]
+            if isinstance(rec["content"], basestring):
+              search_payload += [rec]
+            else:
+              logger.warning(u"Unsupported value for %s #%s in %s %s: %r",
+                             rec["type"], rec["key"], rec["property"],
+                             rec["subproperty"], rec["content"])
 
     delete_records(snapshot_ids)
     insert_records(search_payload)

--- a/src/ggrc/snapshotter/indexer.py
+++ b/src/ggrc/snapshotter/indexer.py
@@ -253,7 +253,7 @@ def reindex_pairs(pairs):  # noqa  # pylint:disable=too-many-branches
       multiple_person_properties = {"owners"}
 
       for prop, val in properties.items():
-        if prop and val:
+        if prop and val is not None:
           # record stub
           rec = {
               "key": snapshot_id,
@@ -274,6 +274,9 @@ def reindex_pairs(pairs):  # noqa  # pylint:disable=too-many-branches
             search_payload += get_person_sort_subprop(rec, val)
           elif isinstance(val, dict) and "title" in val:
             rec["content"] = val["title"]
+            search_payload += [rec]
+          elif isinstance(val, (bool, int, long)):
+            rec["content"] = unicode(val)
             search_payload += [rec]
           else:
             if isinstance(rec["content"], basestring):

--- a/test/integration/ggrc/models/test_snapshot.py
+++ b/test/integration/ggrc/models/test_snapshot.py
@@ -28,8 +28,10 @@ class TestSnapshot(TestCase):
       "directive",
       "directive_id",
 
+      "kind",
       "kind_id",
 
+      "means",
       "means_id",
 
       "meta_kind",
@@ -37,6 +39,7 @@ class TestSnapshot(TestCase):
       "network_zone",
       "network_zone_id",
 
+      "verify_frequency",
       "verify_frequency_id",
 
       "assertions",


### PR DESCRIPTION
Steps to reproduce:
1. Run reindex.

Expected result: reindex is finished without errors.
Actual result: reindex fails with SQL syntax error.

Also this PR fixes fulltext index for Options, displaying Options in "update to latest version" popup and fulltext index for boolean fields in Snapshots (all in a hacky way).

Steps to reproduce:
1. Create a Control with "kind" = "Corrective".
2. Map the Control to a Program, create a Program in the Audit.
3. Go to the Audit, open Controls tab, try to filter by "kind = Corrective".
4. Edit the original Control, set "kind" = "Preventative" and "Fraud related" = "False".
5. Go to the Audit, open Controls tab, update the Snapshot to the latest version.
6. Try to filter by "kind = Preventative" and '"Fraud related" = False'.

Expected results: on 3 and 6, the Control snapshot is displayed. On 5, the "Kind" field is shown correctly in the diff modal.