### PR TITLE
GGRC-2682 Improve formatting in Advanced Search Filter

### DIFF
--- a/src/ggrc/assets/javascripts/components/simple-modal/simple-modal.js
+++ b/src/ggrc/assets/javascripts/components/simple-modal/simple-modal.js
@@ -39,9 +39,9 @@
         return function (el) {
           showContent.bind('change', function (ev, val) {
             if (val) {
-              $(el).dialog();
+              $(el).modal();
             } else {
-              $(el).dialog('destroy');
+              $(el).modal('hide');
             }
           });
         };


### PR DESCRIPTION
Steps to reproduce:
1. Go to My Work page > Control's widget
2. Click "advanced search" icon on the right of search box
3. Look at the "Advanced Search Filter" popup
	font is too large;
	"Add Group Expression" should be in blue color
Actual Result: Formatting in Advanced Search Filter is broken
Expected Result: Improve formatting in Advanced Search Filter according to mockups https://drive.google.com/corp/drive/folders/0B7_NYFVmb896RmQwYXFiNzhQcU0