### PR TITLE
GGRC-3536 Old styles of fields are displayed in New/Edit Assessment modal window

### DIFF
--- a/src/ggrc/assets/mustache/assessments/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessments/modal_content.mustache
@@ -26,9 +26,8 @@
 
       <div class="ggrc-form-item">
         <div class="ggrc-form-item__multiple-row">
-          <label class="form-label required-label">
+          <label class="form-label ggrc-form-item__label">
             Assessment Type
-            <i class="fa fa-asterisk"></i>
           </label>
           <assessment-object-type-dropdown
             {instance}="instance"
@@ -215,7 +214,7 @@
               {is-disabled}="isLoading"
               (createReferenceUrl)="markDocumentForAddition(%event.payload)"
               (removeReferenceUrl)="markDocumentForDeletion(%event.payload)">
-              <label>
+              <label class="ggrc-form-item__label">
                 Reference URL
                 <spinner {toggle}="isDisabled"></spinner>
               </label>

--- a/src/ggrc/assets/mustache/assessments/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessments/modal_content.mustache
@@ -153,11 +153,6 @@
                   </div>
                 {{/each}}
               {{/prune_context}}
-              {{^list.length}}
-                <span>
-                  <em>No mapped objects</em>
-                </span>
-              {{/list.length}}
             </div>
             <div class="objective-selector">
                <map-button-using-assessment-type

--- a/src/ggrc/assets/stylesheets/components/info-pane/_info-pane.scss
+++ b/src/ggrc/assets/stylesheets/components/info-pane/_info-pane.scss
@@ -112,10 +112,9 @@
 
       .state-value {
         box-sizing: border-box;
-        height: 20px;
         white-space: nowrap;
         margin-right: 8px;
-        line-height: 19px;
+        line-height: 18px;
         display: flex;
         align-items: center;
       }

--- a/src/ggrc/assets/stylesheets/components/mapped-objects/_mapped-objects.scss
+++ b/src/ggrc/assets/stylesheets/components/mapped-objects/_mapped-objects.scss
@@ -37,6 +37,8 @@
 
 .mapped-objects__item {
   background: $white;
+  border-radius: 2px;
+  border: 1px solid #ccc;
   line-height: 24px;
   box-sizing: border-box;
   padding: 0 8px 0 4px;
@@ -244,7 +246,7 @@ directly-mapped-objects {
 
 .modal-mapped-objects {
   display: block;
-  margin-bottom: 10px;
+  margin-bottom: 5px;
 
   .modal-mapped-objects-item {
     display: flex;

--- a/src/ggrc/assets/stylesheets/modules/_advanced-info.scss
+++ b/src/ggrc/assets/stylesheets/modules/_advanced-info.scss
@@ -61,6 +61,7 @@
 
 .expand-link {
   a.show-hidden-fields {
+    outline: none;
     display:block;
     padding-top:10px;
     font-size:16px;


### PR DESCRIPTION
# Issue description

Different styles for labels on assessment new/edit modal.

# Steps to reproduce

1. Invoke new/edit Assessment modal window
2. Look at the Assessment Type, Reference url, notifications style: is old one

*Actual Result:* Old styles of fields are displayed in the New/Edit Assessment modal window
*Expected Result:* Actual style of fields should be displayed in the New/Edit Assessment modal window

*Mockups:* https://drive.google.com/corp/drive/folders/0B65BmaCGVTRwSGFRSVpheHJjcEU

# Solution description

Make labels font bold on assessment modal for next fields: "Assessment Title", "Reference URL".

Out of scope:
1) Add border for non-snapsot mapped objects (approved by Ksenia Koltun).
2) Remove text "No mapped objects" (approved by Ksenia Koltun).
3) Remove outline for "Hide additional fields" button.
4) Fix height of status label on assessment info page/pane.


# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests (no functional logic).
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

