### PR TITLE
QUICK-FIX Upgrade mysql to 5.6

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ cleandev:
   links:
    - db
 db:
-  image: mysql:5.5
+  image: mysql:5.6
   ports:
    - "3306:3306"
   volumes:


### PR DESCRIPTION
Upgrading to 5.6 seems to work without a problem.

I have also tried upgrading to 5.7, but the migrations fail and there is a need to run mysql_upgrade command for a missing table to be restored (`Table 'performance_schema.session_variables' doesn't exist") [SQL: "SHOW VARIABLES LIKE 'sql_mode'`). Even after this there were issues like the following stack trace:

```
INFO  [alembic.migration] Running upgrade None -> 262bbe790f4c, Import all squashed migrations from 0.9.5-Zucchini-P1.
ERROR [sqlalchemy.pool.QueuePool] Error closing cursor
Traceback (most recent call last):
  File "/vagrant/src/packages/sqlalchemy/engine/base.py", line 1277, in _safe_close_cursor
    cursor.close()
  File "/vagrant-dev/opt/linked_packages/MySQLdb/cursors.py", line 91, in close
    while self.nextset():
  File "/vagrant-dev/opt/linked_packages/MySQLdb/cursors.py", line 147, in nextset
    self._warning_check()
  File "/vagrant-dev/opt/linked_packages/MySQLdb/cursors.py", line 120, in _warning_check
    warnings = self._get_db().show_warnings()
  File "/vagrant-dev/opt/linked_packages/MySQLdb/connections.py", line 368, in show_warnings
    self.query("SHOW WARNINGS")
  File "/vagrant-dev/opt/linked_packages/MySQLdb/connections.py", line 280, in query
    _mysql.connection.query(self, query)
ProgrammingError: (2014, "Commands out of sync; you can't run this command now")
Traceback (most recent call last):
  File "<string>", line 11, in <module>
  File "ggrc/migrate.py", line 102, in upgradeall
    command.upgrade(config, 'head')
  File "/vagrant-dev/opt/dev_virtualenv/local/lib/python2.7/site-packages/alembic/command.py", line 129, in upgrade
    script.run_env()
  File "/vagrant-dev/opt/dev_virtualenv/local/lib/python2.7/site-packages/alembic/script.py", line 208, in run_env
    util.load_python_file(self.dir, 'env.py')
  File "/vagrant-dev/opt/dev_virtualenv/local/lib/python2.7/site-packages/alembic/util.py", line 230, in load_python_file
    module = load_module_py(module_id, path)
  File "/vagrant-dev/opt/dev_virtualenv/local/lib/python2.7/site-packages/alembic/compat.py", line 63, in load_module_py
    mod = imp.load_source(module_id, path, fp)
  File "/vagrant/src/ggrc/migrations/env.py", line 78, in <module>
    run_migrations_online()
  File "/vagrant/src/ggrc/migrations/env.py", line 71, in run_migrations_online
    context.run_migrations()
  File "<string>", line 7, in run_migrations
  File "/vagrant-dev/opt/dev_virtualenv/local/lib/python2.7/site-packages/alembic/environment.py", line 696, in run_migrations
    self.get_context().run_migrations(**kw)
  File "/vagrant-dev/opt/dev_virtualenv/local/lib/python2.7/site-packages/alembic/migration.py", line 268, in run_migrations
    self._update_current_rev(prev_rev, rev)
  File "/vagrant-dev/opt/dev_virtualenv/local/lib/python2.7/site-packages/alembic/migration.py", line 213, in _update_current_rev
    values(version_num=literal_column("'%s'" % new))
  File "/vagrant-dev/opt/dev_virtualenv/local/lib/python2.7/site-packages/alembic/ddl/impl.py", line 81, in _exec
    conn.execute(construct, *multiparams, **params)
  File "/vagrant/src/packages/sqlalchemy/engine/base.py", line 945, in execute
    return meth(self, multiparams, params)
  File "/vagrant/src/packages/sqlalchemy/sql/elements.py", line 263, in _execute_on_connection
    return connection._execute_clauseelement(self, multiparams, params)
  File "/vagrant/src/packages/sqlalchemy/engine/base.py", line 1053, in _execute_clauseelement
    compiled_sql, distilled_params
  File "/vagrant/src/packages/sqlalchemy/engine/base.py", line 1189, in _execute_context
    context)
  File "/vagrant/src/packages/sqlalchemy/engine/base.py", line 1402, in _handle_dbapi_exception
    exc_info
  File "/vagrant/src/packages/sqlalchemy/util/compat.py", line 203, in raise_from_cause
    reraise(type(exception), exception, tb=exc_tb, cause=cause)
  File "/vagrant/src/packages/sqlalchemy/engine/base.py", line 1182, in _execute_context
    context)
  File "/vagrant/src/packages/sqlalchemy/engine/default.py", line 470, in do_execute
    cursor.execute(statement, parameters)
  File "/vagrant-dev/opt/linked_packages/MySQLdb/cursors.py", line 189, in execute
    while self.nextset():
  File "/vagrant-dev/opt/linked_packages/MySQLdb/cursors.py", line 147, in nextset
    self._warning_check()
  File "/vagrant-dev/opt/linked_packages/MySQLdb/cursors.py", line 120, in _warning_check
    warnings = self._get_db().show_warnings()
  File "/vagrant-dev/opt/linked_packages/MySQLdb/connections.py", line 368, in show_warnings
    self.query("SHOW WARNINGS")
  File "/vagrant-dev/opt/linked_packages/MySQLdb/connections.py", line 280, in query
    _mysql.connection.query(self, query)
sqlalchemy.exc.ProgrammingError: (_mysql_exceptions.ProgrammingError) (2014, "Commands out of sync; you can't run this command now") [SQL: u"INSERT INTO ggrc_alembic_version (version_num) VALUES ('262bbe790f4c')"]
```

So I suggest we simply upgrade to 5.6 for now which will also allow us to go to cloud sql 2nd generation and after this is done see if we can upgrade to 5.7.