### PR TITLE
GGRC-2960 Assessment pane - show "Saving ..." next to COMPLETE button (improvement)

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment/info-pane-save-status.js
+++ b/src/ggrc/assets/javascripts/components/assessment/info-pane-save-status.js
@@ -9,20 +9,7 @@
   GGRC.Components('infoPaneSaveStatus', {
     tag: 'info-pane-save-status',
     viewModel: {
-      define: {
-        infoPaneSaving: {
-          get: function () {
-            return this.attr('assessmentSaving') ||
-              this.attr('evidencesSaving') ||
-              this.attr('commentsSaving') ||
-              this.attr('urlsSaving');
-          }
-        }
-      },
-      assessmentSaving: false,
-      evidencesSaving: false,
-      urlsSaving: false,
-      commentsSaving: false
+      infoPaneSaving: false
     }
   });
 })(window.can, window.GGRC);

--- a/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.js
+++ b/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.js
@@ -95,11 +95,25 @@
               this.attr('instance.archived');
           }
         },
-        instance: {}
+        instance: {},
+        isInfoPaneSaving: {
+          get: function () {
+            if (this.attr('isUpdatingRelatedItems')) {
+              return false;
+            }
+
+            return this.attr('isUpdatingEvidences') ||
+              this.attr('isUpdatingUrls') ||
+              this.attr('isUpdatingComments') ||
+              this.attr('isUpdatingReferenceUrls') ||
+              this.attr('isAssessmentSaving');
+          }
+        }
       },
       modal: {
         open: false
       },
+      isUpdatingRelatedItems: false,
       isAssessmentSaving: false,
       onStateChangeDfd: {},
       formState: {},
@@ -151,6 +165,10 @@
           })
           .always(function () {
             this.attr('isUpdating' + can.capitalize(type), false);
+
+            if (this.attr('isUpdatingRelatedItems')) {
+              this.attr('isUpdatingRelatedItems', false);
+            }
           }.bind(this));
         return dfd;
       },
@@ -231,6 +249,8 @@
           [];
       },
       updateRelatedItems: function () {
+        this.attr('isUpdatingRelatedItems', true);
+
         this.attr('mappedSnapshots')
           .replace(this.loadSnapshots());
         this.attr('comments')

--- a/src/ggrc/assets/mustache/assessments/header.mustache
+++ b/src/ggrc/assets/mustache/assessments/header.mustache
@@ -153,17 +153,13 @@ Copyright (C) 2017 Google Inc.
                 </object-state-toolbar>
         {{/unless}}
         <div class="form-status {{#if is_info_pin}}pane-header__toolbar-item{{/if}}">
-            <info-pane-save-status
-                {evidences-saving}="isUpdatingEvidences"
-                {urls-saving}="isUpdatingUrls"
-                {comments-saving}="isUpdatingComments"
-                {assessment-saving}="isAssessmentSaving">
-                    <loading-status
-                        class="loading-status"
-                        {is-loading}="infoPaneSaving"
-                        loading-text="Saving..."
-                        show-Spinner="true">
-                    </loading-status>
+            <info-pane-save-status {info-pane-saving}="isInfoPaneSaving">
+                <loading-status
+                    class="loading-status"
+                    {is-loading}="infoPaneSaving"
+                    loading-text="Saving..."
+                    show-Spinner="true">
+                </loading-status>
             </info-pane-save-status>
         </div>
     </div>


### PR DESCRIPTION
Scope:
Show gray label "Saving ..." next to Complete button during the time - when user entered smth - until Complete is activated.
From user:
After selecting from the “is control operating effectively” drop down, it takes a few seconds before COMPLETE button activates.

related to: #6170