### PR TITLE
GGRC-2922 Compute attributes after each full reindex

### DIFF
--- a/src/ggrc/views/__init__.py
+++ b/src/ggrc/views/__init__.py
@@ -122,6 +122,7 @@ def do_reindex():
   with benchmark("Create records for %s" % "Snapshot"):
     reindex_snapshots()
   indexer.invalidate_cache()
+  start_compute_attributes("all_latest")
 
 
 def get_permissions_json():

--- a/test/integration/ggrc/converters/test_ca_import_export.py
+++ b/test/integration/ggrc/converters/test_ca_import_export.py
@@ -195,11 +195,6 @@ class TestCustomAttributeImportExport(TestCase):
     filename = "custom_attribute_tests.csv"
     self.import_file(filename)
 
-    # TODO: there is a bug that imports do not index all custom attributes.
-    # After fixing this bug remove the following two lines.
-    from ggrc import views
-    views.do_reindex()
-
     data = [{
         "object_name": "Product",
         "filters": {

--- a/test/integration/ggrc/fulltext/test_mysql.py
+++ b/test/integration/ggrc/fulltext/test_mysql.py
@@ -7,7 +7,6 @@ import ddt
 import sqlalchemy.exc
 
 from ggrc import db
-from ggrc import views
 from ggrc.models import all_models
 from ggrc.fulltext import mysql
 from integration.ggrc import TestCase
@@ -32,8 +31,6 @@ class TestCAD(TestCase):
     CAV(custom_attribute=cad1, attributable=factory, attribute_value="x")
     CAV(custom_attribute=cad2, attributable=factory, attribute_value="x")
 
-    views.do_reindex()
-
     title1_count = mysql.MysqlRecordProperty.query.filter(
         mysql.MysqlRecordProperty.property == title1
     ).count()
@@ -46,8 +43,6 @@ class TestCAD(TestCase):
     cad1 = CAD(title=title1, definition_type="market")
     factory = factories.MarketFactory()
     CAV(custom_attribute=cad1, attributable=factory, attribute_value="x")
-
-    views.do_reindex()
 
     title1_count = mysql.MysqlRecordProperty.query.filter(
         mysql.MysqlRecordProperty.property == title1
@@ -79,8 +74,6 @@ class TestCAD(TestCase):
           attributable=market,
           attribute_value=value)
 
-    views.do_reindex()
-
     contents = [
         i.content
         for i in mysql.MysqlRecordProperty.query.filter(
@@ -103,8 +96,6 @@ class TestCAD(TestCase):
           title=title,
           definition_type="market",
           attribute_type=checkbox_type)
-
-    views.do_reindex()
 
     contents = [
         i.content

--- a/test/integration/ggrc/fulltext/test_total_reindex.py
+++ b/test/integration/ggrc/fulltext/test_total_reindex.py
@@ -8,7 +8,6 @@ from sqlalchemy import orm
 
 from ggrc import db
 from ggrc import fulltext
-from ggrc import views
 from ggrc.fulltext.mysql import MysqlRecordProperty
 from ggrc.utils import QueryCounter
 from ggrc.fulltext import mysql
@@ -93,7 +92,10 @@ class TestTotalReindex(TestCase):
           factory()
     indexer = fulltext.get_indexer()
     count = indexer.record_type.query.count()
-    views.do_reindex()
+    count = indexer.record_type.query.delete()
+    self.client.get("/login")
+    self.client.post("/admin/reindex")
+
     # ACR roles are created in migration and aren't removed in setup
     # Index for them will be created only after reindexing
     reindexed_count = indexer.record_type.query.filter(

--- a/test/integration/ggrc/snapshotter/test_indexing.py
+++ b/test/integration/ggrc/snapshotter/test_indexing.py
@@ -10,7 +10,6 @@ from sqlalchemy.sql.expression import tuple_
 from ggrc import db
 from ggrc import models
 from ggrc.models import all_models
-from ggrc.views import do_reindex
 from ggrc.fulltext.mysql import MysqlRecordProperty as Record
 from ggrc.snapshotter.indexer import delete_records
 
@@ -339,7 +338,7 @@ class TestSnapshotIndexing(SnapshotterBaseTestCase):
     records = get_records(audit, snapshots)
     self.assertEqual(records.count(), 0)
 
-    do_reindex()
+    self.client.post("/admin/reindex")
 
     records = get_records(audit, snapshots)
 
@@ -383,7 +382,11 @@ class TestSnapshotIndexing(SnapshotterBaseTestCase):
       old_content[field] = {"id": person.id}
       revision.content = old_content
       db.session.add(revision)
-    do_reindex()
+    person_id = person.id
+    snapshot_id = snapshot.id
+    self.client.post("/admin/reindex")
+    person = all_models.Person.query.get(person_id)
+    snapshot = all_models.Snapshot.query.get(snapshot_id)
     self.assert_indexed_fields(snapshot, role_name, {
         "{}-email".format(person.id): person.email,
         "{}-name".format(person.id): person.name,
@@ -414,7 +417,11 @@ class TestSnapshotIndexing(SnapshotterBaseTestCase):
           child_type=control.type,
           revision=revision)
     db.session.expire_all()
-    do_reindex()
+    person_id = person.id
+    snapshot_id = snapshot.id
+    self.client.post("/admin/reindex")
+    person = all_models.Person.query.get(person_id)
+    snapshot = all_models.Snapshot.query.get(snapshot_id)
     self.assert_indexed_fields(snapshot, role_name, {
         "{}-email".format(person.id): person.email,
         "{}-name".format(person.id): person.name,
@@ -459,7 +466,9 @@ class TestSnapshotIndexing(SnapshotterBaseTestCase):
           child_type=control.type,
           revision=revision)
     db.session.expire_all()
-    do_reindex()
+    snapshot_id = snapshot.id
+    self.client.post("/admin/reindex")
+    snapshot = all_models.Snapshot.query.get(snapshot_id)
     self.assert_indexed_fields(snapshot, cad_title, {"": search_value})
 
   def test_filter_by_checkbox_cad_no_cav(self):
@@ -486,7 +495,9 @@ class TestSnapshotIndexing(SnapshotterBaseTestCase):
           child_type=control.type,
           revision=revision)
     db.session.expire_all()
-    do_reindex()
+    snapshot_id = snapshot.id
+    self.client.post("/admin/reindex")
+    snapshot = all_models.Snapshot.query.get(snapshot_id)
     self.assert_indexed_fields(snapshot, cad_title, {"": search_value})
 
   def test_index_deleted_acr(self):
@@ -514,7 +525,9 @@ class TestSnapshotIndexing(SnapshotterBaseTestCase):
     db.session.expire_all()
     db.session.delete(acr)
     db.session.commit()
-    do_reindex()
+    snapshot_id = snapshot.id
+    self.client.post("/admin/reindex")
+    snapshot = all_models.Snapshot.query.get(snapshot_id)
     all_found_records = dict(Record.query.filter(
         Record.key == snapshot.id,
         Record.type == snapshot.type,


### PR DESCRIPTION
Reindex breaks the index entries for computed attributes. So to fix
those we should reindex computed attributes as well. The easiest way to
do that is to trigger compute attributes background task for all
attributes.