### PR TITLE
QUICK-FIX Make sure we only build_assets once when deploying

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,10 +135,7 @@ misspell :
 
 ## Deployment!
 
-src/ggrc/assets/stylesheets/dashboard.css : src/ggrc/assets/stylesheets/*.scss
-	bin/build_assets -p
-
-src/ggrc/assets/assets.manifest : src/ggrc/assets/stylesheets/dashboard.css src/ggrc/assets
+src/ggrc/assets/assets.manifest : src/ggrc/assets
 	source "bin/init_env"; \
 		GGRC_SETTINGS_MODULE="$(SETTINGS_MODULE)" bin/build_assets
 


### PR DESCRIPTION
We used to have a different script for building css and js, so we needed
to run build_css on dashboard.css changes. Now we have a single
build_assets script that does everything and doesn't need to be called
twice.

I have mentioned this issue in https://github.com/google/ggrc-core/pull/6565