### PR TITLE
GGRC-2226 Filter by mapping is not preselected and [+] button is disabled on the Export page if Export Cycles/People/Task Group from Workflow page 

### DIFF
--- a/src/ggrc/assets/javascripts/apps/dashboard.js
+++ b/src/ggrc/assets/javascripts/apps/dashboard.js
@@ -258,7 +258,15 @@
       ]
     });
     initWidgets();
-  } else if (/^\/import|export/i.test(location)) {
+  } else if (/^\/import/i.test(location)) {
+    $('#csv_import').html(
+      can.view(GGRC.mustache_path + "/import_export/import.mustache", {}));
+
+    initWidgets();
+  } else if (/^\/export/i.test(location)) {
+    $('#csv_export').html(
+      can.view(GGRC.mustache_path + '/import_export/export.mustache', {}));
+
     initWidgets();
   } else {
     $area.cms_controllers_dashboard({

--- a/src/ggrc/assets/javascripts/components/csv/export.js
+++ b/src/ggrc/assets/javascripts/components/csv/export.js
@@ -241,14 +241,7 @@
       panel_number: '@',
       has_parent: false,
       fetch_relevant_data: function (id, type) {
-        var dfd;
-        var Model = CMS.Models[type];
-
-        //  some models isn't defined at this moment (example: Workflow)
-        if (!Model) {
-          return;
-        }
-        dfd = Model.findOne({id: id});
+        var dfd = CMS.Models[type].findOne({id: id});
         dfd.then(function (result) {
           this.attr('item.relevant').push(new filterModel({
             model_name: url.relevant_type,
@@ -312,11 +305,4 @@
       }
     }
   });
-
-  csvExport = $('#csv_export');
-  if (csvExport.length) {
-    csvExport.html(
-      can.view(GGRC.mustache_path + '/import_export/export.mustache', {})
-    );
-  }
 })(window.can, window.can.$);

--- a/src/ggrc/assets/javascripts/components/csv/import.js
+++ b/src/ggrc/assets/javascripts/components/csv/import.js
@@ -251,8 +251,4 @@
       }
     }
   });
-  var csvImport = $("#csv_import");
-  if (csvImport.length) {
-    csvImport.html(can.view(GGRC.mustache_path + "/import_export/import.mustache", {}));
-  }
 })(window.can, window.can.$, GGRC.Utils);


### PR DESCRIPTION
Steps to reproduce:
1. Have active one time WF
2. Go to Active Cycles tab and Export Cycles
3. Look at Filter by Mapping: is not preselected
4. Click [+] button: is disabled

**Actual Result:** Filter by mapping is not preselected and [+] button is disabled on the Export page if Export Cycles/People/Task Group from Workflow page 
**Expected Result:** Filter by mapping should be preselected (in this case Workflow object and Workflow's title is displayed in the filter field) and [+] button should be enabled on the Export page if Export Cycles/People/Task Group from Workflow page 