### PR TITLE
GGRC-2668 Display "end_date" field with "Deprecated Date" label

### DIFF
--- a/src/ggrc/assets/javascripts/components/effective-dates/effective-dates.js
+++ b/src/ggrc/assets/javascripts/components/effective-dates/effective-dates.js
@@ -20,7 +20,7 @@
         required: false
       },
       configEndDate: {
-        label: 'Stop Date',
+        label: 'Last Deprecated Date',
         helpText: 'Enter the date this object stops being effective.',
         required: false
       }

--- a/src/ggrc/assets/javascripts/design.js
+++ b/src/ggrc/assets/javascripts/design.js
@@ -233,7 +233,7 @@ $('body').on('click', '.fa fa-caret-right', function(e) {
       //We gave relationships
       //Pending approval, start-stop
       var $item2add = '<div class="btn-group inline"> <a class="span7 btn btn-red btn-mini dropdown-toggle nominheight fltrt" data-toggle="dropdown"> Select Relationship <span class="caret"></span> </a> <ul class="dropdown-menu"> <li> <a href="#" id="makeAccountable"> is Accountable for </a> </li> <li> <a href="#" id="makeResponsible"> is Responsible for </a> </li> </ul> </div>';
-      var $additionalinfo = '<div class="row-fluid additional"> <div class="span4"></div> <div class="span4"> <label>Start Date (Optional)</label> <input class="span12 date" id="datepicker-stopdate-rd" placeholder="MM/DD/YYYY" type="text"> </div> <div class="span4"> <label>Stop Date (Optional)</label> <input class="span12 date" id="datepicker-stopdate-rd" placeholder="MM/DD/YYYY" type="text"> </div>';
+      var $additionalinfo = '<div class="row-fluid additional"> <div class="span4"></div> <div class="span4"> <label>Start Date (Optional)</label> <input class="span12 date" id="datepicker-stopdate-rd" placeholder="MM/DD/YYYY" type="text"> </div> <div class="span4"> <label>Last Deprecated Date (Optional)</label> <input class="span12 date" id="datepicker-stopdate-rd" placeholder="MM/DD/YYYY" type="text"> </div>';
     } else if ($this.closest(".modal-body").find("#currentList").hasClass('reference-list')) {
       //Will have assignment items, nothing now.
       //Pending approval, no start-stop

--- a/src/ggrc/assets/javascripts/models/business_object_models.js
+++ b/src/ggrc/assets/javascripts/models/business_object_models.js
@@ -38,7 +38,7 @@
         {attr_title: 'Org Group URL', attr_name: 'url'},
         {attr_title: 'Reference URL', attr_name: 'reference_url'},
         {attr_title: 'Effective Date', attr_name: 'start_date'},
-        {attr_title: 'Stop Date', attr_name: 'end_date'}
+        {attr_title: 'Last Deprecated Date', attr_name: 'end_date'}
       ])
     },
     links_to: {
@@ -99,7 +99,7 @@
         {attr_title: 'Project URL', attr_name: 'url'},
         {attr_title: 'Reference URL', attr_name: 'reference_url'},
         {attr_title: 'Effective Date', attr_name: 'start_date'},
-        {attr_title: 'Stop Date', attr_name: 'end_date'}
+        {attr_title: 'Last Deprecated Date', attr_name: 'end_date'}
       ]),
       add_item_view: GGRC.mustache_path + '/base_objects/tree_add_item.mustache'
     },
@@ -161,7 +161,7 @@
         {attr_title: 'Facility URL', attr_name: 'url'},
         {attr_title: 'Reference URL', attr_name: 'reference_url'},
         {attr_title: 'Effective Date', attr_name: 'start_date'},
-        {attr_title: 'Stop Date', attr_name: 'end_date'}
+        {attr_title: 'Last Deprecated Date', attr_name: 'end_date'}
       ]),
       add_item_view:
         GGRC.mustache_path + '/base_objects/tree_add_item.mustache'
@@ -287,7 +287,7 @@
         {attr_title: 'Data Asset URL', attr_name: 'url'},
         {attr_title: 'Reference URL', attr_name: 'reference_url'},
         {attr_title: 'Effective Date', attr_name: 'start_date'},
-        {attr_title: 'Stop Date', attr_name: 'end_date'}
+        {attr_title: 'Last Deprecated Date', attr_name: 'end_date'}
       ]),
       add_item_view:
         GGRC.mustache_path + '/base_objects/tree_add_item.mustache'
@@ -349,7 +349,7 @@
         {attr_title: 'Access Group URL', attr_name: 'url'},
         {attr_title: 'Reference URL', attr_name: 'reference_url'},
         {attr_title: 'Effective Date', attr_name: 'start_date'},
