### PR TITLE
GGRC-1432 Add filtering by date, datetime and their partials

### DIFF
--- a/src/ggrc/converters/autocast.py
+++ b/src/ggrc/converters/autocast.py
@@ -1,0 +1,128 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Autocast module, populate sent expression"""
+
+import sqlalchemy as sa
+
+from ggrc import db
+from ggrc.models.custom_attribute_definition import CustomAttributeDefinition
+from ggrc.models.reflection import AttributeInfo
+from ggrc.fulltext.mixin import Indexed
+from ggrc.fulltext.attributes import FullTextAttr, DatetimeValue, DateValue
+
+
+EXP_TMPL = {'is_autocasted': True}
+
+
+NOT_AUTOCASTED_OPERATIONS = ["AND",
+                             "OR",
+                             "is",
+                             "similar",
+                             "owned",
+                             "relevant",
+                             "related_people",
+                             "text_search"]
+
+
+def build_exp(left, right, operation):
+  """Util function, Build exp for left and right if they are not empty"""
+  if not left or not right:
+    return None
+  tmp_exp = EXP_TMPL.copy()
+  tmp_exp.update({
+      "left": left,
+      "right": right,
+      "op": {"name": operation}
+  })
+  return tmp_exp
+
+
+def is_autocast_required_for(exp):
+  """Check if autocast is really needed"""
+  operation = exp["op"]["name"]
+  return not (
+      not isinstance(operation, basestring) or
+      exp.get("is_autocasted") or
+      operation in NOT_AUTOCASTED_OPERATIONS
+  )
+
+
+def get_fulltext_parsed_value(klass, key):
+  """Get fulltext parser if it's exists """
+  attrs = AttributeInfo.gather_attrs(klass, '_fulltext_attrs')
+  if not issubclass(klass, Indexed):
+    return
+  for attr in attrs:
+    if isinstance(attr, FullTextAttr) and attr.with_template:
+      attr_key = klass.PROPERTY_TEMPLATE.format(attr.alias)
+    elif isinstance(attr, FullTextAttr):
+      attr_key = attr.alias
+    else:
+      attr_key = klass.PROPERTY_TEMPLATE.format(attr)
+      attr = FullTextAttr(key, key)
+    if attr_key == key:
+      return attr
+
+
+def get_parsers(klass, key):
+  """Return tuple of 2 parsers related to current key and class"""
+  fulltext_parser = get_fulltext_parsed_value(klass, key)
+  if fulltext_parser:
+    if isinstance(fulltext_parser, DatetimeValue):
+      return (fulltext_parser, None)
+    else:
+      return (None, fulltext_parser)
+  try:
+    attr_type = getattr(klass, key).property.columns[0].type
+  except AttributeError:
+    value_types = [i[0] for i in db.session.query(
+        CustomAttributeDefinition.attribute_type
+    ).filter(
+        CustomAttributeDefinition.title == key,
+        CustomAttributeDefinition.definition_type ==
+        klass._inflector.table_singular  # pylint: disable=protected-access
+    ).distinct()]
+    is_date = CustomAttributeDefinition.ValidTypes.DATE in value_types
+    is_any_value = len(value_types) > int(is_date)
+    return (DateValue() if is_date else None,
+            FullTextAttr(key, key) if is_any_value else None)
+  if isinstance(attr_type, sa.sql.sqltypes.DateTime):
+    return (DatetimeValue(), None)
+  elif isinstance(attr_type, sa.sql.sqltypes.Date):
+    return (DateValue(), None)
+  return (None, FullTextAttr(key, key))
+
+
+def autocast(exp, target_class):
+  """Try to guess the type of `value` and parse it from the string.
+
+  Args:
+    operator_name: the name of the operator being applied.
+    value: the value being compared.
+  """
+  if not is_autocast_required_for(exp):
+    return exp
+  operation = exp["op"]["name"]
+  exp.update(EXP_TMPL)
+  key = exp['left']
+  key, _ = target_class.attributes_map().get(key, (key, None))
+  extra_parser, any_parser = get_parsers(target_class, key)
+  if not extra_parser and not any_parser:
+    # It's look like filter by snapshot
+    return exp
+  extra_exp = None
+  current_exp = None
+  if extra_parser:
+    left_date, right_date = extra_parser.get_filter_value(
+        unicode(exp['right']), operation) or [None, None]
+    left_exp = build_exp(key,
+                         left_date,
+                         ">=" if operation == "=" else operation)
+    right_exp = build_exp(key,
+                          right_date,
+                          "<=" if operation == "=" else operation)
+    extra_exp = build_exp(left_exp, right_exp, "AND") or left_exp or right_exp
+  if any_parser:
+    current_exp = exp
+  return build_exp(extra_exp, current_exp, "OR") or current_exp or extra_exp

