### PR TITLE
QUICK-FIX Core global redesign of equal procedure to comparing expected and actual result (objects) and extending of the test suite according new model.

### DIFF
--- a/test/selenium/src/lib/constants/__init__.py
+++ b/test/selenium/src/lib/constants/__init__.py
@@ -1,11 +1,12 @@
 # Copyright (C) 2017 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 """Import constants modules."""
+# flake8: noqa
 
 
 from lib.constants import (
   cls_name,
-  element,  # flake8: noqa
+  element,
   log,
   path,
   locator,

--- a/test/selenium/src/lib/constants/element.py
+++ b/test/selenium/src/lib/constants/element.py
@@ -120,8 +120,7 @@ class Common(object):
   TRUE = "true"
   FALSE = "false"
   # fictional elements (need to convert UI attrs to Entities attrs)
-  CAS_HEADERS = "CAs Headers"
-  CAS_VALUES = "CAs Values"
+  CAS = "CAs"
 
 
 class Base(object):
@@ -165,8 +164,11 @@ class TransformationSetVisibleFields(CommonModalSetVisibleFields):
   AUDIT_LEAD = "Internal Audit Lead"
   MANAGER = "Manager"
   PRIMARY_CONTACT = roles.PRIMARY_CONTACT
-  CREATORS = "Creators"
   MAPPED_OBJECTS = "Mapped Objects"
+  REVIEW_STATE = "Review State"
+  CREATORS = "Creators"
+  ASSIGNEES = "Assignees"
+  VERIFIERS = "Verifiers"
 
 
 class CommonProgram(Common):
@@ -215,6 +217,10 @@ class CommonAssessment(Common):
   STATE = Base.STATE
   CREATORS_ = "Creator(s) *"
   CREATORS = TransformationSetVisibleFields.CREATORS
+  ASSIGNEES_ = "Assignee(s) *"
+  ASSIGNEES = TransformationSetVisibleFields.ASSIGNEES
+  VERIFIERS_ = "Verifier(s)"
+  VERIFIERS = TransformationSetVisibleFields.ASSIGNEES
   MAPPED_OBJECTS = TransformationSetVisibleFields.MAPPED_OBJECTS
   VERIFIED = TransformationSetVisibleFields.VERIFIED
 
@@ -308,6 +314,8 @@ class AssessmentModalSetVisibleFields(CommonModalSetVisibleFields):
  """
   MODAL_HEADER = CommonModalSetVisibleFields.MODAL_HEADER_FORMAT.format(
       CommonAssessment.ASMT)
+  CREATORS = TransformationSetVisibleFields.CREATORS
+  ASSIGNEES = TransformationSetVisibleFields.ASSIGNEES
   VERIFIED = TransformationSetVisibleFields.VERIFIED
   CONCLUSION_DESIGN = "Conclusion: Design"
   CONCLUSION_OPERATION = "Conclusion: Operation"
@@ -317,8 +325,8 @@ class AssessmentModalSetVisibleFields(CommonModalSetVisibleFields):
   REFERENCE_URL = Base.REFERENCE_URL
   TYPE = Base.TYPE
   DEFAULT_SET_FIELDS = (
-      CommonModalSetVisibleFields.TITLE, CommonModalSetVisibleFields.CODE,
-      CommonModalSetVisibleFields.STATE, VERIFIED,
+      CommonModalSetVisibleFields.TITLE, CommonModalSetVisibleFields.STATE,
+      VERIFIED, CommonModalSetVisibleFields.CODE, CREATORS, ASSIGNEES,
       CommonModalSetVisibleFields.LAST_UPDATED)
 
 
@@ -329,6 +337,7 @@ class ControlModalSetVisibleFields(CommonModalSetVisibleFields):
   # pylint: disable=too-many-instance-attributes
   MODAL_HEADER = CommonModalSetVisibleFields.MODAL_HEADER_FORMAT.format(
       CommonControl.CONTROL)
+  REVIEW_STATE = TransformationSetVisibleFields.REVIEW_STATE
   ADMIN = TransformationSetVisibleFields.ADMIN
   URL = Base.URL
   REFERENCE_URL = Base.REFERENCE_URL
@@ -343,7 +352,8 @@ class ControlModalSetVisibleFields(CommonModalSetVisibleFields):
   CATEGORIES = "Categories"
   DEFAULT_SET_FIELDS = (
       CommonModalSetVisibleFields.TITLE, ADMIN,
-      CommonModalSetVisibleFields.CODE, CommonModalSetVisibleFields.STATE)
+      CommonModalSetVisibleFields.CODE, CommonModalSetVisibleFields.STATE,
+      CommonModalSetVisibleFields.LAST_UPDATED, REVIEW_STATE)
 
 
 class IssueModalSetVisibleFields(CommonModalSetVisibleFields):
@@ -354,7 +364,7 @@ class IssueModalSetVisibleFields(CommonModalSetVisibleFields):
   MODAL_HEADER = CommonModalSetVisibleFields.MODAL_HEADER_FORMAT.format(
       CommonIssue.ISSUE)
   ADMIN = TransformationSetVisibleFields.ADMIN
-  REVIEW_STATE = "Review State"
+  REVIEW_STATE = TransformationSetVisibleFields.REVIEW_STATE
   URL = Base.URL
   REFERENCE_URL = Base.REFERENCE_URL
   DEFAULT_SET_FIELDS = (
@@ -370,7 +380,7 @@ class ProgramModalSetVisibleFields(CommonModalSetVisibleFields):
   # pylint: disable=too-many-instance-attributes
   MODAL_HEADER = CommonModalSetVisibleFields.MODAL_HEADER_FORMAT.format(
       CommonProgram.PROGRAM)
-  REVIEW_STATE = "Review State"
+  REVIEW_STATE = TransformationSetVisibleFields.REVIEW_STATE
   MANAGER = CommonProgram.MANAGER
   URL = Base.URL
   REFERENCE_URL = Base.REFERENCE_URL
@@ -378,7 +388,8 @@ class ProgramModalSetVisibleFields(CommonModalSetVisibleFields):
   STOP_DATE = Base.STOP_DATE
   DEFAULT_SET_FIELDS = (
       CommonModalSetVisibleFields.TITLE, CommonModalSetVisibleFields.CODE,
-      CommonModalSetVisibleFields.STATE, MANAGER)
+      CommonModalSetVisibleFields.STATE,
+      CommonModalSetVisibleFields.LAST_UPDATED, REVIEW_STATE)
 
 
 class MappingStatusAttrs(namedtuple('_MappingStatusAttrs',

--- a/test/selenium/src/lib/constants/locator.py
+++ b/test/selenium/src/lib/constants/locator.py
@@ -50,6 +50,7 @@ class Login(object):
 class PageHeader(object):
   """Locators for Dashboard header."""
   _CONTENT = ".header-content"
+  SRC_OBJ_TITLE = (By.CSS_SELECTOR, _CONTENT + " .entity-name")
   TOGGLE_LHN = (By.CSS_SELECTOR, ".lhn-trigger")
   BUTTON_DASHBOARD = (
       By.CSS_SELECTOR, _CONTENT + ' .to-my-work[href="/dashboard"]')

--- a/test/selenium/src/lib/dynamic_fixtures.py
+++ b/test/selenium/src/lib/dynamic_fixtures.py
@@ -49,6 +49,7 @@ def _new_objs_rest(obj_name, obj_count, has_cas=False, factory_params=None):
     and list extra attributes.
     Return: [lib.entities.entity.*Entity, ...]
     """
+    # pylint: disable=no-else-return
     if extra_attrs[0].type == objects.get_singular(objects.CUSTOM_ATTRIBUTES):
       if name == objects.ASSESSMENT_TEMPLATES:
         return factory.get_cls_rest_service(object_name=name)().create_objs(
@@ -61,7 +62,7 @@ def _new_objs_rest(obj_name, obj_count, has_cas=False, factory_params=None):
         return factory.get_cls_rest_service(object_name=name)().create_objs(
             count=1, factory_params=factory_params,
             custom_attributes=CustomAttributeDefinitionsFactory().
-            generate_ca_values(list_ca_objs=extra_attrs))
+            generate_ca_values(list_ca_def_objs=extra_attrs))
     else:
       return ([factory.get_cls_rest_service(object_name=name)().
               create_objs(count=1, factory_params=factory_params,
@@ -76,16 +77,17 @@ def _new_objs_rest(obj_name, obj_count, has_cas=False, factory_params=None):
                   objects.ISSUES):
     parent_obj_name = (objects.get_singular(objects.AUDITS) if obj_count == 1
                        else objects.AUDITS)
-  if (has_cas and obj_name in objects.ALL_OBJS
-      and obj_name not in objects.ASSESSMENT_TEMPLATES):
+  if (has_cas and obj_name in objects.ALL_OBJS and
+          obj_name not in objects.ASSESSMENT_TEMPLATES):
     parent_obj_name = "cas_for_" + obj_name
   if parent_obj_name:
     parent_objs = _get_fixture_from_dict_fixtures(
         fixture="new_{}_rest".format(parent_obj_name))
     if has_cas and obj_name in objects.ASSESSMENT_TEMPLATES:
-      parent_objs = ([CustomAttributeDefinitionsFactory().create(
-          attribute_type=ca_type, definition_type="") for
-                         ca_type in _list_cas_types] + parent_objs)
+      parent_objs = (
+          [CustomAttributeDefinitionsFactory().create(
+              attribute_type=ca_type, definition_type="") for
+              ca_type in _list_cas_types] + parent_objs)
     objs = create_objs_rest_used_exta_arrts(
         name=obj_name, factory_params=factory_params, extra_attrs=parent_objs)
   else:
@@ -94,13 +96,14 @@ def _new_objs_rest(obj_name, obj_count, has_cas=False, factory_params=None):
   return objs
 
 
-def generate_common_fixtures(*fixtures):  # flake8: noqa
+def generate_common_fixtures(*fixtures):  # noqa: ignore=C901
   """Generate, run and return of results for common dynamic fixtures according
   to tuple of fixtures names and used if exist 'web_driver' fixture for UI.
   Examples: fixtures = ('new_program_rest', 'new_controls_rest',
   'map_new_program_rest_to_new_controls_rest', 'new_audit_rest',
   'new_cas_for_controls').
   """
+  # pylint: disable=superfluous-parens
   global dict_executed_fixtures
   _list_cas_types = element.AdminWidgetCustomAttributes.ALL_CA_TYPES
 
@@ -115,11 +118,12 @@ def generate_common_fixtures(*fixtures):  # flake8: noqa
           attribute_type=ca_type,
           definition_type=objects.get_singular(fixture_params))
           for ca_type in _list_cas_types]
-      new_objs = [_new_objs_rest(obj_name=obj_name, obj_count=1,
-                                 factory_params=dict(
-          attribute_type=ca.attribute_type, definition_type=ca.definition_type,
-          multi_choice_options=ca.multi_choice_options))[0]
-                  for ca in factory_cas_for_objs]
+      new_objs = [
+          _new_objs_rest(obj_name=obj_name, obj_count=1, factory_params=dict(
+              attribute_type=ca.attribute_type,
+              definition_type=ca.definition_type,
+              multi_choice_options=ca.multi_choice_options))[0]
+          for ca in factory_cas_for_objs]
     else:
       fixture_params = fixture.replace("new_", "").replace("_rest", "")
       has_cas = False
@@ -193,17 +197,17 @@ def generate_common_fixtures(*fixtures):  # flake8: noqa
       has_cas = True
       obj_name = objects.get_plural(obj_name.replace("_with_cas", ""))
       parent_objs = _get_fixture_from_dict_fixtures(
-        fixture="new_{}_rest".format("cas_for_" + obj_name))
+          fixture="new_{}_rest".format("cas_for_" + obj_name))
     if objs_to_update:
       if has_cas and parent_objs:
         updated_objs = (
-          factory.get_cls_rest_service(object_name=obj_name)().update_objs(
-            objs=objs_to_update,
-            custom_attributes=CustomAttributeDefinitionsFactory().
-              generate_ca_values(list_ca_objs=parent_objs)))
+            factory.get_cls_rest_service(object_name=obj_name)().update_objs(
+                objs=objs_to_update,
+                custom_attributes=CustomAttributeDefinitionsFactory().
+                generate_ca_values(list_ca_def_objs=parent_objs)))
       else:
         updated_objs = factory.get_cls_rest_service(
-          object_name=obj_name)().update_objs(objs=objs_to_update)
+            object_name=obj_name)().update_objs(objs=objs_to_update)
       return updated_objs
 
   def delete_rest_fixture(fixture):

