### PR TITLE
GGRC-3122 Disable assessment related objects optimization

### DIFF
--- a/src/ggrc/query/views.py
+++ b/src/ggrc/query/views.py
@@ -14,7 +14,6 @@ from werkzeug.exceptions import BadRequest
 from ggrc.query.exceptions import BadQueryException
 from ggrc.query.default_handler import DefaultHandler
 from ggrc.query.assessments_summary_handler import AssessmentsSummaryHandler
-from ggrc.query.assessment_related_objects import AssessmentRelatedObjects
 from ggrc.login import login_required
 from ggrc.models.inflector import get_model
 from ggrc.services.common import etag
@@ -27,7 +26,6 @@ logger = logging.getLogger()
 
 OPTIMIZED_HANDLERS = [
     AssessmentsSummaryHandler,
-    AssessmentRelatedObjects,
 ]
 
 


### PR DESCRIPTION
The optimization for related objects omits some data that right now
causes some regressions and has to be reverted until it is fixed.