### PR TITLE
GGRC-2759 Changing the assignee field should not force an assessment to "In Progress"

### DIFF
--- a/src/ggrc/models/mixins/autostatuschangeable.py
+++ b/src/ggrc/models/mixins/autostatuschangeable.py
@@ -27,7 +27,6 @@ class AutoStatusChangeable(object):
 
   FIRST_CLASS_EDIT = ({statusable.Statusable.START_STATE} |
                       statusable.Statusable.DONE_STATES)
-  ASSIGNABLE_EDIT = statusable.Statusable.DONE_STATES
 
   @staticmethod
   def _date_has_changes(attr):
@@ -91,7 +90,7 @@ class AutoStatusChangeable(object):
     cls.set_handlers(model)
 
   @staticmethod
-  def adjust_status(model, obj):
+  def change_to_progress_state(model, obj):
     """Switches state on object to the PROGRESS_STATE
 
     Args:
@@ -103,7 +102,7 @@ class AutoStatusChangeable(object):
     db.session.add(obj)
 
   @classmethod
-  def handle_first_class_edit(cls, model, obj, rel=None, method=None):
+  def handle_first_class_edit(cls, model, obj, method=None):
     """Handles first class edit
 
     Performs check whether object received first class edit (ordinary edit)
@@ -115,8 +114,6 @@ class AutoStatusChangeable(object):
       model: (db.Model class) Class from which to read FIRST_CLASS_EDIT
         property.
       obj: (db.Model instance) Object on which to perform operations.
-      rel: (Relationship) Relationship object, needed here to maintain equal
-        type signature with handle_person_edit.
       method: (string) HTTP method used that triggered signal
     """
 
@@ -137,53 +134,8 @@ class AutoStatusChangeable(object):
     for obj in session.identity_map.values():
       if (isinstance(obj, AutoStatusChangeable) and
               getattr(obj, '_need_status_reset', False)):
-        cls.adjust_status(type(obj), obj)
+        cls.change_to_progress_state(type(obj), obj)
         delattr(obj, '_need_status_reset')
-
-  @classmethod
-  def handle_person_edit(cls, model, obj, rel, method):
-    """Handles person edit
-
-    Args:
-      model: (db.Model class) Class from which to read ASSIGNABLE_EDIT
-        property.
-      obj: (db.Model instance) Object on which to perform operations.
-      rel: (Relationship) Relationship whose attribute have to be inspected for
-        changes.
-      method: (string) HTTP method used that triggered signal
-    """
-    adjust_state = False
-
-    if method == "POST":
-      # On relationship creation inspect(rel) sometime shows relationship
-      # attributes as unchanged and sometimes as added.
-      # But because POST can only ever be issued for creation, we can use this
-      # as a guarantee that this was an editable event that should adjust
-      # status.
-      unchanged = inspect(rel).attrs.relationship_attrs.history.unchanged
-      added = inspect(rel).attrs.relationship_attrs.history.added
-      attr_changed = ({ra.attr_name for ra in unchanged} |
-                      {ra.attr_name for ra in added})
-    else:
-      # Ensures that we only adjust status for AssigneeType relationship
-      # attribute.
-      added = inspect(rel).attrs.relationship_attrs.history.added
-      deleted = inspect(rel).attrs.relationship_attrs.history.deleted
-      attr_changed = ({ra.attr_name for ra in deleted} |
-                      {ra.attr_name for ra in added})
-
-    if obj.status in model.ASSIGNABLE_EDIT:
-      # When object attributes are added or edited, adjust. If user still has
-      # some other role, operation is considered edit.
-      if "AssigneeType" in attr_changed:
-        adjust_state = True
-
-      # When user has no more roles on an object, relationship is deleted.
-      if method == "DELETE":
-        adjust_state = True
-
-    if adjust_state:
-      cls.adjust_status(model, obj)
 
   @staticmethod
   def _has_custom_attr_changes(obj):
@@ -302,13 +254,11 @@ class AutoStatusChangeable(object):
 
         handlers = {
             "Document": cls.handle_first_class_edit,
-            "Person": cls.handle_person_edit,
             "Snapshot": cls.handle_first_class_edit,
         }
         for k in handlers.keys():
           if k in endpoints:
-            handlers[k](model, target_object, obj,
-                        method=service.request.method)
+            handlers[k](model, target_object, method=service.request.method)
 
 
 # pylint: disable=fixme


### PR DESCRIPTION
Comment by User:
What is the problem / issue?
If I edit the assignee via the 'edit object' popup, the assessment is moved to "In Progress" screenshot-1.png, screenshot-2.png
This does not happen if I open the assessment in a new tab.
What is the expected result / outcome? (ie What should happen?)
I should be given the option on whether I want it to be in progress or not.
What is the impact if it is not fixed / implemented? (Quantify the impact, eg, # of hours)
Confusing the assignee whether the assessment truly is in process or not.