--- a/test/selenium/src/lib/entities/entities_factory.py
+++ b/test/selenium/src/lib/entities/entities_factory.py
@@ -5,14 +5,14 @@
 # pylint: disable=invalid-name
 # pylint: disable=redefined-builtin
 
-
 import copy
 import random
 
-import re
 from lib.constants import element, objects, roles, url as const_url
 from lib.constants.element import AdminWidgetCustomAttributes
-from lib.entities import entity
+from lib.entities.entity import (
+    Entity, PersonEntity, CustomAttributeEntity, ProgramEntity, ControlEntity,
+    AuditEntity, AssessmentTemplateEntity, AssessmentEntity, IssueEntity)
 from lib.utils import string_utils
 from lib.utils.string_utils import (random_list_strings, random_string,
                                     random_uuid)
@@ -21,51 +21,223 @@ from lib.utils.string_utils import (random_list_strings, random_string,
 class EntitiesFactory(object):
   """Common factory class for entities."""
   # pylint: disable=too-few-public-methods
-  obj_person = objects.get_singular(objects.PEOPLE, title=True)
-  obj_program = objects.get_singular(objects.PROGRAMS, title=True)
-  obj_control = objects.get_singular(objects.CONTROLS, title=True)
-  obj_audit = objects.get_singular(objects.AUDITS, title=True)
-  obj_asmt_tmpl = objects.get_singular(objects.ASSESSMENT_TEMPLATES,
-                                       title=True)
-  obj_asmt = objects.get_singular(objects.ASSESSMENTS, title=True)
-  obj_issue = objects.get_singular(objects.ISSUES, title=True)
-  obj_ca = objects.get_singular(objects.CUSTOM_ATTRIBUTES)
+  obj_person = unicode(objects.get_singular(objects.PEOPLE, title=True))
+  obj_program = unicode(objects.get_singular(objects.PROGRAMS, title=True))
+  obj_control = unicode(objects.get_singular(objects.CONTROLS, title=True))
+  obj_audit = unicode(objects.get_singular(objects.AUDITS, title=True))
+  obj_asmt_tmpl = unicode(objects.get_singular(
+      objects.ASSESSMENT_TEMPLATES, title=True))
+  obj_asmt = unicode(objects.get_singular(objects.ASSESSMENTS, title=True))
+  obj_issue = unicode(objects.get_singular(objects.ISSUES, title=True))
+  obj_ca = unicode(objects.get_singular(objects.CUSTOM_ATTRIBUTES))
 
-  all_objs_attrs_names = tuple(entity.Entity().attrs_names_all_entities())
+  types_of_values_ui_like_attrs = (str, unicode, int)
+  all_objs_attrs_names = Entity().get_attrs_names_for_entities()
 
   @classmethod
-  def update_obj_attrs_values(cls, obj, attrs_names=all_objs_attrs_names,
-                              **arguments):
-    """Update object's (obj) attributes values according to list of
-    unique possible objects' names and dictionary of arguments (key = value).
+  def convert_obj_repr_from_obj_to_dict(cls, obj):
+    """Convert object or list of objects from object representation
+    'obj.attr_name' = 'attr_value' to dictionary or list of dictionaries with
+    items {'attr_name': 'attr_value'}.
     """
-    # pylint: disable=expression-not-assigned
-    [setattr(obj, attr_name, arguments[attr_name]) for
-        attr_name in attrs_names if arguments.get(attr_name)]
+    if obj:
+      if isinstance(obj, list):
+        if (all(not isinstance(_, dict) and
+                not isinstance(_, cls.types_of_values_ui_like_attrs) and
+                _ for _ in obj)):
+          obj = [_.__dict__ for _ in obj]
+      else:
+        if (not isinstance(obj, dict) and
+                not isinstance(obj, cls.types_of_values_ui_like_attrs)):
+          obj = obj.__dict__
+      return obj
+
+  @classmethod  # noqa: ignore=C901
+  def convert_obj_repr_from_rest_to_ui(cls, obj):
+    """Convert object's attributes values from REST like
+    (dict or list of dict) representation to UI like with unicode.
+    Examples:
+    None to None, u'Ex' to u'Ex', [u'Ex1', u'Ex2', ...] to u'Ex1, Ex2',
+    {'name': u'Ex', ...} to u'Ex',
+    [{'name': u'Ex1', ...}, {'name': u'Ex2', ...}] to u'Ex1, Ex2'
+    """
+    # pylint: disable=too-many-locals
+    def convert_attr_value_from_dict_to_unicode(attr_name, attr_value):
+      """Convert attribute value from dictionary to unicode representation
+      (get value by key from dictionary 'attr_value' where key determine
+      according to 'attr_name').
+      """
+      if isinstance(attr_value, dict):
+        converted_attr_value = attr_value
+        if attr_name in [
+            "contact", "manager", "owners", "assessor", "creator", "verifier",
+            "Assessor", "Creator", "Verifier"
+        ]:
+          converted_attr_value = unicode(attr_value.get("name"))
+        if attr_name in ["custom_attribute_definitions", "program", "audit",
+                         "objects_under_assessment"]:
+          converted_attr_value = (
+              unicode(attr_value.get("title")) if
+              attr_name != "custom_attribute_definitions" else
+              {attr_value.get("id"): attr_value.get("title").upper()}
+          )
+        if attr_name in ["custom_attribute_values"]:
+          converted_attr_value = {attr_value.get("custom_attribute_id"):
+                                  attr_value.get("attribute_value")}
+        return converted_attr_value
+    origin_obj = copy.deepcopy(obj)
+    for obj_attr_name in obj.__dict__.keys():
+      # 'Ex', u'Ex', 1, None to 'Ex', u'Ex', 1, None
+      obj_attr_value = (obj.assignees.get(obj_attr_name.title()) if (
+          obj_attr_name in ["assessor", "creator", "verifier"] and
+          "assignees" in obj.__dict__.keys()) else getattr(obj, obj_attr_name))
+      # u'2017-06-07T16:50:16' to u'06/07/2017'
+      if obj_attr_name == "updated_at" and isinstance(obj_attr_value, unicode):
+        obj_attr_value_as_list = str(obj_attr_value.split("T")[0]).split('-')
+        obj_attr_value = unicode(
+            "/".join(obj_attr_value_as_list[1:] + [obj_attr_value_as_list[0]]))
+      if isinstance(obj_attr_value, dict) and obj_attr_value:
+        # to "assignees" = {"Assessor": [], "Creator": [], "Verifier": []}
+        if obj_attr_name == "assignees":
+          obj_attr_value = {
+              k: ([convert_attr_value_from_dict_to_unicode(k, _v) for _v in v]
+                  if isinstance(v, list) else
+                  convert_attr_value_from_dict_to_unicode(k, v))
+              for k, v in obj_attr_value.iteritems()
+              if k in ["Assessor", "Creator", "Verifier"]}
+        # {'name': u'Ex1', 'type': u'Ex2', ...} to u'Ex1'
+        else:
+          obj_attr_value = convert_attr_value_from_dict_to_unicode(
+              obj_attr_name, obj_attr_value)
+      # [el1, el2, ...] or [{item1}, {item2}, ...] to [u'Ex1, u'Ex2', ...]
+      if (isinstance(obj_attr_value, list) and
+              all(isinstance(item, dict) for item in obj_attr_value)):
+        obj_attr_value = [
+            convert_attr_value_from_dict_to_unicode(obj_attr_name, item) for
+            item in obj_attr_value]
+      setattr(obj, obj_attr_name, obj_attr_value)
+    # merge "custom_attribute_definitions" and "custom_attribute_values"
+    obj_cas_attrs_names = ["custom_attributes", "custom_attribute_definitions",
+                           "custom_attribute_values"]
+    if set(obj_cas_attrs_names).issubset(obj.__dict__.keys()):
+      cas_def = obj.custom_attribute_definitions
+      cas_val = obj.custom_attribute_values
+      # form CAs values of CAs definitions exist but CAs values not, or if CAs
+      # definitions have different then CAs values lengths
+      if cas_def and (not cas_val or (isinstance(cas_def and cas_val, list) and
+                                      len(cas_def) != len(cas_val))):
+        cas_val_dicts_keys = ([_.keys()[0] for _ in cas_val] if
+                              isinstance(cas_val, list) else [None])
+        _cas_val = [
+            {k: v} for k, v in
+            CustomAttributeDefinitionsFactory().generate_ca_values(
+                list_ca_def_objs=origin_obj.custom_attribute_definitions,
+                is_none_values=True).iteritems()
+            if k not in cas_val_dicts_keys]
+        cas_val = _cas_val if not cas_val else cas_val + _cas_val
+      cas_def_dict = (
+          dict([_def.iteritems().next() for _def in cas_def]) if
+          (isinstance(cas_def, list) and
+           all(isinstance(_def, dict) for _def in cas_def)) else {None: None})
+      cas_val_dict = (
+          dict([_val.iteritems().next() for _val in cas_val]) if
+          (isinstance(cas_def, list) and
+           all(isinstance(_def, dict) for _def in cas_def)) else {None: None})
+      cas = string_utils.merge_dicts_by_same_key(cas_def_dict, cas_val_dict)
+      setattr(obj, "custom_attributes", cas)
     return obj
 
   @classmethod
+  def convert_objs_repr_from_rest_to_ui(cls, objs):
+    """Convert objects's attributes values from REST like
+    (dict or list of dict) representation to UI like with unicode.
+    'objs' can be list of objects to convert or one object.
+    """
+    return ([cls.convert_obj_repr_from_rest_to_ui(obj) for obj in objs] if
+            isinstance(objs, list) else
+            cls.convert_obj_repr_from_rest_to_ui(objs))
+
+  @classmethod
+  def update_objs_attrs_values_by_entered_data(
+      cls, objs, is_replace_attrs_values=True, is_allow_none_values=True,
+      **arguments
+  ):
+    """Update object or list of objects ('objs') attributes values by manually
+    entered data if attribute name exist in 'attrs_names' witch equal to
+    'all_objs_attrs_names' according to dictionary of attributes and values
+    '**arguments'. If 'is_replace_attrs_values' then replace attributes values,
+    if not 'is_replace_attrs_values' then update (merge) attributes values
+    witch should be lists. If 'is_allow_none_values' then allow to set None
+    object's attributes values, and vice versa.
+    """
+    # pylint: disable=expression-not-assigned
+    def update_obj_attrs_values(obj, is_replace_attrs_values,
+                                is_allow_none_values, **arguments):
+      """Update object's attributes values."""
+      for obj_attr_name in arguments:
+        if obj_attr_name in obj.__dict__.keys():
+          condition = (True if is_allow_none_values else
+                       arguments.get(obj_attr_name))
+          if condition:
+            obj_attr_value = cls.convert_obj_repr_from_obj_to_dict(
+                arguments.get(obj_attr_name))
+            if not is_replace_attrs_values:
+              origin_obj_attr_value = getattr(obj, obj_attr_name)
+              obj_attr_value = (
+                  dict(origin_obj_attr_value.items() + obj_attr_value.items())
+                  if obj_attr_name == "custom_attributes" else
+                  string_utils.convert_to_list(origin_obj_attr_value) +
+                  string_utils.convert_to_list(obj_attr_value))
+            setattr(obj, obj_attr_name, obj_attr_value)
+      return obj
+    if objs and arguments:
+      return [update_obj_attrs_values(
+          obj, is_replace_attrs_values, is_allow_none_values, **arguments) for
+          obj in objs] if isinstance(objs, list) else update_obj_attrs_values(
+          objs, is_replace_attrs_values, is_allow_none_values, **arguments)
+
+  @classmethod
+  def filter_objs_attrs(cls, objs, attrs_to_include):
+    """Make objects's copy and filter objects's attributes (delete attributes
+    from objects witch not in list'attrs_to_include').
+    'objs' can be list of objects or object.
+    """
+    # pylint: disable=expression-not-assigned
+    def filter_obj_attrs(obj, attrs_to_include):
+      """Filter one object's attributes."""
+      obj = copy.deepcopy(obj)
+      [delattr(obj, obj_attr) for obj_attr in obj.__dict__.keys()
+       if obj_attr not in attrs_to_include]
+      return obj
+    return ([filter_obj_attrs(obj, attrs_to_include) for obj in objs] if
+            isinstance(objs, list) else
+            filter_obj_attrs(objs, attrs_to_include))
+
+  @classmethod
   def generate_string(cls, first_part):
-    """Generate string according object type and random data."""
+    """Generate string in unicode format according object type and random data.
+    """
     special_chars = string_utils.SPECIAL
-    return "{first_part}_{uuid}_{rand_str}".format(
+    return unicode("{first_part}_{uuid}_{rand_str}".format(
         first_part=first_part, uuid=random_uuid(),
-        rand_str=random_string(size=len(special_chars), chars=special_chars))
+        rand_str=random_string(size=len(special_chars), chars=special_chars)))
 
   @classmethod
   def generate_slug(cls):
-    """Generate slug according str part and random data."""
-    return "{slug}".format(slug=random_uuid())
+    """Generate slug in unicode format according str part and random data."""
+    return unicode("{slug}".format(slug=random_uuid()))
 
   @classmethod
   def generate_email(cls, domain=const_url.DEFAULT_EMAIL_DOMAIN):
-    """Generate email according domain."""
-    return "{mail_name}@{domain}".format(
-        mail_name=random_uuid(), domain=domain)
+    """Generate email in unicode format according to domain."""
+    return unicode("{mail_name}@{domain}".format(
+        mail_name=random_uuid(), domain=domain))
 
 
-class ObjectOwnersFactory(EntitiesFactory):
+class ObjectPersonsFactory(EntitiesFactory):
   """Factory class for Persons entities."""
+
+  obj_attrs_names = Entity().get_attrs_names_for_entities(PersonEntity)
 
   @classmethod
   def default(cls):
@@ -77,40 +249,46 @@ class ObjectOwnersFactory(EntitiesFactory):
   @classmethod
   def create(cls, type=None, id=None, name=None, href=None, url=None,
              email=None, company=None, system_wide_role=None, updated_at=None,
-             custom_attribute_definitions=None,
-             custom_attribute_values=None):
+             custom_attribute_definitions=None, custom_attribute_values=None,
+             custom_attributes=None):
     """Create Person object.
     Random values will be used for name.
     Predictable values will be used for type, email and system_wide_role.
     """
     person_entity = cls._create_random_person()
