### PR TITLE
GGRC-2873: Improve padding between label and title

### DIFF
--- a/src/ggrc/assets/stylesheets/modules/_object-header.scss
+++ b/src/ggrc/assets/stylesheets/modules/_object-header.scss
@@ -7,7 +7,7 @@
   h3 {
     max-width: 80%;
     float: left;
-    margin-right: 10px;
+    margin-right: 8px;
   }
   &.pane-header__fixed {
     right: 52px;


### PR DESCRIPTION
Improve padding between label and title on info pane. Should be 8px.
