### PR TITLE
GGRC-2072 Create testing framework read only filter integration tests

### DIFF
--- a/bin/create_apisearch_dump
+++ b/bin/create_apisearch_dump
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+TEST_DB_NAME="ggrcdevtest_apisearch"
+SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
+HOST=${GGRC_DATABASE_HOST-"127.0.0.1"}
+DB_NAME="ggrcdevtest_apisearch"
+DUMP_FILE="api_search.sql"
+DUMP_PATH_NAME="${SCRIPTPATH}/../test/api_search/db_dump/${DUMP_FILE}"
+cd "${SCRIPTPATH}/../test"
+find . -iname "*.pyc" -delete
+
+export GGRC_SETTINGS_MODULE="testing \
+  testing_api_search_db \
+  ggrc_basic_permissions.settings.development \
+  ggrc_risk_assessments.settings.development \
+  ggrc_risks.settings.development \
+  ggrc_workflows.settings.development \
+  ggrc_gdrive_integration.settings.development"
+
+mysql -uroot -proot -h$HOST -e "DROP DATABASE IF EXISTS ${DB_NAME}; CREATE DATABASE ${DB_NAME} CHARACTER SET utf8; USE ${DB_NAME};"
+db_migrate
+
+echo "Fill database with test setup data"
+python -c "\
+from api_search.setup_environment import SetupEnvironment
+SetupEnvironment()
+"
+
+mysqldump -uroot -proot -h$HOST $TEST_DB_NAME > $DUMP_PATH_NAME

--- a/bin/db_reset
+++ b/bin/db_reset
@@ -7,6 +7,7 @@ set -o errexit
 
 
 DB_NAME="ggrcdev"
+API_SEARCH_DB_NAME="ggrcdevtest_apisearch"
 SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
 ROOT_PATH="${SCRIPTPATH}/../"
 DUMP_FILE=${1:-}
@@ -34,6 +35,8 @@ fi
 
 mysql -uroot -proot -h$HOST -e "drop database if exists $DB_NAME"
 mysql -uroot -proot -h$HOST -e "create database $DB_NAME character set utf8"
+mysql -uroot -proot -h$HOST -e "DROP DATABASE IF EXISTS $API_SEARCH_DB_NAME"
+mysql -uroot -proot -h$HOST -e "CREATE DATABASE $API_SEARCH_DB_NAME CHARACTER SET utf8"
 
 if [[ -f "$DUMP_FILE" ]]; then
   echo "Importing: $DUMP_FILE"

--- a/bin/run_api_search
+++ b/bin/run_api_search
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
+HOST=${GGRC_DATABASE_HOST-"127.0.0.1"}
+DB_NAME="ggrcdevtest_apisearch"
+DUMP_NAME="api_search.sql"
+DUMP_PATH="${SCRIPTPATH}/../test/api_search/db_dump/${DUMP_NAME}"
+cd "${SCRIPTPATH}/../test"
+find . -iname "*.pyc" -delete
+
+export GGRC_SETTINGS_MODULE="testing \
+  testing_api_search_db \
+  ggrc_basic_permissions.settings.development \
+  ggrc_risk_assessments.settings.development \
+  ggrc_risks.settings.development \
+  ggrc_workflows.settings.development \
+  ggrc_gdrive_integration.settings.development"
+
+if [[ ! -f "$DUMP_PATH" ]]; then
+  echo "File $DUMP_PATH wasn't found. New one will be created"
+  create_apisearch_dump
+fi
+
+echo "Recreating test db from: $DUMP_PATH"
+mysql -uroot -proot -h$HOST $DB_NAME < $DUMP_PATH
+
+echo -e "\nRunning api_search tests"
+nosetests api_search --logging-clear-handlers -v ${@:1}

