### PR TITLE
GGRC-2001 Workflow: Add State bubbles and State column on Active Cycles tab in tree view

### DIFF
--- a/src/ggrc/assets/javascripts/components/tree/tests/tree-item-extra-info_spec.js
+++ b/src/ggrc/assets/javascripts/components/tree/tests/tree-item-extra-info_spec.js
@@ -45,4 +45,51 @@ describe('GGRC.Components.treeItemExtraInfo', function () {
       }
     });
   });
+
+  describe('isOverdue property', function () {
+    it('returns true if workflow_status is "Overdue"', function () {
+      var result;
+      viewModel.attr('instance', {
+        workflow_state: 'Overdue'
+      });
+
+      result = viewModel.attr('isOverdue');
+
+      expect(result).toBe(true);
+    });
+
+    it('returns false if workflow_status is not "Overdue"', function () {
+      var result;
+      viewModel.attr('instance', {
+        workflow_state: 'AnyState'
+      });
+
+      result = viewModel.attr('isOverdue');
+
+      expect(result).toBe(false);
+    });
+
+    it('returns true if instance is "CycleTasks" and overdue', function () {
+      var result;
+      var instance = new CMS.Models.CycleTaskGroupObjectTask();
+      instance.attr('end_date', moment().subtract(5, 'd'));
+      viewModel.attr('instance', instance);
+
+      result = viewModel.attr('isOverdue');
+
+      expect(result).toBe(true);
+    });
+
+    it('returns false if instance is "CycleTasks" and not overdue',
+    function () {
+      var result;
+      var instance = new CMS.Models.CycleTaskGroupObjectTask();
+      instance.attr('end_date', moment().add(5, 'd'));
+      viewModel.attr('instance', instance);
+
+      result = viewModel.attr('isOverdue');
+
+      expect(result).toBe(false);
+    });
+  });
 });

--- a/src/ggrc/assets/javascripts/components/tree/tree-item-extra-info.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-item-extra-info.js
@@ -8,13 +8,6 @@
 
   var template = can.view(GGRC.mustache_path +
     '/components/tree/tree-item-extra-info.mustache');
-  var statusClasses = {
-    Verified: 'state-verified',
-    Assigned: 'state-assigned',
-    Finished: 'state-finished',
-    InProgress: 'state-inprogress',
-    Overdue: 'state-overdue'
-  };
 
   var viewModel = can.Map.extend({
     define: {
@@ -99,17 +92,27 @@
           return !!this.attr('instance.workflow_state');
         }
       },
+      isOverdue: {
+        type: 'boolean',
+        get: function () {
+          var isWorkflowOverdue =
+            this.attr('drawStatuses') &&
+            this.attr('instance.workflow_state') === 'Overdue';
+
+          var isCycleTasksOverdue =
+            this.attr('isCycleTasks') &&
+            this.attr('instance.isOverdue');
+
+          return isWorkflowOverdue || isCycleTasksOverdue;
+        }
+      },
       cssClasses: {
         type: 'string',
         get: function () {
           var classes = [];
-          var instance = this.attr('instance');
-          if (this.attr('drawStatuses')) {
-            classes.push(statusClasses[instance.workflow_state]);
-          }
 
-          if (this.attr('isCycleTasks') && this.attr('instance.isOverdue')) {
-            classes.push(statusClasses.Overdue);
+          if (this.attr('isOverdue')) {
+            classes.push('state-overdue');
           }
 
           if (this.attr('spin')) {

--- a/src/ggrc/assets/mustache/components/tree/tree-item-extra-info.mustache
+++ b/src/ggrc/assets/mustache/components/tree/tree-item-extra-info.mustache
@@ -136,16 +136,16 @@
               {{/if}}
               {{#switch instance.status}}
                 {{#case 'Verified'}}
-                  <span class="green">Verified</span>
+                  <span class="task-state state-verified">Verified</span>
                 {{/case}}
                 {{#case 'Assigned'}}
-                  <span class="gray">Assigned</span>
+                  <span class="task-state state-assigned">Assigned</span>
                 {{/case}}
                 {{#case 'Finished'}}
-                  <span class="blue">Finished</span>
+                  <span class="task-state state-finished">Finished</span>
                 {{/case}}
                 {{#case 'InProgress'}}
-                  <span class="orange">In progress</span>
+                  <span class="task-state state-inprogress">In progress</span>
                 {{/case}}
               {{/switch}}
             </div>

--- a/src/ggrc/assets/stylesheets/_widget.scss
+++ b/src/ggrc/assets/stylesheets/_widget.scss
@@ -380,6 +380,20 @@
           margin-right: 10px;
         }
       }
+      .task-state {
+        &.state-verified {
+          color: $status-verified;
+        }
+        &.state-assigned{
+          color: $status-draft;
+        }
+        &.state-finished {
+          color: $status-completed;
+        }
+        &.state-inprogress{
+          color: $status-inprogress;
+        }
+      }
     }
     a {
       margin: 10px 0 10px 15px;

--- a/src/ggrc/assets/stylesheets/components/tree/_tree-item-extra-info.scss
+++ b/src/ggrc/assets/stylesheets/components/tree/_tree-item-extra-info.scss
@@ -28,12 +28,6 @@ tree-item-extra-info {
     &.person-tooltip-trigger {
       font-size: 19px;
     }
-    &.state-verified {
-      color: $green;
-    }
-    &.state-inprogress {
-      color: $darkOrange;
-    }
     &.state-overdue {
       color: $status-declined;
       visibility: visible;


### PR DESCRIPTION
The ticket is reopened due to "i" icon is not correspond to requirements: 
"i" icon should be red for mapped to task object if task is overdue
"i" icon is grey for mapped to task object if task is assigned, in progress, finished, declined, verified.
Also , In progress state should be shown in blue color in Info popup. 
