### PR TITLE
QUICK-FIX Test mapping rules for snapshots in audit

### DIFF
--- a/test/selenium/src/lib/base.py
+++ b/test/selenium/src/lib/base.py
@@ -795,16 +795,15 @@ class DropdownMenu(Component):
 
   def is_item_exists(self, out_item_type):
     """Check if element enable on dropdown and return Bool, by comparing
-    aliases.
-    Return bool if element exist
+    icon type.
+    Return bool
     """
     return any(elem_val.item_type for elem_val in self.dropdown_items()
                if out_item_type in elem_val.item_type)
 
   def is_item_enabled(self, out_item_type):
-    """Check if element enable on dropdown, by comparing
-    aliases.
-    Return bool if element exist
+    """Check if element enable on dropdown.
+    Return bool if element found
     If element not found raise exception
     """
     return self.get_dropdown_item(out_item_type).enabled

--- a/test/selenium/src/lib/constants/element.py
+++ b/test/selenium/src/lib/constants/element.py
@@ -385,3 +385,15 @@ class MappingStatusAttrs(namedtuple('_MappingStatusAttrs',
                                     ['title', 'is_checked', 'is_disabled'])):
   """Class for representation of html attributes for mapping checkboxes
    on unified mapper"""
+
+
+class DropdownMenuItemTypes(object):
+  """Class for types of DropdownMenu Item according to "icon" css class"""
+  EDIT = "pencil-square-o"
+  OPEN = "long-arrow-right"
+  GET_PERMALINK = "link"
+  DELETE = "trash"
+  MAP = "code-fork"
+  UNMAP = "ban"
+  CLONE = "clone"
+  UPDATE = "refresh"

--- a/test/selenium/src/lib/constants/locator.py
+++ b/test/selenium/src/lib/constants/locator.py
@@ -870,7 +870,7 @@ class TreeView(object):
   ITEMS = _WIDGET_NOT_HIDDEN_CSS + " .tree-item-element"
   HEADER = Common.TREE_HEADER
   ITEM_LOADING = (By.CSS_SELECTOR, " .tree-item-placeholder")
-  ITEM_EXPAND_BUTTON = " tree-item-actions"
+  ITEM_EXPAND_BUTTON = "tree-item-actions"
   SPINNER = (By.CSS_SELECTOR, " .tree-spinner")
   NO_RESULTS_MESSAGE = (
       By.CSS_SELECTOR, _WIDGET_NOT_HIDDEN_CSS + " .tree-no-results-message")
@@ -879,8 +879,8 @@ class TreeView(object):
   BUTTON_3BBS = "{} " + Common.TREE_LIST + " .details-wrap"
   BUTTON_CREATE = "{} " + Common.TREE_LIST + " .create-button"
   BUTTON_MAP = "{} " + Common.TREE_LIST + " .map-button"
-  ITEM_DROPDOWN_BUTTON = (By.CSS_SELECTOR, _WIDGET_NOT_HIDDEN_CSS +
-                          ITEM_EXPAND_BUTTON)
+  ITEM_DROPDOWN_BUTTON = (By.CSS_SELECTOR, " ".join(
+      (_WIDGET_NOT_HIDDEN_CSS, ITEM_EXPAND_BUTTON)))
 
 
 class AdminTreeView(object):

--- a/test/selenium/src/lib/constants/locator.py
+++ b/test/selenium/src/lib/constants/locator.py
@@ -5,6 +5,7 @@
 # pylint: disable=too-many-lines
 
 from selenium.webdriver.common.by import By
+
 from lib.constants import objects, url
 
 
@@ -16,12 +17,7 @@ class Common(object):
   MODAL_CONFIRM = ".modal.hide"
   MODAL_MAP = ".modal-selector"
   # info page (panel)
-  PIN_CONTENT = ".pin-content "
   INFO_WIDGET = ".info"
-  INFO_HEADER = INFO_WIDGET + " .pane-header"
-  INFO_UTILITY = INFO_WIDGET + " .info-pane-utility"
-  INFO_ACTION = INFO_WIDGET + " .pin-action"
-  INFO_TOGGLE = INFO_UTILITY + " .dropdown-toggle"
   # dropdown
   DROPDOWN_MENU = ".dropdown-menu"
   # tree
@@ -39,6 +35,10 @@ class Common(object):
   MAX = "max"
   NORMAL = "normal"
   DOWN = "down"
+  # xpath helper
+  XPATH_NOT_HIDDEN = "[not(ancestor::section[contains(@class, 'hidden')])]"
+  INFO_WIDGET_XPATH = ("//section[starts-with(@class,'info')]" +
+                       XPATH_NOT_HIDDEN)
 
 
 class Login(object):
@@ -587,55 +587,37 @@ class ModalCloneAudit(ModalCommonConfirmAction):
 
 class CommonWidgetInfo(object):
   """Common locators for Info widgets and Info panels."""
-  WIDGET = Common.INFO_WIDGET
-  PIN_CONTENT = Common.PIN_CONTENT
-  INFO_HEADER = Common.INFO_HEADER
-  _INFO_HEADER = Common.INFO_HEADER + " .span9 "
-  INFO_TOGGLE = Common.INFO_TOGGLE
-  HEADERS_AND_VALUES = WIDGET + ' div [class*="span"]'
-  PAGE_HEADERS_AND_VALUES = (By.CSS_SELECTOR,
-                             HEADERS_AND_VALUES)
-  CAS_HEADERS_AND_VALUES = (
-      By.XPATH, '//*[contains(@class, "inline-edit ") and '
-                'not(ancestor::*[contains(@class, "hidden")])]')
-  CAS_CHECKBOXES = (By.CSS_SELECTOR, " .inline-edit__checkbox input")
+  _NOT_HIDDEN = Common.XPATH_NOT_HIDDEN
+  _INFO_WIDGET_XPATH = Common.INFO_WIDGET_XPATH + _NOT_HIDDEN
+  _MAIN_HEADER_XPATH = "//div[@class='span9']" + _NOT_HIDDEN
+  _HEADERS_AND_VALUES = (_INFO_WIDGET_XPATH +
+                         '//div[starts-with(./@class, "span")]//h6/..')
+  HEADERS_AND_VALUES = (By.XPATH, _HEADERS_AND_VALUES)
+  CAS_HEADERS_AND_VALUES = (By.XPATH, _INFO_WIDGET_XPATH + "//inline-edit/div")
+  CAS_CHECKBOXES = (By.XPATH, _INFO_WIDGET_XPATH + "//inline-edit//input["
+                                                   "@type='checkbox']")
   # labels
-  TITLE = (By.CSS_SELECTOR, _INFO_HEADER + "h6")
-  TITLE_UNDER_AUDIT = (By.CSS_SELECTOR,
-                       PIN_CONTENT + _INFO_HEADER + "h6")
-  TITLE_ENTERED = (By.CSS_SELECTOR, _INFO_HEADER + "h3")
-  TITLE_ENTERED_UNDER_AUDIT = (By.CSS_SELECTOR,
-                               PIN_CONTENT + _INFO_HEADER + "h3")
-  STATE = (By.CSS_SELECTOR, _INFO_HEADER + ".state-value")
-  STATE_UNDER_AUDIT = (By.CSS_SELECTOR,
-                       PIN_CONTENT + _INFO_HEADER + "span:last-of-type")
+  TITLE = (By.XPATH, _MAIN_HEADER_XPATH + "//h6")
+  TITLE_ENTERED = (By.XPATH, _MAIN_HEADER_XPATH + "//h3")
+  STATE = (By.XPATH, _MAIN_HEADER_XPATH + "//span[last()]")
   # user input elements
-  BUTTON_3BBS = (By.CSS_SELECTOR, INFO_TOGGLE)
-  BUTTON_3BBS_UNDER_AUDIT = (By.CSS_SELECTOR, PIN_CONTENT + INFO_TOGGLE)
+  BUTTON_3BBS = (By.XPATH, _INFO_WIDGET_XPATH + "//*[@data-toggle='dropdown']")
 
 
 class WidgetInfoPanel(CommonWidgetInfo):
   """Locators specific for Info panels."""
-  INFO_ACTION = Common.INFO_ACTION
-  PIN_CONTENT = Common.PIN_CONTENT
-  PANEL_HEADERS_AND_VALUES = (
-      By.CSS_SELECTOR, PIN_CONTENT + CommonWidgetInfo.HEADERS_AND_VALUES)
+  _PIN_ACTION = ' .pin-action'
   # user input elements
   BUTTON_MAXIMIZE_MINIMIZE = (By.CSS_SELECTOR,
-                              INFO_ACTION + ' [can-click="toggleSize"]')
+                              _PIN_ACTION + ' [can-click="toggleSize"]')
   BUTTON_CLOSE = (By.CSS_SELECTOR,
-                  INFO_ACTION + ' [can-click="close"]')
+                  _PIN_ACTION + ' [can-click="close"]')
 
 
 class WidgetSnapshotsInfoPanel(WidgetInfoPanel):
   """Locators specific for Info panels of snapshotable objects."""
-  WIDGET = Common.INFO_WIDGET
-  PIN_CONTENT = Common.PIN_CONTENT
-  INFO_HEADER = Common.INFO_HEADER
-  LINK_GET_LAST_VER = (By.CSS_SELECTOR,
-                       WIDGET + ' .snapshot [can-click="compareIt"]')
-  SNAPSHOT_OBJ_VER = (By.CSS_SELECTOR,
-                      PIN_CONTENT + INFO_HEADER + " .span9 span:first-of-type")
+  LINK_GET_LAST_VER = (By.CSS_SELECTOR, ".snapshot [can-click='compareIt']")
+  SNAPSHOT_OBJ_VER = (By.CSS_SELECTOR, "span.snapshot")
 
 
 class WidgetInfoProgram(WidgetInfoPanel):
@@ -842,42 +824,34 @@ class WidgetAdminEvents(object):
       "{0} {1}:first-child".format(_BASE_CSS_SELECTOR, _TREE_ITEMS_SELECTOR))
 
 
-class CommonDropdown3bbsInfoWidget(object):
+class CommonDropdownMenu(object):
+  _DROPDOWN_MAIN = 'ul'
+  _DROPDOWN_ITEMS = 'li'
+  _DROPDOWN_ITEM_ICON = 'i'
+  DROPDOWN_MAIN_CSS = (By.CSS_SELECTOR, _DROPDOWN_MAIN)
+  DROPDOWN_ITEMS_CSS = (By.CSS_SELECTOR, _DROPDOWN_ITEMS)
+  DROPDOWN_ITEM_ICON_CSS = (By.CSS_SELECTOR, _DROPDOWN_ITEM_ICON)
+
+
+class CommonDropdown3bbsInfoWidget(CommonDropdownMenu):
   """Locators for common settings 3BBS dropdown on Info widget and Info page.
  """
-  INFO_3BBS_DROPDOWN = Common.INFO_WIDGET + " .dropdown-menu"
-  PIN_CONTENT = CommonWidgetInfo.PIN_CONTENT
-  EDIT = INFO_3BBS_DROPDOWN + " .fa-pencil-square-o"
-  GET_PERMALINK = (INFO_3BBS_DROPDOWN + " .fa-link")
-  OPEN = (INFO_3BBS_DROPDOWN + " .fa-long-arrow-right")
-  DELETE = (INFO_3BBS_DROPDOWN + " .fa-trash")
-  # user input elements
-  BUTTON_3BBS_EDIT = (By.CSS_SELECTOR, EDIT)
-  BUTTON_3BBS_GET_PERMALINK = (By.CSS_SELECTOR, GET_PERMALINK)
-  BUTTON_3BBS_OPEN = (By.CSS_SELECTOR, OPEN)
-  BUTTON_3BBS_DELETE = (By.CSS_SELECTOR, DELETE)
-  # user input elements under audit
-  BUTTON_3BBS_EDIT_UNDER_AUDIT = (By.CSS_SELECTOR, PIN_CONTENT + EDIT)
-  BUTTON_3BBS_GET_PERMALINK_UNDER_AUDIT = (By.CSS_SELECTOR,
-                                           PIN_CONTENT + GET_PERMALINK)
-  BUTTON_3BBS_OPEN_UNDER_AUDIT = (By.CSS_SELECTOR, PIN_CONTENT + OPEN)
-  BUTTON_3BBS_DELETE_UNDER_AUDIT = (By.CSS_SELECTOR, PIN_CONTENT + DELETE)
+  _INFO_3BBS_DROPDOWN_XPATH = (Common.INFO_WIDGET_XPATH +
+                               "//*[contains(@class,'dropdown-menu')]")
+  INFO_3BBS_DROPDOWN = (By.XPATH, _INFO_3BBS_DROPDOWN_XPATH)
 
 
 class AuditsDropdown3bbsInfoWidget(CommonDropdown3bbsInfoWidget):
   """Locators for Audit settings 3BBS dropdown on Info page and Info panel.
   """
-  INFO_3BBS_DROPDOWN = CommonDropdown3bbsInfoWidget.INFO_3BBS_DROPDOWN
-  BUTTON_3BBS_UPDATE = (
-      By.CSS_SELECTOR, INFO_3BBS_DROPDOWN + " snapshot-scope-update")
-  BUTTON_3BBS_CLONE = (By.CSS_SELECTOR, INFO_3BBS_DROPDOWN + " object-cloner")
 
 
-class CommonDropdown3bbsTreeView(object):
+class CommonDropdown3bbsTreeView(CommonDropdownMenu):
   """Locators for common settings 3BBS dropdown on Tree View."""
   TREE_VIEW_3BBS_DROPDOWN = (
       "{} " + Common.TREE_LIST + " .tree-action-list-items")
   # user input elements
+  TREE_VIEW_3BBS_DROPDOWN_CSS = (By.CSS_SELECTOR, TREE_VIEW_3BBS_DROPDOWN)
   BUTTON_3BBS_IMPORT = TREE_VIEW_3BBS_DROPDOWN + " .fa-cloud-upload"
   BUTTON_3BBS_EXPORT = TREE_VIEW_3BBS_DROPDOWN + " .fa-download"
   BUTTON_3BBS_SELECT_CHILD_TREE = TREE_VIEW_3BBS_DROPDOWN + " .fa-share-alt"
@@ -892,18 +866,21 @@ class AssessmentsDropdown3bbsTreeView(CommonDropdown3bbsTreeView):
 class TreeView(object):
   """Locators for Tree View components."""
   # common
-  ITEMS = ".tree-item-element"
+  _WIDGET_NOT_HIDDEN_CSS = ".widget:not(.hidden)"
+  ITEMS = _WIDGET_NOT_HIDDEN_CSS + " .tree-item-element"
   HEADER = Common.TREE_HEADER
   ITEM_LOADING = (By.CSS_SELECTOR, " .tree-item-placeholder")
-  ITEM_EXPAND_BUTTON = "tree-item-actions"
+  ITEM_EXPAND_BUTTON = " tree-item-actions"
   SPINNER = (By.CSS_SELECTOR, " .tree-spinner")
   NO_RESULTS_MESSAGE = (
-      By.CSS_SELECTOR, ".widget:not(.hidden) .tree-no-results-message")
+      By.CSS_SELECTOR, _WIDGET_NOT_HIDDEN_CSS + " .tree-no-results-message")
   BUTTON_SHOW_FIELDS = "{} " + Common.TREE_HEADER + " .fa-bars"
   # user input elements
   BUTTON_3BBS = "{} " + Common.TREE_LIST + " .details-wrap"
   BUTTON_CREATE = "{} " + Common.TREE_LIST + " .create-button"
   BUTTON_MAP = "{} " + Common.TREE_LIST + " .map-button"
+  ITEM_DROPDOWN_BUTTON = (By.CSS_SELECTOR, _WIDGET_NOT_HIDDEN_CSS +
+                          ITEM_EXPAND_BUTTON)
 
 
 class AdminTreeView(object):

--- a/test/selenium/src/lib/element/tree_view.py
+++ b/test/selenium/src/lib/element/tree_view.py
@@ -6,27 +6,28 @@
 from selenium.webdriver.common.by import By
 
 from lib import base
-from lib.constants import locator, url, objects
+from lib.constants import locator, url
 from lib.page.modal import unified_mapper
 
 
-class CommonDropdownSettings(base.Component):
+class CommonDropdownSettings(base.DropdownMenu):
   """Common for 3BBS button/dropdown settings on Tree View."""
   _locators = locator.CommonDropdown3bbsTreeView
 
-  def __init__(self, driver, obj_name, is_under_audit):
-    super(CommonDropdownSettings, self).__init__(driver)
+  def __init__(self, driver, obj_name):
     self.widget_name = url.get_widget_name_of_mapped_objs(obj_name)
     self.obj_name = obj_name
     # elements
+    _dropdown_element = (
+        By.CSS_SELECTOR,
+        self._locators.TREE_VIEW_3BBS_DROPDOWN.format(self.widget_name))
+    super(CommonDropdownSettings, self).__init__(driver, _dropdown_element)
     self.select_child_tree_locator = (
         self._locators.BUTTON_3BBS_SELECT_CHILD_TREE.format(self.widget_name))
-    # if object is not shapshotable
-    if not (obj_name in objects.ALL_SNAPSHOTABLE_OBJS and is_under_audit):
-      self.import_locator = (
-          self._locators.BUTTON_3BBS_IMPORT.format(self.widget_name))
-      self.export_locator = (
-          self._locators.BUTTON_3BBS_EXPORT.format(self.widget_name))
+    self.import_locator = (
+        self._locators.BUTTON_3BBS_IMPORT.format(self.widget_name))
+    self.export_locator = (
+        self._locators.BUTTON_3BBS_EXPORT.format(self.widget_name))
 
 
 class Assessments(CommonDropdownSettings):

--- a/test/selenium/src/lib/element/tree_view_item.py
+++ b/test/selenium/src/lib/element/tree_view_item.py
@@ -1,0 +1,64 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+"""Module of TreeViewItem dropdownsMenu presented on Genetic TreeView."""
+from lib import base
+
+
+class CommonDropdownTreeViewItem(base.DropdownMenu):
+  """Common Dropdown for TreeView Item"""
+
+  def __init__(self, driver, obj_name, parent_element):
+    super(CommonDropdownTreeViewItem, self).__init__(driver, parent_element)
+    self.obj_name = obj_name
+
+
+class SnapshotsDropdownTreeViewItem(CommonDropdownTreeViewItem):
+  """Class for Dropdown of Snapshotable TreeViewItem"""
+
+
+class AssessmentTemplates(CommonDropdownTreeViewItem):
+  """Class for Dropdown of AssessmentTemplates TreeViewItem"""
+
+
+class Audits(CommonDropdownTreeViewItem):
+  """Class for Dropdown of Audits TreeViewItem"""
+
+
+class Assessments(CommonDropdownTreeViewItem):
+  """Class for Dropdown of Assessments TreeViewItem"""
+
+
+class Issues(CommonDropdownTreeViewItem):
+  """Class for Dropdown of Assessments TreeViewItem"""
+
+
+class Controls(SnapshotsDropdownTreeViewItem):
+  """Class for Dropdown of Controls TreeViewItem"""
+
+
+class Programs(CommonDropdownTreeViewItem):
+  """Class for Dropdown of Programs TreeViewItem"""
+
+
+class DataAssets(SnapshotsDropdownTreeViewItem):
+  """Class for Dropdown of DataAssets TreeViewItem"""
+
+
+class Systems(SnapshotsDropdownTreeViewItem):
+  """Class for Dropdown of Systems TreeViewItem"""
+
+
+class Processes(SnapshotsDropdownTreeViewItem):
+  """Class for Dropdown of Processes TreeViewItem"""
+
+
+class Products(SnapshotsDropdownTreeViewItem):
+  """Class for Dropdown of Products TreeViewItem"""
+
+
+class Projects(SnapshotsDropdownTreeViewItem):
+  """Class for Dropdown of Projects TreeViewItem"""
+
+
+class OrgGroups(SnapshotsDropdownTreeViewItem):
+  """Class for Dropdown of Products TreeViewItem"""

--- a/test/selenium/src/lib/element/widget_info.py
+++ b/test/selenium/src/lib/element/widget_info.py
@@ -3,74 +3,49 @@
 """Info Page and Info Panel dropdown elements."""
 
 from lib import base
-from lib.constants import locator
+from lib.constants import locator, element
 from lib.page.modal import (delete_object, edit_object, update_object,
                             clone_object)
-from lib.utils import selenium_utils
 
 
-class CommonDropdownSettings(base.Component):
+class CommonInfoDropdownSettings(base.DropdownMenu):
   """Common for 3BBS button/dropdown settings on Info pages and Info panels.
   """
   _locators = locator.CommonDropdown3bbsInfoWidget
+  _elements = element.DropdownMenuItemTypes
 
-  def __init__(self, driver, is_under_audit):
-    super(CommonDropdownSettings, self).__init__(driver)
-    self.edit_locator = (
-        self._locators.BUTTON_3BBS_EDIT_UNDER_AUDIT if is_under_audit
-        else self._locators.BUTTON_3BBS_EDIT)
-    self.open_locator = (
-        self._locators.BUTTON_3BBS_OPEN_UNDER_AUDIT if is_under_audit
-        else self._locators.BUTTON_3BBS_OPEN)
-    self.get_permalink_locator = (
-        self._locators.BUTTON_3BBS_GET_PERMALINK_UNDER_AUDIT if is_under_audit
-        else self._locators.BUTTON_3BBS_GET_PERMALINK)
-    self.delete_locator = (
-        self._locators.BUTTON_3BBS_DELETE_UNDER_AUDIT if is_under_audit
-        else self._locators.BUTTON_3BBS_DELETE)
+  def __init__(self, driver):
+    super(CommonInfoDropdownSettings, self).__init__(
+        driver, self._locators.INFO_3BBS_DROPDOWN)
 
   def select_open(self):
     """Select open button in 3BBS dropdown modal."""
-    base.Button(self._driver, self.open_locator).click()
-
-  def is_open_enabled(self):
-    """Find open button in 3BBS dropdown modal and check if it enabled.
-    Return:
-    True if disabled attribute value does not exist for parent element of open,
-    False if disabled attribute value exist for parent element of open.
-    """
-    parent_element_of_open = selenium_utils.get_parent_element(
-        self._driver, self._driver.find_element(*self.open_locator))
-    return not selenium_utils.is_value_in_attr(
-        parent_element_of_open, value=locator.Common.DISABLED_VALUE)
+    self.get_dropdown_item(self._elements.OPEN).click()
 
   def select_edit(self):
     """Select edit button in 3BBS dropdown modal.
     Return: lib.page.modal.edit_object.EditModal
     """
-    base.Button(self._driver, self.edit_locator).click()
+    self.get_dropdown_item(self._elements.EDIT).click()
     return getattr(edit_object, self.__class__.__name__)(self._driver)
-
-  def is_edit_exist(self):
-    """Find edit button in 3BBS dropdown modal.
-    Return: True if edit button is exist,
-            False if edit button is not exist.
-    """
-    return selenium_utils.is_element_exist(self._driver, self.edit_locator)
 
   def select_get_permalink(self):
     """Select get permalink in 3BBS dropdown modal."""
-    base.Button(self._driver, self.get_permalink_locator).click()
+    self.get_dropdown_item(self._elements.GET_PERMALINK).click()
 
   def select_delete(self):
     """Select delete in 3BBS dropdown modal.
     Return: modal.delete_object.DeleteObjectModal
     """
-    base.Button(self._driver, self.delete_locator).click()
+    self.get_dropdown_item(self._elements.DELETE).click()
     return delete_object.DeleteObjectModal(self._driver)
 
 
-class Audits(CommonDropdownSettings):
+class Snapshots(CommonInfoDropdownSettings):
+  """Snapshots 3BBS button/dropdown settings on Info panels."""
+
+
+class Audits(CommonInfoDropdownSettings):
   """Audits 3BBS button/dropdown settings on Info pages and Info panels."""
   _locators = locator.AuditsDropdown3bbsInfoWidget
 
@@ -78,49 +53,49 @@ class Audits(CommonDropdownSettings):
     """Select update objects to latest version in 3BBS dropdown modal.
     Return: modal.update_object.CompareUpdateObjectModal
     """
-    base.Button(self._driver, self._locators.BUTTON_3BBS_UPDATE).click()
+    self.get_dropdown_item(self._elements.UPDATE).click()
     return update_object.CompareUpdateObjectModal(self._driver)
 
   def select_clone(self):
     """Select clone Audit in 3BBS dropdown modal.
     Return: modal.clone_object.CloneAuditModal
     """
-    base.Button(self._driver, self._locators.BUTTON_3BBS_CLONE).click()
+    self.get_dropdown_item(self._elements.CLONE).click()
     return clone_object.CloneAuditModal(self._driver)
 
 
-class Programs(CommonDropdownSettings):
+class Programs(CommonInfoDropdownSettings):
   """Programs 3BBS button/dropdown settings on Info pages and Info panels."""
 
 
-class Controls(CommonDropdownSettings):
+class Controls(Snapshots):
   """Controls 3BBS button/dropdown settings on Info pages and Info panels."""
 
 
-class Processes(CommonDropdownSettings):
+class Processes(CommonInfoDropdownSettings):
   """Processes 3BBS button/dropdown settings on Info pages and Info panels."""
 
 
-class DataAssets(CommonDropdownSettings):
+class DataAssets(CommonInfoDropdownSettings):
   """DataAssets 3BBS button/dropdown settings on Info pages and Info panels."""
 
 
-class Systems(CommonDropdownSettings):
+class Systems(CommonInfoDropdownSettings):
   """Systems 3BBS button/dropdown settings on Info pages and Info panels."""
 
 
-class Products(CommonDropdownSettings):
+class Products(CommonInfoDropdownSettings):
   """Products 3BBS button/dropdown settings on Info pages and Info panels."""
 
 
-class Projects(CommonDropdownSettings):
+class Projects(CommonInfoDropdownSettings):
   """Projects 3BBS button/dropdown settings on Info pages and Info panels."""
 
 
-class OrgGroups(CommonDropdownSettings):
+class OrgGroups(CommonInfoDropdownSettings):
   """OrgGroups 3BBS button/dropdown settings on Info pages and Info panels."""
 
 
-class Assessments(CommonDropdownSettings):
+class Assessments(CommonInfoDropdownSettings):
   """Assessments 3BBS button/dropdown settings on Info pages and Info panels.
   """

--- a/test/selenium/src/lib/factory.py
+++ b/test/selenium/src/lib/factory.py
@@ -4,7 +4,7 @@
 
 from lib import base, cache, constants, exception
 from lib.constants import objects, element, locator
-from lib.element import tree_view, widget_info
+from lib.element import tree_view, widget_info, tree_view_item
 
 
 def _filter_out_underscore(object_name):
@@ -137,9 +137,19 @@ def get_cls_3bbs_dropdown_settings(object_name, is_tree_view_not_info):
   Info widget (Info page or Info panel). As default for Info widget, if
   is_tree_view_not_info is True then for Tree View.
   """
