### PR TITLE
GGRC-2489 Extend Person control to show many people

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment/assessment-people.js
+++ b/src/ggrc/assets/javascripts/components/assessment/assessment-people.js
@@ -1,15 +1,9 @@
-/*!
+/*
  Copyright (C) 2017 Google Inc., authors, and contributors
  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  */
 
-import '../people/deletable-people-group';
-import '../people/editable-people-group';
 import '../related-objects/related-people-mapping';
-import '../related-objects/related-people-access-control';
-import '../related-objects/related-people-access-control-group';
-import '../custom-roles/custom-roles';
-import '../custom-roles/custom-roles-modal';
 
 (function (can, GGRC) {
   'use strict';
@@ -25,13 +19,13 @@ import '../custom-roles/custom-roles-modal';
       define: {
         emptyMessage: {
           type: 'string',
-          value: ''
-        }
+          value: '',
+        },
       },
       roleConflicts: false,
       infoPaneMode: true,
       withDetails: false,
-      instance: {}
-    }
+      instance: {},
+    },
   });
 })(window.can, window.GGRC);

--- a/src/ggrc/assets/javascripts/components/people/editable-people-group-header.js
+++ b/src/ggrc/assets/javascripts/components/people/editable-people-group-header.js
@@ -1,4 +1,4 @@
-/*!
+/*
     Copyright (C) 2017 Google Inc.
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 */
@@ -13,13 +13,21 @@
       '/components/people/editable-people-group-header.mustache'
     ),
     viewModel: {
+      define: {
+        peopleCount: {
+          get: function () {
+            return this.attr('people.length');
+          },
+        },
+      },
       editableMode: false,
       isLoading: false,
       canEdit: true,
       required: false,
+      people: [],
       openEditMode: function () {
         this.dispatch('editPeopleGroup');
-      }
-    }
+      },
+    },
   });
 })(window.can, window.GGRC);

--- a/src/ggrc/assets/javascripts/components/people/editable-people-group.js
+++ b/src/ggrc/assets/javascripts/components/people/editable-people-group.js
@@ -1,55 +1,51 @@
-/*!
+/*
  Copyright (C) 2017 Google Inc.
  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  */
 