--- a/src/ggrc/models/mixins/__init__.py
+++ b/src/ggrc/models/mixins/__init__.py
@@ -163,7 +163,9 @@ class ChangeTracked(object):
   _fulltext_attrs = [
       attributes.DatetimeFullTextAttr('created_at', 'created_at'),
       attributes.DatetimeFullTextAttr('updated_at', 'updated_at'),
-      attributes.FullTextAttr("modified_by", "modified_by", ["name", "email"]),
+      attributes.FullTextAttr(
+          "modified_by", "modified_by", ["name", "email", "user_name"]
+      ),
   ]
 
   _aliases = {

--- a/src/ggrc/settings/testing_api_search_db.py
+++ b/src/ggrc/settings/testing_api_search_db.py
@@ -1,0 +1,7 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+"""Api search test settings."""
+import os
+
+SQLALCHEMY_DATABASE_URI = 'mysql+mysqldb://root:root@{}/ggrcdevtest_apisearch'\
+    .format(os.environ.get('GGRC_DATABASE_HOST', 'localhost'))

--- a/test/api_search/__init__.py
+++ b/test/api_search/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>

--- a/test/api_search/base.py
+++ b/test/api_search/base.py
@@ -1,0 +1,61 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""This module contains SingleSetupQueryAPITest class definition."""
+# pylint: disable=too-many-arguments
+from sqlalchemy import Column, Integer, String, Boolean
+
+from ggrc import app  # noqa  # pylint: disable=unused-import
+from ggrc import db  # noqa  # pylint: disable=unused-import
+from ggrc.models import Snapshot
+from integration.ggrc import TestCase
+from integration.ggrc.query_helper import WithQueryApi
+
+TEST_REPEAT_COUNT = 3
+MULTIPLE_ITEMS_COUNT = 2
+
+OPERATIONS = {
+    "=": "equal",
+    "!=": "not_equal",
+    "~": "contains",
+    "!~": "not_contains",
+    "is empty": "is_empty",
+}
+
+# pylint: disable=invalid-name
+snapshot_mapping = {}  # Mapping snapshot_id to object id
+
+
+# pylint: disable=too-few-public-methods
+class SetupData(db.Model):
+  """Class containing all test cases information"""
+  __tablename__ = 'setup_data'
+
+  id = Column(Integer, primary_key=True)
+  model = Column(String(100))
+  operator = Column(String(30))
+  field = Column(String(200))
+  single = Column(Boolean, nullable=False, default=True)
+  obj_id = Column(Integer)
+  searchable_id = Column(Integer)
+  searchable_type = Column(String(100))
+
+
+# pylint: disable=too-few-public-methods
+class SingleSetupQueryAPITest(TestCase, WithQueryApi):
+  """
+  Base Class for a test container, setting up the environment for the exact
+  test fixture
+  """
+  _data_installed = False
+
+  def setUp(self):
+    """Set up working environment"""
+    if not SingleSetupQueryAPITest._data_installed:
+      SingleSetupQueryAPITest._data_installed = True
+      # pylint: disable=global-statement
+      global snapshot_mapping
+      snapshot_mapping.update(db.session.query(Snapshot.id, Snapshot.child_id))
+
+    self._custom_headers = {}
+    self.client.get("/login")

--- a/test/api_search/helpers.py
+++ b/test/api_search/helpers.py
@@ -1,0 +1,59 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""This module contains helper functions for working with api search tests."""
+
+import uuid
+from collections import namedtuple
+
+from api_search.setters import AC_ROLES, CAD_PERSON_TITLE
+from ggrc.fulltext import get_indexer
+from ggrc.models import all_models
+from ggrc.snapshotter.indexer import reindex_snapshots
+from ggrc.snapshotter.rules import Types
+from integration.ggrc import TestCase
+from integration.ggrc.models import factories
+
+
+def create_reindexed_snapshots(audit_id, objects):
+  """Create snapshots for list of provided objects and reindex them"""
+  # pylint: disable=protected-access
+  snapshottable_objects = [o for o in objects if o.type in Types.all]
+  audit = all_models.Audit.query.get(audit_id)
+  snapshots = TestCase._create_snapshots(audit, snapshottable_objects)
+  reindex_snapshots_ids = [snap.id for snap in snapshots]
+  get_indexer().delete_records_by_ids("Snapshot",
+                                      reindex_snapshots_ids,
+                                      commit=False)
+  reindex_snapshots(reindex_snapshots_ids)
+
+
+def create_tuple_data(obj_id, searchable, subprops):
+  """Create tuple with expected object id and subproperties of
+  searchable object"""
+  expected = namedtuple("expected_row", "props id")
+  if searchable:
+    subprop_vals = [getattr(searchable, sp) for sp in subprops]
+    property_vals = namedtuple("property_vals", " ".join(subprops))
+    expected.props = property_vals(*subprop_vals)
+  else:
+    expected.props = []
+  expected.id = obj_id
+  return expected
+
+
+def create_rand_person():
+  """Create user with random username, name and email"""
+  user_name = uuid.uuid1()
+  return factories.PersonFactory(
+      # Make User Name different from Name
+      name="User {}".format(user_name),
+      email="{}@example.com".format(user_name)
+  )
+
+
+def field_exists(model, field):
+  """Check if field exists for provided model"""
+  return hasattr(model, field) or \
+      field in AC_ROLES[model.__name__] or \
+      field == CAD_PERSON_TITLE

--- a/test/api_search/setters.py
+++ b/test/api_search/setters.py
@@ -1,0 +1,83 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""This module contains setter functions for different types of object
+fields."""
+
+from collections import defaultdict
+
+from ggrc import utils, db
+from ggrc.access_control.role import get_custom_roles_for
+from ggrc.app import app
+
+from ggrc.models import all_models
+from integration.ggrc.models import factories
+
+CAD_PERSON_TYPE = "Map:Person"
+CAD_PERSON_TITLE = "CA_Person"
+
+AC_ROLES = defaultdict(dict)
+CADS = defaultdict(dict)
+
+
+def init_globals(models):
+  """Load all ACRs and CADs into memory from db"""
+  with app.app_context():
+    with factories.single_commit():
+      for model in models:
+        AC_ROLES[model] = {
+            name: id for id, name in
+            get_custom_roles_for(model).items()
+        }
+
+        CADS[model] = {
+            CAD_PERSON_TYPE: factories.CustomAttributeDefinitionFactory(
+                title=CAD_PERSON_TITLE,
+                definition_type=utils.underscore_from_camelcase(model),
+                attribute_type=CAD_PERSON_TYPE,
+            ).id
+        }
+
+
+def generate_cad_attr_setter(cad_type):
+  """Generate object setter function for CAV field"""
+  def set_obj_attr(model, val):
+    return {
+        "custom_attribute_values_": [{
+            "attribute_value": val.type,
+            "attribute_object_id": val.id,
+            "custom_attribute_id": CADS[model][cad_type],
+        }]
+    }
+  return set_obj_attr
+
+
+def generate_acr_attr_setter(role_name):
+  """Generate object setter function for ACL related field"""
+  def set_obj_attr(model, person):
+    return {
+        "access_control_list_": [{
+            "ac_role_id": AC_ROLES[model][role_name],
+            "person_id": person.id
+        }]
+    }
+  return set_obj_attr
+
+
+def generate_foreign_attr_setter(field):
+  """Generate object setter function for foreign key field"""
+  def set_obj_attr(_, val):
+    return {field: val}
+  return set_obj_attr
+
+
+FIELD_SETTERS = {
+    "modified_by": generate_foreign_attr_setter("modified_by"),
+    CAD_PERSON_TITLE: generate_cad_attr_setter(CAD_PERSON_TYPE),
+}
+FIELD_SETTERS.update({
+    role[0]: generate_acr_attr_setter(role[0]) for role in
+    db.session.query(all_models.AccessControlRole.name)
+              .filter(all_models.AccessControlRole.non_editable)
+              .distinct()
+})

--- a/test/api_search/setup_environment.py
+++ b/test/api_search/setup_environment.py
@@ -1,0 +1,173 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""This module contains TestSetup class definition with functionality for
+test data installation."""
+# pylint: disable=too-many-arguments
+from ggrc import db, app
+from ggrc.models import inflector
+from ggrc.snapshotter.rules import Types
+
+from integration.ggrc.models import factories
+
+from api_search.base import SetupData, OPERATIONS, TEST_REPEAT_COUNT, \
+    MULTIPLE_ITEMS_COUNT
+from api_search.helpers import field_exists, create_reindexed_snapshots, \
+    create_rand_person
+from api_search.setters import init_globals, FIELD_SETTERS
+
+
+class SetupEnvironment(object):
+  """Single setup class (data will be installed only in first call)"""
+  def __init__(self):
+    """Set up basic test fixture with the following data:
+    - Persons and Roles
+    - Searchable model instance
+    - basic test cases
+    """
+    if not db.engine.dialect.has_table(db.engine, SetupData.__tablename__):
+      SetupData.__table__.create(db.engine)
+
+    objects = []
+    init_globals(Types.all)
+    with factories.single_commit():
+      audit_id = factories.AuditFactory().id
+      for model in Types.all:
+        for field in FIELD_SETTERS:
+          if field_exists(inflector.get_model(model), field):
+            for operation in OPERATIONS:
+              objects += self.base_single_setup(model, field, operation)
+              objects += self.base_multiple_setup(model, field, operation)
+
+    with app.app.app_context():
+      create_reindexed_snapshots(audit_id, objects)
+
+  def base_single_setup(self, model_name, field, operation):
+    """Set up basic test fixture with the following data:
+    - Persons and Roles
+    - Searchable model instance
+    - basic test cases
+    """
+    setup_func = self.get_setup_func(operation, True)
+    objects = []
+    for _ in range(TEST_REPEAT_COUNT):
+      objects.append(
+          setup_func(model_name, field, create_rand_person())
+      )
+    return objects
+
+  def base_multiple_setup(self, model_name, field, operation):
+    """Set up basic test fixture with the following data:
+    - Persons and Roles
+    - Searchable model instance
+    - basic test cases
+    """
+    persons = []
+    for _ in range(MULTIPLE_ITEMS_COUNT + 1):
+      persons.append(create_rand_person())
+    setup_func = self.get_setup_func(operation, False)
+    return setup_func(model_name, field, persons)
+
+  def single_setup_equal(self, model_name, field, person, operator="="):
+    """Setup single entry for equal operation"""
+    obj_factory = self.get_factory(model_name)
+    obj = obj_factory(**FIELD_SETTERS[field](model_name, person))
+    db.session.add(SetupData(
+        model=model_name, operator=operator, field=field, single=True,
+        obj_id=obj.id, searchable_id=person.id, searchable_type=person.type
+    ))
+    return obj
+
+  def multiple_setup_equal(self, model_name, field, persons, operator="="):
+    """Setup multiple entry for equal operation"""
+    obj_factory = self.get_factory(model_name)
+    objects = []
+    for num, _ in enumerate(persons):
+      # Set one person for several objects
+      if num < MULTIPLE_ITEMS_COUNT:
+        person = persons[0]
+      else:
+        person = persons[num]
+
+      obj = obj_factory(**FIELD_SETTERS[field](model_name, person))
+      db.session.add(SetupData(
+          model=model_name, operator=operator, field=field, single=False,
+          obj_id=obj.id, searchable_id=person.id, searchable_type=person.type
+      ))
+      objects.append(obj)
+    return objects
+
+  def single_setup_not_equal(self, model_name, field, person, operator="!="):
+    # For now single setup is the same
+    return self.single_setup_equal(model_name, field, person, operator)
+
+  def multiple_setup_not_equal(self, model_name, field, persons,
+                               operator="!="):
+    # For now multiple setup is the same
+    return self.multiple_setup_equal(model_name, field, persons, operator)
+
+  def single_setup_contains(self, model_name, field, person, operator="~"):
+    # For now single setup is the same
+    return self.single_setup_equal(model_name, field, person, operator)
+
+  def multiple_setup_contains(self, model_name, field, persons, operator="~"):
+    # For now multiple setup is the same
+    return self.multiple_setup_equal(model_name, field, persons, operator)
+
+  def single_setup_not_contains(self, model_name, field, person,
+                                operator="!~"):
+    # For now single setup is the same
+    return self.single_setup_equal(model_name, field, person, operator)
+
+  def multiple_setup_not_contains(self, model_name, field, persons,
+                                  operator="!~"):
+    # For now multiple setup is the same
+    return self.multiple_setup_equal(model_name, field, persons, operator)
+
+  def single_setup_is_empty(self, model_name, field, person,
+                            operator="is empty"):
+    # For now single setup is the same
+    return self.single_setup_equal(model_name, field, person, operator)
+
+  def multiple_setup_is_empty(self, model_name, field, persons,
+                              operator="is empty"):
+    """Setup multiple entry for is_empty operation"""
+    obj_factory = self.get_factory(model_name)
+    objects = []
+    for num, _ in enumerate(persons):
+      # Don't set searchable field for several objects, they should be empty
+      if num >= MULTIPLE_ITEMS_COUNT:
+        obj = obj_factory(**FIELD_SETTERS[field](model_name, persons[num]))
+      else:
+        obj = factories.get_model_factory(model_name)()
+      db.session.add(SetupData(
+          model=model_name, operator=operator, field=field, single=False,
+          obj_id=obj.id, searchable_id=persons[num].id,
+          searchable_type=persons[num].type
+      ))
+      objects.append(obj)
+    return objects
+
+  def get_setup_func(self, operation, single):
+    """Find setup func by test case parameters"""
+    setup_name = "{}_setup_{}".format(
+        "single" if single else "multiple",
+        OPERATIONS[operation],
+    )
+    if not getattr(self, setup_name):
+      raise NotImplementedError(
+          "Setup {} was not implemented in BaseSetup class".format(setup_name)
+      )
+    return getattr(self, setup_name)
+
+  def get_factory(self, model_name):
+    """Get object factory class for model"""
+    # pylint: disable=no-self-use
+    base_factory = factories.get_model_factory(model_name)
+    # Modify base factory to have possibility to create ACL
+    # and CA in one step
+    return type(
+        base_factory.__name__ + "WithACL_CA",
+        (base_factory, factories.WithACLandCAFactory),
+        {}
+    )

--- a/test/api_search/test_acr.py
+++ b/test/api_search/test_acr.py
@@ -1,0 +1,15 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""This module contains AC roles test classes definition."""
+from api_search.test_person_filters_complete import generate_classes
+from ggrc import db
+from ggrc.models import all_models
+from ggrc.snapshotter.rules import Types
+
+
+AC_ROLES = db.session.query(all_models.AccessControlRole.name) \
+                     .filter(all_models.AccessControlRole.non_editable) \
+                     .distinct()
+for ac_role in AC_ROLES:
+  generate_classes(Types.all, ac_role[0])

--- a/test/api_search/test_ca_person.py
+++ b/test/api_search/test_ca_person.py
@@ -1,0 +1,9 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""This module contains CA Map:Person test classes definition."""
+from api_search.test_person_filters_complete import generate_classes
+from ggrc.snapshotter.rules import Types
+
+
+generate_classes(Types.all, "CA_Person")

--- a/test/api_search/test_modified_by_field.py
+++ b/test/api_search/test_modified_by_field.py
@@ -1,0 +1,9 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""This module contains 'modified_by' filter test classes definition."""
+from api_search.test_person_filters_complete import generate_classes
+from ggrc.snapshotter.rules import Types
+
+
+generate_classes(Types.all, "modified_by")

--- a/test/api_search/test_person_filters_complete.py
+++ b/test/api_search/test_person_filters_complete.py
@@ -1,0 +1,393 @@
+# coding: utf-8
+
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Tests for /query api endpoint."""
+# pylint: disable=too-many-arguments
+# pylint: disable=too-few-public-methods
+import itertools
+import re
+
+import sys
+from six import add_metaclass
+from sqlalchemy import or_, and_
+
+from api_search.base import OPERATIONS, MULTIPLE_ITEMS_COUNT,\
+    SingleSetupQueryAPITest, snapshot_mapping, SetupData
+from api_search.helpers import create_tuple_data
+
+from ggrc import db
+from ggrc.models import inflector
+from ggrc.snapshotter.rules import Types
+
+
+class BaseTestMeta(type):
+  """Metaclass for generation tests by parameters provided into Meta:
+  model, field, subprops, operators, order, property_case, value_case """
+  @classmethod
+  def meta_factory(mcs, instance):
+    """Factory updating the instance with meta data needed in tests
+
+    Args:
+      instance: Created class (result of __new__)
+    """
+    meta_params = {}
+    if hasattr(instance, "Meta"):
+      bases = [
+          class_ for class_ in reversed(instance.__mro__)
+          if issubclass(class_, SingleSetupQueryAPITest) and
+          hasattr(class_, "Meta")
+      ]
+      for base in bases:
+        meta_params.update(base.Meta.__dict__.iteritems())
+    instance.Meta = type("Meta", (object, ), meta_params)
+
+  def __new__(mcs, name, bases, attrs):
+    """Constructor for a new test class instance."""
+    instance = super(BaseTestMeta, mcs).__new__(mcs, name, bases, attrs)
+    mcs.meta_factory(instance)
+    if not hasattr(instance.Meta, "model"):
+      return instance
+    for params in mcs.vary_params(instance.Meta):
+      base_names = [("_filter_by_single_person", True),
+                    ("_filter_by_multi_person", False)]
+      for base_name, is_single in base_names:
+        test_name = mcs._generate_test_name(base_name, params)
+        func = mcs._generate_test_filter(instance.Meta, is_single, *params)
+        func.__name__ = test_name
+        setattr(instance, test_name, func)
+        setattr(instance, "operator", params[0])
+    return instance
+
+  @staticmethod
+  def _generate_test_name(base_name, params):
+    """Generates unique test case name
+
+    Args:
+      base_name: Name for the tests being generated
+      params: Params with which the test would be called (to make test
+                   name unique)
+
+    Returns:
+      String with a test case name
+    """
+    temp_name = "test{}".format(base_name)
+    for param in params:
+      if param in OPERATIONS:
+        temp_name += "_{}_".format(OPERATIONS[param])
+      else:
+        temp_name += "_{}_".format(param)
+
+    non_alphanum_re = re.compile(r"\W")
+    return re.sub(non_alphanum_re, "", temp_name)
+
+  @staticmethod
+  def _generate_test_filter(meta, is_single, operator, order, property_case,
+                            value_case):
+    """Generate test for query filter
+
+    Args:
+      meta: Instance of object with metainformation from child classes
+      is_single(bool): If true single case will be tested else multiple
+      operator: Operator that should be tested by filter
+      order: True - DESC, False - ASC
+      property_case: If True, property will be tested in upper case, else lower
+      value_case: If True, value will be tested in upper case, else lower
+
+    Returns:
+      Test function for provided parameters
+    """
+    # pylint: disable=protected-access
+    # pylint: disable=missing-docstring
+    # Comment string is absent to show different test names on every execution
+    def test_func(self):
+      request_query = []
+      test_values = self.get_expected_vals(
+          is_single, operator, meta.field, meta.model.__name__
+      )
+      for _, value in test_values:
+        order_by = {"name": meta.field}
+        if order is not None:
+          order_by["desc"] = order
+
+        expression = [
+            meta.field.upper() if property_case else meta.field.lower()
+        ]
+
+        if operator != "is empty":
+          expression.append(operator)
+          expression.append(
+              value.upper() if value_case else value.lower()
+          )
+        else:
+          expression.append("is")
+          expression.append("empty")
+
+        request_query.append(self._make_query_dict(
+            meta.model.__name__,
+            expression=expression,
+            order_by=[order_by],
+            type_="ids",
+        ))
+        if meta.model.__name__ in Types.all:
+          request_query.append(self._make_snapshot_query_dict(
+              meta.model.__name__,
+              expression=expression,
+              order_by=[order_by],
+              type_="ids",
+          ))
+
+      data = self._get_all_result_sets(
+          request_query,
+          meta.model.__name__,
+          "Snapshot",
+      )
+      BaseTestMeta.assert_result(
+          self, meta, order, is_single, operator, test_values, data
+      )
+    return test_func
+
+  @staticmethod
+  def assert_result(instance, meta, order, is_single, operator,
+                    expected_values, result_data):
+    """Check response of query api for objects and their snapshots"""
+    # pylint: disable=too-many-locals
+    snapshotable = False
+    if meta.model.__name__ in Types.all:
+      snapshotable = True
+
+    extra_obj_ids = {}
+    if operator in {"!=", "!~", "is empty"}:
+      extra_obj_ids = db.session.query(meta.model.id).join(SetupData, and_(
+          meta.model.id == SetupData.obj_id,
+          meta.model.__name__ == SetupData.model,
+      )).filter(
+          and_(
+              or_(
+                  SetupData.single != is_single,
+                  SetupData.operator != operator,
+                  SetupData.field != meta.field,
+              ),
+              SetupData.model == meta.model.__name__
+          )
+      )
+      # Convert list of tuples to set
+      extra_obj_ids = {id_[0] for id_ in extra_obj_ids}
+
+    if snapshotable:
+      # Combine objects and their snapshots
+      result_pairs = zip(result_data[::2], result_data[1::2])
+    else:
+      result_pairs = result_data
+    for result_pair, expected in zip(result_pairs, expected_values):
+      BaseTestMeta.assert_objects(
+          instance, result_pair, expected, meta, order, extra_obj_ids
+      )
+      if snapshotable:
+        BaseTestMeta.assert_snapshots(
+            instance, result_pair, expected, order, extra_obj_ids
+        )
+
+  @staticmethod
+  def assert_objects(instance, result, expected, meta, order, extra_ids):
+    """Check if received object ids equal to expected"""
+    obj_ids = [
+        id_ for id_ in result[0][meta.model.__name__]["ids"]
+        if id_ not in extra_ids
+    ]
+    order = order if order else False
+
+    expected_model = expected[0]
+    # Sort values by properties if at least one non-empty exist
+    if expected[0] and expected[0][0] and expected[0][0].props:
+      expected_model = sorted(
+          expected[0], key=lambda tup: tup.props.email, reverse=order
+      )
+    instance.assertEqual(obj_ids, [exp.id for exp in expected_model])
+
+  @staticmethod
+  def assert_snapshots(instance, result, expected, order, extra_ids):
+    """Check if received snapshot ids equal to expected"""
+    snapshot_ids = result[1]["Snapshot"]["ids"]
+    snap_obj_ids = [
+        snapshot_mapping[id_] for id_ in snapshot_ids
+        if snapshot_mapping[id_] not in extra_ids
+    ]
+    order = order if order else False
+
+    expected_snap = expected[0]
+    # Sort values by properties if at least one non-empty exist
+    if expected[0] and expected[0][0] and expected[0][0].props:
+      expected_snap = sorted(
+          expected[0], key=lambda tup: tup.props.user_name, reverse=order
+      )
+    instance.assertEqual(snap_obj_ids, [exp.id for exp in expected_snap])
+
+  @staticmethod
+  def vary_params(meta):
+    """Return all combinations of test case input """
+    return itertools.product(meta.operators,
+                             meta.order,
+                             meta.property_case,
+                             meta.value_case)
+
+
+@add_metaclass(BaseTestMeta)
+class BasePersonQueryApiTest(SingleSetupQueryAPITest):
+  """Base class for filter tests, containing test cases generation"""
+  class Meta(object):
+    """Metaclass defining base test parameters"""
+    subprops = ["name", "email", "user_name"]
+    operators = OPERATIONS.keys()
+    order = [True, False]  # desc = True / asc = False
+    property_case = [True, False]  # True ~ upper, False ~ lower
+    value_case = [True, False]  # True ~ upper, False ~ lower
+
+  def get_expected_vals(self, single, operator, field, model_name):
+    """Collect expected objects for provided combination of test parameters"""
+    setup_objs = db.session.query(SetupData).filter(
+        and_(
+            SetupData.single == single,
+            SetupData.operator == operator,
+            SetupData.field == field,
+            SetupData.model == model_name,
+        )
+    ).all()
+    if not setup_objs:
+      return []
+
+    get_exp_func = "expected_{}_{}".format(
+        "single" if single else "multiple",
+        OPERATIONS[operator],
+    )
+    return getattr(self, get_exp_func)(setup_objs)
+
+  def expected_single_equal(self, setup_objs):
+    """Calculate expected values for single test case, equal operator"""
+    values = []
+    for data in setup_objs:
+      search_obj = inflector.get_model(data.searchable_type).query.get(
+          data.searchable_id
+      )
+      for subprop in self.Meta.subprops:
+        values.append((
+            [create_tuple_data(data.obj_id, search_obj, self.Meta.subprops)],
+            getattr(search_obj, subprop)
+        ))
+    return values
+
+  def expected_multiple_equal(self, setup_objs):
+    """Calculate expected values for multiple test case, equal operator"""
+    values, expected_data = [], []
+    search_obj = inflector.get_model(setup_objs[0].searchable_type).query.get(
+        setup_objs[0].searchable_id
+    )
+    for data in setup_objs:
+      if data.searchable_id == setup_objs[0].searchable_id:
+        expected_data.append(
+            create_tuple_data(data.obj_id, search_obj, self.Meta.subprops)
+        )
+
+    for subprop in self.Meta.subprops:
+      values.append(
+          (expected_data, getattr(search_obj, subprop))
+      )
+    return values
+
+  def expected_single_not_equal(self, setup_objs):
+    """Calculate expected values for single test case, not equal operator"""
+    values = []
+    # Think that data type of all searchable objects is the same
+    model = inflector.get_model(setup_objs[0].searchable_type)
+    id_searchables = dict(
+        db.session.query(model.id, model).filter(getattr(model, "id").in_(
+            s.searchable_id for s in setup_objs
+        ))
+    )
+    for data in setup_objs:
+      exp_data = [so for so in setup_objs if so.obj_id != data.obj_id]
+      search_obj = id_searchables[data.searchable_id]
+      for subprop in self.Meta.subprops:
+        values.append((
+            [create_tuple_data(
+                ed.obj_id, id_searchables[ed.searchable_id], self.Meta.subprops
+            ) for ed in exp_data],
+            getattr(search_obj, subprop))
+        )
+    return values
+
+  def expected_multiple_not_equal(self, setup_objs):
+    """Calculate expected values for multiple test case, not equal operator"""
+    values, expected_data = [], []
+    search_obj = inflector.get_model(setup_objs[0].searchable_type).query.get(
+        setup_objs[0].searchable_id
+    )
+    for data in setup_objs:
+      if data.searchable_id != setup_objs[0].searchable_id:
+        expected_data.append(
+            create_tuple_data(data.obj_id, search_obj, self.Meta.subprops)
+        )
+    for subprop in self.Meta.subprops:
+      values.append(
+          (expected_data, getattr(search_obj, subprop))
+      )
+    return values
+
+  def expected_single_contains(self, setup_objs):
+    """Calculate expected values for single test case, contains operator"""
+    # Expected values are the same as for equal
+    return self.expected_single_equal(setup_objs)
+
+  def expected_multiple_contains(self, setup_objs):
+    """Calculate expected values for multiple test case, contains operator"""
+    # Expected values are the same as for equal
+    return self.expected_multiple_equal(setup_objs)
+
+  def expected_single_not_contains(self, setup_objs):
+    """Calculate expected values for single test case, not contains operator"""
+    # Expected values are the same as for not equal
+    return self.expected_single_not_equal(setup_objs)
+
+  def expected_multiple_not_contains(self, setup_objs):
+    """Calculate expected values for multiple test case, not contains
+    operator"""
+    # Expected values are the same as for not equal
+    return self.expected_multiple_not_equal(setup_objs)
+
+  def expected_single_is_empty(self, setup_objs):
+    """Calculate expected values for single test case, is empty operator"""
+    # pylint: disable=no-self-use
+    # pylint: disable=unused-argument
+    return [([], None)]
+
+  def expected_multiple_is_empty(self, setup_objs):
+    """Calculate expected values for multiple test case, is empty operator"""
+    # pylint: disable=no-self-use
+    expected_data = [create_tuple_data(row.obj_id, None, None)
+                     for row in setup_objs[:MULTIPLE_ITEMS_COUNT]]
+    return [(expected_data, None)]
+
+
+def generate_classes(models, field):
+  """Generate test class containing all BasePersonQueryApiTest tests"""
+  def generate(model):
+    """Create test class with meta information"""
+    meta_fields = {"field": field, "model": model}
+    meta = type("Meta", (object,), meta_fields)
+
+    class_name = "Test{}FilterBy{}".format(
+        model.__name__.replace(" ", ""),
+        field.replace(" ", "_")
+    )
+    instance = type(
+        class_name,
+        (BasePersonQueryApiTest,),
+        {"Meta": meta}
+    )
+    return instance
+
+  module = sys.modules[__name__]
+  for model in models:
+    test_model = generate(inflector.get_model(model))
+    setattr(module, test_model.__name__, test_model)

--- a/test/integration/ggrc/__init__.py
+++ b/test/integration/ggrc/__init__.py
@@ -347,12 +347,13 @@ class TestCase(BaseTestCase, object):
     )
     return revisions
 
