### PR TITLE
GGRC-2446 People in PRIMARY CONTACTS/SECONDARY CONTACTS/ASSESSMENT ROLE fields are displayed randomly again after removal in Edit Assessment modal window

### DIFF
--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -328,6 +328,7 @@ dashboard-js-files:
   - components/related-objects/related-people-access-control.js
   - components/related-objects/related-people-access-control-group.js
   - components/custom-roles/custom-roles.js
+  - components/custom-roles/custom-roles-modal.js
 
 app-init-files:
   - apps/dashboard.js
@@ -687,6 +688,7 @@ dashboard-js-template-files:
   - components/people/deletable-people-group.mustache
   - components/people/editable-people-group.mustache
   - components/custom-roles/custom-roles.mustache
+  - components/custom-roles/custom-roles-modal.mustache
 
 dashboard-css-files:
   - dashboard.css

--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -327,6 +327,7 @@ dashboard-js-files:
   - components/related-objects/related-people-mapping.js
   - components/related-objects/related-people-access-control.js
   - components/related-objects/related-people-access-control-group.js
+  - components/custom-roles/custom-roles.js
 
 app-init-files:
   - apps/dashboard.js
@@ -685,6 +686,7 @@ dashboard-js-template-files:
   - components/assessment/attach-button.mustache
   - components/people/deletable-people-group.mustache
   - components/people/editable-people-group.mustache
+  - components/custom-roles/custom-roles.mustache
 
 dashboard-css-files:
   - dashboard.css

