### PR TITLE
GGRC-2378 Fix wrong verification state of Dropdown CA

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.js
+++ b/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.js
@@ -326,10 +326,14 @@
         return this.attr('instance').save();
       },
       saveFormFields: function (modifiedFields) {
+        var self = this;
         var caValues = this.attr('instance.custom_attribute_values');
         CAUtils.applyChangesToCustomAttributeValue(caValues, modifiedFields);
 
-        return this.attr('instance').save();
+        return this.attr('instance').save().then(function (data) {
+          self.initializeFormFields();
+          return data;
+        });
       },
       showRequiredInfoModal: function (e, field) {
         var scope = field || e.field;
@@ -370,9 +374,13 @@
       this.viewModel.updateRelatedItems();
     },
     events: {
-      '{viewModel.instance} refreshMapping': function () {
+      '{viewModel.instance} refreshInstance': function () {
+        var self = this;
         this.viewModel.attr('mappedSnapshots')
-          .replace(this.viewModel.loadSnapshots());
+          .replace(this.viewModel.loadSnapshots().then(function (data) {
+            self.viewModel.initializeFormFields();
+            return data;
+          }));
       },
       '{viewModel.instance} modelBeforeSave': function () {
         this.viewModel.attr('isAssessmentSaving', true);

--- a/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.js
+++ b/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.js
@@ -326,14 +326,13 @@
         return this.attr('instance').save();
       },
       saveFormFields: function (modifiedFields) {
-        var self = this;
         var caValues = this.attr('instance.custom_attribute_values');
         CAUtils.applyChangesToCustomAttributeValue(caValues, modifiedFields);
 
         return this.attr('instance').save().then(function (data) {
-          self.initializeFormFields();
+          this.initializeFormFields();
           return data;
-        });
+        }.bind(this));
       },
       showRequiredInfoModal: function (e, field) {
         var scope = field || e.field;
@@ -374,13 +373,12 @@
       this.viewModel.updateRelatedItems();
     },
     events: {
-      '{viewModel.instance} refreshInstance': function () {
-        var self = this;
+      '{viewModel.instance} refreshed': function () {
+        this.viewModel.initializeFormFields();
+      },
+      '{viewModel.instance} refreshMapping': function () {
         this.viewModel.attr('mappedSnapshots')
-          .replace(this.viewModel.loadSnapshots().then(function (data) {
-            self.viewModel.initializeFormFields();
-            return data;
-          }));
+          .replace(this.viewModel.loadSnapshots());
       },
       '{viewModel.instance} modelBeforeSave': function () {
         this.viewModel.attr('isAssessmentSaving', true);

--- a/src/ggrc/assets/javascripts/components/auto-save-form/auto-save-form-field.js
+++ b/src/ggrc/assets/javascripts/components/auto-save-form/auto-save-form-field.js
@@ -18,7 +18,7 @@
         },
         value: {
           get: function () {
-            return this._value;
+            return this._value || null;
           },
           set: function (newValue) {
             if (!this.attr('isDirty')) {
@@ -27,8 +27,8 @@
           }
         }
       },
+      isDirty: false,
       type: null,
-      value: null,
       fieldId: null,
       placeholder: '',
       options: [],

--- a/src/ggrc/assets/javascripts/components/auto-save-form/auto-save-form-field.js
+++ b/src/ggrc/assets/javascripts/components/auto-save-form/auto-save-form-field.js
@@ -15,6 +15,16 @@
       define: {
         disabled: {
           type: 'htmlbool'
+        },
+        value: {
+          get: function () {
+            return this._value;
+          },
+          set: function (newValue) {
+            if (!this.attr('isDirty')) {
+              this._value = newValue;
+            }
+          }
         }
       },
       type: null,

--- a/src/ggrc/assets/javascripts/components/auto-save-form/auto-save-form.js
+++ b/src/ggrc/assets/javascripts/components/auto-save-form/auto-save-form.js
@@ -59,6 +59,10 @@
           }
         },
         notEnoughEvidences: {
+          /**
+           * Checks if there's enough evidences to pass validation
+           * @return {Boolean} has missing evidences
+           */
           get: function () {
             var optionsWithEvidence = this.attr('fields')
                   .filter(function (item) {
@@ -74,8 +78,6 @@
                   }).length;
             return optionsWithEvidence > this.attr('evidenceAmount');
           }
-<<<<<<< HEAD
-=======
         },
         // update only the fields which values are updated
         // this helps canJS to update only those components which need to be
