### PR TITLE
GGRC-1804 Add original_object_deleted flag to snapshots

### DIFF
--- a/src/ggrc/models/snapshot.py
+++ b/src/ggrc/models/snapshot.py
@@ -46,6 +46,7 @@ class Snapshot(relationship.Relatable, mixins.Base, db.Model):
       "revision_id",
       reflection.PublishOnly("revisions"),
       reflection.PublishOnly("is_latest_revision"),
+      reflection.PublishOnly("original_object_deleted"),
   ]
 
   _update_attrs = [
@@ -90,6 +91,11 @@ class Snapshot(relationship.Relatable, mixins.Base, db.Model):
   def is_latest_revision(self):
     """Flag if the snapshot has the latest revision."""
     return self.revisions and self.revision == self.revisions[-1]
+
+  @computed_property
+  def original_object_deleted(self):
+    """Flag if the snapshot has the latest revision."""
+    return self.revisions and self.revisions[-1].action == "deleted"
 
   @classmethod
   def eager_query(cls):


### PR DESCRIPTION
This flag should be used to show or hide links to original objects on
snapshot page.

This is a performance fix for this line
https://github.com/google/ggrc-core/blob/release/0.10-Raspberry/src/ggrc/assets/javascripts/components/snapshotter/open-original-link.js#L45

that should not be called on every info pin load.