### PR TITLE
GGRC-1268/GGRC-382 Mandatory date fields are missing the red star mark

### DIFF
--- a/src/ggrc/assets/javascripts/components/tests/datepicker_spec.js
+++ b/src/ggrc/assets/javascripts/components/tests/datepicker_spec.js
@@ -7,69 +7,363 @@ describe('GGRC.Components.datepicker', function () {
   'use strict';
 
   var Component;  // the component under test
+  var events;
 
   beforeAll(function () {
     Component = GGRC.Components.get('datepicker');
+    events = Component.prototype.events;
   });
 
-  describe('updateDate() method', function () {
-    var method;
-    var scope;
+  describe('viewModel', function () {
+    var viewModel;
 
-    beforeAll(function () {
-      scope = new can.Map({
-        scope: {
-          picker: {
-            datepicker: jasmine.createSpy()
-          }
-        }
+    beforeEach(function () {
+      viewModel = Component.prototype.viewModel();
+    });
+
+    describe('onSelect() method', function () {
+      it('sets new date', function () {
+        viewModel.attr('date', 'oldDate');
+        viewModel.onSelect('newDate');
+        expect(viewModel.attr('date')).toEqual('newDate');
       });
-      method = Component.prototype.events.updateDate.bind(scope);
+      it('sets false to isShown attribute', function () {
+        viewModel.attr('isShown', true);
+        viewModel.onSelect();
+        expect(viewModel.attr('isShown')).toEqual(false);
+      });
     });
 
-    it('returns undefined for empty date', function () {
-      expect(method('maxDate')).toBe(null);
-      expect(method('maxDate', null)).toBe(null);
-      expect(method('minDate', '')).toBe(null);
-    });
-
-    it('returns a date incremented by a day for maxDate', function () {
-      var result = method('maxDate', new Date(2017, 0, 1));
-
-      expect(result.getDate()).toBe(31);
-      expect(result.getFullYear()).toBe(2016);
-      expect(result.getMonth()).toBe(11);
-    });
-
-    it('returns a date decremented by a day for minDate', function () {
-      var result = method('minDate', new Date(2017, 0, 1));
-
-      expect(result.getDate()).toBe(2);
-      expect(result.getFullYear()).toBe(2017);
-      expect(result.getMonth()).toBe(0);
+    describe('onFocus() method', function () {
+      it('sets false to showTop attribute', function () {
+        spyOn(GGRC.Utils, 'inViewport')
+          .and.returnValue(true);
+        viewModel.attr('showtop', true);
+        viewModel.onFocus();
+        expect(viewModel.attr('showTop')).toEqual(false);
+      });
+      it('sets true to isShown attribute', function () {
+        spyOn(GGRC.Utils, 'inViewport')
+          .and.returnValue(true);
+        viewModel.attr('isShown', false);
+        viewModel.onFocus();
+        expect(viewModel.attr('isShown')).toEqual(true);
+      });
+      it('does not set true to showTop attribute if picker is in viewport',
+        function () {
+          spyOn(GGRC.Utils, 'inViewport')
+            .and.returnValue(true);
+          viewModel.onFocus();
+          expect(viewModel.attr('showTop')).toEqual(false);
+        });
+      it('sets true to showTop attribute if picker is not in viewport',
+        function () {
+          spyOn(GGRC.Utils, 'inViewport')
+            .and.returnValue(false);
+          viewModel.onFocus();
+          expect(viewModel.attr('showTop')).toEqual(true);
+        });
     });
   });
 
-  describe('prepareDate() method', function () {
-    var method;
-    var scope;
+  describe('events', function () {
+    describe('inserted() method', function () {
+      var method;
+      var that;
+      var viewModel;
+      var altField;
+      var element;
 
-    beforeAll(function () {
-      scope = Component.prototype.scope();
-      method = Component.prototype.events.prepareDate.bind(scope);
+      beforeEach(function () {
+        viewModel = Component.prototype.viewModel();
+        viewModel.onSelect.bind = jasmine.createSpy()
+          .and.returnValue('mockOnSelect');
+        element = $('<div class="datepicker__calendar"></div>');
+        altField = $('<div class="datepicker__input"></div>');
+        $('body').append(element);
+        $('body').append(altField);
+        that = {
+          viewModel: viewModel,
+          element: $('body'),
+          getDate: function (date) {
+            return date;
+          },
+          updateDate: jasmine.createSpy()
+        };
+        method = events.inserted.bind(that);
+      });
+      afterEach(function () {
+        $('body').html('');
+      });
+
+      it('create datepicker in specified format', function () {
+        method();
+        expect(element.datepicker('option', 'dateFormat'))
+          .toEqual(viewModel.PICKER_ISO_DATE);
+        expect(element.datepicker('option', 'altField')[0])
+          .toEqual(altField[0]);
+        expect(element.datepicker('option', 'altFormat'))
+          .toEqual(viewModel.PICKER_DISPLAY_FMT);
+      });
+      it('sets new datepicker to picker of viewModel', function () {
+        method();
+        expect(viewModel.attr('picker')[0]).toEqual(element[0]);
+      });
+      it('sets date from viewModel to datepicker', function () {
+        element.datepicker('setDate', '2011-11-11');
+        viewModel.attr('date', '2012-12-12');
+        method();
+        expect(viewModel.picker.datepicker().val()).toEqual('2012-12-12');
+      });
+      it('sets min allowed date to viewModel', function () {
+        viewModel.attr('minDate', '2000-10-10');
+        viewModel.setMinDate = '2001-01-01';
+        method();
+        expect(viewModel.attr('setMinDate')).toEqual('2001-01-01');
+      });
+      it('sets max allowed date to viewModel', function () {
+        viewModel.attr('maxDate', '2000-10-10');
+        viewModel.setMaxDate = '2011-11-11';
+        method();
+        expect(viewModel.attr('setMaxDate')).toEqual('2011-11-11');
+      });
+      it('updates min date if setMinDate is define in viewModel', function () {
+        viewModel.setMinDate = '2001-01-01';
+        method();
+        expect(that.updateDate).toHaveBeenCalledWith('minDate', '2001-01-01');
+      });
+      it('updates max date if setMaxDate is define in viewModel', function () {
+        viewModel.setMaxDate = '2011-11-11';
+        method();
+        expect(that.updateDate).toHaveBeenCalledWith('maxDate', '2011-11-11');
+      });
     });
 
-    it('returns null for incorrect date', function () {
-      expect(method(scope, 'some string')).toBe(null);
-      expect(method(scope, '11.12.68')).toBe(null);
-      expect(method(scope, '11.12.2017')).toBe(null);
-      expect(method(scope, '')).toBe(null);
+    describe('getDate() method', function () {
+      var method;
+      var that;
+      var viewModel;
+
+      beforeEach(function () {
+        viewModel = Component.prototype.viewModel();
+        that = {
+          viewModel: viewModel,
+          isValidDate: events.isValidDate.bind(that)
+        };
+        method = events.getDate.bind(that);
+      });
+
+      it('returns formatted date if it is Date object', function () {
+        expect(method(new Date('2011-11-11 00:00:00'))).toEqual('2011-11-11');
+      });
+      it('returns date if it is valid date', function () {
+        expect(method('2012-12-12')).toEqual('2012-12-12');
+      });
+      it('returns null if it is invalid date', function () {
+        expect(method('2013-13-13')).toEqual(null);
+      });
     });
 
-    it('returns ISO date formated for correct date', function () {
-      expect(method(scope, '11/12/2017')).toBe('2017-11-12');
-      expect(method(scope, ' 11/12/2017')).toBe('2017-11-12');
-      expect(method(scope, '11/12/2017 ')).toBe('2017-11-12');
+    describe('isValidDate() method', function () {
+      var method;
+      var that;
+
+      beforeEach(function () {
+        that = {
+          viewModel: Component.prototype.viewModel()
+        };
+        method = events.isValidDate.bind(that);
+      });
+      it('returns true if it is valid date', function () {
+        expect(method('2011-11-11')).toEqual(true);
+      });
+      it('returns false if it is invalid date', function () {
+        expect(method('-2011-11-11')).toEqual(false);
+        expect(method('2011-33-01')).toEqual(false);
+        expect(method('2011-11-45')).toEqual(false);
+      });
+    });
+
+    describe('updateDate() method', function () {
+      var method;
+      var that;
+
+      beforeEach(function () {
+        that = new can.Map({
+          viewModel: {
+            picker: {
+              datepicker: jasmine.createSpy()
+            }
+          }
+        });
+        method = events.updateDate.bind(that);
+      });
+
+      it('returns undefined for empty date', function () {
+        expect(method('maxDate')).toBe(null);
+        expect(method('maxDate', null)).toBe(null);
+        expect(method('minDate', '')).toBe(null);
+      });
+
+      it('returns a date incremented by a day for maxDate', function () {
+        var result = method('maxDate', new Date(2017, 0, 1));
+
+        expect(result.getDate()).toBe(31);
+        expect(result.getFullYear()).toBe(2016);
+        expect(result.getMonth()).toBe(11);
+      });
+
+      it('returns a date decremented by a day for minDate', function () {
+        var result = method('minDate', new Date(2017, 0, 1));
+
+        expect(result.getDate()).toBe(2);
+        expect(result.getFullYear()).toBe(2017);
+        expect(result.getMonth()).toBe(0);
+      });
+    });
+
+    describe('prepareDate() method', function () {
+      var method;
+      var viewModel;
+
+      beforeEach(function () {
+        viewModel = Component.prototype.viewModel();
+        method = events.prepareDate.bind(viewModel);
+      });
+
+      it('returns null for incorrect date', function () {
+        expect(method(viewModel, 'some string')).toBe(null);
+        expect(method(viewModel, '11.12.68')).toBe(null);
+        expect(method(viewModel, '11.12.2017')).toBe(null);
+        expect(method(viewModel, '')).toBe(null);
+      });
+
+      it('returns ISO date formated for correct date', function () {
+        expect(method(viewModel, '11/12/2017')).toBe('2017-11-12');
+        expect(method(viewModel, ' 11/12/2017')).toBe('2017-11-12');
+        expect(method(viewModel, '11/12/2017 ')).toBe('2017-11-12');
+      });
+    });
+
+    describe('"{viewModel} setMinDate" handler', function () {
+      var method;
+      var viewModel;
+      var that;
+
+      beforeEach(function () {
+        viewModel = Component.prototype.viewModel();
+        that = {
+          viewModel: viewModel
+        };
+        method = events['{viewModel} setMinDate'].bind(that);
+      });
+      it('does not change _date if updated date is falsy', function () {
+        viewModel.attr('_date', '11/11/2011');
+        that.updateDate = jasmine.createSpy()
+          .and.returnValue(new Date());
+        method(viewModel, {});
+        expect(viewModel.attr('_date')).toEqual('11/11/2011');
+      });
+      it('does not change _date if updated date is before current date',
+        function () {
+          viewModel.attr('_date', '11/11/2011');
+          viewModel.attr('date', '2011-11-11');
+          that.updateDate = jasmine.createSpy()
+            .and.returnValue(new Date('2010-10-10'));
+          method(viewModel, {});
+          expect(viewModel.attr('_date')).toEqual('11/11/2011');
+        });
+      it('changes _date if updated date is after current date',
+        function () {
+          viewModel.attr('_date', '2011-11-11');
+          viewModel.attr('date', '2011-11-11');
+          that.updateDate = jasmine.createSpy()
+            .and.returnValue(new Date('2012-12-12'));
+          method(viewModel, {});
+          expect(viewModel.attr('_date')).toEqual('12/12/2012');
+        });
+    });
+
+    describe('"{viewModel} setMaxDate" handler', function () {
+      var method;
+      var that;
+      beforeEach(function () {
+        that = {
+          updateDate: jasmine.createSpy()
+        };
+        method = events['{viewModel} setMaxDate'].bind(that);
+      });
+      it('calls updateDate with "maxDate" and new date as arguments',
+        function () {
+          var date = '11-11-2011';
+          method({}, {}, date);
+          expect(that.updateDate).toHaveBeenCalledWith('maxDate', date);
+        });
+    });
+
+    describe('"{viewModel} _date" handler', function () {
+      var method;
+      var that;
+      var viewModel;
+
+      beforeEach(function () {
+        viewModel = Component.prototype.viewModel();
+        viewModel.picker = {
+          datepicker: jasmine.createSpy()
+        };
+        that = {
+          prepareDate: jasmine.createSpy()
+            .and.returnValue('ISODate')
+        };
+        method = events['{viewModel} _date'].bind(that);
+      });
+
+      it('sets prepared date to viewModel', function () {
+        method(viewModel, {}, {});
+        expect(viewModel.attr('date')).toEqual('ISODate');
+      });
+      it('sets prepared date to datepicker', function () {
+        method(viewModel, {}, {});
+        expect(viewModel.picker.datepicker)
+          .toHaveBeenCalledWith('setDate', 'ISODate');
+      });
+    });
+
+    describe('"{window} mousedown" handler', function () {
+      var method;
+      var that;
+      var viewModel;
+
+      beforeEach(function () {
+        viewModel = Component.prototype.viewModel();
+        that = {
+          viewModel: viewModel
+        };
+        method = events['{window} mousedown'].bind(that);
+      });
+
+      it('sets isShown to false if datepicker is shown' +
+      ' and click was outside the datepicker', function () {
+        viewModel.attr('isShown', true);
+        spyOn(GGRC.Utils.events, 'isInnerClick')
+          .and.returnValue(false);
+        method({}, {});
+        expect(viewModel.attr('isShown')).toEqual(false);
+      });
+      it('does nothing if datepicker is persistent', function () {
+        viewModel.attr('persistent', true);
+        viewModel.attr('isShown', true);
+        method({}, {});
+        expect(viewModel.attr('isShown')).toEqual(true);
+      });
+      it('does nothing if click was inside the datepicker', function () {
+        viewModel.attr('persistent', false);
+        viewModel.attr('isShown', true);
+        spyOn(GGRC.Utils.events, 'isInnerClick')
+          .and.returnValue(true);
+        method({}, {});
+        expect(viewModel.attr('isShown')).toEqual(true);
+      });
     });
   });
 });

--- a/src/ggrc/assets/mustache/components/effective-dates/effective-dates.mustache
+++ b/src/ggrc/assets/mustache/components/effective-dates/effective-dates.mustache
@@ -7,12 +7,12 @@
   <a data-id="hide_effective_date_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
   <datepicker
       tabindex="20"
-      label="configStartDate.label"
+      {label}="configStartDate.label"
       date="instance.start_date"
       set-max-date="instance.end_date"
-      helptext="configStartDate.helpText"
+      {helptext}="configStartDate.helpText"
       test-id="startTestId"
-      {{#configStartDate.required}}required="required"{{/configStartDate.required}}
+      {{#configStartDate.required}}required="true"{{/configStartDate.required}}
   />
 </div>
 
@@ -20,11 +20,11 @@
   <a data-id="hide_stop_date_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
   <datepicker
       tabindex="21"
-      label="configEndDate.label"
+      {label}="configEndDate.label"
       date="instance.end_date"
       set-min-date="instance.start_date"
-      helptext="configEndDate.helpText"
+      {helptext}="configEndDate.helpText"
       test-id="endTestId"
-      {{#configEndDate.required}}required="required"{{/configEndDate.required}}
+      {{#configEndDate.required}}required="true"{{/configEndDate.required}}
   />
 </div>

--- a/src/ggrc/assets/mustache/custom_attributes/modal_content.mustache
+++ b/src/ggrc/assets/mustache/custom_attributes/modal_content.mustache
@@ -19,7 +19,7 @@
               {{cad.title}}
               {{#cad.mandatory}}<span class="required">*</span>{{/cad.mandatory}}
               {{#cad.helptext}}<i class="fa fa-question-circle" rel="tooltip" title="{{cad.helptext}}"></i>{{/cad.helptext}}
-              <a href="javascript://" class="field-hide" tabindex="-1">hide</a>
+              {{#unless cad.mandatory}}<a href="javascript://" class="field-hide" tabindex="-1">hide</a>{{/unless}}
             </label>
             <input tabindex="{{add_index 20 @index}}" data-ram="{{@index}}" class="input-block-level" value="{{cav.attribute_value}}" placeholder="{{cad.placeholder}}" name="custom_attributes.{{cad.id}}" type="text">
           {{/case}}
@@ -28,7 +28,7 @@
               {{cad.title}}
               {{#cad.mandatory}}<span class="required">*</span>{{/cad.mandatory}}
               {{#cad.helptext}}<i class="fa fa-question-circle" rel="tooltip" title="{{cad.helptext}}"></i>{{/cad.helptext}}
-              <a href="javascript://" class="field-hide" tabindex="-1">hide</a>
+              {{#unless cad.mandatory}}<a href="javascript://" class="field-hide" tabindex="-1">hide</a>{{/unless}}
             </label>
             <div class="wysiwyg-area">
               <textarea tabindex="{{add_index 20 @index}}" id="{{cad.title}}" class="span12 double wysihtml5" name="custom_attributes.{{cad.id}}" placeholder="{{cad.placeholder}}">{{{cav.attribute_value}}}</textarea>
@@ -39,7 +39,7 @@
               {{cad.title}}
               {{#cad.mandatory}}<span class="required">*</span>{{/cad.mandatory}}
               {{#cad.helptext}}<i class="fa fa-question-circle" rel="tooltip" title="{{cad.helptext}}"></i>{{/cad.helptext}}
-              <a href="javascript://" class="field-hide" tabindex="-1">hide</a>
+              {{#unless cad.mandatory}}<a href="javascript://" class="field-hide" tabindex="-1">hide</a>{{/unless}}
             </label>
             <select class="input-block-level" name="custom_attributes.{{cad.id}}" null-if-empty="null-if-empty" tabindex="20">
               <option value="" {{#if_equals "" cav.attribute_value}}selected="true"{{/if_equals}}>---</option>
@@ -56,17 +56,19 @@
                 {{cad.title}}
                 {{#cad.mandatory}}<span class="required">*</span>{{/cad.mandatory}}
                 {{#cad.helptext}}<i class="fa fa-question-circle" rel="tooltip" title="{{cad.helptext}}"></i>{{/cad.helptext}}
-                <a href="javascript://" class="field-hide" tabindex="-1">hide</a>
+                {{#unless cad.mandatory}}<a href="javascript://" class="field-hide" tabindex="-1">hide</a>{{/unless}}
               </label>
             </div>
           {{/case}}
           {{#case 'Date'}}
-          <a href="javascript://" class="field-hide" tabindex="-1">hide</a>
-          <datepicker
-            label="cad.title"
-            date="instance.custom_attributes.{{cad.id}}"
-            required="cad.mandatory"
-            helptext="cad.helptext"
+            {{#unless cad.mandatory}}
+              <a href="javascript://" class="field-hide" tabindex="-1">hide</a>
+            {{/unless}}
+            <datepicker
+              {label}="cad.title"
+              date="instance.custom_attributes.{{cad.id}}"
+              required="{{cad.mandatory}}"
+              {helptext}="cad.helptext"
             />
           {{/case}}
           {{#case 'Map:Person'}}
@@ -74,7 +76,7 @@
             {{cad.title}}
             {{#cad.mandatory}}<span class="required">*</span>{{/cad.mandatory}}
             {{#cad.helptext}}<i class="fa fa-question-circle" rel="tooltip" title="{{cad.helptext}}"></i>{{/cad.helptext}}
-            <a href="javascript://" class="field-hide" tabindex="-1">hide</a>
+            {{#unless cad.mandatory}}<a href="javascript://" class="field-hide" tabindex="-1">hide</a>{{/unless}}
           </label>
             {{#using person=cav.attribute_object}}
             <input class="input-block-level"

--- a/src/ggrc_risk_assessments/assets/mustache/risk_assessments/modal_content.mustache
+++ b/src/ggrc_risk_assessments/assets/mustache/risk_assessments/modal_content.mustache
@@ -23,7 +23,7 @@
         label="Effective Date"
         date="instance.start_date"
         set-max-date="instance.end_date"
-        required="{{true}}"
+        required="true"
         />
     </div>
     <div class="span3">
@@ -31,7 +31,7 @@
       <datepicker
         label="End Date"
         date="instance.end_date"
-        required="{{true}}"
+        required="true"
         />
     </div>
     <div class="span3 hidable">

--- a/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/modal_content.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/modal_content.mustache
@@ -124,7 +124,7 @@
           <datepicker
             set-max-date="instance.end_date"
             date="instance.start_date"
-            required="{{true}}"
+            required="true"
             label="Starts Date"
             />
             {{#instance.computed_errors.start_date}}<label class="help-inline warning">{{this}}</label>{{/instance.computed_errors.start_date}}
@@ -134,7 +134,7 @@
           <datepicker
             set-min-date="instance.start_date"
             date="instance.end_date"
-            required="{{true}}"
+            required="true"
             label="Due Date"
             />
             {{#instance.computed_errors.end_date}}<label class="help-inline warning">{{this}}</label>{{/instance.computed_errors.end_date}}

--- a/src/ggrc_workflows/assets/mustache/task_group_tasks/modal_content.mustache
+++ b/src/ggrc_workflows/assets/mustache/task_group_tasks/modal_content.mustache
@@ -78,13 +78,13 @@
         </label>
         <label class="smaller">
            <datepicker date="instance.start_date"
-                       required="{{true}}"
+                       required="true"
                        label="Start Date"></datepicker>
         </label>
         <label class="smaller">
           <datepicker set-min-date="instance.start_date"
                       date="instance.end_date"
-                      required="{{true}}"
+                      required="true"
                       label="Due Date"></datepicker>
         </label>
       </div>


### PR DESCRIPTION
_Steps to reproduce_:
1. Create mandatory GCA with date type for program
2. On My work page click Start a new program
3. Look at the mandatory field with date type: mandatory date fields are missing the red star

_Actual Result_: Mandatory date fields are missing the red star
_Expected Result_: Mandatory date fields should have the red star

![screenshot-1](https://cloud.githubusercontent.com/assets/4204416/24652191/8729a564-1939-11e7-9c57-097c282dea2f.png)

