### PR TITLE
GGRC-3598 Unable to download <object> template on the Import page

### DIFF
--- a/src/ggrc/assets/javascripts/components/csv/csv-template.js
+++ b/src/ggrc/assets/javascripts/components/csv/csv-template.js
@@ -1,11 +1,11 @@
-/*!
+/*
     Copyright (C) 2017 Google Inc.
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 */
 
 import template from './templates/csv-template.mustache';
 
-can.Component.extend({
+GGRC.Components('csvTemplate', {
   tag: 'csv-template',
   template: template,
   scope: {
@@ -30,28 +30,27 @@ can.Component.extend({
       });
     },
     '.import-button click': function (el, ev) {
-      var data;
+      var objects;
       ev.preventDefault();
-      data = _.map(this.scope.attr('selected'), function (el) {
+
+      objects = _.map(this.scope.attr('selected'), function (el) {
         return {
           object_name: el.value,
           fields: 'all'
         };
       });
-      if (!data.length) {
+      if (!objects.length) {
         return;
       }
 
       GGRC.Utils.export_request({
-        data: data
+        data: {
+          objects: objects,
+          export_to: 'csv',
+        },
       }).then(function (data) {
         GGRC.Utils.download('import_template.csv', data);
-      })
-        .fail(function (data) {
-          $('body').trigger('ajax:flash', {
-            error: $(data.responseText.split('\n')[3]).text()
-          });
-        });
+      });
     },
     '.import-list a click': function (el, ev) {
       var index = el.data('index');

--- a/src/ggrc/assets/javascripts/components/csv/test/csv-template_spec.js
+++ b/src/ggrc/assets/javascripts/components/csv/test/csv-template_spec.js
@@ -1,0 +1,55 @@
+/*
+  Copyright (C) 2017 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+describe('GGRC.Components.csvTemplate', function () {
+  var events = GGRC.Components.get('csvTemplate').prototype.events;
+
+  describe('events', function () {
+    var scope;
+    var handler;
+
+    describe('".import-button click" handler', function () {
+      var exportDfd;
+      var selected;
+
+      beforeEach(function () {
+        scope = new can.Map();
+        exportDfd = new can.Deferred();
+        selected = [
+          {value: 'Assessment'},
+          {value: 'Risk'},
+          {value: 'Audit'},
+        ];
+        scope.attr('selected', selected);
+        handler = events['.import-button click'].bind({
+          scope: scope,
+        });
+        spyOn(GGRC.Utils, 'export_request').and.returnValue(exportDfd);
+        spyOn(GGRC.Utils, 'download');
+      });
+
+      it('requests export with proper data', function () {
+        var objects = _.map(selected, function (el) {
+          return {
+            object_name: el.value,
+            fields: 'all',
+          };
+        });
+        handler({}, {preventDefault: jasmine.createSpy()});
+        expect(GGRC.Utils.export_request).toHaveBeenCalledWith({data: {
+          objects: objects,
+          export_to: 'csv',
+        }});
+      });
+
+      it('loads csv-template', function () {
+        exportDfd.resolve('data');
+        handler({}, {preventDefault: jasmine.createSpy()});
+        expect(GGRC.Utils.download)
+          .toHaveBeenCalledWith('import_template.csv', 'data');
+      });
+    });
+  });
+});


### PR DESCRIPTION
# Issue description

Since merging https://github.com/google/ggrc-core/pull/6361 request data for import-template is not valid.

# Steps to reproduce

1. Go to the Import page
2. Select any type of objects, e.g. Issues
3. Click download template

*Actual Result:* Template is not downloaded. POST 400 "Export failed due to server error." is shown in console
*Expected Result:* <Object> template should be dowloaded

# Solution description

Change request data of export in `csv-template` component according new export logic on the BE.

# Sanity check list

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests (if not, include a reason).
- [x] My changes follow the [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/performance.rst).
- [x] My changes follow the [js](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/git/how_to_write_a_commit_message.rst).