### PR TITLE
GGRC-2051 URLs are shown as mapped objects in Edit Assessment modal window 

### DIFF
--- a/src/ggrc/assets/javascripts/components/modal-connector.js
+++ b/src/ggrc/assets/javascripts/components/modal-connector.js
@@ -364,7 +364,8 @@
           .then(function (list) {
             var newList = list.filter(function (item) {
               return !snapshots.isSnapshotModel(item.instance.type) &&
-                  item.instance.type !== 'Comment';
+                  item.instance.type !== 'Comment' &&
+                  item.instance.type !== 'Document'; // exclude urls
             });
             newList.forEach(function (item) {
               var query;

--- a/src/ggrc/assets/javascripts/components/tests/modal-connector_spec.js
+++ b/src/ggrc/assets/javascripts/components/tests/modal-connector_spec.js
@@ -328,6 +328,12 @@ describe('GGRC.Components.modalConnector', function () {
             type: 'Snapshot',
             id: 123
           }
+        },
+        {
+          instance: {
+            type: 'Document',
+            id: 432
+          }
         }
       ]);
 
@@ -371,6 +377,23 @@ describe('GGRC.Components.modalConnector', function () {
 
           expect(snapshotItem.attr('title')).toEqual(responseSnapshotTitle);
           expect(snapshotItem.attr('viewLink')).toEqual(responseSnapshotUrl);
+          done();
+        });
+      }
+    );
+
+    it('result list should not contain objects with "Document" type',
+      function (done) {
+        var dfd = handler();
+
+        dfd.done(function (list) {
+          list = _.map(list, function (item) {
+            return item.instance;
+          });
+          expect(list)
+            .not.toContain(jasmine.objectContaining({
+              type: 'Document'
+            }));
           done();
         });
       }


### PR DESCRIPTION
Steps to reproduce:
1. Open Assessment page 
2. Add at least 3 URLs
3. Open Edit Assessment modal window
4. Look at Mapped objects: urls are shown

Actual Result: URLs are shown as mapped objects in Edit Assessment modal window
Expected Result: URLs, evidences, comments should not be shown as mapped objects in Edit Assessment modal window. Only audit and snapshots that are mapped to assessment are shown.