### PR TITLE
GGRC-2199 Request to view more than 10 assessments per page 

### DIFF
--- a/src/ggrc/assets/javascripts/components/dropdown/dropdown.js
+++ b/src/ggrc/assets/javascripts/components/dropdown/dropdown.js
@@ -25,6 +25,7 @@
             var isGroupedDropdown = this.attr('isGroupedDropdown');
             var optionsGroups = this.attr('optionsGroups');
             var noneValue = this.attr('noValueLabel') || '--';
+            var simpleList = this.attr('simpleList');
             var none = isGroupedDropdown ?
               [{
                 group: noneValue,
@@ -37,7 +38,7 @@
             var list = [];
             if (!isGroupedDropdown) {
               list = can.map(this.attr('optionsList') || [], function (option) {
-                if (_.isString(option)) {
+                if (_.isString(option) || simpleList) {
                   return {
                     value: option,
                     title: option
@@ -82,6 +83,7 @@
        */
       optionsList: [],
       optionsGroups: {},
+      simpleList: false,
       isDisabled: false
     },
     init: function (element, options) {

--- a/src/ggrc/assets/javascripts/components/tree/templates/tree-widget-container.mustache
+++ b/src/ggrc/assets/javascripts/components/tree/templates/tree-widget-container.mustache
@@ -15,7 +15,8 @@
                          {disabled}="advancedSearch.filter"
       ></tree-filter-input>
       {{#if statusFilterVisible}}
-        <tree-status-filter {model-name}="modelName"
+        <tree-status-filter class="flex-size-1"
+                            {model-name}="modelName"
                             {register-filter}="@registerFilter"
                             (filter)="onFilter"
                             {disabled}="advancedSearch.filter"

--- a/src/ggrc/assets/mustache/components/tree_pagination/tree_pagination.mustache
+++ b/src/ggrc/assets/mustache/components/tree_pagination/tree_pagination.mustache
@@ -1,18 +1,21 @@
 <div class="tree-pagination flex-box">
   <div class="tree-pagination__count">
-    <div class="dropdown">
-      <div class="dropdown-toggle tree-view-pagination__count__title"
-          data-toggle="dropdown">{{getPaginationInfo}}</div>
-      <div class="dropdown-menu">
-        <span>Items per page:</span>
-        <div class="btn-group">
-          {{#paging.pageSizeSelect}}
-            <button can-click="changePageSize" class="btn tree-view-pagination__count__button{{#if_equals paging.pageSize .}} active{{/if_equals}}"
-                      data-size="{{.}}">{{.}}</button>
-          {{/paging.pageSizeSelect}}
-        </div>
-      </div>
+    <div class="tree-view-pagination__count__title">
+      {{getPaginationInfo}}
     </div>
+  </div>
+  <div class="pagination dropdown-container">
+    {{#paging}}
+      <dropdown class="pagination-dropdown"
+                tabindex="18"
+                simple-list="true"
+                options-list="pageSizeSelect" 
+                name="pageSize">
+      </dropdown>
+    {{/paging}}
+  </div>
+  <div class="tree-pagination__count per-page">
+    <div class="tree-view-pagination__count__title">per page</div>
   </div>
   <div class="pagination">
     <div class="pagination-item {{#if_equals paging.current 1}} disabled{{/if_equals}}">

--- a/src/ggrc/assets/stylesheets/_colors.scss
+++ b/src/ggrc/assets/stylesheets/_colors.scss
@@ -8,6 +8,7 @@ $widgetBorder: #ccc;
 $widgetHeader: #ddd;
 $widgetTitle: #111;
 $filterBgnd: #bebebe;
+$paginationGray: #F8F8F8; 
 
 // widget info
 $infoWidgetHeader: #111;

--- a/src/ggrc/assets/stylesheets/components/tree/_tree-view.scss
+++ b/src/ggrc/assets/stylesheets/components/tree/_tree-view.scss
@@ -325,6 +325,14 @@ tree-status-filter {
       cursor: pointer;
     }
   }
+
+  .multiselect-dropdown {
+    div {
+      input.multiselect-dropdown__input {
+        background-color: $paginationGray;
+      }
+    }
+  }
 }
 
 tree-header {

--- a/src/ggrc/assets/stylesheets/components/tree_pagination/_tree_pagination.scss
+++ b/src/ggrc/assets/stylesheets/components/tree_pagination/_tree_pagination.scss
@@ -12,7 +12,6 @@ tree-pagination {
     &__count {
       margin: 0 16px;
       line-height: 28px;
-      cursor: pointer;
 
       button {
         line-height: 28px;
@@ -23,7 +22,7 @@ tree-pagination {
         font-weight: normal;
         text-transform: none;
         font-size: 12px;
-        color: #969696;
+        color: $textGray;
         line-height: 28px;
         text-align: right;
         margin: 0;
@@ -31,24 +30,8 @@ tree-pagination {
       }
     }
 
-    .dropdown-menu {
-      padding: 8px;
-      line-height: 38px;
-      min-width: 140px;
-
-      .btn-group {
-        .btn {
-          color: $black;
-          font-size: 14px;
-          font-weight: normal;
-          border: 1px solid $widgetBorder;
-          background: $white;
-          border-radius: 0;
-          &.active {
-            background: $lightGray;
-          }
-        }
-      }
+    .per-page {
+      margin-left: 10px;
     }
 
     .pagination {
@@ -56,8 +39,19 @@ tree-pagination {
       flex-direction: row;
       margin: 0;
       height: 28px;
-      box-shadow: 0 1px 2px 0 rgba(122, 122, 122, 0.15);
       border-radius: 2px;
+
+      &.dropdown-container {
+        dropdown {
+          &.pagination-dropdown {
+            select {
+              cursor: pointer;
+              background-color: $paginationGray;
+              border-radius: 2px;
+            }
+          }
+        }
+      }
 
       .pagination-item {
         line-height: 26px;

--- a/test/selenium/src/lib/constants/__init__.py
+++ b/test/selenium/src/lib/constants/__init__.py
@@ -18,5 +18,8 @@ from lib.constants import (
   settings,
   messages,
   roles,
-  value_aliases
+  value_aliases,
+  files,
+  objects,
+  counters
 )

--- a/test/selenium/src/lib/constants/counters.py
+++ b/test/selenium/src/lib/constants/counters.py
@@ -1,0 +1,6 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+"""Constants for counters."""
+
+
+PAGINATION_CTRLS_COUNT = 2

--- a/test/selenium/src/lib/constants/element.py
+++ b/test/selenium/src/lib/constants/element.py
@@ -484,3 +484,8 @@ class RelatedIssuesTab(object):
 class UnifiedMapperModal(object):
   """Class that represent ui of Unified Mapper."""
   ATTRIBUTE_TITLE = Common.TITLE
+
+
+class GenericWidget(object):
+  """Elements' labels and properties for Generic Widget."""
+  NO_FILTER_RESULTS = "No results, please check your filter criteria"

--- a/test/selenium/src/lib/constants/locator.py
+++ b/test/selenium/src/lib/constants/locator.py
@@ -997,10 +997,8 @@ class BaseWidgetGeneric(object):
       cls.DROPDOWN_STATES = (
           By.CSS_SELECTOR,
           str(_FILTER_DROPDOWN_ELEMENTS).format(cls._object_name))
-  FILTER_PANE_COUNTER = (
-      By.CSS_SELECTOR,
-      "section.widget:not(.hidden) "
-      ".dropdown-toggle.tree-view-pagination__count__title")
+  PAGINATION_CONTROLLERS = (
+      By.CSS_SELECTOR, "section.widget:not(.hidden) .tree-pagination.flex-box")
 
 
 class WidgetAudits(BaseWidgetGeneric):

--- a/test/selenium/src/lib/constants/locator.py
+++ b/test/selenium/src/lib/constants/locator.py
@@ -999,7 +999,8 @@ class BaseWidgetGeneric(object):
           str(_FILTER_DROPDOWN_ELEMENTS).format(cls._object_name))
   FILTER_PANE_COUNTER = (
       By.CSS_SELECTOR,
-      "section.widget:not(.hidden) .tree-view-pagination__count__title")
+      "section.widget:not(.hidden) "
+      ".dropdown-toggle.tree-view-pagination__count__title")
 
 
 class WidgetAudits(BaseWidgetGeneric):

--- a/test/selenium/src/lib/constants/messages.py
+++ b/test/selenium/src/lib/constants/messages.py
@@ -112,3 +112,5 @@ class ExceptionsMessages(CommonMessages):
   err_csv_format = "CSV file has unexpected structure: {}\n"
   err_comments_count = "Comments's count." + CommonMessages.err_common
   err_server_response = "Server response: (code: {}, message: {})\n"
+  err_pagination_count = "Count of pagination controllers is not {}\n"
+  err_pagination_elements = "Pagination controllers were not found {}\n"


### PR DESCRIPTION
Comment by User:
This is almost trivial, but would it be an easy fix to view 20 assessments per page versus the preset limit of 10? I don't see any ability to modify the # viewable. 
Q - What is the problem / issue?
---- No problem, just a feature request.
Q - What is the expected result / outcome? (ie What should happen?)
---- I'd like to view more than 10 assessments per page.
Q - What is the impact if it is not fixed / implemented?
---- Impact isn't easily quantified.

With Ksenya we decided add some pagination buttons which always will displayed.