### PR TITLE
GGRC-3180 FE: make a better error message while date format is wrong

### DIFF
--- a/src/ggrc/assets/javascripts/plugins/ajax_extensions.js
+++ b/src/ggrc/assets/javascripts/plugins/ajax_extensions.js
@@ -120,12 +120,17 @@
 
   $doc.ajaxError(function (event, jqxhr, settings, exception) {
     var message;
+    var response;
+
     if (!jqxhr.hasFailCallback || settings.flashOnFail ||
       (!settings.flashOnFail && jqxhr.flashOnFail)) {
       // TODO: Import produced 'canceled' ajax flash message that needed handling. Will refactor once better method works.
       if (settings.url.indexOf('import') === -1 || exception !== 'canceled') {
+        response = jqxhr.responseJSON;
         message = jqxhr.getResponseHeader('X-Flash-Error') ||
-          GGRC.Errors.messages[jqxhr.status] || exception.message || exception;
+          GGRC.Errors.messages[jqxhr.status] ||
+          (response && response.message) ||
+          exception.message || exception;
 
         if (message) {
           GGRC.Errors.notifier('error', message);


### PR DESCRIPTION
Steps to reproduce:
1. Go to My work page
2. My tasks tab
3. Using Search box filter by "TASK DUE DATE" with search query that contains incorrect date (e,g, "TASK DUE DATE" = "2017-06/12")
4. Click Search button: error is displayed

**Actual Result:** "There was an error!" error occurs if filter by "TASK DUE DATE" with query that contains incorrect date
**Expected Result:** 'Invalid date was typed into '<field name>' field, please change and try again!'