-    person_entity = cls.update_obj_attrs_values(
-        obj=person_entity, type=type, id=id, name=name, href=href, url=url,
-        email=email, company=company, system_wide_role=system_wide_role,
-        updated_at=updated_at,
+    person_entity = cls.update_objs_attrs_values_by_entered_data(
+        objs=person_entity, is_allow_none_values=False, type=type, id=id,
+        name=name, href=href, url=url, email=email, company=company,
+        system_wide_role=system_wide_role, updated_at=updated_at,
         custom_attribute_definitions=custom_attribute_definitions,
-        custom_attribute_values=custom_attribute_values)
+        custom_attribute_values=custom_attribute_values,
+        custom_attributes=custom_attributes)
     return person_entity
 
   @classmethod
   def _create_random_person(cls):
     """Create Person entity with randomly filled fields."""
-    random_person = entity.PersonEntity()
+    random_person = PersonEntity()
     random_person.type = cls.obj_person
     random_person.name = cls.generate_string(cls.obj_person)
     random_person.email = cls.generate_email()
-    random_person.system_wide_role = roles.SUPERUSER
+    random_person.system_wide_role = unicode(roles.SUPERUSER)
     return random_person
 
 
 class CustomAttributeDefinitionsFactory(EntitiesFactory):
-  """Factory class for  entities."""
+  """Factory class for entities."""
+
+  obj_attrs_names = Entity().get_attrs_names_for_entities(
+      CustomAttributeEntity)
 
   @classmethod
-  def generate_ca_values(cls, list_ca_objs):
-    """Generate dictionary of CA random values from exist list CA objects
-    according to CA 'id', 'attribute_type' and 'multi_choice_options' for
-    Dropdown. Return dictionary of CA items that ready to use via REST API:
+  def generate_ca_values(cls, list_ca_def_objs, is_none_values=False):
+    """Generate dictionary of CA random values from exist list CA definitions
+    objects according to CA 'id', 'attribute_type' and 'multi_choice_options'
+    for Dropdown. Return dictionary of CA items that ready to use via REST API:
+    If 'is_none_values' then generate None like CA values according to CA
+    definitions types.
     Example:
     list_ca_objs = [{'attribute_type': 'Text', 'id': 1},
     {'attribute_type': 'Dropdown', 'id': 2, 'multi_choice_options': 'a,b,c'}]
@@ -120,23 +298,31 @@ class CustomAttributeDefinitionsFactory(EntitiesFactory):
       """Generate CA value according to CA 'id', 'attribute_type' and
       'multi_choice_options' for Dropdown.
       """
-      val = {}
-      ca = ca.__dict__
-      if ca.get("attribute_type") in (AdminWidgetCustomAttributes.TEXT,
-                                      AdminWidgetCustomAttributes.RICH_TEXT):
-        val = {ca["id"]: cls.generate_string(ca["attribute_type"])}
-      if ca.get("attribute_type") == AdminWidgetCustomAttributes.DATE:
-        val = {ca["id"]: str(ca["created_at"][:10])}
-      if ca.get("attribute_type") == "Checkbox":
-        val = {ca["id"]: random.choice((True, False))}
-      if ca.get("attribute_type") == "Dropdown":
-        val = {ca["id"]: str(
-            random.choice(ca["multi_choice_options"].split(",")))}
-      if ca.get("attribute_type") == "Map:Person":
-        val = {ca["id"]: ":".join([str(ca["modified_by"]["type"]),
-                                   str(ca["modified_by"]["id"])])}
-      return val
-    return {k: v for _ in [generate_ca_value(ca) for ca in list_ca_objs]
+      if not isinstance(ca, dict):
+        ca = ca.__dict__
+      ca_attr_type = ca.get("attribute_type")
+      ca_value = None
+      if ca_attr_type in AdminWidgetCustomAttributes.ALL_CA_TYPES:
+        if not is_none_values:
+          if ca_attr_type in (AdminWidgetCustomAttributes.TEXT,
+                              AdminWidgetCustomAttributes.RICH_TEXT):
+            ca_value = cls.generate_string(ca_attr_type)
+          if ca_attr_type == AdminWidgetCustomAttributes.DATE:
+            ca_value = unicode(ca["created_at"][:10])
+          if ca_attr_type == AdminWidgetCustomAttributes.CHECKBOX:
+            ca_value = random.choice((True, False))
+          if ca_attr_type == AdminWidgetCustomAttributes.DROPDOWN:
+            ca_value = unicode(
+                random.choice(ca["multi_choice_options"].split(",")))
+          if ca_attr_type == AdminWidgetCustomAttributes.PERSON:
+            ca_value = ":".join([unicode(ca["modified_by"]["type"]),
+                                 unicode(ca["modified_by"]["id"])])
+        else:
+          ca_value = (
+              None if ca_attr_type != AdminWidgetCustomAttributes.CHECKBOX
+              else u"0")
+      return {ca["id"]: ca_value}
+    return {k: v for _ in [generate_ca_value(ca) for ca in list_ca_def_objs]
             for k, v in _.items()}
 
   @classmethod
@@ -157,7 +343,8 @@ class CustomAttributeDefinitionsFactory(EntitiesFactory):
   @classmethod
   def create(cls, title=None, id=None, href=None, type=None,
              definition_type=None, attribute_type=None, helptext=None,
-             placeholder=None, mandatory=None, multi_choice_options=None):
+             placeholder=None, mandatory=None, multi_choice_options=None,
+             updated_at=None, modified_by=None):
     """Create Custom Attribute object. CA object attribute 'definition_type'
     is used as default for REST operations e.g. 'risk_assessment', for UI
     operations need convert to normal form used method objects.get_normal_form
@@ -167,24 +354,26 @@ class CustomAttributeDefinitionsFactory(EntitiesFactory):
     """
     ca_entity = cls._create_random_ca()
     ca_entity = cls._update_ca_attrs_values(
-        obj=ca_entity, title=title, id=id, href=href, type=type,
-        definition_type=definition_type, attribute_type=attribute_type,
-        helptext=helptext, placeholder=placeholder, mandatory=mandatory,
-        multi_choice_options=multi_choice_options)
+        obj=ca_entity, is_allow_none_values=False, title=title, id=id,
+        href=href, type=type, definition_type=definition_type,
+        attribute_type=attribute_type, helptext=helptext,
+        placeholder=placeholder, mandatory=mandatory,
+        multi_choice_options=multi_choice_options, updated_at=updated_at,
+        modified_by=modified_by)
     return ca_entity
 
   @classmethod
   def _create_random_ca(cls):
     """Create CustomAttribute entity with randomly filled fields."""
