### PR TITLE
GGRC-2873 Improve padding between label and title 

### DIFF
--- a/src/ggrc/assets/stylesheets/components/info-pane/_info-pane.scss
+++ b/src/ggrc/assets/stylesheets/components/info-pane/_info-pane.scss
@@ -101,14 +101,14 @@
         white-space: nowrap;
         text-overflow: ellipsis;
         max-width: 600px;
-        margin-right: 0px;
+        margin-right: 8px;
       }
 
       .state-value {
         box-sizing: border-box;
         height: 20px;
         white-space: nowrap;
-        margin: 0 5px 0 5px;
+        margin-right: 8px;
         line-height: 19px;
         display: flex;
         align-items: center;


### PR DESCRIPTION
Steps to reproduce:

1. Have assessment on the audit page 
2. Expand Info pane and look at the padding between label and title 

Expected Result: Improve padding between label and title: 8 px