### PR TITLE
GGRC-2249/3138 Add 'Assessment Procedure' to set of models

### DIFF
--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -332,3 +332,4 @@ dashboard-js-template-files:
   - components/inline/base-inline-control-title.mustache
   - components/assessment/info-pane/inline-item.mustache
   - components/loading/loading-status.mustache
+  - partials/modal-ajax-test-plan.mustache

--- a/src/ggrc/assets/mustache/access_groups/modal_content.mustache
+++ b/src/ggrc/assets/mustache/access_groups/modal_content.mustache
@@ -35,6 +35,8 @@
     </div>
   </div>
 
+  {{> /static/mustache/partials/modal-ajax-test-plan.mustache}}
+
   <div class="row">
     <div class="span12 hide-wrap hidable">
       <access-control-list-roles-helper

--- a/src/ggrc/assets/mustache/base_objects/info.mustache
+++ b/src/ggrc/assets/mustache/base_objects/info.mustache
@@ -19,6 +19,7 @@
         <tab-panel {(panels)}="panels" title-text="{{instance.type}}">
           {{>'/static/mustache/base_objects/object-review.mustache'}}
           {{>'/static/mustache/base_objects/description.mustache'}}
+          {{>'/static/mustache/base_objects/test_plan.mustache'}}
           {{>'/static/mustache/base_objects/notes.mustache'}}
           {{>'/static/mustache/base_objects/contacts.mustache'}}
           {{>'/static/mustache/base_objects/urls.mustache'}}

--- a/src/ggrc/assets/mustache/clauses/modal_content.mustache
+++ b/src/ggrc/assets/mustache/clauses/modal_content.mustache
@@ -37,6 +37,8 @@
     </div>
   </div>
 
+  {{> /static/mustache/partials/modal-ajax-test-plan.mustache}}
+
   <div class="row">
     <div class="span12 hide-wrap hidable">
       <access-control-list-roles-helper

--- a/src/ggrc/assets/mustache/contracts/modal_content.mustache
+++ b/src/ggrc/assets/mustache/contracts/modal_content.mustache
@@ -35,6 +35,8 @@
     </div>
   </div>
 
+  {{> /static/mustache/partials/modal-ajax-test-plan.mustache}}
+
   <div class="row">
     <div class="span12 hide-wrap hidable">
       <access-control-list-roles-helper

--- a/src/ggrc/assets/mustache/data_assets/modal_content.mustache
+++ b/src/ggrc/assets/mustache/data_assets/modal_content.mustache
@@ -35,6 +35,8 @@
     </div>
   </div>
 
+  {{> /static/mustache/partials/modal-ajax-test-plan.mustache}}
+
   <div class="row">
     <div class="span12 hide-wrap hidable">
       <access-control-list-roles-helper

--- a/src/ggrc/assets/mustache/facilities/modal_content.mustache
+++ b/src/ggrc/assets/mustache/facilities/modal_content.mustache
@@ -35,6 +35,8 @@
     </div>
   </div>
 
+  {{> /static/mustache/partials/modal-ajax-test-plan.mustache}}
+
   <div class="row">
     <div class="span12 hide-wrap hidable">
       <access-control-list-roles-helper

--- a/src/ggrc/assets/mustache/markets/modal_content.mustache
+++ b/src/ggrc/assets/mustache/markets/modal_content.mustache
@@ -35,6 +35,8 @@
     </div>
   </div>
 
+  {{> /static/mustache/partials/modal-ajax-test-plan.mustache}}
+
   <div class="row">
     <div class="span12 hide-wrap hidable">
       <access-control-list-roles-helper

--- a/src/ggrc/assets/mustache/objectives/info.mustache
+++ b/src/ggrc/assets/mustache/objectives/info.mustache
@@ -19,6 +19,7 @@
         <tab-panel {(panels)}="panels" title-text="{{instance.type}}">
           {{>'/static/mustache/base_objects/object-review.mustache'}}
           {{>'/static/mustache/base_objects/description.mustache'}}
+          {{>'/static/mustache/base_objects/test_plan.mustache'}}
           {{>'/static/mustache/base_objects/notes.mustache'}}
           {{>'/static/mustache/base_objects/contacts.mustache'}}
           {{>'/static/mustache/base_objects/urls.mustache'}}

--- a/src/ggrc/assets/mustache/objectives/modal_content.mustache
+++ b/src/ggrc/assets/mustache/objectives/modal_content.mustache
@@ -34,6 +34,8 @@
     </div>
   </div>
 
+  {{> /static/mustache/partials/modal-ajax-test-plan.mustache}}
+
   <div class="row">
     <div class="span12 hide-wrap hidable">
       <access-control-list-roles-helper

--- a/src/ggrc/assets/mustache/org_groups/modal_content.mustache
+++ b/src/ggrc/assets/mustache/org_groups/modal_content.mustache
@@ -34,6 +34,8 @@
     </div>
   </div>
 
