### PR TITLE
GGRC-2534 Remove redundant GET request after Assessment edit

### DIFF
--- a/src/ggrc/assets/javascripts/models/assessment.js
+++ b/src/ggrc/assets/javascripts/models/assessment.js
@@ -273,7 +273,6 @@
       return this._super(checkAssociations);
     },
     after_save: function () {
-      this.dispatch('refreshInstance');
       if (this.audit && this.audit.selfLink) {
         this.audit.refresh();
       }


### PR DESCRIPTION
After editing a normal field on an assessment (not mapping a new object to it)
the frontend triggers 3 requests
PUT Assessmnet
GET Assessment
POST query for related snapshots
Since GET Assessmnet returns the exact same data as the PUT requests we do not need it and it should be avoided.
Since editing attribute on an assessment can not change mappings to snapshots and those have already been loaded when the info pin was first loaded, we should not be making the query request for data that is already on the frontend.