### PR TITLE
GGRC-3556 BE updates 'updated_at' field when there were no changes

### DIFF
--- a/src/ggrc/assets/javascripts/plugins/utils/current-page-utils.js
+++ b/src/ggrc/assets/javascripts/plugins/utils/current-page-utils.js
@@ -259,7 +259,7 @@
     function _getCurrentUser() {
       let userId = GGRC.current_user.id;
 
-      return  CMS.Models.Person.store[userId];
+      return  CMS.Models.Person.findInCacheById(userId);
     }
 
     return {

--- a/src/ggrc/models/mixins/__init__.py
+++ b/src/ggrc/models/mixins/__init__.py
@@ -140,6 +140,7 @@ class ChangeTracked(object):
         'Person',
         primaryjoin='{0}.modified_by_id == Person.id'.format(cls.__name__),
         foreign_keys='{0}.modified_by_id'.format(cls.__name__),
+        remote_side='Person.id',
         uselist=False,
     )
 


### PR DESCRIPTION
# Issue description
modified_by_id field is updated not for a newly created person but for a creator. updated_at field is updated automatically when object is set or modified: `onupdate=db.text('current_timestamp')`

# Steps to test the changes

1. Create a person
2. Check modified_by_id of a newly created person
Result: it is None
Expected result: it is equal to  creator id
3. Check creator modified_by_id
Result: it is equal to a newly created person id
Expected result: 
It is not changed

# Solution description

For some unknown reason 
`obj.modified_by = get_current_user()`
updates current user field instead of obj field if obj is instance of Person. It looks like a bug in SQLAlchemy.
The statement is replaced by `obj.modified_by_id = get_current_user_id()` to change modified_by_id field without invoking SQLAlchemy relationships processing.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

