### PR TITLE
GGRC-2232 Tree view is not automatically refreshed if fill CAs with rich text type

### DIFF
--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -270,6 +270,7 @@ dashboard-js-files:
   - components/tree/tree-filter-input.js
   - components/tree/tree-status-filter.js
   - components/tree/tree-item-status-for-workflow.js
+  - components/tree/tree-item-custom-attribute.js
   - components/cycle-task-actions/cycle-task-actions.js
   - components/view-object-buttons/view-object-buttons.js
   - components/add-object-button/add-object-button.js
@@ -527,6 +528,7 @@ dashboard-js-template-files:
   - components/tree/tree-header.mustache
   - components/tree/tree-filter-input.mustache
   - components/tree/tree-item-status-for-workflow.mustache
+  - components/tree/tree-item-custom-attribute.mustache
   - components/cycle-task-actions/cycle-task-actions.mustache
   - components/simple-modal/simple-modal.mustache
   - components/simple-popover/simple-popover.mustache

--- a/src/ggrc/assets/javascripts/components/tree/tree-item-custom-attribute.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-item-custom-attribute.js
@@ -1,0 +1,23 @@
+/*!
+ Copyright (C) 2017 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+(function (can, GGRC) {
+  'use strict';
+
+  var template = can.view(GGRC.mustache_path +
+    '/components/tree/tree-item-custom-attribute.mustache');
+
+  var viewModel = can.Map.extend({
+    instance: null,
+    values: [],
+    column: {}
+  });
+
+  GGRC.Components('treeItemCustomAttribute', {
+    tag: 'tree-item-custom-attribute',
+    template: template,
+    viewModel: viewModel
+  });
+})(window.can, window.GGRC);

--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -2479,9 +2479,14 @@ Mustache.registerHelper('get_url_value', function (attr_name, instance) {
     function (attr, instance, options) {
       var value = '';
       var definition;
+      var customAttrItem;
+      var getValue;
 
       attr = Mustache.resolve(attr);
       instance = Mustache.resolve(instance);
+      customAttrItem = Mustache.resolve(
+        (options.hash || {}).customAttrItem
+      );
 
       can.each(GGRC.custom_attr_defs, function (item) {
         if (item.definition_type === instance.class.table_singular &&
@@ -2491,7 +2496,7 @@ Mustache.registerHelper('get_url_value', function (attr_name, instance) {
       });
 
       if (definition) {
-        can.each(instance.custom_attribute_values, function (item) {
+        getValue = function (item) {
           if (!(instance instanceof CMS.Models.Assessment)) {
             // reify all models with the exception of the Assessment,
             // because it has a different logic of work with the CA
@@ -2507,7 +2512,13 @@ Mustache.registerHelper('get_url_value', function (attr_name, instance) {
               value = item.attribute_value;
             }
           }
-        });
+        };
+
+        if (!_.isUndefined(customAttrItem)) {
+          getValue(customAttrItem);
+        } else {
+          can.each(instance.custom_attribute_values, getValue);
+        }
       }
 
       return value;

--- a/src/ggrc/assets/js_specs/mustache_helpers/get_custom_attr_value_spec.js
+++ b/src/ggrc/assets/js_specs/mustache_helpers/get_custom_attr_value_spec.js
@@ -1,0 +1,102 @@
+/*!
+  Copyright (C) 2017 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+describe('can.mustache.helper.get_custom_attr_value', function () {
+  'use strict';
+
+  var helper;
+  var fakeAttr;
+  var fakeInstance;
+  var fakeOptions;
+  var fakeCustomAttrDefs;
+  var origValue;
+  var getHash;
+
+  beforeAll(function () {
+    helper = can.Mustache._helpers.get_custom_attr_value.fn;
+
+    fakeCustomAttrDefs = [{
+      definition_type: 'control',
+      id: 3,
+      attribute_type: '',
+      title: 'Type'
+    }];
+
+    origValue = GGRC.custom_attr_defs;
+    GGRC.custom_attr_defs = fakeCustomAttrDefs;
+
+    getHash = function (attrValue) {
+      var value = new can.Map({
+        customAttrItem: {
+          attribute_value: attrValue,
+          custom_attribute_id: 3
+        }
+      });
+
+      spyOn(value.customAttrItem, 'reify')
+        .and.returnValue(value.customAttrItem);
+
+      return value;
+    };
+  });
+
+  afterAll(function () {
+    GGRC.custom_attr_defs = origValue;
+  });
+
+  beforeEach(function () {
+    fakeInstance = {};
+    fakeAttr = {};
+    fakeOptions = {};
+    fakeInstance.class = {table_singular: 'control'};
+
+    fakeAttr.attr_name = 'Type';
+  });
+
+  it('reify() is exec if instance is not an Assessment', function () {
+    fakeOptions.hash = getHash();
+    helper(fakeAttr, fakeInstance, fakeOptions);
+
+    expect(fakeOptions.hash.customAttrItem.reify).toHaveBeenCalled();
+  });
+
+  it('return correct value if customAttrItem is undefined', function () {
+    var value;
+    fakeOptions.hash = false;
+    fakeInstance.custom_attribute_values = [
+      getHash('correctValue').customAttrItem
+    ];
+    value = helper(fakeAttr, fakeInstance, fakeOptions);
+
+    expect(value).toEqual('correctValue');
+  });
+
+  it('return correct value if customAttrItem is not undefined', function () {
+    var value;
+    fakeOptions.hash = getHash('correctValue');
+    value = helper(fakeAttr, fakeInstance, fakeOptions);
+
+    expect(value).toEqual('correctValue');
+  });
+
+  it('fn() exec and return correct value (person type)', function () {
+    fakeOptions = {
+      hash: getHash(),
+      contexts: {
+        add: function () {
+          return 'correctValue';
+        }
+      },
+      fn: function (value) {
+        return value;
+      }
+    };
+    spyOn(fakeOptions, 'fn');
+    fakeCustomAttrDefs[0].attribute_type = 'Map:';
+    helper(fakeAttr, fakeInstance, fakeOptions);
+
+    expect(fakeOptions.fn).toHaveBeenCalledWith('correctValue');
+  });
+});

--- a/src/ggrc/assets/mustache/components/tree/tree-item-custom-attribute.mustache
+++ b/src/ggrc/assets/mustache/components/tree/tree-item-custom-attribute.mustache
@@ -1,0 +1,14 @@
+{{!
+    Copyright (C) 2017 Google Inc.
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+}}
+
+{{#values}}
+  {{#get_custom_attr_value column instance customAttrItem=.}}
+      {{! because the object can currently only be a
+      person there is no need to switch }}
+      <tree-people-list-field {source}="object">
+          {{peopleStr}}
+      </tree-people-list-field>
+  {{/get_custom_attr_value}}
+{{/values}}

--- a/src/ggrc/assets/mustache/components/tree/tree-item.mustache
+++ b/src/ggrc/assets/mustache/components/tree/tree-item.mustache
@@ -20,13 +20,10 @@
             {{#switch attr_type}}
               {{#case 'custom'}}
                 <div class="custom attr-content">
-                  {{#get_custom_attr_value thisColumn instance}}
-                     {{! because the object can currently only be a
-                      person there is no need to switch }}
-                      <tree-people-list-field {source}="object">
-                          {{peopleStr}}
-                      </tree-people-list-field>
-                  {{/get_custom_attr_value}}
+                  <tree-item-custom-attribute {instance}="instance"
+                                              {values}="instance.custom_attribute_values"
+                                              {column}="thisColumn"
+                  ></tree-item-custom-attribute>
                 </div>
               {{/case}}
 


### PR DESCRIPTION
Steps to reproduce: 
1. Have GCA with rich text type for Control 
2. Go to My work page > Control's tab 
3. Set Rich text column to be displayed in tree view 
4. Fill GCA field with rich text type on Info pane 
5. Look at the Control's first tier in tree view: data in rich text is not shown 