### PR TITLE
QUICK-FIX Bump version to 0.10.21

### DIFF
--- a/src/ggrc/settings/default.py
+++ b/src/ggrc/settings/default.py
@@ -35,7 +35,7 @@ try:
 except (ImportError):
   pass
 
-VERSION = "0.10.20-Raspberry" + BUILD_NUMBER
+VERSION = "0.10.21-Raspberry" + BUILD_NUMBER
 
 # Migration owner
 MIGRATOR = os.environ.get(


### PR DESCRIPTION
We now merge the version bump into dev immediately after the PR to release is merged, this is according to the new steps in the [deployment doc](https://docs.google.com/document/d/1cB1LqaoD9o7rh6Tum0ZRLE1xY7JX9G5Pi2VCwUKXilA).