### PR TITLE
GGRC-3706 Fix LCA - reserved names collision issue

### DIFF
--- a/src/ggrc/models/assessment_template.py
+++ b/src/ggrc/models/assessment_template.py
@@ -35,6 +35,8 @@ class AssessmentTemplate(assessment.AuditRelationship, relationship.Relatable,
 
   PER_OBJECT_CUSTOM_ATTRIBUTABLE = True
 
+  RELATED_TYPE = 'assessment'
+
   # the type of the object under assessment
   template_object_type = db.Column(db.String, nullable=True)
 

--- a/test/integration/ggrc/models/test_attributevalidator.py
+++ b/test/integration/ggrc/models/test_attributevalidator.py
@@ -171,8 +171,9 @@ class TestCAD(TestCase):
     """Test collisions between assessment template and assessments.
 
     Assessment template is not allowed to have local CAD that match Assessment
-    global CAD, because that will cause collisions when assessments are
-    generated when using the mentioned template.
+    global CAD or Assessment instance attribute, because that will cause
+    collisions when assessments are generated when using the mentioned
+    template.
     """
     with app.app_context():
       CAD(
@@ -195,6 +196,13 @@ class TestCAD(TestCase):
       with self.assertRaises(ValueError):
         CAD(
             title="global title",
+            definition_type="assessment_template",
+            definition_id=1,
+        )
+    with app.app_context():
+      with self.assertRaises(ValueError):
+        CAD(
+            title="due date",
             definition_type="assessment_template",
             definition_id=1,
         )


### PR DESCRIPTION
# Issue description

User can create LCA with the same name as reserved names in Assessment. But he shouldn't.

# Steps to test the changes
Steps to reproduce:
1. Have audit with control snapshot 
2. On the audit page create Assessment template with LCA date type and title 'Due date' screenshot-1.png￼ 
3. Go to Assessment tab and generate assessment based on assessment template and control snapshot

Actual Result: 'Assessment generation has failed.' error occurs while generating assessment based on template that contains LCA 'Due date' Expected Result: no errors should be shown up while generating assessment. Creating of LCAs with title 'Due date' should be restricted.

# Solution description

Added virtual relation between assessment_template and assessment for adding Assessment's reserved names to AssessmentTemplate's reserved names list. So Assessment's reserved names will be taken into an account in AssessmentTemplate.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] db_reset runs without errors or warnings.
- [ ] db_reset ggrc-qa.sql runs without errors or warnings.
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->

<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->
