### PR TITLE
GGRC-2947 Fix document permission issue

### DIFF
--- a/src/ggrc/assets/javascripts/components/quick_form/quick_add.js
+++ b/src/ggrc/assets/javascripts/components/quick_form/quick_add.js
@@ -51,7 +51,6 @@
           title: value,
           context: context,
           document_type: CMS.Models.Document.URL,
-          owners: [{type: 'Person', id: GGRC.current_user.id}],
           created_at: new Date(),
           isDraft: true
         };

--- a/src/ggrc/assets/javascripts/components/related-objects/related-documents.js
+++ b/src/ggrc/assets/javascripts/components/related-objects/related-documents.js
@@ -133,11 +133,7 @@
           context: this.instance.context || new CMS.Models.Context({
             id: null
           }),
-          document_type: this.documentType,
-          owners: [{
-            type: 'Person',
-            id: GGRC.current_user.id
-          }]
+          document_type: this.documentType
         });
         return document;
       },

--- a/src/ggrc/assets/javascripts/models/document.js
+++ b/src/ggrc/assets/javascripts/models/document.js
@@ -4,6 +4,21 @@
 */
 
 (function (ns, can) {
+  function getAccessControlList() {
+    var adminRole;
+    adminRole = _.filter(GGRC.access_control_roles, {
+      object_type: 'Document',
+      name: 'Admin'
+    });
+    if (!adminRole || adminRole.length < 1) {
+      console.warn('Document Admin custom role not found.');
+      return;
+    }
+    return [{
+      ac_role_id: adminRole[0].id,
+      person: {type: 'Person', id: GGRC.current_user.id}
+    }];
+  }
   can.Model.Cacheable('CMS.Models.Document', {
     root_object: 'document',
     root_collection: 'documents',
@@ -44,7 +59,8 @@
       year: 'CMS.Models.Option.stub'
     },
     defaults: {
-      document_type: 'EVIDENCE'
+      document_type: 'EVIDENCE',
+      access_control_list: getAccessControlList()
     },
     tree_view_options: {
       show_view: GGRC.mustache_path + '/documents/tree.mustache',

--- a/src/ggrc_gdrive_integration/assets/javascripts/components/gdrive_folder_picker.js
+++ b/src/ggrc_gdrive_integration/assets/javascripts/components/gdrive_folder_picker.js
@@ -31,8 +31,7 @@
             new CMS.Models.Document({
               context: object.context || {id: null},
               title: file.title,
-              link: file.alternateLink,
-              owners: [{type: 'Person', id: GGRC.current_user.id}]
+              link: file.alternateLink
             }).save().then(function (doc) {
               return $.when([
                 new CMS.Models.Relationship({

--- a/src/ggrc_gdrive_integration/assets/javascripts/components/gdrive_picker_launcher.js
+++ b/src/ggrc_gdrive_integration/assets/javascripts/components/gdrive_picker_launcher.js
@@ -236,20 +236,10 @@
         var that = this;
 
         return files.map(function (file) {
-          var adminRole = _.filter(GGRC.access_control_roles, {
-            object_type: 'Document',
-            name: 'Admin'
-          });
           return new CMS.Models.Document({
             context: that.instance.context || {id: null},
             title: file.title,
-            link: file.alternateLink,
-            access_control_list: adminRole ?
-              [{
-                ac_role_id: adminRole[0].id,
-                person: {type: 'Person', id: GGRC.current_user.id}
-              }] :
-              []
+            link: file.alternateLink
           }).save().then(function (doc) {
             var objectDoc;
 


### PR DESCRIPTION
1. Log as Global Creator (globcreator@gmail.com (engage007)
2. Create control
3. Add Reference url to control

This issue was caused in https://github.com/google/ggrc-core/pull/5745. One Document instance was updated (https://github.com/google/ggrc-core/pull/5745/files#diff-d85d909fa174cbf4f1978d1f761fe00f) but there were other places where we created a new Document instance where the update was not made. The change in this PR makes sure that and admin role is set by default whenever we create an document instance.