### PR TITLE
GGRC-1367 Disable ability to unmap audit from assessment

### DIFF
--- a/src/ggrc/assets/javascripts/models/assessment.js
+++ b/src/ggrc/assets/javascripts/models/assessment.js
@@ -434,14 +434,19 @@
     get_related_objects_as_source: function () {
       var dfd = can.Deferred();
       var self = this;
+      var snapshots = GGRC.Utils.Snapshots;
       this.get_binding('related_objects_as_source')
         .refresh_instances()
         .then(function (list) {
-          list.forEach(function (item) {
+          var newList = list.filter(function (item) {
+            return !snapshots.isSnapshotModel(item.instance.type) &&
+                item.instance.type !== 'Comment';
+          });
+          newList.forEach(function (item) {
             var query;
             var instance = item.instance;
-            if (GGRC.Utils.Snapshots.isSnapshotType(instance)) {
-              query = GGRC.Utils.Snapshots.getSnapshotItemQuery(
+            if (snapshots.isSnapshotType(instance)) {
+              query = snapshots.getSnapshotItemQuery(
                 self, instance.child_id, instance.child_type);
 
               GGRC.Utils.QueryAPI
@@ -464,7 +469,7 @@
                 });
             }
           });
-          dfd.resolve(list);
+          dfd.resolve(newList);
         });
       return dfd;
     }

--- a/src/ggrc/assets/mustache/assessments/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessments/modal_content.mustache
@@ -93,14 +93,16 @@
                               </div>
                             </div> <!-- span10 end -->
 
-                            <div class="span2">
-                              <div class="show-details">
-                                <a href="javascript://" class="unmap" data-toggle="unmap">
-                                  <span class="result" {{data 'result'}}></span>
-                                  <i class="fa fa-trash"></i>
-                                </a>
-                              </div>
-                            </div> <!-- span2 end -->
+                            {{^is type 'Audit'}}
+                              <div class="span2">
+                                <div class="show-details">
+                                  <a href="javascript://" class="unmap" data-toggle="unmap">
+                                    <span class="result" {{data 'result'}}></span>
+                                    <i class="fa fa-trash"></i>
+                                  </a>
+                                </div>
+                              </div> <!-- span2 end -->
+                            {{/is}}
                           </div> <!-- row-fluid end -->
                         </div> <!-- item-data end -->
                       </div> <!-- select end -->


### PR DESCRIPTION
**Possibility unmap assessment from audit**

**Steps to reproduce**:
1. On the Audit page create assessment
2. Map control to audit and map this control to assessment
3. Open Edit Assessment modal window
4. Click trash icon to unmap audit from assessment: success

**Actual Result**: There is a possibility to unmap assessment from audit in Edit Assessment modal window

**Expected Result**: Removing the mapping of assessment to audit is not
allowed. So there cannot be unmap against an audit. 

![image](https://cloud.githubusercontent.com/assets/567805/24410265/51afa0ea-13db-11e7-8d47-7b1efa3b7c4b.png)
