### PR TITLE
QUICK-FIX Design TAF's extended unified equal procedure and human readable entities' comparison

### DIFF
--- a/test/selenium/src/lib/constants/element.py
+++ b/test/selenium/src/lib/constants/element.py
@@ -5,6 +5,7 @@
 # pylint: disable=invalid-name
 
 from collections import namedtuple
+
 from lib.constants import objects, roles
 
 
@@ -225,12 +226,12 @@ class CommonAssessment(Common):
   """Common elements' labels and properties for Assessments objects."""
   ASMT = objects.get_normal_form(objects.get_singular(objects.ASSESSMENTS))
   STATE = Base.STATE
+  CREATORS = "Creators"
   CREATORS_ = "Creator(s)"
-  CREATORS = TransformationSetVisibleFields.CREATORS
+  ASSIGNEES = "Assignees"
   ASSIGNEES_ = "Assignee(s)"
-  ASSIGNEES = TransformationSetVisibleFields.ASSIGNEES
+  VERIFIERS = "Verifiers"
   VERIFIERS_ = "Verifier(s)"
-  VERIFIERS = TransformationSetVisibleFields.ASSIGNEES
   MAPPED_OBJECTS = TransformationSetVisibleFields.MAPPED_OBJECTS
   VERIFIED = TransformationSetVisibleFields.VERIFIED
 
@@ -303,6 +304,7 @@ class AssessmentInfoWidget(CommonAssessment):
   WIDGET_HEADER = Base.WIDGET_INFO_HEADER_FORMAT.format(CommonAssessment.ASMT)
   TITLE_UPPER = CommonAssessment.TITLE.upper()
   CODE_UPPER = CommonAssessment.CODE.upper()
+  COMMENTS_HEADER = "RESPONSES/COMMENTS"
 
 
 class AssessmentTemplateModalSetVisibleFields(CommonModalSetVisibleFields):
@@ -437,3 +439,9 @@ class DropdownMenuItemTypes(object):
   UNMAP = "ban"
   CLONE = "clone"
   UPDATE = "refresh"
+
+
+class TransformationElements(TransformationSetVisibleFields, CommonAssessment):
+  """All transformation elements' labels and properties witch are using to
+  convert UI attributes to entities attributes.
+  """

--- a/test/selenium/src/lib/constants/locator.py
+++ b/test/selenium/src/lib/constants/locator.py
@@ -735,14 +735,17 @@ class WidgetInfoAudit(WidgetInfoPanel):
 
 class WidgetInfoAssessment(WidgetInfoPanel):
   """Locators for Assessment Info widgets."""
+  # pylint: disable=invalid-name
   WIDGET = Common.INFO_WIDGET
   TOGGLE = ' [class*="fa-caret"]'
   # Base
   CAS_HEADERS_AND_VALUES = (By.CSS_SELECTOR,
                             WIDGET + " auto-save-form .flex-size-1")
   CAS_CHECKBOXES = (By.CSS_SELECTOR, '[class*="wrapper"] [type="checkbox"]')