-    random_ca = entity.CustomAttributeEntity()
+    random_ca = CustomAttributeEntity()
     random_ca.type = cls.obj_ca
-    random_ca.attribute_type = random.choice(
-        AdminWidgetCustomAttributes.ALL_CA_TYPES)
+    random_ca.attribute_type = unicode(random.choice(
+        AdminWidgetCustomAttributes.ALL_CA_TYPES))
     random_ca.title = cls.generate_string(random_ca.attribute_type)
     if random_ca.attribute_type == AdminWidgetCustomAttributes.DROPDOWN:
       random_ca.multi_choice_options = random_list_strings()
-    random_ca.definition_type = objects.get_singular(
-        random.choice(objects.ALL_CA_OBJS))
+    random_ca.definition_type = unicode(objects.get_singular(
+        random.choice(objects.ALL_CA_OBJS)))
     random_ca.mandatory = False
     return random_ca
 
@@ -218,184 +407,190 @@ class CustomAttributeDefinitionsFactory(EntitiesFactory):
             AdminWidgetCustomAttributes.DROPDOWN and not
             obj.multi_choice_options):
       obj.multi_choice_options = random_list_strings()
-    return cls.update_obj_attrs_values(obj=obj, **arguments)
+    return cls.update_objs_attrs_values_by_entered_data(objs=obj, **arguments)
 
 
 class ProgramsFactory(EntitiesFactory):
   """Factory class for Programs entities."""
+  # pylint: disable=too-many-locals
+
+  obj_attrs_names = Entity().get_attrs_names_for_entities(ProgramEntity)
 
   @classmethod
   def create_empty(cls):
     """Create blank Program object."""
-    empty_program = entity.ProgramEntity()
+    empty_program = ProgramEntity()
     empty_program.type = cls.obj_program
+    empty_program.custom_attributes = {None: None}
     return empty_program
 
   @classmethod
   def create(cls, type=None, id=None, title=None, href=None, url=None,
              slug=None, status=None, manager=None, contact=None,
-             secondary_contact=None, updated_at=None,
-             custom_attribute_definitions=None, custom_attribute_values=None):
+             secondary_contact=None, updated_at=None, os_state=None,
+             custom_attribute_definitions=None, custom_attribute_values=None,
+             custom_attributes=None):
     """Create Program object.
     Random values will be used for title and slug.
     Predictable values will be used for type, status, manager, contact.
     """
     program_entity = cls._create_random_program()
-    program_entity = cls.update_obj_attrs_values(
-        obj=program_entity, type=type, id=id, title=title, href=href, url=url,
-        slug=slug, status=status, manager=manager, contact=contact,
-        secondary_contact=secondary_contact, updated_at=updated_at,
+    program_entity = cls.update_objs_attrs_values_by_entered_data(
+        objs=program_entity, is_allow_none_values=False, type=type, id=id,
+        title=title, href=href, url=url, slug=slug, status=status,
+        manager=manager, contact=contact, secondary_contact=secondary_contact,
+        updated_at=updated_at, os_state=os_state,
         custom_attribute_definitions=custom_attribute_definitions,
-        custom_attribute_values=custom_attribute_values)
+        custom_attribute_values=custom_attribute_values,
+        custom_attributes=custom_attributes)
     return program_entity
 
   @classmethod
   def _create_random_program(cls):
     """Create Program entity with randomly and predictably filled fields."""
-    random_program = entity.ProgramEntity()
+    random_program = ProgramEntity()
     random_program.type = cls.obj_program
     random_program.title = cls.generate_string(cls.obj_program)
     random_program.slug = cls.generate_slug()
-    random_program.status = element.ObjectStates.DRAFT
-    random_program.manager = ObjectOwnersFactory().default().__dict__
-    random_program.contact = ObjectOwnersFactory().default().__dict__
+    random_program.status = unicode(element.ObjectStates.DRAFT)
+    random_program.manager = ObjectPersonsFactory().default().__dict__
+    random_program.contact = ObjectPersonsFactory().default().__dict__
     return random_program
 
 
 class ControlsFactory(EntitiesFactory):
   """Factory class for Controls entities."""
+  # pylint: disable=too-many-locals
+
+  obj_attrs_names = Entity().get_attrs_names_for_entities(ControlEntity)
 
   @classmethod
   def create_empty(cls):
     """Create blank Control object."""
-    empty_control = entity.ControlEntity()
+    empty_control = ControlEntity()
     empty_control.type = cls.obj_control
+    empty_control.custom_attributes = {None: None}
     return empty_control
 
   @classmethod
   def create(cls, type=None, id=None, title=None, href=None, url=None,
              slug=None, status=None, owners=None, contact=None,
-             secondary_contact=None, updated_at=None,
-             custom_attribute_definitions=None, custom_attribute_values=None):
+             secondary_contact=None, updated_at=None, os_state=None,
+             custom_attribute_definitions=None, custom_attribute_values=None,
+             custom_attributes=None):
     """Create Control object.
     Random values will be used for title and slug.
     Predictable values will be used for type, status, owners and contact.
     """
     control_entity = cls._create_random_control()
-    control_entity = cls.update_obj_attrs_values(
-        obj=control_entity, type=type, id=id, title=title, href=href, url=url,
-        slug=slug, status=status, owners=owners, contact=contact,
-        secondary_contact=secondary_contact, updated_at=updated_at,
+    control_entity = cls.update_objs_attrs_values_by_entered_data(
+        objs=control_entity, is_allow_none_values=False, type=type, id=id,
+        title=title, href=href, url=url, slug=slug, status=status,
+        owners=owners, contact=contact, secondary_contact=secondary_contact,
+        updated_at=updated_at, os_state=os_state,
         custom_attribute_definitions=custom_attribute_definitions,
-        custom_attribute_values=custom_attribute_values)
+        custom_attribute_values=custom_attribute_values,
+        custom_attributes=custom_attributes)
     return control_entity
 
   @classmethod
   def _create_random_control(cls):
     """Create Control entity with randomly and predictably filled fields."""
-    random_control = entity.ControlEntity()
+    random_control = ControlEntity()
     random_control.type = cls.obj_control
     random_control.title = cls.generate_string(cls.obj_control)
     random_control.slug = cls.generate_slug()
-    random_control.status = element.ObjectStates.DRAFT
-    random_control.contact = ObjectOwnersFactory().default().__dict__
-    random_control.owners = [ObjectOwnersFactory().default().__dict__]
+    random_control.status = unicode(element.ObjectStates.DRAFT)
+    random_control.contact = ObjectPersonsFactory().default().__dict__
+    random_control.owners = [ObjectPersonsFactory().default().__dict__]
     return random_control
 
 
 class AuditsFactory(EntitiesFactory):
   """Factory class for Audit entity."""
 
+  obj_attrs_names = Entity().get_attrs_names_for_entities(AuditEntity)
+
   @classmethod
   def clone(cls, audit, count_to_clone=1):
     """Clone Audit object.
-    Predictable values will be used for type, title, id, href, url, slug.
+    Predictable values will be used for type, title.
     """
     # pylint: disable=anomalous-backslash-in-string
-    from lib.service.rest_service import ObjectsInfoService
-    actual_count_all_audits = ObjectsInfoService().get_total_count_objs(
-        obj_name=objects.get_normal_form(cls.obj_audit, with_space=False))
-    if actual_count_all_audits == audit.id:
-      return [
-          cls.update_obj_attrs_values(
-              obj=copy.deepcopy(audit), id=audit.id + num,
-              title=audit.title + " - copy " + str(num),
-              href=re.sub("\d+$", str(audit.id + num), audit.href),
-              url=re.sub("\d+$", str(audit.id + num), audit.url),
-              slug=(cls.obj_audit.upper() + "-" + str(audit.id + num))) for
-          num in xrange(1, count_to_clone + 1)]
+    return [cls.update_objs_attrs_values_by_entered_data(
+        objs=copy.deepcopy(audit), title=audit.title + " - copy " + str(num),
+        slug=None, updated_at=None, href=None, url=None, id=None)
+        for num in xrange(1, count_to_clone + 1)]
 
   @classmethod
   def create_empty(cls):
     """Create blank Audit object."""
-    empty_audit = entity.AuditEntity()
+    empty_audit = AuditEntity()
     empty_audit.type = cls.obj_audit
+    empty_audit.custom_attributes = {None: None}
     return empty_audit
 
   @classmethod
   def create(cls, type=None, id=None, title=None, href=None, url=None,
              slug=None, status=None, program=None, contact=None,
              updated_at=None, custom_attribute_definitions=None,
-             custom_attribute_values=None):
+             custom_attribute_values=None, custom_attributes=None):
     """Create Audit object.
     Random values will be used for title and slug.
     Predictable values will be used for type, status, contact.
     """
     audit_entity = cls._create_random_audit()
-    audit_entity = cls.update_obj_attrs_values(
-        obj=audit_entity, type=type, id=id, title=title, href=href, url=url,
-        slug=slug, status=status, program=program, contact=contact,
-        updated_at=updated_at,
+    audit_entity = cls.update_objs_attrs_values_by_entered_data(
+        objs=audit_entity, is_allow_none_values=False, type=type, id=id,
+        title=title, href=href, url=url, slug=slug, status=status,
+        program=program, contact=contact, updated_at=updated_at,
         custom_attribute_definitions=custom_attribute_definitions,
-        custom_attribute_values=custom_attribute_values)
+        custom_attribute_values=custom_attribute_values,
+        custom_attributes=custom_attributes)
     return audit_entity
 
   @classmethod
   def _create_random_audit(cls):
     """Create Audit entity with randomly and predictably filled fields."""
-    random_audit = entity.AuditEntity()
+    random_audit = AuditEntity()
     random_audit.type = cls.obj_audit
     random_audit.title = cls.generate_string(cls.obj_audit)
     random_audit.slug = cls.generate_slug()
-    random_audit.status = element.AuditStates().PLANNED
-    random_audit.contact = ObjectOwnersFactory().default().__dict__
+    random_audit.status = unicode(element.AuditStates().PLANNED)
+    random_audit.contact = ObjectPersonsFactory().default().__dict__
     return random_audit
 
 
 class AssessmentTemplatesFactory(EntitiesFactory):
   """Factory class for Assessment Templates entities."""
 
