### PR TITLE
GGRC-1939 Related Assessments are not shown in Related Assessments window if open the window via Controls/Objectives Info pane 

### DIFF
--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -175,6 +175,7 @@ dashboard-js-files:
   - components/related-objects/related-assessment-list.js
   - components/related-objects/related-comments.js
   - components/related-objects/related-controls-objectives.js
+  - components/related-objects/related-issues.js
   - components/object-state-toolbar/object-state-toolbar.js
   - components/object-list/object-list.js
   - components/ca-object/ca-object.js
@@ -336,6 +337,7 @@ dashboard-js-template-files:
   - components/object-list-item/person-list-item.mustache
   - components/object-list-item/document-object-list-item.mustache
   - components/mapped-objects/mapped-objects.mustache
+  - components/related-objects/related-issues.mustache
   - components/reusable-objects/reusable-objects-item.mustache
   - components/ca-object/ca-object-validation-icon.mustache
   - components/ca-object/ca-object-modal-content.mustache
@@ -436,7 +438,6 @@ dashboard-js-template-files:
   - assessment_templates/modal_content.mustache
   - assessment_templates/info.mustache
   - assessment_templates/tree_add_item.mustache
-  - assessments/related_issues.mustache
   - issues/modal_content.mustache
   - issues/info.mustache
   - issues/remediation_plan.mustache

--- a/src/ggrc/assets/javascripts/components/related-objects/related-issues.js
+++ b/src/ggrc/assets/javascripts/components/related-objects/related-issues.js
@@ -1,0 +1,53 @@
+/*!
+ Copyright (C) 2017 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+(function (can, GGRC) {
+  'use strict';
+  var tpl = can.view(GGRC.mustache_path +
+    '/components/related-objects/related-issues.mustache');
+
+  GGRC.Components('relatedIssues', {
+    tag: 'related-issues',
+    template: tpl,
+    viewModel: {
+      define: {
+        orderBy: {
+          type: 'string',
+          value: 'created_at'
+        },
+        allRelatedSnapshots: {
+          Value: can.List
+        },
+        itemsType: {
+          type: 'string',
+          value: 'Issue'
+        },
+        relatedIssuesFilter: {
+          type: '*',
+          get: function () {
+            var id = this.attr('baseInstance.id');
+            var type = this.attr('baseInstance.type');
+            return {
+              expression: {
+                left: {
+                  object_name: type,
+                  op: {name: 'relevant'},
+                  ids: [id]
+                },
+                right: {
+                  object_name: type,
+                  op: {name: 'similar'},
+                  ids: [id]
+                },
+                op: {name: 'OR'}
+              }
+            };
+          }
+        }
+      },
+      baseInstance: null
+    }
+  });
+})(window.can, window.GGRC);

--- a/src/ggrc/assets/javascripts/components/related-objects/related-objects.js
+++ b/src/ggrc/assets/javascripts/components/related-objects/related-objects.js
@@ -8,7 +8,7 @@
 
   var defaultOrderBy = 'created_at';
 
-  can.Component.extend({
+  GGRC.Components('relatedObjects', {
     tag: 'related-objects',
     viewModel: {
       define: {
@@ -27,14 +27,36 @@
           value: function () {
             return new GGRC.VM.Pagination({pageSizeSelect: [5, 10, 15]});
           }
+        },
+        relatedObjects: {
+          Value: can.List
+        },
+        predefinedFilter: {
+          type: '*'
         }
       },
       baseInstance: null,
-      relatedObjects: [],
       relatedItemsType: '@',
       orderBy: '@',
       selectedItem: {},
       objectSelectorEl: '.grid-data__action-column button',
+      getFilters: function (id, type, isAssessment) {
+        var predefinedFilter = this.attr('predefinedFilter');
+        var filters;
+
+        if (predefinedFilter) {
+          filters = predefinedFilter;
+        } else {
+          filters = {
+            expression: {
+              object_name: type,
+              op: isAssessment ? {name: 'similar'} : {name: 'relevant'},
+              ids: [id]
+            }
+          };
+        }
+        return filters;
+      },
       getParams: function () {
         var id;
         var type;
@@ -52,27 +74,7 @@
           id = this.attr('baseInstance.id');
           type = this.attr('baseInstance.type');
         }
-        filters = isAssessment ? {
-          expression: {
-            object_name: type,
-            op: {name: 'similar'},
-            ids: [id]
-          }
-        } : {
-          expression: {
-            left: {
-              object_name: type,
-              op: {name: 'relevant'},
-              ids: [id]
-            },
-            right: {
-              object_name: type,
-              op: {name: 'similar'},
-              ids: [id]
-            },
-            op: {name: 'OR'}
-          }
-        };
+        filters = this.getFilters(id, type, isAssessment);
         params.data = [{
           limit: this.attr('paging.limits'),
           object_name: relatedType,

--- a/src/ggrc/assets/mustache/assessments/related-assessments-without-reuse.mustache
+++ b/src/ggrc/assets/mustache/assessments/related-assessments-without-reuse.mustache
@@ -3,8 +3,8 @@ Copyright (C) 2017 Google Inc.
 Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
 <related-objects {base-instance}="instance" related-items-type="Assessment" order-by="finished_date,created_at">
-    <div class="grid-data-toolbar flex-box">
-        <tree-pagination {(paging)}="paging"></tree-pagination>
+    <div class="grid-data__toolbar flex-box">
+        <tree-pagination {(paging)}="paging" class="grid-data__toolbar-item"></tree-pagination>
     </div>
     <div class="grid-data-header flex-row flex-box">
         <div class="grid-data-item-index">

--- a/src/ggrc/assets/mustache/assessments/related-assessments.mustache
+++ b/src/ggrc/assets/mustache/assessments/related-assessments.mustache
@@ -4,12 +4,10 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
 <related-objects {base-instance}="instance" related-items-type="Assessment" order-by="finished_date,created_at">
     <reusable-objects-list {base-instance}="instance">
-        <div class="grid-data-toolbar flex-box">
-            <tree-pagination {(paging)}="paging"></tree-pagination>
+        <div class="grid-data__toolbar flex-box">
+            <tree-pagination {(paging)}="paging" class="grid-data__toolbar-item"></tree-pagination>
             {{#is_allowed 'update' baseInstance context='for'}}
-                <div class="grid-data-toolbar-control">
-                    <button class="btn btn-small btn-full btn-green" ($click)="reuseSelected" {{^hasSelected}}disabled{{/hasSelected}}>Reuse</button>
-                </div>
+                <button class="btn btn-small btn-green grid-data__toolbar-item" ($click)="reuseSelected" {{^hasSelected}}disabled{{/hasSelected}}>Reuse</button>
             {{/is_allowed}}
         </div>
         <div class="grid-data-header flex-row flex-box">

--- a/src/ggrc/assets/mustache/components/assessment/info-pane/info-pane.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/info-pane/info-pane.mustache
@@ -152,7 +152,7 @@
                   {{> '/static/mustache/assessments/related-assessments.mustache' }}
                 </tab-panel>
                 <tab-panel {(panels)}="panels" title-text="Related Issues">
-                  {{> '/static/mustache/assessments/related_issues.mustache' }}
+                  <related-issues {base-instance}="instance" {all-related-snapshots}="mappedSnapshots"></related-issues>
                 </tab-panel>
             </tab-container>
         </div>

--- a/src/ggrc/assets/mustache/components/related-objects/related-issues.mustache
+++ b/src/ggrc/assets/mustache/components/related-objects/related-issues.mustache
@@ -3,12 +3,10 @@ Copyright (C) 2017 Google Inc.
 Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 `}}
 
-<related-objects {base-instance}="instance" related-items-type="Issue">
-    <div class="grid-data-toolbar flex-box">
-        <tree-pagination {(paging)}="paging" class="flex-size-1"></tree-pagination>
-          <div class="grid-data-toolbar-control">
-              <add-issue-button {snapshots}="mappedSnapshots" {related-instance}="baseInstance"></add-issue-button>
-          </div>
+<related-objects {base-instance}="baseInstance" {predefined-filter}="relatedIssuesFilter" related-items-type="Issue">
+    <div class="grid-data__toolbar flex-box">
+        <tree-pagination {(paging)}="paging" class="grid-data__toolbar-item"></tree-pagination>
+        <add-issue-button {snapshots}="allRelatedSnapshots" {related-instance}="baseInstance" class="grid-data__toolbar-item"></add-issue-button>
     </div>
     <div class="grid-data-header flex-row flex-box">
         <div class="flex-size-2">

--- a/src/ggrc/assets/stylesheets/components/grid-data/_grid-data.scss
+++ b/src/ggrc/assets/stylesheets/components/grid-data/_grid-data.scss
@@ -2,28 +2,16 @@
  * Copyright (C) 2017 Google Inc.
  * Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  */
