### PR TITLE
GGRC-2120 Include attachment for audits

### DIFF
--- a/src/ggrc/assets/mustache/audits/info.mustache
+++ b/src/ggrc/assets/mustache/audits/info.mustache
@@ -169,14 +169,18 @@
                 {{#if_helpers '\
                   #if' instance.archived '\
                   or ^is_allowed' "update" instance context="for"}}
-                      <ggrc-gdrive-folder-picker
-                          readonly="true"
-                          instance="instance">
-                      </ggrc-gdrive-folder-picker>
+                    <folder-attachments-list title="Attachment"
+                      readonly="true"
+                      {instance}="instance"
+                      deny-no-folder="true"
+                      tooltip="You can upload up to 10 files in a single batch">
+                    </folder-attachments-list>
                 {{else}}
-                      <ggrc-gdrive-folder-picker
-                          instance="instance">
-                      </ggrc-gdrive-folder-picker>
+                  <folder-attachments-list title="Attachment"
+                    {instance}="instance"
+                    deny-no-folder="true"
+                    tooltip="You can upload up to 10 files in a single batch">
+                  </folder-attachments-list>
                 {{/if_helpers}}
             </div>
           </div>

--- a/src/ggrc_gdrive_integration/assets/mustache/gdrive/gdrive_folder.mustache
+++ b/src/ggrc_gdrive_integration/assets/mustache/gdrive/gdrive_folder.mustache
@@ -6,7 +6,7 @@
 <div>
   {{#unless hideLabel}}
     <label class="multi-type-label">
-      {{instance.class.title_singular}} Folder
+      Attachment
       <label class="inline">
         <i class="fa fa-question-circle" rel="tooltip" data-original-title="If selected, all {{instance.class.title_singular}} attachments go here."></i>
       </label>


### PR DESCRIPTION
**HIGH LEVEL REQUIREMENTS**
1. Add 'Attachments' field on:

- 'Audit info' tab on Audit page.
- Audit info pane.

Note: User should not be able to attach docs during Audit creation (new / edit Audit modal pop-up)

2. 'Attachment' field should function in the same way as 'Evidence' field for Assessment:
User should be able to make multiple attachments.
If user has EDIT rights for an object, then he should be able to delete already attached files.

**ACCEPTANCE CRITERIA - ADD FOLDER**
_AC1_. ATTACHMENT field should be displayed on:

- Add / Edit Audit modal pop-up;
- Audit info pane / page.

_AC2_. ASSIGN FOLDER button should be displayed for ATTACHMENT field by default on:

- Add / Edit Audit modal pop-up;
- Audit info pane / page.

_AC3_. On clicking ASSIGN FOLDER button, SELECT FOLDER modal window should be opened, so that user can select gDrive folder.

_AC4_. On clicking SELECT button on SELECT FOLDER modal window, a new folder should be added and displayed on:

- Add / Edit Audit modal pop-up;
- Audit info pane / page.

_AC5_. On hovering over folder name, pencil and trash icons should be displayed on:

- Add / Edit Audit modal pop-up;
- Audit info pane / page.

_AC6_. On clicking pencil icon, SELECT FOLDER modal window should be opened, so that user can select another gDrive folder.

_AC7_. On clicking trash icon, folder should be deleted and ASSIGN FOLDER button should be displayed.

_AC8_. User should be able to attach only one file at a time.

**ACCEPTANCE CRITERIA - ATTACH FILES**
_AC1_. ATTACH button should be displayed for ATTACHMENT field if a folder is Assigned to Audit on:

- Audit info pane / page.


_AC2_. On clicking ATTACH button, SELECT A FILE modal window should be opened.

_AC3_. On clicking UPLOAD button on SELECT A FILE modal window, a new file(s) should be attached to Audit and displayed in ATTACHMENT field (see design).

_AC4_. If user (who has EDIT rights for Audit) hovers over attached file(s), then trash icon should be displayed on:

- Audit info pane / page.

_AC5_. On clicking trash icon, attached file should be deleted.

_AC6_. User should be able to attach multiple files.

_AC7_. Date when file was attached should be displayed for each file in format MM/DD/YYYY.

**MAKE CONSISTENT LABELS ACROSS APP:**
_AC1_. Change label to 'ATTACHMENT' on:

- Add / Edit Workflow pop-up;
- Workflow info pop-up;
- Add / Edit Control pop-up;