### PR TITLE
GGRC-2494 Assessment: Red triangle is cut off in the popup with required evidence

### DIFF
--- a/src/ggrc/assets/stylesheets/_z_index.scss
+++ b/src/ggrc/assets/stylesheets/_z_index.scss
@@ -18,7 +18,7 @@ $zindex: (
   'extended-content': 1500,
   'lhs': 2050,
   'event-more': 2050,
-  'tooltip': 3100,
+  'tooltip': 4100,
   'pane-header': 3100,
   'info-pin-buttons': 3101,
   'extended-info': 3200,

--- a/src/ggrc/assets/stylesheets/components/attachment-upload-control/attachment-upload-control.scss
+++ b/src/ggrc/assets/stylesheets/components/attachment-upload-control/attachment-upload-control.scss
@@ -24,9 +24,7 @@
     align-items: center;
     justify-content: center;
     width: 28px;
-    left: -28px;
     height: 28px;
-    position: absolute;
     top: 0;
   }
   &__icon__error {

--- a/src/ggrc_gdrive_integration/assets/mustache/requests/gdrive_evidence_storage.mustache
+++ b/src/ggrc_gdrive_integration/assets/mustache/requests/gdrive_evidence_storage.mustache
@@ -13,10 +13,6 @@
                 (on-before-attach)="onBeforeCreate(%event)">Attach
         </ggrc-gdrive-picker-launcher>
     {{else}}
-      <div class="attachment-upload-control__icon attachment-upload-control__icon__error">
-        <i class="fa fa-exclamation-triangle red attachments-list-alert" rel="tooltip" data-placement="bottom"
-           data-original-title="Audit folder not set. Files will be uploaded to your GDrive root folder."></i>
-      </div>
         <ggrc-gdrive-picker-launcher class="attachment-upload-control__button"
                 instance="instance"
                 click_event="trigger_upload"
@@ -24,6 +20,13 @@
                 {items-uploaded-callback}="@itemsUploadedCallback"
                 (on-before-attach)="onBeforeCreate(%event)">Attach
         </ggrc-gdrive-picker-launcher>
+        <div class="attachment-upload-control__icon attachment-upload-control__icon__error">
+            <i class="fa fa-exclamation-triangle red attachments-list-alert"
+              rel="tooltip"
+              data-placement="bottom"
+              data-original-title="Audit folder not set. Files will be uploaded to your GDrive root folder.">
+            </i>
+        </div>
     {{/if}}
   {{else}}
   {{! This is a failure state for with_mapping, if something in the mapping doesn't refresh properly }}


### PR DESCRIPTION
_Steps to reproduce_:
1. Have audit with unassigned folder
2. Have assessment on the audit page with LCA dropdown and required evidence
2. On the Assessment Info pane select the value from LCA dropdown with required evidence
3. Hover over [Attach] button: red triangle is cut off

_Actual Result_: Red triangle is cut off in the popup with required evidence
_Expected Result_: Red triangle should not be cut off in the popup with required evidence

![screenshot-1](https://user-images.githubusercontent.com/4204416/27432264-25e10358-5758-11e7-93b9-a6ece59ae3c0.png)
