### PR TITLE
GGRC-3631 Add IN operator for QueryAPI

### DIFF
--- a/src/ggrc/query/custom_operators.py
+++ b/src/ggrc/query/custom_operators.py
@@ -355,6 +355,20 @@ def or_operation(exp, object_class, target_class, query):
       build_expression(exp["right"], object_class, target_class, query))
 
 
+@validate("left", "right")
+def in_operation(exp, object_class, target_class, query):
+  """Operator generate sqlalchemy for in operation"""
+  if not exp["right"]:
+    return sqlalchemy.sql.false()
+  return object_class.id.in_(
+      db.session.query(Record.key).filter(
+          Record.type == object_class.__name__,
+          Record.property == exp["left"],
+          Record.content.in_(exp["right"])
+      )
+  )
+
+
 @validate("issue", "assessment")
 def cascade_unmappable(exp, object_class, target_class, query):
   """Special operator to get the effect of cascade unmap of Issue from Asmt."""
@@ -476,6 +490,7 @@ GE_OPERATOR = validate("left", "right")(build_op_shortcut(operator.ge))
 OPS = {
     "AND": and_operation,
     "OR": or_operation,
+    "IN": in_operation,
     "=": EQ_OPERATOR,
     "!=": reverse(EQ_OPERATOR),
     "~": like,

--- a/test/integration/ggrc/services/test_query/test_in.py
+++ b/test/integration/ggrc/services/test_query/test_in.py
@@ -1,0 +1,45 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Tests for IN operator."""
+
+import ddt
+
+from integration.ggrc import TestCase
+from integration.ggrc.query_helper import WithQueryApi
+from integration.ggrc.models import factories
+
+
+@ddt.ddt
+class TestIn(TestCase, WithQueryApi):
+  """Test suite for IN operator."""
+
+  def setUp(self):
+    super(TestIn, self).setUp()
+    self.client.get("/login")
+    test_objects = []
+    with factories.single_commit():
+      test_objects.append(factories.ControlFactory(title="c1"))
+      test_objects.append(factories.ControlFactory(title="c2"))
+      test_objects.append(factories.ControlFactory(title="c3",
+                                                   status="Active"))
+
+    self.title_id_map = {ob.title: ob.id for ob in test_objects}
+
+  @ddt.data(("Control", "status", ["Draft"], ["c1", "c2"]),
+            ("Control", "title", ["c1", "c2"], ["c1", "c2"]),
+            ("Control", "title", [], []),
+            ("Control", "status", ["Fake_status"], []),
+            ("Control", "title", ["c1", "c"], ["c1"]))
+  def test_in_operator(self, (object_type, field, values, expected_titles)):
+    """IN operator works for string fields."""
+
+    expected_ids = [self.title_id_map[title] for title in
+                    expected_titles]
+
+    result = self._get_first_result_set(
+        self._make_query_dict(object_type, expression=[field, "IN", values],
+                              type_="ids"),
+        object_type, "ids",
+    )
+    self.assertItemsEqual(result, expected_ids)


### PR DESCRIPTION
# Issue description

The frontend has to emulate IN operator for Status field and the like.

# Steps to test the changes

Compare the output of two requests to QueryAPI:

```json
[{"object_name": "Assessment",
  "type": "ids",
  "filter": {"expression": {
    "op": {"name": "IN"},
    "left": "status",
    "right": ["Not Started", "In Progress"]
  }}}]
```
```json
[{"object_name": "Assessment",
  "type": "ids",
  "filter": {"expression": {
    "op": {"name": "OR"},
    "left": {
      "op": {"name": "="},
      "left": "status",
      "right": "Not Started"
    },
    "right": {
      "op": {"name": "="},
      "left": "status",
      "right": "In Progress"
    }
  }}}]
```

The responses should be the same.

# Solution description

The new `IN` operator works very similar to `=` operator, but with a list as `right` operand. It is translated to `content IN (some_values)` in SQL.

# Benchmark

Tested on ggrc-qa dump from late Aug.

Assessment status in <list> is a case for All Object page.
Assessment owned by <person> and status in <list> is a case for My Work page.
Program slug in <list> is a case for an external service that will be using our QueryAPI.

All queries returned just the ids since the change doesn't affect object serialization in any way.

| Type (matched / total)     | Condition                                                                                                                      | Time IN           | Time =            |
|----------------------------|--------------------------------------------------------------------------------------------------------------------------------|-------------------|-------------------|
| Assessment (11931 / 13106) | status IN [In Progress, Not Started]                                                                                           | 241.5 (std: 78.9) | 291.2 (std: 79.7) |
| Assessment (12161 / 13106) | status IN [In Progress, Not Started, Completed]                                                                                | 214.2 (std: 65.3) | 233.9 (std: 68.9) |
| Assessment (13106 / 13106) | status IN [In Progress, Not Started, Completed, In Review]                                                                     | 216.6 (std: 69.2) | 230.5 (std: 65.3) |
| Program (5 / 1274)         | slug IN [PROGRAM-70, PROGRAM-77, PROGRAM-542, PROGRAM-603, SECTION-340]                                                        | 108.2  (std: 21.7 | 114.8 (std: 20.2) |
| Program (10 / 1274)        | slug IN [PROGRAM-70, PROGRAM-77, PROGRAM-542, PROGRAM-603, SECTION-340, PROGRAM-1555, PROGRAM-141, prog-15, AML, PROGRAM-1330] | 122.4 (std: 21.6) | 138.5 (std: 16.9) |
| Program (30 / 1274)        | slug IN [list of 30 slugs]                                                                                                     | 128.8 (std: 18.9) | 204.4 (std: 26.6) |
| Program (50 / 1274)        | slug IN [list of 50 slugs]                                                                                                     | 124.4 (std: 19.0) | 269.6 (std: 46.7) |
| Assessment (389 / 13106)   | owned ID=328 AND status IN  [In Progress]                                                                                      | 289.9 (std: 76.8) | 291.4 (std: 78.6) |
| Assessment (2191 / 13106)  | owned ID=328 AND status IN [In Progress, Not Started]                                                                          | 244.4 (std: 72)   | 239.5 (std: 75.3) |
| Assessment (2308/ 13106)   | owned ID=328 AND status IN [In Progress, Not Started, Completed]                                                               | 247 (std: 87.0)   | 245 (std: 76.2)   |
| Assessment (2370/ 13106)   | owned ID=328 AND status IN [In Progress, Not Started, Completed, In Review]                                                    | 303.7 (std: 83.8) | 308.1 (std: 86.4) |

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] db_reset runs without errors or warnings.
- [ ] db_reset ggrc-qa.sql runs without errors or warnings.
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