+  obj_attrs_names = Entity().get_attrs_names_for_entities(
+      AssessmentTemplateEntity)
+
   @classmethod
   def clone(cls, asmt_tmpl, count_to_clone=1):
     """Clone Assessment Template object.
-    Predictable values will be used for type, title, id, href, url, slug.
+    Predictable values will be used for type, title.
     """
     # pylint: disable=anomalous-backslash-in-string
-    from lib.service.rest_service import ObjectsInfoService
-    actual_count_all_asmt_tmpls = ObjectsInfoService().get_total_count_objs(
-        obj_name=objects.get_normal_form(cls.obj_asmt_tmpl, with_space=False))
-    if actual_count_all_asmt_tmpls == asmt_tmpl.id:
-      return [
-          cls.update_obj_attrs_values(
-              obj=copy.deepcopy(asmt_tmpl), id=asmt_tmpl.id + num,
-              href=re.sub("\d+$", str(asmt_tmpl.id + num), asmt_tmpl.href),
-              url=re.sub("\d+$", str(asmt_tmpl.id + num), asmt_tmpl.url),
-              slug=("TEMPLATE-" + str(asmt_tmpl.id + num))) for
-          num in xrange(1, count_to_clone + 1)]
+    return [cls.update_objs_attrs_values_by_entered_data(
+        objs=copy.deepcopy(asmt_tmpl), slug=None, updated_at=None, href=None,
+        url=None, id=None) for _ in xrange(1, count_to_clone + 1)]
 
   @classmethod
   def create_empty(cls):
     """Create blank Assessment Template object."""
-    empty_asmt_tmpl = entity.AssessmentTemplateEntity()
+    empty_asmt_tmpl = AssessmentTemplateEntity()
     empty_asmt_tmpl.type = cls.obj_asmt_tmpl
+    empty_asmt_tmpl.custom_attributes = {None: None}
     return empty_asmt_tmpl
 
   @classmethod
   def create(cls, type=None, id=None, title=None, href=None, url=None,
              slug=None, audit=None, default_people=None, verifiers=None,
              assessors=None, template_object_type=None, updated_at=None,
-             custom_attribute_definitions=None,
-             custom_attribute_values=None):
+             custom_attribute_definitions=None, custom_attribute_values=None,
+             custom_attributes=None):
     """Create Assessment Template object.
     Random values will be used for title and slug.
     Predictable values will be used for type, template_object_type and
@@ -403,13 +598,15 @@ class AssessmentTemplatesFactory(EntitiesFactory):
     """
     # pylint: disable=too-many-locals
     asmt_tmpl_entity = cls._create_random_asmt_tmpl()
-    asmt_tmpl_entity = cls.update_obj_attrs_values(
-        obj=asmt_tmpl_entity, type=type, id=id, title=title, href=href,
-        url=url, slug=slug, audit=audit, default_people=default_people,
-        verifiers=verifiers, assessors=assessors,
-        template_object_type=template_object_type, updated_at=updated_at,
+    asmt_tmpl_entity = cls.update_objs_attrs_values_by_entered_data(
+        objs=asmt_tmpl_entity, is_allow_none_values=False, type=type, id=id,
+        title=title, href=href, url=url, slug=slug, audit=audit,
+        default_people=default_people, verifiers=verifiers,
+        assessors=assessors, template_object_type=template_object_type,
+        updated_at=updated_at,
         custom_attribute_definitions=custom_attribute_definitions,
-        custom_attribute_values=custom_attribute_values)
+        custom_attribute_values=custom_attribute_values,
+        custom_attributes=custom_attributes)
     return asmt_tmpl_entity
 
   @classmethod
@@ -417,52 +614,60 @@ class AssessmentTemplatesFactory(EntitiesFactory):
     """Create Assessment Template entity with randomly and predictably
     filled fields.
     """
-    random_asmt_tmpl = entity.AssessmentTemplateEntity()
+    random_asmt_tmpl = AssessmentTemplateEntity()
     random_asmt_tmpl.type = cls.obj_asmt_tmpl
     random_asmt_tmpl.title = cls.generate_string(cls.obj_asmt_tmpl)
     random_asmt_tmpl.slug = cls.generate_slug()
     random_asmt_tmpl.template_object_type = cls.obj_control.title()
-    random_asmt_tmpl.default_people = {"verifiers": roles.AUDITORS,
-                                       "assessors": roles.AUDIT_LEAD}
+    random_asmt_tmpl.default_people = {"verifiers": unicode(roles.AUDITORS),
+                                       "assessors": unicode(roles.AUDIT_LEAD)}
     return random_asmt_tmpl
 
 
 class AssessmentsFactory(EntitiesFactory):
   """Factory class for Assessments entities."""
 
+  obj_attrs_names = Entity().get_attrs_names_for_entities(AssessmentEntity)
+
   @classmethod
   def generate(cls, objs_under_asmt, audit, asmt_tmpl=None):
-    """Generate Assessment objects, if 'asmt_tmpl' then with
-    Assessment Template, if not 'asmt_tmpl' then without Assessment Template.
-    Predictable values will be used for type, title, slug, audit,
-    objects_under_assessment and custom_attribute_definitions.
+    """Generate Assessment objects according to objects under Assessment,
+    Audit, Assessment Template.
+    If 'asmt_tmpl' then generate with Assessment Template, if not 'asmt_tmpl'
+    then generate without Assessment Template. Slug will not be predicted to
+    avoid of rising errors in case of tests parallel running. Predictable
+    values will be used for type, title, audit, objects_under_assessment
+    custom_attribute_definitions and custom_attribute_values.
     """
     # pylint: disable=too-many-locals
-    from lib.service.rest_service import ObjectsInfoService
-    actual_count_all_asmts = ObjectsInfoService().get_total_count_objs(
-        obj_name=objects.get_normal_form(cls.obj_asmt, with_space=False))
-    ca_def = asmt_tmpl.custom_attribute_definitions if asmt_tmpl else None
-    return [cls.create(
+    cas_def = asmt_tmpl.custom_attribute_definitions if asmt_tmpl and getattr(
+        asmt_tmpl, "custom_attribute_definitions") else None
+    asmts_objs = [cls.create(
         title=obj_under_asmt.title + " assessment for " + audit.title,
-        slug=(cls.obj_asmt.upper() + "-" + str(asmt_number)),
         audit=audit.title, objects_under_assessment=[obj_under_asmt],
-        custom_attribute_definitions=ca_def) for asmt_number, obj_under_asmt in
-        enumerate(objs_under_asmt, start=actual_count_all_asmts + 1)]
+        custom_attribute_definitions=cas_def) for
+        obj_under_asmt in objs_under_asmt]
+    return [
+        cls.update_objs_attrs_values_by_entered_data(objs=asmt_obj, slug=None)
+        for asmt_obj in asmts_objs]
 
   @classmethod
   def create_empty(cls):
     """Create blank Assessment object."""
-    empty_asmt = entity.AssessmentEntity()
+    empty_asmt = AssessmentEntity()
     empty_asmt.type = cls.obj_asmt
     empty_asmt.verified = False
+    empty_asmt.custom_attributes = {None: None}
     return empty_asmt
 
   @classmethod
   def create(cls, type=None, id=None, title=None, href=None, url=None,
              slug=None, status=None, owners=None, audit=None,
-             recipients=None, verified=None, updated_at=None,
-             objects_under_assessment=None, custom_attribute_definitions=None,
-             custom_attribute_values=None):
+             recipients=None, assignees=None, assessor=None, creator=None,
+             verifier=None, verified=None, updated_at=None,
+             objects_under_assessment=None, os_state=None,
+             custom_attribute_definitions=None, custom_attribute_values=None,
+             custom_attributes=None):
     """Create Assessment object.
     Random values will be used for title and slug.
     Predictable values will be used for type, status, recipients,
@@ -470,67 +675,80 @@ class AssessmentsFactory(EntitiesFactory):
     """
     # pylint: disable=too-many-locals
     asmt_entity = cls._create_random_asmt()
-    asmt_entity = cls.update_obj_attrs_values(
-        obj=asmt_entity, type=type, id=id, title=title, href=href, url=url,
-        slug=slug, status=status, owners=owners, audit=audit,
-        recipients=recipients, verified=verified, updated_at=updated_at,
-        objects_under_assessment=objects_under_assessment,
+    asmt_entity = cls.update_objs_attrs_values_by_entered_data(
+        objs=asmt_entity, is_allow_none_values=False, type=type, id=id,
+        title=title, href=href, url=url, slug=slug, status=status,
+        owners=owners, audit=audit, recipients=recipients, assignees=assignees,
+        assessor=assessor, creator=creator, verifier=verifier,
+        verified=verified, updated_at=updated_at,
+        objects_under_assessment=objects_under_assessment, os_state=os_state,
         custom_attribute_definitions=custom_attribute_definitions,
-        custom_attribute_values=custom_attribute_values)
+        custom_attribute_values=custom_attribute_values,
+        custom_attributes=custom_attributes)
     return asmt_entity
 
   @classmethod
   def _create_random_asmt(cls):
     """Create Assessment entity with randomly and predictably filled fields."""
-    random_asmt = entity.AssessmentEntity()
+    random_asmt = AssessmentEntity()
     random_asmt.type = cls.obj_asmt
     random_asmt.title = cls.generate_string(cls.obj_asmt)
     random_asmt.slug = cls.generate_slug()
-    random_asmt.status = element.AssessmentStates.NOT_STARTED
-    random_asmt.recipients = ",".join((roles.ASSESSOR, roles.CREATOR,
-                                       roles.VERIFIER))
+    random_asmt.status = unicode(element.AssessmentStates.NOT_STARTED)
+    random_asmt.recipients = ",".join(
+        (unicode(roles.ASSESSOR), unicode(roles.CREATOR),
+         unicode(roles.VERIFIER)))
     random_asmt.verified = False
-    random_asmt.owners = [ObjectOwnersFactory().default().__dict__]
+    random_asmt.owners = [ObjectPersonsFactory().default().__dict__]
+    random_asmt.assignees = {
+        "Assessor": [ObjectPersonsFactory().default().__dict__],
+        "Creator": [ObjectPersonsFactory().default().__dict__]}
     return random_asmt
 
 
 class IssuesFactory(EntitiesFactory):
   """Factory class for Issues entities."""
 
+  obj_attrs_names = Entity().get_attrs_names_for_entities(IssueEntity)
+
   @classmethod
   def create_empty(cls):
     """Create blank Issue object."""
-    empty_issue = entity.IssueEntity
+    empty_issue = IssueEntity
     empty_issue.type = cls.obj_issue
+    empty_issue.custom_attributes = {None: None}
     return empty_issue
 
   @classmethod
   def create(cls, type=None, id=None, title=None, href=None, url=None,
              slug=None, status=None, audit=None, owners=None, contact=None,
-             secondary_contact=None, updated_at=None,
-             custom_attribute_definitions=None, custom_attribute_values=None):
+             secondary_contact=None, updated_at=None, os_state=None,
+             custom_attribute_definitions=None, custom_attribute_values=None,
+             custom_attributes=None):
     """Create Issue object.
     Random values will be used for title and slug.
     Predictable values will be used for type, status, owners and contact.
     """
     # pylint: disable=too-many-locals
     issue_entity = cls._create_random_issue()
-    issue_entity = cls.update_obj_attrs_values(
-        obj=issue_entity, type=type, id=id, title=title, href=href, url=url,
-        slug=slug, status=status, audit=audit, owners=owners, contact=contact,
-        secondary_contact=secondary_contact, updated_at=updated_at,
+    issue_entity = cls.update_objs_attrs_values_by_entered_data(
+        objs=issue_entity, is_allow_none_values=False, type=type, id=id,
+        title=title, href=href, url=url, slug=slug, status=status, audit=audit,
+        owners=owners, contact=contact, secondary_contact=secondary_contact,
+        updated_at=updated_at, os_state=os_state,
         custom_attribute_definitions=custom_attribute_definitions,
-        custom_attribute_values=custom_attribute_values)
+        custom_attribute_values=custom_attribute_values,
+        custom_attributes=custom_attributes)
     return issue_entity
 
   @classmethod
   def _create_random_issue(cls):
     """Create Issue entity with randomly and predictably filled fields."""
-    random_issue = entity.IssueEntity()
+    random_issue = IssueEntity()
     random_issue.type = cls.obj_issue
     random_issue.title = cls.generate_string(cls.obj_issue)
     random_issue.slug = cls.generate_slug()
-    random_issue.status = element.IssueStates.DRAFT
-    random_issue.owners = [ObjectOwnersFactory().default().__dict__]
-    random_issue.contact = ObjectOwnersFactory().default().__dict__
+    random_issue.status = unicode(element.IssueStates.DRAFT)
+    random_issue.owners = [ObjectPersonsFactory().default().__dict__]
+    random_issue.contact = ObjectPersonsFactory().default().__dict__
     return random_issue

--- a/test/selenium/src/lib/page/widget/info_widget.py
+++ b/test/selenium/src/lib/page/widget/info_widget.py
@@ -63,11 +63,11 @@ class CommonInfo(base.Widget):
                             [None, None])
     return header_and_value
 
-  def get_headers_and_values_text_from_cas_scopes(self):  # flake8: noqa
-    """Get and convert to entities form all headers and values elements text
-    from CAs scopes elements.
+  def get_headers_and_values_dict_from_cas_scopes(self):  # noqa: ignore=C901
+    """Get text of all CAs headers and values elements scopes and convert it to
+    dictionary.
     Example:
-    :return [['ca_header1', 'ca_header2'], ['ca_value1', 'ca_value2']]
+    :return {'ca_header1': 'ca_value1', 'ca_header2': 'ca_value2', ...}
     """
     # pylint: disable=invalid-name
     # pylint: disable=too-many-branches
