### PR TITLE
GGRC-1851 "Uncaught TypeError: Cannot read property 'updateScopeObject' of undefined" error occurs if click map button on Issue first tier

### DIFF
--- a/src/ggrc/assets/javascripts/models/issue.js
+++ b/src/ggrc/assets/javascripts/models/issue.js
@@ -21,9 +21,7 @@
     ],
     is_custom_attributable: true,
     attributes: {
-      context: 'CMS.Models.Context.stub',
-      modified_by: 'CMS.Models.Person.stub',
-      custom_attribute_values: 'CMS.Models.CustomAttributeValue.stubs'
+      context: 'CMS.Models.Context.stub'
     },
     tree_view_options: {
       attr_list: can.Model.Cacheable.attr_list.concat([


### PR DESCRIPTION
_Steps to reproduce_:
1. On the audit page create Issue (fill one or more CA)
2. Click map button on the issue first tier

_Actual Result_: "Uncaught TypeError: Cannot read property 'updateScopeObject' of undefined" error occurs if click map button on Issue first tier
_Expected Result_: no error displayed