### PR TITLE
GGRC-2413 Improve logic of 'allow_change_state' flag

### DIFF
--- a/src/ggrc_workflows/models/cycle_task_group_object_task.py
+++ b/src/ggrc_workflows/models/cycle_task_group_object_task.py
@@ -227,7 +227,7 @@ class CycleTaskGroupObjectTask(
 
   @builder.simple_property
   def allow_change_state(self):
-    return self.current_user_wfo_or_assignee()
+    return self.cycle.is_current and self.current_user_wfo_or_assignee()
 
   def current_user_wfo_or_assignee(self):
     """Current user is Workflow owner or Assignee for self."""


### PR DESCRIPTION
In scope of this task, we need to extend the logic of the 'allow_change_state' flag.
Need to add a check that the Cycle (which includes that task) is in active status (Cycle.is_current = true) to avoid extra requests to BE from FE side.