### PR TITLE
GGRC-1699 Frontend: Sorting and Filtering doesn't work for "Last assessment date" column for Controls/Objectives

### DIFF
--- a/src/ggrc/assets/mustache/controls/tree-item-attr.mustache
+++ b/src/ggrc/assets/mustache/controls/tree-item-attr.mustache
@@ -88,7 +88,11 @@
     {{/using}}
   {{/case}}
   {{#case 'last_assessment_date'}}
-    <last-assessment-date instance="instance"/>
+    {{#if instance.snapshot}}
+      <last-assessment-date instance="instance"/>
+    {{else}}
+      {{localize_date instance.last_assessment_date}}
+    {{/if}}
   {{/case}}
   {{#case 'status'}}
     {{#using status=instance.status}}

--- a/src/ggrc/assets/mustache/objectives/tree-item-attr.mustache
+++ b/src/ggrc/assets/mustache/objectives/tree-item-attr.mustache
@@ -28,7 +28,11 @@
     </span>
   {{/case}}
   {{#case 'last_assessment_date'}}
-    <last-assessment-date instance="instance"/>
+    {{#if instance.snapshot}}
+      <last-assessment-date instance="instance"/>
+    {{else}}
+      {{localize_date instance.last_assessment_date}}
+    {{/if}}
   {{/case}}
   {{#case 'status'}}
     {{#using status=instance.status}}


### PR DESCRIPTION
Avoid using of "last_assessment_date" component for original Controls and Objectives.

**NOTE**: this PR depends on PR #5409 
