### PR TITLE
GGRC-3404 Fix audit removal

### DIFF
--- a/src/ggrc/models/hooks/audit.py
+++ b/src/ggrc/models/hooks/audit.py
@@ -18,7 +18,7 @@ def init_hook():
   # pylint: disable=unused-variable
   @signals.Restful.model_put.connect_via(all_models.Audit)
   @signals.Restful.model_deleted.connect_via(all_models.Audit)
-  def handle_audit_permission_put(sender, obj, src, service=None):
+  def handle_audit_permission_put(sender, obj, src=None, service=None):
     """Make sure admins cannot delete/update archived audits"""
     # pylint: disable=unused-argument
     if obj.archived and not db.inspect(


### PR DESCRIPTION
Currently any DELETE request for an Audit fails with HTTP500.

Steps to reproduce:
1. Create a new Audit.
2. Open its Info Pane.
3. Click "Delete" button.

Expected result: the Audit is removed.
Actual result: the Audit is reported to be removed, but stays if you refresh the page.

Note: to get this actual result, please run with GAE.