### PR TITLE
GGRC-2660 Control's/Objective's/Regulation's long title is not cut off in Control's popup view

### DIFF
--- a/src/ggrc/assets/mustache/components/assessment/mapped-objects/mapped-control-related-objects.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/mapped-objects/mapped-control-related-objects.mustache
@@ -9,10 +9,14 @@
             <object-list {items}="items">
                 <div class="flex-size-1">
                     <h6>Title</h6>
-                    <a target="_blank" href="{{originalLink}}" title="{{title}}">{{title}}</a>
-                    <span class="state-value snapshot">
+                    <div class="simple-modal__title">
+                        <div class="simple-modal__title__name">
+                            <a target="_blank" href="{{originalLink}}" title="{{title}}">{{title}}</a>
+                        </div>
+                        <span class="state-value snapshot">
                             {{type}} version as on {{date updated_at}}
                         </span>
+                    </div>
                 </div>
                 <div class="flex-size-1">
                     <h6>Description</h6>

--- a/src/ggrc/assets/mustache/components/assessment/mapped-objects/mapped-controls.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/mapped-objects/mapped-controls.mustache
@@ -12,11 +12,15 @@
 <simple-modal instance="snapshot" modal-title="modalTitle" state="state" extra-css-class="mapped-controls-info" replace-content="true">
     <div class="simple-modal__header flex-box flex-row">
         <div class="simple-modal__header-text flex-size-1">
-            Control:
-            <a target="_blank" href="{{instance.originalLink}}" title="{{instance.title}}">{{instance.title}}</a>
-            <span class="state-value snapshot">
-                {{instance.type}} version as on {{date instance.updated_at}}
-            </span>
+            <div class="simple-modal__title">
+                <div class="simple-modal__title__name">
+                    Control:
+                    <a target="_blank" href="{{instance.originalLink}}" title="{{instance.title}}">{{instance.title}}</a>
+                </div>
+                <span class="state-value snapshot">
+                    {{instance.type}} version as on {{date instance.updated_at}}
+                </span>
+            </div>
         </div>
         <button class="btn btn-small btn-icon" can-click="hide">
             <i class="fa fa-times black"></i>

--- a/src/ggrc/assets/stylesheets/components/simple-modal/_simple-modal.scss
+++ b/src/ggrc/assets/stylesheets/components/simple-modal/_simple-modal.scss
@@ -3,7 +3,7 @@
  * Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  */
 
-$simple-modal-header-height: 42px;
+$simple-modal-header-height: 54px;
 $grid-data-toolbar-height: 42px;
 $grid-data-header-height: 66px;
 
@@ -135,6 +135,23 @@ $grid-data-header-height: 66px;
     font-size: 16px;
     font-weight: normal;
     color: $infoWidgetHeader;
+  }
+
+  &__title {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+
+    .simple-modal__title__name {
+      margin-right: 10px;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+    }
+
+    .state-value {
+      line-height: 18px;
+    }
   }
 
   &__footer {


### PR DESCRIPTION
_Steps to reproduce:_
1. Have program and Control, Objective, Regulation with long title created on the program page
2. Map Objective, Regulation to Control
3. Create audit 
4. Go to audit page and create Assessment template
5. Generate assessment based on control's snapshot and assessment template
6. Navigate to assessment's info pane and open Control's popup view
7. Look at Control's/Objective's/Regulation's title in the modal popup 

_Actual Result_: Control's/Objective's/Regulation's long title is not cut off in Control's popup view
_Expected Result_: Control's/Objective's/Regulation's long title should be cut off in Control's popup view

_Note_: also, snapshot label is displayed on two rows

![screenshot-1](https://user-images.githubusercontent.com/4204416/28411856-d5bbae9c-6d4a-11e7-8276-1190bc333aae.png)
![screenshot-2](https://user-images.githubusercontent.com/4204416/28411855-d5b8a350-6d4a-11e7-956e-b8c521d5ee78.png)