### PR TITLE
GGRC-840 JS error is displayed while GC as program manager clicking on "Compare with the latest version" link

### DIFF
--- a/src/ggrc/assets/javascripts/components/snapshotter/revisions-comparer.js
+++ b/src/ggrc/assets/javascripts/components/snapshotter/revisions-comparer.js
@@ -46,32 +46,13 @@
         }, this.updateRevision.bind(this));
       },
       getRevisions: function (currentRevisionID, newRevisionID) {
-        var additionalFilter = {
-          expression: {
-            op: {name: 'OR'},
-            left: {
-              op: {name: '='},
-              left: 'id',
-              right: currentRevisionID
-            },
-            right: {
-              op: {name: '='},
-              left: 'id',
-              right: newRevisionID
-            }
-          }
-        };
-        var params = GGRC.Utils.QueryAPI.buildParam(
-          'Revision',
-          {},
-          undefined,
-          undefined,
-          additionalFilter
-        );
-        return can.Model.Cacheable.query({data: [params]});
+        return CMS.Models.Revision.findAll({
+          id__in: currentRevisionID + ',' + newRevisionID,
+          __sort: 'id'
+        });
       },
       prepareInstances: function (data) {
-        return data.Revision.values.map(function (value) {
+        return data.map(function (value) {
           var content = value.content;
           var model = CMS.Models[value.resource_type];
           content.isRevision = true;

--- a/src/ggrc/assets/javascripts/components/snapshotter/tests/revisions-comparer_spec.js
+++ b/src/ggrc/assets/javascripts/components/snapshotter/tests/revisions-comparer_spec.js
@@ -18,19 +18,17 @@ describe('GGRC.Components.revisionsComparer', function () {
 
     beforeEach(function () {
       method = Component.prototype.scope.prepareInstances;
-      fakeData = {
-        Revision: {
-          values: [{
-            id: 1,
-            content: {id: 1},
-            resource_type: 'Control'
-          }, {
-            id: 2,
-            content: {id: 1},
-            resource_type: 'Control'
-          }]
+      fakeData = [
+        {
+          id: 1,
+          content: {id: 1},
+          resource_type: 'Control'
+        }, {
+          id: 2,
+          content: {id: 1},
+          resource_type: 'Control'
         }
-      };
+      ];
     });
 
     it('returns instances of necessary type and with isRevision', function () {
@@ -44,12 +42,12 @@ describe('GGRC.Components.revisionsComparer', function () {
 
     it('returns the same length of instances as passed', function () {
       var result = method(fakeData);
-      expect(result.length).toBe(fakeData.Revision.values.length);
+      expect(result.length).toBe(fakeData.length);
     });
 
     it('returns the same data as passed with extra properties', function () {
       var result = method(fakeData);
-      var data = fakeData.Revision.values;
+      var data = fakeData;
       result.forEach(function (item, index) {
         expect(item.instance.id).toEqual(data[index].content.id);
       });


### PR DESCRIPTION
_Precondition_:
Log as GC (progcreator@reciprocitylabs.com (engage007),
create program, object (e.g. "Data Assets"), audit

_Steps to reproduce_:
1. Go to audit page: confirm that "Data Assets" is displayed in HNB
2. Return to program page and make changes in "Data Assets" (e.g. change title, description)
3. Return to audit page
4. Refresh the page
5. Navigate to "Data Assets" Info pane and click on "Compare with the latest version"

_Actual Result:_ JS error is displayed while GC as program manager clicking on "Compare with the latest version" link	
_Expected Result:_ no error displayed. "Compare with the latest version" dialog appears.

![screenshot-1](https://cloud.githubusercontent.com/assets/4204416/25087854/a10792d4-237a-11e7-9bd9-67bca557d50b.png)
