### PR TITLE
QUICK-FIX Test of adding comment to Assessment via Info Panel

### DIFF
--- a/test/selenium/src/lib/constants/locator.py
+++ b/test/selenium/src/lib/constants/locator.py
@@ -761,6 +761,8 @@ class WidgetInfoAssessment(WidgetInfoPanel):
   CODE_CSS = (By.CSS_SELECTOR, _CODE)
   CODE_HEADER_CSS = (By.CSS_SELECTOR, _CODE + " .info-pane__section-title")
   CODE_VALUE_CSS = (By.CSS_SELECTOR, _CODE + " .inline__content-wrapper")
+  # comments section
+  COMMENTS_CSS = (By.CSS_SELECTOR, ".assessment-comments")
 
 
 class WidgetInfoAssessmentTemplate(WidgetInfoPanel):
@@ -1108,3 +1110,21 @@ class CustomAttributesItemContent(AdminCustomAttributes):
   EDIT_BTN = (By.CSS_SELECTOR, CONTENT_OPEN + " " + Common.TREE_LIST)
   ADD_BTN = (By.CSS_SELECTOR, CONTENT_OPEN + " .add-item .btn")
   TREE_SPINNER = (By.CSS_SELECTOR, ".tree-spinner")
+
+
+class CommentsPanel(object):
+  """Locators for comments' panel."""
+  # _form = ".comment-add-form"
+  HEADER_LBL_CSS = (By.CSS_SELECTOR, ".info-pane__section-title")
+  INPUT_TXT_CSS = (By.CSS_SELECTOR, ".ql-editor")
+  CB_SEND_CSS = (By.CSS_SELECTOR, ".comment-add-form__toolbar-item")
+  CB_SPINNER_CSS = (By.CSS_SELECTOR, ".spinner")
+  ADD_BTN_CSS = (By.CSS_SELECTOR, "comment-add-button")
+  ITEMS_CSS = (By.CSS_SELECTOR, "comment-list-item")
+
+
+class CommentItem(object):
+  """Locators for single item in comments' panel."""
+  AUTHOR_CSS = (By.CSS_SELECTOR, ".person-holder")
+  DATETIME_CSS = (By.CSS_SELECTOR, ".comment-object-item__author_info")
+  CONTENT_CSS = (By.CSS_SELECTOR, ".comment-object-item__text")

--- a/test/selenium/src/lib/constants/objects.py
+++ b/test/selenium/src/lib/constants/objects.py
@@ -36,6 +36,7 @@ RISKS = "risks"
 THREATS = "threats"
 RISK_ASSESSMENTS = "risk_assessments"
 CUSTOM_ATTRIBUTES = "custom_attribute_definitions"
+COMMENTS = "comments"
 
 ALL_SNAPSHOTABLE_OBJS = (
     ACCESS_GROUPS, CLAUSES, CONTRACTS, CONTROLS, DATA_ASSETS, FACILITIES,

--- a/test/selenium/src/lib/element/widget_bar.py
+++ b/test/selenium/src/lib/element/widget_bar.py
@@ -12,18 +12,18 @@ from lib.utils import selenium_utils
 class Tab(base.Tab):
   "Tab base elements."
   # pylint: disable=too-few-public-methods
-  def __init__(self, driver, element_locator):
+  def __init__(self, driver, _locator_or_element):
     """
     Args: driver (base.CustomDriver
     """
-    super(Tab, self).__init__(driver, element_locator)
+    super(Tab, self).__init__(driver, _locator_or_element)
     self.member_count = None
     self._set_member_count()
 
   def _set_member_count(self):
     "Select member count."
     widget_title = selenium_utils.get_when_visible(
-        self._driver, self._locator).text
+        self._driver, self.locator_or_element).text
     if "(" not in widget_title:
       self.member_count = int(widget_title)
     else:

--- a/test/selenium/src/lib/entities/entities_factory.py
+++ b/test/selenium/src/lib/entities/entities_factory.py
@@ -15,7 +15,7 @@ from lib.constants.element import AdminWidgetCustomAttributes
 from lib.entities.entity import (
     Entity, PersonEntity, CustomAttributeEntity, ProgramEntity, ControlEntity,
     ObjectiveEntity, AuditEntity, AssessmentTemplateEntity, AssessmentEntity,
-    IssueEntity)
+    IssueEntity, CommentEntity)
 from lib.utils import string_utils
 from lib.utils.string_utils import (random_list_strings, random_string,
                                     random_uuid)
