### PR TITLE
GGRC-2381/2633/2224/2399 Data in Admin/Manager/Authorization columns is not displayed in Global Search/Unified mapper

### DIFF
--- a/src/ggrc/assets/mustache/people/tree-item-attr.mustache
+++ b/src/ggrc/assets/mustache/people/tree-item-attr.mustache
@@ -22,34 +22,48 @@
   {{#case 'authorizations'}}
     <div class="role tree-title-area">
     {{#if result}}
-    {{#with_program_roles_as "roles" result}}
-      {{#if roles.length}}
-        <div class="item-data">
-        <div class="tree-title-area">
-        <span class="role" title="{{#roles}}{{role.permission_summary}} {{/roles}}">
-        {{#if_helpers '\
-          #if_equals' roles.0.role.permission_summary 'Mapped' '\
-          and ^if_equals' roles.length 1}}
-                              {{roles.1.role.permission_summary}}
-                            {{else}}
-                              {{roles.0.role.permission_summary}}
-                            {{/if_helpers}}
-                            {{#roles.1}}
-                              {{#if_in_map roles 'role.permission_summary' 'Mapped'}}
-                                {{^if_equals roles.length 2}}
-                                  + {{sum roles.length '-2'}}
-                                {{/if_equals}}
+      {{#with_program_roles_as "roles" result}}
+        {{#if roles.length}}
+          <div class="item-data">
+          <div class="tree-title-area">
+          <span class="role" title="{{#roles}}{{role.permission_summary}} {{/roles}}">
+          {{#if_helpers '\
+            #if_equals' roles.0.role.permission_summary 'Mapped' '\
+            and ^if_equals' roles.length 1}}
+                                {{roles.1.role.permission_summary}}
                               {{else}}
-                                + {{sum roles.length '-1'}}
-          {{/if_in_map}}
-        {{/roles.1}}
-        </span>
-      </div>
+                                {{roles.0.role.permission_summary}}
+                              {{/if_helpers}}
+                              {{#roles.1}}
+                                {{#if_in_map roles 'role.permission_summary' 'Mapped'}}
+                                  {{^if_equals roles.length 2}}
+                                    + {{sum roles.length '-2'}}
+                                  {{/if_equals}}
+                                {{else}}
+                                  + {{sum roles.length '-1'}}
+              {{/if_in_map}}
+            {{/roles.1}}
+            </span>
+          </div>
+          </div>
+        {{/if}}
+      {{/with_program_roles_as}}
+    {{else}}
+      <div class="item-data">
+        <div class="tree-title-area">
+          {{#if_equals system_wide_role 'No Access'}}
+            <span class="no-role">
+              No Role
+            </span>
+          {{else}}
+            <span class="role">
+              {{system_wide_role}}
+            </span>
+          {{/if_equals}}
+        </div>
       </div>
     {{/if}}
-  {{/with_program_roles_as}}
-  {{/if}}
-  </div>
+    </div>
   {{/case}}
   {{#default}}
     {{get_default_attr_value attr_name instance}}

--- a/src/ggrc/assets/mustache/programs/tree-item-attr.mustache
+++ b/src/ggrc/assets/mustache/programs/tree-item-attr.mustache
@@ -5,16 +5,15 @@
 
 {{#switch attr_name}}
   {{#case 'owner'}}
-    {{#with_mapping 'authorizations' instance}}
-      {{#each authorizations}}
-        <span>
+    {{#with_mapping 'program_authorizations' instance}}
+      {{#each program_authorizations}}
           {{#using role=instance.role}}
             {{#if_equals role.name 'ProgramOwner'}}
-                <tree-people-list-field {source}="instance.contact">
-                </tree-people-list-field>
+                {{#using contact=instance.person}}
+                  <div class="need-comma">{{contact.email}}</div>
+                {{/using}}
             {{/if_equals}}
           {{/using}}
-        </span>
       {{/each}}
     {{/with_mapping}}
   {{/case}}

--- a/src/ggrc/assets/stylesheets/_common.scss
+++ b/src/ggrc/assets/stylesheets/_common.scss
@@ -69,6 +69,15 @@ a {
   word-wrap: break-word;
 }
 
+.need-comma {
+  &:after {
+    content: ",";
+  }
+  &:last-child:after {
+    content: none;
+  }
+}
+
 // status
 .status-label {
   border-radius: 50%;

--- a/src/ggrc_workflows/assets/javascripts/apps/workflows.js
+++ b/src/ggrc_workflows/assets/javascripts/apps/workflows.js
@@ -130,8 +130,7 @@
         context: Direct(
           'Context', 'related_object', 'context'),
         authorization_contexts: Multi(['context']),
-        authorizations: Cross(
-          'authorization_contexts', 'user_roles'),
+        authorizations: Cross('context', 'user_roles'),
         authorized_people: Cross(
           'authorization_contexts', 'authorized_people'),
         mapped_and_or_authorized_people: Multi([

--- a/test/selenium/src/tests/test_audit_page.py
+++ b/test/selenium/src/tests/test_audit_page.py
@@ -235,7 +235,6 @@ class TestAuditPage(base.Test):
     self.general_assert(
         expected_asmt_tmpl, actual_asmt_tmpls, "slug", "updated_at")
 
-  @pytest.mark.xfail(strict=True)
   @pytest.mark.smoke_tests
   @pytest.mark.cloning
   def test_clonable_not_audit_related_objs_move_to_cloned_audit(
@@ -248,15 +247,14 @@ class TestAuditPage(base.Test):
     """
     actual_audit = create_and_clone_audit["actual_audit"]
     expected_control = create_and_clone_audit["control"].repr_ui()
-    # due to 'actual_program.custom_attributes = {None: None}'
-    expected_program = (create_and_clone_audit["program"].
-                        repr_ui().update_attrs(custom_attributes={None: None}))
+    expected_program = create_and_clone_audit["program"].repr_ui()
     actual_controls = (webui_service.ControlsService(selenium).
                        get_list_objs_from_tree_view(src_obj=actual_audit))
     actual_programs = (webui_service.ProgramsService(selenium).
                        get_list_objs_from_tree_view(src_obj=actual_audit))
-    # due to 'actual_control.custom_attributes = {None: None}'
-    self.general_assert(
-        [expected_control], actual_controls, "custom_attributes")
-    self.extended_assert([expected_program], actual_programs,
-                         "Issue in app GGRC-2381", "manager")
+    # due to 'actual_controls.custom_attributes = {None: None}'
+    self.general_assert([expected_control], actual_controls,
+                        "custom_attributes")
+    # due to 'actual_programs.custom_attributes = {None: None}'
+    self.general_assert([expected_program], actual_programs,
+                        "custom_attributes")


### PR DESCRIPTION
Steps to reproduce:
1. Go to My work page and open Global Search
2. Select "Programs" object and look at Manager column: is empty
3. Select "Sections" object and look at the Admin column: is empty
4. Select "People" object: Authorizations column is empty
Actual Result: Data in Admin/Manager/Authorization columns is not displayed in Global Search/Unified mapper
Expected Result: People in Admin/Manager columns should be displayed in Global Search/Unified mapper. Authorizations should be displayed in Global Search/Unified mapper

Also, People are not shown in Global Search/Unified Mapper for the following entities:
Clauses - admin column 
Assessment template - admin column 
Workflow - admin column 