### PR TITLE
GGRC-3212,GGRC-3315,GGRC-3333,GGRC-3334 RMC - Workflow - People error (Access Control Security Risk)

### DIFF
--- a/src/ggrc/converters/base.py
+++ b/src/ggrc/converters/base.py
@@ -52,6 +52,9 @@ class Converter(object):
       "delete",
       "task_type",
       "audit",
+      "workflow",
+      "task_group",
+      "workflow_owner"
   ]
 
   def __init__(self, **kwargs):

--- a/src/ggrc/converters/handlers/handlers.py
+++ b/src/ggrc/converters/handlers/handlers.py
@@ -831,3 +831,41 @@ ExportOnlyUserColumnHandler = type(
     (ExportOnlyColumnHandler, UserColumnHandler),
     {}
 )
+
+
+class ForkColumnHandler(object):
+  """Helper for spliting column handlers with same name by object type."""
+
+  class StubColumnHandler(ColumnHandler):
+    """Stub column handler which does nothing"""
+
+  def parse_item(self):
+    pass
+
+  def set_obj_attr(self):
+    pass
+
+  def get_value(self):
+    pass
+
+  def insert_object(self):
+    pass
+
+  def set_value(self):
+    pass
+
+  default_handler = StubColumnHandler
+  handler_mapping = {}
+
+  def __init__(self, row_converter, key, **kwargs):
+    self.handler = self.handler_mapping.get(
+        type(row_converter.obj),
+        self.default_handler
+    )(row_converter, key, **kwargs)
+
+  def __getattribute__(self, attr):
+    __class__ = super(ForkColumnHandler, self).__getattribute__('__class__')
+    if attr in __class__.__dict__:
+      return getattr(__class__, attr)
+    handler = super(ForkColumnHandler, self).__getattribute__('handler')
+    return getattr(handler, attr)

--- a/src/ggrc_workflows/models/cycle_task_group_object_task.py
+++ b/src/ggrc_workflows/models/cycle_task_group_object_task.py
@@ -30,6 +30,7 @@ class CycleTaskGroupObjectTask(mixins.WithContact,
                                relationship.Relatable,
                                mixins.Notifiable,
                                mixins.Described,
+                               wf_mixins.CheckMappedContact,
                                mixins.Titled,
                                mixins.Slugged,
                                mixins.Base,
@@ -329,6 +330,10 @@ class CycleTaskGroupObjectTask(mixins.WithContact,
             "id"
         ),
     )
+
+  @property
+  def workflow(self):
+    return getattr(self.cycle, 'workflow', None)
 
 
 class CycleTaskable(object):

