### PR TITLE
GGRC-3425 Redirect to Assessment tab while clicking 'Complete' button if mandatory custom attribute is not filled

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment/assessment-local-ca.js
+++ b/src/ggrc/assets/javascripts/components/assessment/assessment-local-ca.js
@@ -8,6 +8,7 @@ import {
   applyChangesToCustomAttributeValue,
 }
   from '../../plugins/utils/ca-utils';
+import {VALIDATION_ERROR} from '../../events/eventTypes';
 
 (function (GGRC, can) {
   'use strict';
@@ -72,6 +73,9 @@ import {
           .each(function (field) {
             self.performValidation(field, true);
           });
+        if (this.attr('instance.hasValidationErrors')) {
+          this.dispatch(VALIDATION_ERROR);
+        }
       },
       performValidation: function (field, formInitCheck) {
         var fieldValid;

--- a/src/ggrc/assets/javascripts/components/object-state-toolbar/object-state-toolbar.js
+++ b/src/ggrc/assets/javascripts/components/object-state-toolbar/object-state-toolbar.js
@@ -3,6 +3,8 @@
  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  */
 
+import {SWITCH_TO_ERROR_PANEL, SHOW_INVALID_FIELD} from '../../events/eventTypes';
+
 (function (can, GGRC) {
   'use strict';
 
@@ -68,7 +70,8 @@
       changeState: function (newState, isUndo) {
         if (this.attr('isDisabled')) {
           if (this.attr('instance.hasValidationErrors')) {
-            this.attr('instance').dispatch('showInvalidField');
+            this.attr('instance').dispatch(SWITCH_TO_ERROR_PANEL);
+            this.attr('instance').dispatch(SHOW_INVALID_FIELD);
           }
           return;
         }

--- a/src/ggrc/assets/javascripts/components/tabs/tab-container.js
+++ b/src/ggrc/assets/javascripts/components/tabs/tab-container.js
@@ -9,6 +9,7 @@ export default GGRC.Components('tabContainer', {
   tag: 'tab-container',
   template: template,
   viewModel: {
+    lastErrorTab: null,
     define: {
       showTabs: {
         type: 'boolean',
@@ -31,7 +32,6 @@ export default GGRC.Components('tabContainer', {
     setActive: function (scope, el, ev) {
       ev.preventDefault();
       this.setActivePanel(scope.attr('tabIndex'));
-      this.dispatch('tabChanged');
     },
     /**
      * Update Panels List setting all panels except selected to inactive state
@@ -39,6 +39,9 @@ export default GGRC.Components('tabContainer', {
      */
     setActivePanel: function (tabIndex) {
       this.attr('selectedTabIndex', tabIndex);
+      if (this.instance) {
+        this.attr('instance.selectedTabIndex', tabIndex);
+      }
       this.attr('panels').forEach(function (panel) {
         var isActive = (panel.attr('tabIndex') === tabIndex);
         panel.attr('active', isActive);
@@ -56,7 +59,10 @@ export default GGRC.Components('tabContainer', {
         tabIndex = panels[0].attr('tabIndex');
       }
       this.setActivePanel(tabIndex);
-    }
+    },
+    setLastErrorTab: function (tabIndex) {
+      this.attr('lastErrorTab', tabIndex);
+    },
   },
   events: {
     /**
@@ -70,6 +76,12 @@ export default GGRC.Components('tabContainer', {
      */
     '{viewModel.panels} panelRemoved': function () {
       this.viewModel.setDefaultActivePanel();
-    }
+    },
+    /**
+     * Activate lastErrorTab.
+     */
+    '{viewModel.instance} switchToErrorPanel': function () {
+      this.viewModel.setActivePanel(this.viewModel.lastErrorTab);
+    },
   }
 });

--- a/src/ggrc/assets/javascripts/events/eventTypes.js
+++ b/src/ggrc/assets/javascripts/events/eventTypes.js
@@ -36,8 +36,38 @@ const ROLES_CONFLICT = {
   type: 'rolesConflict',
 };
 
+/**
+ * Switch to tab with validation error
+ * @event switchToErrorPanel
+ * @type {object}
+ */
+const SWITCH_TO_ERROR_PANEL = {
+  type: 'switchToErrorPanel',
+};
+
+/**
+ * Scroll to validation error field and lint it
+ * @event showInvalidField
+ * @type {object}
+ */
+const SHOW_INVALID_FIELD = {
+  type: 'showInvalidField',
+};
+
+/**
+ * Set id number of tab with validation error
+ * @event validationError
+ * @type {object}
+ */
+const VALIDATION_ERROR = {
+  type: 'validationError',
+};
+
 export {
   REFRESH_RELATED,
   SAVE_CUSTOM_ROLE,
   ROLES_CONFLICT,
+  SWITCH_TO_ERROR_PANEL,
+  SHOW_INVALID_FIELD,
+  VALIDATION_ERROR,
 };

--- a/src/ggrc/assets/mustache/components/assessment/info-pane/info-pane.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/info-pane/info-pane.mustache
@@ -12,7 +12,8 @@
   {{/is_info_pin}}
     <div class="tier-content">
       {{> '/static/mustache/assessments/header.mustache' }}
-      <tab-container>
+      <tab-container
+        {instance}="instance">
           <tab-panel {(panels)}="panels" title-text="Assessment">
         <div class="assessment-info-pane info-pane__body">
             <div class="assessment-attributes info-pane__main-content info-pane__main-content-with-sidebar">
@@ -182,6 +183,7 @@
                         {^saving}="formState.saving"
                         {^form-saved-deferred}="formState.formSavedDeferred"
                         {^is-dirty}="formState.isDirty"
+                        (validation-error)="setLastErrorTab(tabIndex)"
                         (validation-changed)="showRequiredInfoModal(%event)">
 			<custom-attributes
                             {fields}="fields"


### PR DESCRIPTION
# Issue description

In this pr improved redirection method to error cause place.
It switch to needed tab with error cause now.

# Steps to reproduce

1. Have Assessment with mandatory local custom attribute field which is not filled
2. Expand Assessment info pane and open 'Other attributes' tab
3. Click 'Complete' button

# Sanity check list

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description. 
- [x] My changes are covered by tests.
- [x] My changes follow the [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/performance.rst).
- [x] My changes follow the [js](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/javascript.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/git/how_to_write_a_commit_message.rst).
