### PR TITLE
GGRC-1528 Display rich text in tree view

### DIFF
--- a/src/ggrc/assets/javascripts/plugins/utils/tree-view-utils.js
+++ b/src/ggrc/assets/javascripts/plugins/utils/tree-view-utils.js
@@ -208,7 +208,7 @@
      */
     function setColumnsForModel(modelType, columnNames, displayPrefs) {
       var availableColumns =
-        getColumnsForModel(modelType, displayPrefs).available;
+        getColumnsForModel(modelType, displayPrefs, true).available;
       var selectedColumns = [];
       var selectedNames = [];
 


### PR DESCRIPTION
The ticket is reopened due to rich text field is not displayed in tree view after setting the field in "Set visibility" dialog.