### PR TITLE
GGRC-3216 Display bulleted list in comments correctly

### DIFF
--- a/src/ggrc/assets/stylesheets/components/mapped-objects/_mapped-objects.scss
+++ b/src/ggrc/assets/stylesheets/components/mapped-objects/_mapped-objects.scss
@@ -194,7 +194,8 @@
 
     * {
       padding: 0;
-      margin: 0;
+      margin-top: 0;
+      margin-bottom: 0;
     }
   }
 }


### PR DESCRIPTION
# Issue description
Rich text formatting (bullets) was not saved/displayed on an assessment comment. I tried to enter bullets into a comment and they are not displayed in the Read More/Read Less versions after they are added.
