### PR TITLE
GGRC-2415 Add show less/ show all link for evidences and url in Related assessments window

### DIFF
--- a/src/ggrc/assets/javascripts/components/object-list/object-list.js
+++ b/src/ggrc/assets/javascripts/components/object-list/object-list.js
@@ -54,6 +54,7 @@
       },
       spinnerCss: '@',
       isDisabled: false,
+      showMore: false,
       /**
        *
        * @param {can.Map} ctx - current item context

--- a/src/ggrc/assets/mustache/assessments/related-assessments.mustache
+++ b/src/ggrc/assets/mustache/assessments/related-assessments.mustache
@@ -97,7 +97,7 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                             <div class="flex-size-3">
                                 <related-evidences-and-urls {parent-instance}="instance"
                                                             {^is-loading}="loadingState.evidencesAndUrlsLoading">
-                                    <object-list items="documents">
+                                    <object-list items="documents" show-more="true">
                                         <reusable-objects-item {instance}="{.}"
                                                                {is-saving}="isSaving"
                                                                {base-instance-documents}="baseInstanceDocuments"

--- a/src/ggrc/assets/mustache/components/object-list/object-list.mustache
+++ b/src/ggrc/assets/mustache/components/object-list/object-list.mustache
@@ -6,11 +6,19 @@
     <spinner {toggle}="isLoading" {extra-css-class}="spinnerCss" class="spinner-wrapper active"></spinner>
 {{else}}
   {{#if items.length}}
-    {{#items}}
-        <div class="object-list__item {{#isSelected}}object-list__item-selected{{/isSelected}}" ($click)="modifySelection">
+      {{#if showMore}}
+        <show-more class="list-more" items="items" limit="3">
+          <div class="object-list__item {{#isSelected}}object-list__item-selected{{/isSelected}}" ($click)="modifySelection">
             <content>No item component or template is provided</content>
-        </div>
-    {{/items}}
+          </div>
+        </show-more>
+      {{else}}
+        {{#items}}
+          <div class="object-list__item {{#isSelected}}object-list__item-selected{{/isSelected}}" ($click)="modifySelection">
+              <content>No item component or template is provided</content>
+          </div>
+        {{/items}}
+      {{/if}}
   {{else}}
       <div class="object-list__item object-list__item-empty">
         {{emptyMessage}}

--- a/src/ggrc/assets/stylesheets/components/object-list/_object-list.scss
+++ b/src/ggrc/assets/stylesheets/components/object-list/_object-list.scss
@@ -52,6 +52,11 @@ object-list {
       }
     }
   }
+  .list-more {
+    .btn-link {
+      padding: 4px;
+    }
+  }
 
 }
 object-list {


### PR DESCRIPTION
Steps to reproduce:
1. Have audit with control snapshot
2. Generate at least 2 assessments
3. Expand Info pane for one assessment and add at least 10 evidences and 10 urls
2. Open related assessment window for the second assessment 
3. Look at the ATTACHMENTS / URLS column: there is no show less/ show all link
Actual Result: Show less/ show all link for evidences and url is not displayed in Related assessments window
Expected Result: Show less/ show all link for evidences and url should be displayed in Related assessments window