### PR TITLE
GGRC-2521 Required Evidence is not displayed automatically on Assessments info pane if attach evidence via required comment and evidence popup

### DIFF
--- a/src/ggrc/assets/javascripts/components/object-list/object-list.js
+++ b/src/ggrc/assets/javascripts/components/object-list/object-list.js
@@ -56,10 +56,10 @@
       /**
        *
        * @param {can.Map} ctx - current item context
-       * @param {jQuery.Event} ev - click event
        * @param {jQuery} el - selected element
+       * @param {jQuery.Event} ev - click event
        */
-      modifySelection: function (ctx, ev, el) {
+      modifySelection: function (ctx, el, ev) {
         var selectionFilter = this.attr('itemSelector');
         var isSelected = selectionFilter ?
           can.$(ev.target).closest(selectionFilter, el).length :
@@ -94,7 +94,7 @@
       }
     },
     events: {
-      '.object-list-item click': function () {
+      '.object-list__item click': function () {
         this.viewModel.attr('isInnerClick', true);
       },
       '{window} click': function () {

--- a/src/ggrc/assets/javascripts/components/related-objects/related-documents.js
+++ b/src/ggrc/assets/javascripts/components/related-objects/related-documents.js
@@ -45,18 +45,6 @@
           self.attr('documents').replace(documents);
           self.attr('isLoading', false);
         });
-      },
-      removeDocument: function (event) {
-        var item = event.item;
-        var index = this.attr('documents').indexOf(item);
-        this.attr('isLoading', true);
-        return this.attr('documents').splice(index, 1);
-      },
-      addDocuments: function (event) {
-        var items = event.items;
-        this.attr('isLoading', true);
-        return this.attr('documents').unshift
-          .apply(this.attr('documents'), items);
       }
     },
     init: function () {

--- a/src/ggrc/assets/javascripts/components/simple-modal/simple-modal.js
+++ b/src/ggrc/assets/javascripts/components/simple-modal/simple-modal.js
@@ -20,14 +20,14 @@
     template: tpl,
     viewModel: {
       extraCssClass: '@',
-      instance: null,
+      instance: {},
       modalTitle: '',
+      isDisabled: false,
       state: {
         open: false
       },
       hide: function () {
         this.attr('state.open', false);
-        this.dispatch('onClose');
       },
       show: function () {
         this.attr('state.open', true);

--- a/src/ggrc/assets/mustache/components/assessment/info-pane/info-pane.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/info-pane/info-pane.mustache
@@ -12,13 +12,13 @@
       {{> '/static/mustache/assessments/header.mustache' }}
         <div class="assessment-info-pane info-pane__body">
             <div class="assessment-attributes info-pane__main-content info-pane__main-content-with-sidebar">
-                <div class="info-pane__body-section">
+                <div class="info-pane__section">
                     <div class="info-pane__section-title">Test Plan</div>
                     <read-more {text}="instance.test_plan"></read-more>
                 </div>
-                <div class="info-pane__body-section">
+                <div class="info-pane__section">
                     <div class="info-pane__section-title">
-                        <action-toolbar class="action-toolbar">
+                        <div class="action-toolbar">
                             <div class="action-toolbar__content-item">Controls</div>
                           {{#unless instance.archived}}
                             <div class="action-toolbar__controls">
@@ -27,14 +27,14 @@
                                 </action-toolbar-control>
                             </div>
                           {{/unless}}
-                        </action-toolbar>
+                        </div>
                     </div>
-                    <assessment-mapped-controls
+                    <assessment-mapped-controls class="mapped-objects__list info-pane__section-content"
                             {instance}="instance"
                             {mapped-items}="controls"
                             title-text="Controls"></assessment-mapped-controls>
                 </div>
-                <div class="assessment-controls info-pane__body-section">
+                <div class="assessment-controls info-pane__section">
                     <div class="assessment-note">
                         <auto-save-form-status
                                 {form-saving}="formState.saving"
@@ -159,9 +159,9 @@
                                                  (on-state-change)="onStateChange(%event)"
                     ></assessment-controls-toolbar>
                 </div>
-                <div class="info-pane__body-section">
+                <div class="info-pane__section">
                     <div class="info-pane__section-title">
-                       <action-toolbar class="action-toolbar">
+                       <div class="action-toolbar">
                           <div class="action-toolbar__content-item">Related Information</div>
                          {{#unless instance.archived}}
                           <div class="action-toolbar__controls">
@@ -170,9 +170,9 @@
                             </action-toolbar-control>
                           </div>
                          {{/unless}}
-                        </action-toolbar>
+                        </div>
                     </div>
-                    <assessment-mapped-related-information
+                    <assessment-mapped-related-information class="mapped-objects__list info-pane__section-content"
                             {instance}="instance"
                             {mapped-items}="relatedInformation"
                             title-text="Related Information"></assessment-mapped-related-information>

--- a/src/ggrc/assets/mustache/components/assessment/info-pane/info-pane.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/info-pane/info-pane.mustache
@@ -140,10 +140,12 @@
                     <simple-modal {(state)}="modal.state"
                                   {modal-title}="modal.modalTitle"
                                   {instance}="instance"
-                                  (on-close)="updateItems('evidences')">
+                                  {is-disabled}="isUpdatingEvidences">
                         <ca-object-modal-content {instance}="instance"
                                                  {(content)}="modal.content"
                                                  {(state)}="state"
+                                                 {evidences}="evidences"
+                                                 {is-updating-evidences}="isUpdatingEvidences"
                                                  {form-saved-deferred}="formState.formSavedDeferred"
                                                  (before-comment-created)="addItems(%event, 'comments')"
                                                  (after-comment-created)="updateItems('comments')"

--- a/src/ggrc/assets/mustache/components/ca-object/ca-object-modal-content.mustache
+++ b/src/ggrc/assets/mustache/components/ca-object/ca-object-modal-content.mustache
@@ -28,25 +28,23 @@
             <div class="simple-modal__section-title">Evidence
               <spinner class="simple-modal__section-title-icon" {toggle}="isUpdatingEvidences"></spinner>
             </div>
-            <related-documents {instance}="instance" document-type="EVIDENCE" {^is-loading}="isUpdatingEvidences">
-                <object-list {items}="documents" {empty-message}="noItemsText">
-                  <editable-document-object-list-item {document}="{.}">
-                      <action-toolbar-control>
-                          <unmap-button
-                              (before-unmap)="removeDocument(%event)"
-                              (unmapped)="loadDocuments()"
-                              {destination}="instance"
-                              {source}="document">
-                              <i class="fa fa-trash"></i>
-                          </unmap-button>
-                      </action-toolbar-control>
-                  </editable-document-object-list-item>
-                </object-list>
-                <attach-button
-                        (before-create)="addDocuments(%event)"
-                        (refresh-evidences)="loadDocuments()"
-                        {instance}="instance"></attach-button>
-            </related-documents>
+            <object-list {items}="evidences" {empty-message}="noItemsText">
+                <editable-document-object-list-item {document}="{.}">
+                    <action-toolbar-control>
+                        <unmap-button
+                                (before-unmap)="removeItem(%event, 'evidences')"
+                                (after-unmap)="updateItems('evidences')"
+                                {destination}="instance"
+                                {source}="document">
+                            <i class="fa fa-trash"></i>
+                        </unmap-button>
+                    </action-toolbar-control>
+                </editable-document-object-list-item>
+            </object-list>
+            <attach-button
+                    (before-create)="addItems(%event, 'evidences')"
+                    (refresh-evidences)="updateItems('evidences')"
+                    {instance}="instance"></attach-button>
         </div>
       {{/if}}
     </div>

--- a/src/ggrc/assets/mustache/components/object-list-item/editable-document-object-list-item.mustache
+++ b/src/ggrc/assets/mustache/components/object-list-item/editable-document-object-list-item.mustache
@@ -3,7 +3,7 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
 
-<action-toolbar {document}="document" class="action-toolbar">
+<div class="action-toolbar">
     <div class="action-toolbar__content-item">
       <document-object-list-item {instance}="document"></document-object-list-item>
     </div>
@@ -16,4 +16,4 @@
           {{/unless}}
         {{/unless}}
     </div>
-</action-toolbar>
+</div>

--- a/src/ggrc/assets/mustache/components/object-list/object-list.mustache
+++ b/src/ggrc/assets/mustache/components/object-list/object-list.mustache
@@ -6,11 +6,11 @@
     <spinner {toggle}="isLoading" {extra-css-class}="spinnerCss" class="spinner-wrapper active"></spinner>
 {{else}}
   {{#if items.length}}
-    {{#each items}}
+    {{#items}}
         <div class="object-list-item {{#if isSelected}}selected{{/if}}" ($click)="modifySelection(%context, %event, $element)">
             <content>No item component or template is provided</content>
         </div>
-    {{/each}}
+    {{/items}}
   {{else}}
       <span class="empty-message">
         {{emptyMessage}}

--- a/src/ggrc/assets/mustache/components/object-list/object-list.mustache
+++ b/src/ggrc/assets/mustache/components/object-list/object-list.mustache
@@ -6,11 +6,11 @@
     <spinner {toggle}="isLoading" {extra-css-class}="spinnerCss" class="spinner-wrapper active"></spinner>
 {{else}}
   {{#if items.length}}
-    {{#each items}}
+    {{#items}}
         <div class="object-list__item {{#isSelected}}object-list__item-selected{{/isSelected}}" ($click)="modifySelection">
             <content>No item component or template is provided</content>
         </div>
-    {{/each}}
+    {{/items}}
   {{else}}
       <div class="object-list__item object-list__item-empty">
         {{emptyMessage}}

--- a/src/ggrc/assets/mustache/components/object-list/object-list.mustache
+++ b/src/ggrc/assets/mustache/components/object-list/object-list.mustache
@@ -6,14 +6,14 @@
     <spinner {toggle}="isLoading" {extra-css-class}="spinnerCss" class="spinner-wrapper active"></spinner>
 {{else}}
   {{#if items.length}}
-    {{#items}}
-        <div class="object-list-item {{#if isSelected}}selected{{/if}}" ($click)="modifySelection(%context, %event, $element)">
+    {{#each items}}
+        <div class="object-list__item {{#isSelected}}object-list__item-selected{{/isSelected}}" ($click)="modifySelection">
             <content>No item component or template is provided</content>
         </div>
-    {{/items}}
+    {{/each}}
   {{else}}
-      <span class="empty-message">
+      <div class="object-list__item object-list__item-empty">
         {{emptyMessage}}
-      </span>
+      </div>
   {{/if}}
 {{/if}}

--- a/src/ggrc/assets/mustache/components/simple-modal/simple-modal.mustache
+++ b/src/ggrc/assets/mustache/components/simple-modal/simple-modal.mustache
@@ -7,7 +7,7 @@
     <div class="simple-modal {{extraCssClass}}">
         <div class="simple-modal__header">
             <div class="simple-modal__header-text">{{modalTitle}}</div>
-            <button class="btn btn-small btn-icon" ($click)="hide">
+            <button class="btn btn-small btn-icon" {{#if isDisabled}}disabled{{/if}} ($click)="hide">
                 <i class="fa fa-times black"></i>
             </button>
         </div>

--- a/src/ggrc/assets/mustache/components/simple-modal/simple-modal.mustache
+++ b/src/ggrc/assets/mustache/components/simple-modal/simple-modal.mustache
@@ -7,7 +7,7 @@
     <div class="simple-modal {{extraCssClass}}">
         <div class="simple-modal__header">
             <div class="simple-modal__header-text">{{modalTitle}}</div>
-            <button class="btn btn-small btn-icon" {{#if isDisabled}}disabled{{/if}} ($click)="hide">
+            <button class="btn btn-small btn-icon" {{#isDisabled}}disabled{{/isDisabled}} ($click)="hide">
                 <i class="fa fa-times black"></i>
             </button>
         </div>

--- a/src/ggrc/assets/stylesheets/components/info-pane/_info-pane.scss
+++ b/src/ggrc/assets/stylesheets/components/info-pane/_info-pane.scss
@@ -12,8 +12,14 @@
     position: relative;
   }
 
-  &__body-section {
+  &__section {
+    display: block;
     margin: 0 16px 16px 0;
+  }
+
+  &__section-content {
+    display: block;
+    margin: 0 0 16px 0;
   }
 
   &__section-title {
@@ -43,6 +49,7 @@
   &__main-content {
     padding-bottom: 28px;
     min-width: 0;
+    flex: 1;
   }
 
   &__main-content-with-sidebar {

--- a/src/ggrc/assets/stylesheets/components/mapped-objects/_mapped-objects.scss
+++ b/src/ggrc/assets/stylesheets/components/mapped-objects/_mapped-objects.scss
@@ -5,20 +5,18 @@
 
 /* Mapped Object Component CSS spec */
 
-assessment-mapped-controls, assessment-mapped-related-information {
-  margin: 0 0 12px;
-  position: relative;
-  display: block;
+.mapped-objects__list {
+  .object-list__item-selected {
+    .mapped-objects__item {
+      position: relative;
+      border-radius: 2px;
+      box-shadow: none;
+      transition: background 0.2s ease;
+      background: $lightGray;
 
-  .selected .mapped-objects__item {
-    position: relative;
-    border-radius: 2px;
-    box-shadow: none;
-    transition: background 0.2s ease;
-    background: $lightGray;
-
-    &.mapped-snapshot-item {
-      background: $shapshotBorder;
+      &.mapped-snapshot-item {
+        background: $shapshotBorder;
+      }
     }
   }
 
@@ -139,6 +137,7 @@ assessment-mapped-controls, assessment-mapped-related-information {
     }
   }
 }
+
 .comment-object-item {
   display: block;
   margin: 0 0 16px 0;

--- a/src/ggrc/assets/stylesheets/components/object-list/_object-list.scss
+++ b/src/ggrc/assets/stylesheets/components/object-list/_object-list.scss
@@ -53,14 +53,6 @@ object-list {
     }
   }
 
-  .object-list-item {
-    line-height: 28px;
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
-    color: $text;
-    min-width: 0;
-  }
 }
 object-list {
   flex-direction: column;
@@ -70,4 +62,20 @@ related-assessment-list > spinner.active {
 }
 related-assessment-list > object-list > .empty-message {
   margin: auto;
+}
+
+.object-list {
+  &__item {
+    line-height: 28px;
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+    color: $text;
+    min-width: 0;
+  }
+
+  &__item-empty {
+    color: #999;
+    font-style: italic;
+  }
 }

--- a/src/ggrc/assets/stylesheets/components/unified-mapper/_unified-mapper.scss
+++ b/src/ggrc/assets/stylesheets/components/unified-mapper/_unified-mapper.scss
@@ -117,18 +117,23 @@ mapper-results {
     }
 
     object-list {
-      object-list-item {
+      .object-list__item {
         color: $black;
         border-bottom: 1px solid $items-separator-color;
 
         object-selection-item {
+          align-items: center;
           justify-content: flex-end;
           width: $object-selection-item-width;
+
+          input[type="checkbox"] {
+            margin: 0;
+          }
         }
       }
 
-      object-list-item:first-child,
-      spinner + object-list-item {
+      .object-list__item:first-child,
+      spinner + .object-list__item {
         border-top: 1px solid $items-separator-color;
       }
     }

--- a/src/ggrc_gdrive_integration/assets/javascripts/components/gdrive_picker_launcher.js
+++ b/src/ggrc_gdrive_integration/assets/javascripts/components/gdrive_picker_launcher.js
@@ -17,7 +17,7 @@
       itemsUploadedCallback: '@',
       confirmationCallback: '@',
       pickerActive: false,
-      beforeCreateHnadler: function (files) {
+      beforeCreateHandler: function (files) {
         var tempFiles = files.map(function (file) {
           return {
             title: file.name,
@@ -31,7 +31,7 @@
           items: tempFiles
         });
       },
-      onClickHandler: function () {
+      onClickHandler: function (scope, el, event) {
         var eventType = this.attr('click_event');
         var handler = this[eventType] || function () {};
         var confirmation = _.isFunction(this.confirmationCallback) ?
@@ -40,7 +40,8 @@
         var args = arguments;
         var that = this;
 
-        $.when(confirmation).then(function () {
+        event.preventDefault();
+        can.when(confirmation).then(function () {
           handler.apply(that, args);
         });
       },
@@ -63,6 +64,7 @@
               var picker = new google.picker.PickerBuilder()
                 .setOAuthToken(gapi.auth.getToken().access_token)
                 .setDeveloperKey(GGRC.config.GAPI_KEY)
+                .setMaxItems(10)
                 .setCallback(pickerCallback);
 
               if (el.data('type') === 'folders') {
@@ -104,7 +106,7 @@
             files = CMS.Models.GDriveFile.models(data[DOCUMENTS]);
             that.attr('pending', true);
             scope.attr('pickerActive', false);
-            that.beforeCreateHnadler(files);
+            that.beforeCreateHandler(files);
 
             return new RefreshQueue().enqueue(files).trigger()
               .then(function (files) {
@@ -196,7 +198,7 @@
             parentFolder.uploadFiles()
               .then(function (files) {
                 that.attr('pending', true);
-                that.beforeCreateHnadler(files);
+                that.beforeCreateHandler(files);
                 return new RefreshQueue().enqueue(files).trigger()
                   .then(function (fs) {
                     var mapped = can.map(fs, function (file) {

--- a/src/ggrc_gdrive_integration/assets/javascripts/models/gdrive_models.js
+++ b/src/ggrc_gdrive_integration/assets/javascripts/models/gdrive_models.js
@@ -304,6 +304,7 @@
                   .setOAuthToken(gapi.auth.getToken().access_token)
                   .enableFeature(google.picker.Feature.MULTISELECT_ENABLED)
                   .setDeveloperKey(GGRC.config.GAPI_KEY)
+                  .setMaxItems(10)
                   .setCallback(pickerCallback)
                   .build();
 

--- a/src/ggrc_gdrive_integration/assets/js_specs/components/gdrive_picker_launcher_spec.js
+++ b/src/ggrc_gdrive_integration/assets/js_specs/components/gdrive_picker_launcher_spec.js
@@ -9,6 +9,9 @@ describe('GGRC.Components.gDrivePickerLauncher', function () {
   var Component;
   var events;
   var viewModel;
+  var eventStub = {
+    preventDefault: function () {}
+  };
 
   beforeAll(function () {
     Component = GGRC.Components.get('gDrivePickerLauncher');
@@ -23,34 +26,34 @@ describe('GGRC.Components.gDrivePickerLauncher', function () {
     it('call confirmationCallback() if it is provided', function () {
       spyOn(viewModel, 'confirmationCallback');
 
-      viewModel.onClickHandler();
+      viewModel.onClickHandler(null, null, eventStub);
 
       expect(viewModel.confirmationCallback).toHaveBeenCalled();
     });
 
-    it('pass callbackResult to $.when()', function () {
-      var dfd = $.Deferred();
+    it('pass callbackResult to can.when()', function () {
+      var dfd = can.Deferred();
       var thenSpy = jasmine.createSpy('then');
       spyOn(viewModel, 'confirmationCallback').and.returnValue(dfd);
-      spyOn($, 'when').and.returnValue({
+      spyOn(can, 'when').and.returnValue({
         then: thenSpy
       });
 
-      viewModel.onClickHandler();
+      viewModel.onClickHandler(null, null, eventStub);
 
-      expect($.when).toHaveBeenCalledWith(dfd);
+      expect(can.when).toHaveBeenCalledWith(dfd);
       expect(thenSpy).toHaveBeenCalled();
     });
 
-    it('pass null to $.when() when callback is not provided', function () {
+    it('pass null to can.when() when callback is not provided', function () {
       var thenSpy = jasmine.createSpy('then');
-      spyOn($, 'when').and.returnValue({
+      spyOn(can, 'when').and.returnValue({
         then: thenSpy
       });
 
-      viewModel.onClickHandler();
+      viewModel.onClickHandler(null, null, eventStub);
 
-      expect($.when).toHaveBeenCalledWith(null);
+      expect(can.when).toHaveBeenCalledWith(null);
       expect(thenSpy).toHaveBeenCalled();
     });
   });

--- a/test/selenium/src/lib/constants/locator.py
+++ b/test/selenium/src/lib/constants/locator.py
@@ -27,6 +27,7 @@ class Common(object):
   # tree
   TREE_LIST = ".tree-action"
   TREE_HEADER = ".tree-header"
+  TREE_ITEM = " .object-list__item"
   # base
   BUTTON = "BUTTON_"
   BUTTON_CREATE_NEW = "BUTTON_CREATE_NEW_"
@@ -736,7 +737,7 @@ class WidgetInfoAssessment(WidgetInfoPanel):
                             WIDGET + " auto-save-form .flex-size-1")
   CAS_CHECKBOXES = (By.CSS_SELECTOR, '[class*="wrapper"] [type="checkbox"]')
   MAPPED_OBJECTS_TITLES_AND_DESCRIPTIONS = (By.CSS_SELECTOR,
-                                            WIDGET + ' .object-list-item')
+                                            WIDGET + Common.TREE_ITEM)
   # Assessment Attributes tab
   # People section
   _PEOPLE = WIDGET + ' [title-text="People"]'
@@ -925,7 +926,7 @@ class AdminTreeView(object):
 class UnifiedMapperTreeView(TreeView):
   MODAL = ".ggrc_controllers_mapper_modal"
   HEADER = MODAL + " .list-header"
-  ITEMS = MODAL + " .object-list-item"
+  ITEMS = MODAL + Common.TREE_ITEM
   BUTTON_SHOW_FIELDS = HEADER + " .fa-bars"
   NO_RESULTS_MESSAGE = ".well-small:not(.hidden)"
 


### PR DESCRIPTION
Description
Steps to reproduce:
1. Have audit, control's snapshot, assessment template with mandatory LCA dropdown where comment and evidence are required
4. Generate assessment based on control snapshot and assessment template
3. Navigate to assessment info pane, select the value that required comment, evidence from LCA dropdown, red mark is shown
4. Add comment and attach evidence by clicking "attach" button
5. Look at the info pane: evidence is not shown
Actual Result: Required Evidence is not displayed automatically if attach evidence via required comment and evidence popup and there is no spinner for attaching evidence
Expected Result: Required Evidence should be displayed automatically in Assessment info pane if attach evidence via required comment and evidence popup
NOTE: evidence becomes shown on assessment's info pane after refreshing the page or when open required evidence popup once again

Also in a scope of current PR 
**GGRC-2492 Evidence is not attached if close popup with evidence required earlier than evidence appears in popup** is fixed 

Description: 
[x] button is not disabled while attaching evidence and user is able to close popup with evidence required earlier than evidence appears in popup