### PR TITLE
GGRC-2329 RMC - Workflow: Active Cycle UI - Hovering workflow expansion

### DIFF
--- a/src/ggrc/assets/javascripts/components/show-related-assessments-button/show-related-assessments-button.js
+++ b/src/ggrc/assets/javascripts/components/show-related-assessments-button/show-related-assessments-button.js
@@ -56,14 +56,6 @@
         var type = this.attr('instance.type');
         return type === 'Control' || type === 'Objective';
       }
-    },
-    events: {
-      '{viewModel.state} open': function (state) {
-        this.viewModel.dispatch({
-          type: 'forceShow',
-          state: state.attr('open')
-        })
-      }
     }
   });
 })(window.can, window.GGRC);

--- a/src/ggrc/assets/javascripts/components/tree/tree-item-actions.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-item-actions.js
@@ -70,13 +70,6 @@
     subTreeTypes: function () {
       can.trigger(this.attr('$el'), 'childTreeTypes');
     },
-    onForceShow: function (event) {
-      if (event.state) {
-        this.attr('$el').addClass('show-force');
-      } else {
-        this.attr('$el').removeClass('show-force');
-      }
-    },
     instance: null,
     childOptions: null,
     addItem: null,

--- a/src/ggrc/assets/javascripts/components/tree/tree-item-actions.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-item-actions.js
@@ -83,7 +83,17 @@
     allowMapping: null,
     isAllowToExpand: null,
     childModelsList: null,
