### PR TITLE
GGRC-3506 Import of comments: address PR comments

### DIFF
--- a/src/ggrc/converters/handlers/comments.py
+++ b/src/ggrc/converters/handlers/comments.py
@@ -9,7 +9,6 @@ from ggrc.converters import errors
 from ggrc.converters.handlers.handlers import ColumnHandler
 from ggrc.models import Comment
 from ggrc.models import Relationship
-from ggrc.models.comment import Commentable
 from ggrc.login import get_current_user_id
 
 
@@ -18,20 +17,23 @@ class CommentColumnHandler(ColumnHandler):
 
   COMMENTS_SEPARATOR = ";;"
 
+  @staticmethod
+  def split_comments(raw_value):
+    """Split comments"""
+    res = [comment.strip() for comment in
+           raw_value.rsplit(CommentColumnHandler.COMMENTS_SEPARATOR)
+           if comment.strip()]
+    return res
+
   def parse_item(self):
     """Parse a list of comments to be mapped.
 
-    Parse a semicolon separated list of comments
+    Parse a COMMENTS_SEPARATOR separated list of comments
 
     Returns:
-      list of commentst
+      list of comments
     """
-    if not isinstance(self.row_converter.obj, Commentable):
-      self.add_error(errors.UNSUPPORTED_OPERATION_ERROR,
-                     operation="Can't import comments for {}"
-                     .format(self.row_converter.obj.__class__.__name__))
-    comments = [comment for comment in
-                self.raw_value.split(self.COMMENTS_SEPARATOR) if comment]
+    comments = self.split_comments(self.raw_value)
     if self.raw_value and not comments:
       self.add_warning(errors.WRONG_VALUE,
                        column_name=self.display_name)

--- a/test/integration/ggrc/converters/test_import_comments.py
+++ b/test/integration/ggrc/converters/test_import_comments.py
@@ -16,19 +16,19 @@ class TestCommentsImport(TestCase):
   @classmethod
   def setUpClass(cls):
     TestCase.clear_data()
-    TestCase._import_file("import_comments.csv")
+    cls.response = TestCase._import_file("import_comments.csv")
 
   def setUp(self):
     """Log in before performing queries."""
+    self._check_csv_response(self.response, {})
     self.client.get("/login")
 
   @ddt.data(("Assessment 1", ["comment"]),
             ("Assessment 2", ["some comment"]),
             ("Assessment 3", ["<a href=\"goooge.com\">link</a>"]),
             ("Assessment 4", ["comment1", "comment2", "comment3"]),
-            ("Assessment 5", ["one;two", "three", ";four", "hello"]),
-            ("Assessment 6", ["a normal comment with {} characters"]),
-            ("Assessment 7", []))
+            ("Assessment 5", ["one;two", "three;", "four", "hello"]),
+            ("Assessment 6", ["a normal comment with {} characters"]))
   @ddt.unpack
   def test_assessment_comments(self, slug, expected_comments):
     """Test assessment comments import"""

--- a/test/integration/ggrc/test_csvs/import_comments.csv
+++ b/test/integration/ggrc/test_csvs/import_comments.csv
@@ -6,7 +6,6 @@ Assessment,Code*,Audit*,Title*,Description,Notes,State*,Assignees*,Creators*,Rec
 ,Assessment 4,Audit,Assessment title 4,,,Not Started,user@example.com,user@example.com,,,,,comment1;;comment2;;comment3,
 ,Assessment 5,Audit,Assessment title 5,,,Not Started,user@example.com,user@example.com,,,,,one;two;;three;;;four;;;;hello,
 ,Assessment 6,Audit,Assessment title 6,,,Not Started,user@example.com,user@example.com,,,,,"a normal comment with {} characters",
-,Assessment 7,Audit,Assessment title 7,,,Not Started,user@example.com,user@example.com,,,,,;;;;,
 ,,,,,,,,,,,,,,
 Object type,,,,,,,,,,,,,,
 Audit,Code*,Program*,Title*,Audit Captain*,Status,,,,,,,,,

--- a/test/unit/ggrc/converters/handlers/test_comment_column_handler.py
+++ b/test/unit/ggrc/converters/handlers/test_comment_column_handler.py
@@ -1,0 +1,32 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Tests for the CommentColumnHandler class"""
+
+import unittest
+
+import ddt
+
+from ggrc.converters.handlers.comments import CommentColumnHandler
+
+
+@ddt.ddt
+class CommentColumnHandlerTestCase(unittest.TestCase):
+  """Base class for DateColumnHandler tests"""
+
+  @ddt.data((";;;;", []),
+            (" ;; ", []),
+            (" ;; ;; ", []),
+            (" ", []),
+            ("", []),
+            ("a;b", ["a;b"]),
+            ("a;;b", ["a", "b"]),
+            ("a;;;b", ["a;", "b"]),
+            ("a;;;;b", ["a", "b"]),
+            ("a;;;;;b", ["a;", "b"]),
+            (" a;; ;;b ", ["a", "b"]))
+  @ddt.unpack
+  def test_split_comments(self, raw_value, expected_result):
+    """Test splitting of comments"""
+    result = CommentColumnHandler.split_comments(raw_value)
+    self.assertEqual(result, expected_result)


### PR DESCRIPTION
Scope:
1. Grammar issues found by @alieh-rymasheuski: https://github.com/google/ggrc-core/pull/6482
2. Dead code removal for warnings
3. Function for splitting comments must be put outside of parse_item and fully covered with unit tests to check and document all edge cases of ;; ;; ;; a;;;b etc.
4. user can add empty comment - comment1;; ;;comment2;;
5. Leading/ trailing spaces are not ignored