### PR TITLE
GGRC-3735 Fix Deprecate Assessment with mandatory LCA

### DIFF
--- a/src/ggrc/models/assessment.py
+++ b/src/ggrc/models/assessment.py
@@ -77,7 +77,8 @@ class Assessment(Roleable, statusable.Statusable, AuditRelationship,
 
   REWORK_NEEDED = u"Rework Needed"
   NOT_DONE_STATES = statusable.Statusable.NOT_DONE_STATES | {REWORK_NEEDED, }
-  VALID_STATES = tuple(NOT_DONE_STATES | statusable.Statusable.DONE_STATES)
+  VALID_STATES = tuple(NOT_DONE_STATES | statusable.Statusable.DONE_STATES |
+                       statusable.Statusable.INACTIVE_STATES)
 
   class Labels(object):  # pylint: disable=too-few-public-methods
     """Choices for label enum."""
@@ -248,7 +249,7 @@ class Assessment(Roleable, statusable.Statusable, AuditRelationship,
 
   @orm.reconstructor
   def init_on_load(self):
-      self._warnings = collections.defaultdict(list)
+    self._warnings = collections.defaultdict(list)
 
   def add_warning(self, domain, msg):
     self._warnings[domain].append(msg)

--- a/src/ggrc/models/mixins/statusable.py
+++ b/src/ggrc/models/mixins/statusable.py
@@ -21,11 +21,12 @@ class Statusable(object):
   VERIFIED_STATE = u"Verified"
   FINAL_STATE = u"Completed"
   DEPRECATED = u"Deprecated"
-  END_STATES = {VERIFIED_STATE, FINAL_STATE, DEPRECATED}
+  END_STATES = {VERIFIED_STATE, FINAL_STATE}
+  INACTIVE_STATES = {DEPRECATED, }
 
   NOT_DONE_STATES = {START_STATE, PROGRESS_STATE}
   DONE_STATES = {DONE_STATE} | END_STATES
-  VALID_STATES = tuple(NOT_DONE_STATES | DONE_STATES)
+  VALID_STATES = tuple(NOT_DONE_STATES | DONE_STATES | INACTIVE_STATES)
 
   @declared_attr
   def status(cls):  # pylint: disable=no-self-argument


### PR DESCRIPTION
# Issue description

The issue is connected with the fact that Deprecated status is treated as a Done state which in turn is included in FIRST_CLASS_EDIT states (autostatuschangeable.py: 28).
Since object has attribute changes it goes and handles this first_class_edit: set the _need_status_reset flag to True if object state is inside FIRST_CLASS_EDIT states. This is why system changes objects state to "In Progress". 
We should not consider Deprecated state neither START or DONE state.

# Steps to test the changes

Steps to reproduce:
1. Have an Audit with control snapshot
2. Create assessment template with required LCA with any type, e.g. date
3. Generate assessment based on assessment template
4. Navigate to Assessment Info pane > 3 bb's menu > Depecated
5. Look at the screen: 400 error in console
6. Refresh the page: assessment is moved to the previous state
Expected Result: If required LCA is not filled, Deprecated state should be applied for Assessment.

# Solution description

So I added a new class of states - Inactive states and moved Deprecated from Done states to it.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] db_reset runs without errors or warnings.
- [ ] db_reset ggrc-qa.sql runs without errors or warnings.
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->

<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->
