### PR TITLE
GGRC-3520 Assessment control modal should show regulations first and objectives second

### DIFF
--- a/src/ggrc/assets/mustache/components/assessment/mapped-objects/mapped-controls.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/mapped-objects/mapped-controls.mustache
@@ -44,14 +44,14 @@
         </collapsible-panel>
         {{#is assessmentType 'Control'}}
             <assessment-mapped-control-related-objects class="mapped-controls-info__related-objects"
-                                                    title-text="Show Related Objectives ({{objectives.length}})"
-                                                    type="Objective"
-                                                    {items}="objectives">
-            </assessment-mapped-control-related-objects>
-            <assessment-mapped-control-related-objects class="mapped-controls-info__related-objects"
                                                     title-text="Show Related Regulations ({{regulations.length}})"
                                                     type="Regulation"
                                                     {items}="regulations">
+            </assessment-mapped-control-related-objects>
+            <assessment-mapped-control-related-objects class="mapped-controls-info__related-objects"
+                                                    title-text="Show Related Objectives ({{objectives.length}})"
+                                                    type="Objective"
+                                                    {items}="objectives">
             </assessment-mapped-control-related-objects>
         {{/is}}
     </div>


### PR DESCRIPTION
Steps to reproduce:
1. Have program, control, regulation, objective mapped to program and control
2. Create and map audit to program
3. Go to Audit page
4. Generate Assessment based on the control ssnapshot
5. Expand assessment info pane and open control popup
Expected Result: Assessment control modal should show regulations first and objectives second