### PR TITLE
QUICK-FIX Improve procedure of server waiting under docker containers to prevent issues with KOKORO's jobs running

### DIFF
--- a/test/selenium/bin/run_selenium.py
+++ b/test/selenium/bin/run_selenium.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python2.7
 # Copyright (C) 2017 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
-
-""" Basic selenium test runner
-
+""" Basic selenium test runner.
 This script is used for running all selenium tests against the server defined
 in the configuration yaml file. The script will wait a defined time for the
 server to start before running the test. If the server fails to start before
@@ -15,25 +13,29 @@ tests pass.
 import os
 import sys
 import time
-import urllib
 
-import pytest   # pylint: disable=import-error
+import pytest  # pylint: disable=import-error
+import requests
+
+from lib import file_ops, environment, decorator  # noqa
+from lib.service.rest_service import client
+
 
 # add src to path so that we can do imports from our src
 PROJECT_ROOT_PATH = os.path.dirname(os.path.abspath(__file__)) + "/../"
 sys.path.append(PROJECT_ROOT_PATH + "src")
 
-from lib import file_ops  # NOQA
-from lib import environment  # NOQA
 
-
+@decorator.track_time
 def wait_for_server():
-  """ Wait for the server to return a 200 response
+  """Wait for the server to return '200' status code in response during
+  predefined time in 'pytest.ini'.
   """
   sys.stdout.write("Wating on server: ")
   for _ in xrange(environment.SERVER_WAIT_TIME):
     try:
-      if urllib.urlopen(environment.APP_URL).getcode() == 200:
+      if (requests.head(environment.APP_URL).status_code ==
+              client.RestClient.STATUS_CODES["OK"]):
         print "[Done]"
         return True
     except IOError:
@@ -47,8 +49,6 @@ def wait_for_server():
 if __name__ == "__main__":
   if not wait_for_server():
     sys.exit(3)
-
   file_ops.create_directory(environment.LOG_PATH)
   file_ops.delete_directory_contents(environment.LOG_PATH)
-
   sys.exit(pytest.main())

--- a/test/selenium/pytest.ini
+++ b/test/selenium/pytest.ini
@@ -1,6 +1,6 @@
 [webapp]
 # the app server needs a few seconds to start
-wait_for_app_server = 60
+wait_for_app_server = 120
 
 [logging]
 # see python logging module for reference

--- a/test/selenium/src/lib/decorator.py
+++ b/test/selenium/src/lib/decorator.py
@@ -70,3 +70,16 @@ def lazy_property(fun):
       setattr(self, prop_name, fun(self))
     return getattr(self, prop_name)
   return lazy
+
+
+def track_time(fun):
+  """Time tracking decorator which defines how long 'fun' was executing."""
+  @wraps(fun)
+  def wrapper(*args, **kwargs):
+    start_time = time.time()
+    result = fun(*args, **kwargs)
+    elapsed_time = time.time() - start_time
+    print "Execution of '{0:s}' function took {1:.3f} s".format(
+        fun.func_name, elapsed_time)
+    return result
+  return wrapper


### PR DESCRIPTION
This PR improves procedure of server waiting under docker containers to prevent issues with KOKORO's jobs running.

**Before:**
We had to wait max 60 hops (secs) when server will response with '200' status code, and under local env it could be good enough , but under KOKORO's virtual complicated architecture masters, slaves... we extremely often faced issues like:
```bash
Running Test server
Running Selenium tests
Wating on server: ............................................................[Failed]
mv: cannot stat ‘./test/selenium/logs/results.xml’: No such file or directory
```

**Currently:**
We will wait max 120 hops (secs) and will use 'requests.head(environment.APP_URL).status_code ' library instead 'urllib.urlopen' and 'time_tracker' wrapper to have ability investigate approximately values if need it. 

```bash
[Done]
Execution of 'wait_for_server' function took 59.050 s
============================= test session starts ==============================
```