### PR TITLE
GGRC-2669 GGRC-2754 Make "Last Deprecated Date" non editable on frontend and set it to current date when status is Deprecated

### DIFF
--- a/src/ggrc/models/mixins/__init__.py
+++ b/src/ggrc/models/mixins/__init__.py
@@ -342,12 +342,27 @@ class Timeboxed(object):
 class LastDeprecatedTimeboxed(Timeboxed):
   """Mixin that redefines `end_date`'s alias."""
   _aliases = {
-      "end_date": "Last Deprecated Date",
+      "end_date": {
+          "display_name": "Last Deprecated Date",
+          "view_only": True,
+      },
   }
 
   _api_attrs = reflection.ApiAttributes(
       reflection.Attribute('end_date', create=False, update=False),
   )
+
+  AUTO_SETUP_STATUS = "Deprecated"
+
+  @validates('status')
+  def validate_status(self, key, value):
+    """Autosetup current date as end date if 'Deprecated' status will setup."""
+    superinstance = super(Timeboxed, self)
+    if hasattr(superinstance, "validate_status"):
+      value = superinstance.validate_status(key, value)
+    if value != self.status and value == self.AUTO_SETUP_STATUS:
+      self.end_date = datetime.datetime.now()
+    return value
 
 
 class Stateful(object):

--- a/test/integration/ggrc/converters/test_export_snapshots.py
+++ b/test/integration/ggrc/converters/test_export_snapshots.py
@@ -97,7 +97,7 @@ class TestExportSnapshots(TestCase):
             "Review State": control.os_state,
             "Significance": u"key" if control.key_control else u"non-key",
             "State": control.status,
-            "Last Deprecated Date": control.end_date.strftime("%m/%d/%Y"),
+            "Last Deprecated Date": "",
             "Test Plan": control.test_plan,
             "Title": control.title,
             "Type/Means": control.means.display_name,

--- a/test/integration/ggrc/converters/test_import_controls.py
+++ b/test/integration/ggrc/converters/test_import_controls.py
@@ -5,9 +5,12 @@
 
 """Test request import and updates."""
 
+import collections
+
 from ggrc import models
 
 from integration.ggrc import TestCase
+from integration.ggrc.models import factories
 
 
 class TestControlsImport(TestCase):
@@ -32,3 +35,32 @@ class TestControlsImport(TestCase):
     self.assertEqual(len(evidence), 1)
     control = models.Control.query.filter_by(slug="control-3").first()
     self.assertEqual(control.document_evidence[0].title, "Some title 3")
+
+  def test_import_control_end_date(self):
+    """End date on control should be non editable."""
+    control = factories.ControlFactory()
+    self.assertIsNone(control.end_date)
+    resp = self.import_data(collections.OrderedDict([
+        ("object_type", "Control"),
+        ("code", control.slug),
+        ("Last Deprecated Date", "06/06/2017"),
+    ]))
+    control = models.Control.query.get(control.id)
+    self.assertEqual(1, len(resp))
+    self.assertEqual(1, resp[0]["updated"])
+    self.assertIsNone(control.end_date)
+
+  def test_import_control_deprecated(self):
+    """End date should be set up after import in deprecated state."""
+    control = factories.ControlFactory()
+    self.assertIsNone(control.end_date)
+    resp = self.import_data(collections.OrderedDict([
+        ("object_type", "Control"),
+        ("code", control.slug),
+        ("state", models.Control.DEPRECATED),
+    ]))
+    control = models.Control.query.get(control.id)
+    self.assertEqual(1, len(resp))
+    self.assertEqual(1, resp[0]["updated"])
+    self.assertEqual(control.status, control.DEPRECATED)
+    self.assertIsNotNone(control.end_date)

--- a/test/integration/ggrc/models/test_control.py
+++ b/test/integration/ggrc/models/test_control.py
@@ -11,12 +11,15 @@ from integration.ggrc import api_helper
 
 
 class TestControl(TestCase):
+  """Tests for control model."""
 
   def setUp(self):
+    """setUp, nothing else to add."""
     super(TestControl, self).setUp()
     self.api = api_helper.Api()
 
   def test_simple_categorization(self):
+    """Check append category append to control."""
     category = factories.ControlCategoryFactory(scope_id=100)
     control = factories.ControlFactory()
     control.categories.append(category)
@@ -27,6 +30,7 @@ class TestControl(TestCase):
     self.assertIn(category, control.categories)
 
   def test_has_test_plan(self):
+    """Check test plan setup to control."""
     control = factories.ControlFactory(test_plan="This is a test text")
     control = db.session.query(Control).get(control.id)
     self.assertEqual(control.test_plan, "This is a test text")

--- a/test/integration/ggrc/models/test_control.py
+++ b/test/integration/ggrc/models/test_control.py
@@ -7,9 +7,14 @@ from ggrc import db
 from ggrc.models import Control
 from integration.ggrc import TestCase
 from integration.ggrc.models import factories
+from integration.ggrc import api_helper
 
 
 class TestControl(TestCase):
+
+  def setUp(self):
+    super(TestControl, self).setUp()
+    self.api = api_helper.Api()
 
   def test_simple_categorization(self):
     category = factories.ControlCategoryFactory(scope_id=100)
@@ -25,3 +30,18 @@ class TestControl(TestCase):
     control = factories.ControlFactory(test_plan="This is a test text")
     control = db.session.query(Control).get(control.id)
     self.assertEqual(control.test_plan, "This is a test text")
+
+  def test_set_end_date(self):
+    """End_date can't to be updated."""
+    control = factories.ControlFactory()
+    self.api.put(control, {"end_date": "2015-10-10"})
+    control = db.session.query(Control).get(control.id)
+    self.assertIsNone(control.end_date)
+
+  def test_set_deprecated_status(self):
+    """Deprecated status setup end_date."""
+    control = factories.ControlFactory()
+    self.assertIsNone(control.end_date)
+    self.api.put(control, {"status": Control.DEPRECATED})
+    control = db.session.query(Control).get(control.id)
+    self.assertIsNotNone(control.end_date)


### PR DESCRIPTION
~depends on https://github.com/google/ggrc-core/pull/5998~