### PR TITLE
GGRC-829 Local Custom Attributes after Assessment generation are displayed out of order in Assessment's Info pane

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/tree/tree-loader.js
+++ b/src/ggrc/assets/javascripts/controllers/tree/tree-loader.js
@@ -167,6 +167,11 @@
         list = this.options.list;
       }
 
+      // make attributes queue is correct.
+      list.sort(function (a, b) {
+        return a.id - b.id;
+      });
+
       if (!this.element) {
         return undefined;  // controller has been destroyed
       }


### PR DESCRIPTION
Task part from description was already solved. So i fixed bug from this comment:
How to reproduce bug:
1. Go to Administration -> Custom attributes page
2. Add a new custom attribute, name it "Last". It will get added to the bottom. This is correct.
3. Refresh the page. Last is now going to be on the top of the list. This is incorrect.
