### PR TITLE
QUICK-FIX Upgrade tag creation script

### DIFF
--- a/bin/release/tag_current_release.sh
+++ b/bin/release/tag_current_release.sh
@@ -34,10 +34,11 @@ write_visible_message () {
 
 version_script () {
   declare -r SETTINGS_FILE="src/ggrc/settings/default.py"
+  declare -r TARGET_REF="FETCH_HEAD"
 
   cat <<EOF
 BUILD_NUMBER = ""
-$(grep "VERSION =" $SETTINGS_FILE)
+$(git grep -h "VERSION =" $TARGET_REF -- $SETTINGS_FILE)
 print VERSION
 EOF
 }

--- a/bin/release/tag_current_release.sh
+++ b/bin/release/tag_current_release.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 # Copyright (C) 2017 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>

--- a/bin/release/tag_current_release.sh
+++ b/bin/release/tag_current_release.sh
@@ -32,6 +32,16 @@ write_visible_message () {
   echo '-----'
 }
 
+version_script () {
+  declare -r SETTINGS_FILE="src/ggrc/settings/default.py"
+
+  cat <<EOF
+BUILD_NUMBER = ""
+$(grep "VERSION =" $SETTINGS_FILE)
+print VERSION
+EOF
+}
+
 main () {
   if [[ "${1:-}" == "--help" ]]; then
     usage
@@ -40,7 +50,7 @@ main () {
 
   git fetch upstream master
 
-  v=$(python -c "BUILD_NUMBER='' ; $(grep 'VERSION =' src/ggrc/settings/default.py) ; print VERSION")
+  v=$(version_script | python -)
   git tag -s -m "$v" $v FETCH_HEAD
 
   write_visible_message "$(git rev-parse FETCH_HEAD) is tagged as $v"


### PR DESCRIPTION
# Issue description

This PR contains two upgrades to our tag creation script that @IlyaTsupryk has complained about during his tag creation:
1. If `/bin/sh` is really `sh` and not a symlink to `bash`, the script won't start.
2. If `master` and `HEAD` have different versions in `settings`, the tag is created with a wrong version.

# Solution description

`git grep -h PATTERN REF -- PATH` has identical output as `grep PATTERN PATH` so it can be safely used in its place.
The Python one-liner is now separated to keep the line lengths lower. 

# Sanity check list

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else).
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/git/how_to_write_a_commit_message.rst).

No js or python code included, no tests available. 