### PR TITLE
QUICK-FIX Add tests of checking all possible Audit's statuses under cloning

### DIFF
--- a/test/selenium/src/lib/constants/locator.py
+++ b/test/selenium/src/lib/constants/locator.py
@@ -641,6 +641,7 @@ class CommonWidgetInfo(object):
   _HEADERS_AND_VALUES = (_INFO_WIDGET_XPATH +
                          '//div[starts-with(./@class, "span")]//h6/..')
   WIDGET = Common.INFO
+  _FOOTER = Common.INFO_WIDGET_ID + " .info-widget-footer em"
   HEADERS_AND_VALUES = (By.XPATH, _HEADERS_AND_VALUES)
   LCAS_HEADERS_AND_VALUES = None  # due to exist only for WidgetInfoAssessment
   CAS_HEADERS_AND_VALUES = (By.XPATH,
@@ -652,10 +653,9 @@ class CommonWidgetInfo(object):
   TITLE_ENTERED = (By.XPATH, _MAIN_HEADER_XPATH + "//h3")
   STATE = (By.XPATH, _MAIN_HEADER_XPATH +
            "//*[contains(normalize-space(./@class), 'state-value state')]")
-  TXT_FOOTER_CSS = (By.CSS_SELECTOR,
-                    Common.INFO_WIDGET_ID + " .info-widget-footer em")
+  TXT_FOOTER_CSS = (By.CSS_SELECTOR, _FOOTER)
   TXT_MODIFIED_BY_CSS = (By.CSS_SELECTOR,
-                         '[data-test-id="text_manager_7a906d2e"]')
+                         _FOOTER + ' [data-test-id="text_manager_7a906d2e"]')
   TXT_OBJECT_REVIEW = (
       By.CSS_SELECTOR,
       '{} [data-test-id="title_review_0ad9fbaf"] h6'.format(WIDGET))

--- a/test/selenium/src/lib/page/widget/info_widget.py
+++ b/test/selenium/src/lib/page/widget/info_widget.py
@@ -25,11 +25,12 @@ class InfoWidget(base.Widget):
   locator_headers_and_values = None
 
   def __init__(self, driver):
+    super(InfoWidget, self).__init__(driver)
     self.child_cls_name = self.__class__.__name__.lower()
+    selenium_utils.wait_for_js_to_load(self._driver)
     # empty lists of headers and values
     self.list_all_headers_txt = []
     self.list_all_values_txt = []
-    super(InfoWidget, self).__init__(driver)
     # check type and content of Info Widget
     if not self.is_info_page_not_panel:
       self.is_snapshotable_panel = (


### PR DESCRIPTION
This PR depends on #6546 and contains 1 parametrized test which comprising 5 tests of checking Audit's statuses under cloning procedure.
```Python
  @pytest.mark.smoke_tests
  @pytest.mark.cloning
  @pytest.mark.parametrize(
      "create_and_clone_audit_w_params_to_update",
      [("new_audit_rest", {"status": AuditStates.PLANNED}),
       ("new_audit_rest", {"status": AuditStates.IN_PROGRESS}),
       ("new_audit_rest", {"status": AuditStates.MANAGER_REVIEW}),
       ("new_audit_rest", {"status": AuditStates.READY_FOR_EXT_REVIEW}),
       ("new_audit_rest", {"status": AuditStates.COMPLETED})],
      ids=["Audit statuses: 'Planned' - 'Planned'",
           "Audit statuses: 'In Progress' - 'Planned'",
           "Audit statuses: 'Manager Review' - 'Planned'",
           "Audit statuses: 'Ready for External Review' - 'Planned'",
           "Audit statuses: 'Completed' - 'Planned'"],
      indirect=True)
  def test_cloned_audit_contains_new_attrs(
      self, create_and_clone_audit_w_params_to_update
  ):
    """Check via UI that cloned Audit contains new predicted attributes using
    all initial Audit's states.
    Preconditions:
    - Execution and return of fixture
    'create_and_clone_audit_w_params_to_update'.
    """
    expected_audit = (
        create_and_clone_audit_w_params_to_update["expected_audit"].
        update_attrs(status=AuditStates.PLANNED).repr_ui())
    actual_audit = create_and_clone_audit_w_params_to_update["actual_audit"]
    # 'expected_audit': created_at, updated_at, slug (None) *factory
    self.general_equal_assert(
        expected_audit, actual_audit, "created_at", "updated_at", "slug")
```
