### PR TITLE
QUICK-FIX Polishing Custom Roles

### DIFF
--- a/src/ggrc/assets/javascripts/components/access_control_list/access_control_list.js
+++ b/src/ggrc/assets/javascripts/components/access_control_list/access_control_list.js
@@ -125,7 +125,7 @@
 
         var idx = _.findIndex(
           inst.attr('access_control_list'),
-          {person_id: person.id, ac_role_id: roleId}
+          {person: {id: person.id}, ac_role_id: roleId}
         );
 
         if (idx < 0) {

--- a/src/ggrc/assets/javascripts/components/access_control_list/access_control_list.js
+++ b/src/ggrc/assets/javascripts/components/access_control_list/access_control_list.js
@@ -3,7 +3,7 @@
  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  */
 
-(function (can, _, GGRC) {
+(function (can, _, GGRC, Permission) {
   'use strict';
 
   /**
@@ -24,6 +24,13 @@
       instance: null,
 
       define: {
+        // whether or not the instance is a new object that is yet to be
+        // created on the backend
+        isNewInstance: {
+          type: 'boolean',
+          value: false
+        },
+
         // whether or not to automatically save instance on person role changes
         autosave: {
           type: 'boolean',
@@ -180,8 +187,19 @@
        * @param {Object} options - the component instantiation options
        */
       init: function ($element, options) {
+        var canEdit;
         var vm = this.viewModel;
+        var instance = vm.instance;
 
+        if (!instance) {
+          console.error('accessControlList component: instance not given.');
+          return;
+        }
+
+        canEdit = vm.isNewInstance ||
+                  Permission.is_allowed_for('update', instance);
+
+        vm.attr('canEdit', canEdit);
         vm.attr('grantingRoleId', 0);
         vm.attr('_rolesInfoFixed', false);
         vm._rebuildRolesInfo();
@@ -233,4 +251,4 @@
       }
     }
   });
-})(window.can, window._, window.GGRC);
+})(window.can, window._, window.GGRC, window.Permission);

--- a/src/ggrc/assets/mustache/access_groups/modal_content.mustache
+++ b/src/ggrc/assets/mustache/access_groups/modal_content.mustache
@@ -48,6 +48,7 @@
     <div class="span12 hide-wrap hidable">
       <access-control-list
           instance="."
+          {is-new-instance}="new_object_form"
           top-wrapper-class="'span12'"
           role-block-class="'span4'">
       </access-control-list>

--- a/src/ggrc/assets/mustache/clauses/modal_content.mustache
+++ b/src/ggrc/assets/mustache/clauses/modal_content.mustache
@@ -49,6 +49,7 @@
     <div class="span12 hide-wrap hidable">
       <access-control-list
           instance="."
+          {is-new-instance}="new_object_form"
           top-wrapper-class="'span12'"
           role-block-class="'span4'">
       </access-control-list>

--- a/src/ggrc/assets/mustache/components/access_control_list/access_control_list.mustache
+++ b/src/ggrc/assets/mustache/components/access_control_list/access_control_list.mustache
@@ -9,17 +9,22 @@
     <div class="{{roleBlockClass}} bottom-spacing role-block">
       <h6>
         {{role.name}}
