### PR TITLE
GGRC-3188 Set default 'Object Type' on Unified Mapper

### DIFF
--- a/src/ggrc/assets/mustache/base_templates/mapped_objects.mustache
+++ b/src/ggrc/assets/mustache/base_templates/mapped_objects.mustache
@@ -19,11 +19,9 @@
         class="btn btn-white btn-small"
         href="javascript://"
         rel="tooltip"
-        data-type="Program"
         data-placement="right"
         data-toggle="unified-mapper"
         data-join-mapping="related_objects"
-        data-join-option-type="{{model.shortName}}"
         data-join-object-id="{{instance.id}}"
         data-join-object-type="{{instance.class.shortName}}"
         data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty instance.class.title_singular 'Object'}}">


### PR DESCRIPTION
# Issue description

Set default 'Object Type' on Unified Mapper
[spec](https://docs.google.com/spreadsheets/d/11CHxbJZHPwD8rc9-4xCDnHbhQ4SE2SKDJcGxckuk2MQ/edit#gid=0)

# Steps to reproduce

1. Create WF'
2. On the WF page in the setup tab add a task
3. Activate WF
4. Go to Active Cycles tab > Expand third level with cycle task
5. Expand cycle task info pane
6. Click 'Map object' button: default object is 'Program'

# Solution description

This PR contains the fix for case Vadim found:
On CycleTask info-pane default type was overridden.
`mapped_objects.mustache` is used only on CycleTask info-pane


# Sanity check list

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests (if not, include a reason).
- [x] My changes follow the [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/performance.rst).
- [x] My changes follow the [js](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] db_reset runs without errors or warnings
- [ ] db_reset ggrc-qa.sql runs without errors or warnings
-->

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
