### PR TITLE
QUICK-FIX Improve of webui fixtures' dynamic generation procedure

### DIFF
--- a/test/selenium/src/lib/dynamic_fixtures.py
+++ b/test/selenium/src/lib/dynamic_fixtures.py
@@ -250,7 +250,9 @@ def generate_common_fixtures(*fixtures):  # flake8: noqa
         elif fixture.startswith("delete_"):
           deleted_objs = delete_rest_fixture(fixture=fixture)
           dict_executed_fixtures.update({fixture: deleted_objs})
-  executed_fixtures_copy = copy.deepcopy(dict_executed_fixtures)
+  executed_fixtures_copy = (copy.deepcopy(dict_executed_fixtures) if
+                            not dict_executed_fixtures.get("selenium") else
+                            copy.copy(dict_executed_fixtures))
   return executed_fixtures_copy
 
 


### PR DESCRIPTION
This PR improve of exist webui fixtures' dynamic generation procedure and allow to avoid of creating extra copies of webdriver's instances.  It's affected cases like this: https://github.com/google/ggrc-core/pull/5797