### PR TITLE
GGRC-1525 (GGRC-1503) Fix notification in active cycles tab

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/tree/tree-view.js
+++ b/src/ggrc/assets/javascripts/controllers/tree/tree-view.js
@@ -859,11 +859,7 @@
     },
     update_header: function () {
       var treeFilter;
-      var filterHeight;
-      var headerHeight;
-      var parentWidth;
       var headerContentHeight;
-      var treeHeaderContent;
       var elementParent;
 
       if (!this.element || !this.element.parent) {
@@ -871,25 +867,15 @@
       }
 
       elementParent = this.element.parent();
-      treeFilter = elementParent.find('.tree-filter');
+      treeFilter = elementParent.find('.tree-header-content');
 
       if (treeFilter.length === 0) {
         return;
       }
 
-      filterHeight = Number(treeFilter.attr('data-height')) +
-        Number(treeFilter.attr('data-margin-bottom'));
-      headerHeight = elementParent.find('.tree-header').height();
-      parentWidth = elementParent.width();
-      headerContentHeight = filterHeight + headerHeight;
-      treeHeaderContent = elementParent.find('.tree-header-content');
+      headerContentHeight = treeFilter.height();
 
       this.element.css('margin-top', headerContentHeight);
-
-      if (treeHeaderContent) {
-        treeHeaderContent.css('width', parentWidth);
-        treeHeaderContent.height(headerContentHeight);
-      }
     },
     draw_items: function (optionsList) {
       var items;

--- a/src/ggrc/assets/mustache/base_objects/tree_view_filter.mustache
+++ b/src/ggrc/assets/mustache/base_objects/tree_view_filter.mustache
@@ -3,9 +3,7 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
 
-  <div class="tree-filter tree-filter_paging"
-       data-height="42"
-       data-margin-bottom="25">
+  <div class="tree-filter tree-filter_paging">
     <div class="sticky-filter inner-filter-sticky">
       <div class="tree-filter__inline-filtering clearfix" {{ (el) -> el.ggrc_controllers_tree_filter() }} >
 
@@ -29,7 +27,7 @@
           </div>
           <div class="tree-filter__status-wrap">
             {{#if statusFilterVisible}}
-            <multiselect-dropdown 
+            <multiselect-dropdown
               {options}="filter_states"
               placeholder="Filter by State",
               plural="States">

--- a/src/ggrc/assets/stylesheets/modules/_tree-header.scss
+++ b/src/ggrc/assets/stylesheets/modules/_tree-header.scss
@@ -61,13 +61,16 @@
   .header {
     &.tree-header-content {
       position: absolute;
-      z-index: 1; 
+      z-index: 1;
       background-color: $contentBgnd;
       margin: -20px -40px 0px -40px;
       padding-left: 40px;
       padding-right: 40px;
       border-top: solid $contentBgnd;
       border-width: 20px;
+      width: 100%;
+      box-sizing: border-box;
+      height: auto;
     }
     &.tree-header {
       padding: 0 12px 0 70px;

--- a/src/ggrc_workflows/assets/mustache/cycles/tree_header.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycles/tree_header.mustache
@@ -35,24 +35,24 @@
       </div>
     </div>
   </header>
+
+  {{^if_equals mapping 'previous_cycles'}}
+    {{#using workflow=parent_instance}}
+      {{#workflow.next_cycle_start_date}}
+        {{^if_equals workflow.frequency 'one_time'}}
+          {{#if_equals workflow.status 'Active'}}
+            <div class="filters">
+              <div class="alert" style="border-radius: 0px; margin-bottom: 0px;">
+                <button type="button" class="close" data-dismiss="alert">
+                  <span aria-hidden="true">&times;</span>
+                </button>
+                <strong>Note:</strong> Next cycle of this recurring workflow is scheduled to be activated on <strong>{{localize_date workflow.next_cycle_start_date}}</strong>.
+              </div>
+            </div>
+          {{/if_equals workflow.status 'Active'}}
+        {{/if_equals}}
+      {{/workflow.next_cycle_start_date}}
+    {{/using}}
+  {{/if_equals}}
 </div>
 <div class="clearfix"></div>
-
-{{^if_equals mapping 'previous_cycles'}}
-{{#using workflow=parent_instance}}
-{{#workflow.next_cycle_start_date}}
-{{^if_equals workflow.frequency 'one_time'}}
-{{#if_equals workflow.status 'Active'}}
-  <div class="filters">
-    <div class="alert" style="border-radius: 0px; margin-bottom: 0px;">
-      <button type="button" class="close" data-dismiss="alert">
-        <span aria-hidden="true">&times;</span>
-      </button>
-      <strong>Note:</strong> Next cycle of this recurring workflow is scheduled to be activated on <strong>{{localize_date workflow.next_cycle_start_date}}</strong>.
-    </div>
-  </div>
-{{/if_equals workflow.status 'Active'}}
-{{/if_equals}}
-{{/workflow.next_cycle_start_date}}
-{{/using}}
-{{/if_equals}}

--- a/src/ggrc_workflows/assets/mustache/cycles/tree_header.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycles/tree_header.mustache
@@ -42,7 +42,7 @@
         {{^if_equals workflow.frequency 'one_time'}}
           {{#if_equals workflow.status 'Active'}}
             <div class="filters">
-              <div class="alert" style="border-radius: 0px; margin-bottom: 0px;">
+              <div class="alert" style="border-radius: 0px;">
                 <button type="button" class="close" data-dismiss="alert">
                   <span aria-hidden="true">&times;</span>
                 </button>


### PR DESCRIPTION
The PR fixes **GGRC-1525**, **GGRC-1503**

**GGRC-1525**
**User doesn't get notification in Active Cycles that active workflow will start in future**

**Steps to reproduce**:
1. Create weekly WF
2. Create task and set start date in future (e.g. if today Monday - set Wednesday - Friday)
3. Activate workflow and go to Active Cycles tab

**Actual Result**: User doesn't get notification in Active Cycles that active workflow will start in future

**Expected Result**: User should get notification in Active Cycles that active workflow will start in future

![image](https://cloud.githubusercontent.com/assets/567805/24143315/5f779efe-0e3a-11e7-909c-064d6651a1db.png)


**GGRC-1503**
**Tree view collapses if open audit widget**

Steps to reproduce:
1. As admin go to My work page
2. Open All objects page
3. Open Audit widget
Actual Result: Tree view collapses if open audit widget
Expected Result: Tree view should not collapse if open audit widget

![image](https://cloud.githubusercontent.com/assets/567805/24153220/e5ce7634-0e5e-11e7-8bfb-72b02f62603b.png)

