### PR TITLE
GGRC-2930 Improve audit summary query

### DIFF
--- a/src/ggrc/query/assessments_summary_handler.py
+++ b/src/ggrc/query/assessments_summary_handler.py
@@ -47,9 +47,7 @@ class AssessmentsSummaryHandler(DefaultHandler):
             "order_by": {"keys": [], "order": "", "compare": None}},
         "fields": ["status", "verified"]
     }
-    if query != expected:
-      return False
-    return True
+    return query == expected
 
   @cached_property
   def _audit(self):

--- a/src/ggrc/query/assessments_summary_handler.py
+++ b/src/ggrc/query/assessments_summary_handler.py
@@ -6,7 +6,6 @@
 import copy
 
 from werkzeug.exceptions import Forbidden
-from cached_property import cached_property
 
 from ggrc import db
 from ggrc import models
@@ -49,7 +48,6 @@ class AssessmentsSummaryHandler(DefaultHandler):
     }
     return query == expected
 
-  @cached_property
   def _audit(self):
     """Get the audit used in the query and verify its permissions."""
     audit_id = self.query[0]["filters"]["expression"]["ids"][0]
@@ -75,7 +73,7 @@ class AssessmentsSummaryHandler(DefaultHandler):
           models.Assessment.status,
           models.Assessment.verified,
       ).filter(
-          models.Assessment.audit_id == self._audit.id
+          models.Assessment.audit_id == self._audit().id
       ).all()
     with benchmark("serialization: get_results > _transform_to_json"):
       object_query["count"] = len(data)

--- a/src/ggrc/query/assessments_summary_handler.py
+++ b/src/ggrc/query/assessments_summary_handler.py
@@ -25,27 +25,26 @@ class AssessmentsSummaryHandler(DefaultHandler):
   @classmethod
   def match(cls, query):
     """Check if the given query matches current handler."""
-    try:
-      assert len(query) == 1
-      query = query[0]
-      audit_ids = query["filters"]["expression"]["ids"]
-      expected = {
-          "object_name": "Assessment",
-          "filters": {
-              "expression": {
-                  "object_name": "Audit",
-                  "op": {"name": "relevant"},
-                  "ids": audit_ids},
-              "keys": [],
-              "order_by": {"keys": [], "order": "", "compare": None}},
-          "fields": ["status", "verified"]
-      }
-      assert isinstance(audit_ids, list)
-      assert len(audit_ids) == 1
-      assert query == expected
-      return True
-    except (AssertionError, KeyError):
+    if len(query) != 1:
       return False
+    query = query[0]
+    audit_ids = query["filters"]["expression"]["ids"]
+    if not isinstance(audit_ids, list) or len(audit_ids) != 1:
+      return False
+    expected = {
+        "object_name": "Assessment",
+        "filters": {
+            "expression": {
+                "object_name": "Audit",
+                "op": {"name": "relevant"},
+                "ids": audit_ids},
+            "keys": [],
+            "order_by": {"keys": [], "order": "", "compare": None}},
+        "fields": ["status", "verified"]
+    }
+    if query == expected:
+      return False
+    return True
 
   @cached_property
   def _audit(self):

