### PR TITLE
GGRC-1583 States should be preselected in multi select dropdown filter in Unified mapper/Global Search as for tree view

### DIFF
--- a/src/ggrc/assets/javascripts/components/unified-mapper/mapper-toolbar.js
+++ b/src/ggrc/assets/javascripts/components/unified-mapper/mapper-toolbar.js
@@ -56,6 +56,10 @@
           statuses =
             this.attr('displayPrefs').getTreeViewStates(modelName);
 
+          if (!statuses.length) {
+            statuses = GGRC.Utils.State.getDefaultStatesForModel(modelName);
+          }
+
           dropdownOptions = GGRC.Utils.State.getStatesForModel(modelName);
           dropdownOptions = dropdownOptions.map(function (option) {
             if (statuses.indexOf(option) > -1) {

--- a/src/ggrc/assets/javascripts/controllers/tree/tree-view.js
+++ b/src/ggrc/assets/javascripts/controllers/tree/tree-view.js
@@ -413,9 +413,8 @@
               can.bind.call(statusControl.ready(function () {
                 var selectStateList = self.options.attr('selectStateList');
 
-                var checkAll = selectStateList.length === 0;
                 self.options.attr('filter_states').forEach(function (item) {
-                  if (checkAll || selectStateList.indexOf(item.value) > -1) {
+                  if (selectStateList.indexOf(item.value) > -1) {
                     item.attr('checked', true);
                   }
                 });

--- a/src/ggrc/assets/javascripts/plugins/tests/state-utils_spec.js
+++ b/src/ggrc/assets/javascripts/plugins/tests/state-utils_spec.js
@@ -115,4 +115,27 @@ describe('GGRC.Utils.State', function () {
       }
     );
   });
+
+  describe('getDefaultStatesForModel() method', function () {
+    it('get default states for "MyAssessments" page', function () {
+      var defaultStates;
+
+      spyOn(GGRC.Utils.CurrentPage, 'isMyAssessments')
+        .and.returnValue(true);
+
+      defaultStates = GGRC.Utils.State
+        .getDefaultStatesForModel('Assessment');
+
+      expect(defaultStates.length).toEqual(2);
+      expect(defaultStates[0]).toEqual('Not Started');
+    });
+
+    it('get default states for "Control" type', function () {
+      var defaultStates = GGRC.Utils.State
+        .getDefaultStatesForModel('Control');
+
+      expect(defaultStates.length).toEqual(3);
+      expect(defaultStates[0]).toEqual('Active');
+    });
+  });
 });

--- a/src/ggrc/assets/javascripts/plugins/utils/state-utils.js
+++ b/src/ggrc/assets/javascripts/plugins/utils/state-utils.js
@@ -175,13 +175,9 @@
      * @return {Array} List of default states for model
      */
     function getDefaultStatesForModel(model) {
-      var states = [];
-
-      if (GGRC.Utils.CurrentPage.isMyAssessments()) {
-        states = ['Not Started', 'In Progress'];
-      }
-
-      return states;
+      return GGRC.Utils.CurrentPage.isMyAssessments() ?
+        ['Not Started', 'In Progress'] :
+        getStatesForModel(model);
     }
 
     return {


### PR DESCRIPTION
_Steps to reproduce:_
1. Go to My work page and open e.g. "Assessment" widget
2. Click Map button in the first tier
3. Look at dropdown filter

_Actual Result:_ States are not preselected in multi select dropdown filter in Unified mapper/Global Search as for tree view
_Expected Result_: States should be preselected in multi select dropdown filter in Unified mapper/Global Search as for tree view

![screenshot-1](https://cloud.githubusercontent.com/assets/4204416/24499441/669f300e-154a-11e7-8a68-a80dd7796d9d.png)