@@ -34,6 +34,7 @@ class EntitiesFactory(object):
   obj_asmt = unicode(objects.get_singular(objects.ASSESSMENTS, title=True))
   obj_issue = unicode(objects.get_singular(objects.ISSUES, title=True))
   obj_ca = unicode(objects.get_singular(objects.CUSTOM_ATTRIBUTES))
+  obj_comment = unicode(objects.get_singular(objects.COMMENTS, title=True))
 
   types_of_values_ui_like_attrs = (str, unicode, int)
   all_objs_attrs_names = Entity().get_attrs_names_for_entities()
@@ -89,6 +90,12 @@ class EntitiesFactory(object):
         if attr_name in ["custom_attribute_values"]:
           converted_attr_value = {attr_value.get("custom_attribute_id"):
                                   attr_value.get("attribute_value")}
+        if obj_attr_name == "comments":
+          converted_attr_value = {
+              k: (string_utils.convert_str_to_datetime(v) if
+                  k == "created_at" and isinstance(v, unicode) else v)
+              for k, v in attr_value.iteritems()
+              if k in ["modified_by", "created_at", "description"]}
         return converted_attr_value
     origin_obj = copy.deepcopy(obj)
     for obj_attr_name in obj.__dict__.keys():
@@ -252,6 +259,43 @@ class EntitiesFactory(object):
     """Generate email in unicode format according to domain."""
     return unicode("{mail_name}@{domain}".format(
         mail_name=random_uuid(), domain=domain))
+
+
+class CommentsFactory(EntitiesFactory):
+  """Factory class for Comments entities."""
+  # pylint: disable=too-many-locals
+
+  obj_attrs_names = Entity().get_attrs_names_for_entities(CommentEntity)
+
+  @classmethod
+  def create_empty(cls):
+    """Create blank Comment object."""
+    empty_comment = CommentEntity()
+    empty_comment.type = cls.obj_comment
+    return empty_comment
+
+  @classmethod
+  def create(cls, type=None, id=None, href=None, modified_by=None,
+             created_at=None, description=None):
+    """Create Comment object.
+    Random values will be used for description.
+    Predictable values will be used for type, owners, modified_by.
+    """
+    comment_entity = cls._create_random_comment()
+    comment_entity = cls.update_objs_attrs_values_by_entered_data(
+        objs=comment_entity, is_allow_none_values=False, type=type, id=id,
+        href=href, modified_by=modified_by,
+        created_at=created_at, description=description)
+    return comment_entity
+
+  @classmethod
+  def _create_random_comment(cls):
+    """Create Comment entity with randomly and predictably filled fields."""
+    random_comment = CommentEntity()
+    random_comment.type = cls.obj_comment
+    random_comment.modified_by = ObjectPersonsFactory().default().__dict__
+    random_comment.description = cls.generate_string(cls.obj_comment)
+    return random_comment
 
 
 class ObjectPersonsFactory(EntitiesFactory):

--- a/test/selenium/src/lib/entities/entity.py
+++ b/test/selenium/src/lib/entities/entity.py
@@ -115,6 +115,9 @@ class Representation(object):
           elif attr_name in ["updated_at", "created_at"]:
             is_equal = self.compare_datetime(
                 self_attr_value, other_attr_value)
+          elif attr_name == "comments":
+            is_equal = self.compare_comments(
+                self_attr_value, other_attr_value)
           else:
             is_equal = self_attr_value == other_attr_value
         if is_equal:
@@ -157,6 +160,31 @@ class Representation(object):
       Representation.attrs_values_types_error(
           self_attr=self_datetime, other_attr=other_datetime,
           expected_types=(datetime.__name__, type(None).__name__))
