### PR TITLE
GGRC-1199 Unified mapper window is duplicated if click twice on Map button

### DIFF
--- a/src/ggrc/assets/javascripts/components/object-mapper/object-mapper.js
+++ b/src/ggrc/assets/javascripts/components/object-mapper/object-mapper.js
@@ -82,6 +82,7 @@
       },
       '{window} modal:dismiss': function (el, ev, options) {
         var joinObjectId = this.viewModel.attr('join_object_id');
+        $('body').trigger('closeMapper');
 
         // mapper sets uniqueId for modal-ajax.
         // we can check using unique id which modal-ajax is closing
@@ -111,6 +112,7 @@
         self.viewModel.attr('submitCbs').fire();
       },
       closeModal: function () {
+        $('body').trigger('closeMapper');
         this.viewModel.attr('is_saving', false);
 
         // TODO: Find proper way to dismiss the modal

--- a/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
@@ -51,14 +51,6 @@
       }.bind(this));
     },
 
-    disableAll: function (el, ev) {
-      document.body.classList.add('no-events');
-    },
-
-    '[data-toggle="modal-ajax-form"] click': 'disableAll',
-    '[data-toggle="unified-search"] click': 'disableAll',
-    '[data-toggle="unified-mapper"] click': 'disableAll',
-
     init_page_title: function () {
       var pageTitle = null;
       if (typeof (this.options.page_title) === 'function') {

--- a/src/ggrc/assets/javascripts/controllers/mapper.js
+++ b/src/ggrc/assets/javascripts/controllers/mapper.js
@@ -13,6 +13,8 @@
   var OBJECT_REQUIRED_MESSAGE = 'Required Data for In Scope Object is missing' +
     ' - Original Object is mandatory';
 
+  var isMapperOpen = false;
+
   can.Control.extend('GGRC.Controllers.ObjectMapper', {
     defaults: {
       component: GGRC.mustache_path +
@@ -44,7 +46,7 @@
       var self = this;
       var isSearch = /unified-search/ig.test(data.toggle);
 
-      if (disableMapper) {
+      if (disableMapper || isMapperOpen) {
         return;
       }
 
@@ -54,6 +56,7 @@
 
       if (GGRC.Utils.Snapshots
           .isInScopeModel(data.join_object_type) && !isSearch) {
+        isMapperOpen = true;
         openForSnapshots(data);
       } else {
         openForCommonObjects(data, isSearch);
@@ -127,7 +130,6 @@
   }, {
     init: function () {
       this.element.html(can.view(this.options.component, this.options));
-      document.body.classList.remove('no-events');
     }
   });
   GGRC.Controllers.ObjectMapper.extend('GGRC.Controllers.ObjectSearch', {
@@ -162,10 +164,16 @@
     GGRC.Controllers.ObjectMapper.openMapper(data, disableMapper, btn);
   }
   $('body').on('openMapper', function (el, ev, disableMapper) {
-    openMapperByElement(ev, disableMapper);
+    if (!isMapperOpen) {
+      openMapperByElement(ev, disableMapper);
+    }
   });
 
   $('body').on('click', selectors.join(', '), function (ev, disableMapper) {
     openMapperByElement(ev, disableMapper);
+  });
+
+  $('body').on('closeMapper', function () {
+    isMapperOpen = false;
   });
 })(window.can, window.can.$);

--- a/src/ggrc/assets/javascripts/controllers/modals_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/modals_controller.js
@@ -436,8 +436,6 @@
         // When we start, all the ui elements are visible
         this.options.ui_array.push(0);
       }
-
-      document.body.classList.remove('no-events');
     },
 
     setup_wysihtml5: function () {
@@ -689,10 +687,6 @@
           targetEl.datepicker('option', options[otherKey], date);
         }
       }, this);
-    },
-
-    '[data-toggle="unified-mapper"] click': function (el, ev) {
-      document.body.classList.add('no-events');
     },
 
     "{$footer} a.btn[data-toggle='modal-submit-addmore'] click":

--- a/src/ggrc/assets/stylesheets/modules/_modal.scss
+++ b/src/ggrc/assets/stylesheets/modules/_modal.scss
@@ -7,10 +7,6 @@
   background-color: $white;
 }
 
-.no-events {
-  pointer-events: none;
-}
-
 .field-hide {
   display: none;
   .modal & {


### PR DESCRIPTION
Steps to reproduce:
1 - On the audit page create assessment
2 - Click Map button twice in the first tier: confirm Unified Mapper window is duplicated
Actual Result: Unified mapper window is duplicated if click twice on Map button
Expected Result: Unified mapper window should not duplicated if click twice on Map button
The ticket was reopened due to Unified mapper is duplicated if click twice on [+] button to map Controls and Related Information on Assessment's Info pane. Also, Unified mapper is duplicated if click twice [Map objects] in Edit Assessments modal window.