### PR TITLE
GGRC-3880 Add job to synchronize statuses of Assessment and issue tracker BUG

### DIFF
--- a/._license_header_exceptions
+++ b/._license_header_exceptions
@@ -106,7 +106,6 @@
 < src/ggrc-client/styles/components/related-objects/_related-reference-urls.scss
 < src/ggrc/converters/handlers/related_person.py
 < src/ggrc_gdrive_integration/migrations/README
-< src/ggrc/integrations/__init__.py
 < src/ggrc/maintenance_views/__init__.py
 < src/ggrc/migrations/__init__.py
 < src/ggrc/migrations/utils/migrate_contacts.py

--- a/src/cron.yaml
+++ b/src/cron.yaml
@@ -8,7 +8,9 @@ cron:
   url: /nightly_cron_endpoint
   schedule: every day 01:00
   timezone: US/Pacific
+- description: GGRC - Hourly Issue Tracker sync job
+  url: /hourly_issue_tracker_sync_endpoint
+  schedule: every 1 hours synchronized
 - description: GGRC - half hour jobs
   url: /half_hour_cron_endpoint
   schedule: every 30 mins
-  timezone: US/Pacific

--- a/src/ggrc/contributions.py
+++ b/src/ggrc/contributions.py
@@ -3,14 +3,20 @@
 
 """Lists of ggrc contributions."""
 
+from ggrc.integrations import utils
+
 from ggrc.notifications import common
 from ggrc.notifications import notification_handlers
 from ggrc.notifications import data_handlers
 from ggrc.utils import proposal
 
 
