### PR TITLE
GGRC-2900 Fix missing reference URLs in initial object revision (part 2)

### DIFF
--- a/src/ggrc/assets/javascripts/components/related-objects/related-documents.js
+++ b/src/ggrc/assets/javascripts/components/related-objects/related-documents.js
@@ -158,8 +158,10 @@
 
         return this.saveDocument(document)
           .then(this.createRelationship.bind(this))
-          .then(function (result) {
-            self.fetchAndUpdate(self.instance);
+          .then(function () {
+            return self.instance.refresh();
+          })
+          .then(function () {
             self.instance.dispatch('refreshRelatedDocuments');
           })
           .fail(function (err) {
@@ -196,7 +198,9 @@
 
         return this.removeRelationship(relationship)
           .then(function () {
-            self.fetchAndUpdate(self.instance);
+            return self.instance.refresh();
+          })
+          .then(function () {
             self.instance.dispatch('refreshRelatedDocuments');
           })
           .fail(function (err) {
@@ -227,11 +231,6 @@
             document
           );
           self.attr('isLoading', false);
-        });
-      },
-      fetchAndUpdate: function (instance) {
-        instance.refresh().then(function (refreshed) {
-          refreshed.save();
         });
       }
     },

--- a/src/ggrc/models/hooks/relationship.py
+++ b/src/ggrc/models/hooks/relationship.py
@@ -5,12 +5,63 @@
 
 import sqlalchemy as sa
 
+from ggrc import db
 from ggrc.models import all_models
+from ggrc.services import signals
+from ggrc.services.common import log_event
 
 
 def init_hook():
   """Initialize Relationship-related hooks."""
+  # pylint: disable=unused-variable
+
   sa.event.listen(all_models.Relationship, "before_insert",
                   all_models.Relationship.validate_attrs)
   sa.event.listen(all_models.Relationship, "before_update",
                   all_models.Relationship.validate_attrs)
+
+  @signals.Restful.model_posted_after_commit.connect_via(
+      all_models.Relationship)
+  def handle_relationship_post(*args, **kwargs):
+    _handle_relationship_change(*args, **kwargs)
+
+  @signals.Restful.model_deleted_after_commit.connect_via(
+      all_models.Relationship)
+  def handle_relationship_delete(*args, **kwargs):
+    _handle_relationship_change(*args, **kwargs)
+
+  def _handle_relationship_change(
+      obj_type,
+      obj=None,
+      src=None,
+      service=None,
+      event=None
+  ):
+    """Handle a change to a Relationship instance (creation/removal).
+
+    If the Relationship represents a link between an object and a Document,
+    a new revision for that object is created.
+
+    Args:
+      obj_type: type(relationship)
+      obj: Relationship instance that was created/destroyed.
+      src: dictionary containing raw Relationship data sent with client request
+      service: instance of the service that handled the client request
+      event: ggrc.models.event.Event instance representing the event that has
+             occurred (e.g. object modified)
+
+    Returns:
+      None
+    """
+    # pylint: disable=unused-argument
+    doc_parent = None
+
+    if obj.source_type == 'Document':
+      doc_parent = obj.destination
+    elif obj.destination_type == 'Document':
+      doc_parent = obj.source
+
+    if not doc_parent:
+      return
+
+    log_event(db.session, doc_parent, force_obj=True)

--- a/test/integration/ggrc/models/factories.py
+++ b/test/integration/ggrc/models/factories.py
@@ -260,6 +260,10 @@ class EvidenceFactory(DocumentFactory):
   document_type = models.Document.ATTACHMENT
 
 
+class ReferenceUrlFactory(DocumentFactory):
+  document_type = models.Document.REFERENCE_URL
+
+
 class ObjectiveFactory(TitledFactory):
 
   class Meta:

--- a/test/integration/ggrc/models/test_relationship.py
+++ b/test/integration/ggrc/models/test_relationship.py
@@ -5,32 +5,49 @@
 
 import json
 
+from ggrc.models.all_models import Relationship, Revision
 from integration.ggrc import TestCase
+from integration.ggrc.api_helper import Api
 from integration.ggrc.models import factories
+
+
+def _object_revisions(obj):
+  """Return all revisions for an object, sorted ascendingly by IDs."""
+  query = Revision.query.filter(
+      (Revision.resource_id == obj.id) &
+      (Revision.resource_type == type(obj).__name__)
+  ).order_by(Revision.id.asc())
+
+  return query.all()
 
 
 class TestRelationship(TestCase):
   """Integration test suite for Relationship."""
+  # pylint: disable=invalid-name
 
   def setUp(self):
     """Create a Person, an Assessment, prepare a Relationship json."""
     super(TestRelationship, self).setUp()
 
+    self.api = Api()
     self.client.get("/login")
     self.person = factories.PersonFactory()
     self.assessment = factories.AssessmentFactory()
 
-  def _post_relationship(self, attr, value):
-    """POST a Relationship with attr between the Person and the Assessment."""
+  def _post_relationship(self, source_obj, dest_obj, attrs=None):
+    """POST a Relationship with attr between source_obj and dest_obj."""
+    if attrs is None:
+      attrs = {}
+
     headers = {
         "Content-Type": "application/json",
         "X-requested-by": "GGRC",
     }
     relationship_json = [{"relationship": {
-        "source": {"id": self.person.id, "type": "Person"},
-        "destination": {"id": self.assessment.id, "type": "Assessment"},
+        "source": {"id": source_obj.id, "type": source_obj.type},
+        "destination": {"id": dest_obj.id, "type": dest_obj.type},
         "context": {"id": None},
-        "attrs": {attr: value},
+        "attrs": attrs,
     }}]
     return self.client.post("/api/relationships",
                             data=json.dumps(relationship_json),
@@ -38,15 +55,50 @@ class TestRelationship(TestCase):
 
   def test_attrs_validation_ok(self):
     """Can create a Relationship with valid attrs."""
-    response = self._post_relationship("AssigneeType", "Creator")
+    response = self._post_relationship(
+        self.person, self.assessment, {"AssigneeType": "Creator"})
     self.assert200(response)
 
   def test_attrs_validation_invalid_attr(self):
     """Can not create a Relationship with invalid attr name."""
-    response = self._post_relationship("Invalid", "Data")
+    response = self._post_relationship(
+        self.person, self.assessment, {"Invalid": "Data"})
     self.assert400(response)
 
   def test_attrs_validation_invalid_value(self):
     """Can not create a Relationship with invalid attr value."""
-    response = self._post_relationship("AssigneeType", "Monkey")
+    response = self._post_relationship(
+        self.person, self.assessment, {"AssigneeType": "Monkey"})
     self.assert400(response)
+
+  def test_changing_object_documents_creates_object_revision(self):
+    """Changing object documents should generate new object revision."""
+    control = factories.ControlFactory()
+    url = factories.ReferenceUrlFactory(link=u"www.foo.com")
+
+    # attach an url to a control
+    response = self._post_relationship(control, url)
+    self.assert200(response)
+
+    rel_data = response.json[0][-1]["relationship"]
+    relationship = Relationship.query.get(rel_data["id"])
+
+    # check if a revision was created and contains the attached url
+    revisions = _object_revisions(control)
+    self.assertGreater(len(revisions), 0)
+    latest_version = revisions[-1].content
+
+    url_list = latest_version.get("reference_url", [])
+    link = url_list[0].get("link") if url_list else None
+    self.assertEqual(link, u"www.foo.com")
+
+    # now test whether a new revision is created when url is unmapped
+    response = self.api.delete(relationship)
+    self.assert200(response)
+
+    revisions = _object_revisions(control)
+    self.assertGreater(len(revisions), 0)
+    latest_version = revisions[-1].content
+
+    url_list = latest_version.get("reference_url", [])
+    self.assertEqual(url_list, [])


### PR DESCRIPTION
This PR fixes an issue with revisions created for **new** objects that have reference URLs added already in the new object modal. it's a follow-up to the PR #6050 that fixed a different backend issue, but with a same symptom on the frontend.

The issue here was that first the Document(s) and the object itself are created, and object revision is created at that moment. On the other hand, Relationship objects connecting the object with its documents (e.g. REFERENCE URLs) only gets created afterwards, resulting in Documents missing from the initial object revision.

This PR makes sure that whenever object's documents are modified (added/deleted), a new object revision gets created.

**TODO list:**
- [x] General code cleanup (docstrings, etc.)
- [x] Add tests
- [x] Fix creating now redundant revisions through an extra PUT request in the reference url list component.

---

**Steps to reproduce:**
1. Have program
1. Create a new Regulation through a modal and make sure to add at least one reference URL _already in the modal itself_, i.e. when creating the object.
1. Create an Audit and go to the audit page
1. Open Regulations tab, select the snapshot of a regulation created before, expand the pane and look at the reference URL field.

**Actual Result:**
Reference URLs are not shown on the snapshot

**Expected Result:**
Reference URLs should be shown on snapshots

NOTE: This issue only affect new objects. If a reference URL is added/removed from an object at a later point, a correct object revision gets created and the issue disappears.