### PR TITLE
GGRC-3280 Improve audit export performance

### DIFF
--- a/src/ggrc/converters/base_block.py
+++ b/src/ggrc/converters/base_block.py
@@ -12,6 +12,7 @@ from collections import defaultdict
 from collections import OrderedDict
 from collections import Counter
 
+from cached_property import cached_property
 from sqlalchemy import exc
 from sqlalchemy import or_
 from sqlalchemy import and_
@@ -311,6 +312,23 @@ class BlockConverter(object):
     if self._owners_cache is None:
       self._owners_cache = self._create_owners_cache()
     return self._owners_cache
+
+  @cached_property
+  def mapped_snapshots(self):
+    """Cached property of mapped to audit snapshots"""
+    # pylint: disable=protected-access
+    snapshots = defaultdict(lambda: defaultdict(set))
+    query = db.session.query(
+        models.Revision.resource_slug,
+        models.Snapshot.parent_id,
+        models.Snapshot.child_type,
+    ).join(models.Snapshot).filter(
+        models.Snapshot.parent_type == self.object_class.__name__,
+        models.Snapshot.parent_id.in_(self.object_ids),
+    )
+    for slug, parent_id, child_type in query:
+      snapshots[parent_id][child_type].add(slug)
+    return snapshots
 
   def check_for_duplicate_columns(self, raw_headers):
     """Check for duplicate column names in the current block.

--- a/test/integration/ggrc/converters/test_export_audit.py
+++ b/test/integration/ggrc/converters/test_export_audit.py
@@ -50,4 +50,4 @@ class TestAuditExport(TestCase):
     for type_, slugs in mapped_slugs.items():
       mapping_name = "map:{}".format(utils.title_from_camelcase(type_))
       self.assertIn(mapping_name, audit_data)
-      self.assertEqual(audit_data[mapping_name], "\n".join(slugs))
+      self.assertEqual(audit_data[mapping_name], "\n".join(sorted(slugs)))


### PR DESCRIPTION
Basically ever mapping cell in the audit export that was added now triggers a new db query. 
With 20 mapped objects and a few hundred audits, that makes a few thousand queries too many.
Now the handler for mapped snapshots must be changed to prefetch all snapshot data that will be needed for export in a single query (but no more data than is actually needed) and then the cache should be used to fill out the csv cells instead of running a db query for each cell.
