### PR TITLE
GGRC-3531 FE - Run deletion synchronously

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/delete_modal_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/delete_modal_controller.js
@@ -41,7 +41,11 @@ GGRC.Controllers.Modals("GGRC.Controllers.Delete", {
                                // Do not re-enable the form elements.
 
     }).fail(function(xhr, status){
-      $(document.body).trigger("ajax:flash", { error : xhr.responseText });
+      var errorMessage = (xhr.responseJSON && xhr.responseJSON.message) ?
+        xhr.responseJSON.message :
+        xhr.responseText;
+
+      $(document.body).trigger("ajax:flash", { error : errorMessage });
     }), el.add(cancel_button).add(modal_backdrop));
   }
 


### PR DESCRIPTION
The issue was fixed in scope of https://github.com/google/ggrc-core/pull/6471

error messages from delete are not displayed correctly.