### PR TITLE
GGRC-2861 Clean up request headers for background tasks

### DIFF
--- a/src/ggrc/models/background_task.py
+++ b/src/ggrc/models/background_task.py
@@ -97,12 +97,22 @@ def create_task(name, url, queued_callback=None, parameters=None, method=None):
   task.modified_by = get_current_user()
   db.session.add(task)
   db.session.commit()
+  banned = {
+      "X-Appengine-Country",
+      "X-Appengine-Queuename",
+      "X-Appengine-Current-Namespace",
+      "X-Appengine-Taskname",
+      "X-Appengine-Tasketa",
+      "X-Appengine-Taskexecutioncount",
+      "X-Appengine-Taskretrycount",
+      "X-Task-Id",
+  }
 
   # schedule a task queue
   if getattr(settings, 'APP_ENGINE', False):
     from google.appengine.api import taskqueue
-    headers = Headers(request.headers)
-    headers.add('x-task-id', task.id)
+    headers = Headers({k: v for k, v in request.headers if k not in banned})
+    headers.add('X-Task-Id', task.id)
     taskqueue.add(
         queue_name="ggrc",
         url=url,


### PR DESCRIPTION
This commit removes any background task related headers from the request
that generates a background task. This enables us to start a new
background task from an already existing background task.


> Assessment generation does not work.
> Steps to reproduce:
> 1. generate one or more assessments
> 
> Expected: Generation works and green status is displayed
> Actual: an error is shown