### PR TITLE
GGRC-1370 "Item" is displayed out of field

### DIFF
--- a/src/ggrc/assets/stylesheets/components/tree_pagination/_tree_pagination.scss
+++ b/src/ggrc/assets/stylesheets/components/tree_pagination/_tree_pagination.scss
@@ -10,7 +10,7 @@ tree-pagination {
     font-size: 12px;
 
     &__count {
-      width: 130px;
+      width: 175px;
       margin-right: 16px;
       line-height: 26px;
       cursor: pointer;

--- a/src/ggrc/assets/stylesheets/modules/_filters.scss
+++ b/src/ggrc/assets/stylesheets/modules/_filters.scss
@@ -170,7 +170,7 @@
       &__paging-wrap {
         display: block;
         position: absolute;
-        width: 350px;
+        width: 395px;
         right: 0;
         top: 0;
       }


### PR DESCRIPTION
_Steps to reproduce:_
1. Open Section widget on My Work page
2. Look at pagination: "xxx" of "xxx" items
3. Follow to the next page

_Actual Result_: "Item" is displayed out of field
_Expected Result_: "Item" should not displayed out of field

![screenshot-1](https://cloud.githubusercontent.com/assets/4204416/24603412/5ef4b49c-1869-11e7-8483-3cb9db0c61a6.png)
