### PR TITLE
GGRC-3038: Remove 'Frequency' column from Workflows tree view

### DIFF
--- a/src/ggrc_workflows/assets/javascripts/models/workflow.js
+++ b/src/ggrc_workflows/assets/javascripts/models/workflow.js
@@ -46,7 +46,6 @@
         {attr_title: 'Manager', attr_name: 'owner', attr_sort_field: ''},
         {attr_title: 'Code', attr_name: 'slug'},
         {attr_title: 'State', attr_name: 'status'},
-        {attr_title: 'Repeat', attr_name: 'repeat'},
         {attr_title: 'Last Updated', attr_name: 'updated_at'}
       ]
     },


### PR DESCRIPTION
Remove 'Frequency' column from Workflows tree-view cause it is not searchable for now.