### PR TITLE
GGRC-3659 Remove snapshots mapping if it absent for their children

### DIFF
--- a/test/integration/ggrc/snapshotter/__init__.py
+++ b/test/integration/ggrc/snapshotter/__init__.py
@@ -45,7 +45,7 @@ class SnapshotterBaseTestCase(TestCase):
     return obj
 
   def create_audit(self, program, title=None):
-    self.create_object(models.Audit, {
+    return self.create_object(models.Audit, {
         "title": "Snapshotable audit" if title is None else title,
         "program": {"id": program.id},
         "status": "Planned",


### PR DESCRIPTION
# Issue description

Mappings between snapshot objects is not removed if child objects were unmapped and Audit was updated to the latest version.

# Steps to test the changes

1. Create a Program.
2. Create a Control and map it to the Program.
3. Create 5 Regulations and map them both to the Program and to the Control.
4. Create an Audit, generate an Assessment over the Control.
5. Unmap 3 Regulations from the Control.
6. Update Audit to the latest version.
7. Open the Control popup on the Assessment info pane, expand Related Regulations list.
Expected result: 2 Regulations (not unmapped in step 5) are shown.

# Solution description

Add method that find difference between snapshot relationships and their children and remove it.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
