### PR TITLE
GGRC-1369 Fix using of #each helper with #using helper

### DIFF
--- a/src/ggrc/assets/mustache/base_objects/contacts.mustache
+++ b/src/ggrc/assets/mustache/base_objects/contacts.mustache
@@ -26,26 +26,27 @@
           <span class="empty-message">None</span>
         {{/if}}
       {{/with_mapping}}
+    </p>
     {{else}}
     <h6>Owner</h6>
     <p class="oneline">
       {{#if owners.length}}
         {{#using contacts=owners}}
         <ul class="inner-count-list">
-          {{#each contacts}}
+          {{#contacts}}
             <li>
               {{#using person=this}}
                 {{>'/static/mustache/people/popover.mustache'}}
               {{/using}}
             </li>
-          {{/each}}
+          {{/contacts}}
         </ul>
         {{/using}}
       {{else}}
         <span class="empty-message">None</span>
       {{/if}}
-    {{/if}}
     </p>
+    {{/if}}
   </div>
     <div data-test-id="title_contacts_696de7244b84" class="span6">
       {{#using person=contact}}


### PR DESCRIPTION
**Blank field is displayed if open third tier in tree view**

**Steps to reproduce**:
1. On My work page select Sections widget
2. Select Section with "Active" state and click gray triangle to open subtree
3. For the object in the second tier (e.g. "Objective") click gray triangle to open third tier
**Actual Result**: Blank field is displayed if open third tier in tree view
**Expected Result**: No blank field is displayed if open third tier in tree view

![image](https://cloud.githubusercontent.com/assets/567805/24501761/94802178-1553-11e7-816d-7bfe7e55615f.png)

![image](https://cloud.githubusercontent.com/assets/567805/24501764/9913c1ae-1553-11e7-937d-4ac480b49056.png)
