### PR TITLE
QUICK-FIX Use audit cache when generating assessments

### DIFF
--- a/src/ggrc/models/hooks/assessment.py
+++ b/src/ggrc/models/hooks/assessment.py
@@ -82,12 +82,12 @@ def init_hook():
       if not src.get("_generated") and not snapshot:
         continue
       template = template_cache.get(src.get("template", {}).get("id"))
-      audit = audit_cache.get(src.get("audit", {}).get("id"))
+      audit = audit_cache[src["audit"]["id"]]
       relate_assignees(assessment, snapshot, template, audit)
       relate_ca(assessment, template)
       assessment.title = u'{} assessment for {}'.format(
           snapshot.revision.content['title'],
-          snapshot.parent.title,
+          audit.title,
       )
       if not template:
         continue


### PR DESCRIPTION
Prefetch objects when generating assessments

ps: this PR will get a proper ticket number.

Generating 20 assessments:
before:
Total queries: 904
after
Total queries: 885

This PR reduces queries by number of generated assessments