### PR TITLE
GGRC-2442 Reduce time of rendering header

### DIFF
--- a/src/ggrc/assets/javascripts/components/page-header/page-header.js
+++ b/src/ggrc/assets/javascripts/components/page-header/page-header.js
@@ -20,6 +20,21 @@
       showTitles: {
         type: Boolean,
         value: true
+      },
+      model: {
+        get: function () {
+          return this.attr('instance').class;
+        }
+      },
+      instance: {
+        get: function () {
+          return GGRC.page_instance();
+        }
+      },
+      current_user: {
+        get: function () {
+          return GGRC.current_user;
+        }
       }
     },
     showHideTitles: function (element) {

--- a/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
@@ -93,11 +93,10 @@
     },
 
     init_page_header: function () {
-      var that = this;
-      if (this.options.header_view) {
-        can.view(this.options.header_view, this.options, function (frag) {
-          that.element.find('#page-header').html(frag);
-        });
+      var $pageHeader = this.element.find('#page-header');
+
+      if (this.options.header_view && $pageHeader.length) {
+        $pageHeader.html(can.view(this.options.header_view));
       }
     },
 


### PR DESCRIPTION
Currently rendering of page_header.mustache template takes a lot of time.
Need to reduce this time and avoid the use of construction like:
can.view(template_path, options).then();
because these renders in async mode and lead to performance issues.

**Steps to measure:**
1. Open Chrome's DevTool
2. Go to Performance tab
3. Refresh page
4. See timings on chart:
![1](https://user-images.githubusercontent.com/4737102/27679898-c09b9e5c-5cc2-11e7-94bb-ddc8c25cb972.png)

_Expected result:_ scripting time should decrease
