### PR TITLE
GGRC-1532 When user approves/rejects an objects (standard), a different users is shown as approver

### DIFF
--- a/src/ggrc_workflows/__init__.py
+++ b/src/ggrc_workflows/__init__.py
@@ -539,6 +539,7 @@ def handle_cycle_task_group_object_task_put(
   if getattr(obj.task_group_task, 'object_approval', None):
     for tgobj in obj.task_group_task.task_group.objects:
       if obj.status == 'Verified':
+        tgobj.modified_by = get_current_user()
         tgobj.set_reviewed_state()
         db.session.add(tgobj)
     db.session.flush()


### PR DESCRIPTION
When a user approves/rejects an object. A different users shows up as approver after click the approve button.
Please check out the attachment. This is the only screen this happens on, and believe this might be part of the state change.
Steps to reproduce:
1. Log as "user-1"
2. Create Standard
3. Click Submit for review, add reviewer ("user-2") and select a date
4. Log as "user-2"
5. Click Approve button
Actual Result: When user approves/rejects an objects (standard), a different user (not approver - "user-1") is shown as approver.
Expected Result: When user approves/rejects an objects (standard) reviewer should be shown as approver