### PR TITLE
GGRC-1281 Show assessors, creators and verifiers in tree view

### DIFF
--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -248,6 +248,7 @@ dashboard-js-files:
   - components/last-assessment-date/last-assessment-date.js
   - components/tree/tree-node-actions.js
   - components/tree/tree-no-results.js
+  - components/tree/tree-assignee-field.js
   - components/page-header/page-header.js
   #- d3.v2.js
   #- related_graph.js

--- a/src/ggrc/assets/javascripts/components/people_list.js
+++ b/src/ggrc/assets/javascripts/components/people_list.js
@@ -355,15 +355,19 @@
           this.get_roles(person, instance).then(function (result) {
             var roles = result.roles;
             var relationship = result.relationship;
+            var resultPromise;
 
             roles = _.without(roles, roleToRemove);
 
             if (roles.length) {
               relationship.attrs.attr('AssigneeType', roles.join(','));
-              relationship.save();
+              resultPromise = relationship.save();
             } else {
-              relationship.destroy();
+              resultPromise = relationship.destroy();
             }
+            resultPromise.then(function () {
+              instance.refresh();
+            });
           });
         }
       },

--- a/src/ggrc/assets/javascripts/components/tests/people_list_spec.js
+++ b/src/ggrc/assets/javascripts/components/tests/people_list_spec.js
@@ -189,6 +189,100 @@ describe('GGRC.Components.peopleGroup', function () {
        });
   });
 
