### PR TITLE
GGRC-1580 "Uncaught Error: First argument must be an object." error occurs if click on third tier

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/tree/tree-view.js
+++ b/src/ggrc/assets/javascripts/controllers/tree/tree-view.js
@@ -1384,7 +1384,9 @@
         'title',
         'type',
         'viewLink',
-        'workflow_state'
+        'workflow_state',
+        // labels for assessment templates
+        'DEFAULT_PEOPLE_LABELS'
       ];
 
       if (!originalOrder.length) {


### PR DESCRIPTION
_Steps to reproduce:_
1. Open https://grc-test.appspot.com/dashboard#assessment_widget/assessment/11259 link and expand third tier
2. Click on the object that is not marked in blue color (in this case title of the object is "at_v_1")

_Actual Result_: "Uncaught Error: First argument must be an object." error occurs if click on third tier
_Expected Result_: no error is shown

![screenshot-1](https://cloud.githubusercontent.com/assets/4204416/24750158/8cb50640-1ace-11e7-9613-427867064ce0.png)
