### PR TITLE
GGRC-587 Fix filtering by Owners of Control Snapshots

### DIFF
--- a/src/ggrc/converters/query_helper.py
+++ b/src/ggrc/converters/query_helper.py
@@ -337,6 +337,7 @@ class QueryHelper(object):
             object_class,
             query,
             object_query["order_by"],
+            tgt_class,
         )
     with benchmark("Apply limit"):
       limit = object_query.get("limit")
@@ -393,7 +394,7 @@ class QueryHelper(object):
 
     return ids, total
 
-  def _apply_order_by(self, model, query, order_by):
+  def _apply_order_by(self, model, query, order_by, tgt_class):
     """Add ordering parameters to a query for objects.
 
     This works only on direct model properties and related objects defined with
@@ -403,7 +404,8 @@ class QueryHelper(object):
       model: the model instances of which are requested in query;
       query: a query to get objects from the db;
       order_by: a list of dicts with keys "name" (the name of the field by which
-                to sort) and "desc" (optional; do reverse sort if True).
+                to sort) and "desc" (optional; do reverse sort if True);
+      tgt_class: the snapshotted model if `model` is Snapshot else `model`.
 
     If order_by["name"] == "__similarity__" (a special non-field value),
     similarity weights returned by get_similar_objects_query are used for
@@ -475,8 +477,8 @@ class QueryHelper(object):
           raise BadQueryException("Can't order by '__similarity__' when no ",
                                   "'similar' filter was applied.")
       else:
+        key, _ = self.attr_name_map[tgt_class].get(key, (key, None))
         if key in self.getattr_whitelist:
-          key, _ = self.attr_name_map[model].get(key, (key, None))
           attr = getattr(model, key.encode('utf-8'), None)
           if (isinstance(attr, sa.orm.attributes.InstrumentedAttribute) and
               isinstance(attr.property,

--- a/src/ggrc/models/object_owner.py
+++ b/src/ggrc/models/object_owner.py
@@ -1,12 +1,10 @@
 # Copyright (C) 2017 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
-from sqlalchemy import and_, or_
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.ext.declarative import declared_attr
 
 from ggrc import db
-from ggrc.models.person import Person
 from ggrc.models.mixins import Base
 from ggrc.models.reflection import PublishOnly
 
@@ -90,7 +88,6 @@ class Ownable(object):
       "owners": {
           "display_name": "Owner",
           "mandatory": True,
-          "filter_by": "_filter_by_owners",
       }
   }
 
@@ -101,11 +98,3 @@ class Ownable(object):
     query = super(Ownable, cls).eager_query()
     return cls.eager_inclusions(query, Ownable._include_links).options(
         orm.subqueryload('object_owners'))
-
-  @classmethod
-  def _filter_by_owners(cls, predicate):
-    return ObjectOwner.query.join(Person).filter(and_(
-        (ObjectOwner.ownable_id == cls.id),
-        (ObjectOwner.ownable_type == cls.__name__),
-        or_(predicate(Person.name), predicate(Person.email))
-    )).exists()


### PR DESCRIPTION
This PR removes special logic to search by Owners. Since Owners are indexed correctly, the default search via fulltext table works both on the original objects and on Snapshots.

Steps to reproduce:
1. Create a Program.
2. Create a Control with User1 as Owner and map it to the Program.
3. Create an Audit in the Program.
4. Open the Audit, go to Controls tab.
5. Search for "owners = User1" or "owner = User1".

Expected result: the Snapshot is displayed both times.
Actual result: the Snapshot is not displayed on "owner = User1".

~Depends on #5395~