### PR TITLE
GGRC-3099 Remove just deleted custom attributes from the admin dashboard

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/tests/tree_view_controller_spec.js
+++ b/src/ggrc/assets/javascripts/controllers/tests/tree_view_controller_spec.js
@@ -40,4 +40,93 @@ describe('CMS.Controllers.TreeView', function () {
 
     // test cases here...
   });
+
+  describe('{original_list} remove event handler', function () {
+    var ctrlInst; // fake controller instance
+    var method;
+    var removeEventHandler;
+    var tvClass = 'cms_controllers_tree_view_node';
+
+    function genFilteredList(num) {
+      let items = [];
+      for (let i = 1; i <= num; i++) {
+        items.push({
+          element: $(`<tr class="${tvClass}" data-object-id="${i}"></tr>`)
+            .appendTo(ctrlInst.element).get(0),
+          options: new can.Map({
+            instance: {
+              id: i,
+            },
+          }),
+        });
+      }
+      return new can.List(items);
+    }
+
+    function genList(num) {
+      let items = [];
+      for (let i = 1; i <= num; i++) {
+        items.push({
+          instance: new can.Map({
+            id: i,
+          }),
+        });
+      }
+      return new can.List(items);
+    }
+
+    beforeEach(function () {
+      ctrlInst = {
+        element: $('<div></div>'),
+        removeFromList: jasmine.createSpy('removeFromList'),
+      };
+
+      ctrlInst.options = new can.Map({
+        filteredList: genFilteredList(5),
+        list: genList(5),
+      });
+
+      method = Ctrl.prototype.removeFromList.bind(ctrlInst);
+      removeEventHandler =
+        Ctrl.prototype['{original_list} remove'].bind(ctrlInst);
+    });
+
+    it('should remove first element from both lists and its element from DOM ',
+      function () {
+        let removedItems = [new can.Map({id: 1})];
+        let callArgs;
+        let rowSelector = '.cms_controllers_tree_view_node[data-object-id="1"]';
+        expect(ctrlInst.element.find(rowSelector).length).toEqual(1);
+
+        removeEventHandler(null, {type: 'remove'}, removedItems, 0);
+
+        callArgs = ctrlInst.removeFromList.calls.allArgs();
+        expect(callArgs[0]).toEqual([ctrlInst.options.attr('list'), [1]]);
+        expect(callArgs[1])
+          .toEqual([ctrlInst.options.attr('filteredList'), [1]]);
+        expect(ctrlInst.element.find(rowSelector).length).toEqual(0);
+      });
+
+    it('should remove first item from filteredList', function () {
+        let filteredListIds;
+
+        method(ctrlInst.options.attr('filteredList'), [1]);
+
+        expect(ctrlInst.options.attr('filteredList').length).toBe(4);
+        filteredListIds = ctrlInst.options.attr('filteredList')
+          .map((item)=>item.options.attr('instance.id')).serialize();
+        expect(filteredListIds).toEqual([2, 3, 4, 5]);
+      });
+
+    it('should remove fist item from list', function () {
+      let listIds;
+      method(ctrlInst.options.attr('list'), [1]);
+
+      expect(ctrlInst.options.attr('list').length).toBe(4);
+
+      listIds = ctrlInst.options.attr('list')
+        .map((item)=>item.attr('instance.id')).serialize();
+      expect(listIds).toEqual([2, 3, 4, 5]);
+    });
+  });
 });

--- a/src/ggrc/assets/javascripts/controllers/tree/tree-view.js
+++ b/src/ggrc/assets/javascripts/controllers/tree/tree-view.js
@@ -276,6 +276,23 @@ import StateUtils from '../../plugins/utils/state-utils';
       return this.find_all_deferred;
     },
 
+    /*
+     * Removes items from the list by ids
+     * @param  {can.List}      list             list of items
+     * @param  {Array{Number}} removedItemsIds  array of item ids
+     */
+    removeFromList: function (list, removedItemsIds) {
+      // Since list items have slightly different format,
+      // we are lookig for instance property in possible places
+      let itemsToKeep = list.filter((item) => {
+        let inst = item && item.options && item.options.attr('instance') ||
+          item.attr('instance');
+
+        return !_.includes(removedItemsIds, inst.attr('id'));
+      });
+      list.replace(itemsToKeep);
+    },
+
     display_path: function (path, refetch) {
       return this.display(refetch).then(this._ifNotRemoved(function () {
         return GGRC.Utils.TreeView.displayTreeSubpath(this.element, path);
@@ -476,6 +493,25 @@ import StateUtils from '../../plugins/utils/state-utils';
       var node = el.control();
       node.draw_node();
       node.select();
+    },
+
+    '{original_list} remove': function (list, ev, removedItems, index) {
+      var removedItemsIds = removedItems.map((remItem) => {
+        return remItem.attr('id');
+      });
+
+      this.removeFromList(this.options.list, removedItemsIds);
+      this.removeFromList(this.options.filteredList, removedItemsIds);
+
+      // NB: since row element are not rendered with mustache and binded element
+      // not always reflected in the filteredList ( for newly created items )
+      // we are just removeing the items from the lists and removing the DOM
+      // elements by ids
+      removedItemsIds.forEach((id) => {
+        this.element
+          .find(`.cms_controllers_tree_view_node[data-object-id="${id}"]`)
+          .remove();
+      });
     },
 
     '{original_list} add': function (list, ev, newVals, index) {


### PR DESCRIPTION
Steps to reproduce:

1) Go to Admin dashboard/Custom attributes (for ex. Assessments' CAs)
2) Edit then Delete the topmost GCA. System asks if you really want to delete the CA and it's name. Delete it. Message is shown that it's been successfully deleted.
3) CA is still shown on the dashboard
4) Try to delete it again. Pop-up window now offers you to delete a CA with another name. Delete it. Message is shown that it's been successfully deleted. (CA with that "another" name)
5) But the CA it still on the UI, despite some CA is gone from the db. (Checked it, some CA really is being deleted)
6) On the next turn you see that "second" CA name again, and again some CA is deleted from the db.