### PR TITLE
QUICK-FIX Add ggrc_gdrive_integration to local deploy settings

### DIFF
--- a/extras/deploy_settings_local.sh
+++ b/extras/deploy_settings_local.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 APPENGINE_INSTANCE=local
-SETTINGS_MODULE="development app_engine ggrc_basic_permissions.settings.development ggrc_risks.settings.development ggrc_risk_assessments.settings.development ggrc_workflows.settings.development"
+SETTINGS_MODULE="development app_engine ggrc_basic_permissions.settings.development ggrc_risks.settings.development ggrc_risk_assessments.settings.development ggrc_workflows.settings.development ggrc_gdrive_integration.settings.development"
 DATABASE_URI="mysql+mysqldb://root:root@${GGRC_DATABASE_HOST:-localhost}/ggrcdev?charset=utf8"
 SECRET_KEY='Something-secret'
 GOOGLE_ANALYTICS_ID=""


### PR DESCRIPTION
This fixes issues with `launch_ggrc` after running `deploy_appengine
extras/deploy_settings_local.sh`. Gdrive integration still seems not to
work with `launch_gae_ggrc`, but that's a separate issue.