### PR TITLE
GGRC-3581 'Need verification' field is editable if workflow is Inactive

### DIFF
--- a/src/ggrc_workflows/models/workflow.py
+++ b/src/ggrc_workflows/models/workflow.py
@@ -225,16 +225,16 @@ class Workflow(mixins.CustomAttributable, HasOwnContext, mixins.Timeboxed,
     """Validate is_verification_needed field for Workflow.
 
     It's not allowed to change is_verification_needed flag after creation.
-    If is_verification_needed doesn't send,
-    then is_verification_needed flag is True.
+    If is_verification_needed flag not sent, it is set to True.
     """
     if self.is_verification_needed is None:
       return self.IS_VERIFICATION_NEEDED_DEFAULT if value is None else value
     if value is None:
       return self.is_verification_needed
-    if self.status != self.DRAFT and value != self.is_verification_needed:
-      raise ValueError("is_verification_needed value isn't changeble "
-                       "on workflow with '{}' status".format(self.status))
+    # ever after creation changing of this flag is prohibited
+    if value != self.is_verification_needed:
+      raise ValueError("is_verification_needed value isn't changeable "
+                       "on a workflow with '{}' status".format(self.status))
     return value
 
   @builder.simple_property

--- a/test/integration/ggrc_workflows/models/test_workflow.py
+++ b/test/integration/ggrc_workflows/models/test_workflow.py
@@ -242,13 +242,18 @@ class TestWorkflow(TestCase):
       self.assertEqual(all_models.Workflow.INACTIVE, workflow.status)
 
   @ddt.data(
-      ('One time workflow', None, None),
-      ('Daily workflow', all_models.Workflow.DAY_UNIT, 1),
-      ('Weekly workflow', all_models.Workflow.WEEK_UNIT, 1),
-      ('Monthly workflow', all_models.Workflow.MONTH_UNIT, 1),
+      ('One time workflow', None, None, True),
+      ('Daily workflow', all_models.Workflow.DAY_UNIT, 1, True),
+      ('Weekly workflow', all_models.Workflow.WEEK_UNIT, 1, True),
+      ('Monthly workflow', all_models.Workflow.MONTH_UNIT, 1, True),
+      ('One time workflow', None, None, False),
+      ('Daily workflow', all_models.Workflow.DAY_UNIT, 1, False),
+      ('Weekly workflow', all_models.Workflow.WEEK_UNIT, 1, False),
+      ('Monthly workflow', all_models.Workflow.MONTH_UNIT, 1, False),
   )
   @ddt.unpack  # pylint: disable=invalid-name
-  def test_change_verification_flag_positive(self, title, unit, repeat_every):
+  def test_change_verification_flag_negative(self, title, unit,
+                                             repeat_every, activate):
     with freezegun.freeze_time("2017-08-10"):
       with glob_factories.single_commit():
         workflow = factories.WorkflowFactory(title=title, unit=unit,
@@ -261,38 +266,8 @@ class TestWorkflow(TestCase):
             start_date=datetime.date(2017, 8, 3),
             end_date=datetime.date(2017, 8, 7))
       wf_id = workflow.id
-      workflow = all_models.Workflow.query.get(wf_id)
-      verif_default = all_models.Workflow.IS_VERIFICATION_NEEDED_DEFAULT
-      self.assertIs(workflow.is_verification_needed, verif_default)
-      self.generator.modify_object(
-          workflow,
-          {
-              'is_verification_needed': not verif_default
-          })
-      workflow = all_models.Workflow.query.get(wf_id)
-      self.assertIs(workflow.is_verification_needed, not verif_default)
-
-  @ddt.data(
-      ('One time workflow', None, None),
-      ('Daily workflow', all_models.Workflow.DAY_UNIT, 1),
-      ('Weekly workflow', all_models.Workflow.WEEK_UNIT, 1),
-      ('Monthly workflow', all_models.Workflow.MONTH_UNIT, 1),
-  )
-  @ddt.unpack  # pylint: disable=invalid-name
-  def test_change_verification_flag_negative(self, title, unit, repeat_every):
-    with freezegun.freeze_time("2017-08-10"):
-      with glob_factories.single_commit():
-        workflow = factories.WorkflowFactory(title=title, unit=unit,
-                                             repeat_every=repeat_every)
-        factories.TaskGroupTaskFactory(
-            task_group=factories.TaskGroupFactory(
-                workflow=workflow,
-                context=glob_factories.ContextFactory()
-            ),
-            start_date=datetime.date(2017, 8, 3),
-            end_date=datetime.date(2017, 8, 7))
-      wf_id = workflow.id
-      self.generator.activate_workflow(workflow)
+      if activate:
+        self.generator.activate_workflow(workflow)
       workflow = all_models.Workflow.query.get(wf_id)
       verif_default = all_models.Workflow.IS_VERIFICATION_NEEDED_DEFAULT
       self.assertIs(workflow.is_verification_needed, verif_default)

--- a/test/integration/ggrc_workflows/test_api_calls.py
+++ b/test/integration/ggrc_workflows/test_api_calls.py
@@ -225,14 +225,14 @@ class TestWorkflowsApiPost(TestCase):
 
   @ddt.data(True, False)
   def test_change_verification_flag_positive(self, flag):  # noqa pylint: disable=invalid-name
-    """is_verification_needed flag is changeable for DRAFT workflow."""
+    """is_verification_needed flag is not changeable for DRAFT workflow."""
     with factories.single_commit():
       workflow = wf_factories.WorkflowFactory(is_verification_needed=flag)
     self.assertEqual(workflow.status, all_models.Workflow.DRAFT)
     workflow_id = workflow.id
     resp = self.api.put(workflow, {"is_verification_needed": not flag})
-    self.assert200(resp)
-    self.assertEqual(
+    self.assert400(resp)
+    self.assertNotEqual(
         all_models.Workflow.query.get(workflow_id).is_verification_needed,
         not flag)
 


### PR DESCRIPTION
# Issue description

"need verification for tasks" flag could be set only once - on creation of a new workflow. But now it's editable to the not started workflow.

# Steps to test the changes

Steps to reproduce:
1. Create monthly workflow, 'need verification for tasks' set to "true"
2. On the workflow info page add task in the setup tab
3. Activate the workflow
4. At the Active Cycles tab finish and verify the task
5. On the workflow info page invoke Edit workflow modal window
6. Edit 'need verification for tasks' field
7. Click save and close button
Expected: An error should be shown

# Solution description

Fix the validator for the is_verification_needed field

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] db_reset runs without errors or warnings.
- [ ] db_reset ggrc-qa.sql runs without errors or warnings.
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