+
+  @staticmethod
+  def compare_comments(self_comments, other_comments):
+    """Compare entities' 'comments' attributes due to specific dictionaries'
+    format values in list comments.
+    """
+    if (isinstance(self_comments and other_comments, list) and
+            all(isinstance(self_comment and other_comment, dict) for
+                self_comment, other_comment
+                in zip(self_comments, other_comments))):
+      for self_comment, other_comment in zip(self_comments, other_comments):
+        is_comments_datetime_equal = (
+            Representation.compare_datetime(self_comment.get("created_at"),
+                                            other_comment.get("created_at")))
+        self_comment.pop("created_at")
+        other_comment.pop("created_at")
+        # compare comments' datetime and remaining attributes
+        return (is_comments_datetime_equal and
+                string_utils.is_subset_of_dicts(self_comment, other_comment))
+    if isinstance(self_comments and other_comments, (list, type(None))):
+      return self_comments == other_comments
+    else:
+      Representation.attrs_values_types_error(
+          self_attr=self_comments, other_attr=other_comments,
+          expected_types=(list.__name__, type(None).__name__))
 
   @staticmethod
   def attrs_values_types_error(self_attr, other_attr, expected_types):

--- a/test/selenium/src/lib/page/widget/info_widget.py
+++ b/test/selenium/src/lib/page/widget/info_widget.py
@@ -94,7 +94,7 @@ class CommonInfo(base.Widget):
             list_text_cas_scopes.append(
                 [ca_header_text,
                  unicode(int(base.Checkbox(self._driver, scope.find_element(
-                     *self._locators.CAS_CHECKBOXES)).is_element_checked()))
+                     *self._locators.CAS_CHECKBOXES)).is_checked_via_js()))
                  ])
           else:
             list_text_cas_scopes.append([ca_header_text, None])
@@ -289,6 +289,9 @@ class Assessments(InfoPanel):
     self.code_entered_text = (
         self.code_section.element.find_element(
             *self._locators.CODE_VALUE_CSS).text)
+    # comments section
+    self.comments = base.CommentsPanel(
+        self._driver, self._locators.COMMENTS_CSS)
     # scope
     self.list_all_headers_text = [
         self._elements.CAS.upper(), self._elements.TITLE,
@@ -296,7 +299,7 @@ class Assessments(InfoPanel):
         self._elements.VERIFIED.upper(),
         self.creators_text, self.assignees_text,
         self.verifiers_text, self._elements.MAPPED_OBJECTS.upper(),
-        self.code_text]
+        self.code_text, self.comments.header_lbl.text]
     self.list_all_values_text = [
         self.cas_text, self.title_entered().text,
         objects.get_normal_form(self.state().text),
@@ -304,7 +307,7 @@ class Assessments(InfoPanel):
         element.AssessmentStates.COMPLETED.upper(),
         self.creators_entered_text, self.assignees_entered_text,
         self.verifiers_entered_text, self.mapped_objects_titles_text,
-        self.code_entered_text]
+        self.code_entered_text, self.comments.scopes]
 
 
 class AssessmentTemplates(InfoPanel):

--- a/test/selenium/src/lib/service/webui_service.py
+++ b/test/selenium/src/lib/service/webui_service.py
@@ -405,6 +405,16 @@ class AssessmentsService(BaseWebUiService):
     super(AssessmentsService, self).__init__(
         driver, objects.ASSESSMENTS)
 
+  def add_comments(self, src_obj, obj, comment_objs):
+    """Open Info Panel of 'obj' navigate by object's title, maximize it and
+    add comments according to 'comment_objs' descriptions, return
+    'CommentsPanel' class after adding of comments.
+    """
+    comments_descriptions = [comment_obj.description for comment_obj in
+                             comment_objs]
+    obj_info_panel = self.open_info_panel_of_obj_by_title(src_obj, obj)
+    return obj_info_panel.comments.add_comments(comments_descriptions)
+
   def generate_objs_via_tree_view(self, src_obj, objs_under_asmt,
                                   asmt_tmpl_obj=None):
     """Open generic widget of mapped objects, open Generation modal from

--- a/test/selenium/src/lib/utils/selenium_utils.py
+++ b/test/selenium/src/lib/utils/selenium_utils.py
@@ -76,7 +76,7 @@ def get_when_visible(driver, locator):
  Return: selenium.webdriver.remote.webelement.WebElement
  """
   return (_webdriver_wait(driver).
-          until(EC.presence_of_element_located(locator)))
+          until(EC.visibility_of_element_located(locator)))
 
 
 def wait_until_condition(driver, condition):
@@ -210,6 +210,14 @@ def is_element_enabled(element):
   return all([el.is_enabled() and
               not is_value_in_attr(el, value="disabled")
               for el in elements_to_check])
