### PR TITLE
QUICK-FIX Refactor asserts comparing objects

### DIFF
--- a/test/selenium/src/lib/base.py
+++ b/test/selenium/src/lib/base.py
@@ -64,15 +64,14 @@ class Test(InstanceRepresentation):
     Finally, make pytest assert for objects, then xfail assert for attributes.
     """
     split_objs = (
-        Test.extended_assert_w_excluded_attrs(
+        Test.general_assert(
             expected_objs, actual_objs, *exclude_attrs))
     assert (True if Entity.is_list_of_attrs_equal(
         split_objs["exp_ex_attrs"], split_objs["act_ex_attrs"])
         else pytest.xfail(reason=issue_msg))
 
   @staticmethod
-  def extended_assert_w_excluded_attrs(expected_objs, actual_objs,
-                                       *exclude_attrs):
+  def general_assert(expected_objs, actual_objs, *exclude_attrs):
     """Perform extended assert for expected and actual objects according to
     dictionary of attributes to exclude and providing issue's message.
     Initially, based on original objects prepare expected and actual

--- a/test/selenium/src/lib/constants/element.py
+++ b/test/selenium/src/lib/constants/element.py
@@ -242,6 +242,7 @@ class CommonAssessmentTemplate(Common):
 class CommonIssue(Common):
   """Common elements' labels and properties for Issues objects."""
   ISSUE = objects.get_normal_form(objects.get_singular(objects.ISSUES))
+  STATE = Base.STATE
 
 
 class ObjectStates(object):
@@ -303,6 +304,12 @@ class AssessmentInfoWidget(CommonAssessment):
   TITLE_UPPER = CommonAssessment.TITLE.upper()
   CODE_UPPER = CommonAssessment.CODE.upper()
   COMMENTS_HEADER = "RESPONSES/COMMENTS"
+
+
+class IssueInfoWidget(CommonIssue):
+  """Elements' labels and properties for Issue Info widgets."""
+  TITLE_UPPER = CommonIssue.TITLE.upper()
+  CODE_UPPER = CommonIssue.CODE.upper()
 
 
 class AssessmentTemplateModalSetVisibleFields(CommonModalSetVisibleFields):

