### PR TITLE
GGRC-3152 Fix prev/next buttons for first items on non first page

### DIFF
--- a/src/ggrc/assets/javascripts/components/tree/tests/tree-widget-container_spec.js
+++ b/src/ggrc/assets/javascripts/components/tree/tests/tree-widget-container_spec.js
@@ -505,6 +505,14 @@ describe('GGRC.Components.treeWidgetContainer', function () {
 
          expect(result).toEqual(-1);
        });
+    it('should return correct item number for first item on non first page',
+       function () {
+         var result;
+
+         result = vm.getAbsoluteItemNumber({id: 1});
+
+         expect(result).toEqual(20);
+       });
   });
 
   describe('getRelativeItemNumber() method', function () {

--- a/src/ggrc/assets/javascripts/components/tree/tree-widget-container.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-widget-container.js
@@ -552,7 +552,7 @@
       var pageInfo = this.attr('pageInfo');
       var startIndex = pageInfo.pageSize * (pageInfo.current - 1);
       var relativeItemIndex = _.findIndex(showedItems, {id: instance.id});
-      return relativeItemIndex > 0 ?
+      return relativeItemIndex > -1 ?
         startIndex + relativeItemIndex :
         relativeItemIndex;
     },


### PR DESCRIPTION
To reproduce:

1. Load assessment list with at least two pages.
2. Go to page 2
3. Open first item on the list
Prev button is going to be disabled, after clicking the next button you'll navigate to the second item on the second page instead of the second item on the second page.