### PR TITLE
GGRC-3335 RMC - Workflow 2.0 Testing - UX - Task group expansion

### DIFF
--- a/src/ggrc/assets/javascripts/components/tree/templates/sub-tree-item.mustache
+++ b/src/ggrc/assets/javascripts/components/tree/templates/sub-tree-item.mustache
@@ -6,12 +6,12 @@
 <div class="flex-box sub-item-content {{cssClasses}}">
   <tree-item-actions {instance}="instance"
                      (expand)="onExpand()"
-                     (preview)="onPreview(%event)"
+                     (preview)="select($element)"
                      {expanded}="expanded"
                      {child-models-list}="childModelsList"
                      {deep-limit}="limitDepthTree"
   ></tree-item-actions>
-  <div class="flex-box columns" ($click)="select($element)">
+  <div class="flex-box columns" ($click)="onClick($element)">
     <span class="title">
       <i class="fa fa-{{instance.class.table_singular}}"></i>
       {{title}}

--- a/src/ggrc/assets/javascripts/components/tree/templates/tree-item-actions.mustache
+++ b/src/ggrc/assets/javascripts/components/tree/templates/tree-item-actions.mustache
@@ -11,76 +11,82 @@
     </a>
     <ul>
       <lazy-render trigger="activated">
-      <!---->
-      {{#if instance.viewLink}}
         <!-- Link for open instance on info panel at bottom -->
-          <li>
-            <a href="javascript://" ($click)="maximizeObject">
-              <i class="fa fa-info-circle"></i>
-              View Info
-            </a>
-          </li>
-          {{#unless isSnapshot}}
-            <!-- Link for open instance on new Browser tab -->
-            <li>
-              <a href="{{instance.viewLink}}" target="_blank" ($click)="openObject">
-                <i class="fa fa-long-arrow-right"></i>
-                Open in a new tab
-              </a>
-            </li>
-          {{/unless}}
-      {{/if}}
-
-
-      {{#if isAllowedToMap}}
         <li>
-          <tree-item-map {instance}="instance"></tree-item-map>
-        </li>
-      {{/if}}
-      {{#if isAllowedToEdit}}
-        {{#is_allowed 'update' instance context='for'}}
-          <li>
-            <a href="javascript://"
-              data-link-purpose="open-edit-modal"
-              data-toggle="modal-ajax-form"
-              data-modal-reset="reset"
-              data-modal-class="modal-wide"
-              data-object-singular="{{instance.class.model_singular}}"
-              data-object-plural="{{instance.class.table_plural}}"
-              data-object-id="{{instance.id}}">
-              <i class="fa fa-pencil-square-o"></i>
-              Edit object
-            </a>
-          </li>
-        {{/is_allowed}}
-      {{/if}}
-
-      <li>
-        <show-related-assessments-button {instance}="instance"
-                                        {reset-styles}="true"
-                                        {show-title}="false"
-                                        {show-icon}="true"
-                                        text="Show related assessments"
-        ></show-related-assessments-button>
-      </li>
-
-      <li class="splitter"></li>
-
-      {{#unless isSnapshot}}
-        {{#if canExpand}}
-          <li>
-            <sub-tree-models {models-list}="childModelsList"
-                            {title}="instance.title"
-            ></sub-tree-models>
-          </li>
-        <li>
-          <a href="javascript://" ($click)="expand">
-            <i class="fa fa-{{expandIcon}}"></i>
-            {{expanderTitle}}
+          <a href="javascript://" ($click)="maximizeObject">
+            <i class="fa fa-info-circle"></i>
+            View Info
           </a>
         </li>
+
+        {{^if showReducedOptions}}
+
+          {{#if instance.viewLink}}
+            {{#unless isSnapshot}}
+              <!-- Link for open instance on new Browser tab -->
+              <li>
+                <a href="{{instance.viewLink}}" target="_blank" ($click)="openObject">
+                  <i class="fa fa-long-arrow-right"></i>
+                  Open in a new tab
+                </a>
+              </li>
+            {{/unless}}
+          {{/if}}
+
+          {{#if isAllowedToMap}}
+            <li>
+              <tree-item-map {instance}="instance"></tree-item-map>
+            </li>
+          {{/if}}
+
+          {{#if isAllowedToEdit}}
+            {{#is_allowed 'update' instance context='for'}}
+              <li>
+                <a href="javascript://"
+                  data-link-purpose="open-edit-modal"
+                  data-toggle="modal-ajax-form"
+                  data-modal-reset="reset"
+                  data-modal-class="modal-wide"
+                  data-object-singular="{{instance.class.model_singular}}"
+                  data-object-plural="{{instance.class.table_plural}}"
+                  data-object-id="{{instance.id}}">
+                  <i class="fa fa-pencil-square-o"></i>
+                  Edit object
+                </a>
+              </li>
+            {{/is_allowed}}
+          {{/if}}
+
+          <li>
+            <show-related-assessments-button
+              {instance}="instance"
+              {reset-styles}="true"
+              {show-title}="false"
+              {show-icon}="true"
+              text="Show related assessments">
+            </show-related-assessments-button>
+          </li>
+
+          <li class="splitter"></li>
+
+          {{#unless isSnapshot}}
+            {{#if canExpand}}
+              <li>
+                <sub-tree-models
+                  {models-list}="childModelsList"
+                  {title}="instance.title">
+                </sub-tree-models>
+              </li>
+            <li>
+              <a href="javascript://" ($click)="expand">
+                <i class="fa fa-{{expandIcon}}"></i>
+                {{expanderTitle}}
+              </a>
+            </li>
+            {{/if}}
+          {{/unless}}
+
         {{/if}}
-      {{/unless}}
       </lazy-render>
     </ul>
   </div>

--- a/src/ggrc/assets/javascripts/components/tree/templates/tree-item.mustache
+++ b/src/ggrc/assets/javascripts/components/tree/templates/tree-item.mustache
@@ -7,12 +7,12 @@
   <div class="flex-box tree-item-content">
     <tree-item-actions {instance}="instance"
                        (expand)="onExpand()"
-                       (preview)="onPreview(%event)"
+                       (preview)="select($element)"
                        {expanded}="expanded"
                        {child-models-list}="childModelsList"
                        {deep-limit}="limitDepthTree"
     ></tree-item-actions>
-    <div class="flex-box selectable-attrs width-100" ($click)="select($element)">
+    <div class="flex-box selectable-attrs width-100" ($click)="onClick($element)">
         {{#selectedColumns}}
           {{! add alias because "this" is changed inside the switch-case block}}
           {{#add_to_current_scope thisColumn=this}}

--- a/src/ggrc/assets/javascripts/components/tree/tree-item-actions.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-item-actions.js
@@ -97,6 +97,15 @@ import template from './templates/tree-item-actions.mustache';
       ];
       return _.contains(pages, GGRC.Utils.CurrentPage.getPageType()) &&
         _.contains(instanceTypes, this.attr('instance').type);
+    },
+    showReducedOptions: function () {
+      var pages = ['Workflow'];
+      var instanceTypes = [
+        'Cycle',
+        'CycleTaskGroup',
+      ];
+      return _.contains(pages, GGRC.Utils.CurrentPage.getPageType()) &&
+        _.contains(instanceTypes, this.attr('instance').type);
     }
   });
 

--- a/src/ggrc/assets/javascripts/components/view-models/tree-item-base-vm.js
+++ b/src/ggrc/assets/javascripts/components/view-models/tree-item-base-vm.js
@@ -58,8 +58,28 @@
         this.attr('expanded', !isExpanded);
       }
     },
-    onPreview: function (event) {
-      this.select(event.element);
+    onClick: function ($element) {
+      var instance = this.attr('instance');
+
+      switch (instance.attr('type')) {
+        case 'Person':
+          if (!this.attr('result')) {
+            this.attr('resultDfd').then(()=> {
+              this.select($element);
+            });
+            return;
+          }
+          break;
+        case 'Cycle':
+        case 'CycleTaskGroup':
+          if (GGRC.Utils.CurrentPage.getPageType() === 'Workflow') {
+            this.attr('expanded', !this.attr('expanded'));
+            return;
+          }
+          break;
+      }
+
+      this.select($element);
     },
     select: function ($element) {
       var instance = this.attr('instance');
@@ -67,14 +87,7 @@
 
       $element = $element.closest(itemSelector);
 
-      if (instance instanceof CMS.Models.Person && !this.attr('result')) {
-        // for Person instances we need to build ResultMapping object before open the info panel
-        this.attr('resultDfd').then(function () {
-          can.trigger($element, 'selectTreeItem', [$element, instance]);
-        });
-      } else {
-        can.trigger($element, 'selectTreeItem', [$element, instance]);
-      }
+      can.trigger($element, 'selectTreeItem', [$element, instance]);
     },
   });
 })(window.can, window.GGRC);


### PR DESCRIPTION
# Issue description
What is the expected result / outcome? (ie What should happen?)
When user click on the row, task list expand
when user hover over to the little "triangle button, a list populated for user to choose to "review task group detail".

- Cycle 1st level - on click on row - expand second level
- Cycle 1st level - menu - remove Filter and Expand on 1st level; add "View info" - to open info panel
- Task Group 2d level - on click on row - expand third level
- Task Group 2d level - menu - remove Filter and Expand on 1st level; add "View info" - to open info panel
- Task 3d level - leave as is - on click on row - open info panel

# Solution description

- Modify tree item actions to display only "view info" for cycles and groups on workflow page.
- Modify tree item base vm to show info-pane when click for cycles and groups on workflow page.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] db_reset runs without errors or warnings.
- [ ] db_reset ggrc-qa.sql runs without errors or warnings.
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
