### PR TITLE
GGRC-3019 Add tooltip for state on Unified Mapper

### DIFF
--- a/src/ggrc/assets/javascripts/components/advanced-search/advanced-search-filter-state.js
+++ b/src/ggrc/assets/javascripts/components/advanced-search/advanced-search-filter-state.js
@@ -44,6 +44,17 @@
 
           return state;
         }
+      },
+      /**
+       * Indicates whether status tooltip should be displayed
+       * @type {boolean}
+       */
+      statusTooltipVisible: {
+        type: 'boolean',
+        value: false,
+        get: function () {
+          return StateUtils.hasFilterTooltip(this.attr('modelName'));
+        }
       }
     },
     /**

--- a/src/ggrc/assets/mustache/components/advanced-search/advanced-search-filter-state.mustache
+++ b/src/ggrc/assets/mustache/components/advanced-search/advanced-search-filter-state.mustache
@@ -20,7 +20,10 @@
             plural="States">
     </multiselect-dropdown>
   </div>
+  {{#if statusTooltipVisible}}
+    <div class="filter-state__helper">
+        <i class="fa fa-question-circle" rel="tooltip"
+          title="The state represents the state of this object information within GGRC. It does not indicate the state of the underlying product or system."></i>
+    </div>
+  {{/if}}
 </div>
-
-
-


### PR DESCRIPTION
There is some confusion between the status of the object (marked active / draft/ deprecated) in GGRC to the actual status of the underlying system of product.

Expected result:
The tool tip should be added for status attribute on Unified mapper and advanced searh of products or system:
Tool tip text is "The state represents the state of this object information within GGRC. It does not indicate the state of the underlying product or system"