### PR TITLE
QUICK-FIX [Asmts Workflow] Assessments status changes

### DIFF
--- a/test/selenium/src/lib/base.py
+++ b/test/selenium/src/lib/base.py
@@ -2,9 +2,9 @@
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 """Base classes."""
 # pylint: disable=too-few-public-methods
+# pylint: disable=too-many-lines
 
 import re
-
 import pytest
 
 from selenium import webdriver
@@ -63,6 +63,29 @@ class Test(InstanceRepresentation):
     'exclude_attrs' - list of excluding attributes names.
     Finally, make pytest assert for objects, then xfail assert for attributes.
     """
+    split_objs = (
+        Test.extended_assert_w_excluded_attrs(
+            expected_objs, actual_objs, *exclude_attrs))
+    assert (True if Entity.is_list_of_attrs_equal(
+        split_objs["exp_ex_attrs"], split_objs["act_ex_attrs"])
+        else pytest.xfail(reason=issue_msg))
+
+  @staticmethod
+  def extended_assert_w_excluded_attrs(expected_objs, actual_objs,
+                                       *exclude_attrs):
+    """Perform extended assert for expected and actual objects according to
+    dictionary of attributes to exclude and providing issue's message.
+    Initially, based on original objects prepare expected and actual
+    collections to performing of extended comparison procedure ('split_objs'),
+    where:
+    'exp_objs_wo_ex_attrs', 'act_objs_wo_ex_attrs' - list objects w/o excluding
+    attributes;
+    'exp_ex_attrs', 'act_ex_attrs' - list dictionaries w/ excluding attributes
+    (items which contain attributes' names and values);
+    'issue_msg' - issue message for pytest xfail procedure;
+    'exclude_attrs' - list of excluding attributes names.
+    """
+    # pylint: disable=invalid-name
     split_objs = Entity.extract_excluding_attrs(
         expected_objs, actual_objs, *exclude_attrs)
     assert (split_objs["exp_objs_wo_ex_attrs"] ==
@@ -70,9 +93,7 @@ class Test(InstanceRepresentation):
         messages.AssertionMessages.format_err_msg_equal(
             split_objs["exp_objs_wo_ex_attrs"],
             split_objs["act_objs_wo_ex_attrs"]))
-    assert (True if Entity.is_list_of_attrs_equal(
-        split_objs["exp_ex_attrs"], split_objs["act_ex_attrs"])
-        else pytest.xfail(reason=issue_msg))
+    return split_objs
 
 
 class TestUtil(InstanceRepresentation):

--- a/test/selenium/src/lib/constants/element.py
+++ b/test/selenium/src/lib/constants/element.py
@@ -223,6 +223,7 @@ class CommonAssessment(Common):
   STATE = Base.STATE
   CREATORS = "Creators"
   CREATORS_ = "Creator(s)"
+  COMMENTS = "Comments"
   ASSIGNEES = "Assignees"
   ASSIGNEES_ = "Assignee(s)"
   VERIFIERS = "Verifiers"

--- a/test/selenium/src/lib/constants/element.py
+++ b/test/selenium/src/lib/constants/element.py
@@ -253,7 +253,7 @@ class ObjectStates(object):
 
 class BaseStates(object):
   """Common states for Audit and Assessment objects."""
-  IN_PROGRESS = "In progress"
+  IN_PROGRESS = "In Progress"
   COMPLETED = "Completed"
 
 

--- a/test/selenium/src/lib/constants/locator.py
+++ b/test/selenium/src/lib/constants/locator.py
@@ -40,8 +40,7 @@ class Common(object):
   HTML_LIST_CSS = (By.CSS_SELECTOR, 'ul')
   # xpath helper
   XPATH_NOT_HIDDEN = "[not(ancestor::section[contains(@class, 'hidden')])]"
-  INFO_WIDGET_XPATH = ("//section[starts-with(@class,'info')]" +
-                       XPATH_NOT_HIDDEN)
+  INFO_WIDGET_XPATH = "//section[contains(@class,'info')]" + XPATH_NOT_HIDDEN
   # import / export pages
   CONTENT = ".content"
   OPTION = "option"
@@ -584,7 +583,7 @@ class ModalCloneAudit(ModalCommonConfirmAction):
 class CommonWidgetInfo(object):
   """Common locators for Info widgets and Info panels."""
   _NOT_HIDDEN = Common.XPATH_NOT_HIDDEN
-  _INFO_WIDGET_XPATH = Common.INFO_WIDGET_XPATH + _NOT_HIDDEN
+  _INFO_WIDGET_XPATH = Common.INFO_WIDGET_XPATH
   _MAIN_HEADER_XPATH = "//div[contains(@class,'pane-header')]" + _NOT_HIDDEN
   _HEADERS_AND_VALUES = (_INFO_WIDGET_XPATH +
                          '//div[starts-with(./@class, "span")]//h6/..')
@@ -729,10 +728,16 @@ class WidgetInfoAssessment(WidgetInfoPanel):
   RELATED_ISSUES_CSS = (By.CSS_SELECTOR, " ".join(
       [_ASMT_PANEL, "related-objects[related-items-type='Issue']"]))
   ASMT_TAB_CONTAINER_CSS = (By.CSS_SELECTOR, "tab-container")
+  # state section
+  BUTTON_3BBS = (By.CSS_SELECTOR, ".btn-3bbps")
+  BUTTON_COMPLETE = (By.XPATH, "//button[contains(text(), 'Complete')]")
+  BUTTON_VERIFY = (By.XPATH, "//button[contains(text(), 'Verify')]")
+  BUTTON_REJECT = (By.XPATH, "//button[contains(text(), 'Reject')]")
 
-  class TabContainer(object):
-    TAB_CONTROLLER = (By.CSS_SELECTOR, "ul.nav.nav-tabs")
-    TAB_CONTENT = (By.CSS_SELECTOR, '.tab-pane.active')
+
+class TabContainer(object):
+  TAB_CONTROLLER = (By.CSS_SELECTOR, "ul.nav.nav-tabs")
+  TAB_CONTENT = (By.CSS_SELECTOR, '.tab-pane.active')
 
 
 class WidgetInfoAssessmentTemplate(WidgetInfoPanel):

--- a/test/selenium/src/lib/constants/locator.py
+++ b/test/selenium/src/lib/constants/locator.py
@@ -534,10 +534,17 @@ class WidgetBarButtonAddDropdown(object):
 class ObjectWidget(object):
   """Locators for Generic objects widget."""
   _HEADER = '.header [class^="span"]'
+  _STATE = 'div.state-value'
   HEADER_TITLE = (By.CSS_SELECTOR, _HEADER + ' [data-field="title"]')
   HEADER_OWNER = (
       By.CSS_SELECTOR, _HEADER + ' [data-field="owners"]')
-  HEADER_STATE = (By.CSS_SELECTOR, _HEADER + ' [data-field="status"]')
+  HEADER_STATE = (By.CSS_SELECTOR, _STATE)
+  HEADER_STATE_IN_PROGRESS = (By.CSS_SELECTOR, _STATE + '.state-inprogress')
+  HEADER_STATE_COMPLETED = (By.CSS_SELECTOR, _STATE + '.state-completed')
+  HEADER_STATE_READY_FOR_REVIEW = (
+      By.CSS_SELECTOR, _STATE + '.state-readyforreview')
+  HEADER_STATE_VERIFIED = (By.CSS_SELECTOR, _STATE + '.state-verified')
+
   HEADER_LAST_ASSESSMENT_DATE = (
       By.CSS_SELECTOR, _HEADER + ' [data-field="last_assessment_date"]')
   MEMBERS_TITLE_LIST = (
@@ -729,15 +736,15 @@ class WidgetInfoAssessment(WidgetInfoPanel):
       [_ASMT_PANEL, "related-objects[related-items-type='Issue']"]))
   ASMT_TAB_CONTAINER_CSS = (By.CSS_SELECTOR, "tab-container")
   # state section
-  BUTTON_3BBS = (By.CSS_SELECTOR, ".btn-3bbps")
-  BUTTON_COMPLETE = (By.XPATH, "//button[contains(text(), 'Complete')]")
-  BUTTON_VERIFY = (By.XPATH, "//button[contains(text(), 'Verify')]")
-  BUTTON_REJECT = (By.XPATH, "//button[contains(text(), 'Reject')]")
+  _PNL_STATE = ".pane-header__toolbar"
+  BUTTON_COMPLETE = (By.CSS_SELECTOR, _PNL_STATE + " button.btn-darkBlue")
+  BUTTON_VERIFY = (By.CSS_SELECTOR, _PNL_STATE + " button.btn-green")
+  BUTTON_REJECT = (By.CSS_SELECTOR, _PNL_STATE + " button.btn-red")
+  ICON_VERIFIED = (By.CSS_SELECTOR, "i.verified-icon")
 
-
-class TabContainer(object):
-  TAB_CONTROLLER = (By.CSS_SELECTOR, "ul.nav.nav-tabs")
-  TAB_CONTENT = (By.CSS_SELECTOR, '.tab-pane.active')
+  class TabContainer(object):
+    TAB_CONTROLLER = (By.CSS_SELECTOR, "ul.nav.nav-tabs")
+    TAB_CONTENT = (By.CSS_SELECTOR, '.tab-pane.active')
 
 
 class WidgetInfoAssessmentTemplate(WidgetInfoPanel):

--- a/test/selenium/src/lib/element/widget_info.py
+++ b/test/selenium/src/lib/element/widget_info.py
@@ -106,3 +106,4 @@ class OrgGroups(CommonInfoDropdownSettings):
 class Assessments(CommonInfoDropdownSettings):
   """Assessments 3BBS button/dropdown settings on Info pages and Info panels.
   """
+  # _locators = locator.AssessmentsDropdown3bbsTreeView

--- a/test/selenium/src/lib/element/widget_info.py
+++ b/test/selenium/src/lib/element/widget_info.py
@@ -106,4 +106,3 @@ class OrgGroups(CommonInfoDropdownSettings):
 class Assessments(CommonInfoDropdownSettings):
   """Assessments 3BBS button/dropdown settings on Info pages and Info panels.
   """
-  # _locators = locator.AssessmentsDropdown3bbsTreeView

--- a/test/selenium/src/lib/entities/entities_factory.py
+++ b/test/selenium/src/lib/entities/entities_factory.py
@@ -547,6 +547,7 @@ class AssessmentsFactory(EntitiesFactory):
   """Factory class for Assessments entities."""
 
   obj_attrs_names = Entity.get_attrs_names_for_entities(AssessmentEntity)
+  default_person = ObjectPersonsFactory().default()
 
   @classmethod
   def generate(cls, objs_under_asmt, audit, asmt_tmpl=None):
@@ -580,8 +581,8 @@ class AssessmentsFactory(EntitiesFactory):
 
   @classmethod
   def create(cls, type=None, id=None, title=None, href=None, url=None,
-             slug=None, status=None, owners=None, audit=None,
-             recipients=None, assignees=None, verified=None, updated_at=None,
+             slug=None, status=None, owners=None, audit=None, recipients=None,
+             assignees=None, verified=None, verifier=None, updated_at=None,
              objects_under_assessment=None, os_state=None,
              custom_attribute_definitions=None, custom_attribute_values=None,
              custom_attributes=None):
@@ -596,7 +597,7 @@ class AssessmentsFactory(EntitiesFactory):
         obj_or_objs=asmt_entity, is_allow_none_values=False, type=type, id=id,
         title=title, href=href, url=url, slug=slug, status=status,
         owners=owners, audit=audit, recipients=recipients, assignees=assignees,
-        verified=verified, updated_at=updated_at,
+        verified=verified, verifier=verifier, updated_at=updated_at,
         objects_under_assessment=objects_under_assessment, os_state=os_state,
         custom_attribute_definitions=custom_attribute_definitions,
         custom_attribute_values=custom_attribute_values,
@@ -615,10 +616,22 @@ class AssessmentsFactory(EntitiesFactory):
         (unicode(roles.ASSESSOR), unicode(roles.CREATOR),
          unicode(roles.VERIFIER)))
     random_asmt.verified = False
+    random_asmt.assessor = [unicode(cls.default_person.name)]
+    random_asmt.creator = [unicode(cls.default_person.name)]
     random_asmt.assignees = {
-        "Assessor": [ObjectPersonsFactory().default().__dict__],
-        "Creator": [ObjectPersonsFactory().default().__dict__]}
+        "Assessor": [cls.default_person.__dict__],
+        "Creator": [cls.default_person.__dict__]}
     return random_asmt
+
+  @classmethod
+  def _update_asmt_attrs_values(cls, obj, **arguments):
+    """Update Assessments (obj) attributes values according to dictionary of
+    arguments (key = value). Generated data-'obj', entered data-'**arguments'.
+    """
+    if arguments.get("verifier"):
+      obj.assignees['Verifier'] = [cls.default_person.__dict__]
+    return Entity.update_objs_attrs_values_by_entered_data(
+        obj_or_objs=obj, **arguments)
 
 
 class IssuesFactory(EntitiesFactory):

--- a/test/selenium/src/lib/entities/entities_factory.py
+++ b/test/selenium/src/lib/entities/entities_factory.py
@@ -56,43 +56,6 @@ class EntitiesFactory(object):
         mail_name=random_uuid(), domain=domain))
 
 
-class CommentsFactory(EntitiesFactory):
-  """Factory class for Comments entities."""
-  # pylint: disable=too-many-locals
-
-  obj_attrs_names = Entity.get_attrs_names_for_entities(CommentEntity)
-
-  @classmethod
-  def create_empty(cls):
-    """Create blank Comment object."""
-    empty_comment = CommentEntity()
-    empty_comment.type = cls.obj_comment
-    return empty_comment
-
-  @classmethod
-  def create(cls, type=None, id=None, href=None, modified_by=None,
-             created_at=None, description=None):
-    """Create Comment object.
-    Random values will be used for description.
-    Predictable values will be used for type, owners, modified_by.
-    """
-    comment_entity = cls._create_random_comment()
-    comment_entity = Entity.update_objs_attrs_values_by_entered_data(
-        obj_or_objs=comment_entity, is_allow_none_values=False, type=type,
-        id=id, href=href, modified_by=modified_by,
-        created_at=created_at, description=description)
-    return comment_entity
-
-  @classmethod
-  def _create_random_comment(cls):
-    """Create Comment entity with randomly and predictably filled fields."""
-    random_comment = CommentEntity()
-    random_comment.type = cls.obj_comment
-    random_comment.modified_by = ObjectPersonsFactory().default().__dict__
-    random_comment.description = cls.generate_string(cls.obj_comment)
-    return random_comment
-
-
 class ObjectPersonsFactory(EntitiesFactory):
   """Factory class for Persons entities."""
 
@@ -137,6 +100,43 @@ class ObjectPersonsFactory(EntitiesFactory):
     random_person.email = cls.generate_email()
     random_person.system_wide_role = unicode(roles.SUPERUSER)
     return random_person
+
+
+class CommentsFactory(EntitiesFactory):
+  """Factory class for Comments entities."""
+  # pylint: disable=too-many-locals
+
+  obj_attrs_names = Entity.get_attrs_names_for_entities(CommentEntity)
+
+  @classmethod
+  def create_empty(cls):
+    """Create blank Comment object."""
+    empty_comment = CommentEntity()
+    empty_comment.type = cls.obj_comment
+    return empty_comment
+
+  @classmethod
+  def create(cls, type=None, id=None, href=None, modified_by=None,
+             created_at=None, description=None):
+    """Create Comment object.
+    Random values will be used for description.
+    Predictable values will be used for type, owners, modified_by.
+    """
+    comment_entity = cls._create_random_comment()
+    comment_entity = Entity.update_objs_attrs_values_by_entered_data(
+        obj_or_objs=comment_entity, is_allow_none_values=False, type=type,
+        id=id, href=href, modified_by=modified_by, created_at=created_at,
+        description=description)
+    return comment_entity
+
+  @classmethod
+  def _create_random_comment(cls):
+    """Create Comment entity with randomly and predictably filled fields."""
+    random_comment = CommentEntity()
+    random_comment.type = cls.obj_comment
+    random_comment.modified_by = ObjectPersonsFactory().default().__dict__
+    random_comment.description = cls.generate_string(cls.obj_comment)
+    return random_comment
 
 
 class CustomAttributeDefinitionsFactory(EntitiesFactory):
@@ -279,6 +279,7 @@ class ProgramsFactory(EntitiesFactory):
   # pylint: disable=too-many-locals
 
   obj_attrs_names = Entity.get_attrs_names_for_entities(ProgramEntity)
+  default_person = ObjectPersonsFactory().default()
 
   @classmethod
   def create_empty(cls):
@@ -317,8 +318,8 @@ class ProgramsFactory(EntitiesFactory):
     random_program.title = cls.generate_string(cls.obj_program)
     random_program.slug = cls.generate_slug()
     random_program.status = unicode(element.ObjectStates.DRAFT)
-    random_program.manager = ObjectPersonsFactory().default().__dict__
-    random_program.contact = ObjectPersonsFactory().default().__dict__
+    random_program.manager = cls.default_person.__dict__
+    random_program.contact = cls.default_person.__dict__
     return random_program
 
 
@@ -327,6 +328,7 @@ class ControlsFactory(EntitiesFactory):
   # pylint: disable=too-many-locals
 
   obj_attrs_names = Entity.get_attrs_names_for_entities(ControlEntity)
+  default_person = ObjectPersonsFactory().default()
 
   @classmethod
   def create_empty(cls):
@@ -367,8 +369,8 @@ class ControlsFactory(EntitiesFactory):
     random_control.title = cls.generate_string(cls.obj_control)
     random_control.slug = cls.generate_slug()
     random_control.status = unicode(element.ObjectStates.DRAFT)
-    random_control.contact = ObjectPersonsFactory().default().__dict__
-    random_control.owners = [ObjectPersonsFactory().default().__dict__]
+    random_control.contact = cls.default_person.__dict__
+    random_control.owners = [cls.default_person.__dict__]
     random_control.access_control_list = [
         ObjectPersonsFactory().get_acl_member(roles.ADMIN_ID,
                                               random_control.owners[0]),
@@ -382,6 +384,7 @@ class ObjectivesFactory(EntitiesFactory):
   # pylint: disable=too-many-locals
 
   obj_attrs_names = Entity.get_attrs_names_for_entities(ObjectiveEntity)
+  default_person = ObjectPersonsFactory().default()
 
   @classmethod
   def create_empty(cls):
@@ -420,7 +423,7 @@ class ObjectivesFactory(EntitiesFactory):
     random_objective.title = cls.generate_string(cls.obj_objective)
     random_objective.slug = cls.generate_slug()
     random_objective.status = unicode(element.ObjectStates.DRAFT)
-    random_objective.owners = [ObjectPersonsFactory().default().__dict__]
+    random_objective.owners = [cls.default_person.__dict__]
     return random_objective
 
 
@@ -428,6 +431,7 @@ class AuditsFactory(EntitiesFactory):
   """Factory class for Audit entity."""
 
   obj_attrs_names = Entity.get_attrs_names_for_entities(AuditEntity)
+  default_person = ObjectPersonsFactory().default()
 
   @classmethod
   def clone(cls, audit, count_to_clone=1):
@@ -476,7 +480,7 @@ class AuditsFactory(EntitiesFactory):
     random_audit.title = cls.generate_string(cls.obj_audit)
     random_audit.slug = cls.generate_slug()
     random_audit.status = unicode(element.AuditStates().PLANNED)
-    random_audit.contact = ObjectPersonsFactory().default().__dict__
+    random_audit.contact = cls.default_person.__dict__
     return random_audit
 
 
@@ -582,10 +586,10 @@ class AssessmentsFactory(EntitiesFactory):
   @classmethod
   def create(cls, type=None, id=None, title=None, href=None, url=None,
              slug=None, status=None, owners=None, audit=None, recipients=None,
-             assignees=None, verified=None, verifier=None, updated_at=None,
-             objects_under_assessment=None, os_state=None,
-             custom_attribute_definitions=None, custom_attribute_values=None,
-             custom_attributes=None):
+             assignees=None, verified=None, verifier=None, creator=None,
+             assessor=None, updated_at=None, objects_under_assessment=None,
+             os_state=None, custom_attribute_definitions=None,
+             custom_attribute_values=None, custom_attributes=None):
     """Create Assessment object.
     Random values will be used for title and slug.
     Predictable values will be used for type, status, recipients,
@@ -593,11 +597,12 @@ class AssessmentsFactory(EntitiesFactory):
     """
     # pylint: disable=too-many-locals
     asmt_entity = cls._create_random_asmt()
-    asmt_entity = Entity.update_objs_attrs_values_by_entered_data(
-        obj_or_objs=asmt_entity, is_allow_none_values=False, type=type, id=id,
+    asmt_entity = cls._update_asmt_attrs_values(
+        obj=asmt_entity, is_allow_none_values=False, type=type, id=id,
         title=title, href=href, url=url, slug=slug, status=status,
         owners=owners, audit=audit, recipients=recipients, assignees=assignees,
-        verified=verified, verifier=verifier, updated_at=updated_at,
+        verified=verified, verifier=verifier, creator=creator,
+        assessor=assessor, updated_at=updated_at,
         objects_under_assessment=objects_under_assessment, os_state=os_state,
         custom_attribute_definitions=custom_attribute_definitions,
         custom_attribute_values=custom_attribute_values,
@@ -638,6 +643,7 @@ class IssuesFactory(EntitiesFactory):
   """Factory class for Issues entities."""
 
   obj_attrs_names = Entity.get_attrs_names_for_entities(IssueEntity)
+  default_person = ObjectPersonsFactory().default()
 
   @classmethod
   def create_empty(cls):

--- a/test/selenium/src/lib/entities/entity.py
+++ b/test/selenium/src/lib/entities/entity.py
@@ -784,12 +784,12 @@ class AssessmentEntity(Entity):
       "updated_at", "objects_under_assessment", "custom_attributes",
       "comments"]
 
-  def __init__(self, status=None, audit=None, owners=None,
-               recipients=None, assignees=None, assessor=None, creator=None,
-               verifier=None, verified=None, updated_at=None,
-               objects_under_assessment=None, os_state=None,
-               custom_attribute_definitions=None, custom_attribute_values=None,
-               custom_attributes=None, comments=None):
+  def __init__(self, status=None, audit=None, owners=None, recipients=None,
+               assignees=None, assessor=None, creator=None, verifier=None,
+               verified=None, updated_at=None, objects_under_assessment=None,
+               os_state=None, custom_attribute_definitions=None,
+               custom_attribute_values=None, custom_attributes=None,
+               comments=None):
     super(AssessmentEntity, self).__init__()
     # REST and UI
     self.status = status  # state (e.g. "Not Started")

--- a/test/selenium/src/lib/entities/entity.py
+++ b/test/selenium/src/lib/entities/entity.py
@@ -5,8 +5,8 @@
 # pylint: disable=too-few-public-methods
 
 import copy
-from datetime import datetime
 
+from datetime import datetime
 from lib.utils import string_utils, help_utils
 
 
@@ -75,7 +75,7 @@ class Representation(object):
     'attr_value' to dictionary or list of dictionaries with items
     {'attr_name': 'attr_value'}.
     """
-    if obj_or_objs:
+    if obj_or_objs or isinstance(obj_or_objs, bool):
       if isinstance(obj_or_objs, list):
         if (all(not isinstance(_, dict) and
                 not isinstance(_, (str, unicode, int)) and

--- a/test/selenium/src/lib/page/modal/base.py
+++ b/test/selenium/src/lib/page/modal/base.py
@@ -33,6 +33,11 @@ class BaseModal(base.Modal):
     self.enter_code(code)
     return self.__class__(self._driver)
 
+  def edit_minimal_data(self, title):
+    """Edit title of current modal."""
+    self.enter_title(title)
+    return self.__class__(self._driver)
+
 
 class ProgramsModal(BaseModal):
   """Modal base for Program objects."""

--- a/test/selenium/src/lib/page/modal/edit_object.py
+++ b/test/selenium/src/lib/page/modal/edit_object.py
@@ -22,6 +22,10 @@ class _EditModal(modal_base.BaseModal):
     self.button_save_and_close.click()
 
 
+class Assessments(modal_base.AsmtsModal, _EditModal):
+  """Assessments edit modal."""
+
+
 class Programs(modal_base.ProgramsModal, _EditModal):
   """Programs edit modal."""
 

--- a/test/selenium/src/lib/page/widget/generic_widget.py
+++ b/test/selenium/src/lib/page/widget/generic_widget.py
@@ -168,8 +168,7 @@ class TreeView(base.TreeView):
     _locator_3bbs = (
         By.CSS_SELECTOR, self._locators.BUTTON_3BBS.format(self.widget_name))
     base.Button(self._driver, _locator_3bbs).click()
-    return self.dropdown_settings_cls(
-        self._driver, self.obj_name)
+    return self.dropdown_settings_cls(self._driver, self.obj_name)
 
   def select_member_by_title(self, title):
     """Select member on Tree View by title.

--- a/test/selenium/src/lib/page/widget/info_widget.py
+++ b/test/selenium/src/lib/page/widget/info_widget.py
@@ -5,7 +5,9 @@
 
 from lib import base
 from lib.constants import locator, objects, element, roles
+from lib.constants.locator import WidgetInfoAssessment
 from lib.element import widget_info, tab_containers
+from lib.element import widget_info
 from lib.page.modal import update_object
 from lib.utils import selenium_utils
 
@@ -310,6 +312,15 @@ class Assessments(InfoPanel):
         self.creators_entered_text, self.assignees_entered_text,
         self.verifiers_entered_text, self.mapped_objects_titles_text,
         self.code_entered_text, self.comments.scopes]
+
+  def click_complete(self):
+    base.Button(self._driver, WidgetInfoAssessment.BUTTON_COMPLETE).click()
+
+  def click_verify(self):
+    base.Button(self._driver, WidgetInfoAssessment.BUTTON_VERIFY).click()
+
+  def click_reject(self):
+    base.Button(self._driver, WidgetInfoAssessment.BUTTON_REJECT).click()
 
 
 class AssessmentTemplates(InfoPanel):

--- a/test/selenium/src/lib/page/widget/info_widget.py
+++ b/test/selenium/src/lib/page/widget/info_widget.py
@@ -7,7 +7,6 @@ from lib import base
 from lib.constants import locator, objects, element, roles
 from lib.constants.locator import WidgetInfoAssessment
 from lib.element import widget_info, tab_containers
-from lib.element import widget_info
 from lib.page.modal import update_object
 from lib.utils import selenium_utils
 
@@ -286,6 +285,9 @@ class Assessments(InfoPanel):
         self.get_header_and_value_text_from_custom_scopes(
             self._elements.VERIFIERS_.upper(),
             self._locators.PEOPLE_HEADERS_AND_VALUES))
+    self.verified = (
+        selenium_utils.is_element_exist(self._driver,
+                                        self._locators.ICON_VERIFIED))
     # code section
     self.code_text = (
         self.code_section.element.find_element(
@@ -307,8 +309,7 @@ class Assessments(InfoPanel):
     self.list_all_values_text = [
         self.cas_text, self.title_entered().text,
         objects.get_normal_form(self.state().text),
-        self.state().text.upper() in
-        element.AssessmentStates.COMPLETED.upper(),
+        self.verified,
         self.creators_entered_text, self.assignees_entered_text,
         self.verifiers_entered_text, self.mapped_objects_titles_text,
         self.code_entered_text, self.comments.scopes]

--- a/test/selenium/src/lib/service/rest/client.py
+++ b/test/selenium/src/lib/service/rest/client.py
@@ -18,7 +18,7 @@ class RestClient(object):
   """Client for HTTP interactions with GGRC's REST API."""
   BASIC_HEADERS = {'X-Requested-By': 'GGRC',
                    'Content-Type': 'application/json',
-                   'Accept-Encoding': 'gzip, deflate'}
+                   'Accept-Encoding': 'gzip, deflate, br'}
 
   STATUS_CODES = {'OK': 200,
                   'FAIL': [400, 404, 500]}

--- a/test/selenium/src/lib/service/rest_service.py
+++ b/test/selenium/src/lib/service/rest_service.py
@@ -203,12 +203,19 @@ class AssessmentsService(BaseRestService):
     objects with filtered attributes.
     """
     objs = BaseRestService(url.ASSESSMENTS).create_objs(
-        count, factory_params=None, **attrs_for_template)
-    # add Default Person as 'Assessor', 'Creator' to Assessments
-    RelationshipsService().map_objs(
-        src_obj=ObjectPersonsFactory().default(), dest_objs=objs,
-        attrs={"AssigneeType": "Creator,Assessor"})
+        count, factory_params, **attrs_for_template)
+    assignees = [assignee for obj in objs for assignee in obj.assignees]
+    if assignees:
+      RelationshipsService().map_objs(
+          src_obj=ObjectPersonsFactory().default(), dest_objs=objs,
+          attrs={"AssigneeType": ",".join(assignees)})
     return objs
+
+  def update_obj(self, obj):
+    """Update attributes values of existing Assessment via REST API"""
+    return (self.client.update_object(
+        href=obj.href, **dict({k: v for k, v in obj.__dict__
+                              .iteritems() if k != "href"}.items())))
 
 
 class IssuesService(BaseRestService):

--- a/test/selenium/src/lib/service/rest_service.py
+++ b/test/selenium/src/lib/service/rest_service.py
@@ -211,8 +211,9 @@ class AssessmentsService(BaseRestService):
           attrs={"AssigneeType": ",".join(assignees)})
     return objs
 
-  def update_obj(self, obj):
+  def update_obj(self, obj, **attrs):
     """Update attributes values of existing Assessment via REST API"""
+    obj.update_attrs(**attrs)
     return (self.client.update_object(
         href=obj.href, **dict({k: v for k, v in obj.__dict__
                               .iteritems() if k != "href"}.items())))

--- a/test/selenium/src/lib/service/webui_service.py
+++ b/test/selenium/src/lib/service/webui_service.py
@@ -444,13 +444,22 @@ class AssessmentsService(BaseWebUiService):
     and if 'asmt_tmpl_obj' then to Assessment Template title, generate
     new Assessment(s).
     """
-    objs_under_asmt_titles = [obj_under.title for obj_under in
-                              objs_under_asmt]
+    objs_under_asmt_titles = [obj_under.title for obj_under in objs_under_asmt]
     objs_widget = self.open_widget_of_mapped_objs(src_obj)
     asmt_tmpl_title = asmt_tmpl_obj.title if asmt_tmpl_obj else None
     (objs_widget.tree_view.open_3bbs().select_generate().
      generate_asmts(asmt_tmpl_title=asmt_tmpl_title,
                     objs_under_asmt_titles=objs_under_asmt_titles))
+
+  def edit_obj_title_via_info_widget(self, src_obj):
+    """Open generic widget of object, open edit modal from drop down menu.
+    Modify current title and apply changes by pressing 'save and close' button
+    """
+    obj_info_page = self.open_info_page_of_obj(src_obj)
+    modal = obj_info_page.open_info_3bbs().select_edit()
+    modal.enter_title("Assessment " + string_utils.random_string(size=20))
+    modal.save_and_close()
+    return self
 
   def get_log_pane_validation_result(self, obj):
     """Open assessment Info Page. Open Log Pane on Assessment Info Page.
@@ -487,6 +496,24 @@ class AssessmentsService(BaseWebUiService):
     related_issues_tab = asmt_page.workflow_container.get_tab_object(
         element.AssessmentTabContainer.RELATED_ISSUES_TAB)
     related_issues_tab.raise_issue(issue_entity=issue_obj)
+
+  def complete_assessment(self, obj):
+    """Navigate to info page of object according to URL of object then find and
+    click 'Complete' button then return info page of object in new state"""
+    self.open_info_page_of_obj(obj).click_complete()
+    return self
+
+  def verify_assessment(self, obj):
+    """Navigate to info page of object according to URL of object then find and
+    click 'Verify' button then return info page of object in new state"""
+    self.open_info_page_of_obj(obj).click_verify()
+    return self
+
+  def reject_assessment(self, obj):
+    """Navigate to info page of object according to URL of object then find and
+    click 'Reject' button then return info page of object in new state"""
+    self.open_info_page_of_obj(obj).click_reject()
+    return self
 
 
 class ControlsService(SnapshotsWebUiService):

--- a/test/selenium/src/lib/service/webui_service.py
+++ b/test/selenium/src/lib/service/webui_service.py
@@ -451,15 +451,16 @@ class AssessmentsService(BaseWebUiService):
      generate_asmts(asmt_tmpl_title=asmt_tmpl_title,
                     objs_under_asmt_titles=objs_under_asmt_titles))
 
-  def edit_obj_title_via_info_widget(self, src_obj):
+  def edit_obj_via_edit_modal_from_info_page(self, src_obj):
     """Open generic widget of object, open edit modal from drop down menu.
-    Modify current title and apply changes by pressing 'save and close' button
+    Modify current title and code and then apply changes by pressing
+    'save and close' button
     """
-    obj_info_page = self.open_info_page_of_obj(src_obj)
-    modal = obj_info_page.open_info_3bbs().select_edit()
-    modal.enter_title("Assessment " + string_utils.random_string(size=20))
-    modal.save_and_close()
-    return self
+    # pylint: disable=invalid-name
+    src_obj_info_page = self.open_info_page_of_obj(src_obj)
+    (src_obj_info_page.open_info_3bbs().select_edit().
+     edit_minimal_data(title="[EDITED]" + src_obj.title).save_and_close())
+    return self.info_widget_cls(self.driver)
 
   def get_log_pane_validation_result(self, obj):
     """Open assessment Info Page. Open Log Pane on Assessment Info Page.
@@ -501,19 +502,25 @@ class AssessmentsService(BaseWebUiService):
     """Navigate to info page of object according to URL of object then find and
     click 'Complete' button then return info page of object in new state"""
     self.open_info_page_of_obj(obj).click_complete()
-    return self
+    return self.info_widget_cls(self.driver)
 
   def verify_assessment(self, obj):
     """Navigate to info page of object according to URL of object then find and
     click 'Verify' button then return info page of object in new state"""
+    from lib.constants.locator import ObjectWidget
+    from lib.constants.locator import WidgetInfoAssessment
     self.open_info_page_of_obj(obj).click_verify()
-    return self
+    for locator in [ObjectWidget.HEADER_STATE_VERIFIED,
+                    ObjectWidget.HEADER_STATE_COMPLETED,
+                    WidgetInfoAssessment.ICON_VERIFIED]:
+      selenium_utils.wait_until_element_visible(self.driver, locator)
+    return self.info_widget_cls(self.driver)
 
   def reject_assessment(self, obj):
     """Navigate to info page of object according to URL of object then find and
     click 'Reject' button then return info page of object in new state"""
     self.open_info_page_of_obj(obj).click_reject()
-    return self
+    return self.info_widget_cls(self.driver)
 
 
 class ControlsService(SnapshotsWebUiService):

--- a/test/selenium/src/lib/utils/selenium_utils.py
+++ b/test/selenium/src/lib/utils/selenium_utils.py
@@ -33,11 +33,6 @@ def open_url(driver, url):
     driver.get(url)
 
 
-def refresh_page(driver):
-  """Refresh Page in current browser session"""
-  driver.refresh()
-
-
 def switch_to_new_window(driver):
   """Wait until new window will be opened, have the number of windows handles
   increase and then switch to last opened window.
@@ -87,6 +82,11 @@ def get_when_visible(driver, locator):
 def wait_until_condition(driver, condition):
   """Wait until given expected condition is met."""
   _webdriver_wait(driver).until(condition)
+
+
+def wait_until_element_visible(driver, locator):
+  """Wait until element for given locator are present in DOM and visible."""
+  wait_until_condition(driver, EC.visibility_of_element_located(locator))
 
 
 def wait_until_not_present(driver, locator):

--- a/test/selenium/src/lib/utils/selenium_utils.py
+++ b/test/selenium/src/lib/utils/selenium_utils.py
@@ -33,6 +33,11 @@ def open_url(driver, url):
     driver.get(url)
 
 
+def refresh_page(driver):
+  """Refresh Page in current browser session"""
+  driver.refresh()
+
+
 def switch_to_new_window(driver):
   """Wait until new window will be opened, have the number of windows handles
   increase and then switch to last opened window.

--- a/test/selenium/src/tests/conftest.py
+++ b/test/selenium/src/tests/conftest.py
@@ -7,24 +7,25 @@
 
 import pytest
 
-import lib.utils.help_utils
 from lib import dynamic_fixtures
 from lib.page import dashboard
-from lib.utils import selenium_utils
+from lib.utils import selenium_utils, help_utils
 
 # pylint: disable=redefined-outer-name
 pytest_plugins = "selenium", "xdist", "xvfb", "timeout", "flask", \
                  "rerunfailures", "timeout", "repeat", "pycharm"
 
 
-def _common_fixtures(fixturename):
+def _common_fixtures(fixture):
   """Generate common fixtures and return global dictionary of executed
   common fixtures.
   """
-  dynamic_fixtures.generate_common_fixtures(fixturename)
-  fixture = dynamic_fixtures.dict_executed_fixtures[fixturename]
-  return (lib.utils.help_utils.get_single_obj(fixture)
-          if not lib.utils.help_utils.is_multiple_objs(fixture) else fixture)
+  dynamic_fixtures.generate_common_fixtures(fixture)
+  if isinstance(fixture, tuple):
+    fixture, _ = fixture
+  fixture = dynamic_fixtures.dict_executed_fixtures[fixture]
+  return (help_utils.get_single_obj(fixture)
+          if not help_utils.is_multiple_objs(fixture) else fixture)
 
 
 @pytest.fixture(scope="function")
@@ -62,6 +63,16 @@ def chrome_options(chrome_options, create_tmp_dir):
            "download.prompt_for_download": False}
   chrome_options.add_experimental_option("prefs", prefs)
   return chrome_options
+
+
+@pytest.yield_fixture(scope="function")
+def dynamic_new_assessment_template(request):
+  """Dynamically create new Assessment Template under Audit object according
+  to fixturename. Fixturename is indirect parameter that get from
+  'request.param' and have to be string or boolean.
+  Return: lib.entities.entity.AssessmentTemplateEntity
+  """
+  yield _common_fixtures(request.param) if request.param else None
 
 
 @pytest.fixture(scope="function")
@@ -240,6 +251,15 @@ def dynamic_create_audit_with_control(request):
 
 @pytest.fixture(scope="function")
 def dynamic_object(request):
+  """Create object by passed indirect parameter that get from 'request.param'
+  and have to be string or boolean. Return singular or plural object's form
+  according to length of the list objects.
+  """
+  yield _common_fixtures(request.param) if request.param else None
+
+
+@pytest.fixture(scope="function")
+def dynamic_object_w_factory_params(request):
   """Create object by passed indirect parameter that get from 'request.param'
   and have to be string or boolean. Return singular or plural object's form
   according to length of the list objects.

--- a/test/selenium/src/tests/test_asmts_workflow.py
+++ b/test/selenium/src/tests/test_asmts_workflow.py
@@ -5,17 +5,49 @@
 # pylint: disable=invalid-name
 # pylint: disable=unused-argument
 # pylint: disable=too-few-public-methods
+# pylint: disable=too-many-arguments
 
+import copy
 import pytest
 
 from lib import base
-from lib.constants import messages
+from lib.base import Test
+from lib.constants import messages, roles
+from lib.constants.element import AssessmentStates
 from lib.entities import entities_factory
-from lib.service import webui_service
+from lib.service import webui_service, rest_service
+from lib.utils import selenium_utils
 
 
 class TestAssessmentsWorkflow(base.Test):
   """Tests for Assessments Workflow functionality."""
+
+  @staticmethod
+  def create_asmt(
+      new_audit_rest, has_verifier, initial_state, assessments_service
+  ):
+    """Create Assessment with predefined state.
+    Preconditions:
+    - Program created via REST API.
+    - Audit created under Program via REST API.
+    - Assessment created under Audit via REST API.
+    Returns UI representation of created object.
+    """
+    additional_params = {"status": initial_state}
+    if has_verifier:
+      additional_params["verifier"] = [roles.DEFAULT_USER]
+    expected_asmt = rest_service.AssessmentsService().create_objs(
+        count=1, factory_params=additional_params,
+        audit=new_audit_rest.__dict__)[0]
+    expected_asmt_to_compare = copy.copy(expected_asmt)
+    actual_asmt = assessments_service.get_obj_from_info_page(expected_asmt)
+    # due to 'actual_asmt.updated_at = None'
+    # due to 'expected_asmt.custom_attributes = {None: None}'
+    Test.extended_assert(
+        expected_objs=[expected_asmt_to_compare], actual_objs=actual_asmt,
+        issue_msg=None, is_skip_xfail=True,
+        custom_attributes={None: None}, updated_at=None)
+    return expected_asmt
 
   @pytest.mark.smoke_tests
   def test_add_comment_to_asmt_via_info_panel(
@@ -87,3 +119,111 @@ class TestAssessmentsWorkflow(base.Test):
     related_issues_titles = asmt_service.get_related_issues_titles(
         obj=new_assessment_rest)
     assert related_issues_titles == [expected_issue.title]
+
+  @pytest.mark.smoke_tests
+  @pytest.mark.parametrize(
+      ("initial_state", "has_verifier"),
+      [(AssessmentStates.NOT_STARTED, False),
+       (AssessmentStates.NOT_STARTED, True),
+       (AssessmentStates.IN_PROGRESS, False),
+       (AssessmentStates.IN_PROGRESS, True)],
+      ids=["Check if state of Assessment w'o verifier is changed from "
+           "'Not Started' to 'In Progress' after update",
+           "Check if state of Assessment w' verifier is changed from "
+           "'Not Started' to 'In Progress' after update",
+           "Check if state of Assessment w'o verifier is changed from "
+           "'In Progress' to 'In Progress' after update",
+           "Check if state of Assessment w' verifier is changed from "
+           "'In Progress' to 'In Progress' after update"])
+  def test_asmt_state_change_edit(
+      self, new_program_rest, new_audit_rest, initial_state, has_verifier,
+      selenium
+  ):
+    """Check Assessment workflow status change to correct state.
+    Preconditions:
+    - Program created via REST API.
+    - Audit created under Program via REST API.
+    - Assessment created under Audit via REST API.
+    """
+    assessments_service = webui_service.AssessmentsService(selenium)
+    expected_asmt = (
+        self.create_asmt(new_audit_rest, has_verifier, initial_state,
+                         assessments_service))
+    actual_asmt = (
+        assessments_service.edit_obj_title_via_info_widget(
+            expected_asmt).get_obj_from_info_page(obj=None))
+    assert AssessmentStates.IN_PROGRESS.upper() == actual_asmt.status.upper()
+
+  @pytest.mark.smoke_tests
+  @pytest.mark.parametrize(
+      ("initial_state", "final_state", "has_verifier"),
+      [(AssessmentStates.NOT_STARTED, AssessmentStates.COMPLETED, False),
+       (AssessmentStates.IN_PROGRESS, AssessmentStates.COMPLETED, False),
+       (AssessmentStates.NOT_STARTED, AssessmentStates.READY_FOR_REVIEW, True),
+       (AssessmentStates.IN_PROGRESS, AssessmentStates.READY_FOR_REVIEW, True)
+       ],
+      ids=["Check if state of Assessment w'o verifier is changed from "
+           "'Not Started' to 'Completed' after 'Complete' button been pressed",
+           "Check if state of Assessment w'o verifier is changed from "
+           "'In Progress' to 'Completed' after 'Complete' button been pressed",
+           "Check if state of Assessment w' verifier is changed from "
+           "'Not Started' to 'Ready for Review' after 'Complete' button"
+           " been pressed",
+           "Check if state of Assessment w' verifier is changed from "
+           "'In Progress' to 'Ready for Review' after 'Complete' button"
+           " been pressed"
+           ])
+  def test_asmt_state_change_complete(
+      self, new_program_rest, new_audit_rest, initial_state, final_state,
+      has_verifier, selenium
+  ):
+    """Check Assessment workflow status change to correct state.
+    Preconditions:
+    - Program created via REST API.
+    - Audit created under Program via REST API.
+    - Assessment created under Audit via REST API.
+    """
+    assessments_service = webui_service.AssessmentsService(selenium)
+    expected_asmt = (
+        self.create_asmt(new_audit_rest, has_verifier, initial_state,
+                         assessments_service))
+    actual_asmt = (
+        assessments_service.complete_assessment(expected_asmt).
+        get_obj_from_info_page(obj=None))
+    assert final_state.upper() == actual_asmt.status.upper()
+
+  @pytest.mark.smoke_tests
+  @pytest.mark.parametrize(
+      ("expected_state", "is_verify"),
+      [(AssessmentStates.COMPLETED, True),
+       (AssessmentStates.IN_PROGRESS, False)],
+      ids=["Check if state of Assessment w' verifier is changed from "
+           "'Ready for Review' to 'Completed' after 'Verify' button been"
+           " pressed",
+           "Check if state of Assessment w' verifier is changed from "
+           "'Ready for Review' to 'In Progress' after 'Reject' button been"
+           " pressed"
+           ])
+  def test_asmt_state_change_verify_or_reject(
+      self, new_program_rest, new_audit_rest, expected_state, is_verify,
+      selenium
+  ):
+    """Check Assessment workflow status change to correct state.
+    Preconditions:
+    - Program created via REST API.
+    - Audit created under Program via REST API.
+    - Assessment created under Audit via REST API.
+    """
+    assessments_service = webui_service.AssessmentsService(selenium)
+    expected_asmt = (
+        self.create_asmt(new_audit_rest, True, AssessmentStates.IN_PROGRESS,
+                         assessments_service))
+    expected_asmt.update_attrs(status=AssessmentStates.READY_FOR_REVIEW)
+    rest_service.AssessmentsService().update_obj(expected_asmt)
+    selenium_utils.refresh_page(selenium)
+    if is_verify:
+      info_page = assessments_service.verify_assessment(expected_asmt)
+    else:
+      info_page = assessments_service.reject_assessment(expected_asmt)
+    actual_asmt = info_page.get_obj_from_info_page(expected_asmt)
+    assert expected_state.upper() == actual_asmt.status.upper()

--- a/test/selenium/src/tests/test_snapshots.py
+++ b/test/selenium/src/tests/test_snapshots.py
@@ -553,21 +553,23 @@ class TestSnapshots(base.Test):
       - check Assessment
       - check Issue
     """
-    origin_control = create_audit_with_control_and_update_control[
-        "update_control_rest"][0]
     snapshoted_control = create_audit_with_control_and_update_control[
         "new_control_rest"][0]
     # due to 'actual_control.custom_attributes = {None: None}'
+    # expected_obj = (dynamic_object.repr_ui().update_attrs(
+    #     custom_attributes={None: None}))
     expected_obj = (dynamic_object.repr_ui().update_attrs(
-        custom_attributes={None: None}))
+        custom_attributes={None: None}, updated_at=None))
     expected_obj_service = get_ui_service(expected_obj.type)(selenium)
     (webui_service.ControlsService(selenium).map_objs_via_tree_view(
         src_obj=expected_obj, dest_objs=[snapshoted_control]))
