### PR TITLE
GGRC-1366 (GGRC-1628) Remove objects and comments from edit assessment

### DIFF
--- a/src/ggrc/assets/javascripts/models/assessment.js
+++ b/src/ggrc/assets/javascripts/models/assessment.js
@@ -434,14 +434,19 @@
     get_related_objects_as_source: function () {
       var dfd = can.Deferred();
       var self = this;
+      var snapshots = GGRC.Utils.Snapshots;
       this.get_binding('related_objects_as_source')
         .refresh_instances()
         .then(function (list) {
-          list.forEach(function (item) {
+          var newList = list.filter(function (item) {
+            return !snapshots.isSnapshotModel(item.instance.type) &&
+                item.instance.type !== 'Comment';
+          });
+          newList.forEach(function (item) {
             var query;
             var instance = item.instance;
-            if (GGRC.Utils.Snapshots.isSnapshotType(instance)) {
-              query = GGRC.Utils.Snapshots.getSnapshotItemQuery(
+            if (snapshots.isSnapshotType(instance)) {
+              query = snapshots.getSnapshotItemQuery(
                 self, instance.child_id, instance.child_type);
 
               GGRC.Utils.QueryAPI
@@ -464,7 +469,7 @@
                 });
             }
           });
-          dfd.resolve(list);
+          dfd.resolve(newList);
         });
       return dfd;
     }


### PR DESCRIPTION
**GGRC-1366**
**Control and control's snapshot are shown in Edit Assessment modal window**

**Steps to reproduce**:
1. On the Audit page create assessment
2. Map control to audit and map this control to assessment
2. Open Edit Assessment modal window
3. Look at mapped objects to assessment: Control and control's snapshot are shown

**Actual Result**: Control and control's snapshot are shown in Edit Assessment modal window
**Expected Result**: Only control's snapshot that is mapped to assessment should be shown in Edit Assessment modal window and marked with a blue color

![image](https://cloud.githubusercontent.com/assets/567805/24357204/96921c64-1305-11e7-86a5-255d66896023.png)

**GGRC-1628**
**Edit Assessment - remove mapped comments**

![image](https://cloud.githubusercontent.com/assets/567805/24364952/fe142d52-131c-11e7-816d-876c4093cf62.png)
