### PR TITLE
GGRC-3573 Force old version of momentjs which not breaks the build process

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "font-awesome": "~4.5.0",
     "jquery": "^2.2.4",
     "lodash": "^3.10.1",
-    "moment": "^2.17.1",
+    "moment": "2.18.1",
     "moment-timezone": "^0.5.10",
     "mousetrap": "^1.6.0",
     "quill": "^1.2.2",


### PR DESCRIPTION
# Issue description

Build fails on in all environments.

# Steps to reproduce

1. Rebuild container or update npm packages.
2. Run karma tests

# Solution description

The version of momentjs library was not locked down and it was automatically updated to the 2.19.0 which brought the issue ( https://github.com/moment/moment/issues/4216 )

Locking down the momentjs version to previous one solves the issue.