### PR TITLE
GGRC-2369 Custom roles should be able to be mandatory and non-editable

### DIFF
--- a/src/ggrc/assets/mustache/access_control_roles/subtree.mustache
+++ b/src/ggrc/assets/mustache/access_control_roles/subtree.mustache
@@ -15,19 +15,23 @@
   <td>
     <ul class="tree-action-list">
       <li>
-        <a
-          href="javascript://"
-          data-toggle="modal-ajax-form"
-          data-modal-reset="reset"
-          data-object-singular="{{class.model_singular}}"
-          data-object-plural="{{class.table_plural}}"
-          data-object-id="{{id}}"
-          data-object-params='{
-            "parent_type": "{{parent_instance.model_singular}}"
-          }'>
-          <i class="fa fa-pencil-square-o"></i>
-          Edit
-        </a>
+        {{#if non_editable}}
+          <span>Predefined</span>
+        {{else}}
+          <a
+            href="javascript://"
+            data-toggle="modal-ajax-form"
+            data-modal-reset="reset"
+            data-object-singular="{{class.model_singular}}"
+            data-object-plural="{{class.table_plural}}"
+            data-object-id="{{id}}"
+            data-object-params='{
+              "parent_type": "{{parent_instance.model_singular}}"
+            }'>
+            <i class="fa fa-pencil-square-o"></i>
+            Edit
+          </a>
+        {{/if}}
       </li>
     </ul>
   </td>


### PR DESCRIPTION
**ACCEPTANCE CRITERIA**
AC1. Admin as custom role should be by default in Admin Dashboard:
- mandatory;
- non-editable.

This PR contains commit from #5745 (return "mandatory" property from server)