### PR TITLE
GGRC-1498 Audit Module - UI - evidence (bold red font) and red exclamation icon is confusing because it is not a required question

### DIFF
--- a/src/ggrc/assets/stylesheets/components/attachment-upload-control/attachment-upload-control.scss
+++ b/src/ggrc/assets/stylesheets/components/attachment-upload-control/attachment-upload-control.scss
@@ -3,10 +3,16 @@
  * Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  */
 .attachment-upload-control {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   position: relative;
   min-height: 28px;
+
+  &:hover {
+    .attachment-upload-control__icon__error {
+      display: flex;
+    }
+  }
 
   &__button {
     margin: 0;
@@ -24,8 +30,9 @@
     top: 0;
   }
   &__icon__error {
-     i {
-       font-size: 12px;
-     }
+    display: none;
+    i {
+      font-size: 12px;
+    }
   }
 }


### PR DESCRIPTION
Evidence triangle:
 - show only on mouse over of attach button.
 - do not show it by default.