### PR TITLE
GGRC-1584 Apply multi-select dropdown filter for objects first tier only

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/tree/tree-view.js
+++ b/src/ggrc/assets/javascripts/controllers/tree/tree-view.js
@@ -1359,9 +1359,6 @@
       };
       var originalOrder = GGRC.Utils.TreeView.getModelsForSubTier(parent.type);
       var limit = this.options.subTreeElementsLimit;
-      var states = parentCtrl.options.attr('selectStateList');
-      var statesFilter = GGRC.Utils.State.statusFilter(states, '');
-      var statesQuery = GGRC.query_parser.parse(statesFilter);
       var typeModels;
       var fields = [
         'child_id',
@@ -1409,10 +1406,6 @@
           countMap.forEach(function (item) {
             item.fields = fields;
             item.page = {current: 1, pageSize: item.count};
-
-            if (GGRC.Utils.State.hasState(item.type)) {
-              item.filter = statesQuery;
-            }
           });
 
           return this.loadSubTreeData(countMap, relevant);


### PR DESCRIPTION
Precondition: have program, control, audit, assessment with mapped control to assessment 

Steps to reproduce:
1. Go to My assessments page
2. Expand second level for assessment

Actual Result: Mapped Control is not shown in the second level as Control doesn't have states as applied in filter for assessment

Expected Result: Multi select dropdown filter should be applied for objects first tier. In this case multi select dropdown filter should be applied only for Assessment, not for Control which is mapped to Assessment. Control should be shown if expand second level.
