### PR TITLE
GGRC-3222 BE:Add `Rework Needed` state for Assessment

### DIFF
--- a/src/ggrc/migrations/versions/20170908140544_3e7c7f3d9308_add_need_rework_status_for_assessment.py
+++ b/src/ggrc/migrations/versions/20170908140544_3e7c7f3d9308_add_need_rework_status_for_assessment.py
@@ -1,0 +1,73 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+add Rework Needed status for assessment
+
+Create Date: 2017-09-08 14:05:44.404834
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+import sqlalchemy as sa
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '3e7c7f3d9308'
+down_revision = '3897847a6c5c'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  op.alter_column(
+      'assessments', 'status',
+      type_=sa.Enum(
+          "Not Started",
+          "In Progress",
+          "In Review",
+          "Verified",
+          "Completed",
+          "Deprecated",
+          "Rework Needed"
+      ),
+      existing_type=sa.Enum(
+          "Not Started",
+          "In Progress",
+          "In Review",
+          "Verified",
+          "Completed",
+          "Deprecated",
+      ),
+      nullable=False,
+      server_default="Not Started",
+  )
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  op.execute("UPDATE assessments SET status = 'In Progress' "
+             "WHERE status = 'Rework Needed'")
+  op.alter_column(
+      'assessments', 'status',
+      type_=sa.Enum(
+          "Not Started",
+          "In Progress",
+          "In Review",
+          "Verified",
+          "Deprecated",
+          "Completed",
+      ),
+      existing_type=sa.Enum(
+          "Not Started",
+          "In Progress",
+          "In Review",
+          "Verified",
+          "Completed",
+          "Deprecated",
+          "Rework Needed",
+      ),
+      nullable=False,
+      server_default="Not Started",
+  )

--- a/test/integration/ggrc/converters/test_import_assessments.py
+++ b/test/integration/ggrc/converters/test_import_assessments.py
@@ -5,14 +5,11 @@
 
 """Test request import and updates."""
 
-import csv
 import datetime
+from collections import OrderedDict
+
 import ddt
 import freezegun
-
-from cStringIO import StringIO
-from collections import OrderedDict
-from itertools import izip
 
 from ggrc import db
 from ggrc import models
@@ -216,10 +213,11 @@ class TestAssessmentImport(TestCase):
 
   def test_mapping_control_through_snapshot(self):
     "Test for add mapping control on assessment"
