### PR TITLE
GGRC-3522 BE: Handle people creation event

### DIFF
--- a/src/ggrc/automapper/__init__.py
+++ b/src/ggrc/automapper/__init__.py
@@ -19,7 +19,7 @@ from ggrc.models.issue import Issue
 from ggrc.models.relationship import Relationship
 from ggrc.models import exceptions
 from ggrc.rbac.permissions import is_allowed_update
-from ggrc.services.common import get_cache
+from ggrc.models.cache import Cache
 from ggrc.utils import benchmark
 
 
@@ -184,7 +184,7 @@ class AutomapperGenerator(object):
 
       self._set_audit_id_for_issues(automapping_id)
 
-      cache = get_cache(create=True)
+      cache = Cache.get_cache(create=True)
       if cache:
         # Add inserted relationships into new objects collection of the cache,
         # so that they will be logged within event and appropriate revisions

--- a/src/ggrc/converters/base_block.py
+++ b/src/ggrc/converters/base_block.py
@@ -33,7 +33,7 @@ from ggrc.services.common import get_modified_objects
 from ggrc.services.common import update_snapshot_index
 from ggrc.services.common import update_memcache_after_commit
 from ggrc.services.common import update_memcache_before_commit
-from ggrc.services.common import log_event
+from ggrc.utils.log_event import log_event
 from ggrc.services import signals
 from ggrc_workflows.models.cycle_task_group_object_task import \
     CycleTaskGroupObjectTask

--- a/src/ggrc/login/__init__.py
+++ b/src/ggrc/login/__init__.py
@@ -24,7 +24,7 @@ def get_login_module():
 
 
 def user_loader(user_id):
-  from .common import find_user_by_id
+  from ggrc.utils.user_generator import find_user_by_id
   return find_user_by_id(user_id)
 
 

--- a/src/ggrc/login/appengine.py
+++ b/src/ggrc/login/appengine.py
@@ -24,6 +24,7 @@ from werkzeug import exceptions
 from ggrc.login import common
 from ggrc.models import all_models
 from ggrc import settings
+from ggrc.utils.user_generator import find_or_create_user_by_email
 
 
 def get_user():
@@ -31,7 +32,7 @@ def get_user():
   ae_user = users.get_current_user()
   email = ae_user.email()
   nickname = ae_user.nickname()
-  user = common.find_or_create_user_by_email(email, name=nickname)
+  user = find_or_create_user_by_email(email, name=nickname)
   return user
 
 

--- a/src/ggrc/login/common.py
+++ b/src/ggrc/login/common.py
@@ -4,68 +4,6 @@
 """Handle the interface to GGRC models for all login methods.
 """
 
-from ggrc import db, settings
-from ggrc.models.person import Person
-from ggrc.services.common import log_event
-from ggrc_basic_permissions import basic_roles
-from ggrc_basic_permissions.models import UserRole
-
-
-def _base_user_query():
-  from sqlalchemy import orm
-  return Person.query.options(
-      orm.undefer_group('Person_complete'))
-
-
-def find_user_by_id(user_id):
-  """Find Person object by some ``id``.
-  Note that ``id`` need not be Person().id, but should match the value
-  returned by ``Person().get_id()``.
-  """
-  return _base_user_query().filter(Person.id == int(user_id)).first()
-
-
-def find_user_by_email(email):
-  return _base_user_query().filter(Person.email == email).first()
-
-
-def add_creator_role(user):
-  """Add createor role for sent user."""
-  user_creator_role = UserRole(
-      person=user,
-      role=basic_roles.creator(),
-  )
-  db.session.add(user_creator_role)
-  db.session.commit()
-  log_event(db.session, user_creator_role, user_creator_role.id)
-
-
-def create_user(email, **kwargs):
-  """Create User
-
-  attr:
-      email (string) required
-  """
-  user = Person(email=email, **kwargs)
-  db.session.add(user)
-  db.session.flush()
-  log_event(db.session, user, user.id)
-  db.session.commit()
-  return user
-
-
-def find_or_create_user_by_email(email, **kwargs):
-  """Generates or find user for selected email."""
-  user = find_user_by_email(email)
-  if not user:
-    user = create_user(email, **kwargs)
-    authorized_domain = getattr(settings, "AUTHORIZED_DOMAIN")
-    # Email can have multiple @, but last one separates local and domain part
-    user_domain = user.email.split("@")[-1]
-    if user_domain == authorized_domain:
-      add_creator_role(user)
-  return user
-
 
 def get_next_url(request, default_url):
   """Returns next url from requres or default url if it's not found."""

