### PR TITLE
GGRC-1673 JS error message when trying to delete an assignee 

### DIFF
--- a/src/ggrc/assets/javascripts/components/people_list.js
+++ b/src/ggrc/assets/javascripts/components/people_list.js
@@ -351,6 +351,7 @@
             // Turn off popover for the removed person
             $(el).closest('li').find('.person-tooltip-trigger')
               .removeClass('person-tooltip-trigger');
+            $(el).addClass('hidden');
 
             if (deferred) {
               this.deferred_remove_role(person, roleToRemove);
@@ -359,6 +360,10 @@
                 var roles = result.roles;
                 var relationship = result.relationship;
                 var resultPromise;
+
+                if (!relationship) {
+                  return;
+                }
 
                 roles = _.without(roles, roleToRemove);
 

--- a/src/ggrc/assets/javascripts/components/tests/people_list_spec.js
+++ b/src/ggrc/assets/javascripts/components/tests/people_list_spec.js
@@ -244,6 +244,13 @@ describe('GGRC.Components.peopleGroup', function () {
         .toEqual(0);
       $('body').html('');
     });
+    it('adds class "hidden" to event element', function () {
+      $('body').append(el);
+      scope.attr('deferred', true);
+      removeRole({}, el, {});
+      expect($(el).hasClass('hidden')).toEqual(true);
+      $('body').html('');
+    });
     it('calls deferred_remove_role if deferred is true', function () {
       scope.attr('deferred', true);
       removeRole({}, el, {});
@@ -293,6 +300,14 @@ describe('GGRC.Components.peopleGroup', function () {
       removeRole({}, el, {});
       expect(result.relationship.save)
         .not.toHaveBeenCalled();
+    });
+    it('does nothing if relationship is undefined', function () {
+      function foo() {
+        result = {};
+        scope.attr('deferred', false);
+        removeRole({}, el, {});
+      }
+      expect(foo).not.toThrowError(TypeError);
     });
   });
 


### PR DESCRIPTION
Steps:
1. Go to assessment info pane.
2. Add some user to assignees (People attribute).
3. Click on trash icon of added user to delete him.
4. Quickly click again on trash icon.

Actual result: JS error is displayed while deleting assignee.
Expected result: no errors displayed, assignee is deleted.