### PR TITLE
GGRC-1421 Last updated date on assessment should change on comments

### DIFF
--- a/src/ggrc/automapper/__init__.py
+++ b/src/ggrc/automapper/__init__.py
@@ -12,6 +12,8 @@ from ggrc import models
 from ggrc.automapper.rules import rules
 from ggrc.login import get_current_user
 from ggrc.models.relationship import Relationship
+from ggrc.models.comment import Commentable
+from ggrc.models.mixins import ChangeTracked
 from ggrc.rbac.permissions import is_allowed_update
 from ggrc.services.common import Resource, get_cache
 from ggrc.utils import benchmark, with_nop
@@ -259,3 +261,13 @@ def register_automapping_listeners():
         logger.warning("Automapping listener: no obj, no mappings created")
         return
       automapper.generate_automappings(obj)
+
+      if obj.source_type != u"Comment" and obj.destination_type != u"Comment":
+        continue
+
+      comment, other = obj.source, obj.destination
+      if comment.type != u"Comment":
+        comment, other = other, comment
+
+      if isinstance(other, (Commentable, ChangeTracked)):
+        other.updated_at = datetime.now()


### PR DESCRIPTION
Comment from Prasanna:
1. Last updated date on assessments should change when a comment is added.
Precondition:
Have audit and assessment created some time ago
Steps to reproduce:
1. Go to audit page> Assessments tab and add LAST UPDATED field into tree view through Set visible dialog
2. Navigate to Assessment's Info pane and add comment
Actual Result: LAST UPDATED date is not changed if add comment to Assessment 
Expected Result: Last updated date on assessment should change on comments