### PR TITLE
GGRC-3758 If add a user to custom role filed and click 'discard', user is still shown on Info pane

### DIFF
--- a/src/ggrc/assets/javascripts/components/access_control_list/tests/access_control_list_roles_helper_spec.js
+++ b/src/ggrc/assets/javascripts/components/access_control_list/tests/access_control_list_roles_helper_spec.js
@@ -66,7 +66,7 @@ describe('GGRC.Components.accessControlListRolesHelper', function () {
     it('should set current user for 1 role', function () {
       instance = new CMS.Models.Control({id: 25});
       viewModel.attr('instance', instance);
-      expect(instance.access_control_list).toBe(undefined);
+      expect(instance.access_control_list.length).toEqual(0);
       viewModel.setAutoPopulatedRoles();
       expect(instance.access_control_list.length).toEqual(1);
       expect(instance.access_control_list[0].ac_role_id)

--- a/src/ggrc/assets/javascripts/models/business_object_models.js
+++ b/src/ggrc/assets/javascripts/models/business_object_models.js
@@ -14,7 +14,7 @@
     update: 'PUT /api/org_groups/{id}',
     destroy: 'DELETE /api/org_groups/{id}',
     mixins: ['unique_title', 'ca_update',
-              'timeboxed'],
+              'timeboxed', 'accessControlList'],
     is_custom_attributable: true,
     isRoleable: true,
     attributes: {
@@ -78,7 +78,7 @@
     update: 'PUT /api/projects/{id}',
     destroy: 'DELETE /api/projects/{id}',
     mixins:
-      ['unique_title', 'ca_update', 'timeboxed'],
+      ['unique_title', 'ca_update', 'timeboxed', 'accessControlList'],
     is_custom_attributable: true,
     isRoleable: true,
     attributes: {
@@ -141,7 +141,7 @@
     update: 'PUT /api/facilities/{id}',
     destroy: 'DELETE /api/facilities/{id}',
     mixins:
-      ['unique_title', 'ca_update', 'timeboxed'],
+      ['unique_title', 'ca_update', 'timeboxed', 'accessControlList'],
     is_custom_attributable: true,
     isRoleable: true,
     attributes: {
@@ -204,7 +204,7 @@
     create: 'POST /api/products',
     update: 'PUT /api/products/{id}',
     destroy: 'DELETE /api/products/{id}',
-    mixins: ['unique_title', 'ca_update', 'timeboxed'],
+    mixins: ['unique_title', 'ca_update', 'timeboxed', 'accessControlList'],
     is_custom_attributable: true,
     isRoleable: true,
     attributes: {
@@ -269,7 +269,7 @@
     create: 'POST /api/data_assets',
     update: 'PUT /api/data_assets/{id}',
     destroy: 'DELETE /api/data_assets/{id}',
-    mixins: ['unique_title', 'ca_update', 'timeboxed'],
+    mixins: ['unique_title', 'ca_update', 'timeboxed', 'accessControlList'],
     is_custom_attributable: true,
     isRoleable: true,
     attributes: {
@@ -332,7 +332,7 @@
     create: 'POST /api/access_groups',
     update: 'PUT /api/access_groups/{id}',
     destroy: 'DELETE /api/access_groups/{id}',
-    mixins: ['unique_title', 'ca_update'],
+    mixins: ['unique_title', 'ca_update', 'accessControlList'],
     is_custom_attributable: true,
     isRoleable: true,
     attributes: {
@@ -395,7 +395,7 @@
     create: 'POST /api/markets',
     update: 'PUT /api/markets/{id}',
     destroy: 'DELETE /api/markets/{id}',
-    mixins: ['unique_title', 'ca_update', 'timeboxed'],
+    mixins: ['unique_title', 'ca_update', 'timeboxed', 'accessControlList'],
     is_custom_attributable: true,
     isRoleable: true,
     attributes: {
@@ -457,7 +457,7 @@
     create: 'POST /api/vendors',
     update: 'PUT /api/vendors/{id}',
     destroy: 'DELETE /api/vendors/{id}',
-    mixins: ['unique_title', 'ca_update', 'timeboxed'],
+    mixins: ['unique_title', 'ca_update', 'timeboxed', 'accessControlList'],
     is_custom_attributable: true,
     isRoleable: true,
     attributes: {

--- a/src/ggrc/assets/javascripts/models/control.js
+++ b/src/ggrc/assets/javascripts/models/control.js
@@ -14,7 +14,7 @@
     create: 'POST /api/controls',
     update: 'PUT /api/controls/{id}',
     destroy: 'DELETE /api/controls/{id}',
-    mixins: ['unique_title', 'ca_update', 'timeboxed'],
+    mixins: ['unique_title', 'ca_update', 'timeboxed', 'accessControlList'],
     is_custom_attributable: true,
     isRoleable: true,
     attributes: {

--- a/src/ggrc/assets/javascripts/models/directive_models.js
+++ b/src/ggrc/assets/javascripts/models/directive_models.js
@@ -91,7 +91,8 @@ CMS.Models.Directive("CMS.Models.Standard", {
   , is_custom_attributable: true
   , isRoleable: true
   , attributes : {}
-  , meta_kinds : [ "Standard" ]
+  , meta_kinds : [ "Standard" ],
+  mixins: ['accessControlList']
   , cache : can.getObject("cache", CMS.Models.Directive, true),
   sub_tree_view_options: {
     default_filter: ['Section']
@@ -123,7 +124,8 @@ CMS.Models.Directive("CMS.Models.Regulation", {
   , destroy : "DELETE /api/regulations/{id}"
   , is_custom_attributable: true
   , isRoleable: true
-  , attributes : {}
+  , attributes : {},
+  mixins: ['accessControlList']
   , meta_kinds : [ "Regulation" ]
   , cache : can.getObject("cache", CMS.Models.Directive, true),
   sub_tree_view_options: {
@@ -157,7 +159,8 @@ CMS.Models.Directive("CMS.Models.Policy", {
   , tree_view_options : {}
   , is_custom_attributable: true
   , isRoleable: true
-  , attributes : {}
+  , attributes : {},
+  mixins: ['accessControlList']
   , meta_kinds : [  "Company Policy", "Org Group Policy", "Data Asset Policy", "Product Policy", "Contract-Related Policy", "Company Controls Policy" ]
   , cache : can.getObject("cache", CMS.Models.Directive, true),
   sub_tree_view_options: {
@@ -198,7 +201,8 @@ CMS.Models.Directive("CMS.Models.Contract", {
   , findOne : "GET /api/contracts/{id}"
   , create : "POST /api/contracts"
   , update : "PUT /api/contracts/{id}"
-  , destroy : "DELETE /api/contracts/{id}"
+  , destroy : "DELETE /api/contracts/{id}",
+  mixins: ['accessControlList']
   , is_custom_attributable: true
   , isRoleable: true
   , attributes : {

--- a/src/ggrc/assets/javascripts/models/issue.js
+++ b/src/ggrc/assets/javascripts/models/issue.js
@@ -17,6 +17,7 @@
       'timeboxed',
       'mapping-limit-issue',
       'inScopeObjects',
+      'accessControlList',
     ],
     is_custom_attributable: true,
     isRoleable: true,

--- a/src/ggrc/assets/javascripts/models/mixins.js
+++ b/src/ggrc/assets/javascripts/models/mixins.js
@@ -1,9 +1,10 @@
-/*!
+/*
     Copyright (C) 2017 Google Inc.
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 */
 
 import {confirm} from '../plugins/utils/modals';
+import {isSnapshot} from '../plugins/utils/snapshot-utils';
 
 (function (can, GGRC) {
   can.Construct.extend('can.Model.Mixin', {
@@ -169,7 +170,20 @@ import {confirm} from '../plugins/utils/modals';
       if (!this.access_control_list) {
         this.attr('access_control_list', []);
       }
-    }
+    },
+    'before:refresh': function () {
+      // no need to rewrite access_control_list for snapshots
+      if (isSnapshot(this)) {
+        return;
+      }
+
+      // access_control_list should be set from response.
+      // if access_control_list is not empty CanJS try to merge
+      // lists from instance and response. Outcome: wrong date in ACL
+      if (this.attr('access_control_list.length') > 0) {
+        this.attr('access_control_list', []);
+      }
+    },
   });
 
   can.Model.Mixin('ca_update', {}, {

--- a/src/ggrc/assets/javascripts/models/section.js
+++ b/src/ggrc/assets/javascripts/models/section.js
@@ -23,7 +23,7 @@ can.Model.Cacheable('CMS.Models.Section', {
   destroy: 'DELETE /api/sections/{id}',
   is_custom_attributable: true,
   isRoleable: true,
-  mixins: ['unique_title', 'ca_update'],
+  mixins: ['unique_title', 'ca_update', 'accessControlList'],
   attributes: {
     context: 'CMS.Models.Context.stub',
     modified_by: 'CMS.Models.Person.stub',
@@ -74,7 +74,7 @@ can.Model.Cacheable('CMS.Models.Clause', {
   destroy: 'DELETE /api/clauses/{id}',
   is_custom_attributable: true,
   isRoleable: true,
-  mixins: ['unique_title', 'ca_update'],
+  mixins: ['unique_title', 'ca_update', 'accessControlList'],
   attributes: {
     context: 'CMS.Models.Context.stub',
     modified_by: 'CMS.Models.Person.stub',

--- a/src/ggrc/assets/javascripts/models/simple_models.js
+++ b/src/ggrc/assets/javascripts/models/simple_models.js
@@ -123,7 +123,7 @@
     create: 'POST /api/objectives',
     update: 'PUT /api/objectives/{id}',
     destroy: 'DELETE /api/objectives/{id}',
-    mixins: ['ownable', 'unique_title', 'ca_update'],
+    mixins: ['ownable', 'unique_title', 'ca_update', 'accessControlList'],
     is_custom_attributable: true,
     isRoleable: true,
     attributes: {

--- a/src/ggrc/assets/javascripts/models/system.js
+++ b/src/ggrc/assets/javascripts/models/system.js
@@ -99,7 +99,7 @@ CMS.Models.SystemOrProcess('CMS.Models.System', {
   create: 'POST /api/systems',
   update: 'PUT /api/systems/{id}',
   destroy: 'DELETE /api/systems/{id}',
-  mixins: ['ca_update'],
+  mixins: ['ca_update', 'accessControlList'],
   cache: can.getObject('cache', CMS.Models.SystemOrProcess, true),
   is_custom_attributable: true,
   isRoleable: true,
@@ -159,7 +159,7 @@ CMS.Models.SystemOrProcess('CMS.Models.Process', {
   sub_tree_view_options: {
     default_filter: ['Risk'],
   },
-  mixins: ['ca_update'],
+  mixins: ['ca_update', 'accessControlList'],
   statuses: ['Draft', 'Deprecated', 'Active'],
   init: function () {
     can.extend(this.attributes, CMS.Models.SystemOrProcess.attributes);

--- a/src/ggrc_risks/assets/javascripts/models/risk.js
+++ b/src/ggrc_risks/assets/javascripts/models/risk.js
@@ -15,7 +15,7 @@
     create: 'POST /api/risks',
     update: 'PUT /api/risks/{id}',
     destroy: 'DELETE /api/risks/{id}',
-    mixins: ['unique_title', 'ca_update'],
+    mixins: ['unique_title', 'ca_update', 'accessControlList'],
     is_custom_attributable: true,
     isRoleable: true,
     attributes: {

--- a/src/ggrc_risks/assets/javascripts/models/threat.js
+++ b/src/ggrc_risks/assets/javascripts/models/threat.js
@@ -15,7 +15,7 @@
     create: 'POST /api/threats',
     update: 'PUT /api/threats/{id}',
     destroy: 'DELETE /api/threats/{id}',
-    mixins: ['unique_title', 'ca_update'],
+    mixins: ['unique_title', 'ca_update', 'accessControlList'],
     is_custom_attributable: true,
     isRoleable: true,
     attributes: {


### PR DESCRIPTION
# Issue description

If add a user to custom role filed and click 'discard', user is still shown on Info pane

# Steps to test the changes

1. Invoke Edit assessment modal window
2. Add person to custom role field screenshot-1.png
3. Click 'discard' button
4. Look at the custom rile field on Assessment Info pane
_Actual Result_: If add a user to custom role filed and click 'discard', user is still shown on Info pane
_Expected result_: If add a user to custom role filed and click 'discard', user should not be shown on Info pane

# Solution description

Access_control_list should be empty before merge with access_control_list from response.
Added _'before:refresh'_ method to _'accessControlList'_. This method cleans access_control_list before merge

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] db_reset runs without errors or warnings.
- [ ] db_reset ggrc-qa.sql runs without errors or warnings.
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->

<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->