-  base_cls = widget_info.CommonDropdownSettings
+  base_cls = widget_info.CommonInfoDropdownSettings
   if is_tree_view_not_info:
     base_cls = tree_view.CommonDropdownSettings
+  return _factory(cls_name=object_name, parent_cls=base_cls)
+
+
+def get_cls_dropdown_tree_view_item(object_name):
+  """Get and return class of TreeViewItem Dropdown object according to
+  snapshotability
+  """
+  base_cls = tree_view_item.CommonDropdownTreeViewItem
+  if object_name in objects.ALL_SNAPSHOTABLE_OBJS:
+    base_cls = tree_view_item.SnapshotsDropdownTreeViewItem
   return _factory(cls_name=object_name, parent_cls=base_cls)
 
 

--- a/test/selenium/src/lib/page/widget/info_widget.py
+++ b/test/selenium/src/lib/page/widget/info_widget.py
@@ -13,7 +13,7 @@ from lib.utils import selenium_utils
 class CommonInfo(base.Widget):
   """Abstract class of common info for Info pages and Info panels."""
   _locators = locator.CommonWidgetInfo
-  dropdown_settings_cls = widget_info.CommonDropdownSettings
+  dropdown_settings_cls = widget_info.CommonInfoDropdownSettings
   locator_headers_and_values = None
   all_headers_and_values = []
   cas_headers_and_values = []
