### PR TITLE
GGRC-3480 Start search on pressing enter in advanced search modals

### DIFF
--- a/src/ggrc/assets/javascripts/components/advanced-search/advanced-search-filter-attribute.js
+++ b/src/ggrc/assets/javascripts/components/advanced-search/advanced-search-filter-attribute.js
@@ -61,7 +61,17 @@
      */
     createGroup: function () {
       this.dispatch('createGroup');
-    }
+    },
+    /**
+     * Sets attribute value from $element value
+     * Used to update value on pressing enter as $value binding works
+     * on focusout event
+     *
+     * @param {jQuery} $element the DOM element that triggered event
+     */
+    setValue: function ($element) {
+      this.attr('attribute.value', $element.val());
+    },
   });
 
   /**

--- a/src/ggrc/assets/javascripts/components/advanced-search/tests/advanced-search-filter-attribute_spec.js
+++ b/src/ggrc/assets/javascripts/components/advanced-search/tests/advanced-search-filter-attribute_spec.js
@@ -52,4 +52,18 @@ describe('GGRC.Components.advancedSearchFilterAttribute', function () {
       expect(viewModel.dispatch).toHaveBeenCalledWith('createGroup');
     });
   });
+
+  describe('setValue() method', function () {
+    it('updates "attribute value" from $element value', function () {
+      var $element;
+
+      viewModel.attr('attribute').value = 'old value';
+
+      $element = $('<input type="text"/>');
+      $element.val('new value');
+      viewModel.setValue($element);
+
+      expect(viewModel.attr('attribute').value).toBe('new value');
+    });
+  });
 });

--- a/src/ggrc/assets/javascripts/components/tree/templates/tree-widget-container.mustache
+++ b/src/ggrc/assets/javascripts/components/tree/templates/tree-widget-container.mustache
@@ -87,7 +87,8 @@
           <advanced-search-filter-container
             {(items)}="advancedSearch.filterItems"
             {available-attributes}="columns.available"
-            {model-name}="modelName">
+            {model-name}="modelName"
+            ($enter)="applyAdvancedFilters()">
           </advanced-search-filter-container>
         </div>
         <div class="advanced-search__mapping-header">
@@ -96,7 +97,8 @@
         <div class="simple-modal__body">
           <advanced-search-mapping-container
             {(items)}="advancedSearch.mappingItems"
-            {model-name}="modelName">
+            {model-name}="modelName"
+            ($enter)="applyAdvancedFilters()">
           </advanced-search-mapping-container>
         </div>
       </div>

--- a/src/ggrc/assets/mustache/components/advanced-search/advanced-search-filter-attribute.mustache
+++ b/src/ggrc/assets/mustache/components/advanced-search/advanced-search-filter-attribute.mustache
@@ -22,7 +22,12 @@
     </select>
   </div>
   <div class="filter-attribute__value">
-    <input tabindex="3" placeholder="Type here..." name="right" type="text" {($value)}="attribute.value">
+    <input tabindex="3"
+      placeholder="Type here..."
+      name="right"
+      type="text"
+      {($value)}="attribute.value"
+      ($enter)='setValue($element)'>
   </div>
   {{#if showActions}}
   <div class="filter-attribute__action">

--- a/src/ggrc/assets/mustache/components/object-generator/object-generator.mustache
+++ b/src/ggrc/assets/mustache/components/object-generator/object-generator.mustache
@@ -19,7 +19,8 @@
       {^mapping-items}="*mappingItems"
       {^filter-items}="*filterItems"
       {^status-item}="*statusItem"
-      {relevant-to}="relevantTo">
+      {relevant-to}="relevantTo"
+      ($enter)="onSubmit()">
       <div class="object-controls">
         <div class="object-controls__row">
           <div class="object-controls__template">

--- a/src/ggrc/assets/mustache/components/object-mapper/object-mapper.mustache
+++ b/src/ggrc/assets/mustache/components/object-mapper/object-mapper.mustache
@@ -73,7 +73,8 @@
       {^mapping-items}="*mappingItems"
       {^filter-items}="*filterItems"
       {^status-item}="*statusItem"
-      {relevant-to}="relevantTo">
+      {relevant-to}="relevantTo"
+      ($enter)="onSubmit()">
       <div class="object-controls">
         <div class="object-controls__row">
           <div class="object-controls__type">

--- a/src/ggrc/assets/mustache/components/object-search/object-search.mustache
+++ b/src/ggrc/assets/mustache/components/object-search/object-search.mustache
@@ -19,7 +19,8 @@
       {model-display-name}="model.name"
       {^mapping-items}="*mappingItems"
       {^filter-items}="*filterItems"
-      {^status-item}="*statusItem">
+      {^status-item}="*statusItem"
+      ($enter)="onSubmit()">
       <div class="object-controls">
         <div class="object-controls__row">
           <div class="object-controls__type">


### PR DESCRIPTION
# Issue description

Advanced Search should work on pressing Enter.
Advanced search modals:
- Object filter on tree view
- Global search
- Map object 
- Generate assessment

# Solution description

Handle pressing enter on every advanced search component. Call the same handler as on 'Search' button click. 

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".