### PR TITLE
GGRC-1466 Fix filtering and sorting by "Categories", "Assertions" fields

### DIFF
--- a/src/ggrc/converters/snapshot_block.py
+++ b/src/ggrc/converters/snapshot_block.py
@@ -220,6 +220,8 @@ class SnapshotBlockConverter(object):
     """Get string representation of a given value."""
     if isinstance(value, dict) and "type" in value and "id" in value:
       return self._stub_cache.get(value["type"], {}).get(value["id"], u"")
+    elif isinstance(value, dict) and "display_name" in value:
+      return value["display_name"]
     elif isinstance(value, list):
       return u"\n".join(self.get_value_string(val) for val in value)
     elif isinstance(value, bool):

--- a/src/ggrc/fulltext/attributes.py
+++ b/src/ggrc/fulltext/attributes.py
@@ -76,7 +76,7 @@ class FullTextAttr(object):
           sorted_dict[value.id] = unicode(result)
       else:
         results[subprop] = value
-    if self.is_sortable:
+    if self.is_sortable and results:
       results['__sort__'] = u':'.join(sorted(sorted_dict.values()))
     return {self.get_attribute_name(instance): results}
 
@@ -213,7 +213,7 @@ class MultipleSubpropertyFullTextAttr(FullTextAttr):
         else:
           sub_key = self.SUB_KEY_TMPL.format(id_val='EMPTY', sub=sub)
           results[sub_key] = None
-    if self.is_sortable:
+    if self.is_sortable and results:
       results['__sort__'] = u':'.join(sorted(sorted_dict.values()))
     return {self.get_attribute_name(instance): results}
 

--- a/src/ggrc/models/categorization.py
+++ b/src/ggrc/models/categorization.py
@@ -32,6 +32,11 @@ class Categorization(Base, db.Model):
         else None
     return setattr(self, self.category_attr, value)
 
