### PR TITLE
QUICK-FIX Improve approach of selenium container building to keep bundle chromedriver <-> Chrome updated

### DIFF
--- a/Dockerfile-selenium
+++ b/Dockerfile-selenium
@@ -2,17 +2,47 @@
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
 
-FROM selenium/standalone-chrome:3.5.2-antimony
+FROM selenium/standalone-chrome:3.5.3
 
+# Python requirements
 USER root
 COPY ./provision/docker/selenium.bashrc.j2 /root/.bashrc
 RUN apt-get update && apt-get install -y python python-pip python-setuptools
-
 COPY ./src/requirements-selenium.txt /tmp/requirements.txt
 RUN pip install pip \
   && pip install -r /tmp/requirements.txt
 
-RUN usermod -u 1000 seluser
+# All commands below are worked with no-cache option due to function.sh:
+# docker-compose --file docker-compose-testing.yml --project-name ${PROJECT} \
+#   build --build-arg NO_CACHE=$(date +%s) ${MACHINE_ID}
+ARG NO_CACHE=1
 
-WORKDIR /selenium
+# Google Chrome browser
+RUN CHROME_VERSION="google-chrome-stable"
+RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub \
+  | apt-key add - \
+  && echo "deb http://dl.google.com/linux/chrome/deb/ stable main" \
+  >> /etc/apt/sources.list.d/google-chrome.list \
+  && apt-get update -qqy \
+  && apt-get -qqy install \
+    ${CHROME_VERSION:-google-chrome-stable} \
+  && rm /etc/apt/sources.list.d/google-chrome.list \
+  && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+
+# Chrome webdriver
 USER seluser
+WORKDIR /selenium
+RUN usermod -u 1000 seluser
+RUN CHROME_DRIVER_VERSION="latest"
+RUN CD_VER=$(if [ ${CHROME_DRIVER_VERSION:-latest} = "latest" ]; then echo\
+  $(wget -qO- https://chromedriver.storage.googleapis.com/LATEST_RELEASE); \
+  else echo $CHROME_DRIVER_VERSION; fi) \
+  && echo "Using chromedriver version: "$CD_VER \
+  && wget --no-verbose -O /tmp/chromedriver_linux64.zip \
+  https://chromedriver.storage.googleapis.com/$CD_VER/chromedriver_linux64.zip\
+  && rm -rf /opt/selenium/chromedriver \
+  && unzip /tmp/chromedriver_linux64.zip -d /opt/selenium \
+  && rm /tmp/chromedriver_linux64.zip \
+  && mv /opt/selenium/chromedriver /opt/selenium/chromedriver-$CD_VER\
+  && chmod 755 /opt/selenium/chromedriver-$CD_VER \
+  && sudo ln -fs /opt/selenium/chromedriver-$CD_VER /usr/bin/chromedriver

--- a/bin/jenkins/functions.sh
+++ b/bin/jenkins/functions.sh
@@ -48,9 +48,8 @@ setup () {
 
   git submodule update --init
 
-  docker-compose --file docker-compose-testing.yml \
-    --project-name ${PROJECT} \
-    build ${MACHINE_ID}
+  docker-compose --file docker-compose-testing.yml --project-name ${PROJECT} \
+    build --build-arg NO_CACHE=$(date +%s) ${MACHINE_ID}
 
   docker-compose --file docker-compose-testing.yml \
     --project-name ${PROJECT} \


### PR DESCRIPTION
This PR updates version of selenium docker image to 3.5.3 and brings new approach to keep bundle 'chromedriver-chrome' updated.

## **Problem:**
On the current moment:

- not depending on image version of ‘selenium/standalone-chrome:*’;
- according to multiple inheritance of docker images (https://github.com/SeleniumHQ/docker-selenium/tree/master/StandaloneChrome);
- according to used approach of selenium container building without option ‘--no-cache’:

 ```bash
  docker-compose --file docker-compose-testing.yml \
    --project-name ${PROJECT} \
    build ${MACHINE_ID}

  docker-compose --file docker-compose-testing.yml \
    --project-name ${PROJECT} \
    up --force-recreate -d ${MACHINE_ID}
```

**We have cached:**
- a hard-coded version of ‘chromedriver’;
- dynamically created last stable version of Chrome browser (on the moment when target container 'selenium/standalone-chrome' was build and pushed to Docker Hub)**

**Mentioned above scheme will be work but we don’t use really last version of Chrome browser and Test Automation Framework will be testing GGRC application using a quite deprecated bundle of 'chromedriver-Chrome'**

### **NOTES:**
When I updated version of selenium image to 'selenium/standalone-chrome:3.5.3' I build targeted container with 'chromedriver=3.31' and 'Chrome-browser=61.x' but I got and issue with failed tests related with wrong clicking due to:
```
----------ChromeDriver v2.32 (2017-08-30)----------
Supports Chrome v59-61
Resolved issue 1852: Error 'Element is not clickable at point' occurs on Chrome v61+ [['Pri-1']]
...

----------ChromeDriver v2.31 (2017-07-21)----------
Supports Chrome v58-60
...
```

### *selenium/standalone-chrome inheritance:3.5.3*
- https://github.com/SeleniumHQ/docker-selenium/blob/master/StandaloneChrome/Dockerfile:
```dockerfile
FROM selenium/node-chrome:3.5.3-astatine
```
- https://github.com/SeleniumHQ/docker-selenium/blob/master/NodeChrome/Dockerfile:
```dockerfile
FROM selenium/node-base:3.5.3-astatine
ARG CHROME_VERSION="google-chrome-stable"
...
ARG CHROME_DRIVER_VERSION=2.31
....
```
- https://github.com/SeleniumHQ/docker-selenium/tree/master/NodeBase:
```dockerfile
FROM selenium/base:3.5.3-astatine
```
- https://github.com/SeleniumHQ/docker-selenium/tree/master/Base:
```dockerfile
FROM ubuntu:16.04
```

### **POSSIBLE APPROCHES**
| chromedriver | Chrome browser | Notes (Pros / Cons) |
| --- | --- | --- |
| dynamically created (nocached); over selenium docker-hub selenium/node-chrome | dynamically created (nocached); over selenium docker-hub selenium/node-chrome | Pros: None; Cons: actual bundle, * stability of test-suite | 
| hard coded created (cached); over selenium docker-hub selenium/node-chrome | hard coded created (cached); over selenium docker-hub selenium/node-chrome | Pros: - manual supporting of actual bundle; Cons: - stability of test-suite|
| hard coded created (cached); from docker-hub selenium/node-chrome | dynamically created (cached); from docker-hub selenium/node-chrome | Pros: deprecated bundle; Cons: stability of test-suite|

# **HACK:**
Was used a '--no-cache' option only for **chromedriver** and **Google Chrome browser**:
**function.sh**
```bash
  docker-compose --file docker-compose-testing.yml \
    --project-name ${PROJECT} build \
    --build-arg NO_CACHE=$(date +%s) ${MACHINE_ID}
```
**Dockerfile-selenium**
```dockerfile
# no-cache section:
ARG NO_CACHE=1
# Google Chrome browser
RUN CHROME_VERSION="google-chrome-stable"
# Chrome webdriver
RUN CHROME_DRIVER_VERSION="latest"
```