### PR TITLE
GGRC-2744 Make "Last deprecated date" field non-editable on the frontend

### DIFF
--- a/src/ggrc/assets/javascripts/components/effective-dates/effective-dates.js
+++ b/src/ggrc/assets/javascripts/components/effective-dates/effective-dates.js
@@ -18,11 +18,6 @@
         label: 'Effective Date',
         helpText: 'Enter the date this object becomes effective.',
         required: false
-      },
-      configEndDate: {
-        label: 'Last Deprecated Date',
-        helpText: 'Enter the date this object stops being effective.',
-        required: false
       }
     }
   });

--- a/src/ggrc/assets/mustache/components/effective-dates/effective-dates.mustache
+++ b/src/ggrc/assets/mustache/components/effective-dates/effective-dates.mustache
@@ -15,16 +15,3 @@
       {{#configStartDate.required}}required="true"{{/configStartDate.required}}
   />
 </div>
-
-<div data-id="stop_date_hidden" class="span4 hidable">
-  <a data-id="hide_stop_date_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
-  <datepicker
-      tabindex="21"
-      {label}="configEndDate.label"
-      date="instance.end_date"
-      set-min-date="instance.start_date"
-      {helptext}="configEndDate.helpText"
-      test-id="endTestId"
-      {{#configEndDate.required}}required="true"{{/configEndDate.required}}
-  />
-</div>

--- a/test/selenium/src/lib/constants/element.py
+++ b/test/selenium/src/lib/constants/element.py
@@ -182,7 +182,6 @@ class CommonProgram(Common):
   REFERENCE_URL = Base.REFERENCE_URL
   NOTES = "Notes"
   EFFECTIVE_DATE = Base.EFFECTIVE_DATE
-  STOP_DATE = Base.STOP_DATE
   STATE = Base.STATE
 
 
@@ -356,7 +355,6 @@ class ControlModalSetVisibleFields(CommonModalSetVisibleFields):
   URL = Base.URL
   REFERENCE_URL = Base.REFERENCE_URL
   EFFECTIVE_DATE = Base.EFFECTIVE_DATE
-  STOP_DATE = Base.STOP_DATE
   KIND_NATURE = "Kind/Nature"
   FRAUD_RELATED = "Fraud Related"
   SIGNIFICANCE = "Significance"
@@ -382,7 +380,6 @@ class ObjectiveModalSetVisibleFields(CommonModalSetVisibleFields):
   URL = Base.URL
   REFERENCE_URL = Base.REFERENCE_URL
   EFFECTIVE_DATE = Base.EFFECTIVE_DATE
-  STOP_DATE = Base.STOP_DATE
   DEFAULT_SET_FIELDS = (
       CommonModalSetVisibleFields.TITLE, ADMIN,
       CommonModalSetVisibleFields.CODE, CommonModalSetVisibleFields.STATE,
@@ -418,7 +415,6 @@ class ProgramModalSetVisibleFields(CommonModalSetVisibleFields):
   URL = Base.URL
   REFERENCE_URL = Base.REFERENCE_URL
   EFFECTIVE_DATE = Base.EFFECTIVE_DATE
-  STOP_DATE = Base.STOP_DATE
   DEFAULT_SET_FIELDS = (
       CommonModalSetVisibleFields.TITLE, CommonModalSetVisibleFields.CODE,
       CommonModalSetVisibleFields.STATE,

--- a/test/selenium/src/lib/constants/locator.py
+++ b/test/selenium/src/lib/constants/locator.py
@@ -299,14 +299,6 @@ class ModalCreateNewProgram(BaseModalCreateNew):
       By.CSS_SELECTOR,
       '[test-id="new_program_field_effective_date_f2783a28"] '
       '[data-id="effective_date_hidden"] [data-handler="selectDay"]')
-  UI_STOP_DATE = (
-      By.CSS_SELECTOR,
-      '[test-id="new_program_field_effective_date_f2783a28"] '
-      '[data-id="stop_date_hidden"] .datepicker__input')
-  STOP_DATE_DATEPICKER = (
-      By.CSS_SELECTOR,
-      '[test-id="new_program_field_effective_date_f2783a28"] '
-      '[data-id="stop_date_hidden"] [data-handler="selectDay"]')
   TITLE = (By.CSS_SELECTOR, '[data-test-id="label_title_2c925d94"]')
   DESCRIPTION = (
       By.CSS_SELECTOR, '[data-test-id="label_description_2c925d94"]')
@@ -428,14 +420,6 @@ class ModalCreateNewControl(BaseModalCreateNew):
       By.CSS_SELECTOR,
       '[test-id="control_effective_dates_0376cf90"] '
       '[data-id="effective_date_hidden"] [data-handler="selectDay"]')
-  STOP_DATE = (
-      By.CSS_SELECTOR,
-      '[test-id="control_effective_dates_0376cf90"] '
-      '[data-id="stop_date_hidden"] .datepicker__input')
-  DATEPICKER_STOP_DATE = (
-      By.CSS_SELECTOR,
-      '[test-id="control_effective_dates_0376cf90"] '
-      '[data-id="stop_date_hidden"] [data-handler="selectDay"]')
   BUTTON_HIDE_ALL_OPTIONAL_FIELDS = (By.CSS_SELECTOR, '#formHide')
 
 
@@ -700,12 +684,6 @@ class WidgetInfoProgram(WidgetInfoPanel):
   EFFECTIVE_DATE_ENTERED = (
       By.CSS_SELECTOR,
       '[data-test-id="title_effective_date_cf47bc01"] p'.format(WIDGET))
-  STOP_DATE = (
-      By.CSS_SELECTOR,
-      '{} [data-test-id="title_stop_date_cf47bc01"] h6'.format(WIDGET))
-  STOP_DATE_ENTERED = (
-      By.CSS_SELECTOR,
-      '[data-test-id="title_stop_date_cf47bc01"] p'.format(WIDGET))
   PRIVATE_PROGRAM = (By.CSS_SELECTOR,
                      '[data-test-id="title_private_ec758af9"] h6')
   ICON_LOCK = (By.CSS_SELECTOR, '[data-test-id="icon_private_ec758af9"]')

--- a/test/selenium/src/lib/constants/test/modal_create_new.py
+++ b/test/selenium/src/lib/constants/test/modal_create_new.py
@@ -55,5 +55,4 @@ class Programs(object):
   PROGRAM_URL = "www.program_url.com"
   REFERENCE_URL = "www.reference_url.com"
   EFFECTIVE_DATE = "12/01/2014"
-  STOP_DATE = "12/30/2014"
   DEFAULT_MANAGER = "user@example.com"

--- a/test/selenium/src/lib/page/modal/base.py
+++ b/test/selenium/src/lib/page/modal/base.py
@@ -56,9 +56,6 @@ class ProgramsModal(BaseModal):
     self.ui_effective_date = base.DatePicker(
         self._driver, self._locators.EFFECTIVE_DATE_DATEPICKER,
         self._locators.UI_EFFECTIVE_DATE)
-    self.ui_stop_date = base.DatePicker(
-        self._driver, self._locators.STOP_DATE_DATEPICKER,
-        self._locators.UI_STOP_DATE)
     # static elements
     self.title = base.Label(self._driver, self._locators.TITLE)
     self.description = base.Label(self._driver, self._locators.DESCRIPTION)
@@ -109,12 +106,6 @@ class ProgramsModal(BaseModal):
     # pylint: disable=invalid-name
     self.ui_effective_date.select_day_in_current_month(day)
 
-  def enter_stop_date_end_month(self, day):
-    """Select from datepicker end date.
-    Args: day (int): #base.DatePicker.select_day_in_current_month
-    """
-    self.ui_stop_date.select_day_in_current_month(day)
-
 
 class ControlsModal(BaseModal):
   """Modal base for Control objects."""
@@ -153,8 +144,6 @@ class ControlsModal(BaseModal):
     self.ui_effective_date = base.DatePicker(
         driver, self._locators.EFFECTIVE_DATE,
         self._locators.DATEPICKER_EFFECTIVE_DATE)
-    self.ui_stop_date = base.DatePicker(
-        driver, self._locators.STOP_DATE, self._locators.DATEPICKER_STOP_DATE)
     # dropdowns
     self.ui_kind_or_nature = base.Dropdown(
         driver, self._locators.DROPDOWN_KIND_OR_NATURE)

--- a/test/selenium/src/lib/page/widget/info_widget.py
+++ b/test/selenium/src/lib/page/widget/info_widget.py
@@ -207,9 +207,6 @@ class Programs(InfoPanel):
         self._driver, self._locators.EFFECTIVE_DATE)
     self.effective_date_entered = base.Label(
         self._driver, self._locators.EFFECTIVE_DATE_ENTERED)
-    self.stop_date = base.Label(self._driver, self._locators.STOP_DATE)
-    self.stop_date_entered = base.Label(
-        self._driver, self._locators.STOP_DATE_ENTERED)
 
 
 class Workflows(InfoPanel):

--- a/test/selenium/src/lib/utils/test_utils.py
+++ b/test/selenium/src/lib/utils/test_utils.py
@@ -62,17 +62,14 @@ class ModalNewPrograms(ModalInput):
   """Methods for simulating common user actions."""
 
   @staticmethod
-  def set_start_end_dates(modal, day_start, day_end):
-    """Sets dates from datepicker in new program/edit modal.
+  def set_start_date(modal, day_start):
+    """Sets start date from datepicker in new program/edit modal.
     Args:
     modal (lib.page.modal.edit_object.Programs)
     day_start (int): for more info see
     base.DatePicker.select_day_in_current_month
-    day_end (int): for more info see
-    base.DatePicker.select_day_in_current_month
     """
     modal.enter_effective_date_start_month(day_start)
-    modal.enter_stop_date_end_month(day_end)
 
   @staticmethod
   def enter_test_data(modal):
@@ -88,7 +85,7 @@ class ModalNewPrograms(ModalInput):
         modal_create_new.Programs.PROGRAM_URL))
     modal.enter_reference_url(prepend_random_string(
         modal_create_new.Programs.REFERENCE_URL))
-    ModalNewPrograms.set_start_end_dates(modal, 0, -1)
+    ModalNewPrograms.set_start_date(modal, 0)
 
 
 class ModalNewProgramCustomAttribute(ModalInput):

--- a/test/selenium/src/tests/test_program_page.py
+++ b/test/selenium/src/tests/test_program_page.py
@@ -64,7 +64,7 @@ class TestProgramPage(base.Test):
         test_utils.HtmlParser.parse_text(modal.ui_title.text),
         modal.ui_description.text, modal.ui_notes.text, modal.ui_code.text,
         modal.ui_program_url.text, modal.ui_reference_url.text,
-        modal.ui_effective_date.text, modal.ui_stop_date.text]
+        modal.ui_effective_date.text]
     actual_list_texts = [
         program_info_page.title_entered().text,
         program_info_page.description_entered.text,
@@ -72,8 +72,7 @@ class TestProgramPage(base.Test):
         program_info_page.code_entered.text,
         program_info_page.program_url_entered.text,
         program_info_page.reference_url_entered.text,
-        program_info_page.effective_date_entered.text,
-        program_info_page.stop_date_entered.text]
+        program_info_page.effective_date_entered.text]
     assert expected_list_texts == actual_list_texts
 
   @pytest.mark.smoke_tests
@@ -103,7 +102,7 @@ class TestProgramPage(base.Test):
     program_info_page = info_widget.Programs(selenium)
     modal = program_info_page.open_info_3bbs().select_edit()
     test_utils.ModalNewPrograms.enter_test_data(modal)
-    test_utils.ModalNewPrograms.set_start_end_dates(modal, 1, -2)
+    test_utils.ModalNewPrograms.set_start_date(modal, 1)
     modal.save_and_close()
     selenium_utils.open_url(selenium, program_info_page.url)
     updated_program_info_page = info_widget.Programs(selenium)


### PR DESCRIPTION
**NOTE:** Relates to https://github.com/google/ggrc-core/pull/5954

Remove 'Stop Date' / 'Last Deprecated Date' from:
- 'New <object>' pop-up;
- 'Edit <object>' pop-up.