### PR TITLE
GGRC-2888: Remove logic for populating Assignee with currently logged in user on task creation

### DIFF
--- a/src/ggrc_workflows/assets/javascripts/models/cycle_models.js
+++ b/src/ggrc_workflows/assets/javascripts/models/cycle_models.js
@@ -373,20 +373,11 @@
       var workflows;
       var _workflow;
       var cycle;
-      var person = {
-        id: GGRC.current_user.id,
-        type: 'Person'
-      };
 
       if (newObjectForm) {
         // prepopulate dates with default ones
         this.attr('start_date', new Date());
         this.attr('end_date', moment().add({month: 3}).toDate());
-
-        if (!form.contact) {
-          form.attr('contact', person);
-          form.attr('_transient.contact', person);
-        }
 
         // using setTimeout to execute this after the modal is loaded
         // so we can see when the workflow is already set and use that one


### PR DESCRIPTION
Remove Assignee prepopulation logic from all places for Task creation