### PR TITLE
GGRC-1573 Add status label for archived WF

### DIFF
--- a/src/ggrc/assets/stylesheets/_common.scss
+++ b/src/ggrc/assets/stylesheets/_common.scss
@@ -741,7 +741,8 @@ p {
   &.state-notstarted,
   &.state-draft,
   &.state-assigned,
-  &.state-planned {
+  &.state-planned,
+  &.state-archived {
     background: $status-draft;
   }
   &.state-inprogress {

--- a/src/ggrc_workflows/assets/mustache/cycles/tree_header.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycles/tree_header.mustache
@@ -41,14 +41,16 @@
       {{#workflow.next_cycle_start_date}}
         {{^if_equals workflow.frequency 'one_time'}}
           {{#if_equals workflow.status 'Active'}}
-            <div class="filters">
-              <div class="alert" style="border-radius: 0px;">
-                <button type="button" class="close" data-dismiss="alert">
-                  <span aria-hidden="true">&times;</span>
-                </button>
-                <strong>Note:</strong> Next cycle of this recurring workflow is scheduled to be activated on <strong>{{localize_date workflow.next_cycle_start_date}}</strong>.
+            {{#if workflow.recurrences}}
+              <div class="filters">
+                <div class="alert" style="border-radius: 0px;">
+                  <button type="button" class="close" data-dismiss="alert">
+                    <span aria-hidden="true">&times;</span>
+                  </button>
+                  <strong>Note:</strong> Next cycle of this recurring workflow is scheduled to be activated on <strong>{{localize_date workflow.next_cycle_start_date}}</strong>.
+                </div>
               </div>
-            </div>
+            {{/if}}
           {{/if_equals workflow.status 'Active'}}
         {{/if_equals}}
       {{/workflow.next_cycle_start_date}}

--- a/src/ggrc_workflows/assets/mustache/workflows/info.mustache
+++ b/src/ggrc_workflows/assets/mustache/workflows/info.mustache
@@ -104,6 +104,13 @@
             <h6>Title</h6>
             <h3>{{title}}</h3>
             <span class="state-value {{addclass 'state-' status separator=''}}">{{status}}</span>
+            {{#instance.next_cycle_start_date}}
+              {{^if_equals instance.frequency 'one_time'}}
+                {{^if instance.recurrences}}
+                  <span class="state-value state-archived">Archived</span>
+                {{/if}}
+              {{/if_equals}}
+            {{/instance.next_cycle_start_date}}
             {{#if type}}
             <p>
               {{type.title}}


### PR DESCRIPTION
**Archived WF displayed as active**

1. Create annual WF
2. Set start date in future
3. Archive WF

**Excepted**:
a. WF status displayed as Archived not as Active
b. Notification message at active tab shouldn't be displayed

![image](https://cloud.githubusercontent.com/assets/567805/24193081/139f4982-0f02-11e7-8c98-ffd3d52689a6.png)

![image](https://cloud.githubusercontent.com/assets/567805/24193101/201374ea-0f02-11e7-8e1d-d14521eb9b98.png)

