### PR TITLE
GGRC-1523 Default columns for assessment tree view

### DIFF
--- a/src/ggrc/assets/javascripts/models/assessment.js
+++ b/src/ggrc/assets/javascripts/models/assessment.js
@@ -92,7 +92,9 @@
         attr_title: 'Created Date',
         attr_name: 'created_at',
         order: 8
-      }]
+      }],
+      display_attr_names: ['title', 'status', 'assignees', 'verifiers',
+        'updated_at']
     },
     info_pane_options: {
       evidence: {

--- a/src/ggrc/assets/javascripts/plugins/utils/tree-view-utils.js
+++ b/src/ggrc/assets/javascripts/plugins/utils/tree-view-utils.js
@@ -176,10 +176,6 @@
         displayAttrNames.push('end_date');
       }
 
-      if (!savedAttrList.length && CurrentPage.isMyAssessments()) {
-        displayAttrNames.push('assignees', 'verifiers', 'updated_at');
-      }
-
       displayAttrNames = displayAttrNames.concat(mandatoryAttrNames);
 
       allAttrs.forEach(function (attr) {


### PR DESCRIPTION
Make default columns on all assessment lists: 
Title, state, assessors, verifiers, last updated