### PR TITLE
GGRC-2738 Advanced search popup is not opened after clicking ESC, refresh is needed

### DIFF
--- a/src/ggrc/assets/javascripts/components/simple-modal/simple-modal.js
+++ b/src/ggrc/assets/javascripts/components/simple-modal/simple-modal.js
@@ -36,12 +36,13 @@
     },
     helpers: {
       modalWrapper: function (showContent) {
+        var self = this;
         return function (el) {
           showContent.bind('change', function (ev, val) {
             if (val) {
-              $(el).modal();
+              $(el).modal().on('hidden.bs.modal', self.hide.bind(self));
             } else {
-              $(el).modal('hide');
+              $(el).modal('hide').off('hidden.bs.modal');
             }
           });
         };


### PR DESCRIPTION
Steps to reproduce:
1. Go to my work page > Controls tab
2. Open advanced search popup
3. Click ESC
4. Click advanced search icon once again: popup is not displayed
*Actual Result:* Advanced search popup is not opened after clicking ESC, refresh is needed
*Expected Result:* Advanced search popup should be displayed after clicking ESC, refresh is needed. TBD