### PR TITLE
GGRC-1987 "Uncaught TypeError: query.getCounts is not a function" error occurs on the Audit Summary page

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/summary_widget_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/summary_widget_controller.js
@@ -90,7 +90,7 @@
     },
     reloadChart: function (type, elementId) {
       var that = this;
-      var query = GGRC.Utils.QueryAPI;
+      var query = GGRC.Utils.CurrentPage;
       var chartOptions = this.options.context.charts[type];
       // Note that chart will be refreshed only if counts were changed.
       // State changes are not checked.


### PR DESCRIPTION
Steps to reproduce:
1. Create a program
2. Create audit
3. Open adit page

Actual Result: "Uncaught TypeError: query.getCounts is not a function" error occurs on the Audit Summary page
Expected Result: no errors are shown while opening Audit summary page