### PR TITLE
GGRC-2769 Show warning message on deleting/deprecating of Product/System/Process

### DIFF
--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -52,6 +52,8 @@ dashboard-js-files:
   - plugins/utils/ggrcq-utils.js
   - plugins/utils/tree-view-utils.js
   - plugins/utils/dashboards-utils.js
+  - plugins/utils/controllers.js
+  - plugins/utils/modals.js
   - plugins/datepicker.js
   - plugins/can_control.js
   - plugins/wysiwyg.js
@@ -394,6 +396,7 @@ dashboard-js-template-files:
   - base_objects/confirm_archive.mustache
   - base_objects/confirm_delete.mustache
   - base_objects/confirm_unmap.mustache
+  - base_objects/confirm_warning.mustache
   - base_objects/contacts.mustache
   - base_objects/create_objective_dropdown_option.mustache
   - base_objects/general_info.mustache
@@ -597,6 +600,7 @@ dashboard-js-template-files:
   - modals/prompt_buttons.mustache
   - modals/confirm_buttons.mustache
   - modals/confirm_cancel_buttons.mustache
+  - modals/confirm_button.mustache
   - modals/delete_cancel_buttons.mustache
   - modals/done_buttons.mustache
   - modals/modal_header.mustache

--- a/src/ggrc/assets/javascripts/controllers/modals_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/modals_controller.js
@@ -42,7 +42,7 @@
       var $target = $('<div class="modal hide ' +
                       options.extraCssClass +
                       '"></div>');