@@ -114,7 +116,6 @@
             });
             this.attr('_fields', fields);
           }
->>>>>>> 57f60d0a7... fixup! 20bc9d1e8
         }
       },
       formSavedDeferred: can.Deferred().resolve(),
@@ -138,7 +139,6 @@
 
       // part of latency compensation. reflects evidence changes
       updateEvidenceValidation: function () {
-        var self = this;
         var notEnoughEvidences = this.attr('notEnoughEvidences');
         this.attr('fields')
           .filter(function (field) {
@@ -160,12 +160,8 @@
               removeFromSet(errors, 'evidence');
             }
             field.attr('preconditions_failed', errors);
-<<<<<<< HEAD
-            self.performValidation(field, field.value);
-=======
-            self.performValidation(field, field.value, true);
->>>>>>> 57f60d0a7... fixup! 20bc9d1e8
-          });
+            this.performValidation(field, field.value, true);
+          }.bind(this));
       },
 
       hasMissingComment: function (field, value) {
@@ -180,7 +176,7 @@
       },
 
       // instantly reflects changes to the document
-      // to compesate for network latency
+      // to compensate for network latency
       networkLatencyCompensation: function (field, value) {
         var valCfg = field.validationConfig;
         var fieldValidationConf = valCfg && valCfg[value];
@@ -208,11 +204,26 @@
         this.updateEvidenceValidation();
       },
 
-      performValidation: function (field, value) {
+      /**
+       * Performs validation of the changed field
+       * @param  {Object}  field                    field or custom attribute object
+       * @param  {Any}     value                    new value
+       * @param  {Boolean} isAllEvidencesValidation is validation called for all
+       *                                            evidence required fields in
+       *                                            a loop
+       */
+      performValidation: function (field, value, isAllEvidencesValidation) {
         var plainFieldObj = field.attr();
 
         var valResult = GGRC.Utils.CustomAttributes
           .validateField(plainFieldObj, value);
+
+        if (!isAllEvidencesValidation && valResult.validation.hasMissingInfo) {
+          this.dispatch({
+            type: 'validationChanged',
+            field: field
+          });
+        }
 
         field.attr(valResult);
       },

--- a/src/ggrc/assets/javascripts/components/auto-save-form/fields/rich-text-form-field.js
+++ b/src/ggrc/assets/javascripts/components/auto-save-form/fields/rich-text-form-field.js
@@ -15,6 +15,7 @@
       _value: '',
       _oldValue: null,
       placeholder: '',
+      isDirty: false,
       define: {
         value: {
           set: function (newValue, setValue) {
@@ -60,7 +61,11 @@
       }
     },
     events: {
+      '.ql-editor focus': function () {
+        this.viewModel.attr('isDirty', true);
+      },
       '.ql-editor blur': function () {
+        this.viewModel.attr('isDirty', false);
         this.viewModel.onBlur();
       }
     }

--- a/src/ggrc/assets/javascripts/components/auto-save-form/fields/text-form-field.js
+++ b/src/ggrc/assets/javascripts/components/auto-save-form/fields/text-form-field.js
@@ -31,6 +31,7 @@
           }
         }
       },
