### PR TITLE
GGRC-2469 Skip archived permission test when mapping objects to Issues

### DIFF
--- a/test/integration/ggrc/models/factories.py
+++ b/test/integration/ggrc/models/factories.py
@@ -25,6 +25,8 @@ from ggrc.access_control.role import AccessControlRole
 from ggrc.access_control.list import AccessControlList
 
 from integration.ggrc.models.model_factory import ModelFactory
+from integration.ggrc_basic_permissions.models \
+    import factories as rbac_factories
 
 
 def random_str(length=8, prefix="", chars=None):
@@ -161,6 +163,13 @@ class AuditFactory(TitledFactory):
     """Fix context related_object when audit is created"""
     instance = super(AuditFactory, cls)._create(target_class, *args, **kwargs)
     instance.context.related_object = instance
+
+    rbac_factories.ContextImplicationFactory(
+        context=instance.context,
+        source_context=instance.program.context,
+        context_scope="Audit",
+        source_context_scope="Program")
+
     if getattr(db.session, "single_commit", True):
       db.session.commit()
     return instance

--- a/test/integration/ggrc/models/factories.py
+++ b/test/integration/ggrc/models/factories.py
@@ -20,11 +20,11 @@ import factory
 
 from ggrc import db
 from ggrc import models
-from ggrc.login import noop
-from ggrc.fulltext import get_indexer
 
 from ggrc.access_control.role import AccessControlRole
 from ggrc.access_control.list import AccessControlList
+
+from integration.ggrc.models.model_factory import ModelFactory
 
 
 def random_str(length=8, prefix="", chars=None):
@@ -44,52 +44,6 @@ def single_commit():
     db.session.commit()
   finally:
     db.session.single_commit = True
-
-
-class ModelFactory(factory.Factory, object):
-
-  @classmethod
-  def _create(cls, target_class, *args, **kwargs):
-    instance = target_class(*args, **kwargs)
-    db.session.add(instance)
-    if isinstance(instance, models.CustomAttributeValue):
-      cls._log_event(instance.attributable)
-    if hasattr(instance, "log_json"):
-      cls._log_event(instance)
-    if getattr(db.session, "single_commit", True):
-      db.session.commit()
-    return instance
-
-  @classmethod
-  def _log_event(cls, instance):
-    indexer = get_indexer()
-    db.session.flush()
-    user = cls._get_user()
-    revision = models.Revision(
-        instance, user.id, 'created', instance.log_json())
-    event = models.Event(
-        modified_by=user,
-        action="POST",
-        resource_id=instance.id,
-        resource_type=instance.type,
-        context=instance.context,
-        revisions=[revision],
-    )
-    db.session.add(revision)
-    db.session.add(event)
-    indexer.update_record(indexer.fts_record_for(instance), commit=False)
-
-  @staticmethod
-  def _get_user():
-    user = models.Person.query.first()
-    if not user:
-      user = models.Person(
-          name=noop.default_user_name,
-          email=noop.default_user_email,
-      )
-      db.session.add(user)
-      db.session.flush()
-    return user
 
 
 class TitledFactory(ModelFactory):

--- a/test/integration/ggrc/models/factories.py
+++ b/test/integration/ggrc/models/factories.py
@@ -46,7 +46,7 @@ def single_commit():
     db.session.single_commit = True
 
 
-class ModelFactory(factory.Factory):
+class ModelFactory(factory.Factory, object):
 
   @classmethod
   def _create(cls, target_class, *args, **kwargs):
@@ -201,6 +201,15 @@ class AuditFactory(TitledFactory):
   contact = factory.LazyAttribute(lambda _: PersonFactory())
   program = factory.LazyAttribute(lambda _: ProgramFactory())
   context = factory.LazyAttribute(lambda _: ContextFactory())
+
+  @classmethod
+  def _create(cls, target_class, *args, **kwargs):
+    """Fix context related_object when audit is created"""
+    instance = super(AuditFactory, cls)._create(target_class, *args, **kwargs)
+    instance.context.related_object = instance
+    if getattr(db.session, "single_commit", True):
+      db.session.commit()
+    return instance
 
 
 class SnapshotFactory(ModelFactory):

