### PR TITLE
GGRC-2679 Fix columns order for workflow import 

### DIFF
--- a/src/ggrc/models/reflection.py
+++ b/src/ggrc/models/reflection.py
@@ -77,6 +77,10 @@ ATTRIBUTE_ORDER = (
     "send_by_default",
     "document_url",
     "document_evidence",
+    "notify_custom_message",
+    "frequency",
+    "notify_on_change",
+    "is_verification_needed",
     "delete",
 )
 


### PR DESCRIPTION
Any newly added column should be together with all the other primary columns on export page and in the exported CSV.

This ticket was created because the PR for GGRC-2451 was already merged and this slipped past the pull request review (and same for other similar objects)

steps to reproduce
- export a wf template
Expected: all primary coulumns included "need verificiation" need to be grouped together
Actual: "need verfiation" and a few other columns are after Custom attributes.
