### PR TITLE
GGRC-2203 Add message regarding Default Assignee on Assessment Template

### DIFF
--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -355,7 +355,8 @@
         {value: 'Primary Contacts', title: 'Primary Contacts'},
         {value: 'Secondary Contacts', title: 'Secondary Contacts'},
         {value: 'other', title: 'Others...'}
-      ]
+      ],
+      showCaptainAlert: false,
     },
     statuses: ['Draft', 'Deprecated', 'Active'],
     tree_view_options: {
@@ -486,6 +487,12 @@
      * @param {jQuery.Event} ev - the event that was triggered
      */
     defaultAssesorsChanged: function (context, $el, ev) {
+      var changedList = [
+        'Auditors', 'Principal Assignees', 'Secondary Assignees',
+        'Primary Contacts', 'Secondary Contacts'
+      ];
+      this.attr('showCaptainAlert',
+        changedList.indexOf(this.default_people.assessors) >= 0);
       this._updateDropdownEnabled('assessors');
     },
 

--- a/src/ggrc/assets/js_specs/models/assessment_template_spec.js
+++ b/src/ggrc/assets/js_specs/models/assessment_template_spec.js
@@ -291,11 +291,21 @@ describe('can.Model.AssessmentTemplate', function () {
     var context;
     var $element;
     var eventObj;
+    var greenList;
+    var redList;
 
     beforeEach(function () {
       context = {};
       $element = $('<div></div>');
       eventObj = $.Event();
+      instance.attr('showCaptainAlert', false);
+      greenList = [
+        'Auditors', 'Principal Assignees', 'Secondary Assignees',
+        'Primary Contacts', 'Secondary Contacts',
+      ];
+      redList = [
+        'Admin', 'Audit Lead', 'other',
+      ];
     });
 
     it('sets the assessorsListDisable flag if the corresponding ' +
@@ -319,6 +329,30 @@ describe('can.Model.AssessmentTemplate', function () {
         instance.defaultAssesorsChanged(context, $element, eventObj);
 
         expect(instance.attr('assessorsListDisable')).toBe(false);
+      }
+    );
+
+    it('showCaptainAlert value is "true" if default assessor ' +
+      'is one of changedList',
+      function () {
+        greenList.map(function (item) {
+          instance.attr('default_people.assessors', item);
+          instance.defaultAssesorsChanged(context, $element, eventObj);
+
+          expect(instance.attr('showCaptainAlert')).toBe(true);
+        });
+      }
+    );
+
+    it('showCaptainAlert value is "false" if default assessor ' +
+      'is NOT one of changedList',
+      function () {
+        redList.map(function (item) {
+          instance.attr('default_people.assessors', item);
+          instance.defaultAssesorsChanged(context, $element, eventObj);
+
+          expect(instance.attr('showCaptainAlert')).toBe(false);
+        });
       }
     );
   });

--- a/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
@@ -69,6 +69,16 @@
           <input tabindex="2" class="input-block-level" name="audit.title" data-permission-type="update" data-lookup="Audit" data-template="/directives/autocomplete_result.mustache" placeholder="Choose Audit" type="text" null-if-empty="false" value="{{firstnonempty audit.title ''}}" disabled="disabled" />
         {{/using}}
       </div>
+      <div class="span6">
+        {{#instance.showCaptainAlert}}
+            <div class="width-80">
+              <div class="alert alert-nomargin">
+                <p>If default assignee can not be determined,
+                Audit Captain will become the assignee.</p>
+              </div>
+            </div>
+          {{/instance.showCaptainAlert}}
+      </div>
     </div>
 
     <br />
@@ -107,7 +117,6 @@
 
       <div class="span6">
         <div class="row-fluid choose-from-select">
-
           <div class="span6 bottom-spacing{{#validation_error instance.computed_errors 'default_people.assessors'}} field-failure{{/validation_error}}">
             <label>
               Default Assignees

--- a/src/ggrc/assets/stylesheets/_common.scss
+++ b/src/ggrc/assets/stylesheets/_common.scss
@@ -1033,3 +1033,8 @@ p {
   font-style: italic;
   color: black;
 }
+
+.alert.alert-nomargin {
+    margin-top: 0px;
+    margin-bottom: 0px;
+}

--- a/src/ggrc/assets/stylesheets/components/flexbox-layout/_flexbox-layout.scss
+++ b/src/ggrc/assets/stylesheets/components/flexbox-layout/_flexbox-layout.scss
@@ -73,6 +73,10 @@
   width: 100%
 }
 
+.width-80 {
+  width: 80%
+}
+
 .width-70 {
   width: 70%
 }


### PR DESCRIPTION
Add info message for Default Assignee field that should inform that if user selects role optional for an object in Default Assignee dropdown AND such role will be missing for an auditable object, then generated Assessment for such object will be assigned to Internal Audit Lead.
Roles that are optional for snapshottable objects:
	▪	Principal Assignee;
	▪	Secondary Assignee;
	▪	Primary Contact;
	▪	Secondary Contact.
	▪	Auditors