### PR TITLE
GGRC-3218 Text wrapping is unconventional for Assignee field on Assessments object

### DIFF
--- a/src/ggrc/assets/javascripts/components/tree/get-owner-people-list.js
+++ b/src/ggrc/assets/javascripts/components/tree/get-owner-people-list.js
@@ -1,0 +1,26 @@
+/*
+  Copyright (C) 2017 Google Inc., authors, and contributors <see AUTHORS file>
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+const viewModel = can.Map.extend({
+  role: '',
+  define: {
+    allOwners: {
+      get: function () {
+        const roleId = GGRC.roles
+          .find((item) => item.name == this.role).id;
+        return this.data
+          .filter((item) =>
+            item.instance.role && item.instance.role.id == roleId)
+          .map((item) => item.instance.person);
+      },
+    },
+  },
+});
+
+GGRC.Components('getOwnerPeopleList', {
+  tag: 'get-owner-people-list',
+  template: '<content/>',
+  viewModel: viewModel,
+});

--- a/src/ggrc/assets/javascripts/components/tree/templates/tree-people-list-field.mustache
+++ b/src/ggrc/assets/javascripts/components/tree/templates/tree-people-list-field.mustache
@@ -1,0 +1,10 @@
+{{!
+    Copyright (C) 2017 Google Inc.
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+}}
+
+<div rel="tooltip" data-original-title="{{peopleStr}} {{morePeopleStr}}">
+  {{#people}}
+    <div class="people-list">{{displayName}}</div>
+  {{/people}}
+</div>

--- a/src/ggrc/assets/javascripts/components/tree/tree-people-list-field.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-people-list-field.js
@@ -4,6 +4,7 @@
 */
 
 import BaseTreePeopleVM from '../view-models/tree-people-base-vm';
