### PR TITLE
QUICK-FIX Test Fix stability of unified mapper test

### DIFF
--- a/test/selenium/src/lib/base.py
+++ b/test/selenium/src/lib/base.py
@@ -602,6 +602,7 @@ class ListCheckboxes(Component):
 
   def select_by_titles(self, list_titles):
     """Select checkboxes according titles."""
+    selenium_utils.wait_for_js_to_load(self._driver)
     selenium_utils.get_when_all_visible(self._driver, self.locator_titles)
     objs_titles = self._driver.find_elements(*self.locator_titles)
     objs_checkboxes = self._driver.find_elements(*self.locator_checkboxes)

--- a/test/selenium/src/lib/entities/entity.py
+++ b/test/selenium/src/lib/entities/entity.py
@@ -140,6 +140,9 @@ class ControlEntity(Entity):
             self.state == other.state and self.owner == other.owner and
             self.primary_contact == other.primary_contact)
 
+  def __lt__(self, other):
+    return self.code < other.code
+
 
 class AuditEntity(Entity):
   """Class that represent model for Audit."""

--- a/test/selenium/src/tests/test_unified_mapper.py
+++ b/test/selenium/src/tests/test_unified_mapper.py
@@ -32,5 +32,5 @@ class TestProgramPage(base.Test):
     assert len(expected_controls) == actual_controls_tab_count
     actual_controls = (webui_service.ControlsService(selenium).
                        get_list_objs_from_tree_view(src_obj=new_program_rest))
-    assert expected_controls == actual_controls, (
+    assert sorted(expected_controls) == sorted(actual_controls), (
         messages.ERR_MSG_FORMAT.format(expected_controls, actual_controls))


### PR DESCRIPTION
This PR address 2 things:
1. Fix StaleElementException during selecting object in Unified Mapper window that caused by list refreshing after search
2. Fix unstable list comparison that caused by ordering problem of excepted and actual list of object (because we doesn't specify order for queryApi call we can't rely on default ordering by object id)