### PR TITLE
GGRC-3935: provide WF Admin in ACL for Approval WF

### DIFF
--- a/src/ggrc_workflows/assets/javascripts/controllers/approval-workflow-modal.js
+++ b/src/ggrc_workflows/assets/javascripts/controllers/approval-workflow-modal.js
@@ -38,12 +38,24 @@ let ApprovalWorkflow = can.Observe({
       object_type: 'TaskGroupTask',
       name: 'Task Assignees',
     });
+    var wfAdminRole = _.find(GGRC.access_control_roles, {
+      object_type: 'Workflow',
+      name: 'Admin',
+    });
 
     return aws_dfd.then(function (aws) {
       var ret;
+      var user = GGRC.current_user;
       if (aws.length < 1) {
         ret = $.when(
           new CMS.Models.Workflow({
+            access_control_list: [{
+              ac_role_id: wfAdminRole.id,
+              person: {
+                id: user.id,
+                type: 'Person',
+              },
+            }],
             unit: null,
             status: 'Active',
             title: reviewTemplate({
@@ -53,8 +65,8 @@ let ApprovalWorkflow = can.Observe({
             object_approval: true,
             notify_on_change: true,
             notify_custom_message: notifyTemplate({
-              name: GGRC.current_user.name,
-              email: GGRC.current_user.email,
+              name: user.name,
+              email: user.email,
               type: that.original_object.constructor.model_singular,
               title: that.original_object.title,
               before: moment(that.end_date).format('MM/DD/YYYY'),

--- a/src/ggrc_workflows/assets/javascripts/controllers/tests/approval-workflow-model-helper_spec.js
+++ b/src/ggrc_workflows/assets/javascripts/controllers/tests/approval-workflow-model-helper_spec.js
@@ -14,12 +14,18 @@ describe('ApprovalWorkflow', function () {
     var userOldValue;
     var currentUser;
     var assigneeRole;
+    var wfAdminRole;
 
     beforeAll(function () {
       assigneeRole = {
         object_type: 'TaskGroupTask',
         name: 'Task Assignees',
         id: -10,
+      };
+      wfAdminRole = {
+        object_type: 'Workflow',
+        name: 'Admin',
+        id: -12,
       };
       currentUser = new can.Map({
         email: 'test@example.com',
@@ -28,7 +34,7 @@ describe('ApprovalWorkflow', function () {
       });
 
       acrOldValues = GGRC.access_control_roles;
-      GGRC.access_control_roles = [assigneeRole];
+      GGRC.access_control_roles = [assigneeRole, wfAdminRole];
 
       userOldValue = GGRC.current_user;
       GGRC.current_user = currentUser;
@@ -102,6 +108,13 @@ describe('ApprovalWorkflow', function () {
 
       it('creates an appropriate Workflow', function () {
         expect(CMS.Models.Workflow).toHaveBeenCalledWith({
+          access_control_list: [{
+            ac_role_id: wfAdminRole.id,
+            person: {
+              id: currentUser.id,
+              type: 'Person',
+            },
+          }],
           unit: null,
           status: 'Active',
           title: jasmine.any(String),

--- a/src/ggrc_workflows/assets/javascripts/controllers/tests/approval-workflow-model-helper_spec.js
+++ b/src/ggrc_workflows/assets/javascripts/controllers/tests/approval-workflow-model-helper_spec.js
@@ -5,18 +5,18 @@
 
 import {ApprovalWorkflow as Model} from '../approval-workflow-modal';
 
-describe('ApprovalWorkflow', function () {
-  describe('save() method', function () {
-    var method;
-    var originalObject;
-    var awsDfd;
-    var acrOldValues;
-    var userOldValue;
-    var currentUser;
-    var assigneeRole;
-    var wfAdminRole;
+describe('ApprovalWorkflow', ()=> {
+  describe('save() method', ()=> {
+    let method;
+    let originalObject;
+    let awsDfd;
+    let acrOldValues;
+    let userOldValue;
+    let currentUser;
+    let assigneeRole;
+    let wfAdminRole;
 
-    beforeAll(function () {
+    beforeAll(()=> {
       assigneeRole = {
         object_type: 'TaskGroupTask',
         name: 'Task Assignees',
@@ -40,14 +40,14 @@ describe('ApprovalWorkflow', function () {
       GGRC.current_user = currentUser;
     });
 
-    afterAll(function () {
+    afterAll(()=> {
       GGRC.access_control_roles = acrOldValues;
       GGRC.current_user = userOldValue;
     });
 
-    beforeEach(function () {
-      var awBinding;
-      var instance;
+    beforeEach(()=> {
+      let awBinding;
+      let instance;
 
       awsDfd = new can.Deferred();
       awBinding = {
@@ -67,14 +67,14 @@ describe('ApprovalWorkflow', function () {
       method = Model.prototype.save.bind(instance);
     });
 
-    describe('no approval Workflow', function () {
-      var saveWfDfd;
-      var saveTgDfd;
-      var saveTgtDfd;
-      var saveTgoDfd;
-      var saveCycleDfd;
+    describe('no approval Workflow', ()=> {
+      let saveWfDfd;
+      let saveTgDfd;
+      let saveTgtDfd;
+      let saveTgoDfd;
+      let saveCycleDfd;
 
-      beforeEach(function () {
+      beforeEach(()=> {
         saveWfDfd = new can.Deferred();
         saveTgDfd = new can.Deferred();
         saveTgtDfd = new can.Deferred();
@@ -106,7 +106,7 @@ describe('ApprovalWorkflow', function () {
         awsDfd.resolve([]);
       });
 
-      it('creates an appropriate Workflow', function () {
+      it('creates an appropriate Workflow', ()=> {
         expect(CMS.Models.Workflow).toHaveBeenCalledWith({
           access_control_list: [{
             ac_role_id: wfAdminRole.id,
@@ -125,8 +125,8 @@ describe('ApprovalWorkflow', function () {
         });
       });
 
-      it('creates an appropriate TaskGroup', function () {
-        var wf = {};
+      it('creates an appropriate TaskGroup', ()=> {
+        const wf = {};
 
         saveWfDfd.resolve(wf);
 
@@ -138,9 +138,9 @@ describe('ApprovalWorkflow', function () {
         });
       });
 
-      it('creates an appropriate TaskGroupTask', function () {
-        var wf = {};
-        var tg = {};
+      it('creates an appropriate TaskGroupTask', ()=> {
+        const wf = {};
+        const tg = {};
 
         saveWfDfd.resolve(wf);
         saveTgDfd.resolve(tg);
@@ -164,9 +164,9 @@ describe('ApprovalWorkflow', function () {
         });
       });
 
-      it('creates an appropriate TaskGroupObject', function () {
-        var tg = {};
-        var wf = new can.Map({
+      it('creates an appropriate TaskGroupObject', ()=> {
+        const tg = {};
+        const wf = new can.Map({
           context: {},
         });
 
@@ -180,9 +180,9 @@ describe('ApprovalWorkflow', function () {
         });
       });
 
-      it('creates an appropriate Cycle', function () {
-        var tg = {};
-        var wf = {
+      it('creates an appropriate Cycle', ()=> {
+        const tg = {};
+        const wf = {
           context: {},
         };
 
@@ -198,9 +198,9 @@ describe('ApprovalWorkflow', function () {
         });
       });
 
-      it('reloads original object', function () {
-        var tg = {};
-        var wf = {
+      it('reloads original object', ()=> {
+        const tg = {};
+        const wf = {
           context: {},
         };
 
@@ -214,17 +214,17 @@ describe('ApprovalWorkflow', function () {
       });
     });
 
-    describe('couple of approval Workflows', function () {
-      var aws;
-      var tgt;
-      var tg;
-      var saveTgDfd;
-      var saveTgtDfd;
-      var refreshTgtDfd;
-      var saveCycleDfd;
-      var awInstance;
+    describe('couple of approval Workflows', ()=> {
+      let aws;
+      let tgt;
+      let tg;
+      let saveTgDfd;
+      let saveTgtDfd;
+      let refreshTgtDfd;
+      let saveCycleDfd;
+      let awInstance;
 
-      beforeEach(function () {
+      beforeEach(()=> {
         saveTgDfd = can.Deferred();
         saveTgtDfd = can.Deferred();
         refreshTgtDfd = can.Deferred();
@@ -273,22 +273,22 @@ describe('ApprovalWorkflow', function () {
         awsDfd.resolve(aws);
       });
 
-      it('refreshes first Approval WF and TGs only', function () {
+      it('refreshes first Approval WF and TGs only', ()=> {
         expect(aws[0].instance.refresh).toHaveBeenCalled();
         expect(aws[0].instance.task_groups.reify).toHaveBeenCalled();
         expect(tg.refresh).toHaveBeenCalled();
         expect(aws[1].instance.refresh).not.toHaveBeenCalled();
       });
 
-      it('updates contact for TGs', function () {
+      it('updates contact for TGs', ()=> {
         expect(tg.attr('contact')).toEqual(currentUser);
       });
 
-      it('updates TGs contact', function () {
+      it('updates TGs contact', ()=> {
         expect(tg.attr('contact')).toEqual(currentUser);
       });
 
-      it('updates TGTs ACL', function () {
+      it('updates TGTs ACL', ()=> {
         saveTgDfd.resolve(tg);
         refreshTgtDfd.resolve(tgt);
 
@@ -300,7 +300,7 @@ describe('ApprovalWorkflow', function () {
           .toEqual('Person');
       });
 
-      it('creates an appropriate Cycle', function () {
+      it('creates an appropriate Cycle', ()=> {
         saveTgDfd.resolve(tg);
         refreshTgtDfd.resolve(tgt);
         saveTgtDfd.resolve();
@@ -312,7 +312,7 @@ describe('ApprovalWorkflow', function () {
         });
       });
 
-      it('reloads original object', function () {
+      it('reloads original object', ()=> {
         saveTgDfd.resolve(tg);
         refreshTgtDfd.resolve(tgt);
         saveTgtDfd.resolve();


### PR DESCRIPTION
# Dependencies
This PR is `on hold` until the dependencies are merged:
- [x] #6878 

# Issue description
Provide WF Admin in ACL for Approval Workflow.

# Steps to test the changes
1. Open any Control without approval task
2. Run the following code in Web Tools Console 
``` javascript 
GGRC.access_control_roles.push({
default_to_current_user:false,
delete:true,
id:83,
mandatory:true,
modified_by:null,
my_work:false,
name:"Admin",
non_editable:false,
object_type:"Workflow",
read:true,
selfLink:"/api/access_control_roles/83",
tooltip:null,
type:"AccessControlRole",
update:true})
```
3. Create Approval WF and check request on WF creation in Web Tools -> Network tab


# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

