### PR TITLE
GGRC-2155: Rename CTGOT to 'Cycle Tasks' in Search options

### DIFF
--- a/src/ggrc/assets/javascripts/models/cycle_models.js
+++ b/src/ggrc/assets/javascripts/models/cycle_models.js
@@ -258,6 +258,7 @@ import {getClosestWeekday} from '../plugins/utils/date-util';
     update: 'PUT /api/cycle_task_group_object_tasks/{id}',
     destroy: 'DELETE /api/cycle_task_group_object_tasks/{id}',
     title_singular: 'Cycle Task',
+    title_plural: 'Cycle Tasks',
     name_singular: 'Task',
     name_plural: 'Tasks',
     attributes: {


### PR DESCRIPTION
# Issue description
CTGOT should be named as 'Cycle Tasks' in search options.

# Steps to test the changes
1. Open "Global Search modal" modal.
2. Open "Object Type" dropdown and try to select "Cycle Tasks".

**Actual result:** 'Object type' dropdown in 'Global Search modal' contains element "Cycle Task Group Object Tasks"
**Expected result:** 'Object type' dropdown in 'Global Search modal' contains element "Cycle Tasks"

# Solution description
add title_plural property into CTGOT object.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".