### PR TITLE
GGRC-1608 Change the WF Cycle completed text in daily digest

### DIFF
--- a/src/ggrc/notifications/common.py
+++ b/src/ggrc/notifications/common.py
@@ -25,7 +25,7 @@ from ggrc import settings
 from ggrc.models import Person
 from ggrc.models import Notification
 from ggrc.rbac import permissions
-from ggrc.utils import merge_dict
+from ggrc.utils import DATE_FORMAT_US, merge_dict
 
 from ggrc_workflows.notification.data_handler import (
     cycle_tasks_cache, deleted_task_rels_cache, get_cycle_task_data
@@ -412,5 +412,7 @@ def modify_data(data):
     for cycle in data["cycle_data"].values():
       if "my_tasks" in cycle:
         data["cycle_started_tasks"].update(cycle["my_tasks"])
+
+  data["DATE_FORMAT"] = DATE_FORMAT_US
 
   return data

--- a/src/ggrc/templates/notifications/email_digest_content.html
+++ b/src/ggrc/templates/notifications/email_digest_content.html
@@ -163,14 +163,19 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                 {% endif %}
 
                 {% if digest['all_tasks_completed'] %}
-                  <h2 {{ style.sub_title() }} >All tasks completed in the following
+                  <h2 {{ style.sub_title() }} >
+                    All tasks for the following workflow
                     {{ "cycles" if digest['all_tasks_completed']|length > 1 else "cycle" }}
-                    </h2>
+                    are now completed and/or verified. The following workflow
+                    {{ "cycles" if digest['all_tasks_completed']|length > 1 else "cycle" }}
+                    will end on {{ digest['today'].strftime(digest['DATE_FORMAT']) }}:
+                  </h2>
+
                   <ul {{ style.list_wrap() }} >
                   {% for cycle_id, cycle in digest['all_tasks_completed'].iteritems() %}
                     <li {{ style.list_item() }} >
-                      Completed cycle of
-                      <a href="{{ cycle['cycle_url'] }}" {{ style.link_text() }} >{{ cycle['cycle_title'] }}</a>.
+                      {{ cycle['cycle_slug'] }} of
+                      <a href="{{ cycle['cycle_inactive_url'] }}" {{ style.link_text() }} >{{ cycle['cycle_title'] }}</a>
                     </li>
                   {% endfor %}
                   </ul>

--- a/src/ggrc_workflows/notification/data_handler.py
+++ b/src/ggrc_workflows/notification/data_handler.py
@@ -201,10 +201,12 @@ def get_all_cycle_tasks_completed_data(notification, cycle):
   workflow_owners = get_workflow_owners_dict(cycle.context_id)
   force = cycle.workflow.notify_on_change
   result = {}
+
   for workflow_owner in workflow_owners.itervalues():
     wf_data = {
         workflow_owner['email']: {
             "user": workflow_owner,
+            "today": date.today(),
             "force_notifications": {
                 notification.id: force
             },
@@ -544,9 +546,11 @@ def get_cycle_dict(cycle, manual=False):
   return {
       "manually": manual,
       "custom_message": cycle.workflow.notify_custom_message,
+      "cycle_slug": cycle.slug,
       "cycle_title": cycle.title,
       "workflow_owners": workflow_owners,
       "cycle_url": get_cycle_url(cycle),
+      "cycle_inactive_url": get_cycle_url(cycle, active=False),
   }
 
 
@@ -623,9 +627,22 @@ def cycle_task_workflow_cycle_url(cycle_task, filter_exp=u""):
   return urljoin(get_url_root(), url)
 
 
-def get_cycle_url(cycle):
-  url = "workflows/{workflow_id}#current_widget/cycle/{cycle_id}".format(
+def get_cycle_url(cycle, active=True):
+  """Build the URL to the given workflow cycle.
+
+  Args:
+    cycle: The cycle instance to build the URL for.
+    active:
+        If True (default), the URL is generated for when a cycle is active,
+        otherwise the resulting URL is generated for when a cycle is inactive.
+  Returns:
+    Full workflow cycle URL (as a string).
+  """
+  widget_name = "current_widget" if active else "history_widget"
+
+  url = "workflows/{workflow_id}#{widget_name}/cycle/{cycle_id}".format(
       workflow_id=cycle.workflow.id,
       cycle_id=cycle.id,
+      widget_name=widget_name
   )
   return urljoin(get_url_root(), url)

--- a/test/unit/ggrc_workflows/notification/test_data_handler.py
+++ b/test/unit/ggrc_workflows/notification/test_data_handler.py
@@ -1,13 +1,14 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (C) 2017 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
 """A module with tests for the GGRC Workflow's data_handler module."""
 
 import unittest
-
 from mock import MagicMock, patch
 
-from ggrc_workflows.notification.data_handler import get_cycle_task_url
+from ggrc_workflows.notification import data_handler
 
 
 class GetCycleTaskUrlTestCase(unittest.TestCase):
@@ -25,7 +26,7 @@ class GetCycleTaskUrlTestCase(unittest.TestCase):
     task.cycle_task_group.cycle.id = 77
     task.cycle_task_group.cycle.workflow.id = 9
 
-    result = get_cycle_task_url(task)
+    result = data_handler.get_cycle_task_url(task)
 
     expected_url = (
         u"http://www.foo.com/"
@@ -50,7 +51,7 @@ class GetCycleTaskUrlTestCase(unittest.TestCase):
 
     cycle_filter = u"id=77"
 
-    result = get_cycle_task_url(task, filter_exp=cycle_filter)
+    result = data_handler.get_cycle_task_url(task, filter_exp=cycle_filter)
 
     expected_url = (
         u"http://www.foo.com/"
@@ -58,5 +59,45 @@ class GetCycleTaskUrlTestCase(unittest.TestCase):
         u"/cycle/77"
         u"/cycle_task_group/6"
         u"/cycle_task_group_object_task/15"
+    )
+    self.assertEqual(result, expected_url)
+
+
+@patch(
+    u"ggrc_workflows.notification.data_handler.get_url_root",
+    return_value=u"http://www.foo.com/")
+class GetCycleUrlTestCase(unittest.TestCase):
+  """Tests for the get_cycle_url() function."""
+
+  # pylint: disable=invalid-name, unused-argument
+
+  def test_generates_correct_url_for_active_cycle(self, *mocks):
+    """The method should return correct URL for active Cycles."""
+    cycle = MagicMock()
+    cycle.id = 22
+    cycle.workflow.id = 111
+
+    # by default, a cycle is considered active
+    result = data_handler.get_cycle_url(cycle)
+
+    expected_url = (
+        u"http://www.foo.com/"
+        u"workflows/111#current_widget"
+        u"/cycle/22"
+    )
+    self.assertEqual(result, expected_url)
+
+  def test_generates_correct_url_for_inactive_cycle(self, *mocks):
+    """The method should return correct URL for inactive Cycles."""
+    cycle = MagicMock()
+    cycle.id = 22
+    cycle.workflow.id = 111
+
+    result = data_handler.get_cycle_url(cycle, active=False)
+
+    expected_url = (
+        u"http://www.foo.com/"
+        u"workflows/111#history_widget"
+        u"/cycle/22"
     )
     self.assertEqual(result, expected_url)


### PR DESCRIPTION
This PR changes the email text for the "cycle completed" notifications.

---

To test, create a Workflow with a few tasks, activate it, and then finish and Verify all the tasks. Visit the daily digest test page `/_notifications/show_daily_digest` and check the text for the "workflow cycle completed" notification.

Old notification message:

> All tasks completed in the following cycle(s)
> - Completed cycle of <Workflow title>.


**New** notification message:

> All tasks for the following workflow cycle(s) are now completed and/or verified. The following workflow cycle(s) will end on `today date`: 
> - [cycle slug] of [Workflow title with embedded link to workflow cycle]


Singular or plural form should be used for the word "cycle" depending on the number of items in the list.

Besides the text change, the word "today" gets replaced with an actual date in US format, since "today" might be ambiguous.