### PR TITLE
QUICK-FIX sort_by subproperty add into Person

### DIFF
--- a/src/ggrc/models/assessment.py
+++ b/src/ggrc/models/assessment.py
@@ -130,11 +130,11 @@ class Assessment(statusable.Statusable, AuditRelationship,
       'design',
       'operationally',
       MultipleSubpropertyFullTextAttr('related_assessors', 'assessors',
-                                      ['email', 'name']),
+                                      ['user_name', 'email', 'name']),
       MultipleSubpropertyFullTextAttr('related_creators', 'creators',
-                                      ['email', 'name']),
+                                      ['user_name', 'email', 'name']),
       MultipleSubpropertyFullTextAttr('related_verifiers', 'verifiers',
-                                      ['email', 'name']),
+                                      ['user_name', 'email', 'name']),
   ]
 
   _tracked_attrs = {

--- a/src/ggrc/models/object_owner.py
+++ b/src/ggrc/models/object_owner.py
@@ -91,7 +91,8 @@ class Ownable(object):
   ]
   _include_links = []
   _fulltext_attrs = [
-      MultipleSubpropertyFullTextAttr('owners', 'owners', ['name', 'email'])
+      MultipleSubpropertyFullTextAttr('owners', 'owners',
+                                      ['user_name', 'email', 'name'])
   ]
   _aliases = {
       "owners": {

--- a/src/ggrc/models/person.py
+++ b/src/ggrc/models/person.py
@@ -92,6 +92,10 @@ class Person(CustomAttributable, CustomAttributeMapable, HasOwnContext,
   def is_authenticated(self):
     return self.system_wide_role != 'No Access'
 
+  @property
+  def user_name(self):
+    return self.email.split("@")[0]
+
   def is_active(self):
     # pylint: disable=no-self-use
     return True  # self.active


### PR DESCRIPTION
To make all multiple person attributes indexed correctly and in the same way.

Depends on: QUICK-FIX Test Fix stability of unified mapper test #5467
And should work fine then.