### PR TITLE
GGRC-3736 Status propagation over task tree

### DIFF
--- a/src/ggrc_workflows/models/cycle_task_group_object_task.py
+++ b/src/ggrc_workflows/models/cycle_task_group_object_task.py
@@ -333,9 +333,7 @@ class CycleTaskGroupObjectTask(roleable.Roleable,
           [{"status": "Assigned", "id": 1}, {"status": "InProgress", "id": 2}]
 
     Returns:
-        Two lists: updated_ids, skipped_ids.
-        First one contains object's ids that were updated successfully.
-        Second one contains object's ids that were skipped.
+        list of updated_instances
     """
     new_prv_state_map = {
         cls.DEPRECATED: (cls.ASSIGNED, cls.IN_PROGRESS, cls.FINISHED,
@@ -371,8 +369,7 @@ class CycleTaskGroupObjectTask(roleable.Roleable,
     for obj in updatable_objects:
       obj.status = new_state
       obj.modified_by_id = login.get_current_user_id()
-    updated_ids = {obj.id for obj in updatable_objects}
-    return list(updated_ids), list(all_ids - updated_ids)
+    return updatable_objects
 
 
 class CycleTaskable(object):

--- a/src/ggrc_workflows/services/resource.py
+++ b/src/ggrc_workflows/services/resource.py
@@ -4,14 +4,37 @@
 """Workflow specific Resources implementation."""
 
 import datetime
+
+import sqlalchemy as sa
 from flask import current_app
 from ggrc import db
 from ggrc import utils
 from ggrc.services.common import Resource
+import ggrc_workflows
 
 
 class CycleTaskResource(Resource):
   """Contains CycleTask's specific Resource implementation."""
+
+  def propagate_status(self, updated_objects):
+    """Propagate task status to upper tree instances."""
+    if not updated_objects:
+      return
+    signal_context = []
+    for instance in updated_objects:
+      status_history = sa.inspect(instance).attrs["status"].history
+      old_status = status_history.deleted[0]
+      new_status = status_history.added[0]
+      context_element = ggrc_workflows.Signals.StatusChangeSignalObjectContext(
+          instance=instance,
+          new_status=new_status,
+          old_status=old_status
+      )
+      signal_context.append(context_element)
+    ggrc_workflows.Signals.status_change.send(self.model,
+                                              objs=signal_context)
+    ggrc_workflows.update_cycle_task_object_task_parent_state(
+        updated_objects, is_put=True)
 
   def patch(self):
     """PATCH operation handler."""
@@ -20,10 +43,15 @@ class CycleTaskResource(Resource):
       return current_app.make_response(
           ('Content-Type must be application/json', 415, []))
     with utils.benchmark("Do bulk update"):
-      updated_ids, skipped_ids = self.model.bulk_update(src)
+      updated_objects = self.model.bulk_update(src)
+    with utils.benchmark("Status propagation on bulk update"):
+      self.propagate_status(updated_objects)
     with utils.benchmark("Commit"):
       db.session.commit()
     with utils.benchmark("Make response"):
+      updated_ids = {u.id for u in updated_objects}
+      skipped_ids = {int(item['id']) for item in src
+                     if int(item["id"]) not in updated_ids}
       result = [{'status': 'updated', 'id': idx} for idx in updated_ids]
       result.extend([{'status': 'skipped', 'id': idx} for idx in skipped_ids])
       return self.json_success_response(result, datetime.datetime.now())

--- a/test/integration/ggrc_workflows/test_api_calls.py
+++ b/test/integration/ggrc_workflows/test_api_calls.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2017 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
+"""Tests for api calls on ggrc_workflows module."""
+
 import datetime
 import unittest
 from mock import MagicMock
@@ -20,8 +22,9 @@ from integration.ggrc_workflows import WorkflowTestCase
 from integration.ggrc_workflows.models import factories as wf_factories
 
 
-@ddt.ddt
+@ddt.ddt  # pylint: disable=too-many-public-methods
 class TestWorkflowsApiPost(TestCase):
+  """Test class for ggrc workflow api post action."""
 
   def setUp(self):
     super(TestWorkflowsApiPost, self).setUp()
@@ -32,6 +35,7 @@ class TestWorkflowsApiPost(TestCase):
     pass
 
   def test_send_invalid_data(self):
+    """Test send invalid data on Workflow post."""
     data = self.get_workflow_dict()
     del data["workflow"]["title"]
     del data["workflow"]["context"]
@@ -40,6 +44,7 @@ class TestWorkflowsApiPost(TestCase):
     # TODO: check why response.json["message"] is empty
 
   def test_create_one_time_workflows(self):
+    """Test simple create one time Workflow over api."""
     data = self.get_workflow_dict()
     response = self.api.post(all_models.Workflow, data)
     self.assertEqual(response.status_code, 201)
@@ -82,6 +87,7 @@ class TestWorkflowsApiPost(TestCase):
     self.assertEqual(response.status_code, 400)
 
   def test_create_task_group(self):
+    """Test create task group over api."""
     wf_data = self.get_workflow_dict()
     wf_data["workflow"]["title"] = "Create_task_group"
     wf_response = self.api.post(all_models.Workflow, wf_data)
@@ -94,13 +100,14 @@ class TestWorkflowsApiPost(TestCase):
   # TODO: Api should be able to handle invalid data
   @unittest.skip("Not implemented.")
   def test_create_task_group_invalid_workflow_data(self):  # noqa pylint: disable=invalid-name
+    """Test create task group with invalid data."""
     data = self.get_task_group_dict({"id": -1, "context": {"id": -1}})
     response = self.api.post(all_models.TaskGroup, data)
     self.assert400(response)
 
   @staticmethod
   def get_workflow_dict():
-    data = {
+    return {
         "workflow": {
             "custom_attribute_definitions": [],
             "custom_attributes": {},
@@ -116,11 +123,10 @@ class TestWorkflowsApiPost(TestCase):
             "context": None,
         }
     }
-    return data
 
   @staticmethod
   def get_task_group_dict(workflow):
-    data = {
+    return {
         "task_group": {
             "custom_attribute_definitions": [],
             "custom_attributes": {},
@@ -145,14 +151,12 @@ class TestWorkflowsApiPost(TestCase):
             "description": "",
         }
     }
-    return data
 
   @ddt.data({},
             {"repeat_every": 5,
              "unit": "month"})
   def test_repeat_multiplier_field(self, data):
-    """Check repeat_multiplier is set to 0 after wf creation.
-    """
+    """Check repeat_multiplier is set to 0 after wf creation."""
     with factories.single_commit():
       workflow = wf_factories.WorkflowFactory(**data)
     workflow_id = workflow.id


### PR DESCRIPTION

# Issue description

It's required to have status propagation to cycle task instances upper in cycle tree. Workflow of that procedure should be the same as propagation for single task instances.  

# Steps to test the changes

Update cycle task instances status over bulk update/patch and check if propagation works correctly for each possible cases of combination cycle task statuses and workflow is_verification_needed flags. 

# Solution description

1) send status_change signal on bulk_update action 
2) update cycle task parent state if all works correctly 
3) move cycle to history if it's done 
4) move workflow inactive if all cycles moved to history  

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/git/how_to_write_a_commit_message.rst).
- [x] depends on https://github.com/google/ggrc-core/pull/6672.

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] db_reset runs without errors or warnings.
- [ ] db_reset ggrc-qa.sql runs without errors or warnings.
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->