### PR TITLE
GGRC-2421 Add date and time when Assessments state was changed

### DIFF
--- a/src/ggrc/notifications/data_handlers.py
+++ b/src/ggrc/notifications/data_handlers.py
@@ -55,6 +55,15 @@ def _get_assignable_dict(people, notif):
     dict: dictionary containing notification data for all people in the given
       list.
   """
+  datetime_format = DATE_FORMAT_US + " %H:%M:%S %Z"
+
+  # NOTE: For the time being, the majority of users are located in US/Pacific
+  # time zone, thus the latter is used to convert UTC times read from database.
+  pacific_tz = timezone("US/Pacific")
+  notif_created_at = notif.created_at.replace(
+      tzinfo=pytz.utc
+  ).astimezone(pacific_tz)
+
   obj = get_notification_object(notif)
   data = {}
   for person in people:
@@ -68,6 +77,7 @@ def _get_assignable_dict(people, notif):
                 "start_date_statement": utils.get_digest_date_statement(
                     start_date, "start", True),
                 "url": get_object_url(obj),
+                "notif_created_at": notif_created_at.strftime(datetime_format)
             }
         }
     }

--- a/src/ggrc/templates/notifications/email_digest_content.html
+++ b/src/ggrc/templates/notifications/email_digest_content.html
@@ -216,6 +216,7 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                       Assessment:
                       <a href="{{ assessment_data['url'] }}" {{ style.link_text() }} >
                         {{ assessment_data['title'] }}</a>
+                        ({{ assessment_data['notif_created_at'] }})
                     </li>
                   {% endfor %}
                   </ul>
@@ -229,6 +230,7 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                       Assessment:
                       <a href="{{ assessment_data['url'] }}" {{ style.link_text() }} >
                         {{ assessment_data['title'] }}</a>
+                        ({{ assessment_data['notif_created_at'] }})
                     </li>
                   {% endfor %}
                   </ul>
@@ -242,6 +244,7 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                       Assessment:
                       <a href="{{ assessment_data['url'] }}" {{ style.link_text() }} >
                         {{ assessment_data['title'] }}</a>
+                        ({{ assessment_data['notif_created_at'] }})
                     </li>
                   {% endfor %}
                   </ul>
@@ -255,6 +258,7 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                       Assessment:
                       <a href="{{ assessment_data['url'] }}" {{ style.link_text() }} >
                         {{ assessment_data['title'] }}</a>
+                        ({{ assessment_data['notif_created_at'] }})
                     </li>
                   {% endfor %}
                   </ul>
@@ -269,6 +273,7 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                       <a href="{{ assessment_data['url'] }}" {{ style.link_text() }} >
                         {{ assessment_data['title'] }}
                       </a>
+                      ({{ assessment_data['notif_created_at'] }})
                     </li>
                   {% endfor %}
                   </ul>
@@ -282,6 +287,7 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                       Assessment:
                       <a href="{{ assessment_data['url'] }}" {{ style.link_text() }} >
                         {{ assessment_data['title'] }}</a>
+                        ({{ assessment_data['notif_created_at'] }})
                     </li>
                   {% endfor %}
                   </ul>

--- a/test/unit/ggrc/notification/test_data_handlers.py
+++ b/test/unit/ggrc/notification/test_data_handlers.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Tests for the ggrc.notifications.notification_handlers module."""
+
+import unittest
+from datetime import datetime
+
+from ggrc.notifications.data_handlers import as_user_time
+
+
+class TestAsUserTime(unittest.TestCase):
+  """Tests for the as_user_time() helper function."""
+  # pylint: disable=invalid-name
+
+  def test_converting_dst_timestamp(self):
+    """Test converting timestamps in daylight saving time part of the year."""
+    timestamp = datetime(2017, 6, 13, 15, 40, 37)
+    result = as_user_time(timestamp)
+    self.assertEqual(result, "06/13/2017 08:40:37 PDT")
+
+  def test_converting_non_dst_timestamp(self):
+    """Test converting timestamps in non-daylight saving time part of the year.
+    """
+    timestamp = datetime(2017, 2, 13, 15, 40, 37)
+    result = as_user_time(timestamp)
+    self.assertEqual(result, "02/13/2017 07:40:37 PST")


### PR DESCRIPTION
This PR adds information to daily digest notifications on what time a change has occurred.

Even though the task only mentions adding timestamps to Assessment status change notifications, I added it to the Assessment updated notification, too, since adding a timestamp is a recent trend with email notifications (it was e.g. added to "comment created" notifications a few days ago).

Since we generally do not test notification email content with our integration tests, I did not add any here, as a Selenium end-to-end test might be a better choice here (QA add will add it at some point). If I am mistaken, please let me know.

---

To test the change, open an Assessment and modify it, then visit the `/_notifications/show_daily_digest` test page. The notification about the change should have a time information in it, formatted in users' local time (hard-coded to `US/Pacific` timezone for the time being, until we properly address per-user time localization).

Similar time info should be visible for Assessment status changes.

NOTE: Additional time info was not added to "Assessment created" notification, as the latter already includes another time info, i.e. Assessment start date (seems to not be functional ATM, though).