### PR TITLE
GGRC-1845 Local Custom Attributes after Assessment generation are displayed out of order in Assessment's Info pane

### DIFF
--- a/src/ggrc/models/mixins/customattributable.py
+++ b/src/ggrc/models/mixins/customattributable.py
@@ -55,6 +55,8 @@ class CustomAttributable(object):
         "CustomAttributeDefinition",
         primaryjoin=join_function,
         backref='{0}_custom_attributable_definition'.format(self.__name__),
+        order_by=(CustomAttributeDefinition.definition_id.desc(),
+                  CustomAttributeDefinition.id.asc()),
         viewonly=True,
     )
 

--- a/test/integration/ggrc/models/test_assessment.py
+++ b/test/integration/ggrc/models/test_assessment.py
@@ -185,3 +185,58 @@ class TestAssessmentGeneration(TestCase):
     response = self.assessment_post(template)
     self.assertEqual(response.json["assessment"]["test_plan"],
                      test_plan)
+
+  def test_ca_order(self):
+    """Test LCA/GCA order in Assessment"""
+    template = factories.AssessmentTemplateFactory(
+        test_plan_procedure=False,
+        procedure_description="Assessment Template Test Plan"
+    )
+
+    custom_attribute_definitions = [
+        # Global CAs
+        {
+            "definition_type": "assessment",
+            "title": "rich_test_gca",
+            "attribute_type": "Rich Text",
+            "multi_choice_options": ""
+        },
+        {
+            "definition_type": "assessment",
+            "title": "checkbox1_gca",
+            "attribute_type": "Checkbox",
+            "multi_choice_options": "test checkbox label"
+        },
+        # Local CAs
+        {
+            "definition_type": "assessment_template",
+            "definition_id": template.id,
+            "title": "test text field",
+            "attribute_type": "Text",
+            "multi_choice_options": ""
+        },
+        {
+            "definition_type": "assessment_template",
+            "definition_id": template.id,
+            "title": "test RTF",
+            "attribute_type": "Rich Text",
+            "multi_choice_options": ""
+        },
+        {
+            "definition_type": "assessment_template",
+            "definition_id": template.id,
+            "title": "test checkbox",
+            "attribute_type": "Checkbox",
+            "multi_choice_options": "test checkbox label"
+        },
+    ]
+
+    for attribute in custom_attribute_definitions:
+      factories.CustomAttributeDefinitionFactory(**attribute)
+    response = self.assessment_post(template)
+    self.assertListEqual(
+        [u'test text field', u'test RTF', u'test checkbox', u'rich_test_gca',
+         u'checkbox1_gca'],
+        [cad['title'] for cad in
+         response.json["assessment"]["custom_attribute_definitions"]]
+    )


### PR DESCRIPTION
local and global custom attributes
order - the way as it was submitted
it shouldn't be alphabetical order - it should be how admin create on dashboard
local - in order they were cerated
first local then global
—
assessment template order - should be supported
will affect new assessments - and will not affect existing assessments