### PR TITLE
GGRC-1163 Add possible States for the objects in csv file

### DIFF
--- a/src/ggrc/models/mixins/statusable.py
+++ b/src/ggrc/models/mixins/statusable.py
@@ -28,6 +28,14 @@ class Statusable(object):
       nullable=False,
       default=START_STATE)
 
+  _aliases = {
+      "status": {
+          "display_name": "State",
+          "mandatory": False,
+          "description": "Options are:\n{}".format('\n'.join(VALID_STATES))
+      }
+  }
+
   @classmethod
   def default_status(cls):
     return "Not Started"

--- a/src/ggrc/models/reflection.py
+++ b/src/ggrc/models/reflection.py
@@ -175,7 +175,7 @@ class AttributeInfo(object):
   def gather_attr_dicts(cls, tgt_class, src_attr):
     """ Gather dictionaries from target class parets """
     result = {}
-    for base_class in tgt_class.__bases__:
+    for base_class in reversed(tgt_class.__bases__):
       base_result = cls.gather_attr_dicts(base_class, src_attr)
       result.update(base_result)
     attrs = getattr(tgt_class, src_attr, {})

--- a/test/integration/ggrc/converters/test_import_assessments.py
+++ b/test/integration/ggrc/converters/test_import_assessments.py
@@ -409,7 +409,7 @@ class TestAssessmentExport(TestCase):
     }]
     response = self.export_csv(data)
 
-    keys, vals = response.data.strip().split("\n")[7:9]
+    keys, vals = response.data.strip().split("\n")[9:11]
     keys = next(csv.reader(StringIO(keys), delimiter=","), [])
     vals = next(csv.reader(StringIO(vals), delimiter=","), [])
     instance_dict = dict(izip(keys, vals))


### PR DESCRIPTION
Steps to reproduce:
1. Go to Import page
2. Select any object e.g. "Controls" and download template
3. Open csv file, look at the header of the "State" field: there is no possible states to be added by user
Actual Result: there is no possible choices for "States" for user 
Expected Result: Add possible States for all the objects in csv file (e.g. Controls: "Active", "Draft", "Deprecated"/ Audit: Planned, In progress, Manager Review, Ready for External Review, Completed)