### PR TITLE
GGRC-2465 Make sure we don't lose track of automappings

### DIFF
--- a/src/ggrc/automapper/__init__.py
+++ b/src/ggrc/automapper/__init__.py
@@ -11,6 +11,7 @@ from ggrc import db
 from ggrc import models
 from ggrc.automapper.rules import rules
 from ggrc.login import get_current_user
+from ggrc.models.automapping import Automapping
 from ggrc.models.relationship import Relationship
 from ggrc.models.comment import Commentable
 from ggrc.models.mixins import ChangeTracked
@@ -143,6 +144,8 @@ class AutomapperGenerator(object):
       return
     with self.benchmark("Automapping flush"):
       current_user = get_current_user()
+      automapping = Automapping(parent_relationship)
+      db.session.add(automapping)
       db.session.flush()
       now = datetime.now()
       # We are doing an INSERT IGNORE INTO here to mitigate a race condition
@@ -164,7 +167,8 @@ class AutomapperGenerator(object):
           "destination_type": dst.type,
           "context_id": None,
           "status": None,
-          "parent_id": parent_relationship.id}
+          "parent_id": parent_relationship.id,
+          "automapping_id": automapping.id}
           for src, dst in self.auto_mappings
           if (src, dst) != original]))  # (src, dst) is sorted
       cache = get_cache(create=True)

--- a/src/ggrc/automapper/__init__.py
+++ b/src/ggrc/automapper/__init__.py
@@ -164,7 +164,7 @@ class AutomapperGenerator(object):
           "destination_type": dst.type,
           "context_id": None,
           "status": None,
-          "automapping_id": parent_relationship.id}
+          "parent_id": parent_relationship.id}
           for src, dst in self.auto_mappings
           if (src, dst) != original]))  # (src, dst) is sorted
       cache = get_cache(create=True)
