### PR TITLE
GGRC-1496: Archiving: Locking assessments to related objects

### DIFF
--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -126,6 +126,7 @@ dashboard-js-files:
   - controllers/summary_widget_controller.js
   - controllers/dashboard_widget_controller.js
   - controllers/modals_controller.js
+  - controllers/archive_modal_controller.js
   - controllers/delete_modal_controller.js
   - controllers/help_controller.js
   - controllers/quick_search_controller.js
@@ -204,6 +205,7 @@ dashboard-js-files:
   - components/inline_edit/inline_text.js
   - components/inline_edit/inline_person.js
   - components/inline_edit/inline_datepicker.js
+  - components/unarchive_link.js
   - components/link_to_clipboard.js
   - components/relevant_filters.js
   - components/csv/export.js
@@ -361,6 +363,7 @@ dashboard-js-template-files:
   - components/questions-link/questions-link.mustache
   - base_objects/empty.mustache
   - base_objects/autocomplete_result.mustache
+  - base_objects/confirm_archive.mustache
   - base_objects/confirm_delete.mustache
   - base_objects/confirm_unmap.mustache
   - base_objects/contacts.mustache
@@ -549,6 +552,7 @@ dashboard-js-template-files:
   - help/help_modal_header.mustache
   - help/filters_helper_content.mustache
   - markets/modal_content.mustache
+  - modals/archive_cancel_buttons.mustache
   - modals/close_buttons.mustache
   - modals/confirm.mustache
   - modals/prompt_buttons.mustache
@@ -621,6 +625,7 @@ dashboard-js-template-files:
   - audits/search_result.mustache
   - audits/extended_info.mustache
   - audits/object_cloner.mustache
+  - audits/dropdown_menu.mustache
   - base_templates/subtree.mustache
   - objectives/autocomplete_result.mustache
   - documents/autocomplete_result.mustache

--- a/src/ggrc/assets/javascripts/bootstrap/modal-ajax.js
+++ b/src/ggrc/assets/javascripts/bootstrap/modal-ajax.js
@@ -334,8 +334,35 @@
 
     'helpform': function ($target, $trigger, option) {
       $target.modal_form(option, $trigger).ggrc_controllers_help({slug: $trigger.attr('data-help-slug')});
-    }
+    },
 
+    'archiveform': function ($target, $trigger, option) {
+      var model = CMS.Models[$trigger.attr('data-object-singular')]
+        , instance;
+
+      if ($trigger.attr('data-object-id') === 'page') {
+        instance = GGRC.page_instance();
+      } else {
+        instance = model.findInCacheById($trigger.attr('data-object-id'));
+      }
+
+      $target
+        .modal_form(option, $trigger)
+        .ggrc_controllers_toggle_archive({
+          $trigger: $trigger
+          , new_object_form: false
+          , button_view: GGRC.mustache_path + '/modals/archive_cancel_buttons.mustache'
+          , model: model
+          , instance: instance
+          , modal_title: 'Archive ' + $trigger.attr('data-object-singular')
+          , content_view: GGRC.mustache_path + '/base_objects/confirm_archive.mustache'
+        });
+
+      $target.on('modal:success', function (e, data) {
+        $trigger.trigger('modal:success', data);
+        $target.modal_form('hide');
+      });
+    }
   };
 
 
@@ -593,7 +620,8 @@
       'listnewform': handlers['listnewform'],
       'listeditform': handlers['listeditform'],
       'deleteform': handlers['deleteform'],
-      'unmapform': handlers['unmapform']
+      'unmapform': handlers['unmapform'],
+      'archiveform': handlers['archiveform']
     },
       function (launch_fn, toggle) {
         GGRC.register_modal_hook(toggle, launch_fn);

--- a/src/ggrc/assets/javascripts/bootstrap/modal-ajax.js
+++ b/src/ggrc/assets/javascripts/bootstrap/modal-ajax.js
@@ -336,9 +336,9 @@
       $target.modal_form(option, $trigger).ggrc_controllers_help({slug: $trigger.attr('data-help-slug')});
     },
 
