### PR TITLE
GGRC-1727 Tooltip is still shown after Closing info pane

### DIFF
--- a/src/ggrc/assets/javascripts/components/info-pin-buttons/info-pin-buttons.js
+++ b/src/ggrc/assets/javascripts/components/info-pin-buttons/info-pin-buttons.js
@@ -12,7 +12,7 @@
       GGRC.mustache_path +
       '/components/info-pin-buttons/info-pin-buttons.mustache'
     ),
-    scope: {
+    viewModel: {
       onChangeMaximizedState: null,
       onClose: null,
       define: {
@@ -21,19 +21,24 @@
           'default': false
         }
       },
-      toggleSize: function (scope, el, ev) {
+      toggleSize: function (el, ev) {
         var maximized = !this.attr('maximized');
         var onChangeMaximizedState =
-          Mustache.resolve(this.onChangeMaximizedState);
+           Mustache.resolve(this.onChangeMaximizedState);
         ev.preventDefault();
-        this.attr('maximized', maximized);
+
         onChangeMaximizedState(maximized);
+
+        // Add in a callback queue
+        // for executing other
+        // handlers in the first place.
+        // Without it CanJS will ignore them
+        setTimeout(function () {
+          this.attr('maximized', maximized);
+        }.bind(this), 0);
       },
-      close: function (scope, el, ev) {
+      close: function (el, ev) {
         var onClose = Mustache.resolve(this.onClose);
-        if (el) {
-          el.find('[rel=tooltip]').data('tooltip').hide();
-        }
         ev.preventDefault();
         onClose();
       }

--- a/src/ggrc/assets/mustache/components/info-pin-buttons/info-pin-buttons.mustache
+++ b/src/ggrc/assets/mustache/components/info-pin-buttons/info-pin-buttons.mustache
@@ -4,21 +4,17 @@
 }}
 
 <ul class="pin-action">
-  {{#if maximized}}
   <li>
-    <a href="#" class="normal" can-click="toggleSize">
-      <i class="fa fa-fw fa-compress" rel="tooltip" data-placement="left" title="Minimize height"></i>
+    <a href="#" class="normal" ($click)="toggleSize(%element, %event)">
+      {{#if maximized}}
+        <i class="fa fa-fw fa-compress" rel="tooltip" data-placement="left" title="Minimize height"></i>
+      {{else}}
+        <i class="fa fa-fw fa-expand" rel="tooltip" data-placement="left" title="Maximize height"></i>
+      {{/if}}
     </a>
   </li>
-  {{else}}
   <li>
-    <a href="#" class="max" can-click="toggleSize">
-      <i class="fa fa-fw fa-expand" rel="tooltip" data-placement="left" title="Maximize height"></i>
-    </a>
-  </li>
-  {{/if}}
-  <li>
-    <a href="#" class="close-pane" can-click="close">
+    <a href="#" class="close-pane" ($click)="close(%element, %event)">
       <i class="fa fa-fw fa-times" rel="tooltip" data-placement="left" title="Close info pane"></i>
     </a>
   </li>


### PR DESCRIPTION
Steps to reproduce: 
1. Navigate to Assessment's Info pane and Minimize/Maximize info pane
2. Close Info pane

 Actual Result: Tooltip is still shown after closing Info pane 
Expected Result: Tooltip should not be shown after closing info pane
