### PR TITLE
GGRC-3635 Improve Audit tab line

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
@@ -279,12 +279,6 @@
           this.options.attr('widget_list', new can.Observe.List([]));
         }
 
-        // trigger show_hide_title, because numbers of 
-        // widgets can be changed after updating of instance
-        instance.bind('snapshotScopeUpdated', () => {
-          this.show_hide_titles();
-        });
-
         this.options.attr('instance', instance);
         if (!(this.options.contexts instanceof can.Observe)) {
           this.options.attr('contexts', new can.Observe(this.options.contexts));
@@ -536,6 +530,7 @@
         });
       }
       this.update_add_more_link();
+      this.show_hide_titles();
     },
 
     update_add_more_link: function () {
@@ -570,18 +565,14 @@
       } else {
         $hiddenWidgets.find('a').hide();
       }
-      this.show_hide_titles();
     },
-    '{window} resize': _.debounce(function (el, ev) {
-      this.show_hide_titles();
-    }, 100),
 
     show_hide_titles: function () {
-      var pageType = GGRC.Utils.CurrentPage.getPageType();
-      var $el = this.element;
-      var originalWidgets = this.options.widget_list;
-      var dividedTabsMode = this.options.attr('dividedTabsMode');
-      var priorityTabs = this.options.attr('priorityTabs');
+      const pageType = GGRC.Utils.CurrentPage.getPageType();
+      const originalWidgets = this.options.widget_list;
+      const priorityTabsNum = this.options.attr('priorityTabs');
+      const priorityTabs = originalWidgets.slice(0, priorityTabsNum);
+      const notPriorityTabs = originalWidgets.slice(priorityTabsNum);
 
       function hideTitles(widgets) {
         widgets.forEach(function (widget) {
@@ -589,35 +580,17 @@
         });
       }
 
-      function adjust(widgets, isPriorityHide) {
-        var widths;
-
-        // see if too wide
-        widths = _.map($el.children(':visible'),
-          function (el) {
-            return $(el).outerWidth();
-          }).reduce(function (sum, current) {
-            return sum + current;
-          }, 0);
-
-        // adjust
-        if (widths > $el.width()) {
-          if (!isPriorityHide && dividedTabsMode && priorityTabs) {
-            hideTitles(widgets.slice(priorityTabs));
-            adjust(widgets.slice(0, priorityTabs), true);
-          } else {
-            hideTitles(widgets);
-          }
-        }
+      function showTitles(widgets) {
+        widgets.forEach(function (widget) {
+          widget.attr('show_title', true);
+        });
       }
 
-      // first expand all
-      originalWidgets.forEach(function (widget) {
-        widget.attr('show_title', true);
-      });
-
       if (pageType === 'Audit') {
-        adjust(originalWidgets);
+        showTitles(priorityTabs);
+        hideTitles(notPriorityTabs);
+      } else {
+        showTitles(originalWidgets);
       }
     },
     '.closed click': function (el, ev) {
@@ -662,7 +635,6 @@
       } else {
         $hiddenArea.hide();
       }
-      this.show_hide_titles();
     },
   });
 })(window.can, window.can.$);

