### PR TITLE
GGRC-1821/1822/1823 Dropdown filter is not applied for "Not Started"/"In progress" states by default on My Assessments page

### DIFF
--- a/src/ggrc/assets/javascripts/plugins/tests/current-page-utils_spec.js
+++ b/src/ggrc/assets/javascripts/plugins/tests/current-page-utils_spec.js
@@ -1,0 +1,126 @@
+/*!
+ Copyright (C) 2017 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+describe('GGRC Utils CurrentPage', function () {
+  var pageType;
+  beforeEach(function () {
+    pageType = GGRC.pageType;
+  });
+
+  afterAll(function () {
+    GGRC.pageType = pageType;
+  });
+
+  beforeEach(function () {
+    var instance = {
+      id: 1,
+      type: 'Audit'
+    };
+
+    spyOn(GGRC, 'page_instance')
+      .and.returnValue(instance);
+
+    GGRC.pageType = undefined;
+  });
+  describe('getPageType() method', function () {
+    var method;
+
+    beforeEach(function () {
+      method = GGRC.Utils.CurrentPage.getPageType;
+    });
+
+    it('returns pageType value if it defined', function () {
+      GGRC.pageType = 'MOCK_PAGE';
+      expect(method()).toEqual('MOCK_PAGE');
+    });
+
+    it('returns page_instance type if pageType not defined', function () {
+      expect(method()).toEqual('Audit');
+    });
+  });
+
+  describe('isMyAssessments() method', function () {
+    var method;
+
+    beforeEach(function () {
+      method = GGRC.Utils.CurrentPage.isMyAssessments;
+    });
+
+    it('returns True for GGRC.pageType = MY_ASSESSMENTS', function () {
+      GGRC.pageType = 'MY_ASSESSMENTS';
+      expect(method()).toBeTruthy();
+    });
+
+    it('returns False if pageType not defined', function () {
+      expect(method()).toBeFalsy();
+    });
+
+    it('returns False if GGRC.pageType not equal MY_ASSESSMENTS', function () {
+      GGRC.pageType = 'FOO_BAR';
+      expect(method()).toBeFalsy();
+    });
+  });
+
+  describe('isMyWork() method', function () {
+    var method;
+
+    beforeEach(function () {
+      method = GGRC.Utils.CurrentPage.isMyWork;
+    });
+
+    it('returns True for GGRC.pageType = MY_WORK', function () {
+      GGRC.pageType = 'MY_WORK';
+      expect(method()).toBeTruthy();
+    });
+
+    it('returns False if pageType not defined', function () {
+      expect(method()).toBeFalsy();
+    });
+
+    it('returns False if GGRC.pageType not equal MY_WORK', function () {
+      GGRC.pageType = 'FOO_BAR_BAR';
+      expect(method()).toBeFalsy();
+    });
+  });
+
+  describe('isAdmin() method', function () {
+    var method;
+
+    beforeEach(function () {
+      method = GGRC.Utils.CurrentPage.isAdmin;
+    });
+
+    it('returns True for GGRC.pageType = ADMIN', function () {
+      GGRC.pageType = 'ADMIN';
+      expect(method()).toBeTruthy();
+    });
+
+    it('returns False if pageType not defined', function () {
+      expect(method()).toBeFalsy();
+    });
+
+    it('returns False if GGRC.pageType not equal ADMIN', function () {
+      GGRC.pageType = 'FOO_BAR_BAZ';
+      expect(method()).toBeFalsy();
+    });
+  });
+
+  describe('isObjectContextPage() method', function () {
+    var method;
+
+    beforeEach(function () {
+      method = GGRC.Utils.CurrentPage.isObjectContextPage;
+    });
+
+    it('returns True if pageType not defined', function () {
+      expect(method()).toBeTruthy();
+    });
+
+    it('returns False if pageType defined', function () {
+      GGRC.pageType = 'ADMIN';
+      expect(method()).toBeFalsy();
+    });
+  });
+});

--- a/src/ggrc/assets/javascripts/plugins/tests/state-utils_spec.js
+++ b/src/ggrc/assets/javascripts/plugins/tests/state-utils_spec.js
@@ -131,7 +131,12 @@ describe('GGRC.Utils.State', function () {
     });
 
     it('get default states for "Control" type', function () {
-      var defaultStates = GGRC.Utils.State
+      var defaultStates;
+
+      spyOn(GGRC.Utils.CurrentPage, 'isMyAssessments')
+        .and.returnValue(false);
+
+      defaultStates = GGRC.Utils.State
         .getDefaultStatesForModel('Control');
 
       expect(defaultStates.length).toEqual(3);

--- a/src/ggrc/assets/javascripts/plugins/utils/current-page-utils.js
+++ b/src/ggrc/assets/javascripts/plugins/utils/current-page-utils.js
@@ -41,10 +41,12 @@
           return relatedToCurrentInstance;
         });
     }
-    // Needs refactoring: should be modified to some solid solution
+
+    // To identify pages like My Work, My Assessments and Admin Dashboard on the Server-side
+    // was defined variable GGRC.pageType, because for all of them GGRC.page_instance().type = 'Person'.
+    // For other pages using GGRC.page_instance() object.
     function getPageType() {
-      return GGRC.pageType ||
-      GGRC.page_instance() ? GGRC.page_instance().type : '';
+      return GGRC.pageType ? GGRC.pageType : GGRC.page_instance().type;
     }
 
     function isMyAssessments() {
@@ -59,8 +61,12 @@
       return getPageType() === 'ADMIN';
     }
 
+    /**
+     *
+     * @return {boolean} False for My Work, All Objects and My Assessments pages and True for the rest.
+     */
     function isObjectContextPage() {
-      return !getPageType();
+      return !GGRC.pageType;
     }
 
     /**


### PR DESCRIPTION
**GGRC-1821 Dropdown filter is not applied for "Not Started"/"In progress" states by default on My Assessments page**

Steps t reproduce:
1. Open My Assessments page
2. Look at the dropdown filter
Actual Result: All the assessment states are applied in dropdown filter
Expected Result: Dropdown filter should be applied for "Not Started"/"In progress" states by default on My Assessments page

**GGRC-1822
"Last updated" column is not displayed by default on My assessments page**

Steps to reproduce:
1. Open My Assessments page
2. Look at tree view 
Actual Result: "Last updated" column is not displayed by default on My assessments page
Expected Result: "Last updated" column should be displayed by default on My assessments page

**GGRC-1823
"Show objects not directly related to this object" link is not shown in tree view**

Steps to reproduce:
1. Create program
2. Create control and map it to program
3. Expand subtree for control
Actual Result: "Show objects not directly related to this object" link is not shown in tree view
Expected Result: "Show objects not directly related to this object" link should be shown in tree view