### PR TITLE
GGRC-3682: Fix expand/collapse issue on CTGOT state change

### DIFF
--- a/src/ggrc/assets/javascripts/components/cycle-task-actions/cycle-task-actions.js
+++ b/src/ggrc/assets/javascripts/components/cycle-task-actions/cycle-task-actions.js
@@ -65,27 +65,13 @@ import template from './cycle-task-actions.mustache';
     },
     changeStatus: function (ctx, el, ev) {
       var status = el.data('value');
-      var openclose = el.data('openclose');
       var instance = this.attr('instance');
       var oldValue = {
         status: instance.attr('status')
       };
-      var expanded;
 
       ev.stopPropagation();
       this.attr('oldValues').unshift(oldValue);
-
-      if (openclose) {
-        if (openclose === 'open') {
-          expanded = true;
-        } else if (openclose === 'close') {
-          expanded = false;
-        }
-        this.dispatch({
-          type: 'expand',
-          state: expanded
-        });
-      }
 
       this.setStatus(status);
     },

--- a/src/ggrc/assets/javascripts/components/cycle-task-actions/cycle-task-actions.mustache
+++ b/src/ggrc/assets/javascripts/components/cycle-task-actions/cycle-task-actions.mustache
@@ -17,7 +17,6 @@
           {{#if_equals instance.status 'Assigned'}}
             <button class="btn btn-mini btn-lightBlue"
                     ($click)="changeStatus"
-                    data-openclose="open"
                     data-value="InProgress">Start</button>
           {{/if_equals}}
           {{#if_equals instance.status 'InProgress'}}
@@ -43,7 +42,6 @@
                       data-value="Declined">Decline</button>
               <button class="btn btn-mini btn-green"
                       ($click)="changeStatus"
-                      data-openclose="close"
                       data-value="Verified">Verify</button>
             {{/if}}
           {{/if_equals}}

--- a/src/ggrc/assets/javascripts/components/tests/cycle-task-actions_spec.js
+++ b/src/ggrc/assets/javascripts/components/tests/cycle-task-actions_spec.js
@@ -23,7 +23,6 @@ describe('GGRC.Components.subTreeWrapper', function () {
 
     beforeEach(function () {
       spyOn(vm, 'setStatus');
-      spyOn(vm, 'dispatch');
 
       vm.attr('oldValues', []);
       vm.attr('instance', {
@@ -42,7 +41,6 @@ describe('GGRC.Components.subTreeWrapper', function () {
 
       expect(vm.attr('oldValues').length).toEqual(1);
       expect(vm.attr('oldValues')[0].status).toEqual('InProgress');
-      expect(vm.dispatch).not.toHaveBeenCalled();
       expect(vm.setStatus).toHaveBeenCalledWith('Verified');
     });
 
@@ -56,7 +54,6 @@ describe('GGRC.Components.subTreeWrapper', function () {
 
         expect(vm.attr('oldValues').length).toEqual(1);
         expect(vm.attr('oldValues')[0].status).toEqual('InProgress');
-        expect(vm.dispatch).toHaveBeenCalled();
         expect(vm.setStatus).toHaveBeenCalledWith('Verified');
       });
   });


### PR DESCRIPTION
# Issue description
CTGOT is expand/collapsed on state change.

# Steps to test the changes
1. Create any workflow
2. In the setup tab add task to task group
3. Map any entity to task group
4. Activate Workflow
5. In Active Cycles tab expand subtree for cycle and cycle task group
6. Click [Start] button in Task first tier
**Actual Result:** While clicking [Start] button for Task, tree view with mappings is expanded
**Expected Result:** While clicking [Start] button for Task, tree view with mappings should not expand
The same issue should be fixed for moving CTGOT to Verified state (CTGOT tree is collapsed).

# Solution description
Remove functionality for expanding-collapsing CTGOT tree on state change.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
