### PR TITLE
GGRC-3098: Update styles for 'Prev/Next' buttons on Assessment Info pane

### DIFF
--- a/src/ggrc/assets/mustache/components/prev-next-buttons/prev-next-buttons.mustache
+++ b/src/ggrc/assets/mustache/components/prev-next-buttons/prev-next-buttons.mustache
@@ -5,12 +5,14 @@
 
 <div class="navigation-wrap">
     <div class="navigation-item">
-        <a can-click="setPrev()" class="{{#unless hasPrev}}disabled{{/unless}}">
+        <a ($click)="setPrev()" rel="tooltip" title="Open previous Assessment"
+           class="{{#unless hasPrev}}disabled{{/unless}}">
             <i class="fa fa-angle-left"></i>
         </a>
     </div>
     <div class="navigation-item">
-        <a ($click)="setNext()" class="{{#unless hasNext}}disabled{{/unless}}">
+        <a ($click)="setNext()" rel="tooltip" title="Open next Assessment"
+           class="{{#unless hasNext}}disabled{{/unless}}">
             <i class="fa fa-angle-right"></i>
         </a>
     </div>

--- a/src/ggrc/assets/stylesheets/modules/_object-header.scss
+++ b/src/ggrc/assets/stylesheets/modules/_object-header.scss
@@ -209,6 +209,16 @@
       &.disabled {
         cursor: default;
         opacity: 0.7;
+
+        i {
+          color: $grayLight;
+        }
+      }
+    }
+
+    & + .navigation-item {
+      > a {
+        border-left: none;
       }
     }
   }


### PR DESCRIPTION
1. Add tooltips "Open next Assessment", "Open previous Assessment".
2. Reduce border between 'next'/'previous' controls to single line.
3. Update disabled state for 'Prev/Next' buttons.
![_thumb_14329](https://user-images.githubusercontent.com/24203972/29517470-fea579e0-867d-11e7-89cb-65d61c7afacf.png)
![_thumb_14331](https://user-images.githubusercontent.com/24203972/29517483-0a10479c-867e-11e7-929e-279e9f0dd73d.png)
