### PR TITLE
GGRC-2933 (re-submitted) Explicitly provide created/updated date for URLs

### DIFF
--- a/src/ggrc/models/revision.py
+++ b/src/ggrc/models/revision.py
@@ -131,6 +131,7 @@ class Revision(Base, db.Model):
     """Property. Contains the revision content dict.
 
     Updated by required values, generated from saved content dict."""
+    # pylint: disable=too-many-locals
     roles_dict = role.get_custom_roles_for(self.resource_type)
     reverted_roles_dict = {n: i for i, n in roles_dict.iteritems()}
     access_control_list = self._content.get("access_control_list") or []
@@ -184,12 +185,22 @@ class Revision(Base, db.Model):
         # as non-existing (empty) reference URLs
         if not link:
           continue
+
+        # if creation/modification date is not available, we estimate it by
+        # using the corresponding information from the Revision itself
+        created_at = (self._content.get("created_at") or
+                      self.created_at.isoformat())
+        updated_at = (self._content.get("updated_at") or
+                      self.updated_at.isoformat())
+
         reference_url_list.append({
             "display_name": link,
             "document_type": "REFERENCE_URL",
             "link": link,
             "title": link,
-            "id": None
+            "id": None,
+            "created_at": created_at,
+            "updated_at": updated_at,
         })
       populated_content['reference_url'] = reference_url_list
 


### PR DESCRIPTION
This PR is semantically the same as the later-reverted #6082 with merge conflicts resolved when cherry-picking it on top of the `dev` branch.
Assigned @zidarsk8 as he was also the assignee of the original PR.

---

**Steps to reproduce:**
1. Select a snapshotted object in a tree view to open its info pane. If using a recent ggrc-qa database, an example of such object suffering from the problem is the following: `<host>/audits/4182#control_widget`, a control snapshot titled "Startupsum 128".

2. Look at the object's reference URLs.

**Actual result:**
"Invalid date" string is displayed under the items in the reference URLs list.

**Expected result:**
The actual date in US format is displayed under each item in the reference URLs list.