### PR TITLE
GGRC-3366,GGRC-3262: Restrict dates to week days for TGT and CTGOT

### DIFF
--- a/src/ggrc_workflows/assets/javascripts/models/cycle_models.js
+++ b/src/ggrc_workflows/assets/javascripts/models/cycle_models.js
@@ -4,6 +4,7 @@
 */
 
 import RefreshQueue from '../../../../ggrc/assets/javascripts/models/refresh_queue';
+import {getClosestWeekday} from '../utils/date-util';
 
 (function (can) {
   var _mustachePath;
@@ -394,11 +395,16 @@ import RefreshQueue from '../../../../ggrc/assets/javascripts/models/refresh_que
       var workflows;
       var _workflow;
       var cycle;
+      let startDate;
+      let endDate;
 
       if (newObjectForm) {
         // prepopulate dates with default ones
-        this.attr('start_date', new Date());
-        this.attr('end_date', moment().add({month: 3}).toDate());
+        startDate = getClosestWeekday(new Date());
+        endDate = getClosestWeekday(moment().add({month: 3}).toDate());
+
+        this.attr('start_date', startDate);
+        this.attr('end_date', endDate);
 
         // if we are creating a task from the workflow page, the preset
         // workflow should be that one

--- a/src/ggrc_workflows/assets/javascripts/models/task_group.js
+++ b/src/ggrc_workflows/assets/javascripts/models/task_group.js
@@ -3,6 +3,8 @@
  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  */
 
+ import {getClosestWeekday} from '../utils/date-util';
+
 (function (can, GGRC) {
   'use strict';
 
@@ -183,12 +185,15 @@
   }, {
     init: function () {
       // default start and end date
-      var startDate = this.attr('start_date') || new Date();
-      var endDate = this.attr('end_date') ||
+      let startDate = this.attr('start_date') || new Date();
+      let endDate = this.attr('end_date') ||
         new Date(moment().add(7, 'days').format());
       if (this._super) {
         this._super.apply(this, arguments);
       }
+
+      startDate = getClosestWeekday(startDate);
+      endDate = getClosestWeekday(endDate);
       // Add base values to this property
       this.attr('response_options', []);
       this.attr('start_date', startDate);
@@ -229,7 +234,6 @@
         }, this);
       });
     },
-
     _refresh_workflow_people: function () {
       //  TaskGroupTask assignment may add mappings and role assignments in
       //  the backend, so ensure these changes are reflected.

--- a/src/ggrc_workflows/assets/javascripts/utils/date-util.js
+++ b/src/ggrc_workflows/assets/javascripts/utils/date-util.js
@@ -1,0 +1,25 @@
+/*
+ Copyright (C) 2017 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+/**
+ * Adjust date to the closest week day that is less than current.
+ *
+ * @param {Date} date - date value
+ *
+ * @return {Date} closest week date to provided
+ */
+function getClosestWeekday(date) {
+  let momDate = moment(date);
+
+  if (momDate.isoWeekday() > 5) {
+    return momDate.isoWeekday(5).toDate();
+  }
+
+  return date;
+};
+
+export {
+  getClosestWeekday,
+};

--- a/src/ggrc_workflows/assets/javascripts/utils/tests/date-util_spec.js
+++ b/src/ggrc_workflows/assets/javascripts/utils/tests/date-util_spec.js
@@ -1,0 +1,28 @@
+/*
+ Copyright (C) 2017 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+import {getClosestWeekday} from '../date-util';
+
+ describe('GGRC.Utils.DateUtil', ()=> {
+  describe('adjustToClosestWeekday() method', ()=> {
+    it('adjusts to Friday when weekend provided', ()=> {
+      let date = new Date(2017, 11, 24);
+      let actual;
+
+      actual = getClosestWeekday(date);
+
+      expect(actual.getDate()).toEqual(22);
+    });
+
+    it('leaves date as is when week day provided', ()=> {
+      let date = new Date(2017, 11, 20);
+      let actual;
+
+      actual = getClosestWeekday(date);
+
+      expect(actual.getDate()).toEqual(20);
+    });
+  });
+ });

--- a/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/modal_content.mustache
+++ b/src/ggrc_workflows/assets/mustache/cycle_task_group_object_tasks/modal_content.mustache
@@ -169,7 +169,8 @@
             set-max-date="instance.end_date"
             date="instance.start_date"
             required="true"
-            />
+            no-weekends="true"
+            deny-input="true" />
             {{#instance.computed_errors.start_date}}<label class="help-inline warning">{{this}}</label>{{/instance.computed_errors.start_date}}
           </div>
         </div>
@@ -182,7 +183,8 @@
             set-min-date="instance.start_date"
             date="instance.end_date"
             required="true"
-            />
+            no-weekends="true"
+            deny-input="true" />
             {{#instance.computed_errors.end_date}}<label class="help-inline warning">{{this}}</label>{{/instance.computed_errors.end_date}}
           </div>
         </div>

--- a/src/ggrc_workflows/assets/mustache/task_group_tasks/modal_content.mustache
+++ b/src/ggrc_workflows/assets/mustache/task_group_tasks/modal_content.mustache
@@ -80,10 +80,8 @@
                   </label>
                   <datepicker date="instance.start_date"
                               required="true"
-                              {{#is workflow.unit 'day'}}
-                                no-weekends="true"
-                                deny-input="true"
-                              {{/is}}></datepicker>
+                              no-weekends="true"
+                              deny-input="true"></datepicker>
               </label>
               <label class="smaller">
                   <label class="form__label">
@@ -93,10 +91,8 @@
                   <datepicker set-min-date="instance.start_date"
                               date="instance.end_date"
                               required="true"
-                              {{#is workflow.unit 'day'}}
-                                no-weekends="true"
-                                deny-input="true"
-                              {{/is}}></datepicker>
+                              no-weekends="true"
+                              deny-input="true"></datepicker>
               </label>
           </div>
       {{/using}}


### PR DESCRIPTION
# Issue description
User should be able to set week days only for TGT and CTGOT

# Steps to test the changes
1. Create weekday WF
2. Add task and Activate WF
3. Go to the Active Cycles tab
4. Edit task: set TASK START DATE/TASK DUE DATE day off
**Actual Result:** While editing task for weekday WF user is able to set day off
**Expected Result:** While editing task for weekday WF user should not be able to set day off
The same should be fixed for create CTGOT modal and Create/Edit TGT modal.

# Solution description
check via moment.js whether date is weekday and amend it to closest Friday (moment.js is in use due to possible issue for different locales).

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".