### PR TITLE
QUICK-FIX Redesign test-suite and extend tests related to objects mapping according to new standalone Issue object

### DIFF
--- a/test/selenium/src/lib/base.py
+++ b/test/selenium/src/lib/base.py
@@ -586,7 +586,7 @@ class TreeView(Component):
   # pylint: disable=too-many-instance-attributes
   _locators = constants.locator.TreeView
 
-  def __init__(self, driver, obj_name=None):
+  def __init__(self, driver, obj_name=None, is_versions_widget=False):
     super(TreeView, self).__init__(driver)
     self._tree_view_headers = []
     self._tree_view_items = []
@@ -594,7 +594,8 @@ class TreeView(Component):
     self.locator_no_results_message = self._locators.NO_RESULTS_MESSAGE
     self.obj_name = obj_name
     if self.obj_name is not None:
-      self.widget_name = url.get_widget_name_of_mapped_objs(obj_name)
+      self.widget_name = url.get_widget_name_of_mapped_objs(
+          obj_name, is_versions_widget)
       from lib import factory
       self.fields_to_set = factory.get_fields_to_set(object_name=self.obj_name)
 
@@ -676,7 +677,7 @@ class UnifiedMapperTreeView(TreeView):
   _locators = constants.locator.UnifiedMapperTreeView
 
   def __init__(self, driver, obj_name):
-    super(UnifiedMapperTreeView, self).__init__(driver, obj_name=obj_name)
+    super(UnifiedMapperTreeView, self).__init__(driver, obj_name)
     self.locator_set_visible_fields = (By.CSS_SELECTOR,
                                        self._locators.BUTTON_SHOW_FIELDS)
     self.locator_no_results_message = (By.CSS_SELECTOR,

--- a/test/selenium/src/lib/constants/locator.py
+++ b/test/selenium/src/lib/constants/locator.py
@@ -20,6 +20,7 @@ class Common(object):
   MODAL_MAP = ".modal-selector"
   MODAL_FOOTER = " .modal-footer"
   MODAL_FILTER = " .modal-filter"
+  MODAL_HEADER = " .modal-header"
   # info page (panel)
   _INFO = "info"
   INFO = "." + _INFO
@@ -266,6 +267,8 @@ class CommonModalUnifiedMapper(object):
                          " .btn-map")
   RESULT_TOGGLE_CSS = (By.CSS_SELECTOR, MODAL + Common.MODAL_FOOTER +
                        " collapse-panel-click-area")
+  CLOSE_BTN_CSS = (By.CSS_SELECTOR,
+                   MODAL + Common.MODAL_HEADER + " a.modal-dismiss")
 
 
 class ModalMapObjects(CommonModalUnifiedMapper):
@@ -992,98 +995,35 @@ class UnifiedMapperTreeView(TreeView):
 
 class BaseWidgetGeneric(object):
   """Locators for non Info and Admin widgets."""
-  _object_name = None
-  widget_info = Common.INFO_WIDGET_ID
+  # pylint: disable=invalid-name
+  # pylint: disable=no-self-argument
 
-  class __metaclass__(type):
-    """For sharing parametrized class attributes we simply define how
-    class should look like. Note that same functionality can be
-    implemented using properties though with more code."""
-    def __init__(cls, *args):
-      # pylint: disable=invalid-name
-      _WIDJET = "#{}_widget"
-      _FILTER_BUTTON = _WIDJET + " tree-filter-input .tree-filter__actions"
-      _FILTER_DROPDOWN = _WIDJET + " tree-status-filter"
-      _FILTER_DROPDOWN_ELEMENTS = (
-          _FILTER_DROPDOWN + " .multiselect-dropdown__element")
-      cls.TEXTFIELD_TO_FILTER = (
-          By.CSS_SELECTOR, str(_WIDJET + " .tree-filter__input")
-            .format(cls._object_name))
-      cls.BUTTON_FILTER = (
-          By.CSS_SELECTOR,
-          str(_FILTER_BUTTON + ' [type="submit"]').format(cls._object_name))
-      cls.BUTTON_HELP = (
-          By.CSS_SELECTOR,
-          str(_FILTER_BUTTON + " #page-help").format(cls._object_name))
-      cls.DROPDOWN = (
-          By.CSS_SELECTOR,
-          str(_FILTER_DROPDOWN + " .multiselect-dropdown__input-container")
-            .format(cls._object_name))
-      cls.DROPDOWN_STATES = (
-          By.CSS_SELECTOR,
-          str(_FILTER_DROPDOWN_ELEMENTS).format(cls._object_name))
   PAGINATION_CONTROLLERS = (
-      By.CSS_SELECTOR, "section.widget:not(.hidden) .tree-pagination.flex-box")
+      By.CSS_SELECTOR,
+      "section.widget:not(.hidden) .tree-pagination.flex-box")
 
-
-class WidgetAudits(BaseWidgetGeneric):
-  """Locators for Audits generic widgets."""
-  _object_name = objects.get_singular(objects.AUDITS)
-
-
-class WidgetAssessments(BaseWidgetGeneric):
-  """Locators for Assessments generic widgets."""
-  _object_name = objects.get_singular(objects.ASSESSMENTS)
-
-
-class WidgetControls(BaseWidgetGeneric):
-  """Locators for Controls generic widgets."""
-  _object_name = objects.get_singular(objects.CONTROLS)
-
-
-class WidgetObjectives(BaseWidgetGeneric):
-  """Locators for Controls generic widgets."""
-  _object_name = objects.get_singular(objects.OBJECTIVES)
-
-
-class WidgetProducts(BaseWidgetGeneric):
-  """Locators for Products generic widgets."""
-  _object_name = objects.get_singular(objects.PRODUCTS)
-
-
-class WidgetProjects(BaseWidgetGeneric):
-  """Locators for Projects generic widgets."""
-  _object_name = objects.get_singular(objects.PROJECTS)
-
-
-class WidgetSystems(BaseWidgetGeneric):
-  """Locators for Systems generic widgets."""
-  _object_name = objects.get_singular(objects.SYSTEMS)
-
-
-class WidgetDataAssets(BaseWidgetGeneric):
-  """Locators for DataAssets generic widgets."""
-  _object_name = objects.get_singular(objects.PROJECTS)
-
-
-class WidgetProcesses(BaseWidgetGeneric):
-  """Locators for Processes generic widgets."""
-  _object_name = objects.get_singular(objects.PROCESSES)
-
-
-class WidgetIssues(BaseWidgetGeneric):
-  """Locators for Issues generic widgets"""
-  _object_name = objects.get_singular(objects.ISSUES)
-
-
-class WidgetPrograms(BaseWidgetGeneric):
-  """Locators for Programs generic widgets"""
-  _object_name = objects.get_singular(objects.PROGRAMS)
-
-
-class WidgetAssessmentTemplates(BaseWidgetGeneric):
-  """Locators for Assessment Templates generic widgets."""
-  _object_name = objects.get_singular(objects.ASSESSMENT_TEMPLATES)
+  def __init__(cls, obj_name, is_versions_widget=False):
+    from lib.constants import url
+    widget_name = url.get_widget_name_of_mapped_objs(
+        obj_name, is_versions_widget)
+    _filter_button = widget_name + " tree-filter-input .tree-filter__actions"
+    _filter_dropdown = widget_name + " tree-status-filter"
+    _filter_dropdown_elements = (
+        _filter_dropdown + " .multiselect-dropdown__element")
+    cls.TEXTFIELD_TO_FILTER = (
+        By.CSS_SELECTOR,
+        (widget_name + " .tree-filter__input").format(obj_name))
+    cls.BUTTON_FILTER = (
+        By.CSS_SELECTOR,
+        (_filter_button + ' [type="submit"]').format(obj_name))
+    cls.BUTTON_HELP = (
+        By.CSS_SELECTOR, (_filter_button + " #page-help").format(obj_name))
+    cls.DROPDOWN = (
+        By.CSS_SELECTOR,
+        (_filter_dropdown +
+         " .multiselect-dropdown__input-container").format(obj_name))
+    cls.DROPDOWN_STATES = (
+        By.CSS_SELECTOR, (_filter_dropdown_elements).format(obj_name))
 
 
 class AdminCustomAttributes(object):

