### PR TITLE
GGRC-1202 Fix script error when opening Assessments in LHN

### DIFF
--- a/src/ggrc/assets/javascripts/models/assessment.js
+++ b/src/ggrc/assets/javascripts/models/assessment.js
@@ -265,6 +265,10 @@
         });
       }
 
+      if (!model.attr('assignees')) {
+        model.attr('assignees', new can.Map());
+      }
+
       model.assignees.attr(type, unique);
     },
     /**

--- a/src/ggrc/assets/javascripts/models/tests/assessment_model_spec.js
+++ b/src/ggrc/assets/javascripts/models/tests/assessment_model_spec.js
@@ -118,4 +118,36 @@ describe('CMS.Models.Assessment', function () {
       }
     );
   });
+
+  describe('leaveUniqueAssignees() method', function () {
+    var assessment;
+    var method;
+
+    beforeAll(function () {
+      method = CMS.Models.Assessment.leaveUniqueAssignees;
+    });
+
+    beforeEach(function () {
+      assessment = new can.Map({id: 123, title: 'asmt 123'});
+    });
+
+    it('creates assignees object on an instance that lacks one', function () {
+      var actual;
+
+      var attributes = new can.Map({
+        assignees: {
+          Creator: [{id: 5, email: 'john@doe.com'}]
+        }
+      });
+
+      assessment.attr('assignees', undefined);
+
+      method(assessment, attributes, 'Creator');
+
+      actual = assessment.attr('assignees.Creator');
+      expect(actual).toBeDefined();
+      expect(actual.length).toBe(1);
+      expect(actual[0].attr()).toEqual({id: 5, email: 'john@doe.com'});
+    });
+  });
 });


### PR DESCRIPTION
This PR fixes a script error that can occur when opening the Assessments section in LHN. Assigned @xferra because he made a few of the latest changes changes in the affected code.

I'm not completely sure what is meant by "broken" in the ticket description, though, is it about the script error?
(UPDATE: It was confirmed that this ticket is just about the script error.)

I have noticed once or twice that when opening the Assessments section, the list of items was empty, even though the count in the section header suggested otherwise. I'm not sure if this is the same issue, or should that behavior be investigated as a part of a different story...

---

**Steps to reproduce:**
  1. Open LHN
  2. Expand Assessments accordion: Assessments view is broken

**Actual Result:**
Assessments view in LHN is broken

**Expected Result:**
Assessments view in LHN should no be broken. 
