### PR TITLE
GGRC-2634 Disable [Attach] button on Assessment's Info pane while evidence is attached to Assessment

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment/attach-button.js
+++ b/src/ggrc/assets/javascripts/components/assessment/attach-button.js
@@ -15,6 +15,7 @@
     template: template,
     viewModel: {
       instance: {},
+      isAttachActionDisabled: false,
       onBeforeCreate: function (event) {
         var items = event.items;
         this.dispatch({type: 'beforeCreate', items: items});

--- a/src/ggrc/assets/mustache/components/assessment/info-pane/info-pane.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/info-pane/info-pane.mustache
@@ -65,6 +65,7 @@
                             <attach-button
                                         (before-create)="addItems(%event, 'evidences')"
                                         (refresh-evidences)="updateItems('evidences')"
+                                        {is-attach-action-disabled}="isUpdatingEvidences"
                                         {instance}="instance"></attach-button>
                         </div>
                         <div>

--- a/src/ggrc/assets/mustache/components/ca-object/ca-object-modal-content.mustache
+++ b/src/ggrc/assets/mustache/components/ca-object/ca-object-modal-content.mustache
@@ -44,6 +44,7 @@
             <attach-button
                     (before-create)="addItems(%event, 'evidences')"
                     (refresh-evidences)="updateItems('evidences')"
+                    {is-attach-action-disabled}="isUpdatingEvidences"
                     {instance}="instance"></attach-button>
         </div>
       {{/if}}

--- a/src/ggrc_gdrive_integration/assets/javascripts/components/gdrive_picker_launcher.js
+++ b/src/ggrc_gdrive_integration/assets/javascripts/components/gdrive_picker_launcher.js
@@ -10,6 +10,13 @@
     tag: 'ggrc-gdrive-picker-launcher',
     template: can.view(GGRC.mustache_path + '/gdrive/gdrive_file.mustache'),
     viewModel: {
+      define: {
+        isInactive: {
+          get: function () {
+            return this.attr('pickerActive') || this.attr('disabled');
+          }
+        }
+      },
       instance: {},
       deferred: '@',
       link_class: '@',
@@ -17,6 +24,7 @@
       itemsUploadedCallback: '@',
       confirmationCallback: '@',
       pickerActive: false,
+      disabled: false,
       beforeCreateHandler: function (files) {
         var tempFiles = files.map(function (file) {
           return {

--- a/src/ggrc_gdrive_integration/assets/javascripts/components/gdrive_picker_launcher.js
+++ b/src/ggrc_gdrive_integration/assets/javascripts/components/gdrive_picker_launcher.js
@@ -13,7 +13,7 @@
       define: {
         isInactive: {
           get: function () {
-            return this.attr('pickerActive') || this.attr('disabled');
+            return this.attr('disabled');
           }
         }
       },
@@ -59,8 +59,6 @@
         var dfd;
         var folderId = el.data('folder-id');
 
-        that.attr('pickerActive', true);
-
         // Create and render a Picker object for searching images.
         function createPicker() {
           window.oauth_dfd
@@ -97,9 +95,6 @@
               if (dialog) {
                 dialog.style.zIndex = 4001; // our modals start with 2050
               }
-            })
-            .fail(function () {
-              scope.attr('pickerActive', false);
             });
         }
 
@@ -112,7 +107,6 @@
 
           if (data[ACTION] === PICKED) {
             files = CMS.Models.GDriveFile.models(data[DOCUMENTS]);
-            that.attr('pending', true);
             scope.attr('pickerActive', false);
             that.beforeCreateHandler(files);
 
@@ -124,12 +118,10 @@
                   can.trigger(
                     that, 'modal:success', {arr: can.makeArray(arguments)});
                   el.trigger('modal:success', {arr: can.makeArray(arguments)});
-                  that.attr('pending', false);
                 });
               });
           } else if (data[ACTION] === CANCEL) {
             el.trigger('rejected');
-            scope.attr('pickerActive', false);
           }
         }
 
@@ -138,8 +130,6 @@
         );
         dfd.done(function () {
           gapi.load('picker', {callback: createPicker});
-        }).fail(function () {
-          that.attr('pickerActive', false);
         });
       },
 
@@ -162,8 +152,6 @@
             return current || isOwnFolder(mp, instance);
           }, false);
         }
-
-        that.attr('pickerActive', true);
 
         if (that.instance.attr('_transient.folder')) {
           parentFolderDfd = can.when(
@@ -205,7 +193,6 @@
             // --BM 11/19/2013
             parentFolder.uploadFiles()
               .then(function (files) {
-                that.attr('pending', true);
                 that.beforeCreateHandler(files);
                 return new RefreshQueue().enqueue(files).trigger()
                   .then(function (fs) {
@@ -230,8 +217,6 @@
                   can.trigger(
                     that, 'modal:success', {arr: can.makeArray(arguments)});
                   el.trigger('modal:success', {arr: can.makeArray(arguments)});
-                  that.attr('pending', false);
-                  that.attr('pickerActive', false);
                 });
               });
           });

--- a/src/ggrc_gdrive_integration/assets/mustache/gdrive/gdrive_file.mustache
+++ b/src/ggrc_gdrive_integration/assets/mustache/gdrive/gdrive_file.mustache
@@ -3,4 +3,4 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
 
-<button class="{{link_class}} btn btn-small btn-white" {{#if pickerActive}}disabled{{/if}} ($click)="onClickHandler"><content></content></button>
+<button class="{{link_class}} btn btn-small btn-white" {{#isInactive}}disabled{{/isInactive}} ($click)="onClickHandler"><content></content></button>

--- a/src/ggrc_gdrive_integration/assets/mustache/requests/gdrive_evidence_storage.mustache
+++ b/src/ggrc_gdrive_integration/assets/mustache/requests/gdrive_evidence_storage.mustache
@@ -8,6 +8,7 @@
         <ggrc-gdrive-picker-launcher class="attachment-upload-control__button"
                 instance="instance"
                 click_event="trigger_upload_parent"
+                {disabled}="isAttachActionDisabled"
                 {confirmation-callback}="@confirmationCallback"
                 {items-uploaded-callback}="@itemsUploadedCallback"
                 (on-before-attach)="onBeforeCreate(%event)">Attach
@@ -16,6 +17,7 @@
         <ggrc-gdrive-picker-launcher class="attachment-upload-control__button"
                 instance="instance"
                 click_event="trigger_upload"
+                {disabled}="isAttachActionDisabled"
                 {confirmation-callback}="@confirmationCallback"
                 {items-uploaded-callback}="@itemsUploadedCallback"
                 (on-before-attach)="onBeforeCreate(%event)">Attach


### PR DESCRIPTION
Description
Steps to reproduce:
1. Have audit and created assessment
2. Navigate to assessment's info pane and click attach button to attach evidence
3. Select evidence and attach selected
4. Click Attach button while the app is processing to save evidence and look at the attached evidence: delete events causes the a corrupt list
Actual Result: Attaching items while the app is processing delete events causes the a corrupt list
Expected Result: Disable [Attach] button on Assessment's Info pane while evidence is attached to Assessment