### PR TITLE
QUICK-FIX fix export caching and improve fixtures for export integration tests

### DIFF
--- a/src/ggrc/converters/base_block.py
+++ b/src/ggrc/converters/base_block.py
@@ -263,6 +263,9 @@ class BlockConverter(object):
         models.all_models.UserRole.context_id.in_(context_ids)
     ).all()
 
+    if not user_roles:
+      return cache
+
     people_ids = {role[2] for role in user_roles}
 
     emails_map = dict(db.session.query(
@@ -289,6 +292,8 @@ class BlockConverter(object):
       owners = getattr(row_converter.obj, "object_owners", None)
       if owners:
         owner_ids |= {o.person_id for o in owners}
+    if not owner_ids:
+      return {}
     query = db.session.query(
         models.Person.id,
         models.Person.email

--- a/test/integration/ggrc/converters/test_export_csv.py
+++ b/test/integration/ggrc/converters/test_export_csv.py
@@ -54,8 +54,7 @@ class TestExportEmptyTemplate(TestCase):
 class TestExportSingleObject(TestCase):
 
   def setUp(self):
-    self.clear_data()
-    self._import_file("data_for_export_testing.csv")
+    super(TestExportSingleObject, self).setUp()
     self.client.get("/login")
     self.headers = {
         'Content-Type': 'application/json',
@@ -68,6 +67,7 @@ class TestExportSingleObject(TestCase):
                             headers=self.headers)
 
   def test_simple_export_query(self):
+    self._import_file("data_for_export_testing.csv")
     data = [{
         "object_name": "Program",
         "filters": {
@@ -107,6 +107,7 @@ class TestExportSingleObject(TestCase):
         self.assertNotIn(",Cat ipsum {},".format(i), response.data)
 
   def test_and_export_query(self):
+    self._import_file("data_for_export_testing.csv")
     data = [{
         "object_name": "Program",
         "filters": {
@@ -136,6 +137,7 @@ class TestExportSingleObject(TestCase):
         self.assertNotIn(",Cat ipsum {},".format(i), response.data)
 
   def test_simple_relevant_query(self):
+    self._import_file("data_for_export_testing.csv")
     data = [{
         "object_name": "Program",
         "filters": {
@@ -157,6 +159,7 @@ class TestExportSingleObject(TestCase):
         self.assertNotIn(",Cat ipsum {},".format(i), response.data)
 
   def test_program_audit_relevant_query(self):
+    self._import_file("data_for_export_testing.csv")
     data = [{  # should return just program prog-1
         "object_name": "Program",
         "filters": {
@@ -189,6 +192,7 @@ class TestExportSingleObject(TestCase):
         self.assertNotIn(",Audit {},".format(i), response.data)
 
   def test_section_policy_relevant_query(self):
+    self._import_file("data_for_export_testing.csv")
     data = [{  # sec-1
         "object_name": "Section",
         "filters": {
@@ -273,6 +277,7 @@ class TestExportSingleObject(TestCase):
         self.assertNotIn(title, response.data, "'{}' was found".format(title))
 
   def test_multiple_relevant_query(self):
+    self._import_file("data_for_export_testing.csv")
     data = [{
         "object_name": "Program",
         "filters": {
@@ -302,6 +307,7 @@ class TestExportSingleObject(TestCase):
         self.assertNotIn(",Cat ipsum {},".format(i), response.data)
 
   def test_query_all_aliases(self):
+    self._import_file("data_for_export_testing.csv")
     def rhs(model, attr):
       attr = getattr(model, attr, None)
       if attr is not None and hasattr(attr, "_query_clause_element"):
@@ -340,8 +346,7 @@ class TestExportSingleObject(TestCase):
 class TestExportMultipleObjects(TestCase):
 
   def setUp(self):
-    self.clear_data()
-    self._import_file("data_for_export_testing.csv")
+    super(TestExportMultipleObjects, self).setUp()
     self.client.get("/login")
     self.headers = {
         'Content-Type': 'application/json',
@@ -354,6 +359,7 @@ class TestExportMultipleObjects(TestCase):
                             headers=self.headers)
 
   def test_simple_multi_export(self):
+    self._import_file("data_for_export_testing.csv")
     data = [{
         "object_name": "Program",  # prog-1
         "filters": {
@@ -381,6 +387,7 @@ class TestExportMultipleObjects(TestCase):
     self.assertIn(",Hipster ipsum A 1,", response.data)
 
   def test_relevant_to_previous_export(self):
+    self._import_file("data_for_export_testing.csv")
     data = [{
         "object_name": "Program",  # prog-1, prog-23
         "filters": {

--- a/test/integration/ggrc/converters/test_export_csv.py
+++ b/test/integration/ggrc/converters/test_export_csv.py
@@ -401,7 +401,8 @@ class TestExportMultipleObjects(TestCase):
         self.assertNotIn(regulations[i], response.data)
 
   def test_relevant_to_previous_export(self):
-    self._import_file("data_for_export_testing.csv")
+    res = self._import_file("data_for_export_testing_relevant_previous.csv")
+    self._check_csv_response(res, {})
     data = [{
         "object_name": "Program",  # prog-1, prog-23
         "filters": {

--- a/test/integration/ggrc/converters/test_export_csv.py
+++ b/test/integration/ggrc/converters/test_export_csv.py
@@ -67,7 +67,8 @@ class TestExportSingleObject(TestCase):
                             headers=self.headers)
 
   def test_simple_export_query(self):
-    self._import_file("data_for_export_testing.csv")
+    response = self._import_file("data_for_export_testing_program.csv")
+    self._check_csv_response(response, {})
     data = [{
         "object_name": "Program",
         "filters": {
@@ -107,7 +108,8 @@ class TestExportSingleObject(TestCase):
         self.assertNotIn(",Cat ipsum {},".format(i), response.data)
 
   def test_and_export_query(self):
-    self._import_file("data_for_export_testing.csv")
+    response = self._import_file("data_for_export_testing_program.csv")
+    self._check_csv_response(response, {})
     data = [{
         "object_name": "Program",
         "filters": {
@@ -137,7 +139,8 @@ class TestExportSingleObject(TestCase):
         self.assertNotIn(",Cat ipsum {},".format(i), response.data)
 
   def test_simple_relevant_query(self):
-    self._import_file("data_for_export_testing.csv")
+    res = self._import_file("data_for_export_testing_program_contract.csv")
+    self._check_csv_response(res, {})
     data = [{
         "object_name": "Program",
         "filters": {
@@ -159,7 +162,8 @@ class TestExportSingleObject(TestCase):
         self.assertNotIn(",Cat ipsum {},".format(i), response.data)
 
   def test_program_audit_relevant_query(self):
-    self._import_file("data_for_export_testing.csv")
+    response = self._import_file("data_for_export_testing_program_audit.csv")
+    self._check_csv_response(response, {})
     data = [{  # should return just program prog-1
         "object_name": "Program",
         "filters": {
@@ -192,7 +196,8 @@ class TestExportSingleObject(TestCase):
         self.assertNotIn(",Audit {},".format(i), response.data)
 
   def test_section_policy_relevant_query(self):
-    self._import_file("data_for_export_testing.csv")
+    response = self._import_file("data_for_export_testing_directives.csv")
+    self._check_csv_response(response, {})
     data = [{  # sec-1
         "object_name": "Section",
         "filters": {
@@ -277,7 +282,9 @@ class TestExportSingleObject(TestCase):
         self.assertNotIn(title, response.data, "'{}' was found".format(title))
 
   def test_multiple_relevant_query(self):
-    self._import_file("data_for_export_testing.csv")
+    response = self._import_file(
+        "data_for_export_testing_program_policy_contract.csv")
+    self._check_csv_response(response, {})
     data = [{
         "object_name": "Program",
         "filters": {
@@ -307,7 +314,6 @@ class TestExportSingleObject(TestCase):
         self.assertNotIn(",Cat ipsum {},".format(i), response.data)
 
   def test_query_all_aliases(self):
-    self._import_file("data_for_export_testing.csv")
     def rhs(model, attr):
       attr = getattr(model, attr, None)
       if attr is not None and hasattr(attr, "_query_clause_element"):

--- a/test/integration/ggrc/converters/test_export_csv.py
+++ b/test/integration/ggrc/converters/test_export_csv.py
@@ -53,12 +53,9 @@ class TestExportEmptyTemplate(TestCase):
 
 class TestExportSingleObject(TestCase):
 
-  @classmethod
-  def setUpClass(cls):
-    cls.clear_data()
-    cls._import_file("data_for_export_testing.csv")
-
   def setUp(self):
+    self.clear_data()
+    self._import_file("data_for_export_testing.csv")
     self.client.get("/login")
     self.headers = {
         'Content-Type': 'application/json',
@@ -342,12 +339,9 @@ class TestExportSingleObject(TestCase):
 
 class TestExportMultipleObjects(TestCase):
 
-  @classmethod
-  def setUpClass(cls):
-    cls.clear_data()
-    cls._import_file("data_for_export_testing.csv")
-
   def setUp(self):
+    self.clear_data()
+    self._import_file("data_for_export_testing.csv")
     self.client.get("/login")
     self.headers = {
         'Content-Type': 'application/json',

--- a/test/integration/ggrc/converters/test_export_csv.py
+++ b/test/integration/ggrc/converters/test_export_csv.py
@@ -7,6 +7,7 @@ from flask.json import dumps
 from ggrc.converters import get_importables
 from ggrc.models.reflection import AttributeInfo
 from integration.ggrc import TestCase
+from integration.ggrc.models import factories
 
 THIS_ABS_PATH = abspath(dirname(__file__))
 CSV_DIR = join(THIS_ABS_PATH, 'test_csvs/')
@@ -365,14 +366,17 @@ class TestExportMultipleObjects(TestCase):
                             headers=self.headers)
 
   def test_simple_multi_export(self):
-    self._import_file("data_for_export_testing.csv")
+    match = 1
+    programs = [factories.ProgramFactory().title for i in range(3)]
+    regulations = [factories.RegulationFactory().title for i in range(3)]
+
     data = [{
         "object_name": "Program",  # prog-1
         "filters": {
             "expression": {
                 "left": "title",
                 "op": {"name": "="},
-                "right": "cat ipsum 1"
+                "right": programs[match]
             },
         },
         "fields": "all",
@@ -382,15 +386,19 @@ class TestExportMultipleObjects(TestCase):
             "expression": {
                 "left": "title",
                 "op": {"name": "="},
-                "right": "Hipster ipsum A 1"
+                "right": regulations[match]
             },
         },
         "fields": "all",
     }]
     response = self.export_csv(data)
-
-    self.assertIn(",Cat ipsum 1,", response.data)
-    self.assertIn(",Hipster ipsum A 1,", response.data)
+    for i in range(3):
+      if i == match:
+        self.assertIn(programs[i], response.data)
+        self.assertIn(regulations[i], response.data)
+      else:
+        self.assertNotIn(programs[i], response.data)
+        self.assertNotIn(regulations[i], response.data)
 
   def test_relevant_to_previous_export(self):
     self._import_file("data_for_export_testing.csv")

--- a/test/integration/ggrc/test_csvs/data_for_export_testing_directives.csv
+++ b/test/integration/ggrc/test_csvs/data_for_export_testing_directives.csv
@@ -1,0 +1,53 @@
+,,,,,
+Object type,,,,,
+Section,code*,title*,,owner,Policy / Regulation / Standard / Contract
+,sec-1,mapped section 1,,user@example.com,p1
+,sec-2,mapped section 2,,user@example.com,p2
+,sec-3,mapped section 3,,user@example.com,p3
+,sec-4,mapped section 4,,user@example.com,reg-1
+,sec-5,mapped section 5,,user@example.com,reg-2
+,sec-6,mapped section 6,,user@example.com,reg-3
+,sec-7,mapped section 7,,user@example.com,reg-4
+,sec-8,mapped section 8,,user@example.com,std-1
+,sec-9,mapped section 9,,user@example.com,std-2
+,sec-10,mapped section 10,,user@example.com,std-3
+,,,,,
+Object type,,,,,
+Standard,code*,title*,description ,owner,
+,std-1,mapped standard 1,test,user@example.com,
+,std-2,mapped standard 2,test,user@example.com,
+,std-3,mapped standard 3,test,user@example.com,
+,std-4,mapped standard 4,test,user@example.com,
+,std-5,mapped standard 5,test,user@example.com,
+,std-6,mapped standard 6,test,user@example.com,
+,std-7,mapped standard 7,test,user@example.com,
+,std-8,mapped standard 8,test,user@example.com,
+,std-9,mapped standard 9,test,user@example.com,
+,std-10,mapped standard 10,test,user@example.com,
+,,,,,
+,,,,,
+Object type,,,,,
+Regulation,code*,title*,description ,owner,
+,reg-1,mapped reg 1,test,user@example.com,
+,reg-2,mapped reg 2,test,user@example.com,
+,reg-3,mapped reg 3,test,user@example.com,
+,reg-4,mapped reg 4,test,user@example.com,
+,reg-5,mapped reg 5,test,user@example.com,
+,reg-6,mapped reg 6,test,user@example.com,
+,reg-7,mapped reg 7,test,user@example.com,
+,reg-8,mapped reg 8,test,user@example.com,
+,reg-9,mapped reg 9,test,user@example.com,
+,reg-10,mapped reg 10,test,user@example.com,
+,,,,,
+Object type,,,,,
+Policy,code*,title*,description ,owner,
+,p1,mapped policy 1,test,user@example.com,
+,p2,mapped policy 2,test,user@example.com,
+,p3,mapped policy 3,test,user@example.com,
+,p4,mapped policy 4,test,user@example.com,
+,p5,mapped policy 5,test,user@example.com,
+,p6,mapped policy 6,test,user@example.com,
+,p7,mapped policy 7,test,user@example.com,
+,p8,mapped policy 8,test,user@example.com,
+,p9,mapped policy 9,test,user@example.com,
+,p10,mapped policy 10,test,user@example.com,

--- a/test/integration/ggrc/test_csvs/data_for_export_testing_program.csv
+++ b/test/integration/ggrc/test_csvs/data_for_export_testing_program.csv
@@ -1,0 +1,25 @@
+Object Type,,,
+program,Code,Title,Manager
+,prog-1,Cat ipsum 1,user@example.com
+,prog-2,Cat ipsum 2,user@example.com
+,prog-3,Cat ipsum 3,user@example.com
+,prog-4,Cat ipsum 4,user@example.com
+,prog-5,Cat ipsum 5,user@example.com
+,prog-6,Cat ipsum 6,user@example.com
+,prog-7,Cat ipsum 7,user@example.com
+,prog-8,Cat ipsum 8,user@example.com
+,prog-9,Cat ipsum 9,user@example.com
+,prog-10,Cat ipsum 10,user@example.com
+,prog-11,Cat ipsum 11,user@example.com
+,prog-12,Cat ipsum 12,user@example.com
+,prog-13,Cat ipsum 13,user@example.com
+,prog-14,Cat ipsum 14,user@example.com
+,prog-15,Cat ipsum 15,user@example.com
+,prog-16,Cat ipsum 16,user@example.com
+,prog-17,Cat ipsum 17,user@example.com
+,prog-18,Cat ipsum 18,user@example.com
+,prog-19,Cat ipsum 19,user@example.com
+,prog-20,Cat ipsum 20,user@example.com
+,prog-21,Cat ipsum 21,user@example.com
+,prog-22,Cat ipsum 22,user@example.com
+,prog-23,Cat ipsum 23,user@example.com

--- a/test/integration/ggrc/test_csvs/data_for_export_testing_program_audit.csv
+++ b/test/integration/ggrc/test_csvs/data_for_export_testing_program_audit.csv
@@ -1,0 +1,44 @@
+Object Type,,,,,,,,,,,
+program,Code,Title,Manager,,,,,,,,
+,prog-1,Cat ipsum 1,user@example.com,,,,,,,,
+,prog-2,Cat ipsum 2,user@example.com,,,,,,,,
+,prog-3,Cat ipsum 3,user@example.com,,,,,,,,
+,prog-4,Cat ipsum 4,user@example.com,,,,,,,,
+,prog-5,Cat ipsum 5,user@example.com,,,,,,,,
+,prog-6,Cat ipsum 6,user@example.com,,,,,,,,
+,prog-7,Cat ipsum 7,user@example.com,,,,,,,,
+,prog-8,Cat ipsum 8,user@example.com,,,,,,,,
+,prog-9,Cat ipsum 9,user@example.com,,,,,,,,
+,prog-10,Cat ipsum 10,user@example.com,,,,,,,,
+,,,,,,,,,,,
+,,,,,,,,,,,
+,,,,,,,,,,,
+,,,,,,,,,,,
+,,,,,,,,,,,
+,,,,,,,,,,,
+,,,,,,,,,,,
+,,,,,,,,,,,
+,,,,,,,,,,,
+,,,,,,,,,,,
+,,,,,,,,,,,
+,,,,,,,,,,,
+,,,,,,,,,,,
+,,,,,,,,,,,
+,,,,,,,,,,,
+,,,,,,,,,,,
+,,,,,,,,,,,
+Object Type,,,,,,,,,,,
+audit,Program,Title,Description,Internal Audit Lead,Status,Planned Start Date,Planned End Date,Planned Report Period from,Planned Report Period to,Auditors,code
+,prog-1,Audit 1,this is great,user@example.com,PLANNED,5/25/2015,5/26/2015,5/27/2015,5/28/2015,user@example.com,au-1
+,prog-2,Audit 2,this is great,user@example.com,PLANNED,5/26/2015,5/27/2015,5/28/2015,5/29/2015,user@example.com,au-2
+,prog-1,Audit 3,this is great,user@example.com,PLANNED,5/27/2015,5/28/2015,5/29/2015,5/30/2015,user@example.com,au-3
+,prog-2,Audit 4,this is great,user@example.com,PLANNED,5/28/2015,5/29/2015,5/30/2015,5/31/2015,user@example.com,au-4
+,prog-1,Audit 5,this is great,user@example.com,PLANNED,5/29/2015,5/30/2015,5/31/2015,6/1/2015,user@example.com,au-5
+,prog-2,Audit 6,this is great,user@example.com,PLANNED,5/30/2015,5/31/2015,6/1/2015,6/2/2015,user@example.com,au-6
+,prog-1,Audit 7,this is great,user@example.com,PLANNED,5/31/2015,6/1/2015,6/2/2015,6/3/2015,user@example.com,au-7
+,prog-2,Audit 8,this is great,user@example.com,PLANNED,6/1/2015,6/2/2015,6/3/2015,6/4/2015,user@example.com,au-8
+,prog-3,Audit 9,this is great,user@example.com,PLANNED,6/2/2015,6/3/2015,6/4/2015,6/5/2015,user@example.com,au-9
+,prog-4,Audit 10,this is great,user@example.com,PLANNED,6/3/2015,6/4/2015,6/5/2015,6/6/2015,user@example.com,au-10
+,prog-5,Audit 11,this is great,user@example.com,PLANNED,6/4/2015,6/5/2015,6/6/2015,6/7/2015,user@example.com,au-11
+,prog-6,Audit 12,this is great,user@example.com,PLANNED,6/5/2015,6/6/2015,6/7/2015,6/8/2015,user@example.com,au-12
+,prog-7,Audit 13,this is great,user@example.com,PLANNED,6/6/2015,6/7/2015,6/8/2015,6/9/2015,user@example.com,au-13

--- a/test/integration/ggrc/test_csvs/data_for_export_testing_program_contract.csv
+++ b/test/integration/ggrc/test_csvs/data_for_export_testing_program_contract.csv
@@ -1,0 +1,59 @@
+Object Type,,,,
+program,Code,Title,Manager,map:contract
+,prog-1,Cat ipsum 1,user@example.com,"contract-25
+contract-27"
+,prog-2,Cat ipsum 2,user@example.com,"contract-25
+contract-27"
+,prog-3,Cat ipsum 3,user@example.com,"contract-25
+contract-27"
+,prog-4,Cat ipsum 4,user@example.com,"contract-25
+contract-27"
+,prog-5,Cat ipsum 5,user@example.com,"contract-25
+contract-27"
+,prog-6,Cat ipsum 6,user@example.com,"contract-25
+contract-27"
+,prog-7,Cat ipsum 7,user@example.com,
+,prog-8,Cat ipsum 8,user@example.com,contract-40
+,prog-9,Cat ipsum 9,user@example.com,contract-39
+,prog-10,Cat ipsum 10,user@example.com,contract-40
+,prog-11,Cat ipsum 11,user@example.com,contract-40
+,prog-12,Cat ipsum 12,user@example.com,contract-39
+,prog-13,Cat ipsum 13,user@example.com,contract-40
+,prog-14,Cat ipsum 14,user@example.com,contract-40
+,prog-15,Cat ipsum 15,user@example.com,contract-39
+,prog-16,Cat ipsum 16,user@example.com,contract-40
+,prog-17,Cat ipsum 17,user@example.com,contract-41
+,prog-18,Cat ipsum 18,user@example.com,contract-42
+,prog-19,Cat ipsum 19,user@example.com,contract-43
+,prog-20,Cat ipsum 20,user@example.com,contract-44
+,prog-21,Cat ipsum 21,user@example.com,contract-45
+,prog-22,Cat ipsum 22,user@example.com,contract-46
+,prog-23,Cat ipsum 23,user@example.com,
+,,,,
+,,,,
+Object Type,,,,
+contract,Code,Title,Owner,map:program
+,contract-25,con 5,user@example.com,prog-7
+,contract-26,con 10,user@example.com,
+,contract-27,con 15,user@example.com,prog-7
+,contract-28,con 20,user@example.com,
+,contract-29,con 25,user@example.com,
+,contract-30,con 30,user@example.com,
+,contract-31,con 35,user@example.com,
+,contract-32,con 40,user@example.com,
+,contract-33,con 45,user@example.com,
+,contract-34,con 50,user@example.com,
+,contract-35,con 55,user@example.com,
+,contract-36,con 60,user@example.com,
+,contract-37,con 65,user@example.com,
+,contract-38,con 70,user@example.com,
+,contract-39,con 75,user@example.com,
+,contract-40,con 80,user@example.com,
+,contract-41,con 85,user@example.com,
+,contract-42,con 90,user@example.com,
+,contract-43,con 95,user@example.com,
+,contract-44,con 100,user@example.com,
+,contract-45,con 105,user@example.com,
+,contract-46,con 110,user@example.com,
+,contract-47,con 115,user@example.com,prog-23
+,contract-48,con 120,user@example.com,

--- a/test/integration/ggrc/test_csvs/data_for_export_testing_program_policy_contract.csv
+++ b/test/integration/ggrc/test_csvs/data_for_export_testing_program_policy_contract.csv
@@ -1,0 +1,84 @@
+,,,,,
+Object Type,,,,,
+program,Title,Code,Manager,map:policy,map:contract
+,Cat ipsum 1,prog-1,user@example.com,"policy-1
+policy-2
+policy-3
+policy-4
+Policy-5","contract-25
+contract-27"
+,Cat ipsum 2,prog-2,user@example.com,"policy-1
+policy-2
+policy-3
+policy-4
+Policy-5","contract-25
+contract-27"
+,Cat ipsum 3,prog-3,user@example.com,,"contract-25
+contract-27"
+,Cat ipsum 4,prog-4,user@example.com,"policy-1
+policy-2
+policy-3
+policy-4
+Policy-5","contract-25
+contract-27"
+,Cat ipsum 5,prog-5,user@example.com,,"contract-25
+contract-27"
+,Cat ipsum 6,prog-6,user@example.com,,"contract-25
+contract-27"
+,Cat ipsum 7,prog-7,user@example.com,,"contract-25
+contract-27"
+,Cat ipsum 8,prog-8,user@example.com,"policy-1
+policy-2
+policy-3
+policy-4
+Policy-5",contract-40
+,Cat ipsum 9,prog-9,user@example.com,"policy-1
+policy-2
+policy-3
+policy-4",contract-39
+,Cat ipsum 10,prog-10,user@example.com,"policy-1
+policy-2
+policy-3
+policy-4",contract-40
+,Cat ipsum 11,prog-11,user@example.com,"policy-1
+policy-2
+policy-3",contract-40
+,Cat ipsum 12,prog-12,user@example.com,"policy-1
+policy-2
+policy-3",contract-39
+,Cat ipsum 13,prog-13,user@example.com,"policy-1
+policy-2
+policy-3",contract-40
+,Cat ipsum 14,prog-14,user@example.com,"policy-1
+policy-2",contract-40
+,Cat ipsum 15,prog-15,user@example.com,"policy-1
+policy-2",contract-39
+,Cat ipsum 16,prog-16,user@example.com,,contract-40
+,Cat ipsum 17,prog-17,user@example.com,,contract-41
+,Cat ipsum 18,prog-18,user@example.com,,
+,Cat ipsum 19,prog-19,user@example.com,,
+,,,,,
+,,,,,
+,,,,,
+,,,,,
+,,,,,
+,,,,,
+Object Type,,,,,
+policy,Title,Owner,Code,,
+,Cheese ipsum ch 5,user@example.com,policy-1,,
+,Cheese ipsum ch 6,user@example.com,policy-2,,
+,Cheese ipsum ch 7,user@example.com,policy-3,,
+,Cheese ipsum ch 8,user@example.com,policy-4,,
+,Cheese ipsum ch 9,user@example.com,policy-5,,
+,,,,,
+,,,,,
+,,,,,
+Object Type,,,,,
+contract,Title,Code,Owner,,
+,con 5,contract-25,user@example.com,,
+,con 10,contract-26,user@example.com,,
+,con 15,contract-27,user@example.com,,
+,con 70,contract-38,user@example.com,,
+,con 75,contract-39,user@example.com,,
+,con 80,contract-40,user@example.com,,
+,con 85,contract-41,user@example.com,,

--- a/test/integration/ggrc/test_csvs/data_for_export_testing_relevant_previous.csv
+++ b/test/integration/ggrc/test_csvs/data_for_export_testing_relevant_previous.csv
@@ -1,0 +1,238 @@
+,,,,,,
+Object Type,,,,,,
+program,Title,Manager,Code,map:policy,map:contract,map: control
+,Cat ipsum 1,user@example.com,prog-1,"policy-1
+policy-2
+policy-3
+policy-4
+policy-5
+policy-6
+policy-7
+policy-8
+policy-9
+policy-10
+policy-11
+policy-12
+policy-13
+policy-14
+policy-15
+policy-16","contract-25
+contract-27","control-1
+control-2
+control-3
+control-4
+control-5
+control-16
+control-17
+control-18
+control-19
+control-20
+control-21
+control-22
+control-23
+control-24
+control-25"
+,Cat ipsum 2,user@example.com,prog-2,"policy-1
+policy-2
+policy-3
+policy-4
+policy-5
+policy-15
+policy-16","contract-25
+contract-27","control-1
+control-2
+control-3
+control-4"
+,Cat ipsum 3,user@example.com,prog-3,"
+policy-10
+policy-11
+policy-12
+policy-13
+policy-14
+policy-15
+policy-16","contract-25
+contract-27","control-1
+control-2
+control-3
+control-4"
+,Cat ipsum 4,user@example.com,prog-4,"policy-1
+policy-2
+policy-3
+policy-4
+policy-5
+policy-12
+policy-13
+policy-14
+policy-15
+policy-16","contract-25
+contract-27","control-1
+control-2
+control-3
+control-4"
+,Cat ipsum 5,user@example.com,prog-5,"policy-10
+policy-11
+policy-12
+policy-13
+policy-14
+policy-15
+policy-16","contract-25
+contract-27","control-1
+control-2
+control-3
+control-4"
+,Cat ipsum 6,user@example.com,prog-6,"policy-10
+policy-11
+policy-12
+policy-13
+policy-14
+policy-15
+policy-16","contract-25
+contract-27",
+,Cat ipsum 7,user@example.com,prog-7,"policy-10
+policy-11
+policy-12
+policy-13
+policy-14
+policy-15
+policy-16","contract-25
+contract-27",
+,Cat ipsum 8,user@example.com,prog-8,"policy-1
+policy-2
+policy-3
+policy-4
+policy-5
+policy-6
+policy-7
+policy-8",contract-40,
+,Cat ipsum 9,user@example.com,prog-9,"policy-1
+policy-2
+policy-3
+policy-4",contract-39,
+,Cat ipsum 10,user@example.com,prog-10,"policy-1
+policy-2
+policy-3
+policy-4",contract-40,
+,Cat ipsum 11,user@example.com,prog-11,"policy-1
+policy-2
+policy-3",contract-40,
+,Cat ipsum 12,user@example.com,prog-12,"policy-1
+policy-2
+policy-3",contract-39,
+,Cat ipsum 13,user@example.com,prog-13,"policy-1
+policy-2
+policy-3",contract-40,
+,Cat ipsum 14,user@example.com,prog-14,"policy-1
+policy-2",contract-40,
+,Cat ipsum 15,user@example.com,prog-15,"policy-1
+policy-2",contract-39,
+,Cat ipsum 16,user@example.com,prog-16,"policy-1
+policy-2",contract-40,
+,Cat ipsum 17,user@example.com,prog-17,"policy-1
+policy-2",contract-41,
+,Cat ipsum 18,user@example.com,prog-18,"policy-1
+policy-2",contract-42,
+,Cat ipsum 19,user@example.com,prog-19,"policy-1
+policy-2",contract-43,
+,Cat ipsum 20,user@example.com,prog-20,"policy-1
+policy-2",contract-44,
+,Cat ipsum 21,user@example.com,prog-21,"policy-1
+policy-2",contract-45,
+,Cat ipsum 22,user@example.com,prog-22,"policy-1
+policy-2",contract-46,
+,Cat ipsum 23,user@example.com,prog-23,"policy-1
+policy-2",contract-47,
+,,,,,,
+,,,,,,
+,,,,,,
+Object Type,,,,,,
+policy,Title,Owner,Code,map:control,,
+,Cheese ipsum ch 5,user@example.com,policy-1,control-1,,
+,Cheese ipsum ch 6,user@example.com,policy-2,control-2,,
+,Cheese ipsum ch 7,user@example.com,policy-3,"control-5
+control-7",,
+,Cheese ipsum ch 8,user@example.com,policy-4,"control-5
+control-7",,
+,Cheese ipsum ch 9,user@example.com,policy-5,"control-5
+control-7",,
+,Cheese ipsum ch 10,user@example.com,policy-6,"control-5
+control-7",,
+,Cheese ipsum ch 11,user@example.com,policy-7,control-8,,
+,Cheese ipsum ch 12,user@example.com,policy-8,control-8,,
+,Cheese ipsum ch 13,user@example.com,policy-9,control-8,,
+,Cheese ipsum ch 14,user@example.com,policy-10,control-8,,
+,Cheese ipsum ch 15,user@example.com,policy-11,control-8,,
+,Cheese ipsum ch 16,user@example.com,policy-12,control-8,,
+,Cheese ipsum ch 17,user@example.com,policy-13,control-8,,
+,Cheese ipsum ch 18,user@example.com,policy-14,control-8,,
+,Cheese ipsum ch 19,user@example.com,policy-15,"control-5
+control-7",,
+,Cheese ipsum ch 20,user@example.com,policy-16,"control-5
+control-7",,
+,Cheese ipsum ch 21,user@example.com,policy-17,"control-5
+control-7",,
+,Cheese ipsum ch 22,user@example.com,policy-18,"control-5
+control-7",,
+,Cheese ipsum ch 23,user@example.com,policy-19,"control-5
+control-7",,
+,Cheese ipsum ch 24,user@example.com,policy-20,"control-5
+control-7",,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+Object Type,,,,,,
+contract,Title,Owner,Code,,,
+,con 5,user@example.com,contract-25,,,
+,con 10,user@example.com,contract-26,,,
+,con 15,user@example.com,contract-27,,,
+,con 20,user@example.com,contract-28,,,
+,con 25,user@example.com,contract-29,,,
+,con 30,user@example.com,contract-30,,,
+,con 35,user@example.com,contract-31,,,
+,con 40,user@example.com,contract-32,,,
+,con 45,user@example.com,contract-33,,,
+,con 50,user@example.com,contract-34,,,
+,con 55,user@example.com,contract-35,,,
+,con 60,user@example.com,contract-36,,,
+,con 65,user@example.com,contract-37,,,
+,con 70,user@example.com,contract-38,,,
+,con 75,user@example.com,contract-39,,,
+,con 80,user@example.com,contract-40,,,
+,con 85,user@example.com,contract-41,,,
+,con 90,user@example.com,contract-42,,,
+,con 95,user@example.com,contract-43,,,
+,con 100,user@example.com,contract-44,,,
+,con 105,user@example.com,contract-45,,,
+,con 110,user@example.com,contract-46,,,
+,con 115,user@example.com,contract-47,,,
+,con 120,user@example.com,contract-48,,,
+,,,,,,
+,,,,,,
+,,,,,,
+Object Type,,,,,,
+control,Title,Owner,Code,,,
+,Startupsum 115,user@example.com,control-1,,,
+,Startupsum 116,user@example.com,control-2,,,
+,Startupsum 117,user@example.com,control-3,,,
+,Startupsum 118,user@example.com,control-4,,,
+,Startupsum 119,user@example.com,control-5,,,
+,Startupsum 120,user@example.com,control-6,,,
+,Startupsum 121,user@example.com,control-7,,,
+,Startupsum 122,user@example.com,control-8,,,
+,Startupsum 123,user@example.com,control-9,,,
+,Startupsum 124,user@example.com,control-10,,,
+,Startupsum 125,user@example.com,control-11,,,
+,Startupsum 126,user@example.com,control-12,,,
+,Startupsum 127,user@example.com,control-13,,,
+,Startupsum 128,user@example.com,control-14,,,
+,Startupsum 129,user@example.com,control-15,,,
+,Startupsum 130,user@example.com,control-16,,,
+,Startupsum 131,user@example.com,control-17,,,
+,Startupsum 132,user@example.com,control-18,,,
+,Startupsum 133,user@example.com,control-19,,,
+,Startupsum 134,user@example.com,control-20,,,
+,Startupsum 135,user@example.com,control-21,,,
+,Startupsum 136,user@example.com,control-22,,,
+,Startupsum 137,user@example.com,control-23,,,
+,Startupsum 138,user@example.com,control-24,,,
+,Startupsum 139,user@example.com,control-25,,,

--- a/test/integration/ggrc_workflows/converters/test_workflow_export_csv.py
+++ b/test/integration/ggrc_workflows/converters/test_workflow_export_csv.py
@@ -66,17 +66,6 @@ class TestExportMultipleObjects(TestCase):
 
   CSV_DIR = join(abspath(dirname(__file__)), "test_csvs/")
 
-  @classmethod
-  def setUpClass(cls):  # pylint: disable=C0103
-    cls.clear_data()
-    cls.client = app.test_client()
-    cls.client.get("/login")
-    cls.import_file("workflow_big_sheet.csv")
-
-  @classmethod
-  def import_file(cls, filename, dry_run=False):
-    cls._import_file(filename, dry_run)
-
   def activate(self):
     """ activate workflows just once after the class has been initialized
 
@@ -94,6 +83,8 @@ class TestExportMultipleObjects(TestCase):
       gen.activate_workflow(wf)
 
   def setUp(self):
+    self.clear_data()
+    self.import_file("workflow_big_sheet.csv")
     self.client.get("/login")
     self.headers = {
         'Content-Type': 'application/json',


### PR DESCRIPTION
~This PR is just an improvement on the tests refactor from https://github.com/google/ggrc-core/pull/5404.~

~It will be rebased once the original PR is merged.~

This PR is just for performance improvement in tests, but also includes fixes export cache. 

Export tests average runtime
on current raspberry branch: 54.904s
~on PR #5404: 194.893s~
on this PR: 33.329s

Edit: the original PR had the refactor commit removed and I have cherry picked it into this PR.