### PR TITLE
GGRC-1935 Fix bug with improperly update of Issue widget

### DIFF
--- a/src/ggrc/assets/javascripts/components/add-issue-button/add-issue-button.js
+++ b/src/ggrc/assets/javascripts/components/add-issue-button/add-issue-button.js
@@ -3,8 +3,9 @@
  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  */
 
-(function (can) {
+(function (can, GGRC, CMS) {
   'use strict';
+  var CurrentPageUtils = GGRC.Utils.CurrentPage;
 
   GGRC.Components('addIssueButton', {
     tag: 'add-issue-button',
@@ -47,9 +48,20 @@
       }
     },
     events: {
-      '{window} modal:success': function () {
+      '{window} modal:success': function (window, event, instance) {
+        var pageInstance;
+
+        if (instance instanceof CMS.Models.Issue) {
+          pageInstance = GGRC.page_instance();
+          CurrentPageUtils.initCounts(
+            ['Issue'],
+            pageInstance.type,
+            pageInstance.id
+          );
+        }
+
         this.viewModel.attr('relatedInstance').dispatch('refreshInstance');
       }
     }
   });
-})(window.can);
+})(window.can, window.GGRC, window.CMS);

--- a/src/ggrc/assets/javascripts/components/add-issue-button/tests/add-issue-button_spec.js
+++ b/src/ggrc/assets/javascripts/components/add-issue-button/tests/add-issue-button_spec.js
@@ -1,0 +1,68 @@
+/*!
+ Copyright (C) 2017 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+describe('GGRC.Components.addIssueButton', function () {
+  'use strict';
+
+  var Component;
+  var viewModel;
+  var events;
+  var CurrentPageUtils;
+
+  beforeAll(function () {
+    Component = GGRC.Components.get('addIssueButton');
+    events = Component.prototype.events;
+    CurrentPageUtils = GGRC.Utils.CurrentPage;
+  });
+
+  beforeEach(function () {
+    viewModel = GGRC.Components.getViewModel('addIssueButton');
+  });
+
+  describe('on "{window} modal:success" event', function () {
+    var handler;
+    var that;
+    var relatedInstance;
+
+    beforeEach(function () {
+      that = {
+        viewModel: viewModel
+      };
+      relatedInstance = viewModel.attr('relatedInstance');
+      handler = events['{window} modal:success'].bind(that);
+      spyOn(relatedInstance, 'dispatch');
+    });
+
+    describe('in case of Issue instance', function () {
+      var issueWidgetName = 'Issue';
+      var fakeIssueInstance;
+      var fakePageInstance = {
+        type: 'TYPE',
+        id: 'ID'
+      };
+
+      beforeEach(function () {
+        spyOn(CMS.Models, 'Issue');
+        fakeIssueInstance = new CMS.Models.Issue();
+        spyOn(CurrentPageUtils, 'initCounts');
+        spyOn(GGRC, 'page_instance').and.returnValue(fakePageInstance);
+      });
+
+      it('should dispatch refreshInstance event ' +
+        'and update Issues tab counts',
+        function () {
+          handler({}, {}, fakeIssueInstance);
+          expect(CurrentPageUtils.initCounts).toHaveBeenCalledWith(
+            [issueWidgetName],
+            fakePageInstance.type,
+            fakePageInstance.id
+          );
+          expect(relatedInstance.dispatch)
+            .toHaveBeenCalledWith('refreshInstance');
+        }
+      );
+    });
+  });
+});

--- a/src/ggrc/assets/javascripts/components/tree/tests/tree-widget-container_spec.js
+++ b/src/ggrc/assets/javascripts/components/tree/tests/tree-widget-container_spec.js
@@ -7,9 +7,11 @@ describe('GGRC.Components.treeWidgetContainer', function () {
   'use strict';
 
   var vm;
+  var CurrentPageUtils;
 
   beforeEach(function () {
     vm = GGRC.Components.getViewModel('treeWidgetContainer');
+    CurrentPageUtils = GGRC.Utils.CurrentPage;
   });
 
   describe('onSort() method', function () {
@@ -90,5 +92,126 @@ describe('GGRC.Components.treeWidgetContainer', function () {
         done();
       });
     });
+  });
+
+  describe('on widget appearing', function () {
+    var _widgetShown;
+
+    beforeEach(function () {
+      _widgetShown = vm._widgetShown.bind(vm);
+      spyOn(vm, '_triggerListeners');
+      spyOn(vm, 'loadItems');
+    });
+
+    describe('for any viewModel except Issue', function () {
+      beforeEach(function () {
+        var modelName = 'Model';
+        spyOn(CurrentPageUtils, 'getCounts').and.returnValue(
+          _.set({}, modelName, 123)
+        );
+        vm.attr({
+          model: {
+            shortName: modelName
+          },
+          modelName: modelName,
+          loaded: {},
+          pageInfo: {
+            total: 123
+          }
+        });
+      });
+
+      it('should only add listeners', function () {
+        _widgetShown();
+        expect(vm._triggerListeners).toHaveBeenCalled();
+        expect(vm.loadItems).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('for Issue viewModel that wasn\'t loaded before', function () {
+      var modelName = 'Issue';
+
+      beforeEach(function () {
+        vm.attr({
+          model: {
+            shortName: modelName
+          },
+          modelName: modelName
+        });
+        vm.attr('loaded', null);
+        vm.attr('pageInfo', {
+          total: 123
+        });
+        spyOn(CurrentPageUtils, 'getCounts').and.returnValue(
+          _.set({}, modelName, 123)
+        );
+      });
+
+      it('should only add listeners', function () {
+        _widgetShown();
+        expect(vm._triggerListeners).toHaveBeenCalled();
+        expect(vm.loadItems).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('for Issue viewModel that was loaded before' +
+      'in case of equality between counts on tab ' +
+      'and total counts in viewModel',
+      function () {
+        var modelName = 'Issue';
+
+        beforeEach(function () {
+          vm.attr({
+            model: {
+              shortName: modelName
+            },
+            modelName: modelName
+          });
+          vm.attr('loaded', {});
+          vm.attr('pageInfo', {
+            total: 123
+          });
+          spyOn(CurrentPageUtils, 'getCounts').and.returnValue(
+            _.set({}, modelName, 123)
+          );
+        });
+
+        it('should only add listeners', function () {
+          _widgetShown();
+          expect(vm._triggerListeners).toHaveBeenCalled();
+          expect(vm.loadItems).not.toHaveBeenCalled();
+        });
+      }
+    );
+
+    describe('for Issue viewModel that was loaded before' +
+      'in case of inequality between counts on tab ' +
+      'and total counts in viewModel',
+      function () {
+        var modelName = 'Issue';
+
+        beforeEach(function () {
+          vm.attr({
+            model: {
+              shortName: modelName
+            },
+            modelName: modelName
+          });
+          vm.attr('loaded', {});
+          vm.attr('pageInfo', {
+            total: 123
+          });
+          spyOn(CurrentPageUtils, 'getCounts').and.returnValue(
+            _.set({}, modelName, 124)
+          );
+        });
+
+        it('should add listeners and update viewModel', function () {
+          _widgetShown();
+          expect(vm._triggerListeners).toHaveBeenCalled();
+          expect(vm.loadItems).toHaveBeenCalled();
+        });
+      }
+    );
   });
 });

--- a/src/ggrc/assets/javascripts/components/tree/tree-widget-container.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-widget-container.js
@@ -328,6 +328,15 @@
       this._triggerListeners(true);
     },
     _widgetShown: function () {
+      var modelName = this.attr('modelName');
+      var loaded = this.attr('loaded');
+      var total = this.attr('pageInfo.total');
+      var counts = _.get(CurrentPageUtils.getCounts(), modelName);
+
+      if ((modelName === 'Issue') && !_.isNull(loaded) && (total !== counts)) {
+        this.loadItems();
+      }
+
       this._triggerListeners();
     },
     _triggerListeners: (function () {


### PR DESCRIPTION
**Steps to reproduce:**

1. On the audit page create assessment
2. Navigate to assessment's Info pane> Related Issues tab
3. Click Raise an Issue button to create Issue
4. After creating issue go to Issues tab: confirm newly created Issue is displayed
5. Repeat steps 3-4. The second and the third Issue is not displayed in Issues tab

**Actual Result:** Newly created Issue is not displayed in Issues tab if issue was created via Related Issues tab on Assessment's Info pane

**Expected Result:** Newly created Issue should be displayed in Issues tab if issue was created via Related Issues tab on Assessment's Info pane

**Note:** refresh is needed

**Fix overview:**

As widgets on inactive tabs don't listen models changes Issue counts update
can be perfomed from add-issue-button component with the help
of GGRC.Utils.CurrentPage.initCounts method.

Additionally, on Issues tab activation it's neccessary to check the equality
of viewModel.pageInfo.total and GGRC.Utils.CurrentPage.getCounts()[issueWidgetName] and update
view of tree-widget-container component in case of inequality. It is assumed
that removal of issues is possible only on the active Issues tab.