--- a/test/integration/ggrc/models/model_factory.py
+++ b/test/integration/ggrc/models/model_factory.py
@@ -1,0 +1,66 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Factories for ggrc models.
+
+These are factories for generating regular ggrc models. The factories create a
+model and log a post event with the model revision. These do not however
+trigger signals. For tests that rely on proper signals being triggered, we must
+use the object generator in the ggrc.generator module.
+"""
+
+# pylint: disable=too-few-public-methods,missing-docstring,old-style-class
+# pylint: disable=no-init
+
+import factory
+
+from ggrc import db
+from ggrc import models
+from ggrc.login import noop
+from ggrc.fulltext import get_indexer
+
+
+class ModelFactory(factory.Factory, object):
+
+  @classmethod
+  def _create(cls, target_class, *args, **kwargs):
+    instance = target_class(*args, **kwargs)
+    db.session.add(instance)
+    if isinstance(instance, models.CustomAttributeValue):
+      cls._log_event(instance.attributable)
+    if hasattr(instance, "log_json"):
+      cls._log_event(instance)
+    if getattr(db.session, "single_commit", True):
+      db.session.commit()
+    return instance
+
+  @classmethod
+  def _log_event(cls, instance):
+    indexer = get_indexer()
+    db.session.flush()
+    user = cls._get_user()
+    revision = models.Revision(
+        instance, user.id, 'created', instance.log_json())
+    event = models.Event(
+        modified_by=user,
+        action="POST",
+        resource_id=instance.id,
+        resource_type=instance.type,
+        context=instance.context,
+        revisions=[revision],
+    )
+    db.session.add(revision)
+    db.session.add(event)
+    indexer.update_record(indexer.fts_record_for(instance), commit=False)
+
+  @staticmethod
+  def _get_user():
+    user = models.Person.query.first()
+    if not user:
+      user = models.Person(
+          name=noop.default_user_name,
+          email=noop.default_user_email,
+      )
+      db.session.add(user)
+      db.session.flush()
+    return user

--- a/test/integration/ggrc_basic_permissions/models/factories.py
+++ b/test/integration/ggrc_basic_permissions/models/factories.py
@@ -25,3 +25,11 @@ class UserRoleFactory(ModelFactory):
 
   class Meta:
     model = models.UserRole
+
+
+class ContextImplicationFactory(ModelFactory):
+  # pylint: disable=too-few-public-methods,missing-docstring,old-style-class
+  # pylint: disable=no-init
+
+  class Meta:
+    model = models.ContextImplication

--- a/test/integration/ggrc_basic_permissions/models/factories.py
+++ b/test/integration/ggrc_basic_permissions/models/factories.py
@@ -5,7 +5,7 @@
 
 from ggrc_basic_permissions import models
 
-from integration.ggrc.models.factories import ModelFactory
+from integration.ggrc.models.model_factory import ModelFactory
 
 
 class RoleFactory(ModelFactory):

--- a/test/integration/ggrc_basic_permissions/test_issue_mapping.py
+++ b/test/integration/ggrc_basic_permissions/test_issue_mapping.py
@@ -1,0 +1,156 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Test Mapping Issue mapping"""
+
+from ddt import data, ddt, unpack
+from ggrc.app import app  # NOQA pylint: disable=unused-import
+from ggrc.models import all_models
+from integration.ggrc import TestCase
+from integration.ggrc.api_helper import Api
+from integration.ggrc.models import factories
+from integration.ggrc_basic_permissions.models \
+    import factories as rbac_factories
+
+
+def _get_map_dict(destination, source):
+  return {
+      'relationship': {
+          "context": {
+              "id": destination.context.id,
+              "type": "Context"
+          },
+          "source": {
+              "id": source.id,
+              "type": source.type
+          },
+          "destination": {
+              "id": destination.id,
+              "type": destination.type
+          }
+      }
+  }
+
+
+@ddt
+class TestIssueMapping(TestCase):
+  """Test Issue mapping"""
+
+  def setup_roles(self):
+    """Setup necessary roles needed by the tests"""
+    query = all_models.Role.query
+    self.roles = {
+        'creator': query.filter_by(name="Creator").first(),
+        'auditor': query.filter_by(name="Auditor").first(),
+        'program_editor': query.filter_by(name="ProgramEditor").first()
+    }
+
+  def setup_users(self):
+    """Creates two creator users"""
+    self.users = {}
+    for user_name in ('auditor', 'auditlead'):
+      user = factories.PersonFactory()
+      rbac_factories.UserRoleFactory(
+          role=self.roles['creator'],
+          person=user)
+      self.users[user_name] = user
+
+  def setup_audits(self):
+    """Create an audit and an archived audit"""
+    self.audits = {
+        False: self.create_audit(archived=False),
+        True: self.create_audit(archived=True)
+    }
+
+  def setup_snapshots_and_issue(self):
+    """Create snapshot & issue objects"""
+    self.snapshots = {}
+    self.issues = {}
+    self.control = factories.ControlFactory()
+    revision = all_models.Revision.query.filter(
+        all_models.Revision.resource_type == self.control.type).first()
+    for is_archived in (False, True):
+      audit = self.audits[is_archived]
+      # Create a snapshot
+      self.snapshots[is_archived] = factories.SnapshotFactory(
+          child_id=revision.resource_id,
+          child_type=revision.resource_type,
+          revision=revision,
+          parent=audit,
+          context=audit.context,
+      )
+      # Create an issue
+      issue = factories.IssueFactory(
+          audit=audit,
+          context=audit.context
+      )
+      self.issues[is_archived] = issue
+      # Map issue to audit
+      factories.RelationshipFactory(
+          source=audit,
+          destination=issue,
+          context=audit.context
+      )
+
+  def create_audit(self, archived=False):
+    """Create an audit object and fix the it's context"""
+    audit = factories.AuditFactory(
+        contact=self.users['auditlead'],
+        archived=archived
+    )
+
+    # Fix Audit context as AuditFactory's lazy context
+    # does not define related_object
+    audit.context = factories.ContextFactory(
+        related_object=audit
+    )
+
+    # Add auditor & program editor roles
+    rbac_factories.UserRoleFactory(
+        context=audit.context,
+        role=self.roles['auditor'],
+        person=self.users['auditor'])
+    rbac_factories.UserRoleFactory(
+        context=audit.program.context,
+        role=self.roles['program_editor'],
+        person=self.users['auditlead'])
+    rbac_factories.ContextImplicationFactory(
+        context=audit.context,
+        source_context=audit.program.context,
+        context_scope="Audit",
+        source_context_scope="Program")
+
+    return audit
+
+  def setUp(self):
+    """Prepare data needed to run the tests"""
+    self.api = Api()
+    self.setup_roles()
+    self.setup_users()
+    self.setup_audits()
+    self.setup_snapshots_and_issue()
+
+  @data(
+      # user_name, is_archived
+      ('auditor', True),
+      ('auditlead', True),
+      ('auditor', False),
+      ('auditlead', False),
+  )
+  @unpack
+  def test_mapping_to_issue(self, user_name, is_archived):
+    """Test mapping snapshots to issue"""
+    user = self.users[user_name]
+    payload = _get_map_dict(
+        self.snapshots[is_archived],
+        self.issues[is_archived])
+    self.api.set_user(user)
+
+    # Try to map to audit
+    response = self.api.post(all_models.Relationship, payload)
+    self.assertStatus(response, 201)
+
+    rel_id = response.json['relationship']['id']
+    relationship = all_models.Relationship.query.filter_by(id=rel_id).first()
+    response = self.api.delete(relationship)
+    self.assertStatus(response, 200)

