### PR TITLE
BACKMERGE Fix migration chain

### DIFF
--- a/src/ggrc/migrations/versions/20171121072747_5240c67306fe_add_folder_fields.py
+++ b/src/ggrc/migrations/versions/20171121072747_5240c67306fe_add_folder_fields.py
@@ -16,7 +16,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '5240c67306fe'
-down_revision = '1af0b27960a2'
+down_revision = '45ccf2a009bb'
 
 
 TABLES = ('programs', 'audits', 'controls', )

--- a/src/ggrc/migrations/versions/20171208083413_45ccf2a009bb_fix_default_peole.py
+++ b/src/ggrc/migrations/versions/20171208083413_45ccf2a009bb_fix_default_peole.py
@@ -1,0 +1,38 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Fix default_peole for old Assessment templates
+
+Create Date: 2017-12-08 08:34:13.915060
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '45ccf2a009bb'
+down_revision = '1af0b27960a2'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  op.execute("""
+      UPDATE assessment_templates
+      SET default_people = REPLACE(
+          default_people, '"assessors":', '"assignees":'
+      )
+      WHERE default_people like '%"assessors":%'
+  """)
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  op.execute("""
+      UPDATE assessment_templates
+      SET default_people = REPLACE(
+          default_people, '"assignees":', '"assessors":'
+      )
+      WHERE default_people like '%"assignees":%'
+  """)


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

This PR backmerges the release branch and makes all migrations in dev to base on the latest release migration.

Every instance that hosts `dev` branch should have its migrations downgraded to the branchpoint since the migration history is modified.

# Sanity checklist

- [ ] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [ ] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# Migration checklist
- [x] db_reset runs without errors or warnings.
- [x] db_reset ggrc-qa.sql runs without errors or warnings.

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
