### PR TITLE
QUICK-FIX Remove excess import in inline-autocomplete-wrapper.js

### DIFF
--- a/src/ggrc/assets/javascripts/components/external-data-autocomplete/inline-autocomplete-wrapper.js
+++ b/src/ggrc/assets/javascripts/components/external-data-autocomplete/inline-autocomplete-wrapper.js
@@ -3,8 +3,6 @@
  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  */
 
-import './external-data-autocomplete';
-
 /**
  * The component is used to integrate separate autocomplete component
  * with some old pards of code which are working with autocomplete plugin


### PR DESCRIPTION
# Issue description

**Just a cosmetic change**
The import operation is excess here, because `external-data-autocomplete` has been imported in `src/ggrc/assets/javascripts/entrypoints/dashboard/index.js` file.

# Steps to test the changes

There is no way to test - it's just a cosmetic change.

# Solution description

The import left here by mistake during development.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] db_reset runs without errors or warnings.
- [ ] db_reset ggrc-qa.sql runs without errors or warnings.
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
