### PR TITLE
GGRC-1279, GGRC-1288, GGRC-1631 Rich text editor fixes

### DIFF
--- a/src/ggrc/assets/stylesheets/components/ca-object/_ca-object.scss
+++ b/src/ggrc/assets/stylesheets/components/ca-object/_ca-object.scss
@@ -174,7 +174,7 @@
     box-sizing: border-box;
     width: auto;
     line-height: 28px;
-    height: 34px;
+    min-height: 34px;
     margin-left: 0;
     padding: 2px 34px 2px 4px;
 


### PR DESCRIPTION
This PR fixes rich text editor styles issue and also improves processing of urls while typing in rich text editor. (Improvement: no need to write the whole url followed by a whitespace, now it is possible to type, f.e. "google.com" and then move the cursor and prepend it with "http://" and the link will be converted).

Steps to reproduce:
1. Create GCA or LCA with Rich text type for e.g. "Assessment'
2. Navigate to assessment's Info pane and enter a link to CA with Rich Text
3. Save the updates: the link should be clickable
Expected Result: If enter a link into Rich Text CA, once saved - it should be clickable