### PR TITLE
GGRC-3580 Edit icon shows up for Global reader while hovering over GCA field

### DIFF
--- a/src/ggrc/assets/mustache/custom_attributes/info.mustache
+++ b/src/ggrc/assets/mustache/custom_attributes/info.mustache
@@ -22,6 +22,7 @@
             with-read-more="true">
               <base-inline-control-title
                 {edit-mode}="editMode"
+                {is-edit-icon-denied}="isEditDenied"
                 (set-edit-mode-inline)="setEditModeInline(%event)">
                   <div class="info-pane__section-title">{{title}}</div>
               </base-inline-control-title>


### PR DESCRIPTION
Steps to reproduce:
1. Add GCA for Program with any type (e.g. date)
2. Log as admin
3. Create a program
4. Log as Global Reader (globreader@gmail.com (engage007)
5. Open program created by admin
6. Hover over GCA field: edit icon is shown screenshot-1.png
Actual Result: Edit icon shows up for Global reader while hovering over GCA field. While editing GCA and saving a value, 'There was a problem saving' error message occurs screenshot-2.png, value is displayed in GCA field. After page refresh a value is not shown in GCA field.
Expected Result: Global Reader should have only 'Read' permissions if he is not creator of the object, program editor, program manager
NOTE: The same behavior is for Global creator with read rights.