+  {{> /static/mustache/partials/modal-ajax-test-plan.mustache}}
+
   <div class="row">
     <div class="span12 hide-wrap hidable">
       <access-control-list-roles-helper

--- a/src/ggrc/assets/mustache/partials/modal-ajax-test-plan.mustache
+++ b/src/ggrc/assets/mustache/partials/modal-ajax-test-plan.mustache
@@ -1,0 +1,12 @@
+<div class="row-fluid">
+  <div data-id="test_plan_hidden" class="span6 hidable">
+    <label>
+      Assessment Procedure
+      <i class="fa fa-question-circle" rel="tooltip" title="Provide an assessment procedure for this {{model.model_singular}}."></i>
+      <a data-id="hide_description_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
+    </label>
+    <div class="wysiwyg-area">
+      <textarea id="control_test_plan" class="span12 triple wysihtml5" name="test_plan" placeholder="Enter Assessment Procedure">{{instance.test_plan}}</textarea>
+    </div>
+  </div>
+</div>

--- a/src/ggrc/assets/mustache/policies/info.mustache
+++ b/src/ggrc/assets/mustache/policies/info.mustache
@@ -19,6 +19,7 @@
         <tab-panel {(panels)}="panels" title-text="{{instance.type}}">
           {{>'/static/mustache/base_objects/object-review.mustache'}}
           {{>'/static/mustache/base_objects/description.mustache'}}
+          {{>'/static/mustache/base_objects/test_plan.mustache'}}
           {{>'/static/mustache/base_objects/notes.mustache'}}
           {{>'/static/mustache/base_objects/contacts.mustache'}}
           {{>'/static/mustache/base_objects/urls.mustache'}}

--- a/src/ggrc/assets/mustache/policies/modal_content.mustache
+++ b/src/ggrc/assets/mustache/policies/modal_content.mustache
@@ -36,6 +36,8 @@
     </div>
   </div>
 
+  {{> /static/mustache/partials/modal-ajax-test-plan.mustache}}
+
   <div class="row">
     <div class="span12 hide-wrap hidable">
       <access-control-list-roles-helper

--- a/src/ggrc/assets/mustache/processes/info.mustache
+++ b/src/ggrc/assets/mustache/processes/info.mustache
@@ -19,6 +19,7 @@
         <tab-panel {(panels)}="panels" title-text="{{instance.type}}">
           {{>'/static/mustache/base_objects/object-review.mustache'}}
           {{>'/static/mustache/base_objects/description.mustache'}}
+          {{>'/static/mustache/base_objects/test_plan.mustache'}}
           {{>'/static/mustache/base_objects/notes.mustache'}}
           {{>'/static/mustache/base_objects/contacts.mustache'}}
           {{>'/static/mustache/base_objects/urls.mustache'}}

--- a/src/ggrc/assets/mustache/processes/modal_content.mustache
+++ b/src/ggrc/assets/mustache/processes/modal_content.mustache
@@ -36,6 +36,8 @@
     </div>
   </div>
 
+  {{> /static/mustache/partials/modal-ajax-test-plan.mustache}}
+
   <div class="row">
     <div class="span12 hide-wrap hidable">
       <access-control-list-roles-helper

--- a/src/ggrc/assets/mustache/products/info.mustache
+++ b/src/ggrc/assets/mustache/products/info.mustache
@@ -19,6 +19,7 @@
         <tab-panel {(panels)}="panels" title-text="{{instance.type}}">
           {{>'/static/mustache/base_objects/object-review.mustache'}}
           {{>'/static/mustache/base_objects/description.mustache'}}
+          {{>'/static/mustache/base_objects/test_plan.mustache'}}
           {{>'/static/mustache/base_objects/notes.mustache'}}
           {{>'/static/mustache/base_objects/contacts.mustache'}}
           {{>'/static/mustache/base_objects/urls.mustache'}}

--- a/src/ggrc/assets/mustache/products/modal_content.mustache
+++ b/src/ggrc/assets/mustache/products/modal_content.mustache
@@ -34,6 +34,8 @@
     </div>
   </div>
 
+  {{> /static/mustache/partials/modal-ajax-test-plan.mustache}}
+
   <div class="row">
     <div class="span12 hide-wrap hidable">
       <access-control-list-roles-helper

--- a/src/ggrc/assets/mustache/projects/modal_content.mustache
+++ b/src/ggrc/assets/mustache/projects/modal_content.mustache
@@ -35,6 +35,8 @@
     </div>
   </div>
 
+  {{> /static/mustache/partials/modal-ajax-test-plan.mustache}}
+
   <div class="row">
     <div class="span12 hide-wrap hidable">
       <access-control-list-roles-helper

--- a/src/ggrc/assets/mustache/regulations/modal_content.mustache
+++ b/src/ggrc/assets/mustache/regulations/modal_content.mustache
@@ -35,6 +35,8 @@
     </div>
   </div>
 
+  {{> /static/mustache/partials/modal-ajax-test-plan.mustache}}
+
   <div class="row">
     <div class="span12 hide-wrap hidable">
       <access-control-list-roles-helper