--- a/test/selenium/src/lib/entities/entities_factory.py
+++ b/test/selenium/src/lib/entities/entities_factory.py
@@ -597,8 +597,8 @@ class AssessmentsFactory(EntitiesFactory):
     """
     # pylint: disable=too-many-locals
     asmt_entity = cls._create_random_asmt()
-    asmt_entity = cls._update_asmt_attrs_values(
-        obj=asmt_entity, is_allow_none_values=False, type=type, id=id,
+    asmt_entity = Entity.update_objs_attrs_values_by_entered_data(
+        obj_or_objs=asmt_entity, is_allow_none_values=False, type=type, id=id,
         title=title, href=href, url=url, slug=slug, status=status,
         owners=owners, audit=audit, recipients=recipients, assignees=assignees,
         verified=verified, verifier=verifier, creator=creator,
@@ -627,16 +627,6 @@ class AssessmentsFactory(EntitiesFactory):
         "Assessor": [cls.default_person.__dict__],
         "Creator": [cls.default_person.__dict__]}
     return random_asmt
-
-  @classmethod
-  def _update_asmt_attrs_values(cls, obj, **arguments):
-    """Update Assessments (obj) attributes values according to dictionary of
-    arguments (key = value). Generated data-'obj', entered data-'**arguments'.
-    """
-    if arguments.get("verifier"):
-      obj.assignees['Verifier'] = [cls.default_person.__dict__]
-    return Entity.update_objs_attrs_values_by_entered_data(
-        obj_or_objs=obj, **arguments)
 
 
 class IssuesFactory(EntitiesFactory):

--- a/test/selenium/src/lib/entities/entities_factory.py
+++ b/test/selenium/src/lib/entities/entities_factory.py
@@ -648,7 +648,7 @@ class IssuesFactory(EntitiesFactory):
   @classmethod
   def create_empty(cls):
     """Create blank Issue object."""
-    empty_issue = IssueEntity
+    empty_issue = IssueEntity()
     empty_issue.type = cls.obj_issue
     empty_issue.custom_attributes = {None: None}
     empty_issue.access_control_list = []

--- a/test/selenium/src/lib/entities/entity.py
+++ b/test/selenium/src/lib/entities/entity.py
@@ -297,6 +297,12 @@ class Representation(object):
                   string_utils.convert_to_list(origin_obj_attr_value) +
                   string_utils.convert_to_list(obj_attr_value))
             setattr(obj, obj_attr_name, obj_attr_value)
+            if obj_attr_name in ["creator", "assessor", "verifier"]:
+              from lib.entities.entities_factory import ObjectPersonsFactory
+              if not isinstance(obj.assignees, dict):
+                obj.assignees = dict()
+              obj.assignees[obj_attr_name.capitalize()] = (
+                  [ObjectPersonsFactory().default().__dict__])
           if is_replace_values_of_dicts and isinstance(_obj_attr_value, dict):
             obj_attr_value = string_utils.exchange_dicts_items(
                 transform_dict=_obj_attr_value,

--- a/test/selenium/src/lib/page/widget/info_widget.py
+++ b/test/selenium/src/lib/page/widget/info_widget.py
@@ -335,9 +335,22 @@ class AssessmentTemplates(InfoPanel):
 class Issues(InfoPanel):
   """Model for Issue object Info pages and Info panels."""
   _locators = locator.WidgetInfoIssue
+  _elements = element.IssueInfoWidget
 
   def __init__(self, driver):
     super(Issues, self).__init__(driver)
+    self.code_text, self.code_entered_text = (
+        self.get_header_and_value_text_from_custom_scopes(
+            self._elements.CODE.upper()))
+    # all obj scopes
+    self.list_all_headers_text = [
+        self.title().text,
+        self._elements.STATE.upper(),
+        self.code_text]
+    self.list_all_values_text = [
+        self.title_entered().text,
+        objects.get_normal_form(self.state().text),
+        self.code_entered_text]
 
 
 class Regulations(SnapshotableInfoPanel):

--- a/test/selenium/src/lib/service/rest_service.py
+++ b/test/selenium/src/lib/service/rest_service.py
@@ -202,7 +202,7 @@ class AssessmentsService(BaseRestService):
     'Creator', 'Assessor' to them via REST API and return list of created
     objects with filtered attributes.
     """
-    objs = BaseRestService(url.ASSESSMENTS).create_objs(
+    objs = BaseRestService(self.endpoint).create_objs(
         count, factory_params, **attrs_for_template)
     assignees = [assignee for obj in objs for assignee in obj.assignees]
     if assignees:

--- a/test/selenium/src/lib/utils/string_utils.py
+++ b/test/selenium/src/lib/utils/string_utils.py
@@ -172,6 +172,10 @@ def convert_str_to_datetime(datetime_str):
     # u'07/02/2017 04:34:05 PM UTC'
     if len(datetime_parts) == 4 and ":" in datetime_str:
       datetime_format = "%m/%d/%Y %I:%M:%S %p %Z"
+      # u'07/02/2017 04:34:05 PM +03'
+      if datetime_parts[3].upper() != 'UTC':
+        from dateutil import parser
+        return parser.parse(datetime_str)
   # REST and CSV like datetime
   if "/" not in datetime_str and any(_ in datetime_str for _ in ["-", ":"]):
     # u'2017-07-02T16:34:05' and u'2017-07-02 16:34:05'

--- a/test/selenium/src/tests/test_asmts_workflow.py
+++ b/test/selenium/src/tests/test_asmts_workflow.py
@@ -10,8 +10,7 @@
 import pytest
 
 from lib import base
-from lib.base import Test
-from lib.constants import messages, roles
+from lib.constants import roles
 from lib.constants.element import AssessmentStates
 from lib.entities import entities_factory
 from lib.service import webui_service, rest_service
@@ -48,9 +47,7 @@ class TestAssessmentsWorkflow(base.Test):
         get_list_objs_from_info_panels(
             src_obj=new_audit_rest, objs=expected_asmt).update_attrs(
             comments={"created_at": None}, is_replace_dicts_values=True))
