### PR TITLE
GGRC-2377 CAs are shown w/o values on Assessment Info pane after clicking "Complete" button

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.js
+++ b/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.js
@@ -233,6 +233,7 @@
     },
     events: {
       '{viewModel.instance} refreshInstance': function () {
+        this.viewModel.initializeFormFields();
         this.viewModel.updateRelatedItems();
       }
     }


### PR DESCRIPTION
_Steps to reproduce_:
1. Have mandatory GCAs with all the types for assessment
2. Have audit with control snapshot and created assessment template that contains mandatory LCAs with all types
3. Generate assessment based on snapshot and assessment template
4. Navigate to assessment Info pane and fill GCAs/LCAs
5. Click "Complete" button
6. Look at the values in GCAs/LCAs: are not shown
7. Refresh the page: the values are displayed

_Actual Result_: CAs are shown w/o values on Assessment Info pane after clicking "Complete" button
_Expected Result_: CAs should contain values on Assessment Info pane after clicking "Complete" button
