### PR TITLE
QUICK-FIX Test Snapshot filtering

### DIFF
--- a/test/selenium/src/lib/base.py
+++ b/test/selenium/src/lib/base.py
@@ -383,10 +383,17 @@ class FilterCommon(Component):
   def submit_query(self):
     """Submit query that was entered to field."""
     self.button_submit.click()
+    selenium_utils.wait_for_js_to_load(self._driver)
 
   def clear_query(self):
     """Clear query that was entered to field."""
     self.button_clear.click()
+    selenium_utils.wait_for_js_to_load(self._driver)
+
+  def perform_query(self, query):
+    """Clear filtering field, enter query and click submit."""
+    self.enter_query(query)
+    self.submit_query()
 
 
 class AbstractPage(Component):
@@ -495,14 +502,20 @@ class TreeView(Component):
         self._driver, _locator_header)
 
   def get_tree_view_items_elements(self):
-    """Get Tree View items as list of elements from current widget."""
+    """Get Tree View items as list of elements from current widget.
+    If no items in tree view return empty list.
+    """
     _locator_items = (
         By.CSS_SELECTOR, self._locators.ITEMS.format(self.widget_name))
     selenium_utils.get_when_invisible(self._driver, self._locators.SPINNER)
     selenium_utils.wait_until_not_present(
         self._driver, self._locators.ITEM_LOADING)
-    self._tree_view_items_elements = selenium_utils.get_when_all_visible(
-        self._driver, _locator_items)
+    selenium_utils.wait_for_js_to_load(self._driver)
+    has_no_record_found = selenium_utils.is_element_exist(
+        self._driver, self._locators.NO_RESULTS_MESSAGE)
+    self._tree_view_items_elements = (
+        [] if has_no_record_found else
+        selenium_utils.get_when_all_visible(self._driver, _locator_items))
 
   def set_tree_view_items(self):
     """Set Tree View items as list of Tree View item objects from current

--- a/test/selenium/src/lib/constants/locator.py
+++ b/test/selenium/src/lib/constants/locator.py
@@ -904,7 +904,7 @@ class BaseWidgetGeneric(object):
       _FILTER_DROPDOWN_ELEMENTS = \
           _FILTER_DROPDOWN + " .multiselect-dropdown__element"
       cls.TEXTFIELD_TO_FILTER = (
-          By.CSS_SELECTOR, str(_FILTER + " .tree-filter__expression-holder")
+          By.CSS_SELECTOR, str(_FILTER + " .tree-filter__input")
             .format(cls._object_name))
       cls.BUTTON_FILTER = (
           By.CSS_SELECTOR,

--- a/test/selenium/src/lib/page/modal/unified_mapper.py
+++ b/test/selenium/src/lib/page/modal/unified_mapper.py
@@ -45,7 +45,7 @@ class CommonUnifiedMapperModal(base.Modal):
     """
     # pylint: disable=invalid-name
     expression = filter_utils.FilterUtils.get_filter_exp_by_title(
-        list_titles=objs_titles)
+        titles=objs_titles)
     self.filter_via_expression_text_box.enter_text(expression)
 
   def _select_search_dest_objs(self):

--- a/test/selenium/src/lib/service/webui_service.py
+++ b/test/selenium/src/lib/service/webui_service.py
@@ -173,6 +173,16 @@ class BaseWebUiService(object):
     obj_info_panel = self.open_info_panel_of_obj_by_title(src_obj, obj)
     return obj_info_panel.open_info_3bbs().is_open_exist()
 
+  def filter_list_objs_from_tree_view(self, src_obj, filter_exp):
+    """Filter by specified criteria and return list of objects from Tree
+    View."""
+    objs_widget = self.open_widget_of_mapped_objs(src_obj)
+    objs_widget.filter.perform_query(filter_exp)
+    self.set_list_objs_scopes_representation_on_tree_view(src_obj)
+    list_objs_scopes = self.get_list_objs_scopes_from_tree_view(src_obj)
+    return self.create_list_objs(entity_factory=self.entities_factory_cls,
+                                 list_scopes=list_objs_scopes)
+
 
 class SnapshotsWebUiService(BaseWebUiService):
   """Class for snapshots business layer's services objects."""

