### PR TITLE
GGRC-3983: Fix CustomRole column width on modals

### DIFF
--- a/src/ggrc/assets/stylesheets/modules/_modal.scss
+++ b/src/ggrc/assets/stylesheets/modules/_modal.scss
@@ -661,6 +661,12 @@
     .repeat-summary {
       margin: 16px 0 10px 0;
     }
+
+    .people-group {
+      flex-basis: 250px;
+      margin-right: 30px;
+      max-width: 250px;
+    }
   }
   .modal-footer {
     @include box-shadow(none);
@@ -800,6 +806,8 @@
      }
 
      .people-group {
+       flex-basis: 200px;
+
        .editable-people-group {
          margin-right: 15px;
        }


### PR DESCRIPTION
CustomRole columns should occupy the same width as form items.

# Issue description
CustomRole column occupies less space than form item

# Steps to test the changes
1) Open New-Edit  Assessment modal
2) Compare width of "Creators", "Assignees", "Verifiers" at the top of modal with "Code" and "Due Date" at the bottom.

# Solution description
Enlarge width to 250px and make right margin smaller (30px).

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

