### PR TITLE
GGRC-3352 Disable to unmap people from Program for Global Reader

### DIFF
--- a/src/ggrc_basic_permissions/roles/Creator.py
+++ b/src/ggrc_basic_permissions/roles/Creator.py
@@ -10,7 +10,6 @@ owner_base = [
     "Categorization",
     "Category",
     "ControlCategory",
-    "ObjectPerson",
     "Option",
     {
         "type": "BackgroundTask",

--- a/test/integration/ggrc/models/factories.py
+++ b/test/integration/ggrc/models/factories.py
@@ -396,6 +396,13 @@ class FacilityFactory(TitledFactory):
     model = models.Facility
 
 
+class ObjectPersonFactory(ModelFactory):
+  """ObjectPerson factory class"""
+
+  class Meta:
+    model = models.ObjectPerson
+
+
 class ProductFactory(TitledFactory):
   """Product factory class"""
 


### PR DESCRIPTION
# Issue description

Global Reader (Program Reader) is able to Unmap users on People tab

# Steps to test the changes

1. Create program, map Global Creator to program
2. Map GR to program and grant Program Reader role
3. Log as Program Reader (globreader@gmail.com (engage007) and open program page
4. Go to People tab
5. Click on GC's first tier > 3 bb's menu > Unmap
Expected Result: Global Reader (Program Reader) should not be able to Unmap users on People tab

# Solution description

Create separate list of object permissions and used it for Creator/Reader delete

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
