### PR TITLE
GGRC-1461 Multi select dropdown filter is not cleaned if object that contains the states differ from Active, Draft, Deprecated is selected

### DIFF
--- a/src/ggrc/assets/javascripts/components/dropdown/multiselect-dropdown.js
+++ b/src/ggrc/assets/javascripts/components/dropdown/multiselect-dropdown.js
@@ -54,6 +54,7 @@
           type: '*',
           set: function (value) {
             var self = this;
+            this.attr('selected', []);
             if (value) {
               value.forEach(function (item) {
                 self.updateSelected(item);


### PR DESCRIPTION
_Steps to reproduce:_
1. Go to My Work page and Open Search Unified mapper
2. Select "Program" in object type and choose "Active" in Multi select dropdown filter > Search
3. Select another object "Assessment"
4. Look at field in Multi select dropdown filter: active state is applied to Assessment that doesn't have Active state

_Actual Result:_ Multi select dropdown filter is not cleaned if object that contains the states differ from Active, Draft, Deprecated is selected 
_Expected Result:_ Multi select dropdown filter should be cleaned if object that contains the states differ from Active, Draft, Deprecated is selected

![screenshot-1](https://cloud.githubusercontent.com/assets/4204416/24403642/743c96aa-13c6-11e7-8684-1a613932d9e4.png)
