### PR TITLE
GGRC-2647 Disable context update for UserRole after cycle task removing

### DIFF
--- a/src/ggrc_workflows/models/cycle_task_group_object_task.py
+++ b/src/ggrc_workflows/models/cycle_task_group_object_task.py
@@ -223,6 +223,7 @@ class CycleTaskGroupObjectTask(
     return db.relationship(
         bp_models.UserRole,
         primaryjoin=primaryjoin,
+        viewonly=True,
     )
 
   @builder.simple_property


### PR DESCRIPTION
When one cycle task is deleted, linked context field in UserRole shouldn't be updated to None.