### PR TITLE
GGRC-3147 The app freezes if make any inline edit of Creator/Assignee/Verifier on the Assessments Info pane

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment/info-pane/confirm-edit-action.js
+++ b/src/ggrc/assets/javascripts/components/assessment/info-pane/confirm-edit-action.js
@@ -42,7 +42,6 @@
         });
       },
       confirmEdit: function () {
-        document.body.classList.add('no-events');
         if (!this.isInEditableState()) {
           this.showConfirm();
           return;

--- a/src/ggrc/assets/javascripts/components/assessment/map-button-using-assessment-type.js
+++ b/src/ggrc/assets/javascripts/components/assessment/map-button-using-assessment-type.js
@@ -24,7 +24,6 @@
         GGRC.Controllers.ObjectMapper.openMapper(data);
       },
       onClick: function (el, ev) {
-        document.body.classList.add('no-events');
         el.data('type', this.attr('instance.assessment_type'));
         el.data('deferred_to', this.attr('deferredTo'));
         can.trigger(el, 'openMapper', ev);


### PR DESCRIPTION
This fix caused regression with inline edit components

Steps to reproduce:
1. Have Assessment on the audit page
2. Expand Assessment Info pane and try to add Verifier
3. Look at the screen
Actual Result: the app freezes and user is not be able to edit any field after adding Creator/Assignee/Verifier on the Assessments Info pane
Expected Result: the app should not freeze and user should be able to edit any field after adding Creator/Assignee/Verifier on the Assessments Info pane
