### PR TITLE
GGRC-3116 _notifications/show_daily_digest: Internal Server Error

### DIFF
--- a/src/ggrc/notifications/__init__.py
+++ b/src/ggrc/notifications/__init__.py
@@ -41,7 +41,8 @@ def _get_value(cav, _type):
 
 def get_updated_cavs(new_attrs, old_attrs):
   """Get dict of updated custom attributes of assessment"""
-  cad_list = new_attrs.get("custom_attribute_definitions", [])
+  cad_list = old_attrs.get("custom_attribute_definitions", []) + \
+      new_attrs.get("custom_attribute_definitions", [])
   cad_names = {cad["id"]: cad["display_name"] for cad in cad_list}
   cad_types = {cad["id"]: cad["attribute_type"] for cad in cad_list}
 


### PR DESCRIPTION
The error is caused by qa specific data. Notifications are not sent every day. They are accumulated for a year. There are assessments with corrupted revisions.
However, it would be better to make code more robust in order to process any kind of data without an exception.