### PR TITLE
GGRC-1107 Assessment created from Audit summary page is not shown in Assessments tree view and tab is not increased by one

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/dashboard_widgets_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/dashboard_widgets_controller.js
@@ -108,7 +108,7 @@ CMS.Controllers.Filterable('CMS.Controllers.DashboardWidgets', {
       }
     }
   },
-  display: function () {
+  display: function (refetch) {
     var that = this;
     var tracker_stop = GGRC.Tracker.start(
       'DashboardWidget', 'display', this.options.model.shortName
@@ -124,7 +124,7 @@ CMS.Controllers.Filterable('CMS.Controllers.DashboardWidgets', {
       if (!that.content_controller && $containerVM.needToRefresh()) {
         dfd = $containerVM.display(FORCE_REFRESH);
       } else if (that.options.widgetType === 'treeview') {
-        dfd = $containerVM.display();
+        dfd = $containerVM.display(refetch);
       } else if (that.content_controller && that.content_controller.display) {
         dfd = that.content_controller.display();
       } else {
@@ -142,7 +142,7 @@ CMS.Controllers.Filterable('CMS.Controllers.DashboardWidgets', {
   display_path: function (path, refetch) {
     var that = this;
     if (!that.content_controller) {
-      return this.display();
+      return this.display(refetch);
     }
     return this.display().then(function () {
       if (that.content_controller && that.content_controller.display_path)

--- a/src/ggrc/assets/javascripts/models/assessment.js
+++ b/src/ggrc/assets/javascripts/models/assessment.js
@@ -16,7 +16,7 @@
     mixins: [
       'ownable', 'unique_title',
       'autoStatusChangeable', 'timeboxed', 'mapping-limit',
-      'inScopeObjects', 'accessControlList'
+      'inScopeObjects', 'accessControlList', 'refetchHash'
     ],
     is_custom_attributable: true,
     isRoleable: true,

--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -318,7 +318,8 @@
     table_plural: 'assessment_templates',
     mixins: [
       'mapping-limit',
-      'inScopeObjects'
+      'inScopeObjects',
+      'refetchHash'
     ],
     findOne: 'GET /api/assessment_templates/{id}',
     findAll: 'GET /api/assessment_templates',
@@ -567,18 +568,6 @@
       });
     },
 
-    getHashFragment: function () {
-      var widgetName = this.constructor.table_singular;
-      if (window.location.hash
-          .startsWith(['#', widgetName, '_widget'].join(''))) {
-        return;
-      }
-
-      return [widgetName,
-              '_widget/',
-              this.hash_fragment(),
-              '&refetch'].join('');
-    },
     ignore_ca_errors: true
   });
 })(window.can, window.CMS);

--- a/src/ggrc/assets/javascripts/models/mixins.js
+++ b/src/ggrc/assets/javascripts/models/mixins.js
@@ -341,4 +341,22 @@
       return isOverdue;
     }
   });
+
+  /**
+   * A mixin to generate hash with refetch param.
+   */
+  can.Model.Mixin('refetchHash', {
+    getHashFragment: function () {
+      var widgetName = this.constructor.table_singular;
+      if (window.location.hash
+          .startsWith(['#', widgetName, '_widget'].join(''))) {
+        return;
+      }
+
+      return [widgetName,
+              '_widget/',
+              this.hash_fragment(),
+              '&refetch'].join('');
+    }
+  });
 })(window.can, window.GGRC);


### PR DESCRIPTION
Precondition:
created program, audit
Steps to reproduce:
1. Go to Audit summary page
2. Click Create assessment button and create assessment
3. Look at tree view: once redirected to Assessments tab created assessment is not shown and the tab is not increased by one
Actual Result: Assessment created from Audit summary page is not shown in Assessments tree view and tab is not increased by one
Expected Result: Assessment created from Audit summary page should be shown in Assessments tree view and tab should be increased by one

Note: refresh is needed