### PR TITLE
GGRC-2957: Rename Evidence and URL on Assessment Info panel

### DIFF
--- a/src/ggrc/assets/mustache/components/assessment/info-pane/info-pane.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/info-pane/info-pane.mustache
@@ -68,7 +68,7 @@
                         <div>
                             <div class="info-pane__section-title">
                                 <spinner class="info-pane__section-title-icon" {toggle}="isUpdatingEvidences"></spinner>
-                                Evidence
+                                Evidence file
                             </div>
                             <object-list {items}="evidences" {empty-message}="noItemsText">
                                 <editable-document-object-list-item {document}="{.}">
@@ -92,7 +92,7 @@
                         <div>
                             <div class="info-pane__section-title">
                                 <spinner class="info-pane__section-title-icon" {toggle}="isUpdatingUrls"></spinner>
-                                URL
+                                Evidence URL
                             </div>
                             <object-list {items}="urls" {empty-message}="noItemsText">
                                 <editable-document-object-list-item {document}="{.}">


### PR DESCRIPTION
Change text label on Assessment info panel:
* Evidence -> Evidence file
* URL -> Evidence URL