### PR TITLE
GGRC-1203 Fix a copy-paste issue

### DIFF
--- a/src/ggrc/services/relationship_resource.py
+++ b/src/ggrc/services/relationship_resource.py
@@ -39,7 +39,7 @@ class RelationshipResource(ggrc.services.common.Resource):
     if src["source"]["type"] in snapshot_rules.Types.parents:
       parent, child = src["source"], src["destination"]
     elif src["destination"]["type"] in snapshot_rules.Types.parents:
-      parent, child = src["source"], src["destination"]
+      parent, child = src["destination"], src["source"]
 
     is_snapshot = bool(parent) and child["type"] in snapshot_rules.Types.all
     return parent, child, is_snapshot

--- a/test/integration/ggrc/snapshotter/test_snapshoting.py
+++ b/test/integration/ggrc/snapshotter/test_snapshoting.py
@@ -705,7 +705,7 @@ class TestSnapshoting(SnapshotterBaseTestCase):
         models.Audit.title.like("%Snapshotable audit%")).one()
 
     self.create_mapping(audit, objective)
-    self.create_mapping(audit, control)
+    self.create_mapping(control, audit)  # different direction than above
 
     objective_snapshot = db.session.query(models.Snapshot).filter(
         models.Snapshot.child_type == "Objective",


### PR DESCRIPTION
This PR fixes a typo that breaks Snapshot generation on Audit-Snapshottable Relationship POST when `source` is Snapshottable and `destination` is Audit.

Steps to reproduce:
1. Create a Control.
2. Create a Program.
3. Create two Audits in the Program.
4. Open a tree view with the Control, click "map" button on it.
5. Select both Audits in the unified mapper, click "map".

Expected result: the Control is mapped to the Program, Snapshots of the Control are created in both Audits.
Actual result: the Control is mapped to the Audits directly.