+  @property
+  def category_name(self):
+    from ggrc.models.category import CategoryBase
+    return CategoryBase.query.get(self.category_id).name
+
   _publish_attrs = [
       # 'categorizable',
       'category',
@@ -44,6 +49,11 @@ class Categorization(Base, db.Model):
     query = super(Categorization, cls).eager_query()
     return query.options(
         orm.subqueryload('category'))
+
+  def log_json(self):
+    out_json = super(Categorization, self).log_json()
+    out_json["display_name"] = self.category_name
+    return out_json
 
 
 class Categorizable(object):
@@ -61,6 +71,7 @@ class Categorizable(object):
         )
   """
 
+  # pylint: disable=unused-argument
   @classmethod
   def declare_categorizable(cls, category_type, single, plural, ation):
     setattr(
@@ -93,12 +104,3 @@ class Categorizable(object):
         backref=backref,
         cascade='all, delete-orphan',
     )
-
-  @classmethod
-  def _filter_by_category(cls, category_type, predicate):
-    from ggrc.models.category import CategoryBase
-    return Categorization.query.join(CategoryBase).filter(
-        (Categorization.categorizable_type == cls.__name__) &
-        (Categorization.categorizable_id == cls.id) &
-        predicate(CategoryBase.name)
-    ).exists()

--- a/src/ggrc/models/category.py
+++ b/src/ggrc/models/category.py
@@ -24,6 +24,7 @@ class CategorizedPublishable(object):
 
 
 class CategoryBase(Hierarchical, Base, db.Model):
+  """Base class for Categories"""
   _table_plural = 'category_bases'
   __tablename__ = 'categories'
 
@@ -45,6 +46,10 @@ class CategoryBase(Hierarchical, Base, db.Model):
       cascade='all, delete-orphan',
   )
 
+  def __str__(self):
+    return self.name
+
+  # pylint: disable=unused-argument
   @validates('type')
   def validates_type(self, key, value):
     return self.__class__.__name__

--- a/src/ggrc/snapshotter/indexer.py
+++ b/src/ggrc/snapshotter/indexer.py
@@ -215,6 +215,28 @@ def get_access_control_sort_subprop(rec, access_control_list):
       yield newrec
 
 
+def get_category_sort_subprop(rec, category_list):
+  """Get a categories_list subproperty for sorting
+  """
+  newrec = rec.copy()
+  newrec.update({
+      "content": ":".join(sorted([c.get("display_name", None)
+                                  for c in category_list])),
+      "subproperty": "__sort__",
+  })
+  yield newrec
+
+
+def get_category_data(rec, category_item):
+  """Get category's name for fulltext indexing
+  """
+  newrec = rec.copy()
+  newrec.update({
+      "content": category_item.get("display_name"),
+      "subproperty": "{}-category".format(category_item.get("id"))})
+  yield newrec
+
+
 def get_properties(snapshot):
   """Return properties for sent revision dict and pair object."""
   properties = snapshot["revision"].copy()
@@ -249,6 +271,9 @@ def get_record_value(prop, val, rec):
     elif prop == "access_control_list":
       sort_getter = get_access_control_sort_subprop
       item_getter = get_access_control_role_data
+    elif prop in ("assertions", "categories"):
+      sort_getter = get_category_sort_subprop
+      item_getter = get_category_data
     else:
       return []
     results = [item_getter(rec, i) for i in val]

--- a/test/integration/ggrc/converters/test_export_snapshots.py
+++ b/test/integration/ggrc/converters/test_export_snapshots.py
@@ -112,11 +112,9 @@ class TestExportSnapshots(TestCase):
             "person": self._get_cav(control, "person"),
             # Special snapshot export fields
             "Audit": audit.slug,
-            "Evidence": u"\n".join(c.slug for c in control.document_evidence),
-
-            # Fields that are not included in snapshots - Known bugs.
-            "Assertions": u"",  # "\n".join(c.name for c in control.assertions)
-            "Categories": u"",  # "\n".join(c.name for c in control.categories)
+            "Evidence": "\n".join(c.slug for c in control.document_evidence),
+            "Assertions": "\n".join(c.name for c in control.assertions),
+            "Categories": "\n".join(c.name for c in control.categories),
         }
         for snapshot, control in zip(snapshots, controls)
     }

--- a/test/integration/ggrc/converters/test_export_snapshots.py
+++ b/test/integration/ggrc/converters/test_export_snapshots.py
@@ -112,9 +112,9 @@ class TestExportSnapshots(TestCase):
             "person": self._get_cav(control, "person"),
             # Special snapshot export fields
             "Audit": audit.slug,
-            "Evidence": "\n".join(c.slug for c in control.document_evidence),
-            "Assertions": "\n".join(c.name for c in control.assertions),
-            "Categories": "\n".join(c.name for c in control.categories),
+            "Evidence": u"\n".join(c.slug for c in control.document_evidence),
+            "Assertions": u"\n".join(c.name for c in control.assertions),
+            "Categories": u"\n".join(c.name for c in control.categories),
         }
         for snapshot, control in zip(snapshots, controls)
     }

--- a/test/integration/ggrc/services/test_query/test_basic.py
+++ b/test/integration/ggrc/services/test_query/test_basic.py
@@ -679,6 +679,73 @@ class TestAdvancedQueryAPI(BaseQueryAPITestCase):
                                 key=lambda ctrl: ctrl["fraud_related"])
     self.assertListEqual(controls_ordered_1, controls_ordered_2)
 
+  def test_filter_control_by_assertions(self):
+    """Test correct filtering by assertions field"""
+    controls = self._get_first_result_set(
+        self._make_query_dict("Control",
+                              expression=["assertions", "=", "privacy"]),
+        "Control",
+    )
+    self.assertEqual(controls["count"], 3)
+
+  def test_order_control_by_assertions(self):
+    """Test correct ordering and by assertions"""
+    controls_unordered = self._get_first_result_set(
+        self._make_query_dict("Control",),
+        "Control", "values"
+    )
+
+    controls_ordered_1 = self._get_first_result_set(
+        self._make_query_dict("Control",
+                              order_by=[{"name": "assertions"},
+                                        {"name": "id"}]),
+        "Control", "values"
+    )
+    categories = {c.id: c.name for c in models.CategoryBase.query}
+
+    def sort_key(val):
+      ctrl_assertions = val.get("assertions")
+      if isinstance(ctrl_assertions, list) and ctrl_assertions:
+        return (categories.get(ctrl_assertions[0]["id"]), val["id"])
+      return (None, val["id"])
+
+    controls_ordered_2 = sorted(controls_unordered, key=sort_key)
+    self.assertListEqual(controls_ordered_1, controls_ordered_2)
+
+  def test_filter_control_by_categories(self):
+    """Test correct filtering by categories field"""
+    controls = self._get_first_result_set(
+        self._make_query_dict(
+            "Control",
+            expression=["categories", "=", "Physical Security"]),
+        "Control",
+    )
+    self.assertEqual(controls["count"], 3)
+
+  def test_order_control_by_categories(self):
+    """Test correct ordering and by categories"""
+    controls_unordered = self._get_first_result_set(
+        self._make_query_dict("Control",),
+        "Control", "values"
+    )
+
+    controls_ordered_1 = self._get_first_result_set(
+        self._make_query_dict("Control",
+                              order_by=[{"name": "categories"},
+                                        {"name": "id"}]),
+        "Control", "values"
+    )
+    categories = {c.id: c.name for c in models.CategoryBase.query}
+
+    def sort_key(val):
+      ctrl_categories = val.get("categories")
+      if isinstance(ctrl_categories, list) and ctrl_categories:
+        return (categories.get(ctrl_categories[0]["id"]), val["id"])
+      return (None, val["id"])
+
+    controls_ordered_2 = sorted(controls_unordered, key=sort_key)
+    self.assertListEqual(controls_ordered_1, controls_ordered_2)
+
   def test_query_count(self):
     """The value of "count" is same for "values" and "count" queries."""
     programs_values = self._get_first_result_set(

--- a/test/integration/ggrc/test_csvs/data_for_export_testing.csv
+++ b/test/integration/ggrc/test_csvs/data_for_export_testing.csv
@@ -614,49 +614,49 @@ Workflow,code*,title*,description,manager,frequency,force real-time email update
 ,,,,,,,,,,,,,,,,,,,,,,,,
 Object Type,,,,,,,,,,,,,,,,,,,,,,,,
 control,Title,Description,Test Plan,Notes,Admin,,,Control URL,Reference URL,Code,Kind/Nature,Fraud Related,Significance,Type/Means,Effective Date,Last Deprecated Date,Frequency,Assertions,Categories,,,State,map:standard,map:clause
-,Startupsum 115,Series A financing success channels.<br> Ecosystem conversion rockstar value proposition bandwidth,success 111,,smotko@example.com,,,,http://i.imgur.com/aP8UU5I.jpg,control-1,Preventative,yes,,Technical,,,Monthly,,,,,Draft,"standard-1
+,Startupsum 115,Series A financing success channels.<br> Ecosystem conversion rockstar value proposition bandwidth,success 111,,smotko@example.com,,,,http://i.imgur.com/aP8UU5I.jpg,control-1,Preventative,yes,,Technical,,,Monthly,Confidentiality,,,,Draft,"standard-1
 standard-5","clause-1
 clause-2"
-,Startupsum 116,facebook validation responsive web design business plan.<br> Startup pivot founders.<br> Infrastructure f,success 112,,smotko@example.com,,,,http://i.imgur.com/aP8UU5I.jpg,control-2,Preventative,no,,automated,,,Monthly,,,,,Draft,"standard-1
+,Startupsum 116,facebook validation responsive web design business plan.<br> Startup pivot founders.<br> Infrastructure f,success 112,,smotko@example.com,,,,http://i.imgur.com/aP8UU5I.jpg,control-2,Preventative,no,,automated,,,Monthly,Privacy,Training,,,Draft,"standard-1
 standard-5","clause-1
 clause-2"
-,Startupsum 117,unding stock iteration founders freemium hackathon alpha research & development seed money branding.<br> In,success 113,,smotko@example.com,,,,http://i.imgur.com/aP8UU5I.jpg,control-3,Preventative,yes,,Technical,,,,,,,,Draft,"standard-1
+,Startupsum 117,unding stock iteration founders freemium hackathon alpha research & development seed money branding.<br> In,success 113,,smotko@example.com,,,,http://i.imgur.com/aP8UU5I.jpg,control-3,Preventative,yes,,Technical,,,,Confidentiality,,,,Draft,"standard-1
 standard-5","clause-1
 clause-2"
-,Startupsum 118,fluencer scrum project startup android.<br> Partner network interaction design network effects creative conversion business plan equity influencer innovator return on investment validation buzz A/B testing research & development.<br> Non-disclosure agreement business-to-consumer gen-z.<br> Graphical user interface sales conversion pivot market scrum project android angel investor product management ramen entrepreneur rockstar.<br> Churn rate vesting period infographic social proof stealth prototype android traction freemium www.<br>discoverartisans.<br>com.<br> Gamification leverage responsive web design seed money social proof.<br>,success 114,,Urbon.S@example.com,,,,http://i.imgur.com/aP8UU5I.jpg,control-4,,no,,automated,,,,,,,,Draft,"standard-1
+,Startupsum 118,fluencer scrum project startup android.<br> Partner network interaction design network effects creative conversion business plan equity influencer innovator return on investment validation buzz A/B testing research & development.<br> Non-disclosure agreement business-to-consumer gen-z.<br> Graphical user interface sales conversion pivot market scrum project android angel investor product management ramen entrepreneur rockstar.<br> Churn rate vesting period infographic social proof stealth prototype android traction freemium www.<br>discoverartisans.<br>com.<br> Gamification leverage responsive web design seed money social proof.<br>,success 114,,Urbon.S@example.com,,,,http://i.imgur.com/aP8UU5I.jpg,control-4,,no,,automated,,,,Availability,,,,Draft,"standard-1
 standard-5","clause-1
 clause-2"
-,Startupsum 119,,success 115,,Urbon.S@example.com,,,,http://i.imgur.com/aP8UU5I.jpg,control-5,,,key,manual,,,,,,,,Draft,"standard-1
+,Startupsum 119,,success 115,,Urbon.S@example.com,,,,http://i.imgur.com/aP8UU5I.jpg,control-5,,,key,manual,,,,Privacy,,,,Draft,"standard-1
 standard-5","clause-1
 clause-2"
-,Startupsum 120,Business plan startup A/B testing direct mailing angel investor infrastructure gamification business model canvas,success 116,,Urbon.S@example.com,,,,http://i.imgur.com/aP8UU5I.jpg,control-6,,,Non-key,Physical,,,,,,,,Draft,"standard-1
+,Startupsum 120,Business plan startup A/B testing direct mailing angel investor infrastructure gamification business model canvas,success 116,,Urbon.S@example.com,,,,http://i.imgur.com/aP8UU5I.jpg,control-6,,,Non-key,Physical,,,,Availability,,,,Draft,"standard-1
 standard-5","clause-1
 clause-2"
-,Startupsum 121,graphical user interface.<br> Accelerator user experience metrics MVP.<br> Business model canvas termsheet respo,success 117,,Urbon.S@example.com,,,,http://i.imgur.com/aP8UU5I.jpg,control-7,,,key,manual,,,,,,,,Draft,"standard-1
+,Startupsum 121,graphical user interface.<br> Accelerator user experience metrics MVP.<br> Business model canvas termsheet respo,success 117,,Urbon.S@example.com,,,,http://i.imgur.com/aP8UU5I.jpg,control-7,,,key,manual,,,,Privacy,Physical Security,,,Draft,"standard-1
 standard-5","clause-1
 clause-2"
-,Startupsum 122,nsive web design launch party long tail innovator burn rate stealth seed money disruptive startup metrics business plan funding.<br> Early adopters bandwidth monetization equity.<br> Infrastructure ownership iPhone early adopters lean startup buyer iPad founders equity accelerator.<br> Graphical user interface angel investor niche market partnership strategy business-to-business di,success 118,,zidar@example.com,,,,http://i.imgur.com/aP8UU5I.jpg,control-8,,,Non-key,automated,,,,,,,,Draft,"standard-1
+,Startupsum 122,nsive web design launch party long tail innovator burn rate stealth seed money disruptive startup metrics business plan funding.<br> Early adopters bandwidth monetization equity.<br> Infrastructure ownership iPhone early adopters lean startup buyer iPad founders equity accelerator.<br> Graphical user interface angel investor niche market partnership strategy business-to-business di,success 118,,zidar@example.com,,,,http://i.imgur.com/aP8UU5I.jpg,control-8,,,Non-key,automated,,,,,Authentication,,,Draft,"standard-1
 standard-5","clause-1
 clause-2"
-,Startupsum 123,rect mailing founders burn rate crowdsource.<br> Alpha startup client channels hackathon value proposition.<br> Vira,success 119,,Urbon.S@example.com,,,,http://i.imgur.com/aP8UU5I.jpg,control-9,,,key,Technical,,,,,,,,Draft,"standard-1
+,Startupsum 123,rect mailing founders burn rate crowdsource.<br> Alpha startup client channels hackathon value proposition.<br> Vira,success 119,,Urbon.S@example.com,,,,http://i.imgur.com/aP8UU5I.jpg,control-9,,,key,Technical,,,,,Authentication,,,Draft,"standard-1
 standard-5","clause-1
 clause-2"
-,Startupsum 124,lity pivot seed round social media creative burn rate vesting period hackathon metrics branding.<br> Conversion analytics launch party growth hacking android virality.<br> Partnership mass market twitter return on investment seed money lean startup investor iPad.<br>,success 120,,Urbon.S@example.com,,,,http://i.imgur.com/aP8UU5I.jpg,control-10,,,,Physical,,,,,,,,Draft,"standard-1
+,Startupsum 124,lity pivot seed round social media creative burn rate vesting period hackathon metrics branding.<br> Conversion analytics launch party growth hacking android virality.<br> Partnership mass market twitter return on investment seed money lean startup investor iPad.<br>,success 120,,Urbon.S@example.com,,,,http://i.imgur.com/aP8UU5I.jpg,control-10,,,,Physical,,,,,Authentication,,,Draft,"standard-1
 standard-5","clause-1
 clause-2"
-,Startupsum 125,,success 121,,Urbon.S@example.com,,,,http://i.imgur.com/aP8UU5I.jpg,control-11,Corrective,,,manual,,,,,,,,Draft,"standard-1
+,Startupsum 125,,success 121,,Urbon.S@example.com,,,,http://i.imgur.com/aP8UU5I.jpg,control-11,Corrective,,,manual,,,,,Access Management,,,Draft,"standard-1
 standard-5","clause-1
 clause-2"
-,Startupsum 126,Market deployment network effects.<br> Bootstrapping virality android backing seed round prototype rockstar pitch trac,success 122,,Urbon.S@example.com,,,,http://i.imgur.com/aP8UU5I.jpg,control-12,,,,automated,,,,,,,,Draft,"standard-1
+,Startupsum 126,Market deployment network effects.<br> Bootstrapping virality android backing seed round prototype rockstar pitch trac,success 122,,Urbon.S@example.com,,,,http://i.imgur.com/aP8UU5I.jpg,control-12,,,,automated,,,,,Access Management,,,Draft,"standard-1
 standard-5","clause-1
 clause-2"
-,Startupsum 127,tion.<br> Bootstrapping user experience scrum project analytics business plan supply chain first mover advantage channels paradigm shift gen-z backing.<br> Churn rate seed round ecosystem social media buyer bandwidth.<br> Business-to-consumer strategy marketing early adopters growth hacking churn rate non-disclosure agreement holy grail launch party network effects creative iPad analytics.<br>,success 123,,Urbon.S@example.com,,,,http://i.imgur.com/aP8UU5I.jpg,control-13,,,,Technical,,,,,,,,Draft,"standard-1
+,Startupsum 127,tion.<br> Bootstrapping user experience scrum project analytics business plan supply chain first mover advantage channels paradigm shift gen-z backing.<br> Churn rate seed round ecosystem social media buyer bandwidth.<br> Business-to-consumer strategy marketing early adopters growth hacking churn rate non-disclosure agreement holy grail launch party network effects creative iPad analytics.<br>,success 123,,Urbon.S@example.com,,,,http://i.imgur.com/aP8UU5I.jpg,control-13,,,,Technical,,,,,Access Management,,,Draft,"standard-1
 standard-5","clause-1
 clause-2"
-,Startupsum 128,Growth hacking learning curve entrepreneur.<br> Android series A financing buzz network effects burn rate ownership.<br>,success 124,,zidar@example.com,,,,http://i.imgur.com/aP8UU5I.jpg,control-14,,,,automated,,,,,,,,Draft,"standard-1
+,Startupsum 128,Growth hacking learning curve entrepreneur.<br> Android series A financing buzz network effects burn rate ownership.<br>,success 124,,zidar@example.com,,,,http://i.imgur.com/aP8UU5I.jpg,control-14,,,,automated,,,,,Physical Security,,,Draft,"standard-1
 standard-5","clause-1
 clause-2"
-,Startupsum 129,Research & development market pitch focus creative assets.<br> Low hanging fruit alpha social media.<br> Buzz interaction design return on investment monetization A/B testing hypotheses gamification stealth traction niche market.<br>,success 125,,zidar@example.com,,,,http://i.imgur.com/aP8UU5I.jpg,control-15,,,,manual,,,,,,,,Draft,"standard-1
+,Startupsum 129,Research & development market pitch focus creative assets.<br> Low hanging fruit alpha social media.<br> Buzz interaction design return on investment monetization A/B testing hypotheses gamification stealth traction niche market.<br>,success 125,,zidar@example.com,,,,http://i.imgur.com/aP8UU5I.jpg,control-15,,,,manual,,,,,Physical Security,,,Draft,"standard-1
 standard-5",
 ,Startupsum 130,Hypotheses www.<br>discoverartisans.<br>com pitch launch party ownership virality partner network direct mailing bandwid,success 126,,zidar@example.com,,,,http://i.imgur.com/aP8UU5I.jpg,control-16,,,,Physical,,,,,,,,Draft,"standard-1
 standard-5",


### PR DESCRIPTION
Steps to reproduce:
Original objects:
1. Open Controls widget
2. Change values of "Categories" and "Assertions" fields to a few Controls
3. Order by both fields one-by-one in both directions, notice some (or all) results have wrong ordering.
3. Filter might work for "Categories"and "Assertions" before

Snapshots: (Note: Comparison window should work properly for "Categories" and "Assertions" after this ticket is done GGRC-1486)
1. Map few Controls to Audit
2. Change values of "FRAUD RELATED" and "SIGNIFICANCE" fields to a few Controls
3. Update all mapped to Audit objects.
4. Go to Controls widget under the Audit
5. Order by both fields one-by-one in both directions, notice some (or all) results have wrong ordering.
6. Filter might work for "Categories"and "Assertions" before

NOTES: 
- either do reindex after applying changes, or take into consideration the changed objects only (objects with changed fields)
- Correct information about "Categories" and "Assertions" in Snapshots on UI should be displayed now after GGRC-2508

Expected result:
All "order_by"s and filters work within both: original objects and Snapshots

~depends on #5839~ 