### PR TITLE
GGRC-2323 Improve performance of generating daily digest emails

### DIFF
--- a/test/unit/ggrc/notification/test_init.py
+++ b/test/unit/ggrc/notification/test_init.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (C) 2017 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
@@ -10,9 +12,13 @@ from ggrc.notifications import common
 
 class TestNotificationsInit(unittest.TestCase):
 
+  @patch("ggrc.notifications.common.deleted_task_rels_cache")
+  @patch("ggrc.notifications.common.cycle_tasks_cache")
   @patch("ggrc.notifications.common.get_filter_data")
-  def test_get_notification_data(self, get_filter_data):
+  def test_get_notification_data(self, get_filter_data, *cache_mocks):
     """ Test that data does not contain empty emails """
+    for cache_func in cache_mocks:
+      cache_func.return_value = {}
 
     get_filter_data.return_value = {
         "email@example.com": {},


### PR DESCRIPTION
This PR improves the performance of generating daily digest emails.

While not a blocking issue in production (email generation happens in background), it does affect developers and QA engineers using the `/_notifications/show_daily_digest` view - waiting for minutes on every page load is a bit too much.

This is a pre-existing issue that got magnified when "task overdue" notifications were introduced, and created for all existing Workflow Tasks. The thing is that the notifications code processes each notification record from the database separately, fetching related data as needed, resulting in a lot of DB queries.

The fix in this PR pre-fetches Tasks and their related objects, producing a temporary object cache that email generation function can use. Performance gains are significant, the following table summarizes a few metrics:

Metric  | Before | After
------------ | ------------- | -------------
Total page load time | ~ 4m 30s | ~ 55s
Total DB queries | ~ 61k | ~ 19k

Tests were performed on my local laptop using a ggrc-test DB dump from late March which contains approximately 6000 `cycle_task_overdue` notifications (among others).