### PR TITLE
GGRC-4008 Add order to assessment comments

### DIFF
--- a/src/ggrc/services/assessment_resource.py
+++ b/src/ggrc/services/assessment_resource.py
@@ -142,6 +142,9 @@ class AssessmentResource(common.ExtendedResource):
     with benchmark("Get assessment comment data"):
       comments = models.Comment.eager_query().filter(
           models.Comment.id.in_(relationship_ids)
+      ).order_by(
+          models.Comment.created_at.desc(),
+          models.Comment.id.desc(),
       ).all()
     return [comment.log_json() for comment in comments]
 


### PR DESCRIPTION
# Issue description

Currently comments are requested(using Query API) with the following sorting parameters:
{sortBy: 'created_at', sortDirection: 'desc'}
Custom endpoint should return comments with the similar sorting

# Steps to test the changes

trigger a custom endpont for /api/assessments/X/related_objects and check comment order
the latest comment should be on top

# Solution description

Added order by creation date and Id to comments. Id is needed because multiple comments can be added via imports which makes their created at time the same, but we should still retain the same order as they were in the csv fle.

# Sanity checklist

- [ ] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] db_reset runs without errors or warnings.
- [ ] db_reset ggrc-qa.sql runs without errors or warnings.
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