-  MAPPED_OBJECTS_TITLES_AND_DESCRIPTIONS = (By.CSS_SELECTOR,
-                                            WIDGET + Common.TREE_ITEM)
+  MAPPED_OBJECTS_TITLES_AND_DESCRIPTIONS = (
+      By.CSS_SELECTOR, WIDGET + " .mapped-objects__item-body")
+  MAPPED_OBJECT_TITLE = (By.CSS_SELECTOR, ".title")
+  MAPPED_OBJECT_DESCRIPTION = (By.CSS_SELECTOR, ".description")
   # Assessment Attributes tab
   # People section
   PEOPLE_HEADERS_AND_VALUES = (By.CSS_SELECTOR,

--- a/test/selenium/src/lib/constants/messages.py
+++ b/test/selenium/src/lib/constants/messages.py
@@ -1,9 +1,113 @@
 # Copyright (C) 2017 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
-"""Message templates for stdout (e.g. print, assert, etc.)."""
+"""Constants and procedures to make formatted messages."""
 
-ERR_MSG_FORMAT = "Expected: '{}', Got: '{}'\n"
-ERR_MSG_TRIPLE_FORMAT = "Expected: '{}', First Got: '{}', Second Got: '{}'\n"
-ERR_VALUE_OF_ARGUMENT = "The argument does not contain numbers\n"
-ERR_SWITCH_TO_NEW_WINDOW = "New window target doesn't exist\n"
-ERR_CSV_FORMAT = "CSV file has unexpected structure: {}\n"
+import copy
+
+from lib.entities import entity
+
+
+class CommonMessages(object):
+  """Class contains constants and methods to make messages."""
+  # pylint: disable=too-few-public-methods
+  err_common = "\nExpected:\n{}\n\nActual:\n{}\n"
+  err_contains = "\nExpected:\n{}\n\nin\n\nActual:\n{}\n"
+
+
+class AssertionMessages(CommonMessages):
+  """Class contains constants and methods to make messages after assertion
+  procedures.
+  """
+  _line = "\n-----\n"
+  _double_diff = "\nExpected:\n{}\nActual:\n{}\n"
+  _triple_diff = "\nExpected:\n{}\nActual First:\n{}\nActual Second:\n{}\n"
+  err_two_entities_diff = (
+      _line + "\nFULL:" + _double_diff + "\nSAME:" + _double_diff + "\nDIFF:" +
+      _double_diff)
+  err_three_entities_diff = (
+      _line + "\nFULL:" + _triple_diff + "\nSAME:" + _triple_diff + "\nDIFF:" +
+      _triple_diff)
+  entities_cls = tuple(entity.Entity.all_entities_classes())
+
+  @classmethod
+  def diff_error_msg(cls, left, right):
+    """Return formatted error message for two entities."""
+    return cls.err_two_entities_diff.format(
+        left, right, left.diff_info["equal"], right.diff_info["equal"],
+        left.diff_info["diff"], right.diff_info["diff"])
+
+  @classmethod
+  def is_entities_have_err_info(cls, left, right):
+    """Check if entities are instances of entities and have needed attributes
+    and keys to make result error comparison message.
+    """
+    return (isinstance(left and right, cls.entities_cls) and
+            hasattr(left and right, "diff_info") and
+            getattr(left, "diff_info") and getattr(right, "diff_info"))
+
+  @classmethod
+  def set_entities_diff_info(cls, left, right):
+    """Get and set entities diff info attributes info."""
+    comparison = entity.Representation.compare_entities(left, right)
+    left.diff_info = comparison["self_diff"]
+    right.diff_info = comparison["other_diff"]
+
+  @classmethod
+  def format_err_msg_equal(cls, left, right):
+    """Return customized and detailed error message after assert equal
+    comparison.
+    """
+    # comparison of entities
+    assertion_error_msg = cls.err_common.format(left, right)
+    # processing of entity
+    if isinstance(left and right, cls.entities_cls):
+      if not cls.is_entities_have_err_info(left, right):
+        cls.set_entities_diff_info(left, right)
+      assertion_error_msg = cls.diff_error_msg(left, right)
+    # processing list of entities
+    if (isinstance(left and right, list) and
+            all(isinstance(_left and _right, cls.entities_cls)
+                for _left, _right in zip(left, right))):
+      assertion_error_msg = ""
+      for _left, _right in zip(sorted(left), sorted(right)):
+        if not cls.is_entities_have_err_info(_left, _right):
+          cls.set_entities_diff_info(_left, _right)
+        assertion_error_msg = (assertion_error_msg +
+                               cls.diff_error_msg(_left, _right))
+    return assertion_error_msg
+
+  @classmethod
+  def format_err_msg_contains(cls, left, right):
+    """Return customized and detailed error message after assert contains
+    comparison.
+    """
+    # comparison of entities
+    assertion_error_msg = cls.err_contains.format(left, right)
+    # processing of entity
+    if isinstance(left and right, cls.entities_cls):
+      if not cls.is_entities_have_err_info(left, right):
+        cls.set_entities_diff_info(left, right)
+      assertion_error_msg = cls.diff_error_msg(left, right)
+    # processing list of entities
+    if (isinstance(left, cls.entities_cls) and isinstance(right, list) and
+            all(isinstance(_right, cls.entities_cls) for _right in right)):
+      assertion_error_msg = ""
+      for _right in right:
+        left = copy.copy(left)
+        if not cls.is_entities_have_err_info(left, _right):
+          cls.set_entities_diff_info(left, _right)
+        assertion_error_msg = (assertion_error_msg +
+                               cls.diff_error_msg(left, _right))
+    return assertion_error_msg
+
+
+class ExceptionsMessages(CommonMessages):
+  """Class contains constants and methods to make messages after exceptions
+  procedures.
+  """
+  # pylint: disable=too-few-public-methods
+  err_value_of_argument = "The argument does not contain numbers\n"
+  err_switch_to_new_window = "New window target doesn't exist\n"
+  err_csv_format = "CSV file has unexpected structure: {}\n"
+  err_comments_count = "Comments's count." + CommonMessages.err_common
+  err_server_response = "Server response: (code: {}, message: {})\n"

--- a/test/selenium/src/lib/constants/regex.py
+++ b/test/selenium/src/lib/constants/regex.py
@@ -5,3 +5,4 @@
 WIDGET_TITLE_AND_COUNT = r"(.*) \((.*)\)"
 URL_WIDGET_INFO = (
     r"//[0-9a-z\-.]*[:0-9]*?/([a-z_]*)/?(\d*)#?([^/]*)/([a-z_]*)/?(\d*)/*")
+TEXT_WITHIN_PARENTHESES = r"\([^)]*\) "

--- a/test/selenium/src/lib/entities/entity.py
+++ b/test/selenium/src/lib/entities/entity.py
@@ -4,7 +4,8 @@
 # pylint: disable=too-many-arguments
 # pylint: disable=too-few-public-methods
 
-from lib.constants import element, files
+from datetime import datetime
+
 from lib.utils import string_utils
 
 
@@ -12,26 +13,53 @@ class Representation(object):
   """Class that contains methods to update Entity."""
   # pylint: disable=import-error
 
+  diff_info = None  # {"equal": {"atr7": val7, ...}, "diff": {"atr3": val3}}
+  attrs_names_to_compare = None
+  attrs_names_to_repr = None
+  core_attrs_names_to_repr = ["type", "title", "id", "href", "url", "slug"]
+
+  def extended_equal(self, other):
+    """Extended equal procedure fore self and other entities."""
+    comparison = Representation.compare_entities(self, other)
+    self.diff_info = comparison["self_diff"]
+    other.diff_info = comparison["other_diff"]
+    return comparison["is_equal"]
+
+  @classmethod
+  def get_attrs_names_for_entities(cls, entity=None):
+    """Get list unique attributes names for entities. If 'entity' then get
+    attributes of one entered entity, else get attributes of all entities.
+    """
+    all_entities_cls = (string_utils.convert_to_list(entity) if entity
+                        else Entity.all_entities_classes())
+    all_entities_attrs_names = string_utils.convert_list_elements_to_list(
+        [entity_cls().__dict__.keys() for entity_cls in all_entities_cls])
+    return list(set(all_entities_attrs_names))
+
   @staticmethod
   def items_of_remap_keys():
     """Get transformation dictionary {'OLD KEY': 'NEW KEY'}, where
     'OLD KEY' - UI elements and CSV fields correspond to
     'NEW KEY' - objects attributes.
     """
-    el = element.TransformationSetVisibleFields
+    from lib.constants import element, files
+    els = element.TransformationElements
     csv = files.TransformationCSVFields
     # common for UI and CSV
     result_remap_items = {
-        el.TITLE: "title", el.ADMIN: "owners", el.CODE: "slug",
-        el.REVIEW_STATE: "os_state", el.STATE: "status"
+        els.TITLE: "title", els.ADMIN: "owners",
+        els.CODE: "slug", els.REVIEW_STATE: "os_state",
+        els.STATE: "status"
     }
     ui_remap_items = {
-        el.MANAGER: "manager", el.VERIFIED: "verified",
-        el.STATUS: "status", el.LAST_UPDATED: "updated_at",
-        el.AUDIT_LEAD: "contact", el.CAS: "custom_attributes",
-        el.MAPPED_OBJECTS: "objects_under_assessment",
-        el.ASSIGNEES: "assessor", el.CREATORS: "creator",
-        el.VERIFIERS: "verifier"
+        els.MANAGER: "manager", els.VERIFIED: "verified",
+        els.STATUS: "status", els.LAST_UPDATED: "updated_at",
+        els.AUDIT_LEAD: "contact", els.CAS: "custom_attributes",
+        els.MAPPED_OBJECTS: "objects_under_assessment",
+        els.ASSIGNEES: "assessor", els.ASSIGNEES_: "assessor",
+        els.CREATORS: "creator", els.CREATORS_: "creator",
+        els.VERIFIERS: "verifier", els.VERIFIERS_: "verifier",
+        element.AssessmentInfoWidget.COMMENTS_HEADER: "comments"
     }
     csv_remap_items = {
         csv.REVISION_DATE: "updated_at"
@@ -48,15 +76,102 @@ class Representation(object):
     return (entities_factory.EntitiesFactory().
             convert_obj_repr_from_rest_to_ui(obj=self))
 
-  def update_attrs(self, is_replace_attrs=True, is_allow_none=True, **attrs):
+  def update_attrs(self, is_replace_attrs=True, is_allow_none=True,
+                   is_replace_dicts_values=False, **attrs):
     """Update entity's attributes values according to entered data
     (dictionaries of attributes and values).
+    If 'is_replace_values_of_dicts' then update values of dicts in list which
+    is value of particular object's attribute name.
     """
     from lib.entities import entities_factory
     return (entities_factory.EntitiesFactory().
             update_objs_attrs_values_by_entered_data(
                 objs=self, is_replace_attrs_values=is_replace_attrs,
-                is_allow_none_values=is_allow_none, **attrs))
+                is_allow_none_values=is_allow_none,
+                is_replace_values_of_dicts=is_replace_dicts_values, **attrs))
+
+  def compare_entities(self, other):
+    """Extended compare of entities: 'self_entity' and 'other_entity' according
+    to specific 'attrs_names_to_compare' and return:
+    - 'is_equal' - True if entities equal else False;
+    - 'self_diff' - 'equal' and 'diff' parts of 'self_entity' after compare;
+    - 'other_diff' - 'equal' and 'diff' parts of 'other_entity' after compare.
+    """
+    # pylint: disable=not-an-iterable
+    is_equal = False
+    self_equal, self_diff, other_equal, other_diff = {}, {}, {}, {}
+    if (isinstance(self, other.__class__) and
+            self.attrs_names_to_compare == other.attrs_names_to_compare):
+      for attr_name in self.attrs_names_to_compare:
+        self_attr_value = None
+        other_attr_value = None
+        if (attr_name in self.__dict__.keys() and
+                attr_name in other.__dict__.keys()):
+          self_attr_value = getattr(self, attr_name)
+          other_attr_value = getattr(other, attr_name)
+          # get 'is_equal' of attrs' values according to their names
+          if attr_name == "custom_attributes":
+            is_equal = self.compare_cas(self_attr_value, other_attr_value)
+          elif attr_name in ["updated_at", "created_at"]:
+            is_equal = self.compare_datetime(
+                self_attr_value, other_attr_value)
+          else:
+            is_equal = self_attr_value == other_attr_value
+        if is_equal:
+          self_equal[attr_name] = self_attr_value
+          other_equal[attr_name] = other_attr_value
+        else:
+          self_diff[attr_name] = {"val": self_attr_value,
+                                  "type": type(self_attr_value)}
+          other_diff[attr_name] = {"val": other_attr_value,
+                                   "type": type(other_attr_value)}
+      is_equal = self_diff == other_diff == {}
+    return {"is_equal": is_equal,
+            "self_diff": {"equal": self_equal, "diff": self_diff},
+            "other_diff": {"equal": other_equal, "diff": other_diff}
+            }
+
+  @staticmethod
+  def compare_cas(self_cas, other_cas):
+    """Compare entities' 'custom_attributes' attributes."""
+    if isinstance(self_cas and other_cas, dict):
+      return string_utils.is_subset_of_dicts(self_cas, other_cas)
+    else:
+      Representation.attrs_values_types_error(
+          self_attr=self_cas, other_attr=other_cas,
+          expected_types=dict.__name__)
+
+  @staticmethod
+  def compare_datetime(self_datetime, other_datetime):
+    """Compare entities' datetime ('created_at', 'updated_at') attributes."""
+    # pylint: disable=superfluous-parens
+    if (isinstance(self_datetime and other_datetime, (datetime, type(None)))):
+      return (
+          (self_datetime == other_datetime
+           if all(str(_.time()) != "00:00:00"
+                  for _ in [self_datetime, other_datetime])
+           else self_datetime.date() == other_datetime.date())
+          if self_datetime and other_datetime
+          else self_datetime == other_datetime)
+    else:
+      Representation.attrs_values_types_error(
+          self_attr=self_datetime, other_attr=other_datetime,
+          expected_types=(datetime.__name__, type(None).__name__))
+
+  @staticmethod
+  def attrs_values_types_error(self_attr, other_attr, expected_types):
+    raise ValueError("'{}' have to be isinstance of classes: {}\n".
+                     format((self_attr, other_attr), expected_types))
+
+  def __eq__(self, other):
+    return self.extended_equal(other)
+
+  def __repr__(self):
+    # exclude attributes witch are used for REST interaction forming
+    # pylint: disable=not-an-iterable
+    return str(dict(zip(self.attrs_names_to_repr,
+                        [getattr(self, attr_name_to_repr) for attr_name_to_repr
+                         in self.attrs_names_to_repr])))
 
 
 class Entity(Representation):
