### PR TITLE
GGRC-2700 Calculate related Assessments based on Assessment Type

### DIFF
--- a/test/integration/ggrc/models/factories.py
+++ b/test/integration/ggrc/models/factories.py
@@ -20,9 +20,9 @@ import factory
 
 from ggrc import db
 from ggrc import models
-
 from ggrc.access_control.role import AccessControlRole
 from ggrc.access_control.list import AccessControlList
+from ggrc_risks import models as risk_models
 
 from integration.ggrc.models.model_factory import ModelFactory
 from integration.ggrc_basic_permissions.models \
@@ -325,3 +325,14 @@ class AccessControlRoleAdminFactory(AccessControlRoleFactory):
   """Access Control Role Admin factory class"""
   mandatory = u"1"
   name = "Admin"
+
+
+class RiskFactory(TitledFactory):
+  """Risk factory class"""
+
+  class Meta:
+    model = risk_models.Risk
+
+  description = factory.LazyAttribute(
+      lambda _: random_str(prefix="Risk - ")
+  )


### PR DESCRIPTION
Depends on #5859

ACCEPTANCE CRITERIA
AC1. Only snapshots of assessment type should be included in 'Related Assessments' calculation.
AC2. Related Issues should be also calculated based on Assessment Type.
DETAILED REQUIREMENTS
https://docs.google.com/spreadsheets/d/1ey_DaVnsVvDQuBykipquE9s717GfOYYjtAIuis6XdFU/edit#gid=0
DIAGRAMS
Attached below. 
1. Related Assessments. See Diagrams: 1.1 - 1.3; Diagram 2 will be implemented in GGRC-2447.
2. Related Issues. See Diagrams: 1.1-1.2, 2. Diagram 3 will be implemented in GGRC-2141.
![related assessments - related assessments](https://user-images.githubusercontent.com/9151434/28794393-de406876-763e-11e7-8769-90643ea2879b.png)
![related issues](https://user-images.githubusercontent.com/9151434/28794394-de40ed1e-763e-11e7-8e80-74736bc42cad.png)
