### PR TITLE
GGRC-2319: Improvements for Related Assessments popup

### DIFF
--- a/src/ggrc/assets/mustache/assessments/related-assessments-without-reuse.mustache
+++ b/src/ggrc/assets/mustache/assessments/related-assessments-without-reuse.mustache
@@ -42,7 +42,7 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                 <related-assessment-item {^sub-items-loading}="itemLoading" class="{{#itemsLoading}}hidden{{/itemsLoading}}">
                     <div class="grid-data-row flex-row flex-box">
                         <div class="flex-size-3">
-                            <a href="{{instance.viewLink}}" target="_blank" title="{{instance.title}}">{{instance.title}}</a>
+                            <a href="{{instance.viewLink}}" target="_blank" class="grid-data-item__title-cell" title="{{instance.title}}">{{instance.title}}</a>
                         </div>
                         <div class="grid-data-item-index">
                             <state-colors-map {state}="instance.status"></state-colors-map>
@@ -70,7 +70,7 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                                         {parent-instance}="parentInstance"
                                         {related-types}="relatedTypes"
                                         {^is-loading}="loadingState.auditLoading">
-                                    <a href="{{instance.viewLink}}" target="_blank">{{instance.title}}</a>
+                                    <a href="{{instance.viewLink}}" target="_blank" class="grid-data-item__title-cell">{{instance.title}}</a>
                                 </mapped-objects>
                             </related-audits>
                         </div>

--- a/src/ggrc/assets/mustache/assessments/related-assessments.mustache
+++ b/src/ggrc/assets/mustache/assessments/related-assessments.mustache
@@ -54,7 +54,7 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                                              class="{{#itemsLoading}}hidden{{/itemsLoading}}">
                         <div class="grid-data-row flex-row flex-box">
                             <div class="flex-size-3">
-                                <a href="{{instance.viewLink}}" target="_blank" title="{{instance.title}}">{{instance.title}}</a>
+                                <a href="{{instance.viewLink}}" class="grid-data-item__title-cell" target="_blank" title="{{instance.title}}">{{instance.title}}</a>
                             </div>
                             <div class="grid-data-item-index">
                                 <state-colors-map {state}="instance.status"></state-colors-map>
@@ -82,7 +82,7 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                                             {parent-instance}="parentInstance"
                                             {related-types}="relatedTypes"
                                             {^is-loading}="loadingState.auditLoading">
-                                        <a href="{{instance.viewLink}}" target="_blank">{{instance.title}}</a>
+                                        <a href="{{instance.viewLink}}" class="grid-data-item__title-cell" target="_blank">{{instance.title}}</a>
                                     </mapped-objects>
                                 </related-audits>
                             </div>

--- a/src/ggrc/assets/stylesheets/components/action-button/_action-button.scss
+++ b/src/ggrc/assets/stylesheets/components/action-button/_action-button.scss
@@ -182,7 +182,8 @@
       color: $darkBlue;
     }
 
-    .related-assessments &:hover {
+    .related-assessments &:hover,
+    .related-assessments__tab-container &:hover {
       text-decoration: underline;
       color: $blue;
     }

--- a/src/ggrc/assets/stylesheets/components/grid-data/_grid-data.scss
+++ b/src/ggrc/assets/stylesheets/components/grid-data/_grid-data.scss
@@ -153,6 +153,14 @@
     padding: 0 8px;
     box-sizing: border-box;
   }
+
+  .grid-data-item__title-cell {
+    display: -webkit-box;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+  }
 }
 .grid-data__action-column {
   width: 80px;


### PR DESCRIPTION
The following Improvements for Related Assessments popup should be done according to the mockups:
1. Underline "Show All"/"Show less" link when hover over it in Info popup in Attributes and Comments in Related Assessments tab;
2. Cut off Assessment and Audit titles to 2 lines in Releated Assessments view.