@@ -175,7 +175,7 @@ class AutomapperGenerator(object):
         cache.new.update(
             (relationship, relationship.log_json())
             for relationship in Relationship.query.filter_by(
-                automapping_id=parent_relationship.id,
+                parent_id=parent_relationship.id,
                 modified_by_id=current_user.id,
                 created_at=now,
                 updated_at=now,

--- a/src/ggrc/migrations/versions/20170710092621_2ada007df3ee_add_automappings_table.py
+++ b/src/ggrc/migrations/versions/20170710092621_2ada007df3ee_add_automappings_table.py
@@ -15,7 +15,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '2ada007df3ee'
-down_revision = '436dc4cea0f3'
+down_revision = '1e3f798a4cc6'
 
 
 def upgrade():
@@ -54,6 +54,14 @@ def upgrade():
                   ['context_id'], unique=False)
   op.create_index('ix_automappings_updated_at', 'automappings',
                   ['updated_at'], unique=False)
+  op.add_column(
+      'relationships',
+      sa.Column('automapping_id', sa.Integer(), nullable=True))
+  op.create_foreign_key(
+      "fk_relationships_automapping_id",
+      "relationships", "automappings",
+      ["automapping_id"], ["id"],
+      ondelete='CASCADE')
 
 
 def downgrade():
@@ -65,7 +73,10 @@ def downgrade():
 
   # Rename parent id to automapping id
   op.drop_constraint(
+      'fk_relationship_automapping_id', 'relationships', type_='foreignkey')
+  op.drop_constraint(
       'fk_relationship_parent_id', 'relationships', type_='foreignkey')
+  op.drop_column('relationships', 'automapping_id')
   op.alter_column(
       'relationships',
       'parent_id',

--- a/src/ggrc/migrations/versions/20170710092621_2ada007df3ee_add_automappings_table.py
+++ b/src/ggrc/migrations/versions/20170710092621_2ada007df3ee_add_automappings_table.py
@@ -1,0 +1,52 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Add automappings table
+
+Create Date: 2017-07-10 09:26:21.778041
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '2ada007df3ee'
+down_revision = '436dc4cea0f3'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  # Rename automapping_id to parent_id
+  op.drop_constraint(
+      'relationships_automapping_parent', 'relationships', type_='foreignkey')
+  op.alter_column(
+      'relationships',
+      'automapping_id',
+      existing_type=sa.Integer(),
+      new_column_name='parent_id')
+  op.create_foreign_key(
+      "fk_relationships_parent_id",
+      "relationships", "relationships",
+      ["parent_id"], ["id"],
+      ondelete='SET NULL')
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  # Rename parent id to automapping id
+  op.drop_constraint(
+      'fk_relationship_parent_id', 'relationships', type_='foreignkey')
+  op.alter_column(
+      'relationships',
+      'parent_id',
+      existing_type=sa.Integer(),
+      new_column_name='automapping_id')
+  op.create_foreign_key(
+      "relationships_automapping_parent",
+      "relationships", "relationships",
+      ["automapping_id"], ["id"],
+      ondelete='SET NULL')

--- a/src/ggrc/migrations/versions/20170710092621_2ada007df3ee_add_automappings_table.py
+++ b/src/ggrc/migrations/versions/20170710092621_2ada007df3ee_add_automappings_table.py
@@ -34,9 +34,35 @@ def upgrade():
       ["parent_id"], ["id"],
       ondelete='SET NULL')
 
+  # Create the automappings table
+  op.create_table(
+      'automappings',
+      sa.Column('id', sa.Integer(), nullable=False),
+      sa.Column('relationship_id', sa.Integer(), nullable=True),
+      sa.Column('source_id', sa.Integer(), nullable=False),
+      sa.Column('source_type', sa.String(length=250), nullable=False),
+      sa.Column('destination_id', sa.Integer(), nullable=False),
+      sa.Column('destination_type', sa.String(length=250), nullable=False),
+      sa.Column('created_at', sa.DateTime(), nullable=False),
+      sa.Column('modified_by_id', sa.Integer(), nullable=True),
+      sa.Column('updated_at', sa.DateTime(), nullable=False),
+      sa.Column('context_id', sa.Integer(), nullable=True),
+      sa.ForeignKeyConstraint(['context_id'], ['contexts.id'], ),
+      sa.PrimaryKeyConstraint('id')
+  )
+  op.create_index('fk_automappings_contexts', 'automappings',
+                  ['context_id'], unique=False)
+  op.create_index('ix_automappings_updated_at', 'automappings',
+                  ['updated_at'], unique=False)
+
 
 def downgrade():
   """Downgrade database schema and/or data back to the previous revision."""
+  # Drop automappings table
+  op.drop_index('ix_automappings_updated_at', table_name='automappings')
+  op.drop_index('fk_automappings_contexts', table_name='automappings')
+  op.drop_table('automappings')
+
   # Rename parent id to automapping id
   op.drop_constraint(
       'fk_relationship_parent_id', 'relationships', type_='foreignkey')

--- a/src/ggrc/migrations/versions/20170710092621_2ada007df3ee_add_automappings_table.py
+++ b/src/ggrc/migrations/versions/20170710092621_2ada007df3ee_add_automappings_table.py
@@ -15,7 +15,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '2ada007df3ee'
-down_revision = '1e3f798a4cc6'
+down_revision = '51d5958779f1'
 
 
 def upgrade():

--- a/src/ggrc/models/all_models.py
+++ b/src/ggrc/models/all_models.py
@@ -20,6 +20,7 @@ from ggrc.models.assessment import Assessment
 from ggrc.models.assessment_template import AssessmentTemplate
 from ggrc.models.audit import Audit
 from ggrc.models.audit_object import AuditObject
+from ggrc.models.automapping import Automapping
 from ggrc.models.background_task import BackgroundTask
 from ggrc.models.categorization import Categorization
 from ggrc.models.category import CategoryBase
@@ -83,6 +84,7 @@ all_models = [  # pylint: disable=invalid-name
     AssessmentTemplate,
     Audit,
     AuditObject,
+    Automapping,
     Categorization,
     CategoryBase,
     ControlCategory,

--- a/src/ggrc/models/automapping.py
+++ b/src/ggrc/models/automapping.py
@@ -25,3 +25,10 @@ class Automapping(Base, db.Model):
   source_type = db.Column(db.String, nullable=False)
   destination_id = db.Column(db.Integer, nullable=False)
   destination_type = db.Column(db.String, nullable=False)
+
+  def __init__(self, parent):
+    """Automapping helper"""
+    self.source_id = parent.source_id
+    self.source_type = parent.source_type
+    self.destination_type = parent.destination_type
+    self.destination_id = parent.destination_id

--- a/src/ggrc/models/automapping.py
+++ b/src/ggrc/models/automapping.py
@@ -1,0 +1,27 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Automapping model"""
+
+from ggrc import db
+from ggrc.models.mixins import Base
+
+
+class Automapping(Base, db.Model):
+  """Automapping class
+
+     Used to track which relationship objects were created by an
+     automapping even if the base relationship was deleted.
+  """
+  __tablename__ = 'automappings'
+  # relationship_id cannot be a foreign key because of a circular dependency
+  relationship_id = db.Column(
+      db.Integer,
+      nullable=True
+  )
+  # The fields below are in there in case the original releationship gets
+  # deleted
+  source_id = db.Column(db.Integer, nullable=False)
+  source_type = db.Column(db.String, nullable=False)
+  destination_id = db.Column(db.Integer, nullable=False)
+  destination_type = db.Column(db.String, nullable=False)

--- a/src/ggrc/models/relationship.py
+++ b/src/ggrc/models/relationship.py
@@ -21,12 +21,12 @@ class Relationship(Base, db.Model):
   source_type = db.Column(db.String, nullable=False)
   destination_id = db.Column(db.Integer, nullable=False)
   destination_type = db.Column(db.String, nullable=False)
-  automapping_id = db.Column(
+  parent_id = db.Column(
       db.Integer,
       db.ForeignKey('relationships.id', ondelete='SET NULL'),
       nullable=True,
   )
-  automapping = db.relationship(
+  parent = db.relationship(
       lambda: Relationship,
       remote_side=lambda: Relationship.id
   )

--- a/src/ggrc/models/relationship.py
+++ b/src/ggrc/models/relationship.py
@@ -30,6 +30,11 @@ class Relationship(Base, db.Model):
       lambda: Relationship,
       remote_side=lambda: Relationship.id
   )
+  automapping_id = db.Column(
+      db.Integer,
+      db.ForeignKey('automappings.id', ondelete='CASCADE'),
+      nullable=True,
+  )
   relationship_attrs = db.relationship(
       lambda: RelationshipAttr,
       collection_class=attribute_mapped_collection("attr_name"),

--- a/src/ggrc/models/snapshot.py
+++ b/src/ggrc/models/snapshot.py
@@ -298,7 +298,7 @@ def _insert_program_relationships(relationship_stubs):
               "destination_id": relationship_stub.destination_id,
               "context_id": None,
               "status": None,
-              "automapping_id": None
+              "parent_id": None
           }
           for relationship_stub in relationship_stubs
       ])

--- a/src/ggrc/snapshotter/helpers.py
+++ b/src/ggrc/snapshotter/helpers.py
@@ -221,7 +221,7 @@ def create_relationship_revision_dict(action, event_id, relationship,  # noqa # 
           relationship.destination_id
       ),
       "modified_by": create_json_stub("Person", context_id, user_id),
-      "automapping_id": None,
+      "parent_id": None,
       "attrs": {}
   }
   revision_content.update(metadata)


### PR DESCRIPTION
When deleting a relationship that caused automappings the automapped relationship's automapping_id is set to NULL which means that we lose the information if the relationship was automapped. This PR will fix this by adding a new automappings table that will hold this information even when the parent relationship is deleted.

- [x] Rename automapping_id to parent_id.
- [x] Create the automappings table 
- [x] Create an automapping_id foreign key in relationship.
- [x] Populate the automapping table (migration)
- [x] Make sure automappings table is populated correctly and that the data is preserved when the parent relationship is deleted.