### PR TITLE
GGRC-1484 GGRC-1501 Remove create Relationship permission for Auditor

### DIFF
--- a/src/ggrc/assets/javascripts/pbc/workflow_controller.js
+++ b/src/ggrc/assets/javascripts/pbc/workflow_controller.js
@@ -26,8 +26,6 @@
             return this._create_relationship(instance, item);
           }.bind(this)) :
           [];
-        dfd.push(this._create_relationship(instance, instance.audit));
-        dfd.push(this._create_relationship(instance, instance.assessment));
         instance.delay_resolving_save_until($.when.apply($, dfd));
       }.bind(this));
     },

--- a/src/ggrc/assets/mustache/assessments/tree_add_item.mustache
+++ b/src/ggrc/assets/mustache/assessments/tree_add_item.mustache
@@ -6,7 +6,7 @@
 {{#if allow_mapping_or_creating}}
   {{#if_instance_of parent_instance 'Audit'}}
     {{#if allow_creating}}
-    {{#is_allowed_to_map parent_instance model.shortName}}
+    {{#is_allowed 'create' 'Assessment' context=parent_instance.context}}
       <a href="javascript://"
          class="section-create action-button create-button"
          rel="tooltip"
@@ -19,7 +19,7 @@
          data-object-plural="{{model.table_plural}}">
         Create
       </a>
-    {{/is_allowed_to_map}}
+    {{/is_allowed}}
     {{/if}}
   {{/if_instance_of}}
 {{/if}}

--- a/src/ggrc/models/hooks/assessment.py
+++ b/src/ggrc/models/hooks/assessment.py
@@ -14,6 +14,7 @@ from ggrc import db
 from ggrc.login import get_current_user_id
 from ggrc.models import all_models
 from ggrc.models import Assessment
+from ggrc.models import Issue
 from ggrc.models import Person
 from ggrc.models import Relationship
 from ggrc.models import Snapshot
@@ -37,8 +38,8 @@ def init_hook():
     for obj, src in izip(objects, sources):
       src_obj = src.get("object")
       audit = src.get("audit")
-      map_assessment(obj, src_obj)
-      map_assessment(obj, audit)
+      map_objects(obj, src_obj)
+      map_objects(obj, audit)
 
       if not src.get("_generated"):
         continue
@@ -60,25 +61,39 @@ def init_hook():
                                                      parent_title)
 
 
-def map_assessment(assessment, obj):
-  """Creates a relationship between an assessment and an object. This also
-  generates automappings. Fails silently if obj dict does not have id and type
+@Resource.collection_posted.connect_via(Issue)
+def handle_issue_post(sender, objects=None, sources=None):
+  # pylint: disable=unused-argument
+  """Map issue to audit. This makes sure an auditor is able to create
+  an issue on the audit without having permissions to create Relationships
+  in the context"""
+
+  for obj, src in izip(objects, sources):
+    audit = src.get("audit")
+    assessment = src.get("assessment")
+    map_objects(obj, audit)
+    map_objects(obj, assessment)
+
+
+def map_objects(src, dst):
+  """Creates a relationship between an src and dst. This also
+  generates automappings. Fails silently if dst dict does not have id and type
   keys.
 
   Args:
-    assessment (models.Assessment): The assessment model
-    obj (dict): A dict with `id` and `type`.
+    src (model): The src model
+    dst (dict): A dict with `id` and `type`.
   Returns:
     None
   """
-  obj = obj or {}
-  if 'id' not in obj or 'type' not in obj:
+  dst = dst or {}
+  if 'id' not in dst or 'type' not in dst:
     return
   rel = Relationship(**{
-      "source": assessment,
-      "destination_id": obj["id"],
-      "destination_type": obj["type"],
-      "context": assessment.context,
+      "source": src,
+      "destination_id": dst["id"],
+      "destination_type": dst["type"],
+      "context": src.context,
   })
   db.session.add(rel)
 

--- a/src/ggrc_basic_permissions/roles/Auditor.py
+++ b/src/ggrc_basic_permissions/roles/Auditor.py
@@ -27,7 +27,6 @@ permissions = {
         "Request",
         "Assessment",
         "Issue",
-        "Relationship",
         "Comment",
     ],
     "view_object_page": [


### PR DESCRIPTION
Auditor should not be able to create relationships in the audit
context. The only exceptions to this are the relationships that map
Issue/Assessment to the Audit, but those will be handled separately.

- [x] Make sure mapping assessments works after this change
- [x] Make sure mapping issues works after this change