### PR TITLE
GGRC-3125: Remove Confirmation modal on Assignees,Verifiers and Creators edit for Assessments

### DIFF
--- a/src/ggrc/assets/mustache/components/assessment/assessment-people.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/assessment-people.mustache
@@ -44,21 +44,13 @@
               {instance}="instance"
               {title}="title"
               {people}="results">
-                <confirm-edit-action
-                  (set-edit-mode)="changeEditableMode(true)"
-                  (set-in-progress)="setInProgressState()"
-                  {is-edit-icon-denied}="isEditDenied"
-                  {instance}="instance"
-                  {on-state-change-dfd}="onStateChangeDfd"
-                  {edit-mode}="editMode">
-                    <editable-people-group-header
-                      {editable-mode}="editableMode"
-                      {is-loading}="isLoading"
-                      {can-edit}="canEdit"
-                      {required}="required"
-                      (edit-people-group)="confirmEdit()">
-                    </editable-people-group-header>
-                </confirm-edit-action>
+                <editable-people-group-header
+                  {editable-mode}="editableMode"
+                  {is-loading}="isLoading"
+                  {can-edit}="canEdit"
+                  {required}="required"
+                  (edit-people-group)="changeEditableMode(true)">
+                </editable-people-group-header>
             </editable-people-group>
           {{else}}
             <deletable-people-group


### PR DESCRIPTION
Remove confirmation modal for Assessments in states other than 'InProgress' in the following cases:

Assignees edit,
Creators edit,
Verifiers edit,
Custom roles edit.