### PR TITLE
GGRC-1778 RMC - Workflow: Hide Task Group Start/Finish/Verify button

### DIFF
--- a/src/ggrc/assets/mustache/components/cycle-task-actions/cycle-task-actions.mustache
+++ b/src/ggrc/assets/mustache/components/cycle-task-actions/cycle-task-actions.mustache
@@ -3,7 +3,12 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
 
-{{#if_instance_of instance 'CycleTaskGroup|CycleTaskGroupObjectTask'}}
+{{#if_instance_of instance 'CycleTaskGroup'}}
+<div class="flex-box item-actions">
+</div>
+{{/if_instance_of}}
+
+{{#if_instance_of instance 'CycleTaskGroupObjectTask'}}
 <div class="flex-box item-actions">
   {{#with_review_task}}
     {{^if isBacklog}}


### PR DESCRIPTION
ACCEPTANCE CRITERIA:
1. Hide START / FINISH / DECLINE / VERIFY / UNDO buttons from task group level on Workflow - Active Cycles page.
2. Task Group statuses should be kept.
3. Task Group statuses should be changed in accordance with the following rules:
If GGRC-1779 is implemented:
* all tasks = ASSIGNED, then task group = ASSIGNED.
* at least one task = IN PROGRESS, then task group = IN PROGRESS.
* all tasks = FINISHED, then task group = FINISHED.

If GGRC-1779 is NOT implemented:
use current logic
