### PR TITLE
GGRC-1533 Change status color in Related Assessments

### DIFF
--- a/src/ggrc/assets/javascripts/components/state-colors-map/state-colors-map.js
+++ b/src/ggrc/assets/javascripts/components/state-colors-map/state-colors-map.js
@@ -7,15 +7,8 @@
   'use strict';
   /* Default Sate for Assessment should be 'Not Started' */
   var defaultState = 'Not Started';
-  var tpl = '<span style="color: {{color}};">{{state}}</span>';
-  /* Predefined Colors Mapping Object for Assessment */
-  var defaultColorsMap = {
-    'Not Started': '#bdbdbd',
-    'In Progress': '#ffab40',
-    'Ready for Review': '#1378bb',
-    Verified: '#333',
-    Completed: '#8bc34a'
-  };
+  var tpl = '<span class="state-value-dot state-{{suffix}}">{{state}}</span>';
+
   /**
    * can.Map(ViewModel) presenting behavior of State Colors Map Component
    * @type {can.Map}
@@ -26,22 +19,10 @@
         type: 'string',
         value: defaultState
       },
-      color: {
+      suffix: {
         get: function () {
-          var colorsMap = this.attr('colorsMap') || defaultColorsMap;
-          var color = colorsMap[this.attr('state')];
-          if (!color) {
-            console.warn('State of the Instance is not defined in Colors Map: ',
-              this.attr('state'));
-          }
-          /* Set default 'Not Started' State Color in case incorrect state is provided */
-          return color || colorsMap[defaultState];
-        }
-      },
-      colorsMap: {
-        type: '*',
-        value: function () {
-          return defaultColorsMap;
+          var state = this.attr('state') || defaultState;
+          return state.toLowerCase().replace(/[\s\t]+/g, '');
         }
       }
     }

--- a/src/ggrc/assets/javascripts/components/state-colors-map/tests/state-colors-map_spec.js
+++ b/src/ggrc/assets/javascripts/components/state-colors-map/tests/state-colors-map_spec.js
@@ -6,20 +6,20 @@
 describe('GGRC.Components.stateColorsMap', function () {
   'use strict';
 
-  var completedState = 'Completed';
-  var completedColor = '#8bc34a';
-  var defaultColor = '#bdbdbd';
+  var completedState = 'In Progress';
+  var completedSuffix = 'inprogress';
+  var defaultSuffix = 'notstarted';
 
-  describe('in case state is set as "Completed"', function () {
+  describe('in case state is set as "In Progress"', function () {
     var viewModel;
 
     beforeEach(function () {
       viewModel = GGRC.Components.getViewModel('stateColorsMap');
     });
 
-    it('color property should be "#8bc34a"', function () {
+    it('suffix property should be "inprogress"', function () {
       viewModel.attr('state', completedState);
-      expect(viewModel.attr('color')).toBe(completedColor);
+      expect(viewModel.attr('suffix')).toBe(completedSuffix);
     });
   });
 
@@ -30,38 +30,9 @@ describe('GGRC.Components.stateColorsMap', function () {
       viewModel = GGRC.Components.getViewModel('stateColorsMap');
     });
 
-    it('color property should be "#bdbdbd"', function () {
+    it('suffix property should be "notstarted"', function () {
       viewModel.attr('state', null);
-      expect(viewModel.attr('color')).toBe(defaultColor);
-    });
-  });
-
-  describe('in case colorsMap is mistakenly defined as null' +
-    ' default colorMap should be used ', function () {
-    var viewModel;
-
-    beforeEach(function () {
-      viewModel = GGRC.Components.getViewModel('stateColorsMap');
-    });
-
-    it('and color property should be "#bdbdbd"', function () {
-      viewModel.attr('colorsMap', null);
-      viewModel.attr('state', null);
-      expect(viewModel.attr('color')).toBe(defaultColor);
-    });
-  });
-
-  describe('in case colorsMap is redefined', function () {
-    var viewModel;
-
-    beforeEach(function () {
-      viewModel = GGRC.Components.getViewModel('stateColorsMap');
-    });
-
-    it('color property should be "#aaa"', function () {
-      viewModel.attr('colorsMap', {some: '#aaa'});
-      viewModel.attr('state', 'some');
-      expect(viewModel.attr('color')).toBe('#aaa');
+      expect(viewModel.attr('suffix')).toBe(defaultSuffix);
     });
   });
 });


### PR DESCRIPTION
**Unify colors for assessment states in tree view/audit summary page/related assessments tab**

**Steps to reproduce**:
1. Create at least 5 assessments on the audit page
2. States for the created assessments should be: Not Started, In Progress, Ready for Review, Completed and Verified, Completed (no verification)
3. Navigate to Info panel one of the assessment and open Related Assessments window
4. Look at ASSESSMENT STATE

**Actual Result**: ASSESSMENT STATE color in Related Assessments tab is differ from the color in pie chart (e.g. "In progress" is colored with orange, should be in blue color) and there is no dot marked as state color
**Expected Result**: Unify colors for assessment states in tree view/audit summary page/related assessments tab

![image](https://cloud.githubusercontent.com/assets/567805/24601780/e8b111e6-1862-11e7-8555-5845f27c4ab9.png)
