### PR TITLE
GGRC-2204 Update SQLAlchemy to 0.9.8

### DIFF
--- a/src/ggrc/converters/handlers/snapshot_instance_column_handler.py
+++ b/src/ggrc/converters/handlers/snapshot_instance_column_handler.py
@@ -142,7 +142,10 @@ class SnapshotInstanceColumnHandler(MappingColumnHandler):
       # TODO: is_valid_creation should work with codes instead of ids and it
       # should also be checked on dry runs.
       return items
-    exists_ids = {i for i, in self.snapshoted_instances_query.values("id")}
+    exists_ids = {
+        row.id for row in
+        self.snapshoted_instances_query.values(self.mapping_object.id)
+    }
     import_ids = {i.id for i in items or []}
     to_append_ids = import_ids - exists_ids
     self.is_valid_creation(to_append_ids)

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -27,7 +27,7 @@ MonthDelta==0.9.1
 python-dateutil==2.2
 pytz==2015.2
 six==1.10.0
-SQLAlchemy==0.9.4
+SQLAlchemy==0.9.8
 tabulate==0.7.5
 webassets==0.8
 Werkzeug==0.9.3


### PR DESCRIPTION
This PR updates SQLAlchemy to 0.9.8 as it's required in #5614.

Steps to reproduce:
1. Create a Program.
2. Create an Audit.
3. Try to import an Assessment for this Audit with "map:control" column present and empty.

Expected result: the Assessment is imported.
Actual result: on real import (not dry run) an SQLAlchemy OperationalError is raised:
OperationalError: (OperationalError) (1052, "Column 'id' in field list is ambiguous") 'SELECT id \nFROM controls, (SELECT snapshots.child_id AS child_id, snapshots.id AS id \nFROM snapshots, (SELECT relationships.id AS id, relationships.source_id AS source_id, relationships.source_type AS source_type, relationships.destination_id AS destination_id, relationships.destination_type AS destination_type, relationships.automapping_id AS automapping_id, relationships.context_id AS context_id \nFROM relationships \nWHERE relationships.source_type = %s AND relationships.source_id = %s AND relationships.destination_type = %s AND 1 = 1 OR relationships.source_type = %s AND 1 = 1 AND relationships.destination_type = %s AND relationships.destination_id = %s) AS snapshot_rel \nWHERE snapshots.id = CASE WHEN (snapshot_rel.destination_type = %s) THEN snapshot_rel.destination_id ELSE snapshot_rel.source_id END AND snapshots.child_type = %s) AS snapshots \nWHERE controls.id = snapshots.child_id' ('Assessment', 15291L, 'Snapshot', 'Snapshot', 'Assessment', 15291L, 'Snapshot', 'Control')

Note: this bug cannot be reproduced on old SQLAlchemy.