### PR TITLE
QUICK-FIX Remove build flag in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 Governance, Risk and Compliance (GGRC)
 =========
 
-[![Build Status](https://jenkins.reciprocitylabs.com/job/ggrc_develop_build/badge/icon)](https://jenkins.reciprocitylabs.com/job/ggrc_develop_build/)
-
 Governance, Risk Management, and Compliance are activities necessary for any organization with regulatory or contractual obligations.
 
 Governance refers to management structure, policies, procedures, shareholder relations, etc.


### PR DESCRIPTION
We are moving away from publicly accessible Jenkins so having the build
flag in the README.md no longer makes sense.

It currently shows up as a broken image:

<img width="908" alt="screen shot 2017-05-18 at 05 04 16" src="https://cloud.githubusercontent.com/assets/513444/26201365/798f0e10-3b87-11e7-98f2-39fe01bacf9a.png">
