### PR TITLE
GGRC-2651 Fix queryAPI failing (HTTP500) if multiple "relevant" filters applied

### DIFF
--- a/src/ggrc/converters/custom_operators.py
+++ b/src/ggrc/converters/custom_operators.py
@@ -307,7 +307,7 @@ def relevant(exp, object_class, target_class, query):
   ).options(
       load_only("destination_id")
   ).distinct()
-  ids_qs = dest_qs.union(source_qs).distinct().subquery("ids")
+  ids_qs = dest_qs.union(source_qs).distinct().subquery()
   return object_class.id == ids_qs.c.relationships_source_id
 
 

--- a/test/integration/ggrc/services/test_query/test_basic.py
+++ b/test/integration/ggrc/services/test_query/test_basic.py
@@ -13,12 +13,15 @@ from datetime import datetime
 from operator import itemgetter
 from flask import json
 
+import ddt
+
 from ggrc import app
 from ggrc import db
 from ggrc import models
-from ggrc.models import CustomAttributeDefinition as CAD
+from ggrc.models import CustomAttributeDefinition as CAD, all_models
+from ggrc.snapshotter.rules import Types
 
-from integration.ggrc import TestCase
+from integration.ggrc import TestCase, generator
 from integration.ggrc.models import factories
 
 
@@ -36,6 +39,7 @@ class BaseQueryAPITestCase(TestCase):
     # we don't call super as TestCase.setUp clears the DB
     # super(BaseQueryAPITestCase, self).setUp()
     self.client.get("/login")
+    self.generator = generator.ObjectGenerator()
 
   def _post(self, data):
     """Make a POST to /query endpoint."""
@@ -94,6 +98,7 @@ class BaseQueryAPITestCase(TestCase):
 
 
 # pylint: disable=too-many-public-methods
+@ddt.ddt
 class TestAdvancedQueryAPI(BaseQueryAPITestCase):
   """Basic tests for /query api."""
 
@@ -766,6 +771,94 @@ class TestAdvancedQueryAPI(BaseQueryAPITestCase):
                      set([program["title"] for program
                           in programs["values"]]))
 
+  @ddt.data(
+      (all_models.Control, [all_models.Objective, all_models.Control,
+                            all_models.Market, all_models.Objective]),
+      (all_models.Assessment, [all_models.Control, all_models.Control,
+                               all_models.Market, all_models.Objective]),
+      (all_models.Assessment, [all_models.Issue, all_models.Issue,
+                               all_models.Issue, all_models.Issue]),
+      (all_models.Issue, [all_models.Assessment, all_models.Control,
+                          all_models.Market, all_models.Objective]),
+  )
+  @ddt.unpack
+  def test_search_relevant_to_type(self, base_type, relevant_types):
+    """Test filter with 'relevant to' conditions."""
+    is_scoped = base_type.__name__ in Types.scoped
+    audit_data = {}
+    if is_scoped:
+      audit = factories.AuditFactory()
+      audit_data = {"audit": {"id": audit.id}}
+
+    _, base_obj = self.generator.generate_object(base_type, audit_data)
+    relevant_objects = [
+        self.generator.generate_object(type_, audit_data)[1]
+        for type_ in relevant_types
+    ]
+
+    with factories.single_commit():
+      query_data = []
+      for relevant_obj in relevant_objects:
+        related_obj = relevant_obj
+
+        # Snapshotable objects are related through the Snapshot
+        if is_scoped and relevant_obj.type in Types.all:
+          related_obj = factories.SnapshotFactory(
+              parent=audit,
+              child_id=relevant_obj.id,
+              child_type=relevant_obj.type,
+              revision_id=models.Revision.query.filter_by(
+                  resource_type=relevant_obj.type
+              ).first().id,
+          )
+        factories.RelationshipFactory(source=base_obj, destination=related_obj)
+
+        query_data.append(self._make_query_dict(
+            relevant_obj.type,
+            expression=["id", "=", relevant_obj.id],
+            type_="ids",
+        ))
+
+    filter_relevant = {
+        "filters": {
+            "expression": {
+                "left": {
+                    "left": {
+                        "ids": "0",
+                        "object_name": "__previous__",
+                        "op": {"name": "relevant"}
+                    },
+                    "op": {"name": "AND"},
+                    "right": {
+                        "ids": "1",
+                        "object_name": "__previous__",
+                        "op": {"name": "relevant"}
+                    }
+                },
+                "op": {"name": "AND"},
+                "right": {
+                    "left": {
+                        "ids": "2",
+                        "object_name": "__previous__",
+                        "op": {"name": "relevant"}
+                    },
+                    "op": {"name": "AND"},
+                    "right": {
+                        "ids": "3",
+                        "object_name": "__previous__",
+                        "op": {"name": "relevant"}
+                    }
+                }
+            }
+        },
+        "object_name": base_type.__name__
+    }
+    query_data.append(filter_relevant)
+    response = json.loads(self._post(query_data).data)
+    # Last batch contain result for query with "related" condition
+    result_count = response[-1][base_type.__name__]["count"]
+    self.assertEqual(result_count, 1)
+
 
 class TestQueryAssessmentCA(BaseQueryAPITestCase):
   """Test filtering assessments by CAs"""
