### PR TITLE
GGRC-1998 Assessments states are updated  in pie chart after page refresh

### DIFF
--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -51,6 +51,7 @@ dashboard-js-files:
   - plugins/utils/ggrcq-utils.js
   - plugins/utils/tree-view-utils.js
   - plugins/utils/dashboards-utils.js
+  - plugins/utils/model-utils.js
   - plugins/datepicker.js
   - plugins/can_control.js
   - plugins/wysiwyg.js

--- a/src/ggrc/assets/javascripts/controllers/quick_form_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/quick_form_controller.js
@@ -126,7 +126,7 @@
         self.options.instance.refresh().then(function (instance) {
           self.set_value({name: el.data('name'), value: el.data('value')});
           return instance.save();
-        }).then(function () {
+        }).then(function (instance) {
           self.options.instance.attr('_disabled', '');
         });
       }

--- a/src/ggrc/assets/javascripts/controllers/summary_widget_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/summary_widget_controller.js
@@ -92,11 +92,15 @@
       var that = this;
       var query = GGRC.Utils.CurrentPage;
       var chartOptions = this.options.context.charts[type];
-      // Note that chart will be refreshed only if counts were changed.
-      // State changes are not checked.
+      // Note that chart will be refreshed only if:
+      // 1. counts were changed;
+      // 2. any assessment status was changed.
       var countsChanged = query.getCounts().attr(type) !==
                           chartOptions.attr('total');
-      if (chartOptions.attr('isInitialized') && !countsChanged) {
+      var updatesChanged = GGRC.Utils.Model.getUpdateCount(type) !==
+                           chartOptions.attr('version');
+      if (chartOptions.attr('isInitialized') &&
+        !countsChanged && !updatesChanged) {
         return;
       }
       chartOptions.attr('isInitialized', true);
@@ -210,6 +214,7 @@
     },
     setState: function (type, data, isLoading) {
       var chartOptions = this.options.context.charts[type];
+      chartOptions.attr('version', GGRC.Utils.Model.getUpdateCount(type));
       chartOptions.attr('total', data.total);
       chartOptions.attr('any', data.total > 0);
       chartOptions.attr('none', isLoading || data.total === 0);

--- a/src/ggrc/assets/javascripts/models/assessment.js
+++ b/src/ggrc/assets/javascripts/models/assessment.js
@@ -16,7 +16,7 @@
     mixins: [
       'ownable', 'contactable', 'unique_title',
       'autoStatusChangeable', 'timeboxed', 'mapping-limit',
-      'inScopeObjects'
+      'inScopeObjects', 'updateCounter'
     ],
     is_custom_attributable: true,
     defaults: {

--- a/src/ggrc/assets/javascripts/models/mixins.js
+++ b/src/ggrc/assets/javascripts/models/mixins.js
@@ -307,4 +307,15 @@
       }
     }
   }, {});
+
+  /**
+   * A mixin to increase the counter of updates for current model type
+   *
+   * @class CMS.Models.Mixins.updateCounter
+   */
+  can.Model.Mixin('updateCounter', {
+    after_save: function () {
+      GGRC.Utils.Model.incrementUpdateCount(this.type);
+    }
+  });
 })(window.can, window.GGRC);

--- a/src/ggrc/assets/javascripts/plugins/utils/model-utils.js
+++ b/src/ggrc/assets/javascripts/plugins/utils/model-utils.js
@@ -1,0 +1,42 @@
+/*!
+ Copyright (C) 2017 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+(function (GGRC) {
+  'use strict';
+
+  /**
+   * Util methods for Models.
+   */
+  GGRC.Utils.Model = (function () {
+    var changeCount = {};
+
+    /**
+     * Detect how much objects of specified type were changed.
+     * Please note that this count may be incorrect (EXPERIMENTAL).
+     * @param {String} model - The model name
+     * @return {Integer} True or False
+     */
+    function getUpdateCount(model) {
+      return changeCount[model];
+    }
+
+    /**
+     * Increment update count for specified type.
+     * @param {String} model - The model name
+     */
+    function incrementUpdateCount(model) {
+      if (!changeCount[model]) {
+        changeCount[model] = 0;
+      }
+
+      changeCount[model]++;
+    }
+
+    return {
+      getUpdateCount: getUpdateCount,
+      incrementUpdateCount: incrementUpdateCount
+    };
+  })();
+})(window.GGRC);


### PR DESCRIPTION
Steps to reproduce:
1. Create at least 5 assessments on the audit page and move it to different states: Not started, In progress, Completed, Ready for review, Completed
2. Go to Audit summary page

Actual Result: Assessments states are updated  in pie chart after page refresh
Expected Result: Pie chart should contain actual info as soon as assessment changes a state w/o page refresh

NOTE: The suggested fix - to monitor how much objects of the specified type were changed. Every time summary tab opened - previous and current AssessmentsChangeCount will be compared if they're not equal - chart will be reloaded.