### PR TITLE
GGRC-1387 Link on snapshot in New Assessment modal window doesn't open original control page 

### DIFF
--- a/src/ggrc/assets/javascripts/components/modal-connector.js
+++ b/src/ggrc/assets/javascripts/components/modal-connector.js
@@ -356,10 +356,10 @@
         this.viewModel.list.push(item);
       },
       get_mapping: function () {
-        var instance = this.viewModel.attr('instance');
+        var parentInstance = this.viewModel.attr('instance');
         var dfd = can.Deferred();
         var snapshots = GGRC.Utils.Snapshots;
-        instance.get_binding('related_objects_as_source')
+        parentInstance.get_binding('related_objects_as_source')
           .refresh_instances()
           .then(function (list) {
             var newList = list.filter(function (item) {
@@ -370,9 +370,10 @@
             newList.forEach(function (item) {
               var query;
               var instance = item.instance;
+
               if (snapshots.isSnapshotType(instance)) {
                 query = snapshots.getSnapshotItemQuery(
-                  instance, instance.child_id, instance.child_type);
+                  parentInstance, instance.child_id, instance.child_type);
 
                 GGRC.Utils.QueryAPI
                   .makeRequest(query)

--- a/src/ggrc/assets/mustache/assessments/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessments/modal_content.mustache
@@ -84,12 +84,10 @@
                           <div class="row-fluid">
                             <div class="span10">
                               <div class="tree-title-area">
-                                {{#update_link .}}
-                                  <a class="url" href="{{schemed_url link}}" target="_blank">
-                                      <i class="fa fa-{{class.table_singular}} color"></i>
-                                    {{firstexist title name email link}}
-                                  </a>
-                                {{/update_link}}
+                                <a class="url" href="{{viewLink}}" target="_blank">
+                                    <i class="fa fa-{{class.table_singular}} color"></i>
+                                  {{firstexist title name email link}}
+                                </a>
                               </div>
                             </div> <!-- span10 end -->
 


### PR DESCRIPTION
Steps to reproduce:
1. On the audit page invoke New Assessment modal window
2. Click Map object button and map a control
3. Click Control's link to view original control

**Actual Result:** Incorrect link on snapshot for view original control in New Assessment modal window. If click on link it doesn't open Controls page
**Expected Result:** If click on Control's link, original Control's page should be displayed
