### PR TITLE
GGRC 2043: Remove unmap button for not directly related objects 

### DIFF
--- a/src/ggrc/assets/javascripts/components/tree/tests/tree-widget-container_spec.js
+++ b/src/ggrc/assets/javascripts/components/tree/tests/tree-widget-container_spec.js
@@ -483,7 +483,9 @@ describe('GGRC.Components.treeWidgetContainer', function () {
           pageSize: 10,
           count: 5
         },
-        showedItems: [{id: 1}, {id: 2}, {id: 3}]
+        showedItems: [{id: 1, type: 'object'},
+          {id: 2, type: 'object'},
+          {id: 3, type: 'object'}]
       });
       vm.attr('pageInfo.current', 3);
     });
@@ -492,7 +494,7 @@ describe('GGRC.Components.treeWidgetContainer', function () {
       function () {
         var result;
 
-        result = vm.getAbsoluteItemNumber({id: 2});
+        result = vm.getAbsoluteItemNumber({id: 2, type: 'object'});
 
         expect(result).toEqual(21);
       });
@@ -501,15 +503,23 @@ describe('GGRC.Components.treeWidgetContainer', function () {
        function () {
          var result;
 
-         result = vm.getAbsoluteItemNumber({id: 4});
+         result = vm.getAbsoluteItemNumber({id: 4, type: 'object'});
 
          expect(result).toEqual(-1);
        });
+    it('should return "-1" when item is of different type',
+      function () {
+        var result;
+
+        result = vm.getAbsoluteItemNumber({id: 3, type: 'snapshot'});
+
+        expect(result).toEqual(-1);
+      });
     it('should return correct item number for first item on non first page',
        function () {
          var result;
 
-         result = vm.getAbsoluteItemNumber({id: 1});
+         result = vm.getAbsoluteItemNumber({id: 1, type: 'object'});
 
          expect(result).toEqual(20);
        });

--- a/src/ggrc/assets/javascripts/components/tree/tree-widget-container.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-widget-container.js
@@ -551,7 +551,8 @@
       var showedItems = this.attr('showedItems');
       var pageInfo = this.attr('pageInfo');
       var startIndex = pageInfo.pageSize * (pageInfo.current - 1);
-      var relativeItemIndex = _.findIndex(showedItems, {id: instance.id});
+      var relativeItemIndex = _.findIndex(showedItems,
+        {id: instance.id, type: instance.type});
       return relativeItemIndex > -1 ?
         startIndex + relativeItemIndex :
         relativeItemIndex;

--- a/src/ggrc/assets/javascripts/controllers/info_pin_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/info_pin_controller.js
@@ -122,6 +122,11 @@ can.Control('CMS.Controllers.InfoPin', {
     var panelHeight = this.getPinHeight(maximizedState);
     var currentPanelHeight;
     var infoPaneOpenDfd = can.Deferred();
+    var isSubtreeItem = opts.attr('options.isSubTreeItem');
+
+    opts.attr('options.isDirectlyRelated',
+      !isSubtreeItem ||
+      GGRC.Utils.TreeView.isDirectlyRelated(instance));
 
     this.prepareView(opts, el, maximizedState, true);
     // Load trees inside info pin

--- a/src/ggrc/assets/javascripts/plugins/utils/tree-view-utils.js
+++ b/src/ggrc/assets/javascripts/plugins/utils/tree-view-utils.js
@@ -472,7 +472,7 @@
             values.forEach(function (source) {
               var instance = _createInstance(source, modelName);
 
-              if (_isDirectlyRelated(instance)) {
+              if (isDirectlyRelated(instance)) {
                 directlyRelated.push(instance);
               } else {
                 notRelated.push(instance);
@@ -514,6 +514,28 @@
           _getTreeViewOperation(requestedType);
       }
       return expression;
+    }
+
+    /**
+     * Check if object directly mapped to the current context.
+     * @param {Object} instance - Instance of model.
+     * @private
+     * @return {Boolean} Is associated with the current context.
+     */
+    function isDirectlyRelated(instance) {
+      var needToSplit = CurrentPage.isObjectContextPage() &&
+        CurrentPage.getPageType() !== 'Workflow';
+      var relates = CurrentPage.related.attr(instance.type);
+      var result = true;
+      var instanceId = SnapshotUtils.isSnapshot(instance) ?
+        instance.snapshot.id :
+        instance.id;
+
+      if (needToSplit) {
+        result = !!(relates && relates[instanceId]);
+      }
+
+      return result;
     }
 
     /**
@@ -602,28 +624,6 @@
       return instance;
     }
 
-    /**
-     * Check if object directly mapped to the current context.
-     * @param {Object} instance - Instance of model.
-     * @private
-     * @return {Boolean} Is associated with the current context.
-     */
-    function _isDirectlyRelated(instance) {
-      var needToSplit = CurrentPage.isObjectContextPage() &&
-        CurrentPage.getPageType() !== 'Workflow';
-      var relates = CurrentPage.related.attr(instance.type);
-      var result = true;
-      var instanceId = SnapshotUtils.isSnapshot(instance) ?
-        instance.snapshot.id :
-        instance.id;
-
-      if (needToSplit) {
-        result = !!(relates && relates[instanceId]);
-      }
-
-      return result;
-    }
-
     function _getTreeViewOperation(objectName) {
       var isDashboard = /dashboard/.test(window.location);
       var operation;
@@ -643,7 +643,8 @@
       loadFirstTierItems: loadFirstTierItems,
       loadItemsForSubTier: loadItemsForSubTier,
       makeRelevantExpression: makeRelevantExpression,
-      createSelectedColumnsMap: createSelectedColumnsMap
+      createSelectedColumnsMap: createSelectedColumnsMap,
+      isDirectlyRelated: isDirectlyRelated
     };
   })();
 })(window.GGRC);

--- a/src/ggrc/assets/mustache/base_objects/unmap.mustache
+++ b/src/ggrc/assets/mustache/base_objects/unmap.mustache
@@ -6,17 +6,19 @@
 {{#if options.allow_mapping}}
     {{#is_allowed_to_map instance page_instance}}
       {{^is_dashboard_or_all}}
-        <li class="border">
-            <unmap-button {source}="parentInstance"
-            {{#if instance.snapshot}}
-              {destination}="instance.snapshot"
-            {{else}}
-              {destination}="instance"
-            {{/if}}
-            class="unmap-link">
-                <i class="fa fa-ban"></i>Unmap
-            </unmap-button>
-        </li>
+        {{#options.isDirectlyRelated}}
+          <li class="border">
+              <unmap-button {source}="parentInstance"
+              {{#if instance.snapshot}}
+                {destination}="instance.snapshot"
+              {{else}}
+                {destination}="instance"
+              {{/if}}
+              class="unmap-link">
+                  <i class="fa fa-ban"></i>Unmap
+              </unmap-button>
+          </li>
+        {{/options.directlyRelated}}
       {{/is_dashboard_or_all}}
     {{/is_allowed_to_map}}
 {{/if}}


### PR DESCRIPTION
Remove Unmap action from 2d level - on objects which are not related directly to current object (gray ones) on Info pin window.