--- a/test/selenium/src/lib/utils/filter_utils.py
+++ b/test/selenium/src/lib/utils/filter_utils.py
@@ -36,11 +36,17 @@ class FilterUtils(object):
         [(field, operator, value) for value in list_values])
 
   @staticmethod
-  def get_filter_exp_by_title(list_titles):
-    """Get filter expression to search data by title according to list of titles.
+  def get_filter_exp_by_title(titles):
+    """Get filter expression to search data by title according to title(s).
     Example:
-    list_titles = ["title1", "title2"]
+    for single title
+    titles = "title1"
+    :return '"title" = "title1"'
+
+    for list of titles
+    titles = ["title1", "title2"]
     :return '"title" = "title1" OR "title" = "title2"'
     """
+    list_values = [titles] if type(titles) not in [list, tuple] else titles
     return FilterUtils.get_filter_exp(field="title", operator="=",
-                                      list_values=list_titles)
+                                      list_values=list_values)

--- a/test/selenium/src/tests/test_audit_page.py
+++ b/test/selenium/src/tests/test_audit_page.py
@@ -10,15 +10,13 @@ import pytest
 
 from lib import base
 from lib.constants import messages
-from lib.constants.element import Lhn
 from lib.entities.entities_factory import (
     AuditsFactory, AssessmentTemplatesFactory, AssessmentsFactory)
-from lib.page import dashboard
-from lib.service import webui_service, rest_service
+from lib.service import webui_service
 
 
 class TestAuditPage(base.Test):
-  """Tests for audit page."""
+  """Tests for audit functionality."""
 
   @pytest.fixture(scope="function")
   def create_and_clone_audit(
@@ -49,65 +47,6 @@ class TestAuditPage(base.Test):
         "issue": new_issue_rest[0], "asmt_tmpl": new_asmt_tmpl_rest[0],
         "expected_asmt_tmpl": expected_asmt_tmpl,
         "control": new_control_rest, "program": new_program_rest}
-
-  @pytest.fixture(scope="function")
-  def create_audit_and_update_original_control(
-      self, new_control_rest, new_program_rest, map_control_to_program_rest,
-      new_audit_rest, update_control_rest
-  ):
-    """Create Audit with snapshotable Control and update original Control under
-    Program via REST API.
-    Preconditions:
-    - Program, Control created via REST API.
-    - Control mapped to Program via REST API.
-    - Audit created under Program via REST API.
-    - Original Control updated via REST API.
-    """
-    return {
-        "audit": new_audit_rest[0], "program": new_program_rest,
-        "control": new_control_rest, "updated_control": update_control_rest}
-
-  @pytest.fixture(scope="function")
-  def create_audit_and_delete_original_control(
-      self, new_control_rest, new_program_rest, map_control_to_program_rest,
-      new_audit_rest, delete_control_rest
-  ):
-    """Create Audit with snapshotable Control and delete original Control under
-    Program via REST API.
-    Preconditions:
-    - Program, Control created via REST API.
-    - Control mapped to Program via REST API.
-    - Audit created under Program via REST API.
-    - Original Control deleted via REST API.
-    """
-    return {
-        "audit": new_audit_rest[0], "program": new_program_rest,
-        "control": new_control_rest}
-
-  @pytest.fixture(scope="function")
-  def create_audit_and_update_first_of_two_original_controls(
-      self, create_audit_and_update_original_control
-  ):
-    """Create Audit with snapshotable Control and update original Control under
-    Program via REST API. After that create second Control and map it to
-    Program via REST API.
-    Preconditions:
-    - Execution and return of fixture
-      'create_audit_and_update_original_control'.
-    - Second Control created via REST API.
-    - Second Control mapped to Program via REST API.
-    """
-    audit_with_one_control = create_audit_and_update_original_control
-    second_control = rest_service.ControlsService().create(count=1)[0]
-    rest_service.ObjectsOwnersService().create(objs=second_control)
-    rest_service.RelationshipsService().create(
-        src_obj=audit_with_one_control["program"], dest_objs=second_control)
-    return {
-        "audit": create_audit_and_update_original_control["audit"],
-        "program": audit_with_one_control["program"],
-        "control": audit_with_one_control["control"],
-        "updated_control": audit_with_one_control["updated_control"],
-        "second_control": second_control}
 
   @pytest.mark.smoke_tests
   def test_asmt_tmpl_creation(self, new_audit_rest, selenium):
@@ -175,153 +114,7 @@ class TestAuditPage(base.Test):
         messages.ERR_MSG_FORMAT.format(expected_asmts, actual_asmts))
 
   @pytest.mark.smoke_tests
-  def test_audit_contains_readonly_ver_of_control(
-      self, new_control_rest, new_program_rest, map_control_to_program_rest,
-      new_audit_rest, selenium
-  ):
-    """Check via UI that Audit contains read-only snapshotable Control.
-    Preconditions:
-    - Program, Control created via REST API.
-    - Control mapped to Program via REST API.
-    - Audit created under Program via REST API.
-    """
-    audit, _ = new_audit_rest
-    actual_controls_tab_count = (webui_service.ControlsService(selenium).
-                                 get_count_objs_from_tab(src_obj=audit))
-    assert len([new_control_rest]) == actual_controls_tab_count
-    is_control_editable = (
-        webui_service.ControlsService(selenium).is_obj_editable_via_info_panel(
-            src_obj=audit, obj=new_control_rest))
-    assert is_control_editable is False
-
-  @pytest.mark.smoke_tests
-  def test_audit_contains_snapshotable_control_after_updating_control(
-      self, create_audit_and_update_original_control, selenium
-  ):
-    """Check via UI that Audit contains snapshotable Control that does not
-    equal updated version Control without version updating Control.
-    Preconditions:
-    - Execution and return of fixture
-      'create_audit_and_update_original_control'.
-    """
-    audit_with_one_control = create_audit_and_update_original_control
-    audit = audit_with_one_control["audit"]
-    expected_control = audit_with_one_control["control"]
-    actual_controls_tab_count = (webui_service.ControlsService(selenium).
-                                 get_count_objs_from_tab(src_obj=audit))
-    assert len([expected_control]) == actual_controls_tab_count
-    actual_controls = (webui_service.ControlsService(selenium).
-                       get_list_objs_from_tree_view(src_obj=audit))
-    assert [expected_control] == actual_controls, (
-        messages.ERR_MSG_FORMAT.format([expected_control], actual_controls))
-
-  @pytest.mark.smoke_tests
-  def test_update_snapshotable_ver_after_updating_original_control(
-      self, create_audit_and_update_original_control, selenium
-  ):
-    """Check via UI that Audit contains snapshotable Control that up-to-date
-    with it actual state of original control after updating snapshot to latest
-    version.
-    Preconditions:
-    - Execution and return of fixture
-      'create_audit_and_update_original_control'.
-    """
-    audit_with_one_control = create_audit_and_update_original_control
-    audit = audit_with_one_control["audit"]
-    control = audit_with_one_control["control"]
-    expected_control = audit_with_one_control["updated_control"]
-    (webui_service.ControlsService(selenium).
-     update_obj_ver_via_info_panel(src_obj=audit, obj=control))
-    actual_controls_tab_count = (webui_service.ControlsService(selenium).
-                                 get_count_objs_from_tab(src_obj=audit))
-    assert len([expected_control]) == actual_controls_tab_count
-    actual_controls = (webui_service.ControlsService(selenium).
-                       get_list_objs_from_tree_view(src_obj=audit))
-    assert [expected_control] == actual_controls, (
-        messages.ERR_MSG_FORMAT.format([expected_control], actual_controls))
-
-  @pytest.mark.smoke_tests
-  @pytest.mark.skipif(True, reason="Issue in app GGRC-1196")
-  def test_audit_contains_snapshotable_control_after_deleting_original_control(
-      self, create_audit_and_delete_original_control, selenium
-  ):
-    """Check via UI that Audit contains snapshotable Control even after
-    deleting original control.
-    Snapshot does not have links to update version to latest state
-    and to view original Control under Program.
-    Preconditions:
-    - Execution and return of fixture
-      'create_audit_and_delete_original_control'.
-    """
-    audit_with_one_control = create_audit_and_delete_original_control
-    audit = audit_with_one_control["audit"]
-    expected_control = audit_with_one_control["control"]
-    actual_controls_tab_count = (webui_service.ControlsService(selenium).
-                                 get_count_objs_from_tab(src_obj=audit))
-    assert len([expected_control]) == actual_controls_tab_count
-    actual_controls = (webui_service.ControlsService(selenium).
-                       get_list_objs_from_tree_view(src_obj=audit))
-    assert [expected_control] == actual_controls, (
-        messages.ERR_MSG_FORMAT.format([expected_control], actual_controls))
-    is_control_updateable = (webui_service.ControlsService(selenium).
-                             is_obj_updateble_via_info_panel(
-        src_obj=audit, obj=expected_control))
-    is_control_openable = (webui_service.ControlsService(selenium).
-                           is_obj_page_exist_via_info_panel(
-        src_obj=audit, obj=expected_control))
-    assert is_control_updateable is False
-    assert is_control_openable is False
-
-  @pytest.mark.smoke_tests
-  def test_mapped_to_program_controls_does_not_added_to_existing_audit(
-      self, create_audit_and_update_first_of_two_original_controls, selenium
-  ):
-    """Check via UI that Audit contains snapshotable Control that equal to
-    original Control does not contain Control that was mapped to
-    Program after Audit creation.
-    Preconditions:
-    - Execution and return of fixture
-      'create_audit_and_update_first_of_two_original_controls'.
-    """
-    audit_with_two_controls = (
-        create_audit_and_update_first_of_two_original_controls)
-    audit = audit_with_two_controls["audit"]
-    expected_control = audit_with_two_controls["control"]
-    actual_controls_tab_count = (webui_service.ControlsService(selenium).
-                                 get_count_objs_from_tab(src_obj=audit))
-    assert len([expected_control]) == actual_controls_tab_count
-    actual_controls = (webui_service.ControlsService(selenium).
-                       get_list_objs_from_tree_view(src_obj=audit))
-    assert [expected_control] == actual_controls, (
-        messages.ERR_MSG_FORMAT.format([expected_control], actual_controls))
-
-  @pytest.mark.smoke_tests
-  def test_bulk_update_audit_objects_to_latest_ver(
-      self, create_audit_and_update_first_of_two_original_controls, selenium
-  ):
-    """Check via UI that Audit contains snapshotable Controls that up-to-date
-    with their actual states after bulk updated audit objects
-    to latest version.
-    Preconditions:
-    - Execution and return of fixture
-      'create_audit_and_update_first_of_two_original_controls'.
-    """
-    audit_with_two_controls = (
-        create_audit_and_update_first_of_two_original_controls)
-    audit = audit_with_two_controls["audit"]
-    expected_controls = [audit_with_two_controls["updated_control"],
-                         audit_with_two_controls["second_control"]]
-    (webui_service.AuditsService(selenium).
-     bulk_update_via_info_page(audit_obj=audit))
-    actual_controls_tab_count = (webui_service.ControlsService(selenium).
-                                 get_count_objs_from_tab(src_obj=audit))
-    assert len(expected_controls) == actual_controls_tab_count
-    actual_controls = (webui_service.ControlsService(selenium).
-                       get_list_objs_from_tree_view(src_obj=audit))
-    assert expected_controls == actual_controls, (
-        messages.ERR_MSG_FORMAT.format(expected_controls, actual_controls))
-
-  @pytest.mark.smoke_tests
+  @pytest.mark.cloning
   def test_cloned_audit_contains_new_attrs(self, create_and_clone_audit,
                                            selenium):
     """Check via UI that cloned Audit contains new predicted attributes.
