### PR TITLE
GGRC-1244 Show confirmation message for Assessment status change

### DIFF
--- a/src/ggrc/assets/javascripts/components/tests/people_list_spec.js
+++ b/src/ggrc/assets/javascripts/components/tests/people_list_spec.js
@@ -214,6 +214,13 @@ describe('GGRC.Components.peopleGroup', function () {
         deferred_remove_role: jasmine.createSpy(),
         get_roles: function () {
           return can.Deferred().resolve(result);
+        },
+        enabledEdit: true,
+        confirmEdit: function () {
+          if (scope.attr('enabledEdit')) {
+            return can.Deferred().resolve();
+          }
+          return can.Deferred().reject();
         }
       });
       instance = scope.attr('instance');
@@ -280,6 +287,12 @@ describe('GGRC.Components.peopleGroup', function () {
       removeRole({}, el, {});
       expect(instance.refresh)
         .toHaveBeenCalled();
+    });
+    it('relationship was not saved if editing was not confirmed', function () {
+      scope.attr('enabledEdit', false);
+      removeRole({}, el, {});
+      expect(result.relationship.save)
+        .not.toHaveBeenCalled();
     });
   });
 
@@ -545,5 +558,57 @@ describe('GGRC.Components.peopleGroup', function () {
            }
          );
        });
+  });
+  describe('enableEdit() method', function () {
+    var enableEdit;
+    var scope;
+    var event;
+
+    beforeEach(function () {
+      scope = new can.Map({
+        confirmEdit: function () {
+          if (scope.attr('enabledEdit')) {
+            return can.Deferred().resolve();
+          }
+          return can.Deferred().reject();
+        }
+      });
+      enableEdit = Component.prototype.scope.enableEdit.bind(scope);
+      event = $.Event('click');
+    });
+
+    it('isEdit should be truthy when editing was confirmed', function () {
+      var result;
+      scope.attr('enabledEdit', true);
+      enableEdit(scope, {}, event);
+      result = scope.attr('isEdit');
+      expect(result).toBeTruthy();
+    });
+
+    it('isEdit should be falsy when editing was confirmed', function () {
+      var result;
+      scope.attr('enabledEdit', false);
+      enableEdit(scope, {}, event);
+      result = scope.attr('isEdit');
+      expect(result).toBeFalsy();
+    });
+  });
+  describe('disableEdit() method', function () {
+    var disableEdit;
+    var scope;
+
+    beforeEach(function () {
+      scope = new can.Map({
+        isEdit: false
+      });
+      disableEdit = Component.prototype.scope.disableEdit.bind(scope);
+    });
+
+    it('isEdit should be falsy', function () {
+      var result;
+      disableEdit();
+      result = scope.attr('isEdit');
+      expect(result).toBeFalsy();
+    });
   });
 });

--- a/src/ggrc/assets/mustache/base_templates/people_group.mustache
+++ b/src/ggrc/assets/mustache/base_templates/people_group.mustache
@@ -15,13 +15,13 @@
     {{/if}}
     {{#editable}}
       {{#has_permissions}}
-        {{^toggle toggle_add}}
+        {{^isEdit}}
           <span class="person-add">
-            <a href="javascript://" {{toggle_button}}>
+            <a href="javascript://" ($click)="enableEdit">
               <i class="fa fa-plus-circle"></i>
             </a>
           </span>
-        {{/toggle}}
+        {{/isEdit}}
       {{/has_permissions}}
     {{/editable}}
 </label>
@@ -48,15 +48,15 @@
   <li class="person-add">
     {{#show_add}}
       {{#has_permissions}}
-        {{#toggle toggle_add}}
+        {{#isEdit}}
           <i class="fa fa-user green pull-left icon-field"></i>
           <div class="person-selector">
             <input tabindex="7" type="text" name="" class="search-icon" data-lookup="Person" placeholder="Search for {{type}}" null-if-empty="false" value="" {{autocomplete_select}} />
-            <a href="javascript://" {{toggle_button}}>
+            <a href="javascript://" ($click)="disableEdit">
               <i class="fa fa-trash"></i>
             </a>
           </div>
-        {{/toggle}}
+        {{/isEdit}}
       {{/has_permissions}}
     {{/show_add}}
   </li>

--- a/src/ggrc/assets/mustache/base_templates/people_list.mustache
+++ b/src/ggrc/assets/mustache/base_templates/people_list.mustache
@@ -29,6 +29,7 @@
                   heading="title"
                   bold-title="disableTitle"
                   tabindex="7"
+                  can-before-edit="instance.confirmBeginEdit"
                   {{#if required}}
                   required="true"
                   validate="validate"


### PR DESCRIPTION
GCA field with person type for Assessment, created program, audit, created assessment on audit page, assessment is in Ready for review status
1. Navigate to Assessment's Info pane
2. Add a person to GCA field with person type: confirm Ready for review status is not changed to In progress
3. Add a Verifier in People's list: confirm Ready for review status is not changed to In progress
Actual Result: There is no message when assessment moves from Ready for review status to In progress if add a person to CA field/add a Verifier
Expected Result: Should be the message when assessment moves from Ready for review status to In progress if add a person to CA field/add a Verifier