### PR TITLE
GGRC-1488 Hide View original object link for auditors

### DIFF
--- a/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
+++ b/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
@@ -617,6 +617,10 @@
       content.selfLink = content.snapshot.selfLink;
       content.type = instance.child_type;
       content.id = instance.id;
+      content.canRead = Permission.is_allowed_for('read', {
+        type: instance.child_type,
+        id: instance.child_id
+      });
       object = new model(content);
       model.removeFromCacheById(content.id);  /* removes snapshot object from cache */
       return object;

--- a/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
+++ b/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
@@ -621,6 +621,10 @@
         type: instance.child_type,
         id: instance.child_id
       });
+      content.canUpdate = Permission.is_allowed_for('update', {
+        type: instance.child_type,
+        id: instance.child_id
+      });
       object = new model(content);
       model.removeFromCacheById(content.id);  /* removes snapshot object from cache */
       return object;

--- a/src/ggrc/assets/mustache/base_objects/general_info.mustache
+++ b/src/ggrc/assets/mustache/base_objects/general_info.mustache
@@ -26,7 +26,7 @@
         {{! We need to use `using` to ensure that snapshot is actually
             reified by the time is_allowed helper uses it }}
       {{#using reified_snapshot=snapshot}}
-      {{#is_allowed 'update' reified_snapshot context='for'}}
+      {{#canUpdate}}
         {{^isLatestRevision}}
           <div class="span12 snapshot">
             <hr class="snapshot">
@@ -39,7 +39,7 @@
             </p>
           </div>
         {{/isLatestRevision}}
-      {{/is_allowed}}
+      {{/canUpdate}}
       {{/using}}
       {{/if}}
     </div>

--- a/src/ggrc/assets/mustache/snapshots/dropdown_menu.mustache
+++ b/src/ggrc/assets/mustache/snapshots/dropdown_menu.mustache
@@ -39,7 +39,7 @@ TODO: Temporary disabled until snapshot view is added.
             {{! We need to use `using` to ensure that snapshot is actually
                 reified by the time is_allowed helper uses it }}
             {{#using reified_snapshot=snapshot}}
-            {{#is_allowed 'update' reified_snapshot context='for'}}
+            {{#canUpdate}}
             {{^isLatestRevision}}
             <li>
               <revisions-comparer instance="instance"
@@ -51,7 +51,7 @@ TODO: Temporary disabled until snapshot view is added.
               </revisions-comparer>
             </li>
             {{/isLatestRevision}}
-            {{/is_allowed}}
+            {{/canUpdate}}
             {{/using}}
 
             <li>

--- a/src/ggrc/assets/mustache/snapshots/dropdown_menu.mustache
+++ b/src/ggrc/assets/mustache/snapshots/dropdown_menu.mustache
@@ -4,13 +4,7 @@
 }}
 
 {{#instance}}
-{{#if_helpers '\
-#if' is_info_pin '\
-and #is_allowed_to_map' page_instance instance '\
-or #if' is_info_pin '\
-and #if' instance.viewLink '\
-or #is_allowed' 'update' instance '\
-' _4_context='for'}}
+{{#canRead}}
     <div class="details-wrap">
         <a class="btn btn-draft dropdown-toggle" href="#" data-toggle="dropdown">
             <span class="bubble"></span>
@@ -68,5 +62,5 @@ TODO: Temporary disabled until snapshot view is added.
             </li>
         </ul>
     </div>
-{{/if_helpers}}
+{{/canRead}}
 {{/instance}}


### PR DESCRIPTION
Steps to reproduce:
1. Create a program
2. Create a control
3. Create an audit and add auditor to audit (progcreator@reciprocitylabs.com)
4. Log as auditor (progcreator@reciprocitylabs.com (engage007) and go to audit page
5. Open Control widget and click 3 bb's button on Info pane
Actual Result: "View original Control" link is shown in 3bb's menu on Control's snapshot Info pane under GC as auditor
Expected Result: GC as auditor in audit should not be able to see "View original Control" link

In addition this PR also hides update to latest revisions links if the user does not have access to the parent object.