### PR TITLE
GGRC-4150 Remove nullable warning from computed attributes

### DIFF
--- a/src/ggrc/data_platform/attributes.py
+++ b/src/ggrc/data_platform/attributes.py
@@ -27,7 +27,10 @@ class Attributes(base.Base, db.Model):
       db.ForeignKey('attribute_templates.attribute_template_id')
   )
 
-  value_string = db.Column(db.UnicodeText)
+  # value string is not nullable to avoid weird filtering behavior. This is
+  # different than on data platform, but needed here because we decided to make
+  # all text fields mandatory with default empty string
+  value_string = db.Column(db.UnicodeText, nullable=False, default=u"")
   value_integer = db.Column(db.Integer)
   value_datetime = db.Column(db.DateTime)
 

--- a/src/ggrc/data_platform/computed_attributes.py
+++ b/src/ggrc/data_platform/computed_attributes.py
@@ -369,7 +369,7 @@ def compute_values(affected_objects, all_relationships, snapshot_map):
           "source_id": source_id,
           "value_datetime": value,
           "value_integer": None,
-          "value_string": None,
+          "value_string": "",
       }
       for snapshot_id in snapshot_map.get(obj, set()):
         computed_values[attr][(u"Snapshot", snapshot_id)] = {
@@ -377,7 +377,7 @@ def compute_values(affected_objects, all_relationships, snapshot_map):
             "source_id": source_id,
             "value_datetime": value,
             "value_integer": None,
-            "value_string": None,
+            "value_string": "",
         }
 
   return computed_values

--- a/src/ggrc/data_platform/computed_attributes.py
+++ b/src/ggrc/data_platform/computed_attributes.py
@@ -363,6 +363,8 @@ def compute_values(affected_objects, all_relationships, snapshot_map):
     aggregate_function = get_aggregate_function(attr)
     for obj in objects:
       source_id, value = aggregate_function(aggregate_values, rel_map[obj])
+      if source_id is None:
+        continue
 
       computed_values[attr][obj] = {
           "source_type": aggregate_type,


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Compute attributes generates log warnings that are not clean. We should fix those warnings

# Steps to test the changes

Run compute attributes and check the logs for "column can not be null" warnings

# Solution description

The issue was that this field was missed in GGRC-3410 when we were making all texts mandatory, but the database column was still modified. This PR just applies the same changes from GGRC-3410 to the missing attribute.

see https://github.com/google/ggrc-core/pull/6749

# Sanity checklist

- [ ] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [ ] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [ ] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [ ] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->

  