### PR TITLE
GGRC-1957 TreeView: several controls are not displayed in dropdown menu if create object under Global Creator

### DIFF
--- a/src/ggrc/assets/mustache/components/tree/tree-item-actions.mustache
+++ b/src/ggrc/assets/mustache/components/tree/tree-item-actions.mustache
@@ -10,24 +10,22 @@
   <ul>
     <!---->
     {{#if instance.viewLink}}
-      {{#is_allowed "view_object_page" instance}}
-        <!-- Link for open instance on info panel at bottom -->
+      <!-- Link for open instance on info panel at bottom -->
+        <li>
+          <a href="javascript://" ($click)="maximizeObject">
+            <i class="fa fa-info-circle"></i>
+            View Info
+          </a>
+        </li>
+        {{#unless isSnapshot}}
+          <!-- Link for open instance on new Browser tab -->
           <li>
-            <a href="javascript://" ($click)="maximizeObject">
-              <i class="fa fa-info-circle"></i>
-              View Info
+            <a href="{{instance.viewLink}}" target="_blank" ($click)="openObject">
+              <i class="fa fa-long-arrow-right"></i>
+              Open in a new tab
             </a>
           </li>
-          {{#unless isSnapshot}}
-            <!-- Link for open instance on new Browser tab -->
-            <li>
-              <a href="{{instance.viewLink}}" target="_blank" ($click)="openObject">
-                <i class="fa fa-long-arrow-right"></i>
-                Open in a new tab
-              </a>
-            </li>
-          {{/unless}}
-      {{/is_allowed}}
+        {{/unless}}
     {{/if}}
 
     {{#if isAllowedToEdit}}


### PR DESCRIPTION
Steps to reproduce:
1. Log as globcreator@gmail.com (engage007)
2. Create a program
3. Add Objectives tab and invoke new objective modal window
4. Fill in all the fields required and click [Save and Add another button]
5. Click [x] to close New Objective modal window and click [Map Selected] in Unified mapper
6. Hover over gear icon of objective first tier in tree view

**Actual Result:** Several controls are absent in dropdown menu: e.g. "View Info, Open in a new tab, Map to this object, Edit object"
**Expected Result:** All the controls are shown in dropdown menu while hovering gear icon according to New redesign of TreeView. See GGRC-1382 