### PR TITLE
GGRC-1217 Remove Show objects link in snapshots if there is nothing to open 

### DIFF
--- a/src/ggrc/assets/javascripts/components/tree/sub-tree-wrapper.js
+++ b/src/ggrc/assets/javascripts/components/tree/sub-tree-wrapper.js
@@ -43,7 +43,8 @@
         type: Boolean,
         get: function () {
           return CurrentPage.isObjectContextPage() &&
-            CurrentPage.getPageType() !== 'Workflow';
+            CurrentPage.getPageType() !== 'Workflow' &&
+            this.attr('notDirectlyItems').length;
         }
       },
       notResult: {

--- a/src/ggrc/assets/mustache/components/tree/sub-tree-wrapper.mustache
+++ b/src/ggrc/assets/mustache/components/tree/sub-tree-wrapper.mustache
@@ -32,16 +32,16 @@
         </sub-tree-expander>
       </div>
 
-    {{#if notDirectlyExpanded}}
-    {{#notDirectlyItems}}
-      <sub-tree-item class="tree-item-element"
-                     extra-css="not-directly-related"
-                     {instance}="."
-                     {limit-depth-tree}="limitDepthTree"
-                     {make-result}="@makeResult"
-      ></sub-tree-item>
-    {{/notDirectlyItems}}
-    {{/if}}
+      {{#if notDirectlyExpanded}}
+        {{#notDirectlyItems}}
+          <sub-tree-item class="tree-item-element"
+                        extra-css="not-directly-related"
+                        {instance}="."
+                        {limit-depth-tree}="limitDepthTree"
+                        {make-result}="@makeResult"
+          ></sub-tree-item>
+        {{/notDirectlyItems}}
+      {{/if}}
     {{/if}}
 
     {{#if notResult}}


### PR DESCRIPTION
Precondition:
created program, control, audit
Steps to reproduce:
1. Go to the audit page-> Control's tab
2. Expand sub level in tree view: confirm "Show objects not directly related to this Control" but there is nothing to show
Actual Result: Remove Show objects link in snapshots if there is nothing to open
Expected Result: Show objects link in snapshots should not be shown if there is nothing to open