### PR TITLE
GGRC-1959 Access control role name validation

### DIFF
--- a/src/ggrc/access_control/role.py
+++ b/src/ggrc/access_control/role.py
@@ -11,7 +11,8 @@ from ggrc.models.mixins import attributevalidator
 from ggrc.fulltext.mixin import Indexed
 
 
-class AccessControlRole(Indexed, attributevalidator.AttributeValidator, mixins.Base, db.Model):
+class AccessControlRole(Indexed, attributevalidator.AttributeValidator,
+                        mixins.Base, db.Model):
   """Access Control Role
 
   Model holds all roles in the application. These roles can be added

--- a/src/ggrc/models/custom_attribute_definition.py
+++ b/src/ggrc/models/custom_attribute_definition.py
@@ -15,7 +15,8 @@ from ggrc.models.custom_attribute_value import CustomAttributeValue
 from ggrc.models.exceptions import ValidationError
 
 
-class CustomAttributeDefinition(attributevalidator.AttributeValidator, mixins.Base, mixins.Titled, db.Model):
+class CustomAttributeDefinition(attributevalidator.AttributeValidator,
+                                mixins.Base, mixins.Titled, db.Model):
   """Custom attribute definition model.
 
   Attributes:

--- a/src/ggrc/models/custom_attribute_definition.py
+++ b/src/ggrc/models/custom_attribute_definition.py
@@ -8,17 +8,14 @@ from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.orm import validates
 from sqlalchemy.sql.schema import UniqueConstraint
 
-import ggrc.models
 from ggrc import db
-from ggrc.access_control import role
-from ggrc.utils import benchmark
+from ggrc.models.mixins import attributevalidator
 from ggrc.models import mixins
-from ggrc.models.reflection import AttributeInfo
 from ggrc.models.custom_attribute_value import CustomAttributeValue
 from ggrc.models.exceptions import ValidationError
 
 
-class CustomAttributeDefinition(mixins.Base, mixins.Titled, db.Model):
+class CustomAttributeDefinition(attributevalidator.AttributeValidator, mixins.Base, mixins.Titled, db.Model):
   """Custom attribute definition model.
 
   Attributes:
@@ -164,61 +161,6 @@ class CustomAttributeDefinition(mixins.Base, mixins.Titled, db.Model):
       value = ",".join(part.strip() for part in value.split(","))
 
     return value
-
-  @classmethod
-  def _get_reserved_names(cls, definition_type):
-    """Get a list of all attribute names in all objects.
-
-    On first call this function computes all possible names that can be used by
-    any model and stores them in a static frozen set. All later calls just get
-    this set.
-
-    Returns:
-      frozen set containing all reserved attribute names for the current
-      object.
-    """
-    # pylint: disable=protected-access
-    # The _inflector is a false positive in our app.
-    with benchmark("Generate a list of all reserved attribute names"):
-      if not cls._reserved_names.get(definition_type):
-        definition_map = {model._inflector.table_singular: model
-                          for model in ggrc.models.all_models.all_models}
-        definition_model = definition_map.get(definition_type)
-        if not definition_model:
-          raise ValueError("Invalid definition type")
-
-        aliases = AttributeInfo.gather_aliases(definition_model)
-        cls._reserved_names[definition_type] = frozenset(
-            (value["display_name"] if isinstance(
-                value, dict) else value).lower()
-            for value in aliases.values() if value
-        )
-      return cls._reserved_names[definition_type]
-
-  @classmethod
-  def _get_global_cad_names(cls, definition_type):
-    """Get names of global cad for a given object."""
-    definition_types = [definition_type]
-    if definition_type == "assessment_template":
-      definition_types.append("assessment")
-    if not getattr(flask.g, "global_cad_names", set()):
-      query = db.session.query(cls.title, cls.id).filter(
-          cls.definition_type.in_(definition_types),
-          cls.definition_id.is_(None)
-      )
-      flask.g.global_cad_names = {name.lower(): id_ for name, id_ in query}
-    return flask.g.global_cad_names
-
-
-  @classmethod
-  def _get_custom_roles(cls, definition_type):
-    """Get all access control role names for the given object type"""
-    if not getattr(flask.g, "global_role_names", set()):
-      query = db.session.query(role.AccessControlRole.name, role.AccessControlRole.id).filter(
-        role.AccessControlRole.object_type == definition_type
-      )
-      flask.g.global_role_names = {name.lower(): id_ for name, id_ in query}
-    return flask.g.global_role_names
 
   def validate_assessment_title(self, name):
     """Check assessment title uniqueness.

