### PR TITLE
GGRC-3092 Unify 'datetime' representation on GGRC's UI layer (tree view, info widget, e.t.c.) 

### DIFF
--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -1306,7 +1306,7 @@ function localizeDate(date, options, tmpl, allowNonISO) {
 
 can.each({
   localize_date: 'MM/DD/YYYY',
-  localize_datetime: 'MM/DD/YYYY hh:mm:ss A'
+  localize_datetime: 'MM/DD/YYYY hh:mm:ss A Z'
 }, function (tmpl, fn) {
   Mustache.registerHelper(fn, function (date, allowNonISO, options) {
     // allowNonIso was not passed

--- a/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
+++ b/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
@@ -123,7 +123,7 @@
       if (hideTime === true) {
         return inst.format('MM/DD/YYYY');
       }
-      return inst.tz(currentTimezone).format('MM/DD/YYYY hh:mm:ss A z');
+      return inst.tz(currentTimezone).format('MM/DD/YYYY hh:mm:ss A Z');
     },
     getPickerElement: function (picker) {
       return _.find(_.values(picker), function (val) {

--- a/src/ggrc/assets/js_specs/mustache_helpers/date_spec.js
+++ b/src/ggrc/assets/js_specs/mustache_helpers/date_spec.js
@@ -20,7 +20,7 @@ describe('can.mustache.helper.date', function () {
 
   it('returns datetime when stringy truthy value is passed in', function () {
     var timezone = moment(
-      '2015-05-03T12:34:45Z').tz(moment.tz.guess()).format('z');
+      '2015-05-03T12:34:45Z').tz(moment.tz.guess()).format('Z');
     testDate = new Date(2015, 4, 3, 7, 34, 56);
 
     expect(
@@ -29,7 +29,7 @@ describe('can.mustache.helper.date', function () {
 
   it('returns datetime when stringy falsey value is passed in', function () {
     var timezone = moment(
-      '2015-05-03T12:34:45Z').tz(moment.tz.guess()).format('z');
+      '2015-05-03T12:34:45Z').tz(moment.tz.guess()).format('Z');
     testDate = new Date(2015, 4, 3, 7, 34, 56);
 
     expect(
@@ -38,7 +38,7 @@ describe('can.mustache.helper.date', function () {
 
   it('returns datetime when false value is passed in', function () {
     var timezone = moment(
-      '2015-05-03T12:34:45Z').tz(moment.tz.guess()).format('z');
+      '2015-05-03T12:34:45Z').tz(moment.tz.guess()).format('Z');
     testDate = new Date(2015, 4, 3, 7, 34, 56);
 
     expect(
@@ -47,7 +47,7 @@ describe('can.mustache.helper.date', function () {
 
   it('returns datetime when random values are passed in', function () {
     var timezone = moment(
-      '2015-05-03T12:34:45Z').tz(moment.tz.guess()).format('z');
+      '2015-05-03T12:34:45Z').tz(moment.tz.guess()).format('Z');
     testDate = new Date(2015, 4, 3, 7, 34, 56);
 
     expect(

--- a/src/requirements-selenium.txt
+++ b/src/requirements-selenium.txt
@@ -21,3 +21,4 @@ pytest-cov==2.5.1
 pytest-capturelog==0.7
 pytest-xvfb==1.0.0
 pytest-repeat==0.4.1
+python-dateutil==2.6.1

--- a/test/selenium/src/lib/entities/entity.py
+++ b/test/selenium/src/lib/entities/entity.py
@@ -5,8 +5,10 @@
 # pylint: disable=too-few-public-methods
 
 import copy
-
 from datetime import datetime
+
+from dateutil import parser, tz
+
 from lib.utils import string_utils, help_utils
 
 
@@ -144,7 +146,7 @@ class Representation(object):
                                     attr_value.get("attribute_value")}
           if obj_attr_name == "comments":
             converted_attr_value = {
-                k: (string_utils.convert_str_to_datetime(v) if
+                k: (parser.parse(v).replace(tzinfo=tz.tzutc()) if
                     k == "created_at" and isinstance(v, unicode) else v)
                 for k, v in attr_value.iteritems()
                 if k in ["modified_by", "created_at", "description"]}
@@ -156,10 +158,12 @@ class Representation(object):
             obj_attr_name in ["assessor", "creator", "verifier"] and
             "assignees" in obj.__dict__.keys())
             else getattr(obj, obj_attr_name))
-        # u'2017-06-07T16:50:16' and u'2017-06-07 16:50:16' to datetime
+        # REST like u'08-20-2017T04:30:45' to date=2017-08-20,
+        # timetz=04:30:45+00:00
         if (obj_attr_name in ["updated_at", "created_at"] and
                 isinstance(obj_attr_value, unicode)):
-          obj_attr_value = string_utils.convert_str_to_datetime(obj_attr_value)
+          obj_attr_value = (parser.parse(obj_attr_value).
+                            replace(tzinfo=tz.tzutc()))
         if isinstance(obj_attr_value, dict) and obj_attr_value:
           # to "assignees" = {"Assessor": [], "Creator": [], "Verifier": []}
           if obj_attr_name == "assignees":

--- a/test/selenium/src/lib/utils/filter_utils.py
+++ b/test/selenium/src/lib/utils/filter_utils.py
@@ -1,6 +1,9 @@
 # Copyright (C) 2017 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 """Utils for filter operations."""
+
+from dateutil import parser
+
 import string_utils
 from lib.constants import value_aliases as alias
 from lib.constants.element import AdminWidgetCustomAttributes
@@ -69,7 +72,7 @@ class FilterUtils(object):
       values_to_filter = [person.name, person.email]
     elif ca_type == AdminWidgetCustomAttributes.DATE:
       date_formats = ["%m/%d/%Y", "%m/%Y", "%Y-%m-%d", "%Y-%m", "%Y"]
-      date = string_utils.convert_str_to_datetime(ca_val).date()
+      date = parser.parse(ca_val).date()
       values_to_filter = [date.strftime(_format) for _format in date_formats]
     else:
       values_to_filter = [ca_val]

--- a/test/selenium/src/lib/utils/string_utils.py
+++ b/test/selenium/src/lib/utils/string_utils.py
@@ -7,8 +7,6 @@ import string
 import uuid
 from collections import defaultdict
 
-import re
-from datetime import datetime
 
 BLANK = ''
 COMMA = ','  # comma is used as delimiter for multi-choice values
@@ -175,36 +173,6 @@ def get_first_word_from_str(line):
 def dict_keys_to_upper_case(dictionary):
   """Convert keys of dictionary to upper case."""
   return {k.upper(): v for k, v in dictionary.iteritems()}
-
-
-def convert_str_to_datetime(datetime_str):
-  """Convert datetime corresponding to 'datetime_str', picking appropriate
-  format and parsing according to it and return datetime objects like:
-  '2017-07-02 16:34:05', '2017-07-02 00:00:00', e.t.c.
-  """
-  delimeter = "T" if bool(re.search(r"\dT\d", datetime_str)) else " "
-  datetime_parts = datetime_str.split(delimeter)
-  # UI like u'07/02/2017' as default
-  datetime_format = "%m/%d/%Y"
-  # UI like datetime
-  if "/" in datetime_str and "-" not in datetime_str:
-    # u'07/02/2017 04:34:05 PM UTC'
-    if len(datetime_parts) == 4 and ":" in datetime_str:
-      datetime_format = "%m/%d/%Y %I:%M:%S %p %Z"
-      # u'07/02/2017 04:34:05 PM +03'
-      if datetime_parts[3].upper() != 'UTC':
-        from dateutil import parser
-        return parser.parse(datetime_str)
-  # REST and CSV like datetime
-  if "/" not in datetime_str and any(_ in datetime_str for _ in ["-", ":"]):
-    # u'2017-07-02T16:34:05' and u'2017-07-02 16:34:05'
-    if len(datetime_parts) == 2:
-      datetime_format = ("%Y-%m-%dT%H:%M:%S" if "T" in datetime_str
-                         else "%Y-%m-%d %H:%M:%S")
-    # due to issue GGRC-3130
-    elif len(datetime_parts) == 1:
-      datetime_format = "%Y-%m-%d"
-  return datetime.strptime(datetime_str, datetime_format)
 
 
 def update_dicts_values(dic, old_values_list, new_value):


### PR DESCRIPTION
GGRC app shows datetime attributes of entities in different representation.

Expected: 
GGRC should show datetime attributes of entities in a same (unify) representation:
Format: MM/DD/YYYY hh:mm:ss A Z
e.g. 08/22/2017 03:25:47 PM +03:00