+      isDirty: false,
       fieldId: null,
       placeholder: '',
       valueChanged: function (newValue) {

--- a/src/ggrc/assets/javascripts/components/form/form-validation-icon.js
+++ b/src/ggrc/assets/javascripts/components/form/form-validation-icon.js
@@ -10,7 +10,7 @@
    * State object to present possible icons for validation
    */
   var icons = {
-    noValidation: 'fa-check-circle',
+    noValidation: '',
     empty: 'fa-asterisk form-validation-icon__color-empty',
     valid: 'fa-check form-validation-icon__color-valid',
     invalid: 'fa-times form-validation-icon__color-invalid'
@@ -29,12 +29,9 @@
           get: function () {
             var icon = icons.noValidation;
 
-            if (this.attr('validation.mandatory')) {
-              icon = this.attr('validation.empty') ? icons.empty : icons.valid;
-            }
-            /* This validation is required for DropDowns with required attachments */
-            if (!this.attr('validation.valid')) {
-              icon = icons.invalid;
+            if (this.attr('validation.show')) {
+              icon = this.attr('validation.valid') ?
+                icons.valid : icons.invalid;
             }
             return icon;
           }

--- a/src/ggrc/assets/javascripts/models/assessment.js
+++ b/src/ggrc/assets/javascripts/models/assessment.js
@@ -356,6 +356,7 @@
           })
           .done(function () {
             dfd.resolve.apply(dfd, arguments);
+            that.dispatch('refreshed');
           })
           .fail(function () {
             dfd.reject.apply(dfd, arguments);

--- a/src/ggrc/assets/javascripts/plugins/tests/ca_utils_spec.js
+++ b/src/ggrc/assets/javascripts/plugins/tests/ca_utils_spec.js
@@ -128,4 +128,302 @@ describe('GGRC utils isEmptyCustomAttribute() method', function () {
       expect(result).toBe(false);
     });
   });
+
+  describe('check validateField', function () {
+    var validateField = GGRC.Utils.CustomAttributes.validateField;
+    var CA_DD_REQUIRED_DEPS = GGRC.Utils.CustomAttributes.CA_DD_REQUIRED_DEPS;
+    var inputField;
+    var dropdownField;
+    var checkboxField;
+
+    beforeEach(function () {
+      inputField = {
+        attributeType: 'input',
+        validationConfig: null,
+        preconditions_failed: null,
+        validation: {
+          mandatory: false
+        }
+      };
+
+      dropdownField = {
+        attributeType: 'dropdown',
+        validationConfig: {
+          'nothing required': CA_DD_REQUIRED_DEPS.NONE,
+          'comment required': CA_DD_REQUIRED_DEPS.COMMENT,
+          'evidence required': CA_DD_REQUIRED_DEPS.EVIDENCE,
+          'com+ev required': CA_DD_REQUIRED_DEPS.COMMENT_AND_EVIDENCE
+        },
+        preconditions_failed: [],
+        validation: {
+          mandatory: false
+        }
+      };
+
+      checkboxField = {
+        attributeType: 'checkbox',
+        validationConfig: null,
+        preconditions_failed: null,
+        validation: {
+          mandatory: false
+        }
+      };
+    });
+
+    it('should validate non-mandatory checkbox', function () {
+      expect(validateField(checkboxField, null)).toEqual({
+        validation: {
+          show: false,
+          valid: true,
+          hasMissingInfo: false
+        }
+      });
+
+      expect(validateField(checkboxField, '1')).toEqual({
+        validation: {
+          show: false,
+          valid: true,
+          hasMissingInfo: false
+        }
+      });
+    });
+
+    it('should validate mandatory checkbox', function () {
+      checkboxField.validation.mandatory = true;
+      expect(validateField(checkboxField, null)).toEqual({
+        validation: {
+          show: true,
+          valid: false,
+          hasMissingInfo: false
+        }
+      });
+      expect(validateField(checkboxField, 0)).toEqual({
+        validation: {
+          show: true,
+          valid: false,
+          hasMissingInfo: false
+        }
+      });
+      expect(validateField(checkboxField, 1)).toEqual({
+        validation: {
+          show: true,
+          valid: true,
+          hasMissingInfo: false
+        }
+      });
+
+      expect(validateField(checkboxField, '1')).toEqual({
+        validation: {
+          show: true,
+          valid: true,
+          hasMissingInfo: false
+        }
+      });
+    });
+
+    it('should validate non-mandatory input', function () {
+      expect(validateField(inputField, '')).toEqual({
+        validation: {
+          show: false,
+          valid: true,
+          hasMissingInfo: false
+        }
+      });
+
+      expect(validateField(inputField, 'some input')).toEqual({
+        validation: {
+          show: false,
+          valid: true,
+          hasMissingInfo: false
+        }
+      });
+    });
+
+    it('should validate mandatory input', function () {
+      inputField.validation.mandatory = true;
+
+      expect(validateField(inputField, '')).toEqual({
+        validation: {
+          show: true,
+          valid: false,
+          hasMissingInfo: false
+        }
+      });
+
+      expect(validateField(inputField, 'some input')).toEqual({
+        validation: {
+          show: true,
+          valid: true,
+          hasMissingInfo: false
+        }
+      });
+    });
+
+    it('should validate dropdown with not selected value', function () {
+      // Nothing selected. i.e. None
+      dropdownField.preconditions_failed = ['value'];
+
+      expect(validateField(dropdownField, '')).toEqual({
+        validation: {
+          show: false,
+          valid: false,
+          hasMissingInfo: false
+        },
+        errorsMap: {
+          comment: false,
+          evidence: false
+        }
+      });
+    });
+
+    it('should validate dropdown with a plain value', function () {
+      expect(validateField(dropdownField, 'nothing required')).toEqual({
+        validation: {
+          show: true,
+          valid: true,
+          hasMissingInfo: false
+        },
+        errorsMap: {
+          comment: false,
+          evidence: false
+        }
+      });
+    });
+
+    it('should validate dropdown with a comment required value and comment ' +
+       'missing', function () {
+      dropdownField.preconditions_failed = ['comment'];
+
+      expect(validateField(dropdownField, 'comment required')).toEqual({
+        validation: {
+          show: true,
+          valid: false,
+          hasMissingInfo: true
+        },
+        errorsMap: {
+          comment: true,
+          evidence: false
+        }
+      });
+    });
+
+    it('should validate dropdown with a comment required value and comment ' +
+       'present', function () {
+      dropdownField.preconditions_failed = [];
+
+      expect(validateField(dropdownField, 'comment required')).toEqual({
+        validation: {
+          show: true,
+          valid: true,
+          hasMissingInfo: false
+        },
+        errorsMap: {
+          comment: false,
+          evidence: false
+        }
+      });
+    });
+
+    it('should validate dropdown with an evidence required value and ' +
+       'evidence missing', function () {
+      dropdownField.preconditions_failed = ['evidence'];
+
+      expect(validateField(dropdownField, 'evidence required')).toEqual({
+        validation: {
+          show: true,
+          valid: false,
+          hasMissingInfo: true
+        },
+        errorsMap: {
+          comment: false,
+          evidence: true
+        }
+      });
+    });
+
+    it('should validate dropdown with an evidence required value and ' +
+       'evidence present', function () {
+      dropdownField.preconditions_failed = [];
+
+      expect(validateField(dropdownField, 'evidence required')).toEqual({
+        validation: {
+          show: true,
+          valid: true,
+          hasMissingInfo: false
+        },
+        errorsMap: {
+          comment: false,
+          evidence: false
+        }
+      });
+    });
+
+    it('should validate dropdown with both evidence and ' +
+       'comment required values with both of them missing', function () {
+      dropdownField.preconditions_failed = ['evidence', 'comment'];
+
+      expect(validateField(dropdownField, 'com+ev required')).toEqual({
+        validation: {
+          show: true,
+          valid: false,
+          hasMissingInfo: true
+        },
+        errorsMap: {
+          comment: true,
+          evidence: true
+        }
+      });
+    });
+
+    it('should validate dropdown with both evidence and ' +
+       'comment required values with evidence missing', function () {
+      dropdownField.preconditions_failed = ['evidence'];
+
+      expect(validateField(dropdownField, 'com+ev required')).toEqual({
+        validation: {
+          show: true,
+          valid: false,
+          hasMissingInfo: true
+        },
+        errorsMap: {
+          comment: false,
+          evidence: true
+        }
+      });
+    });
+
+    it('should validate dropdown with both evidence and ' +
+       'comment required values with comment missing', function () {
+      dropdownField.preconditions_failed = ['comment'];
+
+      expect(validateField(dropdownField, 'com+ev required')).toEqual({
+        validation: {
+          show: true,
+          valid: false,
+          hasMissingInfo: true
+        },
+        errorsMap: {
+          comment: true,
+          evidence: false
+        }
+      });
+    });
+
+    it('should validate dropdown with both evidence and ' +
+       'comment required values with both of present', function () {
+      dropdownField.preconditions_failed = [];
+
+      expect(validateField(dropdownField, 'com+ev required')).toEqual({
+        validation: {
+          show: true,
+          valid: true,
+          hasMissingInfo: false
+        },
+        errorsMap: {
+          comment: false,
+          evidence: false
+        }
+      });
+    });
+  });
 });

