### PR TITLE
GGRC-3338 Fix Task Group autocomplete issues in Cycle Task modal

### DIFF
--- a/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/modal_content.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/modal_content.mustache
@@ -74,7 +74,10 @@
       <br>
       <div class="{{#instance.computed_errors.cycle_task_group}}field-failure{{/instance.computed_errors.cycle_task_group}}">
         {{#using cycle_task_group=instance.cycle_task_group}}
-          <h6>Task Group <span class="required">*</span></h6>
+          <label class="form__label">
+            Task Group
+            <i class="fa fa-asterisk"></i>
+          </label>
           <input
             {{^if instance.cycle}} disabled {{/if}}
             class="input-block-level required"
@@ -92,6 +95,7 @@
         {{/using}}
       {{#instance.computed_errors.cycle_task_group}}<label class="help-inline warning">{{this}}</label>{{/instance.computed_errors.cycle_task_group}}
     </div>
+    <br>
   </div>
 
   <div class="row-fluid">

--- a/src/ggrc_workflows/assets/mustache/cycle_task_groups/extended_info.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_groups/extended_info.mustache
@@ -9,9 +9,13 @@
 {{#instance}}
   <div class="row-fluid">
     <div class="span12">
-      <a class="main-title {{class.category}} oneline" href="{{viewLink}}">
-        {{title}}
-      </a>
+      {{#using cycle=instance.cycle}}
+      {{#using workflow=cycle.workflow}}
+        <a class="main-title {{class.category}} oneline" href="{{workflow.viewLink}}">
+          {{title}}
+        </a>
+      {{/using}}
+      {{/using}}
     </div>
   </div>
 


### PR DESCRIPTION
# Issue description

1. Wrong formatting of the 'TASK GROUP *' field
<img width="400" alt="" src="https://user-images.githubusercontent.com/3773902/31823961-63d2dbfc-b5b6-11e7-8b97-3f291d2385b2.png">
2. Task Group link in popup is incorrect on My Tasks page: while clicking the link, user is redirected to My work page. Should be redirected to Workflow page.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
