### PR TITLE
GGRC-3616 Remove contact_id from tasks and cycle tasks

### DIFF
--- a/src/ggrc_workflows/migrations/versions/20171030074846_456b7edf6027_remove_contact_id.py
+++ b/src/ggrc_workflows/migrations/versions/20171030074846_456b7edf6027_remove_contact_id.py
@@ -1,0 +1,70 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Drop deprecated column 'contact_id' from 'task_group_tasks' and
+'cycle_task_group_object_tasks'
+
+Create Date: 2017-10-30 07:48:46.425098
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+import sqlalchemy as sa
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '456b7edf6027'
+down_revision = '251191c050d0'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  # task_group_tasks:
+  op.drop_index('fk_task_group_tasks_contact',
+                'task_group_tasks')
+  op.drop_index('fk_task_group_tasks_secondary_contact',
+                'task_group_tasks')
+  op.drop_column('task_group_tasks', 'contact_id')
+  op.drop_column('task_group_tasks', 'secondary_contact_id')
+
+  # cycle_task_group_object_tasks table:
+  op.drop_constraint('cycle_task_group_object_tasks_ibfk_1',
+                     'cycle_task_group_object_tasks',
+                     'foreignkey')
+  op.drop_index('fk_cycle_task_group_object_tasks_contact',
+                'cycle_task_group_object_tasks')
+  op.drop_index('fk_cycle_task_group_object_tasks_secondary_contact',
+                'cycle_task_group_object_tasks')
+  op.drop_column('cycle_task_group_object_tasks', 'contact_id')
+  op.drop_column('cycle_task_group_object_tasks', 'secondary_contact_id')
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  # task_group_tasks:
+  op.add_column('task_group_tasks',
+                sa.Column('contact_id', sa.Integer(), nullable=True))
+  op.add_column('task_group_tasks',
+                sa.Column('secondary_contact_id', sa.Integer(), nullable=True))
+  op.create_index('fk_task_group_tasks_contact', 'task_group_tasks',
+                  ['contact_id'], unique=False)
+  op.create_index('fk_task_group_tasks_secondary_contact', 'task_group_tasks',
+                  ['secondary_contact_id'], unique=False)
+
+  # cycle_task_group_object_tasks table:
+  op.add_column('cycle_task_group_object_tasks',
+                sa.Column('contact_id', sa.Integer(), nullable=True))
+  op.add_column('cycle_task_group_object_tasks',
+                sa.Column('secondary_contact_id', sa.Integer(), nullable=True))
+  op.create_foreign_key("cycle_task_group_object_tasks_ibfk_1",
+                        "cycle_task_group_object_tasks",
+                        "people", ["contact_id"], ["id"])
+  op.create_index('fk_cycle_task_group_object_tasks_contact',
+                  'cycle_task_group_object_tasks', ['contact_id'],
+                  unique=False)
+  op.create_index('fk_cycle_task_group_object_tasks_secondary_contact',
+                  'cycle_task_group_object_tasks', ['secondary_contact_id'],
+                  unique=False)


### PR DESCRIPTION
~~On hold, till #6587 is deployed on prod.~~

# Issue description
Need to remove obsolete contact columns from tasks' and cycle tasks' tables.

This is just a migration needed to remove obsolete columns contact_id and secondary_contact_id from tasks and cycle tasks tables. Because these fields are already removed from the models previously and the columns in the database were left for data backup.

# Steps to test the changes
1. Go to the database
2. describe task_group_tasks;/ describe cycle_task_group_object_tasks;
3. check these tables don't have 'contact_id' and 'secondary_contact_id' columns

# Solution description
Solution: columns should be removed with a migration.
For downgrade - should recover the columns and all related indexes and constraints. There is no need to recover data from the ICL in this migration since we have a two step process for introducing such changes for security reasons. And the second step (like this one, removing obsolete columns) is done only when everything already works on prod.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] db_reset runs without errors or warnings.
- [ ] db_reset ggrc-qa.sql runs without errors or warnings.
-->

# PR Review checklist

- [x] Check the #6587 is deployed on prod
- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
