### PR TITLE
GGRC-2197 Audit Module - FN - filter/search box to generate assessment not working

### DIFF
--- a/src/ggrc/fulltext/recordbuilder.py
+++ b/src/ggrc/fulltext/recordbuilder.py
@@ -4,12 +4,11 @@
 """Module for full text index record builder."""
 
 from ggrc import db
-import ggrc.models.all_models
+from ggrc.models import all_models
 from ggrc.models.reflection import AttributeInfo
 from ggrc.models.person import Person
 from ggrc.models.mixins import CustomAttributable
 from ggrc.fulltext.attributes import FullTextAttr
-from ggrc.fulltext.attributes import CustomRoleAttr
 from ggrc.fulltext.mixin import Indexed
 
 
@@ -51,7 +50,7 @@ class RecordBuilder(object):
       # snapshots is stored in the revision. Snapshots can also be made for
       # different models so we have to get fulltext attrs for the actual child
       # that was snapshotted and get data for those from the revision content.
-      tgt_class = getattr(ggrc.models.all_models, obj.child_type, None)
+      tgt_class = getattr(all_models, obj.child_type, None)
       if not tgt_class:
         return {}
       attrs = AttributeInfo.gather_attrs(tgt_class, '_fulltext_attrs')
@@ -66,14 +65,8 @@ class RecordBuilder(object):
     for attr in self._fulltext_attrs:
       if isinstance(attr, basestring):
         properties[property_tmpl.format(attr)] = {"": getattr(obj, attr)}
-      elif isinstance(attr, CustomRoleAttr):
-        properties.update(attr.get_properties(obj))
       elif isinstance(attr, FullTextAttr):
-        if attr.with_template:
-          property_name = property_tmpl.format(attr.alias)
-        else:
-          property_name = attr.alias
-        properties[property_name] = attr.get_property_for(obj)
+        properties.update(attr.get_property_for(obj))
     return properties
 
   def get_person_id_name_email(self, person):
@@ -89,12 +82,31 @@ class RecordBuilder(object):
       person_name, person_email = self.indexer.cache['people_map'][person_id]
     else:
       if isinstance(person, dict):
-        person = db.session.query(Person).filter_by(id=person["id"]).one()
+        person = db.session.query(Person).filter_by(
+            id=person["id"]
+        ).one()
       person_id = person.id
       person_name = person.name
       person_email = person.email
       self.indexer.cache['people_map'][person_id] = (person_name, person_email)
     return person_id, person_name, person_email
+
+  def get_ac_role_person_id(self, ac_list):
+    """Get ac_role name and person name for ac_role (either object or dict).
+
+    If there is a global ac_role map, get the data from it instead of the DB.
+    """
+    if isinstance(ac_list, dict):
+      ac_role_id = ac_list["ac_role_id"]
+      ac_person_id = ac_list["person_id"]
+    else:
+      ac_role_id = ac_list.role_id
+      ac_person_id = ac_list.person_id
+    if ac_role_id not in self.indexer.cache['ac_role_map']:
+      ac_role = db.session.query(all_models.AccessControlRole).get(ac_role_id)
+      self.indexer.cache['ac_role_map'][ac_role.id] = ac_role.name
+    ac_role_name = self.indexer.cache['ac_role_map'][ac_role_id]
+    return ac_role_name.lower(), ac_person_id
 
   def build_person_subprops(self, person):
     """Get dict of Person properties for fulltext indexing
@@ -106,6 +118,8 @@ class RecordBuilder(object):
         person
     )
     subproperties["{}-name".format(person_id)] = person_name
+    subproperties["{}-user_name".format(person_id)] = \
+        person_email.split("@")[0]
     subproperties["{}-email".format(person_id)] = person_email
     return subproperties
 

--- a/src/ggrc/views/__init__.py
+++ b/src/ggrc/views/__init__.py
@@ -78,6 +78,10 @@ def do_reindex():
   people = db.session.query(all_models.Person.id, all_models.Person.name,
                             all_models.Person.email)
   indexer.cache["people_map"] = {p.id: (p.name, p.email) for p in people}
+  indexer.cache["ac_role_map"] = dict(db.session.query(
+      all_models.AccessControlRole.id,
+      all_models.AccessControlRole.name,
+  ))
   for model in sorted(indexed_models):
     # pylint: disable=protected-access
     logger.info("Updating index for: %s", model)


### PR DESCRIPTION
What is the problem / issue?
The search filter box in the generate assessments popup doesn't work.
What is the expected result / outcome? (ie What should happen?)
Search should work. Tried with the same syntax as outlined in the search query help.
What is the impact if it is not fixed / implemented?
Unable to efficiently create assessments. Annually, we create 1500+ assessments. It means that we'd resort to using a trix to track what assessments need to be generated, manually.
Steps to reproduce:
1. Have audit with mapped Control snapshot with filled Principal Assignee
2. Go to Assessment tab > Click Generate Assessments in 3 bb's menu 
3. Once Unified Mapper displayed type filter query into Search box e.g. "Principal Assignee" = Siarhei
4. Look at filter results
Actual Result: Filter is not applied in generate assessments popup
Expected Result: Filter should work for all fields in generate assessments popup