### PR TITLE
GGRC-1741 Make 'name' field mandatory on new user modal

### DIFF
--- a/src/ggrc/assets/javascripts/models/person.js
+++ b/src/ggrc/assets/javascripts/models/person.js
@@ -106,6 +106,7 @@
 
       this.validateNonBlank('email');
       this.validateFormatOf('email', rEmail);
+      this.validateNonBlank('name');
     },
 
     /**

--- a/src/ggrc/assets/mustache/people/modal_content.mustache
+++ b/src/ggrc/assets/mustache/people/modal_content.mustache
@@ -12,6 +12,7 @@
     <div class="span4">
       <label for="person_name">
         Name
+        <span class="required">*</span>
       </label>
       <input tabindex="1" class="span12" id="person_name" name="name" placeholder="John Doe" size="30" type="text" value="{{name}}" autofocus>
       <br>


### PR DESCRIPTION
# Issue description

The 'name' field should be mandatory when adding a new user into gGRC.

# Steps to test the changes

1. As admin User go to Administration
2. People tab > Click create a new person
3. Look at "Name" field

**Actual Result:** "Name" field is not required
**Expected Result:** "Name" field is required and marked with red star

# Solution description

Add non blanc validation for name property

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
