### PR TITLE
GGRC-2851 Deny unmap:Audit if Issue mapped to an Assessment/Snapshot

### DIFF
--- a/src/ggrc/converters/errors.py
+++ b/src/ggrc/converters/errors.py
@@ -138,3 +138,7 @@ VALIDATION_ERROR = (u"Line {line}: Field '{column_name}' validation failed "
 SINGLE_AUDIT_RESTRICTION = (u"Line {line}: You can not map {mapped_type} to "
                             u"{object_type}, because this {object_type} is "
                             u"already mapped to an {mapped_type}")
+
+UNMAP_AUDIT_RESTRICTION = (u"Line {line}: You can not unmap {mapped_type} "
+                           u"from {object_type} because this {object_type} is "
+                           u"mapped to an {mapped_type}-scope object.")

--- a/src/ggrc/converters/handlers/handlers.py
+++ b/src/ggrc/converters/handlers/handlers.py
@@ -450,7 +450,13 @@ class MappingColumnHandler(ColumnHandler):
                            mapped_type=obj.type,
                            object_type=current_obj.type)
       elif self.unmap and mapping:
-        db.session.delete(mapping)
+        if not (self.mapping_object.__name__ == "Audit" and
+                not getattr(current_obj, "allow_unmap_from_audit", True)):
+          db.session.delete(mapping)
+        else:
+          self.add_warning(errors.UNMAP_AUDIT_RESTRICTION,
+                           mapped_type=obj.type,
+                           object_type=current_obj.type)
     db.session.flush()
     self.dry_run = True
 


### PR DESCRIPTION
# Issue description

If an Issue is mapped to an Assessment, when you try to unmap the Audit from the Issue through the imports, the backend crashes.

# Steps to reproduce

1. Create an Audit.
2. Create an Assessment.
3. Raise an Issue in the Assessment.
4. Export the Issue.
5. Rename "map:Audit" to "unmap:Audit" column.
6. Import the CSV.

Actual result: the backend complains of an uncaught exception.
Expected result: a warning is shown that it is impossible to unmap the Audit.

# Solution description

This is a quick fix that checks the flag that blocks this unmapping before trying to unmap. The warning is not shown during dry run, and it should be addressed at some point.

# Sanity check list

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else).
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/git/how_to_write_a_commit_message.rst).

- [ ] My changes are covered by tests (if not, include a reason).

The whole Issue import/export part should be covered with tests in one single PR (GGRC-3565).