### PR TITLE
GGRC-1683 fulltext sorting fix

### DIFF
--- a/src/ggrc/fulltext/attributes.py
+++ b/src/ggrc/fulltext/attributes.py
@@ -31,7 +31,7 @@ class FullTextAttr(object):
     self.value = value
     self.subproperties = subproperties or [EMPTY_SUBPROPERTY_KEY]
     self.with_template = with_template
-    self.is_sortable = len(self.subproperties) > 1
+    self.is_sortable = EMPTY_SUBPROPERTY_KEY not in self.subproperties
 
   def get_value_for(self, instance):
     """Get value from sended instance using 'value' rule"""
@@ -51,11 +51,11 @@ class FullTextAttr(object):
         result = getattr(value, subprop)
         results[subprop_key] = result
         if result and subprop == sorting_subprop:
-          sorted_dict[value.id] = result
+          sorted_dict[value.id] = unicode(result)
       else:
         results[subprop] = value
     if self.is_sortable:
-      results['__sort__'] = ':'.join(sorted(sorted_dict.values()))
+      results['__sort__'] = u':'.join(sorted(sorted_dict.values()))
     return results
 
   # pylint: disable=unused-argument
@@ -76,7 +76,8 @@ class MultipleSubpropertyFullTextAttr(FullTextAttr):
 
   def __init__(self, *args, **kwargs):
     super(MultipleSubpropertyFullTextAttr, self).__init__(*args, **kwargs)
-    assert self.subproperties != [EMPTY_SUBPROPERTY_KEY]
+    assert EMPTY_SUBPROPERTY_KEY not in self.subproperties
+    assert self.is_sortable
 
   def get_property_for(self, instance):
     """Collect property for sended instance"""
@@ -91,12 +92,12 @@ class MultipleSubpropertyFullTextAttr(FullTextAttr):
           result = getattr(value, sub)
           results[sub_key] = result
           if result and sub == sorting_subprop:
-            sorted_dict[value.id] = result
+            sorted_dict[value.id] = unicode(result)
         else:
           sub_key = self.SUB_KEY_TMPL.format(id_val='EMPTY', sub=sub)
           results[sub_key] = None
     if self.is_sortable:
-      results['__sort__'] = ':'.join(sorted(sorted_dict.values()))
+      results['__sort__'] = u':'.join(sorted(sorted_dict.values()))
     return results
 
 

--- a/test/integration/ggrc/services/test_assessments.py
+++ b/test/integration/ggrc/services/test_assessments.py
@@ -1,0 +1,42 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+
+"""Tests for assessment service handle."""
+import random
+
+from ddt import data, ddt
+
+from integration.ggrc.models import factories
+from integration.ggrc.services.test_query.test_basic import (
+    BaseQueryAPITestCase
+)
+
+
+@ddt
+class TestCollection(BaseQueryAPITestCase):
+
+  """Test for collection assessment objects."""
+
+  def setUp(self):
+    super(TestCollection, self).setUp()
+    self.clear_data()
+    self.expected_ids = []
+    assessments = [factories.AssessmentFactory() for _ in range(10)]
+    random.shuffle(assessments)
+    for idx, assessment in enumerate(assessments):
+      comment = factories.CommentFactory(description=str(idx))
+      factories.RelationshipFactory(source=assessment, destination=comment)
+      self.expected_ids.append(assessment.id)
+
+  @data(True, False)
+  def test_order_by_test(self, desc):
+    """Order by fultext attr"""
+    query = self._make_query_dict(
+        "Assessment", order_by=[{"name": "comment", "desc": desc}]
+    )
+    expected_ids = self.expected_ids
+    if desc:
+      expected_ids = expected_ids[::-1]
+    results = self._get_first_result_set(query, "Assessment", "values")
+    self.assertEqual(expected_ids, [i['id'] for i in results])


### PR DESCRIPTION
Ordering didn't work because there is no "" or "\_\_sort\_\_" indexed subproperty. 