### PR TITLE
QUICK-FIX Install watchdog for more efficient change reloading

### DIFF
--- a/src/requirements-dev.txt
+++ b/src/requirements-dev.txt
@@ -34,6 +34,7 @@ PyYAML==3.11
 requests==2.8.1
 selenium==2.47.3
 sniffer==0.3.5
+watchdog==0.8.3
 webob==1.4.1
 Werkzeug==0.11
 wsgiref==0.1.2


### PR DESCRIPTION
Versions 0.10 and later of Werkzeug use watchdog (if available on the
system) for more efficient file change detection. Installing watchdog
causes  werkzeug to use inotify reloader which is much more efficient
than the basic stat reloader. Developers should notice a drop in CPU
utilization, especially if using docker for mac.

Before this PR hyperkit was using 20-40% of the CPU when launch_ggrc was running:
<img width="702" alt="screen shot 2017-08-22 at 09 48 38" src="https://user-images.githubusercontent.com/513444/29557305-8e57db58-8720-11e7-96bd-437a33c1781e.png">

After the change CPU usage dropped to 3%:
<img width="697" alt="screen shot 2017-08-22 at 09 47 42" src="https://user-images.githubusercontent.com/513444/29557310-93117082-8720-11e7-8e0a-6cee8079e497.png">

I believe the change won't be as drastic on Linux machines, but it should still be better.

To verify this PR works look for the reloader text when starting the app:

Before:
```
INFO     2017-08-22 08:49:42,766 werkzeug  * Running on http://0.0.0.0:8080/ (Press CTRL+C to quit)
INFO     2017-08-22 08:49:42,779 werkzeug  * Restarting with stat
```

After
```
INFO     2017-08-22 08:50:45,947 werkzeug  * Running on http://0.0.0.0:8080/ (Press CTRL+C to quit)
INFO     2017-08-22 08:50:46,000 werkzeug  * Restarting with inotify reloader
```

⚠️ This PR requires changes from #6237 because werkzeug 0.9 does not have this feature.


