### PR TITLE
GGRC-1593 Disable cycle task deletion by assigned users

### DIFF
--- a/src/ggrc_workflows/__init__.py
+++ b/src/ggrc_workflows/__init__.py
@@ -331,7 +331,11 @@ _cycle_task_children_attr = {
 
 
 def update_cycle_task_child_state(obj):
+  """Update child attributes state of cycle task
 
+  Args:
+    obj: Cycle task instance
+  """
   status_order = (None, 'Assigned', 'InProgress',
                   'Declined', 'Finished', 'Verified')
   status = obj.status
@@ -881,6 +885,14 @@ def start_recurring_cycles():
 
 
 def get_cycles(workflow):
+  """Retrieve valid cycles for workflow
+
+  Args:
+    workflow: Workflow instance
+
+  Returns:
+    List of cycles for provided workflow
+  """
   def is_valid_cycle(cycle):
     return ([ct for ct in cycle.cycle_task_group_object_tasks] and
             isinstance(cycle.start_date, (date, datetime)))
@@ -978,7 +990,6 @@ class WorkflowRoleContributions(RoleContributions):
           'create': ['Workflow', 'CycleTaskGroupObjectTask'],
           'update': ['CycleTaskGroupObjectTask'],
           'edit': ['CycleTaskGroupObjectTask'],
-          'delete': ['CycleTaskGroupObjectTask']
       },
       'Reader': {
           'read': ['Workflow', 'CycleTaskGroupObjectTask'],

--- a/src/ggrc_workflows/__init__.py
+++ b/src/ggrc_workflows/__init__.py
@@ -21,7 +21,8 @@ from ggrc_workflows.converters.handlers import COLUMN_HANDLERS
 from ggrc_workflows.services.common import Signals
 from ggrc_workflows.services import workflow_cycle_calculator
 from ggrc_workflows.roles import (
-    WorkflowOwner, WorkflowMember, BasicWorkflowReader, WorkflowBasicReader
+    WorkflowOwner, WorkflowMember, BasicWorkflowReader, WorkflowBasicReader,
+    WorkflowEditor
 )
 from ggrc_basic_permissions.models import Role, UserRole, ContextImplication
 from ggrc_basic_permissions.contributed_roles import (
@@ -999,6 +1000,7 @@ class WorkflowRoleDeclarations(RoleDeclarations):
   def roles(self):
     return {
         'WorkflowOwner': WorkflowOwner,
+        'WorkflowEditor': WorkflowEditor,
         'WorkflowMember': WorkflowMember,
         'BasicWorkflowReader': BasicWorkflowReader,
         'WorkflowBasicReader': WorkflowBasicReader,
@@ -1011,13 +1013,14 @@ class WorkflowRoleImplications(DeclarativeRoleImplications):
   implications = {
       (None, 'Workflow'): {
           'ProgramCreator': ['BasicWorkflowReader'],
-          'Editor': ['WorkflowOwner'],
+          'Editor': ['WorkflowEditor'],
           'Reader': ['BasicWorkflowReader'],
           'Creator': ['WorkflowBasicReader'],
       },
       ('Workflow', None): {
           'WorkflowOwner': ['WorkflowBasicReader'],
           'WorkflowMember': ['WorkflowBasicReader'],
+          'WorkflowEditor': ['WorkflowBasicReader'],
       },
   }
 

--- a/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/info.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/info.mustache
@@ -30,7 +30,7 @@
               <clipboard-link title="Get permalink" notify="true" text="{{get_permalink_url}}" />
             </li>
 
-            {{#if_equals instance.cycle.reify.is_current true}}
+
             {{#is_allowed 'delete' instance}}
               <li>
                 <a data-toggle="modal-ajax-deleteform" data-object-plural="{{model.table_plural}}" data-object-singular="{{model.model_singular}}" data-modal-reset="reset" data-modal-class="modal" data-object-id="{{instance.id}}" href="javascript://">
@@ -39,7 +39,7 @@
                 </a>
               </li>
             {{/is_allowed}}
-            {{/if_equals}}
+
           </ul>
         </div>
       {{/is_allowed}}

--- a/src/ggrc_workflows/migrations/versions/20170626123211_55501ef0f634_add_workfloweditor_role.py
+++ b/src/ggrc_workflows/migrations/versions/20170626123211_55501ef0f634_add_workfloweditor_role.py
@@ -1,0 +1,41 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Add WorkflowEditor permission role
+
+Create Date: 2017-06-26 12:32:11.421317
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+import sqlalchemy
+
+from ggrc import db
+from ggrc_basic_permissions import Role
+
+# revision identifiers, used by Alembic.
+revision = '55501ef0f634'
+down_revision = '50788b66dcd4'
+
+_NOW = sqlalchemy.func.now()
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  db.session.add(Role(
+      name="WorkflowEditor",
+      permissions_json="CODE DECLARED ROLE",
+      description="This role grants a user permission to edit workflow "
+                  "mappings and details",
+      created_at=_NOW,
+      updated_at=_NOW,
+      scope="Workflow Implied"
+  ))
+  db.session.commit()
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  wf_editor_role = Role.query.filter_by(name="WorkflowEditor").first()
+  db.session.delete(wf_editor_role)
+  db.session.commit()

--- a/src/ggrc_workflows/roles/WorkflowEditor.py
+++ b/src/ggrc_workflows/roles/WorkflowEditor.py
@@ -1,0 +1,76 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+"""A module with permissions json for Workflow Editor."""
+
+scope = "Workflow"
+description = """
+  """
+permissions = {
+    "read": [
+        "Workflow",
+        "WorkflowPerson",
+        "TaskGroup",
+        "TaskGroupObject",
+        "TaskGroupTask",
+        "Cycle",
+        "CycleTaskGroup",
+        "CycleTaskGroupObject",
+        "CycleTaskGroupObjectTask",
+        "CycleTaskEntry",
+        "UserRole",
+        "Context",
+        "Document",
+        "ObjectFolder",
+        "ObjectFile",
+    ],
+    "create": [
+        "Workflow",
+        "WorkflowPerson",
+        "TaskGroup",
+        "TaskGroupObject",
+        "TaskGroupTask",
+        "Cycle",
+        "CycleTaskGroup",
+        "CycleTaskGroupObject",
+        "CycleTaskGroupObjectTask",
+        "CycleTaskEntry",
+        "UserRole",
+        "Document",
+        "ObjectFolder",
+        "ObjectFile",
+    ],
+    "update": [
+        "Workflow",
+        "WorkflowPerson",
+        "TaskGroup",
+        "TaskGroupObject",
+        "TaskGroupTask",
+        "Cycle",
+        "CycleTaskGroup",
+        "CycleTaskGroupObject",
+        "CycleTaskGroupObjectTask",
+        "CycleTaskEntry",
+        "UserRole",
+        "Document",
+        "ObjectFolder",
+        "ObjectFile",
+    ],
+    "delete": [
+        "Workflow",
+        "WorkflowPerson",
+        "TaskGroup",
+        "TaskGroupObject",
+        "TaskGroupTask",
+        "Cycle",
+        "CycleTaskGroup",
+        "CycleTaskGroupObject",
+        "CycleTaskEntry",
+        "UserRole",
+        "Document",
+        "ObjectFolder",
+        "ObjectFile",
+    ],
+    "view_object_page": [
+        "Workflow",
+    ],
+}

--- a/src/ggrc_workflows/roles/WorkflowOwner.py
+++ b/src/ggrc_workflows/roles/WorkflowOwner.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2017 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+"""A module with permissions json for Workflow Owner."""
 
 scope = "Workflow"
 description = """
@@ -63,7 +64,14 @@ permissions = {
         "Cycle",
         "CycleTaskGroup",
         "CycleTaskGroupObject",
-        "CycleTaskGroupObjectTask",
+        {
+            "type": "CycleTaskGroupObjectTask",
+            "terms": {
+                "property_name": "cycle.is_current",
+                "value": True
+            },
+            "condition": "is"
+        },
         "CycleTaskEntry",
         "UserRole",
         "Document",

--- a/test/integration/ggrc_workflows/roles/__init__.py
+++ b/test/integration/ggrc_workflows/roles/__init__.py
@@ -46,7 +46,8 @@ class WorkflowRolesTestCase(WorkflowTestCase):
         ("creator", "Creator"),
         ("reader", "Reader"),
         ("editor", "Editor"),
-        ("admin", "Administrator")
+        ("admin", "Administrator"),
+        ("admin2", "Administrator")
     ]
     for (name, role) in users:
       _, user = self.object_generator.generate_person(


### PR DESCRIPTION
Global Administrators can remove any task (active and non-active), WorkflowOwners can remove only active tasks, users with other roles can't remove tasks at all