### PR TITLE
GGRC-3069: Remove 'Reference URLs' from Related Assessments window

### DIFF
--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -189,6 +189,7 @@ dashboard-js-files:
   - components/related-objects/related-comments.js
   - components/related-objects/related-controls-objectives.js
   - components/related-objects/related-issues.js
+  - components/related-objects/related-evidences-and-urls.js
   - components/object-state-toolbar/object-state-toolbar.js
   - components/object-list/object-list.js
   - components/ca-object/ca-object.js

--- a/src/ggrc/assets/javascripts/components/related-objects/related-assessment-item.js
+++ b/src/ggrc/assets/javascripts/components/related-objects/related-assessment-item.js
@@ -15,8 +15,7 @@
       loadingState: {},
       subItemsLoading: function () {
         return this.attr('loadingState.auditLoading') ||
-          this.attr('loadingState.urlsLoading') ||
-          this.attr('loadingState.attachmentsLoading') ||
+          this.attr('loadingState.evidencesAndUrlsLoading') ||
           this.attr('loadingState.controlsLoading');
       }
     }

--- a/src/ggrc/assets/javascripts/components/related-objects/related-evidences-and-urls.js
+++ b/src/ggrc/assets/javascripts/components/related-objects/related-evidences-and-urls.js
@@ -1,0 +1,71 @@
+/*!
+    Copyright (C) 2017 Google Inc.
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+(function (can, $, _, GGRC) {
+  'use strict';
+
+  GGRC.Components('relatedEvidencesAndUrls', {
+    tag: 'related-evidences-and-urls',
+    viewModel: {
+      define: {
+        parentInstance: {
+          value: {}
+        }
+      },
+      documents: [],
+      isLoading: false,
+      getDocumentsQuery: function () {
+        var documentTypes = [
+          CMS.Models.Document.EVIDENCE,
+          CMS.Models.Document.URL];
+        var relevantFilters = [{
+          type: this.attr('parentInstance.type'),
+          id: this.attr('parentInstance.id'),
+          operation: 'relevant'
+        }];
+        var includeFilters = {
+          keys: [],
+          expression: {}
+        };
+        var query;
+
+        documentTypes.forEach(function (type) {
+          includeFilters = GGRC.query_parser.join_queries({
+            expression: {
+              op: {name: '='},
+              left: 'document_type',
+              right: type
+            },
+            keys: []
+          }, includeFilters, 'OR');
+        });
+
+        query = GGRC.Utils.QueryAPI
+          .buildParam('Document', {}, relevantFilters, [], includeFilters);
+        query.order_by = [{name: 'created_at', desc: true}];
+
+        return query;
+      },
+      loadDocuments: function () {
+        var promise;
+        var self = this;
+        var query = this.getDocumentsQuery();
+
+        this.attr('isLoading', true);
+        promise = GGRC.Utils.QueryAPI.batchRequests(query).then(
+          function (response) {
+            var documents = response.Document.values;
+            self.attr('documents').replace(documents);
+            self.attr('isLoading', false);
+          }
+        );
+        return promise;
+      }
+    },
+    init: function () {
+      this.viewModel.loadDocuments();
+    }
+  });
+})(window.can, window.can.$, window._, window.GGRC);

--- a/src/ggrc/assets/javascripts/components/related-objects/tests/related-evidences-and-urls_spec.js
+++ b/src/ggrc/assets/javascripts/components/related-objects/tests/related-evidences-and-urls_spec.js
@@ -1,0 +1,41 @@
+/*!
+ Copyright (C) 2017 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+describe('GGRC.Components.relatedEvidencesAndUrls', function () {
+  'use strict';
+
+  var viewModel;
+  var instance;
+
+  beforeEach(function () {
+    viewModel = GGRC.Components.getViewModel('relatedEvidencesAndUrls');
+    instance = {
+      id: '5',
+      type: 'Assessment'
+    };
+
+    viewModel.attr('parentInstance', instance);
+  });
+
+  describe('"getDocumentsQuery" method', function () {
+    function checkAdditionFilter(leftDocType, rightDocType) {
+      var query;
+      var additionFilter;
+      query = viewModel.getDocumentsQuery();
+
+      expect(query.filters.expression).toBeDefined();
+      additionFilter = query.filters.expression.right;
+      expect(additionFilter.left.left).toEqual('document_type');
+      expect(additionFilter.left.right).toEqual(leftDocType);
+      expect(additionFilter.right.left).toEqual('document_type');
+      expect(additionFilter.right.right).toEqual(rightDocType);
+    }
+
+    it('should get query for urls and evidences', function () {
+      checkAdditionFilter(CMS.Models.Document.URL,
+        CMS.Models.Document.EVIDENCE);
+    });
+  });
+});

--- a/src/ggrc/assets/mustache/assessments/related-assessments-without-reuse.mustache
+++ b/src/ggrc/assets/mustache/assessments/related-assessments-without-reuse.mustache
@@ -75,13 +75,12 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                             </related-audits>
                         </div>
                         <div class="flex-size-3">
-                            <related-documents
-                                {^is-loading}="loadingState.attachmentsLoading"
-                                {instance}="instance">
-                                <object-list {items}="documents">
+                            <related-evidences-and-urls {parent-instance}="instance"
+                                                        {^is-loading}="loadingState.evidencesAndUrlsLoading">
+                                <object-list items="documents">
                                     <document-object-list-item {instance}="{.}"></document-object-list-item>
                                 </object-list>
-                            </related-documents>
+                            </related-evidences-and-urls>
                         </div>
                         <div class="grid-data__action-column">
                             <button class="btn btn-icon btn-icon-sm" title="Show More Information"><i class="fa fa-info-circle"></i></button>

--- a/src/ggrc/assets/mustache/assessments/related-assessments.mustache
+++ b/src/ggrc/assets/mustache/assessments/related-assessments.mustache
@@ -87,16 +87,17 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                                 </related-audits>
                             </div>
                             <div class="flex-size-3">
-                                <related-documents {instance}="instance" {^is-loading}="loadingState.attachmentsLoading">
-                                    <object-list {items}="documents">
+                                <related-evidences-and-urls {parent-instance}="instance"
+                                                            {^is-loading}="loadingState.evidencesAndUrlsLoading">
+                                    <object-list items="documents">
                                         <reusable-objects-item {instance}="{.}"
-                                                            {is-saving}="isSaving"
-                                                            {base-instance-documents}="baseInstanceDocuments"
-                                                            {(selected-list)}="documentList">
+                                                               {is-saving}="isSaving"
+                                                               {base-instance-documents}="baseInstanceDocuments"
+                                                               {(selected-list)}="documentList">
                                             <document-object-list-item {instance}="instance"></document-object-list-item>
                                         </reusable-objects-item>
                                     </object-list>
-                                </related-documents>
+                                </related-evidences-and-urls>
                             </div>
                             <div class="grid-data__action-column">
                                 <button class="btn btn-icon btn-icon-sm" title="Show More Information"><i class="fa fa-info-circle"></i></button>


### PR DESCRIPTION
Steps to reproduce:
1. Have two assessments on the audit page with filled Reference URLs
2. Expand Assessment Info pane for one of Assessment
3. Click 'Related Assessments' button
4. Look at the Attachments/URLs column: Reference URLs are displayed
Actual Result: If user opens Related Assessments window, Reference URls are displayed
Expected Result: If user opens Related Assessments window, Reference URls should not display. Reference URls should be removed from Related Assessments window. Only evidences and URLs (from grey box) should be displayed in Attachments/URLs column in Related Assessments window
