### PR TITLE
GGRC-1491 Fix incorrect title for Org Groups

### DIFF
--- a/src/ggrc/assets/mustache/components/page-header/page-header.mustache
+++ b/src/ggrc/assets/mustache/components/page-header/page-header.mustache
@@ -12,12 +12,12 @@
         All Objects
       {{/is_dashboard}}
     {{else}}
-        <span class="entity-type">{{model.table_singular}}:</span>
+        <span class="entity-type">{{model.title_singular}}:</span>
         <span class="entity-name">{{firstnonempty instance.name instance.email}}</span>
     {{/is_dashboard_or_all}}
   {{/if_equals}}
   {{^if_equals model.table_singular 'person'}}
-    <span class="entity-type">{{model.table_singular}}:</span>
+    <span class="entity-type">{{model.title_singular}}:</span>
     <span class="entity-name">{{instance.title}}</span>
   {{/if_equals}}
 </h1>


### PR DESCRIPTION
Fix incorrect spelling in TopBar for Org Group Info page 
![image](https://cloud.githubusercontent.com/assets/24203972/25628851/5b628f0c-2f70-11e7-9745-77b97f5776fa.png)
