### PR TITLE
GGRC-1900 Changes are not saved if update Standard under several users

### DIFF
--- a/src/ggrc/assets/javascripts/application.js
+++ b/src/ggrc/assets/javascripts/application.js
@@ -56,14 +56,17 @@
   $doc.ready(function () {
     // monitor target, where flash messages are added
     var AUTOHIDE_TIMEOUT = 10000;
+    var timeoutId;
     var target = $('section.content div.flash')[0];
     var observer = new MutationObserver(function (mutations) {
       mutations.forEach(function (mutation) {
         // check for new nodes
-        if (mutation.addedNodes !== null) {
+        if (mutation.addedNodes && mutation.addedNodes.length > 0) {
           // remove the success message from non-expandable
           // flash success messages after timeout
-          setTimeout(function () {
+          clearTimeout(timeoutId);
+
+          timeoutId = setTimeout(function () {
             $('.flash .alert-autohide').remove();
           }, AUTOHIDE_TIMEOUT);
         }

--- a/src/ggrc/assets/javascripts/controllers/modals_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/modals_controller.js
@@ -1136,14 +1136,19 @@
     },
 
     save_error: function (_, error) {
+      if (error) {
+        if (error.status !== 409) {
+          GGRC.Errors.notifier('error', error.responseText);
+        } else {
+          clearTimeout(error.warningId);
+          GGRC.Errors.notifierXHR('warning')(error);
+        }
+      }
       $('html, body').animate({
         scrollTop: '0px'
       }, {
         duration: 200,
         complete: function () {
-          if (error) {
-            GGRC.Errors.notifier('error', error.responseText);
-          }
           delete this.disable_hide;
         }.bind(this)
       });

--- a/src/ggrc/assets/javascripts/controllers/tests/modals_controller_spec.js
+++ b/src/ggrc/assets/javascripts/controllers/tests/modals_controller_spec.js
@@ -95,4 +95,35 @@ describe('GGRC.Controllers.Modals', function () {
       }
     );
   });
+
+  describe('save_error method', function () {
+    var method;
+    var foo;
+
+    beforeEach(function () {
+      foo = jasmine.createSpy();
+      spyOn(GGRC.Errors, 'notifier');
+      spyOn(GGRC.Errors, 'notifierXHR')
+        .and.returnValue(foo);
+      spyOn(window, 'clearTimeout');
+      method = Ctrl.prototype.save_error.bind({});
+    });
+    it('calls GGRC.Errors.notifier with responseText' +
+    ' if error status is not 409', function () {
+      method({}, {status: 400, responseText: 'mockText'});
+      expect(GGRC.Errors.notifier).toHaveBeenCalledWith('error', 'mockText');
+    });
+    it('clears timeout of error warning if error status is 409', function () {
+      method({}, {status: 409, warningId: 999});
+      expect(clearTimeout).toHaveBeenCalledWith(999);
+    });
+    it('calls GGRC.Errors.notifier with specified text' +
+    ' if error status is 409', function () {
+      var error = {status: 409};
+      method({}, error);
+      expect(GGRC.Errors.notifierXHR)
+        .toHaveBeenCalledWith('warning');
+      expect(foo).toHaveBeenCalledWith(error);
+    });
+  });
 });

--- a/src/ggrc/assets/javascripts/ggrc_base.js
+++ b/src/ggrc/assets/javascripts/ggrc_base.js
@@ -153,8 +153,9 @@
       '403': 'You don\'t have the permission to access the ' +
       'requested resource. It is either read-protected or not ' +
       'readable by the server.',
-      '409': 'There was a conflict in the object you were trying to update. ' +
-      'The version on the server is newer.',
+      '409': 'There was a conflict while saving.' +
+      ' Your changes have not yet been saved.' +
+      ' Please refresh the page and try saving again',
       '412': 'One of the form fields isn\'t right. ' +
       'Check the form for any highlighted fields.'
     };

--- a/src/ggrc/assets/javascripts/models/cacheable.js
+++ b/src/ggrc/assets/javascripts/models/cacheable.js
@@ -309,20 +309,21 @@
     //  This leads to conflicts not actually rejecting because on the second go-round
     //  the local and remote objects look the same.  --BM 2015-02-06
       this.update = function (id, params) {
-        var self = this;
         var ret = _update
         .call(this, id, this.process_args(params))
         .then(
           this.resolve_deferred_bindings.bind(this),
           function (xhr) {
             if (xhr.status === 409) {
-              $(document.body).trigger('ajax:flash', {
-                warning: 'There was a conflict while saving.' +
-                'Your changes have not yet been saved.' +
-                ' Please check any fields you were editing and try saving again'
+              xhr.warningId = setTimeout(function () {
+                $(document.body).trigger('ajax:flash', {
+                  warning: 'There was a conflict while saving.' +
+                  ' Your changes have not yet been saved.' +
+                  ' Please check any fields you were editing' +
+                  ' and try saving again'
+                });
               });
               // TODO: we should show modal window here
-              return self.findInCacheById(id).refresh();
             }
             return xhr;
           }

--- a/src/ggrc/assets/js_specs/models/cacheable_spec.js
+++ b/src/ggrc/assets/js_specs/models/cacheable_spec.js
@@ -224,16 +224,31 @@ describe('can.Model.Cacheable', function () {
 
       });
 */
-      it('refreshes model', function (done) {
+      it('does not refresh model', function (done) {
         var obj = _obj;
         spyOn(obj, 'refresh').and.returnValue($.when(obj));
-        spyOn(can, 'ajax').and.returnValue(new $.Deferred().reject({status: 409}, 409, 'CONFLICT'));
+        spyOn(can, 'ajax').and.returnValue(
+          new $.Deferred().reject({status: 409}, 409, 'CONFLICT'));
         CMS.Models.DummyModel.update(obj.id, obj.serialize()).then(function () {
-          expect(obj.refresh).toHaveBeenCalledWith();
-          setTimeout(function () {
-            done();
-          }, 10);
-        }, failAll(done));
+          done();
+        }, function () {
+          expect(obj.refresh).not.toHaveBeenCalled();
+          done();
+        });
+      });
+
+      it('sets timeout id to XHR-response', function (done) {
+        var obj = _obj;
+        spyOn(obj, 'refresh').and.returnValue($.when(obj));
+        spyOn(window, 'setTimeout').and.returnValue(999);
+        spyOn(can, 'ajax').and.returnValue(
+          new $.Deferred().reject({status: 409}, 409, 'CONFLICT'));
+        CMS.Models.DummyModel.update(obj.id, obj.serialize()).then(function () {
+          done();
+        }, function (xhr) {
+          expect(xhr.warningId).toEqual(999);
+          done();
+        });
       });
 
 /*


### PR DESCRIPTION
Steps to reproduce:
1. Log as "user-1"
2. Create Standard
3. Click Submit for review, add reviewer ("user-2") and select a date
4. Log as "user-2" and Invoke Edit Standard modal window, make any changes (e.g. in Notes field) and do not Save changes (leave modal window open)
5. Log as "user-1"> Invoke Edit Standard make any changes (e.g. in Notes field) and Save
6. Log as "user-2" and click Save and close

Actual result: Closes modal and shows warning about success update, but actually not updated.
Expected result: Shows next warning without closing modal: "There was a conflict while saving. Your changes have not yet been saved. Please refresh the page and try saving again."