### PR TITLE
GGRC-1678 Add Show More button for More Info popup

### DIFF
--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -184,6 +184,7 @@ dashboard-js-files:
   - components/reusable-objects/reusable-objects-list.js
   - components/reusable-objects/reusable-objects-item.js
   - components/simple-modal/simple-modal.js
+  - components/show-more/show-more.js
   - components/show-related-assessments-button/show-related-assessments-button.js
   - components/mapping-controls/mapping-type-selector.js
   - components/dropdown/dropdown.js
@@ -334,6 +335,7 @@ dashboard-js-template-files:
   - components/reusable-objects/reusable-objects-item.mustache
   - components/ca-object/ca-object-validation-icon.mustache
   - components/ca-object/ca-object-modal-content.mustache
+  - components/show-more/show-more.mustache
   - components/show-related-assessments-button/show-related-assessments-button.mustache
   - components/view-object-buttons/view-object-buttons.mustache
   - components/add-object-button/add-object-button.mustache

--- a/src/ggrc/assets/javascripts/components/object-popover/object-popover.js
+++ b/src/ggrc/assets/javascripts/components/object-popover/object-popover.js
@@ -59,7 +59,6 @@
         this.viewModel.setStyle(el);
       },
       '.object-popover-wrapper click': function (el, event) {
-        event.preventDefault();
         event.stopPropagation();
       },
       '{viewModel} expanded': function (scope, ev, isExpanded) {

--- a/src/ggrc/assets/javascripts/components/show-more/show-more.js
+++ b/src/ggrc/assets/javascripts/components/show-more/show-more.js
@@ -1,0 +1,78 @@
+/*!
+ Copyright (C) 2017 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+/**
+ * A component that limits list of items to acceptable count and shows
+ * "Show more(<items count>)" link
+ * Usage: <show-more limit="5" {items}="itemsToDisplay"
+ *          should-show-all-items="true">
+ *          <some-item-component></some-item-component>
+ *        </show-more>
+ */
+(function (GGRC, can) {
+  var template = can.view(GGRC.mustache_path +
+    '/components/show-more/show-more.mustache');
+
+  GGRC.Components('showMore', {
+    tag: 'show-more',
+    template: template,
+    viewModel: {
+      define: {
+        limit: {
+          type: 'number',
+          value: 5
+        },
+        items: {
+          value: function () {
+            return [];
+          }
+        },
+        shouldShowAllItems: {
+          type: 'boolean',
+          value: function () {
+            var isOverLimit = this.attr('isOverLimit');
+            return isOverLimit;
+          }
+        },
+        isOverLimit: {
+          get: function () {
+            var items = this.attr('items');
+            var limit = this.attr('limit');
+
+            return items && items.length > limit;
+          }
+        },
+        visibleItems: {
+          get: function () {
+            var limit = this.attr('limit');
+            var isOverLimit = this.attr('isOverLimit');
+            var shouldShowAllItems = this.attr('shouldShowAllItems');
+            var items = this.attr('items');
+
+            return (isOverLimit && !shouldShowAllItems) ?
+              items.slice(0, limit) :
+              items;
+          }
+        },
+        showAllButtonText: {
+          get: function () {
+            var items = this.attr('items');
+            var shouldShowAllItems = this.attr('shouldShowAllItems');
+
+            return !shouldShowAllItems ?
+              'Show more (' + items.length + ')' :
+              'Show less';
+          }
+        }
+      },
+      toggleShowAll: function (event) {
+        var newValue;
+        event.stopPropagation();
+        newValue = !this.attr('shouldShowAllItems');
+        this.attr('shouldShowAllItems', newValue);
+      }
+    }
+  });
+})(window.GGRC, window.can);

--- a/src/ggrc/assets/javascripts/components/show-more/tests/show-more_spec.js
+++ b/src/ggrc/assets/javascripts/components/show-more/tests/show-more_spec.js
@@ -1,0 +1,145 @@
+/*!
+ Copyright (C) 2017 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+describe('showMore', function () {
+  'use strict';
+
+  var viewModel;
+
+  describe('should have some default values', function () {
+    beforeEach(function () {
+      viewModel = GGRC.Components.getViewModel('showMore');
+    });
+
+    it('and they should be correct', function () {
+      expect(viewModel.attr('items').length).toBe(0);
+      expect(viewModel.attr('limit')).toBe(5);
+      expect(viewModel.attr('shouldShowAllItems')).toBeFalsy();
+    });
+  });
+
+  describe('isOverLimit property', function () {
+    var items = new can.List([{id: 1}, {id: 2}]);
+
+    beforeEach(function () {
+      viewModel = GGRC.Components.getViewModel('showMore');
+      viewModel.attr('items', items);
+    });
+
+    it('should return true when more items than limit property', function () {
+      var result;
+
+      viewModel.attr('limit', 1);
+      result = viewModel.attr('isOverLimit');
+
+      expect(result).toBeTruthy();
+    });
+
+    it('should return false when less items than limit property', function () {
+      var result;
+
+      viewModel.attr('limit', 10);
+      result = viewModel.attr('isOverLimit');
+
+      expect(result).toBeFalsy();
+    });
+  });
+
+  describe('showAllButtonText property', function () {
+    var items = new can.List([{id: 1}, {id: 2}]);
+
+    beforeEach(function () {
+      viewModel = GGRC.Components.getViewModel('showMore');
+      viewModel.attr('items', items);
+    });
+
+    it('should return collapsible text when all items are shown', function () {
+      var result;
+
+      viewModel.attr('shouldShowAllItems', true);
+      result = viewModel.attr('showAllButtonText');
+
+      expect(result).toBe('Show less');
+    });
+
+    it('should return expandable text when part of items are shown',
+    function () {
+      var result;
+
+      viewModel.attr('shouldShowAllItems', false);
+      result = viewModel.attr('showAllButtonText');
+
+      expect(result).toBe('Show more (2)');
+    });
+  });
+
+  describe('visibleItems property', function () {
+    var items = new can.List([{id: 1}, {id: 2}]);
+
+    beforeEach(function () {
+      viewModel = GGRC.Components.getViewModel('showMore');
+      viewModel.attr('items', items);
+    });
+
+    it('should return limited items list when should not show all',
+      function () {
+        var result;
+
+        viewModel.attr('limit', 1);
+        result = viewModel.attr('visibleItems');
+
+        expect(result.length).toBe(1);
+      });
+
+    it('should return all items when should show all', function () {
+      var result;
+
+      viewModel.attr('shouldShowAllItems', true);
+      result = viewModel.attr('visibleItems');
+
+      expect(result).toBe(items);
+    });
+
+    it('should return all items when items count is less than limit',
+      function () {
+        var result;
+
+        viewModel.attr('limit', 3);
+        result = viewModel.attr('visibleItems');
+
+        expect(result).toBe(items);
+      });
+  });
+
+  describe('toggleShowAll() method', function () {
+    var eventMock = {
+      stopPropagation: function () {}
+    };
+
+    beforeEach(function () {
+      viewModel = GGRC.Components.getViewModel('showMore');
+    });
+
+    it('should set shouldShowAll property when was false',
+      function () {
+        var result;
+
+        viewModel.toggleShowAll(eventMock);
+        result = viewModel.attr('shouldShowAllItems');
+
+        expect(result).toBeTruthy();
+      });
+
+    it('should reset shouldShowAll property when was true', function () {
+      var result;
+
+      viewModel.attr('shouldShowAllItems', true);
+      viewModel.toggleShowAll(eventMock);
+      result = viewModel.attr('shouldShowAllItems');
+
+      expect(result).toBeFalsy();
+    });
+  });
+});

--- a/src/ggrc/assets/mustache/components/object-popover/related-assessment-popover.mustache
+++ b/src/ggrc/assets/mustache/components/object-popover/related-assessment-popover.mustache
@@ -8,31 +8,31 @@
     <tab-container class="related-assessments__tab-container">
         <tab-panel {(panels)}="panels" title-text="Attributes">
             <div class="fields-wrapper flex-box flex-row">
-              {{#each selectedAssessmentFields}}
-                <div class="field-wrapper flex-size-1">
-                  <ca-object-validation-icon {validation}="validation"></ca-object-validation-icon>
-                  <div class="field-title">
-                    <label class="field-title__text" for="form-field-{{id}}">{{title}}</label>
-                    {{#if helptext}}
-                      <i class="fa fa-question-circle helper-text" rel="tooltip" title="{{helptext}}"></i>
-                    {{/if}}
-                  </div>
-                    <auto-save-form-field-view
-                      {type}="type"
-                      {value}="value"
-                    ></auto-save-form-field-view>
-                </div>
-              {{/each}}
+                <show-more items="selectedAssessmentFields">
+                    <div class="field-wrapper flex-size-1">
+                        <ca-object-validation-icon {validation}="validation"></ca-object-validation-icon>
+                        <div class="field-title">
+                            <label class="field-title__text" for="form-field-{{id}}">{{title}}</label>
+                            {{#if helptext}}
+                                <i class="fa fa-question-circle helper-text" rel="tooltip" title="{{helptext}}"></i>
+                            {{/if}}
+                        </div>
+                        <auto-save-form-field-view
+                                {type}="type"
+                                {value}="value"
+                        ></auto-save-form-field-view>
+                    </div>
+                </show-more>
             </div>
         </tab-panel>
         <tab-panel {(panels)}="panels" title-text="Comments">
-          <related-comments {parent-instance}="item.data">
-              <mapped-objects
-                  {parent-instance}="parentInstance"
-                  {related-types}="relatedTypes">
-                <comment-list-item {instance}="instance"></comment-list-item>
-              </mapped-objects>
-          </related-comments>
+            <related-comments {parent-instance}="item.data">
+                <mapped-objects
+                        {parent-instance}="parentInstance"
+                        {related-types}="relatedTypes">
+                    <comment-list-item {instance}="instance"></comment-list-item>
+                </mapped-objects>
+            </related-comments>
         </tab-panel>
     </tab-container>
 </object-popover>

--- a/src/ggrc/assets/mustache/components/show-more/show-more.mustache
+++ b/src/ggrc/assets/mustache/components/show-more/show-more.mustache
@@ -1,0 +1,13 @@
+{{!
+    Copyright (C) 2017 Google Inc., authors, and contributors
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+}}
+
+{{#each visibleItems}}
+    <content></content>
+{{/each}}
+{{#if isOverLimit}}
+    <div class="flex-box flex-row limit-button-container">
+        <button class="btn btn-link" ($click)="toggleShowAll(%event)">{{showAllButtonText}}</button>
+    </div>
+{{/if}}

--- a/src/ggrc/assets/stylesheets/components/auto-save-form/_auto-save-form.scss
+++ b/src/ggrc/assets/stylesheets/components/auto-save-form/_auto-save-form.scss
@@ -14,6 +14,16 @@ auto-save-form {
   padding-top: 20px;
 }
 
+.fields-wrapper > show-more {
+  display: flex;
+  flex-wrap: wrap;
+
+  .limit-button-container {
+    width: 100%;
+    padding: 0 0 0 12px;
+  }
+}
+
 .fields-wrapper {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
Have program, control, audit, at least 2 generated assessment based on the control on the audit page
Steps to reproduce:
1. On the assessment's Info pane open Related Assessments window
2. Open More Info pop up and click on Show more links
Actual Result: Show more links don't work in More Info pop up 
Expected Result: Show more links should work in More Info pop up