### PR TITLE
QUICK-FIX Bundle only used widgets from jquery-ui

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,6 @@
   "ignore": [],
   "dependencies": {
     "canjs": "2.3.27",
-    "bootstrap": "2.0.4",
-    "fontawesome": "~4.7.0"
+    "bootstrap": "2.0.4"
   }
 }

--- a/src/ggrc/assets/javascripts/entrypoints/vendor.js
+++ b/src/ggrc/assets/javascripts/entrypoints/vendor.js
@@ -6,7 +6,13 @@
 import '../tracker';
 import 'jquery';
 import 'lodash';
-import 'components-jqueryui';
+import 'components-jqueryui/ui/widgets/autocomplete';
+import 'components-jqueryui/ui/widgets/datepicker';
+import 'components-jqueryui/ui/widgets/draggable';
+import 'components-jqueryui/ui/widgets/droppable';
+import 'components-jqueryui/ui/widgets/resizable';
+import 'components-jqueryui/ui/widgets/sortable';
+import 'components-jqueryui/ui/widgets/tooltip';
 import 'bootstrap/js/bootstrap-alert.js';
 import 'bootstrap/js/bootstrap-collapse.js';
 import 'bootstrap/js/bootstrap-dropdown.js';


### PR DESCRIPTION
**Current state of vendor entry:**
![jquey-ui-full](https://user-images.githubusercontent.com/4737102/30316306-7bbe08b0-97af-11e7-8617-bfa294c6663e.png)
**Included only used widgets:**
![jquey-ui-short](https://user-images.githubusercontent.com/4737102/30316307-7be9597a-97af-11e7-8a9d-12aea75e1e63.png)

**Current gzipped size:** 209.2 KB
**Short list of jquery-ui widgets:** 183.23 KB
**Result:** bundle's size reduced on ~12%