### PR TITLE
GGRC-2497 Reduce number of "query" calls when mapping objects to audits

### DIFF
--- a/src/ggrc/assets/javascripts/components/tree/tree-widget-container.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-widget-container.js
@@ -386,6 +386,9 @@
       }
 
       function _refresh(sortByUpdatedAt) {
+        if (self.attr('loading')) {
+          return;
+        }
         if (sortByUpdatedAt) {
           self.attr('sortingInfo.sortDirection', 'desc');
           self.attr('sortingInfo.sortBy', 'updated_at');


### PR DESCRIPTION
Mapping 1000 controls to an audit makes 1000+ query calls to the backend and freezes the chrome window and makes the server extremely slow.