### PR TITLE
GGRC-2667: Send "populated_content" instead of "content" to the frontend for revisions 

### DIFF
--- a/src/ggrc/models/hooks/assessment.py
+++ b/src/ggrc/models/hooks/assessment.py
@@ -210,7 +210,7 @@ def generate_role_object_dict(snapshot, audit):
   acr_dict = role.get_custom_roles_for(snapshot.child_type)
   acl_dict = defaultdict(list)
   # populated content should have access_control_list
-  for acl in snapshot.revision.populated_content["access_control_list"]:
+  for acl in snapshot.revision.content["access_control_list"]:
     acl_dict[acr_dict[acl["ac_role_id"]]].append(acl["person_id"])
   # populate Access Control List by generated role from the related Audit
   acl_dict["Audit Lead"].append(audit.contact_id)

--- a/src/ggrc/models/revision.py
+++ b/src/ggrc/models/revision.py
@@ -20,7 +20,7 @@ class Revision(Base, db.Model):
   event_id = db.Column(db.Integer, db.ForeignKey('events.id'), nullable=False)
   action = db.Column(db.Enum(u'created', u'modified', u'deleted'),
                      nullable=False)
-  content = db.Column(LongJsonType, nullable=False)
+  _content = db.Column('content', LongJsonType, nullable=False)
 
   resource_slug = db.Column(db.String, nullable=True)
   source_type = db.Column(db.String, nullable=True)
@@ -67,7 +67,7 @@ class Revision(Base, db.Model):
     self.resource_slug = getattr(obj, "slug", None)
     self.modified_by_id = modified_by_id
     self.action = action
-    self.content = content
+    self._content = content
 
     for attr in ["source_type",
                  "source_id",
@@ -78,9 +78,9 @@ class Revision(Base, db.Model):
   @builder.simple_property
   def description(self):
     """Compute a human readable description from action and content."""
-    if 'display_name' not in self.content:
+    if 'display_name' not in self._content:
       return ''
-    display_name = self.content['display_name']
+    display_name = self._content['display_name']
     if not display_name:
       result = u"{0} {1}".format(self.resource_type, self.action)
     elif u'<->' in display_name:
@@ -90,15 +90,15 @@ class Revision(Base, db.Model):
         msg = u"{destination} unlinked from {source}"
       else:
         msg = u"{display_name} {action}"
-      source, destination = self.content['display_name'].split('<->')[:2]
+      source, destination = self._content['display_name'].split('<->')[:2]
       result = msg.format(source=source,
                           destination=destination,
-                          display_name=self.content['display_name'],
+                          display_name=self._content['display_name'],
                           action=self.action)
-    elif 'mapped_directive' in self.content:
+    elif 'mapped_directive' in self._content:
       # then this is a special case of combined map/creation
       # should happen only for Section and Control
-      mapped_directive = self.content['mapped_directive']
+      mapped_directive = self._content['mapped_directive']
       if self.action == 'created':
         result = u"New {0}, {1}, created and mapped to {2}".format(
             self.resource_type,
@@ -117,14 +117,14 @@ class Revision(Base, db.Model):
       result += ", via bulk action"
     return result
 
-  @property
-  def populated_content(self):
+  @builder.simple_property
+  def content(self):
     """Property. Contains the revision content dict.
 
     Updated by required values, generated from saved content dict."""
     roles_dict = role.get_custom_roles_for(self.resource_type)
     reverted_roles_dict = {n: i for i, n in roles_dict.iteritems()}
-    access_control_list = self.content.get("access_control_list") or []
+    access_control_list = self._content.get("access_control_list") or []
     map_field_to_role = {
         "principal_assessor": reverted_roles_dict.get("Principal Assignees"),
         "secondary_assessor": reverted_roles_dict.get("Secondary Assignees"),
@@ -133,11 +133,11 @@ class Revision(Base, db.Model):
     }
     exists_roles = {i["ac_role_id"] for i in access_control_list}
     for field, role_id in map_field_to_role.items():
-      if field not in self.content:
+      if field not in self._content:
         continue
       if role_id in exists_roles or role_id is None:
         continue
-      person_id = (self.content.get(field) or {}).get("id")
+      person_id = (self._content.get(field) or {}).get("id")
       if not person_id:
         continue
       access_control_list.append({
@@ -153,6 +153,11 @@ class Revision(Base, db.Model):
           "modified_by": None,
           "id": None,
       })
-    content = self.content.copy()
-    content["access_control_list"] = access_control_list
-    return content
+    populated_content = self._content.copy()
+    populated_content["access_control_list"] = access_control_list
+    return populated_content
+
+  @content.setter
+  def content(self, value):
+    """ Setter for content property."""
+    self._content = value

--- a/src/ggrc/snapshotter/indexer.py
+++ b/src/ggrc/snapshotter/indexer.py
@@ -293,7 +293,7 @@ def reindex_pairs(pairs):
           "id",
           "resource_type",
           "resource_id",
-          "content",
+          "_content",
       ),
       orm.load_only(
           "id",
@@ -318,7 +318,7 @@ def reindex_pairs(pairs):
         "revision": get_searchable_attributes(
             CLASS_PROPERTIES[revision.resource_type],
             cad_dict,
-            revision.populated_content)
+            revision.content)
     }
   search_payload = []
   for snapshot in snapshots.values():

