### PR TITLE
GGRC-1943 JS error occurs while speedily selecting object type in Global Search

### DIFF
--- a/src/ggrc/assets/javascripts/components/unified-mapper/mapper.js
+++ b/src/ggrc/assets/javascripts/components/unified-mapper/mapper.js
@@ -228,7 +228,10 @@
         isLoadingOrSaving: function () {
           return (this.attr('mapper.page_loading') ||
           this.attr('mapper.is_saving') ||
-          this.attr('mapper.block_type_change'));
+          this.attr('mapper.block_type_change')) ||
+          //  disable changing of object type while loading
+          //  to prevent errors while speedily selecting different types
+          this.attr('mapper.is_loading');
         },
         mapper: new MapperModel(can.extend(data, {
           relevantTo: parentScope.attr('relevantTo'),

--- a/src/ggrc/assets/javascripts/components/unified-mapper/tests/mapper_spec.js
+++ b/src/ggrc/assets/javascripts/components/unified-mapper/tests/mapper_spec.js
@@ -416,6 +416,50 @@ describe('GGRC.Components.modalMapper', function () {
     scope = GGRC.Components.getViewModel('modalMapper');
   });
 
+  describe('scope() method', function () {
+    var el;
+    var parentScope;
+
+    beforeEach(function () {
+      el = new can.Map();
+      parentScope = new can.Map();
+    });
+    it('returns object with function "isLoadingOrSaving"', function () {
+      var result = Component.prototype.scope({}, parentScope, el);
+      expect(result.isLoadingOrSaving).toEqual(jasmine.any(Function));
+    });
+
+    describe('isLoadingOrSaving() method', function () {
+      beforeEach(function () {
+        scope = new can.Map(Component.prototype.scope({}, parentScope, el));
+      });
+      it('returns true if page is loading', function () {
+        scope.attr('mapper.page_loading', true);
+        expect(scope.isLoadingOrSaving()).toEqual(true);
+      });
+      it('returns true if it is saving', function () {
+        scope.attr('mapper.is_saving', true);
+        expect(scope.isLoadingOrSaving()).toEqual(true);
+      });
+      it('returns true if type change is blocked', function () {
+        scope.attr('mapper.block_type_change', true);
+        expect(scope.isLoadingOrSaving()).toEqual(true);
+      });
+      it('returns true if mapper is loading', function () {
+        scope.attr('mapper.is_loading', true);
+        expect(scope.isLoadingOrSaving()).toEqual(true);
+      });
+      it('returns false if page is not loading, it is not saving,' +
+      ' type change is not blocked and mapper is not loading', function () {
+        scope.attr('mapper.page_loading', false);
+        scope.attr('mapper.is_saving', false);
+        scope.attr('mapper.block_type_change', false);
+        scope.attr('mapper.is_loading', false);
+        expect(scope.isLoadingOrSaving()).toEqual(false);
+      });
+    });
+  });
+
   describe('".create-control modal:success" event', function () {
     var element;
     var spyObj;

--- a/src/ggrc/assets/mustache/modals/mapper/base.mustache
+++ b/src/ggrc/assets/mustache/modals/mapper/base.mustache
@@ -36,7 +36,7 @@
     class="{{#mapper.useSnapshots}}snapshot-list{{/mapper.useSnapshots}}
       {{^mapper.afterSearch}}hidden{{/mapper.afterSearch}}"
     base-instance="mapper.parentInstance"
-    is-loading="mapper.is_loading"
+    {(is-loading)}="mapper.is_loading"
     object="mapper.object"
     mapper="mapper"
     type="mapper.type"


### PR DESCRIPTION
Steps to reproduce:
1. Open Global Search 
2. Speedily select objects from "Object type" dropdown

Actual Result: "Uncaught TypeError: Cannot read property 'serialize' of null" error occurs while speedily selecting object type in Global Search
Expected Result: no error is displayed while speedily selecting object type in Global Search