### PR TITLE
QUICK-FIX Fix randomly failing integration tests

### DIFF
--- a/test/integration/ggrc/services/test_query/test_basic.py
+++ b/test/integration/ggrc/services/test_query/test_basic.py
@@ -268,6 +268,9 @@ class TestAdvancedQueryAPI(TestCase, WithQueryApi):
         make_query_dict(limit=["10", 21]),
         "Program",
     )
+    self._sort_sublists(programs_10_21_str["values"])
+    self._sort_sublists(programs_10_str_21["values"])
+    self._sort_sublists(programs_10_21["values"])
 
     self.assertDictEqual(programs_10_21_str, programs_10_21)
     self.assertDictEqual(programs_10_str_21, programs_10_21)
@@ -350,6 +353,21 @@ class TestAdvancedQueryAPI(TestCase, WithQueryApi):
     # the titles are sorted descending with desc=True
     self.assertListEqual(titles_desc, list(reversed(titles_asc)))
 
+  @classmethod
+  def _sort_sublists(cls, data_list):
+    """Sort lists contained in result list.
+
+    This function is meant to sort sublists in a list of results. Those
+    sublists can only be a list of stubs from given objects. So when testing
+    an order for a list, if sub elements such as related_sources, don't have
+    the same order they must not raise an exception.
+    """
+    for line in data_list:
+      for item in line.iteritems():
+        if isinstance(item, list):
+          item.sort(key=lambda x: x["id"])
+    return data_list
+
   def test_order_by_several_fields(self):
     """Results get sorted by two fields at once."""
     regulations = self._get_first_result_set(
@@ -363,13 +381,14 @@ class TestAdvancedQueryAPI(TestCase, WithQueryApi):
         self._make_query_dict("Regulation"),
         "Regulation", "values",
     )
+    expected = sorted(sorted(regulations_unsorted,
+                             key=itemgetter("title")),
+                      key=itemgetter("notes"),
+                      reverse=True)
 
     self.assertListEqual(
-        regulations,
-        sorted(sorted(regulations_unsorted,
-                      key=itemgetter("title")),
-               key=itemgetter("notes"),
-               reverse=True),
+        self._sort_sublists(regulations),
+        self._sort_sublists(expected),
     )
 
   def test_order_by_related_titled(self):
@@ -392,11 +411,12 @@ class TestAdvancedQueryAPI(TestCase, WithQueryApi):
     )
     program_id_title = {program["id"]: program["title"]
                         for program in programs}
+    expected = sorted(sorted(audits_unsorted, key=itemgetter("id")),
+                      key=lambda a: program_id_title[a["program"]["id"]])
 
     self.assertListEqual(
-        audits_title,
-        sorted(sorted(audits_unsorted, key=itemgetter("id")),
-               key=lambda a: program_id_title[a["program"]["id"]]),
+        self._sort_sublists(audits_title),
+        self._sort_sublists(expected)
     )
 
   def test_query_order_by_owners(self):
@@ -423,11 +443,12 @@ class TestAdvancedQueryAPI(TestCase, WithQueryApi):
         ]
         for policy in policies_unsorted
     }
+    expected = sorted(sorted(policies_unsorted, key=itemgetter("id")),
+                      key=lambda p: policy_id_owner[p["id"]])
 
     self.assertListEqual(
-        policies_owner,
-        sorted(sorted(policies_unsorted, key=itemgetter("id")),
-               key=lambda p: policy_id_owner[p["id"]]),
+        self._sort_sublists(policies_owner),
+        self._sort_sublists(expected),
     )
 
   def test_query_order_by_assignee(self):
@@ -454,10 +475,12 @@ class TestAdvancedQueryAPI(TestCase, WithQueryApi):
         for control in controls_unsorted
     }
 
+    expected = sorted(sorted(controls_unsorted, key=itemgetter("id")),
+                      key=lambda p: control_id_assignee[p["id"]])
+
     self.assertListEqual(
-        controls_by_assignee,
-        sorted(sorted(controls_unsorted, key=itemgetter("id")),
-               key=lambda p: control_id_assignee[p["id"]]),
+        self._sort_sublists(controls_by_assignee),
+        self._sort_sublists(expected),
     )
 
   def test_filter_control_by_frequency(self):
@@ -491,7 +514,10 @@ class TestAdvancedQueryAPI(TestCase, WithQueryApi):
       return options_map[freq["id"]]
 
     controls_ordered_2 = sorted(controls_unordered, key=sort_key)
