### PR TITLE
GGRC-3411: Clean up function to display custom attribute values

### DIFF
--- a/src/ggrc/assets/javascripts/components/tree/templates/tree-item-custom-attribute.mustache
+++ b/src/ggrc/assets/javascripts/components/tree/templates/tree-item-custom-attribute.mustache
@@ -3,12 +3,10 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
 
-{{#values}}
-  {{#get_custom_attr_value column instance .}}
-      {{! because the object can currently only be a
-      person there is no need to switch }}
-      <tree-people-list-field {source}="object">
-          {{peopleStr}}
-      </tree-people-list-field>
-  {{/get_custom_attr_value}}
-{{/values}}
+{{#get_custom_attr_value column instance}}
+    {{! because the object can currently only be a
+    person there is no need to switch }}
+    <tree-people-list-field {source}="object">
+        {{peopleStr}}
+    </tree-people-list-field>
+{{/get_custom_attr_value}}

--- a/src/ggrc/assets/javascripts/components/tree/templates/tree-item-custom-attribute.mustache
+++ b/src/ggrc/assets/javascripts/components/tree/templates/tree-item-custom-attribute.mustache
@@ -4,7 +4,7 @@
 }}
 
 {{#values}}
-  {{#get_custom_attr_value column instance customAttrItem=.}}
+  {{#get_custom_attr_value column instance .}}
       {{! because the object can currently only be a
       person there is no need to switch }}
       <tree-people-list-field {source}="object">

--- a/src/ggrc/assets/javascripts/components/tree/tests/tree-item-custom-attribute_spec.js
+++ b/src/ggrc/assets/javascripts/components/tree/tests/tree-item-custom-attribute_spec.js
@@ -15,6 +15,7 @@ describe('helpers.get_custom_attr_value', function () {
   var fakeCustomAttrDefs;
   var origValue;
   var getHash;
+  var actual;
 
   beforeAll(function () {
     helper = helpers.get_custom_attr_value;
@@ -23,19 +24,49 @@ describe('helpers.get_custom_attr_value', function () {
       definition_type: 'control',
       id: 3,
       attribute_type: '',
-      title: 'Type'
+      title: 'Type',
     },
     {
       definition_type: 'control',
       title: 'CheckBox',
       attribute_type: 'Checkbox',
-      id: 4
+      id: 4,
+    },
+    {
+      definition_type: 'control',
+      title: 'Start Date',
+      attribute_type: 'Date',
+      id: 5,
+    },
+    {
+      definition_type: 'control',
+      title: 'Text',
+      attribute_type: 'Text',
+      id: 6,
+    },
+    {
+      definition_type: 'control',
+      title: 'Rich Text',
+      attribute_type: 'Rich Text',
+      id: 7,
+    },
+    {
+      definition_type: 'control',
+      title: 'Persons',
+      attribute_type: 'Map:Person',
+      id: 8,
     },
     {
       definition_type: 'control',
       title: 'Date',
       attribute_type: 'Date',
-      id: 5
+      id: 9,
+    },
+    {
+      definition_type: 'control',
+      title: 'Dropdown',
+      attribute_type: 'Dropdown',
+      id: 10,
     }];
 
     origValue = GGRC.custom_attr_defs;
@@ -46,8 +77,8 @@ describe('helpers.get_custom_attr_value', function () {
         customAttrItem: {
           attribute_value: attrValue,
           custom_attribute_id: attrId || 3,
-          attributeType: attrType
-        }
+          attributeType: attrType,
+        },
       });
 
       spyOn(value.customAttrItem, 'reify')
@@ -78,84 +109,328 @@ describe('helpers.get_custom_attr_value', function () {
   });
 
   it('return "correctValue"', function () {
-    var value;
     fakeOptions.hash = false;
     fakeInstance.custom_attribute_values = [
-      getHash('correctValue', 3, 'richText').customAttrItem
+      getHash('correctValue', 3, 'richText').customAttrItem,
     ];
-    value = helper(fakeAttr, fakeInstance, fakeOptions);
+    actual = helper(fakeAttr, fakeInstance, fakeOptions);
 
-    expect(value).toEqual('correctValue');
+    expect(actual).toEqual('correctValue');
   });
+
+  it('return correct value if customAttrItem is not undefined',
+    function () {
+      fakeOptions.hash = getHash('correctValue');
+
+      actual = helper(fakeAttr, fakeInstance, fakeOptions);
+
+      expect(actual).toEqual('correctValue');
+    });
 
   it('return an empty string if customAttrItem is undefined', function () {
-    var value;
     fakeOptions.hash = getHash();
-    value = helper(fakeAttr, fakeInstance, fakeOptions);
+    actual = helper(fakeAttr, fakeInstance, fakeOptions);
 
-    expect(value).toEqual('');
+    expect(actual).toEqual('');
   });
 
-  it('fn() exec and return correct value (person type)', function () {
-    fakeOptions = {
-      hash: getHash(),
-      contexts: {
-        add: function () {
-          return 'correctValue';
-        }
-      },
-      fn: function (value) {
-        return value;
-      }
-    };
-    spyOn(fakeOptions, 'fn');
-    fakeCustomAttrDefs[0].attribute_type = 'Map:';
-    helper(fakeAttr, fakeInstance, fakeOptions);
+  describe('for CA of Checkbox type', function () {
+    var attr = {};
 
-    expect(fakeOptions.fn).toHaveBeenCalledWith('correctValue');
+    it('returns empty string when CAD wasn\'t found', function () {
+      fakeOptions = {
+        hash: getHash('10', 3, 'Checkbox'),
+      };
+
+      actual = helper(attr, fakeInstance, fakeOptions);
+
+      expect(actual).toEqual('');
+    });
+
+    it('returns "Yes" for CA of type checkbox with value "1"',
+      function () {
+        attr.attr_name = 'CheckBox';
+        fakeOptions = {
+          hash: getHash('1', 4, 'checkbox'),
+        };
+
+        actual = helper(attr, fakeInstance, fakeOptions);
+
+        expect(actual).toEqual('Yes');
+      });
+
+    it('returns "No" for CA of type checkbox with value "0"',
+      function () {
+        attr.attr_name = 'CheckBox';
+        fakeOptions = {
+          hash: getHash(0, 4, 'checkbox'),
+        };
+
+        actual = helper(attr, fakeInstance, fakeOptions);
+
+        expect(actual).toEqual('No');
+      });
+
+    it('returns empty string for CA of type checkbox without value',
+      function () {
+        attr.attr_name = 'CheckBox';
+        fakeOptions = {
+          hash: getHash(undefined, 4, 'checkbox'),
+        };
+
+        actual = helper(attr, fakeInstance, fakeOptions);
+
+        expect(actual).toEqual('');
+      });
   });
 
-  it('returns "Yes" for CA of type checkbox with value "1"',
-    function () {
-      var attr = {
-        attr_name: 'CheckBox'
-      };
-      var value;
-      fakeOptions = {
-        hash: getHash('1', 4, 'checkbox')
-      };
-
-      value = helper(attr, fakeInstance, fakeOptions);
-
-      expect(value).toEqual('Yes');
-    });
-
-  it('returns "No" for CA of type checkbox with value "0"',
-    function () {
-      var attr = {
-        attr_name: 'CheckBox'
-      };
-      var value;
-      fakeOptions = {
-        hash: getHash(0, 4, 'checkbox')
-      };
-
-      value = helper(attr, fakeInstance, fakeOptions);
-
-      expect(value).toEqual('No');
-    });
-
-  it('returns formatted date', function () {
+  describe('for CA of Date type', function () {
     var attr = {
-      attr_name: 'Date'
-    };
-    var value;
-    fakeOptions = {
-      hash: getHash('2017-09-30', 5, 'Date')
     };
 
-    value = helper(attr, fakeInstance, fakeOptions);
+    it('returns empty string when CAD wasn\'t found', function () {
+      fakeOptions = {
+        hash: getHash('10', 3, 'Date'),
+      };
 
-    expect(value).toEqual('09/30/2017');
+      actual = helper(attr, fakeInstance, fakeOptions);
+
+      expect(actual).toEqual('');
+    });
+
+    it('returns formatted date when CAD was found', function () {
+      var expected = 'expected date';
+      var attrValue = '2017-09-30';
+      attr.attr_name = 'Date';
+      fakeOptions = {
+        hash: getHash(attrValue, 9, 'Date'),
+      };
+      spyOn(GGRC.Utils, 'formatDate')
+        .and.returnValue(expected);
+
+      actual = helper(attr, fakeInstance, fakeOptions);
+
+      expect(actual).toEqual(expected);
+      expect(GGRC.Utils.formatDate)
+        .toHaveBeenCalledWith(attrValue, true);
+    });
+
+    it('tries to format date for existing CAD and undefined value',
+      function () {
+        var expected = 'expected date';
+        var attrValue = undefined;
+        attr.attr_name = 'Date';
+        fakeOptions = {
+          hash: getHash(attrValue, 9, 'Date'),
+        };
+        spyOn(GGRC.Utils, 'formatDate')
+          .and.returnValue(expected);
+
+        actual = helper(attr, fakeInstance, fakeOptions);
+
+        expect(actual).toEqual(expected);
+        expect(GGRC.Utils.formatDate)
+          .toHaveBeenCalledWith(attrValue, true);
+      });
+  });
+
+  describe('for CA of Dropdown type', function () {
+    var attr = {
+    };
+
+    it('returns empty string when CAD wasn\'t found', function () {
+      fakeOptions = {
+        hash: getHash('10', 3, 'Dropdown'),
+      };
+
+      actual = helper(attr, fakeInstance, fakeOptions);
+
+      expect(actual).toEqual('');
+    });
+
+    it('returns attribute value when CAD was found', function () {
+      attr.attr_name = 'Dropdown';
+      fakeOptions = {
+        hash: getHash('10', 10, 'Dropdown'),
+      };
+
+      actual = helper(attr, fakeInstance, fakeOptions);
+
+      expect(actual).toEqual('10');
+    });
+
+    it('returns empty string for existing CAD and undefined value',
+      function () {
+        attr.attr_name = 'Dropdown';
+        fakeOptions = {
+          hash: getHash(undefined, 10, 'Dropdown'),
+        };
+
+        actual = helper(attr, fakeInstance, fakeOptions);
+
+        expect(actual).toEqual('');
+      });
+  });
+
+  describe('for CA of Text type', function () {
+    var attr = {
+    };
+
+    it('returns empty string when CAD wasn\'t found', function () {
+      fakeOptions = {
+        hash: getHash('10', 3, 'Text'),
+      };
+
+      actual = helper(attr, fakeInstance, fakeOptions);
+
+      expect(actual).toEqual('');
+    });
+
+    it('returns attribute value when CAD was found', function () {
+      attr.attr_name = 'Text';
+      fakeOptions = {
+        hash: getHash('10', 6, 'Text'),
+      };
+
+      actual = helper(attr, fakeInstance, fakeOptions);
+
+      expect(actual).toEqual('10');
+    });
+
+    it('returns empty string for existing CAD and undefined value',
+      function () {
+        attr.attr_name = 'Text';
+        fakeOptions = {
+          hash: getHash(undefined, 6, 'Text'),
+        };
+
+        actual = helper(attr, fakeInstance, fakeOptions);
+
+        expect(actual).toEqual('');
+      });
+  });
+
+  describe('for CA of Rich Text type', function () {
+    var attr = {
+    };
+
+    it('returns empty string when CAD wasn\'t found', function () {
+      fakeOptions = {
+        hash: getHash('10', 3, 'Rich Text'),
+      };
+
+      actual = helper(attr, fakeInstance, fakeOptions);
+
+      expect(actual).toEqual('');
+    });
+
+    it('returns attribute value when CAD was found', function () {
+      attr.attr_name = 'Rich Text';
+      fakeOptions = {
+        hash: getHash('10', 7, 'Rich Text'),
+      };
+
+      actual = helper(attr, fakeInstance, fakeOptions);
+
+      expect(actual).toEqual('10');
+    });
+
+    it('returns empty string for existing CAD and undefined value',
+      function () {
+        attr.attr_name = 'Rich Text';
+        fakeOptions = {
+          hash: getHash(undefined, 7, 'Rich Text'),
+        };
+
+        actual = helper(attr, fakeInstance, fakeOptions);
+
+        expect(actual).toEqual('');
+      });
+  });
+
+  describe('for CA of Map:Person type', function () {
+    var attr = {
+    };
+
+    it('returns empty string when CAD wasn\'t found', function () {
+      fakeOptions = {
+        hash: getHash(null, 3, 'Map:Person'),
+      };
+
+      actual = helper(attr, fakeInstance, fakeOptions);
+
+      expect(actual).toEqual('');
+    });
+
+    describe('when object was provided in attribute', function () {
+      var expected = 'expected persons';
+      var addItemResult = 'added item';
+      var actualObject = {};
+
+      beforeEach(function () {
+        var hash = getHash(undefined, 8, 'Map:Person');
+        hash.customAttrItem.attribute_object = {
+          reify: jasmine.createSpy('reify').and.returnValue(actualObject),
+        };
+        attr.attr_name = 'Persons';
+        fakeOptions = {
+          hash: hash,
+          contexts: {
+            add: jasmine.createSpy('add').and.returnValue(addItemResult),
+          },
+          fn: jasmine.createSpy('fn').and.returnValue(expected),
+        };
+
+        actual = helper(attr, fakeInstance, fakeOptions);
+      });
+
+      it('returns expected result', function () {
+        expect(actual).toEqual(expected);
+      });
+
+      it('reify object attribute', function () {
+        expect(fakeOptions.hash.customAttrItem.attribute_object.reify)
+          .toHaveBeenCalled();
+      });
+
+      it('adds object to contexts list', function () {
+        expect(fakeOptions.contexts.add)
+          .toHaveBeenCalledWith({object: actualObject});
+      });
+
+      it('makes mustache fn-call', function () {
+        expect(fakeOptions.fn).toHaveBeenCalled();
+      });
+    });
+
+    describe('when object wasn\'t provided in attribute', function () {
+      var expected = 'expected persons';
+      var addItemResult = 'added item';
+
+      beforeEach(function () {
+        attr.attr_name = 'Persons';
+        fakeOptions = {
+          hash: getHash(undefined, 8, 'Map:Person'),
+          contexts: {
+            add: jasmine.createSpy('add').and.returnValue(addItemResult),
+          },
+          fn: jasmine.createSpy('fn').and.returnValue(expected),
+        };
+
+        actual = helper(attr, fakeInstance, fakeOptions);
+      });
+
+      it('returns expected result', function () {
+        expect(actual).toEqual(expected);
+      });
+
+      it('adds object to contexts list', function () {
+        expect(fakeOptions.contexts.add).toHaveBeenCalledWith({object: null});
+      });
+
+      it('makes mustache fn-call', function () {
+        expect(fakeOptions.fn).toHaveBeenCalled();
+      });
+    });
   });
 });

--- a/src/ggrc/assets/javascripts/components/tree/tests/tree-item-custom-attribute_spec.js
+++ b/src/ggrc/assets/javascripts/components/tree/tests/tree-item-custom-attribute_spec.js
@@ -110,18 +110,6 @@ describe('helpers.get_custom_attr_value', function () {
     expect(customAttrItem.reify).toHaveBeenCalled();
   });
 
-  it('return "correctValue"', function () {
-    var item = getCustomAttrItem('correctValue', 3, 'richText');
-    spyOn(item, 'reify')
-      .and.returnValue(item);
-    fakeInstance.custom_attribute_values = [
-      item,
-    ];
-    actual = helper(fakeAttr, fakeInstance, undefined, fakeOptions);
-
-    expect(actual).toEqual('correctValue');
-  });
-
   it('return correct value if customAttrItem is not undefined',
     function () {
       setCustomAttrItem('correctValue');

--- a/src/ggrc/assets/javascripts/components/tree/tests/tree-item-custom-attribute_spec.js
+++ b/src/ggrc/assets/javascripts/components/tree/tests/tree-item-custom-attribute_spec.js
@@ -73,6 +73,9 @@ describe('helpers.get_custom_attr_value', function () {
 
     origValue = GGRC.custom_attr_defs;
     GGRC.custom_attr_defs = fakeCustomAttrDefs;
+    fakeInstance = new can.Map({
+      custom_attribute_values: [],
+    });
 
     getCustomAttrItem = function (attrValue, attrId, attrType) {
       return new can.Map({
@@ -84,6 +87,7 @@ describe('helpers.get_custom_attr_value', function () {
 
     setCustomAttrItem = function (attrValue, attrId, attrType) {
       customAttrItem = getCustomAttrItem(attrValue, attrId, attrType);
+      fakeInstance.attr('custom_attribute_values.0', customAttrItem);
 
       spyOn(customAttrItem, 'reify')
         .and.returnValue(customAttrItem);
@@ -95,7 +99,6 @@ describe('helpers.get_custom_attr_value', function () {
   });
 
   beforeEach(function () {
-    fakeInstance = {};
     fakeAttr = {};
     fakeOptions = {};
     fakeInstance.class = {table_singular: 'control'};
@@ -105,7 +108,7 @@ describe('helpers.get_custom_attr_value', function () {
 
   it('reify() is exec if instance is not an Assessment', function () {
     setCustomAttrItem();
-    helper(fakeAttr, fakeInstance, customAttrItem, fakeOptions);
+    helper(fakeAttr, fakeInstance, fakeOptions);
 
     expect(customAttrItem.reify).toHaveBeenCalled();
   });
@@ -114,7 +117,7 @@ describe('helpers.get_custom_attr_value', function () {
     function () {
       setCustomAttrItem('correctValue');
 
-      actual = helper(fakeAttr, fakeInstance, customAttrItem, fakeOptions);
+      actual = helper(fakeAttr, fakeInstance, fakeOptions);
 
       expect(actual).toEqual('correctValue');
     });
@@ -122,7 +125,7 @@ describe('helpers.get_custom_attr_value', function () {
   it('return an empty string if customAttrItem is undefined', function () {
     setCustomAttrItem();
 
-    actual = helper(fakeAttr, fakeInstance, customAttrItem, fakeOptions);
+    actual = helper(fakeAttr, fakeInstance, fakeOptions);
 
     expect(actual).toEqual('');
   });
@@ -133,7 +136,7 @@ describe('helpers.get_custom_attr_value', function () {
     it('returns empty string when CAD wasn\'t found', function () {
       setCustomAttrItem('10', 3, 'Checkbox');
 
-      actual = helper(attr, fakeInstance, customAttrItem, fakeOptions);
+      actual = helper(attr, fakeInstance, fakeOptions);
 
       expect(actual).toEqual('');
     });
@@ -143,7 +146,7 @@ describe('helpers.get_custom_attr_value', function () {
         attr.attr_name = 'CheckBox';
         setCustomAttrItem('1', 4, 'checkbox');
 
-        actual = helper(attr, fakeInstance, customAttrItem, fakeOptions);
+        actual = helper(attr, fakeInstance, fakeOptions);
 
         expect(actual).toEqual('Yes');
       });
@@ -153,7 +156,7 @@ describe('helpers.get_custom_attr_value', function () {
         attr.attr_name = 'CheckBox';
         setCustomAttrItem(0, 4, 'checkbox');
 
-        actual = helper(attr, fakeInstance, customAttrItem, fakeOptions);
+        actual = helper(attr, fakeInstance, fakeOptions);
 
         expect(actual).toEqual('No');
       });
@@ -163,7 +166,7 @@ describe('helpers.get_custom_attr_value', function () {
         attr.attr_name = 'CheckBox';
         setCustomAttrItem(undefined, 4, 'checkbox');
 
-        actual = helper(attr, fakeInstance, customAttrItem, fakeOptions);
+        actual = helper(attr, fakeInstance, fakeOptions);
 
         expect(actual).toEqual('');
       });
@@ -176,7 +179,7 @@ describe('helpers.get_custom_attr_value', function () {
     it('returns empty string when CAD wasn\'t found', function () {
       setCustomAttrItem('10', 3, 'Date');
 
-      actual = helper(attr, fakeInstance, customAttrItem, fakeOptions);
+      actual = helper(attr, fakeInstance, fakeOptions);
 
       expect(actual).toEqual('');
     });
@@ -189,7 +192,7 @@ describe('helpers.get_custom_attr_value', function () {
       spyOn(GGRC.Utils, 'formatDate')
         .and.returnValue(expected);
 
-      actual = helper(attr, fakeInstance, customAttrItem, fakeOptions);
+      actual = helper(attr, fakeInstance, fakeOptions);
 
       expect(actual).toEqual(expected);
       expect(GGRC.Utils.formatDate)
@@ -205,7 +208,7 @@ describe('helpers.get_custom_attr_value', function () {
         spyOn(GGRC.Utils, 'formatDate')
           .and.returnValue(expected);
 
-        actual = helper(attr, fakeInstance, customAttrItem, fakeOptions);
+        actual = helper(attr, fakeInstance, fakeOptions);
 
         expect(actual).toEqual(expected);
         expect(GGRC.Utils.formatDate)
@@ -220,7 +223,7 @@ describe('helpers.get_custom_attr_value', function () {
     it('returns empty string when CAD wasn\'t found', function () {
       setCustomAttrItem('10', 3, 'Dropdown');
 
-      actual = helper(attr, fakeInstance, customAttrItem, fakeOptions);
+      actual = helper(attr, fakeInstance, fakeOptions);
 
       expect(actual).toEqual('');
     });
@@ -229,7 +232,7 @@ describe('helpers.get_custom_attr_value', function () {
       attr.attr_name = 'Dropdown';
       setCustomAttrItem('10', 10, 'Dropdown');
 
-      actual = helper(attr, fakeInstance, customAttrItem, fakeOptions);
+      actual = helper(attr, fakeInstance, fakeOptions);
 
       expect(actual).toEqual('10');
     });
@@ -239,7 +242,7 @@ describe('helpers.get_custom_attr_value', function () {
         attr.attr_name = 'Dropdown';
         setCustomAttrItem(undefined, 10, 'Dropdown');
 
-        actual = helper(attr, fakeInstance, customAttrItem, fakeOptions);
+        actual = helper(attr, fakeInstance, fakeOptions);
 
         expect(actual).toEqual('');
       });
@@ -252,7 +255,7 @@ describe('helpers.get_custom_attr_value', function () {
     it('returns empty string when CAD wasn\'t found', function () {
       setCustomAttrItem('10', 3, 'Text');
 
-      actual = helper(attr, fakeInstance, customAttrItem, fakeOptions);
+      actual = helper(attr, fakeInstance, fakeOptions);
 
       expect(actual).toEqual('');
     });
@@ -261,7 +264,7 @@ describe('helpers.get_custom_attr_value', function () {
       attr.attr_name = 'Text';
       setCustomAttrItem('10', 6, 'Text');
 
-      actual = helper(attr, fakeInstance, customAttrItem, fakeOptions);
+      actual = helper(attr, fakeInstance, fakeOptions);
 
       expect(actual).toEqual('10');
     });
@@ -271,7 +274,7 @@ describe('helpers.get_custom_attr_value', function () {
         attr.attr_name = 'Text';
         setCustomAttrItem(undefined, 6, 'Text');
 
-        actual = helper(attr, fakeInstance, customAttrItem, fakeOptions);
+        actual = helper(attr, fakeInstance, fakeOptions);
 
         expect(actual).toEqual('');
       });
@@ -284,7 +287,7 @@ describe('helpers.get_custom_attr_value', function () {
     it('returns empty string when CAD wasn\'t found', function () {
       setCustomAttrItem('10', 3, 'Rich Text');
 
-      actual = helper(attr, fakeInstance, customAttrItem, fakeOptions);
+      actual = helper(attr, fakeInstance, fakeOptions);
 
       expect(actual).toEqual('');
     });
@@ -293,7 +296,7 @@ describe('helpers.get_custom_attr_value', function () {
       attr.attr_name = 'Rich Text';
       setCustomAttrItem('10', 7, 'Rich Text');
 
-      actual = helper(attr, fakeInstance, customAttrItem, fakeOptions);
+      actual = helper(attr, fakeInstance, fakeOptions);
 
       expect(actual).toEqual('10');
     });
@@ -303,7 +306,7 @@ describe('helpers.get_custom_attr_value', function () {
         attr.attr_name = 'Rich Text';
         setCustomAttrItem(undefined, 7, 'Rich Text');
 
-        actual = helper(attr, fakeInstance, customAttrItem, fakeOptions);
+        actual = helper(attr, fakeInstance, fakeOptions);
 
         expect(actual).toEqual('');
       });
@@ -315,7 +318,7 @@ describe('helpers.get_custom_attr_value', function () {
     it('returns empty string when CAD wasn\'t found', function () {
       setCustomAttrItem(null, 3, 'Map:Person');
 
-      actual = helper(attr, fakeInstance, customAttrItem, fakeOptions);
+      actual = helper(attr, fakeInstance, fakeOptions);
 
       expect(actual).toEqual('');
     });
@@ -327,9 +330,12 @@ describe('helpers.get_custom_attr_value', function () {
 
       beforeEach(function () {
         setCustomAttrItem(undefined, 8, 'Map:Person');
-        customAttrItem.attribute_object = {
-          reify: jasmine.createSpy('reify').and.returnValue(actualObject),
-        };
+        customAttrItem.attr('attribute_object', {
+          reify: function () {},
+        });
+        spyOn(customAttrItem.attr('attribute_object'), 'reify')
+          .and.returnValue(actualObject);
+
         attr.attr_name = 'Persons';
         fakeOptions = {
           contexts: {
@@ -338,7 +344,7 @@ describe('helpers.get_custom_attr_value', function () {
           fn: jasmine.createSpy('fn').and.returnValue(expected),
         };
 
-        actual = helper(attr, fakeInstance, customAttrItem, fakeOptions);
+        actual = helper(attr, fakeInstance, fakeOptions);
       });
 
       it('returns expected result', function () {
@@ -374,7 +380,7 @@ describe('helpers.get_custom_attr_value', function () {
           fn: jasmine.createSpy('fn').and.returnValue(expected),
         };
 
-        actual = helper(attr, fakeInstance, customAttrItem, fakeOptions);
+        actual = helper(attr, fakeInstance, fakeOptions);
       });
 
       it('returns expected result', function () {

--- a/src/ggrc/assets/javascripts/components/tree/tree-item-custom-attribute.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-item-custom-attribute.js
@@ -21,12 +21,17 @@ var helpers = {
     var customAttrItem;
     var getValue;
     var formatValueMap = {
-      Checkbox: function (value) {
-        return ['No', 'Yes'][value];
+      Checkbox: function (item) {
+        return ['No', 'Yes'][item.attribute_value];
       },
-      Date: function (value) {
-        return GGRC.Utils.formatDate(value, true);
-      }
+      Date: function (item) {
+        return GGRC.Utils.formatDate(item.attribute_value, true);
+      },
+      'Map:Person': function (item) {
+        return options.fn(options.contexts.add({
+          object: item.attribute_object ? item.attribute_object.reify() : null,
+        }));
+      },
     };
 
     attr = Mustache.resolve(attr);
@@ -50,14 +55,9 @@ var helpers = {
           item = item.reify();
         }
         if (item.custom_attribute_id === definition.id) {
-          if (definition.attribute_type.startsWith('Map:')) {
-            value = options.fn(options.contexts.add({
-              object: item.attribute_object ?
-                item.attribute_object.reify() : null
-            }));
-          } else if (formatValueMap[definition.attribute_type]) {
+          if (formatValueMap[definition.attribute_type]) {
             value =
-              formatValueMap[definition.attribute_type](item.attribute_value);
+              formatValueMap[definition.attribute_type](item);
           } else {
             value = item.attribute_value;
           }

--- a/src/ggrc/assets/javascripts/components/tree/tree-item-custom-attribute.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-item-custom-attribute.js
@@ -18,7 +18,6 @@ var helpers = {
   get_custom_attr_value: function (attr, instance, customAttrItem, options) {
     var value = '';
     var definition;
-    var getValue;
     var formatValueMap = {
       Checkbox: function (item) {
         return ['No', 'Yes'][item.attribute_value];
@@ -45,26 +44,18 @@ var helpers = {
     });
 
     if (definition) {
-      getValue = function (item) {
-        if (!(instance instanceof CMS.Models.Assessment)) {
-          // reify all models with the exception of the Assessment,
-          // because it has a different logic of work with the CA
-          item = item.reify();
+      if (!(instance instanceof CMS.Models.Assessment)) {
+        // reify all models with the exception of the Assessment,
+        // because it has a different logic of work with the CA
+        customAttrItem = customAttrItem.reify();
+      }
+      if (customAttrItem.custom_attribute_id === definition.id) {
+        if (formatValueMap[definition.attribute_type]) {
+          value =
+            formatValueMap[definition.attribute_type](customAttrItem);
+        } else {
+          value = customAttrItem.attribute_value;
         }
-        if (item.custom_attribute_id === definition.id) {
-          if (formatValueMap[definition.attribute_type]) {
-            value =
-              formatValueMap[definition.attribute_type](item);
-          } else {
-            value = item.attribute_value;
-          }
-        }
-      };
-
-      if (!_.isUndefined(customAttrItem)) {
-        getValue(customAttrItem);
-      } else {
-        can.each(instance.custom_attribute_values, getValue);
       }
     }
 

--- a/src/ggrc/assets/javascripts/components/tree/tree-item-custom-attribute.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-item-custom-attribute.js
@@ -15,10 +15,9 @@ var helpers = {
   /*
     Used to get the string value for custom attributes
   */
-  get_custom_attr_value: function (attr, instance, options) {
+  get_custom_attr_value: function (attr, instance, customAttrItem, options) {
     var value = '';
     var definition;
-    var customAttrItem;
     var getValue;
     var formatValueMap = {
       Checkbox: function (item) {
@@ -36,9 +35,7 @@ var helpers = {
 
     attr = Mustache.resolve(attr);
     instance = Mustache.resolve(instance);
-    customAttrItem = Mustache.resolve(
-      (options.hash || {}).customAttrItem
-    );
+    customAttrItem = Mustache.resolve(customAttrItem);
 
     can.each(GGRC.custom_attr_defs, function (item) {
       if (item.definition_type === instance.class.table_singular &&


### PR DESCRIPTION
 # Issue description

Clean up code for displaying custom attribute values in tree view. Fix performance issue (loop over CAV on Mustache-view).

# Steps to reproduce

1) Create different types of custom attributes (Text, Rich Text, Dropdown, Date, Checkbox, Map:Person) for different types of objects (at least for Assessment and one non-assessment object).
2) Open objects list tab on Dashboard and make these fields visible/invisible in tree view.
3) Open Info pin on objects list tab and try to update custom attribute.
Expected result: custom attributes should be loaded and refreshed correctly in tree view on 2 and 3 steps.

# Solution description

This PR aims solve 2 issues: make code for displaying custom attributes more reliable and fix performance issue caused by redundant loops over all custom attribute values. The proposed solution comprises the following steps:
1) Improve code coverage with unit tests for different custom attribute types.
2) Make code more readable by applying standard approach for 'Map:Person' display value generation.
3) Remove redundant custom attribute population logic from Mustache-view.
4) Remove redundant function in mustache-helper (cause we already know that helper will be used for defined custom attribute).
5) Fix performance issue caused by looping over custom attribute values on Mustache-view.


# Sanity check list

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct labels.
- [x] My changes fix the issue described in the description.
- [x] My changes are covered by tests.
- [x] My changes follow the [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/performance.rst).
- [x] My changes follow the [js](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/javascript.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/git/how_to_write_a_commit_message.rst).