@@ -22,24 +22,23 @@ class CommonInfo(base.Widget):
 
   def __init__(self, driver):
     super(CommonInfo, self).__init__(driver)
-    if self.is_under_audit:
-      self.title = base.Label(driver, self._locators.TITLE_UNDER_AUDIT)
-      self.title_entered = base.Label(
-          driver, self._locators.TITLE_ENTERED_UNDER_AUDIT)
-      self.state = base.Label(driver, self._locators.STATE_UNDER_AUDIT)
-      self.locator_3bbs = self._locators.BUTTON_3BBS_UNDER_AUDIT
-    else:
-      self.title = base.Label(driver, self._locators.TITLE)
-      self.title_entered = base.Label(driver, self._locators.TITLE_ENTERED)
-      self.state = base.Label(driver, self._locators.STATE)
-      self.locator_3bbs = self._locators.BUTTON_3BBS
+    self.locator_headers_and_values = self._locators.HEADERS_AND_VALUES
+
+  def title(self):
+    return base.Label(self._driver, self._locators.TITLE)
+
+  def title_entered(self):
+    return base.Label(self._driver, self._locators.TITLE_ENTERED)
+
+  def state(self):
+    return base.Label(self._driver, self._locators.STATE)
 
   def open_info_3bbs(self):
     """Click to 3BBS button on Info page or Info panel to open info 3BBS modal.
     Return: lib.element.widget_info."obj_name"DropdownSettings
     """
