### PR TITLE
GGRC-2937 JS error message occurs if update CA with rich text on Regulation's Info pane

### DIFF
--- a/src/ggrc/assets/javascripts/components/rich_text/rich_text.js
+++ b/src/ggrc/assets/javascripts/components/rich_text/rich_text.js
@@ -116,8 +116,10 @@
         var editor = this.attr('editor');
         var activeElement = document.activeElement;
 
+        // checks case when we click on another rich-text component
+        // or outside of component
         if (editor.hasFocus() ||
-          $(activeElement).closest('.rich-text__content').length) {
+          $(activeElement).closest('rich-text').viewModel() === this) {
           this.attr('editorHasFocus', true);
           return;
         }
@@ -125,8 +127,11 @@
         this.attr('editorHasFocus', false);
       },
       onRemoved: function () {
-        this.attr('editor')
-          .off('selection-change', this.onSelectionChang);
+        var editor = this.getEditor();
+
+        if (this.attr('hiddenToolbar') && editor) {
+          editor.off('selection-change');
+        }
       },
       onChange: function (delta) {
         var match;


### PR DESCRIPTION
Steps to reproduce:
1. Have GCA with rich text type for Regulation
2. Go to My Work page > Regulations tab
3. Navigate to Regulation's Info pane
4. Fill GCA with rich text > Save
5. Update GCA with rich text > Save
6. Look at the screen: error is shown

***Actual Result:*** "Uncaught TypeError: this.attr(...).off is not a function     at Constructor.onRemoved" error message occurs if update CA with rich text on Regulation's Info pane
***Expected Result:*** no errors are shown while updating GCA with rich text type