### PR TITLE
GGRC-1769 "CREATE DATE" field is not shown in tree view and set visible field dialog. (Assessments view)

### DIFF
--- a/src/ggrc/assets/javascripts/models/assessment.js
+++ b/src/ggrc/assets/javascripts/models/assessment.js
@@ -96,7 +96,7 @@
         attr_name: 'verifiers',
         order: 7
       }, {
-        attr_title: 'Create Date',
+        attr_title: 'Created Date',
         attr_name: 'created_at',
         order: 8
       }]


### PR DESCRIPTION
Updated title for created_at