### PR TITLE
GGRC-3171 Show message on attributes modification (Edit Assessment pop-up)

### DIFF
--- a/src/ggrc/assets/javascripts/components/related-objects/related-documents.js
+++ b/src/ggrc/assets/javascripts/components/related-objects/related-documents.js
@@ -19,6 +19,7 @@
       documentType: '@',
       documents: [],
       isLoading: false,
+      pendingItemsChanged: false,
       define: {
 
         // automatically refresh instance on related document create/remove
@@ -213,6 +214,7 @@
 
         this.attr('documents', documents);
         this.instance.mark_for_deletion('related_objects_as_source', document);
+        this.attr('pendingItemsChanged', true);
       },
       markDocumentForAddition: function (data) {
         var self = this;
@@ -221,6 +223,7 @@
         this.attr('documents').unshift(document);
         this.attr('isLoading', true);
 
+        this.attr('pendingItemsChanged', true);
         return this.saveDocument(document).then(function () {
           self.instance.mark_for_addition(
             'related_objects_as_source',

--- a/src/ggrc/assets/mustache/assessments/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessments/modal_content.mustache
@@ -10,12 +10,17 @@
 
       {{^if new_object_form}}
         {{#if_in instance.status "Not Started,Completed,Verified"}}
+          {{#if_helpers '\
+            #if' instance.isDirty '\
+            or #if' mappedObjectsChanges.length '\
+            or #if' referenceUrlChanged}}
           <div class="ggrc-form-item">
-            <div class="alert warning">
+            <div class="alert warning width-100">
               <i class="fa fa-exclamation-triangle red"></i>
               You are about to move assessment from "{{instance.status}}" to "In Progress".
             </div>
           </div>
+          {{/if_helpers}}
         {{/if_in}}
       {{/if}}
 
@@ -117,7 +122,8 @@
                   mapping="related_objects_as_source"
                   from-binding="true"
                   {type}="instance.assessment_type"
-                  deferred="true">
+                  deferred="true"
+                  {^changes}="mappedObjectsChanges">
             <label class="ggrc-form-item__label">
               Mapped Objects
             </label>
@@ -198,7 +204,11 @@
 
       <div class="ggrc-form-item">
         <div class="ggrc-form-item__multiple-row">
-          <related-documents instance={instance} document-type="REFERENCE_URL" autorefresh="false">
+          <related-documents
+            instance={instance}
+            document-type="REFERENCE_URL"
+            autorefresh="false"
+            {^pending-items-changed}="referenceUrlChanged">
             <related-reference-urls class="related-reference-urls"
               {(urls)}="documents"
               {is-disabled}="isLoading"

--- a/src/ggrc/assets/mustache/assessments/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessments/modal_content.mustache
@@ -9,7 +9,7 @@
     <form action="javascript://">
 
       {{^if new_object_form}}
-        {{#if_in instance.status "Not Started,Completed,Verified"}}
+        {{#if_in instance.status "Not Started,Completed,Verified,In Review"}}
           {{#if_helpers '\
             #if' instance.isDirty '\
             or #if' mappedObjectsChanges.length '\


### PR DESCRIPTION
*ACCEPTANCE CRITERIA*
AC1. Show 'You are about to move assessment from "Completed" to "In Progress".' message only if any attribute except person attributes are modified.

AC2. Increase the width of message and make it same as for 'Please be informed that Assignee and Verifier are the same person.' message.