### PR TITLE
GGRC-3093 Assessment Improvements: Create one single unified batch request for Documents related to Assessment	

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.js
+++ b/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.js
@@ -73,31 +73,28 @@
         },
         urls: {
           get: function () {
-            var self = this;
+            var type = this.attr('documentTypes.urls');
             return this.attr('documents')
               .filter(function (document) {
-                return document.attr('document_type') ===
-                  self.attr('documentTypes.urls');
+                return document.attr('document_type') === type;
               });
           }
         },
         referenceUrls: {
           get: function () {
-            var self = this;
+            var type = this.attr('documentTypes.referenceUrls');
             return this.attr('documents')
               .filter(function (document) {
-                return document.attr('document_type') ===
-                  self.attr('documentTypes.referenceUrls');
+                return document.attr('document_type') === type;
               });
           }
         },
         evidences: {
           get: function () {
-            var self = this;
+            var type = this.attr('documentTypes.evidences');
             return this.attr('documents')
               .filter(function (document) {
-                return document.attr('document_type') ===
-                  self.attr('documentTypes.evidences');
+                return document.attr('document_type') === type;
               });
           }
         },

--- a/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.js
+++ b/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.js
@@ -364,7 +364,7 @@
         this.viewModel.updateRelatedItems();
       },
       '{viewModel.instance} resolvePendingBindings': function () {
-        this.viewModel.loadDocuments(['referenceUrls']);
+        this.viewModel.updateItems('referenceUrls');
       }
     },
     helpers: {

--- a/src/ggrc/assets/mustache/components/assessment/info-pane/info-pane.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/info-pane/info-pane.mustache
@@ -396,7 +396,7 @@
                                         {{#toggle show_new_object_form}}
                                             <ggrc-quick-add
                                                     (before-create)="addItems(%event, 'referenceUrls')"
-                                                    (after-create)="updateItems('referenceUrls')"
+                                                    (after-create)="afterCreate(%event, 'referenceUrls')"
                                                     {parent_instance}="instance"
                                                     join_model="Relationship"
                                                     quick_create="create_url"


### PR DESCRIPTION
Create one single unified batch request for Documents related to Assessment	

On the assessment info pane we request urls, evidences and reference urls using 3 separate sub-queries.
```
[
{object_name: “Document”, filters: {expression: {left: “document_type”, op: {name: “=“}, right: “EVIDENCE”}},
{object_name: “Document”, filters: {expression: {left: “document_type”, op: {name: “=“}, right: “URL”}},
{object_name: “Document”, filters: {expression: {left: “document_type”, op: {name: “=“}, right: “REFERENCE_URL”}}
]
```

In this ticket we have to request all documents in a single query
```
[{object_name: “Document”}]
```
and group results by document_type on FE side.