### PR TITLE
GGRC-2885 Make proper warning for user that Last Assessment Date field should is not editable over import 

### DIFF
--- a/src/ggrc/converters/handlers/handlers.py
+++ b/src/ggrc/converters/handlers/handlers.py
@@ -292,6 +292,8 @@ class DateColumnHandler(ColumnHandler):
       if not value:
         return
       parsed_value = parse(value)
+      if self.key == "last_assessment_date":
+        self.check_last_asmnt_date(parsed_value)
       if type(getattr(self.row_converter.obj, self.key, None)) is date:
         return parsed_value.date()
       else:
@@ -304,6 +306,19 @@ class DateColumnHandler(ColumnHandler):
     if value:
       return value.strftime("%m/%d/%Y")
     return ""
+
+  def check_last_asmnt_date(self, new_last_asmnt_date):
+    """Check if the new object don't contain changed Last Assessment Date."""
+    old_last_asmnt_date = getattr(
+        self.row_converter.obj, "last_assessment_date", None
+    )
+    date_modified = old_last_asmnt_date and new_last_asmnt_date and \
+        old_last_asmnt_date.date() != new_last_asmnt_date.date()
+    if date_modified:
+      self.add_warning(
+          errors.UNMODIFIABLE_COLUMN,
+          column_name=self.display_name,
+      )
 
 
 class EmailColumnHandler(ColumnHandler):

--- a/test/integration/ggrc/data_platform/test_last_assessment_date.py
+++ b/test/integration/ggrc/data_platform/test_last_assessment_date.py
@@ -31,6 +31,7 @@ import freezegun
 import itertools
 
 from ggrc import models
+from ggrc.converters import errors
 from integration.ggrc import TestCase
 from integration.ggrc.api_helper import Api
 from integration.ggrc import generator
@@ -222,6 +223,16 @@ class TestLastAssessmentDate(TestCase):
         ("code", "Control_1"),
         ("Last Assessment Date", "06/06/2017"),
     ]))
+    self._check_csv_response(resp, {
+        "Control": {
+            "row_warnings": {
+                errors.UNMODIFIABLE_COLUMN.format(
+                    line=3, column_name="Last Assessment Date"
+                )
+            }
+        }
+    })
+
     control = models.Control.query.filter(
         models.Control.slug == "Control_1"
     ).one()


### PR DESCRIPTION
Steps to reproduce:
1. Export control that has last assessment date
2. Open csv file and change 'last assessment date' column
3. Import csv file with control
Actual Result: User is not informed that Last Assessment Date field is not editable over import
Expected Result: User should be informed that Last Assessment Date field is not editable over import.
Proposal:
1. Inform user in csv file that 'Last Assessment Date' is not editable.
	'Last assessment date' column - NOTE: cannot change 'Last assessment date';
or
2. Warning during analyzing csv file to import 
