### PR TITLE
GGRC-3564 In the new assessment modal Issues are displayed in Unified mapper as already mapped 

### DIFF
--- a/src/ggrc/assets/javascripts/components/object-mapper/object-mapper.js
+++ b/src/ggrc/assets/javascripts/components/object-mapper/object-mapper.js
@@ -65,8 +65,9 @@
       );
 
       return GGRC.VM.ObjectOperationsBaseVM.extend({
-        join_object_id: resolvedConfig['join-object-id'] ||
-           (GGRC.page_instance() && GGRC.page_instance().id),
+        join_object_id: resolvedConfig.isNew ? null :
+          resolvedConfig['join-object-id'] ||
+          (GGRC.page_instance() && GGRC.page_instance().id),
         object: resolvedConfig.object,
         type: getDefaultType(resolvedConfig.type, resolvedConfig.object),
         config: config,

--- a/src/ggrc/assets/javascripts/components/object-mapper/tests/object-mapper_spec.js
+++ b/src/ggrc/assets/javascripts/components/object-mapper/tests/object-mapper_spec.js
@@ -28,6 +28,30 @@ describe('GGRC.Components.objectMapper', function () {
         special: [],
       });
     });
+
+    it(`initializes join_object_id with "join-object-id"
+    if isNew flag is not passed`,
+    function () {
+      parentViewModel.attr('general.join-object-id', 'testId');
+      let result = Component.prototype.viewModel({}, parentViewModel)();
+      expect(result.join_object_id).toBe('testId');
+    });
+
+    it(`initializes join_object_id with page instance id if
+    "join-object-id" and "isNew" are not passed`,
+    function () {
+      spyOn(GGRC, 'page_instance').and.returnValue({id: 'testId'});
+      let result = Component.prototype.viewModel({}, parentViewModel)();
+      expect(result.join_object_id).toBe('testId');
+    });
+
+    it('initializes join_object_id with null if isNew flag is passed',
+    function () {
+      parentViewModel.attr('general.isNew', true);
+      let result = Component.prototype.viewModel({}, parentViewModel)();
+      expect(result.join_object_id).toBe(null);
+    });
+
     it('returns object with function "isLoadingOrSaving"', function () {
       var result = Component.prototype.viewModel({}, parentViewModel)();
       expect(result.isLoadingOrSaving).toEqual(jasmine.any(Function));

--- a/src/ggrc/assets/javascripts/controllers/mapper.js
+++ b/src/ggrc/assets/javascripts/controllers/mapper.js
@@ -98,6 +98,7 @@ import '../components/unified-mapper/mapper-results';
           _.extend(config.general, {
             object: data.join_object_type,
             type: data.join_option_type,
+            isNew: true,
             relevantTo: [{
               readOnly: true,
               type: data.snapshot_scope_type,

--- a/src/ggrc/assets/javascripts/controllers/tests/mapper_spec.js
+++ b/src/ggrc/assets/javascripts/controllers/tests/mapper_spec.js
@@ -91,8 +91,8 @@ describe('GGRC.Controllers.ObjectMapper', function () {
         });
       });
 
-      it('extends generalConfig with "object", "type" and "relevantTo" if ' +
-      'data has is_new',
+      it(`extends generalConfig with "object", "type" "isNew" and "relevantTo"
+      'if data has is_new`,
       function (done) {
         var args;
         method(_.extend(fakeData, {
@@ -108,6 +108,7 @@ describe('GGRC.Controllers.ObjectMapper', function () {
               general: jasmine.objectContaining({
                 object: fakeData.join_object_type,
                 type: fakeData.join_option_type,
+                isNew: true,
                 relevantTo: jasmine.any(Array),
               }),
             })


### PR DESCRIPTION
# Issue description

Object-mapped is initialized with page instance id.
In this case id should be null.

# Steps to reproduce

Precondition:
1. Have audit with created Issue

Steps to reproduce:
1. On the audit page Invoke New Assessment modal window
2. Click Map objects button
3. Select object type 'Issues' 
4. Click Search 
5. Look at the Search results: Issues that are not mapped to Assessment are shown up as mapped

*Actual Result:* In the new assessment modal Issues are displayed in Unified mapper as already mapped 
*Expected Result:* Issues should not be shown as mapped in Unified mapper in the new assessment modal

# Solution description

Actually the bug is regression caused by splitting unified mapper into 3 components.
In some cases there is`is_new` flag that indicates that id should be null.

# Sanity check list

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests (if not, include a reason).
- [x] My changes follow the [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/performance.rst).
- [x] My changes follow the [js](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] db_reset runs without errors or warnings
- [ ] db_reset ggrc-qa.sql runs without errors or warnings
-->

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
