### PR TITLE
GGRC-1930 Fix bug with flexbox overflow on Controls widget

### DIFF
--- a/src/ggrc/assets/mustache/components/tree/tree-header.mustache
+++ b/src/ggrc/assets/mustache/components/tree/tree-header.mustache
@@ -34,7 +34,7 @@
     </div>
   </tree-header-selector>
   {{/if}}
-  <div class="flex-box width-100">
+  <div class="flex-box tree-header-titles">
     {{#selectedColumns}}
       <div class="flex-box widget-col-title {{attr_sort_field}}" ($click)="onOrderChange($element)" data-field="{{attr_sort_field}}">
           <span>{{attr_title}}</span>

--- a/src/ggrc/assets/stylesheets/components/tree/_tree-view.scss
+++ b/src/ggrc/assets/stylesheets/components/tree/_tree-view.scss
@@ -4,6 +4,7 @@
  */
 
 $itemActionsWidth: 200px;
+$treeHeaderSelectorWidth: 56px;
 
 tree-widget-container {
   .tree-filter {
@@ -265,11 +266,15 @@ tree-header {
       margin-left: 0 !important;
       float: none !important;
       position: inherit !important;
-      width: 56px;
+      min-width: $treeHeaderSelectorWidth;
 
       .visible-columns-icon {
         position: inherit !important;
       }
+    }
+
+    .tree-header-titles {
+      width: calc(100% - #{$treeHeaderSelectorWidth});
     }
 
     .item-actions {


### PR DESCRIPTION
Tree-header component styles look broken on Controls widget in specific cases (long titles in custom attributes).

**Steps to reproduce:**

1. Add several very long custom attributes for controls
2. Navigate to Controls widget
3. Add long custom attributes via Set visible fields for Control
2. Look at Controls widget

**Actual Result:** Titles in the header are improperly aligned with text in the table columns.
**Expected Result:** Titles in the header should be properly aligned with text in the table columns.

**Fix overview:**

The reason is flexbox item overflow and improper width 100% of the titles' container.
Now the containers' width takes into account its sibling width (tree-header-selector element).