### PR TITLE
GGRC-1940 Fix pylint false warnings and errors

### DIFF
--- a/src/requirements-dev.txt
+++ b/src/requirements-dev.txt
@@ -29,7 +29,7 @@ nose==1.3.7
 pep8==1.6.2
 pip==8.0.2
 py==1.4.30
-pylint==1.5.1
+pylint==1.7.1
 PyYAML==3.11
 requests==2.8.1
 selenium==2.47.3


### PR DESCRIPTION
Importing from a flask extension breaks silently breaks pylint. This fix
makes sure that pylint will not fail when the integration ggrc init file
is edited.

Here is an example of the error that this PR fixes:
https://jenkins.reciprocitylabs.com/job/ggrc_code_style/6991/console