### PR TITLE
GGRC-2868 Remove strike-through button from Quill toolbar

### DIFF
--- a/src/ggrc/assets/javascripts/components/rich_text/rich_text.mustache
+++ b/src/ggrc/assets/javascripts/components/rich_text/rich_text.mustache
@@ -9,7 +9,6 @@
     <span class="ql-formats">
       <button type="button" class="ql-bold"></button>
       <button type="button" class="ql-italic"></button>
-      <button type="button" class="ql-strike"></button>
     </span>
     <span class="ql-formats">
       <button type="button" class="ql-link"></button>


### PR DESCRIPTION
# Issue description

Strike-through button was not working in Quill editor(rich-text fields in assessment info-pane and assessment modal) as it's not supported by the BE. 

# Steps to check issue on the dev

1. Open assessment edit modal
2. Fill some rich-text field ( ex. assessment procedure ) with some text
3. Make different words to be bold, italic and strike-though.
4. Save assessment and open its info-pane.
__Actual result__: Strike-through style is gone. Bold and italic words are in place.

# Steps to test the changes

Open assessment edit modal and make sure there're no "Strike-through" button in the rich-editor toolbar.

# Solution description

Remove strike-through button from the Quill editor toolbar to be consistent with BE and wysihtml5 editor used on edit modals of other objects.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests. __N/A__
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".