### PR TITLE
GGRC-2699 Fix script error in info pane's requestQuery() method

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.js
+++ b/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.js
@@ -118,9 +118,16 @@
         GGRC.Utils.QueryAPI
           .batchRequests(query)
           .done(function (response) {
-            var type = Object.keys(response)[0];
-            var values = response[type].values;
-            dfd.resolve(values);
+            var keys;
+            var objType;
+
+            keys = Object.keys(response);
+            _.remove(keys, function (item) {
+              return item === 'selfLink';
+            });
+
+            objType = keys[0];
+            dfd.resolve(response[objType].values);
           })
           .fail(function () {
             dfd.resolve([]);
@@ -128,7 +135,7 @@
           .always(function () {
             this.attr('isUpdating' + can.capitalize(type), false);
           }.bind(this));
-        return dfd;
+        return dfd.promise();
       },
       loadSnapshots: function () {
         var query = this.getSnapshotQuery();

--- a/src/ggrc/assets/javascripts/components/assessment/info-pane/tests/info-pane_spec.js
+++ b/src/ggrc/assets/javascripts/components/assessment/info-pane/tests/info-pane_spec.js
@@ -1,0 +1,59 @@
+/*!
+ Copyright (C) 2017 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+describe('GGRC.Components.assessmentInfoPane', function () {
+  'use strict';
+
+  var vm;  // viewModel of the component under test
+
+  beforeEach(function () {
+    // inside beforeEach (as opposed to befreAll), because a new and clean
+    // viewModel instance should be used for each test case
+    vm = GGRC.Components.getViewModel('assessmentInfoPane');
+  });
+
+  describe('requestQuery() method', function () {
+    var dfdBatchRequests;
+
+    beforeEach(function () {
+      dfdBatchRequests = new can.Deferred();
+      spyOn(GGRC.Utils.QueryAPI, 'batchRequests')
+          .and.returnValue(dfdBatchRequests.promise());
+    });
+
+    it('resolves given promise with a list of objects of the requested type',
+      function (done) {
+        var requestPromise;
+
+        var query = {
+          object_name: 'Document',
+          fields: [],
+          filters: {}
+        };
+
+        // NOTE: It is technically not 100% guaranteed that having selfLink as
+        // the first key would reproduce the original issue, although in
+        // practice major browsers do respect and preserve the object key
+        // which is reflected in what Object.keys() method returns.
+        // See https://stackoverflow.com/a/23202095/5040035 for more details.
+        var serverResponse = {
+          selfLink: null,  // must come frist!
+          Document: {
+            values: [{id: 5, title: 'Document 5'}],
+            total: 1,
+            count: 1
+          }
+        };
+
+        requestPromise = vm.requestQuery(query, 'Document');
+        requestPromise.then(function (result) {
+          expect(result).toEqual([{id: 5, title: 'Document 5'}]);
+          done();
+        });
+        dfdBatchRequests.resolve(serverResponse);
+      }
+    );
+  });
+});


### PR DESCRIPTION
This PR fixes a script error that can sometimes occur on some platforms due to non-deterministic ordering of the object keys received from the backend. The fix removes the frontend code's assumption of a particular key order.

The error is a semi-blocker for me (possibly putting the frontend into inconsistent state), thus a higher priority of the PR.

---

**Steps to reproduce:**
1. Go to My work page > Assessments tab
2. Select any assessment in tree view that contains a snapshot 
3. Click on the first tier to expand info pane
4. Look at the screen

**Actual Result:**
Script error "Cannot read property "values" of null" is displayed while expanding Assessments Info pane on My work page

**Expected Result:**
no error is displayed while expanding assessment's info pane

*NOTE:* the issue is not reproduced in ggrc-dev and ggrc-qa and reproduced locally on a Goobuntu-based machine.