### PR TITLE
GGRC-3201: Fix editing of GCA for the Issue object

### DIFF
--- a/src/ggrc/assets/javascripts/models/issue.js
+++ b/src/ggrc/assets/javascripts/models/issue.js
@@ -20,7 +20,8 @@
     is_custom_attributable: true,
     isRoleable: true,
     attributes: {
-      context: 'CMS.Models.Context.stub'
+      context: 'CMS.Models.Context.stub',
+      custom_attribute_values: 'CMS.Models.CustomAttributeValue.stubs'
     },
     tree_view_options: {
       attr_list: can.Model.Cacheable.attr_list.concat([


### PR DESCRIPTION
Steps to reproduce:
1. Have GCA with any type, e.g. date type
2. Have audit with created Issue 
3. Go to the Issues tab > Expand Issue Info pane
4. Edit GCA with date type and save
5. Look at the screen: 'Save' message is displayed but value is not saved
Actual Result: Editing of GCA doesn't work for the Issue object
Expected Result: Editing of GCA should work for the Issue object