### PR TITLE
QUICK-FIX Turn-off eslint "no-invalid-this" rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -74,6 +74,7 @@
       "boolean": false
     }],
     "no-inline-comments": 0,
+    "no-invalid-this": 0,
     "no-negated-condition": 0,
     "no-unused-vars": [2, {
       "args": "none",


### PR DESCRIPTION
# Issue description

Some of pull requests ( for example GGRC-1783 ) are blocked by newly introduced ESLint rule "no-invalid-this".
Some places of the code use implicit binding of "this" which are normal use cases.
For example: 
1) CanJS validate API implicitly binds validator's "this" to the validated instance.
__src/ggrc/assets/javascripts/models/assessment.js__
```
      this.validate(
        'validate_creator',
        function () {
          if (!this.validate_creator) {
            return 'You need to specify at least one creator';
          }
        }
      );
```

2) Some places use lodash's debounce function.
__src/ggrc/assets/javascripts/controllers/dashboard_controller.js__
```
    '{window} resize': _.debounce(function (el, ev) {
      this.show_hide_titles();
    }, 100),
```
and adding new code requires constant search for workarounds which will add unnecessary complexity to the code.

# Steps to reproduce

Try to duplicate any validation method call ( `this.validate(...)` ) with callback in  
src/ggrc/assets/javascripts/models/assessment.js

# Solution description

Turn-off "no-invalid-this" rule.

# Sanity check list

- [x] My changes fix the issue described in the description (and do nothing else).
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/git/how_to_write_a_commit_message.rst).

Other items are removed from checklist as they are not applicable.
