### PR TITLE
GGRC-3475 Add new logic of moving Assessment between states

### DIFF
--- a/src/ggrc/assets/javascripts/components/custom-attributes/custom-attributes-actions.js
+++ b/src/ggrc/assets/javascripts/components/custom-attributes/custom-attributes-actions.js
@@ -1,4 +1,4 @@
-/*!
+/*
  Copyright (C) 2017 Google Inc.
  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  */
@@ -15,7 +15,7 @@ import template from './custom-attributes-actions.mustache';
       formEditMode: false,
       edit: function () {
         this.attr('formEditMode', true);
-      }
-    }
+      },
+    },
   });
 })(window.can);

--- a/src/ggrc/assets/javascripts/components/custom-attributes/custom-attributes-actions.mustache
+++ b/src/ggrc/assets/javascripts/components/custom-attributes/custom-attributes-actions.mustache
@@ -4,7 +4,11 @@
 }}
 
 {{#unless formEditMode}}
-  <button class="btn btn-small btn-gray custom-attributes-actions__edit-button" ($click)="edit()">
+<confirm-edit-action
+  (set-in-progress)="edit()"
+  {instance}="instance">
+  <button class="btn btn-small btn-gray custom-attributes-actions__edit-button" ($click)="confirmEdit()">
     Edit Answers
   </button>
+</confirm-edit-action>
 {{/unless}}

--- a/src/ggrc/assets/mustache/assessments/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessments/modal_content.mustache
@@ -9,7 +9,7 @@
     <form action="javascript://">
 
       {{^if new_object_form}}
-        {{#if_in instance.status "Not Started,Completed,Verified,In Review"}}
+  {{#if_in instance.status "Completed,Verified,In Review"}}
           {{#if_helpers '#if' instance.isDirty 'or #if' mappedObjectsChanges.length 'or #if' referenceUrlChanged}}
           <div class="ggrc-form-item">
             <div class="alert warning width-100">


### PR DESCRIPTION
# Dependencies

This PR is `on hold` until the dependencies are merged:
- [x] #6927 

# Issue description

Moving assessment between different statuses don't match the desired logic described in the ticket.

# Steps to test the changes

1. Moving assessment from NOT STARTED to IN PROGRESS must not create any confirmation dialogs or show any warnings. See details in the attached spreadsheet in BE subticket GGRC-3947

2. Moving assessment from IN REVIEW to IN PROGRESS by clicking the "Edit Answers" should trigger the status change confirmation dialog.

# Solution description

1. Remove status change warning on Assessment edit modal for 'NOT STARTED' state.
2. Add confirmation dialog for "Edit Answers" button on assessment info-pane.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests. (N/A)
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".