### PR TITLE
GGRC-2629 Workflows are not filtered by Frequency value "one time"

### DIFF
--- a/src/ggrc_workflows/converters/handlers.py
+++ b/src/ggrc_workflows/converters/handlers.py
@@ -20,10 +20,6 @@ class FrequencyColumnHandler(handlers.ColumnHandler):
 
   """ Handler for workflow frequency column """
 
-  frequency_map = {
-      "one time": "one_time"
-  }
-
   def parse_item(self):
     """ parse frequency value
 
@@ -34,15 +30,16 @@ class FrequencyColumnHandler(handlers.ColumnHandler):
                      column_names=self.display_name)
       return None
     value = self.raw_value.lower()
-    frequency = self.frequency_map.get(value, value)
+    inverted_map = {v: k for k, v in
+                    self.row_converter.object_class.VALID_FREQUENCIES.items()}
+    frequency = inverted_map.get(value, value)
     if frequency not in self.row_converter.object_class.VALID_FREQUENCIES:
       self.add_error(errors.WRONG_VALUE_ERROR, column_name=self.display_name)
     return frequency
 
   def get_value(self):
-    reverse_map = {v: k for k, v in self.frequency_map.items()}
     value = getattr(self.row_converter.obj, self.key, self.value)
-    return reverse_map.get(value, value)
+    return self.row_converter.object_class.VALID_FREQUENCIES.get(value, value)
 
 
 class WorkflowColumnHandler(handlers.ParentColumnHandler):

--- a/src/ggrc_workflows/models/workflow.py
+++ b/src/ggrc_workflows/models/workflow.py
@@ -12,6 +12,7 @@ from sqlalchemy import orm
 from ggrc import builder
 from ggrc import db
 from ggrc.fulltext import get_indexer
+from ggrc.fulltext.attributes import ValueMapFullTextAttr
 from ggrc.fulltext.mixin import Indexed
 from ggrc.login import get_current_user
 from ggrc.models import mixins
@@ -33,13 +34,14 @@ class Workflow(mixins.CustomAttributable, HasOwnContext, mixins.Timeboxed,
 
   VALID_STATES = [u"Draft", u"Active", u"Inactive"]
 
-  VALID_FREQUENCIES = [
-      "one_time",
-      "weekly",
-      "monthly",
-      "quarterly",
-      "annually"
-  ]
+  # valid Frequency to user readable values mapping
+  VALID_FREQUENCIES = {
+      "one_time": "one time",
+      "weekly": "weekly",
+      "monthly": "monthly",
+      "quarterly": "quarterly",
+      "annually": "annually"
+  }
 
   @classmethod
   def default_frequency(cls):
@@ -57,7 +59,7 @@ class Workflow(mixins.CustomAttributable, HasOwnContext, mixins.Timeboxed,
       itself.
 
     Raises:
-      Value error, if the value is not None or in the VALID_FREQUENCIES array.
+      Value error, if the value is not in the VALID_FREQUENCIES
     """
     if value is None:
       value = self.default_frequency()
