### PR TITLE
GGRC-3188 Set default 'Object Type' on Unified Mapper

### DIFF
--- a/src/ggrc/assets/javascripts/components/object-mapper/object-mapper.js
+++ b/src/ggrc/assets/javascripts/components/object-mapper/object-mapper.js
@@ -28,7 +28,7 @@
     Program: 'Standard',
     Project: 'Program',
     Risk: 'Control',
-    TaskGroupTask: 'Control',
+    CycleTaskGroupObjectTask: 'Control',
     Threat: 'Risk',
     Vendor: 'Program',
     Audit: 'Product',


### PR DESCRIPTION
*ACCPTANCE CRITERIA*
AC1. Set default values for 'Object Type' dropdown on Unified Mapper, depending for which object it is opened:
https://docs.google.com/spreadsheets/d/11CHxbJZHPwD8rc9-4xCDnHbhQ4SE2SKDJcGxckuk2MQ/edit#gid=0
AC2. Set default value for 'Object Type' dropdown = 'Controls' on Global Search pop-up.

the ticket was reopened due to changes in requirements - 'Cycle task' - preselected object in Unified mapper is a control.