### PR TITLE
GGRC-2501 Remove '+Add Tab' control from Person page

### DIFF
--- a/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
+++ b/src/ggrc/assets/javascripts/controllers/dashboard_controller.js
@@ -28,7 +28,6 @@ const Dashboard = can.Control({
       if (!this.inner_nav_controller) {
         this.init_inner_nav();
       }
-      this.update_inner_nav();
 
       // Before initializing widgets, hide the container to not show
       // loading state of multiple widgets before reducing to one.
@@ -145,9 +144,6 @@ const Dashboard = can.Control({
       if (data) {
         this.inner_nav_controller
           .update_widget(data.widget || data, data.index);
-      } else {
-        this.inner_nav_controller.update_widget_list(
-          this.get_active_widget_elements());
       }
       this.inner_nav_controller.sortWidgets();
     }
@@ -155,10 +151,6 @@ const Dashboard = can.Control({
 
   get_active_widget_containers: function () {
     return this.element.find('.widget-area');
-  },
-
-  get_active_widget_elements: function () {
-    return this.element.find("section.widget[id]:not([id=''])").toArray();
   },
 
   add_widget_from_descriptor: function () {

--- a/src/ggrc/assets/javascripts/controllers/inner-nav-controller.js
+++ b/src/ggrc/assets/javascripts/controllers/inner-nav-controller.js
@@ -133,24 +133,6 @@ export default can.Control({
       _.sortByAll(this.options.widget_list, ['order', 'internav_display']));
   },
 
-  update_widget_list: function (widgetElements) {
-    var widgetList = this.options.widget_list.slice(0);
-    var that = this;
-
-    can.each(widgetElements, function (widgetElement, index) {
-      widgetList.splice(
-        can.inArray(
-          that.update_widget(widgetElement, index)
-          , widgetList)
-        , 1);
-    });
-
-    can.each(widgetList, function (widget) {
-      that.options.widget_list
-        .splice(can.inArray(widget, that.options.widget_list), 1);
-    });
-  },
-
   update_widget: function (widgetElement, index) {
     var $widget = $(widgetElement);
     var widget = this.widget_by_selector('#' + $widget.attr('id'));

--- a/src/ggrc/assets/javascripts/controllers/inner-nav-controller.js
+++ b/src/ggrc/assets/javascripts/controllers/inner-nav-controller.js
@@ -17,11 +17,12 @@ export default can.Control({
     internav_view: '/static/mustache/dashboard/internav_list.mustache',
     pin_view: '.pin-content',
     widget_list: null,
+    priorityTabs: null,
+    notPriorityTabs: null,
     spinners: {},
     contexts: null,
     instance: null,
     isMenuVisible: true,
-    priorityTabs: null,
     counts: null,
     hasHiddenWidgets: false,
   },
@@ -48,11 +49,9 @@ export default can.Control({
         const isAuditScope = instance.type === 'Audit';
         this.element.append(frag);
         if (isAuditScope) {
-          const priorityTabsNum = 4 + isDashboardEnabled(instance);
           this.element.addClass(this.options.instance.type.toLowerCase());
-          this.options.attr('priorityTabs', priorityTabsNum);
         }
-        this.show_hide_titles();
+        this.setTabsPriority();
         this.route(router.attr('widget'));
       });
 
@@ -269,31 +268,17 @@ export default can.Control({
     });
     this.options.attr('hasHiddenWidgets', hasHiddenWidgets);
   },
-
-  show_hide_titles: function () {
-    const pageType = getPageType();
-    const originalWidgets = this.options.widget_list;
-    const priorityTabsNum = this.options.attr('priorityTabs');
-    const priorityTabs = originalWidgets.slice(0, priorityTabsNum);
-    const notPriorityTabs = originalWidgets.slice(priorityTabsNum);
-
-    function hideTitles(widgets) {
-      widgets.forEach(function (widget) {
-        widget.attr('show_title', false);
-      });
-    }
-
-    function showTitles(widgets) {
-      widgets.forEach(function (widget) {
-        widget.attr('show_title', true);
-      });
-    }
+  setTabsPriority: function () {
+    let pageType = getPageType();
+    let widgets = this.options.attr('widget_list');
+    let instance = this.options.attr('instance');
 
     if (pageType === 'Audit') {
-      showTitles(priorityTabs);
-      hideTitles(notPriorityTabs);
+      let priorityTabsNum = 4 + isDashboardEnabled(instance);
+      this.options.attr('priorityTabs', widgets.slice(0, priorityTabsNum));
+      this.options.attr('notPriorityTabs', widgets.slice(priorityTabsNum));
     } else {
-      showTitles(originalWidgets);
+      this.options.attr('priorityTabs', widgets);
     }
   },
   '.closed click': function (el, ev) {

--- a/src/ggrc/assets/javascripts/controllers/inner-nav-controller.js
+++ b/src/ggrc/assets/javascripts/controllers/inner-nav-controller.js
@@ -25,6 +25,7 @@ export default can.Control({
     isMenuVisible: true,
     counts: null,
     hasHiddenWidgets: false,
+    showAddTabButton: true,
   },
 }, {
   init: function (options) {
@@ -40,6 +41,8 @@ export default can.Control({
       if (!(this.options.contexts instanceof can.Observe)) {
         this.options.attr('contexts', new can.Observe(this.options.contexts));
       }
+      this.options.attr('showAddTabButton',
+        !['Audit', 'Person'].includes(getPageType()));
 
       router.bind('widget', (ev, newVal)=>{
         this.route(newVal);

--- a/src/ggrc/assets/javascripts/controllers/inner-nav-controller.js
+++ b/src/ggrc/assets/javascripts/controllers/inner-nav-controller.js
@@ -44,26 +44,17 @@ export default can.Control({
         this.route(newVal);
       });
 
-      can.view(this.options.internav_view, this.options, function (frag) {
+      can.view(this.options.internav_view, this.options, (frag) => {
         const isAuditScope = instance.type === 'Audit';
-        const fn = function () {
-          this.element.append(frag);
-          if (isAuditScope) {
-            const priorityTabsNum = 4 +
-              isDashboardEnabled(instance);
-            this.element.addClass(this.options.instance.type.toLowerCase());
-            this.options.attr('priorityTabs', priorityTabsNum);
-          }
-          this.show_hide_titles();
-          this.route(router.attr('widget'));
-          delete this.delayed_display;
-        }.bind(this);
-
-        this.delayed_display = {
-          fn: fn,
-          timeout: setTimeout(fn, 50),
-        };
-      }.bind(this));
+        this.element.append(frag);
+        if (isAuditScope) {
+          const priorityTabsNum = 4 + isDashboardEnabled(instance);
+          this.element.addClass(this.options.instance.type.toLowerCase());
+          this.options.attr('priorityTabs', priorityTabsNum);
+        }
+        this.show_hide_titles();
+        this.route(router.attr('widget'));
+      });
 
       this.on();
     }.bind(this));
@@ -177,11 +168,6 @@ export default can.Control({
 
     function getWidgetType(widgetId) {
       return isObjectVersion(widgetId) ? 'version' : '';
-    }
-
-    if (this.delayed_display) {
-      clearTimeout(this.delayed_display.timeout);
-      this.delayed_display.timeout = setTimeout(this.delayed_display.fn, 50);
     }
 
     // If the metadata is unrendered, find it via options

--- a/src/ggrc/assets/javascripts/controllers/inner-nav-controller.js
+++ b/src/ggrc/assets/javascripts/controllers/inner-nav-controller.js
@@ -21,9 +21,6 @@ export default can.Control({
     contexts: null,
     instance: null,
     isMenuVisible: true,
-    addTabTitle: 'Add Tab',
-    hideTabTitle: 'Hide',
-    dividedTabsMode: false,
     priorityTabs: null,
     counts: null,
     hasHiddenWidgets: false,
@@ -55,9 +52,6 @@ export default can.Control({
             const priorityTabsNum = 4 +
               isDashboardEnabled(instance);
             this.element.addClass(this.options.instance.type.toLowerCase());
-            this.options.attr('addTabTitle', 'Add Scope');
-            this.options.attr('hideTabTitle', 'Show Audit Scope');
-            this.options.attr('dividedTabsMode', true);
             this.options.attr('priorityTabs', priorityTabsNum);
           }
           this.show_hide_titles();
@@ -348,16 +342,7 @@ export default can.Control({
     }
   },
   '.not-priority-hide click': function (el) {
-    var count = this.options.attr('priorityTabs') + 1;
-    var hiddenAreaSelector = 'li:nth-child(n+' + count + '):not(:last-child)';
-    var $hiddenArea = this.element.find(hiddenAreaSelector);
-
     this.options.attr('isMenuVisible', !this.options.isMenuVisible);
-    if (this.options.isMenuVisible) {
-      $hiddenArea.show();
-    } else {
-      $hiddenArea.hide();
-    }
   },
   '{counts} change': function () {
     this.update_add_more_link();

--- a/src/ggrc/assets/javascripts/controllers/tests/inner_navigation_controller_spec.js
+++ b/src/ggrc/assets/javascripts/controllers/tests/inner_navigation_controller_spec.js
@@ -4,6 +4,7 @@
 */
 
 import * as CurrentPageUtils from '../../plugins/utils/current-page-utils';
+import * as DashboardUtils from '../../plugins/utils/dashboards-utils';
 import Ctrl from '../inner-nav-controller';
 
 describe('CMS.Controllers.InnerNav', function () {
@@ -66,76 +67,59 @@ describe('CMS.Controllers.InnerNav', function () {
     });
   });
 
-  describe('show_hide_titles() method', function () {
-    var DISPLAY_WIDTH = 1920;
-    var ctrlInst; // fake controller instance
-    var showHideTitles;
-    var options;
+  describe('"setTabsPriority" method', () => {
+    let method;
+    let options;
 
-    function createWidgets(titlesStatus) {
-      var widgets = [
-        {name: 'aaa', show_title: titlesStatus},
-        {name: 'bbb', show_title: titlesStatus},
-        {name: 'ccc', show_title: titlesStatus},
-        {name: 'ddd', show_title: titlesStatus},
-        {name: 'eee', show_title: titlesStatus},
-        {name: 'fff', show_title: titlesStatus},
-      ];
-      options.attr('widget_list', widgets);
-      return widgets;
-    }
-
-    function setWidgetsWidth(first, second) {
-      spyOn(Array.prototype, 'reduce').and.returnValues(first, second);
-    }
-
-    beforeEach(function () {
+    beforeEach(() => {
       options = new can.Map({
-        widget_list: new can.Observe.List([]),
+        widget_list: new can.Observe.List([
+          {name: 'aaa'},
+          {name: 'bbb'},
+          {name: 'ccc'},
+          {name: 'ddd'},
+          {name: 'eee'},
+          {name: 'fff'},
+        ]),
         priorityTabs: null,
+        notPriorityTabs: null,
       });
 
-      ctrlInst = {
-        element: {
-          children: jasmine.createSpy(),
-          width: jasmine.createSpy().and.returnValue(DISPLAY_WIDTH),
-        },
+      let ctrl = {
         options: options,
       };
 
-      spyOn(_, 'map')
-        .and
-        .returnValue([]);
-
-      spyOn(CurrentPageUtils, 'getPageType')
-        .and
-        .returnValue('Assessment');
-
-      showHideTitles = Ctrl.prototype.show_hide_titles.bind(ctrlInst);
+      method = Ctrl.prototype.setTabsPriority.bind(ctrl);
     });
 
-    afterEach(function () {
-      Array.prototype.reduce.calls.reset();
+    it('sets first 4 tabs as priority for audit', () => {
+      spyOn(CurrentPageUtils, 'getPageType').and.returnValue('Audit');
+      spyOn(DashboardUtils, 'isDashboardEnabled').and.returnValue(false);
+
+      method();
+
+      expect(options.priorityTabs.length).toEqual(4);
+      expect(options.notPriorityTabs.length).toEqual(2);
     });
 
-    it('doesnt hide titles if the width is enough', function () {
-      createWidgets(false);
+    it('sets first 5 tabs as priority for audit when dashboard is enabled',
+      () => {
+        spyOn(CurrentPageUtils, 'getPageType').and.returnValue('Audit');
+        spyOn(DashboardUtils, 'isDashboardEnabled').and.returnValue(true);
 
-      setWidgetsWidth(1500);
+        method();
 
-      showHideTitles();
+        expect(options.priorityTabs.length).toEqual(5);
+        expect(options.notPriorityTabs.length).toEqual(1);
+      });
 
-      expect(_.every(options.attr('widget_list'), 'show_title')).toBeTruthy();
-    });
+    it('sets all tabs as priority for all objects except audit', () => {
+      spyOn(CurrentPageUtils, 'getPageType').and.returnValue('any type');
 
-    it('doesnt hides titles if the width isnt enough', function () {
-      createWidgets(true);
+      method();
 
-      setWidgetsWidth(2500);
-
-      showHideTitles();
-
-      expect(_.every(options.widget_list, 'show_title')).toBeTruthy();
+      expect(options.priorityTabs.length).toEqual(6);
+      expect(options.notPriorityTabs).toEqual(null);
     });
   });
 });

--- a/src/ggrc/assets/javascripts/controllers/tests/inner_navigation_controller_spec.js
+++ b/src/ggrc/assets/javascripts/controllers/tests/inner_navigation_controller_spec.js
@@ -92,7 +92,6 @@ describe('CMS.Controllers.InnerNav', function () {
     beforeEach(function () {
       options = new can.Map({
         widget_list: new can.Observe.List([]),
-        dividedTabsMode: false,
         priorityTabs: null,
       });
 

--- a/src/ggrc/assets/mustache/dashboard/internav_list.mustache
+++ b/src/ggrc/assets/mustache/dashboard/internav_list.mustache
@@ -8,8 +8,7 @@
   or #is_admin_page' }}
 <div class="tabs priority">
   <ul class="internav {{#if_equals instance.type 'Audit'}}audit{{/if_equals}}">
-    {{#widget_list}}
-      {{#if show_title}}
+    {{#priorityTabs}}
       <li class="{{internav_icon}} {{widgetType}} {{#if_equals contexts.active_widget.selector selector}}active{{/if_equals}}">
         {{#displayWidgetTab . instance}}
 
@@ -29,8 +28,7 @@
         </a>
         {{/displayWidgetTab}}
       </li>
-      {{/if}}
-    {{/widget_list}}
+    {{/priorityTabs}}
 
 
     {{^if_equals instance.type 'Audit'}}
@@ -58,8 +56,7 @@
 
   {{#isMenuVisible}}
     <ul class="internav">
-      {{#widget_list}}
-        {{^if show_title}}
+      {{#notPriorityTabs}}
         <li class="{{internav_icon}} {{widgetType}} {{#if_equals contexts.active_widget.selector selector}}active{{/if_equals}}">
           {{#displayWidgetTab . instance}}
           <a href="{{urlPath}}{{ internav_href }}" rel="tooltip" data-placement="bottom" title="{{ internav_display }}">
@@ -77,8 +74,7 @@
           </a>
           {{/displayWidgetTab}}
         </li>
-        {{/if}}
-      {{/widget_list}}
+      {{/notPriorityTabs}}
 
       {{#hasHiddenWidgets}}
         <add-tab-button

--- a/src/ggrc/assets/mustache/dashboard/internav_list.mustache
+++ b/src/ggrc/assets/mustache/dashboard/internav_list.mustache
@@ -31,7 +31,7 @@
     {{/priorityTabs}}
 
 
-    {{^if_equals instance.type 'Audit'}}
+    {{#if showAddTabButton}}
       {{#hasHiddenWidgets}}
         <add-tab-button
           {instance}="instance"
@@ -39,7 +39,7 @@
           {url-path}="urlPath"
           {add-tab-title}="'Add Tab'"></add-tab-button>
       {{/hasHiddenWidgets}}
-    {{/if_equals}}
+    {{/if}}
 
   </ul>
 </div>

--- a/src/ggrc/assets/mustache/dashboard/internav_list.mustache
+++ b/src/ggrc/assets/mustache/dashboard/internav_list.mustache
@@ -39,7 +39,7 @@
           {instance}="instance"
           {widget-list}="widget_list"
           {url-path}="urlPath"
-          {add-tab-title}="addTabTitle"></add-tab-button>
+          {add-tab-title}="'Add Tab'"></add-tab-button>
       {{/hasHiddenWidgets}}
     {{/if_equals}}
 
@@ -49,14 +49,12 @@
 
 {{#if_equals instance.type 'Audit'}}
 <div class="tabs not-priority">
-  {{#if dividedTabsMode}}
-    <div class="not-priority-hide {{#if isMenuVisible}}visible{{/if}}">
-        <i class="fa fa-angle-{{#if isMenuVisible}}right{{else}}left{{/if}}"></i>
-        {{^if isMenuVisible}}
-        <a href="javascript://">{{hideTabTitle}}</a>
-        {{/if}}
-    </div>
-  {{/if}}
+  <div class="not-priority-hide {{#if isMenuVisible}}visible{{/if}}">
+      <i class="fa fa-angle-{{#if isMenuVisible}}right{{else}}left{{/if}}"></i>
+      {{^if isMenuVisible}}
+        <a href="javascript://">Show Audit Scope</a>
+      {{/if}}
+  </div>
 
   {{#isMenuVisible}}
     <ul class="internav">
@@ -87,7 +85,7 @@
           {instance}="instance"
           {widget-list}="widget_list"
           {url-path}="urlPath"
-          {add-tab-title}="addTabTitle"></add-tab-button>
+          {add-tab-title}="'Add Scope'"></add-tab-button>
       {{/hasHiddenWidgets}}
     </ul>
   {{/isMenuVisible}}


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Remove '+Add Tab' control from Person page

# Steps to test the changes

1. Login to GGRC.
2. Search People in Global search.
3. Click 'open in a new tab' link for any person.
4. System opens Person page.

**Actual result:** '+Add Tab' control present on person page.
**Expected result:** '+Add Tab' control should be removed from person page. Person page is just used to see the objects that are mapped to concrete person. Any mappings are prohibit.

# Solution description

Remove redundant code from dashboard_controller.js

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [ ] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] db_reset runs without errors or warnings.
- [ ] db_reset ggrc-qa.sql runs without errors or warnings.
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
