### PR TITLE
GGRC-3385 Add default CA display value for Checkbox CA type

### DIFF
--- a/src/ggrc/assets/javascripts/components/tree/templates/tree-item-custom-attribute.mustache
+++ b/src/ggrc/assets/javascripts/components/tree/templates/tree-item-custom-attribute.mustache
@@ -3,7 +3,7 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
 
-{{#get_custom_attr_value column instance}}
+{{#getCustomAttrValue column instance}}
     {{! because the object can currently only be a
     person there is no need to switch }}
     <tree-field {source}="object" {field}="'email'"/>

--- a/src/ggrc/assets/javascripts/components/tree/tests/tree-item-custom-attribute_spec.js
+++ b/src/ggrc/assets/javascripts/components/tree/tests/tree-item-custom-attribute_spec.js
@@ -164,6 +164,15 @@ describe('helpers.getCustomAttrValue', () => {
 
       expect(actual).toEqual('');
     });
+
+    it('returns "No" for CA of type checkbox if there are no CA values', () => {
+      attr.attr_name = 'CheckBox';
+      fakeInstance.attr('custom_attribute_values', []);
+
+      actual = helper(attr, fakeInstance, fakeOptions);
+
+      expect(actual).toEqual('No');
+    });
   });
 
   describe('for CA of Date type', () => {

--- a/src/ggrc/assets/javascripts/components/tree/tests/tree-item-custom-attribute_spec.js
+++ b/src/ggrc/assets/javascripts/components/tree/tests/tree-item-custom-attribute_spec.js
@@ -3,24 +3,22 @@
   Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 */
 
-import helpers from './../tree-item-custom-attribute';
+import {helpers} from './../tree-item-custom-attribute';
 
-describe('helpers.get_custom_attr_value', function () {
-  'use strict';
+describe('helpers.getCustomAttrValue', () => {
+  let helper;
+  let fakeAttr;
+  let fakeInstance;
+  let fakeOptions;
+  let fakeCustomAttrDefs;
+  let origValue;
+  let setCustomAttrItem;
+  let getCustomAttrItem;
+  let actual;
+  let customAttrItem;
 
-  var helper;
-  var fakeAttr;
-  var fakeInstance;
-  var fakeOptions;
-  var fakeCustomAttrDefs;
-  var origValue;
-  var setCustomAttrItem;
-  var getCustomAttrItem;
-  var actual;
-  var customAttrItem;
-
-  beforeAll(function () {
-    helper = helpers.get_custom_attr_value;
+  beforeAll(() => {
+    helper = helpers.getCustomAttrValue;
 
     fakeCustomAttrDefs = [{
       definition_type: 'control',
@@ -77,7 +75,7 @@ describe('helpers.get_custom_attr_value', function () {
       custom_attribute_values: [],
     });
 
-    getCustomAttrItem = function (attrValue, attrId, attrType) {
+    getCustomAttrItem = (attrValue, attrId, attrType) => {
       return new can.Map({
         attribute_value: attrValue,
         custom_attribute_id: attrId || 3,
@@ -85,7 +83,7 @@ describe('helpers.get_custom_attr_value', function () {
       });
     };
 
-    setCustomAttrItem = function (attrValue, attrId, attrType) {
+    setCustomAttrItem = (attrValue, attrId, attrType) => {
       customAttrItem = getCustomAttrItem(attrValue, attrId, attrType);
       fakeInstance.attr('custom_attribute_values.0', customAttrItem);
 
@@ -94,11 +92,11 @@ describe('helpers.get_custom_attr_value', function () {
     };
   });
 
-  afterAll(function () {
+  afterAll(() => {
     GGRC.custom_attr_defs = origValue;
   });
 
-  beforeEach(function () {
+  beforeEach(() => {
     fakeAttr = {};
     fakeOptions = {};
     fakeInstance.class = {table_singular: 'control'};
@@ -106,23 +104,22 @@ describe('helpers.get_custom_attr_value', function () {
     fakeAttr.attr_name = 'Type';
   });
 
-  it('reify() is exec if instance is not an Assessment', function () {
+  it('reify() is exec if instance is not an Assessment', () => {
     setCustomAttrItem();
     helper(fakeAttr, fakeInstance, fakeOptions);
 
     expect(customAttrItem.reify).toHaveBeenCalled();
   });
 
-  it('return correct value if customAttrItem is not undefined',
-    function () {
-      setCustomAttrItem('correctValue');
+  it('return correct value if customAttrItem is not undefined', () => {
+    setCustomAttrItem('correctValue');
 
-      actual = helper(fakeAttr, fakeInstance, fakeOptions);
+    actual = helper(fakeAttr, fakeInstance, fakeOptions);
 
-      expect(actual).toEqual('correctValue');
-    });
+    expect(actual).toEqual('correctValue');
+  });
 
-  it('return an empty string if customAttrItem is undefined', function () {
+  it('return an empty string if customAttrItem is undefined', () => {
     setCustomAttrItem();
 
     actual = helper(fakeAttr, fakeInstance, fakeOptions);
@@ -130,10 +127,10 @@ describe('helpers.get_custom_attr_value', function () {
     expect(actual).toEqual('');
   });
 
-  describe('for CA of Checkbox type', function () {
-    var attr = {};
+  describe('for CA of Checkbox type', () => {
+    const attr = {};
 
-    it('returns empty string when CAD wasn\'t found', function () {
+    it('returns empty string when CAD wasn\'t found', () => {
       setCustomAttrItem('10', 3, 'Checkbox');
 
       actual = helper(attr, fakeInstance, fakeOptions);
@@ -141,42 +138,39 @@ describe('helpers.get_custom_attr_value', function () {
       expect(actual).toEqual('');
     });
 
-    it('returns "Yes" for CA of type checkbox with value "1"',
-      function () {
-        attr.attr_name = 'CheckBox';
-        setCustomAttrItem('1', 4, 'checkbox');
+    it('returns "Yes" for CA of type checkbox with value "1"', () => {
+      attr.attr_name = 'CheckBox';
+      setCustomAttrItem('1', 4, 'checkbox');
 
-        actual = helper(attr, fakeInstance, fakeOptions);
+      actual = helper(attr, fakeInstance, fakeOptions);
 
-        expect(actual).toEqual('Yes');
-      });
+      expect(actual).toEqual('Yes');
+    });
 
-    it('returns "No" for CA of type checkbox with value "0"',
-      function () {
-        attr.attr_name = 'CheckBox';
-        setCustomAttrItem(0, 4, 'checkbox');
+    it('returns "No" for CA of type checkbox with value "0"', () => {
+      attr.attr_name = 'CheckBox';
+      setCustomAttrItem(0, 4, 'checkbox');
 
-        actual = helper(attr, fakeInstance, fakeOptions);
+      actual = helper(attr, fakeInstance, fakeOptions);
 
-        expect(actual).toEqual('No');
-      });
+      expect(actual).toEqual('No');
+    });
 
-    it('returns empty string for CA of type checkbox without value',
-      function () {
-        attr.attr_name = 'CheckBox';
-        setCustomAttrItem(undefined, 4, 'checkbox');
+    it('returns empty string for CA of type checkbox without value', () => {
+      attr.attr_name = 'CheckBox';
+      setCustomAttrItem(undefined, 4, 'checkbox');
 
-        actual = helper(attr, fakeInstance, fakeOptions);
+      actual = helper(attr, fakeInstance, fakeOptions);
 
-        expect(actual).toEqual('');
-      });
+      expect(actual).toEqual('');
+    });
   });
 
-  describe('for CA of Date type', function () {
-    var attr = {
+  describe('for CA of Date type', () => {
+    const attr = {
     };
 
-    it('returns empty string when CAD wasn\'t found', function () {
+    it('returns empty string when CAD wasn\'t found', () => {
       setCustomAttrItem('10', 3, 'Date');
 
       actual = helper(attr, fakeInstance, fakeOptions);
@@ -184,9 +178,9 @@ describe('helpers.get_custom_attr_value', function () {
       expect(actual).toEqual('');
     });
 
-    it('returns formatted date when CAD was found', function () {
-      var expected = 'expected date';
-      var attrValue = '2017-09-30';
+    it('returns formatted date when CAD was found', () => {
+      const expected = 'expected date';
+      const attrValue = '2017-09-30';
       attr.attr_name = 'Date';
       setCustomAttrItem(attrValue, 9, 'Date');
       spyOn(GGRC.Utils, 'formatDate')
@@ -199,10 +193,9 @@ describe('helpers.get_custom_attr_value', function () {
         .toHaveBeenCalledWith(attrValue, true);
     });
 
-    it('tries to format date for existing CAD and undefined value',
-      function () {
-        var expected = 'expected date';
-        var attrValue = undefined;
+    it('tries to format date for existing CAD and undefined value', () => {
+        const expected = 'expected date';
+        const attrValue = undefined;
         attr.attr_name = 'Date';
         setCustomAttrItem(attrValue, 9, 'Date');
         spyOn(GGRC.Utils, 'formatDate')
@@ -216,11 +209,11 @@ describe('helpers.get_custom_attr_value', function () {
       });
   });
 
-  describe('for CA of Dropdown type', function () {
-    var attr = {
+  describe('for CA of Dropdown type', () => {
+    const attr = {
     };
 
-    it('returns empty string when CAD wasn\'t found', function () {
+    it('returns empty string when CAD wasn\'t found', () => {
       setCustomAttrItem('10', 3, 'Dropdown');
 
       actual = helper(attr, fakeInstance, fakeOptions);
@@ -228,7 +221,7 @@ describe('helpers.get_custom_attr_value', function () {
       expect(actual).toEqual('');
     });
 
-    it('returns attribute value when CAD was found', function () {
+    it('returns attribute value when CAD was found', () => {
       attr.attr_name = 'Dropdown';
       setCustomAttrItem('10', 10, 'Dropdown');
 
@@ -237,22 +230,21 @@ describe('helpers.get_custom_attr_value', function () {
       expect(actual).toEqual('10');
     });
 
-    it('returns empty string for existing CAD and undefined value',
-      function () {
-        attr.attr_name = 'Dropdown';
-        setCustomAttrItem(undefined, 10, 'Dropdown');
+    it('returns empty string for existing CAD and undefined value', () => {
+      attr.attr_name = 'Dropdown';
+      setCustomAttrItem(undefined, 10, 'Dropdown');
 
-        actual = helper(attr, fakeInstance, fakeOptions);
+      actual = helper(attr, fakeInstance, fakeOptions);
 
-        expect(actual).toEqual('');
-      });
+      expect(actual).toEqual('');
+    });
   });
 
-  describe('for CA of Text type', function () {
-    var attr = {
+  describe('for CA of Text type', () => {
+    const attr = {
     };
 
-    it('returns empty string when CAD wasn\'t found', function () {
+    it('returns empty string when CAD wasn\'t found', () => {
       setCustomAttrItem('10', 3, 'Text');
 
       actual = helper(attr, fakeInstance, fakeOptions);
@@ -260,7 +252,7 @@ describe('helpers.get_custom_attr_value', function () {
       expect(actual).toEqual('');
     });
 
-    it('returns attribute value when CAD was found', function () {
+    it('returns attribute value when CAD was found', () => {
       attr.attr_name = 'Text';
       setCustomAttrItem('10', 6, 'Text');
 
@@ -269,22 +261,21 @@ describe('helpers.get_custom_attr_value', function () {
       expect(actual).toEqual('10');
     });
 
-    it('returns empty string for existing CAD and undefined value',
-      function () {
-        attr.attr_name = 'Text';
-        setCustomAttrItem(undefined, 6, 'Text');
+    it('returns empty string for existing CAD and undefined value', () => {
+      attr.attr_name = 'Text';
+      setCustomAttrItem(undefined, 6, 'Text');
 
-        actual = helper(attr, fakeInstance, fakeOptions);
+      actual = helper(attr, fakeInstance, fakeOptions);
 
-        expect(actual).toEqual('');
-      });
+      expect(actual).toEqual('');
+    });
   });
 
-  describe('for CA of Rich Text type', function () {
-    var attr = {
+  describe('for CA of Rich Text type', () => {
+    const attr = {
     };
 
-    it('returns empty string when CAD wasn\'t found', function () {
+    it('returns empty string when CAD wasn\'t found', () => {
       setCustomAttrItem('10', 3, 'Rich Text');
 
       actual = helper(attr, fakeInstance, fakeOptions);
@@ -292,7 +283,7 @@ describe('helpers.get_custom_attr_value', function () {
       expect(actual).toEqual('');
     });
 
-    it('returns attribute value when CAD was found', function () {
+    it('returns attribute value when CAD was found', () => {
       attr.attr_name = 'Rich Text';
       setCustomAttrItem('10', 7, 'Rich Text');
 
@@ -301,21 +292,20 @@ describe('helpers.get_custom_attr_value', function () {
       expect(actual).toEqual('10');
     });
 
-    it('returns empty string for existing CAD and undefined value',
-      function () {
-        attr.attr_name = 'Rich Text';
-        setCustomAttrItem(undefined, 7, 'Rich Text');
+    it('returns empty string for existing CAD and undefined value', () => {
+      attr.attr_name = 'Rich Text';
+      setCustomAttrItem(undefined, 7, 'Rich Text');
 
-        actual = helper(attr, fakeInstance, fakeOptions);
+      actual = helper(attr, fakeInstance, fakeOptions);
 
-        expect(actual).toEqual('');
-      });
+      expect(actual).toEqual('');
+    });
   });
 
-  describe('for CA of Map:Person type', function () {
-    var attr = {};
+  describe('for CA of Map:Person type', () => {
+    const attr = {};
 
-    it('returns empty string when CAD wasn\'t found', function () {
+    it('returns empty string when CAD wasn\'t found', () => {
       setCustomAttrItem(null, 3, 'Map:Person');
 
       actual = helper(attr, fakeInstance, fakeOptions);
@@ -323,15 +313,15 @@ describe('helpers.get_custom_attr_value', function () {
       expect(actual).toEqual('');
     });
 
-    describe('when object was provided in attribute', function () {
-      var expected = 'expected persons';
-      var addItemResult = 'added item';
-      var actualObject = {};
+    describe('when object was provided in attribute', () => {
+      const expected = 'expected persons';
+      const addItemResult = 'added item';
+      const actualObject = {};
 
-      beforeEach(function () {
+      beforeEach(() => {
         setCustomAttrItem(undefined, 8, 'Map:Person');
         customAttrItem.attr('attribute_object', {
-          reify: function () {},
+          reify: () => {},
         });
         spyOn(customAttrItem.attr('attribute_object'), 'reify')
           .and.returnValue(actualObject);
@@ -347,30 +337,30 @@ describe('helpers.get_custom_attr_value', function () {
         actual = helper(attr, fakeInstance, fakeOptions);
       });
 
-      it('returns expected result', function () {
+      it('returns expected result', () => {
         expect(actual).toEqual(expected);
       });
 
-      it('reify object attribute', function () {
+      it('reify object attribute', () => {
         expect(customAttrItem.attribute_object.reify)
           .toHaveBeenCalled();
       });
 
-      it('adds object to contexts list', function () {
+      it('adds object to contexts list', () => {
         expect(fakeOptions.contexts.add)
           .toHaveBeenCalledWith({object: actualObject});
       });
 
-      it('makes mustache fn-call', function () {
+      it('makes mustache fn-call', () => {
         expect(fakeOptions.fn).toHaveBeenCalled();
       });
     });
 
-    describe('when object wasn\'t provided in attribute', function () {
-      var expected = 'expected persons';
-      var addItemResult = 'added item';
+    describe('when object wasn\'t provided in attribute', () => {
+      const expected = 'expected persons';
+      const addItemResult = 'added item';
 
-      beforeEach(function () {
+      beforeEach(() => {
         attr.attr_name = 'Persons';
         setCustomAttrItem(undefined, 8, 'Map:Person');
         fakeOptions = {
@@ -383,15 +373,15 @@ describe('helpers.get_custom_attr_value', function () {
         actual = helper(attr, fakeInstance, fakeOptions);
       });
 
-      it('returns expected result', function () {
+      it('returns expected result', () => {
         expect(actual).toEqual(expected);
       });
 
-      it('adds object to contexts list', function () {
+      it('adds object to contexts list', () => {
         expect(fakeOptions.contexts.add).toHaveBeenCalledWith({object: null});
       });
 
-      it('makes mustache fn-call', function () {
+      it('makes mustache fn-call', () => {
         expect(fakeOptions.fn).toHaveBeenCalled();
       });
     });

--- a/src/ggrc/assets/javascripts/components/tree/tree-item-custom-attribute.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-item-custom-attribute.js
@@ -5,83 +5,76 @@
 
 import template from './templates/tree-item-custom-attribute.mustache';
 
-var viewModel = can.Map.extend({
+const formatValueMap = {
+  'Checkbox'(item) {
+    return ['No', 'Yes'][item.attr('attribute_value')];
+  },
+  'Date'(item) {
+    return GGRC.Utils.formatDate(item.attr('attribute_value'), true);
+  },
+  'Map:Person'(item, options) {
+    let attr = item.attr('attribute_object');
+    return options.fn(options.contexts.add({
+      object: attr ?
+        attr.reify() :
+        null,
+    }));
+  },
+};
+
+const _prepareCAVs = (instance) => {
+  instance.attr('custom_attribute_values').forEach((cav, index) => {
+    instance.custom_attribute_values.attr(index, cav.reify());
+  });
+};
+
+const getCustomAttrValue = (attr, instance, options) => {
+  let value = '';
+
+  attr = Mustache.resolve(attr);
+  instance = Mustache.resolve(instance);
+
+  let definition = GGRC.custom_attr_defs.find((item) => {
+    return item.definition_type === instance.class.table_singular &&
+      item.title === attr.attr_name;
+  });
+
+  if (definition) {
+    // reify all CA models (with the exception of the Assessment)
+    // to load custom_attribute_id, attribute_value and attribute_object
+    if (!(instance instanceof CMS.Models.Assessment)) {
+      _prepareCAVs(instance);
+    }
+
+    let customAttrItem = _.find(instance.attr('custom_attribute_values'),
+      (cav) => {
+        return cav.custom_attribute_id === definition.id;
+      });
+
+    if (customAttrItem) {
+      value = formatValueMap[definition.attribute_type] ?
+        formatValueMap[definition.attribute_type](customAttrItem, options) :
+        customAttrItem.attr('attribute_value');
+    }
+  }
+
+  return value || '';
+};
+
+
+export const viewModel = can.Map.extend({
   instance: null,
   values: [],
   column: {},
 });
 
-var helpers = {
-  /*
-    Used to get the string value for custom attributes
-  */
-  get_custom_attr_value: function (attr, instance, options) {
-    var value = '';
-    var definition;
-    var customAttrItem;
-    var formatValueMap = {
-      Checkbox: function (item) {
-        return ['No', 'Yes'][item.attr('attribute_value')];
-      },
-      Date: function (item) {
-        return GGRC.Utils.formatDate(item.attr('attribute_value'), true);
-      },
-      'Map:Person': function (item) {
-        var attr = item.attr('attribute_object');
-        return options.fn(options.contexts.add({
-          object: attr ?
-            attr.reify() :
-            null,
-        }));
-      },
-    };
-
-    attr = Mustache.resolve(attr);
-    instance = Mustache.resolve(instance);
-
-    definition = _.find(GGRC.custom_attr_defs, function (item) {
-      return item.definition_type === instance.class.table_singular &&
-        item.title === attr.attr_name;
-    });
-
-    if (definition) {
-      // reify all CA models (with the exception of the Assessment)
-      // to load custom_attribute_id, attribute_value and attribute_object
-      if (!(instance instanceof CMS.Models.Assessment)) {
-        _prepareCAVs();
-      }
-
-      customAttrItem = _.find(instance.attr('custom_attribute_values'),
-        function (cav) {
-          return cav.custom_attribute_id === definition.id;
-        });
-
-      if (customAttrItem) {
-        if (formatValueMap[definition.attribute_type]) {
-          value =
-            formatValueMap[definition.attribute_type](customAttrItem);
-        } else {
-          value = customAttrItem.attr('attribute_value');
-        }
-      }
-    }
-
-    function _prepareCAVs() {
-      _.forEach(instance.attr('custom_attribute_values'),
-        function (cav, index) {
-          instance.custom_attribute_values.attr(index, cav.reify());
-        });
-    }
-
-    return value || '';
-  },
+export const helpers = {
+  getCustomAttrValue,
 };
 
-GGRC.Components('treeItemCustomAttribute', {
+export default can.Component.extend({
   tag: 'tree-item-custom-attribute',
   template: template,
   viewModel: viewModel,
   helpers: helpers,
 });
-
-export default helpers;

--- a/src/ggrc/assets/javascripts/components/tree/tree-item-custom-attribute.js
+++ b/src/ggrc/assets/javascripts/components/tree/tree-item-custom-attribute.js
@@ -22,6 +22,10 @@ const formatValueMap = {
   },
 };
 
+const defaultValueMap = {
+  Checkbox: 'No',
+};
+
 const _prepareCAVs = (instance) => {
   instance.attr('custom_attribute_values').forEach((cav, index) => {
     instance.custom_attribute_values.attr(index, cav.reify());
@@ -55,6 +59,8 @@ const getCustomAttrValue = (attr, instance, options) => {
       value = formatValueMap[definition.attribute_type] ?
         formatValueMap[definition.attribute_type](customAttrItem, options) :
         customAttrItem.attr('attribute_value');
+    } else {
+      value = value || defaultValueMap[definition.attribute_type];
     }
   }
 


### PR DESCRIPTION
# Issue description

If user adds new GCA with checkbox type and doesn't fill GCA field, 'No' is not displayed in tree view

# Steps to test the changes

Steps to reproduce:
1. Have newly created GCA with checkbox type for Assessment
2. Have assessment on the audit page
3. On the Assessment tab Set visible field of GCA with checkbox type
4. Look at the tree view: 'No' is not displayed by default

*Actual Result:* If user adds new GCA with checkbox type and doesn't fill GCA field, 'No' is not displayed in tree view
*Expected Result:* If user adds new GCA with checkbox type and doesn't fill GCA field, 'No' should be displayed in tree view

# Solution description
1) Migrate component to es2015.
2) Add default values map.
3) Add new unit-test.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
