### PR TITLE
GGRC-3316 Primary Contacts and Secondary Contacts are not displayed on the Program Info pane/page

### DIFF
--- a/src/ggrc/assets/mustache/base_objects/contacts.mustache
+++ b/src/ggrc/assets/mustache/base_objects/contacts.mustache
@@ -5,8 +5,8 @@
 
 {{#instance}}
 <div class="row-fluid wrap-row">
-  {{#if is_program}}
-    <div data-test-id="title_manager_7a906d2e" class="span6">
+  <div data-test-id="title_manager_7a906d2e">
+    {{#if is_program}}
       <h6>Manager</h6>
       <p class="oneline">
         {{#with_mapping 'authorizations' instance}}
@@ -27,11 +27,8 @@
           {{/if}}
         {{/with_mapping}}
       </p>
-    </div>
-  {{else}}
-    <div data-test-id="title_manager_7a906d2e">
-       <custom-roles {instance}="."></custom-roles>
-    </div>
-  {{/if}}
+    {{/if}}
+    <custom-roles {instance}="."></custom-roles>
+  </div>
 </div>
 {{/instance}}


### PR DESCRIPTION
Steps to reproduce:
1. Create a program and add Primary and Secondary Contacts
2. Look at the Program info page: Primary and Secondary Contacts are not displayed
Actual Result: Primary Contacts and Secondary Contacts are not displayed on the Program Info pane/page
Expected Result: Primary Contacts and Secondary Contacts should be displayed on the Program Info pane/page
NOTE: Primary and Secondary Contacts are not displayed on the Program's Info pane as well