### PR TITLE
GGRC-1793 Add export link to snapshot tree view 

### DIFF
--- a/src/ggrc/assets/javascripts/components/csv/export.js
+++ b/src/ggrc/assets/javascripts/components/csv/export.js
@@ -177,7 +177,7 @@
     }
   });
 
-  can.Component.extend({
+  GGRC.Components('exportGroup', {
     tag: 'export-group',
     template: '<content></content>',
     scope: {
@@ -186,7 +186,8 @@
     events: {
       inserted: function () {
         this.addPanel({
-          type: url.model_type || 'Program'
+          type: url.model_type || 'Program',
+          isSnapshots: url.isSnapshots
         });
       },
       addPanel: function (data) {
@@ -196,6 +197,9 @@
         data = data || {};
         if (!data.type) {
           data.type = 'Program';
+        } else if (data.isSnapshots === 'true') {
+          data.snapshot_type = data.type;
+          data.type = 'Snapshot';
         }
 
         this.scope.attr('_index', index);
@@ -284,6 +288,10 @@
         this.scope.attr('item.filter', '');
         this.scope.attr('item.snapshot_type', '');
         this.scope.attr('item.has_parent', false);
+
+        if (this.scope.attr('item.type') === 'Snapshot') {
+          this.scope.attr('item.snapshot_type', 'Control');
+        }
 
         this.setSelected();
       }

--- a/src/ggrc/assets/javascripts/components/csv/test/export_spec.js
+++ b/src/ggrc/assets/javascripts/components/csv/test/export_spec.js
@@ -1,0 +1,72 @@
+/*!
+  Copyright (C) 2017 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+describe('GGRC.Components.exportGroup', function () {
+  'use strict';
+
+  var Component;  // the component under test
+
+  beforeAll(function () {
+    Component = GGRC.Components.get('exportGroup');
+  });
+
+  describe('events', function () {
+    describe('inserted() method', function () {
+      var method;  // the method under test
+      var that;
+
+      beforeEach(function () {
+        that = {
+          addPanel: jasmine.createSpy()
+        };
+        method = Component.prototype.events.inserted.bind(that);
+      });
+      it('calls addPanel with proper arguments', function () {
+        method();
+        expect(that.addPanel).toHaveBeenCalledWith(jasmine.objectContaining({
+          type: 'Program',
+          isSnapshots: undefined
+        }));
+      });
+    });
+    describe('addPanel() method', function () {
+      var method;  // the method under test
+      var data;
+      var scope;
+
+      beforeEach(function () {
+        scope = new can.Map({
+          _index: 0,
+          panels: {
+            items: []
+          }
+        });
+        method = Component.prototype.events.addPanel.bind({scope: scope});
+      });
+      it('adds panel with "Program" type if data.type is undefined',
+        function () {
+          data = {};
+          method(data);
+          expect(scope.attr('panels.items')[0].type).toEqual('Program');
+        });
+      it('adds panel with type from data if it is defined',
+        function () {
+          data = {type: 'Audit'};
+          method(data);
+          expect(scope.attr('panels.items')[0].type).toEqual('Audit');
+        });
+      it('adds panel with snapshot_type equal to data.type and' +
+      ' type equal to "Snapshot" if it is snapshot', function () {
+        data = {
+          type: 'Control',
+          isSnapshots: 'true'
+        };
+        method(data);
+        expect(scope.attr('panels.items')[0].type).toEqual('Snapshot');
+        expect(scope.attr('panels.items')[0].snapshot_type).toEqual('Control');
+      });
+    });
+  });
+});

--- a/src/ggrc/assets/javascripts/components/tree/tree-widget-container.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-widget-container.js
@@ -108,7 +108,7 @@
             this.attr('model').tree_view_options.add_item_view;
         }
       },
-      hideImportExport: {
+      isSnapshots: {
         type: Boolean,
         get: function () {
           var Snapshots = GGRC.Utils.Snapshots;

--- a/src/ggrc/assets/mustache/components/tree/tree-widget-container.mustache
+++ b/src/ggrc/assets/mustache/components/tree/tree-widget-container.mustache
@@ -39,8 +39,8 @@
           <span class="bubble"></span>
         </a>
         <ul class="dropdown-menu tree-action-list-items" role="menu">
-          {{^if hideImportExport}}
-            {{^if_instance_of parent_instance 'Assessment'}}
+          {{^if_instance_of parent_instance 'Assessment'}}
+            {{^if isSnapshots}}
               {{#is_allowed 'update' model.shortName context=parent_instance.context}}
                 <li>
                   <a href="/import"
@@ -51,18 +51,18 @@
                   </a>
                 </li>
               {{/is_allowed}}
-              {{#if showedItems.length}}
-                <li>
-                  <a href="/export?model_type={{model.model_singular}}&relevant_type={{parent_instance.type}}&relevant_id={{parent_instance.id}}"
-                     target="_blank"
-                     class="section-import">
-                    <i class="fa fa-fw fa-download"></i>
-                    Export {{model.model_plural}}
-                  </a>
-                </li>
-              {{/if}}
-            {{/if_instance_of}}
-          {{/if}}
+            {{/if}}
+            {{#if showedItems.length}}
+              <li>
+                <a href="/export?model_type={{model.model_singular}}&relevant_type={{parent_instance.type}}&relevant_id={{parent_instance.id}}{{#if isSnapshots}}&isSnapshots=true{{/if}}"
+                   target="_blank"
+                   class="section-import">
+                  <i class="fa fa-fw fa-download"></i>
+                  Export {{model.model_plural}}
+                </a>
+              </li>
+            {{/if}}
+          {{/if_instance_of}}
           {{#if showGenerateAssessments}}
             <assessment-generator-button audit="parent_instance"></assessment-generator-button>
           {{/if}}

--- a/src/ggrc/assets/mustache/import_export/import_export_buttons.mustache
+++ b/src/ggrc/assets/mustache/import_export/import_export_buttons.mustache
@@ -3,8 +3,8 @@
   Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
 
-{{^if display_options.hideImportExport}}
 {{^if_instance_of parent_instance 'Assessment'}}
+{{^if display_options.isSnapshots}}
 {{#is_allowed 'update' model.shortName context=parent_instance.context}}
 <li>
   <a href="/import"
@@ -15,9 +15,10 @@
   </a>
 </li>
 {{/is_allowed}}
+{{/if}}
 {{#if list.length}}
   <li>
-    <a href="/export?model_type={{model.model_singular}}&relevant_type={{parent_instance.type}}&relevant_id={{parent_instance.id}}"
+    <a href="/export?model_type={{model.model_singular}}&relevant_type={{parent_instance.type}}&relevant_id={{parent_instance.id}}{{#if display_options.isSnapshots}}&isSnapshots=true{{/if}}"
       target="_blank"
       class="section-import">
       <i class="fa fa-fw fa-download"></i>
@@ -26,4 +27,3 @@
   </li>
 {{/if}}
 {{/if_instance_of}}
-{{/if}}


### PR DESCRIPTION
Snapshot tree view menu must have export link that navigates to export page with all proper filters set and selected.
The filters that will need to be set are blocked and defined in GGRC-201.
This ticket should also hmake sure that empty snapshot type is not available when doing the "manual" export.