### PR TITLE
GGRC-2285,4063,4127,4131 Fix copy assessment procedure behaviour

### DIFF
--- a/src/ggrc-client/js/components/modal_wrappers/assessment_template_form.js
+++ b/src/ggrc-client/js/components/modal_wrappers/assessment_template_form.js
@@ -12,10 +12,5 @@
     scope: {
       instance: null,
     },
-    events: {
-      '{scope.instance} template_object_type': function () {
-        this.scope.attr('instance.test_plan_procedure', false);
-      },
-    },
   });
 })(window.can, window.can.$);

--- a/src/ggrc-client/js/models/assessment.js
+++ b/src/ggrc-client/js/models/assessment.js
@@ -26,7 +26,7 @@ import {prepareCustomAttributes} from '../plugins/utils/ca-utils';
     is_custom_attributable: true,
     isRoleable: true,
     defaults: {
-      _copyAssessmentProcedure: true,
+      test_plan_procedure: true,
       assessment_type: 'Control',
       status: 'Not Started',
       send_by_default: true,  // notifications when a comment is added

--- a/src/ggrc-client/js/models/assessment.js
+++ b/src/ggrc-client/js/models/assessment.js
@@ -262,16 +262,6 @@ import {prepareCustomAttributes} from '../plugins/utils/ca-utils';
     after_create: function () {
       this._checkIssueTrackerWarnings();
     },
-    before_save: function () {
-      let mappedObjectsChanges = this.attr('mappedObjectsChanges');
-      if ( mappedObjectsChanges ) {
-        mappedObjectsChanges.forEach((mo)=>{
-          mo.extra = {
-            copyAssessmentProcedure: this.attr('_copyAssessmentProcedure'),
-          };
-        });
-      }
-    },
     before_create: function () {
       if (!this.audit) {
         throw new Error('Cannot save assessment, audit not set.');

--- a/src/ggrc-client/js/models/audit_models.js
+++ b/src/ggrc-client/js/models/audit_models.js
@@ -325,12 +325,6 @@ import Permission from '../permission';
       return this._super.apply(this, arguments);
     },
 
-    after_save: function () {
-      if (this.audit) {
-        this.audit.reify().refresh();
-      }
-    },
-
     /**
      * Event handler when an assignee is picked in an autocomplete form field.
      * It adds the picked assignee's ID to the assignees list.

--- a/src/ggrc/assets/mustache/assessment_templates/info.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/info.mustache
@@ -40,7 +40,7 @@
             </div>
 
             <div class="span4">
-              <h6>Use control test plans as procedures</h6>
+              <h6>Copy Assessment Procedure from mapped object</h6>
               {{#if test_plan_procedure}}YES{{else}}NO{{/if}}
             </div>
 

--- a/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
@@ -92,15 +92,15 @@
           <a data-id="hide_default_test_plan_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
         </label>
 
-	<div class="wysiwyg-area">
-	  <textarea
-	    id="system_description"
-	    ($value)="instance.procedure_description"
-	    class="span12 triple wysihtml5"
-	    placeholder="Enter Description"
-	    tabindex="2"
-	    ></textarea>
-	</div>
+        <div class="wysiwyg-area">
+          <textarea
+            id="system_description"
+            ($value)="instance.procedure_description"
+            class="span12 triple wysihtml5"
+            placeholder="Enter Description"
+            tabindex="2"
+            ></textarea>
+        </div>
       </div>
 
       <div class="span6">

--- a/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
@@ -95,7 +95,7 @@
         <div class="wysiwyg-area">
           <textarea
             id="system_description"
-            ($value)="instance.procedure_description"
+            {($value)}="instance.procedure_description"
             class="span12 triple wysihtml5"
             placeholder="Enter Description"
             tabindex="2"

--- a/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
@@ -27,7 +27,7 @@
 
         <label class="inline-check pull-left">
           <input type="checkbox"
-            ($value)="instance.test_plan_procedure"
+            can-value="instance.test_plan_procedure"
             class="js-toggle-controlplans">
 	    Copy Assessment Procedure from mapped object
         </label>

--- a/src/ggrc/assets/mustache/assessments/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessments/modal_content.mustache
@@ -51,7 +51,7 @@
       <div class="ggrc-form-item">
 	<div class="ggrc-form-item__checkbox-item">
 	  <label class="inline-check pull-left">
-	    <input type="checkbox" ($value)="instance._copyAssessmentProcedure" class="js-toggle-controlplans">
+	    <input type="checkbox" can-value="instance._copyAssessmentProcedure" class="js-toggle-controlplans">
 	      Copy Assessment Procedure from mapped object
 	  </label>
 	</div>

--- a/src/ggrc/assets/mustache/assessments/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessments/modal_content.mustache
@@ -51,7 +51,7 @@
       <div class="ggrc-form-item">
 	<div class="ggrc-form-item__checkbox-item">
 	  <label class="inline-check pull-left">
-	    <input type="checkbox" can-value="instance._copyAssessmentProcedure" class="js-toggle-controlplans">
+	    <input type="checkbox" can-value="instance.test_plan_procedure" class="js-toggle-controlplans">
 	      Copy Assessment Procedure from mapped object
 	  </label>
 	</div>

--- a/src/ggrc/migrations/versions/20180105105947_3198c7918360_add_test_plan_procedure_to_assessment.py
+++ b/src/ggrc/migrations/versions/20180105105947_3198c7918360_add_test_plan_procedure_to_assessment.py
@@ -1,0 +1,46 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Add test plan procedure to assessment
+
+Create Date: 2018-01-05 10:59:47.258800
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = '3198c7918360'
+down_revision = '4906ff3f9c7b'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  op.add_column(
+      "assessments",
+      sa.Column(
+          "test_plan_procedure", sa.Boolean, nullable=False, server_default="1"
+      )
+  )
+  op.execute("""
+      UPDATE assessments
+      SET test_plan_procedure = true;
+  """)
+  op.alter_column(
+      "assessment_templates",
+      "test_plan_procedure",
+      server_default="1"
+  )
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  op.alter_column(
+      "assessment_templates",
+      "test_plan_procedure",
+      server_default="0"
+  )
+  op.drop_column("assessments", "test_plan_procedure")

--- a/src/ggrc/models/assessment.py
+++ b/src/ggrc/models/assessment.py
@@ -106,7 +106,7 @@ class Assessment(Roleable, statusable.Statusable, AuditRelationship,
   assessment_type = deferred(
       db.Column(db.String, nullable=False, server_default="Control"),
       "Assessment")
-  # whether to use the object test plan on stanpshot mapping
+  # whether to use the object test plan on snapshot mapping
   test_plan_procedure = db.Column(db.Boolean, nullable=False, default=True)
 
   @declared_attr

--- a/src/ggrc/models/assessment.py
+++ b/src/ggrc/models/assessment.py
@@ -106,6 +106,8 @@ class Assessment(Roleable, statusable.Statusable, AuditRelationship,
   assessment_type = deferred(
       db.Column(db.String, nullable=False, server_default="Control"),
       "Assessment")
+  # whether to use the object test plan on stanpshot mapping
+  test_plan_procedure = db.Column(db.Boolean, nullable=False, default=True)
 
   @declared_attr
   def object_level_definitions(cls):  # pylint: disable=no-self-argument
@@ -142,6 +144,7 @@ class Assessment(Roleable, statusable.Statusable, AuditRelationship,
       'operationally',
       'audit',
       'assessment_type',
+      'test_plan_procedure',
       reflection.Attribute('issue_tracker', create=False, update=False),
       reflection.Attribute('archived', create=False, update=False),
       reflection.Attribute('folder', create=False, update=False),

--- a/src/ggrc/models/hooks/assessment.py
+++ b/src/ggrc/models/hooks/assessment.py
@@ -72,6 +72,7 @@ def _handle_assessment(assessment, src, templates, audits):
     assessment.test_plan = snapshot.revision.content.get("test_plan")
     return
 
+  assessment.test_plan_procedure = template.test_plan_procedure
   assessment.test_plan = template.procedure_description
   if template.test_plan_procedure:
     copy_snapshot_plan(assessment, snapshot)

--- a/src/ggrc/models/hooks/relationship.py
+++ b/src/ggrc/models/hooks/relationship.py
@@ -506,9 +506,9 @@ def handle_relationship_delete(relationship):
     ).delete(synchronize_session='fetch')
 
 
-def copy_snapshot_test_plan(objects, sources):
+def copy_snapshot_test_plan(objects):
   """Append snapshot test plan into assessment test plan"""
-  for obj, src in zip(objects, sources):
+  for obj in objects:
     if (obj.source_type == "Assessment" and
         obj.destination_type == "Snapshot") or (
         obj.source_type == "Snapshot" and
@@ -520,10 +520,9 @@ def copy_snapshot_test_plan(objects, sources):
 
       # Test plan of snapshotted object should be copied to
       # Assessment test plan in case of proper snapshot type
-      # and if copyAssessmentProcedure flag was sent, it should
-      # be set to True
+      # and if test_plan_procedure was set to True
       if asmnt.assessment_type == snapshot.child_type and \
-         src.get("copyAssessmentProcedure", True):
+         asmnt.test_plan_procedure:
         assessment.copy_snapshot_plan(asmnt, snapshot)
 
 
@@ -581,4 +580,4 @@ def init_hook():  # noqa
   def handle_asmnt_plan(sender, objects=None, sources=None, **kwargs):
     """Handle assessment test plan"""
     # pylint: disable=unused-argument
-    copy_snapshot_test_plan(objects, sources)
+    copy_snapshot_test_plan(objects)


### PR DESCRIPTION
# Issue description

"Copy Assessment Procedure" checkbox is not checked by default and is not taken in account during the objects mapping operations.

# Steps to test the changes

1. "Copy Assessment Procedure" checkbox should be check by default in both Assessment and Assessment Templates Edit Modals on creation.
2. "Copy Assessment Procedure" checkbox should be check by default when Assessment is autogenerated without template.
4. 'Default assessment procedure' is not saved in Add/Edit Assessment template popup;
Will be fixed
4. If "Copy Assessment Procedure" checkbox is unchecked for Assessment and we are mapping  
 a Control from Assessment Info Pane, the Assessment Procedure should not be copied( and should be copied if the copy checkbox is checked )

# Solution description

1. Fix checkbox and textarea bindings in mustache.
2. Make "Copy assessment procedure" to be persistent on the assessment instance.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ]  My changes are covered by tests. __N/A__
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# Migration checklist
- [x] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".