### PR TITLE
GGRC-2881: Add ability to change repeat options for Workflow

### DIFF
--- a/src/ggrc/assets/stylesheets/components/simple-modal/_simple-modal.scss
+++ b/src/ggrc/assets/stylesheets/components/simple-modal/_simple-modal.scss
@@ -203,4 +203,24 @@ $grid-data-header-height: 66px;
       }
     }
   }
+
+  &.repeat-on {
+    min-width: 480px;
+    .simple-modal__body {
+      max-height: calc(100% - #{$simple-modal-header-height});
+    }
+
+    .simple-modal__header {
+      border-bottom: none;
+    }
+
+    .repeat-options__toggle {
+      margin-bottom: 10px;
+    }
+
+    .simple-modal__footer {
+      border-top: none;
+      text-align: right;
+    }
+  }
 }

--- a/src/ggrc/assets/stylesheets/components/unified-mapper/_unified-mapper.scss
+++ b/src/ggrc/assets/stylesheets/components/unified-mapper/_unified-mapper.scss
@@ -403,6 +403,10 @@ mapper-results-item-attrs {
         display: inline;
       }
     }
+
+    .repeat-cell > .repeat-summary {
+      margin: 0;
+    }
   }
 }
 

--- a/src/ggrc/assets/stylesheets/modules/_modal.scss
+++ b/src/ggrc/assets/stylesheets/modules/_modal.scss
@@ -652,6 +652,10 @@
         }
       }
     }
