### PR TITLE
GGRC-3143 Audit Info pane collapses and tree view refreshes if add auditor to Audit

### DIFF
--- a/src/ggrc/assets/javascripts/components/tree/tree-widget-container.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-widget-container.js
@@ -31,6 +31,7 @@ import template from './templates/tree-widget-container.mustache';
 
   var TreeViewUtils = GGRC.Utils.TreeView;
   var CurrentPageUtils = GGRC.Utils.CurrentPage;
+  var viewModel;
 
   if (!GGRC.tree_view) {
     GGRC.tree_view = new can.Map();
@@ -38,7 +39,7 @@ import template from './templates/tree-widget-container.mustache';
   GGRC.tree_view.attr('basic_model_list', []);
   GGRC.tree_view.attr('sub_tree_for', {});
 
-  var viewModel = can.Map.extend({
+  viewModel = can.Map.extend({
     define: {
       /**
        * Condition that adds into all request to server-side Query API
@@ -413,7 +414,7 @@ import template from './templates/tree-widget-container.mustache';
           parentInstance.on('change', callback);
         } else if (activeTabModel === instance.type) {
           _refresh(true);
-        } else if (isPerson(instance)) {
+        } else if (activeTabModel === 'Person' && isPerson(instance)) {
           parentInstance.refresh().then(function () {
             _refresh();
           });
@@ -445,6 +446,9 @@ import template from './templates/tree-widget-container.mustache';
               srcType === 'Document' || destType === 'Document') {
               return;
             }
+          } else if (instance instanceof CMS.Models.UserRole &&
+            activeTabModel === 'Audit') {
+            return;
           }
 
           _refresh();


### PR DESCRIPTION
_Steps to reproduce:_
1. Have a program
2. Create audit on the program page
3. Expand Audit Info pane and add auditor

_Actual Result:_ Audit Info pane collapses and tree view refreshes if add auditor to Audit

_Expected Result:_ Audit Info pane should not collapse and tree view should not refresh if add auditor to Audit