### PR TITLE
GGRC-2351 Fix Assessment: 500 error while saving empty person type LCA/GCA

### DIFF
--- a/src/ggrc/models/custom_attribute_value.py
+++ b/src/ggrc/models/custom_attribute_value.py
@@ -248,7 +248,9 @@ class CustomAttributeValue(Base, Indexed, db.Model):
 
     Note: this validator does not check if id is a proper person id.
     """
-    if self.attribute_value and ":" in self.attribute_value:
+    if self.attribute_value is None:
+      self.attribute_object_id = None
+    elif ":" in self.attribute_value:
       value, id_ = self.attribute_value.split(":")
       self.attribute_value = value
       if not id_.isdigit():

--- a/src/ggrc/models/mixins/customattributable.py
+++ b/src/ggrc/models/mixins/customattributable.py
@@ -167,7 +167,7 @@ class CustomAttributable(object):
         mapping_type = definition.attribute_type[4:]
       for val in data['values']:
         attr_val = val['value']
-        if mapping_type:
+        if mapping_type and attr_val is not None:
           attr_val = "{}:{}".format(mapping_type, attr_val)
         if val.get("id"):
           vals[int(val['id'])].attribute_value = attr_val


### PR DESCRIPTION
Steps to reproduce:
1. Have mandatory GCA for assessment with Person type
2. Have audit with control snapshot
3. On the audit page create assessment template with mandatory person LCA
4. Generate assessment based on control snapshot and assessment template
5. Navigate to assessment info pane and fill LCA and GCA with person type, save values
6. Remove values from LCA and GCA with person type, save
7. Fill LCA and GCA with person type once again and save values
8. Look in Console: 500 error is displayed and value is not saved
Actual Result: 500 error is displayed in console while saving value in mandatory person type LCA/ GCA and value is not saved. Assessment couldn't be completed if mandatory CA is not filled or value is not saved
