### PR TITLE
GGRC-3651 Update warning message on login page

### DIFF
--- a/src/ggrc/assets/stylesheets/modules/_notifications.scss
+++ b/src/ggrc/assets/stylesheets/modules/_notifications.scss
@@ -23,7 +23,7 @@
     };
 
     display: table;
-    margin: 0px;
+    margin: 10px 0 0;
     padding: 14px;
     border-radius: 2px;
     border: none;

--- a/src/ggrc/views/__init__.py
+++ b/src/ggrc/views/__init__.py
@@ -373,8 +373,8 @@ def index():
   """The initial entry point of the app
   """
   if not settings.PRODUCTION:
-    flash(u"""<b>WARNING</b> - This is not the production instance
-              of the GGRC application.<br><br>
+    flash(u"""This is not the production instance
+              of the GGRC application.<br>
               Company confidential, sensitive or personally identifiable
               information <b>*MUST NOT*</b> be entered or stored here.
               For any questions, please contact your administrator.""",


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

The following improvements for the message in Login page should be done :
1. Remove wording 'WARNING'
2. Remove space between sentences
3. If two messages are shown make margin-top 10 px.

# Steps to test the changes

1. Open GGRC login page
2. Try to login under inactive user 

# Sanity checklist

- [ ] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [ ] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [ ] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [ ] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] db_reset runs without errors or warnings.
- [ ] db_reset ggrc-qa.sql runs without errors or warnings.
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
