### PR TITLE
GGRC-3145 Generate Assessment button is disabled if click select all in generate assessment popup

### DIFF
--- a/src/ggrc/assets/javascripts/components/unified-mapper/mapper-results.js
+++ b/src/ggrc/assets/javascripts/components/unified-mapper/mapper-results.js
@@ -317,7 +317,7 @@
                 };
               });
             this.setSelectedItems(result);
-            if (relatedData) {
+            if (!this.attr('objectGenerator') && relatedData) {
               disabledIds = relatedData[modelKey].ids;
               this.attr('disabledIds', disabledIds);
               this.setDisabledItems(result, disabledIds);


### PR DESCRIPTION
Steps to reproduce:
1. Have program, control, audit
2. Go to the audit page > Assessments tab
3. Open generate assessments popup
4. Click Select All
5. Look at the 'Generate assessments' button: is disabled while control snapshot is selected
Actual Result: Generate Assessment button is disabled if click select all in generate assessment popup
Expected Result: Generate Assessment button should not be disabled if click select all in generate assessment popup
