### PR TITLE
GGRC-1894/GGRC-1895 Make object type clickable in "Select child tree object type" window

### DIFF
--- a/src/ggrc/assets/javascripts/components/tree/sub-tree-models.js
+++ b/src/ggrc/assets/javascripts/components/tree/sub-tree-models.js
@@ -1,4 +1,4 @@
-/*!
+/*
  Copyright (C) 2017 Google Inc.
  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  */
@@ -13,7 +13,16 @@ import template from './templates/sub-tree-models.mustache';
       isActive: {
         type: Boolean,
         value: false
-      }
+      },
+      uniqueModelsList: {
+        get: function () {
+          return this.attr('modelsList').map(function (model) {
+            model.attr('inputId', 'stm-' +
+              (Date.now() * Math.random()).toFixed());
+            return model;
+          });
+        },
+      },
     },
     modelsList: null,
     title: null,

--- a/src/ggrc/assets/javascripts/components/tree/templates/sub-tree-models.mustache
+++ b/src/ggrc/assets/javascripts/components/tree/templates/sub-tree-models.mustache
@@ -15,16 +15,17 @@
     <span ($click)="selectAll(%event)">Select all</span>
   </div>
   <div class="flex-box flex-box-multi">
-    {{#modelsList}}
+    {{#uniqueModelsList}}
       <div class="flex-box sub-models_item">
           <input type="checkbox"
+                 id="{{inputId}}"
                  {($checked)}="display"
                  value="{{name}}"
                  class="notify-wrap model-checkbox"
           >
-          {{widgetName}}
+          <label for="{{inputId}}">{{widgetName}}</label>
       </div>
-    {{/modelsList}}
+    {{/uniqueModelsList}}
   </div>
   <div class="flex-box sub-tree-models_footer">
     <a class="btn btn-small btn-lightBlue" href="javascript://" ($click)="setDisplayModels(%event)">Set Visibility</a>

--- a/src/ggrc/assets/javascripts/components/tree/tests/sub-tree-models_spec.js
+++ b/src/ggrc/assets/javascripts/components/tree/tests/sub-tree-models_spec.js
@@ -1,0 +1,155 @@
+/* !
+  Copyright (C) 2017 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+  */
+
+describe('GGRC.Components.subTreeModels', function () {
+  var vm;
+  var events;
+
+  beforeEach(function () {
+    vm = GGRC.Components.getViewModel('subTreeModels');
+    events = GGRC.Components.get('subTreeModels').prototype.events;
+  });
+
+  describe('get() of uniqueModelsList', function () {
+    it('sets random stringified number to inputIdPrefix', function () {
+      var result;
+      vm.attr('modelsList', new can.List([
+        {}, {}, {}, {}, {},
+      ]));
+
+      result = _.uniq(vm.attr('uniqueModelsList'), function (el) {
+        return el.attr('inputId');
+      });
+
+      expect(result.length).toEqual(5);
+    });
+  });
+
+  describe('activate() method', function () {
+    it('sets true to viewModel.isActive', function () {
+      vm.attr('isActive', false);
+
+      vm.activate();
+      expect(vm.attr('isActive')).toBe(true);
+    });
+  });
+
+  describe('setDisplayModels() method', function () {
+    var event;
+    var modelsList;
+
+    beforeEach(function () {
+      modelsList = new can.List([
+        {name: 'Audit', display: true},
+        {name: 'Control', display: true},
+        {name: 'Objective', display: false},
+        {name: 'Market', display: true},
+      ]);
+      spyOn(can, 'trigger');
+      event = {
+        stopPropagation: jasmine.createSpy(),
+      };
+      vm.attr('modelsList', modelsList);
+      vm.attr('$el', 'element');
+    });
+
+    it('triggers event "childModelsChange" on element' +
+    ' with array of selected models', function () {
+      var selectedModels;
+
+      vm.setDisplayModels(event);
+      selectedModels = modelsList.filter(function (item) {
+        return item.display;
+      }).map(function (item) {
+        return item.name;
+      }).serialize();
+
+      expect(can.trigger).toHaveBeenCalledWith(vm.attr('$el'),
+        'childModelsChange', [jasmine.objectContaining(selectedModels)]);
+    });
+
+    it('sets false to viewModel.isActive', function () {
+      vm.attr('isActive', true);
+
+      vm.setDisplayModels(event);
+      expect(vm.attr('isActive')).toBe(false);
+    });
+  });
+
+  describe('selectAll(), selectNone() methods', function () {
+    var modelsList;
+    var event;
+
+    beforeEach(function () {
+      modelsList = new can.List([
+        {name: 'Audit', display: true},
+        {name: 'Control', display: true},
+        {name: 'Objective', display: false},
+        {name: 'Market', display: true},
+      ]);
+      vm.attr('modelsList', modelsList);
+      event = {
+        stopPropagation: jasmine.createSpy(),
+      };
+    });
+
+    it('selectAll() sets display true to all models in list', function () {
+      var result;
+
+      vm.selectAll(event);
+      result = _.every(vm.attr('modelsList'), function (item) {
+        return item.display === true;
+      });
+      expect(result).toBe(true);
+    });
+
+    it('selectNone() sets display false to all models in list', function () {
+      var result;
+
+      vm.selectNone(event);
+      result = _.every(vm.attr('modelsList'), function (item) {
+        return item.display === false;
+      });
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('inserted handler', function () {
+    var handler;
+    var viewModel;
+
+    beforeEach(function () {
+      viewModel = new can.Map({});
+      handler = events['inserted'].bind({
+        viewModel: viewModel,
+        element: 'element',
+      });
+    });
+
+    it('saves element into viewModel', function () {
+      handler();
+      expect(viewModel.attr('$el')).toEqual('element');
+    });
+  });
+
+  describe('".sub-tree-models mouseleave" handler', function () {
+    var handler;
+    var viewModel;
+
+    beforeEach(function () {
+      viewModel = new can.Map();
+      handler = events['.sub-tree-models mouseleave'].bind({
+        viewModel: viewModel,
+      });
+    });
+
+    it('sets false to viewModel.isActive', function () {
+      viewModel.attr('isActive', true);
+
+      handler();
+      expect(viewModel.attr('isActive', false));
+    });
+  });
+});

--- a/src/ggrc/assets/stylesheets/components/tree/_tree-view.scss
+++ b/src/ggrc/assets/stylesheets/components/tree/_tree-view.scss
@@ -396,6 +396,7 @@ tree-header {
 sub-tree-models {
   .sub-tree-models {
     display: none;
+    cursor: default;
     position: absolute;
     background-color: $white;
     top: 0;
@@ -427,11 +428,14 @@ sub-tree-models {
     }
 
     .sub-models_item {
-      width: 120px;
+      min-width: 140px;
       margin-bottom: 15px;
 
       input {
         margin-right: 5px;
+      }
+      label {
+        cursor: pointer;
       }
     }
 


### PR DESCRIPTION
# Issue description
Includes:
1) GGRC-1894 Make object type clickable in "Select child tree object type" window
2) GGRC-1895 Cannot select/deselect "Assessment template" checkbox in Select child tree object type window in Audit tab
3) Unit-tests for `sub-tree-models` component

Note: This tickets was done in scope of https://github.com/google/ggrc-core/pull/6474.
Issue: Clicking on label of object type is not checking/unchecking checkbox in sub tree filter.

# Steps to reproduce

GGRC-1894 Steps to reproduce:
1. Go to My objects page and select any object in HNB (e.g. Controls)
2. Hover over the first tier > gear icon> Filter sub tree
3. Click any object type to select checkbox

Actual Result: Object type is not clickable in "Select child tree object type" window
Expected Result: Object type should be clickable in "Select child tree object type" window

GGRC-1895 Steps to reproduce:
1. Create program 
2. Add Audit widget and create audit
3. In audit tab hover over first tier in tree view> gear icon> Filter tree view
4. Try to select/deselect "Assessment template" check box in "Select child tree object type" window 

Actual Result: Cannot select/deselect "Assessment template" checkbox in Select child tree object type window in Audit tab
Expected Result: Use can select/deselect "Assessment template" checkbox in Select child tree object type window in Adit tab

# Solution description

Wrap object names in `<label>` tag, add unique `id="<some_id>"` attributes for checkboxes, `for="<checkbox_id>"` attributes to its labels.

# Sanity check list

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests (if not, include a reason).
- [x] My changes follow the [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/performance.rst).
- [x] My changes follow the [js](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/git/how_to_write_a_commit_message.rst).