### PR TITLE
GGRC-3581: Allow edit Need Verification flag for Draft WF only

### DIFF
--- a/src/ggrc_workflows/assets/mustache/workflows/modal_content.mustache
+++ b/src/ggrc_workflows/assets/mustache/workflows/modal_content.mustache
@@ -87,7 +87,7 @@
           </label>
           <input type="checkbox" name="is_verification_needed"
             {{#if instance.is_verification_needed}}checked="checked"{{/if}}
-            {{#is instance.status 'Active'}}disabled{{/is}}
+            {{^is instance.status 'Draft'}}disabled{{/is}}
             tabindex="-1">
           Show Verify button next to tasks
         </div>


### PR DESCRIPTION
# Issue description

'Show Verify button next to tasks' checkbox should be editable in edit modal for Draft Workflows only.

# Steps to test the changes
1. Create monthly workflow, 'Show Verify button next to tasks' set to "true"
2. On the workflow info page add task in the setup tab
3. Activate workflow
4. At the Active Cycles tab verify task
5. On the workflow info page invoke Edit workflow modal window
6. Edit 'need verification' field: success
7. Click save and close button
Actual Result: 'Need verification' field is editable if workflow is Inactive
Expected Result: 'Need verification' field should not be editable if workflow is Active, Inactive, Active Archived, Inactive Archived

# Solution description
Minor changes on Workflow edit modal.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/performance.rst).
- [ ] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
