### PR TITLE
GGRC-2726 / GGRC-2727 Incorrect number of control's snapshots is displayed on the Assessment Info page

### DIFF
--- a/src/ggrc/assets/javascripts/plugins/utils/current-page-utils.js
+++ b/src/ggrc/assets/javascripts/plugins/utils/current-page-utils.js
@@ -34,14 +34,18 @@
       models = can.makeArray(models);
 
       models.forEach(function (model) {
-        reqParams.push(queryAPI.batchRequests(queryAPI.buildRelevantIdsQuery(
+        var query = queryAPI.buildRelevantIdsQuery(
           model,
           {},
           {
             type: currentPageInstance.type,
             id: currentPageInstance.id,
             operation: 'relevant'
-          })));
+          });
+        if (SnapshotUtils.isSnapshotRelated(currentPageInstance.type, model)) {
+          query = SnapshotUtils.transformQuery(query);
+        }
+        reqParams.push(queryAPI.batchRequests(query));
       });
 
       return can.when.apply(can, reqParams)
@@ -49,7 +53,9 @@
           var response = can.makeArray(arguments);
 
           models.forEach(function (model, idx) {
-            var ids = response[idx][model].ids;
+            var ids = response[idx][model] ?
+              response[idx][model].ids :
+              response[idx].Snapshot.ids;
             var map = ids.reduce(function (mapped, id) {
               mapped[id] = true;
               return mapped;

--- a/src/ggrc/assets/javascripts/plugins/utils/tree-view-utils.js
+++ b/src/ggrc/assets/javascripts/plugins/utils/tree-view-utils.js
@@ -406,9 +406,9 @@
               relevant,
               subTreeFields);
 
-            if ((SnapshotUtils.isSnapshotParent(relevant.type) ||
-              SnapshotUtils.isInScopeModel(relevant.type)) &&
-              SnapshotUtils.isSnapshotModel(params.object_name)) {
+            if (SnapshotUtils.isSnapshotRelated(
+                relevant.type,
+                params.object_name)) {
               params = SnapshotUtils.transformQuery(params);
             }
 
@@ -511,13 +511,23 @@
           showMore: false
         });
       } else {
-        countQuery = QueryAPI.buildCountParams(models, relevant, filter);
+        countQuery = QueryAPI.buildCountParams(models, relevant, filter)
+          .map(function (param) {
+            if (SnapshotUtils.isSnapshotRelated(
+                relevant.type,
+                param.object_name)) {
+              param = SnapshotUtils.transformQuery(param);
+            }
+            return param;
+          });
 
         result = QueryAPI.makeRequest({data: countQuery})
           .then(function (response) {
             var total = 0;
             var showMore = models.some(function (model, index) {
-              var count = response[index][model].total;
+              var count = response[index][model] ?
+                response[index][model].total :
+                response[index].Snapshot.total;
 
               if (!count) {
                 return false;

--- a/src/ggrc/assets/javascripts/plugins/utils/tree-view-utils.js
+++ b/src/ggrc/assets/javascripts/plugins/utils/tree-view-utils.js
@@ -587,7 +587,7 @@
       var relates = CurrentPage.related.attr(instance.type);
       var result = true;
       var instanceId = SnapshotUtils.isSnapshot(instance) ?
-        instance.snapshot.child_id :
+        instance.snapshot.id :
         instance.id;
 
       if (needToSplit) {


### PR DESCRIPTION
The pull request contains fixes for 2 related issues.

GGRC-2726:
Steps to reproduce:
1. Have program, at least 4 controls, audit with control's snapshots
2. On the program page delete one original control
3. Go to audit page and update audit to the latest version
4. Open assessment in a new tab
5. Go to Audit widget > expand subtree for audit > click " Show objects not directly related to this Assessment"
6. Look at the mapped controls snapshots: three controls snapshots instead of four are displayed in sublevel
Actual Result: Incorrect number of control's snapshots is displayed in audit sublevel on the Assessment Info page
Expected Result: All controls snapshots should be displayed in audit sublevel on the Assessment Info page

GGRC-2727:
Steps to reproduce:
1. Have program, at least 4 controls, audit with control's snapshots
2. Create assessment and map control's snapshots to assessment
3. On the program page delete one original control
4. Go to audit page and update audit to the latest version
5. Open assessment in a new tab
6. Go to Audit widget > expand subtree for audit > click " Show objects not directly related to this Assessment"
7. Look at the mapped controls snapshots: one of control's snapshots is displayed under "Show objects not directly related to this Assessment" link
Actual Result: Control's snapshot is displayed under "Show objects not directly related to this Assessment" link
Expected Result: As control's snapshot is mapped to audit it should be displayed above "Show objects not directly related to this Assessment" link after even after removal original control