### PR TITLE
GGRC-2475 Check conditions for null context on the frontend

### DIFF
--- a/src/ggrc/assets/javascripts/permission.js
+++ b/src/ggrc/assets/javascripts/permission.js
@@ -8,7 +8,7 @@
   var _CONDITIONS_MAP = {
     contains: function (instance, args) {
       var value = Permission._resolve_permission_variable(args.value);
-      var list_value = instance[args.list_property];
+      var list_value = instance[args.list_property] || [];
       var i;
       for (i = 0; i < list_value.length; i++) {
         if (list_value[i].id == value.id) {

--- a/src/ggrc/assets/javascripts/permission.js
+++ b/src/ggrc/assets/javascripts/permission.js
@@ -148,23 +148,25 @@
       var condition;
       var i;
 
+      conditions = conditions.concat(conditions_by_context.null || []);
+
       if (checkAdmin(0) || checkAdmin(null)) {
         return true;
       }
       if (~resources.indexOf(instance.id)) {
         return true;
       }
-      if (!this._is_allowed(permissions,
-          new Permission(action, instance_type, null)) &&
-        !this._is_allowed(permissions,
-          new Permission(action, instance_type, context.id))) {
-        return false;
+      if (conditions.length === 0 && (this._is_allowed(permissions,
+          new Permission(action, instance_type, null)) ||
+        this._is_allowed(permissions,
+          new Permission(action, instance_type, context.id)))) {
+        return true;
       }
       // Check any conditions applied per instance
       // If there are no conditions, the user has unconditional access to
       // the current instance. We can safely return true in this case.
       if (conditions.length === 0) {
-        return true;
+        return false;
       }
       for (i = 0; i < conditions.length; i++) {
         condition = conditions[i];

--- a/src/ggrc/assets/javascripts/permission.js
+++ b/src/ggrc/assets/javascripts/permission.js
@@ -37,7 +37,9 @@
       var blacklist = args.blacklist[action] || [];
       return blacklist.indexOf(instance.type) < 0;
     },
-    has_changed: can.noop,
+    has_changed: function (instance, args) {
+      return (instance.attr(args.property_name) === args.prevent_if);
+    },
     has_not_changed: function (instance, args) {
       return !(instance.attr(args.property_name) === args.prevent_if);
     }

--- a/src/ggrc/assets/javascripts/tests/permission_spec.js
+++ b/src/ggrc/assets/javascripts/tests/permission_spec.js
@@ -434,6 +434,50 @@ describe('Permission', function () {
         expect(result).toEqual(true);
       });
     });
+    describe('for null context conditions', function () {
+      it('returns false when condition not matched', function () {
+        permissions.create = {
+          Audit: {
+            contexts: [null],
+            conditions: {
+              'null': [{
+                condition: 'contains',
+                terms: {
+                  value: {id: 0},
+                  list_property: 'list_value'
+                }
+              }]
+            }
+          }
+        };
+        instance = new CMS.Models.Audit();
+        instance.attr('context', {id: 101});
+        instance.list_value = [{id: 100}];
+        result = Permission._is_allowed_for(permissions, instance, 'create');
+        expect(result).toEqual(false);
+      });
+      it('returns true when condition matched', function () {
+        permissions.create = {
+          Audit: {
+            contexts: [null],
+            conditions: {
+              'null': [{
+                condition: 'contains',
+                terms: {
+                  value: {id: 0},
+                  list_property: 'list_value'
+                }
+              }]
+            }
+          }
+        };
+        instance = new CMS.Models.Audit();
+        instance.attr('context', {id: 101});
+        instance.list_value = [{id: 0}];
+        result = Permission._is_allowed_for(permissions, instance, 'create');
+        expect(result).toEqual(true);
+      });
+    });
   });
 
   describe('is_allowed() method', function () {


### PR DESCRIPTION
This commit changes how we check permissions on the frontend.
Up until the archiving feature we never had any conditions on
the null context, but because a global editor can edit an audit
only when it's not archived we need to add a check for permissions
on the null context as well (otherwise the editor will not be able
to edit the audit - this was the bug the commit fixed).

⚠️ **Because this PR changes how we check for permissions on the frontend, we will need to test it thoroughly to make sure it doesn't cause any regressions.**