-    audit = factories.AuditFactory()
-    assessment = factories.AssessmentFactory(audit=audit)
-    factories.RelationshipFactory(source=audit, destination=assessment)
-    control = factories.ControlFactory()
+    with factories.single_commit():
+      audit = factories.AuditFactory()
+      assessment = factories.AssessmentFactory(audit=audit)
+      factories.RelationshipFactory(source=audit, destination=assessment)
+      control = factories.ControlFactory()
     revision = models.Revision.query.filter(
         models.Revision.resource_id == control.id,
         models.Revision.resource_type == control.__class__.__name__
@@ -292,9 +290,10 @@ class TestAssessmentImport(TestCase):
   def test_import_archived_assessment(self, is_archived, value, ignored,
                                       updated, row_errors):
     """Test archived assessment import procedure"""
-    audit = factories.AuditFactory(archived=is_archived)
-    assessment = factories.AssessmentFactory(audit=audit)
-    factories.RelationshipFactory(source=audit, destination=assessment)
+    with factories.single_commit():
+      audit = factories.AuditFactory(archived=is_archived)
+      assessment = factories.AssessmentFactory(audit=audit)
+      factories.RelationshipFactory(source=audit, destination=assessment)
     resp = self.import_data(OrderedDict([
         ("object_type", "Assessment"),
         ("Code*", assessment.slug),
@@ -317,8 +316,9 @@ class TestAssessmentImport(TestCase):
 
   def test_create_new_assessment_with_mapped_control(self):
     "Test for creation assessment with mapped controls"
-    audit = factories.AuditFactory()
-    control = factories.ControlFactory()
+    with factories.single_commit():
+      audit = factories.AuditFactory()
+      control = factories.ControlFactory()
     revision = models.Revision.query.filter(
         models.Revision.resource_id == control.id,
         models.Revision.resource_type == control.__class__.__name__
@@ -355,11 +355,12 @@ class TestAssessmentImport(TestCase):
 
   def test_create_import_assignee(self):
     "Test for creation assessment with mapped assignees"
-    audit = factories.AuditFactory()
     name = "test_name"
     email = "test@email.com"
-    assignee_id = factories.PersonFactory(name=name, email=email).id
     slug = "TestAssessment"
+    with factories.single_commit():
+      audit = factories.AuditFactory()
+      assignee_id = factories.PersonFactory(name=name, email=email).id
     self.import_data(OrderedDict([
         ("object_type", "Assessment"),
         ("Code*", slug),
@@ -375,11 +376,12 @@ class TestAssessmentImport(TestCase):
 
   def test_create_import_creators(self):
     "Test for creation assessment with mapped creator"
-    audit = factories.AuditFactory()
     name = "test_name"
     email = "test@email.com"
-    creator_id = factories.PersonFactory(name=name, email=email).id
     slug = "TestAssessment"
+    with factories.single_commit():
+      audit = factories.AuditFactory()
+      creator_id = factories.PersonFactory(name=name, email=email).id
     self.import_data(OrderedDict([
         ("object_type", "Assessment"),
         ("Code*", slug),
@@ -396,10 +398,11 @@ class TestAssessmentImport(TestCase):
   def test_update_import_creators(self):
     "Test for creation assessment with mapped creator"
     slug = "TestAssessment"
-    assessment = factories.AssessmentFactory(slug=slug)
     name = "test_name"
     email = "test@email.com"
-    creator_id = factories.PersonFactory(name=name, email=email).id
+    with factories.single_commit():
+      assessment = factories.AssessmentFactory(slug=slug)
+      creator_id = factories.PersonFactory(name=name, email=email).id
     self.assertNotEqual([creator_id], [i.id for i in assessment.creators])
     self.import_data(OrderedDict([
         ("object_type", "Assessment"),
@@ -414,10 +417,11 @@ class TestAssessmentImport(TestCase):
   def test_update_import_assignee(self):
     "Test for creation assessment with mapped creator"
     slug = "TestAssessment"
-    assessment = factories.AssessmentFactory(slug=slug)
     name = "test_name"
     email = "test@email.com"
-    assignee_id = factories.PersonFactory(name=name, email=email).id
+    with factories.single_commit():
+      assessment = factories.AssessmentFactory(slug=slug)
+      assignee_id = factories.PersonFactory(name=name, email=email).id
     self.assertNotEqual([assignee_id], [i.id for i in assessment.assessors])
     self.import_data(OrderedDict([
         ("object_type", "Assessment"),
@@ -519,13 +523,7 @@ class TestAssessmentExport(TestCase):
             },
         },
     }]
-    response = self.export_csv(data)
-
-    keys, vals = response.data.strip().split("\n")[10:12]
-    keys = next(csv.reader(StringIO(keys), delimiter=","), [])
-    vals = next(csv.reader(StringIO(vals), delimiter=","), [])
-    instance_dict = dict(izip(keys, vals))
-
+    instance_dict = self.export_parsed_csv(data)[instance.type][0]
     self.assertEqual(value, instance_dict[column])
 
   def test_export_assesments_without_map_control(self):
@@ -550,30 +548,34 @@ class TestAssessmentExport(TestCase):
     self.assertColumnExportedValue("", assessment,
                                    "map:control versions")
 
-  def test_export_assesments_with_map_control(self):
-    """Test export assesment with related control instance
-
-    relation snapshot -> assessment
-    """
-    audit = factories.AuditFactory()
-    assessment = factories.AssessmentFactory(audit=audit)
-    factories.RelationshipFactory(source=audit, destination=assessment)
-    control = factories.ControlFactory()
+  @ddt.data(True, False)
+  def test_export_assesments_map_control(self, with_map):
+    """Test export assesment with and without related control instance"""
+    with factories.single_commit():
+      audit = factories.AuditFactory()
+      assessment = factories.AssessmentFactory(audit=audit)
+      factories.RelationshipFactory(source=audit, destination=assessment)
+      control = factories.ControlFactory()
     revision = models.Revision.query.filter(
         models.Revision.resource_id == control.id,
         models.Revision.resource_type == control.__class__.__name__
     ).order_by(
         models.Revision.id.desc()
     ).first()
-    snapshot = factories.SnapshotFactory(
-        parent=audit,
-        child_id=control.id,
-        child_type=control.__class__.__name__,
-        revision_id=revision.id
-    )
-    db.session.commit()
-    factories.RelationshipFactory(source=snapshot, destination=assessment)
-    self.assertColumnExportedValue(control.slug, assessment,
+    with factories.single_commit():
+      snapshot = factories.SnapshotFactory(
+          parent=audit,
+          child_id=control.id,
+          child_type=control.__class__.__name__,
+          revision_id=revision.id
+      )
+      if with_map:
+        factories.RelationshipFactory(source=snapshot, destination=assessment)
+    if with_map:
+      val = control.slug
+    else:
+      val = ""
+    self.assertColumnExportedValue(val, assessment,
                                    "map:control versions")
 
   def test_export_assesments_with_map_control_mirror_relation(self):
@@ -581,10 +583,11 @@ class TestAssessmentExport(TestCase):
 
     relation assessment -> snapshot
     """
-    audit = factories.AuditFactory()
-    assessment = factories.AssessmentFactory(audit=audit)
-    factories.RelationshipFactory(source=audit, destination=assessment)
-    control = factories.ControlFactory()
+    with factories.single_commit():
+      audit = factories.AuditFactory()
+      assessment = factories.AssessmentFactory(audit=audit)
+      factories.RelationshipFactory(source=audit, destination=assessment)
+      control = factories.ControlFactory()
     revision = models.Revision.query.filter(
         models.Revision.resource_id == control.id,
         models.Revision.resource_type == control.__class__.__name__

--- a/test/integration/ggrc/services/test_assessments.py
+++ b/test/integration/ggrc/services/test_assessments.py
@@ -5,7 +5,7 @@
 """Tests for assessment service handle."""
 import random
 
-from ddt import data, ddt
+import ddt
 
 from ggrc.models import all_models
 from integration.ggrc import TestCase
@@ -15,7 +15,7 @@ from integration.ggrc.api_helper import Api
 from integration.ggrc.generator import ObjectGenerator
 
 
-@ddt
+@ddt.ddt
 class TestCollection(TestCase, WithQueryApi):
 
   """Test for collection assessment objects."""
@@ -24,29 +24,30 @@ class TestCollection(TestCase, WithQueryApi):
     super(TestCollection, self).setUp()
     self.client.get("/login")
     self.clear_data()
-    self.expected_ids = []
     self.api = Api()
     self.generator = ObjectGenerator()
-    assessments = [factories.AssessmentFactory() for _ in range(10)]
-    random.shuffle(assessments)
-    for idx, assessment in enumerate(assessments):
-      comment = factories.CommentFactory(description=str(idx))
-      factories.RelationshipFactory(source=assessment, destination=comment)
-      self.expected_ids.append(assessment.id)
 
-  @data(True, False)
+  @ddt.data(True, False)
   def test_order_by_test(self, desc):
     """Order by fultext attr"""
+    expected_ids = []
+    with factories.single_commit():
+      assessments = [factories.AssessmentFactory() for _ in range(10)]
+    random.shuffle(assessments)
+    with factories.single_commit():
+      for idx, assessment in enumerate(assessments):
+        comment = factories.CommentFactory(description=str(idx))
+        factories.RelationshipFactory(source=assessment, destination=comment)
+        expected_ids.append(assessment.id)
     query = self._make_query_dict(
         "Assessment", order_by=[{"name": "comment", "desc": desc}]
     )
-    expected_ids = self.expected_ids
     if desc:
       expected_ids = expected_ids[::-1]
     results = self._get_first_result_set(query, "Assessment", "values")
     self.assertEqual(expected_ids, [i['id'] for i in results])
 
-  @data("Assessor", "Creator", "Verifier")
+  @ddt.data("Assessor", "Creator", "Verifier")
   def test_delete_assessment_by_role(self, role_name):
     """Delete assessment not allowed for based on Assignee Type."""
     with factories.single_commit():
@@ -72,3 +73,27 @@ class TestCollection(TestCase, WithQueryApi):
     self.assert403(resp)
     self.assertTrue(all_models.Assessment.query.filter(
         all_models.Assessment.id == assessment_id).one())
+
+  @ddt.data(
+      (all_models.Assessment.REWORK_NEEDED, True),
+      (all_models.Assessment.DONE_STATE, True),
+      (all_models.Assessment.FINAL_STATE, True),
+      (all_models.Assessment.START_STATE, False),
+  )
+  @ddt.unpack
+  def test_update_status_need_rework(self, status, is_valid):
+    """Update assessment state from need rework to valid or invalid states."""
+    with factories.single_commit():
+      assessment = factories.AssessmentFactory(
+          status=all_models.Assessment.REWORK_NEEDED
+      )
+    assessment_id = assessment.id
+    resp = self.api.put(assessment, {"status": status})
+    if is_valid:
+      self.assert200(resp)
+      check_status = status
+    else:
+      self.assert400(resp)
+      check_status = all_models.Assessment.REWORK_NEEDED
+    self.assertEqual(
+        check_status, all_models.Assessment.query.get(assessment_id).status)

--- a/test/unit/ggrc/models/test_states.py
+++ b/test/unit/ggrc/models/test_states.py
@@ -1,10 +1,12 @@
 """Test Object State Module"""
 
 import unittest
-import ggrc.app  # noqa pylint: disable=unused-import
+
 from ddt import ddt
 from ddt import data
+
 from ggrc.models import all_models
+import ggrc.app  # noqa pylint: disable=unused-import
 
 
 @ddt

--- a/test/unit/ggrc/models/test_states.py
+++ b/test/unit/ggrc/models/test_states.py
@@ -56,7 +56,8 @@ class TestStates(unittest.TestCase):
     """Test states for Assignable objects (Assessment)"""
     assignable_states = (
         'In Progress', 'Completed', 'Not Started', 'Verified', 'In Review',
-        'Deprecated')
+        'Deprecated', 'Rework Needed',
+    )
     self._assert_states('Assessment', assignable_states, 'Not Started')
 
   def test_issue_states(self):


### PR DESCRIPTION
Add 'Rework Needed' state for Assessment.
FE should have ability to move Assessment to Rework Needed state over api 
From 'Rework Needed' state assessment can be moved only to 'In Review' or 'Completed (no verification)' state.