### PR TITLE
GGRC-1384 While updating snapshots to the latest version search index is not updated

### DIFF
--- a/src/ggrc/snapshotter/indexer.py
+++ b/src/ggrc/snapshotter/indexer.py
@@ -137,6 +137,22 @@ def reindex():
     db.session.commit()
 
 
+def reindex_snapshots(snapshot_ids):
+  """Reindex selected snapshots"""
+  if not snapshot_ids:
+    return
+  columns = db.session.query(
+      models.Snapshot.parent_type,
+      models.Snapshot.parent_id,
+      models.Snapshot.child_type,
+      models.Snapshot.child_id,
+  ).filter(models.Snapshot.id.in_(snapshot_ids))
+  for query_chunk in generate_query_chunks(columns):
+    pairs = {Pair.from_4tuple(p) for p in query_chunk}
+    reindex_pairs(pairs)
+    db.session.commit()
+
+
 def delete_records(snapshot_ids):
   """Delete all records for some snapshots.
   Args:


### PR DESCRIPTION
Precondition:
have a program, control with GCA (e.g. text type), audit
Steps to reproduce:
1. Go to audit page
2. Return back to program and fill GCA 
3. Go to audit page and update control to the latest version
4. Try to filter by GCA in Control: no result
Actual Result: While updating snapshots to the latest version search index is not updated 
Expected Result: While updating snapshots to the latest version search index should be updated
