### PR TITLE
GGRC-2296 Fix JS error on create new Assessment modal

### DIFF
--- a/src/ggrc/assets/mustache/assessments/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessments/modal_content.mustache
@@ -118,23 +118,39 @@
           <div class="objective-selector">
             <div style="clear:both">
               <br>
-              <a class="section-add section-sticky btn btn-small btn-white"
-                 href="javascript://" rel="tooltip"
-                 {{data "deferred_to"}}
-                 data-placement="left"
-                 data-toggle="unified-mapper"
-                 data-deferred="true"
-                 data-object-source="true"
-                 data-is-new="{{instance.isNew}}"
-                 data-join-object-id="{{instance.id}}"
-                 data-join-object-type="{{instance.class.model_singular}}"
-                 data-original-title="Map Object to this {{instance.class.title_singular}}" tabindex="6"
-                 {{#instance.audit }}
-                 data-snapshot-scope-id="{{instance.audit.id}}"
-                 data-snapshot-scope-type="{{instance.audit.type}}"
-                 {{/instance.audit}}>
-                   Map Objects
-              </a>
+              {{#if instance.audit}}
+                <a class="section-add section-sticky btn btn-small btn-white"
+                   href="javascript://" rel="tooltip"
+                  {{data "deferred_to"}}
+                   data-placement="left"
+                   data-toggle="unified-mapper"
+                   data-deferred="true"
+                   data-object-source="true"
+                   data-is-new="{{instance.isNew}}"
+                   data-join-object-id="{{instance.id}}"
+                   data-join-object-type="{{instance.class.model_singular}}"
+                   data-original-title="Map Object to this {{instance.class.title_singular}}" tabindex="6"
+                   data-snapshot-scope-id="{{instance.audit.id}}"
+                   data-snapshot-scope-type="{{instance.audit.type}}"
+                >
+                  Map Objects
+                </a>
+              {{else}}
+                <a class="section-add section-sticky btn btn-small btn-white"
+                   href="javascript://" rel="tooltip"
+                  {{data "deferred_to"}}
+                   data-placement="left"
+                   data-toggle="unified-mapper"
+                   data-deferred="true"
+                   data-object-source="true"
+                   data-is-new="{{instance.isNew}}"
+                   data-join-object-id="{{instance.id}}"
+                   data-join-object-type="{{instance.class.model_singular}}"
+                   data-original-title="Map Object to this {{instance.class.title_singular}}" tabindex="6"
+                >
+                  Map Objects
+                </a>
+              {{/if}}
             </div>
           </div>
       </ggrc-modal-connector>


### PR DESCRIPTION
**Steps to reproduce:**
1. On the audit page Invoke new Assessments modal window
2. Fill in required fields and click Save and Add another button
3. Once new Assessments modal window appears type title and click Map objects button

_Actual Result:_ "Uncaught TypeError: CMS.Models[item.type] is not a constructor at Constructor." error occurs if click Map objects button on New Assessments window
_Expected Result:_ no error is displayed. Unified mapper is displayed to map snapshot to Assessment