--- a/src/ggrc/assets/mustache/sections/modal_content.mustache
+++ b/src/ggrc/assets/mustache/sections/modal_content.mustache
@@ -50,6 +50,8 @@
     </div>
   </div>
 
+  {{> /static/mustache/partials/modal-ajax-test-plan.mustache}}
+
   <div class="row">
     <div class="span12 hide-wrap hidable">
       <access-control-list-roles-helper

--- a/src/ggrc/assets/mustache/standards/modal_content.mustache
+++ b/src/ggrc/assets/mustache/standards/modal_content.mustache
@@ -35,6 +35,8 @@
     </div>
   </div>
 
+  {{> /static/mustache/partials/modal-ajax-test-plan.mustache}}
+
   <div class="row">
     <div class="span12 hide-wrap hidable">
       <access-control-list-roles-helper

--- a/src/ggrc/assets/mustache/systems/info.mustache
+++ b/src/ggrc/assets/mustache/systems/info.mustache
@@ -19,6 +19,7 @@
         <tab-panel {(panels)}="panels" title-text="{{instance.type}}">
           {{>'/static/mustache/base_objects/object-review.mustache'}}
           {{>'/static/mustache/base_objects/description.mustache'}}
+          {{>'/static/mustache/base_objects/test_plan.mustache'}}
           {{>'/static/mustache/base_objects/notes.mustache'}}
           {{>'/static/mustache/base_objects/contacts.mustache'}}
           {{>'/static/mustache/base_objects/urls.mustache'}}

--- a/src/ggrc/assets/mustache/systems/modal_content.mustache
+++ b/src/ggrc/assets/mustache/systems/modal_content.mustache
@@ -36,6 +36,8 @@
     </div>
   </div>
 
+  {{> /static/mustache/partials/modal-ajax-test-plan.mustache}}
+
   <div class="row">
     <div class="span12 hide-wrap hidable">
       <access-control-list-roles-helper

--- a/src/ggrc/assets/mustache/vendors/modal_content.mustache
+++ b/src/ggrc/assets/mustache/vendors/modal_content.mustache
@@ -34,6 +34,8 @@
     </div>
   </div>
 
+  {{> /static/mustache/partials/modal-ajax-test-plan.mustache}}
+
   <div class="row">
     <div class="span12 hide-wrap hidable">
       <access-control-list-roles-helper

--- a/src/ggrc/migrations/versions/20170823155549_3897847a6c5c_add_test_plan_field.py
+++ b/src/ggrc/migrations/versions/20170823155549_3897847a6c5c_add_test_plan_field.py
@@ -16,7 +16,7 @@ from alembic import op
 from ggrc.migrations.utils.resolve_duplicates import rename_ca_title
 
 revision = '3897847a6c5c'
-down_revision = '5299857cfde0'
+down_revision = '2ad7783c176'
 
 table_models = {
     "directives": "directive",

--- a/src/ggrc/migrations/versions/20170823155549_3897847a6c5c_add_test_plan_field.py
+++ b/src/ggrc/migrations/versions/20170823155549_3897847a6c5c_add_test_plan_field.py
@@ -1,0 +1,51 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Add test_plan field to set of models
+
+Create Date: 2017-08-23 15:55:49.838780
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+import sqlalchemy as sa
+
+from alembic import op
+
+from ggrc.migrations.utils.resolve_duplicates import rename_ca_title
+
+revision = '3897847a6c5c'
+down_revision = '5299857cfde0'
+
+table_models = {
+    "directives": "directive",
+    "sections": "section",
+    "objectives": "objective",
+    "products": "product",
+    "systems": "system",
+    "access_groups": "access_group",
+    "clauses": "clause",
+    "data_assets": "data_asset",
+    "facilities": "facility",
+    "markets": "market",
+    "org_groups": "org_group",
+    "projects": "project",
+    "vendors": "vendor",
+}
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  for table in table_models.keys():
+    op.add_column(
+        table,
+        sa.Column("test_plan", sa.Text, nullable=True),
+    )
+  rename_ca_title("Assessment Procedure", table_models.values())
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  for table in table_models.keys():
+    op.drop_column(table, "test_plan")

--- a/src/ggrc/models/access_group.py
+++ b/src/ggrc/models/access_group.py
@@ -5,7 +5,7 @@ from ggrc import db
 from ggrc.access_control.roleable import Roleable
 from ggrc.models.comment import Commentable
 from ggrc.models.mixins import (BusinessObject, LastDeprecatedTimeboxed,
-                                CustomAttributable)
+                                CustomAttributable, TestPlanned)
 from ggrc.models.object_document import PublicDocumentable
 from ggrc.models.object_person import Personable
 from ggrc.models.relationship import Relatable
