### PR TITLE
GGRC-3028: Remove 'Map to this Object' menu item on Workflows tree view

### DIFF
--- a/src/ggrc/assets/javascripts/components/tree/tree-item-actions.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-item-actions.js
@@ -6,7 +6,8 @@
 (function (can, GGRC) {
   'use strict';
 
-  var forbiddenList = ['Cycle', 'CycleTaskGroup'];
+  var forbiddenEditList = ['Cycle', 'CycleTaskGroup'];
+  var forbiddenMapList = ['Workflow'];
 
   var template = can.view(GGRC.mustache_path +
     '/components/tree/tree-item-actions.mustache');
@@ -45,8 +46,18 @@
           var type = this.attr('instance.type');
           var isSnapshot = this.attr('isSnapshot');
           var isArchived = this.attr('instance.archived');
-          var isInForbiddenList = forbiddenList.indexOf(type) > -1;
+          var isInForbiddenList = forbiddenEditList.indexOf(type) > -1;
           return !(isSnapshot || isInForbiddenList || isArchived);
+        }
+      },
+      isAllowedToMap: {
+        type: 'boolean',
+        get: function () {
+          var type = this.attr('instance.type');
+          var isAllowedToEdit = this.attr('isAllowedToEdit');
+          var isInForbiddenList = forbiddenMapList.indexOf(type) > -1;
+
+          return isAllowedToEdit && !isInForbiddenList;
         }
       }
     },

--- a/src/ggrc/assets/mustache/components/tree/tree-item-actions.mustache
+++ b/src/ggrc/assets/mustache/components/tree/tree-item-actions.mustache
@@ -30,10 +30,13 @@
           {{/unless}}
       {{/if}}
 
-      {{#if isAllowedToEdit}}
+
+      {{#if isAllowedToMap}}
         <li>
           <tree-item-map {instance}="instance"></tree-item-map>
         </li>
+      {{/if}}
+      {{#if isAllowedToEdit}}
         {{#is_allowed 'update' instance context='for'}}
           <li>
             <a href="javascript://"


### PR DESCRIPTION
Remove 'Map to this object' option from drop down menu on Workflows tree view.