### PR TITLE
GGRC-3158 Fix LCA dropdown field validation

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment/assessment-local-ca.js
+++ b/src/ggrc/assets/javascripts/components/assessment/assessment-local-ca.js
@@ -89,11 +89,11 @@ import Permission from '../../permission';
           },
         },
       },
-      validateForm: function () {
+      validateForm: function (triggerAttachmentModals = false) {
         var self = this;
         this.attr('fields')
           .each(function (field) {
-            self.performValidation({field});
+            self.performValidation({field, triggerAttachmentModals});
           });
         if (this.attr('instance.hasValidationErrors')) {
           this.dispatch(VALIDATION_ERROR);
@@ -240,7 +240,7 @@ import Permission from '../../permission';
           e.field.attr('errorsMap.comment', true);
         }
 
-        this.performValidation({field: e.field, triggerAttachmentModals: true});
+        this.validateForm(true);
         this.attr('formSavedDeferred', can.Deferred());
         this.save(e.fieldId, e.value);
       },

--- a/src/ggrc/assets/javascripts/components/assessment/assessment-local-ca.js
+++ b/src/ggrc/assets/javascripts/components/assessment/assessment-local-ca.js
@@ -89,11 +89,11 @@ import Permission from '../../permission';
           },
         },
       },
-      validateForm: function (formInit = false) {
+      validateForm: function () {
         var self = this;
         this.attr('fields')
           .each(function (field) {
-            self.performValidation({field, formInit});
+            self.performValidation({field});
           });
         if (this.attr('instance.hasValidationErrors')) {
           this.dispatch(VALIDATION_ERROR);
@@ -101,7 +101,6 @@ import Permission from '../../permission';
       },
       performValidation: function ({
         field,
-        formInit = false,
         triggerAttachmentModals = false,
       }) {
         var fieldValid;
@@ -130,8 +129,7 @@ import Permission from '../../permission';
         hasMissingEvidence = requiresEvidence &&
           !!this.attr('isEvidenceRequired');
 
-        hasMissingComment = formInit ?
-          requiresComment && !!errorsMap.comment : requiresComment;
+        hasMissingComment = requiresComment && !!errorsMap.comment;
 
         if (field.type === 'checkbox') {
           if (value === '1') {
@@ -235,12 +233,6 @@ import Permission from '../../permission';
       },
     },
     events: {
-      inserted: function () {
-        this.viewModel.validateForm(true);
-      },
-      '{viewModel.instance} update': function () {
-        this.viewModel.validateForm();
-      },
       '{viewModel.instance} afterCommentCreated': function () {
         this.viewModel.validateForm();
       },

--- a/src/ggrc/assets/javascripts/components/assessment/assessment-local-ca.js
+++ b/src/ggrc/assets/javascripts/components/assessment/assessment-local-ca.js
@@ -99,7 +99,11 @@ import Permission from '../../permission';
           this.dispatch(VALIDATION_ERROR);
         }
       },
-      performValidation: function ({field, formInit = false}) {
+      performValidation: function ({
+        field,
+        formInit = false,
+        triggerAttachmentModals = false,
+      }) {
         var fieldValid;
         var hasMissingEvidence;
         var hasMissingComment;
@@ -161,7 +165,8 @@ import Permission from '../../permission';
             },
           });
 
-          if (!formInit && (hasMissingEvidence || hasMissingComment)) {
+          if (triggerAttachmentModals &&
+              (hasMissingEvidence || hasMissingComment)) {
             this.dispatch({
               type: 'validationChanged',
               field: field,
@@ -224,7 +229,7 @@ import Permission from '../../permission';
       },
       attributeChanged: function (e) {
         e.field.attr('value', e.value);
-        this.performValidation({field: e.field});
+        this.performValidation({field: e.field, triggerAttachmentModals: true});
         this.attr('formSavedDeferred', can.Deferred());
         this.save(e.fieldId, e.value);
       },

--- a/src/ggrc/assets/javascripts/components/assessment/assessment-local-ca.js
+++ b/src/ggrc/assets/javascripts/components/assessment/assessment-local-ca.js
@@ -89,17 +89,17 @@ import Permission from '../../permission';
           },
         },
       },
-      validateForm: function () {
+      validateForm: function (formInit = false) {
         var self = this;
         this.attr('fields')
           .each(function (field) {
-            self.performValidation(field, true);
+            self.performValidation({field, formInit});
           });
         if (this.attr('instance.hasValidationErrors')) {
           this.dispatch(VALIDATION_ERROR);
         }
       },
-      performValidation: function (field, formInitCheck) {
+      performValidation: function ({field, formInit = false}) {
         var fieldValid;
         var hasMissingEvidence;
         var hasMissingComment;
@@ -126,7 +126,7 @@ import Permission from '../../permission';
         hasMissingEvidence = requiresEvidence &&
           !!this.attr('isEvidenceRequired');
 
-        hasMissingComment = formInitCheck ?
+        hasMissingComment = formInit ?
           requiresComment && !!errorsMap.comment : requiresComment;
 
         if (field.type === 'checkbox') {
@@ -161,7 +161,7 @@ import Permission from '../../permission';
             },
           });
 
-          if (!formInitCheck && (hasMissingEvidence || hasMissingComment)) {
+          if (!formInit && (hasMissingEvidence || hasMissingComment)) {
             this.dispatch({
               type: 'validationChanged',
               field: field,
@@ -224,14 +224,14 @@ import Permission from '../../permission';
       },
       attributeChanged: function (e) {
         e.field.attr('value', e.value);
-        this.performValidation(e.field);
+        this.performValidation({field: e.field});
         this.attr('formSavedDeferred', can.Deferred());
         this.save(e.fieldId, e.value);
       },
     },
     events: {
       inserted: function () {
-        this.viewModel.validateForm();
+        this.viewModel.validateForm(true);
       },
       '{viewModel.instance} update': function () {
         this.viewModel.validateForm();

--- a/src/ggrc/assets/javascripts/components/assessment/assessment-local-ca.js
+++ b/src/ggrc/assets/javascripts/components/assessment/assessment-local-ca.js
@@ -57,7 +57,19 @@ import Permission from '../../permission';
           type: 'number',
           set: function (newValue, setValue) {
             setValue(newValue);
-            this.validateForm();
+            if (this.attr('relatedItemsLoaded')) {
+              this.validateForm();
+            }
+          },
+        },
+        relatedItemsLoaded: {
+          value: false,
+          type: 'boolean',
+          set(newValue, setValue) {
+            setValue(newValue);
+            if (newValue) {
+              this.validateForm();
+            }
           },
         },
         isEvidenceRequired: {

--- a/src/ggrc/assets/javascripts/components/assessment/assessment-local-ca.js
+++ b/src/ggrc/assets/javascripts/components/assessment/assessment-local-ca.js
@@ -225,8 +225,21 @@ import Permission from '../../permission';
           stopFn();
         });
       },
+      fieldRequiresComment: function (field) {
+        let fieldValidationConf = field.validationConfig[field.value];
+          return fieldValidationConf === CA_DD_REQUIRED_DEPS.COMMENT ||
+            fieldValidationConf === CA_DD_REQUIRED_DEPS.COMMENT_AND_EVIDENCE;
+      },
       attributeChanged: function (e) {
         e.field.attr('value', e.value);
+
+        // Removes "link" with the comment for DD field and
+        // makes it require a new one
+        if ( e.field.attr('type') === 'dropdown' &&
+            this.fieldRequiresComment(e.field) ) {
+          e.field.attr('errorsMap.comment', true);
+        }
+
         this.performValidation({field: e.field, triggerAttachmentModals: true});
         this.attr('formSavedDeferred', can.Deferred());
         this.save(e.fieldId, e.value);

--- a/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.js
+++ b/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.js
@@ -185,6 +185,7 @@ import template from './info-pane.mustache';
       _verifierRoleId: undefined,
       isUpdatingRelatedItems: false,
       isAssessmentSaving: false,
+      relatedItemsLoaded: false,
       onStateChangeDfd: {},
       formState: {},
       noItemsText: '',
@@ -394,6 +395,7 @@ import template from './info-pane.mustache';
             this.attr('referenceUrls').replace(data['Document:REFERENCE_URL']);
 
             this.attr('isUpdatingRelatedItems', false);
+            this.attr('relatedItemsLoaded', true);
 
             tracker.stop(this.attr('instance.type'),
               tracker.USER_JOURNEY_KEYS.NAVIGATION,

--- a/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.mustache
+++ b/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.mustache
@@ -82,7 +82,7 @@
                 </div>
                 <div class="assessment-controls info-pane__section">
                     <div class="assessment-note">
-			<custom-attributes-status
+                      <custom-attributes-status
                                 {form-saving}="formState.saving"
                                 {is-dirty}="formState.isDirty">
                                 <loading-status
@@ -91,7 +91,7 @@
                                     always-Show-Text="true"
                                     show-Spinner="true">
                                 </loading-status>
-			</custom-attributes-status>
+                      </custom-attributes-status>
                         <i class="fa fa-question-circle" rel="tooltip"
                            data-original-title="Respond to assessment here. Use comments on the right for free text responses."></i>
                     </div>
@@ -200,11 +200,11 @@
                         {^is-dirty}="formState.isDirty"
                         (validation-error)="setLastErrorTab(tabIndex)"
                         (validation-changed)="showRequiredInfoModal(%event)">
-			<custom-attributes
+                      <custom-attributes
                             {fields}="fields"
                             {edit-mode}="editMode"
                             (value-changed)="attributeChanged(%event)">
-			</custom-attributes>
+                      </custom-attributes>
                     </assessment-local-ca>
                     <!-- Modal Window to fix validation issues of CA fields -->
                     {{#if modal.state}}
@@ -213,7 +213,7 @@
                                     {instance}="instance"
                                     {is-disabled}="isUpdatingEvidences">
                           <ca-object-modal-content {instance}="instance"
-						   {assessment-type-objects}="assessmentTypeObjects"
+                                                   {assessment-type-objects}="assessmentTypeObjects"
                                                    {content}="modal.content"
                                                    {state}="state"
                                                    {evidences}="evidences"

--- a/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.mustache
+++ b/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.mustache
@@ -193,6 +193,7 @@
                         {evidence-amount}="evidences.length"
                         {^has-validation-errors}="instance.hasValidationErrors"
                         {fields}="formFields"
+                        {related-items-loaded}="relatedItemsLoaded"
                         {edit-mode}="editMode"
                         {^saving}="formState.saving"
                         {^form-saved-deferred}="formState.formSavedDeferred"

--- a/src/ggrc/assets/javascripts/components/assessment/tests/assessment-local-ca_spec.js
+++ b/src/ggrc/assets/javascripts/components/assessment/tests/assessment-local-ca_spec.js
@@ -106,7 +106,7 @@ describe('assessmentLocalCa component', () => {
       viewModel.attr('fields', [checkboxField]);
       dropdownField.attr('value', null);
 
-      performValidation(checkboxField);
+      performValidation({field: checkboxField});
 
       expect(checkboxField.attr().validation).toEqual({
         show: false,
@@ -115,7 +115,7 @@ describe('assessmentLocalCa component', () => {
         mandatory: false,
       });
 
-      performValidation(checkboxField);
+      performValidation({field: checkboxField});
 
       expect(checkboxField.attr().validation).toEqual({
         show: false,
@@ -130,7 +130,7 @@ describe('assessmentLocalCa component', () => {
       checkboxField.attr('value', null);
       checkboxField.attr('validation.mandatory', true);
 
-      performValidation(checkboxField);
+      performValidation({field: checkboxField});
       expect(checkboxField.attr().validation).toEqual({
         mandatory: true,
         show: true,
@@ -139,7 +139,7 @@ describe('assessmentLocalCa component', () => {
       });
 
       checkboxField.attr('value', 0);
-      performValidation(checkboxField);
+      performValidation({field: checkboxField});
       expect(checkboxField.attr().validation).toEqual({
         mandatory: true,
         show: true,
@@ -148,7 +148,7 @@ describe('assessmentLocalCa component', () => {
       });
 
       checkboxField.attr('value', 1);
-      performValidation(checkboxField);
+      performValidation({field: checkboxField});
       expect(checkboxField.attr().validation).toEqual({
         mandatory: true,
         show: true,
@@ -157,7 +157,7 @@ describe('assessmentLocalCa component', () => {
       });
 
       checkboxField.attr('value', '1');
-      performValidation(checkboxField);
+      performValidation({field: checkboxField});
       expect(checkboxField.attr().validation).toEqual({
         mandatory: true,
         show: true,
@@ -170,7 +170,7 @@ describe('assessmentLocalCa component', () => {
       viewModel.attr('fields', [inputField]);
       inputField.attr('value', '');
 
-      performValidation(inputField);
+      performValidation({field: inputField});
       expect(inputField.attr().validation).toEqual({
         mandatory: false,
         show: false,
@@ -179,7 +179,7 @@ describe('assessmentLocalCa component', () => {
       });
 
       inputField.attr('value', 'some input');
-      performValidation(inputField);
+      performValidation({field: inputField});
       expect(inputField.attr().validation).toEqual({
         mandatory: false,
         show: false,
@@ -194,7 +194,7 @@ describe('assessmentLocalCa component', () => {
 
       inputField.attr('validation.mandatory', true);
 
-      performValidation(inputField);
+      performValidation({field: inputField});
       expect(inputField.attr().validation).toEqual({
         mandatory: true,
         show: true,
@@ -203,7 +203,7 @@ describe('assessmentLocalCa component', () => {
       });
 
       inputField.attr('value', 'some input');
-      performValidation(inputField);
+      performValidation({field: inputField});
       expect(inputField.attr().validation).toEqual({
         mandatory: true,
         show: true,
@@ -217,7 +217,7 @@ describe('assessmentLocalCa component', () => {
       viewModel.attr('fields', [dropdownField]);
       dropdownField.attr('value', '');
 
-      performValidation(dropdownField);
+      performValidation({field: dropdownField});
       expect(dropdownField.attr().validation).toEqual({
         mandatory: false,
         show: false,
@@ -235,7 +235,7 @@ describe('assessmentLocalCa component', () => {
       viewModel.attr('fields', [dropdownField]);
       dropdownField.attr('value', 'nothing required');
 
-      performValidation(dropdownField);
+      performValidation({field: dropdownField});
       expect(dropdownField.attr().validation).toEqual({
         mandatory: false,
         show: true,
@@ -255,7 +255,7 @@ describe('assessmentLocalCa component', () => {
       dropdownField.attr('value', 'comment required');
 
       dropdownField.attr('errorsMap.comment', true);
-      performValidation(dropdownField, true);
+      performValidation({field: dropdownField});
 
       expect(dropdownField.attr().validation).toEqual({
         mandatory: false,
@@ -275,7 +275,7 @@ describe('assessmentLocalCa component', () => {
       viewModel.attr('fields', [dropdownField]);
       dropdownField.attr('value', 'comment required');
 
-      performValidation(dropdownField, true);
+      performValidation({field: dropdownField});
 
       expect(dropdownField.attr().validation).toEqual({
         mandatory: false,
@@ -296,7 +296,7 @@ describe('assessmentLocalCa component', () => {
       dropdownField.attr('value', 'evidence required');
 
       dropdownField.attr('errorsMap.evidence', true);
-      performValidation(dropdownField);
+      performValidation({field: dropdownField});
 
       expect(viewModel.attr('evidenceAmount')).toBe(0);
       expect(dropdownField.attr().validation).toEqual({
@@ -318,7 +318,7 @@ describe('assessmentLocalCa component', () => {
       viewModel.attr('evidenceAmount', 1);
       dropdownField.attr('value', 'evidence required');
 
-      performValidation(dropdownField, true);
+      performValidation({field: dropdownField});
 
       expect(dropdownField.attr().validation).toEqual({
         mandatory: false,
@@ -341,7 +341,7 @@ describe('assessmentLocalCa component', () => {
       dropdownField.attr('errorsMap.comment', true);
       dropdownField.attr('errorsMap.evidence', true);
 
-      performValidation(dropdownField, true);
+      performValidation({field: dropdownField});
 
       expect(dropdownField.attr().validation).toEqual({
         mandatory: false,
@@ -362,7 +362,7 @@ describe('assessmentLocalCa component', () => {
       dropdownField.attr('value', 'com+ev required');
 
       dropdownField.attr('errorsMap.evidence', true);
-      performValidation(dropdownField, true);
+      performValidation({field: dropdownField});
 
       expect(dropdownField.attr().validation).toEqual({
         mandatory: false,
@@ -385,7 +385,7 @@ describe('assessmentLocalCa component', () => {
       dropdownField.attr('value', 'com+ev required');
       dropdownField.attr('errorsMap.comment', true);
 
-      performValidation(dropdownField);
+      performValidation({field: dropdownField});
 
       expect(dropdownField.attr().validation).toEqual({
         mandatory: false,
@@ -406,7 +406,7 @@ describe('assessmentLocalCa component', () => {
       viewModel.attr('evidenceAmount', 1);
 
       dropdownField.attr('value', 'com+ev required');
-      performValidation(dropdownField, true);
+      performValidation({field: dropdownField});
 
       expect(dropdownField.attr().validation).toEqual({
         mandatory: false,


### PR DESCRIPTION
# Issue description

LCA dropdown fields with evidence required show wrong validation statuses before the attachments are loaded.

# Steps to test the changes

1. Create Assessment with 2 dropdown fields and values which require evidences.
2. Switch dropdown to "evidence required" values and add 2 evidences to the assessment.
3. Switch network throttling in chrome devtools to "slow 3G" and reopen assessment info pane.
4. Validation of the dropdown fields does not switch to "invalid" during all stages of form data loading.

# Solution description

The solution is not to run form validation until all data are available. This is achieved by adding the  flag which changes when all related to assessment items are loaded.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