-    expanded: false
+    expanded: false,
+    showReducedIcon: function () {
+      var pages = ['Workflow'];
+      var instanceTypes = [
+        'Cycle',
+        'CycleTaskGroup',
+        'CycleTaskGroupObjectTask'
+      ];
+      return _.contains(pages, GGRC.Utils.CurrentPage.getPageType()) &&
+        _.contains(instanceTypes, this.attr('instance').type);
+    }
   });
 
   GGRC.Components('treeItemActions', {

--- a/src/ggrc/assets/mustache/components/tree/tree-item-actions.mustache
+++ b/src/ggrc/assets/mustache/components/tree/tree-item-actions.mustache
@@ -3,77 +3,81 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
 
-  <a href="javascript://">
-    <i class="fa fa-cog"></i>
-    <i class="fa fa-caret-down"></i>
-  </a>
-  <ul>
-    <!---->
-    {{#if instance.viewLink}}
-      <!-- Link for open instance on info panel at bottom -->
-        <li>
-          <a href="javascript://" ($click)="maximizeObject">
-            <i class="fa fa-info-circle"></i>
-            View Info
-          </a>
-        </li>
-        {{#unless isSnapshot}}
-          <!-- Link for open instance on new Browser tab -->
+<div class="tree-item-actions {{#if showReducedIcon}}tree-item-actions--visible{{/if}}">
+  <div class="tree-item-actions__content">
+    <a href="javascript://">
+      {{^if showReducedIcon}}<i class="fa fa-cog"></i>{{/if}}
+      <i class="fa fa-caret-down"></i>
+    </a>
+    <ul>
+      <!---->
+      {{#if instance.viewLink}}
+        <!-- Link for open instance on info panel at bottom -->
           <li>
-            <a href="{{instance.viewLink}}" target="_blank" ($click)="openObject">
-              <i class="fa fa-long-arrow-right"></i>
-              Open in a new tab
+            <a href="javascript://" ($click)="maximizeObject">
+              <i class="fa fa-info-circle"></i>
+              View Info
             </a>
           </li>
-        {{/unless}}
-    {{/if}}
+          {{#unless isSnapshot}}
+            <!-- Link for open instance on new Browser tab -->
+            <li>
+              <a href="{{instance.viewLink}}" target="_blank" ($click)="openObject">
+                <i class="fa fa-long-arrow-right"></i>
+                Open in a new tab
+              </a>
+            </li>
+          {{/unless}}
+      {{/if}}
 
-    {{#if isAllowedToEdit}}
-      <li>
-        <tree-item-map {instance}="instance"></tree-item-map>
-      </li>
-      {{#is_allowed 'update' instance context='for'}}
+      {{#if isAllowedToEdit}}
         <li>
-          <a href="javascript://"
-             data-link-purpose="open-edit-modal"
-             data-toggle="modal-ajax-form"
-             data-modal-reset="reset"
-             data-modal-class="modal-wide"
-             data-object-singular="{{instance.class.model_singular}}"
-             data-object-plural="{{instance.class.table_plural}}"
-             data-object-id="{{instance.id}}">
-            <i class="fa fa-pencil-square-o"></i>
-            Edit object
+          <tree-item-map {instance}="instance"></tree-item-map>
+        </li>
+        {{#is_allowed 'update' instance context='for'}}
+          <li>
+            <a href="javascript://"
+              data-link-purpose="open-edit-modal"
+              data-toggle="modal-ajax-form"
+              data-modal-reset="reset"
+              data-modal-class="modal-wide"
+              data-object-singular="{{instance.class.model_singular}}"
+              data-object-plural="{{instance.class.table_plural}}"
+              data-object-id="{{instance.id}}">
+              <i class="fa fa-pencil-square-o"></i>
+              Edit object
+            </a>
+          </li>
+        {{/is_allowed}}
+      {{/if}}
+
+      <li>
+        <show-related-assessments-button {instance}="instance"
+                                        {reset-styles}="true"
+                                        {show-title}="false"
+                                        {show-icon}="true"
+                                        (force-show)="onForceShow(%event)"
+                                        text="Show related assessments"
+        ></show-related-assessments-button>
+      </li>
+
+      <li class="splitter"></li>
+
+      {{#unless isSnapshot}}
+        {{#if canExpand}}
+          <li>
+            <sub-tree-models {models-list}="childModelsList"
+                            {title}="instance.title"
+            ></sub-tree-models>
+          </li>
+        <li>
+          <a href="javascript://" ($click)="expand">
+            <i class="fa fa-{{expandIcon}}"></i>
+            {{expanderTitle}}
           </a>
         </li>
-      {{/is_allowed}}
-    {{/if}}
-
-    <li>
-      <show-related-assessments-button {instance}="instance"
-                                       {reset-styles}="true"
-                                       {show-title}="false"
-                                       {show-icon}="true"
-                                       (force-show)="onForceShow(%event)"
-                                       text="Show related assessments"
-      ></show-related-assessments-button>
-    </li>
-
-    <li class="splitter"></li>
-
-    {{#unless isSnapshot}}
-      {{#if canExpand}}
-        <li>
-          <sub-tree-models {models-list}="childModelsList"
-                           {title}="instance.title"
-          ></sub-tree-models>
-        </li>
-      <li>
-        <a href="javascript://" ($click)="expand">
-          <i class="fa fa-{{expandIcon}}"></i>
-          {{expanderTitle}}
-        </a>
-      </li>
-      {{/if}}
-    {{/unless}}
-  </ul>
+        {{/if}}
+      {{/unless}}
+    </ul>
+  </div>
+</div>

--- a/src/ggrc/assets/mustache/components/tree/tree-item-actions.mustache
+++ b/src/ggrc/assets/mustache/components/tree/tree-item-actions.mustache
@@ -56,7 +56,6 @@
                                         {reset-styles}="true"
                                         {show-title}="false"
                                         {show-icon}="true"
-                                        (force-show)="onForceShow(%event)"
                                         text="Show related assessments"
         ></show-related-assessments-button>
       </li>

--- a/src/ggrc/assets/stylesheets/components/tree/_sub-tree-wrapper.scss
+++ b/src/ggrc/assets/stylesheets/components/tree/_sub-tree-wrapper.scss
@@ -78,7 +78,7 @@ sub-tree-item {
         }
       }
 
-      tree-item-actions, .item-actions {
+      .tree-item-actions, .item-actions {
         visibility: visible;
       }
     }

--- a/src/ggrc/assets/stylesheets/components/tree/_tree-item-extra-info.scss
+++ b/src/ggrc/assets/stylesheets/components/tree/_tree-item-extra-info.scss
@@ -129,101 +129,111 @@ tree-item-extra-info {
   }
 }
 
-tree-item-actions {
-  display: flex;
-  border: 1px solid $warmGray;
-  border-radius: 5px;
-  margin: auto 0;
+.tree-item-actions {
+  margin-left: 10px;
+  margin-right: 10px;
   visibility: hidden;
-  position: relative;
 
-  &.show-force {
+  &--visible {
     visibility: visible;
-
-    ul {
-      display: block;
-    }
   }
 
-  &:hover {
-    ul {
-      display: block;
-    }
-  }
-
-  a {
-    text-decoration: none;
-    line-height: 18px;
-
-    &:hover {
-      text-decoration: none;
-    }
-  }
-
-  > a {
+  &__content {
+    background-color: $white;
     display: flex;
-    margin: 3px 5px;
-    i {
-      font-size: 13px !important;
+    border: 1px solid $warmGray;
+    border-radius: 5px;
+    margin: auto 0;
+    position: relative;
 
-      &:first-child {
-        margin-right: 5px;
+    &.show-force {
+      visibility: visible;
+
+      ul {
+        display: block;
       }
     }
-  }
-  > ul {
-    display: none;
-    position: absolute;
-    top: 20px;
-    width: 220px;
-    background-color: $white;
-    list-style-type: none;
-    z-index: 1000;
-    border: 1px solid $warmGray;
-    margin: 0;
-    box-shadow: 0 3px 1px rgba(0,0,0,.05);
 
     &:hover {
-      display: block;
+      ul {
+        display: block;
+      }
     }
 
-    li {
-      margin: 0;
-      padding: 0;
-      transition: all linear 0.1s;
+    a {
+      text-decoration: none;
+      line-height: 18px;
 
       &:hover {
-        background-color: $lightGray !important;
+        text-decoration: none;
+      }
+    }
 
+    > a {
+      display: flex;
+      margin: 3px 5px;
+      i {
+        font-size: 13px !important;
+
+        &:first-child:not(:only-child) {
+          margin-right: 5px;
+        }
+      }
+    }
+    > ul {
+      display: none;
+      position: absolute;
+      top: 20px;
+      width: 220px;
+      background-color: $white;
+      list-style-type: none;
+      z-index: 1000;
+      border: 1px solid $warmGray;
+      margin: 0;
+      box-shadow: 0 3px 1px rgba(0,0,0,.05);
+
+      &:hover {
+        display: block;
+      }
+
+      li {
+        margin: 0;
+        padding: 0;
+        transition: all linear 0.1s;
+
+        &:hover {
+          background-color: $lightGray !important;
+
+          > a, show-related-assessments-button > a,
+          tree-item-map > a, sub-tree-models > a {
+            color: $black !important;
+          }
+        }
         > a, show-related-assessments-button > a,
         tree-item-map > a, sub-tree-models > a {
-          color: $black !important;
-        }
-      }
-      > a, show-related-assessments-button > a,
-      tree-item-map > a, sub-tree-models > a {
-        line-height: 30px;
-        color: $black;
-        display: block;
-        font-size: 13px;
-        padding: 5px 15px;
-        text-decoration: none;
-        cursor: pointer;
-
-        i.fa {
-          margin-right: 3px;
-          width: 16px;
+          line-height: 30px;
+          color: $black;
+          display: block;
           font-size: 13px;
+          padding: 5px 15px;
+          text-decoration: none;
+          cursor: pointer;
+
+          i.fa {
+            margin-right: 3px;
+            width: 16px;
+            font-size: 13px;
+          }
         }
-      }
 
-      .openclose {
-        float: none !important;
-        padding: 0;
-      }
+        .openclose {
+          float: none !important;
+          padding: 0;
+        }
 
-      &.splitter {
-        border-bottom: 1px solid $lightGray;
+        &.splitter {
+          border-bottom: 1px solid $lightGray;
+        }
       }
     }
   }

--- a/src/ggrc/assets/stylesheets/components/tree/_tree-item-extra-info.scss
+++ b/src/ggrc/assets/stylesheets/components/tree/_tree-item-extra-info.scss
@@ -146,14 +146,6 @@ tree-item-extra-info {
     margin: auto 0;
     position: relative;
 
-    &.show-force {
-      visibility: visible;
-
-      ul {
-        display: block;
-      }
-    }
-
     &:hover {
       ul {
         display: block;

--- a/src/ggrc/assets/stylesheets/components/tree/_tree-view.scss
+++ b/src/ggrc/assets/stylesheets/components/tree/_tree-view.scss
@@ -162,7 +162,7 @@ tree-item {
         }
       }
 
-      tree-item-actions, .item-actions {
+      .tree-item-actions, .item-actions {
         visibility: visible;
       }
     }
@@ -214,12 +214,6 @@ tree-item {
     justify-content: flex-end;
     padding: 0 5px;
     visibility: hidden;
-  }
-
-  tree-item-actions {
-    margin-left: 10px;
-    margin-right: 10px;
-    background-color: $white;
   }
 
   .sub-tier {

--- a/src/ggrc/assets/stylesheets/modules/_tree-content.scss
+++ b/src/ggrc/assets/stylesheets/modules/_tree-content.scss
@@ -169,7 +169,7 @@ ul.new-tree {
             }
           }
 
-          tree-item-actions {
+          .tree-item-actions {
             visibility: visible;
           }
         }


### PR DESCRIPTION
Comment by User:

What is the problem / issue?
- The user journey for new workflow module UI is a little bit confusion for regular gGRC users.

User Journey summary:
Newly implemented Workflow UI requires user to hover over to the corresponding "workflow / task group / task" line item for a wheel shape button to appear on screen. User needs to hover over to the wheel shape button in order for a menu to display with function to expand on workflow where user can expand upon to view the existing task group detail. 
User needs to hover over to the line for another wheel to appear and hover over to the wheel to click on the expand function to see the underlying tasks.

What is the expected result / outcome? (ie What should happen?)

A few things that can improve to provide a more intuitive UI for our regular users.
1. The expand button to be "always on" instead of "upon hover" that users know there are things to expand on for additional detail. 
2. Expand icon to be a triangle instead of wheel to align with standard Google products (e.g. Drive, Gmail, Buganizer)
3. Additional "non-clickable" wheel on task group lines to be removed to avoid confusion (See attachment)

What is the impact if it is not fixed / implemented? 

- There are currently 50+ users who log onto gGRC on a weekly basis and 100+ users who log onto gGRC on more than once a month. They are not power users and would be hesitant to "click around" to explore on the new UI. By making the UI more intuitive, it would save at least 5-10 min per user to raise questions (emails or pings) to program or system admin and for admin to get back to the user and the delay it caused them due to the confusion.