### PR TITLE
GGRC-3691: Fix layout issue in Comparison modal

### DIFF
--- a/src/ggrc/assets/stylesheets/modules/_modal.scss
+++ b/src/ggrc/assets/stylesheets/modules/_modal.scss
@@ -718,7 +718,7 @@
      .info{
        border: 1px solid $warmGray;
        padding: 20px 15px;
-       width: 50%;
+       width: calc(50% - 30px);
        box-shadow: none;
        &:first-child{
          border-right: none;
@@ -749,6 +749,8 @@
          }
        }
        & ~ .info{
+         width: calc(50% - 30px);
+
          .diff-highlighted{
            background-color: $pastelGreen;
          }


### PR DESCRIPTION
# Issue description

Comparison modal is broken for objects with long titles

# Steps to test the changes
1. Have program, control with long title, audit
2. On the program page update control (e.g. description)
3. Refresh audit page > Control's tab
4. Open comparison window by clicking "Get the latest version"
5. Look at the comparison window

# Solution description
Reduce .info sections width in Comparison modal to appropriate value (take into account paddings).

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

![screenshot-1 2](https://user-images.githubusercontent.com/24203972/32405614-d4b5510a-c179-11e7-952b-d00a52cb579e.png)
