### PR TITLE
GGRC-3102 HTTP500 Returned on POST with some utf-8 symbols.

### DIFF
--- a/src/requirements-dev.txt
+++ b/src/requirements-dev.txt
@@ -35,7 +35,6 @@ requests==2.8.1
 selenium==2.47.3
 sniffer==0.3.5
 webob==1.4.1
-Werkzeug==0.11
 wsgiref==0.1.2
 Mako==1.0.4
 Sphinx==1.4.6

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -30,7 +30,7 @@ six==1.10.0
 SQLAlchemy==0.9.8
 tabulate==0.7.5
 webassets==0.8
-Werkzeug==0.9.3
+Werkzeug==0.12.2
 colorlog==2.7.0
 cached-property==1.3.0
 setuptools==3.3


### PR DESCRIPTION
The error was caught while trying to create a new CA from the GGRC-2170 ticket.
Werkzeug returns an error when the title of the CA is "АС\ЫЦУМПА"