### PR TITLE
GGRC-3435,3457,3458,3459,3460,3474 FIx task start dates and end dates for WF after migration

### DIFF
--- a/src/ggrc_workflows/migrations/utils/wf_date_updater.py
+++ b/src/ggrc_workflows/migrations/utils/wf_date_updater.py
@@ -1,0 +1,90 @@
+"""Utils required for migration to fix start and end dates for tasks."""
+from dateutil import relativedelta
+
+from ggrc_workflows.migrations.utils.task_group_task_date_calculator import (
+    google_holidays
+)
+
+# pylint: disable=invalid-name
+
+UPDATE_NOTIFICATIONS = (
+    "UPDATE notifications as n "
+    "JOIN notification_types as t on n.notification_type_id = t.id "
+    "SET send_on = '{send_on}' "
+    "where n.object_type='Workflow' and "
+          "n.object_id in ({ids}) and "  # noqa: E131
+          "sent_at is Null and "
+          "t.name = '{notification_name}'"
+)
+
+UPDATE_TASKS_SQL = (
+    "UPDATE task_group_tasks "
+    "SET start_date='{start_date}', "
+        "end_date='{end_date}' "  # noqa: E131
+    "WHERE id IN ({ids})"
+)
+
+
+UPDATE_WF_SQL = (
+    "UPDATE workflows "
+    "SET repeat_multiplier='{repeat_multiplier}', "
+        "next_cycle_start_date='{next_cycle_start_date}' "  # noqa: E131
+    "WHERE id = {id}"
+)
+
+
+def update_notifications(op, notification_to_update):
+  """Update notifications for new date """
+  for key, wfs in notification_to_update.iteritems():
+    notification_type, send_on = key
+    op.execute(UPDATE_NOTIFICATIONS.format(
+        send_on=send_on,
+        ids=", ".join(str(i) for i in wfs),
+        notification_name=notification_type))
+
+
+def update_task_dates(op, group_days):
+  """update tasks setup dates"""
+  for days, task_ids in group_days.iteritems():
+    start_date, end_date = days
+    op.execute(
+        UPDATE_TASKS_SQL.format(start_date=start_date,
+                                end_date=end_date,
+                                ids=", ".join(str(i) for i in task_ids))
+    )
+
+
+def update_wf(op, repeat_multiplier, next_cycle_start_date, wf):
+  op.execute(
+      UPDATE_WF_SQL.format(repeat_multiplier=repeat_multiplier,
+                           next_cycle_start_date=next_cycle_start_date,
+                           id=wf)
+  )
+
+
+def get_next_cycle_start_date(startup_next_cycle_start_date,
+                              last_cycle_started_date,
+                              months=0,
+                              days=0):
+  """last cycle start date should be in min of started_dates in last cycle
+  last_cycle_date should be in future so compare it with today
+  this is required the next cycle start date will be in future
+  the reason is, we should have skipped cycle in priduction so we guess
+  that next cycles should be only in future and only if user manually start
+  a cycle then last_cycle_started_date will be in future
+  calculate repeat_multiplier and next_cycle_start_date"""
+  holidays = google_holidays.GoogleHolidays()
+  repeat_multiplier = 0
+  next_cycle_start_date = startup_next_cycle_start_date
+  while next_cycle_start_date <= last_cycle_started_date:
+    repeat_multiplier += 1
+    next_cycle_start_date = (
+        startup_next_cycle_start_date + relativedelta.relativedelta(
+            startup_next_cycle_start_date,
+            months=months * repeat_multiplier,
+            days=days * repeat_multiplier))
+    # next cycle start date couldn't be on weekends or on holidays
+    while (next_cycle_start_date.isoweekday() > 5 or
+           next_cycle_start_date in holidays):
+      next_cycle_start_date -= relativedelta.relativedelta(days=1)
+  return repeat_multiplier, next_cycle_start_date

