### PR TITLE
GGRC-1909 There is no Export/Import controls for Audits in 3 bb's menu on the Assessment/Issue/Audit pages

### DIFF
--- a/src/ggrc/assets/javascripts/components/tree/templates/tree-widget-container.mustache
+++ b/src/ggrc/assets/javascripts/components/tree/templates/tree-widget-container.mustache
@@ -51,30 +51,28 @@
           <span class="bubble"></span>
         </a>
         <ul class="dropdown-menu tree-action-list-items" role="menu">
-          {{^if_instance_of parent_instance 'Assessment'}}
-            {{^if isSnapshots}}
-              {{#is_allowed 'update' model.shortName context=parent_instance.context}}
-                <li>
-                  <a href="/import"
-                     target="_blank"
-                     class="section-import">
-                    <i class="fa fa-fw fa-cloud-upload"></i>
-                    Import {{model.model_plural}}
-                  </a>
-                </li>
-              {{/is_allowed}}
-            {{/if}}
-            {{#if showedItems.length}}
+          {{^if isSnapshots}}
+            {{#is_allowed 'update' model.shortName context=parent_instance.context}}
               <li>
-                <a href="/export?model_type={{model.model_singular}}&relevant_type={{parent_instance.type}}&relevant_id={{parent_instance.id}}{{#if isSnapshots}}&isSnapshots=true{{/if}}"
-                   target="_blank"
-                   class="section-import">
-                  <i class="fa fa-fw fa-download"></i>
-                  Export {{model.model_plural}}
+                <a href="/import"
+                    target="_blank"
+                    class="section-import">
+                  <i class="fa fa-fw fa-cloud-upload"></i>
+                  Import {{model.model_plural}}
                 </a>
               </li>
-            {{/if}}
-          {{/if_instance_of}}
+            {{/is_allowed}}
+          {{/if}}
+          {{#if showedItems.length}}
+            <li>
+              <a href="/export?model_type={{model.model_singular}}&relevant_type={{parent_instance.type}}&relevant_id={{parent_instance.id}}{{#if isSnapshots}}&isSnapshots=true{{/if}}"
+                  target="_blank"
+                  class="section-import">
+                <i class="fa fa-fw fa-download"></i>
+                Export {{model.model_plural}}
+              </a>
+            </li>
+          {{/if}}
           {{#if showGenerateAssessments}}
             <assessment-generator-button audit="parent_instance"></assessment-generator-button>
           {{/if}}

--- a/test/selenium/src/tests/test_snapshots.py
+++ b/test/selenium/src/tests/test_snapshots.py
@@ -568,9 +568,8 @@ class TestSnapshots(base.Test):
        (["new_assessment_rest", "new_issue_rest"],
         ["map_new_assessment_rest_to_new_control_rest_snapshot",
          "map_new_assessment_rest_to_new_issue_rest"]),
-       pytest.mark.xfail(reason="Issue GGRC-1909", strict=True)(
-           ("new_assessment_rest",
-            "map_new_assessment_rest_to_new_control_rest_snapshot"))],
+       ("new_assessment_rest",
+        "map_new_assessment_rest_to_new_control_rest_snapshot")],
       ids=["Export of snapshoted Control from Audit's Info Page "
            "via mapped Controls' Tree View",
            "Export of snapshoted Control from Issue's Info Page "


### PR DESCRIPTION
Precondition:
created program, control, audit, assessment, issue
Steps to reproduce:
1. Go to assessment/issue page
2. Audit tab> open 3 bb's menu
Actual Result: There is no Export/Import controls for Audits in 3 bb's menu on the Assessment/Issue page
Expected Result: Should be Export/Import controls for Audits in 3 bb's menu on the Assessment/Issue page
Note: on the audit page open 3 bb's menu in tree view for any snapshot and look at the dropdown: is empty