### PR TITLE
GGRC-2684 "There was an error" is displayed with 500 error in console while applying advanced filter in parallel with query in search box

### DIFF
--- a/src/ggrc/assets/javascripts/components/tree/tree-widget-container.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-widget-container.js
@@ -472,18 +472,21 @@
       var filters = this.attr('advancedSearch.filterItems');
       var mappings = this.attr('advancedSearch.mappingItems');
       var request = can.List();
+      var advancedFilters;
 
       this.attr('advancedSearch.appliedFilterItems', filters);
       this.attr('advancedSearch.appliedMappingItems', mappings);
 
-      this.attr('advancedSearch.filter', GGRC.query_parser.join_queries(
+      advancedFilters = GGRC.query_parser.join_queries(
         GGRC.query_parser
           .parse(GGRC.Utils.AdvancedSearch.buildFilter(filters, request)),
         GGRC.query_parser
           .parse(GGRC.Utils.AdvancedSearch.buildFilter(mappings, request))
-      ));
-
+      );
       this.attr('advancedSearch.request', request);
+
+      this.attr('advancedSearch.filter', advancedFilters);
+
       this.attr('advancedSearch.open', false);
       this.onFilter();
     },


### PR DESCRIPTION
Steps to reproduce:
1. Go to My work page > Controls tab
2. Type into search box any query (e.g. admin = "xxx")
3. Click "advanced search" icon on the right of search box
4. Select Filter by Mapping and add filter query > Apply filter
5. Look at the screen
Actual Result: "There was an error" is displayed with 500 error in console while applying advanced filter in parallel with query in search box 
Expected Result: no error is displayed while applying advanced search filter and search results according to filter queries are displayed in tree view
