### PR TITLE
QUICK-FIX Add test for one time Workflow creation

### DIFF
--- a/test/integration/ggrc_workflows/test_api_calls.py
+++ b/test/integration/ggrc_workflows/test_api_calls.py
@@ -100,6 +100,8 @@ class TestWorkflowsApiPost(TestCase):
             "title": "One_time",
             "description": "",
             "frequency": "one_time",
+            "unit": None,
+            "repeat_every": None,
             "notify_on_change": False,
             "task_group_title": "Task Group 1",
             "notify_custom_message": "",


### PR DESCRIPTION
Now it's tested under test_create_one_time_workflows with the repeat_only and unit default values of None