--- a/src/ggrc/login/noop.py
+++ b/src/ggrc/login/noop.py
@@ -13,6 +13,7 @@ from flask import url_for, redirect, request, session, g, flash
 default_user_name = 'Example User'
 default_user_email = 'user@example.com'
 
+
 def get_user():
   if 'X-ggrc-user' in request.headers:
     json_user = json.loads(request.headers['X-ggrc-user'])
@@ -24,17 +25,19 @@ def get_user():
     email = default_user_email
     name = default_user_name
     permissions = None
-  from ggrc.login.common import find_or_create_user_by_email
+  from ggrc.utils.user_generator import find_or_create_user_by_email
   user = find_or_create_user_by_email(
-    email=email,
-    name=name)
+      email=email,
+      name=name)
   permissions = session['permissions'] if 'permissions' in session else None
   setattr(g, '_request_permissions', permissions)
   return user
 
+
 def before_request(*args, **kwargs):
   permissions = session['permissions'] if 'permissions' in session else None
   setattr(g, '_request_permissions', permissions)
+
 
 def login():
   from ggrc.login.common import get_next_url
@@ -43,8 +46,10 @@ def login():
     flask_login.login_user(user)
     return redirect(get_next_url(request, default_url=url_for('dashboard')))
   else:
-    flash(u'You do not have access. Please contact your administrator.', 'alert alert-info')
+    flash(u'You do not have access. Please contact your administrator.',
+          'alert alert-info')
     return redirect('/')
+
 
 def logout():
   from ggrc.login.common import get_next_url

--- a/src/ggrc/models/__init__.py
+++ b/src/ggrc/models/__init__.py
@@ -123,20 +123,20 @@ def init_lazy_mixins():
 def init_session_monitor_cache():
   from sqlalchemy.orm.session import Session
   from sqlalchemy import event
-  from ggrc.services.common import get_cache
+  from ggrc.models.cache import Cache
 
   def update_cache_before_flush(session, flush_context, objects):
-    cache = get_cache(create=True)
+    cache = Cache.get_cache(create=True)
     if cache:
       cache.update_before_flush(session, flush_context)
 
   def update_cache_after_flush(session, flush_context):
-    cache = get_cache(create=False)
+    cache = Cache.get_cache(create=False)
     if cache:
       cache.update_after_flush(session, flush_context)
 
   def clear_cache(session):
-    cache = get_cache()
+    cache = Cache.get_cache()
     if cache:
       cache.clear()
 

--- a/src/ggrc/models/cache.py
+++ b/src/ggrc/models/cache.py
@@ -1,6 +1,12 @@
 # Copyright (C) 2017 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
