### PR TITLE
GGRC-2908 Unverified workflow moves to History tab

### DIFF
--- a/src/ggrc_workflows/__init__.py
+++ b/src/ggrc_workflows/__init__.py
@@ -682,10 +682,8 @@ def handle_cycle_task_entry_post(
 def handle_cycle_status_change(sender, obj=None, new_status=None,  # noqa pylint: disable=unused-argument
                                old_status=None):  # noqa pylint: disable=unused-argument  # noqa pylint: disable=unused-argument
   if inspect(obj).attrs.status.history.has_changes():
-    if obj.is_done:
-      obj.is_current = False
-      db.session.add(obj)
-      update_workflow_state(obj.workflow)
+    obj.is_current = not obj.is_done
+    update_workflow_state(obj.workflow)
 
 
 @Signals.status_change.connect_via(models.CycleTaskGroupObjectTask)

--- a/src/ggrc_workflows/models/cycle.py
+++ b/src/ggrc_workflows/models/cycle.py
@@ -55,6 +55,19 @@ class Cycle(mixins.WithContact,
   is_current = db.Column(db.Boolean, default=True, nullable=False)
   next_due_date = db.Column(db.Date)
 
+  @property
+  def is_done(self):
+    """Check if cycle's done
+
+    Overrides StatusValidatedMixin method because cycle's is_done state
+    depends on is_verification_needed flag
+    """
+    if super(Cycle, self).is_done:
+      return True
+    if self.cycle_task_group_object_tasks:
+      return False
+    return True
+
   _api_attrs = reflection.ApiAttributes(
       'workflow',
       'cycle_task_groups',

--- a/test/integration/ggrc/access_control/test_access_control_role.py
+++ b/test/integration/ggrc/access_control/test_access_control_role.py
@@ -16,6 +16,7 @@ class TestAccessControlRole(TestCase):
   """TestAccessControlRole"""
 
   def setUp(self):
+    self.clear_data()
     super(TestAccessControlRole, self).setUp()
     self.api = Api()
     self.object_generator = ObjectGenerator()


### PR DESCRIPTION
Steps to reproduce:
1. Create one time workflow
2. Add at least 3 tasks to Task group in Setup tab, one task should be overdue
3. Activate workflow
4. At the Active Cycles tab verify tasks
5. Click 'undo' button for all tasks: make sure that tasks are moved to Finished state
6. Move one task to In progress
7. Verify one task once again (e.g. Overdue task)
8. Open History tab and look at the tree view: Unverified workflow moves to History tab
Actual Result: Unverified workflow moves to History tab
Expected Result: Unverified workflow should not be moved to the History tab