--- a/test/integration/ggrc/snapshotter/test_indexing.py
+++ b/test/integration/ggrc/snapshotter/test_indexing.py
@@ -379,9 +379,10 @@ class TestSnapshotIndexing(SnapshotterBaseTestCase):
           child_id=control.id,
           child_type=control.type,
           revision=revision)
-      revision.content = revision.content.copy()
-      revision.content.pop("access_control_list")
-      revision.content[field] = {"id": person.id}
+      old_content = revision.content.copy()
+      old_content.pop("access_control_list")
+      old_content[field] = {"id": person.id}
+      revision.content = old_content
       db.session.add(revision)
     do_reindex()
     self.assert_indexed_fields(snapshot, role_name, {

--- a/test/integration/ggrc/snapshotter/test_snapshoting.py
+++ b/test/integration/ggrc/snapshotter/test_snapshoting.py
@@ -19,7 +19,7 @@ from integration.ggrc.snapshotter import snapshot_identity
 class TestSnapshoting(SnapshotterBaseTestCase):
   """Test cases for Snapshoter module"""
 
-  # pylint: disable=invalid-name
+  # pylint: disable=invalid-name,protected-access
 
   def test_snapshot_create(self):
     """Test simple snapshot creation with a simple change"""
@@ -63,7 +63,7 @@ class TestSnapshoting(SnapshotterBaseTestCase):
     snapshot_revision = db.session.query(
         models.Revision.resource_type,
         models.Revision.resource_id,
-        models.Revision.content
+        models.Revision._content
     ).filter(
         models.Revision.resource_type == "Snapshot",
         models.Revision.resource_id == snapshot.first().id,
@@ -93,7 +93,7 @@ class TestSnapshoting(SnapshotterBaseTestCase):
     relationship_revision = db.session.query(
         models.Revision.resource_type,
         models.Revision.resource_id,
-        models.Revision.content,
+        models.Revision._content,
     ).filter(
         models.Revision.resource_type == "Relationship",
         models.Revision.resource_id == relationship.first().id,
@@ -243,11 +243,11 @@ class TestSnapshoting(SnapshotterBaseTestCase):
         models.Revision.id,
         models.Revision.resource_type,
         models.Revision.resource_id,
-        models.Revision.content,
+        models.Revision._content,
     ).filter(
         models.Revision.resource_type == control.type,
         models.Revision.resource_id == control.id,
-        models.Revision.content.like("%Test Control Snapshot 1 EDIT 2%"),
+        models.Revision._content.like("%Test Control Snapshot 1 EDIT 2%"),
     ).one()
 
     audit = self.refresh_object(audit)

--- a/test/unit/ggrc/models/test_revision.py
+++ b/test/unit/ggrc/models/test_revision.py
@@ -67,7 +67,7 @@ class TestCheckPopulatedContent(unittest.TestCase):
 
     with mock.patch("ggrc.access_control.role.get_custom_roles_for",
                     return_value=role_dict) as get_roles:
-      self.assertEqual(revision.populated_content, expected)
+      self.assertEqual(revision.content, expected)
       get_roles.assert_called_once_with(self.object_type)
 
   @ddt.data(None, {}, {"id": None})
@@ -83,7 +83,7 @@ class TestCheckPopulatedContent(unittest.TestCase):
     revision = all_models.Revision(obj, mock.Mock(), mock.Mock(), content)
     with mock.patch("ggrc.access_control.role.get_custom_roles_for",
                     return_value=role_dict) as get_roles:
-      self.assertEqual(revision.populated_content, expected)
+      self.assertEqual(revision.content, expected)
       get_roles.assert_called_once_with(self.object_type)
 
   @ddt.data(
@@ -103,5 +103,5 @@ class TestCheckPopulatedContent(unittest.TestCase):
     revision = all_models.Revision(obj, mock.Mock(), mock.Mock(), content)
     with mock.patch("ggrc.access_control.role.get_custom_roles_for",
                     return_value={}) as get_roles:
-      self.assertEqual(revision.populated_content, expected)
+      self.assertEqual(revision.content, expected)
       get_roles.assert_called_once_with(self.object_type)


### PR DESCRIPTION
Add processing of old revisions