### PR TITLE
GGRC-3410 Not started (generated) assessment moves to In progress state.

### DIFF
--- a/src/ggrc/fulltext/mysql.py
+++ b/src/ggrc/fulltext/mysql.py
@@ -36,7 +36,7 @@ class MysqlRecordProperty(db.Model):
   tags = db.Column(db.String)
   property = db.Column(db.String(250), primary_key=True)
   subproperty = db.Column(db.String(64), primary_key=True)
-  content = db.Column(db.Text)
+  content = db.Column(db.Text, nullable=False, default=u"")
 
   @declared_attr
   def __table_args__(cls):  # pylint: disable=no-self-argument

--- a/src/ggrc/migrations/versions/20171122133459_14f51dd9affb_fix_text_fields_data.py
+++ b/src/ggrc/migrations/versions/20171122133459_14f51dd9affb_fix_text_fields_data.py
@@ -1,0 +1,52 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Set all 'text' fields NOT NULLABLE to all tables across the schema
+
+Create Date: 2017-11-22 13:34:59.264965
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+import sqlalchemy as sa
+from sqlalchemy.sql import text
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '14f51dd9affb'
+down_revision = '41f1fe4700d9'
+
+
+IGNORE_TABLES = {
+    "custom_attribute_definitions",
+}
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  connection = op.get_bind()
+  db_name = connection.engine.url.database
+  results = connection.execute(text(
+      """
+      SELECT TABLE_NAME, COLUMN_NAME FROM information_schema.columns
+      WHERE table_schema = :db_name
+      AND data_type = 'text'
+      AND is_nullable = 'YES';
+      """), db_name=db_name)
+  query = "UPDATE {table_name} SET {col_name}='' WHERE {col_name} IS NULL;"
+  for table_name, col_name in results:
+    if table_name in IGNORE_TABLES:
+      continue
+    print "Replacing null values in: {} - {}".format(table_name, col_name)
+    connection.execute(query.format(table_name=table_name,
+                                    col_name=col_name))
+    print "Setting filed to non-nullable: {} - {}".format(table_name, col_name)
+    op.alter_column(table_name, col_name, nullable=False,
+                    existing_type=sa.Text())
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  pass

