### PR TITLE
GGRC-24 Change the title of declined tasks list in daily digest

### DIFF
--- a/src/ggrc/templates/notifications/email_digest_content.html
+++ b/src/ggrc/templates/notifications/email_digest_content.html
@@ -55,9 +55,10 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                 {% endif %}
 
                 {% if digest['task_declined'] %}
-                  <h2 {{ style.sub_title() }} > Following
+                  <h2 {{ style.sub_title() }} >
+                    The following
                     {{ "tasks" if digest['task_declined']|length > 1 else "task" }}
-                    you did, got declined </h2>
+                     assigned to you, got declined</h2>
                   <ul {{ style.list_wrap() }} >
                   {% for task in digest['task_declined'].values() %}
                     <li {{ style.list_item() }} >


### PR DESCRIPTION
This PR changes the text in the daily digest email for declined workflow tasks.

NOTE: I created the [task](https://gojira.corp.google.com/browse/GGRC-24) description myself based on the comments under the task. If there are grammatical errors in the wording, please let me know, and I will update accordingly.

---

**Steps to reproduce:**
- Create a workflow with a few task groups and tasks in it
- Start a cycle
- Start, finish, then decline a few of those tasks
- Open the daily digest page (`/_notifications/show_daily_digest`) and look for the "task declined" section of the tasks assignee's email

**Expected result:**
The title above the list of declined tasks should say _"The following tasks assigned to you, got declined"_

**Actual result:**
The title above the list of declined tasks says _"Following tasks you did, got declined"_

_Note:_ If there is only a single task in the list, a singular form should be used, i.e. "task" instead of "tasks".