### PR TITLE
GGRC-2256 modify backend contract for Evidence 

### DIFF
--- a/src/ggrc/models/object_document.py
+++ b/src/ggrc/models/object_document.py
@@ -108,10 +108,6 @@ PublicDocumentable = type(
     "PublicDocumentable",
     (Documentable, ),
     {
-        "_publish_attrs": [
-            "document_url",
-            "document_evidence",
-        ],
         "_aliases": {
             "document_url": {
                 "display_name": "Url",

--- a/test/integration/ggrc/services/test_query/test_document.py
+++ b/test/integration/ggrc/services/test_query/test_document.py
@@ -1,0 +1,51 @@
+# coding: utf-8
+
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Tests for /query api endpoint."""
+
+import ddt
+
+from ggrc.models import all_models
+
+from integration.ggrc import TestCase
+from integration.ggrc.api_helper import Api
+from integration.ggrc.models import factories
+
+
+@ddt.ddt
+class TestDocumentQueries(TestCase):
+  """Tests for /query api for Audit snapshots"""
+
+  def setUp(self):
+    super(TestDocumentQueries, self).setUp()
+    self.api = Api()
+
+  @ddt.data(all_models.Document.ATTACHMENT, all_models.Document.URL)
+  def test_query_(self, document_type):
+    """test get audit as query get"""
+    data = {
+        all_models.Document.ATTACHMENT: factories.EvidenceFactory().id,
+        all_models.Document.URL: factories.UrlFactory().id,
+    }
+    query_request_data = [{
+        u'fields': [],
+        u'filters': {
+            u'expression': {
+                u'left': u'document_type',
+                u'op': {u'name': u'='},
+                u'right': document_type,
+            }
+        },
+        u'limit': [0, 5],
+        u'object_name': u'Document',
+        u'permissions': u'read',
+        u'type': u'values',
+    }]
+    resp = self.api.send_request(self.api.client.post,
+                                 data=query_request_data,
+                                 api_link="/query")
+    self.assertEqual(1, resp.json[0]["Document"]["count"])
+    self.assertEqual(data[document_type],
+                     resp.json[0]["Document"]["values"][0]["id"])


### PR DESCRIPTION
~depends on https://github.com/google/ggrc-core/pull/5667~ 
1) Check evidences are shown as part of QueryAPI selection array of "relevant filter";
2) Check evidences are only items selected by QueryAPI call "relevant" + document_type == "EVIDENCE";
3)  Add relationship object to "related_destinations" array of business objects to indicate relationship between actual evidence and business object;
4) Remove redundant "document_evidence" and "document_url" arrays from business object;
5) Check availability work of revision comparer functionality for controls in cases when new revision was created by attaching of new evidence.