### PR TITLE
GGRC-1770 Rename Principal Assessor/Secondary Assessor to Principal Assignee/Secondary Assignee in Control modal window and across the application

### DIFF
--- a/src/ggrc/assets/javascripts/components/add_comment/add_comment.js
+++ b/src/ggrc/assets/javascripts/components/add_comment/add_comment.js
@@ -45,7 +45,7 @@
       get_assignee_type: function () {
         var types = new Map([
           ['related_verifiers', 'verifier'],
-          ['related_assessors', 'assessor'],
+          ['related_assessors', 'assignee'],
           ['related_assignees', 'assignee'],
           ['related_requesters', 'requester'],
           ['related_creators', 'creator']

--- a/src/ggrc/assets/mustache/assessment_templates/info.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/info.mustache
@@ -54,7 +54,7 @@
 
       <div class="row-fluid wrap-row">
         <div class="span4">
-          <h6>Default Assessors</h6>
+          <h6>Default Assignees</h6>
           {{#if default_people.assessors}}
             {{#if_string default_people.assessors}}
               {{get_item DEFAULT_PEOPLE_LABELS default_people.assessors}}

--- a/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
@@ -119,7 +119,7 @@
         <div class="row-fluid choose-from-select">
           <div class="span6 bottom-spacing">
             <label>
-              Default Assessors
+              Default Assignees
               <span class="required">*</span>
             </label>
             <dropdown

--- a/src/ggrc/assets/mustache/controls/modal_content.mustache
+++ b/src/ggrc/assets/mustache/controls/modal_content.mustache
@@ -192,7 +192,7 @@
     <div class="row-fluid">
       <div data-test-id="control_primary_assessor_f7379330" data-id="principal_assessor_hidden" class="span4 hidable">
         <label>
-          Principal Assessor
+          Principal Assignee
           <i class="fa fa-question-circle" rel="tooltip" title="Select primary person who is responsible for assessing this control."></i>
           <a data-id="hide_principal_assessor_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
         </label>
@@ -205,7 +205,7 @@
       </div>
       <div data-test-id="control_secondary_assessor_b9439af6"  data-id="secondary_assessor_hidden" class="span4 hidable">
         <label>
-          Secondary Assessor
+          Secondary Assignee
           <i class="fa fa-question-circle" rel="tooltip" title="Select secondary person who is responsible for assessing this control."></i>
           <a data-id="hide_secondary_assessor_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
         </label>


### PR DESCRIPTION
_Steps to reproduce:_
1. Invoke New Control modal window

_Actual Result_: Principal Assessor and Secondary Assessor fields are displayed
_Expected Result_: Principal Assignee and Secondary Assignee fields are displayed in New/Edit Control modal window

**Note**: change Assessor to Assignee across the application

![screenshot-1](https://cloud.githubusercontent.com/assets/4204416/24695812/e4c2d6ee-19ef-11e7-821d-8a63664f0c6a.png)
