### PR TITLE
GGRC-2675 Internal Audit Lead is not preselected by default in New audit modal window

### DIFF
--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -58,6 +58,7 @@
     destroy: 'DELETE /api/audits/{id}',
     create: 'POST /api/audits',
     mixins: [
+      'contactable',
       'unique_title',
       'ca_update',
       'timeboxed',

--- a/src/ggrc/assets/javascripts/models/mixins.js
+++ b/src/ggrc/assets/javascripts/models/mixins.js
@@ -128,6 +128,40 @@
     }
   });
 
+  can.Model.Mixin('contactable', {
+    // NB : Because the attributes object
+    //  isn't automatically cloned into subclasses by CanJS (this is an intentional
+    //  exception), when subclassing a class that uses this mixin, be sure to pull in the
+    //  parent class's attributes using `can.extend(this.attributes, <parent_class>.attributes);`
+    //  in the child class's static init function.
+    'extend:attributes': {
+      contact: 'CMS.Models.Person.stub',
+      secondary_contact: 'CMS.Models.Person.stub'
+    }
+  }, {
+    before_create: function () {
+      var person = {
+        id: GGRC.current_user.id,
+        type: 'Person'
+      };
+      if (!this.contact) {
+        this.attr('contact', person);
+      }
+    },
+    form_preload: function (newObjectForm) {
+      var person = {
+        id: GGRC.current_user.id,
+        type: 'Person'
+      };
+      if (newObjectForm && !this.contact) {
+        this.attr('contact', person);
+        this.attr('_transient.contact', person);
+      } else if (this.contact) {
+        this.attr('_transient.contact', this.contact);
+      }
+    }
+  });
+
   can.Model.Mixin('accessControlList', {
     'after:init': function () {
       if (!this.access_control_list) {

--- a/src/ggrc_workflows/assets/javascripts/models/task_group.js
+++ b/src/ggrc_workflows/assets/javascripts/models/task_group.js
@@ -15,6 +15,7 @@
     create: 'POST /api/task_groups',
     update: 'PUT /api/task_groups/{id}',
     destroy: 'DELETE /api/task_groups/{id}',
+    mixins: ['contactable'],
     permalink_options: {
       url: '<%= base.viewLink %>#task_group_widget/' +
       'task_group/<%= instance.id %>',
@@ -87,7 +88,7 @@
     update: 'PUT /api/task_group_tasks/{id}',
     destroy: 'DELETE /api/task_group_tasks/{id}',
 
-    mixins: ['timeboxed'],
+    mixins: ['contactable', 'timeboxed'],
     permalink_options: {
       url: '<%= base.viewLink %>#task_group_widget/' +
       'task_group/<%= instance.task_group.id %>',


### PR DESCRIPTION
Steps to reproduce:
1. Have program
2. Add audit tab and invoke new audit modal window
3. Look at the "Internal Audit Lead" field: is empty

***Actual Result:*** Internal Audit Lead is not preselected by default in New audit modal window
***Expected Result:*** Internal Audit Lead should be preselected by default in New audit modal window