### PR TITLE
GGRC-3184 Set up notifications for comments created in all models

### DIFF
--- a/src/ggrc/migrations/versions/20171110133934_1af0b27960a2_update_recipients_field.py
+++ b/src/ggrc/migrations/versions/20171110133934_1af0b27960a2_update_recipients_field.py
@@ -1,0 +1,56 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Update recipients field
+
+Create Date: 2017-11-10 13:39:34.865657
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = '1af0b27960a2'
+down_revision = '431dcf5c75af'
+
+COMMENTABLE_TABLES = [
+    "access_groups",
+    "clauses",
+    "controls",
+    "data_assets",
+    "directives",
+    "facilities",
+    "markets",
+    "objectives",
+    "org_groups",
+    "systems",
+    "products",
+    "sections",
+    "vendors",
+    "issues",
+    "projects"
+]
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  for name in COMMENTABLE_TABLES:
+    commentable_table = sa.sql.table(
+        name, sa.Column('recipients', sa.String(length=250))
+    )
+    op.execute(commentable_table.update().values(
+        recipients="Admin,Primary Contacts,Secondary Contacts"
+    ))
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  for name in COMMENTABLE_TABLES:
+    commentable_table = sa.sql.table(
+        name, sa.Column('recipients', sa.String(length=250))
+    )
+    op.execute(commentable_table.update().values(
+        recipients=None
+    ))

--- a/src/ggrc/models/comment.py
+++ b/src/ggrc/models/comment.py
@@ -45,6 +45,9 @@ class Commentable(object):
       "Assignees",
       "Creators",
       "Verifiers",
+      "Admin",
+      "Primary Contacts",
+      "Secondary Contacts",
   ])
 
   @validates("recipients")

--- a/src/ggrc/notifications/data_handlers.py
+++ b/src/ggrc/notifications/data_handlers.py
@@ -102,14 +102,14 @@ def _get_revisions(obj, created_at):
   old_rev = db.session.query(models.Revision) \
       .filter_by(resource_id=obj.id, resource_type=obj.type) \
       .filter(sa.and_(models.Revision.created_at < created_at,
-                   models.Revision.id < new_rev.id)) \
+                      models.Revision.id < new_rev.id)) \
       .order_by(models.Revision.id.desc()) \
       .first()
   if not old_rev:
     old_rev = db.session.query(models.Revision) \
         .filter_by(resource_id=obj.id, resource_type=obj.type) \
         .filter(sa.and_(models.Revision.created_at == created_at,
-                     models.Revision.id < new_rev.id)) \
+                        models.Revision.id < new_rev.id)) \
         .order_by(models.Revision.id) \
         .first()
   return new_rev, old_rev
@@ -422,7 +422,14 @@ def generate_comment_notification(obj, comment, person):
 
 
 def _get_comment_relation(comment):
