### PR TITLE
QUICK-FIX Add fetch tag to PR titles script

### DIFF
--- a/bin/release/get_pr_titles.py
+++ b/bin/release/get_pr_titles.py
@@ -73,6 +73,9 @@ def git_diff(upstream, branch, tag):
   """Get git diff --oneline between tag and latest upstream/branch."""
   subprocess.check_call(["git", "fetch", upstream, branch])
 
+  tag_string = "refs/tags/{tag}:refs/tags/{tag}".format(tag=tag)
+  subprocess.check_call(["git", "fetch", upstream, tag_string])
+
   log_target = "{tag}..{upstream}/{branch}".format(
       tag=tag,
       upstream=upstream,


### PR DESCRIPTION
Since tags are on our master branch but the default base branch that is
pulled is the current release branch, user might not have the tag commit
available locally. This fix makes sure that we can use this script even
if we run it on a clean repo.