### PR TITLE
GGRC-3137/2232 Tree view is not automatically refreshed if fill CAs with rich text type

### DIFF
--- a/src/ggrc/assets/javascripts/components/tree/tests/tree-item-custom-attribute_spec.js
+++ b/src/ggrc/assets/javascripts/components/tree/tests/tree-item-custom-attribute_spec.js
@@ -3,7 +3,9 @@
   Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 */
 
-describe('can.mustache.helper.get_custom_attr_value', function () {
+import helpers from './../tree-item-custom-attribute';
+
+describe('helpers.get_custom_attr_value', function () {
   'use strict';
 
   var helper;
@@ -15,7 +17,7 @@ describe('can.mustache.helper.get_custom_attr_value', function () {
   var getHash;
 
   beforeAll(function () {
-    helper = can.Mustache._helpers.get_custom_attr_value.fn;
+    helper = helpers.get_custom_attr_value;
 
     fakeCustomAttrDefs = [{
       definition_type: 'control',
@@ -26,7 +28,7 @@ describe('can.mustache.helper.get_custom_attr_value', function () {
     {
       definition_type: 'control',
       title: 'CheckBox',
-      attribute_type: 'checkbox',
+      attribute_type: 'Checkbox',
       id: 4
     }];
 
@@ -69,20 +71,20 @@ describe('can.mustache.helper.get_custom_attr_value', function () {
     expect(fakeOptions.hash.customAttrItem.reify).toHaveBeenCalled();
   });
 
-  it('return "No" if customAttrItem is undefined', function () {
+  it('return "correctValue"', function () {
     var value;
     fakeOptions.hash = false;
     fakeInstance.custom_attribute_values = [
-      getHash('correctValue', undefined, 'checkbox').customAttrItem
+      getHash('correctValue', 3, 'richText').customAttrItem
     ];
     value = helper(fakeAttr, fakeInstance, fakeOptions);
 
-    expect(value).toEqual('No');
+    expect(value).toEqual('correctValue');
   });
 
-  it('return an empty string if customAttrItem is not undefined', function () {
+  it('return an empty string if customAttrItem is undefined', function () {
     var value;
-    fakeOptions.hash = getHash('correctValue');
+    fakeOptions.hash = getHash();
     value = helper(fakeAttr, fakeInstance, fakeOptions);
 
     expect(value).toEqual('');
@@ -107,7 +109,7 @@ describe('can.mustache.helper.get_custom_attr_value', function () {
     expect(fakeOptions.fn).toHaveBeenCalledWith('correctValue');
   });
 
-  it('returns "on" for CA of type checkbox with value "1"',
+  it('returns "Yes" for CA of type checkbox with value "1"',
     function () {
       var attr = {
         attr_name: 'CheckBox'
@@ -122,29 +124,14 @@ describe('can.mustache.helper.get_custom_attr_value', function () {
       expect(value).toEqual('Yes');
     });
 
-  it('returns "off" for CA of type checkbox with value "0"',
+  it('returns "No" for CA of type checkbox with value "0"',
     function () {
       var attr = {
         attr_name: 'CheckBox'
       };
       var value;
       fakeOptions = {
-        hash: getHash('0', 4, 'checkbox')
-      };
-
-      value = helper(attr, fakeInstance, fakeOptions);
-
-      expect(value).toEqual('No');
-    });
-
-  it('returns "" for CA of type checkbox with value ""',
-    function () {
-      var attr = {
-        attr_name: 'CheckBox'
-      };
-      var value;
-      fakeOptions = {
-        hash: getHash('', 4, 'checkbox')
+        hash: getHash(0, 4, 'checkbox')
       };
 
       value = helper(attr, fakeInstance, fakeOptions);

--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -2281,62 +2281,6 @@ Mustache.registerHelper('get_url_value', function (attr_name, instance) {
     }
   );
 
-/*
-  Used to get the string value for custom attributes
-*/
-  Mustache.registerHelper('get_custom_attr_value',
-    function (attr, instance, options) {
-      var value = '';
-      var definition;
-      var customAttrItem;
-      var getValue;
-      var typeValueMap = {
-        checkbox: ['No', 'Yes']
-      };
-
-      attr = Mustache.resolve(attr);
-      instance = Mustache.resolve(instance);
-      customAttrItem = Mustache.resolve(
-        (options.hash || {}).customAttrItem
-      );
-
-      can.each(GGRC.custom_attr_defs, function (item) {
-        if (item.definition_type === instance.class.table_singular &&
-          item.title === attr.attr_name) {
-          definition = item;
-        }
-      });
-
-      if (definition) {
-        getValue = function (item) {
-          if (!(instance instanceof CMS.Models.Assessment)) {
-            // reify all models with the exception of the Assessment,
-            // because it has a different logic of work with the CA
-            item = item.reify();
-          }
-          if (item.custom_attribute_id === definition.id) {
-            if (definition.attribute_type.startsWith('Map:')) {
-              value = options.fn(options.contexts.add({
-                object: item.attribute_object ?
-                  item.attribute_object.reify() : null
-              }));
-            } else if (typeValueMap[item.attributeType]) {
-              value = typeValueMap[item.attributeType][item.attribute_value] ||
-                'No';
-            }
-          }
-        };
-
-        if (!_.isUndefined(customAttrItem)) {
-          getValue(customAttrItem);
-        } else {
-          can.each(instance.custom_attribute_values, getValue);
-        }
-      }
-
-      return value;
-    });
-
   Mustache.registerHelper('pretty_role_name', function (name) {
     name = Mustache.resolve(name);
     var ROLE_LIST = {

--- a/src/ggrc/assets/javascripts/plugins/utils/ca-utils.js
+++ b/src/ggrc/assets/javascripts/plugins/utils/ca-utils.js
@@ -262,18 +262,17 @@
     }
 
     function applyChangesToCustomAttributeValue(values, changes) {
-      var caValues = can.makeArray(values);
       can.Map.keys(changes).forEach(function (fieldId) {
-        var caValue =
-          caValues
-            .find(function (item) {
-              return item.def.id === Number(fieldId);
-            });
-        if (!caValue) {
-          console.error('Corrupted Date: ', caValues);
-          return;
-        }
-        updateCustomAttributeValue(caValue, changes[fieldId]);
+        values.each(function (item, key) {
+          if (item.def.id === Number(fieldId)) {
+            if (!item) {
+              console.error('Corrupted Date: ', values);
+              return;
+            }
+            updateCustomAttributeValue(item, changes[fieldId]);
+            values.splice(key, 1, values[key]);
+          }
+        });
       });
     }
     return {

--- a/src/ggrc/assets/mustache/components/unified-mapper/mapper-results-item-attrs.mustache
+++ b/src/ggrc/assets/mustache/components/unified-mapper/mapper-results-item-attrs.mustache
@@ -1,13 +1,13 @@
 <div class="flex-box flex-box-single">
   {{#each selectedColumns}}
+    {{#add_to_current_scope thisColumn=this}}
     <div class="attr">
       {{#switch attr_type}}
         {{#case 'custom'}}
-          {{#get_custom_attr_value this instance}}
-            {{#using person=object}}
-              {{>'/static/mustache/people/popover.mustache'}}
-            {{/using}}
-          {{/get_custom_attr_value}}
+          <tree-item-custom-attribute {instance}="instance"
+                                      {values}="instance.custom_attribute_values"
+                                      {column}="thisColumn"
+          ></tree-item-custom-attribute>
         {{/case}}
 
         {{#case 'role'}}
@@ -37,5 +37,6 @@
         {{/case}}
       {{/switch}}
     </div>
+    {{/add_to_current_scope}}
   {{/each}}
 </div>


### PR DESCRIPTION
1. Have GCA with rich text type for Control
2. Go to My work page > Control's tab
3. Set Rich text column to be displayed in tree view
4. Fill GCA field with rich text type on Info pane
Look at the Control's first tier in tree view: data in rich text is not shown

Other case:
1. Have GCA with rich text type for Assessment
2. Go to My work page > Assessments tab
3. Set Rich text column to be displayed in tree view
3. Fill GCA field with rich text type on Info pane
4. Look at the Assessment's first tier in tree view: data in rich text is not shown
Actual Result: Tree view is not automatically refreshed if fill CAs with rich text type
Expected Result: Tree view should be automatically refreshed if fill CAs with rich text type