### PR TITLE
GGRC-1376 Default Verifier does not required 

### DIFF
--- a/src/ggrc/models/assessment_template.py
+++ b/src/ggrc/models/assessment_template.py
@@ -76,7 +76,7 @@ class AssessmentTemplate(assessment.AuditRelationship, relationship.Relatable,
       },
       "default_verifier": {
           "display_name": "Default Verifier",
-          "mandatory": True,
+          "mandatory": False,
           "filter_by": "_nop_filter",
       },
       "default_test_plan": {

--- a/test/integration/ggrc/converters/test_import_helpers.py
+++ b/test/integration/ggrc/converters/test_import_helpers.py
@@ -359,7 +359,6 @@ class TestGetObjectColumnDefinitions(TestCase):
             "Audit",
             "Code",
             "Default Assessors",
-            "Default Verifier",
         },
         "unique": {
             "Code",


### PR DESCRIPTION
This filed shouldn't be mandatory on import and export actions to Assessment Template