### PR TITLE
GGRC-3485 Show RichText CA in search results

### DIFF
--- a/src/ggrc/assets/javascripts/components/advanced-search/advanced-search-mapping-criteria.js
+++ b/src/ggrc/assets/javascripts/components/advanced-search/advanced-search-mapping-criteria.js
@@ -97,8 +97,7 @@ var viewModel = can.Map.extend({
   availableAttributes: function () {
     var available = getColumnsForModel(
       this.attr('criteria.objectName'),
-      null,
-      true
+      null
     ).available;
     return available;
   },

--- a/src/ggrc/assets/javascripts/components/advanced-search/advanced-search-wrapper.js
+++ b/src/ggrc/assets/javascripts/components/advanced-search/advanced-search-wrapper.js
@@ -26,8 +26,7 @@ export default can.Component.extend({
     availableAttributes: function () {
       var available = getColumnsForModel(
         this.attr('modelName'),
-        null,
-        true
+        null
       ).available;
       return available;
     },

--- a/src/ggrc/assets/javascripts/components/advanced-search/tests/advanced-search-mapping-criteria_spec.js
+++ b/src/ggrc/assets/javascripts/components/advanced-search/tests/advanced-search-mapping-criteria_spec.js
@@ -184,8 +184,7 @@ describe('GGRC.Components.advancedSearchMappingCriteria', function () {
       expect(viewModel.availableAttributes()).toBe(attributes);
       expect(TreeViewUtils.getColumnsForModel).toHaveBeenCalledWith(
         'test',
-        null,
-        true
+        null
       );
     });
   });

--- a/src/ggrc/assets/javascripts/components/tree/tree-widget-container.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-widget-container.js
@@ -338,7 +338,6 @@ viewModel = can.Map.extend({
     var columns = TreeViewUtils.getColumnsForModel(
       this.attr('model').model_singular,
       this.attr('displayPrefs'),
-      true,
       this.attr('optionsData').widgetId
     );
 

--- a/src/ggrc/assets/javascripts/plugins/utils/tree-view-utils.js
+++ b/src/ggrc/assets/javascripts/plugins/utils/tree-view-utils.js
@@ -142,12 +142,10 @@ function skipUnusable(modelName, attrList) {
  * Get available and selected columns for Model type
  * @param {String} modelType - Model type.
  * @param {Object} displayPrefs - Display preferences.
- * @param {Boolean} [includeRichText] - Need to include Rich Text in the configuration
  * @param {String} modelName - Model name.
  * @return {Object} Table columns configuration.
  */
-function getColumnsForModel(modelType, displayPrefs, includeRichText,
-  modelName) {
+function getColumnsForModel(modelType, displayPrefs, modelName) {
   var Cacheable = can.Model.Cacheable;
   var Model = CMS.Models[modelType];
   var modelDefinition = Model().class.root_object;
@@ -201,10 +199,6 @@ function getColumnsForModel(modelType, displayPrefs, includeRichText,
     GGRC.custom_attr_defs
       .filter(function (def) {
         var include = def.definition_type === modelDefinition;
-
-        if (!includeRichText) {
-          include = include && def.attribute_type !== 'Rich Text';
-        }
 
         return include;
       }).map(function (def) {
@@ -275,7 +269,7 @@ function getColumnsForModel(modelType, displayPrefs, includeRichText,
 function setColumnsForModel(modelType, columnNames, displayPrefs,
   modelName) {
   var availableColumns =
-    getColumnsForModel(modelType, displayPrefs, true).available;
+    getColumnsForModel(modelType, displayPrefs).available;
   var selectedColumns = [];
   var selectedNames = [];
 

--- a/src/ggrc/assets/stylesheets/components/unified-mapper/_unified-mapper.scss
+++ b/src/ggrc/assets/stylesheets/components/unified-mapper/_unified-mapper.scss
@@ -371,6 +371,11 @@ mapper-results-item-attrs {
   .attr {
     @include cell-styles();
 
+    white-space: normal;
+    height: 33px;
+    display: -webkit-box;
+    -webkit-line-clamp: 1;
+    -webkit-box-orient: vertical;
     tree-field {
       div.tree-field__item {
         display: none;


### PR DESCRIPTION
# Issue description

GCA with rich text type is not displayed in Global Search / Unified mapper

# Steps to test the changes

Steps to reproduce:
1. Open Global Search
2. Select Controls object type > Search
3. Set visible fields > Rich Text

*Actual Result:* GCA with rich text type is not displayed in Global Search / Unified mapper
*Expected Result:* GCA with rich text type should be displayed in Global Search / Unified mapper

# Solution description

1) Set `includeRichText` property to true for mapper results.
2) See that now this property is always true.
3) Remove `includeRichText` property at all.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] db_reset runs without errors or warnings.
- [ ] db_reset ggrc-qa.sql runs without errors or warnings.
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
