### PR TITLE
GGRC-140 Fix bug with audit roles

### DIFF
--- a/src/ggrc/assets/javascripts/models/mappers/tree-base-loader.js
+++ b/src/ggrc/assets/javascripts/models/mappers/tree-base-loader.js
@@ -37,6 +37,9 @@
           binding.instance.object_people.length) {
           result = CMS.Models.Person
             .getPersonMappings(binding.instance, instance, 'object_people');
+        } else if (binding.instance instanceof CMS.Models.Audit) {
+          result = CMS.Models.Person
+            .getUserRoles(binding.instance, instance, 'program');
         } else {
           result = CMS.Models.Person
             .getUserRoles(binding.instance, instance);

--- a/src/ggrc/assets/javascripts/models/person.js
+++ b/src/ggrc/assets/javascripts/models/person.js
@@ -107,7 +107,7 @@
       this.validateNonBlank('email');
       this.validateFormatOf('email', rEmail);
     },
-    getUserRoles: function (instance, person, specificOject) {
+    getUserRoles: function (instance, person, specificObject) {
       var result = $.Deferred();
       var refreshQueue = new RefreshQueue();
       var userRoles;
@@ -126,8 +126,8 @@
             role.context.id === instance.context.id;
         });
 
-        if (_.isEmpty(userRoles) && !_.isEmpty(specificOject)) {
-          object = _.get(instance, specificOject);
+        if (_.isEmpty(userRoles) && !_.isEmpty(specificObject)) {
+          object = _.get(instance, specificObject);
           objectInstance = _.result(object, 'getInstance');
           objectContextId = _.get(objectInstance, 'context_id');
 
@@ -140,9 +140,9 @@
       });
       return result.promise();
     },
-    getPersonMappings: function (instance, person, specificOject) {
+    getPersonMappings: function (instance, person, specificObject) {
       var result = $.Deferred();
-      var mappingObject = instance[specificOject];
+      var mappingObject = instance[specificObject];
       var mappingsRQ = new RefreshQueue();
       var userRolesRQ = new RefreshQueue();
 

--- a/src/ggrc/assets/javascripts/models/person.js
+++ b/src/ggrc/assets/javascripts/models/person.js
@@ -107,7 +107,7 @@
       this.validateNonBlank('email');
       this.validateFormatOf('email', rEmail);
     },
-    getUserRoles: function (instance, person) {
+    getUserRoles: function (instance, person, specificOject) {
       var result = $.Deferred();
       var refreshQueue = new RefreshQueue();
       var userRoles;
@@ -117,10 +117,25 @@
       });
 
       refreshQueue.trigger().then(function (roles) {
+        var object;
+        var objectInstance;
+        var objectContextId;
+
         userRoles = _.filter(roles, function (role) {
           return instance.context && role.context &&
             role.context.id === instance.context.id;
         });
+
+        if (_.isEmpty(userRoles) && !_.isEmpty(specificOject)) {
+          object = _.get(instance, specificOject);
+          objectInstance = _.result(object, 'getInstance');
+          objectContextId = _.get(objectInstance, 'context_id');
+
+          userRoles = _.filter(roles, function (role) {
+            return role.context && role.context.id === objectContextId;
+          });
+        }
+
         result.resolve(userRoles);
       });
       return result.promise();

--- a/src/ggrc/assets/javascripts/models/person.js
+++ b/src/ggrc/assets/javascripts/models/person.js
@@ -107,6 +107,18 @@
       this.validateNonBlank('email');
       this.validateFormatOf('email', rEmail);
     },
