### PR TITLE
GGRC-3463: FE-Bulk Task Update on My Tasks page

### DIFF
--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -108,6 +108,7 @@ dashboard-js-template-files:
   - issues/remediation_plan.mustache
   - issues/tree_add_item.mustache
   - components/autocomplete/autocomplete.mustache
+  - components/bulk-update-button/bulk-update-button.mustache
   - components/object-mapper/object-mapper.mustache
   - components/object-generator/object-generator.mustache
   - components/object-search/object-search.mustache

--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -109,6 +109,7 @@ dashboard-js-template-files:
   - issues/tree_add_item.mustache
   - components/autocomplete/autocomplete.mustache
   - components/bulk-update-button/bulk-update-button.mustache
+  - components/object-bulk-update/object-bulk-update.mustache
   - components/object-mapper/object-mapper.mustache
   - components/object-generator/object-generator.mustache
   - components/object-search/object-search.mustache
@@ -200,6 +201,7 @@ dashboard-js-template-files:
   - modals/save_cancel_buttons.mustache
   - modals/save_cancel_delete_buttons.mustache
   - modals/unmap_cancel_buttons.mustache
+  - modals/mapper/object-bulk-update-modal.mustache
   - modals/mapper/object-mapper-modal.mustache
   - modals/mapper/object-generator-modal.mustache
   - modals/mapper/object-search-modal.mustache

--- a/src/ggrc/assets/assets.yaml
+++ b/src/ggrc/assets/assets.yaml
@@ -110,6 +110,7 @@ dashboard-js-template-files:
   - components/autocomplete/autocomplete.mustache
   - components/bulk-update-button/bulk-update-button.mustache
   - components/object-bulk-update/object-bulk-update.mustache
+  - components/object-bulk-update/bulk-update-target-state.mustache
   - components/object-mapper/object-mapper.mustache
   - components/object-generator/object-generator.mustache
   - components/object-search/object-search.mustache

--- a/src/ggrc/assets/javascripts/components/bulk-update-button/bulk-update-button.js
+++ b/src/ggrc/assets/javascripts/components/bulk-update-button/bulk-update-button.js
@@ -10,5 +10,16 @@ export default can.Component.extend({
   tag: 'bulk-update-button',
   template: template,
   viewModel: {
+    model: null,
+  },
+  events: {
+    'a click': function (el) {
+      var model = this.viewModel.attr('model');
+      var type = model.model_singular;
+      GGRC.Controllers.ObjectBulkUpdate.launch(el, {
+        object: type,
+        type: type,
+      });
+    },
   },
 });

