### PR TITLE
GGRC-1523/475/1931/1528 UX and styling changes around the tree view in accordance with mockups

### DIFF
--- a/src/ggrc/assets/javascripts/components/tree/tree-header-selector.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-header-selector.js
@@ -19,7 +19,7 @@
       },
 
       disable_attrs: function (el, ev) {
-        var MAX_ATTR = 6;
+        var MAX_ATTR = 7;
         var $check = this.element.find('.attr-checkbox');
         var $mandatory = $check.filter('.mandatory');
         var $selected = $check.filter(':checked');

--- a/src/ggrc/assets/javascripts/components/tree/tree-widget-container.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-widget-container.js
@@ -9,6 +9,7 @@
   var template = can.view(GGRC.mustache_path +
     '/components/tree/tree-widget-container.mustache');
   var TreeViewUtils = GGRC.Utils.TreeView;
+  var CurrentPageUtils = GGRC.Utils.CurrentPage;
 
   var viewModel = can.Map.extend({
     define: {
@@ -59,6 +60,10 @@
 
           if (this.attr('loading')) {
             classes.push('loading');
+          }
+
+          if (CurrentPageUtils.isMyAssessments()) {
+            classes.push('my-assessments');
           }
 
           return classes.join(' ');
@@ -127,8 +132,13 @@
       show3bbs: {
         type: Boolean,
         get: function () {
-          return this.attr('hideImportExport') ||
-            this.attr('showGenerateAssessments');
+          return !CurrentPageUtils.isMyAssessments();
+        }
+      },
+      noResults: {
+        type: Boolean,
+        get: function () {
+          return !this.attr('loading') && !this.attr('showedItems').length;
         }
       },
       pageInfo: {
@@ -204,12 +214,12 @@
 
           if (!this._getFilterByName('custom') &&
             !this._getFilterByName('status') &&
-            total !== GGRC.Utils.CurrentPage.getCounts().attr(countsName)) {
-            GGRC.Utils.CurrentPage.getCounts().attr(countsName, total);
+            total !== CurrentPageUtils.getCounts().attr(countsName)) {
+            CurrentPageUtils.getCounts().attr(countsName, total);
           }
 
           if (this._getFilterByName('status')) {
-            GGRC.Utils.CurrentPage
+            CurrentPageUtils
               .initCounts([modelName], parent.type, parent.id);
           }
         }.bind(this));
@@ -271,7 +281,7 @@
     },
     initCount: function () {
       var $el = this.attr('$el');
-      var counts = GGRC.Utils.CurrentPage.getCounts();
+      var counts = CurrentPageUtils.getCounts();
       var countsName = this.attr('options').countsName ||
         this.attr('model').shortName;
 

--- a/src/ggrc/assets/javascripts/components/tree/tree-widget-container.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-widget-container.js
@@ -234,7 +234,8 @@
     setColumnsConfiguration: function () {
       var columns = TreeViewUtils.getColumnsForModel(
         this.attr('model').model_singular,
-        this.attr('displayPrefs')
+        this.attr('displayPrefs'),
+        true
       );
 
       this.attr('columns.available', columns.available);

--- a/src/ggrc/assets/javascripts/plugins/utils/current-page-utils.js
+++ b/src/ggrc/assets/javascripts/plugins/utils/current-page-utils.js
@@ -93,7 +93,10 @@
 
       // the assessments_view only needs the Assessments widget
       if (isAssessmentsView) {
-        widgetList = {assessment: widgetList.assessment};
+        widgetList = {
+          assessment: widgetList.assessment
+        };
+        widgetList.assessment.treeViewDepth = 0;
       }
 
       return widgetList;

--- a/src/ggrc/assets/javascripts/plugins/utils/tree-view-utils.js
+++ b/src/ggrc/assets/javascripts/plugins/utils/tree-view-utils.js
@@ -134,6 +134,10 @@
         };
       }
 
+      if (!savedAttrList.length && CurrentPage.isMyAssessments()) {
+        displayAttrNames.push('assignees', 'verifiers', 'updated_at');
+      }
+
       displayAttrNames = displayAttrNames.concat(mandatoryAttrNames);
 
       allAttrs.forEach(function (attr) {

--- a/src/ggrc/assets/javascripts/plugins/utils/tree-view-utils.js
+++ b/src/ggrc/assets/javascripts/plugins/utils/tree-view-utils.js
@@ -67,9 +67,10 @@
      * Get available and selected columns for Model type
      * @param {String} modelType - Model type.
      * @param {Object} displayPrefs - Display preferences.
+     * @param {Boolean} [includeRichText] - Need to include Rich Text in the configuration
      * @return {Object} Table columns configuration.
      */
-    function getColumnsForModel(modelType, displayPrefs) {
+    function getColumnsForModel(modelType, displayPrefs, includeRichText) {
       var Cacheable = can.Model.Cacheable;
       var Model = CMS.Models[modelType];
       var modelDefinition = Model().class.root_object;
@@ -112,8 +113,13 @@
         [] :
         GGRC.custom_attr_defs
           .filter(function (def) {
-            return def.definition_type === modelDefinition &&
-              def.attribute_type !== 'Rich Text';
+            var include = def.definition_type === modelDefinition;
+
+            if (!includeRichText) {
+              include = include && def.attribute_type !== 'Rich Text';
+            }
+
+            return include;
           }).map(function (def) {
             return {
               attr_title: def.title,

--- a/src/ggrc/assets/mustache/components/tree/tree-item-extra-info.mustache
+++ b/src/ggrc/assets/mustache/components/tree/tree-item-extra-info.mustache
@@ -151,7 +151,7 @@
           {{/object_tasks}}
           {{/with_mapping}}
           <a class="btn btn-small btn-white" href="{{instance.viewLink}}#task_widget">
-            Open tasks
+            Open Tasks
           </a>
         {{/if}}
       </div>

--- a/src/ggrc/assets/mustache/components/tree/tree-widget-container.mustache
+++ b/src/ggrc/assets/mustache/components/tree/tree-widget-container.mustache
@@ -22,14 +22,16 @@
           </multiselect-dropdown>
         </tree-status-filter>
       {{/if}}
+      {{^if noResults}}
       <tree-pagination {(paging)}="pageInfo"></tree-pagination>
+      {{/if}}
     </div>
 
     <div class="tree-action" style="display: flex; justify-content: flex-end;">
       {{#if addItem}}
         {{{renderLive addItem}}}
       {{/if}}
-      {{!#if show3bbs}}
+      {{#if show3bbs}}
       <div class="details-wrap">
         <a class="btn btn-3bbps dropdown-toggle" href="#" data-toggle="dropdown">
           <span class="bubble"></span>
@@ -66,7 +68,7 @@
           {{/if}}
         </ul>
       </div>
-      {{!/if}}
+      {{/if}}
     </div>
 
     <tree-header {selected-columns}="columns.selected"
@@ -93,6 +95,8 @@
   ></tree-view>
 
   <div class="tree-footer flex-box">
-    <tree-pagination {(paging)}="pageInfo"></tree-pagination>
+    {{^if noResults}}
+      <tree-pagination {(paging)}="pageInfo"></tree-pagination>
+    {{/if}}
   </div>
 </div>

--- a/src/ggrc/assets/stylesheets/components/tree/_sub-tree-wrapper.scss
+++ b/src/ggrc/assets/stylesheets/components/tree/_sub-tree-wrapper.scss
@@ -16,6 +16,7 @@ sub-tree-wrapper {
     min-height: 30px;
     position: relative;
     opacity: .5;
+    border-bottom: 1px solid $itemBorder;
 
     .tree-spinner {
       display: flex;

--- a/src/ggrc/assets/stylesheets/components/tree/_tree-view.scss
+++ b/src/ggrc/assets/stylesheets/components/tree/_tree-view.scss
@@ -164,6 +164,13 @@ tree-item {
         display: -webkit-box;
         -webkit-line-clamp: 2;
         -webkit-box-orient: vertical;
+
+        &.custom {
+          max-height: 32px;
+          p, ul, ol {
+            margin-bottom: 0;
+          }
+        }
       }
     }
   }

--- a/src/ggrc/assets/stylesheets/components/tree/_tree-view.scss
+++ b/src/ggrc/assets/stylesheets/components/tree/_tree-view.scss
@@ -37,6 +37,12 @@ tree-widget-container {
     }
   }
 
+  .my-assessments {
+    tree-view {
+      margin-top: 82px;
+    }
+  }
+
   .tree-action {
     .map-button {
       line-height: 22px;
@@ -120,7 +126,7 @@ tree-item {
   }
 
   .tree-item-content {
-    line-height: 28px;
+    line-height: 16px;
     border-bottom: 1px solid $items-separator-color;
     align-items: center;
 
@@ -277,6 +283,10 @@ tree-header {
     i {
       font-size: 12px;
       margin-left: 10px;
+
+      &.fa-sort {
+        opacity: .5;
+      }
     }
   }
 }
@@ -309,7 +319,7 @@ sub-tree-models {
       span {
         margin-left: 15px;
         cursor: pointer;
-        border-bottom: 1px solid $black;
+        text-decoration: underline;
         font-size: 12px;
       }
     }
@@ -328,7 +338,7 @@ sub-tree-models {
 
       a {
         background-color: $lightBlue !important;
-        color: $white;
+        color: $white !important;
         font-weight: normal;
       }
     }

--- a/src/ggrc/assets/stylesheets/modules/_tree-content.scss
+++ b/src/ggrc/assets/stylesheets/modules/_tree-content.scss
@@ -14,7 +14,8 @@
 .tree-no-results-message {
   opacity: 0.7;
   text-align: center;
-  padding-top: 150px;
+  padding: 250px 0;
+  border: 2px solid $warmGray;
 }
 
 ul.new-tree {

--- a/test/selenium/src/lib/page/widget/generic_widget.py
+++ b/test/selenium/src/lib/page/widget/generic_widget.py
@@ -79,8 +79,7 @@ class Widget(base.Widget):
     """Check that in case of empty table, counter not loaded on filter panel.
     """
     selenium_utils.wait_for_element_text(
-        self._driver,
-        locator.BaseWidgetGeneric.FILTER_PANE_COUNTER, "No records")
+        self._driver, locator.TreeView.NO_RESULTS_MESSAGE, "No results")
 
   def get_items_count(self):
     """Get elements' count from counter on filter panel."""


### PR DESCRIPTION
**GGRC-1523**

The following issues should be fixed in accordance with mockups:
1. Make padding smaller between two rows while wrapping title
2. Sort controls should be gray by default. While clicking on sort controls it should be black
3. [Open Tasks] button in popup. Capital letter "Tasks"
4. [Set visibility] button - should by white color of font
5. Make the possibility to add rich text columns into tree view
6. Make default columns on all assessment lists: 
Title, state, assessors, verifiers, last updated
7. If there is no object in tree view make as in mockup. See screenshot screenshot-1.png

**GGRC-475 Improve My Assessments Page**

1. Disable 3 dots menu for the screen
2. No need of second tier - just a simple list
3. Default columns: Title, state, assessors, verifiers, last updated

**GGRC-1931 Adding up to 7 columns in tree view** 

1. Adding up to 7 columns in tree view (currently, there is a possibility to add 6 columns in tree view).

**GGRC-1528 Display rich text in tree view**