### PR TITLE
GGRC-2960 Assessment pane - show "Saving ..." next to COMPLETE button

### DIFF
--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -340,6 +340,8 @@ dashboard-js-files:
   - components/inline/base-inline-control-title.js
   - components/assessment/info-pane/inline-item.js
   - components/assessment/info-pane/confirm-edit-action.js
+  - components/assessment/info-pane-save-status.js
+  - components/loading/loading-status.js
   - components/object-list-item/object-list-item-updater.js
 
 app-init-files:
@@ -704,6 +706,7 @@ dashboard-js-template-files:
   - components/inline/simple-readonly-text.mustache
   - components/inline/base-inline-control-title.mustache
   - components/assessment/info-pane/inline-item.mustache
+  - components/loading/loading-status.mustache
 
 dashboard-css-files:
   - dashboard.css

--- a/src/ggrc/assets/javascripts/components/assessment/info-pane-save-status.js
+++ b/src/ggrc/assets/javascripts/components/assessment/info-pane-save-status.js
@@ -1,0 +1,28 @@
+/*!
+ Copyright (C) 2017 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+(function (can, GGRC) {
+  'use strict';
+
+  GGRC.Components('infoPaneSaveStatus', {
+    tag: 'info-pane-save-status',
+    viewModel: {
+      define: {
+        infoPaneSaving: {
+          get: function () {
+            return this.attr('assessmentSaving') ||
+              this.attr('evidencesSaving') ||
+              this.attr('commentsSaving') ||
+              this.attr('urlsSaving');
+          }
+        }
+      },
+      assessmentSaving: false,
+      evidencesSaving: false,
+      urlsSaving: false,
+      commentsSaving: false
+    }
+  });
+})(window.can, window.GGRC);

--- a/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.js
+++ b/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.js
@@ -92,6 +92,7 @@
       modal: {
         open: false
       },
+      isAssessmentSaving: false,
       onStateChangeDfd: {},
       formState: {},
       noItemsText: '',
@@ -342,6 +343,12 @@
       '{viewModel.instance} refreshMapping': function () {
         this.viewModel.attr('mappedSnapshots')
           .replace(this.viewModel.loadSnapshots());
+      },
+      '{viewModel.instance} modelBeforeSave': function () {
+        this.viewModel.attr('isAssessmentSaving', true);
+      },
+      '{viewModel.instance} modelAfterSave': function () {
+        this.viewModel.attr('isAssessmentSaving', false);
       },
       '{viewModel} instance': function () {
         this.viewModel.initializeFormFields();

--- a/src/ggrc/assets/javascripts/components/auto-save-form/auto-save-form-status.js
+++ b/src/ggrc/assets/javascripts/components/auto-save-form/auto-save-form-status.js
@@ -11,7 +11,7 @@
 
   GGRC.Components('autoSaveFormStatus', {
     tag: 'auto-save-form-status',
-    template: '{{formStatusText}}<content></content>',
+    template: '<content></content>',
     viewModel: {
       define: {
         isDirty: {

--- a/src/ggrc/assets/javascripts/components/loading/loading-status.js
+++ b/src/ggrc/assets/javascripts/components/loading/loading-status.js
@@ -1,0 +1,33 @@
+/*!
+ Copyright (C) 2017 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+(function (can, GGRC) {
+  'use strict';
+
+  GGRC.Components('loadingStatus', {
+    tag: 'loading-status',
+    template: can.view(
+      GGRC.mustache_path +
+      '/components/loading/loading-status.mustache'
+    ),
+    viewModel: {
+      define: {
+        showSpinner: {
+          type: 'boolean',
+          value: false
+        },
+        alwaysShowText: {
+          type: 'boolean',
+          value: false
+        },
+        isLoading: {
+          type: 'boolean',
+          value: false
+        }
+      },
+      loadingText: '@'
+    }
+  });
+})(window.can, window.GGRC);

--- a/src/ggrc/assets/javascripts/models/cacheable.js
+++ b/src/ggrc/assets/javascripts/models/cacheable.js
@@ -1218,6 +1218,8 @@
         new PersistentNotifier({name:
         this.constructor.model_singular + ' (pre-save)'});
 
+      that.dispatch('modelBeforeSave');
+
       if (this.before_save) {
         this.before_save(pre_save_notifier);
       }
@@ -1257,6 +1259,9 @@
         that.notifier.on_empty(function () {
           dfd.resolve(that);
         });
+      })
+      .always(function () {
+        that.dispatch('modelAfterSave');
       });
 
         GGRC.delay_leaving_page_until(xhr);

--- a/src/ggrc/assets/mustache/assessments/header.mustache
+++ b/src/ggrc/assets/mustache/assessments/header.mustache
@@ -152,5 +152,19 @@ Copyright (C) 2017 Google Inc.
                                     (on-state-change)="onStateChange(%event)">
                 </object-state-toolbar>
         {{/unless}}
+        <div class="form-status {{#if is_info_pin}}pane-header__toolbar-item{{/if}}">
+            <info-pane-save-status
+                {evidences-saving}="isUpdatingEvidences"
+                {urls-saving}="isUpdatingUrls"
+                {comments-saving}="isUpdatingComments"
+                {assessment-saving}="isAssessmentSaving">
+                    <loading-status
+                        class="loading-status"
+                        {is-loading}="infoPaneSaving"
+                        loading-text="Saving..."
+                        show-Spinner="true">
+                    </loading-status>
+            </info-pane-save-status>
+        </div>
     </div>
 </div>

--- a/src/ggrc/assets/mustache/components/assessment/info-pane/info-pane.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/info-pane/info-pane.mustache
@@ -68,7 +68,14 @@
                         <auto-save-form-status
                                 {form-saving}="formState.saving"
                                 {form-all-saved}="formState.allSaved"
-                                {is-dirty}="formState.isDirty"></auto-save-form-status>
+                                {is-dirty}="formState.isDirty">
+                                <loading-status
+                                    {is-loading}="formSaving"
+                                    {loading-text}="formStatusText"
+                                    always-Show-Text="true"
+                                    show-Spinner="true">
+                                </loading-status>
+                        </auto-save-form-status>
                         <i class="fa fa-question-circle" rel="tooltip"
                            data-original-title="Respond to assessment here. Use comments on the right for free text responses."></i>
                     </div>

--- a/src/ggrc/assets/mustache/components/loading/loading-status.mustache
+++ b/src/ggrc/assets/mustache/components/loading/loading-status.mustache
@@ -1,0 +1,15 @@
+{{!
+  Copyright (C) 2017 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+}}
+
+{{#if isLoading}}
+  {{#if showSpinner}}
+    <spinner class="loading-status--spinner" {toggle}="isLoading"></spinner>
+  {{/if}}
+  {{loadingText}}
+{{else}}
+  {{#if alwaysShowText}}
+    {{loadingText}}
+  {{/if}}
+{{/if}}

--- a/src/ggrc/assets/stylesheets/_components.scss
+++ b/src/ggrc/assets/stylesheets/_components.scss
@@ -47,3 +47,4 @@
 @import "components/inline/inline";
 @import "components/related-objects/related-reference-urls";
 @import "components/object-list-item/person-list-item";
+@import "components/loading/loading-status";

--- a/src/ggrc/assets/stylesheets/components/auto-save-form/_auto-save-form.scss
+++ b/src/ggrc/assets/stylesheets/components/auto-save-form/_auto-save-form.scss
@@ -2,7 +2,6 @@
  * Copyright (C) 2017 Google Inc.
  * Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  */
