### PR TITLE
GGRC-3095 Unified Mapper window is displayed instead of Global Search

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/mapper.js
+++ b/src/ggrc/assets/javascripts/controllers/mapper.js
@@ -118,7 +118,7 @@
           'join-object-id': data.join_object_id
         };
         if (isSearch) {
-          self.launch(btn, can.extend(config, data));
+          GGRC.Controllers.ObjectSearch.launch(btn, can.extend(config, data));
         } else {
           self.launch(btn, can.extend(config, data));
         }


### PR DESCRIPTION
**Steps to reproduce**:
1. Go to My Work page
2. Click 'Global Search' button
3. Look at the screen

**Actual Result**: Unified Mapper window is displayed instead of Global Search
**Expected Result**: Global Search window should be displayed if click 'Global Search' button

![screenshot-1](https://user-images.githubusercontent.com/4204416/29463585-e99c29fc-843b-11e7-9c86-d8696b5f5c5e.png)