--- a/test/selenium/src/lib/constants/locator.py
+++ b/test/selenium/src/lib/constants/locator.py
@@ -14,10 +14,9 @@ class Common(object):
   TITLE = " .title"
   DESCRIPTION = " .description"
   # modal
-  MODAL_GENEATE = ".modal-selector"
   MODAL_CREATE = ".modal-wide"
   MODAL_CONFIRM = ".modal.hide"
-  MODAL_MAP = ".modal-selector"
+  MODAL_MAPPER = ".modal-selector"
   MODAL_FOOTER = " .modal-footer"
   MODAL_FILTER = " .modal-filter"
   MODAL_HEADER = " .modal-header"
@@ -61,6 +60,8 @@ class Common(object):
   OBJECT_AREA_CSS = (By.CSS_SELECTOR, ".object-area")
   # alerts
   ALERT_SUCCESS_CSS = (By.CSS_SELECTOR, ".content>.flash>.alert-success")
+  # widgets
+  WIDGET_NOT_HIDDEN = "section.widget:not(.hidden) "
 
 
 class CommonAssessment(object):
@@ -244,7 +245,8 @@ class ExtendedInfo(object):
 class CommonModalUnifiedMapper(object):
   """Common locators for unified mapper modals."""
   # pylint: disable=invalid-name
-  MODAL = Common.MODAL_MAP
+  MODAL = Common.MODAL_MAPPER
+  MODAL_CSS = (By.CSS_SELECTOR, MODAL)
   MODAL_FILTER = Common.MODAL_FILTER
   FILTER_TOGGLE_CSS = (By.CSS_SELECTOR,
                        MODAL_FILTER + " collapse-panel-click-area")
@@ -273,19 +275,19 @@ class CommonModalUnifiedMapper(object):
 
 class ModalMapObjects(CommonModalUnifiedMapper):
   """Locators for map objects modals."""
-  MODAL = Common.MODAL_MAP
+  MODAL = Common.MODAL_MAPPER
   # user input elements
   BUTTON_CREATE_OBJ = (By.CSS_SELECTOR, MODAL + " .create-control")
 
 
 class ModalSearchObjects(CommonModalUnifiedMapper):
   """Locators for search objects modals."""
-  MODAL = Common.MODAL_MAP
+  MODAL = Common.MODAL_MAPPER
 
 
 class ModalGenerateAssessments(CommonModalUnifiedMapper):
   """Locators for generate Assessments modal."""
-  MODAL = Common.MODAL_GENEATE
+  MODAL = Common.MODAL_MAPPER
 
 
 class BaseModalCreateNew(object):
@@ -996,34 +998,21 @@ class UnifiedMapperTreeView(TreeView):
 class BaseWidgetGeneric(object):
   """Locators for non Info and Admin widgets."""
   # pylint: disable=invalid-name
-  # pylint: disable=no-self-argument
-
-  PAGINATION_CONTROLLERS = (
+  _FILTER_BUTTON = (
+      Common.WIDGET_NOT_HIDDEN + "tree-filter-input .tree-filter__actions")
+  _FILTER_DROPDOWN = Common.WIDGET_NOT_HIDDEN + "tree-status-filter"
+  _FILTER_DROPDOWN_ELEMENTS = (
+      _FILTER_DROPDOWN + " .multiselect-dropdown__element")
+  TEXTFIELD_TO_FILTER = (
+      By.CSS_SELECTOR, Common.WIDGET_NOT_HIDDEN + ".tree-filter__input")
+  BUTTON_FILTER = (By.CSS_SELECTOR, _FILTER_BUTTON + ' [type="submit"]')
+  BUTTON_HELP = (By.CSS_SELECTOR, _FILTER_BUTTON + " #page-help")
+  DROPDOWN = (
       By.CSS_SELECTOR,
-      "section.widget:not(.hidden) .tree-pagination.flex-box")
-
-  def __init__(cls, obj_name, is_versions_widget=False):
-    from lib.constants import url
-    widget_name = url.get_widget_name_of_mapped_objs(
-        obj_name, is_versions_widget)
-    _filter_button = widget_name + " tree-filter-input .tree-filter__actions"
-    _filter_dropdown = widget_name + " tree-status-filter"
-    _filter_dropdown_elements = (
-        _filter_dropdown + " .multiselect-dropdown__element")
-    cls.TEXTFIELD_TO_FILTER = (
-        By.CSS_SELECTOR,
-        (widget_name + " .tree-filter__input").format(obj_name))
-    cls.BUTTON_FILTER = (
-        By.CSS_SELECTOR,
-        (_filter_button + ' [type="submit"]').format(obj_name))
-    cls.BUTTON_HELP = (
-        By.CSS_SELECTOR, (_filter_button + " #page-help").format(obj_name))
-    cls.DROPDOWN = (
-        By.CSS_SELECTOR,
-        (_filter_dropdown +
-         " .multiselect-dropdown__input-container").format(obj_name))
-    cls.DROPDOWN_STATES = (
-        By.CSS_SELECTOR, (_filter_dropdown_elements).format(obj_name))
+      _FILTER_DROPDOWN + " .multiselect-dropdown__input-container")
+  DROPDOWN_STATES = (By.CSS_SELECTOR, _FILTER_DROPDOWN_ELEMENTS)
+  PAGINATION_CONTROLLERS = (
+      By.CSS_SELECTOR, Common.WIDGET_NOT_HIDDEN + ".tree-pagination.flex-box")
 
 
 class AdminCustomAttributes(object):

