### PR TITLE
GGRC-3228 Fetch data for Assessment info panel use custom endpoint

### DIFF
--- a/src/ggrc/access_control/list.py
+++ b/src/ggrc/access_control/list.py
@@ -4,6 +4,7 @@
 """Access Control List model"""
 
 from ggrc import db
+from ggrc.builder import simple_property
 from ggrc.models import mixins
 from ggrc.models import reflection
 
@@ -15,10 +16,11 @@ class AccessControlList(mixins.Base, db.Model):
   permission of the role to the person from that object.
   """
   __tablename__ = 'access_control_list'
-
   _api_attrs = reflection.ApiAttributes(
       "person",
       reflection.Attribute("person_id", create=False, update=False),
+      reflection.Attribute("person_email", create=False, update=False),
+      reflection.Attribute("person_name", create=False, update=False),
       "ac_role_id"
   )
 
@@ -37,6 +39,14 @@ class AccessControlList(mixins.Base, db.Model):
       lambda: AccessControlList,
       remote_side=lambda: AccessControlList.id
   )
+
+  @simple_property
+  def person_email(self):
+    return self.person.email if self.person else None
+
+  @simple_property
+  def person_name(self):
+    return self.person.name if self.person else None
 
   @property
   def object_attr(self):

--- a/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.js
+++ b/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.js
@@ -239,9 +239,6 @@ import {REFRESH_TAB_CONTENT} from '../../../events/eventTypes';
           .always(function () {
             this.attr('isUpdating' + can.capitalize(type), false);
 
-            if (this.attr('isUpdatingRelatedItems')) {
-              this.attr('isUpdatingRelatedItems', false);
-            }
             tracker.stop(this.attr('instance.type'),
               tracker.USER_JOURNEY_KEYS.NAVIGATION,
               tracker.USER_ACTIONS.OPEN_INFO_PANE);
@@ -388,16 +385,20 @@ import {REFRESH_TAB_CONTENT} from '../../../events/eventTypes';
       updateRelatedItems: function () {
         this.attr('isUpdatingRelatedItems', true);
 
-        this.attr('mappedSnapshots')
-          .replace(this.loadSnapshots());
-        this.attr('comments')
-          .replace(this.loadComments());
-        this.attr('evidences')
-          .replace(this.loadEvidences());
-        this.attr('urls')
-          .replace(this.loadUrls());
-        this.attr('referenceUrls')
-          .replace(this.loadReferenceUrls());
+        this.attr('instance').getRelatedObjects()
+          .then((data) => {
+            this.attr('mappedSnapshots').replace(data.Snapshot);
+            this.attr('comments').replace(data.Comment);
+            this.attr('evidences').replace(data['Document:EVIDENCE']);
+            this.attr('urls').replace(data['Document:URL']);
+            this.attr('referenceUrls').replace(data['Document:REFERENCE_URL']);
+
+            this.attr('isUpdatingRelatedItems', false);
+
+            tracker.stop(this.attr('instance.type'),
+              tracker.USER_JOURNEY_KEYS.NAVIGATION,
+              tracker.USER_ACTIONS.OPEN_INFO_PANE);
+          });
       },
       initializeFormFields: function () {
         var cavs =

--- a/src/ggrc/assets/javascripts/components/modal-connector.js
+++ b/src/ggrc/assets/javascripts/components/modal-connector.js
@@ -381,12 +381,11 @@ import {
         );
       },
       getMappedObjects: function () {
-        var dfd = can.Deferred();
         var auditQuery = this.buildQuery('Audit')[0];
         var issueQuery = this.buildQuery('Issue')[0];
         var snapshotQuery = this.buildQuery('Snapshot')[0];
 
-        makeRequest({data: [auditQuery, issueQuery, snapshotQuery]})
+        return makeRequest({data: [auditQuery, issueQuery, snapshotQuery]})
           .then(function (response) {
             var snapshots;
             var list;
@@ -406,11 +405,9 @@ import {
               .concat(response[1].Issue.values)
               .concat(snapshots);
 
-            dfd.resolve(list);
+            return list;
           }
         );
-
-        return dfd;
       },
     },
     helpers: {

--- a/src/ggrc/assets/javascripts/components/object-list-item/person-list-item.js
+++ b/src/ggrc/assets/javascripts/components/object-list-item/person-list-item.js
@@ -35,6 +35,8 @@
             actualPerson = CMS.Models.Person.store[newVal.id] || {};
             if (actualPerson.email) {
               setVal(actualPerson);
+            } else if (newVal.email) {
+              setVal(newVal);
             } else {
               actualPerson = new CMS.Models.Person({id: newVal.id});
               new RefreshQueue()

--- a/src/ggrc/assets/javascripts/components/related-objects/related-people-access-control.js
+++ b/src/ggrc/assets/javascripts/components/related-objects/related-people-access-control.js
@@ -13,7 +13,6 @@ export default GGRC.Components('relatedPeopleAccessControl', {
     groups: [],
     updatableGroupId: null,
     isNewInstance: false,
-    includeRoles: [],
     excludeRoles: [],
     conflictRoles: [],
     orderOfRoles: [],
@@ -134,6 +133,8 @@ export default GGRC.Components('relatedPeopleAccessControl', {
         group.map(function (groupItem) {
           return {
             id: groupItem.person.id,
+            email: groupItem.person_email,
+            name: groupItem.person_name,
             type: 'Person',
           };
         }) :

--- a/src/ggrc/assets/javascripts/controllers/mapper/mapper.js
+++ b/src/ggrc/assets/javascripts/controllers/mapper/mapper.js
@@ -116,7 +116,7 @@ const ObjectMapper = can.Control.extend({
       inScopeObject =
         CMS.Models[data.join_object_type].store[data.join_object_id];
       inScopeObject.updateScopeObject().then(function () {
-        var scopeObject = inScopeObject.attr('scopeObject');
+        var scopeObject = inScopeObject.attr('audit');
 
         if (!scopeObject.id) {
           GGRC.Errors.notifier('error', DATA_CORRUPTION_MESSAGE);

--- a/src/ggrc/assets/javascripts/controllers/tests/mapper_spec.js
+++ b/src/ggrc/assets/javascripts/controllers/tests/mapper_spec.js
@@ -39,7 +39,7 @@ describe('ObjectMapper', function () {
             updateScopeObject: jasmine.createSpy('updateScopeObject')
               .and
               .returnValue(updateScopeObject),
-            scopeObject: scopeObject,
+            audit: scopeObject,
           }),
         ],
       };

--- a/src/ggrc/assets/javascripts/models/assessment.js
+++ b/src/ggrc/assets/javascripts/models/assessment.js
@@ -413,5 +413,8 @@ import {prepareCustomAttributes} from '../plugins/utils/ca-utils';
       this._pending_refresh.fn();
       return dfd;
     },
+    getRelatedObjects () {
+      return $.get(`/api/assessments/${this.attr('id')}/related_objects`);
+    },
   });
 })(window.can, window.GGRC, window.CMS);

--- a/src/ggrc/assets/javascripts/models/assessment.js
+++ b/src/ggrc/assets/javascripts/models/assessment.js
@@ -412,7 +412,21 @@ import {prepareCustomAttributes} from '../plugins/utils/ca-utils';
       return dfd;
     },
     getRelatedObjects () {
-      return $.get(`/api/assessments/${this.attr('id')}/related_objects`);
+      return $.get(`/api/assessments/${this.attr('id')}/related_objects`)
+        .then((response) => {
+          let auditTitle = response.Audit.title;
+
+          if (this.attr('audit')) {
+            this.attr('audit.title', auditTitle);
+
+            if (this.attr('audit.issue_tracker')) {
+              this.attr('can_use_issue_tracker',
+                this.attr('audit.issue_tracker.enabled'));
+            }
+          }
+
+          return response;
+        });
     },
   });
 })(window.can, window.GGRC, window.CMS);

--- a/src/ggrc/assets/javascripts/models/assessment.js
+++ b/src/ggrc/assets/javascripts/models/assessment.js
@@ -17,7 +17,7 @@ import {prepareCustomAttributes} from '../plugins/utils/ca-utils';
     destroy: 'DELETE /api/assessments/{id}',
     create: 'POST /api/assessments',
     mixins: [
-      'ownable', 'unique_title',
+      'ownable', 'unique_title', 'ca_update',
       'autoStatusChangeable', 'timeboxed', 'mapping-limit',
       'inScopeObjects', 'accessControlList', 'refetchHash',
       'issueTrackerIntegratable',
@@ -413,8 +413,5 @@ import {prepareCustomAttributes} from '../plugins/utils/ca-utils';
       this._pending_refresh.fn();
       return dfd;
     },
-    info_pane_preload: function () {
-      this.refresh();
-    }
   });
 })(window.can, window.GGRC, window.CMS);

--- a/src/ggrc/assets/javascripts/models/assessment.js
+++ b/src/ggrc/assets/javascripts/models/assessment.js
@@ -311,8 +311,6 @@ import {prepareCustomAttributes} from '../plugins/utils/ca-utils';
       if (pageInstance && (!this.audit || !this.audit.id || !this.audit.type)) {
         if (pageInstance.type === 'Audit') {
           this.attr('audit', pageInstance);
-        } else if (this.scopeObject) {
-          this.audit = this.scopeObject;
         }
       }
 

--- a/src/ggrc/assets/javascripts/models/audit_models.js
+++ b/src/ggrc/assets/javascripts/models/audit_models.js
@@ -381,6 +381,7 @@ import '../components/audit/attach-folder-button'
     mixins: [
       'mapping-limit',
       'inScopeObjects',
+      'inScopeObjectsPreload',
       'refetchHash',
       'issueTrackerIntegratable',
     ],

--- a/src/ggrc/assets/javascripts/models/issue.js
+++ b/src/ggrc/assets/javascripts/models/issue.js
@@ -17,6 +17,7 @@
       'timeboxed',
       'mapping-limit-issue',
       'inScopeObjects',
+      'inScopeObjectsPreload',
       'accessControlList',
       'base-notifications',
     ],

--- a/src/ggrc/assets/javascripts/models/mixins.js
+++ b/src/ggrc/assets/javascripts/models/mixins.js
@@ -199,10 +199,15 @@ import {isSnapshot} from '../plugins/utils/snapshot-utils';
     }
   });
 
-  can.Model.Mixin('inScopeObjects', {}, {
+  can.Model.Mixin('inScopeObjectsPreload', {}, {
     'after:info_pane_preload': function () {
-      return this.updateScopeObject();
+      if (this.updateScopeObject) {
+        this.updateScopeObject();
+      }
     },
+  });
+
+  can.Model.Mixin('inScopeObjects', {}, {
     updateScopeObject: function () {
       var objType = 'Audit';
       var queryType = 'values';

--- a/src/ggrc/assets/javascripts/models/mixins.js
+++ b/src/ggrc/assets/javascripts/models/mixins.js
@@ -219,7 +219,7 @@ import {isSnapshot} from '../plugins/utils/snapshot-utils';
       return batchRequests(query)
         .done(function (valueArr) {
           var audit = valueArr[objType][queryType][0];
-          this.attr('scopeObject', audit);
+
           this.attr('audit', audit);
           if (audit && audit.issue_tracker) {
             this.attr('can_use_issue_tracker',


### PR DESCRIPTION
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [x] https://github.com/google/ggrc-core/pull/6913

# Issue description

After this ticket is done, all information needed to display an assessment info panel or edit modal should be fetched with only two queries
get /api/assessments/x
get /api/assessments/x/related_objects
This ticket does not require the other requests to be removed. That would be good but if it is too much work we should have separate tickets for removal of additional requests.
But the acceptance criteria for this ticket is that all info needed is received by those two mentioned requests.

# Steps to test the changes

Open Assessment Info pane

# Solution description

Assessment indo pane data is loading by optimized endpoint

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] db_reset runs without errors or warnings.
- [ ] db_reset ggrc-qa.sql runs without errors or warnings.
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
