### PR TITLE
GGRC-1411 Notification is not sent if Assessment moves from Not Started to In Progress state

### DIFF
--- a/src/ggrc/migrations/versions/20170608130300_56108297b924_add_assessment_started_state_transition.py
+++ b/src/ggrc/migrations/versions/20170608130300_56108297b924_add_assessment_started_state_transition.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Add Assessment started state transition
+
+Create Date: 2017-06-08 13:03:00.386896
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+from datetime import datetime
+
+from alembic import op
+
+from sqlalchemy import Boolean, Date, Integer, String
+from sqlalchemy.sql import column, table
+
+# revision identifiers, used by Alembic.
+revision = "56108297b924"
+down_revision = "4936d6e2f8dd"
+
+
+_NOTIFICATION_TYPES_TABLE = table(
+    "notification_types",
+    column("name", String),
+    column("description", String),
+    column("template", String),
+    column("advance_notice", Integer),
+    column("instant", Boolean),
+    column("created_at", Date),
+    column("updated_at", Date),
+)
+
+_NOW = datetime.utcnow()
+
+_NOTIFICATION_TYPES = [{
+    "name": "assessment_started",
+    "description": (
+        u"Notify the people assigned to an Assessment that the latter has "
+        u"moved to In Progress."
+    ),
+    "template": "assessment_started",
+    "advance_notice": 0,
+    "instant": False,
+    "created_at": _NOW,
+    "updated_at": _NOW,
+}]
+
+
+def upgrade():
+  """Add new Assessment state change notification - "assessment started"."""
+  op.bulk_insert(
+      _NOTIFICATION_TYPES_TABLE,
+      _NOTIFICATION_TYPES
+  )
+
+
+def downgrade():
+  """Remove "assessment started" notification type.
+
+  Notifications of the removed notification type themselves get removed, too.
+  """
+  sql = """
+      DELETE n
+      FROM notifications AS n
+      LEFT JOIN notification_types AS nt ON
+          n.notification_type_id = nt.id
+      WHERE
+          nt.name = "assessment_started"
+  """
+
+  op.execute(sql)
+
+  sql = _NOTIFICATION_TYPES_TABLE.delete().where(
+      _NOTIFICATION_TYPES_TABLE.c.name == "assessment_started"
+  )
+  op.execute(sql)

--- a/src/ggrc/notifications/data_handlers.py
+++ b/src/ggrc/notifications/data_handlers.py
@@ -233,6 +233,7 @@ def get_assignable_data(notif):
   # notification types
   data_handlers = {
       "_open": assignable_open_data,
+      "_started": assignable_open_data,  # reuse logic, same data needed
       "_updated": assignable_updated_data,
       "_completed": assignable_updated_data,
       "_ready_for_review": assignable_updated_data,

--- a/src/ggrc/templates/notifications/email_digest_content.html
+++ b/src/ggrc/templates/notifications/email_digest_content.html
@@ -208,6 +208,22 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                   </ul>
                 {% endif %}
 
+                {% if digest.get('assessment_started') %}
+                  <h2 {{ style.sub_title() }} >
+                    {{ "Assessments have" if digest['assessment_started']|length > 1 else "Assessment has" }}
+                    been started
+                  </h2>
+                  <ul {{ style.list_wrap() }} >
+                  {% for assessment_id, assessment_data in digest['assessment_started'].iteritems() %}
+                    <li {{ style.list_item() }} >
+                      Assessment:
+                      <a href="{{ assessment_data['url'] }}" {{ style.link_text() }} >
+                        {{ assessment_data['title'] }}</a>
+                    </li>
+                  {% endfor %}
+                  </ul>
+                {% endif %}
+
                 {% if digest.get('assessment_updated') %}
                   <h2 {{ style.sub_title() }} >Assessments have been updated</h2>
                   <ul {{ style.list_wrap() }} >

--- a/test/integration/ggrc/notifications/test_assignable_notifications.py
+++ b/test/integration/ggrc/notifications/test_assignable_notifications.py
@@ -756,6 +756,8 @@ class TestAssignableNotificationUsingAPI(TestAssignableNotification):
       asmt = Assessment.query.get(asmts["A 5"].id)
       self.api_helper.modify_object(
           asmt, {"status": Assessment.PROGRESS_STATE})
+      self.client.get("/_notifications/send_daily_digest")
+      self.assertEqual(self._get_notifications().count(), 0)
 
       asmt = Assessment.query.get(asmts["A 5"].id)
       self.api_helper.modify_object(asmt, {"description": "new description"})
@@ -805,7 +807,7 @@ class TestAssignableNotificationUsingAPI(TestAssignableNotification):
       # start and finish assessment 1
       self.api_helper.modify_object(asmt1,
                                     {"status": Assessment.PROGRESS_STATE})
-      self.assertEqual(self._get_notifications().count(), 0)
+      self.assertEqual(self._get_notifications().count(), 1)
 
       self.api_helper.modify_object(asmt1, {"status": Assessment.DONE_STATE})
       self.assertEqual(self._get_notifications().count(), 1)
@@ -826,7 +828,7 @@ class TestAssignableNotificationUsingAPI(TestAssignableNotification):
       # start and finish assessment 6
       self.api_helper.modify_object(asmt6,
                                     {"status": Assessment.PROGRESS_STATE})
-      self.assertEqual(self._get_notifications().count(), 2)
+      self.assertEqual(self._get_notifications().count(), 3)
       self.api_helper.modify_object(asmt6, {"status": Assessment.DONE_STATE})
       self.assertEqual(self._get_notifications().count(), 3)
       # decline assessment 6


### PR DESCRIPTION
This PR adds a new notification type "Assessment started", which is sent when Assessment is moved from the "not started" to "in progress" state,

**Steps to verfiy:**
1. Create Assessment on the Audit page
2. Edit Assessment: confirm state moves from Not Started to In progress

**Actual Result:**
Notification is not sent if Assessment moves from Not Started to In Progress state

**Expected Result:**
Notification should be send if Assessment moves from Not Started to In Progress state

NOTE: Notifications can be checked by visiting the `/_notifications/show_daily_digest` page.