--- a/src/ggrc/assets/javascripts/plugins/utils/ca-utils.js
+++ b/src/ggrc/assets/javascripts/plugins/utils/ca-utils.js
@@ -16,12 +16,12 @@
     Dropdown: 'dropdown'
   };
 
-  var CA_DD_REQUIRED_DEPS = {
+  var CA_DD_REQUIRED_DEPS = Object.freeze({
     NONE: 0,
     COMMENT: 1,
     EVIDENCE: 2,
     COMMENT_AND_EVIDENCE: 3
-  };
+  });
 
   /**
    * Util methods for custom attributes.
@@ -211,10 +211,10 @@
         valObj = findValueByDefinitionId(values, id);
 
         if (type === 'dropdown') {
-          base.validationConfig = options.reduce(function (conf, item, idx) {
-            conf[item] = Number(optionsRequirements[idx]);
-            return conf;
-          }, {});
+          base.validationConfig = {};
+          options.forEach(function (item, idx) {
+            base.validationConfig[item] = Number(optionsRequirements[idx]);
+          });
         }
 
         if (valObj) {

--- a/src/ggrc/assets/javascripts/plugins/utils/ca-utils.js
+++ b/src/ggrc/assets/javascripts/plugins/utils/ca-utils.js
@@ -1,4 +1,4 @@
-/*!
+/* !
  Copyright (C) 2017 Google Inc.
  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  */
