### PR TITLE
GGRC-2433 Audit Module - BUG - cannot create a new audit with custom audit title

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/modals_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/modals_controller.js
@@ -156,10 +156,11 @@
       var instance;
       var value;
 
-      // in some cases we want to disable automapping the selected item to the
-      // modal's underlying object (e.g. we don't want to map the picked Persons
-      // to an AssessmentTemplates object)
-      if (el.data('no-automap')) {
+      // * in some cases we want to disable automapping the selected item to the
+      // * modal's underlying object (e.g. we don't want to map the picked Persons
+      // * to an AssessmentTemplates object)
+      // ** does nothing after press tab to not lose deafault value in input
+      if (el.data('no-automap') || ev.keyCode === 9) {
         return;
       }
 

--- a/src/ggrc/assets/javascripts/controllers/tree/tree_filter_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/tree/tree_filter_controller.js
@@ -79,30 +79,6 @@ can.Control('GGRC.Controllers.TreeFilter', {}, {
     this.apply_filter(this.$txtFilter.val(), selectedStates);
     ev.stopPropagation();
   },
-  'input keyup': function (el, ev) {
-    this.toggle_indicator(GGRC.query_parser.parse(el.val()));
-
-    if (ev.keyCode === 13) {
-      this.apply_filter(el.val());
-    }
-    ev.stopPropagation();
-  },
-  'input[data-lookup] focus': function (el, ev) {
-    this.autocomplete(el);
-  },
-  autocomplete: function (el) {
-    $.cms_autocomplete.call(this, el);
-  },
-  autocomplete_select: function (el, event, ui) {
-    setTimeout(function () {
-      if (ui.item.title) {
-        el.val(ui.item.title, ui.item);
-      } else {
-        el.val(ui.item.name ? ui.item.name : ui.item.email, ui.item);
-      }
-      el.trigger('change');
-    }, 0);
-  },
   '{states} change': function (states) {
     var that = this;
     this.element


### PR DESCRIPTION
Steps to reproduce:
1. On the audit page create audit
2. Open Edit Audit modal window and hide optional fields 
3. Put cursor into the "Title" field and click [Tab] button to navigate to the next field which internal audit lead
4. Click out of field: Save and close button is disabled

**Actual Result:** Save and close button is disabled if user navigates to the internal audit lead field by clicking tab button. User has to pick the suggested value from dropdown, otherwise save and close is not enabled.
**Expected Result:** Save and close button should not be disabled if user navigates to the internal audit lead field by clicking tab button. 