### PR TITLE
GGRC-2030 Custom role value in tree view is updated after page refresh

### DIFF
--- a/src/ggrc/assets/javascripts/components/tree/tree-people-list-field.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-people-list-field.js
@@ -25,9 +25,6 @@
     template: '<content />',
     viewModel: viewModel,
     events: {
-      '{viewModel} source': function () {
-        this.viewModel.refreshPeople();
-      },
       '{viewModel.source} change': function () {
         this.viewModel.refreshPeople();
       }

--- a/src/ggrc/assets/javascripts/components/tree/tree-people-with-role-list-field.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-people-with-role-list-field.js
@@ -20,7 +20,7 @@
     template: '<content />',
     viewModel: viewModel,
     events: {
-      '{viewModel} source': function () {
+      '{viewModel.source} change': function () {
         this.viewModel.refreshPeople();
       }
     }


### PR DESCRIPTION
Steps to reproduce:
1. Go to admin dashboard> Custom roles tab
2. Add custom role field for Control
3. Create a control
4. Go to My work page> Control's tab
5. Set visible field for added Custom role field in tree view
6. On Control's Info pane add person to Custom role field and look at the tree view

**Actual Result:** Custom role value in tree view is updated after page refresh
**Expected Result:** Custom role value in tree view should be updated automatically

**NOTE**: fixed for any role (not only custom role) of snapshotable objects
