### PR TITLE
GGRC-1199 Unified mapper window is duplicated if click twice on Map button 

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment/info-pane/confirm-edit-action.js
+++ b/src/ggrc/assets/javascripts/components/assessment/info-pane/confirm-edit-action.js
@@ -42,6 +42,7 @@
         });
       },
       confirmEdit: function () {
+        document.body.classList.add('no-events');
         if (!this.isInEditableState()) {
           this.showConfirm();
           return;

--- a/src/ggrc/assets/javascripts/components/assessment/map-button-using-assessment-type.js
+++ b/src/ggrc/assets/javascripts/components/assessment/map-button-using-assessment-type.js
@@ -24,6 +24,7 @@
         GGRC.Controllers.ObjectMapper.openMapper(data);
       },
       onClick: function (el, ev) {
+        document.body.classList.add('no-events');
         el.data('type', this.attr('instance.assessment_type'));
         el.data('deferred_to', this.attr('deferredTo'));
         can.trigger(el, 'openMapper', ev);


### PR DESCRIPTION
Steps to reproduce:
1. On the audit page create assessment
2. Click Map button twice in the first tier: confirm Unified Mapper window is duplicated
Actual Result: Unified mapper window is duplicated if click twice on Map button
Expected Result: Unified mapper window should not duplicated if click twice on Map button

The ticket was reopened due to Unified mapper is duplicated if click twice on [+] button to map Controls and Related Information on Assessment's Info pane. Also, Unified mapper is duplicated if click twice [Map objects] in Edit Assessments modal window. Now it fixed.