### PR TITLE
GGRC-3221 RMC Workflow - Cloned workflow forced verification

### DIFF
--- a/src/ggrc_workflows/models/workflow.py
+++ b/src/ggrc_workflows/models/workflow.py
@@ -210,7 +210,7 @@ class Workflow(mixins.CustomAttributable, HasOwnContext, mixins.Timeboxed,
     return value
 
   @orm.validates('is_verification_needed')
-  def validate_is_verification_needed(self, key, value):
+  def validate_is_verification_needed(self, _, value):
     # pylint: disable=unused-argument
     """Validate is_verification_needed field for Workflow.
 
@@ -222,8 +222,9 @@ class Workflow(mixins.CustomAttributable, HasOwnContext, mixins.Timeboxed,
       return self.IS_VERIFICATION_NEEDED_DEFAULT if value is None else value
     if value is None:
       return self.is_verification_needed
-    if value != self.is_verification_needed:
-      raise ValueError("is_verification_needed value isn't changeble")
+    if self.status != self.DRAFT and value != self.is_verification_needed:
+      raise ValueError("is_verification_needed value isn't changeble "
+                       "on workflow with '{}' status".format(self.status))
     return value
 
   @builder.simple_property
@@ -311,7 +312,8 @@ class Workflow(mixins.CustomAttributable, HasOwnContext, mixins.Timeboxed,
                'end_date',
                'start_date',
                'repeat_every',
-               'unit']
+               'unit',
+               'is_verification_needed']
     target = self.copy_into(_other, columns, **kwargs)
     return target
 

--- a/test/integration/ggrc_workflows/models/test_workflow.py
+++ b/test/integration/ggrc_workflows/models/test_workflow.py
@@ -85,7 +85,7 @@ class TestWorkflow(TestCase):
       ([1], datetime.date(2017, 8, 17)),
       ([0, 1], None),
   )
-  @ddt.unpack
+  @ddt.unpack  # pylint: disable=invalid-name
   def test_recalculate_start_date_on_delete(self, idxs, expected_date):
     start_date_1 = datetime.date(2017, 8, 10)
     start_date_2 = datetime.date(2017, 8, 11)
@@ -131,7 +131,7 @@ class TestWorkflow(TestCase):
       (datetime.date(2017, 8, 6), datetime.date(2017, 8, 11)),
       (datetime.date(2017, 8, 5), datetime.date(2017, 8, 11)),
   )
-  @ddt.unpack
+  @ddt.unpack  # pylint: disable=invalid-name
   def test_recalculate_start_date_on_create(self,
                                             new_start_date,
                                             expected_date):

--- a/test/integration/ggrc_workflows/test_api_calls.py
+++ b/test/integration/ggrc_workflows/test_api_calls.py
@@ -62,7 +62,7 @@ class TestWorkflowsApiPost(TestCase):
     self.assertEqual(response.status_code, 201)
 
   @ddt.data("wrong value", 0, -4)
-  def test_create_wrong_repeat_every_workflow(self, value):
+  def test_create_wrong_repeat_every_workflow(self, value):  # noqa pylint: disable=invalid-name
     """Test case for invalid repeat_every value"""
     data = self.get_workflow_dict()
     data["workflow"]["repeat_every"] = value
@@ -92,7 +92,7 @@ class TestWorkflowsApiPost(TestCase):
 
   # TODO: Api should be able to handle invalid data
   @unittest.skip("Not implemented.")
-  def test_create_task_group_invalid_workflow_data(self):
+  def test_create_task_group_invalid_workflow_data(self):  # noqa pylint: disable=invalid-name
     data = self.get_task_group_dict({"id": -1, "context": {"id": -1}})
     response = self.api.post(all_models.TaskGroup, data)
     self.assert400(response)

--- a/test/integration/ggrc_workflows/test_api_calls.py
+++ b/test/integration/ggrc_workflows/test_api_calls.py
@@ -5,6 +5,7 @@ import datetime
 import unittest
 
 import ddt
+import freezegun
 
 from ggrc import db
 from ggrc.models import all_models
@@ -13,6 +14,7 @@ from integration.ggrc import TestCase
 from integration.ggrc.api_helper import Api
 from integration.ggrc import generator
 from integration.ggrc.models import factories
+from integration.ggrc_workflows import generator as wf_generator
 from integration.ggrc_workflows import WorkflowTestCase
 from integration.ggrc_workflows.models import factories as wf_factories
 
@@ -23,6 +25,7 @@ class TestWorkflowsApiPost(TestCase):
   def setUp(self):
     super(TestWorkflowsApiPost, self).setUp()
     self.api = Api()
+    self.generator = wf_generator.WorkflowsGenerator()
 
   def tearDown(self):
     pass
@@ -221,16 +224,54 @@ class TestWorkflowsApiPost(TestCase):
         all_models.Cycle.query.get(cycle_id).is_verification_needed)
 
   @ddt.data(True, False)
-  def test_change_verification_flag(self, flag):
-    """Check is_verification_needed flag isn't changeable."""
+  def test_change_verification_flag_positive(self, flag):  # noqa pylint: disable=invalid-name
+    """is_verification_needed flag is changeable for DRAFT workflow."""
     with factories.single_commit():
       workflow = wf_factories.WorkflowFactory(is_verification_needed=flag)
+    self.assertEqual(workflow.status, all_models.Workflow.DRAFT)
     workflow_id = workflow.id
     resp = self.api.put(workflow, {"is_verification_needed": not flag})
-    self.assert400(resp)
+    self.assert200(resp)
     self.assertEqual(
-        flag,
-        all_models.Workflow.query.get(workflow_id).is_verification_needed)
+        all_models.Workflow.query.get(workflow_id).is_verification_needed,
+        not flag)
+
+  @ddt.data(True, False)
+  def test_change_verification_flag_negative(self, flag):  # noqa pylint: disable=invalid-name
+    with freezegun.freeze_time("2017-08-10"):
+      with factories.single_commit():
+        workflow = wf_factories.WorkflowFactory(
+            unit=all_models.Workflow.WEEK_UNIT,
+            is_verification_needed=flag,
+            repeat_every=1)
+        wf_factories.TaskGroupTaskFactory(
+            task_group=wf_factories.TaskGroupFactory(
+                context=factories.ContextFactory(),
+                workflow=workflow
+            ),
+            # Two cycles should be created
+            start_date=datetime.date(2017, 8, 3),
+            end_date=datetime.date(2017, 8, 7))
+      workflow_id = workflow.id
+      self.assertEqual(workflow.status, all_models.Workflow.DRAFT)
+      self.generator.activate_workflow(workflow)
+      workflow = all_models.Workflow.query.get(workflow_id)
+      self.assertEqual(workflow.status, all_models.Workflow.ACTIVE)
+      resp = self.api.put(workflow, {"is_verification_needed": not flag})
+      self.assert400(resp)
+      workflow = all_models.Workflow.query.get(workflow_id)
+      self.assertEqual(workflow.is_verification_needed, flag)
+
+      # End all current cycles
+      for cycle in workflow.cycles:
+        self.generator.modify_object(cycle, {'is_current': False})
+      workflow = all_models.Workflow.query.filter(
+          all_models.Workflow.id == workflow_id).first()
+      self.assertEqual(workflow.status, all_models.Workflow.INACTIVE)
+      resp = self.api.put(workflow, {"is_verification_needed": not flag})
+      self.assert400(resp)
+      workflow = all_models.Workflow.query.get(workflow_id)
+      self.assertEqual(workflow.is_verification_needed, flag)
 
   @ddt.data(True, False)
   def test_not_change_vf_flag(self, flag):


### PR DESCRIPTION
Comment by User:

What is the problem / issue?
- Original Workflow (X August) does not require verification, in other words, Need Verification = False
See attachment: Original Workflow 
- However, when user cloned the workflow, the new workflow automatically created as Need Verification = True
See attachment: Cloned Workflow
- User tried to switch from UI, but button is greyed out, user also tried to use CSV upload to change workflow setup. It resulted errors.
See attachment: CSV update error

What is the expected result / outcome? (ie What should happen?)
- Expected the workflow to be cloned EXACTLY the same
- Expected workflow to allow switching verification requirement (until activation)

What is the impact if it is not fixed / implemented? (Quantify the impact, eg, # of hours)
- Redundant workload that added extra 30 sec per task for verification.
With ~20k tasks in system, about 10000 min (or 167 FTE hrs) wasted

Front-end part will be implemented in scope of GGRC-3240. BE part can be merged before FE will be implemented.