-    base.Button(self._driver, self.locator_3bbs).click()
-    return self.dropdown_settings_cls(self._driver, self.is_under_audit)
+    base.Button(self._driver, self._locators.BUTTON_3BBS).click()
+    return self.dropdown_settings_cls(self._driver)
 
   def get_header_and_value_text_from_custom_scopes(self, header_text,
                                                    custom_scopes_locator=None):
@@ -58,10 +57,10 @@ class CommonInfo(base.Widget):
       if not custom_scopes_locator and self.locator_headers_and_values:
         self.all_headers_and_values = self._driver.find_elements(
             *self.locator_headers_and_values)
-    header_and_value = (
-        [scope.text.splitlines()[:2] for scope in self.all_headers_and_values
-         if header_text in scope.text][0]
-        if self.all_headers_and_values else [None, None])
+    header_and_value = next((scope.text.splitlines()[:2]
+                             for scope in self.all_headers_and_values
+                             if header_text in scope.text),
+                            [None, None])
     return header_and_value
 
   def get_headers_and_values_text_from_cas_scopes(self):  # flake8: noqa
@@ -117,8 +116,7 @@ class CommonInfo(base.Widget):
           # Other
           cas_values.append(ca_val)
       return cas_headers, cas_values
-    else:
-      return [None, None]
+    return [None, None]
 
   def get_info_widget_obj_scope(self):
     """Get dict from object (text scope) which displayed on info page or
@@ -133,10 +131,6 @@ class InfoPanel(CommonInfo):
 
   def __init__(self, driver):
     super(InfoPanel, self).__init__(driver)
-    self.locator_headers_and_values = (
-        self._locators.PANEL_HEADERS_AND_VALUES if self.is_info_panel or
-        not self.is_info_panel and not self.is_info_page
-        else self._locators.PAGE_HEADERS_AND_VALUES)
 
   def button_maximize_minimize(self):
     """Button (toggle) maximize and minimize for Info Panels."""
@@ -152,13 +146,15 @@ class SnapshotableInfoPanel(InfoPanel):
   """Class for Info Panels of snapshotable objects."""
   # pylint: disable=too-few-public-methods
   _locators = locator.WidgetSnapshotsInfoPanel
+  dropdown_settings_cls = widget_info.Snapshots
   locator_link_get_latest_ver = _locators.LINK_GET_LAST_VER
 
   def __init__(self, driver):
     super(SnapshotableInfoPanel, self).__init__(driver)
-    if self.is_under_audit and self.is_info_panel:
-      self.snapshot_obj_version = base.Label(
-          driver, self._locators.SNAPSHOT_OBJ_VER)
+
+  def snapshot_obj_version(self):
+    """Label of snapshot version"""
+    return base.Label(self._driver, self._locators.SNAPSHOT_OBJ_VER)
 
   def open_link_get_latest_ver(self):
     """Click on link get latest version under Info panel."""
@@ -242,11 +238,12 @@ class Audits(InfoPanel):
     # all obj scopes
     self.list_all_headers_text = [
         self._elements.CAS_HEADERS.upper(), self._elements.CAS_VALUES.upper(),
-        self.title.text, self._elements.STATUS.upper(), self.audit_lead_text,
+        self.title().text, self._elements.STATUS.upper(), self.audit_lead_text,
         self.code_text]
     self.list_all_values_text = [
-        self.cas_headers_text, self.cas_values_text, self.title_entered.text,
-        objects.get_normal_form(self.state.text), self.audit_lead_entered_text,
+        self.cas_headers_text, self.cas_values_text, self.title_entered().text,
+        objects.get_normal_form(self.state().text),
+        self.audit_lead_entered_text,
         self.code_entered_text]
 
 
@@ -300,14 +297,15 @@ class Assessments(InfoPanel):
     # scope
     self.list_all_headers_text = [
         self._elements.CAS_HEADERS.upper(), self._elements.CAS_VALUES.upper(),
-        self.title.text, self._elements.STATE.upper(),
+        self.title().text, self._elements.STATE.upper(),
         self._elements.VERIFIED.upper(),
         self._elements.CREATORS.upper(),
         self._elements.MAPPED_OBJECTS.upper(), self.code_text]
     self.list_all_values_text = [
-        self.cas_headers_text, self.cas_values_text, self.title_entered.text,
-        objects.get_normal_form(self.state.text),
-        self.state.text.upper() in element.AssessmentStates.COMPLETED.upper(),
+        self.cas_headers_text, self.cas_values_text, self.title_entered().text,
+        objects.get_normal_form(self.state().text),
+        self.state().text.upper() in
+        element.AssessmentStates.COMPLETED.upper(),
         self.creators_entered_text,
         self.mapped_objects_titles_text, self.code_entered_text]
 
@@ -399,11 +397,11 @@ class Controls(SnapshotableInfoPanel):
     # scope
     self.list_all_headers_text = [
         self._elements.CAS_HEADERS.upper(), self._elements.CAS_VALUES.upper(),
-        self.title.text, self._elements.STATE.upper(), self.admin_text,
+        self.title().text, self._elements.STATE.upper(), self.admin_text,
         self.primary_contact_text, self.code_text]
     self.list_all_values_text = [
-        self.cas_headers_text, self.cas_values_text, self.title_entered.text,
-        objects.get_normal_form(self.state.text), self.admin_entered_text,
+        self.cas_headers_text, self.cas_values_text, self.title_entered().text,
+        objects.get_normal_form(self.state().text), self.admin_entered_text,
         self.primary_contact_entered_text, self.code_entered_text]
 
 

--- a/test/selenium/src/lib/service/webui_service.py
+++ b/test/selenium/src/lib/service/webui_service.py
@@ -225,16 +225,29 @@ class BaseWebUiService(object):
     """Open generic widget of mapped objects, select object from Tree View
     by title and check via Info panel that object is editable.
     """
-    obj_info_panel = self.open_info_panel_of_obj_by_title(src_obj, obj)
-    return obj_info_panel.open_info_3bbs().is_edit_exist()
+    dropdown_on_info_panel = (
+        self.open_info_panel_of_obj_by_title(src_obj, obj).open_info_3bbs())
+    element_to_verify = element.DropdownMenuItemTypes.EDIT
+    return dropdown_on_info_panel.is_item_exists(element_to_verify)
+
+  def is_obj_unmappable_via_info_panel(self, src_obj, obj):
+    """""Open generic widget of mapped objects, select object from Tree View
+    by title open dropdown on Info Panel and check that object is unmappable.
+    """
+    dropdown_on_info_panel = (
+        self.open_info_panel_of_obj_by_title(src_obj, obj).open_info_3bbs())
+    element_to_verify = element.DropdownMenuItemTypes.UNMAP
+    return dropdown_on_info_panel.is_item_exists(element_to_verify)
 
   def is_obj_page_exist_via_info_panel(self, src_obj, obj):
     """Open generic widget of mapped objects, select object from Tree View
     by title and check via Info panel that object page is exist.
     """
     # pylint: disable=invalid-name
-    obj_info_panel = self.open_info_panel_of_obj_by_title(src_obj, obj)
-    return obj_info_panel.open_info_3bbs().is_open_enabled()
+    dropdown_on_info_panel = (
+        self.open_info_panel_of_obj_by_title(src_obj, obj).open_info_3bbs())
+    element_to_verify = element.DropdownMenuItemTypes.OPEN
+    return dropdown_on_info_panel.is_item_enabled(element_to_verify)
 
   def filter_list_objs_from_tree_view(self, src_obj, filter_exp):
     """Filter by specified criteria and return list of objects from Tree
