### PR TITLE
GGRC-3296 'Reference' object is displayed in Unified Mapper/Global Search

### DIFF
--- a/src/ggrc/assets/javascripts/models/mappers/mappings-ggrc.js
+++ b/src/ggrc/assets/javascripts/models/mappers/mappings-ggrc.js
@@ -88,7 +88,7 @@
           'Product', 'Project', 'System', 'Regulation', 'Policy', 'Contract',
           'Standard', 'Program', 'Issue', 'Control', 'Section', 'Clause',
           'Objective', 'Audit', 'Assessment', 'AssessmentTemplate',
-          'AccessGroup', 'Document', 'Risk', 'Threat'
+          'AccessGroup', 'Risk', 'Threat'
         ]
       },
       related_objects_as_source: Proxy(


### PR DESCRIPTION
Steps to reproduce:
1. Open Global Search
2. Click 'Add Mapping Filter' button
3. Expand 'Mapped to' dropdown list with the objects
4. Select 'Reference' object
5. Click 'Search' button
*Actual Result:* 'Reference' object is displayed in Unified Mapper/Global Search
*Expected Result:* 'Reference' object should not be displayed in Unified Mapper/Global Search