--- a/src/ggrc/converters/custom_operators.py
+++ b/src/ggrc/converters/custom_operators.py
@@ -1,0 +1,318 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""This module contains custom operators for query helper"""
+
+# pylint: disable=unused-argument
+from operator import eq, lt, gt, le, ge
+
+import flask
+import sqlalchemy
+from sqlalchemy.orm import load_only
+
+from ggrc import db
+from ggrc import models
+from ggrc.converters.autocast import autocast
+from ggrc.converters.exceptions import BadQueryException
+from ggrc.fulltext.mysql import MysqlRecordProperty as Record
+from ggrc.login import is_creator
+from ggrc.models import inflector
+from ggrc.models.relationship_helper import RelationshipHelper
+from ggrc.snapshotter import rules
+from ggrc.utils import query_helpers
+from ggrc_basic_permissions import UserRole
+
+
+GETATTR_WHITELIST = {
+    "child_type",
+    "id",
+    "is_current",
+    "program",
+}
+
+
+def build_op_shortcut(predicate):
+  """A shortcut to call build_op with default lhs and rhs."""
+  def decorated(exp, object_class, target_class, query):
+    """decorator for sended predicate"""
+    key = exp['left'].lower()
+    key, filter_by = target_class.attributes_map().get(key, (key, None))
+    if callable(filter_by):
+      return filter_by(lambda x: predicate(x, exp['right']))
+    if key in GETATTR_WHITELIST:
+      return predicate(getattr(object_class, key, None), exp['right'])
+    return object_class.id.in_(
+        db.session.query(Record.key).filter(
+            Record.type == object_class.__name__,
+            Record.property == key,
+            predicate(Record.content, exp['right'])
+        )
+    )
+  return decorated
+
+
+@build_op_shortcut
+def like(left, right):
+  """Handle ~ operator with SQL LIKE."""
+  return left.ilike(u"%{}%".format(right))
+
+
+def reverse(operation):
+  """ decorator that returns sa.not_ for sending operation"""
+  def decorated(*args, **kwargs):
+    return sqlalchemy.not_(operation(*args, **kwargs))
+  return decorated
+
+
+def is_filter(exp, object_class, target_class, query):
+  """Handle 'is' operator.
+
+  As in 'CA is empty' expression
+  """
+  if exp['right'] != u"empty":
+    raise BadQueryException(
+        u"Invalid operator near 'is': {}".format(exp['right']))
+  left = exp['left'].lower()
+  left, _ = target_class.attributes_map().get(left, (left, None))
+  subquery = db.session.query(Record.key).filter(
+      Record.type == object_class.__name__,
+      Record.property == left,
+      sqlalchemy.not_(
+          sqlalchemy.or_(Record.content == u"", Record.content.is_(None))
+      ),
+  )
+  return object_class.id.notin_(subquery)
+
+
+def unknown(exp, object_class, target_class, query):
+  """A fake operator for invalid operator names."""
+  raise BadQueryException(
+      u"Unknown operator \"{}\"".format(exp["op"]["name"]))
+
+
+def related_people(exp, object_class, target_class, query):
+  """Get people related to the specified object.
+
+  Returns the following people:
+    for each object type: the users mapped via PeopleObjects,
+    for Program: the users that have a Program-wide role,
+    for Audit: the users that have a Program-wide or Audit-wide role,
+    for Workflow: the users mapped via WorkflowPeople and
+                  the users that have a Workflow-wide role.
+
+  Args:
+    related_type: the name of the class of the related objects.
+    related_ids: the ids of related objects.
+
+  Returns:
+    sqlalchemy.sql.elements.BinaryExpression if an object of `object_class`
+    is related to the given users.
+  """
+  if "Person" not in [object_class.__name__, exp['object_name']]:
+    return sqlalchemy.sql.false()
+  model = inflector.get_model(exp['object_name'])
+  res = []
+  res.extend(RelationshipHelper.person_object(
+      object_class.__name__,
+      exp['object_name'],
+      exp['ids'],
+  ))
+
+  if exp['object_name'] in ('Program', 'Audit'):
+    res.extend(
+        db.session.query(UserRole.person_id).join(model, sqlalchemy.and_(
+            UserRole.context_id == model.context_id,
+            model.id.in_(exp['ids']),
+        ))
+    )
+
+  if exp['object_name'] == "Audit":
+    res.extend(
+        db.session.query(UserRole.person_id).join(
+            models.Program,
+            UserRole.context_id == models.Program.context_id,
+        ).join(model, sqlalchemy.and_(
+            models.Program.id == model.program_id,
+            model.id.in_(exp['ids']),
+        ))
+    )
+  if "Workflow" in (object_class.__name__, exp['object_name']):
+    try:
+      from ggrc_workflows.models import (relationship_helper as
+                                         wf_relationship_handler)
+    except ImportError:
+      # ggrc_workflows module is not enabled
+      return sqlalchemy.sql.false()
+    else:
+      res.extend(wf_relationship_handler.workflow_person(
+          object_class.__name__,
+          exp['object_name'],
+          exp['ids'],
+      ))
+  if res:
+    return object_class.id.in_([obj[0] for obj in res])
+  return sqlalchemy.sql.false()
+
+
+def owned(exp, object_class, target_class, query):
+  """Get objects for which the user is owner.
+
+  Note: only the first id from the list of ids is used.
+
+  Args:
+    ids: the ids of owners.
+
+  Returns:
+    sqlalchemy.sql.elements.BinaryExpression if an object of `object_class`
+    is owned by one of the given users.
+  """
+  res = db.session.query(
+      query_helpers.get_myobjects_query(
+          types=[object_class.__name__],
+          contact_id=exp['ids'][0],
+          is_creator=is_creator(),
+      ).alias().c.id
+  )
+  res = res.all()
+  if res:
+    return object_class.id.in_([obj.id for obj in res])
+  return sqlalchemy.sql.false()
+
+
+def text_search(exp, object_class, target_class, query):
+  """Filter by fulltext search.
+
+  The search is done only in fields indexed for fulltext search.
+
+  Args:
+    text: the text we are searching for.
+
+  Returns:
+    sqlalchemy.sql.elements.BinaryExpression if an object of `object_class`
+    has an indexed property that contains `text`.
+  """
+  return object_class.id.in_(
+      db.session.query(Record.key).filter(
+          Record.type == object_class.__name__,
+          Record.content.ilike(u"%{}%".format(exp['text'])),
+      ),
+  )
+
+
+def similar(exp, object_class, target_class, query):
+  """Filter by relationships similarity.
+
+  Note: only the first id from the list of ids is used.
+
+  Args:
+    object_name: the name of the class of the objects to which similarity
+                 will be computed.
+    ids: the ids of similar objects of type `object_name`.
+
+  Returns:
+    sqlalchemy.sql.elements.BinaryExpression if an object of `object_class`
+    is similar to one the given objects.
+  """
+  similar_class = inflector.get_model(exp['object_name'])
+  if not hasattr(similar_class, "get_similar_objects_query"):
+    raise BadQueryException(u"{} does not define weights to count "
+                            u"relationships similarity"
+                            .format(similar_class.__name__))
+  similar_objects_query = similar_class.get_similar_objects_query(
+      id_=exp['ids'][0],
+      types=[object_class.__name__],
+  )
+  flask.g.similar_objects_query = similar_objects_query
+  similar_objects_ids = [obj.id for obj in similar_objects_query]
+  if similar_objects_ids:
+    return object_class.id.in_(similar_objects_ids)
+  return sqlalchemy.sql.false()
+
+
+def relevant(exp, object_class, target_class, query):
+  "Filter by relevant object"
+  if exp['object_name'] == "__previous__":
+    exp = query[exp['ids'][0]]
+  object_name = exp['object_name']
+  ids = exp['ids']
+  snapshoted = (object_class.__name__ in rules.Types.scoped and
+                object_name in rules.Types.all)
+  if not snapshoted:
+    return object_class.id.in_(
+        RelationshipHelper.get_ids_related_to(
+            object_class.__name__,
+            object_name,
+            ids,
+        )
+    )
+  snapshot_qs = models.Snapshot.query.filter(
+      models.Snapshot.parent_type == models.Audit.__name__,
+      models.Snapshot.child_type == object_name,
+      models.Snapshot.child_id.in_(ids),
+  ).options(
+      load_only(models.Snapshot.id),
+  ).distinct(
+  ).subquery(
+      "snapshot"
+  )
+  dest_qs = models.Relationship.query.filter(
+      models.Relationship.destination_id == snapshot_qs.c.id,
+      models.Relationship.destination_type == models.Snapshot.__name__,
+      models.Relationship.source_type == object_class.__name__,
+  ).options(
+      load_only("source_id")
+  ).distinct()
+  source_qs = models.Relationship.query.filter(
+      models.Relationship.source_id == snapshot_qs.c.id,
+      models.Relationship.source_type == models.Snapshot.__name__,
+      models.Relationship.destination_type == object_class.__name__,
+  ).options(
+      load_only("destination_id")
+  ).distinct()
+  ids_qs = dest_qs.union(source_qs).distinct().subquery("ids")
+  return object_class.id == ids_qs.c.relationships_source_id
+
+
+def build_expression(exp, object_class, target_class, query):
+  """Make an SQLAlchemy filtering expression from exp expression tree."""
+  if OPS.get(exp.get("op", {}).get("name")) is None:
+    return
+  exp = autocast(exp, target_class)
+  if not exp:
+    raise BadQueryException("Invalid filter data")
+  operation = OPS.get(exp.get("op", {}).get("name")) or unknown
+  return operation(exp, object_class, target_class, query)
+
+
+def and_operation(exp, object_class, target_class, query):
+  """Operator generate sqlalchemy for and operation"""
+  return sqlalchemy.and_(
+      build_expression(exp["left"], object_class, target_class, query),
+      build_expression(exp["right"], object_class, target_class, query))
+
+
+def or_operation(exp, object_class, target_class, query):
+  """Operator generate sqlalchemy for or operation"""
+  return sqlalchemy.or_(
+      build_expression(exp["left"], object_class, target_class, query),
+      build_expression(exp["right"], object_class, target_class, query))
+
+
+OPS = {
+    "AND": and_operation,
+    "OR": or_operation,
+    "=": build_op_shortcut(eq),
+    "!=": reverse(build_op_shortcut(eq)),
+    "~": like,
+    "!~": reverse(like),
+    "<": build_op_shortcut(lt),
+    ">": build_op_shortcut(gt),
+    "<=": build_op_shortcut(le),
+    ">=": build_op_shortcut(ge),
+    "relevant": relevant,
+    "similar": similar,
+    "owned": owned,
+    "related_people": related_people,
+    "text_search": text_search,
+    "is": is_filter,
+}

--- a/src/ggrc/converters/exceptions.py
+++ b/src/ggrc/converters/exceptions.py
@@ -1,0 +1,8 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""This module contains a class for handling request queries."""
+
+
+class BadQueryException(Exception):
+  pass

