### PR TITLE
GGRC-1927 "Raise an Issue" button is disabled in Related Issues tab if Control is mapped to Assessment

### DIFF
--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -250,6 +250,7 @@ dashboard-js-files:
   - components/tree/tree-status-filter.js
   - components/view-object-buttons/view-object-buttons.js
   - components/add-object-button/add-object-button.js
+  - components/add-issue-button/add-issue-button.js
   - components/effective-dates/effective-dates.js
   - components/snapshotter/revisions-comparer.js
   - components/snapshotter/scope-update.js
@@ -337,6 +338,7 @@ dashboard-js-template-files:
   - components/show-related-assessments-button/show-related-assessments-button.mustache
   - components/view-object-buttons/view-object-buttons.mustache
   - components/add-object-button/add-object-button.mustache
+  - components/add-issue-button/add-issue-button.mustache
   - components/info-pin-buttons/info-pin-buttons.mustache
   - components/questions-link/questions-link.mustache
   - base_objects/empty.mustache

--- a/src/ggrc/assets/javascripts/components/add-issue-button/add-issue-button.js
+++ b/src/ggrc/assets/javascripts/components/add-issue-button/add-issue-button.js
@@ -1,0 +1,50 @@
+/*!
+ Copyright (C) 2017 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+(function (can) {
+  'use strict';
+
+  GGRC.Components('addIssueButton', {
+    tag: 'add-issue-button',
+    template: can.view(
+      GGRC.mustache_path +
+      '/components/add-issue-button/add-issue-button.mustache'
+    ),
+    viewModel: {
+      define: {},
+      relatedInstance: {},
+      snapshots: [],
+      prepareJSON: function () {
+        var instance = this.attr('relatedInstance');
+        var audit = instance.attr('audit');
+        var json;
+        var relatedSnapshots = this.attr('snapshots').attr() || [];
+
+        relatedSnapshots = relatedSnapshots.map(function (item) {
+          return {
+            title: item.title,
+            id: item.id,
+            type: item.type,
+            context: item.context
+          };
+        });
+        json = {
+          audit: {title: audit.title, id: audit.id, type: audit.type},
+          relatedSnapshots: relatedSnapshots,
+          context: {type: audit.context.type, id: audit.context.id},
+          assessment: {
+            title: instance.title,
+            id: instance.id,
+            type: instance.type,
+            title_singular: instance.class.title_singular,
+            table_singular: instance.class.table_singular
+          }
+        };
+
+        return JSON.stringify(json);
+      }
+    }
+  });
+})(window.can);

--- a/src/ggrc/assets/javascripts/components/add-issue-button/add-issue-button.js
+++ b/src/ggrc/assets/javascripts/components/add-issue-button/add-issue-button.js
@@ -45,6 +45,11 @@
 
         return JSON.stringify(json);
       }
+    },
+    events: {
+      '{window} modal:success': function () {
+        this.viewModel.attr('relatedInstance').dispatch('refreshInstance');
+      }
     }
   });
 })(window.can);

--- a/src/ggrc/assets/javascripts/components/related-objects/related-objects.js
+++ b/src/ggrc/assets/javascripts/components/related-objects/related-objects.js
@@ -42,7 +42,7 @@
         var orderBy = this.attr('orderBy') || defaultOrderBy;
         var isAssessment = this.attr('baseInstance.type') === 'Assessment';
         var isSnapshot = !!this.attr('baseInstance.snapshot');
-        var op = isAssessment ? {name: 'similar'} : {name: 'relevant'};
+        var filters;
         var params = {};
 
         if (isSnapshot) {
@@ -52,20 +52,34 @@
           id = this.attr('baseInstance.id');
           type = this.attr('baseInstance.type');
         }
-
+        filters = isAssessment ? {
+          expression: {
+            object_name: type,
+            op: {name: 'relevant'},
+            ids: [id]
+          }
+        } : {
+          expression: {
+            left: {
+              object_name: type,
+              op: {name: 'relevant'},
+              ids: [id]
+            },
+            right: {
+              object_name: type,
+              op: {name: 'similar'},
+              ids: [id]
+            },
+            op: {name: 'OR'}
+          }
+        };
         params.data = [{
           limit: this.attr('paging.limits'),
           object_name: relatedType,
           order_by: orderBy.split(',').map(function (field) {
             return {name: field, desc: true};
           }),
-          filters: {
-            expression: {
-              object_name: type,
-              op: op,
-              ids: [id]
-            }
-          }
+          filters: filters
         }];
         return params;
       },

--- a/src/ggrc/assets/javascripts/components/related-objects/related-objects.js
+++ b/src/ggrc/assets/javascripts/components/related-objects/related-objects.js
@@ -110,15 +110,8 @@
       '{viewModel.paging} pageSize': function () {
         this.viewModel.setRelatedItems();
       },
-      '{viewModel.baseInstance} related_destinations': function () {
-        if (!this.viewModel.attr('isLoading')) {
-          this.viewModel.setRelatedItems();
-        }
-      },
-      '{viewModel.baseInstance} related_sources': function () {
-        if (!this.viewModel.attr('isLoading')) {
-          this.viewModel.setRelatedItems();
-        }
+      '{viewModel.baseInstance} refreshInstance': function () {
+        this.viewModel.setRelatedItems();
       }
     }
   });

--- a/src/ggrc/assets/javascripts/components/related-objects/related-objects.js
+++ b/src/ggrc/assets/javascripts/components/related-objects/related-objects.js
@@ -55,7 +55,7 @@
         filters = isAssessment ? {
           expression: {
             object_name: type,
-            op: {name: 'relevant'},
+            op: {name: 'similar'},
             ids: [id]
           }
         } : {

--- a/src/ggrc/assets/javascripts/models/mixins.js
+++ b/src/ggrc/assets/javascripts/models/mixins.js
@@ -177,23 +177,21 @@
     },
     updateScopeObject: function () {
       var objType = 'Audit';
-      var queryType = 'ids';
+      var queryType = 'values';
+      var queryFields = ['id', 'type', 'title', 'context'];
       var query = GGRC.Utils.QueryAPI
-        .buildRelevantIdsQuery(objType, {
+        .buildParam(objType, {
           current: 1,
           pageSize: 1
         }, {
           type: this.attr('type'),
           operation: 'relevant',
           id: this.attr('id')
-        }, null);
+        }, queryFields);
       return GGRC.Utils.QueryAPI
         .batchRequests(query)
-        .done(function (idsArr) {
-          var audit = {
-            id: idsArr[objType][queryType][0],
-            type: 'Audit'
-          };
+        .done(function (valueArr) {
+          var audit = valueArr[objType][queryType][0];
           this.attr('scopeObject', audit);
           this.attr('audit', audit);
         }.bind(this));

--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -2532,49 +2532,6 @@ Mustache.registerHelper('get_url_value', function (attr_name, instance) {
       return value;
     });
 
-  Mustache.registerHelper('with_create_issue_json', function (instance, options) {
-    var audits;
-    var audit;
-    var json;
-    var relatedSnapshots = [];
-
-    instance = Mustache.resolve(instance);
-    audits = instance.get_mapping('related_audits');
-    if (!audits.length) {
-      return options.inverse(options.contexts);
-    }
-
-    audit = audits[0].instance.reify();
-    if (instance.mappedSnapshots) {
-      relatedSnapshots = instance.mappedSnapshots.map(function (item) {
-        var instance = item.instance;
-        return {
-          title: instance.title,
-          id: instance.id,
-          type: instance.type,
-          context: instance.context
-        };
-      });
-    }
-
-    json = {
-      audit: {title: audit.title, id: audit.id, type: audit.type},
-      relatedSnapshots: relatedSnapshots,
-      context: {type: audit.context.type, id: audit.context.id},
-      assessment: {
-        title: instance.title,
-        id: instance.id,
-        type: instance.type,
-        title_singular: instance.class.title_singular,
-        table_singular: instance.class.table_singular
-      }
-    };
-
-    return options.fn(options.contexts.add({
-        create_issue_json: JSON.stringify(json)
-    }));
-  });
-
   Mustache.registerHelper('pretty_role_name', function (name) {
     name = Mustache.resolve(name);
     var ROLE_LIST = {

--- a/src/ggrc/assets/mustache/assessments/related_issues.mustache
+++ b/src/ggrc/assets/mustache/assessments/related_issues.mustache
@@ -3,34 +3,12 @@ Copyright (C) 2017 Google Inc.
 Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 `}}
 
-<related-objects base-instance="instance" related-items-type="Issue">
+<related-objects {base-instance}="instance" related-items-type="Issue">
     <div class="grid-data-toolbar flex-box">
-        <tree-pagination paging="paging" class="flex-size-1"></tree-pagination>
-      {{#is_allowed 'create' 'Issue' context=baseInstance.context}}
+        <tree-pagination {(paging)}="paging" class="flex-size-1"></tree-pagination>
           <div class="grid-data-toolbar-control">
-            {{#with_mapping 'related_audits' baseInstance}}
-              {{#with_mapping 'related_controls' baseInstance}}
-                {{#using control=control}}
-                  {{#with_create_issue_json baseInstance}}
-                    <a class="btn btn-small btn-red"
-                        {{#if baseInstance.mappedSnapshots.length}}
-                            href="javascript://"
-                            data-toggle="modal-ajax-form"
-                            data-modal-class="modal-wide"
-                            data-object-singular="Issue"
-                            data-object-plural="issues"
-                            data-object-params='{{create_issue_json}}'
-                        {{else}}
-                            disabled
-                        {{/if}}>
-                        Raise an Issue
-                    </a>
-                  {{/with_create_issue_json}}
-                {{/using}}
-              {{/with_mapping}}
-            {{/with_mapping}}
+              <add-issue-button {snapshots}="mappedSnapshots" {related-instance}="baseInstance"></add-issue-button>
           </div>
-      {{/is_allowed}}
     </div>
     <div class="grid-data-header flex-row flex-box">
         <div class="flex-size-2">

--- a/src/ggrc/assets/mustache/components/add-issue-button/add-issue-button.mustache
+++ b/src/ggrc/assets/mustache/components/add-issue-button/add-issue-button.mustache
@@ -4,7 +4,7 @@
 }}
 
 {{#is_allowed 'create' 'Issue' context=relatedInstance.context}}
-    <a class="btn btn-small btn-danger"
+    <a class="btn btn-small btn-red"
        href="javascript://"
        data-toggle="modal-ajax-form"
        data-modal-class="modal-wide"

--- a/src/ggrc/assets/mustache/components/add-issue-button/add-issue-button.mustache
+++ b/src/ggrc/assets/mustache/components/add-issue-button/add-issue-button.mustache
@@ -1,0 +1,16 @@
+{{!
+    Copyright (C) 2017 Google Inc.
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+}}
+
+{{#is_allowed 'create' 'Issue' context=relatedInstance.context}}
+    <a class="btn btn-small btn-danger"
+       href="javascript://"
+       data-toggle="modal-ajax-form"
+       data-modal-class="modal-wide"
+       data-object-singular="Issue"
+       data-object-plural="issues"
+       data-object-params='{{prepareJSON}}'>
+        Raise an Issue
+    </a>
+{{/is_allowed}}


### PR DESCRIPTION
Precondition:
created program, control, audit, generated assessment based on control
Steps to reproduce:
1. Go to Assessment tab on the audit page
2. Navigate to Assessment’s Info panel 
3. Open Related issues tab
4. Look at "Raise an Issue" button
Actual Result: "Raise an Issue" button is disabled in Related Issues tab if Control is mapped to Assessment
Expected Result: "Raise an Issue" button should not be disabled in Related Issues tab if Control is mapped to Assessment
