### PR TITLE
GGRC-1529 Related Assessments popup improve

### DIFF
--- a/src/ggrc/assets/mustache/components/object-popover/related-assessment-popover.mustache
+++ b/src/ggrc/assets/mustache/components/object-popover/related-assessment-popover.mustache
@@ -11,11 +11,11 @@
             <div class="fields-wrapper flex-box flex-row">
                 <show-more items="selectedAssessmentFields">
                     <div class="field-wrapper flex-size-1">
-                        <ca-object-validation-icon {validation}="validation"></ca-object-validation-icon>
-                        <div class="field-title">
-                            <label class="field-title__text" for="form-field-{{id}}">{{title}}</label>
+                        <form-validation-icon {validation}="validation"></form-validation-icon>
+                        <div class="field__title form-field__title">
+                            <label class="field__title-text" for="form-field-{{id}}">{{title}}</label>
                             {{#if helptext}}
-                                <i class="fa fa-question-circle helper-text" rel="tooltip" title="{{helptext}}"></i>
+                                <i class="fa fa-question-circle field__title-helper-text" rel="tooltip" title="{{helptext}}"></i>
                             {{/if}}
                         </div>
                         <auto-save-form-field-view

--- a/src/ggrc/assets/stylesheets/_common.scss
+++ b/src/ggrc/assets/stylesheets/_common.scss
@@ -775,7 +775,7 @@ p {
     display: inline-block;
 
     &:before {
-      top: 7px;
+      top: 4px;
     }
   }
 

--- a/src/ggrc/assets/stylesheets/components/action-button/_action-button.scss
+++ b/src/ggrc/assets/stylesheets/components/action-button/_action-button.scss
@@ -182,6 +182,11 @@
       color: $darkBlue;
     }
 
+    .related-assessments &:hover {
+      text-decoration: underline;
+      color: $blue;
+    }
+
     &.selected {
       background: #40c4ff;
       color: $white;

--- a/src/ggrc/assets/stylesheets/components/auto-save-form/_auto-save-form.scss
+++ b/src/ggrc/assets/stylesheets/components/auto-save-form/_auto-save-form.scss
@@ -15,6 +15,8 @@ auto-save-form {
 .fields-wrapper > show-more {
   display: flex;
   flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: flex-start;
 
   .limit-button-container {
     width: 100%;

--- a/src/ggrc/assets/stylesheets/components/grid-data/_grid-data.scss
+++ b/src/ggrc/assets/stylesheets/components/grid-data/_grid-data.scss
@@ -127,6 +127,14 @@
   padding: 8px 0;
   border-bottom: 1px solid #ccc;
   cursor: default;
+  line-height: 16px;
+  a {
+    line-height: 16px;
+    display: inline-block;
+  }
+  a:hover {
+    text-decoration: underline;
+  }
   // Extra style for columns
   > * {
     overflow: hidden;

--- a/src/ggrc/assets/stylesheets/components/object-list/_object-list.scss
+++ b/src/ggrc/assets/stylesheets/components/object-list/_object-list.scss
@@ -66,3 +66,6 @@ object-list {
 related-assessment-list > spinner.active {
   opacity: 0.5;
 }
+related-assessment-list > object-list > .empty-message {
+  margin: auto;
+}

--- a/src/ggrc/assets/stylesheets/components/simple-modal/_simple-modal.scss
+++ b/src/ggrc/assets/stylesheets/components/simple-modal/_simple-modal.scss
@@ -103,4 +103,3 @@ $grid-data-header-height: 66px;
     background: $white;
   }
 }
-

--- a/src/ggrc/assets/stylesheets/components/tree/_tree-item-extra-info.scss
+++ b/src/ggrc/assets/stylesheets/components/tree/_tree-item-extra-info.scss
@@ -116,17 +116,21 @@ tree-item-actions {
 
       &:hover {
         background-color: $lightGray !important;
-        a {
+        
+        > a, show-related-assessments-button > a,
+        tree-item-map > a, sub-tree-models > a {
           color: $black !important;
         }
       }
-      a {
+      > a, show-related-assessments-button > a,
+      tree-item-map > a, sub-tree-models > a {
         line-height: 30px;
         color: $black;
         display: block;
         font-size: 13px;
         padding: 5px 15px;
         text-decoration: none;
+        cursor: pointer;
 
         i.fa {
           margin-right: 3px;


### PR DESCRIPTION
1. Decrease padding between rows in Assessment title and Assessment state.
2. Evidence/URLs should be shown in one row and cut off with 3 dots.
3. Make "Show more" link for ATTACHMENTS / URLS.
4. Underline "Show more"/"Show less" link when hover over it in Info popup in Attributes and Comments.
5. Improve formatting for Custom attributes in Info pop up.
7. "There was" an error is shown while opening "Comments" in Info popup.
8. Field is not marked as required in Info popup.
9. Improve formatting of Evidence/URLs in Related Assessment if open it on Controls/Objectives.
10. Assessments title is not shown as a link in Related Assessment window if open it via on Controls/Objectives tree view.