### PR TITLE
GGRC-1993 Fix displaying Custom Roles on snapshots

### DIFF
--- a/src/ggrc/assets/javascripts/components/access_control_list/access_control_list.js
+++ b/src/ggrc/assets/javascripts/components/access_control_list/access_control_list.js
@@ -230,14 +230,17 @@
         var canEdit;
         var vm = this.viewModel;
         var instance = vm.instance;
+        var isSnapshot;
 
         if (!instance) {
           console.error('accessControlList component: instance not given.');
           return;
         }
 
-        canEdit = vm.isNewInstance ||
-                  Permission.is_allowed_for('update', instance);
+        isSnapshot = GGRC.Utils.Snapshots.isSnapshot(instance);
+        canEdit = !isSnapshot &&  // snapshots are not editable
+                  (vm.isNewInstance ||
+                   Permission.is_allowed_for('update', instance));
 
         can.batch.start();
         vm.attr('canEdit', canEdit);

--- a/src/ggrc/assets/javascripts/components/person/person.js
+++ b/src/ggrc/assets/javascripts/components/person/person.js
@@ -70,6 +70,7 @@
       // If it is, we can be certain that we can use the object from the cache.
       if (personModel && personModel.email) {
         scope.attr('personObj', personModel);
+        scope.attr('personId', personModel.id);
         return;
       }
       if (isNaN(personId) || personId <= 0) {
@@ -82,6 +83,7 @@
         .then(function (person) {
           person = Array.isArray(person) ? person[0] : person;
           scope.attr('personObj', person);
+          scope.attr('personId', person.id);
         }, function () {
           $(document.body).trigger(
             'ajax:flash',

--- a/src/ggrc/assets/javascripts/components/snapshotter/tests/revisions-comparer_spec.js
+++ b/src/ggrc/assets/javascripts/components/snapshotter/tests/revisions-comparer_spec.js
@@ -21,11 +21,11 @@ describe('GGRC.Components.revisionsComparer', function () {
       fakeData = [
         {
           id: 1,
-          content: {id: 1},
+          content: new can.Map({id: 1}),
           resource_type: 'Control'
         }, {
           id: 2,
-          content: {id: 1},
+          content: new can.Map({id: 1}),
           resource_type: 'Control'
         }
       ];
@@ -50,6 +50,30 @@ describe('GGRC.Components.revisionsComparer', function () {
       var data = fakeData;
       result.forEach(function (item, index) {
         expect(item.instance.id).toEqual(data[index].content.id);
+      });
+    });
+
+    it('adds person stubs to access control list items', function () {
+      var result;
+
+      fakeData.forEach(function (item, i) {
+        var acl = new can.List([
+          {ac_role_id: i * 10, person_id: i * 10},
+          {ac_role_id: i * 10, person_id: i * 10}
+        ]);
+        item.content.attr('access_control_list', acl);
+      });
+
+      result = method(fakeData);
+
+      function checkAclItem(item) {
+        expect(item.person).toBeDefined();
+        expect(item.person.type).toEqual('Person');
+        expect(item.person.id).toEqual(item.person_id);
+      }
+
+      result.forEach(function (item) {
+        item.instance.access_control_list.forEach(checkAclItem);
       });
     });
   });

--- a/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
+++ b/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
@@ -578,6 +578,7 @@
       var model = CMS.Models[instance.child_type];
       var content = instance.revision.content;
       var type = model.root_collection;
+
       content.isLatestRevision = instance.is_latest_revision;
       content.originalLink = '/' + type + '/' + content.id;
       content.snapshot = new can.Map(instance);
@@ -596,6 +597,13 @@
         type: instance.child_type,
         id: instance.child_id
       });
+
+      if (content.access_control_list) {
+        content.access_control_list.forEach(function (item) {
+          item.person = new CMS.Models.Person({id: item.person_id}).stub();
+        });
+      }
+
       object = new model(content);
       model.removeFromCacheById(content.id);  /* removes snapshot object from cache */
       return object;

--- a/src/ggrc/assets/javascripts/plugins/tests/ggrc_utils_snapshots_spec.js
+++ b/src/ggrc/assets/javascripts/plugins/tests/ggrc_utils_snapshots_spec.js
@@ -58,4 +58,43 @@ describe('GGRC Utils Snapshots', function () {
       }
     );
   });
+
+  describe('toObject() method', function () {
+    var snapshot;
+    var toObject;
+
+    beforeAll(function () {
+      toObject = GGRC.Utils.Snapshots.toObject;
+    });
+
+    beforeEach(function () {
+      snapshot = {
+        id: 12345,
+        type: 'Snapshot',
+        child_id: 42,
+        child_type: 'Control',
+        revision: {
+          content: {
+            access_control_list: [
+              {ac_role_id: 10, person_id: 4},
+              {ac_role_id: 17, person_id: 2},
+              {ac_role_id: 12, person_id: 4}
+            ]
+          }
+        }
+      };
+    });
+
+    it('adds person stubs to access control list items', function () {
+      var result = toObject(snapshot);
+
+      expect(result.access_control_list).toBeDefined();
+
+      result.access_control_list.forEach(function (item) {
+        expect(item.person).toBeDefined();
+        expect(item.person.type).toEqual('Person');
+        expect(item.person.id).toEqual(item.person_id);
+      });
+    });
+  });
 });


### PR DESCRIPTION
This PR fixes a few quirks with Custom Roles when displaying them on Snapshots.

Changes:
1. Custom Roles cannot be edited on snapshots
1. Custom Roles are displayed correctly on the Snapshot info pane (by fixing the `access_control_list` attribute in object instances generated from Snapshots.
1. Fixed highlighting of differences in custom role assignments on the "compare revisions" pane.

There are no tests for the revision diff pane changes, as they do not exist yet and a holistic end-to-end approach should probably be taken, but that is outside of the scope of this PR.

NOTE: For now, the PR only highlights the role grants that have been added/revoked, but it does not try to vertically align the same people in the old and new lists. In other words, no empty vertical placeholders are inserted when a particular item is missing in one of the lists. We can change this later if the UX team requests it.