### PR TITLE
QUICK-FIX Unify refresh_object method

### DIFF
--- a/test/integration/ggrc/__init__.py
+++ b/test/integration/ggrc/__init__.py
@@ -389,3 +389,8 @@ class TestCase(BaseTestCase, object):
     ]
     for role, person in roles.items():
       self.assertTrue((role, person) in acl_person_roles)
+
+  @classmethod
+  def refresh_object(cls, obj, id_=None):
+    """Returns a new instance of a model, fresh and warm from the database."""
+    return obj.query.filter_by(id=obj.id if id_ is None else id_).first()

--- a/test/integration/ggrc/models/mixins/test_autostatuschangable.py
+++ b/test/integration/ggrc/models/mixins/test_autostatuschangable.py
@@ -330,11 +330,6 @@ class TestMixinAutoStatusChangeable(TestCase):
     self.assertEqual(len(verifiers), defined_verifiers)
     return assessment
 
-  @classmethod
-  def refresh_object(cls, obj):
-    """Returns a new instance of a model, fresh and warm from the database."""
-    return obj.query.filter_by(id=obj.id).first()
-
   def change_status(self, obj, status,
                     expected_status=None, check_verified=False):
     """Change status of an object."""

--- a/test/integration/ggrc/notifications/test_reminderable.py
+++ b/test/integration/ggrc/notifications/test_reminderable.py
@@ -135,11 +135,6 @@ class TestReminderable(TestCase):
     self.assertEqual(len(verifiers), 2)
     return assessment
 
-  @classmethod
-  def refresh_object(cls, obj):
-    """Returns a new instance of a model, fresh and warm from the database."""
-    return obj.query.filter_by(id=obj.id).first()
-
   def change_status(self, obj, status):
     """Change status of an object."""
     self.api_helper.modify_object(obj, {

--- a/test/integration/ggrc/snapshotter/__init__.py
+++ b/test/integration/ggrc/snapshotter/__init__.py
@@ -54,11 +54,6 @@ class SnapshotterBaseTestCase(TestCase):
         }
     })
 
-  @classmethod
-  def refresh_object(cls, obj):
-    """Returns a new instance of a model, fresh and warm from the database."""
-    return obj.query.filter_by(id=obj.id).one()
-
   @staticmethod
   def create_custom_attribute_definitions(cad_definitions=None):
     """Create custom attribute definitions used throughout snapshotter tests"""


### PR DESCRIPTION
Currently this method is copy-pasted into three different places in the integration test suite.