### PR TITLE
GGRC-3792 LCAs are available for edit and there is no 'Edit answers' button if move Assessment to the 'Deprecated' state

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.js
+++ b/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.js
@@ -27,6 +27,7 @@ import {
   'use strict';
   var tpl = can.view(GGRC.mustache_path +
     '/components/assessment/info-pane/info-pane.mustache');
+  const editableStatuses = ['Not Started', 'In Progress', 'Rework Needed'];
 
   /**
    * Assessment Specific Info Pane View Component
@@ -99,9 +100,10 @@ import {
         editMode: {
           type: 'boolean',
           get: function () {
-            return this.attr('instance.status') !== 'Completed' &&
-              this.attr('instance.status') !== 'In Review' &&
-              !this.attr('instance.archived');
+            let status = this.attr('instance.status');
+
+            return !this.attr('instance.archived') &&
+              editableStatuses.includes(status);
           },
           set: function () {
             this.onStateChange({state: 'In Progress', undo: false});

--- a/src/ggrc/assets/javascripts/components/assessment/info-pane/tests/info-pane_spec.js
+++ b/src/ggrc/assets/javascripts/components/assessment/info-pane/tests/info-pane_spec.js
@@ -13,7 +13,7 @@ describe('GGRC.Components.assessmentInfoPane', function () {
 
   describe('editMode attribute', function () {
     const editableStatuses = ['Not Started', 'In Progress', 'Rework Needed'];
-    const nonEditableStates = ['In Review', 'Completed'];
+    const nonEditableStates = ['In Review', 'Completed', 'Deprecated'];
     const allStatuses = editableStatuses.concat(nonEditableStates);
 
     describe('get() method', function () {

--- a/src/ggrc/assets/javascripts/components/assessment/info-pane/tests/info-pane_spec.js
+++ b/src/ggrc/assets/javascripts/components/assessment/info-pane/tests/info-pane_spec.js
@@ -1,0 +1,41 @@
+/*
+  Copyright (C) 2017 Google Inc., authors, and contributors
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+describe('GGRC.Components.assessmentInfoPane', function () {
+  let vm;
+
+  beforeEach(function () {
+    vm = GGRC.Components.getViewModel('assessmentInfoPane');
+    vm.attr('instance', {});
+  });
+
+  describe('editMode attribute', function () {
+    const editableStatuses = ['Not Started', 'In Progress', 'Rework Needed'];
+    const nonEditableStates = ['In Review', 'Completed'];
+    const allStatuses = editableStatuses.concat(nonEditableStates);
+
+    describe('get() method', function () {
+      it('returns false if instance is archived', function () {
+        vm.attr('instance.archived', true);
+
+        allStatuses.forEach((status) => {
+          vm.attr('instance.status', status);
+          expect(vm.attr('editMode')).toBe(false);
+        });
+      });
+
+      describe('if instance is not archived', function () {
+        it('returns true if instance status is editable otherwise false',
+        function () {
+          allStatuses.forEach((status) => {
+            vm.attr('instance.status', status);
+            expect(vm.attr('editMode'))
+              .toBe(editableStatuses.includes(status));
+          });
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
# Issue description

LCAs are available for edit and there is no 'Edit answers' button if move Assessment to the 'Deprecated' state.

# Steps to test the changes

Steps to reproduce:
1. Have an assessment in "In progress" state on the Audit page with any type of LCA
2. Navigate to Assessment Info pane and click 'Deprecate' in 3 bb's menu
3. Edit LCA attribute: No confirmation massage is shown up while editing

*Actual Result:* LCAs are available for edit and there is no 'Edit answers' button if move Assessment to the 'Deprecated' state
*Expected Result:* LCAs should not be available for edit before clicking 'Edit answers' button if Assessment is in 'Deprecated' state

# Solution description

Refactor getter of `editMode` attribute. Allows edit only if assessment is not archived and it is in editable status.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] db_reset runs without errors or warnings.
- [ ] db_reset ggrc-qa.sql runs without errors or warnings.
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
