### PR TITLE
GGRC-3427 Fix GDrive picker not opening on the first click on Attach button

### DIFF
--- a/src/ggrc_gdrive_integration/assets/javascripts/components/gdrive_folder_picker.js
+++ b/src/ggrc_gdrive_integration/assets/javascripts/components/gdrive_folder_picker.js
@@ -2,6 +2,9 @@
  * Copyright (C) 2017 Google Inc.
  * Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  */
+
+import '../utils/gdrive-picker-utils.js';
+
 (function (can, $) {
   'use strict';
 
@@ -293,6 +296,7 @@
       'a[data-toggle=gdrive-picker] click': function (el, ev) {
         var folder_id = el.data('folder-id');
         var dfd;
+        var picker;
 
         // Create and render a Picker object for searching images.
         function createPicker() {
@@ -301,7 +305,8 @@
             var view;
             var docsUploadView;
             var docsView;
-            var picker = new google.picker.PickerBuilder()
+
+            picker = new google.picker.PickerBuilder()
                   .setOAuthToken(gapi.auth.getToken().access_token)
                   .setDeveloperKey(GGRC.config.GAPI_KEY)
                   .setCallback(pickerCallback);
@@ -357,6 +362,7 @@
           } else if (data[ACTION] === CANCEL) {
             el.trigger('rejected');
           }
+          GGRC.Utils.GDrivePicker.ensurePickerDisposed(picker, data);
         }
 
         dfd = GGRC.Controllers.GAPI.reAuthorize(gapi.auth.getToken());

--- a/src/ggrc_gdrive_integration/assets/javascripts/components/gdrive_folder_picker.js
+++ b/src/ggrc_gdrive_integration/assets/javascripts/components/gdrive_folder_picker.js
@@ -300,7 +300,7 @@ import '../utils/gdrive-picker-utils.js';
 
         // Create and render a Picker object for searching images.
         function createPicker() {
-          window.oauth_dfd.done(function (token, oauth_user) {
+          GGRC.Controllers.GAPI.oauth_dfd.done(function (token, oauth_user) {
             var dialog;
             var view;
             var docsUploadView;

--- a/src/ggrc_gdrive_integration/assets/javascripts/components/gdrive_picker_launcher.js
+++ b/src/ggrc_gdrive_integration/assets/javascripts/components/gdrive_picker_launcher.js
@@ -348,7 +348,7 @@ import '../utils/gdrive-picker-utils.js';
 
                   can.trigger(that, 'modal:success');
                   el.trigger('modal:success');
-                } else if ( error ) {
+                } else if ( error && error !== 'action canceled' ) {
                   that.dispatch({
                     type: 'resetItems'
                   });

--- a/src/ggrc_gdrive_integration/assets/javascripts/components/gdrive_picker_launcher.js
+++ b/src/ggrc_gdrive_integration/assets/javascripts/components/gdrive_picker_launcher.js
@@ -4,6 +4,7 @@
  */
 
 import errorTpl from './templates/gdrive_picker_launcher_upload_error.mustache';
+import '../utils/gdrive-picker-utils.js';
 
 (function (can, $, GGRC, CMS) {
   'use strict';
@@ -164,6 +165,7 @@ import errorTpl from './templates/gdrive_picker_launcher_upload_error.mustache';
         // upload files without a parent folder (risk assesment)
         var that = this;
         var dfd;
+        var picker;
         var folderId = el.data('folder-id');
 
         // Create and render a Picker object for searching images.
@@ -174,7 +176,8 @@ import errorTpl from './templates/gdrive_picker_launcher_upload_error.mustache';
               var view;
               var docsView;
               var docsUploadView;
-              var picker = new google.picker.PickerBuilder()
+
+              picker = new google.picker.PickerBuilder()
                 .setOAuthToken(gapi.auth.getToken().access_token)
                 .setDeveloperKey(GGRC.config.GAPI_KEY)
                 .setMaxItems(10)
@@ -238,6 +241,8 @@ import errorTpl from './templates/gdrive_picker_launcher_upload_error.mustache';
           } else if (data[ACTION] === CANCEL) {
             el.trigger('rejected');
           }
+
+          GGRC.Utils.GDrivePicker.ensurePickerDisposed(picker, data);
         }
 
         dfd = GGRC.Controllers.GAPI.reAuthorize(gapi.auth.getToken());

--- a/src/ggrc_gdrive_integration/assets/javascripts/components/gdrive_picker_launcher.js
+++ b/src/ggrc_gdrive_integration/assets/javascripts/components/gdrive_picker_launcher.js
@@ -170,7 +170,7 @@ import '../utils/gdrive-picker-utils.js';
 
         // Create and render a Picker object for searching images.
         function createPicker() {
-          window.oauth_dfd
+          GGRC.Controllers.GAPI.oauth_dfd
             .done(function () {
               var dialog;
               var view;

--- a/src/ggrc_gdrive_integration/assets/javascripts/controllers/gapi_controllers.js
+++ b/src/ggrc_gdrive_integration/assets/javascripts/controllers/gapi_controllers.js
@@ -3,31 +3,31 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 */
 
-;(function(CMS, GGRC, can, $) {
+(function (CMS, GGRC, can, $) {
   GGRC.Controllers.Modals('GGRC.Controllers.GAPIModal', {
     defaults: {
       skip_refresh: true,
-      content_view : GGRC.mustache_path + '/gdrive/auth_button.mustache'
+      content_view: GGRC.mustache_path + '/gdrive/auth_button.mustache'
     },
-    init : function() {
+    init: function () {
       this._super.apply(this, arguments);
       this.defaults.button_view = can.view.mustache('');
     }
   }, {
-    init : function() {
+    init: function () {
       this._super();
       this.element.trigger('shown');
     },
-    '{scopes} change' : function() {
+    '{scopes} change': function () {
       this.element.trigger('shown');
     },
-    '{$content} a.btn[data-toggle=gapi]:not(.disabled) click' : function(el) {
+    '{$content} a.btn[data-toggle=gapi]:not(.disabled) click': function (el) {
       el.addClass('disabled');
       GGRC.Controllers.GAPI.doGAuth_step2(null, true);
       window.oauth_dfd.always($.proxy(this.element, 'modal_form', 'hide'));
     },
-    ' hide' : function() {
-      if(window.oauth_dfd.state() === 'pending') {
+    ' hide': function () {
+      if (window.oauth_dfd.state() === 'pending') {
         window.oauth_dfd.reject('User canceled operation');
       }
       this.element && this.element.remove();
@@ -37,10 +37,10 @@
   window.oauth_dfd = new $.Deferred();
 
   can.Control('GGRC.Controllers.GAPI', {
-    canonical_instance : null,
-    o2dfd : null,
-    drivedfd : null,
-    gapidfd : new $.Deferred(),
+    canonical_instance: null,
+    o2dfd: null,
+    drivedfd: null,
+    gapidfd: new $.Deferred(),
     reAuthorize: function (token) {
       var params = ['https://www.googleapis.com/auth/drive'];
       var dfd;
@@ -53,26 +53,26 @@
 
       return dfd;
     },
-    authorize : function(newscopes, force) {
+    authorize: function (newscopes, force) {
       return this.canonical_instance.authorize(newscopes, force);
     },
-    doGAuth : function(scopes, use_popup) {
+    doGAuth: function (scopes, usePopup) {
       var that = this;
       var $modal;
 
       this.drive = this.drive || new $.Deferred();
-      if(window.oauth_dfd.state() !== 'pending') {
+      if (window.oauth_dfd.state() !== 'pending') {
         window.oauth_dfd = new $.Deferred();
       }
       can.each({
         drivedfd: 'drive',
         o2dfd: 'oauth2'
-      }, function(p, d) {
-        if(!that[d]) {
+      }, function (p, d) {
+        if (!that[d]) {
           that[d] = new $.Deferred();
-          that.gapidfd.done(function() {
-            window.gapi.client.load(p, 'v2', function(result) {
-              if(!result){
+          that.gapidfd.done(function () {
+            window.gapi.client.load(p, 'v2', function (result) {
+              if (!result) {
                 that[d].resolve();
               } else {
                 that[d].reject(result);
@@ -82,38 +82,38 @@
         }
       });
 
-      if(use_popup) {
+      if (usePopup) {
         $modal = $('.ggrc_controllers_gapi_modal');
-        if(!$modal.length) {
+        if (!$modal.length) {
           $('<div class="modal hide">').modal_form()
             .appendTo(document.body).ggrc_controllers_gapi_modal({
-            scopes : scopes,
-            modal_title : 'Please log in to Google API',
-            new_object_form : true
+            scopes: scopes,
+            modal_title: 'Please log in to Google API',
+            new_object_form: true
           });
         } else {
           $modal.modal_form('show');
         }
       } else {
-        this.doGAuth_step2(scopes, use_popup);
+        this.doGAuth_step2(scopes, usePopup);
       }
     },
-    doGAuth_step2 : function(scopes, use_popup) {
+    doGAuth_step2: function (scopes, usePopup) {
       var authdfd = new $.Deferred();
       var that = this;
 
       scopes = scopes || this.canonical_instance.options.scopes;
 
-      this.gapidfd.done(function() {
+      this.gapidfd.done(function () {
         window.gapi.auth.authorize({
           client_id: GGRC.config.GAPI_CLIENT_ID,
           scope: scopes.serialize(),
-          immediate: !use_popup,
-          login_hint : GGRC.current_user && GGRC.current_user.email
-        }).then(function(authresult) {
+          immediate: !usePopup,
+          login_hint: GGRC.current_user && GGRC.current_user.email
+        }).then(function (authresult) {
           authdfd.resolve(authresult);
-        }, function() {
-          if(!use_popup) {
+        }, function () {
+          if (!usePopup) {
             that.doGAuth(scopes, true);
             authdfd.reject('login required. Switching to non-immediate');
           } else {
@@ -124,12 +124,12 @@
       });
 
       $.when(authdfd, this.o2dfd)
-      .then(function(authresult) {
+      .then(function (authresult) {
         var o2d = new $.Deferred();
 
-        gapi.client.oauth2.userinfo.get().execute(function(user) {
-          if(user.error) {
-            $(document.body).trigger('ajax:flash', { error : user.error });
+        gapi.client.oauth2.userinfo.get().execute(function (user) {
+          if (user.error) {
+            $(document.body).trigger('ajax:flash', {error: user.error});
             o2d.reject(user.error);
           } else {
             o2d.resolve(user);
@@ -138,47 +138,49 @@
 
         return $.when(authresult, o2d);
       })
-      .done(function(authresult, o2result){  //success
-        if(!authresult)
-          return; //assume we had to do a non-immediate auth
+      .done(function (authresult, o2result) { // success
+        if (!authresult) {
+          return; // assume we had to do a non-immediate auth
+        }
 
-        if(o2result.email.toLowerCase().trim() !==
+        if (o2result.email.toLowerCase().trim() !==
           GGRC.current_user.email.toLowerCase().trim()) {
           $(document.body).trigger(
-            'ajax:flash', { warning : ['You are signed into GGRC as',
+            'ajax:flash', {warning: ['You are signed into GGRC as',
               GGRC.current_user.email, 'and into Google Apps as',
-              o2result.email, '. You may experience problems uploading evidence.'
+              o2result.email,
+              '. You may experience problems uploading evidence.'
               ].join(' ')
             });
         }
         window.oauth_dfd.resolve(authresult, o2result);
       });
     },
-    gapi_request_with_auth : function(params) {
+    gapi_request_with_auth: function (params) {
       var that = this;
 
-      return that.authorize(params.scopes).then(function() {
+      return that.authorize(params.scopes).then(function () {
         var dfd = new $.Deferred();
         var cb = params.callback;
-        var check_auth = function(result) {
+        var checkAuth = function (result) {
           var args = can.makeArray(arguments);
           args.unshift(dfd);
-          if(result && result.error && result.error.code === 401) {
-            //that.doGAuth(scopes); //changes oauth_dfd to a new deferred
+          if (result && result.error && result.error.code === 401) {
+            // that.doGAuth(scopes); //changes oauth_dfd to a new deferred
             params.callback = cb;
             that.authorize(params.scopes, true)
               .then($.proxy(that.gapi_request_with_auth, that, params))
-              .then(function() {
+              .then(function () {
                 dfd.resolve.apply(dfd, arguments);
-                }, function() {
+              }, function () {
                 dfd.reject.apply(dfd, arguments);
               });
           } else {
             cb.apply(window, args);
           }
         };
-        params.callback = check_auth;
-        if(typeof params.path === 'function') {
+        params.callback = checkAuth;
+        if (typeof params.path === 'function') {
           params.path = params.path();
         }
         window.gapi.client.request(params);
@@ -186,38 +188,37 @@
       });
     }
   }, {
-    init : function() {
+    init: function () {
       this._super.apply(this, arguments);
-      if(!this.constructor.canonical_instance) {
+      if (!this.constructor.canonical_instance) {
         this.constructor.canonical_instance = this;
       }
 
       this.doGAuthWithScopes = _.debounce($.proxy(this.constructor,
         'doGAuth', this.options.scopes, false), 500);
     },
-    authorize : function(newscopes, force) {
+    authorize: function (newscopes, force) {
       var dfd;
-      var f;
-      var old_dfd;
+      var oldDfd;
       var that = this;
       var found = false;
 
-      can.each(newscopes, function(ns) {
-        if(!~can.inArray(ns, that.options.scopes)) {
+      can.each(newscopes, function (ns) {
+        if (!~can.inArray(ns, that.options.scopes)) {
           that.options.scopes.push(ns);
           found = true;
         }
       });
 
-      if(force || (found ? window.oauth_dfd.state() !== 'pending'
-            : window.oauth_dfd.state() === 'rejected')) {
-        old_dfd = window.oauth_dfd;
+      if (force || (found ? window.oauth_dfd.state() !== 'pending'
+          : window.oauth_dfd.state() === 'rejected')) {
+        oldDfd = window.oauth_dfd;
         dfd = new $.Deferred();
-        setTimeout(f = function() {
-          if(window.oauth_dfd === old_dfd) {
+        setTimeout(f = function () {
+          if (window.oauth_dfd === oldDfd) {
             setTimeout(f, 500);
           } else {
-            window.oauth_dfd.done(function() {
+            window.oauth_dfd.done(function () {
               dfd.resolve.apply(dfd, arguments);
             });
           }
@@ -228,8 +229,8 @@
         return window.oauth_dfd;
       }
     },
-    '{scopes} change' : function(scopes, ev) {
-      this.doGAuthWithScopes(); //debounce in case we push several scopes in sequence
+    '{scopes} change': function (scopes, ev) {
+      this.doGAuthWithScopes(); // debounce in case we push several scopes in sequence
     }
   });
 })(window.CMS, window.GGRC, window.can, window.can.$);

--- a/src/ggrc_gdrive_integration/assets/javascripts/models/gdrive_models.js
+++ b/src/ggrc_gdrive_integration/assets/javascripts/models/gdrive_models.js
@@ -3,6 +3,8 @@
  * Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  */
 
+import '../utils/gdrive-picker-utils.js';
+
 (function (can) {
   'use strict';
 
@@ -290,6 +292,8 @@
     uploadFiles: function () {
       var that = this;
       var dfd = new $.Deferred();
+      var picker;
+
       gapi.load('picker', {
         callback: createPicker
       });
@@ -298,7 +302,8 @@
       function createPicker() {
         window.oauth_dfd.done(function (token, oauth_user) {
           var dialog;
-          var picker = new google.picker.PickerBuilder()
+
+          picker = new google.picker.PickerBuilder()
                   .addView(new google.picker.DocsUploadView().setParent(that.id))
                   .addView(google.picker.ViewId.DOCS)
                   .setOAuthToken(gapi.auth.getToken().access_token)
@@ -324,6 +329,7 @@
         } else if (action === google.picker.Action.CANCEL) {
           dfd.reject('action canceled');
         }
+        GGRC.Utils.GDrivePicker.ensurePickerDisposed(picker, data);
       }
       return dfd.promise();
     }

--- a/src/ggrc_gdrive_integration/assets/javascripts/models/gdrive_models.js
+++ b/src/ggrc_gdrive_integration/assets/javascripts/models/gdrive_models.js
@@ -293,6 +293,7 @@ import '../utils/gdrive-picker-utils.js';
       var that = this;
       var dfd = new $.Deferred();
       var picker;
+      var GAPIController = GGRC.Controllers.GAPI;
 
       gapi.load('picker', {
         callback: createPicker
@@ -300,7 +301,7 @@ import '../utils/gdrive-picker-utils.js';
 
         // Create and render a Picker object for searching images.
       function createPicker() {
-        window.oauth_dfd.done(function (token, oauth_user) {
+        GAPIController.oauth_dfd.done(function (token, oauth_user) {
           var dialog;
 
           picker = new google.picker.PickerBuilder()

--- a/src/ggrc_gdrive_integration/assets/javascripts/utils/gdrive-picker-utils.js
+++ b/src/ggrc_gdrive_integration/assets/javascripts/utils/gdrive-picker-utils.js
@@ -1,0 +1,35 @@
+/*
+ Copyright (C) 2017 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+(function (GGRC) {
+  'use strict';
+
+  /**
+   * Util methods for custom attributes.
+   */
+  GGRC.Utils.GDrivePicker = (function () {
+    /**
+     * Removes picker component after file is picked or cancel is clicked.
+     * This shuold be called last from pickerCallback function
+     * @param  {Object} picker Picker object
+     * @param  {Object} data GDrive Picker action data
+     */
+    function ensurePickerDisposed(picker, data) {
+      var PICKED = google.picker.Action.PICKED;
+      var ACTION = google.picker.Response.ACTION;
+      var CANCEL = google.picker.Action.CANCEL;
+
+      // sometimes pickerCallback is called with data == { action: 'loaded' }
+      // which is not described in the Picker API Docs
+      if ( data[ACTION] === PICKED || data[ACTION] === CANCEL ) {
+        picker.dispose();
+      }
+    }
+
+    return {
+      ensurePickerDisposed: ensurePickerDisposed,
+    };
+  })();
+})(window.GGRC);


### PR DESCRIPTION
Steps to reproduce:
1. Have audit with no folder assigned
2. Create Assessment and expand Assessment info pane
3. Click 'Attach' button: window to attach evidence file is not shown up
4. Click 'Attach' button once again: window appeared

To Reviewer:
The actual problem here is that the old code was overwriting OAuth promise in pending state and creating a new OAuth promise which led to such a weird behavior of the button and appearing of the second picker modal after the file selection.

