### PR TITLE
GGRC-1808 Update Spinner Loading Indication for Related Assessments

### DIFF
--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -168,6 +168,8 @@ dashboard-js-files:
   - components/object-popover/object-popover.js
   - components/mapped-objects/mapped-objects.js
   - components/related-objects/related-audits.js
+  - components/related-objects/related-assessment-item.js
+  - components/related-objects/related-assessment-list.js
   - components/related-objects/related-comments.js
   - components/related-objects/related-controls-objectives.js
   - components/object-state-toolbar/object-state-toolbar.js

--- a/src/ggrc/assets/javascripts/components/related-objects/related-assessment-item.js
+++ b/src/ggrc/assets/javascripts/components/related-objects/related-assessment-item.js
@@ -1,0 +1,24 @@
+/*!
+ Copyright (C) 2017 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+(function (can) {
+  'use strict';
+
+  /**
+   * Simple wrapper component for assessment list item
+   */
+  can.Component.extend({
+    tag: 'related-assessment-item',
+    viewModel: {
+      loadingState: {},
+      subItemsLoading: function () {
+        return this.attr('loadingState.auditLoading') ||
+          this.attr('loadingState.urlsLoading') ||
+          this.attr('loadingState.attachmentsLoading') ||
+          this.attr('loadingState.controlsLoading');
+      }
+    }
+  });
+})(window.can);

--- a/src/ggrc/assets/javascripts/components/related-objects/related-assessment-list.js
+++ b/src/ggrc/assets/javascripts/components/related-objects/related-assessment-list.js
@@ -1,0 +1,28 @@
+/*!
+ Copyright (C) 2017 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+(function (can) {
+  'use strict';
+
+  /**
+   * Simple wrapper component for related assessments table
+   */
+  can.Component.extend({
+    tag: 'related-assessment-list',
+    viewModel: {
+      assessments: null,
+      itemsLoading: function () {
+        var items = this.attr('assessments');
+        if (!items) {
+          return false;
+        }
+
+        return _.any(items, function (item) {
+          return item.attr('itemLoading');
+        });
+      }
+    }
+  });
+})(window.can);

--- a/src/ggrc/assets/mustache/assessments/related-assessments-without-reuse.mustache
+++ b/src/ggrc/assets/mustache/assessments/related-assessments-without-reuse.mustache
@@ -33,56 +33,67 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
         </div>
     </div>
     <div class="grid-data-body center-empty-message {{#if isLoading}}loading{{/if}}">
