### PR TITLE
GGRC-2461 Add permission check for unmap button in snapshot dropdown

### DIFF
--- a/src/ggrc/assets/mustache/snapshots/dropdown_menu.mustache
+++ b/src/ggrc/assets/mustache/snapshots/dropdown_menu.mustache
@@ -71,18 +71,19 @@ TODO: Temporary disabled until snapshot view is added.
                     </a>
                 {{/if}}
             </li>
-
-            {{#is_info_pin}}
-              {{#if_instance_of page_instance "Assessment"}}
-                {{#is_allowed_to_map page_instance instance}}
-                  {{^options.is_in_selector}}
-                     {{#isNotInScopeModel instance.type}}
-                       {{> '/static/mustache/base_objects/unmap.mustache'}}
-                     {{/isNotInScopeModel}}
-                  {{/options.is_in_selector}}
-                {{/is_allowed_to_map}}
-              {{/if_instance_of}}
-            {{/is_info_pin}}
+            {{^if instance.snapshot.archived}}
+              {{#is_info_pin}}
+                {{#if_instance_of page_instance "Assessment"}}
+                  {{#is_allowed_to_map page_instance instance}}
+                    {{^options.is_in_selector}}
+                       {{#isNotInScopeModel instance.type}}
+                         {{> '/static/mustache/base_objects/unmap.mustache'}}
+                       {{/isNotInScopeModel}}
+                    {{/options.is_in_selector}}
+                  {{/is_allowed_to_map}}
+                {{/if_instance_of}}
+              {{/is_info_pin}}
+            {{/if}}
         </ul>
     </div>
 {{/canRead}}


### PR DESCRIPTION
Steps to reproduce:
1. Have audit with control's snapshot
2. Generate assessment based on control's snapshot
3. Archive Audit
4. Go to Assessment Info page > Control's tab
5. Navigate to control's Info pane and open 3 bb's menu: Unmap is displayed
*Actual result:* "Unmap" button is not hidden when audit is archived 
*Expected Result:* "Unmap" button should be hidden when audit is archived