### PR TITLE
GGRC-2318 Display 'Archived' column for Audit and Assessment 

### DIFF
--- a/src/ggrc/assets/javascripts/models/assessment.js
+++ b/src/ggrc/assets/javascripts/models/assessment.js
@@ -92,6 +92,10 @@
         attr_title: 'Created Date',
         attr_name: 'created_at',
         order: 8
+      }, {
+        attr_title: 'Archived',
+        attr_name: 'archived',
+        order: 16,
       }],
       display_attr_names: ['title', 'status', 'assignees', 'verifiers',
         'updated_at']

--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -92,36 +92,50 @@
       attr_view: GGRC.mustache_path + '/audits/tree-item-attr.mustache',
       attr_list: [{
         attr_title: 'Title',
-        attr_name: 'title'
+        attr_name: 'title',
+        order: 1,
       }, {
         attr_title: 'Audit Captain',
         attr_name: 'audit_lead',
-        attr_sort_field: 'contact'
+        attr_sort_field: 'contact',
+        order: 2,
       }, {
         attr_title: 'Code',
-        attr_name: 'slug'
+        attr_name: 'slug',
+        order: 3,
       }, {
         attr_title: 'Status',
-        attr_name: 'status'
+        attr_name: 'status',
+        order: 4,
       }, {
         attr_title: 'Last Updated',
-        attr_name: 'updated_at'
+        attr_name: 'updated_at',
+        order: 5,
       }, {
         attr_title: 'Last Updated By',
-        attr_name: 'modified_by'
+        attr_name: 'modified_by',
+        order: 6,
       }, {
         attr_title: 'Planned Start Date',
-        attr_name: 'start_date'
+        attr_name: 'start_date',
+        order: 7,
       }, {
         attr_title: 'Planned End Date',
-        attr_name: 'end_date'
+        attr_name: 'end_date',
+        order: 8,
       }, {
         attr_title: 'Planned Report Period to',
         attr_name: 'report_period',
-        attr_sort_field: 'report_end_date'
+        attr_sort_field: 'report_end_date',
+        order: 9,
       }, {
         attr_title: 'Audit Firm',
-        attr_name: 'audit_firm'
+        attr_name: 'audit_firm',
+        order: 10,
+      }, {
+        attr_title: 'Archived',
+        attr_name: 'archived',
+        order: 11,
       }],
       draw_children: true
     },

--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -2222,7 +2222,7 @@ Mustache.registerHelper('get_url_value', function (attr_name, instance) {
    * The method only supports instance attributes categorized as "default",
    * and does not support (read: not work for) nested object references.
    *
-   * If the attribute does not exist, has a falsy value, or is not considered
+   * If the attribute does not exist or is not considered
    * to be a "default" attribute, an empty string is returned.
    *
    * If the attribute represents a date information, it is returned in the

--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -2254,7 +2254,8 @@ Mustache.registerHelper('get_url_value', function (attr_name, instance) {
         status: 1,
         url: 1,
         verified: 1,
-        os_state: 1
+        os_state: 1,
+        archived: 1,
       });
 
       var res;

--- a/src/ggrc/assets/js_specs/mustache_helpers/get_default_attr_value_spec.js
+++ b/src/ggrc/assets/js_specs/mustache_helpers/get_default_attr_value_spec.js
@@ -22,14 +22,13 @@ describe('can.mustache.helper.get_default_attr_value', function () {
     expect(result).toEqual('');
   });
 
-  it('returns an empty string if the attribute has a falsy value',
+  it('returns an empty string if the attribute is not considered as "default"',
     function () {
       var result;
-      instance.attr('foo', false);
-      result = helper('foo', instance);
+      instance.attr('is_not_default', true);
+      result = helper('is_not_default', instance);
       expect(result).toEqual('');
-    }
-  );
+    });
 
   describe('retrieving a "default" (non-date) attribute', function () {
     beforeEach(function () {
@@ -44,6 +43,20 @@ describe('can.mustache.helper.get_default_attr_value', function () {
 
       expect(instance.attr).toHaveBeenCalledWith('status');
       expect(result).toEqual('In progress');
+    });
+
+    it('returns "true" string when boolean attr value is true', function () {
+      var result;
+      instance.attr('archived', true);
+      result = helper('archived', instance);
+      expect(result).toEqual('true');
+    });
+
+    it('returns "false" string when boolean attr value is false', function () {
+      var result;
+      instance.attr('archived', false);
+      result = helper('archived', instance);
+      expect(result).toEqual('false');
     });
   });
 


### PR DESCRIPTION
ACCEPTANCE CRITERIA
AC1. Add 'Archived' checkbox on 'Set visible fields for <object>' popover.
AC2. If user selects 'Archived' checkbox, then display 'Archived' column in tree view.
AC3. 'Archived' column should be hidden by default.
AC4. If Audit / Assessment is archived than, it has 'true' value in 'Archived' column.
AC5. If Audit / Assessment is not archived OR unarchived than, it has 'false' value in 'Archived' column.

Make changes for the objects:
- Audit;
- Assessment.

Make changes on the all pages that have tree view for Audit and Assessment. Currently they are:
- Global search;
- Audit page - Assessments tab
- <snapshottable object> page - Audit tab.
- My Assessments page;
- Assessment page - Audit tab.
- Issue page - Audit tab;
- Program page - Audit tab;
- Person page - Audit and Assessment tabs;
- All Objects page - Audit and Assessment tabs;
- My Work page - Audit and Assessment tabs;
- Unified Mapper - object type = Audit.