--- a/test/selenium/src/lib/constants/roles.py
+++ b/test/selenium/src/lib/constants/roles.py
@@ -41,6 +41,9 @@ WORKFLOW = "Workflow"
 SUPERUSER = "Superuser"
 NO_ACCESS = "No Access"
 
+# todo: implement service to get actual ACL's info via api/access_control_roles
 # Access control role ID
-ADMIN_ID = 49
-PRIMARY_CONTACT_ID = 9
+CONTROL_ADMIN_ID = 49
+CONTROL_PRIMARY_CONTACT_ID = 9
+ISSUE_ADMIN_ID = 53
+ISSUE_PRIMARY_CONTACT_ID = 17

--- a/test/selenium/src/lib/constants/url.py
+++ b/test/selenium/src/lib/constants/url.py
@@ -42,8 +42,11 @@ class Widget(object):
   PROGRAMS = "#program_widget"
 
 
-def get_widget_name_of_mapped_objs(obj_name):
+def get_widget_name_of_mapped_objs(obj_name, is_versions_widget=False):
   """Get and return widget name for mapped objects (URL's parts for widgets)
-  based on object name.
+  based on object name. If 'is_versions_widget' then destinations objects's
+  widget will be snapshots' versions.
   """
-  return "#" + get_singular(obj_name) + "_widget"
+  middle_part = (get_singular(obj_name) if not is_versions_widget else
+                 get_singular(obj_name, title=True) + "_versions")
+  return "#" + middle_part + "_widget"

