### PR TITLE
GGRC-2282 Issue in Related Issues tab is displayed after refreshing a page if click Save and Add another button 

### DIFF
--- a/src/ggrc/assets/javascripts/components/add-issue-button/add-issue-button.js
+++ b/src/ggrc/assets/javascripts/components/add-issue-button/add-issue-button.js
@@ -48,7 +48,7 @@
       }
     },
     events: {
-      '{window} modal:success': function (window, event, instance) {
+      refreshIssueList: function (window, event, instance) {
         var pageInstance;
 
         if (instance instanceof CMS.Models.Issue) {
@@ -61,7 +61,9 @@
         }
 
         this.viewModel.attr('relatedInstance').dispatch('refreshInstance');
-      }
+      },
+      '{window} modal:added': 'refreshIssueList',
+      '{window} modal:success': 'refreshIssueList'
     }
   });
 })(window.can, window.GGRC, window.CMS);

--- a/src/ggrc/assets/javascripts/components/add-issue-button/tests/add-issue-button_spec.js
+++ b/src/ggrc/assets/javascripts/components/add-issue-button/tests/add-issue-button_spec.js
@@ -21,18 +21,18 @@ describe('GGRC.Components.addIssueButton', function () {
     viewModel = GGRC.Components.getViewModel('addIssueButton');
   });
 
-  describe('on "{window} modal:success" event', function () {
+  describe('refreshIssueList() method', function () {
+    var relatedInstance;
     var handler;
     var that;
-    var relatedInstance;
 
     beforeEach(function () {
       that = {
         viewModel: viewModel
       };
       relatedInstance = viewModel.attr('relatedInstance');
-      handler = events['{window} modal:success'].bind(that);
       spyOn(relatedInstance, 'dispatch');
+      handler = events.refreshIssueList.bind(that);
     });
 
     describe('in case of Issue instance', function () {


### PR DESCRIPTION
Steps to reproduce:
 1. Have audit with created assessment 
2. Go to Assessment tab and expand Info pane
 3. Go to Related Issues tab and click Raise an Issue button 
4. Fill all the fields required in New Issues modal window and click Save and Add another button 
5. Once new Issue modal window appears click [x] and Discard 
6. Look at the Related Issues tab: new issue is not shown and Issues tab is not increased by one 

Actual Result: Issue in Related Issues tab is displayed after refreshing a page if click Save and Add another button 
Expected Result: Issue in Related Issues tab should be displayed after Save and Add another button
