### PR TITLE
GGRC-1131 More tests for Assessment notifications

### DIFF
--- a/test/integration/ggrc/notifications/test_assignable_notifications.py
+++ b/test/integration/ggrc/notifications/test_assignable_notifications.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2017 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
-# pylint: disable=invalid-name
+# pylint: disable=invalid-name,too-many-lines
 
 """Tests for notifications for models with assignable mixin."""
 
@@ -398,6 +398,145 @@ class TestAssignableNotificationUsingImports(TestAssignableNotification):
 
     query = self._get_notifications(notif_type="assessment_completed")
     self.assertEqual(query.count(), 1)
+
+  @patch("ggrc.notifications.common.send_email")
+  def test_assessment_reopen_notifications_on_edit(self, _):
+    """Test if updating assessment results in reopen notification."""
+    self.import_file("assessment_with_templates.csv")
+
+    asmts = {asmt.slug: asmt for asmt in Assessment.query}
+    asmt = Assessment.query.get(asmts["A 1"].id)
+    asmt_id, asmt_slug = asmt.id, asmt.slug
+
+    for i, new_state in enumerate(Assessment.DONE_STATES):
+      asmt = Assessment.query.get(asmt_id)
+      asmt.status = new_state
+      db.session.commit()
+
+      self.client.get("/_notifications/send_daily_digest")
+      self.assertEqual(self._get_notifications().count(), 0)
+
+      self.import_data(OrderedDict([
+          (u"object_type", u"Assessment"),
+          (u"Code*", asmt_slug),
+          (u"Title", u"New Assessment 1 title - " + unicode(i)),
+      ]))
+
+      query = self._get_notifications(notif_type="assessment_reopened")
+      self.assertEqual(query.count(), 1)
+
+  @unittest.skip("An issue needs to be fixed.")
+  @patch("ggrc.notifications.common.send_email")
+  def test_assessment_reopen_notifications_on_ca_edit(self, _):
+    """Test if updating assessment's CA value in reopen notification."""
+    CAD(definition_type="assessment", title="CA_misc_remarks")
+
+    self.import_file("assessment_with_templates.csv")
+
+    asmts = {asmt.slug: asmt for asmt in Assessment.query}
+    asmt = Assessment.query.get(asmts["A 1"].id)
+    asmt_id, asmt_slug = asmt.id, asmt.slug
+
+    for i, new_state in enumerate(Assessment.DONE_STATES):
+      asmt = Assessment.query.get(asmt_id)
+      asmt.status = new_state
+      db.session.commit()
+
+      self.client.get("/_notifications/send_daily_digest")
+      self.assertEqual(self._get_notifications().count(), 0)
+
+      self.import_data(OrderedDict([
+          (u"object_type", u"Assessment"),
+          (u"Code*", asmt_slug),
+          (u"CA_misc_remarks", u"CA new value" + unicode(i)),
+      ]))
+
+      query = self._get_notifications(notif_type="assessment_reopened")
+      self.assertEqual(query.count(), 1)
+
+  @unittest.skip("An issue needs to be fixed.")
+  @patch("ggrc.notifications.common.send_email")
+  def test_assessment_reopen_notifications_on_url_edit(self, _):
+    """Test if updating assessment's URLs results in reopen notification."""
+    self.import_file("assessment_with_templates.csv")
+
+    asmts = {asmt.slug: asmt for asmt in Assessment.query}
+    asmt = Assessment.query.get(asmts["A 1"].id)
+    asmt_id, asmt_slug = asmt.id, asmt.slug
+
+    for i, new_state in enumerate(Assessment.DONE_STATES):
+      asmt = Assessment.query.get(asmt_id)
+      asmt.status = new_state
+      db.session.commit()
+
+      self.client.get("/_notifications/send_daily_digest")
+      self.assertEqual(self._get_notifications().count(), 0)
+
+      self.import_data(OrderedDict([
+          (u"object_type", u"Assessment"),
+          (u"Code*", asmt_slug),
+          (u"Url", u"www.foo-url-{}.bar".format(i)),
+      ]))
+
+      query = self._get_notifications(notif_type="assessment_reopened")
+      self.assertEqual(query.count(), 1)
+
+  @unittest.skip("An issue needs to be fixed.")
+  @patch("ggrc.notifications.common.send_email")
+  def test_assessment_reopen_notifications_on_evidence_change(self, _):
+    """Test if assessment evidence change results in reopen notification."""
+    self.import_file("assessment_with_templates.csv")
+
+    asmts = {asmt.slug: asmt for asmt in Assessment.query}
+    asmt = Assessment.query.get(asmts["A 1"].id)
+    asmt_id, asmt_slug = asmt.id, asmt.slug
+
+    for i, new_state in enumerate(Assessment.DONE_STATES):
+      asmt = Assessment.query.get(asmt_id)
+      asmt.status = new_state
+      db.session.commit()
+
+      self.client.get("/_notifications/send_daily_digest")
+      self.assertEqual(self._get_notifications().count(), 0)
+
+      self.import_data(OrderedDict([
+          (u"object_type", u"Assessment"),
+          (u"Code*", asmt_slug),
+          (
+              u"Evidence",
+              u"https://gdrive.com/qwerty{0}/view evidence-{0}.txt".format(i)
+          ),
+      ]))
+
+      query = self._get_notifications(notif_type="assessment_reopened")
+      self.assertEqual(query.count(), 1)
+
+  @unittest.skip("An issue needs to be fixed.")
+  @patch("ggrc.notifications.common.send_email")
+  def test_assessment_reopen_notifications_on_person_change(self, _):
+    """Test if updating assessment people results in a reopen notification."""
+    self.import_file("assessment_with_templates.csv")
+
+    asmts = {asmt.slug: asmt for asmt in Assessment.query}
+    asmt = Assessment.query.get(asmts["A 1"].id)
+    asmt_id, asmt_slug = asmt.id, asmt.slug
+
+    for i, new_state in enumerate(Assessment.DONE_STATES):
+      asmt = Assessment.query.get(asmt_id)
+      asmt.status = new_state
+      db.session.commit()
+
+      self.client.get("/_notifications/send_daily_digest")
+      self.assertEqual(self._get_notifications().count(), 0)
+
+      self.import_data(OrderedDict([
+          (u"object_type", u"Assessment"),
+          (u"Code*", asmt_slug),
+          (u"Assignee*", u"john{}@doe.com".format(i)),
+      ]))
+
+      query = self._get_notifications(notif_type="assessment_reopened")
+      self.assertEqual(query.count(), 1)
 
 
 class TestAssignableNotificationUsingAPI(TestAssignableNotification):

