### PR TITLE
GGRC-3583 Fix called function name

### DIFF
--- a/src/ggrc/views/cron.py
+++ b/src/ggrc/views/cron.py
@@ -14,7 +14,7 @@ logger = getLogger(__name__)
 
 def send_error_notification(message):
   try:
-    user_email = common.getAppEngineEmail()
+    user_email = common.get_app_engine_email()
     common.send_email(user_email, "Error in nightly cron job", message)
   except:  # pylint: disable=bare-except
     logger.exception("Failed on sending notification")


### PR DESCRIPTION
Fixes this error on ggrc-qa:

```
Failed on sending notification (/base/data/home/apps/s~ggrc-qa/1.404581647653141798/ggrc/views/cron.py:20)
Traceback (most recent call last):
  File "/base/data/home/apps/s~ggrc-qa/1.404581647653141798/ggrc/views/cron.py", line 17, in send_error_notification
    user_email = common.getAppEngineEmail()
AttributeError: 'module' object has no attribute 'getAppEngineEmail'
```