### PR TITLE
QUICK-FIX Add parametrized test for check Assessment Templates' statuses after Audit cloning w/ them

### DIFF
--- a/test/selenium/src/lib/constants/element.py
+++ b/test/selenium/src/lib/constants/element.py
@@ -320,7 +320,8 @@ class AssessmentTemplateModalSetVisibleFields(CommonModalSetVisibleFields):
   DEFAULT_SET_FIELDS = (
       CommonModalSetVisibleFields.TITLE,
       CommonModalSetVisibleFields.CODE,
-      CommonModalSetVisibleFields.LAST_UPDATED)
+      CommonModalSetVisibleFields.LAST_UPDATED,
+      CommonModalSetVisibleFields.STATE)
 
 
 class AssessmentModalSetVisibleFields(CommonModalSetVisibleFields):

--- a/test/selenium/src/lib/entities/entities_factory.py
+++ b/test/selenium/src/lib/entities/entities_factory.py
@@ -513,7 +513,7 @@ class AssessmentTemplatesFactory(EntitiesFactory):
              slug=None, audit=None, default_people=None,
              template_object_type=None, updated_at=None,
              custom_attribute_definitions=None, custom_attribute_values=None,
-             custom_attributes=None):
+             custom_attributes=None, status=None):
     """Create Assessment Template object.
     Random values will be used for title and slug.
     Predictable values will be used for type, template_object_type and
@@ -528,7 +528,7 @@ class AssessmentTemplatesFactory(EntitiesFactory):
         template_object_type=template_object_type, updated_at=updated_at,
         custom_attribute_definitions=custom_attribute_definitions,
         custom_attribute_values=custom_attribute_values,
-        custom_attributes=custom_attributes)
+        custom_attributes=custom_attributes, status=status)
     return asmt_tmpl_entity
 
   @classmethod
@@ -542,6 +542,7 @@ class AssessmentTemplatesFactory(EntitiesFactory):
     random_asmt_tmpl.assessors = unicode(roles.AUDIT_LEAD)
     random_asmt_tmpl.slug = cls.generate_slug()
     random_asmt_tmpl.template_object_type = cls.obj_control.title()
+    random_asmt_tmpl.status = unicode(element.ObjectStates.DRAFT)
     random_asmt_tmpl.default_people = {"verifiers": unicode(roles.AUDITORS),
                                        "assessors": unicode(roles.AUDIT_LEAD)}
     return random_asmt_tmpl

--- a/test/selenium/src/lib/entities/entity.py
+++ b/test/selenium/src/lib/entities/entity.py
@@ -480,8 +480,8 @@ class Representation(object):
     ''*exclude_attrs' - tuple of excluding attributes names.
     """
     # pylint: disable=invalid-name
-    expected_objs = help_utils.convert_to_list(expected_objs)
-    actual_objs = help_utils.convert_to_list(actual_objs)
+    expected_objs = help_utils.convert_to_list(copy.deepcopy(expected_objs))
+    actual_objs = help_utils.convert_to_list(copy.deepcopy(actual_objs))
     expected_excluded_attrs = [
         dict([(attr, getattr(expected_obj, attr)) for attr in exclude_attrs])
         for expected_obj in expected_objs]
@@ -771,16 +771,19 @@ class AssessmentTemplateEntity(Entity):
   __hash__ = None
 
   attrs_names_to_compare = [
-      "custom_attributes", "slug", "title", "type", "updated_at"]
+      "custom_attributes", "slug", "title", "type", "updated_at", "status"]
   attrs_names_to_repr = Representation.core_attrs_names_to_repr + [
-      "audit", "template_object_type", "updated_at", "custom_attributes"]
+      "audit", "template_object_type", "updated_at", "custom_attributes",
+      "status"]
 
   def __init__(self, audit=None, default_people=None,
                template_object_type=None, updated_at=None,
                custom_attribute_definitions=None,
-               custom_attribute_values=None, custom_attributes=None):
+               custom_attribute_values=None, custom_attributes=None,
+               status=None):
     super(AssessmentTemplateEntity, self).__init__()
     # REST and UI
+    self.status = status  # state ("Active", "Draft", "Deprecated")
     self.default_people = default_people  # {"verifiers": *, "assessors": *}
     self.template_object_type = template_object_type  # objs under asmt
     self.updated_at = updated_at  # last updated datetime

