### PR TITLE
GGRC-1702 Group comments by parent object and add creation times in daily digest

### DIFF
--- a/src/ggrc/templates/notifications/email_digest_content.html
+++ b/src/ggrc/templates/notifications/email_digest_content.html
@@ -322,7 +322,9 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                   {% for comment_id, comment in digest['comment_created'].items() %}
                     <li {{ style.list_item() }} >
                       {{ macro.user_name(comment['commentator']) }}
-                      left a comment on {{ comment['parent_type'] }} <a href="{{ comment['parent_url'] }}">{{ comment['parent_title'] }}</a>:<br />
+                      left a comment on {{ comment['parent_type'] }}
+                      <a href="{{ comment['parent_url'] }}">{{ comment['parent_title'] }}</a>
+                      (at {{ comment['created_at'] }}):<br />
                       <p>{{ comment['description'] }}</p>
                     </li>
                   {% endfor %}

--- a/src/ggrc/templates/notifications/email_digest_content.html
+++ b/src/ggrc/templates/notifications/email_digest_content.html
@@ -318,14 +318,25 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
                 {% if digest.get('comment_created') %}
                   <h2 {{ style.sub_title() }} >New comments</h2>
+
                   <ul {{ style.list_wrap() }} >
-                  {% for comment_id, comment in digest['comment_created'].items() %}
-                    <li {{ style.list_item() }} >
-                      {{ macro.user_name(comment['commentator']) }}
-                      left a comment on {{ comment['parent_type'] }}
-                      <a href="{{ comment['parent_url'] }}">{{ comment['parent_title'] }}</a>
-                      (at {{ comment['created_at'] }}):<br />
-                      <p>{{ comment['description'] }}</p>
+                  {% for parent_info, comments in digest['comment_created'].iteritems() %}
+                    <li {{ style.list_item_no_bullet() }}>
+                      Comments on {{ parent_info.object_type }}
+                      <a href="{{ parent_info.url }}">{{ parent_info.title }}</a>:
+
+                      {% for comment in comments.itervalues() %}
+                        <ul {{ style.list_wrap() }}>
+                          <li {{ style.list_item_sublist() }} >
+                            {{ macro.user_name(comment['commentator']) }}
+                            left a comment at {{ comment['created_at'] }}:
+                            <div {{ style.comment_content() }}>
+                              {{ comment['description'] }}
+                            </div>
+                          </li>
+                        </ul>
+                      {% endfor %}
+
                     </li>
                   {% endfor %}
                   </ul>

--- a/src/ggrc/templates/notifications/style.html
+++ b/src/ggrc/templates/notifications/style.html
@@ -121,6 +121,25 @@ style=" margin-left: 5px;
 "
 {%- endmacro %}
 
+{% macro list_item_no_bullet() -%}
+style=" margin-left: 5px;
+        list-style-position: inside;
+        list-style: none;
+"
+{%- endmacro %}
+
+{% macro list_item_sublist() -%}
+style=" margin-left: 35px;
+        list-style: none;
+"
+{%- endmacro %}
+
+{% macro comment_content() -%}
+style=" margin-left: 2em;
+        display: block;
+"
+{%- endmacro %}
+
 {% macro btn_wrap() -%}
 style=" background-color: #40c4ff;
         margin-bottom: 40px;

--- a/src/ggrc/utils/__init__.py
+++ b/src/ggrc/utils/__init__.py
@@ -123,7 +123,7 @@ def merge_dicts(*args):
 
 
 def get_url_root():
-  if CUSTOM_URL_ROOT is not None:
+  if CUSTOM_URL_ROOT:
     return CUSTOM_URL_ROOT
   return request.url_root
 

--- a/test/integration/ggrc/notifications/test_comment_notifications.py
+++ b/test/integration/ggrc/notifications/test_comment_notifications.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (C) 2017 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
@@ -12,6 +14,7 @@ from ggrc.models import Assessment
 from ggrc.models import Notification
 from ggrc.models import NotificationType
 from ggrc.models import Revision
+from ggrc.notifications import common
 from integration.ggrc import TestCase
 from integration.ggrc import generator
 from integration.ggrc.models import factories
@@ -99,3 +102,47 @@ class TestCommentNotification(TestCase):
     notifications = self._get_notifications(notif_type="comment_created").all()
     self.assertEqual(len(notifications), 0,
                      "Found a comment notification that was not sent.")
