### PR TITLE
GGRC-1997 Import: If there is nothing to import in the csv file (e.g. snapshots), the import button should be disabled.

### DIFF
--- a/src/ggrc/assets/javascripts/components/csv/import.js
+++ b/src/ggrc/assets/javascripts/components/csv/import.js
@@ -33,6 +33,7 @@
                 isDisabled: function () {
                   var toImport = this.import;  // info on blocks to import
                   var nonEmptyBlockExists;
+                  var hasErrors;
 
                   if (!toImport || toImport.length < 1) {
                     return true;
@@ -44,7 +45,11 @@
                     return block.rows > block.ignored;
                   });
 
-                  return !nonEmptyBlockExists;
+                  hasErrors = _.any(toImport, function (block) {
+                    return block.block_errors.length;
+                  });
+
+                  return hasErrors || !nonEmptyBlockExists;
                 }.bind(this)  // bind the scope object as context
               },
               importing: {

--- a/src/ggrc/assets/javascripts/components/csv/test/import_spec.js
+++ b/src/ggrc/assets/javascripts/components/csv/test/import_spec.js
@@ -38,17 +38,20 @@ describe('GGRC.Components.csvImportWidget', function () {
          *   @param {Number} [rowCounts.updated=0] - total rows to update
          *   @param {Number} [rowCounts.deleted=0] - total rows to delete
          *   @param {Number} [rowCounts.ignored=0] - total rows to ignore
+         * @param {Boolean} hasErrors - if true then add non empty array "block_errors"
+         *    to block, if false then add empty array
          *
          * @return {can.Map} - a new dummy import block info instance
          */
-        function makeImportBlock(objectType, rowCounts) {
+        function makeImportBlock(objectType, rowCounts, hasErrors) {
           var COUNT_FIELD_NAMES = ['created', 'updated', 'deleted', 'ignored'];
           var COUNT_ERR = 'Invalid row counts, the sum of created, updated, ' +
               'deleted, and ignored must equal the total row count.';
 
           var blockOptions = {
             name: objectType,
-            rows: rowCounts.totalRows || 0
+            rows: rowCounts.totalRows || 0,
+            block_errors: hasErrors ? new can.List({}) : new can.List()
           };
           var combinedCount = 0;
 
@@ -90,6 +93,21 @@ describe('GGRC.Components.csvImportWidget', function () {
           var importBlocks = [
             makeImportBlock('Assessment', {totalRows: 0}),
             makeImportBlock('Market', {totalRows: 0})
+          ];
+          fakeScope.attr('import', importBlocks);
+
+          result = isDisabled();
+
+          expect(result).toBe(true);
+        });
+
+        it('returns true if blocks has errors', function () {
+          var result;
+          var importBlocks = [
+            makeImportBlock('Assessment', {totalRows: 4, ignored: 4}, true),
+            makeImportBlock('Market', {totalRows: 0, ignored: 0}),
+            makeImportBlock(
+              'Contract', {totalRows: 3, created: 1, ignored: 2})
           ];
           fakeScope.attr('import', importBlocks);
 


### PR DESCRIPTION
Steps to reproduce:
1. Create program, control, audit
2. Go to Export page
3. Select Snapshots form dropdown "Export Object Type"
4. Select Snapshot object type - control and select mapped to the audit, audit title> Export
5. Make changes in scv file and import

**Actual Result:** Import button is enabled while importing snapshot
**Expected Result:** Import button should be disabled if import snapshot. The system should not allow to import snapshot