### PR TITLE
GGRC-1654 Issues with Gdrive attachments in GGRC

### DIFF
--- a/src/ggrc_gdrive_integration/assets/javascripts/components/gdrive_picker_launcher.js
+++ b/src/ggrc_gdrive_integration/assets/javascripts/components/gdrive_picker_launcher.js
@@ -218,6 +218,16 @@
                     that, 'modal:success', {arr: can.makeArray(arguments)});
                   el.trigger('modal:success', {arr: can.makeArray(arguments)});
                 });
+              })
+              .fail(function () {
+                // This case happens when user have no access to write in audit folder
+                var error = _.last(arguments);
+                if (error && error.code === 403) {
+                  GGRC.Errors.notifier('error', GGRC.Errors.messages[403]);
+
+                  can.trigger(that, 'modal:success');
+                  el.trigger('modal:success');
+                }
               });
           });
       },


### PR DESCRIPTION
Steps:
1) Have assigned folder to audit which does not belongs to user;
2) Go to assessments tab and try attach evidences to assessment;

Actual result: no error, infinite spinner, Attach button is disabled.
Expected result: Show permission error, no spinner, Attach button is active.