### PR TITLE
GGRC-2285/2265/3163 Copy Assessment Procedure from snapshot to Assessment on mapping

### DIFF
--- a/src/ggrc/assets/javascripts/models/assessment.js
+++ b/src/ggrc/assets/javascripts/models/assessment.js
@@ -253,6 +253,16 @@ import {prepareCustomAttributes} from '../plugins/utils/ca-utils';
     after_create: function () {
       this._checkIssueTrackerWarnings();
     },
+    before_save: function () {
+      var mappedObjectsChanges = this.attr('mappedObjectsChanges');
+      if ( mappedObjectsChanges ) {
+        mappedObjectsChanges.forEach((mo)=>{
+          mo.extra = {
+            copyAssessmentProcedure: this.attr('_copyAssessmentProcedure'),
+          };
+        });
+      }
+    },
     before_create: function () {
       if (!this.audit) {
         throw new Error('Cannot save assessment, audit not set.');

--- a/src/ggrc/assets/javascripts/models/assessment.js
+++ b/src/ggrc/assets/javascripts/models/assessment.js
@@ -25,6 +25,7 @@ import {prepareCustomAttributes} from '../plugins/utils/ca-utils';
     is_custom_attributable: true,
     isRoleable: true,
     defaults: {
+      _copyAssessmentProcedure: true,
       assessment_type: 'Control',
       status: 'Not Started',
       send_by_default: true,  // notifications when a comment is added

--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -394,7 +394,7 @@ import '../components/audit/attach-folder-button'
       context: 'CMS.Models.Context.stub'
     },
     defaults: {
-      test_plan_procedure: false,
+      test_plan_procedure: true,
       template_object_type: 'Control',
       default_people: {
         assignees: 'Principal Assignees',

--- a/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
@@ -92,26 +92,15 @@
           <a data-id="hide_default_test_plan_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
         </label>
 
-	{{#if instance.test_plan_procedure}}
-	  <div class="wysiwyg-area">
-	    <textarea
-	      class="span12 triple"
-	      placeholder="Enter Description"
-	      tabindex="2"
-	      disabled
-	      ></textarea>
-	  </div>
-	{{else}}
 	<div class="wysiwyg-area">
 	  <textarea
 	    id="system_description"
-	    can-value="instance.procedure_description"
+	    ($value)="instance.procedure_description"
 	    class="span12 triple wysihtml5"
 	    placeholder="Enter Description"
 	    tabindex="2"
 	    ></textarea>
 	</div>
-	{{/if}}
       </div>
 
       <div class="span6">

--- a/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
@@ -25,14 +25,13 @@
           </dropdown>
         </assessment-object-type-dropdown>
 
-        {{#if_equals instance.template_object_type 'Control'}}
         <label class="inline-check pull-left">
           <input type="checkbox"
-            can-value="instance.test_plan_procedure"
+            ($value)="instance.test_plan_procedure"
             class="js-toggle-controlplans">
-          Use control test plans as assessment test plan
+	    Copy Assessment Procedure from mapped object
         </label>
-        {{/if_equals}}
+
       </div>
     </div>
 
@@ -93,26 +92,26 @@
           <a data-id="hide_default_test_plan_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
         </label>
 
-        {{#if instance.test_plan_procedure}}
-          <div class="wysiwyg-area">
-            <textarea
-              class="span12 triple"
-              placeholder="Enter Description"
-              tabindex="2"
-              disabled
-              ></textarea>
-          </div>
-        {{else}}
-          <div class="wysiwyg-area">
-            <textarea
-              id="system_description"
-              can-value="instance.procedure_description"
-              class="span12 triple wysihtml5"
-              placeholder="Enter Description"
-              tabindex="2"
-              ></textarea>
-          </div>
-        {{/if}}
+	{{#if instance.test_plan_procedure}}
+	  <div class="wysiwyg-area">
+	    <textarea
+	      class="span12 triple"
+	      placeholder="Enter Description"
+	      tabindex="2"
+	      disabled
+	      ></textarea>
+	  </div>
+	{{else}}
+	<div class="wysiwyg-area">
+	  <textarea
+	    id="system_description"
+	    can-value="instance.procedure_description"
+	    class="span12 triple wysihtml5"
+	    placeholder="Enter Description"
+	    tabindex="2"
+	    ></textarea>
+	</div>
+	{{/if}}
       </div>
 
       <div class="span6">

--- a/src/ggrc/assets/mustache/assessments/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessments/modal_content.mustache
@@ -21,12 +21,13 @@
         {{/if_in}}
       {{/if}}
 
-      <div class="ggrc-form-item">
+      <div class="ggrc-form-item ggrc-form-item_m-b-0">
         <div class="ggrc-form-item__multiple-row">
           <label class="form-label ggrc-form-item__label">
             Assessment Type
           </label>
           <assessment-object-type-dropdown
+	    class="input-medium"
             {instance}="instance"
             {(assessment-type)}="instance.assessment_type">
             <dropdown
@@ -48,6 +49,14 @@
             <option value="Auditor pulls evidence">Auditor pulls evidence</option>
           </select>
         </div>
+      </div>
+      <div class="ggrc-form-item">
+	<div class="ggrc-form-item__checkbox-item">
+	  <label class="inline-check pull-left">
+	    <input type="checkbox" ($value)="instance._copyAssessmentProcedure" class="js-toggle-controlplans">
+	      Copy Assessment Procedure from mapped object
+	  </label>
+	</div>
       </div>
       <div class="ggrc-form-item">
         <div class="ggrc-form-item__row {{#instance.computed_errors.title}}field-failure{{/instance.computed_errors.title}}">

--- a/src/ggrc/assets/stylesheets/components/form/_ggrc-form.scss
+++ b/src/ggrc/assets/stylesheets/components/form/_ggrc-form.scss
@@ -93,6 +93,15 @@
       }
     }
 
+    .ggrc-form-item__checkbox-item {
+      label {
+        font-size: 14px;
+        white-space: nowrap;
+        font-weight: normal;
+        text-transform: none;
+      }
+    }
+
     .ggrc-from-item__checkbox-list {
       justify-content: flex-start;
       display: flex;
@@ -102,13 +111,6 @@
         flex-basis: 350px;
         max-width: 350px;
         margin-right: 30px;
-
-        label {
-          font-size: 14px;
-          white-space: nowrap;
-          font-weight: normal;
-          text-transform: none;
-        }
       }
     }
 
@@ -135,5 +137,9 @@
       margin-bottom: 8px;
       line-height: 10px;
     }
+  }
+
+  .ggrc-form-item_m-b-0 {
+    margin-bottom: 0;
   }
 }

--- a/src/ggrc/models/hooks/assessment.py
+++ b/src/ggrc/models/hooks/assessment.py
@@ -360,12 +360,13 @@ def _handle_assessment(assessment, src, snapshots, templates, audits):
   )
 
   if not template:
+    # Assessment test plan should inherit test plan of snapshot
+    assessment.test_plan = snapshot.revision.content.get("test_plan")
     return
 
+  assessment.test_plan = template.procedure_description
   if template.test_plan_procedure:
-    assessment.test_plan = snapshot.revision.content['test_plan']
-  else:
-    assessment.test_plan = template.procedure_description
+    copy_snapshot_plan(assessment, snapshot)
   if template.template_object_type:
     assessment.assessment_type = template.template_object_type
 
@@ -872,3 +873,12 @@ def relate_ca(assessment, template):
         placeholder=definition.placeholder,
     )
     db.session.add(cad)
+
+
+def copy_snapshot_plan(assessment, snapshot):
+  """Copy test plan of Snapshot into Assessment"""
+  if assessment.test_plan and snapshot.revision.content["test_plan"]:
+    assessment.test_plan += "<br>"
+    assessment.test_plan += snapshot.revision.content["test_plan"]
+  elif snapshot.revision.content["test_plan"]:
+    assessment.test_plan = snapshot.revision.content["test_plan"]

--- a/test/integration/ggrc/models/test_assessment.py
+++ b/test/integration/ggrc/models/test_assessment.py
@@ -2,6 +2,7 @@
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
 """Integration tests for Assessment"""
+# pylint: disable=too-many-lines
 
 import collections
 import datetime
@@ -514,6 +515,7 @@ class TestAssessment(TestAssessmentBase):
         self.assert_mapped_role(role, person_email, snapshot)
 
 
+@ddt.ddt
 @base.with_memcache
 class TestAssessmentUpdates(ggrc.TestCase):
   """ Test various actions on Assessment updates """
@@ -594,6 +596,63 @@ class TestAssessmentUpdates(ggrc.TestCase):
         new_state,
         content.json['assessments_collection']['assessments'][0]['status']
     )
+
+  @ddt.data(
+      (None, "Control", "Plan - {}", "Plan - 0<br>Plan - 1<br>Plan - 2"),
+      ("", "Control", "Plan - {}",
+       "Plan - 0<br>Plan - 1<br>Plan - 2"),
+      ("Asmnt plan", "Control", "Plan - {}",
+       "Asmnt plan<br>Plan - 0<br>Plan - 1<br>Plan - 2"),
+      ("Asmnt plan", "Market", "Plan - {}", "Asmnt plan"),
+      (None, "Control", None, ""),
+      ("", "Control", None, ""),
+      ("Asmnt plan", "Control", None, "Asmnt plan"),
+      (None, "Control", "", ""),
+      ("", "Control", "", ""),
+      ("Asmnt plan", "Control", "", "Asmnt plan"),
+  )
+  @ddt.unpack
+  def test_assessment_proc_on_map(self, asmnt_plan, asmnt_type, test_plan,
+                                  expected_plan):
+    """Test if Snapshot test_plan added to Assessment after mapping"""
+    # pylint: disable=too-many-locals
+    with factories.single_commit():
+      audit = factories.AuditFactory()
+      assessment = factories.AssessmentFactory(
+          audit=audit, assessment_type=asmnt_type, test_plan=asmnt_plan
+      )
+      factories.RelationshipFactory(source=audit, destination=assessment)
+      controls = [
+          factories.ControlFactory(
+              test_plan=test_plan.format(i) if test_plan else test_plan
+          )
+          for i in range(3)
+      ]
+    snapshots = self._create_snapshots(audit, controls)
+
+    relation = [{
+        "relationship": {
+            "context": {
+                "context_id": None,
+                "id": assessment.context_id,
+                "type": "Context"
+            },
+            "destination": {
+                "id": snapshot.id,
+                "type": "Snapshot"
+            },
+            "source": {
+                "id": assessment.id,
+                "type": "Assessment"
+            }
+        }
+    } for snapshot in snapshots]
+
+    response = self.api.post(all_models.Relationship, relation)
+    self.assertEqual(response.status_code, 200)
+
+    asmnt = all_models.Assessment.query.get(assessment.id)
+    self.assertEqual(asmnt.test_plan, expected_plan)
 
 
 @ddt.ddt
@@ -721,8 +780,10 @@ class TestAssessmentGeneration(TestAssessmentBase):
         test_plan_procedure=True
     )
     response = self.assessment_post(template)
-    self.assertEqual(response.json["assessment"]["test_plan"],
-                     test_plan)
+    self.assertEqual(
+        response.json["assessment"]["test_plan"],
+        "<br>".join([template.procedure_description, test_plan])
+    )
 
   def test_ca_order(self):
     """Test LCA/GCA order in Assessment"""
@@ -1184,3 +1245,10 @@ class TestAssessmentGeneration(TestAssessmentBase):
     assessment = self.refresh_object(asmt)
     self.assertEqual(assessment.status,
                      getattr(all_models.Assessment, test_state))
+
+  def test_generated_test_plan(self):
+    """Check if generated Assessment inherit test plan of Snapshot"""
+    test_plan = self.control.test_plan
+    response = self.assessment_post()
+    self.assertEqual(response.status_code, 201)
+    self.assertEqual(response.json["assessment"]["test_plan"], test_plan)


### PR DESCRIPTION
# Issue description

## Add / Edit Assessment Template pop-up:

- Rename checkbox next to 'Object under assessment' to 'Inherit <object type> Assessment Procedure'. 
- Check box should be shown for all the objects that have 'Assessment Procedure' attribute.
- Checkbox should be checked by default.

## Add / Edit Assessment pop-up:

- Add 'inherit Assessment Procedure" switch next to 'Assessment Type' dropdown;
- Switch should be turned ON by default.
- 'Inherit Assessment Procedure" switch should be displayed for all objects that are selected in 'Assessment Type' dropdown and have 'Assessment Procedure' attribute.


# ACCEPTANCE CRITERIA 
AC1. Snapshot is mapped to Assessment:
- Assessment Procedure text from snapshot should be copied and pasted into Assessment 'Assessment Procedure' field, if snapshot type = type specified in 'Assessment type' attribute in Assessment.
- Snapshot 'Assessment Procedure' text should be pasted below (appended) the existing text in 'Assessment Procedure' in Assessment, if it exists.
- Existing text and newly added text should be divided with empty line.

AC2. Allow to add Default Assessment Test Plan (Default Assessment Procedure) in Assessment Template always (no matter if  'inherit' switch is turned ON / OFF).

AC3. Assessment Procedure should be copied from snapshot to Assessment, if Assessment is generated without template.