### PR TITLE
QUICK-FIX Make it easier to add GAPI keys for local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ src/app.yaml
 *.pyc
 src/instance
 .DS_Store
+docker-compose.override.yml
 
 # Deployment-specific settings
 extras/deploy/*/*

--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ directory
     ./bin/containers setup dev
     ```
 
+* Set up the necessary keys:
+
+    ```
+    mv docker-compose.override.yml{.example,}
+    vim docker-compose.override.yml # Add the keys from cloud console
+    ```
+
 To log into the container, run the following:
 
 ``` sh

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -1,0 +1,7 @@
+cleandev:
+  environment:
+   - GGRC_DATABASE_HOST=db
+   - GGRC_DATABASE_URI=mysql+mysqldb://root:root@db/ggrcdev?charset=utf8
+   - GGRC_GAPI_KEY=<GAPI_KEY>
+   - GGRC_GAPI_CLIENT_ID=<GAPI_CLIENT_ID>
+   - GGRC_GAPI_CLIENT_SECRET=<GAPI_CLEINT_SECRET>


### PR DESCRIPTION
This PR is based on my comments in https://github.com/google/ggrc-core/pull/6433. I believe it's a clean and easy way to allow developers to use GAPI keys on local development machines.

I have also included instructions on how to set up the keys to our README.