### PR TITLE
GGRC-2646: Description/Notes are not shown in Control's popup view on Assessment's Info pane for Objectives and Regulations

### DIFF
--- a/src/ggrc/assets/stylesheets/components/collapsible-panel/_collapsible-panel.scss
+++ b/src/ggrc/assets/stylesheets/components/collapsible-panel/_collapsible-panel.scss
@@ -41,6 +41,10 @@ collapsible-panel {
       }
     }
 
+    .object-list__item h6 {
+      float: none;
+    }
+
     .mapped-object-attributes custom-attributes {
       flex: 0 0 100%;
     }

--- a/src/ggrc/assets/stylesheets/components/object-list/_object-list.scss
+++ b/src/ggrc/assets/stylesheets/components/object-list/_object-list.scss
@@ -64,7 +64,7 @@ related-assessment-list > object-list > .empty-message {
   margin: auto;
 }
 
-.mapped-object-list object-list-item {
+.mapped-object-list .object-list__item {
   line-height: 18px;
 }
 

--- a/src/ggrc/assets/stylesheets/components/read-more/_read-more.scss
+++ b/src/ggrc/assets/stylesheets/components/read-more/_read-more.scss
@@ -10,6 +10,7 @@ read-more {
     transition: display 0.1s ease, height 0.1s ease, max-height 0.3s ease;
     padding: 0;
     box-sizing: border-box;
+    word-break: break-word;
 
     .read-more__body-content {
       line-height: 18px;


### PR DESCRIPTION
Steps to reproduce:
1. Have program, control, objective that is mapped to control, regulation that is mapped to control
2. Add description to control, objective, regulation
3. Create audit and go to Audit page
4. Create assessment and map control's snapshot to assessment
5. Navigate to assessment's Info pane and open Control's popup view
6. Look at the description of objectives and regulations: is not shown 
Actual Result: Description/Notes not shown in Control's popup view on Assessment's Info pane for Objectives and Regulations
Expected Result: Description/Notes should be shown in Control's popup view on Assessment's Info pane for Objectives and Regulations
![image](https://user-images.githubusercontent.com/24203972/27594160-c6a3685a-5b61-11e7-9ed0-e397c9da1d8c.png)
