### PR TITLE
GGRC-1495 Move assignees to contacts in the control popup

### DIFF
--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -372,6 +372,8 @@ dashboard-js-template-files:
   - contracts/modal_content.mustache
   - controls/categories_tree.mustache
   - controls/info.mustache
+  - controls/contacts.mustache
+  - controls/urls.mustache
   - controls/list_popover.mustache
   - controls/modal_content.mustache
   - controls/object_list.mustache

--- a/src/ggrc/assets/mustache/controls/contacts.mustache
+++ b/src/ggrc/assets/mustache/controls/contacts.mustache
@@ -1,0 +1,105 @@
+{{!
+    Copyright (C) 2017 Google Inc.
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+}}
+
+{{#instance}}
+<div class="row-fluid wrap-row">
+  <div data-test-id="title_manager_7a906d2e" class="span4">
+    {{#if is_program}}
+    <h6>Manager</h6>
+    <p class="oneline">
+      {{#with_mapping 'authorizations' instance}}
+        {{#if authorizations.length}}
+          {{#each authorizations}}
+            <span>
+              {{#using role=instance.role}}
+                {{#if_equals role.name 'ProgramOwner'}}
+                  {{#using contact=instance.person}}
+                    {{{renderLive '/static/mustache/people/popover.mustache' person=contact}}}
+                  {{/using}}
+                {{/if_equals}}
+              {{/using}}
+            </span>
+          {{/each}}
+        {{else}}
+          <span class="empty-message">None</span>
+        {{/if}}
+      {{/with_mapping}}
+    {{else}}
+    <h6>Owner</h6>
+    <p class="oneline">
+      {{#if owners.length}}
+        {{#using contacts=owners}}
+        <ul class="inner-count-list">
+          {{#each contacts}}
+            <li>
+              {{#using person=this}}
+                {{>'/static/mustache/people/popover.mustache'}}
+              {{/using}}
+            </li>
+          {{/each}}
+        </ul>
+        {{/using}}
+      {{else}}
+        <span class="empty-message">None</span>
+      {{/if}}
+    {{/if}}
+    </p>
+  </div>
+  <div class="span4">
+    {{#using person=contact}}
+      <div class="bottom-space">
+        <h6>Primary Contact</h6>
+        <p data-test-id="text_primary_contact_696de7244b84" class="oneline">
+          {{#if person}}
+            {{>'/static/mustache/people/popover.mustache'}}
+          {{else}}
+            <span data-test-id="text_primary_contact_696de7244b84" class="empty-message">None</span>
+          {{/if}}
+        </p>
+      </div>
+    {{/using}}
+    {{#using assessor=instance.principal_assessor}}
+      <div class="bottom-space">
+        <h6>Principal Assignee</h6>
+        {{#if instance.principal_assessor}}
+          <p class="oneline">
+            {{{render '/static/mustache/people/popover.mustache' person=assessor}}}
+          </p>
+        {{else}}
+          <span class="empty-message">None</span>
+        {{/if}}
+      </div>
+    {{/using}}
+    {{#using person=secondary_contact}}
+      <div class="bottom-space">
+        <h6>Secondary Contact</h6>
+        <p data-test-id="text_secondary_contact_696de7244b84" class="oneline">
+          {{#if person}}
+            {{>'/static/mustache/people/popover.mustache'}}
+          {{else}}
+            <span data-test-id="text_secondary_contact_696de7244b84" class="empty-message">None</span>
+          {{/if}}
+        </p>
+      </div>
+    {{/using}}
+    {{#using assessor=instance.secondary_assessor}}
+      <!--<div class="bottom-space">-->
+      <div>
+        <h6>Secondary Assignee</h6>
+        {{#if instance.secondary_assessor}}
+          <p class="oneline">
+            {{{render '/static/mustache/people/popover.mustache' person=assessor}}}
+          </p>
+        {{else}}
+          <span class="empty-message">None</span>
+        {{/if}}
+      </div>
+    {{/using}}
+  </div>
+  <div class="span4">
+    {{>'/static/mustache/controls/urls.mustache'}}
+  </div>
+</div>
+{{/instance}}

--- a/src/ggrc/assets/mustache/controls/info.mustache
+++ b/src/ggrc/assets/mustache/controls/info.mustache
@@ -17,8 +17,7 @@
       {{>'/static/mustache/base_objects/description.mustache'}}
       {{>'/static/mustache/base_objects/test_plan.mustache'}}
       {{>'/static/mustache/base_objects/notes.mustache'}}
-      {{>'/static/mustache/base_objects/contacts.mustache'}}
-      {{>'/static/mustache/base_objects/urls.mustache'}}
+      {{>'/static/mustache/controls/contacts.mustache'}}
 
       <div class="custom-attr-wrap">
         <div class="row-fluid">
@@ -40,39 +39,13 @@
         </div>
         <div class="hidden-fields-area">
           <div class="row-fluid wrap-row">
-            <div class="span3">
+            <div class="span4">
               <h6>Code</h6>
               <p>
                 {{slug}}
               </p>
             </div>
-            <div class="span3">
-              <h6>Principal Assignee</h6>
-              {{#using assessor=instance.principal_assessor}}
-              {{#if instance.principal_assessor}}
-                <p>
-                  {{{render '/static/mustache/people/popover.mustache' person=assessor}}}
-                </p>
-              {{else}}
-                <span class="empty-message">None</span>
-              {{/if}}
-              {{/using}}
-            </div>
-            <div class="span3">
-              <h6>Secondary Assignee</h6>
-              {{#using assessor=instance.secondary_assessor}}
-              {{#if instance.secondary_assessor}}
-                <p>
-                  {{{render '/static/mustache/people/popover.mustache' person=assessor}}}
-                </p>
-              {{else}}
-                <span class="empty-message">None</span>
-              {{/if}}
-              {{/using}}
-            </div>
-          </div>
-          <div class="row-fluid wrap-row">
-            <div class="span3">
+            <div class="span4">
               <h6>Kind/Nature</h6>
               {{#if kind}}
                 <p>
@@ -84,7 +57,7 @@
                 <span class="empty-message">None</span>
               {{/if}}
             </div>
-            <div class="span3">
+            <div class="span4">
               <h6>Fraud Related</h6>
               <p>
                 {{#if_equals fraud_related "0"}}
@@ -100,7 +73,9 @@
                 {{/if}}
               </p>
             </div>
-            <div class="span3">
+          </div>
+          <div class="row-fluid wrap-row">
+            <div class="span8">
               <h6>Significance</h6>
               <p>
                 {{#if_equals key_control "1"}}
@@ -116,7 +91,7 @@
                 {{/if}}
               </p>
             </div>
-            <div class="span3">
+            <div class="span4">
               <h6>Type/Means</h6>
               {{#if means}}
                 <p>
@@ -130,7 +105,7 @@
             </div>
           </div>
           <div class="row-fluid wrap-row">
-            <div class="span3">
+            <div class="span4">
               <h6>Effective Date</h6>
               {{#if start_date}}
                 <p>
@@ -140,7 +115,7 @@
                 <span class="empty-message">None</span>
               {{/if}}
             </div>
-            <div class="span3">
+            <div class="span4">
               <h6>Stop Date</h6>
               {{#if end_date}}
                 <p>
@@ -150,7 +125,7 @@
                 <span class="empty-message">None</span>
               {{/if}}
             </div>
-            <div class="span3">
+            <div class="span4">
               <h6>Frequency</h6>
               {{#if verify_frequency}}
                 <p>
@@ -164,7 +139,7 @@
             </div>
           </div>
           <div class="row-fluid wrap-row">
-            <div class="span6">
+            <div class="span8">
               <h6>Assertions</h6>
               {{#using items=assertions}}
               {{#if assertions}}
@@ -178,7 +153,7 @@
               {{/if}}
               {{/using}}
             </div>
-            <div class="span6">
+            <div class="span4">
               <h6>Categories</h6>
               {{#using items=categories}}
               {{#if categories}}

--- a/src/ggrc/assets/mustache/controls/urls.mustache
+++ b/src/ggrc/assets/mustache/controls/urls.mustache
@@ -1,0 +1,34 @@
+{{!
+    Copyright (C) 2017 Google Inc.
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+}}
+
+{{#instance}}
+  <div data-test-id="title_program_url_aa7d1a65" class="bottom-space">
+    <h6>
+      {{firstnonempty constructor.title_singular}}
+      URL
+    </h6>
+    <p>
+      {{#if url}}
+        <a data-test-id="text_program_url_aa7d1a65" class="url" href="{{schemed_url url}}" target="_blank">
+          {{url}}
+        </a>
+      {{else}}
+        <span class="empty-message">None</span>
+      {{/if}}
+    </p>
+  </div>
+  <div data-test-id="title_reference_url_aa7d1a65">
+    <h6>Reference URL</h6>
+    <p>
+      {{#if reference_url}}
+        <a data-test-id="text_reference_url_aa7d1a65" class="url" href="{{schemed_url reference_url}}" target="_blank">
+          {{reference_url}}
+        </a>
+      {{else}}
+        <span class="empty-message">None</span>
+      {{/if}}
+    </p>
+  </div>
+{{/instance}}


### PR DESCRIPTION
**Comment by User:**
_Can we move:_
1) "Principle Assignee" to the spot of "Primary Contact", and
2) "Secondary Assignee" to the spot of "Secondary Contact"?

Since we are using control "owner" field in a different way now and will be named "admin". It would be more useful to see the principle and secondary assignees in the main popup window instead of having to click "show advanced" button. The principal assignee being the real world control owner, and secondary assignee being the real world control oversight owner.

![screenshot-1](https://cloud.githubusercontent.com/assets/4204416/24196189/cde26b3e-0f0d-11e7-935a-9b8cf8a8b772.png)
