### PR TITLE
GGRC-2934 'Secondary contacts' field is missed in Custom Roles for Program

### DIFF
--- a/src/ggrc/migrations/utils/update_acr.py
+++ b/src/ggrc/migrations/utils/update_acr.py
@@ -1,0 +1,84 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+
+"""Helper for updating access_control_roles table with the missing records
+
+"""
+import json
+from datetime import datetime
+
+import sqlalchemy as sa
+from sqlalchemy.sql import table, text, column
+from alembic import op
+
+
+def update_acr(role, model, **kwargs):
+  """Update one row in acr"""
+  connection = op.get_bind()
+  # check if the role exists
+  res = connection.execute(text(
+      """
+      SELECT * FROM access_control_roles
+      WHERE name=:role AND object_type=:type;
+      """
+  ), role=role, type=model)
+  if res.rowcount > 0:
+    return
+  role_content = "%\"name\": \"{}\"%".format(role)
+  model_content = "%\"object_type\": \"{}\"%".format(model)
+  # check if the role could be found among deleted revisions
+  res = connection.execute(text(
+      """
+      SELECT content FROM revisions
+      WHERE resource_type='AccessControlRole'
+      AND action='deleted'
+      AND content LIKE :role_content
+      AND content LIKE :model_content
+      ORDER BY created_at DESC;
+      """
+  ), role_content=role_content, model_content=model_content)
+  acr = res.first()
+  acr_id = None
+  if acr:
+    acr = json.loads(acr[0])
+    acr_id = acr.get("id")
+  # otherwise just insert a new one
+  acr_table = table(
+      "access_control_roles",
+      column('id', sa.Integer()),
+      column('name', sa.String),
+      column('object_type', sa.String),
+      column('created_at', sa.DateTime()),
+      column('updated_at', sa.DateTime()),
+      column('mandatory', sa.Boolean()),
+      column('default_to_current_user', sa.Boolean()),
+      column('non_editable', sa.Boolean()),
+  )
+  now = datetime.now()
+  update_dict = dict(id=acr_id, name=role, object_type=model,
+                     created_at=now, updated_at=now)
+  update_dict.update(kwargs)
+  connection.execute(acr_table.insert(), [update_dict])
+
+
+def update_ownable_models(models):
+  for model in models:
+    update_acr(
+        "Admin",
+        model,
+        mandatory=u"1",
+        default_to_current_user=u"1",
+        non_editable=u"1",
+    )
+
+
+def update_models_with_contacts(models, roles):
+  for model in models:
+    for role in roles:
+      update_acr(
+          role,
+          model,
+          non_editable=u"1",
+      )

--- a/src/ggrc/migrations/versions/20171027124751_3c095f8ad47_recover_missing_acr_mandatory_roles.py
+++ b/src/ggrc/migrations/versions/20171027124751_3c095f8ad47_recover_missing_acr_mandatory_roles.py
@@ -1,0 +1,100 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Check for missing mandatory roles in ACR table and create them.
+
+Create Date: 2017-10-27 12:47:51.389160
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+from ggrc.migrations.utils import update_acr
+
+
+# revision identifiers, used by Alembic.
+revision = '3c095f8ad47'
+down_revision = 'fa2f60a53c9'
+
+
+# have Admin role
+# no Assessment and Program
+OWNABLE_MODELS = {
+    'AccessGroup',
+    'Clause',
+    'Contract',
+    'Control',
+    'DataAsset',
+    'Facility',
+    'Issue',
+    'Market',
+    'Objective',
+    'OrgGroup',
+    'Policy',
+    'Process',
+    'Product',
+    'Project',
+    'Regulation',
+    'Section',
+    'Standard',
+    'System',
+    'Vendor',
+
+    'Comment',
+    'Document',
+}
+
+# have contacts roles
+# no Comment and Document
+MODELS_WITH_CONTACTS = {
+    "AccessGroup",
+    "Assessment",
+    "Clause",
+    "Contract",
+    "Control",
+    "DataAsset",
+    "Facility",
+    "Issue",
+    "Market",
+    "Objective",
+    "OrgGroup",
+    "Policy",
+    "Process",
+    "Product",
+    "Project",
+    "Program",
+    "Regulation",
+    "Section",
+    "Standard",
+    "System",
+    "Vendor",
+}
+
+NON_EDITABLE_ROLES = {
+    "Primary Contacts",
+    "Secondary Contacts",
+}
+
+NON_EDITABLE_CONTROL_ROLES = {
+    "Principal Assignees",
+    "Secondary Assignees",
+}
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  update_acr.update_ownable_models(OWNABLE_MODELS)
+  update_acr.update_models_with_contacts(MODELS_WITH_CONTACTS,
+                                         NON_EDITABLE_ROLES)
+
+  for role in NON_EDITABLE_CONTROL_ROLES:
+    update_acr.update_acr(
+        role,
+        "Control",
+        non_editable=u"1",
+    )
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  pass

--- a/src/ggrc_risks/migrations/versions/20171027124743_1be0dd01f559_create_missing_risks_acr_mandatory_roles.py
+++ b/src/ggrc_risks/migrations/versions/20171027124743_1be0dd01f559_create_missing_risks_acr_mandatory_roles.py
@@ -1,0 +1,49 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Check for missing mandatory roles in ACR table and create them.
+
+Create Date: 2017-10-27 12:47:43.403028
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+from ggrc.migrations.utils import update_acr
+
+
+# revision identifiers, used by Alembic.
+revision = '1be0dd01f559'
+down_revision = '5aa9ec7105d1'
+
+
+# have Admin role
+# no Assessment and Program
+RISKS_OWNABLE_MODELS = {
+    'Risk',
+    'Threat',
+}
+
+# have contacts roles
+# no Comment and Document
+RISKS_MODELS_WITH_CONTACTS = {
+    "Risk",
+    "Threat",
+}
+
+RISKS_NON_EDITABLE_ROLES = {
+    "Primary Contacts",
+    "Secondary Contacts",
+}
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  update_acr.update_ownable_models(RISKS_OWNABLE_MODELS)
+  update_acr.update_models_with_contacts(RISKS_MODELS_WITH_CONTACTS,
+                                         RISKS_NON_EDITABLE_ROLES)
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  pass


### PR DESCRIPTION
Steps to reproduce:
1. As admin go to the Administration page > Custom Roles tab
2. Click gray triangle for Programs and look at the Custom Roles: 'Secondary Contacts' is missing
Actual Result: 'Secondary contacts' field is missed in Custom Roles for Program
Expected Result: 'Secondary contacts' field should be displayed in Custom Roles for Program and should be predefined
