### PR TITLE
GGRC-2035 Improve Unmap button behavior on the People tab

### DIFF
--- a/src/ggrc/assets/javascripts/components/tree/tree-widget-container.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-widget-container.js
@@ -356,7 +356,9 @@
         } else if (activeTabModel === instance.type) {
           _refresh(true);
         } else if (isPerson(instance)) {
-          _refresh();
+          parentInstance.refresh().then(function () {
+            _refresh();
+          });
         }
       }
 

--- a/src/ggrc/assets/javascripts/components/unmap-button/unmap-person-button.js
+++ b/src/ggrc/assets/javascripts/components/unmap-button/unmap-person-button.js
@@ -27,23 +27,38 @@
           }.bind(this));
       },
       getObjectMapping: function () {
-        var sources = this.attr('source.object_people');
-        var destinations = this.attr('destination.object_people');
+        var destinationType = this.attr('destination.type');
+        var mappingType;
+        var sources;
+        var destinations;
         var mapping;
-        destinations = destinations
-          .map(function (item) {
-            return item.id;
+        var isWorkflow = destinationType === 'Workflow';
+
+        if (isWorkflow) {
+          sources = [this.attr('source')];
+          destinations = this.attr('destination.workflow_people');
+          destinations = destinations.map(function (workflowPerson) {
+            return workflowPerson.reify();
           });
+          mappingType = 'WorkflowPerson';
+        } else {
+          sources = this.attr('source.object_people');
+          destinations = this.attr('destination.object_people');
+          mappingType = 'ObjectPerson';
+        }
+
         sources = sources
           .map(function (item) {
             return item.id;
           });
         mapping = destinations
           .filter(function (dest) {
-            return sources.indexOf(dest) > -1;
+            return isWorkflow ?
+              sources.indexOf(dest.person.id) > -1 :
+              sources.indexOf(dest.id) > -1;
           })[0];
-        mapping = mapping ? {id: mapping} : {};
-        return new CMS.Models.ObjectPerson(mapping);
+
+        return new CMS.Models[mappingType](mapping || {});
       },
       getRoleMapping: function () {
         var contextId = this.attr('destination.context.id');


### PR DESCRIPTION
**Test Case 1**.
_Steps to reproduce_:
1. Create program
2. Go to People tab and Map person to program
3. Navigate to Person Info pane and select Unmap in 3 bb's menu
4. Click Unmap

_Actual Result_: If click unmap button to unmap newly mapped Person, query is not run and Person is not unmapped from program. See screenshot-1.png
_Expected Result_: If click unmap button to unmap mapped Person, Person should be unmapped from program.
_Note_: after mapping a new person page refresh is needed to unmap person


**Test case 2.**
_Steps to reproduce:_
1. Create program
2. Go to People tab and Map person to program
3. Refresh the program page
4. Navigate to Person Info pane and select Unmap in 3 bb's menu
5. Click Unmap button

_Actual Result_: A message that person is unmapped successfully is displayed but Info pane of unmapped person was not closed and person is still shown in the tree view. So the tree view is not refreshed automatically. After page refresh unmapped person is not shown in the tree view and is unmapped from program. See screenshot-2.png
_Expected Result_: Tree view should be automatically refreshed if unmap person from program and unmapped person should not be shown in the tree view any more. After click Unmap button in 3 bb's menu, Info pane of unmapped person should be closed.