### PR TITLE
GGRC-3036 Remove stuck "Close info pane" tooltip when the close button is pressed.

### DIFF
--- a/src/ggrc/assets/javascripts/components/info-pin-buttons/info-pin-buttons.js
+++ b/src/ggrc/assets/javascripts/components/info-pin-buttons/info-pin-buttons.js
@@ -39,6 +39,7 @@
       },
       close: function (el, ev) {
         var onClose = Mustache.resolve(this.onClose);
+        $(el).find('[rel="tooltip"]').tooltip('hide');
         ev.preventDefault();
         onClose();
       }


### PR DESCRIPTION
The "Close info pane" tooltip on the assessment info page was stuck in its place when the info pane was closed. 

Steps to reproduce:
1. Have audit with created assessment
2. Go to assessments tab and click first tire to expand Info pane
3. Hover over [x] button to show "Close Info pane" tooltip
4. Close Info pane
5. Look at the screen
Actual Result: "Close Info pane" tooltip is sticking to the screen after closing Assessments Info pane
Expected Result: "Close Info pane" tooltip should disappear after closing Assessments Info pane
