### PR TITLE
GGRC-2196 Add suffixes to the uploaded files

### DIFF
--- a/src/ggrc/assets/javascripts/bootstrap/modal-form.js
+++ b/src/ggrc/assets/javascripts/bootstrap/modal-form.js
@@ -393,6 +393,12 @@
       }
 
       for (type in flash) {
+        // data prop is reserved for mustache template data and
+        // we don't expect to have ajax:flash of a "data" type
+        if ( type === 'data' ) {
+          continue;
+        }
+
         if (flash[type]) {
           if (_.isString(flash[type])) {
             flash[type] = [flash[type]];
@@ -408,30 +414,34 @@
             $html.addClass('alert-autohide');
           }
 
-          for (messageI in flash[type]) {
-            if (!flash[type].hasOwnProperty(messageI)) {
-              continue;
-            }
-            message = flash[type][messageI];
-            // Skip error codes. To force display use String(...) when
-            // triggering the flash.
-            if (_.isString(message)) {
-              addLink = message.indexOf('{reload_link}') > -1;
-              message = message.replace('{reload_link}', '');
-              $html.append($(textContainer).text(message));
-              if (addLink) {
-                $html.removeClass('alert-autohide');
-                $link = $(`<a href="javascript://" class="reload-link">
-                              Show results
-                           </a>`);
-                $link.on('click', function () {
-                  if (redirectLink) {
-                    $('html').addClass('no-js');
-                    window.location.href = redirectLink;
-                  }
-                  window.location.reload();
-                });
-                $html.append($link);
+          if ( _.isFunction(flash[type]) ) {
+            $html.append(flash[type](flash.data || {}));
+          } else {
+            for (messageI in flash[type]) {
+              if (!flash[type].hasOwnProperty(messageI)) {
+                continue;
+              }
+              message = flash[type][messageI];
+              // Skip error codes. To force display use String(...) when
+              // triggering the flash.
+              if (_.isString(message)) {
+                addLink = message.indexOf('{reload_link}') > -1;
+                message = message.replace('{reload_link}', '');
+                $html.append($(textContainer).text(message));
+                if (addLink) {
+                  $html.removeClass('alert-autohide');
+                  $link = $(`<a href="javascript://" class="reload-link">
+                                Show results
+                             </a>`);
+                  $link.on('click', function () {
+                    if (redirectLink) {
+                      $('html').addClass('no-js');
+                      window.location.href = redirectLink;
+                    }
+                    window.location.reload();
+                  });
+                  $html.append($link);
+                }
               }
             }
           }

--- a/src/ggrc/assets/javascripts/bootstrap/tests/modal-form_spec.js
+++ b/src/ggrc/assets/javascripts/bootstrap/tests/modal-form_spec.js
@@ -1,0 +1,28 @@
+
+import template from './test-template.mustache';
+import '../modal-form';
+
+describe('Flash message', function () {
+  it('should trigger ajax:flash with extra data', function () {
+    var triggerData = {
+      error: can.mustache(template),
+      data: {
+        errors: [
+          {
+            msg: 'first error',
+          },
+          {
+            msg: '2nd error',
+          },
+        ],
+      },
+    };
+
+    spyOn($.prototype, 'trigger');
+
+    $(document.body).trigger('ajax:flash', triggerData);
+
+    expect($.prototype.trigger)
+      .toHaveBeenCalledWith('ajax:flash', triggerData);
+  });
+});

--- a/src/ggrc/assets/javascripts/bootstrap/tests/test-template.mustache
+++ b/src/ggrc/assets/javascripts/bootstrap/tests/test-template.mustache
@@ -1,0 +1,8 @@
+<div id="rich-flash-example">
+  <div id="ajax-flash-test-123"></div>
+  <ul>
+    {{#each errors}}
+    <li>{{msg}}</li>
+    {{/each}}
+  </ul>
+</div>

--- a/src/ggrc/assets/javascripts/components/assessment/attach-button.js
+++ b/src/ggrc/assets/javascripts/components/assessment/attach-button.js
@@ -30,6 +30,7 @@
           }
         }
       },
+      assessmentTypeObjects: [],
       canAttach: false,
       isFolderAttached: false,
       checksPassed: false,

--- a/src/ggrc/assets/javascripts/ggrc_base.js
+++ b/src/ggrc/assets/javascripts/ggrc_base.js
@@ -160,8 +160,19 @@
       'Check the form for any highlighted fields.'
     };
 
-    function notifier(type, message) {
+    /**
+     * Shows flash notification
+     * @param  {String} type    type of notification. error|warning
+     * @param  {String} message Plain text message or mustache template if data is passed
+     * @param  {Object} data data to populate mustache template
+     */
+    function notifier(type, message, data) {
       var props = {};
+
+      if ( message && data ) {
+        message = can.mustache(message);
+        props.data = data;
+      }
 
       type = type || 'warning';
       props[type] = message || GGRC.Errors.messages.default;

--- a/src/ggrc/assets/mustache/components/assessment/attach-button.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/attach-button.mustache
@@ -9,6 +9,7 @@
       {{#if canAttach}}
         {{#if isFolderAttached}}
           <ggrc-gdrive-picker-launcher class="attachment-upload-control__button"
+				       {assessment-type-objects}="assessmentTypeObjects"
                                        instance="instance"
                                        click_event="trigger_upload_parent"
                                        {disabled}="isAttachActionDisabled"
@@ -18,6 +19,7 @@
           </ggrc-gdrive-picker-launcher>
         {{else}}
          <ggrc-gdrive-picker-launcher class="attachment-upload-control__button"
+				       {assessment-type-objects}="assessmentTypeObjects"
                                        instance="instance"
                                        click_event="trigger_upload"
                                        {disabled}="isAttachActionDisabled"

--- a/src/ggrc/assets/mustache/components/assessment/info-pane/info-pane.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/info-pane/info-pane.mustache
@@ -108,6 +108,7 @@
                                         {on-state-change-dfd}="onStateChangeDfd"
                                         {edit-mode}="editMode">
                             <attach-button
+					{assessment-type-objects}="assessmentTypeObjects"
                                         (before-create)="addItems(%event, 'evidences')"
                                         (refresh-evidences)="updateItems('evidences')"
                                         {is-attach-action-disabled}="isUpdatingEvidences"
@@ -195,6 +196,7 @@
                                     {instance}="instance"
                                     {is-disabled}="isUpdatingEvidences">
                           <ca-object-modal-content {instance}="instance"
+						   {assessment-type-objects}="assessmentTypeObjects"
                                                    {content}="modal.content"
                                                    {state}="state"
                                                    {evidences}="evidences"

--- a/src/ggrc/assets/mustache/components/ca-object/ca-object-modal-content.mustache
+++ b/src/ggrc/assets/mustache/components/ca-object/ca-object-modal-content.mustache
@@ -38,6 +38,7 @@
                 </editable-document-object-list-item>
             </object-list>
             <attach-button
+		    {assessment-type-objects}="assessmentTypeObjects"
                     (before-create)="addItems(%event, 'evidences')"
                     (refresh-evidences)="updateItems('evidences')"
                     {is-attach-action-disabled}="isUpdatingEvidences"

--- a/src/ggrc_gdrive_integration/assets/javascripts/components/gdrive_folder_picker.js
+++ b/src/ggrc_gdrive_integration/assets/javascripts/components/gdrive_folder_picker.js
@@ -3,7 +3,7 @@
  * Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  */
 
-import '../utils/gdrive-picker-utils.js';
+import {ensurePickerDisposed} from '../utils/gdrive-picker-utils.js';
 
 (function (can, $) {
   'use strict';
@@ -362,7 +362,7 @@ import '../utils/gdrive-picker-utils.js';
           } else if (data[ACTION] === CANCEL) {
             el.trigger('rejected');
           }
-          GGRC.Utils.GDrivePicker.ensurePickerDisposed(picker, data);
+          ensurePickerDisposed(picker, data);
         }
 
         dfd = GGRC.Controllers.GAPI.reAuthorize(gapi.auth.getToken());

--- a/src/ggrc_gdrive_integration/assets/javascripts/components/gdrive_folder_picker.js
+++ b/src/ggrc_gdrive_integration/assets/javascripts/components/gdrive_folder_picker.js
@@ -3,7 +3,10 @@
  * Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  */
 
-import {ensurePickerDisposed} from '../utils/gdrive-picker-utils.js';
+import {
+  uploadFiles,
+  GDRIVE_PICKER_ERR_CANCEL,
+} from '../utils/gdrive-picker-utils.js';
 
 (function (can, $) {
   'use strict';
@@ -294,84 +297,19 @@ import {ensurePickerDisposed} from '../utils/gdrive-picker-utils.js';
         });
       },
       'a[data-toggle=gdrive-picker] click': function (el, ev) {
-        var folder_id = el.data('folder-id');
-        var dfd;
-        var picker;
-
-        // Create and render a Picker object for searching images.
-        function createPicker() {
-          GGRC.Controllers.GAPI.oauth_dfd.done(function (token, oauth_user) {
-            var dialog;
-            var view;
-            var docsUploadView;
-            var docsView;
-
-            picker = new google.picker.PickerBuilder()
-                  .setOAuthToken(gapi.auth.getToken().access_token)
-                  .setDeveloperKey(GGRC.config.GAPI_KEY)
-                  .setCallback(pickerCallback);
-
-            if (el.data('type') === 'folders') {
-              view = new google.picker.DocsView(google.picker.ViewId.FOLDERS)
-                .setMimeTypes(['application/vnd.google-apps.folder'])
-                .setSelectFolderEnabled(true);
-              picker.setTitle('Select folder');
-              picker.addView(view);
-            } else {
-              docsUploadView = new google.picker.DocsUploadView()
-                .setParent(folder_id);
-              docsView = new google.picker.DocsView()
-                .setParent(folder_id);
-
-              picker.addView(docsUploadView)
-                .addView(docsView)
-                .enableFeature(google.picker.Feature.MULTISELECT_ENABLED);
-            }
-            picker = picker.build();
-            picker.setVisible(true);
-            // use undocumented fu to make the Picker be "modal"
-            // this is the "mask" displayed behind the dialog box div
-            $('div.picker-dialog-bg').css('zIndex', 4000);  // there are multiple divs of that sort
-            // and this is the dialog box modal div, which we must display on top of our modal, if any
-
-            dialog = GGRC.Utils.getPickerElement(picker);
-            if (dialog) {
-              dialog.style.zIndex = 4001; // our modals start with 2050
-            }
+        uploadFiles({
+          parentId: el.data('folder-id'),
+          pickFolder: el.data('type') === 'folders',
+        }).then((files, action) => {
+          el.trigger('picked', {
+            files,
           });
-        }
-
-        function pickerCallback(data) {
-          var files;
-          var model;
-          var PICKED = google.picker.Action.PICKED;
-          var ACTION = google.picker.Response.ACTION;
-          var DOCUMENTS = google.picker.Response.DOCUMENTS;
-          var CANCEL = google.picker.Action.CANCEL;
-
-          if (data[ACTION] === PICKED) {
-            if (el.data('type') === 'folders') {
-              model = CMS.Models.GDriveFolder;
-            } else {
-              model = CMS.Mdoels.GDriveFile;
-            }
-            files = model.models(data[DOCUMENTS]);
-            el.trigger('picked', {
-              files: files
-            });
-          } else if (data[ACTION] === CANCEL) {
+        })
+        .fail((err)=>{
+          if ( err && err.type === GDRIVE_PICKER_ERR_CANCEL ) {
             el.trigger('rejected');
           }
-          ensurePickerDisposed(picker, data);
-        }
-
-        dfd = GGRC.Controllers.GAPI.reAuthorize(gapi.auth.getToken());
-        dfd.fail(this.unsetCurrent.bind(this))
-          .done(function () {
-            gapi.load('picker', {
-              callback: createPicker
-            });
-          });
+        });
       },
 
       /*

--- a/src/ggrc_gdrive_integration/assets/javascripts/components/gdrive_picker_launcher.js
+++ b/src/ggrc_gdrive_integration/assets/javascripts/components/gdrive_picker_launcher.js
@@ -3,7 +3,7 @@
  * Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  */
 
-import '../utils/gdrive-picker-utils.js';
+import {ensurePickerDisposed} from '../utils/gdrive-picker-utils.js';
 import errorTpl from './templates/gdrive_picker_launcher_upload_error.mustache';
 
 (function (can, $, GGRC, CMS) {
@@ -270,7 +270,7 @@ import errorTpl from './templates/gdrive_picker_launcher_upload_error.mustache';
             el.trigger('rejected');
           }
 
-          GGRC.Utils.GDrivePicker.ensurePickerDisposed(picker, data);
+          ensurePickerDisposed(picker, data);
         }
 
         dfd = GGRC.Controllers.GAPI.reAuthorize(gapi.auth.getToken());

--- a/src/ggrc_gdrive_integration/assets/javascripts/components/templates/gdrive_picker_launcher_upload_error.mustache
+++ b/src/ggrc_gdrive_integration/assets/javascripts/components/templates/gdrive_picker_launcher_upload_error.mustache
@@ -1,0 +1,9 @@
+<div>
+  <div>Some errors occurred during attaching the files:</div>
+  <ul>
+    {{#each errors}}
+    <li><strong>{{fileName}}</strong></li>
+    {{/each}}
+  </ul>
+  <div>Please try again later.</div>
+</div>

--- a/src/ggrc_gdrive_integration/assets/javascripts/components/tests/gdrive_picker_launcher_spec.js
+++ b/src/ggrc_gdrive_integration/assets/javascripts/components/tests/gdrive_picker_launcher_spec.js
@@ -1,0 +1,62 @@
+/* !
+  Copyright (C) 2017 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+describe('GGRC.Components.gDrivePickerLauncher', function () {
+  'use strict';
+
+  var viewModel;
+
+  beforeAll(function () {
+    viewModel = GGRC.Components.getViewModel('gDrivePickerLauncher');
+    viewModel.attr('assessmentTypeObjects', [
+      {revision: {content: {slug: 'CONTROL-345'}}},
+      {revision: {content: {slug: 'CONTROL-678'}}},
+    ]);
+  });
+
+  it('should test sanitizeSlug() method', function () {
+    var sanitizationCheck = {
+      'abc-test-code-1.CA-865': 'abc-test-code-1-ca-865',
+      'AC01.CA-1121': 'ac01-ca-1121',
+
+      'Automated E-Waste Dashboard.CA-935':
+        'automated-e-waste-dashboard-ca-935',
+
+      'CA.PCI 1.2.1': 'ca-pci-1-2-1',
+      'control-13.CA-855': 'control-13-ca-855',
+      'CONTROL-2084.CA-844': 'control-2084-ca-844',
+      'PCI 10.4.3.CA-1065': 'pci-10-4-3-ca-1065',
+      'REQUEST-957': 'request-957',
+      'TV03.2.4.CA': 'tv03-2-4-ca',
+      'SM05.CA-1178': 'sm05-ca-1178',
+      'ASSESSMENT-12345': 'assessment-12345',
+    };
+
+    Object.keys(sanitizationCheck).forEach(function (key) {
+      expect(viewModel.sanitizeSlug(key)).toBe(sanitizationCheck[key]);
+    });
+  });
+
+  it('should test addFileSuffix() method', function () {
+    var fakeInstance = new can.Map({
+      slug: 'ASSESSMENT-12345',
+    });
+
+    var fileNameTransformationMap = {
+      'Screenshot 2016-04-29 12.56.30.png':
+        'Screenshot 2016-04-29 12.56.30_ggrc_assessment' +
+        '-12345_control-345_control-678.png',
+
+      'IMG-9000_ggrc_request-12345.jpg':
+        'IMG-9000_ggrc_assessment-12345_control-345_control-678.jpg',
+    };
+
+    viewModel.attr('instance', fakeInstance);
+
+    Object.keys(fileNameTransformationMap).forEach(function (key) {
+      expect(viewModel.addFileSuffix(key)).toBe(fileNameTransformationMap[key]);
+    });
+  });
+});

--- a/src/ggrc_gdrive_integration/assets/javascripts/models/gdrive_models.js
+++ b/src/ggrc_gdrive_integration/assets/javascripts/models/gdrive_models.js
@@ -3,7 +3,7 @@
  * Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  */
 
-import '../utils/gdrive-picker-utils.js';
+import {ensurePickerDisposed} from '../utils/gdrive-picker-utils.js';
 
 (function (can) {
   'use strict';
@@ -333,7 +333,7 @@ import '../utils/gdrive-picker-utils.js';
         } else if (action === google.picker.Action.CANCEL) {
           dfd.reject('action canceled');
         }
-        GGRC.Utils.GDrivePicker.ensurePickerDisposed(picker, data);
+        ensurePickerDisposed(picker, data);
       }
       return dfd.promise();
     }

--- a/src/ggrc_gdrive_integration/assets/javascripts/models/gdrive_models.js
+++ b/src/ggrc_gdrive_integration/assets/javascripts/models/gdrive_models.js
@@ -313,7 +313,7 @@ import '../utils/gdrive-picker-utils.js';
                   .setMaxItems(10)
                   .setCallback(pickerCallback)
                   .build();
-
+          console.warn('Next two errors are expected.');
           picker.setVisible(true);
           dialog = GGRC.Utils.getPickerElement(picker);
           if (dialog) {
@@ -326,6 +326,9 @@ import '../utils/gdrive-picker-utils.js';
       function pickerCallback(data) {
         var action = data[google.picker.Response.ACTION];
         if (action === google.picker.Action.PICKED) {
+          data[google.picker.Response.DOCUMENTS].forEach((file) => {
+            file.newUpload = file.uploadState === 'success';
+          });
           dfd.resolve(CMS.Models.GDriveFile.models(data[google.picker.Response.DOCUMENTS]));
         } else if (action === google.picker.Action.CANCEL) {
           dfd.reject('action canceled');

--- a/src/ggrc_gdrive_integration/assets/javascripts/utils/gdrive-picker-utils.js
+++ b/src/ggrc_gdrive_integration/assets/javascripts/utils/gdrive-picker-utils.js
@@ -3,20 +3,117 @@
  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  */
 
-/**
-  * Removes picker component after file is picked or cancel is clicked.
-  * This shuold be called last from pickerCallback function
-  * @param  {Object} picker Picker object
-  * @param  {Object} data GDrive Picker action data
-  */
-export function ensurePickerDisposed(picker, data) {
-  var PICKED = google.picker.Action.PICKED;
-  var ACTION = google.picker.Response.ACTION;
-  var CANCEL = google.picker.Action.CANCEL;
+export const GDRIVE_PICKER_ERR_CANCEL = 'GDRIVE_PICKER_ERR_CANCEL';
 
-  // sometimes pickerCallback is called with data == { action: 'loaded' }
-  // which is not described in the Picker API Docs
-  if ( data[ACTION] === PICKED || data[ACTION] === CANCEL ) {
-   picker.dispose();
+/**
+ * Calls GDrive Picker and returns promise which is resolved to uploaded files
+ * @param  {Object}  [opts={}]     options
+ * @param  {String}  opts.parentId id of the destination folder
+ * @param  {boolean} opts.pickFolder wether to use the single folder picker mode ( overrides multiSelect to false )
+ * @param  {boolean} opts.multiSelect wether to allow multiple file selection available only in file picker mode i.e. pickFolder=false
+ * @return {Promise.<Array.<GDriveFile>>} A Promise which resolves to an array of GDriveFile instances and a picker action as a second parameter
+ */
+export function uploadFiles(opts = {}) {
+  var {parentId=null, pickFolder=false, multiSelect=true} = opts;
+  var dfd = new $.Deferred();
+  var pickerBuilder;
+  var picker;
+
+  GGRC.Controllers.GAPI
+    .reAuthorize(gapi.auth.getToken())
+    .done(()=>{
+      gapi.load('picker', {callback: createPicker});
+    });
+
+    // Create and render a Picker object for searching images.
+  function createPicker() {
+    GGRC.Controllers.GAPI.oauth_dfd.done(function (token, oauthUser) {
+      var dialog;
+      var view;
+
+      pickerBuilder = new google.picker.PickerBuilder();
+
+      if (pickFolder) {
+        view = new google.picker.DocsView(google.picker.ViewId.FOLDERS)
+          // .setMimeTypes(['application/vnd.google-apps.folder'])
+          .setIncludeFolders(true)
+          .setSelectFolderEnabled(true);
+        pickerBuilder.addView(view);
+        pickerBuilder.setTitle('Select folder');
+      } else {
+        pickerBuilder
+          .addView(new google.picker.DocsUploadView().setParent(parentId))
+          .addView(google.picker.ViewId.DOCS);
+          // .addView(new google.picker.DocsView().setParent(parentId));
+        if (multiSelect) {
+          pickerBuilder
+            .enableFeature(google.picker.Feature.MULTISELECT_ENABLED);
+        }
+      }
+
+      picker = pickerBuilder.setOAuthToken(gapi.auth.getToken().access_token)
+            .setDeveloperKey(GGRC.config.GAPI_KEY)
+            .setMaxItems(10)
+            .setCallback(pickerCallback)
+            .build();
+
+      console.warn('Next two errors are expected.');
+      picker.setVisible(true);
+
+      dialog = GGRC.Utils.getPickerElement(picker);
+      if (dialog) {
+        dialog.style.zIndex = 4001; // our modals start with 2050
+      }
+    });
   }
+
+    // A simple callback implementation.
+  function pickerCallback(data) {
+    var ACTION = google.picker.Response.ACTION;
+    var CANCEL = google.picker.Action.CANCEL;
+    var PICKED = google.picker.Action.PICKED;
+    var DOCUMENTS = google.picker.Response.DOCUMENTS;
+    var files;
+    var err;
+    var model = pickFolder ? CMS.Models.GDriveFolder : CMS.Models.GDriveFile;
+
+    // sometimes pickerCallback is called with data == { action: 'loaded' }
+    // which is not described in the Picker API Docs
+    if ( data[ACTION] === PICKED || data[ACTION] === CANCEL ) {
+     picker.dispose();
+    }
+
+    if (data[ACTION] === PICKED) {
+      // adding a newUpload flag so we can later distinguish newly
+      // uploaded files from the picked ones.
+      // we cannot rely on the uploadState prop later on because a call to
+      // the RefreshQueue will overwrite it.
+      data[DOCUMENTS].forEach((file) => {
+        file.newUpload = file.uploadState === 'success';
+      });
+
+      files = model.models(data[DOCUMENTS]);
+
+      // NB: picker file object have different format then GDrive file objects
+      // "name" <=> "title", "url" <=> "alternateLink"
+      // RefreshQueue converts picker file objects into GDrive file objects
+
+      return new RefreshQueue()
+        .enqueue(files)
+        .trigger()
+        .then((files)=>{
+          dfd.resolve(files);
+        }, dfd.reject);
+    } else if (data[ACTION] === CANCEL) {
+      err = new Error('Canceled by user');
+      err.type = GDRIVE_PICKER_ERR_CANCEL;
+      dfd.reject(err);
+    }
+    // sometimes pickerCallback is called with data == { action: 'loaded' }
+    // which is not described in the Picker API Docs
+    if ( data[ACTION] === PICKED || data[ACTION] === CANCEL ) {
+     picker.dispose();
+    }
+  }
+  return dfd.promise();
 }

--- a/src/ggrc_gdrive_integration/assets/javascripts/utils/gdrive-picker-utils.js
+++ b/src/ggrc_gdrive_integration/assets/javascripts/utils/gdrive-picker-utils.js
@@ -3,33 +3,20 @@
  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  */
 
-(function (GGRC) {
-  'use strict';
+/**
+  * Removes picker component after file is picked or cancel is clicked.
+  * This shuold be called last from pickerCallback function
+  * @param  {Object} picker Picker object
+  * @param  {Object} data GDrive Picker action data
+  */
+export function ensurePickerDisposed(picker, data) {
+  var PICKED = google.picker.Action.PICKED;
+  var ACTION = google.picker.Response.ACTION;
+  var CANCEL = google.picker.Action.CANCEL;
 
-  /**
-   * Util methods for custom attributes.
-   */
-  GGRC.Utils.GDrivePicker = (function () {
-    /**
-     * Removes picker component after file is picked or cancel is clicked.
-     * This shuold be called last from pickerCallback function
-     * @param  {Object} picker Picker object
-     * @param  {Object} data GDrive Picker action data
-     */
-    function ensurePickerDisposed(picker, data) {
-      var PICKED = google.picker.Action.PICKED;
-      var ACTION = google.picker.Response.ACTION;
-      var CANCEL = google.picker.Action.CANCEL;
-
-      // sometimes pickerCallback is called with data == { action: 'loaded' }
-      // which is not described in the Picker API Docs
-      if ( data[ACTION] === PICKED || data[ACTION] === CANCEL ) {
-        picker.dispose();
-      }
-    }
-
-    return {
-      ensurePickerDisposed: ensurePickerDisposed,
-    };
-  })();
-})(window.GGRC);
+  // sometimes pickerCallback is called with data == { action: 'loaded' }
+  // which is not described in the Picker API Docs
+  if ( data[ACTION] === PICKED || data[ACTION] === CANCEL ) {
+   picker.dispose();
+  }
+}


### PR DESCRIPTION
# Feature-request description

All uploaded files should be searchable within Google Drive

# Notice
This is a proper solution which covers all the edge cases which where not addressed in #6362 and it was reverted. In particular it did not cover the case of picking already uploaded and renamed file to other assessment. It was adding a suffix with the codes of the latest assessment it was attached to.

# Solution description

Uploaded files should be appended with the suffix which contains of the code of the instance the file is attaching to and the codes of the mapped entities (the ones that match the instance type. for example for Assessment of type Control only mapped Controls' codes will be used in the suffix).
Also, the codes are converted to the filename-safe format (lowercased, and all special character are replaced with the dash character ('-')).
Complete example:
We have an assessment with the code  `ASSESSMENT-12345` and two mapped controls with codes: `CONTROL-2084.CA-844` and `control-13.CA-855`.
The attached file `screenshot-123.jpg` will be renamed to 
`screenshot-123_ggrc_assessment-12345_control-2084-ca-844_control-13-ca-855.jpg`

# Sanity check list

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests where applicable.
- [x] My changes follow the [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/performance.rst).
- [x] My changes follow the [js](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/git/how_to_write_a_commit_message.rst).