--- a/src/ggrc/assets/javascripts/components/custom-roles/custom-roles-modal.js
+++ b/src/ggrc/assets/javascripts/components/custom-roles/custom-roles-modal.js
@@ -1,0 +1,21 @@
+/*!
+ Copyright (C) 2017 Google Inc., authors, and contributors
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+(function (can, GGRC) {
+  'use strict';
+
+  var tag = 'custom-roles-modal';
+  var tpl = can.view(GGRC.mustache_path +
+    '/components/custom-roles/custom-roles-modal.mustache');
+
+  GGRC.Components('customRolesModal', {
+    tag: tag,
+    template: tpl,
+    viewModel: {
+      instance: {},
+      updatableGroupId: null
+    }
+  });
+})(window.can, window.GGRC);

--- a/src/ggrc/assets/javascripts/components/custom-roles/custom-roles.js
+++ b/src/ggrc/assets/javascripts/components/custom-roles/custom-roles.js
@@ -1,0 +1,22 @@
+/*!
+ Copyright (C) 2017 Google Inc., authors, and contributors
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+(function (can, GGRC) {
+  'use strict';
+
+  var tag = 'custom-roles';
+  var tpl = can.view(GGRC.mustache_path +
+    '/components/custom-roles/custom-roles.mustache');
+
+  GGRC.Components('customRoles', {
+    tag: tag,
+    template: tpl,
+    viewModel: {
+      instance: {},
+      infoPaneMode: false,
+      isNewInstance: false
+    }
+  });
+})(window.can, window.GGRC);

--- a/src/ggrc/assets/javascripts/components/custom-roles/custom-roles.js
+++ b/src/ggrc/assets/javascripts/components/custom-roles/custom-roles.js
@@ -15,8 +15,16 @@
     template: tpl,
     viewModel: {
       instance: {},
-      infoPaneMode: false,
-      isNewInstance: false
+      updatableGroupId: null,
+      save: function (args) {
+        var self = this;
+        this.attr('updatableGroupId', args.groupId);
+        this.attr('instance').save()
+          .then(function () {
+            self.attr('instance').dispatch('refreshInstance');
+            self.attr('updatableGroupId', null);
+          });
+      }
     }
   });
 })(window.can, window.GGRC);

--- a/src/ggrc/assets/javascripts/components/people/deletable-people-group.js
+++ b/src/ggrc/assets/javascripts/components/people/deletable-people-group.js
@@ -9,10 +9,12 @@
   var viewModel = can.Map.extend('GGRC.VM.DeletablePeopleGroup', {
     define: {
       emptyListMessage: {
-        type: 'string',
-        value: ''
+        get: function () {
+          return this.attr('showEmptyMessage') ? 'None' : '';
+        }
       }
     },
+    showEmptyMessage: true,
     required: '@',
     people: [],
     groupId: '@',

--- a/src/ggrc/assets/javascripts/components/people/editable-people-group.js
+++ b/src/ggrc/assets/javascripts/components/people/editable-people-group.js
@@ -9,7 +9,7 @@
   var viewModel = GGRC.VM.DeletablePeopleGroup.extend({
     title: '@',
     editableMode: false,
-    validation: {},
+    canEdit: {},
     personSelected: function (person) {
       this.dispatch({
         type: 'personSelected',

--- a/src/ggrc/assets/javascripts/components/people/editable-people-group.js
+++ b/src/ggrc/assets/javascripts/components/people/editable-people-group.js
@@ -27,7 +27,7 @@
       this.attr('editableMode', editableMode);
       this.dispatch({
         type: 'changeEditableMode',
-        isAddEditableGroup: editableMode,
+        editableMode: editableMode,
         groupId: this.attr('groupId')
       });
     }

--- a/src/ggrc/assets/javascripts/components/related-objects/related-people-access-control-group.js
+++ b/src/ggrc/assets/javascripts/components/related-objects/related-people-access-control-group.js
@@ -38,25 +38,18 @@
       isDirty: false,
       required: false,
       backUpPeople: [],
-      infoPaneMode: true,
+      autoUpdate: false,
       updatableGroupId: null,
 
-      refreshInstanceAfterCancel: function (groupId) {
-        this.attr('editableMode', false);
-        this.attr('isDirty', false);
-        this.attr('people').replace(this.attr('backUpPeople'));
-      },
-      // only one group can be editable
       changeEditableGroup: function (args) {
-        var groupId = args.groupId;
-        var isAddEditableGroup = args.isAddEditableGroup;
-
-        if (isAddEditableGroup) {
+        if (args.editableMode) {
           this.attr('editableMode', true);
           this.attr('backUpPeople')
             .replace(this.attr('people'));
         } else {
-          this.refreshInstanceAfterCancel(groupId);
+          this.attr('editableMode', false);
+          this.attr('isDirty', false);
+          this.attr('people').replace(this.attr('backUpPeople'));
         }
       },
       saveChanges: function () {
@@ -65,7 +58,7 @@
         if (this.attr('isDirty')) {
           this.attr('isDirty', false);
           this.dispatch({
-            type: 'saveRoles',
+            type: 'updateRoles',
             people: this.attr('people'),
             roleId: this.attr('groupId')
           });
@@ -75,10 +68,7 @@
         this.addPerson(args.person, args.groupId);
       },
       addPerson: function (person, groupId) {
-        var exist = _.find(
-          this.attr('people'),
-          {id: person.id}
-        );
+        var exist = _.find(this.attr('people'), {id: person.id});
 
         if (exist) {
           console.warn('User ', person.id,
@@ -89,19 +79,11 @@
         this.attr('isDirty', true);
         this.attr('people').push(person);
 
-        // Don't dispatch add role if NOT modal mode
-        if (this.attr('infoPaneMode')) {
-          return;
+        if (this.attr('autoUpdate')) {
+          this.saveChanges();
         }
-
-        this.dispatch({
-          type: 'addRole',
-          person: person,
-          groupId: groupId
-        });
       },
       removePerson: function (args) {
-        var groupId = args.groupId;
         var person = args.person;
         var idx = _.findIndex(
           this.attr('people'),
@@ -110,34 +92,14 @@
         this.attr('isDirty', true);
         this.attr('people').splice(idx, 1);
 
-        // Don't dispatch add role if NOT modal mode
-        if (this.attr('infoPaneMode')) {
-          return;
+        if (this.attr('autoUpdate')) {
+          this.saveChanges();
         }
-
-        this.dispatch({
-          type: 'removeRole',
-          person: person,
-          groupId: groupId
-        });
       }
     },
     events: {
-      /**
-       * The component entry point.
-       *
-       * @param {jQuery} $element - the DOM element that triggered
-       *   creating the component instance
-       * @param {Object} options - the component instantiation options
-       */
       init: function ($element, options) {
         var vm = this.viewModel;
-        var instance = vm.attr('instance');
-        if (!instance) {
-          console.error('accessControlList component: instance not given.');
-          return;
-        }
-
         vm.attr('backUpPeople').replace(vm.attr('people'));
       }
     }

