### PR TITLE
GGRC-2214 LCA with comment required is marked as Add required info while comment was already added

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.js
+++ b/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.js
@@ -183,7 +183,7 @@
           content: data,
           caIds: {
             defId: scope.attr('id'),
-            valueId: scope.attr('valueId')
+            valueId: scope.attr('valueId')()
           },
           modalTitle: title,
           state: {}

--- a/src/ggrc/assets/javascripts/plugins/utils/ca-utils.js
+++ b/src/ggrc/assets/javascripts/plugins/utils/ca-utils.js
@@ -170,11 +170,11 @@
 
     /**
      * Converts CA values array to form fields.
-     * @param {Object|undefined} customAttributeValues - Custom attributes values
+     * @param {can.List|undefined} customAttributeValues - Custom attributes values
      * @return {Array} From fields array
      */
     function convertValuesToFormFields(customAttributeValues) {
-      return can.makeArray(customAttributeValues)
+      return (customAttributeValues || new can.List([]))
         .map(function (attr) {
           var options = attr.def.multi_choice_options;
           return {
@@ -193,7 +193,9 @@
             helptext: attr.def.helptext,
             validation: attr.validation,
             errorsMap: attr.errorsMap,
-            valueId: attr.id
+            valueId: can.compute(function () {
+              return attr.attr('id');
+            })
           };
         });
     }


### PR DESCRIPTION
Steps to reproduce:
1. Have audit with control snapshot
2. Create Assessment template with LCA dropdown type with comment required and marked as mandatory field
3. Generate assessment based on control and assessment template
4. Open assessment Info pane and select the value with required comment from LCA
5. Fill comment and Save
6. Look at the LCA field: is marked as required info
Actual Result: LCA with comment required is marked as Add required info while comment was already added. Users have no opportunity to complete assessment.
Expected Result: Once required comment or evidence are filled or attached LCA should be marked with green icon and Add required info disappears
Second part: comment should be added and linked together with the Custom Attribute name.