### PR TITLE
GGRC-2486 Fix alignment of "Add required info" link

### DIFF
--- a/src/ggrc/assets/stylesheets/components/auto-save-form/_auto-save-form.scss
+++ b/src/ggrc/assets/stylesheets/components/auto-save-form/_auto-save-form.scss
@@ -52,7 +52,7 @@ auto-save-form {
     }
 
     .form-field__content {
-      max-width: 100%;
+      max-width: 360px;
     }
 
     .form-field__validation-hint-placeholder {
@@ -65,10 +65,6 @@ auto-save-form {
       top: 0;
       left: 0;
     }
-  }
-
-  .input-wrapper {
-    max-width: 360px;
   }
 }
 


### PR DESCRIPTION
The link was sliding to far from the related dropdown on a wide screen
monitor.