### PR TITLE
GGRC-2855: Add Prev-Next buttons on Assessment Info pane

### DIFF
--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -207,6 +207,7 @@ dashboard-js-files:
   - components/dropdown/multiselect-dropdown.js
   - components/autocomplete/autocomplete.js
   - components/datepicker/datepicker.js
+  - components/prev-next-buttons/prev-next-buttons.js
   - components/person/person.js
   - components/inline_edit/inline.js
   - components/inline_edit/inline_checkbox.js
@@ -510,6 +511,7 @@ dashboard-js-template-files:
   - components/dropdown/dropdown.mustache
   - components/dropdown/multiselect_dropdown.mustache
   - components/revision-log/revision-log.mustache
+  - components/prev-next-buttons/prev-next-buttons.mustache
   - components/person/person.mustache
   - components/spinner/spinner.mustache
   - components/rich_text/rich_text.mustache

--- a/src/ggrc/assets/javascripts/components/assessment/attach-button.js
+++ b/src/ggrc/assets/javascripts/components/assessment/attach-button.js
@@ -14,11 +14,26 @@
     tag: tag,
     template: template,
     viewModel: {
+      define: {
+        hasPermissions: {
+          get: function (prevValue, setValue) {
+            var instance = this.attr('instance');
+            if (Permission.is_allowed_for('update', instance) &&
+              !instance.archived) {
+              this.checkFolder().always(function () {
+                setValue(true);
+              });
+            } else {
+              setValue(false);
+            }
+          }
+        }
+      },
       canAttach: false,
       isFolderAttached: false,
       checksPassed: false,
       error: {},
-      instance: {},
+      instance: null,
       isAttachActionDisabled: false,
       onBeforeCreate: function (event) {
         var items = event.items;
@@ -89,19 +104,6 @@
 
           return GFolder.findOne({id: id});
         });
-      }
-    },
-    events: {
-      inserted: function () {
-        var viewModel = this.viewModel;
-        var instance = viewModel.attr('instance');
-
-        if (Permission.is_allowed_for('update', instance) &&
-          !instance.archived) {
-          viewModel.checkFolder().always(function () {
-            viewModel.attr('hasPermissions', true);
-          });
-        }
       }
     }
   });

--- a/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.js
+++ b/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.js
@@ -317,6 +317,11 @@
       '{viewModel.instance} refreshInstance': function () {
         this.viewModel.attr('mappedSnapshots')
           .replace(this.viewModel.loadSnapshots());
+      },
+      '{viewModel} instance': function () {
+        this.viewModel.initializeFormFields();
+        this.viewModel.initGlobalAttributes();
+        this.viewModel.updateRelatedItems();
       }
     }
   });

