### PR TITLE
GGRC-2097 Assessments: Verifier doesn't see evidence and folder to which verifier has an access

### DIFF
--- a/src/ggrc/models/assessment.py
+++ b/src/ggrc/models/assessment.py
@@ -93,6 +93,8 @@ class Assessment(Roleable, statusable.Statusable, AuditRelationship,
 
   ASSIGNEE_TYPES = (u"Creator", u"Assessor", u"Verifier")
 
+  MAPPED_WITH_RUD_PERMISSIONS = ["Document"]
+
   REMINDERABLE_HANDLERS = {
       "statusToPerson": {
           "handler":

--- a/src/ggrc/models/mixins/assignable.py
+++ b/src/ggrc/models/mixins/assignable.py
@@ -22,6 +22,8 @@ class Assignable(object):
   _publish_attrs = ["assignees"]
   _update_attrs = []
 
+  MAPPED_WITH_RUD_PERMISSIONS = []
+
   _custom_publish = {
       "assignees": lambda obj: obj.publish_assignees(),
   }

--- a/src/ggrc_basic_permissions/__init__.py
+++ b/src/ggrc_basic_permissions/__init__.py
@@ -20,6 +20,7 @@ from ggrc import settings
 from ggrc.app import app
 from ggrc.login import get_current_user
 from ggrc.models import all_models
+from ggrc.models import mixins
 from ggrc.models.audit import Audit
 from ggrc.models.program import Program
 from ggrc.models.object_owner import ObjectOwner
@@ -51,6 +52,11 @@ blueprint = Blueprint(
 PERMISSION_CACHE_TIMEOUT = 3600  # 60 minutes
 
 
+RUD_MAP = {m.__name__: m.MAPPED_WITH_RUD_PERMISSIONS
+           for m in all_models.all_models
+           if issubclass(m, mixins.assignable.Assignable)}
+
+
 def get_public_config(_):
   """Expose additional permissions-dependent config to client.
     Specifically here, expose GGRC_BOOTSTRAP_ADMIN values to ADMIN users.
@@ -62,7 +68,7 @@ def get_public_config(_):
   return public_config
 
 
-def objects_via_assignable_query(user_id, context_not_role=True):
+def objects_via_assignable_query(user_id):
   """Creates a query that returns objects a user can access because she is
      assigned via the assignable mixin.
 
@@ -71,83 +77,50 @@ def objects_via_assignable_query(user_id, context_not_role=True):
 
     Returns:
         db.session.query object that selects the following columns:
-            | id | type | context_id |
+            access_model | id | type | context_id |
   """
 
-  rel1 = aliased(all_models.Relationship, name="rel1")
-  rel2 = aliased(all_models.Relationship, name="rel2")
-  _attrs = aliased(all_models.RelationshipAttr, name="attrs")
-
-  def assignable_join(query):
-    """Joins relationship_attrs to the query. This filters out only the
-       relationship objects where the user is mapped with an AssigneeType.
-    """
-    return query.join(
-        _attrs, and_(
-            _attrs.relationship_id == rel1.id,
-            _attrs.attr_name == "AssigneeType",
-            case([
-                (rel1.destination_type == "Person",
-                 rel1.destination_id)
-            ], else_=rel1.source_id) == user_id))
-
-  def related_assignables():
-    """Header for the mapped_objects join"""
-    return db.session.query(
-        case([
-            (rel2.destination_type == rel1.destination_type,
-             rel2.source_id)
-        ], else_=rel2.destination_id).label('id'),
-        case([
-            (rel2.destination_type == rel1.destination_type,
-             rel2.source_type)
-        ], else_=rel2.destination_type).label('type'),
-        rel1.context_id if context_not_role else literal('R')
-    ).select_from(rel1)
-
-  # First we fetch objects where a user is mapped as an assignee
-  assigned_objects = assignable_join(db.session.query(
-      case([
-          (rel1.destination_type == "Person",
-           rel1.source_id)
-      ], else_=rel1.destination_id),
-      case([
-          (rel1.destination_type == "Person",
-           rel1.source_type)
-      ], else_=rel1.destination_type),
-      rel1.context_id if context_not_role else literal('RUD')))
-
-  # The user should also have access to objects mapped to the assigned_objects
-  # We accomplish this by filtering out relationships where the user is
-  # assigned and then joining the relationship table for the second time,
-  # retrieving the mapped objects.
-  #
-  # We have a union here because using or_ to join both by destination and
-  # source was not performing well (8s+ query times)
-  mapped_objects = assignable_join(
-      # Join by destination:
-      related_assignables()).join(rel2, and_(
-          case([
-              (rel1.destination_type == "Person",
-               rel1.source_id)
-          ], else_=rel1.destination_id) == rel2.destination_id,
-          case([
-              (rel1.destination_type == "Person",
-               rel1.source_type)
-          ], else_=rel1.destination_type) == rel2.destination_type)
-  ).union(assignable_join(
-      # Join by source:
-      related_assignables()).join(rel2, and_(
-          case([
-              (rel1.destination_type == "Person",
-               rel1.source_id)
-          ], else_=rel1.destination_id) == rel2.source_id,
-          case([
-              (rel1.destination_type == "Person",
-               rel1.source_type)
-          ], else_=rel1.destination_type) == rel2.source_type))
+  assignee_type_sub = all_models.RelationshipAttr.query.filter(
+      all_models.RelationshipAttr.attr_name == "AssigneeType"
+  ).subquery("assignee_type_sub")
+  assignable_relations = db.session.query(
+      literal("RelationshipAttr").label("access_model"),
+      case([(all_models.Relationship.destination_type == "Person",
+             all_models.Relationship.source_id)],
+           else_=all_models.Relationship.destination_id).label("id"),
+      case([(all_models.Relationship.destination_type == "Person",
+             all_models.Relationship.source_type)],
+           else_=all_models.Relationship.destination_type).label("type"),
+      literal("RUD").label("context_id"),
+  ).filter(
+      all_models.Relationship.id == assignee_type_sub.c.relationship_id,
+      case([(all_models.Relationship.destination_type == "Person",
+             all_models.Relationship.destination_id)],
+           else_=all_models.Relationship.source_id) == user_id
+  ).subquery("assignable_relations")
+  destination_query = db.session.query(
+      all_models.Relationship.source_type,
+      all_models.Relationship.destination_id,
+      all_models.Relationship.destination_type,
+      literal("R").label("context_id")
+  ).filter(
+      all_models.Relationship.source_type == assignable_relations.c.type,
+      all_models.Relationship.source_id == assignable_relations.c.id
   )
-  return mapped_objects.union(assigned_objects)
+  source_query = db.session.query(
+      all_models.Relationship.destination_type,
+      all_models.Relationship.source_id,
+      all_models.Relationship.source_type,
+      literal("R").label("context_id")
+  ).filter(
+      all_models.Relationship.destination_type == assignable_relations.c.type,
+      all_models.Relationship.destination_id == assignable_relations.c.id
+  )
+  return source_query.union(
+      destination_query
+  ).union(
+      db.session.query(assignable_relations)
+  )
 
 
 def objects_via_relationships_query(model, roles, user_id, context_not_role):
@@ -660,15 +633,22 @@ def load_assignee_relationships(user, permissions):
   Returns:
       None
   """
-  for id_, type_, role_name in objects_via_assignable_query(user.id, False):
+  query = objects_via_assignable_query(user.id)
+  for access_model, id_, type_, role_name in query:
+    if type_ in RUD_MAP.get(access_model, []):
+      role_name = "RUD"
     actions = ["read", "view_object_page"]
     if role_name == "RUD":
       actions += ["update", "delete"]
     for action in actions:
-      permissions.setdefault(action, {})\
-          .setdefault(type_, {})\
-          .setdefault('resources', list())\
-          .append(id_)
+      if action not in permissions:
+        permissions[action] = {}
+      if type_ not in permissions[action]:
+        permissions[action][type_] = {}
+      if 'resources' not in permissions[action][type_]:
+        permissions[action][type_]['resources'] = []
+      if id_ not in permissions[action][type_]['resources']:
+        permissions[action][type_]['resources'].append(id_)
 
 
 def load_personal_context(user, permissions):
@@ -806,7 +786,6 @@ def load_permissions_for(user):
 
   with benchmark("load_permissions > load assignee relationships"):
     load_assignee_relationships(user, permissions)
-
   with benchmark("load_permissions > load personal context"):
     load_personal_context(user, permissions)
 

--- a/test/integration/ggrc/api_helper.py
+++ b/test/integration/ggrc/api_helper.py
@@ -87,15 +87,18 @@ class Api(object):
   def put(self, obj, data):
     name = obj._inflector.table_singular
     response = self.get(obj, obj.id)
-    headers = {
-        "If-Match": response.headers.get("Etag"),
-        "If-Unmodified-Since": response.headers.get("Last-Modified")
-    }
-    api_link = response.json[name]["selfLink"]
-    if name not in data:
-      response.json[name].update(data)
-      data = response.json
-
+    headers = {}
+    if "Etag" in response.headers:
+      headers["If-Match"] = response.headers["Etag"]
+    if "Last-Modified" in response.headers:
+      headers["If-Unmodified-Since"] = response.headers["Last-Modified"]
+    if response.json:
+      api_link = response.json[name]["selfLink"]
+      if name not in data:
+        response.json[name].update(data)
+        data = response.json
+    else:
+      api_link = data[name]["selfLink"]
     return self.send_request(
         self.client.put, obj, data, headers=headers, api_link=api_link)
 

--- a/test/integration/ggrc_basic_permissions/test_assessment_document.py
+++ b/test/integration/ggrc_basic_permissions/test_assessment_document.py
@@ -1,0 +1,106 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Test permissions on mapped Document to assessment."""
+from ggrc.app import app  # NOQA pylint: disable=unused-import
+from ggrc.models import all_models
+
+from integration.ggrc.models import factories
+from integration.ggrc import generator
+from integration import ggrc
+
+from appengine import base
+
+
+@base.with_memcache
+class BaseTestDocumentPermissions(ggrc.TestCase):
+  """Check permissions for Document instance related to assessment."""
+
+  ROLE = None
+
+  def setUp(self):
+    super(BaseTestDocumentPermissions, self).setUp()
+    self.api = ggrc.api_helper.Api()
+    self.generator = generator.ObjectGenerator()
+    _, program = self.generator.generate_object(all_models.Program)
+    _, audit = self.generator.generate_object(
+        all_models.Audit,
+        {
+            "title": "Audit",
+            "program": {"id": program.id},
+            "status": "Planned"
+        },
+    )
+    _, self.assessment = self.generator.generate_object(
+        all_models.Assessment,
+        {
+            "title": "Assessment",
+            "audit": {"id": audit.id},
+            "audit_title": audit.title,
+        },
+    )
+    _, self.editor = self.generator.generate_person(
+        user_role="Creator"
+    )
+    self.editor_id = self.editor.id
+    self.assessment = all_models.Assessment.query.get(self.assessment.id)
+    self.editor = all_models.Person.query.get(self.editor.id)
+    if self.ROLE:
+      factories.RelationshipAttrFactory(
+          relationship_id=factories.RelationshipFactory(
+              source=self.assessment,
+              destination=self.editor,
+          ).id,
+          attr_name="AssigneeType",
+          attr_value=self.ROLE
+      )
+    self.url_id = factories.DocumentFactory(link="test.com").id
+    self.generator.generate_relationship(
+        all_models.Document.query.get(self.url_id),
+        self.assessment,
+    )
+    self.editor = all_models.Person.query.get(self.editor_id)
+    self.url_get = self.api.get(all_models.Document, self.url_id)
+    self.api.set_user(self.editor)
+
+  def test_get_action_document(self):
+    """Test permissions on get."""
+    resp = self.api.get(all_models.Document, self.url_id)
+    if self.ROLE:
+      self.assert200(resp)
+    else:
+      self.assert403(resp)
+
+  def test_delete_action_document(self):
+    """Test permissions on delete."""
+    resp = self.api.delete(all_models.Document.query.get(self.url_id))
+    if self.ROLE:
+      self.assert200(resp)
+    else:
+      self.assert403(resp)
+
+  def test_put_action_document(self):
+    """Test permissions on put."""
+    data = {
+        'document': {
+            'link': "new_link.com",
+            "selfLink": self.url_get.json["document"]["selfLink"],
+        }
+    }
+    resp = self.api.put(all_models.Document.query.get(self.url_id), data)
+    if self.ROLE:
+      self.assert200(resp)
+    else:
+      self.assert403(resp)
+
+
+class TestCreatorPermissions(BaseTestDocumentPermissions):
+  ROLE = "Creator"
+
+
+class TestVerifierPermissions(BaseTestDocumentPermissions):
+  ROLE = "Verifier"
+
+
+class TestAssessorPermissions(BaseTestDocumentPermissions):
+  ROLE = "Assessor"


### PR DESCRIPTION
Steps to reproduce:
1. Have program, audit, created assessment
2. Go to Audit Info page and assign folder to which verifier (globcreator@gmail.com (engage007) has an access
3. Go to Assessment tab> Info pane> add Verifier (globcreator@gmail.com (engage007) to People list
4. Attach evidence to which Verifier has an access to Assessment from the assigned folder
5. Log as Verifier globcreator@gmail.com (engage007)
6. Go to audit Info page: "No folder for this Audit." is shown
7. Navigate to assessment's Info pane and look at the attached evidence: is not shown
Actual Result: Verifier doesn't see evidence and folder to which verifier has an access
Expected Result: Verifier should see evidence and folder to which verifier has an access
Note: Global Creator as Auditor and Verifier in Audit sees assigned folder by admin to audit and attached evidence