### PR TITLE
GGRC-1535/2980 Re-apply Filter is not applied if searchable value contains some special symbols (e.g. _%\) / Incorrect search by special symbols

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,4 +3,5 @@ third_party/*
 
 src/ggrc/static/**/*.js
 src/ggrc/assets/stylesheets/*.js
+src/ggrc/assets/javascripts/generated/*.js
 src/parser/parser_template.js

--- a/src/ggrc/assets/javascripts/components/tree/tree-filter-input.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-filter-input.js
@@ -13,7 +13,7 @@
       filter: {
         type: 'string',
         set: function (newValue) {
-          this.attr('options.filter', newValue.replace(/\\/g, '\\\\') || '');
+          this.attr('options.filter', newValue || '');
           this.onFilterChange(newValue);
           return newValue;
         }

--- a/src/ggrc/assets/javascripts/components/unified-mapper/mapper-filter.js
+++ b/src/ggrc/assets/javascripts/components/unified-mapper/mapper-filter.js
@@ -13,10 +13,9 @@
     ),
     viewModel: {
       define: {
-        text: {
+        filter: {
           type: 'string',
           set: function (newValue) {
-            this.attr('filter', newValue.replace(/\\/g, '\\\\'));
             this.checkExpression(newValue);
             return newValue;
           }
@@ -35,12 +34,12 @@
         this.dispatch('submit');
       },
       reset: function () {
-        this.attr('text', '');
+        this.attr('filter', '');
       }
     },
     events: {
       '#mapper-filter input': function (el) {
-        this.viewModel.attr('text', el.val());
+        this.viewModel.attr('filter', el.val());
       }
     }
   });

--- a/src/ggrc/assets/javascripts/components/unified-mapper/tests/mapper-filter_spec.js
+++ b/src/ggrc/assets/javascripts/components/unified-mapper/tests/mapper-filter_spec.js
@@ -11,19 +11,18 @@ describe('GGRC.Components.mapperFilter', function () {
     viewModel = GGRC.Components.getViewModel('mapperFilter');
   });
 
-  describe('text set()', function () {
+  describe('filter set()', function () {
     beforeEach(function () {
       spyOn(viewModel, 'checkExpression');
     });
 
     it('sets viewModel.filter', function () {
-      viewModel.attr('filter', '');
-      viewModel.attr('text', 'program');
+      viewModel.attr('filter', 'program');
       expect(viewModel.attr('filter')).toEqual('program');
     });
 
     it('calls checkExpression()', function () {
-      viewModel.attr('text', 'program');
+      viewModel.attr('filter', 'program');
       expect(viewModel.checkExpression)
         .toHaveBeenCalledWith('program');
     });
@@ -64,10 +63,10 @@ describe('GGRC.Components.mapperFilter', function () {
   });
 
   describe('reset() method', function () {
-    it('updates viewModel.text', function () {
-      viewModel.attr('text', 'stub');
+    it('updates viewModel.filter', function () {
+      viewModel.attr('filter', 'text');
       viewModel.reset();
-      expect(viewModel.attr('text')).toEqual('');
+      expect(viewModel.attr('filter')).toEqual('');
     });
   });
 });

--- a/src/ggrc/assets/javascripts/generated/ggrc_filter_query_parser.js
+++ b/src/ggrc/assets/javascripts/generated/ggrc_filter_query_parser.js
@@ -335,8 +335,8 @@ GGRC.query_parser = {
             },
         peg$c36 = "\"",
         peg$c37 = { type: "literal", value: "\"", description: "\"\\\"\"" },
-        peg$c38 = /^[a-zA-Z0-9_\-.\/]/,
-        peg$c39 = { type: "class", value: "[a-zA-Z0-9_\\-./]", description: "[a-zA-Z0-9_\\-./]" },
+        peg$c38 = /^[a-zA-Z0-9_\-.\/%]/,
+        peg$c39 = { type: "class", value: "[a-zA-Z0-9_\\-./%]", description: "[a-zA-Z0-9_\\-./%]" },
         peg$c40 = /^[^"]/,
         peg$c41 = { type: "class", value: "[^\"]", description: "[^\"]" },
         peg$c42 = "\\",
@@ -1426,12 +1426,15 @@ GGRC.query_parser = {
     function peg$parseunqoted_char() {
       var s0;
 
-      if (peg$c38.test(input.charAt(peg$currPos))) {
-        s0 = input.charAt(peg$currPos);
-        peg$currPos++;
-      } else {
-        s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c39); }
+      s0 = peg$parseescaped_symbol();
+      if (s0 === peg$FAILED) {
+        if (peg$c38.test(input.charAt(peg$currPos))) {
+          s0 = input.charAt(peg$currPos);
+          peg$currPos++;
+        } else {
+          s0 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c39); }
+        }
       }
 
       return s0;

--- a/src/ggrc/assets/javascripts/generated/ggrc_filter_query_parser.js
+++ b/src/ggrc/assets/javascripts/generated/ggrc_filter_query_parser.js
@@ -337,13 +337,13 @@ GGRC.query_parser = {
         peg$c37 = { type: "literal", value: "\"", description: "\"\\\"\"" },
         peg$c38 = /^[a-zA-Z0-9_\-.\/]/,
         peg$c39 = { type: "class", value: "[a-zA-Z0-9_\\-./]", description: "[a-zA-Z0-9_\\-./]" },
-        peg$c40 = "\\\"",
-        peg$c41 = { type: "literal", value: "\\\"", description: "\"\\\\\\\"\"" },
-        peg$c42 = function() {
-              return '"';
+        peg$c40 = /^[^"]/,
+        peg$c41 = { type: "class", value: "[^\"]", description: "[^\"]" },
+        peg$c42 = "\\",
+        peg$c43 = { type: "literal", value: "\\", description: "\"\\\\\"" },
+        peg$c44 = function(escape, symbol) {
+              return escape + symbol;
             },
-        peg$c43 = /^[^"]/,
-        peg$c44 = { type: "class", value: "[^\"]", description: "[^\"]" },
         peg$c45 = "and",
         peg$c46 = { type: "literal", value: "AND", description: "\"AND\"" },
         peg$c47 = function() {
@@ -1438,29 +1438,52 @@ GGRC.query_parser = {
     }
 
     function peg$parsequoted_char() {
-      var s0, s1;
+      var s0;
 
-      s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c40) {
-        s1 = peg$c40;
-        peg$currPos += 2;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c41); }
-      }
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c42();
-      }
-      s0 = s1;
+      s0 = peg$parseescaped_symbol();
       if (s0 === peg$FAILED) {
-        if (peg$c43.test(input.charAt(peg$currPos))) {
+        if (peg$c40.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c44); }
+          if (peg$silentFails === 0) { peg$fail(peg$c41); }
         }
+      }
+
+      return s0;
+    }
+
+    function peg$parseescaped_symbol() {
+      var s0, s1, s2;
+
+      s0 = peg$currPos;
+      if (input.charCodeAt(peg$currPos) === 92) {
+        s1 = peg$c42;
+        peg$currPos++;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c43); }
+      }
+      if (s1 !== peg$FAILED) {
+        if (input.length > peg$currPos) {
+          s2 = input.charAt(peg$currPos);
+          peg$currPos++;
+        } else {
+          s2 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c3); }
+        }
+        if (s2 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c44(s1, s2);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
       }
 
       return s0;

--- a/src/ggrc/assets/js_specs/generated/ggrc_filter_query_parser_spec.js
+++ b/src/ggrc/assets/js_specs/generated/ggrc_filter_query_parser_spec.js
@@ -243,6 +243,38 @@ describe('GGRC.query_parser', function () {
         });
     });
 
+    it('correctly handles escaped symbols inside quotes', function () {
+      var queries = [
+        'title ~ "test\\\\"',
+        'title ~ "test\\%"',
+        'title ~ "test\\_"',
+        'title ~ "test\\""'
+      ];
+
+      _.each(queries, function (query) {
+        var value = query.split('~')[1].trim().replace(/^"|"$/g, '');
+        var result = GGRC.query_parser.parse(query);
+
+        expect(result.expression.right).toEqual(value);
+      });
+    });
+
+    it('correctly handles escaped symbols outside quotes', function () {
+      var queries = [
+        'title ~ test\\\\',
+        'title ~ test\\%',
+        'title ~ test\\_',
+        'title ~ test\\"'
+      ];
+
+      _.each(queries, function (query) {
+        var value = query.split('~')[1].trim();
+        var result = GGRC.query_parser.parse(query);
+
+        expect(result.expression.right).toEqual(value);
+      });
+    });
+
     describe('evaluate', function () {
       it('returns true on an empty query', function () {
         expect(GGRC.query_parser.parse('').evaluate()).toEqual(true);

--- a/src/ggrc/assets/js_specs/generated/ggrc_filter_query_parser_spec.js
+++ b/src/ggrc/assets/js_specs/generated/ggrc_filter_query_parser_spec.js
@@ -275,6 +275,22 @@ describe('GGRC.query_parser', function () {
       });
     });
 
+    it('does not change escaped symbols in case of text search', function () {
+      var query = 'some \\\\ test \\% \\_ query';
+
+      var result = GGRC.query_parser.parse(query);
+
+      expect(result.expression.op.name).toBe('text_search');
+      expect(result.expression.text).toBe(query);
+    });
+
+    it('correctly handles escaped symbol inside attribute name', function () {
+      var query = '"my \\" quote" ~ aaa';
+      var result = GGRC.query_parser.parse(query);
+
+      expect(result.expression.left).toEqual('my \\" quote');
+    });
+
     describe('evaluate', function () {
       it('returns true on an empty query', function () {
         expect(GGRC.query_parser.parse('').evaluate()).toEqual(true);

--- a/src/ggrc/assets/mustache/components/unified-mapper/mapper-filter.mustache
+++ b/src/ggrc/assets/mustache/components/unified-mapper/mapper-filter.mustache
@@ -3,7 +3,7 @@
     <input type="text"
            id="mapper-filter"
            placeholder="Enter text to Search"
-           {$value}="text"
+           {$value}="filter"
            ($enter)='onSubmit()'>
     <span class="icon-wrapper flex-box">
       <i class="fa fa-fw

--- a/src/parser/parser.pegjs
+++ b/src/parser/parser.pegjs
@@ -293,11 +293,15 @@ unqoted_char = [a-zA-Z0-9_\-./]
 
 
 quoted_char
-  = '\\"'
-    {
-      return '"';
-    }
+  = escaped_symbol
   / [^"]
+
+
+escaped_symbol
+  = escape:'\\' symbol:.
+    {
+      return escape + symbol;
+    }
 
 
 AND

--- a/src/parser/parser.pegjs
+++ b/src/parser/parser.pegjs
@@ -289,7 +289,9 @@ quoted_word
       return word.join('');
     }
 
-unqoted_char = [a-zA-Z0-9_\-./]
+unqoted_char
+  = escaped_symbol
+  / [a-zA-Z0-9_\-./%]
 
 
 quoted_char


### PR DESCRIPTION
Original PR: [6096](https://github.com/google/ggrc-core/pull/6096)

GGRC-1535:
Steps to reproduce:

Create assessment with a title that contains one of the following special symbols: _%\
Try to filter assessment by title (e.g. "title_")
Actual Result: Filter is not applied if searchable value contains some special symbols (e.g. _%)
Expected Result: Filter should be applied if searchable value contains some special symbols (e.g. _%)
GGRC-2980:
Steps to reproduce:

Have a program
Go to the Objectives tab and create Objective with title 'test%objective'
In Search box enter query: title ~ test%
Look at the search results: filter is not applied for the created objective
Open advanced search and filter by query: 'test%'
Look at the search results: created objective is displayed in Search results
Actual Result: Incorrect search by special symbols
Expected Result: Search should work properly with special symbols