### PR TITLE
GGRC-2372 Make sure we add owners when creating documents

### DIFF
--- a/src/ggrc_gdrive_integration/assets/javascripts/components/gdrive_folder_picker.js
+++ b/src/ggrc_gdrive_integration/assets/javascripts/components/gdrive_folder_picker.js
@@ -31,7 +31,8 @@
             new CMS.Models.Document({
               context: object.context || {id: null},
               title: file.title,
-              link: file.alternateLink
+              link: file.alternateLink,
+              owners: [{type: 'Person', id: GGRC.current_user.id}]
             }).save().then(function (doc) {
               return $.when([
                 new CMS.Models.Relationship({

--- a/src/ggrc_gdrive_integration/assets/javascripts/components/gdrive_picker_launcher.js
+++ b/src/ggrc_gdrive_integration/assets/javascripts/components/gdrive_picker_launcher.js
@@ -227,7 +227,8 @@
                 docs.push(new CMS.Models.Document({
                   context: that.instance.context || {id: null},
                   title: file.title,
-                  link: file.alternateLink
+                  link: file.alternateLink,
+                  owners: [{type: 'Person', id: GGRC.current_user.id}]
                 }));
               }
               if (that.deferred || !docs[0].isNew()) {


### PR DESCRIPTION
Relationship creation requires Update permission on source and destination so we need to add the current user to a list of owners of the document object for them to get Update permissions. 

We did not have this permission issue when we used the object_documents table because the object_documnets table did not have the same permission check as relationships.