### PR TITLE
GGRC-2967 Reference url is not displayed on Info panel if add url via Edit modal window. Refresh is needed

### DIFF
--- a/src/ggrc/assets/javascripts/components/related-objects/related-documents.js
+++ b/src/ggrc/assets/javascripts/components/related-objects/related-documents.js
@@ -247,7 +247,7 @@
       }
     },
     events: {
-      '{viewModel.instance} refreshRelatedDocuments': function () {
+      '{viewModel.instance} resolvePendingBindings': function () {
         if (this.viewModel.autorefresh) {
           this.viewModel.loadDocuments();
         }

--- a/src/ggrc/assets/javascripts/components/related-objects/related-documents.js
+++ b/src/ggrc/assets/javascripts/components/related-objects/related-documents.js
@@ -160,7 +160,7 @@
           .then(this.createRelationship.bind(this))
           .then(function (result) {
             self.fetchAndUpdate(self.instance);
-            self.instance.dispatch('refreshRelatedDocuments');
+            self.refreshRelatedDocuments();
           })
           .fail(function (err) {
             console.error('Unable to create related document: ', err);
@@ -197,7 +197,7 @@
         return this.removeRelationship(relationship)
           .then(function () {
             self.fetchAndUpdate(self.instance);
-            self.instance.dispatch('refreshRelatedDocuments');
+            self.refreshRelatedDocuments();
           })
           .fail(function (err) {
             console.error('Unable to remove related document: ', err);
@@ -233,6 +233,11 @@
         instance.refresh().then(function (refreshed) {
           refreshed.save();
         });
+      },
+      refreshRelatedDocuments: function () {
+        if (this.autorefresh) {
+          this.loadDocuments();
+        }
       }
     },
     init: function () {
@@ -248,9 +253,7 @@
     },
     events: {
       '{viewModel.instance} resolvePendingBindings': function () {
-        if (this.viewModel.autorefresh) {
-          this.viewModel.loadDocuments();
-        }
+        this.viewModel.refreshRelatedDocuments();
       }
     }
   });

--- a/src/ggrc/assets/javascripts/models/assessment.js
+++ b/src/ggrc/assets/javascripts/models/assessment.js
@@ -269,7 +269,6 @@
       return this._super(checkAssociations);
     },
     after_save: function () {
-      this.dispatch('refreshRelatedDocuments');
       if (this.audit && this.audit.selfLink) {
         this.audit.refresh();
       }

--- a/src/ggrc/assets/javascripts/models/business_object_models.js
+++ b/src/ggrc/assets/javascripts/models/business_object_models.js
@@ -63,11 +63,7 @@
 
       this.validateNonBlank('title');
     }
-  }, {
-    after_save: function () {
-      this.dispatch('refreshRelatedDocuments');
-    }
-  });
+  }, {});
 
   can.Model.Cacheable('CMS.Models.Project', {
     root_object: 'project',
@@ -127,11 +123,7 @@
 
         this.validateNonBlank('title');
       }
-    }, {
-      after_save: function () {
-        this.dispatch('refreshRelatedDocuments');
-      }
-    });
+    }, {});
 
   can.Model.Cacheable('CMS.Models.Facility', {
     root_object: 'facility',
@@ -192,11 +184,7 @@
 
       this.validateNonBlank('title');
     }
-  }, {
-    after_save: function () {
-      this.dispatch('refreshRelatedDocuments');
-    }
-  });
+  }, {});
 
   can.Model.Cacheable('CMS.Models.Product', {
     root_object: 'product',
@@ -257,11 +245,7 @@
 
       this.validateNonBlank('title');
     }
-  }, {
-    after_save: function () {
-      this.dispatch('refreshRelatedDocuments');
-    }
-  });
+  }, {});
 
   can.Model.Cacheable('CMS.Models.DataAsset', {
     root_object: 'data_asset',
@@ -321,11 +305,7 @@
 
       this.validateNonBlank('title');
     }
-  }, {
-    after_save: function () {
-      this.dispatch('refreshRelatedDocuments');
-    }
-  });
+  }, {});
 
   can.Model.Cacheable('CMS.Models.AccessGroup', {
     root_object: 'access_group',
@@ -385,11 +365,7 @@
 
       this.validateNonBlank('title');
     }
-  }, {
-    after_save: function () {
-      this.dispatch('refreshRelatedDocuments');
-    }
-  });
+  }, {});
 
   can.Model.Cacheable('CMS.Models.Market', {
     root_object: 'market',
@@ -448,11 +424,7 @@
 
       this.validateNonBlank('title');
     }
-  }, {
-    after_save: function () {
-      this.dispatch('refreshRelatedDocuments');
-    }
-  });
+  }, {});
 
   can.Model.Cacheable('CMS.Models.Vendor', {
     root_object: 'vendor',
@@ -512,9 +484,5 @@
 
       this.validateNonBlank('title');
     }
-  }, {
-    after_save: function () {
-      this.dispatch('refreshRelatedDocuments');
-    }
-  });
+  }, {});
 })(this.can);

