### PR TITLE
GGRC-1944 Unified mapper duplicated if click "Map to this object" in Assessment first tier twice

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/modals_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/modals_controller.js
@@ -691,6 +691,10 @@
       }, this);
     },
 
+    '[data-toggle="unified-mapper"] click': function (el, ev) {
+      document.body.classList.add('no-events');
+    },
+
     "{$footer} a.btn[data-toggle='modal-submit-addmore'] click":
       function (el, ev) {
         if (el.hasClass('disabled')) {


### PR DESCRIPTION
Unified Mapper is duplicated if click twice [Map objects] button in Edit Assessment modal window.
**Steps to reproduce:**
1. Open Edit Assessment modal window
2. Click [Map objects] button twice
3. Look at the screen

**Actual Result:** Unified mapper is duplicated
**Expected Result:** Unified mapper should not be duplicated