### PR TITLE
GGRC-2957: Rename Evidence and URL on Assessment Info panel

### DIFF
--- a/src/ggrc/assets/mustache/assessments/related-assessments-without-reuse.mustache
+++ b/src/ggrc/assets/mustache/assessments/related-assessments-without-reuse.mustache
@@ -26,7 +26,7 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
             Audit Title
         </div>
         <div class="flex-size-3">
-            Attachments / Urls
+            Evidence files / Urls
         </div>
         <div class="grid-data__action-column">
             More info

--- a/src/ggrc/assets/mustache/assessments/related-assessments.mustache
+++ b/src/ggrc/assets/mustache/assessments/related-assessments.mustache
@@ -35,7 +35,7 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                 Audit Title
             </div>
             <div class="flex-size-3">
-                Attachments / Urls
+                Evidence files / Urls
             </div>
             <div class="grid-data__action-column">
                 More info

--- a/src/ggrc/assets/mustache/components/ca-object/ca-object-modal-content.mustache
+++ b/src/ggrc/assets/mustache/components/ca-object/ca-object-modal-content.mustache
@@ -25,7 +25,7 @@
       {{/if}}
       {{#if evidence}}
         <div class="simple-modal__section">
-            <div class="simple-modal__section-title">Evidence
+            <div class="simple-modal__section-title">Evidence file
               <spinner class="simple-modal__section-title-icon" {toggle}="isUpdatingEvidences"></spinner>
             </div>
             <object-list {items}="evidences" {empty-message}="noItemsText">


### PR DESCRIPTION
Changes on Assessment Info component
1. 'Evidence' should be replaced with 'Evidence file'
2. 'URL' should be replaced with 'Evidence URL'
3. 'Attachments/URLs' should be replaced with 'Evidence files/URLs'