### PR TITLE
GGRC-3929 Add Workflow needed ACR records

### DIFF
--- a/src/ggrc/models/reflection.py
+++ b/src/ggrc/models/reflection.py
@@ -418,7 +418,9 @@ class AttributeInfo(object):
         definition.update(value)
       definitions[key] = definition
 
-    definitions.update(cls.get_acl_definitions(object_class))
+    # TODO: remove conditional expression when working on Workflow import
+    if not object_class.__name__ == 'Workflow':
+      definitions.update(cls.get_acl_definitions(object_class))
 
     if object_class.__name__ not in EXCLUDE_CUSTOM_ATTRIBUTES:
       definitions.update(cls.get_custom_attr_definitions(

--- a/src/ggrc_workflows/migrations/versions/20171218080506_3355d60d65d8_add_workflow_acr_records.py
+++ b/src/ggrc_workflows/migrations/versions/20171218080506_3355d60d65d8_add_workflow_acr_records.py
@@ -1,0 +1,107 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Add workflow ACL roles
+
+Create Date: 2017-11-26 00:00:00
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+import datetime
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '3355d60d65d8'
+down_revision = '6a7dbb10dfa'
+
+
+ACR_TABLE = sa.sql.table(
+    'access_control_roles',
+    sa.sql.column('name', sa.String),
+    sa.sql.column('object_type', sa.String),
+    sa.sql.column('read', sa.Boolean),
+    sa.sql.column('update', sa.Boolean),
+    sa.sql.column('delete', sa.Boolean),
+    sa.sql.column('my_work', sa.Boolean),
+    sa.sql.column('created_at', sa.DateTime),
+    sa.sql.column('updated_at', sa.DateTime),
+    sa.sql.column('mandatory', sa.Boolean),
+    sa.sql.column('default_to_current_user', sa.Boolean),
+    sa.sql.column('non_editable', sa.Boolean),
+    sa.sql.column('internal', sa.Boolean),
+)
+
+
+DELETE_SQL = """
+DELETE FROM access_control_roles
+WHERE object_type = 'Workflow'
+"""
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  op.bulk_insert(
+      ACR_TABLE,
+      [{
+          'name': 'Admin',
+          'object_type': 'Workflow',
+          'read': True,
+          'update': True,
+          'delete': True,
+          'my_work': True,
+          'created_at': datetime.datetime.now(),
+          'updated_at': datetime.datetime.now(),
+          'mandatory': True,
+          'default_to_current_user': True,
+          'non_editable': True,
+          'internal': False
+      }, {
+          'name': 'Admin Mapped',
+          'object_type': 'Workflow',
+          'read': True,
+          'update': True,
+          'delete': True,
+          'my_work': False,
+          'created_at': datetime.datetime.now(),
+          'updated_at': datetime.datetime.now(),
+          'mandatory': False,
+          'default_to_current_user': False,
+          'non_editable': True,
+          'internal': True
+      }, {
+          'name': 'Workflow Member',
+          'object_type': 'Workflow',
+          'read': True,
+          'update': False,
+          'delete': False,
+          'my_work': False,
+          'created_at': datetime.datetime.now(),
+          'updated_at': datetime.datetime.now(),
+          'mandatory': False,
+          'default_to_current_user': False,
+          'non_editable': True,
+          'internal': False
+      }, {
+          'name': 'Workflow Member Mapped',
+          'object_type': 'Workflow',
+          'read': True,
+          'update': False,
+          'delete': False,
+          'my_work': False,
+          'created_at': datetime.datetime.now(),
+          'updated_at': datetime.datetime.now(),
+          'mandatory': False,
+          'default_to_current_user': False,
+          'non_editable': True,
+          'internal': True
+      }]
+  )
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  op.execute(DELETE_SQL)


### PR DESCRIPTION
# Issue description

In scope of moving Workflow roles to ACL needed roles should be added.

# Steps to test the changes

alembic upgrade, downgrade + db_reset

# Solution description

Check the code, please. It is pretty simple. [Here is](https://docs.google.com/document/d/1ktIPqtiC84gX9XlKD7O3c5mb-OVnnsnY3T8RqsnL5Y8/edit#) some technical details as well as requirements.

# Sanity checklist

- [ ] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [ ] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [ ] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [ ] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] db_reset runs without errors or warnings.
- [ ] db_reset ggrc-qa.sql runs without errors or warnings.
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