@@ -334,6 +127,7 @@ class TestAuditPage(base.Test):
         messages.ERR_MSG_FORMAT.format(expected_audit, actual_audit))
 
   @pytest.mark.smoke_tests
+  @pytest.mark.cloning
   def test_non_clonable_objs_donot_move_to_cloned_audit(
       self, create_and_clone_audit, selenium
   ):
@@ -350,6 +144,7 @@ class TestAuditPage(base.Test):
     assert actual_asmts_tab_count == actual_issues_tab_count == 0
 
   @pytest.mark.smoke_tests
+  @pytest.mark.cloning
   def test_clonable_audit_related_objs_move_to_cloned_audit(
       self, create_and_clone_audit, selenium
   ):
@@ -367,6 +162,7 @@ class TestAuditPage(base.Test):
             [expected_asmt_tmpl], actual_asmt_tmpls))
 
   @pytest.mark.smoke_tests
+  @pytest.mark.cloning
   def test_clonable_not_audit_related_objs_move_to_cloned_audit(
       self, create_and_clone_audit, selenium
   ):
@@ -386,29 +182,3 @@ class TestAuditPage(base.Test):
     actual_objs = [actual_controls, actual_programs]
     assert expected_objs == actual_objs, (
         messages.ERR_MSG_FORMAT.format(expected_objs, actual_objs))
