### PR TITLE
GGRC-3604/3605 [obsolete] Add optimized end point for my tasks counts

### DIFF
--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -165,7 +165,6 @@ dashboard-js-template-files:
   - components/spinner/spinner.mustache
   - components/rich_text/rich_text.mustache
   - components/datepicker/datepicker.mustache
-  - components/tasks-counter/tasks-counter.mustache
   - components/tree_pagination/tree_pagination.mustache
   - components/cycle-task-actions/cycle-task-actions.mustache
   - components/simple-modal/simple-modal.mustache

--- a/src/ggrc/assets/javascripts/components/tasks-counter/tasks-counter.js
+++ b/src/ggrc/assets/javascripts/components/tasks-counter/tasks-counter.js
@@ -17,8 +17,7 @@
    */
   GGRC.Components('tasksCounter', {
     tag: baseCmpName,
-    template: can.view(GGRC.mustache_path +
-      '/components/tasks-counter/tasks-counter.mustache'),
+    template: `<div class="tasks-counter {{stateCss}}">{{tasksAmount}}</div>`,
     viewModel: {
       define: {
         tasksAmount: {
@@ -48,7 +47,7 @@
             this.loadTasks();
           }
         },
-        stateCssClass: {
+        stateCss: {
           get: function () {
             if (this.attr('tasksAmount') === 0) {
               return baseCmpName + '__empty-state';

--- a/src/ggrc/assets/javascripts/components/tasks-counter/tasks-counter.js
+++ b/src/ggrc/assets/javascripts/components/tasks-counter/tasks-counter.js
@@ -3,119 +3,116 @@
  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  */
 
-(function (can, GGRC, moment) {
-  'use strict';
-  var QueryAPI = GGRC.Utils.QueryAPI;
-  var baseCmpName = 'tasks-counter';
-  var TASKS_OBJECT_TYPE = 'CycleTaskGroupObjectTask';
-  // Temporary Constants => should be replaced by some configuration variables
-  var fieldToFilter = 'task due date';
-  var valueToFilter = moment().format('YYYY-MM-DD');
-  /**
-   *  Component to show number of Tasks Owned by Person
-   *
-   */
-  GGRC.Components('tasksCounter', {
-    tag: baseCmpName,
-    template: `<div class="tasks-counter {{stateCss}}">{{tasksAmount}}</div>`,
-    viewModel: {
-      define: {
-        tasksAmount: {
-          type: 'number',
-          value: 0,
-          set: function (newValue) {
-            return newValue < 0 ? 0 : newValue;
-          }
-        },
-        hasOverdue: {
-          type: 'boolean',
-          value: false
-        },
-        tasksType: {
-          type: 'string',
-          get: function () {
-            return TASKS_OBJECT_TYPE;
-          }
-        },
-        personId: {
-          type: 'number',
-          set: function (value, setValue) {
-            if (!value) {
-              return;
-            }
-            setValue(value);
-            this.loadTasks();
-          }
-        },
-        stateCss: {
-          get: function () {
-            if (this.attr('tasksAmount') === 0) {
-              return baseCmpName + '__empty-state';
-            }
-            return this.attr('hasOverdue') ?
-              baseCmpName + '__overdue-state' :
-              '';
-          }
+var QueryAPI = GGRC.Utils.QueryAPI;
+var baseCmpName = 'tasks-counter';
+var TASKS_OBJECT_TYPE = 'CycleTaskGroupObjectTask';
+// Temporary Constants => should be replaced by some configuration variables
+var fieldToFilter = 'task due date';
+var valueToFilter = moment().format('YYYY-MM-DD');
+/**
+ *  Component to show number of Tasks Owned by Person
+ *
+ */
+export default GGRC.Components('tasksCounter', {
+  tag: baseCmpName,
+  template: `<div class="tasks-counter {{stateCss}}">{{tasksAmount}}</div>`,
+  viewModel: {
+    define: {
+      tasksAmount: {
+        type: 'number',
+        value: 0,
+        set: function (newValue) {
+          return newValue < 0 ? 0 : newValue;
         }
       },
-      getQuery: function (type) {
-        var ownedFilters = [{
-          type: 'Person',
-          id: this.attr('personId'),
-          operation: 'owned',
-          keys: []
-        }];
-        var overdueQuery;
-        var overdueFilter = {
-          expression: {
-            op: {name: '<'},
-            left: fieldToFilter,
-            right: valueToFilter
-          }};
-        overdueQuery = QueryAPI
-          .buildParam(type, {}, ownedFilters, null, overdueFilter);
-        overdueQuery.type = 'count';
-        delete overdueQuery.fields;
-        return {
-          data: [
-            QueryAPI.buildCountParams([type], ownedFilters)[0],
-            overdueQuery
-          ]
-        };
+      hasOverdue: {
+        type: 'boolean',
+        value: false
       },
-      loadTasks: function () {
-        var query = this.getQuery(this.attr('tasksType'));
-        return this.requestQuery(query)
-          .then(function (results) {
-            this.attr('tasksAmount', results.total);
-            this.attr('hasOverdue', results.overdue > 0);
-          }.bind(this));
+      tasksType: {
+        type: 'string',
+        get: function () {
+          return TASKS_OBJECT_TYPE;
+        }
       },
-      requestQuery: function (query) {
-        var dfd = can.Deferred();
-        var type = this.attr('tasksType');
-        QueryAPI
-          .makeRequest(query)
-          .done(function (response) {
-            var total = response[0][type].total;
-            var overdue = response[1][type].total;
-            return dfd.resolve({total: total, overdue: overdue});
-          })
-          .fail(function () {
-            return dfd.resolve({total: 0, overdue: 0});
-          });
-        return dfd;
+      personId: {
+        type: 'number',
+        set: function (value, setValue) {
+          if (!value) {
+            return;
+          }
+          setValue(value);
+          this.loadTasks();
+        }
+      },
+      stateCss: {
+        get: function () {
+          if (this.attr('tasksAmount') === 0) {
+            return baseCmpName + '__empty-state';
+          }
+          return this.attr('hasOverdue') ?
+            baseCmpName + '__overdue-state' :
+            '';
+        }
       }
     },
-    events: {
-      onModelChange: function (model, event, instance) {
-        if (instance instanceof CMS.Models.CycleTaskGroupObjectTask) {
-          this.viewModel.loadTasks();
-        }
-      },
-      '{CMS.Models.CycleTaskGroupObjectTask} updated': 'onModelChange',
-      '{CMS.Models.CycleTaskGroupObjectTask} destroyed': 'onModelChange',
-      '{CMS.Models.CycleTaskGroupObjectTask} created': 'onModelChange'
+    getQuery: function (type) {
+      var ownedFilters = [{
+        type: 'Person',
+        id: this.attr('personId'),
+        operation: 'owned',
+        keys: []
+      }];
+      var overdueQuery;
+      var overdueFilter = {
+        expression: {
+          op: {name: '<'},
+          left: fieldToFilter,
+          right: valueToFilter
+        }};
+      overdueQuery = QueryAPI
+        .buildParam(type, {}, ownedFilters, null, overdueFilter);
+      overdueQuery.type = 'count';
+      delete overdueQuery.fields;
+      return {
+        data: [
+          QueryAPI.buildCountParams([type], ownedFilters)[0],
+          overdueQuery
+        ]
+      };
+    },
+    loadTasks: function () {
+      var query = this.getQuery(this.attr('tasksType'));
+      return this.requestQuery(query)
+        .then(function (results) {
+          this.attr('tasksAmount', results.total);
+          this.attr('hasOverdue', results.overdue > 0);
+        }.bind(this));
+    },
+    requestQuery: function (query) {
+      var dfd = can.Deferred();
+      var type = this.attr('tasksType');
+      QueryAPI
+        .makeRequest(query)
+        .done(function (response) {
+          var total = response[0][type].total;
+          var overdue = response[1][type].total;
+          return dfd.resolve({total: total, overdue: overdue});
+        })
+        .fail(function () {
+          return dfd.resolve({total: 0, overdue: 0});
+        });
+      return dfd;
     }
-  });
-})(window.can, window.GGRC, moment);
+  },
+  events: {
+    onModelChange: function (model, event, instance) {
+      if (instance instanceof CMS.Models.CycleTaskGroupObjectTask) {
+        this.viewModel.loadTasks();
+      }
+    },
+    '{CMS.Models.CycleTaskGroupObjectTask} updated': 'onModelChange',
+    '{CMS.Models.CycleTaskGroupObjectTask} destroyed': 'onModelChange',
+    '{CMS.Models.CycleTaskGroupObjectTask} created': 'onModelChange'
+  }
+});

--- a/src/ggrc/assets/javascripts/components/tasks-counter/tasks-counter.js
+++ b/src/ggrc/assets/javascripts/components/tasks-counter/tasks-counter.js
@@ -3,12 +3,8 @@
  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  */
 
-var QueryAPI = GGRC.Utils.QueryAPI;
-var baseCmpName = 'tasks-counter';
-var TASKS_OBJECT_TYPE = 'CycleTaskGroupObjectTask';
-// Temporary Constants => should be replaced by some configuration variables
-var fieldToFilter = 'task due date';
-var valueToFilter = moment().format('YYYY-MM-DD');
+let baseCmpName = 'tasks-counter';
+
 /**
  *  Component to show number of Tasks Owned by Person
  *
@@ -29,12 +25,6 @@ export default GGRC.Components('tasksCounter', {
         type: 'boolean',
         value: false
       },
-      tasksType: {
-        type: 'string',
-        get: function () {
-          return TASKS_OBJECT_TYPE;
-        }
-      },
       personId: {
         type: 'number',
         set: function (value, setValue) {
@@ -50,60 +40,18 @@ export default GGRC.Components('tasksCounter', {
           if (this.attr('tasksAmount') === 0) {
             return baseCmpName + '__empty-state';
           }
-          return this.attr('hasOverdue') ?
-            baseCmpName + '__overdue-state' :
-            '';
+          return this.attr('hasOverdue') ? baseCmpName + '__overdue-state' : '';
         }
       }
     },
-    getQuery: function (type) {
-      var ownedFilters = [{
-        type: 'Person',
-        id: this.attr('personId'),
-        operation: 'owned',
-        keys: []
-      }];
-      var overdueQuery;
-      var overdueFilter = {
-        expression: {
-          op: {name: '<'},
-          left: fieldToFilter,
-          right: valueToFilter
-        }};
-      overdueQuery = QueryAPI
-        .buildParam(type, {}, ownedFilters, null, overdueFilter);
-      overdueQuery.type = 'count';
-      delete overdueQuery.fields;
-      return {
-        data: [
-          QueryAPI.buildCountParams([type], ownedFilters)[0],
-          overdueQuery
-        ]
-      };
-    },
     loadTasks: function () {
-      var query = this.getQuery(this.attr('tasksType'));
-      return this.requestQuery(query)
+      let currentUser = CMS.Models.Person.store[this.attr('personId')];
+      return currentUser.getTasksCount()
         .then(function (results) {
-          this.attr('tasksAmount', results.total);
-          this.attr('hasOverdue', results.overdue > 0);
+          this.attr('tasksAmount', results.open_task_count);
+          this.attr('hasOverdue', results.has_overdue);
         }.bind(this));
     },
-    requestQuery: function (query) {
-      var dfd = can.Deferred();
-      var type = this.attr('tasksType');
-      QueryAPI
-        .makeRequest(query)
-        .done(function (response) {
-          var total = response[0][type].total;
-          var overdue = response[1][type].total;
-          return dfd.resolve({total: total, overdue: overdue});
-        })
-        .fail(function () {
-          return dfd.resolve({total: 0, overdue: 0});
-        });
-      return dfd;
-    }
   },
   events: {
     onModelChange: function (model, event, instance) {

--- a/src/ggrc/assets/javascripts/models/person.js
+++ b/src/ggrc/assets/javascripts/models/person.js
@@ -195,6 +195,11 @@
       return this.name ?
       this.name + '<span class="url-link">' + this.email + '</span>' :
         this.email;
+    },
+    getTasksCount: function () {
+      let url = `/api/people/${this.attr('id')}/task_count`;
+      return $.get(url)
+        .fail(() => console.warn(`Request on '${url}' failed!`));
     }
   });
 })(window, can);

--- a/src/ggrc/assets/mustache/components/tasks-counter/tasks-counter.mustache
+++ b/src/ggrc/assets/mustache/components/tasks-counter/tasks-counter.mustache
@@ -1,6 +1,0 @@
-{{!
-    Copyright (C) 2017 Google Inc., authors, and contributors
-    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
-}}
-
-<div class="tasks-counter {{stateCssClass}}">{{tasksAmount}}</div>

--- a/src/ggrc/services/__init__.py
+++ b/src/ggrc/services/__init__.py
@@ -15,6 +15,7 @@ def contributed_services():
   from ggrc.services.relationship_resource import RelationshipResource
   from ggrc.services.audit_resource import AuditResource
   from ggrc.services.assessment_resource import AssessmentResource
+  from ggrc.services.person_resource import PersonResource
   from ggrc.access_control.role import AccessControlRole
 
   return [
@@ -51,7 +52,7 @@ def contributed_services():
       service('options', models.Option),
       service('org_groups', models.OrgGroup),
       service('vendors', models.Vendor),
-      service('people', models.Person),
+      service('people', models.Person, PersonResource),
       service('products', models.Product),
       service('projects', models.Project),
       service('programs', models.Program),

--- a/src/ggrc/services/person_resource.py
+++ b/src/ggrc/services/person_resource.py
@@ -3,6 +3,10 @@
 
 """Resource for handling special endpoints for people."""
 
+import datetime
+
+from ggrc import db
+from ggrc.utils import benchmark
 from ggrc.services import common
 
 
@@ -17,8 +21,47 @@ class PersonResource(common.ExtendedResource):
     # pylint: disable=arguments-differ
     command_map = {
         None: super(PersonResource, self).get,
+        "task_count": self._task_count,
     }
     command = kwargs.pop("command", None)
     if command not in command_map:
       self.not_found_response()
     return command_map[command](*args, **kwargs)
+
+  def _task_count(self, id):
+    with benchmark("Make response"):
+      counts_query = db.session.execute(
+          """
+          SELECT
+              ct.end_date < :today AS overdue,
+              count(ct.id) AS task_count
+          FROM cycle_task_group_object_tasks AS ct
+          JOIN cycles AS c
+              ON c.id = ct.cycle_id
+          JOIN access_control_list AS acl
+              ON acl.object_id = ct.id
+              AND acl.object_type = "CycleTaskGroupObjectTask"
+          JOIN access_control_roles as acr
+              ON acl.ac_role_id = acr.id
+          WHERE
+              ct.status != "Verified"
+              AND c.is_current = 1
+              AND acl.person_id = :person_id
+              AND acr.name = "Task Assignees"
+              -- not needed on non_editable role that has read rights:
+              -- acr.read = 1
+          GROUP BY overdue;
+          """,
+          {
+              # Using today instead of DATE(NOW()) for easier testing with
+              # freeze gun.
+              "today": datetime.date.today(),
+              "person_id": id,
+          }
+      )
+      counts = dict(counts_query.fetchall())
+      response_object = {
+          "open_task_count": sum(counts.values()),
+          "has_overdue": bool(counts.get(1, [])),
+      }
+      return self.json_success_response(response_object, )

--- a/src/ggrc/services/person_resource.py
+++ b/src/ggrc/services/person_resource.py
@@ -1,0 +1,24 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Resource for handling special endpoints for people."""
+
+from ggrc.services import common
+
+
+class PersonResource(common.ExtendedResource):
+  """Resource handler for people."""
+
+  # method post is abstract and not used.
+  # pylint: disable=abstract-method
+
+  def get(self, *args, **kwargs):
+    # This is to extend the get request for additional data.
+    # pylint: disable=arguments-differ
+    command_map = {
+        None: super(PersonResource, self).get,
+    }
+    command = kwargs.pop("command", None)
+    if command not in command_map:
+      self.not_found_response()
+    return command_map[command](*args, **kwargs)

--- a/test/integration/ggrc/services/test_person_resource.py
+++ b/test/integration/ggrc/services/test_person_resource.py
@@ -1,0 +1,181 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Tests for /api/people endpoints."""
+
+from datetime import date
+
+from freezegun import freeze_time
+
+from ggrc.models import all_models
+from ggrc.utils import create_stub
+
+from integration.ggrc.models import factories
+from integration.ggrc.services import TestCase
+from integration.ggrc_workflows.generator import WorkflowsGenerator
+
+
+class TestPersonResource(TestCase):
+  """Tests for special people api endpoints."""
+
+  def setUp(self):
+    super(TestPersonResource, self).setUp()
+    self.client.get("/login")
+
+  def test_task_count(self):
+    """Test person task counts.
+
+    This tests checks for correct task counts
+     - with inactive workflows and
+     - with overdue tasks
+     - without overdue tasks
+     - with finished overdue tasks
+
+    The four checks are done in a single test due to complex differences
+    between tests that make ddt cumbersome and the single test also improves
+    integration test performance due to slow workflow setup stage.
+    """
+
+    role_id = all_models.AccessControlRole.query.filter(
+        all_models.AccessControlRole.name == "Task Assignees",
+        all_models.AccessControlRole.object_type == "TaskGroupTask",
+    ).one().id
+
+    wf_generator = WorkflowsGenerator()
+
+    user = all_models.Person.query.first()
+    dummy_user = factories.PersonFactory()
+    user_id = user.id
+    one_time_workflow = {
+        "title": "Person resource test workflow",
+        "notify_on_change": True,
+        "description": "some test workflow",
+        "owners": [create_stub(user)],
+        "task_groups": [{
+            "title": "one time task group",
+            "contact": create_stub(user),
+            "task_group_tasks": [{
+                "title": "task 1",
+                "description": "some task",
+                "access_control_list": [{
+                    "person": create_stub(user),
+                    "ac_role_id": role_id,
+                }],
+                "start_date": date(2017, 5, 5),
+                "end_date": date(2017, 8, 15),
+            }, {
+                "title": "task 2",
+                "description": "some task 3",
+                "access_control_list": [{
+                    "person": create_stub(user),
+                    "ac_role_id": role_id,
+                }],
+                "start_date": date(2017, 5, 5),
+                "end_date": date(2017, 9, 16),
+            }, {
+                "title": "task 3",
+                "description": "some task 4",
+                "access_control_list": [{
+                    "person": create_stub(user),
+                    "ac_role_id": role_id,
+                }, {
+                    "person": create_stub(dummy_user),
+                    "ac_role_id": role_id,
+                }],
+                "start_date": date(2017, 6, 5),
+                "end_date": date(2017, 11, 16),
+            }, {
+                "title": "dummy task 4",  # task should not counted
+                "description": "some task 4",
+                "access_control_list": [{
+                    "person": create_stub(dummy_user),
+                    "ac_role_id": role_id,
+                }],
+                "start_date": date(2017, 6, 5),
+                "end_date": date(2017, 11, 17),
+            }, {
+                "title": "dummy task 5",  # task should not counted
+                "description": "some task 4",
+                "access_control_list": [{
+                    "person": create_stub(dummy_user),
+                    "ac_role_id": role_id,
+                }],
+                "start_date": date(2017, 6, 5),
+                "end_date": date(2017, 11, 18),
+            }],
+            "task_group_objects": []
+        }]
+    }
+
+    inactive_workflow = {
+        "title": "Activated workflow with archived cycles",
+        "notify_on_change": True,
+        "description": "Extra test workflow",
+        "owners": [create_stub(user)],
+        "task_groups": [{
+            "title": "Extra task group",
+            "contact": create_stub(user),
+            "task_group_tasks": [{
+                "title": "not counted existing task",
+                "description": "",
+                "access_control_list": [{
+                    "person": create_stub(user),
+                    "ac_role_id": role_id,
+                }],
+                "start_date": date(2017, 5, 5),
+                "end_date": date(2017, 8, 15),
+            }],
+            "task_group_objects": []
+        }]
+    }
+
+    with freeze_time("2017-10-16 05:09:10"):
+      self.client.get("/login")
+      # Activate normal one time workflow
+      _, workflow = wf_generator.generate_workflow(one_time_workflow)
+      _, cycle = wf_generator.generate_cycle(workflow)
+      tasks = {t.title: t for t in cycle.cycle_task_group_object_tasks}
+      _, workflow = wf_generator.activate_workflow(workflow)
+
+      # Activate and close the inactive workflow
+      _, workflow = wf_generator.generate_workflow(inactive_workflow)
+      _, cycle = wf_generator.generate_cycle(workflow)
+      _, workflow = wf_generator.activate_workflow(workflow)
+      wf_generator.modify_object(cycle, data={"is_current": False})
+
+    with freeze_time("2017-7-16 07:09:10"):
+      self.client.get("/login")
+      response = self.client.get("/api/people/{}/task_count".format(user_id))
+      self.assertEqual(
+          response.json,
+          {"open_task_count": 3, "has_overdue": False}
+      )
+
+    with freeze_time("2017-10-16 08:09:10"):
+      self.client.get("/login")
+      response = self.client.get("/api/people/{}/task_count".format(user_id))
+      self.assertEqual(
+          response.json,
+          {"open_task_count": 3, "has_overdue": True}
+      )
+
+      wf_generator.modify_object(tasks["task 1"], data={"status": "Verified"})
+      response = self.client.get("/api/people/{}/task_count".format(user_id))
+      self.assertEqual(
+          response.json,
+          {"open_task_count": 2, "has_overdue": True}
+      )
+
+      wf_generator.modify_object(tasks["task 2"], data={"status": "Finished"})
+      response = self.client.get("/api/people/{}/task_count".format(user_id))
+      self.assertEqual(
+          response.json,
+          {"open_task_count": 2, "has_overdue": True}
+      )
+
+      wf_generator.modify_object(tasks["task 2"], data={"status": "Verified"})
+      response = self.client.get("/api/people/{}/task_count".format(user_id))
+      self.assertEqual(
+          response.json,
+          {"open_task_count": 1, "has_overdue": False}
+      )


### PR DESCRIPTION
This PR adds an endpoint to replace /query call for my task counts and overdue task counts.

Instead of calling the slow /query api we should have
/api/people/X/my_task_counts
that will return the counts for my work page for a person.

This PR is build on top of https://github.com/google/ggrc-core/pull/6587 in order to avoid conflicts.
- [x] depends on https://github.com/google/ggrc-core/pull/6587

The query speed was checked with the ggrc_dev_db-backup-2017-10-16.sql.gz database and on users with id 5 and 7 which have the most still opened tasks and overdue tasks. 