@@ -64,25 +179,51 @@ class Entity(Representation):
   # pylint: disable=invalid-name
   # pylint: disable=redefined-builtin
 
-  def __init__(self, type=None, id=None, title=None, href=None, url=None):
+  def __init__(self, type=None, slug=None, id=None, title=None, href=None,
+               url=None):
+    # REST and UI
     self.type = type
+    self.slug = slug  # code
     self.id = id
     self.title = title
     self.href = href
     self.url = url
 
   @staticmethod
-  def get_attrs_names_for_entities(entity=None):
-    """Get list unique attributes names for entities. If 'entity' then get
-    attributes of one entered entity, else get attributes of all entities.
-    """
-    all_entities_cls = (
-        [entity] if entity else
-        [PersonEntity, CustomAttributeEntity, ProgramEntity, ControlEntity,
-         AuditEntity, AssessmentEntity, AssessmentTemplateEntity, IssueEntity])
-    all_entities_attrs_names = string_utils.convert_list_elements_to_list(
-        [entity_cls().__dict__.keys() for entity_cls in all_entities_cls])
-    return list(set(all_entities_attrs_names))
+  def all_entities_classes():
+    """Explicitly return list of all entities' classes."""
+    return [
+        PersonEntity, CustomAttributeEntity, ProgramEntity, ControlEntity,
+        AuditEntity, AssessmentEntity, AssessmentTemplateEntity, IssueEntity,
+        CommentEntity]
+
+  def __lt__(self, other):
+    return self.slug < other.slug
+
+
+class CommentEntity(Representation):
+  """Class that represent model for Comment."""
+  # pylint: disable=invalid-name
+  # pylint: disable=redefined-builtin
+  __hash__ = None
+
+  attrs_names_to_compare = ["type", "modified_by", "created_at", "description"]
+  attrs_names_to_repr = [
+      "type", "id", "href", "modified_by", "created_at", "description"]
+
+  def __init__(self, type=None, id=None, href=None, modified_by=None,
+               created_at=None, description=None):
+    super(CommentEntity, self).__init__()
+    # REST and UI
+    self.type = type
+    self.id = id
+    self.href = href
+    self.modified_by = modified_by
+    self.created_at = created_at
+    self.description = description
+
+  def __lt__(self, other):
+    return self.description < other.description
 
 
 class PersonEntity(Representation):
@@ -91,12 +232,18 @@ class PersonEntity(Representation):
   # pylint: disable=redefined-builtin
   # pylint: disable=too-many-instance-attributes
   __hash__ = None
+  attrs_names_to_compare = [
+      "type", "name", "email"]
+  attrs_names_to_repr = [
+      "type", "id", "name", "href", "url", "email", "company",
+      "system_wide_role", "updated_at"]
 
   def __init__(self, type=None, id=None, name=None, href=None, url=None,
                email=None, company=None, system_wide_role=None,
                updated_at=None, custom_attribute_definitions=None,
                custom_attribute_values=None):
     super(PersonEntity, self).__init__()
+    # REST and UI
     self.name = name
     self.id = id
     self.href = href
@@ -105,21 +252,13 @@ class PersonEntity(Representation):
     self.email = email
     self.company = company
     self.system_wide_role = system_wide_role  # authorizations
-    self.updated_at = updated_at  # last updated
+    self.updated_at = updated_at  # last updated datetime
+    # REST
     self.custom_attribute_definitions = custom_attribute_definitions
     self.custom_attribute_values = custom_attribute_values
 
-  def __repr__(self):
-    return ("type: {type}, id: {id}, name: {name}, href: {href}, url: {url}, "
-            "email: {email}, company: {company}, "
-            "system_wide_role: {system_wide_role}, updated_at: {updated_at}, "
-            "custom_attribute_definitions: {custom_attribute_definitions}, "
-            "custom_attribute_values: {custom_attribute_values}").format(
-        type=self.type, id=self.id, name=self.name, href=self.href,
-        url=self.url, email=self.email, company=self.company,
-        system_wide_role=self.system_wide_role, updated_at=self.updated_at,
-        custom_attribute_definitions=self.custom_attribute_definitions,
-        custom_attribute_values=self.custom_attribute_values)
+  def __lt__(self, other):
+    return self.email < other.email
 
 
 class CustomAttributeEntity(Representation):
@@ -129,12 +268,19 @@ class CustomAttributeEntity(Representation):
   # pylint: disable=too-many-instance-attributes
   __hash__ = None
   entity = Entity()
+  attrs_names_to_compare = [
+      "type", "title", "definition_type", "attribute_type", "mandatory"]
+  attrs_names_to_repr = [
+      "type", "title", "id", "href", "definition_type", "attribute_type",
+      "helptext", "placeholder", "mandatory", "multi_choice_options",
+      "created_at", "modified_by"]
 
   def __init__(self, title=None, id=None, href=None, type=None,
                definition_type=None, attribute_type=None, helptext=None,
                placeholder=None, mandatory=None, multi_choice_options=None,
                created_at=None, modified_by=None):
     super(CustomAttributeEntity, self).__init__()
+    # REST and UI
     self.title = title
     self.id = id
     self.href = href
@@ -145,29 +291,12 @@ class CustomAttributeEntity(Representation):
     self.placeholder = placeholder
     self.mandatory = mandatory
     self.multi_choice_options = multi_choice_options
+    # REST
     self.created_at = created_at  # to generate same CAs values
     self.modified_by = modified_by
 
-  def __repr__(self):
-    return ("type: {type}, title: {title}, id: {id}, href: {href}, "
-            "definition_type: {definition_type}, "
-            "attribute_type: {attribute_type}, helptext: {helptext}, "
-            "placeholder: {placeholder}, mandatory: {mandatory}, "
-            "multi_choice_options: {multi_choice_options}, "
-            "created_at: {created_at}, modified_by: {modified_by}").format(
-        type=self.type, title=self.title, id=self.id, href=self.href,
-        definition_type=self.definition_type,
-        attribute_type=self.attribute_type, helptext=self.helptext,
-        placeholder=self.placeholder, mandatory=self.mandatory,
-        multi_choice_options=self.multi_choice_options,
-        created_at=self.created_at, modified_by=self.modified_by)
-
-  def __eq__(self, other):
-    return (isinstance(other, self.__class__) and self.type == other.type and
-            self.title == other.title and
-            self.definition_type == other.definition_type and
-            self.attribute_type == other.attribute_type and
-            self.mandatory == other.mandatory)
+  def __lt__(self, other):
+    return self.title < other.title
 
 
 class ProgramEntity(Entity):
@@ -175,49 +304,30 @@ class ProgramEntity(Entity):
   # pylint: disable=too-many-instance-attributes
   __hash__ = None
 
