### PR TITLE
GGRC-715  Fix incorrect message if Assessment moves from Complete state to In progress

### DIFF
--- a/src/ggrc/assets/mustache/components/assessment/urls-list.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/urls-list.mustache
@@ -18,8 +18,8 @@
       join_model="Relationship"
       quick_create="create_url"
       {{#if_in instance.status 'Completed,Verified,Ready for Review'}}verify_event="true"{{/if_in}}
-      modal_description='You are about to move assessment from "{{instance.status}}" to "In Progress" - are you sure about that?'
-      modal_title='Confirm moving Assessment to "In Progress"'
+      modal_description='You are about to move {{instance.type}} from "{{instance.status}}" to "In Progress" - are you sure about that?'
+      modal_title='Confirm moving {{instance.type}} to "In Progress"'
       modal_button='Confirm'
     >
       {{#prune_context}}

--- a/src/ggrc_gdrive_integration/assets/mustache/requests/gdrive_evidence_storage.mustache
+++ b/src/ggrc_gdrive_integration/assets/mustache/requests/gdrive_evidence_storage.mustache
@@ -20,8 +20,8 @@
             link_text=" "
             click_event="trigger_upload_parent"
             verify_event="true"
-            modal_description='You are about to move request from "{{instance.status}}" to "In Progress" - are you sure about that?'
-            modal_title='Confirm moving Request to "In Progress"'
+            modal_description='You are about to move {{instance.type}} from "{{instance.status}}" to "In Progress" - are you sure about that?'
+            modal_title='Confirm moving {{instance.type}} to "In Progress"'
             modal_button='Confirm'
             >
           </ggrc-gdrive-picker-launcher>
@@ -32,8 +32,8 @@
             link_text=" "
             click_event="trigger_upload"
             verify_event="true"
-            modal_description='You are about to move request from "{{instance.status}}" to "In Progress" - are you sure about that?'
-            modal_title='Confirm moving Request to "In Progress"'
+            modal_description='You are about to move {{instance.type}} from "{{instance.status}}" to "In Progress" - are you sure about that?'
+            modal_title='Confirm moving {{instance.type}} to "In Progress"'
             modal_button='Confirm'
             >
           </ggrc-gdrive-picker-launcher>


### PR DESCRIPTION
Precondition: Created program, audit
Steps to reproduce:
1. Go to audit page
2. Create assessment
3. Fill mandatory CA if any > Click complete button
4. Add a Verifier
5. Click Complete and Verify button
6. Add evidence: confirm incorrect massage is displayed ("Request" instead of "Assessment" was shown)