### PR TITLE
GGRC-1258 Assessment Info pane: Change Assessor to Assignee in comments

### DIFF
--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -1351,7 +1351,13 @@ Mustache.registerHelper("lowercase", function (value, options) {
     }
     value = resolve_computed(value) || '';
     value = _.first(_.map(value.split(','), function (type) {
-      return _.trim(type).toLowerCase();
+      var lowercaseType = _.trim(type).toLowerCase();
+
+      if (lowercaseType === 'assessor') {
+        lowercaseType = 'assignee';
+      }
+
+      return lowercaseType;
     }));
     return _.isEmpty(value) ? '' : '(' + capitalizeFirst(value) + ')';
   });


### PR DESCRIPTION
_Precondition_:
created program, control, audit

_Steps to reproduce_:
1. Generate assessment on the audit page based on control
2. Navigate to assessment's Info pane and add assignee (e.g. reader@reciprocitylabs.com)
3. Log as assignee (reader@reciprocitylabs.com (engage007) and leave a comment in assessment 

_Actual Result_: Assessment Info pane: Assessor instead of Assigne is shown in comments
_Expected Result_: Assessment Info pane: Assignee is shown instead of Assessor in comments

![screenshot-1](https://cloud.githubusercontent.com/assets/4204416/24657377/a54f49a8-194e-11e7-8d09-840ef5fe5d57.png)
