### PR TITLE
QUICK-FIX [Snapshots] Redesign test Issue mapped to origin control (after mapping issue to asmt w/ mapped snapshoted ctrl)

### DIFF
--- a/test/selenium/src/lib/constants/element.py
+++ b/test/selenium/src/lib/constants/element.py
@@ -409,9 +409,12 @@ class IssueModalSetVisibleFields(CommonModalSetVisibleFields):
       CommonIssue.ISSUE)
   ADMIN = TransformationSetVisibleFields.ADMIN
   REVIEW_STATE = TransformationSetVisibleFields.REVIEW_STATE
+  PRIMARY_CONTACTS = TransformationSetVisibleFields.PRIMARY_CONTACTS
   DEFAULT_SET_FIELDS = (
-      CommonModalSetVisibleFields.TITLE, ADMIN,
-      CommonModalSetVisibleFields.CODE, CommonModalSetVisibleFields.STATE)
+      CommonModalSetVisibleFields.TITLE, CommonModalSetVisibleFields.CODE,
+      CommonModalSetVisibleFields.STATE,
+      CommonModalSetVisibleFields.LAST_UPDATED_BY, REVIEW_STATE,
+      PRIMARY_CONTACTS, ADMIN)
 
 
 class ProgramModalSetVisibleFields(CommonModalSetVisibleFields):

--- a/test/selenium/src/tests/test_snapshots.py
+++ b/test/selenium/src/tests/test_snapshots.py
@@ -596,37 +596,47 @@ class TestSnapshots(base.Test):
 
   @pytest.mark.smoke_tests
   @pytest.mark.parametrize(
-      "dynamic_objects, expected_state",
-      [("new_assessment_rest", element.AssessmentStates.NOT_STARTED),
-       pytest.mark.xfail(reason="Issue GGRC-1407", strict=True)(
-          ("new_issue_rest", element.IssueStates.DRAFT))],
-      indirect=["dynamic_objects"])
+      "dynamic_objects, dynamic_relationships, expected_state",
+      [("new_assessment_rest", None, element.AssessmentStates.NOT_STARTED),
+       (["new_assessment_rest", "new_issue_rest"],
+        "map_new_assessment_rest_to_new_control_rest_snapshot",
+        element.IssueStates.DRAFT)],
+      ids=["Mapping snapshot of Control to Assessment",
+           "Mapping Assessment with mapped snapshot of Control to Issue"],
+      indirect=["dynamic_objects", "dynamic_relationships"])
   def test_asmt_and_issue_mapped_to_origin_control(
       self, create_audit_with_control_and_update_control,
-      dynamic_objects, expected_state, selenium
+      dynamic_objects, dynamic_relationships, expected_state, selenium
   ):
     """
-    Check Assessment or Issue was mapped to origin control after mapping
-    snapshot of control to Assessment or Issue.
-    Test parameters:
-      - check Assessment
-      - check Issue
+    Check Assessment, Issue was mapped to origin Control after mapping:
+    - snapshot of Control to Assessment;
+    - Assessment with mapped snapshot of Control to Issue.
     """
+    is_issue_flow = (isinstance(dynamic_objects, dict) and
+                     dynamic_objects.get("new_issue_rest") is not None)
     origin_control = create_audit_with_control_and_update_control[
         "update_control_rest"][0]
     snapshoted_control = create_audit_with_control_and_update_control[
         "new_control_rest"][0]
     expected_obj = (
-        dynamic_objects.repr_ui().update_attrs(status=expected_state))
-    (webui_service.ControlsService(selenium).map_objs_via_tree_view(
-        src_obj=expected_obj, dest_objs=[snapshoted_control]))
+        dynamic_objects.get("new_issue_rest") if is_issue_flow
+        else dynamic_objects).repr_ui().update_attrs(status=expected_state)
+    ui_mapping_service, src_obj, dest_objs = (
+        (webui_service.IssuesService(selenium),
+         dynamic_objects.get("new_assessment_rest"),
+         [dynamic_objects.get("new_issue_rest")]) if is_issue_flow else
+        (webui_service.ControlsService(selenium), expected_obj,
+         [snapshoted_control]))
+    ui_mapping_service.map_objs_via_tree_view(
+        src_obj=src_obj, dest_objs=dest_objs)
     actual_objs = (get_cls_webui_service(
         objects.get_plural(expected_obj.type))(selenium).
         get_list_objs_from_tree_view(src_obj=origin_control))
     # 'actual_controls': created_at, updated_at, custom_attributes (None)
     exclude_attrs = Representation.tree_view_attrs_to_exclude
