### PR TITLE
QUICK-FIX Update freezegun python package

### DIFF
--- a/src/requirements-dev.txt
+++ b/src/requirements-dev.txt
@@ -14,7 +14,7 @@ flask-debugtoolbar==0.10.0
 Flask-Jasmine==1.4
 Flask-Testing==0.4.2
 Flask==0.10.1
-freezegun==0.3.5
+freezegun==0.3.8
 ipdb==0.8.1
 ipython==3.2.0
 itsdangerous==0.24


### PR DESCRIPTION
This update fixes re-running tests with sniffer.

To test this PR, run sniffer inside `test/unit` and save any python test file. On the second run the unittests with freezegun begin failing.