### PR TITLE
GGRC-2508 GGRC-1486 Front-end: Make the values in "Categories" and "Assertions" fields to be displayed in Comparison window

### DIFF
--- a/src/ggrc/assets/javascripts/models/control.js
+++ b/src/ggrc/assets/javascripts/models/control.js
@@ -24,8 +24,6 @@
       object_people: 'CMS.Models.ObjectPerson.stubs',
       documents: 'CMS.Models.Document.stubs',
       people: 'CMS.Models.Person.stubs',
-      categories: 'CMS.Models.ControlCategory.stubs',
-      assertions: 'CMS.Models.ControlAssertion.stubs',
       objectives: 'CMS.Models.Objective.stubs',
       directive: 'CMS.Models.Directive.stub',
       audit_objects: 'CMS.Models.AuditObject.stubs',

--- a/src/ggrc/assets/mustache/controls/info.mustache
+++ b/src/ggrc/assets/mustache/controls/info.mustache
@@ -154,31 +154,51 @@
           <div class="row-fluid wrap-row">
             <div class="span8">
               <h6>Assertions</h6>
-              {{#using items=assertions}}
               {{#if assertions}}
-                <ul>
-                  {{#items}}
-                    <li>{{name}}</li>
-                  {{/items}}
-                </ul>
+                {{#if_helpers '\
+                 #if' instance.snapshot '\
+                 or #if' instance.isRevision}}
+                  <ul>
+                    {{#assertions}}
+                      <li>{{display_name}}</li>
+                    {{/assertions}}
+                  </ul>
+                {{else}}
+                  {{#using items=assertions}}
+                    <ul>
+                      {{#items}}
+                        <li>{{display_name}}</li>
+                      {{/items}}
+                    </ul>
+                  {{/using}}
+                {{/if_helpers}}
               {{else}}
                 <span class="empty-message">None</span>
               {{/if}}
-              {{/using}}
             </div>
             <div class="span4">
               <h6>Categories</h6>
-              {{#using items=categories}}
               {{#if categories}}
-                <ul>
-                  {{#items}}
-                    <li>{{name}}</li>
-                  {{/items}}
-                </ul>
+                {{#if_helpers '\
+                 #if' instance.snapshot '\
+                 or #if' instance.isRevision}}
+                  <ul>
+                    {{#categories}}
+                      <li>{{display_name}}</li>
+                    {{/categories}}
+                  </ul>
+                {{else}}
+                  {{#using items=categories}}
+                    <ul>
+                      {{#items}}
+                        <li>{{display_name}}</li>
+                      {{/items}}
+                    </ul>
+                  {{/using}}
+                {{/if_helpers}}
               {{else}}
                 <span class="empty-message">None</span>
               {{/if}}
-              {{/using}}
             </div>
           </div>
         </div>

--- a/src/ggrc/assets/mustache/controls/tree-item-attr.mustache
+++ b/src/ggrc/assets/mustache/controls/tree-item-attr.mustache
@@ -62,18 +62,30 @@
     {{/using}}
   {{/case}}
   {{#case 'assertions'}}
-    {{#using items=instance.assertions}}
-      {{#items}}
-        {{name}} &nbsp;
-      {{/items}}
-    {{/using}}
+    {{#if instance.snapshot}}
+      {{#instance.assertions}}
+        <span class="with-comma">{{display_name}}</span>
+      {{/instance.assertions}}
+    {{else}}
+      {{#using items=instance.assertions}}
+        {{#items}}
+          <span class="with-comma">{{display_name}}</span>
+        {{/items}}
+      {{/using}}
+    {{/if}}
   {{/case}}
   {{#case 'categories'}}
-    {{#using items=instance.categories}}
-      {{#items}}
-        {{name}} &nbsp;
-      {{/items}}
-    {{/using}}
+    {{#if instance.snapshot}}
+      {{#instance.categories}}
+        <span class="with-comma">{{display_name}}</span>
+      {{/instance.categories}}
+    {{else}}
+      {{#using items=instance.categories}}
+        {{#items}}
+          <span class="with-comma">{{display_name}}</span>
+        {{/items}}
+      {{/using}}
+    {{/if}}
   {{/case}}
   {{#case 'last_assessment_date'}}
     {{#if instance.snapshot}}

--- a/src/ggrc/assets/stylesheets/components/tree/_tree-view.scss
+++ b/src/ggrc/assets/stylesheets/components/tree/_tree-view.scss
@@ -198,6 +198,12 @@ tree-item {
             margin-bottom: 0;
           }
         }
+        .with-comma::after {
+          content: ', ';
+        }
+        .with-comma:last-child::after {
+          content: '';
+        }
       }
     }
   }

--- a/src/ggrc/assets/stylesheets/modules/_modal.scss
+++ b/src/ggrc/assets/stylesheets/modules/_modal.scss
@@ -716,6 +716,10 @@
            margin-bottom: 0;
          }
        }
+       ul.diff-highlighted {
+         margin: 0;
+         padding: 0 0 0 30px;
+       }
        .diff-highlighted{
          display: block;
          width: 100%;
@@ -751,6 +755,7 @@
            .span3,
            .span4,
            .span6,
+           .span8,
            .span9,
            .span12{
              margin-left: 0;


### PR DESCRIPTION
**GGRC-1486** 
Add categories and assertions in compare modal of control-revisions


**GGRC-2508**
When getting info about Control Snapshot front-end goes for revision data, then does two requests for assertions and categories. Which are obsolete and wrong, since this data is already stored in revision content.

Relates to: https://github.com/google/ggrc-core/pull/5879