### PR TITLE
GGRC-2287 If "Task due date" is today it is shown as overdue in WF

### DIFF
--- a/src/ggrc/assets/javascripts/models/mixins.js
+++ b/src/ggrc/assets/javascripts/models/mixins.js
@@ -323,7 +323,7 @@
         this.attr('next_due_date') || this.attr('end_date'));
       var today = moment().startOf('day');
       var startOfDate = moment(endDate).startOf('day');
-      var isOverdue = endDate && today.diff(startOfDate, 'days') >= 0;
+      var isOverdue = endDate && today.diff(startOfDate, 'days') > 0;
       if (this.attr('status') === 'Verified') {
         return false;
       }

--- a/src/ggrc/assets/javascripts/models/tests/isOverdue_mixin_spec.js
+++ b/src/ggrc/assets/javascripts/models/tests/isOverdue_mixin_spec.js
@@ -45,5 +45,23 @@ describe('can.Model.Mixin.isOverdue', function () {
       instance.attr('next_due_date', '2015-01-01');
       expect(method.apply(instance)).toEqual(false);
     });
+
+    it('returns true, if next_due_date is earlier than today', function () {
+      var result;
+      instance.attr('next_due_date', moment().subtract(1, 'd'));
+
+      result = method.apply(instance);
+
+      expect(result).toEqual(true);
+    });
+
+    it('returns false, if next_due_date is today', function () {
+      var result;
+      instance.attr('next_due_date', moment());
+
+      result = method.apply(instance);
+
+      expect(result).toEqual(false);
+    });
   });
 });

--- a/src/ggrc_workflows/assets/javascripts/controllers/dashboard_page.js
+++ b/src/ggrc_workflows/assets/javascripts/controllers/dashboard_page.js
@@ -126,8 +126,7 @@
             if (data.status === 'Verified')
               verified++;
             else {
-              // TODO: [Overdue] Move this logic to helper.
-              if (end_date.getTime() < today.getTime()) {
+              if (data.isOverdue) {
                 over_due++;
                 $('dashboard-errors').control().scope.attr('error_msg', 'Some tasks are overdue!');
               }


### PR DESCRIPTION
Steps to reproduce:
1. Create one time WF
2. Create task with Due date "today"
3. Activate WF
4. At Active Cycles tab look at the Task's first tier and "i" icon: is shown as overdue
Actual Result: If "Task due date" is today it is shown as overdue in WF
Expected Result: If "Task due date" is today "i" icon should be gray and task should not be overdue