+
+    .repeat-summary {
+      margin: 16px 0 10px 0;
+    }
   }
   .modal-footer {
     @include box-shadow(none);

--- a/src/ggrc_workflows/assets/assets.yaml
+++ b/src/ggrc_workflows/assets/assets.yaml
@@ -17,6 +17,7 @@ dashboard-js-files:
   - components/workflow_deactivate.js
   - components/repeat-on-button.js
   - components/repeat-on-button-wrapper.js
+  - components/repeat-on-summary.js
 
 dashboard-js-spec-files:
 
@@ -27,6 +28,7 @@ dashboard-js-template-files:
   - base_objects/approval_link.mustache
   - base_objects/repeat-on-button.mustache
   - base_objects/repeat-on-options.mustache
+  - base_objects/repeat-on-summary.mustache
   - cycles/info.mustache
   - cycle_task_entries/tree.mustache
   - cycle_task_entries/tree_footer.mustache

--- a/src/ggrc_workflows/assets/assets.yaml
+++ b/src/ggrc_workflows/assets/assets.yaml
@@ -1,4 +1,5 @@
 dashboard-js-files:
+  - apps/workflow-config.js
   - apps/workflows.js
   - controllers/dashboard_page.js
   - controllers/workflow_page.js
@@ -14,6 +15,8 @@ dashboard-js-files:
   - components/end_cycle.js
   - components/workflow_active.js
   - components/workflow_deactivate.js
+  - components/repeat-on-button.js
+  - components/repeat-on-button-wrapper.js
 
 dashboard-js-spec-files:
 
@@ -22,6 +25,8 @@ dashboard-js-template-files:
   - base_objects/task_group_subtree_add_item.mustache
   - base_objects/task_group_subtree.mustache
   - base_objects/approval_link.mustache
+  - base_objects/repeat-on-button.mustache
+  - base_objects/repeat-on-options.mustache
   - cycles/info.mustache
   - cycle_task_entries/tree.mustache
   - cycle_task_entries/tree_footer.mustache

--- a/src/ggrc_workflows/assets/javascripts/apps/workflow-config.js
+++ b/src/ggrc_workflows/assets/javascripts/apps/workflow-config.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ * Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+(function (GGRC) {
+  GGRC.Workflow = {
+    unitOptions: [
+      {title: 'Daily', value: 'Day', plural: 'days', singular: 'day'},
+      {title: 'Weekly', value: 'Week', plural: 'weeks', singular: 'week'},
+      {title: 'Monthly', value: 'Month', plural: 'months', singular: 'month'}
+    ],
+    repeatOptions: _.range(1, 31)
+      .map(function (option) {
+        return {
+          value: option
+        };
+      }),
+    defaultRepeatValues: {
+      unit: 'Month',
+      repeatEvery: 1
+    }
+  };
+})(window.GGRC);

--- a/src/ggrc_workflows/assets/javascripts/apps/workflow-config.js
+++ b/src/ggrc_workflows/assets/javascripts/apps/workflow-config.js
@@ -6,9 +6,9 @@
 (function (GGRC) {
   GGRC.Workflow = {
     unitOptions: [
-      {title: 'Daily', value: 'Day', plural: 'days', singular: 'day'},
-      {title: 'Weekly', value: 'Week', plural: 'weeks', singular: 'week'},
-      {title: 'Monthly', value: 'Month', plural: 'months', singular: 'month'}
+      {title: 'Daily', value: 'day', plural: 'days', singular: 'day'},
+      {title: 'Weekly', value: 'week', plural: 'weeks', singular: 'week'},
+      {title: 'Monthly', value: 'month', plural: 'months', singular: 'month'}
     ],
     repeatOptions: _.range(1, 31)
       .map(function (option) {
@@ -17,7 +17,7 @@
         };
       }),
     defaultRepeatValues: {
-      unit: 'Month',
+      unit: 'month',
       repeatEvery: 1
     }
   };

--- a/src/ggrc_workflows/assets/javascripts/components/repeat-on-button-wrapper.js
+++ b/src/ggrc_workflows/assets/javascripts/components/repeat-on-button-wrapper.js
@@ -1,0 +1,59 @@
+/*!
+ Copyright (C) 2017 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+(function (can, GGRC, $) {
+  'use strict';
+
+  GGRC.Components('repeatOnButtonWrapper', {
+    tag: 'repeat-on-button-wrapper',
+    template: '<repeat-on-button ' +
+      '{unit}="instance.unit" ' +
+      '{repeat-every}="instance.repeat_every" ' +
+      '{on-save-repeat}="@onSetRepeat">' +
+      '</repeat-on-button>',
+    viewModel: {
+      define: {
+        autoSave: {
+          type: 'boolean',
+          value: false
+        }
+      },
+      instance: {},
+      setRepeatOn: function (unit, repeatEvery) {
+        this.attr('instance.unit', unit);
+        this.attr('instance.repeat_every', repeatEvery);
+      },
+      updateRepeatOn: function () {
+        var deferred = $.Deferred();
+        var instance = this.attr('instance');
+
+        instance.save()
+          .done(function () {
+            $(document.body).trigger('ajax:flash', {
+              success: 'Repeat updated successfully'
+            });
+          })
+          .fail(function () {
+            $(document.body).trigger('ajax:flash', {
+              error: 'An error occurred'
+            });
+          })
+          .always(function () {
+            deferred.resolve();
+          });
+
+        return deferred;
+      },
+      onSetRepeat: function (unit, repeatEvery) {
+        this.setRepeatOn(unit, repeatEvery);
+        if (this.attr('autoSave')) {
+          return this.updateRepeatOn();
+        }
+
+        return $.Deferred().resolve();
+      }
+    }
+  });
+})(window.can, window.GGRC, window.can.$);

--- a/src/ggrc_workflows/assets/javascripts/components/repeat-on-button.js
+++ b/src/ggrc_workflows/assets/javascripts/components/repeat-on-button.js
@@ -1,0 +1,148 @@
+/*!
+ Copyright (C) 2017 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+(function (can, GGRC, $) {
+  'use strict';
+
+  var template = can.view(GGRC.mustache_path +
+    '/base_objects/repeat-on-button.mustache');
+  var config = GGRC.Workflow;
+
+  GGRC.Components('repeatOnButton', {
+    tag: 'repeat-on-button',
+    template: template,
+    viewModel: {
+      define: {
+        buttonText: {
+          get: function () {
+            return this.getTitle(this.attr('unit'));
+          }
+        },
+        modalTitle: {
+          get: function () {
+            return this.getTitle(this.attr('repeatEnabled'));
+          }
+        },
+        repeatEnabled: {
+          type: 'boolean',
+          value: false
+        },
+        repeatDisabled: {
+          get: function () {
+            return !this.attr('repeatEnabled');
+          }
+        },
+        repeatOptions: {
+          Value: can.List
+        },
+        unitOptions: {
+          Value: can.List
+        },
+        canSave: {
+          type: 'boolean',
+          value: true
+        },
+        isSaving: {
+          type: 'boolean',
+          value: false
+        },
+        onSaveRepeat: {
+          value: function () {
+            return function () {
+              return $.Deferred().resolve();
+            };
+          }
+        }
+      },
+      unit: null,
+      repeatEvery: null,
+      state: {
+        open: false,
+        result: {
+        }
+      },
+      getTitle: function (isEnabled) {
+        return 'Repeat ' + (isEnabled ?
+          'On' :
+          'Off');
+      },
+      showDialog: function () {
+        this.attr('state.open', true);
+      },
+      updateRepeatEveryOptions: function () {
+        var selectedRepeatEvery;
+        var repeatOptions = this.attr('repeatOptions');
+        var unitOptions = this.attr('unitOptions');
+
+        if (this.attr('state.result.unit')) {
+          selectedRepeatEvery = _.find(unitOptions, function (option) {
+            return option.value === this.attr('state.result.unit');
+          }.bind(this));
+          repeatOptions.forEach(function (option) {
+            var unitName = option.value > 1 ?
+              selectedRepeatEvery.plural :
+              selectedRepeatEvery.singular;
+            option.attr('title',
+              option.value + ' ' + unitName);
+          });
+        }
+      },
+      initOptionLists: function () {
+        this.attr('repeatOptions').replace(config.repeatOptions);
+        this.attr('unitOptions').replace(config.unitOptions);
+      },
+      setResultOptions: function (unit, repeatEvery) {
+        this.attr('state.result.unit', unit);
+        this.attr('state.result.repeatEvery', repeatEvery);
+      },
+      setDefaultOptions: function () {
+        this.setResultOptions(config.defaultRepeatValues.unit,
+          config.defaultRepeatValues.repeatEvery);
+      },
+      initSelectedOptions: function () {
+        var repeatEnabled = !!this.attr('unit');
+        this.attr('repeatEnabled', repeatEnabled);
+
+        this.setResultOptions(this.attr('unit'),
+          this.attr('repeatEvery'));
+      },
+      init: function () {
+        this.initSelectedOptions();
+        this.initOptionLists();
+        this.updateRepeatEveryOptions();
+      },
+      save: function () {
+        var unit = null;
+        var repeatEvery = null;
+        var onSave = this.attr('onSaveRepeat');
+
+        if (this.attr('repeatEnabled')) {
+          unit = this.attr('state.result.unit');
+          repeatEvery = this.attr('state.result.repeatEvery');
+        }
+
+        this.attr('isSaving', true);
+        onSave(unit, repeatEvery)
+          .then(function () {
+            this.attr('isSaving', false);
+            this.attr('state.open', false);
+          }.bind(this));
+      }
+    },
+    events: {
+      '{state.result} unit': function () {
+        this.viewModel.updateRepeatEveryOptions();
+      },
+      '{state} open': function () {
+        if (this.viewModel.attr('state.open')) {
+          this.viewModel.initSelectedOptions();
+          if (!this.viewModel.attr('unit')) {
+            this.viewModel.setDefaultOptions();
+          }
+        }
+      }
+    }
+  });
+})(window.can, window.GGRC, window.can.$);

--- a/src/ggrc_workflows/assets/javascripts/components/repeat-on-summary.js
+++ b/src/ggrc_workflows/assets/javascripts/components/repeat-on-summary.js
@@ -1,0 +1,45 @@
+/*!
+ Copyright (C) 2017 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+(function (can, GGRC) {
+  'use strict';
+
+  var template = can.view(GGRC.mustache_path +
+    '/base_objects/repeat-on-summary.mustache');
+
+  GGRC.Components('repeatOnSummary', {
+    tag: 'repeat-on-summary',
+    template: template,
+    viewModel: {
+      define: {
+        unitText: {
+          get: function () {
+            var result = '';
+            var repeatEvery = this.attr('repeatEvery');
+            var unit = GGRC.Workflow.unitOptions
+              .find(function (option) {
+                return option.value === this.attr('unit');
+              }.bind(this));
+
+            if (unit) {
+              if (repeatEvery > 1) {
+                result += repeatEvery + ' ' + unit.plural;
+              } else {
+                result += unit.singular;
+              }
+            }
+            return result;
+          }
+        },
+        showRepeatOff: {
+          type: 'boolean',
+          value: false
+        }
+      },
+      unit: null,
+      repeatEvery: null
+    }
+  });
+})(window.can, window.GGRC);

--- a/src/ggrc_workflows/assets/javascripts/components/repeat-on-summary.js
+++ b/src/ggrc_workflows/assets/javascripts/components/repeat-on-summary.js
@@ -33,9 +33,9 @@
             return result;
           }
         },
-        showRepeatOff: {
+        hideRepeatOff: {
           type: 'boolean',
-          value: false
+          value: true
         }
       },
       unit: null,

--- a/src/ggrc_workflows/assets/javascripts/components/tests/repeat-on-button-wrapper_spec.js
+++ b/src/ggrc_workflows/assets/javascripts/components/tests/repeat-on-button-wrapper_spec.js
@@ -1,0 +1,103 @@
+/*!
+ Copyright (C) 2017 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+describe('GGRC.Components.repeatOnButtonWrapper', function () {
+  'use strict';
+
+  var viewModel;
+
+  beforeEach(function () {
+    viewModel = GGRC.Components.getViewModel('repeatOnButtonWrapper');
+  });
+
+  describe('setRepeatOn method', function () {
+    it('should set unit and repeat_every properties', function () {
+      var unit = 'Day';
+      var repeatEvery = '2';
+
+      viewModel.setRepeatOn(unit, repeatEvery);
+
+      expect(viewModel.attr('instance.unit'))
+        .toEqual(unit);
+      expect(viewModel.attr('instance.repeat_every'))
+        .toEqual(repeatEvery);
+    });
+  });
+
+  describe('updateRepeatOn method', function () {
+    var saveDfd;
+    var instance;
+
+    beforeEach(function () {
+      instance = viewModel.attr('instance');
+      saveDfd = can.Deferred();
+      instance.save = jasmine.createSpy('save')
+        .and
+        .returnValue(saveDfd);
+      spyOn($.prototype, 'trigger');
+    });
+
+    it('should notify when update was successful', function () {
+      viewModel.updateRepeatOn();
+      saveDfd.resolve();
+
+      expect(instance.save.calls.count()).toEqual(1);
+      expect($.prototype.trigger)
+        .toHaveBeenCalledWith(
+          'ajax:flash',
+          {success: 'Repeat updated successfully'});
+    });
+
+    it('should notify when update was unsuccessful', function () {
+      viewModel.updateRepeatOn();
+      saveDfd.reject();
+
+      expect(instance.save.calls.count()).toEqual(1);
+      expect($.prototype.trigger)
+        .toHaveBeenCalledWith(
+          'ajax:flash',
+          {error: 'An error occurred'});
+    });
+  });
+
+  describe('onSetRepeat method', function () {
+    var saveDfd;
+    var instance;
+    beforeEach(function () {
+      instance = viewModel.attr('instance');
+      saveDfd = can.Deferred();
+      instance.save = jasmine.createSpy('save')
+        .and
+        .returnValue(saveDfd);
+      spyOn($.prototype, 'trigger');
+    });
+
+    it('should update instance values when auto-save disabled',
+    function () {
+      var unit = 'Week';
+      var repeatEvery = '22';
+      viewModel.onSetRepeat(unit, repeatEvery);
+      expect(instance.save.calls.count()).toEqual(0);
+      expect(viewModel.attr('instance.unit'))
+        .toEqual(unit);
+      expect(viewModel.attr('instance.repeat_every'))
+        .toEqual(repeatEvery);
+    });
+
+    it('should save instance when auto-save enabled',
+    function () {
+      var unit = 'Week';
+      var repeatEvery = '22';
+      viewModel.attr('autoSave', true);
+      viewModel.onSetRepeat(unit, repeatEvery);
+      saveDfd.resolve();
+      expect(viewModel.attr('instance.unit'))
+        .toEqual(unit);
+      expect(viewModel.attr('instance.repeat_every'))
+        .toEqual(repeatEvery);
+      expect(instance.save.calls.count()).toEqual(1);
+    });
+  });
+});

--- a/src/ggrc_workflows/assets/javascripts/components/tests/repeat-on-button_spec.js
+++ b/src/ggrc_workflows/assets/javascripts/components/tests/repeat-on-button_spec.js
@@ -30,7 +30,7 @@ describe('GGRC.Components.repeatOnButton', function () {
 
     it('returns on-indication when unit was selected', function () {
       var result;
-      viewModel.attr('unit', 'Day');
+      viewModel.attr('unit', 'day');
 
       result = viewModel.attr('buttonText');
 
@@ -66,9 +66,9 @@ describe('GGRC.Components.repeatOnButton', function () {
         title: '2'
       }];
     var unitOptions = [
-      {title: 'Daily', value: 'Day', plural: 'days', singular: 'day'},
-      {title: 'Weekly', value: 'Week', plural: 'weeks', singular: 'week'},
-      {title: 'Monthly', value: 'Month', plural: 'months', singular: 'month'}
+      {title: 'Daily', value: 'day', plural: 'days', singular: 'day'},
+      {title: 'Weekly', value: 'week', plural: 'weeks', singular: 'week'},
+      {title: 'Monthly', value: 'month', plural: 'months', singular: 'month'}
     ];
 
     beforeEach(function () {
@@ -92,7 +92,7 @@ describe('GGRC.Components.repeatOnButton', function () {
     function () {
       var actualTitles;
       var expectedTitles = ['1 week', '2 weeks'];
-      viewModel.attr('state.result.unit', 'Week');
+      viewModel.attr('state.result.unit', 'week');
 
       viewModel.updateRepeatEveryOptions();
 
@@ -105,7 +105,7 @@ describe('GGRC.Components.repeatOnButton', function () {
   describe('initSelectedOptions method', function () {
     it('should initialize values from injected properties',
     function () {
-      var unit = 'Day';
+      var unit = 'day';
       var repeatEvery = '2';
       viewModel.attr('unit', unit);
       viewModel.attr('repeatEvery', repeatEvery);
@@ -121,7 +121,7 @@ describe('GGRC.Components.repeatOnButton', function () {
   describe('init method', function () {
     it('should initialize values from injected properties',
     function () {
-      var unit = 'Day';
+      var unit = 'day';
       var repeatEvery = '2';
       viewModel.attr('unit', unit);
       viewModel.attr('repeatEvery', repeatEvery);
@@ -145,7 +145,7 @@ describe('GGRC.Components.repeatOnButton', function () {
 
     it('should notify with selected values when repeat is enabled',
     function () {
-      var unit = 'Day';
+      var unit = 'day';
       var repeatEvery = '2';
       viewModel.attr('state.result.unit', unit);
       viewModel.attr('state.result.repeatEvery', repeatEvery);
@@ -197,7 +197,7 @@ describe('GGRC.Components.repeatOnButton', function () {
     function () {
       var actualTitles;
       var expectedTitles = ['1 day', '2 days'];
-      context.viewModel.attr('state.result.unit', 'Day');
+      context.viewModel.attr('state.result.unit', 'day');
 
       unitChanged.apply(context);
 
@@ -220,7 +220,7 @@ describe('GGRC.Components.repeatOnButton', function () {
 
     it('should set saved values for options when modal with unit opens',
     function () {
-      var unit = 'Day';
+      var unit = 'day';
       var repeatEvery = '2';
       context.viewModel.attr('state.open', true);
       context.viewModel.attr('unit', unit);
@@ -243,7 +243,7 @@ describe('GGRC.Components.repeatOnButton', function () {
 
       openChanged.apply(context);
 
-      expect(context.viewModel.attr('state.result.unit')).toEqual('Month');
+      expect(context.viewModel.attr('state.result.unit')).toEqual('month');
       expect(context.viewModel.attr('state.result.repeatEvery')).toEqual(1);
     });
   });

--- a/src/ggrc_workflows/assets/javascripts/components/tests/repeat-on-button_spec.js
+++ b/src/ggrc_workflows/assets/javascripts/components/tests/repeat-on-button_spec.js
@@ -1,0 +1,250 @@
+/*!
+ Copyright (C) 2017 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+describe('GGRC.Components.repeatOnButton', function () {
+  'use strict';
+
+  var viewModel;
+  var events;
+  var getTitle = function (option) {
+    return option.title;
+  };
+
+  beforeAll(function () {
+    var Component = GGRC.Components.get('repeatOnButton');
+    events = Component.prototype.events;
+  });
+
+  beforeEach(function () {
+    viewModel = GGRC.Components.getViewModel('repeatOnButton');
+  });
+
+  describe('buttonText getter', function () {
+    it('returns Off-indication when no unit was selected', function () {
+      var result = viewModel.attr('buttonText');
+
+      expect(result).toEqual('Repeat Off');
+    });
+
+    it('returns on-indication when unit was selected', function () {
+      var result;
+      viewModel.attr('unit', 'Day');
+
+      result = viewModel.attr('buttonText');
+
+      expect(result).toEqual('Repeat On');
+    });
+  });
+
+  describe('modalTitle getter', function () {
+    it('returns Off-indication when repeat was disabled', function () {
+      var result = viewModel.attr('modalTitle');
+
+      expect(result).toEqual('Repeat Off');
+    });
+
+    it('returns on-indication when repeat was enabled', function () {
+      var result;
+      viewModel.attr('repeatEnabled', true);
+
+      result = viewModel.attr('modalTitle');
+
+      expect(result).toEqual('Repeat On');
+    });
+  });
+
+  describe('updateRepeatEveryOptions method', function () {
+    var repeatOptions = [
+      {
+        value: 1,
+        title: '1'
+      },
+      {
+        value: 2,
+        title: '2'
+      }];
+    var unitOptions = [
+      {title: 'Daily', value: 'Day', plural: 'days', singular: 'day'},
+      {title: 'Weekly', value: 'Week', plural: 'weeks', singular: 'week'},
+      {title: 'Monthly', value: 'Month', plural: 'months', singular: 'month'}
+    ];
+
+    beforeEach(function () {
+      viewModel.attr('repeatOptions', repeatOptions);
+      viewModel.attr('unitOptions', unitOptions);
+    });
+
+    it('should not update options when unit was not selected',
+    function () {
+      var actualTitles;
+      var expectedTitles = repeatOptions.map(getTitle);
+
+      viewModel.updateRepeatEveryOptions();
+
+      actualTitles = can.makeArray(viewModel.attr('repeatOptions'))
+        .map(getTitle);
+      expect(actualTitles).toEqual(expectedTitles);
+    });
+
+    it('should update options when unit was not selected',
+    function () {
+      var actualTitles;
+      var expectedTitles = ['1 week', '2 weeks'];
+      viewModel.attr('state.result.unit', 'Week');
+
+      viewModel.updateRepeatEveryOptions();
+
+      actualTitles = can.makeArray(viewModel.attr('repeatOptions'))
+        .map(getTitle);
+      expect(actualTitles).toEqual(expectedTitles);
+    });
+  });
+
+  describe('initSelectedOptions method', function () {
+    it('should initialize values from injected properties',
+    function () {
+      var unit = 'Day';
+      var repeatEvery = '2';
+      viewModel.attr('unit', unit);
+      viewModel.attr('repeatEvery', repeatEvery);
+
+      viewModel.initSelectedOptions();
+
+      expect(viewModel.attr('state.result.unit')).toEqual(unit);
+      expect(viewModel.attr('state.result.repeatEvery')).toEqual(repeatEvery);
+      expect(viewModel.attr('repeatEnabled')).toBeTruthy();
+    });
+  });
+
+  describe('init method', function () {
+    it('should initialize values from injected properties',
+    function () {
+      var unit = 'Day';
+      var repeatEvery = '2';
+      viewModel.attr('unit', unit);
+      viewModel.attr('repeatEvery', repeatEvery);
+
+      viewModel.init();
+
+      expect(viewModel.attr('state.result.unit')).toEqual(unit);
+      expect(viewModel.attr('state.result.repeatEvery')).toEqual(repeatEvery);
+      expect(viewModel.attr('repeatEnabled')).toBeTruthy();
+    });
+  });
+
+  describe('save method', function () {
+    var saveDfd;
+    beforeEach(function () {
+      saveDfd = can.Deferred();
+      viewModel.attr('onSaveRepeat', function () {
+        return saveDfd;
+      });
+    });
+
+    it('should notify with selected values when repeat is enabled',
+    function () {
+      var unit = 'Day';
+      var repeatEvery = '2';
+      viewModel.attr('state.result.unit', unit);
+      viewModel.attr('state.result.repeatEvery', repeatEvery);
+      viewModel.attr('repeatEnabled', true);
+
+      viewModel.save();
+
+      expect(viewModel.attr('isSaving')).toBeTruthy();
+
+      saveDfd.resolve();
+      expect(viewModel.attr('isSaving')).toBeFalsy();
+      expect(viewModel.attr('state.open')).toBeFalsy();
+    });
+
+    it('should notify with empty values when repeat is disabled',
+    function () {
+      viewModel.save();
+
+      expect(viewModel.attr('isSaving')).toBeTruthy();
+
+      saveDfd.resolve();
+      expect(viewModel.attr('isSaving')).toBeFalsy();
+      expect(viewModel.attr('state.open')).toBeFalsy();
+    });
+  });
+
+  describe('unit update event', function () {
+    var unitChanged;
+    var context;
+    var repeatOptions = [
+      {
+        value: 1,
+        title: '1'
+      },
+      {
+        value: 2,
+        title: '2'
+      }];
+
+    beforeAll(function () {
+      unitChanged = events['{state.result} unit'];
+      viewModel.attr('repeatOptions', repeatOptions);
+      context = {
+        viewModel: viewModel
+      };
+    });
+
+    it('should update repeat options when unit changed',
+    function () {
+      var actualTitles;
+      var expectedTitles = ['1 day', '2 days'];
+      context.viewModel.attr('state.result.unit', 'Day');
+
+      unitChanged.apply(context);
+
+      actualTitles = can.makeArray(context.viewModel.attr('repeatOptions'))
+        .map(getTitle);
+      expect(actualTitles).toEqual(expectedTitles);
+    });
+  });
+
+  describe('open update event', function () {
+    var openChanged;
+    var context;
+
+    beforeAll(function () {
+      openChanged = events['{state} open'];
+      context = {
+        viewModel: viewModel
+      };
+    });
+
+    it('should set saved values for options when modal with unit opens',
+    function () {
+      var unit = 'Day';
+      var repeatEvery = '2';
+      context.viewModel.attr('state.open', true);
+      context.viewModel.attr('unit', unit);
+      context.viewModel.attr('repeatEvery', repeatEvery);
+      openChanged.apply(context);
+
+      expect(context.viewModel.attr('state.result.unit'))
+        .toEqual(unit);
+      expect(context.viewModel.attr('state.result.repeatEvery'))
+        .toEqual(repeatEvery);
+      expect(context.viewModel.attr('repeatEnabled'))
+        .toBeTruthy();
+    });
+
+    it('should set default values for options when modal without unit opens',
+    function () {
+      context.viewModel.attr('state.open', true);
+      context.viewModel.attr('unit', null);
+      context.viewModel.attr('repeatEvery', 0);
+
+      openChanged.apply(context);
+
+      expect(context.viewModel.attr('state.result.unit')).toEqual('Month');
+      expect(context.viewModel.attr('state.result.repeatEvery')).toEqual(1);
+    });
+  });
+});

--- a/src/ggrc_workflows/assets/javascripts/components/tests/repeat-on-summary_spec.js
+++ b/src/ggrc_workflows/assets/javascripts/components/tests/repeat-on-summary_spec.js
@@ -1,0 +1,77 @@
+/*!
+ Copyright (C) 2017 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+describe('GGRC.Components.repeatOnSummary', function () {
+  'use strict';
+
+  var viewModel;
+
+  beforeEach(function () {
+    viewModel = GGRC.Components.getViewModel('repeatOnSummary');
+  });
+
+  describe('unitText getter', function () {
+    var unitOptions;
+    beforeAll(function () {
+      unitOptions = GGRC.Workflow.unitOptions;
+      GGRC.Workflow.unitOptions = [
+        {
+          title: 'Daily',
+          value: 'Day',
+          plural: 'days',
+          singular: 'day'},
+        {
+          title: 'Weekly',
+          value: 'Week',
+          plural: 'weeks',
+          singular: 'week'},
+        {
+          title: 'Monthly',
+          value: 'Month',
+          plural: 'months',
+          singular: 'month'}];
+    });
+
+    afterAll(function () {
+      GGRC.Workflow.unitOptions = unitOptions;
+    });
+
+    it('returns empty text when unit is not specified', function () {
+      var result;
+
+      result = viewModel.attr('unitText');
+
+      expect(result).toBe('');
+    });
+
+    it('returns empty text when incorrect unit specified', function () {
+      var result;
+      viewModel.attr('unit', 'Hour');
+
+      result = viewModel.attr('unitText');
+
+      expect(result).toBe('');
+    });
+
+    it('returns appropriate when correct unit specified', function () {
+      var result;
+      viewModel.attr('unit', 'Week');
+
+      result = viewModel.attr('unitText');
+
+      expect(result).toBe('week');
+    });
+
+    it('returns appropriate when correct unit specified', function () {
+      var result;
+      viewModel.attr('unit', 'Week');
+      viewModel.attr('repeatEvery', 4);
+
+      result = viewModel.attr('unitText');
+
+      expect(result).toBe('4 weeks');
+    });
+  });
+});

--- a/src/ggrc_workflows/assets/javascripts/models/helpers.js
+++ b/src/ggrc_workflows/assets/javascripts/models/helpers.js
@@ -95,7 +95,7 @@
         if (aws.length < 1) {
           ret = $.when(
             new CMS.Models.Workflow({
-              frequency: 'one_time',
+              unit: null,
               status: 'Active',
               title: reviewTemplate({
                 type: that.original_object.constructor.title_singular,

--- a/src/ggrc_workflows/assets/javascripts/models/workflow.js
+++ b/src/ggrc_workflows/assets/javascripts/models/workflow.js
@@ -46,7 +46,7 @@
         {attr_title: 'Manager', attr_name: 'owner', attr_sort_field: ''},
         {attr_title: 'Code', attr_name: 'slug'},
         {attr_title: 'State', attr_name: 'status'},
-        {attr_title: 'Frequency', attr_name: 'frequency'},
+        {attr_title: 'Repeat', attr_name: 'repeat'},
         {attr_title: 'Last Updated', attr_name: 'updated_at'}
       ]
     },

--- a/src/ggrc_workflows/assets/javascripts/models/workflow.js
+++ b/src/ggrc_workflows/assets/javascripts/models/workflow.js
@@ -18,17 +18,6 @@
     destroy: "DELETE /api/workflows/{id}",
     is_custom_attributable: true,
 
-    defaults: {
-      frequency_options: [
-        {title: 'One time', value: 'one_time'},
-        {title: 'Weekly', value: 'weekly'},
-        {title: 'Monthly', value: 'monthly'},
-        {title: 'Quarterly', value: 'quarterly'},
-        {title: 'Annually', value: 'annually'}
-      ],
-      frequency: 'one_time' // default value
-    },
-
     attributes: {
       people: "CMS.Models.Person.stubs",
       workflow_people: "CMS.Models.WorkflowPerson.stubs",

--- a/src/ggrc_workflows/assets/javascripts/models/workflow.js
+++ b/src/ggrc_workflows/assets/javascripts/models/workflow.js
@@ -27,6 +27,7 @@
       modified_by: "CMS.Models.Person.stub",
       context: "CMS.Models.Context.stub",
       custom_attribute_values: "CMS.Models.CustomAttributeValue.stubs",
+      repeat_every: 'number',
       default_lhn_filters: {
         Workflow: {status: 'Active'},
         Workflow_All: {},

--- a/src/ggrc_workflows/assets/mustache/base_objects/repeat-on-button.mustache
+++ b/src/ggrc_workflows/assets/mustache/base_objects/repeat-on-button.mustache
@@ -1,0 +1,31 @@
+{{!
+    Copyright (C) 2017 Google Inc.
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+}}
+
+<a href="javascript://" ($click)="showDialog"
+   class="btn btn-small {{#if unit}}btn-green{{else}}btn-white{{/if}}">
+    {{buttonText}}
+</a>
+<simple-modal modal-title="modalTitle"
+              state="state"
+              extra-css-class="repeat-on">
+    <div class="simple-modal__body">
+        <div class="ggrc-form">
+            {{{> "/static/mustache/base_objects/repeat-on-options"}}}
+        </div>
+        <div class="simple-modal__footer">
+            <div class="confirm-buttons">
+                <button class="btn btn-small btn-green"
+                        ($click)="save()" {{^canSave}}disabled{{/canSave}}
+                    {{#if isSaving}}disabled{{/if}}>
+                    {{#if isSaving}}
+                        Saving, please wait...
+                    {{else}}
+                        Save &amp; Close
+                    {{/if}}
+                </button>
+            </div>
+        </div>
+    </div>
+</simple-modal>

--- a/src/ggrc_workflows/assets/mustache/base_objects/repeat-on-options.mustache
+++ b/src/ggrc_workflows/assets/mustache/base_objects/repeat-on-options.mustache
@@ -20,7 +20,7 @@
                for="repeats-select">
             Repeats
         </label>
-        <dropdown options-list="unitOptions"
+        <dropdown {options-list}="unitOptions"
                   name="state.result.unit"
                   id="repeats-select"
                   {is-disabled}="repeatDisabled">

--- a/src/ggrc_workflows/assets/mustache/base_objects/repeat-on-options.mustache
+++ b/src/ggrc_workflows/assets/mustache/base_objects/repeat-on-options.mustache
@@ -1,0 +1,41 @@
+{{!
+    Copyright (C) 2017 Google Inc.
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+}}
+
+<div class="ggrc-form-item">
+    <div class="ggrc-form-item__row">
+        <div class="ggrc-form-item__checkbox-item">
+            <label class="input--inline" for="repeat-checkbox">
+                <input type="checkbox" can-value="repeatEnabled" id="repeat-checkbox"/>
+                Repeat Workflow
+            </label>
+        </div>
+    </div>
+</div>
+
+<div class="ggrc-form-item">
+    <div class="ggrc-form-item__multiple-row">
+        <label class="ggrc-form-item__label {{#unless repeatEnabled}}disabled{{/unless}}"
+               for="repeats-select">
+            Repeats
+        </label>
+        <dropdown options-list="unitOptions"
+                  name="state.result.unit"
+                  id="repeats-select"
+                  {is-disabled}="repeatDisabled">
+        </dropdown>
+    </div>
+
+    <div class="ggrc-form-item__multiple-row">
+        <label class="ggrc-form-item__label {{#unless repeatEnabled}}disabled{{/unless}}"
+               for="repeat-every-select">
+            Repeat Every
+        </label>
+        <dropdown {options-list}="repeatOptions"
+                  name="state.result.repeatEvery"
+                  id="repeat-every-select"
+                  {is-disabled}="repeatDisabled">
+        </dropdown>
+    </div>
+</div>

--- a/src/ggrc_workflows/assets/mustache/base_objects/repeat-on-options.mustache
+++ b/src/ggrc_workflows/assets/mustache/base_objects/repeat-on-options.mustache
@@ -3,21 +3,16 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
 
-<div class="ggrc-form-item">
-    <div class="ggrc-form-item__row">
-        <div class="ggrc-form-item__checkbox-item">
-            <label class="input--inline" for="repeat-checkbox">
-                <input type="checkbox" can-value="repeatEnabled" id="repeat-checkbox"/>
-                Repeat Workflow
-            </label>
-        </div>
-    </div>
+<div class="row-fluid">
+    <label class="input--inline repeat-options__toggle" for="repeat-checkbox">
+        <input type="checkbox" can-value="repeatEnabled" id="repeat-checkbox"/>
+        Repeat Workflow
+    </label>
 </div>
 
-<div class="ggrc-form-item">
-    <div class="ggrc-form-item__multiple-row">
-        <label class="ggrc-form-item__label {{#unless repeatEnabled}}disabled{{/unless}}"
-               for="repeats-select">
+<div class="row-fluid">
+    <div class="span5">
+        <label class="{{#unless repeatEnabled}}disabled{{/unless}}">
             Repeats
         </label>
         <dropdown {options-list}="unitOptions"
@@ -26,10 +21,8 @@
                   {is-disabled}="repeatDisabled">
         </dropdown>
     </div>
-
-    <div class="ggrc-form-item__multiple-row">
-        <label class="ggrc-form-item__label {{#unless repeatEnabled}}disabled{{/unless}}"
-               for="repeat-every-select">
+    <div class="span5">
+        <label class="{{#unless repeatEnabled}}disabled{{/unless}}">
             Repeat Every
         </label>
         <dropdown {options-list}="repeatOptions"

--- a/src/ggrc_workflows/assets/mustache/base_objects/repeat-on-summary.mustache
+++ b/src/ggrc_workflows/assets/mustache/base_objects/repeat-on-summary.mustache
@@ -8,9 +8,9 @@
         Repeat every {{unitText}}
     </div>
 {{else}}
-    {{#if showRepeatOff}}
+    {{#unless hideRepeatOff}}
         <div class="repeat-summary">
             Repeat Off
         </div>
-    {{/if}}
+    {{/unless}}
 {{/if}}

--- a/src/ggrc_workflows/assets/mustache/base_objects/repeat-on-summary.mustache
+++ b/src/ggrc_workflows/assets/mustache/base_objects/repeat-on-summary.mustache
@@ -1,0 +1,16 @@
+{{!
+    Copyright (C) 2017 Google Inc.
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+}}
+
+{{#if unit}}
+    <div class="repeat-summary">
+        Repeat every {{unitText}}
+    </div>
+{{else}}
+    {{#if showRepeatOff}}
+        <div class="repeat-summary">
+            Repeat Off
+        </div>
+    {{/if}}
+{{/if}}

--- a/src/ggrc_workflows/assets/mustache/workflows/info.mustache
+++ b/src/ggrc_workflows/assets/mustache/workflows/info.mustache
@@ -138,15 +138,11 @@
       </div>
       <div class="span6">
         <h6>
-          Frequency
+          Repeat Workflow
         </h6>
-        <p>
-          {{#if_equals instance.frequency 'one_time'}}
-            One time
-          {{else}}
-            {{instance.frequency}}
-          {{/if_equals}}
-        </p>
+            <repeat-on-summary {unit}="instance.unit" {repeat-every}="instance.repeat_every"
+                               hide-repeat-off="false">
+        </repeat-on-summary>
       </div>
     </div>
     <div class="row-fluid">

--- a/src/ggrc_workflows/assets/mustache/workflows/modal_content.mustache
+++ b/src/ggrc_workflows/assets/mustache/workflows/modal_content.mustache
@@ -53,8 +53,11 @@
             Repeat Workflow
             <a data-id="hide_frequency_hidden_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
           </label>
-          <repeat-on-button-wrapper {(instance)}="instance"></repeat-on-button-wrapper>
-          <repeat-on-summary {unit}="instance.unit" {repeat-every}="instance.repeat_every">
+          {{#if instance.isNew}}
+            <repeat-on-button-wrapper {(instance)}="instance"></repeat-on-button-wrapper>
+          {{/if}}
+          <repeat-on-summary {unit}="instance.unit" {repeat-every}="instance.repeat_every"
+                             {hide-repeat-off}="instance.isNew">
           </repeat-on-summary>
         </div>
       </div>

--- a/src/ggrc_workflows/assets/mustache/workflows/modal_content.mustache
+++ b/src/ggrc_workflows/assets/mustache/workflows/modal_content.mustache
@@ -54,6 +54,8 @@
             <a data-id="hide_frequency_hidden_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
           </label>
           <repeat-on-button-wrapper {(instance)}="instance"></repeat-on-button-wrapper>
+          <repeat-on-summary {unit}="instance.unit" {repeat-every}="instance.repeat_every">
+          </repeat-on-summary>
         </div>
       </div>
       <div class="row-fluid inner-hide">

--- a/src/ggrc_workflows/assets/mustache/workflows/modal_content.mustache
+++ b/src/ggrc_workflows/assets/mustache/workflows/modal_content.mustache
@@ -50,19 +50,10 @@
       <div class="row-fluid inner-hide">
         <div data-id="frequency_hidden" class="span12 hidable">
           <label>
-            Frequency
-            <i class="fa fa-question-circle" rel="tooltip" title="Choose frequency"></i>
+            Repeat Workflow
             <a data-id="hide_frequency_hidden_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
           </label>
-          <dropdown
-            id="frequency"
-            class-name="input-block-level"
-            options-list="instance.frequency_options"
-            name="instance.frequency"
-            data-id="frequency_dd"
-            tabindex="4"
-            {{^new_object_form}}is-disabled="true"{{/new_object_form}}
-          ></dropdown>
+          <repeat-on-button-wrapper {(instance)}="instance"></repeat-on-button-wrapper>
         </div>
       </div>
       <div class="row-fluid inner-hide">

--- a/src/ggrc_workflows/assets/mustache/workflows/tree-item-attr.mustache
+++ b/src/ggrc_workflows/assets/mustache/workflows/tree-item-attr.mustache
@@ -19,12 +19,10 @@
       {{/each}}
     {{/with_mapping}}
   {{/case}}
-  {{#case 'frequency'}}
-    {{#if_equals instance.frequency 'one_time'}}
-      One time
-    {{else}}
-      {{instance.frequency}}
-    {{/if_equals}}
+  {{#case 'repeat'}}
+      <repeat-on-summary {unit}="instance.unit" {repeat-every}="instance.repeat_every"
+                         hide-repeat-off="false" class="repeat-cell">
+      </repeat-on-summary>
   {{/case}}
   {{#case 'status'}}
     {{#using status=instance.status}}


### PR DESCRIPTION
1. Add button and modal dialog for setting up repeat options.
2. Show repeat summary in user-friendly way (ex., 'Repeat Off', 'Repeat every month', 'Repeat every 2 days', etc.):
* on create-edit dialog,
* on WF info page,
* on 'Workflows' tab (tree-view),
* in unified mapper and global search.

![screen_06](https://user-images.githubusercontent.com/24203972/28610779-3a6c1ad8-71f2-11e7-8fa4-98976aa9df60.png)
<img width="1278" alt="screen_10" src="https://user-images.githubusercontent.com/24203972/28610803-546ac2fe-71f2-11e7-9f43-e84078e2d6ad.png">
<img width="1439" alt="screen_11" src="https://user-images.githubusercontent.com/24203972/28610818-5eb3122a-71f2-11e7-9090-e98a95b3b652.png">
