### PR TITLE
GGRC-2765 Prevent occasional misaligned tree view columns

### DIFF
--- a/src/ggrc/assets/stylesheets/components/tree/_tree-view.scss
+++ b/src/ggrc/assets/stylesheets/components/tree/_tree-view.scss
@@ -227,7 +227,6 @@ tree-item {
 
   .reference-urls-list {
     overflow: hidden;
-    white-space: nowrap;
     width: 100%;
     text-overflow: ellipsis;
 


### PR DESCRIPTION
This PR fixes occasionally broken (read: misaligned) tree views displaying the reference URLs field.

As a bonus, if having multiple shorter reference URLs, these are rendered one below the other, making them all visible to the user (well, up to two of them at least, before running out of vertical space).

**Steps to reproduce:**
1. Have program with mapped control
1. Add long reference url to control
1. Set "Reference url" field to visible in tree view options
4. Look at the reference url in tree view

**Actual Result:**
Data is not aligned if "Reference url" contains a long link

**Expected Result:**
Data should be aligned if "Reference url" contains a long link

NOTE: Locally I wasn't always able to reproduce this issue despite long URLs. it might be the case that an objects listed in the tree view needs to have at least _two_ (or more?) reference URLs.

The bug can also be seen on [ggrc QA](https://ggrc-qa.appspot.com/programs/1658#control_widget), and the trivial fix can actually be tested on the fly there.
