### PR TITLE
GGRC-3338 Add 'Task Group' field on 'Add/Edit Cycle Task' pop-up

### DIFF
--- a/src/ggrc/assets/javascripts/plugins/autocomplete.js
+++ b/src/ggrc/assets/javascripts/plugins/autocomplete.js
@@ -298,10 +298,10 @@
           this.source(this.last_request, function (items) {
             try {
               listItems = context.attr('items');
+              context.attr('oldLen', listItems.length);
               listItems.push.apply(listItems, can.map(items, function (item) {
                 return item.item;
               }));
-              context.attr('oldLen', listItems.length);
             } catch (error) {
               // Really ugly way to hide canjs exception during scrolling.
               // Please note that it occurs in really rear cases.

--- a/src/ggrc/assets/javascripts/plugins/autocomplete.js
+++ b/src/ggrc/assets/javascripts/plugins/autocomplete.js
@@ -361,7 +361,51 @@
     }
   });
 
+  $.widget('ggrc.query_autocomplete', $.ggrc.autocomplete, {
+    options: {
+      source_for_refreshable_objects: function (request) {
+        var queryField = this.element.attr('data-query-field') || 'title';
+        var queryRelevantType = this.element.attr('data-query-relevant-type');
+        var queryRelevantId = this.element.attr('data-query-relevant-id');
+        var dfd = can.Deferred();
+        var objName = this.options.searchtypes[0];
+        var relevant;
+        var filter = {expression: {
+          left: queryField,
+          op: {name: '~'},
+          right: request.term,
+        }};
+        var query;
+
+        if (queryRelevantType && queryRelevantId) {
+          relevant = {
+            type: queryRelevantType,
+            id: queryRelevantId,
+          };
+        }
+
+        query = GGRC.Utils.QueryAPI.buildRelevantIdsQuery(objName, {},
+           relevant, filter);
+
+        GGRC.Utils.QueryAPI
+         .makeRequest({data: [query]})
+         .done(function (responseArr) {
+           var ids = responseArr[0][objName].ids;
+           var model = CMS.Models[objName];
+
+           var res = can.map(ids, function (id) {
+             return CMS.Models.get_instance(model.shortName, id);
+           });
+           dfd.resolve(res);
+         });
+
+        return dfd;
+      },
+    },
+  });
+
   $.widget.bridge('ggrc_mapping_autocomplete', $.ggrc.mapping_autocomplete);
