### PR TITLE
GGRC-997 Add title in Audit Summary widget

### DIFF
--- a/src/ggrc/assets/mustache/dashboard/object_widget.mustache
+++ b/src/ggrc/assets/mustache/dashboard/object_widget.mustache
@@ -21,38 +21,43 @@
     </header>
   {{/if_equals}}
 
-  {{#if_equals widget_id "custom_attribute"}}
   {{^is_dashboard}}
-    <header class="header">
-      <h2>
-        <i class="fa fa-workflow color"></i>
-        {{{widget_name}}}
-      </h2>
-    </header>
-  {{/is_dashboard}}
-  {{/if_equals}}
+    {{#if_equals widget_id "custom_attribute"}}
+      <header class="header">
+        <h2>
+          <i class="fa fa-workflow color"></i>
+          {{{widget_name}}}
+        </h2>
+      </header>
+    {{/if_equals}}
 
-  {{#if_equals widget_id "events_list"}}
-  {{^is_dashboard}}
-    <header class="header">
-      <h2>
-        <i class="fa-history"></i>
-        {{{widget_name}}}
-      </h2>
-    </header>
-  {{/is_dashboard}}
-  {{/if_equals}}
+    {{#if_equals widget_id "events_list"}}
+      <header class="header">
+        <h2>
+          <i class="fa-history"></i>
+          {{{widget_name}}}
+        </h2>
+      </header>
+    {{/if_equals}}
 
-  {{#if_equals widget_id "info"}}
-  {{^is_dashboard}}
-    <header class="header">
-      <h2>
-        <i class="{{widget_icon}}"></i>
-        {{{widget_name}}}
-      </h2>
-    </header>
+    {{#if_equals widget_id "info"}}
+      <header class="header">
+        <h2>
+          <i class="{{widget_icon}}"></i>
+          {{{widget_name}}}
+        </h2>
+      </header>
+    {{/if_equals}}
+
+    {{#if_equals widget_id "Summary"}}
+      <header class="header">
+        <h2>
+          <i class="{{widget_icon}}"></i>
+          {{{widget_name}}}
+        </h2>
+      </header>
+    {{/if_equals}}
   {{/is_dashboard}}
-  {{/if_equals}}
 
   <section class="content">
     {{{widget_initial_content}}}


### PR DESCRIPTION
**Add text "Audit Summary" to Audit Summary page**

**Steps to reproduce**:
1. Go to Audit Summary page
2. Look at page: text "Audit Summary" is absent

**Actual Result**: Text "Audit Summary" in Audit Summary page is not shown
**Expected Result**: Text "Audit Summary" is shown in Audit Summary page

![image](https://cloud.githubusercontent.com/assets/567805/24650748/dec09202-1933-11e7-8744-374980a098e1.png)

