### PR TITLE
GGRC-2730 "Uncaught TypeError: Cannot read property 'filter' of undefined" error occurs while adding a person to Custom role field in New Assessment modal window

### DIFF
--- a/src/ggrc/assets/javascripts/models/assessment.js
+++ b/src/ggrc/assets/javascripts/models/assessment.js
@@ -16,7 +16,7 @@
     mixins: [
       'ownable', 'unique_title',
       'autoStatusChangeable', 'timeboxed', 'mapping-limit',
-      'inScopeObjects'
+      'inScopeObjects', 'accessControlList'
     ],
     is_custom_attributable: true,
     isRoleable: true,

--- a/src/ggrc/assets/javascripts/models/mixins.js
+++ b/src/ggrc/assets/javascripts/models/mixins.js
@@ -128,6 +128,14 @@
     }
   });
 
+  can.Model.Mixin('accessControlList', {
+    'after:init': function () {
+      if (!this.access_control_list) {
+        this.attr('access_control_list', []);
+      }
+    }
+  });
+
   can.Model.Mixin('ca_update', {}, {
     after_save: function () {
       this.attr('isReadyForRender', true);


### PR DESCRIPTION
_Steps to reproduce:_
1. On the audit page invoke New assessment modal window
2. Add a person to the custom role field (e.g. "Primary contacts")
3. Look at the screen: JS error occurs

_Actual Result_: "Uncaught TypeError: Cannot read property 'filter' of undefined" error occurs while adding a person to Custom role field in New Assessment modal window
_Expected Result_: no error is displayed while adding a person to Custom role field in New Assessment modal window

![screenshot-1](https://user-images.githubusercontent.com/4204416/28063304-63255ad0-6639-11e7-842a-c0151424ae1d.png)
