### PR TITLE
GGRC-1493 GGRC-1626 Improve export performance

### DIFF
--- a/src/ggrc/converters/base.py
+++ b/src/ggrc/converters/base.py
@@ -6,6 +6,7 @@
 from collections import defaultdict
 
 from ggrc import settings
+from ggrc.utils import benchmark
 from ggrc.utils import structures
 from ggrc.cache.memcache import MemCache
 from ggrc.converters import get_exportables
@@ -64,9 +65,12 @@ class Converter(object):
     self.indexer = get_indexer()
 
   def to_array(self):
-    self.block_converters_from_ids()
-    self.handle_row_data()
-    return self.to_block_array()
+    with benchmark("Create block converters"):
+      self.block_converters_from_ids()
+    with benchmark("Handle row data"):
+      self.handle_row_data()
+    with benchmark("Make block array"):
+      return self.to_block_array()
 
   def to_block_array(self):
     """ exporting each in it's own block separated by empty lines

--- a/src/ggrc/converters/base_block.py
+++ b/src/ggrc/converters/base_block.py
@@ -178,16 +178,19 @@ class BlockConverter(object):
 
     with benchmark("cache for: {}".format(self.object_class.__name__)):
       with benchmark("cache query"):
-        relationships = relationship.eager_query().filter(or_(
-            and_(
-                relationship.source_type == self.object_class.__name__,
-                relationship.source_id.in_(self.object_ids),
-            ),
-            and_(
-                relationship.destination_type == self.object_class.__name__,
-                relationship.destination_id.in_(self.object_ids),
-            )
-        )).all()
+        if self.object_ids:
+          relationships = relationship.eager_query().filter(or_(
+              and_(
+                  relationship.source_type == self.object_class.__name__,
+                  relationship.source_id.in_(self.object_ids),
+              ),
+              and_(
+                  relationship.destination_type == self.object_class.__name__,
+                  relationship.destination_id.in_(self.object_ids),
+              )
+          )).all()
+        else:
+          relationships = []
       with benchmark("building cache"):
         cache = defaultdict(lambda: defaultdict(list))
         for rel in relationships:

--- a/src/ggrc/converters/base_block.py
+++ b/src/ggrc/converters/base_block.py
@@ -97,6 +97,7 @@ class BlockConverter(object):
     # The protected access is a false warning for inflector access.
     self._mapping_cache = None
     self._owners_cache = None
+    self._roles_cache = None
     self._ca_definitions_cache = None
     self.converter = converter
     self.offset = options.get("offset", 0)
@@ -238,6 +239,13 @@ class BlockConverter(object):
     if self._mapping_cache is None:
       self._mapping_cache = self._create_mapping_cache()
     return self._mapping_cache
+
+  def get_role(self, name):
+    """Get role from local cache for a given name."""
+    if not self._roles_cache:
+      self._roles_cache = {role.name: role for role in
+                           models.all_models.Role.query}
+    return self._roles_cache[name]
 
   def _create_owners_cache(self):
     """Create a cache of emails for all object owners."""

--- a/src/ggrc/converters/base_block.py
+++ b/src/ggrc/converters/base_block.py
@@ -98,6 +98,7 @@ class BlockConverter(object):
     self._mapping_cache = None
     self._owners_cache = None
     self._roles_cache = None
+    self._user_roles_cache = None
     self._ca_definitions_cache = None
     self.converter = converter
     self.offset = options.get("offset", 0)
@@ -246,6 +247,40 @@ class BlockConverter(object):
       self._roles_cache = {role.name: role for role in
                            models.all_models.Role.query}
     return self._roles_cache[name]
+
+  def _create_user_roles_cache(self):
+    """Create cache for user roles.
+
+    The cache returns a list of emails for a role in a context.
+    """
+    cache = defaultdict(lambda: defaultdict(set))
+    context_ids = {rc.obj.context_id for rc in self.row_converters}
+    user_roles = db.session.query(
+        models.all_models.UserRole.context_id,
+        models.all_models.UserRole.role_id,
+        models.all_models.UserRole.person_id,
+    ).filter(
+        models.all_models.UserRole.context_id.in_(context_ids)
+    ).all()
+
+    people_ids = {role[2] for role in user_roles}
+
+    emails_map = dict(db.session.query(
+        models.Person.id,
+        models.Person.email
+    ).filter(
+        models.Person.id.in_(people_ids)
+    ))
+
+    for context_id, role_id, person_id in user_roles:
+      cache[context_id][role_id].add(emails_map[person_id])
+    return cache
+
+  def get_user_roles_cache(self):
+    """Get cache for emails on user roles by context."""
+    if self._user_roles_cache is None:
+      self._user_roles_cache = self._create_user_roles_cache()
+    return self._user_roles_cache
 
   def _create_owners_cache(self):
     """Create a cache of emails for all object owners."""

--- a/src/ggrc/converters/base_block.py
+++ b/src/ggrc/converters/base_block.py
@@ -243,9 +243,9 @@ class BlockConverter(object):
     """Create a cache of emails for all object owners."""
     owner_ids = set()
     for row_converter in self.row_converters:
-      owners = getattr(row_converter.obj, "owners", None)
+      owners = getattr(row_converter.obj, "object_owners", None)
       if owners:
-        owner_ids |= {o.id for o in owners}
+        owner_ids |= {o.person_id for o in owners}
     query = db.session.query(
         models.Person.id,
         models.Person.email

--- a/src/ggrc/converters/handlers/custom_attribute.py
+++ b/src/ggrc/converters/handlers/custom_attribute.py
@@ -80,7 +80,10 @@ class CustomAttributeColumHandler(handlers.TextColumnHandler):
             return getattr(obj, "email", getattr(obj, "slug", None))
         elif value.custom_attribute.attribute_type == _types.CHECKBOX:
           attr_val = value.attribute_value if value.attribute_value else u"0"
-          attr_val = int(attr_val)
+          try:
+            attr_val = int(attr_val)
+          except ValueError:
+            attr_val = False
           return str(bool(attr_val)).upper()
         else:
           return value.attribute_value

--- a/src/ggrc/converters/handlers/handlers.py
+++ b/src/ggrc/converters/handlers/handlers.py
@@ -282,7 +282,8 @@ class OwnerColumnHandler(UserColumnHandler):
   def get_value(self):
     """Get a list of object owner emails."""
     cache = self.row_converter.block_converter.get_owners_cache()
-    emails = [cache[owner.id] for owner in self.row_converter.obj.owners]
+    emails = [cache[owner.person_id]
+              for owner in self.row_converter.obj.object_owners]
     return "\n".join(emails)
 
 

--- a/src/ggrc/converters/handlers/handlers.py
+++ b/src/ggrc/converters/handlers/handlers.py
@@ -280,7 +280,9 @@ class OwnerColumnHandler(UserColumnHandler):
       )
 
   def get_value(self):
-    emails = [owner.email for owner in self.row_converter.obj.owners]
+    """Get a list of object owner emails."""
+    cache = self.row_converter.block_converter.get_owners_cache()
+    emails = [cache[owner.id] for owner in self.row_converter.obj.owners]
     return "\n".join(emails)
 
 

--- a/src/ggrc/models/control.py
+++ b/src/ggrc/models/control.py
@@ -3,6 +3,7 @@
 
 """Module for control model and related classes."""
 
+from sqlalchemy import orm
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.orm import validates
 
@@ -67,7 +68,6 @@ class ControlCategorized(Categorizable):
 
   @classmethod
   def eager_query(cls):
-    from sqlalchemy import orm
     query = super(ControlCategorized, cls).eager_query()
     return query.options(
         orm.subqueryload('categorizations').joinedload('category'),
@@ -100,7 +100,6 @@ class AssertionCategorized(Categorizable):
 
   @classmethod
   def eager_query(cls):
-    from sqlalchemy import orm
     query = super(AssertionCategorized, cls).eager_query()
     return query.options(
         orm.subqueryload('categorized_assertions').joinedload('category'),
@@ -263,12 +262,14 @@ class Control(HasObjectState, Relatable, CustomAttributable,
 
   @classmethod
   def eager_query(cls):
-    from sqlalchemy import orm
     query = super(Control, cls).eager_query()
     return cls.eager_inclusions(query, Control._include_links).options(
         orm.joinedload('directive'),
         orm.joinedload('principal_assessor'),
         orm.joinedload('secondary_assessor'),
+        orm.joinedload('kind'),
+        orm.joinedload('means'),
+        orm.joinedload('verify_frequency'),
     )
 
   def log_json(self):

--- a/src/ggrc/models/option.py
+++ b/src/ggrc/models/option.py
@@ -11,7 +11,7 @@ class Option(Described, Base, db.Model):
 
   role = db.Column(db.String)
   # TODO: inherit from Titled mixin (note: title is nullable here)
-  title = deferred(db.Column(db.String), 'Option')
+  title = db.Column(db.String)
   required = deferred(db.Column(db.Boolean), 'Option')
 
   def __str__(self):

--- a/src/ggrc/views/converters.py
+++ b/src/ggrc/views/converters.py
@@ -54,20 +54,24 @@ def parse_export_request():
 
 def handle_export_request():
   try:
-    data = parse_export_request()
-    query_helper = QueryHelper(data)
-    converter = Converter(ids_by_type=query_helper.get_ids())
-    csv_data = converter.to_array()
-    csv_string = generate_csv_string(csv_data)
-
-    object_names = "_".join(converter.get_object_names())
-    filename = "{}.csv".format(object_names)
-
-    headers = [
-        ("Content-Type", "text/csv"),
-        ("Content-Disposition", "attachment; filename='{}'".format(filename)),
-    ]
-    return current_app.make_response((csv_string, 200, headers))
+    with benchmark("handle export request"):
+      data = parse_export_request()
+      query_helper = QueryHelper(data)
+      ids_by_type = query_helper.get_ids()
+    with benchmark("Generate CSV array"):
+      converter = Converter(ids_by_type=ids_by_type)
+      csv_data = converter.to_array()
+    with benchmark("Generate CSV string"):
+      csv_string = generate_csv_string(csv_data)
+    with benchmark("Make response."):
+      object_names = "_".join(converter.get_object_names())
+      filename = "{}.csv".format(object_names)
+      headers = [
+          ("Content-Type", "text/csv"),
+          ("Content-Disposition",
+           "attachment; filename='{}'".format(filename)),
+      ]
+      return current_app.make_response((csv_string, 200, headers))
   except BadQueryException as exception:
     raise BadRequest(exception.message)
   except:  # pylint: disable=bare-except

--- a/src/ggrc_basic_permissions/converters/handlers.py
+++ b/src/ggrc_basic_permissions/converters/handlers.py
@@ -70,7 +70,7 @@ class ObjectRoleColumnHandler(UserColumnHandler):
 class ProgramOwnerColumnHandler(ObjectRoleColumnHandler):
 
   def __init__(self, row_converter, key, **options):
-    self.role = Role.query.filter_by(name="ProgramOwner").one()
+    self.role = row_converter.block_converter.get_role("ProgramOwner")
     super(ProgramOwnerColumnHandler, self).__init__(
         row_converter, key, **options)
 
@@ -78,7 +78,7 @@ class ProgramOwnerColumnHandler(ObjectRoleColumnHandler):
 class ProgramEditorColumnHandler(ObjectRoleColumnHandler):
 
   def __init__(self, row_converter, key, **options):
-    self.role = Role.query.filter_by(name="ProgramEditor").one()
+    self.role = row_converter.block_converter.get_role("ProgramEditor")
     super(ProgramEditorColumnHandler, self).__init__(
         row_converter, key, **options)
 
@@ -86,7 +86,7 @@ class ProgramEditorColumnHandler(ObjectRoleColumnHandler):
 class ProgramReaderColumnHandler(ObjectRoleColumnHandler):
 
   def __init__(self, row_converter, key, **options):
-    self.role = Role.query.filter_by(name="ProgramReader").one()
+    self.role = row_converter.block_converter.get_role("ProgramReader")
     super(ProgramReaderColumnHandler, self).__init__(
         row_converter, key, **options)
 
@@ -94,7 +94,7 @@ class ProgramReaderColumnHandler(ObjectRoleColumnHandler):
 class WorkflowOwnerColumnHandler(ObjectRoleColumnHandler):
 
   def __init__(self, row_converter, key, **options):
-    self.role = Role.query.filter_by(name="WorkflowOwner").one()
+    self.role = row_converter.block_converter.get_role("WorkflowOwner")
     super(WorkflowOwnerColumnHandler, self).__init__(
         row_converter, key, **options)
 
@@ -102,7 +102,7 @@ class WorkflowOwnerColumnHandler(ObjectRoleColumnHandler):
 class WorkflowMemberColumnHandler(ObjectRoleColumnHandler):
 
   def __init__(self, row_converter, key, **options):
-    self.role = Role.query.filter_by(name="WorkflowMember").one()
+    self.role = row_converter.block_converter.get_role("WorkflowMember")
     super(WorkflowMemberColumnHandler, self).__init__(
         row_converter, key, **options)
 
@@ -110,8 +110,8 @@ class WorkflowMemberColumnHandler(ObjectRoleColumnHandler):
 class AuditAuditorColumnHandler(ObjectRoleColumnHandler):
 
   def __init__(self, row_converter, key, **options):
-    self.role = Role.query.filter_by(name="Auditor").one()
-    self.reader = Role.query.filter_by(name="ProgramReader").one()
+    self.role = row_converter.block_converter.get_role("Auditor")
+    self.reader = row_converter.block_converter.get_role("ProgramReader")
     super(AuditAuditorColumnHandler, self).__init__(
         row_converter, key, **options)
 
@@ -191,6 +191,7 @@ class UserRoleColumnHandler(UserColumnHandler):
     )
     db.session.add(user_role)
     self.dry_run = True
+
 
 COLUMN_HANDLERS = {
     "default": {

--- a/test/integration/ggrc/converters/test_base_block.py
+++ b/test/integration/ggrc/converters/test_base_block.py
@@ -1,0 +1,55 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+
+import mock
+from collections import defaultdict
+
+from ddt import data, ddt
+
+from ggrc.converters import base_block
+from ggrc import models
+
+from integration.ggrc import TestCase
+from integration.ggrc.models import factories
+
+
+@ddt
+class TestBaseBlock(TestCase):
+
+  @staticmethod
+  def dd_to_dict(ddict):
+    return {k: dict(v) for k, v in ddict.items()}
+
+  @data(0, 1, 2, 4)
+  def test_create_mapping_cache(self, count):
+    regulations = [factories.RegulationFactory() for _ in range(count)]
+    markets = [factories.MarketFactory() for _ in range(count)]
+    controls = [factories.ControlFactory() for _ in range(count)]
+
+    expected_cache = defaultdict(lambda: defaultdict(list))
+    for i in range(count):
+      for j in range(i):
+        factories.RelationshipFactory(
+            source=regulations[j] if i % 2 == 0 else markets[i],
+            destination=regulations[j] if i % 2 == 1 else markets[i],
+        )
+        factories.RelationshipFactory(
+            source=regulations[j] if i % 2 == 0 else controls[i],
+            destination=regulations[j] if i % 2 == 1 else controls[i],
+        )
+        expected_cache[regulations[j].id]["Control"].append(
+            controls[i].slug
+        )
+        expected_cache[regulations[j].id]["Market"].append(
+            markets[i].slug
+        )
+    block = base_block.BlockConverter(mock.MagicMock())
+    block.object_class = models.Regulation
+    block.object_ids = [r.id for r in regulations]
+
+    cache = block._create_mapping_cache()
+    self.assertEqual(
+        self.dd_to_dict(cache),
+        self.dd_to_dict(expected_cache),
+    )


### PR DESCRIPTION
Exporting 2K objects with a lot of mappings caused app-engine to timeout and throw an error.

This PR fixes currently the biggest bottleneck in exports with mappings.

Benchmarks (mapping cache for 2k regulations and around 100 different mappings):
before: 18.4923s
after: 0.3593s

Additional benchmark (exporting all Programs, Controls and regulations from grc-test db):
before: 169.3381 seconds - 98001 queries
after: 39.4760 seconds - 14502 queries 
after 5f7937b: 38.9554 seconds - 9485 queries
after 0d302d0: 34.9496 seconds - 3433 queries