### PR TITLE
GGRC-3306 Rename "map:{}" to "map:{} versions" for Snapshots

### DIFF
--- a/src/ggrc/models/reflection.py
+++ b/src/ggrc/models/reflection.py
@@ -313,7 +313,7 @@ class AttributeInfo(object):
       snapshot_mappings = all_mappings & rules.Types.all
       direct_mappings = all_mappings - rules.Types.all
       definitions.update(cls._generate_mapping_definition(
-          snapshot_mappings, cls.SNAPSHOT_MAPPING_PREFIX, "map:{}",
+          snapshot_mappings, cls.SNAPSHOT_MAPPING_PREFIX, "map:{} versions",
       ))
     else:
       direct_mappings = all_mappings

--- a/test/integration/ggrc/converters/test_export_audit.py
+++ b/test/integration/ggrc/converters/test_export_audit.py
@@ -48,6 +48,10 @@ class TestAuditExport(TestCase):
     }])["Audit"][0]
 
     for type_, slugs in mapped_slugs.items():
-      mapping_name = "map:{}".format(utils.title_from_camelcase(type_))
+      if type_ in Types.all:
+        format_ = "map:{} versions"
+      else:
+        format_ = "map:{}"
+      mapping_name = format_.format(utils.title_from_camelcase(type_))
       self.assertIn(mapping_name, audit_data)
       self.assertEqual(audit_data[mapping_name], "\n".join(sorted(slugs)))

--- a/test/integration/ggrc/converters/test_import_assessments.py
+++ b/test/integration/ggrc/converters/test_import_assessments.py
@@ -240,7 +240,7 @@ class TestAssessmentImport(TestCase):
     self.import_data(OrderedDict([
         ("object_type", "Assessment"),
         ("Code*", assessment.slug),
-        ("map:control", control.slug),
+        ("map:Control versions", control.slug),
     ]))
     self.assertTrue(db.session.query(
         models.Relationship.get_related_query(
@@ -344,7 +344,7 @@ class TestAssessmentImport(TestCase):
         ("Assignees*", models.Person.query.all()[0].email),
         ("Creators", models.Person.query.all()[0].email),
         ("Title", "Strange title"),
-        ("map:control", control.slug),
+        ("map:Control versions", control.slug),
     ]))
     assessment = models.Assessment.query.filter(
         models.Assessment.slug == slug
@@ -547,7 +547,8 @@ class TestAssessmentExport(TestCase):
         revision_id=revision.id
     )
     db.session.commit()
-    self.assertColumnExportedValue("", assessment, "map:control")
+    self.assertColumnExportedValue("", assessment,
+                                   "map:control versions")
 
   def test_export_assesments_with_map_control(self):
     """Test export assesment with related control instance
@@ -572,7 +573,8 @@ class TestAssessmentExport(TestCase):
     )
     db.session.commit()
     factories.RelationshipFactory(source=snapshot, destination=assessment)
-    self.assertColumnExportedValue(control.slug, assessment, "map:control")
+    self.assertColumnExportedValue(control.slug, assessment,
+                                   "map:control versions")
 
   def test_export_assesments_with_map_control_mirror_relation(self):
     """Test export assesment with related control instance
@@ -597,7 +599,8 @@ class TestAssessmentExport(TestCase):
     )
     db.session.commit()
     factories.RelationshipFactory(destination=snapshot, source=assessment)
-    self.assertColumnExportedValue(control.slug, assessment, "map:control")
+    self.assertColumnExportedValue(control.slug, assessment,
+                                   "map:control versions")
 
   def test_export_assessments_with_filters_and_conflicting_ca_names(self):
     """Test exporting assessments with conflicting custom attribute names."""

--- a/test/integration/ggrc/converters/test_import_helpers.py
+++ b/test/integration/ggrc/converters/test_import_helpers.py
@@ -11,6 +11,7 @@ from ggrc.access_control import roleable
 from ggrc.converters import column_handlers
 from ggrc.converters import import_helper
 from ggrc.converters.import_helper import get_object_column_definitions
+from ggrc.snapshotter.rules import Types
 from ggrc.utils.rules import get_mapping_rules, get_unmapping_rules
 from ggrc.utils import title_from_camelcase
 from ggrc_risks import models as r_models
