### PR TITLE
GGRC-2923 Fix attribute table indexes and constraints

### DIFF
--- a/src/ggrc/data_platform/attributes.py
+++ b/src/ggrc/data_platform/attributes.py
@@ -56,8 +56,15 @@ class Attributes(base.Base, db.Model):
   @declared_attr
   def __table_args__(cls):  # pylint: disable=no-self-argument
     return (
-        db.Index("source_type", "source_id", "source_attr"),
+        db.Index("ix_source", "source_type", "source_id", "source_attr"),
         # db.Index("value_string"), not needed yet
-        db.Index("value_integer"),
-        db.Index("value_datetime"),
+        db.Index("ix_value_integer", "value_integer"),
+        db.Index("ix_value_datetime", "value_datetime"),
+        db.UniqueConstraint(
+            "object_id",
+            "object_type",
+            "attribute_definition_id",
+            "attribute_template_id",
+            name="uq_attributes",
+        ),
     )

--- a/src/ggrc/migrations/versions/20170728112941_191c7cc1fed8_add_unique_constraint_on_attributes_.py
+++ b/src/ggrc/migrations/versions/20170728112941_191c7cc1fed8_add_unique_constraint_on_attributes_.py
@@ -1,0 +1,35 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Add unique constraint on attributes table
+
+Create Date: 2017-07-28 11:29:41.606021
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '191c7cc1fed8'
+down_revision = '951213087c6'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  op.execute("TRUNCATE TABLE attributes")
+  op.create_unique_constraint(
+      'uq_attributes',
+      'attributes', [
+          'object_id',
+          'object_type',
+          'attribute_definition_id',
+          'attribute_template_id'
+      ]
+  )
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  op.drop_constraint('uq_attributes', 'attributes')


### PR DESCRIPTION
> Computed attributes contain duplicate values and might show wrong results (randomly)
> 
> To check this run $.post('/admin/compute_attributes') and check for duplicates in the attributes table.