### PR TITLE
GGRC-3694 Pagination controls are not function in Global Search/Unified Mapper

### DIFF
--- a/src/ggrc/assets/javascripts/components/base-objects/pagination.js
+++ b/src/ggrc/assets/javascripts/components/base-objects/pagination.js
@@ -28,12 +28,12 @@
         type: 'number',
         value: 5,
         set: function (newValue) {
-          if (!this.attr('disabled')) {
+          if (!this.attr('disabled') && newValue != this.pageSize) {
             this.attr('current', 1);
             return newValue;
           }
           return this.pageSize;
-        }
+        },
       },
       pageSizeSelect: {
         value: [5, 10, 15]

--- a/src/ggrc/assets/javascripts/components/base-objects/tests/pagination_spec.js
+++ b/src/ggrc/assets/javascripts/components/base-objects/tests/pagination_spec.js
@@ -69,6 +69,15 @@ describe('GGRC.VM.Pagination', function () {
       result = paginationViewModel.attr('current');
       expect(result).toEqual(1);
     });
+    it('does not update current page when pageSize does not changed',
+    function () {
+      var result;
+      paginationViewModel.attr('count', 3);
+      paginationViewModel.attr('current', 2);
+      paginationViewModel.attr('pageSize', 5); // set the same pageSize value
+      result = paginationViewModel.attr('current');
+      expect(result).toEqual(2);
+    });
   });
   describe('limits property', function () {
     beforeEach(function () {


### PR DESCRIPTION
# Issue description

Pagination controls are not function in Global Search/Unified Mapper

# Steps to test the changes

Steps to reproduce:
1. Open Global Search
2. Click Search
3. Click '>' or '>>': is not working
**Actual Result:** Pagination controls are not function in Global Search/Unified Mapper
**Expected Result:** Pagination controls should be function in Global Search/Unified Mapper

# Solution description

Looks like it's regression issue after #6559 PR. CanJs select sets pageSize after re rendering.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] db_reset runs without errors or warnings.
- [ ] db_reset ggrc-qa.sql runs without errors or warnings.
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
