### PR TITLE
GGRC-3755: Enable Need Verification checkbox on create WF modal

### DIFF
--- a/src/ggrc_workflows/assets/mustache/workflows/modal_content.mustache
+++ b/src/ggrc_workflows/assets/mustache/workflows/modal_content.mustache
@@ -87,7 +87,9 @@
           </label>
           <input type="checkbox" name="is_verification_needed"
             {{#if instance.is_verification_needed}}checked="checked"{{/if}}
-            {{^is instance.status 'Draft'}}disabled{{/is}}
+            {{#if instance.status}}
+              {{^is instance.status 'Draft'}}disabled{{/is}}
+            {{/if}}
             tabindex="-1">
           Show Verify button next to tasks
         </div>


### PR DESCRIPTION
# Issue description

User unable to change 'Need Verification' flag while creating Workflow

# Steps to test the changes

Steps to reproduce:
1. Invoke New workflow modal window
2. Hover over 'Show Verify button next to tasks' checkbox: is disabled
Actual Result: 'Need Verification' checkbox is disabled in New workflow modal window
Expected Result: 'Need Verification' checkbox should not be disabled in New workflow modal window

# Solution description
Small fix on modal view: check whether status exists for current instance.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
