### PR TITLE
GGRC-2170 HTTP500 returned when you filter by GCA field that contains non-ASCII characters through Filter

### DIFF
--- a/src/ggrc/query/autocast.py
+++ b/src/ggrc/query/autocast.py
@@ -71,9 +71,10 @@ def get_parsers(klass, key):
       return (fulltext_parser, None)
     else:
       return (None, fulltext_parser)
-  try:
-    attr_type = getattr(klass, key).property.columns[0].type
-  except AttributeError:
+  columns = {i.name: i.type for i in klass.__table__.columns}
+  if key in columns:
+    attr_type = columns[key]
+  else:
     value_types = [i[0] for i in db.session.query(
         CustomAttributeDefinition.attribute_type
     ).filter(

--- a/test/integration/ggrc/services/test_query/test_basic.py
+++ b/test/integration/ggrc/services/test_query/test_basic.py
@@ -1301,11 +1301,14 @@ class TestQueryWithCA(TestCase, WithQueryApi):
     self.assertEqual(response.json['message'], "Invalid filter data")
 
 
+@ddt.ddt
 class TestQueryWithUnicode(TestCase, WithQueryApi):
   """Test query API with unicode values."""
 
   CAD_TITLE1 = u"CA список" + "X" * 200
   CAD_TITLE2 = u"CA текст" + "X" * 200
+  # pylint: disable=anomalous-backslash-in-string
+  CAD_TITLE3 = u"АС\ЫЦУМПА"  # definitely did not work
 
   @classmethod
   def setUpClass(cls):
@@ -1327,6 +1330,10 @@ class TestQueryWithUnicode(TestCase, WithQueryApi):
           title=cls.CAD_TITLE2,
           definition_type="program",
       )
+      factories.CustomAttributeDefinitionFactory(
+          title=cls.CAD_TITLE3,
+          definition_type="program",
+      )
 
   @staticmethod
   def _flatten_cav(data):
@@ -1340,17 +1347,20 @@ class TestQueryWithUnicode(TestCase, WithQueryApi):
   def setUp(self):
     self.client.get("/login")
 
-  def test_query(self):
+  @ddt.data(
+      ("title", u"программа A"),
+      (CAD_TITLE3, u"Ы текст")
+  )
+  @ddt.unpack
+  def test_query(self, title, text):
     """Test query by unicode value."""
-    title = u"программа A"
     programs = self._get_first_result_set(
-        self._make_query_dict("Program", expression=["title", "=", title]),
+        self._make_query_dict("Program", expression=[title, "=", text]),
         "Program",
     )
 
     self.assertEqual(programs["count"], 1)
     self.assertEqual(len(programs["values"]), programs["count"])
-    self.assertEqual(programs["values"][0]["title"], title)
 
   def test_sorting_by_ca(self):
     """Test sorting by CA fields with unicode names."""

--- a/test/integration/ggrc/test_csvs/querying_with_unicode.csv
+++ b/test/integration/ggrc/test_csvs/querying_with_unicode.csv
@@ -1,55 +1,55 @@
 Object type,,,,,,,,,,,,,,
-program,code*,title*,description ,Manager,state,primary contact,effective date,last deprecated date,notes,reference url,editor,CA текстXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX,CA списокXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+program,code*,title*,description ,Manager,state,primary contact,effective date,last deprecated date,notes,reference url,editor,АС\ЫЦУМПА,CA текстXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX,CA списокXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 ,prog-1,программа F,2,"anze@example.com
 albert@example.com
 tommy@example.com",Draft,anze@example.com,1/6/2016,1/19/2016,3,http://google.com/_1,"anze@example.com
 albert@example.com
-tommy@example.com",B текст,один
+tommy@example.com",Ы текст,B текст,один
 ,prog-2,программа G,2,"miha@example.com
 rob@example.com
 ken@example.com",Active,albert@example.com,1/7/2016,1/18/2016,2,http://google.com/_2,"miha@example.com
 rob@example.com
-ken@example.com",B текст,два
+ken@example.com",,B текст,два
 ,prog-3,программа H,2,"user@example.com
 anze@example.com
 miha@example.com",Active,tommy@example.com,1/8/2016,1/17/2016,1,http://google.com/_3,"user@example.com
 anze@example.com
-miha@example.com",A текст,два
+miha@example.com",,A текст,два
 ,prog-4,программа I,3,"anze@example.com
 albert@example.com
 tommy@example.com",Active,miha@example.com,1/9/2016,1/16/2016,2,http://google.com/_4,"anze@example.com
 albert@example.com
-tommy@example.com",A текст,один
+tommy@example.com",,A текст,один
 ,prog-5,программа J,3,"miha@example.com
 rob@example.com
 ken@example.com",Active,anze@example.com,1/10/2016,1/15/2016,1,http://google.com/_5,"miha@example.com
 rob@example.com
-ken@example.com",D текст,три
+ken@example.com",,D текст,три
 ,prog-6,программа A,3,"user@example.com
 anze@example.com
 miha@example.com",Draft,albert@example.com,1/1/2016,1/14/2016,5,http://google.com/_6,"user@example.com
 anze@example.com
-miha@example.com",D текст,четыре
+miha@example.com",,D текст,четыре
 ,prog-7,программа B,1,"anze@example.com
 albert@example.com
 tommy@example.com",Active,tommy@example.com,1/2/2016,1/13/2016,5,http://google.com/_7,"anze@example.com
 albert@example.com
-tommy@example.com",E текст,один
+tommy@example.com",,E текст,один
 ,prog-8,программа C,1,"miha@example.com
 rob@example.com
 ken@example.com",Draft,miha@example.com,1/3/2016,1/12/2016,3,http://google.com/_8,"miha@example.com
 rob@example.com
-ken@example.com",E текст,два
+ken@example.com",,E текст,два
 ,prog-9,программа D,1,"user@example.com
 anze@example.com
 miha@example.com",Deprecated,rob@example.com,1/4/2016,1/11/2016,1,http://google.com/_9,"user@example.com
 anze@example.com
-miha@example.com",A текст,четыре
+miha@example.com",,A текст,четыре
 ,prog-10,программа E,1,"anze@example.com
 albert@example.com
 tommy@example.com",Draft,ken@example.com,1/5/2016,1/10/2016,2,http://google.com/_10,"anze@example.com
 albert@example.com
-tommy@example.com",J текст,пять
+tommy@example.com",,J текст,пять
 ,,,,,,,,,,,,,,
 Object type,,,,,,,,,,,,,,
 Person,Name,Email*,Company,Role,,,,,,,,,,


### PR DESCRIPTION
Steps to reproduce:
1. Create GCA with non-ASCII characters with any type
2. Open existent assessment on the audit page 
3. Fill GCA 
4. Type into Search box GCA title with non-ASCII characters and filter by the value, e.g. "АС\ЫЦУМПА" = siarhei"
5. Look at the screen
Actual Result: ""There was an error" is displayed with 500 error in console.
Expected Result: no error is shown. Filter should work for GCA that contains non-ASCII characters.