### PR TITLE
GGRC-2794 "Last deprecated date" column is not displayed in tree view for Product, Clause, Issue, Risk, Threat 

### DIFF
--- a/src/ggrc/assets/javascripts/models/business_object_models.js
+++ b/src/ggrc/assets/javascripts/models/business_object_models.js
@@ -215,7 +215,8 @@
       attr_view: GGRC.mustache_path + '/base_objects/tree-item-attr.mustache',
       attr_list: can.Model.Cacheable.attr_list.concat([
         {attr_title: 'Kind/Type', attr_name: 'type'},
-        {attr_title: 'Reference URL', attr_name: 'reference_url'}
+        {attr_title: 'Reference URL', attr_name: 'reference_url'},
+        {attr_title: 'Last Deprecated Date', attr_name: 'end_date'}
       ]),
       add_item_view:
         GGRC.mustache_path + '/base_objects/tree_add_item.mustache'

--- a/src/ggrc/assets/javascripts/models/issue.js
+++ b/src/ggrc/assets/javascripts/models/issue.js
@@ -25,7 +25,8 @@
     },
     tree_view_options: {
       attr_list: can.Model.Cacheable.attr_list.concat([
-        {attr_title: 'Reference URL', attr_name: 'reference_url'}
+        {attr_title: 'Reference URL', attr_name: 'reference_url'},
+        {attr_title: 'Last Deprecated Date', attr_name: 'end_date'}
       ]),
       attr_view: GGRC.mustache_path + '/base_objects/tree-item-attr.mustache'
     },

--- a/src/ggrc/assets/javascripts/models/section.js
+++ b/src/ggrc/assets/javascripts/models/section.js
@@ -87,7 +87,8 @@ can.Model.Cacheable('CMS.Models.Clause', {
   tree_view_options: {
     attr_view: '/static/mustache/sections/tree-item-attr.mustache',
     attr_list: can.Model.Cacheable.attr_list.concat([
-      {attr_title: 'Reference URL', attr_name: 'reference_url'}
+      {attr_title: 'Reference URL', attr_name: 'reference_url'},
+      {attr_title: 'Last Deprecated Date', attr_name: 'end_date'}
     ]),
     add_item_view: GGRC.mustache_path + '/snapshots/tree_add_item.mustache'
   },

--- a/src/ggrc_risks/assets/javascripts/models/risk.js
+++ b/src/ggrc_risks/assets/javascripts/models/risk.js
@@ -29,7 +29,8 @@
         GGRC.mustache_path + '/base_objects/tree_add_item.mustache',
       attr_view: GGRC.mustache_path + '/base_objects/tree-item-attr.mustache',
       attr_list: can.Model.Cacheable.attr_list.concat([
-        {attr_title: 'Reference URL', attr_name: 'reference_url'}
+        {attr_title: 'Reference URL', attr_name: 'reference_url'},
+        {attr_title: 'Last Deprecated Date', attr_name: 'end_date'}
       ])
     },
     defaults: {

--- a/src/ggrc_risks/assets/javascripts/models/threat.js
+++ b/src/ggrc_risks/assets/javascripts/models/threat.js
@@ -37,7 +37,8 @@
       '/base_objects/tree_add_item.mustache',
       attr_view: GGRC.mustache_path + '/base_objects/tree-item-attr.mustache',
       attr_list: can.Model.Cacheable.attr_list.concat([
-        {attr_title: 'Reference URL', attr_name: 'reference_url'}
+        {attr_title: 'Reference URL', attr_name: 'reference_url'},
+        {attr_title: 'Last Deprecated Date', attr_name: 'end_date'}
       ])
     },
     defaults: {


### PR DESCRIPTION
Steps to reproduce:
1. Go to All objects page > Products tab
2. Open set visible fields dialog and set "Last deprecated date"
3. Look at the tree view
Actual Result: "Last deprecated date" column is not displayed in tree view for Product, Clause, Issue, Risk, Threat
Expected Result: "Last deprecated date" column should be displayed in tree view for Product, Clause, Issue, Risk, Threat