### PR TITLE
GGRC-2275 Add 'Administration' link to user menu on the Import/Export pages

### DIFF
--- a/src/ggrc/templates/base_objects/_page_header.haml
+++ b/src/ggrc/templates/base_objects/_page_header.haml
@@ -1,8 +1,10 @@
 -# Copyright (C) 2017 Google Inc.
 -# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
+-set user_role = current_user.system_wide_role.lower()
+
 .header-content
-  -if current_user.system_wide_role.lower() != 'no access'
+  -if user_role != 'no access'
     %button{ 'class': 'lhn-trigger lhn-no-init pull-left', 'href': 'javascript://'}
       %span.icon-bar
       %span.icon-bar
@@ -49,6 +51,13 @@
         %li{'class': 'user-email'}
           %span
             =current_user.email
+
+        -if user_role == 'administrator' or user_role == 'superuser'
+          %li
+            %a{ 'href': '/admin#people_list_widget', 'class': 'admin-btn' }
+              %i.fa.fa-tachometer
+              %span
+                Administration
 
         %li
           %a{ 'href': '/export', 'class': 'export-btn', 'target': '_blank' }


### PR DESCRIPTION
_Steps to reproduce:_
1. Open Export/Import pages
2. Click on Person icon on the top right corner
3. Look at the dropdown:

_Actual Result:_ There is no "Administration" in dropdown on the Import/Export pages
_Expected Result:_ "Administration" in dropdown is displayed on the Import/Export pages
