### PR TITLE
GGRC-931 "Uncaught SyntaxError: Unexpected token p in JSON at position 40" error is displayed while mapping an audit to the program with "double quotes"

### DIFF
--- a/src/ggrc/assets/mustache/audits/tree_add_item.mustache
+++ b/src/ggrc/assets/mustache/audits/tree_add_item.mustache
@@ -15,7 +15,7 @@
          data-modal-class="modal-wide"
          data-object-singular="Audit"
          data-object-plural="audits"
-         data-object-params='{ "{{parent_instance.class.table_singular}}": { "id" : {{parent_instance.id}}, "title" : "{{parent_instance.title}}" }, "context": { "id" : {{firstnonempty parent_instance.context.id "null"}}, "href" : "{{parent_instance.context.href}}", "type" : "{{parent_instance.context.type}}" } }'>
+         data-object-params='{ "{{parent_instance.class.table_singular}}": { "id" : {{parent_instance.id}}, "title" : "{{json_escape parent_instance.title}}" }, "context": { "id" : {{firstnonempty parent_instance.context.id "null"}}, "href" : "{{parent_instance.context.href}}", "type" : "{{parent_instance.context.type}}" } }'>
         Create
       </a>
     {{/is_allowed}}

--- a/src/ggrc/assets/mustache/dashboard/internav_list.mustache
+++ b/src/ggrc/assets/mustache/dashboard/internav_list.mustache
@@ -65,7 +65,7 @@
               data-object-params='{
                   "{{instance.class.table_singular}}": {
                       "id": {{instance.id}},
-                      "title": "{{instance.title}}"
+                      "title": "{{json_escape instance.title}}"
                   },
                   "context": {
                       "id": {{firstnonempty instance.context.id "null"}},

--- a/src/ggrc/assets/mustache/sections/tree_add_item.mustache
+++ b/src/ggrc/assets/mustache/sections/tree_add_item.mustache
@@ -20,7 +20,7 @@
         data-object-params='{
           "directive": {
               "id": {{parent_instance.id}},
-              "title": "{{parent_instance.title}}"
+              "title": "{{json_escape parent_instance.title}}"
           },
           "context": {
               "id": {{firstnonempty parent_instance.context.id "null"}},

--- a/src/ggrc_risk_assessments/assets/mustache/risk_assessments/tree_add_item.mustache
+++ b/src/ggrc_risk_assessments/assets/mustache/risk_assessments/tree_add_item.mustache
@@ -19,7 +19,7 @@
         data-modal-class="modal-wide"
         data-object-singular="RiskAssessment"
         data-object-plural="risk_assessments"
-        data-object-params='{ "{{parent_instance.class.table_singular}}": { "id" : {{parent_instance.id}}, "title" : "{{parent_instance.title}}" }, "context": { "id" : {{firstnonempty parent_instance.context.id "null"}}, "href" : "{{parent_instance.context.href}}", "type" : "{{parent_instance.context.type}}" } }'>
+        data-object-params='{ "{{parent_instance.class.table_singular}}": { "id" : {{parent_instance.id}}, "title" : "{{json_escape parent_instance.title}}" }, "context": { "id" : {{firstnonempty parent_instance.context.id "null"}}, "href" : "{{parent_instance.context.href}}", "type" : "{{parent_instance.context.type}}" } }'>
         Create
       </a>
     {{/is_allowed}}
@@ -35,7 +35,7 @@
         data-modal-class="modal-wide"
         data-object-singular="RiskAssessment"
         data-object-plural="risk_assessments"
-        data-object-params='{ "{{parent_instance.class.table_singular}}": { "id" : {{parent_instance.id}}, "title" : "{{parent_instance.title}}" }, "context": { "id" : {{firstnonempty parent_instance.context.id "null"}}, "href" : "{{parent_instance.context.href}}", "type" : "{{parent_instance.context.type}}" } }'
+        data-object-params='{ "{{parent_instance.class.table_singular}}": { "id" : {{parent_instance.id}}, "title" : "{{json_escape parent_instance.title}}" }, "context": { "id" : {{firstnonempty parent_instance.context.id "null"}}, "href" : "{{parent_instance.context.href}}", "type" : "{{parent_instance.context.type}}" } }'
         data-placement="right"
         data-original-title="Create {{model.title_singular}}">
         Create


### PR DESCRIPTION
_Steps to reproduce_:
1. Create a program with " or \ (e.g. "test" or test\ )
2. Add Tab-> Audit widget: confirm an error is displayed

_Actual Result_: "Uncaught SyntaxError: Unexpected token p in JSON at position 40" error is displayed while mapping an audit to the program with "double quotes"
_Expected Result_: no error displayed.

_Note_: using the special characters ("double quotes"- ") or ("back slash" - ) in title of the first entity and then mapping to another entity for the fist entity rise JS error. Using the next special characters from the scope (!#$%&'()*+,-./:;<=>?@[]^_`
{|}
~) doesn't rise same JS error.

![screenshot-1](https://cloud.githubusercontent.com/assets/4204416/24868173/e6c837fa-1e17-11e7-8f9d-0242a64407e8.png)