@@ -75,30 +75,30 @@ class CommonInfo(base.Widget):
       selenium_utils.wait_for_js_to_load(self._driver)
       self.cas_headers_and_values = self._driver.find_elements(
           *self._locators.CAS_HEADERS_AND_VALUES)
-    if len(self.cas_headers_and_values) > 1:
+    dict_cas_scopes = {None: None}
+    if len(self.cas_headers_and_values) >= 1:
       list_text_cas_scopes = []
       for scope in self.cas_headers_and_values:
         ca_header_text = scope.text.splitlines()[0]
-        if any(unicode(ca_type.upper()) in ca_header_text for ca_type
-               in element.AdminWidgetCustomAttributes.ALL_CA_TYPES):
-          if len(scope.text.splitlines()) >= 2:
-            if scope.text.splitlines()[1].strip():
-              list_text_cas_scopes.append(
-                  [ca_header_text, scope.text.splitlines()[1]])
-            else:
-              list_text_cas_scopes.append([ca_header_text, None])
-          if len(scope.text.splitlines()) == 1:
-            if (element.AdminWidgetCustomAttributes.CHECKBOX.upper() in
-                    ca_header_text):
-              list_text_cas_scopes.append(
-                  [ca_header_text,
-                   unicode(int(base.Checkbox(self._driver, scope.find_element(
-                       *self._locators.CAS_CHECKBOXES)).is_element_checked()))
-                   ])
-            else:
-              list_text_cas_scopes.append([ca_header_text, None])
-      cas_headers, _cas_values = zip(*list_text_cas_scopes)
-      # convertation
+        if len(scope.text.splitlines()) >= 2:
+          if scope.text.splitlines()[1].strip():
+            list_text_cas_scopes.append(
+                [ca_header_text, scope.text.splitlines()[1]])
+          else:
+            list_text_cas_scopes.append([ca_header_text, None])
+        if len(scope.text.splitlines()) == 1:
+          if (element.AdminWidgetCustomAttributes.CHECKBOX.upper() in
+                  ca_header_text):
+            list_text_cas_scopes.append(
+                [ca_header_text,
+                 unicode(int(base.Checkbox(self._driver, scope.find_element(
+                     *self._locators.CAS_CHECKBOXES)).is_element_checked()))
+                 ])
+          else:
+            list_text_cas_scopes.append([ca_header_text, None])
+      cas_headers, _cas_values = [list(text_cas_scope) for text_cas_scope
+                                  in zip(*list_text_cas_scopes)]
+      # conversion
       cas_values = []
       for ca_val in _cas_values:
         if ca_val is None:
@@ -115,8 +115,8 @@ class CommonInfo(base.Widget):
         else:
           # Other
           cas_values.append(ca_val)
-      return cas_headers, cas_values
-    return [None, None]
+      dict_cas_scopes = dict(zip(cas_headers, cas_values))
+    return dict_cas_scopes
 
   def get_info_widget_obj_scope(self):
     """Get dict from object (text scope) which displayed on info page or
@@ -233,18 +233,15 @@ class Audits(InfoPanel):
     self.code_text, self.code_entered_text = (
         self.get_header_and_value_text_from_custom_scopes(
             self._elements.CODE.upper()))
-    self.cas_headers_text, self.cas_values_text = (
-        self.get_headers_and_values_text_from_cas_scopes())
+    self.cas_text = self.get_headers_and_values_dict_from_cas_scopes()
     # all obj scopes
     self.list_all_headers_text = [
-        self._elements.CAS_HEADERS.upper(), self._elements.CAS_VALUES.upper(),
-        self.title().text, self._elements.STATUS.upper(), self.audit_lead_text,
-        self.code_text]
+        self._elements.CAS.upper(), self.title().text,
+        self._elements.STATUS.upper(), self.audit_lead_text, self.code_text]
     self.list_all_values_text = [
-        self.cas_headers_text, self.cas_values_text, self.title_entered().text,
+        self.cas_text, self.title_entered().text,
         objects.get_normal_form(self.state().text),
-        self.audit_lead_entered_text,
-        self.code_entered_text]
+        self.audit_lead_entered_text, self.code_entered_text]
 
 
 class Assessments(InfoPanel):
@@ -272,16 +269,22 @@ class Assessments(InfoPanel):
           len(mapped_scope.text.splitlines()) >= 2]
       self.mapped_objects_descriptions_text = [
           mapped_scope.text.splitlines()[1]
-        for mapped_scope in self.mapped_objects_titles_and_descriptions if
-        len(mapped_scope.text.splitlines()) >= 2]
-    # CAs
-    self.cas_headers_text, self.cas_values_text = (
-        self.get_headers_and_values_text_from_cas_scopes())
+          for mapped_scope in self.mapped_objects_titles_and_descriptions if
+          len(mapped_scope.text.splitlines()) >= 2]
+    self.cas_text = self.get_headers_and_values_dict_from_cas_scopes()
     # people section
     self.people_section.toggle()
     self.creators_text, self.creators_entered_text = (
         self.get_header_and_value_text_from_custom_scopes(
             self._elements.CREATORS_.upper(),
+            self._locators.PEOPLE_HEADERS_AND_VALUES))
+    self.assignees_text, self.assignees_entered_text = (
+        self.get_header_and_value_text_from_custom_scopes(
+            self._elements.ASSIGNEES_.upper(),
+            self._locators.PEOPLE_HEADERS_AND_VALUES))
+    self.verifiers_text, self.verifiers_entered_text = (
+        self.get_header_and_value_text_from_custom_scopes(
+            self._elements.ASSIGNEES_.upper(),
             self._locators.PEOPLE_HEADERS_AND_VALUES))
     self.people_section.toggle(False)
     # code section
@@ -296,17 +299,17 @@ class Assessments(InfoPanel):
     self.code_section.toggle(False)
     # scope
     self.list_all_headers_text = [
-        self._elements.CAS_HEADERS.upper(), self._elements.CAS_VALUES.upper(),
-        self.title().text, self._elements.STATE.upper(),
-        self._elements.VERIFIED.upper(),
-        self._elements.CREATORS.upper(),
+        self._elements.CAS.upper(), self.title().text,
+        self._elements.STATE.upper(), self._elements.VERIFIED.upper(),
+        self._elements.CREATORS.upper(), self._elements.ASSIGNEES.upper(),
+        self._elements.VERIFIERS.upper(),
         self._elements.MAPPED_OBJECTS.upper(), self.code_text]
     self.list_all_values_text = [
-        self.cas_headers_text, self.cas_values_text, self.title_entered().text,
+        self.cas_text, self.title_entered().text,
         objects.get_normal_form(self.state().text),
         self.state().text.upper() in
-        element.AssessmentStates.COMPLETED.upper(),
-        self.creators_entered_text,
+        element.AssessmentStates.COMPLETED.upper(), self.creators_entered_text,
+        self.assignees_entered_text, self.verifiers_entered_text,
         self.mapped_objects_titles_text, self.code_entered_text]
 
 
@@ -392,15 +395,14 @@ class Controls(SnapshotableInfoPanel):
     self.code_text, self.code_entered_text = (
         self.get_header_and_value_text_from_custom_scopes(
             self._elements.CODE.upper()))
-    self.cas_headers_text, self.cas_values_text = (
-        self.get_headers_and_values_text_from_cas_scopes())
+    self.cas_text = self.get_headers_and_values_dict_from_cas_scopes()
     # scope
     self.list_all_headers_text = [
-        self._elements.CAS_HEADERS.upper(), self._elements.CAS_VALUES.upper(),
-        self.title().text, self._elements.STATE.upper(), self.admin_text,
+        self._elements.CAS.upper(), self.title().text,
+        self._elements.STATE.upper(), self.admin_text,
         self.primary_contact_text, self.code_text]
     self.list_all_values_text = [
-        self.cas_headers_text, self.cas_values_text, self.title_entered().text,
+        self.cas_text, self.title_entered().text,
         objects.get_normal_form(self.state().text), self.admin_entered_text,
         self.primary_contact_entered_text, self.code_entered_text]
 

--- a/test/selenium/src/lib/service/rest/template_provider.py
+++ b/test/selenium/src/lib/service/rest/template_provider.py
@@ -25,7 +25,6 @@ class TemplateProvider(object):
     with open(path) as json_file:
       json_data = json_file.read()
     json_tmpl = json.loads(json_data)
-    dict()[json_tmpl_name] = json_tmpl
     json_tmpl_copy = copy.deepcopy(json_tmpl)
     json_tmpl_copy.update({k: v for k, v in kwargs.iteritems() if v})
     return {json_tmpl_name: json_tmpl_copy}

--- a/test/selenium/src/lib/utils/conftest_utils.py
+++ b/test/selenium/src/lib/utils/conftest_utils.py
@@ -2,31 +2,20 @@
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 """PyTest fixture utils."""
 
-from selenium.common import exceptions
-
 from lib import cache, constants, factory
 from lib.page import dashboard
-
-
-def navigate_to_page_with_lhn(driver):
-  """Navigate to Dashboard it LHN button isn't found."""
-  # pylint: disable=invalid-name
-  try:
-    driver.find_element(*dashboard.Header.locators.TOGGLE_LHN)
-  except exceptions.NoSuchElementException:
-    driver.get(dashboard.Dashboard.URL)
+from lib.utils import selenium_utils
 
 
 def get_lhn_accordion(driver, object_name):
