### PR TITLE
GGRC-3693/3695 Fix js error when open dropdown tasks in tree view

### DIFF
--- a/src/ggrc_workflows/assets/javascripts/components/cycle-task-group-object-task/templates/cycle-task-group-object-task.mustache
+++ b/src/ggrc_workflows/assets/javascripts/components/cycle-task-group-object-task/templates/cycle-task-group-object-task.mustache
@@ -142,7 +142,7 @@
                 {{! here we need to start a quick form or other component}}
                 <ggrc-quick-update instance="instance">
                   <dropdown
-                    name="selected_response_options.0"
+                    name="instance.selected_response_options.0"
                     class-name="noop" {{! to not use default from component}}
                     is-disabled="{{#if instance.responseOptionsEditable}}false{{else}}true{{/if}}"
                     options-list="instance.response_options"></dropdown>


### PR DESCRIPTION
# Issue description

"Uncaught TypeError: Cannot read property '0' of undefined" error occurs if click dropdown Cycle Task in tree view or select 'dropdown' task type in Cycle task modal window

# Steps to test the changes

Case 1:
1. Go to My work page > Tasks tab
2. Click dropdown Cycle task in tree view

**Actual Result:** "Uncaught TypeError: Cannot read property '0' of undefined" error occurs if click dropdown Cycle Task in tree view
**Expected Result:** no errors should be shown while clicking first tier in tree view in Tasks tab

Case 2:
1. Go to My work page > My tasks tab
2. Invoke Edit Task modal window for any Cycle Task
3. Change task type from rich text or checkbox to dropdown
4. Look at the screen: "Uncaught TypeError: Cannot read property '0' of undefined" error occurs

**Actual Result:** "Uncaught TypeError: Cannot read property '0' of undefined" error occurs if select 'dropdown' task type in Cycle task modal window
**Expected Result:** no errors are shown in Cycle task modal window while changing a task type

# Solution description

This is regression issue after refactoring in #6522 PR

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
No changes in logic
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] db_reset runs without errors or warnings.
- [ ] db_reset ggrc-qa.sql runs without errors or warnings.
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
