### PR TITLE
GGRC-2922 Add compute attributes to reindex job

### DIFF
--- a/src/ggrc/views/__init__.py
+++ b/src/ggrc/views/__init__.py
@@ -96,6 +96,7 @@ def start_compute_attributes(revision_ids):
 
 def do_reindex():
   """Update the full text search index."""
+  from ggrc.data_platform import computed_attributes
 
   indexer = get_indexer()
   indexed_models = {
@@ -122,6 +123,7 @@ def do_reindex():
   with benchmark("Create records for %s" % "Snapshot"):
     reindex_snapshots()
   indexer.invalidate_cache()
+  computed_attributes.compute_attributes("all_latest")
 
 
 def get_permissions_json():

--- a/test/integration/ggrc/services/test_query/test_snapshots.py
+++ b/test/integration/ggrc/services/test_query/test_snapshots.py
@@ -13,7 +13,6 @@ from ddt import ddt
 from ddt import unpack
 
 from ggrc import app
-from ggrc import views
 from ggrc import models
 from ggrc.models import all_models
 from ggrc import db
@@ -64,6 +63,7 @@ class TestAuditSnapshotQueries(TestCase):
   def setUp(self):
     """Log in before performing queries."""
     self.client.get("/login")
+    self.client.post("/admin/reindex")
 
   def _post(self, request_data):
     return self.client.post(
@@ -169,8 +169,6 @@ class TestAuditSnapshotQueries(TestCase):
 
     # Create an unmapped control for base tests
     factories.ControlFactory(title="Control 0")
-
-    views.do_reindex()
 
   def test_basic_snapshot_query(self):
     """Test fetching all snapshots for a given Audit."""


### PR DESCRIPTION
Re-index clears the full text index table and populates it with all
objects. The computed attributes are not part of current objects and so
the recompute job must be run after every reindex, so that the computed
values themselves are also indexed correctly.