### PR TITLE
QUICK-FIX Add sorting for objects got from tree view after audit bulk update

### DIFF
--- a/test/selenium/src/tests/test_snapshots.py
+++ b/test/selenium/src/tests/test_snapshots.py
@@ -290,7 +290,7 @@ class TestSnapshots(base.Test):
         src_obj=audit)
     # 'actual_controls': created_at, updated_at, custom_attributes (None)
     self.general_equal_assert(
-        expected_controls, actual_controls,
+        sorted(expected_controls), sorted(actual_controls),
         *Representation.tree_view_attrs_to_exclude)
 
   @pytest.mark.smoke_tests


### PR DESCRIPTION
# Issue description

We got unexpected fail of test **'test_bulk_update_audit_objects_to_latest_ver'** due to approach of rendering tree view items after audit bulk update procedure was changed and order can be different.
![image](https://user-images.githubusercontent.com/16610768/32621051-160776b6-c57f-11e7-90b4-18fa6945352a.png)

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] db_reset runs without errors or warnings.
- [ ] db_reset ggrc-qa.sql runs without errors or warnings.
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
