### PR TITLE
GGRC-1767 finished and verified date as datetime

### DIFF
--- a/src/ggrc/models/mixins/__init__.py
+++ b/src/ggrc/models/mixins/__init__.py
@@ -381,7 +381,7 @@ class FinishedDate(object):
   @declared_attr
   def finished_date(cls):
     return deferred(
-        db.Column(db.Date, nullable=True),
+        db.Column(db.DateTime, nullable=True),
         cls.__name__
     )
 
@@ -394,7 +394,7 @@ class FinishedDate(object):
   }
 
   _fulltext_attrs = [
-      attributes.DateFullTextAttr('finished_date', 'finished_date'),
+      attributes.DatetimeFullTextAttr('finished_date', 'finished_date'),
   ]
 
   @validates('status')
@@ -434,7 +434,7 @@ class VerifiedDate(object):
   @declared_attr
   def verified_date(cls):
     return deferred(
-        db.Column(db.Date, nullable=True),
+        db.Column(db.DateTime, nullable=True),
         cls.__name__
     )
 
@@ -452,7 +452,7 @@ class VerifiedDate(object):
   }
 
   _fulltext_attrs = [
-      attributes.DateFullTextAttr("verified_date", "verified_date"),
+      attributes.DatetimeFullTextAttr("verified_date", "verified_date"),
       "verified",
   ]
 

--- a/test/integration/ggrc/converters/test_export_assessments.py
+++ b/test/integration/ggrc/converters/test_export_assessments.py
@@ -3,6 +3,7 @@
 
 
 """Tests for task group task specific export."""
+import datetime
 from ddt import data, ddt
 
 from ggrc import db
@@ -32,7 +33,10 @@ class TestExport(TestCase):
     factories.RelationshipFactory(source=extr_assessment,
                                   destination=extr_comment)
     self.comment = factories.CommentFactory(description="123")
-    self.assessment = factories.AssessmentFactory()
+    self.assessment = factories.AssessmentFactory(
+        verified_date=datetime.datetime.now(),
+        finished_date=datetime.datetime.now(),
+    )
     self.rel = factories.RelationshipFactory(source=self.comment,
                                              destination=self.assessment)
 
@@ -114,4 +118,18 @@ class TestExport(TestCase):
     """Test filter by updated at"""
     self.filter_by_datetime(alias,
                             self.assessment.updated_at,
+                            [self.assessment.slug])
+
+  @data("finished_date", "Finished Date", "finished date")
+  def test_filter_by_finished_date(self, alias):
+    """Test filter by finished date"""
+    self.filter_by_datetime(alias,
+                            self.assessment.finished_date,
+                            [self.assessment.slug])
+
+  @data("verified_date", "Verified Date", "verified date")
+  def test_filter_by_verified_date(self, alias):
+    """Test filter by verified date"""
+    self.filter_by_datetime(alias,
+                            self.assessment.verified_date,
                             [self.assessment.slug])


### PR DESCRIPTION
It's required for filtering verified_date and finished_date for assessments 

~depends on: https://github.com/google/ggrc-core/pull/5480~