### PR TITLE
GGRC-2182: Split assessment attributes on 1,2,3 columns

### DIFF
--- a/src/ggrc/assets/mustache/components/assessment/custom-attributes.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/custom-attributes.mustache
@@ -3,30 +3,34 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
 {{#each items}}
-    <inline-edit-control class="info-pane__section"
-        (inline-save)="updateGlobalAttribute(%event, %context)"
-        {instance}="instance"
-        {dropdown-options}="options"
-        {dropdown-class}="dropdownClass"
-        dropdown-no-value="true"
-        {edit-mode}="editMode"
-        {is-allow-edit}="isAllowEdit"
-        {is-loading}="isLoading"
-        {value}="value"
-        {type}="type"
-        with-read-more="true">
-              <confirm-edit-action
-                  (set-edit-mode)="setEditModeInline(%event)"
-                  (set-in-progress)="setInProgressState()"
-                  {instance}="instance"
-                  {on-state-change-dfd}="onStateChangeDfd"
-                  {edit-mode}="editMode">
-                    <base-inline-control-title
-                        {edit-mode}="editMode"
-                        {is-edit-icon-denied}="isEditDenied"
-                        (set-edit-mode-inline)="confirmEdit()">
-                      <div class="info-pane__section-title">{{title}}</div>
-                    </base-inline-control-title>
-              </confirm-edit-action>
-    </inline-edit-control>
+    <div class="ggrc-form-item">
+        <div class="{{#is type 'input'}}ggrc-form-item__row{{else}}ggrc-form-item__multiple-row{{/if}}">
+            <inline-edit-control class="inline-edit-control"
+                (inline-save)="updateGlobalAttribute(%event, %context)"
+                {instance}="instance"
+                {dropdown-options}="options"
+                {dropdown-class}="dropdownClass"
+                dropdown-no-value="true"
+                {edit-mode}="editMode"
+                {is-allow-edit}="isAllowEdit"
+                {is-loading}="isLoading"
+                {value}="value"
+                {type}="type"
+                with-read-more="true">
+                      <confirm-edit-action
+                          (set-edit-mode)="setEditModeInline(%event)"
+                          (set-in-progress)="setInProgressState()"
+                          {instance}="instance"
+                          {on-state-change-dfd}="onStateChangeDfd"
+                          {edit-mode}="editMode">
+                            <base-inline-control-title
+                                {edit-mode}="editMode"
+                                {is-edit-icon-denied}="isEditDenied"
+                                (set-edit-mode-inline)="confirmEdit()">
+                              <div class="ggrc-form__title">{{title}}</div>
+                            </base-inline-control-title>
+                      </confirm-edit-action>
+            </inline-edit-control>
+        </div>
+    </div>
 {{/each}}

--- a/src/ggrc/assets/mustache/components/assessment/info-pane/info-pane.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/info-pane/info-pane.mustache
@@ -229,6 +229,7 @@
               <assessment-custom-attributes (on-update-attributes)="saveGlobalAttributes(%event)"
                                                   {items}="globalAttributes"
                                                   {is-edit-denied}="isEditDenied"
+                                            class="ggrc-form ggrc-form-multiple-columns"
               ></assessment-custom-attributes>
             <div class="info-pane__section ggrc-form">
                     <div class="ggrc-form-item">
@@ -246,7 +247,7 @@
                                     {is-edit-icon-denied}="isEditDenied"
                                     {value}="instance.assessment_type"
                                     {instance}="instance">
-                                        <div class="info-pane__section-title">Assessment Type</div>
+                                        <div class="ggrc-form__title">Assessment Type</div>
                                 </assessment-inline-item>
                             </assessment-object-type-dropdown>
                         </div>
@@ -282,7 +283,7 @@
                             {mapped-items}="relatedInformation"
                             title-text="Related Information"></assessment-mapped-related-information>
                 </div>
-                    <div class="ggrc-form assessment-attributes-tab">
+                    <div class="ggrc-form ggrc-form-multiple-columns">
                         <div class="ggrc-form-item">
                             <div class="ggrc-form-item__row">
                                 <assessment-inline-item
@@ -294,7 +295,7 @@
                                     {is-edit-icon-denied}="isEditDenied"
                                     {value}="instance.description"
                                     {instance}="instance">
-                                        <div class="info-pane__section-title">Description</div>
+                                        <div class="ggrc-form__title">Description</div>
                                 </assessment-inline-item>
                             </div>
                         </div>
@@ -312,7 +313,7 @@
                                     {is-edit-icon-denied}="isEditDenied"
                                     {value}="instance.notes"
                                     {instance}="instance">
-                                        <div class="info-pane__section-title">Notes</div>
+                                        <div class="ggrc-form__title">Notes</div>
                                 </assessment-inline-item>
                             </div>
                         </div>
@@ -327,7 +328,7 @@
                                     {is-edit-icon-denied}="isEditDenied"
                                     {value}="instance.slug"
                                     {instance}="instance">
-                                        <div class="info-pane__section-title">Code</div>
+                                        <div class="ggrc-form__title">Code</div>
                                 </assessment-inline-item>
                             </div>
                             <!-- TODO: Assessment object type -->
@@ -346,7 +347,7 @@
                                     {value}="instance.design"
                                     {instance}="instance">
                                         <div>
-                                            <div class="info-pane__section-title">Conclusion: Design</div>
+                                            <div class="ggrc-form__title">Conclusion: Design</div>
                                             <p class="conclusion-small-text">
                                                 <small><em>Is this control design effective?</em></small>
                                             </p>
@@ -366,7 +367,7 @@
                                     {value}="instance.operationally"
                                     {instance}="instance">
                                         <div>
-                                            <div class="info-pane__section-title">Conclusion: Operation</div>
+                                            <div class="ggrc-form__title">Conclusion: Operation</div>
                                             <p class="conclusion-small-text">
                                                 <small><em>Is this control design effective?</em></small>
                                             </p>
@@ -380,7 +381,7 @@
 
                                     <!-- <REFERENCE URLS> -->
                                     <div>
-                                        <div class="info-pane__section-title">
+                                        <div class="ggrc-form__title">
                                             <spinner class="info-pane__section-title-icon"
                                                 {toggle}="isUpdatingReferenceUrls">
                                             </spinner>

--- a/src/ggrc/assets/stylesheets/components/form/_ggrc-form.scss
+++ b/src/ggrc/assets/stylesheets/components/form/_ggrc-form.scss
@@ -5,6 +5,36 @@
 
 .ggrc-form {
 
+  &__title {
+    font-size: 11px;
+    text-transform: uppercase;
+    font-weight: bold;
+    line-height: 28px;
+    margin: 0;
+    padding: 0;
+    position: relative;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  &.ggrc-form-multiple-columns {
+    display: flex;
+    flex-wrap: wrap;
+    max-width: 720px;
+
+    .ggrc-form-item {
+      .ggrc-form-item__multiple-row {
+        flex-basis: 200px;
+        width: 200px;
+        margin-right: 40px;
+      }
+
+      .ggrc-form-item__row {
+        width: 720px;
+      }
+    }
+  }
+
   .additional-fields {
     .hidden-fields-area {
       padding: 0;

--- a/src/ggrc/assets/stylesheets/components/people-group/_people-group.scss
+++ b/src/ggrc/assets/stylesheets/components/people-group/_people-group.scss
@@ -11,9 +11,9 @@
 
   .people-group {
     flex-grow: 1;
-    flex-basis: 250px;
-    max-width: 250px;
-    margin-right: 30px;
+    flex-basis: 200px;
+    max-width: 200px;
+    margin-right: 40px;
 
     input {
       width: 100%;

--- a/src/ggrc/assets/stylesheets/modules/_assessment.scss
+++ b/src/ggrc/assets/stylesheets/modules/_assessment.scss
@@ -117,11 +117,6 @@
     margin-top: -28px;
     position: relative;
 
-    .assessment-attributes-tab {
-      margin-right: 30%;
-      padding-right: 24px;
-    }
-
     .attribute-tab-panel-column {
       display: inline-block;
       width: 32%;

--- a/test/selenium/src/lib/constants/locator.py
+++ b/test/selenium/src/lib/constants/locator.py
@@ -734,8 +734,8 @@ class WidgetInfoAssessment(WidgetInfoPanel):
   # Code section
   _CODE = "assessment-inline-item[prop-name='slug'] "
   CODE_CSS = (By.CSS_SELECTOR, _CODE)
-  CODE_HEADER_CSS = (By.CSS_SELECTOR, _CODE + " .info-pane__section-title")
-  CODE_VALUE_CSS = (By.CSS_SELECTOR, _CODE + " .inline__content-wrapper")
+  CODE_HEADER_CSS = (By.CSS_SELECTOR, _CODE + ".ggrc-form__title")
+  CODE_VALUE_CSS = (By.CSS_SELECTOR, _CODE + ".read-more__body")
   # comments section
   COMMENTS_CSS = (By.CSS_SELECTOR, ".assessment-comments")
   # asmt tab container


### PR DESCRIPTION
Split assessment attributes on 3 columns: 
- 200px for content and 40px for padding,
- 720px for text fields content.

![padding for fields](https://user-images.githubusercontent.com/24203972/29661052-9169da4c-88cb-11e7-8911-f708c55a3f6a.png)