-      $target
+      return $target
         .modal({backdrop: 'static'})
         .ggrc_controllers_modals(can.extend({
           new_object_form: false,
@@ -702,11 +702,31 @@
       },
 
     "{$footer} a.btn[data-toggle='modal-submit'] click": function (el, ev) {
+      var options = this.options;
+      var instance = options.attr('instance');
+      var oldData = options.attr('oldData');
+
       if (el.hasClass('disabled')) {
         return;
       }
-      this.options.attr('add_more', false);
-      this.triggerSave(el, ev);
+
+      GGRC.Utils.Controllers.checkPreconditions({
+        instance: instance,
+        operation: 'deprecation',
+        // functions that will be called as an extra conditions (return true
+        // or false). If all conditions are passed then are showed a
+        // message else - called success handler.
+        extraConditions: [
+          GGRC.Utils.Controllers.becameDeprecated.bind(
+            null,
+            instance,
+            oldData.status
+          )
+        ]
+      }, function () {
+        options.attr('add_more', false);
+        this.triggerSave(el, ev);
+      }.bind(this));
     },
 
     '{$content} a.field-hide click': function (el, ev) { // field hide

--- a/src/ggrc/assets/javascripts/models/cacheable.js
+++ b/src/ggrc/assets/javascripts/models/cacheable.js
@@ -938,8 +938,6 @@
       return this.get_binding(name).refresh_list();
     },
 
-  // This retrieves the potential orphan stats for a given instance
-  // Example: "This may also delete 3 Sections, 2 Controls, and 4 object mappings."
     get_orphaned_count: function () {
       if (!this.get_binding('orphaned_objects')) {
         return can.Deferred().reject();
@@ -947,9 +945,7 @@
       return this.get_list_loader('orphaned_objects').then(function (list) {
         var objects = [];
         var mappings = [];
-        var counts = {};
         var result = [];
-        var parts = 0;
 
         function is_join(mapping) {
           if (mapping.mappings.length > 0) {
@@ -971,35 +967,11 @@
           objects.push(mapping.instance);
         });
 
-      // Generate the summary
-        if (objects.length || mappings.length) {
-          result.push('This may also delete');
-        }
-        if (objects.length) {
-          can.each(objects, function (instance) {
-            var title = instance.constructor.title_singular;
-            counts[title] = counts[title] ||
-              {
-                model: instance.constructor,
-                count: 0
-              };
-            counts[title].count++;
-          });
-          can.each(counts, function (count, i) {
-            parts++;
-            result.push(count.count + ' ' + (count.count === 1 ? count.model.title_singular : count.model.title_plural) + ',');
-          });
-        }
         if (mappings.length) {
-          parts++;
-          result.push(mappings.length + ' object mapping' + (mappings.length !== 1 ? 's' : ''));
+          result.push(mappings.length);
         }
 
-      // Clean up commas, add an "and" if appropriate
-        parts >= 1 && parts <= 2 && (result[result.length - 1] = result[result.length - 1].replace(',', ''));
-        parts === 2 && (result[result.length - 2] = result[result.length - 2].replace(',', ''));
-        parts >= 2 && result.splice(result.length - 1, 0, 'and');
-        return result.join(' ') + (objects.length || mappings.length ? '.' : '');
+        return mappings.length;
       });
     },
 

--- a/src/ggrc/assets/javascripts/plugins/utils/controllers.js
+++ b/src/ggrc/assets/javascripts/plugins/utils/controllers.js
@@ -1,0 +1,61 @@
+/*!
+ Copyright (C) 2017 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+/**
+ * Utils methods shared between GGRC controllers (GGRC.Controllers)
+ */
+GGRC.Utils.Controllers = (function () {
+  var typesWithWarning = ['System', 'Process', 'Product'];
+
+  function checkPreconditions(options, success) {
+    var instance = options.instance;
+    var operation = options.operation;
+    var conditions = options.extraConditions || [];
+
+    if (!hasWarningType(instance)) {
+      success();
+      return;
+    }
+
+    if (!_checkExtraConditions(conditions)) {
+      success();
+      return;
+    }
+
+    GGRC.Utils.Modals.warning({
+      objectShortInfo: [instance.type, instance.title].join(' '),
+      operation: operation
+    }, success);
+  }
+
+  function becameDeprecated(instance, prevStatus) {
+    var status = instance && instance.status;
+
+    return (
+      !_.isEqual(status, prevStatus) && // status was changed
+      _.isEqual(status, 'Deprecated')
+    );
+  }
+
+  function hasWarningType(instance) {
+    return (
+      instance &&
+      _.includes(typesWithWarning, instance.type)
+    );
+  }
+
+  function _checkExtraConditions(conditions) {
+    return _.every(conditions, function (condition) {
+      return condition();
+    });
+  }
+
+  return {
+    TYPES_WITH_CONFIRMATION: typesWithWarning,
+    checkPreconditions: checkPreconditions,
+    hasWarningType: hasWarningType,
+    becameDeprecated: becameDeprecated
+  };
+})();

--- a/src/ggrc/assets/javascripts/plugins/utils/modals.js
+++ b/src/ggrc/assets/javascripts/plugins/utils/modals.js
@@ -1,0 +1,116 @@
+/*!
+ Copyright (C) 2017 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+/**
+ * Utils methods for showing standart modals
+ */
+
+GGRC.Utils.Modals = (function () {
+  /**
+   * Shows a warning popup within given options. If a user confirms
+   * warning popup, then are called a success callback else - a fail callback.
+   *
+   * For showing the popup, by default, are used a
+   * GGRC.Controllers.Modals.confirm method which controls user actions.
+   *
+   * Also the user can set own controller by setting controller field in
+   * extra param.
+   * Warning! Controller should have attached context!
+   *
+   * Note! It's not recommended to override content_view in the options param,
+   * because popup is configured for the default template. If you want to use own
+   * logic for confirmation you should explore _setupWarning method and use
+   * own templates appropriate to its logic.
+   * Be careful with confirmOperationName field - remember that standart
+   * GGRC.Controllers.Modals.confirm uses confirmOperationName='confirm'
+   * If you sets another value (for example, 'delete'), confirm button will
+   * not be able to call success callback. If you want to set it then change
+   * a controller with help extra param
+   * which will process events for tags with data-{{your confirmOperationName}}
+   *
+   * @param {Object} options - Sets options for popup. See warning.settings
+   *                           with default options.
+   * @param {Function} success - Called if a user confirms the warning
+   * @param {Function} fail - Called if a user dismiss the warning
+   * @param {Object} [extra] - Extra options for warning. See warning.extraSettings
+   *                           with default options.
+   * @param {Function} extra.controller - Controller with attached context
+   * @return {Object} - confirm window
+   *
+   * @example <caption>Default usage</caption>
+   * var options = {
+   *  skip_refresh: false,               // refreshes information about instance
+   *  modal_title: 'Delete operation',   // title for popup
+   *  objectShortInfo: 'Object #21',     // short title for object, for which confirmation is required
+   *  modal_description: 'Operation is irreversible', // description for operation
+   *  confirmTextForTyping: 'I confirm deletion', // text for confirm input
+   *  buttonExtraClasses: 'disabled'     // initially confirm button is disabled
+   * };
+   *
+   * GGRC.Utils.Modals.warning(
+   *  options,
+   *  function () {
+   *    console.log('Success!');
+   *  },
+   *  function () {
+   *    console.log('Fail:(');
+   *  }
+   * )
+   */
+  function warning(options, success, fail, extra) {
+    var confirmOptions = _.extend({}, warning.settings, options);
+    var confirmController;
+    var confirm;
+
+    extra = extra || {};
+
+    confirmController = extra.controller || GGRC.Controllers.Modals.confirm;
+    confirm = confirmController(confirmOptions, success, fail);
+
+    _setupWarning(confirm, confirmOptions);
+    return confirm;
+  }
+
+  // default static const settings
+  warning.settings = Object.freeze({
+    skip_refresh: true, // do not reload info about instance
+    modal_title: 'Warning',
+    objectShortInfo: 'Object',
+    modal_description: '',
+    confirmOperationName: 'confirm',
+    confirmTextForTyping: 'I confirm',
+    content_view:
+      GGRC.mustache_path + '/base_objects/confirm_warning.mustache',
+    button_view:
+      GGRC.mustache_path + '/modals/confirm_button.mustache',
+    buttonExtraClasses: 'disabled'
+  });
+
+  function _setupWarning(confirm, settings) {
+    var confirmText = settings.confirmTextForTyping.toLowerCase();
+    var toggleClasses = settings.buttonExtraClasses;
+    var operation = settings.confirmOperationName;
+    var buttonSelector = '[data-toggle=' + operation + ']';
+
+    confirm.on('change paste keyup', 'input[data-edit=confirm]',
+    function (e) {
+      var confirmButton = confirm.find(buttonSelector);
+      var text = $(this)
+        .val()
+          .trim()
+          .toLowerCase();
+
+      if (text === confirmText) {
+        confirmButton.removeClass(toggleClasses);
+      } else {
+        confirmButton.addClass(toggleClasses);
+      }
+    });
+  }
+
+  return {
+    warning: warning
+  };
+})();

--- a/src/ggrc/assets/mustache/base_objects/confirm_delete.mustache
+++ b/src/ggrc/assets/mustache/base_objects/confirm_delete.mustache
@@ -4,8 +4,8 @@
 }}
 
 <div class="centered">
-<p>
 {{#instance}}
+<p>
 Are you sure you want to delete
   <span class="user-string">
     {{#if display_name}}
@@ -21,11 +21,14 @@ Are you sure you want to delete
     <p>The action is not reversible.</p>
   </div>
   {{/if_instance_of}}
-  {{#if delete_counts.loading}}
-	<br/><span {{attach_spinner '{ "radius": 4, "length": 4, "width": 2 }' 'display:inline-block;' }}></span>
-  {{else}}
-	<br/>{{delete_counts.counts}}
-  {{/if}}
-{{/instance}}
 </p>
+<p>
+  {{#delete_counts}}
+    <spinner {toggle}="loading"></spinner>
+    {{#if counts}}
+      This may also delete {{counts}} object mappings.
+    {{/if}}
+  {{/delete_counts}}
+</p>
+{{/instance}}
 </div>

--- a/src/ggrc/assets/mustache/base_objects/confirm_warning.mustache
+++ b/src/ggrc/assets/mustache/base_objects/confirm_warning.mustache
@@ -1,0 +1,33 @@
+{{!
+    Copyright (C) 2017 Google Inc.
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+}}
+
+<div>
+  {{#if modal_description}}
+  <p>
+    {{modal_description}}
+  </p>
+  {{/if}}
+  <p>
+    If there are any compliance/on-boarding Questionnaires related to
+    <strong>
+      {{objectShortInfo}}
+    </strong>
+    in <a href="https://ggrc-q.googleplex.com/">GGRC Questionnaires</a> they will be deprecated too!
+  </p>
+  {{#delete_counts}}
+    <spinner {toggle}="loading"></spinner>
+    <p>
+      {{#if counts}}
+        This also deletes {{counts}} related object mappings in GGRC.
+      {{/if}}
+    </p>
+  {{/delete_counts}}
+  <p>
+    Please type <strong>{{confirmTextForTyping}}</strong> in the box below to confirm {{operation}}.
+  </p>
+  <form>
+    <input class="" type="text" placeholder="{{confirmTextForTyping}}" data-edit="confirm">
+  </form>
+</div>

--- a/src/ggrc/assets/mustache/import_export/import.mustache
+++ b/src/ggrc/assets/mustache/import_export/import.mustache
@@ -20,7 +20,7 @@
             <button id="import_btn" {{#isDisabled}}disabled{{/isDisabled}} class="btn state-{{state}} {{class}}">{{{text}}}</button>
             {{^if_equals state "select"}}
               {{#showSpinner}}
-                <span {{attach_spinner '{ "radius": 4, "length": 4, "width": 2 }' 'display:inline-block; top: -3px; left: 30px;' }}></span>
+                <span {{attach_spinner '{ "radius": 4, "length": 4, "width": 2, "zIndex": 0}' 'display:inline-block; top: -3px; left: 30px;' }}></span>
               {{/showSpinner}}
               {{^showSpinner}}
                 <button class="btn btn-small state-reset">Reset</button>

--- a/src/ggrc/assets/mustache/modals/confirm_button.mustache
+++ b/src/ggrc/assets/mustache/modals/confirm_button.mustache
@@ -1,0 +1,17 @@
+{{!
+    Copyright (C) 2017 Google Inc.
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+}}
+
+<div class="row-fluid">
+  <div class="span6">
+    &nbsp;
+  </div>
+  <div class="span6">
+    <div class="confirm-buttons">
+      <a class="btn btn-small btn-green preventdoubleclick {{buttonExtraClasses}}"
+         data-toggle="{{confirmOperationName}}"
+         href="javascript://" >Confirm</a>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
DELETE SYSTEM / PROCESS / PRODUCT (ACTION BUTTON):
*Variant 1*
1.1a User clicks 'Delete' link for Product / System /Process from 3 dots menu on <object> info pane / page:
- warning pop-up should be shown.

1.2a User clicks 'X' on a warning message:
- warning pop-up should be closed;

1.3a User types 'i confirm' and clicks 'Confirm' button:
- warning pop-up should be closed;
- deletion / depreciation should be performed in GGRC.
- related Questionnaires should be deprecated in GGRCQ (already implemented and tested).

*Variant 2*
1.1b User clicks 'Delete' button on 'Edit <object>' pop-up for Product / System /Process:
- warning pop-up should be shown.

1.2b User clicks 'X' on a warning pop-up:
- warning pop-up should be closed;
- 'Edit <object>' pop-up should be still opened.

1.3b User types 'i confirm' and clicks 'Confirm' button:
- warning pop-up should be closed;
- 'Edit <object>' pop-up should be closed.
- deletion / depreciation should be performed in GGRC.
- related Questionnaires should be deprecated in GGRCQ (already implemented and tested).

DEPRECATE SYSTEM / PROCESS / PRODUCT (ACTION BUTTON):
*Variant 3*
2.1 User changes state of object to 'Deprecated' on 'Edit <object>' pop-up and clicks 'Save & Close' button:
- warning pop-up should be shown.

2.2 User clicks 'X' on a warning pop-up:
- warning pop-up should be closed;
- 'Edit <object>' pop-up should be still opened.

2.3 User types 'i confirm' and clicks 'Confirm' button:
- warning pop-up should be closed;
- 'Edit <object>' pop-up should be closed.
- deletion / depreciation should be performed in GGRC.
- related Questionnaires should be deprecated in GGRCQ (already implemented and tested).

DELETE / DEPRECATE SYSTEM / PROCESS / PRODUCT (VIA IMPORT):
*Variant 4*
3.1 User uploads a spreadsheet* (clicks 'Choose CSV file to import' button and selects spreadsheets), then a warning message should be shown.
*Spreadsheet should contain actions: delete / deprecate Systems / Products / Processes.
3.2 User clicks 'X' on a warning message:
- pop-up should be closed;
- 'Choose CSV file to import' button should be shown (no statistics about spreadsheet)

3.3 User types 'i confirm' and clicks 'Confirm' button:
- the pop-up should be closed;
- 'Import Data' button should be show and all error or warning of spreadsheet if they exist;
- deletion / depreciation should be performed in GGRC.
- related Questionnaires should be deprecated in GGRCQ (already implemented and tested).

WARNING POP-UP
4.1 Should contain the warning message:
- Variants 1 + 2: 
- Variant 3:
- Variant 4:

4.2 (Variants 1-4) Should contain 'I Confirm' field:
- field should be no case sensitive;
- trim spaces before and after typed text.

4.3 (Variants 1-4) Should contain link to GGRCQ
4.4 On clicking link, link should be opened in a new tab.
