### PR TITLE
GGRC-1347 Change style of pie-chart

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/summary_widget_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/summary_widget_controller.js
@@ -167,8 +167,8 @@
 
       chartOptions.attr('legend', legendData);
 
-      this.element.find('#piechart_audit_assessments_chart-legend')
-        .on('mouseenter', 'li', function () {
+      this.element.find('#piechart_audit_assessments_chart-legend tbody')
+        .on('mouseenter', 'tr', function () {
           var $el = $(this);
           var rowIndex = $el.data('row-index');
 
@@ -176,7 +176,7 @@
             chart.setSelection([{row: rowIndex, column: null}]);
           }
         })
-        .on('mouseleave', 'li', function () {
+        .on('mouseleave', 'tr', function () {
           chart.setSelection(null);
         });
     },

--- a/src/ggrc/assets/mustache/audits/summary.mustache
+++ b/src/ggrc/assets/mustache/audits/summary.mustache
@@ -36,7 +36,7 @@
                     {{#instance}}
                         <div class="row-fluid">
                             <div class="span3 title">
-                                <h3>Assessments {{#if charts.Assessment.any}}({{charts.Assessment.total}}){{/if}}</h3>
+                                <h3>Assessments</h3>
                             </div>
                         </div>
                     {{/instance}}
@@ -49,13 +49,48 @@
                 <div class="span6 legend {{#if_helpers '\
                                             ^if' charts.Assessment.isLoaded '\
                                             or #if' charts.Assessment.none}}hidden{{/if_helpers}}">
-                  <ul id="piechart_audit_assessments_chart-legend">
-                  {{#each charts.Assessment.legend}}
-                    <li data-row-index="{{rowIndex}}">
-                      <i class="fa fa-circle" style="color: {{color}}"></i>{{title}} <span>{{count}} ({{percent}} %)</span>
-                    </li>
-                  {{/each}}
-                  </ul>
+                  <table id="piechart_audit_assessments_chart-legend" class="piechart-legend">
+                    <thead>
+                      <tr>
+                        <th>
+                          State
+                        </th>
+                        <th>
+                          Count
+                        </th>
+                        <th>
+                          Percent
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {{#each charts.Assessment.legend}}
+                        <tr data-row-index="{{rowIndex}}">
+                          <td style="color: {{color}}">
+                            <i class="fa fa-circle"></i> {{title}}
+                          </td>
+                          <td>
+                            {{count}}
+                          </td>
+                          <td>
+                            {{percent}} %
+                          </td>
+                        </tr>
+                      {{/each}}
+                    <tbody>
+                    <tfoot>
+                      <tr>
+                        <td>
+                          Total
+                        </td>
+                        <td>
+                          {{charts.Assessment.total}}
+                        </td>
+                        <td>
+                        </td>
+                      </tr>
+                    </tfoot>
+                  </table>
                 </div>
                 {{#if charts.Assessment.isLoading}}
                     <div class="span12 centered">

--- a/src/ggrc/assets/stylesheets/modules/_audit-summary.scss
+++ b/src/ggrc/assets/stylesheets/modules/_audit-summary.scss
@@ -8,25 +8,42 @@
   .legend {
     position: relative;
     min-height: 300px;
-    ul {
+    table {
       position: absolute;
-      top: 25%;
+      top: 9%;
       list-style: none;
       text-align: left;
       min-width: 300px;
       font-size: 14px;
 
-      li {
-        padding-bottom: 5px;
+      th {
+        text-transform: uppercase;
       }
 
-      i {
-        padding-right: 5px;
+      td,
+      th {
+        padding-bottom: 16px;
+        padding-left: 30px;
+        text-align: right;
+
+        &:first-child {
+          text-align: left;
+          padding-left: 0;
+        }
+
+        i {
+          padding-right: 2px;
+          font-size: 9px;
+          vertical-align: 2px;
+        }
       }
 
-      span {
-        color: $grayLight;
-        float: right;
+      tfoot {
+        border-top: 1px solid $warmGray;
+        td {
+          padding-top: 16px;
+          font-weight: bold;
+        }
       }
     }
   }


### PR DESCRIPTION
The following improvements have been confirmed:
1. Assessments are show without numbers in brackets
2. Three columns: state, count, percent
3. Total:
![image](https://cloud.githubusercontent.com/assets/567805/24045419/1545d7b8-0b30-11e7-91b4-f80bf2dccbbd.png)