--- a/test/selenium/src/lib/factory.py
+++ b/test/selenium/src/lib/factory.py
@@ -30,9 +30,8 @@ def _factory(cls_name, parent_cls, search_nested_subclasses=False):
  """
   member_cls = None
   subcls_name = _filter_out_underscore(cls_name.lower())
-  members = _all_subclasses(parent_cls) \
-      if search_nested_subclasses \
-      else parent_cls.__subclasses__()
+  members = (_all_subclasses(parent_cls) if search_nested_subclasses else
+             parent_cls.__subclasses__())
   for member_cls in members:
     if member_cls.__name__.lower() == subcls_name:
       break
@@ -123,6 +122,15 @@ def get_cls_rest_service(object_name):
   return _factory(cls_name=cls_name, parent_cls=base_cls)
 
 
+def get_cls_webui_service(object_name):
+  """Get and return class of webui service."""
+  from lib.service import webui_service
+  cls_name = object_name + constants.cls_name.SERVICE
+  base_cls = webui_service.BaseWebUiService
+  return _factory(cls_name=cls_name, parent_cls=base_cls,
+                  search_nested_subclasses=True)
+
+
 def get_cls_create_obj(object_name):
   """Get and return class of create object."""
   from lib.page.modal import create_new_object
@@ -164,25 +172,3 @@ def get_locator_add_widget(widget_name):
   # todo: unittests
   return getattr(
       constants.locator.WidgetBarButtonAddDropdown, widget_name.upper())
-
-
-def get_ui_service(object_name):
-  """Get and return class of UI service according to name of object
-  Returns:
-    class of ui service by object_name
-  """
-  service_name = objects.get_plural(object_name, title=True)
-  from lib.service import webui_service
-  service_classname = service_name + constants.cls_name.SERVICE
-  return getattr(webui_service, service_classname)
-
-
-def get_rest_service(object_name):
-  """Get and return class of REST service according to name of object
-  Returns:
-    class of REST service by object_name
-  """
-  service_name = objects.get_plural(object_name, title=True)
-  from lib.service import rest_service
-  service_classname = service_name + constants.cls_name.SERVICE
-  return getattr(rest_service, service_classname)

--- a/test/selenium/src/lib/service/rest_service.py
+++ b/test/selenium/src/lib/service/rest_service.py
@@ -65,6 +65,14 @@ class BaseRestService(object):
     return [self.set_obj_attrs(attrs=new_attrs, obj=new_obj) for
             new_attrs, new_obj in zip(list_new_attrs, list_new_objs)]
 
+  def update_obj(self, obj, **attrs):
+    """Update attributes values of existing object via REST API."""
+    obj.update_attrs(**attrs)
+    return self.get_items_from_resp(
+        self.client.update_object(
+            href=obj.href, **dict({k: v for k, v in obj.__dict__
+                                  .iteritems() if k != "href"}.items())))
+
   @staticmethod
   def get_items_from_resp(response):
     """Check response from server and get items {key: value} from it."""
@@ -210,14 +218,6 @@ class AssessmentsService(BaseRestService):
           src_obj=ObjectPersonsFactory().default(), dest_objs=objs,
           attrs={"AssigneeType": ",".join(assignees)})
     return objs
-
-  def update_obj(self, obj, **attrs):
-    """Update attributes values of existing Assessment via REST API"""
-    obj.update_attrs(**attrs)
-    return self.get_items_from_resp(
-        self.client.update_object(
-            href=obj.href, **dict({k: v for k, v in obj.__dict__
-                                  .iteritems() if k != "href"}.items())))
 
 
 class IssuesService(BaseRestService):

--- a/test/selenium/src/tests/conftest.py
+++ b/test/selenium/src/tests/conftest.py
@@ -97,16 +97,6 @@ def chrome_options(chrome_options, create_tmp_dir):
   return chrome_options
 
 
-@pytest.yield_fixture(scope="function")
-def dynamic_new_assessment_template(request):
-  """Dynamically create new Assessment Template under Audit object according
-  to fixturename. Fixturename is indirect parameter that get from
-  'request.param' and have to be string or boolean.
-  Return: lib.entities.entity.AssessmentTemplateEntity
-  """
-  yield _common_fixtures(request.param) if request.param else None
-
-
 @pytest.fixture(scope="function")
 def my_work_dashboard(selenium):
   """Open My Work Dashboard URL and

--- a/test/selenium/src/tests/test_asmts_workflow.py
+++ b/test/selenium/src/tests/test_asmts_workflow.py
@@ -173,7 +173,7 @@ class TestAssessmentsWorkflow(base.Test):
     expected_asmt = dynamic_object_w_factory_params
     if expected_initial_state:
       (rest_service.AssessmentsService().
-       update_obj(expected_asmt, status=expected_initial_state))
+       update_obj(obj=expected_asmt, status=expected_initial_state))
     assessments_service = webui_service.AssessmentsService(selenium)
     getattr(assessments_service, action)(expected_asmt)
     actual_asmt = assessments_service.get_obj_from_info_page(expected_asmt)
@@ -183,8 +183,8 @@ class TestAssessmentsWorkflow(base.Test):
                                    verified=actual_asmt.verified).repr_ui(),
         actual_asmt, "updated_at")
 
-  @pytest.mark.parametrize("operator", [alias.EQUAL_OP, alias.CONTAINS_OP])
   @pytest.mark.smoke_tests
