### PR TITLE
GGRC-2113 GC as Auditor in Audit and doesn't see Audit in Global Search

### DIFF
--- a/src/ggrc/assets/javascripts/components/unified-mapper/mapper-results.js
+++ b/src/ggrc/assets/javascripts/components/unified-mapper/mapper-results.js
@@ -231,7 +231,8 @@
           query = GGRC.Utils.Snapshots.transformQuery(query);
         }
         // Add Permission check
-        query.permissions = (modelName === 'Person') ? 'read' : 'update';
+        query.permissions = (modelName === 'Person') || this.searchOnly() ?
+          'read' : 'update';
         query.type = queryType || 'values';
 
         if (!relatedQuery) {

--- a/src/ggrc/assets/javascripts/components/unified-mapper/tests/mapper-results_spec.js
+++ b/src/ggrc/assets/javascripts/components/unified-mapper/tests/mapper-results_spec.js
@@ -536,6 +536,18 @@ describe('GGRC.Components.mapperResults', function () {
         mockData: 'snapshot'
       }));
     });
+
+    it('set "read" permission if "search_only"', function () {
+      var result;
+      spyOn(viewModel, 'searchOnly')
+        .and.returnValue(true);
+      spyOn(viewModel, 'prepareBaseQuery')
+        .and.returnValue({mockData: 'base'});
+      result = viewModel.getQuery();
+      expect(result.data[0]).toEqual(jasmine.objectContaining({
+        permissions: 'read'
+      }));
+    });
   });
 
   describe('getModelKey() method', function () {


### PR DESCRIPTION
_Steps to reproduce_:
1. Create program and add GC (globcreator@gmail.com (engage007) to program with "no role" role
2. Create audit
3. Create assessment on the audit page and add GC as assignee to assessment
4. Log as GC (globcreator@gmail.com (engage007) and open Global search
5. Insert audit's title into Filter box and click Search: no result

_Actual Result_: GC as Assignee in Assessment and no role in program doesn't see Audit in Global Search
_Expected Result_: GC as Assignee in Assessment and no role in program should see Audit in Global Search

![screenshot-1](https://cloud.githubusercontent.com/assets/4204416/25991321/6f22436e-370b-11e7-82c5-0504af50f0d5.png)

**Comment from @pod2metra** : "In global search send request that filter objects only with "update" permission, but it should filter them by "read" permission."
