### PR TITLE
GGRC-1998 Assessments states are updated in pie chart after page refresh

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/summary_widget_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/summary_widget_controller.js
@@ -11,6 +11,7 @@
       widget_view: GGRC.mustache_path + '/base_objects/summary.mustache',
       isLoading: true,
       isShown: false,
+      forceRefresh: false,
       colorsMap: {
         Completed: '#405f77',
         Verified: '#009925',
@@ -69,6 +70,11 @@
       this.element.html(frag);
       return 0;
     },
+    '{CMS.Models.Assessment} updated': function (model, ev, instance) {
+      if (instance instanceof CMS.Models.Assessment) {
+        this.options.forceRefresh = true;
+      }
+    },
     get_widget_view: function (el) {
       var widgetView = $(el)
         .closest('[data-widget-view]')
@@ -102,9 +108,11 @@
       // State changes are not checked.
       var countsChanged = query.getCounts().attr(type) !==
                           chartOptions.attr('total');
-      if (chartOptions.attr('isInitialized') && !countsChanged) {
+      if (chartOptions.attr('isInitialized') && !countsChanged &&
+      !this.options.forceRefresh) {
         return;
       }
+      this.options.forceRefresh = false;
       chartOptions.attr('isInitialized', true);
 
       that.setState(type, {total: 0, statuses: { }}, true);

--- a/src/ggrc/assets/javascripts/controllers/tests/summary_widget_controller_spec.js
+++ b/src/ggrc/assets/javascripts/controllers/tests/summary_widget_controller_spec.js
@@ -11,6 +11,78 @@ describe('GGRC.Controllers.SummaryWidget', function () {
     Ctrl = GGRC.Controllers.SummaryWidget;
   });
 
+  describe('"{CMS.Models.Assessment} updated" handler', function () {
+    var method;
+    var ctrlInst;
+
+    beforeEach(function () {
+      ctrlInst = {
+        options: {
+          forceRefresh: false
+        }
+      };
+      method = Ctrl.prototype['{CMS.Models.Assessment} updated'].bind(ctrlInst);
+    });
+
+    it('sets true to options.forceRefresh', function () {
+      var assessment = new CMS.Models.Assessment();
+      method({}, {}, assessment);
+      expect(ctrlInst.options.forceRefresh).toBe(true);
+    });
+  });
+
+  describe('reloadChart() method', function () {
+    var method;
+    var ctrlInst;
+    var raw;
+
+    beforeEach(function () {
+      raw = [{type: 'Assessment'}];
+      ctrlInst = {
+        options: {
+          instance: {
+            id: 123
+          },
+          forceRefresh: false,
+          context: {
+            charts: {
+              Assessment: new can.Map({total: 3, isInitialized: true})
+            }
+          }
+        },
+        setState: jasmine.createSpy(),
+        getStatuses: jasmine.createSpy().and
+          .returnValue(new can.Deferred().resolve(raw)),
+        parseStatuses: jasmine.createSpy(),
+        drawChart: jasmine.createSpy(),
+        prepareLegend: jasmine.createSpy()
+      };
+      method = Ctrl.prototype.reloadChart.bind(ctrlInst);
+      spyOn(GGRC.Utils.CurrentPage, 'getCounts')
+        .and.returnValue(new can.Map({Assessment: 3}));
+    });
+
+    it('does nothing if chart options is initialized,' +
+    'counts is not changed and it was not force refresh', function () {
+      method('Assessment');
+      expect(ctrlInst.setState).not.toHaveBeenCalled();
+      expect(ctrlInst.drawChart).not.toHaveBeenCalled();
+    });
+    describe('if it was force refresh then', function () {
+      beforeEach(function () {
+        ctrlInst.options.forceRefresh = true;
+      });
+      it('sets false to options.forceRefresh ', function () {
+        method('Assessment');
+        expect(ctrlInst.options.forceRefresh).toBe(false);
+      });
+      it('calls drawChart() method', function () {
+        method('Assessment');
+        expect(ctrlInst.drawChart).toHaveBeenCalled();
+      });
+    });
+  });
+
   describe('widget_shown(event) method', function () {
     var method;
     var ctrlInst;


### PR DESCRIPTION
Steps to reproduce: 
1. Create at least 5 assessments on the audit page and move it to different states: Not started, In progress, Completed, Ready for review, Completed 
2. Go to Audit summary page 

Actual Result: Assessments states are updated in pie chart after page refresh 
Expected Result: Pie chart should contain actual info as soon as assessment changes a state w/o page refresh