-        {attr_title: 'Stop Date', attr_name: 'end_date'}
+        {attr_title: 'Last Deprecated Date', attr_name: 'end_date'}
       ]),
       add_item_view:
         GGRC.mustache_path + '/base_objects/tree_add_item.mustache'
@@ -411,7 +411,7 @@
         {attr_title: 'Market URL', attr_name: 'url'},
         {attr_title: 'Reference URL', attr_name: 'reference_url'},
         {attr_title: 'Effective Date', attr_name: 'start_date'},
-        {attr_title: 'Stop Date', attr_name: 'end_date'}
+        {attr_title: 'Last Deprecated Date', attr_name: 'end_date'}
       ]),
       add_item_view: GGRC.mustache_path + '/base_objects/tree_add_item.mustache'
     },
@@ -472,7 +472,7 @@
         {attr_title: 'Vendor URL', attr_name: 'url'},
         {attr_title: 'Reference URL', attr_name: 'reference_url'},
         {attr_title: 'Effective Date', attr_name: 'start_date'},
-        {attr_title: 'Stop Date', attr_name: 'end_date'}
+        {attr_title: 'Last Deprecated Date', attr_name: 'end_date'}
       ]),
       add_item_view:
         GGRC.mustache_path + '/base_objects/tree_add_item.mustache'

--- a/src/ggrc/assets/javascripts/models/control.js
+++ b/src/ggrc/assets/javascripts/models/control.js
@@ -58,7 +58,7 @@
         {attr_title: 'Control URL', attr_name: 'url'},
         {attr_title: 'Reference URL', attr_name: 'reference_url'},
         {attr_title: 'Effective Date', attr_name: 'start_date'},
-        {attr_title: 'Stop Date', attr_name: 'end_date'},
+        {attr_title: 'Last Deprecated Date', attr_name: 'end_date'},
         {
           attr_title: 'Kind/Nature',
           attr_name: 'kind',

--- a/src/ggrc/assets/javascripts/models/directive_models.js
+++ b/src/ggrc/assets/javascripts/models/directive_models.js
@@ -22,7 +22,7 @@ can.Model.Cacheable("CMS.Models.Directive", {
       {attr_title: 'URL', attr_name: 'url'},
       {attr_title: 'Reference URL', attr_name: 'reference_url'},
       {attr_title: 'Effective Date', attr_name: 'start_date'},
-      {attr_title: 'Stop Date', attr_name: 'end_date'}
+      {attr_title: 'Last Deprecated Date', attr_name: 'end_date'}
     ])
     , add_item_view : GGRC.mustache_path + "/snapshots/tree_add_item.mustache"
     }
@@ -172,7 +172,7 @@ CMS.Models.Directive("CMS.Models.Policy", {
         attr_sort_field: 'kind'
       },
       {attr_title: 'Effective Date', attr_name: 'start_date'},
-      {attr_title: 'Stop Date', attr_name: 'end_date'},
+      {attr_title: 'Last Deprecated Date', attr_name: 'end_date'},
       {attr_title: 'Policy URL', attr_name: 'url'},
       {attr_title: 'Reference URL', attr_name: 'reference_url'}
     ]);

--- a/src/ggrc/assets/javascripts/models/simple_models.js
+++ b/src/ggrc/assets/javascripts/models/simple_models.js
@@ -61,7 +61,7 @@
         {attr_title: 'Program URL', attr_name: 'url'},
         {attr_title: 'Reference URL', attr_name: 'reference_url'},
         {attr_title: 'Effective Date', attr_name: 'start_date'},
-        {attr_title: 'Stop Date', attr_name: 'end_date'}
+        {attr_title: 'Last Deprecated Date', attr_name: 'end_date'}
       ]),
       add_item_view: GGRC.mustache_path + '/base_objects/tree_add_item.mustache'
     },

--- a/src/ggrc/assets/javascripts/models/system.js
+++ b/src/ggrc/assets/javascripts/models/system.js
@@ -51,7 +51,7 @@ can.Model.Cacheable('CMS.Models.SystemOrProcess', {
         attr_sort_field: 'network_zone'
       },
       {attr_title: 'Effective Date', attr_name: 'start_date'},
-      {attr_title: 'Stop Date', attr_name: 'end_date'},
+      {attr_title: 'Last Deprecated Date', attr_name: 'end_date'},
       {attr_title: 'URL', attr_name: 'url'},
       {attr_title: 'Reference URL', attr_name: 'reference_url'}
     ]),

--- a/src/ggrc/assets/mustache/base_objects/info.mustache
+++ b/src/ggrc/assets/mustache/base_objects/info.mustache
@@ -56,7 +56,7 @@
               {{/if}}
             </div>
             <div class="span4">
