### PR TITLE
GGRC-3165  Wrong links to Objectives and Regulations in Control's popup on the Assessment Info pane.

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment/mapped-objects/mapped-controls.js
+++ b/src/ggrc/assets/javascripts/components/assessment/mapped-objects/mapped-controls.js
@@ -46,12 +46,12 @@ import {
           {
             type: 'objectives',
             objName: 'Objective',
-            fields: ['child_type', 'revision', 'parent'],
+            fields: ['child_id', 'child_type', 'revision', 'parent'],
           },
           {
             type: 'regulations',
             objName: 'Regulation',
-            fields: ['child_type', 'revision', 'parent'],
+            fields: ['child_id', 'child_type', 'revision', 'parent'],
           },
         ],
       },

--- a/src/ggrc/assets/mustache/components/assessment/mapped-objects/mapped-control-related-objects.mustache
+++ b/src/ggrc/assets/mustache/components/assessment/mapped-objects/mapped-control-related-objects.mustache
@@ -27,9 +27,9 @@
       </div>
 
       <div class="mapped-object-info__attributes">
-          {{#using instance=. editMode=false}}
-              {{>'/static/mustache/custom_attributes/info.mustache'}}
-          {{/using}}
+        {{#add_to_current_scope instance=this editMode=false}}
+          {{>'/static/mustache/custom_attributes/info.mustache'}}
+        {{/add_to_current_scope}}
       </div>
     </div>
   </object-list>


### PR DESCRIPTION
# Issue description

Wrong links to Objectives and Regulations in Control's popup on the Assessment Info pane.
'Not found.' is shown while following Objective or Regulation's link via Control's popup on the Assessment Info pane

# Steps to test the changes

1. Have audit with control snapshot with mapped Objective and Regulation to it
2. Go to audit page and generate Assessment based on control snapshot
3. Expand Assessment Info pane and open Control popup
4. Click Objective's or Regulation's link: 'Not found' is displayed

**Actual Result:** 'Not found.' is shown while following Objective's or Regulation's link via Control's popup on the Assessment Info pane
**Expected Result:** If user clicks Objective's or Regulation's link in Control's popup, Info page of original Objective/Regulation should be displayed

# Solution description

Regression issue - #6646 PR.
Get child_id for Regulation and Objective to generate correct link.
Use _add_to_current_scope_ helper instead of _using_ to prevent unneeded request to server.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [ ] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] db_reset runs without errors or warnings.
- [ ] db_reset ggrc-qa.sql runs without errors or warnings.
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
