### PR TITLE
GGRC-1838 Display custom roles in tree views

### DIFF
--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -2816,6 +2816,54 @@ Example:
     }
   );
 
+  /**
+   * Determine the list of people IDs that have `roleName` granted on
+   * `instance` and render the corresponding Mustache block.
+   *
+   * The list of people IDs is exposed to the helper's block context via
+   * the 'peopleIds' Array.
+   *
+   * Example usage:
+   *
+   *   {{#peopleWithRole modelInstance customRoleName}}
+   *     {{#peopleIds}}
+   *       <p>User ID {{.}} has role {{customRoleName}} granted
+   *          on {{modelInstance.type}} with ID {{modelInstance.id}}</p>
+   *     {{/peopleIds}}
+   *   {{/peopleWithRole}}
+   *
+   * @param {CMS.Models.Cacheable} instance - a model instance
+   * @param {String} roleName - the name of the custom role
+   * @param {Object} options - a CanJS options object passed to every helper
+   *
+   * @return {String} - a rendered template block from inside the helper
+   */
+  Mustache.registerHelper(
+    'peopleWithRole',
+    function (instance, roleName, options) {
+      var peopleIds;
+
+      if (arguments.length < 3) {
+        console.warn('Arguments missing for peopleWithRole helper.');
+        return options.fn({peopleIds: []});
+      }
+
+      instance = Mustache.resolve(instance);
+      roleName = Mustache.resolve(roleName);
+
+      if (!instance || !roleName) {
+        return options.fn({peopleIds: []});
+      }
+
+      peopleIds = GGRC.Utils.peopleWithRoleName(instance, roleName);
+
+      if (peopleIds.length > 0) {
+        return options.fn({peopleIds: peopleIds});
+      }
+      return options.inverse({peopleIds: []});
+    }
+  );
+
   Mustache.registerHelper('modifyFieldTitle', function (type, field, options) {
     var titlesMap = {
       Cycle: 'Cycle ',

--- a/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
+++ b/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
@@ -475,6 +475,44 @@
 
       roles.unshift('none');
       return _.max(roles, Array.prototype.indexOf.bind(roleOrder));
+    },
+
+    /**
+     * Compute a list of people IDs that have `roleName` granted on `instance`.
+
+     * @param {CMS.Models.Cacheable} instance - a model instance
+     * @param {String} roleName - the name of the custom role
+     *
+     * @return {Array} - list of people IDs
+     */
+    peopleWithRoleName: function (instance, roleName) {
+      var modelRoles;
+      var peopleIds;
+      var roleId;
+
+      // get role ID by roleName
+      modelRoles = _.filter(
+        GGRC.access_control_roles,
+        {object_type: instance.class.model_singular, name: roleName});
+
+      if (modelRoles.length === 0) {
+        console.warn('peopleWithRole: role not found for instance type');
+        return [];
+      } else if (modelRoles.length > 1) {
+        console.warn('peopleWithRole: found more than a single role');
+        // We do not exit, as we have a reasonable fallback - picking
+        // the first match.
+      }
+
+      roleId = modelRoles[0].id;
+
+      peopleIds = _
+          .chain(instance.access_control_list)
+          .filter({ac_role_id: roleId})
+          .map('person.id')
+          .value();
+
+      return peopleIds;
     }
   };
 

--- a/src/ggrc/assets/javascripts/plugins/tests/ggrc_utils_spec.js
+++ b/src/ggrc/assets/javascripts/plugins/tests/ggrc_utils_spec.js
@@ -144,3 +144,71 @@ describe('GGRC utils isMappableType() method', function () {
     expect(result).toBe(true);
   });
 });
