### PR TITLE
GGRC-3023 Incorrect control's link in Control popup on Assessment's Info pane

### DIFF
--- a/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
+++ b/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
@@ -727,6 +727,7 @@
       }
 
       object = new model(content);
+      object.attr('originalLink', content.originalLink);
       // Update archived flag in content when audit is archived:
       if (instance.parent &&
         CMS.Models.Audit.findInCacheById(instance.parent.id)) {


### PR DESCRIPTION
Steps to reproduce:
1. Have audit with control's snapshot
2. Generate assessment based on the control's snapshot
3. Expand Assessment's Info pane and click control's snapshot to open Control popup
4. Click Control's link
5. Look at the screen
Actual Result: While clicking Control's link in the Control popup audit page is displayed
Expected Result: While clicking Control's link in the Control popup original control Info page should be displayed