### PR TITLE
GGRC-85 Add Audit name on Edit Assessment Template modal window

### DIFF
--- a/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
@@ -37,7 +37,9 @@
     <div class="row-fluid">
       <div class="span6">
         <label>Audit</label>
-        <strong>{{object_params.audit_title}}</strong>
+        {{#using audit=instance.audit }}
+          <input tabindex="2" class="input-block-level" name="audit.title" data-permission-type="update" data-lookup="Audit" data-template="/directives/autocomplete_result.mustache" placeholder="Choose Audit" type="text" null-if-empty="false" value="{{firstnonempty audit.title ''}}" disabled="disabled" />
+        {{/using}}
       </div>
     </div>
 


### PR DESCRIPTION
1) Create Assessment Template
2) Navigate on Assessment Template 
OR
Navigate on Audit page and open Assessment Templates tab
3) Open Edit Assessment Template dialog

Actual: no Audit data in the dialog window.
Expected: Audit name is provided in Edit Assessment Template dialog.