-  """Select relevant section in LHN and return relevant section accordion.
- """
-  navigate_to_page_with_lhn(driver)
-  lhn_contents = dashboard.Header(driver).open_lhn_menu()
+  """Select relevant section in LHN and return relevant section accordion."""
+  selenium_utils.open_url(driver, dashboard.Dashboard.URL)
+  lhn_menu = dashboard.Header(driver).open_lhn_menu()
   # if object button not visible, open this section first
   if object_name in cache.LHN_SECTION_MEMBERS:
     method_name = factory.get_method_lhn_select(object_name)
-    lhn_contents = getattr(lhn_contents, method_name)()
-  return getattr(lhn_contents, constants.method.SELECT_PREFIX + object_name)()
+    lhn_menu = getattr(lhn_menu, method_name)()
+  return getattr(lhn_menu, constants.method.SELECT_PREFIX + object_name)()
 
 
 def create_obj_via_lhn(driver, object_name):

--- a/test/selenium/src/tests/conftest.py
+++ b/test/selenium/src/tests/conftest.py
@@ -8,6 +8,8 @@
 import pytest
 
 from lib import dynamic_fixtures
+from lib.utils import selenium_utils
+from lib.page import dashboard
 
 
 # pylint: disable=redefined-outer-name
@@ -41,6 +43,22 @@ def dynamic_new_assessment_template(request):
   Return: lib.entities.entity.AssessmentTemplateEntity
   """
   yield _common_fixtures(request.param)[0] if request.param else None
+
+
+@pytest.fixture(scope="function")
+def my_work_dashboard(selenium):
+  """Open My Work Dashboard URL and
+  return My Work Dashboard page objects model."""
+  selenium_utils.open_url(selenium, dashboard.Dashboard.URL)
+  return dashboard.Dashboard(selenium)
+
+
+@pytest.fixture(scope="function")
+def header_dashboard(selenium):
+  """Open My Work Dashboard URL and
+  return Header Dashboard page objects model."""
+  selenium_utils.open_url(selenium, dashboard.Dashboard.URL)
+  return dashboard.Header(selenium)
 
 
 @pytest.fixture(scope="function")
@@ -192,5 +210,5 @@ def create_audit_with_control_and_delete_control(request):
 
 @pytest.fixture(scope="function")
 def dynamic_object(request):
-  """Create object by passed indirect parameter in test"""
+  """Create object by passed indirect parameter in test."""
   yield _common_fixtures(request.param)

--- a/test/selenium/src/tests/test_admin_dashboard_page.py
+++ b/test/selenium/src/tests/test_admin_dashboard_page.py
@@ -7,14 +7,14 @@
 # pylint: disable=protected-access
 
 import random
-import re
 
 import pytest
+import re
 
 from lib import base, constants
 from lib.constants import objects, messages
 from lib.constants.element import AdminWidgetCustomAttributes
-from lib.entities.entities_factory import CustomAttributeDefinitionsFactory
+from lib.entities import entities_factory
 from lib.page import dashboard
 from lib.utils import selenium_utils
 
@@ -26,15 +26,17 @@ class TestAdminDashboardPage(base.Test):
 
   @pytest.fixture(scope="function")
   def admin_dashboard(self, selenium):
+    """Open Admin Dashboard URL and
+    return AdminDashboard page objects model."""
     selenium_utils.open_url(selenium, dashboard.AdminDashboard.URL)
     return dashboard.AdminDashboard(selenium)
 
   @pytest.mark.smoke_tests
   def test_roles_widget(self, admin_dashboard):
     """Check count and content of role scopes."""
-    admin_roles_widget = admin_dashboard.select_roles()
+    admin_roles_tab = admin_dashboard.select_roles()
     expected_dict = self._role_el.ROLE_SCOPES_DICT
-    actual_dict = admin_roles_widget.get_role_scopes_text_as_dict()
+    actual_dict = admin_roles_tab.get_role_scopes_text_as_dict()
     assert admin_dashboard.tab_roles.member_count == len(expected_dict)
     assert expected_dict == actual_dict, messages.ERR_MSG_FORMAT.format(
         expected_dict, actual_dict)
@@ -44,7 +46,7 @@ class TestAdminDashboardPage(base.Test):
     """Confirms tree view has at least one data row in valid format."""
     admin_events_tab = admin_dashboard.select_events()
     list_items = admin_events_tab.get_events()
-    assert len(list_items) > 0
+    assert list_items
     items_with_incorrect_format = [
         getattr(item, 'text') for item in list_items if not
         re.compile(self._event_el.TREE_VIEW_ROW_REGEXP).
@@ -57,11 +59,11 @@ class TestAdminDashboardPage(base.Test):
     """Check that full list of Custom Attributes groups is displayed
     on Admin Dashboard panel.
     """
-    ca_widget = admin_dashboard.select_custom_attributes()
+    ca_tab = admin_dashboard.select_custom_attributes()
     expected_ca_groups_set = set(
         [objects.get_normal_form(item) for item in objects.ALL_CA_OBJS])
     actual_ca_groups_set = set(
-        [item.text for item in ca_widget.get_items_list()])
+        [item.text for item in ca_tab.get_items_list()])
     assert expected_ca_groups_set == actual_ca_groups_set, (
         messages.ERR_MSG_FORMAT.format(
             expected_ca_groups_set, actual_ca_groups_set))
@@ -70,14 +72,14 @@ class TestAdminDashboardPage(base.Test):
   @pytest.mark.parametrize(
       "ca_type, def_type",
       [(ca_type_item,
-        objects.get_normal_form(random.choice(
-            [obj for obj in objects.ALL_CA_OBJS if obj != objects.ASSESSMENTS])
-        )) for ca_type_item in AdminWidgetCustomAttributes.ALL_CA_TYPES])
+        objects.get_normal_form(random.choice(objects.ALL_CA_OBJS))) for
+       ca_type_item in AdminWidgetCustomAttributes.ALL_CA_TYPES]
+  )
   def test_add_global_ca(self, admin_dashboard, ca_type, def_type):
     """Create different types of Custom Attribute on Admin Dashboard."""
-    expected_ca = CustomAttributeDefinitionsFactory().create(
+    expected_ca = entities_factory.CustomAttributeDefinitionsFactory().create(
         attribute_type=ca_type, definition_type=def_type)
-    ca_widget = admin_dashboard.select_custom_attributes()
-    ca_widget.add_custom_attribute(ca_obj=expected_ca)
-    list_actual_ca = ca_widget.get_custom_attributes_list(ca_group=expected_ca)
+    ca_tab = admin_dashboard.select_custom_attributes()
+    ca_tab.add_custom_attribute(ca_obj=expected_ca)
+    list_actual_ca = ca_tab.get_custom_attributes_list(ca_group=expected_ca)
     assert expected_ca in list_actual_ca

--- a/test/selenium/src/tests/test_my_work_page.py
+++ b/test/selenium/src/tests/test_my_work_page.py
@@ -6,47 +6,46 @@
 # pylint: disable=too-few-public-methods
 # pylint: disable=unused-argument
 
-import pytest    # pylint: disable=import-error
+import pytest  # pylint: disable=import-error
 
 from lib import base
 from lib.constants import objects
 from lib.page import dashboard, lhn
 from lib.page.widget import generic_widget
-from lib.utils import conftest_utils, selenium_utils
+from lib.utils import selenium_utils
 
 
 class TestMyWorkPage(base.Test):
   """Tests My Work page, part of smoke tests, section 2."""
 
   @pytest.mark.smoke_tests
-  def test_horizontal_nav_bar_tabs(self, new_controls_rest, selenium):
+  def test_horizontal_nav_bar_tabs(self, new_controls_rest, my_work_dashboard,
+                                   selenium):
     """Tests that several objects in widget can be deleted sequentially.
     Preconditions:
     - Controls created via REST API.
     """
-    selenium_utils.open_url(selenium, dashboard.Dashboard.URL)
-    controls_widget = dashboard.Dashboard(selenium).select_controls()
-    for _ in xrange(controls_widget.member_count):
-      counter = controls_widget.get_items_count()
-      (controls_widget.select_member_by_num(0).
+    controls_tab = my_work_dashboard.select_controls()
+    for _ in xrange(controls_tab.member_count):
+      counter = controls_tab.get_items_count()
+      (controls_tab.select_member_by_num(0).
        open_info_3bbs().select_delete().confirm_delete())
-      controls_widget.wait_member_deleted(counter)
-    assert generic_widget.Controls(
-        selenium, objects.CONTROLS).members_listed == []
+      controls_tab.wait_member_deleted(counter)
+    controls_generic_widget = generic_widget.Controls(
+        selenium, objects.CONTROLS)
+    assert controls_generic_widget.members_listed == []
 
   @pytest.mark.smoke_tests
-  def test_redirect(self, selenium):
+  def test_redirect(self, header_dashboard, selenium):
     """Tests if user is redirected to My Work page after clicking on
     the my work button in user dropdown."""
-    conftest_utils.navigate_to_page_with_lhn(selenium)
-    dashboard.Header(selenium).select_my_work()
+    header_dashboard.select_my_work()
     assert selenium.current_url == dashboard.Dashboard.URL
 
   @pytest.mark.smoke_tests
-  def test_lhn_stays_expanded(self, selenium):
+  def test_lhn_stays_expanded(self, header_dashboard, selenium):
     """Tests if, after opening LHN, it slides out and stays expanded."""
-    conftest_utils.navigate_to_page_with_lhn(selenium)
-    lhn_menu = dashboard.Header(selenium).open_lhn_menu()
+    lhn_menu = header_dashboard.open_lhn_menu()
     initial_position = lhn_menu.my_objects.element.location
     selenium_utils.wait_until_stops_moving(lhn_menu.my_objects.element)
     selenium_utils.hover_over_element(
@@ -54,40 +53,38 @@ class TestMyWorkPage(base.Test):
     assert initial_position == lhn.Menu(selenium).my_objects.element.location
 
   @pytest.mark.smoke_tests
-  def test_lhn_remembers_tab_state(self, selenium):
+  def test_lhn_remembers_tab_state(self, header_dashboard, selenium):
     """Tests if LHN remembers which tab is selected (my or all objects) after
     closing it."""
-    conftest_utils.navigate_to_page_with_lhn(selenium)
-    header = dashboard.Header(selenium)
+    lhn_menu = header_dashboard.open_lhn_menu()
     # check if my objects tab saves state
-    lhn_menu = header.open_lhn_menu()
     lhn_menu.select_my_objects()
-    header.close_lhn_menu()
-    header.open_user_list()
-    new_lhn = header.open_lhn_menu()
-    assert selenium_utils.is_value_in_attr(new_lhn.my_objects.element) is True
+    header_dashboard.close_lhn_menu()
+    header_dashboard.open_user_list()
+    selenium.get(dashboard.Dashboard.URL)
+    new_lhn_menu = dashboard.Header(selenium).open_lhn_menu()
+    assert selenium_utils.is_value_in_attr(
+        new_lhn_menu.my_objects.element) is True
     # check if all objects tab saves state
-    lhn_menu = header.open_lhn_menu()
+    lhn_menu = header_dashboard.open_lhn_menu()
     lhn_menu.select_all_objects()
-    header.close_lhn_menu()
-    header.open_user_list()
-    new_lhn = header.open_lhn_menu()
-    assert selenium_utils.is_value_in_attr(new_lhn.all_objects.element) is True
+    header_dashboard.close_lhn_menu()
+    header_dashboard.open_user_list()
+    assert selenium_utils.is_value_in_attr(
+        new_lhn_menu.all_objects.element) is True
 
   @pytest.mark.smoke_tests
-  def test_lhn_pin(self, selenium):
+  def test_lhn_pin(self, header_dashboard):
     """Tests if pin is present and if it's default state is off."""
