### PR TITLE
GGRC-1984/GGRC-1942: Show spinner in Related Assessment window when data is loading

### DIFF
--- a/src/ggrc/assets/javascripts/components/related-objects/related-assessment-list.js
+++ b/src/ggrc/assets/javascripts/components/related-objects/related-assessment-list.js
@@ -12,17 +12,23 @@
   can.Component.extend({
     tag: 'related-assessment-list',
     viewModel: {
-      assessments: null,
-      itemsLoading: function () {
-        var items = this.attr('assessments');
-        if (!items) {
-          return false;
-        }
+      define: {
+        itemsLoading: {
+          get: function () {
+            // due to 'assessments' will be updated via
+            // replace method, 'assessments.length' adds
+            // subscription on 'add' and 'remove' events
+            if (!this.attr('assessments.length')) {
+              return false;
+            }
 
-        return _.any(items, function (item) {
-          return item.attr('itemLoading');
-        });
-      }
+            return _.any(this.attr('assessments'), function (item) {
+              return item.attr('itemLoading');
+            });
+          }
+        }
+      },
+      assessments: null
     }
   });
 })(window.can);


### PR DESCRIPTION
Preconditions: have program, control, audit
Steps to reproduce:
1. On the audit page generate at least 11 assessments based on control
2. Navigate to Assessment's Info pane one of assessments
3. Open Related Assessments window and using pagination follow to the next page
4. Look at the window
Actual Result: Spinner disappears in Related Assessments window before data was loaded; extra spinners are displayed on Related Assessments window while user navigates on next page.
Expected Result: Spinner should disappear in Related Assessments window when data was loaded; there should be no extra spinners while user navigates on next page.