### PR TITLE
GGRC-3551: Fix validation issue on Edit Audit modal

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/modals_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/modals_controller.js
@@ -501,7 +501,8 @@ import '../components/access_control_list/access_control_list_roles_helper'
 
     serialize_form: function () {
       var $form = this.options.$content.find('form');
-      var $elements = $form.find(':input:not(isolate-form *)');
+      var $elements = $form
+        .find(':input:not(isolate-form *):not([data-no-serialization])');
 
       can.each($elements.toArray(), this.proxy('set_value_from_element'));
     },

--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -273,7 +273,25 @@
           return auditorsList;
         });
       });
-    }
+    },
+    form_preload() {
+      let dfd;
+      let contact = this.attr('contact');
+
+      if (contact && !contact.email) {
+        contact = contact.reify();
+
+        dfd = contact.email ?
+          can.Deferred().resolve(contact) :
+          contact.refresh();
+
+        dfd.then((refreshed)=> {
+          this.attr('contact.email', refreshed.email);
+        });
+      }
+
+      return dfd;
+    },
   });
 
   can.Model.Cacheable('CMS.Models.Meeting', {

--- a/src/ggrc/assets/mustache/audits/modal_content.mustache
+++ b/src/ggrc/assets/mustache/audits/modal_content.mustache
@@ -53,9 +53,10 @@
         </label>
         <i class="fa fa-person green pull-left icon-field"></i>
         <div class="objective-selector">
-          {{#using contact=instance.contact}}
             {{^if_config_exist 'external_services.Person'}}
-            <input data-id="audit_lead" tabindex="3" type="text" name="contact.email" data-lookup="Person" class="span10 audit-selector search-icon" placeholder="Enter text to search for Audit Captain" value="{{firstnonempty contact.email ''}}">
+            <input data-id="audit_lead" tabindex="3" type="text" name="contact.email" data-lookup="Person"
+              class="span10 audit-selector search-icon" placeholder="Enter text to search for Audit Captain"
+              value="{{firstnonempty instance.contact.email ''}}" data-no-serialization>
             {{else}}
             <inline-autocomplete-wrapper
               class="inline-block"
@@ -75,7 +76,6 @@
               </external-data-autocomplete>
             </inline-autocomplete-wrapper>
             {{/if_config_exist}}
-          {{/using}}
         </div>
       </div>
       <div data-id="status_hidden" class="span3 hidable">


### PR DESCRIPTION
# Issue description
Save button is disabled in Edit Audit modal window 

# Steps to test the changes
1. Go to All objects page > Audit tab
2. Hover over audit first tier > Edit object
3. Look at the Save button: is disabled
4. Edit audit, e.g. edit description: is still disabled
Actual Result: Save button is disabled in Edit Audit modal window
Expected Result: Save button should be enabled in Edit Audit modal window if all the required fields are filled
NOTE: the issue is reproduced not only for all audits (can be reproduced when Audit Captain is not current user and was not loaded in cache before modal opening).

# Solution description
Replace user load via 'using' mustache-helper with 'form_preload' step.
Need to ignore Audit Captain input while serializing modal form - it will reset 'contact' field.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
