### PR TITLE
GGRC-1526 Add Assessment Type to Assessment

### DIFF
--- a/src/ggrc/migrations/versions/20170628101923_55575f96bb3c_add_assessment_type.py
+++ b/src/ggrc/migrations/versions/20170628101923_55575f96bb3c_add_assessment_type.py
@@ -30,8 +30,21 @@ def upgrade():
           server_default="Control",
       )
   )
+  # Change CA help text "Assessment type" to "Assessment Category"
+  op.execute(
+      'UPDATE custom_attribute_definitions '
+      'SET helptext = "Assessment Category" '
+      'WHERE helptext = "Assessment type" '
+      'AND definition_type = "assessment" AND title = "Type";'
+  )
 
 
 def downgrade():
   """Downgrade database schema and/or data back to the previous revision."""
   op.drop_column('assessments', 'assessment_type')
+  op.execute(
+      'UPDATE custom_attribute_definitions '
+      'SET helptext = "Assessment type" '
+      'WHERE helptext = "Assessment Category"'
+      'AND definition_type = "assessment" AND title = "Type";'
+  )

--- a/src/ggrc/migrations/versions/20170628101923_55575f96bb3c_add_assessment_type.py
+++ b/src/ggrc/migrations/versions/20170628101923_55575f96bb3c_add_assessment_type.py
@@ -1,0 +1,37 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Add assessment_type field to Assessment
+
+Create Date: 2017-06-28 10:19:23.789991
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+import sqlalchemy as sa
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '55575f96bb3c'
+down_revision = '436dc4cea0f3'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  op.add_column(
+      'assessments',
+      sa.Column(
+          'assessment_type',
+          sa.String(length=250),
+          nullable=False,
+          server_default="Control",
+      )
+  )
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  op.drop_column('assessments', 'assessment_type')