--- a/test/integration/ggrc_basic_permissions/test_issue_mapping.py
+++ b/test/integration/ggrc_basic_permissions/test_issue_mapping.py
@@ -99,12 +99,6 @@ class TestIssueMapping(TestCase):
         archived=archived
     )
 
-    # Fix Audit context as AuditFactory's lazy context
-    # does not define related_object
-    audit.context = factories.ContextFactory(
-        related_object=audit
-    )
-
     # Add auditor & program editor roles
     rbac_factories.UserRoleFactory(
         context=audit.context,

--- a/test/integration/ggrc_basic_permissions/test_issue_mapping.py
+++ b/test/integration/ggrc_basic_permissions/test_issue_mapping.py
@@ -108,11 +108,6 @@ class TestIssueMapping(TestCase):
         context=audit.program.context,
         role=self.roles['program_editor'],
         person=self.users['auditlead'])
-    rbac_factories.ContextImplicationFactory(
-        context=audit.context,
-        source_context=audit.program.context,
-        context_scope="Audit",
-        source_context_scope="Program")
 
     return audit
 

--- a/test/integration/ggrc_workflows/models/factories.py
+++ b/test/integration/ggrc_workflows/models/factories.py
@@ -10,8 +10,8 @@ import factory
 
 from ggrc_workflows import models
 from integration.ggrc.models.factories import ContextFactory
-from integration.ggrc.models.factories import ModelFactory
 from integration.ggrc.models.factories import TitledFactory
+from integration.ggrc.models.model_factory import ModelFactory
 
 
 class WorkflowFactory(TitledFactory):


### PR DESCRIPTION
The description of the issue is not correct, the map button should not be hidden, instead we should allow mapping objects to issues even when the audit is archived.