### PR TITLE
GGRC-2312 Workflow stats on My work page is not correspond to tasks states color

### DIFF
--- a/src/ggrc/assets/stylesheets/_placeholders.scss
+++ b/src/ggrc/assets/stylesheets/_placeholders.scss
@@ -105,7 +105,7 @@
 %bar-pending {
   background: $status-draft;
 }
-%bar-warning {
+%bar-decline {
   background: $status-declined;
 }
 

--- a/src/ggrc/assets/stylesheets/modules/_progress.scss
+++ b/src/ggrc/assets/stylesheets/modules/_progress.scss
@@ -15,7 +15,7 @@
     margin-right: 0px;
   }
 
-  @each $bar_color in finish, verify, progress, pending, warning {
+  @each $bar_color in finish, verify, progress, pending, decline {
     .bar-#{$bar_color} {
       @extend %bar-#{$bar_color};
     }

--- a/src/ggrc_workflows/assets/javascripts/controllers/dashboard_page.js
+++ b/src/ggrc_workflows/assets/javascripts/controllers/dashboard_page.js
@@ -122,22 +122,26 @@
             else if (end_date.getTime() < first_end_date.getTime())
               first_end_date = end_date;
 
-            //Any task not verified is subject to overdue
-            if (data.status === 'Verified')
-              verified++;
-            else {
-              if (data.isOverdue) {
-                over_due++;
-                GGRC.Errors.notifier('error', 'Some tasks are overdue!');
-              }
-              else if (data.status === 'Finished')
+            if (data.isOverdue) {
+              over_due++;
+              GGRC.Errors.notifier('error', 'Some tasks are overdue!');
+            }
+            switch (data.status) {
+              case 'Verified':
+                verified++;
+                break;
+              case 'Finished':
                 finished++;
-              else if (data.status === 'InProgress')
+                break;
+              case 'InProgress':
                 in_progress++;
-              else if (data.status === 'Declined')
+                break;
+              case 'Declined':
                 declined++;
-              else
+                break;
+              case 'Assigned':
                 assigned++;
+                break;
             }
           }
           //Update Task_data object for workflow and Calculate %

--- a/src/ggrc_workflows/assets/javascripts/controllers/dashboard_page.js
+++ b/src/ggrc_workflows/assets/javascripts/controllers/dashboard_page.js
@@ -4,7 +4,7 @@
 */
 
 ;(function (CMS, GGRC, can, $) {
-  can.Component.extend({
+  GGRC.Components('dashboardWidgets', {
     tag: "dashboard-widgets",
     template: "<content/>",
     scope: {

--- a/src/ggrc_workflows/assets/javascripts/controllers/tests/dashbodrd_page_spec.js
+++ b/src/ggrc_workflows/assets/javascripts/controllers/tests/dashbodrd_page_spec.js
@@ -1,0 +1,81 @@
+/*
+    Copyright (C) 2017 Google Inc.
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+describe('GGRC.Components.dashboardWidgets', function () {
+  var methods;
+  var method;
+
+  beforeEach(function () {
+    methods = GGRC.Components.get('dashboardWidgets').prototype;
+  });
+
+  describe('update_tasks_for_workflow() method', function () {
+    var workflow;
+    var tasks;
+
+    function generatePreConditions(states, endDates = [], isOverdue = []) {
+      var refresh_instances;
+      var data = states.map(function (state) {
+        return {
+          instance: {status: state},
+        };
+      });
+      endDates.forEach(function (date, i) {
+        data[i].instance.end_date = date;
+      });
+      isOverdue.forEach(function (flag, i) {
+        data[i].instance.isOverdue = flag;
+      });
+      refresh_instances = jasmine.createSpy()
+        .and.returnValue(new can.Deferred().resolve(data));
+      tasks = {
+        refresh_instances: refresh_instances,
+      };
+      workflow = new can.Map({
+        get_binding: jasmine.createSpy().and.returnValue(tasks),
+      });
+      spyOn($.prototype, 'control').and.returnValue({
+        scope: new can.Map(),
+      });
+    };
+
+    beforeEach(function () {
+      method = methods['update_tasks_for_workflow'];
+    });
+
+    it('generates tasks percentage and counts into workflow', function (done) {
+      var states = ['Assigned', 'Assigned',
+        'Verified', 'Finished', 'InProgress', 'Declined'];
+      var isOverdue = [true, true];
+      var expectedResult = {
+        task_count: 6,
+        assigned: 2,
+        assigned_percentage: '33.33',
+        completed_percentage: '16.67',
+        days_left_for_first_task: 0,
+        declined: 1,
+        declined_percentage: '16.67',
+        finished: 1,
+        finished_percentage: '16.67',
+        in_progress: 1,
+        in_progress_percentage: '16.67',
+        over_due: 2,
+        over_due_flag: true,
+        over_due_percentage: '33.33',
+        task_count: 6,
+        verified: 1,
+        verified_percentage: '16.67',
+      };
+
+      generatePreConditions(states, [], isOverdue);
+
+      method(workflow).then(function () {
+        expect(workflow.attr('task_data').serialize())
+          .toEqual(jasmine.objectContaining(expectedResult));
+        done();
+      });
+    });
+  });
+});

--- a/src/ggrc_workflows/assets/mustache/dashboard/info/workflow_progress.mustache
+++ b/src/ggrc_workflows/assets/mustache/dashboard/info/workflow_progress.mustache
@@ -42,9 +42,6 @@
                 {{#if ins.task_data.declined_percentage}}
                   <div class="bar bar-decline" style="width: {{ins.task_data.declined_percentage}}%;" rel="tooltip" data-original-title="Declined {{ins.task_data.declined_percentage}}%"></div>
                 {{/if}}
-                {{#if ins.task_data.over_due_percentage}}
-                  <div class="bar bar-warning" style="width: {{ins.task_data.over_due_percentage}}%;" rel="tooltip" data-original-title="Overdue {{ins.task_data.over_due_percentage}}%"></div>
-                {{/if}}
               </div>
               <ul class="item-util">
                 {{#if ins.task_data.over_due_flag}}


### PR DESCRIPTION
# Issue description

On the My Work page in a progress-bar for workflows 'Declined' status color is not red. Instead of this 'Overdue' tasks is displayed as red. But 'Overdue' is not a status but a label, so it should not be displayed on the progress-bar. Also amount of overdue task is displayed below the bar. (approved by Ksenia Koltun)

# Steps to reproduce

Steps to reproduce:
1. Create one time WF
2. Create at least 5 tasks including 1 overdue task and Activate WF
3. On Active Cycles tab move tasks to the following states: Assigned, In progress, Finished, Declined, Assigned (overdue task)
4. Go to My Work page and look at the created WF stats

**Actual Result:** Workflow stats on My work page is not correspond to tasks states color
**Expected Result:** Tasks states should be correspond to the following requirements:
Assigned - grey color (#bdbdbd);
In Progress - blue color (#3369e8);
Finished - #405f77;
Declined - red (#d50f25);
Verified - green (#009925).
OVERDUE - red

# Solution description

Remove displaying of overdue task inside of progress bar. Not include percentage of overdue tasks into percentage summary.

# Sanity check list

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow the [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/performance.rst).
- [x] My changes follow the [js](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/git/how_to_write_a_commit_message.rst).