--- a/test/selenium/src/lib/dynamic_fixtures.py
+++ b/test/selenium/src/lib/dynamic_fixtures.py
@@ -82,8 +82,7 @@ def _new_objs_rest(obj_name, obj_count,  # noqa: ignore=C901
   if obj_name == objects.AUDITS:
     parent_obj_name = (objects.get_singular(objects.PROGRAMS) if obj_count == 1
                        else objects.PROGRAMS)
-  if obj_name in (objects.ASSESSMENT_TEMPLATES, objects.ASSESSMENTS,
-                  objects.ISSUES):
+  if obj_name in (objects.ASSESSMENT_TEMPLATES, objects.ASSESSMENTS):
     parent_obj_name = objects.get_singular(objects.AUDITS)
   if (has_cas and obj_name in objects.ALL_OBJS and
           obj_name not in objects.ASSESSMENT_TEMPLATES):

--- a/test/selenium/src/lib/element/tree_view.py
+++ b/test/selenium/src/lib/element/tree_view.py
@@ -17,8 +17,9 @@ class CommonDropdownSettings(elements_list.DropdownMenu):
   """Common for 3BBS button/dropdown settings on Tree View."""
   _locators = locator.CommonDropdown3bbsTreeView
 
-  def __init__(self, driver, obj_name):
-    self.widget_name = url.get_widget_name_of_mapped_objs(obj_name)
+  def __init__(self, driver, obj_name, is_versions_widget=False):
+    self.widget_name = url.get_widget_name_of_mapped_objs(
+        obj_name, is_versions_widget)
     self.obj_name = obj_name
     # elements
     _dropdown_element = (

--- a/test/selenium/src/lib/entities/entities_factory.py
+++ b/test/selenium/src/lib/entities/entities_factory.py
@@ -376,10 +376,10 @@ class ControlsFactory(EntitiesFactory):
     random_control.contact = cls.default_person.__dict__
     random_control.owners = [cls.default_person.__dict__]
     random_control.access_control_list = [
-        ObjectPersonsFactory().get_acl_member(roles.ADMIN_ID,
-                                              random_control.owners[0]),
-        ObjectPersonsFactory().get_acl_member(roles.PRIMARY_CONTACT_ID,
-                                              random_control.contact)]
+        ObjectPersonsFactory().get_acl_member(
+            roles.CONTROL_ADMIN_ID, random_control.owners[0]),
+        ObjectPersonsFactory().get_acl_member(
+            roles.CONTROL_PRIMARY_CONTACT_ID, random_control.contact)]
     random_control.os_state = unicode(element.ReviewStates.UNREVIEWED)
     return random_control
 
@@ -660,7 +660,7 @@ class IssuesFactory(EntitiesFactory):
 
   @classmethod
   def create(cls, type=None, id=None, title=None, href=None, url=None,
-             slug=None, status=None, audit=None, owners=None, contact=None,
+             slug=None, status=None, owners=None, contact=None,
              secondary_contact=None, updated_at=None, os_state=None,
              custom_attribute_definitions=None, custom_attribute_values=None,
              custom_attributes=None, access_control_list=None, created_at=None,
@@ -673,7 +673,7 @@ class IssuesFactory(EntitiesFactory):
     issue_entity = cls._create_random_issue()
     issue_entity = Entity.update_objs_attrs_values_by_entered_data(
         obj_or_objs=issue_entity, is_allow_none_values=False, type=type, id=id,
-        title=title, href=href, url=url, slug=slug, status=status, audit=audit,
+        title=title, href=href, url=url, slug=slug, status=status,
         owners=owners, contact=contact, secondary_contact=secondary_contact,
         updated_at=updated_at, os_state=os_state,
         custom_attribute_definitions=custom_attribute_definitions,
@@ -694,9 +694,9 @@ class IssuesFactory(EntitiesFactory):
     random_issue.owners = [ObjectPersonsFactory().default().__dict__]
     random_issue.contact = ObjectPersonsFactory().default().__dict__
     random_issue.access_control_list = [
-        ObjectPersonsFactory().get_acl_member(roles.ADMIN_ID,
-                                              random_issue.owners[0]),
-        ObjectPersonsFactory().get_acl_member(roles.PRIMARY_CONTACT_ID,
-                                              random_issue.contact)]
+        ObjectPersonsFactory().get_acl_member(
+            roles.ISSUE_ADMIN_ID, random_issue.owners[0]),
+        ObjectPersonsFactory().get_acl_member(
+            roles.ISSUE_PRIMARY_CONTACT_ID, random_issue.contact)]
     random_issue.os_state = unicode(element.ReviewStates.UNREVIEWED)
     return random_issue

--- a/test/selenium/src/lib/entities/entity.py
+++ b/test/selenium/src/lib/entities/entity.py
@@ -911,10 +911,10 @@ class IssueEntity(Entity):
       "type", "title", "slug", "status", "contact", "os_state", "created_at",
       "updated_at", "modified_by"]
   attrs_names_to_repr = Representation.core_attrs_names_to_repr + [
-      "status", "audit", "contact", "secondary_contact", "updated_at",
+      "status", "contact", "secondary_contact", "updated_at",
       "custom_attributes", "access_control_list", "os_state", "modified_by"]
 
-  def __init__(self, status=None, audit=None, owners=None,
+  def __init__(self, status=None, owners=None,
                contact=None, secondary_contact=None, updated_at=None,
                custom_attribute_definitions=None, os_state=None,
                custom_attribute_values=None, custom_attributes=None,
@@ -932,6 +932,5 @@ class IssueEntity(Entity):
     self.custom_attribute_definitions = custom_attribute_definitions
     self.custom_attribute_values = custom_attribute_values
     # additional
-    self.audit = audit  # audit title
     self.custom_attributes = custom_attributes  # map of cas def and values
     self.access_control_list = access_control_list

--- a/test/selenium/src/lib/factory.py
+++ b/test/selenium/src/lib/factory.py
@@ -1,8 +1,9 @@
 # Copyright (C) 2017 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 "Factory for modules, classes, methods, functions."
+
 from lib import base, cache, constants, exception
-from lib.constants import objects, element, locator
+from lib.constants import objects, element
 from lib.element import tree_view, widget_info, tree_view_item
 
 
@@ -97,13 +98,6 @@ def get_cls_widget(object_name, is_info=False, is_admin=False):
   else:
     base_cls = generic_widget.Widget
   return _factory(cls_name=object_name, parent_cls=base_cls)
-
-
-def get_cls_locators_generic_widget(object_name):
-  """Get and return class of locators for object generic widget."""
-  cls_name = constants.cls_name.WIDGET + object_name
-  base_cls = locator.BaseWidgetGeneric
-  return _factory(cls_name=cls_name, parent_cls=base_cls)
 
 
 def get_cls_entity_factory(object_name):

--- a/test/selenium/src/lib/page/modal/unified_mapper.py
+++ b/test/selenium/src/lib/page/modal/unified_mapper.py
@@ -155,6 +155,8 @@ class CommonUnifiedMapperModal(base.Modal):
   def close_modal(self):
     """Close Unified Mapper's modal window."""
     self.close_btn.click()
+    selenium_utils.wait_until_not_present(
+        self._driver, self._locators.MODAL_CSS)
 
 
 class MapObjectsModal(CommonUnifiedMapperModal):

--- a/test/selenium/src/lib/page/modal/unified_mapper.py
+++ b/test/selenium/src/lib/page/modal/unified_mapper.py
@@ -15,15 +15,18 @@ class CommonUnifiedMapperModal(base.Modal):
   def __init__(self, driver, obj_name):
     super(CommonUnifiedMapperModal, self).__init__(driver)
     # labels
-    self.filter_toggle = base.Toggle(driver, self._locators.FILTER_TOGGLE_CSS)
+    self.filter_toggle = base.Toggle(
+        self._driver, self._locators.FILTER_TOGGLE_CSS)
     self.filter_toggle.is_activated = True
-    self.title_modal = base.Label(driver, self._locators.MODAL_TITLE)
-    self.obj_type = base.Label(driver, self._locators.OBJ_TYPE)
+    self.title_modal = base.Label(self._driver, self._locators.MODAL_TITLE)
+    self.obj_type = base.Label(self._driver, self._locators.OBJ_TYPE)
     # user input elements
-    self.tree_view = base.UnifiedMapperTreeView(driver, obj_name=obj_name)
+    self.tree_view = base.UnifiedMapperTreeView(
+        self._driver, obj_name=obj_name)
     self._add_attr_btn = None
     self.search_result_toggle = base.Toggle(
-        driver, self._locators.RESULT_TOGGLE_CSS)
+        self._driver, self._locators.RESULT_TOGGLE_CSS)
+    self.close_btn = base.Button(self._driver, self._locators.CLOSE_BTN_CSS)
 
   def get_available_to_map_obj_aliases(self):
     """Return texts of all objects available to map via UnifiedMapper."""
@@ -148,6 +151,10 @@ class CommonUnifiedMapperModal(base.Modal):
                           is_asmts_generation=is_asmts_generation)
     self._select_dest_objs_to_map(objs_titles=dest_objs_titles)
     self._confirm_map_selected()
+
+  def close_modal(self):
+    """Close Unified Mapper's modal window."""
+    self.close_btn.click()
 
 
 class MapObjectsModal(CommonUnifiedMapperModal):

--- a/test/selenium/src/lib/page/widget/generic_widget.py
+++ b/test/selenium/src/lib/page/widget/generic_widget.py
@@ -18,7 +18,7 @@ class Widget(base.Widget):
   destinations objects's widget will be snapshots' versions.
   """
   # pylint: disable=too-many-instance-attributes
-  def __init__(self, driver, obj_name, is_versions_widget):
+  def __init__(self, driver, obj_name, is_versions_widget=False):
     self.obj_name = obj_name
     self.is_versions_widget = is_versions_widget
     self._locators_filter = locator.BaseWidgetGeneric(

--- a/test/selenium/src/lib/page/widget/generic_widget.py
+++ b/test/selenium/src/lib/page/widget/generic_widget.py
@@ -21,8 +21,7 @@ class Widget(base.Widget):
   def __init__(self, driver, obj_name, is_versions_widget=False):
     self.obj_name = obj_name
     self.is_versions_widget = is_versions_widget
-    self._locators_filter = locator.BaseWidgetGeneric(
-        self.obj_name, self.is_versions_widget)
+    self._locators_filter = locator.BaseWidgetGeneric
     self._locators_widget = factory.get_locator_widget(self.obj_name.upper())
     self.info_widget_cls = factory.get_cls_widget(
         object_name=obj_name, is_info=True)

--- a/test/selenium/src/lib/page/widget/info_widget.py
+++ b/test/selenium/src/lib/page/widget/info_widget.py
@@ -25,11 +25,11 @@ class InfoWidget(base.Widget):
   locator_headers_and_values = None
 
   def __init__(self, driver):
+    super(InfoWidget, self).__init__(driver)
     self.child_cls_name = self.__class__.__name__.lower()
     # empty lists of headers and values
     self.list_all_headers_txt = []
     self.list_all_values_txt = []
-    super(InfoWidget, self).__init__(driver)
     # check type and content of Info Widget
     if not self.is_info_page_not_panel:
       self.is_snapshotable_panel = (

--- a/test/selenium/src/lib/service/rest/template/issue.json
+++ b/test/selenium/src/lib/service/rest/template/issue.json
@@ -4,8 +4,6 @@
   "slug": null,
   "status": null,
   "owners": [],
-  "audit": null,
-  "audit_title": null,
   "contact": null,
   "description": "",
   "test_plan": "",

--- a/test/selenium/src/lib/service/rest_service.py
+++ b/test/selenium/src/lib/service/rest_service.py
@@ -129,7 +129,7 @@ class BaseRestService(object):
       # for Audit objects
       if kwargs.get("program"):
         obj.program = kwargs["program"]
-      # for Assessment, Assessment Template, Issues objects
+      # for Assessment, Assessment Template objects
       if kwargs.get("audit"):
         obj.audit = kwargs["audit"]
     return obj

--- a/test/selenium/src/lib/service/webui_service.py
+++ b/test/selenium/src/lib/service/webui_service.py
@@ -18,17 +18,18 @@ class BaseWebUiService(object):
   """Base class for business layer's services objects."""
   # pylint: disable=too-many-instance-attributes
   # pylint: disable=too-many-public-methods
-  def __init__(self, driver, obj_name):
+  def __init__(self, driver, obj_name, is_versions_widget=False):
     self.driver = driver
     self.obj_name = obj_name
+    self.is_versions_widget = is_versions_widget
     self.generic_widget_cls = factory.get_cls_widget(object_name=self.obj_name)
     self.info_widget_cls = factory.get_cls_widget(
         object_name=self.obj_name, is_info=True)
     self.entities_factory_cls = factory.get_cls_entity_factory(
         object_name=self.obj_name)
-    # URLs
     self.url_mapped_objs = (
-        "{src_obj_url}" + url.get_widget_name_of_mapped_objs(self.obj_name))
+        "{src_obj_url}" +
+        url.get_widget_name_of_mapped_objs(self.obj_name, is_versions_widget))
     self.url_obj_info_page = "{obj_url}" + url.Widget.INFO
     self._unified_mapper = None
 
