### PR TITLE
GGRC-3641 Fix issue when unified mapper is not shown up while adding a new tab after pressing ESC

### DIFF
--- a/src/ggrc/assets/javascripts/components/object-mapper/object-mapper.js
+++ b/src/ggrc/assets/javascripts/components/object-mapper/object-mapper.js
@@ -149,7 +149,6 @@
       },
       '{window} modal:dismiss': function (el, ev, options) {
         var joinObjectId = this.viewModel.attr('join_object_id');
-        $('body').trigger('closeMapper');
 
         // mapper sets uniqueId for modal-ajax.
         // we can check using unique id which modal-ajax is closing
@@ -181,7 +180,6 @@
         self.viewModel.attr('submitCbs').fire();
       },
       closeModal: function () {
-        $('body').trigger('closeMapper');
         this.viewModel.attr('is_saving', false);
 
         // TODO: Find proper way to dismiss the modal


### PR DESCRIPTION
# Issue description

Unified Mapper is not shown up by default while adding a new tab after closing unified mapper by pressing ESC for Assessment object. The same behavior if open unified mapper by clicking on Map button.
Issue is reproducible only for snapshots. 

# Steps to test the changes

1. Have an audit with created assessment
2. Go to the assessment page
3. Click Add Tab > Controls or Map button
4. Once Unified Mapper appears press ESC on the keyboard and close Controls tab
5. Click Add tab > Objectives  or Map button
6. Look at the screen: Unified mapper is not shown up

**Actual Result:** Unified Mapper is not shown up by default while adding a new tab after click ESC
**Expected Result:** Unified Mapper should be not shown up by default while adding a new tab after click ESC

# Solution description

This is regression issue after #6328 changes. 
'modal:dismiss' event is not triggered after pressing ESC If focus is not set to modal so 'closeMapper' event which set isMapperOpen prop to false also is not triggered. In this case modal is not opened anymore.
There are several options to fix it. 
First, subscribe on modal 'hidden.bs.modal' event and trigger 'closeMapper'. 
Second, #6328 PR fixes duplicating unified mapper windows if click several times on Map button. This issue is reproducible only for snapshots as there is updateScopeObject ajax request happens before opening the modal. This issue can be fixed if prevent opening new modal while ajax request is not finished.
It localizes logic in one file and prevents other regression issues.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] db_reset runs without errors or warnings.
- [ ] db_reset ggrc-qa.sql runs without errors or warnings.
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
