### PR TITLE
QUICK-FIX Reduce the number of commits during test init

### DIFF
--- a/test/integration/ggrc/converters/test_acl_import_export.py
+++ b/test/integration/ggrc/converters/test_acl_import_export.py
@@ -48,8 +48,9 @@ class TestACLImportExport(TestCase):
 
   def test_acl_multiple_entries(self):
     """Test ACL column import with multiple emails."""
-    role = factories.AccessControlRoleFactory(object_type="Market")
-    emails = {factories.PersonFactory().email for _ in range(3)}
+    with factories.single_commit():
+      role = factories.AccessControlRoleFactory(object_type="Market")
+      emails = {factories.PersonFactory().email for _ in range(3)}
 
     response = self.import_data(OrderedDict([
         ("object_type", "Market"),
@@ -67,8 +68,10 @@ class TestACLImportExport(TestCase):
 
   def test_acl_update(self):
     """Test ACL column import with multiple emails."""
-    role_name = factories.AccessControlRoleFactory(object_type="Market").name
-    emails = {factories.PersonFactory().email for _ in range(4)}
+    with factories.single_commit():
+      role_name = factories.AccessControlRoleFactory(object_type="Market").name
+      emails = {factories.PersonFactory().email for _ in range(4)}
+
     update_emails = set(list(emails)[:2]) | {"user@example.com"}
 
     response = self.import_data(OrderedDict([
@@ -95,8 +98,9 @@ class TestACLImportExport(TestCase):
 
   def test_acl_empty_update(self):
     """Test ACL column import with multiple emails."""
-    role_name = factories.AccessControlRoleFactory(object_type="Market").name
-    emails = {factories.PersonFactory().email for _ in range(3)}
+    with factories.single_commit():
+      role_name = factories.AccessControlRoleFactory(object_type="Market").name
+      emails = {factories.PersonFactory().email for _ in range(3)}
 
     response = self.import_data(OrderedDict([
         ("object_type", "Market"),
@@ -122,9 +126,13 @@ class TestACLImportExport(TestCase):
 
   def test_acl_export(self):
     """Test ACL field export."""
-    role_name = factories.AccessControlRoleFactory(object_type="Market").name
-    empty_name = factories.AccessControlRoleFactory(object_type="Market").name
-    emails = {factories.PersonFactory().email for _ in range(3)}
+    with factories.single_commit():
+      role_name = factories.AccessControlRoleFactory(object_type="Market").name
+      empty_name = factories.AccessControlRoleFactory(
+          object_type="Market",
+      ).name
+      emails = {factories.PersonFactory().email for _ in range(3)}
+
     self.import_data(OrderedDict([
         ("object_type", "Market"),
         ("code", "market-1"),
@@ -177,14 +185,15 @@ class TestACLImportExport(TestCase):
   })
   def test_multiple_acl_roles_add(self, roles):
     """Test importing new object with multiple ACL roles."""
-    for email in self._random_emails:
-      factories.PersonFactory(email=email)
+    with factories.single_commit():
+      for email in self._random_emails:
+        factories.PersonFactory(email=email)
 
-    for role_name in roles.keys():
-      factories.AccessControlRoleFactory(
-          object_type="Market",
-          name=role_name + "  ",
-      )
+      for role_name in roles.keys():
+        factories.AccessControlRoleFactory(
+            object_type="Market",
+            name=role_name + "  ",
+        )
 
     import_dict = self._generate_role_import_dict(roles)
     self.import_data(import_dict)
@@ -219,14 +228,15 @@ class TestACLImportExport(TestCase):
   @ddt.unpack
   def test_multiple_acl_roles_update(self, first_roles, edited_roles):
     """Test updating objects via import with multiple ACL roles."""
-    for email in self._random_emails:
-      factories.PersonFactory(email=email)
+    with factories.single_commit():
+      for email in self._random_emails:
+        factories.PersonFactory(email=email)
 
-    for role_name in first_roles.keys():
-      factories.AccessControlRoleFactory(
-          object_type="Market",
-          name=role_name,
-      )
+      for role_name in first_roles.keys():
+        factories.AccessControlRoleFactory(
+            object_type="Market",
+            name=role_name,
+        )
 
     import_dict = self._generate_role_import_dict(first_roles)
     self.import_data(import_dict)
@@ -267,18 +277,21 @@ class TestACLImportExport(TestCase):
   })
   def test_same_name_roles(self, model_dict):
     """Test role with the same names on different objects."""
-    for email in self._random_emails:
-      factories.PersonFactory(email=email)
+    with factories.single_commit():
+      for email in self._random_emails:
+        factories.PersonFactory(email=email)
 
-    import_dicts = []
-    for object_type, roles in model_dict.items():
-      for role_name in roles.keys():
-        factories.AccessControlRoleFactory(
-            object_type=object_type,
-            name=role_name,
+      import_dicts = []
+      for object_type, roles in model_dict.items():
+        for role_name in roles.keys():
+          factories.AccessControlRoleFactory(
+              object_type=object_type,
+              name=role_name,
+          )
+
+        import_dicts.append(
+            self._generate_role_import_dict(roles, object_type)
         )
-
-      import_dicts.append(self._generate_role_import_dict(roles, object_type))
 
     response = self.import_data(*import_dicts)
     self._check_csv_response(response, {})
@@ -297,8 +310,9 @@ class TestACLImportExport(TestCase):
 
   def test_acl_revision_on_import(self):
     """Test creation of separate revision for ACL in import"""
-    role_name = factories.AccessControlRoleFactory(object_type="Market").name
-    emails = {factories.PersonFactory().email for _ in range(3)}
+    with factories.single_commit():
+      role_name = factories.AccessControlRoleFactory(object_type="Market").name
+      emails = {factories.PersonFactory().email for _ in range(3)}
 
     response = self.import_data(OrderedDict([
         ("object_type", "Market"),

--- a/test/integration/ggrc/converters/test_base_block.py
+++ b/test/integration/ggrc/converters/test_base_block.py
@@ -34,27 +34,30 @@ class TestBaseBlock(TestCase):
   @data(0, 1, 2, 4, 8)
   def test_create_mapping_cache(self, count):
     """Test creation of mapping cache for export."""
-    regulations = [factories.RegulationFactory() for _ in range(count)]
-    markets = [factories.MarketFactory() for _ in range(count)]
-    controls = [factories.ControlFactory() for _ in range(count)]
 
-    expected_cache = defaultdict(lambda: defaultdict(list))
-    for i in range(count):
-      for j in range(i):
-        factories.RelationshipFactory(
-            source=regulations[j] if i % 2 == 0 else markets[i],
-            destination=regulations[j] if i % 2 == 1 else markets[i],
-        )
-        factories.RelationshipFactory(
-            source=regulations[j] if i % 2 == 0 else controls[i],
-            destination=regulations[j] if i % 2 == 1 else controls[i],
-        )
-        expected_cache[regulations[j].id]["Control"].append(
-            controls[i].slug
-        )
-        expected_cache[regulations[j].id]["Market"].append(
-            markets[i].slug
-        )
+    with factories.single_commit():
+      regulations = [factories.RegulationFactory() for _ in range(count)]
+      markets = [factories.MarketFactory() for _ in range(count)]
+      controls = [factories.ControlFactory() for _ in range(count)]
+
+      expected_cache = defaultdict(lambda: defaultdict(list))
+      for i in range(count):
+        for j in range(i):
+          factories.RelationshipFactory(
+              source=regulations[j] if i % 2 == 0 else markets[i],
+              destination=regulations[j] if i % 2 == 1 else markets[i],
+          )
+          factories.RelationshipFactory(
+              source=regulations[j] if i % 2 == 0 else controls[i],
+              destination=regulations[j] if i % 2 == 1 else controls[i],
+          )
+          expected_cache[regulations[j].id]["Control"].append(
+              controls[i].slug
+          )
+          expected_cache[regulations[j].id]["Market"].append(
+              markets[i].slug
+          )
+
     block = base_block.BlockConverter(mock.MagicMock())
     block.object_class = models.Regulation
     block.object_ids = [r.id for r in regulations]
@@ -70,24 +73,26 @@ class TestBaseBlock(TestCase):
   def test_get_identifier_mappings(self):
     """Test _get_identifier_mappings function."""
     count = 3
-    regulation = factories.RegulationFactory()
-    markets = [factories.MarketFactory() for _ in range(count)]
-    controls = [factories.ControlFactory() for _ in range(count)]
-    expected_id_map = {
-        "Market": {o.id: o.slug for o in markets},
-        "Control": {o.id: o.slug for o in controls},
-    }
 
-    relationships = []
-    for i in range(count):
-      relationships.append(factories.RelationshipFactory(
-          source=regulation if i % 2 == 0 else markets[i],
-          destination=regulation if i % 2 == 1 else markets[i],
-      ))
-      relationships.append(factories.RelationshipFactory(
-          source=regulation if i % 2 == 0 else controls[i],
-          destination=regulation if i % 2 == 1 else controls[i],
-      ))
+    with factories.single_commit():
+      regulation = factories.RegulationFactory()
+      markets = [factories.MarketFactory() for _ in range(count)]
+      controls = [factories.ControlFactory() for _ in range(count)]
+      expected_id_map = {
+          "Market": {o.id: o.slug for o in markets},
+          "Control": {o.id: o.slug for o in controls},
+      }
+
+      relationships = []
+      for i in range(count):
+        relationships.append(factories.RelationshipFactory(
+            source=regulation if i % 2 == 0 else markets[i],
+            destination=regulation if i % 2 == 1 else markets[i],
+        ))
+        relationships.append(factories.RelationshipFactory(
+            source=regulation if i % 2 == 0 else controls[i],
+            destination=regulation if i % 2 == 1 else controls[i],
+        ))
 
     block = base_block.BlockConverter(mock.MagicMock())
     block.object_class = models.Regulation

--- a/test/integration/ggrc/converters/test_export_controls.py
+++ b/test/integration/ggrc/converters/test_export_controls.py
@@ -23,17 +23,18 @@ class TestExportControls(TestCase):
           "X-Requested-By": "GGRC",
           "X-export-view": "blocks",
       }
-      self.basic_owner = factories.PersonFactory(name="basic owner")
-      self.control = factories.ControlFactory()
-      self.acr_id = all_models.AccessControlRole.query.filter_by(
-          object_type=self.control.type,
-          name="Admin"
-      ).first().id
-      self.owner_object = factories.AccessControlListFactory(
-          person=self.basic_owner,
-          object=self.control,
-          ac_role_id=self.acr_id
-      )
+      with factories.single_commit():
+        self.basic_owner = factories.PersonFactory(name="basic owner")
+        self.control = factories.ControlFactory()
+        self.acr_id = all_models.AccessControlRole.query.filter_by(
+            object_type=self.control.type,
+            name="Admin"
+        ).first().id
+        self.owner_object = factories.AccessControlListFactory(
+            person=self.basic_owner,
+            object=self.control,
+            ac_role_id=self.acr_id
+        )
 
   def test_search_by_owner_email(self):
     self.assert_slugs("Admin",
@@ -48,12 +49,14 @@ class TestExportControls(TestCase):
   def test_search_by_new_owner(self):
     """Filter by added new owner and old owner"""
     basic_email, basic_name = self.basic_owner.email, self.basic_owner.name
-    new_owner = factories.PersonFactory(name="new owner")
-    factories.AccessControlListFactory(
-        person=new_owner,
-        object=self.control,
-        ac_role_id=self.acr_id
-    )
+    with factories.single_commit():
+      new_owner = factories.PersonFactory(name="new owner")
+      factories.AccessControlListFactory(
+          person=new_owner,
+          object=self.control,
+          ac_role_id=self.acr_id
+      )
+
     self.assert_slugs("Admin",
                       new_owner.email,
                       [self.control.slug])

--- a/test/integration/ggrc/converters/test_export_csv.py
+++ b/test/integration/ggrc/converters/test_export_csv.py
@@ -369,8 +369,9 @@ class TestExportMultipleObjects(TestCase):
 
   def test_simple_multi_export(self):
     match = 1
-    programs = [factories.ProgramFactory().title for i in range(3)]
-    regulations = [factories.RegulationFactory().title for i in range(3)]
+    with factories.single_commit():
+      programs = [factories.ProgramFactory().title for i in range(3)]
+      regulations = [factories.RegulationFactory().title for i in range(3)]
 
     data = [{
         "object_name": "Program",  # prog-1

--- a/test/integration/ggrc/converters/test_import_helpers.py
+++ b/test/integration/ggrc/converters/test_import_helpers.py
@@ -49,12 +49,14 @@ class TestACLAttributeDefinitions(TestCase):
   @ddt.data(*models.all_models.all_models)
   def test_acl_definitions(self, model):
     """Test ACL column definitions."""
-    factory = factories.AccessControlRoleFactory
-    factories.AccessControlRoleFactory(
-        object_type="Control",
-        read=True
-    )
-    role_names = {factory(object_type=model.__name__).name for _ in range(2)}
+    with factories.single_commit():
+      factory = factories.AccessControlRoleFactory
+      factories.AccessControlRoleFactory(
+          object_type="Control",
+          read=True
+      )
+      role_names = {factory(object_type=model.__name__).name for _ in range(2)}
+
     expected_names = set()
     if issubclass(model, roleable.Roleable):
       expected_names = role_names

--- a/test/integration/ggrc/converters/test_import_issues.py
+++ b/test/integration/ggrc/converters/test_import_issues.py
@@ -46,8 +46,10 @@ class TestImportIssues(TestCase):
 
   def test_audit_change(self):
     """Test audit changing"""
-    audit = factories.AuditFactory()
-    issue = factories.IssueFactory()
+    with factories.single_commit():
+      audit = factories.AuditFactory()
+      issue = factories.IssueFactory()
+
     response = self.import_data(OrderedDict([
         ("object_type", "Issue"),
         ("Code*", issue.slug),
@@ -69,8 +71,10 @@ class TestImportIssues(TestCase):
   @ddt.unpack
   def test_issue_deprecate_change(self, start_state, final_state, dep_count):
     """Test counter on changing state to deprecate"""
-    factories.AuditFactory()
-    issue = factories.IssueFactory(status=start_state)
+    with factories.single_commit():
+      factories.AuditFactory()
+      issue = factories.IssueFactory(status=start_state)
+
     response = self.import_data(OrderedDict([
         ("object_type", "Issue"),
         ("Code*", issue.slug),
@@ -105,16 +109,17 @@ class TestImportIssues(TestCase):
     # Import of data should be allowed if mandatory role provided
     # and can process situation when nonmandatory roles are absent
     # without any errors and warnings
-    mandatory_role = factories.AccessControlRoleFactory(
-        object_type="Market",
-        mandatory=True
-    ).name
-    factories.AccessControlRoleFactory(
-        object_type="Market",
-        mandatory=False
-    )
+    with factories.single_commit():
+      mandatory_role = factories.AccessControlRoleFactory(
+          object_type="Market",
+          mandatory=True
+      ).name
+      factories.AccessControlRoleFactory(
+          object_type="Market",
+          mandatory=False
+      )
+      email = factories.PersonFactory().email
 
-    email = factories.PersonFactory().email
     response_json = self.import_data(OrderedDict([
         ("object_type", "Market"),
         ("code", "market-1"),
@@ -129,16 +134,17 @@ class TestImportIssues(TestCase):
   def test_import_without_mandatory(self):
     """Test import of data without mandatory role"""
     # Data can't be imported if mandatory role is not provided
-    mandatory_role = factories.AccessControlRoleFactory(
-        object_type="Market",
-        mandatory=True
-    ).name
-    not_mandatory_role = factories.AccessControlRoleFactory(
-        object_type="Market",
-        mandatory=False
-    ).name
+    with factories.single_commit():
+      mandatory_role = factories.AccessControlRoleFactory(
+          object_type="Market",
+          mandatory=True
+      ).name
+      not_mandatory_role = factories.AccessControlRoleFactory(
+          object_type="Market",
+          mandatory=False
+      ).name
+      email = factories.PersonFactory().email
 
-    email = factories.PersonFactory().email
     response_json = self.import_data(OrderedDict([
         ("object_type", "Market"),
         ("code", "market-1"),
@@ -163,16 +169,17 @@ class TestImportIssues(TestCase):
 
   def test_import_empty_mandatory(self):
     """Test import of data with empty mandatory role"""
-    mandatory_role = factories.AccessControlRoleFactory(
-        object_type="Market",
-        mandatory=True
-    ).name
-    not_mandatory_role = factories.AccessControlRoleFactory(
-        object_type="Market",
-        mandatory=False
-    ).name
+    with factories.single_commit():
+      mandatory_role = factories.AccessControlRoleFactory(
+          object_type="Market",
+          mandatory=True
+      ).name
+      not_mandatory_role = factories.AccessControlRoleFactory(
+          object_type="Market",
+          mandatory=False
+      ).name
+      email = factories.PersonFactory().email
 
-    email = factories.PersonFactory().email
     response_json = self.import_data(OrderedDict([
         ("object_type", "Market"),
         ("code", "market-1"),

--- a/test/integration/ggrc/converters/test_imported_api_requests.py
+++ b/test/integration/ggrc/converters/test_imported_api_requests.py
@@ -115,11 +115,13 @@ class TestComprehensiveSheets(TestCase):
   def create_custom_attributes():
     """Generate custom attributes needed by comprehensive_sheet1.csv."""
     cad = factories.CustomAttributeDefinitionFactory
-    cad(definition_type="control", title="my custom text", mandatory=True)
-    cad(definition_type="program", title="my_text", mandatory=True)
-    cad(definition_type="program", title="my_date", attribute_type="Date")
-    cad(definition_type="program", title="my_checkbox",
-        attribute_type="Checkbox")
-    cad(definition_type="program", title="my_dropdown",
-        attribute_type="Dropdown",
-        multi_choice_options="a,b,c,d")
+
+    with factories.single_commit():
+      cad(definition_type="control", title="my custom text", mandatory=True)
+      cad(definition_type="program", title="my_text", mandatory=True)
+      cad(definition_type="program", title="my_date", attribute_type="Date")
+      cad(definition_type="program", title="my_checkbox",
+          attribute_type="Checkbox")
+      cad(definition_type="program", title="my_dropdown",
+          attribute_type="Dropdown",
+          multi_choice_options="a,b,c,d")


### PR DESCRIPTION
This PR basically wraps all repeating factory calls into `factories.single_commit` context.

The affected 261 tests took on my machine:
- on dev: 154.223s
- on PR: 123.609s
