### PR TITLE
GGRC-2446 People in PRIMARY CONTACTS/SECONDARY CONTACTS/ASSESSMENT ROLE fields are displayed randomly again after removal in Edit Assessment modal window

### DIFF
--- a/src/ggrc/assets/javascripts/components/related-objects/related-people-mapping.js
+++ b/src/ggrc/assets/javascripts/components/related-objects/related-people-mapping.js
@@ -390,7 +390,7 @@
         var rolesDfd = $.Deferred();
 
         CMS.Models.Relationship
-          .getRelationshipBetweenInstances(person, instance, instance.isNew())
+          .getRelationshipBetweenInstances(person, instance, true)
           .done(function (relationships) {
             var found = false;
             _.map(relationships, function (relationship) {


### PR DESCRIPTION
_Steps to reproduce:_
1. Have audit with created assessment
2. Go to Assessment info page and invoke Edit assessment modal widow
3. Add to PRIMARY CONTACTS/SECONDARY CONTACTS/ASSESSMENT ROLE people - at least two people for each field> Save
4. Ensure that all people are displayed in People list on Assessment Info pane correctly
5. Invoke Edit assessment modal widow again and remove some people from PRIMARY CONTACTS/SECONDARY CONTACTS/ASSESSMENT ROLE fields by clicking trash icon
6. Add more Assignees to Assessment (at least 2 new assignees) and look at the PRIMARY CONTACTS/SECONDARY CONTACTS/ASSESSMENT ROLE fields: people that have been deleted appeared

_Actual Result_: Person in PRIMARY CONTACTS/SECONDARY CONTACTS/ASSESSMENT ROLE fields are displayed randomly again after removal in Edit Assessment modal window
_Expected Result_: Person in PRIMARY CONTACTS/SECONDARY CONTACTS/ASSESSMENT ROLE fields should not displayed randomly again after removal in Edit Assessment modal window