### PR TITLE
GGRC-1523 Fix border for empty tree view

### DIFF
--- a/src/ggrc/assets/stylesheets/components/tree/_tree-view.scss
+++ b/src/ggrc/assets/stylesheets/components/tree/_tree-view.scss
@@ -86,7 +86,7 @@ tree-view {
   flex-direction: column;
   font-size: 13px !important;
   margin-bottom: 40px;
-  margin-top: 110px;
+  margin-top: 115px;
   position: relative;
   color: rgba(0, 0, 0, .7);
 


### PR DESCRIPTION
**Actual result:**
![screenshot-8](https://cloud.githubusercontent.com/assets/4737102/26446543/2d0821dc-414d-11e7-905c-f7b21134562c.png)

**Expected result:**
The bottom border is agreed with the UX
![screenshot-1](https://cloud.githubusercontent.com/assets/4737102/26446541/2a596734-414d-11e7-8ba8-4ee184441ee1.png)