--- a/src/ggrc/assets/javascripts/components/related-objects/related-people-access-control.js
+++ b/src/ggrc/assets/javascripts/components/related-objects/related-people-access-control.js
@@ -10,12 +10,166 @@
     tag: 'related-people-access-control',
     viewModel: {
       instance: {},
-      define: {
-        accessControlGroups: {
-          get: function () {
-            return this.getRoleList();
-          }
+      includeRoles: [],
+      groups: [],
+      updatableGroupId: null,
+      infoPaneMode: true,
+      isNewInstance: false,
+      autosave: false,
+
+      saveRoles: function (args) {
+        var self = this;
+        var people = args.people;
+        var roleId = args.roleId;
+        this.attr('updatableGroupId', roleId);
+
+        this.updateAccessContolList(people, roleId);
+
+        this.attr('instance').save()
+          .then(function () {
+            self.attr('instance').dispatch('refreshInstance');
+            self.attr('updatableGroupId', null);
+            self.attr('groups', self.getRoleList());
+          });
+      },
+      updateAccessContolList: function (people, roleId) {
+        var instance = this.attr('instance');
+
+        // remove all people with current role
+        var listWithoutRole = instance
+          .attr('access_control_list').filter(function (item) {
+            return item.ac_role_id !== roleId;
+          });
+
+        // push update people with current role
+        people.forEach(function (person) {
+          listWithoutRole.push({
+            ac_role_id: roleId,
+            person: {id: person.id, type: 'Person'}
+          });
+        });
+
+        instance.attr('access_control_list')
+          .replace(listWithoutRole);
+      },
+      addPerson: function (args) {
+        var person = args.person;
+        var groupId = args.groupId;
+
+        this.grantRole(person, groupId);
+      },
+      removePerson: function (args) {
+        var person = args.person;
+        var groupId = args.groupId;
+
+        this.revokeRole(person, groupId);
+      },
+
+      /**
+       * Grant role to user on the model instance.
+       *
+       * If the user already has this role assigned on the model instance,
+       * nothing happens.
+       *
+       * @param {CMS.Models.Person} person - the user to grant a role to
+       * @param {Number} roleId - ID if the role to grant
+       */
+      grantRole: function (person, roleId) {
+        var roleEntry;
+
+        if (this.attr('updatableGroupId')) {
+          return;
         }
+
+        this.attr('updatableGroupId', roleId);
+
+        roleEntry = _.find(
+          this.attr('instance.access_control_list'),
+          {person: {id: person.id}, ac_role_id: roleId}
+        );
+
+        if (roleEntry) {
+          console.warn(
+            'User ', person.id, 'already has role', roleId, 'assigned');
+          this.attr('updatableGroupId', null);
+          return;
+        }
+
+        if (!this.attr('instance.access_control_list')) {
+          this.attr('instance.access_control_list', []);
+        }
+
+        can.batch.start();
+        roleEntry = {
+          person: {id: person.id, type: 'Person'},
+          ac_role_id: roleId};
+        this.attr('instance.access_control_list').push(roleEntry);
+
+        this._save(true);
+      },
+
+      /**
+       * Revoke role from user on the model instance.
+       *
+       * If the user already does not have this role assigned on the model
+       * instance, nothing happens.
+       *
+       * @param {CMS.Models.Person} person - the user to grant a role to
+       * @param {Number} roleId - ID if the role to grant
+       */
+      revokeRole: function (person, roleId) {
+        var idx;
+
+        if (this.attr('updatableGroupId')) {
+          return;
+        }
+
+        this.attr('updatableGroupId', roleId);
+
+        idx = _.findIndex(
+          this.attr('instance.access_control_list'),
+          {person: {id: person.id}, ac_role_id: roleId}
+        );
+
+        if (idx < 0) {
+          console.warn('Role ', roleId, 'not found for user', person.id);
+          this.attr('updatableGroupId', null);
+          return;
+        }
+
+        can.batch.start();
+        this.attr('instance.access_control_list').splice(idx, 1);
+
+        this._save();
+      },
+
+      buildGroups: function (role, roleAssignments) {
+        var includeRoles = this.attr('includeRoles');
+        var groupId = role.id;
+        var title = role.name;
+        var group;
+        var people;
+
+        if (includeRoles.length && includeRoles.indexOf(title) === -1) {
+          return;
+        }
+
+        group = roleAssignments[groupId];
+        people = group ?
+          group.map(function (groupItem) {
+            return {
+              id: groupItem.person.id,
+              type: 'Person'
+            };
+          }) :
+          [];
+
+        return {
+          title: title,
+          groupId: groupId,
+          people: people,
+          required: role.mandatory
+        };
       },
       getRoleList: function () {
         var roleAssignments;
@@ -36,23 +190,55 @@
         });
 
         groups = _.map(roles, function (role) {
-          var groupId = role.id;
-          var title = role.name;
-          var group = roleAssignments[groupId];
-          var people = group ?
-            group.map(function (groupItem) {
-              return groupItem.person;
-            }) :
-            [];
+          return this.buildGroups(role, roleAssignments);
+        }.bind(this))
+        .filter(function (group) {
+          return typeof group !== 'undefined';
+        })
+        // sort by required
+        .sort(function (a, b) {
+          if (a.required === b.required) {
+            return 0;
+          }
 
-          return {
-            title: title,
-            groupId: groupId,
-            people: people
-          };
+          return a.required ? -1 : 1;
         });
 
         return groups;
+      },
+      _save: function (isAdding) {
+        var successMessage = 'User role ' +
+          (isAdding ? 'added.' : 'removed.');
+        var errorMessage = isAdding ? 'Adding' : 'Removing' +
+          ' user role failed.';
+
+        if (!this.autosave) {
+          this.attr('updatableGroupId', null);
+          can.batch.stop();
+          return;
+        }
+
+        this.attr('instance').save()
+          .done(function () {
+            GGRC.Errors.notifier('success', successMessage);
+          })
+          .fail(function () {
+            GGRC.Errors.notifier('error', errorMessage);
+          })
+          .always(function () {
+            this.attr('updatableGroupId', null);
+            can.batch.stop();
+          }.bind(this));
+      }
+    },
+    events: {
+      inserted: function () {
+        this.viewModel.attr('groups',
+          this.viewModel.getRoleList());
+      },
+      '{viewModel.instance.access_control_list} change':
+      function () {
+        this.viewModel.attr('groups', this.viewModel.getRoleList());
       }
     }
   });

