### PR TITLE
GGRC-3588 If user invokes New Assessment modal window then clicks ESC and opens New Assessment modal once again, 'Map Objects' button becomes disabled

### DIFF
--- a/src/ggrc/assets/javascripts/bootstrap/modal-ajax.js
+++ b/src/ggrc/assets/javascripts/bootstrap/modal-ajax.js
@@ -509,6 +509,7 @@ import '../components/gca-controls/gca-controls';
       }).length < 1) {
       $el.on('keyup.preventdoubleescape', function (ev) {
         if (ev.which === 27 && $(ev.target).closest('.modal').length) {
+          $('body').trigger('closeMapper');
           $(ev.target).closest('.modal').attr('tabindex', -1).focus();
           ev.stopPropagation();
           if (ev.originalEvent) {


### PR DESCRIPTION
# Issue description

PR fix issue with 'Map Objects' button which becomes disabled If user invokes New Assessment modal window then clicks ESC and opens New Assessment modal once again.

# Steps to reproduce

1. On the audit page Invoke New Assessment modal window
2. Click ESC button on a keyboard
3. Invoke New Assessment modal window
4. Click 'Map Objects' button: is disabled
Actual Result: If user invokes New Assessment modal window then clicks ESC and opens New Assessment modal once again, 'Map Objects' button becomes disabled
Expected Result: If user invokes New Assessment modal window and then clicks ESC and opens New Assessment modal once again, 'MapObjects' button should not be disabled
NOTE: User has to refresh the page

# Sanity check list

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 
- [x] My changes are covered by tests (if not, include a reason).
- [x] My changes follow the [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/performance.rst).
- [x] My changes follow the [js](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/javascript.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/git/how_to_write_a_commit_message.rst).
