### PR TITLE
GGRC-921-additional Unbind event from pie chart legend

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/summary_widget_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/summary_widget_controller.js
@@ -168,6 +168,7 @@
       chartOptions.attr('legend', legendData);
 
       this.element.find('#piechart_audit_assessments_chart-legend tbody')
+        .off('mouseenter', 'tr')
         .on('mouseenter', 'tr', function () {
           var $el = $(this);
           var rowIndex = $el.data('row-index');


### PR DESCRIPTION
**"Script error" message is displayed while moving to the audit page**

**Precondition**: 
Create program, control, audit, several assessments.
It is necessary to have at least one empty state in legend
 (line with zero count, for example Not Started .......... 0)

**Steps to reproduce**:
1. Go to Audit Summary
2. Go to assessment widget and add new Assessment in Not Started state
3. Go to audit page, over mouse to legend items: confirm an error is displayed

**Actual Result**: "Script error" message is displayed while moving to the audit page
**Expected Result**: no error displayed

