### PR TITLE
GGRC-3188 Set default 'Object Type' on Unified Mapper

### DIFF
--- a/src/ggrc/assets/javascripts/components/object-mapper/object-mapper.js
+++ b/src/ggrc/assets/javascripts/components/object-mapper/object-mapper.js
@@ -13,7 +13,27 @@
     Regulation: 'Section',
     Product: 'System',
     Standard: 'Section',
-    Contract: 'Clause'
+    Contract: 'Clause',
+    Control: 'Objective',
+    System: 'Product',
+    Process: 'Risk',
+    AccessGroup: 'System',
+    Clause: 'Contract',
+    DataAsset: 'Policy',
+    Facility: 'Program',
+    Issue: 'Control',
+    Market: 'Program',
+    OrgGroup: 'Program',
+    Policy: 'DataAsset',
+    Program: 'Standard',
+    Project: 'Program',
+    Risk: 'Control',
+    TaskGroupTask: 'Control',
+    Threat: 'Risk',
+    Vendor: 'Program',
+    Audit: 'Product',
+    RiskAssessment: 'Program',
+    TaskGroup: 'Control'
   };
 
   var getDefaultType = function (type, object) {

--- a/src/ggrc/assets/javascripts/components/object-search/object-search.js
+++ b/src/ggrc/assets/javascripts/components/object-search/object-search.js
@@ -13,7 +13,7 @@
     viewModel: function () {
       return GGRC.VM.ObjectOperationsBaseVM.extend({
         object: 'MultitypeSearch',
-        type: 'Program',
+        type: 'Control',
         availableTypes: function () {
           var types = GGRC.Mappings.getMappingTypes(
             this.attr('object'),


### PR DESCRIPTION
ACCPTANCE CRITERIA
AC1. Set default values for 'Object Type' dropdown on Unified Mapper, depending for which object it is opened:
https://docs.google.com/spreadsheets/d/11CHxbJZHPwD8rc9-4xCDnHbhQ4SE2SKDJcGxckuk2MQ/edit#gid=0
AC2. Set default value for 'Object Type' dropdown = 'Controls' on Global Search pop-up.