### PR TITLE
GGRC-3844 Default sorting control is not set in the tree view for Last updated column for Assessment

### DIFF
--- a/src/ggrc/assets/javascripts/components/tree/tree-header.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-header.js
@@ -5,7 +5,8 @@
 
 import '../sortable-column/sortable-column';
 import template from './templates/tree-header.mustache';
-import {createSelectedColumnsMap} from '../../plugins/utils/tree-view-utils';
+import {createSelectedColumnsMap, getSortingForModel}
+  from '../../plugins/utils/tree-view-utils';
 
 export default GGRC.Components('treeHeader', {
   tag: 'tree-header',
@@ -98,7 +99,18 @@ export default GGRC.Components('treeHeader', {
 
       return modelName === 'CycleTaskGroupObjectTask' || modelName === 'Cycle';
     },
+    initializeOrder() {
+      let sortingInfo;
+      if (!this.attr('model')) {
+        return;
+      }
+
+      sortingInfo = getSortingForModel(this.attr('model').shortName);
+      this.attr('orderBy.field', sortingInfo.key);
+      this.attr('orderBy.direction', sortingInfo.direction);
+    },
     init: function () {
+      this.initializeOrder();
       this.initializeColumns();
     },
   },


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Tree view doesn't sorted by 'Last updated' by default

# Steps to test the changes

1. On the My work page open Assessment tab
2. Look at the Last updated column: sorting control is not set by default by DESC
_Actual Result_: Default sorting control is not set in the tree view for Last updated column for Assessment
_Expected Result_: Default sorting control should be set in the tree view for Last updated column for Assessment. Sorting by DESC

# Solution description

'_tree-header_' component sets '_order_' property by default

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] db_reset runs without errors or warnings.
- [ ] db_reset ggrc-qa.sql runs without errors or warnings.
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
