### PR TITLE
GGRC-2895/3948/3954 Task Group showing as overdue even when all milestones completed

### DIFF
--- a/src/ggrc_workflows/migrations/versions/20171204095103_6a7dbb10dfa_fix_cycle_and_cycle_task_group_dates.py
+++ b/src/ggrc_workflows/migrations/versions/20171204095103_6a7dbb10dfa_fix_cycle_and_cycle_task_group_dates.py
@@ -1,0 +1,90 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Recalculate cycle and cycle_task_group end and next due dates and update them
+
+Create Date: 2017-12-04 09:51:03.929341
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '6a7dbb10dfa'
+down_revision = '3e0a6fc71158'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  op.execute("""
+      UPDATE cycle_task_groups g1
+      LEFT JOIN (
+          SELECT g.id, MAX(t.end_date) AS max_end_date
+          FROM cycle_task_groups g
+          JOIN cycles c
+              ON g.cycle_id = c.id
+          LEFT JOIN cycle_task_group_object_tasks t
+              ON t.cycle_task_group_id = g.id
+          WHERE t.status IN ('Assigned', 'InProgress') OR (
+              c.is_verification_needed = 1 AND t.status IN ('Finished'))
+          GROUP BY g.id
+      ) AS g2
+      ON g1.id = g2.id
+      SET g1.end_date = g2.max_end_date
+  """)
+
+  op.execute("""
+      UPDATE cycle_task_groups g1
+      LEFT JOIN (
+          SELECT g.id, MIN(t.end_date) AS min_end_date
+          FROM cycle_task_groups g
+          JOIN cycles c
+              ON g.cycle_id = c.id
+          LEFT JOIN cycle_task_group_object_tasks t
+              ON t.cycle_task_group_id = g.id
+          WHERE t.end_date > NOW() AND (
+              t.status in ('Assigned', 'InProgress') OR (
+              c.is_verification_needed = 1 AND t.status IN ('Finished')))
+          GROUP BY g.id
+      ) AS g2
+      ON g1.id = g2.id
+      SET g1.next_due_date = g2.min_end_date
+  """)
+
+  op.execute("""
+      UPDATE cycles c1
+      LEFT JOIN (
+          SELECT c.id, MAX(g.end_date) AS max_end_date
+          FROM cycles c
+          JOIN cycle_task_groups g
+              ON g.cycle_id = c.id
+          WHERE g.status IN ('Assigned', 'InProgress') OR (
+              c.is_verification_needed = 1 AND g.status IN ('Finished'))
+          GROUP BY c.id
+      ) AS c2
+      ON c1.id = c2.id
+      SET c1.end_date = c2.max_end_date
+  """)
+
+  op.execute("""
+      UPDATE cycles c1
+          LEFT JOIN (
+          SELECT c.id, MIN(g.next_due_date) AS min_next_due_date
+          FROM cycles c
+          JOIN cycle_task_groups g
+              ON g.cycle_id = c.id
+          WHERE g.end_date > NOW() AND (
+              g.status IN ('Assigned', 'InProgress') OR (
+              c.is_verification_needed = 1 AND g.status IN ('Finished')))
+          GROUP BY c.id
+      ) AS c2
+      ON c1.id = c2.id
+      SET c1.next_due_date = c2.min_next_due_date
+  """)
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""

--- a/src/ggrc_workflows/services/resource.py
+++ b/src/ggrc_workflows/services/resource.py
@@ -35,7 +35,7 @@ class CycleTaskResource(common.Resource):
       signal_context.append(context_element)
     ggrc_workflows.Signals.status_change.send(self.model,
                                               objs=signal_context)
-    ggrc_workflows.update_cycle_task_object_task_parent_state(updated_objects)
+    ggrc_workflows.update_cycle_task_tree(updated_objects)
 
   @staticmethod
   def log_event():


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

*ISSUE 1: Task Group state is NOT recalculated when cycle task is deleted*

*ISSUE 2: Cycle and cycle task group are still overdue, if all overdue tasks are completed / verified.*

# Steps to test the changes

*ISSUE 1: Task Group state is NOT recalcualated when cycle task is deleted*

1. Cycle task group should have 2 cycle tasks: In Progress and Finished.
2. Remove 'In Progress' cycle task.
Actual result: Cycle task group has 'In Progress' state.
Expected result: Cycle task group has 'Finished' state.


*ISSUE 2: Cycle and cycle task group are still overdue, if all overdue tasks are completed / verified.*
1. Create a WF with a task group.
2. Add 2 tasks into task group. (1 of them should be overdue after activation)
3. Activate WF.
4. Complete / Verify overdue tasks.

Actual result: cycle and cycle task group still have overdue flag.
Expected result: cycle and cycle task group should NOT have overdue flag.

# Solution description

1) cycle task group state should be re-calculated if  tasks are added/deleted.
2) cycle task group should be moved to 'Deprecated' state, if all cycle tasks are removed.
3) cycle and cycle task group statuses and dates calculation is moved to a separate commit in order to prevent deadlocks.
4) updated records are locked while reading in order to prevent async changes.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# Migration checklist
- [x] db_reset runs without errors or warnings.
- [x] db_reset ggrc-qa.sql runs without errors or warnings.
- [x] db_migrate, db_downgrade, db_migrate work on a full database in that order.

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
