### PR TITLE
GGRC-1380 UI: Fix filters by Name and Roles in People tab on Admin Dashboard

### DIFF
--- a/src/ggrc/assets/mustache/people/filters.mustache
+++ b/src/ggrc/assets/mustache/people/filters.mustache
@@ -16,13 +16,13 @@
       <div class="span9">
         <ul class="tree-filter__filter-people">
           <li>
-            <label>
+            <label class="tree-filter__filter-label-name">
               By Name
             </label>
             <input name="search" type="text" value="" class="tree-filter__input tree-filter__input--medium" value="{{search_query}}" placeholder="By name, email or company">
           </li>
           <li>
-            <label>
+            <label class="tree-filter__filter-label-role">
               By Roles
             </label>
             <select name="user_role">

--- a/src/ggrc/assets/stylesheets/modules/_filters.scss
+++ b/src/ggrc/assets/stylesheets/modules/_filters.scss
@@ -152,9 +152,19 @@
     @extend %reset-list;
     float:right;
     li {
-      display:inline-block;
+      display:inline-flex;
       margin-left: 20px;
+
+      label {
+        margin-right: 5px;
+      }
     }
+  }
+  &__filter-label-name {
+    line-height: 26px;
+  }
+  &__filter-label-role {
+    line-height: 21px;
   }
 
   &.tree-filter_paging {


### PR DESCRIPTION
_Steps to reproduce:_
1. Log as admin and open People tab on admin dashboard
2. Look at filters By Name and By Roles

_Actual Result_: Filters By Name and By Roles are broken in People tab on Admin Dashboard
_Expected Result_: Filters By Name and By Roles should not be broken in People tab on Admin Dashboard

![screenshot-1](https://cloud.githubusercontent.com/assets/4204416/24608451/3e7e9ee2-187f-11e7-967f-336970c55458.png)
