### PR TITLE
GGRC-1945 Mappings are not shown in tree view if Search box contains filter

### DIFF
--- a/src/ggrc/assets/javascripts/components/tree/tree-filter-input.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-filter-input.js
@@ -40,7 +40,7 @@
       options.attr('filter', filter);
       options.attr('operation', operation);
       options.attr('depth', depth);
-      options.attr('depth', 'custom');
+      options.attr('name', 'custom');
 
       if (this.registerFilter) {
         this.registerFilter(options);


### PR DESCRIPTION
**Precondition:**
have Regulation and map to Regulation any control, program
Steps to reproduce:
1. On My work page go to Regulations tab and find created Regulation
2. Type any filter query into Search box (e.g. "title ~ "xxx")
3. Once filter is applied, hover over Regulation first tier and expand sub tree
4. Look at the tree view
Actual Result: Mappings are not shown in tree view if Search box contains filter
Expected Result: Mappings should be shown in tree view if Search box contains filter
Note: the behavior effects not only "Regulation" but also Assessments and other objets