-  def _create_snapshots(self, audit, objects):
+  @classmethod
+  def _create_snapshots(cls, audit, objects):
     """Create snapshots of latest object revisions for given objects."""
     # This commit is needed if we're using factories with single_commit, so
     # that the latest revisions will be fetched properly.
     db.session.commit()
-    revisions = self._get_latest_object_revisions(objects)
+    revisions = cls._get_latest_object_revisions(objects)
     snapshots = [
         factories.SnapshotFactory(
             child_id=revision.resource_id,

--- a/test/integration/ggrc/query_helper.py
+++ b/test/integration/ggrc/query_helper.py
@@ -26,6 +26,17 @@ class WithQueryApi(object):
       self.assertIsNot(result, None)
     return result
 
+  def _get_all_result_sets(self, data, *keys):
+    """Post data, get response, get values for provided models."""
+    response = self._post(data)
+    self.assert200(response)
+    resp_data = json.loads(response.data)
+
+    result = []
+    for obj in resp_data:
+      result.extend(obj for key in keys if obj.get(key))
+    return result
+
   @staticmethod
   def _make_query_dict_base(object_name, type_=None, filters=None,
                             limit=None, order_by=None):

--- a/test/integration/ggrc/query_helper.py
+++ b/test/integration/ggrc/query_helper.py
@@ -75,6 +75,23 @@ class WithQueryApi(object):
     return cls._make_query_dict_base(object_name, filters=filters, *args,
                                      **kwargs)
 
+  @classmethod
+  def _make_snapshot_query_dict(cls, child_type, expression=None, *args,
+                                **kwargs):
+    """Make a dict with query for Snapshots of child_type."""
+    child_type_filter = cls.make_filter_expression(("child_type", "=",
+                                                    child_type))
+    if expression:
+      snapshot_filter = cls.make_filter_expression(expression)
+      filters = {"expression": {"op": {"name": "AND"},
+                                "left": snapshot_filter,
+                                "right": child_type_filter}}
+    else:
+      filters = {"expression": child_type_filter}
+
+    return cls._make_query_dict_base("Snapshot", filters=filters, *args,
+                                     **kwargs)
+
   def simple_query(self, model_name, expression=None, *args, **kwargs):
     return self._get_first_result_set(
         self._make_query_dict(

--- a/test/integration/ggrc/services/test_query/test_snapshots.py
+++ b/test/integration/ggrc/services/test_query/test_snapshots.py
@@ -412,23 +412,6 @@ class TestSnapshotIndexing(TestCase, WithQueryApi):
     self.generator = generator.ObjectGenerator()
     self.client.get("/login")
 
-  @classmethod
-  def _make_snapshot_query_dict(cls, child_type, expression=None, *args,
-                                **kwargs):
-    """Make a dict with query for Snapshots of child_type."""
-    child_type_filter = cls.make_filter_expression(("child_type", "=",
-                                                    child_type))
-    if expression:
-      snapshot_filter = cls.make_filter_expression(expression)
-      filters = {"expression": {"op": {"name": "AND"},
-                                "left": snapshot_filter,
-                                "right": child_type_filter}}
-    else:
-      filters = {"expression": child_type_filter}
-
-    return cls._make_query_dict_base("Snapshot", filters=filters, *args,
-                                     **kwargs)
-
   def _create_audit(self, program, title):
     """Make a POST to create an Audit.
 


### PR DESCRIPTION
Create a framework for running full integration test suite for read only tests.


EDIT: the old obsolete description
Create integration tests for following parameters
field type: Person
operators: !=,!~, =, ~, is empty
ordering: asc, desc
sub-property: username, email, name
amount: one, two
search property: PERSON, person
search value: VALUE, value
models: all + snapshots
