### PR TITLE
GGRC-1850 Rename "Created on date" filter to "Created Date" on backend

### DIFF
--- a/src/ggrc/models/mixins/__init__.py
+++ b/src/ggrc/models/mixins/__init__.py
@@ -171,7 +171,7 @@ class ChangeTracked(object):
           "filter_only": True,
       },
       "created_at": {
-          "display_name": "Created On",
+          "display_name": "Created Date",
           "filter_only": True,
       },
   }

--- a/test/integration/ggrc/converters/test_export_assessments.py
+++ b/test/integration/ggrc/converters/test_export_assessments.py
@@ -70,7 +70,7 @@ class TestExport(TestCase):
     db.session.commit()
     self.assertSlugs("comment", self.comment.description, [])
 
-  @data("created_at", "Created On", "created on")
+  @data("created_at", "Created Date", "created Date")
   def test_filter_by_created_at(self, alias):
     """Test filter by created at"""
     self.assertFilterByDatetime(alias,

--- a/test/integration/ggrc/services/test_query/test_snapshots.py
+++ b/test/integration/ggrc/services/test_query/test_snapshots.py
@@ -613,7 +613,7 @@ class TestSnapshotIndexing(BaseQueryAPITestCase):
 
   @data(
       ("updated_at", ("updated_at", "Last Updated", "last updated")),
-      ("created_at", ("updated_at", "Created On", "Created On")),
+      ("created_at", ("updated_at", "Created Date", "Created Date")),
   )
   @unpack
   def test_filter_by_dt_field(self, field, aliases):

--- a/test/integration/ggrc_workflows/converters/test_export_cycle_task_group_object_tasks.py
+++ b/test/integration/ggrc_workflows/converters/test_export_cycle_task_group_object_tasks.py
@@ -121,7 +121,7 @@ class TestExportTasks(TestCase):
       ),
       (
           "created_at",
-          ["task Created On", "task created on", "task created_at"],
+          ["task Created Date", "task created Date", "task created_at"],
       ),
   )
   @unpack


### PR DESCRIPTION
In this ticked back-end changes of 'created_at' alias were needed only.
Frontend already fixed.