### PR TITLE
GGRC-3370 Pagination controls are not function in Global Search/Unified Mapper 

### DIFF
--- a/src/ggrc/assets/javascripts/components/dropdown/dropdown.js
+++ b/src/ggrc/assets/javascripts/components/dropdown/dropdown.js
@@ -25,7 +25,6 @@
             var isGroupedDropdown = this.attr('isGroupedDropdown');
             var optionsGroups = this.attr('optionsGroups');
             var noneValue = this.attr('noValueLabel') || '--';
-            var simpleList = this.attr('simpleList');
             var none = isGroupedDropdown ?
               [{
                 group: noneValue,
@@ -38,7 +37,7 @@
             var list = [];
             if (!isGroupedDropdown) {
               list = can.map(this.attr('optionsList') || [], function (option) {
-                if (_.isString(option) || simpleList) {
+                if (_.isString(option)) {
                   return {
                     value: option,
                     title: option
@@ -83,7 +82,6 @@
        */
       optionsList: [],
       optionsGroups: {},
-      simpleList: false,
       isDisabled: false
     },
     init: function (element, options) {

--- a/src/ggrc/assets/mustache/components/tree_pagination/tree_pagination.mustache
+++ b/src/ggrc/assets/mustache/components/tree_pagination/tree_pagination.mustache
@@ -6,12 +6,13 @@
   </div>
   <div class="pagination dropdown-container">
     {{#paging}}
-      <dropdown class="pagination-dropdown"
-                tabindex="18"
-                simple-list="true"
-                options-list="pageSizeSelect" 
-                name="pageSize">
-      </dropdown>
+    <select class="pagination-dropdown"
+            ($change)="changePageSize(%element.value)">
+      <option selected hidden>{{pageSize}}</option>
+      {{#pageSizeSelect}}
+        <option value="{{.}}" >{{.}}</option>
+      {{/pageSizeSelect}}
+    </select>
     {{/paging}}
   </div>
   <div class="tree-pagination__count per-page">

--- a/src/ggrc/assets/stylesheets/components/tree_pagination/_tree_pagination.scss
+++ b/src/ggrc/assets/stylesheets/components/tree_pagination/_tree_pagination.scss
@@ -42,13 +42,16 @@ tree-pagination {
       border-radius: 2px;
 
       &.dropdown-container {
-        dropdown {
+        select {
+          color: $textGray;
+          width: 100%;
+          cursor: pointer;
           &.pagination-dropdown {
-            select {
-              cursor: pointer;
-              background-color: $paginationGray;
-              border-radius: 2px;
-            }
+            background-color: $paginationGray;
+            border-radius: 2px;
+          }
+          &:disabled {
+            cursor: default;
           }
         }
       }


### PR DESCRIPTION
Steps to reproduce:
1. Open Global Search
2. Click Search
3. Click '>' or '>>': is not working
Actual Result: Pagination controls are not function in Global Search/Unified Mapper
Expected Result: Pagination controls should be function in Global Search/Unified Mapper