### PR TITLE
GGRC-3510 Do not collapse line with tabs on All Objects page

### DIFF
--- a/src/ggrc/assets/javascripts/apps/business_objects.js
+++ b/src/ggrc/assets/javascripts/apps/business_objects.js
@@ -84,6 +84,7 @@ import SummaryWidgetController from '../controllers/summary_widget_controller';
           instance: object,
           widget_view: summaryWidgetViews[objectTable],
           order: 3,
+          uncountable: true,
         });
       }
       if (GGRC.Utils.Dashboards.isDashboardEnabled(object)) {
@@ -93,6 +94,7 @@ import SummaryWidgetController from '../controllers/summary_widget_controller';
           instance: object,
           widget_view: path + '/base_objects/dashboard_widget.mustache',
           order: 6,
+          uncountable: true,
         });
       }
       infoWidgetViews = {
@@ -116,6 +118,7 @@ import SummaryWidgetController from '../controllers/summary_widget_controller';
         instance: object,
         widget_view: infoWidgetViews[objectTable],
         order: 5,
+        uncountable: true,
       });
       modelNames = can.Map.keys(baseWidgetsByType);
       modelNames.sort();

--- a/src/ggrc/assets/javascripts/components/snapshotter/scope-update.js
+++ b/src/ggrc/assets/javascripts/components/snapshotter/scope-update.js
@@ -58,6 +58,7 @@
           .then(function () {
             this._updateVisibleContainer.bind(this)();
             this._showSuccessMsg();
+            instance.dispatch('snapshotScopeUpdated');
           }.bind(this));
       },
       _dismiss: _.identity,

--- a/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
@@ -502,6 +502,7 @@
         spinner: this.options.spinners['#' + $widget.attr('id')],
         model: widgetOptions && widgetOptions.model,
         order: (widgetOptions || widget).order,
+        uncountable: (widgetOptions || widget).uncountable,
       });
 
       index = this.options.widget_list.length;

--- a/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
@@ -279,6 +279,12 @@
           this.options.attr('widget_list', new can.Observe.List([]));
         }
 
+        // trigger show_hide_title, because numbers of 
+        // widgets can be changed after updating of instance
+        instance.bind('snapshotScopeUpdated', () => {
+          this.show_hide_titles();
+        });
+
         this.options.attr('instance', instance);
         if (!(this.options.contexts instanceof can.Observe)) {
           this.options.attr('contexts', new can.Observe(this.options.contexts));
@@ -568,7 +574,9 @@
     '{window} resize': _.debounce(function (el, ev) {
       this.show_hide_titles();
     }, 100),
+
     show_hide_titles: function () {
+      var pageType = GGRC.Utils.CurrentPage.getPageType();
       var $el = this.element;
       var originalWidgets = this.options.widget_list;
       var dividedTabsMode = this.options.attr('dividedTabsMode');
@@ -607,7 +615,9 @@
         widget.attr('show_title', true);
       });
 
