### PR TITLE
GGRC-2627 Reused evidence appears on Assessment's info pane after page refresh

### DIFF
--- a/src/ggrc/assets/javascripts/components/reusable-objects/reusable-objects-item.js
+++ b/src/ggrc/assets/javascripts/components/reusable-objects/reusable-objects-item.js
@@ -23,9 +23,11 @@
               return false;
             }
 
-            isMapped = baseInstanceObjects.map(function (document) {
-              return document.id;
-            }).indexOf(this.attr('instance.id')) > -1;
+            isMapped = baseInstanceObjects
+                .map(function (document) {
+                  return document.id;
+                })
+                .indexOf(this.attr('instance.id')) > -1;
 
             return this.attr('instance.isMapped') ||
               isMapped;
@@ -44,9 +46,11 @@
       isSelected: function () {
         var instanceId = this.attr('instance.id');
 
-        return _.some(this.attr('selectedList'), function (item) {
-          return item.id === instanceId;
-        });
+        return this.attr('selectedList')
+            .map(function (item) {
+              return item.id;
+            })
+            .indexOf(instanceId) > -1;
       },
       toggleSelection: function (isChecked) {
         var list = this.attr('selectedList');
@@ -73,13 +77,13 @@
       }
     },
     init: function () {
-      if (this.scope.isSelected()) {
-        this.scope.attr('isChecked', true);
+      if (this.viewModel.isSelected()) {
+        this.viewModel.attr('isChecked', true);
       }
     },
     events: {
       '{viewModel} isChecked': function (scope, ev, isChecked) {
-        this.scope.toggleSelection(isChecked);
+        this.viewModel.toggleSelection(isChecked);
       }
     }
   });

--- a/src/ggrc/assets/mustache/assessments/related-assessments.mustache
+++ b/src/ggrc/assets/mustache/assessments/related-assessments.mustache
@@ -2,14 +2,17 @@
 Copyright (C) 2017 Google Inc.
 Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
