### PR TITLE
GGRC-1797 Switching between two snapshots now always trigers an extra query

### DIFF
--- a/src/ggrc/assets/javascripts/components/snapshotter/tests/revisions-comparer_spec.js
+++ b/src/ggrc/assets/javascripts/components/snapshotter/tests/revisions-comparer_spec.js
@@ -165,4 +165,90 @@ describe('GGRC.Components.revisionsComparer', function () {
       expect(dfds.length).toEqual(0);
     });
   });
+
+  describe('getRevisions() method', function () {
+    var method;
+    var Revision;
+
+    beforeEach(function () {
+      method = Component.prototype.scope.getRevisions;
+      Revision = CMS.Models.Revision;
+    });
+
+    it('when cache is empty doing ajax call for all revisions',
+      function (done) {
+        Revision.store = undefined;
+
+        spyOn(Revision, 'findAll').and.returnValue(
+          can.Deferred().resolve([{id: 42}, {id: 11}])
+        );
+
+        spyOn(Revision, 'findOne').and.returnValue(
+          can.Deferred().resolve({id: 42})
+        );
+
+        method(42, 11).then(function (result) {
+          expect(result.length).toEqual(2);
+
+          expect(Revision.findAll).toHaveBeenCalledWith({
+            id__in: '42,11'
+          });
+
+          expect(Revision.findOne).not.toHaveBeenCalled();
+
+          done();
+        });
+      });
+
+    it('when in cache only one object doing findOne call',
+      function (done) {
+        Revision.store = {
+          '42': {id: 42}
+        };
+
+        spyOn(Revision, 'findAll').and.returnValue(
+          can.Deferred().resolve([{id: 42}, {id: 11}])
+        );
+
+        spyOn(Revision, 'findOne').and.returnValue(
+          can.Deferred().resolve({id: 42})
+        );
+
+        method(42, 11).then(function (result) {
+          expect(result.length).toEqual(2);
+
+          expect(Revision.findAll).not.toHaveBeenCalled();
+
+          expect(Revision.findOne).toHaveBeenCalledWith({id: 11});
+
+          done();
+        });
+      });
+
+    it('when cache contains all objects are not doing ajax call',
+      function (done) {
+        Revision.store = {
+          '11': {id: 11},
+          '42': {id: 42}
+        };
+
+        spyOn(Revision, 'findAll').and.returnValue(
+          can.Deferred().resolve([{id: 42}, {id: 11}])
+        );
+
+        spyOn(Revision, 'findOne').and.returnValue(
+          can.Deferred().resolve({id: 42})
+        );
+
+        method(42, 11).then(function (result) {
+          expect(result.length).toEqual(2);
+
+          expect(Revision.findAll).not.toHaveBeenCalled();
+
+          expect(Revision.findOne).not.toHaveBeenCalled();
+
+          done();
+        });
+      });
+  });
 });


### PR DESCRIPTION
Performance research:
https://github.com/google/ggrc-core/pull/5489/commits/86be6ccd2f26f1b61e53b19c656d4c4b8a50f920#r110023039

> zidarsk8 16 hours ago • edited Collaborator
>
> We should really try to avoid making requests that are not needed. Switching between two snapshots now always trigers an extra query which is quite bad.
> Since revisions are immutable it would be best to always check if the current Id exists in cache before sending this query. ~CMS.Models.Revision.cache.indexOf(revisionDi)