### PR TITLE
GGRC-3249: Fix issue with editing GCA for Risks and Threats

### DIFF
--- a/src/ggrc_risks/assets/javascripts/models/risk.js
+++ b/src/ggrc_risks/assets/javascripts/models/risk.js
@@ -22,7 +22,8 @@
       context: 'CMS.Models.Context.stub',
       modified_by: 'CMS.Models.Person.stub',
       objects: 'CMS.Models.get_stubs',
-      risk_objects: 'CMS.Models.RiskObject.stubs'
+      risk_objects: 'CMS.Models.RiskObject.stubs',
+      custom_attribute_values: 'CMS.Models.CustomAttributeValue.stubs',
     },
     tree_view_options: {
       add_item_view:

--- a/src/ggrc_risks/assets/javascripts/models/threat.js
+++ b/src/ggrc_risks/assets/javascripts/models/threat.js
@@ -30,7 +30,8 @@
       object_controls: 'CMS.Models.ObjectControl.stubs',
       controls: 'CMS.Models.Control.stubs',
       object_sections: 'CMS.Models.ObjectSection.stubs',
-      sections: 'CMS.Models.get_stubs'
+      sections: 'CMS.Models.get_stubs',
+      custom_attribute_values: 'CMS.Models.CustomAttributeValue.stubs',
     },
     tree_view_options: {
       add_item_view: GGRC.mustache_path +


### PR DESCRIPTION
 # Issue description

GCA cannot be updated for Risks and Threats.

# Steps to reproduce

1. Have GCA with any type for Risks, Threats
2. Go to My work page
3. Threats tab > Expand Threats Info pane
4. Edit GCA with date type and save
5. Look at the screen: 'Save' message is displayed but value is not saved
Actual Result: Editing of GCA doesn't work
Expected Result: Editing of GCA should work for all objects across the app


# Solution description

Actual cause of issue - custom_attribute_values stores the whole objects for Risks and Threats(not Stubs). That causes reseting GCA value on back-end.
Solution - declare custom_attribute_values as 'CMS.Models.CustomAttributeValue.stubs'.


# Sanity check list

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct labels.
- [x] My changes fix the issue described in the description.
- [x] My changes follow the [js](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/javascript.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/git/how_to_write_a_commit_message.rst).

Unit tests are not applicable for this issue.