### PR TITLE
GGRC-2485 If type space into LCA rich text type, error is shown in console and all the values in other LCAs are not saved

### DIFF
--- a/src/ggrc/assets/javascripts/components/rich_text/rich_text.js
+++ b/src/ggrc/assets/javascripts/components/rich_text/rich_text.js
@@ -22,7 +22,6 @@
           value: ''
         },
         disabled: {
-          type: 'boolean',
           set: function (newValue) {
             this.toggle(!newValue);
             return newValue;
@@ -159,7 +158,9 @@
       setText: function (text) {
         var editor = this.getEditor();
         if (editor && !text.length) {
-          editor.setText('');
+          setTimeout(function () {
+            editor.setText('');
+          }, 0);
         }
       },
       /**


### PR DESCRIPTION
Steps to reproduce:
1. Have audit, control's snapshot and Assessment template that contains LCAs with all the types (text, rich text, dropdown, checkbox, date, person)
2. Generate assessment based on the control's snapshot and assessment template
3. Navigate to assessment's info pane > LCA with rich text type
4. Type space and save
5. Fill other LCAs and Save
6. Refresh the page and look at the LCAs values: are not saved
*Actual Result*: If type space into LCA rich text type, error is shown in console and all the values in other LCAs are not saved
*Expected Result:* If type space into LCA rich text type should not be error in console and all the values in other LCAs should be saved

[Related Issue](https://github.com/quilljs/quill/issues/1134)

