### PR TITLE
GGRC-1800 "500 Server Error" occurred while downloading csv file with Assessments

### DIFF
--- a/src/ggrc/converters/base.py
+++ b/src/ggrc/converters/base.py
@@ -69,19 +69,17 @@ class Converter(object):
   def to_array(self):
     with benchmark("Create block converters"):
       self.block_converters_from_ids()
-    with benchmark("Handle row data"):
-      self.handle_row_data()
-    with benchmark("Make block array"):
+    with benchmark("Handle block converters"):
       return self.to_block_array()
 
   def to_block_array(self):
-    """ exporting each in it's own block separated by empty lines
+    """Export each block separated by empty lines
 
     Generate 2d array where each cell represents a cell in a csv file
     """
     csv_data = []
     for block_converter in self.block_converters:
-      csv_header, csv_body = block_converter.to_array()
+      csv_header, csv_body = block_converter.row_data_to_array()
       # multi block csv must have first column empty
       two_empty_lines = [[], []]
       block_data = csv_header + csv_body + two_empty_lines
@@ -114,18 +112,15 @@ class Converter(object):
       for block_converter in self.block_converters:
         block_converter.handle_row_data(attr_name)
 
-  def handle_row_data(self):
-    for converter in self.block_converters:
-      converter.handle_row_data()
-
   def row_converters_from_csv(self):
     for converter in self.block_converters:
       converter.row_converters_from_csv()
 
   def block_converters_from_ids(self):
-    """ fill the block_converters class variable
+    """Generate block converters.
 
-    Generate block converters from a list of tuples with an object name and ids
+    Generate block converters from a list of tuples with an object name and
+    ids and store it to an instance variable.
     """
     object_map = {o.__name__: o for o in self.exportable.values()}
     for object_data in self.ids_by_type:
@@ -141,7 +136,6 @@ class Converter(object):
                                          fields=fields, object_ids=object_ids,
                                          class_name=class_name)
         block_converter.check_block_restrictions()
-        block_converter.row_converters_from_ids()
         self.block_converters.append(block_converter)
 
   def block_converters_from_csv(self):

--- a/src/ggrc/converters/base_row.py
+++ b/src/ggrc/converters/base_row.py
@@ -97,10 +97,8 @@ class RowConverter(object):
         self.objects[attr_name] = item
 
   def handle_row_data(self, field_list=None):
-    if self.from_ids:
-      self.handle_obj_row_data()
-    else:
-      self.handle_csv_row_data(field_list)
+    """Handle row data on import"""
+    self.handle_csv_row_data(field_list)
 
   def check_mandatory_fields(self):
     """Check if the new object contains all mandatory columns."""

--- a/src/ggrc/converters/snapshot_block.py
+++ b/src/ggrc/converters/snapshot_block.py
@@ -338,6 +338,6 @@ class SnapshotBlockConverter(object):
         for snapshot in self.snapshots
     ] or [[]]
 
-  def to_array(self):
+  def row_data_to_array(self):
     """Get 2D list representing the CSV file."""
     return self._header_list, self._body_list

--- a/src/ggrc/views/converters.py
+++ b/src/ggrc/views/converters.py
@@ -62,7 +62,7 @@ def parse_export_request():
 def handle_export_request():
   """Export request handler"""
   try:
-    with benchmark("handle export request"):
+    with benchmark("handle export request data"):
       data = parse_export_request()
       objects = data.get("objects")
       export_to = data.get("export_to")


### PR DESCRIPTION
# Issue description

The issue with export is that it consumes a lot of memory. Export creates in memory all the exported block instances and fills it with data, creates all the row converters and column handlers instances and also fills it with the data. Then it converts all this data to 2d array of csv data. And after consuming all the container memory - python process just breaks.
As for now, we have ~13K assessments in our qa db. Querying them all in row_converters_from_ids() immediately consumes ~700M of memory. While we have 1G available on our qa instance.
Then while converting them to rows one by one consumes ~2M per each (with all fields, mappings and CAs) and processing of all this lasts ~1-2 sec. Even if we'd have 30Gig of RAM export would take ~26K sec. Without all CAs checked ~3 Assessments are processed per sec.

# Steps to test the changes

To test my changes we might need to find the amount of data which could not be exported before the changes applied and could be processed after.
For my local container ~4400 Assessments without CAs checked worked. But my container has 2Gigs of RAM. And exporting 4400 assessments without the changes applied fails in approx 30-40 sec after export started.
I managed to export ~4400 assessments by importing the ones mapped to person Vadim

# Solution description

My solution moves rows data conversion to a generator. Thus it consumes drastically less memory during the export process. Also it does not query all() objects row_converters_from_ids() at once. I do not do fetch them with .all() but just iterate over sqlalchemy query.
I did not move block converters to a generator because me don't have many blocks, at most ~30 since we have about 30 types of objects in our system.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] db_reset runs without errors or warnings.
- [ ] db_reset ggrc-qa.sql runs without errors or warnings.
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
