### PR TITLE
GGRC-1487 Fix script error when create assessment button is clicked

### DIFF
--- a/src/ggrc/assets/javascripts/models/assessment.js
+++ b/src/ggrc/assets/javascripts/models/assessment.js
@@ -258,11 +258,10 @@
     before_create: function (dfd) {
       if (!this.audit) {
         throw new Error('Cannot save assessment, audit not set.');
-      } else if (!this.audit.program || !this.audit.context) {
+      } else if (!this.audit.context) {
         throw new Error(
-          'Cannot save assessment, audit context or program not set.');
+          'Cannot save assessment, audit context not set.');
       }
-      this.attr('program', this.attr('audit.program'));
       this.attr('context', this.attr('audit.context'));
     },
     after_save: function () {

--- a/src/ggrc/assets/javascripts/models/tests/assessment_model_spec.js
+++ b/src/ggrc/assets/javascripts/models/tests/assessment_model_spec.js
@@ -25,7 +25,6 @@ describe('CMS.Models.Assessment', function () {
       assessment.attr('audit', audit);
       assessment.before_create();
       expect(assessment.context.id).toEqual(context.id);
-      expect(assessment.program.id).toEqual(program.id);
     });
 
     it('throws an error if audit is not defined', function () {
@@ -39,7 +38,7 @@ describe('CMS.Models.Assessment', function () {
       expect(function () {
         assessment.before_create();
       }).toThrow(new Error(
-        'Cannot save assessment, audit context or program not set.'));
+        'Cannot save assessment, audit context not set.'));
     });
   });
 


### PR DESCRIPTION
Steps to reproduce:

1. As auditor go to the issues tab and open an issue info pane.
2. After step 1, anytime you click the create assessment button, a script error is thrown.

Auditor does not have access to the program so the program property on
the audit might not be set. Because we do not map assessments to
programs anymore it’s safe to just remove the check and prevent
assigning the program variable on the assessment.