### PR TITLE
GGRC-3386 Due Date not Displayed in Due Date Field in Assessment view

### DIFF
--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -2319,6 +2319,10 @@ Mustache.registerHelper('get_url_value', function (attr_name, instance) {
             } else if (typeValueMap[item.attributeType]) {
               value = typeValueMap[item.attributeType][item.attribute_value] ||
                 'No';
+            } else {
+              value = (item.attributeType === 'date') ?
+                GGRC.Utils.formatDate(item.attribute_value, true) :
+                item.attribute_value;
             }
           }
         };
@@ -2330,7 +2334,7 @@ Mustache.registerHelper('get_url_value', function (attr_name, instance) {
         }
       }
 
-      return value;
+      return value || '';
     });
 
   Mustache.registerHelper('pretty_role_name', function (name) {

--- a/src/ggrc/assets/js_specs/mustache_helpers/get_custom_attr_value_spec.js
+++ b/src/ggrc/assets/js_specs/mustache_helpers/get_custom_attr_value_spec.js
@@ -80,9 +80,9 @@ describe('can.mustache.helper.get_custom_attr_value', function () {
     expect(value).toEqual('No');
   });
 
-  it('return an empty string if customAttrItem is not undefined', function () {
+  it('return an empty string if customAttrItem is undefined', function () {
     var value;
-    fakeOptions.hash = getHash('correctValue');
+    fakeOptions.hash = getHash();
     value = helper(fakeAttr, fakeInstance, fakeOptions);
 
     expect(value).toEqual('');


### PR DESCRIPTION
What is the problem / issue?
If I go to "My Assessments", the "Due Date" column doesn't display any data. The Due Date shows up in the assessment in "Other Attributes" and I'm still able to filter by it when using Advanced Search.
See screenshot here: [^screenshot-1.png]

What is the expected result / outcome? (ie What should happen?)
Due data values should display in the column and allow sorting.

What is the impact if it is not fixed / implemented? (Quantify the impact, eg, # of hours)
Slows down ECBP workflow, requiring filtering by date through advanced search rather than being able to sort and see all the assessments at once.

The cause of issue is https://github.com/google/ggrc-core/pull/6188. It breaks displaying of custom attributes in tree-view except checkbox type.
Fix allows correctly display another types of CA including date in proper format.
