### PR TITLE
GGRC-2966 Assessment UX - checkbox

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.js
+++ b/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.js
@@ -318,6 +318,16 @@
         this.viewModel.attr('mappedSnapshots')
           .replace(this.viewModel.loadSnapshots());
       }
+    },
+    helpers: {
+      extraClass: function (type) {
+        switch (type()) {
+          case 'checkbox':
+            return 'inline-reverse';
+          default:
+            return '';
+        }
+      }
     }
   });
 })(window.can, window.GGRC, window.CMS);

--- a/src/ggrc/assets/javascripts/components/auto-save-form/auto-save-form.js
+++ b/src/ggrc/assets/javascripts/components/auto-save-form/auto-save-form.js
@@ -199,16 +199,6 @@
       removed: function () {
         this.viewModel.unsubscribe();
       }
-    },
-    helpers: {
-      extraClass: function (type) {
-        switch (type()) {
-          case 'checkbox':
-            return 'inline-reverse';
-          default:
-            return '';
-        }
-      }
     }
   });
 })(window.can, window.GGRC, window.jQuery);

--- a/src/ggrc/assets/javascripts/components/auto-save-form/auto-save-form.js
+++ b/src/ggrc/assets/javascripts/components/auto-save-form/auto-save-form.js
@@ -199,6 +199,16 @@
       removed: function () {
         this.viewModel.unsubscribe();
       }
+    },
+    helpers: {
+      extraClass: function (type) {
+        switch (type()) {
+          case 'checkbox':
+            return 'inline-reverse';
+          default:
+            return '';
+        }
+      }
     }
   });
 })(window.can, window.GGRC, window.jQuery);

--- a/src/ggrc/assets/mustache/components/auto-save-form/auto-save-form.mustache
+++ b/src/ggrc/assets/mustache/components/auto-save-form/auto-save-form.mustache
@@ -5,7 +5,7 @@
 
 <div class="fields-wrapper flex-box flex-row">
   {{#each fields}}
-    <div class="field-wrapper flex-size-1">
+    <div class="field-wrapper flex-size-1 {{extraClass type}}">
       <form-validation-icon {validation}="validation"></form-validation-icon>
       <div class="field__title form-field__title">
         <label class="field__title-text" for="form-field-{{id}}">{{title}}</label>
@@ -21,13 +21,13 @@
           {placeholder}="placeholder"
           {options}="options"
           (value-changed)="fieldValueChanged(%event, %context)"
-          class="form-field__content"
+          class="form-field__content {{{extraClass type}}"
         ></auto-save-form-field>
       {{else}}
         <auto-save-form-field-view
           {type}="type"
           {value}="value"
-          class="form-field__content"
+          class="form-field__content {{extraClass type}}"
         ></auto-save-form-field-view>
       {{/if}}
       {{#unless validation.valid}}

--- a/src/ggrc/assets/mustache/components/auto-save-form/auto-save-form.mustache
+++ b/src/ggrc/assets/mustache/components/auto-save-form/auto-save-form.mustache
@@ -8,7 +8,7 @@
     <div class="field-wrapper flex-size-1 {{extraClass type}}">
       <form-validation-icon {validation}="validation"></form-validation-icon>
       <div class="field__title form-field__title">
-        <label class="field__title-text" for="form-field-{{id}}">{{title}}</label>
+        <label class="field__title-text {{extraClass type}}" for="form-field-{{id}}">{{title}}</label>
         {{#if helptext}}
           <i class="fa fa-question-circle field__title-helper-text" rel="tooltip" title="{{helptext}}"></i>
         {{/if}}

--- a/src/ggrc/assets/mustache/components/object-popover/related-assessment-popover.mustache
+++ b/src/ggrc/assets/mustache/components/object-popover/related-assessment-popover.mustache
@@ -10,10 +10,10 @@
         <tab-panel {(panels)}="panels" title-text="Attributes">
             <div class="fields-wrapper flex-box flex-row">
                 <show-more items="selectedAssessmentFields">
-                    <div class="field-wrapper flex-size-1">
+                    <div class="field-wrapper flex-size-1 {{extraClass type}}">
                         <form-validation-icon {validation}="validation"></form-validation-icon>
                         <div class="field__title form-field__title">
-                            <label class="field__title-text" for="form-field-{{id}}">{{title}}</label>
+                            <label class="field__title-text {{extraClass type}}" for="form-field-{{id}}">{{title}}</label>
                             {{#if helptext}}
                                 <i class="fa fa-question-circle field__title-helper-text" rel="tooltip" title="{{helptext}}"></i>
                             {{/if}}
@@ -21,6 +21,7 @@
                         <auto-save-form-field-view
                                 {type}="type"
                                 {value}="value"
+                                class="form-field__content {{{extraClass type}}"
                         ></auto-save-form-field-view>
                     </div>
                 </show-more>

--- a/src/ggrc/assets/stylesheets/components/auto-save-form/_auto-save-form.scss
+++ b/src/ggrc/assets/stylesheets/components/auto-save-form/_auto-save-form.scss
@@ -56,10 +56,6 @@ auto-save-form {
     }
 
     auto-save-form-field {
-      &.inline-reverse {
-        min-width: auto;
-        padding-top: 5px;
-      }
       display: block;
       flex: 1;
       min-width: 150px;
@@ -75,6 +71,10 @@ auto-save-form {
 
     .form-field__content {
       max-width: 360px;
+      &.inline-reverse {
+        min-width: auto;
+        padding: 5px 8px 0 0;
+      }
     }
 
     .form-field__validation-hint-placeholder {
@@ -110,6 +110,9 @@ auto-save-form {
     text-transform: uppercase;
     line-height: 16px;
     padding: 5px 0;
+    &.inline-reverse {
+      max-width: 332px;
+    }
   }
 
   &__title-helper-text {

--- a/src/ggrc/assets/stylesheets/components/auto-save-form/_auto-save-form.scss
+++ b/src/ggrc/assets/stylesheets/components/auto-save-form/_auto-save-form.scss
@@ -50,7 +50,16 @@ auto-save-form {
     align-items: flex-start;
     justify-content: flex-start;
 
+    &.inline-reverse {
+      flex-direction: row-reverse;
+      flex-wrap: nowrap
+    }
+
     auto-save-form-field {
+      &.inline-reverse {
+        min-width: auto;
+        padding-top: 5px;
+      }
       display: block;
       flex: 1;
       min-width: 150px;


### PR DESCRIPTION
Scope:
- move the checkbox control right before the text - see the mock

UX of checkbox - https://drive.google.com/file/d/0B7_NYFVmb896WnFvVVg4dmsyd00/view


--from user
Why is this generic attestation a checkbox rather than the drop down as others? For a moment, I was confused as I didn’t expect this new interaction.  https://screenshot.googleplex.com/fLUaVWbgQcT 
