### PR TITLE
QUICK-FIX Build fewer containers

### DIFF
--- a/bin/jenkins/functions.sh
+++ b/bin/jenkins/functions.sh
@@ -44,15 +44,17 @@ setup () {
     PROJECT="${1}"
   fi
 
+  MACHINE_ID="${2:-dev selenium}"
+
   git submodule update --init
 
   docker-compose --file docker-compose-testing.yml \
     --project-name ${PROJECT} \
-    build
+    build ${MACHINE_ID}
 
   docker-compose --file docker-compose-testing.yml \
     --project-name ${PROJECT} \
-    up --force-recreate -d
+    up --force-recreate -d ${MACHINE_ID}
 
   if [[ $UID -eq 0 ]]; then
     # Allow users inside the containers to access files.

--- a/bin/jenkins/run_checkstyle
+++ b/bin/jenkins/run_checkstyle
@@ -12,7 +12,7 @@ source bin/jenkins/functions.sh
 
 PROJECT=$( project_name "$@" -d "$PROJECT" )
 
-setup $PROJECT
+setup $PROJECT dev
 
 checkstyle_tests $PROJECT && rc=$? || rc=$?
 

--- a/bin/jenkins/run_code_style
+++ b/bin/jenkins/run_code_style
@@ -12,7 +12,7 @@ source bin/jenkins/functions.sh
 
 PROJECT=$( project_name "$@" -d "$PROJECT" )
 
-setup $PROJECT
+setup $PROJECT dev
 
 code_style_tests $PROJECT && rc=$? || rc=$?
 

--- a/bin/jenkins/run_integration
+++ b/bin/jenkins/run_integration
@@ -12,7 +12,7 @@ source bin/jenkins/functions.sh
 
 PROJECT=$( project_name "$@" -d "$PROJECT" )
 
-setup $PROJECT
+setup $PROJECT dev
 
 integration_tests $PROJECT && rc=$? || rc=$?
 

--- a/bin/jenkins/run_unittests
+++ b/bin/jenkins/run_unittests
@@ -12,7 +12,7 @@ source bin/jenkins/functions.sh
 
 PROJECT=$( project_name "$@" -d "$PROJECT" )
 
-setup $PROJECT
+setup $PROJECT dev
 
 unittests_tests $PROJECT && rc=$? || rc=$?
 


### PR DESCRIPTION
This PR makes sure we don't build `selenium` container in jobs for unit tests, integration tests and style checks.