### PR TITLE
GGRC-2907: Fix issue with 'Verify'/'Decline' buttons on 'Tasks' tree view

### DIFF
--- a/src/ggrc/assets/javascripts/components/cycle-task-actions/cycle-task-actions.js
+++ b/src/ggrc/assets/javascripts/components/cycle-task-actions/cycle-task-actions.js
@@ -39,7 +39,7 @@
 
           if (pageType === 'Workflow') {
             return !this.isBacklog() &&
-              this.attr('cycle').reify().is_current;
+              this.attr('cycle').reify().attr('is_current');
           }
 
           return allowChangeState;

--- a/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
@@ -354,7 +354,7 @@
       }
       if (widget) {
         this.set_active_widget(widget);
-        return this.display_widget_path(rest, refetch);
+        return this.display_widget_path(rest, refetch || widget.forceRefetch);
       }
       return new $.Deferred().resolve();
     },
@@ -493,6 +493,7 @@
       widget.attr({
         internav_icon: icon,
         internav_display: title,
+        forceRefetch: widgetOptions && widgetOptions.forceRefetch,
         spinner: this.options.spinners['#' + $widget.attr('id')],
         model: widgetOptions && widgetOptions.model,
         order: (widgetOptions || widget).order

--- a/src/ggrc/assets/mustache/components/cycle-task-actions/cycle-task-actions.mustache
+++ b/src/ggrc/assets/mustache/components/cycle-task-actions/cycle-task-actions.mustache
@@ -53,16 +53,16 @@
                       data-value="Verified">Verify</button>
             {{/if}}
           {{/if_equals}}
-          {{#if oldValues.length}}
-            <a href="javascript://" data-name="status"
-                {{#if disabled}}disabled{{/if}}
-                ($click)="undo"
-                data-undo="true"
-                class="undo">Undo</a>
-          {{/if}}
         </div>
       {{/is_allowed}}
     {{/if}}
+      {{#if oldValues.length}}
+          <a href="javascript://" data-name="status"
+             {{#if disabled}}disabled{{/if}}
+             ($click)="undo"
+             data-undo="true"
+             class="undo">Undo</a>
+      {{/if}}
   {{/with_review_task}}
 </div>
 {{/if_instance_of}}

--- a/src/ggrc/assets/mustache/components/cycle-task-actions/cycle-task-actions.mustache
+++ b/src/ggrc/assets/mustache/components/cycle-task-actions/cycle-task-actions.mustache
@@ -56,13 +56,13 @@
         </div>
       {{/is_allowed}}
     {{/if}}
-      {{#if oldValues.length}}
-          <a href="javascript://" data-name="status"
-             {{#if disabled}}disabled{{/if}}
-             ($click)="undo"
-             data-undo="true"
-             class="undo">Undo</a>
-      {{/if}}
+    {{#if oldValues.length}}
+      <a href="javascript://" data-name="status"
+         {{#if disabled}}disabled{{/if}}
+         ($click)="undo"
+         data-undo="true"
+         class="undo">Undo</a>
+    {{/if}}
   {{/with_review_task}}
 </div>
 {{/if_instance_of}}

--- a/src/ggrc_workflows/assets/javascripts/apps/workflows.js
+++ b/src/ggrc_workflows/assets/javascripts/apps/workflows.js
@@ -546,6 +546,7 @@
       widget_name: 'History',
       widget_icon: 'history',
       model: CMS.Models.Cycle,
+      forceRefetch: true,
       content_controller_options: {
         draw_children: true,
         parent_instance: object,
@@ -563,6 +564,7 @@
       widget_name: 'Active Cycles',
       widget_icon: 'cycle',
       model: CMS.Models.Cycle,
+      forceRefetch: true,
       content_controller_options: {
         draw_children: true,
         parent_instance: object,


### PR DESCRIPTION
Steps to reproduce:
1. Create one time workflow.
2. Add at least 3 tasks to Task group in Setup tab, one task should be overdue.
3. Activate workflow.
4. At the Active Cycles tab verify tasks.
5. Click 'undo' button for all tasks and hover over first Tasks's tiers: only overdue task contains 'Verify'/'Decline' buttons.

Expected Result: 'Verify'/'Decline' buttons should be displayed in Tasks first tier after clicking 'undo'