### PR TITLE
GGRC-2975 Fix data conflict on notifications

### DIFF
--- a/src/ggrc/notifications/common.py
+++ b/src/ggrc/notifications/common.py
@@ -154,8 +154,6 @@ def get_notification_data(notifications):
   # Remove notifications for objects without a contact (such as task groups)
   aggregate_data.pop("", None)
 
-  sort_comments(aggregate_data)
-
   return aggregate_data
 
 
@@ -171,14 +169,13 @@ def sort_comments(notif_data):
   Returns:
     None
   """
-  for user_notifs in notif_data.itervalues():
-    comment_notifs = user_notifs.get("comment_created", {})
+  comment_notifs = notif_data.get("comment_created", {})
 
-    for parent_obj_info, comments in comment_notifs.iteritems():
-      comments_as_list = sorted(
-          comments.itervalues(), key=itemgetter("created_at"), reverse=True)
-      # modifying a value for a given existing key is fine...
-      comment_notifs[parent_obj_info] = comments_as_list
+  for parent_obj_info, comments in comment_notifs.iteritems():
+    comments_as_list = sorted(
+        comments.itervalues(), key=itemgetter("created_at"), reverse=True)
+    # modifying a value for a given existing key is fine...
+    comment_notifs[parent_obj_info] = comments_as_list
 
 
 def get_pending_notifications():
@@ -407,6 +404,9 @@ def modify_data(data):
       if "my_tasks" in cycle:
         data["cycle_started_tasks"].update(cycle["my_tasks"])
 
+  # Move comment notifications for same object into list and sort by
+  # created_at field
+  sort_comments(data)
   data["DATE_FORMAT"] = DATE_FORMAT_US
 
   return data

--- a/src/ggrc/utils/__init__.py
+++ b/src/ggrc/utils/__init__.py
@@ -102,7 +102,23 @@ def encoded_dict(in_dict):
 
 
 def merge_dict(destination, source, path=None):
-  """merges source into destination"""
+  """Merge source into destination.
+
+  This function prevent creation of duplicates during merging as
+  any subdict in destination related to unique key (user_email,
+  notification_id, ParentObjInfo, ...). Merging duplicated value will
+  be ignored.
+
+  Args:
+      destination: Dict in which we want to merge data. It can contain only
+          dicts or simple types as values.
+      source: Dict that should be merged. It can contain only
+          dicts or simple types as values.
+      path: List with keys to any node of source (only for internal usage).
+
+  Returns:
+      Dict with data combination from destination and source.
+  """
   if path is None:
     path = []
   for key in source:

--- a/test/integration/ggrc/notifications/test_comment_notifications.py
+++ b/test/integration/ggrc/notifications/test_comment_notifications.py
@@ -8,6 +8,7 @@
 from datetime import datetime
 
 import ddt
+from freezegun import freeze_time
 from mock import patch
 from sqlalchemy import and_
 
@@ -218,3 +219,30 @@ class TestCommentNotification(TestCase):
     notifications = self._get_notifications(notif_type="comment_created").all()
     self.assertEqual(len(notifications), 0,
                      "Found a comment notification that was not sent.")
+
+  def test_old_comments(self):
+    """Test if notifications will be sent for mix of old and new comments"""
+    cur_user = all_models.Person.query.filter_by(
+        email="user@example.com"
+    ).first()
+    assigee_role_id = {
+        v: k for k, v in get_custom_roles_for("Assessment").items()
+    }["Assignees"]
+    with factories.single_commit():
+      assessment = factories.AssessmentFactory()
+      factories.AccessControlListFactory(
+          ac_role_id=assigee_role_id, person=cur_user, object=assessment
+      )
+    with freeze_time("2015-04-01 17:13:10"):
+      self.generator.generate_comment(
+          assessment, "", "some comment1", send_notification="true"
+      )
+    self.generator.generate_comment(
+        assessment, "", "some comment2", send_notification="true"
+    )
+    response = self.client.get("/_notifications/show_pending")
+    for comment in ["some comment1", "some comment2"]:
+      self.assertIn(
+          comment, response.data,
+          "Information about comment '{}' absent in report".format(comment)
+      )

--- a/test/integration/ggrc/notifications/test_comment_notifications.py
+++ b/test/integration/ggrc/notifications/test_comment_notifications.py
@@ -139,6 +139,7 @@ class TestCommentNotification(TestCase):
     _, notif_data = common.get_daily_notifications()
 
     assignee_notifs = notif_data.get("user@example.com", {})
+    common.sort_comments(assignee_notifs)
     comment_notifs = assignee_notifs.get("comment_created", {})
     self.assertEqual(len(comment_notifs), 3)  # for 3 different Assessments
 

--- a/test/unit/ggrc/notification/test_common.py
+++ b/test/unit/ggrc/notification/test_common.py
@@ -20,25 +20,23 @@ class TestSortComments(unittest.TestCase):
     asmt5_info = (5, "Assessment", "Asmt 5", "www.5.com")
 
     data = {
-        "email@foo.com": {
-            "comment_created": {
-                asmt5_info: {
-                    12: {
-                        "description": "ABCD...",
-                        "created_at": datetime(2017, 5, 31, 8, 15, 0)
-                    },
-                    19: {
-                        "description": "All tasks can be closed",
-                        "created_at": datetime(2017, 10, 16, 0, 30, 0)
-                    },
-                    10: {
-                        "description": "Comment One",
-                        "created_at": datetime(2017, 5, 29, 16, 20, 0)
-                    },
-                    15: {
-                        "description": "I am confused",
-                        "created_at": datetime(2017, 8, 15, 11, 13, 0)
-                    }
+        "comment_created": {
+            asmt5_info: {
+                12: {
+                    "description": "ABCD...",
+                    "created_at": datetime(2017, 5, 31, 8, 15, 0)
+                },
+                19: {
+                    "description": "All tasks can be closed",
+                    "created_at": datetime(2017, 10, 16, 0, 30, 0)
+                },
+                10: {
+                    "description": "Comment One",
+                    "created_at": datetime(2017, 5, 29, 16, 20, 0)
+                },
+                15: {
+                    "description": "I am confused",
+                    "created_at": datetime(2017, 8, 15, 11, 13, 0)
                 }
             }
         }
@@ -46,7 +44,7 @@ class TestSortComments(unittest.TestCase):
 
     sort_comments(data)
 
-    comment_data = data["email@foo.com"]["comment_created"].values()[0]
+    comment_data = data["comment_created"].values()[0]
     self.assertIsInstance(comment_data, list)
 
     descriptions = [c["description"] for c in comment_data]


### PR DESCRIPTION
# Issue description

When `_notifications/show_pending` is accessed error thrown:

File "/vagrant/src/ggrc/notifications/common.py", line 326, in show_pending_notifications
    _, notif_data = get_pending_notifications()
  File "/vagrant/src/ggrc/notifications/common.py", line 207, in get_pending_notifications
    get_notification_data(notif))
  File "/vagrant/src/ggrc/utils/__init__.py", line 111, in merge_dict
    merge_dict(destination[key], source[key], path + [str(key)])
  File "/vagrant/src/ggrc/utils/__init__.py", line 111, in merge_dict
    merge_dict(destination[key], source[key], path + [str(key)])
  File "/vagrant/src/ggrc/utils/__init__.py", line 115, in merge_dict
    raise Exception('Conflict at %s' % '.'.join(path + [str(key)]))
Exception: Conflict at user@example.com.comment_created.ParentObjInfo(id=16L, object_type='Assessment', title=u'title .UJAJW75', url=u'http://localhost/assessments/16')

The bug was hidden by changing the error into a warning in #6083.
Such error can take place in following scenarios:
1. Create comment for Assessment (or any other object)
2. Don't send notifications in this day
3. In other day create one more comment for same object
Notifications for one day will not be sent and log will contain error.

# Steps to test the changes

1. Create comment for Assessment (or any other object)
2. Don't send notifications in this day
3. In other day create one more comment for same object
Notifications for both days should be received, no error should be in log.

# Solution description

The reason of issue is that we try to merge dicts with notifications data for different days recursively but on one of recursion step we need to merge lists of comment data but not dicts and such scenarios is unforeseen.
The reason why we have lists in notification data is the following: for notification data we create structure like
`user_email: <type of notification>: notification_id: {notification data}`
But if type of notification is "comment" we have structure
`user_email: <type of notification>: ParentObj (tuple with parent_id and type):notification_id: {notification data}`
and before sending we have sorting procedure for these comment notifications that change structure to:
`user_email: <type of notification>: ParentObj: [{notification data}, ...]`

My solution is to concatenate such lists of notifications as information from them should be sent in one mail.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] db_reset runs without errors or warnings.
- [ ] db_reset ggrc-qa.sql runs without errors or warnings.
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
