### PR TITLE
GGRC-3452 Use Audit Captain as default assignee if Auditor is absent

### DIFF
--- a/src/ggrc/models/hooks/assessment.py
+++ b/src/ggrc/models/hooks/assessment.py
@@ -202,9 +202,11 @@ def generate_role_object_dict(snapshot, audit):
   acl_dict["Audit Lead"].extend([acl.person_id
                                 for acl in audit.access_control_list
                                 if acl.ac_role_id == leads_role])
-  acl_dict["Auditors"].extend([acl.person_id
-                               for acl in audit.access_control_list
-                               if acl.ac_role_id == auditors_role])
+  auditors = [
+      acl.person_id for acl in audit.access_control_list
+      if acl.ac_role_id == auditors_role
+  ]
+  acl_dict["Auditors"].extend(auditors or acl_dict["Audit Lead"])
   return acl_dict
 
 

--- a/src/ggrc/models/hooks/assessment.py
+++ b/src/ggrc/models/hooks/assessment.py
@@ -173,7 +173,7 @@ def get_people_ids_based_on_role(assignee_role,
                                  template_settings,
                                  acl_dict):
   """Get people_ids base on role and template settings."""
-  if assignee_role not in template_settings:
+  if not template_settings.get(assignee_role):
     return []
   template_role = template_settings[assignee_role]
   if isinstance(template_role, list):

--- a/test/selenium/src/lib/entities/entities_factory.py
+++ b/test/selenium/src/lib/entities/entities_factory.py
@@ -528,7 +528,8 @@ class AssessmentsFactory(EntitiesFactory):
     asmts_objs = [cls.create(
         title=obj_under_asmt.title + " assessment for " + audit.title,
         audit=audit.title, objects_under_assessment=[obj_under_asmt],
-        custom_attribute_definitions=cas_def) for
+        custom_attribute_definitions=cas_def,
+        verifier=[audit.contact["name"]]) for
         obj_under_asmt in objs_under_asmt]
     return [Entity.update_objs_attrs_values_by_entered_data(
         obj_or_objs=asmt_obj, slug=None) for asmt_obj in asmts_objs]


### PR DESCRIPTION
# Issue description

If auditor is not assigned to audit and is a default assignee in assessment template, after assessment generation assignee is missed for Assessment.
Steps to reproduce:
1. Have audit w/o assigned auditor
2. Create assessment template with auditor that is a default Assignee
3. Generate assessment based on Assessment template
4. Look at the Assignee in the Assessment tree view: is not displayed
5. Navigate to Assessment Info pane > Assessment tab: Assignee is not displayed
6. Invoke Edit Assessment modal window: Assignee is not displayed

# Steps to test the changes

Steps to reproduce:
1. Have audit without assigned auditor
2. Create assessment template with auditor that is a default Assignee/default Verifier
3. Generate assessment based on Assessment template
4. Assessment Assignee/Verifier should be filled with Audit Captain

# Solution description

Currently if we have default Assignee in Assessment template we populate it with Auditors from UserRoles, but if Auditor is not added for Audit it will be empty. By requirements in the ticket in case of missing Auditors default value will be populated with Audit Captain.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".