### PR TITLE
GGRC-2407 If assessment is completed and verified, "Undo" doesn't return assessment to Ready for review state

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.js
+++ b/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.js
@@ -60,7 +60,7 @@
               !this.attr('instance.archived');
           },
           set: function () {
-            this.onStateChange({state: 'In Progress', undo: true});
+            this.onStateChange({state: 'In Progress', undo: false});
           }
         },
         instance: {}
@@ -189,26 +189,23 @@
         this.attr('triggerFormSaveCbs').fire();
       },
       onStateChange: function (event) {
-        var undo = event.undo;
-        var state = event.state;
+        var isUndo = event.undo;
+        var newStatus = event.state;
         var instance = this.attr('instance');
         var self = this;
+        var previousStatus = instance.attr('previousStatus') || 'In Progress';
 
-        if (!instance.attr('_undo')) {
-          instance.attr('_undo', []);
-        }
-
-        if (undo) {
-          instance.attr('_undo').shift();
+        if (isUndo) {
+          instance.attr('previousStatus', undefined);
         } else {
-          instance.attr('_undo').unshift(state);
+          instance.attr('previousStatus', instance.attr('status'));
         }
         instance.attr('isPending', true);
 
         this.attr('formState.formSavedDeferred')
           .then(function () {
             instance.refresh().then(function () {
-              instance.attr('status', state);
+              instance.attr('status', isUndo ? previousStatus : newStatus);
               return instance.save()
               .then(function () {
                 instance.attr('isPending', false);

--- a/src/ggrc/assets/javascripts/components/object-state-toolbar/object-state-toolbar.js
+++ b/src/ggrc/assets/javascripts/components/object-state-toolbar/object-state-toolbar.js
@@ -65,12 +65,12 @@
       isInReview: function () {
         return this.attr('instance.status') === 'Ready for Review';
       },
-      changeState: function (newState, undo) {
+      changeState: function (newState, isUndo) {
         newState = newState || this.attr('updateState');
         this.dispatch({
           type: 'onStateChange',
           state: newState,
-          undo: undo
+          undo: isUndo
         });
       }
     }

--- a/src/ggrc/assets/mustache/components/object-state-toolbar/object-state-toolbar.mustache
+++ b/src/ggrc/assets/mustache/components/object-state-toolbar/object-state-toolbar.mustache
@@ -22,7 +22,7 @@
     {{/if}}
   {{/if}}
   {{#unless isInProgress}}
-    {{#instance._undo.0}}
+    {{#instance.previousStatus}}
         <button class="btn btn-small btn-link object-state-toolbar__item"
                 {{#if isDisabled}}disabled{{/if}}
                 ($click)="changeState('In Progress', true)">Undo


### PR DESCRIPTION
Steps to reproduce:
1. Have assessment with verifier
2. Log as verifier and complete and verify assessment
3. Click "undo" button near 3 bb's menu
4. Look at the assessment state: it returns back ti verified state and then to Completed again

**Actual Result:** If assessment is completed and verified, "Undo" doesn't return assessment to Ready for review state
**Expected Result:** If assessment is completed and verified, "Undo" should return assessment to Ready for review state