### PR TITLE
GGRC-333 Return the Undo button in task group

### DIFF
--- a/src/ggrc_workflows/assets/mustache/cycle_task_groups/tree.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_groups/tree.mustache
@@ -59,11 +59,9 @@
                               <em>Verified</em>
                             </span>
                           {{/if_equals}}
-                          <!--
                           {{#instance._undo.0}}
                             <a href="javascript://" data-name="status" data-value="{{instance._undo.0}}" data-undo="true" class="undo {{instance._disabled}}">Undo</a>
                           {{/instance._undo.0}}
-                          -->
                         </div>
                       {{/is_allowed 'update' instance}}
                       {{/if_equals}}


### PR DESCRIPTION
There is no "Undo" in Task Group's 1st tier after clicking control buttons