### PR TITLE
GGRC-2457 GGRC-2461 Update archived flag in snapshot content when audit is archived

### DIFF
--- a/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
+++ b/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
@@ -710,6 +710,7 @@
       var model = CMS.Models[instance.child_type];
       var content = instance.revision.content;
       var type = model.root_collection;
+      var audit = CMS.Models[instance.parent.type].cache[instance.parent.id];
 
       content.isLatestRevision = instance.is_latest_revision;
       content.originalLink = '/' + type + '/' + content.id;
@@ -741,7 +742,17 @@
       }
 
       object = new model(content);
+      // Update archived flag in content when audit is archived:
+      audit.bind('change', function () {
+        var field = arguments[1];
+        var newValue = arguments[3];
+        if (field !== 'archived' || !object.snapshot) {
+          return;
+        }
+        object.snapshot.attr('archived', newValue);
+      });
       model.removeFromCacheById(content.id);  /* removes snapshot object from cache */
+
       return object;
     }
 

--- a/src/ggrc/assets/javascripts/plugins/tests/ggrc_utils_snapshots_spec.js
+++ b/src/ggrc/assets/javascripts/plugins/tests/ggrc_utils_snapshots_spec.js
@@ -68,11 +68,16 @@ describe('GGRC Utils Snapshots', function () {
     });
 
     beforeEach(function () {
+      new CMS.Models.Audit({id: 1});
       snapshot = {
         id: 12345,
         type: 'Snapshot',
         child_id: 42,
         child_type: 'Control',
+        parent: {
+          id: 1,
+          type: 'Audit'
+        },
         revision: {
           content: {
             access_control_list: [


### PR DESCRIPTION
Audit archiving flag was not properly updated when audit was archived/unarchived causing multiple bugs.

In the offlines we decided to make this issue critical as it needs to go into the 0.10.20 release, that is why I have added the critical label and why I am omitting the code freeze label.