### PR TITLE
GGRC-3916 "Add required info" link of LCA with dropdown type is active if assessment is archived

### DIFF
--- a/src/ggrc/assets/mustache/components/custom-attributes/custom-attributes.mustache
+++ b/src/ggrc/assets/mustache/components/custom-attributes/custom-attributes.mustache
@@ -25,6 +25,17 @@
           (value-changed)="fieldValueChanged(%event, %context)"
 	  class="form-field__content {{extraClass type}}"
         ></custom-attributes-field>
+        {{#if validation.hasMissingInfo}}
+          <div class="form-field__validation-hint-placeholder">
+              <button class="btn btn-small btn-link btn-link-nopadding" ($click)="showRequiredInfoModal(%event, %context)">Add required info</button>
+          </div>
+        {{/if}}
+        {{#isInvalidField validation.show validation.valid highlightInvalidFields}}
+          <form-validation-text
+            {validation}="validation"
+            {type}="type">
+          </form-validation-text>
+        {{/isInvalidField}}
       {{else}}
         <custom-attributes-field-view
           {type}="type"
@@ -32,17 +43,6 @@
           class="form-field__content {{extraClass type}}"
         ></custom-attributes-field-view>
       {{/if}}
-      {{#if validation.hasMissingInfo}}
-        <div class="form-field__validation-hint-placeholder">
-            <button class="btn btn-small btn-link btn-link-nopadding" ($click)="showRequiredInfoModal(%event, %context)">Add required info</button>
-        </div>
-      {{/if}}
-      {{#isInvalidField validation.show validation.valid highlightInvalidFields}}
-        <form-validation-text
-          {validation}="validation"
-          {type}="type">
-        </form-validation-text>
-      {{/isInvalidField}}
     </div>
   {{/each}}
 </div>


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

"Add required info" link is shown when assessment is not in an editable state.

# Steps to test the changes

**Steps to reproduce:**
1. Have audit with a control snapshot
2. Create assessment template with LCA (dropdown type, comment, evidence are required)
3. Generate assessment based on a control snapshot and assessment template
4. Expand Assessment Info pane and select the value that require a comment from LCA
5. Do not enter a comment and click Close: "Add required info" link should be displayed in grey box
6. Archive audit
7. Expand Assessment info pane and click on "Add required info" link: comment box is displayed
8. Type any comment and click Save: "Uncaught TypeError: e.item.attr is not a function" error message is displayed

**Actual Result:** "Add required info" link of LCA with dropdown type is active if assessment is archived. While clicking on it and adding a comment, JS error is displayed.
**Expected Result:** "Add required info" link of LCA with dropdown type should be hidden if assessment is archived - TBD.

# Solution description

Show "Add required info" button and validation text only when assessment is in `editMode`.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] db_reset runs without errors or warnings.
- [ ] db_reset ggrc-qa.sql runs without errors or warnings.
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
