### PR TITLE
GGRC-1998 Assessments states are updated in pie chart after page refresh 

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/summary_widget_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/summary_widget_controller.js
@@ -70,6 +70,15 @@
       this.element.html(frag);
       return 0;
     },
+    onRelationshipChange: function (model, ev, instance) {
+      if (instance instanceof CMS.Models.Relationship &&
+      instance.attr('destination.type') === 'Document' &&
+      instance.attr('source.type') === 'Assessment') {
+        this.options.forceRefresh = true;
+      }
+    },
+    '{CMS.Models.Relationship} destroyed': 'onRelationshipChange',
+    '{CMS.Models.Relationship} created': 'onRelationshipChange',
     '{CMS.Models.Assessment} updated': function (model, ev, instance) {
       if (instance instanceof CMS.Models.Assessment) {
         this.options.forceRefresh = true;

--- a/src/ggrc/assets/javascripts/controllers/tests/summary_widget_controller_spec.js
+++ b/src/ggrc/assets/javascripts/controllers/tests/summary_widget_controller_spec.js
@@ -31,6 +31,66 @@ describe('GGRC.Controllers.SummaryWidget', function () {
     });
   });
 
+  describe('onRelationshipChange() method', function () {
+    var method;
+    var ctrlInst;
+
+    beforeEach(function () {
+      ctrlInst = {
+        options: {
+          forceRefresh: false
+        }
+      };
+      method = Ctrl.prototype.onRelationshipChange.bind(ctrlInst);
+    });
+
+    it('sets true to options.forceRefresh if destination type is Document' +
+    'and source type is Assessment',
+      function () {
+        var relationship = new CMS.Models.Relationship({
+          destination: {
+            type: 'Document',
+            id: 1
+          }, source: {
+            type: 'Assessment',
+            id: 1
+          }
+        });
+        method({}, {}, relationship);
+        expect(ctrlInst.options.forceRefresh).toBe(true);
+      });
+
+    it('does not set true to options.forceRefresh' +
+    ' if destination type is not Document', function () {
+      var relationship = new CMS.Models.Relationship({
+        destination: {
+          type: 'Control',
+          id: 1
+        }, source: {
+          type: 'Assessment',
+          id: 1
+        }
+      });
+      method({}, {}, relationship);
+      expect(ctrlInst.options.forceRefresh).toBe(false);
+    });
+
+    it('does not set true to options.forceRefresh' +
+    ' if source type is not Assessment', function () {
+      var relationship = new CMS.Models.Relationship({
+        destination: {
+          type: 'Document',
+          id: 1
+        }, source: {
+          type: 'Issue',
+          id: 1
+        }
+      });
+      method({}, {}, relationship);
+      expect(ctrlInst.options.forceRefresh).toBe(false);
+    });
+  });
+
   describe('reloadChart() method', function () {
     var method;
     var ctrlInst;


### PR DESCRIPTION
Pie chart is not updated automatically if attach evidence or url and assessment changes state.

Steps to reproduce:
1. Have assessment that "completed and verified"
2. Attach evidence or add url: assessment moves to "In progress" state 
3. Go to Audit Summary page: assessment's state is not updated in legend and pie chart.

Expected Result: Pie chart should contain actual info as soon as assessment changes a state w/o page refresh