--- a/src/ggrc/assets/javascripts/components/prev-next-buttons/prev-next-buttons.js
+++ b/src/ggrc/assets/javascripts/components/prev-next-buttons/prev-next-buttons.js
@@ -1,0 +1,55 @@
+/*!
+ Copyright (C) 2017 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+(function (can, GGRC, CMS) {
+  'use strict';
+
+  GGRC.Components('prevNextButtons', {
+    tag: 'prev-next-buttons',
+    template: can.view(
+      GGRC.mustache_path +
+      '/components/prev-next-buttons/prev-next-buttons.mustache'
+    ),
+    viewModel: {
+      define: {
+        currentIndex: {
+          type: 'number'
+        },
+        totalCount: {
+          type: 'number'
+        },
+        hasNext: {
+          get: function () {
+            var current = this.attr('currentIndex');
+            var total = this.attr('totalCount');
+            return current < total - 1;
+          }
+        },
+        hasPrev: {
+          get: function () {
+            var current = this.attr('currentIndex');
+            return current > 0;
+          }
+        }
+      },
+      setNext: function () {
+        var current = this.attr('currentIndex');
+        var hasNext = this.attr('hasNext');
+
+        if (hasNext) {
+          this.attr('currentIndex', current + 1);
+        }
+      },
+      setPrev: function () {
+        var current = this.attr('currentIndex');
+        var hasPrev = this.attr('hasPrev');
+
+        if (hasPrev) {
+          this.attr('currentIndex', current - 1);
+        }
+      }
+    }
+  });
+})(window.can, window.GGRC, window.CMS);

--- a/src/ggrc/assets/javascripts/components/prev-next-buttons/tests/prev-next-buttons_spec.js
+++ b/src/ggrc/assets/javascripts/components/prev-next-buttons/tests/prev-next-buttons_spec.js
@@ -1,0 +1,162 @@
+/*!
+  Copyright (C) 2017 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+describe('GGRC.Components.prevNextButtons', function () {
+  'use strict';
+
+  describe('hasNext getter', function () {
+    var viewModel;
+
+    beforeAll(function () {
+      viewModel = GGRC.Components.getViewModel('prevNextButtons');
+    });
+
+    it('returns true when current index is less than total',
+      function () {
+        var result;
+        viewModel.attr('currentIndex', 1);
+        viewModel.attr('totalCount', 3);
+
+        result = viewModel.attr('hasNext');
+
+        expect(result).toBeTruthy();
+      });
+
+    it('returns false when current index is greater than total',
+      function () {
+        var result;
+        viewModel.attr('currentIndex', 4);
+        viewModel.attr('totalCount', 3);
+
+        result = viewModel.attr('hasNext');
+
+        expect(result).toBeFalsy();
+      });
+
+    it('returns false when current index is equal to last item number',
+      function () {
+        var result;
+        viewModel.attr('currentIndex', 2);
+        viewModel.attr('totalCount', 3);
+
+        result = viewModel.attr('hasNext');
+
+        expect(result).toBeFalsy();
+      });
+
+    it('returns false when current index is equal to total',
+      function () {
+        var result;
+        viewModel.attr('currentIndex', 3);
+        viewModel.attr('totalCount', 3);
+
+        result = viewModel.attr('hasNext');
+
+        expect(result).toBeFalsy();
+      });
+  });
+
+  describe('hasPrev getter', function () {
+    var viewModel;
+
+    beforeAll(function () {
+      viewModel = GGRC.Components.getViewModel('prevNextButtons');
+    });
+
+    it('returns true when current index is greater than 0',
+      function () {
+        var result;
+        viewModel.attr('currentIndex', 1);
+
+        result = viewModel.attr('hasPrev');
+
+        expect(result).toBeTruthy();
+      });
+
+    it('returns false when current index equals 0',
+      function () {
+        var result;
+        viewModel.attr('currentIndex', 0);
+
+        result = viewModel.attr('hasPrev');
+
+        expect(result).toBeFalsy();
+      });
+  });
+
+  describe('setNext method', function () {
+    var viewModel;
+
+    beforeAll(function () {
+      viewModel = GGRC.Components.getViewModel('prevNextButtons');
+    });
+
+    it('increments current index when there is next item',
+      function () {
+        var result;
+        viewModel.attr('currentIndex', 1);
+        viewModel.attr('totalCount', 3);
+
+        viewModel.setNext();
+        result = viewModel.attr('currentIndex');
+
+        expect(result).toEqual(2);
+      });
+
+    it('leaves current index as is when it is last item',
+      function () {
+        var result;
+        viewModel.attr('currentIndex', 2);
+        viewModel.attr('totalCount', 3);
+
+        viewModel.setNext();
+        result = viewModel.attr('currentIndex');
+
+        expect(result).toEqual(2);
+      });
+
+    it('leaves current index as is when there is no next item',
+      function () {
+        var result;
+        viewModel.attr('currentIndex', 3);
+        viewModel.attr('totalCount', 3);
+
+        viewModel.setNext();
+        result = viewModel.attr('currentIndex');
+
+        expect(result).toEqual(3);
+      });
+  });
+
+  describe('setPrev method', function () {
+    var viewModel;
+
+    beforeAll(function () {
+      viewModel = GGRC.Components.getViewModel('prevNextButtons');
+    });
+
+    it('decrements current index when there is previous item',
+      function () {
+        var result;
+        viewModel.attr('currentIndex', 1);
+
+        viewModel.setPrev();
+        result = viewModel.attr('currentIndex');
+
+        expect(result).toEqual(0);
+      });
+
+    it('leaves current index as is when there is no previous item',
+      function () {
+        var result;
+        viewModel.attr('currentIndex', 0);
+
+        viewModel.setPrev();
+        result = viewModel.attr('currentIndex');
+
+        expect(result).toEqual(0);
+      });
+  });
+});

--- a/src/ggrc/assets/javascripts/components/tree/tests/tree-widget-container_spec.js
+++ b/src/ggrc/assets/javascripts/components/tree/tests/tree-widget-container_spec.js
@@ -61,6 +61,7 @@ describe('GGRC.Components.treeWidgetContainer', function () {
       vm.attr('pageInfo.count', 3);
 
       spyOn(vm, 'loadItems');
+      spyOn(vm, 'closeInfoPane');
     });
 
     it('sets current order properties', function () {
@@ -72,6 +73,7 @@ describe('GGRC.Components.treeWidgetContainer', function () {
       expect(vm.attr('sortingInfo.sortDirection')).toEqual('desc');
       expect(vm.attr('pageInfo.current')).toEqual(1);
       expect(vm.loadItems).toHaveBeenCalled();
+      expect(vm.closeInfoPane).toHaveBeenCalled();
     });
 
     it('changes sortDirection for current column', function () {
@@ -87,6 +89,7 @@ describe('GGRC.Components.treeWidgetContainer', function () {
       expect(vm.attr('sortingInfo.sortDirection')).toEqual('asc');
       expect(vm.attr('pageInfo.current')).toEqual(1);
       expect(vm.loadItems).toHaveBeenCalled();
+      expect(vm.closeInfoPane).toHaveBeenCalled();
     });
 
     it('changes sortBy property', function () {
@@ -471,5 +474,66 @@ describe('GGRC.Components.treeWidgetContainer', function () {
 
       expect(vm.attr('advancedSearch.mappingItems.length')).toBe(0);
     });
+  });
+
+  describe('getAbsoluteItemNumber() method', function () {
+    beforeEach(function () {
+      vm.attr({
+        pageInfo: {
+          pageSize: 10,
+          count: 5
+        },
+        showedItems: [{id: 1}, {id: 2}, {id: 3}]
+      });
+      vm.attr('pageInfo.current', 3);
+    });
+
+    it('should return correct item number when item is on page',
+      function () {
+        var result;
+
+        result = vm.getAbsoluteItemNumber({id: 2});
+
+        expect(result).toEqual(21);
+      });
+
+    it('should return "-1" when item is not on page',
+       function () {
+         var result;
+
+         result = vm.getAbsoluteItemNumber({id: 4});
+
+         expect(result).toEqual(-1);
+       });
+  });
+
+  describe('getRelativeItemNumber() method', function () {
+    it('should return correct item number on page', function () {
+      var result = vm.getRelativeItemNumber(12, 5);
+
+      expect(result).toEqual(2);
+    });
+  });
+
+  describe('getNextItemPage() method', function () {
+    beforeEach(function () {
+      spyOn(vm, 'loadItems');
+    });
+
+    it('should load items for appropriate page when item is not loaded',
+      function () {
+        vm.getNextItemPage(10, {current: 2, pageSize: 5});
+
+        expect(vm.attr('loading')).toBeTruthy();
+        expect(vm.loadItems).toHaveBeenCalled();
+      });
+
+    it('shouldn\'t load items when current item was already loaded',
+      function () {
+        vm.getNextItemPage(10, {current: 3, pageSize: 5});
+
+        expect(vm.attr('loading')).toBeFalsy();
+        expect(vm.loadItems).not.toHaveBeenCalled();
+      });
   });
 });

--- a/src/ggrc/assets/javascripts/controllers/info_pin_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/info_pin_controller.js
@@ -148,6 +148,18 @@ can.Control('CMS.Controllers.InfoPin', {
     this.element.trigger('scroll');
     return infoPaneOpenDfd;
   },
+  updateInstance: function (selector, instance) {
+    this.element.find(selector)
+      .viewModel()
+      .attr('instance', instance);
+  },
+  setLoadingIndicator: function (selector, isLoading) {
+    this.element.toggleClass('loading');
+
+    this.element.find(selector)
+      .viewModel()
+      .attr('isLoading', isLoading);
+  },
   ensureElementVisible: function (el) {
     var $objectArea;
     var $header;

--- a/src/ggrc/assets/mustache/assessments/header.mustache
+++ b/src/ggrc/assets/mustache/assessments/header.mustache
@@ -133,14 +133,24 @@ Copyright (C) 2017 Google Inc.
                 </ul>
             </div>
         </div>
-        {{#is_allowed 'update' instance context='for'}}
-            {{^if instance.archived}}
+
+        {{#is_info_pin}}
+            {{#unless options.isSubTreeItem}}
+                <div class="pane-header__toolbar-item">
+                    <prev-next-buttons {(current-index)}="options.selectedItem"
+                                       {(total-count)}="options.pageInfo.total"
+                    is-subtree-item="isSubTreeItem">
+                    </prev-next-buttons>
+                </div>
+            {{/unless}}
+        {{/is_info_pin}}
+
+        {{#unless isEditDenied}}
                 <object-state-toolbar {{#if is_info_pin}}class="pane-header__toolbar-item"{{/if}}
                                     {verifiers}="instance.assignees.Verifier"
                                     {instance}="instance"
                                     (on-state-change)="onStateChange(%event)">
                 </object-state-toolbar>
-            {{/if}}
-        {{/is_allowed}}
+        {{/unless}}
     </div>
 </div>

--- a/src/ggrc/assets/mustache/assessments/info.mustache
+++ b/src/ggrc/assets/mustache/assessments/info.mustache
@@ -3,6 +3,6 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
 {{#if instance}}
-  <assessment-info-pane {(instance)}="instance"></assessment-info-pane>
+  <assessment-info-pane {instance}="instance"></assessment-info-pane>
   <info-pane-footer {created-at}="instance.created_at" {modified-at}="instance.updated_at" {modified-by}="instance.modified_by"></info-pane-footer>
 {{/if}}

--- a/src/ggrc/assets/mustache/components/assessment/assessment-people.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/assessment-people.mustache
@@ -17,6 +17,7 @@
     </div>
 
     <div class="people-groups">
+    {{#instance}}
       {{#instance.class.assignable_list}}
         <related-people-mapping
           class="people-group"
@@ -91,6 +92,7 @@
           {{/if}}
         </related-people-mapping>
       {{/instance.class.assignable_list}}
+    {{/instance}}
     </div>
 </div>
 

--- a/src/ggrc/assets/mustache/components/assessment/info-pane/info-pane.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/info-pane/info-pane.mustache
@@ -4,6 +4,7 @@
 }}
 
 <section class="assessment-module info info-pane{{#is_info_pin}} sticky-info-panel assignable{{/is_info_pin}}">
+  <spinner {toggle}="isLoading" class="spinner-wrapper active"></spinner>
   <inline-form-control {instance}="instance">
   {{#is_info_pin}}
       <info-pin-buttons class="details-wrap" maximized="maximized" on-change-maximized-state="@onChangeMaximizedState"
@@ -107,12 +108,11 @@
                                     </action-toolbar-control>
                                 </editable-document-object-list-item>
                             </object-list>
-                          {{#unless instance.archived}}
-                            {{#is_allowed 'update' instance context='for'}}
+                          {{#unless isEditDenied}}
                             {{#toggle show_new_object_form}}
                                 <ggrc-quick-add
                                         (before-create)="addItems(%event, 'urls')"
-                                        (after-create)="updateItems('urls')"
+                                        (after-create)="updateItems( 'urls')"
                                         {parent_instance}="instance"
                                         join_model="Relationship"
                                         quick_create="create_url">
@@ -141,7 +141,6 @@
                             {{else}}
                                 <button class="btn btn-small btn-gray" {{toggle_button}}>Add</button>
                             {{/toggle}}
-                          {{/is_allowed}}
                           {{/unless}}
                         </div>
                     </div>
@@ -239,15 +238,13 @@
             </div>
             <div class="assessment-comments info-pane__sidebar">
                 <div class="info-pane__section-title">Responses/Comments</div>
-                {{#unless instance.archived}}
-                  {{#is_allowed 'update' instance context='for'}}
+                {{#unless isEditDenied}}
                     <comment-add-form class="comment-add-form"
                                     {instance}="instance"
                                     {is-saving}="isUpdatingComments"
                                     (after-create)="updateItems('comments')"
                                     (before-create)="addItems(%event, 'comments')"
                     ></comment-add-form>
-                  {{/is_allowed}}
                 {{/unless}}
                 <assessment-mapped-comments {mapped-items}="comments"></assessment-mapped-comments>
             </div>

--- a/src/ggrc/assets/mustache/components/prev-next-buttons/prev-next-buttons.mustache
+++ b/src/ggrc/assets/mustache/components/prev-next-buttons/prev-next-buttons.mustache
@@ -1,0 +1,17 @@
+{{!
+  Copyright (C) 2017 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+}}
+
+<div class="navigation-wrap">
+    <div class="navigation-item">
+        <a can-click="setPrev()" class="{{#unless hasPrev}}disabled{{/unless}}">
+            <i class="fa fa-angle-left"></i>
+        </a>
+    </div>
+    <div class="navigation-item">
+        <a ($click)="setNext()" class="{{#unless hasNext}}disabled{{/unless}}">
+            <i class="fa fa-angle-right"></i>
+        </a>
+    </div>
+</div>

--- a/src/ggrc/assets/mustache/components/related-objects/related-issues.mustache
+++ b/src/ggrc/assets/mustache/components/related-objects/related-issues.mustache
@@ -3,6 +3,7 @@ Copyright (C) 2017 Google Inc.
 Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 `}}
 
+{{#baseInstance}}
 <related-objects {base-instance}="baseInstance" {predefined-filter}="relatedIssuesFilter" related-items-type="Issue">
     <div class="grid-data__toolbar flex-box">
         <tree-pagination {(paging)}="paging" class="grid-data__toolbar-item"></tree-pagination>
@@ -33,3 +34,4 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
         </object-list>
     </div>
 </related-objects>
+{{/baseInstance}}

--- a/src/ggrc/assets/stylesheets/modules/_info-pin.scss
+++ b/src/ggrc/assets/stylesheets/modules/_info-pin.scss
@@ -16,6 +16,45 @@
   transition: height 0.3s ease-in, z-index 0.3s ease-in, opacity 0.3s ease-in;
 
   .info {
+    > .spinner-wrapper {
+      display: none;
+    }
+  }
+
+  &.loading {
+    overflow: hidden;
+
+    .info {
+      // Should affect only direct children
+      > .spinner-wrapper {
+        align-items: center;
+        bottom: 0;
+        display: flex;
+        justify-content: center;
+        left: 0;
+        right: 0;
+        top: 0;
+        position: absolute;
+        z-index: 1;
+
+        .spinner {
+          font-size: 18px;
+
+          .fa {
+            color: $defaultWidget;
+            font-size: 32px;
+          }
+        }
+      }
+
+      .tier-content {
+        opacity: 0.5;
+        pointer-events: none;
+      }
+    }
+  }
+
+  .info {
     box-shadow: none;
     padding: 15px 25px 20px;
     .small-info {

--- a/src/ggrc/assets/stylesheets/modules/_object-header.scss
+++ b/src/ggrc/assets/stylesheets/modules/_object-header.scss
@@ -188,3 +188,28 @@
     }
   }
 }
+
+.navigation-wrap {
+  display: flex;
+  margin-left: 10px;
+
+  > .navigation-item {
+    line-height: 27px;
+
+    > a {
+      border: 1px solid #ccc;
+      background: #fff;
+      cursor: pointer;
+      padding: 6px 10px;
+
+      &:hover {
+        background: $warmGray;
+      }
+
+      &.disabled {
+        cursor: default;
+        opacity: 0.7;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add ability to navigate between assessments by clicking on "Next" and "Previous" buttons in info pane.

![assessmentpage_next_previous_02](https://user-images.githubusercontent.com/24203972/29166765-6a7dc8d6-7dd0-11e7-9a22-e78a5a8429ec.png)
![assessmentpage_next_previous_01](https://user-images.githubusercontent.com/24203972/29166770-73912daa-7dd0-11e7-88fc-2a5f7e23cc14.png)

Assessment info pane should be closed when the following actions are performed on the page:
1. Sorting;
2. Pagination;
3. Filtering (simple search / advanced search / filtering by states)
4. On creating new object.