### PR TITLE
GGRC-3107 Remove requests on Relationship after open Assessment Generation modal

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment_generator.js
+++ b/src/ggrc/assets/javascripts/components/assessment_generator.js
@@ -102,8 +102,6 @@
         }.bind(this));
       },
       generateModel: function (object, template, type) {
-        var assessmentTemplate = CMS.Models.AssessmentTemplate.findInCacheById(
-          template);
         var title = 'Generated Assessment for ' + this.scope.audit.title;
         var data = {
           _generated: true,
@@ -115,11 +113,17 @@
             href: object.selfLink
           },
           context: this.scope.audit.context,
-          template: assessmentTemplate && assessmentTemplate.stub(),
           title: title,
           assessment_type: type
         };
         data.run_in_background = true;
+
+        if (template) {
+          data.template = {
+            id: Number(template),
+            type: 'AssessmentTemplate'
+          };
+        }
         return new CMS.Models.Assessment(data).save();
       },
       notify: function () {

--- a/src/ggrc/assets/javascripts/components/assessment_templates/assessment_templates.js
+++ b/src/ggrc/assets/javascripts/components/assessment_templates/assessment_templates.js
@@ -3,8 +3,10 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 */
 
-(function (can, $) {
+(function (can, GGRC) {
   'use strict';
+
+  var QueryAPI = GGRC.Utils.QueryAPI;
 
   GGRC.Components('assessmentTemplates', {
     tag: 'assessment-templates',
@@ -13,7 +15,6 @@
       '/components/assessment_templates/assessment_templates.mustache'
     ),
     viewModel: {
-      binding: '@',
       responses: [],
       instance: null,
       assessmentTemplate: null,
@@ -25,14 +26,9 @@
           title: 'No template',
           value: ''
         };
-        _.each(responses, function (response) {
+        _.each(responses, function (instance) {
           var type;
-          var instance;
 
-          if (!response.instance) {
-            return;
-          }
-          instance = response.instance;
           type = instance.template_object_type;
           if (!result[type]) {
             result[type] = {
@@ -92,12 +88,17 @@
     init: function () {
       var viewModel = this.viewModel;
       var instance = viewModel.attr('instance');
-      var binding = instance.get_binding(viewModel.attr('binding'));
+      var param = QueryAPI.buildParam('AssessmentTemplate', {}, {
+        type: instance.type,
+        id: instance.id
+      }, ['id', 'type', 'title', 'template_object_type']);
 
-      binding.refresh_instances().done(function (response) {
-        viewModel.attr('responses', response);
+      QueryAPI.makeRequest({data: [param]}).then(function (response) {
+        var values = response[0].AssessmentTemplate.values;
+
+        viewModel.attr('responses', values);
         viewModel._selectInitialTemplate(viewModel.templates());
       });
     }
   });
-})(window.can, window.can.$);
+})(window.can, window.GGRC);

--- a/src/ggrc/assets/javascripts/models/assessment.js
+++ b/src/ggrc/assets/javascripts/models/assessment.js
@@ -268,11 +268,6 @@
       this._transformBackupProperty(['design', 'operationally', '_disabled']);
       return this._super(checkAssociations);
     },
-    after_save: function () {
-      if (this.audit && this.audit.selfLink) {
-        this.audit.refresh();
-      }
-    },
     form_preload: function (newObjectForm) {
       var pageInstance = GGRC.page_instance();
       var currentUser = CMS.Models.get_instance('Person',

--- a/src/ggrc/assets/mustache/components/object-generator/object-generator.mustache
+++ b/src/ggrc/assets/mustache/components/object-generator/object-generator.mustache
@@ -25,7 +25,6 @@
             <assessment-templates
               instance="parentInstance"
               type="type"
-              binding="related_assessment_templates"
               assessment-template="assessmentTemplate">
             </assessment-templates>
           </div>


### PR DESCRIPTION
Remove redundant requests on Relationships after open Assessment Generation modal and migrate loading Assessment Templates by Query API

Pre-requirements:
1. Open Network tab in Chrome DevTool

Steps for reproduce:
1. Create Program
2. Map to this Program 1000+ objects of different types
3. Create Audit
4. Open Audit page
5. Go to Assessment tab
6. Open Assessment Generation modal by 3bbs button

Actual result: many GET requests on Relationship in network tab
Expected result: Migrate loading Assessment Templates on Query API