--- a/src/ggrc/assets/javascripts/components/related-objects/related-people-access-control.js
+++ b/src/ggrc/assets/javascripts/components/related-objects/related-people-access-control.js
@@ -13,24 +13,14 @@
       includeRoles: [],
       groups: [],
       updatableGroupId: null,
-      infoPaneMode: true,
       isNewInstance: false,
-      autosave: false,
 
-      saveRoles: function (args) {
-        var self = this;
-        var people = args.people;
-        var roleId = args.roleId;
-        this.attr('updatableGroupId', roleId);
-
-        this.updateAccessContolList(people, roleId);
-
-        this.attr('instance').save()
-          .then(function () {
-            self.attr('instance').dispatch('refreshInstance');
-            self.attr('updatableGroupId', null);
-            self.attr('groups', self.getRoleList());
-          });
+      updateRoles: function (args) {
+        this.updateAccessContolList(args.people, args.roleId);
+        this.dispatch({
+          type: 'saveCustomRole',
+          groupId: args.roleId
+        });
       },
       updateAccessContolList: function (people, roleId) {
         var instance = this.attr('instance');
@@ -51,96 +41,6 @@
 
         instance.attr('access_control_list')
           .replace(listWithoutRole);
-      },
-      addPerson: function (args) {
-        var person = args.person;
-        var groupId = args.groupId;
-
-        this.grantRole(person, groupId);
-      },
-      removePerson: function (args) {
-        var person = args.person;
-        var groupId = args.groupId;
-
-        this.revokeRole(person, groupId);
-      },
-
-      /**
-       * Grant role to user on the model instance.
-       *
-       * If the user already has this role assigned on the model instance,
-       * nothing happens.
-       *
-       * @param {CMS.Models.Person} person - the user to grant a role to
-       * @param {Number} roleId - ID if the role to grant
-       */
-      grantRole: function (person, roleId) {
-        var roleEntry;
-
-        if (this.attr('updatableGroupId')) {
-          return;
-        }
-
-        this.attr('updatableGroupId', roleId);
-
-        roleEntry = _.find(
-          this.attr('instance.access_control_list'),
-          {person: {id: person.id}, ac_role_id: roleId}
-        );
-
-        if (roleEntry) {
-          console.warn(
-            'User ', person.id, 'already has role', roleId, 'assigned');
-          this.attr('updatableGroupId', null);
-          return;
-        }
-
-        if (!this.attr('instance.access_control_list')) {
-          this.attr('instance.access_control_list', []);
-        }
-
-        can.batch.start();
-        roleEntry = {
-          person: {id: person.id, type: 'Person'},
-          ac_role_id: roleId};
-        this.attr('instance.access_control_list').push(roleEntry);
-
-        this._save(true);
-      },
-
-      /**
-       * Revoke role from user on the model instance.
-       *
-       * If the user already does not have this role assigned on the model
-       * instance, nothing happens.
-       *
-       * @param {CMS.Models.Person} person - the user to grant a role to
-       * @param {Number} roleId - ID if the role to grant
-       */
-      revokeRole: function (person, roleId) {
-        var idx;
-
-        if (this.attr('updatableGroupId')) {
-          return;
-        }
-
-        this.attr('updatableGroupId', roleId);
-
-        idx = _.findIndex(
-          this.attr('instance.access_control_list'),
-          {person: {id: person.id}, ac_role_id: roleId}
-        );
-
-        if (idx < 0) {
-          console.warn('Role ', roleId, 'not found for user', person.id);
-          this.attr('updatableGroupId', null);
-          return;
-        }
-
-        can.batch.start();
-        this.attr('instance.access_control_list').splice(idx, 1);
-
-        this._save();
       },
 
       buildGroups: function (role, roleAssignments) {
@@ -205,40 +105,19 @@
         });
 
         return groups;
