### PR TITLE
GGRC-1533 Fix status label in Related Assessment

### DIFF
--- a/src/ggrc/assets/stylesheets/_common.scss
+++ b/src/ggrc/assets/stylesheets/_common.scss
@@ -778,9 +778,16 @@ p {
     height: 8px;
     display: inline-block;
     left: 0;
-    top: 50%;
-    margin-top: -5px;
+    top: 3px;
     border-radius: 50%;
+  }
+
+  .grid-data-row & {
+    display: inline-block;
+
+    &:before {
+      top: 7px;
+    }
   }
 
   &.state-notstarted,


### PR DESCRIPTION
**Unify colors for assessment states in tree view/audit summary page/related assessments tab**

**Steps to reproduce**:
1. Create at least 5 assessments on the audit page
2. States for the created assessments should be: Not Started, In Progress, Ready for Review, Completed and Verified, Completed (no verification)
3. Navigate to Info panel one of the assessment and open Related Assessments window
4. Look at ASSESSMENT STATE

**Actual Result**: ASSESSMENT STATE color in Related Assessments tab is differ from the color in pie chart (e.g. "In progress" is colored with orange, should be in blue color) and there is no dot marked as state color
**Expected Result**: Unify colors for assessment states in tree view/audit summary page/related assessments tab

![image](https://cloud.githubusercontent.com/assets/567805/24953673/db8298b8-1f84-11e7-9b3e-5046e1bfc05b.png)

![image](https://cloud.githubusercontent.com/assets/567805/24953657/c64a7506-1f84-11e7-8943-6b36d77858c5.png)
