### PR TITLE
GGRC-3688 Fix assessment PUT fail when "recipients" field contains ",," value

### DIFF
--- a/src/ggrc/migrations/versions/20171124111204_3911f39325b4_fix_wrong_recipients.py
+++ b/src/ggrc/migrations/versions/20171124111204_3911f39325b4_fix_wrong_recipients.py
@@ -1,0 +1,31 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Fix wrong recipients
+
+Create Date: 2017-11-24 11:12:04.455535
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '3911f39325b4'
+down_revision = '3c69a1e45812'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  op.execute("""
+      UPDATE assessments
+      SET recipients = ''
+      WHERE recipients RLIKE '^,+$';
+  """)
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  # We can't change recients back as we don't know what item was empty
+  # at first and what not (also there is no sense to do it).

--- a/src/ggrc/models/comment.py
+++ b/src/ggrc/models/comment.py
@@ -68,7 +68,7 @@ class Commentable(object):
       # given data - this is intended.
       return ",".join(value)
     elif not value:
-      return value
+      return ""
     else:
       raise ValueError(value,
                        'Value should be either empty ' +

--- a/test/unit/ggrc/models/test_assessement.py
+++ b/test/unit/ggrc/models/test_assessement.py
@@ -3,10 +3,12 @@
 
 """ Unit tests for the Assessment object """
 
+import ddt
+
 from sqlalchemy.orm import attributes
 
 from ggrc import db
-from ggrc.models import Assessment
+from ggrc.models import Assessment, comment
 from ggrc.models import mixins
 from ggrc.models import object_document
 from ggrc.models import object_person
@@ -17,6 +19,7 @@ from ggrc.models.mixins import assignable
 from unit.ggrc.models import test_mixins_base
 
 
+@ddt.ddt
 class TestAssessmentMixins(test_mixins_base.TestMixinsBase):
   """ Tests inclusion of correct mixins and their attributes """
 
@@ -58,3 +61,12 @@ class TestAssessmentMixins(test_mixins_base.TestMixinsBase):
         ('test_plan', attributes.InstrumentedAttribute),                 # TestPlanned    # noqa
         ('title', attributes.InstrumentedAttribute),                     # Titled         # noqa
     ]
+
+  @ddt.data("", ",", ",,", None)
+  def test_empty_recipients(self, recipients):
+    """Test validation of empty recipients: '{}'"""
+    validator = comment.Commentable.validate_recipients
+    self.assertEqual(
+        validator(Assessment(), "recipients", recipients),
+        ""
+    )


### PR DESCRIPTION
# Dependencies

- [x] #6817 (migration for the release branch)


# Issue description

Steps to reproduce:
1. Create an Assessment with "recipients" = ",," (no idea how to do it through the UI, I just had such data in ggrc-qa dump)
2. Click "Complete" on this Assessment's info pane.
Expected result: the state is changed.
Actual result: the backend returns HTTP500.
Supposedly, no other edit to the Assessment succeeds.
Such data shouldn't exit in the app in the first place, we mishandle the "recipients" field in some scenario.
...
```python
  File "/vagrant/src/packages/flask/app.py", line 1475, in full_dispatch_request
    rv = self.dispatch_request()
  File "/vagrant/src/packages/flask/app.py", line 1461, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/vagrant/src/packages/flask_login.py", line 758, in decorated_view
    return func(*args, **kwargs)
  File "/vagrant/src/packages/flask/views.py", line 84, in view
    return self.dispatch_request(*args, **kwargs)
  File "/vagrant/src/ggrc/services/common.py", line 717, in dispatch_request
    return self.put(*args, **kwargs)
  File "/vagrant/src/ggrc/services/common.py", line 854, in put
    obj.__class__, obj=obj, src=src, service=self)
  File "/vagrant/src/packages/blinker/base.py", line 267, in send
    for receiver in self.receivers_for(sender)]
  File "/vagrant/src/ggrc/notifications/notification_handlers.py", line 417, in assignable_modified_listener
    handle_assignable_modified(obj)
  File "/vagrant/src/ggrc/notifications/notification_handlers.py", line 224, in handle_assignable_modified
    if attr_name == u"recipients" and not _recipients_changed(val.history):
  File "/vagrant/src/ggrc/notifications/notification_handlers.py", line 328, in _recipients_changed
    return sorted(old_val.split(",")) != sorted(new_val.split(","))
```

# Steps to test the changes

1. Create an Assessment with "recipients" = ",," or find existing one
2. Click "Complete" on this Assessment's info pane.
Assessment should update its status

# Solution description

Update old corrupted data in db with empty recipients.
Correct recipients validator to set up empty value if non-empty string with empty roles provided (',,')

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# Migration checklist
- [x] db_reset runs without errors or warnings.
- [x] db_reset ggrc-qa.sql runs without errors or warnings.

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