@@ -95,7 +96,8 @@ class BaseWebUiService(object):
     """
     generic_widget_url = self.url_mapped_objs.format(src_obj_url=src_obj.url)
     selenium_utils.open_url(self.driver, generic_widget_url)
-    return self.generic_widget_cls(self.driver, self.obj_name)
+    return self.generic_widget_cls(
+        self.driver, self.obj_name, self.is_versions_widget)
 
   def open_info_page_of_obj(self, obj):
     """Navigate to info page URL of object according to URL of object and
@@ -128,6 +130,7 @@ class BaseWebUiService(object):
     self._set_list_objs_scopes_repr_on_mapper_tree_view(src_obj)
     list_objs_scopes, mapping_statuses = (
         self._search_objs_via_tree_view(src_obj, dest_objs))
+    self._get_unified_mapper(src_obj).close_modal()
     return self._create_list_objs(
         entity_factory=self.entities_factory_cls,
         list_scopes=list_objs_scopes), mapping_statuses
@@ -581,14 +584,16 @@ class AssessmentsService(BaseWebUiService):
 
 class ControlsService(SnapshotsWebUiService):
   """Class for Controls business layer's services objects."""
-  def __init__(self, driver):
-    super(ControlsService, self).__init__(driver, objects.CONTROLS)
+  def __init__(self, driver, is_versions_widget=False):
+    super(ControlsService, self).__init__(
+        driver, objects.CONTROLS, is_versions_widget)
 
 
 class ObjectivesService(SnapshotsWebUiService):
   """Class for Objectives business layer's services objects."""
-  def __init__(self, driver):
-    super(ObjectivesService, self).__init__(driver, objects.OBJECTIVES)
+  def __init__(self, driver, is_versions_widget=False):
+    super(ObjectivesService, self).__init__(
+        driver, objects.OBJECTIVES, is_versions_widget)
 
 
 class IssuesService(BaseWebUiService):

--- a/test/selenium/src/tests/conftest.py
+++ b/test/selenium/src/tests/conftest.py
@@ -29,6 +29,13 @@ def _common_fixtures(fixture):
           if not help_utils.is_multiple_objs(fixture) else fixture)
 
 
+def _snapshots_fixtures(fixturename):
+  """Generate snapshot fixtures used generation of common fixtures and return
+  dictionary of executed common fixtures in scope of snapshot fixtures.
+  """
+  return dynamic_fixtures.generate_snapshots_fixtures(fixturename)
+
+
 @pytest.mark.hookwrapper
 def pytest_runtest_makereport(item, call):
   """Replace common screenshot from html-report by full size screenshot."""
@@ -146,6 +153,14 @@ def new_program_rest(request):
 
 
 @pytest.fixture(scope="function")
+def new_programs_rest(request):
+  """Create new Controls objects via REST API.
+  Return: [lib.entities.entity.ProgramEntity, ...]
+  """
+  yield _common_fixtures(request.fixturename)
+
+
+@pytest.fixture(scope="function")
 def new_control_rest(request):
   """Create new Control object via REST API.
   Return: lib.entities.entity.ControlEntity
@@ -186,10 +201,26 @@ def new_audit_rest(request):
 
 
 @pytest.fixture(scope="function")
+def new_audits_rest(request):
+  """Create new Controls objects via REST API.
+  Return: [lib.entities.entity.AuditEntity, ...]
+  """
+  yield _common_fixtures(request.fixturename)
+
+
+@pytest.fixture(scope="function")
 def new_assessment_rest(request):
   """Create new Assessment under Audit object via REST API.
   Return: lib.entities.entity.AssessmentEntity
   """
+  yield _common_fixtures(request.fixturename)
+
+
+@pytest.fixture(scope="function")
+def new_assessments_rest(request):
+  """Create new Assessments objects via REST API.
+   Return: [lib.entities.entity.AssessmentEntity, ...]
+   """
   yield _common_fixtures(request.fixturename)
 
 
@@ -218,90 +249,25 @@ def new_assessment_template_with_cas_rest(request):
 
 
 @pytest.fixture(scope="function")
-def map_new_control_rest_to_new_objective_rest(request):
-  """Map Objective to Control object via REST API return response from server.
+def new_cas_for_assessments_rest(request):
+  """New global Custom Attributes for assessments created via REST API.
+  Teardown - remove created gCAs.
   """
-  yield _common_fixtures(request.fixturename)
+  cas = _common_fixtures(request.fixturename)
+  yield cas
+  from lib.service.rest_service import CustomAttributeDefinitionsService
+  CustomAttributeDefinitionsService().delete_objs(cas)
 
 
 @pytest.fixture(scope="function")
