### PR TITLE
GGRC-3473 Refactor mapping rules

### DIFF
--- a/src/ggrc/utils/rules.py
+++ b/src/ggrc/utils/rules.py
@@ -3,81 +3,226 @@
 
 """Mapping rules for Relationship validation and map:model import columns."""
 
-import copy
+import collections
+import functools
 
 
-def get_mapping_rules():
-  """ Get mappings rules as defined in business_object.js
+class ImmutableDict(collections.Mapping):
+  """An immutable wrapper for defaultdict with False by default."""
+
+  __slots__ = ("_dict", "_hash")
+  DEFAULT_VALUE = False
+
+  def __init__(self, **kwargs):
+    super(ImmutableDict, self).__init__()
+    self._dict = collections.defaultdict(lambda: self.DEFAULT_VALUE)
+    self._hash = None
+    self._update(**kwargs)
+
+  def _update(self, *args, **kwargs):
+    """Update internal dict."""
+    self._dict.update(*args, **kwargs)
+
+  def __getitem__(self, key):
+    """Passthrough to internal dict."""
+    return self._dict[key]
+
+  def __iter__(self):
+    """Passthrough to internal dict."""
+    return self._dict.__iter__()
+
+  def __len__(self):
+    """Passthrough to internal dict."""
+    return self._dict.__len__()
+
+  def __hash__(self):
+    """Hash of own values (computed lazily)."""
+    if self._hash is None:
+      self._hash = hash(frozenset(self._dict.iteritems()))
+    return self._hash
+
+  def __eq__(self, other):
+    """True if other is instance of self.__class__ and has same _dict."""
+    # pylint: disable=protected-access; we check other to be of same type first
+    return isinstance(other, self.__class__) and self._dict == other._dict
+
+  def __repr__(self):
+    return "{cls}(**{arg})".format(cls=self.__class__.__name__,
+                                   arg=dict(self._dict))
+
+
+class Labels(object):  # pylint: disable=too-few-public-methods
+  """Enum with labels used as MappingRule keys."""
+  MAP = "map"
+  UNMAP = "unmap"
+  TYPE = "type"
+  MAP_SNAPSHOT = "map_snapshot"
+
+
+class BasicRule(ImmutableDict):
+  """Passes cls.VALUE to ImmutableDict."""
+
+  VALUE = {}
+
+  def __init__(self, type_):
+    value = {Labels.TYPE: type_}
+    value.update(self.VALUE)
+    super(BasicRule, self).__init__(**value)
+
+
+class MappingRule(BasicRule):
+  """Boolean flags for mappings."""
+
+  VALUE = {Labels.MAP: True,
+           Labels.UNMAP: True}
+
+
+class StaticMappingRule(BasicRule):
+  """Boolean flags to only show mapped objects."""
+
+  VALUE = {Labels.MAP: True}
+
+
+class SnapshotMappingRule(MappingRule):
+  """Boolean flags to map snapshots."""
+
+  VALUE = {Labels.MAP_SNAPSHOT: True}
+
+
+class StaticSnapshotMappingRule(MappingRule):
+  """Boolean flags to only show mapped snapshots."""
+
+  VALUE = {Labels.MAP_SNAPSHOT: True}
+
+
+def wrap_rules(func):
+  """Transform str-type rules into MappingRule(str)."""
+  def make_rules(items):
+    """For all non-BasicRule items, replace them with MappingRule(item)."""
+    for item in items:
+      if not isinstance(item, BasicRule):
+        item = MappingRule(type_=item)
+      yield item
+
+  @functools.wraps(func)
+  def inner(*args, **kwargs):
+    """Transform func result {key: {rule}} -> {key: {rule.type: rule}}."""
+    result = func(*args, **kwargs)
+    return {key: set(make_rules(value))
+            for (key, value) in result.iteritems()}
+
+  return inner
+
+
+def cached(func):
+  """Memoize the return value of a function with zero arguments."""
+  @functools.wraps(func)
+  def inner():
+    """Get memoized result or calculate and memoize it."""
+    try:
+      result = func.result
+    except AttributeError:
+      result = func.result = func()
+    return result
+
+  return inner
+
+
+@cached
+@wrap_rules
+def _all_rules():
+  """Get mapping, unmapping and snapshot mapping rules.
 
   Special cases:
-    Aduit has direct mapping to Program with program_id
-    Section has a direct mapping to Standard/Regulation/Poicy with directive_id
+    Audit has direct mapping to Program with program_id
+    Assessment has direct mapping to Audit as well as Relationship
   """
   from ggrc import snapshotter
-  all_rules = set(['AccessGroup', 'Clause', 'Contract', 'Control',
-                   'CycleTaskGroupObjectTask', 'DataAsset', 'Facility',
-                   'Market', 'Objective', 'OrgGroup', 'Person', 'Policy',
-                   'Process', 'Product', 'Program', 'Project', 'Regulation',
-                   'Risk', 'Section', 'Standard', 'System', 'Threat',
-                   'Vendor'])
+
+  all_models = {'AccessGroup', 'Clause', 'Contract', 'Control',
+                'CycleTaskGroupObjectTask', 'DataAsset', 'Facility',
+                'Market', 'Objective', 'OrgGroup', 'Person',
+                'Policy', 'Process', 'Product', 'Program', 'Project',
+                'Regulation', 'Risk', 'Section', 'Standard',
+                'System', 'Threat', 'Vendor'}
 
   snapshots = snapshotter.rules.Types.all
 
-  business_object_rules = {
-      "AccessGroup": all_rules - set(['AccessGroup']),
-      "Clause": all_rules - set(['Clause']),
-      "Contract": all_rules - set(['Policy', 'Regulation',
+  all_rules = {
+      "AccessGroup": all_models - set(['AccessGroup']),
+      "Clause": all_models - set(['Clause']),
+      "Contract": all_models - set(['Policy', 'Regulation',
                                    'Contract', 'Standard']),
-      "Control": all_rules,
-      "CycleTaskGroupObjectTask": (all_rules -
+      "Control": all_models,
+      "CycleTaskGroupObjectTask": (all_models -
                                    set(['CycleTaskGroupObjectTask'])),
-      "DataAsset": all_rules,
-      "Facility": all_rules,
-      "Market": all_rules,
-      "Objective": all_rules,
-      "OrgGroup": all_rules,
-      "Person": all_rules - set(['Person']),
-      "Policy": all_rules - set(['Policy', 'Regulation',
-                                 'Contract', 'Standard']),
-      "Process": all_rules,
-      "Product": all_rules,
-      "Program": all_rules - set(['Program']),
-      "Project": all_rules,
-      "Regulation": all_rules - set(['Policy', 'Regulation',
+      "DataAsset": all_models,
+      "Facility": all_models,
+      "Market": all_models,
+      "Objective": all_models,
+      "OrgGroup": all_models,
+      "Person": all_models - set(['Person']),
+      "Policy": all_models - set(['Policy', 'Regulation',
+                                  'Contract', 'Standard']),
+      "Process": all_models,
+      "Product": all_models,
+      "Program": all_models - set(['Program']),
+      "Project": all_models,
+      "Regulation": all_models - set(['Policy', 'Regulation',
                                      'Contract', 'Standard']),
-      "Risk": all_rules - set(['Risk']),
-      "Section": all_rules,
-      "Standard": all_rules - set(['Policy', 'Regulation',
-                                   'Contract', 'Standard']),
-      "System": all_rules,
-      "Threat": all_rules - set(['Threat']),
-      "Vendor": all_rules,
+      "Risk": all_models - set(['Risk']),
+      "Section": all_models,
+      "Standard": all_models - set(['Policy', 'Regulation',
+                                    'Contract', 'Standard']),
+      "System": all_models,
+      "Threat": all_models - set(['Threat']),
+      "Vendor": all_models,
   }
 
   # Audit and Audit-scope objects
   # Assessment and Issue have a special Audit field instead of map:audit
-  business_object_rules.update({
-      "Audit": snapshots | {"Assessment", "Issue"},
-      "Assessment": snapshots | {"Issue"},
-      "Issue": snapshots | {"Assessment"},
+
+  all_rules.update({
+      "Audit": {
+          StaticMappingRule("Assessment"),
+          StaticMappingRule("Issue")
+      } | {
+          StaticSnapshotMappingRule(type_) for type_ in snapshots
+      },
+      "Assessment": {"Issue"} | {
+          StaticSnapshotMappingRule(type_) for type_ in snapshots
+      },
+      "Issue": {"Assessment"} | {
+          StaticSnapshotMappingRule(type_) for type_ in snapshots
+      },
   })
 
-  return business_object_rules
+  return all_rules
 
 
+def _filter_rules(rules, flag):
+  """Get rule.type_ for each rule[flag] == True."""
+  return {key: {rule[Labels.TYPE] for rule in value if rule[flag]}
+          for (key, value) in rules.iteritems()}
+
+
+@cached
+def get_mapping_rules():
+  return _filter_rules(_all_rules(), Labels.MAP)
+
+
+@cached
 def get_unmapping_rules():
-  """Get unmapping rules from mapping dict."""
-  unmapping_rules = copy.deepcopy(get_mapping_rules())
+  return _filter_rules(_all_rules(), Labels.UNMAP)
 
-  # Audit and Audit-scope objects
-  unmapping_rules["Audit"] = set()
-  unmapping_rules["Assessment"] = {"Issue"}
-  unmapping_rules["Issue"] = {"Assessment"}
 
-  return unmapping_rules
+@cached
+def get_snapshot_mapping_rules():
+  return _filter_rules(_all_rules(), Labels.MAP_SNAPSHOT)
 
 
 __all__ = [
     "get_mapping_rules",
+    "get_snapshot_mapping_rules",
     "get_unmapping_rules",
 ]

--- a/test/unit/ggrc/utils/test_rules.py
+++ b/test/unit/ggrc/utils/test_rules.py
@@ -31,15 +31,8 @@ class TestMappingRules(BaseTestMappingRules):
                'Objective', 'OrgGroup', 'Person', 'Policy', 'Process',
                'Product', 'Program', 'Project', 'Regulation', 'Risk',
                'Section', 'Standard', 'System', 'Threat', 'Vendor', ]
-  assessment_rules = ['AccessGroup', 'Clause', 'Contract', 'Control',
-                      'DataAsset', 'Facility', 'Issue', 'Market', 'Objective',
-                      'OrgGroup', 'Policy', 'Process', 'Product', 'Regulation',
-                      'Risk', 'Section', 'Standard', 'System', 'Threat',
-                      'Vendor', ]
-  audit_rules = ['AccessGroup', 'Assessment', 'Clause', 'Contract', 'Control',
-                 'DataAsset', 'Facility', 'Issue', 'Market', 'Objective',
-                 'OrgGroup', 'Policy', 'Process', 'Product', 'Regulation',
-                 'Risk', 'Section', 'Standard', 'System', 'Threat', 'Vendor']
+  assessment_rules = ['Issue']
+  audit_rules = ['Assessment', 'Issue']
   accessgroup_rules = ['Clause', 'Contract', 'Control',
                        'CycleTaskGroupObjectTask', 'DataAsset', 'Facility',
                        'Market', 'Objective', 'OrgGroup', 'Person', 'Policy',
@@ -63,10 +56,7 @@ class TestMappingRules(BaseTestMappingRules):
                   'Market', 'Objective', 'OrgGroup', 'Person', 'Policy',
                   'Process', 'Product', 'Program', 'Project', 'Regulation',
                   'Risk', 'Section', 'Standard', 'System', 'Threat', 'Vendor']
-  issue_rules = ['AccessGroup', 'Assessment', 'Clause', 'Contract', 'Control',
-                 'DataAsset', 'Facility', 'Market', 'Objective', 'OrgGroup',
-                 'Policy', 'Process', 'Product', 'Regulation', 'Risk',
-                 'Section', 'Standard', 'System', 'Threat', 'Vendor', ]
+  issue_rules = ['Assessment']
   person_rules = ['AccessGroup', 'Clause', 'Contract', 'Control',
                   'CycleTaskGroupObjectTask', 'DataAsset', 'Facility',
                   'Market', 'Objective', 'OrgGroup', 'Policy', 'Process',
@@ -232,6 +222,60 @@ class TestUnMappingRules(BaseTestMappingRules):
         ("Standard", standard_rules),
         ("System", all_rules),
         ("Threat", threat_rules),
+        ("Vendor", all_rules))
+  @unpack
+  def test_field(self, field, rules):
+    self.assertRules(field, *rules)
+
+
+@ddt
+class TestSnapshotMappingRules(BaseTestMappingRules):
+  """Test case for snapshot mapping rules."""
+
+  rules = ggrc.utils.rules.get_snapshot_mapping_rules()
+
+  all_rules = []
+  assessment_rules = ["AccessGroup", "Clause", "Contract", "Control",
+                      "DataAsset", "Facility", "Market", "Objective",
+                      "OrgGroup", "Policy", "Process", "Product",
+                      "Regulation", "Section", "Standard", "System",
+                      "Vendor", "Risk", "Threat"]
+  audit_rules = ["AccessGroup", "Clause", "Contract", "Control",
+                 "DataAsset", "Facility", "Market", "Objective",
+                 "OrgGroup", "Policy", "Process", "Product",
+                 "Regulation", "Section", "Standard", "System",
+                 "Vendor", "Risk", "Threat"]
+  issue_rules = ["AccessGroup", "Clause", "Contract", "Control",
+                 "DataAsset", "Facility", "Market", "Objective",
+                 "OrgGroup", "Policy", "Process", "Product",
+                 "Regulation", "Section", "Standard", "System",
+                 "Vendor", "Risk", "Threat"]
+
+  @data(("AccessGroup", all_rules),
+        ("Assessment", assessment_rules),
+        ("Audit", audit_rules),
+        ("Clause", all_rules),
+        ("Contract", all_rules),
+        ("Control", all_rules),
+        ("CycleTaskGroupObjectTask", all_rules),
+        ("DataAsset", all_rules),
+        ("Facility", all_rules),
+        ("Issue", issue_rules),
+        ("Market", all_rules),
+        ("Objective", all_rules),
+        ("OrgGroup", all_rules),
+        ("Person", all_rules),
+        ("Policy", all_rules),
+        ("Process", all_rules),
+        ("Product", all_rules),
+        ("Program", all_rules),
+        ("Project", all_rules),
+        ("Regulation", all_rules),
+        ("Risk", all_rules),
+        ("Section", all_rules),
+        ("Standard", all_rules),
+        ("System", all_rules),
+        ("Threat", all_rules),
         ("Vendor", all_rules))
   @unpack
   def test_field(self, field, rules):


### PR DESCRIPTION
Split map/unmap rules into explicit settings for direct mapping, direct unmapping, snapshot mapping to avoid handling it in consumer code.