-.grid-data-toolbar {
-  height: 26px;
-  margin: 0 0 16px 0;
-  justify-content: flex-end;
-
-  .grid-data-toolbar-control {
-    display: flex;
-    height: 26px;
-    line-height: 26px;
-    padding: 0 0 0 16px;
-
-    .btn.btn-small {
-      height: 26px;
-      line-height: 26px;
-      box-sizing: border-box;
-      padding: 0 16px;
-    }
-
-    > * {
-      min-width: 86px;
-      margin: 0 0 0 12px;
-    }
+.grid-data {
+  &__toolbar {
+    height: 28px;
+    margin: 0 0 16px 0;
+    align-items: center;
+    justify-content: flex-end;
+  }
+  &__toolbar-item {
+    display: inline-flex;
+    margin: 0 0 0 16px;
   }
 }
 


### PR DESCRIPTION
Steps to reproduce:
1. Create program, control, audit
2. Go to audit page and generate assessment based on control
3. Go to program page> Controls tab and Open related Assessment window
4. On the audit page go to Controls tab and invoke Related assessments window clicking on "Assessments" button on Control's Info pane
Actual Result: Related Assessments are not shown in Related Assessments window if open the window via Controls/Objectives Info pane 
Expected Result: Related Assessments should be shown in Related Assessments window if open the window via Controls/Objectives Info pane
