### PR TITLE
GGRC-3176 Fix error msg for invalid asmnt add_related

### DIFF
--- a/src/ggrc/models/mixins/with_action.py
+++ b/src/ggrc/models/mixins/with_action.py
@@ -142,7 +142,15 @@ class WithAction(object):
       try:
         return ntuple(**_action)
       except TypeError:
-        raise ValidationError("Missed action parameters")
+        # According to documentation _fields is not private property
+        # but public, '_' added to prevent conflicts with tuple field names
+        # pylint: disable=protected-access
+        missing_fields = set(ntuple._fields) - set(_action)
+        raise ValidationError(
+            "Fields {} are missing for action: {!r}".format(
+                ", ".join(missing_fields), _action
+            )
+        )
 
     # pylint: disable=unused-argument,no-self-use
     def _create(self, parent, action):

--- a/test/integration/ggrc/models/mixins/test_with_action.py
+++ b/test/integration/ggrc/models/mixins/test_with_action.py
@@ -533,6 +533,27 @@ class TestCommentWithActionMixin(TestCase):
     self.assertEqual(comment.description, "comment")
     self.assertEqual(comment.custom_attribute_definition_id, ca_def.id)
 
+  def test_wrong_comment(self):
+    """Test add custom attribute comment action without description."""
+    with factories.single_commit():
+      assessment = factories.AssessmentFactory()
+      ca_def = factories.CustomAttributeDefinitionFactory(
+          title="def1",
+          definition_type="assessment",
+          attribute_type="Dropdown",
+          multi_choice_options="no,yes",
+      )
+    data = {
+        u"id": None,
+        u"type": u"Comment",
+        u"custom_attribute_definition_id": int(ca_def.id),
+    }
+    response = self.api.put(assessment, {"actions": {"add_related": [data]}})
+    self.assert400(response)
+
+    err = u"Fields {} are missing for action: {!r}".format("description", data)
+    self.assertEqual(response.json.get("message"), err)
+
   def test_wrong_add_comment(self):
     """Test wrong add comment action."""
     assessment = factories.AssessmentFactory()


### PR DESCRIPTION
# Issue description

Sending PUT with
```
actions: { add_related: {
id: null,
type: "Comment",
custom_attribute_definition_id: 70
}}
```
lead to error "Missed action parameters". That's not informative, need to change it to "Field description is missed"

# Steps to test the changes

Send PUT with
```
actions: { add_related: {
id: null,
type: "Comment",
custom_attribute_definition_id: 70
}}
```
to api/assessments/<id>. Error "Field 'description' is missed." should be shown

# Solution description

Compare set of required columns and received, put difference into error message.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".