### PR TITLE
GGRC-1773 "Get the latest version" link not shown in control snapshot Info pane after Deleting CADs

### DIFF
--- a/src/ggrc/models/hooks/__init__.py
+++ b/src/ggrc/models/hooks/__init__.py
@@ -9,6 +9,7 @@ from ggrc.models.hooks import comment
 from ggrc.models.hooks import issue
 from ggrc.models.hooks import relationship
 from ggrc.models.hooks import access_control_list
+from ggrc.models.hooks import custom_attribute_definition
 
 
 ALL_HOOKS = [
@@ -18,6 +19,7 @@ ALL_HOOKS = [
     issue,
     relationship,
     access_control_list,
+    custom_attribute_definition,
 ]
 
 

--- a/src/ggrc/models/hooks/custom_attribute_definition.py
+++ b/src/ggrc/models/hooks/custom_attribute_definition.py
@@ -1,0 +1,29 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Custom Attribute Definition hooks"""
+
+import datetime
+
+from ggrc.models import all_models
+from ggrc.services import signals
+from ggrc.login import get_current_user_id
+
+
+def init_hook():
+  """Initialize CAD hooks"""
+  # pylint: disable=unused-variable
+  @signals.Restful.model_deleted.connect_via(
+      all_models.CustomAttributeDefinition)
+  def handle_cad_delete(sender, obj, src=None, service=None):
+    """Make sure create revision after deleting CAD from admin panel"""
+    # pylint: disable=unused-argument
+    now = datetime.datetime.now()
+    current_user_id = get_current_user_id()
+    for model in all_models.all_models:
+      if model._inflector.table_singular != obj.definition_type:
+        continue
+      for instance in model.eager_query():
+        instance.updated_at = now
+        instance.modified_by_id = current_user_id
+      return

--- a/test/integration/ggrc/models/mixins/test_customattributable.py
+++ b/test/integration/ggrc/models/mixins/test_customattributable.py
@@ -9,9 +9,6 @@ from ggrc import db
 from ggrc import models
 
 from integration.ggrc import TestCase
-from integration.ggrc.models.factories import ProgramFactory
-from integration.ggrc.models.factories import \
-    CustomAttributeDefinitionFactory as CAD
 from integration.ggrc.models import factories
 from integration.ggrc import api_helper
 
@@ -22,9 +19,12 @@ class TestCustomAttributableMixin(TestCase):
 
   def test_setting_ca_values(self):
     """Test normal setting of custom attribute values."""
-    prog = ProgramFactory()
-    cad1 = CAD(definition_type="program", title="CA 1",)
-    cad2 = CAD(definition_type="program", title="CA 2",)
+    with factories.single_commit():
+      prog = factories.ProgramFactory()
+      cad1 = factories.CustomAttributeDefinitionFactory(
+          definition_type="program", title="CA 1", )
+      cad2 = factories.CustomAttributeDefinitionFactory(
+          definition_type="program", title="CA 2", )
 
     prog = prog.__class__.query.get(prog.id)
 
@@ -42,7 +42,7 @@ class TestCustomAttributableMixin(TestCase):
     prog = prog.__class__.query.get(prog.id)
     self.assertEqual(len(prog.custom_attribute_values), 1)
 
-    prog = ProgramFactory()
+    prog = factories.ProgramFactory()
     prog.custom_attribute_values.append(val1)
     db.session.commit()
     prog = prog.__class__.query.get(prog.id)
@@ -52,7 +52,7 @@ class TestCustomAttributableMixin(TestCase):
         set(v.attribute_value for v in prog.custom_attribute_values),
     )
 
-    prog = ProgramFactory()
+    prog = factories.ProgramFactory()
     prog.custom_attribute_values = [val1, val2]
     db.session.commit()
     prog = prog.__class__.query.get(prog.id)
@@ -65,13 +65,15 @@ class TestCustomAttributableMixin(TestCase):
 
   def test_updating_ca_values(self):
     """Test updating custom attribute values."""
-    cad1 = CAD(definition_type="program", title="CA 1",)
+    cad1 = factories.CustomAttributeDefinitionFactory(
+        definition_type="program",
+        title="CA 1",
+    )
     val1 = models.CustomAttributeValue(
         attribute_value="55",
         custom_attribute=cad1,
     )
-
-    prog = ProgramFactory()
+    prog = factories.ProgramFactory()
     prog.custom_attribute_values = [val1]
     db.session.commit()
 
@@ -91,8 +93,12 @@ class TestCustomAttributableMixin(TestCase):
 
   def test_ca_setattr(self):
     """Test setting custom attribute values with setattr."""
-    prog = ProgramFactory()
-    cad1 = CAD(definition_type="program", title="CA 1",)
+    with factories.single_commit():
+      prog = factories.ProgramFactory()
+      cad1 = factories.CustomAttributeDefinitionFactory(
+          definition_type="program",
+          title="CA 1",
+      )
 
     setattr(prog, "custom_attribute_values", [{
             "attribute_value": "55",
@@ -109,9 +115,15 @@ class TestCustomAttributableMixin(TestCase):
 
   def test_setting_ca_dict(self):
     """Test setting custom attribute values dict."""
-    prog = ProgramFactory()
-    cad1 = CAD(definition_type="program", title="CA 1",)
-    cad2 = CAD(definition_type="program", title="CA 2",)
+    with factories.single_commit():
+      prog = factories.ProgramFactory()
+      cad1 = factories.CustomAttributeDefinitionFactory(
+          definition_type="program",
+          title="CA 1", )
+      cad2 = factories.CustomAttributeDefinitionFactory(
+          definition_type="program",
+          title="CA 2",
+      )
 
     prog.custom_attribute_values = [
         {
@@ -133,8 +145,12 @@ class TestCustomAttributableMixin(TestCase):
 
   def test_updating_ca_dict(self):
     """Test updating custom attribute values with a dict."""
-    prog = ProgramFactory()
-    cad1 = CAD(definition_type="program", title="CA 1",)
+    with factories.single_commit():
+      prog = factories.ProgramFactory()
+      cad1 = factories.CustomAttributeDefinitionFactory(
+          definition_type="program",
+          title="CA 1",
+      )
 
     prog.custom_attribute_values = [{
         "attribute_value": "55",
@@ -153,8 +169,12 @@ class TestCustomAttributableMixin(TestCase):
 
   def test_adding_bad_ca_dict(self):
     """Test setting invalid custom attribute values."""
-    prog = ProgramFactory()
-    cad1 = CAD(definition_type="section", title="CA 1",)
+    with factories.single_commit():
+      prog = factories.ProgramFactory()
+      cad1 = factories.CustomAttributeDefinitionFactory(
+          definition_type="section",
+          title="CA 1",
+      )
 
     with self.assertRaises(ValueError):
       prog.custom_attribute_values = [{
@@ -172,13 +192,18 @@ class TestCustomAttributableMixin(TestCase):
 
   def test_adding_mapping_ca_dict(self):
     """Test adding mapping custom attribute values with a dict."""
-    cad1 = CAD(definition_type="program",
-               attribute_type="Map:Person", title="CA 1",)
-    cad2 = CAD(definition_type="program",
-               attribute_type="Map:Person", title="CA 2",)
-    db.session.commit()
-
-    prog = ProgramFactory()
+    with factories.single_commit():
+      cad1 = factories.CustomAttributeDefinitionFactory(
+          definition_type="program",
+          attribute_type="Map:Person",
+          title="CA 1",
+      )
+      cad2 = factories.CustomAttributeDefinitionFactory(
+          definition_type="program",
+          attribute_type="Map:Person",
+          title="CA 2",
+      )
+      prog = factories.ProgramFactory()
     prog.custom_attribute_values = [
         {
             "attribute_value": "Person:1",
@@ -240,7 +265,8 @@ class TestCreateRevisionAfterDeleteCAD(TestCase):
         factories.CustomAttributeValueFactory(
             custom_attribute=cad,
             attributable=control,
-            attribute_value="test")
+            attribute_value="test",
+        )
 
       last_revision = models.Revision.query.filter(
           models.Revision.resource_id == control.id,
@@ -251,7 +277,8 @@ class TestCreateRevisionAfterDeleteCAD(TestCase):
           parent=audit,
           child_id=control.id,
           child_type=control.type,
-          revision=last_revision)
+          revision=last_revision,
+      )
 
     self.assertTrue(snapshot.is_latest_revision)
 

--- a/test/integration/ggrc/models/mixins/test_customattributable.py
+++ b/test/integration/ggrc/models/mixins/test_customattributable.py
@@ -3,6 +3,8 @@
 
 """Integration test for custom attributable mixin"""
 
+import ddt
+
 from ggrc import db
 from ggrc import models
 
@@ -10,6 +12,8 @@ from integration.ggrc import TestCase
 from integration.ggrc.models.factories import ProgramFactory
 from integration.ggrc.models.factories import \
     CustomAttributeDefinitionFactory as CAD
+from integration.ggrc.models import factories
+from integration.ggrc import api_helper
 
 
 class TestCustomAttributableMixin(TestCase):
@@ -62,7 +66,6 @@ class TestCustomAttributableMixin(TestCase):
   def test_updating_ca_values(self):
     """Test updating custom attribute values."""
     cad1 = CAD(definition_type="program", title="CA 1",)
-
     val1 = models.CustomAttributeValue(
         attribute_value="55",
         custom_attribute=cad1,
@@ -198,3 +201,62 @@ class TestCustomAttributableMixin(TestCase):
         set(v.attribute_value for v in prog.custom_attribute_values),
     )
     self.assertEqual(len(prog.custom_attribute_values), 2)
+
+
+@ddt.ddt
+class TestCreateRevisionAfterDeleteCAD(TestCase):
+  """Test cases for creating new revision after delete CAD"""
+  def setUp(self):
+    self.api_helper = api_helper.Api()
+
+  @ddt.data(True, False)
+  def test_latest_revision_delete_cad(self, is_add_cav):
+    """Test creating new revision after deleting CAD.
+
+    In case of deleting CAD, snapshot attribute is_latest_revision
+    must be False
+    """
+    with factories.single_commit():
+      control = factories.ControlFactory()
+      program = factories.ProgramFactory()
+      factories.RelationshipFactory(
+          source=program,
+          destination=control,
+      )
+
+      audit = factories.AuditFactory()
+
+      factories.RelationshipFactory(
+          source=audit,
+          destination=control
+      )
+      cad = factories.CustomAttributeDefinitionFactory(
+          title="test_name",
+          definition_type="control",
+          attribute_type="Text",
+      )
+
+      if is_add_cav:
+        factories.CustomAttributeValueFactory(
+            custom_attribute=cad,
+            attributable=control,
+            attribute_value="test")
+
+      last_revision = models.Revision.query.filter(
+          models.Revision.resource_id == control.id,
+          models.Revision.resource_type == control.type,
+      ).order_by(models.Revision.id.desc()).first()
+
+      snapshot = factories.SnapshotFactory(
+          parent=audit,
+          child_id=control.id,
+          child_type=control.type,
+          revision=last_revision)
+
+    self.assertTrue(snapshot.is_latest_revision)
+
+    self.api_helper.delete(cad)
+
+    snapshot = models.Snapshot.query.filter().first()
+
+    self.assertEqual(snapshot.is_latest_revision, False)

--- a/test/integration/ggrc/models/test_revision.py
+++ b/test/integration/ggrc/models/test_revision.py
@@ -133,6 +133,7 @@ class TestRevisions(TestCase):
   @ddt.data(True, False)
   def test_revision_after_del_cad(self, is_add_cav):
     """Test creating new revision after deleting CAD.
+
     In case of deleting CAD, new revision must be created for object,
     which had this CAD.
     """
@@ -147,7 +148,8 @@ class TestRevisions(TestCase):
         factories.CustomAttributeValueFactory(
             custom_attribute=cad,
             attributable=control,
-            attribute_value="text")
+            attribute_value="text",
+        )
 
       revision_id = ggrc.models.Revision.query.filter(
           ggrc.models.Revision.resource_id == control.id,

--- a/test/integration/ggrc/models/test_revision.py
+++ b/test/integration/ggrc/models/test_revision.py
@@ -2,12 +2,14 @@
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
 """ Tests for ggrc.models.Revision """
+import ddt
 
 import ggrc.models
 import integration.ggrc.generator
 from integration.ggrc import TestCase
 
 from integration.ggrc.models import factories
+from integration.ggrc import api_helper
 
 
 def _get_revisions(obj, field="resource"):
@@ -30,12 +32,14 @@ def _project_content(content):
   }
 
 
+@ddt.ddt
 class TestRevisions(TestCase):
   """ Tests for ggrc.models.Revision """
 
   def setUp(self):
     super(TestRevisions, self).setUp()
     self.gen = integration.ggrc.generator.ObjectGenerator()
+    self.api_helper = api_helper.Api()
 
   def test_revisions(self):
     """ Test revision creation for POST and PUT """
@@ -125,3 +129,38 @@ class TestRevisions(TestCase):
     self.assertIsNotNone(revision)
     self.assertEqual(revision.content["title"], process.title)
     self.assertEqual(revision.content["description"], process.description)
+
+  @ddt.data(True, False)
+  def test_revision_after_del_cad(self, is_add_cav):
+    """Test creating new revision after deleting CAD.
+    In case of deleting CAD, new revision must be created for object,
+    which had this CAD.
+    """
+    with factories.single_commit():
+      control = factories.ControlFactory()
+
+      cad = factories.CustomAttributeDefinitionFactory(
+          title="test_name",
+          definition_type="control",
+      )
+      if is_add_cav:
+        factories.CustomAttributeValueFactory(
+            custom_attribute=cad,
+            attributable=control,
+            attribute_value="text")
+
+      revision_id = ggrc.models.Revision.query.filter(
+          ggrc.models.Revision.resource_id == control.id,
+          ggrc.models.Revision.resource_type == control.type,
+      ).order_by(ggrc.models.Revision.id.desc()).first().id
+
+    self.api_helper.delete(cad)
+
+    control = ggrc.models.Control.query.first()
+
+    last_revision_id = ggrc.models.Revision.query.filter(
+        ggrc.models.Revision.resource_id == control.id,
+        ggrc.models.Revision.resource_type == control.type,
+    ).order_by(ggrc.models.Revision.id.desc()).first().id
+
+    self.assertGreater(last_revision_id, revision_id)

--- a/test/selenium/src/tests/test_snapshots.py
+++ b/test/selenium/src/tests/test_snapshots.py
@@ -103,16 +103,15 @@ class TestSnapshots(base.Test):
 
   @pytest.mark.smoke_tests
   @pytest.mark.parametrize(
-      ("dynamic_create_audit_with_control", "expected_control",
-       "is_openable", "is_ggrc_1773"),
+      ("dynamic_create_audit_with_control", "expected_control", "is_openable"),
       [("create_audit_with_control_and_update_control",
-        "new_control_rest", True, False),
+        "new_control_rest", True),
        ("create_audit_with_control_and_delete_control",
-        "new_control_rest", False, False),
+        "new_control_rest", False),
        ("create_audit_with_control_with_cas_and_update_control_with_cas",
-        "new_control_with_cas_rest", True, False),
+        "new_control_with_cas_rest", True),
        ("create_audit_with_control_with_cas_and_delete_cas_for_controls",
-        "new_control_with_cas_rest", True, True)],
+        "new_control_with_cas_rest", True)],
       ids=["Audit contains snapshotable Control after updating Control",
            "Audit contains snapshotable Control after deleting Control",
            "Audit contains snapshotable Control "
@@ -122,7 +121,7 @@ class TestSnapshots(base.Test):
       indirect=["dynamic_create_audit_with_control"])
   def test_audit_contains_snapshotable_control(
       self, new_cas_for_controls_rest, dynamic_create_audit_with_control,
-      expected_control, is_openable, is_ggrc_1773, selenium
+      expected_control, is_openable, selenium
   ):
     """Test snapshotable Control and check via UI that:
     - Audit contains snapshotable Control after updating Control.
@@ -144,19 +143,15 @@ class TestSnapshots(base.Test):
     actual_controls_tab_count = controls_ui_service.get_count_objs_from_tab(
         src_obj=audit)
     assert len([expected_control]) == actual_controls_tab_count
-    is_control_openable = controls_ui_service.is_obj_page_exist_via_info_panel(
-        src_obj=audit, obj=expected_control)
     is_control_updateable = (
         controls_ui_service.is_obj_updateble_via_info_panel(
             src_obj=audit, obj=expected_control))
+    is_control_openable = controls_ui_service.is_obj_page_exist_via_info_panel(
+        src_obj=audit, obj=expected_control)
     actual_control = controls_ui_service.get_list_objs_from_info_panels(
         src_obj=audit, objs=expected_control)
+    assert is_control_updateable is True
     assert is_control_openable is is_openable
-    is_updateable_condition = is_control_updateable is True
-    if is_ggrc_1773:
-      self.check_ggrc_1773(is_updateable_condition, is_control_updateable)
-    else:
-      assert is_updateable_condition
     # 'actual_control': created_at, updated_at, modified_by (None)
     self.general_equal_assert(
         expected_control, actual_control,
@@ -168,17 +163,15 @@ class TestSnapshots(base.Test):
   @pytest.mark.smoke_tests
   @pytest.mark.parametrize(
       ("dynamic_create_audit_with_control", "control", "expected_control",
-       "is_openable", "is_ggrc_1773"),
+       "is_openable"),
       [("create_audit_with_control_and_update_control",
-        "new_control_rest", "update_control_rest", True, False),
+        "new_control_rest", "update_control_rest", True),
        ("create_audit_with_control_and_delete_control",
-        "new_control_rest", "new_control_rest", False, False),
+        "new_control_rest", "new_control_rest", False),
        ("create_audit_with_control_with_cas_and_update_control_with_cas",
-        "new_control_with_cas_rest", "update_control_with_cas_rest",
-        True, False),
+        "new_control_with_cas_rest", "update_control_with_cas_rest", True),
        ("create_audit_with_control_with_cas_and_delete_cas_for_controls",
-        "new_control_with_cas_rest", "new_control_with_cas_rest",
-        False, True)],
+        "new_control_with_cas_rest", "new_control_with_cas_rest", True)],
       ids=["Update snapshotable Control to latest ver after updating Control",
            "Update snapshotable Control to latest ver after deleting Control",
            "Update snapshotable Control to latest ver "
@@ -188,7 +181,7 @@ class TestSnapshots(base.Test):
       indirect=["dynamic_create_audit_with_control"])
   def test_update_snapshotable_control_to_latest_ver(
       self, new_cas_for_controls_rest, dynamic_create_audit_with_control,
-      control, expected_control, is_openable, is_ggrc_1773, selenium
+      control, expected_control, is_openable, selenium
   ):
     """Test snapshotable Control and check via UI that:
     - Update snapshotable Control to latest ver after updating Control.
@@ -213,22 +206,17 @@ class TestSnapshots(base.Test):
     actual_controls_tab_count = controls_ui_service.get_count_objs_from_tab(
         src_obj=audit)
     assert len([expected_control]) == actual_controls_tab_count
-    is_updateable_condition = (
-        controls_ui_service.is_obj_updateble_via_info_panel(
-            src_obj=audit, obj=control))
-    if is_ggrc_1773:
-      self.check_ggrc_1773(is_updateable_condition, is_updateable_condition)
     controls_ui_service.update_obj_ver_via_info_panel(
         src_obj=audit, obj=control)
-    is_control_openable = controls_ui_service.is_obj_page_exist_via_info_panel(
-        src_obj=audit, obj=expected_control)
     is_control_updateable = (
         controls_ui_service.is_obj_updateble_via_info_panel(
             src_obj=audit, obj=expected_control))
+    is_control_openable = controls_ui_service.is_obj_page_exist_via_info_panel(
+        src_obj=audit, obj=expected_control)
     actual_control = controls_ui_service.get_list_objs_from_info_panels(
         src_obj=audit, objs=expected_control)
-    assert is_control_openable is is_openable
     assert is_control_updateable is False
+    assert is_control_openable is is_openable
     # 'actual_control': created_at, updated_at, modified_by (None)
     self.general_equal_assert(
         expected_control, actual_control,


### PR DESCRIPTION
# Issue description

After the deletion of CADs new revision for object that have value for this CAD is not created. And at the FE in not shown link "Get the latest version" for snapshots after deleting CADs.

# Steps to test the changes

Steps to reproduce: 
1. Go to audit page and confirm that Control is displayed in tree view with values in CAs on the Info pane 
2. Go to Administration > Custom attributes tab and remove all created CAs 
3. Go to audit page, refresh the page and look at the Control's Info pane 

Actual Result: "Get the latest version" link is not shown in Control snapshot Info pane after updating CAs 

Expected Result: "Get the latest version" link should be shown in Control snapshot Info pane after updating CADs

# Solution description

Snapshot has bool attribute "is_latest_revision", which is True if there are no new revisions for snapshot-object, and is False if object was modified after creating snapshot. This attribute use at the FE to showing link "Get the latest version".
After the investigation, I noticed that after removing the CADs, a new revision for the object was not created (dirty-set in the db.session not contain this object).
In the time of deleting CAD is generate event "model_deleted". In the models/hooks were added new listener for this event. This listener change "updated_at" field of objects, that has CAVs for this CADs, to current date. In this case object is modified and appended to the dirty-set of db.Session, and for this object is created a new revision, and snapshot field "is_latest_revision" will be False.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->

<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->
