### PR TITLE
GGRC-3593,3595 Handle unset Relationship.source in relationship hooks

### DIFF
--- a/src/ggrc/models/hooks/relationship.py
+++ b/src/ggrc/models/hooks/relationship.py
@@ -65,6 +65,14 @@ def handle_audit_issue_mapping(session, flush_context, instances):
 
   for instance in itertools.chain(session.new, session.dirty):
     if isinstance(instance, all_models.Relationship):
+      if not instance.source:
+        # TODO: fix actions to make this impossible
+        LOGGER.error(u"Relationship.source is not filled in properly: "
+                     u"id=%r, source_id=%r, source_type=%r, "
+                     u"destination_id=%r, destination_type=%r.",
+                     instance.id, instance.source_id, instance.source_type,
+                     instance.destination_id, instance.destination_type)
+        continue
       if not instance.destination:
         # TODO: fix Document imports to make this impossible
         LOGGER.error(u"Relationship.destination is not filled in properly: "

--- a/src/ggrc/models/hooks/relationship.py
+++ b/src/ggrc/models/hooks/relationship.py
@@ -4,7 +4,7 @@
 """Relationship creation/modification hooks."""
 
 from datetime import datetime
-
+import logging
 import itertools
 
 import sqlalchemy as sa
@@ -15,6 +15,9 @@ from ggrc.models import all_models
 from ggrc.models.comment import Commentable
 from ggrc.models.mixins import ChangeTracked
 from ggrc.models import exceptions
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 def _handle_del_audit_issue_mapping(audit, issue):
@@ -64,6 +67,11 @@ def handle_audit_issue_mapping(session, flush_context, instances):
     if isinstance(instance, all_models.Relationship):
       if not instance.destination:
         # TODO: fix Document imports to make this impossible
+        LOGGER.error(u"Relationship.destination is not filled in properly: "
+                     u"id=%r, source_id=%r, source_type=%r, "
+                     u"destination_id=%r, destination_type=%r.",
+                     instance.id, instance.source_id, instance.source_type,
+                     instance.destination_id, instance.destination_type)
         continue
       src, dst = order(instance.source, instance.destination)
       if is_audit_issue(src, dst):

--- a/test/unit/ggrc/models/hooks/test_relationship.py
+++ b/test/unit/ggrc/models/hooks/test_relationship.py
@@ -1,0 +1,89 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Test relationship hooks."""
+
+import unittest
+
+import ddt
+import mock
+
+from ggrc.models.hooks import relationship
+
+
+@ddt.ddt
+class TestFromSession(unittest.TestCase):
+  """Test session-listener wrapper.
+
+  Models are substituted with builtin types as they can be used for
+  isinstance checks too.
+  """
+
+  N_INT = 1
+  N_STR = "2"
+  M_INT = 3
+  M_STR = "4"
+  D_INT = 5
+  D_STR = "6"
+
+  NEW = {N_INT, N_STR}
+  DIRTY = {M_INT, M_STR}
+  DELETED = {D_INT, D_STR}
+
+  @staticmethod
+  def target(objects):
+    return list(objects)
+
+  def setUp(self):
+    super(TestFromSession, self).setUp()
+    self.session = mock.Mock(
+        new=self.NEW,
+        dirty=self.DIRTY,
+        deleted=self.DELETED,
+    )
+
+  @ddt.data(
+      ((False, False, False), (), set()),
+      ((False, False, False), (int,), set()),
+      ((False, False, False), (str,), set()),
+      ((False, False, False), (int, str), set()),
+      ((False, False, True), (), set()),
+      ((False, False, True), (int,), {D_INT}),
+      ((False, False, True), (str,), {D_STR}),
+      ((False, False, True), (int, str), {D_INT, D_STR}),
+      ((False, True, False), (), set()),
+      ((False, True, False), (int,), {M_INT}),
+      ((False, True, False), (str,), {M_STR}),
+      ((False, True, False), (int, str), {M_INT, M_STR}),
+      ((False, True, True), (), set()),
+      ((False, True, True), (int,), {M_INT, D_INT}),
+      ((False, True, True), (str,), {M_STR, D_STR}),
+      ((False, True, True), (int, str), {M_INT, M_STR, D_INT, D_STR}),
+      ((True, False, False), (), set()),
+      ((True, False, False), (int,), {N_INT}),
+      ((True, False, False), (str,), {N_STR}),
+      ((True, False, False), (int, str), {N_INT, N_STR}),
+      ((True, False, True), (), set()),
+      ((True, False, True), (int,), {N_INT, D_INT}),
+      ((True, False, True), (str,), {N_STR, D_STR}),
+      ((True, False, True), (int, str), {N_INT, N_STR, D_INT, D_STR}),
+      ((True, True, False), (), set()),
+      ((True, True, False), (int,), {N_INT, M_INT}),
+      ((True, True, False), (str,), {N_STR, M_STR}),
+      ((True, True, False), (int, str), {N_INT, N_STR, M_INT, M_STR}),
+      ((True, True, True), (), set()),
+      ((True, True, True), (int,), {N_INT, M_INT, D_INT}),
+      ((True, True, True), (str,), {N_STR, M_STR, D_STR}),
+      ((True, True, True), (int, str), {N_INT, N_STR, M_INT, M_STR,
+                                        D_INT, D_STR}),
+  )
+  @ddt.unpack
+  def test_from_session(self, (new, dirty, deleted), types, expected):
+    """@from_session filters correct sets and types."""
+    decorated = relationship.from_session(
+        new=new, dirty=dirty, deleted=deleted, *types
+    )(self.target)
+
+    result = decorated(self.session, None, None)
+
+    self.assertItemsEqual(result, expected)


### PR DESCRIPTION
# Issue description

Sometimes a Relationship object gets `source_type` and `source_id` set, but `source` unset, and it breaks the optimistic hook that neither checks `if source` nor handles `AttributeError`. 

# Steps to test the changes

Precondition:
1. Have an audit with assigned folder and attachment
2. Create Assessment on the audit page

Steps to reproduce:
1. Expand Assessment Info pane
2. Attach evidence
3. Click 'Complete' button immediately to make sure both edits are submitted with a single request.

Expected result: the evidence is attached, the state is changed.
Actual result: random; some reports said the evidence is attached, but the state is unchanged.

# Solution description

Look before you leap. Although not very pythonic, it's how we handle broken relationships in our app.

Also there is an utility decorator that hides typical loop over new/changed/deleted objects in the session.

I was unable to locate the place where the invalid objects gets created, although it's somewhere in the `actions` field handler.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->