-(function (can, GGRC, Mustache) {
-  'use strict';
+var viewModel = GGRC.VM.DeletablePeopleGroup.extend({
+  title: '@',
+  editableMode: false,
+  canEdit: {},
+  personSelected: function (person) {
+    this.dispatch({
+      type: 'personSelected',
+      person: person,
+      groupId: this.attr('groupId'),
+    });
+  },
+  save: function () {
+    this.dispatch('saveChanges');
+  },
+  cancel: function () {
+    this.changeEditableMode(false);
+  },
+  changeEditableMode: function (editableMode) {
+    this.attr('editableMode', editableMode);
+    this.dispatch({
+      type: 'changeEditableMode',
+      editableMode: editableMode,
+      groupId: this.attr('groupId'),
+    });
+  },
+});
 
-  var viewModel = GGRC.VM.DeletablePeopleGroup.extend({
-    title: '@',
-    editableMode: false,
-    canEdit: {},
-    personSelected: function (person) {
-      this.dispatch({
-        type: 'personSelected',
-        person: person,
-        groupId: this.attr('groupId')
-      });
-    },
-    save: function () {
-      this.dispatch('saveChanges');
-    },
-    cancel: function () {
-      this.changeEditableMode(false);
-    },
-    changeEditableMode: function (editableMode) {
-      this.attr('editableMode', editableMode);
-      this.dispatch({
-        type: 'changeEditableMode',
-        editableMode: editableMode,
-        groupId: this.attr('groupId')
-      });
-    }
-  });
+export default GGRC.Components('editablePeopleGroup', {
+  tag: 'editable-people-group',
+  template: can.view(
+    GGRC.mustache_path +
+    '/components/people/editable-people-group.mustache'
+  ),
+  viewModel: viewModel,
+  events: {
+    '{window} mousedown': function (el, ev) {
+      var viewModel = this.viewModel;
+      var isInside = GGRC.Utils.events.isInnerClick(this.element, ev.target);
+      var editableMode = viewModel.attr('editableMode');
 
-  GGRC.Components('editablePeopleGroup', {
-    tag: 'editable-people-group',
-    template: can.view(
-      GGRC.mustache_path +
-      '/components/people/editable-people-group.mustache'
-    ),
-    viewModel: viewModel,
-    events: {
-      '{window} mousedown': function (el, ev) {
-        var viewModel = this.viewModel;
-        var isInside = GGRC.Utils.events.isInnerClick(this.element, ev.target);
-        var editableMode = viewModel.attr('editableMode');
-
-        if (!isInside && editableMode) {
-          viewModel.save();
-        }
+      if (!isInside && editableMode) {
+        viewModel.save();
       }
-    }
-  });
-})(window.can, window.GGRC, can.Mustache);
+    },
+  },
+});

--- a/src/ggrc/assets/javascripts/components/people/editable-people-group.js
+++ b/src/ggrc/assets/javascripts/components/people/editable-people-group.js
@@ -3,10 +3,39 @@
  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  */
 
+import './people-group-modal';
+import './editable-people-group-header';
+
+const SHOW_MODAL_LIMIT = 4;
+
 var viewModel = GGRC.VM.DeletablePeopleGroup.extend({
   title: '@',
-  editableMode: false,
   canEdit: {},
+  showPeopleGroupModal: false,
+  define: {
+    editableMode: {
+      set: function (newValue, setValue) {
+        this.attr('showPeopleGroupModal',
+          this.attr('people.length') > SHOW_MODAL_LIMIT);
+        setValue(newValue);
+      },
+    },
+    showSeeMoreLink: {
+      get: function () {
+        return !this.attr('editableMode') &&
+          this.attr('people.length') > SHOW_MODAL_LIMIT;
+      },
+    },
+    readonlyPeople: {
+      get: function () {
+        if (this.attr('showPeopleGroupModal')) {
+          return this.attr('people').attr().slice(0, SHOW_MODAL_LIMIT);
+        }
+
+        return this.attr('people').attr();
+      },
+    },
+  },
   personSelected: function (person) {
     this.dispatch({
       type: 'personSelected',

--- a/src/ggrc/assets/javascripts/components/people/people-group-modal.js
+++ b/src/ggrc/assets/javascripts/components/people/people-group-modal.js
@@ -1,0 +1,28 @@
+/*
+ Copyright (C) 2017 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+import template from './templates/people-group-modal.mustache';
+
+export default GGRC.Components('peopleGroupModal', {
+  tag: 'people-group-modal',
+  template: template,
+  viewModel: {
+    define: {
+      selectedCount: {
+        get: function () {
+          return `${this
+            .attr('people.length')} ${this.attr('title')} Selected`;
+        },
+      },
+    },
+    modalState: {
+      open: true,
+    },
+    isLoading: false,
+    emptyListMessage: '',
+    title: '',
+    people: [],
+  },
+});

--- a/src/ggrc/assets/javascripts/components/people/templates/people-group-modal.mustache
+++ b/src/ggrc/assets/javascripts/components/people/templates/people-group-modal.mustache
@@ -1,0 +1,72 @@
+{{!
+  Copyright (C) 2017 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+}}
+
+<simple-modal modal-title="title" state="modalState" replace-content="true" extra-css-class="people-group-modal">
+  <div class="simple-modal__header flex-box flex-row">
+    <div class="simple-modal__header-text flex-size-1">
+      <div class="simple-modal__title">
+        <div class="simple-modal__title__name">
+          {{title}}
+        </div>
+      </div>
+    </div>
+    <button class="btn btn-small btn-icon" ($click)="cancel() hide">
+      <i class="fa fa-times black"></i>
+    </button>
+  </div>
+
+  <div class="simple-modal__body {{#if isLoading}}loading{{/if}}">
+    <div class="simple-modal__section simple-modal__sub-header-section">
+      <p>
+        Add person
+      </p>
+      {{#if isLoading}}
+        <spinner {toggle}="isLoading"></spinner>
+      {{else}}
+        <autocomplete search-items-type="Person"
+          (item-selected)="personSelected(%event.selectedItem)"
+          placeholder="Type person">
+        </autocomplete>
+      {{/if}}
+    </div>
+    <div class="simple-modal__section people-group-modal__people-section">
+      <div>
+        <object-list
+          class="people-group-modal__people-list"
+          ({items})="people"
+          {is-disabled}="isLoading"
+          {empty-message}="emptyListMessage">
+            <person-list-item person="{.}" {with-details}="withDetails">
+              {{#unmapablePerson}}
+                <a href="javascript://"
+                  class="info-action people-group-modal__unmap {{#if isDisabled}}disabled{{/if}}"
+                  ($click)="unmap(person)">
+                    <i class="fa fa-close"></i>
+                </a>
+              {{/unmapablePerson}}
+            </person-list-item>
+        </object-list>
+      </div>
+    </div>
+  </div>
+
+  <div class="simple-modal__footer">
+    <div class="simple-modal__toolbar people-group-modal__footer">
+      <button class="btn btn-green people-group-modal__button"
+        ($click)="save()"
+        {{#if isLoading}}disabled{{/if}}>
+          Save &amp; Close
+      </button>
+      <button class="btn btn-small people-group-modal__button btn-white"
+        ($click)="cancel()"
+        {{#if isLoading}}disabled{{/if}}>
+          Cancel
+      </button>
+      <div class="people-group-modal__selected-count">
+        {{selectedCount}}
+      </div>
+    </div>
+  </div>
+</simple-modal>

--- a/src/ggrc/assets/javascripts/components/people/tests/editable-people-group_spec.js
+++ b/src/ggrc/assets/javascripts/components/people/tests/editable-people-group_spec.js
@@ -1,0 +1,72 @@
+/*
+  Copyright (C) 2017 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+import Component from '../editable-people-group';
+
+describe('GGRC.Components.editablePeopleGroup', function () {
+  'use strict';
+
+  var viewModel;
+  var peopleItems = [
+    {id: 1}, {id: 2}, {id: 3}, {id: 4}, {id: 5}, {id: 6}
+  ];
+
+  beforeAll(function () {
+    viewModel = new Component.prototype.viewModel;
+  });
+
+  beforeEach(function () {
+    viewModel.attr('editableMode', false);
+  });
+
+  describe('"showSeeMoreLink" property', function () {
+    it('"showSeeMoreLink" should be FALSE. edit mode', function () {
+      viewModel.attr('people', peopleItems);
+      viewModel.attr('editableMode', true);
+      expect(viewModel.attr('showSeeMoreLink')).toBe(false);
+    });
+
+    it('"showSeeMoreLink" should be TRUE. edit mode is false', function () {
+      viewModel.attr('people', peopleItems);
+      expect(viewModel.attr('showSeeMoreLink')).toBe(true);
+    });
+
+    it('"showSeeMoreLink" should be FALSE. People length less than 5',
+      function () {
+        // get 4 persons
+        var people = peopleItems.slice(0, 4);
+        viewModel.attr('people', people);
+
+        expect(viewModel.attr('showSeeMoreLink')).toBe(false);
+      }
+    );
+  });
+
+  describe('"showPeopleGroupModal" property', function () {
+    it('"showPeopleGroupModal" should be FALSE. People length less than 5',
+      function () {
+        // get 4 persons
+        var people = peopleItems.slice(0, 4);
+        viewModel.attr('people', people);
+
+        // trigger editableMode setter
+        viewModel.attr('editableMode', true);
+
+        expect(viewModel.attr('showPeopleGroupModal')).toBe(false);
+      }
+    );
+
+    it('"showPeopleGroupModal" should be TRUE',
+      function () {
+        viewModel.attr('people', peopleItems);
+
+        // trigger editableMode setter
+        viewModel.attr('editableMode', true);
+
+        expect(viewModel.attr('showPeopleGroupModal')).toBe(true);
+      }
+    );
+  });
+});

--- a/src/ggrc/assets/javascripts/components/related-objects/related-people-access-control-group.js
+++ b/src/ggrc/assets/javascripts/components/related-objects/related-people-access-control-group.js
@@ -3,6 +3,9 @@
   Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 */
 
+import '../people/deletable-people-group';
+import '../people/editable-people-group';
+
 (function (can, _, GGRC, Permission) {
   'use strict';
 

--- a/src/ggrc/assets/javascripts/components/related-objects/related-people-access-control.js
+++ b/src/ggrc/assets/javascripts/components/related-objects/related-people-access-control.js
@@ -3,6 +3,8 @@
   Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 */
 
+import './related-people-access-control-group';
+
 (function (can, _, GGRC) {
   'use strict';
 

--- a/src/ggrc/assets/javascripts/components/related-objects/related-people-mapping.js
+++ b/src/ggrc/assets/javascripts/components/related-objects/related-people-mapping.js
@@ -3,6 +3,9 @@
   Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 */
 
+import '../people/deletable-people-group';
+import '../people/editable-people-group';
+
 (function (can) {
   'use strict';
 

--- a/src/ggrc/assets/javascripts/entrypoints/dashboard/index.js
+++ b/src/ggrc/assets/javascripts/entrypoints/dashboard/index.js
@@ -1,4 +1,4 @@
-/*!
+/*
  Copyright (C) 2017 Google Inc.
  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  */
@@ -145,11 +145,16 @@ import '../../components/assessment/info-pane-save-status';
 import '../../components/inline/inline';
 import '../../components/csv/export';
 import '../../components/csv/import';
-import '../../components/people/editable-people-group-header';
 import '../../components/people/people-list-info';
 import '../../components/prev-next-buttons/prev-next-buttons';
 import '../../components/loading/loading-status';
 import '../../components/lazy-render/lazy-render';
+
+// people
+import '../../components/related-objects/related-people-access-control';
+import '../../components/custom-roles/custom-roles';
+import '../../components/custom-roles/custom-roles-modal';
+
 import '../../components/custom-attributes/custom-attributes-field-view';
 import '../../components/form/form-validation-text';
 

--- a/src/ggrc/assets/mustache/components/assessment/assessment-people.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/assessment-people.mustache
@@ -50,6 +50,7 @@
                   {is-loading}="isLoading"
                   {can-edit}="canEdit"
                   {required}="required"
+                  {people}="people"
                   (edit-people-group)="changeEditableMode(true)">
                 </editable-people-group-header>
             </editable-people-group>

--- a/src/ggrc/assets/mustache/components/custom-roles/custom-roles.mustache
+++ b/src/ggrc/assets/mustache/components/custom-roles/custom-roles.mustache
@@ -43,6 +43,7 @@
                         {is-loading}="isLoading"
                         {can-edit}="canEdit"
                         {required}="required"
+                        {people}="people"
                         (edit-people-group)="changeEditableMode(true)">
                       </editable-people-group-header>
                   </editable-people-group>

--- a/src/ggrc/assets/mustache/components/people/editable-people-group-header.mustache
+++ b/src/ggrc/assets/mustache/components/people/editable-people-group-header.mustache
@@ -4,12 +4,17 @@
 }}
 
 <label class="action-toolbar editable-people-group__label form-label required-label">
-  <span class="people-group__title">
-    {{#unless editableMode}}
-      <spinner class="people-group__title-spinner" {toggle}="isLoading"></spinner>
-    {{/unless}}
-    {{title}}
-  </span>
+  <div class="people-group__title-content">
+    <div class="people-group__title">
+      {{#unless editableMode}}
+        <spinner class="people-group__title-spinner" {toggle}="isLoading"></spinner>
+      {{/unless}}
+      {{title}}
+    </div>
+    <div>
+      ({{peopleCount}})
+    </div>
+  </div>
   {{#if canEdit}}
     {{#if required}}
       <i class="fa fa-asterisk"></i>

--- a/src/ggrc/assets/mustache/components/people/editable-people-group.mustache
+++ b/src/ggrc/assets/mustache/components/people/editable-people-group.mustache
@@ -8,12 +8,28 @@
   <content></content>
 
   {{#unless editableMode}}
-    <object-list ({items})="people" {empty-message}="emptyListMessage">
-      <person-list-item person="{.}" {with-details}="withDetails">
+    <object-list ({items})="readonlyPeople" {empty-message}="emptyListMessage">
+      <person-list-item class="people-group__readonly-person"
+        person="{.}"
+        {with-details}="withDetails">
       </person-list-item>
     </object-list>
+
+    {{#if showSeeMoreLink}}
+      <div class="editable-people-group__see-more">
+        <a href="javascript://" ($click)="changeEditableMode(true)">See more</a>
+      </div>
+    {{/if}}
   {{else}}
-    <div class="inline-edit inline-edit--active">
+    {{#if showPeopleGroupModal}}
+      <people-group-modal
+        {title}="title"
+        {is-loading}="isLoading"
+        {empty-list-message}="emptyListMessage"
+        {(people)}="people">
+      </people-group-modal>
+    {{else}}
+      <div class="inline-edit inline-edit--active">
         <div class="inline-edit__content editable-people-group__inline">
           <div class="editable-people-group__inline-content">
             <object-list
@@ -55,6 +71,7 @@
             </ul>
           </div>
         </div>
-    </div>
+      </div>
+    {{/if}}
   {{/unless}}
 </div>

--- a/src/ggrc/assets/stylesheets/_colors.scss
+++ b/src/ggrc/assets/stylesheets/_colors.scss
@@ -119,6 +119,7 @@ $btnPriority: #4B898B;
 $redBtn:#F44336;
 $lightBlueBtn: #03A9F4;
 $createBtn: #1976D2;
+$unmapIcon: #797979;
 
 // compliance
 $defaultWidget: #444;

--- a/src/ggrc/assets/stylesheets/components/people-group/_people-group.scss
+++ b/src/ggrc/assets/stylesheets/components/people-group/_people-group.scss
@@ -21,13 +21,18 @@
 
     .people-group__title {
       text-transform: uppercase;
-      font-size: 12px;
-      font-weight: bold;
-      margin-bottom: 0px;
       overflow: hidden;
       white-space: nowrap;
       text-overflow: ellipsis;
-      max-width: 240px;
+      max-width: 160px;
+      margin-right: 4px;
+    }
+
+    .people-group__title-content {
+      display: flex;
+      font-size: 12px;
+      font-weight: bold;
+      margin-bottom: 0px;
     }
 
     .people-group__title-spinner {
@@ -92,7 +97,85 @@
       }
 
       .person-name {
-        max-width: 210px;
+        max-width: 160px;
+      }
+    }
+
+    .editable-people-group__see-more {
+      margin-top: 8px;
+    }
+  }
+
+  .people-group-modal {
+    max-width: 800px;
+
+    .people-group-modal__people-list {
+      display: flex;
+      flex-direction: row;
+      flex-wrap: wrap;
+
+      .object-list__item:not(.object-list__item-empty) {
+        background: #f3f3f3;
+
+        padding: 6px 10px;
+        border-radius: 16px;
+        line-height: 14px;
+        margin: 5px 6px 5px 0;
+
+        .person-name {
+          font-style: normal;
+        }
+      }
+    }
+
+    .people-group-modal__unmap {
+      margin-left: 4px;
+      opacity: 1;
+
+      .fa {
+        color: $unmapIcon;
+      }
+    }
+
+    .people-group-modal__people-section {
+      max-height: 500px;
+      overflow: auto;
+    }
+
+    .people-group-modal__footer {
+      line-height: 30px;
+    }
+
+    .people-group-modal__button {
+      line-height: 18px;
+      margin-left: 10px;
+    }
+
+    .people-group-modal__selected-count {
+      opacity: 0.6;
+    }
+
+    .simple-modal {
+      &__header {
+        border-bottom: none;
+      }
+  
+      &__title__name {
+        font-size: 24px;
+      }
+  
+      &__body {
+        padding-top: 8px;
+      }
+  
+      &__sub-header-section {
+        font-size: 15px;
+        margin-bottom: 40px;
+      }
+  
+      &__footer {
+        border-top: none;
+        padding: 16px;
       }
     }
   }

--- a/test/selenium/src/lib/constants/locator.py
+++ b/test/selenium/src/lib/constants/locator.py
@@ -681,6 +681,12 @@ class CommonWidgetInfo(object):
       By.CSS_SELECTOR, "{} .object-approved".format(WIDGET))
   LINK_SUBMIT_FOR_REVIEW = (By.CSS_SELECTOR,
                             "{} .non-transparent".format(WIDGET))
+  # people section
+  _PEOPLE_ITEM = ".editable-people-group"
+  PEOPLE_HEADERS_AND_VALUES_CSS = (By.CSS_SELECTOR, _PEOPLE_ITEM)
+  PEOPLE_HEADER_CSS = (
+      By.CSS_SELECTOR, _PEOPLE_ITEM + " editable-people-group-header")
+  PEOPLE_VALUE_CSS = (By.CSS_SELECTOR, _PEOPLE_ITEM + " object-list")
   # user input elements
   BUTTON_3BBS = (By.XPATH, _INFO_WIDGET_XPATH + "//*[@data-toggle='dropdown']")
 

--- a/test/selenium/src/lib/constants/messages.py
+++ b/test/selenium/src/lib/constants/messages.py
@@ -114,3 +114,7 @@ class ExceptionsMessages(CommonMessages):
   err_server_response = "Server response: (code: {}, message: {})\n"
   err_pagination_count = "Count of pagination controllers is not {}\n"
   err_pagination_elements = "Pagination controllers were not found {}\n"
+  err_counters_are_different = (
+      "Counter: {} is different to another counter: {}\n")
+  err_results_are_different = (
+      "Expected result: {} is different to Actual result: {}\n")

--- a/test/selenium/src/lib/constants/regex.py
+++ b/test/selenium/src/lib/constants/regex.py
@@ -5,4 +5,5 @@
 WIDGET_TITLE_AND_COUNT = r"(.*) \((.*)\)"
 URL_WIDGET_INFO = (
     r"//[0-9a-z\-.]*[:0-9]*?/([a-z_]*)/?(\d*)#?([^/]*)/([a-z_]*)/?(\d*)/*")
-TEXT_WITHIN_PARENTHESES = r"\([^)]*\) "
+TEXT_W_PARENTHESES = r"\([^)]*\) "
+TEXT_WO_PARENTHESES = r"\((.*?)\)"

--- a/test/selenium/src/lib/constants/roles.py
+++ b/test/selenium/src/lib/constants/roles.py
@@ -4,6 +4,7 @@
 
 # global roles
 NO_ROLE = "No role"
+NO_ROLE_UI = "(Inactive user)"
 ADMIN = "Admin"
 CREATOR = "Creator"
 READER = "Reader"

--- a/test/selenium/src/lib/element/elements_list.py
+++ b/test/selenium/src/lib/element/elements_list.py
@@ -62,3 +62,4 @@ class TabController(base.ElementsList):
       self._active_tab = self.get_item(tab_name)
       selenium_utils.scroll_into_view(self._driver, self._active_tab.element)
       self._active_tab.click()
+      selenium_utils.wait_for_js_to_load(self._driver)

--- a/test/selenium/src/lib/element/tables.py
+++ b/test/selenium/src/lib/element/tables.py
@@ -77,6 +77,7 @@ class AssessmentRelatedIssuesTable(CommonTable):
     raise_btn.click()
     create_new_object.IssuesCreate(self._driver).fill_minimal_data(
         issue_entity.title, issue_entity.slug).save_and_close()
+    selenium_utils.wait_for_js_to_load(self._driver)
 
 
 class AssessmentRelatedAsmtsTable(CommonTable):

--- a/test/selenium/src/lib/page/widget/info_widget.py
+++ b/test/selenium/src/lib/page/widget/info_widget.py
@@ -27,6 +27,7 @@ class InfoWidget(base.Widget):
 
   def __init__(self, driver):
     super(InfoWidget, self).__init__(driver)
+    selenium_utils.wait_for_js_to_load(self._driver)
     self.child_cls_name = self.__class__.__name__.lower()
     self.list_all_headers_txt = []
     self.list_all_values_txt = []
@@ -126,10 +127,13 @@ class InfoWidget(base.Widget):
     'header_text' = 'ASSIGNEE(S)', return: ['ASSIGNEE(S)', 'user@example.com']
     """
     # pylint: disable=invalid-name
+    # pylint: disable=expression-not-assigned
     _header_msg, _value_msg = (
         "people header: {}, count: {}", "people list: {}, count: {}")
     people_scopes = self._driver.find_elements(
         *self._locators.PEOPLE_HEADERS_AND_VALUES_CSS)
+    [selenium_utils.wait_until_stops_moving(people_scope)
+     for people_scope in people_scopes]
     matched_people_scopes = [people_scope for people_scope in people_scopes
                              if header_text in people_scope.text]
     if len(matched_people_scopes) != 1:
@@ -160,7 +164,7 @@ class InfoWidget(base.Widget):
       raise ValueError(
           messages.ExceptionsMessages.err_counters_are_different.format(
               _header_msg.format(
-                  people_header_txt, str(people_count_from_header)),
+                  _people_header_parts, str(people_count_from_header)),
               _value_msg.format(people_value_txt, len(people_value_txt))))
     return (people_header_txt,
             None if people_value_txt == ["None"] else people_value_txt)

--- a/test/selenium/src/lib/service/webui_service.py
+++ b/test/selenium/src/lib/service/webui_service.py
@@ -70,14 +70,16 @@ class BaseWebUiService(object):
                   all(isinstance(comment, dict) for comment in val)):
             # extract datetime from u'(Creator) 08/20/2017 07:30:45 AM +03:00'
             scope[key] = [
-                {k: (parser.parse(re.sub(regex.TEXT_WITHIN_PARENTHESES,
+                {k: (parser.parse(re.sub(regex.TEXT_W_PARENTHESES,
                                          string_utils.BLANK, v)
                                   ).astimezone(tz=tz.tzutc())
                      if k == "created_at" else v)
                  for k, v in comment.iteritems()} for comment in val]
           # convert multiple values to list of strings and split if need it
-          if key in ["owners", "assessor", "creator", "verifier"]:
-            # split multiple values if need 'Ex1, Ex2 F' to ['Ex1', 'Ex2 F']
+          if (key in ["owners", "assessor", "creator", "verifier"] and
+             not isinstance(val, list)):
+            # split Tree View values if need 'Ex1, Ex2 F' to ['Ex1', 'Ex2 F']
+            # Info Widget values will be represent by internal methods
             scope[key] = val.split(", ")
           # convert 'slug' from CSV for snapshoted objects u'*23eb72ac-4d9d'
           if (key == "slug" and


### PR DESCRIPTION
# Issue description

The People list, which contain a lot of people, uses a big area of page.

# Steps to reproduce

Open "Control" info page.
Add 10+ persons in one of Custom Roles

# Solution description

**If person list contains more than 4 people**:
  1) _Edit mode_: show modal with "Add Person" input and list of added people items.
![screen shot 2017-10-12 at 3 29 31 pm](https://user-images.githubusercontent.com/4204416/31495946-317b72cc-af62-11e7-8d5f-2afd0c6fd564.png)

  2) _Read mode_: show only 4 people and "See more" link. See more link should turn on "Edit" mode.
![screen shot 2017-10-12 at 3 29 39 pm](https://user-images.githubusercontent.com/4204416/31495951-3704bdd4-af62-11e7-99a4-0ab359f62874.png)


**If person list contains 1 - 4 persons:**
  The People list should work as before.

# Sanity check list

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests (if not, include a reason).
- [x] My changes follow the [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/performance.rst).
- [x] My changes follow the [js](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/git/how_to_write_a_commit_message.rst).