### PR TITLE
GGRC-2308 Fix access control role validation

### DIFF
--- a/src/ggrc/access_control/role.py
+++ b/src/ggrc/access_control/role.py
@@ -74,14 +74,15 @@ class AccessControlRole(Indexed, attributevalidator.AttributeValidator,
     Returns:
       value if the name passes all uniqueness checks.
     """
+    value = value.strip()
     if key == "name" and self.object_type:
-      name = value.strip()
+      name = value
       object_type = self.object_type
     elif key == "object_type" and self.name:
       name = self.name.strip()
-      object_type = value.strip()
+      object_type = value
     else:
-      return value.strip()
+      return value
 
     if name in self._get_reserved_names(object_type):
       raise ValueError(u"Attribute name '{}' is reserved for this object type."
@@ -91,6 +92,4 @@ class AccessControlRole(Indexed, attributevalidator.AttributeValidator,
       raise ValueError(u"Global custom attribute '{}' "
                        u"already exists for this object type"
                        .format(name))
-    if key == "name":
-      return name
-    return object_type
+    return value

--- a/src/ggrc/access_control/role.py
+++ b/src/ggrc/access_control/role.py
@@ -91,5 +91,6 @@ class AccessControlRole(Indexed, attributevalidator.AttributeValidator,
       raise ValueError(u"Global custom attribute '{}' "
                        u"already exists for this object type"
                        .format(name))
-
-    return name
+    if key == "name":
+      return name
+    return object_type

--- a/test/unit/ggrc/models/test_access_control_roles.py
+++ b/test/unit/ggrc/models/test_access_control_roles.py
@@ -1,0 +1,45 @@
+"""Test Access Control Role validation"""
+
+import unittest
+from mock import MagicMock
+
+import ggrc.app  # noqa pylint: disable=unused-import
+from ggrc.models import all_models
+
+
+class TestAccessControlRoles(unittest.TestCase):
+  """Test Access Control Role validation"""
+
+  def setUp(self):
+    # pylint: disable=protected-access
+    self.acr = all_models.AccessControlRole()
+    self.acr._get_reserved_names = MagicMock(return_value=frozenset({'title'}))
+    self.acr._get_global_cad_names = MagicMock(
+        return_value={'reg url': 1})
+
+  def test_simple_validation(self):
+    """Test if access control role validation sets the fields correctly"""
+    name, object_type = "New Object name", "Control"
+    self.acr.name = name
+    self.acr.object_type = object_type
+    assert self.acr.name == name, \
+        "Access control name not properly set {} != {}".format(
+            self.acr.name, name)
+    assert self.acr.object_type == object_type, \
+        "Access control object type not properly set {} != {}".format(
+            self.acr.object_type, object_type)
+
+  def test_invalid_name_throws(self):
+    """Test if raises on collision with global attributes"""
+
+    with self.assertRaises(ValueError):
+      name, object_type = "title", "Control"
+      self.acr.name = name
+      self.acr.object_type = object_type
+
+  def test_if_invalid_ca_check(self):
+    """Test if raises on collision with custom attributes attributes"""
+    with self.assertRaises(ValueError):
+      name, object_type = "reg url", "Regulation"
+      self.acr.name = name
+      self.acr.object_type = object_type


### PR DESCRIPTION
Validating object_type property was accidentally changing it's value to
the name of the the role.

The regression was caused by https://github.com/google/ggrc-core/pull/5638