-        <i class="fa fa-plus-circle add-role"
-           title="Grant Role {{role.name}}"
-           ($click)="grantRoleMode(role.id)"></i>
+
+        {{#if canEdit}}
+          <i class="fa fa-plus-circle add-role"
+             title="Grant Role {{role.name}}"
+             ($click)="grantRoleMode(role.id)"></i>
+        {{/if}}
       </h6>
 
       {{#if_equals role.id grantingRoleId}}
+        {{#if canEdit}}
         <autocomplete
           search-items-type="Person"
           (item-selected)="grantRole(%event.selectedItem, %context.role.id)"
           placeholder="Select person"
         ></autocomplete>
+        {{/if}}
       {{/if}}
 
       {{^roleAssignments}}
@@ -31,7 +36,7 @@
       {{#roleAssignments}}
         <person-info
           person-id="person.id"
-          editable="true"
+          editable="{{canEdit}}"
           (person-remove)="revokeRole(%event.person, %context.ac_role_id)"
           ></person-info>
       {{/roleAssignments}}

--- a/src/ggrc/assets/mustache/components/access_control_list/access_control_list.mustache
+++ b/src/ggrc/assets/mustache/components/access_control_list/access_control_list.mustache
@@ -24,6 +24,10 @@
           (item-selected)="grantRole(%event.selectedItem, %context.role.id)"
           placeholder="Select person"
         ></autocomplete>
+
+        <i class="fa fa-trash hide-input"
+           title="Hide"
+           ($click)="grantRoleMode(0)"></i>
         {{/if}}
       {{/if}}
 

--- a/src/ggrc/assets/mustache/contracts/modal_content.mustache
+++ b/src/ggrc/assets/mustache/contracts/modal_content.mustache
@@ -48,6 +48,7 @@
     <div class="span12 hide-wrap hidable">
       <access-control-list
           instance="."
+          {is-new-instance}="new_object_form"
           top-wrapper-class="'span12'"
           role-block-class="'span4'">
       </access-control-list>

--- a/src/ggrc/assets/mustache/controls/modal_content.mustache
+++ b/src/ggrc/assets/mustache/controls/modal_content.mustache
@@ -64,6 +64,7 @@
     <div class="span12 hide-wrap hidable">
       <access-control-list
           instance="."
+          {is-new-instance}="new_object_form"
           top-wrapper-class="'span12'"
           role-block-class="'span4'"></access-control-list>
     </div>

--- a/src/ggrc/assets/mustache/data_assets/modal_content.mustache
+++ b/src/ggrc/assets/mustache/data_assets/modal_content.mustache
@@ -48,6 +48,7 @@
     <div class="span12 hide-wrap hidable">
       <access-control-list
           instance="."
+          {is-new-instance}="new_object_form"
           top-wrapper-class="'span12'"
           role-block-class="'span4'">
       </access-control-list>

--- a/src/ggrc/assets/mustache/facilities/modal_content.mustache
+++ b/src/ggrc/assets/mustache/facilities/modal_content.mustache
@@ -48,6 +48,7 @@
     <div class="span12 hide-wrap hidable">
       <access-control-list
           instance="."
+          {is-new-instance}="new_object_form"
           top-wrapper-class="'span12'"
           role-block-class="'span4'">
       </access-control-list>

--- a/src/ggrc/assets/mustache/issues/modal_content.mustache
+++ b/src/ggrc/assets/mustache/issues/modal_content.mustache
@@ -89,6 +89,7 @@
     <div class="span12 hide-wrap hidable">
       <access-control-list
           instance="."
+          {is-new-instance}="new_object_form"
           top-wrapper-class="'span12'"
           role-block-class="'span4'">
       </access-control-list>

--- a/src/ggrc/assets/mustache/markets/modal_content.mustache
+++ b/src/ggrc/assets/mustache/markets/modal_content.mustache
@@ -48,6 +48,7 @@
     <div class="span12 hide-wrap hidable">
       <access-control-list
           instance="."
+          {is-new-instance}="new_object_form"
           top-wrapper-class="'span12'"
           role-block-class="'span4'">
       </access-control-list>

--- a/src/ggrc/assets/mustache/objectives/modal_content.mustache
+++ b/src/ggrc/assets/mustache/objectives/modal_content.mustache
@@ -47,6 +47,7 @@
     <div class="span12 hide-wrap hidable">
       <access-control-list
           instance="."
+          {is-new-instance}="new_object_form"
           top-wrapper-class="'span12'"
           role-block-class="'span4'">
       </access-control-list>

--- a/src/ggrc/assets/mustache/org_groups/modal_content.mustache
+++ b/src/ggrc/assets/mustache/org_groups/modal_content.mustache
@@ -47,6 +47,7 @@
     <div class="span12 hide-wrap hidable">
       <access-control-list
           instance="."
+          {is-new-instance}="new_object_form"
           top-wrapper-class="'span12'"
           role-block-class="'span4'">
       </access-control-list>

--- a/src/ggrc/assets/mustache/policies/modal_content.mustache
+++ b/src/ggrc/assets/mustache/policies/modal_content.mustache
@@ -49,6 +49,7 @@
     <div class="span12 hide-wrap hidable">
       <access-control-list
           instance="."
+          {is-new-instance}="new_object_form"
           top-wrapper-class="'span12'"
           role-block-class="'span4'">
       </access-control-list>

--- a/src/ggrc/assets/mustache/processes/modal_content.mustache
+++ b/src/ggrc/assets/mustache/processes/modal_content.mustache
@@ -49,6 +49,7 @@
     <div class="span12 hide-wrap hidable">
       <access-control-list
           instance="."
+          {is-new-instance}="new_object_form"
           top-wrapper-class="'span12'"
           role-block-class="'span4'">
       </access-control-list>

--- a/src/ggrc/assets/mustache/products/modal_content.mustache
+++ b/src/ggrc/assets/mustache/products/modal_content.mustache
@@ -47,6 +47,7 @@
     <div class="span12 hide-wrap hidable">
       <access-control-list
           instance="."
+          {is-new-instance}="new_object_form"
           top-wrapper-class="'span12'"
           role-block-class="'span4'">
       </access-control-list>

--- a/src/ggrc/assets/mustache/projects/modal_content.mustache
+++ b/src/ggrc/assets/mustache/projects/modal_content.mustache
@@ -48,6 +48,7 @@
     <div class="span12 hide-wrap hidable">
       <access-control-list
           instance="."
+          {is-new-instance}="new_object_form"
           top-wrapper-class="'span12'"
           role-block-class="'span4'">
       </access-control-list>

--- a/src/ggrc/assets/mustache/regulations/modal_content.mustache
+++ b/src/ggrc/assets/mustache/regulations/modal_content.mustache
@@ -47,6 +47,7 @@
     <div class="span12 hide-wrap hidable">
       <access-control-list
           instance="."
+          {is-new-instance}="new_object_form"
           top-wrapper-class="'span12'"
           role-block-class="'span4'">
       </access-control-list>

--- a/src/ggrc/assets/mustache/sections/modal_content.mustache
+++ b/src/ggrc/assets/mustache/sections/modal_content.mustache
@@ -63,6 +63,7 @@
     <div class="span12 hide-wrap hidable">
       <access-control-list
           instance="."
+          {is-new-instance}="new_object_form"
           top-wrapper-class="'span12'"
           role-block-class="'span4'">
       </access-control-list>

--- a/src/ggrc/assets/mustache/standards/modal_content.mustache
+++ b/src/ggrc/assets/mustache/standards/modal_content.mustache
@@ -48,6 +48,7 @@
     <div class="span12 hide-wrap hidable">
       <access-control-list
           instance="."
+          {is-new-instance}="new_object_form"
           top-wrapper-class="'span12'"
           role-block-class="'span4'">
       </access-control-list>

--- a/src/ggrc/assets/mustache/systems/modal_content.mustache
+++ b/src/ggrc/assets/mustache/systems/modal_content.mustache
@@ -49,6 +49,7 @@
     <div class="span12 hide-wrap hidable">
       <access-control-list
           instance="."
+          {is-new-instance}="new_object_form"
           top-wrapper-class="'span12'"
           role-block-class="'span4'">
       </access-control-list>

--- a/src/ggrc/assets/mustache/vendors/modal_content.mustache
+++ b/src/ggrc/assets/mustache/vendors/modal_content.mustache
@@ -47,6 +47,7 @@
     <div class="span12 hide-wrap hidable">
       <access-control-list
           instance="."
+          {is-new-instance}="new_object_form"
           top-wrapper-class="'span12'"
           role-block-class="'span4'">
       </access-control-list>

--- a/src/ggrc/assets/stylesheets/components/access-control-list/_access-control-list.scss
+++ b/src/ggrc/assets/stylesheets/components/access-control-list/_access-control-list.scss
@@ -8,6 +8,9 @@ access-control-list {
     margin-left: 0
   }
   .role-block {
+    h6 {
+      width: 100%;
+    }
     .modal-body & {
       margin-left: 0;
       display: inline-block;
@@ -20,9 +23,17 @@ access-control-list {
       color: $defaultGreen;
     }
     .autocomplete--wrapper {
+      max-width: 90%;
+      display: inline-block;
       .modal-body & {
         max-width: 92%;
+        input {
+          margin-bottom: 5px;
+        }
       }
+    }
+    .hide-input {
+      cursor: pointer;
     }
     .person {
       margin-bottom: 0.3em;

--- a/src/ggrc_risks/assets/mustache/risks/modal_content.mustache
+++ b/src/ggrc_risks/assets/mustache/risks/modal_content.mustache
@@ -62,6 +62,7 @@
     <div class="span12 hide-wrap hidable">
       <access-control-list
           instance="."
+          {is-new-instance}="new_object_form"
           top-wrapper-class="'span12'"
           role-block-class="'span4'">
       </access-control-list>

--- a/src/ggrc_risks/assets/mustache/threats/modal_content.mustache
+++ b/src/ggrc_risks/assets/mustache/threats/modal_content.mustache
@@ -47,6 +47,7 @@
     <div class="span12 hide-wrap hidable">
       <access-control-list
           instance="."
+          {is-new-instance}="new_object_form"
           top-wrapper-class="'span12'"
           role-block-class="'span4'">
       </access-control-list>


### PR DESCRIPTION
This is a follow-up to the #5468 that has now been merged into the release branch, but a few commits were not included there, as they were not merged to the topic branch in time. This PR contains these missing commits.

It fixes/improves the following things:
- It disables editing custom roles on object info panes if a user does not have the "update" permission on the object (rule of thumb - when the user does not see the "Edit ..." link in the info pane three dots menu in thus cannot open the edit modal).
Mind, however, that a user _can_ edit custom roles in the new object modal (opening the modal implies that the user has the "create" permission).
- Fix removing just-added roles in the new object modal.
 To test, start creating a new Roleable model, then in a modal, assign a few roles to people, and then try to remove those roles - before the fix this was not possible.
- There is now a trash icon on roleable objects' info panes that allows hiding the "assign new person" autocomplete field without selecting a person.


