### PR TITLE
GGRC-2530 Remove query for related original object ids on initialization of  page

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
@@ -8,14 +8,12 @@
     defaults: {
       widget_descriptors: null
     }
-
   }, {
     init: function (el, options) {
       CMS.Models.DisplayPrefs.getSingleton().then(function (prefs) {
         this.display_prefs = prefs;
 
         this.init_tree_view_settings();
-        this.initCurrentRelatedInstanses();
         this.init_page_title();
         this.init_page_help();
         this.init_page_header();
@@ -60,21 +58,6 @@
     '[data-toggle="modal-ajax-form"] click': 'disableAll',
     '[data-toggle="unified-search"] click': 'disableAll',
     '[data-toggle="unified-mapper"] click': 'disableAll',
-
-    initCurrentRelatedInstanses: function () {
-      var instance;
-      if (!GGRC.Utils.CurrentPage.isObjectContextPage()) {
-        return;
-      }
-
-      instance = this.options.instance;
-
-      GGRC.Utils.CurrentPage.initMappedInstances(
-        GGRC.Mappings.getMappingList(instance.type), {
-          type: instance.type,
-          id: instance.id
-        });
-    },
 
     init_page_title: function () {
       var pageTitle = null;


### PR DESCRIPTION
Single assessment info page makes a query to fetch all ids from related original objects.

That query should not be needed since we must only use snapshots on assessment page.

Additionally if the data is actually needed, we should discuss on why it could not be retrieved from snapshots themselves since they contain all data on their original objects.