### PR TITLE
GGRC-1456 Fix the formatting of the Date type CA in tree view

### DIFF
--- a/src/ggrc/assets/javascripts/components/tree/tests/tree-item-custom-attribute_spec.js
+++ b/src/ggrc/assets/javascripts/components/tree/tests/tree-item-custom-attribute_spec.js
@@ -30,6 +30,12 @@ describe('helpers.get_custom_attr_value', function () {
       title: 'CheckBox',
       attribute_type: 'Checkbox',
       id: 4
+    },
+    {
+      definition_type: 'control',
+      title: 'Date',
+      attribute_type: 'Date',
+      id: 5
     }];
 
     origValue = GGRC.custom_attr_defs;
@@ -138,4 +144,18 @@ describe('helpers.get_custom_attr_value', function () {
 
       expect(value).toEqual('No');
     });
+
+  it('returns formatted date', function () {
+    var attr = {
+      attr_name: 'Date'
+    };
+    var value;
+    fakeOptions = {
+      hash: getHash('2017-09-30', 5, 'Date')
+    };
+
+    value = helper(attr, fakeInstance, fakeOptions);
+
+    expect(value).toEqual('09/30/2017');
+  });
 });

--- a/src/ggrc/assets/javascripts/components/tree/tree-item-custom-attribute.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-item-custom-attribute.js
@@ -20,8 +20,13 @@ var helpers = {
     var definition;
     var customAttrItem;
     var getValue;
-    var typeValueMap = {
-      Checkbox: ['No', 'Yes']
+    var formatValueMap = {
+      Checkbox: function (value) {
+        return ['No', 'Yes'][value];
+      },
+      Date: function (value) {
+        return GGRC.Utils.formatDate(value, true);
+      }
     };
 
     attr = Mustache.resolve(attr);
@@ -50,9 +55,9 @@ var helpers = {
               object: item.attribute_object ?
                 item.attribute_object.reify() : null
             }));
-          } else if (typeValueMap[definition.attribute_type]) {
+          } else if (formatValueMap[definition.attribute_type]) {
             value =
-              typeValueMap[definition.attribute_type][item.attribute_value];
+              formatValueMap[definition.attribute_type](item.attribute_value);
           } else {
             value = item.attribute_value;
           }


### PR DESCRIPTION
_Steps to reproduce:_
1. Create CA with date type for Control ("date-1")
2. Create program and control
3. On control's Info pane fill CA with date ("date-1") type
4. Set visible field in tree view and look at date

_Actual Result:_ Date is displayed in ISO format (like YYYY-MM-DD) 
_Expected Result:_ Date should be displayed in USA format (like MM/DD/YYYY)