### PR TITLE
GGRC-3838: Remove redundant calls after Bulk Update

### DIFF
--- a/src/ggrc/assets/javascripts/components/bulk-update-button/bulk-update-button.js
+++ b/src/ggrc/assets/javascripts/components/bulk-update-button/bulk-update-button.js
@@ -12,7 +12,7 @@ export default can.Component.extend({
   template: template,
   viewModel: {
     model: null,
-    openBulkUpdateModal: function (type) {
+    openBulkUpdateModal: function (el, type) {
       import(/*webpackChunkName: "mapper"*/ '../../controllers/mapper/mapper')
         .then(mapper => {
           mapper.ObjectBulkUpdate.launch(el, {
@@ -22,16 +22,8 @@ export default can.Component.extend({
           });
         });
     },
-  },
-  events: {
-    'a click': function (el) {
-      var model = this.viewModel.attr('model');
-      var type = model.model_singular;
-
-      this.viewModel.openBulkUpdateModal(type);
-    },
     updateObjects: function (context, args) {
-      var model = this.viewModel.attr('model');
+      var model = this.attr('model');
       var nameSingular = model.name_singular;
       var progressMessage =
         `${nameSingular} update is in progress. This may take several minutes.`;
@@ -64,6 +56,14 @@ export default can.Component.extend({
         `${nameSingularLowerCase} was ` :
         `${namePluralLowerCase} were `) +
         'updated successfully.';
+    },
+  },
+  events: {
+    'a click': function (el) {
+      var model = this.viewModel.attr('model');
+      var type = model.model_singular;
+
+      this.viewModel.openBulkUpdateModal(el, type);
     },
   },
 });

--- a/src/ggrc/assets/javascripts/components/bulk-update-button/bulk-update-button.js
+++ b/src/ggrc/assets/javascripts/components/bulk-update-button/bulk-update-button.js
@@ -18,11 +18,11 @@ export default can.Component.extend({
           mapper.ObjectBulkUpdate.launch(el, {
             object: type,
             type: type,
-            callback: this.updateObjects.bind(this),
+            callback: this.updateObjects.bind(this, el),
           });
         });
     },
-    updateObjects: function (context, args) {
+    updateObjects: function (el, context, args) {
       var model = this.attr('model');
       var nameSingular = model.name_singular;
       var progressMessage =
@@ -39,7 +39,7 @@ export default can.Component.extend({
           GGRC.Errors.notifier('info', message);
 
           if (updatedCount > 0) {
-            can.trigger($('tree-widget-container'), 'refreshTree');
+            can.trigger(el.closest('tree-widget-container'), 'refreshTree');
           }
         }.bind(this));
     },

--- a/src/ggrc/assets/javascripts/components/bulk-update-button/tests/bulk-update-button_spec.js
+++ b/src/ggrc/assets/javascripts/components/bulk-update-button/tests/bulk-update-button_spec.js
@@ -41,8 +41,13 @@ describe('GGRC.Components.bulkUpdateButton', function () {
     var context;
     var args;
     var resMessage;
+    let el;
+    const parentEl = {};
 
     beforeEach(function () {
+      el = {
+        closest: jasmine.createSpy().and.returnValue(parentEl),
+      };
       context = {
         closeModal: jasmine.createSpy(),
       };
@@ -65,7 +70,7 @@ describe('GGRC.Components.bulkUpdateButton', function () {
       spyOn(viewModel, 'getResultNotification')
         .and.returnValue(resMessage);
 
-      viewModel.updateObjects(context, args);
+      viewModel.updateObjects(el, context, args);
     });
 
     it('closes ObjectBulkUpdate modal', function () {
@@ -90,14 +95,16 @@ describe('GGRC.Components.bulkUpdateButton', function () {
     it('triggers TreeView refresh when some items updated', function () {
       updateDfd.resolve([{status: 'updated'}]);
 
+      expect(el.closest).toHaveBeenCalled();
       expect(can.trigger)
-        .toHaveBeenCalledWith(jasmine.any(Object), 'refreshTree');
+        .toHaveBeenCalledWith(parentEl, 'refreshTree');
     });
 
     it('does not trigger TreeView refresh when no item was updated',
       function () {
         updateDfd.resolve([]);
 
+        expect(el.closest).not.toHaveBeenCalled();
         expect(can.trigger)
           .not.toHaveBeenCalled();
       });


### PR DESCRIPTION
# Issue description
Redundant calls after bulk updates

# Steps to test the changes
1) Go on My Work page 
2) Open Assessments
3) Open Tasks and apply Bulk Update
Actual Result: 2 calls for CTGOT and Assesments refresh are made
Expected Result: only 1 call for CTGOT refresh should be made

# Solution description
Find closest tree-widget-container component and trigger refresh on it.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

