### PR TITLE
GGRC-2886: Add ability to see repeat on options for Cycles

### DIFF
--- a/src/ggrc_workflows/assets/mustache/cycles/info.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycles/info.mustache
@@ -58,15 +58,11 @@
         </div>
         <div class="span6">
           <h6>
-            Frequency
+              Repeat Cycle
           </h6>
-          <p>
-            {{#if_equals instance.frequency 'one_time'}}
-              One time
-            {{else}}
-              {{instance.frequency}}
-            {{/if_equals}}
-          </p>
+          <repeat-on-summary {unit}="instance.unit" {repeat-every}="instance.repeat_every"
+                             hide-repeat-off="false">
+          </repeat-on-summary>
         </div>
       {{/using}}
     </div>


### PR DESCRIPTION
Show repeat summary in user-friendly way in Cycle Info pane:
- Repeat Off,
- Repeat every month,
- Repeat every 2 months, etc.

![screen_08](https://user-images.githubusercontent.com/24203972/28621466-b8cfa6b6-7219-11e7-9107-0d963d3f1e82.png)
