### PR TITLE
GGRC-4020 Fix Audit cloning server error

### DIFF
--- a/src/ggrc/migrations/versions/20171208083413_45ccf2a009bb_fix_default_peole.py
+++ b/src/ggrc/migrations/versions/20171208083413_45ccf2a009bb_fix_default_peole.py
@@ -1,0 +1,38 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Fix default_peole for old Assessment templates
+
+Create Date: 2017-12-08 08:34:13.915060
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '45ccf2a009bb'
+down_revision = '1af0b27960a2'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  op.execute("""
+      UPDATE assessment_templates
+      SET default_people = REPLACE(
+          default_people, '"assessors":', '"assignees":'
+      )
+      WHERE default_people like '%"assessors":%'
+  """)
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  op.execute("""
+      UPDATE assessment_templates
+      SET default_people = REPLACE(
+          default_people, '"assignees":', '"assessors":'
+      )
+      WHERE default_people like '%"assignees":%'
+  """)


### PR DESCRIPTION
# Issue description

1. Have an audit with an old assessment template (created before migration Assignees to ACL)
2. Clone audit
There will be a script error + a message in the console:
WARNING  2017-12-07 21:58:54,647 ggrc.services.common Invalid value for default_people.assignees. Expected a people label in string or a list of int people ids, received None.


# Steps to test the changes

1. Have an audit with an assessment templates
2. Clone audit with assessment templates
Audit should be cloned successfully

# Solution description

This issue is a regression of https://github.com/google/ggrc-core/pull/6629.
There are wrong default_people groups ("assessors") in Assessment templates now in db. But in code this group is named "assignees". When we try to find mandatory "assignees" group in some old default_people value we get validation error.
Selenium tests didn't catch it as they create new instances of Audit and Assessment template, but new instances contain proper value of default_people.
This PR has a migration that replace all "assessors" to "assignees" in `assessment_templates.default_people`.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# Migration checklist
- [x] db_reset runs without errors or warnings.
- [x] db_reset ggrc-qa.sql runs without errors or warnings.

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".


