### PR TITLE
GGRC-4180: Correct 'Activate Workflow' display

### DIFF
--- a/src/ggrc/assets/mustache/dashboard/internav_list.mustache
+++ b/src/ggrc/assets/mustache/dashboard/internav_list.mustache
@@ -6,7 +6,7 @@
 {{#if_helpers '\
   ^is_empty' counts '\
   or #is_admin_page' }}
-<div class="tabs priority">
+<div class="tabs priority {{^is instance.type 'Audit'}}single-set{{/is}}">
   <ul class="internav {{#if_equals instance.type 'Audit'}}audit{{/if_equals}}">
     {{#priorityTabs}}
       <li class="{{internav_icon}} {{widgetType}} {{#if_equals contexts.active_widget.selector selector}}active{{/if_equals}}">
@@ -40,10 +40,9 @@
           {add-tab-title}="'Add Tab'"></add-tab-button>
       {{/hasHiddenWidgets}}
     {{/if}}
-
+    {{{render_hooks 'ObjectNav.Actions'}}}
   </ul>
 </div>
-{{{render_hooks 'ObjectNav.Actions'}}}
 
 {{#if_equals instance.type 'Audit'}}
 <div class="tabs not-priority">

--- a/src/ggrc/assets/stylesheets/modules/_top-nav.scss
+++ b/src/ggrc/assets/stylesheets/modules/_top-nav.scss
@@ -190,6 +190,10 @@ ul.internav {
 
 .tabs {
   &.priority {
+    &.single-set {
+      width: 100%;
+    }
+
     ul.internav {
       display: flex;
       flex-flow: row wrap;


### PR DESCRIPTION
# Issue description
Fix incorrect 'Activate Workflow' button display 

# Steps to test the changes
1. Create Repeat off Workflow
2. On the Workflow Info page look at the [Activate Workflow] button
**Actual Result:** Incorrect display of [Activate Workflow] button
**Expected Result:** [Activate Workflow] button should be displayed according to UX mockups. 

# Solution description
Return 'Activate Workflow' button back in the options list and expand it on a row width.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