-@import "auto-save-form-status";
 @import "auto-save-form-actions";
 @import "fields/fields";
 @import "field-views/field-views";

--- a/src/ggrc/assets/stylesheets/components/info-pane/_info-pane.scss
+++ b/src/ggrc/assets/stylesheets/components/info-pane/_info-pane.scss
@@ -125,6 +125,14 @@
       flex-direction: row-reverse;
       flex: 3 3;
 
+      .form-status {
+        line-height: 28px;
+
+        .loading-status {
+          margin-right: 5px;
+        }
+      }
+
       .pane-header__toolbar-item {
         margin-top: 20px;
 

--- a/src/ggrc/assets/stylesheets/components/loading/_loading-status.scss
+++ b/src/ggrc/assets/stylesheets/components/loading/_loading-status.scss
@@ -3,9 +3,13 @@
  * Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  */
 
-auto-save-form-status {
+loading-status {
   display: block;
   margin-right: 20px;
   font-size: 12px;
   color: #8a8a8a;
+
+  .loading-status--spinner {
+    margin-right: 5px;
+  }
 }


### PR DESCRIPTION
Scope:
Show gray label "Saving ..." next to Complete button during the time - when user entered smth - until Complete is activated.
From user:
After selecting from the “is control operating effectively” drop down, it takes a few seconds before COMPLETE button activates.

![screen shot 2017-08-14 at 12 22 34 pm](https://user-images.githubusercontent.com/4204416/29265857-412a9a04-80eb-11e7-9ccb-a44ecbe3d81a.png)
