### PR TITLE
QUICK-FIX Downgrade version to 0.10.28-Raspberry

### DIFF
--- a/src/ggrc/settings/default.py
+++ b/src/ggrc/settings/default.py
@@ -35,7 +35,7 @@ try:
 except (ImportError):
   pass
 
-VERSION = "0.10.29-Raspberry" + BUILD_NUMBER
+VERSION = "0.10.28-Raspberry" + BUILD_NUMBER
 
 # Migration owner
 MIGRATOR = os.environ.get(


### PR DESCRIPTION
Reverts google/ggrc-core#6252

We decided to postpone the delivery of 0.10.28 by a week.