-        <object-list {items}="relatedObjects" {is-loading}="isLoading" spinner-css="grid-spinner" {(selected-item)}="selectedItem"
-                    {item-selector}="objectSelectorEl" {empty-message}="noRelatedObjectsMessage">
-            <div class="grid-data-row flex-row flex-box">
-                <div class="grid-data-item-index">
-                    <state-colors-map {state}="instance.status"></state-colors-map>
-                </div>
-                <div class="grid-data-item-index">
-                  {{localize_date instance.finished_date}}
-                </div>
-                <div class="grid-data-item-index">
-                  {{localize_date instance.created_at}}
-                </div>
-                <div class="flex-size-3">
-                    <related-controls-objectives {parent-instance}="instance">
-                        <mapped-objects
-                                {mapped-snapshots}="mappedSnapshots"
-                                {filter}="filter"
-                                {parent-instance}="parentInstance">
-                            <business-object-list-item {instance}="instance"></business-object-list-item>
-                        </mapped-objects>
-                    </related-controls-objectives>
-                </div>
-                <div class="flex-size-3">
-                    <related-audits {parent-instance}="instance">
-                        <mapped-objects
-                                {parent-instance}="parentInstance"
-                                {related-types}="relatedTypes">
-                            <a href="{{instance.viewLink}}" target="_blank">{{instance.title}}</a>
-                        </mapped-objects>
-                    </related-audits>
-                </div>
-                <div class="flex-size-3">
-                    <mapped-objects
-                            {parent-instance}="instance"
-                            mapping="all_documents">
-                        <document-object-list-item {instance}="instance"></document-object-list-item>
-                    </mapped-objects>
-                </div>
-                <div class="flex-size-3">
-                    <mapped-objects
-                            {parent-instance}="instance"
-                            mapping="all_urls">
-                        <document-object-list-item {instance}="instance"></document-object-list-item>
-                    </mapped-objects>
-                </div>
-                <div class="grid-data__action-column">
-                    <button class="btn btn-icon btn-icon-sm" title="Show More Information"><i class="fa fa-comment-o"></i></button>
-                </div>
-            </div>
-        </object-list>
+        <related-assessment-list {assessments}="relatedObjects">
+            {{#if assessments.length}}
+                <spinner toggle="itemsLoading" class="spinner-wrapper active" extra-css-class="grid-spinner"></spinner>
+            {{/if}}
+            <object-list {(items)}="assessments" {is-loading}="isLoading" spinner-css="grid-spinner" {(selected-item)}="selectedItem"
+                                      {item-selector}="objectSelectorEl" {empty-message}="noRelatedObjectsMessage">
+                <related-assessment-item {^sub-items-loading}="itemLoading" class="{{#itemsLoading}}hidden{{/itemsLoading}}">
+                    <div class="grid-data-row flex-row flex-box">
+                        <div class="grid-data-item-index">
+                            <state-colors-map {state}="instance.status"></state-colors-map>
+                        </div>
+                        <div class="grid-data-item-index">
+                          {{localize_date instance.finished_date}}
+                        </div>
+                        <div class="grid-data-item-index">
+                          {{localize_date instance.created_at}}
+                        </div>
+                        <div class="flex-size-3">
+                            <related-controls-objectives {parent-instance}="instance">
+                                <mapped-objects
+                                        {mapped-snapshots}="mappedSnapshots"
+                                        {filter}="filter"
+                                        {parent-instance}="parentInstance"
+                                        {^is-loading}="loadingState.controlsLoading">
+                                    <business-object-list-item {instance}="instance"></business-object-list-item>
+                                </mapped-objects>
+                            </related-controls-objectives>
+                        </div>
+                        <div class="flex-size-3">
+                            <related-audits {parent-instance}="instance">
+                                <mapped-objects
+                                        {parent-instance}="parentInstance"
+                                        {related-types}="relatedTypes"
+                                        {^is-loading}="loadingState.auditLoading">
+                                    <a href="{{instance.viewLink}}" target="_blank">{{instance.title}}</a>
+                                </mapped-objects>
+                            </related-audits>
+                        </div>
+                        <div class="flex-size-3">
+                            <mapped-objects
+                                    {parent-instance}="instance"
+                                    mapping="all_documents"
+                                    {^is-loading}="loadingState.attachmentsLoading">
+                                <document-object-list-item {instance}="instance"></document-object-list-item>
+                            </mapped-objects>
+                        </div>
+                        <div class="flex-size-3">
+                            <mapped-objects
+                                    {parent-instance}="instance"
+                                    mapping="all_urls"
+                                    {^is-loading}="loadingState.urlsLoading">
+                                <document-object-list-item {instance}="instance"></document-object-list-item>
+                            </mapped-objects>
+                        </div>
+                        <div class="grid-data__action-column">
+                            <button class="btn btn-icon btn-icon-sm" title="Show More Information"><i class="fa fa-comment-o"></i></button>
+                        </div>
+                    </div>
+                </related-assessment-item>
+            </object-list>
+        </related-assessment-list>
         <related-assessment-popover class="object-popover related-assessments__object-popover" {selected-assessment}="selectedItem"></related-assessment-popover>
     </div>
 </related-objects>

--- a/src/ggrc/assets/stylesheets/components/object-list/_object-list.scss
+++ b/src/ggrc/assets/stylesheets/components/object-list/_object-list.scss
@@ -3,17 +3,21 @@
  * Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  */
 
+related-assessment-list,
 object-list {
   box-sizing: border-box;
   width: 100%;
   align-self: stretch;
-  flex-direction: column;
   position: relative;
   list-style: none;
   padding: 0;
   margin: 0;
   min-height: 24px;
   display: flex;
+
+  .hidden {
+    opacity: 0;
+  }
   // Should affect only direct children
   > spinner {
     display: flex;
@@ -54,4 +58,10 @@ object-list {
     color: $text;
     cursor: pointer;
   }
+}
+object-list {
+  flex-direction: column;
+}
+related-assessment-list > spinner.active {
+  opacity: 0.5;
 }


### PR DESCRIPTION
Should be only one spinner for one page loading (no loading indicators for URLS, Attachments, Audits, Controls and Objectives)