--- a/src/ggrc_workflows/models/task_group.py
+++ b/src/ggrc_workflows/models/task_group.py
@@ -16,11 +16,12 @@ from ggrc.models.mixins import (
 from ggrc.models.reflection import AttributeInfo
 from ggrc.models import reflection
 from ggrc.models import all_models
+from ggrc_workflows.models import mixins as wf_mixins
 from ggrc_workflows.models.task_group_object import TaskGroupObject
 
 
-class TaskGroup(
-        WithContact, Timeboxed, Described, Titled, Slugged, Indexed, db.Model):
+class TaskGroup(WithContact, Timeboxed, Described, Titled,
+                wf_mixins.CheckMappedContact, Slugged, Indexed, db.Model):
   """Workflow TaskGroup model."""
 
   __tablename__ = 'task_groups'

--- a/src/ggrc_workflows/models/task_group_task.py
+++ b/src/ggrc_workflows/models/task_group_task.py
@@ -17,11 +17,13 @@ from ggrc.models import mixins
 from ggrc.models.types import JsonType
 from ggrc.models import reflection
 from ggrc_workflows.models.task_group import TaskGroup
+from ggrc_workflows.models import mixins as wf_mixins
 
 
 class TaskGroupTask(mixins.WithContact,
                     mixins.Titled,
                     mixins.Described,
+                    wf_mixins.CheckMappedContact,
                     mixins.Slugged,
                     mixins.Timeboxed,
                     Indexed,
@@ -107,11 +109,11 @@ class TaskGroupTask(mixins.WithContact,
           "display_name": "Task Description",
           "handler_key": "task_description",
       },
-      "contact": {
-          "display_name": "Assignee",
-          "mandatory": True,
-      },
       "secondary_contact": None,
+      "contact": {
+          "mandatory": True,
+          "display_name": "Assignee",
+      },
       "start_date": {
           "display_name": "Start Date",
           "mandatory": True,
@@ -189,3 +191,7 @@ class TaskGroupTask(mixins.WithContact,
 
     target = self.copy_into(_other, columns, contact=contact, **kwargs)
     return target
+
+  @property
+  def workflow(self):
+    return getattr(self.task_group, 'workflow', None)

--- a/test/integration/ggrc_workflows/converters/test_column_definitions.py
+++ b/test/integration/ggrc_workflows/converters/test_column_definitions.py
@@ -65,8 +65,8 @@ class TestWorkflowObjectColumnDefinitions(TestCase):
     self.assertTrue(vals["Manager"]["mandatory"])
     self.assertIn("type", vals["Manager"])
     self.assertIn("type", vals["Member"])
-    self.assertEqual(vals["Manager"]["type"], "user_role")
-    self.assertEqual(vals["Member"]["type"], "user_role")
+    self.assertEqual(vals["Manager"]["type"], "property")
+    self.assertEqual(vals["Member"]["type"], "property")
 
   def test_task_group_definitions(self):
     """ test default headers for Task Group """
@@ -89,7 +89,7 @@ class TestWorkflowObjectColumnDefinitions(TestCase):
     self.assertTrue(vals["Summary"]["mandatory"])
     self.assertTrue(vals["Assignee"]["mandatory"])
 
-  def test_task_group_task_definitions(self):
+  def test_task_group_task_definitions(self):  # pylint: disable=invalid-name
     """ test default headers for Task Group Task """
     definitions = get_object_column_definitions(wf_models.TaskGroupTask)
     display_names = {val["display_name"] for val in definitions.itervalues()}

--- a/test/integration/ggrc_workflows/converters/test_import_workflow_related_people.py
+++ b/test/integration/ggrc_workflows/converters/test_import_workflow_related_people.py
@@ -1,0 +1,181 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Tests for workflow related objects people imports."""
+# pylint: disable=invalid-name
+
+import collections
+import string
+import ddt
+
+from ggrc_workflows.models.workflow import Workflow
+from integration.ggrc import TestCase
+from integration.ggrc.models import factories as ggrc_factories
+
+
+@ddt.ddt
+class TestWorkflowRelatedPeopleImport(TestCase):
+  """Tests for workflow related objects people imports."""
+
+  def setUp(self):
+    self.users = []
+    for _ in xrange(8):
+      self.users.append(ggrc_factories.PersonFactory())
+    self.users.sort(key=lambda u: u.email)
+    self.wf_slug = ggrc_factories.random_str(chars=string.ascii_letters)
+    self.wf_import_params = [
+        ("object_type", "Workflow"),
+        ("code", self.wf_slug),
+        ("title", "SomeTitle"),
+        ("Need Verification", 'True')
+    ]
+
+  def _get_people_emails_by_role(self, workflow, role_name):
+    """Get people emails by user_role.
+
+    Args:
+        workflow: Workflow instance
+        role_name: Workflow user role name
+
+    Returns:
+        People emails sorted by alphabet.
+    """
+    people_emails = []
+    for wp in workflow.workflow_people:
+      self.assertEqual(len(wp.person.user_roles), 1)
+      if wp.person.user_roles[0].role.name == role_name:
+        people_emails.append(wp.person.email)
+    people_emails.sort()
+    return people_emails
+
+  def _check_workflow_people(self, owners_idx, members_idx,  # noqa pylint: disable=too-many-arguments,too-many-locals
+                             expected_owners_idx, expected_members_idx,
+                             is_success, success_resp_action):
+    """Import people list to workflow and compare with expected results.
+
+    Args:
+        owners_idx: Indexes of the test people data who should get Owner role.
+        members_idx: Indexes of the test people data who should get Member
+            role.
+        expected_owners_idx: Expected indexes for the people with Owner role.
+        expected_members_idx: Expected indexes for the people with Member role.
+        is_success: Shows is import was successful or not.
+        success_resp_action: Action which was performed on imported item.
+    """
+    if members_idx:
+      import_members = '\n'.join(
+          (self.users[idx].email for idx in members_idx))
+      self.wf_import_params.append(('member', import_members))
+    if owners_idx:
+      import_owners = '\n'.join((self.users[idx].email for idx in owners_idx))
+      self.wf_import_params.append(('manager', import_owners))
+    resp = self.import_data(collections.OrderedDict(self.wf_import_params))
+    if is_success:
+      self.assertEqual(resp[0][success_resp_action], 1)
+      self._check_csv_response(resp, {})
+      workflow = Workflow.query.filter(Workflow.slug == self.wf_slug).first()
+
+      exst_owners = self._get_people_emails_by_role(workflow, 'WorkflowOwner')
+      expected_owners = [self.users[idx].email for idx in expected_owners_idx]
+      self.assertEqual(exst_owners, expected_owners)
+
+      exst_members = self._get_people_emails_by_role(workflow,
+                                                     'WorkflowMember')
+      expected_members = [self.users[idx].email
+                          for idx in expected_members_idx]
+      self.assertEqual(exst_members, expected_members)
+    else:
+      self.assertEqual(resp[0]['ignored'], 1)
+
+  @ddt.data(
+      ([0, 1], [2, 3], [0, 1], [2, 3], True),
+      ([0, 1], [1, 2], [0, 1], [2], True),
+      ([0, 1], [0, 1], [0, 1], [], True),
+      ([0, 1], [], [0, 1], [], True),
+      ([], [0, 1], [], [], False),
+      ([], [], [], [], False),
+  )
+  @ddt.unpack  # noqa pylint: disable=too-many-arguments
+  def test_create_workflow_with_people(self, owners_idx, members_idx,
+                                       expected_owners_idx,
+                                       expected_members_idx, is_success):
+    """Tests importing new workflow with lists of owners and members."""
+    self._check_workflow_people(owners_idx, members_idx, expected_owners_idx,
+                                expected_members_idx, is_success, 'created')
+
+  @ddt.data(
+      ([0, 1], [2, 3], [0, 1], [2, 3], True),
+      ([0, 1], [1, 2], [0, 1], [2], True),
+      ([0, 1], [0, 1], [0, 1], [4, 5], True),
+      ([0, 1], [], [0, 1], [4, 5], True),
+      ([4, 5], [], [4, 5], [], True),
+      ([], [0, 1], [6, 7], [0, 1], True),
+      ([], [], [6, 7], [4, 5], True),
+  )
+  @ddt.unpack  # noqa pylint: disable=too-many-arguments
+  def test_update_workflow_with_people(self, owners_idx, members_idx,
+                                       expected_owners_idx,
+                                       expected_members_idx, is_success):
+    """Tests importing existing workflow with lists of owners and members."""
+    def_params = (
+        self.wf_import_params +
+        [
+            ('member', '\n'.join((self.users[4].email, self.users[5].email))),
+            ('manager', '\n'.join((self.users[6].email, self.users[7].email))),
+        ]
+    )
+    self.import_data(collections.OrderedDict(def_params))
+    self._check_workflow_people(owners_idx, members_idx, expected_owners_idx,
+                                expected_members_idx, is_success, 'updated')
+
+  @ddt.data(
+      (4, 5, [2, 3, 4, 5]),
+      (0, 1, [2, 3]),
+      (0, 6, [2, 3, 6]),
+      (7, 1, [2, 3, 7]),
+      (2, 3, [2, 3]),
+      (2, 4, [2, 3, 4]),
+      (5, 3, [2, 3, 5])
+  )
+  @ddt.unpack
+  def test_import_assignees(self, tg_assignee_id, tgt_assignee_id,
+                            expected_members_idx):
+    """Tests importing TaskGroup and TaskGroupTask with assignee."""
+    self._check_workflow_people([0, 1], [2, 3], [0, 1], [2, 3], True,
+                                'created')
+
+    tg_slug = ggrc_factories.random_str(chars=string.ascii_letters)
+    tg_import_params = [
+        ("object_type", "Task Group"),
+        ("code", tg_slug),
+        ("summary", "SomeTitle"),
+        ("assignee", self.users[tg_assignee_id].email),
+        ("workflow", self.wf_slug),
+    ]
+    resp = self.import_data(collections.OrderedDict(tg_import_params))
+    self.assertEqual(resp[0]['created'], 1)
+    self._check_csv_response(resp, {})
+
+    tgt_slug = ggrc_factories.random_str(chars=string.ascii_letters)
+    tgt_import_params = [
+        ("object_type", "Task"),
+        ("code", tgt_slug),
+        ("summary", "SomeTitle"),
+        ("assignee", self.users[tgt_assignee_id].email),
+        ("task group", tg_slug),
+        ("task type", "Rich text"),
+        ("start date", "7/1/2015"),
+        ("end date", "7/15/2015")
+    ]
+    resp = self.import_data(collections.OrderedDict(tgt_import_params))
+    self.assertEqual(resp[0]['created'], 1)
+    self._check_csv_response(resp, {})
+
+    workflow = Workflow.query.filter(Workflow.slug == self.wf_slug).first()
+    exst_owners = self._get_people_emails_by_role(workflow, 'WorkflowOwner')
+    expected_owners = [self.users[idx].email for idx in [0, 1]]
+    self.assertEqual(exst_owners, expected_owners)
+    exst_members = self._get_people_emails_by_role(workflow,
+                                                   'WorkflowMember')
+    expected_members = [self.users[idx].email for idx in expected_members_idx]
+    self.assertEqual(exst_members, expected_members)


### PR DESCRIPTION
Comment by User:
What is the problem / issue?
- Multiple People-tab data error. 

Workflow-267
- There are 9 workflow manager listed on Workflow info page
See screenshot: [^screenshot-1.png]

People were added via import

Workflow-265
- There is only 1 manager &/or person on the workflow
See screenshot: [^screenshot-2.png]

People were removed via import

What is the expected result / outcome? (ie What should happen?)
- Correct number of people are listed in people tab to align both Workflow Info & People tab

What is the impact if it is not fixed / implemented? (Quantify the impact, eg, # of hours)
- We are not able to tightly control workflow access as this bug is blocking us to review who has or does not have access to a particular workflow which poses Access-Control security risk.