### PR TITLE
GGRC-2673 Disable Advanced Search for Workflow Related (Cycles, Workflows, Tasks, Tasks Group), Assessment Template,  People  Tree Views

### DIFF
--- a/src/ggrc/assets/javascripts/components/tree/tree-filter-input.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-filter-input.js
@@ -32,6 +32,7 @@
       }
     },
     disabled: false,
+    showAdvanced: false,
     options: {},
     filters: null,
     init: function () {

--- a/src/ggrc/assets/mustache/components/tree/tree-filter-input.mustache
+++ b/src/ggrc/assets/mustache/components/tree/tree-filter-input.mustache
@@ -12,15 +12,17 @@
   <span class="tree-filter_is-expression {{#if isExpression}}valid{{/if}}">
     <i class="fa fa-check-circle{{#unless isExpression}}-o{{/unless}}"></i>
   </span>
-  {{^if disabled}}
-  <a href="javascript://" class="advanced-filter" ($click)="openAdvancedFilter()">
-    <i class="fa fa-filter"></i>
-  </a>
-  {{else}}
-  <div class="advanced-filter-controls">
-    <a href="javascript://" ($click)="openAdvancedFilter()">Filtered</a>
-    <a href="javascript://" ($click)="removeAdvancedFilters()"><i class="fa fa-remove"></i></a>
-  </div>
+  {{#if showAdvanced}}
+    {{^if disabled}}
+    <a href="javascript://" class="advanced-filter" ($click)="openAdvancedFilter()">
+      <i class="fa fa-filter"></i>
+    </a>
+    {{else}}
+    <div class="advanced-filter-controls">
+      <a href="javascript://" ($click)="openAdvancedFilter()">Filtered</a>
+      <a href="javascript://" ($click)="removeAdvancedFilters()"><i class="fa fa-remove"></i></a>
+    </div>
+    {{/if}}
   {{/if}}
 </div>
 <div class="flex-box tree-filter__actions">

--- a/src/ggrc/assets/mustache/components/tree/tree-widget-container.mustache
+++ b/src/ggrc/assets/mustache/components/tree/tree-widget-container.mustache
@@ -11,6 +11,7 @@
                          (filter)="onFilter"
                          (openAdvanced)="openAdvancedFilter"
                          (removeAdvanced)="removeAdvancedFilters"
+                         {show-advanced}="statusFilterVisible"
                          {disabled}="advancedSearch.filter"
       ></tree-filter-input>
       {{#if statusFilterVisible}}


### PR DESCRIPTION
Hide Advanced search for the following objects:
1. Person; 
2. CycleTaskGroupObjectTask;
3. AssessmentTemplate;
4. Workflow;
5. TaskGroup;
6. Cycle.