### PR TITLE
GGRC-1955: Shorten contact and url columns for Controls in tree-view

### DIFF
--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -270,6 +270,8 @@ dashboard-js-files:
   - components/last-assessment-date/last-assessment-date.js
   - components/tree/tree-no-results.js
   - components/tree/tree-assignee-field.js
+  - components/tree/tree-people-list-field.js
+  - components/tree/tree-people-with-role-list-field.js
   - components/page-header/page-header.js
   - components/info-pane/info-pane-footer.js
   - components/assessment/mapped-objects/mapped-controls.js

--- a/src/ggrc/assets/javascripts/components/tree/tree-people-list-field.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-people-list-field.js
@@ -1,0 +1,81 @@
+/*!
+  Copyright (C) 2017 Google Inc., authors, and contributors <see AUTHORS file>
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+(function (can, GGRC) {
+  'use strict';
+
+  GGRC.Components('treePeopleListField', {
+    tag: 'tree-people-list-field',
+    template: '<content />',
+    viewModel: can.Map.extend({
+      source: null,
+      filter: '@',
+      people: [],
+      peopleStr: '',
+      init: function () {
+        this.refreshPeople();
+      },
+      refreshPeople: function () {
+        this.getPeopleList()
+          .then(function (data) {
+            this.attr('people', data);
+            this.attr('peopleStr', data.map(function (item) {
+              return item.displayName;
+            }).join(', '));
+          }.bind(this));
+      },
+      getPeopleList: function () {
+        var sourceList = this.getSourceList();
+        var result;
+        var deferred = can.Deferred();
+
+        if (!sourceList.length) {
+          return deferred.resolve([]);
+        }
+
+        this.loadItems(sourceList)
+          .then(function (data) {
+            result = data.map(function (item) {
+              var shortEmail = item.email.replace(/@.*$/, '');
+              var displayName = item.name || shortEmail;
+              return {
+                name: item.name,
+                email: item.email,
+                shortEmail: shortEmail,
+                displayName: displayName
+              };
+            });
+            deferred.resolve(result);
+          })
+          .fail(function () {
+            deferred.resolve([]);
+          });
+
+        return deferred;
+      },
+      getSourceList: function () {
+        var filter = this.attr('filter');
+        var sourceString = 'source';
+
+        if (filter) {
+          sourceString += '.' + filter;
+        }
+
+        return can.makeArray(this.attr(sourceString));
+      },
+      loadItems: function (items) {
+        var ids = items.map(function (item) {
+          return item.id;
+        });
+        return CMS.Models.Person.findAll({id__in: ids.join(',')});
+      }
+    }),
+    events: {
+      '{viewModel} source': function () {
+        this.viewModel.refreshPeople();
+      }
+    }
+  });
+})(window.can, window.GGRC);

--- a/src/ggrc/assets/javascripts/components/tree/tree-people-with-role-list-field.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-people-with-role-list-field.js
@@ -1,0 +1,75 @@
+/*!
+  Copyright (C) 2017 Google Inc., authors, and contributors <see AUTHORS file>
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+(function (can, GGRC) {
+  'use strict';
+
+  GGRC.Components('treePeopleWithRoleListField', {
+    tag: 'tree-people-with-role-list-field',
+    template: '<content />',
+    viewModel: can.Map.extend({
+      source: null,
+      role: null,
+      people: [],
+      peopleStr: '',
+      init: function () {
+        this.refreshPeople();
+      },
+      refreshPeople: function () {
+        this.getPeopleList()
+          .then(function (data) {
+            this.attr('people', data);
+            this.attr('peopleStr', data.map(function (item) {
+              return item.displayName;
+            }).join(', '));
+          }.bind(this));
+      },
+      getPeopleList: function () {
+        var sourceList = this.getSourceList();
+        var result;
+        var deferred = can.Deferred();
+
+        if (!sourceList.length) {
+          return deferred.resolve([]);
+        }
+
+        this.loadItems(sourceList)
+          .then(function (data) {
+            result = data.map(function (item) {
+              var shortEmail = item.email.replace(/@.*$/, '');
+              var displayName = item.name || shortEmail;
+              return {
+                name: item.name,
+                email: item.email,
+                shortEmail: shortEmail,
+                displayName: displayName
+              };
+            });
+            deferred.resolve(result);
+          })
+          .fail(function () {
+            deferred.resolve([]);
+          });
+
+        return deferred;
+      },
+      getSourceList: function () {
+        var roleName = this.attr('role');
+        var instance = this.attr('source');
+        var peopleIds = GGRC.Utils.peopleWithRoleName(instance, roleName);
+
+        return peopleIds;
+      },
+      loadItems: function (ids) {
+        return CMS.Models.Person.findAll({id__in: ids.join(',')});
+      }
+    }),
+    events: {
+      '{viewModel} source': function () {
+        this.viewModel.refreshPeople();
+      }
+    }
+  });
+})(window.can, window.GGRC);

--- a/src/ggrc/assets/mustache/audits/tree-item-attr.mustache
+++ b/src/ggrc/assets/mustache/audits/tree-item-attr.mustache
@@ -5,11 +5,9 @@
 
 {{#switch attr_name}}
   {{#case 'audit_lead'}}
-    {{#if instance.contact}}
-      {{#using contact=instance.contact}}
-        {{{renderLive '/static/mustache/people/popover.mustache' person=contact}}}
-      {{/using}}
-    {{/if}}
+      <tree-people-list-field {source}="instance.contact">
+          {{peopleStr}}
+      </tree-people-list-field>
   {{/case}}
   {{#case 'report_period'}}
     {{#if instance.report_start_date}}

--- a/src/ggrc/assets/mustache/base_objects/tree-item-attr.mustache
+++ b/src/ggrc/assets/mustache/base_objects/tree-item-attr.mustache
@@ -5,27 +5,19 @@
 
 {{#switch attr_name}}
   {{#case 'owner'}}
-    {{#if owners.length}}
-      {{#using contacts=owners}}
-        {{#contacts}}
-          {{{renderLive '/static/mustache/people/popover.mustache' person=this}}}
-        {{/contacts}}
-      {{/using}}
-    {{/if}}
+      <tree-people-list-field {source}="instance.owners">
+          {{peopleStr}}
+      </tree-people-list-field>
   {{/case}}
   {{#case 'contact'}}
-    <span>
-      {{#using contact=instance.contact}}
-        {{{renderLive '/static/mustache/people/popover.mustache' person=contact}}}
-      {{/using}}
-    </span>
+      <tree-people-list-field {source}="instance.contact">
+          {{peopleStr}}
+      </tree-people-list-field>
   {{/case}}
   {{#case 'secondary_contact'}}
-    <span>
-      {{#using contact=instance.secondary_contact}}
-        {{{renderLive '/static/mustache/people/popover.mustache' person=contact}}}
-      {{/using}}
-    </span>
+      <tree-people-list-field {source}="instance.secondary_contact">
+          {{peopleStr}}
+      </tree-people-list-field>
   {{/case}}
   {{#case 'network_zone'}}
     {{#using network_zone=instance.network_zone}}
@@ -51,22 +43,19 @@
   {{/case}}
 
   {{#case 'creators'}}
-      <tree-assignee-field type="Creator"
-        {instance}='instance'>
-        {{assigneeStr}}
-      </tree-assignee-field>
+      <tree-people-list-field {source}="instance.assignees" filter="Creator">
+          {{peopleStr}}
+      </tree-people-list-field>
   {{/case}}
   {{#case 'assignees'}}
-      <tree-assignee-field type="Assessor"
-        {instance}='instance'>
-        {{assigneeStr}}
-      </tree-assignee-field>
+      <tree-people-list-field {source}="instance.assignees" filter="Assessor">
+          {{peopleStr}}
+      </tree-people-list-field>
   {{/case}}
   {{#case 'verifiers'}}
-      <tree-assignee-field type="Verifier"
-        {instance}='instance'>
-        {{assigneeStr}}
-      </tree-assignee-field>
+      <tree-people-list-field {source}="instance.assignees" filter="Verifier">
+          {{peopleStr}}
+      </tree-people-list-field>
   {{/case}}
   {{#case 'created_at'}}
       {{localize_date instance.created_at}}
@@ -81,6 +70,14 @@
   {{/case}}
 
   {{#default}}
-    {{get_default_attr_value attr_name instance}}
+      {{#if_helpers '\
+      #if_equals' attr_name 'url' '\
+      or #if_equals' attr_name 'reference_url'}}
+          <a class="url" href="{{get_url_value attr_name instance}}" target="_blank">
+              {{get_default_attr_value attr_name instance}}
+          </a>
+      {{else}}
+          {{get_default_attr_value attr_name instance}}
+      {{/if_helpers}}
   {{/default}}
 {{/switch}}

--- a/src/ggrc/assets/mustache/base_objects/tree.mustache
+++ b/src/ggrc/assets/mustache/base_objects/tree.mustache
@@ -31,11 +31,9 @@
                       {{#if_equals attr_type 'custom'}}
                         <div class="custom tree-title-area">
                           {{#get_custom_attr_value this instance}}
-                            {{! because the object can currently only be a
-                                person there is no need to switch }}
-                            {{#using person=object}}
-                              {{>'/static/mustache/people/popover.mustache'}}
-                            {{/using}}
+                              <tree-people-list-field {source}="object">
+                                  {{peopleStr}}
+                              </tree-people-list-field>
                           {{/get_custom_attr_value}}
                         </div>
                       {{else}}

--- a/src/ggrc/assets/mustache/components/tree/tree-item.mustache
+++ b/src/ggrc/assets/mustache/components/tree/tree-item.mustache
@@ -21,40 +21,23 @@
             {{#switch attr_type}}
               {{#case 'custom'}}
                 <div class="custom attr-content">
-                  {{#get_custom_attr_value this instance}}
-                  {{! because the object can currently only be a
+                  {{#get_custom_attr_value thisColumn instance}}
+                     {{! because the object can currently only be a
                       person there is no need to switch }}
-                    {{#using person=object}}
-                      {{>'/static/mustache/people/popover.mustache'}}
-                    {{/using}}
+                      <tree-people-list-field {source}="object">
+                          {{peopleStr}}
+                      </tree-people-list-field>
                   {{/get_custom_attr_value}}
                 </div>
               {{/case}}
 
               {{#case 'role'}}
                 <div class="roles attr-content">
-                  {{#peopleWithRole instance attr_name}}
-                    {{! For the time being, until the UI is clarified, we show
-                        only the first two people with a particular role, and
-                        an ellipsis if truncating was needed.
-                    }}
-                    {{#each peopleIds}}
-                      {{#if_less @index 2}}
-                        <person-info
-                          person-id="{{.}}"
-                          editable="'false'"
-                        ></person-info>
-                      {{/if_less}}
-                    {{/each}}
-
-                    {{#if_less 2 peopleIds.length}}
-                      <span
-                        class="list-truncated"
-                        title="People with this role: {{peopleIds.length}}"
-                        >&hellip;</span>
-                    {{/if_less}}
-
-                  {{/peopleWithRole}}
+                    <tree-people-with-role-list-field
+                            {source}="instance"
+                            {role}="attr_name">
+                        {{peopleStr}}
+                    </tree-people-with-role-list-field>
                 </div>
               {{/case}}
 

--- a/src/ggrc/assets/mustache/controls/tree-item-attr.mustache
+++ b/src/ggrc/assets/mustache/controls/tree-item-attr.mustache
@@ -6,41 +6,29 @@
 
 {{#switch attr_name}}
   {{#case 'owner'}}
-    {{#if owners.length}}
-      {{#using contacts=owners}}
-        {{#contacts}}
-          {{{renderLive '/static/mustache/people/popover.mustache' person=this}}}
-        {{/contacts}}
-      {{/using}}
-    {{/if}}
+      <tree-people-list-field {source}="instance.owners">
+          {{peopleStr}}
+      </tree-people-list-field>
   {{/case}}
   {{#case 'contact'}}
-    <span>
-      {{#using contact=instance.contact}}
-        {{{renderLive '/static/mustache/people/popover.mustache' person=contact}}}
-      {{/using}}
-    </span>
+      <tree-people-list-field {source}="instance.contact">
+          {{peopleStr}}
+      </tree-people-list-field>
   {{/case}}
   {{#case 'secondary_contact'}}
-    <span>
-      {{#using contact=instance.secondary_contact}}
-        {{{renderLive '/static/mustache/people/popover.mustache' person=contact}}}
-      {{/using}}
-    </span>
+      <tree-people-list-field {source}="instance.secondary_contact">
+          {{peopleStr}}
+      </tree-people-list-field>
   {{/case}}
   {{#case 'principal_assessor'}}
-    <span>
-      {{#using contact=instance.principal_assessor}}
-        {{{renderLive '/static/mustache/people/popover.mustache' person=contact}}}
-      {{/using}}
-    </span>
+      <tree-people-list-field {source}="instance.principal_assessor">
+          {{peopleStr}}
+      </tree-people-list-field>
   {{/case}}
   {{#case 'secondary_assessor'}}
-    <span>
-      {{#using contact=instance.secondary_assessor}}
-        {{{renderLive '/static/mustache/people/popover.mustache' person=contact}}}
-      {{/using}}
-    </span>
+      <tree-people-list-field {source}="instance.secondary_assessor">
+          {{peopleStr}}
+      </tree-people-list-field>
   {{/case}}
   {{#case 'kind'}}
     {{#using kind=instance.kind}}

--- a/src/ggrc/assets/mustache/directives/tree-item-attr.mustache
+++ b/src/ggrc/assets/mustache/directives/tree-item-attr.mustache
@@ -5,27 +5,19 @@
 
 {{#switch attr_name}}
   {{#case 'owner'}}
-    {{#if owners.length}}
-      {{#using contacts=owners}}
-        {{#contacts}}
-          {{{renderLive '/static/mustache/people/popover.mustache' person=this}}}
-        {{/contacts}}
-      {{/using}}
-    {{/if}}
+      <tree-people-list-field {source}="instance.owners">
+          {{peopleStr}}
+      </tree-people-list-field>
   {{/case}}
   {{#case 'contact'}}
-    <span>
-      {{#using contact=instance.contact}}
-        {{{renderLive '/static/mustache/people/popover.mustache' person=contact}}}
-      {{/using}}
-    </span>
+      <tree-people-list-field {source}="instance.contact">
+          {{peopleStr}}
+      </tree-people-list-field>
   {{/case}}
   {{#case 'secondary_contact'}}
-    <span>
-      {{#using contact=instance.secondary_contact}}
-        {{{renderLive '/static/mustache/people/popover.mustache' person=contact}}}
-      {{/using}}
-    </span>
+      <tree-people-list-field {source}="instance.secondary_contact">
+          {{peopleStr}}
+      </tree-people-list-field>
   {{/case}}
   {{#case 'status'}}
     {{#using status=instance.status}}

--- a/src/ggrc/assets/mustache/objectives/tree-item-attr.mustache
+++ b/src/ggrc/assets/mustache/objectives/tree-item-attr.mustache
@@ -5,27 +5,19 @@
 
 {{#switch attr_name}}
   {{#case 'owner'}}
-    {{#if owners.length}}
-      {{#using contacts=owners}}
-        {{#contacts}}
-          {{{renderLive '/static/mustache/people/popover.mustache' person=this}}}
-        {{/contacts}}
-      {{/using}}
-    {{/if}}
+      <tree-people-list-field {source}="instance.owners">
+          {{peopleStr}}
+      </tree-people-list-field>
   {{/case}}
   {{#case 'contact'}}
-    <span>
-      {{#using contact=instance.contact}}
-        {{{renderLive '/static/mustache/people/popover.mustache' person=contact}}}
-      {{/using}}
-    </span>
+      <tree-people-list-field {source}="instance.contact">
+          {{peopleStr}}
+      </tree-people-list-field>
   {{/case}}
   {{#case 'secondary_contact'}}
-    <span>
-      {{#using contact=instance.secondary_contact}}
-        {{{renderLive '/static/mustache/people/popover.mustache' person=contact}}}
-      {{/using}}
-    </span>
+      <tree-people-list-field {source}="instance.secondary_contact">
+          {{peopleStr}}
+      </tree-people-list-field>
   {{/case}}
   {{#case 'last_assessment_date'}}
     {{#if instance.snapshot}}

--- a/src/ggrc/assets/mustache/programs/tree-item-attr.mustache
+++ b/src/ggrc/assets/mustache/programs/tree-item-attr.mustache
@@ -10,9 +10,8 @@
         <span>
           {{#using role=instance.role}}
             {{#if_equals role.name 'ProgramOwner'}}
-              {{#using contact=instance.person}}
-                {{{renderLive '/static/mustache/people/popover.mustache' person=contact}}}
-              {{/using}}
+                <tree-people-list-field {source}="instance.contact">
+                </tree-people-list-field>
             {{/if_equals}}
           {{/using}}
         </span>
@@ -20,18 +19,12 @@
     {{/with_mapping}}
   {{/case}}
   {{#case 'contact'}}
-    <span>
-      {{#using contact=instance.contact}}
-        {{{renderLive '/static/mustache/people/popover.mustache' person=contact}}}
-      {{/using}}
-    </span>
+      <tree-people-list-field {source}="instance.contact">
+      </tree-people-list-field>
   {{/case}}
   {{#case 'secondary_contact'}}
-    <span>
-      {{#using contact=instance.secondary_contact}}
-        {{{renderLive '/static/mustache/people/popover.mustache' person=contact}}}
-      {{/using}}
-    </span>
+      <tree-people-list-field {source}="instance.secondary_contact">
+      </tree-people-list-field>
   {{/case}}
   {{#case 'status'}}
     {{#using status=instance.status}}
@@ -45,7 +38,8 @@
     {{#if_helpers '\
     #if_equals' attr_name 'url' '\
     or #if_equals' attr_name 'reference_url'}}
-      <a class="url" href="{{get_url_value attr_name instance}}" target="_blank">
+      <a class="url" href="{{get_url_value attr_name instance}}" target="_blank"
+        rel="tooltip" title="{{get_default_attr_value attr_name instance}}">
         {{get_default_attr_value attr_name instance}}
       </a>
     {{else}}

--- a/src/ggrc/assets/mustache/sections/tree-item-attr.mustache
+++ b/src/ggrc/assets/mustache/sections/tree-item-attr.mustache
@@ -5,27 +5,16 @@
 
 {{#switch attr_name}}
   {{#case 'owner'}}
-    {{#if owners.length}}
-      {{#using contacts=owners}}
-        {{#contacts}}
-          {{{renderLive '/static/mustache/people/popover.mustache' person=this}}}
-        {{/contacts}}
-      {{/using}}
-    {{/if}}
+      <tree-people-list-field {source}="instance.owners">
+      </tree-people-list-field>
   {{/case}}
   {{#case 'contact'}}
-    <span>
-      {{#using contact=instance.contact}}
-        {{{renderLive '/static/mustache/people/popover.mustache' person=contact}}}
-      {{/using}}
-    </span>
+      <tree-people-list-field {source}="instance.contact">
+      </tree-people-list-field>
   {{/case}}
   {{#case 'secondary_contact'}}
-    <span>
-      {{#using contact=instance.secondary_contact}}
-        {{{renderLive '/static/mustache/people/popover.mustache' person=contact}}}
-      {{/using}}
-    </span>
+      <tree-people-list-field {source}="instance.secondary_contact">
+      </tree-people-list-field>
   {{/case}}
   {{#case 'status'}}
     {{#using status=instance.status}}
@@ -39,7 +28,8 @@
     {{#if_helpers '\
     #if_equals' attr_name 'url' '\
     or #if_equals' attr_name 'reference_url'}}
-      <a class="url" href="{{get_url_value attr_name instance}}" target="_blank">
+      <a class="url" href="{{get_url_value attr_name instance}}" target="_blank"
+        rel="tooltip" title="{{get_default_attr_value attr_name instance}}">
         {{get_default_attr_value attr_name instance}}
       </a>
     {{else}}

--- a/src/ggrc/assets/stylesheets/components/tree/_tree-view.scss
+++ b/src/ggrc/assets/stylesheets/components/tree/_tree-view.scss
@@ -162,14 +162,20 @@ tree-item {
       }
     }
 
-    .selectable-attrs {
-      padding: 0 10px;
+    .flex-box.selectable-attrs {
+      flex-wrap: wrap;
     }
 
     .attr-cell {
       height: 60px;
       align-items: center;
       flex: 1 1;
+      margin: 0 5px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      word-wrap: break-word;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
 
       &:first-child {
         flex: 2 2;
@@ -186,24 +192,6 @@ tree-item {
           max-height: 32px;
           p, ul, ol {
             margin-bottom: 0;
-          }
-        }
-
-        &.roles {
-          display: block;
-          max-height: 100%;
-          width: 100%;
-          padding: 0 10px;
-          .person {
-            height: 20px;
-            max-width: 1px;  // FIXME: dirty fix for flex box overstretching
-            overflow: visible;
-            white-space: nowrap;
-          }
-          .list-truncated {
-            display: inline-block;
-            width: 100%;
-            cursor: default;
           }
         }
       }

--- a/src/ggrc_risk_assessments/assets/mustache/risk_assessments/tree-item-attr.mustache
+++ b/src/ggrc_risk_assessments/assets/mustache/risk_assessments/tree-item-attr.mustache
@@ -5,18 +5,14 @@
 
 {{#switch attr_name}}
   {{#case 'ra_manager'}}
-    <span>
-      {{#using contact=instance.ra_manager}}
-        {{{renderLive '/static/mustache/people/popover.mustache' person=contact}}}
-      {{/using}}
-    </span>
+      <tree-people-list-field {source}="instance.ra_manager">
+          {{peopleStr}}
+      </tree-people-list-field>
   {{/case}}
   {{#case 'ra_counsel'}}
-    <span>
-      {{#using contact=instance.ra_counsel}}
-        {{{renderLive '/static/mustache/people/popover.mustache' person=contact}}}
-      {{/using}}
-    </span>
+      <tree-people-list-field {source}="instance.ra_counsel">
+          {{peopleStr}}
+      </tree-people-list-field>
   {{/case}}
   {{#case 'status'}}
     {{#using status=instance.status}}

--- a/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/tree-item-attr.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/tree-item-attr.mustache
@@ -16,9 +16,9 @@
     {{/using}}
   {{/case}}
   {{#case 'assignee'}}
-    {{#using contact=instance.contact}}
-      <div>{{firstnonempty contact.name contact.email ''}}</div>
-    {{/using}}
+      <tree-people-list-field {source}="instance.contact">
+          {{peopleStr}}
+      </tree-people-list-field>
   {{/case}}
   {{#case 'status'}}
     {{#using status=instance.status}}

--- a/src/ggrc_workflows/assets/mustache/task_group_tasks/tree-item-attr.mustache
+++ b/src/ggrc_workflows/assets/mustache/task_group_tasks/tree-item-attr.mustache
@@ -5,11 +5,9 @@
 
 {{#switch attr_name}}
   {{#case 'assignee'}}
-    {{#using assignee=instance.contact}}
-      {{#using workflow=instance.workflow}}
-        {{{renderLive '/static/mustache/people/popover.mustache' person=assignee}}}
-      {{/using}}
-    {{/using}}
+      <tree-people-list-field {source}="instance.contact">
+          {{peopleStr}}
+      </tree-people-list-field>
   {{/case}}
   {{#case 'status'}}
     {{#using status=instance.status}}

--- a/src/ggrc_workflows/assets/mustache/task_groups/tree-item-attr.mustache
+++ b/src/ggrc_workflows/assets/mustache/task_groups/tree-item-attr.mustache
@@ -5,11 +5,9 @@
 
 {{#switch attr_name}}
   {{#case 'assignee'}}
-    {{#using assignee=instance.contact}}
-      {{#using workflow=instance.workflow}}
-        {{{renderLive '/static/mustache/people/popover.mustache' person=assignee}}}
-      {{/using}}
-    {{/using}}
+      <tree-people-list-field {source}="instance.contact">
+          {{peopleStr}}
+      </tree-people-list-field>
   {{/case}}
   {{#case 'status'}}
     {{#using status=instance.status}}

--- a/src/ggrc_workflows/assets/mustache/workflows/tree-item-attr.mustache
+++ b/src/ggrc_workflows/assets/mustache/workflows/tree-item-attr.mustache
@@ -10,9 +10,9 @@
         <span>
           {{#using role=instance.role}}
             {{#if_equals role.name 'WorkflowOwner'}}
-              {{#using contact=instance.person}}
-                {{{renderLive '/static/mustache/people/popover.mustache' person=contact}}}
-              {{/using}}
+                <tree-people-list-field {source}="instance.person">
+                    {{peopleStr}}
+                </tree-people-list-field>
             {{/if_equals}}
           {{/using}}
         </span>


### PR DESCRIPTION
Controls tree view:
- Shorten urls and contacts columns to 20 characters width.