### PR TITLE
GGRC-2169 500 Server error is shown while importing Assessment csv file

### DIFF
--- a/src/ggrc/access_control/list.py
+++ b/src/ggrc/access_control/list.py
@@ -46,5 +46,7 @@ class AccessControlList(mixins.Base, db.Model):
   def _extra_table_args(_):
     return (
         db.UniqueConstraint(
-            'person_id', 'ac_role_id', 'object_id', 'object_type'),
+            'person_id', 'ac_role_id', 'object_id', 'object_type'
+        ),
+        db.Index('idx_object_type_object_idx', 'object_type', 'object_id'),
     )

--- a/src/ggrc/access_control/roleable.py
+++ b/src/ggrc/access_control/roleable.py
@@ -92,6 +92,21 @@ class Roleable(object):
     return cls.eager_inclusions(query, Roleable._include_links).options(
         orm.subqueryload('access_control_list'))
 
+  @classmethod
+  def indexed_query(cls):
+    query = super(Roleable, cls).indexed_query()
+    return query.options(
+        orm.subqueryload(
+            'access_control_list'
+        ).subqueryload(
+            "person"
+        ).load_only(
+            "id",
+            "name",
+            "email",
+        )
+    )
+
   def log_json(self):
     """Log custom attribute values."""
     # pylint: disable=not-an-iterable

--- a/src/ggrc/migrations/versions/20170517162818_59a7bd61e36a_add_index_on_access_control_list.py
+++ b/src/ggrc/migrations/versions/20170517162818_59a7bd61e36a_add_index_on_access_control_list.py
@@ -1,0 +1,28 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Add index on access_control_list
+
+Create Date: 2017-05-17 16:28:18.428357
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '59a7bd61e36a'
+down_revision = '1ac595e94a23'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  op.create_index('idx_object_type_object_idx',
+                  'access_control_list',
+                  ['object_type', 'object_id'])
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  op.drop_index('idx_object_type_object_idx', table_name='access_control_list')

--- a/src/ggrc/models/mixins/customattributable.py
+++ b/src/ggrc/models/mixins/customattributable.py
@@ -396,15 +396,19 @@ class CustomAttributable(object):
     """Get all applicable CA definitions (even ones without a value yet)."""
     from ggrc.models.custom_attribute_definition import \
         CustomAttributeDefinition as cad
+
     if cls.__name__ == "Assessment":
-      return cad.query.filter(or_(
+      query = cad.query.filter(or_(
           cad.definition_type == utils.underscore_from_camelcase(cls.__name__),
           cad.definition_type == "assessment_template",
-      )).all()
+      ))
     else:
-      return cad.query.filter(
+      query = cad.query.filter(
           cad.definition_type == utils.underscore_from_camelcase(cls.__name__)
-      ).all()
+      )
+    return query.options(
+        orm.undefer_group('CustomAttributeDefinition_complete')
+    )
 
   @classmethod
   def eager_query(cls):


### PR DESCRIPTION
make sql query less on reindex procedure (from 1019 to 20 for 1000 instances)  
add index on access_control_list on complex FK fields (object_type and object_id) 
make sql query less on import custom attributable objects (validate on import 1 assessment in my env from 1559 to 4) 