### PR TITLE
GGRC-3572 Imports allowing empty fields to be imported and updated. 

### DIFF
--- a/test/integration/ggrc/converters/test_import_assessments.py
+++ b/test/integration/ggrc/converters/test_import_assessments.py
@@ -429,6 +429,35 @@ class TestAssessmentImport(TestCase):
     ).first()
     self.assertEqual([assignee_id], [i.id for i in assessment.assessors])
 
+  def test_update_import_verifiers(self):
+    """Test import does not delete verifiers if empty value imported"""
+    slug = "TestAssessment"
+    assessment = factories.AssessmentFactory(slug=slug)
+
+    name = "test_name"
+    email = "test@email.com"
+    verifier = factories.PersonFactory(name=name, email=email)
+    verifier_id = verifier.id
+
+    self.import_data(OrderedDict([
+        ("object_type", "Assessment"),
+        ("Code*", slug),
+        ("Verifiers", email),
+    ]))
+    assessment = models.Assessment.query.filter(
+        models.Assessment.slug == slug
+    ).first()
+    self.assertEqual([verifier_id], [i.id for i in assessment.verifiers])
+    self.import_data(OrderedDict([
+        ("object_type", "Assessment"),
+        ("Code*", slug),
+        ("Verifiers", ""),
+    ]))
+    assessment = models.Assessment.query.filter(
+        models.Assessment.slug == slug
+    ).first()
+    self.assertEqual([verifier_id], [i.id for i in assessment.verifiers])
+
   @ddt.data(
       (
           "Last Updated",


### PR DESCRIPTION
# From JIRA ticket:
1) User imported assessment procedure update along with verifier column (empty), it updated all the assessments with none verifier - empty updates should not be allowed
2) The assessment log showed update of assessment procedure but not verifier update

# Issue description
Verifier is deleted from an Assessment when an empty Verifier field is imported

# Steps to reproduce
1. Add a verifier to an Assessment over UI
2. Export the Assessment
3. Delete the Verifier field in the csv file
4. Import the modified csv
5. Check the Verifier was deleted

# Solution description
We should only delete people when the imported value is valid and is not empty
Additionally fixes wrong relationship attr handling for related AssigneeTypes. When modifying with import and removing person from all the lists, relationship_attr remained empty and relationship was not deleted. And it led to an error.
Now relationship is being deleted once AssigneeTypes list becomes empty.

# Sanity check list

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [ ] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests (if not, include a reason).
- [x] My changes follow the [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/performance.rst).
- [x] My changes follow the [js](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/git/how_to_write_a_commit_message.rst).
