### PR TITLE
GGRC-1493 Fix downloading large exported data sets

### DIFF
--- a/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
+++ b/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
@@ -137,15 +137,67 @@
       });
     },
     download: function (filename, text) {
-      var element = document.createElement('a');
-      element.setAttribute(
-        'href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(text));
-      element.setAttribute('download', filename);
-      element.style.display = 'none';
-      document.body.appendChild(element);
-      element.click();
-      document.body.removeChild(element);
+      var TMP_FILENAME = 'export_objects.csv';
+
+      // a helper for opening the "Save File" dialog to save downloaded data
+      function promptSaveFile() {
+        var downloadURL = [
+          'filesystem:', window.location.origin, '/temporary/', TMP_FILENAME
+        ].join('');
+
+        var link = document.createElement('a');
+
+        link.setAttribute('href', downloadURL);
+        link.setAttribute('download', TMP_FILENAME);
+        link.style.display = 'none';
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+      }
+
+      function errorHandler(error) {
+        console.error('LocalFileSys error:', error);
+      }
+
+      // a callback for when the browser's virtual file system is obtained
+      function fileSystemObtained(localstorage) {
+        localstorage.root.getFile(
+          TMP_FILENAME, {create: true}, fileEntryObtained, errorHandler);
+      }
+
+      // a helper that writes thee downloaded data to a tmeporary file
+      // and then opens the "Save File" dialog
+      function fileEntryObtained(fileEntry) {
+        fileEntry.createWriter(function (fileWriter) {
+          var truncated = false;
+
+          // the onwriteevent fires twice - once after truncating the file,
+          // and then after writing the downloaded text content to it
+          fileWriter.onwriteend = function (ev) {
+            var blob;
+            if (!truncated) {
+              truncated = true;
+              blob = new Blob([text], {type: 'text/plain'});
+              fileWriter.write(blob);
+            } else {
+              promptSaveFile();
+            }
+          };
+
+          fileWriter.onerror = function (ev) {
+            console.error('Writing temp file failed: ' + ev.toString());
+          };
+
+          fileWriter.truncate(0);  // in case the file exists and is non-empty
+        }, errorHandler);
+      }
+
+      // start storing the downloaded data to a temporary file for the user to
+      // save it on his/her computers storage
+      window.webkitRequestFileSystem(
+        window.TEMPORARY, text.length, fileSystemObtained, errorHandler);
     },
+
     loadScript: function (url, callback) {
       var script = document.createElement('script');
       script.type = 'text/javascript';


### PR DESCRIPTION
IMPORTANT: If we decide, based on the risk assessment, that we will not include this fix in the upcoming release, please apply the `on hold` label to the PR on my behalf, thanks.

---

This PR fixes a problem with exporting large amount of data (i.e. more than ~1.4 MB).

The root cause was handling the data on the frontend after downloading it. The data was first URL-encoded and then set as a value of the temp DOM element's `href` attribute using the "data:" protocol. In Chrome at least, the maximum permitted size of that attribute is 2 MB, and large CSV data hits that limit.

This PR changes the way data is handled. It creates a temporary file using the browser's virtual file system API, and then points to that temporary file using the `'filesystem:<host>/temporary/<filename.csv>` link.

The storage limitations of such temporary files are 33 % of the local computer's storage space with each application allowed to occupy up to 20 % of that space (something like that, not necessarily 100 % true). In practice, this means "quite a lot", and definitely significantly more than 2 MB.

A few things to note, though:
  * The solution uses the fairly new File System API currently only supported by Chrome and (partially) Firefox
  * During the development I accidentally caused infinite "Save File" dialogs and clicked "YES" when asked whether to prevent the browser from further showing these dialogs. I consequently experienced that the "Save As" dialog did not pop up a few times, but after opening a new browser session, clearing the cache and local data the problem went away.
It might have been a coincidence though, and the issue would still emerge in some odd edge case, thus please make sure to click around thoroughly and test as much as you can, so that we can be confident that users will not experience the same problem.
 * I was able to successfully export and save a ~3.5 MB large CSV file using Chrome 57.0.2987.110 (64-bit) on Goobuntu 14.04. There is a small chance users on Macs and other systems might not have the same experience.
 * Even though this PR seemingly fixes the issue, we might be better off by refactoring the export page form and the server API, and submit query as a regular form POST, letting the browser handle the file-like response from the server without having to rely on a non-trivial frontend code. We might want to open a refactoring ticket for this purpose. 

---

**Steps to reproduce:**
  1. As admin user go to Data Export page
  2. In export object types select Regulations, Programs, Objectives, Policies (+ some more), and click "Export objects"
NOTE: You should use a pretty large DB dump, e.g. the one from grc-test @ 23rd March.

**Actual Result:**
Extremely slow to export objects. The download error while exporting (the "save file" dialog does not open, even though the data has been downloaded successfully according to the Dev Tools' network tab)

**Expected Result:**
to improve performance while exporting and no error displayed while exporting a huge amount of objects - the limit seems to be around 1.4 MB, check the Network tab in Dev Tools to see the size of the downloaded data.