--- a/src/ggrc/assets/javascripts/models/cacheable.js
+++ b/src/ggrc/assets/javascripts/models/cacheable.js
@@ -421,7 +421,7 @@
         obj.attr('_pending_joins_dfd', dfds_apply);
 
         return dfds_apply.then(function () {
-          can.trigger(this, 'resolved');
+          obj.dispatch('resolvePendingBindings');
           return obj.refresh();
         });
       });

--- a/src/ggrc/assets/javascripts/models/control.js
+++ b/src/ggrc/assets/javascripts/models/control.js
@@ -109,9 +109,6 @@
         }
       });
       this.bind('refreshInstance', this.refresh.bind(this));
-    },
-    after_save: function () {
-      this.dispatch('refreshRelatedDocuments');
     }
   });
 })(this, can.$);

--- a/src/ggrc/assets/javascripts/models/directive_models.js
+++ b/src/ggrc/assets/javascripts/models/directive_models.js
@@ -102,11 +102,7 @@ CMS.Models.Directive("CMS.Models.Standard", {
     can.extend(this.attributes, CMS.Models.Directive.attributes);
     this._super.apply(this, arguments);
   }
-}, {
-  after_save: function () {
-    this.dispatch('refreshRelatedDocuments');
-  }
-});
+}, {});
 
 CMS.Models.Directive("CMS.Models.Regulation", {
   root_object : "regulation"
@@ -136,11 +132,7 @@ CMS.Models.Directive("CMS.Models.Regulation", {
     can.extend(this.attributes, CMS.Models.Directive.attributes);
     this._super.apply(this, arguments);
   }
-}, {
-  after_save: function () {
-    this.dispatch('refreshRelatedDocuments');
-  }
-});
+}, {});
 
 CMS.Models.Directive("CMS.Models.Policy", {
   root_object : "policy"
@@ -182,11 +174,7 @@ CMS.Models.Directive("CMS.Models.Policy", {
     ]);
     this._super.apply(this, arguments);
   }
-}, {
-  after_save: function () {
-    this.dispatch('refreshRelatedDocuments');
-  }
-});
+}, {});
 
 CMS.Models.Directive("CMS.Models.Contract", {
   root_object : "contract"
@@ -217,10 +205,6 @@ CMS.Models.Directive("CMS.Models.Contract", {
     can.extend(this.attributes, CMS.Models.Directive.attributes);
     this._super.apply(this, arguments);
   }
-}, {
-  after_save: function () {
-    this.dispatch('refreshRelatedDocuments');
-  }
-});
+}, {});
 
 })(this.can);

--- a/src/ggrc/assets/javascripts/models/issue.js
+++ b/src/ggrc/assets/javascripts/models/issue.js
@@ -50,9 +50,6 @@
     },
     object_model: function () {
       return CMS.Models[this.attr('object_type')];
-    },
-    after_save: function () {
-      this.dispatch('refreshRelatedDocuments');
     }
   });
 })(window.can, window.GGRC, window.CMS);

--- a/src/ggrc/assets/javascripts/models/section.js
+++ b/src/ggrc/assets/javascripts/models/section.js
@@ -51,11 +51,7 @@ can.Model.Cacheable('CMS.Models.Section', {
     this._super.apply(this, arguments);
     this.validateNonBlank('title');
   }
-}, {
-  after_save: function () {
-    this.dispatch('refreshRelatedDocuments');
-  }
-});
+}, {});
 
 can.Model.Cacheable('CMS.Models.Clause', {
   root_object: 'clause',
@@ -103,8 +99,4 @@ can.Model.Cacheable('CMS.Models.Clause', {
     this._super.apply(this, arguments);
     this.validateNonBlank('title');
   }
-}, {
-  after_save: function () {
-    this.dispatch('refreshRelatedDocuments');
-  }
-});
+}, {});

