### PR TITLE
GGRC-3207,3268 Add 'Last Updated By' column to all objects

### DIFF
--- a/src/ggrc/converters/column_handlers.py
+++ b/src/ggrc/converters/column_handlers.py
@@ -107,6 +107,9 @@ _DEFAULT_COLUMN_HANDLERS_DICT = {
     "test_plan_procedure": boolean.CheckboxColumnHandler,
     "title": handlers.RequiredTextColumnHandler,
     "verify_frequency": handlers.OptionColumnHandler,
+    "updated_at": handlers.ExportOnlyDateColumnHandler,
+    "created_at": handlers.ExportOnlyDateColumnHandler,
+    "modified_by": handlers.ExportOnlyUserColumnHandler,
 
     # Mapping column handlers
     "__mapping__:person": handlers.PersonMappingColumnHandler,

--- a/src/ggrc/converters/handlers/handlers.py
+++ b/src/ggrc/converters/handlers/handlers.py
@@ -810,6 +810,11 @@ class DocumentsColumnHandler(ColumnHandler):
 
 class ExportOnlyColumnHandler(ColumnHandler):
 
+  def __init__(self, *args, **kwargs):
+    kwargs["view_only"] = True
+    kwargs["mandatory"] = False
+    super(ExportOnlyColumnHandler, self).__init__(*args, **kwargs)
+
   def parse_item(self):
     pass
 
@@ -824,3 +829,17 @@ class ExportOnlyColumnHandler(ColumnHandler):
 
   def set_value(self):
     pass
+
+
+ExportOnlyDateColumnHandler = type(
+    "ExportOnlyDateColumnHandler",
+    (ExportOnlyColumnHandler, DateColumnHandler),
+    {}
+)
+
+
+ExportOnlyUserColumnHandler = type(
+    "ExportOnlyUserColumnHandler",
+    (ExportOnlyColumnHandler, UserColumnHandler),
+    {}
+)

--- a/src/ggrc/models/mixins/__init__.py
+++ b/src/ggrc/models/mixins/__init__.py
@@ -169,14 +169,9 @@ class ChangeTracked(object):
   ]
 
   _aliases = {
-      "updated_at": {
-          "display_name": "Last Updated",
-          "filter_only": True,
-      },
-      "created_at": {
-          "display_name": "Created Date",
-          "filter_only": True,
-      },
+      "updated_at": "Last Updated",
+      "created_at": "Created Date",
+      "modified_by": "Last Updated By",
   }
 
   @classmethod
@@ -629,7 +624,6 @@ class Base(ChangeTracked, ContextRBAC, Identifiable):
       except AttributeError:
         pass
     res["display_name"] = self.display_name
-
     return res
 
   def log_json(self):

--- a/src/ggrc/models/mixins/__init__.py
+++ b/src/ggrc/models/mixins/__init__.py
@@ -307,7 +307,6 @@ class Hierarchical(object):
 
 class Timeboxed(object):
   """Mixin that defines `start_date` and `end_date` fields."""
-
   @declared_attr
   def start_date(cls):  # pylint: disable=no-self-argument
     return deferred(db.Column(db.Date), cls.__name__)
@@ -316,11 +315,11 @@ class Timeboxed(object):
   def end_date(cls):  # pylint: disable=no-self-argument
     return deferred(db.Column(db.Date), cls.__name__)
 
+  # pylint: disable=unused-argument,no-self-use
   @validates('start_date', 'end_date')
   def validate_date(self, key, value):
-    if isinstance(value, datetime.datetime):
-      value = value.date()
-    return value
+    return value.date() if isinstance(value, datetime.datetime) else value
+  # pylint: enable=unused-argument,no-self-use
 
   # REST properties
   _api_attrs = reflection.ApiAttributes('start_date', 'end_date')