--- a/src/ggrc_workflows/migrations/versions/20170926125029_3ea1293a93bb_update_monthly_wfs.py
+++ b/src/ggrc_workflows/migrations/versions/20170926125029_3ea1293a93bb_update_monthly_wfs.py
@@ -1,0 +1,104 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+update monthly wfs
+
+Create Date: 2017-09-26 12:50:29.595921
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+import collections
+import datetime
+from dateutil import relativedelta
+
+from alembic import op
+
+from ggrc_workflows.migrations.utils import wf_date_updater
+
+
+# revision identifiers, used by Alembic.
+revision = '3ea1293a93bb'
+down_revision = '3ebe14ae9547'
+
+MONTHLY_SQL = (
+    'SELECT w.id, w.next_cycle_start_date, w.status, w.recurrences, '
+           't.id, t.relative_start_day, t.relative_end_day, '  # noqa: E131
+           'MAX(COALESCE(ct.start_date, CURDATE())) '
+    'FROM workflows AS w '
+    'JOIN task_groups AS tg ON tg.workflow_id = w.id '
+    'JOIN task_group_tasks AS t ON t.task_group_id = tg.id '
+    'LEFT JOIN cycle_task_group_object_tasks AS ct '
+           'ON ct.task_group_task_id = t.id '
+    'WHERE w.frequency = "monthly" GROUP BY 1, 5;'
+)
+
+NOTIFICATION_OFFSET = {
+    "month_workflow_starts_in": 1,
+    "cycle_task_failed": -1,
+}
+
+MONTH = 8
+YEAR = 2017
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  # pylint: disable=too-many-locals
+  ctg_wf = collections.defaultdict(set)  # collect last task start date
+  tg_dates_dict = {}  # collect start and end days setup for task group
+  tg_wf = collections.defaultdict(set)  # collect task groups for workflows
+  wf_next_cycle_start_dates = {}
+  wf_statuses = {}
+  for row in op.get_bind().execute(MONTHLY_SQL):
+    (wf, wf_next_cycle_start_date, wf_status, wf_recurrences,
+     tgt, start_day, end_day, last_task_start_date) = row
+    if not (start_day and end_day):
+      continue
+    wf_next_cycle_start_dates[wf] = wf_next_cycle_start_date
+    wf_statuses[wf] = (wf_status, wf_recurrences)
+    tg_wf[wf].add(tgt)
+    ctg_wf[wf].add(last_task_start_date)
+    tg_dates_dict[tgt] = (start_day, end_day)
+
+  today = datetime.date.today()
+  group_days = collections.defaultdict(set)
+  notification_to_update = collections.defaultdict(set)
+  for wf, task_ids in tg_wf.iteritems():
+    start_dates = []
+    for task_id in task_ids:
+      start_date, end_date = [datetime.date(YEAR, MONTH, d)
+                              for d in tg_dates_dict[task_id]]
+      start_dates.append(start_date)
+      if end_date < start_date:
+        end_date += relativedelta.relativedelta(end_date, months=1)
+      group_days[(start_date, end_date)].add(task_id)
+    # min start_date is the setup start date of workflow
+    # next cycle start date should be calculated based on that date
+    repeat_multiplier, next_cycle_start_date = \
+        wf_date_updater.get_next_cycle_start_date(
+            min(start_dates),
+            max([min(ctg_wf[wf]), today]),
+            months=1)
+    if wf_statuses[wf] == ("Active", 1):
+      wf_date_updater.update_wf(op,
+                                repeat_multiplier,
+                                next_cycle_start_date,
+                                wf)
+    if wf_statuses[wf] == ("Active", 1) and (
+            next_cycle_start_date != wf_next_cycle_start_dates[wf]):
+      print ("Next cycle start date changed for "
+             "active workflow {} from {} to {}".format(
+                 wf, wf_next_cycle_start_dates[wf], next_cycle_start_date))
+      for notification_type, offset in NOTIFICATION_OFFSET.iteritems():
+        key = (notification_type,
+               next_cycle_start_date - datetime.timedelta(offset))
+        notification_to_update[key].add(wf)
+  wf_date_updater.update_notifications(op, notification_to_update)
+  wf_date_updater.update_task_dates(op, group_days)
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  pass

