### PR TITLE
GGRC-2981 Cannot add custom attribute in Edit Assessment template

### DIFF
--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -325,6 +325,7 @@
     destroy: 'DELETE /api/assessment_templates/{id}',
     create: 'POST /api/assessment_templates',
     is_custom_attributable: false,
+    hasCustomAttributes: true,
     attributes: {
       audit: 'CMS.Models.Audit.stub',
       context: 'CMS.Models.Context.stub'

--- a/src/ggrc/assets/javascripts/models/cacheable.js
+++ b/src/ggrc/assets/javascripts/models/cacheable.js
@@ -633,7 +633,7 @@
         return params;
       }
       // Temporary Solution to fix saving of Custom Attributable Instances
-      if (this.is_custom_attributable) {
+      if (this.is_custom_attributable || this.hasCustomAttributes) {
         if (params.local_attributes) {
           delete params.local_attributes;
         }


### PR DESCRIPTION
**Steps to reproduce:**
1. Have audit with Assessment template
2. Go to the Assessment template tab and invoke Edit Assessment template modal window
3. Add custom attribute and Save 
4. Invoke Edit Assessment template modal window once again and look at the custom attributes: custom attribute is not saved

**Actual Result:**
Cannot add custom attribute in Edit Assessment template

**Expected Result**:
User should have the possibility to edit/add custom attributes into Edit Assessment template modal window
