### PR TITLE
GGRC-2115/GGRC-2367 Task action buttons should be displayed in tree view on 'Workflow Tasks' tab on object page./No way to complete tasks in My Tasks please to github title

### DIFF
--- a/src/ggrc/assets/javascripts/components/cycle-task-actions/cycle-task-actions.js
+++ b/src/ggrc/assets/javascripts/components/cycle-task-actions/cycle-task-actions.js
@@ -31,6 +31,19 @@
 
           return classes.join(' ');
         }
+      },
+      isShowActionButtons: {
+        get: function () {
+          var pageType = GGRC.Utils.CurrentPage.getPageType();
+          var allowChangeState = this.attr('instance.allow_change_state');
+
+          if (pageType === 'Workflow') {
+            return !this.isBacklog() &&
+              this.attr('cycle').reify().is_current;
+          }
+
+          return allowChangeState;
+        }
       }
     },
     instance: null,
@@ -46,9 +59,6 @@
       }
 
       return result;
-    },
-    isCurrent: function () {
-      return this.attr('cycle').reify().is_current;
     },
     changeStatus: function (ctx, el, ev) {
       var status = el.data('value');

--- a/src/ggrc/assets/mustache/components/cycle-task-actions/cycle-task-actions.mustache
+++ b/src/ggrc/assets/mustache/components/cycle-task-actions/cycle-task-actions.mustache
@@ -11,57 +11,55 @@
 {{#if_instance_of instance 'CycleTaskGroupObjectTask'}}
 <div class="flex-box item-actions">
   {{#with_review_task}}
-    {{^if isBacklog}}
-      {{#if isCurrent}}
-        {{#is_allowed 'update' instance}}
-          <div class="request-control">
-            {{#if_equals instance.status 'Assigned'}}
+    {{#if isShowActionButtons}}
+      {{#is_allowed 'update' instance}}
+        <div class="request-control">
+          {{#if_equals instance.status 'Assigned'}}
+            <button {{#if disabled}}disabled{{/if}}
+                    class="btn btn-mini btn-lightBlue"
+                    ($click)="changeStatus"
+                    data-openclose="open"
+                    data-value="InProgress">Start</button>
+          {{/if_equals}}
+          {{#if_equals instance.status 'InProgress'}}
+            <button {{#if disabled}}disabled{{/if}}
+                    class="btn btn-mini btn-white"
+                    ($click)="changeStatus"
+                    data-value="Finished">Finish</button>
+          {{/if_equals}}
+          {{#if_equals instance.status 'Declined'}}
+            {{#if review_task.object_review}}
               <button {{#if disabled}}disabled{{/if}}
-                      class="btn btn-mini btn-lightBlue"
+                      class="btn btn-mini btn-white"
                       ($click)="changeStatus"
-                      data-openclose="open"
-                      data-value="InProgress">Start</button>
-            {{/if_equals}}
-            {{#if_equals instance.status 'InProgress'}}
+                      data-value="Verified">Finish</button>
+            {{else}}
               <button {{#if disabled}}disabled{{/if}}
                       class="btn btn-mini btn-white"
                       ($click)="changeStatus"
                       data-value="Finished">Finish</button>
-            {{/if_equals}}
-            {{#if_equals instance.status 'Declined'}}
-              {{#if review_task.object_review}}
-                <button {{#if disabled}}disabled{{/if}}
-                        class="btn btn-mini btn-white"
-                        ($click)="changeStatus"
-                        data-value="Verified">Finish</button>
-              {{else}}
-                <button {{#if disabled}}disabled{{/if}}
-                        class="btn btn-mini btn-white"
-                        ($click)="changeStatus"
-                        data-value="Finished">Finish</button>
-              {{/if}}
-            {{/if_equals}}
-            {{#if_equals instance.status 'Finished'}}
-              <button {{#if disabled}}disabled{{/if}}
-                      class="btn btn-mini btn-red"
-                      ($click)="changeStatus"
-                      data-value="Declined">Decline</button>
-              <button {{#if disabled}}disabled{{/if}}
-                      class="btn btn-mini btn-green"
-                      ($click)="changeStatus"
-                      data-openclose="close"
-                      data-value="Verified">Verify</button>
-            {{/if_equals}}
-            {{#if oldValues.length}}
-              <a href="javascript://" data-name="status"
-                 {{#if disabled}}disabled{{/if}}
-                 ($click)="undo"
-                 data-undo="true"
-                 class="undo">Undo</a>
             {{/if}}
-          </div>
-        {{/is_allowed}}
-      {{/if}}
+          {{/if_equals}}
+          {{#if_equals instance.status 'Finished'}}
+            <button {{#if disabled}}disabled{{/if}}
+                    class="btn btn-mini btn-red"
+                    ($click)="changeStatus"
+                    data-value="Declined">Decline</button>
+            <button {{#if disabled}}disabled{{/if}}
+                    class="btn btn-mini btn-green"
+                    ($click)="changeStatus"
+                    data-openclose="close"
+                    data-value="Verified">Verify</button>
+          {{/if_equals}}
+          {{#if oldValues.length}}
+            <a href="javascript://" data-name="status"
+                {{#if disabled}}disabled{{/if}}
+                ($click)="undo"
+                data-undo="true"
+                class="undo">Undo</a>
+          {{/if}}
+        </div>
+      {{/is_allowed}}
     {{/if}}
   {{/with_review_task}}
 </div>


### PR DESCRIPTION
_Description_:
1. User goes to GGRC.
2. User create Workflow.
3. User creates a task for workflow.
4. User maps an object to a task.
5. User activates a Workflow.
6. User goes to object page from step 4.
7. User clicks 'Workflow Tasks' tab.
_Actual Result_: No task action buttons are displayed (Start / Finish / Decline / Verify / undo).
_Expected result:_ Task action button should be displayed.


_More details_:
1. Task buttons should be displayed in accordance with the same logic as on My Tasks and Workflow pages:
Task is ASSIGNED - display 'Start' button.
Task is IN PROGRESS - display 'Finish' and 'Undo' buttons.
Task is FINISHED - display 'Decline', 'Verify' and 'Undo' buttons.
Task is DECLINED - display 'Finish' and 'Undo' buttons.
Task is VERIFIED - display 'Undo' button.

2. Task buttons should be displayed **ONLY** for:
Workflow Owner;
Task assignee.

**NOTE**: this PR depends on #5722