--- a/src/ggrc/assets/javascripts/components/bulk-update-button/bulk-update-button.js
+++ b/src/ggrc/assets/javascripts/components/bulk-update-button/bulk-update-button.js
@@ -1,0 +1,14 @@
+/*
+ Copyright (C) 2017 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+import template from
+  '../../../mustache/components/bulk-update-button/bulk-update-button.mustache';
+
+export default can.Component.extend({
+  tag: 'bulk-update-button',
+  template: template,
+  viewModel: {
+  },
+});

--- a/src/ggrc/assets/javascripts/components/bulk-update-button/bulk-update-button.js
+++ b/src/ggrc/assets/javascripts/components/bulk-update-button/bulk-update-button.js
@@ -5,6 +5,7 @@
 
 import template from
   '../../../mustache/components/bulk-update-button/bulk-update-button.mustache';
+import updateService from '../../plugins/utils/bulk-update-service';
 
 export default can.Component.extend({
   tag: 'bulk-update-button',
@@ -19,7 +20,43 @@ export default can.Component.extend({
       GGRC.Controllers.ObjectBulkUpdate.launch(el, {
         object: type,
         type: type,
+        callback: this.updateObjects.bind(this),
       });
+    },
+    updateObjects: function (context, args) {
+      var model = this.viewModel.attr('model');
+      var nameSingular = model.name_singular;
+      var progressMessage =
+        `${nameSingular} update is in progress. This may take several minutes.`;
+
+      context.closeModal();
+      GGRC.Errors.notifier('progress', progressMessage);
+      updateService.update(model, args.selected, args.options)
+        .then(function (res) {
+          var updated = _.filter(res, {status: 'updated'});
+          var updatedCount = updated.length;
+          var message = this.getResultNotification(model, updatedCount);
+
+          GGRC.Errors.notifier('info', message);
+
+          if (updatedCount > 0) {
+            can.trigger($('tree-widget-container'), 'refreshTree');
+          }
+        }.bind(this));
+    },
+    getResultNotification: function (model, updatedCount) {
+      var nameSingularLowerCase = model.name_singular.toLowerCase();
+      var namePlural = model.name_plural;
+      var namePluralLowerCase = namePlural.toLowerCase();
+
+      if (updatedCount === 0) {
+        return `No ${namePluralLowerCase} were updated.`;
+      }
+
+      return `${updatedCount} ` + (updatedCount === 1 ?
+        `${nameSingularLowerCase} was ` :
+        `${namePluralLowerCase} were `) +
+        'updated successfully.';
     },
   },
 });

--- a/src/ggrc/assets/javascripts/components/bulk-update-button/tests/bulk-update-button_spec.js
+++ b/src/ggrc/assets/javascripts/components/bulk-update-button/tests/bulk-update-button_spec.js
@@ -1,0 +1,154 @@
+/*
+  Copyright (C) 2017 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+import Component from '../bulk-update-button';
+import updateService from '../../../plugins/utils/bulk-update-service';
+
+describe('GGRC.Components.bulkUpdateButton', function () {
+  var viewModel;
+  var events;
+
+  beforeAll(function () {
+    viewModel = new (can.Map.extend(Component.prototype.viewModel));
+    events = Component.prototype.events;
+    events.viewModel = viewModel;
+  });
+
+  describe('button click event', function () {
+    var event;
+    beforeAll(function () {
+      event = events['a click'].bind(events);
+      spyOn(GGRC.Controllers.ObjectBulkUpdate, 'launch');
+    });
+
+    it('should launch ObjectBulkUpdate modal', function () {
+      var type = 'some model';
+      var element = {};
+      viewModel.attr('model', {
+        model_singular: type,
+      });
+
+      event(element);
+
+      expect(GGRC.Controllers.ObjectBulkUpdate.launch)
+        .toHaveBeenCalledWith(element, {
+          type: type,
+          object: type,
+          callback: jasmine.any(Function),
+        });
+    });
+  });
+
+  describe('updateObjects callback', function () {
+    var updateDfd;
+    var context;
+    var args;
+    var resMessage;
+
+    beforeEach(function () {
+      context = {
+        closeModal: jasmine.createSpy(),
+      };
+      args = {
+        selected: [1],
+        options: {},
+      };
+
+      viewModel.attr('model', {
+        name_singular: 'Some Model',
+      });
+      resMessage = 'items updated';
+      updateDfd = can.Deferred();
+      event = events.updateObjects.bind(events);
+
+      spyOn(can, 'trigger');
+      spyOn(GGRC.Errors, 'notifier');
+      spyOn(updateService, 'update')
+        .and.returnValue(updateDfd);
+
+      spyOn(events, 'getResultNotification')
+        .and.returnValue(resMessage);
+
+      event(context, args);
+    });
+
+    it('closes ObjectBulkUpdate modal', function () {
+      expect(context.closeModal).toHaveBeenCalled();
+    });
+
+    it('shows notification about bulk progress', function () {
+      expect(GGRC.Errors.notifier)
+        .toHaveBeenCalledWith('progress',
+          'Some Model update is in progress. This may take several minutes.');
+    });
+
+    it('shows notification about bulk update result', function () {
+      updateDfd.resolve([{status: 'updated'}]);
+
+      expect(events.getResultNotification)
+        .toHaveBeenCalledWith(viewModel.attr('model'), 1);
+      expect(GGRC.Errors.notifier)
+       .toHaveBeenCalledWith('info', resMessage);
+    });
+
+    it('triggers TreeView refresh when some items updated', function () {
+      updateDfd.resolve([{status: 'updated'}]);
+
+      expect(can.trigger)
+        .toHaveBeenCalledWith(jasmine.any(Object), 'refreshTree');
+    });
+
+    it('does not trigger TreeView refresh when no item was updated',
+      function () {
+        updateDfd.resolve([]);
+
+        expect(can.trigger)
+          .not.toHaveBeenCalled();
+      });
+
+    it('does not show notification when update failed', function () {
+      updateDfd.reject();
+
+      expect(events.getResultNotification)
+        .not.toHaveBeenCalled();
+      expect(GGRC.Errors.notifier)
+        .not.toHaveBeenCalledWith('info', jasmine.any(String));
+    });
+  });
+
+  describe('getResultNotification event', function () {
+    var model = {
+      name_singular: 'Task',
+      name_plural: 'Tasks',
+    };
+    var event;
+
+    beforeAll(function () {
+      event = events.getResultNotification;
+    });
+
+    it('returns correct message when no objects were updated', function () {
+      var expected = 'No tasks were updated.';
+      var actual = event(model, 0);
+
+      expect(actual).toEqual(expected);
+    });
+
+    it('returns correct message when 1 object was updated', function () {
+      var expected = '1 task was updated successfully.';
+      var actual = event(model, 1);
+
+      expect(actual).toEqual(expected);
+    });
+
+    it('returns correct message when multiple objects were updated',
+      function () {
+        var expected = '4 tasks were updated successfully.';
+        var actual = event(model, 4);
+
+        expect(actual).toEqual(expected);
+      });
+  });
+});

--- a/src/ggrc/assets/javascripts/components/object-bulk-update/bulk-update-target-state.js
+++ b/src/ggrc/assets/javascripts/components/object-bulk-update/bulk-update-target-state.js
@@ -1,0 +1,42 @@
+/*
+ Copyright (C) 2017 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+import template from
+  '../../../mustache/components/object-bulk-update/bulk-update-target-state.mustache'; // eslint-disable-line
+
+var objectStateToWarningMap = {
+  CycleTaskGroupObjectTask: {
+    InProgress: 'Please be aware that Finished, Declined and Verified ' +
+      'tasks cannot be moved to In Progress state.',
+    Finished: 'Please be aware that Assigned and Verified ' +
+      'tasks cannot be moved to Finished state.',
+    Declined: 'Please be aware that Assigned, In Progress and Verified ' +
+      'tasks cannot be moved to Declined state.',
+    Verified: 'Please be aware that Assigned, In Progress and Declined ' +
+      'tasks cannot be moved to Verified state.',
+  },
+};
+
+export default can.Component.extend({
+  tag: 'bulk-update-target-state',
+  template: template,
+  viewModel: {
+    define: {
+      warningMessage: {
+        get: function () {
+          var model = this.attr('modelName');
+          var targetState = this.attr('targetState');
+          return objectStateToWarningMap[model]
+            && objectStateToWarningMap[model][targetState]
+            || '';
+        },
+      },
+    },
+    modelName: null,
+    targetState: null,
+    targetStates: [],
+    enabled: false,
+  },
+ });

--- a/src/ggrc/assets/javascripts/components/object-bulk-update/object-bulk-update.js
+++ b/src/ggrc/assets/javascripts/components/object-bulk-update/object-bulk-update.js
@@ -1,0 +1,22 @@
+/*
+ Copyright (C) 2017 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+import template from
+  '../../../mustache/components/object-bulk-update/object-bulk-update.mustache';
+
+export default can.Component.extend({
+  tag: 'object-bulk-update',
+  template: template,
+  viewModel: function (attrs, parentViewModel) {
+    return GGRC.VM.ObjectOperationsBaseVM.extend({
+      type: attrs.type,
+      object: attrs.object,
+      availableTypes: function () {
+        var object = this.attr('object');
+        var type = GGRC.Mappings.getMappingType(object);
+        return type;
+      },
+    });
+  },
+});

--- a/src/ggrc/assets/javascripts/components/object-bulk-update/object-bulk-update.js
+++ b/src/ggrc/assets/javascripts/components/object-bulk-update/object-bulk-update.js
@@ -17,6 +17,7 @@ export default can.Component.extend({
         var type = GGRC.Mappings.getMappingType(object);
         return type;
       },
+      reduceToOwnedItems: true,
     });
   },
 });

--- a/src/ggrc/assets/javascripts/components/object-bulk-update/object-bulk-update.js
+++ b/src/ggrc/assets/javascripts/components/object-bulk-update/object-bulk-update.js
@@ -2,6 +2,9 @@
  Copyright (C) 2017 Google Inc.
  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  */
+
+import './bulk-update-target-state';
+import {getBulkStatesForModel} from '../../plugins/utils/state-utils';
 import template from
   '../../../mustache/components/object-bulk-update/object-bulk-update.mustache';
 
@@ -9,6 +12,10 @@ export default can.Component.extend({
   tag: 'object-bulk-update',
   template: template,
   viewModel: function (attrs, parentViewModel) {
+    var type = attrs.type;
+    var targetStates = getBulkStatesForModel(type);
+    var targetState = targetStates.length ? targetStates[0] : null;
+
     return GGRC.VM.ObjectOperationsBaseVM.extend({
       type: attrs.type,
       object: attrs.object,
@@ -18,6 +25,19 @@ export default can.Component.extend({
         return type;
       },
       reduceToOwnedItems: true,
+      showTargetState: true,
+      targetStates: targetStates,
+      targetState: targetState,
     });
+  },
+  events: {
+    closeModal: function () {
+      if (this.element) {
+        this.element.find('.modal-dismiss').trigger('click');
+      }
+    },
+    '.btn-cancel click': function () {
+      this.closeModal();
+    },
   },
 });

--- a/src/ggrc/assets/javascripts/components/object-bulk-update/object-bulk-update.js
+++ b/src/ggrc/assets/javascripts/components/object-bulk-update/object-bulk-update.js
@@ -28,6 +28,7 @@ export default can.Component.extend({
       showTargetState: true,
       targetStates: targetStates,
       targetState: targetState,
+      callback: parentViewModel.attr('callback'),
     });
   },
   events: {
@@ -38,6 +39,16 @@ export default can.Component.extend({
     },
     '.btn-cancel click': function () {
       this.closeModal();
+    },
+    '.btn-update click': function () {
+      var callback = this.viewModel.callback;
+
+      callback(this, {
+        selected: this.viewModel.attr('selected'),
+        options: {
+          state: this.viewModel.attr('targetState'),
+        },
+      });
     },
   },
 });

