### PR TITLE
GGRC-2732 Spinner is turning around endlessly and [Add] comment button is not displayed after Saving changes in Edit Assessment modal window

### DIFF
--- a/src/ggrc/assets/javascripts/components/comment/comment-add-form.js
+++ b/src/ggrc/assets/javascripts/components/comment/comment-add-form.js
@@ -48,6 +48,7 @@
         comment.save()
           .always(function () {
             this.attr('isSaving', false);
+            this.dispatch('afterCreate');
             this.attr('instance').dispatch('refreshInstance');
           }.bind(this));
       }


### PR DESCRIPTION
_Steps to reproduce:_
1. Have audit and assessment 
2. Go to Assessment tab> Expand Info pane and add a comment into comment box > click Add button
3. Invoke Edit assessment modal window and make changes (e.g. change test plan > Save
4. Look under the comment box in Assessment's Info pane: spinner Spinner is turning around endlessly and Add button is absent

_Actual Result:_ Spinner is turning around endlessly and [Add] comment button is not displayed after Saving changes in Edit Assessment modal window
_Expected Result:_ Spinner should not turn around endlessly and [Add] comment button should be displayed after Saving changes in Edit Assessment modal window

![screenshot-1 1](https://user-images.githubusercontent.com/4204416/28417582-50cbe17c-6d61-11e7-9072-59e359ab5f7f.png)

