### PR TITLE
GGRC-2897 Make appropriate width for Reference URLs on objects Info pane

### DIFF
--- a/src/ggrc/assets/stylesheets/components/related-objects/_related-reference-urls.scss
+++ b/src/ggrc/assets/stylesheets/components/related-objects/_related-reference-urls.scss
@@ -17,6 +17,9 @@
 
   & .document-object-item__body {
     padding-right: 8px;
+    .link {
+      max-width: 200px;
+    }
   }
 
   & .link {


### PR DESCRIPTION
Steps to reproduce: 
1. Have any program 
2. Add long Reference URL 
3. Look at the URL 
"Actual Result:" Reference URL has too long width on the Info pane 
Expected Result: Make appropriate width for Reference URLs on objects Info pane. TBD with UX person
New of url field is 200px.