-  """Get relationship objects for provided comment"""
+  """Get relationship objects for provided comment
+
+  Args:
+      comment: a Comment instance
+
+  Returns:
+      Relationship between comment object and any other
+  """
   return models.Relationship.query.filter(sa.or_(
       sa.and_(
           models.Relationship.source_type == "Comment",
@@ -436,13 +443,13 @@ def _get_comment_relation(comment):
 
 
 def _get_people_with_roles(comment_obj):
-  """Collect recipients with they roles
+  """Collect recipients with their roles
 
   Args:
-    comment_obj: Commentable object for which notification should be send
+      comment_obj: Commentable object for which notification should be send
 
   Returns:
-    Dict with Person instances and set of role names
+      Dict with Person instances and set of role names
   """
   assignees = defaultdict(set)
   for acl in comment_obj.access_control_list:
@@ -474,8 +481,9 @@ def get_comment_data(notif):
       issubclass(type(rel.source), Commentable) or
       issubclass(type(rel.destination), Commentable)
   ):
-    comment_obj = rel.source if rel.source_type != "Comment" \
-        else rel.destination
+    comment_obj = rel.source
+    if rel.source_type == "Comment":
+      comment_obj = rel.destination
   if not comment_obj:
     logger.warning('Comment object not found for notification %s', notif.id)
     return {}

--- a/test/integration/ggrc/converters/test_import_commentable.py
+++ b/test/integration/ggrc/converters/test_import_commentable.py
@@ -1,0 +1,79 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+# pylint: disable=maybe-no-member, invalid-name
+
+"""Test import of commentable fields."""
+from collections import OrderedDict
+
+from ggrc.models import inflector
+from ggrc.models.mixins import Described
+from ggrc.models.mixins.audit_relationship import AuditRelationship
+from integration.ggrc import TestCase
+from integration.ggrc.models import factories
+
+COMMENTABLE_MODELS = [
+    "AccessGroup",
+    "Clause",
+    "Control",
+    "DataAsset",
+    "Facility",
+    "Market",
+    "Objective",
+    "OrgGroup",
+    "System",
+    "Process",
+    "Product",
+    "Section",
+    "Vendor",
+    "Issue",
+    "Policy",
+    "Regulation",
+    "Standard",
+    "Contract",
+    "Risk",
+    "Threat",
+]
+RECIPIENTS = ["Admin", "Primary Contacts", "Secondary Contacts"]
+
+
+class TestCommentableImport(TestCase):
+  """Class with tests of importing fields of Commentable mixin"""
+  def setUp(self):
+    """Set up for Assessment test cases."""
+    super(TestCommentableImport, self).setUp()
+    self.client.get("/login")
+
+    # Audit should be in db when data will be imported
+    audit = factories.AuditFactory().slug
+    with factories.single_commit():
+      for model in COMMENTABLE_MODELS:
+        self.import_model(model, audit, ",".join(RECIPIENTS), True)
+
+  def import_model(self, model_name, audit, recipients, send_by_default):
+    """Import model data with commentable fields"""
+    # pylint: disable=protected-access
+    import_data = [
+        ("object_type", model_name),
+        ("Code", "{}-1".format(model_name)),
+        ("Title", "{}-Title".format(model_name)),
+        ("Admin", "user@example.com"),
+        ("Recipients", recipients),
+        ("Send by default", send_by_default),
+    ]
+    model_cls = inflector.get_model(model_name)
+    if issubclass(model_cls, AuditRelationship):
+      import_data.append(("Map:Audit", audit))
+    if issubclass(model_cls, Described) and \
+       "description" not in model_cls._aliases:
+      import_data.append(("description", "{}-Description".format(model_name)))
+    response = self.import_data(OrderedDict(import_data))
+    self._check_csv_response(response, {})
+
+  def test_commentable_import(self):
+    """Test import of recipients and send_by_default fields"""
+    for model_name in COMMENTABLE_MODELS:
+      model_cls = inflector.get_model(model_name)
+      obj = model_cls.query.first()
+      self.assertEqual(obj.recipients, ",".join(RECIPIENTS))
+      self.assertEqual(obj.send_by_default, True)

--- a/test/integration/ggrc/models/test_control.py
+++ b/test/integration/ggrc/models/test_control.py
@@ -49,3 +49,37 @@ class TestControl(TestCase):
     self.api.put(control, {"status": Control.DEPRECATED})
     control = db.session.query(Control).get(control.id)
     self.assertIsNotNone(control.end_date)
+
+  def test_create_commentable(self):
+    """Test if commentable fields are set on creation"""
+    recipients = "Admin,Primary Contacts,Secondary Contacts"
+    send_by_default = 0
+    response = self.api.post(Control, {
+        "control": {
+            "title": "Control title",
+            "context": None,
+            "recipients": recipients,
+            "send_by_default": send_by_default,
+        },
+    })
+    self.assertEqual(response.status_code, 201)
+    control_id = response.json.get("control").get("id")
+    control = db.session.query(Control).get(control_id)
+    self.assertEqual(control.recipients, recipients)
+    self.assertEqual(control.send_by_default, send_by_default)
+
+  def test_update_commentable(self):
+    """Test update of commentable fields"""
+    control = factories.ControlFactory()
+    self.assertEqual(control.recipients, "")
+    self.assertIs(control.send_by_default, True)
+
+    recipients = "Admin,Primary Contacts,Secondary Contacts"
+    send_by_default = 0
+    self.api.put(control, {
+        "recipients": recipients,
+        "send_by_default": send_by_default,
+    })
+    control = db.session.query(Control).get(control.id)
+    self.assertEqual(control.recipients, recipients)
+    self.assertEqual(control.send_by_default, send_by_default)

--- a/test/integration/ggrc/notifications/test_comment_notifications.py
+++ b/test/integration/ggrc/notifications/test_comment_notifications.py
@@ -6,11 +6,14 @@
 """Tests for notifications for models with assignable mixin."""
 
 from datetime import datetime
+
+import ddt
 from mock import patch
 from sqlalchemy import and_
 
 from ggrc import db
-from ggrc.models import Assessment
+from ggrc.access_control.role import get_custom_roles_for
+from ggrc.models import Assessment, all_models
 from ggrc.models import Notification
 from ggrc.models import NotificationType
 from ggrc.models import Revision
@@ -20,6 +23,7 @@ from integration.ggrc import generator
 from integration.ggrc.models import factories
 
 
+@ddt.ddt
 class TestCommentNotification(TestCase):
 
   """Test notification on assessment comments."""
@@ -146,3 +150,71 @@ class TestCommentNotification(TestCase):
         self.assertEqual(comment["parent_type"], "Assessment")
         expected_suffix = "asmt " + str(parent_obj_key.id)
         self.assertTrue(comment["description"].endswith(expected_suffix))
+
+  @ddt.data(
+      factories.AccessGroupFactory,
+      factories.ClauseFactory,
+      factories.ControlFactory,
+      factories.DataAssetFactory,
+      factories.FacilityFactory,
+      factories.MarketFactory,
+      factories.ObjectiveFactory,
+      factories.OrgGroupFactory,
+      factories.SystemFactory,
+      factories.ProcessFactory,
+      factories.ProductFactory,
+      factories.SectionFactory,
+      factories.VendorFactory,
+      factories.IssueFactory,
+      factories.PolicyFactory,
+      factories.RegulationFactory,
+      factories.StandardFactory,
+      factories.ContractFactory,
+      factories.RiskFactory,
+      factories.ThreatFactory,
+  )
+  @patch("ggrc.notifications.common.send_email")
+  def test_models_comments(self, obj_factory, _):
+    """Test setting notification entries for model comments.
+
+    Check if the correct notification entries are created when a comment gets
+    posted.
+    """
+    recipient_types = ["Admin", "Primary Contacts", "Secondary Contacts"]
+    person = all_models.Person.query.first()
+    person_email = person.email
+
+    with factories.single_commit():
+      obj = obj_factory(
+          recipients=",".join(recipient_types),
+          send_by_default=False,
+      )
+      ac_roles = get_custom_roles_for(obj.type)
+      for acr_id, acr_name in ac_roles.items():
+        if acr_name in recipient_types:
+          factories.AccessControlListFactory(
+              ac_role_id=acr_id, object=obj, person=person
+          )
+
+    self.generator.generate_comment(
+        obj, "", "some comment", send_notification="true")
+
+    notifications, notif_data = common.get_daily_notifications()
+    self.assertEqual(len(notifications), 1,
+                     "Missing comment notification entry.")
+
+    recip_notifs = notif_data.get(person_email, {})
+    comment_notifs = recip_notifs.get("comment_created", {})
+    self.assertEqual(len(comment_notifs), 1)
+
+    # Check if correct revisions count is created
+    revisions = Revision.query.filter(
+        Revision.resource_type == 'Notification',
+        Revision.resource_id.in_([n.id for n in notifications])
+    )
+    self.assertEqual(revisions.count(), 1)
+
+    self.client.get("/_notifications/send_daily_digest")
+    notifications = self._get_notifications(notif_type="comment_created").all()
+    self.assertEqual(len(notifications), 0,
+                     "Found a comment notification that was not sent.")


### PR DESCRIPTION
Notification should be sent if comment created in any model. It should be sent to Admins, Primary Contacts, Secondary Contacts of the object.

~This PR depends on #6320 . It contains cherry picked comments from it~
FE for this ticket in #6404 