+import logging
+from flask import g, has_request_context
+
+logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+
+
 class Cache:
   """
   Tracks modified objects in the session distinguished by
@@ -50,3 +56,19 @@ class Cache:
     copied_cache.dirty = dict(self.dirty)
     copied_cache.deleted = dict(self.deleted)
     return copied_cache
+
+  @staticmethod
+  def get_cache(create=False):
+    """
+    Retrieves the cache from the Flask global object. The create arg
+    indicates if a new cache should be created if none exists. If we
+    are not in a request context, no cache is created (return None).
+    """
+    if has_request_context():
+      cache = getattr(g, 'cache', None)
+      if cache is None and create:
+        cache = g.cache = Cache()
+      return cache
+    else:
+      logger.warning("No request context - no cache created")
+      return None

--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -17,7 +17,7 @@ from exceptions import TypeError
 from wsgiref.handlers import format_date_time
 from urllib import urlencode
 
-from flask import url_for, request, current_app, g, has_request_context
+from flask import url_for, request, current_app, g
 from flask.views import View
 from flask.ext.sqlalchemy import Pagination
 import sqlalchemy.orm.exc
@@ -267,25 +267,9 @@ def inclusion_filter(obj):
                                      obj.id, obj.context_id)
 
 
-def get_cache(create=False):
-  """
-  Retrieves the cache from the Flask global object. The create arg
-  indicates if a new cache should be created if none exists. If we
-  are not in a request context, no cache is created (return None).
-  """
-  if has_request_context():
-    cache = getattr(g, 'cache', None)
-    if cache is None and create:
-      cache = g.cache = Cache()
-    return cache
-  else:
-    logger.warning("No request context - no cache created")
-    return None
-
-
 def get_modified_objects(session):
   session.flush()
-  cache = get_cache()
+  cache = Cache.get_cache()
   if cache:
     return cache.copy()
   else:
@@ -641,7 +625,7 @@ class Resource(ModelView):
           # When running integration tests, cache sometimes does not clear
           # correctly
           if getattr(settings, 'TESTING', False):
-            cache = get_cache()
+            cache = Cache.get_cache()
             if cache:
               cache.clear()
 

--- a/src/ggrc/utils/log_event.py
+++ b/src/ggrc/utils/log_event.py
@@ -7,6 +7,7 @@ import itertools
 
 from flask import request
 
+from ggrc.models.cache import Cache
 from ggrc.models.event import Event
 from ggrc.models.revision import Revision
 from ggrc.login import get_current_user_id
@@ -20,8 +21,7 @@ def _revision_generator(user_id, action, objects):
 def _get_log_revisions(current_user_id, obj=None, force_obj=False):
   """Generate and return revisions for all cached objects."""
   revisions = []
-  from ggrc.services.common import get_cache
-  cache = get_cache()
+  cache = Cache.get_cache()
   if not cache:
     return revisions
   modified_objects = set(cache.dirty)

--- a/src/ggrc/utils/log_event.py
+++ b/src/ggrc/utils/log_event.py
@@ -1,0 +1,103 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Utils for event logging"""
+
+import itertools
+
+from flask import request
+
+from ggrc.models.event import Event
+from ggrc.models.revision import Revision
+from ggrc.login import get_current_user_id
+
+
+def _revision_generator(user_id, action, objects):
+  for obj in objects:
+    yield Revision(obj, user_id, action, obj.log_json())
+
+
+def _get_log_revisions(current_user_id, obj=None, force_obj=False):
+  """Generate and return revisions for all cached objects."""
+  revisions = []
+  from ggrc.services.common import get_cache
+  cache = get_cache()
+  if not cache:
+    return revisions
+  modified_objects = set(cache.dirty)
+  new_objects = set(cache.new)
+  delete_objects = set(cache.deleted)
+  all_edited_objects = itertools.chain(cache.new, cache.dirty, cache.deleted)
+  for o in all_edited_objects:
+    if o.type == "ObjectFolder" and o.folderable:
+      modified_objects.add(o.folderable)
+    if o.type == "Relationship" and o.get_related_for("Document"):
+      documentable = o.get_related_for("Document")
+      document = o.get_related_for(documentable.type)
+      if o in new_objects and document not in documentable.documents:
+        documentable.documents.append(document)
+      if o in delete_objects and document in documentable.documents:
+        documentable.documents.remove(document)
+      if (
+          documentable not in new_objects and
+              documentable not in delete_objects):
+        modified_objects.add(documentable)
+
+  revisions.extend(_revision_generator(
+      current_user_id, "created", cache.new
+  ))
+  revisions.extend(_revision_generator(
+      current_user_id, "modified", modified_objects
+  ))
+  if force_obj and obj is not None and obj not in cache.dirty:
+    # If the ``obj`` has been updated, but only its custom attributes have
+    # been changed, then this object will not be added into
+    # ``cache.dirty set``. So that its revision will not be created.
+    # The ``force_obj`` flag solves the issue, but in a bit dirty way.
+    revision = Revision(obj, current_user_id, 'modified', obj.log_json())
+    revisions.append(revision)
+  revisions.extend(_revision_generator(
+      current_user_id, "deleted", cache.deleted
+  ))
+  return revisions
+
+
+def log_event(session, obj=None, current_user_id=None, flush=True,
+              force_obj=False):
+  """Logs an event on object `obj`.
+
+  Args:
+    session: Current SQLAlchemy session (db.session)
+    obj: object on which some operation took place
+    current_user_id: ID of the user performing operation
+    flush: If set to true, flush the session at the start
+    force_obj: Used in case of custom attribute changes to force revision write
+  Returns:
+    Uncommitted models.Event instance
+  """
+  event = None
+  if flush:
+    session.flush()
+  if current_user_id is None:
+    current_user_id = get_current_user_id()
+  revisions = _get_log_revisions(current_user_id, obj=obj, force_obj=force_obj)
+  if obj is None:
+    resource_id = 0
+    resource_type = None
+    action = 'BULK'
+    context_id = 0
+  else:
+    resource_id = obj.id
+    resource_type = str(obj.__class__.__name__)
+    action = request.method
+    context_id = obj.context_id
+  if revisions:
+    event = Event(
+        modified_by_id=current_user_id,
+        action=action,
+        resource_id=resource_id,
+        resource_type=resource_type,
+        context_id=context_id)
+    event.revisions = revisions
+    session.add(event)
+  return event