@@ -14,7 +14,7 @@ from ggrc.fulltext.mixin import Indexed
 
 
 class AccessGroup(Roleable, HasObjectState, PublicDocumentable, Commentable,
-                  CustomAttributable, Personable, Relatable,
+                  CustomAttributable, Personable, Relatable, TestPlanned,
                   LastDeprecatedTimeboxed, BusinessObject, Indexed, db.Model):
   __tablename__ = 'access_groups'
 

--- a/src/ggrc/models/clause.py
+++ b/src/ggrc/models/clause.py
@@ -6,8 +6,8 @@ from sqlalchemy import orm
 
 from ggrc import db
 from ggrc.access_control.roleable import Roleable
+from ggrc.models.mixins import CustomAttributable, TestPlanned
 from ggrc.models.comment import Commentable
-from ggrc.models.mixins import CustomAttributable
 from ggrc.models.deferred import deferred
 from ggrc.models.mixins import Hierarchical
 from ggrc.models.mixins import LastDeprecatedTimeboxed
@@ -22,7 +22,8 @@ from ggrc.models import reflection
 
 class Clause(Roleable, HasObjectState, Hierarchical, CustomAttributable,
              Personable, LastDeprecatedTimeboxed, Relatable, Commentable,
-             PublicDocumentable, BusinessObject, Indexed, db.Model):
+             PublicDocumentable, TestPlanned, BusinessObject, Indexed,
+             db.Model):
 
   __tablename__ = 'clauses'
   _table_plural = 'clauses'

--- a/src/ggrc/models/data_asset.py
+++ b/src/ggrc/models/data_asset.py
@@ -6,7 +6,7 @@ from ggrc.access_control.roleable import Roleable
 from ggrc.fulltext.mixin import Indexed
 from ggrc.models.comment import Commentable
 from .mixins import (BusinessObject, LastDeprecatedTimeboxed,
-                     CustomAttributable)
+                     CustomAttributable, TestPlanned)
 from .object_document import PublicDocumentable
 from .object_person import Personable
 from .relationship import Relatable
@@ -15,7 +15,7 @@ from .track_object_state import HasObjectState
 
 class DataAsset(Roleable, HasObjectState, PublicDocumentable,
                 CustomAttributable, Personable, Relatable, Commentable,
-                LastDeprecatedTimeboxed, BusinessObject, Indexed,
+                TestPlanned, LastDeprecatedTimeboxed, BusinessObject, Indexed,
                 db.Model):
   __tablename__ = 'data_assets'
 

--- a/src/ggrc/models/directive.py
+++ b/src/ggrc/models/directive.py
@@ -9,7 +9,7 @@ from ggrc.access_control.roleable import Roleable
 from ggrc.models.comment import Commentable
 from ggrc.models.deferred import deferred
 from ggrc.models.mixins import (BusinessObject, LastDeprecatedTimeboxed,
-                                CustomAttributable)
+                                CustomAttributable, TestPlanned)
 from ggrc.models import reflection
 from ggrc.fulltext.mixin import Indexed
 from .object_document import PublicDocumentable
@@ -28,7 +28,7 @@ from .track_object_state import HasObjectState
 # (of course, if there is a nice way of overriding/customizing declared
 # attributes in subclasses, we might want to use that approach)
 class Directive(HasObjectState, LastDeprecatedTimeboxed,
-                Commentable, BusinessObject, db.Model):
+                Commentable, TestPlanned, BusinessObject, db.Model):
   __tablename__ = 'directives'
 
   version = deferred(db.Column(db.String), 'Directive')

--- a/src/ggrc/models/facility.py
+++ b/src/ggrc/models/facility.py
@@ -6,7 +6,7 @@ from ggrc.access_control.roleable import Roleable
 from ggrc.fulltext.mixin import Indexed
 from ggrc.models.comment import Commentable
 from .mixins import (BusinessObject, LastDeprecatedTimeboxed,
-                     CustomAttributable)
+                     CustomAttributable, TestPlanned)
 from .object_document import PublicDocumentable
 from .object_person import Personable
 from .relationship import Relatable
@@ -15,7 +15,7 @@ from .track_object_state import HasObjectState
 
 class Facility(Roleable, HasObjectState, PublicDocumentable,
                CustomAttributable, Personable, Relatable, Commentable,
-               LastDeprecatedTimeboxed, BusinessObject, Indexed,
+               TestPlanned, LastDeprecatedTimeboxed, BusinessObject, Indexed,
                db.Model):
   __tablename__ = 'facilities'
   _aliases = {

--- a/src/ggrc/models/inflector.py
+++ b/src/ggrc/models/inflector.py
@@ -75,7 +75,7 @@ class ModelInflector(object):
   @property
   def title_singular(self):
     return getattr(self.model, 'readable_name_alias',
-                   utils.title_from_camelcase(self.model.__name__))
+                   utils.title_from_camelcase(self.model.__name__).title())
 
   @property
   def title_plural(self):

