### PR TITLE
GGRC-1947 Mappings should be displayed in tree view without page refresh after Mapping via Unified mapper 

### DIFF
--- a/src/ggrc/assets/javascripts/components/unified-mapper/mapper.js
+++ b/src/ggrc/assets/javascripts/components/unified-mapper/mapper.js
@@ -419,6 +419,22 @@
               }
               // This Method should be modified to event
               GGRC.Utils.CurrentPage.refreshCounts();
+
+              _.each($('sub-tree-wrapper'), function (wrapper) {
+                var vm = $(wrapper).viewModel();
+
+                if (vm.attr('parent') === instance) {
+                  if (vm.attr('isOpen') && vm.attr('dataIsReady')) {
+                    vm.loadItems();
+                  } else {
+                    // remove old data
+                    // new data will be loaded after sub-tree is expanded
+                    vm.attr('dataIsReady', null);
+                  }
+
+                  return false;
+                }
+              });
             });
         }.bind(this));
       },


### PR DESCRIPTION
**Precondition:** have program, control, audit, created assessment 
**Steps to reproduce:**
1. Go to Assessment tab
2. Expand sub tree for assessment 
3. Hover over first tier and select Map to this object 
4. Map control snapshot to assessment
5. Look at the tree view: mapped control is not shown
6. Collapse subtree and expand subtree once again: mapped control is not shown 

**Actual Result:** Mapped control is not shown in subtree after mapping. Refresh is needed to see mapped control. 
**Expected Result:** Mappings should be displayed in tree view without page refresh after Mapping via Unified mapper
