### PR TITLE
GGRC-4113 Fix Audit creation failure

### DIFF
--- a/src/ggrc/fulltext/recordbuilder.py
+++ b/src/ggrc/fulltext/recordbuilder.py
@@ -123,12 +123,18 @@ class RecordBuilder(object):
       ac_person_id = ac_list.person_id
     if ac_role_id not in self.indexer.cache['ac_role_map']:
       ac_role = db.session.query(all_models.AccessControlRole).get(ac_role_id)
-      ac_role_name = ac_role.name if ac_role else None
-      self.indexer.cache['ac_role_map'][ac_role_id] = ac_role_name
-      if ac_role_name is None:
-        # index only existed role, if it have already been
-        # removed than nothing to index.
-        LOGGER.error("Trying to index not existing ACR with id %s", ac_role_id)
+      # Internal roles should not be indexed
+      if ac_role and ac_role.internal:
+        self.indexer.cache['ac_role_map'][ac_role_id] = None
+      else:
+        ac_role_name = ac_role.name if ac_role else None
+        self.indexer.cache['ac_role_map'][ac_role_id] = ac_role_name
+        if ac_role_name is None:
+          # index only existed role, if it have already been
+          # removed than nothing to index.
+          LOGGER.error(
+              "Trying to index not existing ACR with id %s", ac_role_id
+          )
     ac_role_name = self.indexer.cache['ac_role_map'][ac_role_id]
     if ac_role_name:
       ac_role_name = ac_role_name.lower()

--- a/test/integration/ggrc/models/test_audit.py
+++ b/test/integration/ggrc/models/test_audit.py
@@ -1,0 +1,56 @@
+# Copyright (C) 2017 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Tests for Audit model."""
+from ggrc.models import all_models
+from integration.ggrc import generator
+from integration.ggrc import TestCase, Api
+from integration.ggrc.models import factories
+
+
+class TestAudit(TestCase):
+  """ Test Audit class. """
+  def setUp(self):
+    super(TestAudit, self).setUp()
+    self.api = Api()
+    self.gen = generator.ObjectGenerator()
+
+  def generate_control_mappings(self, control):
+    """Map Control to several Assessments"""
+    acr_creator = all_models.AccessControlRole.query.filter_by(
+        name="Creators", object_type="Assessment"
+    ).first()
+    with factories.single_commit():
+      person = factories.PersonFactory()
+      asmnt_ids = []
+      for _ in range(2):
+        asmnt = factories.AssessmentFactory()
+        asmnt_ids.append(asmnt.id)
+        factories.AccessControlListFactory(
+            object=asmnt, person=person, ac_role=acr_creator
+        )
+
+    for asmnt_id in asmnt_ids:
+      asmnt = all_models.Assessment.query.get(asmnt_id)
+      self.gen.generate_relationship(source=asmnt, destination=control)
+
+  def test_creation_mapped_control(self):
+    """Check creation of new Audit if Program has Control with mapped roles"""
+    control = factories.ControlFactory()
+    # Map original of control to several assessments to get propagated roles
+    self.generate_control_mappings(control)
+
+    # Existing control should be updated to create new revision with ACL
+    self.api.put(control, {"title": "Test Control"})
+
+    program = factories.ProgramFactory()
+    factories.RelationshipFactory(source=program, destination=control)
+    response = self.api.post(all_models.Audit, [{
+        "audit": {
+            "title": "New Audit",
+            "program": {"id": program.id},
+            "status": "Planned",
+            "context": None
+        }
+    }])
+    self.assert200(response)


### PR DESCRIPTION
# Issue description

Steps to reproduce:
1. Find program with mapped controls and existing Audits (the issue is reproduced on https://ggrc-qa.appspot.com/programs/1344#!info_widget)
2. Invoke New Audit modal window on the program page
3. Fill out the required fields and click Save button
Actual Result: Error message is displayed while creating a new audit. New Audit modal window is not closed. If user clicks X button and refreshes the page, new audit is displayed in tree view. 

# Steps to test the changes

1. Find program with mapped controls and existing Audits
2. Invoke New Audit modal window on the program page
3. Fill out the required fields and click Save button
Expected Result: no errors should be shown while creating a new audit. New audit should be shown in tree view.

# Solution description

Reason of issue is that internal ACL roles are indexed. If we have same mapped roles which differ by parent_id only we will try to insert same data into `fultext_record_properties`.
Solution is to not index internal ACL roles.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

  
  