### PR TITLE
DOCS List json attributes for all services

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -38,7 +38,7 @@ extensions = [
 
 extlinks = {
     'src': (
-        'https://github.com/google/ggrc-core/tree/develop/src/%s',
+        'https://github.com/google/ggrc-core/tree/dev/src/%s',
         'src/',
     ),
 }

--- a/src/docbuilder/descriptors/service.py
+++ b/src/docbuilder/descriptors/service.py
@@ -3,10 +3,58 @@
 
 """Service descriptor."""
 
+from ggrc.models.reflection import AttributeInfo
 from cached_property import cached_property
 
 from docbuilder.descriptors.base import Descriptor
 from docbuilder.descriptors.model import Model
+
+MOCK_DATA = {
+    "id": "1",
+    "context": """{{ "id": 1, "type": "Context" }}""",
+    "default_to_current_user": 'false',
+    "delete": 'false',
+    "mandatory": 'true',
+    "read": 'true',
+    "my_work": 'true',
+    "name": '"Name"',
+    'object_type': '"Object Type"',
+    "tooltip": '"Tooltip information"',
+    "update": 'false',
+    "type": '"{object_type}"',
+    "created_at": '"2015-08-14T14:24:43"',
+    "updated_at": '"2015-08-14T14:24:43"',
+    "modified_by": """{{ "id": 1, "type": "Person"}}""",
+    "non_editable": "false",
+    "access_control_list": """[{{}}]""",
+    "custom_attribute_values": """[{{}}]""",
+    "custom_attributes": """[{{}}]""",
+    "custom_attribute_definitions": """[{{}}]""",
+    "description": '"Object <b>description</b>"',
+    "notes": "'Object <i>Notes</i>'",
+    "object_people": "{{}}",
+    "related_destinations": "[]",
+    "related_sources": "[]",
+    "slug": '"OBJECT-1"',
+    "start_date": '"2015-08-14"',
+    "status": '"Active"',
+    "task_group_objects": "[]",
+    "title": '"Object title"',
+    "preconditions_failed": 'false',
+    'archived': 'false',
+    'assessment_type': 'Control',
+    'assignees': '[]',
+    'audit': '{{ "id": 1, "type": "Audit"}}',
+    "design": '"Operationally"',
+    "end_date": '"2015-08-14"',
+    "finished_date": '"2015-08-14"',
+    'send_by_default': "false",
+    'verified': 'false',
+    'verified_date': 'null',
+    'audit_firm': '{{ "id": 1, "type": "OrgGroup"}}',
+    'program': '{{ "id": 1, "type": "Program"}}',
+    'snapshotted_objects': '[]',
+}
 
 
 class Service(Descriptor):
@@ -16,7 +64,6 @@ class Service(Descriptor):
   def collect(cls):
     """Collects all application services."""
     from ggrc.services import all_services
-
     return all_services()
 
   @cached_property
@@ -25,9 +72,27 @@ class Service(Descriptor):
     return '%s -> %s' % (self.model.name, self.obj.name)
 
   @cached_property
+  def table_singular(self):
+    """Object's table_singualr forme."""
+    return self.obj.model_class._inflector.table_singular
+
+  @cached_property
+  def json_value(self):
+    """Json value"""
+    def func(name):
+      return MOCK_DATA.get(name, '""').format(
+          object_type=self.obj.model_class.__name__)
+    return func
+
+  @cached_property
   def url(self):
     """Endpoint URL."""
     return '/api/%s' % self.obj.name
+
+  @cached_property
+  def attributes(self):
+    """Endpoint attributes"""
+    return AttributeInfo.gather_attr_dicts(self.obj.model_class, '_api_attrs')
 
   @cached_property
   def doc(self):

--- a/src/docbuilder/templates/package/services.mako
+++ b/src/docbuilder/templates/package/services.mako
@@ -16,8 +16,8 @@ Methods::
     GET ${service.url}
     GET ${service.url}/{id}
   % else:
-    GET    ${service.url}
     POST   ${service.url}
+    GET    ${service.url}
     GET    ${service.url}/{id}
     PUT    ${service.url}/{id}
     DELETE ${service.url}/{id}
@@ -25,5 +25,99 @@ Methods::
 
 Model :class:`${service.model.name}`
 
+
+POST Example::
+
+    POST ${service.url}/
+
+    Request headers:
+      content-type:application/json
+      cookie:SACSID=<ID>;
+             session=<SessionID>
+      x-requested-by:GGRC
+
+    Request body:
+    {
+      "${service.table_singular}": {
+      % for name, res in sorted(service.attributes.items()):
+        % if res.create:
+        "${name}": ${service.json_value(name)},
+        % endif
+      % endfor
+      }
+    }
+
+    Response body:
+    {
+      "${service.table_singular}": {
+      % for name, res in sorted(service.attributes.items()):
+        % if res.read:
+        "${name}": ${service.json_value(name)},
+        % endif
+      % endfor
+      }
+    }
+
+GET Example::
+
+
+    GET ${service.url}/1
+
+    Request headers:
+      content-type:application/json
+      cookie:SACSID=<ID>;
+             session=<SessionID>
+      x-requested-by:GGRC
+
+    Response body:
+    {
+      "${service.table_singular}": {
+      % for name, res in sorted(service.attributes.items()):
+        % if res.read:
+        "${name}": ${service.json_value(name)},
+        % endif
+      % endfor
+      }
+    }
+
+PUT Example::
+
+    PUT ${service.url}/1
+
+    Request headers:
+      content-type:application/json
+      cookie:SACSID=<ID>;
+             session=<SessionID>
+      if-match:"d87058b07a1c1efe8bc2949033b5766db239fb9d"
+      if-unmodified-since:Thu, 30 Mar 2017 10:51:14 GMT
+      x-requested-by:GGRC
+
+    Request body:
+    {
+      "${service.table_singular}": {
+      % for name, res in sorted(service.attributes.items()):
+        % if res.update:
+        "${name}": ${service.json_value(name)},
+        % endif
+      % endfor
+      }
+    }
+
+    Response headers:
+      content-type:application/json
+      date:Mon, 16 Oct 2017 15:10:07 GMT
+      etag:"d87058b07a1c1efe8bc2949033b5766db239fb9d"
+      last-modified:Thu, 30 Mar 2017 10:51:14 GMT
+
+    Response body:
+    {
+      "${service.table_singular}": {
+      % for name, res in sorted(service.attributes.items()):
+        % if res.read:
+        "${name}": ${service.json_value(name)},
+        % endif
+      % endfor
+      }
+    }
 
 % endfor

--- a/src/docbuilder/templates/package/services.mako
+++ b/src/docbuilder/templates/package/services.mako
@@ -69,6 +69,11 @@ GET Example::
              session=<SessionID>
       x-requested-by:GGRC
 
+    Response headers:
+      content-type:application/json
+      Date:Thu, 30 Mar 2017 10:51:14 GMT
+      etag:"d87058b07a1c1efe8bc2949033b5766db239fb9d"
+
     Response body:
     {
       "${service.table_singular}": {

--- a/src/ggrc/__init__.py
+++ b/src/ggrc/__init__.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2017 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
+"""Main GGRC module"""
+
 from ggrc import bootstrap
 
 db = bootstrap.get_db()

--- a/src/ggrc_basic_permissions/__init__.py
+++ b/src/ggrc_basic_permissions/__init__.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2017 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
-"""Initialize RBAC"""
+"""RBAC module"""
 
 import datetime
 import itertools

--- a/src/ggrc_gdrive_integration/__init__.py
+++ b/src/ggrc_gdrive_integration/__init__.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2017 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
+"""GDrive module"""
+
 import flask
 
 from flask import Blueprint

--- a/src/ggrc_risk_assessments/__init__.py
+++ b/src/ggrc_risk_assessments/__init__.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2017 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
+"""Risk Assessment module"""
+
 from flask import Blueprint
 from sqlalchemy import orm
 

--- a/src/ggrc_risks/__init__.py
+++ b/src/ggrc_risks/__init__.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2017 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
+"""Risk module"""
+
 from flask import Blueprint
 
 from ggrc.services.registry import service

--- a/src/ggrc_workflows/__init__.py
+++ b/src/ggrc_workflows/__init__.py
@@ -3,6 +3,8 @@
 
 # pylint: disable=redefined-outer-name
 
+"""Workflows module"""
+
 from datetime import datetime, date
 from flask import Blueprint
 from logging import getLogger


### PR DESCRIPTION
This PR adds json examples to our endpoints. It's was implemented in a rush way before a demo so it's not the best. Ideally instead of having the `MOCK_DATA` dict we should find out the type of each attribute and create json values based on the type instead of the attribute name.