### PR TITLE
GGRC-3033 New assessment is created in "In progress" state if add Reference URL while creation

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment/info-pane/confirm-edit-action.js
+++ b/src/ggrc/assets/javascripts/components/assessment/info-pane/confirm-edit-action.js
@@ -16,13 +16,14 @@
       onStateChangeDfd: can.Deferred().resolve(),
       openEditMode: function (el) {
         this.attr('onStateChangeDfd').then(function () {
-          if (this.isInProgress()) {
+          if (this.isInEditableState()) {
             this.dispatch('setEditMode');
           }
         }.bind(this));
       },
-      isInProgress: function () {
-        return this.attr('instance.status') === 'In Progress';
+      isInEditableState: function () {
+        var editableStates = ['In Progress', 'Not Started'];
+        return _.contains(editableStates, this.attr('instance.status'));
       },
       showConfirm: function () {
         var self = this;
@@ -41,7 +42,7 @@
         });
       },
       confirmEdit: function () {
-        if (!this.isInProgress()) {
+        if (!this.isInEditableState()) {
           this.showConfirm();
           return;
         }


### PR DESCRIPTION
Steps to reproduce:
1. On the audit page Invoke new assessment modal window
2. Fill the required fields and add Reference URL > Save and Close
3. Look at the assessment's state in tree view: is "In progress"
*Actual Result:* New assessment is created in "In progress" state if add Reference URL while creation
*Expected Result:* If user create/generate new assessment, assessment should be in "Not Started" state

-------
Discussed with Lilia and Andrei K.
Original issue will be fixed in separate ticket on backend side.
In scope of this ticket I should prevent confirmation modal appearing in 'not started' state.