### PR TITLE
GGRC-3900 'Actual Finish Date' contains 'none' after bulk update of Cycle task via Import

### DIFF
--- a/src/ggrc_workflows/__init__.py
+++ b/src/ggrc_workflows/__init__.py
@@ -757,6 +757,8 @@ def handle_cycle_task_status_change(sender, objs=None):
       continue
     if obj.new_status == obj.instance.VERIFIED:
       obj.instance.verified_date = datetime.now()
+      if obj.instance.finished_date is None:
+        obj.instance.finished_date = obj.instance.verified_date
     elif obj.new_status == obj.instance.FINISHED:
       obj.instance.finished_date = datetime.now()
       obj.instance.verified_date = None


### PR DESCRIPTION
# Issue description

If you update cycle task state over import from Assigned/InProgress state right to the Verified state when Cycle Task finished day is empty. It shouldn't happen. 

# Steps to test the changes

Steps to reproduce:
1. Create any WF (Verification flag - TRUE)
2. Add 1 task to Task Group
3. Activate WF > Cycle Task has 'Assigned' state
4. Export Cycle Task of the Cycle
5. Change state of cycle task to 'Verified' and Import the Cycle task
6. Expand Cycle Task Info pane in UI and look at the Actual Finish Date: is empty
Actual Result: 'Actual Finish Date' contains 'none' after bulk update of Cycle task via Import
Expected Result: 'Actual Finish Date' should contain 'Actual finished date' after bulk update of Cycle task via Import
Attach one or more files to this issue

# Solution description

On update Cycle status to verified check if finished date is empty and if it is when setup finished date same as verified date.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] db_reset runs without errors or warnings.
- [ ] db_reset ggrc-qa.sql runs without errors or warnings.
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->

<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->
