### PR TITLE
GGRC-2893 Remove audit GET request from findFolder

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment/attach-button.js
+++ b/src/ggrc/assets/javascripts/components/assessment/attach-button.js
@@ -67,18 +67,16 @@
       },
       findFolderId: function () {
         var self = this;
-        var Audit = CMS.Models.Audit;
         var auditId = this.attr('instance.audit.id');
-        var cached = Audit.findInCacheById(auditId);
-        var auditDfd = cached ? $.when(cached) : Audit.findOne({id: auditId});
+        var foldersDfd = CMS.Models.ObjectFolder.findAll({
+          folderable_id: auditId,
+          folderable_type: 'Audit'});
 
-        return auditDfd.then(function (audit) {
-          var folder = audit.folders[0];
-
-          if (!folder) {
-            self.attr('canAttach', true);
+        return foldersDfd.then(function (folders) {
+          if (folders.length > 0) {
+            return folders[0].folder_id;
           }
-          return folder ? folder.id : undefined;
+          self.attr('canAttach', true);
         });
       },
       findFolder: function () {


### PR DESCRIPTION
This fixes the page freeze issue when opening the Assessment info pane on my work/my assessment/assessment info pages. We never really needed to fetch the whole audit just to get the folder id, we can simply do a GET to the object_folders API and just fetch the list of folders from there - the response from object_folders is never going to be as complex as the response from /audit and the page freeze will now no longer happen.

⚠️ **Note:** We still fetch the full audit for **NO REASON** when we click the attach button (so the app will still freeze when the user tries to attach evidence). This is bad and needs to be fixed as well, but is unfortunately out of scope of this PR.