@@ -790,7 +789,7 @@ class Slugged(Base):
     for o in session.new:
       if isinstance(o, Slugged) and (o.slug is None or o.slug == ''):
         o.slug = str(uuid1())
-        o._replace_slug = True
+        o._replace_slug = True  # pylint: disable=protected-access
 
   @classmethod
   def ensure_slug_after_flush_postexec(cls, session, flush_context):

--- a/src/ggrc/models/reflection.py
+++ b/src/ggrc/models/reflection.py
@@ -79,6 +79,9 @@ ATTRIBUTE_ORDER = (
     "frequency",
     "notify_on_change",
     "is_verification_needed",
+    "updated_at",
+    "modified_by",
+    "created_at",
     "delete",
     "repeat_every",
     "unit",
@@ -412,10 +415,13 @@ class AttributeInfo(object):
 
     for key, value in aliases:
       column = object_class.__table__.columns.get(key)
+      mandatory = False
+      if column is not None:
+        mandatory = not column.nullable and not column.default
       definition = {
           "display_name": value,
           "attr_name": key,
-          "mandatory": False if column is None else not column.nullable,
+          "mandatory": mandatory,
           "unique": key in unique_columns,
           "description": "",
           "type": cls.Type.PROPERTY,

--- a/test/integration/ggrc/converters/test_export_snapshots.py
+++ b/test/integration/ggrc/converters/test_export_snapshots.py
@@ -123,6 +123,9 @@ class TestExportSnapshots(TestCase):
             "Secondary Contacts": u"creator@example.com",
             "Principal Assignees": u"creator@example.com",
             "Secondary Assignees": u"creator@example.com",
+            'Created Date': control.created_at.strftime("%Y-%m-%dT%H:%M:%S"),
+            'Last Updated': control.updated_at.strftime("%Y-%m-%dT%H:%M:%S"),
+            'Last Updated By': control.modified_by.email,
         }
         for snapshot, control in zip(snapshots, controls)
     }
@@ -236,6 +239,9 @@ class TestExportSnapshots(TestCase):
             "Secondary Contacts": u"",
             "Principal Assignees": u"",
             "Secondary Assignees": u"",
+            'Created Date': control.created_at.strftime("%Y-%m-%dT%H:%M:%S"),
+            'Last Updated': control.updated_at.strftime("%Y-%m-%dT%H:%M:%S"),
+            'Last Updated By': "",
         }
         for snapshot, control in zip(snapshots, controls)
     }
@@ -422,6 +428,9 @@ class TestExportSnapshots(TestCase):
           "Assertions": u"",
           "Categories": u"",
           "Evidence File": u"",
+          'Created Date': control.created_at.strftime("%Y-%m-%dT%H:%M:%S"),
+          'Last Updated': control.updated_at.strftime("%Y-%m-%dT%H:%M:%S"),
+          'Last Updated By': "",
       }
       control_dicts[control.slug].update(**control_acr_people[control.slug])
 

--- a/test/integration/ggrc/converters/test_import_assessments.py
+++ b/test/integration/ggrc/converters/test_import_assessments.py
@@ -5,24 +5,23 @@
 
 """Test request import and updates."""
 
+from cStringIO import StringIO
+from collections import OrderedDict
+from itertools import izip
 import csv
 import datetime
-import freezegun
 
-from collections import OrderedDict
-from cStringIO import StringIO
-from itertools import izip
-
-import ddt
 from flask.json import dumps
+import ddt
+import freezegun
 
 from ggrc import db
 from ggrc import models
 from ggrc.converters import errors
 
-from integration.ggrc.models import factories
 from integration.ggrc import TestCase
 from integration.ggrc.generator import ObjectGenerator
+from integration.ggrc.models import factories
 
 
 @ddt.ddt

--- a/test/integration/ggrc/converters/test_import_helpers.py
+++ b/test/integration/ggrc/converters/test_import_helpers.py
@@ -97,6 +97,9 @@ class TestCustomAttributesDefinitions(TestCase):
         "Delete",
         "Primary Contacts",
         "Secondary Contacts",
