### PR TITLE
GGRC-1906/2054/2055/2060 "Edit authorizations" link is not shown in 3 bb's menu

### DIFF
--- a/src/ggrc/assets/javascripts/components/unified-mapper/mapper-results.js
+++ b/src/ggrc/assets/javascripts/components/unified-mapper/mapper-results.js
@@ -231,7 +231,7 @@
           query = GGRC.Utils.Snapshots.transformQuery(query);
         }
         // Add Permission check
-        query.permissions = 'update';
+        query.permissions = (modelName === 'Person') ? 'read' : 'update';
         query.type = queryType || 'values';
 
         if (!relatedQuery) {

--- a/src/ggrc/assets/javascripts/components/unified-mapper/tests/mapper-results_spec.js
+++ b/src/ggrc/assets/javascripts/components/unified-mapper/tests/mapper-results_spec.js
@@ -503,6 +503,21 @@ describe('GGRC.Components.mapperResults', function () {
       }));
     });
 
+    it('sets "read" to permissions if model is person', function () {
+      var result;
+      viewModel.attr('type', 'Person');
+      spyOn(viewModel, 'useSnapshots')
+        .and.returnValue(false);
+      spyOn(viewModel, 'prepareBaseQuery')
+        .and.returnValue({mockData: 'basePagingSort'});
+      result = viewModel.getQuery('Person', true);
+      expect(result.data[0]).toEqual(jasmine.objectContaining({
+        mockData: 'basePagingSort',
+        permissions: 'read',
+        type: 'Person'
+      }));
+    });
+
     it('transform query to snapshot if useSnapshots is true', function () {
       var result;
       spyOn(viewModel, 'useSnapshots')

--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -1122,12 +1122,6 @@ Mustache.registerHelper('date', function (date, hideTime) {
         // Passed in the context object instead of the context ID, so use the ID
         contextId = contextId.id;
       }
-      //  When checking permission for changing person role,
-      //  context_id is in parentInstance
-      if (contextId === undefined && options.context &&
-      options.context.parentInstance) {
-        contextId = options.context.parentInstance.context_id;
-      }
       //  Using `context=null` in Mustache templates, when `null` is not defined,
       //  causes `context_id` to be `""`.
       if (contextId === '' || contextId === undefined) {

--- a/src/ggrc_basic_permissions/assets/mustache/ggrc_basic_permissions/people_roles/info.mustache
+++ b/src/ggrc_basic_permissions/assets/mustache/ggrc_basic_permissions/people_roles/info.mustache
@@ -17,8 +17,8 @@
         <span class="bubble"></span>
       </a>
       <ul class="dropdown-menu three-dots-list" aria-labelledby="drop1" role="menu">
-        {{#if_instance_of parentInstance 'Program|Audit'}}
-          {{#is_allowed 'create' 'delete' 'UserRole' context=options.parent_instance.context.id}}
+        {{#if_instance_of parentInstance 'Program|Audit|Workflow'}}
+          {{#is_allowed 'create' 'delete' 'UserRole' context=parentInstance.context.id}}
             {{#is_info_pin}}
               <li>
                 <a data-modal-class="modal-wide"


### PR DESCRIPTION
Steps to reproduce:
1. Create program
2. Go to people tab
3. Open Info pane for current user
4. Click on 3 bb's menu

Actual Result: "Edit authorizations" link is not shown in 3 bb's menu
Expected Result: "Edit authorizations" link is shown in 3 bb's menu

Relates to GGRC-2055, GGRC-2060, GGRC-2054