### PR TITLE
GGRC-2518 Remove unneeded data from post requests

### DIFF
--- a/src/ggrc/assets/javascripts/components/access_control_list/access_control_list.js
+++ b/src/ggrc/assets/javascripts/components/access_control_list/access_control_list.js
@@ -110,7 +110,13 @@
         }
 
         can.batch.start();
-        roleEntry = {person: person, ac_role_id: roleId};
+        roleEntry = {
+          person: {
+            id: person.id,
+            type: person.type
+          },
+          ac_role_id: roleId
+        };
         inst.attr('access_control_list').push(roleEntry);
 
         if (!this.autosave) {

--- a/src/ggrc/assets/javascripts/components/modal-connector.js
+++ b/src/ggrc/assets/javascripts/components/modal-connector.js
@@ -104,7 +104,7 @@
         this.on();
       },
       destroy: function () {
-        this.viewModel.parent_instance.removeAttr('changes');
+        this.viewModel.parent_instance.removeAttr('_changes');
       },
       setListItems: function (list) {
         var currentList = this.viewModel.attr('list');
@@ -180,7 +180,7 @@
             how: 'add',
             extra: extraAttrs
           });
-          this.viewModel.parent_instance.attr('changes',
+          this.viewModel.parent_instance.attr('_changes',
             this.viewModel.changes);
         } else {
           mapping = this.viewModel.mapping ||
@@ -215,7 +215,7 @@
 
           if (this.viewModel.attr('deferred')) {
             this.viewModel.changes.push({what: obj, how: 'remove'});
-            this.viewModel.parent_instance.attr('changes',
+            this.viewModel.parent_instance.attr('_changes',
               this.viewModel.changes);
           } else {
             mapping = this.viewModel.mapping ||
@@ -300,7 +300,7 @@
         can.each(data.arr || [data], function (obj) {
           if (this.viewModel.attr('deferred')) {
             this.viewModel.changes.push({what: obj, how: 'add'});
-            this.viewModel.parent_instance.attr('changes',
+            this.viewModel.parent_instance.attr('_changes',
               this.viewModel.changes);
           } else {
             mapping = this.viewModel.mapping ||

--- a/src/ggrc/assets/javascripts/components/tests/modal-connector_spec.js
+++ b/src/ggrc/assets/javascripts/components/tests/modal-connector_spec.js
@@ -157,7 +157,7 @@ describe('GGRC.Components.modalConnector', function () {
     it('removes changes from parent_instance', function () {
       that.viewModel.parent_instance.attr('changes', [1, 2]);
       handler();
-      expect(that.viewModel.parent_instance.changes).toEqual(undefined);
+      expect(that.viewModel.parent_instance._changes).toEqual(undefined);
     });
   });
   describe('setListItems() method', function () {
@@ -219,9 +219,9 @@ describe('GGRC.Components.modalConnector', function () {
           .toEqual(jasmine.objectContaining({what: 'mock', how: 'remove'}));
       });
     it('adds all changes to parent_instance if it is deferred', function () {
-      that.viewModel.parent_instance.changes = [];
+      that.viewModel.parent_instance._changes = [];
       handler(element, event);
-      expect(that.viewModel.parent_instance.changes.length).toEqual(2);
+      expect(that.viewModel.parent_instance._changes.length).toEqual(2);
     });
   });
   describe('addMapings() method', function () {
@@ -254,9 +254,9 @@ describe('GGRC.Components.modalConnector', function () {
           .toEqual(jasmine.objectContaining({how: 'add'}));
       });
     it('adds all changes to parent_instance if it is deferred', function () {
-      that.viewModel.parent_instance.changes = [];
+      that.viewModel.parent_instance._changes = [];
       handler({}, event, {data: [1, 2]});
-      expect(that.viewModel.parent_instance.changes.length).toEqual(2);
+      expect(that.viewModel.parent_instance._changes.length).toEqual(2);
     });
   });
   describe('autocomplete_select() method', function () {
@@ -287,9 +287,9 @@ describe('GGRC.Components.modalConnector', function () {
           }));
       });
     it('adds all changes to parent_instance if it is deferred', function () {
-      that.viewModel.parent_instance.changes = [];
+      that.viewModel.parent_instance._changes = [];
       handler(element, {}, {item: 'mock'});
-      expect(that.viewModel.parent_instance.changes.length).toEqual(2);
+      expect(that.viewModel.parent_instance._changes.length).toEqual(2);
     });
   });
   describe('get_mapping() method', function () {

--- a/src/ggrc/assets/javascripts/models/assessment.js
+++ b/src/ggrc/assets/javascripts/models/assessment.js
@@ -14,7 +14,7 @@
     destroy: 'DELETE /api/assessments/{id}',
     create: 'POST /api/assessments',
     mixins: [
-      'ownable', 'contactable', 'unique_title',
+      'ownable', 'unique_title',
       'autoStatusChangeable', 'timeboxed', 'mapping-limit',
       'inScopeObjects'
     ],

--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -58,7 +58,6 @@
     destroy: 'DELETE /api/audits/{id}',
     create: 'POST /api/audits',
     mixins: [
-      'contactable',
       'unique_title',
       'ca_update',
       'timeboxed',

--- a/src/ggrc/assets/javascripts/models/business_object_models.js
+++ b/src/ggrc/assets/javascripts/models/business_object_models.js
@@ -13,7 +13,7 @@
     create: 'POST /api/org_groups',
     update: 'PUT /api/org_groups/{id}',
     destroy: 'DELETE /api/org_groups/{id}',
-    mixins: ['ownable', 'contactable', 'unique_title', 'ca_update',
+    mixins: ['ownable', 'unique_title', 'ca_update',
               'timeboxed'],
     is_custom_attributable: true,
     isRoleable: true,
@@ -77,7 +77,7 @@
     update: 'PUT /api/projects/{id}',
     destroy: 'DELETE /api/projects/{id}',
     mixins:
-      ['ownable', 'contactable', 'unique_title', 'ca_update', 'timeboxed'],
+      ['ownable', 'unique_title', 'ca_update', 'timeboxed'],
     is_custom_attributable: true,
     isRoleable: true,
     attributes: {
@@ -139,7 +139,7 @@
     update: 'PUT /api/facilities/{id}',
     destroy: 'DELETE /api/facilities/{id}',
     mixins:
-      ['ownable', 'contactable', 'unique_title', 'ca_update', 'timeboxed'],
+      ['ownable', 'unique_title', 'ca_update', 'timeboxed'],
     is_custom_attributable: true,
     isRoleable: true,
     attributes: {
@@ -202,7 +202,7 @@
     update: 'PUT /api/products/{id}',
     destroy: 'DELETE /api/products/{id}',
     mixins:
-      ['ownable', 'contactable', 'unique_title', 'ca_update', 'timeboxed'],
+      ['ownable', 'unique_title', 'ca_update', 'timeboxed'],
     is_custom_attributable: true,
     isRoleable: true,
     attributes: {
@@ -265,8 +265,7 @@
     create: 'POST /api/data_assets',
     update: 'PUT /api/data_assets/{id}',
     destroy: 'DELETE /api/data_assets/{id}',
-    mixins:
-      ['ownable', 'contactable', 'unique_title', 'ca_update', 'timeboxed'],
+    mixins: ['ownable', 'unique_title', 'ca_update', 'timeboxed'],
     is_custom_attributable: true,
     isRoleable: true,
     attributes: {
@@ -328,7 +327,7 @@
     create: 'POST /api/access_groups',
     update: 'PUT /api/access_groups/{id}',
     destroy: 'DELETE /api/access_groups/{id}',
-    mixins: ['ownable', 'contactable', 'unique_title', 'ca_update'],
+    mixins: ['ownable', 'unique_title', 'ca_update'],
     is_custom_attributable: true,
     isRoleable: true,
     attributes: {
@@ -390,8 +389,7 @@
     create: 'POST /api/markets',
     update: 'PUT /api/markets/{id}',
     destroy: 'DELETE /api/markets/{id}',
-    mixins: ['ownable', 'contactable', 'unique_title', 'ca_update',
-             'timeboxed'],
+    mixins: ['ownable', 'unique_title', 'ca_update', 'timeboxed'],
     is_custom_attributable: true,
     isRoleable: true,
     attributes: {
@@ -452,8 +450,7 @@
     create: 'POST /api/vendors',
     update: 'PUT /api/vendors/{id}',
     destroy: 'DELETE /api/vendors/{id}',
-    mixins:
-      ['ownable', 'contactable', 'unique_title', 'ca_update', 'timeboxed'],
+    mixins: ['ownable', 'unique_title', 'ca_update', 'timeboxed'],
     is_custom_attributable: true,
     isRoleable: true,
     attributes: {

--- a/src/ggrc/assets/javascripts/models/cacheable.js
+++ b/src/ggrc/assets/javascripts/models/cacheable.js
@@ -1112,6 +1112,9 @@
       }
       /* Serialize only meaningful properties */
       Object.keys(this._data).forEach(function (name) {
+        if (name.startsWith('_')) {
+          return;
+        }
         val = this[name];
         if (this.constructor.attributes && this.constructor.attributes[name]) {
           fnName = this.constructor.attributes[name];

--- a/src/ggrc/assets/javascripts/models/control.js
+++ b/src/ggrc/assets/javascripts/models/control.js
@@ -14,8 +14,7 @@
     create: 'POST /api/controls',
     update: 'PUT /api/controls/{id}',
     destroy: 'DELETE /api/controls/{id}',
-    mixins: ['ownable', 'contactable', 'unique_title', 'ca_update',
-             'timeboxed'],
+    mixins: ['ownable', 'unique_title', 'ca_update', 'timeboxed'],
     is_custom_attributable: true,
     isRoleable: true,
     attributes: {

--- a/src/ggrc/assets/javascripts/models/directive_models.js
+++ b/src/ggrc/assets/javascripts/models/directive_models.js
@@ -14,7 +14,7 @@ can.Model.Cacheable("CMS.Models.Directive", {
   , findAll : "/api/directives"
   , findOne : "/api/directives/{id}"
   , mixins : [
-    'ownable', 'contactable', 'unique_title', 'timeboxed', 'ca_update'
+    'ownable', 'unique_title', 'timeboxed', 'ca_update'
   ]
   , tree_view_options : {
     attr_view: GGRC.mustache_path + '/directives/tree-item-attr.mustache'

--- a/src/ggrc/assets/javascripts/models/issue.js
+++ b/src/ggrc/assets/javascripts/models/issue.js
@@ -13,7 +13,6 @@
     create: 'POST /api/issues',
     mixins: [
       'ownable',
-      'contactable',
       'ca_update',
       'timeboxed',
       'mapping-limit',

--- a/src/ggrc/assets/javascripts/models/mixins.js
+++ b/src/ggrc/assets/javascripts/models/mixins.js
@@ -128,40 +128,6 @@
     }
   });
 
-  can.Model.Mixin('contactable', {
-    // NB : Because the attributes object
-    //  isn't automatically cloned into subclasses by CanJS (this is an intentional
-    //  exception), when subclassing a class that uses this mixin, be sure to pull in the
-    //  parent class's attributes using `can.extend(this.attributes, <parent_class>.attributes);`
-    //  in the child class's static init function.
-    'extend:attributes': {
-      contact: 'CMS.Models.Person.stub',
-      secondary_contact: 'CMS.Models.Person.stub'
-    }
-  }, {
-    before_create: function () {
-      var person = {
-        id: GGRC.current_user.id,
-        type: 'Person'
-      };
-      if (!this.contact) {
-        this.attr('contact', person);
-      }
-    },
-    form_preload: function (newObjectForm) {
-      var person = {
-        id: GGRC.current_user.id,
-        type: 'Person'
-      };
-      if (newObjectForm && !this.contact) {
-        this.attr('contact', person);
-        this.attr('_transient.contact', person);
-      } else if (this.contact) {
-        this.attr('_transient.contact', this.contact);
-      }
-    }
-  });
-
   can.Model.Mixin('ca_update', {}, {
     after_save: function () {
       this.attr('isReadyForRender', true);

--- a/src/ggrc/assets/javascripts/models/section.js
+++ b/src/ggrc/assets/javascripts/models/section.js
@@ -23,7 +23,7 @@ can.Model.Cacheable('CMS.Models.Section', {
   destroy: 'DELETE /api/sections/{id}',
   is_custom_attributable: true,
   isRoleable: true,
-  mixins: ['ownable', 'contactable', 'unique_title', 'ca_update'],
+  mixins: ['ownable', 'unique_title', 'ca_update'],
   attributes: {
     context: 'CMS.Models.Context.stub',
     owners: 'CMS.Models.Person.stubs',
@@ -74,7 +74,7 @@ can.Model.Cacheable('CMS.Models.Clause', {
   destroy: 'DELETE /api/clauses/{id}',
   is_custom_attributable: true,
   isRoleable: true,
-  mixins: ['ownable', 'contactable', 'unique_title', 'ca_update'],
+  mixins: ['ownable', 'unique_title', 'ca_update'],
   attributes: {
     context: 'CMS.Models.Context.stub',
     owners: 'CMS.Models.Person.stubs',

--- a/src/ggrc/assets/javascripts/models/simple_models.js
+++ b/src/ggrc/assets/javascripts/models/simple_models.js
@@ -29,7 +29,7 @@
     create: 'POST /api/programs',
     update: 'PUT /api/programs/{id}',
     destroy: 'DELETE /api/programs/{id}',
-    mixins: ['contactable', 'unique_title', 'ca_update', 'timeboxed'],
+    mixins: ['unique_title', 'ca_update', 'timeboxed'],
     is_custom_attributable: true,
     isRoleable: true,
     attributes: {
@@ -121,7 +121,7 @@
     create: 'POST /api/objectives',
     update: 'PUT /api/objectives/{id}',
     destroy: 'DELETE /api/objectives/{id}',
-    mixins: ['ownable', 'contactable', 'unique_title', 'ca_update'],
+    mixins: ['ownable', 'unique_title', 'ca_update'],
     is_custom_attributable: true,
     isRoleable: true,
     attributes: {

--- a/src/ggrc/assets/javascripts/models/system.js
+++ b/src/ggrc/assets/javascripts/models/system.js
@@ -27,7 +27,7 @@ can.Model.Cacheable('CMS.Models.SystemOrProcess', {
       return CMS.Models.System.model(params);
     }
   },
-  mixins: ['ownable', 'contactable', 'unique_title', 'timeboxed'],
+  mixins: ['ownable', 'unique_title', 'timeboxed'],
   attributes: {
     context: 'CMS.Models.Context.stub',
     owners: 'CMS.Models.Person.stubs',

--- a/src/ggrc_risks/assets/javascripts/models/risk.js
+++ b/src/ggrc_risks/assets/javascripts/models/risk.js
@@ -15,12 +15,11 @@
     create: 'POST /api/risks',
     update: 'PUT /api/risks/{id}',
     destroy: 'DELETE /api/risks/{id}',
-    mixins: ['ownable', 'contactable', 'unique_title', 'ca_update'],
+    mixins: ['ownable', 'unique_title', 'ca_update'],
     is_custom_attributable: true,
     isRoleable: true,
     attributes: {
       context: 'CMS.Models.Context.stub',
-      contact: 'CMS.Models.Person.stub',
       owners: 'CMS.Models.Person.stubs',
       modified_by: 'CMS.Models.Person.stub',
       objects: 'CMS.Models.get_stubs',
@@ -36,7 +35,7 @@
     },
     statuses: ['Draft', 'Deprecated', 'Active'],
     init: function () {
-      var reqFields = ['title', 'description', 'contact'];
+      var reqFields = ['title', 'description'];
       if (this._super) {
         this._super.apply(this, arguments);
       }

--- a/src/ggrc_risks/assets/javascripts/models/threat.js
+++ b/src/ggrc_risks/assets/javascripts/models/threat.js
@@ -15,12 +15,11 @@
     create: 'POST /api/threats',
     update: 'PUT /api/threats/{id}',
     destroy: 'DELETE /api/threats/{id}',
-    mixins: ['ownable', 'contactable', 'unique_title', 'ca_update'],
+    mixins: ['ownable', 'unique_title', 'ca_update'],
     is_custom_attributable: true,
     isRoleable: true,
     attributes: {
       context: 'CMS.Models.Context.stub',
-      contact: 'CMS.Models.Person.stub',
       owners: 'CMS.Models.Person.stubs',
       modified_by: 'CMS.Models.Person.stub',
       object_people: 'CMS.Models.ObjectPerson.stubs',

--- a/src/ggrc_workflows/assets/javascripts/models/task_group.js
+++ b/src/ggrc_workflows/assets/javascripts/models/task_group.js
@@ -15,8 +15,6 @@
     create: 'POST /api/task_groups',
     update: 'PUT /api/task_groups/{id}',
     destroy: 'DELETE /api/task_groups/{id}',
-
-    mixins: ['contactable'],
     permalink_options: {
       url: '<%= base.viewLink %>#task_group_widget/' +
       'task_group/<%= instance.id %>',
@@ -91,7 +89,7 @@
     update: 'PUT /api/task_group_tasks/{id}',
     destroy: 'DELETE /api/task_group_tasks/{id}',
 
-    mixins: ['contactable', 'timeboxed'],
+    mixins: ['timeboxed'],
     permalink_options: {
       url: '<%= base.viewLink %>#task_group_widget/' +
       'task_group/<%= instance.task_group.id %>',


### PR DESCRIPTION
**Overview:**
This is how a post request for a control with a title and 5 people mapped to it looks:
https://gist.github.com/zidarsk8/801799f03a3f597a2fb0272399b6044f
This is a normal control, and Person object has a few custom attributes defined on it.
 - People sent to the backend should be stubs not full objects.
 - fields with "_" prefix should be omitted: "_transient", "_pending_joins" and any other like that
 - obsolete attributes should be removed: contact (it's already sent with ACL)
 - "attribute_name" field in custom attribute definitions array when creating assessment templates.
 - "changes" field when creating an audit
 - all cases of custom attribute definitions that are not in obj["custom_attribute_definitinos"] ... one such example is in custom attribute values property "cad" it just duplicates the data.


Note: This PR is part of the performance epic, but we are not concerned with any performance gains we might get here. Main reason for this pr is the fact that our performance tests do not have this extra bloated data included and we need to make sure they match our app as close as possible. Any performance gain is just an extra bonus.