+
+    /**
+     * @description
+     * Retrieves user roles for the person according to
+     * instance or/and specific object contexts
+     *
+     * @param  {Object} instance - Instance object
+     * @param  {CMS.Models.Person} person - Person object
+     * @param  {String} specificObject - Property of instance object
+     * @return {Promise.<Object[]>} - Returns promise with person's user roles
+     */
+
     getUserRoles: function (instance, person, specificObject) {
       var result = $.Deferred();
       var refreshQueue = new RefreshQueue();

--- a/src/ggrc/assets/javascripts/models/tests/person_model_spec.js
+++ b/src/ggrc/assets/javascripts/models/tests/person_model_spec.js
@@ -1,0 +1,109 @@
+/*!
+  Copyright (C) 2017 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+describe('CMS.Models.Person', function () {
+  'use strict';
+
+  describe('when requesting person\'s user roles', function () {
+    var method;
+    var person;
+    var fakeUserRole1;
+    var fakeUserRole2;
+    var fakeUserRoleInstace1;
+    var fakeUserRoleInstace2;
+    var instance;
+    var refreshedUserRoles = [];
+    var fakeProgramInstance;
+
+    beforeEach(function () {
+      fakeProgramInstance = jasmine.createSpyObj(
+        'fakeProgramInstance', ['getInstance']
+      );
+      fakeProgramInstance.getInstance.and.returnValue({
+        context_id: 666
+      });
+      instance = {
+        context: {
+          id: 444
+        },
+        program: fakeProgramInstance
+      };
+      person = new CMS.Models.Person();
+      method = CMS.Models.Person.getUserRoles;
+      fakeUserRole1 = jasmine.createSpyObj('fakeUserRole', ['getInstance']);
+      fakeUserRole2 = jasmine.createSpyObj('fakeUserRole', ['getInstance']);
+      fakeUserRoleInstace1 = {id: 1};
+      fakeUserRoleInstace2 = {id: 2};
+      fakeUserRole1.getInstance.and.returnValue(fakeUserRoleInstace1);
+      fakeUserRole2.getInstance.and.returnValue(fakeUserRoleInstace2);
+      person.user_roles = [fakeUserRole1, fakeUserRole2];
+    });
+
+    it('should enqueue user roles instances for refresh', function () {
+      var dfd = $.when();
+      spyOn(RefreshQueue.prototype, 'enqueue');
+      spyOn(RefreshQueue.prototype, 'trigger').and.returnValue(dfd);
+      method(instance, person);
+      expect(RefreshQueue.prototype.enqueue.calls.count()).toEqual(2);
+      expect(RefreshQueue.prototype.enqueue)
+        .toHaveBeenCalledWith(fakeUserRoleInstace1);
+      expect(RefreshQueue.prototype.enqueue)
+        .toHaveBeenCalledWith(fakeUserRoleInstace2);
+    });
+
+    it('should apply a filter to user roles based on ' +
+      'the instance and role contexts after refresh',
+      function () {
+        var dfd;
+        refreshedUserRoles = [{
+          context: {
+            id: 444
+          }
+        }, {
+          context: {
+            id: 555
+          }
+        }];
+        dfd = $.when(refreshedUserRoles);
+        spyOn(RefreshQueue.prototype, 'enqueue');
+        spyOn(RefreshQueue.prototype, 'trigger').and.returnValue(dfd);
+        method(instance, person).then(function (roles) {
+          expect(roles).toEqual([refreshedUserRoles[0]]);
+        });
+      }
+    );
+
+    describe('and specificOject is defined', function () {
+      var specificObject;
+
+      beforeEach(function () {
+        specificObject = 'program';
+        refreshedUserRoles = [{
+          context: {
+            id: 555
+          }
+        }, {
+          context: {
+            id: 666
+          }
+        }];
+      });
+
+      it('should apply a filter to user roles based on ' +
+        'the specificObject and role contexts after refresh' +
+        'if all user roles were rejected for the instance context',
+        function () {
+          var dfd = $.when(refreshedUserRoles);
+          var validateExpectation = function (roles) {
+            expect(roles).toEqual([refreshedUserRoles[1]]);
+          };
+          spyOn(RefreshQueue.prototype, 'enqueue');
+          spyOn(RefreshQueue.prototype, 'trigger').and.returnValue(dfd);
+          method(instance, person, specificObject).then(validateExpectation);
+        }
+      );
+    });
+  });
+});

--- a/src/ggrc/assets/javascripts/models/tests/person_model_spec.js
+++ b/src/ggrc/assets/javascripts/models/tests/person_model_spec.js
@@ -6,7 +6,7 @@
 describe('CMS.Models.Person', function () {
   'use strict';
 
-  describe('when requesting person\'s user roles', function () {
+  describe('getUserRoles() method', function () {
     var method;
     var person;
     var fakeUserRole1;
@@ -75,7 +75,7 @@ describe('CMS.Models.Person', function () {
       }
     );
 
-    describe('and specificOject is defined', function () {
+    describe('when specificObject is passed', function () {
       var specificObject;
 
       beforeEach(function () {

--- a/src/ggrc/assets/javascripts/models/tests/person_model_spec.js
+++ b/src/ggrc/assets/javascripts/models/tests/person_model_spec.js
@@ -55,7 +55,7 @@ describe('CMS.Models.Person', function () {
 
     it('should apply a filter to user roles based on ' +
       'the instance and role contexts after refresh',
-      function () {
+      function (done) {
         var dfd;
         refreshedUserRoles = [{
           context: {
@@ -71,6 +71,7 @@ describe('CMS.Models.Person', function () {
         spyOn(RefreshQueue.prototype, 'trigger').and.returnValue(dfd);
         method(instance, person).then(function (roles) {
           expect(roles).toEqual([refreshedUserRoles[0]]);
+          done();
         });
       }
     );
@@ -94,10 +95,11 @@ describe('CMS.Models.Person', function () {
       it('should apply a filter to user roles based on ' +
         'the specificObject and role contexts after refresh' +
         'if all user roles were rejected for the instance context',
-        function () {
+        function (done) {
           var dfd = $.when(refreshedUserRoles);
           var validateExpectation = function (roles) {
             expect(roles).toEqual([refreshedUserRoles[1]]);
+            done();
           };
           spyOn(RefreshQueue.prototype, 'enqueue');
           spyOn(RefreshQueue.prototype, 'trigger').and.returnValue(dfd);

--- a/src/ggrc/assets/javascripts/models/tests/tree-base-loader_spec.js
+++ b/src/ggrc/assets/javascripts/models/tests/tree-base-loader_spec.js
@@ -1,0 +1,43 @@
+/*!
+  Copyright (C) 2017 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+describe('GGRC.ListLoaders.TreeBaseLoader', function () {
+  'use strict';
+  var treeBaseLoader;
+  var person;
+  var audit;
+
+  beforeEach(function () {
+    person = new CMS.Models.Person();
+    audit = new CMS.Models.Audit();
+    treeBaseLoader = new GGRC.ListLoaders.TreeBaseLoader(null, person);
+  });
+
+  describe('makeResult() method', function () {
+    var method;
+    var getUserRolesSpy;
+    var dfd;
+    var binding;
+
+    beforeEach(function () {
+      dfd = $.when();
+      binding = {
+        instance: audit
+      };
+      method = treeBaseLoader.makeResult;
+      getUserRolesSpy = spyOn(CMS.Models.Person, 'getUserRoles')
+        .and.returnValue(dfd);
+    });
+
+    it('should be able to retrieve audit and program person\'s user roles' +
+      ' on Audit page',
+      function () {
+        method(person, binding);
+        expect(getUserRolesSpy)
+          .toHaveBeenCalledWith(binding.instance, person, 'program');
+      }
+    );
+  });
+});


### PR DESCRIPTION
**Steps to reproduce:**

1. Create a program
2. Go to People’s tab
3. Map people to the program with Program Editor and Program Reader Roles
4. Create an Audit-> Add auditor
5. Go to Audit page-> People’s tab
6. Look at AUTHORIZATIONS column: AUTHORIZATIONS except Auditor role are not displayed

**Actual Result:** AUTHORIZATIONS except Auditor role are not displayed in People's tab at Audit Info page

**Expected Result:** Program-level roles + Auditor are displayed in People's tab at Audit Info page 

**Fix overview:**

Additional check was added for Audit: from now program's user roles should be displayed
in Authorizations column in People's tab at Audit Info page in case of person doesn't
have any audit role.