--- a/src/ggrc/assets/javascripts/controllers/tests/inner_navigation_controller_spec.js
+++ b/src/ggrc/assets/javascripts/controllers/tests/inner_navigation_controller_spec.js
@@ -6,14 +6,14 @@
 describe('CMS.Controllers.InnerNav', function () {
   'use strict';
 
-  var Ctrl;  // the controller under test
+  var Ctrl; // the controller under test
 
   beforeAll(function () {
     Ctrl = CMS.Controllers.InnerNav;
   });
 
   describe('sortWidgets() method', function () {
-    var ctrlInst;  // fake controller instance
+    var ctrlInst; // fake controller instance
     var sortWidgets;
     var options;
 
@@ -46,7 +46,8 @@ describe('CMS.Controllers.InnerNav', function () {
       expect(widgetOrder).toEqual(['ddd', 'bbb', 'eee', 'aaa', 'ccc']);
     });
 
-    it('places widgets with unknown "order" at the end and sort them in alphabetical order', function () {
+    it('places widgets with unknown "order" at' +
+      'the end and sort them in alphabetical order', function () {
       var widgetOrder;
       var widgets = [
         {internav_display: 'abc'},
@@ -70,10 +71,9 @@ describe('CMS.Controllers.InnerNav', function () {
 
   describe('show_hide_titles() method', function () {
     var DISPLAY_WIDTH = 1920;
-    var ctrlInst;  // fake controller instance
+    var ctrlInst; // fake controller instance
     var showHideTitles;
     var options;
-    var getPageTypeSpy;
 
     function createWidgets(titlesStatus) {
       var widgets = [
@@ -111,39 +111,15 @@ describe('CMS.Controllers.InnerNav', function () {
         .and
         .returnValue([]);
 
-      getPageTypeSpy = spyOn(GGRC.Utils.CurrentPage, 'getPageType')
+      spyOn(GGRC.Utils.CurrentPage, 'getPageType')
         .and
-        .returnValue('Audit');
+        .returnValue('Assessment');
 
       showHideTitles = Ctrl.prototype.show_hide_titles.bind(ctrlInst);
     });
 
     afterEach(function () {
       Array.prototype.reduce.calls.reset();
-    });
-
-
-    it('always show titles if page instance is not AUDIT', function () {
-      var types = ['Assessment', 'Audit', 'Control', 'Program'];
-
-      setWidgetsWidth(2400);
-
-      types.forEach((type) => {
-        getPageTypeSpy.and.returnValue(type);
-
-        showHideTitles = Ctrl.prototype.show_hide_titles.bind(ctrlInst);
-
-        createWidgets(false);
-        showHideTitles();
-
-        if (type !== 'Audit') {
-          expect(_.every(options.attr('widget_list'), 'show_title'))
-            .toBeTruthy();
-        } else {
-          expect(_.every(options.attr('widget_list'), 'show_title'))
-            .toBeFalsy();
-        }
-      });
     });
 
     it('doesnt hide titles if the width is enough', function () {
@@ -156,47 +132,14 @@ describe('CMS.Controllers.InnerNav', function () {
       expect(_.every(options.attr('widget_list'), 'show_title')).toBeTruthy();
     });
 
-    it('hides titles if the width isnt enough', function () {
+    it('doesnt hides titles if the width isnt enough', function () {
       createWidgets(true);
 
       setWidgetsWidth(2500);
 
       showHideTitles();
 
-      expect(_.every(options.widget_list, 'show_title', false)).toBeTruthy();
-    });
-
-    it('hides not priority titles if the width isnt enough', function () {
-      var widgetList;
-      createWidgets(true);
-
-      options.attr('dividedTabsMode', true);
-      options.attr('priorityTabs', 3);
-
-      setWidgetsWidth(2500, 1500);
-
-      showHideTitles();
-
-      widgetList = options.attr('widget_list');
-
-      expect(_.every(widgetList.slice(0, 3), 'show_title')).toBeTruthy();
-      expect(_.every(widgetList.slice(3), 'show_title', false)).toBeTruthy();
-    });
-
-    it('hides all titles if the width isnt enough', function () {
-      var widgetList;
-      createWidgets(true);
-
-      options.attr('dividedTabsMode', true);
-      options.attr('priorityTabs', 3);
-
-      setWidgetsWidth(3000, 2000);
-
-      showHideTitles();
-
-      widgetList = options.attr('widget_list');
-
-      expect(_.every(widgetList, 'show_title', false)).toBeTruthy();
+      expect(_.every(options.widget_list, 'show_title')).toBeTruthy();
     });
   });
 });

--- a/src/ggrc/assets/mustache/dashboard/internav_list.mustache
+++ b/src/ggrc/assets/mustache/dashboard/internav_list.mustache
@@ -33,6 +33,7 @@
 {{#is_allowed 'update' instance}}
 {{#if widget_list.length}}
 {{^if instance.archived}}
+{{#isMenuVisible}}
 <li data-test-id="button_widget_add_2c925d94" class="hidden-widgets-list">
   <a href="{{urlPath}}#dropdown-widgets" class="dropdown-toggle" data-toggle="dropdown" rel="tooltip" data-placement="bottom" title="{{addTabTitle}}"><i class="fa fa-plus-circle"></i> {{addTabTitle}}</a>
   <div class="dropdown-menu" role="menu">
@@ -110,6 +111,7 @@
     {{/widget_list}}
   </div>
 </li>
+{{/isMenuVisible}}
 {{/if}}
 {{/if}}
 {{/is_allowed}}


### PR DESCRIPTION
# Steps to reproduce

Go to Audit page a and look at the tabs.
Expected:
1. Left part should always be expanded (icons + inscriptions). (as on screenshot - it should never get collapsed) (sample - https://ggrc-qa.appspot.com/audits/4229)
2. Right part should always be collapsed (only icons).
3. For Audit - Audit Summary should be default tab

# Sanity check list

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description. 
- [x] My changes are covered by tests.
- [x] My changes follow the [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/performance.rst).
- [x] My changes follow the [js](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/javascript.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/git/how_to_write_a_commit_message.rst).
