### PR TITLE
GGRC-2422 Sort comment notifications - most recent first

### DIFF
--- a/src/ggrc/notifications/data_handlers.py
+++ b/src/ggrc/notifications/data_handlers.py
@@ -301,7 +301,8 @@ def generate_comment_notification(obj, comment, person):
                   "parent_id": parent_info.id,
                   "parent_url": get_object_url(obj),
                   "parent_title": obj.title,
-                  "created_at": as_user_time(comment.created_at)
+                  "created_at": comment.created_at,
+                  "created_at_str": as_user_time(comment.created_at)
               }
           }
       }

--- a/src/ggrc/templates/notifications/email_digest_content.html
+++ b/src/ggrc/templates/notifications/email_digest_content.html
@@ -348,11 +348,11 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                       Comments on {{ parent_info.object_type }}
                       <a href="{{ parent_info.url }}">{{ parent_info.title }}</a>:
 
-                      {% for comment in comments.itervalues() %}
+                      {% for comment in comments %}
                         <ul {{ style.list_wrap() }}>
                           <li {{ style.list_item_sublist() }} >
                             {{ macro.user_name(comment['commentator']) }}
-                            left a comment at {{ comment['created_at'] }}:
+                            left a comment at {{ comment['created_at_str'] }}:
                             <div {{ style.comment_content() }}>
                               {{ comment['description'] }}
                             </div>

--- a/test/integration/ggrc/notifications/test_comment_notifications.py
+++ b/test/integration/ggrc/notifications/test_comment_notifications.py
@@ -141,7 +141,7 @@ class TestCommentNotification(TestCase):
     # for that particular Assessment
     for parent_obj_key, comments_info in comment_notifs.iteritems():
       self.assertIn(parent_obj_key.id, asmt_ids)
-      for comment in comments_info.itervalues():
+      for comment in comments_info:
         self.assertEqual(comment["parent_id"], parent_obj_key.id)
         self.assertEqual(comment["parent_type"], "Assessment")
         expected_suffix = "asmt " + str(parent_obj_key.id)

--- a/test/unit/ggrc/notification/test_common.py
+++ b/test/unit/ggrc/notification/test_common.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Tests for the ggrc.notifications.common module."""
+
+import unittest
+from datetime import datetime
+
+from ggrc.notifications.common import sort_comments
+
+
+class TestSortComments(unittest.TestCase):
+  """Tests for the as_user_time() helper function."""
+  # pylint: disable=invalid-name
+
+  def test_sorts_comments_inline_newest_first(self):
+    """Test that comments data is sorted by creation date (descending)."""
+    asmt5_info = (5, "Assessment", "Asmt 5", "www.5.com")
+
+    data = {
+        "email@foo.com": {
+            "comment_created": {
+                asmt5_info: {
+                    12: {
+                        "description": "ABCD...",
+                        "created_at": datetime(2017, 5, 31, 8, 15, 0)
+                    },
+                    19: {
+                        "description": "All tasks can be closed",
+                        "created_at": datetime(2017, 10, 16, 0, 30, 0)
+                    },
+                    10: {
+                        "description": "Comment One",
+                        "created_at": datetime(2017, 5, 29, 16, 20, 0)
+                    },
+                    15: {
+                        "description": "I am confused",
+                        "created_at": datetime(2017, 8, 15, 11, 13, 0)
+                    }
+                }
+            }
+        }
+    }
+
+    sort_comments(data)
+
+    comment_data = data["email@foo.com"]["comment_created"].values()[0]
+    self.assertIsInstance(comment_data, list)
+
+    descriptions = [c["description"] for c in comment_data]
+    expected_descriptions = [
+        "All tasks can be closed", "I am confused", "ABCD...", "Comment One"
+    ]
+    self.assertEqual(descriptions, expected_descriptions)


### PR DESCRIPTION
NOTE: Based on #5789, please wait until the latter has been merged.
(I built this fix on top of it to preemptively resolve a merge conflict that would otherwise invariably occur if both PRs were submitted separately.

---

This PR order the comments in email notifications in the same way as they are displayed in the UI, i.e. newest on top.

To test, open an Assessment in progress with a few people assigned to it, and add a few comments under that Assessment on its info pane (make sure that "Send Notifications" checkbox is checked). Then open the `/_notifications/show_daily_digest` test page, and verify that comments in the notification emails are indeed listed in the required order.