### PR TITLE
GGRC-3243 FE: Add first-class attribute 'State' to Assessment Template

### DIFF
--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -341,6 +341,7 @@
         assessors: 'Principal Assignees',
         verifiers: 'Auditors'
       },
+      status: 'Draft',
       // the custom lists of assessor / verifier IDs if "other" is selected for
       // the corresponding default_people setting
       assessorsList: {},
@@ -356,6 +357,7 @@
         {value: 'other', title: 'Others...'}
       ]
     },
+    statuses: ['Draft', 'Deprecated', 'Active'],
     tree_view_options: {
       attr_view: GGRC.mustache_path + '/base_objects/tree-item-attr.mustache'
     },

--- a/src/ggrc/assets/javascripts/plugins/utils/state-utils.js
+++ b/src/ggrc/assets/javascripts/plugins/utils/state-utils.js
@@ -16,7 +16,7 @@
           'Control', 'DataAsset', 'Facility', 'Market',
           'Objective', 'OrgGroup', 'Policy', 'Process', 'Product', 'Program',
           'Project', 'Regulation', 'Risk', 'Section', 'Standard', 'System',
-          'Threat', 'Vendor'
+          'Threat', 'Vendor', 'AssessmentTemplate'
         ],
         states: ['Active', 'Draft', 'Deprecated']
       },

--- a/src/ggrc/assets/mustache/assessment_templates/info.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/info.mustache
@@ -20,8 +20,8 @@
             <h6>Title</h6>
             <h3>{{title}}</h3>
 
-            {{#if type}}
-              <p>{{type.title}}</p>
+            {{#if status}}
+              <span class="state-value {{addclass 'state-' status separator=''}}">{{un_camel_case status}}</span>
             {{/if}}
           </div>
         </div>

--- a/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
@@ -200,6 +200,18 @@
         </label>
         <input data-id="code_txtbx" tabindex="3" class="input-block-level" name="slug" placeholder="AUDIT-XXX" type="text" value="{{instance.slug}}">
       </div>
+      <div class="span4 hidable">
+        <label>
+          State
+          <i class="fa fa-question-circle" rel="tooltip" title="Indicates the status of this object."></i>
+          <a href="javascript://" class="field-hide" tabindex="-1">hide</a>
+        </label>
+          <dropdown data-test-id="new_program_dropdown_state_036a1fa6"
+                    options-list="model.statuses"
+                    name="instance.status"
+                    tabindex="23">
+          </dropdown>
+      </div>
     </div>
 
     <div class="spacing-top row-fluid hidable">


### PR DESCRIPTION
**Acceptance Criteria:**
**AC1.** Add first-class attribute 'State' to Assessment Template. 
It should be a dropdown with options: Draft, Active, Deprecated.
**AC2.** Allow user to filter Assessment Template by state.
**AC3.** Allow user to import / export state for Assessment Template

**Depends on** https://github.com/google/ggrc-core/pull/6420