--- a/src/ggrc/models/mixins/attributevalidator.py
+++ b/src/ggrc/models/mixins/attributevalidator.py
@@ -1,0 +1,73 @@
+"""Attribute validatior"""
+
+import flask
+import ggrc.models
+import ggrc.access_control
+from ggrc import db
+from ggrc.utils import benchmark
+from ggrc.models.reflection import AttributeInfo
+
+
+class AttributeValidator(object):
+  """Adds methods needed for attribute name vaidation"""
+  # pylint: disable=too-few-public-methods
+
+  @classmethod
+  def _get_reserved_names(cls, definition_type):
+    """Get a list of all attribute names in all objects.
+
+    On first call this function computes all possible names that can be used by
+    any model and stores them in a static frozen set. All later calls just get
+    this set.
+
+    Returns:
+      frozen set containing all reserved attribute names for the current
+      object.
+    """
+    # pylint: disable=protected-access
+    # The _inflector is a false positive in our app.
+    with benchmark("Generate a list of all reserved attribute names"):
+      if not cls._reserved_names.get(definition_type):
+        definition_map = {model._inflector.table_singular: model
+                          for model in ggrc.models.all_models.all_models}
+        definition_map.update({model._inflector.model_singular: model
+                          for model in ggrc.models.all_models.all_models})
+
+        definition_model = definition_map.get(definition_type)
+        if not definition_model:
+          raise ValueError("Invalid definition type")
+
+        aliases = AttributeInfo.gather_aliases(definition_model)
+        cls._reserved_names[definition_type] = frozenset(
+            (value["display_name"] if isinstance(
+                value, dict) else value).lower()
+            for value in aliases.values() if value
+        )
+      return cls._reserved_names[definition_type]
+
+  @classmethod
+  def _get_global_cad_names(cls, definition_type):
+    """Get names of global cad for a given object"""
+    cad = ggrc.models.custom_attribute_definition.CustomAttributeDefinition
+    definition_types = [definition_type]
+    if definition_type == "assessment_template":
+      definition_types.append("assessment")
+    if not getattr(flask.g, "global_cad_names", set()):
+      query = db.session.query(cad.title, cad.id).filter(
+          cad.definition_type.in_(definition_types),
+          cad.definition_id.is_(None)
+      )
+      flask.g.global_cad_names = {name.lower(): id_ for name, id_ in query}
+    return flask.g.global_cad_names
+
+
+  @classmethod
+  def _get_custom_roles(cls, definition_type):
+    """Get all access control role names for the given object type"""
+    if not getattr(flask.g, "global_role_names", set()):
+      role = ggrc.access_control.role
+      query = db.session.query(role.AccessControlRole.name, role.AccessControlRole.id).filter(
+        role.AccessControlRole.object_type == definition_type
+      )
+      flask.g.global_role_names = {name.lower(): id_ for name, id_ in query}
+    return flask.g.global_role_names

--- a/src/ggrc/models/mixins/attributevalidator.py
+++ b/src/ggrc/models/mixins/attributevalidator.py
@@ -31,7 +31,7 @@ class AttributeValidator(object):
         definition_map = {model._inflector.table_singular: model
                           for model in ggrc.models.all_models.all_models}
         definition_map.update({model._inflector.model_singular: model
-                          for model in ggrc.models.all_models.all_models})
+                              for model in ggrc.models.all_models.all_models})
 
         definition_model = definition_map.get(definition_type)
         if not definition_model:
