### PR TITLE
GGRC-1049 Change comment order

### DIFF
--- a/src/ggrc/assets/javascripts/components/mapped_tree_view.js
+++ b/src/ggrc/assets/javascripts/components/mapped_tree_view.js
@@ -4,7 +4,7 @@
 */
 
 (function (can, $) {
-  can.Component.extend({
+  GGRC.Components('mappingTreeView', {
     tag: 'mapping-tree-view',
     template: can.view(GGRC.mustache_path +
       '/base_templates/mapping_tree_view.mustache'),
@@ -12,6 +12,7 @@
       treeViewClass: '@',
       expandable: '@',
       sortField: '@',
+      sortOrder: '@',
       emptyText: '@',
       parentInstance: null,
       mappedObjects: [],
@@ -53,6 +54,7 @@
     },
     /**
       * Sort objects list by this.scope.sortField, if defined
+      * in order defined in this.scope.sortOrder (asc or desc)
       *
       * @param {Array} mappedObjects - the list of objects to be sorted
       *
@@ -62,8 +64,10 @@
       *                   mappedObjects.
       */
     _sortObjects: function (mappedObjects) {
-      if (this.scope.attr('sortField')) {
-        return _.sortBy(mappedObjects, this.scope.attr('sortField'));
+      var sortField = this.scope.attr('sortField');
+      var sortOrder = this.scope.attr('sortOrder');
+      if (sortField) {
+        return _.sortByOrder(mappedObjects, sortField, sortOrder);
       }
       return mappedObjects;
     },

--- a/src/ggrc/assets/javascripts/components/tests/mapped_tree_view_spec.js
+++ b/src/ggrc/assets/javascripts/components/tests/mapped_tree_view_spec.js
@@ -1,0 +1,64 @@
+/*!
+ Copyright (C) 2017 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+describe('GGRC.Components.mappingTreeView', function () {
+  'use strict';
+
+  var unsortedArray = [
+    {
+      value: 1,
+      field: 'a'
+    },
+    {
+      value: 4,
+      field: 'd'
+    },
+    {
+      value: 3,
+      field: 'c'
+    },
+    {
+      value: 2,
+      field: 'b'
+    }
+  ];
+  var sortedAsc = _.sortByOrder(unsortedArray, 'field');
+  var sortedDesc = _.sortByOrder(unsortedArray, 'field', 'desc');
+  var Component;  // the component under test
+
+  beforeAll(function () {
+    Component = GGRC.Components.get('mappingTreeView');
+  });
+
+  describe('_sortObjects() method', function () {
+    var method;
+    var scope;
+
+    beforeAll(function () {
+      scope = new can.Map({
+        scope: {
+          sortField: null
+        }
+      });
+      method = Component.prototype._sortObjects.bind(scope);
+    });
+
+    it('returns unsorted array when sortField is not defined', function () {
+      expect(method(unsortedArray)).toEqual(unsortedArray);
+    });
+
+    it('returns asc sorted array when sortField is defined', function () {
+      scope.attr('scope.sortField', 'field');
+      expect(method(unsortedArray)).toEqual(sortedAsc);
+    });
+
+    it('returns desc sorted array when sortField and sortOrder are defined',
+      function () {
+        scope.attr('scope.sortField', 'field');
+        scope.attr('scope.sortOrder', 'desc');
+        expect(method(unsortedArray)).toEqual(sortedDesc);
+      });
+  });
+});

--- a/src/ggrc/assets/mustache/base_templates/comment_list.mustache
+++ b/src/ggrc/assets/mustache/base_templates/comment_list.mustache
@@ -11,6 +11,8 @@
     is-loading="isLoading"
     mapping="comments"
     tree-view-class="comment-list"
+    sort-field="instance.created_at"
+    sort-order="desc"
     item-template="/static/mustache/base_templates/comment_subtree.mustache"
     >
   </mapping-tree-view>


### PR DESCRIPTION
**Improve comments ordering in Assessment's Info panel**

**Steps to reproduce**:
1. Navigate to assessment's Info panel
2. Add at least 3 comments
3. Look at the comments ordering: new comment is shown below the previous one

**Actual Result**: New comment is shown below the previous one
**Expected Result**: New added comment should be displayed above the previous one

![image](https://cloud.githubusercontent.com/assets/567805/24554915/edbda74e-1637-11e7-8a97-dc30a643013f.png)

