### PR TITLE
GGRC-2269 Assessments: only five snapshots are mapped to Assessments if select All in Unified Mapper	

### DIFF
--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -337,6 +337,7 @@ dashboard-js-files:
   - components/inline/base-inline-control-title.js
   - components/assessment/info-pane/inline-item.js
   - components/assessment/info-pane/confirm-edit-action.js
+  - components/object-list-item/object-list-item-updater.js
 
 app-init-files:
   - apps/dashboard.js

--- a/src/ggrc/assets/javascripts/components/object-list-item/object-list-item-updater.js
+++ b/src/ggrc/assets/javascripts/components/object-list-item/object-list-item-updater.js
@@ -1,0 +1,40 @@
+/*!
+ Copyright (C) 2017 Google Inc., authors, and contributors
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+(function (can, GGRC) {
+  'use strict';
+
+  var tag = 'object-list-item-updater';
+
+  GGRC.Components('objectListItemUpdater', {
+    tag: tag,
+    viewModel: {
+      define: {
+        targetInstance: {
+          set: function (value) {
+            this.attr('instanceUpdated', false);
+
+            if (value.isNeedRefresh) {
+              this.updateInstance(value);
+              return;
+            }
+
+            this.attr('instance', value);
+            this.attr('instanceUpdated', true);
+          }
+        }
+      },
+      instance: {},
+      instanceUpdated: false,
+      updateInstance: function (instance) {
+        new RefreshQueue().enqueue(instance)
+          .trigger().then(function (refreshedInstances) {
+            this.attr('instance', refreshedInstances[0]);
+            this.attr('instanceUpdated', true);
+          }.bind(this));
+      }
+    }
+  });
+})(window.can, window.GGRC);

--- a/src/ggrc/assets/javascripts/components/object-mapper/object-mapper.js
+++ b/src/ggrc/assets/javascripts/components/object-mapper/object-mapper.js
@@ -128,20 +128,11 @@
           arr: _.compact(_.map(
             this.viewModel.attr('selected'),
             function (desination) {
-              var isAllowed = GGRC.Utils.allowed_to_map(source, desination);
-              var instance =
-                can.makeArray(this.viewModel.attr('entries'))
-                  .map(function (entry) {
-                    return entry.instance || entry;
-                  })
-                  .find(function (instance) {
-                    return instance.id === desination.id &&
-                      instance.type === desination.type;
-                  });
-              if (instance && isAllowed) {
-                return instance;
+              if (GGRC.Utils.allowed_to_map(source, desination)) {
+                desination.isNeedRefresh = true;
+                return desination;
               }
-            }.bind(this)
+            }
           ))
         };
 

--- a/src/ggrc/assets/javascripts/models/join_models.js
+++ b/src/ggrc/assets/javascripts/models/join_models.js
@@ -107,8 +107,7 @@
     attributes: {
       context: 'CMS.Models.Context.stub',
       modified_by: 'CMS.Models.Person.stub',
-      parent: 'CMS.Models.Cacheable.stub',
-      revision: 'CMS.Models.Revision.stub'
+      parent: 'CMS.Models.Cacheable.stub'
     },
     join_keys: {
       parent: can.Model.Cacheable,

--- a/src/ggrc/assets/mustache/assessments/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessments/modal_content.mustache
@@ -126,11 +126,15 @@
                 {{#each list}}
                   <div class="modal-mapped-objects-item">
                     <div class="modal-mapped-objects-item__details">
-                      <business-object-list-item {instance}="{.}">
-                        <div class="description">
-                          <read-more {text}="itemData.description" max-lines-number="1"></read-more>
-                        </div>
-                      </business-object-list-item>
+                      <object-list-item-updater {target-instance}="{.}">
+                        {{#if instanceUpdated}}
+                          <business-object-list-item {instance}="instance">
+                            <div class="description">
+                              <read-more {text}="itemData.description" max-lines-number="1"></read-more>
+                            </div>
+                          </business-object-list-item>
+                        {{/if}}
+                      </object-list-item-updater>
                     </div>
                     <div class="modal-mapped-objects-item__unmap">
                       {{^is type 'Audit'}}


### PR DESCRIPTION
_Steps to reproduce:_
1. Have at least 10 Control's snapshots on the audit page
2. Invoke New Assessments modal window
3. Click Map objects button
4. Once 10 Control's snapshots are displayed in Unified mapper Select All and Click Map Selected
5. Look at mapped snapshots: only first 5 Control's snapshots were mapped

_Actual Result_: Only five snapshots are mapped to Assessments if select All in Unified Mapper
_Expected Result_: If user clicks "Select All" in Unified mapper to map Control's snapshots to Assessment, all Control's snapshots that exist in audit scope should be mapped to Assessment

![screenshot-2](https://user-images.githubusercontent.com/4204416/29064271-21cdf962-7c31-11e7-85ff-b1b1b47cf794.png)