+        'Created Date',
+        'Last Updated',
+        'Last Updated By',
     }
     expected_names = element_names.union(mapping_names).union(unmapping_names)
     self.assertEqual(expected_names, display_names)
@@ -146,6 +149,9 @@ class TestCustomAttributesDefinitions(TestCase):
         "Delete",
         "Primary Contacts",
         "Secondary Contacts",
+        'Created Date',
+        'Last Updated',
+        'Last Updated By',
     }
     expected_names = element_names.union(mapping_names).union(unmapping_names)
     self.assertEqual(expected_names, display_names)
@@ -312,6 +318,9 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Delete",
         "Primary Contacts",
         "Secondary Contacts",
+        'Created Date',
+        'Last Updated',
+        'Last Updated By',
     }
     expected_fields = {
         "mandatory": {
@@ -347,7 +356,10 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Archived",
         "Delete",
         "Evidence URL",
-        "Evidence File"
+        "Evidence File",
+        'Created Date',
+        'Last Updated',
+        'Last Updated By',
     }
     expected_fields = {
         "mandatory": {
@@ -377,6 +389,9 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Custom Attributes",
         "Code",
         "Archived",
+        'Created Date',
+        'Last Updated',
+        'Last Updated By',
         "Delete",
     }
     expected_fields = {
@@ -430,6 +445,9 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Delete",
         "Primary Contacts",
         "Secondary Contacts",
+        'Created Date',
+        'Last Updated',
+        'Last Updated By',
     }
     expected_fields = {
         "mandatory": {
@@ -470,6 +488,9 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Delete",
         "Primary Contacts",
         "Secondary Contacts",
+        'Created Date',
+        'Last Updated',
+        'Last Updated By',
     }
     expected_fields = {
         "mandatory": {
@@ -505,6 +526,9 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Delete",
         "Primary Contacts",
         "Secondary Contacts",
+        'Created Date',
+        'Last Updated',
+        'Last Updated By',
     }
     self._test_single_object(models.Policy, names, self.COMMON_EXPECTED)
 
@@ -524,6 +548,9 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Delete",
         "Primary Contacts",
         "Secondary Contacts",
+        'Created Date',
+        'Last Updated',
+        'Last Updated By',
     }
     self._test_single_object(models.Clause, names, self.COMMON_EXPECTED)
 
@@ -542,6 +569,9 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Delete",
         "Primary Contacts",
         "Secondary Contacts",
+        'Created Date',
+        'Last Updated',
+        'Last Updated By',
     }
     self._test_single_object(models.Section, names, self.COMMON_EXPECTED)
 
@@ -573,6 +603,9 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Secondary Contacts",
         "Principal Assignees",
         "Secondary Assignees",
+        'Created Date',
+        'Last Updated',
+        'Last Updated By',
     }
     self._test_single_object(models.Control, names, self.COMMON_EXPECTED)
 
@@ -591,6 +624,9 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Delete",
         "Primary Contacts",
         "Secondary Contacts",
+        'Created Date',
+        'Last Updated',
+        'Last Updated By',
     }
     self._test_single_object(models.Objective, names, self.COMMON_EXPECTED)
 
@@ -601,6 +637,9 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Email",
         "Company",
         "Role",
+        'Created Date',
+        'Last Updated',
+        'Last Updated By',
     }
     expected_fields = {
         "mandatory": {
@@ -629,6 +668,9 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Delete",
         "Primary Contacts",
         "Secondary Contacts",
+        'Created Date',
+        'Last Updated',
+        'Last Updated By',
     }
     self._test_single_object(models.System, names, self.COMMON_EXPECTED)
 
@@ -649,6 +691,9 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Delete",
         "Primary Contacts",
         "Secondary Contacts",
+        'Created Date',
+        'Last Updated',
+        'Last Updated By',
     }
     self._test_single_object(models.Process, names, self.COMMON_EXPECTED)
 
