### PR TITLE
GGRC-2500 Impossible to remove date from CA field with date type

### DIFF
--- a/src/ggrc/assets/javascripts/components/datepicker/datepicker.js
+++ b/src/ggrc/assets/javascripts/components/datepicker/datepicker.js
@@ -54,6 +54,12 @@
           this.attr('showTop', true);
         }
       },
+      removeValue: function (event) {
+        event.preventDefault();
+
+        this.picker.datepicker('setDate', null);
+        this.attr('date', null);
+      },
 
       // Date formats for the actual selected value, and for the date as
       // displayed to the user. The Moment.js library and the jQuery datepicker

--- a/src/ggrc/assets/mustache/components/auto-save-form/fields/person-form-field.mustache
+++ b/src/ggrc/assets/mustache/components/auto-save-form/fields/person-form-field.mustache
@@ -6,8 +6,8 @@
 <div class="input-wrapper">
   {{#if _value}}
     <div class="person-info-wrapper">
-      <a href="#" ($click)="unsetPerson">
-        <i class="fa fa-fw fa-times" aria-hidden="true"></i>
+      <a class="person-info-wrapper__remove-value" href="#" ($click)="unsetPerson">
+        <i class="fa fa-times" aria-hidden="true"></i>
       </a>
       <person-list-item {person-id}="_value" {with-Details}="withDetails"></person-list-item>
     </div>

--- a/src/ggrc/assets/mustache/components/datepicker/datepicker.mustache
+++ b/src/ggrc/assets/mustache/components/datepicker/datepicker.mustache
@@ -25,6 +25,11 @@
       {(value)}="_date"
       can-focus="onFocus"
     >
+    {{#if date}}
+    <a class="datepicker__remove-value" ($click)="removeValue(%event)">
+      <i class="fa fa-times"></i>
+    </a>
+    {{/if}}
     <div
       class="datepicker__calendar {{#showTop}}datepicker__calendar--top{{/showTop}}
       {{#isHidden}}hide{{/isHidden}}"

--- a/src/ggrc/assets/stylesheets/components/auto-save-form/fields/_date-form-field.scss
+++ b/src/ggrc/assets/stylesheets/components/auto-save-form/fields/_date-form-field.scss
@@ -30,10 +30,14 @@ date-form-field {
           }
         }
 
-        i {
+        .fa-calendar {
           font-size: 14px;
           top: 6px;
           left: 7px;
+        }
+
+        .datepicker__remove-value {
+          top: 6px;
         }
       }
     }

--- a/src/ggrc/assets/stylesheets/components/auto-save-form/fields/_person-form-field.scss
+++ b/src/ggrc/assets/stylesheets/components/auto-save-form/fields/_person-form-field.scss
@@ -18,9 +18,12 @@ person-form-field {
       border-radius: 2px;
       padding: 4px;
       box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+      position: relative;
 
-      a {
-        flex: 0 1;
+      &__remove-value {
+        position: absolute;
+        top: 1px;
+        right: 5px;
 
         i {
           color: $icon-color-dark;

--- a/src/ggrc/assets/stylesheets/modules/_datepicker.scss
+++ b/src/ggrc/assets/stylesheets/modules/_datepicker.scss
@@ -31,6 +31,19 @@
 
 .datepicker__input-wrapper {
   position: relative;
+  .datepicker__remove-value {
+    cursor: pointer;
+    position: absolute;
+    top: 4px;
+    right: 5px;
+    i {
+      font-size: 16px;
+      color: $icon-color-dark;
+      &:hover {
+        color: $black;
+      }
+    }
+  }
 }
 
 .ui-datepicker-inline {


### PR DESCRIPTION
Steps to reproduce:
1. Have GCA/LCA with date type for assessment
2. Navigate to assessment's Info pane> CA with date type
3. Select date from date picker and save 
4. Try to remove date from CA with date type: there is no possibility to remove date
*Actual Result:* Impossible to remove date from CA field with date type
*Expected Result*: Should be a possibility to remove date from CA field with date type