### PR TITLE
GGRC-2199 Request to view more than 10 assessments per page

### DIFF
--- a/src/ggrc/assets/mustache/components/tree_pagination/tree_pagination.mustache
+++ b/src/ggrc/assets/mustache/components/tree_pagination/tree_pagination.mustache
@@ -10,7 +10,7 @@
             ($change)="changePageSize(%element.value)">
       <option selected hidden>{{pageSize}}</option>
       {{#pageSizeSelect}}
-        <option value="{{.}}" >{{.}}</option>
+        <option {{#if_equals pageSize .}}selected{{/if_equals}} value="{{.}}" >{{.}}</option>
       {{/pageSizeSelect}}
     </select>
     {{/paging}}


### PR DESCRIPTION
How to reproduce:
1. Go to My Work page > Assessments tab
2. Set view 25 items per page from the top pagination dropdown
3. Set view 50 items per page from the bottom pagination dropdown
4. Look at the pagination top dropdown: shows different settings