### PR TITLE
GGRC-3213 Unified mapper pop up improvements

### DIFF
--- a/src/ggrc/assets/javascripts/components/unified-mapper/mapper-results.js
+++ b/src/ggrc/assets/javascripts/components/unified-mapper/mapper-results.js
@@ -26,7 +26,7 @@ import * as AdvancedSearch from '../../plugins/utils/advanced-search-utils';
 import Pagination from '../base-objects/pagination';
 import tracker from '../../tracker';
 
-const DEFAULT_PAGE_SIZE = 5;
+const DEFAULT_PAGE_SIZE = 10;
 
 export default GGRC.Components('mapperResults', {
   tag: 'mapper-results',
@@ -35,7 +35,7 @@ export default GGRC.Components('mapperResults', {
     define: {
       paging: {
         value: function () {
-          return new Pagination({pageSizeSelect: [5, 10, 15]});
+          return new Pagination({pageSizeSelect: [10, 25, 50]});
         },
       },
     },

--- a/src/ggrc/assets/javascripts/components/unified-mapper/templates/mapper-results.mustache
+++ b/src/ggrc/assets/javascripts/components/unified-mapper/templates/mapper-results.mustache
@@ -44,7 +44,7 @@
         </mapper-results-item>
       </object-list>
     </div>
-    <tree-pagination paging="paging" class="list-pagination"></tree-pagination>
+    <tree-pagination paging="paging"></tree-pagination>
   {{else}}
     {{#if isLoading}}
       <div class="no-items-spinner-wrapper">

--- a/src/ggrc/assets/javascripts/components/unified-mapper/tests/mapper-results_spec.js
+++ b/src/ggrc/assets/javascripts/components/unified-mapper/tests/mapper-results_spec.js
@@ -198,7 +198,7 @@ describe('GGRC.Components.mapperResults', function () {
   });
 
   describe('resetSearchParams() method', function () {
-    var DEFAULT_PAGE_SIZE = 5;
+    const DEFAULT_PAGE_SIZE = 10;
 
     beforeEach(function () {
       viewModel.attr('paging', {});

--- a/src/ggrc/assets/stylesheets/components/unified-mapper/_unified-mapper.scss
+++ b/src/ggrc/assets/stylesheets/components/unified-mapper/_unified-mapper.scss
@@ -29,31 +29,17 @@ mapper-results {
     padding: 9px 16px 7px;
   }
 
-  .list-pagination {
-    display: block;
+  .tree-pagination {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
 
-    .tree-pagination {
-      display: flex;
-      justify-content: flex-end;
-      align-items: center;
-
-      .dropdown-toggle {
-        font-size: 12px;
-      }
-
-      .dropdown-toggle,
-      ::-webkit-input-placeholder {
-        color: $gray;
-      }
+    ::-webkit-input-placeholder {
+      color: $gray;
     }
 
-    .clearfix {
-      display: none;
-    }
-
-    .pagination {
-      float: none;
-      height: auto;
+    .pagination-dropdown {
+      margin: 0;
     }
   }
 

--- a/src/ggrc/assets/stylesheets/components/unified-mapper/_unified-mapper.scss
+++ b/src/ggrc/assets/stylesheets/components/unified-mapper/_unified-mapper.scss
@@ -70,7 +70,6 @@ mapper-results {
 
   .list-body {
     display: flex;
-    max-height: 240px;
     box-sizing: border-box;
     overflow: auto;
     position: relative;


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

ACCEPTANCE CRITERIA:
AC1. Remove scroll for search results in modal.
AC2. Dropdown with a list of number of objects to display should contain: 10, 25, 50.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [ ] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] db_reset runs without errors or warnings.
- [ ] db_reset ggrc-qa.sql runs without errors or warnings.
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
