### PR TITLE
GGRC-1758 Update tree view columns on My Tasks tab

### DIFF
--- a/src/ggrc_workflows/assets/javascripts/models/cycle_models.js
+++ b/src/ggrc_workflows/assets/javascripts/models/cycle_models.js
@@ -332,34 +332,39 @@
       attr_view: _mustachePath + '/tree-item-attr.mustache',
       attr_list: [
         {
-          attr_title: 'Title',
-          attr_name: 'title'
+          attr_title: 'Task title',
+          attr_name: 'title',
+          attr_sort_field: 'task title'
         },
         {
-          attr_title: 'Workflow',
+          attr_title: 'Cycle title',
           attr_name: 'workflow',
-          attr_sort_field: 'cycle.workflow.title'
+          attr_sort_field: 'cycle title'
         },
         {
-          attr_title: 'State',
-          attr_name: 'status'
+          attr_title: 'Task state',
+          attr_name: 'status',
+          attr_sort_field: 'task state'
         },
         {
-          attr_title: 'Assignee',
+          attr_title: 'Task assignee',
           attr_name: 'assignee',
-          attr_sort_field: 'contact'
+          attr_sort_field: 'task assignee'
         },
         {
-          attr_title: 'Start Date',
-          attr_name: 'start_date'
+          attr_title: 'Task start date',
+          attr_name: 'start_date',
+          attr_sort_field: 'task start date'
         },
         {
-          attr_title: 'End Date',
-          attr_name: 'end_date'
+          attr_title: 'Task due date',
+          attr_name: 'end_date',
+          attr_sort_field: 'task due date'
         },
         {
-          attr_title: 'Last Updated',
-          attr_name: 'updated_at'
+          attr_title: 'Task last updated',
+          attr_name: 'updated_at',
+          attr_sort_field: 'task last updated'
         }
       ],
       display_attr_names: ['title', 'assignee', 'start_date'],

--- a/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/tree_header.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/tree_header.mustache
@@ -11,8 +11,8 @@
     <div class="row-fluid">
       <div class="span{{display_options.title_width}}">
         <div class="title-heading oneline">
-          <span class="widget-col-title" data-field="title">
-            Title
+          <span class="widget-col-title" data-field="task title">
+            Task title
             <i class="fa fa-caret-down"></i>
           </span>
         </div>


### PR DESCRIPTION
Tree view column names on My Tasks tab are out of sync with Task info pane labels.

_Proposed renames:_
1. Title -> Task title
2. Workflow -> Cycle title
3. State -> Task state
4. Assignee -> Task assignee
5. Start date -> Task start date
6. End date -> Task due date
7. Last updated -> Task last updated

The values of **attr_sort_fields** match the column titles.

Related to PR #5480