### PR TITLE
GGRC-1582 Change wording "owner" to "admin" in all objects across the application

### DIFF
--- a/src/ggrc/assets/javascripts/design.js
+++ b/src/ggrc/assets/javascripts/design.js
@@ -83,7 +83,7 @@ jQuery(function ($) {
   });
 
   $(".addpersonItem").click(function () {
-    $('#modalpeopleList').append("<li class='controlSlot ui-draggable'><div class='arrowcontrols-group'> <div class='controls-type'>Controls-Type</div><div class='controls-subtype'> <a class='dropdown-toggle statustextred' data-toggle='dropdown' href='#'>Select Role</a> <ul class='dropdown-menu dropdown-menusmall'><li>Owner</li><li>User</li></ul> </div>  <div class='controls-subgroup'>Controls-Subgroup</div></div><a class='personItem'><div class='removeCircleButton fltrt'><i class='gcmssmallicon-dash-white'></i></div></a></li>");
+    $('#modalpeopleList').append("<li class='controlSlot ui-draggable'><div class='arrowcontrols-group'> <div class='controls-type'>Controls-Type</div><div class='controls-subtype'> <a class='dropdown-toggle statustextred' data-toggle='dropdown' href='#'>Select Role</a> <ul class='dropdown-menu dropdown-menusmall'><li>Admin</li><li>User</li></ul> </div>  <div class='controls-subgroup'>Controls-Subgroup</div></div><a class='personItem'><div class='removeCircleButton fltrt'><i class='gcmssmallicon-dash-white'></i></div></a></li>");
   });
 
   $(".referenceItem").click(function () {

--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -344,7 +344,7 @@
       assessorsList: {},
       verifiersList: {},
       people_values: [
-        {value: 'Object Owners', title: 'Object Owners'},
+        {value: 'Object Owners', title: 'Object Admins'},
         {value: 'Audit Lead', title: 'Audit Lead'},
         {value: 'Auditors', title: 'Auditors'},
         {value: 'Primary Assessor', title: 'Principal Assignee'},

--- a/src/ggrc/assets/javascripts/models/cacheable.js
+++ b/src/ggrc/assets/javascripts/models/cacheable.js
@@ -119,7 +119,7 @@
         order: 10
       },
       {
-        attr_title: 'Owner',
+        attr_title: 'Admin',
         attr_name: 'owner',
         attr_sort_field: 'owners',
         order: 20

--- a/src/ggrc/assets/javascripts/models/simple_models.js
+++ b/src/ggrc/assets/javascripts/models/simple_models.js
@@ -232,7 +232,7 @@
     },
     permission_summary: function () {
       if (this.name === 'ProgramOwner') {
-        return 'Owner';
+        return 'Admin';
       }
       if (this.name === 'ProgramEditor') {
         return 'Can Edit';

--- a/src/ggrc/assets/js_specs/models/assessment_template_spec.js
+++ b/src/ggrc/assets/js_specs/models/assessment_template_spec.js
@@ -431,7 +431,7 @@ describe('can.Model.AssessmentTemplate', function () {
       'selected option is different from "other"',
       function () {
         instance.attr('assessorsListDisable', false);
-        instance.attr('default_people.assessors', 'Object Owners');
+        instance.attr('default_people.assessors', 'Object Admins');
 
         instance.defaultAssesorsChanged(context, $element, eventObj);
 
@@ -467,7 +467,7 @@ describe('can.Model.AssessmentTemplate', function () {
       'selected option is different from "other"',
       function () {
         instance.attr('verifiersListDisable', false);
-        instance.attr('default_people.verifiers', 'Object Owners');
+        instance.attr('default_people.verifiers', 'Object Admins');
 
         instance.defaultVerifiersChanged(context, $element, eventObj);
 

--- a/src/ggrc/assets/mockups/request/assessment_modal.mustache
+++ b/src/ggrc/assets/mockups/request/assessment_modal.mustache
@@ -92,7 +92,7 @@
               <span class="required">*</span>
             </label>
             <select class="input-block-level js-toggle-field" data-target=".choose-assessor" data-value="other">
-              <option>Object Owners</option>
+              <option>Object Admins</option>
               <option>Audit Lead</option>
               <option>Object contact</option>
               <option>Principal assessor</option>
@@ -112,7 +112,7 @@
               <span class="required">*</span>
             </label>
             <select class="input-block-level js-toggle-field" data-target=".choose-verifier" data-value="other">
-              <option>Object Owners</option>
+              <option>Object Admins</option>
               <option>Audit Lead</option>
               <option>Object contact</option>
               <option>Principal assessor</option>

--- a/src/ggrc/assets/mustache/base_objects/contacts.mustache
+++ b/src/ggrc/assets/mustache/base_objects/contacts.mustache
@@ -28,7 +28,7 @@
       {{/with_mapping}}
     </p>
     {{else}}
-    <h6>Owner</h6>
+    <h6>Admin</h6>
     <p class="oneline">
       {{#if owners.length}}
         {{#using contacts=owners}}

--- a/src/ggrc/assets/mustache/base_objects/mapper-item-description.mustache
+++ b/src/ggrc/assets/mustache/base_objects/mapper-item-description.mustache
@@ -5,7 +5,7 @@
 
 <div class="col-container">
   <div class="attr-container title">
-    <h6>Owner</h6>
+    <h6>Admin</h6>
     {{#if item.owners.length}}
       <ul class="inner-count-list">
         {{#each item.owners}}

--- a/src/ggrc/assets/mustache/components/object-list-item/detailed-business-object-list-item.mustache
+++ b/src/ggrc/assets/mustache/components/object-list-item/detailed-business-object-list-item.mustache
@@ -12,7 +12,7 @@
         <span>{{itemData.slug}}</span>
     </div>
     <div class="flex-size-1">
-        <h6>Owner</h6>
+        <h6>Admin</h6>
       {{#if itemData.owners.length}}
           <ul class="inner-count-list">
             {{#each itemData.owners}}

--- a/src/ggrc/assets/mustache/people/owners_modal_connector.mustache
+++ b/src/ggrc/assets/mustache/people/owners_modal_connector.mustache
@@ -12,7 +12,7 @@
   >
 {{#if list.length}}
   <label>
-    {{#if_equals list.length 1}}Owner{{else}}Owners{{/if_equals}}
+    {{#if_equals list.length 1}}Admin{{else}}Admins{{/if_equals}}
     <i class="fa fa-question-circle" rel="tooltip"
        title="This is the person in charge of this {{firstnonempty model_singular model.model_singular 'object'}}."></i>
     <a data-id="hide_owner_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
@@ -28,24 +28,24 @@
   {{/each}}
 {{else}}
   <label>
-    Owners
+    Admins
     <i class="fa fa-question-circle" rel="tooltip"
        title="This is the person in charge of this {{firstnonempty model_singular model.model_singular 'object'}}."></i>
     <a data-id="hide_owner_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
   </label>
-  <p>No owners assigned</p>
+  <p>No admins assigned</p>
 {{/if}}
 {{#toggle show_new_object_form}}
   {{#prune_context}}
     <div class="span12 objective-selector field-wrap">
-      <input tabindex="11" data-id="owner_txtbx" type="text" data-lookup="Person" null-if-empty="true" class="search-icon" placeholder="Enter text to search for Owner" {{autocomplete_select}} value="{{instance.email}}">
+      <input tabindex="11" data-id="owner_txtbx" type="text" data-lookup="Person" null-if-empty="true" class="search-icon" placeholder="Enter text to search for Admin" {{autocomplete_select}} value="{{instance.email}}">
       <a class="remove-field" href="javascript://" {{toggle_button}}><i class="fa fa-trash"></i></a>
 
     </div>
-    <!--input type="hidden" name="role_name" value="Owner" /-->
+    <!--input type="hidden" name="role_name" value="Admin" /-->
   {{/prune_context}}
 {{else}}
-<a href="javascript://" class="btn btn-small btn-draft" tabindex="11" {{toggle_button}}>Add Owner</a>
+<a href="javascript://" class="btn btn-small btn-draft" tabindex="11" {{toggle_button}}>Add Admin</a>
 
 {{/toggle}}
 </ggrc-modal-connector>

--- a/src/ggrc/models/assessment_template.py
+++ b/src/ggrc/models/assessment_template.py
@@ -49,7 +49,7 @@ class AssessmentTemplate(assessment.AuditRelationship, relationship.Relatable,
 
   # labels to show to the user in the UI for various default people values
   DEFAULT_PEOPLE_LABELS = {
-      "Object Owners": "Object Owners",
+      "Object Owners": "Object Admins",
       "Audit Lead": "Audit Lead",
       "Auditors": "Auditors",
       "Primary Assessor": "Principal Assessor",

--- a/test/integration/ggrc/test_csvs/assessment_template_no_warnings.csv
+++ b/test/integration/ggrc/test_csvs/assessment_template_no_warnings.csv
@@ -10,7 +10,7 @@ list of attribute values: comma separetd list, only used if attribute type is ""
 
 Limitations: Dropdown values can not start with either ""(a)"" or ""(c)"" and attribute names can not contain commas "","".",,,,,,,,
 Assessment Template,Code,Audit,Title,Object under assessment,Use control test plan,Default Test Plan,Default Assignee,Default Verifier,Custom Attributes,,,,,,,,
-,T-1,Audit,Template 1,Control,yes,this will be ignored,Object owners,Auditors,"Text, my text name
+,T-1,Audit,Template 1,Control,yes,this will be ignored,Object admins,Auditors,"Text, my text name
 mandatory Text, Some Other text name
 Rich text, custom description
 Mandatory Date, date of birth

--- a/test/integration/ggrc/test_csvs/assessment_template_with_warnings_and_errors.csv
+++ b/test/integration/ggrc/test_csvs/assessment_template_with_warnings_and_errors.csv
@@ -10,7 +10,7 @@ list of attribute values: comma separetd list, only used if attribute type is ""
 
 Limitations: Dropdown values can not start with either ""(a)"" or ""(c)"" and attribute names can not contain commas "","".",,,,,,,,
 Assessment Template,Code,Audit,Title,Object under assessment,Use control test plan,Default Test Plan,Default Assignee,Default Verifier,Custom Attributes,,,,,,,,
-,T-1,Audit,Template 1,Control,yes,this will be ignored,Object owners,Auditors,"Text, my text name
+,T-1,Audit,Template 1,Control,yes,this will be ignored,Object admins,Auditors,"Text, my text name
 mandatory Text, Some Other text name
 Rich text, custom description
 Mandatory Date, date of birth

--- a/test/selenium/src/lib/constants/element.py
+++ b/test/selenium/src/lib/constants/element.py
@@ -155,7 +155,7 @@ class TransformationSetVisibleFields(CommonModalSetVisibleFields):
   """To transformation elements' labels and properties for Modal to Set
  visible fields for object as Tree View headers.
  """
-  OWNER = "Owner"
+  ADMIN = "Admin"
   VERIFIED = "Verified"
   STATUS = "Status"
   AUDIT_LEAD = "Internal Audit Lead"
@@ -268,7 +268,7 @@ class AssessmentTemplateModalSetVisibleFields(CommonModalSetVisibleFields):
  """
   MODAL_HEADER = CommonModalSetVisibleFields.MODAL_HEADER_FORMAT.format(
       CommonAssessmentTemplate.ASMT_TMPL)
-  OWNER = TransformationSetVisibleFields.OWNER
+  ADMIN = TransformationSetVisibleFields.ADMIN
   PRIMARY_CONTACT = roles.PRIMARY_CONTACT
   SECONDARY_CONTACT = roles.SECONDARY_CONTACT
   DEFAULT_SET_FIELDS = (
@@ -304,7 +304,7 @@ class ControlModalSetVisibleFields(CommonModalSetVisibleFields):
   # pylint: disable=too-many-instance-attributes
   MODAL_HEADER = CommonModalSetVisibleFields.MODAL_HEADER_FORMAT.format(
       CommonControl.CONTROL)
-  OWNER = TransformationSetVisibleFields.OWNER
+  ADMIN = TransformationSetVisibleFields.ADMIN
   PRIMARY_CONTACT = roles.PRIMARY_CONTACT
   SECONDARY_CONTACT = roles.SECONDARY_CONTACT
   URL = Base.URL
@@ -321,7 +321,7 @@ class ControlModalSetVisibleFields(CommonModalSetVisibleFields):
   PRINCIPAL_ASSIGNEE = roles.PRINCIPAL_ASSIGNEE
   SECONDARY_ASSIGNEE = roles.SECONDARY_ASSIGNEE
   DEFAULT_SET_FIELDS = (
-      CommonModalSetVisibleFields.TITLE, OWNER,
+      CommonModalSetVisibleFields.TITLE, ADMIN,
       CommonModalSetVisibleFields.CODE, CommonModalSetVisibleFields.STATE,
       PRIMARY_CONTACT)
 
@@ -333,14 +333,14 @@ class IssueModalSetVisibleFields(CommonModalSetVisibleFields):
   # pylint: disable=too-many-instance-attributes
   MODAL_HEADER = CommonModalSetVisibleFields.MODAL_HEADER_FORMAT.format(
       CommonIssue.ISSUE)
-  OWNER = TransformationSetVisibleFields.OWNER
+  ADMIN = TransformationSetVisibleFields.ADMIN
   PRIMARY_CONTACT = roles.PRIMARY_CONTACT
   SECONDARY_CONTACT = roles.SECONDARY_CONTACT
   REVIEW_STATE = "Review State"
   URL = Base.URL
   REFERENCE_URL = Base.REFERENCE_URL
   DEFAULT_SET_FIELDS = (
-      CommonModalSetVisibleFields.TITLE, OWNER,
+      CommonModalSetVisibleFields.TITLE, ADMIN,
       CommonModalSetVisibleFields.CODE, CommonModalSetVisibleFields.STATE,
       CommonModalSetVisibleFields.LAST_UPDATED)
 

--- a/test/selenium/src/lib/constants/locator.py
+++ b/test/selenium/src/lib/constants/locator.py
@@ -381,7 +381,7 @@ class ModalCreateNewControl(BaseModalCreateNew):
   SECONDARY_ASSESSOR = (
       By.CSS_SELECTOR,
       '[data-test-id="control_secondary_assessor_b9439af6"] label')
-  OWNER = (
+  ADMIN = (
       By.CSS_SELECTOR, '[data-test-id="control_owner_587d12d6"] label')
   BUTTON_ADD_OWNER = (By.CSS_SELECTOR, 'isolate-form .btn')
   PRIMARY_CONTACT = (

--- a/test/selenium/src/lib/page/modal/base.py
+++ b/test/selenium/src/lib/page/modal/base.py
@@ -154,7 +154,7 @@ class ControlsModal(BaseModal):
         driver, self._locators.PRINCIPAL_ASSESSOR)
     self.secondary_assessor = base.Label(
         driver, self._locators.SECONDARY_ASSESSOR)
-    self.owner = base.Label(driver, self._locators.OWNER)
+    self.admin = base.Label(driver, self._locators.ADMIN)
     self.primary_contact = base.Label(driver, self._locators.PRIMARY_CONTACT)
     self.secondary_contact = base.Label(
         driver, self._locators.SECONDARY_CONTACT)

--- a/test/selenium/src/lib/service/webui_service.py
+++ b/test/selenium/src/lib/service/webui_service.py
@@ -48,7 +48,7 @@ class BaseWebUiService(object):
     """
     fields = element.TransformationSetVisibleFields
     return {
-        fields.TITLE.upper(): "title", fields.OWNER.upper(): "owners",
+        fields.TITLE.upper(): "title", fields.ADMIN.upper(): "owners",
         fields.CODE.upper(): "slug",
         fields.STATE.upper(): "status", fields.STATUS.upper(): "status",
         fields.VERIFIED.upper(): "verified",


### PR DESCRIPTION
_Comment by user:_
Since we are using control "owner" field in a different way now and will be named "admin". It would be more useful to see the principle and secondary assignees in the main popup window instead of having to click "show advanced" button. The principal assignee being the real world control owner, and secondary assignee being the real world control oversight owner.
Change wording "owner" to "admin" in all objects across the application.


![screenshot-1](https://cloud.githubusercontent.com/assets/4204416/24457152/0be90768-149e-11e7-819e-508a268b5efa.png)