--- a/src/ggrc/query/assessments_summary_handler.py
+++ b/src/ggrc/query/assessments_summary_handler.py
@@ -1,0 +1,85 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""This module contains special query helper class for query API."""
+
+from werkzeug.exceptions import Forbidden
+from cached_property import cached_property
+
+from ggrc import db
+from ggrc import models
+from ggrc.utils import benchmark
+from ggrc.rbac import permissions
+from ggrc.query.default_handler import DefaultHandler
+
+
+# pylint: disable=too-few-public-methods
+
+class AssessmentsSummaryHandler(DefaultHandler):
+  """Handler for assessment filter on my assessments page.
+
+  Query filters with single relevant person and assessment statuses.
+
+  """
+
+  @classmethod
+  def match(cls, query):
+    """Check if the given query matches current handler."""
+    try:
+      assert len(query) == 1
+      query = query[0]
+      audit_ids = query["filters"]["expression"]["ids"]
+      expected = {
+          "object_name": "Assessment",
+          "filters": {
+              "expression": {
+                  "object_name": "Audit",
+                  "op": {"name": "relevant"},
+                  "ids": audit_ids},
+              "keys": [],
+              "order_by": {"keys": [], "order": "", "compare": None}},
+          "fields": ["status", "verified"]
+      }
+      assert isinstance(audit_ids, list)
+      assert len(audit_ids) == 1
+      assert query == expected
+      return True
+    except (AssertionError, KeyError):
+      return False
+
+  @cached_property
+  def _audit(self):
+    audit_id = self.query[0]["filters"]["expression"]["ids"][0]
+    audit = models.Audit.query.get(audit_id)
+    if permissions.is_allowed_read_for(audit):
+      return audit
+    raise Forbidden()
+
+  def get_results(self):
+    """Filter the objects and get their information.
+
+    Updates self.query items with their results. The type of results required
+    is read from "type" parameter of every object_query in self.query.
+
+    Returns:
+      list of dicts: same query as the input with requested results that match
+                     the filter.
+    """
+    object_query = self.query[0]
+
+    with benchmark("Get Assessment statuses"):
+      data = db.session.query(
+          models.Assessment.status,
+          models.Assessment.verified,
+      ).filter(
+          models.Assessment.audit_id == self._audit.id
+      ).all()
+    with benchmark("serialization: get_results > _transform_to_json"):
+      object_query["count"] = len(data)
+      object_query["total"] = len(data)
+      object_query["last_modified"] = None
+      object_query["values"] = [
+          {"status": status, "verified": bool(verified)}
+          for status, verified in data
+      ]
+    return self.query

--- a/src/ggrc/query/assessments_summary_handler.py
+++ b/src/ggrc/query/assessments_summary_handler.py
@@ -49,6 +49,7 @@ class AssessmentsSummaryHandler(DefaultHandler):
 
   @cached_property
   def _audit(self):
+    """Get the audit used in the query and verify its permissions."""
     audit_id = self.query[0]["filters"]["expression"]["ids"][0]
     audit = models.Audit.query.get(audit_id)
     if permissions.is_allowed_read_for(audit):

--- a/src/ggrc/query/assessments_summary_handler.py
+++ b/src/ggrc/query/assessments_summary_handler.py
@@ -3,6 +3,8 @@
 
 """This module contains special query helper class for query API."""
 
+import copy
+
 from werkzeug.exceptions import Forbidden
 from cached_property import cached_property
 
@@ -27,9 +29,12 @@ class AssessmentsSummaryHandler(DefaultHandler):
     """Check if the given query matches current handler."""
     if len(query) != 1:
       return False
-    query = query[0]
+    query = copy.deepcopy(query[0])
     audit_ids = query["filters"]["expression"]["ids"]
     if not isinstance(audit_ids, list) or len(audit_ids) != 1:
+      return False
+    query_type = query.pop("type", "values")
+    if query_type != "values":
       return False
     expected = {
         "object_name": "Assessment",
@@ -42,7 +47,7 @@ class AssessmentsSummaryHandler(DefaultHandler):
             "order_by": {"keys": [], "order": "", "compare": None}},
         "fields": ["status", "verified"]
     }
-    if query == expected:
+    if query != expected:
       return False
     return True
 

--- a/src/ggrc/query/builder.py
+++ b/src/ggrc/query/builder.py
@@ -308,8 +308,23 @@ class QueryHelper(object):
       delattr(flask.g, "similar_objects_query")
     return ids
 
-  @staticmethod
-  def _apply_limit(query, limit):
+  def _get_limit(self, limit):
+    """Get limit parameters for sqlalchemy."""
+    try:
+      first = int(limit[0])
+      last = int(limit[1])
+    except (ValueError, TypeError):
+      raise BadQueryException("Invalid limit operator. Integers expected.")
+
+    if first < 0 or last < 0:
+      raise BadQueryException("Limit cannot contain negative numbers.")
+    elif first >= last:
+      raise BadQueryException("Limit start should be smaller than end.")
+    else:
+      page_size = last - first
+    return page_size, first
+
+  def _apply_limit(self, query, limit):
     """Apply limits for pagination.
 
     Args:
