### PR TITLE
GGRC-2545 Remove redundant GET request before assessment state change

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.js
+++ b/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.js
@@ -449,7 +449,7 @@ import tracker from '../../../tracker';
         }
         instance.attr('isPending', true);
 
-        this.attr('formState.formSavedDeferred')
+        return this.attr('formState.formSavedDeferred')
           .then(() => {
             instance.attr('status', isUndo ? previousStatus : newStatus);
 

--- a/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.js
+++ b/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.js
@@ -434,6 +434,12 @@ import tracker from '../../../tracker';
         let stopFn = tracker.start(instance.type,
           tracker.USER_JOURNEY_KEYS.NAVIGATION,
           tracker.USER_ACTIONS.ASSESSMENT.CHANGE_STATUS);
+        const resetStatusOnConflict = (object, xhr) => {
+          if (xhr && xhr.status === 409 && xhr.remoteObject) {
+            instance.attr('status', xhr.remoteObject.status);
+          }
+        };
+
         this.attr('onStateChangeDfd', can.Deferred());
 
         if (isUndo) {
@@ -460,7 +466,8 @@ import tracker from '../../../tracker';
             this.attr('onStateChangeDfd').resolve();
             stopFn();
           })
-          .always(() => instance.attr('isPending', false));
+          .always(() => instance.attr('isPending', false))
+          .fail(resetStatusOnConflict);
       },
       saveGlobalAttributes: function (event) {
         var globalAttributes = event.globalAttributes;

--- a/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.js
+++ b/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.js
@@ -430,7 +430,6 @@ import tracker from '../../../tracker';
         var isUndo = event.undo;
         var newStatus = event.state;
         var instance = this.attr('instance');
-        var self = this;
         var previousStatus = instance.attr('previousStatus') || 'In Progress';
         let stopFn = tracker.start(instance.type,
           tracker.USER_JOURNEY_KEYS.NAVIGATION,
@@ -445,24 +444,22 @@ import tracker from '../../../tracker';
         instance.attr('isPending', true);
 
         this.attr('formState.formSavedDeferred')
-          .then(function () {
-            instance.refresh().then(function () {
-              instance.attr('status', isUndo ? previousStatus : newStatus);
+          .then(() => {
+            instance.attr('status', isUndo ? previousStatus : newStatus);
 
-              if (instance.attr('status') === 'In Review' && !isUndo) {
-                $(document.body).trigger('ajax:flash',
-                  {hint: 'The assessment is complete. ' +
-                  'The verifier may revert it if further input is needed.'});
-              }
+            if (instance.attr('status') === 'In Review' && !isUndo) {
+              $(document.body).trigger('ajax:flash',
+                {hint: 'The assessment is complete. ' +
+                'The verifier may revert it if further input is needed.'});
+            }
 
-              return instance.save()
-              .then(function () {
-                instance.attr('isPending', false);
-                self.initializeFormFields();
-                self.attr('onStateChangeDfd').resolve();
-                stopFn();
-              });
-            });
+            return instance.save();
+          })
+          .then(() => {
+            instance.attr('isPending', false);
+            this.initializeFormFields();
+            this.attr('onStateChangeDfd').resolve();
+            stopFn();
           });
       },
       saveGlobalAttributes: function (event) {

--- a/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.js
+++ b/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.js
@@ -456,11 +456,11 @@ import tracker from '../../../tracker';
             return instance.save();
           })
           .then(() => {
-            instance.attr('isPending', false);
             this.initializeFormFields();
             this.attr('onStateChangeDfd').resolve();
             stopFn();
-          });
+          })
+          .always(() => instance.attr('isPending', false));
       },
       saveGlobalAttributes: function (event) {
         var globalAttributes = event.globalAttributes;

--- a/src/ggrc/assets/javascripts/models/cacheable_conflict_resolution.js
+++ b/src/ggrc/assets/javascripts/models/cacheable_conflict_resolution.js
@@ -52,6 +52,7 @@ export default function resolveConflict(xhr, obj) {
       $(document.body).trigger('ajax:flash', {
         warning: GGRC.Errors.messages[409],
       });
+      xhr.remoteObject = remoteAttrs;
       return new $.Deferred().reject(xhr, 409, 'CONFLICT');
     }
     return obj.save();


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Changing a state on assessment should be the same as editing a field in an assessment and there is no need to make a get request before put.
Assessment shown is the one being verified and we should always have the latest etag for it. If someone edited the assessment elsewhere, we would still allow the state change without warning a user that he might be verifying data that is not displayed.
Such assumptions are dangerous and the fact that we might not have the correct etag should be solved elsewhere not on the state button click.

# Steps to test the changes

1. Open Assessment info-pane
2. Change status of Assessment

**Actual result:** before PUT request sended extra GET request on assessment
**Expected result:** must be sended only PUT request

# Solution description

was removed extra GET request,
conflict resolution of simple property was done in https://github.com/google/ggrc-core/pull/6720

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] db_reset runs without errors or warnings.
- [ ] db_reset ggrc-qa.sql runs without errors or warnings.
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
