### PR TITLE
GGRC-3031 If audit is archived a control for edit GCA is not disabled

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment/custom-attributes.js
+++ b/src/ggrc/assets/javascripts/components/assessment/custom-attributes.js
@@ -16,6 +16,7 @@
       items: [],
       editMode: false,
       modifiedFields: {},
+      isEditDenied: false,
       updateGlobalAttribute: function (event, field) {
         this.attr('modifiedFields').attr(field.id, event.value);
         this.dispatch({

--- a/src/ggrc/assets/mustache/components/assessment/custom-attributes.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/custom-attributes.mustache
@@ -23,7 +23,7 @@
                   {edit-mode}="editMode">
                     <base-inline-control-title
                         {edit-mode}="editMode"
-                        {is-edit-icon-denied}="isEditIconDenied"
+                        {is-edit-icon-denied}="isEditDenied"
                         (set-edit-mode-inline)="confirmEdit()">
                       <div class="info-pane__section-title">{{title}}</div>
                     </base-inline-control-title>

--- a/src/ggrc/assets/mustache/components/assessment/info-pane/info-pane.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/info-pane/info-pane.mustache
@@ -188,6 +188,7 @@
                     </assessment-people>
                     <assessment-custom-attributes (on-update-attributes)="saveGlobalAttributes(%event)"
                                                   {items}="globalAttributes"
+                                                  {is-edit-denied}="isEditDenied"
                     ></assessment-custom-attributes>
                 </div>
                 <div class="info-pane__section ggrc-form">


### PR DESCRIPTION
_Steps to reproduce:_
1. Have archived audit with assessment 
2. Go to assessment tab and expand Info pane
3. Hover over GCA field: edit icon is displayed
4. Click edit icon and update GCA field: 403 error is displayed in console, value is displayed in GCA field

_Actual result:_
If audit is archived a control for edit GCA is not disabled. If update GCA while audit is archived, the app allows to save changes, 403 error is displayed in console. After page refresh value in GCA field is not displayed

_Expected result:_
If audit is archived a control for edit GCA should not displayed