### PR TITLE
GGRC-4158, GGRC-4159: Fix an issue with cloning Workflow

### DIFF
--- a/src/ggrc/assets/javascripts/models/workflow.js
+++ b/src/ggrc/assets/javascripts/models/workflow.js
@@ -91,7 +91,7 @@
       dfd.then(function (instance) {
         redirectLink = instance.viewLink + '#task_group_widget';
         instance.attr('_redirect', redirectLink);
-        if (!taskGroupTitle || !isNew) {
+        if (!taskGroupTitle || !isNew || instance.clone) {
           return instance;
         }
         taskGroup = new CMS.Models.TaskGroup({


### PR DESCRIPTION
# Issue description
Redundant TaskGroup is created on Workflow cloning

# Steps to test the changes
Try to clone any existing Workflow.

# Solution description
Check whether 'clone' property is filled for Workflow on saving.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".