-    self.assertListEqual(controls_ordered_1, controls_ordered_2)
+    self.assertListEqual(
+        self._sort_sublists(controls_ordered_1),
+        self._sort_sublists(controls_ordered_2),
+    )
 
   def test_filter_control_by_kind(self):
     """Test correct filtering by kind/nature"""
@@ -524,7 +550,10 @@ class TestAdvancedQueryAPI(TestCase, WithQueryApi):
       return options_map[kind["id"]]
 
     controls_ordered_2 = sorted(controls_unordered, key=sort_key)
-    self.assertListEqual(controls_ordered_1, controls_ordered_2)
+    self.assertListEqual(
+        self._sort_sublists(controls_ordered_1),
+        self._sort_sublists(controls_ordered_2),
+    )
 
   def test_filter_control_by_means(self):
     """Test correct filtering by means"""
@@ -557,7 +586,10 @@ class TestAdvancedQueryAPI(TestCase, WithQueryApi):
       return options_map[kind["id"]]
 
     controls_ordered_2 = sorted(controls_unordered, key=sort_key)
-    self.assertListEqual(controls_ordered_1, controls_ordered_2)
+    self.assertListEqual(
+        self._sort_sublists(controls_ordered_1),
+        self._sort_sublists(controls_ordered_2),
+    )
 
   def test_filter_control_by_key_control(self):
     """Test correct filtering by SIGNIFICANCE field"""
@@ -584,7 +616,10 @@ class TestAdvancedQueryAPI(TestCase, WithQueryApi):
                                 key=lambda ctrl: (ctrl["key_control"] is None,
                                                   ctrl["key_control"]),
                                 reverse=True)
-    self.assertListEqual(controls_ordered_1, controls_ordered_2)
+    self.assertListEqual(
+        self._sort_sublists(controls_ordered_1),
+        self._sort_sublists(controls_ordered_2),
+    )
 
   def test_filter_control_by_fraud_related(self):
     """Test correct filtering by fraud_related field"""
@@ -610,7 +645,10 @@ class TestAdvancedQueryAPI(TestCase, WithQueryApi):
     )
     controls_ordered_2 = sorted(controls_unordered,
                                 key=lambda ctrl: ctrl["fraud_related"])
-    self.assertListEqual(controls_ordered_1, controls_ordered_2)
+    self.assertListEqual(
+        self._sort_sublists(controls_ordered_1),
+        self._sort_sublists(controls_ordered_2),
+    )
 
   def test_filter_control_by_assertions(self):
     """Test correct filtering by assertions field"""
@@ -643,7 +681,10 @@ class TestAdvancedQueryAPI(TestCase, WithQueryApi):
       return (None, val["id"])
 
     controls_ordered_2 = sorted(controls_unordered, key=sort_key)
-    self.assertListEqual(controls_ordered_1, controls_ordered_2)
+    self.assertListEqual(
+        self._sort_sublists(controls_ordered_1),
+        self._sort_sublists(controls_ordered_2),
+    )
 
   def test_filter_control_by_categories(self):
     """Test correct filtering by categories field"""
@@ -677,7 +718,10 @@ class TestAdvancedQueryAPI(TestCase, WithQueryApi):
       return (None, val["id"])
 
     controls_ordered_2 = sorted(controls_unordered, key=sort_key)
-    self.assertListEqual(controls_ordered_1, controls_ordered_2)
+    self.assertListEqual(
+        self._sort_sublists(controls_ordered_1),
+        self._sort_sublists(controls_ordered_2),
+    )
 
   def test_query_count(self):
     """The value of "count" is same for "values" and "count" queries."""


### PR DESCRIPTION
This commit makes sure that random order in a sub-list does not affect
the result outcome. Since all elements contain items with unordered list
such as related_sources and related_destinations, we must make sure to
ignore those when making an order comparison.

Example of a test result that failed randomly:

```
    u'type': u'Program'},
    u'related_destinations': [],
    u'related_sources': [{u'context_id': None,
+                         u'href': u'/api/relationships/2699',
+                         u'id': 2699,
+                         u'type': u'Relationship'},
+                        {u'context_id': None,
                          u'href': u'/api/relationships/2698',
                          u'id': 2698,
                          u'type': u'Relationship'},
                         {u'context_id': None,
                          u'href': u'/api/relationships/2689',
                          u'id': 2689,
-                         u'type': u'Relationship'},
-                        {u'context_id': None,
-                         u'href': u'/api/relationships/2699',
-                         u'id': 2699,
                          u'type': u'Relationship'}],
    u'report_end_date': u'2015-06-06',
    u'report_start_date': u'2015-06-05',
```