### PR TITLE
GGRC-342 Second tree view collapses in Assessment tab

### DIFF
--- a/src/ggrc/assets/javascripts/components/tree/tree-widget-container.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-widget-container.js
@@ -351,7 +351,7 @@
           _refresh(true);
         }
 
-        if (_verifyRelationship(instance, activeTabModel)) {
+        if (_verifyRelationship(instance, activeTabModel, parentInstance)) {
           parentInstance.on('change', callback);
         } else if (activeTabModel === instance.type) {
           _refresh(true);
@@ -406,8 +406,17 @@
         self.loadItems();
       }
 
-      function _verifyRelationship(instance, shortName) {
+      function _verifyRelationship(instance, shortName, parentInstance) {
         if (!(instance instanceof CMS.Models.Relationship)) {
+          return false;
+        }
+
+        if (parentInstance && instance.destination && instance.source) {
+          if (instance.source.type === parentInstance.type &&
+            (instance.destination.type === shortName ||
+            instance.destination.type === 'Snapshot')) {
+            return true;
+          }
           return false;
         }
         if (instance.destination &&


### PR DESCRIPTION
_The issue is reproduced with the following steps:_
1. My work page > Regulation widget
2. Hover over Regulation first tier and select map to this object
3. Map any object to Regulations (e.g. Sections, select at least 3 Sections)
4. Hover over Regulation first tier and select Expand tree: tree view becomes grey and then collapses

_Actual Result_: tree view becomes grey and then collapses
_Expected Result_: tree view should not collapse