@@ -779,9 +872,9 @@ class TestQueryAssessmentCA(BaseQueryAPITestCase):
     self.client.get("/login")
 
   def _generate_special_assessments(self):
+    """Generate two Assessments for two local CADs with same name."""
     assessment_with_date = None
     assessment_with_text = None
-    """Generate two Assessments for two local CADs with same name."""
     audit = factories.AuditFactory(
         slug="audit"
     )


### PR DESCRIPTION
Applying several "relevant" filters to assessment lead to queryAPI failing (HTTP500). Backend error looked like following:

`OperationalError: (OperationalError) (1066, "Not unique table/alias: 'ids'") 'SELECT assessments.id AS assessments_id \nFROM assessments, (SELECT DISTINCT anon_1.relationships_id AS relationships_id, anon_1.relationships_source_id AS relationships_source_id \nFROM (SELECT DISTINCT relationships.id AS relationships_id, relationships.source_id AS relationships_source_id \nFROM relationships, (SELECT DISTINCT snapshots.id AS id \nFROM snapshots \nWHERE snapshots.parent_type = %s AND snapshots.child_type = %s AND snapshots.child_id != snapshots.child_id) AS snapshot \nWHERE relationships.destination_id = snapshot.id AND relationships.destination_type = %s AND relationships.source_type = %s UNION SELECT DISTINCT relationships.id AS relationships_id, relationships.destination_id AS relationships_destination_id \nFROM relationships, (SELECT DISTINCT snapshots.id AS id \nFROM snapshots \nWHERE snapshots.parent_type = %s AND snapshots.child_type = %s AND snapshots.child_id != snapshots.child_id) AS snapshot \nWHERE relationships.source_id = snapshot.id AND relationships.source_type = %s AND relationships.destination_type = %s) AS anon_1) AS ids, (SELECT DISTINCT anon_2.relationships_id AS relationships_id, anon_2.relationships_source_id AS relationships_source_id \nFROM (SELECT DISTINCT relationships.id AS relationships_id, relationships.source_id AS relationships_source_id \nFROM relationships, (SELECT DISTINCT snapshots.id AS id \nFROM snapshots \nWHERE snapshots.parent_type = %s AND snapshots.child_type = %s AND snapshots.child_id IN (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)) AS snapshot \nWHERE relationships.destination_id = snapshot.id AND relationships.destination_type = %s AND relationships.source_type = %s UNION SELECT DISTINCT relationships.id AS relationships_id, relationships.destination_id AS relationships_destination_id \nFROM relationships, (SELECT DISTINCT snapshots.id AS id \nFROM snapshots \nWHERE snapshots.parent_type = %s AND snapshots.child_type = %s AND snapshots.child_id IN (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)) AS snapshot \nWHERE relationships.source_id = snapshot.id AND relationships.source_type = %s AND relationships.destination_type = %s) AS anon_2) AS ids \nWHERE assessments.id IN (SELECT anon_3.anon_4_custom_attribute_values_attributable_id AS anon_3_anon_4_custom_attribute_values_attributable_id \nFROM (SELECT anon_4.custom_attribute_values_attributable_id AS anon_4_custom_attribute_values_attributable_id \nFROM (SELECT custom_attribute_values.attributable_id AS custom_attribute_values_attributable_id \nFROM custom_attribute_values \nWHERE custom_attribute_values.attributable_type = %s AND custom_attribute_values.attribute_value = %s AND custom_attribute_values.attribute_object_id IN (%s) UNION SELECT custom_attribute_values.attribute_object_id AS custom_attribute_values_attribute_object_id \nFROM custom_attribute_values \nWHERE custom_attribute_values.attribute_value = %s AND custom_attribute_values.attributable_type = %s AND custom_attribute_values.attributable_id IN (%s)) AS anon_4 UNION SELECT relationships.destination_id AS relationships_destination_id \nFROM relationships \nWHERE relationships.destination_type = %s AND relationships.source_type = %s AND relationships.source_id IN (%s) UNION SELECT relationships.source_id AS relationships_source_id \nFROM relationships \nWHERE relationships.source_type = %s AND relationships.destination_type = %s AND relationships.destination_id IN (%s) UNION SELECT anon_5.anon_6 AS anon_5_anon_6 \nFROM (SELECT DISTINCT assessments.id AS anon_6 \nFROM assessments INNER JOIN user_roles ON user_roles.context_id = assessments.context_id \nWHERE user_roles.person_id IN (%s)) AS anon_5 UNION SELECT object_people.personable_id AS object_people_personable_id \nFROM object_people \nWHERE object_people.personable_type = %s AND object_people.person_id IN (%s) UNION SELECT object_owners.ownable_id AS object_owners_ownable_id \nFROM object_owners \nWHERE object_owners.ownable_type = %s AND object_owners.person_id IN (%s)) AS anon_3) AND assessments.id NOT IN (SELECT fulltext_record_properties.`key` AS fulltext_record_properties_key \nFROM fulltext_record_properties \nWHERE fulltext_record_properties.type = %s AND fulltext_record_properties.property = %s AND fulltext_record_properties.content = %s) AND assessments.id = ids.relationships_source_id AND assessments.id = ids.relationships_source_id \n LIMIT %s, %s' ('Audit', 'AccessGroup', 'Snapshot', 'Assessment', 'Audit', 'AccessGroup', 'Snapshot', 'Assessment', 'Audit', 'AccessGroup', 10L, 15L, 49L, 77L, 78L, 79L, 1L, 5L, 17L, 34L, 37L, 39L, 41L, 42L, 48L, 52L, 57L, 60L, 61L, 66L, 85L, 3L, 11L, 12L, 13L, 86L, 2L, 51L, 71L, 76L, 21L, 23L, 24L, 25L, 26L, 68L, 70L, 50L, 35L, 40L, 43L, 44L, 46L, 56L, 63L, 64L, 65L, 67L, 47L, 75L, 84L, 87L, 88L, 89L, 93L, 94L, 92L, 72L, 74L, 100L, 98L, 91L, 80L, 95L, 97L, 99L, 101L, 102L, 96L, 'Snapshot', 'Assessment', 'Audit', 'AccessGroup', 10L, 15L, 49L, 77L, 78L, 79L, 1L, 5L, 17L, 34L, 37L, 39L, 41L, 42L, 48L, 52L, 57L, 60L, 61L, 66L, 85L, 3L, 11L, 12L, 13L, 86L, 2L, 51L, 71L, 76L, 21L, 23L, 24L, 25L, 26L, 68L, 70L, 50L, 35L, 40L, 43L, 44L, 46L, 56L, 63L, 64L, 65L, 67L, 47L, 75L, 84L, 87L, 88L, 89L, 93L, 94L, 92L, 72L, 74L, 100L, 98L, 91L, 80L, 95L, 97L, 99L, 101L, 102L, 96L, 'Snapshot', 'Assessment', 'Assessment', 'Person', 150, 'Assessment', 'Person', 150, 'Assessment', 'Person', 150, 'Assessment', 'Person', 150, 150, 'Assessment', 150, 'Assessment', 150, 'Assessment', 'status', 'Not Started', 0, 10)`