--- a/src/ggrc_workflows/migrations/versions/20170927132542_ab76b910268_set_valid_start_date_and_end_dates_for_.py
+++ b/src/ggrc_workflows/migrations/versions/20170927132542_ab76b910268_set_valid_start_date_and_end_dates_for_.py
@@ -1,0 +1,125 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Set valid start_date and end_dates for quarterly
+
+Create Date: 2017-09-27 13:25:42.962481
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+import collections
+import calendar
+import datetime
+from dateutil import relativedelta
+
+from alembic import op
+
+from ggrc_workflows.migrations.utils import wf_date_updater
+
+# revision identifiers, used by Alembic.
+revision = 'ab76b910268'
+down_revision = '3ea1293a93bb'
+
+QUARTERLY_SQL = (
+    'SELECT w.id, w.next_cycle_start_date, w.status, w.recurrences, '
+           't.id, t.relative_start_day, t.relative_start_month, '  # noqa: E131
+           't.relative_end_day, t.relative_end_month, '
+           'MAX(COALESCE(ct.start_date, CURDATE())) '
+    'FROM workflows AS w '
+    'JOIN task_groups AS tg ON tg.workflow_id = w.id '
+    'JOIN task_group_tasks AS t ON t.task_group_id = tg.id '
+    'LEFT JOIN cycle_task_group_object_tasks AS ct '
+           'ON ct.task_group_task_id = t.id '
+    'WHERE w.frequency = "quarterly" GROUP BY 1, 5;'
+)
+
+NOTIFICATION_OFFSET = {
+    "month_workflow_starts_in": 1,
+    "cycle_task_failed": -1,
+}
+
+
+YEAR = 2016
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  # pylint: disable=too-many-locals
+  connection = op.get_bind()
+  quarterly_tasks = connection.execute(QUARTERLY_SQL)
+
+  tg_dates_dict = {}
+  tg_wf = collections.defaultdict(set)
+  ctg_wf = collections.defaultdict(set)
+  wf_next_cycle_start_dates = {}
+  wf_statuses = {}
+  for (
+          wf,
+          wf_next_cycle_start_date,
+          wf_status,
+          w_recur,
+          tgt,
+          start_day,
+          start_month,
+          end_day,
+          end_month,
+          last_task_start_date) in quarterly_tasks:
+
+    if not (start_day and end_day and start_month and end_month):
+      continue
+    tg_wf[wf].add(tgt)
+    ctg_wf[wf].add(last_task_start_date)
+    tg_dates_dict[tgt] = (start_day, start_month, end_day, end_month)
+    wf_next_cycle_start_dates[wf] = wf_next_cycle_start_date
+    wf_statuses[wf] = (wf_status, w_recur)
+
+  today = datetime.date.today()
+  group_days = collections.defaultdict(set)
+  notification_to_update = collections.defaultdict(set)
+  for wf, task_ids in tg_wf.iteritems():
+    start_dates = []
+    for task_id in task_ids:
+      start_day, start_month, end_day, end_month = tg_dates_dict[task_id]
+      start_month += 6
+      end_month += 6
+      _, max_start_day = calendar.monthrange(YEAR, start_month)
+      _, max_end_day = calendar.monthrange(YEAR, end_month)
+      start_date = datetime.date(YEAR,
+                                 start_month,
+                                 min([start_day, max_start_day]))
+      end_date = datetime.date(YEAR,
+                               end_month,
+                               min([end_day, max_end_day]))
+      while end_date < start_date:
+        end_date += relativedelta.relativedelta(end_date, months=3)
+      start_dates.append(start_date)
+      group_days[(start_date, end_date)].add(task_id)
+    repeat_multiplier, next_cycle_start_date = \
+        wf_date_updater.get_next_cycle_start_date(
+            min(start_dates),
+            max([min(ctg_wf[wf]), today]),
+            months=3
+        )
+    if wf_statuses[wf] == ("Active", 1):
+      wf_date_updater.update_wf(op,
+                                repeat_multiplier,
+                                next_cycle_start_date,
+                                wf)
+    if wf_statuses[wf] == ("Active", 1) and (
+            next_cycle_start_date != wf_next_cycle_start_dates[wf]):
+      print ("Next cycle start date changed for "
+             "active workflow {} from {} to {}".format(
+                 wf, wf_next_cycle_start_dates[wf], next_cycle_start_date))
+      for notification_type, offset in NOTIFICATION_OFFSET.iteritems():
+        key = (notification_type,
+               next_cycle_start_date - datetime.timedelta(offset))
+        notification_to_update[key].add(wf)
+  wf_date_updater.update_notifications(op, notification_to_update)
+  wf_date_updater.update_task_dates(op, group_days)
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  pass

