### PR TITLE
GGRC-1975 Include attachment and URLs for audits

### DIFF
--- a/src/ggrc/models/audit.py
+++ b/src/ggrc/models/audit.py
@@ -12,6 +12,7 @@ from ggrc.models.mixins import (
     Titled, Slugged, CustomAttributable, Stateful
 )
 
+from ggrc.models.object_document import PublicDocumentable
 from ggrc.models.mixins import clonable
 from ggrc.models.relationship import Relatable
 from ggrc.models.object_person import Personable
@@ -24,7 +25,7 @@ from ggrc.models.snapshot import Snapshotable
 from ggrc.fulltext.mixin import Indexed
 
 
-class Audit(Snapshotable, clonable.Clonable,
+class Audit(Snapshotable, clonable.Clonable, PublicDocumentable,
             CustomAttributable, Personable, HasOwnContext, Relatable,
             Timeboxed, Noted, Described, Hyperlinked, WithContact, Titled,
             Stateful, Slugged, Indexed, db.Model):

--- a/src/ggrc/models/object_document.py
+++ b/src/ggrc/models/object_document.py
@@ -99,8 +99,10 @@ class Documentable(object):
   @classmethod
   def indexed_query(cls):
     return super(Documentable, cls).indexed_query().options(
-        orm.subqueryload("document_url").load_only("id", "title", "link"),
-        orm.subqueryload("document_evidence").load_only("id", "link"),
+        orm.subqueryload("document_url").undefer_group("Document_complete"),
+        orm.subqueryload("document_evidence").undefer_group(
+            "Document_complete"
+        ),
     )
 
 

--- a/test/integration/ggrc/converters/test_import_helpers.py
+++ b/test/integration/ggrc/converters/test_import_helpers.py
@@ -337,6 +337,8 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Planned Report Period to",
         "Auditors",
         "Delete",
+        "Url",
+        "Evidence",
     }
     expected_fields = {
         "mandatory": {

--- a/test/integration/ggrc/services/test_audits.py
+++ b/test/integration/ggrc/services/test_audits.py
@@ -1,0 +1,90 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Tests for actions available on audits handle."""
+
+from ggrc.models import Audit
+from ggrc.models import Program
+from ggrc.models import all_models
+
+from integration.ggrc import generator
+from integration.ggrc.models import factories
+from integration.ggrc.services.test_query.test_basic import (
+    BaseQueryAPITestCase
+)
+
+
+class TestAuditActions(BaseQueryAPITestCase):
+  """Test Audit related actions"""
+
+  def setUp(self):
+    self.clear_data()
+    super(TestAuditActions, self).setUp()
+    self.client.get("/login")
+    self.gen = generator.ObjectGenerator()
+    filename = "program_audit.csv"
+    self.import_file(filename)
+    self.assertEqual(2, Audit.query.count())
+    audit = Audit.query.filter(Audit.slug == "Aud-1").first()
+    program = Program.query.filter(Program.slug == "prog-1").first()
+    self.assertEqual(audit.program_id, program.id)
+
+  def test_filter_by_evidence_url(self):
+    """Filter by = operator."""
+    evidence = "Some title 3"
+    audits = self._get_first_result_set(
+        self._make_query_dict("Audit", expression=["evidence", "=", evidence]),
+        "Audit",
+    )
+    self.assertEqual(audits["count"], 1)
+    self.assertEqual(len(audits["values"]), audits["count"])
+
+  def test_audit_post_put(self):
+    """Test create document and map it to audit"""
+    data = {
+        "link": "test_link",
+    }
+    doc_type = all_models.Document.URL
+    data["document_type"] = doc_type
+    resp, doc = self.gen.generate_object(
+        all_models.Document,
+        data
+    )
+    self.assertEqual(resp.status_code, 201)
+    self.assertTrue(
+        all_models.Document.query.filter(
+            all_models.Document.id == resp.json["document"]['id'],
+            all_models.Document.document_type == doc_type,
+        ).all()
+    )
+    doc = all_models.Document.query.get(doc.id)
+    self.assertEqual(doc.link, "test_link")
+
+    audit = Audit.query.filter(Audit.slug == "Aud-1").first()
+    data = {
+        "source": self.gen.create_stub(audit),
+        "destination": self.gen.create_stub(doc),
+        "context": self.gen.create_stub(audit.context)
+    }
+    resp, _ = self.gen.generate_object(
+        all_models.Relationship, add_fields=False, data=data)
+    self.assertEqual(resp.status_code, 201)
+
+    audits = self._get_first_result_set(
+        self._make_query_dict("Audit",
+                              expression=["url", "=", "test_link"]),
+        "Audit",
+    )
+    self.assertEqual(audits["count"], 1)
+
+  def test_evidence_create_an_map(self):
+    """Test document is created and mapped to audit"""
+    audit = factories.AuditFactory(slug="Audit")
+    evidence = factories.EvidenceFactory(
+        title="evidence",
+    )
+    factories.RelationshipFactory(
+        source=audit,
+        destination=evidence,
+    )
+    self.assertEqual(audit.document_evidence[0].title, "evidence")

--- a/test/integration/ggrc/test_csvs/program_audit.csv
+++ b/test/integration/ggrc/test_csvs/program_audit.csv
@@ -17,9 +17,10 @@ user12@example.com
 ,,,,,,,,,,,,,,,
 ,,,,,,,,,,,,,,,
 Object type,"Must be unique. Can be left empty for autogeneration. If updating or deleting, code is required",Mandatory field,,,Mapping is mandatory as Audit needs to be associated with some Program,"For a new audit, Status is always 'planned' by default",,,,,,,,,
-Audit,code*,title*,description,Internal Audit Lead*,Program*,Status,Planned Start Date,Planned End Date,Auditors,,,,,,
-,Aud-1,Aud-1,test,user1@example.com,prog-1,Planned,7/1/2015,7/15/2015,user2@example.com,,,,,,
-,Aud-2,Aud-2,test,user1@example.com,prog-2,Planned,7/1/2015,7/15/2015,user2@example.com,,,,,,
+Audit,code*,title*,description,Internal Audit Lead*,Program*,Status,Planned Start Date,Planned End Date,Auditors,url,evidence,,,,
+,Aud-1,Aud-1,test,user1@example.com,prog-1,Planned,7/1/2015,7/15/2015,user2@example.com,http://i.imgur.com/Lppr247.jpg,"http://i.imgur.com/Lppr247.jpg evidence 啕 title 1
+http://i.imgur.com/qA0l5tb.gifv some title 2",,,,
+,Aud-2,Aud-2,test,user1@example.com,prog-2,Planned,7/1/2015,7/15/2015,user2@example.com,http://i.imgur.com/Lppr347.jpg,http://i.imgur.com/Lppr547.jpg Some title 3,,,,
 ,,,,,,,,,,,,,,,
 ,,,,,,,,,,,,,,,
 ,,,,,,,,,,,,,,,


### PR DESCRIPTION
Expected result:
Attachments to audit object
What is the impact if it is not fixed / implemented? 
Scope and bounds assertion may change every adit and including it at the audit level is the appropriate approach. Current approach of tracking at program level does not enable us to keep track of how the document evolved across multiple audits
Steps to reproduce:
1. Create Program
2. Create Audit for the program
3. Navigate to Audit's Info pane
Expected Result: Should be the possibility to add Attachments and URLs to audit object

Requires front-end changes