### PR TITLE
GGRC-2370 Add 'mandatory' flag to ACR

### DIFF
--- a/src/ggrc/access_control/role.py
+++ b/src/ggrc/access_control/role.py
@@ -28,6 +28,7 @@ class AccessControlRole(Indexed, attributevalidator.AttributeValidator,
   update = db.Column(db.Boolean, nullable=False, default=True)
   delete = db.Column(db.Boolean, nullable=False, default=True)
   my_work = db.Column(db.Boolean, nullable=False, default=True)
+  mandatory = db.Column(db.Boolean, nullable=False, default=False)
 
   access_control_list = db.relationship(
       'AccessControlList', backref='ac_role', cascade='all, delete-orphan')

--- a/src/ggrc/migrations/versions/20170605110159_17e1b92055da_add_field_mandatory_to_acr.py
+++ b/src/ggrc/migrations/versions/20170605110159_17e1b92055da_add_field_mandatory_to_acr.py
@@ -20,13 +20,13 @@ down_revision = '59d9fbfb42dc'
 
 
 def upgrade():
-    """Upgrade database schema and/or data, creating a new revision."""
-    op.add_column(
+  """Upgrade database schema and/or data, creating a new revision."""
+  op.add_column(
       'access_control_roles',
       sa.Column('mandatory', sa.Boolean(), nullable=False, server_default="0")
-    )
+  )
 
 
 def downgrade():
-    """Downgrade database schema and/or data back to the previous revision."""
-    op.drop_column('access_control_roles', 'mandatory')
+  """Downgrade database schema and/or data back to the previous revision."""
+  op.drop_column('access_control_roles', 'mandatory')

--- a/src/ggrc/migrations/versions/20170605110159_17e1b92055da_add_field_mandatory_to_acr.py
+++ b/src/ggrc/migrations/versions/20170605110159_17e1b92055da_add_field_mandatory_to_acr.py
@@ -16,7 +16,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '17e1b92055da'
-down_revision = '281fea549981'
+down_revision = '59d9fbfb42dc'
 
 
 def upgrade():

--- a/src/ggrc/migrations/versions/20170605110159_17e1b92055da_add_field_mandatory_to_acr.py
+++ b/src/ggrc/migrations/versions/20170605110159_17e1b92055da_add_field_mandatory_to_acr.py
@@ -1,0 +1,35 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Add field 'mandatory' to access_control_roles
+
+Create Date: 2017-06-05 11:01:59.066792
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+import sqlalchemy as sa
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '17e1b92055da'
+down_revision = '281fea549981'
+
+
+def upgrade():
+    """Upgrade database schema and/or data, creating a new revision."""
+    op.add_column(
+      'access_control_roles',
+      sa.Column('mandatory', sa.Boolean(), nullable=False, server_default="0")
+    )
+    op.execute('UPDATE access_control_roles '
+               'SET mandatory = true '
+               'WHERE name = "Admin"')
+
+
+def downgrade():
+    """Downgrade database schema and/or data back to the previous revision."""
+    op.drop_column('access_control_roles', 'mandatory')

--- a/src/ggrc/migrations/versions/20170605110159_17e1b92055da_add_field_mandatory_to_acr.py
+++ b/src/ggrc/migrations/versions/20170605110159_17e1b92055da_add_field_mandatory_to_acr.py
@@ -25,9 +25,6 @@ def upgrade():
       'access_control_roles',
       sa.Column('mandatory', sa.Boolean(), nullable=False, server_default="0")
     )
-    op.execute('UPDATE access_control_roles '
-               'SET mandatory = true '
-               'WHERE name = "Admin"')
 
 
 def downgrade():

--- a/src/ggrc/models/reflection.py
+++ b/src/ggrc/models/reflection.py
@@ -262,20 +262,21 @@ class AttributeInfo(object):
       names_query = db.session.query(
           AccessControlRole.object_type,
           AccessControlRole.name,
+          AccessControlRole.mandatory,
       )
-      for object_type, name in names_query:
-        flask.g.acl_role_names[object_type].add(name)
+      for object_type, name, mandatory in names_query:
+        flask.g.acl_role_names[object_type].add((name, mandatory))
 
     return {
         "{}:{}".format(cls.ALIASES_PREFIX, name): {
             "display_name": name,
             "attr_name": name,
-            "mandatory": False,
+            "mandatory": mandatory,
             "unique": False,
             "description": "List of people with '{}' role".format(name),
             "type": cls.Type.AC_ROLE,
         }
-        for name in flask.g.acl_role_names[object_class.__name__]
+        for name, mandatory in flask.g.acl_role_names[object_class.__name__]
     }
 
   @classmethod

