### PR TITLE
GGRC-2725 Moved to history cycle if status is in inactive_state

### DIFF
--- a/src/ggrc_workflows/__init__.py
+++ b/src/ggrc_workflows/__init__.py
@@ -82,14 +82,11 @@ def contributed_object_views():
   ]
 
 
-DONE_STATUSES = ("Verified",)
-
-
-def _get_min_next_due_date(due_dated_objects, exclude_statuses=DONE_STATUSES):
+def _get_min_next_due_date(due_dated_objects):
   next_due_date = None
 
   for obj in due_dated_objects:
-    if obj.status not in exclude_statuses:
+    if obj.status not in obj.inactive_states:
       obj_next_due_date = obj.next_due_date
       if isinstance(obj_next_due_date, datetime):
         obj_next_due_date = obj_next_due_date.date()
@@ -100,11 +97,10 @@ def _get_min_next_due_date(due_dated_objects, exclude_statuses=DONE_STATUSES):
   return next_due_date
 
 
-def _get_min_end_date(timeboxed_objects, exclude_statuses=DONE_STATUSES):
+def _get_min_end_date(timeboxed_objects):
   end_date = None
-
   for obj in timeboxed_objects:
-    if obj.status not in exclude_statuses:
+    if obj.status not in obj.inactive_states:
       obj_end_date = obj.end_date
       if isinstance(obj_end_date, datetime):
         obj_end_date = obj_end_date.date()

--- a/src/ggrc_workflows/__init__.py
+++ b/src/ggrc_workflows/__init__.py
@@ -86,7 +86,7 @@ def _get_min_next_due_date(due_dated_objects):
   next_due_date = None
 
   for obj in due_dated_objects:
-    if obj.status not in obj.inactive_states:
+    if not obj.is_done:
       obj_next_due_date = obj.next_due_date
       if isinstance(obj_next_due_date, datetime):
         obj_next_due_date = obj_next_due_date.date()
@@ -100,7 +100,7 @@ def _get_min_next_due_date(due_dated_objects):
 def _get_min_end_date(timeboxed_objects):
   end_date = None
   for obj in timeboxed_objects:
-    if obj.status not in obj.inactive_states:
+    if not obj.is_done:
       obj_end_date = obj.end_date
       if isinstance(obj_end_date, datetime):
         obj_end_date = obj_end_date.date()
@@ -672,7 +672,7 @@ def handle_cycle_task_entry_post(
 def handle_cycle_status_change(sender, obj=None, new_status=None,  # noqa pylint: disable=unused-argument
                                old_status=None):  # noqa pylint: disable=unused-argument  # noqa pylint: disable=unused-argument
   if inspect(obj).attrs.status.history.has_changes():
-    if obj.status in obj.inactive_states:
+    if obj.is_done:
       obj.is_current = False
       db.session.add(obj)
       update_workflow_state(obj.workflow)

--- a/src/ggrc_workflows/__init__.py
+++ b/src/ggrc_workflows/__init__.py
@@ -664,7 +664,7 @@ def handle_cycle_task_entry_post(
         sender, obj=None, src=None, service=None):  # noqa pylint: disable=unused-argument
   if src['is_declining_review'] == '1':
     task = obj.cycle_task_group_object_task
-    task.status = 'Declined'
+    task.status = task.DECLINED
     db.session.add(obj)
   else:
     src['is_declining_review'] = 0
@@ -676,7 +676,7 @@ def handle_cycle_task_entry_post(
 def handle_cycle_status_change(sender, obj=None, new_status=None,  # noqa pylint: disable=unused-argument
                                old_status=None):  # noqa pylint: disable=unused-argument  # noqa pylint: disable=unused-argument
   if inspect(obj).attrs.status.history.has_changes():
-    if obj.status == 'Verified':
+    if obj.status in obj.inactive_states:
       obj.is_current = False
       db.session.add(obj)
       update_workflow_state(obj.workflow)
@@ -686,9 +686,9 @@ def handle_cycle_status_change(sender, obj=None, new_status=None,  # noqa pylint
 def handle_cycle_task_status_change(sender, obj=None, new_status=None,  # noqa pylint: disable=unused-argument
                                     old_status=None):  # noqa pylint: disable=unused-argument
   if inspect(obj).attrs.status.history.has_changes():
-    if new_status == 'Verified':
+    if new_status == obj.VERIFIED:
       obj.verified_date = datetime.now()
-    elif new_status == 'Finished':
+    elif new_status == obj.FINISHED:
       obj.finished_date = datetime.now()
       obj.verified_date = None
     else:

--- a/src/ggrc_workflows/models/mixins.py
+++ b/src/ggrc_workflows/models/mixins.py
@@ -61,14 +61,15 @@ class StatusValidatedMixin(mixins.Stateful):
 
   @property
   def active_states(self):
-    return [i for i in self.valid_statuses() if i not in self.inactive_states]
+    return [i for i in self.valid_statuses() if i != self.done_status]
 
   @property
-  def inactive_states(self):
-    if self.is_verification_needed:
-      return [self.VERIFIED]
-    else:
-      return [self.FINISHED]
+  def done_status(self):
+    return self.VERIFIED if self.is_verification_needed else self.FINISHED
+
+  @property
+  def is_done(self):
+    return self.done_status == self.status
 
 
 class CycleStatusValidatedMixin(StatusValidatedMixin):
@@ -114,7 +115,7 @@ class CycleTaskStatusValidatedMixin(CycleTaskGroupRelatedStatusValidatedMixin):
     """Return True if task is overdue."""
     today = date.today()
     task_end_date = self.end_date or today
-    return self.status not in self.inactive_states and task_end_date < today
+    return not self.is_done and task_end_date < today
 
   _aliases = {
       "status": {

--- a/src/ggrc_workflows/notification/notification_handler.py
+++ b/src/ggrc_workflows/notification/notification_handler.py
@@ -82,7 +82,7 @@ def add_cycle_task_due_notifications(task):
   Args:
     task: CycleTaskGroupObjectTask instance to generate the notifications for.
   """
-  if task.status in task.inactive_states:
+  if task.is_done:
     return
   if not task.cycle_task_group.cycle.is_current:
     return
@@ -216,12 +216,11 @@ def handle_cycle_task_status_change(obj, new_status, old_status):
     add_notif(obj, notif_type)
     return
 
-  if obj.status in obj.inactive_states:
+  if obj.is_done:
     for notif in get_notification(obj):
       db.session.delete(notif)  # delete all notification for inactive obj
     # if all tasks are in inactive states then add notification to cycle
-    if all(task.status in task.inactive_states for task in
-           obj.cycle.cycle_task_group_object_tasks):
+    if all(task.is_done for task in obj.cycle.cycle_task_group_object_tasks):
       add_notif(obj.cycle, get_notification_type("all_cycle_tasks_completed"))
     db.session.flush()
     return


### PR DESCRIPTION
If is_verification_needed flag is active then cycle should be moved to history if cycle status is Verified.
If is_verification_needed flag is not active then cycle should be moved to history if cycle status is Finished.