-<related-objects {base-instance}="instance" related-items-type="Assessment" order-by="finished_date,created_at">
-    <reusable-objects-list {base-instance}="instance" {evidences}="evidences" {urls}="urls">
+<reusable-objects-list {base-instance}="instance"
+                       {evidences}="evidences"
+                       {urls}="urls"
+                       (after-object-reused)="updateItems('evidences', 'urls')">
+    <related-objects {base-instance}="instance" related-items-type="Assessment" order-by="finished_date,created_at">
         <div class="grid-data__toolbar flex-box">
             <tree-pagination {(paging)}="paging" class="grid-data__toolbar-item"></tree-pagination>
             {{#is_allowed 'update' baseInstance context='for'}}
-                {{^if instance.archived}}
-                    <button class="btn btn-small btn-green grid-data__toolbar-item" ($click)="reuseSelected" {{^hasSelected}}disabled{{/hasSelected}}>Reuse</button>
-                {{/if}}
+                {{#unless instance.archived}}
+                    <button class="btn btn-small btn-green grid-data__toolbar-item" ($click)="reuseSelected()" {{^hasSelected}}disabled{{/hasSelected}}>Reuse</button>
+                {{/unless}}
             {{/is_allowed}}
         </div>
         <div class="grid-data-header flex-row flex-box">
@@ -38,7 +41,7 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                 More info
             </div>
         </div>
-        <div class="grid-data-body center-empty-message {{#if isLoading}}loading{{/if}}">
+        <div class="grid-data-body center-empty-message {{#isLoading}}loading{{/isLoading}}">
             <related-assessment-list {assessments}="relatedObjects">
                 {{#if assessments.length}}
                     <spinner {toggle}="itemsLoading" class="spinner-wrapper active"
@@ -96,8 +99,7 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                                 </related-documents>
                             </div>
                             <div class="grid-data__action-column">
-                                <button class="btn btn-icon btn-icon-sm" title="Show More Information"><i
-                                        class="fa fa-info-circle"></i></button>
+                                <button class="btn btn-icon btn-icon-sm" title="Show More Information"><i class="fa fa-info-circle"></i></button>
                             </div>
                         </div>
                     </related-assessment-item>
@@ -106,5 +108,5 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
             <related-assessment-popover class="object-popover related-assessments__object-popover"
                                         {selected-assessment}="selectedItem" hide-title="true"></related-assessment-popover>
         </div>
-    </reusable-objects-list>
-</related-objects>
+    </related-objects>
+</reusable-objects-list>

--- a/src/ggrc/assets/mustache/components/assessment/controls-toolbar/controls-toolbar.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/controls-toolbar/controls-toolbar.mustache
@@ -3,24 +3,21 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
 <button class="btn btn-small btn-lightBlue" ($click)="showRelatedResponses" title="Show Related Assessments">Related Assessments</button>
-{{^if instance.archived}}
-    <auto-save-form-actions
-      {(form-edit-mode)}="editMode"
-      {form-saving}="formState.saving"
-      {form-fields-to-save-available}="formState.fieldsToSaveAvailable"
-      (on-save)="onFormSave()"
-    ></auto-save-form-actions>
-{{/if}}
-{{#is_allowed 'update' instance context='for'}}
-    {{^if instance.archived}}
-         <object-state-toolbar {verifiers}="instance.assignees.Verifier"
-                          {instance}="instance"
-                          (on-state-change)="onStateChange(%event)">
-         </object-state-toolbar>
-    {{/if}}
-{{/is_allowed}}
 <simple-modal {instance}="instance" modal-title="modalTitle" {(state)}="state" extra-css-class="related-assessments">
     <div class="simple-modal__body">
       {{> '/static/mustache/assessments/related-assessments.mustache' }}
     </div>
 </simple-modal>
+{{#unless instance.archived}}
+  {{#is_allowed 'update' instance context='for'}}
+      <auto-save-form-actions
+              {(form-edit-mode)}="editMode"
+              {form-saving}="formState.saving"
+              {form-fields-to-save-available}="formState.fieldsToSaveAvailable"
+              (on-save)="onFormSave()"></auto-save-form-actions>
+      <object-state-toolbar {verifiers}="instance.assignees.Verifier"
+                            {instance}="instance"
+                            (on-state-change)="onStateChange(%event)">
+      </object-state-toolbar>
+  {{/is_allowed}}
+{{/unless}}

--- a/src/ggrc_gdrive_integration/assets/javascripts/components/gdrive_picker_launcher.js
+++ b/src/ggrc_gdrive_integration/assets/javascripts/components/gdrive_picker_launcher.js
@@ -42,7 +42,7 @@
       onClickHandler: function (scope, el, event) {
         var eventType = this.attr('click_event');
         var handler = this[eventType] || function () {};
-        var confirmation = _.isFunction(this.confirmationCallback) ?
+        var confirmation = can.isFunction(this.confirmationCallback) ?
           this.confirmationCallback() :
           null;
         var args = arguments;
@@ -113,7 +113,7 @@
             return new RefreshQueue().enqueue(files).trigger()
               .then(function (files) {
                 var docDfds = that.handle_file_upload(files);
-                $.when.apply($, docDfds).then(function () {
+                can.when.apply(can, docDfds).then(function () {
                   // Trigger modal:success event on scope
                   can.trigger(
                     that, 'modal:success', {arr: can.makeArray(arguments)});
@@ -204,7 +204,7 @@
                       }
                       return file;
                     });
-                    return can.when.apply($, mapped);
+                    return can.when.apply(can, mapped);
                   });
               })
               .done(function () {
@@ -213,7 +213,7 @@
                 });
                 var dfdsDoc = that.handle_file_upload(files);
 
-                can.when.apply($, dfdsDoc).then(function () {
+                can.when.apply(can, dfdsDoc).then(function () {
                   can.trigger(
                     that, 'modal:success', {arr: can.makeArray(arguments)});
                   el.trigger('modal:success', {arr: can.makeArray(arguments)});
@@ -278,7 +278,7 @@
         var instance = this.viewModel.instance;
         var itemsUploadedCallback = this.viewModel.itemsUploadedCallback;
 
-        if (_.isFunction(itemsUploadedCallback)) {
+        if (can.isFunction(itemsUploadedCallback)) {
           itemsUploadedCallback();
         } else {
           instance.reify();


### PR DESCRIPTION
In scope of this PR GGRC-2627 and GGRC-2628 are fixed

**GGRC-2627 Reused evidence appears on Assessment's info pane after page refresh**
Steps to reproduce:
1. Have at least 2 related assessments on the audit page
2. Attach evidence to one of the assessment
3. Navigate on Assessment's info pane of the second assessment and be open Related assessments window
4. Select evidence to reuse and click Reuse button> Close Related assessments window
5. Look at the Assessment's info pane: reused evidence is not shown
**Actual Result**: Reused evidence doesn't appear on Assessment's info pane. Refresh is needed.
**Expected Result**: Reused evidence should appears on Assessment's info pane after reusing

**GGRC-2628 Checkbox is active after reusing evidence in Related Assessments Window**
Steps to reproduce:
1. Have at least 2 related assessments on the audit page
2. Attach evidence to one of the assessment
3. Navigate on Assessment's info pane of the second assessment and open Related assessments window
4. Select evidence to reuse and click Reuse button
5. Look at the checkbox after evidence was reused: is active
**Actual Result**: Checkbox is active after reusing evidence in Related Assessments Window
**Expected Result**: Checkbox should not be active after reusing evidence in Related Assessments Window
