### PR TITLE
GGRC-2111: Improve Performance of Assessment Model Save operation 

### DIFF
--- a/src/ggrc/models/custom_attribute_value.py
+++ b/src/ggrc/models/custom_attribute_value.py
@@ -16,7 +16,6 @@ from ggrc import db
 from ggrc.models.mixins import Base
 from ggrc.models.reflection import PublishOnly
 from ggrc.models.revision import Revision
-from ggrc.models.object_document import Documentable
 from ggrc import utils
 from ggrc.fulltext.mixin import Indexed
 from ggrc.fulltext import get_indexer
@@ -332,7 +331,7 @@ class CustomAttributeValue(Base, Indexed, db.Model):
       if flags.comment_required:
         failed_preconditions += self._check_mandatory_comment()
       if flags.evidence_required:
-        failed_preconditions += self._check_mandatory_evidence()
+        failed_preconditions += self.attributable.check_mandatory_evidence()
     return failed_preconditions
 
   def _check_mandatory_comment(self):
@@ -348,28 +347,6 @@ class CustomAttributeValue(Base, Indexed, db.Model):
       comment_found = False
     if not comment_found:
       return ["comment"]
-    else:
-      return []
-
-  def _check_mandatory_evidence(self):
-    """Check presence of mandatory evidence."""
-    if isinstance(self.attributable, Documentable):
-      # Note: this is a suboptimal implementation of mandatory evidence check;
-      # it should be refactored once Evicence-CA mapping is introduced
-      def evidence_required(cav):
-        """Return True if an evidence is required for this `cav`."""
-        flags = (self._multi_choice_options_to_flags(cav.custom_attribute)
-                 .get(cav.attribute_value))
-        return flags and flags.evidence_required
-      evidence_found = (len(self.attributable.document_evidence) >=
-                        len([cav
-                             for cav in self.attributable
-                                            .custom_attribute_values
-                             if evidence_required(cav)]))
-    else:
-      evidence_found = False
-    if not evidence_found:
-      return ["evidence"]
     else:
       return []
 

--- a/src/ggrc/models/document.py
+++ b/src/ggrc/models/document.py
@@ -25,9 +25,10 @@ class Document(Ownable, Relatable, Base, Indexed, db.Model):
   title = deferred(db.Column(db.String), 'Document')
   link = deferred(db.Column(db.String), 'Document')
   description = deferred(db.Column(db.Text), 'Document')
-  kind_id = deferred(db.Column(db.Integer), 'Document')
-  year_id = deferred(db.Column(db.Integer), 'Document')
-  language_id = deferred(db.Column(db.Integer), 'Document')
+  kind_id = db.Column(db.Integer, db.ForeignKey('options.id'), nullable=True)
+  year_id = db.Column(db.Integer, db.ForeignKey('options.id'), nullable=True)
+  language_id = db.Column(db.Integer, db.ForeignKey('options.id'),
+                          nullable=True)
 
   URL = "URL"
   ATTACHMENT = "EVIDENCE"
@@ -41,18 +42,21 @@ class Document(Ownable, Relatable, Base, Indexed, db.Model):
       primaryjoin='and_(foreign(Document.kind_id) == Option.id, '
       'Option.role == "reference_type")',
       uselist=False,
+      lazy="joined",
   )
   year = db.relationship(
       'Option',
       primaryjoin='and_(foreign(Document.year_id) == Option.id, '
       'Option.role == "document_year")',
       uselist=False,
+      lazy="joined",
   )
   language = db.relationship(
       'Option',
       primaryjoin='and_(foreign(Document.language_id) == Option.id, '
       'Option.role == "language")',
       uselist=False,
+      lazy="joined",
   )
 
   _fulltext_attrs = [

--- a/src/ggrc/models/issue.py
+++ b/src/ggrc/models/issue.py
@@ -39,4 +39,4 @@ class Issue(Roleable, HasObjectState, TestPlanned, CustomAttributable,
 
   audit_id = deferred(
       db.Column(db.Integer, db.ForeignKey('audits.id'), nullable=False),
-      'Assessment')
+      'Issue')

--- a/src/ggrc/models/mixins/customattributable.py
+++ b/src/ggrc/models/mixins/customattributable.py
@@ -473,7 +473,12 @@ class CustomAttributable(object):
 
   @builder.simple_property
   def preconditions_failed(self):
-    """Returns True if any mandatory CAV, comment or evidence is missing."""
+    """Returns True if any mandatory CAV, comment or evidence is missing.
+
+    Note: return value may be incorrect if evidence count is changed
+    after the first property calculation (see check_mandatory_evidence
+    function).
+    """
     values_map = {
         cav.custom_attribute_id or cav.custom_attribute.id: cav
         for cav in self.custom_attribute_values
@@ -490,6 +495,7 @@ class CustomAttributable(object):
 
   def check_mandatory_evidence(self):
     """Check presence of mandatory evidence.
+
     Note:  mandatory evidence precondition is checked only once.
     Any additional changes to evidences after the first checking
     of the precondition will cause incorrect result of the function.

--- a/test/integration/ggrc/models/mixins/test_customattributable_preconditions_failed.py
+++ b/test/integration/ggrc/models/mixins/test_customattributable_preconditions_failed.py
@@ -270,7 +270,7 @@ class TestPreconditionsFailed(TestCase):
 
     self.assertEqual(preconditions_failed, True)
 
-  def test_preconditions_failed_with_several_mandatory_evidences(self):
+  def test_preconditions_failed_with_missing_several_mandatory_evidences(self):
     """Preconditions failed if count(evidences) < count(evidences_required)."""
     ca1 = CustomAttributeMock(
         self.assessment,
@@ -298,6 +298,29 @@ class TestPreconditionsFailed(TestCase):
     self.assertEqual(preconditions_failed, True)
     self.assertEqual(ca1.value.preconditions_failed, ["evidence"])
     self.assertEqual(ca2.value.preconditions_failed, ["evidence"])
+
+  def test_preconditions_failed_with_several_mandatory_evidences(self):
+    """No preconditions failed if evidences required by CAs are present"""
+    ca1 = CustomAttributeMock(
+        self.assessment,
+        attribute_type="Dropdown",
+        dropdown_parameters=("foo,evidence_required", "0,2"),
+        value="evidence_required"
+    )
+    ca2 = CustomAttributeMock(
+        self.assessment,
+        attribute_type="Dropdown",
+        dropdown_parameters=("foo,evidence_required", "0,2"),
+        value="evidence_required"
+    )
+    # only one evidence provided yet
+    evidence = factories.EvidenceFactory(
+        title="Mandatory evidence",
+    )
+    factories.RelationshipFactory(
+        source=self.assessment,
+        destination=evidence,
+    )
 
     # the second evidence
     evidence = factories.EvidenceFactory(


### PR DESCRIPTION
Performance of 'PUT' request is improved. This PR mostly focuses on improvement of save operation for assessments with custom attributes (especially with comments and evidences)  as reported performance issues are usually reproduced on such type of assessments.
Performance tests:
Assessment with 600 custom attributes (100 of each type):
Before: put 23.39s
After: put 3.75s