### PR TITLE
GGRC-2181 People in tree view appear with latency

### DIFF
--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -117,6 +117,7 @@ dashboard-js-files:
   - models/join_models.js
   # ViewModels
   - components/view-models/tree-item-base-vm.js
+  - components/view-models/tree-people-base-vm.js
   - components/base-objects/pagination.js
   # Controllers
   - controllers/filterable_controller.js

--- a/src/ggrc/assets/javascripts/components/tree/tree-people-list-field.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-people-list-field.js
@@ -66,10 +66,13 @@
         return can.makeArray(this.attr(sourceString));
       },
       loadItems: function (items) {
-        var ids = items.map(function (item) {
-          return item.id;
+        var rq = new RefreshQueue();
+
+        can.each(items, function (item) {
+          rq.enqueue(CMS.Models.Person.model(item));
         });
-        return CMS.Models.Person.findAll({id__in: ids.join(',')});
+
+        return rq.trigger();
       }
     }),
     events: {

--- a/src/ggrc/assets/javascripts/components/tree/tree-people-list-field.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-people-list-field.js
@@ -6,75 +6,24 @@
 (function (can, GGRC) {
   'use strict';
 
+  var viewModel = GGRC.VM.BaseTreePeopleField.extend({
+    filter: '@',
+    getSourceList: function () {
+      var filter = this.attr('filter');
+      var sourceString = 'source';
+
+      if (filter) {
+        sourceString += '.' + filter;
+      }
+
+      return can.makeArray(this.attr(sourceString));
+    }
+  });
+
   GGRC.Components('treePeopleListField', {
     tag: 'tree-people-list-field',
     template: '<content />',
-    viewModel: can.Map.extend({
-      source: null,
-      filter: '@',
-      people: [],
-      peopleStr: '',
-      init: function () {
-        this.refreshPeople();
-      },
-      refreshPeople: function () {
-        this.getPeopleList()
-          .then(function (data) {
-            this.attr('people', data);
-            this.attr('peopleStr', data.map(function (item) {
-              return item.displayName;
-            }).join(', '));
-          }.bind(this));
-      },
-      getPeopleList: function () {
-        var sourceList = this.getSourceList();
-        var result;
-        var deferred = can.Deferred();
-
-        if (!sourceList.length) {
-          return deferred.resolve([]);
-        }
-
-        this.loadItems(sourceList)
-          .then(function (data) {
-            result = data.map(function (item) {
-              var shortEmail = item.email.replace(/@.*$/, '');
-              var displayName = item.name || shortEmail;
-              return {
-                name: item.name,
-                email: item.email,
-                shortEmail: shortEmail,
-                displayName: displayName
-              };
-            });
-            deferred.resolve(result);
-          })
-          .fail(function () {
-            deferred.resolve([]);
-          });
-
-        return deferred;
-      },
-      getSourceList: function () {
-        var filter = this.attr('filter');
-        var sourceString = 'source';
-
-        if (filter) {
-          sourceString += '.' + filter;
-        }
-
-        return can.makeArray(this.attr(sourceString));
-      },
-      loadItems: function (items) {
-        var rq = new RefreshQueue();
-
-        can.each(items, function (item) {
-          rq.enqueue(CMS.Models.Person.model(item));
-        });
-
-        return rq.trigger();
-      }
-    }),
+    viewModel: viewModel,
     events: {
       '{viewModel} source': function () {
         this.viewModel.refreshPeople();

--- a/src/ggrc/assets/javascripts/components/tree/tree-people-with-role-list-field.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-people-with-role-list-field.js
@@ -6,70 +6,19 @@
 (function (can, GGRC) {
   'use strict';
 
+  var viewModel = GGRC.VM.BaseTreePeopleField.extend({
+    role: null,
+    getSourceList: function () {
+      var roleName = this.attr('role');
+      var instance = this.attr('source');
+      return GGRC.Utils.peopleWithRoleName(instance, roleName);
+    }
+  });
+
   GGRC.Components('treePeopleWithRoleListField', {
     tag: 'tree-people-with-role-list-field',
     template: '<content />',
-    viewModel: can.Map.extend({
-      source: null,
-      role: null,
-      people: [],
-      peopleStr: '',
-      init: function () {
-        this.refreshPeople();
-      },
-      refreshPeople: function () {
-        this.getPeopleList()
-          .then(function (data) {
-            this.attr('people', data);
-            this.attr('peopleStr', data.map(function (item) {
-              return item.displayName;
-            }).join(', '));
-          }.bind(this));
-      },
-      getPeopleList: function () {
-        var sourceList = this.getSourceList();
-        var result;
-        var deferred = can.Deferred();
-
-        if (!sourceList.length) {
-          return deferred.resolve([]);
-        }
-
-        this.loadItems(sourceList)
-          .then(function (data) {
-            result = data.map(function (item) {
-              var shortEmail = item.email.replace(/@.*$/, '');
-              var displayName = item.name || shortEmail;
-              return {
-                name: item.name,
-                email: item.email,
-                shortEmail: shortEmail,
-                displayName: displayName
-              };
-            });
-            deferred.resolve(result);
-          })
-          .fail(function () {
-            deferred.resolve([]);
-          });
-
-        return deferred;
-      },
-      getSourceList: function () {
-        var roleName = this.attr('role');
-        var instance = this.attr('source');
-        return GGRC.Utils.peopleWithRoleName(instance, roleName);
-      },
-      loadItems: function (items) {
-        var rq = new RefreshQueue();
-
-        can.each(items, function (item) {
-          rq.enqueue(CMS.Models.Person.model(item));
-        });
-
-        return rq.trigger();
-      }
-    }),
+    viewModel: viewModel,
     events: {
       '{viewModel} source': function () {
         this.viewModel.refreshPeople();

--- a/src/ggrc/assets/javascripts/components/tree/tree-people-with-role-list-field.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-people-with-role-list-field.js
@@ -58,12 +58,16 @@
       getSourceList: function () {
         var roleName = this.attr('role');
         var instance = this.attr('source');
-        var peopleIds = GGRC.Utils.peopleWithRoleName(instance, roleName);
-
-        return peopleIds;
+        return GGRC.Utils.peopleWithRoleName(instance, roleName);
       },
-      loadItems: function (ids) {
-        return CMS.Models.Person.findAll({id__in: ids.join(',')});
+      loadItems: function (items) {
+        var rq = new RefreshQueue();
+
+        can.each(items, function (item) {
+          rq.enqueue(CMS.Models.Person.model(item));
+        });
+
+        return rq.trigger();
       }
     }),
     events: {

--- a/src/ggrc/assets/javascripts/components/view-models/tree-people-base-vm.js
+++ b/src/ggrc/assets/javascripts/components/view-models/tree-people-base-vm.js
@@ -1,0 +1,69 @@
+/*!
+ Copyright (C) 2017 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+(function (can, GGRC) {
+  'use strict';
+
+  can.Map.extend('GGRC.VM.BaseTreePeopleField', {
+    source: null,
+    people: [],
+    peopleStr: '',
+    init: function () {
+      this.refreshPeople();
+    },
+    refreshPeople: function () {
+      this.getPeopleList()
+        .then(function (data) {
+          this.attr('people', data);
+          this.attr('peopleStr', data.map(function (item) {
+            return item.displayName;
+          }).join(', '));
+        }.bind(this));
+    },
+    getPeopleList: function () {
+      var sourceList = this.getSourceList();
+      var result;
+      var deferred = can.Deferred();
+
+      if (!sourceList.length) {
+        return deferred.resolve([]);
+      }
+
+      this.loadItems(sourceList)
+        .then(function (data) {
+          result = data.map(function (item) {
+            var shortEmail = item.email.replace(/@.*$/, '');
+            var displayName = item.name || shortEmail;
+            return {
+              name: item.name,
+              email: item.email,
+              shortEmail: shortEmail,
+              displayName: displayName
+            };
+          });
+          deferred.resolve(result);
+        })
+        .fail(function () {
+          deferred.resolve([]);
+        });
+
+      return deferred;
+    },
+    getSourceList: function () {
+      console.warn('Function "getSourceList" is not implemented,' +
+        'please implement');
+      return [];
+    },
+    loadItems: function (items) {
+      var rq = new RefreshQueue();
+
+      can.each(items, function (item) {
+        rq.enqueue(CMS.Models.Person.model(item));
+      });
+
+      return rq.trigger();
+    }
+  });
+})(window.can, window.GGRC);

--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -2829,7 +2829,10 @@ Example:
         return options.fn({peopleIds: []});
       }
 
-      peopleIds = GGRC.Utils.peopleWithRoleName(instance, roleName);
+      peopleIds = GGRC.Utils.peopleWithRoleName(instance, roleName)
+        .map(function (person) {
+          return person.id;
+        });
 
       if (peopleIds.length > 0) {
         return options.fn({peopleIds: peopleIds});

--- a/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
+++ b/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
@@ -483,7 +483,7 @@
      * @param {CMS.Models.Cacheable} instance - a model instance
      * @param {String} roleName - the name of the custom role
      *
-     * @return {Array} - list of people IDs
+     * @return {Array} - list of people
      */
     peopleWithRoleName: function (instance, roleName) {
       var modelRoles;
@@ -509,7 +509,7 @@
       peopleIds = _
           .chain(instance.access_control_list)
           .filter({ac_role_id: roleId})
-          .map('person.id')
+          .map('person')
           .value();
 
       return peopleIds;

--- a/src/ggrc/assets/javascripts/plugins/tests/ggrc_utils_spec.js
+++ b/src/ggrc/assets/javascripts/plugins/tests/ggrc_utils_spec.js
@@ -187,10 +187,12 @@ describe('GGRC utils peopleWithRoleName() method', function () {
     });
   });
 
-  it('returns user IDs that have a role granted on a particular instance',
+  it('returns users that have a role granted on a particular instance',
     function () {
       var result = method(instance, 'Role B');
-      expect(result.sort()).toEqual([2, 5]);
+      expect(result.map(function (person) {
+        return person.id;
+      }).sort()).toEqual([2, 5]);
     }
   );
 


### PR DESCRIPTION
**Steps to reproduce:**
1. Have at least 10 assessment with Creators, Assignees, Verifiers on the audit page
2. Go to Assessments tab
3. Set visible fields Creators, Assignees, Verifiers
4. Refresh the page and look at the People loading: appear with latency

_Actual Result:_ People in tree view appear with latency 
_Expected Result:_ improve performance of people display in tree view

***Note:*** such behavior concerns not only original objects but snapshots as well. E.g. Controls - too slow display in tree view of Principal/Secondary assignees, Primary/Secondary contacts