-
-  @pytest.mark.smoke_tests
-  @pytest.mark.parametrize("tab_name", [Lhn.ALL_OBJS, Lhn.MY_OBJS])
-  @pytest.mark.parametrize(
-      "version_of_ctrl, is_found",
-      [("control", False), ("updated_control", True)],
-      ids=["Snapshoted version is not found",
-           "Actual snapshotable control is presented"])
-  def test_search_snapshots_lhn(
-      self, create_audit_and_update_original_control, selenium,
-          version_of_ctrl, is_found, tab_name):
-    """Check via UI that LHN search not looking for snapshots."""
-    selenium.get(dashboard.Dashboard.URL)
-    lhn_menu = dashboard.Dashboard(selenium).open_lhn_menu()
-    lhn_menu.select_tab(tab_name)
-    control_title = (
-        create_audit_and_update_original_control[version_of_ctrl].title
-    )
-    lhn_menu.filter_query(control_title)
-    list_of_ctrls = (
-        lhn_menu.select_controls_or_objectives()
-        .select_controls().members_visible
-    )
-    assert (control_title in
-            [el.text for el in list_of_ctrls if len(list_of_ctrls) != 0]
-            ) == is_found

--- a/test/selenium/src/tests/test_snapshots.py
+++ b/test/selenium/src/tests/test_snapshots.py
@@ -1,0 +1,251 @@
+# Copyright (C) 2017 Google Inc., authors, and contributors <see AUTHORS file>
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+"""Snapshot smoke tests."""
+# pylint: disable=no-self-use
+# pylint: disable=invalid-name
+# pylint: disable=unused-argument
+# pylint: disable=too-many-arguments
+
+import pytest
+
+from lib import base
+from lib.constants import messages
+from lib.constants.element import Lhn
+from lib.page import dashboard
+from lib.service import webui_service, rest_service
+
+
+class TestSnapshots(base.Test):
+  """Tests for snapshot functionality."""
+
+  @pytest.fixture(scope="function")
+  def create_audit_and_update_original_control(
+      self, new_control_rest, new_program_rest, map_control_to_program_rest,
+      new_audit_rest, update_control_rest
+  ):
+    """Create Audit with snapshotable Control and update original Control under
+    Program via REST API.
+    Preconditions:
+    - Program, Control created via REST API.
+    - Control mapped to Program via REST API.
+    - Audit created under Program via REST API.
+    - Original Control updated via REST API.
+    """
+    return {
+        "audit": new_audit_rest[0], "program": new_program_rest,
+        "control": new_control_rest, "updated_control": update_control_rest}
+
+  @pytest.fixture(scope="function")
+  def create_audit_and_delete_original_control(
+      self, new_control_rest, new_program_rest, map_control_to_program_rest,
+      new_audit_rest, delete_control_rest
+  ):
+    """Create Audit with snapshotable Control and delete original Control under
+    Program via REST API.
+    Preconditions:
+    - Program, Control created via REST API.
+    - Control mapped to Program via REST API.
+    - Audit created under Program via REST API.
+    - Original Control deleted via REST API.
+    """
+    return {
+        "audit": new_audit_rest[0], "program": new_program_rest,
+        "control": new_control_rest}
+
+  @pytest.fixture(scope="function")
+  def create_audit_and_update_first_of_two_original_controls(
+      self, create_audit_and_update_original_control
+  ):
+    """Create Audit with snapshotable Control and update original Control under
+    Program via REST API. After that create second Control and map it to
+    Program via REST API.
+    Preconditions:
+    - Execution and return of fixture
+      'create_audit_and_update_original_control'.
+    - Second Control created via REST API.
+    - Second Control mapped to Program via REST API.
+    """
+    audit_with_one_control = create_audit_and_update_original_control
+    second_control = rest_service.ControlsService().create(count=1)[0]
+    rest_service.ObjectsOwnersService().create(objs=second_control)
+    rest_service.RelationshipsService().create(
+        src_obj=audit_with_one_control["program"], dest_objs=second_control)
+    return {
+        "audit": create_audit_and_update_original_control["audit"],
+        "program": audit_with_one_control["program"],
+        "control": audit_with_one_control["control"],
+        "updated_control": audit_with_one_control["updated_control"],
+        "second_control": second_control}
+
+  @pytest.mark.smoke_tests
+  def test_audit_contains_readonly_ver_of_control(
+      self, new_control_rest, new_program_rest, map_control_to_program_rest,
+      new_audit_rest, selenium
+  ):
+    """Check via UI that Audit contains read-only snapshotable Control.
+    Preconditions:
+    - Program, Control created via REST API.
+    - Control mapped to Program via REST API.
+    - Audit created under Program via REST API.
+    """
+    audit, _ = new_audit_rest
+    actual_controls_tab_count = (webui_service.ControlsService(selenium).
+                                 get_count_objs_from_tab(src_obj=audit))
+    assert len([new_control_rest]) == actual_controls_tab_count
+    is_control_editable = (
+        webui_service.ControlsService(selenium).is_obj_editable_via_info_panel(
+            src_obj=audit, obj=new_control_rest))
+    assert is_control_editable is False
+
+  @pytest.mark.smoke_tests
+  def test_audit_contains_snapshotable_control_after_updating_control(
+      self, create_audit_and_update_original_control, selenium
+  ):
+    """Check via UI that Audit contains snapshotable Control that does not
+    equal updated version Control without version updating Control.
+    Preconditions:
+    - Execution and return of fixture
+      'create_audit_and_update_original_control'.
+    """
+    audit_with_one_control = create_audit_and_update_original_control
+    audit = audit_with_one_control["audit"]
+    expected_control = audit_with_one_control["control"]
+    actual_controls_tab_count = (webui_service.ControlsService(selenium).
+                                 get_count_objs_from_tab(src_obj=audit))
+    assert len([expected_control]) == actual_controls_tab_count
+    actual_controls = (webui_service.ControlsService(selenium).
+                       get_list_objs_from_tree_view(src_obj=audit))
+    assert [expected_control] == actual_controls, (
+        messages.ERR_MSG_FORMAT.format([expected_control], actual_controls))
+
+  @pytest.mark.smoke_tests
+  def test_update_snapshotable_ver_after_updating_original_control(
+      self, create_audit_and_update_original_control, selenium
+  ):
+    """Check via UI that Audit contains snapshotable Control that up-to-date
+    with it actual state of original control after updating snapshot to latest
+    version.
+    Preconditions:
+    - Execution and return of fixture
+      'create_audit_and_update_original_control'.
+    """
+    audit_with_one_control = create_audit_and_update_original_control
+    audit = audit_with_one_control["audit"]
+    control = audit_with_one_control["control"]
+    expected_control = audit_with_one_control["updated_control"]
+    (webui_service.ControlsService(selenium).
+     update_obj_ver_via_info_panel(src_obj=audit, obj=control))
+    actual_controls_tab_count = (webui_service.ControlsService(selenium).
+                                 get_count_objs_from_tab(src_obj=audit))
+    assert len([expected_control]) == actual_controls_tab_count
+    actual_controls = (webui_service.ControlsService(selenium).
+                       get_list_objs_from_tree_view(src_obj=audit))
+    assert [expected_control] == actual_controls, (
+        messages.ERR_MSG_FORMAT.format([expected_control], actual_controls))
+
+  @pytest.mark.smoke_tests
+  @pytest.mark.skipif(True, reason="Issue in app GGRC-1196")
+  def test_audit_contains_snapshotable_control_after_deleting_original_control(
+      self, create_audit_and_delete_original_control, selenium
+  ):
+    """Check via UI that Audit contains snapshotable Control even after
+    deleting original control.
+    Snapshot does not have links to update version to latest state
+    and to view original Control under Program.
+    Preconditions:
+    - Execution and return of fixture
+      'create_audit_and_delete_original_control'.
+    """
+    audit_with_one_control = create_audit_and_delete_original_control
+    audit = audit_with_one_control["audit"]
+    expected_control = audit_with_one_control["control"]
+    actual_controls_tab_count = (webui_service.ControlsService(selenium).
+                                 get_count_objs_from_tab(src_obj=audit))
+    assert len([expected_control]) == actual_controls_tab_count
+    actual_controls = (webui_service.ControlsService(selenium).
+                       get_list_objs_from_tree_view(src_obj=audit))
+    assert [expected_control] == actual_controls, (
+        messages.ERR_MSG_FORMAT.format([expected_control], actual_controls))
+    is_control_updateable = (webui_service.ControlsService(selenium).
+                             is_obj_updateble_via_info_panel(
+        src_obj=audit, obj=expected_control))
+    is_control_openable = (webui_service.ControlsService(selenium).
+                           is_obj_page_exist_via_info_panel(
+        src_obj=audit, obj=expected_control))
+    assert is_control_updateable is False
+    assert is_control_openable is False
+
+  @pytest.mark.smoke_tests
+  def test_mapped_to_program_controls_does_not_added_to_existing_audit(
+      self, create_audit_and_update_first_of_two_original_controls, selenium
+  ):
+    """Check via UI that Audit contains snapshotable Control that equal to
+    original Control does not contain Control that was mapped to
+    Program after Audit creation.
+    Preconditions:
+    - Execution and return of fixture
+      'create_audit_and_update_first_of_two_original_controls'.
+    """
+    audit_with_two_controls = (
+        create_audit_and_update_first_of_two_original_controls)
+    audit = audit_with_two_controls["audit"]
+    expected_control = audit_with_two_controls["control"]
+    actual_controls_tab_count = (webui_service.ControlsService(selenium).
+                                 get_count_objs_from_tab(src_obj=audit))
+    assert len([expected_control]) == actual_controls_tab_count
+    actual_controls = (webui_service.ControlsService(selenium).
+                       get_list_objs_from_tree_view(src_obj=audit))
+    assert [expected_control] == actual_controls, (
+        messages.ERR_MSG_FORMAT.format([expected_control], actual_controls))
+
+  @pytest.mark.smoke_tests
+  def test_bulk_update_audit_objects_to_latest_ver(
+      self, create_audit_and_update_first_of_two_original_controls, selenium
+  ):
+    """Check via UI that Audit contains snapshotable Controls that up-to-date
+    with their actual states after bulk updated audit objects
+    to latest version.
+    Preconditions:
+    - Execution and return of fixture
+      'create_audit_and_update_first_of_two_original_controls'.
+    """
+    audit_with_two_controls = (
+        create_audit_and_update_first_of_two_original_controls)
+    audit = audit_with_two_controls["audit"]
+    expected_controls = [audit_with_two_controls["updated_control"],
+                         audit_with_two_controls["second_control"]]
+    (webui_service.AuditsService(selenium).
+     bulk_update_via_info_page(audit_obj=audit))
+    actual_controls_tab_count = (webui_service.ControlsService(selenium).
+                                 get_count_objs_from_tab(src_obj=audit))
+    assert len(expected_controls) == actual_controls_tab_count
+    actual_controls = (webui_service.ControlsService(selenium).
+                       get_list_objs_from_tree_view(src_obj=audit))
+    assert expected_controls == actual_controls, (
+        messages.ERR_MSG_FORMAT.format(expected_controls, actual_controls))
+
+  @pytest.mark.smoke_tests
+  @pytest.mark.parametrize("tab_name", [Lhn.ALL_OBJS, Lhn.MY_OBJS])
+  @pytest.mark.parametrize(
+      "version_of_ctrl, is_found",
+      [("control", False), ("updated_control", True)],
+      ids=["Snapshoted version is not found",
+           "Actual snapshotable control is presented"])
+  def test_search_snapshots_in_lhn(
+      self, create_audit_and_update_original_control, selenium,
+          version_of_ctrl, is_found, tab_name):
+    """Check via UI that LHN search not looking for snapshots."""
+    selenium.get(dashboard.Dashboard.URL)
+    lhn_menu = dashboard.Dashboard(selenium).open_lhn_menu()
+    lhn_menu.select_tab(tab_name)
+    control_title = (
+        create_audit_and_update_original_control[version_of_ctrl].title
+    )
+    lhn_menu.filter_query(control_title)
+    list_of_ctrls = (
+        lhn_menu.select_controls_or_objectives()
+        .select_controls().members_visible
+    )
+    assert (control_title in
+            [el.text for el in list_of_ctrls if len(list_of_ctrls) != 0]
+            ) == is_found


### PR DESCRIPTION
This PR address 2 things:
1. Split snapshot tests and regular audit tests
2. Add test `test_filter_of_snapshotable_control` to check that filtering in scope of Audit works by snapshoted version of object (not actual)