@@ -15,6 +15,14 @@
     Checkbox: 'checkbox',
     Dropdown: 'dropdown'
   };
+
+  var CA_DD_REQUIRED_DEPS = {
+    NONE: 0,
+    COMMENT: 1,
+    EVIDENCE: 2,
+    COMMENT_AND_EVIDENCE: 3
+  };
+
   /**
    * Util methods for custom attributes.
    */
@@ -93,6 +101,79 @@
       return value;
     }
 
+    function validateField(field, value) {
+      var fieldValid;
+      var hasMissingEvidence;
+      var hasMissingComment;
+      var hasMissingValue;
+      var requiresEvidence;
+      var requiresComment;
+      var valCfg = field.validationConfig;
+      var fieldValidationConf = valCfg && valCfg[value];
+      var isMandatory = field.validation.mandatory;
+      var errors = field.preconditions_failed || [];
+      var type = field.attributeType || field.type;
+
+      hasMissingValue = errors.indexOf('value') > -1;
+
+      if (type === 'checkbox') {
+        if (value === '1') {
+          value = true;
+        } else if (value === '0') {
+          value = false;
+        }
+
+        return {
+          validation: {
+            show: isMandatory,
+            valid: isMandatory ? !hasMissingValue && !!(value) : true,
+            hasMissingInfo: false
+          }
+        };
+      } else if (type !== 'dropdown') {
+        return {
+          validation: {
+            show: isMandatory,
+            valid: isMandatory ? !hasMissingValue && !!(value) : true,
+            hasMissingInfo: false
+          }
+        };
+      }
+
+      requiresEvidence =
+        fieldValidationConf === CA_DD_REQUIRED_DEPS.EVIDENCE ||
+        fieldValidationConf === CA_DD_REQUIRED_DEPS.COMMENT_AND_EVIDENCE;
+
+      requiresComment =
+        fieldValidationConf === CA_DD_REQUIRED_DEPS.COMMENT ||
+        fieldValidationConf === CA_DD_REQUIRED_DEPS.COMMENT_AND_EVIDENCE;
+
+      hasMissingEvidence = requiresEvidence && errors.indexOf('evidence') > -1;
+      hasMissingComment = requiresComment && errors.indexOf('comment') > -1;
+
+      fieldValid = (value) ?
+        !(hasMissingEvidence || hasMissingComment || hasMissingValue) :
+        !isMandatory && !hasMissingValue;
+
+      return {
+        validation: {
+          show: isMandatory || !!value,
+          valid: fieldValid,
+          hasMissingInfo: (hasMissingEvidence || hasMissingComment)
+        },
+        errorsMap: {
+          evidence: hasMissingEvidence,
+          comment: hasMissingComment
+        }
+      };
+    }
+
+    function findValueByDefinitionId(values, defId) {
+      return values.find(function (v) {
+        return v.custom_attribute_id === defId;
+      });
+    }
+
     /**
      * Custom Attributes specific parsing logic to simplify business logic of Custom Attributes
      * @param {Array} definitions - original list of Custom Attributes Definition
@@ -101,21 +182,23 @@
      */
     function prepareCustomAttributes(definitions, values) {
       return definitions.map(function (def) {
-        var valueData = false;
+        var valObj;
         var id = def.id;
         var options = (def.multi_choice_options || '').split(',');
         var optionsRequirements = (def.multi_choice_mandatory || '').split(',');
         var type = getCustomAttributeType(def.attribute_type);
-        var stub = {
+
+        var base = {
           id: null,
           custom_attribute_id: id,
           attribute_value: null,
           attribute_object: null,
           validation: {
-            empty: true,
+            show: false,
             mandatory: def.mandatory,
             valid: true
           },
+          validationConfig: null,
           def: def,
           attributeType: type,
           preconditions_failed: [],
@@ -125,36 +208,21 @@
           }
         };
 
-        values.forEach(function (value) {
-          var errors = [];
-          if (value.custom_attribute_id === id) {
-            errors = value.preconditions_failed || [];
-            value.def = def;
-            value.attributeType = type;
-            value.validation = {
-              empty: errors.indexOf('value') > -1,
-              mandatory: def.mandatory,
-              valid: errors.indexOf('comment') < 0 &&
-              errors.indexOf('evidence') < 0
-            };
-            value.errorsMap = {
-              comment: errors.indexOf('comment') > -1,
-              evidence: errors.indexOf('evidence') > -1
-            };
-            valueData = value;
-          }
-        });
-
-        valueData = valueData || stub;
+        valObj = findValueByDefinitionId(values, id);
 
         if (type === 'dropdown') {
-          valueData.validationConfig = {};
-          options.forEach(function (item, index) {
-            valueData.validationConfig[item] =
-              Number(optionsRequirements[index]);
-          });
+          base.validationConfig = options.reduce(function (conf, item, idx) {
+            conf[item] = Number(optionsRequirements[idx]);
+            return conf;
+          }, {});
         }
-        return valueData;
+
+        if (valObj) {
+          _.merge(base, valObj);
+          _.merge(base, validateField(base, base.attribute_value));
+        }
+
+        return base;
       });
     }
 
