### PR TITLE
GGRC-2904 Add reference URLs widget to Process modal form

### DIFF
--- a/src/ggrc/assets/javascripts/models/system.js
+++ b/src/ggrc/assets/javascripts/models/system.js
@@ -169,5 +169,8 @@ CMS.Models.SystemOrProcess('CMS.Models.Process', {
   init: function () {
     this._super && this._super.apply(this, arguments);
     this.attr('is_biz_process', true);
+  },
+  after_save: function () {
+    this.dispatch('refreshRelatedDocuments');
   }
 });

--- a/src/ggrc/assets/mustache/processes/modal_content.mustache
+++ b/src/ggrc/assets/mustache/processes/modal_content.mustache
@@ -63,24 +63,7 @@
     </div>
     <div class="span6 hide-wrap hidable">
       <div class="row-fluid inner-hide">
-        <div data-id="url_hidden" class="span12 hidable">
-          <label>
-            Process URL
-            <i class="fa fa-question-circle" rel="tooltip" title="Web link to the Sites page / {{model.model_singular}} documentation."></i>
-            <a data-id="hide_url_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
-          </label>
-          <input data-id="url_txtbx" tabindex="6" class="input-block-level" name="url" placeholder="http://www.domain.com/" type="text" value="{{url}}">
-        </div>
-      </div>
-      <div class="row-fluid inner-hide">
-        <div data-id="reference_url_hidden" class="span12 hidable">
-          <label>
-            Reference URL
-            <i class="fa fa-question-circle" rel="tooltip" title="Web links to other references."></i>
-            <a data-id="hide_reference_url_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
-          </label>
-          <input data-id="reference_url_txtbx" tabindex="7" id="reference_url" class="input-block-level" placeholder="https://www.example.com/" name="reference_url" type="text" value="{{reference_url}}">
-        </div>
+        {{> '/static/mustache/base_objects/modal_content_urls.mustache'}}
       </div>
     </div>
   </div>


### PR DESCRIPTION
This PR fixes the modal content template for Process modal form.

It replaces legacy URL input fields with Reference URLs widget. It also makes sure that if reference URLs are changed when editing a Process, the reference URL list on the info pane gets refreshed after a save.
(hint: open a Process info pane and click select "edit process" from the info pane menu to observe the refresh in action)