### PR TITLE
GGRC-2192 Add a tooltip to clarify object status in GGRC

### DIFF
--- a/src/ggrc/assets/javascripts/components/tree/tree-widget-container.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-widget-container.js
@@ -57,6 +57,12 @@
           return GGRC.Utils.State.hasFilter(this.attr('modelName'));
         }
       },
+      statusTooltipVisible: {
+        type: Boolean,
+        get: function () {
+          return GGRC.Utils.State.hasFilterTooltip(this.attr('modelName'));
+        }
+      },
       cssClasses: {
         type: String,
         get: function () {

--- a/src/ggrc/assets/javascripts/plugins/utils/state-utils.js
+++ b/src/ggrc/assets/javascripts/plugins/utils/state-utils.js
@@ -75,6 +75,15 @@
     }
 
     /**
+     * Check if tooltip should be shown for filter by state
+     * @param {String} model - The model name
+     * @return {Boolean} True or False
+     */
+    function hasFilterTooltip(model) {
+      return model === 'Product' || model === 'System';
+    }
+
+    /**
      * Get States-Models pair.
      * @param {String} model - The model name
      * @return {Object} object with 'models' and 'states' properties
@@ -212,6 +221,7 @@
     return {
       hasState: hasState,
       hasFilter: hasFilter,
+      hasFilterTooltip: hasFilterTooltip,
       statusFilter: statusFilter,
       unlockedFilter: unlockedFilter,
       getStatesForModel: getStatesForModel,

--- a/src/ggrc/assets/mustache/components/tree/tree-widget-container.mustache
+++ b/src/ggrc/assets/mustache/components/tree/tree-widget-container.mustache
@@ -26,6 +26,10 @@
             plural="States"
             {disabled}="advancedSearch.filter">
           </multiselect-dropdown>
+          {{#if statusTooltipVisible}}
+            <i class="fa fa-question-circle" rel="tooltip"
+              title="The state represents the state of this object information within GGRC. It does not indicate the state of the underlying product or system."></i>
+          {{/if}}
         </tree-status-filter>
       {{/if}}
       {{^if noResults}}

--- a/src/ggrc/assets/stylesheets/components/tree/_tree-view.scss
+++ b/src/ggrc/assets/stylesheets/components/tree/_tree-view.scss
@@ -313,6 +313,22 @@ tree-filter-input {
   }
 }
 
+tree-status-filter {
+  display: flex;
+  align-items: center;
+
+  .fa-question-circle {
+    opacity: 0.7;
+    transition: opacity 0.2s ease;
+    margin: 0 0 0 8px;
+    color: $black;
+    &:hover {
+      opacity: 1;
+      cursor: pointer;
+    }
+  }
+}
+
 tree-header {
   .tree-header {
     align-items: center;


### PR DESCRIPTION
There is some confusion between the status of the object (marked active / draft/ deprecated) in GGRC to the actual status of the underlying system of product.

_Expected result:_
The tool tip should be added for status attribute on tree view of products or system:
Tool tip text is "The state represents the state of this object information within GGRC. It does not indicate the state of the underlying product or system"