### PR TITLE
GGRC-3650 Remove shadow for action toolbar buttons

### DIFF
--- a/src/ggrc/assets/stylesheets/components/action-toolbar/_action-toolbar.scss
+++ b/src/ggrc/assets/stylesheets/components/action-toolbar/_action-toolbar.scss
@@ -38,7 +38,6 @@
 
     &:hover {
       background: darken(#444, 10%);
-      box-shadow: 0 1px 10px -1px rgba(0, 0, 0, 0.4);
     }
 
     &-disabled {


### PR DESCRIPTION
# Issue description

Action toolbar buttons have shadow when in hover state.

# Steps to test the changes

Open Assessment Info Pane and take a look at any inline edit control ( ex. Assessment Procedure or Assignees )

# Solution description

Remove box-shadow css prop from inline edit button hover state.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests. __N/A__
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".