### PR TITLE
GGRC-2200/2202 Fix shown evidences on issues and assessments CA

### DIFF
--- a/src/ggrc/assets/mustache/components/ca-object/ca-object-modal-content.mustache
+++ b/src/ggrc/assets/mustache/components/ca-object/ca-object-modal-content.mustache
@@ -24,7 +24,7 @@
               class="assesment-attachment-list attachments-list-control"
               title="Evidence"
               tooltip="You can upload up to 10 files in a single batch"
-              {parent-instance}="instance">
+              {instance}="instance">
         </assessment-attachments-list>
       {{/if}}
     </div>

--- a/src/ggrc/assets/mustache/issues/info.mustache
+++ b/src/ggrc/assets/mustache/issues/info.mustache
@@ -25,7 +25,9 @@
         <div class="span6">
           <assessment-attachments-list class="attachments-list-control oneline"
                                        title="Evidence"
-                                       tooltip="You can upload up to 10 files in a single batch">
+                                       tooltip="You can upload up to 10 files in a single batch"
+                                       {instance}="instance"
+          >
           </assessment-attachments-list>
         </div>
       </div>


### PR DESCRIPTION
**GGRC-2200**
Steps to reproduce:
1. On the audit page create Issue
2. On the Issues tab click on first tier in tree view
3. Look at the screen
Actual Result: "Uncaught TypeError: Cannot read property 'get_mapping_deferred' of null" error is displayed if click on Issues first tier 
Expected Result: no errors is shown. Info pane is not expanded and the app freezes.

*NOTE:* also, "Uncaught TypeError: Cannot read property 'get_mapping_deferred' of null" error is displayed if open "Issue" via LHN. Issues info page is not opened.

**GGRC-2202**
Steps to reproduce:
1. Have audit and control snapshot mapped to audit
2. Create assessment template with LCA dropdown type with comment or evidence required
3. Generate assessment based on control and assessment template
4. Navigate to Assessment's Info pane, select value in LCA dropdown
5. Once "Add required info" link appears click on it: error is shown 
Actual Result: "Uncaught TypeError: Cannot read property 'get_mapping_deferred' of null" error occurs if click "Add required info" on Assessment Info pane. There is no possibility to add comment or evidence that are required
Expected Result: no error is shown. Comment or evidence should be added if it is required