### PR TITLE
GGRC-1391 - Disable discard modal if no changes were made

### DIFF
--- a/src/ggrc/assets/javascripts/bootstrap/modal-form.js
+++ b/src/ggrc/assets/javascripts/bootstrap/modal-form.js
@@ -177,8 +177,13 @@
           return;
         }
         if (instance) {
+          instance._backupStore()['-1'] = instance['-1'];
           changedInstance = instance.isDirty(true);
-          hasPending = GGRC.Utils.hasPending(instance);
+          if (!instance.id) {
+            hasPending = false;
+          } else {
+            hasPending = GGRC.Utils.hasPending(instance);
+          }
         }
         if (this.is_form_dirty() || changedInstance || hasPending) {
             // Confirm that the user wants to lose the data prior to hiding

--- a/src/ggrc/assets/javascripts/components/tests/modal-connector_spec.js
+++ b/src/ggrc/assets/javascripts/components/tests/modal-connector_spec.js
@@ -1,0 +1,297 @@
+/*!
+  Copyright (C) 2017 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+describe('GGRC.Components.modalConnector', function () {
+  'use strict';
+
+  var Component;
+  var viewModel;
+  var events;
+  var handler;
+
+  beforeAll(function () {
+    Component = GGRC.Components.get('modalConnector');
+    events = Component.prototype.events;
+  });
+  beforeEach(function () {
+    viewModel = new can.Map();
+  });
+  describe('init() method', function () {
+    var that;
+    var reifiedInstance;
+    var binding;
+    beforeEach(function () {
+      binding = {
+        refresh_instances: jasmine.createSpy()
+          .and.returnValue(can.Deferred().resolve('mockList'))
+      };
+      viewModel.attr({
+        parent_instance: {
+          _transient: {
+            _mockSource: 'transientList'
+          }
+        },
+        default_mappings: [{
+          id: 123,
+          type: 'Assessment'
+        }],
+        mapping: 'mockSource',
+        mapping_getter: can.Deferred().resolve('mockList'),
+        setListItems: jasmine.createSpy(),
+        instance_attr: ''
+      });
+      viewModel.instance = {
+        reify: jasmine.createSpy().and.returnValue(reifiedInstance),
+        mark_for_addition: jasmine.createSpy(),
+        get_binding: jasmine.createSpy().and.returnValue(binding)
+      };
+      reifiedInstance = new can.Map(viewModel.instance);
+      that = {
+        viewModel: viewModel,
+        addListItem: jasmine.createSpy(),
+        setListItems: jasmine.createSpy(),
+        options: {},
+        on: jasmine.createSpy()
+      };
+      spyOn(CMS.Models.Assessment, 'findInCacheById')
+        .and.returnValue('mockObject');
+      handler = events.init.bind(that);
+    });
+    it('sets instance of component to viewModel.controller', function () {
+      handler();
+      expect(viewModel.attr('controller').viewModel)
+        .toEqual(that.viewModel);
+    });
+    it('sets true to viewModel.deferred if viewModel.instance is undefined',
+      function () {
+        viewModel.instance = undefined;
+        viewModel.default_mappings = [];
+        handler();
+        expect(viewModel.attr('deferred')).toEqual(true);
+      });
+    it('sets reified instance to viewModel if it is defined',
+      function () {
+        handler();
+        expect(viewModel.attr('instance'))
+          .toEqual(jasmine.any(can.Map));
+        expect(!!viewModel.attr('instance').get_binding)
+          .toEqual(true);
+      });
+    it('marks for addition mapped objects', function () {
+      handler();
+      expect(viewModel.instance.mark_for_addition)
+        .toHaveBeenCalledWith('related_objects_as_source', 'mockObject',
+          {});
+    });
+    it('adds to list mapped objects', function () {
+      handler();
+      expect(that.addListItem).toHaveBeenCalledWith('mockObject');
+    });
+    it('sets mapping to source_mapping if source_mapping is undefined',
+      function () {
+        handler();
+        expect(viewModel.attr('source_mapping')).toEqual('mockSource');
+      });
+    it('sets "instance" to source_mapping_source if source_mapping_source' +
+    ' is undefined',
+      function () {
+        handler();
+        expect(viewModel.source_mapping_source)
+          .toEqual('instance');
+      });
+    it('calls setListItems() after getting mapper list' +
+    ' if mapper getter is defined', function () {
+      handler();
+      expect(that.setListItems).toHaveBeenCalledWith('mockList');
+    });
+    it('calls setListItems after refresing binding' +
+    ' if mapper getter is undefined', function () {
+      viewModel.mapping_getter = undefined;
+      handler();
+      expect(that.setListItems).toHaveBeenCalledWith('mockList');
+    });
+    it('sets empty array to viewModel.list' +
+    ' and parent_instance._transient[key]' +
+    ' if source mapping and parent_instance.transient[key] is undefined',
+      function () {
+        viewModel.source_mapping_source = 'a';
+        viewModel.parent_instance._transient._mockSource = undefined;
+        viewModel.attr('list', [1, 2, 3]);
+        handler();
+        expect(viewModel.attr('list').length).toEqual(0);
+        expect(viewModel.parent_instance.attr('_transient._mockSource').length)
+          .toEqual(0);
+      });
+    it('sets parent_instance._transient[key] to viewModel.list' +
+    ' if source mapping is undefined',
+      function () {
+        viewModel.source_mapping_source = '';
+        viewModel.attr('list', ['transientList']);
+        handler();
+        expect(viewModel.attr('list')[0]).toEqual('transientList');
+      });
+    it('sets parent_instance form viewModel to options', function () {
+      handler();
+      expect(that.options.parent_instance).toEqual(viewModel.parent_instance);
+    });
+    it('sets instance form viewModel to options', function () {
+      handler();
+      expect(that.options.instance).toEqual(viewModel.instance);
+    });
+    it('calls on() method', function () {
+      handler();
+      expect(that.on).toHaveBeenCalled();
+    });
+  });
+  describe('destroy() method', function () {
+    var handler;
+    var that;
+    beforeEach(function () {
+      that = {
+        viewModel: {
+          parent_instance: new can.Map()
+        }
+      };
+      handler = events.destroy.bind(that);
+    });
+    it('removes changes from parent_instance', function () {
+      that.viewModel.parent_instance.attr('changes', [1, 2]);
+      handler();
+      expect(that.viewModel.parent_instance.changes).toEqual(undefined);
+    });
+  });
+  describe('setListItems() method', function () {
+    var handler;
+    var that;
+    beforeEach(function () {
+      that = {
+        viewModel: new can.Map({
+          list: [123]
+        })
+      };
+      handler = events.setListItems.bind(that);
+    });
+    it('sets concatenated list with current list to viewModel.list',
+      function () {
+        handler([{
+          instance: 321
+        }]);
+        expect(that.viewModel.list.length).toEqual(2);
+        expect(that.viewModel.list[0]).toEqual(123);
+        expect(that.viewModel.list[1]).toEqual(321);
+      });
+  });
+  describe('[data-toggle=unmap] click', function () {
+    var handler;
+    var that;
+    var element;
+    var result;
+    var event;
+    beforeEach(function () {
+      element = $('body');
+      result = $('<div class="result"></div>');
+      result.data('result', 'mock');
+      element.append(result);
+      event = {
+        stopPropagation: jasmine.createSpy()
+      };
+      that = {
+        viewModel: new can.Map({
+          list: [1, 2],
+          deferred: true,
+          changes: ['firstChange'],
+          parent_instance: new can.Map()
+        })
+      };
+      handler = events['[data-toggle=unmap] click'].bind(that);
+    });
+    afterEach(function () {
+      $('body').html('');
+    });
+    it('calls stopPropagation of event', function () {
+      handler(element, event);
+      expect(event.stopPropagation).toHaveBeenCalled();
+    });
+    it('adds remove-change to viewModel.changes if it is deferred',
+      function () {
+        handler(element, event);
+        expect(that.viewModel.changes[1])
+          .toEqual(jasmine.objectContaining({what: 'mock', how: 'remove'}));
+      });
+    it('adds all changes to parent_instance if it is deferred', function () {
+      that.viewModel.parent_instance.changes = [];
+      handler(element, event);
+      expect(that.viewModel.parent_instance.changes.length).toEqual(2);
+    });
+  });
+  describe('addMapings() method', function () {
+    var handler;
+    var that;
+    var event;
+    beforeEach(function () {
+      event = {
+        stopPropagation: jasmine.createSpy()
+      };
+      that = {
+        viewModel: new can.Map({
+          list: [1, 2],
+          deferred: true,
+          changes: ['firstChange'],
+          parent_instance: new can.Map()
+        }),
+        addListItem: jasmine.createSpy()
+      };
+      handler = events.addMapings.bind(that);
+    });
+    it('calls stopPropagation of event', function () {
+      handler({}, event, {data: 1});
+      expect(event.stopPropagation).toHaveBeenCalled();
+    });
+    it('adds add-change to viewModel.changes if it is deferred',
+      function () {
+        handler({}, event, {data: 1});
+        expect(that.viewModel.changes[1])
+          .toEqual(jasmine.objectContaining({how: 'add'}));
+      });
+    it('adds all changes to parent_instance if it is deferred', function () {
+      that.viewModel.parent_instance.changes = [];
+      handler({}, event, {data: [1, 2]});
+      expect(that.viewModel.parent_instance.changes.length).toEqual(2);
+    });
+  });
+  describe('autocomplete_select() method', function () {
+    var handler;
+    var that;
+    var element;
+    beforeEach(function () {
+      element = $('body');
+      that = {
+        viewModel: new can.Map({
+          list: [1, 2],
+          deferred: true,
+          changes: ['firstChange'],
+          parent_instance: new can.Map()
+        }),
+        element: element,
+        addListItem: jasmine.createSpy()
+      };
+      handler = events.autocomplete_select.bind(that);
+    });
+    it('adds add-change with extra attributes' +
+    ' to viewModel.changes if it is deferred',
+      function () {
+        handler(element, {}, {item: 'mock'});
+        expect(that.viewModel.changes[1])
+          .toEqual(jasmine.objectContaining({
+            what: 'mock', how: 'add', extra: jasmine.any(can.Map)
+          }));
+      });
+    it('adds all changes to parent_instance if it is deferred', function () {
+      that.viewModel.parent_instance.changes = [];
+      handler(element, {}, {item: 'mock'});
+      expect(that.viewModel.parent_instance.changes.length).toEqual(2);
+    });
+  });
+});

--- a/src/ggrc/assets/javascripts/models/assessment.js
+++ b/src/ggrc/assets/javascripts/models/assessment.js
@@ -312,6 +312,31 @@
           'Cannot save assessment, audit context not set.');
       }
       this.attr('context', this.attr('audit.context'));
+      this.attr('design', '');
+      this.attr('operationally', '');
+    },
+    _transformBackupProperty: function (badProperties) {
+      var backupInstance = this._backupStore();
+      if (!backupInstance) {
+        return;
+      }
+      badProperties.forEach(function (property) {
+        if (!this[property] && !backupInstance[property] &&
+        (this[property] !== backupInstance[property])) {
+          backupInstance[property] = this[property];
+        }
+      }.bind(this));
+
+      if (this.validate_assessor !== undefined) {
+        backupInstance.validate_assessor = this.validate_assessor;
+      }
+      if (this.validate_creator !== undefined) {
+        backupInstance.validate_creator = this.validate_creator;
+      }
+    },
+    isDirty: function (checkAssociations) {
+      this._transformBackupProperty(['design', 'operationally', '_disabled']);
+      return this._super(checkAssociations);
     },
     after_save: function () {
       this.updateValidation();

--- a/src/ggrc/assets/javascripts/models/tests/assessment_model_spec.js
+++ b/src/ggrc/assets/javascripts/models/tests/assessment_model_spec.js
@@ -40,6 +40,87 @@ describe('CMS.Models.Assessment', function () {
       }).toThrow(new Error(
         'Cannot save assessment, audit context not set.'));
     });
+    it('sets empty string to design property', function () {
+      assessment.attr('audit', audit);
+      assessment.attr('design', undefined);
+      assessment.before_create();
+      expect(assessment.attr('design')).toEqual('');
+    });
+    it('sets empty string to operationally property', function () {
+      assessment.attr('audit', audit);
+      assessment.attr('operationally', undefined);
+      assessment.before_create();
+      expect(assessment.attr('operationally')).toEqual('');
+    });
+  });
+
+  describe('_transformBackupProperty() method', function () {
+    var assessment;
+
+    beforeEach(function () {
+      assessment = new CMS.Models.Assessment();
+    });
+    it('does nothing if no backup of instance', function () {
+      assessment.attr('name', '');
+      assessment._transformBackupProperty(['name']);
+      expect(assessment.attr('name')).toEqual('');
+    });
+    it('transforms backups property if it is falsy in instance and in backup' +
+    'but not equal', function () {
+      assessment.attr('name', '');
+      assessment.backup();
+      assessment._backupStore().name = null;
+      assessment._transformBackupProperty(['name']);
+      expect(assessment._backupStore().name).toEqual('');
+    });
+    it('updates validate_assessor in backup if it is define in instance',
+      function () {
+        assessment.backup();
+        assessment.attr('validate_assessor', true);
+        assessment._backupStore().validate_assessor = undefined;
+        assessment._transformBackupProperty(['name']);
+        expect(assessment._backupStore().validate_assessor).toEqual(true);
+      });
+    it('updates validate_creator in backup if it is define in instance',
+      function () {
+        assessment.backup();
+        assessment.attr('validate_creator', true);
+        assessment._backupStore().validate_creator = undefined;
+        assessment._transformBackupProperty(['name']);
+        expect(assessment._backupStore().validate_creator).toEqual(true);
+      });
+  });
+  describe('isDirty() method', function () {
+    var assessment;
+
+    beforeEach(function () {
+      assessment = new CMS.Models.Assessment();
+      spyOn(assessment, '_transformBackupProperty')
+        .and.callThrough();
+    });
+    it('calls _transformBackupProperty() with specified arguments',
+      function () {
+        assessment.isDirty();
+        expect(assessment._transformBackupProperty)
+          .toHaveBeenCalledWith(['design', 'operationally', '_disabled']);
+      });
+    it('returns result of inherited function, true if instance is dirty',
+      function () {
+        var result;
+        assessment.attr('name', 'assessment1');
+        assessment.backup();
+        assessment.attr('name', 'assessment1.1');
+        result = assessment.isDirty();
+        expect(result).toEqual(true);
+      });
+    it('returns result of inherited function, false if instance is not dirty',
+      function () {
+        var result;
+        assessment.attr('name', 'assessment1');
+        assessment.backup();
+        result = assessment.isDirty();
+        expect(result).toEqual(false);
+      });
   });
 
   describe('get_related_objects_as_source() method', function () {


### PR DESCRIPTION
**Window with "Discard Changes" is displayed if there is no changes made**

**Steps to reproduce**:
1. On the audit page invoke New Assessment modal window
2. Click [x] to close the window

**Actual Result**: Window with "Discard Changes" is displayed if there is no changes made
**Expected Result**: Window with "Discard Changes" should display if some changes were made in New Assessment modal window
Note: such behavior should be for other new modal windows

![image](https://cloud.githubusercontent.com/assets/567805/25072249/57fccb2a-22d2-11e7-9d85-ed2110b35b26.png)
