### PR TITLE
GGRC-3231/GGRC-1644 FE: Update /export page. Add export to spreadsheets option

### DIFF
--- a/src/ggrc/assets/javascripts/components/csv/export.js
+++ b/src/ggrc/assets/javascripts/components/csv/export.js
@@ -29,9 +29,9 @@
     url: '/_service/export_csv',
     type: url.model_type || 'Program',
     only_relevant: false,
-    filename: 'export_objects.csv'
+    filename: 'export_objects.csv',
+    format: 'gdrive'
   });
-  var csvExport;
 
   can.Component.extend({
     tag: 'csv-template',
@@ -58,21 +58,26 @@
         });
       },
       '.import-button click': function (el, ev) {
-        var data;
+        var objects;
         ev.preventDefault();
-        data = _.map(this.scope.attr('selected'), function (el) {
+
+        objects = _.map(this.viewModel.attr('selected'), function (el) {
           return {
             object_name: el.value,
             fields: 'all'
           };
         });
-        if (!data.length) {
+        if (!objects.length) {
           return;
         }
 
         GGRC.Utils.export_request({
-          data: data
-        }).then(function (data) {
+          data: {
+            objects: objects,
+            export_to: 'csv'
+          }
+        })
+        .done(function (data) {
           GGRC.Utils.download('import_template.csv', data);
         })
         .fail(function (data) {
@@ -121,15 +126,10 @@
       '.option-type-selector change': function (el, ev) {
         this.scope.attr('isFilterActive', false);
       },
-      '#export-csv-button click': function (el, ev) {
-        var panels;
-        var query;
+      getObjectsForExport: function () {
+        var panels = this.scope.attr('export.panels.items');
 
-        ev.preventDefault();
-        this.scope.attr('export.loading', true);
-
-        panels = this.scope.attr('export.panels.items');
-        query = _.map(panels, function (panel, index) {
+        return _.map(panels, function (panel, index) {
           var relevantFilter;
           var predicates;
           predicates = _.map(panel.attr('relevant'), function (el) {
@@ -159,11 +159,32 @@
             )
           };
         });
+      },
+      '#export-csv-button click': function (el, ev) {
+        this.scope.attr('export.loading', true);
 
         GGRC.Utils.export_request({
-          data: query
+          data: {
+            objects: this.getObjectsForExport(),
+            export_to: this.scope.attr('export.chosenFormat')
+          }
         }).then(function (data) {
-          GGRC.Utils.download(this.scope.attr('export.filename'), data);
+          var link;
+
+          if (this.scope.attr('export.chosenFormat') === 'gdrive') {
+            data = JSON.parse(data);
+            link = 'https://docs.google.com/spreadsheets/d/' + data.id;
+
+            GGRC.Controllers.Modals.confirm({
+              modal_title: 'Export Completed',
+              modal_description: 'File is exported successfully. ' +
+              'You can view the file here: ' +
+              '<a href="' + link + '" target="_blank">' + link + '</a>',
+              button_view: GGRC.mustache_path + '/modals/close_buttons.mustache'
+            });
+          } else {
+            GGRC.Utils.download(this.scope.attr('export.filename'), data);
+          }
         }.bind(this))
         .fail(function (data) {
           $('body').trigger('ajax:flash', {
@@ -173,6 +194,10 @@
         .always(function () {
           this.scope.attr('export.loading', false);
         }.bind(this));
+      },
+      '#addAnotherObjectType click': function (el, ev) {
+        ev.preventDefault();
+        this.scope.attr('export').dispatch('addPanel');
       }
     }
   });
@@ -181,7 +206,8 @@
     tag: 'export-group',
     template: '<content></content>',
     scope: {
-      _index: 0
+      _index: 0,
+      'export': '@'
     },
     events: {
       inserted: function () {
@@ -225,8 +251,7 @@
         ev.preventDefault();
         this.scope.attr('panels.items').splice(index, 1);
       },
-      '#addAnotherObjectType click': function (el, ev) {
-        ev.preventDefault();
+      '{scope.export} addPanel': function () {
         this.addPanel();
       }
     }

--- a/src/ggrc/assets/javascripts/components/csv/export.js
+++ b/src/ggrc/assets/javascripts/components/csv/export.js
@@ -236,6 +236,14 @@
     tag: 'export-panel',
     template: '<content></content>',
     scope: {
+      define: {
+        first_panel: {
+          type: 'boolean',
+          get: function () {
+            return Number(this.attr('panel_number')) === 0;
+          }
+        }
+      },
       exportable: GGRC.Bootstrap.exportable,
       snapshotable_objects: GGRC.config.snapshotable_objects,
       panel_number: '@',
@@ -294,14 +302,6 @@
         }
 
         this.setSelected();
-      }
-    },
-    helpers: {
-      first_panel: function (options) {
-        if (Number(this.attr('panel_number')) > 0) {
-          return options.fn();
-        }
-        return options.inverse();
       }
     }
   });

--- a/src/ggrc/assets/javascripts/components/csv/export.js
+++ b/src/ggrc/assets/javascripts/components/csv/export.js
@@ -78,11 +78,6 @@ GGRC.Components('csvTemplate', {
       })
       .done(function (data) {
         GGRC.Utils.download('import_template.csv', data);
-      })
-      .fail(function (data) {
-        $('body').trigger('ajax:flash', {
-          error: $(data.responseText.split('\n')[3]).text()
-        });
       });
     },
     '.import-list a click': function (el, ev) {
@@ -169,7 +164,6 @@ GGRC.Components('csvExport', {
         var link;
 
         if (this.viewModel.attr('export.chosenFormat') === 'gdrive') {
-          data = JSON.parse(data);
           link = 'https://docs.google.com/spreadsheets/d/' + data.id;
 
           GGRC.Controllers.Modals.confirm({
@@ -183,11 +177,6 @@ GGRC.Components('csvExport', {
           GGRC.Utils.download(this.viewModel.attr('export.filename'), data);
         }
       }.bind(this))
-      .fail(function (data) {
-        $('body').trigger('ajax:flash', {
-          error: $(data.responseText.split('\n')[3]).text()
-        });
-      })
       .always(function () {
         this.viewModel.attr('export.loading', false);
       }.bind(this));

--- a/src/ggrc/assets/javascripts/components/csv/export.js
+++ b/src/ggrc/assets/javascripts/components/csv/export.js
@@ -3,331 +3,325 @@
   Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 */
 
-(function (can, $) {
-  var url = can.route.deparam(window.location.search.substr(1));
-  var filterModel = can.Map({
-    model_name: 'Program',
-    value: '',
-    filter: {}
-  });
-  var panelModel = can.Map({
-    selected: {},
-    models: null,
-    type: 'Program',
-    filter: '',
-    relevant: can.compute(function () {
-      return new can.List();
-    }),
-    columns: []
-  });
-  var panelsModel = can.Map({
-    items: new can.List()
-  });
-  var exportModel = can.Map({
-    panels: new panelsModel(),
-    loading: false,
+var url = can.route.deparam(window.location.search.substr(1));
+var filterModel = can.Map({
+  model_name: 'Program',
+  value: '',
+  filter: {}
+});
+var panelModel = can.Map({
+  selected: {},
+  models: null,
+  type: 'Program',
+  filter: '',
+  relevant: can.compute(function () {
+    return new can.List();
+  }),
+  columns: []
+});
+var panelsModel = can.Map({
+  items: new can.List()
+});
+var exportModel = can.Map({
+  panels: new panelsModel(),
+  loading: false,
+  url: '/_service/export_csv',
+  type: url.model_type || 'Program',
+  only_relevant: false,
+  filename: 'export_objects.csv',
+  format: 'gdrive'
+});
+
+GGRC.Components('csvTemplate', {
+  tag: 'csv-template',
+  template: '<content></content>',
+  viewModel: {
     url: '/_service/export_csv',
-    type: url.model_type || 'Program',
-    only_relevant: false,
-    filename: 'export_objects.csv',
-    format: 'gdrive'
-  });
+    selected: [],
+    importable: GGRC.Bootstrap.importable
+  },
+  events: {
+    '#importSelect change': function (el, ev) {
+      var $items = el.find(':selected');
+      var selected = this.viewModel.attr('selected');
 
-  can.Component.extend({
-    tag: 'csv-template',
-    template: '<content></content>',
-    scope: {
-      url: '/_service/export_csv',
-      selected: [],
-      importable: GGRC.Bootstrap.importable
-    },
-    events: {
-      '#importSelect change': function (el, ev) {
-        var $items = el.find(':selected');
-        var selected = this.scope.attr('selected');
-
-        $items.each(function () {
-          var $item = $(this);
-          if (_.findWhere(selected, {value: $item.val()})) {
-            return;
-          }
-          return selected.push({
-            name: $item.attr('label'),
-            value: $item.val()
-          });
-        });
-      },
-      '.import-button click': function (el, ev) {
-        var objects;
-        ev.preventDefault();
-
-        objects = _.map(this.viewModel.attr('selected'), function (el) {
-          return {
-            object_name: el.value,
-            fields: 'all'
-          };
-        });
-        if (!objects.length) {
+      $items.each(function () {
+        var $item = $(this);
+        if (_.findWhere(selected, {value: $item.val()})) {
           return;
         }
-
-        GGRC.Utils.export_request({
-          data: {
-            objects: objects,
-            export_to: 'csv'
-          }
-        })
-        .done(function (data) {
-          GGRC.Utils.download('import_template.csv', data);
-        })
-        .fail(function (data) {
-          $('body').trigger('ajax:flash', {
-            error: $(data.responseText.split('\n')[3]).text()
-          });
+        return selected.push({
+          name: $item.attr('label'),
+          value: $item.val()
         });
-      },
-      '.import-list a click': function (el, ev) {
-        var index = el.data('index');
-        var item = this.scope.attr('selected').splice(index, 1)[0];
-
-        ev.preventDefault();
-
-        this.element.find('#importSelect option:selected').each(function () {
-          var $item = $(this);
-          if ($item.val() === item.value) {
-            $item.prop('selected', false);
-          }
-        });
-      }
-    }
-  });
-
-  can.Component.extend({
-    tag: 'csv-export',
-    template: '<content></content>',
-    scope: function () {
-      return {
-        isFilterActive: false,
-        'export': new exportModel()
-      };
+      });
     },
-    events: {
-      toggleIndicator: function (currentFilter) {
-        var isExpression =
-            !!currentFilter &&
-            !!currentFilter.expression.op &&
-            currentFilter.expression.op.name !== 'text_search' &&
-            currentFilter.expression.op.name !== 'exclude_text_search';
-        this.scope.attr('isFilterActive', isExpression);
-      },
-      '.tree-filter__expression-holder input keyup': function (el, ev) {
-        this.toggleIndicator(GGRC.query_parser.parse(el.val()));
-      },
-      '.option-type-selector change': function (el, ev) {
-        this.scope.attr('isFilterActive', false);
-      },
-      getObjectsForExport: function () {
-        var panels = this.scope.attr('export.panels.items');
+    '.import-button click': function (el, ev) {
+      var objects;
+      ev.preventDefault();
 
-        return _.map(panels, function (panel, index) {
-          var relevantFilter;
-          var predicates;
-          predicates = _.map(panel.attr('relevant'), function (el) {
-            var id = el.model_name === '__previous__' ?
-              index - 1 : el.filter.id;
-            return id ? '#' + el.model_name + ',' + id + '#' : null;
-          });
-          if (panel.attr('snapshot_type')) {
-            predicates.push(
-              ' child_type = ' + panel.attr('snapshot_type') + ' '
-            );
-          }
-          relevantFilter = _.reduce(predicates, function (p1, p2) {
-            return p1 + ' AND ' + p2;
-          });
-          return {
-            object_name: panel.type,
-            fields: _.compact(_.map(panel.columns(),
-              function (item, index) {
-                if (panel.selected[index]) {
-                  return item.key;
-                }
-              })),
-            filters: GGRC.query_parser.join_queries(
-              GGRC.query_parser.parse(relevantFilter || ''),
-              GGRC.query_parser.parse(panel.filter || '')
-            )
-          };
-        });
-      },
-      '#export-csv-button click': function (el, ev) {
-        this.scope.attr('export.loading', true);
-
-        GGRC.Utils.export_request({
-          data: {
-            objects: this.getObjectsForExport(),
-            export_to: this.scope.attr('export.chosenFormat')
-          }
-        }).then(function (data) {
-          var link;
-
-          if (this.scope.attr('export.chosenFormat') === 'gdrive') {
-            data = JSON.parse(data);
-            link = 'https://docs.google.com/spreadsheets/d/' + data.id;
-
-            GGRC.Controllers.Modals.confirm({
-              modal_title: 'Export Completed',
-              modal_description: 'File is exported successfully. ' +
-              'You can view the file here: ' +
-              '<a href="' + link + '" target="_blank">' + link + '</a>',
-              button_view: GGRC.mustache_path + '/modals/close_buttons.mustache'
-            });
-          } else {
-            GGRC.Utils.download(this.scope.attr('export.filename'), data);
-          }
-        }.bind(this))
-        .fail(function (data) {
-          $('body').trigger('ajax:flash', {
-            error: $(data.responseText.split('\n')[3]).text()
-          });
-        })
-        .always(function () {
-          this.scope.attr('export.loading', false);
-        }.bind(this));
-      },
-      '#addAnotherObjectType click': function (el, ev) {
-        ev.preventDefault();
-        this.scope.attr('export').dispatch('addPanel');
+      objects = _.map(this.viewModel.attr('selected'), function (el) {
+        return {
+          object_name: el.value,
+          fields: 'all'
+        };
+      });
+      if (!objects.length) {
+        return;
       }
-    }
-  });
 
-  GGRC.Components('exportGroup', {
-    tag: 'export-group',
-    template: '<content></content>',
-    scope: {
-      _index: 0,
-      'export': '@'
-    },
-    events: {
-      inserted: function () {
-        this.addPanel({
-          type: url.model_type || 'Program',
-          isSnapshots: url.isSnapshots
-        });
-      },
-      addPanel: function (data) {
-        var index = this.scope.attr('_index') + 1;
-        var pm;
-
-        data = data || {};
-        if (!data.type) {
-          data.type = 'Program';
-        } else if (data.isSnapshots === 'true') {
-          data.snapshot_type = data.type;
-          data.type = 'Snapshot';
+      GGRC.Utils.export_request({
+        data: {
+          objects: objects,
+          export_to: 'csv'
         }
+      })
+      .done(function (data) {
+        GGRC.Utils.download('import_template.csv', data);
+      })
+      .fail(function (data) {
+        $('body').trigger('ajax:flash', {
+          error: $(data.responseText.split('\n')[3]).text()
+        });
+      });
+    },
+    '.import-list a click': function (el, ev) {
+      var index = el.data('index');
+      var item = this.viewModel.attr('selected').splice(index, 1)[0];
 
-        this.scope.attr('_index', index);
-        pm = new panelModel(data);
-        pm.attr('columns', can.compute(function () {
-          var definitions = GGRC.model_attr_defs[pm.attr('type')];
-          return _.filter(definitions, function (el) {
-            return (!el.import_only) &&
-                   (el.display_name.indexOf('unmap:') === -1);
+      ev.preventDefault();
+
+      this.element.find('#importSelect option:selected').each(function () {
+        var $item = $(this);
+        if ($item.val() === item.value) {
+          $item.prop('selected', false);
+        }
+      });
+    }
+  }
+});
+
+GGRC.Components('csvExport', {
+  tag: 'csv-export',
+  template: '<content></content>',
+  viewModel: {
+    isFilterActive: false,
+    'export': new exportModel()
+  },
+  events: {
+    toggleIndicator: function (currentFilter) {
+      var isExpression =
+          !!currentFilter &&
+          !!currentFilter.expression.op &&
+          currentFilter.expression.op.name !== 'text_search' &&
+          currentFilter.expression.op.name !== 'exclude_text_search';
+      this.viewModel.attr('isFilterActive', isExpression);
+    },
+    '.tree-filter__expression-holder input keyup': function (el, ev) {
+      this.toggleIndicator(GGRC.query_parser.parse(el.val()));
+    },
+    '.option-type-selector change': function (el, ev) {
+      this.viewModel.attr('isFilterActive', false);
+    },
+    getObjectsForExport: function () {
+      var panels = this.viewModel.attr('export.panels.items');
+
+      return _.map(panels, function (panel, index) {
+        var relevantFilter;
+        var predicates;
+        predicates = _.map(panel.attr('relevant'), function (el) {
+          var id = el.model_name === '__previous__' ?
+            index - 1 : el.filter.id;
+          return id ? '#' + el.model_name + ',' + id + '#' : null;
+        });
+        if (panel.attr('snapshot_type')) {
+          predicates.push(
+            ' child_type = ' + panel.attr('snapshot_type') + ' '
+          );
+        }
+        relevantFilter = _.reduce(predicates, function (p1, p2) {
+          return p1 + ' AND ' + p2;
+        });
+        return {
+          object_name: panel.type,
+          fields: _.compact(_.map(panel.columns(),
+            function (item, index) {
+              if (panel.selected[index]) {
+                return item.key;
+              }
+            })),
+          filters: GGRC.query_parser.join_queries(
+            GGRC.query_parser.parse(relevantFilter || ''),
+            GGRC.query_parser.parse(panel.filter || '')
+          )
+        };
+      });
+    },
+    '#export-csv-button click': function (el, ev) {
+      this.viewModel.attr('export.loading', true);
+
+      GGRC.Utils.export_request({
+        data: {
+          objects: this.getObjectsForExport(),
+          export_to: this.viewModel.attr('export.chosenFormat')
+        }
+      }).then(function (data) {
+        var link;
+
+        if (this.viewModel.attr('export.chosenFormat') === 'gdrive') {
+          data = JSON.parse(data);
+          link = 'https://docs.google.com/spreadsheets/d/' + data.id;
+
+          GGRC.Controllers.Modals.confirm({
+            modal_title: 'Export Completed',
+            modal_description: 'File is exported successfully. ' +
+            'You can view the file here: ' +
+            '<a href="' + link + '" target="_blank">' + link + '</a>',
+            button_view: GGRC.mustache_path + '/modals/close_buttons.mustache'
           });
+        } else {
+          GGRC.Utils.download(this.viewModel.attr('export.filename'), data);
+        }
+      }.bind(this))
+      .fail(function (data) {
+        $('body').trigger('ajax:flash', {
+          error: $(data.responseText.split('\n')[3]).text()
+        });
+      })
+      .always(function () {
+        this.viewModel.attr('export.loading', false);
+      }.bind(this));
+    },
+    '#addAnotherObjectType click': function (el, ev) {
+      ev.preventDefault();
+      this.viewModel.attr('export').dispatch('addPanel');
+    }
+  }
+});
+
+GGRC.Components('exportGroup', {
+  tag: 'export-group',
+  template: '<content></content>',
+  viewModel: {
+    index: 0,
+    'export': '@'
+  },
+  events: {
+    inserted: function () {
+      this.addPanel({
+        type: url.model_type || 'Program',
+        isSnapshots: url.isSnapshots
+      });
+    },
+    addPanel: function (data) {
+      var index = this.viewModel.attr('index') + 1;
+      var pm;
+
+      data = data || {};
+      if (!data.type) {
+        data.type = 'Program';
+      } else if (data.isSnapshots === 'true') {
+        data.snapshot_type = data.type;
+        data.type = 'Snapshot';
+      }
+
+      this.viewModel.attr('index', index);
+      pm = new panelModel(data);
+      pm.attr('columns', can.compute(function () {
+        var definitions = GGRC.model_attr_defs[pm.attr('type')];
+        return _.filter(definitions, function (el) {
+          return (!el.import_only) &&
+                 (el.display_name.indexOf('unmap:') === -1);
+        });
+      }));
+      return this.viewModel.attr('panels.items').push(pm);
+    },
+    getIndex: function (el) {
+      return Number($(el.closest('export-panel'))
+        .viewModel().attr('panel_number'));
+    },
+    '.remove_filter_group click': function (el, ev) {
+      var index = this.getIndex(el);
+
+      ev.preventDefault();
+      this.viewModel.attr('panels.items').splice(index, 1);
+    },
+    '{viewModel.export} addPanel': function () {
+      this.addPanel();
+    }
+  }
+});
+
+GGRC.Components('exportPanel', {
+  tag: 'export-panel',
+  template: '<content></content>',
+  viewModel: {
+    define: {
+      first_panel: {
+        type: 'boolean',
+        get: function () {
+          return Number(this.attr('panel_number')) === 0;
+        }
+      }
+    },
+    exportable: GGRC.Bootstrap.exportable,
+    snapshotable_objects: GGRC.config.snapshotable_objects,
+    panel_number: '@',
+    has_parent: false,
+    fetch_relevant_data: function (id, type) {
+      var dfd = CMS.Models[type].findOne({id: id});
+      dfd.then(function (result) {
+        this.attr('item.relevant').push(new filterModel({
+          model_name: url.relevant_type,
+          value: url.relevant_id,
+          filter: result
         }));
-        return this.scope.attr('panels.items').push(pm);
-      },
-      getIndex: function (el) {
-        return Number(el.closest('export-panel')
-          .control().scope.attr('item.index'));
-      },
-      '.remove_filter_group click': function (el, ev) {
-        var elIndex = this.getIndex(el);
-        var index = _.pluck(this.scope.attr('panels.items'), 'index')
-            .indexOf(elIndex);
-
-        ev.preventDefault();
-        this.scope.attr('panels.items').splice(index, 1);
-      },
-      '{scope.export} addPanel': function () {
-        this.addPanel();
-      }
+      }.bind(this));
     }
-  });
+  },
+  events: {
+    inserted: function () {
+      var panelNumber = Number(this.viewModel.attr('panel_number'));
 
-  can.Component.extend({
-    tag: 'export-panel',
-    template: '<content></content>',
-    scope: {
-      define: {
-        first_panel: {
-          type: 'boolean',
-          get: function () {
-            return Number(this.attr('panel_number')) === 0;
-          }
-        }
-      },
-      exportable: GGRC.Bootstrap.exportable,
-      snapshotable_objects: GGRC.config.snapshotable_objects,
-      panel_number: '@',
-      has_parent: false,
-      fetch_relevant_data: function (id, type) {
-        var dfd = CMS.Models[type].findOne({id: id});
-        dfd.then(function (result) {
-          this.attr('item.relevant').push(new filterModel({
-            model_name: url.relevant_type,
-            value: url.relevant_id,
-            filter: result
-          }));
-        }.bind(this));
+      if (!panelNumber && url.relevant_id && url.relevant_type) {
+        this.viewModel.fetch_relevant_data(url.relevant_id, url.relevant_type);
       }
+      this.setSelected();
     },
-    events: {
-      inserted: function () {
-        var panelNumber = Number(this.scope.attr('panel_number'));
+    '[data-action=attribute_select_toggle] click': function (el, ev) {
+      var items = GGRC.model_attr_defs[this.viewModel.attr('item.type')];
+      var isMapping = el.data('type') === 'mappings';
+      var value = el.data('value');
 
-        if (!panelNumber && url.relevant_id && url.relevant_type) {
-          this.scope.fetch_relevant_data(url.relevant_id, url.relevant_type);
+      _.each(items, function (item, index) {
+        if (isMapping && item.type === 'mapping') {
+          this.viewModel.attr('item.selected.' + index, value);
         }
-        this.setSelected();
-      },
-      '[data-action=attribute_select_toggle] click': function (el, ev) {
-        var items = GGRC.model_attr_defs[this.scope.attr('item.type')];
-        var isMapping = el.data('type') === 'mappings';
-        var value = el.data('value');
-
-        _.each(items, function (item, index) {
-          if (isMapping && item.type === 'mapping') {
-            this.scope.attr('item.selected.' + index, value);
-          }
-          if (!isMapping && item.type !== 'mapping') {
-            this.scope.attr('item.selected.' + index, value);
-          }
-        }.bind(this));
-      },
-      setSelected: function () {
-        var selected = _.reduce(this.scope.attr('item').columns(),
-          function (memo, data, index) {
-            memo[index] = true;
-            return memo;
-          }, {});
-        this.scope.attr('item.selected', selected);
-      },
-      '{scope.item} type': function () {
-        this.scope.attr('item.selected', {});
-        this.scope.attr('item.relevant', []);
-        this.scope.attr('item.filter', '');
-        this.scope.attr('item.snapshot_type', '');
-        this.scope.attr('item.has_parent', false);
-
-        if (this.scope.attr('item.type') === 'Snapshot') {
-          this.scope.attr('item.snapshot_type', 'Control');
+        if (!isMapping && item.type !== 'mapping') {
+          this.viewModel.attr('item.selected.' + index, value);
         }
+      }.bind(this));
+    },
+    setSelected: function () {
+      var selected = _.reduce(this.viewModel.attr('item').columns(),
+        function (memo, data, index) {
+          memo[index] = true;
+          return memo;
+        }, {});
+      this.viewModel.attr('item.selected', selected);
+    },
+    '{viewModel.item} type': function () {
+      this.viewModel.attr('item.selected', {});
+      this.viewModel.attr('item.relevant', []);
+      this.viewModel.attr('item.filter', '');
+      this.viewModel.attr('item.snapshot_type', '');
+      this.viewModel.attr('item.has_parent', false);
 
-        this.setSelected();
+      if (this.viewModel.attr('item.type') === 'Snapshot') {
+        this.viewModel.attr('item.snapshot_type', 'Control');
       }
+
+      this.setSelected();
     }
-  });
-})(window.can, window.can.$);
+  }
+});

--- a/src/ggrc/assets/javascripts/components/csv/test/export_spec.js
+++ b/src/ggrc/assets/javascripts/components/csv/test/export_spec.js
@@ -34,28 +34,30 @@ describe('GGRC.Components.exportGroup', function () {
     describe('addPanel() method', function () {
       var method;  // the method under test
       var data;
-      var scope;
+      var viewModel;
 
       beforeEach(function () {
-        scope = new can.Map({
+        viewModel = new can.Map({
           _index: 0,
           panels: {
             items: []
           }
         });
-        method = Component.prototype.events.addPanel.bind({scope: scope});
+        method = Component.prototype.events.addPanel.bind({
+          viewModel: viewModel
+        });
       });
       it('adds panel with "Program" type if data.type is undefined',
         function () {
           data = {};
           method(data);
-          expect(scope.attr('panels.items')[0].type).toEqual('Program');
+          expect(viewModel.attr('panels.items')[0].type).toEqual('Program');
         });
       it('adds panel with type from data if it is defined',
         function () {
           data = {type: 'Audit'};
           method(data);
-          expect(scope.attr('panels.items')[0].type).toEqual('Audit');
+          expect(viewModel.attr('panels.items')[0].type).toEqual('Audit');
         });
       it('adds panel with snapshot_type equal to data.type and' +
       ' type equal to "Snapshot" if it is snapshot', function () {
@@ -64,8 +66,9 @@ describe('GGRC.Components.exportGroup', function () {
           isSnapshots: 'true'
         };
         method(data);
-        expect(scope.attr('panels.items')[0].type).toEqual('Snapshot');
-        expect(scope.attr('panels.items')[0].snapshot_type).toEqual('Control');
+        expect(viewModel.attr('panels.items')[0].type).toEqual('Snapshot');
+        expect(viewModel.attr('panels.items')[0].snapshot_type)
+          .toEqual('Control');
       });
     });
   });

--- a/src/ggrc/assets/javascripts/plugins/ajax_extensions.js
+++ b/src/ggrc/assets/javascripts/plugins/ajax_extensions.js
@@ -122,11 +122,11 @@
     var message;
     var response;
 
-    if (!jqxhr.hasFailCallback || settings.flashOnFail ||
-      (!settings.flashOnFail && jqxhr.flashOnFail)) {
+    if (!jqxhr.hasFailCallback) {
       // TODO: Import produced 'canceled' ajax flash message that needed handling. Will refactor once better method works.
       if (settings.url.indexOf('import') === -1 || exception !== 'canceled') {
-        response = jqxhr.responseJSON;
+        response = jqxhr.responseJSON || JSON.parse(jqxhr.responseText);
+
         message = jqxhr.getResponseHeader('X-Flash-Error') ||
           GGRC.Errors.messages[jqxhr.status] ||
           (response && response.message) ||

--- a/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
+++ b/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
@@ -202,7 +202,6 @@
     export_request: function (request) {
       return $.ajax({
         type: 'POST',
-        dataType: 'text',
         headers: $.extend({
           'Content-Type': 'application/json',
           'X-export-view': 'blocks',

--- a/src/ggrc/assets/mustache/import_export/export.mustache
+++ b/src/ggrc/assets/mustache/import_export/export.mustache
@@ -6,15 +6,6 @@
 <csv-export filename="Export Objects">
 <div class="info no-space">
   <div class="choose-object-wrap">
-    <div class="row-fluid">
-      <div class="span12">
-        <div class="report-title">
-          <h2 class="title">
-            Export Objects
-          </h2>
-        </div>
-      </div>
-    </div>
 
     <export-group panels="export.panels">
       <div class="relevant-filter-group">
@@ -23,13 +14,15 @@
             <export-panel type="{{type}}" item="." panel_number="{{@index}}">
               <div class="row-fluid">
                 <div class="span4">
-                  <h6>Export object type</h6>
-                  <div class="single-line-filter">
-                    {{#first_panel}}
+                  <div class="flex-box">
+                    <h6>Export object type</h6>
+                    {{#unless first_panel}}
                       <button type="submit" class="remove_filter_group">
                         <i class="fa fa-trash"></i>
                       </button>
-                    {{/first_panel}}
+                    {{/unless}}
+                  </div>
+                  <div class="single-line-filter">
                     <select can-value="type" class="input-block-level option-type-selector">
                       {{#exportable}}
                         <option value="{{model_singular}}" label="{{title_plural}}"></option>

--- a/src/ggrc/assets/mustache/import_export/export.mustache
+++ b/src/ggrc/assets/mustache/import_export/export.mustache
@@ -4,10 +4,10 @@
 }}
 
 <csv-export filename="Export Objects">
-<div class="info no-space">
+<div class="info">
   <div class="choose-object-wrap">
 
-    <export-group panels="export.panels">
+    <export-group panels="export.panels" {export}="export">
       <div class="relevant-filter-group">
         {{#each panels.items}}
           <div class="new-relevant-block">
@@ -55,18 +55,26 @@
           </div>
         {{/each}}
       </div>
-      <div class="export-group__actions-wrap">
-        <a href="#" id="addAnotherObjectType" class="addFilterRule btn btn-small btn-white">Add Object Type</a>
-        {{^export.loading}}
-          <button type="submit" id="export-csv-button" class="btn btn-green btn-small">
-            Export Objects
-          </button>
-        {{/loading }}
-        {{#export.loading}}
-          <span {{attach_spinner '{ "radius": 4, "length": 4, "width": 2 }' 'display:inline-block; top: -3px; left: 30px;' }}></span>
-        {{/loading }}
-      </div>
     </export-group>
+  </div>
+</div>
+<div class="export-group__actions-wrap">
+  <div class="export-format-wrap">
+    <h6>Export format</h6>
+    <select class="export-format" can-value="export.chosenFormat">
+        <option value="gdrive" label="Google Sheet"></option>
+        <option value="csv" label="CSV File"></option>
+    </select>
+  </div>
+  <div class="export-buttons-wrap">
+    <a href="#" id="addAnotherObjectType" class="addFilterRule btn btn-small btn-white">Add Object Type</a>
+    {{#unless export.loading}}
+      <button type="submit" id="export-csv-button" class="btn btn-green btn-small">
+        Export Objects
+      </button>
+    {{else}}
+      <span {{attach_spinner '{ "radius": 4, "length": 4, "width": 2 }' 'display:inline-block; top: -3px; left: 30px;' }}></span>
+    {{/unless}}
   </div>
 </div>
 </csv-export>

--- a/src/ggrc/assets/mustache/modals/close_buttons.mustache
+++ b/src/ggrc/assets/mustache/modals/close_buttons.mustache
@@ -9,7 +9,7 @@
     </div>
     <div class="span9">
       <div class="confirm-buttons">
-        <a class="btn" data-dismiss="modal" href="javascript://">Close</a>
+        <a class="btn btn-small btn-white" data-dismiss="modal" href="javascript://">Close</a>
       </div>
     </div>
   </div>

--- a/src/ggrc/assets/mustache/modals/confirm.mustache
+++ b/src/ggrc/assets/mustache/modals/confirm.mustache
@@ -5,6 +5,6 @@
 
 <div class="centered">
 <p>
-{{modal_description}}
+{{{modal_description}}}
 </p>
 </div>

--- a/src/ggrc/assets/stylesheets/modules/_import-export.scss
+++ b/src/ggrc/assets/stylesheets/modules/_import-export.scss
@@ -254,9 +254,18 @@ form.import {
   }
 }
 
+#export_view .info {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+}
+
 .export-group__actions-wrap {
   margin-top: 6px;
   & > .btn-success {
     background-color: $btnGreen;
   }
+}
+
+.remove_filter_group {
+  margin: 0 0 5px 10px;
 }

--- a/src/ggrc/assets/stylesheets/modules/_import-export.scss
+++ b/src/ggrc/assets/stylesheets/modules/_import-export.scss
@@ -259,10 +259,33 @@ form.import {
   box-shadow: none;
 }
 
+.export-add-filter-button {
+  margin: 20px 0 0 30px;
+}
+
 .export-group__actions-wrap {
-  margin-top: 6px;
+  display: flex;
+  align-items: flex-end;
+  margin: 30px 0;
   & > .btn-success {
     background-color: $btnGreen;
+  }
+
+  .export-format-wrap {
+    width: 25%;
+
+    h6 {
+      padding-bottom: 6px;
+    }
+
+    select {
+      width: 100%;
+      margin: 0;
+    }
+  }
+
+  .export-buttons-wrap {
+    margin-left: 20px;
   }
 }
 

--- a/src/ggrc/templates/import_export/export_content.haml
+++ b/src/ggrc/templates/import_export/export_content.haml
@@ -17,4 +17,4 @@
     Export Objects
 
 -block main
-  #csv_export.info
+  #csv_export

--- a/src/ggrc/views/converters.py
+++ b/src/ggrc/views/converters.py
@@ -7,12 +7,12 @@ This module handles all view related function to import and export pages
 including the import/export api endponts.
 """
 
+from logging import getLogger
+
 import httplib2
 
 from apiclient import discovery
 from apiclient import http
-
-from logging import getLogger
 
 from flask import current_app
 from flask import request
@@ -20,6 +20,7 @@ from flask import json
 from flask import render_template
 from werkzeug.exceptions import BadRequest
 
+from ggrc import settings
 from ggrc_gdrive_integration import get_credentials
 from ggrc_gdrive_integration import verify_credentials
 from ggrc.app import app
@@ -37,6 +38,7 @@ logger = getLogger(__name__)
 
 
 def check_required_headers(required_headers):
+  """Check required headers to the current request"""
   errors = []
   for header, valid_values in required_headers.items():
     if header not in request.headers:
@@ -156,24 +158,29 @@ def init_converter_views():
   @app.route("/_service/export_csv", methods=["POST"])
   @login_required
   def handle_export_csv():
+    """Calls export handler"""
     with benchmark("handle export request"):
       return handle_export_request()
 
   @app.route("/_service/import_csv", methods=["POST"])
   @login_required
   def handle_import_csv():
+    """Calls import handler"""
     with benchmark("handle import request"):
       return handle_import_request()
 
   @app.route("/import")
   @login_required
   def import_view():
+    """Get import view"""
     return render_template("import_export/import.haml")
 
   @app.route("/export")
   @login_required
   def export_view():
-    authorize = verify_credentials()
-    if authorize:
-      return authorize
+    """Get export view"""
+    if getattr(settings, "GAPI_CLIENT_ID", None):
+      authorize = verify_credentials()
+      if authorize:
+        return authorize
     return render_template("import_export/export.haml")

--- a/test/integration/ggrc/__init__.py
+++ b/test/integration/ggrc/__init__.py
@@ -136,6 +136,7 @@ class TestCase(BaseTestCase, object):
   def setUp(self):
     self.clear_data()
     self._custom_headers = {}
+    self.headers = {}
 
   def tearDown(self):  # pylint: disable=no-self-use
     db.session.remove()
@@ -248,14 +249,21 @@ class TestCase(BaseTestCase, object):
     return post action response to export_csv service with data argument as
     sended data
     """
-    headers = {
-        'Content-Type': 'application/json',
-        "X-requested-by": "GGRC",
-        "X-export-view": "blocks",
+    if not hasattr(self, "headers") or not self.headers:
+      self.headers = {
+          'Content-Type': 'application/json',
+          "X-requested-by": "GGRC",
+          "X-export-view": "blocks",
+      }
+    if hasattr(self, "_custom_headers"):
+      self.headers.update(self._custom_headers)
+    request_body = {
+        "export_to": "csv",
+        "objects": data
     }
-    headers.update(self._custom_headers)
-    return self.client.post("/_service/export_csv", data=json.dumps(data),
-                            headers=headers)
+    return self.client.post("/_service/export_csv",
+                            data=json.dumps(request_body),
+                            headers=self.headers)
 
   def export_parsed_csv(self, data):
     """returns the dict of list of dict

--- a/test/integration/ggrc/converters/test_ca_import_export.py
+++ b/test/integration/ggrc/converters/test_ca_import_export.py
@@ -173,13 +173,16 @@ class TestCustomAttributeImportExport(TestCase):
     filename = "custom_attribute_tests.csv"
     self.import_file(filename)
 
-    data = [{
-        "object_name": "Product",
-        "filters": {
-            "expression": {},
-        },
-        "fields": "all",
-    }]
+    data = {
+        "export_to": "csv",
+        "objects": [{
+            "object_name": "Product",
+            "filters": {
+                "expression": {},
+            },
+            "fields": "all",
+        }]
+    }
     response = self.client.post("/_service/export_csv", data=dumps(data),
                                 headers=self.headers)
 
@@ -195,17 +198,20 @@ class TestCustomAttributeImportExport(TestCase):
     filename = "custom_attribute_tests.csv"
     self.import_file(filename)
 
-    data = [{
-        "object_name": "Product",
-        "filters": {
-            "expression": {
-                "left": "normal text",
-                "op": {"name": "="},
-                "right": "some text",
+    data = {
+        "export_to": "csv",
+        "objects": [{
+            "object_name": "Product",
+            "filters": {
+                "expression": {
+                    "left": "normal text",
+                    "op": {"name": "="},
+                    "right": "some text",
+                },
             },
-        },
-        "fields": "all",
-    }]
+            "fields": "all",
+        }]
+    }
     response = self.client.post("/_service/export_csv", data=dumps(data),
                                 headers=self.headers)
     self.assert200(response)

--- a/test/integration/ggrc/converters/test_import_assessments.py
+++ b/test/integration/ggrc/converters/test_import_assessments.py
@@ -5,15 +5,14 @@
 
 """Test request import and updates."""
 
+import csv
+import datetime
+import ddt
+import freezegun
+
 from cStringIO import StringIO
 from collections import OrderedDict
 from itertools import izip
-import csv
-import datetime
-
-from flask.json import dumps
-import ddt
-import freezegun
 
 from ggrc import db
 from ggrc import models
@@ -487,10 +486,6 @@ class TestAssessmentExport(TestCase):
     super(TestAssessmentExport, self).setUp()
     self.client.get("/login")
     self.headers = ObjectGenerator.get_header()
-
-  def export_csv(self, data):
-    return self.client.post("/_service/export_csv", data=dumps(data),
-                            headers=self.headers)
 
   def test_simple_export(self):
     """ Test full assessment export with no warnings

--- a/test/integration/ggrc/services/test_collection_post.py
+++ b/test/integration/ggrc/services/test_collection_post.py
@@ -19,7 +19,7 @@ class TestCollectionPost(TestCase):
     return response.headers['Location'][16:]
 
   @staticmethod
-  def headers(*args, **kwargs):
+  def get_headers(*args, **kwargs):
     """Get request headers."""
     ret = list(args)
     ret.append(('X-Requested-By', 'Unit Tests'))
@@ -35,12 +35,12 @@ class TestCollectionPost(TestCase):
         self.mock_url(),
         content_type='application/json',
         data=data,
-        headers=self.headers(),
+        headers=self.get_headers(),
     )
     self.assertStatus(response, 201)
     self.assertIn('Location', response.headers)
     response = self.client.get(
-        self.get_location(response), headers=self.headers())
+        self.get_location(response), headers=self.get_headers())
     self.assert200(response)
     self.assertIn('Content-Type', response.headers)
     self.assertEqual('application/json', response.headers['Content-Type'])
@@ -48,7 +48,7 @@ class TestCollectionPost(TestCase):
     self.assertIn('foo', response.json['services_test_mock_model'])
     self.assertEqual('bar', response.json['services_test_mock_model']['foo'])
     # check the collection, too
-    response = self.client.get(self.mock_url(), headers=self.headers())
+    response = self.client.get(self.mock_url(), headers=self.get_headers())
     self.assert200(response)
     self.assertEqual(
         1, len(response.json['test_model_collection']['test_model']))
@@ -64,13 +64,13 @@ class TestCollectionPost(TestCase):
         self.mock_url(),
         content_type='application/json',
         data=data,
-        headers=self.headers(),
+        headers=self.get_headers(),
     )
     self.assert200(response)
     self.assertEqual(type(response.json), list)
     self.assertEqual(len(response.json), 1)
 
-    response = self.client.get(self.mock_url(), headers=self.headers())
+    response = self.client.get(self.mock_url(), headers=self.get_headers())
     self.assert200(response)
     self.assertEqual(
         1, len(response.json['test_model_collection']['test_model']))
@@ -88,7 +88,7 @@ class TestCollectionPost(TestCase):
         self.mock_url(),
         content_type='application/json',
         data=data,
-        headers=self.headers(),
+        headers=self.get_headers(),
     )
     self.assert200(response)
     self.assertEqual(type(response.json), list)
@@ -97,7 +97,7 @@ class TestCollectionPost(TestCase):
         'bar1', response.json[0][1]['services_test_mock_model']['foo'])
     self.assertEqual(
         'bar2', response.json[1][1]['services_test_mock_model']['foo'])
-    response = self.client.get(self.mock_url(), headers=self.headers())
+    response = self.client.get(self.mock_url(), headers=self.get_headers())
     self.assert200(response)
     self.assertEqual(
         2, len(response.json['test_model_collection']['test_model']))
@@ -119,12 +119,12 @@ class TestCollectionPost(TestCase):
         self.mock_url(),
         content_type='application/json',
         data=data,
-        headers=self.headers(),
+        headers=self.get_headers(),
     )
 
     self.assertEqual(400, response.status_code)
     self.assertEqual([400], [i[0] for i in response.json])
-    response = self.client.get(self.mock_url(), headers=self.headers())
+    response = self.client.get(self.mock_url(), headers=self.get_headers())
     self.assert200(response)
     self.assertEqual(
         0, len(response.json['test_model_collection']['test_model']))
@@ -135,7 +135,7 @@ class TestCollectionPost(TestCase):
         self.mock_url(),
         content_type='application/json',
         data='This is most definitely not valid content.',
-        headers=self.headers(),
+        headers=self.get_headers(),
     )
     self.assert400(response)
     self.assertEqual(
@@ -150,7 +150,7 @@ class TestCollectionPost(TestCase):
         self.mock_url(),
         content_type='text/plain',
         data="Doesn't matter, now does it?",
-        headers=self.headers(),
+        headers=self.get_headers(),
     )
     self.assertStatus(response, 415)
 
@@ -177,7 +177,7 @@ class TestCollectionPost(TestCase):
         "/api/relationships",
         content_type='application/json',
         data=data,
-        headers=self.headers(),
+        headers=self.get_headers(),
     )
 
     self.assert200(response)
@@ -209,7 +209,7 @@ class TestCollectionPost(TestCase):
         "/api/relationships",
         content_type='application/json',
         data=data,
-        headers=self.headers(),
+        headers=self.get_headers(),
     )
 
     self.assert200(response)

--- a/test/selenium/src/lib/constants/element.py
+++ b/test/selenium/src/lib/constants/element.py
@@ -489,3 +489,9 @@ class UnifiedMapperModal(object):
 class GenericWidget(object):
   """Elements' labels and properties for Generic Widget."""
   NO_FILTER_RESULTS = "No results, please check your filter criteria"
+
+
+class ExportPage(object):
+  """Elements' labels and properties for Export Page."""
+  GOOGLE_SHEET = "Google Sheet"
+  CSV = "CSV File"

--- a/test/selenium/src/lib/constants/locator.py
+++ b/test/selenium/src/lib/constants/locator.py
@@ -203,14 +203,17 @@ class ExportPage(object):
   _EXPORT_PAGE = _CONTENT + " #csv_export"
   _EXPORT_PANEL = ".new-relevant-block"
   # general
-  EXPORT_PAGE = (By.CSS_SELECTOR, _EXPORT_PAGE)
-  EXPORT_PANEL = (By.CSS_SELECTOR, _EXPORT_PANEL)
+  EXPORT_PAGE_CSS = (By.CSS_SELECTOR, _EXPORT_PAGE)
+  EXPORT_PANEL_CSS = (By.CSS_SELECTOR, ".choose-object-wrap " + _EXPORT_PANEL)
   # labels
-  TITLE = (By.CSS_SELECTOR, Common.TITLE)
+  TITLE_LBL_CSS = (By.CSS_SELECTOR, Common.TITLE)
   # user input elements
-  BUTTON_ADD_OBJECT_TYPE = (By.CSS_SELECTOR, "#addAnotherObjectType")
-  BUTTON_EXPORT_OBJECTS = (By.CSS_SELECTOR, "#export-csv-button")
-  SPINNER_EXPORT_OBJECTS = (By.CSS_SELECTOR, ".spinner")
+  EXPORT_FORMAT_DD_CSS = (
+      By.CSS_SELECTOR, ".export-format")
+  ADD_OBJECT_TYPE_BTN_CSS = (
+      By.CSS_SELECTOR, "#addAnotherObjectType")
+  EXPORT_OBJECTS_BTN_CSS = (By.CSS_SELECTOR, "#export-csv-button")
+  EXPORT_OBJECTS_SPINNER_CSS = (By.CSS_SELECTOR, ".spinner")
 
 
 class ExtendedInfo(object):

--- a/test/selenium/src/lib/page/export_page.py
+++ b/test/selenium/src/lib/page/export_page.py
@@ -3,7 +3,7 @@
 """Export page with Export Panels."""
 
 from lib import base
-from lib.constants import locator
+from lib.constants import locator, element
 from lib.utils import selenium_utils
 
 
@@ -17,24 +17,37 @@ class ExportPanel(base.Component):
 class ExportPage(base.Page):
   """Export Page."""
   _locators = locator.ExportPage
+  _elements = element.ExportPage
 
   def __init__(self, driver):
     super(ExportPage, self).__init__(driver)
-    self.export_page = self._driver.find_element(*self._locators.EXPORT_PAGE)
+    self.export_page = self._driver.find_element(
+        *self._locators.EXPORT_PAGE_CSS)
     self.export_panels = self.get_list_export_panels()
+    self.export_format_dd = base.DropdownStatic(
+        self.export_page, self._locators.EXPORT_FORMAT_DD_CSS)
+    self.add_obj_type_btn = base.Button(
+        self.export_page, self._locators.ADD_OBJECT_TYPE_BTN_CSS)
+    self.export_objs_btn = base.Button(
+        self.export_page, self._locators.EXPORT_OBJECTS_BTN_CSS)
 
   def get_list_export_panels(self):
     """Get list of all Export Panels witch are presented on Export Page at the
     moment of getting.
     """
     return [ExportPanel(self._driver, exp_panel_el) for exp_panel_el in
-            self.export_page.find_elements(*self._locators.EXPORT_PANEL)]
+            self.export_page.find_elements(*self._locators.EXPORT_PANEL_CSS)]
 
-  def export_objects(self):
-    """Select 'Export Objects' button to confirm export objects to test's
-    temporary directory as CSV file.
+  def click_export_objs(self):
+    """Click to 'Export Objects' button to confirm export objects according to
+    selected before export format (Google Sheet or CSV).
     """
-    button_export_objs = self.export_page.find_element(
-        *self._locators.BUTTON_EXPORT_OBJECTS)
-    base.Button(self._driver, button_export_objs).click()
+    self.export_objs_btn.click()
+    selenium_utils.get_when_invisible(
+        self.export_page, self._locators.EXPORT_OBJECTS_SPINNER_CSS)
     selenium_utils.wait_for_js_to_load(self._driver)
+
+  def export_objs_to_csv(self):
+    """Export objects choosing CSV as exporting format."""
+    self.export_format_dd.select_by_label(self._elements.CSV)
+    self.click_export_objs()

--- a/test/selenium/src/lib/service/webui_service.py
+++ b/test/selenium/src/lib/service/webui_service.py
@@ -183,7 +183,7 @@ class BaseWebUiService(object):
     queries) and export objects to test's temporary directory as CSV file.
     """
     objs_widget = self.open_widget_of_mapped_objs(src_obj)
-    objs_widget.tree_view.open_3bbs().select_export().export_objects()
+    objs_widget.tree_view.open_3bbs().select_export().export_objs_to_csv()
 
   def _get_unified_mapper(self, src_obj):
     """Open generic widget of mapped objects, open unified mapper modal from


### PR DESCRIPTION
**Includes:** https://github.com/google/ggrc-core/pull/6355

Mock-Ups: https://drive.google.com/corp/drive/folders/0B7_NYFVmb896X3lLQ3pHTktMQUk
Acceptance Criteria:
AC1. Add 'Export Format' dropdown on Export page. The dropdownd should have 2 options: 'Google Sheet' (selected by default) and CSV file.
AC2. Results should be exported in Google Sheet if user selected 'Google Sheet' export format. Google sheet should be created in default folder specified by the user in his Drive.
