### PR TITLE
GGRC-1582 Change wording "owner" to "admin" in all objects across the application except Workflow

### DIFF
--- a/src/ggrc/assets/mustache/controls/contacts.mustache
+++ b/src/ggrc/assets/mustache/controls/contacts.mustache
@@ -27,7 +27,7 @@
         {{/if}}
       {{/with_mapping}}
     {{else}}
-    <h6>Owner</h6>
+    <h6>Admin</h6>
     <p class="oneline">
       {{#if owners.length}}
         {{#using contacts=owners}}

--- a/src/ggrc/assets/mustache/help/filters_helper_content.mustache
+++ b/src/ggrc/assets/mustache/help/filters_helper_content.mustache
@@ -49,14 +49,14 @@
         <tr>
           <td><span class="code"></span></td>
           <td><strong></strong></td>
-          <td><span class="code">owner ~ john</span></td>
-          <td>All objects that have <em>john</em> as part of the owner name</td>
+          <td><span class="code">admin ~ john</span></td>
+          <td>All objects that have <em>john</em> as part of the admin name</td>
         </tr>
         <tr>
           <td><span class="code">=</span></td>
           <td><strong>equals</strong></td>
-          <td><span class="code">owner = “john doe”</span></td>
-          <td>All objects that have <em>john doe</em> as an owner</td>
+          <td><span class="code">admin = “john doe”</span></td>
+          <td>All objects that have <em>john doe</em> as an admin</td>
         </tr>
         <tr>
           <td><span class="code">!~</span></td>
@@ -79,7 +79,7 @@
         <tr>
           <td><span class="code">AND</span></td>
           <td><strong>logical AND</strong></td>
-          <td><span class="code">title ~ PCI AND owner = “john doe”</span></td>
+          <td><span class="code">title ~ PCI AND admin = “john doe”</span></td>
           <td>All objects that contain word <em>PCI</em> in title and are owned by <em>john doe</em></td>
         </tr>
         <tr>
@@ -91,8 +91,8 @@
         <tr>
           <td><span class="code">ORDER BY ASC/DESC</span></td>
           <td><strong>sort by</strong></td>
-          <td><span class="code">title ~ PCI order by owner asc</span></td>
-          <td>All objects that contain <em>PCI</em> in the title, in ascending order by owner</td>
+          <td><span class="code">title ~ PCI order by admin asc</span></td>
+          <td>All objects that contain <em>PCI</em> in the title, in ascending order by admin</td>
         </tr>
         <tr>
           <td><span class="code"></span></td>


### PR DESCRIPTION
Since we are using control "owner" field in a different way now and will be named "admin". It would be more useful to see the principle and secondary assignees in the main popup window instead of having to click "show advanced" button. The principal assignee being the real world control owner, and secondary assignee being the real world control oversight owner.

Change wording "owner" to "admin" in all objects across the application except Workflow

![screenshot-2](https://cloud.githubusercontent.com/assets/4204416/24853739/c04c07d8-1de4-11e7-91c8-f532329cc2e2.png)