--- a/src/ggrc/assets/javascripts/components/object-bulk-update/tests/bulk-update-target-state_spec.js
+++ b/src/ggrc/assets/javascripts/components/object-bulk-update/tests/bulk-update-target-state_spec.js
@@ -1,0 +1,48 @@
+/*
+ Copyright (C) 2017 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+import Component from '../bulk-update-target-state.js';
+
+var objectStateToWarningMap = {
+  CycleTaskGroupObjectTask: {
+    InProgress: 'Please be aware that Finished, Declined and Verified ' +
+      'tasks cannot be moved to In Progress state.',
+    Finished: 'Please be aware that Assigned and Verified ' +
+      'tasks cannot be moved to Finished state.',
+    Declined: 'Please be aware that Assigned, In Progress and Verified ' +
+      'tasks cannot be moved to Declined state.',
+    Verified: 'Please be aware that Assigned, In Progress and Declined ' +
+      'tasks cannot be moved to Verified state.',
+  },
+};
+var viewModel;
+
+define('GGRC.Components.bulkUpdateTargetState', function () {
+  beforeAll(function () {
+    viewModel = new (can.Map.extend(Component.prototype.viewModel));
+  });
+  define('warningMessage property', function () {
+    it('should return appropriate warnings for objects', function () {
+      var objectStatesMap = {
+        CycleTaskGroupObjectTask: ['Assigned', 'InProgress', 'Finished',
+          'Declined', 'Deprecated', 'Verified'],
+      };
+
+      _.forEach(objectStatesMap, function (states, obj) {
+        viewModel.attr('modelName', obj);
+
+        _.forEach(states, function (state) {
+          var warning;
+          var expected = objectStateToWarningMap[obj][state] || '';
+          viewModel.attr('targetState', state);
+
+          warning = viewModel.attr('warningMessage');
+
+          expect(warning).toEqual(expected);
+        });
+      });
+    });
+  });
+});

--- a/src/ggrc/assets/javascripts/components/object-bulk-update/tests/object-bulk-update_spec.js
+++ b/src/ggrc/assets/javascripts/components/object-bulk-update/tests/object-bulk-update_spec.js
@@ -1,0 +1,102 @@
+/*
+ Copyright (C) 2017 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+import Component from '../object-bulk-update';
+import * as stateUtils from '../../../plugins/utils/state-utils';
+
+describe('GGRC.Components.objectBulkUpdate', function () {
+  var events;
+
+  beforeAll(function () {
+    events = Component.prototype.events;
+  });
+
+  describe('viewModel() method', function () {
+    var parentViewModel;
+    var method;
+    var targetStates;
+    var mappingType;
+    var result;
+
+    beforeEach(function () {
+      parentViewModel = new can.Map();
+      method = Component.prototype.viewModel;
+      mappingType = {
+        type: 'the same type',
+      };
+      targetStates = ['Assigned', 'InProgress'];
+
+      spyOn(stateUtils, 'getBulkStatesForModel')
+        .and.returnValue(targetStates);
+      spyOn(GGRC.Mappings, 'getMappingType')
+        .and.returnValue(mappingType);
+
+      result = method({type: 'some type'}, parentViewModel)();
+    });
+
+    it('returns correct type', function () {
+      expect(result.type).toEqual('some type');
+    });
+
+    it('returns correct target states', function () {
+      var actual = can.makeArray(result.targetStates);
+      expect(actual).toEqual(targetStates);
+    });
+
+    it('returns correct target state', function () {
+      expect(result.targetState).toEqual('Assigned');
+    });
+
+    it('returns set reduceToOwnedItems flag', function () {
+      expect(result.reduceToOwnedItems).toBeTruthy();
+    });
+
+    it('returns set showTargetState flag', function () {
+      expect(result.showTargetState).toBeTruthy();
+    });
+
+    it('returns correct availableTypes', function () {
+      expect(result.availableTypes())
+        .toEqual(mappingType);
+    });
+  });
+
+  describe('closeModal event', function () {
+    var event;
+    var element;
+
+    beforeAll(function () {
+      var scope;
+      element = {
+        trigger: jasmine.createSpy(),
+      };
+      element.find = jasmine.createSpy().and.returnValue(element);
+      scope = {
+        element: element,
+      };
+
+      event = events.closeModal.bind(scope);
+    });
+
+    it('closes modal if element defined', function () {
+      event();
+
+      expect(element.trigger).toHaveBeenCalledWith('click');
+    });
+  });
+
+  describe('.btn-cancel click event', function () {
+    it('closes modal', function () {
+      var context = {
+        closeModal: jasmine.createSpy(),
+      };
+      var event = events['.btn-cancel click'].bind(context);
+
+      event();
+
+      expect(context.closeModal).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/ggrc/assets/javascripts/components/object-bulk-update/tests/object-bulk-update_spec.js
+++ b/src/ggrc/assets/javascripts/components/object-bulk-update/tests/object-bulk-update_spec.js
@@ -99,4 +99,27 @@ describe('GGRC.Components.objectBulkUpdate', function () {
       expect(context.closeModal).toHaveBeenCalled();
     });
   });
+
+  describe('.btn-update click event', function () {
+    var event;
+    var context;
+
+    beforeEach(function () {
+      context = {
+        viewModel: new can.Map(),
+      };
+      event = events['.btn-update click'].bind(context);
+    });
+
+    it('invokes update callback', function () {
+      context.viewModel.callback = jasmine.createSpy();
+      context.viewModel.attr('selected', [1]);
+      context.viewModel.attr('targetState', 'InProgress');
+
+      event();
+
+      expect(context.viewModel.callback)
+        .toHaveBeenCalled();
+    });
+  });
 });

--- a/src/ggrc/assets/javascripts/components/tree/templates/tree-widget-container.mustache
+++ b/src/ggrc/assets/javascripts/components/tree/templates/tree-widget-container.mustache
@@ -76,6 +76,11 @@
           {{#if showGenerateAssessments}}
             <assessment-generator-button audit="parent_instance"></assessment-generator-button>
           {{/if}}
+          {{#if showBulkUpdate}}
+            <li>
+              <bulk-update-button></bulk-update-button>
+            </li>
+          {{/if}}
         </ul>
       </div>
       {{/if}}

--- a/src/ggrc/assets/javascripts/components/tree/templates/tree-widget-container.mustache
+++ b/src/ggrc/assets/javascripts/components/tree/templates/tree-widget-container.mustache
@@ -78,7 +78,8 @@
           {{/if}}
           {{#if showBulkUpdate}}
             <li>
-              <bulk-update-button></bulk-update-button>
+              <bulk-update-button {model}="model">
+              </bulk-update-button>
             </li>
           {{/if}}
         </ul>

--- a/src/ggrc/assets/javascripts/components/tree/tree-widget-container.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-widget-container.js
@@ -25,6 +25,7 @@ import './get-owner-people-list';
 import './tree-people-with-role-list-field';
 import '../advanced-search/advanced-search-filter-container';
 import '../advanced-search/advanced-search-mapping-container';
+import '../bulk-update-button/bulk-update-button';
 import template from './templates/tree-widget-container.mustache';
 import * as StateUtils from '../../plugins/utils/state-utils';
 import {
@@ -206,6 +207,12 @@ viewModel = can.Map.extend({
 
         return parentInstance.type === 'Audit' &&
           model.shortName === 'Assessment';
+      },
+    },
+    showBulkUpdate: {
+      type: 'boolean',
+      get: function () {
+        return this.attr('options.showBulkUpdate');
       },
     },
     show3bbs: {

--- a/src/ggrc/assets/javascripts/components/unified-mapper/mapper-results.js
+++ b/src/ggrc/assets/javascripts/components/unified-mapper/mapper-results.js
@@ -50,6 +50,7 @@ export default GGRC.Components('mapperResults', {
     submitCbs: null,
     displayPrefs: null,
     disableColumnsConfiguration: false,
+    applyOwnedFilter: false,
     objectsPlural: false,
     relatedAssessments: {
       state: {},
@@ -152,6 +153,18 @@ export default GGRC.Components('mapperResults', {
       var filterString = StateUtils.unlockedFilter();
       return GGRC.query_parser.parse(filterString);
     },
+    prepareOwnedFilter: function () {
+      var userId = GGRC.current_user.id;
+      return {
+        expression: {
+          object_name: 'Person',
+          op: {
+            name: 'owned',
+          },
+          ids: [userId],
+        },
+      };
+    },
     shouldApplyUnlockedFilter: function (modelName) {
       return modelName === 'Audit' && !this.attr('searchOnly');
     },
@@ -199,6 +212,12 @@ export default GGRC.Components('mapperResults', {
         advancedFilters = GGRC.query_parser.join_queries(
           advancedFilters,
           this.prepareUnlockedFilter());
+      }
+
+      if (this.attr('applyOwnedFilter')) {
+        advancedFilters = GGRC.query_parser.join_queries(
+          advancedFilters,
+          this.prepareOwnedFilter());
       }
 
       // prepare and add main query to request

--- a/src/ggrc/assets/javascripts/components/unified-mapper/tests/mapper-results_spec.js
+++ b/src/ggrc/assets/javascripts/components/unified-mapper/tests/mapper-results_spec.js
@@ -314,8 +314,8 @@ describe('GGRC.Components.mapperResults', function () {
     var mockMappingItems = ['mappingItem'];
     var mockStatusItem = new can.Map({
       value: {
-        items: ['statusItem']
-      }
+        items: ['statusItem'],
+      },
     });
 
     beforeEach(function () {
@@ -427,6 +427,30 @@ describe('GGRC.Components.mapperResults', function () {
 
       expect(GGRC.query_parser.join_queries.calls.argsFor(2)[1])
         .toBe('unlocked');
+    });
+
+    it('prepare request for owned items if flag was set', function () {
+      var mockUser = {
+        id: -1,
+      };
+      var oldUser = GGRC.current_user;
+      GGRC.current_user = mockUser;
+      spyOn(GGRC.current_user, 'id').and.returnValue(-1);
+      viewModel.attr('applyOwnedFilter', true);
+
+      viewModel.getQuery();
+
+      expect(GGRC.query_parser.join_queries.calls.argsFor(2)[1]).toEqual({
+        expression: {
+          object_name: 'Person',
+          op: {
+            name: 'owned',
+          },
+          ids: [mockUser.id],
+        },
+      });
+
+      GGRC.current_user = oldUser;
     });
   });
 

--- a/src/ggrc/assets/javascripts/controllers/mapper.js
+++ b/src/ggrc/assets/javascripts/controllers/mapper.js
@@ -5,6 +5,7 @@
 
 import '../components/view-models/object-operations-base-vm';
 import '../components/advanced-search/advanced-search-wrapper';
+import '../components/object-bulk-update/object-bulk-update';
 import '../components/object-mapper/object-mapper';
 import '../components/object-generator/object-generator';
 import '../components/object-search/object-search';
@@ -199,6 +200,12 @@ import {
     defaults: {
       component: GGRC.mustache_path +
         '/modals/mapper/object-generator-modal.mustache',
+    },
+  }, {});
+  GGRC.Controllers.ObjectMapper.extend('GGRC.Controllers.ObjectBulkUpdate', {
+    defaults: {
+      component: GGRC.mustache_path +
+        '/modals/mapper/object-bulk-update-modal.mustache',
     },
   }, {});
 

--- a/src/ggrc/assets/javascripts/models/mappers/mappings.js
+++ b/src/ggrc/assets/javascripts/models/mappers/mappings.js
@@ -109,6 +109,16 @@
       return groups;
     },
     /**
+     * Return allowed for mapping type in appropriate group.
+     * @param {String} type - base model type
+     * @return {Array} - object with one allowed for mapping Model
+     */
+    getMappingType: function (type) {
+      var groups = this.getTypeGroups();
+      this._addFormattedType(type, groups);
+      return groups;
+    },
+    /**
      * Returns cmsModel fields in required format.
      * @param {can.Model} cmsModel - cms model
      * @return {object} - cms model in required format

--- a/src/ggrc/assets/javascripts/plugins/tests/advanced-search-utils_spec.js
+++ b/src/ggrc/assets/javascripts/plugins/tests/advanced-search-utils_spec.js
@@ -24,12 +24,30 @@ describe('AdvancedSearch', function () {
         .toBe(expectedResult);
     });
 
+    it(`builds correct statuses with "ANY" operator for
+      CycleTaskGroupObjectTask`,
+      function () {
+        var items = [
+          AdvancedSearch.create.state({
+            items: ['Active', 'Draft', 'Deprecated'],
+            operator: 'ANY',
+            modelName: 'CycleTaskGroupObjectTask',
+          }),
+        ];
+        var expectedResult = '("Task State"="Active" ' +
+                             'OR "Task State"="Draft" ' +
+                             'OR "Task State"="Deprecated")';
+
+        expect(AdvancedSearch.buildFilter(items))
+          .toBe(expectedResult);
+      });
+
     it('builds correct statuses with "NONE" operator', function () {
       var items = [
         AdvancedSearch.create.state({
           items: ['Active', 'Draft', 'Deprecated'],
-          operator: 'NONE'
-        })
+          operator: 'NONE',
+        }),
       ];
       var expectedResult = '("Status"!="Active" ' +
                            'AND "Status"!="Draft" ' +
@@ -38,6 +56,24 @@ describe('AdvancedSearch', function () {
       expect(AdvancedSearch.buildFilter(items))
         .toBe(expectedResult);
     });
+
+    it(`builds correct statuses with "NONE" operator for
+      CycleTaskGroupObjectTask`,
+      function () {
+        var items = [
+          AdvancedSearch.create.state({
+            items: ['Active', 'Draft', 'Deprecated'],
+            operator: 'NONE',
+            modelName: 'CycleTaskGroupObjectTask',
+          }),
+        ];
+        var expectedResult = '("Task State"!="Active" ' +
+                             'AND "Task State"!="Draft" ' +
+                             'AND "Task State"!="Deprecated")';
+
+        expect(AdvancedSearch.buildFilter(items))
+          .toBe(expectedResult);
+      });
 
     it('builds correct filter string', function () {
       var items = [

--- a/src/ggrc/assets/javascripts/plugins/tests/state-utils_spec.js
+++ b/src/ggrc/assets/javascripts/plugins/tests/state-utils_spec.js
@@ -137,4 +137,75 @@ describe('StateUtils', function () {
       expect(defaultStates[0]).toEqual('Active');
     });
   });
+
+  describe('getStatusFieldName() method', function () {
+    it('returns "Task State" for CycleTaskGroupObjectTask', function () {
+      var expected = 'Task State';
+
+      var actual = StateUtils.getStatusFieldName('CycleTaskGroupObjectTask');
+
+      expect(actual).toEqual(expected);
+    });
+
+    it('returns "Status" when model is not provided', function () {
+      var expected = 'Status';
+
+      var actual = StateUtils.getStatusFieldName('');
+
+      expect(actual).toEqual(expected);
+    });
+
+    it('returns "Status" for non-CycleTaskGroupObjectTask models',
+      function () {
+        var models = ['Standard', 'Regulation', 'Section', 'Objective',
+          'Control', 'Product', 'System', 'Process', 'AccessGroup',
+          'Assessment', 'Clause', 'Contract', 'DataAsset', 'Facility',
+          'Issue', 'Market', 'OrgGroup', 'Policy', 'Program', 'Project',
+          'Risk', 'Threat', 'Vendor', 'Audit', 'RiskAssessment', 'Workflow',
+          'AssessmentTemplate', 'Person', 'TaskGroup', 'TaskGroupTask',
+          'Cycle', 'CycleTaskGroup'];
+
+        _.forEach(models, function (model) {
+          expect(StateUtils.getStatusFieldName(model))
+            .toEqual('Status');
+        });
+      });
+  });
+
+  describe('getBulkStatesForModel() method', function () {
+    it('returns expected states for CycleTaskGroupObjectTask', function () {
+      var expected = ['InProgress', 'Finished',
+        'Declined', 'Deprecated', 'Verified'];
+
+      var actual = StateUtils
+        .getBulkStatesForModel('CycleTaskGroupObjectTask');
+
+      expect(actual).toEqual(expected);
+    });
+
+    it('returns an empty array when model is not provided', function () {
+      var expected = [];
+
+      var actual = StateUtils.getBulkStatesForModel('');
+
+      expect(actual).toEqual(expected);
+    });
+
+    it('returns an empty array for non-CycleTaskGroupObjectTask models',
+      function () {
+        var expected = [];
+        var models = ['Standard', 'Regulation', 'Section', 'Objective',
+          'Control', 'Product', 'System', 'Process', 'AccessGroup',
+          'Assessment', 'Clause', 'Contract', 'DataAsset', 'Facility',
+          'Issue', 'Market', 'OrgGroup', 'Policy', 'Program', 'Project',
+          'Risk', 'Threat', 'Vendor', 'Audit', 'RiskAssessment', 'Workflow',
+          'AssessmentTemplate', 'Person', 'TaskGroup', 'TaskGroupTask',
+          'Cycle', 'CycleTaskGroup'];
+
+        _.forEach(models, function (model) {
+          expect(StateUtils.getBulkStatesForModel(model))
+            .toEqual(expected);
+        });
+      });
+  });
 });

--- a/src/ggrc/assets/javascripts/plugins/tests/utils/bulk-update-service_spec.js
+++ b/src/ggrc/assets/javascripts/plugins/tests/utils/bulk-update-service_spec.js
@@ -1,0 +1,43 @@
+/*
+  Copyright (C) 2017 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+import service from '../../utils/bulk-update-service';
+
+describe('GGRC.Utils.BulkUpdateService', function () {
+  describe('update() method', function () {
+    var method;
+    var ajaxRes;
+
+    beforeEach(function () {
+      method = service.update;
+      ajaxRes = {
+      };
+      ajaxRes.done = jasmine.createSpy().and.returnValue(ajaxRes);
+      ajaxRes.fail = jasmine.createSpy().and.returnValue(ajaxRes);
+
+      spyOn($, 'ajax')
+        .and.returnValue(ajaxRes);
+    });
+
+    it('makes ajax call with transformed data', function () {
+      var model = {
+        table_plural: 'some_model',
+      };
+      var data = [{
+        id: 1,
+      }];
+
+      method(model, data, {state: 'InProgress'});
+
+      expect($.ajax)
+        .toHaveBeenCalledWith({
+          url: '/api/some_model',
+          method: 'PATCH',
+          contentType: 'application/json',
+          data: '[{"id":1,"state":"InProgress"}]',
+        });
+    });
+  });
+});

--- a/src/ggrc/assets/javascripts/plugins/utils/advanced-search-utils.js
+++ b/src/ggrc/assets/javascripts/plugins/utils/advanced-search-utils.js
@@ -72,22 +72,28 @@ var create = {
 var richOperators = {
   /**
    * @param {Array} values - filter statements.
+   * @param {String} modelName - model name
    * @return {string} - filter string.
    */
