### PR TITLE
GGRC-3639 Prevent reloading of related assessments when navigating to other tabs and back

### DIFF
--- a/src/ggrc/assets/javascripts/components/tabs/tab-panel.js
+++ b/src/ggrc/assets/javascripts/components/tabs/tab-panel.js
@@ -12,6 +12,18 @@
       GGRC.mustache_path + '/components/tabs/tab-panel.mustache'
     ),
     viewModel: {
+      define: {
+        cssClasses: {
+          type: 'string',
+          get: function () {
+            return this.attr('active') ? '' : 'hidden';
+          },
+        },
+        cacheContent: {
+          type: 'boolean',
+          value: false,
+        },
+      },
       active: false,
       titleText: '@',
       panels: [],

--- a/src/ggrc/assets/mustache/components/assessment/info-pane/info-pane.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/info-pane/info-pane.mustache
@@ -231,7 +231,7 @@
             </div>
         </div>
          </tab-panel>
-          <tab-panel {(panels)}="panels" title-text="Related Assessments">
+          <tab-panel {(panels)}="panels" {cache-content}="true" title-text="Related Assessments">
                   {{> '/static/mustache/assessments/related-assessments.mustache' }}
           </tab-panel>
           <tab-panel {(panels)}="panels" title-text="Related Issues">

--- a/src/ggrc/assets/mustache/components/tabs/tab-panel.mustache
+++ b/src/ggrc/assets/mustache/components/tabs/tab-panel.mustache
@@ -3,10 +3,20 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
 
-{{#if active}}
-<div class="tab-content">
-    <div class="tab-pane active">
-      <content></content>
+{{#if cacheContent}}
+  <lazy-render {trigger}="active">
+    <div class="tab-content {{cssClasses}}">
+      <div class="tab-pane active">
+        <content></content>
+      </div>
     </div>
-</div>
+  </lazy-render>
+{{else}}
+  {{#if active}}
+    <div class="tab-content">
+      <div class="tab-pane active">
+        <content></content>
+      </div>
+    </div>
+  {{/if}}
 {{/if}}


### PR DESCRIPTION
# Issue description

Related assessments are loading each time when user open the corresponding tab on Assessment Info pane

# Steps to reproduce

1. Open Assessment tab
2. Move on `Related Assessments` tab
3. Watch on the spinner
4. Move on any other tab
5. Repeat point `2`
6. Watch on the spinner again

# Solution description

Cache current content of `Related Assessments` tab when user move on other tabs