+
+describe('GGRC utils peopleWithRoleName() method', function () {
+  var instance;
+  var method;  // the method under test
+  var origRoleList;
+
+  beforeAll(function () {
+    method = GGRC.Utils.peopleWithRoleName;
+
+    origRoleList = GGRC.access_control_roles;
+    GGRC.access_control_roles = [
+      {id: 5, name: 'Role A', object_type: 'Market'},
+      {id: 9, name: 'Role A', object_type: 'Audit'},
+      {id: 1, name: 'Role B', object_type: 'Market'},
+      {id: 7, name: 'Role A', object_type: 'Policy'},
+      {id: 3, name: 'Role B', object_type: 'Audit'},
+      {id: 2, name: 'Role B', object_type: 'Policy'}
+    ];
+  });
+
+  afterAll(function () {
+    GGRC.access_control_roles = origRoleList;
+  });
+
+  beforeEach(function () {
+    var acl = [
+      {person: {id: 3}, ac_role_id: 1},
+      {person: {id: 5}, ac_role_id: 3},
+      {person: {id: 6}, ac_role_id: 9},
+      {person: {id: 2}, ac_role_id: 3},
+      {person: {id: 7}, ac_role_id: 9},
+      {person: {id: 5}, ac_role_id: 2},
+      {person: {id: 9}, ac_role_id: 9}
+    ];
+
+    instance = new can.Map({
+      id: 42,
+      type: 'Audit',
+      'class': {model_singular: 'Audit'},
+      access_control_list: acl
+    });
+  });
+
+  it('returns user IDs that have a role granted on a particular instance',
+    function () {
+      var result = method(instance, 'Role B');
+      expect(result.sort()).toEqual([2, 5]);
+    }
+  );
+
+  it('returns empty array if role name not found', function () {
+    var result = method(instance, 'Role X');
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array if no users are granted a particular role',
+    function () {
+      var result;
+
+      instance.attr('type', 'Policy');
+      instance.attr('class.model_singular', 'Policy');
+
+      result = method(instance, 'Role A');
+
+      expect(result).toEqual([]);
+    }
+  );
+});

--- a/src/ggrc/assets/javascripts/plugins/tests/utils/tree-view-utils_spec.js
+++ b/src/ggrc/assets/javascripts/plugins/tests/utils/tree-view-utils_spec.js
@@ -1,0 +1,74 @@
+/*!
+  Copyright (C) 2017 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+describe('GGRC.Utils.TreeView module', function () {
+  'use strict';
+
+  var method;
+  var module;
+  var origPageType;
+
+  beforeAll(function () {
+    module = GGRC.Utils.TreeView;
+
+    origPageType = GGRC.pageType;
+    GGRC.pageType = 'MY_WORK';
+  });
+
+  afterAll(function () {
+    GGRC.pageType = origPageType;
+  });
+
+  describe('getColumnsForModel() method', function () {
+    var origCustomAttrDefs;
+    var origRoleList;
+
+    beforeAll(function () {
+      method = module.getColumnsForModel;
+
+      origRoleList = GGRC.access_control_roles;
+      GGRC.access_control_roles = [
+        {id: 5, name: 'Role 5', object_type: 'Market'},
+        {id: 9, name: 'Role 9', object_type: 'Audit'},
+        {id: 1, name: 'Role 1', object_type: 'Market'},
+        {id: 7, name: 'Role 7', object_type: 'Policy'},
+        {id: 3, name: 'Role 3', object_type: 'Audit'},
+        {id: 2, name: 'Role 2', object_type: 'Policy'}
+      ];
+
+      origCustomAttrDefs = GGRC.custom_attr_defs;
+      GGRC.custom_attr_defs = [{
+        id: 16, attribute_type: 'Text',
+        definition_type: 'market', title: 'CA def 16'
+      }, {
+        id: 5, attribute_type: 'Text',
+        definition_type: 'policy', title: 'CA def 5'
+      }, {
+        id: 11, attribute_type: 'Text',
+        definition_type: 'audit', title: 'CA def 11'
+      }];
+    });
+
+    afterAll(function () {
+      GGRC.access_control_roles = origRoleList;
+      GGRC.custom_attr_defs = origCustomAttrDefs;
+    });
+
+    it('includes custom roles info in the result ', function () {
+      var result = method('Audit', null);
+      result = _.filter(result.available, {attr_type: 'role'});
+
+      ['Role 3', 'Role 9'].forEach(function (title) {
+        var expected = {
+          attr_type: 'role',
+          attr_title: 'Role 9',
+          attr_name: 'Role 9',
+          attr_sort_field: 'Role 9'
+        };
+        expect(result).toContain(jasmine.objectContaining(expected));
+      });
+    });
+  });
+});

--- a/src/ggrc/assets/javascripts/plugins/utils/tree-view-utils.js
+++ b/src/ggrc/assets/javascripts/plugins/utils/tree-view-utils.js
@@ -109,6 +109,7 @@
           return a.order - b.order;
         });
 
+      // add custom attributes information
       var customAttrs = disableConfiguration ?
         [] :
         GGRC.custom_attr_defs
@@ -129,8 +130,22 @@
               attr_type: 'custom'
             };
           });
-
       var allAttrs = attrs.concat(customAttrs);
+
+      // add custom roles information
+      var modelRoles = _.filter(GGRC.access_control_roles, {
+        object_type: modelType
+      });
+      var roleAttrs = modelRoles.map(function (role) {
+        return {
+          attr_title: role.name,
+          attr_name: role.name,
+          attr_sort_field: role.name,
+          display_status: false,
+          attr_type: 'role'
+        };
+      });
+      allAttrs = allAttrs.concat(roleAttrs);
 
       if (disableConfiguration) {
         return {

--- a/src/ggrc/assets/mustache/components/tree/tree-item.mustache
+++ b/src/ggrc/assets/mustache/components/tree/tree-item.mustache
@@ -15,62 +15,96 @@
     <tree-item-status-for-workflow {instance}="instance"></tree-item-status-for-workflow>
     <div class="flex-box selectable-attrs width-100" ($click)="select($element)">
         {{#selectedColumns}}
+          {{! add alias because "this" is changed inside the switch-case block}}
+          {{#add_to_current_scope thisColumn=this}}
           <div class="flex-box attr-cell">
-            {{#if_equals attr_type 'custom'}}
-              <div class="custom attr-content">
-                {{#get_custom_attr_value this instance}}
-                {{! because the object can currently only be a
-                    person there is no need to switch }}
-                  {{#using person=object}}
-                    {{>'/static/mustache/people/popover.mustache'}}
-                  {{/using}}
-                {{/get_custom_attr_value}}
-              </div>
-            {{else}}
-              <div class="owner attr-content">
-                {{#instance}}
-                  {{#switch type}}
-                    {{#case 'Audit'}}
-                      {{> '/static/mustache/audits/tree-item-attr.mustache'}}
-                    {{/case}}
-                    {{#case 'Control'}}
-                      {{> '/static/mustache/controls/tree-item-attr.mustache'}}
-                    {{/case}}
-                    {{#case 'Directive'}}
-                      {{> '/static/mustache/directives/tree-item-attr.mustache'}}
-                    {{/case}}
-                    {{#case 'Objective'}}
-                      {{> '/static/mustache/objectives/tree-item-attr.mustache'}}
-                    {{/case}}
-                    {{#case 'Person'}}
-                      {{> '/static/mustache/people/tree-item-attr.mustache'}}
-                    {{/case}}
-                    {{#case 'Program'}}
-                      {{> '/static/mustache/programs/tree-item-attr.mustache'}}
-                    {{/case}}
-                    {{#case 'Section'}}
-                      {{> '/static/mustache/sections/tree-item-attr.mustache'}}
-                    {{/case}}
-                    {{#case 'RiskAssessment'}}
-                      {{> '/static/mustache/risk_assessments/tree-item-attr.mustache'}}
-                    {{/case}}
-                    {{#case 'Workflow'}}
-                      {{> '/static/mustache/workflows/tree-item-attr.mustache'}}
-                    {{/case}}
-                    {{#case 'CycleTaskGroupObjectTask'}}
-                      {{> '/static/mustache/cycle_task_group_object_tasks/tree-item-attr.mustache'}}
-                    {{/case}}
-                    {{#case 'TaskGroup'}}
-                      {{> '/static/mustache/task_groups/tree-item-attr.mustache'}}
-                    {{/case}}
-                    {{#default}}
-                      {{> '/static/mustache/base_objects/tree-item-attr.mustache'}}
-                    {{/default}}
-                  {{/switch}}
-                {{/instance}}
-              </div>
-            {{/if_equals}}
+            {{#switch attr_type}}
+              {{#case 'custom'}}
+                <div class="custom attr-content">
+                  {{#get_custom_attr_value this instance}}
+                  {{! because the object can currently only be a
+                      person there is no need to switch }}
+                    {{#using person=object}}
+                      {{>'/static/mustache/people/popover.mustache'}}
+                    {{/using}}
+                  {{/get_custom_attr_value}}
+                </div>
+              {{/case}}
+
+              {{#case 'role'}}
+                <div class="roles attr-content">
+                  {{#peopleWithRole instance attr_name}}
+                    {{! For the time being, until the UI is clarified, we show
+                        only the first two people with a particular role, and
+                        an ellipsis if truncating was needed.
+                    }}
+                    {{#each peopleIds}}
+                      {{#if_less @index 2}}
+                        <person-info
+                          person-id="{{.}}"
+                          editable="'false'"
+                        ></person-info>
+                      {{/if_less}}
+                    {{/each}}
+
+                    {{#if_less 2 peopleIds.length}}
+                      <span
+                        class="list-truncated"
+                        title="People with this role: {{peopleIds.length}}"
+                        >&hellip;</span>
+                    {{/if_less}}
+
+                  {{/peopleWithRole}}
+                </div>
+              {{/case}}
+
+              {{#case 'default'}}
+                <div class="owner attr-content">
+                  {{#instance}}
+                    {{#switch type}}
+                      {{#case 'Audit'}}
+                        {{> '/static/mustache/audits/tree-item-attr.mustache'}}
+                      {{/case}}
+                      {{#case 'Control'}}
+                        {{> '/static/mustache/controls/tree-item-attr.mustache'}}
+                      {{/case}}
+                      {{#case 'Directive'}}
+                        {{> '/static/mustache/directives/tree-item-attr.mustache'}}
+                      {{/case}}
+                      {{#case 'Objective'}}
+                        {{> '/static/mustache/objectives/tree-item-attr.mustache'}}
+                      {{/case}}
+                      {{#case 'Person'}}
+                        {{> '/static/mustache/people/tree-item-attr.mustache'}}
+                      {{/case}}
+                      {{#case 'Program'}}
+                        {{> '/static/mustache/programs/tree-item-attr.mustache'}}
+                      {{/case}}
+                      {{#case 'Section'}}
+                        {{> '/static/mustache/sections/tree-item-attr.mustache'}}
+                      {{/case}}
+                      {{#case 'RiskAssessment'}}
+                        {{> '/static/mustache/risk_assessments/tree-item-attr.mustache'}}
+                      {{/case}}
+                      {{#case 'Workflow'}}
+                        {{> '/static/mustache/workflows/tree-item-attr.mustache'}}
+                      {{/case}}
+                      {{#case 'CycleTaskGroupObjectTask'}}
+                        {{> '/static/mustache/cycle_task_group_object_tasks/tree-item-attr.mustache'}}
+                      {{/case}}
+                      {{#case 'TaskGroup'}}
+                        {{> '/static/mustache/task_groups/tree-item-attr.mustache'}}
+                      {{/case}}
+                      {{#default}}
+                        {{> '/static/mustache/base_objects/tree-item-attr.mustache'}}
+                      {{/default}}
+                    {{/switch}}
+                  {{/instance}}
+                </div>
+              {{/case}}
+           {{/switch}}
           </div>
+          {{/add_to_current_scope}}
         {{/selectedColumns}}
     </div>
 

--- a/src/ggrc/assets/mustache/components/unified-mapper/mapper-results-item-attrs.mustache
+++ b/src/ggrc/assets/mustache/components/unified-mapper/mapper-results-item-attrs.mustache
@@ -1,23 +1,41 @@
 <div class="flex-box flex-box-single">
   {{#each selectedColumns}}
     <div class="attr">
-      {{#if_equals attr_type 'custom'}}
-        {{#get_custom_attr_value this instance}}
-          {{#using person=object}}
-            {{>'/static/mustache/people/popover.mustache'}}
-          {{/using}}
-        {{/get_custom_attr_value}}
-      {{else}}
-        {{#instance}}
-          {{#if_equals attr_name 'title'}}
-            <span class="title-attr">
-              {{title}}
-            </span>
-          {{else}}
-            {{> attrTemplate}}
-          {{/if_equals}}
-        {{/instance}}
-      {{/if_equals}}
+      {{#switch attr_type}}
+        {{#case 'custom'}}
+          {{#get_custom_attr_value this instance}}
+            {{#using person=object}}
+              {{>'/static/mustache/people/popover.mustache'}}
+            {{/using}}
+          {{/get_custom_attr_value}}
+        {{/case}}
+
+        {{#case 'role'}}
+          <div class="roles">
+            {{#peopleWithRole instance attr_name}}
+              {{#each peopleIds}}
+                {{^if_less @index 1}},{{/if}}
+                <person-info
+                  person-id="{{.}}"
+                  editable="'false'"
+                ></person-info>
+              {{/each}}
+            {{/peopleWithRole}}
+          </div>
+        {{/case}}
+
+        {{#case 'default'}}
+          {{#instance}}
+            {{#if_equals attr_name 'title'}}
+              <span class="title-attr">
+                {{title}}
+              </span>
+            {{else}}
+              {{> attrTemplate}}
+            {{/if_equals}}
+          {{/instance}}
+        {{/case}}
+      {{/switch}}
     </div>
   {{/each}}
 </div>

--- a/src/ggrc/assets/stylesheets/components/tree/_tree-view.scss
+++ b/src/ggrc/assets/stylesheets/components/tree/_tree-view.scss
@@ -188,6 +188,24 @@ tree-item {
             margin-bottom: 0;
           }
         }
+
+        &.roles {
+          display: block;
+          max-height: 100%;
+          width: 100%;
+          padding: 0 10px;
+          .person {
+            height: 20px;
+            max-width: 1px;  // FIXME: dirty fix for flex box overstretching
+            overflow: visible;
+            white-space: nowrap;
+          }
+          .list-truncated {
+            display: inline-block;
+            width: 100%;
+            cursor: default;
+          }
+        }
       }
     }
   }

--- a/src/ggrc/assets/stylesheets/components/unified-mapper/_unified-mapper.scss
+++ b/src/ggrc/assets/stylesheets/components/unified-mapper/_unified-mapper.scss
@@ -390,6 +390,14 @@ mapper-results-item-attrs {
     &:first-child {
       flex: 1 1 $first-column-width;
     }
+
+    .roles {
+      overflow: hidden;
+      text-overflow: ellipsis;;
+      .person {
+        display: inline;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
PLEASE DO NOT MERGE YET
---

This PR adds an option to display Custom Roles in tree view in the same way as regular instance attributes  and Custom Attributes can be selected to be displayed in tree items.

Things to do:
- [x] Show custom roles in tree views that use the new tree view component (dashboard page, all objects page, related objects tabs, snapshotted related items).
- [x] Show custom roles in the search results / unified mapper view ~~(works, too, but needs polishing, thus not published yet)~~