### PR TITLE
GGRC-2954 Cursor when hovering over lines doesn’t make it clear the rows are clickable

### DIFF
--- a/src/ggrc/assets/stylesheets/components/tree/_tree-view.scss
+++ b/src/ggrc/assets/stylesheets/components/tree/_tree-view.scss
@@ -121,6 +121,7 @@ tree-view {
 tree-item {
   >.tree-item-wrapper {
     background-color: $white;
+    cursor: pointer;
 
     &.snapshot {
       .tree-item-content {


### PR DESCRIPTION
Over "tree-view" component, cursor looks like pointer now.