### PR TITLE
GGRC-3154 Fix issue with updating mapped snapshots after Assessment editing

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/modals_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/modals_controller.js
@@ -1214,6 +1214,7 @@ import '../components/access_control_list/access_control_list_roles_helper'
           this.options.instance.attr('custom_attribute_definitions', cad);
         }
         this.options.instance.refresh();
+        this.options.instance.dispatch('refreshMapping');
       }
     },
 

--- a/test/selenium/src/tests/test_asmts_workflow.py
+++ b/test/selenium/src/tests/test_asmts_workflow.py
@@ -294,8 +294,4 @@ class TestAssessmentsWorkflow(base.Test):
         expected_asmt.update_attrs(updated_at=self.info_service.get_obj(
             obj=expected_asmt).updated_at).repr_ui())
     actual_asmt = asmts_ui_service.get_obj_from_info_page(expected_asmt)
-    self.general_equal_assert(
-        expected_asmt, actual_asmt, "objects_under_assessment")
-    self.xfail_equal_assert(
-        expected_asmt, actual_asmt,
-        "Issue in app GGRC-3154", "objects_under_assessment")
+    self.general_equal_assert(expected_asmt, actual_asmt)


### PR DESCRIPTION
# Steps to reproduce
1. Have audit with control snapshot and assessment
2. Open edit assessment modal window, fill required fields and map control snapshot > Save
3. Expand Assessment Info pane
4. Look at the control section: control snapshot is not shown

**Actual Result:** After mapping snapshot to Assessment via modal window, snapshot is not displayed on the Assessment Info pane. Refresh is needed
**Expected Result:** After mapping snapshot to Assessment via modal window, snapshot should be displayed on the Assessment Info pane w/o refreshing the page