### PR TITLE
GGRC-1580 "Uncaught Error: First argument must be an object." error occurs if click on third tier

### DIFF
--- a/src/ggrc/assets/javascripts/plugins/utils/tree-view-utils.js
+++ b/src/ggrc/assets/javascripts/plugins/utils/tree-view-utils.js
@@ -37,7 +37,9 @@
       'title',
       'type',
       'viewLink',
-      'workflow_state'
+      'workflow_state',
+      // labels for assessment templates
+      'DEFAULT_PEOPLE_LABELS'
     ]);
 
     allTypes.forEach(function (type) {


### PR DESCRIPTION
_Steps to reproduce_:
1. Have program, control, audit, assessment template, generated assessment based on the control and assessment template
2. Expand subtree for assessment and click on assessment template

_Actual Result_: "Uncaught Error: First argument must be an object." error occurs
_Expected Result_: no error is displayed

![screenshot-1](https://cloud.githubusercontent.com/assets/4204416/25123585/975c75b2-2431-11e7-9f8c-52cd3daaee4a.png)
