### PR TITLE
GGRC-1711 Fix script error when clicking 'Submit on review' on the Standard page

### DIFF
--- a/src/ggrc_workflows/assets/javascripts/controllers/approval_workflow_controller.js
+++ b/src/ggrc_workflows/assets/javascripts/controllers/approval_workflow_controller.js
@@ -13,15 +13,17 @@ GGRC.Controllers.Modals("GGRC.Controllers.ApprovalWorkflow", {
     modal_title: "Submit for review",
     custom_save_button_text: "Submit",
     content_view: GGRC.mustache_path + "/wf_objects/approval_modal_content.mustache",
-    button_view : GGRC.Controllers.Modals.BUTTON_VIEW_SAVE_CANCEL
+    button_view : GGRC.Controllers.Modals.BUTTON_VIEW_SAVE_CANCEL,
+    afterFetch: function () {
+      this.attr("instance", new CMS.ModelHelpers.ApprovalWorkflow({
+        original_object : this.attr('instance')
+      }));
+    }
   }
 }, {
   init : function() {
     this.options.button_view = GGRC.Controllers.Modals.BUTTON_VIEW_SAVE_CANCEL;
     this._super.apply(this, arguments);
-    this.options.attr("instance", new CMS.ModelHelpers.ApprovalWorkflow({
-      original_object : this.options.instance
-    }));
   },
   "input[null-if-empty] change" : function(el, ev) {
     if(el.val() === "") {


### PR DESCRIPTION
_Steps to reproduce:_
1. Go to https://ggrc-qa.appspot.com/standards/54 and click on "Submit for review" link on Standards info pane

_Actual Result:_ "Uncaught TypeError: instance.refresh is not a function" error is shown on the Standard page if click "Submit for review" 

_Expected Result:_ no error is shown if click "Submit for review" link