### PR TITLE
GGRC-2630 Reduce time of initialization page of tree view after loading data

### DIFF
--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -340,6 +340,7 @@ dashboard-js-files:
   - components/assessment/info-pane/inline-item.js
   - components/assessment/info-pane/confirm-edit-action.js
   - components/object-list-item/object-list-item-updater.js
+  - components/lazy-render/lazy-render.js
 
 app-init-files:
   - apps/dashboard.js

--- a/src/ggrc/assets/javascripts/components/lazy-render/lazy-render.js
+++ b/src/ggrc/assets/javascripts/components/lazy-render/lazy-render.js
@@ -1,0 +1,31 @@
+/*!
+ Copyright (C) 2017 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+(function (can, GGRC) {
+  'use strict';
+
+  var viewModel = can.Map.extend({
+    define: {
+      trigger: {
+        type: 'boolean',
+        set: function (value) {
+          if (!this.attr('activated') && value) {
+            this.attr('activated', true);
+          }
+        }
+      }
+    },
+    activated: false
+  });
+
+  /**
+   *
+   */
+  GGRC.Components('lazyRender', {
+    tag: 'lazy-render',
+    template: '{{#if activated}}<content/>{{/if}}',
+    viewModel: viewModel
+  });
+})(window.can, window.GGRC);

--- a/src/ggrc/assets/javascripts/components/tree/tree-item-actions.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-item-actions.js
@@ -77,6 +77,7 @@
     isAllowToExpand: null,
     childModelsList: null,
     expanded: false,
+    activated: false,
     showReducedIcon: function () {
       var pages = ['Workflow'];
       var instanceTypes = [
@@ -99,6 +100,15 @@
         var canExpand = parents < this.viewModel.attr('deepLimit');
         this.viewModel.attr('canExpand', canExpand);
         this.viewModel.attr('$el', this.element);
+      },
+      '.tree-item-actions__content mouseenter': function (el, ev) {
+        var vm = this.viewModel;
+
+        if (!vm.attr('activated')) {
+          vm.attr('activated', true);
+        }
+        // event not needed after render of content
+        el.off(ev);
       }
     }
   });

--- a/src/ggrc/assets/mustache/components/tree/tree-item-actions.mustache
+++ b/src/ggrc/assets/mustache/components/tree/tree-item-actions.mustache
@@ -10,6 +10,7 @@
       <i class="fa fa-caret-down"></i>
     </a>
     <ul>
+      <lazy-render trigger="activated">
       <!---->
       {{#if instance.viewLink}}
         <!-- Link for open instance on info panel at bottom -->
@@ -77,6 +78,7 @@
         </li>
         {{/if}}
       {{/unless}}
+      </lazy-render>
     </ul>
   </div>
 </div>

--- a/src/ggrc/assets/mustache/components/tree/tree-item.mustache
+++ b/src/ggrc/assets/mustache/components/tree/tree-item.mustache
@@ -92,12 +92,14 @@
     <tree-item-extra-info {instance}="instance"></tree-item-extra-info>
   </div>
 
-  <div class="sub-tier">
-    <sub-tree-wrapper {parent}="instance"
-                      {limit-depth-tree}="limitDepthTree"
-                      {child-models}="selectedChildModels"
-                      {get-depth-filter}="@getDepthFilter"
-                      {is-open}="expanded"
-    ></sub-tree-wrapper>
-  </div>
+  <lazy-render trigger="expanded">
+    <div class="sub-tier">
+      <sub-tree-wrapper {parent}="instance"
+                        {limit-depth-tree}="limitDepthTree"
+                        {child-models}="selectedChildModels"
+                        {get-depth-filter}="@getDepthFilter"
+                        {is-open}="expanded"
+      ></sub-tree-wrapper>
+    </div>
+  </lazy-render>
 </div>

--- a/test/selenium/src/lib/base.py
+++ b/test/selenium/src/lib/base.py
@@ -912,10 +912,9 @@ class ElementsList(Component):
     "self.item_class" property.
     """
     if not self._items:
-      items_elements = selenium_utils.get_nested_elements(
-          self.list_element)
       self._items = [self.item_class(self._driver, el) for el in
-                     items_elements]
+                     self.list_element.find_elements(
+                         *CommonDropdownMenu.DROPDOWN_ITEMS_CSS)]
     return self._items
 
   def get_item(self, text):


### PR DESCRIPTION
**Issue:** The main problem is updating the list of items to display ('showedItems' list)
**Target:** Reduce the time of rendering page of treeview

**Results:**
 - before:
![1](https://user-images.githubusercontent.com/4737102/29275835-27e4d1f2-8115-11e7-8f81-f1aa6a51dce4.png)
 - after:
![2](https://user-images.githubusercontent.com/4737102/29275834-27e13baa-8115-11e7-8538-fb190cbeab18.png)

**For reviewer:**
 - Enable showing all levels of log in the Chrome console (see screenshot 1)
 - Go through a few pages of the tree view and look the results