### PR TITLE
GGRC-1972 Issues object need new states

### DIFF
--- a/src/ggrc/assets/javascripts/models/issue.js
+++ b/src/ggrc/assets/javascripts/models/issue.js
@@ -35,7 +35,7 @@
     defaults: {
       status: 'Draft'
     },
-    statuses: ['Draft', 'Deprecated', 'Active'],
+    statuses: ['Draft', 'Deprecated', 'Active', 'Fixed', 'Fixed and Verified'],
     init: function () {
       if (this._super) {
         this._super.apply(this, arguments);

--- a/src/ggrc/assets/javascripts/plugins/utils/state-utils.js
+++ b/src/ggrc/assets/javascripts/plugins/utils/state-utils.js
@@ -13,10 +13,10 @@
       {
         models: [
           'AccessGroup', 'Clause', 'Contract',
-          'Control', 'DataAsset', 'Facility', 'Issue', 'Market',
+          'Control', 'DataAsset', 'Facility', 'Market',
           'Objective', 'OrgGroup', 'Policy', 'Process', 'Product', 'Program',
           'Project', 'Regulation', 'Risk', 'Section', 'Standard', 'System',
-          'Threat', 'Vendor', 'Issue'
+          'Threat', 'Vendor'
         ],
         states: ['Active', 'Draft', 'Deprecated']
       },
@@ -41,6 +41,12 @@
           'TaskGroup', 'Cycle'
         ],
         states: []
+      },
+      {
+        models: ['Issue'],
+        states: [
+          'Active', 'Draft', 'Deprecated', 'Fixed', 'Fixed and Verified'
+        ]
       }
     ];
 

--- a/src/ggrc/assets/js_specs/models/object_state_spec.js
+++ b/src/ggrc/assets/js_specs/models/object_state_spec.js
@@ -5,7 +5,7 @@
 
 describe('Model states test', function () {
   var basicStateObjects = ['AccessGroup', 'Clause', 'Contract',
-      'Control', 'DataAsset', 'Facility', 'Issue', 'Market',
+      'Control', 'DataAsset', 'Facility', 'Market',
       'Objective', 'OrgGroup', 'Policy', 'Process', 'Product', 'Program',
       'Project', 'Regulation', 'Risk', 'Section', 'Standard', 'System',
       'Threat', 'Vendor'];
@@ -26,6 +26,11 @@ describe('Model states test', function () {
     var expectedStatuses = ['Not Started', 'In Progress', 'Ready for Review',
         'Verified', 'Completed'];
     expect(CMS.Models.Assessment.statuses).toEqual(expectedStatuses);
+  });
+  it('checks if Issue has correct statuses', function () {
+    var expectedStatuses = ['Draft', 'Deprecated', 'Active', 'Fixed',
+        'Fixed and Verified'];
+    expect(CMS.Models.Issue.statuses).toEqual(expectedStatuses);
   });
 });
 

--- a/src/ggrc/models/issue.py
+++ b/src/ggrc/models/issue.py
@@ -25,6 +25,14 @@ class Issue(Roleable, HasObjectState, TestPlanned, CustomAttributable,
 
   __tablename__ = 'issues'
 
+  VALID_STATES = [
+      "Draft",
+      "Active",
+      "Deprecated",
+      "Fixed",
+      "Fixed and Verified"
+  ]
+
   # REST properties
   _publish_attrs = [
       "audit"
@@ -34,7 +42,12 @@ class Issue(Roleable, HasObjectState, TestPlanned, CustomAttributable,
       "url": "Issue URL",
       "test_plan": {
           "display_name": "Remediation Plan"
-      }
+      },
+      "status": {
+          "display_name": "State",
+          "mandatory": False,
+          "description": "Options are: \n{} ".format('\n'.join(VALID_STATES))
+      },
   }
 
   audit_id = deferred(

--- a/test/integration/ggrc/converters/test_import_issues.py
+++ b/test/integration/ggrc/converters/test_import_issues.py
@@ -59,6 +59,26 @@ class TestImportIssues(TestCase):
         }
     })
 