-def map_new_control_rest_to_new_objectives_rest(request):
-  """Map Objectives to Control object via REST API return response from server.
+def new_cas_for_controls_rest(request):
+  """Create new Global Custom Attributes for Controls via REST API and
+  delete GCAs as teardown section.
   """
-  yield _common_fixtures(request.fixturename)
-
-
-@pytest.fixture(scope="function")
-def map_new_program_rest_to_new_objective_rest(request):
-  """Map Program to Objective object via REST API return response from server.
-  """
-  yield _common_fixtures(request.fixturename)
-
-
-@pytest.fixture(scope="function")
-def map_new_program_rest_to_new_control_rest(request):
-  """Map Control to Program object via REST API return response from server.
-  """
-  yield _common_fixtures(request.fixturename)
-
-
-@pytest.fixture(scope="function")
-def map_new_program_rest_to_new_controls_rest(request):
-  """Map Controls to Program object via REST API return response from server.
-  """
-  yield _common_fixtures(request.fixturename)
-
-
-@pytest.fixture(scope="function")
-def map_new_control_rest_to_new_programs_rest(request):
-  """Map Control to Programs objects via REST API return response from server.
-  """
-  yield _common_fixtures(request.fixturename)
-
-
-def _snapshots_fixtures(fixturename):
-  """Generate snapshot fixtures used generation of common fixtures and return
-  dictionary of executed common fixtures in scope of snapshot fixtures.
-  """
-  return dynamic_fixtures.generate_snapshots_fixtures(fixturename)
-
-
-@pytest.fixture(scope="function")
-def dynamic_create_audit_with_control(request):
-  """Create Program and Control, map Control to Program, create Audit
-  under Program and dynamically make manipulations on Control (update,
-  delete, ...) via REST API according to fixturename. Fixturename is indirect
-  parameter that get from 'request.param' and have to be string or boolean.
-  Return: lib.entities.entity.AssessmentTemplateEntity
-  """
-  yield (dynamic_fixtures.generate_snapshots_fixtures(request.param) if
-         request.param else None)
-
-
-@pytest.fixture(scope="function")
-def dynamic_object(request):
-  """Create object by passed indirect parameter that get from 'request.param'
-  and have to be string or boolean. Return singular or plural object's form
-  according to length of the list objects.
-  """
-  yield _common_fixtures(request.param) if request.param else None
-
-
-@pytest.fixture(scope="function")
-def dynamic_object_w_factory_params(request):
-  """Create object by passed indirect parameter that get from 'request.param'
-  and have to be string or boolean. Return singular or plural object's form
-  according to length of the list objects.
-  """
-  yield _common_fixtures(request.param) if request.param else None
-
-
-@pytest.fixture(scope="function")
-def dynamic_relationships(request):
-  """Create relationships between source and destinations objects by passed
-  indirect parameter that get from 'request.param' and have to be string
-  or boolean."""
-  yield _common_fixtures(request.param) if request.param else None
+  cas = _common_fixtures(request.fixturename)
+  yield cas
+  from lib.service.rest_service import CustomAttributeDefinitionsService
+  CustomAttributeDefinitionsService().delete_objs(cas)
 
 
 @pytest.fixture(scope="function")
@@ -331,52 +297,125 @@ def create_audit_with_control_and_delete_control(request):
 
 
 @pytest.fixture(scope="function")
-def new_programs_rest(request):
-  """Create new Controls objects via REST API.
-  Return: [lib.entities.entity.ProgramEntity, ...]
+def map_new_control_rest_to_new_objective_rest(request):
+  """Map Objective to Control object via REST API return response from server.
   """
   yield _common_fixtures(request.fixturename)
 
 
 @pytest.fixture(scope="function")
-def new_audits_rest(request):
-  """Create new Controls objects via REST API.
-  Return: [lib.entities.entity.AuditEntity, ...]
+def map_new_control_rest_to_new_objectives_rest(request):
+  """Map Objectives to Control object via REST API return response from server.
   """
   yield _common_fixtures(request.fixturename)
 
 
 @pytest.fixture(scope="function")
-def new_assessments_rest(request):
-  """Create new Assessments objects via REST API.
-   Return: [lib.entities.entity.AssessmentEntity, ...]
-   """
+def map_new_control_rest_to_new_programs_rest(request):
+  """Map Programs to Control objects via REST API return response from server.
+  """
   yield _common_fixtures(request.fixturename)
 
 
 @pytest.fixture(scope="function")
 def map_new_control_rest_to_new_assessments_rest(request):
-  """Map control to assessments via REST API"""
+  """Map Assessments to Control via REST API return response from server."""
   yield _common_fixtures(request.fixturename)
 
 
 @pytest.fixture(scope="function")
-def new_cas_for_assessments_rest(request):
-  """Create new Global Custom Attributes for Assessments via REST API and
-  delete GCAs as teardown section.
+def map_new_program_rest_to_new_objective_rest(request):
+  """Map Objective to Program object via REST API return response from server.
   """
-  cas = _common_fixtures(request.fixturename)
-  yield cas
-  from lib.service.rest_service import CustomAttributeDefinitionsService
-  CustomAttributeDefinitionsService().delete_objs(cas)
+  yield _common_fixtures(request.fixturename)
 
 
 @pytest.fixture(scope="function")
