### PR TITLE
GGRC-3957,GGRC-3958: Make Workflow and TaskGroup readonly on CTGOT Edit modal

### DIFF
--- a/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/modal_content.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/modal_content.mustache
@@ -49,19 +49,27 @@
             Active Workflow
             <i class="fa fa-asterisk"></i>
           </label>
-          <input
-            class="input-block-level required"
-            name="workflow."
-            model="Workflow"
-            data-lookup="Workflow"
-            data-params="Workflow:status=Active,frequency=one_time"
-            data-lookup-cb="set_properties_from_workflow"
-            placeholder="Select a Workflow"
-            type="text"
-            value="{{workflow.title}}"
-            tabindex="4" />
-          {{#instance.computed_errors.workflow}}<label class="help-inline warning">{{this}}</label>{{/instance.computed_errors.workflow}}
-          {{^instance.computed_errors.workflow}}{{#instance.computed_errors.cycle}}<label class="help-inline warning">No active cycles in this workflow</label>{{/instance.computed_errors.cycle}}{{/instance.computed_errors.workflow}}
+          {{#if new_object_form}}
+            <input
+              class="input-block-level required"
+              name="workflow."
+              model="Workflow"
+              data-lookup="Workflow"
+              data-params="Workflow:status=Active,frequency=one_time"
+              data-lookup-cb="set_properties_from_workflow"
+              placeholder="Select a Workflow"
+              type="text"
+              value="{{workflow.title}}"
+              tabindex="4" />
+            {{#instance.computed_errors.workflow}}<label class="help-inline warning">{{this}}</label>{{/instance.computed_errors.workflow}}
+            {{^instance.computed_errors.workflow}}{{#instance.computed_errors.cycle}}<label class="help-inline warning">No active cycles in this workflow</label>{{/instance.computed_errors.cycle}}{{/instance.computed_errors.workflow}}
+          {{else}}
+            <input
+              class="input-block-level"
+              type="text"
+              disabled
+              {$value}="workflow.title" />
+          {{/if}}
         {{/using}}
       </div>
       <br>
@@ -71,20 +79,28 @@
             Task Group
             <i class="fa fa-asterisk"></i>
           </label>
-          <input
-            {{^if instance.cycle}} disabled {{/if}}
-            class="input-block-level required"
-            name="cycle_task_group."
-            data-lookup="CycleTaskGroup"
-            data-query
-            data-query-field="group title"
-            data-query-relevant-type="{{instance.cycle.type}}"
-            data-query-relevant-id="{{instance.cycle.id}}"
-            placeholder="Select a Task Group"
-            type="text"
-            value="{{cycle_task_group.title}}"
-            data-template="/cycle_task_groups/autocomplete_result.mustache"
-            tabindex="5" />
+          {{#if new_object_form}}
+            <input
+              {{^if instance.cycle}} disabled {{/if}}
+              class="input-block-level required"
+              name="cycle_task_group."
+              data-lookup="CycleTaskGroup"
+              data-query
+              data-query-field="group title"
+              data-query-relevant-type="{{instance.cycle.type}}"
+              data-query-relevant-id="{{instance.cycle.id}}"
+              placeholder="Select a Task Group"
+              type="text"
+              value="{{cycle_task_group.title}}"
+              data-template="/cycle_task_groups/autocomplete_result.mustache"
+              tabindex="5" />
+            {{else}}
+              <input
+                class="input-block-level"
+                type="text"
+                disabled
+                {$value}="cycle_task_group.title" />
+            {{/if}}
         {{/using}}
       {{#instance.computed_errors.cycle_task_group}}<label class="help-inline warning">{{this}}</label>{{/instance.computed_errors.cycle_task_group}}
     </div>


### PR DESCRIPTION
# Issue description
Remove ability to move CTGOT to other Workflow or TaskGroup.

# Steps to test the changes
Open Edit modal for CTGOT on MyTasks page or on Active Cycles tab for Workflow.

# Solution description
Check whether it is existing object and show fields in read-only mode.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

NOTE: there is known issue with empty values for Workflow and TaskGroup if user opens Edit modal on My Tasks page via flipped down menu.