### PR TITLE
GGRC-2924 Add validator for TGT model

### DIFF
--- a/src/ggrc_workflows/__init__.py
+++ b/src/ggrc_workflows/__init__.py
@@ -450,8 +450,14 @@ def ensure_assignee_is_workflow_member(workflow, assignee):
     db.session.add(user_role)
 
 
+def start_end_date_validator(tgt):
+  if tgt.start_date > tgt.end_date:
+      raise ValueError('End date can not be behind Start date')
+
+
 @signals.Restful.model_put.connect_via(models.TaskGroupTask)
 def handle_task_group_task_put(sender, obj=None, src=None, service=None):  # noqa pylint: disable=unused-argument
+  start_end_date_validator(obj)
   if inspect(obj).attrs.contact.history.has_changes():
     ensure_assignee_is_workflow_member(obj.task_group.workflow, obj.contact)
 
@@ -464,6 +470,7 @@ def handle_task_group_task_put(sender, obj=None, src=None, service=None):  # noq
 
 @signals.Restful.model_posted.connect_via(models.TaskGroupTask)
 def handle_task_group_task_post(sender, obj=None, src=None, service=None):  # noqa pylint: disable=unused-argument
+  start_end_date_validator(obj)
   ensure_assignee_is_workflow_member(obj.task_group.workflow, obj.contact)
   if update_workflow_state(obj.task_group.workflow):
     db.session.add(obj.task_group.workflow)

--- a/test/integration/ggrc_workflows/test_api_calls.py
+++ b/test/integration/ggrc_workflows/test_api_calls.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2017 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
+import datetime
 import unittest
 
 import ddt
@@ -11,6 +12,7 @@ from ggrc.models import all_models
 from integration.ggrc import TestCase
 from integration.ggrc.api_helper import Api
 from integration.ggrc.models import factories
+from integration.ggrc_workflows import WorkflowTestCase
 from integration.ggrc_workflows.models import factories as wf_factories
 
 
@@ -255,6 +257,29 @@ class TestWorkflowsApiPost(TestCase):
     self.assertEqual(
         flag if flag is not None else True,
         all_models.Workflow.query.get(workflow_id).is_verification_needed)
+
+
+class TestTaskGroupTaskApiPost(WorkflowTestCase):
+  """
+  Tesk TestTaskGroupTask basic api actions
+  """
+  def test_create_tgt_correct_dates(self):
+    """Test case for correct tgt start_ end_ dates"""
+    response, _ = self.generator.generate_task_group_task(
+        data={"start_date": datetime.date.today(),
+              "end_date": datetime.date.today() + datetime.timedelta(days=4)}
+    )
+    self.assertEqual(response.status_code, 201)
+
+  def test_create_tgt_wrong_dates(self):
+    """Test case for tgt wrong start_ end_ dates"""
+    with self.assertRaises(Exception):
+      self.generator.generate_task_group_task(
+          data={
+              "start_date": datetime.date.today(),
+              "end_date": datetime.date.today() - datetime.timedelta(days=4)
+          }
+      )
 
 
 @ddt.ddt

--- a/test/unit/ggrc_workflows/models/test_task_group_task.py
+++ b/test/unit/ggrc_workflows/models/test_task_group_task.py
@@ -18,23 +18,14 @@ class TestTaskGroupTask(unittest.TestCase):
 
   def test_validate_date(self):
     t = task_group_task.TaskGroupTask()
-    self.assertEqual(date(2002, 4, 16), t.validate_date(date(2, 4, 16)))
+    self.assertEqual(date(2002, 4, 16),
+                     t.validate_date('start_date', date(2, 4, 16)))
     self.assertEqual(date(2014, 7, 23),
-                     t.validate_date(datetime(2014, 7, 23, 22, 5, 7)))
+                     t.validate_date('start_date',
+                                     datetime(2014, 7, 23, 22, 5, 7)))
     self.assertEqual(date(2014, 7, 23),
-                     t.validate_date(datetime(2014, 7, 23, 0, 0, 0)))
-
-  def test_validate_end_date_decorator(self):
-    t = task_group_task.TaskGroupTask()
-    t.end_date = date(15, 4, 17)
-    self.assertEqual(date(2015, 4, 17), t.end_date)
-
-    t.start_date = date(2015, 4, 17)
-    self.assertRaises(ValueError,
-                      t.validate_end_date, "end_date", date(2014, 2, 5))
-
-    t.end_date = date(2015, 2, 17)
-    self.assertEqual(date(2015, 2, 17), t.end_date)
+                     t.validate_date('start_date',
+                                     datetime(2014, 7, 23, 0, 0, 0)))
 
   def test_validate_start_date_decorator(self):
     t = task_group_task.TaskGroupTask()


### PR DESCRIPTION
* Add validator for TGT model: start_date <= end_date on POST/PUT requests.
* Cover new validator with positive/negative integration tests.