### PR TITLE
GGRC-3202 Set default selections for 'Filter sub tree' on tree view

### DIFF
--- a/src/ggrc/assets/javascripts/components/view-models/tests/tree-item-base-vm_spec.js
+++ b/src/ggrc/assets/javascripts/components/view-models/tests/tree-item-base-vm_spec.js
@@ -15,7 +15,10 @@ describe('GGRC.VM.BaseTreeItemVM', function () {
   describe('initChildTreeDisplay() method', function () {
     beforeEach(function () {
       spyOn(GGRC.Utils.TreeView, 'getModelsForSubTier')
-        .and.returnValue(['Foo', 'Bar', 'Baz']);
+        .and.returnValue({
+          available: ['Foo', 'Bar', 'Baz'],
+          selected: ['Foo'],
+        });
       spyOn(GGRC.Utils.ObjectVersions, 'getWidgetConfig')
         .and.callFake(function (model) {
           return {
@@ -34,8 +37,8 @@ describe('GGRC.VM.BaseTreeItemVM', function () {
       modelsList = vm.attr('selectedChildModels').serialize();
       displayList = vm.attr('childModelsList').serialize();
 
-      expect(modelsList.length).toEqual(3);
-      expect(modelsList).toEqual(['Foo', 'Bar', 'Baz']);
+      expect(modelsList.length).toEqual(1);
+      expect(modelsList).toEqual(['Foo']);
 
       expect(displayList).toEqual([
         {
@@ -45,11 +48,11 @@ describe('GGRC.VM.BaseTreeItemVM', function () {
         }, {
           name: 'Bar',
           widgetName: 'BarWidget',
-          display: true,
+          display: false,
         }, {
           name: 'Baz',
           widgetName: 'BazWidget',
-          display: true,
+          display: false,
         },
       ]);
     });
@@ -80,12 +83,12 @@ describe('GGRC.VM.BaseTreeItemVM', function () {
 
     it('calls the select method woth the element from event', function () {
       var event = {
-        element: 'fakeElement'
+        element: 'fakeElement',
       };
       vm.onPreview(event);
 
       expect(vm.select).toHaveBeenCalledWith('fakeElement');
-    })
+    });
   });
 
   describe('select() method', function () {
@@ -93,7 +96,7 @@ describe('GGRC.VM.BaseTreeItemVM', function () {
 
     beforeEach(function () {
       fakeElement = {
-        closest: jasmine.createSpy()
+        closest: jasmine.createSpy(),
       };
 
       spyOn(can, 'trigger');
@@ -114,6 +117,6 @@ describe('GGRC.VM.BaseTreeItemVM', function () {
 
     describe('for Person instances', function () {
       //
-    })
+    });
   });
 });

--- a/src/ggrc/assets/javascripts/components/view-models/tree-item-base-vm.js
+++ b/src/ggrc/assets/javascripts/components/view-models/tree-item-base-vm.js
@@ -30,18 +30,19 @@
     selectedChildModels: [],
     initChildTreeDisplay: function () {
       var modelName = this.attr('instance').type;
-      var modelsList = TreeViewUtils.getModelsForSubTier(modelName);
-      var displayList = modelsList.map(function (model) {
+      var models = TreeViewUtils.getModelsForSubTier(modelName);
+
+      var displayList = models.available.map(function (model) {
         return {
           widgetName: GGRC.Utils.ObjectVersions
             .getWidgetConfig(model).widgetName,
           name: model,
-          display: true,
+          display: models.selected.indexOf(model) !== -1,
         };
       });
 
       this.attr('childModelsList', displayList);
-      this.attr('selectedChildModels', modelsList);
+      this.attr('selectedChildModels', models.selected);
     },
     setChildModels: function (selected) {
       this.attr('selectedChildModels', selected);

--- a/src/ggrc/assets/javascripts/models/assessment.js
+++ b/src/ggrc/assets/javascripts/models/assessment.js
@@ -100,6 +100,9 @@
       display_attr_names: ['title', 'status', 'assignees', 'verifiers',
         'updated_at']
     },
+    sub_tree_view_options: {
+      default_filter: ['Control'],
+    },
     info_pane_options: {
     },
     confirmEditModal: {

--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -139,6 +139,9 @@
       }],
       draw_children: true
     },
+    sub_tree_view_options: {
+      default_filter: ['Product'],
+    },
     init: function () {
       if (this._super) {
         this._super.apply(this, arguments);

--- a/src/ggrc/assets/javascripts/models/business_object_models.js
+++ b/src/ggrc/assets/javascripts/models/business_object_models.js
@@ -39,6 +39,9 @@
         {attr_title: 'Last Deprecated Date', attr_name: 'end_date'}
       ])
     },
+    sub_tree_view_options: {
+      default_filter: ['Program'],
+    },
     links_to: {
       System: {},
       Process: {},
@@ -98,6 +101,9 @@
         {attr_title: 'Last Deprecated Date', attr_name: 'end_date'}
       ]),
       add_item_view: GGRC.mustache_path + '/base_objects/tree_add_item.mustache'
+    },
+    sub_tree_view_options: {
+      default_filter: ['Program'],
     },
     links_to: {
       System: {},
@@ -160,6 +166,9 @@
       add_item_view:
         GGRC.mustache_path + '/base_objects/tree_add_item.mustache'
     },
+    sub_tree_view_options: {
+      default_filter: ['Program'],
+    },
     links_to: {
       System: {},
       Process: {},
@@ -220,6 +229,9 @@
       ]),
       add_item_view:
         GGRC.mustache_path + '/base_objects/tree_add_item.mustache'
+    },
+    sub_tree_view_options: {
+      default_filter: ['System'],
     },
     links_to: {
       System: {},
@@ -282,6 +294,9 @@
       add_item_view:
         GGRC.mustache_path + '/base_objects/tree_add_item.mustache'
     },
+    sub_tree_view_options: {
+      default_filter: ['Policy'],
+    },
     links_to: {
       System: {},
       Process: {},
@@ -342,6 +357,9 @@
       add_item_view:
         GGRC.mustache_path + '/base_objects/tree_add_item.mustache'
     },
+    sub_tree_view_options: {
+      default_filter: ['System'],
+    },
     links_to: {
       System: {},
       Process: {},
@@ -400,6 +418,9 @@
         {attr_title: 'Last Deprecated Date', attr_name: 'end_date'}
       ]),
       add_item_view: GGRC.mustache_path + '/base_objects/tree_add_item.mustache'
+    },
+    sub_tree_view_options: {
+      default_filter: ['Program'],
     },
     links_to: {
       System: {},
@@ -460,6 +481,9 @@
       ]),
       add_item_view:
         GGRC.mustache_path + '/base_objects/tree_add_item.mustache'
+    },
+    sub_tree_view_options: {
+      default_filter: ['Program'],
     },
     links_to: {
       System: {},

--- a/src/ggrc/assets/javascripts/models/cacheable.js
+++ b/src/ggrc/assets/javascripts/models/cacheable.js
@@ -670,6 +670,7 @@
       display_attr_names: ['title', 'owner', 'status'],
       mandatory_attr_names: ['title']
     },
+    sub_tree_view_options: {},
     obj_nav_options: {},
     list_view_options: {},
 

--- a/src/ggrc/assets/javascripts/models/control.js
+++ b/src/ggrc/assets/javascripts/models/control.js
@@ -80,6 +80,9 @@
       show_related_assessments: true,
       draw_children: true
     },
+    sub_tree_view_options: {
+      default_filter: ['Objective'],
+    },
     info_pane_options: {
       evidence: {
         model: CMS.Models.Document,

--- a/src/ggrc/assets/javascripts/models/directive_models.js
+++ b/src/ggrc/assets/javascripts/models/directive_models.js
@@ -93,6 +93,9 @@ CMS.Models.Directive("CMS.Models.Standard", {
   , attributes : {}
   , meta_kinds : [ "Standard" ]
   , cache : can.getObject("cache", CMS.Models.Directive, true),
+  sub_tree_view_options: {
+    default_filter: ['Section']
+  },
   defaults: {
     status: 'Draft',
     kind: 'Standard'
@@ -123,6 +126,9 @@ CMS.Models.Directive("CMS.Models.Regulation", {
   , attributes : {}
   , meta_kinds : [ "Regulation" ]
   , cache : can.getObject("cache", CMS.Models.Directive, true),
+  sub_tree_view_options: {
+    default_filter: ['Section']
+  },
   defaults: {
     status: 'Draft',
     kind: 'Regulation'
@@ -154,6 +160,9 @@ CMS.Models.Directive("CMS.Models.Policy", {
   , attributes : {}
   , meta_kinds : [  "Company Policy", "Org Group Policy", "Data Asset Policy", "Product Policy", "Contract-Related Policy", "Company Controls Policy" ]
   , cache : can.getObject("cache", CMS.Models.Directive, true),
+  sub_tree_view_options: {
+    default_filter: ['DataAsset'],
+  },
   defaults: {
     status: 'Draft',
     kind: null
@@ -196,6 +205,9 @@ CMS.Models.Directive("CMS.Models.Contract", {
   }
   , meta_kinds : [ "Contract" ]
   , cache : can.getObject("cache", CMS.Models.Directive, true),
+  sub_tree_view_options: {
+    default_filter: ['Clause'],
+  },
   defaults: {
     status: 'Draft',
     kind: 'Contract'

--- a/src/ggrc/assets/javascripts/models/issue.js
+++ b/src/ggrc/assets/javascripts/models/issue.js
@@ -32,6 +32,9 @@
       attr_view: GGRC.mustache_path + '/base_objects/tree-item-attr.mustache',
       display_attr_names: ['title', 'Admin', 'status'],
     },
+    sub_tree_view_options: {
+      default_filter: ['Control', 'Control_versions'],
+    },
     info_pane_options: {
     },
     defaults: {

--- a/src/ggrc/assets/javascripts/models/person.js
+++ b/src/ggrc/assets/javascripts/models/person.js
@@ -99,6 +99,9 @@
     list_view_options: {
       find_params: {__sort: 'name,email'}
     },
+    sub_tree_view_options: {
+      default_filter: ['Program', 'Control', 'Risk', 'Assessment'],
+    },
     init: function () {
       var rEmail =
         /^[-!#$%&*+\\.\/0-9=?A-Z^_`{|}~]+@([-0-9A-Z]+\.)+([0-9A-Z]){2,4}$/i;

--- a/src/ggrc/assets/javascripts/models/section.js
+++ b/src/ggrc/assets/javascripts/models/section.js
@@ -43,6 +43,9 @@ can.Model.Cacheable('CMS.Models.Section', {
     ]),
     add_item_view: GGRC.mustache_path + '/snapshots/tree_add_item.mustache'
   },
+  sub_tree_view_options: {
+    default_filter: ['Objective'],
+  },
   defaults: {
     status: 'Draft'
   },
@@ -91,6 +94,9 @@ can.Model.Cacheable('CMS.Models.Clause', {
       {attr_title: 'Last Deprecated Date', attr_name: 'end_date'}
     ]),
     add_item_view: GGRC.mustache_path + '/snapshots/tree_add_item.mustache'
+  },
+  sub_tree_view_options: {
+    default_filter: ['Contract'],
   },
   defaults: {
     status: 'Draft'

--- a/src/ggrc/assets/javascripts/models/simple_models.js
+++ b/src/ggrc/assets/javascripts/models/simple_models.js
@@ -64,6 +64,9 @@
       ]),
       add_item_view: GGRC.mustache_path + '/base_objects/tree_add_item.mustache'
     },
+    sub_tree_view_options: {
+      default_filter: ['Standard'],
+    },
     links_to: {
       System: {},
       Process: {},
@@ -150,6 +153,9 @@
       show_related_assessments: true,
       // draw_children: true,
       start_expanded: false
+    },
+    sub_tree_view_options: {
+      default_filter: ['Control'],
     },
     defaults: {
       status: 'Draft'

--- a/src/ggrc/assets/javascripts/models/system.js
+++ b/src/ggrc/assets/javascripts/models/system.js
@@ -109,6 +109,9 @@ CMS.Models.SystemOrProcess('CMS.Models.System', {
     url: '',
     status: 'Draft'
   },
+  sub_tree_view_options: {
+    default_filter: ['Product'],
+  },
   statuses: ['Draft', 'Deprecated', 'Active'],
   init: function () {
     can.extend(this.attributes, CMS.Models.SystemOrProcess.attributes);
@@ -152,6 +155,9 @@ CMS.Models.SystemOrProcess('CMS.Models.Process', {
     title: '',
     url: '',
     status: 'Draft'
+  },
+  sub_tree_view_options: {
+    default_filter: ['Risk'],
   },
   mixins: ['ca_update'],
   statuses: ['Draft', 'Deprecated', 'Active'],

--- a/src/ggrc/assets/javascripts/plugins/tests/utils/tree-view-utils_spec.js
+++ b/src/ggrc/assets/javascripts/plugins/tests/utils/tree-view-utils_spec.js
@@ -38,7 +38,7 @@ describe('GGRC.Utils.TreeView module', function () {
         {id: 1, name: 'Role 1', object_type: 'Market'},
         {id: 7, name: 'Role 7', object_type: 'Policy'},
         {id: 3, name: 'Role 3', object_type: 'Audit'},
-        {id: 2, name: 'Role 2', object_type: 'Policy'}
+        {id: 2, name: 'Role 2', object_type: 'Policy'},
       ];
 
       origCustomAttrDefs = GGRC.custom_attr_defs;
@@ -75,6 +75,52 @@ describe('GGRC.Utils.TreeView module', function () {
         };
         expect(result).toContain(jasmine.objectContaining(expected));
       });
+    });
+  });
+
+  describe('getModelsForSubTier() method', function () {
+    var baseWidgetsByType;
+    var origFilter;
+
+    beforeAll(function () {
+      baseWidgetsByType = GGRC.tree_view.attr('base_widgets_by_type');
+      origFilter = CMS.Models.CycleTaskGroupObjectTask
+        .sub_tree_view_options.default_filter;
+
+      GGRC.tree_view.attr('base_widgets_by_type', {
+        CycleTaskGroupObjectTask: ['Audit', 'Program'],
+      });
+    });
+
+    afterAll(function () {
+      GGRC.tree_view.attr('base_widgets_by_type', baseWidgetsByType);
+      CMS.Models.CycleTaskGroupObjectTask
+        .sub_tree_view_options.default_filter = origFilter;
+    });
+
+    it('gets selected models from model\'s default_filter when available',
+    function () {
+      var result;
+
+      CMS.Models.CycleTaskGroupObjectTask
+        .sub_tree_view_options.default_filter = ['Audit'];
+
+      result = module.getModelsForSubTier('CycleTaskGroupObjectTask');
+      expect(result.available.length).toEqual(2);
+      expect(result.selected.length).toEqual(1);
+      expect(result.selected[0]).toEqual('Audit');
+    });
+
+    it('returns all available models as selected when ' +
+      'model\'s default_filter is not available', function () {
+      var result;
+
+      CMS.Models.CycleTaskGroupObjectTask
+        .sub_tree_view_options.default_filter = null;
+
+      result = module.getModelsForSubTier('CycleTaskGroupObjectTask');
+      expect(result.available.length).toEqual(2);
+      expect(result.selected.length).toEqual(2);
     });
   });
 });

--- a/src/ggrc/assets/javascripts/plugins/utils/tree-view-utils.js
+++ b/src/ggrc/assets/javascripts/plugins/utils/tree-view-utils.js
@@ -340,15 +340,36 @@
       return can.Deferred().resolve();
     }
 
-    function getModelsForSubTier(model) {
+    /**
+     * Get available and selected models for the Model sub tier
+     * @param {String} modelName - Model name.
+     * @return {Object} Sub tier filter configuration.
+     */
+    function getModelsForSubTier(modelName) {
+      var Model = CMS.Models[modelName];
+      var availableModels;
+      var selectedModels;
+
       // getMappableTypes can't be run at once,
       // cause GGRC.Mappings is not loaded yet
-      if (model === 'CycleTaskGroupObjectTask' &&
-      !orderedModelsForSubTier[model].length) {
-        orderedModelsForSubTier[model] =
+      if (modelName === 'CycleTaskGroupObjectTask' &&
+      !orderedModelsForSubTier[modelName].length) {
+        orderedModelsForSubTier[modelName] =
         GGRC.Utils.getMappableTypes('CycleTaskGroupObjectTask');
       }
-      return orderedModelsForSubTier[model] || [];
+
+      availableModels = orderedModelsForSubTier[modelName] || [];
+
+      if (Model.sub_tree_view_options.default_filter) {
+        selectedModels = Model.sub_tree_view_options.default_filter;
+      } else {
+        selectedModels = availableModels;
+      }
+
+      return {
+        available: availableModels,
+        selected: selectedModels,
+      };
     }
 
     /**

--- a/src/ggrc_risk_assessments/assets/javascripts/models/risk_assessment.js
+++ b/src/ggrc_risk_assessments/assets/javascripts/models/risk_assessment.js
@@ -47,6 +47,9 @@
       ],
       add_item_view: path + '/tree_add_item.mustache'
     },
+    sub_tree_view_options: {
+      default_filter: ['Program'],
+    },
     init: function () {
       this._super && this._super.apply(this, arguments);
       this.validateNonBlank("title");

--- a/src/ggrc_risks/assets/javascripts/models/risk.js
+++ b/src/ggrc_risks/assets/javascripts/models/risk.js
@@ -33,6 +33,9 @@
         {attr_title: 'Last Deprecated Date', attr_name: 'end_date'}
       ])
     },
+    sub_tree_view_options: {
+      default_filter: ['Control'],
+    },
     defaults: {
       status: 'Draft'
     },

--- a/src/ggrc_risks/assets/javascripts/models/threat.js
+++ b/src/ggrc_risks/assets/javascripts/models/threat.js
@@ -41,6 +41,9 @@
         {attr_title: 'Last Deprecated Date', attr_name: 'end_date'}
       ])
     },
+    sub_tree_view_options: {
+      default_filter: ['Risk'],
+    },
     defaults: {
       status: 'Draft'
     },

--- a/src/ggrc_workflows/assets/javascripts/models/cycle_models.js
+++ b/src/ggrc_workflows/assets/javascripts/models/cycle_models.js
@@ -347,6 +347,9 @@
       mandatory_attr_name: ['title'],
       draw_children: true
     },
+    sub_tree_view_options: {
+      default_filter: ['Control'],
+    },
     init: function () {
       var that = this;
       this._super.apply(this, arguments);


### PR DESCRIPTION
# Issue description

Each object should have default settings for 'Filter sub tree' filter due to the table:
https://docs.google.com/spreadsheets/d/11CHxbJZHPwD8rc9-4xCDnHbhQ4SE2SKDJcGxckuk2MQ/edit#gid=0

# Solution description

Specify sub_tree_view_options prop for every required model. Use it to get default filter settings for sub tree view filter.

# Sanity check list

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests (if not, include a reason).
- [x] My changes follow the [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/performance.rst).
- [x] My changes follow the [js](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/git/how_to_write_a_commit_message.rst).