--- a/src/ggrc/utils/user_generator.py
+++ b/src/ggrc/utils/user_generator.py
@@ -5,7 +5,10 @@
 """
 
 from ggrc import db, settings
+from ggrc.integrations import client
+from ggrc.login import get_current_user_id
 from ggrc.models.person import Person
+from ggrc.rbac import SystemWideRoles
 from ggrc.utils.log_event import log_event
 from ggrc_basic_permissions import basic_roles
 from ggrc_basic_permissions.models import UserRole
@@ -19,10 +22,11 @@ def _base_user_query():
 
 def find_user_by_id(user_id):
   """Find Person object by some ``id``.
+
   Note that ``id`` need not be Person().id, but should match the value
   returned by ``Person().get_id()``.
   """
-  return _base_user_query().filter(Person.id == int(user_id)).first()
+  return _base_user_query().get(int(user_id))
 
 
 def find_user_by_email(email):
@@ -54,14 +58,42 @@ def create_user(email, **kwargs):
   return user
 
 
-def find_or_create_user_by_email(email, **kwargs):
+def is_authorized_domain(email):
+  """Check whether user's email belongs to authorized domain"""
+  # Email can have multiple @, but last one separates local and domain part
+  user_domain = email.split("@")[-1]
+  return user_domain.lower() == settings.AUTHORIZED_DOMAIN.lower()
+
+
+def find_or_create_user_by_email(email, name):
   """Generates or find user for selected email."""
   user = find_user_by_email(email)
   if not user:
-    user = create_user(email, **kwargs)
-    authorized_domain = getattr(settings, "AUTHORIZED_DOMAIN")
-    # Email can have multiple @, but last one separates local and domain part
-    user_domain = user.email.split("@")[-1]
-    if user_domain == authorized_domain:
-      add_creator_role(user)
+    user = create_user(email,
+                       name=name,
+                       modified_by_id=get_current_user_id())
+  if is_authorized_domain(email) and \
+     user.system_wide_role == SystemWideRoles.NO_ACCESS:
+    add_creator_role(user)
   return user
+
+
+def search_user(email):
+  """Search user by Integration Service
+
+    Returns:
+        string: user name for success, None otherwise
+  """
+  service = client.PersonClient()
+  if is_authorized_domain(email):
+    ldaps = service.search_persons([email.split("@")[0]])
+    if ldaps:
+      return "%s %s" % (ldaps[0]["firstName"], ldaps[0]["lastName"])
+  return None
+
+
+def find_or_create_external_user(email, name):
+  """Find or generate user after verification"""
+  if settings.INTEGRATION_SERVICE_URL and search_user(email):
+    return find_or_create_user_by_email(email, name)
+  return None

--- a/src/ggrc/utils/user_generator.py
+++ b/src/ggrc/utils/user_generator.py
@@ -6,7 +6,7 @@
 
 from ggrc import db, settings
 from ggrc.models.person import Person
-from ggrc.services.common import log_event
+from ggrc.utils.log_event import log_event
 from ggrc_basic_permissions import basic_roles
 from ggrc_basic_permissions.models import UserRole
 
@@ -30,7 +30,7 @@ def find_user_by_email(email):
 
 
 def add_creator_role(user):