--- a/test/integration/ggrc/notifications/test_assignable_notifications.py
+++ b/test/integration/ggrc/notifications/test_assignable_notifications.py
@@ -30,15 +30,12 @@ from integration.ggrc.models.factories import \
 
 
 class TestAssignableNotification(TestCase):
-
-  """Test setting notifications for assignable mixin."""
+  """Base class for testing notification creation for assignable mixin."""
 
   def setUp(self):
     super(TestAssignableNotification, self).setUp()
     self.client.get("/login")
     self._fix_notification_init()
-    self.api_helper = api_helper.Api()
-    self.objgen = generator.ObjectGenerator()
     factories.AuditFactory(slug="Audit")
 
   def _fix_notification_init(self):
@@ -85,6 +82,20 @@ class TestAssignableNotification(TestCase):
     return db.session.query(Notification).join(NotificationType).filter(
         notif_filter
     )
+
+
+class TestAssignableNotificationUsingImports(TestAssignableNotification):
+  """Tests for notifications when interacting with objects through imports."""
+  pass
+
+
+class TestAssignableNotificationUsingAPI(TestAssignableNotification):
+  """Tests for notifications when interacting with objects through an API."""
+
+  def setUp(self):
+    super(TestAssignableNotificationUsingAPI, self).setUp()
+    self.api_helper = api_helper.Api()
+    self.objgen = generator.ObjectGenerator()
 
   @patch("ggrc.notifications.common.send_email")
   def test_assessment_without_verifiers(self, _):


### PR DESCRIPTION
This PR adds even more integration tests on top of the existing ones for Assessment notifications. Some of them cover a few extra edge cases when modifying Assessments through the API, while the rest focus on testing notifications when interacting with Assessments through imports.

The tests that have discovered issues and would otherwise fail were marked as skipped, as fixing the corresponding issues is out of scope of this PR, namely:

- changing Assessment people through imports
- changing Assessment URLs through imports
- attaching Assessment evidence through imports
- modifying Assessment's custom attribute values
- creating "assessment reopened" notification when editing Assessment people through imports
- creating "assessment reopened" notification when editing Assessment URLs through imports
- creating "assessment reopened" notification when editing Assessment evidence through imports
- creating "assessment reopened" notification when editing Assessment CA values through imports

The tests still to be added:

- [x] notifications on Assessment state transitions through imports (seems to work, but not completely done yet),
- [x] notifications on automatically reopening an Assessment by editing it through imports