### PR TITLE
GGRC-3043 Optional fields of search criteria do not correspond to selected object in Advanced Search filter

### DIFF
--- a/src/ggrc/assets/javascripts/components/advanced-search/advanced-search-filter-attribute.js
+++ b/src/ggrc/assets/javascripts/components/advanced-search/advanced-search-filter-attribute.js
@@ -72,6 +72,13 @@
   GGRC.Components('advancedSearchFilterAttribute', {
     tag: 'advanced-search-filter-attribute',
     template: template,
-    viewModel: viewModel
+    viewModel: viewModel,
+    events: {
+      '{viewModel} availableAttributes': function (ev, desc, attributes) {
+        if (attributes[0] && attributes[0].attr_title) {
+          this.viewModel.attr('attribute.field', attributes[0].attr_title);
+        }
+      }
+    }
   });
 })(window.can, window.GGRC);

--- a/src/ggrc/assets/javascripts/components/advanced-search/advanced-search-mapping-container.js
+++ b/src/ggrc/assets/javascripts/components/advanced-search/advanced-search-mapping-container.js
@@ -24,11 +24,6 @@
      */
     modelName: null,
     /**
-     * Contains available attributes for specific model.
-     * @type {can.List}
-     */
-    availableAttributes: can.List(),
-    /**
      * Adds Mapping Criteria and Operator to the collection.
      * Adds only Mapping Criteria if collection is empty.
      */

--- a/src/ggrc/assets/javascripts/components/advanced-search/advanced-search-mapping-criteria.js
+++ b/src/ggrc/assets/javascripts/components/advanced-search/advanced-search-mapping-criteria.js
@@ -92,10 +92,17 @@
      */
     extendable: false,
     /**
-     * Contains available attributes for specific model.
-     * @type {can.List}
+     * Returns a list of available attributes for specific model.
+     * @return {can.List} - List of available attributes.
      */
-    availableAttributes: can.List(),
+    availableAttributes: function () {
+      var available = GGRC.Utils.TreeView.getColumnsForModel(
+        this.attr('criteria.objectName'),
+        null,
+        true
+      ).available;
+      return available;
+    },
     /**
      * Returns a list of available mapping types for specific model.
      * @return {Array} - List of available mapping types.

--- a/src/ggrc/assets/javascripts/components/advanced-search/advanced-search-mapping-group.js
+++ b/src/ggrc/assets/javascripts/components/advanced-search/advanced-search-mapping-group.js
@@ -29,11 +29,6 @@
      */
     root: false,
     /**
-     * Contains available attributes for specific model.
-     * @type {can.List}
-     */
-    availableAttributes: can.List(),
-    /**
      * Adds Filter Operator and Mapping Criteria to the collection.
      */
     addMappingCriteria: function () {

--- a/src/ggrc/assets/javascripts/components/advanced-search/tests/advanced-search-mapping-criteria_spec.js
+++ b/src/ggrc/assets/javascripts/components/advanced-search/tests/advanced-search-mapping-criteria_spec.js
@@ -168,4 +168,21 @@ describe('GGRC.Components.advancedSearchMappingCriteria', function () {
       expect(viewModel.attr('criteria.objectName')).toBe('test');
     });
   });
+
+  describe('availableAttributes() method', function () {
+    it('returns available attributes', function () {
+      var attributes = ['attr1', 'attr2'];
+      spyOn(GGRC.Utils.TreeView, 'getColumnsForModel').and.returnValue({
+        available: attributes
+      });
+      viewModel.attr('criteria.objectName', 'test');
+
+      expect(viewModel.availableAttributes()).toBe(attributes);
+      expect(GGRC.Utils.TreeView.getColumnsForModel).toHaveBeenCalledWith(
+        'test',
+        null,
+        true
+      );
+    });
+  });
 });

--- a/src/ggrc/assets/mustache/components/advanced-search/advanced-search-mapping-container.mustache
+++ b/src/ggrc/assets/mustache/components/advanced-search/advanced-search-mapping-container.mustache
@@ -19,7 +19,6 @@
           <advanced-search-mapping-criteria
             {(criteria)}="value"
             (remove)="removeItem(../)"
