### PR TITLE
GGRC-3756 Migrate advanced search utils on module syntax

### DIFF
--- a/src/ggrc/assets/javascripts/components/advanced-search/advanced-search-filter-container.js
+++ b/src/ggrc/assets/javascripts/components/advanced-search/advanced-search-filter-container.js
@@ -8,6 +8,7 @@ import './advanced-search-filter-group';
 import './advanced-search-filter-operator';
 import './advanced-search-filter-state';
 import * as StateUtils from '../../plugins/utils/state-utils';
+import * as AdvancedSearch from '../../plugins/utils/advanced-search-utils';
 
 (function (can, GGRC) {
   'use strict';
@@ -33,7 +34,7 @@ import * as StateUtils from '../../plugins/utils/state-utils';
         get: function (items) {
           if (this.attr('defaultStatusFilter') && items && !items.length &&
             StateUtils.hasFilter(this.attr('modelName'))) {
-            items.push(GGRC.Utils.AdvancedSearch.create.state());
+            items.push(AdvancedSearch.create.state());
           }
           return items;
         }
@@ -73,9 +74,9 @@ import * as StateUtils from '../../plugins/utils/state-utils';
     addFilterCriterion: function () {
       var items = this.attr('items');
       if (items.length) {
-        items.push(GGRC.Utils.AdvancedSearch.create.operator('AND'));
+        items.push(AdvancedSearch.create.operator('AND'));
       }
-      items.push(GGRC.Utils.AdvancedSearch.create.attribute());
+      items.push(AdvancedSearch.create.attribute());
     },
     /**
      * Transforms Filter Attribute to Filter Group.
@@ -84,10 +85,10 @@ import * as StateUtils from '../../plugins/utils/state-utils';
     createGroup: function (attribute) {
       var items = this.attr('items');
       var index = items.indexOf(attribute);
-      items.attr(index, GGRC.Utils.AdvancedSearch.create.group([
+      items.attr(index, AdvancedSearch.create.group([
         attribute,
-        GGRC.Utils.AdvancedSearch.create.operator('AND'),
-        GGRC.Utils.AdvancedSearch.create.attribute()
+        AdvancedSearch.create.operator('AND'),
+        AdvancedSearch.create.attribute()
       ]));
     }
   });

--- a/src/ggrc/assets/javascripts/components/advanced-search/advanced-search-filter-group.js
+++ b/src/ggrc/assets/javascripts/components/advanced-search/advanced-search-filter-group.js
@@ -3,6 +3,8 @@
  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  */
 
+import * as AdvancedSearch from '../../plugins/utils/advanced-search-utils';
+
 (function (can, GGRC) {
   'use strict';
 
@@ -25,8 +27,8 @@
      */
     addFilterCriterion: function () {
       var items = this.attr('items');
-      items.push(GGRC.Utils.AdvancedSearch.create.operator('AND'));
-      items.push(GGRC.Utils.AdvancedSearch.create.attribute());
+      items.push(AdvancedSearch.create.operator('AND'));
+      items.push(AdvancedSearch.create.attribute());
     }
   });
 

--- a/src/ggrc/assets/javascripts/components/advanced-search/advanced-search-mapping-container.js
+++ b/src/ggrc/assets/javascripts/components/advanced-search/advanced-search-mapping-container.js
@@ -6,6 +6,7 @@
 import './advanced-search-mapping-group';
 import './advanced-search-mapping-criteria';
 import './advanced-search-filter-operator';
+import * as AdvancedSearch from '../../plugins/utils/advanced-search-utils';
 
 (function (can, GGRC) {
   'use strict';
@@ -34,9 +35,9 @@ import './advanced-search-filter-operator';
     addMappingCriteria: function () {
       var items = this.attr('items');
       if (items.length) {
-        items.push(GGRC.Utils.AdvancedSearch.create.operator('AND'));
+        items.push(AdvancedSearch.create.operator('AND'));
       }
-      items.push(GGRC.Utils.AdvancedSearch.create.mappingCriteria());
+      items.push(AdvancedSearch.create.mappingCriteria());
     },
     /**
      * Transforms Mapping Criteria to Mapping Group.
@@ -45,10 +46,10 @@ import './advanced-search-filter-operator';
     createGroup: function (criteria) {
       var items = this.attr('items');
       var index = items.indexOf(criteria);
-      items.attr(index, GGRC.Utils.AdvancedSearch.create.group([
+      items.attr(index, AdvancedSearch.create.group([
         criteria,
-        GGRC.Utils.AdvancedSearch.create.operator('AND'),
-        GGRC.Utils.AdvancedSearch.create.mappingCriteria()
+        AdvancedSearch.create.operator('AND'),
+        AdvancedSearch.create.mappingCriteria()
       ]));
     },
     /**

--- a/src/ggrc/assets/javascripts/components/advanced-search/advanced-search-mapping-criteria.js
+++ b/src/ggrc/assets/javascripts/components/advanced-search/advanced-search-mapping-criteria.js
@@ -4,6 +4,7 @@
  */
 
 import {getColumnsForModel} from '../../plugins/utils/tree-view-utils';
+import * as AdvancedSearch from '../../plugins/utils/advanced-search-utils';
 
 (function (can, GGRC, CMS) {
   'use strict';
@@ -30,7 +31,7 @@ import {getColumnsForModel} from '../../plugins/utils/tree-view-utils';
         set: function (criteria) {
           if (!criteria.filter) {
             criteria.attr('filter',
-              GGRC.Utils.AdvancedSearch.create.attribute());
+              AdvancedSearch.create.attribute());
           }
           return criteria;
         }
@@ -159,7 +160,7 @@ import {getColumnsForModel} from '../../plugins/utils/tree-view-utils';
      */
     addRelevant: function () {
       this.attr('criteria.mappedTo',
-        GGRC.Utils.AdvancedSearch.create.mappingCriteria());
+        AdvancedSearch.create.mappingCriteria());
     },
     /**
      * Removes the child Mapping Criteria.
@@ -172,10 +173,10 @@ import {getColumnsForModel} from '../../plugins/utils/tree-view-utils';
      */
     relevantToGroup: function () {
       this.attr('criteria.mappedTo',
-        GGRC.Utils.AdvancedSearch.create.group([
+        AdvancedSearch.create.group([
           this.attr('criteria.mappedTo'),
-          GGRC.Utils.AdvancedSearch.create.operator('AND'),
-          GGRC.Utils.AdvancedSearch.create.mappingCriteria()
+          AdvancedSearch.create.operator('AND'),
+          AdvancedSearch.create.mappingCriteria()
         ]));
     }
   });

--- a/src/ggrc/assets/javascripts/components/advanced-search/advanced-search-mapping-group.js
+++ b/src/ggrc/assets/javascripts/components/advanced-search/advanced-search-mapping-group.js
@@ -3,6 +3,8 @@
  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  */
 
+import * as AdvancedSearch from '../../plugins/utils/advanced-search-utils';
+
 (function (can, GGRC) {
   'use strict';
 
@@ -33,8 +35,8 @@
      */
     addMappingCriteria: function () {
       var items = this.attr('items');
-      items.push(GGRC.Utils.AdvancedSearch.create.operator('AND'));
-      items.push(GGRC.Utils.AdvancedSearch.create.mappingCriteria());
+      items.push(AdvancedSearch.create.operator('AND'));
+      items.push(AdvancedSearch.create.mappingCriteria());
     }
   });
 

--- a/src/ggrc/assets/javascripts/components/advanced-search/advanced-search-wrapper.js
+++ b/src/ggrc/assets/javascripts/components/advanced-search/advanced-search-wrapper.js
@@ -5,6 +5,7 @@
 
 import * as StateUtils from '../../plugins/utils/state-utils';
 import {getColumnsForModel} from '../../plugins/utils/tree-view-utils';
+import * as AdvancedSearch from '../../plugins/utils/advanced-search-utils';
 
 (function (can, GGRC) {
   'use strict';
@@ -23,7 +24,7 @@ import {getColumnsForModel} from '../../plugins/utils/tree-view-utils';
       modelDisplayName: null,
       filterItems: [],
       mappingItems: [],
-      statusItem: GGRC.Utils.AdvancedSearch.create.state(),
+      statusItem: AdvancedSearch.create.state(),
       relevantTo: [],
       availableAttributes: function () {
         var available = getColumnsForModel(
@@ -36,16 +37,16 @@ import {getColumnsForModel} from '../../plugins/utils/tree-view-utils';
       addFilterAttribute: function () {
         var items = this.attr('filterItems');
         if (items.length) {
-          items.push(GGRC.Utils.AdvancedSearch.create.operator('AND'));
+          items.push(AdvancedSearch.create.operator('AND'));
         }
-        items.push(GGRC.Utils.AdvancedSearch.create.attribute());
+        items.push(AdvancedSearch.create.attribute());
       },
       addMappingFilter: function () {
         var items = this.attr('mappingItems');
         if (items.length) {
-          items.push(GGRC.Utils.AdvancedSearch.create.operator('AND'));
+          items.push(AdvancedSearch.create.operator('AND'));
         }
-        items.push(GGRC.Utils.AdvancedSearch.create.mappingCriteria());
+        items.push(AdvancedSearch.create.mappingCriteria());
       },
       resetFilters: function () {
         this.attr('filterItems', []);

--- a/src/ggrc/assets/javascripts/components/advanced-search/tests/advanced-search-filter-container_spec.js
+++ b/src/ggrc/assets/javascripts/components/advanced-search/tests/advanced-search-filter-container_spec.js
@@ -4,6 +4,7 @@
 */
 
 import * as StateUtils from '../../../plugins/utils/state-utils';
+import * as AdvancedSearch from '../../../plugins/utils/advanced-search-utils';
 
 describe('GGRC.Components.advancedSearchFilterContainer', function () {
   'use strict';
@@ -45,7 +46,7 @@ describe('GGRC.Components.advancedSearchFilterContainer', function () {
     it('adds operator and attribute', function () {
       var items;
       viewModel.attr('items',
-        [GGRC.Utils.AdvancedSearch.create.attribute()]);
+        [AdvancedSearch.create.attribute()]);
 
       viewModel.addFilterCriterion();
 
@@ -62,9 +63,9 @@ describe('GGRC.Components.advancedSearchFilterContainer', function () {
     function () {
       var viewItems;
       viewModel.attr('items', new can.List([
-        GGRC.Utils.AdvancedSearch.create.attribute({field: 'first'}),
-        GGRC.Utils.AdvancedSearch.create.operator(),
-        GGRC.Utils.AdvancedSearch.create.attribute({field: 'second'})
+        AdvancedSearch.create.attribute({field: 'first'}),
+        AdvancedSearch.create.operator(),
+        AdvancedSearch.create.attribute({field: 'second'})
       ]));
       viewItems = viewModel.attr('items');
 

--- a/src/ggrc/assets/javascripts/components/advanced-search/tests/advanced-search-filter-group_spec.js
+++ b/src/ggrc/assets/javascripts/components/advanced-search/tests/advanced-search-filter-group_spec.js
@@ -3,6 +3,8 @@
   Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 */
 
+import * as AdvancedSearch from '../../../plugins/utils/advanced-search-utils';
+
 describe('GGRC.Components.advancedSearchFilterGroup', function () {
   'use strict';
 
@@ -15,7 +17,7 @@ describe('GGRC.Components.advancedSearchFilterGroup', function () {
   describe('addFilterCriterion() method', function () {
     it('adds operator and attribute', function () {
       var items;
-      viewModel.attr('items', [GGRC.Utils.AdvancedSearch.create.attribute()]);
+      viewModel.attr('items', [AdvancedSearch.create.attribute()]);
       viewModel.addFilterCriterion();
 
       items = viewModel.attr('items');

--- a/src/ggrc/assets/javascripts/components/advanced-search/tests/advanced-search-mapping-container_spec.js
+++ b/src/ggrc/assets/javascripts/components/advanced-search/tests/advanced-search-mapping-container_spec.js
@@ -3,6 +3,8 @@
   Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 */
 
+import * as AdvancedSearch from '../../../plugins/utils/advanced-search-utils';
+
 describe('GGRC.Components.advancedSearchMappingContainer', function () {
   'use strict';
 
@@ -27,7 +29,7 @@ describe('GGRC.Components.advancedSearchMappingContainer', function () {
     it('adds operator and criteria if list is not empty', function () {
       var items;
       viewModel.attr('items',
-        [GGRC.Utils.AdvancedSearch.create.mappingCriteria()]);
+        [AdvancedSearch.create.mappingCriteria()]);
       viewModel.addMappingCriteria();
 
       items = viewModel.attr('items');
@@ -43,9 +45,9 @@ describe('GGRC.Components.advancedSearchMappingContainer', function () {
     function () {
       var viewItems;
       viewModel.attr('items', new can.List([
-        GGRC.Utils.AdvancedSearch.create.mappingCriteria({field: 'first'}),
-        GGRC.Utils.AdvancedSearch.create.operator(),
-        GGRC.Utils.AdvancedSearch.create.mappingCriteria({field: 'second'})
+        AdvancedSearch.create.mappingCriteria({field: 'first'}),
+        AdvancedSearch.create.operator(),
+        AdvancedSearch.create.mappingCriteria({field: 'second'})
       ]));
       viewItems = viewModel.attr('items');
 

--- a/src/ggrc/assets/javascripts/components/advanced-search/tests/advanced-search-mapping-criteria_spec.js
+++ b/src/ggrc/assets/javascripts/components/advanced-search/tests/advanced-search-mapping-criteria_spec.js
@@ -4,6 +4,7 @@
 */
 
 import * as TreeViewUtils from '../../../plugins/utils/tree-view-utils';
+import * as AdvancedSearch from '../../../plugins/utils/advanced-search-utils';
 
 describe('GGRC.Components.advancedSearchMappingCriteria', function () {
   'use strict';
@@ -81,7 +82,7 @@ describe('GGRC.Components.advancedSearchMappingCriteria', function () {
     function () {
       var relevant;
       viewModel.attr('criteria.mappedTo',
-        GGRC.Utils.AdvancedSearch.create.mappingCriteria()
+        AdvancedSearch.create.mappingCriteria()
       );
 
       viewModel.relevantToGroup();

--- a/src/ggrc/assets/javascripts/components/advanced-search/tests/advanced-search-mapping-group_spec.js
+++ b/src/ggrc/assets/javascripts/components/advanced-search/tests/advanced-search-mapping-group_spec.js
@@ -3,6 +3,8 @@
   Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 */
 
+import * as AdvancedSearch from '../../../plugins/utils/advanced-search-utils';
+
 describe('GGRC.Components.advancedSearchMappingGroup', function () {
   'use strict';
 
@@ -16,7 +18,7 @@ describe('GGRC.Components.advancedSearchMappingGroup', function () {
     it('adds operator and criteria', function () {
       var items;
       viewModel.attr('items',
-        [GGRC.Utils.AdvancedSearch.create.mappingCriteria()]);
+        [AdvancedSearch.create.mappingCriteria()]);
       viewModel.addMappingCriteria();
 
       items = viewModel.attr('items');

--- a/src/ggrc/assets/javascripts/components/tree/tests/tree-widget-container_spec.js
+++ b/src/ggrc/assets/javascripts/components/tree/tests/tree-widget-container_spec.js
@@ -5,6 +5,7 @@
 
 import * as TreeViewUtils from '../../../plugins/utils/tree-view-utils';
 import * as SnapshotUtils from '../../../plugins/utils/snapshot-utils';
+import * as AdvancedSearch from '../../../plugins/utils/advanced-search-utils';
 
 describe('GGRC.Components.treeWidgetContainer', function () {
   'use strict';
@@ -455,11 +456,11 @@ describe('GGRC.Components.treeWidgetContainer', function () {
   describe('openAdvancedFilter() method', function () {
     it('copies applied filter and mapping items', function () {
       var appliedFilterItems = new can.List([
-        GGRC.Utils.AdvancedSearch.create.attribute()
+        AdvancedSearch.create.attribute()
       ]);
       var appliedMappingItems = new can.List([
-        GGRC.Utils.AdvancedSearch.create.mappingCriteria({
-          filter: GGRC.Utils.AdvancedSearch.create.attribute()
+        AdvancedSearch.create.mappingCriteria({
+          filter: AdvancedSearch.create.attribute()
         })
       ]);
       vm.attr('advancedSearch.appliedFilterItems', appliedFilterItems);
@@ -486,11 +487,11 @@ describe('GGRC.Components.treeWidgetContainer', function () {
 
   describe('applyAdvancedFilters() method', function () {
     var filterItems = new can.List([
-      GGRC.Utils.AdvancedSearch.create.attribute()
+      AdvancedSearch.create.attribute()
     ]);
     var mappingItems = new can.List([
-      GGRC.Utils.AdvancedSearch.create.mappingCriteria({
-        filter: GGRC.Utils.AdvancedSearch.create.attribute()
+      AdvancedSearch.create.mappingCriteria({
+        filter: AdvancedSearch.create.attribute()
       })
     ]);
     beforeEach(function () {
@@ -499,7 +500,7 @@ describe('GGRC.Components.treeWidgetContainer', function () {
       vm.attr('advancedSearch.appliedFilterItems', can.List());
       vm.attr('advancedSearch.appliedMappingItems', can.List());
       spyOn(vm, 'onFilter');
-      spyOn(GGRC.Utils.AdvancedSearch, 'buildFilter')
+      spyOn(AdvancedSearch, 'buildFilter')
         .and.callFake(function (items, request) {
           request.push({name: 'item'});
         });

--- a/src/ggrc/assets/javascripts/components/tree/tree-widget-container.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-widget-container.js
@@ -33,6 +33,7 @@ import {
 } from '../../plugins/utils/snapshot-utils';
 import {REFRESH_RELATED} from '../../events/eventTypes';
 import * as TreeViewUtils from '../../plugins/utils/tree-view-utils';
+import * as AdvancedSearch from '../../plugins/utils/advanced-search-utils';
 
 var CurrentPageUtils = GGRC.Utils.CurrentPage;
 var viewModel;
@@ -602,9 +603,9 @@ viewModel = can.Map.extend({
 
     advancedFilters = GGRC.query_parser.join_queries(
       GGRC.query_parser
-        .parse(GGRC.Utils.AdvancedSearch.buildFilter(filters, request)),
+        .parse(AdvancedSearch.buildFilter(filters, request)),
       GGRC.query_parser
-        .parse(GGRC.Utils.AdvancedSearch.buildFilter(mappings, request))
+        .parse(AdvancedSearch.buildFilter(mappings, request))
     );
     this.attr('advancedSearch.request', request);
 

--- a/src/ggrc/assets/javascripts/components/unified-mapper/mapper-results.js
+++ b/src/ggrc/assets/javascripts/components/unified-mapper/mapper-results.js
@@ -13,6 +13,7 @@ import {
   transformQuery,
   toObject,
 } from '../../plugins/utils/snapshot-utils';
+import * as AdvancedSearch from '../../plugins/utils/advanced-search-utils';
 
 const DEFAULT_PAGE_SIZE = 5;
 
@@ -167,17 +168,17 @@ export default GGRC.Components('mapperResults', {
       var request = [];
       var status;
       var filters = GGRC.query_parser.parse(
-        GGRC.Utils.AdvancedSearch.buildFilter(this.attr('filterItems'),
+        AdvancedSearch.buildFilter(this.attr('filterItems'),
         request));
       var mappings = GGRC.query_parser.parse(
-        GGRC.Utils.AdvancedSearch.buildFilter(this.attr('mappingItems'),
+        AdvancedSearch.buildFilter(this.attr('mappingItems'),
         request));
       var advancedFilters = GGRC.query_parser.join_queries(filters, mappings);
 
       // the edge case caused by stateless objects
       if (this.attr('statusItem.value.items')) {
         status = GGRC.query_parser.parse(
-          GGRC.Utils.AdvancedSearch.buildFilter([this.attr('statusItem')],
+          AdvancedSearch.buildFilter([this.attr('statusItem')],
           request));
         advancedFilters = GGRC.query_parser
           .join_queries(advancedFilters, status);

--- a/src/ggrc/assets/javascripts/components/unified-mapper/tests/mapper-results_spec.js
+++ b/src/ggrc/assets/javascripts/components/unified-mapper/tests/mapper-results_spec.js
@@ -5,6 +5,7 @@
 
 import * as TreeViewUtils from '../../../plugins/utils/tree-view-utils';
 import * as SnapshotUtils from '../../../plugins/utils/snapshot-utils';
+import * as AdvancedSearch from '../../../plugins/utils/advanced-search-utils';
 
 describe('GGRC.Components.mapperResults', function () {
   'use strict';
@@ -332,26 +333,26 @@ describe('GGRC.Components.mapperResults', function () {
 
       spyOn(GGRC.Utils.QueryAPI, 'buildParam')
         .and.returnValue({});
-      spyOn(GGRC.Utils.AdvancedSearch, 'buildFilter');
+      spyOn(AdvancedSearch, 'buildFilter');
       spyOn(GGRC.query_parser, 'parse');
       spyOn(GGRC.query_parser, 'join_queries');
     });
 
     it('builds advanced filters', function () {
       viewModel.getQuery('values', true);
-      expect(GGRC.Utils.AdvancedSearch.buildFilter.calls.argsFor(0)[0].attr())
+      expect(AdvancedSearch.buildFilter.calls.argsFor(0)[0].attr())
         .toEqual(mockFilterItems);
     });
 
     it('builds advanced mappings', function () {
       viewModel.getQuery('values', true);
-      expect(GGRC.Utils.AdvancedSearch.buildFilter.calls.argsFor(1)[0].attr())
+      expect(AdvancedSearch.buildFilter.calls.argsFor(1)[0].attr())
         .toEqual(mockMappingItems);
     });
 
     it('builds advanced status', function () {
       viewModel.getQuery('values', true);
-      expect(GGRC.Utils.AdvancedSearch.buildFilter.calls.argsFor(2)[0][0])
+      expect(AdvancedSearch.buildFilter.calls.argsFor(2)[0][0])
         .toEqual(mockStatusItem);
     });
 
@@ -359,7 +360,7 @@ describe('GGRC.Components.mapperResults', function () {
     function () {
       viewModel.attr('statusItem', {});
       viewModel.getQuery('values', true);
-      expect(GGRC.Utils.AdvancedSearch.buildFilter.calls.count()).toBe(2);
+      expect(AdvancedSearch.buildFilter.calls.count()).toBe(2);
     });
 
     it('adds paging to query if addPaging is true', function () {

--- a/src/ggrc/assets/javascripts/components/view-models/tests/advanced-search-container-vm_spec.js
+++ b/src/ggrc/assets/javascripts/components/view-models/tests/advanced-search-container-vm_spec.js
@@ -3,6 +3,8 @@
   Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 */
 
+import * as AdvancedSearch from '../../../plugins/utils/advanced-search-utils';
+
 describe('GGRC.VM.AdvancedSearchContainer', function () {
   'use strict';
 
@@ -17,9 +19,9 @@ describe('GGRC.VM.AdvancedSearchContainer', function () {
     function () {
       var viewItems;
       viewModel.attr('items', [
-        GGRC.Utils.AdvancedSearch.create.attribute({field: 'first'}),
-        GGRC.Utils.AdvancedSearch.create.operator(),
-        GGRC.Utils.AdvancedSearch.create.attribute({field: 'second'})
+        AdvancedSearch.create.attribute({field: 'first'}),
+        AdvancedSearch.create.operator(),
+        AdvancedSearch.create.attribute({field: 'second'})
       ]);
       viewItems = viewModel.attr('items');
 
@@ -34,9 +36,9 @@ describe('GGRC.VM.AdvancedSearchContainer', function () {
     function () {
       var viewItems;
       viewModel.attr('items', [
-        GGRC.Utils.AdvancedSearch.create.attribute({field: 'first'}),
-        GGRC.Utils.AdvancedSearch.create.operator(),
-        GGRC.Utils.AdvancedSearch.create.attribute({field: 'second'})
+        AdvancedSearch.create.attribute({field: 'first'}),
+        AdvancedSearch.create.operator(),
+        AdvancedSearch.create.attribute({field: 'second'})
       ]);
       viewItems = viewModel.attr('items');
 
@@ -51,7 +53,7 @@ describe('GGRC.VM.AdvancedSearchContainer', function () {
     function () {
       var viewItems;
       viewModel.attr('items', [
-        GGRC.Utils.AdvancedSearch.create.attribute({field: 'single'})
+        AdvancedSearch.create.attribute({field: 'single'})
       ]);
       viewItems = viewModel.attr('items');
       spyOn(viewModel, 'remove');
@@ -66,7 +68,7 @@ describe('GGRC.VM.AdvancedSearchContainer', function () {
     function () {
       var viewItems;
       viewModel.attr('items', [
-        GGRC.Utils.AdvancedSearch.create.attribute({field: 'single'})
+        AdvancedSearch.create.attribute({field: 'single'})
       ]);
       viewItems = viewModel.attr('items');
       spyOn(viewModel, 'remove');

--- a/src/ggrc/assets/javascripts/plugins/tests/advanced-search-utils_spec.js
+++ b/src/ggrc/assets/javascripts/plugins/tests/advanced-search-utils_spec.js
@@ -3,13 +3,15 @@
   Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 */
 
+import * as AdvancedSearch from '../../plugins/utils/advanced-search-utils';
+
 'use strict';
 
-describe('GGRC.Utils.AdvancedSearch', function () {
+describe('AdvancedSearch', function () {
   describe('buildFilter() method', function () {
     it('builds correct statuses with "ANY" operator', function () {
       var items = [
-        GGRC.Utils.AdvancedSearch.create.state({
+        AdvancedSearch.create.state({
           items: ['Active', 'Draft', 'Deprecated'],
           operator: 'ANY'
         })
@@ -18,13 +20,13 @@ describe('GGRC.Utils.AdvancedSearch', function () {
                            'OR "Status"="Draft" ' +
                            'OR "Status"="Deprecated")';
 
-      expect(GGRC.Utils.AdvancedSearch.buildFilter(items))
+      expect(AdvancedSearch.buildFilter(items))
         .toBe(expectedResult);
     });
 
     it('builds correct statuses with "NONE" operator', function () {
       var items = [
-        GGRC.Utils.AdvancedSearch.create.state({
+        AdvancedSearch.create.state({
           items: ['Active', 'Draft', 'Deprecated'],
           operator: 'NONE'
         })
@@ -33,31 +35,31 @@ describe('GGRC.Utils.AdvancedSearch', function () {
                            'AND "Status"!="Draft" ' +
                            'AND "Status"!="Deprecated")';
 
-      expect(GGRC.Utils.AdvancedSearch.buildFilter(items))
+      expect(AdvancedSearch.buildFilter(items))
         .toBe(expectedResult);
     });
 
     it('builds correct filter string', function () {
       var items = [
-        GGRC.Utils.AdvancedSearch.create.state({
+        AdvancedSearch.create.state({
           items: ['Active', 'Draft'],
           operator: 'ANY'
         }),
-        GGRC.Utils.AdvancedSearch.create.operator('AND'),
-        GGRC.Utils.AdvancedSearch.create.attribute({
+        AdvancedSearch.create.operator('AND'),
+        AdvancedSearch.create.attribute({
           field: 'Title',
           operator: '~',
           value: ' test'
         }),
-        GGRC.Utils.AdvancedSearch.create.operator('OR'),
-        GGRC.Utils.AdvancedSearch.create.group([
-          GGRC.Utils.AdvancedSearch.create.attribute({
+        AdvancedSearch.create.operator('OR'),
+        AdvancedSearch.create.group([
+          AdvancedSearch.create.attribute({
             field: 'Para',
             operator: '=',
             value: 'meter'
           }),
-          GGRC.Utils.AdvancedSearch.create.operator('AND'),
-          GGRC.Utils.AdvancedSearch.create.attribute({
+          AdvancedSearch.create.operator('AND'),
+          AdvancedSearch.create.attribute({
             field: 'Other',
             operator: '~=',
             value: 'value '
@@ -67,49 +69,49 @@ describe('GGRC.Utils.AdvancedSearch', function () {
       var expectedResult = '("Status"="Active" OR "Status"="Draft") ' +
                            'AND "Title" ~ "test" ' +
                            'OR ("Para" = "meter" AND "Other" ~= "value")';
-      expect(GGRC.Utils.AdvancedSearch.buildFilter(items))
+      expect(AdvancedSearch.buildFilter(items))
         .toBe(expectedResult);
     });
 
     it('builds correct mapping filters', function () {
       var items = [
-        GGRC.Utils.AdvancedSearch.create.mappingCriteria({
+        AdvancedSearch.create.mappingCriteria({
           objectName: 'product',
-          filter: GGRC.Utils.AdvancedSearch.create.attribute({
+          filter: AdvancedSearch.create.attribute({
             field: 'title',
             operator: '~',
             value: 'A'
           }),
-          mappedTo: GGRC.Utils.AdvancedSearch.create.mappingCriteria({
+          mappedTo: AdvancedSearch.create.mappingCriteria({
             objectName: 'system',
-            filter: GGRC.Utils.AdvancedSearch.create.attribute({
+            filter: AdvancedSearch.create.attribute({
               field: 'title',
               operator: '~',
               value: 'B'
             })
           })
         }),
-        GGRC.Utils.AdvancedSearch.create.operator('AND'),
-        GGRC.Utils.AdvancedSearch.create.mappingCriteria({
+        AdvancedSearch.create.operator('AND'),
+        AdvancedSearch.create.mappingCriteria({
           objectName: 'control',
-          filter: GGRC.Utils.AdvancedSearch.create.attribute({
+          filter: AdvancedSearch.create.attribute({
             field: 'title',
             operator: '~',
             value: 'C'
           }),
-          mappedTo: GGRC.Utils.AdvancedSearch.create.group([
-            GGRC.Utils.AdvancedSearch.create.mappingCriteria({
+          mappedTo: AdvancedSearch.create.group([
+            AdvancedSearch.create.mappingCriteria({
               objectName: 'system',
-              filter: GGRC.Utils.AdvancedSearch.create.attribute({
+              filter: AdvancedSearch.create.attribute({
                 field: 'title',
                 operator: '~',
                 value: 'D'
               })
             }),
-            GGRC.Utils.AdvancedSearch.create.operator('OR'),
-            GGRC.Utils.AdvancedSearch.create.mappingCriteria({
+            AdvancedSearch.create.operator('OR'),
+            AdvancedSearch.create.mappingCriteria({
               objectName: 'system',
-              filter: GGRC.Utils.AdvancedSearch.create.attribute({
+              filter: AdvancedSearch.create.attribute({
                 field: 'title',
                 operator: '~',
                 value: 'E'
@@ -232,7 +234,7 @@ describe('GGRC.Utils.AdvancedSearch', function () {
       ];
       var request = [];
 
-      var result = GGRC.Utils.AdvancedSearch.buildFilter(items, request);
+      var result = AdvancedSearch.buildFilter(items, request);
 
       expect(result).toBe(expectedFilters);
       expect(JSON.parse(JSON.stringify(request))).toEqual(expectedRequest);

--- a/src/ggrc/assets/javascripts/plugins/utils/advanced-search-utils.js
+++ b/src/ggrc/assets/javascripts/plugins/utils/advanced-search-utils.js
@@ -5,204 +5,198 @@
 
 import * as StateUtils from './state-utils';
 
-(function (GGRC, can, _) {
-  'use strict';
-
-  GGRC.Utils.AdvancedSearch = (function () {
-    /**
-     * Factory allowing to create Advanced Search Filter Items.
-     */
-    var create = {
-      /**
-       * Creates Filter Attribute.
-       * @param {object} value - Filter Attribute data.
-       * @return {object} - Attribute model.
-       */
-      attribute: function (value) {
-        return {
-          type: 'attribute',
-          value: value || { }
-        };
-      },
-      /**
-       * Creates Group.
-       * @param {Array} value - Group data.
-       * @return {object} - Group model.
-       */
-      group: function (value) {
-        return {
-          type: 'group',
-          value: value || []
-        };
-      },
-      /**
-       * Creates Operator.
-       * @param {string} value - Operator name.
-       * @return {object} - Operator model.
-       */
-      operator: function (value) {
-        return {
-          type: 'operator',
-          value: value || ''
-        };
-      },
-      /**
-       * Creates Filter State
-       * @param {object} value - State data.
-       * @return {object} - State model.
-       */
-      state: function (value) {
-        return {
-          type: 'state',
-          value: value || { }
-        };
-      },
-      /**
-       * Creates Mapping Criteria
-       * @param {object} value - Mapping Criteria data.
-       * @return {object} - Mapping Criteria model.
-       */
-      mappingCriteria: function (value) {
-        return {
-          type: 'mappingCriteria',
-          value: value || { }
-        };
-      }
-    };
-
-    /**
-     * Contains rich Status Filter operators.
-     */
-    var richOperators = {
-      /**
-       * @param {Array} values - filter statements.
-       * @return {string} - filter string.
-       */
-      ANY: function (values) {
-        return _.map(values, function (value) {
-          return '"Status"="' + value + '"';
-        }).join(' OR ');
-      },
-      /**
-       * @param {Array} values - filter statements.
-       * @return {string} - filter string.
-       */
-      NONE: function (values) {
-        return _.map(values, function (value) {
-          return '"Status"!="' + value + '"';
-        }).join(' AND ');
-      }
-    };
-
-    /**
-     * Contains QueryAPI filter builders.
-     */
-    var builders = {
-      attribute: attributeToFilter,
-      operator: operatorToFilter,
-      state: stateToFilter,
-      group: groupToFilter,
-      mappingCriteria: mappingCriteriaToFilter
-    };
-    /**
-     * Transforms Filter Attribute model to valid QueryAPI filter string.
-     * @param {object} attribute - Filter Attribute model value.
-     * @return {string} - Valid QueryAPI filter string.
-     */
-    function attributeToFilter(attribute) {
-      return '"' + attribute.field +
-             '" ' + attribute.operator +
-             ' "' + attribute.value.trim() + '"';
-    }
-    /**
-     * Transforms Operator model to valid QueryAPI filter string.
-     * @param {object} operator - Operator model value.
-     * @return {string} - Valid QueryAPI filter string.
-     */
-    function operatorToFilter(operator) {
-      return ' ' + operator + ' ';
-    }
-    /**
-     * Transforms State model to valid QueryAPI filter string.
-     * @param {object} state - State model value.
-     * @return {string} - Valid QueryAPI filter string.
-     */
-    function stateToFilter(state) {
-      return '(' + StateUtils.buildStatusFilter(
-        state.items,
-        richOperators[state.operator],
-        state.modelName) + ')';
-    }
-    /**
-     * Transforms Group model to valid QueryAPI filter string.
-     * @param {array} items - Group model value.
-     * @param {Array} request - Collection of QueryAPI sub-requests.
-     * @return {string} - Valid QueryAPI filter string.
-     */
-    function groupToFilter(items, request) {
-      return '(' + buildFilter(items, request) + ')';
-    }
-    /**
-     * Transforms Mapping Criteria model to valid QueryAPI filter string.
-     * @param {object} criteria - Mapping Criteria model value.
-     * @param {Array} request - Collection of QueryAPI sub-requests.
-     * @return {string} - Valid QueryAPI filter string.
-     */
-    function mappingCriteriaToFilter(criteria, request) {
-      var criteriaId = addMappingCriteria(criteria, request);
-      return previousToFilter(criteriaId);
-    }
-    /**
-     * Creates filter based on reauest id.
-     * @param {number} requestId - index of QueryApi request.
-     * @return {string} - Valid QueryAPI filter string.
-     */
-    function previousToFilter(requestId) {
-      return '#__previous__,' + requestId + '#';
-    }
-    /**
-     * Adds Mapping Criteria as separate QueryAPI request.
-     * @param {object} mapping - Mapping Criteria model value.
-     * @param {Array} request - Collection of QueryAPI sub-requests.
-     * @return {number} - QueryAPI request id.
-     */
-    function addMappingCriteria(mapping, request) {
-      var filterObject = GGRC.query_parser
-        .parse(attributeToFilter(mapping.filter.value));
-      var relevantResult;
-      if (mapping.mappedTo) {
-        relevantResult =
-          builders[mapping.mappedTo.type](mapping.mappedTo.value, request);
-        filterObject = GGRC.query_parser.join_queries(
-          filterObject,
-          GGRC.query_parser.parse(relevantResult)
-        );
-      }
-      request.push({
-        object_name: mapping.objectName,
-        type: 'ids',
-        filters: filterObject
-      });
-      return request.length - 1;
-    }
-    /**
-     * Builds QueryAPI valid filter based on Advanced Search models.
-     * @param {Array} data - Collection of Advanced Search models.
-     * @param {Array} request - Collection of QueryAPI sub-requests.
-     * @return {string} - valid QueryAPI filter string.
-     */
-    function buildFilter(data, request) {
-      var result = '';
-      request = request || [];
-      _.each(data, function (item) {
-        result += builders[item.type](item.value, request);
-      });
-      return result;
-    }
-
+/**
+ * Factory allowing to create Advanced Search Filter Items.
+ */
+var create = {
+  /**
+   * Creates Filter Attribute.
+   * @param {object} value - Filter Attribute data.
+   * @return {object} - Attribute model.
+   */
+  attribute: function (value) {
     return {
-      buildFilter: buildFilter,
-      create: create
+      type: 'attribute',
+      value: value || { }
     };
-  })();
-})(window.GGRC, window.can, window._);
+  },
+  /**
+   * Creates Group.
+   * @param {Array} value - Group data.
+   * @return {object} - Group model.
+   */
+  group: function (value) {
+    return {
+      type: 'group',
+      value: value || []
+    };
+  },
+  /**
+   * Creates Operator.
+   * @param {string} value - Operator name.
+   * @return {object} - Operator model.
+   */
+  operator: function (value) {
+    return {
+      type: 'operator',
+      value: value || ''
+    };
+  },
+  /**
+   * Creates Filter State
+   * @param {object} value - State data.
+   * @return {object} - State model.
+   */
+  state: function (value) {
+    return {
+      type: 'state',
+      value: value || { }
+    };
+  },
+  /**
+   * Creates Mapping Criteria
+   * @param {object} value - Mapping Criteria data.
+   * @return {object} - Mapping Criteria model.
+   */
+  mappingCriteria: function (value) {
+    return {
+      type: 'mappingCriteria',
+      value: value || { }
+    };
+  }
+};
+
+/**
+ * Contains rich Status Filter operators.
+ */
+var richOperators = {
+  /**
+   * @param {Array} values - filter statements.
+   * @return {string} - filter string.
+   */
+  ANY: function (values) {
+    return _.map(values, function (value) {
+      return '"Status"="' + value + '"';
+    }).join(' OR ');
+  },
+  /**
+   * @param {Array} values - filter statements.
+   * @return {string} - filter string.
+   */
+  NONE: function (values) {
+    return _.map(values, function (value) {
+      return '"Status"!="' + value + '"';
+    }).join(' AND ');
+  }
+};
+
+/**
+ * Contains QueryAPI filter builders.
+ */
+var builders = {
+  attribute: attributeToFilter,
+  operator: operatorToFilter,
+  state: stateToFilter,
+  group: groupToFilter,
+  mappingCriteria: mappingCriteriaToFilter
+};
+/**
+ * Transforms Filter Attribute model to valid QueryAPI filter string.
+ * @param {object} attribute - Filter Attribute model value.
+ * @return {string} - Valid QueryAPI filter string.
+ */
+function attributeToFilter(attribute) {
+  return '"' + attribute.field +
+         '" ' + attribute.operator +
+         ' "' + attribute.value.trim() + '"';
+}
+/**
+ * Transforms Operator model to valid QueryAPI filter string.
+ * @param {object} operator - Operator model value.
+ * @return {string} - Valid QueryAPI filter string.
+ */
+function operatorToFilter(operator) {
+  return ' ' + operator + ' ';
+}
+/**
+ * Transforms State model to valid QueryAPI filter string.
+ * @param {object} state - State model value.
+ * @return {string} - Valid QueryAPI filter string.
+ */
+function stateToFilter(state) {
+  return '(' + StateUtils.buildStatusFilter(
+    state.items,
+    richOperators[state.operator],
+    state.modelName) + ')';
+}
+/**
+ * Transforms Group model to valid QueryAPI filter string.
+ * @param {array} items - Group model value.
+ * @param {Array} request - Collection of QueryAPI sub-requests.
+ * @return {string} - Valid QueryAPI filter string.
+ */
+function groupToFilter(items, request) {
+  return '(' + buildFilter(items, request) + ')';
+}
+/**
+ * Transforms Mapping Criteria model to valid QueryAPI filter string.
+ * @param {object} criteria - Mapping Criteria model value.
+ * @param {Array} request - Collection of QueryAPI sub-requests.
+ * @return {string} - Valid QueryAPI filter string.
+ */
+function mappingCriteriaToFilter(criteria, request) {
+  var criteriaId = addMappingCriteria(criteria, request);
+  return previousToFilter(criteriaId);
+}
+/**
+ * Creates filter based on reauest id.
+ * @param {number} requestId - index of QueryApi request.
+ * @return {string} - Valid QueryAPI filter string.
+ */
+function previousToFilter(requestId) {
+  return '#__previous__,' + requestId + '#';
+}
+/**
+ * Adds Mapping Criteria as separate QueryAPI request.
+ * @param {object} mapping - Mapping Criteria model value.
+ * @param {Array} request - Collection of QueryAPI sub-requests.
+ * @return {number} - QueryAPI request id.
+ */
+function addMappingCriteria(mapping, request) {
+  var filterObject = GGRC.query_parser
+    .parse(attributeToFilter(mapping.filter.value));
+  var relevantResult;
+  if (mapping.mappedTo) {
+    relevantResult =
+      builders[mapping.mappedTo.type](mapping.mappedTo.value, request);
+    filterObject = GGRC.query_parser.join_queries(
+      filterObject,
+      GGRC.query_parser.parse(relevantResult)
+    );
+  }
+  request.push({
+    object_name: mapping.objectName,
+    type: 'ids',
+    filters: filterObject
+  });
+  return request.length - 1;
+}
+/**
+ * Builds QueryAPI valid filter based on Advanced Search models.
+ * @param {Array} data - Collection of Advanced Search models.
+ * @param {Array} request - Collection of QueryAPI sub-requests.
+ * @return {string} - valid QueryAPI filter string.
+ */
+function buildFilter(data, request) {
+  var result = '';
+  request = request || [];
+  _.each(data, function (item) {
+    result += builders[item.type](item.value, request);
+  });
+  return result;
+}
+
+export {
+  buildFilter,
+  create,
+};


### PR DESCRIPTION
# Issue description

Currently we can't import specific utils in small bundles because root namespace `GGRC.Utils` not defined there and we have to import one with all not needed utils or check and create namespace if it not exist, but both option not good since we have Import/export syntax.

# Steps to test the changes

Try to import some util without `ggrc_utils.js` file

# Solution description

Migration `advanced-search-utils` on module syntax

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/guidelines/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] db_reset runs without errors or warnings.
- [ ] db_reset ggrc-qa.sql runs without errors or warnings.
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