-  """Add createor role for sent user."""
+  """Add creator role for sent user."""
   user_creator_role = UserRole(
       person=user,
       role=basic_roles.creator(),

--- a/src/ggrc/utils/user_generator.py
+++ b/src/ggrc/utils/user_generator.py
@@ -1,0 +1,67 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Collection of utils for login and user generation.
+"""
+
+from ggrc import db, settings
+from ggrc.models.person import Person
+from ggrc.services.common import log_event
+from ggrc_basic_permissions import basic_roles
+from ggrc_basic_permissions.models import UserRole
+
+
+def _base_user_query():
+  from sqlalchemy import orm
+  return Person.query.options(
+      orm.undefer_group('Person_complete'))
+
+
+def find_user_by_id(user_id):
+  """Find Person object by some ``id``.
+  Note that ``id`` need not be Person().id, but should match the value
+  returned by ``Person().get_id()``.
+  """
+  return _base_user_query().filter(Person.id == int(user_id)).first()
+
+
+def find_user_by_email(email):
+  return _base_user_query().filter(Person.email == email).first()
+
+
+def add_creator_role(user):
+  """Add createor role for sent user."""
+  user_creator_role = UserRole(
+      person=user,
+      role=basic_roles.creator(),
+  )
+  db.session.add(user_creator_role)
+  db.session.commit()
+  log_event(db.session, user_creator_role, user_creator_role.id)
+
+
+def create_user(email, **kwargs):
+  """Create User
+
+  attr:
+      email (string) required
+  """
+  user = Person(email=email, **kwargs)
+  db.session.add(user)
+  db.session.flush()
+  log_event(db.session, user, user.id)
+  db.session.commit()
+  return user
+
+
+def find_or_create_user_by_email(email, **kwargs):
+  """Generates or find user for selected email."""
+  user = find_user_by_email(email)
+  if not user:
+    user = create_user(email, **kwargs)
+    authorized_domain = getattr(settings, "AUTHORIZED_DOMAIN")
+    # Email can have multiple @, but last one separates local and domain part
+    user_domain = user.email.split("@")[-1]
+    if user_domain == authorized_domain:
+      add_creator_role(user)
+  return user

--- a/src/ggrc_workflows/__init__.py
+++ b/src/ggrc_workflows/__init__.py
@@ -17,7 +17,7 @@ from ggrc.models.relationship import Relationship
 from ggrc.rbac.permissions import is_allowed_update
 from ggrc.access_control import role
 from ggrc.services import signals
-from ggrc.services.common import log_event
+from ggrc.utils.log_event import log_event
 from ggrc_workflows import models, notification
 from ggrc_workflows import services
 from ggrc_workflows.models import relationship_helper

--- a/test/integration/ggrc/services/test_user_generator.py
+++ b/test/integration/ggrc/services/test_user_generator.py
@@ -1,0 +1,106 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Tests for user generator"""
+
+import json
+import mock
+
+from integration.ggrc.services import TestCase
+from ggrc.integrations.client import PersonClient
+from ggrc.models import Person
+from ggrc_basic_permissions.models import UserRole
+
+
+class TestUserGenerator(TestCase):
+  """Test user generation."""
+
+  def setUp(self):
+    super(TestUserGenerator, self).setUp()
+    self.clear_data()
+    self.client.get("/login")
+
+  def _post(self, data):
+    return self.client.post(
+        '/api/people',
+        content_type='application/json',
+        data=data,
+        headers=[('X-Requested-By', 'Unit Tests')],
+    )
+
+  @staticmethod
+  def _mock_post(*args, **kwargs):
+    """Mock of IntegrationService _post"""
+    # pylint: disable=unused-argument
+    payload = kwargs["payload"]
+    res = []
+    for name in payload["usernames"]:
+      res.append({'firstName': name,
+                  'lastName': name,
+                  'username': name})
+    return {'persons': res}
+
+  @mock.patch('ggrc.settings.INTEGRATION_SERVICE_URL', new='endpoint')
+  @mock.patch('ggrc.settings.AUTHORIZED_DOMAIN', new='example.com')
+  def test_user_generation(self):
+    """Test user generation."""
+    with mock.patch.multiple(
+        PersonClient,
+        _post=self._mock_post
+    ):
+      data = json.dumps([{'person': {
+          'name': 'Alan Turing',
+          'email': 'aturing@example.com',
+          'context': None,
+          'external': True
+      }}])
+      response = self._post(data)
+      self.assertStatus(response, 200)
+
+      user = Person.query.filter_by(email='aturing@example.com').one()
+      self.assertEqual(user.name, 'Alan Turing')
+
+      roles = UserRole.query.filter_by(person_id=user.id)
+      self.assertEqual(roles.count(), 1)
+
+  @mock.patch('ggrc.settings.INTEGRATION_SERVICE_URL', new='endpoint')
+  @mock.patch('ggrc.settings.AUTHORIZED_DOMAIN', new='example.com')
+  def test_user_creation(self):
+    """Test user creation."""
+    with mock.patch.multiple(
+        PersonClient,
+        _post=self._mock_post
+    ):
+      data = json.dumps([{'person': {
+          'name': 'Alan Turing',
+          'email': 'aturing@example.com',
+          'context': None
+      }}])
+      response = self._post(data)
+      self.assertStatus(response, 200)
+
+      user = Person.query.filter_by(email='aturing@example.com').one()
+      self.assertEqual(user.name, 'Alan Turing')
+
+      roles = UserRole.query.filter_by(person_id=user.id)
+      self.assertEqual(roles.count(), 0)
+
+  @mock.patch('ggrc.settings.INTEGRATION_SERVICE_URL', new='endpoint')
+  @mock.patch('ggrc.settings.AUTHORIZED_DOMAIN', new='example.com')
+  def test_wrong_user_creation(self):
+    """Test wrong user creation."""
+    with mock.patch.multiple(
+        PersonClient,
+        _post=mock.MagicMock(return_value={'persons': []})
+    ):
+      data = json.dumps([{'person': {
+          'name': 'Alan Turing',
+          'email': 'aturing@example.com',
+          'context': None,
+          'external': True
+      }}])
+      response = self._post(data)
+      self.assertStatus(response, 406)
+
+      user = Person.query.filter_by(email='aturing@example.com').first()
+      self.assertIsNone(user)

--- a/test/unit/ggrc/services/test_common.py
+++ b/test/unit/ggrc/services/test_common.py
@@ -56,7 +56,7 @@ class TestGetRevisionsList(TestCase):
   @staticmethod
   @contextmanager
   def mock_get_cache(new, deleted, dirty):
-    with mock.patch.object(common, "get_cache") as mock_get_cache:
+    with mock.patch.object(models.cache.Cache, "get_cache") as mock_get_cache:
       cache_mock = mock_get_cache.return_value
       cache_mock.new = new
       cache_mock.deleted = deleted

--- a/test/unit/ggrc/services/test_common.py
+++ b/test/unit/ggrc/services/test_common.py
@@ -13,6 +13,7 @@ from ddt import ddt, data, unpack
 # pylint: disable=unused-import
 from ggrc import models  # NOQA
 from ggrc.services import common
+from ggrc.utils import log_event
 
 
 @ddt
@@ -65,7 +66,7 @@ class TestGetRevisionsList(TestCase):
 
   def get_log_revisions(self, obj=None):
     # pylint: disable=protected-access
-    return common._get_log_revisions(self.FAKE_USER_ID, obj, bool(obj))
+    return log_event._get_log_revisions(self.FAKE_USER_ID, obj, bool(obj))
 
   # pylint: disable=too-many-arguments
   @staticmethod


### PR DESCRIPTION
# Issue description
If  /api/people post request contains
 'external': True
user has to be verified via Integration Service and  added to db with Creator role. 
If user already exists in db then found user info is returned.

# Solution description

- Move user generation methods to a separate module. [Currently, all users trying to login are added to db. Users with emails from authorized domains are added with Creator role.]
- Implement 'find or add' method and call it from common.collection_post.

In addition, to avoid cyclic imports:
- Move log_event from services/common.py to a separate module
- Move get_cache method from services/common.py to models/cache.py


# Sanity check list

- [x] My changes are covered by tests.
- [x] My changes follow the performance guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/git/how_to_write_a_commit_message.rst).

# Note

The PR depends on #6584. Please, review only 5 last commits.

# Depends on
- [x]  #6584
