### PR TITLE
GGRC-2328 RMC - Workflow - Status Color - Add Overdue

### DIFF
--- a/src/ggrc/assets/javascripts/components/tree/sub-tree-item.js
+++ b/src/ggrc/assets/javascripts/components/tree/sub-tree-item.js
@@ -11,6 +11,27 @@
   var BaseTreeItemVM = GGRC.VM.BaseTreeItemVM;
   var viewModel = BaseTreeItemVM.extend({
     define: {
+      dueDate: {
+        type: 'date',
+        get: function () {
+          return this.attr('instance.next_due_date') ||
+            this.attr('instance.end_date');
+        }
+      },
+      dueDateCssClass: {
+        type: 'string',
+        get: function () {
+          var isOverdue = this.attr('instance.isOverdue');
+          return isOverdue ? 'state-overdue' : '';
+        }
+      },
+      isCycleTaskGroupObjectTask: {
+        type: 'boolean',
+        get: function () {
+          return this.attr('instance') instanceof
+            CMS.Models.CycleTaskGroupObjectTask;
+        }
+      },
       cssClasses: {
         type: String,
         get: function () {

--- a/src/ggrc/assets/javascripts/components/tree/tree-item-extra-info.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-item-extra-info.js
@@ -11,32 +11,9 @@
 
   var viewModel = can.Map.extend({
     define: {
-      dueDate: {
-        type: 'date',
-        get: function () {
-          return this.attr('instance.next_due_date') ||
-            this.attr('instance.end_date');
-        }
-      },
-      dueDateCssClass: {
-        type: 'string',
-        get: function () {
-          var isOverdue = this.attr('isCycleTasks') &&
-            this.attr('instance.isOverdue');
-          return isOverdue ? 'state-overdue' : '';
-        }
-      },
       isSubTreeItem: {
         type: 'htmlbool',
         value: false
-      },
-      showingOverdueDate: {
-        type: 'boolean',
-        value: false,
-        get: function () {
-          return this.attr('isSubTreeItem') &&
-              this.attr('isCycleTaskGroupObjectTask');
-        }
       },
       isActive: {
         type: 'boolean',
@@ -105,6 +82,13 @@
         type: 'boolean',
         get: function () {
           return !!this.attr('instance.workflow_state');
+        }
+      },
+      isShowOverdue: {
+        type: 'boolean',
+        get: function () {
+          return this.attr('isCycleTaskGroup') ||
+            this.attr('isCycleTaskGroupObjectTask');
         }
       },
       isOverdue: {

--- a/src/ggrc/assets/mustache/components/tree/sub-tree-item.mustache
+++ b/src/ggrc/assets/mustache/components/tree/sub-tree-item.mustache
@@ -17,6 +17,10 @@
       {{title}}
     </span>
       <tree-item-status-for-workflow {instance}="instance"></tree-item-status-for-workflow>
+
+      {{#if isCycleTaskGroupObjectTask}}
+        <span class="tree-item__overdue {{dueDateCssClass}}">{{localize_date dueDate}}</span>
+      {{/if}}
   </div>
 
   <cycle-task-actions {instance}="instance"

--- a/src/ggrc/assets/mustache/components/tree/tree-item-extra-info.mustache
+++ b/src/ggrc/assets/mustache/components/tree/tree-item-extra-info.mustache
@@ -4,13 +4,14 @@
 }}
 
 {{#if isActive}}
-  {{#if showingOverdueDate}}
-    <span class="tree-item__due-date {{dueDateCssClass}}">{{localize_date dueDate}}</span>
-  {{/if}}
+  {{#isShowOverdue}}
+    {{#isOverdue}}
+      <span class="tree-item__overdue state-overdue">OVERDUE</span>
+    {{/isOverdue}}
+  {{/isShowOverdue}}
   <i class="fa {{cssClasses}} popover-target"
      ($mouseenter)="onEnter()"
      ($mouseleave)="onLeave()"></i>
-
   {{^if disablePopover}}
   <div class="tree-item__popover">
     <div class="tree-item__popover-content">

--- a/src/ggrc/assets/mustache/components/unified-mapper/mapper-results-item-status.mustache
+++ b/src/ggrc/assets/mustache/components/unified-mapper/mapper-results-item-status.mustache
@@ -1,5 +1,9 @@
 {{#if_instance_of itemData "Cycle|CycleTaskGroup|CycleTaskGroupObjectTask"}}
-  <span class="status-label" {{addclass "status-" itemData.status}} {{addclass "status-" itemData.overdue}}></span>
+  {{#if itemData.isOverdue}}
+    <span class="status-label status-overdue"></span>
+  {{else}}
+    <span class="status-label" {{addclass "status-" itemData.status}}></span>
+  {{/if}}
 {{else}}
   {{#if itemData.workflow_state}}
     <span class="status-label" {{addclass "status-" itemData.workflow_state}}></span>

--- a/src/ggrc/assets/stylesheets/components/tree/_sub-tree-wrapper.scss
+++ b/src/ggrc/assets/stylesheets/components/tree/_sub-tree-wrapper.scss
@@ -50,6 +50,18 @@ sub-tree-item {
       align-items: center;
       width: 80px;
     }
+
+    tree-item-status-for-workflow {
+      width: 25%;
+
+      .tree-item__icon-wrapper {
+        justify-content: flex-start;
+      }
+    }
+
+    .state-overdue {
+      color: $status-declined;
+    }
   }
 
   cycle-task-actions {

--- a/src/ggrc/assets/stylesheets/components/tree/_tree-item-extra-info.scss
+++ b/src/ggrc/assets/stylesheets/components/tree/_tree-item-extra-info.scss
@@ -13,9 +13,10 @@ tree-item-extra-info {
   box-sizing: border-box;
   position: relative;
 
-  .tree-item__due-date {
+  .tree-item__overdue {
     position: absolute;
-    right: 38px;
+    right: 42px;
+    top: 1px;
     font-weight: 500;
   }
 
@@ -121,7 +122,7 @@ tree-item-extra-info {
 .sub-item-content {
   &:hover {
     tree-item-extra-info {
-      .tree-item__due-date {
+      .tree-item__overdue {
         z-index: -1;
       }
     }

--- a/src/ggrc/assets/stylesheets/components/tree/_tree-view.scss
+++ b/src/ggrc/assets/stylesheets/components/tree/_tree-view.scss
@@ -156,6 +156,9 @@ tree-item {
         i {
           visibility: visible;
         }
+        .tree-item__overdue {
+          z-index: -1;
+        }
       }
 
       tree-item-actions, .item-actions {


### PR DESCRIPTION
UX: https://drive.google.com/corp/drive/folders/0BxUZsNDMuM58dV8tSGphTkFGRW8
ACCEPTANCE CRITERIA
AC1. Add 'Overdue' word next to task state.
AC2. Add 'Overdue' word next to task group state.
'Overdue' flag should be added to a task group if task group has at least one overdue task.
AC3. 'Overdue' word should be red.
AC4. Make changes on the following pages:
Workflow page - Active Cycles;
My Work page - Tasks;
Person page - Workflow Tasks;
<snapshottable object> page - Workflow Tasks;
Program page - Workflow Tasks;
Assessment page - Workflow Tasks;
Issue page - Workflow Tasks;
Global search - Cycle Task Group Object Tasks.
