### PR TITLE
GGRC-3578 Cut off program managers list in tree view

### DIFF
--- a/src/ggrc/assets/mustache/programs/tree-item-attr.mustache
+++ b/src/ggrc/assets/mustache/programs/tree-item-attr.mustache
@@ -10,7 +10,7 @@
           {{#using role=instance.role}}
             {{#if_equals role.name 'ProgramOwner'}}
                 {{#using contact=instance.person}}
-                  <div class="need-comma">{{contact.email}}</div>
+                  <span class="need-comma">{{contact.email}}</span>
                 {{/using}}
             {{/if_equals}}
           {{/using}}


### PR DESCRIPTION
# Issue description

Manager names are not getting cut off in tree view

# Steps to reproduce

1. Create a program 'program1'
2. On the program Info page in Peoples tab map at least 5 user's and grant them 'Program manager' role
3. Go to the My work page > Programs tab
4. Look at the Manager column in the tree view of the 'program1': Manager names are not cut off

**Actual Result:** Manager names are not getting cut off in tree view
**Expected Result:** Manager names should be cut off in tree view

# Solution description

Text-overflow css property doesn't work with block elements. Use inline tags.

# Sanity check list

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests (if not, include a reason).
- [x] My changes follow the [js](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/python.rst) guidelines.
- [x] My changes follow the [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/performance.rst).
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/git/how_to_write_a_commit_message.rst).
