### PR TITLE
GGRC-1463  Multi select dropdown filter isn't applied in Unified mapper if state contains two words or more

### DIFF
--- a/src/ggrc/assets/javascripts/components/unified-mapper/mapper-toolbar.js
+++ b/src/ggrc/assets/javascripts/components/unified-mapper/mapper-toolbar.js
@@ -68,8 +68,8 @@
           });
 
           this.attr('dropdown_options', dropdownOptions);
-          this.attr('statusFilter',
-            GGRC.Utils.State.statusFilter(statuses, ''));
+          this.attr('statusFilter', GGRC.Utils.State
+            .statusFilter(statuses, '', this.attr('mapper.type')));
 
           this.attr('statuses', statuses);
         } else {
@@ -103,8 +103,8 @@
         });
         this.viewModel.attr('statuses', selectedStatuses);
 
-        this.viewModel.attr('statusFilter',
-          GGRC.Utils.State.statusFilter(selectedStatuses, ''));
+        this.viewModel.attr('statusFilter', GGRC.Utils.State.statusFilter(
+          selectedStatuses, '', this.viewModel.attr('mapper.type')));
         ev.stopPropagation();
       }
     }

--- a/src/ggrc/assets/javascripts/controllers/tree/tree-view.js
+++ b/src/ggrc/assets/javascripts/controllers/tree/tree-view.js
@@ -396,14 +396,11 @@
                 .find('.tree-filter__status-wrap');
               // set state filter (checkboxes)
               can.bind.call(statusControl.ready(function () {
-                var unwrappedStates = self.options.attr('selectStateList')
-                  .map(function (state) {
-                    return state.replace(/"/g, '');
-                  });
+                var selectStateList = self.options.attr('selectStateList');
 
-                var checkAll = unwrappedStates.length === 0;
+                var checkAll = selectStateList.length === 0;
                 self.options.attr('filter_states').forEach(function (item) {
-                  if (checkAll || unwrappedStates.indexOf(item.value) > -1) {
+                  if (checkAll || selectStateList.indexOf(item.value) > -1) {
                     item.attr('checked', true);
                   }
                 });
@@ -1160,10 +1157,8 @@
         return;
       }
 
-      selectedStates.forEach(function (state) {
-        // wrap in quotes
-        var value = '"' + state.value + '"';
-        stateToSave.push(value);
+      stateToSave = selectedStates.map(function (state) {
+        return state.value;
       });
 
       this.options.attr('selectStateList', stateToSave);

--- a/src/ggrc/assets/javascripts/plugins/tests/state-utils_spec.js
+++ b/src/ggrc/assets/javascripts/plugins/tests/state-utils_spec.js
@@ -10,7 +10,7 @@ describe('GGRC.Utils.State', function () {
     it('statusFilter() should return filter with all statuses',
       function () {
         var statuses = [
-          '"Draft"', '"Active"', '"Deprecated"'
+          'Draft', 'Active', 'Deprecated'
         ];
 
         var statesFilter = GGRC.Utils.State
@@ -28,7 +28,7 @@ describe('GGRC.Utils.State', function () {
     it('statesFilter should not update Assessmnet statuses',
       function () {
         var statuses = [
-          '"Not Started"', '"In Progress"', '"Ready for Review"'
+          'Not Started', 'In Progress', 'Ready for Review'
         ];
 
         var statesFilter = GGRC.Utils.State
@@ -48,7 +48,7 @@ describe('GGRC.Utils.State', function () {
     it('statesFilter should have "Completed" status and "verified=true"',
       function () {
         var statuses = [
-          '"Ready for Review"', '"Completed and Verified"'
+          'Ready for Review', 'Completed and Verified'
         ];
 
         var statesFilter = GGRC.Utils.State
@@ -69,7 +69,7 @@ describe('GGRC.Utils.State', function () {
     it('statesFilter should have "Completed" status and "verified=false"',
       function () {
         var statuses = [
-          '"Ready for Review"', '"Completed (no verification)"'
+          'Ready for Review', 'Completed (no verification)'
         ];
 
         var statesFilter = GGRC.Utils.State
@@ -91,8 +91,8 @@ describe('GGRC.Utils.State', function () {
     it('statesFilter should have "Completed" status',
       function () {
         var statuses = [
-          '"In Progress"', '"Completed (no verification)"',
-          '"Completed and Verified"'
+          'In Progress', 'Completed (no verification)',
+          'Completed and Verified'
         ];
 
         var statesFilter = GGRC.Utils.State

--- a/src/ggrc/assets/javascripts/plugins/utils/state-utils.js
+++ b/src/ggrc/assets/javascripts/plugins/utils/state-utils.js
@@ -121,7 +121,8 @@
      */
     function buildStatusesFilterString(statuses) {
       return statuses.map(function (item) {
-        return 'Status=' + item;
+        // wrap in quotes
+        return 'Status="' + item + '"';
       }).join(' Or ');
     }
 
@@ -131,9 +132,8 @@
      * @return {String} statuses filter
      */
     function buildAssessmentFilter(statuses) {
-      // statuses wrapped in quotes
-      var verifiedIndex = statuses.indexOf('"Completed and Verified"');
-      var completedIndex = statuses.indexOf('"Completed (no verification)"');
+      var verifiedIndex = statuses.indexOf('Completed and Verified');
+      var completedIndex = statuses.indexOf('Completed (no verification)');
       var isVerified = false;
       var filter;
 
@@ -148,7 +148,7 @@
       if (verifiedIndex > -1 && completedIndex > -1) {
         // server doesn't know about "Completed (no verification)"
         // we replace it with "Completed"
-        statuses.splice(completedIndex, 1, '"Completed"');
+        statuses.splice(completedIndex, 1, 'Completed');
 
         // database doesn't have "Verified" status
         // remove it
@@ -158,11 +158,11 @@
       }
 
       if (completedIndex > -1 && verifiedIndex === -1) {
-        statuses.splice(completedIndex, 1, '"Completed"');
+        statuses.splice(completedIndex, 1, 'Completed');
       } else if (verifiedIndex > -1 && completedIndex === -1) {
         isVerified = true;
         statuses.splice(verifiedIndex, 1);
-        statuses.push('"Completed"');
+        statuses.push('Completed');
       }
 
       filter = buildStatusesFilterString(statuses);
@@ -178,7 +178,7 @@
       var states = [];
 
       if (GGRC.Utils.CurrentPage.isMyAssessments()) {
-        states = ['"Not Started"', '"In Progress"'];
+        states = ['Not Started', 'In Progress'];
       }
 
       return states;


### PR DESCRIPTION
**Steps to reproduce:**
1. Open Search Unified mapper
2. Select "Assessment" in object type
3. Apply filter by "In progress" or "Not Started"> Search: no results
4. Apply filter by "Completed"> Search: works

_Actual Results_: Multi select dropdown filter is not applied in Unified mapper if state contains two words or more
_Expected Result_: Multi select dropdown filter should be applied in Unified mapper if state contains two words or more