-    actual_objs = expected_obj_service.get_list_objs_from_tree_view(
-        src_obj=origin_control)
-    assert [expected_obj] == actual_objs, (
+    actual_obj = expected_obj_service.get_obj_from_info_page(obj=expected_obj)
+    # due to 'expected_obj.objects_under_assessment = None'
+    actual_obj.update_attrs(objects_under_assessment=None,
+                            custom_attributes={None: None})
+    assert expected_obj == actual_obj, (
         messages.AssertionMessages.
-        format_err_msg_equal(expected_obj, actual_objs))
+        format_err_msg_equal(expected_obj, actual_obj))
 
   @pytest.mark.parametrize(
       "dynamic_object",


### PR DESCRIPTION
Adding test to verify Assessment states flow.
```Python
def test_check_asmt_state_change(
      self, new_program_rest, new_audit_rest, dynamic_object_w_factory_params,
      action, expected_initial_state, expected_final_state, selenium
  ):
    """Check Assessment workflow status change to correct state.
    Preconditions:
    - Program created via REST API.
    - Audit created under Program via REST API.
    - Assessment created and updated under Audit via REST API.
    """
    expected_asmt = dynamic_object_w_factory_params
    assessments_service = webui_service.AssessmentsService(selenium)
    getattr(assessments_service, action)(expected_asmt)
    actual_asmt = assessments_service.get_obj_from_info_page(expected_asmt)
    Test.extended_assert_w_excluded_attrs(
        expected_asmt.update_attrs(status=expected_final_state.title(),
                                   title=actual_asmt.title,
                                   verified=actual_asmt.verified).repr_ui(),
        actual_asmt, "updated_at")
```