### PR TITLE
GGRC-3646 Avoid permissions loading if possible on query api requests

### DIFF
--- a/src/ggrc/query/builder.py
+++ b/src/ggrc/query/builder.py
@@ -218,6 +218,12 @@ class QueryHelper(object):
     Prepare query to filter models based on the available contexts and
     resources for the given type of object.
     """
+    if permission_type == "read" and permissions.has_system_wide_read():
+      return None
+
+    if permission_type == "update" and permissions.has_system_wide_update():
+      return None
+
     contexts, resources = permissions.get_context_resource(
         model_name=model.__name__, permission_type=permission_type
     )
@@ -354,8 +360,8 @@ class QueryHelper(object):
     Args:
       model: the model instances of which are requested in query;
       query: a query to get objects from the db;
-      order_by: a list of dicts with keys "name" (the name of the field by which
-                to sort) and "desc" (optional; do reverse sort if True);
+      order_by: a list of dicts with keys "name" (the name of the field by
+                which to sort) and "desc" (optional; do reverse sort if True);
       tgt_class: the snapshotted model if `model` is Snapshot else `model`.
 
     If order_by["name"] == "__similarity__" (a special non-field value),

--- a/src/ggrc/rbac/__init__.py
+++ b/src/ggrc/rbac/__init__.py
@@ -22,6 +22,19 @@ class SystemWideRoles(object):
       ADMINISTRATOR
   }
 
+  read_roles = {
+      SUPERUSER,
+      ADMINISTRATOR,
+      EDITOR,
+      READER,
+  }
+
+  update_roles = {
+      SUPERUSER,
+      ADMINISTRATOR,
+      EDITOR,
+  }
+
 
 def context_query_filter(context_column, contexts):
   '''

--- a/src/ggrc/rbac/permissions.py
+++ b/src/ggrc/rbac/permissions.py
@@ -54,7 +54,7 @@ def is_allowed_create_for(instance):
   return permissions_for(get_user()).is_allowed_create_for(instance)
 
 
-def _system_wide_read():
+def has_system_wide_read():
   """Check if user has system wide read access to all objects."""
   user = login.get_current_user()
   system_wide_role = getattr(user, "system_wide_role",
@@ -66,7 +66,7 @@ def is_allowed_read(resource_type, resource_id, context_id):
   """Whether or not the user is allowed to read a resource of the specified
   type in the context.
   """
-  if _system_wide_read():
+  if has_system_wide_read():
     return True
   return permissions_for(get_user()).is_allowed_read(
       resource_type, resource_id, context_id)
@@ -76,7 +76,7 @@ def is_allowed_read_for(instance):
   """Whether or not the user is allowed to read this particular resource
   instance.
   """
-  if _system_wide_read():
+  if has_system_wide_read():
     return True
   return permissions_for(get_user()).is_allowed_read_for(instance)
 

--- a/src/ggrc/rbac/permissions.py
+++ b/src/ggrc/rbac/permissions.py
@@ -18,6 +18,12 @@ SYSTEM_WIDE_READ_ROLES = {
     SystemWideRoles.READER,
 }
 
+SYSTEM_WIDE_UPDATE_ROLES = {
+    SystemWideRoles.SUPERUSER,
+    SystemWideRoles.ADMINISTRATOR,
+    SystemWideRoles.EDITOR,
+}
+
 
 def get_permissions_provider():
   return get_extension_instance(
@@ -52,6 +58,14 @@ def is_allowed_create_for(instance):
   instance.
   """
   return permissions_for(get_user()).is_allowed_create_for(instance)
+
+
+def has_system_wide_update():
+  """Check if user has system wide update access to all objects."""
+  user = login.get_current_user()
+  system_wide_role = getattr(user, "system_wide_role",
+                             SystemWideRoles.NO_ACCESS)
+  return system_wide_role in SYSTEM_WIDE_UPDATE_ROLES
 
 
 def has_system_wide_read():

--- a/src/ggrc/rbac/permissions.py
+++ b/src/ggrc/rbac/permissions.py
@@ -11,20 +11,6 @@ from ggrc.extensions import get_extension_instance
 from ggrc.rbac import SystemWideRoles
 
 
-SYSTEM_WIDE_READ_ROLES = {
-    SystemWideRoles.SUPERUSER,
-    SystemWideRoles.ADMINISTRATOR,
-    SystemWideRoles.EDITOR,
-    SystemWideRoles.READER,
-}
-
-SYSTEM_WIDE_UPDATE_ROLES = {
-    SystemWideRoles.SUPERUSER,
-    SystemWideRoles.ADMINISTRATOR,
-    SystemWideRoles.EDITOR,
-}
-
-
 def get_permissions_provider():
   return get_extension_instance(
       'USER_PERMISSIONS_PROVIDER',
@@ -65,7 +51,7 @@ def has_system_wide_update():
   user = login.get_current_user()
   system_wide_role = getattr(user, "system_wide_role",
                              SystemWideRoles.NO_ACCESS)
-  return system_wide_role in SYSTEM_WIDE_UPDATE_ROLES
+  return system_wide_role in SystemWideRoles.update_roles
 
 
 def has_system_wide_read():
@@ -73,7 +59,7 @@ def has_system_wide_read():
   user = login.get_current_user()
   system_wide_role = getattr(user, "system_wide_role",
                              SystemWideRoles.NO_ACCESS)
-  return system_wide_role in SYSTEM_WIDE_READ_ROLES
+  return system_wide_role in SystemWideRoles.read_roles
 
 
 def is_allowed_read(resource_type, resource_id, context_id):


### PR DESCRIPTION
This is a quick easy performance fix for navigting our tree views for anyone with high enough system role

to check this take a random tree view navigate left and right, and I suggest using `export GGRC_BENCHMARK=last` for log format.