--- a/src/ggrc/models/market.py
+++ b/src/ggrc/models/market.py
@@ -6,7 +6,7 @@ from ggrc.access_control.roleable import Roleable
 from ggrc.fulltext.mixin import Indexed
 from ggrc.models.comment import Commentable
 from .mixins import (BusinessObject, LastDeprecatedTimeboxed,
-                     CustomAttributable)
+                     CustomAttributable, TestPlanned)
 from .object_document import PublicDocumentable
 from .object_person import Personable
 from .relationship import Relatable
@@ -15,7 +15,7 @@ from .track_object_state import HasObjectState
 
 class Market(Roleable, HasObjectState, CustomAttributable, Personable,
              Relatable, LastDeprecatedTimeboxed, PublicDocumentable,
-             Commentable, BusinessObject, Indexed, db.Model):
+             Commentable, TestPlanned, BusinessObject, Indexed, db.Model):
   __tablename__ = 'markets'
   _aliases = {
       "document_url": None,

--- a/src/ggrc/models/mixins/__init__.py
+++ b/src/ggrc/models/mixins/__init__.py
@@ -913,7 +913,7 @@ class TestPlanned(object):
   _api_attrs = reflection.ApiAttributes('test_plan')
   _fulltext_attrs = ['test_plan']
   _sanitize_html = ['test_plan']
-  _aliases = {"test_plan": "Test Plan"}
+  _aliases = {"test_plan": "Assessment Procedure"}
 
   @classmethod
   def indexed_query(cls):

--- a/src/ggrc/models/objective.py
+++ b/src/ggrc/models/objective.py
@@ -5,7 +5,7 @@ from ggrc import db
 from ggrc.access_control.roleable import Roleable
 from ggrc.fulltext.mixin import Indexed
 from ggrc.models.comment import Commentable
-from .mixins import BusinessObject, CustomAttributable
+from .mixins import BusinessObject, CustomAttributable, TestPlanned
 from .object_document import PublicDocumentable
 from .object_person import Personable
 from .audit_object import Auditable
@@ -16,7 +16,7 @@ from .mixins.with_last_assessment_date import WithLastAssessmentDate
 
 class Objective(WithLastAssessmentDate, Roleable, HasObjectState,
                 CustomAttributable, Auditable, Relatable, Personable,
-                PublicDocumentable, Commentable, BusinessObject,
+                PublicDocumentable, Commentable, TestPlanned, BusinessObject,
                 Indexed, db.Model):
   __tablename__ = 'objectives'
   _include_links = []

--- a/src/ggrc/models/org_group.py
+++ b/src/ggrc/models/org_group.py
@@ -6,7 +6,7 @@ from ggrc.access_control.roleable import Roleable
 from ggrc.fulltext.mixin import Indexed
 from ggrc.models.comment import Commentable
 from .mixins import (BusinessObject, LastDeprecatedTimeboxed,
-                     CustomAttributable)
+                     CustomAttributable, TestPlanned)
 from .object_document import PublicDocumentable
 from .object_person import Personable
 from .relationship import Relatable
@@ -15,7 +15,8 @@ from .track_object_state import HasObjectState
 
 class OrgGroup(Roleable, HasObjectState, CustomAttributable,
                Personable, Relatable, LastDeprecatedTimeboxed, Commentable,
-               PublicDocumentable, BusinessObject, Indexed, db.Model):
+               TestPlanned, PublicDocumentable, BusinessObject,
+               Indexed, db.Model):
   __tablename__ = 'org_groups'
   _aliases = {
       "document_url": None,

--- a/src/ggrc/models/product.py
+++ b/src/ggrc/models/product.py
@@ -9,7 +9,7 @@ from ggrc.fulltext.mixin import Indexed
 from ggrc.models.comment import Commentable
 from ggrc.models.deferred import deferred
 from ggrc.models.mixins import (BusinessObject, LastDeprecatedTimeboxed,
-                                CustomAttributable)
+                                CustomAttributable, TestPlanned)
 from ggrc.models.object_document import PublicDocumentable
 from ggrc.models.object_person import Personable
 from ggrc.models.option import Option
@@ -21,7 +21,7 @@ from ggrc.models.track_object_state import HasObjectState
 
 class Product(Roleable, HasObjectState, CustomAttributable, Personable,
               Relatable, LastDeprecatedTimeboxed, PublicDocumentable,
-              Commentable, BusinessObject, Indexed, db.Model):
+              Commentable, TestPlanned, BusinessObject, Indexed, db.Model):
   __tablename__ = 'products'
 
   kind_id = deferred(db.Column(db.Integer), 'Product')

--- a/src/ggrc/models/project.py
+++ b/src/ggrc/models/project.py
@@ -6,7 +6,7 @@ from ggrc.access_control.roleable import Roleable
 from ggrc.fulltext.mixin import Indexed
 from ggrc.models.comment import Commentable
 from .mixins import (BusinessObject, LastDeprecatedTimeboxed,
-                     CustomAttributable)
+                     CustomAttributable, TestPlanned)
 from .object_document import PublicDocumentable
 from .object_person import Personable
 from .relationship import Relatable
