### PR TITLE
GGRC-1849 Hide "Get latest version" link for deleted object

### DIFF
--- a/src/ggrc/assets/mustache/base_objects/general-page-header.mustache
+++ b/src/ggrc/assets/mustache/base_objects/general-page-header.mustache
@@ -36,6 +36,8 @@
             reified by the time is_allowed helper uses it }}
       {{#using reified_snapshot=snapshot}}
       {{#canUpdate}}
+
+      {{^if instance.originalObjectDeleted}}
         {{^isLatestRevision}}
           {{^if instance.snapshot.archived}}
           <div class="span12 snapshot">
@@ -59,6 +61,8 @@
           </div>
           {{/if}}
         {{/isLatestRevision}}
+      {{/if}}
+
       {{/canUpdate}}
       {{/using}}
       {{/if}}

--- a/src/ggrc/assets/mustache/snapshots/dropdown_menu.mustache
+++ b/src/ggrc/assets/mustache/snapshots/dropdown_menu.mustache
@@ -42,26 +42,29 @@ TODO: Temporary disabled until snapshot view is added.
             {{#using reified_snapshot=snapshot}}
             {{#canUpdate}}
             {{^isLatestRevision}}
-            {{^if instance.snapshot.archived}}
-            <li>
-                <snapshot-comparer-config
-                    {instance}="instance"
-                    {left-revision-id}="instance.snapshot.revision_id"
-                    {right-revisions}="instance.snapshot.revisions">
-                        <revisions-comparer
-                        {modal-title}="modalTitle"
-                        {modal-confirm}="modalConfirm"
-                        {button-view}="buttonView"
-                        {instance}="instance"
-                        {left-revision-id}="leftRevisionId"
-                        {right-revision}="rightRevision">
-                            <a href="javascript://" can-click="compareIt">
-                                <i class="fa fa-refresh"></i>
-                                Get the latest version
-                            </a>
-                    </revisions-comparer>
-                </snapshot-comparer-config>
-            </li>
+
+            {{^if instance.originalObjectDeleted}}
+              {{^if instance.snapshot.archived}}
+              <li>
+                  <snapshot-comparer-config
+                      {instance}="instance"
+                      {left-revision-id}="instance.snapshot.revision_id"
+                      {right-revisions}="instance.snapshot.revisions">
+                          <revisions-comparer
+                          {modal-title}="modalTitle"
+                          {modal-confirm}="modalConfirm"
+                          {button-view}="buttonView"
+                          {instance}="instance"
+                          {left-revision-id}="leftRevisionId"
+                          {right-revision}="rightRevision">
+                              <a href="javascript://" can-click="compareIt">
+                                  <i class="fa fa-refresh"></i>
+                                  Get the latest version
+                              </a>
+                      </revisions-comparer>
+                  </snapshot-comparer-config>
+              </li>
+              {{/if}}
             {{/if}}
             {{/isLatestRevision}}
             {{/canUpdate}}

--- a/test/selenium/src/tests/test_snapshots.py
+++ b/test/selenium/src/tests/test_snapshots.py
@@ -103,15 +103,16 @@ class TestSnapshots(base.Test):
 
   @pytest.mark.smoke_tests
   @pytest.mark.parametrize(
-      ("dynamic_create_audit_with_control", "expected_control", "is_openable"),
+      ("dynamic_create_audit_with_control", "expected_control", "is_openable",
+       "is_updateable"),
       [("create_audit_with_control_and_update_control",
-        "new_control_rest", True),
+        "new_control_rest", True, True),
        ("create_audit_with_control_and_delete_control",
-        "new_control_rest", False),
+        "new_control_rest", False, False),
        ("create_audit_with_control_with_cas_and_update_control_with_cas",
-        "new_control_with_cas_rest", True),
+        "new_control_with_cas_rest", True, True),
        ("create_audit_with_control_with_cas_and_delete_cas_for_controls",
-        "new_control_with_cas_rest", True)],
+        "new_control_with_cas_rest", True, True)],
       ids=["Audit contains snapshotable Control after updating Control",
            "Audit contains snapshotable Control after deleting Control",
            "Audit contains snapshotable Control "
@@ -121,7 +122,7 @@ class TestSnapshots(base.Test):
       indirect=["dynamic_create_audit_with_control"])
   def test_audit_contains_snapshotable_control(
       self, new_cas_for_controls_rest, dynamic_create_audit_with_control,
-      expected_control, is_openable, selenium
+      expected_control, is_openable, is_updateable, selenium
   ):
     """Test snapshotable Control and check via UI that:
     - Audit contains snapshotable Control after updating Control.
@@ -150,7 +151,7 @@ class TestSnapshots(base.Test):
         src_obj=audit, obj=expected_control)
     actual_control = controls_ui_service.get_list_objs_from_info_panels(
         src_obj=audit, objs=expected_control)
-    assert is_control_updateable is True
+    assert is_control_updateable is is_updateable
     assert is_control_openable is is_openable
     # 'actual_control': created_at, updated_at, modified_by (None)
     self.general_equal_assert(
@@ -162,18 +163,14 @@ class TestSnapshots(base.Test):
 
   @pytest.mark.smoke_tests
   @pytest.mark.parametrize(
-      ("dynamic_create_audit_with_control", "control", "expected_control",
-       "is_openable"),
+      ("dynamic_create_audit_with_control", "control", "expected_control"),
       [("create_audit_with_control_and_update_control",
-        "new_control_rest", "update_control_rest", True),
-       ("create_audit_with_control_and_delete_control",
-        "new_control_rest", "new_control_rest", False),
+        "new_control_rest", "update_control_rest"),
        ("create_audit_with_control_with_cas_and_update_control_with_cas",
-        "new_control_with_cas_rest", "update_control_with_cas_rest", True),
+        "new_control_with_cas_rest", "update_control_with_cas_rest"),
        ("create_audit_with_control_with_cas_and_delete_cas_for_controls",
-        "new_control_with_cas_rest", "new_control_with_cas_rest", True)],
+        "new_control_with_cas_rest", "new_control_with_cas_rest")],
       ids=["Update snapshotable Control to latest ver after updating Control",
-           "Update snapshotable Control to latest ver after deleting Control",
            "Update snapshotable Control to latest ver "
            "after updating Control with CAs",
            "Update snapshotable Control to latest ver "
@@ -181,11 +178,10 @@ class TestSnapshots(base.Test):
       indirect=["dynamic_create_audit_with_control"])
   def test_update_snapshotable_control_to_latest_ver(
       self, new_cas_for_controls_rest, dynamic_create_audit_with_control,
-      control, expected_control, is_openable, selenium
+      control, expected_control, selenium
   ):
     """Test snapshotable Control and check via UI that:
     - Update snapshotable Control to latest ver after updating Control.
-    - Update snapshotable Control to latest ver after deleting Control.
     - Update snapshotable Control to latest ver
     after updating Control with CAs.
     - Update snapshotable Control to latest ver
@@ -194,7 +190,6 @@ class TestSnapshots(base.Test):
       Execution and return of dynamic fixtures used REST API:
     - 'new_cas_for_controls_rest' *(due to Issue in app GGRC-2344)
     - 'create_audit_with_control_and_update_control'.
-    - 'create_audit_with_control_and_delete_control'.
     - 'create_audit_with_control_with_cas_and_update_control_with_cas'.
     - 'create_audit_with_control_with_cas_and_delete_cas_for_controls'.
     """
@@ -216,7 +211,7 @@ class TestSnapshots(base.Test):
     actual_control = controls_ui_service.get_list_objs_from_info_panels(
         src_obj=audit, objs=expected_control)
     assert is_control_updateable is False
-    assert is_control_openable is is_openable
+    assert is_control_openable is True
     # 'actual_control': created_at, updated_at, modified_by (None)
     self.general_equal_assert(
         expected_control, actual_control,


### PR DESCRIPTION
# Issue description

"Get the latest version" link is shown on Control's snapshot info pane when original control was deleted. 

# Steps to test the changes

1. On the audit page make sure that control is shown
2. Go to program page and delete control
3. Go to audit page and navigate to control's info pane
Actual Result: "Get the latest version" link is shown
Expected Result: "Get the latest version" link should not be visible if original control is deleted

# Solution description

Reuse `originalObjectDeleted` flag check for "Get the latest version" link.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests. __N/A__
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".