### PR TITLE
GGRC-2930 Update read permission checks

### DIFF
--- a/src/ggrc/rbac/permissions.py
+++ b/src/ggrc/rbac/permissions.py
@@ -10,10 +10,20 @@ from ggrc import login
 from ggrc.extensions import get_extension_instance
 
 
+from enum import Enum
+
+
+class SystemWideRoles(Enum):
+  Editor = "Editor"
+  Administrator = "Administrator"
+  Reader = "Reader"
+  NoAccess = "No Access"
+
+
 SYSTEM_WIDE_READ_ROLES = {
-    "Editor",
-    "Administrator",
-    "Reader",
+    SystemWideRoles.Administrator,
+    SystemWideRoles.Editor,
+    SystemWideRoles.Reader,
 }
 
 
@@ -55,7 +65,8 @@ def is_allowed_create_for(instance):
 def _system_wide_read():
   """Check if user has system wide read access to all objects."""
   user = login.get_current_user()
-  system_wide_role = getattr(user, "system_wide_role", "No Access")
+  system_wide_role = getattr(user, "system_wide_role",
+                             SystemWideRoles.NoAccess)
   return system_wide_role in SYSTEM_WIDE_READ_ROLES
 
 

--- a/src/ggrc/rbac/permissions.py
+++ b/src/ggrc/rbac/permissions.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2017 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
+"""Basic RBAC permissions module."""
+
 from flask import g
 from flask.ext.login import current_user
 
@@ -22,17 +24,17 @@ def get_permissions_provider():
 
 
 def permissions_for(user=None):
+  """Get full permissions for user."""
   if user is None:
     user = get_user()
   return get_permissions_provider().permissions_for(user)
 
 
 def get_user():
+  """Get selected user."""
   if hasattr(g, 'user'):
     return g.user
-  else:
-    return current_user
-  return None
+  return current_user
 
 
 def is_allowed_create(resource_type, resource_id, context_id):
@@ -151,15 +153,17 @@ def is_allowed_view_object_page_for(instance):
 
 
 def is_admin():
-  """Whether the current user has ADMIN permission"""
+  """Whether the current user has ADMIN permission."""
   return permissions_for(get_user()).is_admin()
 
 
 def has_conditions(action, resource):
-  """
+  """Check permission conditions.
+
   Checks if the resource has a condition that needs to be checked with
-  is_allowed_for
+  is_allowed_for.
   """
+  # pylint disable=protected-access
   _permissions = permissions_for()._permissions()
   return bool(_permissions.get(action, {})
               .get(resource, {})


### PR DESCRIPTION
We should avoid permission queries and building the permission dict if
we can. One such case is read permissions, if a user has global read
access.

The biggest improvement seen with this can be seen after merging https://github.com/google/ggrc-core/pull/6048 for users with global read permissions.