### PR TITLE
GGRC-2325 Audit Object - Internal Audit Lead field name is confusing

### DIFF
--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -344,7 +344,7 @@
       verifiersList: {},
       people_values: [
         {value: 'Admin', title: 'Object Admins'},
-        {value: 'Audit Lead', title: 'Audit Lead'},
+        {value: 'Audit Lead', title: 'Audit Captain'},
         {value: 'Auditors', title: 'Auditors'},
         {value: 'Principal Assignees', title: 'Principal Assignees'},
         {value: 'Secondary Assignees', title: 'Secondary Assignees'},

--- a/src/ggrc/assets/mustache/audits/extended_info.mustache
+++ b/src/ggrc/assets/mustache/audits/extended_info.mustache
@@ -28,7 +28,7 @@
   </div>
   <div class="row-fluid">
     <div class="span12">
-      <h6>Audit Lead</h6>
+      <h6>Audit Captain</h6>
       <p class="oneline">
         <person-info empty-text="Not assigned" person-obj="instance.contact"></person-info>
       </p>

--- a/src/ggrc/models/assessment_template.py
+++ b/src/ggrc/models/assessment_template.py
@@ -51,7 +51,7 @@ class AssessmentTemplate(assessment.AuditRelationship, relationship.Relatable,
   # labels to show to the user in the UI for various default people values
   DEFAULT_PEOPLE_LABELS = {
       "Admin": "Object Admins",
-      "Audit Lead": "Audit Lead",
+      "Audit Lead": "Audit Captain",
       "Auditors": "Auditors",
       "Principal Assignees": "Principal Assignees",
       "Secondary Assignees": "Secondary Assignees",

--- a/test/integration/ggrc/test_csvs/assessment_template_no_warnings.csv
+++ b/test/integration/ggrc/test_csvs/assessment_template_no_warnings.csv
@@ -16,7 +16,7 @@ Rich text, custom description
 Mandatory Date, date of birth
 Checkbox, dashie?
 peRson, santa clause",,,,,,,,
-,T-2,Audit,Template 2,Control,,Some test plan,Audit lead,"user3@a.com
+,T-2,Audit,Template 2,Control,,Some test plan,Audit Captain,"user3@a.com
 user1@a.com",,,,,,,,,
 ,T-3,Audit,Template 2,Market,,Market test plan,principal assignees,primary contacts,"Dropdown, my dropdown, value 1, value 2, value 3
 mandatory dropdown, my second dropdown, value1, value2

--- a/test/integration/ggrc/test_csvs/assessment_template_with_warnings_and_errors.csv
+++ b/test/integration/ggrc/test_csvs/assessment_template_with_warnings_and_errors.csv
@@ -16,7 +16,7 @@ Rich text, custom description
 Mandatory Date, date of birth
 Checkbox, dashie?
 peRson, santa clause",,,,,,,,
-,T-2,Audit,Template 2,Control,,Some test plan,Audit lead,"user3@a.com
+,T-2,Audit,Template 2,Control,,Some test plan,Audit Captain,"user3@a.com
 user1@a.com",,,,,,,,,
 ,T-3,Audit,Template 2,Market,,Market test plan,principal assignees,primary contacts,"Dropdown, my dropdown, value 1, value 2, value 3
 mandatory dropdown, my second dropdown, value1, value2


### PR DESCRIPTION
"Audit Lead" field name could be misleading on the Audit object.

_Expected result:_
Use 'Audit Captain' label on Assessment template form and Audit extended info panel.