### PR TITLE
GGRC-2862 Make a better error message while date format is wrong

### DIFF
--- a/src/ggrc/fulltext/attributes.py
+++ b/src/ggrc/fulltext/attributes.py
@@ -224,9 +224,9 @@ class DatetimeValue(object):
   This mixin should be used for filtering datetime fields values only.
   """
 
-  VALUE_ERROR_MSG = (u"Specified date format is invalid for search,"
-                     u"please use the following format for date:"
-                     u"mm/dd/yyyy, mm-dd-yyyy, mm/yyyy, mm-yyyy, yyyy")
+  VALUE_ERROR_MSG = (u"Specified date format is invalid for search, "
+                     u"please use the following format for date: "
+                     u"mm/dd/yyyy, mm-dd-yyyy, mm/yyyy, mm-yyyy, yyyy.")
 
   def get_value_error_msg(self):
     return self.VALUE_ERROR_MSG
@@ -257,7 +257,6 @@ class DateValue(DatetimeValue):
   """
 
   def get_filter_value(self, value, operation):
-
     results = super(DateValue, self).get_filter_value(value, operation)
     if not results:
       return


### PR DESCRIPTION
# Issue description

The point of this PR is to fix error message that appears when invalid date format is used in search.

# Steps to reproduce

See screenshots:
![screenshot-1](https://user-images.githubusercontent.com/9151434/31441560-d642732a-ae93-11e7-8572-7dd4fe80f2c3.png)
![screenshot-2](https://user-images.githubusercontent.com/9151434/31441562-d7c95c22-ae93-11e7-8199-a9c8c826bb05.png)

# Solution description

Add spaces and "." to message

# Sanity check list

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests (if not, include a reason).
- [x] My changes follow the [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/performance.rst).
- [x] My changes follow the [js](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/git/how_to_write_a_commit_message.rst).