### PR TITLE
QUICK-FIX Cleanup CAV component

### DIFF
--- a/src/ggrc/assets/javascripts/components/tree/templates/tree-item-custom-attribute.mustache
+++ b/src/ggrc/assets/javascripts/components/tree/templates/tree-item-custom-attribute.mustache
@@ -4,7 +4,7 @@
 }}
 
 {{#values}}
-  {{#get_custom_attr_value column instance customAttrItem=.}}
+  {{#get_custom_attr_value column instance .}}
       {{! because the object can currently only be a
       person there is no need to switch }}
       <tree-people-list-field {source}="object">

--- a/src/ggrc/assets/javascripts/components/tree/tree-item-custom-attribute.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-item-custom-attribute.js
@@ -42,14 +42,18 @@ var helpers = {
       // reify all models with the exception of the Assessment,
       // because it has a different logic of work with the CA
       customAttrItem = customAttrItem.reify();
+
+      // Getting a definition should be done with a def map for both
+      // assessment and non assessment objects.
+      definition = _.find(instance.custom_attribute_definitions, function(def){
+        return def.id == customAttrItem.custom_attribute_id
+      });
+    } else {
+      // In assessments we have custom attr def right in the CAV
+      definition = customAttrItem.def
+
     }
 
-    can.each(GGRC.custom_attr_defs, function (item) {
-      if (item.definition_type === instance.class.table_singular &&
-        item.title === attr.attr_name) {
-        definition = item;
-      }
-    });
 
     if (definition) {
       if (customAttrItem.custom_attribute_id === definition.id) {

--- a/src/ggrc/assets/javascripts/components/tree/tree-item-custom-attribute.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-item-custom-attribute.js
@@ -54,6 +54,16 @@ var helpers = {
 
     }
 
+    // Parent mustache helper should not loop through all and expect this
+    // filter to work. It should only call this once with the correct CAV
+    // see tree-item-custom-attribute.mustache - for every single value that
+    // it needs to display, it loop through all values and then hopefully just
+    // displays the single one that matches the column name
+    // NOTE: The current implementation of the mustache file is also really bad
+    // for performance!
+    if (definition.title !== attr.attr_title) {
+      return ''
+    }
 
     if (definition) {
       if (customAttrItem.custom_attribute_id === definition.id) {

--- a/src/ggrc/assets/javascripts/components/tree/tree-item-custom-attribute.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-item-custom-attribute.js
@@ -65,12 +65,9 @@ var helpers = {
     }
 
     if (formatValueMap[definition.attribute_type]) {
-      value = formatValueMap[definition.attribute_type](customAttrItem);
-    } else {
-      value = customAttrItem.attribute_value;
+      return formatValueMap[definition.attribute_type](customAttrItem);
     }
-
-    return value || '';
+    return customAttrItem.attribute_value;
   }
 };
 

--- a/src/ggrc/assets/javascripts/components/tree/tree-item-custom-attribute.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-item-custom-attribute.js
@@ -46,25 +46,17 @@ var helpers = {
     });
 
     if (definition) {
-      getValue = function (item) {
-        if (!(instance instanceof CMS.Models.Assessment)) {
-          // reify all models with the exception of the Assessment,
-          // because it has a different logic of work with the CA
-          item = item.reify();
+      if (!(instance instanceof CMS.Models.Assessment)) {
+        // reify all models with the exception of the Assessment,
+        // because it has a different logic of work with the CA
+        customAttrItem = customAttrItem.reify();
+      }
+      if (customAttrItem.custom_attribute_id === definition.id) {
+        if (formatValueMap[definition.attribute_type]) {
+          value = formatValueMap[definition.attribute_type](customAttrItem);
+        } else {
+          value = customAttrItem.attribute_value;
         }
-        if (item.custom_attribute_id === definition.id) {
-          if (formatValueMap[definition.attribute_type]) {
-            value = formatValueMap[definition.attribute_type](item);
-          } else {
-            value = item.attribute_value;
-          }
-        }
-      };
-
-      if (!_.isUndefined(customAttrItem)) {
-        getValue(customAttrItem);
-      } else {
-        can.each(instance.custom_attribute_values, getValue);
       }
     }
 

--- a/src/ggrc/assets/javascripts/components/tree/tree-item-custom-attribute.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-item-custom-attribute.js
@@ -51,7 +51,6 @@ var helpers = {
     } else {
       // In assessments we have custom attr def right in the CAV
       definition = customAttrItem.def
-
     }
 
     // Parent mustache helper should not loop through all and expect this
@@ -65,14 +64,10 @@ var helpers = {
       return ''
     }
 
-    if (definition) {
-      if (customAttrItem.custom_attribute_id === definition.id) {
-        if (formatValueMap[definition.attribute_type]) {
-          value = formatValueMap[definition.attribute_type](customAttrItem);
-        } else {
-          value = customAttrItem.attribute_value;
-        }
-      }
+    if (formatValueMap[definition.attribute_type]) {
+      value = formatValueMap[definition.attribute_type](customAttrItem);
+    } else {
+      value = customAttrItem.attribute_value;
     }
 
     return value || '';

--- a/src/ggrc/assets/javascripts/components/tree/tree-item-custom-attribute.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-item-custom-attribute.js
@@ -38,6 +38,12 @@ var helpers = {
     instance = Mustache.resolve(instance);
     customAttrItem = Mustache.resolve(customAttrItem);
 
+    if (!(instance instanceof CMS.Models.Assessment)) {
+      // reify all models with the exception of the Assessment,
+      // because it has a different logic of work with the CA
+      customAttrItem = customAttrItem.reify();
+    }
+
     can.each(GGRC.custom_attr_defs, function (item) {
       if (item.definition_type === instance.class.table_singular &&
         item.title === attr.attr_name) {
@@ -46,11 +52,6 @@ var helpers = {
     });
 
     if (definition) {
-      if (!(instance instanceof CMS.Models.Assessment)) {
-        // reify all models with the exception of the Assessment,
-        // because it has a different logic of work with the CA
-        customAttrItem = customAttrItem.reify();
-      }
       if (customAttrItem.custom_attribute_id === definition.id) {
         if (formatValueMap[definition.attribute_type]) {
           value = formatValueMap[definition.attribute_type](customAttrItem);

--- a/src/ggrc/assets/javascripts/components/tree/tree-item-custom-attribute.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-item-custom-attribute.js
@@ -15,7 +15,7 @@ var helpers = {
   /*
     Used to get the string value for custom attributes
   */
-  get_custom_attr_value: function (attr, instance, options) {
+  get_custom_attr_value: function (attr, instance, customAttrItem, options) {
     var value = '';
     var definition;
     var customAttrItem;
@@ -36,9 +36,7 @@ var helpers = {
 
     attr = Mustache.resolve(attr);
     instance = Mustache.resolve(instance);
-    customAttrItem = Mustache.resolve(
-      (options.hash || {}).customAttrItem
-    );
+    customAttrItem = Mustache.resolve(customAttrItem);
 
     can.each(GGRC.custom_attr_defs, function (item) {
       if (item.definition_type === instance.class.table_singular &&

--- a/src/ggrc/assets/javascripts/components/tree/tree-item-custom-attribute.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-item-custom-attribute.js
@@ -26,6 +26,11 @@ var helpers = {
       },
       Date: function (item) {
         return GGRC.Utils.formatDate(item.attribute_value, true);
+      },
+      'Map:Person': function (item) {
+        return options.fn(options.contexts.add({
+          object: item.attribute_object ? item.attribute_object.reify() : null
+        }));
       }
     };
 
@@ -50,12 +55,7 @@ var helpers = {
           item = item.reify();
         }
         if (item.custom_attribute_id === definition.id) {
-          if (definition.attribute_type.startsWith('Map:')) {
-            value = options.fn(options.contexts.add({
-              object: item.attribute_object ?
-                item.attribute_object.reify() : null
-            }));
-          } else if (formatValueMap[definition.attribute_type]) {
+          if (formatValueMap[definition.attribute_type]) {
             value = formatValueMap[definition.attribute_type](item);
           } else {
             value = item.attribute_value;

--- a/src/ggrc/assets/javascripts/components/tree/tree-item-custom-attribute.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-item-custom-attribute.js
@@ -21,11 +21,11 @@ var helpers = {
     var customAttrItem;
     var getValue;
     var formatValueMap = {
-      Checkbox: function (value) {
-        return ['No', 'Yes'][value];
+      Checkbox: function (item) {
+        return ['No', 'Yes'][item.attribute_value];
       },
-      Date: function (value) {
-        return GGRC.Utils.formatDate(value, true);
+      Date: function (item) {
+        return GGRC.Utils.formatDate(item.attribute_value, true);
       }
     };
 
@@ -56,8 +56,7 @@ var helpers = {
                 item.attribute_object.reify() : null
             }));
           } else if (formatValueMap[definition.attribute_type]) {
-            value =
-              formatValueMap[definition.attribute_type](item.attribute_value);
+            value = formatValueMap[definition.attribute_type](item);
           } else {
             value = item.attribute_value;
           }


### PR DESCRIPTION
This is just an example PR for proper code cleanup. The code itself is still not as optimal as it could be.
The proper overall solution would not have aloop in the mustache file. would only send CAD and instance into the helper and just receive the display value. But as an example of how code cleanup should look, this PR is sufficient.

The PR itself brings a noticable performance improvement as well for tree view rendering.
All failed tests are due to different helper parameters.