### PR TITLE
QUICK-FIX Modify chrome_options fixture to start chrome maximized (res. 1440x900)

### DIFF
--- a/test/selenium/src/tests/conftest.py
+++ b/test/selenium/src/tests/conftest.py
@@ -101,6 +101,7 @@ def chrome_options(chrome_options, create_tmp_dir):
   prefs = {"download.default_directory": create_tmp_dir,
            "download.prompt_for_download": False}
   chrome_options.add_experimental_option("prefs", prefs)
+  chrome_options.add_argument("--start-maximized")
   return chrome_options
 
 


### PR DESCRIPTION
# Issue description
This PR modify chrome_options fixture to start chrome maximized but with resolution 1440x900 which is required from business perspective (*minimal from chain below):
MacBook Pro 13.3": 1440x900 (127.68 PPI)
MacBook Pro 15.4": 1440x900 (110.27 PPI)
MacBook Pro 15.4": 1680x1050 (128 PPI)
MacBook Pro 17": 1920x1200 (133.19 PPI)

 

# Solution description
Before this PR, resolution of docker's virtual Linux environment was set to 1440x900 by docker-compose (ggrc-core/docker-compose-testing.yml):
```
  selenium:
    build: 
      context: .
      dockerfile: Dockerfile-selenium
    volumes:
     - "./test/selenium:/selenium"
     - "/dev/shm:/dev/shm"
    links:
     - dev
    environment:
     - "TZ=America/Los_Angeles"
     - PYTHONDONTWRITEBYTECODE=true
     - PYTHONPATH=/selenium/src
     - SCREEN_WIDTH=1440
     - SCREEN_HEIGHT=900
```

Additionally,  chrome-browser resolution was set to 1440x900 (/Users/anestsiarovich/google/ggrc-core/test/selenium/src/tests/conftest.py):

```Python
@pytest.fixture(scope="function")
def selenium(selenium):
  """Create Web Driver instance and setup test resources for running test
  in headless mode.
  """
  selenium.set_window_size(1440, 900)
  dynamic_fixtures.dict_executed_fixtures.update({"selenium": selenium})
  yield selenium
```

but without maximizing, which could be root-cause of potential issues like: 

**"WebDriverException: Element is not clickable at point (x, y). Other element would receive the click: ..."**

**Solution:**
Add maximization option to chrome-options fixture:
```Python
@pytest.fixture
def chrome_options(chrome_options, create_tmp_dir):
  """Set configuration to run Chrome with specific options."""
  prefs = {"download.default_directory": create_tmp_dir,
           "download.prompt_for_download": False}
  chrome_options.add_experimental_option("prefs", prefs)
  chrome_options.add_argument("--start-maximized")
  return chrome_options
```

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] db_reset runs without errors or warnings.
- [ ] db_reset ggrc-qa.sql runs without errors or warnings.
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