+  @pytest.mark.parametrize("operator", [alias.EQUAL_OP, alias.CONTAINS_OP])
   def test_asmts_gcas_filtering(
       self, new_program_rest, new_audit_rest, new_cas_for_assessments_rest,
       new_assessments_rest, selenium, operator
@@ -228,6 +228,7 @@ class TestAssessmentsWorkflow(base.Test):
         messages.AssertionMessages.format_err_msg_equal(expected_results,
                                                         actual_results))
 
+  @pytest.mark.smoke_tests
   @pytest.mark.parametrize(
       "dynamic_object, dynamic_relationships",
       [("new_objective_rest", "map_new_program_rest_to_new_objective_rest"),


### PR DESCRIPTION
This PR add parametrized test for check Assessment Templates' statuses after Audit cloning w/ them.

```Python

  @pytest.fixture(scope="function")
  def create_and_clone_audit_w_params_to_update(
      self, request, new_program_rest, new_control_rest,
      map_new_program_rest_to_new_control_rest, new_audit_rest,
      new_assessment_rest, new_assessment_template_rest, new_issue_rest,
      selenium
  ):
    """Create Audit with clonable and non clonable objects via REST API and
    clone it with them via UI.
    Preconditions:
    - Program, Control created via REST API.
    - Control mapped to Program via REST API.
    - Audit created under Program via REST API.
    - Assessment, Assessment Template, Issue created under Audit via REST API.
    - Issue mapped to Audit via REST API.
    """
    # pylint: disable=too-many-locals
    if request.param:
      if isinstance(request.param, tuple):
        fixture, params_to_update = request.param
        # fixtures from 'create_and_clone_audit_w_params_to_update' which are objects
        if fixture in request.fixturenames and fixture.startswith("new_"):
          fixture = locals().get(fixture)
          (get_cls_rest_service(objects.get_plural(fixture.type))().
           update_obj(obj=fixture, **params_to_update))
    expected_audit = entities_factory.AuditsFactory().clone(
        audit=new_audit_rest)[0]
    expected_asmt_tmpl = entities_factory.AssessmentTemplatesFactory().clone(
        asmt_tmpl=new_assessment_template_rest)[0]
    actual_audit = (webui_service.AuditsService(selenium).
                    clone_via_info_page_and_get_obj(audit_obj=new_audit_rest))
    return {
        "audit": new_audit_rest, "expected_audit": expected_audit,
        "actual_audit": actual_audit, "assessment": new_assessment_rest,
        "issue": new_issue_rest,
        "assessment_template": new_assessment_template_rest,
        "expected_assessment_template": expected_asmt_tmpl,
        "control": new_control_rest, "program": new_program_rest
    }

...


  @pytest.mark.smoke_tests
  @pytest.mark.cloning
  @pytest.mark.parametrize(
      "create_and_clone_audit_w_params_to_update",
      [("new_assessment_template_rest", {"status": ObjectStates.DRAFT}),
       ("new_assessment_template_rest", {"status": ObjectStates.DEPRECATED}),
       ("new_assessment_template_rest", {"status": ObjectStates.ACTIVE})],
      ids=["Using initial Assessment Template w' 'Draft' status",
           "Using initial Assessment Template w' 'Deprecated' status",
           "Using initial Assessment Template w' 'Active' status"],
      indirect=True)
  def test_clonable_audit_related_objs_move_to_cloned_audit(
      self, create_and_clone_audit_w_params_to_update, selenium
  ):
    """Check via UI that clonable audit related object Assessment Template
    move to cloned Audit using all initial Assessment Templates's states.
    Preconditions:
    -Execution and return of fixture
    'create_and_clone_audit_w_params_to_update'.
    Test parameters:
    - 'create_and_clone_audit_w_params_to_update' which contains params to
    update asmt tmpl status via REST API.
    """
    actual_audit = create_and_clone_audit_w_params_to_update["actual_audit"]
    expected_asmt_tmpl = (
        create_and_clone_audit_w_params_to_update[
            "expected_assessment_template"].repr_ui())
    actual_asmt_tmpls = (webui_service.AssessmentTemplatesService(selenium).
                         get_list_objs_from_tree_view(src_obj=actual_audit))
    # due to 'expected_asmt_tmpl.slug = None',
    #        'expected_asmt_tmpl.updated_at = {None: None}'
    actual_asmt_tmpls = [
        actual_asmt_tmpl.update_attrs(slug=None, updated_at=None, status=None)
        for actual_asmt_tmpl in actual_asmt_tmpls]
    # due to issue GGRC-3423
    if expected_asmt_tmpl.status != ObjectStates.DRAFT:
      if expected_asmt_tmpl.status != actual_asmt_tmpls[0].status:
        pytest.xfail(reason="GGRC-3423 Issue")
      else:
        pytest.fail(msg="GGRC-3423 Issue was fixed")
```