### PR TITLE
QUICK-FIX Remove duplicate ACL check from my_work

### DIFF
--- a/src/ggrc/query/my_objects.py
+++ b/src/ggrc/query/my_objects.py
@@ -63,21 +63,6 @@ def get_myobjects_query(types=None, contact_id=None, is_creator=False):  # noqa
     )
     return object_people_query
 
-  def _get_object_owners():
-    """Objects for which the user is an 'owner'."""
-    object_owners_query = db.session.query(
-        all_models.AccessControlList.object_id.label('id'),
-        all_models.AccessControlList.object_type.label('type'),
-        literal(None).label('context_id')
-    ).filter(
-        and_(
-            all_models.AccessControlList.person_id == contact_id,
-            all_models.AccessControlList.object_type.in_(model_names),
-            all_models.AccessControlRole.name == "Admin"
-        )
-    )
-    return object_owners_query
-
   def _get_object_mapped_ca():
     """Objects to which the user is mapped via a custom attribute."""
     ca_mapped_objects_query = db.session.query(
@@ -261,8 +246,7 @@ def get_myobjects_query(types=None, contact_id=None, is_creator=False):  # noqa
   if not is_creator:
     type_union_queries.append(_get_object_people())
 
-  type_union_queries.extend((_get_object_owners(),
-                            _get_object_mapped_ca(),
+  type_union_queries.extend((_get_object_mapped_ca(),
                             _get_objects_user_assigned(),
                             _get_context_relationships(),
                             _get_custom_roles(),))

--- a/test/integration/ggrc/services/test_query/test_owned.py
+++ b/test/integration/ggrc/services/test_query/test_owned.py
@@ -1,0 +1,63 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Tests for owned operator."""
+
+import ddt
+
+from integration.ggrc import TestCase
+from integration.ggrc.query_helper import WithQueryApi
+from integration.ggrc.models import factories
+
+
+@ddt.ddt
+class TestOwned(TestCase, WithQueryApi):
+  """Test for correct working operator owned"""
+
+  def setUp(self):
+    super(TestOwned, self).setUp()
+    self.client.get("/login")
+    with factories.single_commit():
+      self.person = factories.PersonFactory()
+      self.control = factories.ControlFactory()
+
+  @ddt.data(
+      ((True, True), True),
+      ((True, False), True),
+      ((False, True), True),
+      ((False, False), False),
+  )
+  @ddt.unpack
+  def test_acl_people(self, my_work_flags, should_return):
+    """Owned returns objects where person has role with my_work set."""
+    with factories.single_commit():
+      for my_work in my_work_flags:
+        role = factories.AccessControlRoleFactory(object_type="Control",
+                                                  my_work=my_work)
+        factories.AccessControlListFactory(
+            ac_role=role,
+            person=self.person,
+            object=self.control,
+        )
+
+    control_id = self.control.id
+
+    ids = self._get_first_result_set(
+        {
+            "object_name": "Control",
+            "type": "ids",
+            "filters": {
+                "expression": {
+                    "object_name": "Person",
+                    "op": {"name": "owned"},
+                    "ids": [self.person.id]
+                }
+            }
+        },
+        "Control", "ids"
+    )
+
+    if should_return:
+      self.assertEqual(ids, [control_id])
+    else:
+      self.assertEqual(ids, [])


### PR DESCRIPTION
The check for "Admin" is excessive because there is another query for all ACRoles with "my_work" set.