-  ANY: function (values) {
+  ANY: function (values, modelName) {
+    var statusField = StateUtils.getStatusFieldName(
+      modelName);
     return _.map(values, function (value) {
-      return '"Status"="' + value + '"';
+      return '"' + statusField + '"="' + value + '"';
     }).join(' OR ');
   },
   /**
    * @param {Array} values - filter statements.
+   * @param {String} modelName - model name
    * @return {string} - filter string.
    */
-  NONE: function (values) {
+  NONE: function (values, modelName) {
+    var statusField = StateUtils.getStatusFieldName(
+      modelName);
     return _.map(values, function (value) {
-      return '"Status"!="' + value + '"';
+      return '"' + statusField + '"!="' + value + '"';
     }).join(' AND ');
-  }
+  },
 };
 
 /**

--- a/src/ggrc/assets/javascripts/plugins/utils/bulk-update-service.js
+++ b/src/ggrc/assets/javascripts/plugins/utils/bulk-update-service.js
@@ -1,0 +1,34 @@
+/*
+ Copyright (C) 2017 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+const toBulkModel = (instances, targetProps)=> {
+  var state = targetProps.state;
+  return _.map(instances, (item)=> {
+    return {
+      id: item.id,
+      state: state,
+    };
+  });
+};
+
+export default {
+  update: function (model, instances, targetProps) {
+    const url = '/api/' + model.table_plural;
+    const dfd = can.Deferred();
+    instances = toBulkModel(instances, targetProps);
+
+    $.ajax({
+      url: url,
+      method: 'PATCH',
+      data: JSON.stringify(instances),
+      contentType: 'application/json',
+    }).done(function (res) {
+      dfd.resolve(res);
+    }).fail(function (err) {
+      dfd.reject(err);
+    });
+    return dfd;
+  },
+};

--- a/src/ggrc/assets/javascripts/plugins/utils/state-utils.js
+++ b/src/ggrc/assets/javascripts/plugins/utils/state-utils.js
@@ -38,10 +38,18 @@ let statesModels = [
   },
   {
     models: [
-      'Person', 'CycleTaskGroupObjectTask', 'Workflow',
-      'TaskGroup', 'Cycle'
+      'Person', 'Workflow', 'TaskGroup', 'Cycle',
     ],
-    states: []
+    states: [],
+  },
+  {
+    models: [
+      'CycleTaskGroupObjectTask',
+    ],
+    states: [
+      'Assigned', 'InProgress', 'Finished',
+      'Declined', 'Deprecated', 'Verified',
+    ],
   },
   {
     models: ['Issue'],

--- a/src/ggrc/assets/javascripts/plugins/utils/state-utils.js
+++ b/src/ggrc/assets/javascripts/plugins/utils/state-utils.js
@@ -50,6 +50,10 @@ let statesModels = [
       'Assigned', 'InProgress', 'Finished',
       'Declined', 'Deprecated', 'Verified',
     ],
+    bulkStates: [
+      'InProgress', 'Finished',
+      'Declined', 'Deprecated', 'Verified',
+    ],
   },
   {
     models: ['Issue'],
@@ -113,6 +117,17 @@ function getStatesModelsPair(model) {
 function getStatesForModel(model) {
   var pair = getStatesModelsPair(model);
   return pair ? pair.states : [];
+}
+
+/**
+ * Get states for model that can be used
+ * as target in Bulk Update modal.
+ * @param {String} model - The model name
+ * @return {Array} array of strings
+ */
+function getBulkStatesForModel(model) {
+  var pair = getStatesModelsPair(model);
+  return pair && pair.bulkStates ? pair.bulkStates : [];
 }
 
 /**
@@ -251,6 +266,7 @@ export {
   statusFilter,
   unlockedFilter,
   getStatesForModel,
+  getBulkStatesForModel,
   getDefaultStatesForModel,
   buildStatusFilter,
   getStatusFieldName,

--- a/src/ggrc/assets/javascripts/plugins/utils/state-utils.js
+++ b/src/ggrc/assets/javascripts/plugins/utils/state-utils.js
@@ -125,7 +125,7 @@ function getStatesForModel(model) {
 function statusFilter(statuses, filterString, modelName) {
   var filter = modelName === 'Assessment' ?
     buildAssessmentFilter(statuses, buildStatusesFilterString) :
-    buildStatusesFilterString(statuses);
+    buildStatusesFilterString(statuses, modelName);
 
   filterString = filterString || '';
   if (filter !== '') {
@@ -156,20 +156,37 @@ function unlockedFilter() {
 function buildStatusFilter(statuses, builder, modelName) {
   var filter = modelName === 'Assessment' ?
     buildAssessmentFilter(statuses, builder) :
-    builder(statuses);
+    builder(statuses, modelName);
   return filter;
 }
 
 /**
  * Build statuses filter string
  * @param {Array} statuses - array of active statuses
+ * @param {String} modelName - model name
  * @return {String} statuses filter
  */
