### PR TITLE
GGRC-2003 Workflow: JS Error on click "Edit" button in tree view Cycle and Task Group

### DIFF
--- a/src/ggrc/assets/javascripts/components/tree/tree-item-actions.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-item-actions.js
@@ -6,29 +6,46 @@
 (function (can, GGRC) {
   'use strict';
 
+  var forbiddenList = ['Cycle', 'CycleTaskGroup'];
+
   var template = can.view(GGRC.mustache_path +
     '/components/tree/tree-item-actions.mustache');
 
   var viewModel = can.Map.extend({
     define: {
       deepLimit: {
-        type: Number,
+        type: 'number',
         value: 0
       },
       canExpand: {
-        type: Boolean,
+        type: 'boolean',
         value: false
       },
       expandIcon: {
-        type: String,
+        type: 'string',
         get: function () {
           return this.attr('expanded') ? 'compress' : 'expand';
         }
       },
       expanderTitle: {
-        type: String,
+        type: 'string',
         get: function () {
           return this.attr('expanded') ? 'Collapse tree' : 'Expand tree';
+        }
+      },
+      isSnapshot: {
+        type: 'boolean',
+        get: function () {
+          return GGRC.Utils.Snapshots.isSnapshot(this.attr('instance'));
+        }
+      },
+      isAllowedToEdit: {
+        type: 'boolean',
+        get: function () {
+          var type = this.attr('instance.type');
+          var isSnapshot = this.attr('isSnapshot');
+          var isInForbiddenList = forbiddenList.indexOf(type) > -1;
+          return !(isSnapshot || isInForbiddenList);
         }
       }
     },

--- a/src/ggrc/assets/mustache/components/tree/tree-item-actions.mustache
+++ b/src/ggrc/assets/mustache/components/tree/tree-item-actions.mustache
@@ -18,7 +18,7 @@
               View Info
             </a>
           </li>
-          {{^instance.snapshot}}
+          {{#unless isSnapshot}}
             <!-- Link for open instance on new Browser tab -->
             <li>
               <a href="{{instance.viewLink}}" target="_blank" ($click)="openObject">
@@ -26,31 +26,30 @@
                 Open in a new tab
               </a>
             </li>
-          {{/instance.snapshot}}
+          {{/unless}}
       {{/is_allowed}}
     {{/if}}
 
-    {{#unless instance.snapshot}}
+    {{#if isAllowedToEdit}}
       <li>
         <tree-item-map {instance}="instance"></tree-item-map>
       </li>
-
       {{#is_allowed 'update' instance context='for'}}
-      <li>
-        <a href="javascript://"
-           data-link-purpose="open-edit-modal"
-           data-toggle="modal-ajax-form"
-           data-modal-reset="reset"
-           data-modal-class="modal-wide"
-           data-object-singular="{{instance.class.model_singular}}"
-           data-object-plural="{{instance.class.table_plural}}"
-           data-object-id="{{instance.id}}">
-          <i class="fa fa-pencil-square-o"></i>
-          Edit object
-        </a>
-      </li>
+        <li>
+          <a href="javascript://"
+             data-link-purpose="open-edit-modal"
+             data-toggle="modal-ajax-form"
+             data-modal-reset="reset"
+             data-modal-class="modal-wide"
+             data-object-singular="{{instance.class.model_singular}}"
+             data-object-plural="{{instance.class.table_plural}}"
+             data-object-id="{{instance.id}}">
+            <i class="fa fa-pencil-square-o"></i>
+            Edit object
+          </a>
+        </li>
       {{/is_allowed}}
-    {{/unless}}
+    {{/if}}
 
     <li>
       <show-related-assessments-button {instance}="instance"
@@ -64,7 +63,7 @@
 
     <li class="splitter"></li>
 
-    {{#unless instance.snapshot}}
+    {{#unless isSnapshot}}
       {{#if canExpand}}
         <li>
           <sub-tree-models {models-list}="childModelsList"

--- a/src/ggrc/assets/mustache/components/tree/tree-item.mustache
+++ b/src/ggrc/assets/mustache/components/tree/tree-item.mustache
@@ -79,11 +79,11 @@
   </div>
 
   <div class="sub-tier">
-  <sub-tree-wrapper {parent}="instance"
-                    {limit-depth-tree}="limitDepthTree"
-                    {child-models}="selectedChildModels"
-                    {get-depth-filter}="@getDepthFilter"
-                    {is-open}="expanded"
-  ></sub-tree-wrapper>
-</div>
+    <sub-tree-wrapper {parent}="instance"
+                      {limit-depth-tree}="limitDepthTree"
+                      {child-models}="selectedChildModels"
+                      {get-depth-filter}="@getDepthFilter"
+                      {is-open}="expanded"
+    ></sub-tree-wrapper>
+  </div>
 </div>


### PR DESCRIPTION
Steps to reproduce:
1. Create one time WF
2. Add task to Task Group
3. Activate WF
4. On the Active Cycles tab click Edit this object in tree view Cycle and Task Group
Actual Result: "Uncaught Error: can.view: No template or empty template:/static/mustache/cycles/modal_content.mustache" error occurs on Active Cycles tab if click Edit this object in tree view Cycle and Task Group
Expected Result: edit action should be forbidden for Cycles and Cycle Task Groups