--- a/src/ggrc_workflows/migrations/versions/20170927171105_564555de4abb_set_valid_start_date_and_end_dates_for_.py
+++ b/src/ggrc_workflows/migrations/versions/20170927171105_564555de4abb_set_valid_start_date_and_end_dates_for_.py
@@ -1,0 +1,122 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Set valid start_date and end_dates for annually
+
+Create Date: 2017-09-27 13:25:42.962481
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+import collections
+import calendar
+import datetime
+from dateutil import relativedelta
+
+from alembic import op
+
+from ggrc_workflows.migrations.utils import wf_date_updater
+
+# revision identifiers, used by Alembic.
+revision = 'ab78b910268'
+down_revision = 'ab76b910268'
+
+ANNUALLY_SQL = (
+    'SELECT w.id, w.next_cycle_start_date, w.status, w.recurrences, '
+           't.id, t.relative_start_day, t.relative_start_month, '  # noqa: E131
+           't.relative_end_day, t.relative_end_month, '
+           'MAX(COALESCE(ct.start_date, CURDATE())) '
+    'FROM workflows AS w '
+    'JOIN task_groups AS tg ON tg.workflow_id = w.id '
+    'JOIN task_group_tasks AS t ON t.task_group_id = tg.id '
+    'LEFT JOIN cycle_task_group_object_tasks AS ct '
+           'ON ct.task_group_task_id = t.id '
+    'WHERE w.frequency = "annually" GROUP BY 1, 5;'
+)
+
+NOTIFICATION_OFFSET = {
+    "month_workflow_starts_in": 1,
+    "cycle_task_failed": -1,
+}
+
+YEAR = 2016
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  # pylint: disable=too-many-locals
+  connection = op.get_bind()
+  annually_tasks = connection.execute(ANNUALLY_SQL)
+
+  tg_dates_dict = {}
+  tg_wf = collections.defaultdict(set)
+  ctg_wf = collections.defaultdict(set)
+  wf_next_cycle_start_dates = {}
+  wf_statuses = {}
+  for (
+          wf,
+          wf_next_cycle_start_date,
+          wf_status,
+          wf_recur,
+          tgt,
+          start_day,
+          start_month,
+          end_day,
+          end_month,
+          last_task_start_date) in annually_tasks:
+
+    if not (start_day and end_day and start_month and end_month):
+      continue
+    tg_wf[wf].add(tgt)
+    ctg_wf[wf].add(last_task_start_date)
+    tg_dates_dict[tgt] = (start_day, start_month, end_day, end_month)
+    wf_next_cycle_start_dates[wf] = wf_next_cycle_start_date
+    wf_statuses[wf] = (wf_status, wf_recur)
+
+  today = datetime.date.today()
+  group_days = collections.defaultdict(set)
+  notification_to_update = collections.defaultdict(set)
+  for wf, task_ids in tg_wf.iteritems():
+    start_dates = []
+    for task_id in task_ids:
+      start_day, start_month, end_day, end_month = tg_dates_dict[task_id]
+      _, max_start_day = calendar.monthrange(YEAR, start_month)
+      _, max_end_day = calendar.monthrange(YEAR, end_month)
+      start_date = datetime.date(YEAR,
+                                 start_month,
+                                 min(start_day, max_start_day))
+      end_date = datetime.date(YEAR,
+                               end_month,
+                               min(end_day, max_end_day))
+      while end_date < start_date:
+        end_date += relativedelta.relativedelta(end_date, months=12)
+      start_dates.append(start_date)
+      group_days[(start_date, end_date)].add(task_id)
+    repeat_multiplier, next_cycle_start_date = \
+        wf_date_updater.get_next_cycle_start_date(
+            min(start_dates),
+            max([min(ctg_wf[wf]), today]),
+            months=12
+        )
+    if wf_statuses[wf] == ("Active", 1):
+      wf_date_updater.update_wf(op,
+                                repeat_multiplier,
+                                next_cycle_start_date,
+                                wf)
+    if wf_statuses[wf] == ("Active", 1) and (
+            next_cycle_start_date != wf_next_cycle_start_dates[wf]):
+      print ("Next cycle start date changed for "
+             "active workflow {} from {} to {}".format(
+                 wf, wf_next_cycle_start_dates[wf], next_cycle_start_date))
+      for notification_type, offset in NOTIFICATION_OFFSET.iteritems():
+        key = (notification_type,
+               next_cycle_start_date - datetime.timedelta(offset))
+        notification_to_update[key].add(wf)
+  wf_date_updater.update_notifications(op, notification_to_update)
+  wf_date_updater.update_task_dates(op, group_days)
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  pass

