### PR TITLE
GGRC-1959 Fix attribute validator name check

### DIFF
--- a/src/ggrc/access_control/role.py
+++ b/src/ggrc/access_control/role.py
@@ -83,7 +83,6 @@ class AccessControlRole(Indexed, attributevalidator.AttributeValidator,
     else:
       return value.strip()
 
-    name = value.strip()
     if name in self._get_reserved_names(object_type):
       raise ValueError(u"Attribute name '{}' is reserved for this object type."
                        .format(name))


### PR DESCRIPTION
This fixes the issue discovered by @ahetmanski in https://github.com/google/ggrc-core/pull/5638#discussion_r118198024

