### PR TITLE
GGRC-4022 Exclude exclamation symbol when build modalId

### DIFF
--- a/src/ggrc/assets/javascripts/bootstrap/modal-ajax.js
+++ b/src/ggrc/assets/javascripts/bootstrap/modal-ajax.js
@@ -600,7 +600,7 @@ import {
           loadHref = !$this.data().noHrefLoad;
 
           modalId = 'ajax-modal-' +
-            href.replace(/[\/\?=&#%]/g, '-').replace(/^-/, '');
+            href.replace(/[\/\?=&#%!]/g, '-').replace(/^-/, '');
           target = $this.attr('data-target') || $('#' + modalId);
 
           $target = $(target);


### PR DESCRIPTION
# Issue description

JS error occurs while adding 'Audits' tab on the Program page

# Steps to test the changes

Steps to reproduce:
1. Create a program
2. On program Info page click Add tab and click Audits
Actual Result: "Uncaught Error: Syntax error, unrecognized expression: #ajax-modal-programs-1483-!audit_widget" error occurs while adding Audits tab on the program page
Expected Result: no errors should be shown while adding Audits tab on the program page

# Solution description

When we moved to can.route we started use links with exclamation `!` symbol.
The solution is add exclamation to 'blacklist'.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] db_reset runs without errors or warnings.
- [ ] db_reset ggrc-qa.sql runs without errors or warnings.
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
