### PR TITLE
GGRC-3826: Search results on Generate Assessment modal after AT is loaded

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment_templates/assessment_templates.js
+++ b/src/ggrc/assets/javascripts/components/assessment_templates/assessment_templates.js
@@ -102,6 +102,7 @@ import {
 
         viewModel.attr('responses', values);
         viewModel._selectInitialTemplate(viewModel.templates());
+        viewModel.dispatch('assessmentTemplateLoaded');
       });
     }
   });

--- a/src/ggrc/assets/javascripts/components/assessment_templates/assessment_templates.js
+++ b/src/ggrc/assets/javascripts/components/assessment_templates/assessment_templates.js
@@ -1,4 +1,4 @@
-/*!
+/* !
     Copyright (C) 2017 Google Inc.
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 */
@@ -8,102 +8,88 @@ import {
   buildParam,
   makeRequest,
 } from '../../plugins/utils/query-api-utils';
-
-(function (can, GGRC) {
-  'use strict';
-
-  GGRC.Components('assessmentTemplates', {
-    tag: 'assessment-templates',
-    template: can.view(
-      GGRC.mustache_path +
-      '/components/assessment_templates/assessment_templates.mustache'
-    ),
-    viewModel: {
-      responses: [],
-      instance: null,
-      assessmentTemplate: null,
-
-      templates: function () {
-        var result = {};
-        var responses = this.attr('responses');
-        var noValue = {
-          title: 'No template',
-          value: ''
-        };
-        _.each(responses, function (instance) {
-          var type;
-
-          type = instance.template_object_type;
-          if (!result[type]) {
-            result[type] = {
-              group: type,
-              subitems: []
-            };
-          }
-          result[type].subitems.push({
-            title: instance.title,
-            value: instance.id + '-' + type
-          });
+import template from
+  '../../../mustache/components/assessment_templates/assessment_templates.mustache'; // eslint-disable-line
+export default can.Component.extend({
+  tag: 'assessment-templates',
+  template,
+  viewModel: {
+    responses: [],
+    instance: null,
+    assessmentTemplate: null,
+    templates() {
+      const result = {};
+      const responses = this.attr('responses');
+      const noValue = {
+        title: 'No template',
+        value: '',
+      };
+      _.each(responses, function (instance) {
+        var type;
+        type = instance.template_object_type;
+        if (!result[type]) {
+          result[type] = {
+            group: type,
+            subitems: [],
+          };
+        }
+        result[type].subitems.push({
+          title: instance.title,
+          value: instance.id + '-' + type,
         });
-        return [noValue].concat(_.toArray(result));
-      },
-
-      /**
-       * Set the initial Assessment Template to be selected in the relevant
-       * dropdown menu.
-       *
-       * By default, the first option from the first option group is selected,
-       * unless such option does not exist.
-       *
-       * @param {Array} templates - a list of possible options for the dropdown
-       */
-      _selectInitialTemplate: function (templates) {
-        var WARN_EMPTY_GROUP = [
-          'GGRC.Components.assessmentTemplates: ',
-          'An empty template group encountered, possible API error'
-        ].join('');
-
-        var initialTemplate;
-        var nonDummyItem;
-
-        // The first element is a dummy option, thus if there are no other
-        // elements, simply don't pick anything.
-        if (templates.length < 2) {
-          return;
+      });
+      return [noValue].concat(_.toArray(result));
+    },
+    /**
+     * Set the initial Assessment Template to be selected in the relevant
+     * dropdown menu.
+     *
+     * By default, the first option from the first option group is selected,
+     * unless such option does not exist.
+     *
+     * @param {Array} templates - a list of possible options for the dropdown
+     */
+    _selectInitialTemplate(templates) {
+      const WARN_EMPTY_GROUP = [
+        'GGRC.Components.assessmentTemplates: ',
+        'An empty template group encountered, possible API error',
+      ].join('');
+      let initialTemplate;
+      let nonDummyItem;
+      // The first element is a dummy option, thus if there are no other
+      // elements, simply don't pick anything.
+      if (templates.length < 2) {
+        return;
+      }
+      nonDummyItem = templates[1]; // a single item or an object group
+      if (!nonDummyItem.group) {
+        // a single item
+        initialTemplate = nonDummyItem.value;
+      } else {
+        if (!nonDummyItem.subitems || nonDummyItem.subitems.length === 0) {
+          console.warn(WARN_EMPTY_GROUP);
+          return; // an empty group, no option to pick from it
         }
-
-        nonDummyItem = templates[1];  // a single item or an object group
-
-        if (!nonDummyItem.group) {  // a single item
-          initialTemplate = nonDummyItem.value;
-        } else {
-          if (!nonDummyItem.subitems || nonDummyItem.subitems.length === 0) {
-            console.warn(WARN_EMPTY_GROUP);
-            return;  // an empty group, no option to pick from it
-          }
-          initialTemplate = nonDummyItem.subitems[0].value;
-        }
-
-        if (!this.attr('assessmentTemplate')) {
-          this.attr('assessmentTemplate', initialTemplate);
-        }
+        initialTemplate = nonDummyItem.subitems[0].value;
+      }
+      if (!this.attr('assessmentTemplate')) {
+        this.attr('assessmentTemplate', initialTemplate);
       }
     },
-    init: function () {
-      var viewModel = this.viewModel;
-      var instance = viewModel.attr('instance');
-      var param = buildParam('AssessmentTemplate', {}, {
-        type: instance.type,
-        id: instance.id,
-      }, ['id', 'type', 'title', 'template_object_type']);
+  },
+  init() {
+    const viewModel = this.viewModel;
+    const instance = viewModel.attr('instance');
+    const param = buildParam('AssessmentTemplate', {}, {
+      type: instance.type,
+      id: instance.id,
+    }, ['id', 'type', 'title', 'template_object_type']);
 
-      makeRequest({data: [param]}).then(function (response) {
-        var values = response[0].AssessmentTemplate.values;
-
-        viewModel.attr('responses', values);
-        viewModel._selectInitialTemplate(viewModel.templates());
-        viewModel.dispatch('assessmentTemplateLoaded');
-      });
-    }
-  });
-})(window.can, window.GGRC);
+    makeRequest({data: [param]}).then((response)=> {
+      const values = response[0].AssessmentTemplate.values;
+      viewModel.attr('responses', values);
+      viewModel._selectInitialTemplate(viewModel.templates());
+      viewModel.dispatch('assessmentTemplateLoaded');
+    });
+  },
+});

--- a/src/ggrc/assets/javascripts/components/assessment_templates/tests/assessment_templates_spec.js
+++ b/src/ggrc/assets/javascripts/components/assessment_templates/tests/assessment_templates_spec.js
@@ -4,6 +4,7 @@
 */
 
 import Component from '../assessment_templates';
+import * as QueryAPI from '../../../plugins/utils/query-api-utils';
 
 describe('assessmentTemplates', ()=> {
   let viewModel;
@@ -100,5 +101,70 @@ describe('assessmentTemplates', ()=> {
         expect(viewModel.attr('assessmentTemplate')).toEqual('single');
       }
     );
+  });
+
+  describe('init() method', ()=> {
+    const reqParam = {};
+    let makeRequestDfd;
+    let method;
+
+    beforeAll(()=> {
+      method = Component.prototype.init.bind({
+        viewModel,
+      });
+    });
+
+    beforeEach(()=> {
+      makeRequestDfd = can.Deferred();
+      viewModel.attr('instance', {
+        id: 1,
+        type: 'AssessmentTemplate',
+      });
+
+      spyOn(QueryAPI, 'buildParam')
+        .and.returnValue(reqParam);
+      spyOn(QueryAPI, 'makeRequest')
+        .and.returnValue(makeRequestDfd);
+      spyOn(viewModel, '_selectInitialTemplate');
+    });
+
+    it('makse relevant call', ()=> {
+      method();
+
+      expect(QueryAPI.buildParam)
+        .toHaveBeenCalled();
+      expect(QueryAPI.makeRequest)
+        .toHaveBeenCalledWith({data: [reqParam]});
+    });
+
+    it('sets initial Assessment Template', ()=> {
+      spyOn(viewModel, 'dispatch');
+
+      method();
+
+      makeRequestDfd.resolve([{
+        AssessmentTemplate: {
+          values: [],
+        },
+      }]);
+
+      expect(viewModel._selectInitialTemplate)
+        .toHaveBeenCalled();
+    });
+
+    it('dispatches "assessmentTemplateLoaded" event', ()=> {
+      spyOn(viewModel, 'dispatch');
+
+      method();
+
+      makeRequestDfd.resolve([{
+        AssessmentTemplate: {
+          values: [],
+        },
+      }]);
+
+      expect(viewModel.dispatch)
+        .toHaveBeenCalledWith('assessmentTemplateLoaded');
+    });
   });
 });

--- a/src/ggrc/assets/javascripts/components/assessment_templates/tests/assessment_templates_spec.js
+++ b/src/ggrc/assets/javascripts/components/assessment_templates/tests/assessment_templates_spec.js
@@ -1,75 +1,74 @@
-/*!
+/* !
   Copyright (C) 2017 Google Inc.
   Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 */
 
-describe('GGRC.Components.assessmentTemplates', function () {
-  'use strict';
+import Component from '../assessment_templates';
 
-  var viewModel;
+describe('assessmentTemplates', ()=> {
+  let viewModel;
 
-  beforeAll(function () {
-    viewModel = GGRC.Components.getViewModel('assessmentTemplates');
+  beforeAll(()=> {
+    viewModel = new (can.Map.extend(Component.prototype.viewModel));
   });
 
   describe('_selectInitialTemplate() method', function () {
-    var templates;
+    let templates;
 
-    beforeEach(function () {
+    beforeEach(()=> {
       templates = [
         {
           title: 'No Template',
-          value: ''
+          value: '',
         },
         {
           group: 'FooBarBaz objects',
           subitems: [
             {title: 'object Foo', value: 'foo'},
             {title: 'object Bar', value: 'bar'},
-            {title: 'object Baz', value: 'baz'}
-          ]
+            {title: 'object Baz', value: 'baz'},
+          ],
         },
         {
           group: 'Animal objects',
           subitems: [
             {title: 'Elephant Dumbo', value: 'elephant'},
             {title: 'Flying Pig', value: 'pig'},
-            {title: 'Tiny Mouse', value: 'mouse'}
-          ]
-        }
+            {title: 'Tiny Mouse', value: 'mouse'},
+          ],
+        },
       ];
     });
 
     it('selects the first item from the first option group if it was empty',
-    function () {
-      viewModel.attr('assessmentTemplate', null);
-      viewModel._selectInitialTemplate(templates);
-      expect(viewModel.attr('assessmentTemplate')).toEqual('foo');
-    });
+      ()=> {
+        viewModel.attr('assessmentTemplate', null);
+        viewModel._selectInitialTemplate(templates);
+        expect(viewModel.attr('assessmentTemplate')).toEqual('foo');
+      });
 
-    it('leaves item if the option was not empty', function () {
+    it('leaves item if the option was not empty', ()=> {
       viewModel.attr('assessmentTemplate', 'template-123');
       viewModel._selectInitialTemplate(templates);
       expect(viewModel.attr('assessmentTemplate')).toEqual('template-123');
     });
 
-    it('leaves the current template unchanged if only a dummy value in ' +
-      'the templates list',
-      function () {
+    it(`leaves the current template unchanged if only a dummy value in
+      the templates list`,
+      ()=> {
         viewModel.attr('assessmentTemplate', 'template-123');
-        templates.splice(1);  // keep only the 1st (dummy) option
+        templates.splice(1); // keep only the 1st (dummy) option
 
         viewModel._selectInitialTemplate(templates);
 
         expect(viewModel.attr('assessmentTemplate')).toEqual('template-123');
-      }
-    );
+      });
 
     it('leaves the current template unchanged if first object group empty',
-      function () {
+      ()=> {
         viewModel.attr('assessmentTemplate', 'template-123');
         templates[1].subitems.length = 0;
-        spyOn(console, 'warn');  // just to silence it
+        spyOn(console, 'warn'); // just to silence it
 
         viewModel._selectInitialTemplate(templates);
 
@@ -77,10 +76,10 @@ describe('GGRC.Components.assessmentTemplates', function () {
       }
     );
 
-    it('issues a warning if an empty group is encountered', function () {
-      var expectedMsg = [
+    it('issues a warning if an empty group is encountered', ()=> {
+      const expectedMsg = [
         'GGRC.Components.assessmentTemplates: ',
-        'An empty template group encountered, possible API error'
+        'An empty template group encountered, possible API error',
       ].join('');
 
       spyOn(console, 'warn');
@@ -92,7 +91,7 @@ describe('GGRC.Components.assessmentTemplates', function () {
     });
 
     it('selects the first non-dummy value if it precedes all object groups',
-      function () {
+      ()=> {
         viewModel.attr('assessmentTemplate', null);
         templates.splice(1, 0, {title: 'No Group Template', value: 'single'});
 

--- a/src/ggrc/assets/javascripts/components/object-generator/object-generator.js
+++ b/src/ggrc/assets/javascripts/components/object-generator/object-generator.js
@@ -39,17 +39,18 @@ import ObjectOperationsBaseVM from '../view-models/object-operations-base-vm';
           //  disable changing of object type while loading
           //  to prevent errors while speedily selecting different types
           this.attr('is_loading');
-        }
+        },
       });
     },
 
     events: {
       inserted: function () {
-        var self = this;
         this.viewModel.attr('selected').replace([]);
         this.viewModel.attr('entries').replace([]);
 
-        self.viewModel.attr('submitCbs').fire();
+        // show loading indicator before actual
+        // Assessment Template is loading
+        this.viewModel.attr('is_loading', true);
       },
       closeModal: function () {
         this.viewModel.attr('is_saving', false);

--- a/src/ggrc/assets/mustache/components/object-generator/object-generator.mustache
+++ b/src/ggrc/assets/mustache/components/object-generator/object-generator.mustache
@@ -27,7 +27,8 @@
             <assessment-templates
               instance="parentInstance"
               type="type"
-              assessment-template="assessmentTemplate">
+              assessment-template="assessmentTemplate"
+              (assessment-template-loaded)="onSubmit()">
             </assessment-templates>
           </div>
           <div class="object-controls__type">


### PR DESCRIPTION
# Issue description
Search results are not relevant in Assessment Generation popup 

# Steps to test the changes
1. Have an audit with a control and an objective snapshots
2. Create assessment template with 'Objectives' Assessment type
3. Open Generate Assessment popup
4. Look at the screen: object type is updated from 'Controls' to 'Objectives', Search results contain control snapshot
Actual Result: If generate assessment based on Assessment template with 'Objective' object type (or other objects except Control), search results are not updated and show control snapshots by default in generation popup
Expected Result: Search results should be updated in Generation popup

# Solution description
Fire event from assessment-templates component when AT is loaded and search results only after that.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".