-              <h6>Stop Date</h6>
+              <h6>Last Deprecated Date</h6>
               {{#if end_date}}
                 <p>
                   {{localize_date end_date}}

--- a/src/ggrc/assets/mustache/controls/info.mustache
+++ b/src/ggrc/assets/mustache/controls/info.mustache
@@ -129,7 +129,7 @@
               {{/if}}
             </div>
             <div class="span4">
-              <h6>Stop Date</h6>
+              <h6>Last Deprecated Date</h6>
               {{#if end_date}}
                 <p>
                   {{localize_date end_date}}

--- a/src/ggrc/assets/mustache/issues/info.mustache
+++ b/src/ggrc/assets/mustache/issues/info.mustache
@@ -80,7 +80,7 @@
               {{/if}}
             </div>
             <div class="span4">
-              <h6>Stop Date</h6>
+              <h6>Last Deprecated Date</h6>
               {{#if end_date}}
                 <p>
                   {{localize_date end_date}}

--- a/src/ggrc/assets/mustache/policies/info.mustache
+++ b/src/ggrc/assets/mustache/policies/info.mustache
@@ -66,7 +66,7 @@
               {{/if}}
             </div>
             <div class="span3">
-              <h6>Stop Date</h6>
+              <h6>Last Deprecated Date</h6>
               {{#if end_date}}
                 <p>
                   {{localize_date end_date}}

--- a/src/ggrc/assets/mustache/processes/info.mustache
+++ b/src/ggrc/assets/mustache/processes/info.mustache
@@ -67,7 +67,7 @@
               {{/if}}
             </div>
             <div class="span3">
-              <h6>Stop Date</h6>
+              <h6>Last Deprecated Date</h6>
               {{#if end_date}}
                 <p>
                   {{localize_date end_date}}

--- a/src/ggrc/assets/mustache/products/info.mustache
+++ b/src/ggrc/assets/mustache/products/info.mustache
@@ -68,7 +68,7 @@
               {{/if}}
             </div>
             <div class="span3">
-              <h6>Stop Date</h6>
+              <h6>Last Deprecated Date</h6>
               {{#if end_date}}
                 <p>
                   {{localize_date end_date}}

--- a/src/ggrc/assets/mustache/programs/info.mustache
+++ b/src/ggrc/assets/mustache/programs/info.mustache
@@ -57,7 +57,7 @@
               {{/if}}
             </div>
             <div data-test-id="title_stop_date_cf47bc01" class="span4">
-              <h6>Stop Date</h6>
+              <h6>Last Deprecated Date</h6>
               {{#if end_date}}
                 <p>
                   {{localize_date end_date}}

--- a/src/ggrc/assets/mustache/systems/info.mustache
+++ b/src/ggrc/assets/mustache/systems/info.mustache
@@ -67,7 +67,7 @@
               {{/if}}
             </div>
             <div class="span3">
-              <h6>Stop Date</h6>
+              <h6>Last Deprecated Date</h6>
               {{#if end_date}}
                 <p>
                   {{localize_date end_date}}

--- a/src/ggrc_risk_assessments/assets/javascripts/models/risk_assessment.js
+++ b/src/ggrc_risk_assessments/assets/javascripts/models/risk_assessment.js
@@ -33,7 +33,7 @@
         {attr_title: 'Title', attr_name: 'title'},
         {attr_title: 'Code', attr_name: 'slug'},
         {attr_title: 'Start Date', attr_name: 'start_date'},
-        {attr_title: 'Stop Date', attr_name: 'end_date'},
+        {attr_title: 'Last Deprecated Date', attr_name: 'end_date'},
         {
           attr_title: 'Risk Manager',
           attr_name: 'ra_manager',

--- a/src/ggrc_risks/assets/mustache/risks/info.mustache
+++ b/src/ggrc_risks/assets/mustache/risks/info.mustache
@@ -55,7 +55,7 @@
               {{/if}}
             </div>
             <div class="span4">
-              <h6>Stop Date</h6>
+              <h6>Last Deprecated Date</h6>
               {{#if end_date}}
                 <p>
                   {{localize_date end_date}}


### PR DESCRIPTION
*Acceptance Criteria*
1. Change 'Stop Date' label into 'Last Deprecated Date' label.

2. Make changes for the following objects:
- Program
- Standard
- Regulation
- Control
- Product
- System
- Process
- Access Group
- Clause
- Contract
- Data Asset
- Facility
- Issue
- Market
- Org Groups
- Policy
- Project
- Risk
- Threat
- Vendor
- Risk Assessment

3. Make changes on the following places:
- <Object> info page;
- <Object> info pane;
- 'New <object>' modal window;
- 'Edit <object>' modal window.
- 'Set visible fields for <object>' pop-up (on widget and unified mapper)
- name of the column on <object> tab.
- name of the column on Unified Mapper.
- name of the column on Global Search.
- name of the column on 'Generate Assessment' mapper.
- pop-up on Assessment info page.

 **NOTE:** for correct work need backend to filter tree-view by 'Last Deprecated Date' instead of 'Stop Date'.