### PR TITLE
GGRC-4089 Remove Meeting data

### DIFF
--- a/src/ggrc/migrations/versions/20170908142613_3c69a1e45812_remove_meeting_and_objectevent_data.py
+++ b/src/ggrc/migrations/versions/20170908142613_3c69a1e45812_remove_meeting_and_objectevent_data.py
@@ -1,0 +1,41 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Remove Meeting and ObjectEvent data
+
+Create Date: 2017-09-08 14:26:13.029930
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+from alembic import op
+
+from ggrc.migrations.utils import cleanup
+
+# revision identifiers, used by Alembic.
+revision = '3c69a1e45812'
+down_revision = 'f0dade8da1'
+
+
+DELETIONS = (
+    ("audit_objects", "auditable_type"),
+    ("custom_attribute_definitions", "definition_type"),
+    ("fulltext_record_properties", "type"),
+    ("notifications", "object_type"),
+    ("object_people", "personable_type"),
+    ("relationships", "source_type"),
+    ("relationships", "destination_type"),
+)
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  for table, field in DELETIONS:
+    cleanup.delete(op, table, field, value="Meeting")
+    cleanup.delete(op, table, field, value="ObjectEvent")
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  pass

--- a/src/ggrc_gdrive_integration/migrations/versions/20170908141255_4bb6fa8fb5e1_remove_meeting.py
+++ b/src/ggrc_gdrive_integration/migrations/versions/20170908141255_4bb6fa8fb5e1_remove_meeting.py
@@ -1,0 +1,67 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Remove Meeting
+
+Create Date: 2017-09-08 14:12:55.361026
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+# revision identifiers, used by Alembic.
+revision = '4bb6fa8fb5e1'
+down_revision = '5405cc1ae721'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  op.drop_table('object_events')
+  op.drop_table('meetings')
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  op.create_table('meetings',
+                  sa.Column('id', mysql.INTEGER(display_width=11),
+                            nullable=False),
+                  sa.Column('title', mysql.VARCHAR(length=250),
+                            nullable=False),
+                  sa.Column('created_at', mysql.DATETIME(), nullable=False),
+                  sa.Column('modified_by_id', mysql.INTEGER(display_width=11),
+                            autoincrement=False, nullable=True),
+                  sa.Column('updated_at', mysql.DATETIME(), nullable=False),
+                  sa.Column('context_id', mysql.INTEGER(display_width=11),
+                            autoincrement=False, nullable=True),
+                  sa.Column('description', mysql.TEXT(), nullable=True),
+                  sa.Column('start_at', mysql.DATETIME(), nullable=False),
+                  sa.Column('end_at', mysql.DATETIME(), nullable=False),
+                  sa.ForeignKeyConstraint(['context_id'], [u'contexts.id'],
+                                          name=u'meetings_ibfk_1'),
+                  sa.PrimaryKeyConstraint('id'),
+                  mysql_default_charset=u'utf8',
+                  mysql_engine=u'InnoDB')
+  op.create_table('object_events',
+                  sa.Column('id', mysql.INTEGER(display_width=11),
+                            nullable=False),
+                  sa.Column('modified_by_id', mysql.INTEGER(display_width=11),
+                            autoincrement=False, nullable=True),
+                  sa.Column('created_at', mysql.DATETIME(), nullable=False),
+                  sa.Column('updated_at', mysql.DATETIME(), nullable=False),
+                  sa.Column('context_id', mysql.INTEGER(display_width=11),
+                            autoincrement=False, nullable=True),
+                  sa.Column('calendar_id', mysql.VARCHAR(length=250),
+                            nullable=True),
+                  sa.Column('event_id', mysql.VARCHAR(length=250),
+                            nullable=False),
+                  sa.Column('eventable_id', mysql.INTEGER(display_width=11),
+                            autoincrement=False, nullable=False),
+                  sa.Column('eventable_type', mysql.VARCHAR(length=250),
+                            nullable=False),
+                  sa.PrimaryKeyConstraint('id'),
+                  mysql_default_charset=u'utf8',
+                  mysql_engine=u'InnoDB')

--- a/src/ggrc_workflows/migrations/versions/20170908142618_14b87f599ede_remove_meeting_and_objectevent_data.py
+++ b/src/ggrc_workflows/migrations/versions/20170908142618_14b87f599ede_remove_meeting_and_objectevent_data.py
@@ -1,0 +1,30 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Remove Meeting and ObjectEvent data
+
+Create Date: 2017-09-08 14:26:18.104984
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+from alembic import op
+
+from ggrc.migrations.utils import cleanup
+
+
+# revision identifiers, used by Alembic.
+revision = '14b87f599ede'
+down_revision = '6a7dbb10dfa'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  cleanup.delete(op, "task_group_objects", "object_type", value="Meeting")
+  cleanup.delete(op, "task_group_objects", "object_type", value="ObjectEvent")
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  pass


### PR DESCRIPTION
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [x] #6817 (migration targeting release branch)
- [x] #6711 (`TestCase.clean_data` fails without this code)

# Issue description

Meeting model data cleanup (previously part of #6711)

# Solution description

Just a copy of the cleanup of `Request` model with replaced names.

# Sanity checklist

- [ ] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [ ] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# Migration checklist
- [x] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
