### PR TITLE
GGRC-3955,3952 Correct assessment status update to Deprecated

### DIFF
--- a/src/ggrc/models/assessment.py
+++ b/src/ggrc/models/assessment.py
@@ -186,7 +186,6 @@ class Assessment(Roleable, statusable.Statusable, AuditRelationship,
       'test_plan',
       'title',
       'start_date',
-      'end_date'
   }
 
   _aliases = {

--- a/src/ggrc/models/assessment.py
+++ b/src/ggrc/models/assessment.py
@@ -264,7 +264,7 @@ class Assessment(Roleable, statusable.Statusable, AuditRelationship,
     if self.status == value:
       return value
     if self.status == self.REWORK_NEEDED:
-      valid_states = [self.DONE_STATE, self.FINAL_STATE]
+      valid_states = [self.DONE_STATE, self.FINAL_STATE, self.DEPRECATED]
       if value not in valid_states:
         raise ValueError("Assessment in `Rework Needed` "
                          "state can be only moved to: [{}]".format(

--- a/test/integration/ggrc/converters/test_import_assessments.py
+++ b/test/integration/ggrc/converters/test_import_assessments.py
@@ -540,6 +540,24 @@ class TestAssessmentImport(TestCase):
     self.assertEqual(1, resp[0]["updated"])
     self.assertEqual(result.end_date, datetime.date(2017, 1, 1))
 
+  @ddt.data(*models.Assessment.VALID_STATES)
+  def test_import_set_up_deprecated(self, start_state):
+    """Update assessment from {0} to Deprecated."""
+    with factories.single_commit():
+      assessment = factories.AssessmentFactory(status=start_state)
+    resp = self.import_data(
+        OrderedDict([
+            ("object_type", "Assessment"),
+            ("code", assessment.slug),
+            ("State", models.Assessment.DEPRECATED),
+        ]))
+    self.assertEqual(1, len(resp))
+
+    self.assertEqual(1, resp[0]["updated"])
+    self.assertEqual(
+        models.Assessment.query.get(assessment.id).status,
+        models.Assessment.DEPRECATED)
+
 
 @ddt.ddt
 class TestAssessmentExport(TestCase):


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

1) Over import and over api not started assessment on status update to Deprecated will be moved in Progress state.
2) Imposible to move assessment from ReworkNeeded state to Deprecated

# Steps to test the changes

1) create new assessment 
2) update it's state to deprecated
--------------------
1) create new assessment 
2) update state to rework needed 
3) update state to deprecated

# Solution description

1) remove end_date from tracked fields, end date is the service field and it's not allowed to change by user 
2) add Deprecated state as valid to move from Rework Needed 

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] db_reset runs without errors or warnings.
- [ ] db_reset ggrc-qa.sql runs without errors or warnings.
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
