### PR TITLE
GGRC-1130 expander icon for Related Information on Assessment's Info panel

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment/mapped-objects/mapped-related-information.js
+++ b/src/ggrc/assets/javascripts/components/assessment/mapped-objects/mapped-related-information.js
@@ -32,7 +32,6 @@
       titleText: '@',
       mapping: '@',
       mappingType: '@',
-      expanded: true,
       selectedItem: {}
     }
   });

--- a/src/ggrc/assets/mustache/components/assessment/mapped-objects/mapped-related-information.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/mapped-objects/mapped-related-information.mustache
@@ -2,7 +2,8 @@
     Copyright (C) 2017 Google Inc., authors, and contributors
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
-<collapsible-panel-header title-text="titleText" {(expanded)}="expanded">
+<div class="section-title">
+  {{titleText}}
   {{#is_allowed 'update' instance context='for'}}
       <i class="fa fa-plus-circle"
          rel="tooltip"
@@ -17,12 +18,10 @@
  >
       </i>
   {{/is_allowed}}
-</collapsible-panel-header>
-<collapsible-panel-body {expanded}="expanded" class="collapsible-panel-body">
-    <object-list {(selected-item)}="selectedItem" {items}="mappedItems">
-      <business-object-list-item {instance}="instance"></business-object-list-item>
-    </object-list>
-    <object-popover class="object-popover" {item}="selectedItem">
-        <detailed-business-object-list-item {instance}="item.data" {^object-title}="popoverTitle" {^object-link}="popoverLink"></detailed-business-object-list-item>
-    </object-popover>
-</collapsible-panel-body>
+</div>
+<object-list {(selected-item)}="selectedItem" {items}="mappedItems">
+  <business-object-list-item {instance}="instance"></business-object-list-item>
+</object-list>
+<object-popover class="object-popover" {item}="selectedItem">
+    <detailed-business-object-list-item {instance}="item.data" {^object-title}="popoverTitle" {^object-link}="popoverLink"></detailed-business-object-list-item>
+</object-popover>

--- a/src/ggrc/assets/stylesheets/modules/_assessment.scss
+++ b/src/ggrc/assets/stylesheets/modules/_assessment.scss
@@ -16,7 +16,7 @@
     min-width: 0; /* fixes known issue with flexboxes and text-overflow */
 
     assessment-mapped-controls,
-    collapsible-panel-header {
+    assessment-mapped-related-information {
       .fa-plus-circle {
         opacity: 1;
         color: $btnGreen;


### PR DESCRIPTION
**Steps to reproduce:**

1. Navigate to Assessment Info panel
2. Look at Related Information section

**Actual Result:** Expander icon for Related Information section is _visible_ on Assessment's Info panel.
**Expected Result:** Expander icon for Related Information section is _hidden_ on Assessment's Info panel.

**Fix overview:**

Collapsible functionality was removed from mapped-related-information component and its template.