### PR TITLE
QUICK-FIX Proper support for docker-compose override files

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,33 +39,23 @@ have Docker up and running. Here are the steps:
 **NOTE for Windows/OSX users:** Make sure `docker` is up and running by following the [windows guide](https://docs.docker.com/engine/installation/windows/#using-docker-from-windows-command-prompt-cmd-exe) / [osx guide](https://docs.docker.com/engine/installation/mac/#from-your-shell).
 
 * clone the repo
-* cd to the project
-directory
-* Run the following:
-
-    ```
-    ./bin/containers setup dev
-    ```
-
+* cd to the project directory
 * Set up the necessary keys:
 
-    ```
-    mv docker-compose.override.yml{.example,}
-    vim docker-compose.override.yml # Add the keys from cloud console
-    ```
+``` sh
+mv docker-compose.override.yml{.example,}
+vim docker-compose.override.yml # Add the keys from cloud console
+```
+* Run the following:
 
-    Note: if the keys aren't set in with your override file, try restarting the 
-    container with 
-
-    ```
-    docker-compose stop
-    docker-compose up -d
-    ```
+``` sh
+./bin/containers setup dev
+```
 
 To log into the container, run the following:
 
 ``` sh
-    docker exec -it ggrccore_cleandev_1 su
+./bin/containers connect
 ```
 
 If you see download errors during the `docker-compose up -d` stage, or if any subsequent

--- a/bin/containers
+++ b/bin/containers
@@ -13,6 +13,10 @@ declare -r DOCKERFILE_DEPLOY="docker-compose-deploy.yml"
 cd "${SCRIPTPATH}/../"
 source "$SCRIPTPATH/util.sh"
 
+get_override_filename () {
+  echo "${1:-}" | sed "s/.yml$/.override.yml/"
+}
+
 usage () {
   cat <<EOF
 Usage: $(basename ${0}) ACTION [MODE [PROJECT]]
@@ -67,16 +71,22 @@ setup () {
   PROJECT="$2"
 
   DOCKERFILE=$(mode_to_docker_compose_yml "$MODE")
+  DOCKERFILE_OVERRIDE=$(get_override_filename "$DOCKERFILE");
 
+  OVERRIDE=""
+
+  if [ -f "$DOCKERFILE_OVERRIDE" ]; then
+    OVERRIDE="--file $DOCKERFILE_OVERRIDE"
+  fi
   git submodule update --init
 
   # allow non-privileged mysqld to read provisioned mysql configs
   chmod o+r ./provision/docker/mysql
   chmod o+r ./provision/docker/mysql/*
 
-  docker-compose --file "$DOCKERFILE" --project-name "$PROJECT" \
+  docker-compose --file "$DOCKERFILE" $OVERRIDE --project-name "$PROJECT" \
     build
-  docker-compose --file "$DOCKERFILE" --project-name "$PROJECT" \
+  docker-compose --file "$DOCKERFILE" $OVERRIDE --project-name "$PROJECT" \
     up --force-recreate -d
 
   docker exec -i "${PROJECT}_cleandev_1" su -c "

--- a/bin/containers
+++ b/bin/containers
@@ -24,6 +24,8 @@ Usage: $(basename ${0}) ACTION [MODE [PROJECT]]
 Allowed ACTIONs:
   setup           (Re-)build, run and provision the required containers
   stop            Stop the containers
+  run             Run the containers
+  connect         Connect to app container  
 
 Allowed MODEs:
   dev             (default) Setup application container + db container
@@ -54,6 +56,8 @@ main () {
   case "$ACTION" in
     "setup") setup "$MODE" "$PROJECT" ;;
     "stop") stop "$MODE" "$PROJECT" ;;
+    "run") run "$MODE" "$PROJECT" ;;
+    "connect") connect "$MODE" "$PROJECT" ;;    
     *) fail_invalid_usage ;;
   esac
 }
@@ -72,7 +76,6 @@ setup () {
 
   DOCKERFILE=$(mode_to_docker_compose_yml "$MODE")
   DOCKERFILE_OVERRIDE=$(get_override_filename "$DOCKERFILE");
-
   OVERRIDE=""
 
   if [ -f "$DOCKERFILE_OVERRIDE" ]; then
@@ -110,5 +113,33 @@ stop () {
 
   docker-compose --file "$DOCKERFILE" --project-name "$PROJECT" stop
 }
+
+connect() {
+  MODE="$1"
+  PROJECT="$2"
+
+  docker exec -it "${PROJECT}_cleandev_1" su
+}
+
+run () {
+  MODE="$1"
+  PROJECT="$2"
+
+  DOCKERFILE=$(mode_to_docker_compose_yml "$MODE")
+  DOCKERFILE_OVERRIDE=$(get_override_filename "$DOCKERFILE");  
+  OVERRIDE=""
+    
+  if [ -f "$DOCKERFILE_OVERRIDE" ]; then
+    OVERRIDE="--file $DOCKERFILE_OVERRIDE"
+  fi
+    
+  docker-compose --file "$DOCKERFILE" $OVERRIDE --project-name "$PROJECT" \
+    up --force-recreate -d
+    
+  if [[ "$MODE" == "dev" ]]; then
+    docker exec -it "${PROJECT}_cleandev_1" su
+  fi
+}
+
 
 main "$@"


### PR DESCRIPTION
# Issue description

Currently when container is rebulit with `./bin/containers setup dev` docker-compose.override.yaml file is not used and developer needs to make additional steps to load GDrive API keys. This PR amends and completes the solution made in #6479.

# Steps to test the changes

1. Have a __docker-compose.override.yml__ file in the project directory ( https://github.com/google/ggrc-core/blob/dev/README.md describes how to create one )
2. Run `./bin/containers setup dev`
3. Run `./bin/containers connect` which is a shortcut to the `docker exec -it ggrccore_cleandev_1 su`
4. Run `echo $GGRC_GAPI_KEY` and see the API key set up normally.

# Solution description

When `docker-compose` command is used with the `--file` param it does not look for the override files automatically. Instead, the user must provide a chain of *.yml files which will be merged and used ([documentation](https://docs.docker.com/compose/reference/overview/#specifying-multiple-compose-files)). This solution looks for an override file for the used docker-compose config. 

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests. ( N/A )
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst). ( N/A )
- [ ] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python] (https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines. ( N/A )
- [ ] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".