### PR TITLE
GGRC-2018/2420 Workflow Owner except Workflow manager is displayed in Peoples tab on the Workflow page

### DIFF
--- a/src/ggrc/assets/javascripts/models/simple_models.js
+++ b/src/ggrc/assets/javascripts/models/simple_models.js
@@ -216,14 +216,17 @@
       return this.attr('scope') !== 'System';
     },
     permission_summary: function () {
-      if (this.name === 'ProgramOwner') {
-        return 'Admin';
-      }
-      if (this.name === 'ProgramEditor') {
-        return 'Can Edit';
-      }
-      if (this.name === 'ProgramReader') {
-        return 'View Only';
+      var RoleList = {
+        ProgramOwner: 'Program Manager',
+        ProgramEditor: 'Program Editor',
+        ProgramReader: 'Program Reader',
+        WorkflowOwner: 'Workflow Manager',
+        WorkflowMember: 'Workflow Member',
+        Mapped: 'No Role',
+        Owner: 'Manager',
+      };
+      if (RoleList[this.name]) {
+        return RoleList[this.name];
       }
       return this.name;
     }

--- a/src/ggrc/assets/mustache/people/tree-item-attr.mustache
+++ b/src/ggrc/assets/mustache/people/tree-item-attr.mustache
@@ -27,20 +27,20 @@
           <div class="item-data">
           <div class="tree-title-area">
           <span class="role" title="{{#roles}}{{role.permission_summary}} {{/roles}}">
-          {{#if_helpers '\
-            #if_equals' roles.0.role.permission_summary 'Mapped' '\
-            and ^if_equals' roles.length 1}}
-                                {{roles.1.role.permission_summary}}
-                              {{else}}
-                                {{roles.0.role.permission_summary}}
-                              {{/if_helpers}}
-                              {{#roles.1}}
-                                {{#if_in_map roles 'role.permission_summary' 'Mapped'}}
-                                  {{^if_equals roles.length 2}}
-                                    + {{sum roles.length '-2'}}
-                                  {{/if_equals}}
-                                {{else}}
-                                  + {{sum roles.length '-1'}}
+          {{#if_equals roles.0.role.permission_summary 'Mapped'}}
+            <span class="no-role">
+              No Role
+            </span>
+          {{else}}
+            {{roles.0.role.permission_summary}}
+          {{/if_equals}}
+            {{#roles.1}}
+              {{#if_in_map roles 'role.permission_summary' 'Mapped'}}
+                {{^if_equals roles.length 2}}
+                  + {{sum roles.length '-2'}}
+                {{/if_equals}}
+              {{else}}
+                + {{sum roles.length '-1'}}
               {{/if_in_map}}
             {{/roles.1}}
             </span>

--- a/src/ggrc_basic_permissions/assets/mustache/ggrc_basic_permissions/people_roles/info.mustache
+++ b/src/ggrc_basic_permissions/assets/mustache/ggrc_basic_permissions/people_roles/info.mustache
@@ -95,20 +95,18 @@
             <h6>Authorizations</h6>
             <p>
               {{#with_program_roles_as "roles" result}}
-                {{#roles}}
-                  {{#if_helpers '\
-                    ^if_equals' role.permission_summary 'Mapped' '\
-                    or #if_equals' roles.length 1}}
-                      {{role.permission_summary}}
-                      {{#if_equals role.permission_summary 'Auditor'}}:
-                        {{#with_mapping 'audit_via_context' user_role}}
-                          <span class="role">
-                            {{audit_via_context.0.instance.title}}
-                          </span>
-                        {{/with_mapping}}
-                      {{/if_equals}}
-                  {{/if_helpers}}
-                {{/roles}}
+                {{#if_equals roles.0.role.permission_summary 'Mapped'}}
+                  No Role
+                {{else}}
+                  {{roles.0.role.permission_summary}}
+                  {{#if_equals role.permission_summary 'Auditor'}}:
+                    {{#with_mapping 'audit_via_context' user_role}}
+                      <span class="role">
+                        {{audit_via_context.0.instance.title}}
+                      </span>
+                    {{/with_mapping}}
+                  {{/if_equals}}
+                {{/if_equals}}
               {{/with_program_roles_as}}
             </p>
           </div>


### PR DESCRIPTION
Steps to reproduce:
 1. Create one time workflow 
2. Go to Peoples tab and look at the tree view 
Actual Result: Workflow Owner except Workflow manager is displayed 
Expected Result: Workflow manager is displayed in Peoples tab on the Workflow page
![screenshot-1](https://user-images.githubusercontent.com/25414700/30695769-0d461a50-9ee2-11e7-901c-e9b84d2d9045.png)
![screenshot-2](https://user-images.githubusercontent.com/25414700/30695771-0d51ea42-9ee2-11e7-816e-c73891a4d5b7.png)
![screenshot-3](https://user-images.githubusercontent.com/25414700/30695770-0d4b3954-9ee2-11e7-8a9d-c86710d959a2.png)
