### PR TITLE
GGRC-3012: Cut off controls/objectives title on Related Assessment Info and Related Assessments modal

### DIFF
--- a/src/ggrc/assets/stylesheets/components/mapped-objects/_mapped-objects.scss
+++ b/src/ggrc/assets/stylesheets/components/mapped-objects/_mapped-objects.scss
@@ -53,9 +53,15 @@
 
   .title {
     color: $middleText;
+    display: -webkit-box;
     padding: 0 16px 0 24px;
     position: relative;
     font-size: 13px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    word-wrap: break-word;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
 
     .fa {
       position: absolute;


### PR DESCRIPTION
Fix issues on screens:
![screenshot-3](https://user-images.githubusercontent.com/24203972/29447685-b356245a-83fb-11e7-9c45-8498b5f76352.png)

![screenshot-1 2](https://user-images.githubusercontent.com/24203972/29447686-b5cde06a-83fb-11e7-8966-1b31da430095.png)