@@ -24,8 +25,17 @@ def get_mapping_names(class_name):
   """Get mapping column names."""
   mapping_rules = get_mapping_rules().get(class_name)
   if mapping_rules is not None:
-    pretty_mapping_rules = (title_from_camelcase(r) for r in mapping_rules)
-    mapping_names = {"map:{}".format(n) for n in pretty_mapping_rules}
+    if class_name in Types.scoped | Types.parents:
+      mapping_names = set()
+      for mapped_type in mapping_rules:
+        if mapped_type in Types.all:
+          format_ = "map:{} versions"
+        else:
+          format_ = "map:{}"
+        mapping_names.add(format_.format(title_from_camelcase(mapped_type)))
+    else:
+      pretty_mapping_rules = (title_from_camelcase(r) for r in mapping_rules)
+      mapping_names = {"map:{}".format(n) for n in pretty_mapping_rules}
   else:
     mapping_names = None
   return mapping_names

--- a/test/integration/ggrc/test_csvs/assessment_full_no_warnings.csv
+++ b/test/integration/ggrc/test_csvs/assessment_full_no_warnings.csv
@@ -1,5 +1,5 @@
 Object type,,,,,,,,,,,,,,
-Assessment,Code*,Audit*,Title*,Description,Notes,State*,Assignees*,Creators*,Recipients,Send by default,Reference URL,evidence file,map:Facility,map: Market
+Assessment,Code*,Audit*,Title*,Description,Notes,State*,Assignees*,Creators*,Recipients,Send by default,Reference URL,evidence file,map:Facility versions,map: Market versions
 ,Assessment 1,Audit,Assessment title 1,Some desc 1,notes 1,NOT STARTED,"user1@a.com
 user2@a.com","user2@a.com
 user5@a.com","Verifier, Assessor",Yes,http://i.imgur.com/Lppr247.jpg,"http://i.imgur.com/Lppr247.jpg evidence 啕 title 1

--- a/test/integration/ggrc/test_csvs/assessment_update_intermediate.csv
+++ b/test/integration/ggrc/test_csvs/assessment_update_intermediate.csv
@@ -1,5 +1,5 @@
 Object type,,,,,,,,,,,,
-Assessment,Code*,Audit*,Title*,Description,Notes,State*,Assignees*,Creators*,,map: Market,evidence url,evidence file
+Assessment,Code*,Audit*,Title*,Description,Notes,State*,Assignees*,Creators*,,map: Market versions,evidence url,evidence file
 ,Assessment 1,Audit,Assessment title 1,Some desc 1,Edited notes,NOT STARTED,"user1@a.com
 user2@a.com","user2@a.com
 user3@a.com",,,"a.b.com

--- a/test/integration/ggrc/test_csvs/assessment_with_warnings_and_errors.csv
+++ b/test/integration/ggrc/test_csvs/assessment_with_warnings_and_errors.csv
@@ -1,6 +1,6 @@
 Object type,"This needs to be imported after assessment_full_no_warnings
 ",,,These are the expected warnings,,,,,,,,,,
-Assessment,Code*,Audit*,Title*,Error description - non existing column will be ignored,Actual Error message,Notes,State*,Assignees*,Creators*,Finished Date,Verified Date,map:project,map: Market,reference url
+Assessment,Code*,Audit*,Title*,Error description - non existing column will be ignored,Actual Error message,Notes,State*,Assignees*,Creators*,Finished Date,Verified Date,map:project,map: Market versions,reference url
 ,Assessment 2,Audit,Assessment title 2,"you are not verifier, you can not verify this assessment",,notes 2,In Progress,user1@a.com,user2@a.com,7/2/2015,5/12/2016,,,http://i.imgur.com/Lppr247.jpg some invalid title
 ,Assessment 3,Audit,Assessment title 3,"this assessment has changed and can not be verified in the first step, verification will be done only upon re-importing this csv", ,changed notes,In Progress,user1@a.com,user2@a.com,7/3/2015,5/13/2016,,,
 ,Assessment 4,Audit,Assessment title 4,This should work and the state will be changed to verified,,notes 4,In Progress,user1@a.com,user2@a.com,7/4/2015,5/14/2016,,,


### PR DESCRIPTION
This rename is required to display "map:"/"unmap:" columns both Snapshot and Snapshottable original objects for Issues.