### PR TITLE
GGRC-3035 Remove redundant requests on Revisions if it already cached on FE

### DIFF
--- a/src/ggrc/assets/javascripts/components/snapshotter/revisions-comparer.js
+++ b/src/ggrc/assets/javascripts/components/snapshotter/revisions-comparer.js
@@ -94,7 +94,7 @@
         var Revision = CMS.Models.Revision;
         var notCached = [];
         var cached = [currentRevisionID, newRevisionID].map(function (id) {
-          var cache = Revision.store ? Revision.store[id] : undefined;
+          var cache = Revision.findInCacheById(id);
           if (!cache) {
             notCached.push(id);
           }

--- a/src/ggrc/assets/javascripts/components/snapshotter/tests/revisions-comparer_spec.js
+++ b/src/ggrc/assets/javascripts/components/snapshotter/tests/revisions-comparer_spec.js
@@ -177,7 +177,7 @@ describe('GGRC.Components.revisionsComparer', function () {
 
     it('when cache is empty doing ajax call for all revisions',
       function (done) {
-        Revision.store = undefined;
+        spyOn(Revision, 'findInCacheById').and.returnValue(undefined);
 
         spyOn(Revision, 'findAll').and.returnValue(
           can.Deferred().resolve([{id: 42}, {id: 11}])
@@ -202,9 +202,8 @@ describe('GGRC.Components.revisionsComparer', function () {
 
     it('when in cache only one object doing findOne call',
       function (done) {
-        Revision.store = {
-          '42': {id: 42}
-        };
+        spyOn(Revision, 'findInCacheById').and
+          .returnValues({id: 42}, undefined);
 
         spyOn(Revision, 'findAll').and.returnValue(
           can.Deferred().resolve([{id: 42}, {id: 11}])
@@ -227,10 +226,7 @@ describe('GGRC.Components.revisionsComparer', function () {
 
     it('when cache contains all objects are not doing ajax call',
       function (done) {
-        Revision.store = {
-          '11': {id: 11},
-          '42': {id: 42}
-        };
+        spyOn(Revision, 'findInCacheById').and.returnValues({id: 42}, {id: 11});
 
         spyOn(Revision, 'findAll').and.returnValue(
           can.Deferred().resolve([{id: 42}, {id: 11}])


### PR DESCRIPTION
Expected result:
1. Open info pane of Snapshot, whose original object was changed
2. Open Revision comparer (see request on revision in DevTool)
3. Close revision comparer
4. Open again (request on revision shouldn't be sent)