### PR TITLE
GGRC-2276 Unify types ordering on Admin page

### DIFF
--- a/src/ggrc/assets/javascripts/models/assessment.js
+++ b/src/ggrc/assets/javascripts/models/assessment.js
@@ -11,6 +11,7 @@ import {prepareCustomAttributes} from '../plugins/utils/ca-utils';
   can.Model.Cacheable('CMS.Models.Assessment', {
     root_object: 'assessment',
     root_collection: 'assessments',
+    category: 'governance',
     findOne: 'GET /api/assessments/{id}',
     findAll: 'GET /api/assessments',
     update: 'PUT /api/assessments/{id}',

--- a/src/ggrc/assets/javascripts/models/custom_attributes.js
+++ b/src/ggrc/assets/javascripts/models/custom_attributes.js
@@ -4,20 +4,6 @@
 */
 
 (function (can, GGRC, CMS) {
-  /* function sortCustomAttributables
-   *
-   * Groups custom attributes by category.
-   *
-   */
-  function sortCustomAttributables(a, b) {
-    if (a.category < b.category) {
-      return 1;
-    } else if (a.category > b.category) {
-      return -1;
-    }
-    return 0;
-  }
-
   /* class CustomAttributable
    *
    * CustomAttributable does not query the backend, it is used to display a
@@ -28,8 +14,9 @@
    */
   can.Model.Cacheable('CMS.Models.CustomAttributable', {
     findAll: function () {
-      var types;
-      types = GGRC.custom_attributable_types.sort(sortCustomAttributables);
+      var types = _.sortByOrder(GGRC.custom_attributable_types,
+        'category', false);
+
       return can.when(can.map(types, function (type, i) {
         return new CMS.Models.CustomAttributable(can.extend(type, {
           id: i

--- a/src/ggrc/assets/javascripts/models/custom_roles.js
+++ b/src/ggrc/assets/javascripts/models/custom_roles.js
@@ -5,17 +5,6 @@
 
 (function (can, GGRC, CMS) {
   'use strict';
-
-   // using this function for sorting will group model types by categories
-  function sortByCategory(a, b) {
-    if (a.category < b.category) {
-      return -1;
-    } else if (a.category > b.category) {
-      return 1;
-    }
-    return 0;
-  }
-
   /**
    * A "mixin" denoting a model type that can be assigned custom roles.
    *
@@ -31,7 +20,7 @@
     findAll: function () {
       // We do not query the backend, this implementation is used to diplay
       // a list of objects in the Custom Roles widget.
-      var types = GGRC.roleableTypes.sort(sortByCategory);
+      var types = _.sortByOrder(GGRC.roleableTypes, 'category', false);
 
       var instances = can.map(types, function (type, i) {
         var withId = can.extend(type, {id: i});


### PR DESCRIPTION
# Issue description

Unify ordering of object types in "Custom attributes" and Custom Roles" tabs on Admin Dashboard

# Steps to test the changes

Currently objects are displayed randomly in "Custom attributes" and Custom Roles" tabs on Admin Dashboard. 
Suggestion:
Make object types in alphabetical order or another order due to business requirements.
Actual Result: user have to find objects in different places in the tabs and scroll up and down

*EXPECTED RESULT:*
'Custom Roles' tab should be sorted just like 'Custom Attributes' tab. 

# Solution description

1) Use lodash with the same options for both tabs.
2) Fix category for Assessment model


# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