-def new_cas_for_controls_rest(request):
-  """Create new Global Custom Attributes for Controls via REST API and
-  delete GCAs as teardown section.
+def map_new_program_rest_to_new_control_rest(request):
+  """Map Control to Program object via REST API return response from server.
   """
-  cas = _common_fixtures(request.fixturename)
-  yield cas
-  from lib.service.rest_service import CustomAttributeDefinitionsService
-  CustomAttributeDefinitionsService().delete_objs(cas)
+  yield _common_fixtures(request.fixturename)
+
+
+@pytest.fixture(scope="function")
+def map_new_program_rest_to_new_controls_rest(request):
+  """Map Controls to Program object via REST API return response from server.
+  """
+  yield _common_fixtures(request.fixturename)
+
+
+@pytest.fixture(scope="function")
+def map_new_assessment_rest_to_new_issue_rest(request):
+  """Map Objectives to Control object via REST API return response from server.
+  """
+  yield _common_fixtures(request.fixturename)
+
+
+@pytest.fixture(scope="function")
+def map_new_assessment_rest_to_new_control_rest_snapshot(request):
+  """Map Objectives to Control object via REST API return response from server.
+  """
+  yield _common_fixtures(request.fixturename)
+
+
+def _common_request_param(request):
+  """Processing for common fixtures of request object which gives access to the
+  requesting test context and has an optional param attribute in case the
+  fixture is parametrized indirectly.
+  """
+  # todo implement '_snapshot_request_param'
+  if hasattr(request, "param") and request.param:
+    params = request.param
+    return (({param: _common_fixtures(param) for param in params}
+            if isinstance(params, list) else _common_fixtures(params)) if
+            params else None)
+
+
+@pytest.fixture(scope="function")
+def dynamic_create_audit_with_control(request):
+  """Create Program and Control, map Control to Program, create Audit
+  under Program and dynamically make manipulations on Control (update,
+  delete, ...) via REST API according to fixturename. Fixturename is indirect
+  parameter that get from 'request.param' and have to be string or boolean.
+  Return: lib.entities.entity.AssessmentTemplateEntity
+  """
+  if hasattr(request, "param") and request.param:
+    yield (dynamic_fixtures.generate_snapshots_fixtures(request.param) if
+           request.param else None)
+
+
+@pytest.fixture(scope="function")
+def dynamic_objects(request):
+  """Create new object or objects via REST API or UI according to indirect
+  parameter 'request.param' which can be: str, list of str, bool.
+  Examples:
+  - 'new_program_rest': lib.entities.entity.ProgramEntity;
+  - 'new_programs_rest': [lib.entities.entity.ProgramEntity, ...];
+  - ['new_program_rest', 'new_control_rest']:
+    {'new_program_rest': lib.entities.entity.ProgramEntity,
+     'new_control_rest': lib.entities.entity.ControlEntity};
+  - True: None.
+  """
+  yield _common_request_param(request)
+
+
+@pytest.fixture(scope="function")
+def dynamic_objects_w_factory_params(request):
+  """Create new object or objects via REST API or UI according to indirect
+  parameter 'request.param' and w/ the same logic as 'dynamic_objects' fixture
+  but using extra parameters to have option change default flow.
+  """
+  yield _common_request_param(request)
+
+
+@pytest.fixture(scope="function")
+def dynamic_relationships(request):
+  """Create single or multiply relationships between source and destinations
+  objects via REST API according to indirect parameter 'request.param' which
+  can be: str, list of str, bool and return response or responses from server.
+  Example:
+  - 'map_new_program_rest_to_new_control_rest';
+  - {'map_new_program_rest_to_new_control_rest': resp1,
+     'map_new_control_rest_to_new_objective_rest': resp2}.
+  """
+  yield _common_request_param(request)

--- a/test/selenium/src/tests/test_asmts_workflow.py
+++ b/test/selenium/src/tests/test_asmts_workflow.py
@@ -113,7 +113,7 @@ class TestAssessmentsWorkflow(base.Test):
 
   @pytest.mark.smoke_tests
   @pytest.mark.parametrize(
-      ("dynamic_object_w_factory_params", "action",
+      ("dynamic_objects_w_factory_params", "action",
        "expected_initial_state", "expected_final_state", "expected_verified"),
       [(("new_assessment_rest", {"status":
                                  AssessmentStates.NOT_STARTED}),
@@ -168,9 +168,9 @@ class TestAssessmentsWorkflow(base.Test):
            "Complete asmt w' verifier 'In Progress' - 'In Review'",
            "Verify asmt w' verifier 'In Review' - 'Completed'",
            "Reject asmt w' verifier 'In Review' - 'In Progress'"],
-      indirect=["dynamic_object_w_factory_params"])
+      indirect=["dynamic_objects_w_factory_params"])
   def test_check_asmt_state_change(
-      self, new_program_rest, new_audit_rest, dynamic_object_w_factory_params,
+      self, new_program_rest, new_audit_rest, dynamic_objects_w_factory_params,
       action, expected_initial_state, expected_final_state, expected_verified,
       selenium
   ):
@@ -180,7 +180,7 @@ class TestAssessmentsWorkflow(base.Test):
     - Audit created under Program via REST API.
     - Assessment created and updated under Audit via REST API.
     """
-    expected_asmt = dynamic_object_w_factory_params
+    expected_asmt = dynamic_objects_w_factory_params
     if expected_initial_state:
       (rest_service.AssessmentsService().
        update_obj(expected_asmt, status=expected_initial_state))
@@ -212,6 +212,7 @@ class TestAssessmentsWorkflow(base.Test):
     - Global Custom Attributes for Assessment created via REST API.
     - Set revers value of GCA with Checkbox type for second Assessment.
     """
+    # pylint: disable=too-many-locals
     custom_attr_values = (
         CustomAttributeDefinitionsFactory().generate_ca_values(
             list_ca_def_objs=new_cas_for_assessments_rest))
@@ -259,30 +260,30 @@ class TestAssessmentsWorkflow(base.Test):
 
   @pytest.mark.smoke_tests
   @pytest.mark.parametrize(
-      "dynamic_object, dynamic_relationships",
+      "dynamic_objects, dynamic_relationships",
       [("new_objective_rest", "map_new_program_rest_to_new_objective_rest"),
        ("new_control_rest", "map_new_program_rest_to_new_control_rest")],
       indirect=True)
   def test_map_snapsots_to_asmt_via_edit_modal(
-      self, new_program_rest, dynamic_object, dynamic_relationships,
+      self, new_program_rest, dynamic_objects, dynamic_relationships,
       new_audit_rest, new_assessment_rest, selenium
   ):
     """Check Assessment can be mapped with snapshot via Modal Edit
     on Assessments Info Page. Additional check existing of mapped obj Titles
     on Modal Edit.
     Preconditions:
-    - Program, dynamic_object created via REST API.
-    - dynamic_object mapped to Program via REST API.
+    - Program, dynamic_objects created via REST API.
+    - dynamic_objects mapped to Program via REST API.
     - Audit created under Program via REST API.
     - Assessment created under audit via REST API.
     Test parameters:
-    - 'dynamic_object'.
+    - 'dynamic_objects'.
     - 'dynamic_relationships'.
     """
     expected_asmt = (new_assessment_rest.update_attrs(
-        objects_under_assessment=[dynamic_object],
+        objects_under_assessment=[dynamic_objects],
         status=AssessmentStates.IN_PROGRESS))
-    expected_titles = [dynamic_object.title]
+    expected_titles = [dynamic_objects.title]
     asmts_ui_service = webui_service.AssessmentsService(selenium)
     actual_titles = (
         asmts_ui_service.map_objs_and_get_mapped_titles_from_edit_modal(

--- a/test/selenium/src/tests/test_audit_page.py
+++ b/test/selenium/src/tests/test_audit_page.py
@@ -103,29 +103,29 @@ class TestAuditPage(base.Test):
 
   @pytest.mark.smoke_tests
   @pytest.mark.parametrize(
-      "dynamic_object, dynamic_relationships",
+      "dynamic_objects, dynamic_relationships",
       [("new_control_rest", "map_new_program_rest_to_new_control_rest"),
        ("new_objective_rest", "map_new_program_rest_to_new_objective_rest")],
       indirect=True)
   def test_asmt_creation_with_mapping(
-      self, new_program_rest, dynamic_object, dynamic_relationships,
+      self, new_program_rest, dynamic_objects, dynamic_relationships,
       new_audit_rest, selenium
   ):
     """Check if Assessment can be created with mapped snapshot via
     Modal Create on Assessments TreeView. Additional check existing of
     mapped objs Titles on Modal Create.
     Preconditions:
-    - Program, dynamic_object created via REST API.
-    - dynamic_object mapped to Program via REST API.
+    - Program, dynamic_objects created via REST API.
+    - dynamic_objects mapped to Program via REST API.
     - Audit created under Program via REST API.
     Test parameters:
