### PR TITLE
GGRC-1375/GGRC-1377 "Default Verifier" field marked as mandatory in New Assessment template modal window

### DIFF
--- a/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
@@ -156,7 +156,6 @@
           <div class="span6 bottom-spacing">
             <label>
               Default Verifier
-              <span class="required">*</span>
             </label>
 
             <dropdown

--- a/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
@@ -163,6 +163,7 @@
               options-list="instance.people_values"
               name="instance.default_people.verifiers"
               on-change="instance.defaultVerifiersChanged"
+              no-value="true"
             ></dropdown>
           </div>
 

--- a/src/ggrc/models/assessment_template.py
+++ b/src/ggrc/models/assessment_template.py
@@ -29,7 +29,7 @@ class AssessmentTemplate(assessment.AuditRelationship, relationship.Relatable,
   object.
   """
   __tablename__ = "assessment_templates"
-  _mandatory_default_people = ("assessors", "verifiers")
+  _mandatory_default_people = ("assessors",)
 
   PER_OBJECT_CUSTOM_ATTRIBUTABLE = True
 


### PR DESCRIPTION
**GGRC-1375 "Default Verifier" field marked as mandatory in New Assessment template modal window**

_Steps to reproduce:_
1. On the audit page invoke New Assessment template modal window
2. Look at the "Default Verifier" field

_Actual Result_: "Default Verifier" field marked as mandatory in New Assessment template modal window
_Expected Result_: "Default Verifier" field should not marked as mandatory in New Assessment template modal window

![screenshot-1](https://cloud.githubusercontent.com/assets/4204416/24145265/6be7dd82-0e41-11e7-88d4-92bf5416b8b5.png)

 
**GGRC-1377 Allow "Default Verifier" field be empty in New Assessment template modal window**

_Steps to reproduce:_
1. On the audit page invoke New Assessment template modal window
2. Expand dropdown for the "Default Verifier" field: confirm it cannot be empty

_Actual Result_: the "Default Verifier" field cannot be empty in New Assessment template modal window
_Expected Result_: Should be allowed the "Default Verifier" field be empty  in New Assessment template modal window.

![screenshot-1 1](https://cloud.githubusercontent.com/assets/4204416/24145288/95639b56-0e41-11e7-87ce-88822e233029.png)


**NOTE:** This PR is related to PR #5382 and should be merged after it.
