### PR TITLE
GGRC-755: Save and Close button is disabled if mandatory fields are filled in New Task modal window

### DIFF
--- a/src/ggrc/assets/javascripts/components/datepicker/datepicker.js
+++ b/src/ggrc/assets/javascripts/components/datepicker/datepicker.js
@@ -68,16 +68,7 @@
         this.picker.datepicker('setDate', null);
         this.attr('date', null);
       },
-
-      // Date formats for the actual selected value, and for the date as
-      // displayed to the user. The Moment.js library and the jQuery datepicker
-      // use different format notation, thus separate settings for each.
-      // IMPORTANT: The pair of settings for each "type" of value (i.e. actual
-      // value / display value) must be consistent across both libraries!
-      MOMENT_ISO_DATE: 'YYYY-MM-DD',
-      MOMENT_DISPLAY_FMT: 'MM/DD/YYYY',
-      PICKER_ISO_DATE: 'yy-mm-dd',
-      PICKER_DISPLAY_FMT: 'mm/dd/yy'
+      MOMENT_DISPLAY_FMT: GGRC.Date.MOMENT_DISPLAY_FMT,
     }),
 
     events: {
@@ -88,9 +79,9 @@
         var maxDate;
         var date;
         var options = {
-          dateFormat: viewModel.PICKER_ISO_DATE,
+          dateFormat: GGRC.Date.PICKER_ISO_DATE,
           altField: this.element.find('.datepicker__input'),
-          altFormat: viewModel.PICKER_DISPLAY_FMT,
+          altFormat: GGRC.Date.PICKER_DISPLAY_FMT,
           onSelect: this.viewModel.onSelect.bind(this.viewModel)
         };
 
@@ -125,15 +116,13 @@
        * @return {string|null} - date in ISO format or null if empty or invalid
        */
       getDate: function (date) {
-        var viewModel = this.viewModel;
-
         if (date instanceof Date) {
           // NOTE: Not using moment.utc(), because if a Date instance is given,
           // it is in the browser's local timezone, thus we need to take that
           // into account to not end up with a different date. Ideally this
           // should never happen, but that would require refactoring the way
           // Date objects are created throughout the app.
-          return moment(date).format(viewModel.MOMENT_ISO_DATE);
+          return moment(date).format(GGRC.Date.MOMENT_ISO_DATE);
         } else if (this.isValidDate(date)) {
           return date;
         }
@@ -142,8 +131,7 @@
       },
 
       isValidDate: function (date) {
-        var viewModel = this.viewModel;
-        return moment(date, viewModel.MOMENT_ISO_DATE, true).isValid();
+        return moment(date, GGRC.Date.MOMENT_ISO_DATE, true).isValid();
       },
 
       /**
@@ -179,7 +167,7 @@
           // into account to not end up with a different date. Ideally this
           // should never happen, but that would require refactoring the way
           // Date objects are created throughout the app.
-          date = moment(date).format(viewModel.MOMENT_ISO_DATE);
+          date = moment(date).format(GGRC.Date.MOMENT_ISO_DATE);
         }
         date = moment.utc(date);
 
@@ -205,9 +193,9 @@
 
         if (val) {
           val = val.trim();
-          valF = moment.utc(val, viewModel.MOMENT_DISPLAY_FMT, true);
+          valF = moment.utc(val, GGRC.Date.MOMENT_DISPLAY_FMT, true);
           valISO = valF.isValid() ?
-            valF.format(viewModel.MOMENT_ISO_DATE) :
+            valF.format(GGRC.Date.MOMENT_ISO_DATE) :
             null;
         }
         return valISO;
@@ -222,7 +210,7 @@
           if (currentDateObj < updated) {
             this.viewModel.attr(
               '_date',
-              moment.utc(updated).format(viewModel.MOMENT_DISPLAY_FMT));
+              moment.utc(updated).format(GGRC.Date.MOMENT_DISPLAY_FMT));
           }
         }
       },

--- a/src/ggrc/assets/javascripts/components/tests/datepicker_spec.js
+++ b/src/ggrc/assets/javascripts/components/tests/datepicker_spec.js
@@ -99,11 +99,11 @@ describe('GGRC.Components.datepicker', function () {
       it('create datepicker in specified format', function () {
         method();
         expect(element.datepicker('option', 'dateFormat'))
-          .toEqual(viewModel.PICKER_ISO_DATE);
+          .toEqual(GGRC.Date.PICKER_ISO_DATE);
         expect(element.datepicker('option', 'altField')[0])
           .toEqual(altField[0]);
         expect(element.datepicker('option', 'altFormat'))
-          .toEqual(viewModel.PICKER_DISPLAY_FMT);
+          .toEqual(GGRC.Date.PICKER_DISPLAY_FMT);
       });
       it('sets new datepicker to picker of viewModel', function () {
         method();

--- a/src/ggrc/assets/javascripts/ggrc_base.js
+++ b/src/ggrc/assets/javascripts/ggrc_base.js
@@ -2,7 +2,7 @@
     Copyright (C) 2017 Google Inc.
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 */
-(function(GGRC) {
+(function(GGRC, moment) {
   GGRC.mustache_path = '/static/mustache';
 
   GGRC.hooks = GGRC.hooks || {};
@@ -338,4 +338,42 @@
     }
 
   });
-})(window.GGRC = window.GGRC || {});
+
+  /*
+    The GGRC Date library provides basic methods for Date-to-string conversion.
+  */
+  GGRC.Date = GGRC.Date || {};
+  $.extend(GGRC.Date, {
+    // Date formats for the actual selected value, and for the date as
+    // displayed to the user. The Moment.js library and the jQuery datepicker
+    // use different format notation, thus separate settings for each.
+    // IMPORTANT: The pair of settings for each "type" of value (i.e. actual
+    // value / display value) must be consistent across both libraries!
+    MOMENT_ISO_DATE: 'YYYY-MM-DD',
+    MOMENT_DISPLAY_FMT: 'MM/DD/YYYY',
+    PICKER_ISO_DATE: 'yy-mm-dd',
+    PICKER_DISPLAY_FMT: 'mm/dd/yy',
+
+    /**
+    * Convert given Date, string or null to an Date object.
+    *
+    * @param {Date|string|null} date - Date, string in ISO date format or null
+    * @param {string} format - date format string ('YYYY-MM-DD' default value)
+    * @return {string|null} - Date object or null if string is not in ISO format or null
+    */
+    getDate(date, format = GGRC.Date.MOMENT_ISO_DATE) {
+      var momDate;
+
+      if (date instanceof Date) {
+        return date;
+      }
+
+      momDate = moment(date, format, true);
+      if (momDate.isValid()) {
+        return momDate.toDate();
+      }
+
+      return null;
+    },
+  });
+})(window.GGRC = window.GGRC || {}, moment);

