### PR TITLE
GGRC-2052 Fix gdrive folder assigning

### DIFF
--- a/src/ggrc_gdrive_integration/models/__init__.py
+++ b/src/ggrc_gdrive_integration/models/__init__.py
@@ -1,17 +1,13 @@
 # Copyright (C) 2017 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
+"""Gdrive Models"""
 
-import ggrc.models.all_models #import all_models,  __all__
-from .object_folder import ObjectFolder
-from .object_file import ObjectFile
-from .object_event import ObjectEvent
+from ggrc.models.all_models import register_model
+from ggrc_gdrive_integration.models.object_event import ObjectEvent
+from ggrc_gdrive_integration.models.object_file import ObjectFile
+from ggrc_gdrive_integration.models.object_folder import ObjectFolder
 
-ggrc.models.all_models.ObjectFolder = ObjectFolder
-ggrc.models.all_models.ObjectFile = ObjectFile
-ggrc.models.all_models.ObjectEvent = ObjectEvent
-ggrc.models.all_models.ObjectFolder._inflector
-ggrc.models.all_models.ObjectFile._inflector
-ggrc.models.all_models.ObjectEvent._inflector
-ggrc.models.all_models.all_models += [ObjectFolder, ObjectFile, ObjectEvent]
-ggrc.models.all_models.__all__ += [ObjectFolder.__name__, ObjectFile.__name__, ObjectEvent.__name__]
+register_model(ObjectEvent)
+register_model(ObjectFile)
+register_model(ObjectFolder)


### PR DESCRIPTION
Steps to reproduce:
1. Go to a Program with an Audit without a folder assigned.
1. Open the Audit info pane.
2. Assign a new folder to it (check that it's displayed correctly).
3. Close the info pane.
4. Open the Audit's info pane again.
Expected result: the folder is still there.
Actual result: A message "Warning: You need permission to access Audit folder. Request access." is displayed instead of the folder, an HTTP500 is returned from the backend.