### PR TITLE
GGRC-1906 Unable to add role to user in People tab at Program level 

### DIFF
--- a/src/ggrc_basic_permissions/assets/mustache/ggrc_basic_permissions/people_roles/info.mustache
+++ b/src/ggrc_basic_permissions/assets/mustache/ggrc_basic_permissions/people_roles/info.mustache
@@ -17,21 +17,23 @@
         <span class="bubble"></span>
       </a>
       <ul class="dropdown-menu three-dots-list" aria-labelledby="drop1" role="menu">
-        {{#is_allowed 'create' 'delete' 'UserRole' context=options.parent_instance.context.id}}
-          {{#is_info_pin}}
-            <li>
-              <a data-modal-class="modal-wide"
-                 data-modal-selector-options="user_roles"
-                 data-person_id="{{instance.id}}"
-                 data-placement="left"
-                 data-toggle="user-roles-modal-selector"
-                 href="javascript://">
-                <i class="fa fa-role color"></i>
-                Edit Authorizations
-              </a>
-            </li>
-          {{/is_info_pin}}
-        {{/is_allowed}}
+        {{#if_instance_of parentInstance 'Program|Audit'}}
+          {{#is_allowed 'create' 'delete' 'UserRole' context=options.parent_instance.context.id}}
+            {{#is_info_pin}}
+              <li>
+                <a data-modal-class="modal-wide"
+                   data-modal-selector-options="user_roles"
+                   data-person_id="{{instance.id}}"
+                   data-placement="left"
+                   data-toggle="user-roles-modal-selector"
+                   href="javascript://">
+                  <i class="fa fa-role color"></i>
+                  Edit Authorizations
+                </a>
+              </li>
+            {{/is_info_pin}}
+          {{/is_allowed}}
+        {{/if_instance_of}}
         <li class="border-bottom">
           <clipboard-link title="Get permalink" notify="true" text="{{get_permalink_for_object instance}}" />
         </li>


### PR DESCRIPTION
There is no way to add/change authorizations on people tab at the program level. User is added to the program by the admin, however cannot assign any roles.

The ticket is reopened due to "Edit authorizations" link appears on the object's page. It shouldn't be.