### PR TITLE
GGRC-3368 Fetch data for audit summary graph with custom endpoint

### DIFF
--- a/src/ggrc/assets/javascripts/apps/business_objects.js
+++ b/src/ggrc/assets/javascripts/apps/business_objects.js
@@ -3,6 +3,8 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 */
 
+import SummaryWidgetController from '../controllers/summary_widget_controller';
+
 (function (can, $) {
   var CoreExtension = {};
 
@@ -78,7 +80,7 @@
       if (summaryWidgetViews[objectTable]) {
         widgetList.add_widget(object.constructor.shortName, 'summary', {
           widget_id: 'summary',
-          content_controller: GGRC.Controllers.SummaryWidget,
+          content_controller: SummaryWidgetController,
           instance: object,
           widget_view: summaryWidgetViews[objectTable],
           order: 3

--- a/src/ggrc/assets/javascripts/controllers/summary_widget_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/summary_widget_controller.js
@@ -5,278 +5,276 @@
 
 import '../components/add-object-button/add-object-button';
 
-(function (can, $) {
-  can.Control('GGRC.Controllers.SummaryWidget', {
-    defaults: {
-      model: null,
-      instance: null,
-      widget_view: GGRC.mustache_path + '/base_objects/summary.mustache',
-      isLoading: true,
-      isShown: false,
-      forceRefresh: false,
-      colorsMap: {
-        Completed: '#405f77',
-        Verified: '#009925',
-        'In Progress': '#3369e8',
-        'Not Started': '#9e9e9e',
-        'In Review': '#ff9100'
+can.Control('GGRC.Controllers.SummaryWidget', {
+  defaults: {
+    model: null,
+    instance: null,
+    widget_view: GGRC.mustache_path + '/base_objects/summary.mustache',
+    isLoading: true,
+    isShown: false,
+    forceRefresh: false,
+    colorsMap: {
+      Completed: '#405f77',
+      Verified: '#009925',
+      'In Progress': '#3369e8',
+      'Not Started': '#9e9e9e',
+      'In Review': '#ff9100'
+    },
+    chartOptions: {
+      pieSliceText: 'value-and-percentage',
+      chartArea: {
+        width: '100%',
+        height: '90%'
       },
-      chartOptions: {
-        pieSliceText: 'value-and-percentage',
-        chartArea: {
-          width: '100%',
-          height: '90%'
-        },
-        height: 300,
-        legend: {
-          position: 'none'
-        }
+      height: 300,
+      legend: {
+        position: 'none'
       }
-    },
-    init: function () {
-      var that = this;
-      $(function () {
-        if (GGRC.page_object) {
-          $.extend(that.defaults, {
-            model: GGRC.infer_object_type(GGRC.page_object),
-            instance: GGRC.page_instance()
-          });
-        }
-      });
     }
-  }, {
-    init: function () {
-      var frag;
-      if (this.element.data('widget-view')) {
-        this.options.widget_view = GGRC.mustache_path +
-          this.element.data('widget-view');
+  },
+  init: function () {
+    var that = this;
+    $(function () {
+      if (GGRC.page_object) {
+        $.extend(that.defaults, {
+          model: GGRC.infer_object_type(GGRC.page_object),
+          instance: GGRC.page_instance()
+        });
       }
-      this.element.closest('.widget')
-        .on('widget_shown', this.widget_shown.bind(this));
-      this.element.closest('.widget')
-        .on('widget_hidden', this.widget_hidden.bind(this));
-      this.options.context = new can.Map({
-        model: this.options.model,
-        instance: this.options.instance,
-        error_msg: '',
-        error: true,
-        charts: {
-          Assessment: {
-            legend: []
-          }
+    });
+  }
+}, {
+  init: function () {
+    var frag;
+    if (this.element.data('widget-view')) {
+      this.options.widget_view = GGRC.mustache_path +
+        this.element.data('widget-view');
+    }
+    this.element.closest('.widget')
+      .on('widget_shown', this.widget_shown.bind(this));
+    this.element.closest('.widget')
+      .on('widget_hidden', this.widget_hidden.bind(this));
+    this.options.context = new can.Map({
+      model: this.options.model,
+      instance: this.options.instance,
+      error_msg: '',
+      error: true,
+      charts: {
+        Assessment: {
+          legend: []
         }
-      });
-      frag = can.view(this.get_widget_view(this.element),
-                      this.options.context);
-      this.widget_shown();
-      this.element.html(frag);
-      return 0;
-    },
-    onRelationshipChange: function (model, ev, instance) {
-      if (instance instanceof CMS.Models.Relationship &&
-      instance.attr('destination.type') === 'Document' &&
-      instance.attr('source.type') === 'Assessment') {
-        this.options.forceRefresh = true;
       }
-    },
-    '{CMS.Models.Relationship} destroyed': 'onRelationshipChange',
-    '{CMS.Models.Relationship} created': 'onRelationshipChange',
-    '{CMS.Models.Assessment} updated': function (model, ev, instance) {
-      if (instance instanceof CMS.Models.Assessment) {
-        this.options.forceRefresh = true;
-      }
-    },
-    get_widget_view: function (el) {
-      var widgetView = $(el)
-        .closest('[data-widget-view]')
-        .attr('data-widget-view');
-      return (widgetView && widgetView.length > 0) ?
-          GGRC.mustache_path + widgetView :
-          this.options.widget_view;
-    },
-    widget_shown: function (event) {
-      this.options.isShown = true;
-      setTimeout(this.reloadSummary.bind(this), 0);
+    });
+    frag = can.view(this.get_widget_view(this.element),
+                    this.options.context);
+    this.widget_shown();
+    this.element.html(frag);
+    return 0;
+  },
+  onRelationshipChange: function (model, ev, instance) {
+    if (instance instanceof CMS.Models.Relationship &&
+    instance.attr('destination.type') === 'Document' &&
+    instance.attr('source.type') === 'Assessment') {
+      this.options.forceRefresh = true;
+    }
+  },
+  '{CMS.Models.Relationship} destroyed': 'onRelationshipChange',
+  '{CMS.Models.Relationship} created': 'onRelationshipChange',
+  '{CMS.Models.Assessment} updated': function (model, ev, instance) {
+    if (instance instanceof CMS.Models.Assessment) {
+      this.options.forceRefresh = true;
+    }
+  },
+  get_widget_view: function (el) {
+    var widgetView = $(el)
+      .closest('[data-widget-view]')
+      .attr('data-widget-view');
+    return (widgetView && widgetView.length > 0) ?
+        GGRC.mustache_path + widgetView :
+        this.options.widget_view;
+  },
+  widget_shown: function (event) {
+    this.options.isShown = true;
+    setTimeout(this.reloadSummary.bind(this), 0);
 
+    $(window).trigger('resize');
+    return false;
+  },
+  widget_hidden: function (event) {
+    this.options.isShown = false;
+    return false;
+  },
+  reloadSummary: function () {
+    var that = this;
+    this.loadChartLibrary(function () {
+      that.reloadChart('Assessment', 'piechart_audit_assessments_chart');
+    });
+  },
+  reloadChart: function (type, elementId) {
+    var that = this;
+    var query = GGRC.Utils.CurrentPage;
+    var chartOptions = this.options.context.charts[type];
+    // Note that chart will be refreshed only if counts were changed.
+    // State changes are not checked.
+    var countsChanged = query.getCounts().attr(type) !==
+                        chartOptions.attr('total');
+    if (chartOptions.attr('isInitialized') && !countsChanged &&
+    !this.options.forceRefresh) {
+      return;
+    }
+    this.options.forceRefresh = false;
+    chartOptions.attr('isInitialized', true);
+
+    that.setState(type, {total: 0, statuses: { }}, true);
+    that.getStatuses(that.options.instance.id).then(function (raw) {
+      var data = that.parseStatuses(type, raw);
+      var chart = that.drawChart(elementId, data);
+
+      that.prepareLegend(type, chart, data);
+      that.setState(type, data, false);
+    });
+  },
+  drawChart: function (elementId, raw) {
+    var chart;
+    var that = this;
+    var options = this.getChartOptions(raw);
+    var data = new google.visualization.DataTable();
+    var statuses = raw.statuses.map(function (item) {
+      return item.map(function (status) {
+        return that.prepareTitle(status);
+      });
+    });
+    this.options.chartOptions = options;
+    this.options.data = data;
+
+    data.addColumn('string', 'Status');
+    data.addColumn('number', 'Count');
+    data.addRows(statuses);
+
+    chart = new google.visualization.PieChart(
+      document.getElementById(elementId));
+    this.options.chart = chart;
+
+    chart.draw(data, options);
+    setTimeout(function () {
       $(window).trigger('resize');
-      return false;
-    },
-    widget_hidden: function (event) {
-      this.options.isShown = false;
-      return false;
-    },
-    reloadSummary: function () {
-      var that = this;
-      this.loadChartLibrary(function () {
-        that.reloadChart('Assessment', 'piechart_audit_assessments_chart');
-      });
-    },
-    reloadChart: function (type, elementId) {
-      var that = this;
-      var query = GGRC.Utils.CurrentPage;
-      var chartOptions = this.options.context.charts[type];
-      // Note that chart will be refreshed only if counts were changed.
-      // State changes are not checked.
-      var countsChanged = query.getCounts().attr(type) !==
-                          chartOptions.attr('total');
-      if (chartOptions.attr('isInitialized') && !countsChanged &&
-      !this.options.forceRefresh) {
-        return;
-      }
-      this.options.forceRefresh = false;
-      chartOptions.attr('isInitialized', true);
+    }, 0);
 
-      that.setState(type, {total: 0, statuses: { }}, true);
-      that.getStatuses(that.options.instance.id).then(function (raw) {
-        var data = that.parseStatuses(type, raw);
-        var chart = that.drawChart(elementId, data);
-
-        that.prepareLegend(type, chart, data);
-        that.setState(type, data, false);
-      });
-    },
-    drawChart: function (elementId, raw) {
-      var chart;
-      var that = this;
-      var options = this.getChartOptions(raw);
-      var data = new google.visualization.DataTable();
-      var statuses = raw.statuses.map(function (item) {
-        return item.map(function (status) {
-          return that.prepareTitle(status);
-        });
-      });
-      this.options.chartOptions = options;
-      this.options.data = data;
-
-      data.addColumn('string', 'Status');
-      data.addColumn('number', 'Count');
-      data.addRows(statuses);
-
-      chart = new google.visualization.PieChart(
-        document.getElementById(elementId));
-      this.options.chart = chart;
-
-      chart.draw(data, options);
-      setTimeout(function () {
-        $(window).trigger('resize');
-      }, 0);
-
-      return chart;
-    },
-    prepareTitle: function (status) {
-      if (status === 'Verified') {
-        return 'Completed and Verified';
-      }
-      if (status === 'Completed') {
-        return 'Completed (no verification)';
-      }
-      return status;
-    },
-    prepareLegend: function (type, chart, data) {
-      var legendData = [];
-      var that = this;
-      var chartOptions = this.options.context.charts[type];
-      var colorsMap = this.options.colorsMap;
-
-      data.statuses.forEach(function (statusData, rowIndex) {
-        legendData.push({
-          title: that.prepareTitle(statusData[0]),
-          count: statusData[1],
-          percent: (statusData[1] / data.total * 100).toFixed(1),
-          rowIndex: rowIndex,
-          color: colorsMap[statusData[0]]
-        });
-      });
-
-      chartOptions.attr('legend', legendData);
-
-      this.element.find('#piechart_audit_assessments_chart-legend tbody')
-        .off('mouseenter', 'tr')
-        .on('mouseenter', 'tr', function () {
-          var $el = $(this);
-          var rowIndex = $el.data('row-index');
-
-          if (_.isNumber(rowIndex)) {
-            chart.setSelection([{row: rowIndex, column: null}]);
-          }
-        })
-        .on('mouseleave', 'tr', function () {
-          chart.setSelection(null);
-        });
-    },
-    getChartOptions: function (raw) {
-      var options = _.assign({}, this.options.chartOptions);
-      var colorMaps = this.options.colorsMap;
-      options.colors = raw.statuses.map(function (e) {
-        return colorMaps[e[0]];
-      });
-
-      return options;
-    },
-    '{window} resize': function (ev) {
-      var chart = this.options.chart;
-      var data = this.options.data;
-      var options = this.options.chartOptions;
-      var isSummaryWidgetShown = this.options.isShown;
-
-      if (isSummaryWidgetShown && chart && options && data) {
-        chart.draw(data, options);
-      }
-    },
-    setState: function (type, data, isLoading) {
-      var chartOptions = this.options.context.charts[type];
-      chartOptions.attr('total', data.total);
-      chartOptions.attr('any', data.total > 0);
-      chartOptions.attr('none', isLoading || data.total === 0);
-      chartOptions.attr('isLoading', isLoading);
-      chartOptions.attr('isLoaded', !isLoading);
-      if (isLoading) {
-        chartOptions.attr('legend', []);
-      }
-    },
-    parseStatuses: function (type, data) {
-      var statuses = CMS.Models[type].statuses;
-      var groups = _.object(statuses, new Array(statuses.length).fill(0));
-      var result;
-      data.forEach(function (item) {
-        if (item[1]) {
-          item[0] = 'Verified';
-        }
-        groups[item[0]]++;
-      });
-      result = _.pairs(groups);
-      return {
-        total: data.length,
-        statuses: result
-      };
-    },
-    /**
-     * Get statuses of mapped Assessments
-     * @param {Number} auditId
-     * @return {Promise<Array>}
-     * @example
-     * Example of response:
-     * [
-     * ["In Review", 0],
-     * ["In Progress", 0],
-     * ["Completed", 1]
-     * ]
-     * where first value in array - title of status,
-     * and second - 0(not verified), 1(verified) assessment
-     */
-    getStatuses: function (auditId) {
-      return $.get('/api/audits/'+ auditId + '/summary');
-    },
-    loadChartLibrary: function (callback) {
-      if (typeof google !== 'undefined' &&
-          typeof google.charts !== 'undefined') {
-        callback();
-        return;
-      }
-      GGRC.Utils.loadScript('https://www.gstatic.com/charts/loader.js', function () {
-        google.charts.load('45', {packages: ['corechart']});
-        google.charts.setOnLoadCallback(callback);
-      });
+    return chart;
+  },
+  prepareTitle: function (status) {
+    if (status === 'Verified') {
+      return 'Completed and Verified';
     }
-  });
-})(window.can, window.can.$);
+    if (status === 'Completed') {
+      return 'Completed (no verification)';
+    }
+    return status;
+  },
+  prepareLegend: function (type, chart, data) {
+    var legendData = [];
+    var that = this;
+    var chartOptions = this.options.context.charts[type];
+    var colorsMap = this.options.colorsMap;
+
+    data.statuses.forEach(function (statusData, rowIndex) {
+      legendData.push({
+        title: that.prepareTitle(statusData[0]),
+        count: statusData[1],
+        percent: (statusData[1] / data.total * 100).toFixed(1),
+        rowIndex: rowIndex,
+        color: colorsMap[statusData[0]]
+      });
+    });
+
+    chartOptions.attr('legend', legendData);
+
+    this.element.find('#piechart_audit_assessments_chart-legend tbody')
+      .off('mouseenter', 'tr')
+      .on('mouseenter', 'tr', function () {
+        var $el = $(this);
+        var rowIndex = $el.data('row-index');
+
+        if (_.isNumber(rowIndex)) {
+          chart.setSelection([{row: rowIndex, column: null}]);
+        }
+      })
+      .on('mouseleave', 'tr', function () {
+        chart.setSelection(null);
+      });
+  },
+  getChartOptions: function (raw) {
+    var options = _.assign({}, this.options.chartOptions);
+    var colorMaps = this.options.colorsMap;
+    options.colors = raw.statuses.map(function (e) {
+      return colorMaps[e[0]];
+    });
+
+    return options;
+  },
+  '{window} resize': function (ev) {
+    var chart = this.options.chart;
+    var data = this.options.data;
+    var options = this.options.chartOptions;
+    var isSummaryWidgetShown = this.options.isShown;
+
+    if (isSummaryWidgetShown && chart && options && data) {
+      chart.draw(data, options);
+    }
+  },
+  setState: function (type, data, isLoading) {
+    var chartOptions = this.options.context.charts[type];
+    chartOptions.attr('total', data.total);
+    chartOptions.attr('any', data.total > 0);
+    chartOptions.attr('none', isLoading || data.total === 0);
+    chartOptions.attr('isLoading', isLoading);
+    chartOptions.attr('isLoaded', !isLoading);
+    if (isLoading) {
+      chartOptions.attr('legend', []);
+    }
+  },
+  parseStatuses: function (type, data) {
+    var statuses = CMS.Models[type].statuses;
+    var groups = _.object(statuses, new Array(statuses.length).fill(0));
+    var result;
+    data.forEach(function (item) {
+      if (item[1]) {
+        item[0] = 'Verified';
+      }
+      groups[item[0]]++;
+    });
+    result = _.pairs(groups);
+    return {
+      total: data.length,
+      statuses: result
+    };
+  },
+  /**
+   * Get statuses of mapped Assessments
+   * @param {Number} auditId
+   * @return {Promise<Array>}
+   * @example
+   * Example of response:
+   * [
+   * ["In Review", 0],
+   * ["In Progress", 0],
+   * ["Completed", 1]
+   * ]
+   * where first value in array - title of status,
+   * and second - 0(not verified), 1(verified) assessment
+   */
+  getStatuses: function (auditId) {
+    return $.get('/api/audits/'+ auditId + '/summary');
+  },
+  loadChartLibrary: function (callback) {
+    if (typeof google !== 'undefined' &&
+        typeof google.charts !== 'undefined') {
+      callback();
+      return;
+    }
+    GGRC.Utils.loadScript('https://www.gstatic.com/charts/loader.js', function () {
+      google.charts.load('45', {packages: ['corechart']});
+      google.charts.setOnLoadCallback(callback);
+    });
+  }
+});

--- a/src/ggrc/assets/javascripts/controllers/summary_widget_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/summary_widget_controller.js
@@ -5,7 +5,7 @@
 
 import '../components/add-object-button/add-object-button';
 
-can.Control('GGRC.Controllers.SummaryWidget', {
+export default can.Control({
   defaults: {
     model: null,
     instance: null,

--- a/src/ggrc/assets/javascripts/controllers/tests/summary_widget_controller_spec.js
+++ b/src/ggrc/assets/javascripts/controllers/tests/summary_widget_controller_spec.js
@@ -3,13 +3,10 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 */
 
-describe('GGRC.Controllers.SummaryWidget', function () {
-  'use strict';
-  var Ctrl;
+import Ctrl from '../summary_widget_controller';
 
-  beforeAll(function () {
-    Ctrl = GGRC.Controllers.SummaryWidget;
-  });
+describe('SummaryWidgetController', function () {
+  'use strict';
 
   describe('"{CMS.Models.Assessment} updated" handler', function () {
     var method;

--- a/src/ggrc/assets/javascripts/modules/widget_descriptor.js
+++ b/src/ggrc/assets/javascripts/modules/widget_descriptor.js
@@ -3,6 +3,8 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 */
 
+import SummaryWidgetController from '../controllers/summary_widget_controller';
+
 (function ($, CMS, GGRC) {
   // A widget descriptor has the minimum five properties:
   // widget_id:  the unique ID string for the widget
@@ -57,7 +59,7 @@
             return instance.constructor.title_singular + ' Summary';
           },
           widget_icon: 'pie-chart',
-          content_controller: GGRC.Controllers.SummaryWidget,
+          content_controller: SummaryWidgetController,
           content_controller_options: {
             instance: instance,
             model: instance.constructor,

--- a/src/ggrc/assets/javascripts/modules/widget_list.js
+++ b/src/ggrc/assets/javascripts/modules/widget_list.js
@@ -4,6 +4,7 @@
 */
 
 import './widget_descriptor';
+import SummaryWidgetController from '../controllers/summary_widget_controller';
 
 (function ($, CMS, GGRC) {
   /*
@@ -52,7 +53,7 @@ import './widget_descriptor';
             options && options.instance || widget.instance,
             options && options.widget_view || widget.widget_view
           );
-        } else if (ctrl && ctrl === GGRC.Controllers.SummaryWidget) {
+        } else if (ctrl && ctrl === SummaryWidgetController) {
           descriptors[widgetId] = GGRC.WidgetDescriptor.make_summary_widget(
             options &&
             options.instance ||


### PR DESCRIPTION
Since we have moved how we do performance optimizations, we have to update the frontend
the audit summary page is no longer as fast as it should be because we moved the query optimization to custom endpoint
/api/audits/x/summary
We have to update the frontend to use that endpoint instead of the /query api.