@@ -15,7 +15,7 @@ from .track_object_state import HasObjectState
 
 class Project(Roleable, HasObjectState, CustomAttributable, Personable,
               Relatable, LastDeprecatedTimeboxed, PublicDocumentable,
-              Commentable, BusinessObject, Indexed, db.Model):
+              Commentable, TestPlanned, BusinessObject, Indexed, db.Model):
   __tablename__ = 'projects'
   _aliases = {
       "document_url": None,

--- a/src/ggrc/models/section.py
+++ b/src/ggrc/models/section.py
@@ -6,7 +6,7 @@ from ggrc.access_control.roleable import Roleable
 from ggrc.fulltext.mixin import Indexed
 from ggrc.models.comment import Commentable
 from ggrc.models.directive import Directive
-from ggrc.models.mixins import CustomAttributable
+from ggrc.models.mixins import CustomAttributable, TestPlanned
 from ggrc.models.mixins import Hierarchical
 from ggrc.models.mixins import BusinessObject
 from ggrc.models.deferred import deferred
@@ -20,7 +20,7 @@ from ggrc.models.track_object_state import HasObjectState
 
 class Section(Roleable, HasObjectState, Hierarchical, db.Model,
               CustomAttributable, Personable, Relatable, Indexed,
-              Commentable, PublicDocumentable, BusinessObject):
+              Commentable, TestPlanned, PublicDocumentable, BusinessObject):
 
   __tablename__ = 'sections'
   _table_plural = 'sections'

--- a/src/ggrc/models/system.py
+++ b/src/ggrc/models/system.py
@@ -9,7 +9,7 @@ from ggrc.fulltext.mixin import Indexed
 from ggrc.models.comment import Commentable
 from ggrc.models.deferred import deferred
 from ggrc.models.mixins import (BusinessObject, LastDeprecatedTimeboxed,
-                                CustomAttributable)
+                                CustomAttributable, TestPlanned)
 from ggrc.models.object_document import PublicDocumentable
 from ggrc.models.object_person import Personable
 from ggrc.models.relationship import Relatable
@@ -27,7 +27,7 @@ from ggrc.models import reflection
 # (of course, if there is a nice way of overriding/customizing declared
 # attributes in subclasses, we might want to use that approach)
 class SystemOrProcess(track_object_state.HasObjectState,
-                      Commentable, LastDeprecatedTimeboxed,
+                      Commentable, TestPlanned, LastDeprecatedTimeboxed,
                       BusinessObject, db.Model):
   # Override model_inflector
   _table_plural = 'systems_or_processes'

--- a/src/ggrc/models/vendor.py
+++ b/src/ggrc/models/vendor.py
@@ -6,7 +6,7 @@ from ggrc.access_control.roleable import Roleable
 from ggrc.fulltext.mixin import Indexed
 from ggrc.models.comment import Commentable
 from .mixins import (BusinessObject, LastDeprecatedTimeboxed,
-                     CustomAttributable)
+                     CustomAttributable, TestPlanned)
 from .object_document import PublicDocumentable
 from .object_person import Personable
 from .relationship import Relatable
@@ -15,7 +15,7 @@ from .track_object_state import HasObjectState
 
 class Vendor(Roleable, HasObjectState, CustomAttributable, Personable,
              Relatable, LastDeprecatedTimeboxed, PublicDocumentable,
-             Commentable, BusinessObject, Indexed, db.Model):
+             Commentable, TestPlanned, BusinessObject, Indexed, db.Model):
   __tablename__ = 'vendors'
 
   _aliases = {

--- a/src/ggrc_risk_assessments/assets/mustache/risk_assessments/info.mustache
+++ b/src/ggrc_risk_assessments/assets/mustache/risk_assessments/info.mustache
@@ -18,6 +18,7 @@
       <tab-panel {(panels)}="panels" title-text="Risk Assessment">
         {{>'/static/mustache/base_objects/object-review.mustache'}}
         {{>'/static/mustache/base_objects/description.mustache'}}
+        {{>'/static/mustache/base_objects/test_plan.mustache'}}
 
         <div class="row-fluid wrap-row">
           <div class="span12">

--- a/src/ggrc_risk_assessments/assets/mustache/risk_assessments/modal_content.mustache
+++ b/src/ggrc_risk_assessments/assets/mustache/risk_assessments/modal_content.mustache
@@ -81,6 +81,9 @@
       </div>
     </div>
   </div>
+
+  {{> /static/mustache/partials/modal-ajax-test-plan.mustache}}
+
   <div class="row-fluid">
     <div data-id="code_hidden" class="span4 hidable">
       <label>

--- a/src/ggrc_risk_assessments/migrations/versions/20170823163135_2d5bf2f9e510_add_test_plan_field.py
+++ b/src/ggrc_risk_assessments/migrations/versions/20170823163135_2d5bf2f9e510_add_test_plan_field.py
@@ -1,0 +1,33 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Add test_plan field
+
+Create Date: 2017-08-23 16:31:35.304942
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+import sqlalchemy as sa
+
+from alembic import op
+
+from ggrc.migrations.utils.resolve_duplicates import rename_ca_title
+
+revision = '2d5bf2f9e510'
+down_revision = '237ccd7c769c'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  op.add_column(
+      "risk_assessments",
+      sa.Column("test_plan", sa.Text, nullable=True),
+  )
+  rename_ca_title("Assessment Procedure", ["risk_assessment"])
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  op.drop_column("risk_assessments", "test_plan")

--- a/src/ggrc_risk_assessments/models/risk_assessment.py
+++ b/src/ggrc_risk_assessments/models/risk_assessment.py
@@ -5,7 +5,7 @@
 
 from ggrc import db
 from ggrc.fulltext.mixin import Indexed
-from ggrc.models.mixins import CustomAttributable
+from ggrc.models.mixins import CustomAttributable, TestPlanned
 from ggrc.models.mixins import Described
 from ggrc.models.mixins import Noted
 from ggrc.models.mixins import Slugged
@@ -21,7 +21,7 @@ from ggrc.models import reflection
 
 class RiskAssessment(Documentable, Timeboxed, Noted, Described,
                      CustomAttributable, Titled, Relatable, Slugged,
-                     Indexed, db.Model):
+                     TestPlanned, Indexed, db.Model):
   """Risk Assessment model."""
   __tablename__ = 'risk_assessments'
   _title_uniqueness = False
