### PR TITLE
QUICK-FIX Test exporting of snapshoted Control from Audit's, Issue's, Assessment's Info Pages

### DIFF
--- a/test/selenium/src/lib/constants/__init__.py
+++ b/test/selenium/src/lib/constants/__init__.py
@@ -17,6 +17,5 @@ from lib.constants import (
   test_runner,
   settings,
   messages,
-  roles,
-  templates
+  roles
 )

--- a/test/selenium/src/lib/constants/element.py
+++ b/test/selenium/src/lib/constants/element.py
@@ -404,7 +404,7 @@ class ProgramModalSetVisibleFields(CommonModalSetVisibleFields):
   DEFAULT_SET_FIELDS = (
       CommonModalSetVisibleFields.TITLE, CommonModalSetVisibleFields.CODE,
       CommonModalSetVisibleFields.STATE,
-      CommonModalSetVisibleFields.LAST_UPDATED, REVIEW_STATE)
+      CommonModalSetVisibleFields.LAST_UPDATED, REVIEW_STATE, MANAGER)
 
 
 class MappingStatusAttrs(namedtuple('_MappingStatusAttrs',

--- a/test/selenium/src/lib/constants/messages.py
+++ b/test/selenium/src/lib/constants/messages.py
@@ -27,7 +27,7 @@ class AssertionMessages(CommonMessages):
   err_three_entities_diff = (
       _line + "\nFULL:" + _triple_diff + "\nSAME:" + _triple_diff + "\nDIFF:" +
       _triple_diff)
-  entities_cls = tuple(entity.Entity.all_entities_classes())
+  all_entities_classes = tuple(entity.Entity().all_entities_classes())
 
   @classmethod
   def diff_error_msg(cls, left, right):
@@ -41,7 +41,7 @@ class AssertionMessages(CommonMessages):
     """Check if entities are instances of entities and have needed attributes
     and keys to make result error comparison message.
     """
-    return (isinstance(left and right, cls.entities_cls) and
+    return (isinstance(left and right, cls.all_entities_classes) and
             hasattr(left and right, "diff_info") and
             getattr(left, "diff_info") and getattr(right, "diff_info"))
 
@@ -60,13 +60,13 @@ class AssertionMessages(CommonMessages):
     # comparison of entities
     assertion_error_msg = cls.err_common.format(left, right)
     # processing of entity
-    if isinstance(left and right, cls.entities_cls):
+    if isinstance(left and right, cls.all_entities_classes):
       if not cls.is_entities_have_err_info(left, right):
         cls.set_entities_diff_info(left, right)
       assertion_error_msg = cls.diff_error_msg(left, right)
     # processing list of entities
     if (isinstance(left and right, list) and
-            all(isinstance(_left and _right, cls.entities_cls)
+            all(isinstance(_left and _right, cls.all_entities_classes)
                 for _left, _right in zip(left, right))):
       assertion_error_msg = ""
       for _left, _right in zip(sorted(left), sorted(right)):
@@ -84,13 +84,15 @@ class AssertionMessages(CommonMessages):
     # comparison of entities
     assertion_error_msg = cls.err_contains.format(left, right)
     # processing of entity
-    if isinstance(left and right, cls.entities_cls):
+    if isinstance(left and right, cls.all_entities_classes):
       if not cls.is_entities_have_err_info(left, right):
         cls.set_entities_diff_info(left, right)
       assertion_error_msg = cls.diff_error_msg(left, right)
     # processing list of entities
-    if (isinstance(left, cls.entities_cls) and isinstance(right, list) and
-            all(isinstance(_right, cls.entities_cls) for _right in right)):
+    if (isinstance(left, cls.all_entities_classes) and
+            isinstance(right, list) and
+            all(isinstance(_right, cls.all_entities_classes)
+                for _right in right)):
       assertion_error_msg = ""
       for _right in right:
         left = copy.copy(left)

--- a/test/selenium/src/lib/constants/messages.py
+++ b/test/selenium/src/lib/constants/messages.py
@@ -1,10 +1,9 @@
 # Copyright (C) 2017 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 """Constants and procedures to make formatted messages."""
-
 import copy
 
-from lib.entities import entity
+from lib.entities.entity import Entity
 
 
 class CommonMessages(object):
@@ -27,7 +26,7 @@ class AssertionMessages(CommonMessages):
   err_three_entities_diff = (
       _line + "\nFULL:" + _triple_diff + "\nSAME:" + _triple_diff + "\nDIFF:" +
       _triple_diff)
-  all_entities_classes = tuple(entity.Entity().all_entities_classes())
+  _all_entities_classes = tuple(Entity.all_entities_classes())
 
   @classmethod
   def diff_error_msg(cls, left, right):
@@ -41,14 +40,15 @@ class AssertionMessages(CommonMessages):
     """Check if entities are instances of entities and have needed attributes
     and keys to make result error comparison message.
     """
-    return (isinstance(left and right, cls.all_entities_classes) and
-            hasattr(left and right, "diff_info") and
-            getattr(left, "diff_info") and getattr(right, "diff_info"))
+    return (
+        isinstance(left and right, cls._all_entities_classes) and
+        hasattr(left and right, "diff_info") and
+        getattr(left, "diff_info") and getattr(right, "diff_info"))
 
   @classmethod
   def set_entities_diff_info(cls, left, right):
     """Get and set entities diff info attributes info."""
-    comparison = entity.Representation.compare_entities(left, right)
+    comparison = Entity.compare_entities(left, right)
     left.diff_info = comparison["self_diff"]
     right.diff_info = comparison["other_diff"]
 
@@ -60,14 +60,14 @@ class AssertionMessages(CommonMessages):
     # comparison of entities
     assertion_error_msg = cls.err_common.format(left, right)
     # processing of entity
-    if isinstance(left and right, cls.all_entities_classes):
+    if isinstance(left and right, cls._all_entities_classes):
       if not cls.is_entities_have_err_info(left, right):
         cls.set_entities_diff_info(left, right)
       assertion_error_msg = cls.diff_error_msg(left, right)
     # processing list of entities
     if (isinstance(left and right, list) and
-            all(isinstance(_left and _right, cls.all_entities_classes)
-                for _left, _right in zip(left, right))):
+        all(isinstance(_left and _right, cls._all_entities_classes)
+            for _left, _right in zip(left, right))):
       assertion_error_msg = ""
       for _left, _right in zip(sorted(left), sorted(right)):
         if not cls.is_entities_have_err_info(_left, _right):
@@ -84,14 +84,14 @@ class AssertionMessages(CommonMessages):
     # comparison of entities
     assertion_error_msg = cls.err_contains.format(left, right)
     # processing of entity
-    if isinstance(left and right, cls.all_entities_classes):
+    if isinstance(left and right, cls._all_entities_classes):
       if not cls.is_entities_have_err_info(left, right):
         cls.set_entities_diff_info(left, right)
       assertion_error_msg = cls.diff_error_msg(left, right)
     # processing list of entities
-    if (isinstance(left, cls.all_entities_classes) and
+    if (isinstance(left, cls._all_entities_classes) and
             isinstance(right, list) and
-            all(isinstance(_right, cls.all_entities_classes)
+            all(isinstance(_right, cls._all_entities_classes)
                 for _right in right)):
       assertion_error_msg = ""
       for _right in right:

--- a/test/selenium/src/lib/constants/objects.py
+++ b/test/selenium/src/lib/constants/objects.py
@@ -37,6 +37,7 @@ THREATS = "threats"
 RISK_ASSESSMENTS = "risk_assessments"
 CUSTOM_ATTRIBUTES = "custom_attribute_definitions"
 COMMENTS = "comments"
+SNAPSHOTS = "snapshots"
 
 ALL_SNAPSHOTABLE_OBJS = (
     ACCESS_GROUPS, CLAUSES, CONTRACTS, CONTROLS, DATA_ASSETS, FACILITIES,

--- a/test/selenium/src/lib/constants/templates.py
+++ b/test/selenium/src/lib/constants/templates.py
@@ -1,7 +1,0 @@
-# Copyright (C) 2017 Google Inc.
-# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
-"""Constants and methods for work with templates."""
-
-
-# REST API templates
-COUNT = "count"

--- a/test/selenium/src/lib/dynamic_fixtures.py
+++ b/test/selenium/src/lib/dynamic_fixtures.py
@@ -10,8 +10,8 @@ import copy
 from lib import factory
 from lib.constants import element, objects
 from lib.constants.test import batch
-from lib.entities.entities_factory import (
-    CustomAttributeDefinitionsFactory, EntitiesFactory)
+from lib.entities.entities_factory import CustomAttributeDefinitionsFactory
+from lib.entities.entity import Entity
 from lib.page.widget import info_widget
 from lib.service import rest_service
 from lib.utils import conftest_utils, test_utils, string_utils
@@ -29,7 +29,7 @@ def _get_fixture_from_dict_fixtures(fixture):
         fixture.replace("_snapshot", ""))
     parent_obj = _get_fixture_from_dict_fixtures("new_audit_rest")[0]
     dict_executed_fixtures.update(
-        {fixture: EntitiesFactory.convert_objs_repr_to_snapshot(
+        {fixture: Entity.convert_objs_repr_to_snapshot(
             obj_or_objs=origin_obj, parent_obj=parent_obj)})
   return {k: v for k, v in dict_executed_fixtures.iteritems()
           if k == fixture}[fixture]

--- a/test/selenium/src/lib/entities/entity.py
+++ b/test/selenium/src/lib/entities/entity.py
@@ -4,27 +4,21 @@
 # pylint: disable=too-many-arguments
 # pylint: disable=too-few-public-methods
 
+import copy
 from datetime import datetime
+
 import pytest
 
-from lib.utils import string_utils
+from lib.utils import string_utils, help_utils
 
 
 class Representation(object):
   """Class that contains methods to update Entity."""
   # pylint: disable=import-error
-
   diff_info = None  # {"equal": {"atr7": val7, ...}, "diff": {"atr3": val3}}
   attrs_names_to_compare = None
   attrs_names_to_repr = None
   core_attrs_names_to_repr = ["type", "title", "id", "href", "url", "slug"]
-
-  def extended_equal(self, other):
-    """Extended equal procedure fore self and other entities."""
-    comparison = Representation.compare_entities(self, other)
-    self.diff_info = comparison["self_diff"]
-    other.diff_info = comparison["other_diff"]
-    return comparison["is_equal"]
 
   @classmethod
   def get_attrs_names_for_entities(cls, entity=None):
@@ -36,6 +30,13 @@ class Representation(object):
     all_entities_attrs_names = string_utils.convert_list_elements_to_list(
         [entity_cls().__dict__.keys() for entity_cls in all_entities_cls])
     return list(set(all_entities_attrs_names))
+
+  def __repr__(self):
+    # exclude attributes witch are used for REST interaction forming
+    # pylint: disable=not-an-iterable
+    return str(dict(zip(self.attrs_names_to_repr,
+                        [getattr(self, attr_name_to_repr) for attr_name_to_repr
+                         in self.attrs_names_to_repr])))
 
   @staticmethod
   def items_of_remap_keys():
@@ -70,20 +71,182 @@ class Representation(object):
     result_remap_items.update(csv_remap_items)
     return string_utils.dict_keys_to_upper_case(result_remap_items)
 
+  @staticmethod
+  def convert_objs_repr_to_dict(obj_or_objs):
+    """Convert objects' representation to dictionary 'obj.attr_name' =
+    'attr_value' to dictionary or list of dictionaries with items
+    {'attr_name': 'attr_value'}.
+    """
+    if obj_or_objs:
+      if isinstance(obj_or_objs, list):
+        if (all(not isinstance(_, dict) and
+                not isinstance(_, (str, unicode, int)) and
+                _ for _ in obj_or_objs)):
+          obj_or_objs = [_.__dict__ for _ in obj_or_objs]
+      else:
+        if (not isinstance(obj_or_objs, dict) and
+                not isinstance(obj_or_objs, (str, unicode, int))):
+          obj_or_objs = obj_or_objs.__dict__
+      return obj_or_objs
+
+  @staticmethod
+  def convert_dict_to_obj_repr(dic):
+    """Convert dictionary to Entity representation (dictionary's keys and
+    values to attributes names and attributes values).
+    """
+    # pylint: disable=expression-not-assigned
+    # pylint: disable=consider-iterating-dictionary
+    entity = Entity()
+    [delattr(entity, k) for k in entity.__dict__.keys()]
+    [setattr(entity, k, v) for k, v in dic.iteritems()]
+    return entity
+
   def repr_ui(self):
     """Convert entity's attributes values from REST like to UI like
     representation.
     """
-    from lib.entities import entities_factory
-    return (entities_factory.EntitiesFactory().
-            convert_objs_repr_from_rest_to_ui(obj_or_objs=self))
+    return self.convert_objs_repr_from_rest_to_ui(obj_or_objs=self)
+
+  @classmethod  # noqa: ignore=C901
+  def convert_objs_repr_from_rest_to_ui(cls, obj_or_objs):
+    """Convert object's or objects' attributes values from REST like
+    (dict or list of dict) representation to UI like with unicode.
+    Examples:
+    None to None, u'Ex' to u'Ex', [u'Ex1', u'Ex2', ...] to u'Ex1, Ex2',
+    {'name': u'Ex', ...} to u'Ex',
+    [{'name': u'Ex1', ...}, {'name': u'Ex2', ...}] to u'Ex1, Ex2'
+    """
+    # pylint: disable=too-many-locals
+    # pylint: disable=undefined-loop-variable
+    # pylint: disable=invalid-name
+    def convert_obj_repr_from_rest_to_ui(obj):
+      """Convert object's attributes from REST to UI like representation."""
+      def convert_attr_value_from_dict_to_unicode(attr_name, attr_value):
+        """Convert attribute value from dictionary to unicode representation
+        (get value by key from dictionary 'attr_value' where key determine
+        according to 'attr_name').
+        """
+        if isinstance(attr_value, dict):
+          converted_attr_value = attr_value
+          if attr_name in [
+              "contact", "manager", "owners", "assessor", "creator",
+              "verifier", "created_by", "modified_by", "Assessor", "Creator",
+              "Verifier"
+          ]:
+            converted_attr_value = unicode(attr_value.get("name"))
+          if attr_name in ["custom_attribute_definitions", "program", "audit",
+                           "objects_under_assessment"]:
+            converted_attr_value = (
+                unicode(attr_value.get("title")) if
+                attr_name != "custom_attribute_definitions" else
+                {attr_value.get("id"): attr_value.get("title").upper()}
+            )
+          if attr_name in ["custom_attribute_values"]:
+            converted_attr_value = {attr_value.get("custom_attribute_id"):
+                                    attr_value.get("attribute_value")}
+          if obj_attr_name == "comments":
+            converted_attr_value = {
+                k: (string_utils.convert_str_to_datetime(v) if
+                    k == "created_at" and isinstance(v, unicode) else v)
+                for k, v in attr_value.iteritems()
+                if k in ["modified_by", "created_at", "description"]}
+          return converted_attr_value
+      origin_obj = copy.deepcopy(obj)
+      for obj_attr_name in obj.__dict__.keys():
+        # 'Ex', u'Ex', 1, None to 'Ex', u'Ex', 1, None
+        obj_attr_value = (obj.assignees.get(obj_attr_name.title()) if (
+            obj_attr_name in ["assessor", "creator", "verifier"] and
+            "assignees" in obj.__dict__.keys())
+            else getattr(obj, obj_attr_name))
+        # u'2017-06-07T16:50:16' and u'2017-06-07 16:50:16' to datetime
+        if (obj_attr_name in ["updated_at", "created_at"] and
+                isinstance(obj_attr_value, unicode)):
+          obj_attr_value = string_utils.convert_str_to_datetime(obj_attr_value)
+        if isinstance(obj_attr_value, dict) and obj_attr_value:
+          # to "assignees" = {"Assessor": [], "Creator": [], "Verifier": []}
+          if obj_attr_name == "assignees":
+            obj_attr_value = {
+                k: ([convert_attr_value_from_dict_to_unicode(k, _v)
+                     for _v in v] if isinstance(v, list) else
+                    convert_attr_value_from_dict_to_unicode(k, v))
+                for k, v in obj_attr_value.iteritems()
+                if k in ["Assessor", "Creator", "Verifier"]}
+          # {'name': u'Ex1', 'type': u'Ex2', ...} to u'Ex1'
+          else:
+            obj_attr_value = convert_attr_value_from_dict_to_unicode(
+                obj_attr_name, obj_attr_value)
+        # [el1, el2, ...] or [{item1}, {item2}, ...] to [u'Ex1, u'Ex2', ...]
+        if (isinstance(obj_attr_value, list) and
+                all(isinstance(item, dict) for item in obj_attr_value)):
+          obj_attr_value = [
+              convert_attr_value_from_dict_to_unicode(obj_attr_name, item) for
+              item in obj_attr_value]
+        setattr(obj, obj_attr_name, obj_attr_value)
+      # merge "custom_attribute_definitions" and "custom_attribute_values"
+      obj_cas_attrs_names = [
+          "custom_attributes", "custom_attribute_definitions",
+          "custom_attribute_values"]
+      if set(obj_cas_attrs_names).issubset(obj.__dict__.keys()):
+        cas_def = obj.custom_attribute_definitions
+        cas_val = obj.custom_attribute_values
+        # form CAs values of CAs definitions exist but CAs values not, or CAs
+        # definitions have different then CAs values lengths
+        if (cas_def and
+                (not cas_val or (isinstance(cas_def and cas_val, list)) and
+                 len(cas_def) != len(cas_val))):
+          from lib.entities.entities_factory import (
+              CustomAttributeDefinitionsFactory)
+          cas_val_dicts_keys = ([_.keys()[0] for _ in cas_val] if
+                                isinstance(cas_val, list) else [None])
+          _cas_val = [
+              {k: v} for k, v in
+              CustomAttributeDefinitionsFactory.generate_ca_values(
+                  list_ca_def_objs=origin_obj.custom_attribute_definitions,
+                  is_none_values=True).iteritems()
+              if k not in cas_val_dicts_keys]
+          cas_val = _cas_val if not cas_val else cas_val + _cas_val
+        cas_def_dict = (
+            dict([_def.iteritems().next() for _def in cas_def]) if
+            (isinstance(cas_def, list) and
+             all(isinstance(_def, dict)
+                 for _def in cas_def)) else {None: None})
+        cas_val_dict = (
+            dict([_val.iteritems().next() for _val in cas_val]) if
+            (isinstance(cas_def, list) and
+             all(isinstance(_def, dict)
+                 for _def in cas_def)) else {None: None})
+        cas = string_utils.merge_dicts_by_same_key(cas_def_dict, cas_val_dict)
+        setattr(obj, "custom_attributes", cas)
+      return obj
+    return help_utils.execute_method_according_to_plurality(
+        obj_or_objs=obj_or_objs, types=Entity.all_entities_classes(),
+        method_name=convert_obj_repr_from_rest_to_ui)
 
   def repr_snapshot(self, parent_obj):
     """Convert entity's attributes values to Snapshot representation."""
-    from lib.entities import entities_factory
-    return (entities_factory.EntitiesFactory().
-            convert_objs_repr_to_snapshot(
-                obj_or_objs=self, parent_obj=parent_obj))
+    return (self.convert_objs_repr_to_snapshot(
+        obj_or_objs=self, parent_obj=parent_obj))
+
+  @classmethod  # noqa: ignore=C901
+  def convert_objs_repr_to_snapshot(cls, obj_or_objs, parent_obj):
+    """Convert object's or objects' attributes values to Snapshot
+    representation.
+    Retrieved values will be used for: 'id'.
+    Set values will be used for: 'title, 'type', 'slug', 'href'.
+    """
+    def convert_obj_repr_to_snapshot(origin_obj, parent_obj):
+      """Convert object's attributes to Snapshot representation."""
+      from lib.service import rest_service
+      origin_obj = copy.deepcopy(origin_obj)
+      snapshoted_obj = (
+          rest_service.ObjectsInfoService().get_snapshoted_obj(
+              origin_obj=origin_obj, paren_obj=parent_obj))
+      origin_obj.__dict__.update(
+          {k: v for k, v in snapshoted_obj.__dict__.iteritems()})
+      return origin_obj
+    return help_utils.execute_method_according_to_plurality(
+        obj_or_objs=obj_or_objs, types=Entity.all_entities_classes(),
+        method_name=convert_obj_repr_to_snapshot, parent_obj=parent_obj)
 
   def update_attrs(self, is_replace_attrs=True, is_allow_none=True,
                    is_replace_dicts_values=False, **attrs):
@@ -92,47 +255,95 @@ class Representation(object):
     If 'is_replace_values_of_dicts' then update values of dicts in list which
     is value of particular object's attribute name.
     """
-    from lib.entities import entities_factory
-    return (entities_factory.EntitiesFactory().
-            update_objs_attrs_values_by_entered_data(
-                obj_or_objs=self, is_replace_attrs_values=is_replace_attrs,
-                is_allow_none_values=is_allow_none,
-                is_replace_values_of_dicts=is_replace_dicts_values, **attrs))
+    return (self.update_objs_attrs_values_by_entered_data(
+        obj_or_objs=self, is_replace_attrs_values=is_replace_attrs,
+        is_allow_none_values=is_allow_none,
+        is_replace_values_of_dicts=is_replace_dicts_values, **attrs))
 
-  def compare_entities(self, other):
-    """Extended compare of entities: 'self_entity' and 'other_entity' according
-    to specific 'attrs_names_to_compare' and return:
-    - 'is_equal' - True if entities equal else False;
-    - 'self_diff' - 'equal' and 'diff' parts of 'self_entity' after compare;
-    - 'other_diff' - 'equal' and 'diff' parts of 'other_entity' after compare.
+  @classmethod
+  def update_objs_attrs_values_by_entered_data(
+      cls, obj_or_objs, is_replace_attrs_values=True,
+      is_allow_none_values=True, is_replace_values_of_dicts=False, **arguments
+  ):
+    """Update object or list of objects ('obj_or_objs') attributes values by
+    manually entered data if attribute name exist in 'attrs_names' witch equal
+    to 'all_objs_attrs_names' according to dictionary of attributes and values
+    '**arguments'. If 'is_replace_attrs_values' then replace attributes values,
+    if not 'is_replace_attrs_values' then update (merge) attributes values
+    witch should be lists. If 'is_allow_none_values' then allow to set None
+    object's attributes values, and vice versa.
+    If 'is_replace_values_of_dicts' then update values of dicts in list which
+    is value of particular object's attribute name:
+    (**arguments is attr={'key1': 'new_value2', 'key2': 'new_value2'}).
     """
-    # pylint: disable=not-an-iterable
-    is_equal = False
-    self_equal, self_diff, other_equal, other_diff = {}, {}, {}, {}
-    if (isinstance(self, other.__class__) and
-            self.attrs_names_to_compare == other.attrs_names_to_compare):
-      for attr_name in self.attrs_names_to_compare:
-        self_attr_value = None
-        other_attr_value = None
-        if (attr_name in self.__dict__.keys() and
-                attr_name in other.__dict__.keys()):
-          self_attr_value = getattr(self, attr_name)
-          other_attr_value = getattr(other, attr_name)
-          is_equal = self.is_attrs_equal(
-              attr_name, self_attr_value, other_attr_value)
-        if is_equal:
-          self_equal[attr_name] = self_attr_value
-          other_equal[attr_name] = other_attr_value
-        else:
-          self_diff[attr_name] = {"val": self_attr_value,
-                                  "type": type(self_attr_value)}
-          other_diff[attr_name] = {"val": other_attr_value,
-                                   "type": type(other_attr_value)}
-      is_equal = self_diff == other_diff == {}
-    return {"is_equal": is_equal,
-            "self_diff": {"equal": self_equal, "diff": self_diff},
-            "other_diff": {"equal": other_equal, "diff": other_diff}
-            }
+    # pylint: disable=expression-not-assigned
+    # pylint: disable=invalid-name
+    def update_obj_attrs_values(obj, is_replace_attrs_values,
+                                is_allow_none_values, **arguments):
+      """Update object's attributes values."""
+      for obj_attr_name in arguments:
+        if (obj_attr_name in
+                Entity.get_attrs_names_for_entities(obj.__class__)):
+          _obj_attr_value = arguments.get(obj_attr_name)
+          condition = (True if is_allow_none_values else _obj_attr_value)
+          if condition and not is_replace_values_of_dicts:
+            # convert repr from objects to dicts exclude datetime objects
+            obj_attr_value = (
+                cls.convert_objs_repr_to_dict(_obj_attr_value) if
+                not isinstance(_obj_attr_value, datetime) else _obj_attr_value)
+            if not is_replace_attrs_values:
+              origin_obj_attr_value = getattr(obj, obj_attr_name)
+              obj_attr_value = (
+                  dict(origin_obj_attr_value.items() + obj_attr_value.items())
+                  if obj_attr_name == "custom_attributes" else
+                  string_utils.convert_to_list(origin_obj_attr_value) +
+                  string_utils.convert_to_list(obj_attr_value))
+            setattr(obj, obj_attr_name, obj_attr_value)
+          if is_replace_values_of_dicts and isinstance(_obj_attr_value, dict):
+            obj_attr_value = string_utils.exchange_dicts_items(
+                transform_dict=_obj_attr_value,
+                dicts=string_utils.convert_to_list(
+                    getattr(obj, obj_attr_name)),
+                is_keys_not_values=False)
+            obj_attr_value = (
+                obj_attr_value if isinstance(getattr(obj, obj_attr_name), list)
+                else obj_attr_value[0])
+            setattr(obj, obj_attr_name, obj_attr_value)
+      return obj
+    return help_utils.execute_method_according_to_plurality(
+        obj_or_objs=obj_or_objs, types=Entity.all_entities_classes(),
+        method_name=update_obj_attrs_values,
+        is_replace_attrs_values=is_replace_attrs_values,
+        is_allow_none_values=is_allow_none_values, **arguments)
+
+  @classmethod
+  def filter_objs_attrs(cls, obj_or_objs, attrs_to_include):
+    """Make objects's copy and filter objects's attributes (delete attributes
+    from objects witch not in list'attrs_to_include').
+    'objs' can be list of objects or object.
+    """
+    # pylint: disable=expression-not-assigned
+    def filter_obj_attrs(obj, attrs_to_include):
+      """Filter one object's attributes."""
+      obj = copy.deepcopy(obj)
+      [delattr(obj, obj_attr) for obj_attr in obj.__dict__.keys()
+       if obj_attr not in attrs_to_include]
+      return obj
+    return ([filter_obj_attrs(obj, attrs_to_include) for obj in obj_or_objs] if
+            isinstance(obj_or_objs, list) else
+            filter_obj_attrs(obj_or_objs, attrs_to_include))
+
+  def __eq__(self, other):
+    """Extended equal procedure fore self and other entities."""
+    comparison = Representation.compare_entities(self, other)
+    self.diff_info = comparison["self_diff"]
+    other.diff_info = comparison["other_diff"]
+    return comparison["is_equal"]
+
+  @staticmethod
+  def attrs_values_types_error(self_attr, other_attr, expected_types):
+    raise ValueError("'{}' have to be isinstance of classes: {}\n".
+                     format((self_attr, other_attr), expected_types))
 
   @classmethod
   def is_attrs_equal(cls, attr_name, self_attr_value, other_attr_value):
@@ -202,10 +413,40 @@ class Representation(object):
           self_attr=self_comments, other_attr=other_comments,
           expected_types=(list.__name__, type(None).__name__))
 
-  @staticmethod
-  def attrs_values_types_error(self_attr, other_attr, expected_types):
-    raise ValueError("'{}' have to be isinstance of classes: {}\n".
-                     format((self_attr, other_attr), expected_types))
+  def compare_entities(self, other):
+    """Extended compare of entities: 'self_entity' and 'other_entity' according
+    to specific 'attrs_names_to_compare' and return:
+    - 'is_equal' - True if entities equal else False;
+    - 'self_diff' - 'equal' and 'diff' parts of 'self_entity' after compare;
+    - 'other_diff' - 'equal' and 'diff' parts of 'other_entity' after compare.
+    """
+    # pylint: disable=not-an-iterable
+    is_equal = False
+    self_equal, self_diff, other_equal, other_diff = {}, {}, {}, {}
+    if (isinstance(self, other.__class__) and
+            self.attrs_names_to_compare == other.attrs_names_to_compare):
+      for attr_name in self.attrs_names_to_compare:
+        self_attr_value = None
+        other_attr_value = None
+        if (attr_name in self.__dict__.keys() and
+                attr_name in other.__dict__.keys()):
+          self_attr_value = getattr(self, attr_name)
+          other_attr_value = getattr(other, attr_name)
+          is_equal = self.is_attrs_equal(
+              attr_name, self_attr_value, other_attr_value)
+        if is_equal:
+          self_equal[attr_name] = self_attr_value
+          other_equal[attr_name] = other_attr_value
+        else:
+          self_diff[attr_name] = {"val": self_attr_value,
+                                  "type": type(self_attr_value)}
+          other_diff[attr_name] = {"val": other_attr_value,
+                                   "type": type(other_attr_value)}
+      is_equal = self_diff == other_diff == {}
+    return {"is_equal": is_equal,
+            "self_diff": {"equal": self_equal, "diff": self_diff},
+            "other_diff": {"equal": other_equal, "diff": other_diff}
+            }
 
   @classmethod
   def issue_assert(cls, expected_objs, actual_objs, issue_msg,
@@ -239,16 +480,6 @@ class Representation(object):
         for expected_exclude_attr, actual_exclude_attr
         in zip(expected_exclude_attrs, actual_exclude_attrs))
         else pytest.xfail(reason=issue_msg))
-
-  def __eq__(self, other):
-    return self.extended_equal(other)
-
-  def __repr__(self):
-    # exclude attributes witch are used for REST interaction forming
-    # pylint: disable=not-an-iterable
-    return str(dict(zip(self.attrs_names_to_repr,
-                        [getattr(self, attr_name_to_repr) for attr_name_to_repr
-                         in self.attrs_names_to_repr])))
 
 
 class Entity(Representation):
@@ -345,7 +576,6 @@ class CustomAttributeEntity(Representation):
   # pylint: disable=redefined-builtin
   # pylint: disable=too-many-instance-attributes
   __hash__ = None
-  entity = Entity()
   attrs_names_to_compare = [
       "type", "title", "definition_type", "attribute_type", "mandatory"]
   attrs_names_to_repr = [

--- a/test/selenium/src/lib/service/rest/query.py
+++ b/test/selenium/src/lib/service/rest/query.py
@@ -1,0 +1,37 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+"""Constants and methods for work with REST and QUERY API interactions."""
+
+
+class Query(object):
+  """Query API constants, templates, methods."""
+  # pylint: disable=too-few-public-methods
+
+  @staticmethod
+  def expression_get_snapshoted_obj(obj_type, obj_id, parent_type, parent_id):
+    """Expression to get snapshoted object according to original and parent
+    objects attributes.
+    """
+    return {
+        "expression": {
+            "left": {
+                "left": {
+                    "left": "child_type",
+                    "op": {"name": "="},
+                    "right": obj_type
+                },
+                "op": {"name": "AND"},
+                "right": {
+                    "left": "child_id",
+                    "op": {"name": "="},
+                    "right": str(obj_id)
+                }
+            },
+            "op": {"name": "AND"},
+            "right": {
+                "object_name": parent_type,
+                "op": {"name": "relevant"},
+                "ids": [str(parent_id)]
+            }
+        }
+    }

--- a/test/selenium/src/lib/service/rest/template/count.json
+++ b/test/selenium/src/lib/service/rest/template/count.json
@@ -1,7 +1,0 @@
-{
-  "object_name": null,
-  "filters": {
-    "expression": {}
-  },
-  "type": "count"
-}

--- a/test/selenium/src/lib/service/rest/template/query.json
+++ b/test/selenium/src/lib/service/rest/template/query.json
@@ -1,0 +1,5 @@
+{
+  "object_name": null,
+  "filters": null,
+  "limit": [0, 10]
+}

--- a/test/selenium/src/lib/service/rest_service.py
+++ b/test/selenium/src/lib/service/rest_service.py
@@ -10,6 +10,7 @@ from requests import exceptions
 from lib import environment, factory
 from lib.constants import url, objects, messages
 from lib.entities.entities_factory import ObjectPersonsFactory, EntitiesFactory
+from lib.entities.entity import Entity
 from lib.service.rest import client, query
 from lib.utils import string_utils
 
@@ -132,7 +133,7 @@ class BaseRestService(object):
     list_objs = self.create_list_objs(
         entity_factory=self.entities_factory_cls(), count=count,
         attrs_to_factory=factory_params, **attrs_for_template)
-    return self.entities_factory_cls().filter_objs_attrs(
+    return Entity.filter_objs_attrs(
         obj_or_objs=list_objs,
         attrs_to_include=self.entities_factory_cls().obj_attrs_names)
 
@@ -144,7 +145,7 @@ class BaseRestService(object):
         entity_factory=self.entities_factory_cls(),
         list_objs_to_update=string_utils.convert_to_list(objs),
         attrs_to_factory=factory_params, **attrs_for_template)
-    return self.entities_factory_cls().filter_objs_attrs(
+    return Entity.filter_objs_attrs(
         obj_or_objs=list_objs,
         attrs_to_include=self.entities_factory_cls().obj_attrs_names)
 
@@ -261,9 +262,9 @@ class ObjectsInfoService(HelpRestService):
     """
     snapshoted_obj_item = (
         BaseRestService.get_items_from_resp(self.client.create_object(
-            type=self.endpoint, object_name=EntitiesFactory().obj_snapshot,
+            type=self.endpoint, object_name=EntitiesFactory.obj_snapshot,
             filters=query.Query.expression_get_snapshoted_obj(
                 obj_type=origin_obj.type, obj_id=origin_obj.id,
                 parent_type=paren_obj.type,
                 parent_id=paren_obj.id))).get("values")[0])
-    return EntitiesFactory.convert_dict_to_obj_repr(snapshoted_obj_item)
+    return Entity.convert_dict_to_obj_repr(snapshoted_obj_item)

--- a/test/selenium/src/lib/service/webui_service.py
+++ b/test/selenium/src/lib/service/webui_service.py
@@ -7,7 +7,6 @@ import re
 
 from lib import factory
 from lib.constants import objects, url, path, messages, roles, element, regex
-from lib.entities.entities_factory import EntitiesFactory
 from lib.entities.entity import Entity
 from lib.page import dashboard
 from lib.page.widget.info_widget import SnapshotableInfoPanel
@@ -79,7 +78,7 @@ class BaseWebUiService(object):
                   "*" in val):
             scope[key] = val.replace("*", "")
     return [
-        EntitiesFactory.update_objs_attrs_values_by_entered_data(
+        Entity.update_objs_attrs_values_by_entered_data(
             obj_or_objs=factory_obj, is_allow_none_values=False, **scope) for
         scope, factory_obj in zip(list_scopes_to_convert, list_factory_objs)]
 

--- a/test/selenium/src/lib/service/webui_service.py
+++ b/test/selenium/src/lib/service/webui_service.py
@@ -80,7 +80,7 @@ class BaseWebUiService(object):
             scope[key] = val.replace("*", "")
     return [
         EntitiesFactory.update_objs_attrs_values_by_entered_data(
-            objs=factory_obj, is_allow_none_values=False, **scope) for
+            obj_or_objs=factory_obj, is_allow_none_values=False, **scope) for
         scope, factory_obj in zip(list_scopes_to_convert, list_factory_objs)]
 
   def open_widget_of_mapped_objs(self, src_obj):

--- a/test/selenium/src/lib/utils/help_utils.py
+++ b/test/selenium/src/lib/utils/help_utils.py
@@ -1,0 +1,38 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+"""Help functions."""
+
+
+def is_multiple_objs(obj_or_objs, types=None):
+  """Check if 'obj_or_objs' is single or plural objects and if 'types' then
+  check it according types, return boolean value.
+  Examples:
+  if 'obj_or_objs':
+  [obj1, obj2, ...]; (obj1, obj2); (obj1 and obj2) then True
+  [obj]; (obj); obj then False
+  """
+  is_multiple = False
+  if isinstance(obj_or_objs, (list, tuple)) and len(obj_or_objs) >= 2:
+    is_multiple = (all(isinstance(item, types) for item in obj_or_objs)
+                   if types else True)
+  return is_multiple
+
+
+def get_single_obj(obj):
+  """Check if 'obj' is single or single in list or tuple and return got object
+  accordingly.
+  """
+  return (obj[0] if (not is_multiple_objs(obj) and
+                     isinstance(obj, (list, tuple))) else obj)
+
+
+def execute_method_according_to_plurality(obj_or_objs, method_name, types=None,
+                                          **method_kwargs):
+  """Get single object or multiple objects from 'obj_or_objs' according to
+  'types' and execute procedure under got executing method by 'method_name'.
+  """
+  # pylint: disable=invalid-name
+  return (
+      [method_name(obj, **method_kwargs) for obj in obj_or_objs] if
+      is_multiple_objs(obj_or_objs, types) else
+      method_name(get_single_obj(obj_or_objs), **method_kwargs))

--- a/test/selenium/src/tests/conftest.py
+++ b/test/selenium/src/tests/conftest.py
@@ -7,10 +7,10 @@
 
 import pytest
 
+import lib.utils.help_utils
 from lib import dynamic_fixtures
-from lib.utils import selenium_utils
 from lib.page import dashboard
-
+from lib.utils import selenium_utils
 
 # pylint: disable=redefined-outer-name
 pytest_plugins = "selenium", "xdist", "xvfb", "timeout", "flask", \
@@ -22,7 +22,9 @@ def _common_fixtures(fixturename):
   common fixtures.
   """
   dynamic_fixtures.generate_common_fixtures(fixturename)
-  return dynamic_fixtures.dict_executed_fixtures[fixturename]
+  fixture = dynamic_fixtures.dict_executed_fixtures[fixturename]
+  return (lib.utils.help_utils.get_single_obj(fixture)
+          if not lib.utils.help_utils.is_multiple_objs(fixture) else fixture)
 
 
 @pytest.fixture(scope="function")
@@ -62,16 +64,6 @@ def chrome_options(chrome_options, create_tmp_dir):
   return chrome_options
 
 
-@pytest.yield_fixture(scope="function")
-def dynamic_new_assessment_template(request):
-  """Dynamically create new Assessment Template under Audit object according
-  to fixturename. Fixturename is indirect parameter that get from
-  'request.param' and have to be string or boolean.
-  Return: lib.entities.entity.AssessmentTemplateEntity
-  """
-  yield _common_fixtures(request.param)[0] if request.param else None
-
-
 @pytest.fixture(scope="function")
 def my_work_dashboard(selenium):
   """Open My Work Dashboard URL and
@@ -101,7 +93,7 @@ def new_org_group_ui(selenium, request):
   """Create new Org Group object via UI (LHN).
   Return: lib.page.widget.OrgGroupInfo
   """
-  yield _common_fixtures(request.fixturename)[0]
+  yield _common_fixtures(request.fixturename)
 
 
 @pytest.fixture(scope="function")
@@ -109,7 +101,7 @@ def new_risk_ui(selenium, request):
   """Create new Risk Group object via UI (LHN).
   Return: lib.page.widget.Risks
   """
-  yield _common_fixtures(request.fixturename)[0]
+  yield _common_fixtures(request.fixturename)
 
 
 @pytest.fixture(scope="function")
@@ -117,7 +109,7 @@ def new_program_rest(request):
   """Create new Program object via REST API.
   Return: lib.entities.entity.ProgramEntity
   """
-  yield _common_fixtures(request.fixturename)[0]
+  yield _common_fixtures(request.fixturename)
 
 
 @pytest.fixture(scope="function")
@@ -125,7 +117,7 @@ def new_control_rest(request):
   """Create new Control object via REST API.
   Return: lib.entities.entity.ControlEntity
   """
-  yield _common_fixtures(request.fixturename)[0]
+  yield _common_fixtures(request.fixturename)
 
 
 @pytest.fixture(scope="function")
@@ -141,7 +133,7 @@ def new_objective_rest(request):
   """Create new Objective object via REST API.
   Return: lib.entities.entity.ObjectiveEntity
   """
-  yield _common_fixtures(request.fixturename)[0]
+  yield _common_fixtures(request.fixturename)
 
 
 @pytest.fixture(scope="function")
@@ -157,7 +149,7 @@ def new_audit_rest(request):
   """Create new Audit under Program object via REST API.
   Return: lib.entities.entity.AuditEntity
   """
-  yield _common_fixtures(request.fixturename)[0]
+  yield _common_fixtures(request.fixturename)
 
 
 @pytest.fixture(scope="function")
@@ -165,7 +157,7 @@ def new_assessment_rest(request):
   """Create new Assessment under Audit object via REST API.
   Return: lib.entities.entity.AssessmentEntity
   """
-  yield _common_fixtures(request.fixturename)[0]
+  yield _common_fixtures(request.fixturename)
 
 
 @pytest.fixture(scope="function")
@@ -173,7 +165,7 @@ def new_issue_rest(request):
   """Create new Issue under Audit object via REST API.
   Return: lib.entities.entity.IssueEntity
   """
-  yield _common_fixtures(request.fixturename)[0]
+  yield _common_fixtures(request.fixturename)
 
 
 @pytest.fixture(scope="function")
@@ -181,7 +173,7 @@ def new_assessment_template_rest(request):
   """Create new Assessment Template under Audit object via REST API.
   Return: lib.entities.entity.AssessmentTemplateEntity
   """
-  yield _common_fixtures(request.fixturename)[0]
+  yield _common_fixtures(request.fixturename)
 
 
 @pytest.fixture(scope="function")
@@ -189,7 +181,7 @@ def new_assessment_template_with_cas_rest(request):
   """Create new Assessment Template with CAs under Audit object via REST API.
   Return: lib.entities.entity.AssessmentTemplateEntity
   """
-  yield _common_fixtures(request.fixturename)[0]
+  yield _common_fixtures(request.fixturename)
 
 
 @pytest.fixture(scope="function")
@@ -240,6 +232,23 @@ def dynamic_create_audit_with_control(request):
 
 
 @pytest.fixture(scope="function")
+def dynamic_object(request):
+  """Create object by passed indirect parameter that get from 'request.param'
+  and have to be string or boolean. Return singular or plural object's form
+  according to length of the list objects.
+  """
+  yield _common_fixtures(request.param) if request.param else None
+
+
+@pytest.fixture(scope="function")
+def dynamic_relationships(request):
+  """Create relationships between source and destinations objects by passed
+  indirect parameter that get from 'request.param' and have to be string
+  or boolean."""
+  yield _common_fixtures(request.param) if request.param else None
+
+
+@pytest.fixture(scope="function")
 def create_audit_with_control(request):
   """Create Program and Control, map Control to Program, create Audit
   under Program via REST API and return dictionary of executed fixtures.
@@ -263,16 +272,3 @@ def create_audit_with_control_and_delete_control(request):
   fixtures.
   """
   yield _snapshots_fixtures(request.fixturename)
-
-
-@pytest.fixture(scope="function")
-def dynamic_object(request):
-  """Create object by passed indirect parameter in test."""
-  yield _common_fixtures(request.param)
-
-
-@pytest.fixture(scope="function")
-def dynamic_relationships(request):
-  """Create relationships between source and destinations objects by passed
-  indirect parameter in test."""
-  yield _common_fixtures(request.param)

--- a/test/selenium/src/tests/test_audit_page.py
+++ b/test/selenium/src/tests/test_audit_page.py
@@ -10,7 +10,7 @@ import pytest
 
 from lib import base
 from lib.constants import messages
-from lib.entities import entities_factory, entity
+from lib.entities import entities_factory
 from lib.service import webui_service
 
 
@@ -231,6 +231,6 @@ class TestAuditPage(base.Test):
     assert [expected_control] == actual_controls, (
         messages.AssertionMessages.
         format_err_msg_equal([expected_control], actual_controls))
-    entity.Entity.issue_assert(
+    self.extended_assert(
         expected_objs=[expected_program], actual_objs=actual_programs,
         issue_msg="Issue in app GGRC-2381", manager=None)

--- a/test/selenium/src/tests/test_objective.py
+++ b/test/selenium/src/tests/test_objective.py
@@ -38,10 +38,10 @@ class TestObjectivePage(base.Test):
   ):
     """Check if Objectives can be mapped to Control via REST."""
     # pylint: disable=too-many-arguments
-
     expected_status_code = RestClient.STATUS_CODES["OK"]
-    actual_status_code = dynamic_relationships[0].status_code
-    assert expected_status_code == actual_status_code
+    dynamic_relationships = string_utils.convert_to_list(dynamic_relationships)
+    assert all(expected_status_code == relationship.status_code
+               for relationship in dynamic_relationships)
     assert (
         (rest_service.RelationshipsService().map_objs(
             src_obj=new_control_rest,

--- a/test/selenium/src/tests/test_snapshots.py
+++ b/test/selenium/src/tests/test_snapshots.py
@@ -635,14 +635,12 @@ class TestSnapshots(base.Test):
     """
     mapped_audit = create_audit_with_control_and_update_control[
         'new_audit_rest'][0]
-    source_obj = (dynamic_object[0].repr_ui().update_attrs(
-        custom_attributes={None: None}))
-    obj_service = get_ui_service(source_obj.type)(selenium)
+    obj_service = get_ui_service(dynamic_object.type)(selenium)
     objs_types_from_mapper = (
         obj_service.get_objs_available_to_map_via_mapper(src_obj=mapped_audit))
     objs_types_from_add_widget = (
         obj_service.get_objs_available_to_map_via_add_widget(
-            src_obj=source_obj))
+            src_obj=dynamic_object))
     expected_objs_types = sorted(
         objects.get_normal_form(snap_obj)
         for snap_obj in objects.ALL_SNAPSHOTABLE_OBJS)

--- a/test/selenium/src/tests/test_snapshots.py
+++ b/test/selenium/src/tests/test_snapshots.py
@@ -5,13 +5,13 @@
 # pylint: disable=invalid-name
 # pylint: disable=unused-argument
 # pylint: disable=too-many-arguments
+# pylint: disable=too-many-locals
 
 import pytest
 
 from lib import base
 from lib.constants import messages, objects
 from lib.constants.element import Lhn, MappingStatusAttrs
-from lib.entities import entity
 from lib.factory import get_ui_service
 from lib.page import dashboard
 from lib.service import webui_service
@@ -123,7 +123,7 @@ class TestSnapshots(base.Test):
     assert is_control_openable is is_openable
     assert (True if is_control_updateable is is_updateable else
             pytest.xfail(reason="Issue in app GGRC-1773"))
-    entity.Entity.issue_assert(
+    self.extended_assert(
         expected_objs=expected_control, actual_objs=actual_control,
         issue_msg="Issue in app GGRC-2344", custom_attributes={None: None})
 
@@ -195,7 +195,7 @@ class TestSnapshots(base.Test):
         get_list_objs_from_info_panels(src_obj=audit, objs=expected_control))
     assert is_control_openable is is_openable
     assert is_control_updateable is is_updateable
-    entity.Entity.issue_assert(
+    self.extended_assert(
         expected_objs=expected_control, actual_objs=actual_control,
         issue_msg="Issue in app GGRC-2344", custom_attributes={None: None})
 
@@ -534,7 +534,7 @@ class TestSnapshots(base.Test):
     export_service.export_objs_via_tree_view(src_obj=dynamic_object)
     actual_controls = export_service.get_list_objs_from_csv(
         path_to_export_dir=create_tmp_dir)
-    entity.Entity.issue_assert(
+    self.extended_assert(
         expected_objs=[expected_control], actual_objs=actual_controls,
         issue_msg="Issue in app GGRC-2750", owners={None: None})
 


### PR DESCRIPTION
This PR add 3 parametrized test-cases of exporting snapshoted Control from Audit, Issue's, Assessment's Info Pages.

**Test-case:**
```Python
  @pytest.mark.xfail(strict=True)
  @pytest.mark.smoke_tests
  @pytest.mark.parametrize(
      "dynamic_object, dynamic_relationships",
      [(None, None),
       ("new_issue_rest",
        "map_new_issue_rest_to_new_control_rest_snapshot"),
       pytest.mark.xfail(reason="Issue GGRC-1909", strict=True)(
           ("new_assessment_rest",
            "map_new_assessment_rest_to_new_control_rest_snapshot"))],
      ids=["Export of snapshoted Control from Audit's Info Page "
           "via mapped Controls' Tree View",
           "Export of snapshoted Control from Issue's Info Page "
           "via mapped Controls' Tree View",
           "Export of snapshoted Control from Assessment's Info Page "
           "via mapped Controls' Tree View"],
      indirect=["dynamic_object", "dynamic_relationships"])
  @pytest.mark.smoke_tests
  def test_export_of_snapshoted_control_from_src_objs_pages_via_tree_view(
      self, create_tmp_dir, create_audit_with_control_and_update_control,
      dynamic_object, dynamic_relationships, selenium
  ):
    """Check if snapshoted Control can be exported from (Audit's, Issue's,
    Assessment's) Info Page via mapped Controls's Tree View.
    Preconditions:
    - Execution and return of fixtures:
      - 'create_tmp_dir';
      - 'create_audit_and_update_first_of_two_original_controls'.
    Test parameters:
    - 'dynamic_object';
    - 'dynamic_relationships'.
    """
    audit_with_one_control = create_audit_with_control_and_update_control
    dynamic_object = (dynamic_object if dynamic_object
                      else audit_with_one_control["new_audit_rest"][0])
    # due to 'actual_control.custom_attributes = {None: None}'
    expected_control = (audit_with_one_control["new_control_rest"][0].
                        repr_ui().update_attrs(custom_attributes={None: None}))
    export_service = webui_service.BaseWebUiService(
        selenium, objects.get_plural(expected_control.type))
    export_service.export_objs_via_tree_view(src_obj=dynamic_object)
    actual_controls = export_service.get_list_objs_from_csv(
        path_to_export_dir=create_tmp_dir)
    # due to issue in app GGRC-2750
    exp_objs_wo_ex_attrs, act_objs_wo_ex_attrs, exp_ex_attrs, act_ex_attrs = (
        Representation.prepare_entities_excluding_attrs(
            expected_objs=[expected_control], actual_objs=actual_controls,
            owners={None: None}))
    assert exp_objs_wo_ex_attrs == act_objs_wo_ex_attrs, (
        messages.AssertionMessages.
        format_err_msg_equal(exp_objs_wo_ex_attrs, act_objs_wo_ex_attrs))
    assert (True if Representation.is_list_of_attrs_equal(
        exp_ex_attrs, act_ex_attrs)
        else pytest.xfail(reason="Issue in app GGRC-2750"))
```

**Additionally:**
- Add new dynamic model to work w/ shapshots via REST;
-  Improve and extend TAF's REST services to work with shapshots;
- Add new model to represent exist objects as snapshots;
- Improve extended assertion in a part of xfail due to issue;
- Improve audit test module and add xfail assert for program obj.