--- a/src/ggrc/models/assessment.py
+++ b/src/ggrc/models/assessment.py
@@ -271,6 +271,14 @@ class Assessment(Roleable, statusable.Statusable, AuditRelationship,
     # pylint: disable=unused-argument
     return self.validate_conclusion(value)
 
+  @validates("assessment_type")
+  def validate_assessment_type(self, key, value):
+    # pylint: disable=unused-argument
+    from ggrc.models.all_models import __all__ as model_names
+    if value and value not in model_names:
+      raise ValueError("Assessment type '{}' doesn't exist".format(value))
+    return value
+
   @classmethod
   def _ignore_filter(cls, _):
     return None

--- a/src/ggrc/models/assessment.py
+++ b/src/ggrc/models/assessment.py
@@ -111,6 +111,9 @@ class Assessment(Roleable, statusable.Statusable, AuditRelationship,
   audit_id = deferred(
       db.Column(db.Integer, db.ForeignKey('audits.id'), nullable=False),
       'Assessment')
+  assessment_type = deferred(
+      db.Column(db.String, nullable=False, server_default="Control"),
+      "Assessment")
 
   @declared_attr
   def object_level_definitions(cls):  # pylint: disable=no-self-argument
@@ -146,6 +149,7 @@ class Assessment(Roleable, statusable.Statusable, AuditRelationship,
       'design',
       'operationally',
       'audit',
+      'assessment_type',
       PublishOnly('archived'),
       PublishOnly('object')
   ]

--- a/src/ggrc/models/assessment.py
+++ b/src/ggrc/models/assessment.py
@@ -201,6 +201,10 @@ class Assessment(Roleable, statusable.Statusable, AuditRelationship,
           "filter_by": "_ignore_filter",
           "type": reflection.AttributeInfo.Type.MAPPING,
       },
+      "assessment_type": {
+          "display_name": "Assessment Type",
+          "mandatory": False,
+      },
       "url": "Assessment URL",
       "design": "Conclusion: Design",
       "operationally": "Conclusion: Operation",
@@ -273,10 +277,14 @@ class Assessment(Roleable, statusable.Statusable, AuditRelationship,
 
   @validates("assessment_type")
   def validate_assessment_type(self, key, value):
+    """Validate assessment type to be the same as existing model name"""
     # pylint: disable=unused-argument
-    from ggrc.models.all_models import __all__ as model_names
-    if value and value not in model_names:
-      raise ValueError("Assessment type '{}' doesn't exist".format(value))
+    # pylint: disable=no-self-use
+    from ggrc.snapshotter.rules import Types
+    if value and value not in Types.all:
+      raise ValueError(
+          "Assessment type '{}' is not snapshotable".format(value)
+      )
     return value
 
   @classmethod

--- a/src/ggrc/models/hooks/assessment.py
+++ b/src/ggrc/models/hooks/assessment.py
@@ -95,6 +95,8 @@ def init_hook():
         assessment.test_plan = snapshot.revision.content['test_plan']
       else:
         assessment.test_plan = template.procedure_description
+      if template.template_object_type:
+        assessment.assessment_type = template.template_object_type
 
   @signals.Restful.model_put.connect_via(Assessment)
   @signals.Restful.model_put.connect_via(Issue)

--- a/src/ggrc/models/reflection.py
+++ b/src/ggrc/models/reflection.py
@@ -66,6 +66,7 @@ ATTRIBUTE_ORDER = (
     "secondary_assessor",
     "secondary_contact",
     "url",
+    "assessment_type",
     "reference_url",
     "verify_frequency",
     "name",

--- a/test/integration/ggrc/converters/test_import_helpers.py
+++ b/test/integration/ggrc/converters/test_import_helpers.py
@@ -405,6 +405,7 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Assignees",
         "Verifiers",
         "Assessment URL",
+        "Assessment Type",
         "Reference URL",
         "Evidence",
         "Url",

--- a/test/integration/ggrc/models/test_assessment.py
+++ b/test/integration/ggrc/models/test_assessment.py
@@ -210,7 +210,7 @@ class TestAssessmentGeneration(ggrc.TestCase):
       self.control = factories.ControlFactory(test_plan="Control Test Plan")
       self.snapshot = self._create_snapshots(self.audit, [self.control])[0]
 
-  def assessment_post(self, template=None):
+  def assessment_post(self, template=None, extra_data=None):
     """Helper function to POST an assessment"""
     assessment_dict = {
         "_generated": True,
@@ -233,6 +233,8 @@ class TestAssessmentGeneration(ggrc.TestCase):
           "id": template.id,
           "type": "AssessmentTemplate"
       }
+    if extra_data:
+      assessment_dict.update(extra_data)
 
     return self.api.post(all_models.Assessment, {
         "assessment": assessment_dict
@@ -717,3 +719,33 @@ class TestAssessmentGeneration(ggrc.TestCase):
       else:
         self.assertEqual([url.link for url in asmt.document_url], urls)
         self.assertEqual([ev.link for ev in asmt.document_evidence], evidences)
+
+  @ddt.data(
+      (None, "Control", "Control"),
+      (None, "Objective", "Objective"),
+      (None, None, "Control"),
+      ("Market", "Objective", "Market"),
+      ("Objective", "Control", "Objective"),
+      ("Objective", "Objective", "Objective"),
+      ("Objective", None, "Objective"),
+  )
+  @ddt.unpack
+  def test_generated_assessment_type(self, templ_type, obj_type, exp_type):
+    """Test assessment type for generated assessments"""
+    template = None
+    if templ_type:
+      template = factories.AssessmentTemplateFactory(
+          template_object_type=templ_type
+      )
+    assessment_type = None
+    if obj_type:
+      assessment_type = {"assessment_type": obj_type}
+
+    response = self.assessment_post(
+        template=template,
+        extra_data=assessment_type
+    )
+    self.assertEqual(response.status_code, 201)
+
+    assessment = all_models.Assessment.query.first()
+    self.assertEqual(assessment.assessment_type, exp_type)

--- a/test/integration/ggrc/models/test_assessment.py
+++ b/test/integration/ggrc/models/test_assessment.py
@@ -728,6 +728,9 @@ class TestAssessmentGeneration(ggrc.TestCase):
       ("Objective", "Control", "Objective"),
       ("Objective", "Objective", "Objective"),
       ("Objective", None, "Objective"),
+      ("Invalid Type", "Invalid Type", None),
+      (None, "Invalid Type", None),
+      ("Invalid Type", None, None),
   )
   @ddt.unpack
   def test_generated_assessment_type(self, templ_type, obj_type, exp_type):
@@ -745,7 +748,9 @@ class TestAssessmentGeneration(ggrc.TestCase):
         template=template,
         extra_data=assessment_type
     )
-    self.assertEqual(response.status_code, 201)
-
-    assessment = all_models.Assessment.query.first()
-    self.assertEqual(assessment.assessment_type, exp_type)
+    if exp_type:
+      self.assertEqual(response.status_code, 201)
+      assessment = all_models.Assessment.query.first()
+      self.assertEqual(assessment.assessment_type, exp_type)
+    else:
+      self.assertEqual(response.status_code, 400)


### PR DESCRIPTION
**Functional Requirements:**
1. All mapped snapshot(s) of type X should be displayed on top of Assessment info pane/page if 'Assessment type' = X. (Use Cases 1-3)
2. All mapped snapshot(s) of type that is not equal to the type specified in 'Assessment type' for the assessment should be displayed at the bottom of Assessment info pane / tab. (Use Cases 1-3)
3. 'Assessment Type' attribute should be auto-populated based on user selection for 'Object Type' on 'Generate Assessment' mapper, if Assessment is generated without template. (Use Case 4)

**USE CASE 1** for Assessment that is created
1. User goes to GGRC.
2. User goes to Audit.
3. User goes to 'Assessments' tab.
4. User clicks CREATE button to open 'Add Assessment' pop-up.
5. User selects any value in 'Assessment object' dropdown, for example, 'Objectives'.
6. User fills out all the required fields and saves an Assessment.
7. User maps any Objective to newly-created Assessment.
8. User maps any Control to newly-created Assessment.
9. User clicks newly-created Assessment row in tree view to open Assessment info pane.
Expected result1: Mapped Objectives should be displayed under grey box on Assessment info pane.
Expected result 2: Mapped Controls should be displayed in RELATED INFORMATION section on Assessment info pane.

**USE CASE 2** Edit Assessment.
Use steps 1-9 from USE CASE 1.
10. User clicks 'EDIT' link for a newly added Assessment to open 'Edit Assessment' pop-up.
11. User changes 'Assessment Type' from 'Objectives' to 'Controls'.
12. User saves changes.
13. User clicks newly-created Assessment row in tree view to open Assessment info pane.
Expected result1: Mapped Controls should be displayed under grey box on Assessment info pane.
Expected result 2: Mapped Objectives should be displayed in RELATED INFORMATION section on Assessment info pane.

**USE CASE 3** Generate Assessment based on template.
1. User goes to GGRC.
2. User goes to Audit.
3. User goes to 'Assessment Template' tab.
4. User clicks CREATE button to open 'Add Assessment Template' pop-up.
5. User selects any value in 'Assessment object' dropdown, for example, 'Objectives'.
6. User fills out all the required fields and saves the Assessment Template.
7. User clicks 'AUTOGENERATE' button to open 'Generate Assessments' mapper.
8. User selects newly created Assessment Template.
9. User selects an Objective and an Control to generate Assessments for them.
10. User generates Assessments.
11. User clicks User clicks newly-created Assessment for Objective row in tree view to open Assessment info pane.
Expected result1: Mapped Objectives should be displayed under grey box on Assessment info pane.
Expected result 2: Mapped Controls should be displayed in RELATED INFORMATION section on Assessment info pane.
12. User clicks User clicks newly-created Assessment for Control row in tree view to open Assessment info pane.
Expected result1: Mapped Controls should be displayed under grey box on Assessment info pane.
Expected result 2: Mapped Objectives should be displayed in RELATED INFORMATION section on Assessment info pane.

**USE CASE 4** Generate Assessment without template.
1. User goes to GGRC.
2. User goes to Audit.
3. User clicks 'AUTOGENERATE' button to open 'Generate Assessments' mapper.
4. User selects 'no template'.
5. User selects Objective in 'Object Type' dropdown.
6. User selects an Objective from tree view to generate Assessments for it.
7. User generates Assessments.
8. User clicks newly-generated Assessment row in tree view to open Assessment info pane.
Expected result1: 'Objectives' is auto-populated in 'Assessment Type' dropdown.
Expected result2: Mapped Objectives should be displayed under grey box on Assessment info pane.
Expected result3: Mapped Controls should be displayed in RELATED INFORMATION section on Assessment info pane.

This ticket depend on #5859