### PR TITLE
GGRC-3382 Top Navigation line: update orange color as it's too bright

### DIFF
--- a/src/ggrc/assets/stylesheets/_colors.scss
+++ b/src/ggrc/assets/stylesheets/_colors.scss
@@ -8,7 +8,7 @@ $widgetBorder: #ccc;
 $widgetHeader: #ddd;
 $widgetTitle: #111;
 $filterBgnd: #bebebe;
-$paginationGray: #F8F8F8; 
+$paginationGray: #F8F8F8;
 
 // widget info
 $infoWidgetHeader: #111;
@@ -182,4 +182,4 @@ $icon-color-hover: #333;
 $border-color: #eee;
 
 // headers colors
-$header-colors: #43A047, #FB8C00, #B71C1C, #1E88E5, #3F51B5;
+$header-colors: #43A047, #795548, #B71C1C, #1E88E5, #3F51B5;


### PR DESCRIPTION
Change color of Top Navigation line to brown for:
- Audit;
- Assessment.

**Mock-Ups:** https://drive.google.com/corp/drive/folders/0B65BmaCGVTRwYUFCVm92MklfbEU 