@@ -320,30 +335,20 @@ class QueryHelper(object):
     Returns:
       matched objects ids and total count.
     """
-    try:
-      first, last = limit
-      first, last = int(first), int(last)
-    except (ValueError, TypeError):
-      raise BadQueryException("Invalid limit operator. Integers expected.")
+    page_size, first = self._get_limit(limit)
 
-    if first < 0 or last < 0:
-      raise BadQueryException("Limit cannot contain negative numbers.")
-    elif first >= last:
-      raise BadQueryException("Limit start should be smaller than end.")
-    else:
-      page_size = last - first
-      with benchmark("Apply limit: _apply_limit > query_limit"):
-        # Note: limit request syntax is limit:[0,10]. We are counting
-        # offset from 0 as the offset of the initial row for sql is 0 (not 1).
-        ids = [obj.id for obj in query.limit(page_size).offset(first)]
-      with benchmark("Apply limit: _apply_limit > query_count"):
-        if len(ids) < page_size:
-          total = len(ids) + first
-        else:
-          # Note: using func.count() as query.count() is generating additional
-          # subquery
-          count_q = query.statement.with_only_columns([sa.func.count()])
-          total = db.session.execute(count_q).scalar()
+    with benchmark("Apply limit: _apply_limit > query_limit"):
+      # Note: limit request syntax is limit:[0,10]. We are counting
+      # offset from 0 as the offset of the initial row for sql is 0 (not 1).
+      ids = [obj.id for obj in query.limit(page_size).offset(first)]
+    with benchmark("Apply limit: _apply_limit > query_count"):
+      if len(ids) < page_size:
+        total = len(ids) + first
+      else:
+        # Note: using func.count() as query.count() is generating additional
+        # subquery
+        count_q = query.statement.with_only_columns([sa.func.count()])
+        total = db.session.execute(count_q).scalar()
 
     return ids, total
 

--- a/src/ggrc/query/builder.py
+++ b/src/ggrc/query/builder.py
@@ -311,8 +311,7 @@ class QueryHelper(object):
   def _get_limit(cls, limit):
     """Get limit parameters for sqlalchemy."""
     try:
-      first = int(limit[0])
-      last = int(limit[1])
+      first, last = [int(i) for i in limit]
     except (ValueError, TypeError):
       raise BadQueryException("Invalid limit operator. Integers expected.")
 

--- a/src/ggrc/query/builder.py
+++ b/src/ggrc/query/builder.py
@@ -145,8 +145,7 @@ class QueryHelper(object):
     left = exp.get("left", None)
     if left is not None and isinstance(left, collections.Hashable):
       return set([left])
-    else:
-      return set()
+    return set()
 
   def _macro_expand_object_query(self, object_query):
     """Expand object query."""
@@ -308,7 +307,8 @@ class QueryHelper(object):
       delattr(flask.g, "similar_objects_query")
     return ids
 
-  def _get_limit(self, limit):
+  @classmethod
+  def _get_limit(cls, limit):
     """Get limit parameters for sqlalchemy."""
     try:
       first = int(limit[0])

--- a/src/ggrc/query/views.py
+++ b/src/ggrc/query/views.py
@@ -59,11 +59,6 @@ def get_objects_by_query():
   collection_fields = ["ids", "values", "count", "total"]
 
   for result in results:
-    if last_modified is None:
-      last_modified = result["last_modified"]
-    elif result["last_modified"] is not None:
-      last_modified = max(last_modified, result["last_modified"])
-
     model = get_model(result["object_name"])
 
     collection = build_collection_representation(

--- a/src/ggrc/query/views.py
+++ b/src/ggrc/query/views.py
@@ -56,7 +56,7 @@ def get_objects_by_query():
                         if result["last_modified"]]
   last_modified = max(last_modified_list) if last_modified_list else None
   collections = []
-  collection_fields = ["ids", "values", "count", "total"]
+  collection_fields = ["ids", "values", "count", "total", "object_name"]
 
   for result in results:
     model = get_model(result["object_name"])

--- a/src/ggrc/query/views.py
+++ b/src/ggrc/query/views.py
@@ -45,12 +45,24 @@ def http_timestamp(timestamp):
   return format_date_time(time.mktime(timestamp.utctimetuple()))
 
 
+def get_handler_results(query):
+  """Get results from the best matching query handler.
+
+  Args:
+    query: dict containing query parameters.
+  Returns:
+    dict containing json serializable query results.
+  """
+
+  query_handler = DefaultHandler(query)
+  return query_handler.get_results()
+
+
 def get_objects_by_query():
   """Return objects corresponding to a POST'ed query list."""
   query = request.json
 
