### PR TITLE
GGRC-2933 (part2) Explicitly provide created/updated date for URLs

### DIFF
--- a/src/ggrc/models/revision.py
+++ b/src/ggrc/models/revision.py
@@ -185,12 +185,22 @@ class Revision(Base, db.Model):
       # as non-existing (empty) reference URLs
       if not link:
         continue
+
+      # if creation/modification date is not available, we estimate it by using
+      # the corresponding information from the Revision itself
+      created_at = (self._content.get("created_at") or
+                    self.created_at.isoformat())
+      updated_at = (self._content.get("updated_at") or
+                    self.updated_at.isoformat())
+
       reference_url_list.append({
           "display_name": link,
           "document_type": "REFERENCE_URL",
           "link": link,
           "title": link,
-          "id": None
+          "id": None,
+          "created_at": created_at,
+          "updated_at": updated_at,
       })
     return {'reference_url': reference_url_list}
 


### PR DESCRIPTION
This PR fixes "invalid date" sometimes shown on snapshot info panes under the object's reference URLs. 

It's a follow up to #6052 and fixes an issue that was subsequently discovered for what seem to be some very old object revisions containing reference URLs. While the old fix handled skipping empty reference URL data, this fix handles non-empty data by explicitly providing created/updated at dates for every reference URL data object sent to the client.

---

**Steps to reproduce:**
1. Select a snapshotted object in a tree view to open its info pane. If using a recent ggrc-qa database, an example of such object suffering from the problem is the following: `<host>/audits/4182#control_widget`, a control snapshot titled "Startupsum 128".

2. Look at the object's reference URLs.

**Actual result:**
"Invalid date" string is displayed under the items in the reference URLs list.

**Expected result:**
The actual date in US format is displayed under each item in the reference URLs list.