### PR TITLE
GGRC-2903: Hide 'Create' button for recurrent workflows

### DIFF
--- a/src/ggrc_workflows/assets/javascripts/workflow_mustache_helpers.js
+++ b/src/ggrc_workflows/assets/javascripts/workflow_mustache_helpers.js
@@ -193,8 +193,8 @@
   Mustache.registerHelper('if_recurring_workflow', function (object, options) {
     object = Mustache.resolve(object);
     if (object.type === 'Workflow' &&
-        _.includes(['weekly', 'monthly', 'quarterly', 'annually'],
-                   object.frequency)) {
+        _.includes(['day', 'week', 'month'],
+                   object.unit)) {
       return options.fn(this);
     }
     return options.inverse(this);


### PR DESCRIPTION
Create button should be available on TGT tree-view for one-time workflows only.