### PR TITLE
GGRC-2043 Unmap on 2d level: tree view is not refreshed

### DIFF
--- a/src/ggrc/assets/javascripts/components/tree/sub-tree-item.js
+++ b/src/ggrc/assets/javascripts/components/tree/sub-tree-item.js
@@ -59,7 +59,7 @@ import template from './templates/sub-tree-item.mustache';
       }
     },
     itemSelector: '.sub-item-content',
-    extraCss: '@'
+    extraCss: '@',
   });
 
   GGRC.Components('subTreeItem', {
@@ -71,6 +71,7 @@ import template from './templates/sub-tree-item.mustache';
         var viewModel = this.viewModel;
         var instance = viewModel.attr('instance');
         var resultDfd;
+        viewModel.attr('$el', this.element);
 
         if (instance instanceof CMS.Models.Person) {
           resultDfd = viewModel.makeResult(instance).then(function (result) {

--- a/src/ggrc/assets/javascripts/components/tree/templates/sub-tree-item.mustache
+++ b/src/ggrc/assets/javascripts/components/tree/templates/sub-tree-item.mustache
@@ -36,5 +36,6 @@
                     {child-models}="selectedChildModels"
                     {get-depth-filter}="@getDepthFilter"
                     {is-open}="expanded"
+                    (collapse-subtree)="collapseAndHighlightItem()"
   ></sub-tree-wrapper>
 </div>

--- a/src/ggrc/assets/javascripts/components/tree/templates/tree-item.mustache
+++ b/src/ggrc/assets/javascripts/components/tree/templates/tree-item.mustache
@@ -97,6 +97,7 @@
                         {child-models}="selectedChildModels"
                         {get-depth-filter}="@getDepthFilter"
                         {is-open}="expanded"
+                        (collapse-subtree)="collapseAndHighlightItem()"
       ></sub-tree-wrapper>
     </div>
   </lazy-render>

--- a/src/ggrc/assets/javascripts/components/tree/tests/sub-tree-wrapper_spec.js
+++ b/src/ggrc/assets/javascripts/components/tree/tests/sub-tree-wrapper_spec.js
@@ -63,9 +63,9 @@ describe('GGRC.Components.subTreeWrapper', function () {
       vm.attr('childModels', ['a', 'b', 'c']);
       spyOn(TreeViewUtils, 'loadItemsForSubTier').and
         .returnValue(can.Deferred().resolve({
-          directlyItems: [1, 2, 3],
-          notDirectlyItems: [4, 5, 6, 7],
-          showMore: false
+          directlyItems: [{id: 1}, {id: 2}, {id: 3}],
+          notDirectlyItems: [{id: 4}, {id: 5}, {id: 6}, {id: 7}],
+          showMore: false,
         }));
 
       method().then(function () {

--- a/src/ggrc/assets/javascripts/components/tree/tree-item.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-item.js
@@ -53,7 +53,7 @@ import template from './templates/tree-item.mustache';
     selectedColumns: [],
     mandatory: [],
     disableConfiguration: null,
-    itemSelector: '.tree-item-content'
+    itemSelector: '.tree-item-content',
   });
 
   /**
@@ -69,6 +69,7 @@ import template from './templates/tree-item.mustache';
         var instance = viewModel.attr('instance');
         var resultDfd;
 
+        viewModel.attr('$el', this.element.find('.tree-item-wrapper'));
         if (instance instanceof CMS.Models.Person) {
           resultDfd = viewModel.makeResult(instance).then(function (result) {
             viewModel.attr('result', result);

--- a/src/ggrc/assets/javascripts/components/tree/tree-widget-container.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-widget-container.js
@@ -40,6 +40,7 @@ import {
   isMyAssessments,
   getCounts,
   initCounts,
+  initMappedInstances,
 } from '../../plugins/utils/current-page-utils';
 import * as AdvancedSearch from '../../plugins/utils/advanced-search-utils';
 import Pagination from '../base-objects/pagination';
@@ -515,6 +516,9 @@ viewModel = can.Map.extend({
         if (!self.attr('$el').closest('.cms_controllers_info_pin').length) {
           $('.cms_controllers_info_pin').control().unsetInstance();
         }
+      } else {
+        // reinit mapped instances (subTree uses mapped instances)
+        initMappedInstances();
       }
     }
 

--- a/src/ggrc/assets/javascripts/components/unmap-button/unmap-button.js
+++ b/src/ggrc/assets/javascripts/components/unmap-button/unmap-button.js
@@ -3,6 +3,8 @@
  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  */
 
+import {DESTINATION_UNMAPPED} from '../../events/eventTypes';
+
 (function (can, GGRC, CMS) {
   'use strict';
 
@@ -17,16 +19,16 @@
       source: {},
       preventClick: false,
       unmapInstance: function () {
-        var self = this;
         this.dispatch({type: 'beforeUnmap', item: this.attr('source')});
         this.getMapping()
           .refresh()
-          .done(function (item) {
+          .done((item) => {
             item.destroy()
-              .then(function () {
-                self.dispatch('unmapped');
-                self.attr('destination').dispatch('refreshInstance');
-                self.dispatch('afterUnmap');
+              .then(() => {
+                this.dispatch('unmapped');
+                this.attr('destination').dispatch('refreshInstance');
+                this.attr('destination').dispatch(DESTINATION_UNMAPPED);
+                this.dispatch('afterUnmap');
               });
           });
       },

--- a/src/ggrc/assets/javascripts/components/view-models/tree-item-base-vm.js
+++ b/src/ggrc/assets/javascripts/components/view-models/tree-item-base-vm.js
@@ -28,6 +28,7 @@ export default can.Map.extend({
    * List of models for show in sub-level for current item.
    */
   selectedChildModels: [],
+  $el: null,
   initChildTreeDisplay: function () {
     var modelName = this.attr('instance').type;
     var models = TreeViewUtils.getModelsForSubTier(modelName);
@@ -80,6 +81,18 @@ export default can.Map.extend({
     }
 
     this.select($element);
+  },
+  collapseAndHighlightItem: function () {
+    const animationDuration = 2000;
+    let el = this.attr('$el');
+    this.attr('expanded', false);
+
+    el.addClass('tree-item-refresh-animation')
+      .delay(animationDuration)
+      .queue((next) => {
+        el.removeClass('tree-item-refresh-animation');
+        next();
+      });
   },
   select: function ($element) {
     var instance = this.attr('instance');

--- a/src/ggrc/assets/javascripts/events/eventTypes.js
+++ b/src/ggrc/assets/javascripts/events/eventTypes.js
@@ -63,6 +63,16 @@ const VALIDATION_ERROR = {
   type: 'validationError',
 };
 
+/**
+ *
+ * @event destinationUnmapped
+ * @type {object}
+ * @property {string} type - Event name.
+ */
+const DESTINATION_UNMAPPED = {
+  type: 'destinationUnmapped',
+};
+
 export {
   REFRESH_RELATED,
   SAVE_CUSTOM_ROLE,
@@ -70,4 +80,5 @@ export {
   SWITCH_TO_ERROR_PANEL,
   SHOW_INVALID_FIELD,
   VALIDATION_ERROR,
+  DESTINATION_UNMAPPED,
 };

--- a/src/ggrc/assets/stylesheets/_colors.scss
+++ b/src/ggrc/assets/stylesheets/_colors.scss
@@ -120,6 +120,7 @@ $btnPriority: #4B898B;
 $redBtn:#F44336;
 $lightBlueBtn: #03A9F4;
 $createBtn: #1976D2;
+$treeItemRefreshed: #AEAEAE;
 $unmapIcon: #797979;
 
 // compliance

--- a/src/ggrc/assets/stylesheets/components/tree/_sub-tree-wrapper.scss
+++ b/src/ggrc/assets/stylesheets/components/tree/_sub-tree-wrapper.scss
@@ -2,6 +2,9 @@
  * Copyright (C) 2017 Google Inc.
  * Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  */
+
+@import "./tree-view-animations";
+
 sub-tree-wrapper {
   display: flex;
   flex-direction: column;

--- a/src/ggrc/assets/stylesheets/components/tree/_tree-view-animations.scss
+++ b/src/ggrc/assets/stylesheets/components/tree/_tree-view-animations.scss
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ * Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+@keyframes itemRefreshed {
+  0% {
+    background-color: $white;
+  }
+  50% {
+    background-color: $treeItemRefreshed;
+  }
+  100% {
+    background-color: $white;
+  }
+}
+
+.tree-item-refresh-animation {
+  animation: itemRefreshed 2s 1;
+}

--- a/src/ggrc/assets/stylesheets/components/tree/_tree-view.scss
+++ b/src/ggrc/assets/stylesheets/components/tree/_tree-view.scss
@@ -3,6 +3,8 @@
  * Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  */
 
+@import "./tree-view-animations";
+
 $itemActionsWidth: 200px;
 $treeHeaderSelectorWidth: 56px;
 


### PR DESCRIPTION
Tree view is not refreshed if Unmap object on the second level.

**Current solution:** Collapse and highlight open subtrees which contain unmapped item.