### PR TITLE
GGRC-1926 Polish custom roles UX

### DIFF
--- a/src/ggrc/assets/mustache/access_groups/modal_content.mustache
+++ b/src/ggrc/assets/mustache/access_groups/modal_content.mustache
@@ -50,7 +50,7 @@
           instance="."
           {is-new-instance}="new_object_form"
           top-wrapper-class="'span12'"
-          role-block-class="'span4'">
+          role-block-class="'span6'">
       </access-control-list>
     </div>
   </div>

--- a/src/ggrc/assets/mustache/base_objects/contacts.mustache
+++ b/src/ggrc/assets/mustache/base_objects/contacts.mustache
@@ -47,7 +47,14 @@
       {{/if}}
     </p>
     {{/if}}
+
+    <access-control-list
+        instance="."
+        autosave="true"
+        top-wrapper-class="'span12'">
+    </access-control-list>
   </div>
+
     <div data-test-id="title_contacts_696de7244b84" class="span6">
       {{#using person=contact}}
       <div data-test-id="title_primary_contact_696de7244b84"
@@ -74,14 +81,4 @@
       {{/using}}
     </div>
 </div>
-
-<div class="row-fluid wrap-row">
-  <access-control-list
-      instance="."
-      autosave="true"
-      top-wrapper-class="'span12'"
-      role-block-class="'span4'">
-  </access-control-list>
-</div>
-
 {{/instance}}

--- a/src/ggrc/assets/mustache/clauses/modal_content.mustache
+++ b/src/ggrc/assets/mustache/clauses/modal_content.mustache
@@ -51,7 +51,7 @@
           instance="."
           {is-new-instance}="new_object_form"
           top-wrapper-class="'span12'"
-          role-block-class="'span4'">
+          role-block-class="'span6'">
       </access-control-list>
     </div>
   </div>

--- a/src/ggrc/assets/mustache/components/access_control_list/access_control_list.mustache
+++ b/src/ggrc/assets/mustache/components/access_control_list/access_control_list.mustache
@@ -19,15 +19,19 @@
 
       {{#if_equals role.id grantingRoleId}}
         {{#if canEdit}}
-        <autocomplete
-          search-items-type="Person"
-          (item-selected)="grantRole(%event.selectedItem, %context.role.id)"
-          placeholder="Select person"
-        ></autocomplete>
+          {{#if isPendingGrant}}
+            <spinner toggle="isPendingGrant"></spinner>
+          {{else}}
+            <autocomplete
+              search-items-type="Person"
+              (item-selected)="grantRole(%event.selectedItem, %context.role.id)"
+              placeholder="Select person"
+            ></autocomplete>
 
-        <i class="fa fa-trash hide-input"
-           title="Hide"
-           ($click)="grantRoleMode(0)"></i>
+            <i class="fa fa-trash hide-input"
+               title="Hide"
+               ($click)="grantRoleMode(0)"></i>
+          {{/if}}
         {{/if}}
       {{/if}}
 
@@ -38,11 +42,19 @@
       {{/roleAssignments}}
 
       {{#roleAssignments}}
-        <person-info
-          person-id="person.id"
-          editable="{{canEdit}}"
-          (person-remove)="revokeRole(%event.person, %context.ac_role_id)"
-          ></person-info>
+        <div class="row-fluid person-row">
+          <person-info person-id="person.id"></person-info>
+
+          {{#if canEdit}}
+            {{#ifRevokingRole person.id ac_role_id}}
+              <spinner toggle="pendingRevoke"></spinner>
+            {{else}}
+              <i class="fa fa-trash revoke-role"
+                 title="Remove"
+                 ($click)="revokeRole(person, ac_role_id)"></i>
+            {{/ifRevokingRole}}
+          {{/canEdit}}
+        </div>
       {{/roleAssignments}}
     </div>
   {{/rolesInfo}}

--- a/src/ggrc/assets/mustache/contracts/modal_content.mustache
+++ b/src/ggrc/assets/mustache/contracts/modal_content.mustache
@@ -50,7 +50,7 @@
           instance="."
           {is-new-instance}="new_object_form"
           top-wrapper-class="'span12'"
-          role-block-class="'span4'">
+          role-block-class="'span6'">
       </access-control-list>
     </div>
   </div>

--- a/src/ggrc/assets/mustache/controls/contacts.mustache
+++ b/src/ggrc/assets/mustache/controls/contacts.mustache
@@ -46,7 +46,16 @@
       {{/if}}
     {{/if}}
     </p>
+
+    {{^if is_program}}
+      <access-control-list
+          instance="."
+          autosave="true"
+          top-wrapper-class="'span12'">
+      </access-control-list>
+    {{/if}}
   </div>
+
   <div class="span6">
     {{#using person=contact}}
       <div class="bottom-space">
@@ -86,7 +95,7 @@
     {{/using}}
     {{#using assessor=instance.secondary_assessor}}
       <!--<div class="bottom-space">-->
-      <div>
+      <div class="bottom-space">
         <h6>Secondary Assignee</h6>
         {{#if instance.secondary_assessor}}
           <p class="oneline">
@@ -97,18 +106,12 @@
         {{/if}}
       </div>
     {{/using}}
+
+    <div>
+      {{>'/static/mustache/controls/urls.mustache'}}
+    </div>
+
   </div>
 </div>
 
-<div class="row-fluid wrap-row">
-  <access-control-list
-      instance="."
-      autosave="true"
-      top-wrapper-class="'span6'">
-  </access-control-list>
-
-  <div class="span6">
-    {{>'/static/mustache/controls/urls.mustache'}}
-  </div>
-</div>
 {{/instance}}

--- a/src/ggrc/assets/mustache/controls/modal_content.mustache
+++ b/src/ggrc/assets/mustache/controls/modal_content.mustache
@@ -66,7 +66,7 @@
           instance="."
           {is-new-instance}="new_object_form"
           top-wrapper-class="'span12'"
-          role-block-class="'span4'"></access-control-list>
+          role-block-class="'span6'"></access-control-list>
     </div>
   </div>
 

--- a/src/ggrc/assets/mustache/data_assets/modal_content.mustache
+++ b/src/ggrc/assets/mustache/data_assets/modal_content.mustache
@@ -50,7 +50,7 @@
           instance="."
           {is-new-instance}="new_object_form"
           top-wrapper-class="'span12'"
-          role-block-class="'span4'">
+          role-block-class="'span6'">
       </access-control-list>
     </div>
   </div>

--- a/src/ggrc/assets/mustache/facilities/modal_content.mustache
+++ b/src/ggrc/assets/mustache/facilities/modal_content.mustache
@@ -50,7 +50,7 @@
           instance="."
           {is-new-instance}="new_object_form"
           top-wrapper-class="'span12'"
-          role-block-class="'span4'">
+          role-block-class="'span6'">
       </access-control-list>
     </div>
   </div>

--- a/src/ggrc/assets/mustache/issues/modal_content.mustache
+++ b/src/ggrc/assets/mustache/issues/modal_content.mustache
@@ -91,7 +91,7 @@
           instance="."
           {is-new-instance}="new_object_form"
           top-wrapper-class="'span12'"
-          role-block-class="'span4'">
+          role-block-class="'span6'">
       </access-control-list>
     </div>
   </div>

--- a/src/ggrc/assets/mustache/markets/modal_content.mustache
+++ b/src/ggrc/assets/mustache/markets/modal_content.mustache
@@ -50,7 +50,7 @@
           instance="."
           {is-new-instance}="new_object_form"
           top-wrapper-class="'span12'"
-          role-block-class="'span4'">
+          role-block-class="'span6'">
       </access-control-list>
     </div>
   </div>

--- a/src/ggrc/assets/mustache/objectives/modal_content.mustache
+++ b/src/ggrc/assets/mustache/objectives/modal_content.mustache
@@ -49,7 +49,7 @@
           instance="."
           {is-new-instance}="new_object_form"
           top-wrapper-class="'span12'"
-          role-block-class="'span4'">
+          role-block-class="'span6'">
       </access-control-list>
     </div>
   </div>

--- a/src/ggrc/assets/mustache/org_groups/modal_content.mustache
+++ b/src/ggrc/assets/mustache/org_groups/modal_content.mustache
@@ -49,7 +49,7 @@
           instance="."
           {is-new-instance}="new_object_form"
           top-wrapper-class="'span12'"
-          role-block-class="'span4'">
+          role-block-class="'span6'">
       </access-control-list>
     </div>
   </div>

--- a/src/ggrc/assets/mustache/policies/modal_content.mustache
+++ b/src/ggrc/assets/mustache/policies/modal_content.mustache
@@ -51,7 +51,7 @@
           instance="."
           {is-new-instance}="new_object_form"
           top-wrapper-class="'span12'"
-          role-block-class="'span4'">
+          role-block-class="'span6'">
       </access-control-list>
     </div>
   </div>

--- a/src/ggrc/assets/mustache/processes/modal_content.mustache
+++ b/src/ggrc/assets/mustache/processes/modal_content.mustache
@@ -51,7 +51,7 @@
           instance="."
           {is-new-instance}="new_object_form"
           top-wrapper-class="'span12'"
-          role-block-class="'span4'">
+          role-block-class="'span6'">
       </access-control-list>
     </div>
   </div>

--- a/src/ggrc/assets/mustache/products/modal_content.mustache
+++ b/src/ggrc/assets/mustache/products/modal_content.mustache
@@ -49,7 +49,7 @@
           instance="."
           {is-new-instance}="new_object_form"
           top-wrapper-class="'span12'"
-          role-block-class="'span4'">
+          role-block-class="'span6'">
       </access-control-list>
     </div>
   </div>

--- a/src/ggrc/assets/mustache/projects/modal_content.mustache
+++ b/src/ggrc/assets/mustache/projects/modal_content.mustache
@@ -50,7 +50,7 @@
           instance="."
           {is-new-instance}="new_object_form"
           top-wrapper-class="'span12'"
-          role-block-class="'span4'">
+          role-block-class="'span6'">
       </access-control-list>
     </div>
   </div>

--- a/src/ggrc/assets/mustache/regulations/modal_content.mustache
+++ b/src/ggrc/assets/mustache/regulations/modal_content.mustache
@@ -49,7 +49,7 @@
           instance="."
           {is-new-instance}="new_object_form"
           top-wrapper-class="'span12'"
-          role-block-class="'span4'">
+          role-block-class="'span6'">
       </access-control-list>
     </div>
   </div>

--- a/src/ggrc/assets/mustache/sections/modal_content.mustache
+++ b/src/ggrc/assets/mustache/sections/modal_content.mustache
@@ -65,7 +65,7 @@
           instance="."
           {is-new-instance}="new_object_form"
           top-wrapper-class="'span12'"
-          role-block-class="'span4'">
+          role-block-class="'span6'">
       </access-control-list>
     </div>
   </div>

--- a/src/ggrc/assets/mustache/standards/modal_content.mustache
+++ b/src/ggrc/assets/mustache/standards/modal_content.mustache
@@ -50,7 +50,7 @@
           instance="."
           {is-new-instance}="new_object_form"
           top-wrapper-class="'span12'"
-          role-block-class="'span4'">
+          role-block-class="'span6'">
       </access-control-list>
     </div>
   </div>

--- a/src/ggrc/assets/mustache/systems/modal_content.mustache
+++ b/src/ggrc/assets/mustache/systems/modal_content.mustache
@@ -51,7 +51,7 @@
           instance="."
           {is-new-instance}="new_object_form"
           top-wrapper-class="'span12'"
-          role-block-class="'span4'">
+          role-block-class="'span6'">
       </access-control-list>
     </div>
   </div>

--- a/src/ggrc/assets/mustache/vendors/modal_content.mustache
+++ b/src/ggrc/assets/mustache/vendors/modal_content.mustache
@@ -49,7 +49,7 @@
           instance="."
           {is-new-instance}="new_object_form"
           top-wrapper-class="'span12'"
-          role-block-class="'span4'">
+          role-block-class="'span6'">
       </access-control-list>
     </div>
   </div>

--- a/src/ggrc/assets/stylesheets/components/access-control-list/_access-control-list.scss
+++ b/src/ggrc/assets/stylesheets/components/access-control-list/_access-control-list.scss
@@ -36,10 +36,18 @@ access-control-list {
     .hide-input {
       cursor: pointer;
     }
-    .person {
-      margin-bottom: 0.3em;
-      a.unmap {
+    .person-row {
+      .person {
+        display: inline-flex;
+        margin-bottom: 0.3em;
+      }
+      .revoke-role {
         cursor: pointer;
+        margin-left: 0.2em;
+        visibility: hidden;
+      }
+      &:hover .revoke-role {
+        visibility: visible;
       }
     }
   }

--- a/src/ggrc/assets/stylesheets/components/access-control-list/_access-control-list.scss
+++ b/src/ggrc/assets/stylesheets/components/access-control-list/_access-control-list.scss
@@ -13,6 +13,7 @@ access-control-list {
     }
     .modal-body & {
       margin-left: 0;
+      margin-right: 8px;
       display: inline-block;
       float: none;
       vertical-align: top;

--- a/src/ggrc_risks/assets/mustache/risks/modal_content.mustache
+++ b/src/ggrc_risks/assets/mustache/risks/modal_content.mustache
@@ -64,7 +64,7 @@
           instance="."
           {is-new-instance}="new_object_form"
           top-wrapper-class="'span12'"
-          role-block-class="'span4'">
+          role-block-class="'span6'">
       </access-control-list>
     </div>
   </div>

--- a/src/ggrc_risks/assets/mustache/threats/modal_content.mustache
+++ b/src/ggrc_risks/assets/mustache/threats/modal_content.mustache
@@ -49,7 +49,7 @@
           instance="."
           {is-new-instance}="new_object_form"
           top-wrapper-class="'span12'"
-          role-block-class="'span4'">
+          role-block-class="'span6'">
       </access-control-list>
     </div>
   </div>


### PR DESCRIPTION
This PR improves a few UX things (listed below) related to custom roles as suggested by the UX team. Please refer to the Jira [ticket](https://gojira.corp.google.com/browse/GGRC-1926) for screenshots, if necessary.

Change list:
- [x] On the object info pane, move the custom roles list up, directly under the Admin role.
- [x] In the object add/edit modal, display two custom roles per line (and not anymore three) .
- [x] The trash icon for revoking a role is now shown only when hovering over a partilcular person row
- [x] When selecting a person to grant a role to in the autocomplete field, a spinner is displayed while the "grant" action is being executed (NOTE: info pane only, since in the modals, the changes are not auto saved to the server)
- [x] When revoking a role from a person, a spinner is displayed instead of the clicked trash icon while the "revoke" action is being executed (NOTE: info pane only, since in the modals, the changes are not auto saved to the server)

Things left to do (perhaps optional, debatable - please give feedback):
- [ ] Dealing with extremely long lists of people under a particular role that would disproportionately vertically stretch a particular custom role block - need to talk with @andrei-karalionak as he is presumably solving the same edge case on Assessments. 
We might want to fix this in a separate ticket, though, if such use cases are improbable and/or the resulting appearance is not considered severe
- [ ] Locking the custom roles UX while an action is being executed to prevent possible quirks due to race conditions. This would probably be a very welcome addition, and I plan to add this tomorrow).