-    assert expected_asmt == actual_asmt, (
-        messages.AssertionMessages.
-        format_err_msg_equal(expected_asmt, actual_asmt))
+    self.general_assert(expected_asmt, actual_asmt)
 
   @pytest.mark.smoke_tests
   def test_asmt_logs(
@@ -180,7 +177,7 @@ class TestAssessmentsWorkflow(base.Test):
     assessments_service = webui_service.AssessmentsService(selenium)
     getattr(assessments_service, action)(expected_asmt)
     actual_asmt = assessments_service.get_obj_from_info_page(expected_asmt)
-    Test.extended_assert_w_excluded_attrs(
+    self.general_assert(
         expected_asmt.update_attrs(status=expected_final_state.title(),
                                    title=actual_asmt.title,
                                    verified=actual_asmt.verified).repr_ui(),

--- a/test/selenium/src/tests/test_audit_page.py
+++ b/test/selenium/src/tests/test_audit_page.py
@@ -9,7 +9,6 @@
 import pytest
 
 from lib import base
-from lib.constants import messages
 from lib.entities import entities_factory
 from lib.service import webui_service
 
@@ -69,11 +68,8 @@ class TestAuditPage(base.Test):
         webui_service.AssessmentTemplatesService(selenium).
         get_list_objs_from_tree_view(src_obj=new_audit_rest))
     # due to 'expected_asmt_tmpl.updated_at = None'
-    actual_asmt_tmpls = [actual_asmt_tmpl.update_attrs(updated_at=None)
-                         for actual_asmt_tmpl in actual_asmt_tmpls]
-    assert [expected_asmt_tmpl] == actual_asmt_tmpls, (
-        messages.AssertionMessages.
-        format_err_msg_equal([expected_asmt_tmpl], actual_asmt_tmpls))
+    self.general_assert(
+        [expected_asmt_tmpl], actual_asmt_tmpls, "updated_at")
 
   @pytest.mark.smoke_tests
   def test_asmt_creation(self, new_program_rest, new_audit_rest, selenium):
@@ -92,11 +88,8 @@ class TestAuditPage(base.Test):
     actual_asmts = (webui_service.AssessmentsService(selenium).
                     get_list_objs_from_tree_view(src_obj=new_audit_rest))
     # due to 'expected_asmt.updated_at = None'
-    actual_asmts = [actual_asmt.update_attrs(updated_at=None)
-                    for actual_asmt in actual_asmts]
-    assert [expected_asmt] == actual_asmts, (
-        messages.AssertionMessages.
-        format_err_msg_equal([expected_asmt], actual_asmts))
+    self.general_assert(
+        [expected_asmt], actual_asmts, "updated_at")
 
   @pytest.mark.smoke_tests
   @pytest.mark.parametrize(
@@ -136,14 +129,12 @@ class TestAuditPage(base.Test):
                     get_list_objs_from_info_panels(
                         src_obj=new_audit_rest, objs=expected_asmts))
     # due to 'expected_asmt.updated_at = None',
+    #        'expected_asmt.slug = None'
     #        'expected_asmt.custom_attributes = {None: None}'
-    actual_asmts = [
-        actual_asmt.update_attrs(is_replace_attrs=True, slug=None).
-        update_attrs(is_replace_attrs=False, custom_attributes={None: None})
+    actual_asmts = [actual_asmt.update_attrs(
+        is_replace_attrs=False, custom_attributes={None: None})
         for actual_asmt in actual_asmts]
-    assert expected_asmts == actual_asmts, (
-        messages.AssertionMessages.
-        format_err_msg_equal(expected_asmts, actual_asmts))
+    self.general_assert(expected_asmts, actual_asmts, "updated_at", "slug")
 
   @pytest.mark.smoke_tests
   @pytest.mark.cloning
@@ -153,12 +144,10 @@ class TestAuditPage(base.Test):
     - Execution and return of fixture 'create_and_clone_audit'.
     """
     expected_audit = create_and_clone_audit["expected_audit"].repr_ui()
+    actual_audit = create_and_clone_audit["actual_audit"]
     # due to 'expected_audit.slug = None'
-    actual_audit = (
-        create_and_clone_audit["actual_audit"].update_attrs(slug=None))
-    assert expected_audit == actual_audit, (
-        messages.AssertionMessages.
-        format_err_msg_equal(expected_audit, actual_audit))
+    self.general_assert(
+        expected_audit, actual_audit, "slug")
 
   @pytest.mark.smoke_tests
   @pytest.mark.cloning
@@ -199,12 +188,8 @@ class TestAuditPage(base.Test):
                          get_list_objs_from_tree_view(src_obj=actual_audit))
     # due to 'expected_asmt_tmpl.slug = None',
     #        'expected_asmt_tmpl.updated_at = {None: None}'
-    actual_asmt_tmpls = [
-        actual_asmt_tmpl.update_attrs(slug=None, updated_at=None)
-        for actual_asmt_tmpl in actual_asmt_tmpls]
-    assert [expected_asmt_tmpl] == actual_asmt_tmpls, (
-        messages.AssertionMessages.
-        format_err_msg_equal([expected_asmt_tmpl], actual_asmt_tmpls))
+    self.general_assert(
+        expected_asmt_tmpl, actual_asmt_tmpls, "slug", "updated_at")
 
   @pytest.mark.xfail(strict=True)
   @pytest.mark.smoke_tests
@@ -218,9 +203,7 @@ class TestAuditPage(base.Test):
     -Execution and return of fixture 'create_and_clone_audit'.
     """
     actual_audit = create_and_clone_audit["actual_audit"]
-    # due to 'actual_control.custom_attributes = {None: None}'
-    expected_control = (create_and_clone_audit["control"].
-                        repr_ui().update_attrs(custom_attributes={None: None}))
+    expected_control = create_and_clone_audit["control"].repr_ui()
     # due to 'actual_program.custom_attributes = {None: None}'
     expected_program = (create_and_clone_audit["program"].
                         repr_ui().update_attrs(custom_attributes={None: None}))
@@ -228,8 +211,8 @@ class TestAuditPage(base.Test):
                        get_list_objs_from_tree_view(src_obj=actual_audit))
     actual_programs = (webui_service.ProgramsService(selenium).
                        get_list_objs_from_tree_view(src_obj=actual_audit))
-    assert [expected_control] == actual_controls, (
-        messages.AssertionMessages.
-        format_err_msg_equal([expected_control], actual_controls))
+    # due to 'actual_control.custom_attributes = {None: None}'
+    self.general_assert(
+        [expected_control], actual_controls, "custom_attributes")
     self.extended_assert([expected_program], actual_programs,
                          "Issue in app GGRC-2381", "manager")

--- a/test/selenium/src/tests/test_snapshots.py
+++ b/test/selenium/src/tests/test_snapshots.py
@@ -12,6 +12,7 @@ import pytest
 from lib import base
 from lib.constants import messages, objects, element
 from lib.constants.element import Lhn, MappingStatusAttrs
+from lib.entities import entities_factory
 from lib.factory import get_ui_service
 from lib.page import dashboard
 from lib.service import webui_service
@@ -211,17 +212,15 @@ class TestSnapshots(base.Test):
     audit_with_two_controls = (
         create_audit_and_update_first_of_two_original_controls)
     audit = audit_with_two_controls["audit"]
-    # due to 'actual_control.custom_attributes = {None: None}'
-    expected_control = (audit_with_two_controls["control"].repr_ui().
-                        update_attrs(custom_attributes={None: None}))
+    expected_control = audit_with_two_controls["control"].repr_ui()
     actual_controls_tab_count = (webui_service.ControlsService(selenium).
                                  get_count_objs_from_tab(src_obj=audit))
     assert len([expected_control]) == actual_controls_tab_count
     actual_controls = (webui_service.ControlsService(selenium).
                        get_list_objs_from_tree_view(src_obj=audit))
-    assert [expected_control] == actual_controls, (
-        messages.AssertionMessages.
-        format_err_msg_equal([expected_control], actual_controls))
+    # due to 'actual_control.custom_attributes = {None: None}'
+    self.general_assert(
+        [expected_control], actual_controls, "custom_attributes")
 
   @pytest.mark.smoke_tests
   def test_bulk_update_audit_objects_to_latest_ver(
@@ -237,11 +236,9 @@ class TestSnapshots(base.Test):
     audit_with_two_controls = (
         create_audit_and_update_first_of_two_original_controls)
     audit = audit_with_two_controls["audit"]
-    # due to 'actual_control.custom_attributes = {None: None}'
-    expected_controls = [
-        expected_control.repr_ui().update_attrs(custom_attributes={None: None})
-        for expected_control in [audit_with_two_controls["updated_control"],
-                                 audit_with_two_controls["second_control"]]]
+    expected_controls = [expected_control.repr_ui() for expected_control
+                         in [audit_with_two_controls["updated_control"],
+                             audit_with_two_controls["second_control"]]]
     (webui_service.AuditsService(selenium).
      bulk_update_via_info_page(audit_obj=audit))
     actual_controls_tab_count = (webui_service.ControlsService(selenium).
@@ -249,9 +246,9 @@ class TestSnapshots(base.Test):
     assert len(expected_controls) == actual_controls_tab_count
     actual_controls = (webui_service.ControlsService(selenium).
                        get_list_objs_from_tree_view(src_obj=audit))
-    assert expected_controls == actual_controls, (
-        messages.AssertionMessages.
-        format_err_msg_equal(expected_controls, actual_controls))
+    # due to 'actual_control.custom_attributes = {None: None}'
+    self.general_assert(expected_controls, actual_controls,
+                        "custom_attributes")
 
   @pytest.mark.smoke_tests
   @pytest.mark.parametrize("tab_name", [Lhn.ALL_OBJS, Lhn.MY_OBJS])
@@ -437,10 +434,9 @@ class TestSnapshots(base.Test):
     "Checking assessment"
     "Checking issue"
     """
-    # due to 'actual_control.custom_attributes = {None: None}'
     expected_control = (
         create_audit_with_control_and_update_control["new_control_rest"][0].
-        repr_ui().update_attrs(custom_attributes={None: None}))
+        repr_ui())
     source_obj = dynamic_object
     control_service = webui_service.ControlsService(selenium)
     control_service.map_objs_via_tree_view(src_obj=source_obj,
@@ -449,9 +445,9 @@ class TestSnapshots(base.Test):
         src_obj=source_obj)
     actual_controls = control_service.get_list_objs_from_tree_view(source_obj)
     assert len([expected_control]) == actual_controls_count_in_tab
-    assert [expected_control] == actual_controls, (
-        messages.AssertionMessages.
-        format_err_msg_equal([expected_control], actual_controls))
+    # due to 'actual_control.custom_attributes = {None: None}'
+    self.general_assert([expected_control], actual_controls,
+                        "custom_attributes")
 
   @pytest.mark.smoke_tests
   @pytest.mark.parametrize(
@@ -470,10 +466,7 @@ class TestSnapshots(base.Test):
     "Checking issue"
     """
     audit_with_one_control = create_audit_with_control_and_update_control
-    # due to 'actual_control.custom_attributes = {None: None}'
-    expected_control = (
-        audit_with_one_control["new_control_rest"][0].
-        repr_ui().update_attrs(custom_attributes={None: None}))
+    expected_control = audit_with_one_control["new_control_rest"][0].repr_ui()
     audit = audit_with_one_control["new_audit_rest"][0]
     existing_obj = dynamic_object
     existing_obj_service = get_ui_service(existing_obj.type)(selenium)
@@ -485,9 +478,9 @@ class TestSnapshots(base.Test):
     actual_controls = (controls_service.get_list_objs_from_tree_view(
         src_obj=existing_obj))
     assert len([expected_control]) == actual_controls_count
-    assert [expected_control] == actual_controls, (
-        messages.AssertionMessages.
-        format_err_msg_equal([expected_control], actual_controls))
+    # due to 'actual_control.custom_attributes = {None: None}'
+    self.general_assert([expected_control], actual_controls,
+                        "custom_attributes")
 
   @pytest.mark.xfail(strict=True)
   @pytest.mark.smoke_tests
@@ -537,14 +530,14 @@ class TestSnapshots(base.Test):
 
   @pytest.mark.smoke_tests
   @pytest.mark.parametrize(
-      "dynamic_object",
-      ["new_assessment_rest",
-       pytest.mark.xfail(reason="Issue GGRC-1407", strict=True)
-          ("new_issue_rest")],
+      "dynamic_object, expected_state",
+      [("new_assessment_rest", element.BaseStates.IN_PROGRESS),
+       pytest.mark.xfail(reason="Issue GGRC-1407", strict=True)(
+          ("new_issue_rest", element.IssueStates.DRAFT))],
       indirect=["dynamic_object"])
   def test_asmt_and_issue_mapped_to_origin_control(
       self, create_audit_with_control_and_update_control,
-      dynamic_object, selenium
+      dynamic_object, expected_state, selenium
   ):
     """
     Check Assessment or Issue was mapped to origin control after mapping
@@ -553,24 +546,22 @@ class TestSnapshots(base.Test):
       - check Assessment
       - check Issue
     """
+    origin_control = create_audit_with_control_and_update_control[
+        "update_control_rest"][0]
     snapshoted_control = create_audit_with_control_and_update_control[
         "new_control_rest"][0]
-    # due to 'actual_control.custom_attributes = {None: None}'
-    # expected_obj = (dynamic_object.repr_ui().update_attrs(
-    #     custom_attributes={None: None}))
-    expected_obj = (dynamic_object.repr_ui().update_attrs(
-        custom_attributes={None: None}, updated_at=None,
-        status=element.AssessmentStates.IN_PROGRESS))
+    expected_obj = dynamic_object.repr_ui().update_attrs(status=expected_state)
     expected_obj_service = get_ui_service(expected_obj.type)(selenium)
     (webui_service.ControlsService(selenium).map_objs_via_tree_view(
         src_obj=expected_obj, dest_objs=[snapshoted_control]))
-    actual_obj = expected_obj_service.get_obj_from_info_page(obj=expected_obj)
-    # due to 'expected_obj.objects_under_assessment = None'
-    actual_obj.update_attrs(objects_under_assessment=None,
-                            custom_attributes={None: None})
-    assert expected_obj == actual_obj, (
-        messages.AssertionMessages.
-        format_err_msg_equal(expected_obj, actual_obj))
+    actual_objs = expected_obj_service.get_list_objs_from_tree_view(
+        src_obj=origin_control)
+    # due to 'actual_obj.custom_attributes = {None: None}'
+    #        'expected_asmt.objects_under_assessment = None'
+    self.general_assert(
+        [expected_obj], actual_objs, "custom_attributes"
+        if dynamic_object.type == entities_factory.EntitiesFactory.obj_issue
+        else "objects_under_assessment", "custom_attributes")
 
   @pytest.mark.parametrize(
       "dynamic_object",

--- a/test/selenium/src/tests/test_unified_mapper.py
+++ b/test/selenium/src/tests/test_unified_mapper.py
@@ -8,7 +8,6 @@
 import pytest
 
 from lib import base
-from lib.constants import messages
 from lib.service import webui_service
 
 
@@ -37,6 +36,5 @@ class TestProgramPage(base.Test):
     assert len(expected_controls) == actual_controls_tab_count
     actual_controls = (webui_service.ControlsService(selenium).
                        get_list_objs_from_tree_view(src_obj=new_program_rest))
-    assert sorted(expected_controls) == sorted(actual_controls), (
-        messages.AssertionMessages.
-        format_err_msg_equal(expected_controls, actual_controls))
+    self.general_assert(
+        sorted(expected_controls), sorted(actual_controls))


### PR DESCRIPTION
Reuse method for objects comparison in tests. Fix issue with converting datetime string to object. Move logic to update assessor value to Entity object and remove redundant code from child.