### PR TITLE
GGRC-2294 Edit old Threats migration

### DIFF
--- a/src/ggrc_risks/migrations/versions/20151112161029_62f26762d0a_add_missing_constraints_for_threats.py
+++ b/src/ggrc_risks/migrations/versions/20151112161029_62f26762d0a_add_missing_constraints_for_threats.py
@@ -10,8 +10,8 @@ Create Date: 2015-11-12 16:10:29.579969
 """
 
 from alembic import op
-from ggrc.migrations.utils.resolve_duplicates import resolve_duplicates
-from ggrc_risks.models import Threat
+# from ggrc.migrations.utils.resolve_duplicates import resolve_duplicates
+# from ggrc_risks.models import Threat
 
 # revision identifiers, used by Alembic.
 revision = '62f26762d0a'
@@ -19,7 +19,7 @@ down_revision = '2837682ad516'
 
 
 def upgrade():
-  resolve_duplicates(Threat, 'slug')
+  # resolve_duplicates(Threat, 'slug')
   op.create_unique_constraint('uq_threats', 'threats', ['slug'])
 
 


### PR DESCRIPTION
Migrations should not use ggrc models and the ones that do should be
disabled after they are run on prod. This fixes issues with creating new
models whose tables do not yet exist.

This change is safe because the migration has already been run on all
deployed instances, and when doing a migration for a fresh database
there can not be any duplicates so the commented line can be ignored.