-  def __init__(self, slug=None, status=None, manager=None, contact=None,
+  attrs_names_to_compare = [
+      "custom_attributes", "manager", "os_state", "slug", "status", "title",
+      "type", "updated_at"]
+  attrs_names_to_repr = Representation.core_attrs_names_to_repr + [
+      "status", "manager", "contact", "secondary_contact", "updated_at",
+      "custom_attributes"]
+
+  def __init__(self, status=None, manager=None, contact=None,
                secondary_contact=None, updated_at=None, os_state=None,
                custom_attribute_definitions=None, custom_attribute_values=None,
                custom_attributes=None):
     super(ProgramEntity, self).__init__()
-    self.slug = slug  # code
+    # REST and UI
     self.status = status  # state
-    self.manager = manager  # predefined and same as primary contact
+    self.manager = manager  # predefined
     self.contact = contact  # primary contact
     self.secondary_contact = secondary_contact
-    self.updated_at = updated_at  # last updated
-    self.os_state = os_state  # review state
+    self.updated_at = updated_at  # last updated datetime
+    # REST
+    self.os_state = os_state  # review state (e.g. "Unreviewed")
     self.custom_attribute_definitions = custom_attribute_definitions
     self.custom_attribute_values = custom_attribute_values
+    # additional
     self.custom_attributes = custom_attributes  # map of cas def and values
-
-  def __repr__(self):
-    return ("type: {type}, id: {id}, title: {title}, href: {href}, "
-            "url: {url}, slug: {slug}, status: {status}, manager: {manager}, "
-            "contact: {contact}, secondary_contact: {secondary_contact}, "
-            "updated_at: {updated_at}, os_state: {os_state}, "
-            "custom_attribute_definitions: {custom_attribute_definitions}, "
-            "custom_attribute_values: {custom_attribute_values}, "
-            "custom_attributes: {custom_attributes}").format(
-        type=self.type, title=self.title, id=self.id, href=self.href,
-        url=self.url, slug=self.slug, status=self.status, manager=self.manager,
-        contact=self.contact, secondary_contact=self.secondary_contact,
-        updated_at=self.updated_at, os_state=self.os_state,
-        custom_attribute_definitions=self.custom_attribute_definitions,
-        custom_attribute_values=self.custom_attribute_values,
-        custom_attributes=self.custom_attributes)
-
-  def __eq__(self, other):
-    return (isinstance(other, self.__class__) and
-            string_utils.is_one_dict_is_subset_another_dict(
-                self.custom_attributes, other.custom_attributes) and
-            self.manager == other.manager and
-            self.os_state == other.os_state and self.slug == other.slug and
-            self.status == other.status and self.title == other.title and
-            self.type == other.type and self.updated_at == other.updated_at)
-
-  def __lt__(self, other):
-    return self.slug < other.slug
 
 
 class ControlEntity(Entity):
@@ -225,49 +335,30 @@ class ControlEntity(Entity):
   # pylint: disable=too-many-instance-attributes
   __hash__ = None
 
-  def __init__(self, slug=None, status=None, owners=None, contact=None,
+  attrs_names_to_compare = [
+      "custom_attributes", "os_state", "slug", "status", "title", "type",
+      "updated_at"]
+  attrs_names_to_repr = Representation.core_attrs_names_to_repr + [
+      "status", "contact", "secondary_contact", "updated_at",
+      "os_state", "custom_attributes"]
+
+  def __init__(self, status=None, owners=None, contact=None,
                secondary_contact=None, updated_at=None, os_state=None,
                custom_attribute_definitions=None, custom_attribute_values=None,
                custom_attributes=None):
     super(ControlEntity, self).__init__()
-    self.slug = slug  # code
-    self.status = status  # state
-    self.owners = owners
+    # REST and UI
+    self.status = status  # state (e.g. "Draft")
     self.contact = contact  # primary contact
     self.secondary_contact = secondary_contact
-    self.updated_at = updated_at  # last updated
-    self.os_state = os_state  # review state
+    self.updated_at = updated_at  # last updated datetime
+    self.os_state = os_state  # review state (e.g. "Unreviewed")
+    # REST
+    self.owners = owners
     self.custom_attribute_definitions = custom_attribute_definitions
     self.custom_attribute_values = custom_attribute_values
+    # additional
     self.custom_attributes = custom_attributes  # map of cas def and values
-
-  def __repr__(self):
-    return ("type: {type}, id: {id}, title: {title}, href: {href}, "
-            "url: {url}, slug: {slug}, status: {status}, owners: {owners}, "
-            "contact: {contact}, secondary_contact: {secondary_contact}, "
-            "updated_at: {updated_at}, os_state: {os_state}, "
-            "custom_attribute_definitions: {custom_attribute_definitions}, "
-            "custom_attribute_values: {custom_attribute_values}, "
-            "custom_attributes: {custom_attributes}").format(
-        type=self.type, title=self.title, id=self.id, href=self.href,
-        url=self.url, slug=self.slug, status=self.status, owners=self.owners,
-        contact=self.contact, secondary_contact=self.secondary_contact,
-        updated_at=self.updated_at, os_state=self.os_state,
-        custom_attribute_definitions=self.custom_attribute_definitions,
-        custom_attribute_values=self.custom_attribute_values,
-        custom_attributes=self.custom_attributes)
-
-  def __eq__(self, other):
-    return (isinstance(other, self.__class__) and
-            string_utils.is_one_dict_is_subset_another_dict(
-                self.custom_attributes, other.custom_attributes) and
-            self.os_state == other.os_state and self.owners == other.owners and
-            self.slug == other.slug and self.status == other.status and
-            self.title == other.title and self.type == other.type and
-            self.updated_at == other.updated_at)
-
-  def __lt__(self, other):
-    return self.slug < other.slug
 
 
 class ObjectiveEntity(Entity):
@@ -275,49 +366,30 @@ class ObjectiveEntity(Entity):
   # pylint: disable=too-many-instance-attributes
   __hash__ = None
 
-  def __init__(self, slug=None, status=None, owners=None, contact=None,
+  attrs_names_to_compare = [
+      "custom_attributes", "os_state", "slug", "status", "title", "type",
+      "updated_at"]
+  attrs_names_to_repr = Representation.core_attrs_names_to_repr + [
+      "status", "contact", "secondary_contact", "updated_at",
+      "os_state", "custom_attributes"]
+
+  def __init__(self, status=None, owners=None, contact=None,
                secondary_contact=None, updated_at=None, os_state=None,
                custom_attribute_definitions=None, custom_attribute_values=None,
                custom_attributes=None):
     super(ObjectiveEntity, self).__init__()
-    self.slug = slug  # code
+    # REST and UI
     self.status = status  # state
-    self.owners = owners
     self.contact = contact  # primary contact
     self.secondary_contact = secondary_contact
     self.updated_at = updated_at  # last updated
     self.os_state = os_state  # review state
+    # REST
+    self.owners = owners
     self.custom_attribute_definitions = custom_attribute_definitions
     self.custom_attribute_values = custom_attribute_values
+    # additional
     self.custom_attributes = custom_attributes  # map of cas def and values
-
-  def __repr__(self):
-    return ("type: {type}, id: {id}, title: {title}, href: {href}, "
-            "url: {url}, slug: {slug}, status: {status}, owners: {owners}, "
-            "contact: {contact}, secondary_contact: {secondary_contact}, "
-            "updated_at: {updated_at}, os_state: {os_state}, "
-            "custom_attribute_definitions: {custom_attribute_definitions}, "
-            "custom_attribute_values: {custom_attribute_values}, "
-            "custom_attributes: {custom_attributes}").format(
-        type=self.type, title=self.title, id=self.id, href=self.href,
-        url=self.url, slug=self.slug, status=self.status, owners=self.owners,
-        contact=self.contact, secondary_contact=self.secondary_contact,
-        updated_at=self.updated_at, os_state=self.os_state,
-        custom_attribute_definitions=self.custom_attribute_definitions,
-        custom_attribute_values=self.custom_attribute_values,
-        custom_attributes=self.custom_attributes)
-
-  def __eq__(self, other):
-    return (isinstance(other, self.__class__) and
-            string_utils.is_one_dict_is_subset_another_dict(
-                self.custom_attributes, other.custom_attributes) and
-            self.os_state == other.os_state and self.owners == other.owners and
-            self.slug == other.slug and self.status == other.status and
-            self.title == other.title and self.type == other.type and
-            self.updated_at == other.updated_at)
-
-  def __lt__(self, other):
-    return self.slug < other.slug
 
 
 class AuditEntity(Entity):
@@ -325,44 +397,26 @@ class AuditEntity(Entity):
   # pylint: disable=too-many-instance-attributes
   __hash__ = None
 
-  def __init__(self, slug=None, status=None, program=None, contact=None,
+  attrs_names_to_compare = [
+      "contact", "custom_attributes", "slug", "status", "title", "type",
+      "updated_at"]
+  attrs_names_to_repr = Representation.core_attrs_names_to_repr + [
+      "status", "program", "contact", "updated_at", "custom_attributes"]
+
+  def __init__(self, status=None, program=None, contact=None,
                updated_at=None, custom_attribute_definitions=None,
                custom_attribute_values=None, custom_attributes=None):
     super(AuditEntity, self).__init__()
-    self.slug = slug  # code
-    self.status = status  # status
-    self.program = program
+    # REST and UI
+    self.status = status  # status (e.g. "Planned")
     self.contact = contact  # internal audit lead
-    self.updated_at = updated_at  # last updated
+    self.updated_at = updated_at  # last updated datetime
+    # REST
     self.custom_attribute_definitions = custom_attribute_definitions
     self.custom_attribute_values = custom_attribute_values
+    # additional
+    self.program = program  # program title
     self.custom_attributes = custom_attributes  # map of cas def and values
-
-  def __repr__(self):
-    return ("type: {type}, id: {id}, title: {title}, href: {href}, "
-            "url: {url}, slug: {slug}, status: {status}, program: {program}, "
-            "contact: {contact}, updated_at: {updated_at}, "
-            "custom_attribute_definitions: {custom_attribute_definitions}, "
-            "custom_attribute_values: {custom_attribute_values}, "
-            "custom_attributes: {custom_attributes}").format(
-        type=self.type, title=self.title, id=self.id, href=self.href,
-        url=self.url, slug=self.slug, status=self.status, program=self.program,
-        contact=self.contact, updated_at=self.updated_at,
-        custom_attribute_definitions=self.custom_attribute_definitions,
-        custom_attribute_values=self.custom_attribute_values,
-        custom_attributes=self.custom_attributes)
-
-  def __eq__(self, other):
-    return (isinstance(other, self.__class__) and
-            self.contact == other.contact and
-            string_utils.is_one_dict_is_subset_another_dict(
-                self.custom_attributes, other.custom_attributes) and
-            self.slug == other.slug and self.status == other.status and
-            self.title == other.title and self.type == other.type and
-            self.updated_at == other.updated_at)
-
-  def __lt__(self, other):
-    return self.slug < other.slug
 
 
 class AssessmentTemplateEntity(Entity):
@@ -371,49 +425,26 @@ class AssessmentTemplateEntity(Entity):
   # pylint: disable=too-many-instance-attributes
   __hash__ = None
 
-  def __init__(self, slug=None, audit=None, default_people=None,
-               verifiers=None, assessors=None, template_object_type=None,
-               updated_at=None, custom_attribute_definitions=None,
+  attrs_names_to_compare = [
+      "custom_attributes", "slug", "title", "type", "updated_at"]
+  attrs_names_to_repr = Representation.core_attrs_names_to_repr + [
+      "audit", "template_object_type", "updated_at", "custom_attributes"]
+
+  def __init__(self, audit=None, default_people=None,
+               template_object_type=None, updated_at=None,
+               custom_attribute_definitions=None,
                custom_attribute_values=None, custom_attributes=None):
     super(AssessmentTemplateEntity, self).__init__()
-    self.slug = slug  # code
-    self.audit = audit
+    # REST and UI
     self.default_people = default_people  # {"verifiers": *, "assessors": *}
-    self.verifiers = verifiers  # item of default_people
-    self.assessors = assessors  # item of default_people
     self.template_object_type = template_object_type  # objs under asmt
-    self.updated_at = updated_at  # last updated
+    self.updated_at = updated_at  # last updated datetime
+    # REST
     self.custom_attribute_definitions = custom_attribute_definitions
     self.custom_attribute_values = custom_attribute_values
+    # additional
+    self.audit = audit  # audit title
     self.custom_attributes = custom_attributes  # map of cas def and values
-
-  def __repr__(self):
-    return ("type: {type}, id: {id}, title: {title}, href: {href}, "
-            "url: {url}, slug: {slug}, audit: {audit}, "
-            "verifiers: {verifiers}, assessors: {assessors}, "
-            "template_object_type: {template_object_type}, "
-            "updated_at: {updated_at}, "
-            "custom_attribute_definitions: {custom_attribute_definitions}, "
-            "custom_attribute_values: {custom_attribute_values}, "
-            "custom_attributes: {custom_attributes}").format(
-        type=self.type, title=self.title, id=self.id, href=self.href,
-        url=self.url, slug=self.slug, audit=self.audit,
-        verifiers=self.verifiers, assessors=self.assessors,
-        template_object_type=self.template_object_type,
-        updated_at=self.updated_at,
-        custom_attribute_definitions=self.custom_attribute_definitions,
-        custom_attribute_values=self.custom_attribute_values,
-        custom_attributes=self.custom_attributes)
-
-  def __eq__(self, other):
-    return (isinstance(other, self.__class__) and
-            string_utils.is_one_dict_is_subset_another_dict(
-                self.custom_attributes, other.custom_attributes) and
-            self.slug == other.slug and self.title == other.title and
-            self.type == other.type and self.updated_at == other.updated_at)
-
-  def __lt__(self, other):
-    return self.slug < other.slug
 
 
 class AssessmentEntity(Entity):
@@ -424,69 +455,43 @@ class AssessmentEntity(Entity):
   # pylint: disable=duplicate-code
   __hash__ = None
 
-  def __init__(self, slug=None, status=None, audit=None, owners=None,
+  attrs_names_to_compare = [
+      "assessor", "creator", "verifier", "custom_attributes",
+      "objects_under_assessment", "slug", "status", "title", "type",
+      "updated_at", "verified", "comments"]
+  attrs_names_to_repr = Representation.core_attrs_names_to_repr + [
+      "status", "audit", "assessor", "creator", "verifier", "verified",
+      "updated_at", "objects_under_assessment", "custom_attributes",
+      "comments"]
+
+  def __init__(self, status=None, audit=None, owners=None,
                recipients=None, assignees=None, assessor=None, creator=None,
                verifier=None, verified=None, updated_at=None,
                objects_under_assessment=None, os_state=None,
                custom_attribute_definitions=None, custom_attribute_values=None,
-               custom_attributes=None):
+               custom_attributes=None, comments=None):
     super(AssessmentEntity, self).__init__()
-    self.slug = slug  # code
-    self.status = status  # state
-    self.owners = owners
-    self.audit = audit
-    self.recipients = recipients  # assessor, creator, verifier
-    self.assignees = assignees  # {"Assessor": *, "Creator": *, "Verifier": *}
-    self.assessor = assessor  # Assignee(s)
-    self.creator = creator  # Creator(s)
-    self.verifier = verifier  # Verifier(s)
+    # REST and UI
+    self.status = status  # state (e.g. "Not Started")
+    self.assessor = assessor  # assignees
+    self.creator = creator  # creators
+    self.verifier = verifier  # verifiers
     self.verified = verified
-    self.updated_at = updated_at  # last updated
+    self.updated_at = updated_at  # last updated datetime
     self.objects_under_assessment = objects_under_assessment  # mapped objs
-    self.os_state = os_state  # review state
+    # REST
+    # {"Assessor": [{}, {}], "Creator": [{}, {}], "Verifier": [{}, {}]}
+    self.assignees = assignees
+    self.owners = owners
+    self.os_state = os_state  # review state (e.g. "Unreviewed")
+    self.recipients = recipients  # "Verifier,Assessor,Creator"
     self.custom_attribute_definitions = custom_attribute_definitions
     self.custom_attribute_values = custom_attribute_values
+    # additional
+    self.audit = audit  # audit title
     self.custom_attributes = custom_attributes  # map of cas def and values
-
-  def __repr__(self):
-    return ("type: {type}, id: {id}, title: {title}, href: {href}, "
-            "url: {url}, slug: {slug}, status: {status}, owners: {owners}, "
-            "audit: {audit}, recipients: {recipients}, "
-            "assignees: {assignees}, assessor: {assessor}, "
-            "creator: {creator}, verifier: {verifier}, verified: {verified}, "
-            "updated_at: {updated_at}, "
-            "objects_under_assessment: {objects_under_assessment}, "
-            "os_state: {os_state}, "
-            "custom_attribute_definitions: {custom_attribute_definitions}, "
-            "custom_attribute_values: {custom_attribute_values}, "
-            "custom_attributes: {custom_attributes}").format(
-        type=self.type, title=self.title, id=self.id, href=self.href,
-        url=self.url, slug=self.slug, status=self.status, owners=self.owners,
-        audit=self.audit, recipients=self.recipients, assignees=self.assignees,
-        assessor=self.assessor, creator=self.creator, verifier=self.verifier,
-        verified=self.verified, updated_at=self.updated_at,
-        objects_under_assessment=self.objects_under_assessment,
-        os_state=self.os_state,
-        custom_attribute_definitions=self.custom_attribute_definitions,
-        custom_attribute_values=self.custom_attribute_values,
-        custom_attributes=self.custom_attributes)
-
-  def __eq__(self, other):
-    return (isinstance(other, self.__class__) and
-            self.assessor == other.assessor and
-            self.creator == other.creator and
-            string_utils.is_one_dict_is_subset_another_dict(
-                self.custom_attributes, other.custom_attributes) and
-            self.objects_under_assessment == other.objects_under_assessment and
-            self.os_state == other.os_state and self.owners == other.owners and
-            self.slug == other.slug and self.status == other.status and
-            self.title == other.title and self.type == other.type and
-            self.updated_at == other.updated_at and
-            self.verifier == other.verifier and
-            self.verified == other.verified)
-
-  def __lt__(self, other):
-    return self.slug < other.slug
+    # [{"modified_by": *, "created_at": *, "description": *}, {}]
+    self.comments = comments
 
 
 class IssueEntity(Entity):
@@ -494,46 +499,27 @@ class IssueEntity(Entity):
   # pylint: disable=too-many-instance-attributes
   __hash__ = None
 
-  def __init__(self, slug=None, status=None, audit=None, owners=None,
+  attrs_names_to_compare = [
+      "type", "title", "slug", "status", "contact"]
+  attrs_names_to_repr = Representation.core_attrs_names_to_repr + [
+      "status", "audit", "contact", "secondary_contact", "updated_at",
+      "custom_attributes"]
+
+  def __init__(self, status=None, audit=None, owners=None,
                contact=None, secondary_contact=None, updated_at=None,
                custom_attribute_definitions=None, os_state=None,
                custom_attribute_values=None, custom_attributes=None):
     super(IssueEntity, self).__init__()
-    self.slug = slug  # code
+    # REST and UI
     self.status = status  # state
-    self.audit = audit
-    self.owners = owners
     self.contact = contact  # primary contact
     self.secondary_contact = secondary_contact
-    self.updated_at = updated_at  # last updated
-    self.os_state = os_state  # review state
+    self.updated_at = updated_at  # last updated datetime
+    # REST
+    self.owners = owners
+    self.os_state = os_state  # review state (e.g. "Unreviewed")
     self.custom_attribute_definitions = custom_attribute_definitions
     self.custom_attribute_values = custom_attribute_values
+    # additional
+    self.audit = audit  # audit title
     self.custom_attributes = custom_attributes  # map of cas def and values
-
-  def __repr__(self):
-    return ("type: {type}, id: {id}, title: {title}, href: {href}, "
-            "url: {url}, slug: {slug}, status: {status}, audit: {audit}, "
-            "owners: {owners}, contact: {contact}, "
-            "secondary_contact: {secondary_contact}, "
-            "updated_at: {updated_at}, os_state: {os_state}, "
-            "custom_attribute_definitions: {custom_attribute_definitions}, "
-            "custom_attribute_values: {custom_attribute_values}, "
-            "custom_attributes: {custom_attributes}").format(
-        type=self.type, title=self.title, id=self.id, href=self.href,
-        url=self.url, slug=self.slug, status=self.status, audit=self.audit,
-        owners=self.owners, contact=self.contact,
-        secondary_contact=self.secondary_contact, updated_at=self.updated_at,
-        os_state=self.os_state,
-        custom_attribute_definitions=self.custom_attribute_definitions,
-        custom_attribute_values=self.custom_attribute_values,
-        custom_attributes=self.custom_attributes)
-
-  def __eq__(self, other):
-    return (isinstance(other, self.__class__) and self.type == other.type and
-            self.title == other.title and self.slug == other.slug and
-            self.status == other.status and self.contact == other.contact and
-            self.owners == other.owners)
-
-  def __lt__(self, other):
-    return self.slug < other.slug

--- a/test/selenium/src/lib/page/widget/admin_widget.py
+++ b/test/selenium/src/lib/page/widget/admin_widget.py
@@ -101,6 +101,5 @@ class CustomAttributes(widget_base.WidgetAdminCustomAttributes):
     return ca_item_content.get_ca_list_from_group()
 
 
-class ModalCustomAttributes(widget_base.CustomAttributeModal,
-                            widget_base.CreateNewCustomAttributeModal):
+class ModalCustomAttributes(widget_base.CustomAttributeModal):
   """Custom attributes modal."""

--- a/test/selenium/src/lib/page/widget/widget_base.py
+++ b/test/selenium/src/lib/page/widget/widget_base.py
@@ -9,7 +9,7 @@ from lib import base, decorator, environment
 from lib.constants import locator, url, objects
 from lib.entities.entity import CustomAttributeEntity
 from lib.utils import selenium_utils
-from lib.utils.string_utils import get_bool_from_string
+from lib.utils.string_utils import get_bool_value_from_arg
 
 
 class _Modal(base.Modal):
@@ -32,23 +32,6 @@ class _Modal(base.Modal):
     Return: WidgetAdminCustomAttributes
     """
     self.button_submit.click()
-
-
-class CreateNewCustomAttributeModal(base.Modal):
-  """Create new custom attribute modal."""
-  _locators = locator.ModalCustomAttribute
-
-  def __init__(self, driver):
-    super(CreateNewCustomAttributeModal, self).__init__(driver)
-    self.button_add_more = base.Button(
-        self._driver, self._locators.BUTTON_ADD_ANOTHER)
-
-  def save_and_add_another(self):
-    """
-    Return: ModalCustomAttributes
-    """
-    self.button_add_more.click_when_visible()
-    return self.__class__(self._driver)
 
 
 class CustomAttributesItemContent(base.Component):
@@ -88,7 +71,7 @@ class CustomAttributesItemContent(base.Component):
               title=attrs[0],
               type=objects.get_singular(objects.CUSTOM_ATTRIBUTES),
               attribute_type=attrs[1],
-              mandatory=get_bool_from_string(attrs[2]),
+              mandatory=get_bool_value_from_arg(attrs[2]),
               definition_type=self._item_name))
 
   def get_ca_list_from_group(self):

--- a/test/selenium/src/lib/utils/selenium_utils.py
+++ b/test/selenium/src/lib/utils/selenium_utils.py
@@ -34,9 +34,9 @@ def switch_to_new_window(driver):
   try:
     wait_until_condition(driver, EC.new_window_is_opened)
     driver.switch_to.window(driver.window_handles.pop())
-  except exceptions.NoSuchWindowException as exception:
-    LOGGER.exception(exception, messages.ERR_SWITCH_TO_NEW_WINDOW)
-    raise exception
+  except:
+    raise exceptions.NoSuchWindowException(
+        messages.ExceptionsMessages.err_switch_to_new_window)
 
 
 def wait_until_stops_moving(element):

--- a/test/selenium/src/lib/utils/string_utils.py
+++ b/test/selenium/src/lib/utils/string_utils.py
@@ -7,6 +7,8 @@ import string
 import uuid
 from collections import defaultdict
 
+import re
+from datetime import datetime
 
 BLANK = ''
 COMMA = ','  # comma is used as delimiter for multi-choice values
@@ -35,17 +37,56 @@ def random_list_strings(list_len=3, item_size=5,
   return COMMA.join(random_string(item_size, chars) for i in range(list_len))
 
 
-def get_bool_from_string(str_to_bool):
-  """Return True for 'Yes' or 'True' and False for 'No' or 'False'
-  for string and unicode 'str_to_bool', else return source value
-  of 'str_to_bool'.
+def get_bool_value_from_arg(arg):
+  """Get and return boolean value from argument in title case (return
+  True if 'arg': 'Yes', 'True', else return False if 'arg': 'No', 'False') else
+  return 'arg' without changing.
   """
-  return ((True if str_to_bool.title() in ['Yes', "True"] else
-           False if str_to_bool.title() in ['No', "False"] else str_to_bool)
-          if isinstance(str_to_bool, (str, unicode)) else str_to_bool)
+  converted_value = arg
+  if isinstance(arg, (str, unicode)):
+    converted_value = (True if arg.title() in ["Yes", "True"] else
+                       False if arg.title() in ["No", "False"] else arg)
+  return converted_value
 
 
-def remap_keys_for_list_dicts(dict_of_transform_keys, list_dicts):
+def exchange_dicts_items(transform_dict, dicts,
+                         is_keys_not_values=True):
+  """Exchange items (keys as default or optional values if 'is_keys_not_values'
+  is False) for 'dicts' (can be dict or list of dicts) according to
+  'transform_dict'. If 'dicts' is dict then return dictionary, if 'dicts' is
+  list of dicts then return list of dictionaries.
+  Examples:
+  'list_dicts=[{"a": 1, "c": 2}, {"a": 3, "c": 4}, {"a": 5, "c": 6}]'
+  'is_keys_not_values=True'
+  'transform_dict={"a": "a_", "b": "b_"}',
+  return:'list_dicts=[{"a_": 1, "c": 2}, {"a_": 3, "c": 4}, {"a_": 5, "b": 6}]'
+  'is_keys_not_values=False'
+  'transform_dict={"a": "5", "b": "4"}',
+  return:'list_dicts=[{"a": 5, "c": 2}, {"a": 5, "c":4}, {"a": 5, "b": 6}]'
+  """
+
+  def replace_dict_keys(dic):
+    """Replace keys of dictionary."""
+    return {(transform_dict[k] if transform_dict.get(k) else k): v
+            for k, v in dic.iteritems()}
+
+  def replace_dict_values(dic):
+    """Replace values of dictionary."""
+    return {k: (transform_dict.get(k) if k in transform_dict.keys() else v)
+            for k, v in dic.iteritems()}
+
+  if isinstance(dicts, dict):
+    dicts = (
+        replace_dict_keys(dicts) if is_keys_not_values
+        else replace_dict_values(dicts))
+  if isinstance(dicts, list) and all(isinstance(dic, dict) for dic in dicts):
+    dicts = [
+        replace_dict_keys(dic) if is_keys_not_values
+        else replace_dict_values(dic) for dic in dicts]
+  return dicts
+
+
+def remap_values_for_list_dicts(dict_of_transform_keys, list_dicts):
   """Remap keys names for old list of dictionaries according
   transformation dictionary {OLD KEY: NEW KEY} and return new updated
   list of dictionaries.
@@ -96,7 +137,7 @@ def merge_dicts_by_same_key(*dicts):
   return dict([tuple(item) for item in merged_dict.values()])
 
 
-def is_one_dict_is_subset_another_dict(src_dict, dest_dict):
+def is_subset_of_dicts(src_dict, dest_dict):
   """Check is all items of one dictionary 'src_dict' is subset of items of
   another dictionary 'dest_dict', where 'src_dict' should has same or less
   length then 'dest_dict'.
@@ -104,8 +145,7 @@ def is_one_dict_is_subset_another_dict(src_dict, dest_dict):
   ({"b": 2, "a": 1}, {"a": 1, "b": 2, "c": 4}) = True
   ({"a": 1, "b": 2, "c": 4}, {"b": 2, "a": 1}) = False
   """
-  # pylint: disable=invalid-name
-  return not bool(set(src_dict) - set(dest_dict))
+  return all(item in dest_dict.iteritems() for item in src_dict.iteritems())
 
 
 def get_first_word_from_str(line):
@@ -116,3 +156,26 @@ def get_first_word_from_str(line):
 def dict_keys_to_upper_case(dictionary):
   """Convert keys of dictionary to upper case."""
   return {k.upper(): v for k, v in dictionary.iteritems()}
+
+
+def convert_str_to_datetime(datetime_str):
+  """Convert datetime corresponding to 'datetime_str', picking appropriate
+  format and parsing according to it and return datetime objects like:
+  '2017-07-02 16:34:05', '2017-07-02 00:00:00', e.t.c.
+  """
+  delimeter = "T" if bool(re.search(r"\dT\d", datetime_str)) else " "
+  datetime_parts = datetime_str.split(delimeter)
+  # UI like u'07/02/2017' as default
+  datetime_format = "%m/%d/%Y"
+  # UI like datetime
+  if "/" in datetime_str and "-" not in datetime_str:
+    # u'07/02/2017 04:34:05 PM UTC'
+    if len(datetime_parts) == 4 and ":" in datetime_str:
+      datetime_format = "%m/%d/%Y %I:%M:%S %p %Z"
+  # REST and CSV like datetime
+  if "/" not in datetime_str and any(_ in datetime_str for _ in ["-", ":"]):
+    # u'2017-07-02T16:34:05' and u'2017-07-02 16:34:05'
+    if len(datetime_parts) == 2:
+      datetime_format = ("%Y-%m-%dT%H:%M:%S" if "T" in datetime_str
+                         else "%Y-%m-%d %H:%M:%S")
+  return datetime.strptime(datetime_str, datetime_format)

--- a/test/selenium/src/tests/test_admin_dashboard_page.py
+++ b/test/selenium/src/tests/test_admin_dashboard_page.py
@@ -8,8 +8,8 @@
 
 import random
 
-import pytest
 import re
+import pytest
 
 from lib import base, constants
 from lib.constants import objects, messages
@@ -38,8 +38,9 @@ class TestAdminDashboardPage(base.Test):
     expected_dict = self._role_el.ROLE_SCOPES_DICT
     actual_dict = admin_roles_tab.get_role_scopes_text_as_dict()
     assert admin_dashboard.tab_roles.member_count == len(expected_dict)
-    assert expected_dict == actual_dict, messages.ERR_MSG_FORMAT.format(
-        expected_dict, actual_dict)
+    assert expected_dict == actual_dict, (
+        messages.AssertionMessages.
+        format_err_msg_equal(expected_dict, expected_dict))
 
   @pytest.mark.smoke_tests
   def test_events_widget_tree_view_has_data(self, admin_dashboard):
@@ -52,7 +53,9 @@ class TestAdminDashboardPage(base.Test):
         re.compile(self._event_el.TREE_VIEW_ROW_REGEXP).
         match(getattr(item, 'text'))]
     assert items_with_incorrect_format == []
-    assert admin_events_tab.widget_header.text == self._event_el.WIDGET_HEADER
+    expected_header_text = self._event_el.WIDGET_HEADER
+    actual_header_text = admin_events_tab.widget_header.text
+    assert expected_header_text == actual_header_text
 
   @pytest.mark.smoke_tests
   def test_check_ca_groups(self, admin_dashboard):
@@ -64,9 +67,7 @@ class TestAdminDashboardPage(base.Test):
         [objects.get_normal_form(item) for item in objects.ALL_CA_OBJS])
     actual_ca_groups_set = set(
         [item.text for item in ca_tab.get_items_list()])
-    assert expected_ca_groups_set == actual_ca_groups_set, (
-        messages.ERR_MSG_FORMAT.format(
-            expected_ca_groups_set, actual_ca_groups_set))
+    assert expected_ca_groups_set == actual_ca_groups_set
 
   @pytest.mark.smoke_tests
   @pytest.mark.parametrize(
@@ -82,4 +83,6 @@ class TestAdminDashboardPage(base.Test):
     ca_tab = admin_dashboard.select_custom_attributes()
     ca_tab.add_custom_attribute(ca_obj=expected_ca)
     list_actual_ca = ca_tab.get_custom_attributes_list(ca_group=expected_ca)
-    assert expected_ca in list_actual_ca
+    assert expected_ca in list_actual_ca, (
+        messages.AssertionMessages.
+        format_err_msg_contains(expected_ca, list_actual_ca))

--- a/test/selenium/src/tests/test_audit_page.py
+++ b/test/selenium/src/tests/test_audit_page.py
@@ -12,6 +12,7 @@ from lib import base
 from lib.constants import messages
 from lib.entities import entities_factory
 from lib.service import webui_service
+from lib.utils import string_utils
 
 
 class TestAuditPage(base.Test):
@@ -72,8 +73,8 @@ class TestAuditPage(base.Test):
     actual_asmt_tmpls = [actual_asmt_tmpl.update_attrs(updated_at=None)
                          for actual_asmt_tmpl in actual_asmt_tmpls]
     assert [expected_asmt_tmpl] == actual_asmt_tmpls, (
-        messages.ERR_MSG_FORMAT.format(
-            [expected_asmt_tmpl], actual_asmt_tmpls))
+        messages.AssertionMessages.
+        format_err_msg_equal([expected_asmt_tmpl], actual_asmt_tmpls))
 
   @pytest.mark.smoke_tests
   def test_asmt_creation(self, new_program_rest, new_audit_rest, selenium):
@@ -95,7 +96,8 @@ class TestAuditPage(base.Test):
     actual_asmts = [actual_asmt.update_attrs(updated_at=None)
                     for actual_asmt in actual_asmts]
     assert [expected_asmt] == actual_asmts, (
-        messages.ERR_MSG_FORMAT.format([expected_asmt], actual_asmts))
+        messages.AssertionMessages.
+        format_err_msg_equal([expected_asmt], actual_asmts))
 
   @pytest.mark.smoke_tests
   @pytest.mark.parametrize(
@@ -140,7 +142,8 @@ class TestAuditPage(base.Test):
         update_attrs(is_replace_attrs=False, custom_attributes={None: None})
         for actual_asmt in actual_asmts]
     assert expected_asmts == actual_asmts, (
-        messages.ERR_MSG_FORMAT.format(expected_asmts, actual_asmts))
+        messages.AssertionMessages.
+        format_err_msg_equal(expected_asmts, actual_asmts))
 
   @pytest.mark.smoke_tests
   @pytest.mark.cloning
@@ -154,7 +157,8 @@ class TestAuditPage(base.Test):
     actual_audit = (
         create_and_clone_audit["actual_audit"].update_attrs(slug=None))
     assert expected_audit == actual_audit, (
-        messages.ERR_MSG_FORMAT.format(expected_audit, actual_audit))
+        messages.AssertionMessages.
+        format_err_msg_equal(expected_audit, actual_audit))
 
   @pytest.mark.smoke_tests
   @pytest.mark.cloning
@@ -199,8 +203,8 @@ class TestAuditPage(base.Test):
         actual_asmt_tmpl.update_attrs(slug=None, updated_at=None)
         for actual_asmt_tmpl in actual_asmt_tmpls]
     assert [expected_asmt_tmpl] == actual_asmt_tmpls, (
-        messages.ERR_MSG_FORMAT.format(
-            [expected_asmt_tmpl], actual_asmt_tmpls))
+        messages.AssertionMessages.
+        format_err_msg_equal([expected_asmt_tmpl], actual_asmt_tmpls))
 
   @pytest.mark.smoke_tests
   @pytest.mark.cloning
@@ -225,7 +229,12 @@ class TestAuditPage(base.Test):
                        get_list_objs_from_tree_view(src_obj=actual_audit))
     actual_programs = (webui_service.ProgramsService(selenium).
                        get_list_objs_from_tree_view(src_obj=actual_audit))
-    expected_objs = [[expected_control], [expected_program]]
-    actual_objs = [actual_controls, actual_programs]
+    expected_objs = (
+        string_utils.convert_list_elements_to_list(
+            [[expected_control], [expected_program]]))
+    actual_objs = (
+        string_utils.convert_list_elements_to_list(
+            [actual_controls, actual_programs]))
     assert expected_objs == actual_objs, (
-        messages.ERR_MSG_FORMAT.format(expected_objs, actual_objs))
+        messages.AssertionMessages.
+        format_err_msg_equal(expected_objs, actual_objs))

--- a/test/selenium/src/tests/test_my_work_page.py
+++ b/test/selenium/src/tests/test_my_work_page.py
@@ -33,14 +33,18 @@ class TestMyWorkPage(base.Test):
       controls_tab.wait_member_deleted(counter)
     controls_generic_widget = generic_widget.Controls(
         selenium, objects.CONTROLS)
-    assert controls_generic_widget.members_listed == []
+    expected_widget_members = []
+    actual_widget_members = controls_generic_widget.members_listed
+    assert expected_widget_members == actual_widget_members
 
   @pytest.mark.smoke_tests
   def test_redirect(self, header_dashboard, selenium):
     """Tests if user is redirected to My Work page after clicking on
     the my work button in user dropdown."""
     header_dashboard.select_my_work()
-    assert selenium.current_url == dashboard.Dashboard.URL
+    expected_url = dashboard.Dashboard.URL
+    actual_url = selenium.current_url
+    assert expected_url == actual_url
 
   @pytest.mark.smoke_tests
   def test_lhn_stays_expanded(self, header_dashboard, selenium):
@@ -50,7 +54,9 @@ class TestMyWorkPage(base.Test):
     selenium_utils.wait_until_stops_moving(lhn_menu.my_objects.element)
     selenium_utils.hover_over_element(
         selenium, dashboard.Header(selenium).button_my_tasks.element)
-    assert initial_position == lhn.Menu(selenium).my_objects.element.location
+    expected_el_position = initial_position
+    actual_el_position = lhn.Menu(selenium).my_objects.element.location
+    assert expected_el_position == actual_el_position
 
   @pytest.mark.smoke_tests
   def test_lhn_remembers_tab_state(self, header_dashboard, selenium):

--- a/test/selenium/src/tests/test_people_groups_page.py
+++ b/test/selenium/src/tests/test_people_groups_page.py
@@ -4,7 +4,7 @@
 # pylint: disable=no-self-use
 # pylint: disable=invalid-name
 
-import pytest    # pylint: disable=import-error
+import pytest  # pylint: disable=import-error
 
 from lib import base
 from lib.constants import url
@@ -23,5 +23,7 @@ class TestOrgGroupPage(base.Test):
     object id.
     """
     # pylint: disable=unused-argument
-    assert (url.ORG_GROUPS + "/" + new_org_group_ui.source_obj_id_from_url in
-            new_org_group_ui.url)
+    expected_url = (
+        url.ORG_GROUPS + "/" + new_org_group_ui.source_obj_id_from_url)
+    actual_url = new_org_group_ui.url
+    assert expected_url in actual_url

--- a/test/selenium/src/tests/test_program_page.py
+++ b/test/selenium/src/tests/test_program_page.py
@@ -35,8 +35,10 @@ class TestProgramPage(base.Test):
     object id.
     """
     _, program_info_page = new_program_ui
-    assert (url.PROGRAMS + "/" + program_info_page.source_obj_id_from_url in
-            program_info_page.url)
+    expected_url = (
+        url.PROGRAMS + "/" + program_info_page.source_obj_id_from_url)
+    actual_url = program_info_page.url
+    assert expected_url in actual_url
 
   @pytest.mark.smoke_tests
   def test_info_tab_is_active_by_default(self, new_program_ui,
@@ -49,27 +51,30 @@ class TestProgramPage(base.Test):
     """
     _, program_info_page = new_program_ui
     program_info_page.navigate_to()
-    assert (my_work_dashboard.get_active_widget_name() ==
-            element.ProgramInfoWidget().WIDGET_HEADER)
+    expected_widget_name = element.ProgramInfoWidget().WIDGET_HEADER
+    actual_widget_name = my_work_dashboard.get_active_widget_name()
+    assert expected_widget_name == actual_widget_name
 
   @pytest.mark.smoke_tests
   def test_info_tab_contains_entered_data(self, new_program_ui):
     """Verify that created object contains data we've entered
     into modal."""
     modal, program_info_page = new_program_ui
-    assert (test_utils.HtmlParser.parse_text(modal.ui_title.text) ==
-            program_info_page.title_entered().text)
-    assert (modal.ui_description.text ==
-            program_info_page.description_entered.text)
-    assert modal.ui_notes.text == program_info_page.notes_entered.text
-    assert modal.ui_code.text == program_info_page.code_entered.text
-    assert (modal.ui_program_url.text ==
-            program_info_page.program_url_entered.text)
-    assert (modal.ui_reference_url.text ==
-            program_info_page.reference_url_entered.text)
-    assert (modal.ui_effective_date.text ==
-            program_info_page.effective_date_entered.text)
-    assert modal.ui_stop_date.text == program_info_page.stop_date_entered.text
+    expected_list_texts = [
+        test_utils.HtmlParser.parse_text(modal.ui_title.text),
+        modal.ui_description.text, modal.ui_notes.text, modal.ui_code.text,
+        modal.ui_program_url.text, modal.ui_reference_url.text,
+        modal.ui_effective_date.text, modal.ui_stop_date.text]
+    actual_list_texts = [
+        program_info_page.title_entered().text,
+        program_info_page.description_entered.text,
+        program_info_page.notes_entered.text,
+        program_info_page.code_entered.text,
+        program_info_page.program_url_entered.text,
+        program_info_page.reference_url_entered.text,
+        program_info_page.effective_date_entered.text,
+        program_info_page.stop_date_entered.text]
+    assert expected_list_texts == actual_list_texts
 
   @pytest.mark.smoke_tests
   def test_permalink(self, selenium, new_program_ui):
@@ -85,7 +90,9 @@ class TestProgramPage(base.Test):
     # test generated link
     modal = program_info_page.open_info_3bbs().select_edit()
     modal.ui_title.paste_from_clipboard(modal.ui_description)
-    assert modal.ui_title.text == program_info_page.url
+    expected_url = program_info_page.url
+    actual_url = modal.ui_title.text
+    assert expected_url in actual_url
 
   @pytest.mark.smoke_tests
   def test_edit_modal(self, selenium, new_program_ui):
@@ -100,12 +107,14 @@ class TestProgramPage(base.Test):
     modal.save_and_close()
     selenium_utils.open_url(selenium, program_info_page.url)
     updated_program_info_page = info_widget.Programs(selenium)
-    assert (test_utils.HtmlParser.parse_text(modal.ui_title.text) ==
-            updated_program_info_page.title_entered().text)
-    assert (modal.ui_description.text ==
-            updated_program_info_page.description_entered.text)
-    assert modal.ui_notes.text == updated_program_info_page.notes_entered.text
-    assert (modal.ui_program_url.text ==
-            updated_program_info_page.program_url_entered.text)
-    assert (modal.ui_reference_url.text ==
-            updated_program_info_page.reference_url_entered.text)
+    expected_list_texts = [
+        test_utils.HtmlParser.parse_text(modal.ui_title.text),
+        modal.ui_description.text, modal.ui_notes.text,
+        modal.ui_program_url.text, modal.ui_reference_url.text]
+    actual_list_texts = [
+        updated_program_info_page.title_entered().text,
+        updated_program_info_page.description_entered.text,
+        updated_program_info_page.notes_entered.text,
+        updated_program_info_page.program_url_entered.text,
+        updated_program_info_page.reference_url_entered.text]
+    assert expected_list_texts == actual_list_texts

--- a/test/selenium/src/tests/test_risk_threats_page.py
+++ b/test/selenium/src/tests/test_risk_threats_page.py
@@ -5,7 +5,7 @@
 # pylint: disable=invalid-name
 # pylint: disable=too-few-public-methods
 
-import pytest    # pylint: disable=import-error
+import pytest  # pylint: disable=import-error
 
 from lib import base
 from lib.constants import url
@@ -23,5 +23,7 @@ class TestRiskThreatPage(base.Test):
     object id.
     """
     # pylint: disable=unused-argument
-    assert (url.RISKS + "/" + new_risk_ui.source_obj_id_from_url in
-            new_risk_ui.url)
+    expected_url = (
+        url.RISKS + "/" + new_risk_ui.source_obj_id_from_url)
+    actual_url = new_risk_ui.url
+    assert expected_url in actual_url

--- a/test/selenium/src/tests/test_unified_mapper.py
+++ b/test/selenium/src/tests/test_unified_mapper.py
@@ -38,4 +38,5 @@ class TestProgramPage(base.Test):
     actual_controls = (webui_service.ControlsService(selenium).
                        get_list_objs_from_tree_view(src_obj=new_program_rest))
     assert sorted(expected_controls) == sorted(actual_controls), (
-        messages.ERR_MSG_FORMAT.format(expected_controls, actual_controls))
+        messages.AssertionMessages.
+        format_err_msg_equal(expected_controls, actual_controls))


### PR DESCRIPTION
**This PR contains new design of TAF in a part:**
- extend assertion for "equal" and "contains" operations with human readable diff info:
  **equl:**
 obj1 = obj2,
 [objs1] = [objs2]
 **contains:**
obj in [objs]
- add conversion of strings to datetime format;
- fully improve entity in a part unify repr, equal, less code and e.t.c.;
- improve entities factory as a part improving data parsing;
- actualize of REST interaction procedures of TAF with app
- other...

**EQUAL ASSERTIONS:**
**Before:**
![image](https://user-images.githubusercontent.com/16610768/27809551-2a84ae5a-6040-11e7-8ae3-0454aa8dd641.png)


**After:**
![image](https://user-images.githubusercontent.com/16610768/27809561-3fb27000-6040-11e7-8dbc-d431e675ef29.png)

