### PR TITLE
GGRC-2822 Fix duplicate tab ids in assessment info pane.

### DIFF
--- a/src/ggrc/assets/javascripts/components/tabs/tab-panel.js
+++ b/src/ggrc/assets/javascripts/components/tabs/tab-panel.js
@@ -22,7 +22,7 @@
         if (isAlreadyAdded) {
           return;
         }
-        this.attr('tabIndex', Date.now());
+        this.attr('tabIndex', panels.length + 1);
         panels.push(this);
       },
       removePanel: function () {


### PR DESCRIPTION
Sometimes duplicate tab ids where generated which led to making active
two tabs at the same time.

The issue is hard to reproduce due to reliance on the current time stamp which was used as the tab id. On a fast machine, where the code executes faster, this issue should appear more frequently.

Steps to reproduce:
1. Go to My work page > Assessments tab
2. Click on first tier of any Assessment in tree view
3. Once Assessment's first tier is expanded click on Related Issues or Related Assessment tab
4. Look at the screen: Related Issues and Related assessments tab are both opening
Actual Result: If user clicks on related assessments or related issues tabs on Assessment's Info pane, mentioned tabs are both opening. Related Issues data is displayed under Related assessments data
Expected Result: Related Issues and Related assessments tab should not both opening if click one of this tabs
