### PR TITLE
GGRC-3214/GGRC-1253 Primary/Secondary contacts shown as mapped in the unified mapper but missing in People tab

### DIFF
--- a/src/ggrc/query/custom_operators.py
+++ b/src/ggrc/query/custom_operators.py
@@ -14,14 +14,15 @@ from sqlalchemy.orm import load_only
 
 from ggrc import db
 from ggrc import models
-from ggrc.query import autocast
-from ggrc.query.exceptions import BadQueryException
+from ggrc.access_control.list import AccessControlList
 from ggrc.fulltext.mysql import MysqlRecordProperty as Record
 from ggrc.login import is_creator
 from ggrc.models import inflector
 from ggrc.models import relationship_helper
-from ggrc.snapshotter import rules
+from ggrc.query import autocast
 from ggrc.query import my_objects
+from ggrc.query.exceptions import BadQueryException
+from ggrc.snapshotter import rules
 from ggrc_basic_permissions import UserRole
 
 
@@ -151,6 +152,12 @@ def related_people(exp, object_class, target_class, query):
       object_class.__name__,
       exp['object_name'],
       exp['ids'],
+  ))
+
+  res.extend(db.session.query(AccessControlList.person_id).filter(
+      sqlalchemy.and_(
+          AccessControlList.object_id.in_(exp['ids']),
+          AccessControlList.object_type == exp['object_name'])
   ))
 
   if exp['object_name'] in ('Program', 'Audit'):

--- a/test/integration/ggrc/services/test_query/test_basic.py
+++ b/test/integration/ggrc/services/test_query/test_basic.py
@@ -593,6 +593,31 @@ class TestAdvancedQueryAPI(TestCase, WithQueryApi):
         self._sort_sublists(controls_ordered_2),
     )
 
+  def test_query_related_people_for_program(self):
+    """Test correct querying of the related people to Program"""
+    program_id = all_models.Program.query.filter_by(
+        title="Cat ipsum 1").one().id
+    query_filter = {
+        "object_name": "Person",
+        "filters": {
+            "expression": {
+                "object_name": "Program",
+                "op": {
+                    "name": "related_people",
+                },
+                "ids": [program_id],
+            },
+        },
+    }
+    people = self._get_first_result_set(
+        query_filter,
+        "Person",
+    )
+    user_list = [p['email'] for p in people["values"]]
+    ref_list = [u'smotko@example.com', u'urbon.s@example.com',
+                u'zidar@example.com', u'sec.con@example.com']
+    self.assertItemsEqual(user_list, ref_list)
+
   def test_filter_control_by_key_control(self):
     """Test correct filtering by SIGNIFICANCE field"""
     controls = self._get_first_result_set(

--- a/test/integration/ggrc/test_csvs/data_for_export_testing.csv
+++ b/test/integration/ggrc/test_csvs/data_for_export_testing.csv
@@ -1,7 +1,7 @@
 ,,,,,,,,,,,,,,,,,,,,,
 Object Type,,,,,,,,,,,,,,,,,,,,,
-program,Title,Description,Notes,Manager,Reference URL,,Code,Effective Date,Last Deprecated Date,State,map:policy,map:contract,map:  regulation,map: control,,map: objective,,,,,
-,Cat ipsum 1,Climb leg rub face on everything give attitude nap all day for under the bed. Chase mice attack feet,,smotko@example.com,http://www.google.com,,prog-1,5/9/2015,11/1/2015,Draft,"policy-1
+program,Title,Description,Notes,Manager,Reference URL,Primary Contacts,Code,Effective Date,Last Deprecated Date,State,map:policy,map:contract,map:  regulation,map: control,,map: objective,,,,,
+,Cat ipsum 1,Climb leg rub face on everything give attitude nap all day for under the bed. Chase mice attack feet,,smotko@example.com,http://www.google.com,sec.con@example.com,prog-1,5/9/2015,11/1/2015,Draft,"policy-1
 policy-2
 policy-3
 policy-4


### PR DESCRIPTION
Problem definition:
- Primary/Secondary contacts are missing in People tab

Steps to reproduce:
1. Add/Change Primary or Secondary contact for the Program
2. Navigate to People tab
Actual result: Primary/Secondary contact are not shown in the list
Expected result: Primary/Secondary contact are shown in the list
3. Click Map button, and search for Primary/Secondary contact:
Primary/Secondary contact person is shown as mapped

Primary/Secondary contacts are granted an access to the object they are assigned to.

The issue:
- The issue is that persons linked over ACL are not gathered while querying over query API in custom_operators module, "related_people" query operator.