-    'archiveform': function ($target, $trigger, option) {
-      var model = CMS.Models[$trigger.attr('data-object-singular')]
-        , instance;
+    archiveform: function ($target, $trigger, option) {
+      var model = CMS.Models[$trigger.attr('data-object-singular')];
+      var instance;
 
       if ($trigger.attr('data-object-id') === 'page') {
         instance = GGRC.page_instance();
@@ -349,13 +349,15 @@
       $target
         .modal_form(option, $trigger)
         .ggrc_controllers_toggle_archive({
-          $trigger: $trigger
-          , new_object_form: false
-          , button_view: GGRC.mustache_path + '/modals/archive_cancel_buttons.mustache'
-          , model: model
-          , instance: instance
-          , modal_title: 'Archive ' + $trigger.attr('data-object-singular')
-          , content_view: GGRC.mustache_path + '/base_objects/confirm_archive.mustache'
+          $trigger: $trigger,
+          new_object_form: false,
+          button_view: GGRC.mustache_path +
+            '/modals/archive_cancel_buttons.mustache',
+          model: model,
+          instance: instance,
+          modal_title: 'Archive ' + $trigger.attr('data-object-singular'),
+          content_view: GGRC.mustache_path +
+            '/base_objects/confirm_archive.mustache'
         });
 
       $target.on('modal:success', function (e, data) {
@@ -364,7 +366,6 @@
       });
     }
   };
-
 
   var arrangeBackgroundModals = function (modals, referenceModal) {
     modals = $(modals).not(referenceModal);
@@ -621,7 +622,7 @@
       'listeditform': handlers['listeditform'],
       'deleteform': handlers['deleteform'],
       'unmapform': handlers['unmapform'],
-      'archiveform': handlers['archiveform']
+      archiveform: handlers.archiveform
     },
       function (launch_fn, toggle) {
         GGRC.register_modal_hook(toggle, launch_fn);

--- a/src/ggrc/assets/javascripts/components/access_control_list/access_control_list.js
+++ b/src/ggrc/assets/javascripts/components/access_control_list/access_control_list.js
@@ -240,7 +240,8 @@
         isSnapshot = GGRC.Utils.Snapshots.isSnapshot(instance);
         canEdit = !isSnapshot &&  // snapshots are not editable
                   (vm.isNewInstance ||
-                   Permission.is_allowed_for('update', instance));
+                   Permission.is_allowed_for('update', instance)) &&
+                  !instance.archived;
 
         can.batch.start();
         vm.attr('canEdit', canEdit);

--- a/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.js
+++ b/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.js
@@ -56,7 +56,8 @@
           type: 'boolean',
           get: function () {
             return this.attr('instance.status') !== 'Completed' &&
-              this.attr('instance.status') !== 'Ready for Review';
+              this.attr('instance.status') !== 'Ready for Review' &&
+              !this.attr('instance.archived');
           },
           set: function () {
             this.attr('instance.status', 'In Progress');

--- a/src/ggrc/assets/javascripts/components/people_list.js
+++ b/src/ggrc/assets/javascripts/components/people_list.js
@@ -609,7 +609,9 @@
         if (this.attr('deferred')) {
           return options.fn(options.context);
         }
-        isAllowed = Permission.is_allowed_for('update', this.attr('instance'));
+        isAllowed =
+          Permission.is_allowed_for('update', this.attr('instance')) &&
+          !this.attr('instance.archived');
         return options[isAllowed ? 'fn' : 'inverse'](options.context);
       },
       can_unmap: function (options) {

--- a/src/ggrc/assets/javascripts/components/tests/unarchive_link_spec.js
+++ b/src/ggrc/assets/javascripts/components/tests/unarchive_link_spec.js
@@ -1,0 +1,83 @@
+/*!
+  Copyright (C) 2017 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+describe('GGRC.Components.UnarchiveLink', function () {
+  'use strict';
+
+  var Component;
+
+  beforeAll(function () {
+    Component = GGRC.Components.get('unarchiveLink');
+  });
+
+  describe('click() event', function () {
+    var displayName = 'DISPLAY NAME';
+    var notifyText = 'was unarchived successfully';
+    var eventObj;
+    var instance;
+    var pendingSave;
+    var scope;
+    var $element;
+    var event;
+
+    beforeEach(function () {
+      pendingSave = new can.Deferred();
+
+      instance = new can.Map({
+        save: jasmine.createSpy('save')
+                     .and.returnValue(pendingSave.promise()),
+        display_name: function () {
+          return displayName;
+        },
+        setup_custom_attributes: jasmine.createSpy()
+      });
+
+      scope = new can.Map({
+        instance: instance,
+        notifyText: notifyText
+      });
+      eventObj = $.Event();
+      $element = $('<div></div>');
+
+      spyOn($.fn, 'trigger').and.callThrough();
+
+      event = Component.prototype.events['a click']
+        .bind({scope: scope});
+    });
+
+    it('instance was not unarchived if was not archived', function () {
+      event($element, eventObj);
+
+      expect(instance.attr('archived')).toBeFalsy();
+      expect(instance.save).not.toHaveBeenCalled();
+      expect($.fn.trigger).not.toHaveBeenCalled();
+    });
+
+    it('instance was saved without notification', function () {
+      instance.attr('archived', true);
+
+      event($element, eventObj);
+      pendingSave.resolve();
+
+      expect(instance.attr('archived')).toBeFalsy();
+      expect(instance.save).toHaveBeenCalled();
+      expect($.fn.trigger).not.toHaveBeenCalled();
+    });
+
+    it('instance was saved without notification', function () {
+      var successMessage = displayName + ' ' + notifyText;
+      instance.attr('archived', true);
+      scope.attr('notify', true);
+
+      event($element, eventObj);
+      pendingSave.resolve();
+
+      expect(instance.attr('archived')).toBeFalsy();
+      expect(instance.save).toHaveBeenCalled();
+      expect($.fn.trigger).toHaveBeenCalledWith('ajax:flash',
+        {success: [successMessage]});
+    });
+  });
+});

--- a/src/ggrc/assets/javascripts/components/tree/tree-item-actions.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-item-actions.js
@@ -44,8 +44,9 @@
         get: function () {
           var type = this.attr('instance.type');
           var isSnapshot = this.attr('isSnapshot');
+          var isArchived = this.attr('instance.archived');
           var isInForbiddenList = forbiddenList.indexOf(type) > -1;
-          return !(isSnapshot || isInForbiddenList);
+          return !(isSnapshot || isInForbiddenList || isArchived);
         }
       }
     },

--- a/src/ggrc/assets/javascripts/components/unarchive_link.js
+++ b/src/ggrc/assets/javascripts/components/unarchive_link.js
@@ -1,0 +1,39 @@
+/*!
+    Copyright (C) 2017 Google Inc.
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+(function (can, $) {
+  'use strict';
+
+  can.Component.extend({
+    tag: 'unarchive-link',
+    scope: {
+      notify: '@',
+      instance: null,
+      notifyText: 'was unarchived successfully'
+    },
+    template: ['<a href="#">',
+               '<content></content>',
+               '</a>'].join(''),
+    events: {
+      'a click': function (el, event) {
+        var instance = this.scope.attr('instance');
+        var notifyText = this.scope.attr('instance.title') + ' ' +
+          this.scope.attr('notifyText');
+
+        event.preventDefault();
+
+        if (instance && instance.archived) {
+          instance.archived = false;
+          instance.save()
+            .then(function () {
+              if (this.scope.attr('notify')) {
+                $('body').trigger('ajax:flash', {success: notifyText});
+              }
+            }.bind(this));
+        }
+      }
+    }
+  });
+})(window.can, window.can.$);

--- a/src/ggrc/assets/javascripts/components/unarchive_link.js
+++ b/src/ggrc/assets/javascripts/components/unarchive_link.js
@@ -3,10 +3,10 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 */
 
-(function (can, $) {
+(function (GGRC, $) {
   'use strict';
 
-  can.Component.extend({
+  GGRC.Components('unarchiveLink', {
     tag: 'unarchive-link',
     scope: {
       notify: '@',
@@ -24,7 +24,7 @@
 
         event.preventDefault();
 
-        if (instance && instance.archived) {
+        if (instance && instance.attr('archived')) {
           instance.attr('archived', false);
 
           // Need to be fixed via new API:
@@ -43,4 +43,4 @@
       }
     }
   });
-})(window.can, window.can.$);
+})(window.GGRC, window.can.$);

--- a/src/ggrc/assets/javascripts/components/unarchive_link.js
+++ b/src/ggrc/assets/javascripts/components/unarchive_link.js
@@ -19,15 +19,22 @@
     events: {
       'a click': function (el, event) {
         var instance = this.scope.attr('instance');
-        var notifyText = this.scope.attr('instance.title') + ' ' +
+        var notifyText = instance.display_name() + ' ' +
           this.scope.attr('notifyText');
 
         event.preventDefault();
 
         if (instance && instance.archived) {
-          instance.archived = false;
+          instance.attr('archived', false);
+
+          // Need to be fixed via new API:
+          // saving with filled custom_attributes
+          // will cause 403 error
+          instance.removeAttr('custom_attributes');
           instance.save()
             .then(function () {
+              var instance = this.scope.attr('instance');
+              instance.setup_custom_attributes();
               if (this.scope.attr('notify')) {
                 $('body').trigger('ajax:flash', {success: notifyText});
               }

--- a/src/ggrc/assets/javascripts/components/unified-mapper/tests/mapper-results_spec.js
+++ b/src/ggrc/assets/javascripts/components/unified-mapper/tests/mapper-results_spec.js
@@ -548,6 +548,19 @@ describe('GGRC.Components.mapperResults', function () {
         permissions: 'read'
       }));
     });
+
+    it('prepare request for unlocked items for Audits', function () {
+      var filter = viewModel.attr('filter');
+      viewModel.attr('type', 'Audit');
+      spyOn(viewModel, 'prepareBaseQuery')
+        .and.returnValue({mockData: 'base'});
+      spyOn(viewModel, 'joinQueries')
+        .and.returnValue(filter);
+
+      viewModel.getQuery();
+
+      expect(viewModel.joinQueries).toHaveBeenCalled();
+    });
   });
 
   describe('getModelKey() method', function () {

--- a/src/ggrc/assets/javascripts/controllers/archive_modal_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/archive_modal_controller.js
@@ -30,15 +30,9 @@
         }.bind(this))
         .then(function () {
           var instance = this.options.instance;
-          var parentController =
-            $(this.options.$trigger).closest('.modal').control();
           var msg;
 
           instance.setup_custom_attributes();
-
-          if (parentController) {
-            parentController.options.skip_refresh = true;
-          }
 
           msg = instance.display_name() + ' archived successfully';
           $(document.body).trigger('ajax:flash', {success: msg});

--- a/src/ggrc/assets/javascripts/controllers/archive_modal_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/archive_modal_controller.js
@@ -1,0 +1,47 @@
+/*!
+    Copyright (C) 2017 Google Inc.
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+(function (can, $) {
+  GGRC.Controllers.Modals('GGRC.Controllers.ToggleArchive', {
+    defaults: {
+      skip_refresh: false
+    }
+  }, {
+    init: function () {
+      this._super();
+    },
+    'a.btn[data-toggle=archive]:not(:disabled) click': function (el, ev) {
+      var that = this;
+      // Disable the cancel button.
+      var cancelButton = this.element.find('a.btn[data-dismiss=modal]');
+      var modalBackdrop = this.element.data('modal_form').$backdrop;
+
+      this.bindXHRToButton(this.options.instance.refresh()
+        .then(function (instance) {
+          instance.archived = true;
+          return instance.save();
+        })
+        .then(function (instance) {
+          var parentController =
+            $(that.options.$trigger).closest('.modal').control();
+          var msg;
+          if (parentController) {
+            parentController.options.skip_refresh = true;
+          }
+
+          msg = instance.display_name() + ' archived successfully';
+          $(document.body).trigger('ajax:flash', {success: msg});
+          if (that.element) {
+            that.element.trigger('modal:success', that.options.instance);
+          }
+
+          return new $.Deferred();
+        })
+        .fail(function (xhr, status) {
+          $(document.body).trigger('ajax:flash', {error: xhr.responseText});
+        }), el.add(cancelButton).add(modalBackdrop));
+    }
+  });
+})(window.can, window.can.$);

--- a/src/ggrc/assets/javascripts/controllers/tests/archive_modal_controller_spec.js
+++ b/src/ggrc/assets/javascripts/controllers/tests/archive_modal_controller_spec.js
@@ -1,0 +1,91 @@
+/*!
+    Copyright (C) 2017 Google Inc.
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+describe('GGRC.Controllers.ToggleArchive', function () {
+  'use strict';
+  var Ctrl;
+
+  beforeAll(function () {
+    Ctrl = GGRC.Controllers.ToggleArchive;
+  });
+
+  describe('click() event', function () {
+    var displayName = 'DISPLAY NAME';
+    var event;
+    var eventObj;
+    var $element;
+    var instance;
+    var ctrlInst;
+    var pendingRefresh;
+    var pendingSave;
+
+    beforeEach(function () {
+      pendingRefresh = new can.Deferred();
+      pendingSave = new can.Deferred();
+
+      $element = $('<div data-modal_form="">' +
+        '<a data-dismiss="modal"></a>' +
+        '</div>');
+      instance = new can.Map({
+        save: jasmine.createSpy('save')
+          .and.returnValue(pendingSave.promise()),
+        setup_custom_attributes: jasmine.createSpy(),
+        refresh: jasmine.createSpy('save')
+          .and.returnValue(pendingRefresh.promise()),
+        display_name: function () {
+          return displayName;
+        }
+      });
+
+      ctrlInst = {
+        bindXHRToButton: jasmine.createSpy('bindXHRToButton'),
+        element: $element,
+        options: {
+          instance: instance
+        }
+      };
+      spyOn($.fn, 'trigger').and.callThrough();
+      event = Ctrl.prototype['a.btn[data-toggle=archive]:not(:disabled) click']
+        .bind(ctrlInst);
+      eventObj = $.Event();
+    });
+
+    it('was notified when was archived successfully', function () {
+      var successMessage = displayName + ' archived successfully';
+      event($element, eventObj);
+      pendingRefresh.resolve();
+      pendingSave.resolve();
+
+      expect(instance.attr('archived')).toBeTruthy();
+      expect(instance.refresh).toHaveBeenCalled();
+      expect(instance.save).toHaveBeenCalled();
+      expect($.fn.trigger).toHaveBeenCalledWith('ajax:flash',
+        {success: [successMessage]});
+    });
+
+    it('was notified when was not archived successfully', function () {
+      var errorMessage = 'Internal error';
+      event($element, eventObj);
+      pendingRefresh.resolve();
+      pendingSave.reject({responseText: errorMessage});
+
+      expect(instance.refresh).toHaveBeenCalled();
+      expect(instance.save).toHaveBeenCalled();
+      expect($.fn.trigger).toHaveBeenCalledWith('ajax:flash',
+        {error: [errorMessage]});
+    });
+
+    it('was notified when was not refreshed successfully', function () {
+      var errorMessage = 'Internal error';
+      event($element, eventObj);
+      pendingRefresh.reject({responseText: errorMessage});
+
+      expect(instance.refresh).toHaveBeenCalled();
+      expect(instance.save).not.toHaveBeenCalled();
+      expect($.fn.trigger).toHaveBeenCalledWith('ajax:flash',
+        {error: [errorMessage]});
+    });
+  });
+});

--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -2851,4 +2851,28 @@ Example:
 
     return titlesMap[type] ? titlesMap[type] + field : field;
   });
+
+  Mustache.registerHelper(
+    'withRoleForInstance',
+    function (instance, roleName, options) {
+      var userId = GGRC.current_user.id;
+      var hasRoleForContextDfd;
+      instance = resolve_computed(instance);
+
+      if (!instance.contextId) {
+        instance = CMS.Models[instance.type].findInCacheById(instance.id);
+      }
+
+      hasRoleForContextDfd =
+        GGRC.Utils.hasRoleForContext(userId, instance.context_id, roleName);
+
+      return Mustache.defer_render('span',
+        function (hasRole) {
+          if (hasRole) {
+            return options.fn(options.contexts.add({hasRole: hasRole}));
+          }
+
+          return options.inverse(options.contexts.add({hasRole: hasRole}));
+        }, hasRoleForContextDfd);
+    });
 })(this, jQuery, can);

--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -2868,11 +2868,7 @@ Example:
 
       return Mustache.defer_render('span',
         function (hasRole) {
-          if (hasRole) {
-            return options.fn(options.contexts.add({hasRole: hasRole}));
-          }
-
-          return options.inverse(options.contexts.add({hasRole: hasRole}));
+          return options.fn(options.contexts.add({hasRole: hasRole}));
         }, hasRoleForContextDfd);
     });
 })(this, jQuery, can);

--- a/src/ggrc/assets/javascripts/permission.js
+++ b/src/ggrc/assets/javascripts/permission.js
@@ -36,7 +36,8 @@
     forbid: function (instance, args, action) {
       var blacklist = args.blacklist[action] || [];
       return blacklist.indexOf(instance.type) < 0;
-    }
+    },
+    has_changed: can.noop
   };
   var permissions_compute = can.compute(GGRC.permissions);
 

--- a/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
+++ b/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
@@ -523,9 +523,9 @@
         CMS.Models.Person.findInCacheById(userId) ||
         CMS.Models.Person.findOne({id: userId});
 
-      $.when([userDfd])
+      $.when(userDfd)
         .then(function (user) {
-          return user[0].get_mapping_deferred('authorizations');
+          return user.get_mapping_deferred('authorizations');
         })
         .then(function (uRoles) {
           contextRoles = _.filter(uRoles, function (role) {

--- a/src/ggrc/assets/javascripts/plugins/utils/state-utils.js
+++ b/src/ggrc/assets/javascripts/plugins/utils/state-utils.js
@@ -115,6 +115,14 @@
     }
 
     /**
+     * Return query for unlocked objects
+     * @return {String} The unlocked query
+     */
+    function unlockedFilter() {
+      return '"Archived"="False"';
+    }
+
+    /**
      * Build statuses filter string
      * @param {Array} statuses - array of active statuses
      * @return {String} statuses filter
@@ -184,6 +192,7 @@
       hasState: hasState,
       hasFilter: hasFilter,
       statusFilter: statusFilter,
+      unlockedFilter: unlockedFilter,
       getStatesForModel: getStatesForModel,
       getDefaultStatesForModel: getDefaultStatesForModel
     };

--- a/src/ggrc/assets/javascripts/plugins/utils/tree-view-utils.js
+++ b/src/ggrc/assets/javascripts/plugins/utils/tree-view-utils.js
@@ -37,6 +37,9 @@
       'type',
       'viewLink',
       'workflow_state',
+      'archived',
+      // label for Audit
+      'program',
       // labels for assessment templates
       'DEFAULT_PEOPLE_LABELS'
     ]);

--- a/src/ggrc/assets/mustache/assessment_templates/tree_add_item.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/tree_add_item.mustache
@@ -4,17 +4,18 @@
 }}
 
 {{#is_allowed 'update' parent_instance context='for'}}
-  <a href="javascript://"
-     class="action-button create-button"
-     rel="tooltip"
-     data-placement="left"
-     data-toggle="modal-ajax-form"
-     data-original-title="Define Assessment template"
-     data-modal-reset="reset"
-     data-modal-class="modal-wide"
-     data-object-singular="{{model_info 'AssessmentTemplate' 'model_singular'}}"
-     data-object-plural="{{model_info 'AssessmentTemplate' 'root_collection'}}"
-     data-object-params='{
+    {{^if parent_instance.archived}}
+        <a href="javascript://"
+           class="action-button create-button"
+           rel="tooltip"
+           data-placement="left"
+           data-toggle="modal-ajax-form"
+           data-original-title="Define Assessment template"
+           data-modal-reset="reset"
+           data-modal-class="modal-wide"
+           data-object-singular="{{model_info 'AssessmentTemplate' 'model_singular'}}"
+           data-object-plural="{{model_info 'AssessmentTemplate' 'root_collection'}}"
+           data-object-params='{
       "audit": {
         "id": {{parent_instance.id}},
         "type": "{{json_escape parent_instance.type}}"
@@ -25,8 +26,9 @@
       },
       "audit_title": "{{json_escape parent_instance.title}}"
     }'
-  >
-    Create
-  </a>
+        >
+            Create
+        </a>
+    {{/if}}
 {{/is_allowed}}
 

--- a/src/ggrc/assets/mustache/assessments/header.mustache
+++ b/src/ggrc/assets/mustache/assessments/header.mustache
@@ -10,6 +10,9 @@ Copyright (C) 2017 Google Inc.
             <div class="pane-header__title">
                 <h3>{{instance.title}}</h3>
                   <span class="state-value {{addclass 'state-' instance.status separator=''}}">{{instance.status}}</span>
+                  {{#if instance.archived}}
+                      <span class="state-value state-archived">Archived</span>
+                  {{/if}}
                   {{#eq instance.status 'Completed'}}
                     {{#if instance.verified}}
                       <i class="fa fa-check-circle green"
@@ -30,7 +33,9 @@ Copyright (C) 2017 Google Inc.
                     </a>
                     <ul class="dropdown-menu three-dots-list" aria-labelledby="drop1" role="menu">
                       {{#is_allowed 'update' instance context='for'}}
-                        {{> '/static/mustache/base_objects/edit_object_link.mustache'}}
+                          {{^if instance.archived}}
+                            {{> '/static/mustache/base_objects/edit_object_link.mustache'}}
+                          {{/if}}
                       {{/is_allowed}}
                         <li>
                             <clipboard-link title="Get permalink" notify="true"
@@ -54,52 +59,58 @@ Copyright (C) 2017 Google Inc.
                         {{#is_allowed 'update' instance context='for'}}
                             <li>
                               {{#unless instance._disabled}}
-                                {{#if instance.assignees.Verifier.length}}
-                                    <reminder
-                                            {instance}="instance"
-                                            {type}="statusToPerson"
-                                            modal_title="Reminder for Assignees set"
-                                            modal_description="Tomorrow all Assignees will receive a notification to look at this Assessment if they didn't move it to 'Finished' in between."
-                                    >
-                                        <a href="javascript://" ($click)="reminder">
-                                            <i class="fa fa-bell-o"></i>
-                                            Send reminder to assignees</a>
-                                    </reminder>
-                                {{else}}
-                                    <reminder
-                                            {instance}="instance"
-                                            {type}="statusToPerson"
-                                            modal_title="Reminder for Assignees set"
-                                            modal_description="Tomorrow all Assignees will receive a notification to look at this Assessment if they didn't move it to 'Final' in between."
-                                    >
-                                        <a href="javascript://" ($click)="reminder">
-                                            <i class="fa fa-bell-o"></i>
-                                            Send reminder to assignees</a>
-                                    </reminder>
-                                {{/if}}
+                                {{#unless instance.archived}}
+                                  {{#if instance.assignees.Verifier.length}}
+                                      <reminder
+                                              {instance}="instance"
+                                              {type}="statusToPerson"
+                                              modal_title="Reminder for Assignees set"
+                                              modal_description="Tomorrow all Assignees will receive a notification to look at this Assessment if they didn't move it to 'Finished' in between."
+                                      >
+                                          <a href="javascript://" ($click)="reminder">
+                                              <i class="fa fa-bell-o"></i>
+                                              Send reminder to assignees</a>
+                                      </reminder>
+                                  {{else}}
+                                      <reminder
+                                              {instance}="instance"
+                                              {type}="statusToPerson"
+                                              modal_title="Reminder for Assignees set"
+                                              modal_description="Tomorrow all Assignees will receive a notification to look at this Assessment if they didn't move it to 'Final' in between."
+                                      >
+                                          <a href="javascript://" ($click)="reminder">
+                                              <i class="fa fa-bell-o"></i>
+                                              Send reminder to assignees</a>
+                                      </reminder>
+                                  {{/if}}
+                                {{/unless}}
                               {{/unless}}
                             </li>
                         {{/is_allowed}}
                       {{/if_in}}
 
                       {{#is_allowed 'delete' instance}}
-                          <li>
-                              <a data-toggle="modal-ajax-deleteform" data-object-plural="{{model.table_plural}}"
-                                 data-object-singular="{{model.model_singular}}" data-modal-reset="reset"
-                                 data-modal-class="modal" data-object-id="{{instance.id}}" href="javascript://">
-                                  <i class="fa fa-trash"></i>
-                                  Delete
-                              </a>
-                          </li>
+                          {{^if instance.archived}}
+                            <li>
+                                <a data-toggle="modal-ajax-deleteform" data-object-plural="{{model.table_plural}}"
+                                   data-object-singular="{{model.model_singular}}" data-modal-reset="reset"
+                                   data-modal-class="modal" data-object-id="{{instance.id}}" href="javascript://">
+                                    <i class="fa fa-trash"></i>
+                                    Delete
+                                </a>
+                            </li>
+                          {{/if}}
                       {{/is_allowed}}
                     </ul>
                 </div>
             </div>
           {{#is_allowed 'update' instance context='for'}}
-            <object-state-toolbar {verifiers}="instance.assignees.Verifier"
-                                  {instance}="instance"
-                                  (on-state-change)="onStateChange(%event)">
-            </object-state-toolbar>
+              {{^if instance.archived}}
+                  <object-state-toolbar {verifiers}="instance.assignees.Verifier"
+                                        {instance}="instance"
+                                        (on-state-change)="onStateChange(%event)">
+                  </object-state-toolbar>
+              {{/if}}
           {{/is_allowed}}
         </div>
     </div>

--- a/src/ggrc/assets/mustache/assessments/related-assessments.mustache
+++ b/src/ggrc/assets/mustache/assessments/related-assessments.mustache
@@ -7,7 +7,9 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
         <div class="grid-data__toolbar flex-box">
             <tree-pagination {(paging)}="paging" class="grid-data__toolbar-item"></tree-pagination>
             {{#is_allowed 'update' baseInstance context='for'}}
-                <button class="btn btn-small btn-green grid-data__toolbar-item" ($click)="reuseSelected" {{^hasSelected}}disabled{{/hasSelected}}>Reuse</button>
+                {{^if instance.archived}}
+                    <button class="btn btn-small btn-green grid-data__toolbar-item" ($click)="reuseSelected" {{^hasSelected}}disabled{{/hasSelected}}>Reuse</button>
+                {{/if}}
             {{/is_allowed}}
         </div>
         <div class="grid-data-header flex-row flex-box">

--- a/src/ggrc/assets/mustache/assessments/tree_add_item.mustache
+++ b/src/ggrc/assets/mustache/assessments/tree_add_item.mustache
@@ -5,6 +5,7 @@
 
 {{#if allow_mapping_or_creating}}
   {{#if_instance_of parent_instance 'Audit'}}
+    {{^if instance.archived}}
     {{#if allow_creating}}
     {{#is_allowed 'create' 'Assessment' context=parent_instance.context}}
       <a href="javascript://"
@@ -20,6 +21,7 @@
         Create
       </a>
     {{/is_allowed}}
+    {{/if}}
     {{/if}}
   {{/if_instance_of}}
 {{/if}}

--- a/src/ggrc/assets/mustache/audits/dropdown_menu.mustache
+++ b/src/ggrc/assets/mustache/audits/dropdown_menu.mustache
@@ -12,6 +12,7 @@
        or #if' hasRole '\
        and ^if' instance.archived '\
        or #system_role' 'Administrator' '\
+       or #system_role' 'Superuser' '\
        or #is_allowed' 'update' instance '\
        ' _4_context='for'}}
     <div class="details-wrap">
@@ -135,6 +136,7 @@
         {{^if instance.archived}}
             {{#if_helpers '\
                #system_role' 'Administrator' '\
+               or #system_role' 'Superuser' '\
                or #if' hasRole}}
                <li>
                   <a data-toggle="modal-ajax-archiveform"
@@ -161,14 +163,16 @@
                 </li>
             {{/is_allowed}}
         {{else}}
-            {{#system_role 'Administrator'}}
-               <li>
+            {{#if_helpers '\
+              #system_role' 'Administrator' '\
+              or #system_role' 'Superuser'}}
+                <li>
                    <unarchive-link instance="instance" notify="true">
                        <i class="fa fa-archive"></i>
                        Unarchive Audit
                    </unarchive-link>
-               </li>
-            {{/system_role}}
+                </li>
+            {{/if_helpers}}
         {{/if}}
 
       </ul>

--- a/src/ggrc/assets/mustache/audits/dropdown_menu.mustache
+++ b/src/ggrc/assets/mustache/audits/dropdown_menu.mustache
@@ -1,0 +1,177 @@
+{{!
+    Copyright (C) 2017 Google Inc.
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+}}
+
+{{#withRoleForInstance instance.program 'ProgramOwner'}}
+    {{#if_helpers '\
+       #if' is_info_pin '\
+       and #is_allowed_to_map' page_instance instance '\
+       or #if' is_info_pin '\
+       and #if' instance.viewLink '\
+       or #is_allowed' 'update' instance '\
+       ' _4_context='for' '\
+       or #system_role' 'Administrator' '\
+       or ^if' instance.archived '\
+       and #if' hasRole}}
+    <div class="details-wrap">
+      <a class="btn btn-3bbps dropdown-toggle" href="#" data-toggle="dropdown">
+        <span class="bubble"></span>
+        <span class="bubble"></span>
+        <span class="bubble"></span>
+      </a>
+      <ul class="dropdown-menu three-dots-list" aria-labelledby="drop1" role="menu">
+        {{#is_allowed 'update' instance context='for'}}
+          {{#if instance.is_snapshotable}}
+            <li>
+              <snapshot-scope-update instance="instance">
+                <a href="javascript://" can-click="upsertIt">
+                  <i class="fa fa-refresh"></i>
+                  Update objects to latest version</a>
+              </snapshot-scope-update>
+            </li>
+          {{/if}}
+          {{> /static/mustache/base_objects/edit_object_link.mustache}}
+        {{/is_allowed}}
+
+        {{! Audit-specific link for defining its AssessmentTemplate}}
+        {{#if_equals instance.type 'Audit'}}
+        {{#is_allowed 'update' instance context='for'}}
+        <li>
+          <a href="javascript://"
+            data-toggle="modal-ajax-form"
+            data-modal-reset="reset"
+            data-modal-class="modal-wide"
+            data-object-singular="{{model_info 'AssessmentTemplate' 'model_singular'}}"
+            data-object-plural="{{model_info 'AssessmentTemplate' 'root_collection'}}"
+            data-object-params='{
+              "audit": {
+                "id": {{instance.id}},
+                "type": "{{json_escape instance.type}}"
+              },
+              "context": {
+                "id": {{instance.context.id}},
+                "type": "{{json_escape instance.context.type}}"
+              },
+              "audit_title": "{{json_escape instance.title}}"
+            }'
+          >
+            <i class="fa fa-sliders"></i>
+            Define Assessment template
+          </a>
+        </li>
+        {{/is_allowed}}
+        {{/if_equals}}
+
+        {{#if instance.class.is_clonable}}
+        {{#is_allowed 'update' instance context='for'}}
+        <li>
+          <object-cloner
+            instance="instance"
+            modal-title="Clone {{ instance.type }}"
+            modal-description="Select all that you would like to clone as well?"
+
+          >
+            <a href="javascript://" can-click="cloneObject">
+              <i class="fa fa-clone"></i>
+              Clone {{ instance.type }}</a>
+          </object-cloner>
+        </li>
+        {{/is_allowed}}
+        {{/if}}
+
+        <li>
+          {{#is_allowed 'create' 'CycleTaskGroupObjectTask' context=null}}
+            {{#is_allowed 'update' instance context='for'}}
+              <a
+                rel="tooltip"
+                data-placement="left"
+                data-original-title="Create Cycle Task for object"
+                data-object-plural="cycle_task_group_object_tasks"
+                data-modal-class="modal-wide" href="javascript://"
+                data-object-singular="CycleTaskGroupObjectTask"
+                data-toggle="modal-ajax-form"
+                data-modal-reset="reset"
+                data-object-params='{
+                  "pre_mapped_objects": [{
+                    "type": "{{ instance.type }}",
+                    "id": {{ instance.id }}
+                  }],
+                  "modal_title": "Create New Task"}'>
+                <i class="fa fa-calendar-check-o"></i> Create task
+              </a>
+            {{/is_allowed}}
+          {{/is_allowed}}
+        </li>
+
+        <li>
+          <clipboard-link
+                  data-test-id="dropdown_settings_get_permalink_75e3bf91"
+                  title="Get permalink"
+                  notify="true"
+                  text="{{get_permalink_for_object instance}}" />
+        </li>
+
+        {{#is_info_pin}}
+          {{#is_allowed_to_map page_instance instance}}
+            {{^options.is_in_selector}}
+               {{#isNotInScopeModel instance.type}}
+                 {{> '/static/mustache/base_objects/unmap.mustache'}}
+               {{/isNotInScopeModel}}
+            {{/options.is_in_selector}}
+          {{/is_allowed_to_map}}
+          {{#if instance.viewLink}}
+            {{#is_allowed "view_object_page" instance}}
+              <li>
+                <a href="{{instance.viewLink}}">
+                  <i class="fa fa-long-arrow-right"></i>
+                  Open {{instance.class.title_singular}}
+                </a>
+              </li>
+            {{/is_allowed}}
+          {{/if}}
+        {{/is_info_pin}}
+
+        {{#is_allowed 'delete' instance}}
+          <li>
+            <a data-test-id="dropdown_settings_delete_6a62eaaf"
+               data-toggle="modal-ajax-deleteform"
+               data-object-plural="{{model.table_plural}}"
+               data-object-singular="{{model.model_singular}}"
+               data-modal-reset="reset" data-modal-class="modal"
+               data-object-id="{{instance.id}}" href="javascript://">
+              <i class="fa fa-trash"></i>
+              Delete
+            </a>
+          </li>
+        {{/is_allowed}}
+ 
+        {{^if instance.archived}}
+            {{#if_helpers '\
+               #system_role' 'Administrator' '\
+               or #if' hasRole}}
+               <li>
+                  <a data-toggle="modal-ajax-archiveform"
+                     data-object-plural="{{model.table_plural}}"
+                     data-object-singular="{{model.model_singular}}"
+                     data-modal-reset="reset" data-modal-class="modal"
+                     data-object-id="{{instance.id}}" href="javascript://">
+                     <i class="fa fa-trash"></i>
+                        Archive Audit
+                  </a>
+               </li>
+            {{/if_helpers}}
+        {{else}}
+            {{#system_role 'Administrator'}}
+               <li>
+                   <unarchive-link instance="instance" notify="true">
+                       Unarchive Audit
+                   </unarchive-link>
+               </li>
+            {{/system_role}}
+        {{/if}}
+
+      </ul>
+    </div>
+    {{/if_helpers}}
+{{/withRoleForInstance}}

--- a/src/ggrc/assets/mustache/audits/dropdown_menu.mustache
+++ b/src/ggrc/assets/mustache/audits/dropdown_menu.mustache
@@ -9,11 +9,11 @@
        and #is_allowed_to_map' page_instance instance '\
        or #if' is_info_pin '\
        and #if' instance.viewLink '\
-       or #is_allowed' 'update' instance '\
-       ' _4_context='for' '\
+       or #if' hasRole '\
+       and ^if' instance.archived '\
        or #system_role' 'Administrator' '\
-       or ^if' instance.archived '\
-       and #if' hasRole}}
+       or #is_allowed' 'update' instance '\
+       ' _4_context='for'}}
     <div class="details-wrap">
       <a class="btn btn-3bbps dropdown-toggle" href="#" data-toggle="dropdown">
         <span class="bubble"></span>
@@ -21,68 +21,69 @@
         <span class="bubble"></span>
       </a>
       <ul class="dropdown-menu three-dots-list" aria-labelledby="drop1" role="menu">
-        {{#is_allowed 'update' instance context='for'}}
-          {{#if instance.is_snapshotable}}
-            <li>
-              <snapshot-scope-update instance="instance">
-                <a href="javascript://" can-click="upsertIt">
-                  <i class="fa fa-refresh"></i>
-                  Update objects to latest version</a>
-              </snapshot-scope-update>
-            </li>
-          {{/if}}
-          {{> /static/mustache/base_objects/edit_object_link.mustache}}
-        {{/is_allowed}}
+        {{^if instance.archived}}
+          {{#is_allowed 'update' instance context='for'}}
+            {{#if instance.is_snapshotable}}
+              <li>
+                <snapshot-scope-update instance="instance">
+                  <a href="javascript://" can-click="upsertIt">
+                    <i class="fa fa-refresh"></i>
+                    Update objects to latest version</a>
+                </snapshot-scope-update>
+              </li>
+            {{/if}}
+            {{> /static/mustache/base_objects/edit_object_link.mustache}}
+          {{/is_allowed}}
 
-        {{! Audit-specific link for defining its AssessmentTemplate}}
-        {{#if_equals instance.type 'Audit'}}
-        {{#is_allowed 'update' instance context='for'}}
-        <li>
-          <a href="javascript://"
-            data-toggle="modal-ajax-form"
-            data-modal-reset="reset"
-            data-modal-class="modal-wide"
-            data-object-singular="{{model_info 'AssessmentTemplate' 'model_singular'}}"
-            data-object-plural="{{model_info 'AssessmentTemplate' 'root_collection'}}"
-            data-object-params='{
-              "audit": {
-                "id": {{instance.id}},
-                "type": "{{json_escape instance.type}}"
-              },
-              "context": {
-                "id": {{instance.context.id}},
-                "type": "{{json_escape instance.context.type}}"
-              },
-              "audit_title": "{{json_escape instance.title}}"
-            }'
-          >
-            <i class="fa fa-sliders"></i>
-            Define Assessment template
-          </a>
-        </li>
-        {{/is_allowed}}
-        {{/if_equals}}
+          {{#is_allowed 'update' instance context='for'}}
+            <li>
+              <a href="javascript://"
+                data-toggle="modal-ajax-form"
+                data-modal-reset="reset"
+                data-modal-class="modal-wide"
+                data-object-singular="{{model_info 'AssessmentTemplate' 'model_singular'}}"
+                data-object-plural="{{model_info 'AssessmentTemplate' 'root_collection'}}"
+                data-object-params='{
+                  "audit": {
+                    "id": {{instance.id}},
+                    "type": "{{json_escape instance.type}}"
+                  },
+                  "context": {
+                    "id": {{instance.context.id}},
+                    "type": "{{json_escape instance.context.type}}"
+                  },
+                  "audit_title": "{{json_escape instance.title}}"
+                }'
+              >
+                <i class="fa fa-sliders"></i>
+                Define Assessment template
+              </a>
+            </li>
+          {{/is_allowed}}
+        {{/if}}
 
         {{#if instance.class.is_clonable}}
-        {{#is_allowed 'update' instance context='for'}}
-        <li>
-          <object-cloner
-            instance="instance"
-            modal-title="Clone {{ instance.type }}"
-            modal-description="Select all that you would like to clone as well?"
-
-          >
-            <a href="javascript://" can-click="cloneObject">
-              <i class="fa fa-clone"></i>
-              Clone {{ instance.type }}</a>
-          </object-cloner>
-        </li>
-        {{/is_allowed}}
+          {{#if_helpers '\
+            #if' hasRole '\
+            or #is_allowed' 'update' instance context='for'}}
+              <li>
+                  <object-cloner
+                        instance="instance"
+                        modal-title="Clone {{ instance.type }}"
+                        modal-description="Select all that you would like to clone as well?">
+                    <a href="javascript://" can-click="cloneObject">
+                        <i class="fa fa-clone"></i>
+                        Clone {{ instance.type }}</a>
+                  </object-cloner>
+              </li>
+          {{/if_helpers}}
         {{/if}}
 
         <li>
-          {{#is_allowed 'create' 'CycleTaskGroupObjectTask' context=null}}
-            {{#is_allowed 'update' instance context='for'}}
+          {{#if_helpers '\
+            #if' hasRole '\
+            or #is_allowed' 'create' 'CycleTaskGroupObjectTask' context=null '\
+            and #is_allowed' 'update' instance context='for'}}
               <a
                 rel="tooltip"
                 data-placement="left"
@@ -100,8 +101,7 @@
                   "modal_title": "Create New Task"}'>
                 <i class="fa fa-calendar-check-o"></i> Create task
               </a>
-            {{/is_allowed}}
-          {{/is_allowed}}
+          {{/if_helpers}}
         </li>
 
         <li>
@@ -132,20 +132,6 @@
           {{/if}}
         {{/is_info_pin}}
 
-        {{#is_allowed 'delete' instance}}
-          <li>
-            <a data-test-id="dropdown_settings_delete_6a62eaaf"
-               data-toggle="modal-ajax-deleteform"
-               data-object-plural="{{model.table_plural}}"
-               data-object-singular="{{model.model_singular}}"
-               data-modal-reset="reset" data-modal-class="modal"
-               data-object-id="{{instance.id}}" href="javascript://">
-              <i class="fa fa-trash"></i>
-              Delete
-            </a>
-          </li>
-        {{/is_allowed}}
- 
         {{^if instance.archived}}
             {{#if_helpers '\
                #system_role' 'Administrator' '\
@@ -156,15 +142,29 @@
                      data-object-singular="{{model.model_singular}}"
                      data-modal-reset="reset" data-modal-class="modal"
                      data-object-id="{{instance.id}}" href="javascript://">
-                     <i class="fa fa-trash"></i>
+                     <i class="fa fa-archive"></i>
                         Archive Audit
                   </a>
                </li>
             {{/if_helpers}}
+            {{#is_allowed 'delete' instance}}
+                <li>
+                  <a data-test-id="dropdown_settings_delete_6a62eaaf"
+                     data-toggle="modal-ajax-deleteform"
+                     data-object-plural="{{model.table_plural}}"
+                     data-object-singular="{{model.model_singular}}"
+                     data-modal-reset="reset" data-modal-class="modal"
+                     data-object-id="{{instance.id}}" href="javascript://">
+                    <i class="fa fa-trash"></i>
+                    Delete
+                  </a>
+                </li>
+            {{/is_allowed}}
         {{else}}
             {{#system_role 'Administrator'}}
                <li>
                    <unarchive-link instance="instance" notify="true">
+                       <i class="fa fa-archive"></i>
                        Unarchive Audit
                    </unarchive-link>
                </li>

--- a/src/ggrc/assets/mustache/audits/info.mustache
+++ b/src/ggrc/assets/mustache/audits/info.mustache
@@ -20,6 +20,9 @@
               <h6>Title</h6>
               <h3>{{title}}</h3>
               <span class="state-value {{addclass 'state-' status separator=''}}">{{status}}</span>
+                {{#if instance.archived}}
+                    <span class="state-value state-archived">Archived</span>
+                {{/if}}
               {{#if type}}
               <p>
                 {{type.title}}
@@ -102,12 +105,14 @@
                     {{#using auditor=instance.person}}
                       {{{renderLive '/static/mustache/people/popover.mustache' person=auditor}}}
                     {{/using}}
-                    {{#is_allowed 'delete' this}}
-                      <a href="javascript://" class="unmap" data-toggle="unmap">
-                        <span class="result" {{data 'result'}}></span>
-                        <i class="fa fa-trash"></i>
-                      </a>
-                    {{/is_allowed}}
+                    {{^if instance.archived}}
+                        {{#is_allowed 'delete' this}}
+                            <a href="javascript://" class="unmap" data-toggle="unmap">
+                                <span class="result" {{data 'result'}}></span>
+                                    <i class="fa fa-trash"></i>
+                            </a>
+                        {{/is_allowed}}
+                    {{/if}}
                   </li>
                 {{/each}}
               </ul>
@@ -116,6 +121,7 @@
               <span class="empty-message">None</span>
             {{/if}}
           {{/with_mapping}}
+          {{^if instance.archived}}
           {{#is_allowed 'create' 'UserRole' context=instance.context.id}}
           {{#toggle show_new_object_form}}
             {{#with_page_object_as 'page_instance'}}
@@ -146,6 +152,7 @@
               <a href="javascript://" class="btn btn-small btn-white" {{toggle_button}}>Add Auditor</a>
           {{/toggle}}
           {{/is_allowed}}
+          {{/if}}
         </div>
       </div>
 
@@ -159,7 +166,18 @@
     </div>
     <div class="row-fluid wrap-row">
       <div class="span12">
-        {{{render_hooks 'Audit.tree_view_info'}}}
+          {{#if_helpers '\
+            #if' instance.archived '\
+            or ^is_allowed' "update" instance context="for"}}
+                <ggrc-gdrive-folder-picker
+                    readonly="true"
+                    instance="instance">
+                </ggrc-gdrive-folder-picker>
+          {{else}}
+                <ggrc-gdrive-folder-picker
+                    instance="instance">
+                </ggrc-gdrive-folder-picker>
+          {{/if_helpers}}
       </div>
     </div>
     {{>'/static/mustache/custom_attributes/info.mustache'}}

--- a/src/ggrc/assets/mustache/audits/summary.mustache
+++ b/src/ggrc/assets/mustache/audits/summary.mustache
@@ -9,26 +9,29 @@
     <div class="span12">
         <section class="info audit-summary">
             <div class="info-pane-utility">
-                <add-object-button
-                    instance="instance"
-                    linkclass="btn btn-small btn-white"
-                    content="Create assessment"
-                    text="Create Assessment"
-                    singular="Assessment"
-                    plural="assessments"
-                    noparams="true">
-                </add-object-button>
-                <add-object-button
-                    instance="instance"
-                    linkclass="btn btn-small btn-darkBlue"
-                    content="Create Template"
-                    text="Define Assessment Template"
-                    singular="AssessmentTemplate"
-                    plural="assessment_templates">
-                </add-object-button>
-                {{#is_allowed 'create' 'Assessment' context=instance.context}}
-                  <assessment-generator-button audit="instance" button='true'></assessment-generator-button>
-                {{/is_allowed}}
+                {{^if instance.archived}}
+                    <add-object-button
+                        instance="instance"
+                        linkclass="btn btn-small btn-white"
+                        content="Create assessment"
+                        text="Create Assessment"
+                        singular="Assessment"
+                        plural="assessments"
+                        noparams="true">
+                    </add-object-button>
+
+                    <add-object-button
+                        instance="instance"
+                        linkclass="btn btn-small btn-darkBlue"
+                        content="Create Template"
+                        text="Define Assessment Template"
+                        singular="AssessmentTemplate"
+                        plural="assessment_templates">
+                    </add-object-button>
+                    {{#is_allowed 'create' 'Assessment' context=instance.context}}
+                        <assessment-generator-button audit="instance" button='true'></assessment-generator-button>
+                    {{/is_allowed}}
+                {{/if}}
             </div>
 
             <div class="tier-content">

--- a/src/ggrc/assets/mustache/base_objects/confirm_archive.mustache
+++ b/src/ggrc/assets/mustache/base_objects/confirm_archive.mustache
@@ -1,0 +1,19 @@
+{{!
+    Copyright (C) 2017 Google Inc.
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+}}
+
+<div class="centered">
+<p>
+{{#instance}}
+Are you sure you want to archive
+  <span class="user-string">
+    {{#if display_name}}
+      {{display_name}}?
+    {{else}}
+      this {{type_to_readable instance.type}}?
+    {{/if}}
+  </span>
+{{/instance}}
+</p>
+</div>

--- a/src/ggrc/assets/mustache/base_objects/dropdown_menu.mustache
+++ b/src/ggrc/assets/mustache/base_objects/dropdown_menu.mustache
@@ -10,138 +10,146 @@
    and #if' instance.viewLink '\
    or #is_allowed' 'update' instance '\
    ' _4_context='for'}}
-<div class="details-wrap">
-  <a class="btn btn-3bbps dropdown-toggle" href="#" data-toggle="dropdown">
-    <span class="bubble"></span>
-    <span class="bubble"></span>
-    <span class="bubble"></span>
-  </a>
-  <ul class="dropdown-menu three-dots-list" aria-labelledby="drop1" role="menu">
-    {{#is_allowed 'update' instance context='for'}}
-      {{#if instance.is_snapshotable}}
-        <li>
-          <snapshot-scope-update instance="instance">
-            <a href="javascript://" can-click="upsertIt">
-              <i class="fa fa-refresh"></i>
-              Update objects to latest version</a>
-          </snapshot-scope-update>
-        </li>
-      {{/if}}
-      {{> /static/mustache/base_objects/edit_object_link.mustache}}
-    {{/is_allowed}}
-
-    {{! Audit-specific link for defining its AssessmentTemplate}}
-    {{#if_equals instance.type 'Audit'}}
-    {{#is_allowed 'update' instance context='for'}}
-    <li>
-      <a href="javascript://"
-        data-toggle="modal-ajax-form"
-        data-modal-reset="reset"
-        data-modal-class="modal-wide"
-        data-object-singular="{{model_info 'AssessmentTemplate' 'model_singular'}}"
-        data-object-plural="{{model_info 'AssessmentTemplate' 'root_collection'}}"
-        data-object-params='{
-          "audit": {
-            "id": {{instance.id}},
-            "type": "{{json_escape instance.type}}"
-          },
-          "context": {
-            "id": {{instance.context.id}},
-            "type": "{{json_escape instance.context.type}}"
-          },
-          "audit_title": "{{json_escape instance.title}}"
-        }'
-      >
-        <i class="fa fa-sliders"></i>
-        Define Assessment template
-      </a>
-    </li>
-    {{/is_allowed}}
-    {{/if_equals}}
-
-    {{#if instance.class.is_clonable}}
-    {{#is_allowed 'update' instance context='for'}}
-    <li>
-      <object-cloner
-        instance="instance"
-        modal-title="Clone {{ instance.type }}"
-        modal-description="Select all that you would like to clone as well?"
-
-      >
-        <a href="javascript://" can-click="cloneObject">
-          <i class="fa fa-clone"></i>
-          Clone {{ instance.type }}</a>
-      </object-cloner>
-    </li>
-    {{/is_allowed}}
-    {{/if}}
-
-    <li>
-      {{#is_allowed 'create' 'CycleTaskGroupObjectTask' context=null}}
-        {{#is_allowed 'update' instance context='for'}}
-          <a
-            rel="tooltip"
-            data-placement="left"
-            data-original-title="Create Cycle Task for object"
-            data-object-plural="cycle_task_group_object_tasks"
-            data-modal-class="modal-wide" href="javascript://"
-            data-object-singular="CycleTaskGroupObjectTask"
-            data-toggle="modal-ajax-form"
-            data-modal-reset="reset"
-            data-object-params='{
-              "pre_mapped_objects": [{
-                "type": "{{ instance.type }}",
-                "id": {{ instance.id }}
-              }],
-              "modal_title": "Create New Task"}'>
-            <i class="fa fa-calendar-check-o"></i> Create task
+   {{#if_helpers '\
+     ^if' instance.archived '\
+     or #if_equals' instance.type 'AssessmentTemplate'}}
+        <div class="details-wrap">
+          <a class="btn btn-3bbps dropdown-toggle" href="#" data-toggle="dropdown">
+            <span class="bubble"></span>
+            <span class="bubble"></span>
+            <span class="bubble"></span>
           </a>
-        {{/is_allowed}}
-      {{/is_allowed}}
-    </li>
+          <ul class="dropdown-menu three-dots-list" aria-labelledby="drop1" role="menu">
+            {{#is_allowed 'update' instance context='for'}}
+              {{#if instance.is_snapshotable}}
+                <li>
+                  <snapshot-scope-update instance="instance">
+                    <a href="javascript://" can-click="upsertIt">
+                      <i class="fa fa-refresh"></i>
+                      Update objects to latest version</a>
+                  </snapshot-scope-update>
+                </li>
+              {{/if}}
+              {{^if instance.archived}}
+                {{> /static/mustache/base_objects/edit_object_link.mustache}}
+              {{/if}}
+            {{/is_allowed}}
 
-    <li>
-      <clipboard-link
-              data-test-id="dropdown_settings_get_permalink_75e3bf91"
-              title="Get permalink"
-              notify="true"
-              text="{{get_permalink_for_object instance}}" />
-    </li>
+            {{! Audit-specific link for defining its AssessmentTemplate}}
+            {{#if_equals instance.type 'Audit'}}
+            {{#is_allowed 'update' instance context='for'}}
+            <li>
+              <a href="javascript://"
+                data-toggle="modal-ajax-form"
+                data-modal-reset="reset"
+                data-modal-class="modal-wide"
+                data-object-singular="{{model_info 'AssessmentTemplate' 'model_singular'}}"
+                data-object-plural="{{model_info 'AssessmentTemplate' 'root_collection'}}"
+                data-object-params='{
+                  "audit": {
+                    "id": {{instance.id}},
+                    "type": "{{json_escape instance.type}}"
+                  },
+                  "context": {
+                    "id": {{instance.context.id}},
+                    "type": "{{json_escape instance.context.type}}"
+                  },
+                  "audit_title": "{{json_escape instance.title}}"
+                }'
+              >
+                <i class="fa fa-sliders"></i>
+                Define Assessment template
+              </a>
+            </li>
+            {{/is_allowed}}
+            {{/if_equals}}
 
-    {{#is_info_pin}}
-      {{#is_allowed_to_map page_instance instance}}
-        {{^options.is_in_selector}}
-           {{#isNotInScopeModel instance.type}}
-             {{> '/static/mustache/base_objects/unmap.mustache'}}
-           {{/isNotInScopeModel}}
-        {{/options.is_in_selector}}
-      {{/is_allowed_to_map}}
-      {{#if instance.viewLink}}
-        {{#is_allowed "view_object_page" instance}}
-          <li>
-            <a href="{{instance.viewLink}}">
-              <i class="fa fa-long-arrow-right"></i>
-              Open {{instance.class.title_singular}}
-            </a>
-          </li>
-        {{/is_allowed}}
-      {{/if}}
-    {{/is_info_pin}}
+            {{#if instance.class.is_clonable}}
+            {{#is_allowed 'update' instance context='for'}}
+            <li>
+              <object-cloner
+                instance="instance"
+                modal-title="Clone {{ instance.type }}"
+                modal-description="Select all that you would like to clone as well?"
 
-    {{#is_allowed 'delete' instance}}
-      <li>
-        <a data-test-id="dropdown_settings_delete_6a62eaaf"
-           data-toggle="modal-ajax-deleteform"
-           data-object-plural="{{model.table_plural}}"
-           data-object-singular="{{model.model_singular}}"
-           data-modal-reset="reset" data-modal-class="modal"
-           data-object-id="{{instance.id}}" href="javascript://">
-          <i class="fa fa-trash"></i>
-          Delete
-        </a>
-      </li>
-    {{/is_allowed}}
+              >
+                <a href="javascript://" can-click="cloneObject">
+                  <i class="fa fa-clone"></i>
+                  Clone {{ instance.type }}</a>
+              </object-cloner>
+            </li>
+            {{/is_allowed}}
+            {{/if}}
 
-  </ul>
-</div>
+            <li>
+              {{#is_allowed 'create' 'CycleTaskGroupObjectTask' context=null}}
+                {{#is_allowed 'update' instance context='for'}}
+                  <a
+                    rel="tooltip"
+                    data-placement="left"
+                    data-original-title="Create Cycle Task for object"
+                    data-object-plural="cycle_task_group_object_tasks"
+                    data-modal-class="modal-wide" href="javascript://"
+                    data-object-singular="CycleTaskGroupObjectTask"
+                    data-toggle="modal-ajax-form"
+                    data-modal-reset="reset"
+                    data-object-params='{
+                      "pre_mapped_objects": [{
+                        "type": "{{ instance.type }}",
+                        "id": {{ instance.id }}
+                      }],
+                      "modal_title": "Create New Task"}'>
+                    <i class="fa fa-calendar-check-o"></i> Create task
+                  </a>
+                {{/is_allowed}}
+              {{/is_allowed}}
+            </li>
+
+            <li>
+              <clipboard-link
+                      data-test-id="dropdown_settings_get_permalink_75e3bf91"
+                      title="Get permalink"
+                      notify="true"
+                      text="{{get_permalink_for_object instance}}" />
+            </li>
+
+            {{#is_info_pin}}
+              {{#is_allowed_to_map page_instance instance}}
+                {{^options.is_in_selector}}
+                   {{#isNotInScopeModel instance.type}}
+                     {{> '/static/mustache/base_objects/unmap.mustache'}}
+                   {{/isNotInScopeModel}}
+                {{/options.is_in_selector}}
+              {{/is_allowed_to_map}}
+              {{#if instance.viewLink}}
+                {{#is_allowed "view_object_page" instance}}
+                  <li>
+                    <a href="{{instance.viewLink}}">
+                      <i class="fa fa-long-arrow-right"></i>
+                      Open {{instance.class.title_singular}}
+                    </a>
+                  </li>
+                {{/is_allowed}}
+              {{/if}}
+            {{/is_info_pin}}
+
+            {{#is_allowed 'delete' instance}}
+              {{^if instance.archived}}
+                <li>
+                  <a data-test-id="dropdown_settings_delete_6a62eaaf"
+                     data-toggle="modal-ajax-deleteform"
+                     data-object-plural="{{model.table_plural}}"
+                     data-object-singular="{{model.model_singular}}"
+                     data-modal-reset="reset" data-modal-class="modal"
+                     data-object-id="{{instance.id}}" href="javascript://">
+                    <i class="fa fa-trash"></i>
+                    Delete
+                  </a>
+                </li>
+              {{/if}}
+            {{/is_allowed}}
+
+          </ul>
+        </div>
+    {{/if_helpers}}
 {{/if_helpers}}

--- a/src/ggrc/assets/mustache/base_objects/general_info.mustache
+++ b/src/ggrc/assets/mustache/base_objects/general_info.mustache
@@ -16,6 +16,9 @@
         {{#if status}}
           <span class="state-value {{addclass 'state-' status separator=''}}">{{un_camel_case status}}</span>
         {{/if}}
+        {{#if snapshot.archived}}
+          <span class="state-value state-archived">Archived</span>
+        {{/if}}
         {{#if type}}
         <p>
           {{type.title}}
@@ -28,6 +31,7 @@
       {{#using reified_snapshot=snapshot}}
       {{#canUpdate}}
         {{^isLatestRevision}}
+          {{^if instance.snapshot.archived}}
           <div class="span12 snapshot">
             <hr class="snapshot">
             <p>
@@ -38,6 +42,7 @@
               </revisions-comparer>
             </p>
           </div>
+          {{/if}}
         {{/isLatestRevision}}
       {{/canUpdate}}
       {{/using}}

--- a/src/ggrc/assets/mustache/base_objects/generate_assessments_button.mustache
+++ b/src/ggrc/assets/mustache/base_objects/generate_assessments_button.mustache
@@ -19,12 +19,14 @@
   {{#if_instance_of parent_instance 'Audit'}}
     {{#if_in model.shortName 'Assessment,Control'}}
         {{#is_allowed 'update' parent_instance context="for"}}
-          <li class="generate-control-assessments">
-            <a href="javascript://">
-              <i class="fa fa-fw fa-magic"></i>
-              Generate Assessments
-            </a>
-          </li>
+            {{^if instance.archived}}
+                <li class="generate-control-assessments">
+                  <a href="javascript://">
+                    <i class="fa fa-fw fa-magic"></i>
+                    Generate Assessments
+                  </a>
+                </li>
+            {{/if}}
         {{/is_allowed}}
     {{/if_in}}
   {{/if_instance_of}}

--- a/src/ggrc/assets/mustache/base_objects/info-pane-utility.mustache
+++ b/src/ggrc/assets/mustache/base_objects/info-pane-utility.mustache
@@ -9,6 +9,10 @@
     {{#if instance.snapshot}}
         {{> '/static/mustache/snapshots/dropdown_menu.mustache'}}
     {{else}}
-        {{> '/static/mustache/base_objects/dropdown_menu.mustache'}}
+        {{#if_equals instance.type 'Audit'}}
+            {{> '/static/mustache/audits/dropdown_menu.mustache'}}
+        {{else}}
+            {{> '/static/mustache/base_objects/dropdown_menu.mustache'}}
+        {{/if_equals}}
      {{/if}}
 </div>

--- a/src/ggrc/assets/mustache/components/assessment/attach-button.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/attach-button.mustache
@@ -6,7 +6,9 @@
 <div>
   {{#if_mapping_ready "audits" instance}}
     {{#is_allowed 'update' instance context='for'}}
-      {{{render_hooks "Request.gdrive_evidence_storage"}}}
+        {{^if instance.archived}}
+            {{{render_hooks "Request.gdrive_evidence_storage"}}}
+        {{/if}}
     {{/is_allowed}}
   {{/if_mapping_ready}}
 </div>

--- a/src/ggrc/assets/mustache/components/assessment/controls-toolbar/controls-toolbar.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/controls-toolbar/controls-toolbar.mustache
@@ -3,17 +3,21 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
 <button class="btn btn-small btn-lightBlue" ($click)="showRelatedResponses" title="Show Related Assessments">Related Assessments</button>
-<auto-save-form-actions
-  {(form-edit-mode)}="editMode"
-  {form-saving}="formState.saving"
-  {form-fields-to-save-available}="formState.fieldsToSaveAvailable"
-  (on-save)="onFormSave()"
-></auto-save-form-actions>
+{{^if instance.archived}}
+    <auto-save-form-actions
+      {(form-edit-mode)}="editMode"
+      {form-saving}="formState.saving"
+      {form-fields-to-save-available}="formState.fieldsToSaveAvailable"
+      (on-save)="onFormSave()"
+    ></auto-save-form-actions>
+{{/if}}
 {{#is_allowed 'update' instance context='for'}}
-    <object-state-toolbar {verifiers}="instance.assignees.Verifier"
+    {{^if instance.archived}}
+         <object-state-toolbar {verifiers}="instance.assignees.Verifier"
                           {instance}="instance"
                           (on-state-change)="onStateChange(%event)">
-    </object-state-toolbar>
+         </object-state-toolbar>
+    {{/if}}
 {{/is_allowed}}
 <simple-modal {instance}="instance" modal-title="modalTitle" {(state)}="state" extra-css-class="related-assessments">
     <div class="simple-modal__body">

--- a/src/ggrc/assets/mustache/components/assessment/info-pane/info-pane.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/info-pane/info-pane.mustache
@@ -83,8 +83,10 @@
                 <div class="section-title">Responses/Comments</div>
               {{^if_in instance.status 'Completed,Final'}}
                 {{#is_allowed 'update' instance context='for'}}
-                    <assessment-add-comment class="assessment-comments-add"
+                    {{^if instance.archived}}
+                        <assessment-add-comment class="assessment-comments-add"
                                             {instance}="instance"></assessment-add-comment>
+                    {{/if}}
                 {{/is_allowed}}
               {{/if_in}}
                 <assessment-mapped-comments {mapped-items}="comments"></assessment-mapped-comments>
@@ -137,22 +139,27 @@
                                     <p>
                                         <small><em>Is this control design effective?</em></small>
                                     </p>
-                                  {{#is_allowed 'update' instance context='for'}}
+                                  {{#if_helpers '\
+                                    #is_allowed' 'update' instance context='for' '\
+                                    and ^if' instance.archived}}
                                       <dropdown options-list="model.conclusions"
                                                 no-value="true"
                                                 no-value-label="---"
                                                 name="instance.design">
                                       </dropdown>
+
                                   {{else}}
                                     {{firstnonempty design '--'}}
-                                  {{/is_allowed}}
+                                  {{/if_helpers}}
                                 </div>
                                 <div class="flex-size-1 flex-gutter-2">
                                     <label class="title-text">Conclusion: Operation</label>
                                     <p>
                                         <small><em>Is this control operationally effective?</em></small>
                                     </p>
-                                  {{#is_allowed 'update' instance context='for'}}
+                                  {{#if_helpers '\
+                                    #is_allowed' 'update' instance context='for' '\
+                                    and ^if' instance.archived}}
                                       <dropdown options-list="model.conclusions"
                                                 no-value="true"
                                                 no-value-label="---"
@@ -160,7 +167,7 @@
                                       </dropdown>
                                   {{else}}
                                     {{firstnonempty operationally '--'}}
-                                  {{/is_allowed}}
+                                  {{/if_helpers}}
                                 </div>
                             </div>
                         </collapsible-panel>

--- a/src/ggrc/assets/mustache/components/assessment/mapped-objects/mapped-controls.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/mapped-objects/mapped-controls.mustache
@@ -5,6 +5,7 @@
 <div class="section-title">
   {{titleText}}
   {{#is_allowed 'update' instance context='for'}}
+      {{^if instance.archived}}
     <click-filter>
       <i class="fa fa-plus-circle"
          rel="tooltip"
@@ -19,6 +20,7 @@
  >
       </i>
     </click-filter>
+      {{/if}}
   {{/is_allowed}}
 </div>
 <object-list {(selected-item)}="selectedItem" {items}="mappedItems">

--- a/src/ggrc/assets/mustache/components/assessment/mapped-objects/mapped-related-information.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/mapped-objects/mapped-related-information.mustache
@@ -5,20 +5,22 @@
 <div class="section-title">
   {{titleText}}
   {{#is_allowed 'update' instance context='for'}}
-    <click-filter>
-      <i class="fa fa-plus-circle"
-         rel="tooltip"
-         data-type="{{mappingType}}"
-         data-placement="right"
-         data-toggle="unified-mapper"
-         data-join-mapping="related_objects"
-         data-join-option-type="{{model.shortName}}"
-         data-join-object-id="{{instance.id}}"
-         data-join-object-type="{{instance.class.shortName}}"
-         data-original-title="Map {{firstnonempty mappingType 'Object'}} to this {{firstnonempty instance.class.title_singular 'Object'}}"
+      {{^if instance.archived}}
+      <click-filter>
+        <i class="fa fa-plus-circle"
+           rel="tooltip"
+           data-type="{{mappingType}}"
+           data-placement="right"
+           data-toggle="unified-mapper"
+           data-join-mapping="related_objects"
+           data-join-option-type="{{model.shortName}}"
+           data-join-object-id="{{instance.id}}"
+           data-join-object-type="{{instance.class.shortName}}"
+           data-original-title="Map {{firstnonempty mappingType 'Object'}} to this {{firstnonempty instance.class.title_singular 'Object'}}"
  >
-      </i>
-    </click-filter>
+        </i>
+      </click-filter>
+      {{/if}}
   {{/is_allowed}}
 </div>
 <object-list {(selected-item)}="selectedItem" {items}="mappedItems">

--- a/src/ggrc/assets/mustache/components/assessment/urls-list.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/urls-list.mustache
@@ -9,45 +9,53 @@
       {{#if showAction}}
         <div class="action-toolbar__controls">
         {{#is_allowed 'update' instance context='for'}}
+            {{^if instance.archived}}
               <unmap-button {destination}="instance" {source}="document">
                   <action-toolbar-control><i class="fa fa-trash"></i></action-toolbar-control>
               </unmap-button>
+            {{/if}}
         {{/is_allowed}}
         </div>
         {{/if}}
      </action-toolbar>
 </object-list>
 <div>
-  {{#is_allowed 'update' instance context='for'}}
-    {{#toggle show_new_object_form}}
-        <ggrc-quick-add
-                {parent_instance}="instance"
-                join_model="Relationship"
-                quick_create="create_url">
-          {{#prune_context}}
-              <div class="inline-edit inline-edit--active">
-                  <div class="inline-edit__content">
-                      <input tabindex="3" type="text" name="instance" placeholder="Add URL">
-                      <input type="hidden" name="role_name" value="Auditor"/>
-                      <ul class="inline-edit__controls inline-edit__controls--edit-mode">
-                          <li>
-                              <a href="javascript://" class="{{#if disabled}}disabled{{/if}}"
-                                 data-toggle="submit" {{toggle_button 'modal:success'}}>
-                                  <i class="fa fa-check"></i>
-                              </a>
-                          </li>
-                          <li>
-                              <a href="javascript://" {{toggle_button}}>
-                                  <i class="fa fa-times"></i>
-                              </a>
-                          </li>
-                      </ul>
+  {{#if_helpers '\
+    #is_allowed' 'update' instance context='for' '\
+    and ^if' instance.archived}}
+        {{#toggle show_new_object_form}}
+            <ggrc-quick-add
+                    {parent_instance}="instance"
+                    join_model="Relationship"
+                    quick_create="create_url">
+              {{#prune_context}}
+                  <div class="inline-edit inline-edit--active">
+                      <div class="inline-edit__content">
+                          <input tabindex="3" type="text" name="instance" placeholder="Add URL">
+                          <input type="hidden" name="role_name" value="Auditor"/>
+                          <ul class="inline-edit__controls inline-edit__controls--edit-mode">
+                              <li>
+                                  <a href="javascript://" class="{{#if disabled}}disabled{{/if}}"
+                                     data-toggle="submit" {{toggle_button 'modal:success'}}>
+                                      <i class="fa fa-check"></i>
+                                  </a>
+                              </li>
+                              <li>
+                                  <a href="javascript://" {{toggle_button}}>
+                                      <i class="fa fa-times"></i>
+                                  </a>
+                              </li>
+                          </ul>
+                      </div>
                   </div>
-              </div>
-          {{/prune_context}}
-        </ggrc-quick-add>
-    {{else}}
-        <button class="btn btn-small btn-gray" {{toggle_button}}>Add</button>
-    {{/toggle}}
-  {{/is_allowed}}
+              {{/prune_context}}
+            </ggrc-quick-add>
+        {{else}}
+            <button class="btn btn-small btn-gray" {{toggle_button}}>Add</button>
+        {{/toggle}}
+  {{else}}
+    {{^if mappedItems.length}}
+        <span class="empty-message">None</span>
+    {{/if}}
+  {{/if_helpers}}
 </div>

--- a/src/ggrc/assets/mustache/components/object-list-item/editable-document-object-list-item.mustache
+++ b/src/ggrc/assets/mustache/components/object-list-item/editable-document-object-list-item.mustache
@@ -8,7 +8,9 @@
     {{#if showAction}}
       <div class="action-toolbar__controls">
         {{#is_allowed 'update' instance context='for'}}
-          <content></content>
+            {{^if instance.archived}}
+                <content></content>
+            {{/if}}
         {{/is_allowed}}
       </div>
     {{/if}}

--- a/src/ggrc/assets/mustache/components/related-objects/related-issues.mustache
+++ b/src/ggrc/assets/mustache/components/related-objects/related-issues.mustache
@@ -6,7 +6,9 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 <related-objects {base-instance}="baseInstance" {predefined-filter}="relatedIssuesFilter" related-items-type="Issue">
     <div class="grid-data__toolbar flex-box">
         <tree-pagination {(paging)}="paging" class="grid-data__toolbar-item"></tree-pagination>
-        <add-issue-button {snapshots}="allRelatedSnapshots" {related-instance}="baseInstance" class="grid-data__toolbar-item"></add-issue-button>
+        {{^if baseInstance.archived}}
+                <add-issue-button {snapshots}="allRelatedSnapshots" {related-instance}="baseInstance" class="grid-data__toolbar-item"></add-issue-button>
+        {{/if}}
     </div>
     <div class="grid-data-header flex-row flex-box">
         <div class="flex-size-2">

--- a/src/ggrc/assets/mustache/components/reusable-objects/reusable-objects-item.mustache
+++ b/src/ggrc/assets/mustache/components/reusable-objects/reusable-objects-item.mustache
@@ -6,7 +6,7 @@
 <reusable-objets-item-control>
   {{#is_allowed 'update' baseInstance context='for'}}
     {{#is_allowed 'update' instance context='for'}}
-      {{^if instance.archived}}
+      {{^if baseInstance.archived}}
         {{#if disabled}}
             <input type="checkbox" checked="checked" disabled/>
         {{else}}

--- a/src/ggrc/assets/mustache/components/reusable-objects/reusable-objects-item.mustache
+++ b/src/ggrc/assets/mustache/components/reusable-objects/reusable-objects-item.mustache
@@ -6,12 +6,14 @@
 <reusable-objets-item-control>
   {{#is_allowed 'update' baseInstance context='for'}}
     {{#is_allowed 'update' instance context='for'}}
-      {{#if disabled}}
-          <input type="checkbox" checked="checked" disabled/>
-      {{else}}
-          <input type="checkbox"
-                 can-value="isChecked"
-            {{#if isSaving}}disabled{{/if}}/>
+      {{^if instance.archived}}
+        {{#if disabled}}
+            <input type="checkbox" checked="checked" disabled/>
+        {{else}}
+            <input type="checkbox"
+                   can-value="isChecked"
+                   {{#if isSaving}}disabled{{/if}}/>
+        {{/if}}
       {{/if}}
     {{/is_allowed}}
   {{/is_allowed}}

--- a/src/ggrc/assets/mustache/components/unified-mapper/mapper-results-item-details.mustache
+++ b/src/ggrc/assets/mustache/components/unified-mapper/mapper-results-item-details.mustache
@@ -10,7 +10,11 @@
     {{#if_equals instance.type "Person"}}
       {{> '/static/mustache/people/dropdown_menu.mustache'}}
     {{else}}
-      {{> '/static/mustache/base_objects/dropdown_menu.mustache'}}
+        {{#if_equals instance.type 'Audit'}}
+            {{> '/static/mustache/audits/dropdown_menu.mustache'}}
+        {{else}}
+            {{> '/static/mustache/base_objects/dropdown_menu.mustache'}}
+        {{/if_equals}}
     {{/if_equals}}
   {{/if}}
 </div>

--- a/src/ggrc/assets/mustache/custom_attributes/info.mustache
+++ b/src/ggrc/assets/mustache/custom_attributes/info.mustache
@@ -10,31 +10,33 @@
       {{#list}}
         <div class="span6">
           <div data-custom-attribute="{{id}}" data-type="{{attribute_type}}">
-            <inline-edit
-              instance="instance"
-              ca-id="cad.id"
-              {{#if cav.attribute_object}}
-              value="cav.attribute_object"
-              {{else}}
-              value="cav.attribute_value"
-              {{/if}}
-              values="cad.multi_choice_options"
-              title-text="cad.title"
-              label="cad.label"
-              type="{{type}}"
-              mandatory="cad.mandatory"
-              placeholder="cad.placeholder"
-              helptext="cad.helptext"
-              {{#if_helpers '\
+            {{#if_helpers '\
                 #if' instance.snapshot '\
-                or #if' instance.isRevision }}
-                readonly="true"
-              {{else}}
-                {{^is_allowed 'update' instance context='for'}}
-                  readonly="true"
-                {{/is_allowed}}
-              {{/if_helpers}}
-            ></inline-edit>
+                or #if' instance.isRevision '\
+                or #if' instance.archived '\
+                or ^is_allowed' 'update' instance context='for'}}
+                <inline-edit instance="instance" ca-id="cad.id"
+                        {{#if cav.attribute_object}}
+                            value="cav.attribute_object"
+                        {{else}}
+                            value="cav.attribute_value"
+                        {{/if}}
+                        values="cad.multi_choice_options" title-text="cad.title"
+                        label="cad.label" type="{{type}}" mandatory="cad.mandatory"
+                        placeholder="cad.placeholder" helptext="cad.helptext" readonly="true">
+                </inline-edit>
+            {{else}}
+                <inline-edit instance="instance" ca-id="cad.id"
+                    {{#if cav.attribute_object}}
+                             value="cav.attribute_object"
+                    {{else}}
+                             value="cav.attribute_value"
+                    {{/if}}
+                             values="cad.multi_choice_options" title-text="cad.title"
+                             label="cad.label" type="{{type}}" mandatory="cad.mandatory"
+                             placeholder="cad.placeholder" helptext="cad.helptext">
+                </inline-edit>
+            {{/if_helpers}}
           </div>
         </div>
       {{/list}}

--- a/src/ggrc/assets/mustache/dashboard/internav_list.mustache
+++ b/src/ggrc/assets/mustache/dashboard/internav_list.mustache
@@ -35,8 +35,10 @@
   </li>
 {{/widget_list}}
 
+
 {{#is_allowed 'update' instance}}
 {{#if widget_list.length}}
+{{^if instance.archived}}
 <li data-test-id="button_widget_add_2c925d94" class="hidden-widgets-list">
   <a href="{{urlPath}}#dropdown-widgets" class="dropdown-toggle" data-toggle="dropdown" rel="tooltip" data-placement="bottom" title="{{addTabTitle}}"><i class="fa fa-plus-circle"></i> {{addTabTitle}}</a>
   <div class="dropdown-menu" role="menu">
@@ -108,6 +110,7 @@
     {{/widget_list}}
   </div>
 </li>
+{{/if}}
 {{/if}}
 {{/is_allowed}}
 

--- a/src/ggrc/assets/mustache/modals/archive_cancel_buttons.mustache
+++ b/src/ggrc/assets/mustache/modals/archive_cancel_buttons.mustache
@@ -1,0 +1,15 @@
+{{!
+    Copyright (C) 2017 Google Inc.
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+}}
+
+<div class="row-fluid">
+  <div class="span6">
+    &nbsp;
+  </div>
+  <div class="span6">
+    <div class="confirm-buttons">
+      <a class="btn btn-small btn-red" data-toggle="archive" href="javascript://">Archive</a>
+    </div>
+  </div>
+</div>

--- a/src/ggrc/assets/mustache/snapshots/dropdown_menu.mustache
+++ b/src/ggrc/assets/mustache/snapshots/dropdown_menu.mustache
@@ -42,6 +42,7 @@ TODO: Temporary disabled until snapshot view is added.
             {{#using reified_snapshot=snapshot}}
             {{#canUpdate}}
             {{^isLatestRevision}}
+            {{^if instance.snapshot.archived}}
             <li>
               <revisions-comparer instance="instance"
                                   left-revision-id="instance.snapshot.revision_id"
@@ -51,6 +52,7 @@ TODO: Temporary disabled until snapshot view is added.
                   Get the latest version</a>
               </revisions-comparer>
             </li>
+            {{/if}}
             {{/isLatestRevision}}
             {{/canUpdate}}
             {{/using}}

--- a/src/ggrc/assets/mustache/snapshots/tree_add_item.mustache
+++ b/src/ggrc/assets/mustache/snapshots/tree_add_item.mustache
@@ -5,19 +5,21 @@
 
 {{#is_allowed_to_map parent_instance model.shortName}}
 {{#if allow_mapping_or_creating}}
+{{^if parent_instance.archived}}
   <click-filter>
     <a
-      class="section-add btn btn-mini action-button map-button"
-      href="javascript://"
-      rel="tooltip"
-      data-placement="left"
-      data-toggle="unified-mapper"
-      data-join-option-type="{{model.shortName}}"
-      data-join-object-id="{{parent_instance.id}}"
-      data-join-object-type="{{parent_instance.class.shortName}}"
-      data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}">
-        Map
-    </a>
+    class="section-add btn btn-mini action-button map-button"
+    href="javascript://"
+    rel="tooltip"
+    data-placement="left"
+    data-toggle="unified-mapper"
+    data-join-option-type="{{model.shortName}}"
+    data-join-object-id="{{parent_instance.id}}"
+    data-join-object-type="{{parent_instance.class.shortName}}"
+    data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}">
+      Map
+  </a>
   </click-filter>
+{{/if}}
 {{/if}}
 {{/is_allowed_to_map}}

--- a/src/ggrc_gdrive_integration/assets/javascripts/apps/gdrive.js
+++ b/src/ggrc_gdrive_integration/assets/javascripts/apps/gdrive.js
@@ -98,6 +98,9 @@
 
   can.view.mustache('picker-tag-default',
     '<ggrc-gdrive-folder-picker ' +
+    '{{#if instance.archived}}' +
+    'readonly=true' +
+    '{{/if}}' +
     '{{^is_allowed "update" instance context="for"}}' +
     'readonly=true{{/is_allowed}}' +
     ' instance="instance"/>');


### PR DESCRIPTION
AS a Global Admin (any Program / Audit role) or Program Manager (GR = Reader / Creator / Editor)
I WANT TO archive an Audit at any time 
SO THAT no one can change an Audit (update Audit / Issues / Assessments / Snapshots; map new objects to Audit / Assessment / Issue) until it is unarchived by Global Admin.
Requirements: https://docs.google.com/spreadsheets/d/1ay370HpmagLqwhV3iG1fErgX-4K1gQx3MvnK38UQmL0/edit#gid=0
![image](https://cloud.githubusercontent.com/assets/24203972/26790195/8f26a2ea-4a1b-11e7-904d-49fbca0e36d1.png)
![image](https://cloud.githubusercontent.com/assets/24203972/26790213/978abfe8-4a1b-11e7-9c53-99d146f69cc6.png)

