### PR TITLE
GGRC-2403 Verify button is broken on Assessment Info pane

### DIFF
--- a/src/ggrc/assets/mustache/components/object-state-toolbar/object-state-toolbar.mustache
+++ b/src/ggrc/assets/mustache/components/object-state-toolbar/object-state-toolbar.mustache
@@ -26,7 +26,7 @@
       {{#if isCurrentUserVerifier}}
         {{#unless hasErrors}}
             <button class="btn btn-small btn-green pull-right btn-info-pin-header"
-                    ($click)="changeState('Verified')"
+                    ($click)="changeState('Verified')">
                     Verify
             </button>
             <button class="btn btn-small btn-red pull-right btn-info-pin-header"


### PR DESCRIPTION
Steps to reproduce:
 1. Have assessment on the audit page
 2. Navigate to Assessment Info pane and add a verifier
 3. Log as verifier and move assessment to the "Ready for review" state 
4. Look at the "Verify" button: is broken 

Actual Result: Verify button is broken on Assessment Info pane
 Expected Result: Verify button should not be broken on Assessment Info pane