### PR TITLE
GGRC-2969 FE: Task Group showing as overdue even when all milestones completed (refresh helps)

### DIFF
--- a/src/ggrc/cache/cache.py
+++ b/src/ggrc/cache/cache.py
@@ -137,6 +137,7 @@ def all_mapping_entries():
       mapping('CycleTaskGroup', 'task_group'),
       mapping('CycleTaskGroupObjectTask', 'cycle'),
       mapping('CycleTaskGroupObjectTask', 'cycle_task_entries'),
+      mapping('CycleTaskGroupObjectTask', 'cycle_task_group'),
       mapping('CycleTaskGroupObjectTask', 'task_group_task'),
       mapping('CycleTaskGroupObjectTask', 'cycle_task_objects_for_cache'),
       mapping('CycleTaskEntry', 'cycle'),


### PR DESCRIPTION
Cycle task group status isn't deleted from memcache after cycle task updating (put).

Steps of reproduction:
1. Create workflow.
2. Add a task to task group.
3. Activate workflow.
4. Press 'Start' for task.
Result: task group status is 'InProgress'.
5. Press 'Undo" for task.
Result:  task group status is 'InProgress'.
Expected result: task group status is 'Assigned'.