### PR TITLE
GGRC-2988 Add mapped objects to Audit export

### DIFF
--- a/src/ggrc/utils/rules.py
+++ b/src/ggrc/utils/rules.py
@@ -57,7 +57,7 @@ def get_mapping_rules():
   # Audit and Audit-scope objects
   # Assessment and Issue have a special Audit field instead of map:audit
   business_object_rules.update({
-      "Audit": set(),
+      "Audit": snapshots | {"Assessment", "Issue"},
       "Assessment": snapshots | {"Issue"},
       "Issue": snapshots | {"Assessment"},
   })

--- a/test/integration/ggrc/converters/test_export_audit.py
+++ b/test/integration/ggrc/converters/test_export_audit.py
@@ -1,0 +1,53 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Tests export of Audit and mapped objects."""
+from collections import defaultdict
+
+from ggrc import utils
+from ggrc.snapshotter.rules import Types
+
+from integration.ggrc import TestCase
+from integration.ggrc.models import factories
+from integration.ggrc.models.factories import get_model_factory
+
+
+class TestAuditExport(TestCase):
+  """Test export of Audit"""
+  def setUp(self):
+    super(TestAuditExport, self).setUp()
+    self.client.get("/login")
+
+  def test_export_audit_mappings(self):
+    """Test export of audit mapped objects"""
+    snap_objects = []
+    mapped_slugs = defaultdict(list)
+    with factories.single_commit():
+      audit = factories.AuditFactory(slug="Audit")
+      # Create a group of mapped objects for current audit
+      for _ in range(3):
+        # All snapshotable objects should be mapped to Audit + Issue
+        # and Assessment
+        for type_ in Types.all.union(Types.scoped):
+          if type_ in Types.scoped:
+            obj = get_model_factory(type_)(audit=audit)
+            factories.RelationshipFactory(source=audit, destination=obj)
+          else:
+            obj = get_model_factory(type_)()
+          mapped_slugs[type_].append(obj.slug)
+          snap_objects.append(obj)
+
+    self._create_snapshots(audit, snap_objects)
+
+    audit_data = self.export_parsed_csv([{
+        "object_name": "Audit",
+        "filters": {
+            "expression": {}
+        },
+        "fields": "all",
+    }])["Audit"][0]
+
+    for type_, slugs in mapped_slugs.items():
+      mapping_name = "map:{}".format(utils.title_from_camelcase(type_))
+      self.assertIn(mapping_name, audit_data)
+      self.assertEqual(audit_data[mapping_name], "\n".join(slugs))

--- a/test/integration/ggrc/models/factories.py
+++ b/test/integration/ggrc/models/factories.py
@@ -20,8 +20,10 @@ import factory
 
 from ggrc import db
 from ggrc import models
+
 from ggrc.access_control.role import AccessControlRole
 from ggrc.access_control.list import AccessControlList
+
 from ggrc_risks import models as risk_models
 
 from integration.ggrc.models.model_factory import ModelFactory
@@ -330,12 +332,117 @@ class AccessControlRoleAdminFactory(AccessControlRoleFactory):
   name = "Admin"
 
 
+class AccessGroupFactory(TitledFactory):
+  """Access Group factory class"""
+
+  class Meta:
+    model = models.AccessGroup
+
+
+class ClauseFactory(TitledFactory):
+  """Clause factory class"""
+
+  class Meta:
+    model = models.Clause
+
+
+class DataAssetFactory(TitledFactory):
+  """DataAsset factory class"""
+
+  class Meta:
+    model = models.DataAsset
+
+
+class FacilityFactory(TitledFactory):
+  """Facility factory class"""
+
+  class Meta:
+    model = models.Facility
+
+
+class ProductFactory(TitledFactory):
+  """Product factory class"""
+
+  class Meta:
+    model = models.Product
+
+
+class SectionFactory(TitledFactory):
+  """Section factory class"""
+
+  class Meta:
+    model = models.Section
+
+
+class StandardFactory(TitledFactory):
+  """Standard factory class"""
+
+  class Meta:
+    model = models.Standard
+
+  description = factory.LazyAttribute(lambda _: random_str(length=100))
+
+
+class VendorFactory(TitledFactory):
+  """Vendor factory class"""
+
+  class Meta:
+    model = models.Vendor
+
+
 class RiskFactory(TitledFactory):
   """Risk factory class"""
 
   class Meta:
     model = risk_models.Risk
 
-  description = factory.LazyAttribute(
-      lambda _: random_str(prefix="Risk - ")
-  )
+  description = factory.LazyAttribute(lambda _: random_str(length=100))
+
+
+class ThreatFactory(TitledFactory):
+  """Threat factory class"""
+
+  class Meta:
+    model = risk_models.Threat
+
+
+def get_model_factory(model_name):
+  """Get object factory for provided model name"""
+  from integration.ggrc_workflows.models import factories as wf_factories
+  model_factories = {
+      "AccessControlRole": AccessControlRoleFactory,
+      "AccessControlList": AccessControlListFactory,
+      "AccessGroup": AccessGroupFactory,
+      "Assessment": AssessmentFactory,
+      "AssessmentTemplate": AssessmentTemplateFactory,
+      "Audit": AuditFactory,
+      "Clause": ClauseFactory,
+      "Contract": ContractFactory,
+      "Control": ControlFactory,
+      "TaskGroupFactory": wf_factories.TaskGroupFactory,
+      "TaskGroupObjectFactory": wf_factories.TaskGroupObjectFactory,
+      "TaskGroupTaskFactory": wf_factories.TaskGroupTaskFactory,
+      "CycleFactory": wf_factories.CycleFactory,
+      "CycleTaskGroupFactory": wf_factories.CycleTaskGroupFactory,
+      "CycleTaskFactory": wf_factories.CycleTaskFactory,
+      "CycleTaskEntryFactory": wf_factories.CycleTaskEntryFactory,
+      "DataAsset": DataAssetFactory,
+      "Facility": FacilityFactory,
+      "Issue": IssueFactory,
+      "Market": MarketFactory,
+      "Objective": ObjectiveFactory,
+      "OrgGroup": OrgGroupFactory,
+      "Person": PersonFactory,
+      "Policy": PolicyFactory,
+      "Process": ProcessFactory,
+      "Product": ProductFactory,
+      "Regulation": RegulationFactory,
+      "Section": SectionFactory,
+      "Standard": StandardFactory,
+      "System": SystemFactory,
+      "Vendor": VendorFactory,
+      "Risk": RiskFactory,
+      "Threat": ThreatFactory,
+      "Workflow": wf_factories.WorkflowFactory,
+  }
+  return model_factories[model_name]

--- a/test/unit/ggrc/utils/test_rules.py
+++ b/test/unit/ggrc/utils/test_rules.py
@@ -36,7 +36,10 @@ class TestMappingRules(BaseTestMappingRules):
                       'OrgGroup', 'Policy', 'Process', 'Product', 'Regulation',
                       'Risk', 'Section', 'Standard', 'System', 'Threat',
                       'Vendor', ]
-  audit_rules = []
+  audit_rules = ['AccessGroup', 'Assessment', 'Clause', 'Contract', 'Control',
+                 'DataAsset', 'Facility', 'Issue', 'Market', 'Objective',
+                 'OrgGroup', 'Policy', 'Process', 'Product', 'Regulation',
+                 'Risk', 'Section', 'Standard', 'System', 'Threat', 'Vendor']
   accessgroup_rules = ['Clause', 'Contract', 'Control',
                        'CycleTaskGroupObjectTask', 'DataAsset', 'Facility',
                        'Market', 'Objective', 'OrgGroup', 'Person', 'Policy',


### PR DESCRIPTION
Export of Audit should work in the same way as export of Assessment: all mapped objects should be exported. Linked Assessments and Issues should be exported also.