### PR TITLE
GGRC-2100 Make task status color on (i) pop up consistence with other places in app

### DIFF
--- a/src/ggrc/assets/stylesheets/components/object-tasks/_object-tasks.scss
+++ b/src/ggrc/assets/stylesheets/components/object-tasks/_object-tasks.scss
@@ -43,7 +43,7 @@ object-tasks {
         &.state-inprogress{
           color: $status-inprogress;
         }
-        &.state-deprecated {
+        &.state-declined {
           color: $status-declined;
         }
       }


### PR DESCRIPTION
Update colors of task state on info pop-up in the following way:
Assigned - grey color (#bdbdbd);
In Progress - blue color (#3369e8);
Finished - #405f77;
Declined - red (#d50f25);
Verified - green (#009925).