### PR TITLE
GGRC-3857 Add context to raise issue button

### DIFF
--- a/src/ggrc/assets/javascripts/components/add-issue-button/add-issue-button.js
+++ b/src/ggrc/assets/javascripts/components/add-issue-button/add-issue-button.js
@@ -24,6 +24,10 @@ export default GGRC.Components('addIssueButton', {
               title_singular: instance.class.title_singular,
               table_singular: instance.class.table_singular,
             },
+            context: {
+              type: 'Context',
+              id: instance.attr('context.id'),
+            },
           };
 
           return JSON.stringify(json);


### PR DESCRIPTION
⚠️  I did not have the time today to figure out when the blocker was introduced, but I did checkout 0.10.34 locally and verified that the issue is reproducible there. Hopefully I (or another frontend dev) will do a quick git bisect to determine when the issue was introduced. 

⚠️  I also did not have the time to look at the problems with the editor role (as described in the 3 NOTEs below).

# Issue description

Creator with Auditor role cannot create an Issue from the related issues tab on assessment.

# Steps to test the changes

Steps to reproduce:
1. Log as Global Reader/Global Creator (globcreator@gmail.com (engage007)
2. Create a program, audit
3. On the audit page create assessment and raise an issue for assesment
Actual Result: A message that 'you don't permissions' occurs
Expected Result: Global Reader/Global Creator should have the possibility to raise an issue in their own audit

NOTE:
1. Global Editor can be able to raise an issue for assessment, but the issue is not mapped to audit screenshot-2.png;
2. If Global Editor tries to unmap the issue that he raised a JS error occurs screenshot-3.png;
3. Global Reader/Creator as Auditors have no the possibility to raise an issue: A message that 'you don't permissions' occurs screenshot-4.png;

# Solution description

Permission check was failing for the creator role, because the creator
does not have the permission to create an issue. Auditors get create
issue permission throught the Auditor role, but without the audit
context, the permission check failed.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] db_reset runs without errors or warnings.
- [ ] db_reset ggrc-qa.sql runs without errors or warnings.
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->

<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->
