### PR TITLE
GGRC-2872 HTTP500 is returned on deletion of object with CA after the object is deleted

### DIFF
--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -932,13 +932,10 @@ class Resource(ModelView):
       with benchmark("Send DELETEd - after commit event"):
         signals.Restful.model_deleted_after_commit.send(
             obj.__class__, obj=obj, service=self, event=event)
-      with benchmark("Query for object"):
-        object_for_json = self.object_for_json(obj)
       with benchmark("Send event job"):
         send_event_job(event)
       with benchmark("Make response"):
-        result = self.json_success_response(
-            object_for_json, self.modified_at(obj))
+        result = self.json_success_response({}, datetime.datetime.now())
     except:
       import traceback
       task.finish("Failure", traceback.format_exc())


### PR DESCRIPTION
The exception raises when json is formed for deleted object. 
As frontend doesn't use json representation of deleted object it is no need to send it in response.