### PR TITLE
GGRC-1891 Audits tab doesn't exist under 'All object / My Work' widget

### DIFF
--- a/src/ggrc/assets/javascripts/modules/widget_descriptor.js
+++ b/src/ggrc/assets/javascripts/modules/widget_descriptor.js
@@ -90,13 +90,12 @@
       You must provide:
       instance - an instance that is a subclass of can.Model.Cacheable
       farModel - a can.Model.Cacheable class
-      mapping - a mapping object taken from the instance
       extenders [optional] - an array of objects that will extend the default widget config.
     */
-    make_tree_view: function (instance, farModel, mapping, extenders, id) {
+    make_tree_view: function (instance, farModel, extenders, id) {
       var descriptor;
       // Should not even try to create descriptor if configuration options are missing
-      if (!instance || !farModel || !mapping) {
+      if (!instance || !farModel) {
         console
           .debug('Arguments are missing or have incorrect format', arguments);
         return null;
@@ -138,10 +137,7 @@
         content_controller_options: {
           draw_children: true,
           parent_instance: instance,
-          model: farModel,
-          list_loader: function () {
-            return mapping.refresh_list();
-          }
+          model: farModel
         }
       };
 

--- a/src/ggrc/assets/javascripts/modules/widget_list.js
+++ b/src/ggrc/assets/javascripts/modules/widget_list.js
@@ -72,14 +72,12 @@
           descriptors[widgetId] = GGRC.WidgetDescriptor.make_tree_view(
             options && (options.instance || options.parent_instance) || widget.instance,
             options && options.model || widget.far_model || widget.model,
-            options && options.mapping || widget.mapping,
             widget
           );
         } else if (widget.widgetType === 'treeview') {
           descriptors[widgetId] = GGRC.WidgetDescriptor.make_tree_view(
             options && (options.instance || options.parent_instance) || widget.instance,
             options && options.model || widget.far_model || widget.model,
-            options && options.mapping || widget.mapping,
             widget,
             widgetId
           );


### PR DESCRIPTION
Steps to reproduce:
1. Open link of 'All object' widget.
2. Click to + "Add tab" and try to find and add "Audits" tab to represent under widget.

Actual result:
Audits tab doesn't exist under 'All object' widget
Expected result:
Audits tab have to be exist under 'All object' widget.