### PR TITLE
GGRC-3811,3841 Fix issues with attaching of shared files and files from the same folder

### DIFF
--- a/src/ggrc_gdrive_integration/assets/javascripts/components/gdrive_picker_launcher.js
+++ b/src/ggrc_gdrive_integration/assets/javascripts/components/gdrive_picker_launcher.js
@@ -60,76 +60,80 @@ import errorTpl from './templates/gdrive_picker_launcher_upload_error.mustache';
           this.removeOldSuffix(fileName) + '_' + suffixArr.join('_');
       },
       /**
-       * Copys or renames files adding new suffixes to the file names
-       * @param  {Object} [opts={}] Options object.
-       * @param  {Array}  files     Array of files models
-       * @return {Promise}          Promise which resolves to array of new files
+       * Creates a file edit request
+       * @param  {Objects} file       file object
+       * @return {Object}             gapi.client.request object
        */
-      addFilesSuffixes: function (opts = {}, files) {
-        var fileRenameBatch = gapi.client.newBatch();
-        var fileRenameDfd = can.Deferred();
-        var errors = [];
-        var originalFileNames = {};
-        var newParentId = opts.dest && opts.dest.id;
+      createEditRequest: function (file) {
+        var requestBody = {};
 
-        files.forEach((file) => {
-          var req;
-          var requestBody = {};
+        requestBody.name = file.attr('name');
 
-          // TODO: maybe pick the one format (the one that comes after refresh)?
-          var originalFileName = file.attr('title') ||
-            file.attr('originalFilename') || file.attr('name');
-
-          var newFileName = this.addFileSuffix(originalFileName);
-
-          var parents = (file.parents && file.parents.attr()) || [];
-          var existsInParent = Boolean(
-            parents.find((parent) => parent.id === newParentId)
-          );
-
-          // We change the file if it's a new upload
-          // or file with the same name already exists in the directory
-          var changeExistingFile = file.newUpload ||
-            (existsInParent && originalFileName === newFileName);
-
-          var reqPath = changeExistingFile ? `/drive/v3/files/${file.id}`
-            : `/drive/v3/files/${file.id}/copy`;
-          var reqMethod = changeExistingFile ? 'PATCH' : 'POST';
-
-          file.attr('title', newFileName);
-          file.attr('name', newFileName);
-          originalFileNames[file.id] = originalFileName;
-
-          requestBody.name = newFileName;
-
-          // If there're no such file in the destination directory
-          // we'll move or copy it there
-          if ( newParentId && !existsInParent ) {
-            requestBody.parents = [newParentId];
-          }
-
-          // updating filenames on GDrive
-          req = gapi.client.request({
-            path: reqPath,
-            method: reqMethod,
-            params: {
-              alt: 'json',
-            },
-            headers: {
-              'Content-Type': 'application/json',
-            },
-            body: JSON.stringify(requestBody),
-          });
-
-          fileRenameBatch.add(req, {
-            id: file.id, // settings request id to file id to find the failed file later
-          });
+        // updating filenames on GDrive
+        return gapi.client.request({
+          path: `/drive/v3/files/${file.id}`,
+          method: 'PATCH',
+          params: {
+            alt: 'json',
+          },
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(requestBody),
         });
+      },
+      /**
+       * Creates a file copy request
+       * @param  {Object} file        file object
+       * @param  {String} newParentId id of the destination folder
+       * @return {Object}             gapi.client.request object
+       */
+      createCopyRequest: function (file, newParentId) {
+        var requestBody = {
+          parents: [newParentId || 'root'],
+        };
 
-        // Batch promise always resolves even when some of requests failed
-        // so we manually parsing the response object to find errors
+        requestBody.name = file.attr('name');
+
+        // updating filenames on GDrive
+        return gapi.client.request({
+          path: `/drive/v3/files/${file.id}/copy`,
+          method: 'POST',
+          params: {
+            alt: 'json',
+          },
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(requestBody),
+        });
+      },
+      /**
+       * This function creates a batch request from the
+       * array of requests with extra data
+       * @param  {Array} requestsBatch Array of objects with gapi.client.request and extra options
+       * @param  {Object} originalFileNames Object with original files names. key - fileId, values - original file name
+       * @return {Promise} Promise which resolves to array of renamed file objects
+       */
+      runRenameBatch: function (requestsBatch, originalFileNames) {
+        var fileRenameBatch = gapi.client.newBatch();
+        var resultFiles = new can.Deferred();
+
+        if ( !requestsBatch.length ) {
+          return resultFiles.resolve([]);
+        } else {
+          requestsBatch.forEach((reqData) => {
+            fileRenameBatch.add(reqData.req, reqData.options);
+          });
+        }
+
+        // Batch promise always resolves ( except when the batch is empty )
+        // even when some of requests failed so we manually parsing the
+        // response object to find errors
         fileRenameBatch.then((batchRes) => {
           var newFiles = [];
+          var errors = [];
+
           can.each(batchRes.result, function (response, fileId) {
             if ( response.status === 200 ) {
               newFiles.push(response.result);
@@ -153,14 +157,87 @@ import errorTpl from './templates/gdrive_picker_launcher_upload_error.mustache';
               });
             }
 
-            this.refreshFilesModel(CMS.Models.GDriveFile.models(newFiles))
-              .then(fileRenameDfd.resolve, fileRenameDfd.reject);
+            resultFiles.resolve(newFiles);
           } else {
-            fileRenameDfd.reject(new Error(
+            resultFiles.reject(new Error(
                 `Failed to attach uploaded files.
                 An error occurred while adding suffixes.`));
           }
         });
+
+        return resultFiles;
+      },
+      /**
+       * Copys or renames files adding new suffixes to the file names
+       * @param  {Object} [opts={}] Options object.
+       * @param  {Array}  files     Array of files models
+       * @return {Promise}          Promise which resolves to array of new files
+       */
+      addFilesSuffixes: function (opts = {}, files) {
+        var fileRenameDfd = can.Deferred();
+        var requestsBatch = [];
+        var originalFileNames = {};
+        var newParentId = opts.dest && opts.dest.id;
+        var untouchedFiles = [];
+
+        files.forEach((file) => {
+          var req;
+
+          // TODO: maybe pick the one format (the one that comes after refresh)?
+          var originalFileName = file.attr('title') ||
+            file.attr('originalFilename') || file.attr('name');
+
+          var newFileName = this.addFileSuffix(originalFileName);
+
+          var parents = (file.parents && file.parents.attr()) || [];
+
+          var originalFileExistsInDest = Boolean(
+            parents.find((parent) =>
+              (parent.id === newParentId) || (!newParentId && parent.isRoot))
+          );
+          var newFileExistsInDest = originalFileExistsInDest &&
+            ( newFileName === originalFileName );
+
+          var sharedFile = file.attr('userPermission.role') !== 'owner';
+
+          file.attr('title', newFileName);
+          file.attr('name', newFileName);
+          originalFileNames[file.id] = originalFileName;
+
+
+          // We change the file if it's a new upload (New files are uploaded
+          // to the audit folder or GDrive root folder)
+          if ( file.newUpload ) {
+            req = this.createEditRequest(file, newParentId);
+
+          // ...and copy file if it's a shared one or
+          // there's no file with the same name in the folder
+          } else if ( sharedFile || !newFileExistsInDest ) {
+            req = this.createCopyRequest(file, newParentId);
+          // file with the targeted name already exists in the destination directory -
+          // just using it ( it can happen when user picks the just attached file again )
+          } else {
+            untouchedFiles.push(file);
+          }
+
+          // updating filenames on GDrive
+          if ( req ) {
+            requestsBatch.push({
+              req,
+              options: {
+                id: file.id, // settings request id to file id to find the failed file later
+              },
+            });
+          }
+        });
+
+        this.runRenameBatch(requestsBatch, originalFileNames)
+          .then((files) => {
+            files = files.concat(untouchedFiles);
+            this.refreshFilesModel(CMS.Models.GDriveFile.models(files))
+              .then(fileRenameDfd.resolve, fileRenameDfd.reject);
+          })
+          .fail(fileRenameDfd.reject);
 
         return fileRenameDfd;
       },

--- a/src/ggrc_gdrive_integration/assets/javascripts/utils/gdrive-picker-utils.js
+++ b/src/ggrc_gdrive_integration/assets/javascripts/utils/gdrive-picker-utils.js
@@ -86,10 +86,11 @@ export function uploadFiles(opts = {}) {
     if (data[ACTION] === PICKED) {
       // adding a newUpload flag so we can later distinguish newly
       // uploaded files from the picked ones.
-      // we cannot rely on the uploadState prop later on because a call to
-      // the RefreshQueue will overwrite it.
+      // isNew is not reliable later as we have a similar method on
+      // the model and it will be overwritten when we create Models
+      // from file objects
       data[DOCUMENTS].forEach((file) => {
-        file.newUpload = file.uploadState === 'success';
+        file.newUpload = file.isNew;
       });
 
       files = model.models(data[DOCUMENTS]);


### PR DESCRIPTION
# Issue description

The issue was that if there where no audit folder assigned to the audit, GDrive API gave an error when we where trying to attach ( copy and rename ) shared files. As stated in the [API Doc](https://developers.google.com/drive/v3/reference/files/copy#parents) if we need to copy file to the GDrive root folder, we need to omit the parents param from the request. Somehow it works for the own file but doesn't work for shared files. For shared files we need provided `root` as the id of the folder. It's not described in the doc, but buried deep in the examples.

# Steps to test the changes

__GGRC-3811__
_Precondition:
1. User1 has a file in GDrive folder.
2. Owner of the file shares the link/can comment/can view with User1 to this file. 
3. User1 has read access to the file_
Steps to reproduce:
1. Have an Assessment on the audit page
2. Navigate to Assessment Info pane and attach the file from Precondition
3. Look at the screen: the file is not attached and warning message is shown screenshot-1.png
Actual Result: File is not attached by user if he tries to attach evidence with read access to the file and non-informative message is displayed
Expected Result: User should attach a file from GDrive folder with readonly rights

__GGRC-3841__
_Precondition:
1. User1 has a file in GDrive folder._
Steps to reproduce:
1. Have an Assessment on the audit page
2. Navigate to Assessment Info pane and attach the file from Precondition
3. Look at GDrive folder: an original file was not renamed, a copy was created by adding suffixes
4. Attach the original file once again and look at GDrive folder: original file was renamed by adding suffixes
Actual Result: Original file is renamed in GDrive folder if user attaches the file for the second time
Expected Result: Original file should be renamed while attaching, a copy of the original file should be created with adding suffixes.
Attach one or more files to this issue

# Solution description

My apologies to the reviewers, PR to the release branch is intended to be small, but this functionality is very crucial to the end-user and heavily used on a daily basis. We need to be sure that the logic is correct. That's why I rearranged the code a bit. Git doesn't show a good diff here, but the code and the logic became clearer and easier to read.
The logic is the following:
1. If file is uploaded by user, it's renamed ( adding suffix )
2. if file is picked
   2.1 ... and file with the new file name ( with suffix ) __exists__ in the destination folder - just use the file
   2.2 ... and file with the new file name ( with suffix ) __does not exist__ in the destination folder - copy the file to the destination folder with the new name.
   2.3 ... and file is shared - copy the file to the destination folder with the new name.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".