### PR TITLE
QUICK-FIX Remove "AssessmentTemplate" from list of objects without states

### DIFF
--- a/src/ggrc/assets/javascripts/plugins/utils/state-utils.js
+++ b/src/ggrc/assets/javascripts/plugins/utils/state-utils.js
@@ -37,8 +37,7 @@
       },
       {
         models: [
-          'Person', 'CycleTaskGroupObjectTask',
-          'AssessmentTemplate', 'Workflow',
+          'Person', 'CycleTaskGroupObjectTask', 'Workflow',
           'TaskGroup', 'Cycle'
         ],
         states: []


### PR DESCRIPTION
# Issue description

In state-utils.js 'AssessmentTemplate' is present in two lists of models with different sets of states. It should be removed from second list with no states. It was missed in the next PR: https://github.com/google/ggrc-core/pull/6436/files#diff-750fc82dad94c4cd40fb9be8b5698f7bR40 .

# Solution description

Remove "AssessmentTemplate" from list of objects without states.

# Sanity check list

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else).
- [ ] My changes are covered by tests.
- [x] My changes follow the [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/performance.rst).
- [x] My changes follow the [js](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/git/how_to_write_a_commit_message.rst).