### PR TITLE
GGRC-3060 FE: hide 'delete' button in Edit Task modal

### DIFF
--- a/src/ggrc/assets/mustache/modals/save_cancel_delete_buttons.mustache
+++ b/src/ggrc/assets/mustache/modals/save_cancel_delete_buttons.mustache
@@ -13,7 +13,7 @@
       {{else}}
         <div class="deny-buttons">
           {{^new_object_form}}
-            {{#is_allowed 'delete' instance}}
+            {{#is_allowed 'delete' instance context='for'}}
               {{^if_equals modal_title 'Edit Person'}}
                 <a
                   tabindex="37"


### PR DESCRIPTION
Only Admin can delete historic and active cycle tasks
WF manager can only delete active cycle tasks