-    conftest_utils.navigate_to_page_with_lhn(selenium)
-    lhn_menu = dashboard.Header(selenium).open_lhn_menu()
+    lhn_menu = header_dashboard.open_lhn_menu()
     assert lhn_menu.pin.is_activated is False
 
   @pytest.mark.smoke_tests
-  def test_user_menu_checkbox(self, selenium):
+  def test_user_menu_checkbox(self, header_dashboard):
     """Tests user menu checkbox. With that also user menu itself is
     tested since model initializes all elements (and throws and
     exception if they're not present."""
-    conftest_utils.navigate_to_page_with_lhn(selenium)
-    user_list = dashboard.Header(selenium).open_user_list()
+    user_list = header_dashboard.open_user_list()
     user_list.checkbox_daily_digest.click()
     user_list.checkbox_daily_digest.element.get_attribute("disabled")
     # restore previous state

--- a/test/selenium/src/tests/test_program_page.py
+++ b/test/selenium/src/tests/test_program_page.py
@@ -6,11 +6,10 @@
 # pylint: disable=too-few-public-methods
 # pylint: disable=unused-argument
 
-import pytest    # pylint: disable=import-error
+import pytest  # pylint: disable=import-error
 
 from lib import base
 from lib.constants import element, locator, url
-from lib.page import dashboard, widget_bar
 from lib.page.widget import info_widget
 from lib.utils import test_utils, selenium_utils
 
@@ -19,11 +18,11 @@ class TestProgramPage(base.Test):
   """A part of smoke tests, section 4."""
 
   @pytest.mark.smoke_tests
-  def test_object_count_updates(self, selenium, new_program_ui):
+  def test_object_count_updates(self, new_program_ui, header_dashboard):
     """Checks if count updates in LHN after creating new program
     object."""
     _, program_info_page = new_program_ui
-    lhn_menu = dashboard.Header(selenium).open_lhn_menu().select_my_objects()
+    lhn_menu = header_dashboard.open_lhn_menu().select_my_objects()
     assert (lhn_menu.toggle_programs.members_count >=
             int(program_info_page.source_obj_id_from_url))
 
@@ -40,7 +39,8 @@ class TestProgramPage(base.Test):
             program_info_page.url)
 
   @pytest.mark.smoke_tests
-  def test_info_tab_is_active_by_default(self, selenium, new_program_ui):
+  def test_info_tab_is_active_by_default(self, new_program_ui,
+                                         my_work_dashboard):
     """Tests if after lhn_modal is saved we're redirected and info
     tab is activated.
     Because app uses url arguments to remember state of page
@@ -49,8 +49,7 @@ class TestProgramPage(base.Test):
     """
     _, program_info_page = new_program_ui
     program_info_page.navigate_to()
-    horizontal_bar = widget_bar.Dashboard(selenium)
-    assert (horizontal_bar.get_active_widget_name() ==
+    assert (my_work_dashboard.get_active_widget_name() ==
             element.ProgramInfoWidget().WIDGET_HEADER)
 
   @pytest.mark.smoke_tests

--- a/test/selenium/src/tests/test_unified_mapper.py
+++ b/test/selenium/src/tests/test_unified_mapper.py
@@ -25,7 +25,9 @@ class TestProgramPage(base.Test):
     - Program, Controls created via REST API.
     """
     # pylint: disable=no-self-use
-    expected_controls = new_controls_rest
+    expected_controls = [
+        expected_control.repr_ui().update_attrs(custom_attributes={None: None})
+        for expected_control in new_controls_rest]
     (webui_service.ControlsService(selenium).map_objs_via_tree_view(
         src_obj=new_program_rest, dest_objs=expected_controls))
     actual_controls_tab_count = (


### PR DESCRIPTION
This PR is core global redesign of equal procedure to comparing expected and actual result (objects) and extended test suite according new model.

**PROS:**

- **accurate comparison** of expected and actual result (objects) using '==' operator and avoiding statements like "None == object" and flexible and maintainable comparison of global and local custom attributes for all objects;  
- **all test cases brings value for testing process** due excluding of skipping ('skipif') failing test cause issues on GGRC app and switching to use 'xfail' model which fail test in a last part of execution with and catch particular fail (test case isn't failing in this case);
 - **test suite** fully redesign to new equal model and **ready to run in parallel**;
- new functionality and implementation of **test suite is protected from unexpected fail due previous random data generation** during UI CAs test-cases execution: 
ggrc-core/test/selenium/src/tests/test_admin_dashboard_page.pytest_add_global_ca;
- more **explicit and maintainable representation** of objects in a process of assertion and as a mater affect **easily and quick debug** *** factory and REST like data is converting to UI like representation and object has just hard count of represented objects attributes according to entity model;
- **flexible and useful model** of **representing** objects and **manipulating with expected and actual** data in a context of particular test cases.

**CONS:**
- complicated logic to represent REST like data to WebUI like data and vice versa.

**EXAMPLES:**

**entity.py**
```Python
class AssessmentEntity(Entity):
...

  def __repr__(self):
    return ("type: {type}, id: {id}, title: {title}, href: {href}, "
            "url: {url}, slug: {slug}, status: {status}, owners: {owners}, "
            "audit: {audit}, recipients: {recipients}, "
            "assignees: {assignees}, assessor: {assessor}, "
            "creator: {creator}, verifier: {verifier}, verified: {verified}, "
            "updated_at: {updated_at}, "
            "objects_under_assessment: {objects_under_assessment}, "
            "os_state: {os_state}, "
            "custom_attribute_definitions: {custom_attribute_definitions}, "
            "custom_attribute_values: {custom_attribute_values}, "
            "custom_attributes: {custom_attributes}").format(
        type=self.type, title=self.title, id=self.id, href=self.href,
        url=self.url, slug=self.slug, status=self.status, owners=self.owners,
        audit=self.audit, recipients=self.recipients, assignees=self.assignees,
        assessor=self.assessor, creator=self.creator, verifier=self.verifier,
        verified=self.verified, updated_at=self.updated_at,
        objects_under_assessment=self.objects_under_assessment,
        os_state=self.os_state,
        custom_attribute_definitions=self.custom_attribute_definitions,
        custom_attribute_values=self.custom_attribute_values,
        custom_attributes=self.custom_attributes)

  def __eq__(self, other):
    return (isinstance(other, self.__class__) and
            self.assessor == other.assessor and
            self.creator == other.creator and
            string_utils.is_one_dict_is_subset_another_dict(
                self.custom_attributes, other.custom_attributes) and
            self.objects_under_assessment == other.objects_under_assessment and
            self.os_state == other.os_state and self.owners == other.owners and
            self.slug == other.slug and self.status == other.status and
            self.title == other.title and self.type == other.type and
            self.updated_at == other.updated_at and
            self.verifier == other.verifier and
            self.verified == other.verified)
```

**test-case**      
```Python          ** - new implementation
  @pytest.mark.smoke_tests
  @pytest.mark.parametrize(
      "dynamic_new_assessment_template",
      [None, "new_assessment_template_rest",
       "new_assessment_template_with_cas_rest"],
      ids=["Assessments generation without Assessment Template",
           "Assessments generation based on Assessment Template without LCAs",
           "Assessments generation based on Assessment Template with LCAs"],
      indirect=["dynamic_new_assessment_template"])
  def test_asmts_generation(
      self, new_program_rest, new_controls_rest,
      map_new_program_rest_to_new_controls_rest, new_audit_rest,
      dynamic_new_assessment_template, selenium
  ):
    """Check if Assessments can be generated from Audit page via Assessments
    widget using Assessment template and Controls.
    Preconditions:
    - Program, Controls created via REST API.
    - Controls mapped to Program via REST API.
    - Audit created under Program via REST API.
    - Assessment Template with CAs created under Audit via REST API.
    """
    expected_asmts = (entities_factory.AssessmentsFactory().generate(
        objs_under_asmt=new_controls_rest, audit=new_audit_rest,
        asmt_tmpl=dynamic_new_assessment_template))
  
  **expected_asmts = [
        expected_asmt.repr_ui() for expected_asmt in expected_asmts]**

    (webui_service.AssessmentsService(selenium).generate_objs_via_tree_view(
        src_obj=new_audit_rest, objs_under_asmt=new_controls_rest,
        asmt_tmpl_obj=dynamic_new_assessment_template))
    actual_asmts_tab_count = (webui_service.AssessmentsService(selenium).
                              get_count_objs_from_tab(src_obj=new_audit_rest))
    assert len(expected_asmts) == actual_asmts_tab_count
    actual_asmts = (webui_service.AssessmentsService(selenium).
                    get_list_objs_from_info_panels(
                        src_obj=new_audit_rest, objs=expected_asmts))
   
 **actual_asmts = [
        actual_asmt.update_attrs(slug=None) for actual_asmt in actual_asmts]**

    **actual_asmts = [
        actual_asmt.update_attrs(
            is_replace_attrs=False, custom_attributes={None: None})
        for actual_asmt in actual_asmts]**
   
 assert expected_asmts == actual_asmts, (
        messages.ERR_MSG_FORMAT.format(expected_asmts, actual_asmts))
```