-CONTRIBUTED_CRON_JOBS = [
+NIGHTLY_CRON_JOBS = [
     common.send_daily_digest_notifications,
+]
+
+HOURLY_CRON_JOBS = [
+    utils.sync_issue_tracker_statuses,
 ]
 
 HALF_HOUR_CRON_JOBS = [

--- a/src/ggrc/integrations/__init__.py
+++ b/src/ggrc/integrations/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>

--- a/src/ggrc/integrations/utils.py
+++ b/src/ggrc/integrations/utils.py
@@ -1,0 +1,52 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Module provides various utils for Issue tracker integration service."""
+
+import logging
+
+from sqlalchemy.sql import expression
+from ggrc.integrations import issues, integrations_errors
+from ggrc.models import IssuetrackerIssue
+from ggrc.models.hooks.issue_tracker import _STATUSES as STATUSES_MAP
+
+
+logger = logging.getLogger(__name__)
+
+
+def sync_issue_tracker_statuses():
+  """Synchronize issue tracker ticket statuses with the Assessment statuses.
+
+  Check for Assessments which are in sync with issue tracker issues and update
+  their statuses in accordance to the corresponding Assessments if differ.
+  """
+  issue_objects = IssuetrackerIssue.query.filter(
+      IssuetrackerIssue.object_type == 'Assessment',
+      IssuetrackerIssue.enabled == expression.true(),
+      IssuetrackerIssue.issue_id.isnot(None),
+  ).order_by(IssuetrackerIssue.object_id).all()
+  for iti in issue_objects:
+    asmt = iti.issue_tracked_obj
+    if not asmt:
+      logger.error(
+          "The Assessment corresponding to the Issue Tracker Issue ID=%d "
+          "does not exist.", iti.issue_id)
+      continue
+    status_value = STATUSES_MAP.get(asmt.status)
+    if status_value:
+      issue_params = {
+          'status': status_value,
+          'type': iti.issue_type,
+          'priority': iti.issue_priority,
+          'severity': iti.issue_severity,
+      }
+    else:
+      logger.error(
+          "Inexistent Issue Tracker status for assessment ID=%d "
+          "with status: %s.", asmt.id, status_value)
+    try:
+      issues.Client().update_issue(iti.issue_id, issue_params)
+    except integrations_errors.Error as error:
+      logger.error(
+          'Unable to update IssueTracker issue status ID=%s '
+          'for assessment ID=%d: %s', iti.issue_id, asmt.id, error)

--- a/src/ggrc/views/cron.py
+++ b/src/ggrc/views/cron.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2018 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
-"""Collects specific cton views."""
+""" Cron job endpoints initialization and running stuff """
 
 from logging import getLogger
 from traceback import format_exc
@@ -37,7 +37,7 @@ def run_job(job):
 
 
 def job_runner(name):
-  """Run jobs related to sent name."""
+  """Run all contributed jobs from all extension modules"""
   cron_jobs = extensions.get_module_contributions(name)
   for job in cron_jobs:
     run_job(job)
@@ -55,11 +55,12 @@ def hourly_issue_tracker_sync_endpoint():
 
 
 def half_hour_cron_endpoint():
+  """Endpoint running half hourly jobs from all modules"""
   return job_runner("HALF_HOUR_CRON_JOBS")
 
 
 def init_cron_views(app):
-  """Init cron views."""
+  """Init all cron jobs' endpoints"""
   app.add_url_rule(
       "/nightly_cron_endpoint", "nightly_cron_endpoint",
       view_func=nightly_cron_endpoint)

--- a/src/ggrc/views/cron.py
+++ b/src/ggrc/views/cron.py
@@ -45,7 +45,13 @@ def job_runner(name):
 
 
 def nightly_cron_endpoint():
-  return job_runner("CONTRIBUTED_CRON_JOBS")
+  """Endpoint running nightly jobs from all modules"""
+  return job_runner("NIGHTLY_CRON_JOBS")
+
+
+def hourly_issue_tracker_sync_endpoint():
+  """Endpoint running hourly jobs from all modules"""
+  return job_runner("HOURLY_CRON_JOBS")
 
 
 def half_hour_cron_endpoint():
@@ -55,13 +61,16 @@ def half_hour_cron_endpoint():
 def init_cron_views(app):
   """Init cron views."""
   app.add_url_rule(
-      "/nightly_cron_endpoint",
-      "nightly_cron_endpoint",
-      view_func=nightly_cron_endpoint
+      "/nightly_cron_endpoint", "nightly_cron_endpoint",
+      view_func=nightly_cron_endpoint)
+
+  app.add_url_rule(
+      "/hourly_issue_tracker_sync_endpoint",
+      "hourly_issue_tracker_sync_endpoint",
+      view_func=half_hour_cron_endpoint
   )
 
   app.add_url_rule(
-      "/half_hour_cron_endpoint",
-      "half_hour_cron_endpoint",
+      "/half_hour_cron_endpoint", "half_hour_cron_endpoint",
       view_func=half_hour_cron_endpoint
   )

--- a/src/ggrc_workflows/__init__.py
+++ b/src/ggrc_workflows/__init__.py
@@ -862,5 +862,5 @@ contributed_importables = IMPORTABLE
 contributed_exportables = EXPORTABLE
 contributed_column_handlers = COLUMN_HANDLERS
 contributed_get_ids_related_to = relationship_helper.get_ids_related_to
-CONTRIBUTED_CRON_JOBS = [start_recurring_cycles]
+NIGHTLY_CRON_JOBS = [start_recurring_cycles]
 NOTIFICATION_LISTENERS = [notification.register_listeners]

--- a/test/integration/ggrc/integrations/__init__.py
+++ b/test/integration/ggrc/integrations/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>

--- a/test/integration/ggrc/integrations/test_issuetracker_issue.py
+++ b/test/integration/ggrc/integrations/test_issuetracker_issue.py
@@ -1,0 +1,78 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Integration test for Clonable mixin"""
+
+from mock import patch
+
+from ggrc import db
+from ggrc import models
+from ggrc.integrations import issues as issues_module
+from ggrc.integrations import utils
+
+from integration.ggrc.models import factories
+from integration.ggrc.snapshotter import SnapshotterBaseTestCase
+
+
+class TestIssueTrackerIntegration(SnapshotterBaseTestCase):
+
+  """Test set for IssueTracker integration functionality"""
+
+  # pylint: disable=invalid-name
+
+  def setUp(self):
+    # pylint: disable=super-on-old-class
+    # pylint seems to get confused, mro chain successfully resolves and returns
+    # <type 'object'> as last entry.
+    super(TestIssueTrackerIntegration, self).setUp()
+
+    self.client.get("/login")
+
+  # pylint: disable=unused-argument
+  @patch('ggrc.integrations.issues.Client.update_issue')
+  def test_update_issuetracker_info(self, mock_update_issue):
+    """Test that issuetracker issues are updated by the utility"""
+    from ggrc.models.hooks import issue_tracker
+    with patch.object(issue_tracker, '_is_issue_tracker_enabled',
+                      return_value=True):
+      iti_issue_id = []
+      for _ in range(2):
+        iti = factories.IssueTrackerIssueFactory()
+        iti_issue_id.append(iti.issue_id)
+        asmt = iti.issue_tracked_obj
+        asmt_id = asmt.id
+        audit = asmt.audit
+        self.api.modify_object(audit, {
+            "issue_tracker": {
+                "enabled": True,
+                "component_id": "11111",
+                "hotlist_id": "222222",
+            },
+        })
+        asmt = db.session.query(models.Assessment).get(asmt_id)
+        self.api.modify_object(asmt, {
+            "issue_tracker": {
+                "enabled": True,
+                "component_id": "11111",
+                "hotlist_id": "222222",
+            },
+        })
+        asmt = db.session.query(models.Assessment).get(asmt_id)
+        self.api.modify_object(asmt, {
+            "issue_tracker": {
+                "enabled": True,
+                "component_id": "11111",
+                "hotlist_id": "222222",
+                "issue_priority": "P4",
+                "issue_severity": "S3",
+            },
+        })
+      self.api.delete(asmt)
+      with patch.object(issues_module.Client, 'update_issue',
+                        return_value=None) as mock_method:
+        utils.sync_issue_tracker_statuses()
+        mock_method.assert_called_once_with(iti_issue_id[0],
+                                            {'status': 'ASSIGNED',
+                                             'priority': u'P4',
+                                             'type': None,
+                                             'severity': u'S3'})


### PR DESCRIPTION
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [x] GGRC-4033

# Issue description

The issue is that someone may come and change the status of the BUG in the issue tracker system. While corresponding Assessment did not change it's status. The status of the BUG should be adjusted back to the status of the corresponding Assessment.

# Steps to test the changes

1. User create Assessment with Issue Tracker switch ON.
2. Assessment is in 'Not Started' state for example.
3. User goes and moved assessment into 'Fixed' state.
Expected result: BUG status should be equal to Assessment state. BUG status should be reverted to 'Assigned'.


# Solution description

A cron job was created.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] db_reset runs without errors or warnings.
- [ ] db_reset ggrc-qa.sql runs without errors or warnings.
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
