### PR TITLE
QUICK-FIX Fix floating integration test bug "A conflicting state is already present in the identity map for key"

### DIFF
--- a/test/integration/ggrc/snapshotter/test_indexing.py
+++ b/test/integration/ggrc/snapshotter/test_indexing.py
@@ -173,9 +173,8 @@ class TestSnapshotIndexing(SnapshotterBaseTestCase):
 
   def test_update_indexing(self):
     """Test that creating objects results in full index"""
-    custom_attribute_defs = self.create_custom_attribute_definitions()
-
     self._import_file("snapshotter_create.csv")
+    custom_attribute_defs = self.create_custom_attribute_definitions()
 
     access_group = db.session.query(models.AccessGroup).filter(
         models.AccessGroup.title == "ag-2"


### PR DESCRIPTION
Periodically integration test "test_update_indexing" fail with following stack trace:

FAIL: Test that creating objects results in full index
18:03:02.885

18:03:02.885
Traceback (most recent call last):
18:03:02.885
File "/vagrant/test/integration/ggrc/snapshotter/test_indexing.py", line 200, in test_update_indexing
18:03:02.885
factories.CustomAttributeValueFactory(**value)
18:03:02.885
File "/vagrant-dev/opt/dev_virtualenv/local/lib/python2.7/site-packages/factory/base.py", line 69, in __call__
18:03:02.885
return cls.create(**kwargs)
18:03:02.885
File "/vagrant-dev/opt/dev_virtualenv/local/lib/python2.7/site-packages/factory/base.py", line 623, in create
18:03:02.885
return cls._generate(True, attrs)
18:03:02.885
File "/vagrant-dev/opt/dev_virtualenv/local/lib/python2.7/site-packages/factory/base.py", line 548, in _generate
18:03:02.885
obj = cls._prepare(create, **attrs)
18:03:02.885
File "/vagrant-dev/opt/dev_virtualenv/local/lib/python2.7/site-packages/factory/base.py", line 523, in _prepare
18:03:02.885
return cls._create(model_class, *args, **kwargs)
18:03:02.885
File "/vagrant/test/integration/ggrc/models/model_factory.py", line 27, in _create
18:03:02.885
instance = target_class(*args, **kwargs)
18:03:02.885
File "<string>", line 4, in __init__
18:03:02.885
File "/vagrant/src/packages/sqlalchemy/orm/state.py", line 260, in _initialize_instance
18:03:02.885
return manager.original_init(*mixed[1:], **kwargs)
18:03:02.885
File "/vagrant/src/packages/sqlalchemy/ext/declarative/base.py", line 526, in _declarative_constructor
18:03:02.885
setattr(self, k, kwargs[k])
18:03:02.885
File "/vagrant/src/ggrc/models/custom_attribute_value.py", line 121, in attributable
18:03:02.885
return setattr(self, self.attributable_attr, value)
18:03:02.885
File "/vagrant/src/packages/sqlalchemy/orm/attributes.py", line 226, in __set__
18:03:02.885
instance_dict(instance), value, None)
18:03:02.885
File "/vagrant/src/packages/sqlalchemy/orm/attributes.py", line 812, in set
18:03:02.885
value = self.fire_replace_event(state, dict_, value, old, initiator)
18:03:02.885
File "/vagrant/src/packages/sqlalchemy/orm/attributes.py", line 832, in fire_replace_event
18:03:02.885
state, value, previous, initiator or self._replace_token)
18:03:02.885
File "/vagrant/src/packages/sqlalchemy/orm/attributes.py", line 1148, in emit_backref_from_scalar_set_event
18:03:02.885
passive=PASSIVE_NO_FETCH)
18:03:02.885
File "/vagrant/src/packages/sqlalchemy/orm/attributes.py", line 975, in append
18:03:02.885
value = self.fire_append_event(state, dict_, value, initiator)
18:03:02.885
File "/vagrant/src/packages/sqlalchemy/orm/attributes.py", line 929, in fire_append_event
18:03:02.885
value = fn(state, value, initiator or self._append_token)
18:03:02.885
File "/vagrant/src/packages/sqlalchemy/orm/unitofwork.py", line 45, in append
18:03:02.885
sess._save_or_update_state(item_state)
18:03:02.885
File "/vagrant/src/packages/sqlalchemy/orm/session.py", line 1511, in _save_or_update_state
18:03:02.885
self._save_or_update_impl(st_)
18:03:02.885
File "/vagrant/src/packages/sqlalchemy/orm/session.py", line 1761, in _save_or_update_impl
18:03:02.885
self._update_impl(state)
18:03:02.885
File "/vagrant/src/packages/sqlalchemy/orm/session.py", line 1754, in _update_impl
18:03:02.885
self.identity_map.add(state)
18:03:02.885
File "/vagrant/src/packages/sqlalchemy/orm/identity.py", line 123, in add
18:03:02.885
% (key, ))
18:03:02.885
AssertionError: A conflicting state is already present in the identity map for key (<class 'ggrc.models.custom_attribute_definition.CustomAttributeDefinition'>, (366L,))