+
+  @patch("ggrc.notifications.common.send_email")
+  def test_grouping_comments(self, _):
+    """Test that comments are grouped by parent object in daily digest data."""
+
+    factories.AuditFactory(slug="Audit")
+    self.import_file("assessment_with_templates.csv")
+    asmt1 = Assessment.query.filter_by(slug="A 1").first()
+    asmt4 = Assessment.query.filter_by(slug="A 4").first()
+    asmt6 = Assessment.query.filter_by(slug="A 6").first()
+
+    asmt_ids = (asmt1.id, asmt4.id, asmt6.id)
+
+    self.generator.generate_comment(
+        asmt1, "Verifier", "comment X on asmt " + str(asmt1.id),
+        send_notification="true")
+    self.generator.generate_comment(
+        asmt6, "Verifier", "comment A on asmt " + str(asmt6.id),
+        send_notification="true")
+    self.generator.generate_comment(
+        asmt4, "Verifier", "comment FOO on asmt " + str(asmt4.id),
+        send_notification="true")
+    self.generator.generate_comment(
+        asmt4, "Verifier", "comment BAR on asmt " + str(asmt4.id),
+        send_notification="true")
+    self.generator.generate_comment(
+        asmt1, "Verifier", "comment Y on asmt " + str(asmt1.id),
+        send_notification="true")
+
+    _, notif_data = common.get_daily_notifications()
+
+    assignee_notifs = notif_data.get("user@example.com", {})
+    comment_notifs = assignee_notifs.get("comment_created", {})
+    self.assertEqual(len(comment_notifs), 3)  # for 3 different Assessments
+
+    # for each group of comment notifications, check that it contains comments
+    # for that particular Assessment
+    for parent_obj_key, comments_info in comment_notifs.iteritems():
+      self.assertIn(parent_obj_key.id, asmt_ids)
+      for comment in comments_info.itervalues():
+        self.assertEqual(comment["parent_id"], parent_obj_key.id)
+        self.assertEqual(comment["parent_type"], "Assessment")
+        expected_suffix = "asmt " + str(parent_obj_key.id)
+        self.assertTrue(comment["description"].endswith(expected_suffix))

--- a/test/unit/ggrc/utils/test_util_functions.py
+++ b/test/unit/ggrc/utils/test_util_functions.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Tests for functions in the ggrc.utils module."""
+
+
+import unittest
+
+from mock import patch
+
+from ggrc.utils import get_url_root
+
+
+class TestGetUrlRoot(unittest.TestCase):
+  """Test suite for the get_url_root() function."""
+
+  # pylint: disable=invalid-name
+
+  def test_using_request_url_when_custom_url_root_setting_undefined(self):
+    """Url root should be read from request if not set in environment."""
+    with patch("ggrc.utils.CUSTOM_URL_ROOT", None):
+      with patch("ggrc.utils.request") as fake_request:
+        fake_request.url_root = "http://www.foo.com/"
+        result = get_url_root()
+
+    self.assertEqual(result, "http://www.foo.com/")
+
+  def test_using_request_url_when_custom_url_root_setting_empty_string(self):
+    """Url root should be read from request if set to empty string in environ.
+    """
+    with patch("ggrc.utils.CUSTOM_URL_ROOT", ""):
+      with patch("ggrc.utils.request") as fake_request:
+        fake_request.url_root = "http://www.foo.com/"
+        result = get_url_root()
+
+    self.assertEqual(result, "http://www.foo.com/")
+
+  def test_using_custom_url_root_setting_if_defined(self):
+    """Url root should be read from environment if defined there."""
+    with patch("ggrc.utils.CUSTOM_URL_ROOT", "http://www.default-root.com/"):
+      with patch("ggrc.utils.request") as fake_request:
+        fake_request.url_root = "http://www.foo.com/"
+        result = get_url_root()
+
+    self.assertEqual(result, "http://www.default-root.com/")


### PR DESCRIPTION
As requested by users, this PR changes the comment notifications a bit. In the daily digest email, comments are now grouped by the object they were posted on. On top of that, the comment creation date has been added, too.

NOTE: As discussed in an offline, the majority of the users live in the `US/Pacific` time zone, thus this is the time zone the UTC datetime from the database are converted to, as we currently have no good way of knowing what time zone a particular user uses on the backend.

---

To test, one should post a few comments under different Assessments a particular user is assigned to. (make sure the "Send Notifications" checkbox is ticked when posting them). When visiting the daily digest email link (`/_notifications/show_daily_digest`), the comments should be grouped by their parent object as can be seen in the screenshot.

All comments should have their creation date displayed as well.

![grouped_comments](https://cloud.githubusercontent.com/assets/1235663/26551192/92f17cd2-4481-11e7-874d-f2b805912f7f.png)

