### PR TITLE
GGRC-2161 JS error occurs if click "Get the latest version" link in Unified mapper

### DIFF
--- a/src/ggrc/assets/javascripts/components/unified-mapper/mapper-results-item-details.js
+++ b/src/ggrc/assets/javascripts/components/unified-mapper/mapper-results-item-details.js
@@ -23,7 +23,8 @@
       },
       item: null,
       instance: null,
-      model: null
+      model: null,
+      isMapperDetails: true
     }
   });
 })(window.can, window.GGRC, window.CMS);

--- a/src/ggrc/assets/mustache/snapshots/dropdown_menu.mustache
+++ b/src/ggrc/assets/mustache/snapshots/dropdown_menu.mustache
@@ -38,6 +38,7 @@ TODO: Temporary disabled until snapshot view is added.
 -->
             {{! We need to use `using` to ensure that snapshot is actually
                 reified by the time is_allowed helper uses it }}
+            {{^if isMapperDetails}}
             {{#using reified_snapshot=snapshot}}
             {{#canUpdate}}
             {{^isLatestRevision}}
@@ -53,6 +54,7 @@ TODO: Temporary disabled until snapshot view is added.
             {{/isLatestRevision}}
             {{/canUpdate}}
             {{/using}}
+            {{/if}}
 
             <li>
                 {{#if instance.originalObjectDeleted}}


### PR DESCRIPTION
Steps to reproduce:
1. Have program, control, audit
2. On the program page update control (e.g. description)
3. Go to audit page> Assessments tab
4. Select Generate assessments in 3 bb's menu
5. Select Control that was updated on the program page in Umapper and click triangle
6. In 3 bb's menu click "Get the latest version"

Actual Result: "Uncaught TypeError: Cannot read property 'url' of undefined" occurs if click "Get the latest version" link in Unified mapper
Expected Result: no error is shown while clicking "Get the latest version" in Unified mapper

As discussed w/Akhil "Get the latest version" should be removed from Unified Mapper due to it was a regression caused by TreeView redesign.