### PR TITLE
GGRC-3207/GGRC-3279 Add 'Last Updated By' column to all objects

### DIFF
--- a/src/ggrc/assets/javascripts/models/assessment.js
+++ b/src/ggrc/assets/javascripts/models/assessment.js
@@ -53,25 +53,29 @@
         attr_name: 'updated_at',
         order: 9
       }, {
+        attr_title: 'Last Updated By',
+        attr_name: 'modified_by',
+        order: 10
+      }, {
         attr_title: 'Conclusion: Design',
         attr_name: 'design',
-        order: 13
+        order: 14
       }, {
         attr_title: 'Conclusion: Operation',
         attr_name: 'operationally',
-        order: 14
+        order: 15
       }, {
         attr_title: 'Finished Date',
         attr_name: 'finished_date',
-        order: 11
+        order: 12
       }, {
         attr_title: 'Verified Date',
         attr_name: 'verified_date',
-        order: 10
+        order: 11
       }, {
         attr_title: 'Reference URL',
         attr_name: 'reference_url',
-        order: 12
+        order: 13
       }, {
         attr_title: 'Creators',
         attr_name: 'creators',

--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -107,6 +107,9 @@
         attr_title: 'Last Updated',
         attr_name: 'updated_at'
       }, {
+        attr_title: 'Last Updated By',
+        attr_name: 'modified_by'
+      }, {
         attr_title: 'Planned Start Date',
         attr_name: 'start_date'
       }, {

--- a/src/ggrc/assets/javascripts/models/cacheable.js
+++ b/src/ggrc/assets/javascripts/models/cacheable.js
@@ -134,6 +134,11 @@
         order: 70
       },
       {
+        attr_title: 'Last Updated By',
+        attr_name: 'modified_by',
+        order: 71
+      },
+      {
         attr_title: 'Review State',
         attr_name: 'os_state',
         order: 80

--- a/src/ggrc/assets/mustache/audits/tree-item-attr.mustache
+++ b/src/ggrc/assets/mustache/audits/tree-item-attr.mustache
@@ -9,6 +9,11 @@
           {{peopleStr}}
       </tree-people-list-field>
   {{/case}}
+  {{#case 'modified_by'}}
+      <tree-people-list-field {source}="instance.modified_by">
+          {{peopleStr}}
+      </tree-people-list-field>
+  {{/case}}
   {{#case 'report_period'}}
     {{#if instance.report_start_date}}
       {{#if instance.report_end_date}}

--- a/src/ggrc/assets/mustache/base_objects/tree-item-attr.mustache
+++ b/src/ggrc/assets/mustache/base_objects/tree-item-attr.mustache
@@ -52,6 +52,11 @@
           {{peopleStr}}
       </tree-people-list-field>
   {{/case}}
+  {{#case 'modified_by'}}
+      <tree-people-list-field {source}="instance.modified_by">
+          {{peopleStr}}
+      </tree-people-list-field>
+  {{/case}}
   {{#case 'created_at'}}
       {{localize_date instance.created_at}}
   {{/case}}

--- a/src/ggrc/assets/mustache/controls/tree-item-attr.mustache
+++ b/src/ggrc/assets/mustache/controls/tree-item-attr.mustache
@@ -25,6 +25,11 @@
           {{peopleStr}}
       </tree-people-list-field>
   {{/case}}
+  {{#case 'modified_by'}}
+      <tree-people-list-field {source}="instance.modified_by">
+          {{peopleStr}}
+      </tree-people-list-field>
+  {{/case}}
   {{#case 'kind'}}
     {{#using kind=instance.kind}}
       {{kind.title}}

--- a/src/ggrc/assets/mustache/directives/tree-item-attr.mustache
+++ b/src/ggrc/assets/mustache/directives/tree-item-attr.mustache
@@ -14,6 +14,11 @@
           {{peopleStr}}
       </tree-people-list-field>
   {{/case}}
+  {{#case 'modified_by'}}
+      <tree-people-list-field {source}="instance.modified_by">
+          {{peopleStr}}
+      </tree-people-list-field>
+  {{/case}}
   {{#case 'status'}}
     {{#using status=instance.status}}
       <span class="state-value-dot {{addclass 'state-' status separator=''}}">

--- a/src/ggrc/assets/mustache/objectives/tree-item-attr.mustache
+++ b/src/ggrc/assets/mustache/objectives/tree-item-attr.mustache
@@ -14,6 +14,11 @@
           {{peopleStr}}
       </tree-people-list-field>
   {{/case}}
+  {{#case 'modified_by'}}
+      <tree-people-list-field {source}="instance.modified_by">
+          {{peopleStr}}
+      </tree-people-list-field>
+  {{/case}}
   {{#case 'last_assessment_date'}}
     {{localize_date instance.last_assessment_date}}
   {{/case}}

--- a/src/ggrc/assets/mustache/programs/tree-item-attr.mustache
+++ b/src/ggrc/assets/mustache/programs/tree-item-attr.mustache
@@ -26,6 +26,11 @@
       <tree-people-list-field {source}="instance.secondary_contact">
       </tree-people-list-field>
   {{/case}}
+  {{#case 'modified_by'}}
+      <tree-people-list-field {source}="instance.modified_by">
+          {{peopleStr}}
+      </tree-people-list-field>
+  {{/case}}
   {{#case 'status'}}
     {{#using status=instance.status}}
       <span class="state-value-dot {{addclass 'state-' status separator=''}}">

--- a/src/ggrc/assets/mustache/sections/tree-item-attr.mustache
+++ b/src/ggrc/assets/mustache/sections/tree-item-attr.mustache
@@ -12,6 +12,11 @@
       <tree-people-list-field {source}="instance.secondary_contact">
       </tree-people-list-field>
   {{/case}}
+  {{#case 'modified_by'}}
+      <tree-people-list-field {source}="instance.modified_by">
+          {{peopleStr}}
+      </tree-people-list-field>
+  {{/case}}
   {{#case 'status'}}
     {{#using status=instance.status}}
       <span class="state-value-dot {{addclass 'state-' status separator=''}}">

--- a/src/ggrc_workflows/assets/javascripts/models/cycle_models.js
+++ b/src/ggrc_workflows/assets/javascripts/models/cycle_models.js
@@ -330,6 +330,11 @@
           attr_title: 'Task last updated',
           attr_name: 'updated_at',
           attr_sort_field: 'task last updated'
+        },
+        {
+          attr_title: 'Task last updated by',
+          attr_name: 'modified_by',
+          attr_sort_field: 'task last updated by'
         }
       ],
       display_attr_names: ['title', 'assignee', 'start_date', 'end_date'],

--- a/src/ggrc_workflows/assets/javascripts/models/workflow.js
+++ b/src/ggrc_workflows/assets/javascripts/models/workflow.js
@@ -46,7 +46,8 @@
         {attr_title: 'Manager', attr_name: 'owner', attr_sort_field: ''},
         {attr_title: 'Code', attr_name: 'slug'},
         {attr_title: 'State', attr_name: 'status'},
-        {attr_title: 'Last Updated', attr_name: 'updated_at'}
+        {attr_title: 'Last Updated', attr_name: 'updated_at'},
+        {attr_title: 'Last Updated By', attr_name: 'modified_by'}
       ]
     },
 

--- a/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/tree-item-attr.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/tree-item-attr.mustache
@@ -20,6 +20,11 @@
           {{peopleStr}}
       </tree-people-list-field>
   {{/case}}
+  {{#case 'modified_by'}}
+      <tree-people-list-field {source}="instance.modified_by">
+          {{peopleStr}}
+      </tree-people-list-field>
+  {{/case}}
   {{#case 'status'}}
     {{#using status=instance.status}}
       <span class="state-value-dot {{addclass 'state-' status separator=''}}">

--- a/src/ggrc_workflows/assets/mustache/task_groups/tree-item-attr.mustache
+++ b/src/ggrc_workflows/assets/mustache/task_groups/tree-item-attr.mustache
@@ -9,6 +9,11 @@
           {{peopleStr}}
       </tree-people-list-field>
   {{/case}}
+  {{#case 'modified_by'}}
+      <tree-people-list-field {source}="instance.modified_by">
+          {{peopleStr}}
+      </tree-people-list-field>
+  {{/case}}
   {{#case 'status'}}
     {{#using status=instance.status}}
       <span class="state-value-dot {{addclass 'state-' status separator=''}}">

--- a/src/ggrc_workflows/assets/mustache/workflows/tree-item-attr.mustache
+++ b/src/ggrc_workflows/assets/mustache/workflows/tree-item-attr.mustache
@@ -19,6 +19,11 @@
       {{/each}}
     {{/with_mapping}}
   {{/case}}
+  {{#case 'modified_by'}}
+      <tree-people-list-field {source}="instance.modified_by">
+          {{peopleStr}}
+      </tree-people-list-field>
+  {{/case}}
   {{#case 'repeat'}}
       <repeat-on-summary {unit}="instance.unit" {repeat-every}="instance.repeat_every"
                          hide-repeat-off="false" class="repeat-cell">


### PR DESCRIPTION
_Acceptance criteria:_
- Add column 'Last Updated by' to tree view. Column should be displayed after 'Last Updated' column.
- 'Last Updated by' should be hidden in tree view by default. User should be able to add it via 'Set visible fields' pop-up.
- 'Last Update by' column should be added for all objects that have 'Last Updated' column.
- Allow user to sort objects by 'Last Updated by'.
- Allow user to search / filter by 'Last Updated By'