### PR TITLE
GGRC-2449 Creator/Assignee/Verifier are displayed in tree view after newly created assessment

### DIFF
--- a/src/ggrc/assets/javascripts/components/tree/tree-people-list-field.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-people-list-field.js
@@ -27,6 +27,9 @@
     events: {
       '{viewModel} source': function () {
         this.viewModel.refreshPeople();
+      },
+      '{viewModel.source} change': function () {
+        this.viewModel.refreshPeople();
       }
     }
   });


### PR DESCRIPTION
_Steps to reproduce:_
1. On the audit page go to Assessment tab and Set visible fields: Creator/Assignee/Verifier
2. Invoke New Assessment modal window
3. Fill all the required fields and add verifier> Save
4. Look at the tree view

_Actual Result_: Creator/Assignee/Verifier are not displayed in tree view after newly created assessment
_Expected Result_: Creator/Assignee/Verifier should be displayed in tree view after newly created assessment