### PR TITLE
GGRC-2793 "There was an error" message is displayed if date contains a space in Advanced Search filter

### DIFF
--- a/src/ggrc/assets/javascripts/components/tree/tests/tree-widget-container_spec.js
+++ b/src/ggrc/assets/javascripts/components/tree/tests/tree-widget-container_spec.js
@@ -262,6 +262,10 @@ describe('GGRC.Components.treeWidgetContainer', function () {
       vm.attr('advancedSearch.appliedFilterItems', can.List());
       vm.attr('advancedSearch.appliedMappingItems', can.List());
       spyOn(vm, 'onFilter');
+      spyOn(GGRC.Utils.AdvancedSearch, 'buildFilter')
+        .and.callFake(function (items, request) {
+          request.push({name: 'item'});
+        });
     });
 
     it('copies filter and mapping items to applied', function () {
@@ -287,10 +291,6 @@ describe('GGRC.Components.treeWidgetContainer', function () {
     it('initializes advancedSearch.request property', function () {
       vm.attr('advancedSearch.request', can.List());
       spyOn(GGRC.query_parser, 'join_queries');
-      spyOn(GGRC.Utils.AdvancedSearch, 'buildFilter')
-        .and.callFake(function (items, request) {
-          request.push({name: 'item'});
-        });
 
       vm.applyAdvancedFilters();
 

--- a/src/ggrc/assets/javascripts/plugins/tests/advanced-search-utils_spec.js
+++ b/src/ggrc/assets/javascripts/plugins/tests/advanced-search-utils_spec.js
@@ -47,7 +47,7 @@ describe('GGRC.Utils.AdvancedSearch', function () {
         GGRC.Utils.AdvancedSearch.create.attribute({
           field: 'Title',
           operator: '~',
-          value: 'test'
+          value: ' test'
         }),
         GGRC.Utils.AdvancedSearch.create.operator('OR'),
         GGRC.Utils.AdvancedSearch.create.group([
@@ -60,7 +60,7 @@ describe('GGRC.Utils.AdvancedSearch', function () {
           GGRC.Utils.AdvancedSearch.create.attribute({
             field: 'Other',
             operator: '~=',
-            value: 'value'
+            value: 'value '
           })
         ])
       ];

--- a/src/ggrc/assets/javascripts/plugins/utils/advanced-search-utils.js
+++ b/src/ggrc/assets/javascripts/plugins/utils/advanced-search-utils.js
@@ -110,7 +110,7 @@
     function attributeToFilter(attribute) {
       return '"' + attribute.field +
              '" ' + attribute.operator +
-             ' "' + attribute.value + '"';
+             ' "' + attribute.value.trim() + '"';
     }
     /**
      * Transforms Operator model to valid QueryAPI filter string.


### PR DESCRIPTION
Steps to reproduce:
1. Go to My work page > Controls tab
2. Click advanced search icon and filter by "Last deprecated date" "Lesser than" "2016" and add a space
3. Click apply and look at the screen
*Actual Result:* "There was an error" message is displayed if date contains a space in Advanced Search filter
*Expected Result:* no error is displayed while filter by date using advanced search filter