### PR TITLE
GGRC-1910 CAs are not displayed on the Assessment page

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.js
+++ b/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.js
@@ -144,6 +144,10 @@
               .find(function (item) {
                 return item.def.id === Number(fieldId);
               });
+          if (!caValue) {
+            console.error('Corrupted Date: ', caValues);
+            return;
+          }
           caValue.attr('attribute_value',
             GGRC.Utils.CustomAttributes.convertToCaValue(
               caValue.attr('attributeType'),
@@ -155,8 +159,16 @@
         return this.attr('instance').save();
       },
       showRequiredInfoModal: function (scope) {
+        var errors = scope.attr('errorsMap');
+        var errorsList = can.Map.keys(errors)
+          .map(function (error) {
+            return errors[error] ? error : null;
+          })
+          .filter(function (errorCode) {
+            return !!errorCode;
+          });
         var data = {
-          fields: scope.attr('errors') || [],
+          fields: errorsList,
           value: scope.attr('value'),
           title: scope.attr('title'),
           type: scope.attr('type')
@@ -180,9 +192,12 @@
         this.attr('modal.state.open', true);
       }
     },
+    init: function () {
+      this.viewModel.initializeFormFields();
+      this.viewModel.updateRelatedItems();
+    },
     events: {
       '{viewModel.instance} refreshInstance': function () {
-        this.viewModel.initializeFormFields();
         this.viewModel.updateRelatedItems();
       }
     }

--- a/src/ggrc/assets/javascripts/components/info-pin-buttons/info-pin-buttons.js
+++ b/src/ggrc/assets/javascripts/components/info-pin-buttons/info-pin-buttons.js
@@ -23,14 +23,17 @@
       },
       toggleSize: function (scope, el, ev) {
         var maximized = !this.attr('maximized');
-        var onChangeMaximizedState = Mustache.resolve(this.onChangeMaximizedState);
+        var onChangeMaximizedState =
+          Mustache.resolve(this.onChangeMaximizedState);
         ev.preventDefault();
         this.attr('maximized', maximized);
         onChangeMaximizedState(maximized);
       },
       close: function (scope, el, ev) {
         var onClose = Mustache.resolve(this.onClose);
-        el.find('[rel=tooltip]').data('tooltip').hide();
+        if (el) {
+          el.find('[rel=tooltip]').data('tooltip').hide();
+        }
         ev.preventDefault();
         onClose();
       }

--- a/src/ggrc/assets/javascripts/models/assessment.js
+++ b/src/ggrc/assets/javascripts/models/assessment.js
@@ -344,7 +344,7 @@
       return dfd;
     },
     info_pane_preload: function () {
-      this.dispatch('refreshInstance');
+      this.refresh();
     },
     get_related_objects_as_source: function () {
       var dfd = can.Deferred();

--- a/src/ggrc/assets/javascripts/plugins/utils/ca-utils.js
+++ b/src/ggrc/assets/javascripts/plugins/utils/ca-utils.js
@@ -116,7 +116,11 @@
           },
           def: def,
           attributeType: type,
-          preconditions_failed: []
+          preconditions_failed: [],
+          errorsMap: {
+            comment: false,
+            evidence: false
+          }
         };
 
         values.forEach(function (value) {
@@ -131,7 +135,10 @@
               valid: errors.indexOf('comment') < 0 &&
               errors.indexOf('evidence') < 0
             };
-
+            value.errorsMap = {
+              comment: errors.indexOf('comment') > -1,
+              evidence: errors.indexOf('evidence') > -1
+            };
             valueData = value;
           }
         });
@@ -185,7 +192,7 @@
               options.split(',') : [],
             helptext: attr.def.helptext,
             validation: attr.validation,
-            errors: attr.preconditions_failed,
+            errorsMap: attr.errorsMap,
             valueId: attr.id
           };
         });


### PR DESCRIPTION

Precondition:
created CAs for assessment with all the types, program, control, audit
Steps to reproduce:
1. Go to audit page and generate assessment based on control
2. Go to assessment page
3. Look at the assessment Info page: CAs are not displayed
Actual Result: CAs are not displayed on the Assessment page
Expected Result: CAs are should be displayed on the Assessment page

Extra solved issues:
- JS Error on missed Tooltip text on Assessment Info Pane "open/close" status changes
- Improved CA fields updates to avoid users input data losses
- Remove redundant Assessment CA refreshes 
