### PR TITLE
GGRC-1509 Fix verified state color in TreeView and Assessment Info Pane

### DIFF
--- a/src/ggrc/assets/javascripts/components/unified-mapper/templates/mapper-results-item-status.mustache
+++ b/src/ggrc/assets/javascripts/components/unified-mapper/templates/mapper-results-item-status.mustache
@@ -7,11 +7,11 @@
   {{#if itemData.isOverdue}}
     <span class="status-label status-overdue"></span>
   {{else}}
-    <span class="status-label" {{addclass "status-" itemData.status}}></span>
+    <span class="status-label {{addclass 'status' itemData.status}}"></span>
   {{/if}}
 {{else}}
   {{#if itemData.workflow_state}}
-    <span class="status-label" {{addclass "status-" itemData.workflow_state}}></span>
+    <span class="status-label {{addclass 'status' itemData.workflow_state}}"></span>
   {{else}}
     <span class="status-label"></span>
   {{/if}}

--- a/src/ggrc/assets/mustache/assessment_templates/info.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/info.mustache
@@ -21,7 +21,7 @@
             <h3>{{title}}</h3>
 
             {{#if status}}
-              <span class="state-value {{addclass 'state-' status separator=''}}">{{un_camel_case status}}</span>
+              <span class="state-value {{addclass 'state' status}}">{{un_camel_case status}}</span>
             {{/if}}
           </div>
         </div>

--- a/src/ggrc/assets/mustache/assessments/header.mustache
+++ b/src/ggrc/assets/mustache/assessments/header.mustache
@@ -33,7 +33,7 @@ Copyright (C) 2017 Google Inc.
                                     {is-edit-icon-denied}="isEditIconDenied"
                                     (set-edit-mode-inline)="confirmEdit()">
                                         <h3 class="pane-header__title-name">{{instance.title}}</h3>
-                                        <div class="state-value {{addclass 'state-' instance.status separator=''}}">
+                                        <div class="state-value {{addclass 'state-' instance.status separator=''}} {{#if instance.verified}}verified{{/if}}">
                                             {{instance.status}}
                                         </div>
                                         {{#if instance.archived}}

--- a/src/ggrc/assets/mustache/assessments/header.mustache
+++ b/src/ggrc/assets/mustache/assessments/header.mustache
@@ -33,7 +33,7 @@ Copyright (C) 2017 Google Inc.
                                     {is-edit-icon-denied}="isEditIconDenied"
                                     (set-edit-mode-inline)="confirmEdit()">
                                         <h3 class="pane-header__title-name">{{instance.title}}</h3>
-                                        <div class="state-value {{addclass 'state-' instance.status separator=''}} {{#if instance.verified}}verified{{/if}}">
+                                        <div class="state-value {{addclass 'state' instance.status}} {{#if instance.verified}}verified{{/if}}">
                                             {{instance.status}}
                                         </div>
                                         {{#if instance.archived}}

--- a/src/ggrc/assets/mustache/audits/info.mustache
+++ b/src/ggrc/assets/mustache/audits/info.mustache
@@ -19,7 +19,7 @@
             <div class="span9">
               <h6>Title</h6>
               <h3>{{title}}</h3>
-              <span class="state-value {{addclass 'state-' status separator=''}}">{{status}}</span>
+              <span class="state-value {{addclass 'state' status}}">{{status}}</span>
                 {{#if instance.archived}}
                     <span class="state-value state-archived">Archived</span>
                 {{/if}}

--- a/src/ggrc/assets/mustache/audits/tree-item-attr.mustache
+++ b/src/ggrc/assets/mustache/audits/tree-item-attr.mustache
@@ -30,7 +30,7 @@
   {{/case}}
   {{#case 'status'}}
     {{#using status=instance.status}}
-      <span class="state-value-dot {{addclass 'state-' status separator=''}}">
+      <span class="state-value-dot {{addclass 'state' status}}">
         {{status}}
       </span>
     {{/using}}

--- a/src/ggrc/assets/mustache/base_objects/general-page-header.mustache
+++ b/src/ggrc/assets/mustache/base_objects/general-page-header.mustache
@@ -14,7 +14,7 @@
           <span class="state-value snapshot">{{instance.class.title_singular}} version as at {{date instance.updated_at}}</span>
         {{/if}}
         {{#if status}}
-          <span class="state-value {{addclass 'state-' status separator=''}}">{{un_camel_case status}}</span>
+          <span class="state-value {{addclass 'state' status}}">{{un_camel_case status}}</span>
         {{/if}}
         {{#if snapshot.archived}}
           <span class="state-value state-archived">Archived</span>

--- a/src/ggrc/assets/mustache/base_objects/open_close.mustache
+++ b/src/ggrc/assets/mustache/base_objects/open_close.mustache
@@ -5,7 +5,7 @@
 {{#unless instance.snapshot}}
 <div class="openclose{{^if draw_children}}__empty{{/if}}">
   {{#if_instance_of instance "Cycle|CycleTaskGroup|CycleTaskGroupObjectTask"}}
-    <span class="status-label {{#if instance.isOverdue}}status-overdue{{/if}}" {{addclass "status-" instance.status}}></span>
+    <span class="status-label {{#if instance.isOverdue}}status-overdue{{/if}} {{addclass 'status' instance.status}}"></span>
   {{/if_instance_of}}
   {{#if draw_children}}
   <i class="fa fa-caret-right"></i>

--- a/src/ggrc/assets/mustache/base_objects/tree-item-attr.mustache
+++ b/src/ggrc/assets/mustache/base_objects/tree-item-attr.mustache
@@ -25,7 +25,7 @@
   {{/case}}
   {{#case 'status'}}
     {{#using status=instance.status}}
-      <span class="state-value-dot {{addclass 'state-' status separator=''}} {{#if instance.verified}}verified{{/if}}">
+      <span class="state-value-dot {{addclass 'state' status}} {{#if instance.verified}}verified{{/if}}">
         {{status}}
       </span>
     {{/using}}

--- a/src/ggrc/assets/mustache/base_objects/tree-item-attr.mustache
+++ b/src/ggrc/assets/mustache/base_objects/tree-item-attr.mustache
@@ -25,7 +25,7 @@
   {{/case}}
   {{#case 'status'}}
     {{#using status=instance.status}}
-      <span class="state-value-dot {{addclass 'state-' status separator=''}}">
+      <span class="state-value-dot {{addclass 'state-' status separator=''}} {{#if instance.verified}}verified{{/if}}">
         {{status}}
       </span>
     {{/using}}

--- a/src/ggrc/assets/mustache/controls/tree-item-attr.mustache
+++ b/src/ggrc/assets/mustache/controls/tree-item-attr.mustache
@@ -84,7 +84,7 @@
   {{/case}}
   {{#case 'status'}}
     {{#using status=instance.status}}
-      <span class="state-value-dot {{addclass 'state-' status separator=''}}">
+      <span class="state-value-dot {{addclass 'state' status}}">
         {{status}}
       </span>
     {{/using}}

--- a/src/ggrc/assets/mustache/cycle_task_group_object_tasks/tree-item-attr.mustache
+++ b/src/ggrc/assets/mustache/cycle_task_group_object_tasks/tree-item-attr.mustache
@@ -23,7 +23,7 @@
   {{/case}}
   {{#case 'status'}}
     {{#using status=instance.status}}
-      <span class="state-value-dot {{addclass 'state-' status separator=''}}">
+      <span class="state-value-dot {{addclass 'state' status}}">
         {{un_camel_case status}}
       </span>
     {{/using}}

--- a/src/ggrc/assets/mustache/directives/tree-item-attr.mustache
+++ b/src/ggrc/assets/mustache/directives/tree-item-attr.mustache
@@ -15,7 +15,7 @@
   {{/case}}
   {{#case 'status'}}
     {{#using status=instance.status}}
-      <span class="state-value-dot {{addclass 'state-' status separator=''}}">
+      <span class="state-value-dot {{addclass 'state' status}}">
         {{status}}
       </span>
     {{/using}}

--- a/src/ggrc/assets/mustache/objectives/tree-item-attr.mustache
+++ b/src/ggrc/assets/mustache/objectives/tree-item-attr.mustache
@@ -18,7 +18,7 @@
   {{/case}}
   {{#case 'status'}}
     {{#using status=instance.status}}
-      <span class="state-value-dot {{addclass 'state-' status separator=''}}">
+      <span class="state-value-dot {{addclass 'state' status}}">
         {{status}}
       </span>
     {{/using}}

--- a/src/ggrc/assets/mustache/programs/tree-item-attr.mustache
+++ b/src/ggrc/assets/mustache/programs/tree-item-attr.mustache
@@ -20,7 +20,7 @@
   {{/case}}
   {{#case 'status'}}
     {{#using status=instance.status}}
-      <span class="state-value-dot {{addclass 'state-' status separator=''}}">
+      <span class="state-value-dot {{addclass 'state' status}}">
         {{status}}
       </span>
     {{/using}}

--- a/src/ggrc/assets/mustache/risk_assessments/tree-item-attr.mustache
+++ b/src/ggrc/assets/mustache/risk_assessments/tree-item-attr.mustache
@@ -12,7 +12,7 @@
   {{/case}}
   {{#case 'status'}}
     {{#using status=instance.status}}
-      <span class="state-value-dot {{addclass 'state-' status separator=''}}">
+      <span class="state-value-dot {{addclass 'state' status}}">
         {{status}}
       </span>
     {{/using}}

--- a/src/ggrc/assets/mustache/sections/tree-item-attr.mustache
+++ b/src/ggrc/assets/mustache/sections/tree-item-attr.mustache
@@ -15,7 +15,7 @@
   {{/case}}
   {{#case 'status'}}
     {{#using status=instance.status}}
-      <span class="state-value-dot {{addclass 'state-' status separator=''}}">
+      <span class="state-value-dot {{addclass 'state' status}}">
         {{status}}
       </span>
     {{/using}}

--- a/src/ggrc/assets/mustache/task_group_tasks/tree-item-attr.mustache
+++ b/src/ggrc/assets/mustache/task_group_tasks/tree-item-attr.mustache
@@ -9,7 +9,7 @@
   {{/case}}
   {{#case 'status'}}
     {{#using status=instance.status}}
-      <span class="state-value-dot {{addclass 'state-' status separator=''}}">
+      <span class="state-value-dot {{addclass 'state' status}}">
         {{status}}
       </span>
     {{/using}}

--- a/src/ggrc/assets/mustache/task_groups/tree-item-attr.mustache
+++ b/src/ggrc/assets/mustache/task_groups/tree-item-attr.mustache
@@ -12,7 +12,7 @@
   {{/case}}
   {{#case 'status'}}
     {{#using status=instance.status}}
-      <span class="state-value-dot {{addclass 'state-' status separator=''}}">
+      <span class="state-value-dot {{addclass 'state' status}}">
         {{status}}
       </span>
     {{/using}}

--- a/src/ggrc/assets/mustache/workflows/info.mustache
+++ b/src/ggrc/assets/mustache/workflows/info.mustache
@@ -103,7 +103,7 @@
           <div class="span9">
             <h6>Title</h6>
             <h3>{{title}}</h3>
-            <span class="state-value {{addclass 'state-' status separator=''}}">{{status}}</span>
+            <span class="state-value {{addclass 'state' status}}">{{status}}</span>
             {{#instance.next_cycle_start_date}}
               {{#if instance.unit}}
                 {{^if instance.recurrences}}

--- a/src/ggrc/assets/mustache/workflows/tree-item-attr.mustache
+++ b/src/ggrc/assets/mustache/workflows/tree-item-attr.mustache
@@ -19,7 +19,7 @@
   {{/case}}
   {{#case 'status'}}
     {{#using status=instance.status}}
-      <span class="state-value-dot {{addclass 'state-' status separator=''}}">
+      <span class="state-value-dot {{addclass 'state' status}}">
         {{status}}
       </span>
     {{/using}}

--- a/src/ggrc/assets/stylesheets/_common.scss
+++ b/src/ggrc/assets/stylesheets/_common.scss
@@ -769,6 +769,9 @@ p {
   &.state-finished,
   &.state-completed {
     background: $status-completed;
+    &.verified {
+      background: $status-verified;
+    }
   }
   &.state-declined,
   &.state-deprecated {
@@ -842,6 +845,13 @@ p {
 
     &:before {
       background: $status-completed;
+    }
+    &.verified {
+      color: $status-verified;
+
+      &:before {
+        background: $status-verified;
+      }
     }
   }
   &.state-declined,


### PR DESCRIPTION
# Issue description

"Completed and Verified" state has a wrong color in tree view and assessment info pane status label.

# Steps to test the changes

1. Create an assessment and move it to the verified state. 
2. Look at the status label on the assessment info pane ( near the title ) it has a proper green color.
3. Take a look at the status of the assessment in the tree view it also has a proper green color.

# Solution description

I added a `verified` css class that overrides the color of the completed class and applied it where necessary. Also during the implementation, I found a bug in `addclass` mustache helper which occurred when using this helper with the mustache variable interpolation. For example, when we used it like this: 
```mustache
<div class="state-value {{addclass 'state' instance.status}} {{#if instance.verified}}verified{{/if}}">
```
the value of the addclass helper's first run where cached and applied later when the if statement passed and verified class where applied.
The steps where as follows:
```html
<!-- initial render of the tag. newly created assessment -->
<div class="state-value state-notstarted"> 
```

```html
<!-- assessement was moved to completed and then to verified state -->
<div class="state-value state-notstarted verified">
```
When the assessment was moved to the verified state a `verified` class was applied from the interpolation and the current addclass value where replaced with the one which where cached on the first run.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests. __N/A__
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".