### PR TITLE
GGRC-3741 BE: Update /people/suggest to process autocomplete requests with spaces

### DIFF
--- a/src/ggrc/integrations/client.py
+++ b/src/ggrc/integrations/client.py
@@ -133,11 +133,11 @@ class PersonClient(JsonClient):
         payload={'usernames': usernames})
     return response['persons']
 
-  def suggest_persons(self, prefix):
+  def suggest_persons(self, tokens):
     """Performs suggest persons request to integration server.
 
     Args:
-      prefix: A prefix to lookup for in 'email', 'first name' and 'last name'
+      tokens: prefixes to lookup for in 'email', 'first name' and 'last name'
       of person's info.
 
     Returns:
@@ -145,5 +145,5 @@ class PersonClient(JsonClient):
     """
     response = self._post(
         '%s:suggest' % self._BASE_PATH,
-        payload={'tokens': [prefix]})
+        payload={'tokens': tokens})
     return response['persons']

--- a/src/ggrc/services/suggest.py
+++ b/src/ggrc/services/suggest.py
@@ -17,10 +17,12 @@ def suggest():
   if not settings.INTEGRATION_SERVICE_URL:
     return make_suggest_result([])
 
-  prefix = request.args.get("prefix", "").strip()
-  person_client = client.PersonClient()
-  entries = person_client.suggest_persons(prefix)
-  return make_suggest_result(entries)
+  tokens = request.args.get("prefix", "").split()
+  if tokens:
+    person_client = client.PersonClient()
+    entries = person_client.suggest_persons(tokens)
+    return make_suggest_result(entries)
+  return make_suggest_result([])
 
 
 def make_suggest_result(entries):

--- a/test/unit/ggrc/integrations/test_client.py
+++ b/test/unit/ggrc/integrations/test_client.py
@@ -177,7 +177,7 @@ class PersonClientTest(unittest.TestCase):
         _post=mock.MagicMock(return_value={'persons': 'persons data'})
     ):
       testable_obj = self.testable_cls()
-      actual = testable_obj.suggest_persons("pit")
+      actual = testable_obj.suggest_persons(["pit"])
 
       self.assertEqual(actual, 'persons data')
       testable_obj._post.assert_called_once_with(


### PR DESCRIPTION
# Issue description

Currently /people/suggest doesn't process prefixes with spaces correctly. If user, for instance, types 'Jhon Sn' in autocomplete component, the user 'Jhon Snow' won't be found. 

# Solution description

It is needed to split prefix on tokens before making request to Integration Service.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".