@@ -245,6 +258,17 @@ class BaseWebUiService(object):
     list_objs_scopes = self.get_list_objs_scopes_from_tree_view(src_obj)
     return self.create_list_objs(entity_factory=self.entities_factory_cls,
                                  list_scopes=list_objs_scopes)
+
+  def is_obj_mappable_via_tree_view(self, src_obj, obj):
+    """""Open dropdown of Tree View Item  by title, an check is object
+    mappable.
+    """
+    objs_widget = self.open_widget_of_mapped_objs(src_obj)
+    dropdown_on_tree_view_item = (objs_widget.tree_view.
+                                  open_tree_actions_dropdown_by_title
+                                  (title=obj.title))
+    element_to_verify = element.DropdownMenuItemTypes.MAP
+    return dropdown_on_tree_view_item.is_item_exists(element_to_verify)
 
 
 class SnapshotsWebUiService(BaseWebUiService):

--- a/test/selenium/src/lib/utils/selenium_utils.py
+++ b/test/selenium/src/lib/utils/selenium_utils.py
@@ -172,11 +172,6 @@ def scroll_into_view(driver, element):
   return element
 
 
-def get_parent_element(driver, element):
-  """Get parent element of current element using JS."""
-  return driver.execute_script("return arguments[0].parentNode;", element)
-
-
 def wait_for_js_to_load(driver):
   """Wait until there all JS are completed."""
   return wait_until_condition(
@@ -186,3 +181,30 @@ def wait_for_js_to_load(driver):
 def click_via_js(driver, element):
   """Click on element using JS."""
   driver.execute_script("arguments[0].click();", element)
+
+
+def is_element_enabled(element):
+  """Is this element and first parent and first level child elements is
+  enabled"""
+  elements_to_check = [element, element.find_element_by_xpath("../.")]
+  elements_to_check.extend(get_nested_elements(element))
+  return all([el.is_enabled() and
+              not is_value_in_attr(el, value="disabled")
+              for el in elements_to_check])
+
+
+def get_nested_elements(element, all_nested=False):
+  """Get nested elements of current element by Xpath. If all_nested=True,
+  return all-levels nested elements
+  """
+  nested_locator = './*'
+  if all_nested:
+    nested_locator = './/*'
+  return element.find_elements_by_xpath(nested_locator)
+
+
+def get_element_by_element_safe(element, locator):
+  """Get element from current element by locator.
+  Return "None" if element not found
+  """
+  return next((el for el in element.find_elements(*locator)), None)

--- a/test/selenium/src/tests/test_program_page.py
+++ b/test/selenium/src/tests/test_program_page.py
@@ -59,7 +59,7 @@ class TestProgramPage(base.Test):
     into modal."""
     modal, program_info_page = new_program_ui
     assert (test_utils.HtmlParser.parse_text(modal.ui_title.text) ==
-            program_info_page.title_entered.text)
+            program_info_page.title_entered().text)
     assert (modal.ui_description.text ==
             program_info_page.description_entered.text)
     assert modal.ui_notes.text == program_info_page.notes_entered.text
@@ -102,7 +102,7 @@ class TestProgramPage(base.Test):
     selenium_utils.open_url(selenium, program_info_page.url)
     updated_program_info_page = info_widget.Programs(selenium)
     assert (test_utils.HtmlParser.parse_text(modal.ui_title.text) ==
-            updated_program_info_page.title_entered.text)
+            updated_program_info_page.title_entered().text)
     assert (modal.ui_description.text ==
             updated_program_info_page.description_entered.text)
     assert modal.ui_notes.text == updated_program_info_page.notes_entered.text

--- a/test/selenium/src/tests/test_snapshots.py
+++ b/test/selenium/src/tests/test_snapshots.py
@@ -339,3 +339,25 @@ class TestSnapshots(base.Test):
             actual_control_in_program), messages.ERR_MSG_TRIPLE_FORMAT.format(
                 expected_control, actual_control_in_audit,
                 actual_control_in_program)
+
+  @pytest.mark.smoke_tests
+  def test_snapshot_cannot_be_unmapped_from_audit(
+      self, create_audit_with_control, selenium
+  ):
+    """Check Snapshot cannot be unmapped from audit.
+    Check that snapshot cannot be mapped from tree-view.
+    Preconditions:
+    - Audit with mapped Control Snapshot created via REST API
+    """
+    audit_with_one_control = create_audit_with_control
+    audit = audit_with_one_control["new_audit_rest"][0]
+    control = audit_with_one_control["new_control_rest"][0]
+    is_mappable_on_tree_view_item = (webui_service.ControlsService(
+        selenium).is_obj_mappable_via_tree_view(audit, control))
+    is_unmappable_on_info_panel = (webui_service.ControlsService(
+        selenium).is_obj_unmappable_via_info_panel(src_obj=audit, obj=control))
+    assert ((False is
+             is_mappable_on_tree_view_item is
+             is_unmappable_on_info_panel),
+            messages.ERR_MSG_TRIPLE_FORMAT.format(
+            False, is_mappable_on_tree_view_item, is_unmappable_on_info_panel))

--- a/test/selenium/src/tests/test_snapshots.py
+++ b/test/selenium/src/tests/test_snapshots.py
@@ -344,8 +344,10 @@ class TestSnapshots(base.Test):
   def test_snapshot_cannot_be_unmapped_from_audit(
       self, create_audit_with_control, selenium
   ):
-    """Check Snapshot cannot be unmapped from audit.
-    Check that snapshot cannot be mapped from tree-view.
+    """Check Snapshot cannot be unmapped from audit using "Unmap" button on
+    info panel.
+    Check that snapshot cannot be mapped from tree-view using "Map to this
+    object" button.
     Preconditions:
     - Audit with mapped Control Snapshot created via REST API
     """
@@ -356,8 +358,9 @@ class TestSnapshots(base.Test):
         selenium).is_obj_mappable_via_tree_view(audit, control))
     is_unmappable_on_info_panel = (webui_service.ControlsService(
         selenium).is_obj_unmappable_via_info_panel(src_obj=audit, obj=control))
-    assert ((False is
-             is_mappable_on_tree_view_item is
-             is_unmappable_on_info_panel),
-            messages.ERR_MSG_TRIPLE_FORMAT.format(
-            False, is_mappable_on_tree_view_item, is_unmappable_on_info_panel))
+    assert (False is
+            is_mappable_on_tree_view_item is
+            is_unmappable_on_info_panel), (
+        messages.ERR_MSG_TRIPLE_FORMAT.format(
+            False, is_mappable_on_tree_view_item,
+            is_unmappable_on_info_panel))


### PR DESCRIPTION
This PR cover smoke test scenario and verify following items:
 - there is no possibility to unmap snapshot from audit
 - there is no possibility to map some object to snapshot from tree view in scope of audit page