### PR TITLE
GGRC-3275 Confirmation message is displayed if there were no changes on asmt new/edit modal

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment/assessment-people.js
+++ b/src/ggrc/assets/javascripts/components/assessment/assessment-people.js
@@ -28,6 +28,7 @@ import '../custom-roles/custom-roles-modal';
           value: ''
         }
       },
+      roleConflicts: false,
       infoPaneMode: true,
       withDetails: false,
       instance: {}

--- a/src/ggrc/assets/javascripts/components/object-list/object-list.js
+++ b/src/ggrc/assets/javascripts/components/object-list/object-list.js
@@ -78,7 +78,7 @@
        */
       clearSelection: function () {
         this.attr('items').forEach(function (item) {
-          item.attr('isSelected', false);
+          item.removeAttr('isSelected', false);
         });
         this.attr('selectedItem.el', null);
         this.attr('selectedItem.data', null);

--- a/src/ggrc/assets/javascripts/components/related-objects/related-people-mapping.js
+++ b/src/ggrc/assets/javascripts/components/related-objects/related-people-mapping.js
@@ -22,6 +22,7 @@
       editableMode: false,
       isLoading: false,
       validation: {mandatory: true, empty: true, valid: true},
+      roleConflicts: false,
 
       backUpPendings: [],
       saveChanges: function () {
@@ -107,7 +108,7 @@
             });
             var hasConflicts = !_.isEmpty(
                 _.intersection.apply(null, rolePeople));
-            this.instance.attr('roleConflicts', hasConflicts);
+            this.attr('roleConflicts', hasConflicts);
           }.bind(this));
         }
 
@@ -121,6 +122,7 @@
             roleBinding.list.bind('change', checkConflicts.bind(this));
           }.bind(this));
         }.bind(this));