@@ -225,6 +293,7 @@
         helptext: attr.def.helptext,
         validation: attr.validation.attr(),
         validationConfig: attr.validationConfig,
+        preconditions_failed: attr.preconditions_failed,
         errorsMap: attr.errorsMap.attr(),
         valueId: can.compute(function () {
           return attr.attr('id');
@@ -269,7 +338,9 @@
       });
     }
     return {
+      CA_DD_REQUIRED_DEPS: CA_DD_REQUIRED_DEPS,
       convertFromCaValue: convertFromCaValue,
+      validateField: validateField,
       convertToCaValue: convertToCaValue,
       convertValuesToFormFields: convertValuesToFormFields,
       prepareCustomAttributes: prepareCustomAttributes,

--- a/src/ggrc/assets/mustache/components/auto-save-form/auto-save-form-field.mustache
+++ b/src/ggrc/assets/mustache/components/auto-save-form/auto-save-form-field.mustache
@@ -9,6 +9,7 @@
                      {field-id}="id"
                      {placeholder}="placeholder"
                      {disabled}="disabled"
+		     {(is-dirty)}="isDirty"
                      (value-changed)="fieldValueChanged(%event)"
     ></text-form-field>
   {{/case}}
@@ -17,6 +18,7 @@
                           {field-id}="id"
                           {placeholder}="placeholder"
                           {disabled}="disabled"
+			  {(is-dirty)}="isDirty"
                           (value-changed)="fieldValueChanged(%event)"
     ></rich-text-form-field>
   {{/case}}

--- a/src/ggrc/assets/mustache/components/auto-save-form/auto-save-form.mustache
+++ b/src/ggrc/assets/mustache/components/auto-save-form/auto-save-form.mustache
@@ -9,6 +9,9 @@
       <form-validation-icon {validation}="validation"></form-validation-icon>
       <div class="field__title form-field__title">
         <label class="field__title-text {{extraClass type}}" for="form-field-{{id}}">{{title}}</label>
+	{{#if validation.mandatory}}
+	  <i class="fa fa-asterisk field__mandatory"></i>
+	{{/if}}
         {{#if helptext}}
           <i class="fa fa-question-circle field__title-helper-text" rel="tooltip" title="{{helptext}}"></i>
         {{/if}}
@@ -21,7 +24,7 @@
           {placeholder}="placeholder"
           {options}="options"
           (value-changed)="fieldValueChanged(%event, %context)"
-          class="form-field__content {{{extraClass type}}"
+	  class="form-field__content {{extraClass type}}"
         ></auto-save-form-field>
       {{else}}
         <auto-save-form-field-view
@@ -30,11 +33,11 @@
           class="form-field__content {{extraClass type}}"
         ></auto-save-form-field-view>
       {{/if}}
-      {{#unless validation.valid}}
+      {{#if validation.hasMissingInfo}}
         <div class="form-field__validation-hint-placeholder">
             <button class="btn btn-small btn-link btn-link-nopadding" ($click)="showRequiredInfoModal(%event, %context)">Add required info</button>
         </div>
-      {{/unless}}
+      {{/if}}
     </div>
   {{/each}}
 </div>

--- a/src/ggrc/assets/stylesheets/components/auto-save-form/_auto-save-form.scss
+++ b/src/ggrc/assets/stylesheets/components/auto-save-form/_auto-save-form.scss
@@ -98,6 +98,18 @@ auto-save-form {
     box-sizing: border-box;
   }
 
+  &__mandatory {
+    width: 18px;
+    height: 26px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: $icon-color-empty;
+    font-size: 11px;
+    opacity: 1;
+  }
+
+
   &__title-text {
     display: inline-flex;
     margin: 0;


### PR DESCRIPTION
Custom attribute of dropdown type was not correctly displaying
verification icon for certain values.

Some code commits solved the original issue but brought a new one. The non-mandatory dropdown CA was showing the "None" value as invalid and thus required change.