@@ -74,7 +74,7 @@ class RiskAssessment(Documentable, Timeboxed, Noted, Described,
           "display_name": "Program",
           "mandatory": True,
           "filter_by": "_filter_by_program",
-      }
+      },
   }
 
   @classmethod

--- a/src/ggrc_risks/assets/mustache/risks/info.mustache
+++ b/src/ggrc_risks/assets/mustache/risks/info.mustache
@@ -19,6 +19,7 @@
         <tab-panel {(panels)}="panels" title-text="{{instance.type}}">
           {{>'/static/mustache/base_objects/object-review.mustache'}}
           {{>'/static/mustache/base_objects/description.mustache'}}
+          {{>'/static/mustache/base_objects/test_plan.mustache'}}
           {{>'/static/mustache/base_objects/contacts.mustache'}}
           {{>'/static/mustache/base_objects/urls.mustache'}}
 

--- a/src/ggrc_risks/assets/mustache/risks/modal_content.mustache
+++ b/src/ggrc_risks/assets/mustache/risks/modal_content.mustache
@@ -50,6 +50,8 @@
     </div>
   </div>
 
+  {{> /static/mustache/partials/modal-ajax-test-plan.mustache}}
+
   <div class="row">
     <div class="span12 hide-wrap hidable">
       <access-control-list-roles-helper

--- a/src/ggrc_risks/assets/mustache/threats/modal_content.mustache
+++ b/src/ggrc_risks/assets/mustache/threats/modal_content.mustache
@@ -34,6 +34,8 @@
     </div>
   </div>
 
+  {{> /static/mustache/partials/modal-ajax-test-plan.mustache}}
+
   <div class="row">
     <div class="span12 hide-wrap hidable">
       <access-control-list-roles-helper

--- a/src/ggrc_risks/migrations/versions/20170823162755_5aa9ec7105d1_add_test_plan_field.py
+++ b/src/ggrc_risks/migrations/versions/20170823162755_5aa9ec7105d1_add_test_plan_field.py
@@ -1,0 +1,35 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Add test_plan field
+
+Create Date: 2017-08-23 16:27:55.094736
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+import sqlalchemy as sa
+
+from alembic import op
+
+from ggrc.migrations.utils.resolve_duplicates import rename_ca_title
+
+revision = '5aa9ec7105d1'
+down_revision = '4e90a7e4907c'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  for table in ["risks", "threats"]:
+    op.add_column(
+        table,
+        sa.Column("test_plan", sa.Text, nullable=True),
+    )
+  rename_ca_title("Assessment Procedure", ["risk", "threat"])
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  for table in ["risks", "threats"]:
+    op.drop_column(table, "test_plan")

--- a/src/ggrc_risks/models/risk.py
+++ b/src/ggrc_risks/models/risk.py
@@ -12,6 +12,7 @@ from ggrc.models.associationproxy import association_proxy
 from ggrc.models import mixins
 from ggrc.models.comment import Commentable
 from ggrc.models.deferred import deferred
+from ggrc.models.mixins import TestPlanned
 from ggrc.models.object_document import PublicDocumentable
 from ggrc.models.object_person import Personable
 from ggrc.models import reflection
@@ -20,10 +21,10 @@ from ggrc.models.track_object_state import HasObjectState
 
 
 class Risk(Roleable, HasObjectState, mixins.CustomAttributable, Relatable,
-           Personable, PublicDocumentable, Commentable,
+           Personable, PublicDocumentable, Commentable, TestPlanned,
            mixins.LastDeprecatedTimeboxed, mixins.BusinessObject,
            Indexed, db.Model):
