### PR TITLE
GGRC-2377: Load CAs after Assessment state change

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment/controls-toolbar/controls-toolbar.js
+++ b/src/ggrc/assets/javascripts/components/assessment/controls-toolbar/controls-toolbar.js
@@ -23,6 +23,13 @@
       },
       onFormSave: function () {
         this.dispatch('onFormSave');
+      },
+      onStateChange: function (event) {
+        this.dispatch({
+          type: 'onStateChange',
+          state: event.state,
+          undo: event.undo
+        });
       }
     }
   });

--- a/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.js
+++ b/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.js
@@ -169,6 +169,30 @@
       onFormSave: function () {
         this.attr('triggerFormSaveCbs').fire();
       },
+      onStateChange: function (event) {
+        var undo = event.undo;
+        var state = event.state;
+        var instance = this.attr('instance');
+
+        if (!instance.attr('_undo')) {
+          instance.attr('_undo', []);
+        }
+
+        if (undo) {
+          instance.attr('_undo').shift();
+        } else {
+          instance.attr('_undo').unshift(state);
+        }
+
+        instance.refresh()
+          .then(function () {
+            instance.attr('status', state);
+            return instance.save();
+          })
+          .then(function () {
+            this.initializeFormFields();
+          }.bind(this));
+      },
       saveFormFields: function (formFields) {
         var caValues = can.makeArray(
           this.attr('instance.custom_attribute_values')

--- a/src/ggrc/assets/javascripts/components/object-state-toolbar/object-state-toolbar.js
+++ b/src/ggrc/assets/javascripts/components/object-state-toolbar/object-state-toolbar.js
@@ -59,6 +59,13 @@
       },
       hasErrors: function () {
         return this.attr('instance.preconditions_failed');
+      },
+      changeState: function (newState, undo) {
+        this.dispatch({
+          type: 'onStateChange',
+          state: newState,
+          undo: undo
+        });
       }
     }
   });

--- a/src/ggrc/assets/mustache/assessments/header.mustache
+++ b/src/ggrc/assets/mustache/assessments/header.mustache
@@ -96,7 +96,10 @@ Copyright (C) 2017 Google Inc.
                 </div>
             </div>
           {{#is_allowed 'update' instance context='for'}}
-            <object-state-toolbar {verifiers}="instance.assignees.Verifier" {instance}="instance"></object-state-toolbar>
+            <object-state-toolbar {verifiers}="instance.assignees.Verifier"
+                                  {instance}="instance"
+                                  (on-state-change)="onStateChange(%event)">
+            </object-state-toolbar>
           {{/is_allowed}}
         </div>
     </div>

--- a/src/ggrc/assets/mustache/components/assessment/controls-toolbar/controls-toolbar.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/controls-toolbar/controls-toolbar.mustache
@@ -10,7 +10,10 @@
   (on-save)="onFormSave()"
 ></auto-save-form-actions>
 {{#is_allowed 'update' instance context='for'}}
-    <object-state-toolbar {verifiers}="instance.assignees.Verifier" {instance}="instance"></object-state-toolbar>
+    <object-state-toolbar {verifiers}="instance.assignees.Verifier"
+                          {instance}="instance"
+                          (on-state-change)="onStateChange(%event)">
+    </object-state-toolbar>
 {{/is_allowed}}
 <simple-modal {instance}="instance" modal-title="modalTitle" {(state)}="state" extra-css-class="related-assessments">
     <div class="simple-modal__body">

--- a/src/ggrc/assets/mustache/components/assessment/info-pane/info-pane.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/info-pane/info-pane.mustache
@@ -36,7 +36,7 @@
                             <h6>Evidence</h6>
                             <object-list {items}="evidences" {empty-message}="noItemsText">
                                 <editable-document-object-list-item {document}="{.}">
-                                    <unmap-button 
+                                    <unmap-button
                                         {destination}="instance"
                                         {source}="document">
                                         <action-toolbar-control>
@@ -69,6 +69,7 @@
                                                  {instance}="instance"
                                                  {form-state}="formState"
                                                  (on-form-save)="onFormSave()"
+                                                 (on-state-change)="onStateChange(%event)"
                     ></assessment-controls-toolbar>
                 </div>
                 <assessment-mapped-related-information

--- a/src/ggrc/assets/mustache/components/object-state-toolbar/object-state-toolbar.mustache
+++ b/src/ggrc/assets/mustache/components/object-state-toolbar/object-state-toolbar.mustache
@@ -9,13 +9,14 @@
       {{^if hasErrors}}
         {{#if hasVerifiers}}
             <button class="btn btn-small btn-darkBlue pull-right btn-info-pin-header"
-                    data-name="status"
-                    data-value="Ready for Review">
-                Complete</button>
+                    ($click)="changeState('Ready for Review')">
+                Complete
+            </button>
         {{else}}
             <button class="btn btn-small btn-darkBlue pull-right btn-info-pin-header"
-                    data-name="status"
-                    data-value="Completed">Complete</button>
+                    ($click)="changeState('Completed')">
+                Complete
+            </button>
         {{/if}}
       {{else}}
           <button class="btn btn-small btn-darkBlue pull-right btn-info-pin-header disabled" {{#if errorMsg }}title="{{errorMsg}}"{{/if}}>Complete</button>
@@ -25,31 +26,31 @@
       {{#if isCurrentUserVerifier}}
         {{#unless hasErrors}}
             <button class="btn btn-small btn-green pull-right btn-info-pin-header"
-                    data-name="status"
-                    data-value="Verified">Verify
+                    ($click)="changeState('Verified')"
+                    Verify
             </button>
             <button class="btn btn-small btn-red pull-right btn-info-pin-header"
-                    data-name="status"
-                    data-value="In Progress">Reject
+                    ($click)="changeState('In Progress')">
+                Reject
             </button>
         {{else}}
             <button class="btn btn-small btn-green pull-right btn-info-pin-header disabled"
-                    data-name="status"
-                    data-value="Verified"
-                    title="{{errorMsg}}">Verify
+                    ($click)="changeState('Verified')"
+                    title="{{errorMsg}}">
+                Verify
             </button>
             <button class="btn btn-small btn-red pull-right btn-info-pin-header disabled"
-                    data-name="status"
-                    data-value="In Progress"
-                    title="{{errorMsg}}">Reject
+                    ($click)="changeState('In Progress')"
+                    title="{{errorMsg}}">
+                Reject
             </button>
         {{/unless}}
       {{/if}}
     {{/if}}
     {{#unless isInProgress}}
       {{#instance._undo.0}}
-          <a data-name="status" data-value="{{instance._undo.0}}" data-undo="true"
-             class="undo btn btn-small btn-link btn-info-pin-header pull-right {{#if isDisabled}}disabled{{/if}}">Undo</a>
+          <a data-name="status" ($click)="changeState(instance._undo.0, true)"
+             class="btn btn-small btn-link btn-info-pin-header pull-right {{#if isDisabled}}disabled{{/if}}">Undo</a>
       {{/instance._undo.0}}
     {{/unless}}
   {{/unless}}


### PR DESCRIPTION
Steps to reproduce:
1. Have mandatory GCAs with all the types for assessment
2. Have audit with control snapshot and created assessment template that contains mandatory LCAs with all types
3. Generate assessment based on snapshot and assessment template
4. Navigate to assessment Info pane and fill GCAs/LCAs
5. Click "Complete" button
6. Look at the values in GCAs/LCAs: are not shown
7. Refresh the page: the values are displayed
Actual Result: CAs are shown w/o values on Assessment Info pane after clicking "Complete" button
Expected Result: CAs should contain values on Assessment Info pane after clicking "Complete" button