### PR TITLE
QUICK-FIX: Delete indexed record on add new record

### DIFF
--- a/src/ggrc/views/__init__.py
+++ b/src/ggrc/views/__init__.py
@@ -23,8 +23,7 @@ from ggrc.builder.json import publish
 from ggrc.builder.json import publish_representation
 from ggrc.converters import get_importables, get_exportables
 from ggrc.extensions import get_extension_modules
-from ggrc.fulltext import get_indexer, get_indexed_model_names
-from ggrc.fulltext.recordbuilder import fts_record_for
+from ggrc.fulltext import get_indexed_model_names
 from ggrc.login import get_current_user
 from ggrc.login import login_required
 from ggrc.models import all_models
@@ -73,10 +72,6 @@ def reindex(_):
 def do_reindex():
   """Update the full text search index."""
 
-  indexer = get_indexer()
-  with benchmark('Delete all records'):
-    indexer.delete_all_records(False)
-
   indexed_models = get_indexed_model_names()
 
   people = db.session.query(all_models.Person.id, all_models.Person.name,
@@ -94,7 +89,7 @@ def do_reindex():
       )
       for query_chunk in generate_query_chunks(query):
         for instance in query_chunk:
-          indexer.create_record(fts_record_for(instance), False)
+          instance.update_indexer()
         db.session.commit()
 
   reindex_snapshots()

--- a/test/integration/ggrc/converters/test_ca_import_export.py
+++ b/test/integration/ggrc/converters/test_ca_import_export.py
@@ -195,11 +195,6 @@ class TestCustomAttributeImportExport(TestCase):
     filename = "custom_attribute_tests.csv"
     self.import_file(filename)
 
-    # TODO: there is a bug that imports do not index all custom attributes.
-    # After fixing this bug remove the following two lines.
-    from ggrc import views
-    views.do_reindex()
-
     data = [{
         "object_name": "Product",
         "filters": {

--- a/test/integration/ggrc/fulltext/test_mysql.py
+++ b/test/integration/ggrc/fulltext/test_mysql.py
@@ -6,7 +6,6 @@
 import sqlalchemy.exc
 
 from ggrc import db
-from ggrc import views
 from ggrc.fulltext import mysql
 from integration.ggrc import TestCase
 from integration.ggrc.models import factories
@@ -28,9 +27,6 @@ class TestCAD(TestCase):
     factory = factories.MarketFactory()
     CAV(custom_attribute=cad1, attributable=factory, attribute_value="x")
     CAV(custom_attribute=cad2, attributable=factory, attribute_value="x")
-
-    views.do_reindex()
-
     title1_count = mysql.MysqlRecordProperty.query.filter(
         mysql.MysqlRecordProperty.property == title1
     ).count()
@@ -43,9 +39,6 @@ class TestCAD(TestCase):
     cad1 = CAD(title=title1, definition_type="market")
     factory = factories.MarketFactory()
     CAV(custom_attribute=cad1, attributable=factory, attribute_value="x")
-
-    views.do_reindex()
-
     title1_count = mysql.MysqlRecordProperty.query.filter(
         mysql.MysqlRecordProperty.property == title1
     ).count()


### PR DESCRIPTION
This is prevent conflicts on reindex procedure. 