--- a/src/ggrc/models/mixins/__init__.py
+++ b/src/ggrc/models/mixins/__init__.py
@@ -620,6 +620,28 @@ class Base(ChangeTracked, ContextRBAC, Identifiable):
 
     return target
 
+  CACHED_ATTRIBUTE_MAP = None
+
+  @classmethod
+  def attributes_map(cls):
+    if cls.CACHED_ATTRIBUTE_MAP:
+      return cls.CACHED_ATTRIBUTE_MAP
+    aliases = AttributeInfo.gather_aliases(cls)
+    cls.CACHED_ATTRIBUTE_MAP = {}
+    for key, value in aliases.items():
+      if isinstance(value, dict):
+        name = value["display_name"]
+        filter_by = None
+        if value.get("filter_by"):
+          filter_by = getattr(cls, value["filter_by"], None)
+      else:
+        name = value
+        filter_by = None
+      if not name:
+        continue
+      cls.CACHED_ATTRIBUTE_MAP[name.lower()] = (key.lower(), filter_by)
+    return cls.CACHED_ATTRIBUTE_MAP
+
 
 class Slugged(Base):
 

--- a/src/ggrc/models/mixins/__init__.py
+++ b/src/ggrc/models/mixins/__init__.py
@@ -159,8 +159,8 @@ class ChangeTracked(object):
       'updated_at',
   ]
   _fulltext_attrs = [
-      'created_at',
-      'updated_at',
+      attributes.DatetimeFullTextAttr('created_at', 'created_at'),
+      attributes.DatetimeFullTextAttr('updated_at', 'updated_at'),
       attributes.FullTextAttr("modified_by", "modified_by", ["name", "email"]),
   ]
 