--- a/test/integration/ggrc/converters/test_import_issues.py
+++ b/test/integration/ggrc/converters/test_import_issues.py
@@ -110,7 +110,7 @@ class TestImportIssues(TestCase):
         "Market": {
             "row_errors": {
                 errors.MISSING_COLUMN.format(
-                    line = 3, column_names = mandatory_role, s = ""
+                    line=3, column_names=mandatory_role, s=""
                 ),
             }
         }
@@ -123,12 +123,12 @@ class TestImportIssues(TestCase):
   def test_import_empty_mandatory(self):
     """Test import of data with empty mandatory role"""
     mandatory_role = factories.AccessControlRoleFactory(
-        object_type = "Market",
-        mandatory = True
+        object_type="Market",
+        mandatory=True
     ).name
     not_mandatory_role = factories.AccessControlRoleFactory(
-        object_type = "Market",
-        mandatory = False
+        object_type="Market",
+        mandatory=False
     ).name
 
     email = factories.PersonFactory().email
@@ -145,7 +145,7 @@ class TestImportIssues(TestCase):
         "Market": {
             "row_warnings": {
                 errors.OWNER_MISSING.format(
-                    line = 3, column_name = mandatory_role
+                    line=3, column_name=mandatory_role
                 ),
             }
         }

--- a/test/integration/ggrc/converters/test_import_issues.py
+++ b/test/integration/ggrc/converters/test_import_issues.py
@@ -43,6 +43,7 @@ class TestImportIssues(TestCase):
       )
 
   def test_audit_change(self):
+    """Test audit changing"""
     audit = factories.AuditFactory()
     issue = factories.IssueFactory()
     response = self.import_data(OrderedDict([
@@ -64,21 +65,21 @@ class TestImportIssues(TestCase):
     # and can process situation when nonmandatory roles are absent
     # without any errors and warnings
     mandatory_role = factories.AccessControlRoleFactory(
-      object_type="Market",
-      mandatory=True
+        object_type="Market",
+        mandatory=True
     ).name
     factories.AccessControlRoleFactory(
-      object_type="Market",
-      mandatory=False
+        object_type="Market",
+        mandatory=False
     ).name
 
     email = factories.PersonFactory().email
     response_json = self.import_data(OrderedDict([
-      ("object_type", "Market"),
-      ("code", "market-1"),
-      ("title", "Title"),
-      ("Admin", "user@example.com"),
-      (mandatory_role, email),
+        ("object_type", "Market"),
+        ("code", "market-1"),
+        ("title", "Title"),
+        ("Admin", "user@example.com"),
+        (mandatory_role, email),
     ]))
     self._check_csv_response(response_json, {})
     self.assertEqual(1, response_json[0]["created"])
@@ -88,25 +89,27 @@ class TestImportIssues(TestCase):
     """Test import of data without mandatory role"""
     # Data can't be imported if mandatory role is not provided
     mandatory_role = factories.AccessControlRoleFactory(
-      object_type="Market",
-      mandatory=True
+        object_type="Market",
+        mandatory=True
     ).name
     not_mandatory_role = factories.AccessControlRoleFactory(
-      object_type="Market",
-      mandatory=False
+        object_type="Market",
+        mandatory=False
     ).name
 
     email = factories.PersonFactory().email
     response_json = self.import_data(OrderedDict([
-      ("object_type", "Market"),
-      ("code", "market-1"),
-      ("title", "Title"),
-      ("Admin", "user@example.com"),
-      (not_mandatory_role, email),
+        ("object_type", "Market"),
+        ("code", "market-1"),
+        ("title", "Title"),
+        ("Admin", "user@example.com"),
+        (not_mandatory_role, email),
     ]))
 
     expected_errors = {
-        errors.MISSING_COLUMN.format(line=3, column_names=mandatory_role, s=""),
+        errors.MISSING_COLUMN.format(
+            line=3, column_names=mandatory_role, s=""
+        ),
     }
     response_errors = response_json[0]["row_errors"]
     self.assertEqual(expected_errors, set(response_errors))


### PR DESCRIPTION
New field 'mandatory' was added to access_control_roles table and AccessControlRole model. This field is used for creation of ACL definitions