### PR TITLE
GGRC-1318 Fix sending declined notifications to all Assessment roles

### DIFF
--- a/src/ggrc/notifications/data_handlers.py
+++ b/src/ggrc/notifications/data_handlers.py
@@ -122,8 +122,8 @@ def _get_declined_people(obj):
     return [person for person, role in obj.assignees
             if "Requester" in role]
   elif obj.type == "Assessment":
-    return [person for person, role in obj.assignees
-            if "Assessor" in role]
+    return [person for person, _ in obj.assignees]
+
   return []
 
 

--- a/test/integration/ggrc/notifications/test_data_handlers.py
+++ b/test/integration/ggrc/notifications/test_data_handlers.py
@@ -91,9 +91,13 @@ class TestAssessmentDataHandlers(TestCase):
     self.assertEqual(revisions, 1)
 
     declined_data = self._call_notif_handler(notif)
-    requester_emails = {"user1@example.com", }
+    expected_emails = {  # literally everybody assigned to an Assessment
+        "user1@example.com",
+        "user2@example.com",
+        "user3@example.com"
+    }
 
-    self.assertEqual(set(declined_data.keys()), requester_emails)
+    self.assertEqual(set(declined_data.keys()), expected_emails)
 
   def test_assessment_comments(self):
     """Test data handlers for comment to assessment"""


### PR DESCRIPTION
This PR makes sure that Assessment declined notifications are sent to all people assigned to an Assessment, not just to Assignees.

---

**Steps to reproduce:**
  1. Create assessment on the audit page 
  1. Make sure that creator, assignee and verifier exist in People list 
  1. Change assessment's states: complete, update, ready for review, reject, verify, reopen assessment 
  1. Add new Creator, Assignee, Verifier to assessment 

**Actual Result:**
New added Creator and Verifier don't get notification that assessment has been declined 

**Expected Result:**
Notification to be added when a new creator, assignee, verifier are added to assessment
