### PR TITLE
GGRC-3124 "Uncaught TypeError: Cannot read property 'custom_attribute_id' of undefined"

### DIFF
--- a/src/ggrc/assets/javascripts/plugins/utils/dashboards-utils.js
+++ b/src/ggrc/assets/javascripts/plugins/utils/dashboards-utils.js
@@ -77,13 +77,9 @@
         return [];
       }
 
-      cavs = cavs.map(function (cav) {
-        return cav.reify();
-      });
-
       return cads.reduce(function (result, cad) {
         var caType = cad.attr('attribute_type');
-        var dashboardName = '';
+        var dashboardName;
         var caName;
         var caNameMatches;
         var caValue;


### PR DESCRIPTION
Steps to reproduce:
1. Create a new Assessment.
2. Open it in a new tab.

Actual Result: "Uncaught TypeError: Cannot read property 'custom_attribute_id' of undefined" error occurs
Expected Result: no errors are displayed, the info page is shown.