### PR TITLE
QUICK-FIX Cleaner ticket ids list

### DIFF
--- a/bin/release/get_pr_titles.py
+++ b/bin/release/get_pr_titles.py
@@ -102,7 +102,7 @@ def try_parse_ticket_ids(title):
     "ggrc-1234/1235: Do something" -> ["GGRC-1234", "GGRC-1235"]
 
   Special prefixes:
-    "QUICK-FIX", "DOCS"
+    "QUICK-FIX", "DOCS", "MERGE", "BACKMERGE"
 
   Returns:
     a list of string ticket ids.
@@ -111,7 +111,7 @@ def try_parse_ticket_ids(title):
   ticket = ticket.upper()
   ticket = ticket.rstrip(":")
 
-  if ticket in ("QUICK-FIX", "DOCS"):
+  if ticket in ("QUICK-FIX", "DOCS", "MERGE", "BACKMERGE"):
     return [ticket]
 
   ticket = ticket.replace("/", ",")

--- a/bin/release/get_pr_titles.py
+++ b/bin/release/get_pr_titles.py
@@ -158,6 +158,16 @@ def print_unicode(line):
   print(line.encode("UTF-8"))
 
 
+def check_tickets(tickets):
+  """Splits ticket ids into valid and special/malformed."""
+  valid_ticket_re = re.compile(r"GGRC-\d+")
+
+  valid = (ticket for ticket in tickets if valid_ticket_re.match(ticket))
+  invalid = (ticket for ticket in tickets if not valid_ticket_re.match(ticket))
+
+  return valid, invalid
+
+
 def print_pr_details(pr_details):
   """Print PR list summary in table format.
 
@@ -199,9 +209,13 @@ def print_pr_details(pr_details):
 
   print_table(row_tuple, rows)
 
+  valid_tickets, invalid_tickets = check_tickets(assumed_tickets)
   print_unicode("")
   print_unicode("Assumed ticket ids")
-  print_unicode(u", ".join(assumed_tickets))
+  print_unicode(u", ".join(valid_tickets))
+  print_unicode("")
+  print_unicode("Malformed/special ticket ids")
+  print_unicode(u", ".join(invalid_tickets))
 
 
 def main():


### PR DESCRIPTION
# Issue description

The ticket list generated by `get_pr_titles` is hard to read.

# Steps to reproduce

Run `get_pr_titles` with parameters that list at least one PR starting with "MERGE" word.

# Solution description

1. "MERGE" and "BACKMERGE" (case-insensitive, same as all marks) are added to the list of "special" marks same as "DOCS" and "QUICK-FIX" (even though our guidelines don't have these documented yet, we use them heavily).
2. Ticket-like ("GGRC-some-number") marks are listed separately from all special and malformed marks.

# Sanity check list

- [ ] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else).
- [ ] My changes are covered by tests (if not, include a reason).
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/git/how_to_write_a_commit_message.rst).

The app is not affected, this is a standalone script.
The standalone scripts don't (and, IMO, shouldn't) have tests.

# Example output
```
[arymasheuski@arymasheuski ggrc-core]$ ./bin/release/get_pr_titles.py 0.10.31-Raspberry 
From https://github.com/google/ggrc-core
 * branch                release/0.10-Raspberry -> FETCH_HEAD
Username: alieh-rymasheuski
Password: 

<table skipped>

Assumed ticket ids
GGRC-3435, GGRC-3573, GGRC-3459, GGRC-3458, GGRC-3578, GGRC-3579, GGRC-3473, GGRC-3474, GGRC-2203, GGRC-3368, GGRC-3188, GGRC-3344, GGRC-3240, GGRC-2746, GGRC-2031, GGRC-3340, GGRC-3457, GGRC-3521, GGRC-3070, GGRC-3549, GGRC-3427, GGRC-3506, GGRC-3503, GGRC-3449, GGRC-3460, GGRC-2318, GGRC-2120, GGRC-3198, GGRC-3382, GGRC-3433, GGRC-3290, GGRC-3418, GGRC-2199, GGRC-2196

Malformed/special ticket ids
GGRC-REVERT, GGRC-BUMP, DOCS, QUICK-FIX, MERGE, GGRC-EPIC, BACKMERGE
```