### PR TITLE
GGRC-1324 Improve dropdown multi select filter

### DIFF
--- a/src/ggrc/assets/mustache/components/dropdown/multiselect_dropdown.mustache
+++ b/src/ggrc/assets/mustache/components/dropdown/multiselect_dropdown.mustache
@@ -4,11 +4,12 @@
 }}
 
 <div class="multiselect-dropdown flex-box flex-col">
-  <div class="multiselect-dropdown__input-container" ($click)="openDropdown($element, %event)"> 
+  <!-- HACK: using of tabindex can set styles on focus -->
+  <div tabindex="-1" class="multiselect-dropdown__input-container" ($click)="openDropdown($element, %event)">
     <input 
       type="text"
       readonly="readonly" 
-      class="multiselect-dropdown__input" 
+      class="multiselect-dropdown__input {{#if isOpen}}dropdown-focus{{/if}}" 
       placeholder="{{placeholder}}" 
       value="{{_displayValue}}"/>
     <span class="multiselect-dropdown__icon">

--- a/src/ggrc/assets/stylesheets/components/multiselect-dropdown/_multiselect-dropdown.scss
+++ b/src/ggrc/assets/stylesheets/components/multiselect-dropdown/_multiselect-dropdown.scss
@@ -4,6 +4,13 @@
  */
 
 .multiselect-dropdown {
+  .dropdown-focus {
+    outline-color: rgb(59, 153, 252);
+    outline-offset: -2px;
+    outline-style: auto;
+    outline-width: 5px;
+  }
+
   input.multiselect-dropdown__input {
     width: 100%;
     padding: 4px 24px 4px 8px;
@@ -16,6 +23,17 @@
     user-select: none;
     text-overflow: ellipsis;
     background-color: white;
+    border-radius: 5px;
+    color: rgb(85, 85, 85);
+    font-size: 12px;
+
+    &:focus {
+      @extend .dropdown-focus;
+     }
+  }
+
+  input.multiselect-dropdown__input::-webkit-input-placeholder{
+    color: #969696;
   }
 
   label.multiselect-dropdown__label {
@@ -43,7 +61,7 @@
       z-index: 2000;
       float: none;
       display: block;
-      border-radius: 0;
+      border-radius: 5px;
     }
 
     &__body-wrapper {
@@ -79,6 +97,10 @@
       cursor: pointer;
       line-height: 28px;
       position: relative;
+
+      &:focus {
+        @extend .dropdown-focus;
+      }
     }
   }
 }

--- a/src/ggrc/assets/stylesheets/modules/_filters.scss
+++ b/src/ggrc/assets/stylesheets/modules/_filters.scss
@@ -112,7 +112,7 @@
   &__button-wrap {
     width: 164px;
     float:left;
-    margin-right: 20px;
+    margin-right: 30px;
   }
   &__button {
     @extend %clearfix;


### PR DESCRIPTION
As discussed with Kseniya Koltun the ticket is reopened due to the following:
1. Filter by State: should be 12 font size, #969696.
2. Padding between question icon and Filter by state should be 30.
3. Filter by state in Unified mapper should be with rounded corners.
4. Filter in blue button - should be regular weight.
5. If click Filter by state blue line around the filter is shown. Should be the same in Unified mapper.

![screenshot-7](https://cloud.githubusercontent.com/assets/4204416/24190296/560f09a0-0ef9-11e7-8d3e-286e336a2ea5.png)

**NOTE**: Point #4 is not implemented, because we need to discuss this with Kseniya
