### PR TITLE
GGRC-1478 Related Assessment popup and table redesign

### DIFF
--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -173,6 +173,7 @@ dashboard-js-files:
   - components/object-popover/object-popover.js
   - components/mapped-objects/mapped-objects.js
   - components/related-objects/related-audits.js
+  - components/related-objects/related-attachments-and-urls.js
   - components/related-objects/related-assessment-item.js
   - components/related-objects/related-assessment-list.js
   - components/related-objects/related-comments.js

--- a/src/ggrc/assets/javascripts/components/object-popover/object-popover.js
+++ b/src/ggrc/assets/javascripts/components/object-popover/object-popover.js
@@ -18,6 +18,12 @@
     tag: tag,
     template: tpl,
     viewModel: {
+      define: {
+        hideTitle: {
+          type: Boolean,
+          value: false
+        }
+      },
       expanded: false,
       direction: 'left',
       maxInnerHeight: defaultMaxInnerHeight,

--- a/src/ggrc/assets/javascripts/components/object-popover/related-assessment-popover.js
+++ b/src/ggrc/assets/javascripts/components/object-popover/related-assessment-popover.js
@@ -18,6 +18,10 @@
       selectedAssessment: {},
       popoverTitleInfo: 'Assessment Title: ',
       define: {
+        hideTitle: {
+          type: Boolean,
+          value: false
+        },
         popoverDirection: {
           type: String,
           value: 'right'

--- a/src/ggrc/assets/javascripts/components/related-objects/related-attachments-and-urls.js
+++ b/src/ggrc/assets/javascripts/components/related-objects/related-attachments-and-urls.js
@@ -1,0 +1,40 @@
+/*!
+ Copyright (C) 2017 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+(function (can) {
+  'use strict';
+
+  /**
+   * Simple wrapper component for related attachments and urls
+   */
+  can.Component.extend({
+    tag: 'related-attachments-and-urls',
+    viewModel: {
+      define: {
+        noRelatedItemMessage: {
+          type: String,
+          value: function () {
+            return '';
+          }
+        },
+        emptyMessage: {
+          type: String,
+          value: function () {
+            return 'None';
+          }
+        },
+        loadingState: {},
+        showEmptyMessage: {
+          get: function () {
+            return !this.attr('loadingState.urlsLoading') &&
+              !this.attr('loadingState.attachmentsLoading') &&
+              !this.attr('urls.length') &&
+              !this.attr('attachments.length');
+          }
+        }
+      }
+    }
+  });
+})(window.can);

--- a/src/ggrc/assets/mustache/assessments/related-assessments-without-reuse.mustache
+++ b/src/ggrc/assets/mustache/assessments/related-assessments-without-reuse.mustache
@@ -7,6 +7,9 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
         <tree-pagination {(paging)}="paging" class="grid-data__toolbar-item"></tree-pagination>
     </div>
     <div class="grid-data-header flex-row flex-box">
+        <div class="flex-size-3">
+            Assessment Title
+        </div>
         <div class="grid-data-item-index">
             Assessment State
         </div>
@@ -23,10 +26,7 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
             Audit Title
         </div>
         <div class="flex-size-3">
-            Attachments
-        </div>
-        <div class="flex-size-3">
-            Urls
+            Attachments / Urls
         </div>
         <div class="grid-data__action-column">
             More info
@@ -41,6 +41,9 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                                       {item-selector}="objectSelectorEl" {empty-message}="noRelatedObjectsMessage" class="object-list__limited-height">
                 <related-assessment-item {^sub-items-loading}="itemLoading" class="{{#itemsLoading}}hidden{{/itemsLoading}}">
                     <div class="grid-data-row flex-row flex-box">
+                        <div class="flex-size-3">
+                            <a href="{{instance.viewLink}}" target="_blank" title="{{instance.title}}">{{instance.title}}</a>
+                        </div>
                         <div class="grid-data-item-index">
                             <state-colors-map {state}="instance.status"></state-colors-map>
                         </div>
@@ -72,28 +75,37 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                             </related-audits>
                         </div>
                         <div class="flex-size-3">
-                            <mapped-objects
-                                    {parent-instance}="instance"
-                                    mapping="all_documents"
-                                    {^is-loading}="loadingState.attachmentsLoading">
-                                <document-object-list-item {instance}="instance"></document-object-list-item>
-                            </mapped-objects>
-                        </div>
-                        <div class="flex-size-3">
-                            <mapped-objects
-                                    {parent-instance}="instance"
-                                    mapping="all_urls"
-                                    {^is-loading}="loadingState.urlsLoading">
-                                <document-object-list-item {instance}="instance"></document-object-list-item>
-                            </mapped-objects>
+                            <related-attachments-and-urls>
+                                <mapped-objects
+                                        {parent-instance}="instance"
+                                        mapping="all_documents"
+                                        {^is-loading}="loadingState.attachmentsLoading"
+                                        {empty-message}="noRelatedItemMessage"
+                                        {^show-items}="attachments">
+                                    <document-object-list-item {instance}="instance"></document-object-list-item>
+                                </mapped-objects>
+                                <mapped-objects
+                                        {parent-instance}="instance"
+                                        mapping="all_urls"
+                                        {^is-loading}="loadingState.urlsLoading"
+                                        {empty-message}="noRelatedItemMessage"
+                                        {^show-items}="urls">
+                                    <document-object-list-item {instance}="instance"></document-object-list-item>
+                                </mapped-objects>
+                                {{#if showEmptyMessage}}
+                                    <span class="empty-message">{{emptyMessage}}</span>
+                                {{/if}}
+                            </related-attachments-and-urls>
                         </div>
                         <div class="grid-data__action-column">
-                            <button class="btn btn-icon btn-icon-sm" title="Show More Information"><i class="fa fa-comment-o"></i></button>
+                            <button class="btn btn-icon btn-icon-sm" title="Show More Information"><i class="fa fa-info-circle"></i></button>
                         </div>
                     </div>
                 </related-assessment-item>
             </object-list>
         </related-assessment-list>
-        <related-assessment-popover class="object-popover related-assessments__object-popover" {selected-assessment}="selectedItem"></related-assessment-popover>
+        <related-assessment-popover class="object-popover related-assessments__object-popover"
+                                    {selected-assessment}="selectedItem" hide-title="true">
+        </related-assessment-popover>
     </div>
 </related-objects>

--- a/src/ggrc/assets/mustache/assessments/related-assessments.mustache
+++ b/src/ggrc/assets/mustache/assessments/related-assessments.mustache
@@ -11,6 +11,9 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
             {{/is_allowed}}
         </div>
         <div class="grid-data-header flex-row flex-box">
+            <div class="flex-size-3">
+                Assessment Title
+            </div>
             <div class="grid-data-item-index">
                 Assessment State
             </div>
@@ -27,10 +30,7 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                 Audit Title
             </div>
             <div class="flex-size-3">
-                Attachments
-            </div>
-            <div class="flex-size-3">
-                Urls
+                Attachments / Urls
             </div>
             <div class="grid-data__action-column">
                 More info
@@ -48,6 +48,9 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                     <related-assessment-item {^sub-items-loading}="itemLoading"
                                              class="{{#itemsLoading}}hidden{{/itemsLoading}}">
                         <div class="grid-data-row flex-row flex-box">
+                            <div class="flex-size-3">
+                                <a href="{{instance.viewLink}}" target="_blank" title="{{instance.title}}">{{instance.title}}</a>
+                            </div>
                             <div class="grid-data-item-index">
                                 <state-colors-map {state}="instance.status"></state-colors-map>
                             </div>
@@ -79,45 +82,52 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                                 </related-audits>
                             </div>
                             <div class="flex-size-3">
-                                <mapped-objects
-                                        {parent-instance}="instance"
-                                        mapping="all_documents"
-                                        {^is-loading}="loadingState.attachmentsLoading">
-                                    <reusable-objects-item {instance}="instance"
-                                                           {is-saving}="isSaving"
-                                                           {base-instance}="baseInstance"
-                                                           {mapping}="mapping"
-                                                           {check-reused-status}="checkReusedStatus"
-                                                           {(selected-list)}="evidenceList">
-                                        <document-object-list-item {instance}="instance"></document-object-list-item>
-                                    </reusable-objects-item>
-                                </mapped-objects>
-                            </div>
-                            <div class="flex-size-3">
-                                <mapped-objects
-                                        {parent-instance}="instance"
-                                        mapping="all_urls"
-                                        {^is-loading}="loadingState.urlsLoading">
-                                    <reusable-objects-item {instance}="instance"
-                                                           {is-saving}="isSaving"
-                                                           {base-instance}="baseInstance"
-                                                           {mapping}="mapping"
-                                                           check-reused-status="checkReusedStatus"
-                                                           {(selected-list)}="urlList">
-                                        <document-object-list-item {instance}="instance"></document-object-list-item>
-                                    </reusable-objects-item>
-                                </mapped-objects>
+                                <related-attachments-and-urls>
+                                    <mapped-objects
+                                            {parent-instance}="instance"
+                                            mapping="all_documents"
+                                            {^is-loading}="loadingState.attachmentsLoading"
+                                            {empty-message}="noRelatedItemMessage"
+                                            {^show-items}="attachments">
+                                        <reusable-objects-item {instance}="instance"
+                                                               {is-saving}="isSaving"
+                                                               {base-instance}="baseInstance"
+                                                               {mapping}="mapping"
+                                                               {check-reused-status}="checkReusedStatus"
+                                                               {(selected-list)}="evidenceList">
+                                            <document-object-list-item {instance}="instance"></document-object-list-item>
+                                        </reusable-objects-item>
+                                    </mapped-objects>
+                                    <mapped-objects
+                                            {parent-instance}="instance"
+                                            mapping="all_urls"
+                                            {^is-loading}="loadingState.urlsLoading"
+                                            {empty-message}="noRelatedItemMessage"
+                                            {^show-items}="urls">
+                                        <reusable-objects-item {instance}="instance"
+                                                               {is-saving}="isSaving"
+                                                               {base-instance}="baseInstance"
+                                                               {mapping}="mapping"
+                                                               check-reused-status="checkReusedStatus"
+                                                               {(selected-list)}="urlList">
+                                            <document-object-list-item {instance}="instance"></document-object-list-item>
+                                        </reusable-objects-item>
+                                    </mapped-objects>
+                                    {{#if showEmptyMessage}}
+                                        <span class="empty-message">{{emptyMessage}}</span>
+                                    {{/if}}
+                                </related-attachments-and-urls>
                             </div>
                             <div class="grid-data__action-column">
                                 <button class="btn btn-icon btn-icon-sm" title="Show More Information"><i
-                                        class="fa fa-comment-o"></i></button>
+                                        class="fa fa-info-circle"></i></button>
                             </div>
                         </div>
                     </related-assessment-item>
                 </object-list>
             </related-assessment-list>
             <related-assessment-popover class="object-popover related-assessments__object-popover"
-                                        {selected-assessment}="selectedItem"></related-assessment-popover>
+                                        {selected-assessment}="selectedItem" hide-title="true"></related-assessment-popover>
         </div>
     </reusable-objects-list>
 </related-objects>

--- a/src/ggrc/assets/mustache/components/object-popover/object-popover.mustache
+++ b/src/ggrc/assets/mustache/components/object-popover/object-popover.mustache
@@ -5,9 +5,11 @@
 {{#if isActive}}
 <div class="object-popover-wrapper active" style="{{openStyle}}">
     <div class="object-popover-body">
-        <div class="object-popover-title">
-          {{popoverTitleInfo}}<a href="{{popoverLink}}" target="_blank" title="{{popoverTitle}}">{{popoverTitle}}</a>
-        </div>
+        {{^hideTitle}}
+            <div class="object-popover-title">
+              {{popoverTitleInfo}}<a href="{{popoverLink}}" target="_blank" title="{{popoverTitle}}">{{popoverTitle}}</a>
+            </div>
+        {{/hideTitle}}
         <div class="object-popover-content flex-box flex-col flex-box-single" style="max-height: {{maxInnerHeight}}px;">
           <content>No Component or Template is provided</content>
         </div>

--- a/src/ggrc/assets/mustache/components/object-popover/related-assessment-popover.mustache
+++ b/src/ggrc/assets/mustache/components/object-popover/related-assessment-popover.mustache
@@ -4,7 +4,8 @@
 }}
 
 <object-popover {item}="selectedAssessment" {popover-title}="selectedAssessmentTitle" {direction}="popoverDirection"
-                {popover-link}="selectedAssessmentLink" {popover-title-info}="popoverTitleInfo">
+                {popover-link}="selectedAssessmentLink" {popover-title-info}="popoverTitleInfo"
+                {hide-title}="hideTitle">
     <tab-container class="related-assessments__tab-container">
         <tab-panel {(panels)}="panels" title-text="Attributes">
             <div class="fields-wrapper flex-box flex-row">

--- a/src/ggrc/assets/stylesheets/components/object-popover/_object-popover.scss
+++ b/src/ggrc/assets/stylesheets/components/object-popover/_object-popover.scss
@@ -21,7 +21,7 @@
       opacity: 1;
     }
 
-    > .object-popover-body {
+    > .object-popover-title + .object-popover-body {
       padding: 16px 0 0;
       box-sizing: border-box;
       display: flex;


### PR DESCRIPTION
1. insert Assessment Title column as first one in related assessment modal
2. Attachment and URL - move into one column,
3. replace MoreInfo icon with an appropriate one.
![image](https://cloud.githubusercontent.com/assets/24203972/25771531/01055b44-325d-11e7-9849-41860ad52016.png)
