### PR TITLE
QUICK-FIX Add cron jobs and task queues to deployment script

### DIFF
--- a/bin/do_deploy
+++ b/bin/do_deploy
@@ -51,4 +51,6 @@ write_visible_message 'Authenticating'
 gcloud auth activate-service-account "$ACCOUNT" --key-file="$KEY_FILE"
 
 write_visible_message "Deploying src/app.yaml into version $VERSION"
-gcloud app deploy src/app.yaml --version="$VERSION"
+yes | gcloud app deploy src/cron.yaml
+yes | gcloud app deploy src/queue.yaml
+yes | gcloud app deploy src/app.yaml --version="$VERSION"


### PR DESCRIPTION
We should not rely on previous deployments for task queues and cron jobs
to be running normally and should always make sure to deploy them with
the latest data