### PR TITLE
GGRC-2066 Audit: JS error occurred while clicking "Assign folder" link on Audit Info pane

### DIFF
--- a/src/ggrc_gdrive_integration/assets/javascripts/components/gdrive_folder_picker.js
+++ b/src/ggrc_gdrive_integration/assets/javascripts/components/gdrive_folder_picker.js
@@ -290,10 +290,9 @@
           viewModel.attr('folder_error', null);
         });
       },
-
       'a[data-toggle=gdrive-picker] click': function (el, ev) {
-        var dfd = GGRC.Controllers.GAPI.authorize(['https://www.googleapis.com/auth/drive']);
         var folder_id = el.data('folder-id');
+        var dfd;
 
         // Create and render a Picker object for searching images.
         function createPicker() {
@@ -360,6 +359,7 @@
           }
         }
 
+        dfd = GGRC.Controllers.GAPI.reAuthorize(gapi.auth.getToken());
         dfd.fail(this.unsetCurrent.bind(this))
           .done(function () {
             gapi.load('picker', {

--- a/src/ggrc_gdrive_integration/assets/javascripts/components/gdrive_picker_launcher.js
+++ b/src/ggrc_gdrive_integration/assets/javascripts/components/gdrive_picker_launcher.js
@@ -125,9 +125,7 @@
           }
         }
 
-        dfd = GGRC.Controllers.GAPI.authorize(
-          ['https://www.googleapis.com/auth/drive']
-        );
+        dfd = GGRC.Controllers.GAPI.reAuthorize(gapi.auth.getToken());
         dfd.done(function () {
           gapi.load('picker', {callback: createPicker});
         });

--- a/src/ggrc_gdrive_integration/assets/javascripts/controllers/gapi_controllers.js
+++ b/src/ggrc_gdrive_integration/assets/javascripts/controllers/gapi_controllers.js
@@ -41,6 +41,18 @@
     o2dfd : null,
     drivedfd : null,
     gapidfd : new $.Deferred(),
+    reAuthorize: function (token) {
+      var params = ['https://www.googleapis.com/auth/drive'];
+      var dfd;
+
+      if (_.isEmpty(token)) {
+        dfd = this.authorize(params, true);
+      } else {
+        dfd = this.authorize(params);
+      }
+
+      return dfd;
+    },
     authorize : function(newscopes, force) {
       return this.canonical_instance.authorize(newscopes, force);
     },


### PR DESCRIPTION
_Steps to reproduce:_
1. Create new program
2. Create new Audit on the program page
3. Navigate to Audit's Info pane and click "Assign folder" link
4. Look at the screen

_Actual Result:_ JS error occurred while clicking "Assign folder" link on Audit Info pane
_Expected Result:_ no error is shown

_Note:_ The issue is reproduced if Audit tab is opened (e.g. On My Work page) and user did not use it for some time. Then user returns to Audit tab, expands Audit Info pane and clicks [Assign folder] button. In this case an error is shown.