### PR TITLE
GGRC-4189: Remove unused 'kind' property

### DIFF
--- a/src/ggrc/assets/javascripts/components/cycle-task-actions/cycle-task-actions.js
+++ b/src/ggrc/assets/javascripts/components/cycle-task-actions/cycle-task-actions.js
@@ -41,28 +41,16 @@ import template from './cycle-task-actions.mustache';
           var allowChangeState = this.attr('instance.allow_change_state');
 
           if (pageType === 'Workflow') {
-            return !this.isBacklog() &&
-              this.attr('cycle').reify().attr('is_current');
+            return this.attr('cycle').reify().attr('is_current');
           }
 
           return allowChangeState;
-        }
-      }
+        },
+      },
     },
     instance: null,
     disabled: false,
     oldValues: [],
-    isBacklog: function () {
-      var result = false;
-      var cycle;
-
-      if (this.attr('instance') instanceof CMS.Models.CycleTaskGroup) {
-        cycle = this.attr('instance').cycle.reify();
-        result = cycle.workflow.reify().kind === 'Backlog';
-      }
-
-      return result;
-    },
     changeStatus: function (ctx, el, ev) {
       var status = el.data('value');
       var instance = this.attr('instance');

--- a/src/ggrc/assets/javascripts/components/cycle-task-actions/cycle-task-actions.mustache
+++ b/src/ggrc/assets/javascripts/components/cycle-task-actions/cycle-task-actions.mustache
@@ -61,15 +61,13 @@
 {{#if_instance_of instance 'Cycle'}}
 <div class="flex-box item-actions">
   <div class="request-control">
-      {{^if_equals instance.workflow.kind "Backlog"}}
-        <cycle-end-cycle cycle="instance">
-          {{#is_allowed 'update' instance.workflow.reify}}
-            {{#if instance.is_current}}
-              <button class="btn btn-white btn-small end-cycle">End Cycle</button>
-            {{/if}}
-          {{/is_allowed}}
-        </cycle-end-cycle>
-      {{/if_equals}}
+     <cycle-end-cycle cycle="instance">
+       {{#is_allowed 'update' instance.workflow.reify}}
+         {{#if instance.is_current}}
+           <button class="btn btn-white btn-small end-cycle">End Cycle</button>
+         {{/if}}
+       {{/is_allowed}}
+     </cycle-end-cycle>
   </div>
 </div>
 {{/if_instance_of}}

--- a/src/ggrc/assets/javascripts/models/cycle_models.js
+++ b/src/ggrc/assets/javascripts/models/cycle_models.js
@@ -413,23 +413,6 @@ import {getClosestWeekday} from '../plugins/utils/date-util';
           populateFromWorkflow(form, objectParams.workflow);
           return;
         }
-
-        workflows = CMS.Models.Workflow.findAll({
-          kind: 'Backlog', status: 'Active', __sort: '-created_at'});
-        workflows.then(function (workflowList) {
-          if (!workflowList.length) {
-            $(document.body).trigger(
-              'ajax:flash',
-              {warning: 'No Backlog' +
-              ' workflows found!' +
-              ' Contact your administrator to enable this functionality.',
-              }
-            );
-            return;
-          }
-          _workflow = workflowList[0];
-          populateFromWorkflow(form, _workflow);
-        });
       } else {
         cycle = form.cycle.reify();
         if (!_.isUndefined(cycle.workflow)) {

--- a/src/ggrc/assets/mustache/dashboard/info/wf_owner.mustache
+++ b/src/ggrc/assets/mustache/dashboard/info/wf_owner.mustache
@@ -5,21 +5,19 @@
 
 {{#instance}}
 <!--p class="oneline"-->
-  {{^if_equals instance.kind "Backlog"}}
-    Owned by:
-    {{#with_mapping 'authorizations' instance}}
-      {{#each authorizations}}
-      <span>
-        {{#using role=instance.role}}
-          {{#if_equals role.name 'WorkflowOwner'}}
-            {{#using contact=instance.person}}
-              {{{renderLive '/static/mustache/people/popover.mustache' person=contact}}}
-            {{/using}}
-          {{/if_equals}}
-        {{/using}}
-      </span>
-      {{/each}}
-    {{/with_mapping}}
-  {{/if_equals}}
+  Owned by:
+  {{#with_mapping 'authorizations' instance}}
+    {{#each authorizations}}
+    <span>
+      {{#using role=instance.role}}
+        {{#if_equals role.name 'WorkflowOwner'}}
+          {{#using contact=instance.person}}
+            {{{renderLive '/static/mustache/people/popover.mustache' person=contact}}}
+          {{/using}}
+        {{/if_equals}}
+      {{/using}}
+    </span>
+    {{/each}}
+  {{/with_mapping}}
 <!--/p-->
 {{/instance}}

--- a/src/ggrc/assets/mustache/dashboard/object_nav_actions.mustache
+++ b/src/ggrc/assets/mustache/dashboard/object_nav_actions.mustache
@@ -22,9 +22,7 @@
         {{^if_equals instance.status 'Inactive'}}
         {{^if waiting}}
           {{^can_activate}}
-            {{^if_equals instance.kind "Backlog"}}
             <p class="alert tiny-help-text" style="margin-bottom:0px;"><strong>Note:</strong> At least one of the task groups is missing either a task or an object.</p>
-            {{/if_equals}}
           {{/can_activate}}
         {{/if}}
         {{/if_equals}}

--- a/src/ggrc/assets/mustache/wf_people/tree_add_item.mustache
+++ b/src/ggrc/assets/mustache/wf_people/tree_add_item.mustache
@@ -2,7 +2,6 @@
     Copyright (C) 2018 Google Inc.
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
-{{^if_equals parent_instance.kind "Backlog"}}
 {{#if allow_mapping_or_creating}}
 {{#is_allowed_to_map parent_instance model.shortName}}
   <a
@@ -19,4 +18,3 @@
   </a>
 {{/is_allowed_to_map}}
 {{/if}}
-{{/if_equals}}

--- a/src/ggrc/assets/mustache/workflows/info.mustache
+++ b/src/ggrc/assets/mustache/workflows/info.mustache
@@ -21,14 +21,12 @@
         <ul class="dropdown-menu three-dots-list" aria-labelledby="drop1" role="menu">
           {{^is_info_pin}}
             {{{render_hooks instance.class.shortName 'info_widget_actions'}}}
-            {{^if_equals instance.kind "Backlog"}}
               <li>
                 <a href="javascript://" data-toggle="modal-ajax-form" data-object-plural="{{model.table_plural}}" data-object-singular="{{model.model_singular}}" data-modal-reset="reset" data-modal-class="modal-wide" title="Edit {{model.model_title}}" data-object-id="{{instance.id}}">
                   <i class="fa fa-pencil-square-o"></i>
                   Edit Workflow Info
                 </a>
               </li>
-            {{/if_equals}}
           {{/is_info_pin}}
 
           <li>
@@ -36,38 +34,37 @@
           </li>
 
           {{^is_info_pin}}
-            {{^if_equals instance.kind "Backlog"}}
+            <li>
+              <workflow-clone workflow="instance">
+                <a href="javascript://">
+                  <i class="fa fa-clone"></i>
+                  Clone Workflow
+                </a>
+              </workflow-clone>
+            </li>
+            {{#if instance.recurrences}}
               <li>
-                <workflow-clone workflow="instance">
-                  <a href="javascript://">
-                    <i class="fa fa-clone"></i>
-                    Clone Workflow
-                  </a>
-                </workflow-clone>
+                <workflow-start-cycle workflow="instance">
+                  <workflow-activate workflow="instance" deferredData="can_activate">
+                    {{#can_activate}}
+                      <a href="#workflowStart" {{^instance.task_groups.length}}disabled="disabled"{{/task_groups}}>
+                        <i class="fa fa-sliders"></i>
+                        Manually Start a Cycle
+                      </a>
+                    {{/can_activate}}
+                  </workflow-activate>
+                </workflow-start-cycle>
               </li>
-              {{#if instance.recurrences}}
-                <li>
-                  <workflow-start-cycle workflow="instance">
-                    <workflow-activate workflow="instance" deferredData="can_activate">
-                      {{#can_activate}}
-                        <a href="#workflowStart" {{^instance.task_groups.length}}disabled="disabled"{{/task_groups}}>
-                          <i class="fa fa-sliders"></i>
-                          Manually Start a Cycle
-                        </a>
-                      {{/can_activate}}
-                    </workflow-activate>
-                  </workflow-start-cycle>
-                </li>
-                <li>
-                  <workflow-deactivate workflow="instance">
-                    <a href="#workflowStart" {{^instance.task_groups.length}}disabled="disabled"{{/task_groups}}>
-                      <i class="fa fa-archive"></i>
-                      Archive workflow
-                    </a>
-                  </workflow-deactivate>
-                </li>
-              {{/if}}
-              {{#is_allowed 'delete' instance}}
+              <li>
+                <workflow-deactivate workflow="instance">
+                  <a href="#workflowStart" {{^instance.task_groups.length}}disabled="disabled"{{/task_groups}}>
+                    <i class="fa fa-archive"></i>
+                    Archive workflow
+                  </a>
+                </workflow-deactivate>
+              </li>
+            {{/if}}
+            {{#is_allowed 'delete' instance}}
                 <li>
                   <a data-toggle="modal-ajax-deleteform" data-object-plural="{{model.table_plural}}" data-object-singular="{{model.model_singular}}" data-modal-reset="reset" data-modal-class="modal" data-object-id="{{instance.id}}" href="javascript://">
                     <i class="fa fa-trash"></i>
@@ -75,7 +72,6 @@
                   </a>
                 </li>
               {{/is_allowed}}
-            {{/if_equals}}
           {{/is_info_pin}}
 
           {{#is_info_pin}}


### PR DESCRIPTION
# Issue description
Remove unused 'kind' property from FE.

# Steps to test the changes
Click through workflow functionality.

# Solution description
- Remove 'kind' Workflow object property from front-end
- Remove pre-population logic for 'Active Workflow' on 'Create Cycle Task' modal (My Tasks page)

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".