### PR TITLE
GGRC-2431 Maximize info pane on selecting a tree view item

### DIFF
--- a/src/ggrc/assets/javascripts/components/tree/tree-widget-container.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-widget-container.js
@@ -559,7 +559,7 @@
         selectedEl.addClass('item-active');
 
         $('.pin-content').control()
-          .setInstance(infoPaneOptions, selectedEl);
+          .setInstance(infoPaneOptions, selectedEl, true);
       },
       ' refreshTree': function (el, ev) {
         ev.stopPropagation();


### PR DESCRIPTION
As per user request, this PR makes sure that an object's info pane is automatically maximized when an object is selected in a tree view.

Open question:
Is this applicable for _all_ objects or just "my assessments" as seen in the screenshot attached to the [Jira ticket](https://gojira.corp.google.com/browse/GGRC-2431)?

cc: @akhilp1 