--- a/src/ggrc_workflows/migrations/versions/20170928103322_4131bd4a8a4d_set_valid_start_date_and_end_dates_for_.py
+++ b/src/ggrc_workflows/migrations/versions/20170928103322_4131bd4a8a4d_set_valid_start_date_and_end_dates_for_.py
@@ -1,0 +1,117 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Set valid start_date and end_dates for weekly
+
+Create Date: 2017-09-28 10:33:22.595314
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+import collections
+import datetime
+
+from alembic import op
+
+from ggrc_workflows.migrations.utils import wf_date_updater
+
+# revision identifiers, used by Alembic.
+revision = '4131bd4a8a4d'
+down_revision = 'ab78b910268'
+
+MONTH = 8
+YEAR = 2017
+DAYS = {
+    1: datetime.date(YEAR, MONTH, 7),
+    2: datetime.date(YEAR, MONTH, 8),
+    3: datetime.date(YEAR, MONTH, 9),
+    4: datetime.date(YEAR, MONTH, 10),
+    5: datetime.date(YEAR, MONTH, 11),
+}
+WEEK_DELTA = datetime.timedelta(7)
+
+WEEKLY_SQL = (
+    'SELECT w.id, w.next_cycle_start_date, w.status, w.recurrences, '
+           't.id, t.relative_start_day, t.relative_end_day, '  # noqa: E131
+           'MAX(COALESCE(ct.start_date, CURDATE())) '
+    'FROM workflows AS w '
+    'JOIN task_groups AS tg ON tg.workflow_id = w.id '
+    'JOIN task_group_tasks AS t ON t.task_group_id = tg.id '
+    'LEFT JOIN cycle_task_group_object_tasks AS ct '
+           'ON ct.task_group_task_id = t.id '
+    'WHERE w.frequency = "weekly" GROUP BY 1, 5;'
+)
+
+NOTIFICATION_OFFSET = {
+    "week_workflow_starts_in": 1,
+    "cycle_task_failed": -1,
+}
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  # pylint: disable=too-many-locals
+  week_tasks = op.get_bind().execute(WEEKLY_SQL)
+  ctg_wf = collections.defaultdict(set)
+  group_days = collections.defaultdict(set)
+
+  notification_to_update = collections.defaultdict(set)
+  tg_dates_dict = {}
+  tg_wf = collections.defaultdict(set)
+  today = datetime.date.today()
+  wf_next_cycle_start_dates = {}
+  wf_statuses = {}
+  for (wf,
+       wf_next_cycle_start_date,
+       wf_status,
+       w_recur,
+       tgt,
+       start_day,
+       end_day,
+       last_task_start_date) in week_tasks:
+    if not (start_day and end_day):
+      continue
+    ctg_wf[wf].add(last_task_start_date)
+    tg_dates_dict[tgt] = (start_day, end_day)
+    tg_wf[wf].add(tgt)
+    wf_next_cycle_start_dates[wf] = wf_next_cycle_start_date
+    wf_statuses[wf] = (wf_status, w_recur)
+
+  for wf, task_ids in tg_wf.iteritems():
+    start_dates = []
+    for task_id in task_ids:
+      start_day, end_day = tg_dates_dict[task_id]
+      start_date = DAYS[start_day]
+      start_dates.append(start_date)
+      end_date = DAYS[end_day]
+      if end_date < start_date:
+        end_date += WEEK_DELTA
+      group_days[(start_date, end_date)].add(task_id)
+    repeat_multiplier, next_cycle_start_date = \
+        wf_date_updater.get_next_cycle_start_date(
+            min(start_dates),
+            max([min(ctg_wf[wf]), today]),
+            days=7
+        )
+    if wf_statuses[wf] == ("Active", 1):
+      wf_date_updater.update_wf(op,
+                                repeat_multiplier,
+                                next_cycle_start_date,
+                                wf)
+    if wf_statuses[wf] == ("Active", 1) and (
+            next_cycle_start_date != wf_next_cycle_start_dates[wf]):
+      print ("Next cycle start date changed for "
+             "active workflow {} from {} to {}".format(
+                 wf, wf_next_cycle_start_dates[wf], next_cycle_start_date))
+      for notification_type, offset in NOTIFICATION_OFFSET.iteritems():
+        key = (notification_type,
+               next_cycle_start_date - datetime.timedelta(offset))
+        notification_to_update[key].add(wf)
+  wf_date_updater.update_notifications(op, notification_to_update)
+  wf_date_updater.update_task_dates(op, group_days)
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  pass


### PR DESCRIPTION
*ISSUE 1*
After migration tasks dates inside one cycle were mixed-up.

I. Workflow Setup (before migration):
TASK1: 4-5
TASK2: 7-11

II. Migration was launched, for example, on 6 September 2017.

III. Workflow Setup (after migration):
*Expected result:*
TASK1: 4 Sep, 2017 - 5 Sep, 2017
TASK2: 7 Sep,2017 - 11 Sep, 2017

*Actual Result:*
*TASK1: 4 Oct, 2017 - 5 Oct, 2017*
TASK2: 7 Sep,2017 - 11 Sep, 2017

*ISSUE 2*
After migration, manually started cycles were not taken into consideration:

I. Workflow Setup (before migration):
TASK1: 4-5
TASK2: 7-11

II User manually starts a cycle (before migration).

III. Migration was launched, for example, on 6 September 2017.

IV. Workflow Setup (after migration):
*Expected result:*
TASK1: 4 Oct, 2017 - 5 Oct, 2017
TASK2: 7 Oct,2017 - 11 Oct, 2017

*Actual Result:*
*TASK1: 4 Oct, 2017 - 5 Oct, 2017*
*TASK2: 7 Sep,2017 - 11 Sep, 2017*