### PR TITLE
QUICK-FIX GGRC-2446 People in PRIMARY CONTACTS/SECONDARY CONTACTS/ASSESSMENT ROLE fields are displayed randomly again after removal in Edit Assessment modal window

### DIFF
--- a/src/ggrc/assets/javascripts/components/related-objects/related-people-mapping.js
+++ b/src/ggrc/assets/javascripts/components/related-objects/related-people-mapping.js
@@ -41,10 +41,9 @@
         }
       },
       changeEditableGroup: function (args) {
-        var isAddEditableGroup = args.isAddEditableGroup;
         var pendingJoins = this.attr('instance._pending_joins');
 
-        if (isAddEditableGroup) {
+        if (args.editableMode) {
           this.attr('editableMode', true);
           this.attr('backUpPendings').replace(pendingJoins);
         } else {


### PR DESCRIPTION
Quick fix of #5898 PR