### PR TITLE
GGRC-2616 Remove redundant requests after adding URL and Evidence to Assessment

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.js
+++ b/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.js
@@ -289,12 +289,6 @@
     init: function () {
       this.viewModel.initializeFormFields();
       this.viewModel.updateRelatedItems();
-    },
-    events: {
-      '{viewModel.instance} refreshInstance': function () {
-        this.viewModel.attr('mappedSnapshots')
-          .replace(this.viewModel.loadSnapshots());
-      }
     }
   });
 })(window.can, window.GGRC);

--- a/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.js
+++ b/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.js
@@ -156,6 +156,19 @@
           this.attr(type).replace(this['load' + can.capitalize(type)]());
         }.bind(this));
       },
+      afterCreate: function (event, type) {
+        var instance = event.item;
+        var items = this.attr(type);
+
+        this.attr('isUpdating' + can.capitalize(type), false);
+        items.replace(items.map(function (item) {
+          if (item._stamp === instance._stamp) {
+            instance.attr('isDraft', false);
+            return instance;
+          }
+          return item;
+        }));
+      },
       removeItem: function (event, type) {
         var item = event.item;
         var index = this.attr(type).indexOf(item);

--- a/src/ggrc/assets/javascripts/components/comment/comment-add-form.js
+++ b/src/ggrc/assets/javascripts/components/comment/comment-add-form.js
@@ -31,7 +31,8 @@
           context: source.context,
           assignee_type: GGRC.Utils.getAssigneeType(source),
           created_at: new Date(),
-          modified_by: {type: 'Person', id: GGRC.current_user.id}
+          modified_by: {type: 'Person', id: GGRC.current_user.id},
+          _stamp: Date.now()
         };
       },
       updateComment: function (comment) {
@@ -46,9 +47,12 @@
         comment = this.updateComment(comment);
         this.dispatch({type: 'beforeCreate', items: [comment.attr()]});
         comment.save()
-          .always(function () {
+          .always(function (instance) {
             this.attr('isSaving', false);
-            this.dispatch('afterCreate');
+            this.dispatch({
+              type: 'afterCreate',
+              item: instance
+            });
             this.attr('instance').dispatch('refreshInstance');
           }.bind(this));
       }

--- a/src/ggrc/assets/javascripts/components/quick_form/quick_add.js
+++ b/src/ggrc/assets/javascripts/components/quick_form/quick_add.js
@@ -53,7 +53,8 @@
           document_type: CMS.Models.Document.URL,
           owners: [{type: 'Person', id: GGRC.current_user.id}],
           created_at: new Date(),
-          isDraft: true
+          isDraft: true,
+          _stamp: Date.now()
         };
         this.viewModel.dispatch({type: 'beforeCreate', items: [attrs]});
         // We are not validating the URL because application can locally we can
@@ -189,11 +190,15 @@
             this.bindXHRToButton(
               join_object.save()
                 .done(function () {
+                  var instance = this.viewModel.attr('instance');
                   el.trigger('modal:success', join_object);
                   this.viewModel
                     .attr('parent_instance')
                     .dispatch('refreshInstance');
-                  this.viewModel.dispatch('afterCreate');
+                  this.viewModel.dispatch({
+                    type: 'afterCreate',
+                    item: instance
+                  });
                 }.bind(this)), el);
           }.bind(this))
           .always(function () {

--- a/src/ggrc/assets/javascripts/components/quick_form/quick_add.js
+++ b/src/ggrc/assets/javascripts/components/quick_form/quick_add.js
@@ -192,9 +192,7 @@
                 .done(function () {
                   var instance = this.viewModel.attr('instance');
                   el.trigger('modal:success', join_object);
-                  this.viewModel
-                    .attr('parent_instance')
-                    .dispatch('refreshInstance');
+
                   this.viewModel.dispatch({
                     type: 'afterCreate',
                     item: instance

--- a/src/ggrc/assets/mustache/components/assessment/info-pane/info-pane.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/info-pane/info-pane.mustache
@@ -101,7 +101,7 @@
                             {{#toggle show_new_object_form}}
                                 <ggrc-quick-add
                                         (before-create)="addItems(%event, 'urls')"
-                                        (after-create)="updateItems('urls')"
+                                        (after-create)="afterCreate(%event, 'urls')"
                                         {parent_instance}="instance"
                                         join_model="Relationship"
                                         quick_create="create_url">

--- a/src/ggrc/assets/mustache/components/assessment/info-pane/info-pane.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/info-pane/info-pane.mustache
@@ -200,7 +200,7 @@
                     <comment-add-form class="comment-add-form"
                                     {instance}="instance"
                                     {is-saving}="isUpdatingComments"
-                                    (after-create)="updateItems('comments')"
+                                    (after-create)="afterCreate(%event, 'comments')"
                                     (before-create)="addItems(%event, 'comments')"
                     ></comment-add-form>
                   {{/is_allowed}}


### PR DESCRIPTION
After adding a URL or Evidence to an assessment the last three requests we run are:
POST: /query [related Snapshots and Documents]
GET: /api/assessments?id__in=1
GET: /api/documents?id__in=1
And all the information is already was already present on the frontend before these requests.
We should investigate why they occur and if there is no need for them, they should be removed

**Result:**
- GET request on objects will be removed in scope of GGRC-2798
- In scope of this issue was removed only request on Snapshot, that really not needed. Request on Documents need for make sure that URL/Evidence was added