### PR TITLE
GGRC-2426 Fix info popover for TaskGroup

### DIFF
--- a/src/ggrc/assets/javascripts/components/mapped-counter/mapped-counter.js
+++ b/src/ggrc/assets/javascripts/components/mapped-counter/mapped-counter.js
@@ -14,6 +14,10 @@
     CycleTaskEntry: {
       title: 'Comments',
       icon: 'comment-o'
+    },
+    CycleTaskGroupObjectTask: {
+      title: 'Total',
+      icon: 'calendar-check-o'
     }
   };
 

--- a/src/ggrc/assets/mustache/components/tree/tree-item-extra-info.mustache
+++ b/src/ggrc/assets/mustache/components/tree/tree-item-extra-info.mustache
@@ -72,7 +72,7 @@
           <section>
             <h3 class="task-list-title">Number of mapped tasks</h3>
             <mapped-counter {instance}="instance"
-                            type="CycleTaskGroupTask"
+                            type="CycleTaskGroupObjectTask"
                             {add-content}="@addContent"
             ></mapped-counter>
           </section>


### PR DESCRIPTION
**Steps to reproduce:**
1. Create one time WF
2. Add task to task group and activate WF
3. Once redirecting to Active Cycles tab expand tree with Task Group 
4. Hover over "i" icon and look at the screen

**Actual Result:** "There was an error" message is displayed with 500 error in console while hovering over task group first tier on Active Cycles tab. Info popup with mapped tasks to Task Group is not displayed.
**Expected Result:** no error is shown. If hover over "i" icon for task group tier, info popup with mapped tasks should be displayed