-    if dynamic_objects.type == entities_factory.EntitiesFactory.obj_issue:
-      exclude_attrs = exclude_attrs + ("objects_under_assessment", )
+    if is_issue_flow:
+      exclude_attrs += ("objects_under_assessment", )
     self.general_equal_assert([expected_obj], actual_objs, *exclude_attrs)
 
   @pytest.mark.smoke_tests


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# PR description

Un-skip and redesign test Issue mapped to origin control (after mapping issue to asmt w/ mapped snapshoted ctrl).

![peek 2017-12-12 18-57](https://user-images.githubusercontent.com/16610768/33900415-8ff62ec8-df6e-11e7-9b6a-df77b4d48ea7.gif)


# Solution description

```Python
  @pytest.mark.smoke_tests
  @pytest.mark.parametrize(
      "dynamic_objects, dynamic_relationships, expected_state",
      [("new_assessment_rest", None, element.AssessmentStates.NOT_STARTED),
       (["new_assessment_rest", "new_issue_rest"],
        "map_new_assessment_rest_to_new_control_rest_snapshot",
        element.IssueStates.DRAFT)],
      ids=["Mapping snapshot of Control to Assessment",
           "Mapping Assessment with mapped snapshot of Control to Issue"],
      indirect=["dynamic_objects", "dynamic_relationships"])
  def test_asmt_and_issue_mapped_to_origin_control(
      self, create_audit_with_control_and_update_control,
      dynamic_objects, dynamic_relationships, expected_state, selenium
  ):
    """
    Check Assessment, Issue was mapped to origin Control after mapping:
    - snapshot of Control to Assessment;
    - Assessment with mapped snapshot of Control to Issue.
    """
    is_issue_flow = (isinstance(dynamic_objects, dict) and
                     dynamic_objects.get("new_issue_rest") is not None)
    origin_control = create_audit_with_control_and_update_control[
        "update_control_rest"][0]
    snapshoted_control = create_audit_with_control_and_update_control[
        "new_control_rest"][0]
    expected_obj = (
        dynamic_objects.get("new_issue_rest") if is_issue_flow
        else dynamic_objects).repr_ui().update_attrs(status=expected_state)
    ui_mapping_service, src_obj, dest_objs = (
        (webui_service.IssuesService(selenium),
         dynamic_objects.get("new_assessment_rest"),
         [dynamic_objects.get("new_issue_rest")]) if is_issue_flow else
        (webui_service.ControlsService(selenium), expected_obj,
         [snapshoted_control]))
    ui_mapping_service.map_objs_via_tree_view(
        src_obj=src_obj, dest_objs=dest_objs)
    actual_objs = (get_cls_webui_service(
        objects.get_plural(expected_obj.type))(selenium).
        get_list_objs_from_tree_view(src_obj=origin_control))
    # 'actual_controls': created_at, updated_at, custom_attributes (None)
    exclude_attrs = Representation.tree_view_attrs_to_exclude
    if is_issue_flow:
      exclude_attrs += ("objects_under_assessment", )
    self.general_equal_assert([expected_obj], actual_objs, *exclude_attrs)
```

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] db_reset runs without errors or warnings.
- [ ] db_reset ggrc-qa.sql runs without errors or warnings.
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
