### PR TITLE
GGRC-4128 Fix status filter in disabled mode

### DIFF
--- a/src/ggrc/assets/javascripts/components/tree/tree-status-filter.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-status-filter.js
@@ -31,7 +31,8 @@ let viewModel = can.Map.extend({
     });
     this.setFilter(states);
   },
-  loadDefaultStates(modelName) {
+  getDefaultStates() {
+    let modelName = this.attr('widgetId') || this.attr('modelName');
     // Get the status list from local storage
     let savedStates = this.attr('displayPrefs').getTreeViewStates(modelName);
     // Get the status list from query string
@@ -79,7 +80,7 @@ export default can.Component.extend({
       let filter = vm.attr('filter');
       let operation = vm.attr('operation');
       let depth = vm.attr('depth');
-      let filterName = vm.attr('widgetId') || vm.attr('modelName');
+
       let filterStates = StateUtils.getStatesForModel(vm.attr('modelName'))
         .map((state) => {
           return {
@@ -101,7 +102,7 @@ export default can.Component.extend({
       CMS.Models.DisplayPrefs.getSingleton().then((displayPrefs) => {
         vm.attr('displayPrefs', displayPrefs);
 
-        let defaultStates = vm.loadDefaultStates(filterName);
+        let defaultStates = vm.getDefaultStates();
         vm.initializeFilter(defaultStates);
 
         // Start listening route events only after full initialization.
@@ -116,17 +117,20 @@ export default can.Component.extend({
     },
     '{viewModel} disabled'() {
       if (this.viewModel.attr('disabled')) {
-        this.viewModel.attr('selectedStates', []);
+        this.viewModel.initializeFilter([]);
       } else {
-        this.viewModel.loadTreeStates(this.viewModel.attr('modelName'));
+        let defaultStates = this.viewModel.getDefaultStates();
+        this.viewModel.initializeFilter(defaultStates);
       }
     },
     '{viewModel.router} state'(router, event, newValue) {
-      let states = newValue ||
+      if (!this.viewModel.attr('disabled')) {
+        let states = newValue ||
         this.viewModel.attr('filterStates').map((state) => state.value);
 
-      this.viewModel.initializeFilter(states);
-      this.viewModel.dispatch('filter');
+        this.viewModel.initializeFilter(states);
+        this.viewModel.dispatch('filter');
+      }
     },
   },
 });


### PR DESCRIPTION
# Issue description

"Uncaught TypeError: this.viewModel.loadTreeStates is not a function" error is displayed if close advanced search in Search box

# Steps to test the changes

Steps to reproduce:
1. Go to My work page > Controls tab
2. Click Advanced search icon in tree view
3. Once advanced search pop up appears click Apply button
4. Click close [x] advanced search in search box
Actual Result: "Uncaught TypeError: this.viewModel.loadTreeStates is not a function" error is displayed if close advanced search in Search box
Expected Result: no errors should be shown

# Solution description

The component was broken when it was improved to work with query string.
The fix is adjusting work in 'disabled' mode.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