-            {available-attributes}="availableAttributes"
             {model-name}="modelName"
             {root}="true"
             {extendable}="true"
@@ -32,7 +31,6 @@
           <advanced-search-mapping-group
             {(items)}="value"
             (remove)="removeItem(../)"
-            {available-attributes}="availableAttributes"
             {model-name}="modelName"
             {root}="true">
           </advanced-search-mapping-group>

--- a/src/ggrc/assets/mustache/components/advanced-search/advanced-search-mapping-criteria.mustache
+++ b/src/ggrc/assets/mustache/components/advanced-search/advanced-search-mapping-criteria.mustache
@@ -49,7 +49,6 @@
         <advanced-search-mapping-criteria
           {(criteria)}="criteria.mappedTo.value"
           (remove)="removeRelevant()"
-          {available-attributes}="availableAttributes"
           {model-name}="criteria.objectName"
           {extendable}="extendable"
           (createGroup)="relevantToGroup()"
@@ -60,7 +59,6 @@
         <advanced-search-mapping-group
           {(items)}="criteria.mappedTo.value"
           (remove)="removeRelevant()"
-          {available-attributes}="availableAttributes"
           {model-name}="criteria.objectName"
           {^root}="../childCanBeGrouped">
         </advanced-search-mapping-group>

--- a/src/ggrc/assets/mustache/components/advanced-search/advanced-search-mapping-group.mustache
+++ b/src/ggrc/assets/mustache/components/advanced-search/advanced-search-mapping-group.mustache
@@ -24,7 +24,6 @@
           <advanced-search-mapping-criteria
             {(criteria)}="value"
             (remove)="removeItem(../, true)"
-            {available-attributes}="availableAttributes"
             {model-name}="modelName"
             {root}="root">
           </advanced-search-mapping-criteria>

--- a/src/ggrc/assets/mustache/components/object-generator/object-generator.mustache
+++ b/src/ggrc/assets/mustache/components/object-generator/object-generator.mustache
@@ -55,7 +55,6 @@
             {{/each}}
             <advanced-search-mapping-container
               {(items)}="mappingItems"
-              {available-attributes}="availableAttributes"
               {model-name}="modelName">
             </advanced-search-mapping-container>
           </div>

--- a/src/ggrc/assets/mustache/components/object-mapper/object-mapper.mustache
+++ b/src/ggrc/assets/mustache/components/object-mapper/object-mapper.mustache
@@ -102,7 +102,6 @@
             {{/each}}
             <advanced-search-mapping-container
               {(items)}="mappingItems"
-              {available-attributes}="availableAttributes"
               {model-name}="modelName">
             </advanced-search-mapping-container>
           </div>

--- a/src/ggrc/assets/mustache/components/object-search/object-search.mustache
+++ b/src/ggrc/assets/mustache/components/object-search/object-search.mustache
@@ -42,7 +42,6 @@
             </div>
             <advanced-search-mapping-container
               {(items)}="mappingItems"
-              {available-attributes}="availableAttributes"
               {model-name}="modelName">
             </advanced-search-mapping-container>
           </div>

--- a/src/ggrc/assets/mustache/components/tree/tree-widget-container.mustache
+++ b/src/ggrc/assets/mustache/components/tree/tree-widget-container.mustache
@@ -96,7 +96,6 @@
         <div class="simple-modal__body">
           <advanced-search-mapping-container
             {(items)}="advancedSearch.mappingItems"
-            {available-attributes}="columns.available"
             {model-name}="modelName">
           </advanced-search-mapping-container>
         </div>


### PR DESCRIPTION
Steps to reproduce:
1. Go to My work page > Control tab
2. Open Control Advanced Filter
3. Click 'Add attribute' button
4. Select any search criteria from the dropdown list (e.g. Title)
5. Click 'Add Mapping Filter' button and select an object to which Control is mapped to (e.g. Program)
6. Look at the search criteria from the dropdown list: is not correspond to optional fields for program
*Actual Result:* Optional fields of search criteria do not correspond to selected object in Advanced Search filter
*Expected Result:* Optional fields of search criteria should correspond to selected object in Advanced Search filter