+
+
+def is_element_checked(driver, element):
+  """Check DOM input element checked property using JS.
+  Args: driver (base.CustomDriver), locator (tuple)
+  Return: True if element is checked, False if element is not checked.
+  """
+  return driver.execute_script("return arguments[0].checked", element)
 
 
 def get_nested_elements(element, all_nested=False):

--- a/test/selenium/src/tests/test_asmts_workflow.py
+++ b/test/selenium/src/tests/test_asmts_workflow.py
@@ -1,0 +1,50 @@
+# Copyright (C) 2017 Google Inc., authors, and contributors <see AUTHORS file>
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+"""Assessments Workflow smoke tests."""
+# pylint: disable=no-self-use
+# pylint: disable=invalid-name
+# pylint: disable=unused-argument
+# pylint: disable=too-few-public-methods
+
+import pytest
+
+from lib import base
+from lib.constants import messages
+from lib.entities import entities_factory
+from lib.service import webui_service
+
+
+class TestAssessmentsWorkflow(base.Test):
+  """Tests for Assessments Workflow functionality."""
+
+  @pytest.mark.smoke_tests
+  def test_add_comment_to_asmt_via_info_panel(
+      self, new_program_rest, new_audit_rest, new_assessment_rest, selenium
+  ):
+    """Check via UI of possibility to correctly add comment to Assessment via
+    Info Panel.
+    Preconditions:
+    - Program created via REST API.
+    - Audit created under Program via REST API.
+    - Assessment created under Audit via REST API.
+    Test parameters: None
+    """
+    expected_asmt = new_assessment_rest
+    expected_asmt_comments = [entities_factory.CommentsFactory().
+                              create().repr_ui()]
+    # due to 'actual_asmt.updated_at = None'
+    (expected_asmt.
+     update_attrs(comments=expected_asmt_comments, updated_at=None).repr_ui())
+    assessments_service = webui_service.AssessmentsService(selenium)
+    asmt_comments_panel = assessments_service.add_comments(
+        src_obj=new_audit_rest, obj=expected_asmt,
+        comment_objs=expected_asmt_comments)
+    assert asmt_comments_panel.is_input_empty is True
+    actual_asmt = (
+        webui_service.AssessmentsService(selenium).
+        get_list_objs_from_info_panels(
+            src_obj=new_audit_rest, objs=expected_asmt).update_attrs(
+            comments={"created_at": None}, is_replace_dicts_values=True))
+    assert expected_asmt == actual_asmt, (
+        messages.AssertionMessages.
+        format_err_msg_equal(expected_asmt, actual_asmt))


### PR DESCRIPTION
This PR add new automation test-case **"Test of adding comment to Assessment via Info Panel"** as a part of GGRC's smoke test.

```Python
  @pytest.mark.smoke_tests
  def test_add_comment_to_asmt_via_info_panel(
      self, new_program_rest, new_audit_rest, new_assessment_rest, selenium
  ):
    """Check via UI of possibility to correctly add comment  to Assessment via
    Info Panel.
    Preconditions:
    - Program created via REST API.
    - Audit created under Program via REST API.
    - Assessment created under Audit via REST API.
    Test parameters: None
    """
    expected_asmt = new_assessment_rest
    expected_asmt_comments = [entities_factory.CommentsFactory().
                              create().repr_ui()]
    # due to 'actual_asmt.updated_at = None'
    (expected_asmt.
     update_attrs(comments=expected_asmt_comments, updated_at=None).repr_ui())
    assessments_service = webui_service.AssessmentsService(selenium)
    assessments_service.add_comments_via_info_panel(
        src_obj=new_audit_rest, obj=expected_asmt,
        comment_objs=expected_asmt_comments)
    is_comments_input_empty = (
        assessments_service.is_comment_field_on_info_panel_empty(
            src_obj=new_audit_rest, obj=expected_asmt))
    # due to 'expected_asmt.comments["created_at"] = None'
    actual_asmt = (
        webui_service.AssessmentsService(selenium).
        get_list_objs_from_info_panels(
            src_obj=new_audit_rest, objs=expected_asmt).update_attrs(
            comments={"created_at": None}, is_replace_dicts_values=True))
    assert expected_asmt == actual_asmt, (
        messages.AssertionMessages.
        format_err_msg_equal(expected_asmt, actual_asmt))
    assert is_comments_input_empty is True
```

**NOTES:**
test-cases have been implemented based on new strings (unicode) to datetime model of TAF's