### PR TITLE
GGRC-839 Fix GCA visibility after discarding changes in it

### DIFF
--- a/src/ggrc/assets/javascripts/components/inline_edit/inline.js
+++ b/src/ggrc/assets/javascripts/components/inline_edit/inline.js
@@ -71,8 +71,8 @@
 
       onCancel: function (ctx, el, ev) {
         ev.preventDefault();
-        this.attr('context.isEdit', false);
         this.attr('context.value', this.attr('_value'));
+        this.attr('context.isEdit', false);
       },
       onSave: function (ctx, el, ev) {
         var caid = this.attr('caId');


### PR DESCRIPTION
Preconditions:
1. Create GCA with person type for Control
2. Created program, Control

Steps to reproduce:
1. Navigate to Control's Info pane
2. Add person to GCA (e.g. "Person1") 
3. Save it 
4. Click edit icon to edit GCA "Person1"
5. Click ''X' without any changes

Actual result: value is hidden in GCA field with person type after closing GCA without changes in Object's Info pane
Expected result: Value is shown in GCA field with person type after closing GCA without changes in Object's Info pane