### PR TITLE
GGRC-1603 Show exact date in task due today notification

### DIFF
--- a/src/ggrc/notifications/common.py
+++ b/src/ggrc/notifications/common.py
@@ -25,7 +25,7 @@ from ggrc import settings
 from ggrc.models import Person
 from ggrc.models import Notification
 from ggrc.rbac import permissions
-from ggrc.utils import merge_dict
+from ggrc.utils import DATE_FORMAT_US, merge_dict
 
 from ggrc_workflows.notification.data_handler import (
     cycle_tasks_cache, deleted_task_rels_cache, get_cycle_task_data
@@ -389,7 +389,8 @@ def send_email(user_email, subject, body):
 def modify_data(data):
   """Modify notification data dictionary.
 
-  For easier use in templates, it joins the due_in and due today fields
+  For easier use in templates, it computes/aggregates some additional
+  notification data.
   together.
 
   Args:
@@ -399,18 +400,13 @@ def modify_data(data):
     dict: the received dict with some additional fields for easier traversal
       in the notification template.
   """
-
-  data["due_soon"] = {}
-  if "due_in" in data:
-    data["due_soon"].update(data["due_in"])
-  if "due_today" in data:
-    data["due_soon"].update(data["due_today"])
-
   # combine "my_tasks" from multiple cycles
   data["cycle_started_tasks"] = {}
   if "cycle_data" in data:
     for cycle in data["cycle_data"].values():
       if "my_tasks" in cycle:
         data["cycle_started_tasks"].update(cycle["my_tasks"])
+
+  data["DATE_FORMAT"] = DATE_FORMAT_US
 
   return data

--- a/src/ggrc/templates/notifications/email_digest_content.html
+++ b/src/ggrc/templates/notifications/email_digest_content.html
@@ -74,17 +74,46 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                   </ul>
                 {% endif %}
 
-                {% if digest['due_soon'] %}
+                {% if digest['due_today'] %}
                   <h2 {{ style.sub_title() }} >
-                  {% if digest['due_soon']|length == 1 %}
+                    The following
+                    {{ "tasks are" if digest['due_today']|length > 1 else "task is" }}
+                    due on {{ digest['today'].strftime(digest['DATE_FORMAT']) }}
+                  </h2>
+                  <ul {{ style.list_wrap() }} >
+                  {% for task in digest['due_today'].itervalues() %}
+                    <li {{ style.list_item() }} >
+                      <a href="{{ task['cycle_task_url'] }}" {{ style.link_text() }} >
+                        {{ task['title'] }}
+                      </a>
+
+                      under
+                      <a
+                        href="{{ task['task_group_url'] }}"
+                        {{ style.link_text() }}
+                      >{{ task['task_group'].title }}</a>
+
+                      of
+                      <a
+                        href="{{ task['workflow_cycle_url'] }}"
+                        {{ style.link_text() }}
+                      >{{ task['workflow'].title }}</a>
+                    </li>
+                  {% endfor %}
+                  </ul>
+                {% endif %}
+
+                {% if digest['due_in'] %}
+                  <h2 {{ style.sub_title() }} >
+                  {% if digest['due_in']|length == 1 %}
                     1 task is
                   {% else %}
-                    {{ digest['due_soon']|length }} tasks are
+                    {{ digest['due_in']|length }} tasks are
                   {% endif %}
                   due very soon
                   </h2>
                   <ul {{ style.list_wrap() }} >
-                  {% for task in digest['due_soon'].values() %}
+                  {% for task in digest['due_in'].values() %}
                     <li {{ style.list_item() }} >
                       <a href="{{ task['cycle_task_url'] }}" {{ style.link_text() }} >
                       {{ task['title'] }}</a> {{ task['due_date_statement'] }}

--- a/src/ggrc_workflows/notification/data_handler.py
+++ b/src/ggrc_workflows/notification/data_handler.py
@@ -107,8 +107,26 @@ def get_cycle_created_task_data(notification):
   return merge_dicts(result, assignee_data, tg_assignee_data)
 
 
-def get_cycle_task_due(notification):
-  cycle_task = get_object(CycleTaskGroupObjectTask, notification.object_id)
+def get_cycle_task_due(notification, tasks_cache=None, del_rels_cache=None):
+  """Build data needed for the "task due" email notifications.
+
+  Args:
+    notification (Notification): The notification to aggregate the data for.
+    tasks_cache (dict): prefetched CycleTaskGroupObjectTask instances
+      accessible by their ID as a key
+    del_rels_cache (dict): prefetched Revision instances representing the
+      relationships to Tasks that were deleted grouped by task ID as a key
+  Returns:
+    Data aggregated in a dictionary, grouped by task assignee's email address,
+    which is used as a key.
+  """
+  if tasks_cache is None:
+    tasks_cache = {}
+
+  cycle_task = tasks_cache.get(notification.object_id)
+  if not cycle_task:
+    cycle_task = get_object(CycleTaskGroupObjectTask, notification.object_id)
+
   if not cycle_task:
     logger.warning(
         '%s for notification %s not found.',
@@ -123,14 +141,27 @@ def get_cycle_task_due(notification):
   notif_name = notification.notification_type.name
   due = "due_today" if notif_name == "cycle_task_due_today" else "due_in"
   force = cycle_task.cycle_task_group.cycle.workflow.notify_on_change
+
+  url_filter_exp = u"id={}".format(cycle_task.cycle_id)
+  task_info = get_cycle_task_dict(cycle_task, del_rels_cache=del_rels_cache)
+
+  task_info["task_group"] = cycle_task.cycle_task_group
+  task_info["task_group_url"] = cycle_task_group_url(
+      cycle_task, filter_exp=url_filter_exp)
+
+  task_info["workflow"] = cycle_task.cycle.workflow
+  task_info["workflow_cycle_url"] = cycle_task_workflow_cycle_url(
+      cycle_task, filter_exp=url_filter_exp)
+
   return {
       cycle_task.contact.email: {
           "user": data_handlers.get_person_dict(cycle_task.contact),
+          "today": date.today(),
           "force_notifications": {
               notification.id: force
           },
           due: {
-              cycle_task.id: get_cycle_task_dict(cycle_task)
+              cycle_task.id: task_info
           }
       }
   }
@@ -365,7 +396,8 @@ def get_cycle_task_data(notification, tasks_cache=None, del_rels_cache=None):
                              "quarterly_cycle_task_due_in",
                              "annually_cycle_task_due_in",
                              "cycle_task_due_today"]:
-    return get_cycle_task_due(notification)
+    return get_cycle_task_due(
+        notification, tasks_cache=tasks_cache, del_rels_cache=del_rels_cache)
   elif notification_name == "cycle_task_overdue":
     return get_cycle_task_overdue_data(
         notification, tasks_cache=tasks_cache, del_rels_cache=del_rels_cache)

--- a/test/integration/ggrc_workflows/notifications/test_task_due_notifications.py
+++ b/test/integration/ggrc_workflows/notifications/test_task_due_notifications.py
@@ -1,0 +1,145 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Integration tests for sending the notifications about WF tasks "due soon".
+"""
+
+import functools
+from datetime import date, datetime
+
+from freezegun import freeze_time
+from mock import patch
+
+import ddt
+
+from ggrc import models
+from ggrc.notifications import common
+
+from integration.ggrc import TestCase
+from integration.ggrc_workflows.generator import WorkflowsGenerator
+from integration.ggrc.api_helper import Api
+from integration.ggrc.generator import ObjectGenerator
+
+
+@ddt.ddt
+class TestTaskDueNotifications(TestCase):
+  """Test suite for task due soon/today notifications."""
+
+  # pylint: disable=invalid-name
+
+  def _fix_notification_init(self):
+    """Fix Notification object init function.
+
+    This is a fix needed for correct created_at field when using freezgun. By
+    default the created_at field is left empty and filed by database, which
+    uses system time and not the fake date set by freezugun plugin. This fix
+    makes sure that object created in freeze_time block has all dates set with
+    the correct date and time.
+    """
+    def init_decorator(init):
+      """"Adjust the value of the object's created_at attribute to now."""
+      @functools.wraps(init)
+      def new_init(self, *args, **kwargs):
+        init(self, *args, **kwargs)
+        if hasattr(self, "created_at"):
+          self.created_at = datetime.now()
+      return new_init
+
+    models.Notification.__init__ = init_decorator(models.Notification.__init__)
+
+  def setUp(self):
+    super(TestTaskDueNotifications, self).setUp()
+    self.api = Api()
+    self.wf_generator = WorkflowsGenerator()
+    self.object_generator = ObjectGenerator()
+    models.Notification.query.delete()
+
+    self._fix_notification_init()
+
+    self.random_objects = self.object_generator.generate_random_objects(2)
+    _, self.user = self.object_generator.generate_person(
+        user_role="Administrator")
+
+    person_dict = {
+        "href": "/api/people/{}".format(self.user.id),
+        "id": self.user.id,
+        "type": "Person",
+    }
+
+    self.one_time_workflow = {
+        "title": "one time test workflow",
+        "notify_on_change": True,
+        "description": "some test workflow",
+        "is_verification_needed": False,
+        "owners": [person_dict.copy()],
+        "task_groups": [{
+            "title": "one time task group",
+            "contact": person_dict.copy(),
+            "task_group_tasks": [{
+                "title": "task 1",
+                "description": "some task",
+                "contact": person_dict.copy(),
+                "start_date": date(2017, 5, 15),
+                "end_date": date(2017, 6, 11),
+            }, {
+                "title": "task 2",
+                "description": "some task 2",
+                "contact": person_dict.copy(),
+                "start_date": date(2017, 5, 8),
+                "end_date": date(2017, 6, 12),
+            }, {
+                "title": "task 3",
+                "description": "some task 3",
+                "contact": person_dict.copy(),
+                "start_date": date(2017, 5, 31),
+                "end_date": date(2017, 6, 13),
+            }, {
+                "title": "task 4",
+                "description": "some task 4",
+                "contact": person_dict.copy(),
+                "start_date": date(2017, 6, 2),
+                "end_date": date(2017, 6, 14),
+            }, {
+                "title": "task 5",
+                "description": "some task 5",
+                "contact": person_dict.copy(),
+                "start_date": date(2017, 6, 8),
+                "end_date": date(2017, 6, 15),
+            }],
+            "task_group_objects": self.random_objects
+        }]
+    }
+
+  @ddt.unpack
+  @ddt.data(
+      ("2017-06-12 12:12:12", [], []),
+      ("2017-06-13 13:13:13", ["task 3"], ["task 4"]),
+  )
+  @patch("ggrc.notifications.common.send_email")
+  def test_creating_obsolete_notifications(
+      self, fake_now, expected_due_today, expected_due_in, _
+  ):
+    """Notifications already obsolete on creation date should not be created.
+    """
+    with freeze_time("2017-06-12 09:39:32"):
+      tmp = self.one_time_workflow.copy()
+      _, workflow = self.wf_generator.generate_workflow(tmp)
+      self.wf_generator.generate_cycle(workflow)
+      response, workflow = self.wf_generator.activate_workflow(workflow)
+      self.assert200(response)
+
+    user = models.Person.query.get(self.user.id)
+
+    with freeze_time(fake_now):
+      _, notif_data = common.get_daily_notifications()
+      user_notifs = notif_data.get(user.email, {})
+
+      due_today_notifs = user_notifs.get("due_today", {})
+      titles = [n['title'] for n in due_today_notifs.itervalues()]
+      self.assertEqual(titles, expected_due_today)
+
+      due_in_notifs = user_notifs.get("due_in", {})
+      titles = [n['title'] for n in due_in_notifs.itervalues()]
+      self.assertEqual(titles, expected_due_in)


### PR DESCRIPTION
This PR changes the email text for the "cycle task due today" notifications.

---

How to test:
- create a Workflow (best to use one-time WF) with a few tasks, with some of them scheduled to be finished _tomorrow_, i.e. current date + 1 day.
- Activate workflow
- Change system time to tomorrow and visit the daily digest preview page `/_notifications/show_daily_digest`.
- Search for the "due on" text

**Expected result:**
The tasks due on fake "today" (i.e. real current date + 1 day) are indeed listed, there is no ambiguous word _"today"_ - instead, the actual date (in US format) the tasks are due on is displayed.

NOTE:
Singular or plural form should be used for the word "task" depending on the number of items in the list.

NOTE 2:
Notification should not be sent if is relevant for a past date, e.g. if creating a task that is already overdue.

Also, if creating a task that is due on the current date, a notification **is not created**, because by the time such notification would be sent (next day at ~1 AM), it would already be obsolete. Please see the comment in the code for additional explanation.

NOTE 3:
For the same reason, if you create a task that is due "tomorrow", you will not see the _"task due very soon" notification - this PR also fixes the problem with those notifications that were being sent even for overdue tasks or tasks due "today".
