### PR TITLE
GGRC-1779 RMC - Workflow: Hide/Disable Verify button for workflow task

### DIFF
--- a/src/ggrc/assets/javascripts/models/mixins.js
+++ b/src/ggrc/assets/javascripts/models/mixins.js
@@ -293,12 +293,15 @@
       }.bind(this));
     },
     _isOverdue: function () {
+      var doneState = this.attr('is_verification_needed') ?
+        'Verified' : 'Finished';
       var endDate = moment(
         this.attr('next_due_date') || this.attr('end_date'));
       var today = moment().startOf('day');
       var startOfDate = moment(endDate).startOf('day');
       var isOverdue = endDate && today.diff(startOfDate, 'days') > 0;
-      if (this.attr('status') === 'Verified') {
+
+      if (this.attr('status') === doneState) {
         return false;
       }
       return isOverdue;

--- a/src/ggrc/assets/javascripts/models/tests/isOverdue_mixin_spec.js
+++ b/src/ggrc/assets/javascripts/models/tests/isOverdue_mixin_spec.js
@@ -28,8 +28,20 @@ describe('can.Model.Mixin.isOverdue', function () {
       expect(method).toBeDefined();
     });
 
-    it('returns false, if status is "Verified"', function () {
+    it('returns false, if status is "Verified" ' +
+    'and is_verification_needed is true', function () {
+      instance.attr('next_due_date', moment().subtract(1, 'd'));
+      instance.attr('is_verification_needed', true);
       instance.attr('status', 'Verified');
+
+      expect(method.apply(instance)).toEqual(false);
+    });
+
+    it('returns false, if status is "Finished"' +
+    ' and is_verification_needed is false', function () {
+      instance.attr('next_due_date', moment().subtract(1, 'd'));
+      instance.attr('is_verification_needed', false);
+      instance.attr('status', 'Finished');
 
       expect(method.apply(instance)).toEqual(false);
     });


### PR DESCRIPTION
During verification the following issues have been found:
1. If Task completion if Verified = false: Finished cycle tasks becomes Overdue. But it shouldn't be. (4.3 Finished cycle tasks should not become Overdue.)
2. If Task completion if Verified = false: Cycle isn't moved to history if all cycle tasks have 'Finished' state (4.2 Cycle should be moved to history if all cycle tasks have 'Finished' state.)
3. Mandatory 'Need Verification' field is not validated while importing. In this case 'Need Verification' field becomes false by default and Task completion works as Verified = false. Means, that users won't get notifications about overdue tasks. (A8. Import : 'Need Verification' column should be mandatory.)

**NOTE:** Actually here is a little bit changes for first option but for proper application work here is still needed the backend changes. 2) and 3) options for backend.

Depends on: 
1) https://github.com/google/ggrc-core/pull/5910
2) https://github.com/google/ggrc-core/pull/5911