### PR TITLE
GGRC-3022 Text overlap of "More Information" link of snapshot on the Assessment's Info pane

### DIFF
--- a/src/ggrc/assets/mustache/components/assessment/mapped-objects/mapped-controls.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/mapped-objects/mapped-controls.mustache
@@ -4,8 +4,10 @@
 }}
 <object-list {(selected-item)}="selectedItem" {items}="mappedItems">
     <business-object-list-item {instance}="instance">
-        <div class="description control-description">
+        <div class="description">
             {{{itemData.description}}}
+        </div>
+        <div class="more-information-wrapper">
             <button class="btn btn-link more-information-button">More Information</button>
         </div>
     </business-object-list-item>

--- a/src/ggrc/assets/stylesheets/components/mapped-objects/_mapped-objects.scss
+++ b/src/ggrc/assets/stylesheets/components/mapped-objects/_mapped-objects.scss
@@ -55,6 +55,7 @@
     color: $middleText;
     padding: 0 16px 0 24px;
     position: relative;
+    font-size: 13px;
 
     .fa {
       position: absolute;
@@ -71,17 +72,16 @@
     width: 100%;
     padding: 0 8px 0 28px;
     box-sizing: border-box;
-
-    &.control-description {
-      position: relative;
-    }
   }
 
-  .more-information-button {
-    bottom: 0;
-    right: 0;
-    position: absolute;
-    line-height: 12px;
+  .more-information-wrapper {
+    display: flex;
+    justify-content: flex-end;
+    height: 18px;
+
+    .more-information-button {
+      line-height: 12px;
+    }
   }
 
   .fa {


### PR DESCRIPTION
_Steps to reproduce:_
1. Have audit with control snapshot with long title
2. Generate assessment based on the control snapshot
3. Expand assessment's Info pane and look at the mapped control snapshot: text overlap of "More Information" link

_Actual Result:_ Text overlap of "More Information" link of snapshot on the Assessment's Info pane
_Expected Result:_ Text should not overlap of "More Information" link of snapshot on the Assessment's Info pane

![screenshot-1](https://user-images.githubusercontent.com/4204416/29111839-9cfaa6bc-7cf4-11e7-9cdf-bf98905df105.png)
