### PR TITLE
GGRC-3052: update UI for daily Workflows

### DIFF
--- a/src/ggrc/assets/javascripts/components/datepicker/datepicker.js
+++ b/src/ggrc/assets/javascripts/components/datepicker/datepicker.js
@@ -40,6 +40,14 @@
         isShown: {
           type: 'boolean',
           value: false
+        },
+        noWeekends: {
+          type: 'boolean',
+          value: false
+        },
+        denyInput: {
+          type: 'boolean',
+          value: false
         }
       },
       onSelect: function (val, ev) {
@@ -73,13 +81,18 @@
         var minDate;
         var maxDate;
         var date;
-
-        element.datepicker({
+        var options = {
           dateFormat: viewModel.PICKER_ISO_DATE,
           altField: this.element.find('.datepicker__input'),
           altFormat: viewModel.PICKER_DISPLAY_FMT,
           onSelect: this.viewModel.onSelect.bind(this.viewModel)
-        });
+        };
+
+        if (viewModel.attr('noWeekends')) {
+          options.beforeShowDay = can.$.datepicker.noWeekends;
+        }
+
+        element.datepicker(options);
         viewModel.attr('picker', element);
 
         date = this.getDate(viewModel.attr('date'));

--- a/src/ggrc/assets/mustache/components/datepicker/datepicker.mustache
+++ b/src/ggrc/assets/mustache/components/datepicker/datepicker.mustache
@@ -18,10 +18,13 @@
     <i class="fa fa-calendar"></i>
     <input
       {{#if disabled}}disabled{{/if}}
-      {{#if readonly}}readonly{{/if}}
+      {{#if_helpers '\
+        #if' readonly '\
+        or #if' denyInput}}readonly
+      {{/if_helpers}}
       placeholder="{{MOMENT_DISPLAY_FMT}}"
       type="text"
-      class="datepicker__input date"
+      class="datepicker__input date {{#if denyInput}}datepicker__input--denied{{/if}}"
       {(value)}="_date"
       can-focus="onFocus"
     >

--- a/src/ggrc/assets/stylesheets/modules/_datepicker.scss
+++ b/src/ggrc/assets/stylesheets/modules/_datepicker.scss
@@ -27,6 +27,11 @@
   margin-bottom: 0;
   // This is not good, but our global inputs have fixed height and paddings
   height: 26px !important;
+
+  &--denied {
+    background: $white;
+    cursor: default;
+  }
 }
 
 .datepicker__input-wrapper {

--- a/src/ggrc_workflows/assets/javascripts/apps/workflow-config.js
+++ b/src/ggrc_workflows/assets/javascripts/apps/workflow-config.js
@@ -6,7 +6,7 @@
 (function (GGRC) {
   GGRC.Workflow = {
     unitOptions: [
-      {title: 'Daily', value: 'day', plural: 'days', singular: 'day'},
+      {title: 'Weekday', value: 'day', plural: 'weekdays', singular: 'weekday'},
       {title: 'Weekly', value: 'week', plural: 'weeks', singular: 'week'},
       {title: 'Monthly', value: 'month', plural: 'months', singular: 'month'}
     ],

--- a/src/ggrc_workflows/assets/javascripts/components/tests/repeat-on-button_spec.js
+++ b/src/ggrc_workflows/assets/javascripts/components/tests/repeat-on-button_spec.js
@@ -196,7 +196,7 @@ describe('GGRC.Components.repeatOnButton', function () {
     it('should update repeat options when unit changed',
     function () {
       var actualTitles;
-      var expectedTitles = ['1 day', '2 days'];
+      var expectedTitles = ['1 weekday', '2 weekdays'];
       context.viewModel.attr('state.result.unit', 'day');
 
       unitChanged.apply(context);

--- a/src/ggrc_workflows/assets/mustache/task_group_tasks/modal_content.mustache
+++ b/src/ggrc_workflows/assets/mustache/task_group_tasks/modal_content.mustache
@@ -80,12 +80,20 @@
               <label class="smaller">
                   <datepicker date="instance.start_date"
                               required="true"
+                              {{#is workflow.unit 'day'}}
+                                no-weekends="true"
+                                deny-input="true"
+                              {{/is}}
                               label="Start Date"></datepicker>
               </label>
               <label class="smaller">
                   <datepicker set-min-date="instance.start_date"
                               date="instance.end_date"
                               required="true"
+                              {{#is workflow.unit 'day'}}
+                                no-weekends="true"
+                                deny-input="true"
+                              {{/is}}
                               label="Due Date"></datepicker>
               </label>
           </div>


### PR DESCRIPTION
Replace 'daily' option in RepeatOn component with 'weekday' and update appropriate summary message.
Allow weekdays in 'Start Date' and 'Due Date' in Tasks setup for Daily Workflows, restrict datepicker input from keyboard.