### PR TITLE
 GGRC-3215 Hover-over text for long file names 

### DIFF
--- a/src/ggrc/assets/mustache/components/object-list-item/document-object-list-item.mustache
+++ b/src/ggrc/assets/mustache/components/object-list-item/document-object-list-item.mustache
@@ -5,7 +5,11 @@
 <div class="document-object-item {{#if iconCls}}document-object-item__with-icon{{/if}}">
     {{#if iconCls}}<i class="fa {{iconCls}}"></i>{{/if}}
     <div class="document-object-item__body">
-        <a class="link" href="{{itemData.link}}" target="_blank">{{itemTitle}}</a>
+        <a class="link" 
+           href="{{itemData.link}}" 
+           target="_blank"
+           rel="tooltip"
+           data-original-title="{{itemTitle}}">{{itemTitle}}</a>
         <span class="date">{{localize_date itemCreationDate}}</span>
     </div>
 </div>

--- a/src/ggrc/assets/stylesheets/_common.scss
+++ b/src/ggrc/assets/stylesheets/_common.scss
@@ -66,6 +66,7 @@ a {
 .tooltip {
   // The bootstrap default is incorrect with modals as of bootstrap 2.0.x
   z-index: zIndex(tooltip) !important;
+  word-wrap: break-word;
 }
 
 // status


### PR DESCRIPTION
Comment by User:
What is the problem / issue?
If the file name exceeds a certain length, I can't see the whole name without opening the file. The link in the bottom tray show the location in Drive. 
screenshot-1.png
What is the expected result / outcome? (ie What should happen?)
I would like to be able to hover my cursor over the text and have a tool tip window show me the whole file name. 
What is the impact if it is not fixed / implemented? (Quantify the impact, eg, # of hours)
Minimal, nice to have