### PR TITLE
GGRC-3576 Speed up render of people assignees lists in tree view

### DIFF
--- a/src/ggrc/assets/javascripts/components/tree/templates/tree-item-custom-attribute.mustache
+++ b/src/ggrc/assets/javascripts/components/tree/templates/tree-item-custom-attribute.mustache
@@ -5,10 +5,8 @@
 
 {{#values}}
   {{#get_custom_attr_value column instance customAttrItem=.}}
-      {{! because the object can currently only be a
-      person there is no need to switch }}
-      <tree-people-list-field {source}="object">
-          {{peopleStr}}
-      </tree-people-list-field>
+  {{! because the object can currently only be a
+  person there is no need to switch }}
+    <tree-people-list-field {source}="object"/>
   {{/get_custom_attr_value}}
 {{/values}}

--- a/src/ggrc/assets/javascripts/components/tree/templates/tree-item.mustache
+++ b/src/ggrc/assets/javascripts/components/tree/templates/tree-item.mustache
@@ -31,9 +31,7 @@
                 <div class="roles attr-content">
                     <tree-people-with-role-list-field
                             {source}="instance"
-                            {role}="attr_name">
-                        {{peopleStr}}
-                    </tree-people-with-role-list-field>
+                            {role}="attr_name"/>
                 </div>
               {{/case}}
 

--- a/src/ggrc/assets/javascripts/components/tree/tree-people-list-field.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-people-list-field.js
@@ -5,31 +5,27 @@
 
 import BaseTreePeopleVM from '../view-models/tree-people-base-vm';
 
-(function (can, GGRC) {
-  'use strict';
+var viewModel = BaseTreePeopleVM.extend({
+  filter: '@',
+  getSourceList: function () {
+    var filter = this.attr('filter');
+    var sourceString = 'source';
 
-  var viewModel = BaseTreePeopleVM.extend({
-    filter: '@',
-    getSourceList: function () {
-      var filter = this.attr('filter');
-      var sourceString = 'source';
-
-      if (filter) {
-        sourceString += '.' + filter;
-      }
-
-      return can.makeArray(this.attr(sourceString));
+    if (filter) {
+      sourceString += '.' + filter;
     }
-  });
 
-  GGRC.Components('treePeopleListField', {
-    tag: 'tree-people-list-field',
-    template: '{{peopleStr}}',
-    viewModel: viewModel,
-    events: {
-      '{viewModel.source} change': function () {
-        this.viewModel.refreshPeople();
-      }
+    return can.makeArray(this.attr(sourceString));
+  }
+});
+
+export default GGRC.Components('treePeopleListField', {
+  tag: 'tree-people-list-field',
+  template: '{{peopleStr}}',
+  viewModel: viewModel,
+  events: {
+    '{viewModel.source} change': function () {
+      this.viewModel.refreshPeople();
     }
-  });
-})(window.can, window.GGRC);
+  }
+});

--- a/src/ggrc/assets/javascripts/components/tree/tree-people-list-field.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-people-list-field.js
@@ -3,10 +3,12 @@
   Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 */
 
+import BaseTreePeopleVM from '../view-models/tree-people-base-vm';
+
 (function (can, GGRC) {
   'use strict';
 
-  var viewModel = GGRC.VM.BaseTreePeopleField.extend({
+  var viewModel = BaseTreePeopleVM.extend({
     filter: '@',
     getSourceList: function () {
       var filter = this.attr('filter');

--- a/src/ggrc/assets/javascripts/components/tree/tree-people-list-field.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-people-list-field.js
@@ -1,22 +1,22 @@
-/*!
+/*
   Copyright (C) 2017 Google Inc., authors, and contributors <see AUTHORS file>
   Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 */
 
 import BaseTreePeopleVM from '../view-models/tree-people-base-vm';
 
-var viewModel = BaseTreePeopleVM.extend({
+const viewModel = BaseTreePeopleVM.extend({
   filter: '@',
   getSourceList: function () {
-    var filter = this.attr('filter');
-    var sourceString = 'source';
+    let filter = this.attr('filter');
+    let sourceString = 'source';
 
     if (filter) {
       sourceString += '.' + filter;
     }
 
     return can.makeArray(this.attr(sourceString));
-  }
+  },
 });
 
 export default GGRC.Components('treePeopleListField', {
@@ -26,6 +26,6 @@ export default GGRC.Components('treePeopleListField', {
   events: {
     '{viewModel.source} change': function () {
       this.viewModel.refreshPeople();
-    }
-  }
+    },
+  },
 });

--- a/src/ggrc/assets/javascripts/components/tree/tree-people-list-field.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-people-list-field.js
@@ -22,7 +22,7 @@
 
   GGRC.Components('treePeopleListField', {
     tag: 'tree-people-list-field',
-    template: '<content />',
+    template: '{{peopleStr}}',
     viewModel: viewModel,
     events: {
       '{viewModel.source} change': function () {

--- a/src/ggrc/assets/javascripts/components/tree/tree-people-with-role-list-field.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-people-with-role-list-field.js
@@ -1,17 +1,17 @@
-/*!
+/*
   Copyright (C) 2017 Google Inc., authors, and contributors <see AUTHORS file>
   Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 */
 
 import BaseTreePeopleVM from '../view-models/tree-people-base-vm';
 
-var viewModel = BaseTreePeopleVM.extend({
+const viewModel = BaseTreePeopleVM.extend({
   role: null,
   getSourceList: function () {
-    var roleName = this.attr('role');
-    var instance = this.attr('source');
+    let roleName = this.attr('role');
+    let instance = this.attr('source');
     return GGRC.Utils.peopleWithRoleName(instance, roleName);
-  }
+  },
 });
 
 export default GGRC.Components('treePeopleWithRoleListField', {
@@ -21,6 +21,6 @@ export default GGRC.Components('treePeopleWithRoleListField', {
   events: {
     '{viewModel.source} change': function () {
       this.viewModel.refreshPeople();
-    }
-  }
+    },
+  },
 });

--- a/src/ggrc/assets/javascripts/components/tree/tree-people-with-role-list-field.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-people-with-role-list-field.js
@@ -3,10 +3,12 @@
   Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 */
 
+import BaseTreePeopleVM from '../view-models/tree-people-base-vm';
+
 (function (can, GGRC) {
   'use strict';
 
-  var viewModel = GGRC.VM.BaseTreePeopleField.extend({
+  var viewModel = BaseTreePeopleVM.extend({
     role: null,
     getSourceList: function () {
       var roleName = this.attr('role');

--- a/src/ggrc/assets/javascripts/components/tree/tree-people-with-role-list-field.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-people-with-role-list-field.js
@@ -5,26 +5,22 @@
 
 import BaseTreePeopleVM from '../view-models/tree-people-base-vm';
 
-(function (can, GGRC) {
-  'use strict';
+var viewModel = BaseTreePeopleVM.extend({
+  role: null,
+  getSourceList: function () {
+    var roleName = this.attr('role');
+    var instance = this.attr('source');
+    return GGRC.Utils.peopleWithRoleName(instance, roleName);
+  }
+});
 
-  var viewModel = BaseTreePeopleVM.extend({
-    role: null,
-    getSourceList: function () {
-      var roleName = this.attr('role');
-      var instance = this.attr('source');
-      return GGRC.Utils.peopleWithRoleName(instance, roleName);
+export default GGRC.Components('treePeopleWithRoleListField', {
+  tag: 'tree-people-with-role-list-field',
+  template: '{{peopleStr}}',
+  viewModel: viewModel,
+  events: {
+    '{viewModel.source} change': function () {
+      this.viewModel.refreshPeople();
     }
-  });
-
-  GGRC.Components('treePeopleWithRoleListField', {
-    tag: 'tree-people-with-role-list-field',
-    template: '{{peopleStr}}',
-    viewModel: viewModel,
-    events: {
-      '{viewModel.source} change': function () {
-        this.viewModel.refreshPeople();
-      }
-    }
-  });
-})(window.can, window.GGRC);
+  }
+});

--- a/src/ggrc/assets/javascripts/components/tree/tree-people-with-role-list-field.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-people-with-role-list-field.js
@@ -17,7 +17,7 @@
 
   GGRC.Components('treePeopleWithRoleListField', {
     tag: 'tree-people-with-role-list-field',
-    template: '<content />',
+    template: '{{peopleStr}}',
     viewModel: viewModel,
     events: {
       '{viewModel.source} change': function () {

--- a/src/ggrc/assets/javascripts/components/view-models/tree-people-base-vm.js
+++ b/src/ggrc/assets/javascripts/components/view-models/tree-people-base-vm.js
@@ -7,9 +7,16 @@
   'use strict';
 
   can.Map.extend('GGRC.VM.BaseTreePeopleField', {
+    define: {
+      stub: {
+        type: 'boolean',
+        value: true
+      }
+    },
     source: null,
     people: [],
     peopleStr: '',
+    stub: '@',
     init: function () {
       this.refreshPeople();
     },
@@ -18,34 +25,29 @@
         .then(function (data) {
           this.attr('people', data);
           this.attr('peopleStr', data.map(function (item) {
-            return item.displayName;
+            return item.email;
           }).join(', '));
         }.bind(this));
     },
     getPeopleList: function () {
       var sourceList = this.getSourceList();
-      var result;
       var deferred = can.Deferred();
 
       if (!sourceList.length) {
         return deferred.resolve([]);
       }
 
-      this.loadItems(sourceList)
-        .then(function (data) {
-          result = data.map(function (item) {
-            var displayName = item.email;
-            return {
-              name: item.name,
-              email: item.email,
-              displayName: displayName
-            };
+      if (this.attr('stub')) {
+        this.loadItems(sourceList)
+          .then(function (data) {
+            deferred.resolve(data);
+          })
+          .fail(function () {
+            deferred.resolve([]);
           });
-          deferred.resolve(result);
-        })
-        .fail(function () {
-          deferred.resolve([]);
-        });
+      } else {
+        deferred.resolve(sourceList);
+      }
 
       return deferred;
     },

--- a/src/ggrc/assets/javascripts/components/view-models/tree-people-base-vm.js
+++ b/src/ggrc/assets/javascripts/components/view-models/tree-people-base-vm.js
@@ -3,67 +3,63 @@
  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  */
 
-(function (can, GGRC) {
-  'use strict';
-
-  can.Map.extend('GGRC.VM.BaseTreePeopleField', {
-    define: {
-      stub: {
-        type: 'boolean',
-        value: true
-      }
-    },
-    source: null,
-    people: [],
-    peopleStr: '',
-    stub: '@',
-    init: function () {
-      this.refreshPeople();
-    },
-    refreshPeople: function () {
-      this.getPeopleList()
-        .then(function (data) {
-          this.attr('people', data);
-          this.attr('peopleStr', data.map(function (item) {
-            return item.email;
-          }).join(', '));
-        }.bind(this));
-    },
-    getPeopleList: function () {
-      var sourceList = this.getSourceList();
-      var deferred = can.Deferred();
-
-      if (!sourceList.length) {
-        return deferred.resolve([]);
-      }
-
-      if (this.attr('stub')) {
-        this.loadItems(sourceList)
-          .then(function (data) {
-            deferred.resolve(data);
-          })
-          .fail(function () {
-            deferred.resolve([]);
-          });
-      } else {
-        deferred.resolve(sourceList);
-      }
-
-      return deferred;
-    },
-    getSourceList: function () {
-      console.warn('Function "getSourceList" is not implemented,' +
-        'please implement');
-      return [];
-    },
-    loadItems: function (items) {
-      var rq = new RefreshQueue();
-
-      can.each(items, function (item) {
-        rq.enqueue(CMS.Models.Person.model(item));
-      });
-
-      return rq.trigger();
+export default can.Map.extend({
+  define: {
+    stub: {
+      type: 'boolean',
+      value: true
     }
-  });
-})(window.can, window.GGRC);
+  },
+  source: null,
+  people: [],
+  peopleStr: '',
+  stub: '@',
+  init: function () {
+    this.refreshPeople();
+  },
+  refreshPeople: function () {
+    this.getPeopleList()
+      .then(function (data) {
+        this.attr('people', data);
+        this.attr('peopleStr', data.map(function (item) {
+          return item.email;
+        }).join(', '));
+      }.bind(this));
+  },
+  getPeopleList: function () {
+    var sourceList = this.getSourceList();
+    var deferred = can.Deferred();
+
+    if (!sourceList.length) {
+      return deferred.resolve([]);
+    }
+
+    if (this.attr('stub')) {
+      this.loadItems(sourceList)
+        .then(function (data) {
+          deferred.resolve(data);
+        })
+        .fail(function () {
+          deferred.resolve([]);
+        });
+    } else {
+      deferred.resolve(sourceList);
+    }
+
+    return deferred;
+  },
+  getSourceList: function () {
+    console.warn('Function "getSourceList" is not implemented,' +
+      'please implement');
+    return [];
+  },
+  loadItems: function (items) {
+    var rq = new RefreshQueue();
+
+    can.each(items, function (item) {
+      rq.enqueue(CMS.Models.Person.model(item));
+    });
+
+    return rq.trigger();
+  }
+});

--- a/src/ggrc/assets/javascripts/components/view-models/tree-people-base-vm.js
+++ b/src/ggrc/assets/javascripts/components/view-models/tree-people-base-vm.js
@@ -1,4 +1,4 @@
-/*!
+/*
  Copyright (C) 2017 Google Inc.
  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  */
@@ -7,8 +7,8 @@ export default can.Map.extend({
   define: {
     stub: {
       type: 'boolean',
-      value: true
-    }
+      value: true,
+    },
   },
   source: null,
   people: [],
@@ -61,5 +61,5 @@ export default can.Map.extend({
     });
 
     return rq.trigger();
-  }
+  },
 });

--- a/src/ggrc/assets/mustache/audits/tree-item-attr.mustache
+++ b/src/ggrc/assets/mustache/audits/tree-item-attr.mustache
@@ -5,14 +5,10 @@
 
 {{#switch attr_name}}
   {{#case 'audit_lead'}}
-      <tree-people-list-field {source}="instance.contact">
-          {{peopleStr}}
-      </tree-people-list-field>
+      <tree-people-list-field {source}="instance.contact"/>
   {{/case}}
   {{#case 'modified_by'}}
-      <tree-people-list-field {source}="instance.modified_by">
-          {{peopleStr}}
-      </tree-people-list-field>
+      <tree-people-list-field {source}="instance.modified_by"/>
   {{/case}}
   {{#case 'report_period'}}
     {{#if instance.report_start_date}}

--- a/src/ggrc/assets/mustache/base_objects/tree-item-attr.mustache
+++ b/src/ggrc/assets/mustache/base_objects/tree-item-attr.mustache
@@ -34,13 +34,13 @@
   {{/case}}
 
   {{#case 'creators'}}
-      <tree-people-list-field {source}="instance.assignees" filter="Creator"/>
+      <tree-people-list-field {source}="instance.assignees" filter="Creator" stub="false"/>
   {{/case}}
   {{#case 'assignees'}}
-      <tree-people-list-field {source}="instance.assignees" filter="Assessor"/>
+      <tree-people-list-field {source}="instance.assignees" filter="Assessor" stub="false"/>
   {{/case}}
   {{#case 'verifiers'}}
-      <tree-people-list-field {source}="instance.assignees" filter="Verifier"/>
+      <tree-people-list-field {source}="instance.assignees" filter="Verifier" stub="false"/>
   {{/case}}
   {{#case 'modified_by'}}
       <tree-people-list-field {source}="instance.modified_by"/>

--- a/src/ggrc/assets/mustache/base_objects/tree-item-attr.mustache
+++ b/src/ggrc/assets/mustache/base_objects/tree-item-attr.mustache
@@ -5,14 +5,10 @@
 
 {{#switch attr_name}}
   {{#case 'contact'}}
-      <tree-people-list-field {source}="instance.contact">
-          {{peopleStr}}
-      </tree-people-list-field>
+      <tree-people-list-field {source}="instance.contact"/>
   {{/case}}
   {{#case 'secondary_contact'}}
-      <tree-people-list-field {source}="instance.secondary_contact">
-          {{peopleStr}}
-      </tree-people-list-field>
+      <tree-people-list-field {source}="instance.secondary_contact"/>
   {{/case}}
   {{#case 'network_zone'}}
     {{#using network_zone=instance.network_zone}}
@@ -38,24 +34,16 @@
   {{/case}}
 
   {{#case 'creators'}}
-      <tree-people-list-field {source}="instance.assignees" filter="Creator">
-          {{peopleStr}}
-      </tree-people-list-field>
+      <tree-people-list-field {source}="instance.assignees" filter="Creator"/>
   {{/case}}
   {{#case 'assignees'}}
-      <tree-people-list-field {source}="instance.assignees" filter="Assessor">
-          {{peopleStr}}
-      </tree-people-list-field>
+      <tree-people-list-field {source}="instance.assignees" filter="Assessor"/>
   {{/case}}
   {{#case 'verifiers'}}
-      <tree-people-list-field {source}="instance.assignees" filter="Verifier">
-          {{peopleStr}}
-      </tree-people-list-field>
+      <tree-people-list-field {source}="instance.assignees" filter="Verifier"/>
   {{/case}}
   {{#case 'modified_by'}}
-      <tree-people-list-field {source}="instance.modified_by">
-          {{peopleStr}}
-      </tree-people-list-field>
+      <tree-people-list-field {source}="instance.modified_by"/>
   {{/case}}
   {{#case 'created_at'}}
       {{localize_date instance.created_at}}

--- a/src/ggrc/assets/mustache/controls/tree-item-attr.mustache
+++ b/src/ggrc/assets/mustache/controls/tree-item-attr.mustache
@@ -6,29 +6,19 @@
 
 {{#switch attr_name}}
   {{#case 'contact'}}
-      <tree-people-list-field {source}="instance.contact">
-          {{peopleStr}}
-      </tree-people-list-field>
+      <tree-people-list-field {source}="instance.contact"/>
   {{/case}}
   {{#case 'secondary_contact'}}
-      <tree-people-list-field {source}="instance.secondary_contact">
-          {{peopleStr}}
-      </tree-people-list-field>
+      <tree-people-list-field {source}="instance.secondary_contact"/>
   {{/case}}
   {{#case 'principal_assessor'}}
-      <tree-people-list-field {source}="instance.principal_assessor">
-          {{peopleStr}}
-      </tree-people-list-field>
+      <tree-people-list-field {source}="instance.principal_assessor"/>
   {{/case}}
   {{#case 'secondary_assessor'}}
-      <tree-people-list-field {source}="instance.secondary_assessor">
-          {{peopleStr}}
-      </tree-people-list-field>
+      <tree-people-list-field {source}="instance.secondary_assessor"/>
   {{/case}}
   {{#case 'modified_by'}}
-      <tree-people-list-field {source}="instance.modified_by">
-          {{peopleStr}}
-      </tree-people-list-field>
+      <tree-people-list-field {source}="instance.modified_by"/>
   {{/case}}
   {{#case 'kind'}}
     {{#using kind=instance.kind}}

--- a/src/ggrc/assets/mustache/directives/tree-item-attr.mustache
+++ b/src/ggrc/assets/mustache/directives/tree-item-attr.mustache
@@ -15,9 +15,7 @@
       </tree-people-list-field>
   {{/case}}
   {{#case 'modified_by'}}
-      <tree-people-list-field {source}="instance.modified_by">
-          {{peopleStr}}
-      </tree-people-list-field>
+      <tree-people-list-field {source}="instance.modified_by"/>
   {{/case}}
   {{#case 'status'}}
     {{#using status=instance.status}}

--- a/src/ggrc/assets/mustache/objectives/tree-item-attr.mustache
+++ b/src/ggrc/assets/mustache/objectives/tree-item-attr.mustache
@@ -5,19 +5,13 @@
 
 {{#switch attr_name}}
   {{#case 'contact'}}
-      <tree-people-list-field {source}="instance.contact">
-          {{peopleStr}}
-      </tree-people-list-field>
+      <tree-people-list-field {source}="instance.contact"/>
   {{/case}}
   {{#case 'secondary_contact'}}
-      <tree-people-list-field {source}="instance.secondary_contact">
-          {{peopleStr}}
-      </tree-people-list-field>
+      <tree-people-list-field {source}="instance.secondary_contact"/>
   {{/case}}
   {{#case 'modified_by'}}
-      <tree-people-list-field {source}="instance.modified_by">
-          {{peopleStr}}
-      </tree-people-list-field>
+      <tree-people-list-field {source}="instance.modified_by"/>
   {{/case}}
   {{#case 'last_assessment_date'}}
     {{localize_date instance.last_assessment_date}}

--- a/src/ggrc/assets/mustache/programs/tree-item-attr.mustache
+++ b/src/ggrc/assets/mustache/programs/tree-item-attr.mustache
@@ -26,9 +26,7 @@
       </tree-people-list-field>
   {{/case}}
   {{#case 'modified_by'}}
-      <tree-people-list-field {source}="instance.modified_by">
-          {{peopleStr}}
-      </tree-people-list-field>
+      <tree-people-list-field {source}="instance.modified_by"/>
   {{/case}}
   {{#case 'status'}}
     {{#using status=instance.status}}

--- a/src/ggrc/assets/mustache/sections/tree-item-attr.mustache
+++ b/src/ggrc/assets/mustache/sections/tree-item-attr.mustache
@@ -13,9 +13,7 @@
       </tree-people-list-field>
   {{/case}}
   {{#case 'modified_by'}}
-      <tree-people-list-field {source}="instance.modified_by">
-          {{peopleStr}}
-      </tree-people-list-field>
+      <tree-people-list-field {source}="instance.modified_by"/>
   {{/case}}
   {{#case 'status'}}
     {{#using status=instance.status}}

--- a/src/ggrc_risk_assessments/assets/mustache/risk_assessments/tree-item-attr.mustache
+++ b/src/ggrc_risk_assessments/assets/mustache/risk_assessments/tree-item-attr.mustache
@@ -5,14 +5,10 @@
 
 {{#switch attr_name}}
   {{#case 'ra_manager'}}
-      <tree-people-list-field {source}="instance.ra_manager">
-          {{peopleStr}}
-      </tree-people-list-field>
+      <tree-people-list-field {source}="instance.ra_manager"/>
   {{/case}}
   {{#case 'ra_counsel'}}
-      <tree-people-list-field {source}="instance.ra_counsel">
-          {{peopleStr}}
-      </tree-people-list-field>
+      <tree-people-list-field {source}="instance.ra_counsel"/>
   {{/case}}
   {{#case 'status'}}
     {{#using status=instance.status}}

--- a/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/tree-item-attr.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/tree-item-attr.mustache
@@ -16,14 +16,10 @@
     {{/using}}
   {{/case}}
   {{#case 'assignee'}}
-      <tree-people-list-field {source}="instance.contact">
-          {{peopleStr}}
-      </tree-people-list-field>
+      <tree-people-list-field {source}="instance.contact"/>
   {{/case}}
   {{#case 'modified_by'}}
-      <tree-people-list-field {source}="instance.modified_by">
-          {{peopleStr}}
-      </tree-people-list-field>
+      <tree-people-list-field {source}="instance.modified_by"/>
   {{/case}}
   {{#case 'status'}}
     {{#using status=instance.status}}

--- a/src/ggrc_workflows/assets/mustache/task_group_tasks/tree-item-attr.mustache
+++ b/src/ggrc_workflows/assets/mustache/task_group_tasks/tree-item-attr.mustache
@@ -5,9 +5,7 @@
 
 {{#switch attr_name}}
   {{#case 'assignee'}}
-      <tree-people-list-field {source}="instance.contact">
-          {{peopleStr}}
-      </tree-people-list-field>
+      <tree-people-list-field {source}="instance.contact"/>
   {{/case}}
   {{#case 'status'}}
     {{#using status=instance.status}}

--- a/src/ggrc_workflows/assets/mustache/task_groups/tree-item-attr.mustache
+++ b/src/ggrc_workflows/assets/mustache/task_groups/tree-item-attr.mustache
@@ -5,14 +5,10 @@
 
 {{#switch attr_name}}
   {{#case 'assignee'}}
-      <tree-people-list-field {source}="instance.contact">
-          {{peopleStr}}
-      </tree-people-list-field>
+      <tree-people-list-field {source}="instance.contact"/>
   {{/case}}
   {{#case 'modified_by'}}
-      <tree-people-list-field {source}="instance.modified_by">
-          {{peopleStr}}
-      </tree-people-list-field>
+      <tree-people-list-field {source}="instance.modified_by"/>
   {{/case}}
   {{#case 'status'}}
     {{#using status=instance.status}}

--- a/src/ggrc_workflows/assets/mustache/workflows/tree-item-attr.mustache
+++ b/src/ggrc_workflows/assets/mustache/workflows/tree-item-attr.mustache
@@ -10,9 +10,7 @@
         <span>
           {{#using role=instance.role}}
             {{#if_equals role.name 'WorkflowOwner'}}
-                <tree-people-list-field {source}="instance.person">
-                    {{peopleStr}}
-                </tree-people-list-field>
+                <tree-people-list-field {source}="instance.person"/>
             {{/if_equals}}
           {{/using}}
         </span>
@@ -20,9 +18,7 @@
     {{/with_mapping}}
   {{/case}}
   {{#case 'modified_by'}}
-      <tree-people-list-field {source}="instance.modified_by">
-          {{peopleStr}}
-      </tree-people-list-field>
+      <tree-people-list-field {source}="instance.modified_by"/>
   {{/case}}
   {{#case 'repeat'}}
       <repeat-on-summary {unit}="instance.unit" {repeat-every}="instance.repeat_every"


### PR DESCRIPTION
# Issue description

Currently we make additional request on `/api/people` endpoint in order to show people from assignees lists (Creators, Verifiers etc.) in tree view on Assessment tab

# Steps to reproduce

1. Open Assessment tab
2. Add `Verifiers` , `Creators' and/or `Assignees` columns to treeview
3. Look into `Network` tab in Chrome DevTool

# Solution description

Assessment instance already have all necessary data for it (in assignees field), because we need to show just an email and  in this case we avoid extra request on `/api/people/` endpoint in order to show assignees lists on Assessment tab.