### PR TITLE
GGRC-905 The selected value in Response options field for dropdown is changed to the previous one in Task's Info pane

### DIFF
--- a/src/ggrc/assets/javascripts/components/quick_form/quick_update.js
+++ b/src/ggrc/assets/javascripts/components/quick_form/quick_update.js
@@ -66,6 +66,7 @@
       //  generally for these.
       "input:not([data-mapping]), select change" : function(el) {
         var isCheckbox = el.is("[type=checkbox][multiple]");
+        var isDropdown = el.is('select');
         if (isCheckbox) {
           if(!this.scope.instance[el.attr("name")]) {
             this.scope.instance.attr(el.attr("name"), new can.List());
@@ -83,10 +84,15 @@
           this.element.find("input:checkbox").prop("disabled", true);
         } else {
           this.scope.instance.attr(el.attr("name"), el.val());
+          if (isDropdown) {
+            el.closest('dropdown').attr('is-disabled', true);
+          }
         }
         this.scope.instance.save().then(function () {
           if (isCheckbox) {
             this.element.find("input:checkbox").prop("disabled", false);
+          } else if (isDropdown) {
+            el.closest('dropdown').attr('is-disabled', false);
           }
         }.bind(this));
       },


### PR DESCRIPTION
_Precondition_:
Activated one-time WF, a task with Dropdown Task type with values

_Steps to reproduce_:
1. Go to Active Cycles tab
2. Navigate to Task's Info pane
3. Choose the value in Response options field and quickly change the value: confirm the selected value changes to the previous one

_Actual Result_: The selected value in Response options field for dropdown is changed to the previous one in Task's Info pane
_Expected Result_: The selected value in Response options field for dropdown should not be changed to the previous one in Task's Info pane
