### PR TITLE
GGRC-2220 Filter for custom roles on snapshots

### DIFF
--- a/src/ggrc/snapshotter/indexer.py
+++ b/src/ggrc/snapshotter/indexer.py
@@ -287,7 +287,12 @@ def reindex_pairs(pairs):
           {pair.to_4tuple() for pair in pairs}
       )
   ).options(
-      orm.subqueryload("revision").load_only("id", "resource_type", "content"),
+      orm.subqueryload("revision").load_only(
+          "id",
+          "resource_type",
+          "resource_id",
+          "content",
+      ),
       orm.load_only(
           "id",
           "context_id",
@@ -311,7 +316,7 @@ def reindex_pairs(pairs):
         "revision": get_searchable_attributes(
             CLASS_PROPERTIES[revision.resource_type],
             cad_dict,
-            revision.content)
+            revision.populated_content)
     }
   search_payload = []
   for snapshot in snapshots.values():


### PR DESCRIPTION
~depends on https://github.com/google/ggrc-core/pull/5754~ 

Filters for custom roles do not work on snapshots.
to test this try "principal assignees" filter on control snapshots tree view.
Please pay attention to test this with snapshots that are have principal assignees and are older than 1 month)
Preconditions
Audit with control snapshots that have principal assignees. Some snapshots must be new and some must be older than 1 month.
Steps to reproduce
1 try to filter by principal assignees.
Actual: no results are displayed
Expected: filter should display matching results