### PR TITLE
Send correct reference URL data for snapshots

### DIFF
--- a/src/ggrc/models/revision.py
+++ b/src/ggrc/models/revision.py
@@ -180,6 +180,10 @@ class Revision(Base, db.Model):
       reference_url_list = []
       for key in ('url', 'reference_url'):
         link = self._content[key]
+        # link might exist, but can be an empty string - we treat those values
+        # as non-existing (empty) reference URLs
+        if not link:
+          continue
         reference_url_list.append({
             "display_name": link,
             "document_type": "REFERENCE_URL",


### PR DESCRIPTION
If an old object revision contains an attribute containing reference
URL data, and its value is empty, we treat that as a non-existent
value and thus do not create any REFERENCE_URL document instances
in that particular Revision.