### PR TITLE
GGRC-2836 "There was an error!" error occurs if filter by "TASK DUE DATE" with query that contains incorrect date

### DIFF
--- a/src/ggrc/query/autocast.py
+++ b/src/ggrc/query/autocast.py
@@ -113,8 +113,11 @@ def autocast(exp, target_class):
   extra_exp = None
   current_exp = None
   if extra_parser:
-    left_date, right_date = extra_parser.get_filter_value(
-        unicode(exp['right']), operation) or [None, None]
+    try:
+      left_date, right_date = extra_parser.get_filter_value(
+          unicode(exp['right']), operation) or [None, None]
+    except ValueError:
+      raise BadQueryException(extra_parser.get_value_error_msg(exp['left']))
     if not left_date and not right_date and not any_parser:
       raise BadQueryException(extra_parser.get_value_error_msg(exp['left']))
     if any(o in operation for o in ["~", "="]):

--- a/test/integration/ggrc/services/test_query/test_basic.py
+++ b/test/integration/ggrc/services/test_query/test_basic.py
@@ -151,6 +151,8 @@ class TestAdvancedQueryAPI(TestCase, WithQueryApi):
   @ddt.data(
       ("effective date", ">", "05-18-2015"),
       ("start_date", "=", "2017-06/12"),
+      ("start_date", "=", "2017-33-12"),
+      ("start_date", "=", "2017-06-33"),
   )
   @ddt.unpack
   def test_basic_query_incorrect_date_format(self, field, operation, date):


### PR DESCRIPTION
on hold till ~https://github.com/google/ggrc-core/pull/6359~ will be merged