-      },
-      _save: function (isAdding) {
-        var successMessage = 'User role ' +
-          (isAdding ? 'added.' : 'removed.');
-        var errorMessage = isAdding ? 'Adding' : 'Removing' +
-          ' user role failed.';
-
-        if (!this.autosave) {
-          this.attr('updatableGroupId', null);
-          can.batch.stop();
-          return;
-        }
-
-        this.attr('instance').save()
-          .done(function () {
-            GGRC.Errors.notifier('success', successMessage);
-          })
-          .fail(function () {
-            GGRC.Errors.notifier('error', errorMessage);
-          })
-          .always(function () {
-            this.attr('updatableGroupId', null);
-            can.batch.stop();
-          }.bind(this));
       }
     },
     events: {
-      inserted: function () {
+      refreshGroups: function () {
         this.viewModel.attr('groups',
           this.viewModel.getRoleList());
       },
+      inserted: function () {
+        this.refreshGroups();
+      },
       '{viewModel.instance.access_control_list} change':
       function () {
-        this.viewModel.attr('groups', this.viewModel.getRoleList());
+        this.refreshGroups();
       }
     }
   });

--- a/src/ggrc/assets/mustache/components/assessment/assessment-people.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/assessment-people.mustache
@@ -79,8 +79,14 @@
     </div>
 </div>
 
