### PR TITLE
GGRC-1538 Filter by Evidence, URL doesn't work

### DIFF
--- a/src/ggrc/models/assessment.py
+++ b/src/ggrc/models/assessment.py
@@ -39,7 +39,10 @@ from ggrc.fulltext.attributes import MultipleSubpropertyFullTextAttr
 
 
 def reindex_by_relationship_attr(relationship_attr):
-  """Return a list of assessments which which need to be reindexed"""
+  """Return a list of assessments which which need to be reindexed
+
+  In case RelationshipAttr changed
+  """
   source_query = db.session.query(Relationship.source_id).filter(
       Relationship.source_type == "Assessment",
       Relationship.id == relationship_attr.relationship_id
@@ -50,6 +53,24 @@ def reindex_by_relationship_attr(relationship_attr):
   )
   resulting_subquery = source_query.union(dest_query)
   return Assessment.query.filter(Assessment.id.in_(resulting_subquery)).all()
+
+
+def reindex_by_relationship(relationship):
+  """Return a list of assessments which which need to be reindexed
+
+  In case Relationship changed or created or deleted
+  """
+  source_type = relationship.source_type
+  destination_type = relationship.destination_type
+  if destination_type == "Assessment" and source_type == "Document":
+    instance = relationship.destination
+  elif source_type == "Assessment" and destination_type == "Document":
+    instance = relationship.source
+  else:
+    return []
+  if isinstance(instance, (Indexed, Commentable)):
+    return [instance]
+  return []
 
 
 class Assessment(statusable.Statusable, AuditRelationship,
@@ -135,6 +156,10 @@ class Assessment(statusable.Statusable, AuditRelationship,
                                       ['user_name', 'email', 'name']),
       MultipleSubpropertyFullTextAttr('related_verifiers', 'verifiers',
                                       ['user_name', 'email', 'name']),
+      MultipleSubpropertyFullTextAttr('document_evidence', 'document_evidence',
+                                      ['title', 'link']),
+      MultipleSubpropertyFullTextAttr('document_url', 'document_url',
+                                      ['link']),
   ]
 
   _tracked_attrs = {
@@ -180,7 +205,8 @@ class Assessment(statusable.Statusable, AuditRelationship,
   }
 
   AUTO_REINDEX_RULES = [
-      ReindexRule("RelationshipAttr", reindex_by_relationship_attr)
+      ReindexRule("RelationshipAttr", reindex_by_relationship_attr),
+      ReindexRule("Relationship", reindex_by_relationship)
   ]
 
   similarity_options = similarity_options_module.ASSESSMENT
@@ -199,6 +225,14 @@ class Assessment(statusable.Statusable, AuditRelationship,
   def verifiers(self):
     """Get the list of verifier assignees"""
     return self.assignees_by_type.get("Verifier", [])
+
+  @property
+  def document_evidence(self):
+    return self.documents_by_type("document_evidence")
+
+  @property
+  def document_url(self):
+    return self.documents_by_type("document_url")
 
   def validate_conclusion(self, value):
     return value if value in self.VALID_CONCLUSIONS else None

--- a/src/ggrc/models/document.py
+++ b/src/ggrc/models/document.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2017 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
+"""Module containing Document model."""
+
 from sqlalchemy.orm import validates
 
 from ggrc import db
@@ -13,6 +15,7 @@ from ggrc.models.utils import validate_option
 
 
 class Document(Ownable, Relatable, Indexed, Base, db.Model):
+  """Audit model."""
   __tablename__ = 'documents'
 
   # TODO: inherit from Titled mixin (note: title is nullable here)
@@ -73,6 +76,7 @@ class Document(Ownable, Relatable, Indexed, Base, db.Model):
 
   @validates('kind', 'year', 'language')
   def validate_document_options(self, key, option):
+    """Returns correct option, otherwise rises an error"""
     if key == 'year':
       desired_role = 'document_year'
     elif key == 'kind':

--- a/src/ggrc/models/document.py
+++ b/src/ggrc/models/document.py
@@ -4,6 +4,7 @@
 from sqlalchemy.orm import validates
 
 from ggrc import db
+from ggrc.fulltext.mixin import Indexed
 from ggrc.models.deferred import deferred
 from ggrc.models.mixins import Base
 from ggrc.models.relationship import Relatable
@@ -11,7 +12,7 @@ from ggrc.models.object_owner import Ownable
 from ggrc.models.utils import validate_option
 
 
-class Document(Ownable, Relatable, Base, db.Model):
+class Document(Ownable, Relatable, Indexed, Base, db.Model):
   __tablename__ = 'documents'
 
   # TODO: inherit from Titled mixin (note: title is nullable here)

--- a/src/ggrc/models/object_document.py
+++ b/src/ggrc/models/object_document.py
@@ -141,19 +141,21 @@ class EvidenceURL(Documentable):
   }
 
   def documents_by_type(self, doc_type):
+    """Returns a list of document objects of requested type"""
     if doc_type == "document_evidence":
-      return [object.document for object in self.object_documents]
+      # pylint: disable=not-an-iterable
+      return [instance.document for instance in self.object_documents]
     if doc_type == "document_url":
-      temp = db.session.query(Document).filter(
+      documents = db.session.query(Document).filter(
           Document.id == Relationship.destination_id,
           Relationship.source_type == "Assessment",
           Relationship.source_id == self.id,
           Relationship.destination_type == "Document"
       ).all()
-      temp += db.session.query(Document).filter(
+      documents += db.session.query(Document).filter(
           Document.id == Relationship.source_id,
           Relationship.destination_type == "Assessment",
           Relationship.destination_id == self.id,
           Relationship.source_type == "Document"
       ).all()
-      return temp
+      return documents

--- a/src/ggrc/models/object_document.py
+++ b/src/ggrc/models/object_document.py
@@ -9,8 +9,10 @@ from sqlalchemy.ext.declarative import declared_attr
 from ggrc import db
 from ggrc.models import reflection
 from ggrc.models.deferred import deferred
+from ggrc.models.document import Document
 from ggrc.models.mixins import Base
 from ggrc.models.mixins import Timeboxed
+from ggrc.models.relationship import Relationship
 
 
 class ObjectDocument(Timeboxed, Base, db.Model):
@@ -126,13 +128,11 @@ class EvidenceURL(Documentable):
   _aliases = {
       "document_url": {
           "display_name": "Url",
-          "filter_by": "_filter_by_url",
           "type": reflection.AttributeInfo.Type.SPECIAL_MAPPING,
           "description": "New line separated list of URLs.",
       },
       "document_evidence": {
           "display_name": "Evidence",
-          "filter_by": "_filter_by_evidence",
           "type": reflection.AttributeInfo.Type.SPECIAL_MAPPING,
           "description": ("New line separated list of evidence links and "
                           "titles.\nExample:\n\nhttp://my.gdrive.link/file "
@@ -140,10 +140,20 @@ class EvidenceURL(Documentable):
       },
   }
 
-  @classmethod
-  def _filter_by_url(cls, _):
-    return None
-
-  @classmethod
-  def _filter_by_evidence(cls, _):
-    return None
+  def documents_by_type(self, doc_type):
+    if doc_type == "document_evidence":
+      return [object.document for object in self.object_documents]
+    if doc_type == "document_url":
+      temp = db.session.query(Document).filter(
+          Document.id == Relationship.destination_id,
+          Relationship.source_type == "Assessment",
+          Relationship.source_id == self.id,
+          Relationship.destination_type == "Document"
+      ).all()
+      temp += db.session.query(Document).filter(
+          Document.id == Relationship.source_id,
+          Relationship.destination_type == "Assessment",
+          Relationship.destination_id == self.id,
+          Relationship.source_type == "Document"
+      ).all()
+      return temp

--- a/test/integration/ggrc/services/test_query/test_basic.py
+++ b/test/integration/ggrc/services/test_query/test_basic.py
@@ -3,6 +3,8 @@
 # Copyright (C) 2017 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
+# pylint: disable=too-many-lines
+
 """Tests for /query api endpoint."""
 
 import unittest
@@ -835,6 +837,44 @@ class TestSortingQuery(BaseQueryAPITestCase):
     )
     self.assertListEqual([ass["title"] for ass in assessments_by_assessors],
                          ["Assessment_2", "Assessment_1"])
+
+
+class TestQueryAssessmentByEvidenceURL(BaseQueryAPITestCase):
+  """Test assessments filtering by Evidence and/or URL"""
+  def setUp(self):
+    """Set up test cases for all tests."""
+    TestCase.clear_data()
+    response = self._import_file("assessment_full_no_warnings.csv")
+    self._check_csv_response(response, {})
+    self.client.get("/login")
+
+  def test_query_evidence_url(self):
+    """Test assessments query filtered by Evidence"""
+    assessments_by_evidence = self._get_first_result_set(
+        self._make_query_dict(
+            "Assessment",
+            expression=["Evidence", "~", "i.imgur.com"],
+        ),
+        "Assessment", "values",
+    )
+
+    self.assertEqual(len(assessments_by_evidence), 2)
+    self.assertItemsEqual([asmt["title"] for asmt in assessments_by_evidence],
+                          ["Assessment title 1", "Assessment title 3"])
+
+    assessments_by_evidence = self._get_first_result_set(
+        self._make_query_dict(
+            "Assessment",
+            expression=["url", "~", "i.imgur.com"],
+        ),
+        "Assessment", "values",
+    )
+
+    self.assertEqual(len(assessments_by_evidence), 3)
+    self.assertItemsEqual([asmt["title"] for asmt in assessments_by_evidence],
+                          ["Assessment title 1",
+                           "Assessment title 3",
+                           "Assessment title 4"])
 
 
 class TestQueryWithCA(BaseQueryAPITestCase):

--- a/test/integration/ggrc/test_csvs/assessment_full_no_warnings.csv
+++ b/test/integration/ggrc/test_csvs/assessment_full_no_warnings.csv
@@ -5,8 +5,8 @@ user2@a.com","user2@a.com
 user5@a.com","Verifier, Requester",Yes,http://i.imgur.com/Lppr247.jpg,"http://i.imgur.com/Lppr247.jpg evidence 啕 title 1
 http://i.imgur.com/qA0l5tb.gifv some title 2",,
 ,Assessment 2,Audit,Assessment title 2,Some desc 2,notes 2,In Progress,user1@a.com,user2@a.com,,No,,,,
-,Assessment 3,Audit,Assessment title 3,Some desc 3,notes 3,Not StarTED,user1@a.com,user2@a.com,,,,,,
-,Assessment 4,Audit,Assessment title 4,Some desc 4,notes 4,In PROGRESS,user1@a.com,user2@a.com,,,,,,
+,Assessment 3,Audit,Assessment title 3,Some desc 3,notes 3,Not StarTED,user1@a.com,user2@a.com,,,http://i.imgur.com/Lppr347.jpg,http://i.imgur.com/Lppr547.jpg Some title 3,,
+,Assessment 4,Audit,Assessment title 4,Some desc 4,notes 4,In PROGRESS,user1@a.com,user2@a.com,,,http://i.imgur.com/Lppr447.jpg,,,
 ,Assessment 5,Audit,Assessment title 5,,,not started,user1@a.com,user2@a.com,,,,,,
 ,Assessment 6,Audit,Assessment title 6,,,not started,user1@a.com,user2@a.com,,,,,,
 ,Assessment 7,Audit,Assessment title 7,,,not started,user1@a.com,user2@a.com,,,,,,


### PR DESCRIPTION
filter for original objects - doesn’t work
Evidence, URL
Tech note: Evidence is a Document mapped via ObjectDocuments table, URL is a Document mapped via Relationships table (both m2m mappings).