### PR TITLE
GGRC-2750 Fix absence of AC roles in exported csv file for snapshots

### DIFF
--- a/src/ggrc/converters/snapshot_block.py
+++ b/src/ggrc/converters/snapshot_block.py
@@ -42,6 +42,10 @@ class SnapshotBlockConverter(object):
       "__mapping__:Issue": "Map: Issue",
   }
 
+  EXTRA_CACHE_MODELS = {
+      "AccessControlRole": "name",
+  }
+
   BOOLEAN_ALIASES = {
       True: "yes",
       "1": "yes",
@@ -156,6 +160,7 @@ class SnapshotBlockConverter(object):
       logger.warning("Exporting invalid snapshot model: %s", self.child_type)
       return {}
     aliases = AttributeInfo.gather_visible_aliases(model)
+    aliases.update(AttributeInfo.get_acl_definitions(model))
     aliases.update(self.CUSTOM_SNAPSHOT_ALIASES)
     if self.MAPPINGS_KEY in self.fields:
       aliases.update(self.SNAPSHOT_MAPPING_ALIASES)
@@ -194,7 +199,9 @@ class SnapshotBlockConverter(object):
         "Person": "email",
         "Option": "title",
     }
+    id_map.update(self.EXTRA_CACHE_MODELS)
     stubs = self._gather_stubs()
+    stubs.update({model: None for model in self.EXTRA_CACHE_MODELS})
     cache = {}
     for model_name, ids in stubs.iteritems():
       with benchmark("Generate snapshot cache for: {}".format(model_name)):
@@ -203,12 +210,33 @@ class SnapshotBlockConverter(object):
         if not hasattr(model, attr_name):
           continue
         attr = getattr(model, attr_name)
-        model_count = model.query.count()
         query = db.session.query(model.id, attr)
-        if len(ids) < model_count / 2:
-          query = query.filter(model.id.in_(ids))
+        if ids:
+          model_count = model.query.count()
+          if len(ids) < model_count / 2:
+            query = query.filter(model.id.in_(ids))
         cache[model_name] = dict(query)
     return cache
+
+  @cached_property
+  def _access_control_map(self):
+    """Get AC role name to person emails mapping."""
+    acr = self._stub_cache.get("AccessControlRole", {})
+    people = self._stub_cache.get("Person", {})
+    _access_control_map = {}
+    for snap in self.snapshots:
+      _access_control_map[snap.content["id"]] = defaultdict(list)
+      for acl in snap.content.get("access_control_list", []):
+        role_name = acr[acl["ac_role_id"]]
+        email = people.get(acl["person_id"], "")
+        _access_control_map[snap.content["id"]][role_name].append(email)
+
+      # Emails should be sorted in asc order
+      _access_control_map[snap.content["id"]] = {
+          role: sorted(emails)
+          for role, emails in _access_control_map[snap.content["id"]].items()
+      }
+    return _access_control_map
 
   def get_value_string(self, value):
     """Get string representation of a given value."""
@@ -244,6 +272,11 @@ class SnapshotBlockConverter(object):
         # values in format of "YYYY-MM-DDThh:mm:ss" and "YYYY-MM-DD hh:mm:ss"
         return val.replace("T", " ")
       return utils.iso_to_us_date(val)
+    elif AttributeInfo.ALIASES_PREFIX in name:
+      _, role_name = name.split(":")
+      return "\n".join(
+          self._access_control_map[content["id"]].get(role_name, [])
+      )
     return self.get_value_string(content.get(name))
 
   @property

--- a/test/integration/ggrc/converters/test_export_snapshots.py
+++ b/test/integration/ggrc/converters/test_export_snapshots.py
@@ -2,9 +2,9 @@
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
 """Tests for snapshot export."""
+import collections
 
-
-from ggrc import models
+from ggrc import models, db
 from ggrc.utils import QueryCounter
 from integration.ggrc import TestCase
 from integration.ggrc.models import factories
@@ -76,7 +76,8 @@ class TestExportSnapshots(TestCase):
     self.import_file("control_snapshot_data_single.csv")
     # Duplicate import because we have a bug in logging revisions and this
     # makes sure that the fixture created properly.
-    self.import_file("control_snapshot_data_single.csv")
+    response = self.import_file("control_snapshot_data_single.csv")
+    self._check_csv_response(response, {})
 
     controls = models.Control.query.all()
     with factories.single_commit():
