### PR TITLE
GGRC-3946 Fix import with line breaks inside cells

### DIFF
--- a/src/ggrc_gdrive_integration/file_actions.py
+++ b/src/ggrc_gdrive_integration/file_actions.py
@@ -3,6 +3,8 @@
 
 """File action utitlities for GDrive module"""
 
+from StringIO import StringIO
+
 from apiclient import discovery
 from apiclient import http
 from apiclient.errors import HttpError
@@ -45,7 +47,7 @@ def get_gdrive_file(file_data):
     else:
       file_data = drive_service.files().export_media(
           fileId=file_data['id'], mimeType='text/csv').execute()
-    csv_data = read_csv_file(file_data.splitlines())
+    csv_data = read_csv_file(StringIO(file_data))
   except AttributeError:
     # when file_data has no splitlines() method
     raise BadRequest("Wrong file format.")

--- a/test/unit/ggrc/converters/test_get_gdrive_file.py
+++ b/test/unit/ggrc/converters/test_get_gdrive_file.py
@@ -1,0 +1,44 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Tests for GDrive integration."""
+
+import unittest
+import mock
+
+import ddt
+
+from ggrc_gdrive_integration import file_actions
+
+
+@ddt.ddt
+class TestGetGDRiveFile(unittest.TestCase):
+  """Test getter info from GDrive."""
+
+  CSV_DATA = ('Object_tyle,Code*,Title*,LIST*\n'
+              ',OBJ-1185,OBJ_title,"user1\nuser2"')
+
+  @ddt.data(
+      {"id": "123123", "mimeType": "text/csv"},
+      {"id": "123123"},
+  )
+  @mock.patch("ggrc_gdrive_integration.file_actions.get_http_auth")
+  @mock.patch("ggrc_gdrive_integration.file_actions.discovery")
+  def test_getter_csv(self, file_data, disco_mock, auth_mock):
+    """Test getter csv data over GDrive."""
+    disco_files = disco_mock.build.return_value.files.return_value
+    disco_files.get.return_value.execute.return_value = file_data
+    if "mimeType" in file_data:
+      data_getter = disco_files.get_media.return_value.execute
+    else:
+      data_getter = disco_files.export_media.return_value.execute
+    data_getter.return_value = self.CSV_DATA
+    self.assertEqual(
+        [[u'Object_tyle', u'Code*', u'Title*', u'LIST*'],
+         [u'', u'OBJ-1185', u'OBJ_title', u'user1\nuser2']],
+        file_actions.get_gdrive_file(file_data))
+    auth_mock.assert_called_once_with()
+    disco_mock.build.assert_called_once_with("drive",
+                                             "v3",
+                                             http=auth_mock.return_value)
+    disco_files.get.assert_called_once_with(fileId=file_data["id"])


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

If we have \n in column that we want to import then we will have a Bug on it. Column Value will be broken.

# Steps to test the changes

try to import data if there are line breaks in column

# Solution description

Pull all data from gDrive to Buffer and use that buffer as file in csv parser.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] db_reset runs without errors or warnings.
- [ ] db_reset ggrc-qa.sql runs without errors or warnings.
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