@@ -308,8 +308,8 @@ class Timeboxed(object):
   }
 
   _fulltext_attrs = [
-      'start_date',
-      'end_date'
+      attributes.DateFullTextAttr('start_date', 'start_date'),
+      attributes.DateFullTextAttr('end_date', 'end_date'),
   ]
 
 
@@ -384,7 +384,7 @@ class FinishedDate(object):
   }
 
   _fulltext_attrs = [
-      'finished_date',
+      attributes.DateFullTextAttr('finished_date', 'finished_date'),
   ]
 
   @validates('status')
@@ -442,7 +442,7 @@ class VerifiedDate(object):
   }
 
   _fulltext_attrs = [
-      "verified_date",
+      attributes.DateFullTextAttr("verified_date", "verified_date"),
       "verified",
   ]
 

--- a/src/ggrc/services/query.py
+++ b/src/ggrc/services/query.py
@@ -59,7 +59,7 @@ def get_objects_by_query():
   """Return objects corresponding to a POST'ed query list."""
   query = request.json
 
-  query_helper = QueryAPIQueryHelper(query, ca_disabled=True)
+  query_helper = QueryAPIQueryHelper(query)
   results = query_helper.get_results()
 
   last_modified_list = [result["last_modified"] for result in results

--- a/src/ggrc/services/query_helper.py
+++ b/src/ggrc/services/query_helper.py
@@ -5,6 +5,7 @@
 
 from ggrc.builder import json
 from ggrc.converters.query_helper import QueryHelper
+from ggrc.models import inflector
 from ggrc.utils import benchmark
 
 
@@ -47,7 +48,7 @@ class QueryAPIQueryHelper(QueryHelper):
       if query_type not in {"values", "ids", "count"}:
         raise NotImplementedError("Only 'values', 'ids' and 'count' queries "
                                   "are supported now")
-      model = self.object_map[object_query["object_name"]]
+      model = inflector.get_model(object_query["object_name"])
       if query_type == "values":
         with benchmark("Get result set: get_results > _get_objects"):
           objects = self._get_objects(object_query)

--- a/src/ggrc/utils/date_parsers.py
+++ b/src/ggrc/utils/date_parsers.py
@@ -1,0 +1,208 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""This module contains date parser classes"""
+import re
+import datetime
+import calendar
+
+
+class Parser(object):
+
+  GENERAL_PATTERN = None
+
+  @classmethod
+  def is_match(cls, date):
+    return re.match(cls.GENERAL_PATTERN, date)
+
+  @staticmethod
+  def parse(date):
+    raise NotImplementedError()
+
+
+class YearParser(Parser):
+  """Class Parser year"""
+  GENERAL_PATTERN = r'^\d{4}$'
+
+  @staticmethod
+  def parse(date):
+    year = int(date)
+
+    return (datetime.datetime(year, 1, 1, 0, 0, 0),
+            datetime.datetime(year, 12, 31, 23, 59, 59))
+
+
+class IsoMonthParser(Parser):
+  """Class Parser for Iso format date time year-month"""
+  GENERAL_PATTERN = r'^\d{4}(-\d{1,2})$'
+
+  @staticmethod
+  def parse(date):
+    year, month = [int(i) for i in re.split(r"\D", date)]
+
+    days = calendar.monthrange(year, month)[1]
+    return (datetime.datetime(year, month, 1, 0, 0, 0),
+            datetime.datetime(year, month, days, 23, 59, 59))
+
+
+class IsoDayParser(Parser):
+  """Class Parser for Iso format date time year-month-day"""
+  GENERAL_PATTERN = r'^\d{4}(-\d{1,2}){2}$'
+
+  @staticmethod
+  def parse(date):
+    year, month, day = [int(i) for i in re.split(r"\D", date)]
+
+    return (datetime.datetime(year, month, day, 0, 0, 0),
+            datetime.datetime(year, month, day, 23, 59, 59))
+
+
+class IsoHourParser(Parser):
+  """Class Parser for Iso format date time year-month-day hour"""
+  GENERAL_PATTERN = r'^\d{4}((-\d{1,2}){0,2}:\d{1,2})$'
+
+  @staticmethod
+  def parse(date):
+    year, month, day, hour = [int(i) for i in re.split(r"\D", date)]
+
+    return (datetime.datetime(year, month, day, hour, 0, 0),
+            datetime.datetime(year, month, day, hour, 59, 59))
+
+
+class IsoMinuteParser(Parser):
+  """Class Parser for Iso format date time year-month-day hour:minute"""
+  GENERAL_PATTERN = r'^\d{4}((-\d{1,2}){0,2}(:\d{1,2}){2})$'
+
+  @staticmethod
+  def parse(date):
+    year, month, day, hour, minute = [int(i) for i in re.split(r"\D", date)]
+
+    return (datetime.datetime(year, month, day, hour, minute, 0),
+            datetime.datetime(year, month, day, hour, minute, 59))
+
+
+class IsoSecondParser(Parser):
+  """Class Parser for Iso format date time year-month-day hour:minute:second"""
+  GENERAL_PATTERN = r'^\d{4}((-\d{1,2}){0,2}(:\d{1,2}){3})$'
+
+  @staticmethod
+  def parse(date):
+    year, month, day, hour, minute, second = [int(i)
+                                              for i in re.split(r"\D", date)]
+
+    return (datetime.datetime(year, month, day, hour, minute, second),
+            datetime.datetime(year, month, day, hour, minute, second))
+
+
+class CombineParser(Parser):
+
+  PARSERS = []
+
+  @classmethod
+  def parse(cls, date):
+    for parser in cls.PARSERS:
+      if parser.is_match(date):
+        return parser.parse(date)
+
+
+class USSecondParser(Parser):
+  """Class Parser for US format date time day/month/year hour:minute:second"""
+  GENERAL_PATTERN = r'^(\d{0,2}\/){2}\d{4} \d{1,2}(:\d{1,2}){2}$'
+
+  @staticmethod
+  def parse(date):
+    month, day, year, hour, minute, second = [int(i)
+                                              for i in re.split(r"\D", date)]
+
+    return (datetime.datetime(year, month, day, hour, minute, second),
+            datetime.datetime(year, month, day, hour, minute, second))
+
+
+class USMinuteParser(Parser):
+  """Class Parser for US format date time day/month/year hour:minute"""
+  GENERAL_PATTERN = r'^(\d{0,2}\/){2}\d{4} \d{1,2}(:\d{1,2}){1}$'
+
+  @staticmethod
+  def parse(date):
+    month, day, year, hour, minute = [int(i) for i in re.split(r"\D", date)]
+
+    return (datetime.datetime(year, month, day, hour, minute, 0),
+            datetime.datetime(year, month, day, hour, minute, 59))
+
+
+class USHourParser(Parser):
+  """Class Parser for US format date time day/month/year hour"""
+  GENERAL_PATTERN = r'^(\d{0,2}\/){2}\d{4} \d{1,2}$'
+
+  @staticmethod
+  def parse(date):
+    month, day, year, hour = [int(i) for i in re.split(r"\D", date)]
+
+    return (datetime.datetime(year, month, day, hour, 0, 0),
+            datetime.datetime(year, month, day, hour, 59, 59))
+
+
+class USDayParser(Parser):
+  """Class Parser for US format date time day/month/year"""
+  GENERAL_PATTERN = r'^(\d{0,2}\/){2}\d{4}$'
+
+  @staticmethod
+  def parse(date):
+    month, day, year = [int(i) for i in re.split(r"\D", date)]
+
+    return (datetime.datetime(year, month, day, 0, 0, 0),
+            datetime.datetime(year, month, day, 23, 59, 59))
+
+
+class USMonthParser(Parser):
+  """Class Parser for US format date time month/year"""
+  GENERAL_PATTERN = r'^(\d{0,2}\/){1}\d{4}$'
+
+  @staticmethod
+  def parse(date):
+    month, year = [int(i) for i in re.split(r"\D", date)]
+
+    days = calendar.monthrange(year, month)[1]
+    return (datetime.datetime(year, month, 1, 0, 0, 0),
+            datetime.datetime(year, month, days, 23, 59, 59))
+
+
+def combiner_factory(name, pattern, parsers):
+  return type(name,
+              (CombineParser, ),
+              {"GENERAL_PATTERN": pattern, "PARSERS": parsers})
+
+USCombiner = combiner_factory(  # pylint: disable=invalid-name
+    "USCombiner",
+    r'^(\d{0,2}\/){0,2}(\d{4})(( \d{1,2}(:\d{1,2}){0,2})?)$',
+    [
+        USSecondParser,
+        USMinuteParser,
+        USHourParser,
+        USDayParser,
+        USMonthParser,
+        YearParser
+    ])
+
+IsoCombiner = combiner_factory(  # pylint: disable=invalid-name
+    "IsoCombiner",
+    r'^\d{4}((-\d{1,2}){0,2}(:\d{1,2}){0,3})$',
+    [
+        IsoSecondParser,
+        IsoMinuteParser,
+        IsoHourParser,
+        IsoDayParser,
+        IsoMonthParser,
+        YearParser
+    ])
+
+
+DEFAULT_PARSERS = [IsoCombiner, USCombiner]
+
+
+def parse_date(date, parsers=None):
+  """Try to parse sended date string"""
+  parsers = parsers or DEFAULT_PARSERS
+  for parser in parsers:
+    if parser.is_match(date):
+      return parser.parse(date)

--- a/src/ggrc_workflows/models/cycle.py
+++ b/src/ggrc_workflows/models/cycle.py
@@ -16,7 +16,8 @@ from ggrc.models.mixins import Titled
 from ggrc.models.mixins import WithContact
 from ggrc.fulltext.attributes import (
     MultipleSubpropertyFullTextAttr,
-    FullTextAttr,
+    DateMultipleSubpropertyFullTextAttr,
+    DateFullTextAttr,
 )
 from ggrc.fulltext.mixin import Indexed, ReindexRule
 
@@ -76,7 +77,7 @@ class Cycle(WithContact, Stateful, Timeboxed, Described, Titled, Slugged,
           ["name", "email"],
           False,
       ),
-      MultipleSubpropertyFullTextAttr(
+      DateMultipleSubpropertyFullTextAttr(
           "group due date",
           'cycle_task_groups',
           ["next_due_date"],
@@ -95,13 +96,13 @@ class Cycle(WithContact, Stateful, Timeboxed, Described, Titled, Slugged,
           ["name", "email"],
           False
       ),
-      MultipleSubpropertyFullTextAttr(
+      DateMultipleSubpropertyFullTextAttr(
           "task due date",
           "cycle_task_group_object_tasks",
           ["end_date"],
           False
       ),
-      FullTextAttr("due date", "next_due_date"),
+      DateFullTextAttr("due date", "next_due_date"),
   ]
 
   AUTO_REINDEX_RULES = [

--- a/src/ggrc_workflows/models/cycle_task_group.py
+++ b/src/ggrc_workflows/models/cycle_task_group.py
@@ -18,7 +18,9 @@ from ggrc_workflows.models.cycle import Cycle
 from ggrc.fulltext.mixin import Indexed, ReindexRule
 from ggrc.fulltext.attributes import (
     MultipleSubpropertyFullTextAttr,
-    FullTextAttr
+    DateMultipleSubpropertyFullTextAttr,
+    FullTextAttr,
+    DateFullTextAttr,
 )
 
 
@@ -80,18 +82,18 @@ class CycleTaskGroup(WithContact, Stateful, Slugged, Timeboxed, Described,
           ["name", "email"],
           False
       ),
-      MultipleSubpropertyFullTextAttr(
+      DateMultipleSubpropertyFullTextAttr(
           "task due date", "cycle_task_group_tasks", ["end_date"], False
       ),
-      FullTextAttr("due date", 'next_due_date',),
+      DateFullTextAttr("due date", 'next_due_date',),
       FullTextAttr("assignee", "contact", ['name', 'email']),
       FullTextAttr("cycle title", 'cycle', ['title'], False),
       FullTextAttr("cycle assignee",
                    lambda x: x.cycle.contact,
                    ['email', 'name'], False),
-      FullTextAttr("cycle due date",
-                   lambda x: x.cycle.next_due_date,
-                   with_template=False),
+      DateFullTextAttr("cycle due date",
+                       lambda x: x.cycle.next_due_date,
+                       with_template=False),
   ]
 
   AUTO_REINDEX_RULES = [

--- a/src/ggrc_workflows/models/cycle_task_group_object_task.py
+++ b/src/ggrc_workflows/models/cycle_task_group_object_task.py
@@ -25,6 +25,7 @@ from ggrc_workflows.models.cycle_task_group import CycleTaskGroup
 from ggrc.fulltext.attributes import (
     FullTextAttr,
     MultipleSubpropertyFullTextAttr,
+    DateFullTextAttr
 )
 from ggrc.fulltext.mixin import Indexed, ReindexRule
 
@@ -57,7 +58,7 @@ class CycleTaskGroupObjectTask(
   PROPERTY_TEMPLATE = u"task {}"
 
   _fulltext_attrs = [
-      FullTextAttr("due date", 'end_date',),
+      DateFullTextAttr("due date", 'end_date',),
       FullTextAttr("assignee", 'contact', ['name', 'email']),
       FullTextAttr("group title", 'cycle_task_group', ['title'], False),
       FullTextAttr("cycle title", 'cycle', ['title'], False),
@@ -67,12 +68,12 @@ class CycleTaskGroupObjectTask(
       FullTextAttr("cycle assignee",
                    lambda x: x.cycle.contact,
                    ['email', 'name'], False),
-      FullTextAttr("group due date",
-                   lambda x: x.cycle_task_group.next_due_date,
-                   with_template=False),
-      FullTextAttr("cycle due date",
-                   lambda x: x.cycle.next_due_date,
-                   with_template=False),
+      DateFullTextAttr("group due date",
+                       lambda x: x.cycle_task_group.next_due_date,
+                       with_template=False),
+      DateFullTextAttr("cycle due date",
+                       lambda x: x.cycle.next_due_date,
+                       with_template=False),
       MultipleSubpropertyFullTextAttr("comment",
                                       "cycle_task_entries",
                                       ["description"]),

--- a/test/integration/ggrc_workflows/converters/test_export_cycle_tasks.py
+++ b/test/integration/ggrc_workflows/converters/test_export_cycle_tasks.py
@@ -193,3 +193,54 @@ class TestExportTasks(TestCase):
       ).one()
       self.assertCycles("task assignee", task.contact.email, [slug])
       self.assertCycles("task assignee", task.contact.name, [slug])
+
+  @data(
+      #  (Cycle count, tasks in cycle)
+      (0, 0),
+      (1, 1),
+      (2, 1),
+      (2, 1),
+      (2, 2),
+  )
+  @unpack
+  def test_filter_by_task_due_date_year(self, cycle_count, task_count):
+    """Test filter cycles by task due date year"""
+    task_cycle_filter = self.generate_tasks_for_cycle(cycle_count, task_count)
+    self.assertEqual(bool(cycle_count), bool(task_cycle_filter))
+    due_date_dict = defaultdict(set)
+    for task_id, slug in task_cycle_filter.iteritems():
+      task = CycleTaskGroupObjectTask.query.filter(
+          CycleTaskGroupObjectTask.id == task_id
+      ).one()
+      key = (task.end_date.year, task.end_date.month, task.end_date.day)
+      due_date_dict[key].add(slug)
+
+    for due_date, cycle_slugs in due_date_dict.iteritems():
+      self.assertCycles("task due date",
+                        "{}-{}-{}".format(*due_date),
+                        list(cycle_slugs))
+
+  @data(
+      #  (Cycle count, tasks in cycle)
+      (0, 0),
+      (1, 1),
+      (2, 1),
+      (2, 1),
+      (2, 2),
+  )
+  @unpack
+  def test_filter_by_task_due_date_year_month(self, cycle_count, task_count):
+    """Test filter cycles by task due date year month"""
+    task_cycle_filter = self.generate_tasks_for_cycle(cycle_count, task_count)
+    self.assertEqual(bool(cycle_count), bool(task_cycle_filter))
+    due_date_dict = defaultdict(set)
+    for task_id, slug in task_cycle_filter.iteritems():
+      task = CycleTaskGroupObjectTask.query.filter(
+          CycleTaskGroupObjectTask.id == task_id
+      ).one()
+      due_date_dict[(task.end_date.year, task.end_date.month)].add(slug)
+
+    for due_date, cycle_slugs in due_date_dict.iteritems():
+      self.assertCycles("task due date",
+                        "{}-{}".format(*due_date),
+                        list(cycle_slugs))


### PR DESCRIPTION
Implements a custom handler for `=` operator for datetime values and a custom parser for partial datetime values in filter query.

Cases covered:
`updated_at = 2017`
`updated_at = 2017-12`
`updated_at = 2017-12-01`
`updated_at = "2017-12-01 13"`
`updated_at = "2017-12-01 13:45"`
`updated_at = "2017-12-01 13:45:55"`
`updated_at = 12/2017`
`updated_at = 12/01/2017`
`updated_at = "12/01/2017 13"`
`updated_at = "12/01/2017 13:45"`
`updated_at = "12/01/2017 13:45:55"`

Note: all dates entered are supposed to be in UTC. Timezone conversion will be added in a separate PR.