### PR TITLE
GGRC-2180 Filter applies if click out of Search box 

### DIFF
--- a/src/ggrc/assets/javascripts/components/tree/tree-filter-input.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-filter-input.js
@@ -51,7 +51,7 @@
       }
     },
     submit: function () {
-      this.dispatch('filter');
+      this.dispatch('submit');
     },
     onFilterChange: function (newValue) {
       var filter = GGRC.query_parser.parse(newValue);

--- a/src/ggrc/assets/mustache/components/tree/tree-widget-container.mustache
+++ b/src/ggrc/assets/mustache/components/tree/tree-widget-container.mustache
@@ -8,7 +8,7 @@
     <div class="flex-box tree-filter">
       <tree-filter-input class="flex-size-1"
                          {register-filter}="@registerFilter"
-                         (filter)="onFilter"
+                         (submit)="onFilter"
                          (openAdvanced)="openAdvancedFilter"
                          (removeAdvanced)="removeAdvancedFilters"
                          {show-advanced}="statusFilterVisible"


### PR DESCRIPTION
Steps to reproduce:
1. Go to My work page > Assessments tab
2. Type any filter query into Search box (e.g. "Assignees = user@google.com")
3. Click out of the Search box: filter is applied
Actual Result: Filter applies if click out of Search box 
Expected Result: Filter should be applied if click [Filter] button and [Enter]

*Note:* this causes some unfriendly behavior. If user types any Filter query into Search box and then wants to copy some values from the tree view, user clicks out of the Search box and tree view is refreshed. User needs to click reset and type filter query once again.