### PR TITLE
GGRC-3059 BE: add support for filtering and sorting assessments by GCA with type 'checkbox'

### DIFF
--- a/src/ggrc/fulltext/recordbuilder.py
+++ b/src/ggrc/fulltext/recordbuilder.py
@@ -176,7 +176,9 @@ class RecordBuilder(object):
       properties[attribute_name].update(self.build_list_sort_subprop(
           [obj.attribute_object]))
     else:
-      properties[attribute_name] = {"": obj.attribute_value}
+      properties[attribute_name] = {
+          "": obj.custom_attribute.get_indexed_value(obj.attribute_value)
+      }
     return properties
 
   def as_record(self, obj):  # noqa  # pylint:disable=too-many-branches

--- a/src/ggrc/models/custom_attribute_definition.py
+++ b/src/ggrc/models/custom_attribute_definition.py
@@ -55,6 +55,13 @@ class CustomAttributeDefinition(attributevalidator.AttributeValidator,
   def definition(self):
     return getattr(self, self.definition_attr)
 
+  @property
+  def value_mapping(self):
+    return self.ValidTypes.DEFAULT_VALUE_MAPPING.get(self.attribute_type) or {}
+
+  def get_indexed_value(self, value):
+    return self.value_mapping.get(value, value)
+
   @definition.setter
   def definition(self, value):
     self.definition_id = getattr(value, 'id', None)
@@ -118,6 +125,15 @@ class CustomAttributeDefinition(attributevalidator.AttributeValidator,
     CHECKBOX = "Checkbox"
     DATE = "Date"
     MAP = "Map"
+
+    DEFAULT_VALUE_MAPPING = {
+        CHECKBOX: {
+            True: "Yes",
+            False: "No",
+            "0": "No",
+            "1": "Yes",
+        },
+    }
 
   class MultiChoiceMandatoryFlags(object):
     """Enum representing flags in multi_choice_mandatory bitmaps."""

--- a/src/ggrc/snapshotter/indexer.py
+++ b/src/ggrc/snapshotter/indexer.py
@@ -68,15 +68,10 @@ def _get_custom_attribute_dict():
   cadef_klass_names = {getattr(all_models, klass)._inflector.table_singular
                        for klass in Types.all}
 
-  cads = db.session.query(
-      models.CustomAttributeDefinition.id,
-      models.CustomAttributeDefinition.title,
-      models.CustomAttributeDefinition.attribute_type,
-  ).filter(
+  query = models.CustomAttributeDefinition.query.filter(
       models.CustomAttributeDefinition.definition_type.in_(cadef_klass_names)
   )
-
-  return {cad.id: cad for cad in cads}
+  return {cad.id: cad for cad in query}
 
 
 def get_searchable_attributes(attributes, cad_dict, content):
@@ -102,7 +97,9 @@ def get_searchable_attributes(attributes, cad_dict, content):
       if cad.attribute_type == "Map:Person":
         searchable_values[cad.title] = cav.get("attribute_object")
       else:
-        searchable_values[cad.title] = cav["attribute_value"]
+        searchable_values[cad.title] = cad.get_indexed_value(
+            cav["attribute_value"]
+        )
   return searchable_values
 
 


### PR DESCRIPTION
BE should support filtering and sorting Assessments by GCA with type 'checkbox' (available values 'Yes' and 'No').
