### PR TITLE
GGRC-3405: Fix styling issue on Setup tab for WFs

### DIFF
--- a/src/ggrc/assets/mustache/task_group_tasks/task_group_subtree.mustache
+++ b/src/ggrc/assets/mustache/task_group_tasks/task_group_subtree.mustache
@@ -28,13 +28,13 @@
 
 
     <div class="task_group_tasks__list-item-column">
-      <span class="inline-data-content inline-data-content-small">
+      <span class="inline-data-content">
         {{localize_date instance.start_date}} - {{localize_date instance.end_date}}
       </span>
     </div>
 
     <div class="task_group_tasks__list-item-column">
-      <span class="inline-data-content inline-data-content-small">
+      <span class="inline-data-content">
         {{localize_date instance.view_start_date}} - {{localize_date instance.view_end_date}}
       </span>
     </div>

--- a/src/ggrc/assets/stylesheets/modules/_workflow.scss
+++ b/src/ggrc/assets/stylesheets/modules/_workflow.scss
@@ -154,11 +154,9 @@
   text-overflow: ellipsis;
   word-wrap:no-wrap;
   width:100%;
-  &.inline-data-content-small {
-    font-size:11px;
-  }
   &.oneline {
     display: block;
+    width: fit-content;
   }
 
   .deleteTrigger {
@@ -330,6 +328,12 @@ ul.add-task-comment {
         -webkit-line-clamp: 2;
         -webkit-box-orient: vertical;
       }
+    }
+  }
+
+  &__list {
+    .tree-item-add {
+      padding-top: 30px;
     }
   }
 }


### PR DESCRIPTION
# Issue description
Fix styling issues on Setup tab for Workflows.

# Steps to test the changes
1. Create Repeat on workflow (weekly)
2. Go to Setup tab and expand Task Group Info pane
3. Create at least 3 tasks: icon for replace tasks are not centered
4. Map any object to the tasks group
5. Hover over mapped object: tooltip is displayed too far from object
6. Look at the Assignee in Assignee column: font is differ from 'Initial setup' and 'Next Cycle' columns
7. Padding between Create task button and line: approx. 30 pxls

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".