### PR TITLE
GGRC-3643 Disable 3 bb's menu button in tab with snapshot on the assessment Info page if there is no object in tree view

### DIFF
--- a/src/ggrc/assets/javascripts/components/tree/templates/tree-widget-container.mustache
+++ b/src/ggrc/assets/javascripts/components/tree/templates/tree-widget-container.mustache
@@ -45,7 +45,7 @@
       {{/if}}
       {{#if show3bbs}}
       <div class="details-wrap">
-        <a class="btn btn-3bbps dropdown-toggle" href="#" data-toggle="dropdown">
+        <a class="btn {{#if disable3bbs}}disabled{{/if}} btn-3bbps dropdown-toggle" href="#" data-toggle="dropdown">
           <span class="bubble"></span>
           <span class="bubble"></span>
           <span class="bubble"></span>

--- a/src/ggrc/assets/javascripts/components/tree/tree-widget-container.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-widget-container.js
@@ -206,6 +206,12 @@ import template from './templates/tree-widget-container.mustache';
           return !CurrentPageUtils.isMyAssessments();
         },
       },
+      disable3bbs: {
+        type: Boolean,
+        get: function () {
+          return this.attr('isSnapshots') && !this.attr('showedItems').length;
+        },
+      },
       noResults: {
         type: Boolean,
         get: function () {


### PR DESCRIPTION
# Issue description

The 3bbs button will disable in snapshot with no length.

# Steps to test the changes

1. Have assessment with mapped snapshot
2. On the assessment info page click Add tab > e.g. Objectives
3. Once Unified mapper is displayed close it
4. Click 3 bb''s menu: empty dropdown is shown screenshot-1.png
Actual Result: 3 bb's menu button is not disabled in tab with snapshot on the assessment Info page if there is no object in tree view
Expected Result: Disable 3 bb's menu button in tab with snapshot on the assessment Info page if there is no object in tree view

# Solution description

Add disabled class to button if it's a snapshot and tab have no items.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".