### PR TITLE
GGRC-1967 My Work - My Tasks - add def column Task Due Date 

### DIFF
--- a/src/ggrc/assets/javascripts/plugins/tests/utils/tree-view-utils_spec.js
+++ b/src/ggrc/assets/javascripts/plugins/tests/utils/tree-view-utils_spec.js
@@ -76,35 +76,5 @@ describe('GGRC.Utils.TreeView module', function () {
         expect(result).toContain(jasmine.objectContaining(expected));
       });
     });
-
-    it('adds to selected columns "end_date" ' +
-    'if modelType is CycleTaskGroupObjectTask and current page is MyWork',
-    function () {
-      var result;
-      var modelType = 'CycleTaskGroupObjectTask';
-      GGRC.pageType = 'MY_WORK';
-      CMS.Models[modelType].tree_view_options.display_attr_names =
-        ['title', 'assignee', 'start_date'];
-
-      result = method(modelType, null);
-      expect(result.selected).toContain(jasmine.objectContaining({
-        attr_name: 'end_date'
-      }));
-    });
-
-    it('does not add to selected columns "end_date" ' +
-    'if it is CycleTaskGroupObjectTask but current page is not MyWork',
-    function () {
-      var result;
-      var modelType = 'CycleTaskGroupObjectTask';
-      GGRC.pageType = 'Person';
-      CMS.Models[modelType].tree_view_options.display_attr_names =
-        ['title', 'assignee', 'start_date'];
-
-      result = method(modelType, null);
-      expect(result.selected).not.toContain(jasmine.objectContaining({
-        attr_name: 'end_date'
-      }));
-    });
   });
 });

--- a/src/ggrc/assets/javascripts/plugins/utils/tree-view-utils.js
+++ b/src/ggrc/assets/javascripts/plugins/utils/tree-view-utils.js
@@ -171,10 +171,6 @@
           disableConfiguration: true
         };
       }
-      //  it should be like optional parameter on higher-level logic
-      if (modelType === 'CycleTaskGroupObjectTask' && CurrentPage.isMyWork()) {
-        displayAttrNames.push('end_date');
-      }
 
       displayAttrNames = displayAttrNames.concat(mandatoryAttrNames);
 

--- a/src/ggrc_workflows/assets/javascripts/models/cycle_models.js
+++ b/src/ggrc_workflows/assets/javascripts/models/cycle_models.js
@@ -345,7 +345,7 @@
           attr_sort_field: 'task last updated'
         }
       ],
-      display_attr_names: ['title', 'assignee', 'start_date'],
+      display_attr_names: ['title', 'assignee', 'start_date', 'end_date'],
       mandatory_attr_name: ['title'],
       draw_children: true
     },


### PR DESCRIPTION
Acceptance criteria
1. Task Due column should be shown by default on:
My Tasks page; 
Global Search modal window when 'Cycle Task Group Object Tasks' object is selected. 
'Workflow Tasks' tab on Person page; 
'Workflow Tasks' tab on object page. 
2. User should be able to hide 'Task Due Date' column if uncheck 'Task Due Date' checkbox on 'Set visible fields for' pop up.