### PR TITLE
GGRC-3067 Cloned WF should have the same repeat as the original WF

### DIFF
--- a/src/ggrc_workflows/models/workflow.py
+++ b/src/ggrc_workflows/models/workflow.py
@@ -184,7 +184,7 @@ class Workflow(mixins.CustomAttributable, HasOwnContext, mixins.Timeboxed,
 
     repeat_every shouldn't have 0 value.
     """
-    if value is not None and not isinstance(value, int):
+    if value is not None and not isinstance(value, (int, long)):
       raise ValueError("'repeat_every' should be integer or 'null'")
     if value is not None and value <= 0:
       raise ValueError("'repeat_every' should be strictly greater than 0")
@@ -296,10 +296,14 @@ class Workflow(mixins.CustomAttributable, HasOwnContext, mixins.Timeboxed,
   def copy(self, _other=None, **kwargs):
     """Create a partial copy of the current workflow.
     """
-    columns = [
-        'title', 'description', 'notify_on_change', 'notify_custom_message',
-        'end_date', 'start_date'
-    ]
+    columns = ['title',
+               'description',
+               'notify_on_change',
+               'notify_custom_message',
+               'end_date',
+               'start_date',
+               'repeat_every',
+               'unit']
     target = self.copy_into(_other, columns, **kwargs)
     return target
 


### PR DESCRIPTION
1. Go to WF info tab with repeat on (for example, repeat every 1 month).
2. Click 3 dots button and select 'Clone Workflow'.
3. Click 'Proceed' button on 'Clone Workflow' pop-up.
Actual result: New workflow has repeat off.
Expected result: New workflow should have repeat 'every 1 month'.