@@ -669,6 +714,9 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Delete",
         "Primary Contacts",
         "Secondary Contacts",
+        'Created Date',
+        'Last Updated',
+        'Last Updated By',
     }
     self._test_single_object(models.Product, names, self.COMMON_EXPECTED)
 
@@ -688,6 +736,9 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Title",
         "Primary Contacts",
         "Secondary Contacts",
+        'Created Date',
+        'Last Updated',
+        'Last Updated By',
     }
     expected_fields = {
         "mandatory": {
@@ -731,6 +782,9 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Delete",
         "Primary Contacts",
         "Secondary Contacts",
+        'Created Date',
+        'Last Updated',
+        'Last Updated By',
     }
     self._test_single_object(model, names, self.COMMON_EXPECTED)
 
@@ -760,6 +814,9 @@ class TestRiskAssessmentColumnDefinitions(TestCase):
         "Code",
         "Program",
         "Delete",
+        'Created Date',
+        'Last Updated',
+        'Last Updated By',
     }
     self.assertEqual(expected_names, display_names)
     vals = {val["display_name"]: val for val in definitions.itervalues()}

--- a/test/integration/ggrc/converters/test_snapshot_block.py
+++ b/test/integration/ggrc/converters/test_snapshot_block.py
@@ -96,6 +96,9 @@ class TestSnapshotBlockConverter(TestCase):
         ('reference_url', 'Reference URL'),
         ('verify_frequency', 'Frequency'),
         ('document_evidence', 'Evidence File'),
+        ('updated_at', 'Last Updated'),
+        ('modified_by', 'Last Updated By'),
+        ('created_at', 'Created Date'),
     ]
     ac_roles = db.session.query(all_models.AccessControlRole.name).filter(
         all_models.AccessControlRole.object_type == "Control"

--- a/test/integration/ggrc_workflows/converters/test_column_definitions.py
+++ b/test/integration/ggrc_workflows/converters/test_column_definitions.py
@@ -55,6 +55,9 @@ class TestWorkflowObjectColumnDefinitions(TestCase):
         "Code",
         "Delete",
         "Need Verification",
+        'Created Date',
+        'Last Updated',
+        'Last Updated By',
     }
     self.assertEqual(expected_names, display_names)
     vals = {val["display_name"]: val for val in definitions.itervalues()}
@@ -77,6 +80,9 @@ class TestWorkflowObjectColumnDefinitions(TestCase):
         "Workflow",
         "Objects",
         "Delete",
+        'Created Date',
+        'Last Updated',
+        'Last Updated By',
     }
     self.assertEqual(expected_names, display_names)
     vals = {val["display_name"]: val for val in definitions.itervalues()}
@@ -97,6 +103,9 @@ class TestWorkflowObjectColumnDefinitions(TestCase):
         "Task Group",
         "Code",
         "Delete",
+        'Created Date',
+        'Last Updated',
+        'Last Updated By',
     }
     self.assertEqual(expected_names, display_names)
     vals = {val["display_name"]: val for val in definitions.itervalues()}
@@ -126,6 +135,9 @@ class TestWorkflowObjectColumnDefinitions(TestCase):
         "Task Group",
         "State",
         "Delete",
+        'Created Date',
+        'Last Updated',
+        'Last Updated By',
     }
     expected_names = element_names.union(mapping_names).union(unmapping_names)
     self.assertEqual(expected_names, display_names)


### PR DESCRIPTION
Add column 'Last Updated by'. Column should be displayed after 'Last Updated' column.
'Last Update by' column should be added for all objects that have 'Last Updated' column.
Allow user to sort objects by 'Last Updated by'.
Allow user to search / filter by last updated by + advanced search.
Allow user to import / export 'Last Updated by' attribute.
Show emails in 'Last Updated by' column.