### PR TITLE
GGRC-650 Remove duplicate relationships between snapshots and original objects

### DIFF
--- a/src/ggrc/migrations/versions/20180122110011_21db8dd549ac_remove_snapshot_relationships_to_own_originals.py
+++ b/src/ggrc/migrations/versions/20180122110011_21db8dd549ac_remove_snapshot_relationships_to_own_originals.py
@@ -1,0 +1,62 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Delete relationships which connect Snapshots to their original objects
+
+Create Date: 2018-01-22 11:00:11.079686
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+import sqlalchemy as sa
+from sqlalchemy.sql import table, column
+from sqlalchemy.sql.expression import select, join, and_
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '21db8dd549ac'
+down_revision = '2ac95a7b18fa'
+
+
+relationships = table(
+    "relationships",
+    column('id', sa.Integer),
+    column('source_id', sa.Integer),
+    column('source_type', sa.String),
+    column('destination_id', sa.Integer),
+    column('destination_type', sa.String),
+)
+
+snapshots = table(
+    "snapshots",
+    column('id', sa.Integer),
+    column('child_type', sa.String),
+)
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  # connection = op.get_bind()
+  src_dst_snapshots = join(relationships, snapshots,
+                           relationships.c.destination_id == snapshots.c.id)
+  sel1 = select([relationships.c.id]).select_from(src_dst_snapshots)\
+    .where(and_(snapshots.c.child_type == relationships.c.source_type,  # noqa
+           relationships.c.destination_type == "Snapshot"))
+
+  dst_src_snapshots = join(relationships, snapshots,
+                           relationships.c.source_id == snapshots.c.id)
+  sel2 = select([relationships.c.id]).select_from(dst_src_snapshots)\
+    .where(and_(snapshots.c.child_type == relationships.c.destination_type,  # noqa
+           relationships.c.source_type == "Snapshot"))
+
+  op.execute(relationships.delete().where(relationships.c.id.in_(
+      sel1.union_all(sel2).alias("delete_it").select()
+  )))
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  pass

--- a/src/ggrc/models/relationship.py
+++ b/src/ggrc/models/relationship.py
@@ -134,7 +134,9 @@ class Relationship(Base, db.Model):
             .format(self.type, self.source_type, self.destination_type)
         )
 
+
 class Relatable(object):
+  """Mixin adding Relationship functionality to an object"""
 
   @declared_attr
   def related_sources(cls):  # pylint: disable=no-self-argument

--- a/src/ggrc/models/relationship.py
+++ b/src/ggrc/models/relationship.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.declarative import declared_attr
 from ggrc import db
 from ggrc.models.mixins import Base
 from ggrc.models import reflection
+from ggrc.models.exceptions import ValidationError
 
 
 class Relationship(Base, db.Model):
@@ -53,6 +54,7 @@ class Relationship(Base, db.Model):
   def source(self, value):
     self.source_id = getattr(value, 'id', None)
     self.source_type = getattr(value, 'type', None)
+    self.validate_relatable_type("source", value)
     return setattr(self, self.source_attr, value)
 
   @property
@@ -67,6 +69,7 @@ class Relationship(Base, db.Model):
   def destination(self, value):
     self.destination_id = getattr(value, 'id', None)
     self.destination_type = getattr(value, 'type', None)
+    self.validate_relatable_type("destination", value)
     return setattr(self, self.destination_attr, value)
 
   @classmethod
@@ -105,6 +108,31 @@ class Relationship(Base, db.Model):
     return "{}:{} <-> {}:{}".format(self.source_type, self.source_id,
                                     self.destination_type, self.destination_id)
 
+  def validate_relatable_type(self, field, value):
+    tgt_type = self.source_type
+    tgt_id = self.source_id
+    if field == "source":
+      tgt_type = self.destination_type
+      tgt_id = self.destination_id
+    if value and getattr(value, "type") == "Snapshot":
+      if not tgt_type:
+        return
+      if value.child_type == tgt_type and value.child_id == tgt_id:
+        raise ValidationError(
+            u"Invalid source-destination types pair for {}: "
+            u"source_type={!r}, destination_type={!r}"
+            .format(self.type, self.source_type, self.destination_type)
+        )
+    # else check if the opposite is a Snapshot
+    elif tgt_type == "Snapshot":
+      from ggrc.models import Snapshot
+      snapshot = db.session.query(Snapshot).get(tgt_id)
+      if snapshot.child_type == value.type and snapshot.child_id == value.id:
+        raise ValidationError(
+            u"Invalid source-destination types pair for {}: "
+            u"source_type={!r}, destination_type={!r}"
+            .format(self.type, self.source_type, self.destination_type)
+        )
 
 class Relatable(object):
 

--- a/test/integration/ggrc/models/test_relationship.py
+++ b/test/integration/ggrc/models/test_relationship.py
@@ -18,6 +18,7 @@ from integration.ggrc.models import factories
 @ddt.ddt
 class TestRelationship(TestCase):
   """Integration test suite for Relationship."""
+  # pylint: disable=invalid-name
 
   def setUp(self):
     """Create a Person, an Assessment, prepare a Relationship json."""


### PR DESCRIPTION
# Dependencies

This PR is `on hold` until this list gets merged:
- [x] #6817 (migration for the release branch)


# Issue description

For some reason we have weird mappings of Snapshots to their original objects in our relationships table. Which is not used and redundant.

# Steps to test the changes

-

# Solution description

The solution is to create a validator for the relationship's source and destination to avoid the described situation. And then remove all the erroneous rows from the relationships table.

# Sanity checklist

- [ ] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] db_reset runs without errors or warnings.
- [ ] db_reset ggrc-qa.sql runs without errors or warnings.
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