@@ -156,7 +158,11 @@ class Workflow(mixins.CustomAttributable, HasOwnContext, mixins.Timeboxed,
   ]
 
   _fulltext_attrs = [
-      "frequency",
+      ValueMapFullTextAttr(
+          "frequency",
+          "frequency",
+          value_map=VALID_FREQUENCIES,
+      )
   ]
 
   _aliases = {

--- a/test/integration/ggrc/services/test_query/test_basic.py
+++ b/test/integration/ggrc/services/test_query/test_basic.py
@@ -605,6 +605,27 @@ class TestAdvancedQueryAPI(BaseQueryAPITestCase):
     controls_ordered_2 = sorted(controls_unordered, key=sort_key)
     self.assertListEqual(controls_ordered_1, controls_ordered_2)
 
+  def test_query_wf_by_frequency(self):
+    """Test correct filtering of Workflows by frequency
+
+    The case this test was created for is: frequency = "one time"
+    Because it consists of two words, and we need to test the new
+    "value mapping"s for such cases
+    Also another regular test case added.
+    """
+    workflows = self._get_first_result_set(
+        self._make_query_dict("Workflow",
+                              expression=["frequency", "=", "one time"]),
+        "Workflow",
+    )
+    self.assertEqual(workflows["count"], 1)
+    workflows = self._get_first_result_set(
+        self._make_query_dict("Workflow",
+                              expression=["frequency", "=", "monthly"]),
+        "Workflow",
+    )
+    self.assertEqual(workflows["count"], 6)
+
   def test_filter_control_by_key_control(self):
     """Test correct filtering by SIGNIFICANCE field"""
     controls = self._get_first_result_set(

--- a/test/integration/ggrc/test_csvs/data_for_export_testing.csv
+++ b/test/integration/ggrc/test_csvs/data_for_export_testing.csv
@@ -593,14 +593,23 @@ clause,Title,Text of Clause,Notes,Admin,,,Clause URL,Reference URL,Code,Effectiv
 ,Startupsum 27,rch & development iPad seed round ecosystem gen-z focus user experience ownership beta startup funding.<br> User experience focus infrastructure partnership.<br> Startup stock pitch A/B testing pivot termsheet validation vesting period.<br> Bootstrapping supply chain business-to-business research & development influencer venture ecosystem android gamification.<br> Business-to-consumer crowdfunding,success 133,user@example.com,,,,,clause-23,3/26/2016,5/2/2016,active,,,,,,,,,,,,
 ,,,,,,,,,,,,,,,,,,,,,,,,
 ,,,,,,,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,,,,,,,
+Object type,"Must be unique.  Can be left empty for autogeneration.  If updating or deleting, code is required",Mandatory field,,,"Accepted values are:
+One time
+Weekly
+Monthly
+Quarterly
+Annually",,,,,,,,,,,,,,,,,,,
+Workflow,code*,title*,description,manager,frequency,force real-time email updates,custom email message,member,Need Verification,,,,,,,,,,,,,,,
+,wf-1,wf-1,test,user1@ggrc.com,One time,no,this is super custom,user2@ggrc.com,False,,,,,,,,,,,,,,,
+,wf-2,wf-2,test,user1@ggrc.com,Weekly,yes,this is super custom,user2@ggrc.com,False,,,,,,,,,,,,,,,
+,wf-3,wf-3,test,user1@ggrc.com,Monthly,no,this is super custom,user2@ggrc.com,False,,,,,,,,,,,,,,,
+,wf-4,wf-4,test,user1@ggrc.com,Quarterly,yes,this is super custom,user2@ggrc.com,False,,,,,,,,,,,,,,,
+,wf-5,wf-5,test,user1@ggrc.com,Annually,no,this is super custom,user2@ggrc.com,False,,,,,,,,,,,,,,,
+,wf-6,wf-6,test,user1@ggrc.com,Monthly,yes,this is super custom,user2@ggrc.com,False,,,,,,,,,,,,,,,
+,wf-7,wf-7,test,user1@ggrc.com,Monthly,no,this is super custom,user2@ggrc.com,False,,,,,,,,,,,,,,,
+,wf-8,wf-8,test,user1@ggrc.com,Monthly,yes,this is super custom,user2@ggrc.com,False,,,,,,,,,,,,,,,
+,wf-9,wf-9,test,user1@ggrc.com,Monthly,no,not so custom,user2@ggrc.com,False,,,,,,,,,,,,,,,
+,wf-10,wf-10,test,user1@ggrc.com,Monthly,yes,,user2@ggrc.com,False,,,,,,,,,,,,,,,
 ,,,,,,,,,,,,,,,,,,,,,,,,
 ,,,,,,,,,,,,,,,,,,,,,,,,
 Object Type,,,,,,,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
Frequency in Workflows needs same "value mapping" solution as boolean fields. Because of one value: "one_time", which is passed to backend as "one_time" and indexed ad "one_time" but users search as "one time"

~depends on: #5839~