### PR TITLE
GGRC-3528: Fix tooltip for people role (Program object)

### DIFF
--- a/src/ggrc/assets/mustache/people/tree-item-attr.mustache
+++ b/src/ggrc/assets/mustache/people/tree-item-attr.mustache
@@ -26,7 +26,7 @@
         {{#if roles.length}}
           <div class="item-data">
           <div class="tree-title-area">
-          <span class="role" title="{{#roles}}{{role.permission_summary}} {{/roles}}">
+          <span class="role" title="{{#is roles.0.role.permission_summary 'Mapped'}}No Role{{else}}{{roles.0.role.permission_summary}}{{/is}}">
           {{#if_equals roles.0.role.permission_summary 'Mapped'}}
             <span class="no-role">
               No Role


### PR DESCRIPTION
# Issue description
Incorrect tooltip is shown for person with no role for Program on People tab.

# Steps to test the changes
1. Have program 
2. Go to Peoples tab > map person: confirm mapped person has 'no role' 
3. Hover over first tier in tree vier: 'Mapped' tooltip is shown instead of 'no role'
Actual Result: If hover over user's program role incorrect tooltip is shown up
Expected Result: If hover over user's program role tooltip should be the same as user's program role

# Solution description
Check whether role is 'Mapped' and provide appropriate title value.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".