### PR TITLE
GGRC-2823 BE: Return count of objects to be marked Deprecated in Import response

### DIFF
--- a/src/ggrc/converters/base_block.py
+++ b/src/ggrc/converters/base_block.py
@@ -453,16 +453,23 @@ class BlockConverter(object):
 
   def get_info(self):
     """Returns info dict for current block."""
-    created, updated, ignored, deleted = 0, 0, 0, 0
+    created = 0
+    updated = 0
+    ignored = 0
+    deleted = 0
+    deprecated = 0
     for row in self.row_converters:
       if row.ignore:
         ignored += 1
-      elif row.is_delete:
+        continue
+      if row.is_delete:
         deleted += 1
-      elif row.is_new:
+        continue
+      if row.is_new:
         created += 1
       else:
         updated += 1
+      deprecated += int(row.is_deprecated)
     info = {
         "name": self.name,
         "rows": len(self.rows),
@@ -470,6 +477,7 @@ class BlockConverter(object):
         "updated": updated,
         "ignored": ignored,
         "deleted": deleted,
+        "deprecated": deprecated,
         "block_warnings": self.block_warnings,
         "block_errors": self.block_errors,
         "row_warnings": self.row_warnings,

--- a/src/ggrc/converters/base_row.py
+++ b/src/ggrc/converters/base_row.py
@@ -27,6 +27,7 @@ class RowConverter(object):
     self.from_ids = self.obj is not None
     self.is_new = True
     self.is_delete = False
+    self.is_deprecated = False
     self.ignore = False
     self.index = options.get("index", -1)
     self.row = options.get("row", [])
@@ -74,11 +75,15 @@ class RowConverter(object):
         self.attrs[attr_name] = item
       else:
         self.objects[attr_name] = item
-
-      if not self.ignore and attr_name in ("slug", "email"):
-        self.id_key = attr_name
-        self.obj = self.get_or_generate_object(attr_name)
-        item.set_obj_attr()
+      if not self.ignore:
+        if attr_name == "status" and hasattr(self.obj, "DEPRECATED"):
+          self.is_deprecated = (
+              self.obj.DEPRECATED == item.value != self.obj.status
+          )
+        if attr_name in ("slug", "email"):
+          self.id_key = attr_name
+          self.obj = self.get_or_generate_object(attr_name)
+          item.set_obj_attr()
       item.check_unique_consistency()
 
   def handle_obj_row_data(self):

--- a/src/ggrc/models/issue.py
+++ b/src/ggrc/models/issue.py
@@ -25,13 +25,10 @@ class Issue(Roleable, HasObjectState, TestPlanned, CustomAttributable,
 
   __tablename__ = 'issues'
 
-  VALID_STATES = [
-      "Draft",
-      "Active",
-      "Deprecated",
-      "Fixed",
-      "Fixed and Verified"
-  ]
+  FIXED = "Fixed"
+  FIXED_AND_VERIFIED = "Fixed and Verified"
+
+  VALID_STATES = BusinessObject.VALID_STATES + (FIXED, FIXED_AND_VERIFIED, )
 
   # REST properties
   _publish_attrs = [

--- a/src/ggrc/models/mixins/__init__.py
+++ b/src/ggrc/models/mixins/__init__.py
@@ -901,11 +901,11 @@ class WithContact(object):
 class BusinessObject(Stateful, Noted, Described, Hyperlinked,
                      Titled, Slugged):
   """Mixin that groups most commonly-used mixins into one."""
-  VALID_STATES = (
-      'Draft',
-      'Active',
-      'Deprecated'
-  )
+  DRAFT = 'Draft'
+  ACTIVE = 'Active'
+  DEPRECATED = 'Deprecated'
+
+  VALID_STATES = (DRAFT, ACTIVE, DEPRECATED, )
 
   _aliases = {
       "status": {

--- a/src/ggrc_risks/models/risk.py
+++ b/src/ggrc_risks/models/risk.py
@@ -16,18 +16,18 @@ from ggrc.models.relationship import Relatable
 from ggrc.models.track_object_state import HasObjectState
 
 
-class Risk(Roleable, HasObjectState, mixins.CustomAttributable,
-           mixins.Stateful, Relatable, mixins.Described, Ownable, Personable,
-           mixins.Titled, mixins.LastDeprecatedTimeboxed,
-           mixins.Noted, mixins.Hyperlinked, mixins.Slugged, Indexed,
+class Risk(Roleable,
+           HasObjectState,
+           mixins.CustomAttributable,
+           Relatable,
+           Ownable,
+           Personable,
+           mixins.LastDeprecatedTimeboxed,
+           mixins.BusinessObject,
+           Indexed,
            db.Model):
-  __tablename__ = 'risks'
 
-  VALID_STATES = [
-      'Draft',
-      'Deprecated',
-      'Active'
-  ]
+  __tablename__ = 'risks'
 
   # Overriding mixin to make mandatory
   @declared_attr
@@ -47,6 +47,7 @@ class Risk(Roleable, HasObjectState, mixins.CustomAttributable,
       "status": {
           "display_name": "State",
           "mandatory": False,
-          "description": "Options are: \n {}".format('\n'.join(VALID_STATES))
+          "description": "Options are: \n {}".format('\n'.join(
+              mixins.BusinessObject.VALID_STATES))
       }
   }

--- a/test/integration/ggrc/converters/test_import_assessments.py
+++ b/test/integration/ggrc/converters/test_import_assessments.py
@@ -276,6 +276,7 @@ class TestAssessmentImport(TestCase):
             u'name': u'Assessment',
             u'created': 0,
             u'deleted': 0,
+            u'deprecated': 0,
             u'row_warnings': row_warnings,
             u'rows': 1,
             u'block_warnings': [],


### PR DESCRIPTION
Currently the backend provides the counts:
- created
- modified
- deleted
We should provide an additional count:
- deprecated: count of objects with state moved to Deprecated in this request

The format can still be changed to more general.