### PR TITLE
QUICK-FIX Fix migrations on a fresh cloud sql mysql 5.6 instance

### DIFF
--- a/src/ggrc/migrations/utils/url_util.py
+++ b/src/ggrc/migrations/utils/url_util.py
@@ -7,150 +7,16 @@ from alembic import op
 from sqlalchemy import Enum
 
 
-def _create_documents(connection, object_type, table_name):
-  """Create documents and prepare relationships for insert."""
-  sql = """
-        INSERT INTO temp_url (object_id, url, modified_by_id,
-                              parent_created_at, parent_updated_at,
-                              context_id, directive_type, system_type)
-        SELECT id, url, modified_by_id, created_at, updated_at,
-               context_id, {directive_type}, {system_type}
-        FROM {table_name}
-        WHERE url > ''
-        UNION
-        SELECT id, reference_url, modified_by_id, created_at, updated_at,
-               context_id, {directive_type}, {system_type}
-        FROM {table_name}
-        WHERE reference_url > ''
-    """
+def migrate_urls_to_documents(_):
+  """Move url and reference url values to documents table
 
-  directive_type, system_type = 'NULL', 'NULL'
-
-  if table_name == 'directives':
-    directive_type = 'meta_kind'
-  elif table_name == 'systems':
-    system_type = "IF(is_biz_process = 1, 'Process', 'System')"
-
-  sql = sql.format(
-      table_name=table_name,
-      directive_type=directive_type,
-      system_type=system_type
-  )
-  connection.execute(sql)
-
-  connection.execute(
-      """ INSERT INTO documents (modified_by_id, title, link, created_at,
-                                 updated_at, document_type, context_id)
-          SELECT modified_by_id, url, url, parent_created_at,
-                 parent_updated_at, 'REFERENCE_URL', context_id
-          FROM temp_url
-          ORDER BY id
-      """
-  )
-
-  # LAST_INSERT_ID() returns the value generated for the first inserted row
-  # if you insert multiple rows using a single INSERT statement.
-  # If no rows were successfully inserted, LAST_INSERT_ID() returns 0.
-  last_id = int(connection.execute('SELECT LAST_INSERT_ID()').first()[0])
-
-  if last_id:
-    sql = """
-          INSERT INTO relationships (modified_by_id,
-                                     source_id,
-                                     source_type,
-                                     destination_id,
-                                     destination_type,
-                                     created_at,
-                                     updated_at,
-                                     context_id)
-          SELECT t.modified_by_id,
-                 t.object_id,
-                 {object_type},
-                 d.id,
-                 'Document',
-                 t.parent_created_at,
-                 t.parent_updated_at,
-                 d.context_id
-          FROM temp_url t
-          JOIN documents d ON d.id = t.id + {delta}
-      """
-
-    if table_name == 'directives':
-      object_type = 't.directive_type'
-    elif table_name == 'systems':
-      object_type = 't.system_type'
-    else:
-      object_type = "'{}'".format(object_type)
-
-    sql = sql.format(object_type=object_type, delta=last_id - 1)
-    connection.execute(sql)
-
-  connection.execute('TRUNCATE TABLE temp_url')
-
-
-def migrate_urls_to_documents(objects):
-  """Move url and reference url values to documents table"""
+  NOTE: This function also included a data migration, but we have removed it
+  because of an issue with mysql 5.6 on cloudsql. If for some reason the data
+  migration is still needed, please check the git changelog of this file"""
   op.alter_column(
       'documents', 'document_type',
       type_=Enum(u'URL', u'EVIDENCE', u'REFERENCE_URL'),
       existing_type=Enum(u'URL', u'EVIDENCE'),
-      nullable=False,
-      server_default=u'URL'
-  )
-
-  connection = op.get_bind()
-  connection.execute("""
-        CREATE TEMPORARY TABLE temp_url (
-            id int(11) NOT NULL AUTO_INCREMENT,
-            object_id int(11) NOT NULL,
-            url varchar(250) NOT NULL,
-            modified_by_id int(11) DEFAULT NULL,
-            parent_created_at datetime NOT NULL,
-            parent_updated_at datetime NOT NULL,
-            context_id int(11) DEFAULT NULL,
-            directive_type varchar(50) DEFAULT NULL,
-            system_type varchar(50) DEFAULT NULL,
-            PRIMARY KEY (id)
-        )
-    """)
-
-  for object_type, table_name in objects.iteritems():
-    _create_documents(connection, object_type, table_name)
-
-  connection.execute('DROP TABLE temp_url')
-
-
-def delete_reference_urls(object_types):
-  """Delete reference URL documents and their relations to objects."""
-  delete_reletionships = """
-      DELETE FROM relationships
-      WHERE (destination_type = 'Document'
-         AND source_type IN ({object_types})
-         AND destination_id IN (SELECT id FROM documents
-                                WHERE document_type='REFERENCE_URL'))
-         OR (destination_type IN ({object_types})
-         AND source_type = 'Document'
-         AND source_id IN (SELECT id FROM documents
-                                WHERE document_type='REFERENCE_URL'))
-   """
-
-  delete_document = """
-      DELETE FROM documents
-      WHERE document_type='REFERENCE_URL'
-   """
-
-  object_types_to_delete = "'%s'" % "','".join(object_types)
-
-  connection = op.get_bind()
-  connection.execute(delete_document.format(
-      object_types=object_types_to_delete))
-  connection.execute(delete_reletionships.format(
-      object_types=object_types_to_delete))
-
-  op.alter_column(
-      'documents', 'document_type',
-      type_=Enum(u'URL', u'EVIDENCE'),
-      existing_type=Enum(u'URL', u'EVIDENCE', u'REFERENCE_URL'),
       nullable=False,
       server_default=u'URL'
   )


### PR DESCRIPTION
The migration that migrates urls fails on a new cloud sql instance, but
since a fresh instance does not contain any data (and all of our db
instances were already migrated) it is safe to skip migrating the data.

The original migration fails with:

```
sqlalchemy.exc.OperationalError: (OperationalError) (1787, 'When @@GLOBAL.ENFORCE_GTID_CONSISTENCY = 1, the statements CREATE TEMPORARY TABLE and DROP TEMPORARY TABLE can be executed in a non-transactional context only, and require that AUTOCOMMIT = 1. These statements are also not allowed in a function or trigger because functions and triggers are also considered to be multi-statement transactions.') '
        CREATE TEMPORARY TABLE temp_url (
            id int(11) NOT NULL AUTO_INCREMENT,
            object_id int(11) NOT NULL,
            url varchar(250) NOT NULL,
            modified_by_id int(11) DEFAULT NULL,
            parent_created_at datetime NOT NULL,
            parent_updated_at datetime NOT NULL,
            context_id int(11) DEFAULT NULL,
            directive_type varchar(50) DEFAULT NULL,
            system_type varchar(50) DEFAULT NULL,
            PRIMARY KEY (id)
        )
    ' ()
```