### PR TITLE
QUICK-FIX Update docker selenium environment (chrome 62, chromedriver 2.33)

### DIFF
--- a/Dockerfile-selenium
+++ b/Dockerfile-selenium
@@ -2,7 +2,7 @@
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
 
-FROM selenium/standalone-chrome:3.5.3
+FROM selenium/standalone-chrome:3.6.0
 
 USER root
 COPY ./provision/docker/selenium.bashrc.j2 /root/.bashrc

--- a/docker-compose-testing.yml
+++ b/docker-compose-testing.yml
@@ -5,7 +5,7 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        CHROME_DRIVER_VERSION: "2.32"
+        CHROME_DRIVER_VERSION: "2.33"
     volumes:
      - ".:/vagrant"
      - ".:/vagrant_bind"


### PR DESCRIPTION
# PR's description

Update bundle chrome - chromedriver to latest stable version for docker environment:
- chrome 62.0.3202.62;
- chromedriver 2.33.506092

# Steps to test the changes

Run test suite with at least 5 times runs for each particular test.

# Solution description

We should have last stable version of chrome to run selenium tests.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] db_reset runs without errors or warnings.
- [ ] db_reset ggrc-qa.sql runs without errors or warnings.
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