--- a/src/ggrc/models/assessment_template.py
+++ b/src/ggrc/models/assessment_template.py
@@ -45,7 +45,7 @@ class AssessmentTemplate(assessment.AuditRelationship, relationship.Relatable,
   test_plan_procedure = db.Column(db.Boolean, nullable=False, default=False)
 
   # procedure description
-  procedure_description = db.Column(db.Text, nullable=True)
+  procedure_description = db.Column(db.Text, nullable=False, default=u"")
 
   # the people that should be assigned by default to each assessment created
   # within the releated audit

--- a/src/ggrc/models/clause.py
+++ b/src/ggrc/models/clause.py
@@ -37,7 +37,7 @@ class Clause(Roleable, HasObjectState, Hierarchical, CustomAttributable,
   # pylint: disable=invalid-name
   na = deferred(db.Column(db.Boolean, default=False, nullable=False),
                 'Clause')
-  notes = deferred(db.Column(db.Text), 'Clause')
+  notes = deferred(db.Column(db.Text, nullable=False, default=u""), 'Clause')
 
   _api_attrs = reflection.ApiAttributes('na', 'notes')
 

--- a/src/ggrc/models/comment.py
+++ b/src/ggrc/models/comment.py
@@ -150,7 +150,7 @@ class Comment(Roleable, Relatable, Described, Notifiable,
   """Basic comment model."""
   __tablename__ = "comments"
 
-  assignee_type = db.Column(db.String)
+  assignee_type = db.Column(db.String, nullable=False, default=u"")
   revision_id = deferred(db.Column(
       db.Integer,
       db.ForeignKey('revisions.id', ondelete='SET NULL'),

--- a/src/ggrc/models/context.py
+++ b/src/ggrc/models/context.py
@@ -17,7 +17,8 @@ class Context(Base, db.Model):
   #  for fulltext search leads to undesirable results
   @declared_attr
   def description(cls):  # pylint: disable=no-self-argument
-    return deferred(db.Column(db.Text), cls.__name__)
+    return deferred(db.Column(db.Text, nullable=False, default=u""),
+                    cls.__name__)
 
   name = deferred(db.Column(db.String(128), nullable=True), 'Context')
   related_object_id = deferred(

--- a/src/ggrc/models/control.py
+++ b/src/ggrc/models/control.py
@@ -160,7 +160,8 @@ class Control(WithLastAssessmentDate,
   kind_id = deferred(db.Column(db.Integer), 'Control')
   means_id = deferred(db.Column(db.Integer), 'Control')
   version = deferred(db.Column(db.String), 'Control')
-  documentation_description = deferred(db.Column(db.Text), 'Control')
+  documentation_description = deferred(db.Column(db.Text, nullable=False,
+                                                 default=u""), 'Control')
   verify_frequency_id = deferred(db.Column(db.Integer), 'Control')
   fraud_related = deferred(db.Column(db.Boolean), 'Control')
   key_control = deferred(db.Column(db.Boolean), 'Control')

--- a/src/ggrc/models/custom_attribute_value.py
+++ b/src/ggrc/models/custom_attribute_value.py
@@ -49,7 +49,7 @@ class CustomAttributeValue(Base, Indexed, db.Model):
   )
   attributable_id = db.Column(db.Integer)
   attributable_type = db.Column(db.String)
-  attribute_value = db.Column(db.String)
+  attribute_value = db.Column(db.String, nullable=False, default=u"")
 
   # When the attibute is of a mapping type this will hold the id of the mapped
   # object while attribute_value will hold the type name.

--- a/src/ggrc/models/directive.py
+++ b/src/ggrc/models/directive.py
@@ -33,7 +33,8 @@ class Directive(HasObjectState, LastDeprecatedTimeboxed,
 
   version = deferred(db.Column(db.String), 'Directive')
   organization = deferred(db.Column(db.String), 'Directive')
-  scope = deferred(db.Column(db.Text), 'Directive')
+  scope = deferred(db.Column(db.Text, nullable=False, default=u""),
+                   'Directive')
   kind_id = deferred(db.Column(db.Integer), 'Directive')
   audit_start_date = deferred(db.Column(db.DateTime), 'Directive')
   audit_frequency_id = deferred(db.Column(db.Integer), 'Directive')

--- a/src/ggrc/models/document.py
+++ b/src/ggrc/models/document.py
@@ -25,7 +25,8 @@ class Document(Roleable, Relatable, Base, Indexed, db.Model):
   # TODO: inherit from Titled mixin (note: title is nullable here)
   title = deferred(db.Column(db.String), 'Document')
   link = deferred(db.Column(db.String), 'Document')
-  description = deferred(db.Column(db.Text), 'Document')
+  description = deferred(db.Column(db.Text, nullable=False, default=u""),
+                         'Document')
   kind_id = db.Column(db.Integer, db.ForeignKey('options.id'), nullable=True)
   year_id = db.Column(db.Integer, db.ForeignKey('options.id'), nullable=True)
   language_id = db.Column(db.Integer, db.ForeignKey('options.id'),

--- a/src/ggrc/models/help.py
+++ b/src/ggrc/models/help.py
@@ -11,7 +11,7 @@ class Help(Titled, Slugged, db.Model):
   __tablename__ = 'helps'
   _title_uniqueness = False
 
-  content = deferred(db.Column(db.Text), 'Help')
+  content = deferred(db.Column(db.Text, nullable=False, default=u""), 'Help')
 
   _fulltext_attrs = [
       'content',

--- a/src/ggrc/models/issuetracker_issue.py
+++ b/src/ggrc/models/issuetracker_issue.py
@@ -23,7 +23,7 @@ class IssuetrackerIssue(Base, db.Model):
   issue_priority = db.Column(db.String(50), nullable=True)
   issue_severity = db.Column(db.String(50), nullable=True)
   assignee = db.Column(db.String(250), nullable=True)
-  cc_list = db.Column(db.Text, nullable=True)
+  cc_list = db.Column(db.Text, nullable=False, default="")
 
   issue_id = db.Column(db.String(50), nullable=True)
   issue_url = db.Column(db.String(250), nullable=True)

--- a/src/ggrc/models/mixins/__init__.py
+++ b/src/ggrc/models/mixins/__init__.py
@@ -231,7 +231,8 @@ class Described(object):
 
   @declared_attr
   def description(cls):  # pylint: disable=no-self-argument
-    return deferred(db.Column(db.Text), cls.__name__)
+    return deferred(db.Column(db.Text, nullable=False, default=u""),
+                    cls.__name__)
 
   # REST properties
   _api_attrs = reflection.ApiAttributes('description')
@@ -251,7 +252,8 @@ class Noted(object):
 
   @declared_attr
   def notes(cls):  # pylint: disable=no-self-argument
-    return deferred(db.Column(db.Text), cls.__name__)
+    return deferred(db.Column(db.Text, nullable=False, default=u""),
+                    cls.__name__)
 
   # REST properties
   _api_attrs = reflection.ApiAttributes('notes')
@@ -906,7 +908,8 @@ class TestPlanned(object):
 
   @declared_attr
   def test_plan(cls):  # pylint: disable=no-self-argument
-    return deferred(db.Column(db.Text), cls.__name__)
+    return deferred(db.Column(db.Text, nullable=False, default=u""),
+                    cls.__name__)
 
   # REST properties
   _api_attrs = reflection.ApiAttributes('test_plan')

--- a/src/ggrc/models/notification.py
+++ b/src/ggrc/models/notification.py
@@ -51,7 +51,7 @@ class Notification(Base, db.Model):
   object_type = db.Column(db.String, nullable=False)
   send_on = db.Column(db.DateTime, nullable=False)
   sent_at = db.Column(db.DateTime, nullable=True)
-  custom_message = db.Column(db.Text, nullable=True)
+  custom_message = db.Column(db.Text, nullable=False, default=u"")
   force_notifications = db.Column(db.Boolean, default=False, nullable=False)
   repeating = db.Column(db.Boolean, nullable=False, default=False)
   notification_type_id = db.Column(

--- a/src/ggrc/models/object_person.py
+++ b/src/ggrc/models/object_person.py
@@ -16,7 +16,8 @@ class ObjectPerson(Timeboxed, Base, db.Model):
   __tablename__ = 'object_people'
 
   role = deferred(db.Column(db.String), 'ObjectPerson')
-  notes = deferred(db.Column(db.Text), 'ObjectPerson')
+  notes = deferred(db.Column(db.Text, nullable=False, default=u""),
+                   'ObjectPerson')
   person_id = db.Column(db.Integer, db.ForeignKey('people.id'), nullable=False)
   personable_id = db.Column(db.Integer, nullable=False)
   personable_type = db.Column(db.String, nullable=False)

--- a/src/ggrc/models/section.py
+++ b/src/ggrc/models/section.py
@@ -37,7 +37,7 @@ class Section(Roleable, HasObjectState, Hierarchical, db.Model,
 
   na = deferred(db.Column(db.Boolean, default=False, nullable=False),
                 'Section')
-  notes = deferred(db.Column(db.Text), 'Section')
+  notes = deferred(db.Column(db.Text, nullable=False, default=u""), 'Section')
 
   _api_attrs = reflection.ApiAttributes('na', 'notes')
   _sanitize_html = ['notes']

--- a/src/ggrc_risks/models/risk.py
+++ b/src/ggrc_risks/models/risk.py
@@ -30,7 +30,8 @@ class Risk(Roleable, HasObjectState, mixins.CustomAttributable, Relatable,
   # Overriding mixin to make mandatory
   @declared_attr
   def description(cls):  # pylint: disable=no-self-argument
-    return deferred(db.Column(db.Text, nullable=False), cls.__name__)
+    return deferred(db.Column(db.Text, nullable=False, default=u""),
+                    cls.__name__)
 
   risk_objects = db.relationship(
       'RiskObject', backref='risk', cascade='all, delete-orphan')
@@ -42,6 +43,9 @@ class Risk(Roleable, HasObjectState, mixins.CustomAttributable, Relatable,
   )
 
   _aliases = {
+      "description": {
+          "display_name": "Description",
+          "mandatory": True},
       "document_url": None,
       "document_evidence": None,
       "status": {

--- a/src/ggrc_workflows/models/workflow.py
+++ b/src/ggrc_workflows/models/workflow.py
@@ -59,7 +59,7 @@ class Workflow(mixins.CustomAttributable,
   notify_on_change = deferred(
       db.Column(db.Boolean, default=False, nullable=False), 'Workflow')
   notify_custom_message = deferred(
-      db.Column(db.Text, nullable=True), 'Workflow')
+      db.Column(db.Text, nullable=False, default=u""), 'Workflow')
 
   object_approval = deferred(
       db.Column(db.Boolean, default=False, nullable=False), 'Workflow')

--- a/test/integration/ggrc/converters/test_import_commentable.py
+++ b/test/integration/ggrc/converters/test_import_commentable.py
@@ -64,8 +64,8 @@ class TestCommentableImport(TestCase):
     model_cls = inflector.get_model(model_name)
     if issubclass(model_cls, AuditRelationship):
       import_data.append(("Map:Audit", audit))
-    if issubclass(model_cls, Described) and \
-       "description" not in model_cls._aliases:
+    if (issubclass(model_cls, Described) and
+       "description" not in model_cls._aliases) or model_name == "Risk":
       import_data.append(("description", "{}-Description".format(model_name)))
     response = self.import_data(OrderedDict(import_data))
     self._check_csv_response(response, {})

--- a/test/integration/ggrc/models/test_assessment.py
+++ b/test/integration/ggrc/models/test_assessment.py
@@ -1161,3 +1161,26 @@ class TestAssessmentGeneration(TestAssessmentBase):
       self.assertEqual(assessment.assessment_type, exp_type)
     else:
       self.assertEqual(response.status_code, 400)
+
+  def test_changing_text_fields_should_not_change_status(self):
+    """Test Assessment does not change status if 'design', 'operationally',
+    'notes' posted as empty strings
+    """
+    test_state = "START_STATE"
+    response = self.assessment_post()
+    self.assertEqual(response.status_code, 201)
+    asmt = all_models.Assessment.query.one()
+    self.assertEqual(asmt.status,
+                     getattr(all_models.Assessment, test_state))
+    response = self.assessment_post(
+        extra_data={
+            "id": asmt.id,
+            "design": "",
+            "operationally": "",
+            "notes": ""
+        }
+    )
+    self.assertEqual(response.status_code, 201)
+    assessment = self.refresh_object(asmt)
+    self.assertEqual(assessment.status,
+                     getattr(all_models.Assessment, test_state))


### PR DESCRIPTION
# Issue description

Not started assessment moves to In progress state if open Edit assessment modal window and w/o any updates click Save

# Steps to test the changes

Steps to reproduce:
1. Have an audit with a control snapshot
2. Generate assessment based on a control snapshot screenshot-2.png
3. In the Assessment tab invoke Edit Assessment modal window screenshot-3.png
4. Do not update assessment and click Save and Close button. Look at the state of Assessment screenshot-4.png
Actual Result: Assessment changed a state from Not started to In progress
Expected Result: Assessment should not change a state from Not started to In progress

# Solution description

The issue appeared because of the difference in the data stored in the database and the data being posted in the PR. For example, let's have a text field which is represented as NULLABLE TEXT in the database. If it has no value and is stored as NULL, front-end tries to post the data with this particular field represented as "" (empty string). Back-end evaluates this as a mismatch and moved Assessment to "In progress" state.
And since TEXT field in MySQL can not have a default value (like design/operationally asmt fields), the solution was to add a validator for "Notes" field in Assessment. And it always converts empty data to None. Along with the migration converting all empty strings in Notes field to NULLs.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] db_reset runs without errors or warnings.
- [ ] db_reset ggrc-qa.sql runs without errors or warnings.
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
