### PR TITLE
GGRC-3934: Update tree-view columns for WFs

### DIFF
--- a/src/ggrc_workflows/assets/javascripts/models/workflow.js
+++ b/src/ggrc_workflows/assets/javascripts/models/workflow.js
@@ -46,12 +46,13 @@
       attr_view: GGRC.mustache_path + '/workflows/tree-item-attr.mustache',
       attr_list : [
         {attr_title: 'Title', attr_name: 'title'},
-        {attr_title: 'Manager', attr_name: 'owner', attr_sort_field: ''},
         {attr_title: 'Code', attr_name: 'slug'},
         {attr_title: 'State', attr_name: 'status'},
         {attr_title: 'Last Updated', attr_name: 'updated_at'},
         {attr_title: 'Last Updated By', attr_name: 'modified_by'}
-      ]
+      ],
+      display_attr_names: ['title', 'status', 'updated_at', 'Admin',
+        'Workflow Member'],
     },
 
     init: function() {

--- a/src/ggrc_workflows/assets/mustache/workflows/tree-item-attr.mustache
+++ b/src/ggrc_workflows/assets/mustache/workflows/tree-item-attr.mustache
@@ -4,11 +4,6 @@
 }}
 
 {{#switch attr_name}}
-  {{#case 'owner'}}
-    {{#with_mapping 'authorizations' instance}}
-      <get-owner-people-list data="authorizations" role="'WorkflowOwner'"/>
-    {{/with_mapping}}
-  {{/case}}
   {{#case 'modified_by'}}
       <tree-people-list-field {source}="instance.modified_by"/>
   {{/case}}


### PR DESCRIPTION
# Issue description
Add default columns for Admin and Workflow Member in tree-view.

# Steps to test the changes
1. Open Workflows tab on All Objects page
2. Run the following code in Web Tools Console (add breakpoint in the bootstrap.js)
``` javascript 
GGRC.access_control_roles.push({
default_to_current_user:true,
delete:true,
id:83,
mandatory:true,
modified_by:null,
my_work:false,
name:"Admin",
non_editable:false,
object_type:"Workflow",
read:true,
selfLink:"/api/access_control_roles/83",
tooltip:null,
type:"AccessControlRole",
update:true})
GGRC.access_control_roles.push({
default_to_current_user:false,
delete:true,
id:85,
mandatory:true,
modified_by:null,
my_work:false,
name:"Workflow Member",
non_editable:false,
object_type:"Workflow",
read:true,
selfLink:"/api/access_control_roles/83",
tooltip:null,
type:"AccessControlRole",
update:true})
```


# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

