### PR TITLE
GGRC-1682 "Issue" field instead of "Issue URL" is displayed in tree view and Set visibility dialog

### DIFF
--- a/src/ggrc/assets/javascripts/models/issue.js
+++ b/src/ggrc/assets/javascripts/models/issue.js
@@ -27,7 +27,7 @@
     },
     tree_view_options: {
       attr_list: can.Model.Cacheable.attr_list.concat([
-        {attr_title: 'Issue', attr_name: 'url'},
+        {attr_title: 'Issue URL', attr_name: 'url'},
         {attr_title: 'Reference URL', attr_name: 'reference_url'}
       ]),
       attr_view: GGRC.mustache_path + '/base_objects/tree-item-attr.mustache'


### PR DESCRIPTION
_Steps to reproduce:_
1. On the audit page create Issue and add Issue URL while creating
2. Open Set visibility dialog and mark Issue url> Set fields

_Actual Result_: "Issue" field instead of "Issue URL" is displayed in tree view and Set visibility dialog
_Expected Result_: "Issue URL" is displayed in tree view and Set visibility dialog

![screenshot-1](https://cloud.githubusercontent.com/assets/4204416/24396986/a66c41c0-13ad-11e7-8c2d-e0a3f9892d46.png)
