### PR TITLE
GGRC-3039 Incorrect behavior of GCA with dropdown type

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment/custom-attributes.js
+++ b/src/ggrc/assets/javascripts/components/assessment/custom-attributes.js
@@ -13,6 +13,7 @@
     template: tpl,
     viewModel: {
       globalAttributes: [],
+      items: [],
       editMode: false,
       modifiedFields: {},
       updateGlobalAttribute: function (event, field) {

--- a/src/ggrc/assets/javascripts/components/assessment/info-pane/inline-item.js
+++ b/src/ggrc/assets/javascripts/components/assessment/info-pane/inline-item.js
@@ -18,7 +18,7 @@
       value: '',
       type: '@',
       dropdownOptions: [],
-      dropdwonOptionsGroups: {},
+      dropdownOptionsGroups: {},
       dropdownClass: '@',
       isGroupedDropdown: false,
       dropdownNoValue: false,

--- a/src/ggrc/assets/javascripts/components/auto-save-form/fields/dropdown-form-field.js
+++ b/src/ggrc/assets/javascripts/components/auto-save-form/fields/dropdown-form-field.js
@@ -42,7 +42,7 @@
       },
       options: [],
       isGroupedDropdown: false,
-      dropdwonOptionsGroups: {},
+      dropdownOptionsGroups: {},
       noValue: true,
       valueChanged: function (newValue) {
         this.dispatch({

--- a/src/ggrc/assets/javascripts/components/dropdown/dropdown.js
+++ b/src/ggrc/assets/javascripts/components/dropdown/dropdown.js
@@ -24,7 +24,7 @@
           get: function () {
             var isGroupedDropdown = this.attr('isGroupedDropdown');
             var optionsGroups = this.attr('optionsGroups');
-            var noneValue = this.attr('noValueLabel') || 'None';
+            var noneValue = this.attr('noValueLabel') || '--';
             var none = isGroupedDropdown ?
               [{
                 group: noneValue,
@@ -69,7 +69,7 @@
       name: '@',
       className: '@',
       onChange: $.noop,
-      noValue: false,
+      noValue: '@',
       noValueLabel: '@',
       controlId: '@',
       isGroupedDropdown: false,

--- a/src/ggrc/assets/javascripts/components/dropdown/tests/dropdown_spec.js
+++ b/src/ggrc/assets/javascripts/components/dropdown/tests/dropdown_spec.js
@@ -142,6 +142,7 @@ describe('GGRC.Components.dropdown', function () {
 
     beforeEach(function () {
       viewModel = GGRC.Components.getViewModel('dropdown');
+      viewModel.attr('noValue', false);
     });
 
     it('should build list from optionsList', function () {
@@ -163,7 +164,7 @@ describe('GGRC.Components.dropdown', function () {
       list = viewModel.attr('options');
 
       expect(list.length).toEqual(4);
-      expect(list[0].title).toEqual('None');
+      expect(list[0].title).toEqual('--');
       expect(list[3].title).toEqual(optionsList[2].title);
     });
 
@@ -193,7 +194,7 @@ describe('GGRC.Components.dropdown', function () {
       expect(list[1].subitems.length).toEqual(3);
       expect(list[2].subitems.length).toEqual(2);
       expect(list[1].group).toEqual('group 1');
-      expect(list[0].group).toEqual('None');
+      expect(list[0].group).toEqual('--');
       expect(list[2].subitems[0].title).toEqual('gr 2 name 1');
     });
   });

--- a/src/ggrc/assets/javascripts/components/inline/inline.js
+++ b/src/ggrc/assets/javascripts/components/inline/inline.js
@@ -31,7 +31,7 @@
       propName: '@',
       dropdownOptions: [],
       dropdownNoValue: false,
-      dropdwonOptionsGroups: {},
+      dropdownOptionsGroups: {},
       isGroupedDropdown: false,
       isLastOpenInline: false,
       isEditIconDenied: false,

--- a/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
@@ -22,8 +22,7 @@
             class="input-medium pull-left"
             {options-groups}="objectTypes"
             is-grouped-dropdown="true"
-            name="assessmentType"
-            no-value="false">
+            name="assessmentType">
           </dropdown>
         </assessment-object-type-dropdown>
 

--- a/src/ggrc/assets/mustache/assessments/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessments/modal_content.mustache
@@ -31,8 +31,7 @@
             <dropdown
               {options-groups}="objectTypes"
               is-grouped-dropdown="true"
-              name="assessmentType"
-              no-value="false">
+              name="assessmentType">
             </dropdown>
           </assessment-object-type-dropdown>
         </div>

--- a/src/ggrc/assets/mustache/components/assessment/custom-attributes.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/custom-attributes.mustache
@@ -8,7 +8,7 @@
         {instance}="instance"
         {dropdown-options}="options"
         {dropdown-class}="dropdownClass"
-        {dropdown-no-value}="dropdownNoValue"
+        dropdown-no-value="true"
         {edit-mode}="editMode"
         {is-allow-edit}="isAllowEdit"
         {is-loading}="isLoading"

--- a/src/ggrc/assets/mustache/components/assessment/info-pane/info-pane.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/info-pane/info-pane.mustache
@@ -200,7 +200,7 @@
                                     is-grouped-dropdown="true"
                                     {set-in-progress}="@setInProgressState"
                                     {on-state-change-dfd}="onStateChangeDfd"
-                                    {dropdwon-options-groups}="objectTypes"
+                                    {dropdown-options-groups}="objectTypes"
                                     {is-edit-icon-denied}="isEditDenied"
                                     {value}="instance.assessment_type"
                                     {instance}="instance">

--- a/src/ggrc/assets/mustache/components/assessment/info-pane/inline-item.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/info-pane/inline-item.mustache
@@ -6,7 +6,7 @@
 <inline-edit-control
   (inline-save)="saveInlineForm(%event)"
   {is-grouped-dropdown}="isGroupedDropdown"
-  {dropdwon-options-groups}="dropdwonOptionsGroups"
+  {dropdown-options-groups}="dropdownOptionsGroups"
   {is-edit-icon-denied}="isEditIconDenied"
   {prop-name}="propName"
   {dropdown-options}="dropdownOptions"

--- a/src/ggrc/assets/mustache/components/auto-save-form/fields/dropdown-form-field.mustache
+++ b/src/ggrc/assets/mustache/components/auto-save-form/fields/dropdown-form-field.mustache
@@ -9,7 +9,7 @@
     {options-list}="options"
     name="_value"
     {is-grouped-dropdown}="isGroupedDropdown"
-    {options-groups}="dropdwonOptionsGroups"
+    {options-groups}="dropdownOptionsGroups"
     {no-value}="noValue"
     control-id="form-field-{{fieldId}}"
   ></dropdown>

--- a/src/ggrc/assets/mustache/components/inline/inline.mustache
+++ b/src/ggrc/assets/mustache/components/inline/inline.mustache
@@ -16,7 +16,7 @@
               class="inline__content-input"
               {options}="dropdownOptions"
               {no-value}="dropdownNoValue"
-              {dropdwon-options-groups}="dropdwonOptionsGroups"
+              {dropdown-options-groups}="dropdownOptionsGroups"
               {is-grouped-dropdown}="isGroupedDropdown"
               (value-changed)="fieldValueChanged(%event)"
             ></dropdown-form-field>

--- a/src/ggrc/assets/mustache/components/inline/readonly-inline-content.mustache
+++ b/src/ggrc/assets/mustache/components/inline/readonly-inline-content.mustache
@@ -18,7 +18,7 @@
       {value}="context.value"
       {options}="dropdownOptions"
       {no-value}="dropdownNoValue"
-      {dropdwon-options-groups}="dropdwonOptionsGroups"
+      {dropdown-options-groups}="dropdownOptionsGroups"
       {is-grouped-dropdown}="isGroupedDropdown"
       disabled="true"
     ></dropdown-form-field>


### PR DESCRIPTION
_Steps to reproduce:_
1. Have GCA with dropdown type (3 possible values) for assessment
2. Have audit with created assessment
3. Expand Assessment's Info pane and select any value from GCA with dropdown type > Save
4. Look at the screen: selected value is not displayed 

_Actual Result_: If user select a value from GCA with dropdown type and save it, value is not shown on the Assessment's Info pane
_Expected Result_: If user select a value from GCA with dropdown type and save it, value should be shown on the Assessment's Info pane

![screenshot-2](https://user-images.githubusercontent.com/4204416/29170766-bde5c17e-7de2-11e7-9987-fe9fe3e0486f.png)

