### PR TITLE
QUICK-FIX Remove username and password from mysql commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \
     zip \
   && rm -rf /var/lib/apt/lists/*
 
+COPY ./provision/docker/my.cnf /root/.my.cnf
 COPY ./provision/docker/vagrant.bashrc /root/.bashrc
 COPY ./git_hooks/post-checkout /home/vagrant/.git/hooks/post-checkout
 COPY ./git_hooks/post-merge /home/vagrant/.git/hooks/post-merge

--- a/bin/create_apisearch_dump
+++ b/bin/create_apisearch_dump
@@ -22,4 +22,4 @@ from api_search.setup_environment import SetupEnvironment
 SetupEnvironment()
 "
 
-mysqldump -uroot -proot -h$HOST $DB_NAME > $DUMP_PATH_NAME
+mysqldump -h$HOST $DB_NAME > $DUMP_PATH_NAME

--- a/bin/db_reset
+++ b/bin/db_reset
@@ -65,12 +65,12 @@ then
   exit 1
 fi
 
-mysql -uroot -proot -h$HOST -e "drop database if exists $DB_NAME"
-mysql -uroot -proot -h$HOST -e "create database $DB_NAME character set utf8"
+mysql -h$HOST -e "drop database if exists $DB_NAME"
+mysql -h$HOST -e "create database $DB_NAME character set utf8"
 
 if [[ -f "$DUMP_FILE" ]]; then
   echo "Importing: $DUMP_FILE"
-  mysql -uroot -proot -h$HOST $DB_NAME < $DUMP_FILE
+  mysql -h$HOST $DB_NAME < $DUMP_FILE
 fi
 
 db_migrate

--- a/provision/docker/my.cnf
+++ b/provision/docker/my.cnf
@@ -1,0 +1,7 @@
+[mysqldump]
+user=root
+password=root
+
+[mysql]
+user=root
+password=root


### PR DESCRIPTION
Using usernames and passwords in cli shows a warning when resetting the
database and the safer option is to have those in a config file. With
this change we can now omit -u and -p flags on all mysql commands.