### PR TITLE
QUICK-FIX Disable accessControlList UI when action pending

### DIFF
--- a/src/ggrc/assets/javascripts/components/access_control_list/access_control_list.js
+++ b/src/ggrc/assets/javascripts/components/access_control_list/access_control_list.js
@@ -47,6 +47,14 @@
         roleBlockClass: {
           type: 'string',
           value: 'row-fluid'
+        },
+
+        // a flag indicating whether a user role modification is in progress
+        isUpdating: {
+          get: function () {
+            return Boolean(this.attr('isPendingGrant') ||
+                           this.attr('pendingRevoke') !== null);
+          }
         }
       },
 
@@ -59,6 +67,10 @@
        *   role" mode
        */
       grantRoleMode: function (roleId) {
+        if (this.attr('isUpdating')) {
+          return;
+        }
+
         this.attr('grantingRoleId', roleId);
       },
 
@@ -74,6 +86,10 @@
       grantRole: function (person, roleId) {
         var inst = this.instance;
         var roleEntry;
+
+        if (this.attr('isUpdating')) {
+          return;
+        }
 
         this.attr('isPendingGrant', true);
 
@@ -132,6 +148,10 @@
       revokeRole: function (person, roleId) {
         var idx;
         var inst = this.instance;
+
+        if (this.attr('isUpdating')) {
+          return;
+        }
 
         this.attr('pendingRevoke', [person.id, roleId]);
 
@@ -219,6 +239,7 @@
         canEdit = vm.isNewInstance ||
                   Permission.is_allowed_for('update', instance);
 
+        can.batch.start();
         vm.attr('canEdit', canEdit);
         vm.attr('grantingRoleId', 0);  // which "add role" autocomplete to show
         vm.attr('isPendingGrant', false);
@@ -228,6 +249,7 @@
 
         vm.attr('_rolesInfoFixed', false);
         vm._rebuildRolesInfo();
+        can.batch.stop();
       },
 
       '{viewModel.instance.access_control_list} change':

--- a/src/ggrc/assets/mustache/components/access_control_list/access_control_list.mustache
+++ b/src/ggrc/assets/mustache/components/access_control_list/access_control_list.mustache
@@ -3,7 +3,7 @@
   Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
 
-<div class="{{topWrapperClass}}">
+<div class="{{topWrapperClass}} {{#if isUpdating}}updating{{/isUpdating}}">
 
   {{#rolesInfo}}
     <div class="{{roleBlockClass}} bottom-spacing role-block">

--- a/src/ggrc/assets/stylesheets/components/access-control-list/_access-control-list.scss
+++ b/src/ggrc/assets/stylesheets/components/access-control-list/_access-control-list.scss
@@ -51,4 +51,12 @@ access-control-list {
       }
     }
   }
+
+  // special control styles while they should be disabled
+  & > div.updating {
+    .add-role, .revoke-role {
+      cursor: default !important;
+      opacity: 0.4;
+    }
+  }
 }


### PR DESCRIPTION
This PR is a follow-up to #5608 and it prevents triggering custom role changes while another action (grant/revoke) is in progress.

The [UX Jira ticket](https://gojira.corp.google.com/browse/GGRC-1926) did not specify any of this, but I added this improvement nevertheless, in order to avoid any issues that might arise due to race conditions. Mind that this change applies to info panes only, because in modals, no actions take place in the background and thus locking the Custom Roles UI is not needed.

**Steps to verify:**
1. Open an object instance that has a few Custom Roles defined (if not, define a few in the admin panel)
1. On the info pane, try assigning/revoking a role to/from a person.

**Expected result:**
While the change is pending (i.e. the server has not responded yet), the trash can icons and the `(+)` icons are disabled - clicking them does not do anything, and their appearance is temporarily changed.
(pro tip: simulating a slow connection helps, more time to observe the effects)