### PR TITLE
GGRC-3091 Fix UI issues with object's long title

### DIFF
--- a/src/ggrc/assets/mustache/assessments/modal_content_additional_fields.mustache
+++ b/src/ggrc/assets/mustache/assessments/modal_content_additional_fields.mustache
@@ -113,7 +113,7 @@
     <label class="ggrc-form-item__label">
       Audit
     </label>
-    <div>
+    <div class="ggrc-form-item__text">
       {{instance.audit.title}}
     </div>
   </div>

--- a/src/ggrc/assets/mustache/components/related-objects/related-issues.mustache
+++ b/src/ggrc/assets/mustache/components/related-objects/related-issues.mustache
@@ -23,7 +23,7 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
         <object-list {items}="relatedObjects" {is-loading}="isLoading" spinner-css="grid-spinner">
             <div class="grid-data-row flex-row flex-box">
                 <div class="flex-size-2">
-                    <a href="{{instance.viewLink}}" target="_blank">
+                    <a href="{{instance.viewLink}}" target="_blank" class="grid-data-item__title-cell">
                       {{instance.title}}
                     </a>
                 </div>

--- a/src/ggrc/assets/stylesheets/components/form/_ggrc-form.scss
+++ b/src/ggrc/assets/stylesheets/components/form/_ggrc-form.scss
@@ -104,6 +104,10 @@
       margin-bottom: 5px;
     }
 
+    &__text {
+      word-wrap: break-word;
+    }
+
     .ggrc-form-item__small-text {
       opacity: 0.7;
       color: gray;

--- a/src/ggrc/assets/stylesheets/components/grid-data/_grid-data.scss
+++ b/src/ggrc/assets/stylesheets/components/grid-data/_grid-data.scss
@@ -152,6 +152,7 @@
     text-overflow: ellipsis;
     -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
+    word-wrap: break-word;
   }
 }
 .grid-data__action-column {

--- a/src/ggrc/assets/stylesheets/components/mapped-objects/_mapped-objects.scss
+++ b/src/ggrc/assets/stylesheets/components/mapped-objects/_mapped-objects.scss
@@ -78,6 +78,7 @@
     width: 100%;
     padding: 0 8px 0 28px;
     box-sizing: border-box;
+    word-wrap: break-word;
   }
 
   .more-information-wrapper {
@@ -254,6 +255,7 @@ directly-mapped-objects {
       align-self: center;
       line-height: 50px;
       margin-bottom: 5px;
+      min-width: 0;
     }
 
     .modal-mapped-objects-item__unmap {

--- a/src/ggrc/assets/stylesheets/components/tree/_tree-view.scss
+++ b/src/ggrc/assets/stylesheets/components/tree/_tree-view.scss
@@ -174,6 +174,7 @@ tree-item {
 
     .flex-box.selectable-attrs {
       flex-wrap: wrap;
+      min-width: 0; 
     }
 
     .attr-cell {

--- a/src/ggrc/assets/stylesheets/modules/_log-list.scss
+++ b/src/ggrc/assets/stylesheets/modules/_log-list.scss
@@ -6,7 +6,8 @@
 .third-col {
   float: left;
   width: 30%;
-  margin-right: 3.33%
+  margin-right: 3.33%;
+  word-wrap: break-word;
 }
 
 .instruction {

--- a/src/ggrc/assets/stylesheets/modules/_modal.scss
+++ b/src/ggrc/assets/stylesheets/modules/_modal.scss
@@ -223,6 +223,7 @@
       font-weight: normal;
       color: $subTitle;
       font-family: $fontTitle;
+      word-wrap: break-word;
 
       span {
         display: block;

--- a/src/ggrc/assets/stylesheets/modules/_notifications.scss
+++ b/src/ggrc/assets/stylesheets/modules/_notifications.scss
@@ -77,6 +77,8 @@
   @include border-radius(2px);
   border: 1px solid;
   margin-bottom: 20px;
+  word-wrap: break-word;
+  
   p {
     margin-bottom: 0;
   }

--- a/src/ggrc/assets/stylesheets/modules/_object-header.scss
+++ b/src/ggrc/assets/stylesheets/modules/_object-header.scss
@@ -8,6 +8,7 @@
     max-width: 80%;
     float: left;
     margin-right: 8px;
+    word-wrap: break-word;
   }
   &.pane-header__fixed {
     right: 52px;


### PR DESCRIPTION
# Steps to reproduce
1. Have a program, mapped control with long title, audit
2. On the audit page create assessment and map control snapshot to assessment 
3. There are UI issues on:

Tree view 
<img width="300" alt="screen shot 2017-10-09 at 4 05 32 pm" src="https://user-images.githubusercontent.com/3773902/31339510-c044f14e-ad0b-11e7-906c-14143e3d01f2.png">

Info pane modal/page
<img width="300" alt="screen shot 2017-10-09 at 4 05 32 pm" src="https://user-images.githubusercontent.com/3773902/31339666-450bfb7a-ad0c-11e7-9409-6065570fd5da.png">

Assessment info pane and create/edit modal
<img width="300" alt="screen shot 2017-10-09 at 4 05 32 pm" src="https://user-images.githubusercontent.com/3773902/31339818-cf8b79e2-ad0c-11e7-99aa-d159cfffe293.png">   <img width="300" alt="screen shot 2017-10-09 at 4 05 32 pm" src="https://user-images.githubusercontent.com/3773902/31339887-041a472e-ad0d-11e7-9116-e5616e173f38.png">

<img width="300" alt="screen shot 2017-10-09 at 4 05 32 pm" src="https://user-images.githubusercontent.com/3773902/31339792-b987eb62-ad0c-11e7-9197-4a6372018e17.png"> 

Unified mapper
<img width="300" alt="screen shot 2017-10-09 at 4 05 32 pm" src="https://user-images.githubusercontent.com/3773902/31339751-8ef40d18-ad0c-11e7-8f17-86e8371a0d08.png">

Change Log
<img width="300" alt="screen shot 2017-10-09 at 4 05 32 pm" src="https://user-images.githubusercontent.com/3773902/31339853-e965f608-ad0c-11e7-9a0e-1e255116dd27.png">



 
