### PR TITLE
GGRC-2126/GGRC-2958/GGRC-2763 Overflow of text in fields/Assessment UX - read more - expand by def/Assessment: Comment text shows coding

### DIFF
--- a/src/ggrc/assets/javascripts/components/read-more/read-more.js
+++ b/src/ggrc/assets/javascripts/components/read-more/read-more.js
@@ -22,9 +22,7 @@
       define: {
         text: {
           type: 'string',
-          set: function (newValue) {
-            return GGRC.Utils.getPlainText(newValue);
-          }
+          value: ''
         },
         maxLinesNumber: {
           type: 'number',

--- a/src/ggrc/assets/javascripts/components/read-more/read-more.js
+++ b/src/ggrc/assets/javascripts/components/read-more/read-more.js
@@ -43,7 +43,7 @@
       btnText: function () {
         return this.attr('expanded') ? readLess : readMore;
       },
-      toggle: function (viewModel, el, ev) {
+      toggle: function (ev) {
         ev.stopPropagation();
         this.attr('expanded', !this.attr('expanded'));
       },
@@ -59,21 +59,22 @@
             (this.attr('lineHeight') * this.attr('maxLinesNumber'));
         }
         this.attr('overflowing', result);
+      },
+      checkOverflowing: function (el) {
+        var $element = $(el).find('.read-more__body');
+        var element = $element[0];
+
+        this.attr('lineHeight',
+          parseInt($element.css('line-height'), 10));
+
+        if (element) {
+          this.isOverflowing(element);
+        }
       }
     },
     events: {
-      inserted: function () {
-        var $element = $(this.element).find('.read-more__body');
-
-        this.viewModel.attr('lineHeight',
-          parseInt($element.css('line-height'), 10));
-      },
-      '{element} mouseover': function (ev) {
-        var element = $(this.element).find('.read-more__body')[0];
-
-        if (element) {
-          this.viewModel.isOverflowing(element);
-        }
+      '{element} mouseover': function () {
+        this.viewModel.checkOverflowing(this.element);
       }
     }
   });

--- a/src/ggrc/assets/javascripts/components/read-more/tests/read-more_spec.js
+++ b/src/ggrc/assets/javascripts/components/read-more/tests/read-more_spec.js
@@ -36,16 +36,6 @@ describe('GGRC.Component.ReadMore', function () {
       expect(vm.attr('expanded')).toBe(true);
     });
   });
