### PR TITLE
GGRC-2692 Incorrect placement of 3 bb's menu and [Assessments] button on Controls/Objectives Info pane

### DIFF
--- a/src/ggrc/assets/stylesheets/modules/_info-pin.scss
+++ b/src/ggrc/assets/stylesheets/modules/_info-pin.scss
@@ -117,6 +117,9 @@
     position: static;
     margin-top: 0;
   }
+  show-related-assessments-button {
+    display: inline-block;
+  }
 }
 
 .question-link {


### PR DESCRIPTION
Steps to reproduce:
1. Go to My work page > Control's tab
2. Navigate to Control's Info pane
3. Look at the [Assessments] button and 3 bb's menu
Actual Result: There is no padding between 3 bb's menu and [Assessments] button on Controls/Objectives Info pane
Expected Result: Improve placement of 3 bb's menu and [Assessments] button on Controls/Objectives Info pane as on screenshot-2.png