### PR TITLE
GGRC-2270: Restrict possibility to map already mapped objects to Assessment

### DIFF
--- a/src/ggrc/assets/javascripts/components/object-selection/object-selection.js
+++ b/src/ggrc/assets/javascripts/components/object-selection/object-selection.js
@@ -17,6 +17,7 @@
       items: [],
       // This is an array by default replace with deferred on actual load
       allItems: [],
+      disabledIds: [],
       refreshSelection: null,
       allSelected: false,
       selectAllCheckboxValue: false,
@@ -83,11 +84,16 @@
         this.emptySelection();
       },
       selectAll: function () {
+        var selectedItems;
+        var disabledIds = this.attr('disabledIds');
         this.attr('allSelected', true);
         // Replace with actual items loaded from Query API
         this.attr('allItems')
           .done(function (allItems) {
-            this.attr('selectedItems').replace(allItems);
+            selectedItems = allItems.filter(function (item) {
+              return disabledIds.indexOf(item.id) < 0;
+            });
+            this.attr('selectedItems').replace(selectedItems);
             // Add visual selection
             this.toggleItems(true);
           }.bind(this))

--- a/src/ggrc/assets/javascripts/components/unified-mapper/mapper-results.js
+++ b/src/ggrc/assets/javascripts/components/unified-mapper/mapper-results.js
@@ -55,6 +55,7 @@
       relevantTo: [],
       objectGenerator: false,
       deferredList: [],
+      disabledIds: [],
       init: function () {
         var self = this;
         this.attr('submitCbs').add(this.onSearch.bind(this, true));
@@ -305,6 +306,7 @@
             var relatedData = this.buildRelatedData(
               responseArr[query.relatedQueryIndex],
               modelKey);
+            var disabledIds;
 
             var result =
               data[modelKey].values.map(function (value) {
@@ -316,7 +318,9 @@
               });
             this.setSelectedItems(result);
             if (relatedData) {
-              this.setDisabledItems(result, relatedData[modelKey].ids);
+              disabledIds = relatedData[modelKey].ids;
+              this.attr('disabledIds', disabledIds);
+              this.setDisabledItems(result, disabledIds);
             }
             // Update paging object
             this.paging.attr('total', data[modelKey].total);

--- a/src/ggrc/assets/mustache/components/unified-mapper/mapper-results.mustache
+++ b/src/ggrc/assets/mustache/components/unified-mapper/mapper-results.mustache
@@ -4,7 +4,7 @@
 }}
 
 <object-selection items="items" selected-items="selected" refresh-selection="refreshItems" all-items="allItems"
-                  all-selected="allSelected">
+                  all-selected="allSelected" {disabled-ids}="disabledIds">
   {{#if items.length}}
     <div class="list-header">
       {{^disableColumnsConfiguration}}


### PR DESCRIPTION
Steps to reproduce:
1. Have Control snapshot on the audit page
2. Invoke New Assessments modal window
3. Click Map objects button
4. Once Control snapshot is displayed in Unified mapper Select All and Click Map Selected
5. Look at the mapped snapshot
6. Click Map Objects once again and Select All in Unified mapper: confirm Map selected button in enabled
7. Click Map selected button and look at the mapped snapshots: snapshots are duplicated
Actual Result: Already mapped snapshots to Assessment can be mapped again if click Select all in Unified mapper
Expected Result: Already mapped snapshots to Assessment should not be mapped again if click Select all in Unified mapper
