### PR TITLE
GGRC-3240 'Need Verification for tasks?' should be enabled for non-activated workflow on front-end 

### DIFF
--- a/src/ggrc_workflows/assets/mustache/workflows/modal_content.mustache
+++ b/src/ggrc_workflows/assets/mustache/workflows/modal_content.mustache
@@ -87,7 +87,7 @@
           </label>
           <input type="checkbox" name="is_verification_needed"
             {{#if instance.is_verification_needed}}checked="checked"{{/if}}
-            {{^new_object_form}}disabled{{/new_object_form}}
+            {{#is instance.status 'Active'}}disabled{{/is}}
             tabindex="-1">
           Show Verify button next to tasks
         </div>


### PR DESCRIPTION
'Need Verification for tasks' need to be disabled if workflow is Active only.

Can be merged only after
#6349  