-  query_handler = DefaultHandler(query)
-  results = query_handler.get_results()
+  results = get_handler_results(query)
 
   last_modified_list = [result["last_modified"] for result in results
                         if result["last_modified"]]

--- a/src/ggrc/query/views.py
+++ b/src/ggrc/query/views.py
@@ -12,10 +12,12 @@ from werkzeug.exceptions import BadRequest
 
 from ggrc.query.exceptions import BadQueryException
 from ggrc.query.default_handler import DefaultHandler
+from ggrc.query.assessments_summary_handler import AssessmentsSummaryHandler
 from ggrc.login import login_required
 from ggrc.models.inflector import get_model
 from ggrc.services.common import etag
 from ggrc.utils import as_json
+from ggrc.utils import benchmark
 
 
 def build_collection_representation(model, description):
@@ -53,9 +55,13 @@ def get_handler_results(query):
   Returns:
     dict containing json serializable query results.
   """
-
-  query_handler = DefaultHandler(query)
-  return query_handler.get_results()
+  if AssessmentsSummaryHandler.match(query):
+    query_handler = AssessmentsSummaryHandler(query)
+  else:
+    query_handler = DefaultHandler(query)
+  name = query_handler.__class__.__name__
+  with benchmark("Get query Handler results from: {}".format(name)):
+    return query_handler.get_results()
 
 
 def get_objects_by_query():

--- a/test/unit/ggrc/query/test_assessments_summary_handler.py
+++ b/test/unit/ggrc/query/test_assessments_summary_handler.py
@@ -9,89 +9,106 @@ import ddt
 from ggrc.query import assessments_summary_handler
 
 
+class TestQueries(object):
+  """Test data for matcher for assessment query handler."""
+  # pylint: disable=too-few-public-methods
+
+  NO_QUERIES = []
+
+  MULTIPLE_EMPTY = [{}, {}, {}]
+
+  ORDER_BY_TITLE = [{
+      "object_name": "Assessment",
+      "filters": {
+          "expression": {
+              "object_name": "Audit",
+              "op": {"name": "relevant"},
+              "ids": ["347"]},
+          "keys":[],
+          "order_by":{"keys": [], "order":"title", "compare":None}},
+      "fields":["status", "verified"],
+  }]
+
+  INVALID_REQUESTED_FIELDS = [{
+      "object_name": "Assessment",
+      "filters": {
+          "expression": {
+              "object_name": "Audit",
+              "op": {"name": "relevant"},
+              "ids": ["347"]},
+          "keys":[],
+          "order_by":{"keys": [], "order":"", "compare":None}},
+      "fields":["status"],
+  }]
+
+  TOO_MANY_AUDIT_IDS = [{
+      "object_name": "Assessment",
+      "filters": {
+          "expression": {
+              "object_name": "Audit",
+              "op": {"name": "relevant"},
+              "ids": ["1", "2", "55"]},
+          "keys":[],
+          "order_by":{"keys": [], "order":"", "compare":None}},
+      "fields":["status", "verified"],
+      "type": "values",
+  }]
+
+  MISSING_AUDIT_IDS = [{
+      "object_name": "Assessment",
+      "filters": {
+          "expression": {
+              "object_name": "Audit",
+              "op": {"name": "relevant"},
+              "ids": []},
+          "keys":[],
+          "order_by":{"keys": [], "order":"", "compare":None}},
+      "fields":["status", "verified"],
+      "type": "values",
+  }]
+
+  NORMAL_REQUEST = [{
+      "object_name": "Assessment",
+      "filters": {
+          "expression": {
+              "object_name": "Audit",
+              "op": {"name": "relevant"},
+              "ids": ["347"]},
+          "keys":[],
+          "order_by":{"keys": [], "order":"", "compare":None}},
+      "fields":["status", "verified"],
+  }]
+
+  WITH_QUERY_TYPE_FIELD = [{
+      "object_name": "Assessment",
+      "filters": {
+          "expression": {
+              "object_name": "Audit",
+              "op": {"name": "relevant"},
+              "ids": ["347"]},
+          "keys":[],
+          "order_by":{"keys": [], "order":"", "compare":None}},
+      "fields":["status", "verified"],
+      "type": "values",
+  }]
+
+
 @ddt.ddt
 class TestAssessmentSummarHandler(unittest.TestCase):
   """Unit tests for Assessment summary query handler."""
 
-  @ddt.data(
-      [],
-      [{}, {}, {}],
-      [{  # contains order by title
-          "object_name": "Assessment",
-          "filters": {
-              "expression": {
-                  "object_name": "Audit",
-                  "op": {"name": "relevant"},
-                  "ids": ["347"]},
-              "keys":[],
-              "order_by":{"keys": [], "order":"title", "compare":None}},
-          "fields":["status", "verified"],
-      }],
-      [{  # invalid requested fields
-          "object_name": "Assessment",
-          "filters": {
-              "expression": {
-                  "object_name": "Audit",
-                  "op": {"name": "relevant"},
-                  "ids": ["347"]},
-              "keys":[],
-              "order_by":{"keys": [], "order":"", "compare":None}},
-          "fields":["status"],
-      }],
-      [{  # too many Audit ids
-          "object_name": "Assessment",
-          "filters": {
-              "expression": {
-                  "object_name": "Audit",
-                  "op": {"name": "relevant"},
-                  "ids": ["1", "2", "55"]},
-              "keys":[],
-              "order_by":{"keys": [], "order":"", "compare":None}},
-          "fields":["status", "verified"],
-          "type": "values",
-      }],
-      [{  # missing audit ids
-          "object_name": "Assessment",
-          "filters": {
-              "expression": {
-                  "object_name": "Audit",
-                  "op": {"name": "relevant"},
-                  "ids": []},
-              "keys":[],
-              "order_by":{"keys": [], "order":"", "compare":None}},
-          "fields":["status", "verified"],
-          "type": "values",
-      }],
-  )
-  def test_not_matching(self, data):
-    handler = assessments_summary_handler.AssessmentsSummaryHandler
-    self.assertFalse(handler.match(data))
+  HANDLER = assessments_summary_handler.AssessmentsSummaryHandler
 
   @ddt.data(
-      [{  # normal request
-          "object_name": "Assessment",
-          "filters": {
-              "expression": {
-                  "object_name": "Audit",
-                  "op": {"name": "relevant"},
-                  "ids": ["347"]},
-              "keys":[],
-              "order_by":{"keys": [], "order":"", "compare":None}},
-          "fields":["status", "verified"],
-      }],
-      [{  # with query type filed
-          "object_name": "Assessment",
-          "filters": {
-              "expression": {
-                  "object_name": "Audit",
-                  "op": {"name": "relevant"},
-                  "ids": ["347"]},
-              "keys":[],
-              "order_by":{"keys": [], "order":"", "compare":None}},
-          "fields":["status", "verified"],
-          "type": "values",
-      }],
+      (False, TestQueries.INVALID_REQUESTED_FIELDS),
+      (False, TestQueries.MISSING_AUDIT_IDS),
+      (False, TestQueries.MULTIPLE_EMPTY),
+      (False, TestQueries.NO_QUERIES),
+      (False, TestQueries.ORDER_BY_TITLE),
+      (False, TestQueries.TOO_MANY_AUDIT_IDS),
+      (True, TestQueries.NORMAL_REQUEST),
+      (True, TestQueries.WITH_QUERY_TYPE_FIELD),
   )
-  def test_matching(self, data):
-    handler = assessments_summary_handler.AssessmentsSummaryHandler
-    self.assertTrue(handler.match(data))
+  @ddt.unpack
+  def test_not_matching(self, match, data):
+    self.assertIs(match, self.HANDLER.match(data))

--- a/test/unit/ggrc/query/test_assessments_summary_handler.py
+++ b/test/unit/ggrc/query/test_assessments_summary_handler.py
@@ -1,0 +1,97 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Unit tests for Assessment summary query handler."""
+
+import unittest
+import ddt
+
+from ggrc.query import assessments_summary_handler
+
+
+@ddt.ddt
+class TestAssessmentSummarHandler(unittest.TestCase):
+  """Unit tests for Assessment summary query handler."""
+
+  @ddt.data(
+      [],
+      [{}, {}, {}],
+      [{  # contains order by title
+          "object_name": "Assessment",
+          "filters": {
+              "expression": {
+                  "object_name": "Audit",
+                  "op": {"name": "relevant"},
+                  "ids": ["347"]},
+              "keys":[],
+              "order_by":{"keys": [], "order":"title", "compare":None}},
+          "fields":["status", "verified"],
+      }],
+      [{  # invalid requested fields
+          "object_name": "Assessment",
+          "filters": {
+              "expression": {
+                  "object_name": "Audit",
+                  "op": {"name": "relevant"},
+                  "ids": ["347"]},
+              "keys":[],
+              "order_by":{"keys": [], "order":"", "compare":None}},
+          "fields":["status"],
+      }],
+      [{  # too many Audit ids
+          "object_name": "Assessment",
+          "filters": {
+              "expression": {
+                  "object_name": "Audit",
+                  "op": {"name": "relevant"},
+                  "ids": ["1", "2", "55"]},
+              "keys":[],
+              "order_by":{"keys": [], "order":"", "compare":None}},
+          "fields":["status", "verified"],
+          "type": "values",
+      }],
+      [{  # missing audit ids
+          "object_name": "Assessment",
+          "filters": {
+              "expression": {
+                  "object_name": "Audit",
+                  "op": {"name": "relevant"},
+                  "ids": []},
+              "keys":[],
+              "order_by":{"keys": [], "order":"", "compare":None}},
+          "fields":["status", "verified"],
+          "type": "values",
+      }],
+  )
+  def test_not_matching(self, data):
+    handler = assessments_summary_handler.AssessmentsSummaryHandler
+    self.assertFalse(handler.match(data))
+
+  @ddt.data(
+      [{  # normal request
+          "object_name": "Assessment",
+          "filters": {
+              "expression": {
+                  "object_name": "Audit",
+                  "op": {"name": "relevant"},
+                  "ids": ["347"]},
+              "keys":[],
+              "order_by":{"keys": [], "order":"", "compare":None}},
+          "fields":["status", "verified"],
+      }],
+      [{  # with query type filed
+          "object_name": "Assessment",
+          "filters": {
+              "expression": {
+                  "object_name": "Audit",
+                  "op": {"name": "relevant"},
+                  "ids": ["347"]},
+              "keys":[],
+              "order_by":{"keys": [], "order":"", "compare":None}},
+          "fields":["status", "verified"],
+          "type": "values",
+      }],
+  )
+  def test_matching(self, data):
+    handler = assessments_summary_handler.AssessmentsSummaryHandler
+    self.assertTrue(handler.match(data))


### PR DESCRIPTION
Local benchamark on audit with 300 assessments and 2500 snapshots
```
before: 7.170 s average
After:  0.209 s average  (from this 0.162 s was permissions query which will be removed after ACL)
```


This PR also serves as an example for specific query API request improvements. 