### PR TITLE
GGRC-3140: UX updates for Search component

### DIFF
--- a/src/ggrc/assets/mustache/components/tree/tree-filter-input.mustache
+++ b/src/ggrc/assets/mustache/components/tree/tree-filter-input.mustache
@@ -4,11 +4,11 @@
 }}
 
 <div class="tree-filter__expression-holder width-100">
-  <input type="text" 
-         class="tree-filter__input width-100" 
-         {($value)}="filter" 
+  <input type="text"
+         class="tree-filter__input width-100"
+         {($value)}="filter"
          {{#disabled}}disabled{{/disabled}}
-         placeholder="Type for search here...">
+         placeholder="Type here to search or click the advanced search icon">
   <span class="tree-filter_is-expression {{#if isExpression}}valid{{/if}}">
     <i class="fa fa-check-circle{{#unless isExpression}}-o{{/unless}}"></i>
   </span>
@@ -26,7 +26,7 @@
   {{/if}}
 </div>
 <div class="flex-box tree-filter__actions">
-  <button type="submit" 
+  <button type="submit"
           class="btn btn-small btn-lightBlue"
           ($click)="submit()"
           {{#disabled}}disabled{{/disabled}}>

--- a/src/ggrc/assets/mustache/components/tree/tree-widget-container.mustache
+++ b/src/ggrc/assets/mustache/components/tree/tree-widget-container.mustache
@@ -81,7 +81,7 @@
       {{/if}}
     </div>
 
-    <simple-modal {state}="advancedSearch" modal-title="'{{model.title_singular}} Advanced Filter'" extra-css-class="advanced-search">
+    <simple-modal {state}="advancedSearch" modal-title="'{{model.title_singular}} Advanced Search'" extra-css-class="advanced-search">
       <div class="advanced-search__content">
         <div class="simple-modal__body">
           <advanced-search-filter-container

--- a/src/ggrc/assets/stylesheets/components/tree/_tree-view.scss
+++ b/src/ggrc/assets/stylesheets/components/tree/_tree-view.scss
@@ -275,7 +275,7 @@ tree-filter-input {
       }
     }
     .advanced-filter{
-      opacity: .25;
+      opacity: .7;
       position: absolute;
       right: 6px;
       top: 1px;


### PR DESCRIPTION
1. Update placeholder in 'Search' field to 'Type here to search or click the advanced search icon'
2. Advanced search icon should not be grey (because it seems as disabled) - color for advanced search icon = black #000000
opacity = 70%
3. Use ‘Advance Search’ title on pop-up.