### PR TITLE
GGRC-2816 JS error is displayed if close "generate assessments" popup while assessment generation

### DIFF
--- a/src/ggrc/assets/javascripts/components/object-generator/object-generator.js
+++ b/src/ggrc/assets/javascripts/components/object-generator/object-generator.js
@@ -45,7 +45,9 @@
       },
       closeModal: function () {
         this.viewModel.attr('is_saving', false);
-        this.element.find('.modal-dismiss').trigger('click');
+        if (this.element) {
+          this.element.find('.modal-dismiss').trigger('click');
+        }
       },
       '.modal-footer .btn-map click': function (el, ev) {
         var type = this.viewModel.attr('type');


### PR DESCRIPTION
**Steps to reproduce:**
1. Have audit with control snapshot and assessment template
2. Go to assessments tab > select Generate assessments from 3 bb's menu in tree view
3. Select a control in generate assessments popup and click "Generate assessments" button
4. Click [x] to close generate assessments popup
5. Look at the screen


***Actual Result:*** "Uncaught TypeError: Cannot read property 'find' of null" error is displayed if close "generate assessments" popup while assessment generation
***Expected Result:*** no error is displayed if close "generate assessments" popup while assessment generation