+  $.widget.bridge('ggrc_query_autocomplete', $.ggrc.query_autocomplete);
 
   /**
    * Convert an input element to an autocomplete field.
@@ -386,9 +430,14 @@
     } else {
       el = $(el);
     }
-    el.filter("[name][name!='']")
+    el.filter("[name][name!='']:not([data-query])")
       .ggrc_autocomplete({
         controller: ctl
+      });
+
+    el.filter('[data-query]')
+      .ggrc_query_autocomplete({
+        controller: ctl,
       });
   };
 })(jQuery);

--- a/src/ggrc_workflows/assets/assets.yaml
+++ b/src/ggrc_workflows/assets/assets.yaml
@@ -15,6 +15,7 @@ dashboard-js-template-files:
   - cycle_task_entries/tree_add_item.mustache
   - cycle_task_entries/modal_content.mustache
   - cycle_task_groups/info.mustache
+  - cycle_task_groups/autocomplete_result.mustache
   - cycle_task_group_objects/info.mustache
   - cycle_task_group_object_tasks/info.mustache
   - cycle_task_group_object_tasks/tree-item-attr.mustache

--- a/src/ggrc_workflows/assets/assets.yaml
+++ b/src/ggrc_workflows/assets/assets.yaml
@@ -16,6 +16,7 @@ dashboard-js-template-files:
   - cycle_task_entries/modal_content.mustache
   - cycle_task_groups/info.mustache
   - cycle_task_groups/autocomplete_result.mustache
+  - cycle_task_groups/extended_info.mustache
   - cycle_task_group_objects/info.mustache
   - cycle_task_group_object_tasks/info.mustache
   - cycle_task_group_object_tasks/tree-item-attr.mustache

--- a/src/ggrc_workflows/assets/javascripts/models/cycle_models.js
+++ b/src/ggrc_workflows/assets/javascripts/models/cycle_models.js
@@ -22,8 +22,12 @@
 
   function populateFromWorkflow(form, workflow) {
     if (!workflow || typeof workflow === 'string') {
-      // We need to invalidate the form, so we remove workflow if it's not set
+      // We need to invalidate the form, so we remove workflow and dependencies
+      // if it's not set
       form.removeAttr('workflow');
+      form.removeAttr('context');
+      form.removeAttr('cycle');
+      form.removeAttr('cycle_task_group');
       return;
     }
     if (workflow.reify) {
@@ -57,7 +61,9 @@
       form.attr('workflow', {id: workflow.id, type: 'Workflow'});
       form.attr('context', {id: workflow.context.id, type: 'Context'});
       form.attr('cycle', {id: activeCycle.id, type: 'Cycle'});
-      form.cycle_task_group = activeCycle.cycle_task_groups[0].id;
+
+      //reset cycle task group after workflow updating
+      form.removeAttr('cycle_task_group');
     });
   }
 
@@ -347,6 +353,7 @@
       this.validateNonBlank('title');
       this.validateNonBlank('workflow');
       this.validateNonBlank('cycle');
+      this.validateNonBlank('cycle_task_group');
       this.validateContact(['_transient.contact', 'contact']);
       this.validateNonBlank('start_date');
       this.validateNonBlank('end_date');
@@ -367,8 +374,10 @@
       });
     },
     set_properties_from_workflow: function (workflow) {
-      // The form sometimes returns plaintext instead of object, return in that case
-      if (typeof workflow === 'string') {
+      // The form sometimes returns plaintext instead of object,
+      // return in that case
+      // If workflow is empty form should be invalidated
+      if (typeof workflow === 'string' && workflow !== '') {
         return;
       }
       populateFromWorkflow(this, workflow);

--- a/src/ggrc_workflows/assets/javascripts/models/tests/CycleTaskGroupObjectTask_model_spec.js
+++ b/src/ggrc_workflows/assets/javascripts/models/tests/CycleTaskGroupObjectTask_model_spec.js
@@ -76,4 +76,45 @@ describe('CMS.Models.CycleTaskGroupObjectTask', function () {
       }
     );
   });
+
+  describe('form_preload method', function () {
+    var instance;
+
+    beforeEach(function () {
+      instance = new CMS.Models.CycleTaskGroupObjectTask({
+        status: 'Assigned',
+        cycle: {
+          is_current: false,
+        },
+      });
+    });
+
+    it('populates the workflow and related objects ' +
+      'when creating new task from workflow page',
+    function () {
+      var cycles = [{
+        id: 'cycle id',
+        is_current: true}];
+
+      var workflow = new CMS.Models.Workflow({
+        id: 'workflow id',
+        context: {
+          id: 'context id',
+        },
+        cycles: cycles,
+      });
+
+      spyOn(workflow, 'refresh_all').and
+        .returnValue(can.Deferred().resolve(cycles));
+
+      instance.form_preload(true, {workflow: workflow});
+
+      expect(instance.attr('workflow.id')).toEqual('workflow id');
+      expect(instance.attr('workflow.type')).toEqual('Workflow');
+      expect(instance.attr('context.id')).toEqual('context id');
+      expect(instance.attr('context.type')).toEqual('Context');
+      expect(instance.attr('cycle.id')).toEqual('cycle id');
+      expect(instance.attr('cycle.type')).toEqual('Cycle');
+    });
+  });
 });

--- a/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/modal_content.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/modal_content.mustache
@@ -64,6 +64,26 @@
           {{^instance.computed_errors.workflow}}{{#instance.computed_errors.cycle}}<label class="help-inline warning">No active cycles in this workflow</label>{{/instance.computed_errors.cycle}}{{/instance.computed_errors.workflow}}
         {{/using}}
       </div>
+      <br>
+      <div class="{{#instance.computed_errors.cycle_task_group}}field-failure{{/instance.computed_errors.cycle_task_group}}">
+        {{#using cycle_task_group=instance.cycle_task_group}}
+          <h6>Task Group <span class="required">*</span></h6>
+          <input
+            {{^if instance.cycle}} disabled {{/if}}
+            class="input-block-level required"
+            name="cycle_task_group."
+            data-lookup="CycleTaskGroup"
+            data-query
+            data-query-field="group title"
+            data-query-relevant-type="{{instance.cycle.type}}"
+            data-query-relevant-id="{{instance.cycle.id}}"
+            placeholder="Select a Task Group"
+            type="text"
+            value="{{cycle_task_group.title}}"
+            data-template="/cycle_task_groups/autocomplete_result.mustache"
+            tabindex="5" />
+        {{/using}}
+      {{#instance.computed_errors.cycle_task_group}}<label class="help-inline warning">{{this}}</label>{{/instance.computed_errors.cycle_task_group}}
     </div>
   </div>
 
@@ -145,7 +165,6 @@
   </div>
   <div class="row-fluid hidden">
     <input type="hidden" name="task_group" model="TaskGroup" value="{{firstnonempty object_params.task_group instance.task_group.id}}" />
-    <input type="hidden" name="cycle_task_group" model="CycleTaskGroup" value="{{firstnonempty object_params.task_group instance.task_group.id}}" data-populated-in-callback />
     <input type="hidden" name="sort_index" value="{{firstnonempty object_params.sort_index instance.sort_index}}" />
     <input type="hidden" name="cycle" model="Cycle" value="{{instance.cycle.id}}" data-populated-in-callback />
     <input type="hidden" name="context" model="Context" value="{{firstnonempty object_params.context instance.context.id}}" data-populated-in-callback />

--- a/src/ggrc_workflows/assets/mustache/cycle_task_groups/autocomplete_result.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_groups/autocomplete_result.mustache
@@ -5,7 +5,8 @@
 
 {{#each items}}
 <li class="ui-menu-item" {{data 'ui-autocomplete-item'}}>
-  <a href="javascript://" class='show-extended' {{data 'model'}}>
+  <a href="javascript://" class='show-extended' {{data 'model'}}
+    data-tooltip-view="/cycle_task_groups/extended_info.mustache">
     {{title}}
   </a>
 </li>

--- a/src/ggrc_workflows/assets/mustache/cycle_task_groups/autocomplete_result.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_groups/autocomplete_result.mustache
@@ -1,0 +1,22 @@
+{{!
+    Copyright (C) 2017 Google Inc.
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+}}
+
+{{#each items}}
+<li class="ui-menu-item" {{data 'ui-autocomplete-item'}}>
+  <a href="javascript://" class='show-extended' {{data 'model'}}>
+    {{title}}
+  </a>
+</li>
+{{/each}}
+{{^items}}
+  <li class="ui-menu-item" data-ui-autocomplete-item="">
+    No results
+  </li>
+{{/items}}
+{{#if items_loading}}
+  <li class="spinner ui-menu-item" data-ui-autocomplete-item="">
+    <span {{attach_spinner '{ "radius": 4, "length": 4, "width": 2 }' 'display:inline-block; top: -3px; left: 30px;' }}></span>
+  </li>
+{{/if}}

--- a/src/ggrc_workflows/assets/mustache/cycle_task_groups/extended_info.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_groups/extended_info.mustache
@@ -1,0 +1,34 @@
+{{!
+    Copyright (C) 2017 Google Inc.
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+    Template applicable to workflows only
+}}
+
+
+{{#instance}}
+  <div class="row-fluid">
+    <div class="span12">
+      <a class="main-title {{class.category}} oneline" href="{{viewLink}}">
+        {{title}}
+      </a>
+    </div>
+  </div>
+
+  <div class="row-fluid">
+    <div class="span12">
+      <h6>Description</h6>
+      <div class="rtf">
+        {{{firstnonempty description '<span class="empty-message">None</span>'}}}
+      </div>
+    </div>
+  </div>
+
+  <div class="row-fluid">
+    <div class="span12">
+      <div class="code">
+        Code: {{slug}}
+      </div>
+    </div>
+  </div>
+{{/instance}}


### PR DESCRIPTION
# Acceptance criteria

AC1. Add 'Task Group' field on 'Add/Edit Cycle Task' pop-up. Task Group field should be a text field with autosuggest. 
Autosuggest should contain:
a) all tasks groups for a particular workflow selected in 'Active Workflow' field - if task is created out of Workflow (My Tasks page, Create a task for an object, All Objects - Tasks).
b) all tasks groups for a particular workflow in which the task is created (Workflow page - Active Cycles).
AC2. 'Task Group' field should be mandatory. Error message 'Cannot be blank'.
AC3. 'Task Group' field should be cleaned up if user deletes Active Cycle (case when task is created out of Workflow page).
AC4. 'Task Group' field should be editable.
AC5. 'Task Group' should be empty by default.
AC6. 'Task Group' should be disabled until user selects an active workflow.
AC7. On saving, Cycle should be added to specified cycle task group.

# Solution description
As Cycle Task Groups are not available through Search API, new autocomplete widget based on existing one was added to get data using Query API.