### PR TITLE
GGRC-1919 Formatting of "Created at/ Modified by" information is broken at the bottom of Assessment Info page

### DIFF
--- a/src/ggrc/assets/stylesheets/_widget.scss
+++ b/src/ggrc/assets/stylesheets/_widget.scss
@@ -192,6 +192,11 @@
     a {
       color: $textGray;
     }
+    person-info {
+      > div {
+        display: inline;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Steps to reproduce:
1. On the audit page create assessment and go to Assessment Info page
2. Look at the "Created at/ Modified by" information at the bottom of Assessment Info page

**Actual Result:** Formatting of "Created at/ Modified by" information is broken at the bottom of Assessment Info page
**Expected Result:** Formatting of "Created at/ Modified by" information should not be broken at the bottom of Assessment Info page