### PR TITLE
DOCS Add a list of dependencies to PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -40,3 +40,12 @@
 
 - [ ] First item on the TODO
 -->
+
+<!-- If your PR depends on other tickets or PRs, you can list them here
+# Dependencies
+
+This PR is `on hold` until the dependencies are merged:
+
+- [ ] GGRC-1234
+- [ ] #1234
+-->


### PR DESCRIPTION
# Issue description

Currently the dependencies are not tracked in a common way, leading to
misunderstandings on why a PR is on hold and whether the dependency
has already been merged.

# Steps to test the changes

Copy the new version of the template into the description of a PR.

See the example of the dependency list in the end of this description (note that it is illustrative, thus should not be considered real).

# Solution description

We have a de-facto standard of a list of dependencies that is now added to the template.

The dependencies list is organized as a list of checkboxes with PR numbers or (if no PR is open yet) ticket ids.
Once a dependency is merged, its checkbox must be checked.
Once all dependencies are merged, `on hold` label should be removed.

PR numbers are preferred over ticket ids since they are clickable and easier to check: a ticket can be reopened once its solution is merged, but a PR can be only reverted through another PR.

# Sanity checklist

- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] db_reset runs without errors or warnings.
- [ ] db_reset ggrc-qa.sql runs without errors or warnings.
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->

# Dependencies

This PR is `on hold` until the dependencies are merged:

- [x] #6544 
- [x] #6725 
