### PR TITLE
GGRC-2168 "Test plan" is not displayed on Control's Info page/pane after adding

### DIFF
--- a/src/ggrc/assets/mustache/base_objects/test_plan.mustache
+++ b/src/ggrc/assets/mustache/base_objects/test_plan.mustache
@@ -5,7 +5,7 @@
 
 {{#instance}}
   {{#if_helpers '\
-    #if' notes '\
+    #if' test_plan '\
     or #if' isRevision}}
     <div class="row-fluid wrap-row">
       <div class="span12">


### PR DESCRIPTION
Steps to reproduce:
1. Invoke New Control modal window
2. Fill all the fields required and Test plan field > Save
3. Look at Control's Info page: Test plan is not shown
Actual Result: "Test plan" is not displayed on Control's Info page/pane after adding
Expected Result: "Test plan" should be displayed on Control's Info page/pane after adding