--- a/src/ggrc/assets/javascripts/tests/ggrc_date_spec.js
+++ b/src/ggrc/assets/javascripts/tests/ggrc_date_spec.js
@@ -1,0 +1,79 @@
+/*!
+ Copyright (C) 2017 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+'use strict';
+
+describe('GGRC.Date module', function () {
+  describe('getDate() method', function () {
+    var method;
+
+    beforeAll(function () {
+      method = GGRC.Date.getDate;
+    });
+
+    it('returns date for Date object parameter', function () {
+      var expected = new Date();
+      var actual = method(expected);
+
+      expect(actual).toEqual(expected);
+    });
+
+    it('returns null for null parameter', function () {
+      var actual = method(null);
+
+      expect(actual).toBeNull();
+    });
+
+    describe('when date format is not specified', function () {
+      it('returns null for Date in moment display format', function () {
+        var param = '04/30/2017';
+        var actual = method(param);
+
+        expect(actual).toBeNull();
+      });
+
+      it('returns null for Date in picker ISO format', function () {
+        var param = '17-04-30';
+        var actual = method(param);
+
+        expect(actual).toBeNull();
+      });
+
+      it('returns null for Date in picker display format', function () {
+        var param = '04/30/17';
+        var actual = method(param);
+
+        expect(actual).toBeNull();
+      });
+
+      it('returns correct Date for Date in moment ISO format', function () {
+        var dateString = '2017-04-30';
+        var expected = new Date(2017, 3, 30);
+        var actual = method(dateString);
+
+        expect(actual).toEqual(expected);
+      });
+    });
+
+    it('returns null when date string is not in correct date format',
+      function () {
+        var dateString = '2017/04/30';
+        var dateFormat = 'YYYY/DD/MM';
+        var actual = method(dateString, dateFormat);
+
+        expect(actual).toBeNull();
+      });
+
+    it('returns expected Date when date string is in correct date format',
+      function () {
+        var dateString = '2017/30/04';
+        var dateFormat = 'YYYY/DD/MM';
+        var expected = new Date(2017, 3, 30);
+        var actual = method(dateString, dateFormat);
+
+        expect(actual).toEqual(expected);
+      });
+  });
+});

--- a/src/ggrc_workflows/assets/javascripts/models/task_group.js
+++ b/src/ggrc_workflows/assets/javascripts/models/task_group.js
@@ -123,14 +123,16 @@
         var that = this;
         var workflow = GGRC.page_instance();
         var datesAreValid = true;
+        var startDate = GGRC.Date.getDate(that.attr('start_date'));
+        var endDate = GGRC.Date.getDate(that.attr('end_date'));
 
         if (!(workflow instanceof CMS.Models.Workflow)) {
           return;
         }
 
         // Handle cases of a workflow with start and end dates
-        datesAreValid = that.start_date && that.end_date &&
-          that.start_date <= that.end_date;
+        datesAreValid = startDate && endDate &&
+          startDate <= endDate;
 
         if (!datesAreValid) {
           return 'Start and/or end date is invalid';


### PR DESCRIPTION
 # Issue description

Save & Close button is disabled on Create New Task modal until Start Date or Due Date are not reselected

# Steps to reproduce

1. Navigate on Setup tab of any active Workflow
2. Open Create New Task modal
3. Fill mandatary fields in.
Actual Result: Save & Close button is disabled.
Expected Result: Save and Close button should be active if mandatory fields are filled in New Task modal window

# Solution description

Actual cause of issue - issue in datepicker component that converts one of dates to string and leaves another one as Date object (This bug was introduced quite long ago and fixing it via converting string representation to Date object in every place in datepicker component might be very risky and cause a lot of regressions). Proposed solution - try to get Date representation of start_date and end_date properties in TaskGroupTask validation method and compare these values.


# Sanity check list

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct labels.
- [x] My changes fix the issue described in the description.
- [x] My changes are covered by tests.
- [x] My changes follow the [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/performance.rst).
- [x] My changes follow the [js](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/javascript.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/git/how_to_write_a_commit_message.rst).