-
+  """Basic Risk model."""
   __tablename__ = 'risks'
 
   # Overriding mixin to make mandatory

--- a/src/ggrc_risks/models/threat.py
+++ b/src/ggrc_risks/models/threat.py
@@ -8,7 +8,7 @@ from ggrc.access_control.roleable import Roleable
 from ggrc.fulltext.mixin import Indexed
 from ggrc.models.comment import Commentable
 from ggrc.models.mixins import (CustomAttributable, BusinessObject,
-                                LastDeprecatedTimeboxed)
+                                LastDeprecatedTimeboxed, TestPlanned)
 from ggrc.models.object_document import PublicDocumentable
 from ggrc.models.object_person import Personable
 from ggrc.models.relationship import Relatable
@@ -17,7 +17,7 @@ from ggrc.models.track_object_state import HasObjectState
 
 class Threat(Roleable, HasObjectState, CustomAttributable, Personable,
              Relatable, LastDeprecatedTimeboxed, PublicDocumentable,
-             Commentable, BusinessObject, Indexed, db.Model):
+             Commentable, TestPlanned, BusinessObject, Indexed, db.Model):
   __tablename__ = 'threats'
 
   _aliases = {

--- a/test/integration/ggrc/__init__.py
+++ b/test/integration/ggrc/__init__.py
@@ -210,6 +210,14 @@ class TestCase(BaseTestCase, object):
                      "EXPECTED:\n{}\n\nRECEIVED:\n{}".format(
                          expected_str, response_str))
 
+  def check_import_errors(self, response):
+    """Check if import response doesn't contain any errors"""
+    messages = ("block_errors", "row_errors")
+    for block in response:
+      for message in messages:
+        errors = block.get(message, [])
+        self.assertEqual(errors, [], str(errors))
+
   @classmethod
   def import_data(cls, *import_data, **kwargs):
     """generate tmp file in csv directory and import it after that remove file

--- a/test/integration/ggrc/converters/test_import_helpers.py
+++ b/test/integration/ggrc/converters/test_import_helpers.py
@@ -97,6 +97,7 @@ class TestCustomAttributesDefinitions(TestCase):
         "Recipients",
         "Send by default",
         "Comments",
+        "Assessment Procedure",
         'Created Date',
         'Last Updated',
         'Last Updated By',
@@ -526,6 +527,7 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Recipients",
         "Send by default",
         "Comments",
+        "Assessment Procedure",
         'Created Date',
         'Last Updated',
         'Last Updated By',
@@ -554,6 +556,7 @@ class TestGetObjectColumnDefinitions(TestCase):
         'Created Date',
         'Last Updated',
         'Last Updated By',
+        "Assessment Procedure",
     }
     self._test_single_object(models.Clause, names, self.COMMON_EXPECTED)
 
@@ -578,6 +581,7 @@ class TestGetObjectColumnDefinitions(TestCase):
         'Created Date',
         'Last Updated',
         'Last Updated By',
+        "Assessment Procedure",
     }
     self._test_single_object(models.Section, names, self.COMMON_EXPECTED)
 
@@ -636,6 +640,7 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Recipients",
         "Send by default",
         "Comments",
+        "Assessment Procedure",
         'Created Date',
         'Last Updated',
         'Last Updated By',
@@ -683,6 +688,7 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Recipients",
         "Send by default",
         "Comments",
+        "Assessment Procedure",
         'Created Date',
         'Last Updated',
         'Last Updated By',
@@ -709,6 +715,7 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Recipients",
         "Send by default",
         "Comments",
+        "Assessment Procedure",
         'Created Date',
         'Last Updated',
         'Last Updated By',
@@ -735,6 +742,7 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Recipients",
         "Send by default",
         "Comments",
+        "Assessment Procedure",
         'Created Date',
         'Last Updated',
         'Last Updated By',
@@ -760,6 +768,7 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Recipients",
         "Send by default",
         "Comments",
+        "Assessment Procedure",
         'Created Date',
         'Last Updated',
         'Last Updated By',
@@ -809,6 +818,7 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Recipients",
         "Send by default",
         "Comments",
+        "Assessment Procedure",
         'Created Date',
         'Last Updated',
         'Last Updated By',
@@ -841,6 +851,7 @@ class TestRiskAssessmentColumnDefinitions(TestCase):
         "Code",
         "Program",
         "Delete",
+        "Assessment Procedure",
         'Created Date',
         'Last Updated',
         'Last Updated By',


### PR DESCRIPTION
Add 'Assessment Procedure' field for the following objects:
	Standards
	Regulations
	Sections
	Objectives
	Products
	Systems
	Processes
	Access Groups
	Clauses
	Contracts
	Data Assets
	Facilities
	Markets
	Org Groups
	Policies
	Projects
	Risks
	Threats
	Vendors
	Risk Assessment.

~This PR depends on frontend (GGRC-3138)~