-  describe('set() of "text" attribute', function () {
-    it('sets plain text to attribute', function () {
-      var htmlText = '<p>test-text</p>';
-      var expectedResult = GGRC.Utils.getPlainText(htmlText);
-
-      vm.attr('text', htmlText);
-
-      expect(vm.attr('text')).toEqual(expectedResult);
-    });
-  });
   describe('set() of cssClass attribute', function () {
     it('returns empty string if viewModel.expanded is true', function () {
       vm.attr('expanded', true);

--- a/src/ggrc/assets/javascripts/components/read-more/tests/read-more_spec.js
+++ b/src/ggrc/assets/javascripts/components/read-more/tests/read-more_spec.js
@@ -21,17 +21,17 @@ describe('GGRC.Component.ReadMore', function () {
     });
 
     it('calls stopPropagation()', function () {
-      vm.toggle(null, null, eventMock);
+      vm.toggle(eventMock);
 
       expect(eventMock.stopPropagation).toHaveBeenCalled();
     });
 
     it('switchs expanded attribute', function () {
       vm.attr('expanded', true);
-      vm.toggle(null, null, eventMock);
+      vm.toggle(eventMock);
 
       expect(vm.attr('expanded')).toBe(false);
-      vm.toggle(null, null, eventMock);
+      vm.toggle(eventMock);
 
       expect(vm.attr('expanded')).toBe(true);
     });

--- a/src/ggrc/assets/mustache/assessments/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessments/modal_content.mustache
@@ -121,7 +121,7 @@
                     <div class="modal-mapped-objects-item__details">
                       <business-object-list-item {instance}="{.}">
                         <div class="description">
-                          <read-more {text}="itemData.description" max-text-length="90"></read-more>
+                          <read-more {text}="itemData.description" max-lines-number="1"></read-more>
                         </div>
                       </business-object-list-item>
                     </div>

--- a/src/ggrc/assets/mustache/audits/info.mustache
+++ b/src/ggrc/assets/mustache/audits/info.mustache
@@ -37,7 +37,7 @@
         <div class="span12">
           <h6>Description</h6>
           <div class="rtf-block">
-            {{{firstnonempty instance.description '<span class="empty-message">None</span>'}}}
+            <read-more {text}="instance.description"></read-more>
           </div>
         </div>
       </div>

--- a/src/ggrc/assets/mustache/base_objects/description.mustache
+++ b/src/ggrc/assets/mustache/base_objects/description.mustache
@@ -9,7 +9,7 @@
     <div data-test-id="title_description_7a906d2e" class="span12">
       <h6>Description</h6>
       <div data-test-id="title_description_content_7a906d2e" class="rtf-block">
-        {{{firstnonempty description '<span class="empty-message">None</span>'}}}
+        <read-more {text}="description"></read-more>
       </div>
     </div>
   </div>

--- a/src/ggrc/assets/mustache/base_objects/notes.mustache
+++ b/src/ggrc/assets/mustache/base_objects/notes.mustache
@@ -11,7 +11,7 @@
       <div data-test-id="title_notes_ef5bc3a71e88" class="span12">
         <h6>Notes</h6>
         <div data-test-id="title_notes_content_ef5bc3a71e88" class="rtf-block">
-          {{{firstnonempty notes '<span class="empty-message">None</span>'}}}
+          <read-more {text}="notes"></read-more>
         </div>
       </div>
     </div>

--- a/src/ggrc/assets/mustache/base_objects/test_plan.mustache
+++ b/src/ggrc/assets/mustache/base_objects/test_plan.mustache
@@ -11,7 +11,7 @@
       <div class="span12">
         <h6>Test Plan</h6>
         <div class="rtf-block">
-          {{{firstnonempty test_plan '<span class="empty-message">None</span>'}}}
+          <read-more {text}="test_plan"></read-more>
         </div>
       </div>
     </div>

--- a/src/ggrc/assets/mustache/base_templates/notes.mustache
+++ b/src/ggrc/assets/mustache/base_templates/notes.mustache
@@ -5,5 +5,5 @@
 
 <h6>Notes</h6>
 <div class="rtf-block">
-  {{notes}}
+  <read-more {text}="notes"></read-more>
 </div>

--- a/src/ggrc/assets/mustache/components/assessment/mapped-objects/mapped-controls.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/mapped-objects/mapped-controls.mustache
@@ -5,7 +5,7 @@
 <object-list {(selected-item)}="selectedItem" {items}="mappedItems">
     <business-object-list-item {instance}="instance">
         <div class="description">
-            <read-more {text}="itemData.description" max-text-length="90"></read-more>
+            <read-more {text}="itemData.description" max-lines-number="1"></read-more>
         </div>
     </business-object-list-item>
 </object-list>

--- a/src/ggrc/assets/mustache/components/assessment/mapped-objects/mapped-controls.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/mapped-objects/mapped-controls.mustache
@@ -5,7 +5,7 @@
 <object-list {(selected-item)}="selectedItem" {items}="mappedItems">
     <business-object-list-item {instance}="instance">
         <div class="description">
-            <read-more {text}="itemData.description" max-lines-number="1"></read-more>
+            <read-more {text}="itemData.description" expanded="true" max-lines-number="1"></read-more>
         </div>
     </business-object-list-item>
 </object-list>

--- a/src/ggrc/assets/mustache/components/auto-save-form/auto-save-form-field-view.mustache
+++ b/src/ggrc/assets/mustache/components/auto-save-form/auto-save-form-field-view.mustache
@@ -5,9 +5,9 @@
 
 {{#switch type}}
   {{#case 'input'}}
-    <rich-text-form-field-view
+    <text-form-field-view
       {value}="value"
-    ></rich-text-form-field-view>
+    ></text-form-field-view>
   {{/case}}
   {{#case 'text'}}
     <rich-text-form-field-view

--- a/src/ggrc/assets/mustache/components/auto-save-form/auto-save-form-field-view.mustache
+++ b/src/ggrc/assets/mustache/components/auto-save-form/auto-save-form-field-view.mustache
@@ -5,9 +5,9 @@
 
 {{#switch type}}
   {{#case 'input'}}
-    <text-form-field-view
+    <rich-text-form-field-view
       {value}="value"
-    ></text-form-field-view>
+    ></rich-text-form-field-view>
   {{/case}}
   {{#case 'text'}}
     <rich-text-form-field-view

--- a/src/ggrc/assets/mustache/components/read-more/read-more.mustache
+++ b/src/ggrc/assets/mustache/components/read-more/read-more.mustache
@@ -2,21 +2,17 @@
     Copyright (C) 2017 Google Inc.
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
-{{#if text}}
+<div class="read-more">
+  {{#if text}}
+      <div class="read-more__body {{cssClass}}">
+        {{text}}
+      </div>
       {{#if overflowing}}
-        <div class="read-more__body">
-          {{#if expanded}}
-            {{{text}}}
-          {{else}}
-            {{resultedText}}
-          {{/if}}
+        <div class="read-more__controls">
+            <a can-click="toggle" class="read-more__btn">{{btnText}}</a>
         </div>
-          <div class="read-more__controls">
-              <a can-click="toggle" class="read-more__btn">{{btnText}}</a>
-          </div>
-      {{else}}
-        {{{text}}}
       {{/if}}
-{{else}}
-    <span class="empty-message">None</span>
-{{/if}}
+  {{else}}
+      <span class="empty-message">None</span>
+  {{/if}}
+</div>

--- a/src/ggrc/assets/mustache/components/read-more/read-more.mustache
+++ b/src/ggrc/assets/mustache/components/read-more/read-more.mustache
@@ -5,11 +5,13 @@
 <div class="read-more">
   {{#if text}}
       <div class="read-more__body {{cssClass}}">
-        {{{text}}}
+        <div>
+            {{{text}}}
+        </div>
       </div>
       {{#if overflowing}}
         <div class="read-more__controls">
-            <a can-click="toggle" class="read-more__btn">{{btnText}}</a>
+            <a ($click)="toggle(%event)" class="read-more__btn">{{btnText}}</a>
         </div>
       {{/if}}
   {{else}}

--- a/src/ggrc/assets/mustache/components/read-more/read-more.mustache
+++ b/src/ggrc/assets/mustache/components/read-more/read-more.mustache
@@ -5,7 +5,7 @@
 <div class="read-more">
   {{#if text}}
       <div class="read-more__body {{cssClass}}">
-        {{text}}
+        {{{text}}}
       </div>
       {{#if overflowing}}
         <div class="read-more__controls">

--- a/src/ggrc/assets/mustache/components/related-objects/related-issues.mustache
+++ b/src/ggrc/assets/mustache/components/related-objects/related-issues.mustache
@@ -27,7 +27,7 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                     </a>
                 </div>
                 <div class="flex-size-3">
-                    <read-more {text}="instance.description"></read-more>
+                    <read-more {text}="instance.description" max-lines-number="2"></read-more>
                 </div>
             </div>
         </object-list>

--- a/src/ggrc/assets/mustache/issues/remediation_plan.mustache
+++ b/src/ggrc/assets/mustache/issues/remediation_plan.mustache
@@ -9,7 +9,7 @@
         <div class="span12">
             <h6>Remediation Plan</h6>
             <div class="rtf-block">
-                {{{firstnonempty test_plan '<span class="empty-message">None</span>'}}}
+              <read-more {text}="test_plan"></read-more>
             </div>
         </div>
     </div>

--- a/src/ggrc/assets/stylesheets/components/grid-data/_grid-data.scss
+++ b/src/ggrc/assets/stylesheets/components/grid-data/_grid-data.scss
@@ -141,8 +141,12 @@
   cursor: default;
   line-height: 16px;
   a {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
     line-height: 16px;
-    display: inline-block;
   }
   a:hover {
     text-decoration: underline;

--- a/src/ggrc/assets/stylesheets/components/read-more/_read-more.scss
+++ b/src/ggrc/assets/stylesheets/components/read-more/_read-more.scss
@@ -57,6 +57,7 @@ read-more {
   read-more {
     .read-more__controls {
       box-shadow: -6px 0px 18px 7px $snapshotBgnd;
+      background: $snapshotBgnd;
 
       .read-more__btn {
         background-color: $snapshotBgnd;
@@ -64,13 +65,16 @@ read-more {
     }
   }
 }
-.mapped-snapshot-item:hover {
-  read-more {
-    .read-more__controls {
-      box-shadow: -6px 0px 18px 7px $shapshotBorder;
 
-      .read-more__btn {
-        background-color: $shapshotBorder;
+.mapped-objects__list {
+  .mapped-snapshot-item:hover {
+    read-more {
+      .read-more__controls {
+        box-shadow: -6px 0px 18px 7px $shapshotBorder;
+
+        .read-more__btn {
+          background-color: $shapshotBorder;
+        }
       }
     }
   }

--- a/src/ggrc/assets/stylesheets/components/read-more/_read-more.scss
+++ b/src/ggrc/assets/stylesheets/components/read-more/_read-more.scss
@@ -4,42 +4,47 @@ read-more {
   transition: height 0.1s ease;
   position: relative;
   display: block;
+  overflow: hidden;
 
-  .read-more__body {
-    overflow: hidden;
-    transition: display 0.1s ease, height 0.1s ease, max-height 0.3s ease;
-    padding: 0;
-    box-sizing: border-box;
-    word-break: break-word;
-
-    .read-more__body-content {
-      line-height: 18px;
-      position: relative;
-
-      * {
-        margin: 0;
-        padding: 0;
-      }
+  @for $i from 1 through 10 {
+    .ellipsis-truncation-#{$i} {
+      display: -webkit-box !important;
+      text-overflow: ellipsis;
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: $i;
+      margin-bottom: 5px !important;
     }
   }
 
+  .read-more__body {
+    display: block;
+    margin-bottom: 20px;
+    overflow: hidden;
+    box-sizing: border-box;
+    word-break: break-word;
+  }
+
+  &:hover .read-more__controls{
+    visibility: visible;
+    opacity: 1;
+  }
+
   .read-more__controls {
-    padding: 0 8px;
-    height: 22px;
-    line-height: 22px;
-    margin: 0;
+    visibility: hidden;
+    opacity: 0;
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    background-color: $white;
+    line-height: 20px;
     text-align: right;
-    position: relative;
+    transition: opacity 600ms, visibility 600ms;
+    box-shadow: -6px 0px 18px 7px $white;
 
     .read-more__btn {
-      padding: 2px 0;
-      box-sizing: border-box;
-      text-align: right;
-      min-width: 78px;
-      cursor: pointer;
-      line-height: 18px;
       display: inline-block;
-      transition: display 0.3s ease;
+      box-sizing: border-box;
+      cursor: pointer;
 
       &:hover {
         text-decoration: none;
@@ -48,11 +53,37 @@ read-more {
   }
 }
 
-read-more-text-overflow {
-  box-sizing: border-box;
-  width: 100%;
-  text-overflow: ellipsis;
-  overflow: hidden;
-  line-height: 18px;
-  font-size: 13px;
+.mapped-snapshot-item {
+  read-more {
+    .read-more__controls {
+      box-shadow: -6px 0px 18px 7px $snapshotBgnd;
+
+      .read-more__btn {
+        background-color: $snapshotBgnd;
+      }
+    }
+  }
+}
+.mapped-snapshot-item:hover {
+  read-more {
+    .read-more__controls {
+      box-shadow: -6px 0px 18px 7px $shapshotBorder;
+
+      .read-more__btn {
+        background-color: $shapshotBorder;
+      }
+    }
+  }
+}
+
+.assessment-controls {
+  read-more {
+    .read-more__controls {
+      box-shadow: -6px 0px 18px 7px $light-grey-background;
+
+      .read-more__btn {
+        background-color: $light-grey-background;
+      }
+    }
+  }
 }

--- a/src/ggrc/assets/stylesheets/modules/_inline-edit.scss
+++ b/src/ggrc/assets/stylesheets/modules/_inline-edit.scss
@@ -4,6 +4,9 @@
  */
 
 .inline-edit {
+  &__text {
+    word-break: break-word;
+  }
   &__title {
     padding-left: 4px;
   }

--- a/src/ggrc_risk_assessments/assets/mustache/risk_assessments/info.mustache
+++ b/src/ggrc_risk_assessments/assets/mustache/risk_assessments/info.mustache
@@ -19,7 +19,7 @@
       <div class="span12">
         <h6>Notes</h6>
         <div class="rtf-block">
-          {{{firstnonempty instance.notes '<span class="empty-message">None</span>'}}}
+          <read-more {text}="instance.notes"></read-more>
         </div>
       </div>
     </div>

--- a/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/info.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/info.mustache
@@ -127,7 +127,7 @@
             or #if_null' instance.task_type}}
             <h6>Task details</h6>
             <div class="rtf-block">
-              {{{firstnonempty instance.description 'No additional details'}}}
+              <read-more {text}="instance.description"></read-more>
             </div>
           {{/if_helpers}}
           {{#if_equals instance.task_type 'menu'}}

--- a/src/ggrc_workflows/assets/mustache/cycle_task_groups/info.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_groups/info.mustache
@@ -17,7 +17,7 @@
         <div class="span12">
           <h6>{{instance.class.title_singular}} description</h6>
           <div class="rtf-block">
-            {{{firstnonempty instance.description '<span class="empty-message">None</span>'}}}
+            <read-more {text}="instance.description"></read-more>
           </div>
         </div>
       </div>

--- a/src/ggrc_workflows/assets/mustache/cycles/info.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycles/info.mustache
@@ -44,7 +44,7 @@
       <div class="span12">
         <h6>Description</h6>
         <div class="rtf-block">
-          <p>{{{firstnonempty instance.description '<span class="empty-message">None</span>'}}}</p>
+          <read-more {text}="instance.description"></read-more>
         </div>
       </div>
     </div>

--- a/src/ggrc_workflows/assets/mustache/workflows/info.mustache
+++ b/src/ggrc_workflows/assets/mustache/workflows/info.mustache
@@ -125,7 +125,7 @@
       <div class="span12">
         <h6>Description</h6>
         <div class="rtf-block">
-          <p>{{{firstnonempty instance.description '<span class="empty-message">None</span>'}}}</p>
+          <read-more {text}="instance.description"></read-more>
         </div>
       </div>
     </div>


### PR DESCRIPTION
**GGRC-2126**
The url/text comes out of the assigned instead of wrapping or shown in a more cleaner way. We are seeing several of this instances occurring, developer and QA team needs to ensure long text/urls are tested through the app

**GGRC-2958**
Have the description for control expanded by default

**GGRC-2763**
_Comment by User:_
_What is the problem / issue?_
When my comment is in the truncated view, things like " " appear and the line breaks are off. When I click "Read more", the formatting is correct.

_What is the expected result / outcome?_ (ie What should happen?)
The text should look the same in the show more/show less views.

_What is the impact if it is not fixed / implemented_? (Quantify the impact, eg, # of hours)
Minimal

![screenshot-1](https://user-images.githubusercontent.com/4204416/28784567-7c0a8dd4-761c-11e7-9d47-1ea34d554cba.png)
