### PR TITLE
GGRC 1175 Move export objects button to the left "Add another object type" button

### DIFF
--- a/src/ggrc/assets/mustache/import_export/export.mustache
+++ b/src/ggrc/assets/mustache/import_export/export.mustache
@@ -5,7 +5,7 @@
 
 <csv-export filename="Export Objects">
 <div class="info no-space">
-  <div class="choose-object-wrap bottom-space">
+  <div class="choose-object-wrap">
     <div class="row-fluid">
       <div class="span12">
         <div class="report-title">
@@ -47,23 +47,18 @@
           </div>
         {{/each}}
       </div>
-      <div class="add-rule add-object">
-        <a href="#" id="addAnotherObjectType" class="addFilterRule btn btn-small btn-info">Add another object type</a>
+      <div class="export-group__actions-wrap">
+        <a href="#" id="addAnotherObjectType" class="addFilterRule btn btn-small btn-info">Add Object Type</a>
+        {{^export.loading}}
+          <button type="submit" id="export-csv-button" class="btn btn-success btn-small">
+            Export Objects
+          </button>
+        {{/loading }}
+        {{#export.loading}}
+          <span {{attach_spinner '{ "radius": 4, "length": 4, "width": 2 }' 'display:inline-block; top: -3px; left: 30px;' }}></span>
+        {{/loading }}
       </div>
     </export-group>
-  </div>
-  <div class="save-template-wrap">
-    <div class="btn-group pull-right">
-      {{^export.loading}}
-        <button type="submit" id="export-csv-button" class="btn btn-success btn-small">
-          <i class="fa fa-download white"></i>
-          Export Objects
-        </button>
-      {{/loading }}
-      {{#export.loading}}
-        <span {{attach_spinner '{ "radius": 4, "length": 4, "width": 2 }' 'display:inline-block; top: -3px; left: 30px;' }}></span>
-      {{/loading }}
-    </div>
   </div>
 </div>
 </csv-export>

--- a/src/ggrc/assets/stylesheets/modules/_import-export.scss
+++ b/src/ggrc/assets/stylesheets/modules/_import-export.scss
@@ -249,3 +249,14 @@ form.import {
     margin-bottom: 0;
   }
 }
+
+.export-group__actions-wrap {
+  margin-top: 6px;
+  & > .btn-success {
+    background-color: $btnGreen;
+  }
+
+  & > .btn-info {
+    background-color: $blue;
+  }
+}


### PR DESCRIPTION
 Move Export Object button to the left side of Add object type button, so that the user doesnt have to move their mouse on each side.
![image](https://cloud.githubusercontent.com/assets/24203972/24411237/12b396aa-13de-11e7-86af-e320f6e4f507.png)
