### PR TITLE
GGRC-3162: Fix alignment issues in 'Other attributes' tab

### DIFF
--- a/src/ggrc/assets/mustache/components/assessment/custom-attributes.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/custom-attributes.mustache
@@ -4,7 +4,7 @@
 }}
 {{#each items}}
     <div class="ggrc-form-item">
-        <div class="{{#is type 'input'}}ggrc-form-item__row{{else}}ggrc-form-item__multiple-row{{/if}}">
+        <div class="{{#if_in type 'input,text'}}ggrc-form-item__row{{else}}ggrc-form-item__multiple-row{{/if}}">
             <inline-edit-control class="inline-edit-control"
                 (inline-save)="updateGlobalAttribute(%event, %context)"
                 {instance}="instance"

--- a/src/ggrc/assets/mustache/components/assessment/info-pane/info-pane.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/info-pane/info-pane.mustache
@@ -207,7 +207,7 @@
               <related-issues {base-instance}="instance"
                                     {all-related-snapshots}="mappedSnapshots"></related-issues>
           </tab-panel>
-          <tab-panel {(panels)}="panels" title-text="Other Attributes">
+          <tab-panel {(panels)}="panels" title-text="Other Attributes" class="assessment-attributes-panel">
               <assessment-custom-attributes (on-update-attributes)="saveGlobalAttributes(%event)"
                                                   {items}="globalAttributes"
                                                   {is-edit-denied}="isEditDenied"

--- a/src/ggrc/assets/stylesheets/components/form/_ggrc-form.scss
+++ b/src/ggrc/assets/stylesheets/components/form/_ggrc-form.scss
@@ -6,15 +6,19 @@
 .ggrc-form {
 
   &__title {
+    display: -webkit-box;
     font-size: 11px;
     text-transform: uppercase;
     font-weight: bold;
-    line-height: 28px;
+    line-height: 16px;
     margin: 0;
-    padding: 0;
+    padding: 5px 0;
     position: relative;
     overflow: hidden;
     text-overflow: ellipsis;
+    word-wrap: break-word;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
   }
 
   &.ggrc-form-multiple-columns {


### PR DESCRIPTION
Fix for alignment issues in 'Other attributes' tab:
1. CA of type 'Rich text' should occupy one row.
2. Reduce CA title maximum length to 3 lines to avoid issue with hovering over long CAs. 