### PR TITLE
QUICK-FIX Adjust eslint config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -43,6 +43,9 @@
   },
 
   "rules": {
+    "comma-dangle": [
+      1, "always-multiline"
+    ],
     "id-length": [1, {
       "min": 2,
       "max": 25,
@@ -76,8 +79,10 @@
       "args": "none",
       "vars": "all"
     }],
+    "no-var": 0,
     // Each variable declaration must have its own var keyword
     "one-var": [2, "never"],
+    "prefer-rest-params": 0,
     "quote-props": [2, "as-needed", {
       "numbers": true,
       "keywords": true


### PR DESCRIPTION
Until https://github.com/google/ggrc-core/pull/6444 is merged and we update uglify-js we'll have to keep writing vars. Disabling `no-var` until then.

Adjustments:

`no-var` - we can't use let yet
`prefer-rest-params` - we can't use rest params yet
`comma-dangle` - adjusted to always-multiline because it is useful for making diffs nicer