### PR TITLE
GGRC-2899 There is no wrapping for reference url in Global Search/Unified Mapper

### DIFF
--- a/src/ggrc/assets/stylesheets/components/unified-mapper/_unified-mapper.scss
+++ b/src/ggrc/assets/stylesheets/components/unified-mapper/_unified-mapper.scss
@@ -394,12 +394,15 @@ mapper-results-item-attrs {
       flex: 1 1 $first-column-width;
     }
 
-    .roles {
+    .roles, .reference-urls-list {
       overflow: hidden;
       text-overflow: ellipsis;;
       .person {
         display: inline;
       }
+    }
+    .reference-urls-list {
+      color: $link;
     }
   }
 }


### PR DESCRIPTION
Steps to reproduce: 
1. Have a program with mapped control 
2. Go to Controls tab and add Reference URL to control 
3. Click 'Global Search' button and find control 
4. Set 'Reference URL' field and look at the search results: there is no wrapping between link and [Assessments] button 
Actual Result: There is no wrapping for reference url in Global Search/Unified Mapper 
Expected Result: Reference url should be cut off with three dots and should be wrapping for reference url in Global Search/Unified Mapper