### PR TITLE
GGRC-1941 add aliases on contact and secondary_contact fields

### DIFF
--- a/src/ggrc/models/audit.py
+++ b/src/ggrc/models/audit.py
@@ -99,7 +99,6 @@ class Audit(Snapshotable, clonable.Clonable,
       "contact": {
           "display_name": "Internal Audit Lead",
           "mandatory": True,
-          "filter_by": "_filter_by_contact",
       },
       "secondary_contact": None,
       "notes": None,

--- a/src/ggrc/models/mixins/__init__.py
+++ b/src/ggrc/models/mixins/__init__.py
@@ -785,33 +785,9 @@ class WithContact(object):
           ["name", "email"]),
   ]
   _aliases = {
-      "contact": {
-          "display_name": "Primary Contact",
-          "filter_by": "_filter_by_contact",
-      },
-      "secondary_contact": {
-          "display_name": "Secondary Contact",
-          "filter_by": "_filter_by_secondary_contact",
-      },
+      "contact": "Primary Contact",
+      "secondary_contact": "Secondary Contact",
   }
-
-  @classmethod
-  def _filter_by_contact(cls, predicate):
-    # dependency cycle mixins.py <~> person.py
-    from ggrc.models.person import Person
-    return Person.query.filter(
-        (Person.id == cls.contact_id) &
-        (predicate(Person.name) | predicate(Person.email))
-    ).exists()
-
-  @classmethod
-  def _filter_by_secondary_contact(cls, predicate):
-    # dependency cycle mixins.py <~> person.py
-    from ggrc.models.person import Person
-    return Person.query.filter(
-        (Person.id == cls.secondary_contact_id) &
-        (predicate(Person.name) | predicate(Person.email))
-    ).exists()
 
 
 class BusinessObject(Stateful, Noted, Described, Hyperlinked, WithContact,

--- a/src/ggrc_risks/models/risk.py
+++ b/src/ggrc_risks/models/risk.py
@@ -43,11 +43,6 @@ class Risk(HasObjectState, mixins.CustomAttributable, mixins.Stateful,
   ]
 
   _aliases = {
-      "contact": {
-          "display_name": "Contact",
-          "filter_by": "_filter_by_contact",
-      },
-      "secondary_contact": None,
       "status": {
           "display_name": "State",
           "mandatory": False,

--- a/src/ggrc_risks/models/threat.py
+++ b/src/ggrc_risks/models/threat.py
@@ -16,10 +16,5 @@ class Threat(
   __tablename__ = 'threats'
 
   _aliases = {
-      "contact": {
-          "display_name": "Contact",
-          "filter_by": "_filter_by_contact",
-      },
-      "secondary_contact": None,
       "url": "Threat URL",
   }

--- a/src/ggrc_workflows/models/cycle.py
+++ b/src/ggrc_workflows/models/cycle.py
@@ -62,7 +62,9 @@ class Cycle(WithContact, Stateful, Timeboxed, Described, Titled, Slugged,
           "display_name": "State",
           "mandatory": False,
           "description": "Options are: \n{} ".format('\n'.join(VALID_STATES))
-      }
+      },
+      "contact": "Assignee",
+      "secondary_contact": None,
   }
 
   PROPERTY_TEMPLATE = u"cycle {}"

--- a/src/ggrc_workflows/models/cycle_task_group_object_task.py
+++ b/src/ggrc_workflows/models/cycle_task_group_object_task.py
@@ -149,7 +149,6 @@ class CycleTaskGroupObjectTask(
       "contact": {
           "display_name": "Assignee",
           "mandatory": True,
-          "filter_by": "_filter_by_contact",
       },
       "secondary_contact": None,
       "finished_date": "Actual Finish Date",

--- a/src/ggrc_workflows/models/task_group.py
+++ b/src/ggrc_workflows/models/task_group.py
@@ -65,7 +65,6 @@ class TaskGroup(
       "contact": {
           "display_name": "Assignee",
           "mandatory": True,
-          "filter_by": "_filter_by_contact",
       },
       "secondary_contact": None,
       "start_date": None,

--- a/src/ggrc_workflows/models/task_group_task.py
+++ b/src/ggrc_workflows/models/task_group_task.py
@@ -105,7 +105,6 @@ class TaskGroupTask(WithContact, Titled, Described, RelativeTimeboxed,
       "contact": {
           "display_name": "Assignee",
           "mandatory": True,
-          "filter_by": "_filter_by_contact",
       },
       "secondary_contact": None,
       "start_date": None,

--- a/test/integration/ggrc/converters/test_import_helpers.py
+++ b/test/integration/ggrc/converters/test_import_helpers.py
@@ -854,7 +854,8 @@ class TestGetObjectColumnDefinitions(TestCase):
 
     names = {
         "Code",
-        "Contact",
+        "Primary Contact",
+        "Secondary Contact",
         "Delete",
         "Description",
         "Effective Date",

--- a/test/integration/ggrc/test_csvs/all_snapshottable_objects.csv
+++ b/test/integration/ggrc/test_csvs/all_snapshottable_objects.csv
@@ -72,7 +72,7 @@ Regulation,Code*,Title*,Description,Notes,,Admin*,Effective Date,Stop Date,State
 user1@example.com",20/2/2020,22/2/2022,Draft,user2@example.com,user3@example.com,http://url.example.zzz,reference.example.zzz,,,,,,,,,,,,,,,,,,,
 ,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Object type,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Risk,Code*,Title*,Description*,Notes,,Admin*,Effective Date,Stop Date,State,Contact,,Url,Reference URL,,,,,,,,,,,,,Delete,,,,,,
+Risk,Code*,Title*,Description*,Notes,,Admin*,Effective Date,Stop Date,State,Primary Contact,,Url,Reference URL,,,,,,,,,,,,,Delete,,,,,,
 ,Risk code,Risk title,Risk description,Risk notes,,"user@example.com
 user1@example.com",20/2/2020,22/2/2022,Draft,user2@example.com,,http://url.example.zzz,reference.example.zzz,,,,,,,,,,,,,,,,,,,
 ,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
@@ -93,7 +93,7 @@ System,Code*,Title*,Description,Notes,,Admin*,Effective Date,Stop Date,State,Pri
 user1@example.com",20/2/2020,22/2/2022,Draft,user2@example.com,user3@example.com,http://url.example.zzz,reference.example.zzz,,,,,,,,,,,core,,,,,,,,
 ,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 Object type,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Threat,Code*,Title*,Description,Notes,,Admin*,Effective Date,Stop Date,State,Contact,,Threat URL,Reference URL,,,,,,,,,,,,,Delete,CA date,CA dropdown,CA text,CA rich text,CA checkbox,CA person
+Threat,Code*,Title*,Description,Notes,,Admin*,Effective Date,Stop Date,State,Primary Contact,,Threat URL,Reference URL,,,,,,,,,,,,,Delete,CA date,CA dropdown,CA text,CA rich text,CA checkbox,CA person
 ,Threat code,Threat title,Threat description,Threat notes,,"user@example.com
 user1@example.com",20/2/2020,22/2/2022,Draft,user2@example.com,,http://url.example.zzz,reference.example.zzz,,,,,,,,,,,,,,22/2/2022,four,Threat ca text,"Threat<br><br>
 rich text",no,user4@example.com


### PR DESCRIPTION
Contact fields on models inherited from "WithContact" mixin should be able to filter by "PRIMARY CONTACT" alias. 
Secondary contact fields on models inherited from "WithContact" mixin should be able to filter by "Secondary CONTACT" alias. 

Except:
    Task Group (`Assignee` as alias to `contact`; `secondary_contact` isn't aliased)
    Task Group Task (`Assignee` as alias to `contact`; `secondary_contact` isn't aliased)
    Cycle (`Cycle Assignee` as alias to `contact`; `secondary_contact` isn't aliased)
    Cycle Task Group (`Group Assignee` as alias to `contact`; `secondary_contact` isn't aliased)
    Cycle Task Group Object Task  (`Task Assignee` as alias to `contact`; `secondary_contact` isn't aliased)