### PR TITLE
QUICK-FIX Test "add dashboard through the 'Dashboard' GCA"

### DIFF
--- a/bin/jenkins/functions.sh
+++ b/bin/jenkins/functions.sh
@@ -112,6 +112,7 @@ selenium_tests () {
   docker exec -id ${PROJECT}_dev_1 su -c "
     source /vagrant/bin/init_vagrant_env
     source /vagrant/bin/init_test_env
+    export DASHBOARD_INTEGRATION='on'
     launch_ggrc
   "
 

--- a/test/selenium/src/lib/base.py
+++ b/test/selenium/src/lib/base.py
@@ -13,9 +13,10 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.remote import webelement
 
 from lib import constants, exception, mixin
-from lib.constants import url, messages, objects, locator
+from lib.constants import url, messages, objects
 from lib.constants.element import MappingStatusAttrs, WidgetBar
 from lib.constants.locator import CommonDropdownMenu
+from lib.decorator import lazy_property
 from lib.entities.entity import Entity
 from lib.utils import selenium_utils, help_utils
 
@@ -569,7 +570,7 @@ class Widget(AbstractPage):
     checking existing of element by locator and URL's logic."""
     is_info_page = False
     if selenium_utils.is_element_exist(
-        self._driver, (By.XPATH, locator.Common.INFO_PAGE_XPATH)
+        self._driver, (By.XPATH, constants.locator.Common.INFO_PAGE_XPATH)
     ):
       if ((self.widget_name_from_url == WidgetBar.INFO.lower()) or
           ((objects.get_singular(self.source_obj_from_url) ==
@@ -1004,9 +1005,6 @@ class AbstractTabContainer(Component):
     super(AbstractTabContainer, self).__init__(driver)
     self.container_element = container_element
     self._locators = self._get_locators()
-    from lib.element.elements_list import TabController
-    self._tab_controller = TabController(
-        self._driver, self._locators.TAB_CONTROLLER)
     self.tabs = self._tabs()
 
   def _get_locators(self):
@@ -1017,17 +1015,15 @@ class AbstractTabContainer(Component):
     """Return element of active tab"""
     return self.container_element.find_element(*self._locators.TAB_CONTENT)
 
-  def get_tab_object(self, tab_name):
-    """Switch to tab, then return object of this tab, for example:
-    Page Object or any
-    """
-    self._tab_controller.active_tab = tab_name
-    return self.tabs[tab_name](
-        self._driver, self._get_active_tab_element())
-
   def _tabs(self):
     """Abstract method. Should return dict. {'tab_name': tab_object, ...}"""
     raise NotImplementedError
+
+  @lazy_property
+  def tab_controller(self):
+    """Lazy property for dashboard controller."""
+    from lib.element.elements_list import TabController
+    return TabController(self._driver, self._locators.TAB_CONTROLLER)
 
 
 class AbstractTable(Component):

--- a/test/selenium/src/lib/constants/locator.py
+++ b/test/selenium/src/lib/constants/locator.py
@@ -552,6 +552,7 @@ class WidgetBar(object):
   ROLES = _Locator.get_widget("roles_list")
   RISK_ASSESSMENTS = _Locator.get_widget("risk_assessment")
   TASKS = _Locator.get_widget("task")
+  DASHBOARD_TAB = _Locator.get_widget("dashboard")
 
 
 class WidgetBarButtonAddDropdown(object):
@@ -1202,3 +1203,11 @@ class AssessmentRelatedTable(object):
   ROWS = (By.CSS_SELECTOR, ".grid-data-row")
   CELLS = (By.CSS_SELECTOR, "div")
   TAB_BUTTON = (By.CSS_SELECTOR, ".btn.btn-small")
+
+
+class DashboardWidget(object):
+  """Locators for DashboardWidget."""
+  _TAB_CONTAINER = ".dashboard-widget.info"
+  TAB_CONTAINER = (By.CSS_SELECTOR, _TAB_CONTAINER)
+  TAB_CONTROLLER = (By.CSS_SELECTOR, ".dashboard-list")
+  TAB_CONTENT = (By.CSS_SELECTOR, _TAB_CONTAINER + " iframe")

--- a/test/selenium/src/lib/constants/value_aliases.py
+++ b/test/selenium/src/lib/constants/value_aliases.py
@@ -18,3 +18,6 @@ CONTAINS_OP = "~"
 WIDTH = "width"
 HEIGHT = "height"
 SCROLL_HEIGHT = "scrollHeight"
+
+DEFAULT = "default"
+DASHBOARD = "Dashboard"

--- a/test/selenium/src/lib/entities/entities_factory.py
+++ b/test/selenium/src/lib/entities/entities_factory.py
@@ -8,7 +8,8 @@
 import copy
 import random
 
-from lib.constants import element, objects, roles, url as const_url
+from lib.constants import (element, objects, roles, value_aliases,
+                           url as const_url)
 from lib.constants.element import AdminWidgetCustomAttributes
 from lib.entities.entity import (
     Entity, PersonEntity, CustomAttributeEntity, ProgramEntity, ControlEntity,
@@ -272,6 +273,19 @@ class CustomAttributeDefinitionsFactory(EntitiesFactory):
       obj.multi_choice_options = random_list_strings()
     return Entity.update_objs_attrs_values_by_entered_data(
         obj_or_objs=obj, **arguments)
+
+  @classmethod
+  def create_dashboard_ca(cls, definition_type):
+    """Create and return CA entity with valid filled fields for
+    creating N'Dashboard'.
+    """
+    dashboard_ca = CustomAttributeEntity()
+    dashboard_ca.type = cls.obj_ca
+    dashboard_ca.attribute_type = AdminWidgetCustomAttributes.TEXT
+    dashboard_ca.title = cls.generate_string(value_aliases.DASHBOARD)
+    dashboard_ca.mandatory = False
+    dashboard_ca.definition_type = definition_type
+    return dashboard_ca
 
 
 class ProgramsFactory(EntitiesFactory):

--- a/test/selenium/src/lib/page/widget/info_widget.py
+++ b/test/selenium/src/lib/page/widget/info_widget.py
@@ -320,7 +320,7 @@ class Assessments(InfoWidget):
     self.workflow_container = tab_containers.AssessmentTabContainer(
         self._driver,
         self._driver.find_element(*self._locators.ASMT_TAB_CONTAINER_CSS))
-    self.workflow_container.switch_to_tab(
+    self.workflow_container.tab_controller.active_tab = (
         element.AssessmentTabContainer.ASMT_TAB)
     self.mapped_objects_lbl_txt = self._elements.MAPPED_OBJECTS.upper()
     self.mapped_objects_titles_txt = self._get_mapped_objs_titles_txt()
@@ -366,7 +366,7 @@ class Assessments(InfoWidget):
     """Get an Assessment object's text scope (headers' (real and synthetic)
     and values' txt) from Info Widget navigating through the Assessment's tabs.
     """
-    self.workflow_container.switch_to_tab(
+    self.workflow_container.tab_controller.active_tab = (
         element.AssessmentTabContainer.OTHER_ATTRS_TAB)
     self.mapped_objects_titles_txt += self._get_mapped_objs_titles_txt()
     cas_scope_txt = self.get_headers_and_values_dict_from_cas_scopes()

--- a/test/selenium/src/lib/page/widget_bar.py
+++ b/test/selenium/src/lib/page/widget_bar.py
@@ -6,6 +6,7 @@ what is mappable to it.
 """
 
 from lib import base, factory
+from lib.base import Button
 from lib.constants import locator, element
 from lib.element import widget_bar
 from lib.page.widget import admin_widget
@@ -62,6 +63,17 @@ class _ObjectWidgetBar(_WidgetBar):
         self._driver,
         locator.WidgetBarButtonAddDropdown.ALL_MAPPABLE_WIDGETS_OBJS)
     return [add_el.text for add_el in add_elements]
+
+  def select_dashboard_tab(self):
+    """Select 'Dashboard' tab on Object Widget Bar."""
+    Button(self._driver, locator.WidgetBar.DASHBOARD_TAB).click()
+    return selenium_utils.get_when_visible(
+        self._driver, locator.DashboardWidget.TAB_CONTAINER)
+
+  def is_dashboard_tab_exist(self):
+    """Check is 'Dashboard' tab exist on Object Widget Bar."""
+    return selenium_utils.is_element_exist(
+        self._driver, locator.WidgetBar.DASHBOARD_TAB)
 
   def select_info(self):
     """Select Info widget/tab. Each object has different Info widget."""

--- a/test/selenium/src/lib/service/rest_service.py
+++ b/test/selenium/src/lib/service/rest_service.py
@@ -9,7 +9,8 @@ from requests import exceptions
 
 from lib import environment, factory
 from lib.constants import url, objects, messages
-from lib.entities.entities_factory import ObjectPersonsFactory, EntitiesFactory
+from lib.entities.entities_factory import (
+    ObjectPersonsFactory, EntitiesFactory, CustomAttributeDefinitionsFactory)
 from lib.entities.entity import Entity
 from lib.service.rest import client, query
 from lib.utils import help_utils
@@ -68,10 +69,10 @@ class BaseRestService(object):
   def update_obj(self, obj, **attrs):
     """Update attributes values of existing object via REST API."""
     obj.update_attrs(**attrs)
-    return self.get_items_from_resp(
+    return self.set_obj_attrs(obj=obj, attrs=self.get_items_from_resp(
         self.client.update_object(
             href=obj.href, **dict({k: v for k, v in obj.__dict__
-                                  .iteritems() if k != "href"}.items())))
+                                  .iteritems() if k != "href"}.items()))))
 
   @staticmethod
   def get_items_from_resp(response):
@@ -231,6 +232,13 @@ class CustomAttributeDefinitionsService(BaseRestService):
   def __init__(self):
     super(CustomAttributeDefinitionsService, self).__init__(
         url.CUSTOM_ATTRIBUTES)
+
+  def create_dashboard_gcas(self, obj_type, count=1):
+    """Create 'Dashboard' CAs via rest according to passed obj_type and count.
+    """
+    return [self.create_objs(1, CustomAttributeDefinitionsFactory().
+            create_dashboard_ca(obj_type.lower()).__dict__)[0]
+            for _ in xrange(count)]
 
 
 class RelationshipsService(HelpRestService):

--- a/test/selenium/src/lib/service/webui_service.py
+++ b/test/selenium/src/lib/service/webui_service.py
@@ -8,6 +8,7 @@ from dateutil import parser, tz
 
 from lib import factory
 from lib.constants import objects, url, path, messages, element, regex
+from lib.element.tab_containers import DashboardWidget
 from lib.entities.entity import Entity
 from lib.page import dashboard
 from lib.page.widget.info_widget import SnapshotableInfoPanel
@@ -371,6 +372,24 @@ class BaseWebUiService(object):
                     tree_view.open_create())
     modal_create.fill_minimal_data(title=obj.title, code=obj.slug)
     return modal_create
+
+  def is_dashboard_tab_exist(self, obj):
+    """Navigate to InfoPage of object and check is 'Dashboard' tab exist.
+      - Return: bool.
+    """
+    self.open_info_page_of_obj(obj)
+    return dashboard.Dashboard(self.driver).is_dashboard_tab_exist()
+
+  def get_items_from_dashboard_widget(self, obj):
+    """Navigate to InfoPage of object. Open 'Dashboard' tab and return
+    all urls of dashboard items.
+      - Return: list of str
+    """
+    self.open_info_page_of_obj(obj)
+    dashboard_widget_elem = (
+        dashboard.Dashboard(self.driver).select_dashboard_tab())
+    return DashboardWidget(
+        self.driver, dashboard_widget_elem).get_all_tab_names_and_urls()
 
 
 class SnapshotsWebUiService(BaseWebUiService):

--- a/test/selenium/src/tests/conftest.py
+++ b/test/selenium/src/tests/conftest.py
@@ -97,6 +97,12 @@ def chrome_options(chrome_options, create_tmp_dir):
   return chrome_options
 
 
+@pytest.fixture(scope="session")
+def base_url(base_url):
+  """Add '/' if base_url not end by '/'."""
+  yield base_url if base_url[-1] == "/" else base_url + "/"
+
+
 @pytest.fixture(scope="function")
 def my_work_dashboard(selenium):
   """Open My Work Dashboard URL and


### PR DESCRIPTION
Test to check ability to create object dashboards using global custom attributes.

Steps:
  - Create 'Dashboard' GCAs for object.
  - Fill CAs with urls
  - Check if 'Dashboard' tab exist.
  - Navigate to 'Dashboard' tab.
  - Check only right filled CA values displayed on the tab.