### PR TITLE
GGRC-3021 [BE] Add filtering by 'unit' field (via Search API)

### DIFF
--- a/src/ggrc_workflows/migrations/versions/20170724180338_545d1c7adca5_update_workflow_patch1_related_tables.py
+++ b/src/ggrc_workflows/migrations/versions/20170724180338_545d1c7adca5_update_workflow_patch1_related_tables.py
@@ -34,6 +34,7 @@ def upgrade():
                                        nullable=True, server_default=None))
   op.add_column('workflows', sa.Column('repeat_multiplier', sa.Integer,
                                        nullable=False, server_default='0'))
+  op.create_index('ix_workflows_unit', 'workflows', ['unit'])
 
 
 def downgrade():


### PR DESCRIPTION
It is needed for 'My Tasks' page. When user presses "Create Task" button he filters by "One Time" workflow frequency. 

**FE sends next request:**
Request URL:https://ggrc-qa.appspot.com/search?q=&types=Workflow&extra_params=Workflow%3Astatus%3DActive%2Cfrequency%3Done_time
Request Method:GET

So to not break it I've decided to add hybrid property.