### PR TITLE
GGRC-3287 Fix missing Assessment Template dropdown in Generate Assessment modal

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment_templates/assessment_templates.js
+++ b/src/ggrc/assets/javascripts/components/assessment_templates/assessment_templates.js
@@ -3,6 +3,8 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 */
 
+import '../dropdown/dropdown';
+
 (function (can, GGRC) {
   'use strict';
 


### PR DESCRIPTION
Due to move to webpack dropdown element was not imported in the the
Generate Assessment modal.