### PR TITLE
GGRC-2933 Send correct reference URL data for snapshots

### DIFF
--- a/src/ggrc/models/revision.py
+++ b/src/ggrc/models/revision.py
@@ -180,6 +180,10 @@ class Revision(Base, db.Model):
       reference_url_list = []
       for key in ('url', 'reference_url'):
         link = self._content[key]
+        # link might exist, but can be an empty string - we treat those values
+        # as non-existing (empty) reference URLs
+        if not link:
+          continue
         reference_url_list.append({
             "display_name": link,
             "document_type": "REFERENCE_URL",


### PR DESCRIPTION
NOTE: This PR is provisional, we need to discuss whether we really want it in the upcoming release. If not, it should be re-opened against the `develop` branch.

---

This PR fixes a backend issue with handling reference URLs for old revisions. It makes sure that revisions containing empty reference URL data treat that data as non-existent, and do not sent empty reference URL objects to the frontend.

**Steps to reproduce:**
- Find a snapshoted object containing such reference URL data in its revision. One example is a regulation G111 on Audit 1029 (at least on ggrc-qa database)
- Select that object snapshot in tree view to open its info pane
- Look at the "Reference URL" widget

**Actual result:**
"Invalid date" is displayed and no reference URL link

**Expected result:**
Nothing is displayed under the "reference URLs" label, as the original object does not contain any reference URLs as well.

Note: Do not modify the snapshot, or the revision in the DB will be updated with new data that does not suffer from the issue described.