--- a/src/ggrc/assets/javascripts/models/simple_models.js
+++ b/src/ggrc/assets/javascripts/models/simple_models.js
@@ -84,11 +84,7 @@
       this.validateNonBlank('title');
       this._super.apply(this, arguments);
     }
-  }, {
-    after_save: function () {
-      this.dispatch('refreshRelatedDocuments');
-    }
-  });
+  }, {});
 
   can.Model.Cacheable('CMS.Models.Option', {
     root_object: 'option',
@@ -163,11 +159,7 @@
       this.validateNonBlank('title');
       this._super.apply(this, arguments);
     }
-  }, {
-    after_save: function () {
-      this.dispatch('refreshRelatedDocuments');
-    }
-  });
+  }, {});
 
   can.Model.Cacheable('CMS.Models.Help', {
     root_object: 'help',

--- a/src/ggrc/assets/javascripts/models/system.js
+++ b/src/ggrc/assets/javascripts/models/system.js
@@ -127,9 +127,6 @@ CMS.Models.SystemOrProcess('CMS.Models.System', {
   init: function () {
     this._super && this._super.apply(this, arguments);
     this.attr('is_biz_process', false);
-  },
-  after_save: function () {
-    this.dispatch('refreshRelatedDocuments');
   }
 });
 
@@ -169,8 +166,5 @@ CMS.Models.SystemOrProcess('CMS.Models.Process', {
   init: function () {
     this._super && this._super.apply(this, arguments);
     this.attr('is_biz_process', true);
-  },
-  after_save: function () {
-    this.dispatch('refreshRelatedDocuments');
   }
 });

--- a/src/ggrc/assets/js_specs/models/cacheable_spec.js
+++ b/src/ggrc/assets/js_specs/models/cacheable_spec.js
@@ -308,7 +308,8 @@ describe('can.Model.Cacheable', function () {
       var dummy;
       beforeEach(function () {
         dummy = new CMS.Models.DummyModel({id: 1});
-        instance = jasmine.createSpyObj('instance', ['get_binding', 'isNew', 'refresh', 'attr']);
+        instance = jasmine.createSpyObj('instance',
+          ['get_binding', 'isNew', 'refresh', 'attr', 'dispatch']);
         binding = jasmine.createSpyObj('binding', ['refresh_stubs']);
         instance._pending_joins = [{what: dummy, how: 'add', through: 'foo'}];
         instance.isNew.and.returnValue(false);
@@ -345,7 +346,8 @@ describe('can.Model.Cacheable', function () {
       beforeEach(function () {
         dummy = new CMS.Models.DummyModel({id: 1});
         dummy_join = new CMS.Models.DummyJoin({id: 1});
-        instance = jasmine.createSpyObj('instance', ['get_binding', 'isNew', 'refresh', 'attr']);
+        instance = jasmine.createSpyObj('instance',
+          ['get_binding', 'isNew', 'refresh', 'attr', 'dispatch']);
         binding = jasmine.createSpyObj('binding', ['refresh_stubs']);
         instance._pending_joins = [{what: dummy, how: 'remove', through: 'foo'}];
         instance.isNew.and.returnValue(false);

--- a/src/ggrc_risks/assets/javascripts/models/risk.js
+++ b/src/ggrc_risks/assets/javascripts/models/risk.js
@@ -45,9 +45,5 @@
         this.validatePresenceOf(reqField);
       }.bind(this));
     }
-  }, {
-    after_save: function () {
-      this.dispatch('refreshRelatedDocuments');
-    }
-  });
+  }, {});
 })(window.can);

--- a/src/ggrc_risks/assets/javascripts/models/threat.js
+++ b/src/ggrc_risks/assets/javascripts/models/threat.js
@@ -50,9 +50,5 @@
       }
       this.validatePresenceOf('title');
     }
-  }, {
-    after_save: function () {
-      this.dispatch('refreshRelatedDocuments');
-    }
-  });
+  }, {});
 })(window.can);


### PR DESCRIPTION
Steps to reproduce:
1. Have audit with Assessment
2. Expand Assessment's Info pane
3. Invoke Edit Assessment modal window
4. Add Reference url > Click Save
5. Look at the Reference url on Assessment's Info pane
Actual Result: Reference url is not displayed on Info panel if add url via Edit Assessment modal window. REFRESH is needed
Expected Result: Reference url should be displayed on Assessment's Info pane after adding via Edit Assessment modal window
NOTE: Assessment entity is taken as en example. There is necessary to check for other objects