@@ -115,6 +116,12 @@ class TestExportSnapshots(TestCase):
             "Categories": u"\n".join(c.name for c in control.categories),
             # Computed attributes
             "Last Assessment Date": u"",
+            "Admin": u"admin@example.com\ncreator@example.com\n"
+                     u"editor@example.com",
+            "Primary Contacts": u"creator@example.com",
+            "Secondary Contacts": u"creator@example.com",
+            "Principal Assignees": u"creator@example.com",
+            "Secondary Assignees": u"creator@example.com",
         }
         for snapshot, control in zip(snapshots, controls)
     }
@@ -222,6 +229,11 @@ class TestExportSnapshots(TestCase):
             "Assertions": u"",
             "Categories": u"",
             "Evidence": u"",
+            "Admin": u"",
+            "Primary Contacts": u"",
+            "Secondary Contacts": u"",
+            "Principal Assignees": u"",
+            "Secondary Assignees": u"",
         }
     }
 
@@ -280,11 +292,13 @@ class TestExportSnapshots(TestCase):
     The number of database queries should not be linked to the amount of data
     that is being exported.
     """
+    # pylint: disable=too-many-locals
     self._create_cads("control")
     self.import_file("control_snapshot_data_multiple.csv")
     # Duplicate import because we have a bug in logging revisions and this
     # makes sure that the fixture created properly.
-    self.import_file("control_snapshot_data_multiple.csv")
+    response = self.import_file("control_snapshot_data_multiple.csv")
+    self._check_csv_response(response, {})
 
     controls = models.Control.query.all()
     with factories.single_commit():
@@ -343,3 +357,86 @@ class TestExportSnapshots(TestCase):
       multiple_query_count = counter.get
 
     self.assertEqual(multiple_query_count, single_query_count)
+
+  def test_acr_control_export(self):
+    """Test exporting of a AC roles with linked users."""
+    # pylint: disable=too-many-locals
+    ac_roles = models.AccessControlRole.query.filter_by(
+        object_type="Control"
+    ).all()
+    control_acr_people = collections.defaultdict(dict)
+    with factories.single_commit():
+      # Create one more custom role
+      ac_roles.append(
+          factories.AccessControlRoleFactory(object_type="Control")
+      )
+      controls = [factories.ControlFactory(slug="Control {}".format(i))
+                  for i in range(3)]
+      for control in controls:
+        for ac_role in ac_roles:
+          person = factories.PersonFactory()
+          factories.AccessControlListFactory(
+              ac_role=ac_role,
+              person=person,
+              object=control,
+          )
+          control_acr_people[control.slug][ac_role.name] = person.email
+      audit = factories.AuditFactory()
+      snapshots = self._create_snapshots(audit, *controls)
+
+    control_dicts = {}
+    for snapshot, control in zip(snapshots, controls):
+      # As revisions for snapshot are created using factories need to
+      # update their content and rewrite acl
+      snapshot.revision.content = control.log_json()
+      for acl in snapshot.revision.content["access_control_list"]:
+        acl["person"] = {
+            "id": acl["person_id"],
+            "type": "Person",
+        }
+      db.session.add(snapshot.revision)
+      db.session.commit()
+
+      control_dicts[control.slug] = {
+          "Code": "*" + control.slug,
+          "Revision Date": unicode(snapshot.revision.created_at),
+          "Description": u"",
+          "Effective Date": u"",
+          "Fraud Related": u"",
+          "Frequency": u"",
+          "Kind/Nature": u"",
+          "Notes": u"",
+          "Reference URL": u"",
+          "Review State": u"Unreviewed",
+          "Significance": u"",
+          "State": u"Draft",
+          "Last Assessment Date": u"",
+          "Last Deprecated Date": u"",
+          "Test Plan": u"",
+          "Title": control.title,
+          "Type/Means": u"",
+          "Audit": audit.slug,
+          "Assertions": u"",
+          "Categories": u"",
+          "Evidence": u"",
+      }
+      control_dicts[control.slug].update(**control_acr_people[control.slug])
+
+    search_request = [{
+        "object_name": "Snapshot",
+        "filters": {
+            "expression": {
+                "left": "child_type",
+                "op": {"name": "="},
+                "right": "Control",
+            },
+        },
+    }]
+    parsed_data = self.export_parsed_csv(search_request)["Control Snapshot"]
+    parsed_dict = {line["Code"]: line for line in parsed_data}
+
+    for i, _ in enumerate(controls):
+      self.assertEqual(
+          parsed_dict["*Control {}".format(i)],
+          control_dicts["Control {}".format(i)],
+      )

--- a/test/integration/ggrc/converters/test_snapshot_block.py
+++ b/test/integration/ggrc/converters/test_snapshot_block.py
@@ -5,7 +5,9 @@
 
 import mock
 
+from ggrc import db
 from ggrc.converters.snapshot_block import SnapshotBlockConverter
+from ggrc.models import all_models
 from integration.ggrc import TestCase
 from integration.ggrc.models import factories
 
@@ -75,29 +77,38 @@ class TestSnapshotBlockConverter(TestCase):
     converter = mock.MagicMock()
     block = SnapshotBlockConverter(converter, [])
     block.child_type = "Control"
+    expected_attrs = [
+        ('slug', 'Code'),
+        ('audit', 'Audit'),  # inserted attribute
+        ('revision_date', 'Revision Date'),  # inserted attribute
+        ('title', 'Title'),
+        ('description', 'Description'),
+        ('notes', 'Notes'),
+        ('test_plan', 'Test Plan'),
+        ('start_date', 'Effective Date'),
+        ('end_date', 'Last Deprecated Date'),
+        ('status', 'State'),
+        ('os_state', 'Review State'),
+        ('assertions', 'Assertions'),
+        ('categories', 'Categories'),
+        ('fraud_related', 'Fraud Related'),
+        ('key_control', 'Significance'),
+        ('kind', 'Kind/Nature'),
+        ('means', 'Type/Means'),
+        ('reference_url', 'Reference URL'),
+        ('verify_frequency', 'Frequency'),
+        ('document_evidence', 'Evidence'),
+    ]
+    ac_roles = db.session.query(all_models.AccessControlRole.name).filter(
+        all_models.AccessControlRole.object_type == "Control"
+    ).all()
+    expected_attrs += [
+        ("__acl__:{}".format(role[0]), role[0]) for role in ac_roles
+    ]
+    # last_assessment_date should be in the end according to current order
+    expected_attrs.append(('last_assessment_date', 'Last Assessment Date'))
+
     self.assertEqual(
         block._attribute_name_map.items(),
-        [
-            ('slug', 'Code'),
-            ('audit', 'Audit'),  # inserted attribute
-            ('revision_date', 'Revision Date'),  # inserted attribute
-            ('title', 'Title'),
-            ('description', 'Description'),
-            ('notes', 'Notes'),
-            ('test_plan', 'Test Plan'),
-            ('start_date', 'Effective Date'),
-            ('end_date', 'Last Deprecated Date'),
-            ('status', 'State'),
-            ('os_state', 'Review State'),
-            ('assertions', 'Assertions'),
-            ('categories', 'Categories'),
-            ('fraud_related', 'Fraud Related'),
-            ('key_control', 'Significance'),
-            ('kind', 'Kind/Nature'),
-            ('means', 'Type/Means'),
-            ('reference_url', 'Reference URL'),
-            ('verify_frequency', 'Frequency'),
-            ('document_evidence', 'Evidence'),
-            ('last_assessment_date', 'Last Assessment Date'),
-        ]
+        expected_attrs
     )

--- a/test/integration/ggrc/test_csvs/control_snapshot_data_multiple.csv
+++ b/test/integration/ggrc/test_csvs/control_snapshot_data_multiple.csv
@@ -4,23 +4,23 @@ Active
 Deprecated",,,,,,"Allowed values are:
 key
 non-key
----",,,,,,,,,,,"Accepted values are:
+---",,,,,,,,,,"Accepted values are:
 one
 two
 three
 four
 five",,
-Control,Code*,Title*,Description,Notes,Test Plan,Admin*,Effective Date,Last Deprecated Date,State,Review State,Assertions,Categories,Primary Contact,Fraud Related,Significance,Kind/Nature,Type/Means,Principal Assignee,Secondary Assignee,Secondary Contact,Reference URL,Frequency,checkbox,date,dropdown,person,RT
-,Control 1,Control title 1,Control description 1,Control notes 1,Control Test Plan 1,admin@example.com,02/22/2022,02/22/2022,Draft,,Privacy,Data Centers,creator@example.com,No,key,Corrective,Physical,creator@example.com,creator@example.com,creator@example.com,control.example.com,control.example.com,Weekly,yes,02/22/2022,one,creator@example.com,Rich text 1
-,Control 2,Control title 2,Control description 2,Control notes 2,Control Test Plan 2,creator@example.com,02/23/2022,02/23/2022,Active,,Security,Disaster Recovery,editor@example.com,Yes,Non-key,Preventive,Technical,editor@example.com,editor@example.com,editor@example.com,control.example.com,control.example.com,Daily,no,02/23/2022,two,editor@example.com,Rich text 2
-,Control 3,Control title 3,Control description 3,Control notes 3,Control Test Plan 3,editor@example.com,02/24/2022,02/24/2022,Deprecated,,Availability,Logical Access/ Access Control,reader@example.com,No,key,Corrective,Physical,reader@example.com,reader@example.com,reader@example.com,control.example.com,control.example.com,Hourly,no,02/24/2022,three,reader@example.com,Rich text 3
-,Control 4,Control title 4,Control description 4,Control notes 4,Control Test Plan 4,reader@example.com,02/25/2022,02/25/2022,Draft,,Integrity,Sites,creator@example.com,Yes,Non-key,Preventive,Technical,creator@example.com,creator@example.com,creator@example.com,control.example.com,control.example.com,Transactional,true,02/25/2022,four,creator@example.com,Rich text 4
-,Control 5,Control title 5,Control description 5,Control notes 5,Control Test Plan 5,admin@example.com,02/26/2022,02/26/2022,Active,,Confidentiality,Training,editor@example.com,No,key,Corrective,Physical,editor@example.com,editor@example.com,editor@example.com,control.example.com,control.example.com,Transactional,false,02/26/2022,five,editor@example.com,Rich text 5
-,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Object Type,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-person,Name,Email,Company,role,,,,,,,,,,,,,,,,,,,,,,,,
-,admin,admin@example.com,google,Administrator,,,,,,,,,,,,,,,,,,,,,,,,
-,creator,creator@example.com,google,creator,,,,,,,,,,,,,,,,,,,,,,,,
-,editor,editor@example.com,google,Editor,,,,,,,,,,,,,,,,,,,,,,,,
-,reader,reader@example.com,google,reader,,,,,,,,,,,,,,,,,,,,,,,,
+Control,Code*,Title*,Description,Notes,Test Plan,Admin*,Effective Date,Last Deprecated Date,State,Review State,Assertions,Categories,Primary Contacts,Fraud Related,Significance,Kind/Nature,Type/Means,Principal Assignees,Secondary Assignees,Secondary Contacts,Reference URL,Frequency,checkbox,date,dropdown,person,RT
+,Control 1,Control title 1,Control description 1,Control notes 1,Control Test Plan 1,admin@example.com,02/22/2022,02/22/2022,Draft,,Privacy,Data Centers,creator@example.com,No,key,Corrective,Physical,creator@example.com,creator@example.com,creator@example.com,control.example.com,Weekly,yes,02/22/2022,one,creator@example.com,Rich text 1
+,Control 2,Control title 2,Control description 2,Control notes 2,Control Test Plan 2,creator@example.com,02/23/2022,02/23/2022,Active,,Security,Disaster Recovery,editor@example.com,Yes,Non-key,Preventive,Technical,editor@example.com,editor@example.com,editor@example.com,control.example.com,Daily,no,02/23/2022,two,editor@example.com,Rich text 2
+,Control 3,Control title 3,Control description 3,Control notes 3,Control Test Plan 3,editor@example.com,02/24/2022,02/24/2022,Deprecated,,Availability,Logical Access/ Access Control,reader@example.com,No,key,Corrective,Physical,reader@example.com,reader@example.com,reader@example.com,control.example.com,Hourly,no,02/24/2022,three,reader@example.com,Rich text 3
+,Control 4,Control title 4,Control description 4,Control notes 4,Control Test Plan 4,reader@example.com,02/25/2022,02/25/2022,Draft,,Integrity,Sites,creator@example.com,Yes,Non-key,Preventive,Technical,creator@example.com,creator@example.com,creator@example.com,control.example.com,Transactional,true,02/25/2022,four,creator@example.com,Rich text 4
+,Control 5,Control title 5,Control description 5,Control notes 5,Control Test Plan 5,admin@example.com,02/26/2022,02/26/2022,Active,,Confidentiality,Training,editor@example.com,No,key,Corrective,Physical,editor@example.com,editor@example.com,editor@example.com,control.example.com,Transactional,false,02/26/2022,five,editor@example.com,Rich text 5
+,,,,,,,,,,,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Object Type,,,,,,,,,,,,,,,,,,,,,,,,,,,
+person,Name,Email,Company,role,,,,,,,,,,,,,,,,,,,,,,,
+,admin,admin@example.com,google,Administrator,,,,,,,,,,,,,,,,,,,,,,,
+,creator,creator@example.com,google,creator,,,,,,,,,,,,,,,,,,,,,,,
+,editor,editor@example.com,google,Editor,,,,,,,,,,,,,,,,,,,,,,,
+,reader,reader@example.com,google,reader,,,,,,,,,,,,,,,,,,,,,,,

--- a/test/integration/ggrc/test_csvs/control_snapshot_data_single.csv
+++ b/test/integration/ggrc/test_csvs/control_snapshot_data_single.csv
@@ -9,8 +9,8 @@ one
 two
 three
 four
-five",,,
-Control,Code*,Title*,Description,Notes,Test Plan,Admin*,Effective Date,Last Deprecated Date,State,Review State,Assertions,Categories,Primary Contact,Fraud Related,Significance,Kind/Nature,Type/Means,Principal Assignee,Secondary Assignee,Secondary Contact,Reference URL,Frequency,checkbox,date,dropdown,person,RT,Evidence
+five",,
+Control,Code*,Title*,Description,Notes,Test Plan,Admin*,Effective Date,Last Deprecated Date,State,Review State,Assertions,Categories,Primary Contacts,Fraud Related,Significance,Kind/Nature,Type/Means,Principal Assignees,Secondary Assignees,Secondary Contacts,Reference URL,Frequency,checkbox,date,dropdown,person,RT,Evidence
 ,Control 1,Control title 1,Control description 1,Control notes 1,Control Test Plan 1,"admin@example.com
 creator@example.com
 editor@example.com",02/22/2022,02/22/2022,Draft,,"Privacy
@@ -19,14 +19,14 @@ Availability","Data Centers
 Disaster Recovery
 Logical Access/ Access Control",creator@example.com,No,key,Corrective,Physical,creator@example.com,creator@example.com,creator@example.com,control.example.com,Weekly,yes,02/22/2022,one,creator@example.com,Rich text 1,"www.google.com hello world
 Www.com dot com"
-,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Object Type,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-person,Name,Email,Company,role,,,,,,,,,,,,,,,,,,,,,,,,,
-,admin,admin@example.com,google,Administrator,,,,,,,,,,,,,,,,,,,,,,,,,
-,creator,creator@example.com,google,creator,,,,,,,,,,,,,,,,,,,,,,,,,
-,editor,editor@example.com,google,Editor,,,,,,,,,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Object Type,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+person,Name,Email,Company,role,,,,,,,,,,,,,,,,,,,,,,,,
+,admin,admin@example.com,google,Administrator,,,,,,,,,,,,,,,,,,,,,,,,
+,creator,creator@example.com,google,creator,,,,,,,,,,,,,,,,,,,,,,,,
+,editor,editor@example.com,google,Editor,,,,,,,,,,,,,,,,,,,,,,,,

--- a/test/selenium/src/tests/test_snapshots.py
+++ b/test/selenium/src/tests/test_snapshots.py
@@ -489,7 +489,6 @@ class TestSnapshots(base.Test):
         messages.AssertionMessages.
         format_err_msg_equal([expected_control], actual_controls))
 
-  @pytest.mark.xfail(strict=True)
   @pytest.mark.smoke_tests
   @pytest.mark.parametrize(
       "dynamic_object, dynamic_relationships",


### PR DESCRIPTION
Steps to reproduce:
1. Have program, control with Custom role field (e.g. "Primary Contacts"), audit with control snapshot
2. On the audit page go to Controls tab and Export controls
3. Open csv file and look at the custom role field: "Primary Contacts" is not shown
Actual Result: If export control snapshot custom roles are absent in csv file 
Expected Result: If export control snapshot custom roles should be displayed in csv file 
https://ggrc-qa.appspot.com/audits/4160#control_widget


on hold untill https://github.com/google/ggrc-core/pull/5933 is merged.