### PR TITLE
GGRC-3478 Monthly Workflow: Consider 28, 29 of Feb and 30 of Apr, June, Sep, Nov as a last days of the month during tasks generations

### DIFF
--- a/test/integration/ggrc_workflows/test_basic_workflow_actions.py
+++ b/test/integration/ggrc_workflows/test_basic_workflow_actions.py
@@ -130,7 +130,9 @@ class TestWorkflowsCycleGeneration(TestCase):
   # pylint: disable=too-many-arguments
   @ddt.data(
       # (expected, setup_date, freeze_date, repeat_every, unit),
-      (dtm.date(2017, 3, 28), dtm.date(2017, 2, 28), dtm.date(2017, 4, 28), 1,
+      (dtm.date(2017, 3, 31), dtm.date(2017, 2, 28), dtm.date(2017, 4, 1), 1,
+       Workflow.MONTH_UNIT),
+      (dtm.date(2016, 3, 28), dtm.date(2016, 2, 28), dtm.date(2016, 4, 1), 1,
        Workflow.MONTH_UNIT),
       (dtm.date(2017, 2, 28), dtm.date(2017, 1, 31), dtm.date(2017, 3, 31), 1,
        Workflow.MONTH_UNIT),

--- a/test/unit/ggrc_workflows/models/test_workflow.py
+++ b/test/unit/ggrc_workflows/models/test_workflow.py
@@ -61,7 +61,7 @@ class TestWorkflowState(unittest.TestCase):
 
   @ddt.data(
       # (expected, setup_date, repeat_every, unit),
-      (date(2017, 3, 28), date(2017, 2, 28), 1, workflow.Workflow.MONTH_UNIT),
+      (date(2017, 3, 31), date(2017, 2, 28), 1, workflow.Workflow.MONTH_UNIT),
       (date(2017, 2, 28), date(2017, 1, 31), 1, workflow.Workflow.MONTH_UNIT),
       (date(2017, 4, 28), date(2017, 1, 31), 3, workflow.Workflow.MONTH_UNIT),
       (date(2017, 2, 28), date(2016, 2, 29), 12, workflow.Workflow.MONTH_UNIT),


### PR DESCRIPTION
I. WORKFLOW SETUP:
Task: 29 Feb 2016 - 30 Apr 2016.
II. Workflow with 1 month repeat was activated, for example, on 28 Feb 2016.
III. GENERATED TASKS:
Cycle1: 29 Feb 2016 - 30 Apr 2016.
Actual result: Cycle2: 29 March 2016 - 30 May 2016.
Expected result: Cycle2: 31 March 2016 - 31 May 2016.
!!EXCEPTIONAL CASE:
During leap year only 29 Feb is considered as a last day of month. For example, task 28 Feb 2016 will be generated on 28 March 2016 in next cycle (in repeat every 1 month WF).
During non-leap year 28 Feb is considered as a last day of month. For example, task 28 Feb 2017 will be generated on 31 March 2017 in next cycle (in repeat every 1 month WF).