### PR TITLE
GGRC-3159: Refresh related assessments after Prev/Next navigation

### DIFF
--- a/src/ggrc/assets/javascripts/components/related-objects/related-objects.js
+++ b/src/ggrc/assets/javascripts/components/related-objects/related-objects.js
@@ -128,6 +128,9 @@
       },
       '{viewModel.baseInstance} refreshInstance': function () {
         this.viewModel.setRelatedItems();
+      },
+      '{viewModel.baseInstance} refreshRelatedAssessments': function () {
+        this.viewModel.setRelatedItems();
       }
     }
   });

--- a/src/ggrc/assets/javascripts/components/tree/tree-widget-container.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-widget-container.js
@@ -694,6 +694,7 @@
             pinControl
               .updateInstance(componentSelector, newInstance);
             newInstance.dispatch('refreshRelatedDocuments');
+            newInstance.dispatch('refreshRelatedAssessments');
 
             this.viewModel.updateActiveItemIndicator(relativeIndex);
           }.bind(this))


### PR DESCRIPTION
Steps to reproduce:
1. Have audit with control snapshot
2. Have at least 3 assessments: control snapshot is mapped to both assessments, 1 assessment has no mapping 
3. Expand Info pane of assessment that has mapped control snapshot
4. Open Related Assessment tab
5. Click Next/Prev
6. Look at the Related Assessments
Actual Result: Related assessments of previous assessment are displayed while click 'Prev/Next'
Expected Result: Related assessments of previous assessment should not be displayed while click 'Prev/Next'