### PR TITLE
GGRC-2201 JS error occurs if click [Global Search] button on the Import/Export pages 

### DIFF
--- a/src/ggrc/assets/javascripts/components/csv/export.js
+++ b/src/ggrc/assets/javascripts/components/csv/export.js
@@ -241,7 +241,14 @@
       panel_number: '@',
       has_parent: false,
       fetch_relevant_data: function (id, type) {
-        var dfd = CMS.Models[type].findOne({id: id});
+        var dfd;
+        var Model = CMS.Models[type];
+
+        //  some models isn't defined at this moment (example: Workflow)
+        if (!Model) {
+          return;
+        }
+        dfd = Model.findOne({id: id});
         dfd.then(function (result) {
           this.attr('item.relevant').push(new filterModel({
             model_name: url.relevant_type,

--- a/src/ggrc/templates/import_export/export.haml
+++ b/src/ggrc/templates/import_export/export.haml
@@ -11,6 +11,7 @@
   GGRC.access_control_roles =  ={ access_control_roles_json()|safe }
   GGRC.model_attr_defs =  ={ all_attributes_json(True)|safe }
   GGRC.Bootstrap.exportable = ={ export_definitions()|safe };
+  GGRC.pageType = "EXPORT";
 
 -block title
   Export

--- a/src/ggrc/templates/import_export/import.haml
+++ b/src/ggrc/templates/import_export/import.haml
@@ -6,6 +6,7 @@
 -block extra_javascript
   =super()
   GGRC.Bootstrap.importable = ={ import_definitions()|safe };
+  GGRC.pageType = "IMPORT";
 
 -block title
   Import


### PR DESCRIPTION
Steps to reproduce:
1. Go to Import/Export pages
2. Click on [Global Search] button
3. Look at the screen

Actual Result: "Uncaught TypeError: Cannot read property 'type' of undefined" error occurs if click [Global Search] button on the Import page. No objects are displayed in the list, if Global Search is opened from 'Import' page and object type = Cycle Task Group Object Tasks
Expected Result: no error is displayed. Objects are displayed in Search Result