-<custom-roles
-  {info-pane-mode}="infoPaneMode"
-  {instance}="instance"
-  {is-new-instance}="new_object_form">
-</custom-roles>
+{{#if infoPaneMode}}
+  <custom-roles
+    {instance}="instance"
+    {is-new-instance}="new_object_form">
+  </custom-roles>
+{{else}}
+  <custom-roles-modal
+    {instance}="instance"
+    {is-new-instance}="new_object_form">
+  </custom-roles-modal>
+{{/if}}

--- a/src/ggrc/assets/mustache/components/assessment/assessment-people.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/assessment-people.mustache
@@ -79,66 +79,8 @@
     </div>
 </div>
 
-
-<!-- ACL -->
-  <div class="flex-box">
-    <related-people-access-control
-      class="width-100"
-      {is-new-instance}="new_object_form"
-      {instance}="instance">
-        <div class="people-groups">
-          {{#accessControlGroups}}
-            <related-people-access-control-group
-              {group-id}="groupId"
-              {title}="title"
-              {people}="people"
-              {instance}="instance"
-              class="people-group"
-            >
-            <div>
-              {{#if infoPaneMode}}
-                <editable-people-group
-                  (unmap)="removePerson(%event)"
-                  (change-editable-mode)="changeEditableGroup(%event)"
-                  (save-changes)="saveChanges()"
-                  (person-selected)="personSelected(%event)"
-                  {editable-mode}="editableMode"
-                  {can-unmap}="canEdit"
-                  {is-loading}="isUpdating"
-                  {group-id}="groupId"
-                  {instance}="instance"
-                  {title}="title"
-                  {people}="people">
-                </editable-people-group>
-              {{else}}
-                <deletable-people-group
-                  (unmap)="removePerson(%event)"
-                  {can-unmap}="canEdit"
-                  {is-loading}="isUpdating"
-                  {group-id}="groupId"
-                  {instance}="instance"
-                  {people}="people">
-                  <label class="people-group__title">
-                    {{title}}
-                  </label>
-                </deletable-people-group>
-                <div>
-                  {{#if isUpdating}}
-                    <spinner {toggle}="isUpdating"></spinner>
-                  {{else}}
-                    {{#is_allowed 'update' instance}}
-                      <autocomplete
-                          search-items-type="Person"
-                          (item-selected)="addPerson(%event.selectedItem, @groupId)"
-                          placeholder="Add person">
-                      </autocomplete>
-                    {{/is_allowed}}
-                  {{/if}}
-                </div>
-              {{/if}}
-            </div>
-            </related-people-access-control-group>
-          {{/accessControlGroups}}
-        </div>
-    </related-people-access-control>
-  </div>
+<custom-roles
+  {info-pane-mode}="infoPaneMode"
+  {instance}="instance"
+  {is-new-instance}="new_object_form">
+</custom-roles>

--- a/src/ggrc/assets/mustache/components/custom-roles/custom-roles-modal.mustache
+++ b/src/ggrc/assets/mustache/components/custom-roles/custom-roles-modal.mustache
@@ -1,0 +1,60 @@
+{{!
+    Copyright (C) 2017 Google Inc., authors, and contributors
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+}}
+
+<div class="flex-box">
+  <related-people-access-control
+    class="width-100"
+    {updatable-group-id}="updatableGroupId"
+    {info-pane-mode}="infoPaneMode"
+    {is-new-instance}="isNewInstance"
+    {instance}="instance">
+      <div class="people-groups">
+        {{#groups}}
+          <related-people-access-control-group
+            class="people-group"
+            auto-update="true"
+            (update-roles)="updateRoles(%event)"
+            {required}="required"
+            {group-id}="groupId"
+            {title}="title"
+            {people}="people"
+            {instance}="instance"
+            {updatable-group-id}="updatableGroupId">
+              <div>
+                <deletable-people-group
+                  show-empty-message="false"
+                  {required}="required"
+                  (unmap)="removePerson(%event)"
+                  {can-unmap}="canEdit"
+                  {is-loading}="isLoading"
+                  {group-id}="groupId"
+                  {instance}="instance"
+                  {people}="people">
+                  <label class="people-group__title form-label required-label">
+                    {{title}}
+                    {{#if required}}
+                      <i class="fa fa-asterisk"></i>
+                    {{/if}}
+                  </label>
+                </deletable-people-group>
+                <div>
+                  {{#if isUpdating}}
+                    <spinner {toggle}="isUpdating"></spinner>
+                  {{else}}
+                    {{#is_allowed 'update' instance}}
+                      <autocomplete
+                          search-items-type="Person"
+                          (item-selected)="addPerson(%event.selectedItem, @groupId)"
+                          placeholder="Add person">
+                      </autocomplete>
+                    {{/is_allowed}}
+                  {{/if}}
+                </div>
+              </div>
+          </related-people-access-control-group>
+        {{/groups}}
+      </div>
+  </related-people-access-control>
+</div>

--- a/src/ggrc/assets/mustache/components/custom-roles/custom-roles.mustache
+++ b/src/ggrc/assets/mustache/components/custom-roles/custom-roles.mustache
@@ -1,0 +1,84 @@
+{{!
+  Copyright (C) 2017 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+}}
+{{!
+    Copyright (C) 2017 Google Inc., authors, and contributors
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+}}
+
+<div class="flex-box">
+  <related-people-access-control
+    class="width-100"
+    {info-pane-mode}="infoPaneMode"
+    {is-new-instance}="isNewInstance"
+    {instance}="instance">
+      <div class="people-groups">
+        {{#groups}}
+          <related-people-access-control-group
+            {info-pane-mode}="infoPaneMode"
+            (add-role)="addPerson(%event)"
+            (remove-role)="removePerson(%event)"
+            (save-roles)="saveRoles(%event)"
+            {required}="required"
+            {group-id}="groupId"
+            {title}="title"
+            {people}="people"
+            {instance}="instance"
+            class="people-group"
+            {updatable-group-id}="updatableGroupId"
+          >
+          <div>
+            {{#if infoPaneMode}}
+              <editable-people-group
+                {required}="required"
+                (unmap)="removePerson(%event)"
+                (change-editable-mode)="changeEditableGroup(%event)"
+                (save-changes)="saveChanges()"
+                (person-selected)="personSelected(%event)"
+                {editable-mode}="editableMode"
+                {can-unmap}="canEdit"
+                {can-edit}="canEdit"
+                {is-loading}="isLoading"
+                {group-id}="groupId"
+                {instance}="instance"
+                {title}="title"
+                {people}="people">
+              </editable-people-group>
+            {{else}}
+              <deletable-people-group
+                show-empty-message="false"
+                {required}="required"
+                (unmap)="removePerson(%event)"
+                {can-unmap}="canEdit"
+                {is-loading}="isLoading"
+                {group-id}="groupId"
+                {instance}="instance"
+                {people}="people">
+                <label class="people-group__title form-label required-label">
+                  {{title}}
+                  {{#if required}}
+                    <i class="fa fa-asterisk"></i>
+                  {{/if}}
+                </label>
+              </deletable-people-group>
+              <div>
+                {{#if isUpdating}}
+                  <spinner {toggle}="isUpdating"></spinner>
+                {{else}}
+                  {{#is_allowed 'update' instance}}
+                    <autocomplete
+                        search-items-type="Person"
+                        (item-selected)="addPerson(%event.selectedItem, @groupId)"
+                        placeholder="Add person">
+                    </autocomplete>
+                  {{/is_allowed}}
+                {{/if}}
+              </div>
+            {{/if}}
+          </div>
+          </related-people-access-control-group>
+        {{/groups}}
+      </div>
+  </related-people-access-control>
+</div>

--- a/src/ggrc/assets/mustache/components/custom-roles/custom-roles.mustache
+++ b/src/ggrc/assets/mustache/components/custom-roles/custom-roles.mustache
@@ -1,7 +1,4 @@
-{{!
-  Copyright (C) 2017 Google Inc.
-  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
-}}
+
 {{!
     Copyright (C) 2017 Google Inc., authors, and contributors
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
@@ -10,73 +7,39 @@
 <div class="flex-box">
   <related-people-access-control
     class="width-100"
+    (save-custom-role)="save(%event)"
+    {updatable-group-id}="updatableGroupId"
     {info-pane-mode}="infoPaneMode"
     {is-new-instance}="isNewInstance"
     {instance}="instance">
       <div class="people-groups">
         {{#groups}}
           <related-people-access-control-group
-            {info-pane-mode}="infoPaneMode"
-            (add-role)="addPerson(%event)"
-            (remove-role)="removePerson(%event)"
-            (save-roles)="saveRoles(%event)"
+            class="people-group"
+            (update-roles)="updateRoles(%event)"
             {required}="required"
             {group-id}="groupId"
             {title}="title"
             {people}="people"
             {instance}="instance"
-            class="people-group"
-            {updatable-group-id}="updatableGroupId"
-          >
-          <div>
-            {{#if infoPaneMode}}
-              <editable-people-group
-                {required}="required"
-                (unmap)="removePerson(%event)"
-                (change-editable-mode)="changeEditableGroup(%event)"
-                (save-changes)="saveChanges()"
-                (person-selected)="personSelected(%event)"
-                {editable-mode}="editableMode"
-                {can-unmap}="canEdit"
-                {can-edit}="canEdit"
-                {is-loading}="isLoading"
-                {group-id}="groupId"
-                {instance}="instance"
-                {title}="title"
-                {people}="people">
-              </editable-people-group>
-            {{else}}
-              <deletable-people-group
-                show-empty-message="false"
-                {required}="required"
-                (unmap)="removePerson(%event)"
-                {can-unmap}="canEdit"
-                {is-loading}="isLoading"
-                {group-id}="groupId"
-                {instance}="instance"
-                {people}="people">
-                <label class="people-group__title form-label required-label">
-                  {{title}}
-                  {{#if required}}
-                    <i class="fa fa-asterisk"></i>
-                  {{/if}}
-                </label>
-              </deletable-people-group>
+            {updatable-group-id}="updatableGroupId">
               <div>
-                {{#if isUpdating}}
-                  <spinner {toggle}="isUpdating"></spinner>
-                {{else}}
-                  {{#is_allowed 'update' instance}}
-                    <autocomplete
-                        search-items-type="Person"
-                        (item-selected)="addPerson(%event.selectedItem, @groupId)"
-                        placeholder="Add person">
-                    </autocomplete>
-                  {{/is_allowed}}
-                {{/if}}
+                  <editable-people-group
+                    {required}="required"
+                    (unmap)="removePerson(%event)"
+                    (change-editable-mode)="changeEditableGroup(%event)"
+                    (save-changes)="saveChanges()"
+                    (person-selected)="personSelected(%event)"
+                    {editable-mode}="editableMode"
+                    {can-unmap}="canEdit"
+                    {can-edit}="canEdit"
+                    {is-loading}="isLoading"
+                    {group-id}="groupId"
+                    {instance}="instance"
+                    {title}="title"
+                    {people}="people">
+                  </editable-people-group>
               </div>
-            {{/if}}
-          </div>
           </related-people-access-control-group>
         {{/groups}}
       </div>

--- a/src/ggrc/assets/mustache/components/people/deletable-people-group.mustache
+++ b/src/ggrc/assets/mustache/components/people/deletable-people-group.mustache
@@ -8,7 +8,7 @@
 
   <div class="people-list">
     <object-list ({items})="people" {empty-message}="emptyListMessage" {is-disabled}="isLoading">
-      <div class="deletable-people-group__person action-toolbar">
+      <div class="action-toolbar {{#unless canUnmap}}people-group__readonly-person{{/unless}}">
         <person-list-item person="{.}" {with-details}="withDetails">
           {{#unless isDisabled}}
             {{#unmapablePerson}}

--- a/src/ggrc/assets/mustache/components/people/editable-people-group.mustache
+++ b/src/ggrc/assets/mustache/components/people/editable-people-group.mustache
@@ -11,16 +11,18 @@
     {{/unless}}
     {{title}}
   </span>
-  {{#if required}}
-    <form-validation-icon {validation}="validation"></form-validation-icon>
+  {{#if canEdit}}
+    {{#if required}}
+      <i class="fa fa-asterisk"></i>
+    {{/if}}
+    {{#unless editableMode}}
+      <div class="action-toolbar__controls">
+        <action-toolbar-control>
+          <i class="fa fa-pencil set-editable-group"></i>
+        </action-toolbar-control>
+      </div>
+    {{/unless}}
   {{/if}}
-  {{#unless editableMode}}
-    <div class="action-toolbar__controls">
-      <action-toolbar-control>
-        <i class="fa fa-pencil set-editable-group"></i>
-      </action-toolbar-control>
-    </div>
-  {{/unless}}
 </label>
 {{#unless editableMode}}
   <object-list ({items})="people" {empty-message}="emptyListMessage">

--- a/src/ggrc/assets/stylesheets/components/people-group/_people-group.scss
+++ b/src/ggrc/assets/stylesheets/components/people-group/_people-group.scss
@@ -44,6 +44,10 @@
       margin-bottom: 3px;
     }
 
+    .people-group__readonly-person {
+      line-height: 22px;
+    }
+
     .person-name {
       overflow: hidden;
       white-space: nowrap;

--- a/src/ggrc/assets/stylesheets/components/unified-mapper/_unified-mapper.scss
+++ b/src/ggrc/assets/stylesheets/components/unified-mapper/_unified-mapper.scss
@@ -116,8 +116,8 @@ mapper-results {
       }
     }
 
-    object-list {
-      .object-list__item {
+    > object-list {
+      > .object-list__item {
         color: $black;
         border-bottom: 1px solid $items-separator-color;
 
@@ -132,7 +132,7 @@ mapper-results {
         }
       }
 
-      .object-list__item:first-child,
+      > .object-list__item:first-child,
       spinner + .object-list__item {
         border-top: 1px solid $items-separator-color;
       }


### PR DESCRIPTION
**Steps to reproduce**:
1. Have audit with created assessment
2. Go to Assessment info page and invoke Edit assessment modal widow
3. Add to PRIMARY CONTACTS/SECONDARY CONTACTS/ASSESSMENT ROLE people - at least two people for each field> Save
4. Ensure that all people are displayed in People list on Assessment Info pane correctly
5. Invoke Edit assessment modal widow again and remove some people from PRIMARY CONTACTS/SECONDARY CONTACTS/ASSESSMENT ROLE fields by clicking trash icon
6. Add more Assignees to Assessment (at least 2 new assignees) and look at the PRIMARY CONTACTS/SECONDARY CONTACTS/ASSESSMENT ROLE fields: people that have been deleted appeared

_Actual Result_: Person in PRIMARY CONTACTS/SECONDARY CONTACTS/ASSESSMENT ROLE fields are displayed randomly again after removal in Edit Assessment modal window
_Expected Result_: Person in PRIMARY CONTACTS/SECONDARY CONTACTS/ASSESSMENT ROLE fields should not displayed randomly again after removal in Edit Assessment modal window

![screenshot-3](https://user-images.githubusercontent.com/4204416/27951551-05176d4e-630e-11e7-9f3b-1e285d0e8e45.png)
