### PR TITLE
QUICK-FIX Add Document model to fulltext index

### DIFF
--- a/src/ggrc/fulltext/__init__.py
+++ b/src/ggrc/fulltext/__init__.py
@@ -69,6 +69,7 @@ def get_indexed_model_names():
       "Contract",
       "Control",
       "Cycle",
+      "Document",
       "CycleTaskEntry",
       "CycleTaskGroup",
       "CycleTaskGroupObjectTask",


### PR DESCRIPTION
This PR enables reindex of `Document` model on full reindex procedure.

The issue resulted in the fact that old Evidences/URLs were not shown in Evidences/URLs fields since the queries for these components rely on `Document.document_type` field being indexed.