### PR TITLE
QUICK-FIX Add ability to load GAPI Keys from external file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ coverage
 
 # LibreOffice locks
 .~lock.*#
+
+# GGRC GAPI KEYS
+provision/docker/ggrc-gapi-keys

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \
   && rm -rf /var/lib/apt/lists/*
 
 COPY ./provision/docker/vagrant.bashrc /root/.bashrc
+COPY ./provision/docker/ggrc-gapi-keys /root/ggrc-gapi-keys
 COPY ./git_hooks/post-checkout /home/vagrant/.git/hooks/post-checkout
 COPY ./git_hooks/post-merge /home/vagrant/.git/hooks/post-merge
 WORKDIR /vagrant

--- a/bin/containers
+++ b/bin/containers
@@ -74,6 +74,13 @@ setup () {
   chmod o+r ./provision/docker/mysql
   chmod o+r ./provision/docker/mysql/*
 
+  # copying GAPI keys template file if not already present
+  if [ ! -f ./provision/docker/ggrc-gapi-keys ]; then
+    cp ./extras/ggrc-gapi-keys.template ./provision/docker/ggrc-gapi-keys
+    echo "Please add your GAPI keys to the provision/docker/ggrc-gapi-keys and run the command again"
+    exit
+  fi
+
   docker-compose --file "$DOCKERFILE" --project-name "$PROJECT" \
     build
   docker-compose --file "$DOCKERFILE" --project-name "$PROJECT" \

--- a/extras/ggrc-gapi-keys.template
+++ b/extras/ggrc-gapi-keys.template
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+export GGRC_GAPI_KEY=""
+export GGRC_GAPI_CLIENT_ID=""
+export GGRC_GAPI_CLIENT_SECRET=""

--- a/provision/docker/vagrant.bashrc
+++ b/provision/docker/vagrant.bashrc
@@ -112,3 +112,7 @@ source /vagrant/bin/init_vagrant_env
 export TERM=xterm-color
 export EDITOR=vim
 PS1='\[\033[01;35m\]\u@\h\[\033[01;34m\] \w \n\$\[\033[00m\] '
+
+if [ -f ~/ggrc-gapi-keys ]; then
+  source ~/ggrc-gapi-keys
+fi


### PR DESCRIPTION
This will simplify usage of GAPI keys. No more git-stashing or running commands in container.
you will have to create file `provision/docker/ggrc-gapi-keys` with the following content:

```
#!/usr/bin/env bash

export GGRC_GAPI_KEY=""
export GGRC_GAPI_CLIENT_ID=""
export GGRC_GAPI_CLIENT_SECRET=""
```

fill the vars with appropriate keys and rebuild the containers with `./bin/containers setup dev` command. The keys files is added to .gitignore so the keys will not be committed back to the repo.