+import template from './templates/tree-people-list-field.mustache';
 
 const viewModel = BaseTreePeopleVM.extend({
   filter: '@',
@@ -19,9 +20,9 @@ const viewModel = BaseTreePeopleVM.extend({
   },
 });
 
-export default GGRC.Components('treePeopleListField', {
+GGRC.Components('treePeopleListField', {
   tag: 'tree-people-list-field',
-  template: '{{peopleStr}}',
+  template: template,
   viewModel: viewModel,
   events: {
     '{viewModel.source} change': function () {

--- a/src/ggrc/assets/javascripts/components/tree/tree-widget-container.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-widget-container.js
@@ -21,6 +21,7 @@ import './tree-item-status-for-workflow';
 import './tree-no-results';
 import './tree-assignee-field';
 import './tree-people-list-field';
+import './get-owner-people-list';
 import './tree-people-with-role-list-field';
 import '../advanced-search/advanced-search-filter-container';
 import '../advanced-search/advanced-search-mapping-container';

--- a/src/ggrc/assets/javascripts/components/view-models/tree-people-base-vm.js
+++ b/src/ggrc/assets/javascripts/components/view-models/tree-people-base-vm.js
@@ -13,38 +13,51 @@ export default can.Map.extend({
   source: null,
   people: [],
   peopleStr: '',
+  morePeopleStr: '',
+  peopleNum: 5,
   stub: '@',
   init: function () {
     this.refreshPeople();
   },
   refreshPeople: function () {
     this.getPeopleList()
-      .then(function (data) {
+      .then((data) => {
+        const peopleStr = data
+        .slice(0, this.peopleNum)
+        .map((item) => item.displayName)
+        .join('\n');
+
+        const morePeopleStr = data.length > this.peopleNum ?
+          `\n and ${data.length - this.peopleNum} more` : '';
+
         this.attr('people', data);
-        this.attr('peopleStr', data.map(function (item) {
-          return item.email;
-        }).join(', '));
-      }.bind(this));
+        this.attr('peopleStr', peopleStr);
+        this.attr('morePeopleStr', morePeopleStr);
+      });
   },
   getPeopleList: function () {
     var sourceList = this.getSourceList();
+    var result;
     var deferred = can.Deferred();
 
     if (!sourceList.length) {
       return deferred.resolve([]);
     }
-
-    if (this.attr('stub')) {
-      this.loadItems(sourceList)
-        .then(function (data) {
-          deferred.resolve(data);
-        })
-        .fail(function () {
-          deferred.resolve([]);
+    this.loadItems(sourceList)
+      .then(function (data) {
+        result = data.map(function (item) {
+          var displayName = item.email;
+          return {
+            name: item.name,
+            email: item.email,
+            displayName: displayName,
+          };
         });
-    } else {
-      deferred.resolve(sourceList);
-    }
+        deferred.resolve(result);
+      })
+      .fail(function () {
+        deferred.resolve([]);
+      });
 
     return deferred;
   },

--- a/src/ggrc/assets/mustache/directives/tree-item-attr.mustache
+++ b/src/ggrc/assets/mustache/directives/tree-item-attr.mustache
@@ -5,14 +5,10 @@
 
 {{#switch attr_name}}
   {{#case 'contact'}}
-      <tree-people-list-field {source}="instance.contact">
-          {{peopleStr}}
-      </tree-people-list-field>
+      <tree-people-list-field {source}="instance.contact"/>
   {{/case}}
   {{#case 'secondary_contact'}}
-      <tree-people-list-field {source}="instance.secondary_contact">
-          {{peopleStr}}
-      </tree-people-list-field>
+      <tree-people-list-field {source}="instance.secondary_contact"/>
   {{/case}}
   {{#case 'modified_by'}}
       <tree-people-list-field {source}="instance.modified_by"/>

--- a/src/ggrc/assets/mustache/programs/tree-item-attr.mustache
+++ b/src/ggrc/assets/mustache/programs/tree-item-attr.mustache
@@ -6,24 +6,16 @@
 {{#switch attr_name}}
   {{#case 'owner'}}
     {{#with_mapping 'program_authorizations' instance}}
-      {{#each program_authorizations}}
-          {{#using role=instance.role}}
-            {{#if_equals role.name 'ProgramOwner'}}
-                {{#using contact=instance.person}}
-                  <span class="need-comma">{{contact.email}}</span>
-                {{/using}}
-            {{/if_equals}}
-          {{/using}}
-      {{/each}}
+      <get-owner-people-list data="program_authorizations" role="'ProgramOwner'">
+        <tree-people-list-field {source}="allOwners"/>
+      </get-owner-people-list>
     {{/with_mapping}}
   {{/case}}
   {{#case 'contact'}}
-      <tree-people-list-field {source}="instance.contact">
-      </tree-people-list-field>
+      <tree-people-list-field {source}="instance.contact"/>
   {{/case}}
   {{#case 'secondary_contact'}}
-      <tree-people-list-field {source}="instance.secondary_contact">
-      </tree-people-list-field>
+      <tree-people-list-field {source}="instance.secondary_contact"/>
   {{/case}}
   {{#case 'modified_by'}}
       <tree-people-list-field {source}="instance.modified_by"/>

--- a/src/ggrc/assets/mustache/sections/tree-item-attr.mustache
+++ b/src/ggrc/assets/mustache/sections/tree-item-attr.mustache
@@ -5,12 +5,10 @@
 
 {{#switch attr_name}}
   {{#case 'contact'}}
-      <tree-people-list-field {source}="instance.contact">
-      </tree-people-list-field>
+      <tree-people-list-field {source}="instance.contact"/>
   {{/case}}
   {{#case 'secondary_contact'}}
-      <tree-people-list-field {source}="instance.secondary_contact">
-      </tree-people-list-field>
+      <tree-people-list-field {source}="instance.secondary_contact"/>
   {{/case}}
   {{#case 'modified_by'}}
       <tree-people-list-field {source}="instance.modified_by"/>

--- a/src/ggrc/assets/stylesheets/_common.scss
+++ b/src/ggrc/assets/stylesheets/_common.scss
@@ -70,6 +70,7 @@ a {
 
 .tooltip {
   // The bootstrap default is incorrect with modals as of bootstrap 2.0.x
+  white-space: pre-line;
   z-index: zIndex(tooltip) !important;
   word-wrap: break-word;
 }

--- a/src/ggrc/assets/stylesheets/components/tree/_tree-view.scss
+++ b/src/ggrc/assets/stylesheets/components/tree/_tree-view.scss
@@ -124,6 +124,13 @@ tree-view {
 }
 
 tree-item {
+  tree-people-list-field {
+    div.people-list {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+  }
   >.tree-item-wrapper {
     background-color: $white;
     cursor: pointer;
@@ -205,12 +212,7 @@ tree-item {
             margin-bottom: 0;
           }
         }
-        .with-comma::after {
-          content: ', ';
-        }
-        .with-comma:last-child::after {
-          content: '';
-        }
+
       }
     }
   }

--- a/src/ggrc/assets/stylesheets/components/unified-mapper/_unified-mapper.scss
+++ b/src/ggrc/assets/stylesheets/components/unified-mapper/_unified-mapper.scss
@@ -386,6 +386,17 @@ mapper-results-item-attrs {
   .attr {
     @include cell-styles();
 
+    tree-people-list-field {
+      div.people-list {
+        display: none;
+        &:nth-child(1) {
+          display: block;
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
+      }
+    }
+
     .title-attr {
       font-size: 14px;
     }

--- a/src/ggrc_workflows/assets/mustache/workflows/tree-item-attr.mustache
+++ b/src/ggrc_workflows/assets/mustache/workflows/tree-item-attr.mustache
@@ -6,15 +6,9 @@
 {{#switch attr_name}}
   {{#case 'owner'}}
     {{#with_mapping 'authorizations' instance}}
-      {{#each authorizations}}
-        <span>
-          {{#using role=instance.role}}
-            {{#if_equals role.name 'WorkflowOwner'}}
-                <tree-people-list-field {source}="instance.person"/>
-            {{/if_equals}}
-          {{/using}}
-        </span>
-      {{/each}}
+      <get-owner-people-list data="authorizations" role="'WorkflowOwner'">
+        <tree-people-list-field {source}="allOwners"/>
+      </get-owner-people-list>
     {{/with_mapping}}
   {{/case}}
   {{#case 'modified_by'}}


### PR DESCRIPTION
# Issue description

From user: "Text wrapping is a little off in the assignee column because the comma doesn't stay with the first entry"
Solution: 
I had a discussion with Kseniya Koltun and she decide remove commas at all. 
Also we decide add a tooltip with maximum 5 people and phrase with number of hidden from list persons.

# Steps to reproduce

Go to assessment or any other tab and have more then 1 person in some people column.

# Sanity check list

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 
- [x] My changes are covered by tests.
- [x] My changes follow the [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/performance.rst).
- [x] My changes follow the [js](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/javascript.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/git/how_to_write_a_commit_message.rst).
