### PR TITLE
GGRC-1666 Default Assessment "Default Assignee" should be able to be blank

### DIFF
--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -334,7 +334,7 @@
       test_plan_procedure: false,
       template_object_type: 'Control',
       default_people: {
-        assessors: 'Audit Lead',
+        assessors: '',
         verifiers: 'Auditors'
       },
       // the custom lists of assessor / verifier IDs if "other" is selected for
@@ -364,6 +364,7 @@
     init: function () {
       this._super.apply(this, arguments);
       this.validateNonBlank('title');
+      this.validateNonBlank('default_people.assessors');
 
       this.validateListNonBlank(
         'assessorsList',

--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -2664,6 +2664,48 @@ Example:
   );
 
   /**
+   * Check if property's value did not pass validation, and render the
+   * corresponding block in the template. The error messages, if any, are
+   * available in the "error" variable within the "truthy" block.
+   *
+   * Example usage:
+   *
+   *   {{#validation_error validationErrors propertyName}}
+   *     Invalid value for the property {{propertyName}}: {{errors.0}}
+   *   {{else}}
+   *     Hooray, no errors, a correct value is set!
+   *   {{/validation_error}}
+   *
+   * @param {Object} validationErrors - an object containing validation results
+   *   of a can.Model instance
+   * @param {Number} propertyName - Name of the property to check for
+   *   validation errors
+   * @param {Object} options - a CanJS options argument passed to every helper
+   */
+  Mustache.registerHelper(
+    'validation_error',
+    function (validationErrors, propertyName, options) {
+      var errors;
+      var property;
+      var contextStack;
+
+      validationErrors = Mustache.resolve(validationErrors) || {};
+      if (_.isFunction(validationErrors)) {
+        validationErrors = Mustache.resolve(validationErrors) || {};
+      }
+
+      property = Mustache.resolve(propertyName);
+      errors = validationErrors[property] || [];
+
+      if (errors.length > 0) {
+        contextStack = options.contexts.add({errors: errors});
+        return options.fn(contextStack);
+      }
+      return options.inverse(options.contexts);
+    }
+  );
+
+  /**
    * Check if Custom Atttribute's value did not pass validation, and render the
    * corresponding block in the template. The error messages, if any, are
    * available in the "error" variable within the "truthy" block.

--- a/src/ggrc/assets/js_specs/mustache_helpers/validation_error_spec.js
+++ b/src/ggrc/assets/js_specs/mustache_helpers/validation_error_spec.js
@@ -1,0 +1,61 @@
+/*!
+  Copyright (C) 2017 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+describe('can.mustache.helper.validation_error', function () {
+  'use strict';
+
+  var helper;
+  var fakeOptions;
+
+  beforeAll(function () {
+    helper = can.Mustache._helpers.validation_error.fn;
+  });
+
+  beforeEach(function () {
+    fakeOptions = {
+      fn: jasmine.createSpy('options.fn'),
+      inverse: jasmine.createSpy('options.inverse'),
+      contexts: {
+        add: jasmine.createSpy('contexts.add')
+      }
+    };
+  });
+
+  it('renders the "truthy" block if there are validation errors for the ' +
+    'property',
+    function () {
+      var validationErrors = {
+        'property_name.1': ['invalid value']
+      };
+      helper(validationErrors, 'property_name.1', fakeOptions);
+      expect(fakeOptions.fn).toHaveBeenCalled();
+    }
+  );
+
+  it('adds the errors list to the scope if there are validation errors for ' +
+    'the property',
+    function () {
+      var validationErrors = {
+        'property_name.1': ['invalid  date format'],
+        'property_name.4': ['value is too short', 'not a number']
+      };
+      helper(validationErrors, 'property_name.4', fakeOptions);
+      expect(fakeOptions.contexts.add).toHaveBeenCalledWith(
+        {errors: ['value is too short', 'not a number']}
+      );
+    }
+  );
+
+  it('renders the "falsy" block if there are no validation errors for the ' +
+    'property',
+    function () {
+      var validationErrors = {
+        'property_name.4': ['invalid value']
+      };
+      helper(validationErrors, 'property_name', fakeOptions);
+      expect(fakeOptions.inverse).toHaveBeenCalled();
+    }
+  );
+});

--- a/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
@@ -117,7 +117,8 @@
 
       <div class="span6">
         <div class="row-fluid choose-from-select">
-          <div class="span6 bottom-spacing">
+
+          <div class="span6 bottom-spacing{{#validation_error instance.computed_errors 'default_people.assessors'}} field-failure{{/validation_error}}">
             <label>
               Default Assignees
               <span class="required">*</span>
@@ -127,8 +128,15 @@
               options-list="instance.people_values"
               name="instance.default_people.assessors"
               on-change="instance.defaultAssesorsChanged"
+              no-value="true"
+              no-value-label=" "
             ></dropdown>
+
+            {{#validation_error instance.computed_errors 'default_people.assessors'}}
+              <label class="help-inline warning">{{errors.0}}</label>
+            {{/validation_error}}
           </div>
+
 
           <div class="span6{{#instance.computed_errors.assessorsList}} field-failure{{/instance.computed_errors.assessorsList}}">
             <label>&nbsp;</label>

--- a/src/ggrc/assets/stylesheets/_common.scss
+++ b/src/ggrc/assets/stylesheets/_common.scss
@@ -316,6 +316,9 @@ select.input-block-level {
   label {
     color: $red;
   }
+  select {
+    border: 1px solid $red;
+  }
   .help-inline {
     margin: -8px 0 8px 0;
     display: block;

--- a/src/ggrc/assets/stylesheets/modules/_modal.scss
+++ b/src/ggrc/assets/stylesheets/modules/_modal.scss
@@ -419,6 +419,9 @@
       label {
         color: $red;
       }
+      select {
+        border: 1px solid $red;
+      }
       .help-inline {
         margin: -8px 0 8px 0;
         display: block;

--- a/test/selenium/src/lib/constants/locator.py
+++ b/test/selenium/src/lib/constants/locator.py
@@ -453,6 +453,11 @@ class ModalCreateNewAsmt(BaseModalCreateNew):
 
 class ModalCreateNewAsmtTmpl(BaseModalCreateNew):
   """Locators for Create new Assessment Template modals."""
+  ASSIGNEE_DROPDOWN = (
+      By.CSS_SELECTOR, 'select[can-value="instance.default_people.assessors"]')
+  ASSIGNEE_DROPDOWN_OPTION = (
+      By.CSS_SELECTOR,
+      'select[can-value="instance.default_people.assessors"] option')
 
 
 class ModalEditObject(BaseModalCreateNew):

--- a/test/selenium/src/lib/entities/entities_factory.py
+++ b/test/selenium/src/lib/entities/entities_factory.py
@@ -669,6 +669,7 @@ class AssessmentTemplatesFactory(EntitiesFactory):
     random_asmt_tmpl = AssessmentTemplateEntity()
     random_asmt_tmpl.type = cls.obj_asmt_tmpl
     random_asmt_tmpl.title = cls.generate_string(cls.obj_asmt_tmpl)
+    random_asmt_tmpl.assessors = unicode(roles.AUDIT_LEAD)
     random_asmt_tmpl.slug = cls.generate_slug()
     random_asmt_tmpl.template_object_type = cls.obj_control.title()
     random_asmt_tmpl.default_people = {"verifiers": unicode(roles.AUDITORS),

--- a/test/selenium/src/lib/page/modal/base.py
+++ b/test/selenium/src/lib/page/modal/base.py
@@ -259,6 +259,14 @@ class AsmtTmplModal(BaseModal):
 
   def __init__(self, driver):
     super(AsmtTmplModal, self).__init__(driver)
+    self.ui_assignees = base.DropdownStatic(
+        driver, locator.ModalCreateNewAsmtTmpl.ASSIGNEE_DROPDOWN,
+        locator.ModalCreateNewAsmtTmpl.ASSIGNEE_DROPDOWN_OPTION)
+
+  def select_assignee(self, assignee):
+    """Select 'Default Assignees' from drop down list."""
+    self.ui_assignees.select(assignee)
+    return self.__class__(self._driver)
 
 
 class AsmtsModal(BaseModal):

--- a/test/selenium/src/lib/service/webui_service.py
+++ b/test/selenium/src/lib/service/webui_service.py
@@ -367,6 +367,14 @@ class AssessmentTemplatesService(BaseWebUiService):
     super(AssessmentTemplatesService, self).__init__(
         driver, objects.ASSESSMENT_TEMPLATES)
 
+  def create_obj_via_tree_view(self, src_obj, obj):
+    """Open generic widget of mapped objects, open creation modal from
+    Tree View, fill data according to object attributes and create new object.
+    """
+    objs_widget = self.open_widget_of_mapped_objs(src_obj)
+    (objs_widget.tree_view.open_create().select_assignee(obj.assessors).
+        fill_minimal_data(title=obj.title, code=obj.slug).save_and_close())
+
 
 class AssessmentsService(BaseWebUiService):
   """Class for Assessments business layer's services objects."""


### PR DESCRIPTION
_Steps to reproduce:_
Whenever the auditors create a new assessment, it is assigned to the default auditor. It seems like the default template does not let this be blank by default. As we have many audits with a variety of people working, the default value should be able to be blank. The assignee should be required; but it does not need to have a default value.

_Expected result:_ Default assignee should be blank

_Notes:_ The value is still required before submission but it doesnt need to be pre populated, the user should select the assignee.