### PR TITLE
GGRC-3945 Fix deletion of LCA from Edit Assessment template window

### DIFF
--- a/src/ggrc/models/mixins/customattributable.py
+++ b/src/ggrc/models/mixins/customattributable.py
@@ -321,7 +321,7 @@ class CustomAttributable(object):
       return
 
     definitions = src.get("custom_attribute_definitions")
-    if definitions:
+    if definitions is not None:
       self.process_definitions(definitions)
 
     attributes = src.get("custom_attributes")

--- a/test/integration/ggrc/models/mixins/test_customattributable.py
+++ b/test/integration/ggrc/models/mixins/test_customattributable.py
@@ -2,7 +2,7 @@
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
 """Integration test for custom attributable mixin"""
-
+import collections
 import ddt
 
 from ggrc import db
@@ -287,3 +287,58 @@ class TestCreateRevisionAfterDeleteCAD(TestCase):
     snapshot = models.Snapshot.query.filter().first()
 
     self.assertEqual(snapshot.is_latest_revision, False)
+
+
+class TestCADUpdate(TestCase):
+  """Test cases for updating model inherited custom attributable mixin."""
+  def setUp(self):
+    """Set up test cases."""
+    super(TestCADUpdate, self).setUp()
+    self.client.get("/login")
+    self.api = api_helper.Api()
+
+  def test_lcads_removing(self):
+    """Test removing of LCADs from AssessmentTemplate"""
+    with factories.single_commit():
+      template = factories.AssessmentTemplateFactory()
+      for i in range(2):
+        factories.CustomAttributeDefinitionFactory(
+            title="test CA def {}".format(i),
+            definition_type=template._inflector.table_singular,
+            definition_id=template.id,
+            attribute_type="Text"
+        )
+
+    response = self.api.put(template, {"custom_attribute_definitions": []})
+    self.assert200(response)
+
+    cads_query = models.CustomAttributeDefinition.query.filter_by(
+        definition_type=template._inflector.table_singular,
+        definition_id=template.id,
+    )
+    self.assertEqual(cads_query.count(), 0)
+
+  def test_lcads_import_update(self):
+    """Test saving of LCADs for Assessment Template after import"""
+    cads_count = 2
+    with factories.single_commit():
+      template = factories.AssessmentTemplateFactory()
+      for i in range(cads_count):
+        factories.CustomAttributeDefinitionFactory(
+            title="test CA def {}".format(i),
+            definition_type=template._inflector.table_singular,
+            definition_id=template.id,
+            attribute_type="Text"
+        )
+    response = self.import_data(collections.OrderedDict([
+        ("object_type", "Assessment_Template"),
+        ("Code*", template.slug),
+        ("Title", "New title"),
+    ]))
+    self._check_csv_response(response, {})
+
+    cads_query = models.CustomAttributeDefinition.query.filter_by(
+        definition_type=template._inflector.table_singular,
+        definition_id=template.id,
+    )
+    self.assertEqual(cads_query.count(), cads_count)


### PR DESCRIPTION
# Issue description

User cannot delete LCA from Edit Assessment template modal window.
Steps to reproduce:
1. On the audit page create Assessment template with LCA (any type)
2. Invoke Edit Assessment template modal window and remove LCA > Click Save and Close
3. Invoke Edit Assessment template modal window again: LCA wasn't removed

# Steps to test the changes

1. On the audit page create Assessment template with LCA (any type)
2. Invoke Edit Assessment template modal window and remove LCA > Click Save and Close
3. Invoke Edit Assessment template modal window again: LCA should be removed

# Solution description

Reason of issue is that local CADs will be removed on BE only if we receive non-empty list in `custom_attribute_definition` field from FE. So if user want to remove all CADs from Assessment template, this list will be empty and BE skip deletion code. I remove this check as we have to process CADs in any case.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
