### PR TITLE
GGRC-1594 Keep sending task overdue notifications until done

### DIFF
--- a/src/ggrc/models/notification.py
+++ b/src/ggrc/models/notification.py
@@ -52,6 +52,7 @@ class Notification(Base, db.Model):
   sent_at = db.Column(db.DateTime, nullable=True)
   custom_message = db.Column(db.Text, nullable=True)
   force_notifications = db.Column(db.Boolean, default=False, nullable=False)
+  repeating = db.Column(db.Boolean, nullable=False, default=False)
   notification_type_id = db.Column(
       db.Integer, db.ForeignKey('notification_types.id'), nullable=False)
   notification_type = db.relationship(

--- a/src/ggrc/notifications/notification_handlers.py
+++ b/src/ggrc/notifications/notification_handlers.py
@@ -22,6 +22,7 @@ from enum import Enum
 
 from sqlalchemy import inspect
 from sqlalchemy import and_
+from sqlalchemy.sql.expression import true
 
 from ggrc import db
 from ggrc.services import signals
@@ -72,12 +73,14 @@ def _has_unsent_notifications(notif_type, obj):
     True if there are any unsent notifications of notif_type for the given
     object, and False otherwise.
   """
+  Notification = models.Notification  # pylint: disable=invalid-name
+
   return db.session.query(models.Notification).join(
       models.NotificationType).filter(and_(
           models.NotificationType.id == notif_type.id,
-          models.Notification.object_id == obj.id,
-          models.Notification.object_type == obj.type,
-          models.Notification.sent_at.is_(None),
+          Notification.object_id == obj.id,
+          Notification.object_type == obj.type,
+          (Notification.sent_at.is_(None) | (Notification.repeating == true()))
       )).count() > 0
 
 

--- a/src/ggrc/templates/notifications/email_digest_content.html
+++ b/src/ggrc/templates/notifications/email_digest_content.html
@@ -97,6 +97,35 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                   </ul>
                 {% endif %}
 
+                {% if digest['task_overdue'] %}
+                  <h2 {{ style.sub_title() }} >
+                    The following tasks are overdue, please finish ASAP:
+                  </h2>
+                  <ul {{ style.list_wrap() }} >
+                  {% for task in digest['task_overdue'].itervalues() %}
+                    <li {{ style.list_item() }} >
+                      <a
+                        href="{{ task['cycle_task_url'] }}"
+                        {{ style.link_text() }}>{{ task['title'] }}</a>
+                        under
+                      <a
+                        href="{{ task['task_group_url'] }}"
+                        {{ style.link_text() }}>{{ task['task_group'].title }}</a>
+                        of
+                      <a
+                        href="{{ task['workflow_cycle_url'] }}"
+                        {{ style.link_text() }}>{{ task['workflow'].title }}</a>
+                      ({{ task['due_date_statement'] }})
+                      <ul>
+                      {% for related_object_title in task['related_objects'] %}
+                        <li>{{ "%s" % related_object_title if related_object_title }}</li>
+                      {% endfor %}
+                      </ul>
+                    </li>
+                  {% endfor %}
+                  </ul>
+                {% endif %}
+
                 {% if digest['cycle_started'] %}
                   <h2 {{ style.sub_title() }} >New workflow
                     {{ "cycles" if digest['cycle_started']|length > 1 else "cycle" }}

--- a/src/ggrc_workflows/migrations/versions/20170522102213_30ea07e9d452_add_task_overdue_notifications.py
+++ b/src/ggrc_workflows/migrations/versions/20170522102213_30ea07e9d452_add_task_overdue_notifications.py
@@ -1,0 +1,139 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Add task overdue notification type
+
+Create Date: 2017-05-04 09:03:39.661039
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+from datetime import datetime, timedelta
+
+from alembic import op
+
+import sqlalchemy as sa
+from sqlalchemy import Boolean, DateTime, Integer, String, Text
+from sqlalchemy.sql import column, table
+
+
+# revision identifiers, used by Alembic.
+revision = '30ea07e9d452'
+down_revision = '1142135ce819'
+
+_NOTIFICATION_TYPES_TABLE = table(
+    "notification_types",
+    column("name", String),
+    column("description", String),
+    column("template", String),
+    column("advance_notice", Integer),
+    column("instant", Boolean),
+    column("repeating", Boolean),
+    column("created_at", DateTime),
+    column("updated_at", DateTime),
+)
+
+_NOTIFICATIONS_TABLE = table(
+    "notifications",
+    column("object_id", Integer),
+    column("object_type", String),
+    column("notification_type_id", Integer),
+    column("send_on", DateTime),
+    column("sent_at", DateTime),
+    column("custom_message", Text),
+    column("force_notifications", Boolean),
+    column("created_at", DateTime),
+    column("modified_by_id", Integer),
+    column("updated_at", DateTime),
+    column("context_id", Integer),
+    column("repeating", Boolean),
+)
+
+_NOW = datetime.utcnow()
+
+_NOTIFICATION_TYPES = [{
+    "name": "cycle_task_overdue",
+    "description": (
+        u"Notify a task assignee that a task is overdue."
+    ),
+    "template": "cycle_task_overdue",
+    "advance_notice": 0,
+    "instant": False,
+    "created_at": _NOW,
+    "updated_at": _NOW,
+}]
+
+
+def upgrade():
+  """Add new Workflow Task notification type and a new flag column.
+
+  Also create overdue notification records for all existing active Tasks.
+  """
+  op.add_column(
+      "notifications",
+      sa.Column("repeating", sa.Boolean(), nullable=False, default=False)
+  )
+
+  op.bulk_insert(
+      _NOTIFICATION_TYPES_TABLE,
+      _NOTIFICATION_TYPES
+  )
+
+  # schedule overdue notifications for all currently active tasks
+  conn = op.get_bind()
+
+  sql = "SELECT id FROM notification_types WHERE name = 'cycle_task_overdue';"
+  overdue_type_id = conn.execute(sql).scalar()  # never None here
+
+  sql = """
+      SELECT ct.id AS task_id, ct.end_date
+      FROM cycle_task_group_object_tasks AS ct
+      LEFT JOIN cycles AS c ON
+          ct.cycle_id = c.id
+      WHERE
+          c.is_current = 1 AND ct.status != "Verified";
+  """
+
+  active_tasks = conn.execute(sql).fetchall()
+  overdue_notifs = [
+      {
+          "object_id": task[0],
+          "object_type": "CycleTaskGroupObjectTask",
+          "notification_type_id": overdue_type_id,
+          "send_on": (task[1] + timedelta(1)).isoformat(),
+          "force_notifications": 0,  # not applicable to overdue notifications
+          "created_at": _NOW,
+          "updated_at": _NOW,
+          "repeating": 1,
+      }
+      for task in active_tasks
+  ]
+
+  op.bulk_insert(_NOTIFICATIONS_TABLE, overdue_notifs)
+
+
+def downgrade():
+  """Remove Task overdue notification type and the `repeating` column.
+
+  All notifications of the deleted notification type get deleted as well.
+  """
+  sql = """
+      DELETE n
+      FROM notifications AS n
+      LEFT JOIN notification_types AS nt ON
+          n.notification_type_id = nt.id
+      WHERE
+          nt.name = "cycle_task_overdue"
+  """
+
+  op.execute(sql)
+
+  sql = _NOTIFICATION_TYPES_TABLE.delete().where(
+      _NOTIFICATION_TYPES_TABLE.c.name == "cycle_task_overdue"
+  )
+  op.execute(sql)
+
+  op.drop_column("notifications", "repeating")

--- a/src/ggrc_workflows/notification/notification_handler.py
+++ b/src/ggrc_workflows/notification/notification_handler.py
@@ -22,6 +22,7 @@ from datetime import date
 from sqlalchemy import and_
 from sqlalchemy import or_
 from sqlalchemy import inspect
+from sqlalchemy.sql.expression import true
 
 from ggrc import db
 from ggrc.models.notification import Notification
@@ -124,7 +125,10 @@ def modify_cycle_task_notification(obj, notification_name):
       .join(NotificationType)\
       .filter(and_(Notification.object_id == obj.id,
                    Notification.object_type == obj.type,
-                   Notification.sent_at == None,  # noqa
+                   or_(
+                       Notification.sent_at.is_(None),
+                       Notification.repeating == true()
+                   ),
                    NotificationType.name == notification_name,
                    ))
   notif_type = get_notification_type(notification_name)
@@ -217,7 +221,11 @@ def get_notification(obj):
   result = Notification.query.filter(
       and_(Notification.object_id == obj.id,
            Notification.object_type == obj.type,
-           Notification.sent_at == None))  # noqa
+           or_(
+               Notification.sent_at.is_(None),
+               Notification.repeating == true())
+           )
+  )
   return result.all()
 
 

--- a/test/integration/ggrc_workflows/notifications/test_task_overdue_notifications.py
+++ b/test/integration/ggrc_workflows/notifications/test_task_overdue_notifications.py
@@ -1,0 +1,345 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Integration tests for sending the notifications about overdue WF tasks."""
+
+import functools
+
+from collections import OrderedDict
+from datetime import date, datetime
+from os.path import abspath, dirname, join
+
+from freezegun import freeze_time
+from mock import patch
+
+from ggrc import db, models
+from ggrc.notifications import common
+from ggrc_workflows.models import CycleTaskGroupObjectTask, Workflow
+
+from integration.ggrc import TestCase
+from integration.ggrc_workflows.generator import WorkflowsGenerator
+from integration.ggrc.api_helper import Api
+from integration.ggrc.generator import ObjectGenerator
+
+
+class TestTaskOverdueNotifications(TestCase):
+  """Base class for task overdue notifications test suite."""
+
+  def _fix_notification_init(self):
+    """Fix Notification object init function.
+
+    This is a fix needed for correct created_at field when using freezgun. By
+    default the created_at field is left empty and filed by database, which
+    uses system time and not the fake date set by freezugun plugin. This fix
+    makes sure that object created in freeze_time block has all dates set with
+    the correct date and time.
+    """
+    def init_decorator(init):
+      """"Adjust the value of the object's created_at attribute to now."""
+      @functools.wraps(init)
+      def new_init(self, *args, **kwargs):
+        init(self, *args, **kwargs)
+        if hasattr(self, "created_at"):
+          self.created_at = datetime.now()
+      return new_init
+
+    models.Notification.__init__ = init_decorator(models.Notification.__init__)
+
+
+class TestTaskOverdueNotificationsUsingAPI(TestTaskOverdueNotifications):
+  """Tests for overdue notifications when changing Tasks with an API."""
+
+  # pylint: disable=invalid-name
+
+  def setUp(self):
+    super(TestTaskOverdueNotificationsUsingAPI, self).setUp()
+    self.api = Api()
+    self.wf_generator = WorkflowsGenerator()
+    self.object_generator = ObjectGenerator()
+    models.Notification.query.delete()
+
+    self._fix_notification_init()
+
+    self.random_objects = self.object_generator.generate_random_objects(2)
+    _, self.user = self.object_generator.generate_person(
+        user_role="Administrator")
+    self._create_test_cases()
+
+  @patch("ggrc.notifications.common.send_email")
+  def test_sending_overdue_notifications_for_tasks(self, _):
+    """Overdue notifications should be sent for overdue tasks every day.
+
+    Even if an overdue notification has already been sent, it should still be
+    sent in every following daily digest f a task is still overdue.
+    """
+    with freeze_time("2017-05-15 14:25:36"):
+      _, workflow = self.wf_generator.generate_workflow(self.one_time_workflow)
+      self.wf_generator.generate_cycle(workflow)
+      response, workflow = self.wf_generator.activate_workflow(workflow)
+      self.assert200(response)
+
+    tasks = workflow.cycles[0].cycle_task_group_object_tasks
+    task1_id = tasks[0].id
+    task2_id = tasks[1].id
+
+    user = models.Person.query.get(self.user.id)
+
+    with freeze_time("2017-05-14 08:09:10"):
+      _, notif_data = common.get_daily_notifications()
+      user_notifs = notif_data.get(user.email, {})
+      self.assertNotIn("task_overdue", user_notifs)
+
+    with freeze_time("2017-05-15 08:09:10"):  # task 1 due date
+      _, notif_data = common.get_daily_notifications()
+      user_notifs = notif_data.get(user.email, {})
+      self.assertNotIn("task_overdue", user_notifs)
+
+    with freeze_time("2017-05-16 08:09:10"):  # task 2 due date
+      _, notif_data = common.get_daily_notifications()
+      user_notifs = notif_data.get(user.email, {})
+      self.assertIn("task_overdue", user_notifs)
+
+      overdue_task_ids = sorted(user_notifs["task_overdue"].keys())
+      self.assertEqual(overdue_task_ids, [task1_id])
+
+    with freeze_time("2017-05-17 08:09:10"):  # after both tasks' due dates
+      _, notif_data = common.get_daily_notifications()
+      user_notifs = notif_data.get(user.email, {})
+      self.assertIn("task_overdue", user_notifs)
+
+      overdue_task_ids = sorted(user_notifs["task_overdue"].keys())
+      self.assertEqual(overdue_task_ids, [task1_id, task2_id])
+
+      common.send_daily_digest_notifications()
+
+    # even after sending the overdue notifications, they are sent again the
+    # day after, too
+    with freeze_time("2017-05-18 08:09:10"):
+      _, notif_data = common.get_daily_notifications()
+      user_notifs = notif_data.get(user.email, {})
+      self.assertIn("task_overdue", user_notifs)
+
+      overdue_task_ids = sorted(user_notifs["task_overdue"].keys())
+      self.assertEqual(overdue_task_ids, [task1_id, task2_id])
+
+  @patch("ggrc.notifications.common.send_email")
+  def test_adjust_overdue_notifications_on_task_due_date_change(self, _):
+    """Sending overdue notifications should adjust to task due date changes."""
+    with freeze_time("2017-05-15 14:25:36"):
+      _, workflow = self.wf_generator.generate_workflow(self.one_time_workflow)
+      self.wf_generator.generate_cycle(workflow)
+      response, workflow = self.wf_generator.activate_workflow(workflow)
+      self.assert200(response)
+
+    tasks = workflow.cycles[0].cycle_task_group_object_tasks
+    task1, task2 = tasks
+    self.wf_generator.modify_object(task2, {"end_date": date(2099, 12, 31)})
+
+    user = models.Person.query.get(self.user.id)
+
+    with freeze_time("2017-05-16 08:09:10"):  # a day after task1 due date
+      _, notif_data = common.get_daily_notifications()
+      user_notifs = notif_data.get(user.email, {})
+      self.assertIn("task_overdue", user_notifs)
+      self.assertEqual(len(user_notifs["task_overdue"]), 1)
+
+      # change task1 due date, there should be no overdue notification anymore
+      self.wf_generator.modify_object(task1, {"end_date": date(2017, 5, 16)})
+      _, notif_data = common.get_daily_notifications()
+      user_notifs = notif_data.get(user.email, {})
+      self.assertNotIn("task_overdue", user_notifs)
+
+      # change task1 due date to the past there should a notification again
+      self.wf_generator.modify_object(task1, {"end_date": date(2017, 5, 14)})
+      _, notif_data = common.get_daily_notifications()
+      user_notifs = notif_data.get(user.email, {})
+      self.assertIn("task_overdue", user_notifs)
+      self.assertEqual(len(user_notifs["task_overdue"]), 1)
+
+  @patch("ggrc.notifications.common.send_email")
+  def test_adjust_overdue_notifications_on_task_status_change(self, _):
+    """Sending overdue notifications should take task status into account."""
+    with freeze_time("2017-05-15 14:25:36"):
+      _, workflow = self.wf_generator.generate_workflow(self.one_time_workflow)
+      self.wf_generator.generate_cycle(workflow)
+      response, workflow = self.wf_generator.activate_workflow(workflow)
+      self.assert200(response)
+
+    tasks = workflow.cycles[0].cycle_task_group_object_tasks
+    task1, task2 = tasks
+    self.wf_generator.modify_object(task2, {"end_date": date(2099, 12, 31)})
+
+    user = models.Person.query.get(self.user.id)
+    user_email = user.email
+
+    with freeze_time("2017-05-16 08:09:10"):  # a day after task1 due date
+      for state in CycleTaskGroupObjectTask.ACTIVE_STATES:
+        # clear all notifications before before changing the task status
+        models.Notification.query.delete()
+        _, notif_data = common.get_daily_notifications()
+        self.assertEqual(notif_data, {})
+
+        self.wf_generator.modify_object(task1, {"status": state})
+
+        _, notif_data = common.get_daily_notifications()
+        user_notifs = notif_data.get(user_email, {})
+        self.assertIn("task_overdue", user_notifs)
+        self.assertEqual(len(user_notifs["task_overdue"]), 1)
+
+      # WITHOUT clearing the overdue notifications, move the task to "verified"
+      # state, and the overdue notification should disappear.
+      self.wf_generator.modify_object(task1, {"status": "Verified"})
+      _, notif_data = common.get_daily_notifications()
+      user_notifs = notif_data.get(user_email, {})
+      self.assertNotIn("task_overdue", user_notifs)
+
+  @patch("ggrc.notifications.common.send_email")
+  def test_stop_sending_overdue_notification_if_task_gets_deleted(self, _):
+    """Overdue notifications should not be sent for deleted tasks."""
+    with freeze_time("2017-05-15 14:25:36"):
+      _, workflow = self.wf_generator.generate_workflow(self.one_time_workflow)
+      self.wf_generator.generate_cycle(workflow)
+      response, workflow = self.wf_generator.activate_workflow(workflow)
+      self.assert200(response)
+
+    tasks = workflow.cycles[0].cycle_task_group_object_tasks
+    task1, task2 = tasks
+
+    user = models.Person.query.get(self.user.id)
+    user_email = user.email
+
+    with freeze_time("2017-10-16 08:09:10"):  # long after both task due dates
+      _, notif_data = common.get_daily_notifications()
+      user_notifs = notif_data.get(user_email, {})
+      self.assertIn("task_overdue", user_notifs)
+      self.assertEqual(len(user_notifs["task_overdue"]), 2)
+
+      db.session.delete(task2)
+      db.session.commit()
+
+      _, notif_data = common.get_daily_notifications()
+      user_notifs = notif_data.get(user_email, {})
+      self.assertIn("task_overdue", user_notifs)
+      self.assertEqual(len(user_notifs["task_overdue"]), 1)
+
+      db.session.delete(task1)
+      db.session.commit()
+
+      _, notif_data = common.get_daily_notifications()
+      user_notifs = notif_data.get(user.email, {})
+      self.assertNotIn("task_overdue", user_notifs)
+
+  def _create_test_cases(self):
+    """Create configuration to use for generating a new workflow."""
+    def person_dict(person_id):
+      return {
+          "href": "/api/people/" + str(person_id),
+          "id": person_id,
+          "type": "Person"
+      }
+
+    self.one_time_workflow = {
+        "title": "one time test workflow",
+        "notify_on_change": True,
+        "description": "some test workflow",
+        "owners": [person_dict(self.user.id)],
+        "task_groups": [{
+            "title": "one time task group",
+            "contact": person_dict(self.user.id),
+            "task_group_tasks": [{
+                "title": "task 1",
+                "description": "some task",
+                "contact": person_dict(self.user.id),
+                "start_date": date(2017, 5, 5),  # Friday
+                "end_date": date(2017, 5, 15),
+            }, {
+                "title": "task 2",
+                "description": "some task 2",
+                "contact": person_dict(self.user.id),
+                "start_date": date(2017, 5, 5),  # Friday
+                "end_date": date(2017, 5, 16),
+            }],
+            "task_group_objects": self.random_objects
+        }]
+    }
+
+
+class TestTaskOverdueNotificationsUsingImports(TestTaskOverdueNotifications):
+  """Tests for overdue notifications when changing Tasks via imports."""
+
+  # pylint: disable=invalid-name
+
+  CSV_DIR = join(abspath(dirname(__file__)), "../converters/test_csvs/")
+
+  def setUp(self):
+    self.wf_generator = WorkflowsGenerator()
+    self._fix_notification_init()
+
+  @patch("ggrc.notifications.common.send_email")
+  def test_creating_overdue_notifications_for_new_tasks(self, _):
+    """Overdue notifications should be created for tasks created with imports.
+    """
+    Workflow.query.delete()
+    models.Notification.query.delete()
+    db.session.commit()
+
+    filename = join(self.CSV_DIR, "workflow_small_sheet.csv")
+    response = self.import_file(filename)
+    self._check_csv_response(response, expected_messages={})
+
+    workflow = Workflow.query.one()
+    self.wf_generator.generate_cycle(workflow)
+    response, workflow = self.wf_generator.activate_workflow(workflow)
+
+    user = models.Person.query.filter(
+        models.Person.email == 'user1@ggrc.com').one()
+
+    with freeze_time("2020-01-01 00:00:00"):  # afer all tasks' due dates
+      _, notif_data = common.get_daily_notifications()
+      user_notifs = notif_data.get(user.email, {})
+      self.assertIn("task_overdue", user_notifs)
+      self.assertEqual(len(user_notifs["task_overdue"]), 4)
+
+  @patch("ggrc.notifications.common.send_email")
+  def test_overdue_notifications_when_task_due_date_is_changed(self, _):
+    """Overdue notifications should adjust to task due date changes."""
+    Workflow.query.delete()
+    models.Notification.query.delete()
+    db.session.commit()
+
+    filename = join(self.CSV_DIR, "workflow_small_sheet.csv")
+    response = self.import_file(filename)
+    self._check_csv_response(response, expected_messages={})
+
+    workflow = Workflow.query.one()
+    self.wf_generator.generate_cycle(workflow)
+    response, workflow = self.wf_generator.activate_workflow(workflow)
+
+    user = models.Person.query.filter(
+        models.Person.email == 'user1@ggrc.com').one()
+
+    with freeze_time("2015-01-01 00:00:00"):  # before all tasks' due dates
+      _, notif_data = common.get_daily_notifications()
+      user_notifs = notif_data.get(user.email, {})
+      self.assertNotIn("task_overdue", user_notifs)
+
+      # now modify task's due date and check if overdue notification appears
+      task = CycleTaskGroupObjectTask.query.filter(
+          CycleTaskGroupObjectTask.title == "task for wf-2").one()
+      task_id, task_code = task.id, task.slug
+
+      response = self.import_data(OrderedDict((
+          ("object_type", "CycleTask"),
+          ("Code*", task_code),
+          ("Start Date", "12/15/2014"),
+          ("Due Date", "12/31/2014"),
+      )))
+      self._check_csv_response(response, expected_messages={})
+
+      _, notif_data = common.get_daily_notifications()
+      user_notifs = notif_data.get(user.email, {})
+      self.assertIn("task_overdue", user_notifs)
+      self.assertEqual(len(user_notifs["task_overdue"]), 1)
+      self.assertIn(task_id, user_notifs["task_overdue"])


### PR DESCRIPTION
NOTE: It seems that the ticket [GGRC-1594](https://gojira.corp.google.com/browse/GGRC-1594) also covers tickets [GGRC-1600](https://gojira.corp.google.com/browse/GGRC-1600) and [GGRC-1601](https://gojira.corp.google.com/browse/GGRC-1601).

---

This PR changes the behavior of Workflow Task overdue notifications - the latter are now sent in every day (in the daily digest) until a task is complete (i.e. Verified), and not just on the day when a task becomes overdue.

Two related Jira tickets are `GGRC-1600` and `GGRC-1601`, and they are also handled in the scope of this PR, since `GGRC-1594` essentially covers them, too.

NOTE: The Jira ticket descriptions are kind of incomplete/obsolete, I asked the QA team to check all the points below, and then update the ticket descriptions as necessary.

---

To test, one should define a Workflow and some tasks in it, activate it and then make sure that some of the tasks are overdue, i.e. their Due Date should be be _strictly_ smaller than the current date. For these overdue tasks, there should be a section in the daily digest email (`/_notifications/show_daily_digest`).

A few things to keep in mind:
- A task overdue notification is not sent until a task becomes overdue (i.e. on the first day _after_ the task's due date). The same notification is also sent on every day that follows, indefinitely, until a task gets completed or deleted.
To test, try sending the daily digest (`/_notifications/send_daily_digest`), and the overdue notificaitons should still be present in daily digests.
- If a task's Due Date is modified, this is reflected in the overdue notifications. If a task is not overdue anymore, there should be no overdue notification for it anymore, too. Similar reasoning is applied if a task suddenly becomes overdue.
- Overdue notifications are sent for all overdue tasks that are in one of the active states. The only inactive state at the time of writing is `Verified` (BTW, the `Finished` state is considered active!). The notifications of course react to task's status changes.
- If a task gets deleted, the corresponding overdue notifications should get removed as well.
- All the behavior described above is applicable to task modifications via imports, too.
(NOTE: There are some issues with the Assessment change notifications on imports due to a bug in the imports module, and maybe the same will be observed with the overdue notifications, too. If this happens, we will discuss whether to address that in this PR or maybe some other, e.g. #5629 )

Things left to do:
- [x] Add overdue notifications for all existing and active WF tasks as a part of the DB migration step.
- [x] Code cleanup, docstrings
- [x] Tests for notifications when using the imports to manipulate tasks
