### PR TITLE
GGRC-3274 Remove invalid client keys

### DIFF
--- a/src/ggrc_gdrive_integration/settings/development.py
+++ b/src/ggrc_gdrive_integration/settings/development.py
@@ -5,8 +5,8 @@ import os
 EXTENSIONS = ['ggrc_gdrive_integration']
 exports = ["GAPI_KEY", "GAPI_CLIENT_ID", "GAPI_ADMIN_GROUP"]
 
-GAPI_KEY = os.environ.get('GGRC_GAPI_KEY', "AIzaSyAndAzs1E-8brJdESH7YSuvrj3A8Y-MZCg")
-GAPI_CLIENT_ID = os.environ.get('GGRC_GAPI_CLIENT_ID', "831270113958.apps.googleusercontent.com")
-#Admin group gets writer access to all
-GAPI_ADMIN_GROUP = os.environ.get('GGRC_GAPI_ADMIN_GROUP', "ggrc-dev@reciprocitylabs.com")
-GAPI_CLIENT_SECRET = os.environ.get('GGRC_GAPI_CLIENT_SECRET', "no-default")
+GAPI_KEY = os.environ.get('GGRC_GAPI_KEY', "")
+GAPI_CLIENT_ID = os.environ.get('GGRC_GAPI_CLIENT_ID', "")
+# Admin group gets writer access to all
+GAPI_ADMIN_GROUP = os.environ.get('GGRC_GAPI_ADMIN_GROUP', "")
+GAPI_CLIENT_SECRET = os.environ.get('GGRC_GAPI_CLIENT_SECRET', "")


### PR DESCRIPTION
We should not store any private keys in our repo.

From now on keys will have to be specially set up on each dev environment.