### PR TITLE
GGRC-1307 Remove Map button from Assessment's Audits tab

### DIFF
--- a/src/ggrc/assets/mustache/audits/tree_add_item.mustache
+++ b/src/ggrc/assets/mustache/audits/tree_add_item.mustache
@@ -21,6 +21,7 @@
     {{/is_allowed}}
     {{/if}}
 {{else}}
+    {{^if_instance_of parent_instance 'Assessment'}}
     {{#is_allowed_to_map parent_instance model.shortName}}
     {{#if allow_mapping_or_creating}}
       <a
@@ -39,5 +40,6 @@
       </a>
     {{/if}}
     {{/is_allowed_to_map}}
+    {{/if}}
 {{/if_instance_of}}
 {{/if}}


### PR DESCRIPTION
This PR removes the Map button from the tree view on an Audit tab if the parent object's type is "Assessment".

The way I understood the ticket is to just remove the button. _Enforcing_ a backend check that an Assessment could not get mapped to multiple Audits is probably a whole different story.

---

**Precondition:**
created program, control, audit, assessment

**Steps to reproduce:**
  1. Go to Assessment Info page
  2. Audit tab: Map button in tree view is shown

**Actual Result:**
Map button in Audit tab is shown on Assessment Info page

**Expected Result:**
Assessment Info page: Remove [Map] button in tree view in audit tab. There should not be the possibility to map assessment to another audit