### PR TITLE
GGRC-1725 Already mapped snapshot is shown in Unified mapper as non mapped to assessment

### DIFF
--- a/src/ggrc/assets/javascripts/components/unified-mapper/mapper-results.js
+++ b/src/ggrc/assets/javascripts/components/unified-mapper/mapper-results.js
@@ -305,7 +305,8 @@
           .makeRequest(query)
           .done(function (responseArr) {
             var data = responseArr[0];
-            var relatedData = responseArr[1];
+            var relatedData =
+              this.buildRelatedData(responseArr[1], modelKey);
             var result =
               data[modelKey].values.map(function (value) {
                 return {
@@ -329,6 +330,36 @@
             this.attr('isLoading', false);
           }.bind(this));
         return dfd;
+      },
+      buildRelatedData: function (relatedData, type) {
+        var deferredList = this.attr('mapper.deferred_list');
+        var ids;
+
+        if (!deferredList || !deferredList.length) {
+          return relatedData;
+        } else if (!relatedData) {
+          relatedData = {};
+          relatedData[type] = {};
+          ids = deferredList
+            .map(function (item) {
+              return item.id;
+            });
+        } else {
+          ids = deferredList
+            .filter(function (item) {
+              return relatedData[item.type];
+            })
+            .map(function (item) {
+              return item.id;
+            });
+
+          if (!ids.length) {
+            return relatedData;
+          }
+        }
+
+        relatedData[type].ids = ids;
+        return relatedData;
       },
       loadAllItemsIds: function () {
         var modelKey = this.getModelKey();

--- a/src/ggrc/assets/javascripts/components/unified-mapper/mapper.js
+++ b/src/ggrc/assets/javascripts/components/unified-mapper/mapper.js
@@ -78,6 +78,7 @@
     relevant: [],
     submitCbs: $.Callbacks(),
     afterSearch: false,
+    deferred_list: [],
     afterShown: function () {
       this.onSubmit();
     },
@@ -270,11 +271,24 @@
       },
       inserted: function () {
         var self = this;
+        var deferredToList;
         this.scope.attr('mapper.selected').replace([]);
         this.scope.attr('mapper.entries').replace([]);
 
         this.setModel();
         this.setBinding();
+
+        if (this.scope.attr('deferred_to') &&
+          this.scope.attr('deferred_to').list) {
+          deferredToList = this.scope.attr('deferred_to').list
+            .map(function (item) {
+              return {
+                id: item.id,
+                type: item.type
+              };
+            });
+          this.scope.attr('mapper.deferred_list', deferredToList);
+        }
 
         setTimeout(function () {
           self.scope.attr('mapper').afterShown();

--- a/src/ggrc/assets/javascripts/components/unified-mapper/tests/mapper-results_spec.js
+++ b/src/ggrc/assets/javascripts/components/unified-mapper/tests/mapper-results_spec.js
@@ -1014,4 +1014,67 @@ describe('GGRC.Components.mapperResults', function () {
       });
     });
   });
+
+  describe('buildRelatedData() method', function () {
+    var viewModel;
+
+    beforeEach(function () {
+      var Component = GGRC.Components.get('mapperResults');
+      Component.prototype.viewModel.init = undefined;
+      viewModel = GGRC.Components.getViewModel('mapperResults');
+      viewModel.attr('mapper', {});
+    });
+
+    it('method should return data from "relatedData" array',
+      function () {
+        var relatedData = {
+          Snapshot: {
+            ids: [1, 2, 3]
+          }
+        };
+
+        var result = viewModel
+          .buildRelatedData(relatedData, 'Snapshot');
+        expect(result.Snapshot.ids.length).toEqual(3);
+        expect(result.Snapshot.ids[0]).toEqual(1);
+      }
+    );
+
+    it('method should return data from "deferred_list" array',
+      function () {
+        var relatedData = {
+          Snapshot: {
+            ids: [1, 2, 3]
+          }
+        };
+        var result;
+
+        viewModel.attr('mapper.deferred_list', [
+          {id: 5, type: 'Snapshot'},
+          {id: 25, type: 'Snapshot'}
+        ]);
+
+        result = viewModel
+          .buildRelatedData(relatedData, 'Snapshot');
+        expect(result.Snapshot.ids.length).toEqual(2);
+        expect(result.Snapshot.ids[0]).toEqual(5);
+      }
+    );
+
+    it('return data from "deferred_list" array. RelatedData is undefined',
+      function () {
+        var result;
+
+        viewModel.attr('mapper.deferred_list', [
+          {id: 5, type: 'Snapshot'},
+          {id: 25, type: 'Snapshot'}
+        ]);
+
+        result = viewModel
+          .buildRelatedData(undefined, 'Snapshot');
+        expect(result.Snapshot.ids.length).toEqual(2);
+        expect(result.Snapshot.ids[0]).toEqual(5);
+      }
+    );
+  });
 });


### PR DESCRIPTION
_Precondition_:
have program, audit

_Steps to reproduce_:
1. On the audit page invoke new assessment modal window
2. Map object to assessment via modal window
3. Click Map objects once again and look at search results in Unified mapper 

_Actual Result_: already mapped snapshot is marked as non mapped
_Expected Result_: already mapped snapshot is marked as mapped (with filled checkbox)

![screenshot-1](https://cloud.githubusercontent.com/assets/4204416/25238963/61f447b6-25f7-11e7-92c6-c6f30b276308.png)