+  def test_issue_state_import(self):
+    """Test import of issue state."""
+    audit = factories.AuditFactory()
+    statuses = ["Fixed", "Fixed and Verified"]
+    imported_data = []
+    for i in range(2):
+      imported_data.append(OrderedDict([
+          ("object_type", "Issue"),
+          ("Code*", ""),
+          ("Title*", "Test issue {}".format(i)),
+          ("Admin*", "user@example.com"),
+          ("audit", audit.slug),
+          ("State", statuses[i]),
+      ]))
+
+    response = self.import_data(*imported_data)
+    self._check_csv_response(response, {})
+    db_statuses = [i.status for i in models.Issue.query.all()]
+    self.assertEqual(statuses, db_statuses)
+
   def test_import_with_mandatory(self):
     """Test import of data with mandatory role"""
     # Import of data should be allowed if mandatory role provided

--- a/test/integration/ggrc/models/test_issue.py
+++ b/test/integration/ggrc/models/test_issue.py
@@ -1,0 +1,51 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Tests for Issue model."""
+from ggrc.models import all_models
+from integration.ggrc import TestCase, Api
+from integration.ggrc.models import factories
+
+
+class TestIssue(TestCase):
+  """ Test Issue class. """
+  def setUp(self):
+    super(TestIssue, self).setUp()
+    self.api = Api()
+    with factories.single_commit():
+      audit = factories.AuditFactory()
+      for status in all_models.Issue.VALID_STATES:
+        factories.IssueFactory(audit=audit, status=status)
+
+  def test_filter_by_status(self):
+    """Test Issue filtering by status."""
+    query_request_data = [{
+        'fields': [],
+        'filters': {
+            'expression': {
+                'left': {
+                    'left': 'status',
+                    'op': {'name': '='},
+                    'right': 'Fixed'
+                },
+                'op': {'name': 'OR'},
+                'right': {
+                    'left': 'status',
+                    'op': {'name': '='},
+                    'right': 'Fixed and Verified'
+                },
+            },
+        },
+        'object_name': 'Issue',
+        'permissions': 'read',
+        'type': 'values',
+    }]
+    response = self.api.send_request(
+        self.api.client.post,
+        data=query_request_data,
+        api_link="/query"
+    )
+    self.assertEqual(response.status_code, 200)
+
+    statuses = {i["status"] for i in response.json[0]["Issue"]["values"]}
+    self.assertEqual(statuses, {"Fixed", "Fixed and Verified"})

--- a/test/selenium/src/lib/constants/element.py
+++ b/test/selenium/src/lib/constants/element.py
@@ -276,6 +276,8 @@ class AssessmentStates(BaseStates):
 
 class IssueStates(ObjectStates):
   """States for Issues objects."""
+  FIXED = "Fixed"
+  FIXED_AND_VERIFIED = "Fixed and Verified"
 
 
 class ProgramInfoWidget(CommonProgram):

--- a/test/unit/ggrc/models/test_states.py
+++ b/test/unit/ggrc/models/test_states.py
@@ -13,7 +13,7 @@ class TestStates(unittest.TestCase):
 
   BASIC_STATE_OBJECTS = (
       'AccessGroup', 'Clause', 'Contract',
-      'Control', 'DataAsset', 'Directive', 'Facility', 'Issue', 'Market',
+      'Control', 'DataAsset', 'Directive', 'Facility', 'Market',
       'Objective', 'OrgGroup', 'Policy', 'Process', 'Product', 'Program',
       'Project', 'Regulation', 'Risk', 'Section', 'Standard', 'System',
       'SystemOrProcess', 'Threat', 'Vendor')
@@ -57,3 +57,10 @@ class TestStates(unittest.TestCase):
         'In Progress', 'Completed', 'Not Started', 'Verified',
         'Ready for Review')
     self._assert_states('Assessment', assignable_states, 'Not Started')
+
+  def test_issue_states(self):
+    """Test states for Issue object"""
+    issue_states = (
+        'Draft', 'Active', 'Deprecated', 'Fixed', 'Fixed and Verified'
+    )
+    self._assert_states('Issue', issue_states, 'Draft')


### PR DESCRIPTION
Two more states should be added for Issue:

	Fixed (no verification);
	Fixed and Verified.

**ACCEPTANCE CRITERIA**
A1. User should be able to set 'Fixed' / 'Fixed and Verified' state for Issue.
A2. User should be able to see 'Fixed' / 'Fixed and Verified' states on Issue info pane, tree view, unified mapper, global search
A3. User should be able to filter Issues by 'Fixed' / 'Fixed and Verified' state.
A4. User should be able to see 'Fixed' / 'Fixed and Verified' state in Issue export spreadsheet.
A5. User should be able to import 'Fixed' / 'Fixed and Verified' state for an issue.


