### PR TITLE
GGRC-3284 JS error occurs while importing csv file

### DIFF
--- a/src/ggrc/assets/javascripts/components/csv/import.js
+++ b/src/ggrc/assets/javascripts/components/csv/import.js
@@ -206,9 +206,7 @@
         }.bind(this))
         .fail(function (data) {
           this.scope.attr("state", "select");
-          $("body").trigger("ajax:flash", {
-            "error": $(data.responseText.split("\n")[3]).text()
-          });
+          GGRC.Errors.notifier('error', data.responseJSON.message);
         }.bind(this))
         .always(function () {
           this.scope.attr("isLoading", false);
@@ -245,10 +243,8 @@
             );
           }.bind(this))
           .fail(function (data) {
-            this.attr("state", "select");
-            $("body").trigger("ajax:flash", {
-              "error": $(data.responseText.split("\n")[3]).text()
-            });
+            this.scope.attr("state", "select");
+            GGRC.Errors.notifier('error', data.responseJSON.message);
           }.bind(this))
           .always(function () {
             this.scope.attr("isLoading", false);


### PR DESCRIPTION
Just wanted to let you know that when importing an excel sheet into GGRC, I keep getting this error (screenshot attached to this email). It is preventing me from mapping and creating systems.
Steps to reproduce:
1. Have csv file with Section object (attached)
2. Import csv file
3. Look at the screen

**Actual Result:** "Uncaught TypeError: this.attr is not a function" error occurs while importing csv file with section
**Expected Result:** no error are displayed while importing

![image](https://user-images.githubusercontent.com/10946494/30162424-69cb8efa-93dd-11e7-8f95-5cce9f8a595c.png)

I reproduced the issue with next steps:
1) Have non csv-file as "some_spreadsheet.ods".
2) Rename file as "some_spreadsheet.csv".
3) Try import this file.

In scope of this ticket: fix frontend logic of import to show error message from backend.