### PR TITLE
GGRC-1440 Global Creator Auditor (no Program role) doesn't get autopopulated into Creators in Assessment creation modal

### DIFF
--- a/src/ggrc/assets/javascripts/models/assessment.js
+++ b/src/ggrc/assets/javascripts/models/assessment.js
@@ -306,7 +306,14 @@
 
         this.audit.findAuditors().then(function (list) {
           list.forEach(function (item) {
-            markForAddition(self, item.person, 'Verifier');
+            var type = 'Verifier';
+            if (item.person === auditLead) {
+              type += ',Assessor';
+            }
+            if (item.person === currentUser) {
+              type += ',Creator';
+            }
+            markForAddition(self, item.person, type);
           });
         });
       } else {

--- a/src/ggrc/assets/javascripts/models/tests/cacheable_model_spec.js
+++ b/src/ggrc/assets/javascripts/models/tests/cacheable_model_spec.js
@@ -49,4 +49,83 @@ describe('CMS.Models.Cacheable', function () {
       expect(actualOrder).toEqual([]);
     });
   });
+
+  describe('mark_for_addition() method', function () {
+    var instance;
+    var obj;
+    var extraAttrs;
+    var options;
+    var joinAttr;
+
+    beforeEach(function () {
+      instance = new can.Model.Cacheable({
+        related_sources: new can.Map()
+      });
+      spyOn(instance, 'remove_duplicate_pending_joins');
+      obj = {};
+      extraAttrs = {field: 'not empty'};
+      options = 'options';
+      joinAttr = 'related_sources';
+    });
+
+    it('calls remove_duplicate_pending_joins() method', function () {
+      instance.mark_for_addition(joinAttr, obj, extraAttrs, options);
+      expect(instance.remove_duplicate_pending_joins)
+        .toHaveBeenCalledWith(obj);
+    });
+
+    it('pushes specified object to _pending_joins', function () {
+      instance.mark_for_addition(joinAttr, obj, extraAttrs, options);
+      obj = jasmine.objectContaining(obj);
+      extraAttrs = jasmine.objectContaining(extraAttrs);
+
+      expect(instance._pending_joins[0].how).toEqual('add');
+      expect(instance._pending_joins[0].what).toEqual(obj);
+      expect(instance._pending_joins[0].through).toEqual(joinAttr);
+      expect(instance._pending_joins[0].extra).toEqual(extraAttrs);
+      expect(instance._pending_joins[0].opts).toEqual(options);
+    });
+  });
+
+  describe('remove_duplicate_pending_joins() method', function () {
+    var instance;
+    var obj;
+    var extraAttrs;
+
+    beforeEach(function () {
+      instance = new can.Model.Cacheable({
+        related_sources: new can.Map()
+      });
+      obj = new can.Map({});
+      extraAttrs = new can.Map({field: 'not empty'});
+    });
+
+    it('sets empty array to _pending_joins if it is undefined', function () {
+      instance.attr('_pending_joins', undefined);
+      instance.remove_duplicate_pending_joins(obj);
+      expect(instance._pending_joins.length).toEqual(0);
+    });
+
+    it('removes elemnts from _pending_joins' +
+      'if elements fields "what" equals to parametr',
+      function () {
+        instance._pending_joins.push({
+          what: obj
+        });
+        instance.remove_duplicate_pending_joins(obj);
+        expect(instance._pending_joins.length).toEqual(0);
+      });
+
+    it('does not remove elemnts from _pending_joins ' +
+      'if elements field "what" does not equal to parametr',
+      function () {
+        instance._pending_joins.push({
+          what: obj,
+          extra: extraAttrs
+        });
+        obj = new can.Map({});
+        instance.remove_duplicate_pending_joins(obj, extraAttrs);
+        expect(instance._pending_joins.length).toEqual(1);
+      });
+  });
 });


### PR DESCRIPTION
**Steps to reproduce:**
1. Create a program and add GC (progcreator@reciprocitylabs.com) as Program reader into program
2. Create a control
3. Create an audit and add auditor to audit (progcreator@reciprocitylabs.com)
4. Log as auditor (progcreator@reciprocitylabs.com (engage007) and go to audit page
5. Click Create assessment

**Actual Result:** Creator is not selected by default 
**Expected Result:** Creator should be selected by default 
