### PR TITLE
QUICK-FIX Remove relationship helper class

### DIFF
--- a/src/ggrc/converters/custom_operators.py
+++ b/src/ggrc/converters/custom_operators.py
@@ -18,7 +18,7 @@ from ggrc.converters.exceptions import BadQueryException
 from ggrc.fulltext.mysql import MysqlRecordProperty as Record
 from ggrc.login import is_creator
 from ggrc.models import inflector
-from ggrc.models.relationship_helper import RelationshipHelper
+from ggrc.models import relationship_helper
 from ggrc.snapshotter import rules
 from ggrc.utils import query_helpers
 from ggrc_basic_permissions import UserRole
@@ -146,7 +146,7 @@ def related_people(exp, object_class, target_class, query):
     return sqlalchemy.sql.false()
   model = inflector.get_model(exp['object_name'])
   res = []
-  res.extend(RelationshipHelper.person_object(
+  res.extend(relationship_helper.person_object(
       object_class.__name__,
       exp['object_name'],
       exp['ids'],
@@ -277,7 +277,7 @@ def relevant(exp, object_class, target_class, query):
                 object_name in rules.Types.all)
   if not snapshoted:
     return object_class.id.in_(
-        RelationshipHelper.get_ids_related_to(
+        relationship_helper.get_ids_related_to(
             object_class.__name__,
             object_name,
             ids,

--- a/src/ggrc/models/relationship_helper.py
+++ b/src/ggrc/models/relationship_helper.py
@@ -18,306 +18,302 @@ from ggrc.models.relationship import Relationship
 from ggrc.snapshotter.rules import Types
 
 
-class RelationshipHelper(object):
-  """Helpers for related objects with special relationships."""
+def program_audit(object_type, related_type, related_ids):
+  if {object_type, related_type} != {"Program", "Audit"} or not related_ids:
+    return None
 
-  @classmethod
-  def program_audit(cls, object_type, related_type, related_ids):
-    if {object_type, related_type} != {"Program", "Audit"} or not related_ids:
-      return None
+  if object_type == "Program":
+    return db.session.query(Audit.program_id).filter(
+        Audit.id.in_(related_ids))
+  else:
+    return db.session.query(Audit.id).filter(
+        Audit.program_id.in_(related_ids))
 
-    if object_type == "Program":
-      return db.session.query(Audit.program_id).filter(
-          Audit.id.in_(related_ids))
-    else:
-      return db.session.query(Audit.id).filter(
-          Audit.program_id.in_(related_ids))
 
-  @classmethod
-  def person_withcontact(cls, object_type, related_type, related_ids):
-    object_model = getattr(models, object_type, None)
-    related_model = getattr(models, related_type, None)
-    if None in [object_model, related_model]:
-      return None
-    if object_model == models.Person:
-      if issubclass(related_model, models.mixins.WithContact):
-        return db.session.query(related_model.contact_id).filter(
-            related_model.id.in_(related_ids)).union(
-            db.session.query(related_model.secondary_contact_id).filter(
-                related_model.id.in_(related_ids)))
-      else:
-        return None
-    elif related_model == models.Person:
-      if issubclass(object_model, models.mixins.WithContact):
-        return db.session.query(object_model.id).filter(
-            object_model.contact_id.in_(related_ids) |
-            object_model.secondary_contact_id.in_(related_ids))
+def person_withcontact(object_type, related_type, related_ids):
+  object_model = getattr(models, object_type, None)
+  related_model = getattr(models, related_type, None)
+  if None in [object_model, related_model]:
+    return None
+  if object_model == models.Person:
+    if issubclass(related_model, models.mixins.WithContact):
+      return db.session.query(related_model.contact_id).filter(
+          related_model.id.in_(related_ids)).union(
+          db.session.query(related_model.secondary_contact_id).filter(
+              related_model.id.in_(related_ids)))
     else:
       return None
+  elif related_model == models.Person:
+    if issubclass(object_model, models.mixins.WithContact):
+      return db.session.query(object_model.id).filter(
+          object_model.contact_id.in_(related_ids) |
+          object_model.secondary_contact_id.in_(related_ids))
+  else:
+    return None
 
-  @classmethod
-  def person_ownable(cls, object_type, related_type, related_ids):
-    if object_type == "Person":
-      return db.session.query(models.ObjectOwner.person_id).filter(
-          (models.ObjectOwner.ownable_type == related_type) &
-          (models.ObjectOwner.ownable_id.in_(related_ids)))
-    elif related_type == "Person":
-      return db.session.query(models.ObjectOwner.ownable_id).filter(
-          (models.ObjectOwner.ownable_type == object_type) &
-          (models.ObjectOwner.person_id.in_(related_ids)))
-    else:
-      return None
 
-  @classmethod
-  def person_object(cls, object_type, related_type, related_ids):
-    if "Person" not in [object_type, related_type]:
-      return None
-    if object_type == "Person":
-      return db.session.query(models.ObjectPerson.person_id).filter(
-          (models.ObjectPerson.personable_type == related_type) &
-          (models.ObjectPerson.personable_id.in_(related_ids))
-      )
-    else:
-      return db.session.query(models.ObjectPerson.personable_id).filter(
-          (models.ObjectPerson.personable_type == object_type) &
-          (models.ObjectPerson.person_id.in_(related_ids))
-      )
+def person_ownable(object_type, related_type, related_ids):
+  if object_type == "Person":
+    return db.session.query(models.ObjectOwner.person_id).filter(
+        (models.ObjectOwner.ownable_type == related_type) &
+        (models.ObjectOwner.ownable_id.in_(related_ids)))
+  elif related_type == "Person":
+    return db.session.query(models.ObjectOwner.ownable_id).filter(
+        (models.ObjectOwner.ownable_type == object_type) &
+        (models.ObjectOwner.person_id.in_(related_ids)))
+  else:
+    return None
 
-  @classmethod
-  def custom_attribute_mapping(cls, object_type, related_type, related_ids):
-    return db.session.query(models.CustomAttributeValue.attributable_id)\
-        .filter(
-            (models.CustomAttributeValue.attributable_type == object_type) &
-            (models.CustomAttributeValue.attribute_value == related_type) &
-            models.CustomAttributeValue.attribute_object_id.in_(related_ids))\
-        .union(
-        db.session.query(models.CustomAttributeValue.attribute_object_id)
-        .filter(
-            (models.CustomAttributeValue.attribute_value == object_type) &
-            (models.CustomAttributeValue.attributable_type == related_type) &
-            models.CustomAttributeValue.attributable_id.in_(related_ids)
-        )
+
+def person_object(object_type, related_type, related_ids):
+  if "Person" not in [object_type, related_type]:
+    return None
+  if object_type == "Person":
+    return db.session.query(models.ObjectPerson.person_id).filter(
+        (models.ObjectPerson.personable_type == related_type) &
+        (models.ObjectPerson.personable_id.in_(related_ids))
+    )
+  else:
+    return db.session.query(models.ObjectPerson.personable_id).filter(
+        (models.ObjectPerson.personable_type == object_type) &
+        (models.ObjectPerson.person_id.in_(related_ids))
     )
 
-  @classmethod
-  def program_risk_assessment(cls, object_type, related_type, related_ids):
-    if {object_type, related_type} != {"Program", "RiskAssessment"} or \
-            not related_ids:
-      return None
-    if object_type == "Program":
-      return db.session.query(all_models.RiskAssessment.program_id).filter(
-          all_models.RiskAssessment.id.in_(related_ids))
-    else:
-      return db.session.query(all_models.RiskAssessment.id).filter(
-          all_models.RiskAssessment.program_id.in_(related_ids))
 
-  @classmethod
-  def task_group_object(cls, object_type, related_type, related_ids):
-    if not related_ids:
-      return None
-    if object_type == "TaskGroup":
-      return db.session.query(all_models.TaskGroupObject.task_group_id).filter(
-          (all_models.TaskGroupObject.object_type == related_type) &
-          all_models.TaskGroupObject.object_id.in_(related_ids))
-    elif related_type == "TaskGroup":
-      return db.session.query(all_models.TaskGroupObject.object_id).filter(
-          (all_models.TaskGroupObject.object_type == related_type) &
-          all_models.TaskGroupObject.task_group_id.in_(related_ids))
-    else:
-      return None
-
-  @classmethod
-  def _audit_snapshot(cls, object_type, related_type, related_ids):
-    if {object_type, related_type} != {"Audit", "Snapshot"} or not related_ids:
-      return None
-
-    if object_type == "Audit":
-      return db.session.query(Snapshot.parent_id).filter(
-          Snapshot.id.in_(related_ids))
-    else:
-      return db.session.query(Snapshot.id).filter(
-          Snapshot.parent_id.in_(related_ids))
-
-  @classmethod
-  def get_special_mappings(cls, object_type, related_type, related_ids):
-    return [
-        cls._audit_snapshot(object_type, related_type, related_ids),
-        cls.person_object(object_type, related_type, related_ids),
-        cls.person_ownable(object_type, related_type, related_ids),
-        cls.person_withcontact(object_type, related_type, related_ids),
-        cls.program_audit(object_type, related_type, related_ids),
-        cls.program_risk_assessment(object_type, related_type, related_ids),
-        cls.task_group_object(object_type, related_type, related_ids),
-        cls.custom_attribute_mapping(object_type, related_type, related_ids),
-    ]
-
-  @classmethod
-  def get_extension_mappings(cls, object_type, related_type, related_ids):
-    queries = []
-    for extension in get_extension_modules():
-      get_ids = getattr(extension, "contributed_get_ids_related_to", None)
-      if callable(get_ids):
-        queries.append(get_ids(object_type, related_type, related_ids))
-    return queries
-
-  @classmethod
-  def _array_union(cls, queries):
-    """ Union of all valid queries in array """
-    clean_queries = [q for q in queries if q]
-    if not clean_queries:
-      return db.session.query(Relationship.source_id).filter(sql.false())
-
-    query = clean_queries.pop()
-    return query.union(*clean_queries)
-
-  @classmethod
-  def _assessment_object_mappings(cls, object_type, related_type, related_ids):
-    """Get Object ids for audit scope objects and snapshotted objects."""
-
-    if object_type in Types.scoped and related_type in Types.all:
-
-      source_query = db.session.query(
-          Relationship.destination_id.label("result_id"),
-          Relationship.destination_type,
-          Snapshot.child_id,
-          Snapshot.child_type,
-      ).join(
-          Snapshot,
-          and_(
-              Relationship.source_id == Snapshot.id,
-              Relationship.source_type == Snapshot.__name__,
-              Relationship.destination_type == object_type,
-              Snapshot.child_type == related_type,
-              Snapshot.child_id.in_(related_ids),
-          )
+def custom_attribute_mapping(object_type, related_type, related_ids):
+  return db.session.query(models.CustomAttributeValue.attributable_id)\
+      .filter(
+          (models.CustomAttributeValue.attributable_type == object_type) &
+          (models.CustomAttributeValue.attribute_value == related_type) &
+          models.CustomAttributeValue.attribute_object_id.in_(related_ids))\
+      .union(
+      db.session.query(models.CustomAttributeValue.attribute_object_id)
+      .filter(
+          (models.CustomAttributeValue.attribute_value == object_type) &
+          (models.CustomAttributeValue.attributable_type == related_type) &
+          models.CustomAttributeValue.attributable_id.in_(related_ids)
       )
+  )
 
-      destination_query = db.session.query(
-          Relationship.source_id.label("result_id"),
-          Relationship.source_type,
-          Snapshot.child_id,
-          Snapshot.child_type,
-      ).join(
-          Snapshot,
-          and_(
-              Relationship.destination_id == Snapshot.id,
-              Relationship.destination_type == Snapshot.__name__,
-              Relationship.source_type == object_type,
-              Snapshot.child_type == related_type,
-              Snapshot.child_id.in_(related_ids),
-          )
-      )
 
-    elif object_type in Types.all and related_type in Types.scoped:
-      source_query = db.session.query(
-          Relationship.destination_id,
-          Relationship.destination_type,
-          Snapshot.child_id.label("result_id"),
-          Snapshot.child_type,
-      ).join(
-          Snapshot,
-          and_(
-              Relationship.source_id == Snapshot.id,
-              Relationship.source_type == Snapshot.__name__,
-              Relationship.destination_type == related_type,
-              Relationship.destination_id.in_(related_ids),
-              Snapshot.child_type == object_type,
-          )
-      )
+def program_risk_assessment(object_type, related_type, related_ids):
+  if {object_type, related_type} != {"Program", "RiskAssessment"} or \
+          not related_ids:
+    return None
+  if object_type == "Program":
+    return db.session.query(all_models.RiskAssessment.program_id).filter(
+        all_models.RiskAssessment.id.in_(related_ids))
+  else:
+    return db.session.query(all_models.RiskAssessment.id).filter(
+        all_models.RiskAssessment.program_id.in_(related_ids))
 
-      destination_query = db.session.query(
-          Relationship.source_id,
-          Relationship.source_type,
-          Snapshot.child_id.label("result_id"),
-          Snapshot.child_type,
-      ).join(
-          Snapshot,
-          and_(
-              Relationship.destination_id == Snapshot.id,
-              Relationship.destination_type == Snapshot.__name__,
-              Relationship.source_type == related_type,
-              Relationship.source_id.in_(related_ids),
-              Snapshot.child_type == object_type,
-          )
-      )
 
-    else:
-      raise Exception(
-          "Snapshot relationship called with invalid types.\n"
-          "object types: '{}' - '{}'".format(object_type, related_type)
-      )
+def task_group_object(object_type, related_type, related_ids):
+  if not related_ids:
+    return None
+  if object_type == "TaskGroup":
+    return db.session.query(all_models.TaskGroupObject.task_group_id).filter(
+        (all_models.TaskGroupObject.object_type == related_type) &
+        all_models.TaskGroupObject.object_id.in_(related_ids))
+  elif related_type == "TaskGroup":
+    return db.session.query(all_models.TaskGroupObject.object_id).filter(
+        (all_models.TaskGroupObject.object_type == related_type) &
+        all_models.TaskGroupObject.task_group_id.in_(related_ids))
+  else:
+    return None
 
-    query = aliased(union(source_query, destination_query))
 
-    return db.session.query(query.c.result_id)
+def _audit_snapshot(object_type, related_type, related_ids):
+  if {object_type, related_type} != {"Audit", "Snapshot"} or not related_ids:
+    return None
 
-  @classmethod
-  def _parent_object_mappings(cls, object_type, related_type, related_ids):
-    """Get Object ids for audit and snapshotted object mappings."""
+  if object_type == "Audit":
+    return db.session.query(Snapshot.parent_id).filter(
+        Snapshot.id.in_(related_ids))
+  else:
+    return db.session.query(Snapshot.id).filter(
+        Snapshot.parent_id.in_(related_ids))
 
-    if object_type in Types.parents and related_type in Types.all:
-      query = db.session.query(Snapshot.parent_id).filter(
-          Snapshot.parent_type == object_type,
-          Snapshot.child_type == related_type,
-          Snapshot.child_id.in_(related_ids)
-      )
-    elif related_type in Types.parents and object_type in Types.all:
-      query = db.session.query(Snapshot.child_id).filter(
-          Snapshot.parent_type == related_type,
-          Snapshot.parent_id.in_(related_ids),
-          Snapshot.child_type == object_type,
-      )
-    else:
-      raise Exception(
-          "Parent relationship called with invalid types.\n"
-          "object types: '{}' - '{}'".format(object_type, related_type)
-      )
 
-    return query
+def get_special_mappings(object_type, related_type, related_ids):
+  return [
+      _audit_snapshot(object_type, related_type, related_ids),
+      person_object(object_type, related_type, related_ids),
+      person_ownable(object_type, related_type, related_ids),
+      person_withcontact(object_type, related_type, related_ids),
+      program_audit(object_type, related_type, related_ids),
+      program_risk_assessment(object_type, related_type, related_ids),
+      task_group_object(object_type, related_type, related_ids),
+      custom_attribute_mapping(object_type, related_type, related_ids),
+  ]
 
-  @classmethod
-  def get_ids_related_to(cls, object_type, related_type, related_ids=None):
-    """ get ids of objects
 
-    Get a list of all ids for object with object_type, that are related to any
-    of the objects with type related_type and id in related_ids
-    """
+def get_extension_mappings(object_type, related_type, related_ids):
+  queries = []
+  for extension in get_extension_modules():
+    get_ids = getattr(extension, "contributed_get_ids_related_to", None)
+    if callable(get_ids):
+      queries.append(get_ids(object_type, related_type, related_ids))
+  return queries
 
-    if isinstance(related_ids, (int, long)):
-      related_ids = [related_ids]
 
-    if not related_ids:
-      return db.session.query(Relationship.source_id).filter(sql.false())
+def _array_union(queries):
+  """ Union of all valid queries in array """
+  clean_queries = [q for q in queries if q]
+  if not clean_queries:
+    return db.session.query(Relationship.source_id).filter(sql.false())
 
-    if (object_type in Types.scoped and related_type in Types.all or
-            related_type in Types.scoped and object_type in Types.all):
-      return cls._assessment_object_mappings(
-          object_type, related_type, related_ids)
+  query = clean_queries.pop()
+  return query.union(*clean_queries)
 
-    if (object_type in Types.parents and related_type in Types.all or
-            related_type in Types.parents and object_type in Types.all):
-      return cls._parent_object_mappings(
-          object_type, related_type, related_ids)
 
-    destination_ids = db.session.query(Relationship.destination_id).filter(
+def _assessment_object_mappings(object_type, related_type, related_ids):
+  """Get Object ids for audit scope objects and snapshotted objects."""
+
+  if object_type in Types.scoped and related_type in Types.all:
+
+    source_query = db.session.query(
+        Relationship.destination_id.label("result_id"),
+        Relationship.destination_type,
+        Snapshot.child_id,
+        Snapshot.child_type,
+    ).join(
+        Snapshot,
         and_(
+            Relationship.source_id == Snapshot.id,
+            Relationship.source_type == Snapshot.__name__,
             Relationship.destination_type == object_type,
-            Relationship.source_type == related_type,
-            Relationship.source_id.in_(related_ids),
+            Snapshot.child_type == related_type,
+            Snapshot.child_id.in_(related_ids),
         )
     )
-    source_ids = db.session.query(Relationship.source_id).filter(
+
+    destination_query = db.session.query(
+        Relationship.source_id.label("result_id"),
+        Relationship.source_type,
+        Snapshot.child_id,
+        Snapshot.child_type,
+    ).join(
+        Snapshot,
         and_(
+            Relationship.destination_id == Snapshot.id,
+            Relationship.destination_type == Snapshot.__name__,
             Relationship.source_type == object_type,
+            Snapshot.child_type == related_type,
+            Snapshot.child_id.in_(related_ids),
+        )
+    )
+
+  elif object_type in Types.all and related_type in Types.scoped:
+    source_query = db.session.query(
+        Relationship.destination_id,
+        Relationship.destination_type,
+        Snapshot.child_id.label("result_id"),
+        Snapshot.child_type,
+    ).join(
+        Snapshot,
+        and_(
+            Relationship.source_id == Snapshot.id,
+            Relationship.source_type == Snapshot.__name__,
             Relationship.destination_type == related_type,
             Relationship.destination_id.in_(related_ids),
+            Snapshot.child_type == object_type,
         )
     )
 
-    queries = [destination_ids, source_ids]
-    queries.extend(cls.get_extension_mappings(
-        object_type, related_type, related_ids))
-    queries.extend(cls.get_special_mappings(
-        object_type, related_type, related_ids))
+    destination_query = db.session.query(
+        Relationship.source_id,
+        Relationship.source_type,
+        Snapshot.child_id.label("result_id"),
+        Snapshot.child_type,
+    ).join(
+        Snapshot,
+        and_(
+            Relationship.destination_id == Snapshot.id,
+            Relationship.destination_type == Snapshot.__name__,
+            Relationship.source_type == related_type,
+            Relationship.source_id.in_(related_ids),
+            Snapshot.child_type == object_type,
+        )
+    )
 
-    return cls._array_union(queries)
+  else:
+    raise Exception(
+        "Snapshot relationship called with invalid types.\n"
+        "object types: '{}' - '{}'".format(object_type, related_type)
+    )
+
+  query = aliased(union(source_query, destination_query))
+
+  return db.session.query(query.c.result_id)
+
+
+def _parent_object_mappings(object_type, related_type, related_ids):
+  """Get Object ids for audit and snapshotted object mappings."""
+
+  if object_type in Types.parents and related_type in Types.all:
+    query = db.session.query(Snapshot.parent_id).filter(
+        Snapshot.parent_type == object_type,
+        Snapshot.child_type == related_type,
+        Snapshot.child_id.in_(related_ids)
+    )
+  elif related_type in Types.parents and object_type in Types.all:
+    query = db.session.query(Snapshot.child_id).filter(
+        Snapshot.parent_type == related_type,
+        Snapshot.parent_id.in_(related_ids),
+        Snapshot.child_type == object_type,
+    )
+  else:
+    raise Exception(
+        "Parent relationship called with invalid types.\n"
+        "object types: '{}' - '{}'".format(object_type, related_type)
+    )
+
+  return query
+
+
+def get_ids_related_to(object_type, related_type, related_ids=None):
+  """ get ids of objects
+
+  Get a list of all ids for object with object_type, that are related to any
+  of the objects with type related_type and id in related_ids
+  """
+
+  if isinstance(related_ids, (int, long)):
+    related_ids = [related_ids]
+
+  if not related_ids:
+    return db.session.query(Relationship.source_id).filter(sql.false())
+
+  if (object_type in Types.scoped and related_type in Types.all or
+          related_type in Types.scoped and object_type in Types.all):
+    return _assessment_object_mappings(
+        object_type, related_type, related_ids)
+
+  if (object_type in Types.parents and related_type in Types.all or
+          related_type in Types.parents and object_type in Types.all):
+    return _parent_object_mappings(
+        object_type, related_type, related_ids)
+
+  destination_ids = db.session.query(Relationship.destination_id).filter(
+      and_(
+          Relationship.destination_type == object_type,
+          Relationship.source_type == related_type,
+          Relationship.source_id.in_(related_ids),
+      )
+  )
+  source_ids = db.session.query(Relationship.source_id).filter(
+      and_(
+          Relationship.source_type == object_type,
+          Relationship.destination_type == related_type,
+          Relationship.destination_id.in_(related_ids),
+      )
+  )
+
+  queries = [destination_ids, source_ids]
+  queries.extend(get_extension_mappings(
+      object_type, related_type, related_ids))
+  queries.extend(get_special_mappings(
+      object_type, related_type, related_ids))
+
+  return _array_union(queries)


### PR DESCRIPTION
Creating a relationships helper class was a wrong design decision
because we never bind any data to the class. This commits changes the
relationship helper from class to module for clarity.

Hint: for cleaner diff view use https://github.com/google/ggrc-core/pull/5779/files?w=1