### PR TITLE
GGRC-3803: Fix request for object counts on Audit Dashboard page

### DIFF
--- a/src/ggrc/assets/javascripts/plugins/utils/tree-view-utils.js
+++ b/src/ggrc/assets/javascripts/plugins/utils/tree-view-utils.js
@@ -16,6 +16,7 @@ import {
   initMappedInstances,
   isObjectContextPage,
   getPageType,
+  isMyWork,
 } from './current-page-utils';
 import './query-api-utils';
 
@@ -739,7 +740,7 @@ function _createInstance(source, modelName) {
 }
 
 function _getTreeViewOperation(objectName) {
-  var isDashboard = /dashboard/.test(window.location);
+  var isDashboard = isMyWork();
   var operation;
   if (isDashboard) {
     operation = 'owned';


### PR DESCRIPTION
# Issue description
Object counts in HNB have incorrect values while Audit Dashboard is opened

# Steps to test the changes
1. Log as Admin
2. On the Administration page > Custom attributes tab> Audits >Add global custom attribute with text type and title as "Dashboard_report"
3. Create a program and map control to the program
4. Create and map an audit to the program
5. On the Audit Info page fill GCA "Dashboard_report": e.g. https://ggrc-test.googleplex.com > Save
6. Create an Assessment 
7. Refresh the audit page: confirm Configurable dashboard tab is displayed in HNB
8. Select Configurable dashboard tab and refresh the page
9. Look at the HNB: Assessment tab shows zero, no mappings are displayed in HNB, count in the People tab is incorrect
Actual Result: Incorrect info is displayed in HNB after refreshing the Audit page while Audit Dashboard tab is selected
Expected Result: Correct tab counts should be displayed in HNB after refreshing the Audit page while Audit Dashboard tab is selected. All mappings should be displayed in HNB.

![screen shot 2017-11-10 at 4 23 32 pm](https://user-images.githubusercontent.com/24203972/32663556-69075636-c63f-11e7-9d0a-065363269b68.png)
![screen shot 2017-11-10 at 4 23 28 pm](https://user-images.githubusercontent.com/24203972/32663559-6ce1efd2-c63f-11e7-9071-637d2ec776ba.png)


# Solution description
Incorrect request was sent for 'owned' objects - it was caused by mistake in regular expression.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests. (N/A cause legacy code should be refactored -> window object should not be used in this file)
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

NOTE: 
this changes should be updated in case if #6768 will be merged previously.