+        checkConflicts.call(this);
       },
 
       /**

--- a/src/ggrc/assets/javascripts/controllers/modals_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/modals_controller.js
@@ -349,6 +349,7 @@ import '../components/access_control_list/access_control_list_roles_helper'
     reset_form: function (setFieldsCb) {
       var $textArea = $('#program_description');
       var editorData = $textArea.data('wysihtml5');
+      var preloadDfd;
 
       // If the modal is closed early, the element no longer exists
       if (this.element) {
@@ -363,8 +364,14 @@ import '../components/access_control_list/access_control_list_roles_helper'
         this.options.instance.attr('_transient', new can.Observe({}));
       }
       if (this.options.instance.form_preload) {
-        this.options.instance.form_preload(this.options.new_object_form,
+        preloadDfd = this.options.instance.form_preload(
+          this.options.new_object_form,
           this.options.object_params);
+        if (preloadDfd) {
+          preloadDfd.then(function () {
+            this.options.instance.backup();
+          }.bind(this))
+        }
       }
 
       // The rich text editor's content is not a "normal" form field, thus

--- a/src/ggrc/assets/javascripts/models/assessment.js
+++ b/src/ggrc/assets/javascripts/models/assessment.js
@@ -172,6 +172,7 @@
     model: function (attributes, oldModel) {
       var model;
       var id;
+      var backup;
       if (!attributes) {
         return;
       }
@@ -190,6 +191,14 @@
       model = oldModel && can.isFunction(oldModel.attr) ?
         oldModel.attr(attributes) :
           new this(attributes);
+
+      // Sometimes we are updating model partially and asynchronous
+      // for example when we load relationships.
+      // In this case we have to update backup to solve isDirty issues.
+      backup = model._backupStore();
+      if (backup) {
+        _.extend(backup, attributes);
+      }
 
       // This is a temporary solution
       if (attributes.documents) {

--- a/src/ggrc/assets/javascripts/models/assessment.js
+++ b/src/ggrc/assets/javascripts/models/assessment.js
@@ -308,7 +308,7 @@
           markForAddition(this, currentUser, 'Creator');
         }
 
-        this.audit.findAuditors().then(function (list) {
+        return this.audit.findAuditors().then(function (list) {
           list.forEach(function (item) {
             var type = 'Verifier';
             if (item.person === auditLead) {
@@ -320,9 +320,9 @@
             markForAddition(self, item.person, type);
           });
         });
-      } else {
-        markForAddition(this, currentUser, 'Creator');
       }
+
+      markForAddition(this, currentUser, 'Creator');
 
       function markForAddition(instance, user, type) {
         instance.mark_for_addition('related_objects_as_destination', user, {

--- a/src/ggrc/assets/javascripts/models/tests/assessment_model_spec.js
+++ b/src/ggrc/assets/javascripts/models/tests/assessment_model_spec.js
@@ -154,4 +154,45 @@ describe('CMS.Models.Assessment', function () {
       expect(actual[0].attr()).toEqual({id: 5, email: 'john@doe.com'});
     });
   });
+
+  describe('model() method', function () {
+    it('does not update backup if backup was not created', function () {
+      spyOn(_, 'extend');
+      CMS.Models.Assessment.model({data: 'test'}, new CMS.Models.Assessment());
+      expect(_.extend).not.toHaveBeenCalled();
+    });
+
+    it('updates backup if backup was created', function () {
+      var model = new CMS.Models.Assessment();
+      model.backup();
+      CMS.Models.Assessment.model({data: 'test'}, model);
+      expect(model._backupStore().data).toBe('test');
+    });
+  });
+
+  describe('form_preload() method', function () {
+    it('returns deferred indicates that auditors have been found', function () {
+      var model = new CMS.Models.Assessment();
+      var findAuditorsCallbackDfd = 'findAuditorsCallbackDfd';
+      var findAuditorsDfd = function () {
+        return {
+          then: function () {
+            return findAuditorsCallbackDfd;
+          }
+        };
+      };
+      var result;
+      spyOn(model, 'before_create');
+      spyOn(model, 'mark_for_addition');
+
+      model.attr('audit', new can.Map({
+        findAuditors: findAuditorsDfd,
+        contact: new can.Map()
+      }));
+
+      result = model.form_preload(true);
+
+      expect(result).toBe(findAuditorsCallbackDfd);
+    });
+  });
 });

--- a/src/ggrc/assets/javascripts/plugins/utils/ca-utils.js
+++ b/src/ggrc/assets/javascripts/plugins/utils/ca-utils.js
@@ -158,8 +158,10 @@
         if (type === 'dropdown') {
           valueData.validationConfig = {};
           options.forEach(function (item, index) {
-            valueData.validationConfig[item] =
-              Number(optionsRequirements[index]);
+            if (optionsRequirements[index]) {
+              valueData.validationConfig[item] =
+                Number(optionsRequirements[index]);
+            }
           });
         }
         return valueData;

--- a/src/ggrc/assets/mustache/components/assessment/assessment-people.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/assessment-people.mustache
@@ -5,7 +5,7 @@
 
 <div class="flex-box flex-box-multi">
     <div class="flex-box width-100">
-      {{#instance.roleConflicts}}
+      {{#if roleConflicts}}
         <div class="width-100">
           <div class="alert alert-verifier">
             <p>
@@ -13,7 +13,7 @@
             </p>
           </div>
         </div>
-      {{/instance.roleConflicts}}
+      {{/if}}
     </div>
 
     <div class="people-groups">
@@ -25,6 +25,7 @@
           mapping="mapping"
           type="type"
           heading="title"
+          {(role-conflicts)}="roleConflicts"
           {{#if required}}
             required="true"
             validate="validate"


### PR DESCRIPTION
Steps to reproduce:
1. On the audit page Invoke New/Edit assessment modal window
2. Without any updates click [x] button to close the window
3. Look at the screen
*Actual Result:* Confirmation message is displayed if there were no changes on asmt new/edit modal
*Expected Result:* Confirmation message should not displayed if there were no changes on asmt new/edit modal

I have found 3 issues broke changes tracking on edit modal:
1) mistake in preparing CustomAttributes.
2) relationships are loading asynchronous, as result - model is changing when backup was already created.
3) some components use instance to store service flags.

Also there were 2 issues on create modal:
1) object-list component sets 'isSelected' flag but does not remove it correctly.
2) default users are initializing asynchronous, as result - model is changing when backup was already created.