### PR TITLE
GGRC-2979 "Failed to fetch data for person 229." error message is displayed while expanding Assessment's Info pane	

### DIFF
--- a/src/ggrc/models/custom_attribute_definition.py
+++ b/src/ggrc/models/custom_attribute_definition.py
@@ -128,22 +128,13 @@ class CustomAttributeDefinition(attributevalidator.AttributeValidator,
     DATE = "Date"
     MAP = "Map"
 
-  class MultiChoiceMandatoryFlags(dict):
-    """Enum representing flags in multi_choice_mandatory bitmaps."""
-    # pylint: disable=too-few-public-methods
-    COMMENT_REQUIRED = 0b01
-    EVIDENCE_REQUIRED = 0b10
+  COMMENT_REQUIRED = 0b01
+  EVIDENCE_REQUIRED = 0b10
 
-    def __init__(self, mask):
-      """Initialize flag instance."""
-      self.comment_required = bool(mask & self.COMMENT_REQUIRED)
-      self.evidence_required = bool(mask & self.EVIDENCE_REQUIRED)
-      super(
-          CustomAttributeDefinition.MultiChoiceMandatoryFlags,
-          self
-      ).__init__(
-          **self.__dict__
-      )
+  def _multi_choice_flags(self, mask):
+    """ Create flags dict from multi_choice_mandatory bitmaps."""
+    return {"comment_required": bool(mask & self.COMMENT_REQUIRED),
+            "evidence_required": bool(mask & self.EVIDENCE_REQUIRED)}
 
   VALID_TYPES = {
       "Text": "Text",
@@ -303,7 +294,7 @@ class CustomAttributeDefinition(attributevalidator.AttributeValidator,
     masks = itertools.cycle([0])
     if self.multi_choice_mandatory:
       masks = (int(m) for m in self.multi_choice_mandatory.split(","))
-    flags = (self.MultiChoiceMandatoryFlags(m) for m in masks)
+    flags = (self._multi_choice_flags(m) for m in masks)
     return dict(itertools.izip(mc_options, flags))
 
   @validates("mandatory")

--- a/src/ggrc/models/custom_attribute_value.py
+++ b/src/ggrc/models/custom_attribute_value.py
@@ -335,12 +335,14 @@ class CustomAttributeValue(Base, Indexed, db.Model):
     if not flags:
       return {}
     failed_preconditions = {}
-    if flags.comment_required and isinstance(self.attributable, Commentable):
+    if flags["comment_required"] and isinstance(self.attributable,
+                                                Commentable):
       failed_preconditions["comment"] = not any(
           self.custom_attribute_id == c.custom_attribute_definition_id and
           self.latest_revision.id == c.revision_id
           for c in self.attributable.comments)
-    if flags.evidence_required and isinstance(self.attributable, Documentable):
+    if flags["evidence_required"] and isinstance(self.attributable,
+                                                 Documentable):
       evidences_count = len(self.attributable.document_evidence)
       cav_evidence_count = self.attributable.cav_evidence_count
       failed_preconditions["evidence"] = evidences_count < cav_evidence_count

--- a/src/ggrc/models/mixins/customattributable.py
+++ b/src/ggrc/models/mixins/customattributable.py
@@ -511,7 +511,7 @@ class CustomAttributable(object):
     count = 0
     for cav in self.custom_attribute_values:
       cav_flags = cav.custom_attribute.options.get(cav.attribute_value)
-      if cav_flags and cav_flags.evidence_required:
+      if cav_flags and cav_flags["evidence_required"]:
         count += 1
     return count
 


### PR DESCRIPTION
Nested class is replaced by function as lookup for nested class causes error during pickling:
PicklingError: Can't pickle : attribute lookup ggrc.models.custom_attribute_definition.MultiChoiceMandatoryFlags failed