### PR TITLE
GGRC-2898/ GGRC-2314 'Principal Assignee' option is not selected by default for 'Default Assignee' dropdown on Assessment Template

### DIFF
--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -335,7 +335,7 @@
       test_plan_procedure: false,
       template_object_type: 'Control',
       default_people: {
-        assessors: '',
+        assessors: 'Principal Assignees',
         verifiers: 'Auditors'
       },
       // the custom lists of assessor / verifier IDs if "other" is selected for

--- a/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
@@ -12,7 +12,6 @@
       <div class="span12">
         <label>
           Default Assessment Type
-          <span class="required">*</span>
         </label>
 
         <assessment-object-type-dropdown
@@ -112,15 +111,12 @@
           <div class="span6 bottom-spacing{{#validation_error instance.computed_errors 'default_people.assessors'}} field-failure{{/validation_error}}">
             <label>
               Default Assignees
-              <span class="required">*</span>
             </label>
             <dropdown
               class-name="input-block-level js-toggle-field"
               options-list="instance.people_values"
               name="instance.default_people.assessors"
               on-change="instance.defaultAssesorsChanged"
-              no-value="true"
-              no-value-label=" "
             ></dropdown>
 
             {{#validation_error instance.computed_errors 'default_people.assessors'}}


### PR DESCRIPTION
**NOTE:** In scope of this ticket I fixed GGRC-2314 because GGRC-2898 is redundant.

GGRC-2314 Steps to reproduce:
1. Invoke New assessment template modal window
2. Look at the "Default Assignees" dropdown: 'Principal Assignee' option should is not selected by default

**Actual Result:** 'Principal Assignee' option is not selected by default for 'Default Assignee' dropdown on Assessment Template
**Expected Result:** 'Principal Assignee' option should be selected by default for 'Default Assignee' dropdown on Assessment Template