### PR TITLE
GGRC-2900 Fix Reference URLs revisions for polymorphic types

### DIFF
--- a/src/ggrc/models/directive.py
+++ b/src/ggrc/models/directive.py
@@ -19,7 +19,14 @@ from .utils import validate_option
 from .track_object_state import HasObjectState
 
 
-class Directive(HasObjectState, LastDeprecatedTimeboxed, PublicDocumentable,
+# NOTE: The PublicDocumentable mixin is not applied directly to the Directive
+# base class, but instead to all of its specialized subclasses. The reason for
+# this is the PublicDocumentable's declared attribute `documents` that builds a
+# dynamic DB relationship based on the class name, and thus the attribute needs
+# to be run in the context of each particular subclass.
+# (of course, if there is a nice way of overriding/customizing declared
+# attributes in subclasses, we might want to use that approach)
+class Directive(HasObjectState, LastDeprecatedTimeboxed,
                 BusinessObject, db.Model):
   __tablename__ = 'directives'
 
@@ -138,7 +145,7 @@ class Directive(HasObjectState, LastDeprecatedTimeboxed, PublicDocumentable,
 
 # FIXME: For subclasses, restrict kind
 class Policy(Roleable, CustomAttributable, Relatable,
-             Personable, Directive, Indexed):
+             Personable, PublicDocumentable, Directive, Indexed):
   __mapper_args__ = {
       'polymorphic_identity': 'Policy'
   }
@@ -150,13 +157,18 @@ class Policy(Roleable, CustomAttributable, Relatable,
       "Product Policy", "Contract-Related Policy", "Company Controls Policy"
   ])
 
+  _aliases = {
+      "document_url": None,
+      "document_evidence": None,
+  }
+
   @validates('meta_kind')
   def validates_meta_kind(self, key, value):
     return 'Policy'
 
 
 class Regulation(Roleable, CustomAttributable, Relatable,
-                 Personable, Directive, Indexed):
+                 Personable, PublicDocumentable, Directive, Indexed):
   __mapper_args__ = {
       'polymorphic_identity': 'Regulation'
   }
@@ -167,6 +179,8 @@ class Regulation(Roleable, CustomAttributable, Relatable,
 
   _aliases = {
       "kind": None,
+      "document_url": None,
+      "document_evidence": None,
   }
 
   @validates('meta_kind')
@@ -175,7 +189,7 @@ class Regulation(Roleable, CustomAttributable, Relatable,
 
 
 class Standard(Roleable, CustomAttributable, Relatable,
-               Personable, Directive, Indexed):
+               Personable, PublicDocumentable, Directive, Indexed):
   __mapper_args__ = {
       'polymorphic_identity': 'Standard'
   }
@@ -186,6 +200,8 @@ class Standard(Roleable, CustomAttributable, Relatable,
 
   _aliases = {
       "kind": None,
+      "document_url": None,
+      "document_evidence": None,
   }
 
   @validates('meta_kind')
@@ -194,7 +210,7 @@ class Standard(Roleable, CustomAttributable, Relatable,
 
 
 class Contract(Roleable, CustomAttributable, Relatable,
-               Personable, Directive, Indexed):
+               Personable, PublicDocumentable, Directive, Indexed):
   __mapper_args__ = {
       'polymorphic_identity': 'Contract'
   }
@@ -205,6 +221,8 @@ class Contract(Roleable, CustomAttributable, Relatable,
 
   _aliases = {
       "kind": None,
+      "document_url": None,
+      "document_evidence": None,
   }
 
   @validates('meta_kind')

--- a/src/ggrc/models/system.py
+++ b/src/ggrc/models/system.py
@@ -17,8 +17,16 @@ from ggrc.models import track_object_state
 from ggrc.models import reflection
 
 
+# NOTE: The PublicDocumentable mixin is not applied directly to the
+# SystemOrProcess base class, but instead to all of its specialized subclasses.
+# The reason for this is the PublicDocumentable's declared attribute
+# `documents` that builds a dynamic DB relationship based on the class name,
+# and thus the attribute needs to be run in the context of each particular
+# subclass.
+# (of course, if there is a nice way of overriding/customizing declared
+# attributes in subclasses, we might want to use that approach)
 class SystemOrProcess(track_object_state.HasObjectState,
-                      LastDeprecatedTimeboxed, PublicDocumentable,
+                      LastDeprecatedTimeboxed,
                       BusinessObject, db.Model):
   # Override model_inflector
   _table_plural = 'systems_or_processes'
@@ -95,11 +103,16 @@ class SystemOrProcess(track_object_state.HasObjectState,
 
 
 class System(CustomAttributable, Personable, Roleable,
-             Relatable, SystemOrProcess, Indexed):
+             Relatable, PublicDocumentable, SystemOrProcess, Indexed):
   __mapper_args__ = {
       'polymorphic_identity': False
   }
   _table_plural = 'systems'
+
+  _aliases = {
+      "document_url": None,
+      "document_evidence": None,
+  }
 
   @validates('is_biz_process')
   def validates_is_biz_process(self, key, value):
@@ -107,11 +120,16 @@ class System(CustomAttributable, Personable, Roleable,
 
 
 class Process(CustomAttributable, Personable, Roleable,
-              Relatable, SystemOrProcess, Indexed):
+              Relatable, PublicDocumentable, SystemOrProcess, Indexed):
   __mapper_args__ = {
       'polymorphic_identity': True
   }
   _table_plural = 'processes'
+
+  _aliases = {
+      "document_url": None,
+      "document_evidence": None,
+  }
 
   @validates('is_biz_process')
   def validates_is_biz_process(self, key, value):


### PR DESCRIPTION
This PR fixes creating revisions for polymorphic types, resulting in missing reference URLs on those objects' snapshots.

This is a blocker for the upcoming release, hence the `critical` label.

---

**Steps to reproduce:**
1. Have a program with mapped Standard
1. Add Reference URL to Standard
1. Create an Audit and go to the Audit page
1. Go to Standards tab and expand Standard's Info pane
1. Look at the Reference URL

**Actual Result:** Reference URLs are not shown on snapshots
**Expected Result:** Reference URLs should be shown on snapshots

Mind: This bug was affecting all polymorphic types, i.e. Directive types (Contract, Policy, Regulation, Standard) and SystemOrProcess (System, Process) types.