+  describe('remove_role() method', function () {
+    var removeRole;
+    var personMock;
+    var scope;
+    var el;
+    var result;
+    var instance;
+
+    beforeEach(function () {
+      result = {
+        relationship: {
+          attrs: new can.Map(),
+          destroy: function () {},
+          save: function () {}
+        }
+      };
+      instance = {
+        refresh: jasmine.createSpy()
+      };
+      scope = new can.Map({
+        type: 'Verifier',
+        instance: instance,
+        deferred_remove_role: jasmine.createSpy(),
+        get_roles: function () {
+          return can.Deferred().resolve(result);
+        }
+      });
+      instance = scope.attr('instance');
+      removeRole = Component.prototype.scope.remove_role.bind(scope);
+      personMock = {
+        name: 'person'
+      };
+      el = $('<li><div class="person-tooltip-trigger">DIV</div></li>');
+      spyOn(CMS.Models.Person, 'findInCacheById')
+        .and.returnValue(personMock);
+      spyOn(result.relationship, 'destroy')
+        .and.returnValue(can.Deferred().resolve());
+      spyOn(result.relationship, 'save')
+        .and.returnValue(can.Deferred().resolve());
+    });
+    it('removes class .person-tooltip-trigger', function () {
+      $('body').append(el);
+      scope.attr('deferred', true);
+      removeRole({}, el, {});
+      expect($(el).closest('li').find('.person-tooltip-trigger').length)
+        .toEqual(0);
+      $('body').html('');
+    });
+    it('calls deferred_remove_role if deferred is true', function () {
+      scope.attr('deferred', true);
+      removeRole({}, el, {});
+      expect(scope.deferred_remove_role)
+        .toHaveBeenCalledWith(personMock, 'Verifier');
+    });
+    it('destroys relationship if it has only removing role', function () {
+      scope.attr('deferred', false);
+      result.roles = ['Verifier'];
+      removeRole({}, el, {});
+      expect(result.relationship.destroy)
+        .toHaveBeenCalled();
+    });
+    it('calls refresh of instance if relationship has only removing role',
+      function () {
+        scope.attr('deferred', false);
+        result.roles = ['Verifier'];
+        removeRole({}, el, {});
+        expect(instance.refresh)
+          .toHaveBeenCalled();
+      });
+    it('save relationship if it has multiple roles', function () {
+      scope.attr('deferred', false);
+      result.roles = ['Verifier', 'Assessor', 'Creator'];
+      removeRole({}, el, {});
+      expect(result.relationship.save)
+        .toHaveBeenCalled();
+    });
+    it('adds joined roles to relationship.attrs.AssigneeType' +
+    ' if relationship has multiple roles', function () {
+      scope.attr('deferred', false);
+      result.roles = ['Verifier', 'Assessor', 'Creator'];
+      removeRole({}, el, {});
+      expect(result.relationship.attrs.attr('AssigneeType'))
+        .toEqual('Assessor,Creator');
+    });
+    it('calls refresh of instance if relationship has multiple roles',
+    function () {
+      scope.attr('deferred', false);
+      result.roles = ['Verifier', 'Assessor', 'Creator'];
+      removeRole({}, el, {});
+      expect(instance.refresh)
+        .toHaveBeenCalled();
+    });
+  });
+
   describe('deferred_add_role() method', function () {
     var deferredAddRole;  // the method under test
     var personMock;

--- a/src/ggrc/assets/javascripts/components/tree/tests/tree-assignee-field_spec.js
+++ b/src/ggrc/assets/javascripts/components/tree/tests/tree-assignee-field_spec.js
@@ -1,0 +1,79 @@
+/*!
+  Copyright (C) 2017 Google Inc., authors, and contributors <see AUTHORS file>
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+describe('GGRC.Components.treeAssigneeField', function () {
+  'use strict';
+
+  var viewModel;
+
+  beforeEach(function () {
+    var newViewModel;
+    viewModel = GGRC.Components.get('treeAssigneeField').prototype
+      .viewModel.prototype;
+    //  avoiding of calling init() in creation of viewModel object
+    newViewModel = Object.assign({}, viewModel);
+    newViewModel.init = function () {};
+    newViewModel.oldInit = viewModel.init;
+    viewModel = can.Map.extend(newViewModel)();
+    viewModel.init = viewModel.oldInit;
+  });
+
+  describe('init() method', function () {
+    var instance;
+
+    beforeEach(function () {
+      spyOn(viewModel, 'sliceAssignees')
+        .and.returnValue('mockString');
+      viewModel.attr('instance', {});
+      instance = viewModel.attr('instance');
+      spyOn(instance, 'bind');
+    });
+    it('sets result of sliceAssignees to assigneeStr field', function () {
+      viewModel.init();
+      expect(viewModel.attr('assigneeStr')).toEqual('mockString');
+      expect(viewModel.sliceAssignees).toHaveBeenCalled();
+    });
+    it('listens to instance changing', function () {
+      viewModel.init();
+      expect(instance.bind)
+        .toHaveBeenCalledWith('change', jasmine.any(Function));
+    });
+  });
+
+  describe('sliceAssignees() method', function () {
+    var result;
+    it('returns empty string if instance is falsy', function () {
+      viewModel.attr('instance', false);
+      result = viewModel.sliceAssignees();
+      expect(result).toEqual('');
+    });
+    it('returns empty string if instance.assignees is falsy', function () {
+      viewModel.attr('instance', {});
+      result = viewModel.sliceAssignees();
+      expect(result).toEqual('');
+    });
+    it('returns empty string if instance.assignees.type is falsy', function () {
+      viewModel.attr('instance', {
+        assignees: {}
+      });
+      viewModel.attr('type', 'Verifier');
+      result = viewModel.sliceAssignees();
+      expect(result).toEqual('');
+    });
+    it('returns string with sliced mails if instance.assignees.type is truly',
+      function () {
+        viewModel.attr('instance', {
+          assignees: {
+            Verifier: [
+              {email: 'mock1@google.com'}, {email: 'mock2@google.com'}
+            ]
+          }
+        });
+        viewModel.attr('type', 'Verifier');
+        result = viewModel.sliceAssignees();
+        expect(result).toEqual('mock1 mock2');
+      });
+  });
+});

--- a/src/ggrc/assets/javascripts/components/tree/tree-assignee-field.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-assignee-field.js
@@ -1,0 +1,39 @@
+/*!
+  Copyright (C) 2017 Google Inc., authors, and contributors <see AUTHORS file>
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+(function (can) {
+  'use strict';
+
+  GGRC.Components('treeAssigneeField', {
+    tag: 'tree-assignee-field',
+    template: '<content/>',
+    viewModel: can.Map.extend({
+      type: '@',
+      instance: '@',
+      assigneeStr: '',
+      init: function () {
+        this.attr('assigneeStr', this.sliceAssignees());
+        this.attr('instance').bind('change', function () {
+          this.attr('assigneeStr', this.sliceAssignees());
+        }.bind(this));
+      },
+      sliceAssignees: function () {
+        var result = '';
+        var assignees;
+        var instance = this.attr('instance');
+        if (!instance || !instance.assignees) {
+          return result;
+        }
+        assignees = instance.assignees[this.attr('type')];
+        if (assignees) {
+          result = assignees.map(function (e) {
+            return e.email.replace(/@.*$/, '');
+          }).join(' ');
+        }
+        return result;
+      }
+    })
+  });
+})(window.can);

--- a/src/ggrc/assets/javascripts/models/assessment.js
+++ b/src/ggrc/assets/javascripts/models/assessment.js
@@ -71,6 +71,15 @@
       }, {
         attr_title: 'Reference URL',
         attr_name: 'reference_url'
+      }, {
+        attr_title: 'Creators',
+        attr_name: 'creators'
+      }, {
+        attr_title: 'Assignees',
+        attr_name: 'assessors'
+      }, {
+        attr_title: 'Verifiers',
+        attr_name: 'verifiers'
       }]
     },
     info_pane_options: {
@@ -237,9 +246,26 @@
 
       model = oldModel && can.isFunction(oldModel.attr) ?
         oldModel.attr(attributes) :
-        new this(attributes);
+          new this(attributes);
+
+      if (attributes.assignees) {
+        this.leaveUniqueAssignees(model, attributes, 'Verifier');
+        this.leaveUniqueAssignees(model, attributes, 'Assessor');
+        this.leaveUniqueAssignees(model, attributes, 'Creator');
+      }
 
       return model;
+    },
+    leaveUniqueAssignees: function (model, attributes, type) {
+      var assignees = attributes.assignees[type];
+      var unique = [];
+      if (assignees) {
+        unique = _.uniq(assignees, function (item) {
+          return item.id;
+        });
+      }
+
+      model.assignees.attr(type, unique);
     },
     /**
      * Replace Cacheble#findInCacheById method with the latest feature of can.Model - store

--- a/src/ggrc/assets/mustache/base_objects/tree-item-attr.mustache
+++ b/src/ggrc/assets/mustache/base_objects/tree-item-attr.mustache
@@ -50,6 +50,25 @@
     {{/using}}
   {{/case}}
 
+  {{#case 'creators'}}
+      <tree-assignee-field type="Creator"
+        {instance}='instance'>
+        {{assigneeStr}}
+      </tree-assignee-field>
+  {{/case}}
+  {{#case 'assessors'}}
+      <tree-assignee-field type="Assessor"
+        {instance}='instance'>
+        {{assigneeStr}}
+      </tree-assignee-field>
+  {{/case}}
+  {{#case 'verifiers'}}
+      <tree-assignee-field type="Verifier"
+        {instance}='instance'>
+        {{assigneeStr}}
+      </tree-assignee-field>
+  {{/case}}
+
   {{#default}}
     {{get_default_attr_value attr_name instance}}
   {{/default}}


### PR DESCRIPTION
Precondition:
- have program, audit

Steps to reproduce:
1. Create assessment on the audit page and add assignee and verifier (make sure that creator, assignee, verifier are shown in People list)
2. Look at Assessment's tree view first level: creator, assignee, verifier are shown

Actual Result: currently creator, assignee, verifier are not shown in tree view first level
Expected Result: creator, assignee, verifier are shown are shown in tree view first level