### PR TITLE
GGRC-3203/GGRC-3244 Add first-class attribute 'State' to Assessment Template

### DIFF
--- a/src/ggrc/migrations/versions/20170913123343_487c94a432b9_update_assessment_template_with_status.py
+++ b/src/ggrc/migrations/versions/20170913123343_487c94a432b9_update_assessment_template_with_status.py
@@ -1,0 +1,38 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Update AssessmentTemplate with status column
+
+Create Date: 2017-09-13 12:33:43.305853
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+import sqlalchemy as sa
+
+from alembic import op
+from ggrc.migrations.utils.resolve_duplicates import rename_ca_title
+
+
+# revision identifiers, used by Alembic.
+revision = '434683ceff87'
+down_revision = '2cdde3aa3844'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  rename_ca_title("state",
+                  ["assessment_template", ])
+  op.add_column(
+      "assessment_templates",
+      sa.Column('status',
+                sa.String(length=250),
+                nullable=False,
+                server_default='Draft'),
+  )
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  op.drop_column("assessment_templates", "status")

--- a/src/ggrc/models/assessment_template.py
+++ b/src/ggrc/models/assessment_template.py
@@ -22,7 +22,7 @@ from ggrc.fulltext.mixin import Indexed
 
 class AssessmentTemplate(assessment.AuditRelationship, relationship.Relatable,
                          mixins.Titled, mixins.CustomAttributable,
-                         mixins.Slugged, Indexed, db.Model):
+                         mixins.Slugged, mixins.Stateful, Indexed, db.Model):
   """A class representing the assessment template entity.
 
   An Assessment Template is a template that allows users for easier creation of
@@ -61,6 +61,12 @@ class AssessmentTemplate(assessment.AuditRelationship, relationship.Relatable,
 
   _title_uniqueness = False
 
+  DRAFT = 'Draft'
+  ACTIVE = 'Active'
+  DEPRECATED = 'Deprecated'
+
+  VALID_STATES = (DRAFT, ACTIVE, DEPRECATED, )
+
   # REST properties
   _api_attrs = reflection.ApiAttributes(
       "template_object_type",
@@ -78,6 +84,11 @@ class AssessmentTemplate(assessment.AuditRelationship, relationship.Relatable,
   ]
 
   _aliases = {
+      "status": {
+          "display_name": "State",
+          "mandatory": False,
+          "description": "Options are:\n{}".format('\n'.join(VALID_STATES))
+      },
       "default_assessors": {
           "display_name": "Default Assignee",
           "mandatory": True,
@@ -230,4 +241,4 @@ def handle_assessment_template(sender, obj=None, src=None, service=None):
   If "audit" is set on POST, create relationship with Assessment template.
   """
   if "audit" in src:
-      create_audit_relationship(src["audit"], obj)
+    create_audit_relationship(src["audit"], obj)

--- a/src/ggrc/models/audit.py
+++ b/src/ggrc/models/audit.py
@@ -8,8 +8,7 @@ from sqlalchemy import orm
 from ggrc import db
 from ggrc.models.deferred import deferred
 from ggrc.models.mixins import (
-    Timeboxed, Noted, Described, WithContact,
-    Titled, Slugged, CustomAttributable, Stateful
+    Timeboxed, WithContact, CustomAttributable, BusinessObject
 )
 
 from ggrc.models.object_document import PublicDocumentable
@@ -27,8 +26,7 @@ from ggrc.fulltext.mixin import Indexed
 
 class Audit(Snapshotable, clonable.Clonable, PublicDocumentable,
             CustomAttributable, Personable, HasOwnContext, Relatable,
-            Timeboxed, Noted, Described, WithContact, Titled,
-            Stateful, Slugged, Indexed, db.Model):
+            Timeboxed, WithContact, BusinessObject, Indexed, db.Model):
   """Audit model."""
 
   __tablename__ = 'audits'
@@ -64,7 +62,6 @@ class Audit(Snapshotable, clonable.Clonable, PublicDocumentable,
       'report_start_date',
       'report_end_date',
       'audit_firm',
-      'status',
       'gdrive_evidence_folder',
       'program',
       'object_type',
@@ -77,7 +74,6 @@ class Audit(Snapshotable, clonable.Clonable, PublicDocumentable,
       'report_start_date',
       'report_end_date',
       'audit_firm',
-      'status',
       'gdrive_evidence_folder',
   ]
 

--- a/test/integration/ggrc/converters/test_import_helpers.py
+++ b/test/integration/ggrc/converters/test_import_helpers.py
@@ -395,6 +395,7 @@ class TestGetObjectColumnDefinitions(TestCase):
         'Last Updated',
         'Last Updated By',
         "Delete",
+        "State",
     }
     expected_fields = {
         "mandatory": {


### PR DESCRIPTION
BE part only.

AC1. Add first-class attribute 'State' to Assessment Template. 
It should be a dropdown with options: Draft, Active, Deprecated.
AC2. Allow user to filter Assessment Template by state.
AC3. Allow user to import / export state for Assessment Template
