### PR TITLE
GGRC-4190,4101 Fix formatting of date in tree view when empty string is passed

### DIFF
--- a/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
+++ b/src/ggrc/assets/javascripts/plugins/ggrc_utils.js
@@ -103,7 +103,7 @@ import Permission from '../permission';
       ];
       var inst;
 
-      if (date === undefined || date === null) {
+      if ( !date ) {
         return '';
       }
 

--- a/src/ggrc/assets/javascripts/plugins/tests/ggrc_utils_spec.js
+++ b/src/ggrc/assets/javascripts/plugins/tests/ggrc_utils_spec.js
@@ -251,3 +251,15 @@ describe('GGRC utils getAssigneeType() method', function () {
     expect(userType).toEqual(expectedString);
   });
 });
+
+describe('GGRC utils formatDate() method', function () {
+  let formatDate = GGRC.Utils.formatDate;
+
+  it('should return empty string for false values', function () {
+    expect(formatDate(null)).toEqual('');
+    expect(formatDate(undefined)).toEqual('');
+    expect(formatDate('')).toEqual('');
+    expect(formatDate(false)).toEqual('');
+    expect(formatDate(0)).toEqual('');
+  });
+});


### PR DESCRIPTION
# Issue description

If assessment have a GCA of the Date type and new assessment created without filling this field an "Invalid date" is shown in the field's column in tree view.

# Steps to test the issue in dev branch

1. Have GCA with date type for Assessment
2. Go to an audit page
3. Create assessment leaving that field empty
4. Enable the field in tree view and see the value of this field for the newly created assessment - it says: "Invalid date" 

# Steps to test the changes
Same as above, but now an empty cell is shown instead of the "Invalid date" message.

# Solution description

There was a check for undefined and null values for the field. The solution is to return an empty string for any falsy value passed to the formatDate function.

__Notice__: The formatDate function was not covered by tests. I added test just for the logic that I touched because the rest of the function have some weird parts and in my opinion needs refactoring which is out of scope of this ticket.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".