### PR TITLE
GGRC-3024 JS error is displayed if close Unified Mapper while mapping an object

### DIFF
--- a/src/ggrc/assets/javascripts/components/object-mapper/object-mapper.js
+++ b/src/ggrc/assets/javascripts/components/object-mapper/object-mapper.js
@@ -115,7 +115,9 @@
         this.viewModel.attr('is_saving', false);
 
         // TODO: Find proper way to dismiss the modal
-        this.element.find('.modal-dismiss').trigger('click');
+        if (this.element) {
+          this.element.find('.modal-dismiss').trigger('click');
+        }
       },
       deferredSave: function () {
         var source = this.viewModel.attr('deferred_to').instance ||


### PR DESCRIPTION
Steps to reproduce:
1. Have a program
2. Click Add tab button > Controls
3. Click Map button in the tree view
4. Select Control from the Search results and click [Map selected]
5. Click [x] button 
6. Look at the screen: JS error occurs

***Actual Result:*** "Uncaught TypeError: Cannot read property 'find' of null" error is displayed if close Unified Mapper while mapping an object
***Expected Result*:** no errors are shown while clicking [x] button during mapping an object
***NOTE:*** the issue is reproduced on the audit page while mapping an object to the audit taking into account the steps mentioned above (4-5)