-    - 'dynamic_object'.
+    - 'dynamic_objects'.
     - 'dynamic_relationships'.
     """
     expected_asmt = (
         entities_factory.AssessmentsFactory().create(
-            objects_under_assessment=[dynamic_object]))
-    expected_titles = [dynamic_object.title]
+            objects_under_assessment=[dynamic_objects]))
+    expected_titles = [dynamic_objects.title]
     asmts_ui_service = webui_service.AssessmentsService(selenium)
     actual_titles = (
         asmts_ui_service.create_obj_and_get_mapped_titles_from_modal(
@@ -143,7 +143,7 @@ class TestAuditPage(base.Test):
 
   @pytest.mark.smoke_tests
   @pytest.mark.parametrize(
-      "dynamic_object",
+      "dynamic_objects",
       [None, "new_assessment_template_rest",
        "new_assessment_template_with_cas_rest"],
       ids=["Assessments generation without Assessment Template",
@@ -153,7 +153,7 @@ class TestAuditPage(base.Test):
   def test_asmts_generation(
       self, new_program_rest, new_controls_rest,
       map_new_program_rest_to_new_controls_rest, new_audit_rest,
-      dynamic_object, selenium
+      dynamic_objects, selenium
   ):
     """Check if Assessments can be generated from Audit page via Assessments
     widget using Assessment template and Controls.
@@ -162,17 +162,17 @@ class TestAuditPage(base.Test):
     - Controls mapped to Program via REST API.
     - Audit created under Program via REST API.
     Test parameters:
-    - 'dynamic_object'.
+    - 'dynamic_objects'.
     """
     expected_asmts = (entities_factory.AssessmentsFactory().generate(
         objs_under_asmt=new_controls_rest, audit=new_audit_rest,
-        asmt_tmpl=dynamic_object))
+        asmt_tmpl=dynamic_objects))
     expected_asmts = [
         expected_asmt.repr_ui() for expected_asmt in expected_asmts]
     asmts_ui_service = webui_service.AssessmentsService(selenium)
     asmts_ui_service.generate_objs_via_tree_view(
         src_obj=new_audit_rest, objs_under_asmt=new_controls_rest,
-        asmt_tmpl_obj=dynamic_object)
+        asmt_tmpl_obj=dynamic_objects)
     actual_asmts_tab_count = asmts_ui_service.get_count_objs_from_tab(
         src_obj=new_audit_rest)
     assert len(expected_asmts) == actual_asmts_tab_count

--- a/test/selenium/src/tests/test_objective.py
+++ b/test/selenium/src/tests/test_objective.py
@@ -20,7 +20,7 @@ class TestObjectivePage(base.Test):
 
   @pytest.mark.smoke_tests
   @pytest.mark.parametrize(
-      "dynamic_object, dynamic_relationships, is_map_again",
+      "dynamic_objects, dynamic_relationships, is_map_again",
       [("new_objective_rest",
         "map_new_control_rest_to_new_objective_rest", False),
        ("new_objectives_rest",
@@ -31,9 +31,9 @@ class TestObjectivePage(base.Test):
       ids=["Check if Objective can be mapped to Control via REST",
            "Check if Multiple Objectives can be mapped to Control via REST",
            "Check if Objective can't be mapped to Control twice via REST"],
-      indirect=["dynamic_object", "dynamic_relationships"])
+      indirect=["dynamic_objects", "dynamic_relationships"])
   def test_mapping_objectives_to_control_via_rest(
-      self, new_control_rest, dynamic_object, dynamic_relationships,
+      self, new_control_rest, dynamic_objects, dynamic_relationships,
       is_map_again, selenium
   ):
     """Check if Objectives can be mapped to Control via REST."""
@@ -45,10 +45,10 @@ class TestObjectivePage(base.Test):
     assert (
         (rest_service.RelationshipsService().map_objs(
             src_obj=new_control_rest,
-            dest_objs=dynamic_object))[0].status_code ==
+            dest_objs=dynamic_objects))[0].status_code ==
         expected_status_code) if is_map_again else True
     actual_objectives_tab_count = (
         webui_service.ObjectivesService(selenium).get_count_objs_from_tab(
             src_obj=new_control_rest))
-    assert (len(help_utils.convert_to_list(dynamic_object)) ==
+    assert (len(help_utils.convert_to_list(dynamic_objects)) ==
             actual_objectives_tab_count)

--- a/test/selenium/src/tests/test_snapshots.py
+++ b/test/selenium/src/tests/test_snapshots.py
@@ -373,7 +373,6 @@ class TestSnapshots(base.Test):
     """Check searching of shapshotable and snapshoted objects via Unified
     Mapper modal and check their correct mapping.
     """
-    # pylint: disable=assert-on-tuple
     audit_with_one_control = create_audit_with_control_and_update_control
     source_obj = dynamic_objects
     expected_control_from_mapper = (
@@ -403,20 +402,24 @@ class TestSnapshots(base.Test):
               [expected_control_from_tree_view],
               actual_controls_from_tree_view,
               *Representation.tree_view_attrs_to_exclude))
-    assert ((
-        (expected_is_found
-         is (expected_controls_from_mapper[0] in actual_controls_from_mapper)
-         is (expected_map_status in actual_map_status)) is
-        (expected_controls_from_tree_view[0] in actual_controls_from_tree_view
-         if expected_control_from_tree_view else
-         expected_controls_from_tree_view ==
-         expected_controls_from_tree_view)), (
+    assert (
+        expected_is_found
+        is (expected_controls_from_mapper[0] in actual_controls_from_mapper)
+        is (expected_map_status in actual_map_status)) == (
+        (expected_controls_from_tree_view[0] in actual_controls_from_tree_view)
+        if expected_control_from_tree_view else
+        expected_controls_from_tree_view ==
+        actual_controls_from_tree_view), (
         messages.AssertionMessages.format_err_msg_equal(
             messages.AssertionMessages.format_err_msg_contains(
                 expected_controls_from_mapper[0], actual_controls_from_mapper),
             messages.AssertionMessages.format_err_msg_contains(
                 expected_controls_from_tree_view[0],
-                actual_controls_from_tree_view))))
+                actual_controls_from_tree_view)
+            if expected_control_from_tree_view else
+            messages.AssertionMessages.format_err_msg_equal(
+                expected_controls_from_tree_view,
+                actual_controls_from_tree_view)))
 
   @pytest.mark.smoke_tests
   def test_mapping_control_to_existing_audit(


### PR DESCRIPTION
This PR redesigns test-suite and extends tests related to objects mapping according to new standalone Issue object.

**TODO:**
**Redesign and extend the next tests as a part of future PRs:**

- test_mapping_of_objects_to_snapshots_via_map_btn
- test_mapping_of_objects_to_snapshots_via_tree_view
- test_availability_mapping_of_objects_to_snapshotable_objs