### PR TITLE
GGRC-1944 Unified mapper duplicated if click "Map to this object" in Assessment first tier twice 

### DIFF
--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -151,6 +151,7 @@ dashboard-js-files:
   - apps/business_objects.js
   - apps/custom_attributes.js
   # Components
+  - components/click-filter.js
   - components/state-colors-map/state-colors-map.js
   - components/spinner/spinner.js
   - components/modal-connector.js

--- a/src/ggrc/assets/javascripts/components/click-filter.js
+++ b/src/ggrc/assets/javascripts/components/click-filter.js
@@ -1,0 +1,33 @@
+/*!
+    Copyright (C) 2017 Google Inc.
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+(function ($, GGRC) {
+  'use strict';
+
+  GGRC.Components('clickFilter', {
+    tag: 'click-filter',
+    viewModel: {
+      delay: 300
+    },
+    events: {
+      click: function (el, ev) {
+        var $self = $(el);
+        var isDisabled = $self.prop('disabled');
+
+        if (isDisabled) {
+          ev.stopPropagation();
+          return;
+        }
+
+        // prevent open of two mappers
+        $self.prop('disabled', true);
+
+        setTimeout(function () {
+          $self.prop('disabled', false);
+        }, this.viewModel.attr('delay'));
+      }
+    }
+  });
+})(window.can.$, window.GGRC);

--- a/src/ggrc/assets/javascripts/components/tests/click-filter_spec.js
+++ b/src/ggrc/assets/javascripts/components/tests/click-filter_spec.js
@@ -1,0 +1,67 @@
+/*!
+ Copyright (C) 2017 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+describe('GGRC.Components.clickFilter', function () {
+  'use strict';
+
+  describe('click action', function () {
+    var method;
+    var element;
+    var event;
+    var viewModel;
+    var $element;
+    var delay = 300;
+
+    beforeEach(function () {
+      var component;
+      viewModel = new can.Map({
+        delay: delay
+      });
+      element = {};
+      $element = $(element);
+      event = {
+        stopPropagation: jasmine.createSpy('stopPropagation')
+      };
+      component = GGRC.Components.get('clickFilter');
+      method = component.prototype.events.click.bind({
+        viewModel: viewModel
+      });
+
+      jasmine.clock().install();
+    });
+
+    afterEach(function () {
+      jasmine.clock().uninstall();
+    });
+
+    it('must disable the element', function () {
+      var before = $element.prop('disabled');
+      var after;
+
+      method(element, event);
+      after = $element.prop('disabled');
+
+      expect(before).toBeFalsy();
+      expect(after).toBeTruthy();
+    });
+
+    it('must enable the element after defined delay time', function () {
+      var result;
+
+      method(element, event);
+      jasmine.clock().tick(delay + 1);
+      result = $element.prop('disabled');
+
+      expect(result).toBe(false);
+    });
+
+    it('must stop a propagation if element is disabled', function () {
+      method(element, event); // first click
+      method(element, event); // second click
+
+      expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/ggrc/assets/javascripts/components/tree/tree-item-map.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-item-map.js
@@ -38,32 +38,12 @@
       }
     },
     instance: null,
-    cssClasses: null,
-    disableLink: false
+    cssClasses: null
   });
 
   GGRC.Components('treeItemMap', {
     tag: 'tree-item-map',
     template: template,
-    viewModel: viewModel,
-    events: {
-      'a click': function (el, ev) {
-        var self = this;
-
-        if (!self.viewModel.attr('disableLink')) {
-          el.trigger('openMapper', ev);
-        }
-
-        self.viewModel.attr('disableLink', true);
-
-        // prevent open of two mappers
-        setTimeout(function () {
-          self.viewModel.attr('disableLink', false);
-        }, 300);
-
-        ev.preventDefault();
-        return false;
-      }
-    }
+    viewModel: viewModel
   });
 })(window.can, window.GGRC);

--- a/src/ggrc/assets/javascripts/controllers/mapper.js
+++ b/src/ggrc/assets/javascripts/controllers/mapper.js
@@ -12,6 +12,7 @@
               'Missing Scope Object';
   var OBJECT_REQUIRED_MESSAGE = 'Required Data for In Scope Object is missing' +
     ' - Original Object is mandatory';
+  var $body = $('body');
 
   can.Control.extend('GGRC.Controllers.MapperModal', {
     defaults: {
@@ -142,11 +143,5 @@
     }
   }
 
-  $('body').on('openMapper', function (el, ev, disableMapper) {
-    openMapper(ev, disableMapper);
-  });
-
-  $('body').on('click', selectors.join(', '), function (ev, disableMapper) {
-    openMapper(ev, disableMapper);
-  });
+  $body.on('click', selectors.join(', '), openMapper);
 })(window.can, window.can.$);

--- a/src/ggrc/assets/mustache/assessments/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessments/modal_content.mustache
@@ -118,6 +118,7 @@
           <div class="objective-selector">
             <div style="clear:both">
               <br>
+              <click-filter>
               {{#if instance.audit}}
                 <a class="section-add section-sticky btn btn-small btn-white"
                    href="javascript://" rel="tooltip"
@@ -151,6 +152,7 @@
                   Map Objects
                 </a>
               {{/if}}
+              </click-filter>
             </div>
           </div>
       </ggrc-modal-connector>

--- a/src/ggrc/assets/mustache/audits/tree_add_item.mustache
+++ b/src/ggrc/assets/mustache/audits/tree_add_item.mustache
@@ -24,19 +24,21 @@
     {{^if_instance_of parent_instance 'Assessment'}}
     {{#is_allowed_to_map parent_instance model.shortName}}
     {{#if allow_mapping_or_creating}}
-      <a
-        class="section-add btn btn-mini action-button map-button"
-        href="javascript://"
-        rel="tooltip"
-        data-placement="left"
-        data-toggle="unified-mapper"
-        data-join-option-type="{{model.shortName}}"
-        data-join-object-id="{{parent_instance.id}}"
-        data-join-object-type="{{parent_instance.class.shortName}}"
-        data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}"
-      >
-        Map
-      </a>
+      <click-filter>
+        <a
+          class="section-add btn btn-mini action-button map-button"
+          href="javascript://"
+          rel="tooltip"
+          data-placement="left"
+          data-toggle="unified-mapper"
+          data-join-option-type="{{model.shortName}}"
+          data-join-object-id="{{parent_instance.id}}"
+          data-join-object-type="{{parent_instance.class.shortName}}"
+          data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}"
+        >
+          Map
+        </a>
+      </click-filter>
     {{/if}}
     {{/is_allowed_to_map}}
     {{/if_instance_of}}

--- a/src/ggrc/assets/mustache/base_objects/tree_add_item.mustache
+++ b/src/ggrc/assets/mustache/base_objects/tree_add_item.mustache
@@ -8,18 +8,20 @@
   {{#if model.root_object}}
     {{^if_equals model.shortName 'Assessment'}}
     {{^if_equals model.shortName 'Issue'}}
-      <a
-        class="btn btn-mini action-button map-button"
-        href="javascript://"
-        rel="tooltip"
-        data-placement="left"
-        data-toggle="unified-mapper"
-        data-join-option-type="{{model.shortName}}"
-        data-join-object-id="{{parent_instance.id}}"
-        data-join-object-type="{{parent_instance.class.shortName}}"
-        data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}">
-        Map
-      </a>
+      <click-filter>
+        <a
+          class="btn btn-mini action-button map-button"
+          href="javascript://"
+          rel="tooltip"
+          data-placement="left"
+          data-toggle="unified-mapper"
+          data-join-option-type="{{model.shortName}}"
+          data-join-object-id="{{parent_instance.id}}"
+          data-join-object-type="{{parent_instance.class.shortName}}"
+          data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}">
+          Map
+        </a>
+      </click-filter>
     {{/if_equals}}
     {{/if_equals}}
   {{#if null}}
@@ -40,32 +42,36 @@
   {{/if}}
   {{else}}
   {{#if_instance_of parent_instance "Section"}}
-  <a
-    class="btn btn-mini action-button map-button"
-    href="javascript://"
-    rel="tooltip"
-    data-placement="left"
-    data-toggle="unified-mapper"
-    data-join-object-id="{{instance.id}}"
-    data-join-object-type="{{parent_instance.class.shortName}}"
-    data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}"
-    data-object-params='{ "section": { "id": {{parent_instance.id}}, "title": "{{json_escape parent_instance.title}}", "description": "{{json_escape parent_instance.description}}" } }'
->
-    Map
-  </a>
+    <click-filter>
+      <a
+        class="btn btn-mini action-button map-button"
+        href="javascript://"
+        rel="tooltip"
+        data-placement="left"
+        data-toggle="unified-mapper"
+        data-join-object-id="{{instance.id}}"
+        data-join-object-type="{{parent_instance.class.shortName}}"
+        data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}"
+        data-object-params='{ "section": { "id": {{parent_instance.id}}, "title": "{{json_escape parent_instance.title}}", "description": "{{json_escape parent_instance.description}}" } }'
+    >
+        Map
+      </a>
+    </click-filter>
   {{else}}
-  <a
-    class="btn btn-mini action-button map-button"
-    href="javascript://"
-    rel="tooltip"
-    data-placement="left"
-    data-toggle="unified-mapper"
-    data-join-object-id="{{instance.id}}"
-    data-join-object-type="{{parent_instance.class.shortName}}"
-    data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}"
->
-    Map
-  </a>
+    <click-filter>
+      <a
+        class="btn btn-mini action-button map-button"
+        href="javascript://"
+        rel="tooltip"
+        data-placement="left"
+        data-toggle="unified-mapper"
+        data-join-object-id="{{instance.id}}"
+        data-join-object-type="{{parent_instance.class.shortName}}"
+        data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}"
+    >
+        Map
+      </a>
+    </click-filter>
   {{/if_instance_of}}
   {{/if}}
 {{/if}}

--- a/src/ggrc/assets/mustache/base_templates/mapped_objects.mustache
+++ b/src/ggrc/assets/mustache/base_templates/mapped_objects.mustache
@@ -15,37 +15,41 @@
 {{#if_equals instance.type 'CycleTaskGroupObjectTask'}}
   {{^if_in instance.status "Finished,Verified"}}
     {{#is_allowed 'update' instance context='for'}}
-      <a
-        class="btn btn-white btn-small"
-        href="javascript://"
-        rel="tooltip"
-        data-type="Program"
-        data-placement="right"
-        data-toggle="unified-mapper"
-        data-join-mapping="related_objects"
-        data-join-option-type="{{model.shortName}}"
-        data-join-object-id="{{instance.id}}"
-        data-join-object-type="{{instance.class.shortName}}"
-        data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty instance.class.title_singular 'Object'}}">
-        Map Objects
-      </a>
+      <click-filter>
+        <a
+          class="btn btn-white btn-small"
+          href="javascript://"
+          rel="tooltip"
+          data-type="Program"
+          data-placement="right"
+          data-toggle="unified-mapper"
+          data-join-mapping="related_objects"
+          data-join-option-type="{{model.shortName}}"
+          data-join-object-id="{{instance.id}}"
+          data-join-object-type="{{instance.class.shortName}}"
+          data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty instance.class.title_singular 'Object'}}">
+          Map Objects
+        </a>
+      </click-filter>
     {{/is_allowed}}
   {{/if_in}}
 {{else}}
   {{#is_allowed 'update' instance context='for'}}
-  <a
-    class="btn btn-white btn-small"
-    href="javascript://"
-    rel="tooltip"
-    data-type="Program"
-    data-placement="right"
-    data-toggle="unified-mapper"
-    data-join-mapping="related_objects"
-    data-join-option-type="{{model.shortName}}"
-    data-join-object-id="{{instance.id}}"
-    data-join-object-type="{{instance.class.shortName}}"
-    data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty instance.class.title_singular 'Object'}}">
-    Map Objects
-  </a>
+  <click-filter>
+    <a
+      class="btn btn-white btn-small"
+      href="javascript://"
+      rel="tooltip"
+      data-type="Program"
+      data-placement="right"
+      data-toggle="unified-mapper"
+      data-join-mapping="related_objects"
+      data-join-option-type="{{model.shortName}}"
+      data-join-object-id="{{instance.id}}"
+      data-join-object-type="{{instance.class.shortName}}"
+      data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty instance.class.title_singular 'Object'}}">
+      Map Objects
+    </a>
+  </click-filter>
   {{/is_allowed}}
 {{/if_equals}}

--- a/src/ggrc/assets/mustache/components/assessment/mapped-objects/mapped-controls.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/mapped-objects/mapped-controls.mustache
@@ -5,6 +5,7 @@
 <div class="section-title">
   {{titleText}}
   {{#is_allowed 'update' instance context='for'}}
+    <click-filter>
       <i class="fa fa-plus-circle"
          rel="tooltip"
          data-type="{{mappingType}}"
@@ -17,6 +18,7 @@
          data-original-title="Map {{firstnonempty mappingType 'Object'}} to this {{firstnonempty instance.class.title_singular 'Object'}}"
  >
       </i>
+    </click-filter>
   {{/is_allowed}}
 </div>
 <object-list {(selected-item)}="selectedItem" {items}="mappedItems">

--- a/src/ggrc/assets/mustache/components/assessment/mapped-objects/mapped-related-information.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/mapped-objects/mapped-related-information.mustache
@@ -5,6 +5,7 @@
 <div class="section-title">
   {{titleText}}
   {{#is_allowed 'update' instance context='for'}}
+    <click-filter>
       <i class="fa fa-plus-circle"
          rel="tooltip"
          data-type="{{mappingType}}"
@@ -17,6 +18,7 @@
          data-original-title="Map {{firstnonempty mappingType 'Object'}} to this {{firstnonempty instance.class.title_singular 'Object'}}"
  >
       </i>
+    </click-filter>
   {{/is_allowed}}
 </div>
 <object-list {(selected-item)}="selectedItem" {items}="mappedItems">

--- a/src/ggrc/assets/mustache/components/tree/tree-item-actions.mustache
+++ b/src/ggrc/assets/mustache/components/tree/tree-item-actions.mustache
@@ -32,7 +32,9 @@
 
     {{#if isAllowedToEdit}}
       <li>
-        <tree-item-map {instance}="instance"></tree-item-map>
+        <click-filter>
+          <tree-item-map {instance}="instance"></tree-item-map>
+        </click-filter>
       </li>
       {{#is_allowed 'update' instance context='for'}}
         <li>

--- a/src/ggrc/assets/mustache/components/tree/tree-item-map.mustache
+++ b/src/ggrc/assets/mustache/components/tree/tree-item-map.mustache
@@ -6,17 +6,14 @@
 {{#is_allowed_to_map instance model.shortName}}
   {{#if allow_mapping_or_creating}}
     <a class="{{cssClasses}}"
-       href="javascript://"
-       {{#if disableLink}}
-         class="disabled"
-       {{/if}}
-       rel="tooltip"
-       data-placement="left"
-       data-toggle="unified-mapper"
-       data-join-object-id="{{instance.id}}"
-       data-join-object-type="{{instance.class.shortName}}"
+      href="javascript://"
+      rel="tooltip"
+      data-placement="left"
+      data-toggle="unified-mapper"
+      data-join-object-id="{{instance.id}}"
+      data-join-object-type="{{instance.class.shortName}}"
       {{#if_instance_of instance "Section"}}
-       data-object-params='{{objectParams}}'
+      data-object-params='{{objectParams}}'
       {{/if_instance_of}}
     >
       <i class="fa fa-code-fork"></i>

--- a/src/ggrc/assets/mustache/controls/object_list.mustache
+++ b/src/ggrc/assets/mustache/controls/object_list.mustache
@@ -87,18 +87,20 @@
       <div class="span12 section-expandable">
 
         {{#if_instance_of parent_instance "Program"}}
-          <a
-            href="javascript://"
-            rel="tooltip"
-            data-placement="left"
-            data-toggle="unified-mapper"
-            data-modal-selector-options="program_controls"
-            data-modal-class="modal-wide"
-            data-original-title="Map {{model.title_singular}} to this {{parent_instance.class.shortName}}"
-            data-join-object-id="{{parent_instance.id}}"
-            data-join-object-type="{{parent_instance.class.shortName}}">
-            + {{model.title_singular}}
-          </a>
+          <click-filter>
+            <a
+              href="javascript://"
+              rel="tooltip"
+              data-placement="left"
+              data-toggle="unified-mapper"
+              data-modal-selector-options="program_controls"
+              data-modal-class="modal-wide"
+              data-original-title="Map {{model.title_singular}} to this {{parent_instance.class.shortName}}"
+              data-join-object-id="{{parent_instance.id}}"
+              data-join-object-type="{{parent_instance.class.shortName}}">
+              + {{model.title_singular}}
+            </a>
+          </click-filter>
         {{else}}
           {{#if_instance_of parent_instance 'Directive'}}
             <a href="javascript://" class="section-add">

--- a/src/ggrc/assets/mustache/documents/list.mustache
+++ b/src/ggrc/assets/mustache/documents/list.mustache
@@ -28,8 +28,10 @@
   </li>
   {{/list}}
   <li class="tree-item tree-item-add">
-    <a href="javascript://" data-modal-selector-options="relationsips" data-toggle="unified-mapper" data-modal-class="modal-wide" data-original-title="Map Reference Links" data-placement="left" rel="tooltip" title="Map Reference Links to this {{parent_instance.class.shortName}}">
-      + Reference Link
-    </a>
+    <click-filter>
+      <a href="javascript://" data-modal-selector-options="relationsips" data-toggle="unified-mapper" data-modal-class="modal-wide" data-original-title="Map Reference Links" data-placement="left" rel="tooltip" title="Map Reference Links to this {{parent_instance.class.shortName}}">
+        + Reference Link
+      </a>
+    </click-filter>
   </li>
 </ul>

--- a/src/ggrc/assets/mustache/documents/tree_add_item.mustache
+++ b/src/ggrc/assets/mustache/documents/tree_add_item.mustache
@@ -5,18 +5,20 @@
 
 {{#if allow_mapping_or_creating}}
 {{#is_allowed_to_map parent_instance model.shortName}}
-  <a
-    class="btn btn-mini action-button map-button"
-    href="javascript://"
-    rel="tooltip"
-    data-placement="left"
-    data-toggle="unified-mapper"
-    data-join-option-type="{{model.shortName}}"
-    data-join-object-id="{{parent_instance.id}}"
-    data-join-object-type="{{parent_instance.class.shortName}}"
-    data-original-title="{{#if_equals model.title_singular 'Reference'}}Link non-GGRC URLs as References{{else}}Map {{firstnonempty title_singular model.title_singular 'Object'}}{{/if_equals}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}"
->
-      Map
-  </a>
+  <click-filter>
+    <a
+      class="btn btn-mini action-button map-button"
+      href="javascript://"
+      rel="tooltip"
+      data-placement="left"
+      data-toggle="unified-mapper"
+      data-join-option-type="{{model.shortName}}"
+      data-join-object-id="{{parent_instance.id}}"
+      data-join-object-type="{{parent_instance.class.shortName}}"
+      data-original-title="{{#if_equals model.title_singular 'Reference'}}Link non-GGRC URLs as References{{else}}Map {{firstnonempty title_singular model.title_singular 'Object'}}{{/if_equals}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}"
+  >
+        Map
+    </a>
+  </click-filter>
 {{/is_allowed_to_map}}
 {{/if}}

--- a/src/ggrc/assets/mustache/people/tree_add_item.mustache
+++ b/src/ggrc/assets/mustache/people/tree_add_item.mustache
@@ -6,17 +6,19 @@
 
 {{#if allow_mapping_or_creating}}
 {{#is_allowed_to_map parent_instance model.shortName}}
-  <a
-    class="btn btn-mini action-button map-button"
-    href="javascript://"
-    rel="tooltip"
-    data-placement="left"
-    data-toggle="unified-mapper"
-    data-join-option-type="{{model.shortName}}"
-    data-join-object-id="{{parent_instance.id}}"
-    data-join-object-type="{{parent_instance.class.shortName}}"
-    data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}">
-    Map
-  </a>
+  <click-filter>
+    <a
+      class="btn btn-mini action-button map-button"
+      href="javascript://"
+      rel="tooltip"
+      data-placement="left"
+      data-toggle="unified-mapper"
+      data-join-option-type="{{model.shortName}}"
+      data-join-object-id="{{parent_instance.id}}"
+      data-join-object-type="{{parent_instance.class.shortName}}"
+      data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}">
+      Map
+    </a>
+  </click-filter>
 {{/is_allowed_to_map}}
 {{/if}}

--- a/src/ggrc/assets/mustache/snapshots/tree_add_item.mustache
+++ b/src/ggrc/assets/mustache/snapshots/tree_add_item.mustache
@@ -5,17 +5,19 @@
 
 {{#is_allowed_to_map parent_instance model.shortName}}
 {{#if allow_mapping_or_creating}}
-  <a
-    class="section-add btn btn-mini action-button map-button"
-    href="javascript://"
-    rel="tooltip"
-    data-placement="left"
-    data-toggle="unified-mapper"
-    data-join-option-type="{{model.shortName}}"
-    data-join-object-id="{{parent_instance.id}}"
-    data-join-object-type="{{parent_instance.class.shortName}}"
-    data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}">
-      Map
-  </a>
+  <click-filter>
+    <a
+      class="section-add btn btn-mini action-button map-button"
+      href="javascript://"
+      rel="tooltip"
+      data-placement="left"
+      data-toggle="unified-mapper"
+      data-join-option-type="{{model.shortName}}"
+      data-join-object-id="{{parent_instance.id}}"
+      data-join-object-type="{{parent_instance.class.shortName}}"
+      data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}">
+        Map
+    </a>
+  </click-filter>
 {{/if}}
 {{/is_allowed_to_map}}

--- a/src/ggrc_workflows/assets/mustache/base_objects/task_group_subtree_footer.mustache
+++ b/src/ggrc_workflows/assets/mustache/base_objects/task_group_subtree_footer.mustache
@@ -8,21 +8,23 @@
 {{#if_task_group_assignee_privileges instance}}
 {{^if_equals parent_instance.status 'Inactive'}}
 <div class="tree-item-add">
-  <a
-    class="btn btn-small btn-white"
-    rel="tooltip"
-    data-placement="right"
-    data-original-title="Add Object"
-    href="javascript://"
-    data-toggle="unified-mapper"
-    data-modal-class="modal-wide"
-    data-modal-reset="reset"
-    data-join-mapping="objects"
-    data-join-object-id="{{instance.id}}"
-    data-join-object-type="TaskGroup"
-    data-exclude-option-types="">
-    <i class="fa fa-plus-circle"></i>
-  </a>
+  <click-filter>
+    <a
+      class="btn btn-small btn-white"
+      rel="tooltip"
+      data-placement="right"
+      data-original-title="Add Object"
+      href="javascript://"
+      data-toggle="unified-mapper"
+      data-modal-class="modal-wide"
+      data-modal-reset="reset"
+      data-join-mapping="objects"
+      data-join-object-id="{{instance.id}}"
+      data-join-object-type="TaskGroup"
+      data-exclude-option-types="">
+      <i class="fa fa-plus-circle"></i>
+    </a>
+  </click-filter>
 </div>
 {{/if_equals}}
 {{/if}}

--- a/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/modal_content.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/modal_content.mustache
@@ -100,19 +100,21 @@
           <div style="clear:both">
             <br>
             {{^if_in instance.status "Finished,Verified"}}
-            <a class="section-add section-sticky btn btn-small btn-white"
-              href="javascript://" rel="tooltip"
-              {{data "deferred_to"}}
-              data-placement="left"
-              data-toggle="unified-mapper"
-              data-deferred="true"
-              data-object-source="true"
-              data-join-mapping="info_related_objects"
-              data-join-object-id="{{instance.id}}"
-              data-join-object-type="{{instance.class.model_singular}}"
-              data-original-title="Map Object to this {{instance.class.title_singular}}" tabindex="6">
-              Map Objects
-            </a>
+              <click-filter>
+                <a class="section-add section-sticky btn btn-small btn-white"
+                  href="javascript://" rel="tooltip"
+                  {{data "deferred_to"}}
+                  data-placement="left"
+                  data-toggle="unified-mapper"
+                  data-deferred="true"
+                  data-object-source="true"
+                  data-join-mapping="info_related_objects"
+                  data-join-object-id="{{instance.id}}"
+                  data-join-object-type="{{instance.class.model_singular}}"
+                  data-original-title="Map Object to this {{instance.class.title_singular}}" tabindex="6">
+                  Map Objects
+                </a>
+              </click-filter>
             {{/if_in}}
           </div>
         </div>

--- a/src/ggrc_workflows/assets/mustache/wf_objects/autocomplete_result.mustache
+++ b/src/ggrc_workflows/assets/mustache/wf_objects/autocomplete_result.mustache
@@ -25,25 +25,27 @@
  <!-- Add Map Object Here -->
  {{#with_page_object_as 'page_instance'}}
  <li class="ui-menu-item add-new" data-ui-autocomplete-item="">
-   <a
-     data-object-plural="{{model.table_plural}}"
-     data-modal-class="modal-wide"
-     href="javascript://"
-     data-object-singular="{{model.model_singular}}"
+  <click-filter>
+    <a
+      data-object-plural="{{model.table_plural}}"
+      data-modal-class="modal-wide"
+      href="javascript://"
+      data-object-singular="{{model.model_singular}}"
 
-     data-toggle="unified-mapper"
-     data-modal-reset="reset"
-     data-mapping="false"
-     rel="tooltip"
-     data-placement="left"
-     data-join-mapping="objects"
-     data-join-object-id="{{page_instance.id}}"
-     data-join-object-type="Workflow"
-     data-map-task-group="true"
+      data-toggle="unified-mapper"
+      data-modal-reset="reset"
+      data-mapping="false"
+      rel="tooltip"
+      data-placement="left"
+      data-join-mapping="objects"
+      data-join-object-id="{{page_instance.id}}"
+      data-join-object-type="Workflow"
+      data-map-task-group="true"
 
-     data-exclude-option-types=""
-     data-original-title="Map Object to this Workflow and TaskGroup">
-     + Map Objects
-   </a>
+      data-exclude-option-types=""
+      data-original-title="Map Object to this Workflow and TaskGroup">
+      + Map Objects
+    </a>
+  </click-filter>
  </li>
  {{/with_page_object_as}}

--- a/src/ggrc_workflows/assets/mustache/wf_objects/tree_footer.mustache
+++ b/src/ggrc_workflows/assets/mustache/wf_objects/tree_footer.mustache
@@ -8,20 +8,22 @@
 <li class="tree-footer tree-item tree-item-add">
   <div class="row-fluid">
     <div class="span12 section-expandable">
-      <a
-        class="section-add section-sticky"
-        href="javascript://"
-        rel="tooltip"
-        data-placement="left"
-        data-toggle="unified-mapper"
-        data-join-mapping="{{mapping}}"
-        data-join-object-id="{{parent_instance.id}}"
-        data-join-object-type="{{parent_instance.class.shortName}}"
-        data-exclude-option-types="{{exclude_option_types}}"
-        data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}"
-        >
-        Add Objects
-      </a>
+      <click-filter>
+        <a
+          class="section-add section-sticky"
+          href="javascript://"
+          rel="tooltip"
+          data-placement="left"
+          data-toggle="unified-mapper"
+          data-join-mapping="{{mapping}}"
+          data-join-object-id="{{parent_instance.id}}"
+          data-join-object-type="{{parent_instance.class.shortName}}"
+          data-exclude-option-types="{{exclude_option_types}}"
+          data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}"
+          >
+          Add Objects
+        </a>
+      </click-filter>
     </div>
   </div>
 </li>

--- a/src/ggrc_workflows/assets/mustache/wf_people/tree_add_item.mustache
+++ b/src/ggrc_workflows/assets/mustache/wf_people/tree_add_item.mustache
@@ -5,18 +5,20 @@
 {{^if_equals parent_instance.kind "Backlog"}}
 {{#if allow_mapping_or_creating}}
 {{#is_allowed_to_map parent_instance model.shortName}}
-  <a
-    href="javascript://"
-    class="section-add btn btn-mini action-button map-button"
-    rel="tooltip"
-    data-placement="left"
-    data-toggle="unified-mapper"
-    data-join-option-type="{{model.shortName}}"
-    data-join-object-id="{{parent_instance.id}}"
-    data-join-object-type="{{parent_instance.class.shortName}}"
-    data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}">
-    Map
-  </a>
+  <click-filter>
+    <a
+      href="javascript://"
+      class="section-add btn btn-mini action-button map-button"
+      rel="tooltip"
+      data-placement="left"
+      data-toggle="unified-mapper"
+      data-join-option-type="{{model.shortName}}"
+      data-join-object-id="{{parent_instance.id}}"
+      data-join-object-type="{{parent_instance.class.shortName}}"
+      data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}">
+      Map
+    </a>
+  </click-filter>
 {{/is_allowed_to_map}}
 {{/if}}
 {{/if_equals}}


### PR DESCRIPTION
**Steps to reproduce:**
1. On the audit page create assessment 
2. Hover over Assessment first tier and click "Map to this object" twice
3. Look at the Unified mapper 

**Actual Result:** Unified mapper duplicated if click "Map to this object" in Assessment first tier twice 
**Expected Result:** Unified mapper should not duplicated if click "Map to this object" in Assessment first tier twice