### PR TITLE
GGRC-1591 Tasks are not ordered by date in Active Cycles tab (subtreeview)

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/tree/tree-view.js
+++ b/src/ggrc/assets/javascripts/controllers/tree/tree-view.js
@@ -1398,7 +1398,9 @@
           var typeModels = {
             type: item,
             fields: [],
-            page: {}
+            page: parent.type === 'CycleTaskGroup' ?
+              {sortBy: 'task due date'} :
+              {}
           };
           var rootFilter = parentCtrl.options.attr('paging.filter');
           if (rootFilter) {


### PR DESCRIPTION
The functionality needs to be implemented on active cycle tab, the sorting on tasks needs to occur on due date (sorting in ascending order)

![screen shot 2017-04-07 at 4 35 56 pm](https://cloud.githubusercontent.com/assets/4204416/24802343/4d3c8f00-1bb0-11e7-8551-60469850b7a0.png)