### PR TITLE
GGRC-2042 "Select none" in Filter sub tree doesn't work for Risks/Threats 

### DIFF
--- a/src/ggrc/assets/javascripts/components/tree/sub-tree-wrapper.js
+++ b/src/ggrc/assets/javascripts/components/tree/sub-tree-wrapper.js
@@ -16,7 +16,7 @@
       parentModel: {
         type: String,
         get: function () {
-          return this.attr('parent').type
+          return this.attr('parent').type;
         }
       },
       parentId: {
@@ -86,7 +86,7 @@
           } else {
             this.loadItems(models).then(function () {
               setResult(models);
-            })
+            });
           }
         }
       },
@@ -128,6 +128,8 @@
       models = can.makeArray(models);
 
       if (!models.length) {
+        this.attr('directlyItems', []);
+        this.attr('notDirectlyItems', []);
         return can.Deferred().resolve();
       }
 


### PR DESCRIPTION
Steps to reproduce:
1. Have Risk/Threat
2. Go to My work page> Risk tab
3. Hover over first tier and Expand subtree
4. Select Filter sub tree > Select "select none" and Click Set Visibility
5. Collapse sublevel
5. Expand Sub level: confirm mappings are shown
Actual Result: "Select none" in Filter sub tree doesn't work for Risks/Threats
Expected Result: "Select none" in Filter sub tree should work for Risks/Threats

If we choose "select none", in sub tree not display any results now.