### PR TITLE
GGRC-2520 "Uncaught TypeError: Cannot read property 'find' of null" error is shown if click Map selected button twice in Unified mapper

### DIFF
--- a/src/ggrc/assets/javascripts/components/unified-mapper/mapper.js
+++ b/src/ggrc/assets/javascripts/components/unified-mapper/mapper.js
@@ -345,7 +345,7 @@
         var que = new RefreshQueue();
 
         ev.preventDefault();
-        if (el.hasClass('disabled')) {
+        if (el.hasClass('disabled') || this.scope.attr('mapper.is_saving')) {
           return;
         }
         if (this.scope.attr('mapper.assessmentGenerator')) {

--- a/src/ggrc/assets/javascripts/components/unified-mapper/tests/mapper_spec.js
+++ b/src/ggrc/assets/javascripts/components/unified-mapper/tests/mapper_spec.js
@@ -772,11 +772,6 @@ describe('GGRC.Components.modalMapper', function () {
       result = handler.call(that, element, event);
       expect(result).toEqual('deferredSave');
     });
-    it('sets false to mapper.is_saving', function () {
-      scope.attr('mapper.is_saving', true);
-      handler.call(that, element, event);
-      expect(scope.attr('mapper.is_saving')).toEqual(false);
-    });
     it('calls closeModal()', function () {
       handler.call(that, element, event);
       expect(that.closeModal).toHaveBeenCalled();


### PR DESCRIPTION
_Steps to reproduce_:
1. Have a program
2. Go to Peoples tab and Click Map button
3. Select a person in Search results and click Map selected button twice
4. Look at the screen: JS error is shown

_Actual Result_: "Uncaught TypeError: Cannot read property 'find' of null" error is shown if click Map selected button twice in Unified mapper
_Expected Result_: no error is shown while clicking Map selected button in Unified mapper

**Note**: error occurs if map not only people but objects via Unified mapper using steps mentioned above