### PR TITLE
GGRC-1888 Filter is not applied if click [enter] button

### DIFF
--- a/src/ggrc/assets/javascripts/components/tree/tree-filter-input.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-filter-input.js
@@ -70,6 +70,14 @@
     template: template,
     viewModel: viewModel,
     events: {
+      'input keyup': function (el, ev) {
+        this.viewModel.onFilterChange(el.val());
+
+        if (ev.keyCode === 13) {
+          this.viewModel.submit();
+        }
+        ev.stopPropagation();
+      }
     }
   });
 })(window.can, window.GGRC);


### PR DESCRIPTION
Steps to reproduce:
1. On the audit page create at least 2 assessments
2. Type any query to find assessment (e.g. "CREATED DATE" =, <, > "xxx") and click enter button

Actual Result: Filter is not applied if click [enter] button after typing search query into search box
Expected Result: Filter should be applied if click [enter] button after typing search query into search box