-      adjust(originalWidgets);
+      if (pageType === 'Audit') {
+        adjust(originalWidgets);
+      }
     },
     '.closed click': function (el, ev) {
       var $link = el.closest('a');

--- a/src/ggrc/assets/javascripts/controllers/tests/inner_navigation_controller_spec.js
+++ b/src/ggrc/assets/javascripts/controllers/tests/inner_navigation_controller_spec.js
@@ -1,4 +1,4 @@
-/*!
+/*
   Copyright (C) 2017 Google Inc.
   Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 */
@@ -73,6 +73,7 @@ describe('CMS.Controllers.InnerNav', function () {
     var ctrlInst;  // fake controller instance
     var showHideTitles;
     var options;
+    var getPageTypeSpy;
 
     function createWidgets(titlesStatus) {
       var widgets = [
@@ -81,7 +82,7 @@ describe('CMS.Controllers.InnerNav', function () {
         {name: 'ccc', show_title: titlesStatus},
         {name: 'ddd', show_title: titlesStatus},
         {name: 'eee', show_title: titlesStatus},
-        {name: 'fff', show_title: titlesStatus}
+        {name: 'fff', show_title: titlesStatus},
       ];
       options.attr('widget_list', widgets);
       return widgets;
@@ -95,26 +96,54 @@ describe('CMS.Controllers.InnerNav', function () {
       options = new can.Map({
         widget_list: new can.Observe.List([]),
         dividedTabsMode: false,
-        priorityTabs: null
+        priorityTabs: null,
       });
 
       ctrlInst = {
         element: {
           children: jasmine.createSpy(),
-          width: jasmine.createSpy().and.returnValue(DISPLAY_WIDTH)
+          width: jasmine.createSpy().and.returnValue(DISPLAY_WIDTH),
         },
-        options: options
+        options: options,
       };
 
       spyOn(_, 'map')
         .and
         .returnValue([]);
 
+      getPageTypeSpy = spyOn(GGRC.Utils.CurrentPage, 'getPageType')
+        .and
+        .returnValue('Audit');
+
       showHideTitles = Ctrl.prototype.show_hide_titles.bind(ctrlInst);
     });
 
     afterEach(function () {
       Array.prototype.reduce.calls.reset();
+    });
+
+
+    it('always show titles if page instance is not AUDIT', function () {
+      var types = ['Assessment', 'Audit', 'Control', 'Program'];
+
+      setWidgetsWidth(2400);
+
+      types.forEach((type) => {
+        getPageTypeSpy.and.returnValue(type);
+
+        showHideTitles = Ctrl.prototype.show_hide_titles.bind(ctrlInst);
+
+        createWidgets(false);
+        showHideTitles();
+
+        if (type !== 'Audit') {
+          expect(_.every(options.attr('widget_list'), 'show_title'))
+            .toBeTruthy();
+        } else {
+          expect(_.every(options.attr('widget_list'), 'show_title'))
+            .toBeFalsy();
+        }
+      });
     });
 
     it('doesnt hide titles if the width is enough', function () {

--- a/src/ggrc/assets/javascripts/modules/widget_descriptor.js
+++ b/src/ggrc/assets/javascripts/modules/widget_descriptor.js
@@ -40,7 +40,8 @@ import SummaryWidgetController from '../controllers/summary_widget_controller';
             model: instance.constructor,
             widget_view: widgetView || defaultInfoWidgetView
           },
-          order: 5
+          order: 5,
+          uncountable: true,
         });
     },
     /*
@@ -65,7 +66,8 @@ import SummaryWidgetController from '../controllers/summary_widget_controller';
             model: instance.constructor,
             widget_view: widgetView || defaultView
           },
-          order: 3
+          order: 3,
+          uncountable: true,
         });
     },
     make_dashboard_widget: function (instance, widgetView) {
@@ -87,7 +89,8 @@ import SummaryWidgetController from '../controllers/summary_widget_controller';
             model: instance.constructor,
             widget_view: widgetView || defaultView
           },
-          order: 6
+          order: 6,
+          uncountable: true,
         });
     },
     /*

--- a/src/ggrc/assets/javascripts/mustache_helper.js
+++ b/src/ggrc/assets/javascripts/mustache_helper.js
@@ -2676,4 +2676,28 @@ Example:
       return options.fn(options.contexts);
     }
   );
+  Mustache.registerHelper('displayWidgetTab',
+    function (widget, instance, options) {
+      var displayTab;
+      var inForceShowList;
+      widget = Mustache.resolve(widget);
+      instance = Mustache.resolve(instance);
+
+      inForceShowList = can.inArray(widget.attr('internav_display'),
+        instance.constructor.obj_nav_options.force_show_list) > -1;
+
+      displayTab = widget.attr('has_count') &&
+        widget.attr('count') ||
+        widget.attr('uncountable') ||
+        widget.attr('force_show') ||
+        instance.constructor.obj_nav_options.show_all_tabs ||
+        inForceShowList;
+
+      if (!displayTab) {
+        return options.inverse(options.contexts);
+      }
+
+      return options.fn(options.contexts);
+    }
+  );
 })(jQuery, can);

--- a/src/ggrc/assets/mustache/dashboard/internav_list.mustache
+++ b/src/ggrc/assets/mustache/dashboard/internav_list.mustache
@@ -4,35 +4,29 @@
 }}
 
 {{#widget_list}}
-  <li class="{{internav_icon}} {{widgetType}}">
-    {{#if_helpers '\
-      #if' has_count '\
-      and #if' count '\
-      or ^if' has_count '\
-      or #if' force_show '\
-      or #if' instance.constructor.obj_nav_options.show_all_tabs '\
-      or #in_array' internav_display instance.constructor.obj_nav_options.force_show_list}}
+<li class="{{internav_icon}} {{widgetType}}">
+  {{#displayWidgetTab . instance}}
 
-    <a href="{{urlPath}}{{ selector }}" rel="tooltip" data-placement="bottom" title="{{ internav_display }}">
-      <div class="oneline">
-        <i class="fa fa-{{ internav_icon }} color"></i>
-        {{#if show_title}}
-          {{internav_display}}
-          {{#has_count}}({{firstnonempty count 0}}){{/has_count}}
-        {{else}}
-          {{#has_count}}{{firstnonempty count 0}}{{/has_count}}
-        {{/if}}
-        {{^count}}{{#has_count}}
-          {{^instance.constructor.obj_nav_options.show_all_tabs}}
-            {{^in_array internav_display instance.constructor.obj_nav_options.force_show_list}}
-              <span class="closed"><i class="fa fa-times"></i></span>
-            {{/in_array}}
-          {{/instance.constructor.obj_nav_options.show_all_tabs}}
-        {{/has_count}}{{/count}}
-      </div>
-    </a>
-    {{/if_helpers}}
-  </li>
+  <a href="{{urlPath}}{{ selector }}" rel="tooltip" data-placement="bottom" title="{{ internav_display }}">
+    <div class="oneline">
+      <i class="fa fa-{{ internav_icon }} color"></i>
+      {{#if show_title}}
+        {{internav_display}}
+        {{#has_count}}({{firstnonempty count 0}}){{/has_count}}
+      {{else}}
+        {{#has_count}}{{firstnonempty count 0}}{{/has_count}}
+      {{/if}}
+      {{^count}}{{#has_count}}
+        {{^instance.constructor.obj_nav_options.show_all_tabs}}
+          {{^in_array internav_display instance.constructor.obj_nav_options.force_show_list}}
+            <span class="closed"><i class="fa fa-times"></i></span>
+          {{/in_array}}
+        {{/instance.constructor.obj_nav_options.show_all_tabs}}
+      {{/has_count}}{{/count}}
+    </div>
+  </a>
+  {{/displayWidgetTab}}
+</li>
 {{/widget_list}}
 
 


### PR DESCRIPTION
# Issue description

**ISSUE 1**
1. Go to any page, for example 'All Objects'.
2. Change the size of the page.
_Actual result_: names of the tabs are changed from icons with inscription into just icons.
_Expected result_: Name of the tabs should always be displayed in full format (icon + inscription) on all pages except Audit and My Assessments

<img width="1284" alt="issue 1" src="https://user-images.githubusercontent.com/4204416/31605888-3582b1e4-b270-11e7-9c9e-3cdb0c5b6aa5.png">


**ISSUE2.**
1. Go to any page, for example issue page https://ggrc-qa.appspot.com/issues/171.
2. Change the size of the page.
_Actual result_: For a pair of secs all tabs are displayed.
_Expected result_: 
option1: only tabs with actually mapped objects to issue should be displayed right away.
option 2: only  tab should be displayed until all other mappings are loaded.

<img width="1440" alt="issue-2" src="https://user-images.githubusercontent.com/4204416/31605896-393e96a4-b270-11e7-9788-53fd0e0ee212.png">


# Solution description

**ISSUE1**: Do not trigger "adjust" function all instance's types except of 'Audit".
**ISSUE2**: Do not show all tab except of 'Info' before "counts" load.

# Sanity check list

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests (if not, include a reason).
- [x] My changes follow the [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/performance.rst).
- [x] My changes follow the [js](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/git/how_to_write_a_commit_message.rst).