### PR TITLE
GGRC-2312 Workflow stats on My work page is not correspond to tasks states color

### DIFF
--- a/src/ggrc/assets/stylesheets/_placeholders.scss
+++ b/src/ggrc/assets/stylesheets/_placeholders.scss
@@ -94,19 +94,19 @@
 
 // progress bar placeholder colors
 %bar-finish {
-  background: $lightBlue;
+  background: $status-completed;
 }
 %bar-verify {
-  background: $lightGreen;
+  background: $status-verified;
 }
 %bar-progress {
-  background: $orange;
+  background: $status-inprogress;
 }
 %bar-pending {
-  background: $gray;
+  background: $status-draft;
 }
 %bar-warning {
-  background: $red;
+  background: $status-declined;
 }
 
 // status label placeholder colors

--- a/src/ggrc/assets/stylesheets/modules/_progress.scss
+++ b/src/ggrc/assets/stylesheets/modules/_progress.scss
@@ -10,13 +10,12 @@
   height: 20px;
   margin: 4px 0 0 0;
   .bar {
-    @include box-shadow(none);
     height: 20px;
     float: left;
     margin-right: 0px;
   }
 
-  @each $bar_color in verify, progress, pending, warning {
+  @each $bar_color in finish, verify, progress, pending, warning {
     .bar-#{$bar_color} {
       @extend %bar-#{$bar_color};
     }
@@ -68,6 +67,9 @@ ul.new-tree {
   li {
     margin-right: 30px;
     float: left;
+    &.overdue-text {
+      color: $red;
+    }
     &:last-child {
       margin-right: 0;
     }

--- a/src/ggrc_workflows/assets/javascripts/controllers/dashboard_page.js
+++ b/src/ggrc_workflows/assets/javascripts/controllers/dashboard_page.js
@@ -165,6 +165,8 @@
               var day_in_milli_secs = 24 * 60 * 60 * 1000;
               task_data.days_left_for_first_task = Math.floor(time_interval/day_in_milli_secs);
             }
+            task_data.completed_percentage = workflow.is_verification_needed ?
+              task_data.verified_percentage : task_data.finished_percentage;
 
             //set overdue flag
             task_data.over_due_flag = over_due ? true : false;

--- a/src/ggrc_workflows/assets/mustache/dashboard/info/workflow_progress.mustache
+++ b/src/ggrc_workflows/assets/mustache/dashboard/info/workflow_progress.mustache
@@ -47,9 +47,13 @@
                 {{/if}}
               </div>
               <ul class="item-util">
-                <li>
-                  {{ins.task_data.task_count}} tasks in total / {{ins.task_data.verified_percentage}}% completed
-                </li>
+                {{#if ins.task_data.over_due_flag}}
+                  <li class="overdue-text">
+                    {{ins.task_data.over_due}} of {{ins.task_data.task_count}} tasks are overdue / {{ins.task_data.completed_percentage}}% completed
+                  </li>
+                {{else}}
+                  <li>{{ins.task_data.task_count}} tasks in total / {{ins.task_data.completed_percentage}}% completed</li>
+                {{/if}}
               </ul>
             </div>
           </div>


### PR DESCRIPTION
Steps to reproduce:
1. Create one time WF
2. Create at least 5 tasks including 1 overdue task and Activate WF
3. On Active Cycles tab move tasks to the following states: Assigned, In progress, Finished, Declined, Assigned (overdue task)
4. Go to My Work page and look at the created WF stats

**Actual Result:** Workflow stats on My work page is not correspond to tasks states color
**Expected Result:** Tasks states should be correspond to the following requirements:
Assigned - grey color (#bdbdbd);
In Progress - blue color (#3369e8);
Finished - #405f77;
Declined - red (#d50f25);
Verified - green (#009925).
OVERDUE - red

Visual Design: https://drive.google.com/corp/drive/folders/0B65BmaCGVTRwTGc5S296WjVqY3c