### PR TITLE
GGRC-3229 Assessor/Creator/Verifier shouldn't delete assessment

### DIFF
--- a/src/ggrc_basic_permissions/__init__.py
+++ b/src/ggrc_basic_permissions/__init__.py
@@ -119,7 +119,7 @@ def objects_via_assignable_query(user_id, context_not_role=True):
           (rel1.destination_type == "Person",
            rel1.source_type)
       ], else_=rel1.destination_type),
-      rel1.context_id if context_not_role else literal('RUD')))
+      rel1.context_id if context_not_role else literal('RU')))
 
   # The user should also have access to objects mapped to the assigned_objects
   # We accomplish this by filtering out relationships where the user is
@@ -643,8 +643,10 @@ def load_assignee_relationships(user, permissions):
   """
   for id_, type_, role_name in objects_via_assignable_query(user.id, False):
     actions = ["read", "view_object_page"]
-    if role_name == "RUD":
-      actions += ["update", "delete"]
+    if "U" in role_name:
+      actions.append("update")
+    if "D" in role_name:
+      actions.append("delete")
     for action in actions:
       permissions.setdefault(action, {})\
           .setdefault(type_, {})\

--- a/test/integration/ggrc/services/test_assessments.py
+++ b/test/integration/ggrc/services/test_assessments.py
@@ -7,9 +7,12 @@ import random
 
 from ddt import data, ddt
 
+from ggrc.models import all_models
 from integration.ggrc import TestCase
 from integration.ggrc.query_helper import WithQueryApi
 from integration.ggrc.models import factories
+from integration.ggrc.api_helper import Api
+from integration.ggrc.generator import ObjectGenerator
 
 
 @ddt
@@ -22,6 +25,8 @@ class TestCollection(TestCase, WithQueryApi):
     self.client.get("/login")
     self.clear_data()
     self.expected_ids = []
+    self.api = Api()
+    self.generator = ObjectGenerator()
     assessments = [factories.AssessmentFactory() for _ in range(10)]
     random.shuffle(assessments)
     for idx, assessment in enumerate(assessments):
@@ -40,3 +45,30 @@ class TestCollection(TestCase, WithQueryApi):
       expected_ids = expected_ids[::-1]
     results = self._get_first_result_set(query, "Assessment", "values")
     self.assertEqual(expected_ids, [i['id'] for i in results])
+
+  @data("Assessor", "Creator", "Verifier")
+  def test_delete_assessment_by_role(self, role_name):
+    """Delete assessment not allowed for based on Assignee Type."""
+    with factories.single_commit():
+      assessment = factories.AssessmentFactory()
+      context = factories.ContextFactory(related_object=assessment)
+      assessment.context = context
+      person = factories.PersonFactory()
+      object_person_rel = factories.RelationshipFactory(
+          source=assessment, destination=person)
+      factories.RelationshipAttrFactory(
+          relationship_id=object_person_rel.id,
+          attr_name="AssigneeType",
+          attr_value=role_name,
+      )
+    assessment_id = assessment.id
+    role = all_models.Role.query.filter(
+        all_models.Role.name == "Creator"
+    ).first()
+    self.generator.generate_user_role(person, role, context)
+    self.api.set_user(person)
+    assessment = all_models.Assessment.query.get(assessment_id)
+    resp = self.api.delete(assessment)
+    self.assert403(resp)
+    self.assertTrue(all_models.Assessment.query.filter(
+        all_models.Assessment.id == assessment_id).one())


### PR DESCRIPTION
It's not allowed to delete assessment based on the AssigneeType related to assessment. 