### PR TITLE
GGRC-3040 "Uncaught TypeError: Cannot read property 'element' of undefined" error occurs while mapping object to Assessment via Edit/New Assessment modal window

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment/map-button-using-assessment-type.js
+++ b/src/ggrc/assets/javascripts/components/assessment/map-button-using-assessment-type.js
@@ -13,12 +13,18 @@
     viewModel: {
       assessmentType: '',
       instance: {},
+      deferredTo: {},
       onClick: function (el, ev) {
         el.data('type', this.attr('assessmentType'));
+        el.data('deferred_to', this.attr('deferredTo'));
         can.trigger(el, 'openMapper', ev);
       }
     },
     events: {
+      inserted: function () {
+        this.viewModel.attr('deferredTo',
+          this.element.data('deferred_to'));
+      },
       '.assessment-map-btn click': function (el, ev) {
         this.viewModel.onClick(el, ev);
         ev.preventDefault();

--- a/src/ggrc/assets/mustache/assessments/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessments/modal_content.mustache
@@ -117,6 +117,7 @@
                   instance="instance"
                   mapping="related_objects_as_source"
                   from-binding="true"
+                  {type}="instance.assessment_type"
                   deferred="true">
             <label class="ggrc-form-item__label">
               Mapped Objects
@@ -150,14 +151,14 @@
               {{/list.length}}
             </div>
             <div class="objective-selector">
-              <map-button-using-assessment-type
+               <map-button-using-assessment-type
+                {{data "deferred_to"}}
                 {instance}="instance"
                 {assessment-type}="instance.assessment_type">
                   {{#if instance.audit}}
                     <a class="section-add section-sticky btn btn-small btn-white assessment-map-btn"
                       href="javascript://"
                       rel="tooltip"
-                      {{data "deferred_to"}}
                       data-placement="left"
                       data-deferred="true"
                       data-object-source="true"
@@ -175,7 +176,6 @@
                     <a class="section-add section-sticky btn btn-small btn-white assessment-map-btn"
                       href="javascript://"
                       rel="tooltip"
-                      {{data "deferred_to"}}
                       data-placement="left"
                       data-deferred="true"
                       data-object-source="true"


### PR DESCRIPTION
_Steps to reproduce:_
1. On the audit page invoke new assessment modal window
2. Click 'Map Objects' button
3. Select an object in Unified mapper and click 'Map Selected'
4. Look at the screen: error occurs

_Actual Result:_ "Uncaught TypeError: Cannot read property 'element' of undefined" error occurs while mapping object to Assessment via Edit/New Assessment modal window
_Expected Result:_ no errors are shown while mapping object to Assessment via Edit/New Assessment modal window

![screenshot-1](https://user-images.githubusercontent.com/4204416/29168222-a8a66856-7dd6-11e7-8336-90c88cabc5af.png)
