### PR TITLE
GGRC-2699 Locally: Script error "Cannot read property "values" of null" is displayed while expanding Assessments Info pane on My work page

### DIFF
--- a/src/ggrc/services/query.py
+++ b/src/ggrc/services/query.py
@@ -23,7 +23,6 @@ def build_collection_representation(model, description):
   # pylint: disable=protected-access
   collection = {
       model.__name__: description,
-      "selfLink": None,  # not implemented yet
   }
   return collection
 

--- a/test/integration/ggrc/services/test_query/test_basic.py
+++ b/test/integration/ggrc/services/test_query/test_basic.py
@@ -687,16 +687,6 @@ class TestAdvancedQueryAPI(BaseQueryAPITestCase):
         set(programs_ids["ids"]),
     )
 
-  @unittest.skip("Not implemented")
-  def test_self_link(self):
-    # It would be good if the api accepted get requests and we could add the
-    # query into a get parameter, then each request would also get a self link
-    # that could be tested to see that it truly returns what the original
-    # request was.
-    # In the end, instead of returning mapped object stubs like we do now, we'd
-    # just return a self link for fetching those objects.
-    pass
-
   def test_multiple_queries(self):
     """Multiple queries POST is identical to multiple single-query POSTs."""
     data_list = [


### PR DESCRIPTION
Steps to reproduce:
1. Go to My work page > Assessments tab
2. Select any assessment in tree view that contains a snapshot 
3. Click on the first tier to expand info pane
4. Look at the screen
Actual Result: Script error "Cannot read property "values" of null" is displayed while expanding Assessments Info pane on My work page
Expected Result: no error is displayed while expanding assessment's info pane
NOTE: the issue is not reproduced in ggrc-dev and ggrc-qa and reproduced locally