### PR TITLE
GGRC-1706 Send only the last status change notification for an object

### DIFF
--- a/src/ggrc/notifications/notification_handlers.py
+++ b/src/ggrc/notifications/notification_handlers.py
@@ -103,11 +103,35 @@ def _add_assessment_updated_notif(obj):
   """Add a notification record on the change of an object.
 
   If the same notification type for the object already exists and has not been
-  sent yet, do not do anything.
+  sent yet, do not do anything. The same if there already exist unsent status
+  change notifications for the object.
 
   Args:
     obj (models.mixins.Assignable): an object for which to add a notification
   """
+  # If there already exists a status change notification, an assessment updated
+  # notification should not be sent, and is thus not added.
+  notif_type_names = ["assessment_declined"]
+  notif_type_names.extend(item.value for item in Transitions)
+
+  notif_types = models.NotificationType.query.filter(
+      models.NotificationType.name.in_(notif_type_names)
+  )
+  notif_type_ids = [ntype.id for ntype in notif_types]
+
+  has_status_change = models.Notification.query.filter(
+      models.Notification.object_id == obj.id,
+      models.Notification.object_type == obj.type,
+      models.Notification.notification_type_id.in_(notif_type_ids),
+      (
+          models.Notification.sent_at.is_(None) |
+          (models.Notification.repeating == true())
+      )
+  ).exists()
+
+  if db.session.query(has_status_change).scalar():
+    return
+
   notif_type = models.NotificationType.query.filter_by(
       name="assessment_updated").first()
 
@@ -127,21 +151,24 @@ def _add_state_change_notif(obj, state_change, remove_existing=False):
     remove_existing (bool): whether or not to remove all exisiting state change
       notifications for `obj`
   """
+  # Assessment updated notifications should not be sent if there is a state
+  # change notification - we must thus delete the former.
+  notif_type_names = ["assessment_updated"]
+
   if remove_existing:
-    notif_type_names = (
-        [item.value for item in Transitions] + ["assessment_declined"]
-    )
+    notif_type_names.extend(item.value for item in Transitions)
+    notif_type_names.append("assessment_declined")
 
-    notif_types = models.NotificationType.query.filter(
-        models.NotificationType.name.in_(notif_type_names)
-    )
-    notif_type_ids = [ntype.id for ntype in notif_types]
+  notif_types = models.NotificationType.query.filter(
+      models.NotificationType.name.in_(notif_type_names)
+  )
+  notif_type_ids = [ntype.id for ntype in notif_types]
 
-    models.Notification.query.filter(
-        models.Notification.object_id == obj.id,
-        models.Notification.object_type == obj.type,
-        models.Notification.notification_type_id.in_(notif_type_ids)
-    ).delete(synchronize_session=False)
+  models.Notification.query.filter(
+      models.Notification.object_id == obj.id,
+      models.Notification.object_type == obj.type,
+      models.Notification.notification_type_id.in_(notif_type_ids)
+  ).delete(synchronize_session=False)
 
   notif_type = models.NotificationType.query.filter_by(
       name=state_change.value).first()


### PR DESCRIPTION
This PR removes some noise from the daily digest email, sending much fewer "update" notifications for a particular object.

The new behavior is as follows:
1. If multiple Assessment state transitions have occurred for the same object, only the last one is included in the daily email, and not each and every state transition anymore.
1. The "assessment updated" notifications is only included in the email if there are no "state change" notifications for a particular object.

---

**The changes can be tested as follows (part 1):**
- Create an assessment (possibly with a Verifier assigned) and change its state a couple of times - move it to "in progress", submit it for a review, decline it, complete it, etc.
- Open the daily digest test page (`/_notifications/show_daily_digest`)

_Expected result:_ Only the last state change notification is included in the email body for a particular person assigned to an Assessment.

**Testing the second requirement (part 2):**
- Perform the same steps as under `part 1` with an addition to modify one of the Assessment fields as well somewhere during the process.

_Expected result:_ The "assessment updated" notification is not included in the email text if there is a status change notification, regardless of whether an attribute change has been done before or after a state change.

---

NOTE:
If changing the Assessment status back and forth and ending up in the same state as at the beginning, the status "change" notification will still be sent, because we do not yet track the status of an Assessment at the time a notification entry is created. This can probably be considered a glitch, although it is probably a minor one, as (by my knowledge) state changes usually happen rarely (read: significantly less than several times a day).

This can be holistically addressed once we start implementing "object diff" in [GGRC-2400](https://gojira.corp.google.com/browse/GGRC-2400) - once we have version tracking in place, computing the state change difference (if any) will become straightforward.

