### PR TITLE
GGRC-2493 "Import failed due to unknown error." error is displayed while importing assessment

### DIFF
--- a/src/ggrc/converters/base_row.py
+++ b/src/ggrc/converters/base_row.py
@@ -182,7 +182,8 @@ class RowConverter(object):
       return
 
     for item_handler in self.attrs.values():
-      item_handler.set_obj_attr()
+      if not item_handler.view_only:
+        item_handler.set_obj_attr()
 
   def send_post_commit_signals(self, event=None):
     """Send after commit signals for all objects

--- a/src/ggrc/converters/handlers/handlers.py
+++ b/src/ggrc/converters/handlers/handlers.py
@@ -54,6 +54,7 @@ class ColumnHandler(object):
     self.raw_value = options.get("raw_value", "").strip()
     self.validator = options.get("validator")
     self.mandatory = options.get("mandatory", False)
+    self.view_only = options.get("view_only", False)
     self.default = options.get("default")
     self.description = options.get("description", "")
     self.display_name = options.get("display_name", "")

--- a/src/ggrc/models/assessment.py
+++ b/src/ggrc/models/assessment.py
@@ -214,6 +214,7 @@ class Assessment(Roleable, statusable.Statusable, AuditRelationship,
           "display_name": "Archived",
           "mandatory": False,
           "ignore_on_update": True,
+          "view_only": True,
       },
   }
 


### PR DESCRIPTION

Test case 1.
Steps to reproduce:
1. Go to Import page and Download Assessment template
2. Fill the fields required in csv file and Save
3. Import Assessment
Actual Result: "Import failed due to unknown error." error is displayed while importing assessment
Expected Result: Assessment should be imported and displayed on the Audit info page