### PR TITLE
GGRC-2293 Assessment: if copy text and insert into Rich text field text is not saved and Save Changes button is disabled

### DIFF
--- a/src/ggrc/assets/javascripts/components/auto-save-form/fields/rich-text-form-field.js
+++ b/src/ggrc/assets/javascripts/components/auto-save-form/fields/rich-text-form-field.js
@@ -13,14 +13,31 @@
     ),
     viewModel: {
       _value: '',
-      _oldValue: '',
+      _oldValue: null,
       focused: false,
       placeholder: '',
       define: {
         value: {
           set: function (newValue, setValue) {
             setValue(newValue);
-            this.attr('_value', newValue);
+            if (!_.isNull(newValue)) {
+              this.attr('_value', newValue);
+            }
+          }
+        },
+        _value: {
+          set: function (newValue, setValue, onError, oldValue) {
+            setValue(newValue);
+            this.attr('_oldValue', oldValue);
+            if (oldValue === undefined ||
+                newValue === oldValue ||
+                newValue.length && !can.trim(newValue).length) {
+              return;
+            }
+
+            setTimeout(function () {
+              this.checkValueChanged();
+            }.bind(this), 5000);
           }
         }
       },
@@ -41,10 +58,6 @@
       },
       onFocus: function () {
         this.attr('focused', true);
-        this.attr(
-          '_oldValue',
-          this.attr('_value')
-        );
       },
       onBlur: function () {
         this.attr('focused', false);
@@ -55,13 +68,7 @@
       '.ql-editor focus': function () {
         this.viewModel.onFocus();
       },
-      'rich-text mousedown': function (el, ev) {
-        ev.stopPropagation();
-      },
-      '{window} mousedown': function () {
-        if (!this.viewModel.attr('focused')) {
-          return;
-        }
+      '.ql-editor blur': function () {
         this.viewModel.onBlur();
       }
     }


### PR DESCRIPTION
_Steps to reproduce_:
1. Have GCA with rich text for assessment
2. Have audit with assessment in scope of this audit
2. Expand Assessment's Info pane
3. Copy any text and insert into GCA with Rich text type: is not saving and Save changes button is disabled
4. Refresh the page and look at the value in GCA with rich text: is not saved

_Actual Result_: if copy text and insert into Rich text field text is not saved and Save Changes button is disabled
_Expected Result_: Data in rich text field should be saved if copy paste it and insert into rich text field

![screenshot-1](https://user-images.githubusercontent.com/4204416/27028300-13621156-4f6d-11e7-86a8-0ebe1c4e1719.png)
