### PR TITLE
GGRC-2938: Fix issue with create WF on Export page

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/modals_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/modals_controller.js
@@ -85,7 +85,7 @@
       // loaded before rendering the form, otherwise initial validation can
       // incorrectly fail for form fields whose values rely on current user's
       // attributes.
-      currentUser = CMS.Models.Person.cache[GGRC.current_user.id];
+      currentUser = CMS.Models.Person.store[GGRC.current_user.id];
 
       if (currentUser) {
         currentUser = currentUser.reify();

--- a/src/ggrc/assets/javascripts/controllers/tests/modals_controller_spec.js
+++ b/src/ggrc/assets/javascripts/controllers/tests/modals_controller_spec.js
@@ -64,7 +64,7 @@ describe('GGRC.Controllers.Modals', function () {
         });
 
         spyOn(partialUser, 'reify').and.returnValue(partialUser);
-        CMS.Models.Person.cache[userId] = partialUser;
+        CMS.Models.Person.store[userId] = partialUser;
 
         init();
 
@@ -86,7 +86,7 @@ describe('GGRC.Controllers.Modals', function () {
         });
 
         spyOn(fullUser, 'reify').and.returnValue(fullUser);
-        CMS.Models.Person.cache[userId] = fullUser;
+        CMS.Models.Person.store[userId] = fullUser;
 
         init();
 


### PR DESCRIPTION
Steps to reproduce:
1. Go to the Export page
2. Expand LHN
3. Click 'Create' Workflow button
4. Look at the screen
Actual Result: "Uncaught TypeError: Cannot read property '328' of undefined" error occurred while clicking 'Create' Workflow button in LHN 
Expected Result: no error is shown
TECH NOTE: can be reproduced with low internet connection on opening create modal dialog.
