### PR TITLE
GGRC-3101 "Empty actions list" Error

### DIFF
--- a/src/ggrc/models/mixins/with_action.py
+++ b/src/ggrc/models/mixins/with_action.py
@@ -101,7 +101,7 @@ class WithAction(object):
         continue
 
       if not self._actions[operation]:
-        raise ValueError('Empty actions list')
+        continue
 
       self._build_relationships_map()
       self._process_operation(operation)

--- a/test/integration/ggrc/models/mixins/test_with_action.py
+++ b/test/integration/ggrc/models/mixins/test_with_action.py
@@ -23,6 +23,13 @@ class TestDocumentWithActionMixin(TestCase, WithQueryApi):
     self.client.get("/login")
     self.api = api_helper.Api()
 
+  def test_empty_list(self):
+    """Test actions with empty lists."""
+    assessment = factories.AssessmentFactory()
+    response = self.api.put(assessment, {"actions": {"add_related": [],
+                                                     "remove_related": []}})
+    self.assert200(response)
+
   def test_add_url(self):
     """Test add url action."""
     assessment = factories.AssessmentFactory()
@@ -91,9 +98,6 @@ class TestDocumentWithActionMixin(TestCase, WithQueryApi):
   def test_wrong_add_action(self):
     """Test wrong add action."""
     assessment = factories.AssessmentFactory()
-    response = self.api.put(assessment, {"actions": {"add_related": []}})
-    self.assert400(response)
-
     response = self.api.put(assessment, {"actions": {"add_related": [{}]}})
     self.assert400(response)
 
@@ -147,9 +151,6 @@ class TestDocumentWithActionMixin(TestCase, WithQueryApi):
     """Test wrong remove action."""
     assessment = factories.AssessmentFactory()
     document_id = factories.DocumentFactory().id
-
-    response = self.api.put(assessment, {"actions": {"remove_related": []}})
-    self.assert400(response)
 
     response = self.api.put(assessment, {"actions": {"remove_related": [{}]}})
     self.assert400(response)


### PR DESCRIPTION
Allow empty lists for operations. The change is requested by FE team. It will improve FE code readability.