### PR TITLE
GGRC-2031 Mappings for tasks are not shown in Active Cycles tab

### DIFF
--- a/src/ggrc/assets/javascripts/plugins/utils/tree-view-utils.js
+++ b/src/ggrc/assets/javascripts/plugins/utils/tree-view-utils.js
@@ -46,7 +46,8 @@
 
     var FULL_SUB_LEVEL_LIST = Object.freeze([
       'Cycle',
-      'CycleTaskGroup'
+      'CycleTaskGroup',
+      'CycleTaskGroupObjectTask'
     ]);
 
     var NO_FIELDS_LIMIT_LIST = Object.freeze([
@@ -75,6 +76,7 @@
     // Define specific rules for Workflow models
     orderedModelsForSubTier.Cycle = ['CycleTaskGroup'];
     orderedModelsForSubTier.CycleTaskGroup = ['CycleTaskGroupObjectTask'];
+    orderedModelsForSubTier.CycleTaskGroupObjectTask = [];
 
     function getSubTreeFields(parent, child) {
       var noFieldsLimitOnChild = hasNoFieldsLimit(child);
@@ -335,6 +337,13 @@
     }
 
     function getModelsForSubTier(model) {
+      // getMappableTypes can't be run at once,
+      // cause GGRC.Mappings is not loaded yet
+      if (model === 'CycleTaskGroupObjectTask' &&
+      !orderedModelsForSubTier[model].length) {
+        orderedModelsForSubTier[model] =
+        GGRC.Utils.getMappableTypes('CycleTaskGroupObjectTask');
+      }
       return orderedModelsForSubTier[model] || [];
     }
 


### PR DESCRIPTION
Steps to reproduce:
1. Create one time wf
2. In Setup tab add task to task group and map any object to task group
3. Activate Workflow
4. Go to Active Cycles tab, expand sublevel with task
5. Expand fourth level to see mappings for task
Actual Result: Mappings for tasks are not shown in Active Cycles tab
Expected Result: Add fourth sublevel to see mappings for tasks. Mappings for tasks should be shown in Active Cycles tab