### PR TITLE
GGRC-1944 Unified mapper duplicated if click "Map to this object" in Assessment first tier twice

### DIFF
--- a/src/ggrc/assets/javascripts/components/tree/tree-item-map.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-item-map.js
@@ -38,32 +38,12 @@
       }
     },
     instance: null,
-    cssClasses: null,
-    disableLink: false
+    cssClasses: null
   });
 
   GGRC.Components('treeItemMap', {
     tag: 'tree-item-map',
     template: template,
-    viewModel: viewModel,
-    events: {
-      'a click': function (el, ev) {
-        var self = this;
-
-        if (!self.viewModel.attr('disableLink')) {
-          el.trigger('openMapper', ev);
-        }
-
-        self.viewModel.attr('disableLink', true);
-
-        // prevent open of two mappers
-        setTimeout(function () {
-          self.viewModel.attr('disableLink', false);
-        }, 300);
-
-        ev.preventDefault();
-        return false;
-      }
-    }
+    viewModel: viewModel
   });
 })(window.can, window.GGRC);

--- a/src/ggrc/assets/javascripts/components/unified-mapper/mapper.js
+++ b/src/ggrc/assets/javascripts/components/unified-mapper/mapper.js
@@ -81,6 +81,7 @@
     deferred_list: [],
     afterShown: function () {
       this.onSubmit();
+      document.body.classList.remove('no-events');
     },
     allowedToCreate: function () {
       var isSearch = this.attr('search_only');

--- a/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
@@ -53,6 +53,14 @@
       }.bind(this));
     },
 
+    disableAll: function (el, ev) {
+      document.body.classList.add('no-events');
+    },
+
+    '[data-toggle="modal-ajax-form"] click': 'disableAll',
+    '[data-toggle="unified-search"] click': 'disableAll',
+    '[data-toggle="unified-mapper"] click': 'disableAll',
+
     initCurrentRelatedInstanses: function () {
       var instance;
       if (!GGRC.Utils.CurrentPage.isObjectContextPage()) {

--- a/src/ggrc/assets/javascripts/controllers/mapper.js
+++ b/src/ggrc/assets/javascripts/controllers/mapper.js
@@ -43,7 +43,7 @@
     }
   });
 
-  function openMapper(ev, disableMapper) {
+  $('body').on('click', selectors.join(', '), function (ev, disableMapper) {
     var btn = $(ev.currentTarget);
     var data = {};
     var isSearch;
@@ -140,13 +140,5 @@
       };
       GGRC.Controllers.MapperModal.launch(btn, can.extend(config, data));
     }
-  }
-
-  $('body').on('openMapper', function (el, ev, disableMapper) {
-    openMapper(ev, disableMapper);
-  });
-
-  $('body').on('click', selectors.join(', '), function (ev, disableMapper) {
-    openMapper(ev, disableMapper);
   });
 })(window.can, window.can.$);

--- a/src/ggrc/assets/javascripts/controllers/modals_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/modals_controller.js
@@ -107,7 +107,6 @@
         this.after_preload();
       }.bind(this));
     },
-
     after_preload: function (content) {
       var that = this;
       if (content) {
@@ -436,6 +435,8 @@
         // When we start, all the ui elements are visible
         this.options.ui_array.push(0);
       }
+
+      document.body.classList.remove('no-events');
     },
 
     setup_wysihtml5: function () {

--- a/src/ggrc/assets/mustache/components/tree/tree-item-map.mustache
+++ b/src/ggrc/assets/mustache/components/tree/tree-item-map.mustache
@@ -7,9 +7,6 @@
   {{#if allow_mapping_or_creating}}
     <a class="{{cssClasses}}"
        href="javascript://"
-       {{#if disableLink}}
-         class="disabled"
-       {{/if}}
        rel="tooltip"
        data-placement="left"
        data-toggle="unified-mapper"

--- a/src/ggrc/assets/stylesheets/modules/_modal.scss
+++ b/src/ggrc/assets/stylesheets/modules/_modal.scss
@@ -7,6 +7,10 @@
   background-color: $white;
 }
 
+.no-events {
+  pointer-events: none;
+}
+
 .field-hide {
   display: none;
   .modal & {


### PR DESCRIPTION
Steps to reproduce:
1. On the audit page create assessment
2. Hover over Assessment first tier and click "Map to this object" twice
3. Look at the Unified mapper

**Actual Result:** Unified mapper duplicated if click "Map to this object" in Assessment first tier twice
**Expected Result:** Unified mapper should not duplicated if click "Map to this object" in Assessment first tier twice