### PR TITLE
QUICK-FIX GGRC-3579 If hover over GCA fields in Control popup on the Assessment Info pane, edit icon is shown

### DIFF
--- a/src/ggrc/assets/mustache/components/assessment/mapped-objects/mapped-control-related-objects.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/mapped-objects/mapped-control-related-objects.mustache
@@ -27,7 +27,7 @@
       </div>
 
       <div class="mapped-object-info__attributes">
-          {{#using instance=.}}
+          {{#using instance=. editMode=false}}
               {{>'/static/mustache/custom_attributes/info.mustache'}}
           {{/using}}
       </div>

--- a/src/ggrc/assets/mustache/custom_attributes/info.mustache
+++ b/src/ggrc/assets/mustache/custom_attributes/info.mustache
@@ -22,6 +22,7 @@
             with-read-more="true">
               <base-inline-control-title
                 {edit-mode}="editMode"
+                {is-edit-icon-denied}="isEditIconDenied"
                 (set-edit-mode-inline)="setEditModeInline(%event)">
                   <div class="info-pane__section-title">{{title}}</div>
               </base-inline-control-title>


### PR DESCRIPTION
**Steps to reproduce**:
1. Have GCA with any type (e.g. 'Rich text') for controls, objectives, regulations
2. Create a program
3. On the program info page map to program control, objective, regulation with value in GCA field
4. Map objective and regulation to control
5. Create an audit > Go to the audit info page
6. Generate assessment based on the control snapshot
7. Navigate to Assessment Info pane and open Control popup
8. Expand "SHOW RELATED OBJECTIVES' and 'SHOW RELATED REGULATIONS'
9. Hover over GCA field: edit icon is shown

_Actual Result_: If hover over GCA fields in Control popup on the Assessment Info pane, edit icon is shown
_Expected Result_: If hover over GCA fields in Control popup on the Assessment Info pane, edit icon should not be shown

HOT-FIX of #6592 
