### PR TITLE
GGRC-1126 Fix mapper relevant control autocomplete issues

### DIFF
--- a/src/ggrc/assets/javascripts/components/relevant_filters.js
+++ b/src/ggrc/assets/javascripts/components/relevant_filters.js
@@ -31,6 +31,7 @@
         this.attr('relevant').push({
           value: false,
           filter: new can.Map(),
+          textValue: '',
           menu: menu,
           model_name: menu[0].model_singular
         });
@@ -75,6 +76,7 @@
             readOnly: item.readOnly,
             value: true,
             filter: model,
+            textValue: '',
             menu: this.scope.attr('menu'),
             model_name: model.constructor.shortName
           });
@@ -83,10 +85,20 @@
       '.ui-autocomplete-input autocomplete:select': function (el, ev, data) {
         var index = el.data('index');
         var panel = this.scope.attr('relevant')[index];
+        var textValue = el.data('ggrc-autocomplete').term;
 
-        panel.attr('filter', data.item);
+        panel.attr('filter', data.item.attr());
         panel.attr('value', true);
+        panel.attr('textValue', textValue);
       },
+      '.ui-autocomplete-input input': function (el, ev, data) {
+        var index = el.data('index');
+        var panel = this.scope.attr('relevant')[index];
+
+        panel.attr('value', false);
+        panel.attr('textValue', el.val());
+      },
+
       '.remove_filter click': function (el) {
         this.scope.attr('relevant').splice(el.data('index'), 1);
       },

--- a/src/ggrc/assets/javascripts/components/unified-mapper/mapper-results.js
+++ b/src/ggrc/assets/javascripts/components/unified-mapper/mapper-results.js
@@ -161,6 +161,9 @@
         filters = relevantList.attr()
           .map(function (relevant) {
             if (!relevant.value || !relevant.filter) {
+              if (!relevant.textValue) {
+                return null;
+              }
               return {
                 type: relevant.model_name,
                 operation: 'relevant',
@@ -172,6 +175,8 @@
               operation: 'relevant',
               id: Number(relevant.filter.id)
             };
+          }).filter(function (v) {
+            return v !== null;
           });
         return filters;
       },


### PR DESCRIPTION
Steps to reproduce:
1. Open Search Unified mapper and click filter by mapping: preselected object is not displayed
2. Select object from dropdown list (e.g. Audit), enter text to search audit, then select audit from list and click search: results are displayed in search results
3. Delete audit title and click Search: search results are the same
4. Change audit title but don't select from dropdown list (type audit title): search results are the same
Expected result: 
1. If click Filter by mapping preselected object should display. In this case "Access Group" 
2. Search results should correspond according to selected title of the object