### PR TITLE
GGRC-3764 3bbs shows an empty menu - fix the empty menu on the audit (tab) tree view screen.

### DIFF
--- a/src/ggrc/assets/javascripts/components/three-dots-menu/templates/three-dots-menu.mustache
+++ b/src/ggrc/assets/javascripts/components/three-dots-menu/templates/three-dots-menu.mustache
@@ -1,0 +1,15 @@
+{{!
+    Copyright (C) 2017 Google Inc.
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+}}
+
+<div class="details-wrap">
+  <a class="btn {{#if disabled}}disabled{{/if}} btn-3bbps dropdown-toggle" href="#" data-toggle="dropdown">
+    <span class="bubble"></span>
+    <span class="bubble"></span>
+    <span class="bubble"></span>
+  </a>
+  <ul class="dropdown-menu tree-action-list-items" role="menu">
+    <content/>
+  </ul>
+</div>

--- a/src/ggrc/assets/javascripts/components/three-dots-menu/tests/three-dots-menu_spec.js
+++ b/src/ggrc/assets/javascripts/components/three-dots-menu/tests/three-dots-menu_spec.js
@@ -1,0 +1,164 @@
+/*
+ Copyright (C) 2017 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+import Component from '../three-dots-menu';
+
+describe('three-dots-menu component', function () {
+  let vm;
+
+  beforeEach(function () {
+    vm = getComponentVM(Component);
+  });
+
+  describe('manageEmptyList() method', function () {
+    let menuNode;
+
+    beforeEach(function () {
+      menuNode = {
+        children: [],
+      };
+    });
+
+    it('sets disabled field to true if the menu node does not have childrens',
+    function () {
+      vm.manageEmptyList(menuNode);
+      expect(vm.attr('disabled')).toBe(true);
+    });
+
+    it('sets disabled field to false if the menu node has childrens',
+    function () {
+      menuNode.children = [1, 2, 3];
+      vm.manageEmptyList(menuNode);
+      expect(vm.attr('disabled')).toBe(false);
+    });
+  });
+
+  describe('mutationCallback() method', function () {
+    let mutationList;
+
+    beforeEach(function () {
+      mutationList = [];
+    });
+
+    it('calls manageEmptyList method for each mutation with passed menu node',
+    function () {
+      spyOn(vm, 'manageEmptyList');
+
+      mutationList.push(
+        {target: {}},
+        {target: {}}
+      );
+      vm.mutationCallback(mutationList);
+
+      mutationList.forEach((mutation) => {
+        const menuNode = mutation.target;
+        expect(vm.manageEmptyList).toHaveBeenCalledWith(menuNode);
+      });
+    });
+  });
+
+  describe('initObserver() method', function () {
+    let element;
+
+    beforeEach(function () {
+      [element] = $('<ul role="menu"></ul>');
+    });
+
+    it('sets observer field to the new instance of MutationObserver object',
+    function () {
+      vm.initObserver(element);
+      expect(vm.attr('observer')).toEqual(jasmine.any(MutationObserver));
+    });
+
+    describe('calls observe method which', function () {
+      let observer;
+
+      beforeEach(function () {
+        observer = {
+          observe: jasmine.createSpy('observe'),
+        };
+        spyOn(window, 'MutationObserver').and.returnValue(observer);
+      });
+
+      it('observes passed menu node', function () {
+        const MENU_NODE_ARG_ORDER = 0;
+        vm.initObserver(element);
+        expect(observer.observe.calls.argsFor(0)[MENU_NODE_ARG_ORDER])
+          .toBe(element);
+      });
+
+      it('watches only childList changes', function () {
+        const CONFIG_ARG_ORDER = 1;
+        const expectedConfig = {childList: true};
+        vm.initObserver(element);
+        expect(observer.observe.calls.argsFor(0)[CONFIG_ARG_ORDER])
+          .toEqual(expectedConfig);
+      });
+    });
+  });
+
+  describe('events scope', () => {
+    let events;
+    let eventsContext;
+
+    beforeEach(function () {
+      events = Component.prototype.events;
+      eventsContext = {
+        viewModel: vm,
+      };
+    });
+
+    describe('inserted() event', function () {
+      let method;
+      let $element;
+
+      beforeEach(function () {
+        $element = $(
+          `<div>
+            <ul role="menu"></ul>
+          </div>`
+        );
+      });
+
+      beforeEach(function () {
+        method = events.inserted.bind(eventsContext);
+      });
+
+      it('calls viewModel.initObserver() method with passed menu node',
+      function () {
+        const [menuNode] = $element.find('[role=menu]');
+        spyOn(vm, 'initObserver');
+        method($element);
+        expect(vm.initObserver).toHaveBeenCalledWith(menuNode);
+      });
+
+      it('calls viewModel.manageEmptyList() method with passed menu node',
+      function () {
+        const [menuNode] = $element.find('[role=menu]');
+        spyOn(vm, 'manageEmptyList');
+        method($element);
+        expect(vm.manageEmptyList).toHaveBeenCalledWith(menuNode);
+      });
+    });
+
+    describe('removed() event', function () {
+      let method;
+
+      beforeEach(function () {
+        method = events.removed.bind(eventsContext);
+      });
+
+      it('calls disconnect method for observer field', function () {
+        const observer = {
+          disconnect: jasmine.createSpy('disconnect'),
+        };
+        vm.attr('observer', observer);
+        method();
+        expect(observer.disconnect).toHaveBeenCalled();
+      });
+    });
+  });
+});
+

--- a/src/ggrc/assets/javascripts/components/three-dots-menu/three-dots-menu.js
+++ b/src/ggrc/assets/javascripts/components/three-dots-menu/three-dots-menu.js
@@ -1,0 +1,45 @@
+/*
+ Copyright (C) 2017 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+import template from './templates/three-dots-menu.mustache';
+
+const viewModel = can.Map.extend({
+  disabled: true,
+  observer: null,
+  manageEmptyList(menuNode) {
+    const isEmpty = menuNode.children.length === 0;
+    this.attr('disabled', isEmpty);
+  },
+  mutationCallback(mutationsList) {
+    mutationsList.forEach((mutation) => {
+      const menuNode = mutation.target;
+      this.manageEmptyList(menuNode);
+    });
+  },
+  initObserver(menuNode) {
+    const config = {childList: true};
+    const observer = new MutationObserver(this.mutationCallback.bind(this));
+    observer.observe(menuNode, config);
+    this.attr('observer', observer);
+  },
+});
+
+const events = {
+  inserted(element) {
+    const [menuNode] = element.find('[role=menu]');
+    this.viewModel.initObserver(menuNode);
+    this.viewModel.manageEmptyList(menuNode);
+  },
+  removed() {
+    this.viewModel.attr('observer').disconnect();
+  },
+};
+
+export default can.Component({
+  tag: 'three-dots-menu',
+  template,
+  viewModel,
+  events,
+});

--- a/src/ggrc/assets/javascripts/components/tree/templates/tree-widget-container.mustache
+++ b/src/ggrc/assets/javascripts/components/tree/templates/tree-widget-container.mustache
@@ -44,13 +44,7 @@
         {{{renderLive addItem}}}
       {{/if}}
       {{#if show3bbs}}
-      <div class="details-wrap">
-        <a class="btn {{#if disable3bbs}}disabled{{/if}} btn-3bbps dropdown-toggle" href="#" data-toggle="dropdown">
-          <span class="bubble"></span>
-          <span class="bubble"></span>
-          <span class="bubble"></span>
-        </a>
-        <ul class="dropdown-menu tree-action-list-items" role="menu">
+        <three-dots-menu>
           {{^if isSnapshots}}
             {{#is_allowed 'update' model.shortName context=parent_instance.context}}
               <li>
@@ -82,8 +76,7 @@
               </bulk-update-button>
             </li>
           {{/if}}
-        </ul>
-      </div>
+        </three-dots-menu>
       {{/if}}
     </div>
 

--- a/src/ggrc/assets/javascripts/components/tree/tree-widget-container.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-widget-container.js
@@ -27,6 +27,7 @@ import '../advanced-search/advanced-search-mapping-container';
 import '../bulk-update-button/bulk-update-button';
 import '../dropdown/multiselect-dropdown';
 import '../assessment_generator';
+import '../three-dots-menu/three-dots-menu';
 import template from './templates/tree-widget-container.mustache';
 import * as StateUtils from '../../plugins/utils/state-utils';
 import {
@@ -221,12 +222,6 @@ viewModel = can.Map.extend({
       type: Boolean,
       get: function () {
         return !isMyAssessments();
-      },
-    },
-    disable3bbs: {
-      type: Boolean,
-      get: function () {
-        return this.attr('isSnapshots') && !this.attr('showedItems').length;
       },
     },
     noResults: {


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

*Empty 3dds menu.*

![screen shot 2017-10-17 at 1 53 41 pm 1](https://user-images.githubusercontent.com/13063442/33756752-f8aa9342-dc07-11e7-9734-b1433d32ac15.png)

# Steps to test the changes

*Open any Object tab when you have Creator role. When the objects is loaded the 3bbs menu is empty.*

# Solution description

*Disable 3bbs button while the object is loaded.*

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] db_reset runs without errors or warnings.
- [ ] db_reset ggrc-qa.sql runs without errors or warnings.
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
