### PR TITLE
GGRC-3162: Fix alignment issue for GCA of checkbox type

### DIFF
--- a/src/ggrc/assets/stylesheets/components/inline/_inline.scss
+++ b/src/ggrc/assets/stylesheets/components/inline/_inline.scss
@@ -9,7 +9,7 @@ inline-edit-control {
       display: flex;
       align-items: center;
       line-height: 28px;
-      min-height: 28px;
+      min-height: 42px;
 
       label {
         margin: 0;


### PR DESCRIPTION
Alignment issue for GCA of 'checkbox' type:
leaping effect when user hovers over CA title (should be short enough).

![apzuwhk6vl2](https://user-images.githubusercontent.com/24203972/30054979-9c880a6a-9236-11e7-8bbe-e68d1a4e6d9a.png)

![hcelbrfgpqb](https://user-images.githubusercontent.com/24203972/30054989-a702dc72-9236-11e7-9e78-fff7233f66d2.png)
