### PR TITLE
QUICK-FIX Test to check object mapping to existing audit

### DIFF
--- a/test/selenium/src/lib/constants/messages.py
+++ b/test/selenium/src/lib/constants/messages.py
@@ -3,4 +3,5 @@
 """Message templates for stdout (e.g. print, assert, etc.)."""
 
 ERR_MSG_FORMAT = "Expected: '{}', Got: '{}'\n"
+ERR_MSG_TRIPLE_FORMAT = "Expected: '{}', First Got: '{}', Second Got: '{}'\n"
 ERR_VALUE_OF_ARGUMENT = "The argument does not contain numbers\n"

--- a/test/selenium/src/lib/constants/objects.py
+++ b/test/selenium/src/lib/constants/objects.py
@@ -67,11 +67,16 @@ def _get_singular(plurals):
   return singulars
 
 
-def get_singular(plural):
-  """Transform object name to singular and lower form.
+def get_singular(plural, title=False):
+  """Transform object name to singular and lower or title form.
  Example: risk_assessments -> risk_assessment
  """
-  return _get_singular([plural])[0].lower()
+  _singular = _get_singular([plural])[0]
+  if title:
+    _singular = _singular.title()
+  else:
+    _singular = _singular.lower()
+  return _singular
 
 
 def get_normal_form(obj_name, with_space=True):

--- a/test/selenium/src/lib/entities/entities_factory.py
+++ b/test/selenium/src/lib/entities/entities_factory.py
@@ -21,13 +21,14 @@ from lib.utils.string_utils import (random_list_strings, random_string,
 class EntitiesFactory(object):
   """Common factory class for entities."""
   # pylint: disable=too-few-public-methods
-  obj_person = objects.get_singular(objects.PEOPLE)
-  obj_program = objects.get_singular(objects.PROGRAMS)
-  obj_control = objects.get_singular(objects.CONTROLS)
-  obj_audit = objects.get_singular(objects.AUDITS)
-  obj_asmt_tmpl = objects.get_singular(objects.ASSESSMENT_TEMPLATES)
-  obj_asmt = objects.get_singular(objects.ASSESSMENTS)
-  obj_issue = objects.get_singular(objects.ISSUES)
+  obj_person = objects.get_singular(objects.PEOPLE, title=True)
+  obj_program = objects.get_singular(objects.PROGRAMS, title=True)
+  obj_control = objects.get_singular(objects.CONTROLS, title=True)
+  obj_audit = objects.get_singular(objects.AUDITS, title=True)
+  obj_asmt_tmpl = objects.get_singular(objects.ASSESSMENT_TEMPLATES,
+                                       title=True)
+  obj_asmt = objects.get_singular(objects.ASSESSMENTS, title=True)
+  obj_issue = objects.get_singular(objects.ISSUES, title=True)
   obj_ca = objects.get_singular(objects.CUSTOM_ATTRIBUTES)
 
   all_objs_attrs_names = tuple(entity.Entity().attrs_names_all_entities())

--- a/test/selenium/src/lib/service/rest/template_provider.py
+++ b/test/selenium/src/lib/service/rest/template_provider.py
@@ -19,6 +19,7 @@ class TemplateProvider(object):
     (items (kwargs): key=value).
     Return dictionary like as {type: {key: value, ...}}.
     """
+    json_tmpl_name = json_tmpl_name.lower()
     path = os.path.join(
         os.path.dirname(__file__), "template/{0}.json".format(json_tmpl_name))
     with open(path) as json_file:

--- a/test/selenium/src/tests/test_snapshots.py
+++ b/test/selenium/src/tests/test_snapshots.py
@@ -330,3 +330,40 @@ class TestSnapshots(base.Test):
         src_obj=audit, dest_objs=[expected_ctrl])
     assert (((expected_ctrl in actual_ctrls) and
             (expected_map_status in actual_map_status)) is is_found)
+
+  @pytest.mark.smoke_tests
+  def test_mapping_control_to_existing_audit(
+      self, new_audit_rest, new_control_rest, selenium
+  ):
+    """Check if Control can be mapped to existing Audit and mapping
+    between Control and Program of this Audit automatically created.
+    Preconditions:
+    - Audit and program, and different control created via REST API
+    """
+    audit, program = new_audit_rest
+    expected_control = new_control_rest
+    (webui_service.ControlsService(selenium).map_objs_via_tree_view(
+        src_obj=audit, dest_objs=[new_control_rest]))
+    actual_controls_count_in_tab_audit = (
+        webui_service.ControlsService(selenium).
+        get_count_objs_from_tab(src_obj=audit))
+    actual_control_in_audit = (
+        webui_service.ControlsService(selenium).
+        get_list_objs_from_tree_view(src_obj=audit))
+    actual_controls_count_in_tab_program = (
+        webui_service.ControlsService(selenium).
+        get_count_objs_from_tab(src_obj=program))
+    actual_control_in_program = (
+        webui_service.ControlsService(selenium).
+        get_list_objs_from_tree_view(src_obj=program))
+
+    assert (len([expected_control]) ==
+            actual_controls_count_in_tab_audit ==
+            actual_controls_count_in_tab_program)
+
+    assert ([expected_control] ==
+            actual_control_in_audit ==
+            actual_control_in_program), messages.ERR_MSG_TRIPLE_FORMAT.format(
+                expected_control,
+                actual_control_in_audit,
+                actual_control_in_program)


### PR DESCRIPTION
This PR add test from Smoke test suite regarding possibility to map Control object to existing Audit:
 - check that snapshot of control is mapped to audit
 - check that program mapped to this control
 