-function buildStatusesFilterString(statuses) {
+function buildStatusesFilterString(statuses, modelName) {
+  var fieldName = getStatusFieldName(modelName);
+
   return statuses.map(function (item) {
     // wrap in quotes
-    return '"Status"="' + item + '"';
+    return '"' + fieldName + '"="' + item + '"';
   }).join(' Or ');
+}
+
+/**
+* Return status field name for model
+* @param {String} modelName - model name
+* @return {String} status field name
+*/
+function getStatusFieldName(modelName) {
+  var modelToStateFieldMap = {
+    CycleTaskGroupObjectTask: 'Task State',
+  };
+  var fieldName = modelToStateFieldMap[modelName] || 'Status';
+
+  return fieldName;
 }
 
 /**
@@ -189,7 +206,7 @@ function buildAssessmentFilter(statuses, builder) {
 
   // do not update statuses
   if (verifiedIndex === -1 && completedIndex === -1) {
-    return builder(statuses);
+    return builder(statuses, 'Assessment');
   }
 
   if (verifiedIndex > -1 && completedIndex > -1) {
@@ -201,7 +218,7 @@ function buildAssessmentFilter(statuses, builder) {
     // remove it
     statuses.splice(verifiedIndex, 1);
 
-    return builder(statuses);
+    return builder(statuses, 'Assessment');
   }
 
   if (completedIndex > -1 && verifiedIndex === -1) {
@@ -212,7 +229,7 @@ function buildAssessmentFilter(statuses, builder) {
     statuses.push('Completed');
   }
 
-  filter = builder(statuses);
+  filter = builder(statuses, 'Assessment');
   return filter + ' AND verified=' + isVerified;
 }
 
@@ -235,5 +252,6 @@ export {
   unlockedFilter,
   getStatesForModel,
   getDefaultStatesForModel,
-  buildStatusFilter
+  buildStatusFilter,
+  getStatusFieldName,
 };

--- a/src/ggrc/assets/mustache/components/bulk-update-button/bulk-update-button.mustache
+++ b/src/ggrc/assets/mustache/components/bulk-update-button/bulk-update-button.mustache
@@ -1,0 +1,9 @@
+{{!
+    Copyright (C) 2017 Google Inc.
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+}}
+
+<a class="bulk-update-button">
+  <i class="fa fa-fw fa-refresh"></i>
+  Bulk Update
+</a>

--- a/src/ggrc/assets/mustache/components/object-bulk-update/bulk-update-target-state.mustache
+++ b/src/ggrc/assets/mustache/components/object-bulk-update/bulk-update-target-state.mustache
@@ -1,0 +1,24 @@
+{{!
+    Copyright (C) 2017 Google Inc.
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+}}
+
+{{#if warningMessage}}
+  <div class="alert">
+    <p>
+        {{warningMessage}}
+    </p>
+  </div>
+{{/if}}
+
+<div class="target-state-control">
+  <div class="target-state-control__label">
+    <h6>State</h6>
+  </div>
+  <select id="targetState" {($value)}="targetState" class="target-state-control__selector"
+    {{^enabled}}disabled="disabled"{{/enabled}}>
+    {{#targetStates}}
+      <option value="{{.}}">{{.}}</option>
+    {{/targetStates}}
+  </select>
+</div>

--- a/src/ggrc/assets/mustache/components/object-bulk-update/object-bulk-update.mustache
+++ b/src/ggrc/assets/mustache/components/object-bulk-update/object-bulk-update.mustache
@@ -65,7 +65,8 @@
         {^paging.total}="*totalObjects"
         {(entries)}="entries"
         {filter-items}="*filterItems"
-        {status-item}="*statusItem">
+        {status-item}="*statusItem"
+        {apply-owned-filter}="reduceToOwnedItems">
       </mapper-results>
     </div>
   </collapsible-panel>

--- a/src/ggrc/assets/mustache/components/object-bulk-update/object-bulk-update.mustache
+++ b/src/ggrc/assets/mustache/components/object-bulk-update/object-bulk-update.mustache
@@ -70,4 +70,29 @@
       </mapper-results>
     </div>
   </collapsible-panel>
+  <collapsible-panel {soft-mode}="true" {title-text}="'Bulk Update'" {(expanded)}="showTargetState">
+    <bulk-update-target-state
+      {target-states}="targetStates"
+      {(target-state)}="targetState"
+      {model-name}="model.singular"
+      {enabled}="selected.length"
+      class="target-state">
+    </bulk-update-target-state>
+  </collapsible-panel>
+  <div class="control-buttons">
+    <div class="confirm-buttons">
+      <span>
+        {{selected.length}}
+          object(s) selected
+        </span>
+        <button class="btn btn-small btn-white btn-cancel">
+          Cancel
+        </button>
+        <button class="btn-update btn btn-small btn-green preventdoubleclick"
+          {{^if selected.length}}disabled="disabled"{{/if}}>
+          Update
+        </button>
+      </div>
+    </div>
+  </div>
 </div>

--- a/src/ggrc/assets/mustache/components/object-bulk-update/object-bulk-update.mustache
+++ b/src/ggrc/assets/mustache/components/object-bulk-update/object-bulk-update.mustache
@@ -1,0 +1,72 @@
+{{!
+    Copyright (C) 2017 Google Inc.
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+}}
+
+<div class="modal-header">
+  <a class="modal-dismiss pull-right" href="javascript://" data-dismiss="modal">
+    <i class="fa fa-times black"></i>
+  </a>
+  <h2>
+    Bulk Update
+  </h2>
+</div>
+<div class="modal-filter modal-body">
+  <collapsible-panel {soft-mode}="true" {title-text}="'filter'" {(expanded)}="showSearch">
+    <advanced-search-wrapper
+      {model-name}="model.singular"
+      {model-display-name}="model.name"
+      {^filter-items}="*filterItems"
+      {^status-item}="*statusItem"
+      ($enter)="onSubmit()">
+      <div class="object-controls">
+        <div class="object-controls__row">
+          <div class="object-controls__state">
+            <advanced-search-filter-state
+              {model-name}="modelName"
+              {(state-model)}="statusItem.value"
+              {show-operator}="false">
+            </advanced-search-filter-state>
+          </div>
+        </div>
+        <div class="object-controls__filters">
+          <advanced-search-filter-container
+            {(items)}="filterItems"
+            {available-attributes}="availableAttributes"
+            {model-name}="modelName"
+            {default-status-filter}="false"
+            {show-add-button}="mappingItems.length">
+          </advanced-search-filter-container>
+        </div>
+        <div class="object-controls__actions">
+          <div class="object-controls__actions--left">
+            <button class="btn btn-small btn-white" ($click)="addFilterAttribute">Add Attribute</button>
+          </div>
+          <div class="object-controls__actions--right">
+            <button type="reset" class="btn btn-small btn-white" {{#if is_loading}}disabled="disabled"{{/if}} ($click)="resetFilters()">Reset</button>
+           <button type="submit" class="btn btn-small btn-lightBlue" {{#if is_loading}}disabled="disabled"{{/if}} ($click)="onSubmit()">Search</button>
+          </div>
+        </div>
+      </div>
+    </advanced-search-wrapper>
+  </collapsible-panel>
+</div>
+
+<div class="modal-footer {{#if showResults}}expanded{{/if}}">
+  <collapsible-panel {soft-mode}="true" {title-text}="'Search Results ({{*totalObjects}})'" {(expanded)}="showResults">
+    <div class="search-results">
+      <mapper-results
+        base-instance="parentInstance"
+        {(is-loading)}="is_loading"
+        object="object"
+        type="type"
+        selected="selected"
+        submit-cbs="submitCbs"
+        {^paging.total}="*totalObjects"
+        {(entries)}="entries"
+        {filter-items}="*filterItems"
+        {status-item}="*statusItem">
+      </mapper-results>
+    </div>
+  </collapsible-panel>
+</div>

--- a/src/ggrc/assets/mustache/components/object-bulk-update/object-bulk-update.mustache
+++ b/src/ggrc/assets/mustache/components/object-bulk-update/object-bulk-update.mustache
@@ -52,7 +52,7 @@
   </collapsible-panel>
 </div>
 
-<div class="modal-footer {{#if showResults}}expanded{{/if}}">
+<div class="modal-body">
   <collapsible-panel {soft-mode}="true" {title-text}="'Search Results ({{*totalObjects}})'" {(expanded)}="showResults">
     <div class="search-results">
       <mapper-results
@@ -70,6 +70,8 @@
       </mapper-results>
     </div>
   </collapsible-panel>
+</div>
+<div class="modal-body">
   <collapsible-panel {soft-mode}="true" {title-text}="'Bulk Update'" {(expanded)}="showTargetState">
     <bulk-update-target-state
       {target-states}="targetStates"
@@ -79,19 +81,22 @@
       class="target-state">
     </bulk-update-target-state>
   </collapsible-panel>
+</div>
+
+<div class="modal-footer modal-footer--trailed {{#if showResults}}expanded{{/if}}">
   <div class="control-buttons">
     <div class="confirm-buttons">
-      <span>
+      <span class="confirm-buttons__objects-count">
         {{selected.length}}
-          object(s) selected
-        </span>
-        <button class="btn btn-small btn-white btn-cancel">
-          Cancel
-        </button>
-        <button class="btn-update btn btn-small btn-green preventdoubleclick"
-          {{^if selected.length}}disabled="disabled"{{/if}}>
-          Update
-        </button>
+        object(s) selected
+      </span>
+      <button class="btn btn-small btn-white btn-cancel">
+        Cancel
+      </button>
+      <button class="btn-update btn btn-small btn-green preventdoubleclick"
+        {{^if selected.length}}disabled="disabled"{{/if}}>
+        Update
+      </button>
       </div>
     </div>
   </div>

--- a/src/ggrc/assets/mustache/modals/mapper/object-bulk-update-modal.mustache
+++ b/src/ggrc/assets/mustache/modals/mapper/object-bulk-update-modal.mustache
@@ -1,0 +1,9 @@
+{{!
+    Copyright (C) 2017 Google Inc.
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+}}
+
+<object-bulk-update
+    {type}="type"
+    {object}="object">
+</object-bulk-update>

--- a/src/ggrc/assets/mustache/modals/mapper/object-bulk-update-modal.mustache
+++ b/src/ggrc/assets/mustache/modals/mapper/object-bulk-update-modal.mustache
@@ -5,5 +5,6 @@
 
 <object-bulk-update
     {type}="type"
-    {object}="object">
+    {object}="object"
+    class="object-bulk-update">
 </object-bulk-update>

--- a/src/ggrc/assets/stylesheets/_components.scss
+++ b/src/ggrc/assets/stylesheets/_components.scss
@@ -4,6 +4,7 @@
  */
 
 @import "components/advanced-search/advanced-search";
+@import "components/bulk-update/bulk-update";
 @import "components/info-pane/info-pane";
 @import "components/comment/comment-input";
 @import "components/comment/comment-add-form";

--- a/src/ggrc/assets/stylesheets/components/bulk-update/_bulk-update.scss
+++ b/src/ggrc/assets/stylesheets/components/bulk-update/_bulk-update.scss
@@ -1,0 +1,8 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ * Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+.bulk-update-button:hover {
+  text-decoration: none;
+}

--- a/src/ggrc/assets/stylesheets/components/bulk-update/_bulk-update.scss
+++ b/src/ggrc/assets/stylesheets/components/bulk-update/_bulk-update.scss
@@ -6,3 +6,27 @@
 .bulk-update-button:hover {
   text-decoration: none;
 }
+
+.target-state {
+  display: flex;
+  flex-direction: column;
+  margin-top: 20px;
+
+  &-control {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+
+    &__label {
+      margin-right: 16px;
+      width: 35px;
+    }
+
+    &__selector {
+      background: #fff url("data:image/svg+xml;utf8,<svg width='24' height='16' viewBox='0 0 1792 1792' xmlns='http://www.w3.org/2000/svg'><path fill='#797979' d='M1408 704q0 26-19 45l-448 448q-19 19-45 19t-45-19l-448-448q-19-19-19-45t19-45 45-19h896q26 0 45 19t19 45z'/></svg>") no-repeat 100% 50%;
+      padding: 0 24px 0 4px;
+      width: 320px;
+      -webkit-appearance: none;
+    }
+  }
+}

--- a/src/ggrc/assets/stylesheets/components/bulk-update/_bulk-update.scss
+++ b/src/ggrc/assets/stylesheets/components/bulk-update/_bulk-update.scss
@@ -7,6 +7,17 @@
   text-decoration: none;
 }
 
