### PR TITLE
GGRC-2290 Cannot click "Read More" in Response/Comment section if browser window is too narrow

### DIFF
--- a/src/ggrc/assets/stylesheets/components/info-pane/_info-pane.scss
+++ b/src/ggrc/assets/stylesheets/components/info-pane/_info-pane.scss
@@ -56,6 +56,7 @@
     right: 0;
     bottom: 0;
     padding-left: 16px;
+    padding-bottom: 20px;
     width: 30%;
     display: flex;
     flex-direction: column;

--- a/src/ggrc/assets/stylesheets/components/mapped-objects/_mapped-objects.scss
+++ b/src/ggrc/assets/stylesheets/components/mapped-objects/_mapped-objects.scss
@@ -141,7 +141,7 @@ assessment-mapped-controls, assessment-mapped-related-information {
 }
 .comment-object-item {
   display: block;
-  margin: 0 0 16px 0;
+  margin: 0 16px 16px 0;
 
   .comment-list__ca-description {
     font-size: 11px;
@@ -174,6 +174,7 @@ assessment-mapped-controls, assessment-mapped-related-information {
   }
   .comment-object-item__text {
     font-size: 13px;
+    word-wrap: break-word;
 
     * {
       padding: 0;

--- a/src/ggrc/assets/stylesheets/components/read-more/_read-more.scss
+++ b/src/ggrc/assets/stylesheets/components/read-more/_read-more.scss
@@ -29,20 +29,20 @@ read-more {
     margin: 0;
     text-align: right;
     position: relative;
-  }
 
-  .read-more__btn {
-    padding: 2px 0;
-    box-sizing: border-box;
-    text-align: right;
-    min-width: 78px;
-    cursor: pointer;
-    line-height: 18px;
-    display: inline-block;
-    transition: display 0.3s ease;
+    .read-more__btn {
+      padding: 2px 0;
+      box-sizing: border-box;
+      text-align: right;
+      min-width: 78px;
+      cursor: pointer;
+      line-height: 18px;
+      display: inline-block;
+      transition: display 0.3s ease;
 
-    &:hover {
-      text-decoration: none;
+      &:hover {
+        text-decoration: none;
+      }
     }
   }
 }

--- a/src/ggrc/assets/stylesheets/modules/_rich-text.scss
+++ b/src/ggrc/assets/stylesheets/modules/_rich-text.scss
@@ -20,6 +20,8 @@ rich-text {
     .rich-text__content {
       border: none;
       padding: 8px 10px;
+      max-height: 424px;
+      overflow-y: auto;
 
       .ql-editor {
         padding: 0;


### PR DESCRIPTION
**Comment by User:**
_What is the problem / issue?_
If my browser window is sized to use up less of my screen, sometimes I cannot click on the "Read More" or "Read Less" links (see attached screen recording). I've also seen this happen to the "Add" button where it won't let me click to add a comment unless I expand the screen.

_What is the expected result / outcome?_
I should be able to click to reduce/expand the text regardless of my browser window size.

_What is the impact if it is not fixed / implemented?_
It's a minor annoyance. I have to expand my window to make it work.

<img width="897" alt="screen shot 2017-06-12 at 5 41 25 pm" src="https://user-images.githubusercontent.com/4204416/27039356-669213e8-4f96-11e7-8aa5-14e6c7cbb607.png">