### PR TITLE
GGRC-3749 Extra 'undo' button is displayed for Assessment

### DIFF
--- a/src/ggrc/assets/javascripts/components/object-state-toolbar/object-state-toolbar.js
+++ b/src/ggrc/assets/javascripts/components/object-state-toolbar/object-state-toolbar.js
@@ -65,6 +65,9 @@
       isInReview: function () {
         return this.attr('instance.status') === 'In Review';
       },
+      hasPreviousState: function () {
+        return !!this.attr('instance.previousStatus');
+      },
       changeState: function (newState, isUndo) {
         if (this.attr('isDisabled')) {
           if (this.attr('instance.hasValidationErrors')) {

--- a/src/ggrc/assets/javascripts/components/object-state-toolbar/tests/object-state-toolbar_spec.js
+++ b/src/ggrc/assets/javascripts/components/object-state-toolbar/tests/object-state-toolbar_spec.js
@@ -1,0 +1,24 @@
+/*
+  Copyright (C) 2017 Google Inc., authors, and contributors
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+describe('GGRC.Components.objectStateToolbar', function () {
+  let vm;
+
+  beforeEach(function () {
+    vm = GGRC.Components.getViewModel('objectStateToolbar');
+  });
+
+  describe('hasPreviousState() method', function () {
+    it('returns true if instance has previous state', function () {
+      vm.attr('instance.previousStatus', 'In Progress');
+      expect(vm.hasPreviousState()).toBe(true);
+    });
+
+    it('returns false if instance has not previous state', function () {
+      vm.attr('instance.previousStatus', undefined);
+      expect(vm.hasPreviousState()).toBe(false);
+    });
+  });
+});

--- a/src/ggrc/assets/mustache/components/object-state-toolbar/object-state-toolbar.mustache
+++ b/src/ggrc/assets/mustache/components/object-state-toolbar/object-state-toolbar.mustache
@@ -19,10 +19,10 @@
     {{/if}}
   {{/if}}
   {{#unless isInProgress}}
-    {{#instance.previousStatus}}
+      {{#if hasPreviousState}}
         <button class="btn btn-small btn-link object-state-toolbar__item"
                 ($click)="changeState('In Progress', true)">Undo
         </button>
-    {{/instance._undo.0}}
+      {{/if}}
   {{/unless}}
 </div>


### PR DESCRIPTION
# Issue description

When we change state of assessment then `undo` buttons appears. If after this we click `next` or `prev` button and move to other assessment and if its state is not `In Progress` then `undo` button appears only on section with local CA, despite the fact that the assessment was not changed.

![image](https://user-images.githubusercontent.com/10946494/32540800-d879753e-c47e-11e7-8407-c9cac54fa5f7.png)

# Steps to test the changes

Steps to reproduce:
1. Have at least 3 assessments in 1. 'In progress', 2. 'In review', 3. 'Not started' states on the audit page
2. Expand Info pane for 'Not started' assessment and complete it
3. Click 'Next'/'Prev' button
4. Look at the Info pane of Assessment 'In review': 'undo' button is displayed but no changes have been made for such assessment

*Actual Result:* Extra 'undo' button is displayed for Assessment
*Expected Result:* Extra 'undo' button should not be displayed for Assessment

# Solution description

Add method hasPreviousState which return boolean value: `true` if there is previous state, otherwise `false`. The value will be recalculated if an instance is changed.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] db_reset runs without errors or warnings.
- [ ] db_reset ggrc-qa.sql runs without errors or warnings.
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