+.object-bulk-update {
+  .search-results {
+    margin-top: 20px;
+  }
+
+  .modal-footer.modal-footer--trailed {
+    border-top: none;
+    padding-top: 0;
+  }
+}
+
 .target-state {
   display: flex;
   flex-direction: column;

--- a/src/ggrc/assets/stylesheets/components/unified-mapper/_unified-mapper.scss
+++ b/src/ggrc/assets/stylesheets/components/unified-mapper/_unified-mapper.scss
@@ -520,7 +520,7 @@ mapper-results-columns-configuration {
 
 .object-modal {
 
-  object-mapper, object-search, object-generator {
+  object-mapper, object-search, object-generator, object-bulk-update {
     collapsible-panel {
       h6 {
         width: inherit;

--- a/src/ggrc/assets/stylesheets/modules/_modal.scss
+++ b/src/ggrc/assets/stylesheets/modules/_modal.scss
@@ -678,6 +678,10 @@
     }
     .confirm-buttons {
       text-align: right;
+
+      &__objects-count {
+        margin-right: 20px;
+      }
     }
   }
   .actions {

--- a/src/ggrc_workflows/assets/javascripts/apps/workflows.js
+++ b/src/ggrc_workflows/assets/javascripts/apps/workflows.js
@@ -612,6 +612,8 @@ import {
   WorkflowExtension.init_widgets_for_person_page = function () {
     var descriptor = {};
     var pageInstance = GGRC.page_instance();
+    const isObjectBrowser = /^\/objectBrowser\/?$/
+      .test(window.location.pathname);
 
     descriptor[pageInstance.constructor.shortName] = {
       task: {
@@ -630,6 +632,7 @@ import {
           sort_property: null,
           sort_function: _taskSortFunction,
           draw_children: true,
+          showBulkUpdate: !isObjectBrowser,
           events: {
             'show-history': function (el, ev) {
               this.options.attr('mapping', el.attr('mapping'));
@@ -641,7 +644,7 @@ import {
     };
 
     // add 'Workflows' tab for 'All Objects' view
-    if (/^\/objectBrowser\/?$/.test(window.location.pathname)) {
+    if (isObjectBrowser) {
       descriptor[pageInstance.constructor.shortName].workflow = {
         widget_id: 'workflow',
         widget_name: 'Workflows',

--- a/src/ggrc_workflows/assets/javascripts/models/cycle_models.js
+++ b/src/ggrc_workflows/assets/javascripts/models/cycle_models.js
@@ -340,6 +340,7 @@
         }
       ],
       display_attr_names: ['title',
+                           'status',
                            'Task Assignees',
                            'start_date',
                            'end_date'],

--- a/src/ggrc_workflows/assets/javascripts/models/cycle_models.js
+++ b/src/ggrc_workflows/assets/javascripts/models/cycle_models.js
@@ -270,6 +270,8 @@
     update: 'PUT /api/cycle_task_group_object_tasks/{id}',
     destroy: 'DELETE /api/cycle_task_group_object_tasks/{id}',
     title_singular: 'Cycle Task',
+    name_singular: 'Task',
+    name_plural: 'Tasks',
     attributes: {
       cycle_task_group: 'CMS.Models.CycleTaskGroup.stub',
       task_group_task: 'CMS.Models.TaskGroupTask.stub',
@@ -337,9 +339,9 @@
           attr_sort_field: 'task last updated by'
         }
       ],
-      display_attr_names: ['title', 
-                           'Task Assignees', 
-                           'start_date', 
+      display_attr_names: ['title',
+                           'Task Assignees',
+                           'start_date',
                            'end_date'],
       mandatory_attr_name: ['title'],
       draw_children: true


### PR DESCRIPTION
NOTE: 
- [x] This PR should be checked after   #6672 
- [x] This PR should be checked after   #6703 
- [x] This PR should be checked after   #6704 
- [x] This PR should be checked after   #6705 
- [x] This PR should be checked after   #6708 

# Issue description

Add ability to update CycleTaskGroupObjectTask state in bulk.

# Steps to test the changes

1) WHERE?
My Work - Tasks page. 

2) BULK UPDATE in tree view:
'BULK UPDATE' option should be displayed under 3 dots on My Tasks page.
On clicking 'BULK UPDATE', 'Bulk Update' pop-up should be opened. 

3) BULK UPDATE pop-up:
Advanced filters on BULK UPDATE pop-up:
 - Task State (Assigned / In Progress / Finished / Declined / Deprecated / Verified); 
 - Task Attributes (Summary / Assignee / Start Date / Due Date)
 
List of tasks related to logged-in user should be displayed on pop-up (same as on My Tasks page); 
 - Task Title, Task State, Task Assignees, Task Start Date, Task Due Date columns should be displayed by default for tasks list. 
 - Cycle title, Task Last Updated, Task Last Updated By columns should be hidden by default. 
 - Task state filed should be displayed with options: In Progress / Declined / Finished / Verified

4) MESSAGES on Bulk Update pop-up, depending on value selected in 'State' dropdown:
 - In Progress: "Please be aware that Finished, Declined and Verified tasks cannot be moved to In Progress state." 
 - Finished: "Please be aware that Assigned and Verified tasks cannot be moved to Finished state." 
 - Declined: "Please be aware that Assigned, In Progress and Verified tasks cannot be moved to Declined state." 
 - Verified: "Please be aware that Assigned, In Progress and Declined tasks cannot be moved to Verified state." 
 - Deprecated: Notes: no message. 

5) UPDATE button:
 - On clicking UPDATE button, pop-up should be closed. 
 - On clicking 'UPDATE' button, message 'Task update is in progress. This may take several minutes' should be shown while task updating is in progress.' should be shown while task are being updated. 
Message '# tasks were updated successfully.' / '1 task was updated successfully.' should be shown when updating is finished and at least one task is updated. 
 - After tasks are successfully updated, tree view should be reloaded and display the updated results. 
- Message 'No tasks were updated.' should be shown when updating is finished and no task is updated. 

# Solution description
https://docs.google.com/document/d/1xJWcNy1aBXEjSdZREwW-YJBxYwbPFKEiToUul0POJ2M/edit

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

NOTE:
- It was agreed with BA that user will be able to filter CTGOT by value in 'Status' dropdown in the scope of this ticket on My Tasks page and Global Search modal - this functionality works out of the box when adding possibility to filter Tasks by Status in Bulk Update modal.
- 'Task State' column was made default on Global Search and CTGOT tree views.