@@ -60,14 +60,15 @@ class AttributeValidator(object):
       flask.g.global_cad_names = {name.lower(): id_ for name, id_ in query}
     return flask.g.global_cad_names
 
-
   @classmethod
   def _get_custom_roles(cls, definition_type):
     """Get all access control role names for the given object type"""
     if not getattr(flask.g, "global_role_names", set()):
       role = ggrc.access_control.role
-      query = db.session.query(role.AccessControlRole.name, role.AccessControlRole.id).filter(
-        role.AccessControlRole.object_type == definition_type
+      query = db.session.query(
+          role.AccessControlRole.name,
+          role.AccessControlRole.id).filter(
+          role.AccessControlRole.object_type == definition_type
       )
       flask.g.global_role_names = {name.lower(): id_ for name, id_ in query}
     return flask.g.global_role_names

--- a/test/integration/ggrc/access_control/test_access_control_role.py
+++ b/test/integration/ggrc/access_control/test_access_control_role.py
@@ -29,7 +29,7 @@ class TestAccessControlRole(TestCase):
     return self.api.post(AccessControlRole, {
         "access_control_role": {
             "name": name,
-            "objec_type": "Control",
+            "object_type": "Control",
             "context": None,
             "read": True
         },

--- a/test/integration/ggrc/models/test_attributevalidator.py
+++ b/test/integration/ggrc/models/test_attributevalidator.py
@@ -198,3 +198,26 @@ class TestCAD(TestCase):
             definition_type="assessment_template",
             definition_id=1,
         )
+
+  def test_role_attribute(self):
+    """Test access control role collisions with attributes & CADs"""
+    db.session.add(models.CustomAttributeDefinition(
+        title="my custom attribute title",
+        definition_type="section",
+        attribute_type="Text",
+    ))
+    db.session.commit()
+
+    with self.assertRaises(ValueError):
+      db.session.add(models.AccessControlRole(
+          name="title",
+          object_type="Market",
+      ))
+      db.session.commit()
+
+    with self.assertRaises(ValueError):
+      db.session.add(models.AccessControlRole(
+          name="my custom attribute title",
+          object_type="Section",
+      ))
+      db.session.commit()

--- a/test/integration/ggrc/models/test_cad.py
+++ b/test/integration/ggrc/models/test_cad.py
@@ -6,8 +6,8 @@
 from sqlalchemy.exc import IntegrityError
 
 from ggrc import db
-from ggrc import models
 from ggrc.app import app
+from ggrc.models import all_models as models
 from integration.ggrc import TestCase
 from integration.ggrc.models import factories
 
@@ -68,6 +68,10 @@ class TestCAD(TestCase):
         definition_id=2,
         attribute_type="Text",
     ))
+    db.session.add(models.AccessControlRole(
+        name="a name for a role",
+        object_type="Section",
+    ))
     db.session.commit()
 
     with self.assertRaises(IntegrityError):
@@ -89,12 +93,26 @@ class TestCAD(TestCase):
       ))
       db.session.commit()
 
+    with self.assertRaises(ValueError):
+      db.session.add(models.CustomAttributeDefinition(
+          title="a name for a role",
+          definition_type="section",
+          definition_id=2,
+          attribute_type="Text",
+      ))
+      db.session.commit()
+
   def test_different_models(self):
     """Test unique names over on different models."""
     db.session.add(models.CustomAttributeDefinition(
         title="my custom attribute title",
         definition_type="section",
         attribute_type="Text",
+    ))
+    db.session.commit()
+    db.session.add(models.AccessControlRole(
+        name="my custom attribute title",
+        object_type="Contract",
     ))
     db.session.commit()
     cad = models.CustomAttributeDefinition(


### PR DESCRIPTION
This adds validation to access control names so that the name does not clash with object attributes and global custom attributes.