### PR TITLE
QUICK-FIX Remove auditor role permissions

### DIFF
--- a/src/ggrc_basic_permissions/roles/Auditor.py
+++ b/src/ggrc_basic_permissions/roles/Auditor.py
@@ -7,33 +7,9 @@ description = """
   program being audited.
   """
 permissions = {
-    "read": [
-        "Audit",
-        "Assessment",
-        "Issue",
-        "Snapshot",
-        "ObjectPerson",
-        "Relationship",
-        "Document",
-        "UserRole",
-        "Comment",
-        "Context",
-    ],
-    "create": [
-        "Assessment",
-        "Issue",
-        "Comment",
-    ],
-    "view_object_page": [
-        "__GGRC_ALL__"
-    ],
-    "update": [
-        "Assessment",
-        "Snapshot",  # Needed for mapping snapshots to Assessments/Issues
-        "Issue",
-    ],
-    "delete": [
-        "Assessment",
-        "Issue"
-    ],
+    "read": [],
+    "create": [],
+    "view_object_page": [],
+    "update": [],
+    "delete": [],
 }

--- a/test/integration/ggrc_basic_permissions/test_auditor_filter.py
+++ b/test/integration/ggrc_basic_permissions/test_auditor_filter.py
@@ -12,8 +12,6 @@ from integration.ggrc.api_helper import Api
 from integration.ggrc.generator import ObjectGenerator
 
 from integration.ggrc.models import factories
-from integration.ggrc_basic_permissions.models \
-    import factories as rbac_factories
 
 from appengine import base
 
@@ -27,16 +25,18 @@ class TestFilterByAuditor(TestCase):
     self.api = Api()
     self.generator = ObjectGenerator()
     _, self.auditor = self.generator.generate_person(user_role="Creator")
-    auditor_role = all_models.Role.query.filter_by(name="Auditor").first()
+    auditor_role = all_models.AccessControlRole.query.filter_by(
+        name="Auditors").one()
     with factories.single_commit():
       self.audit = factories.AuditFactory(status="In Progress")
       self.audit_id = self.audit.id
       audit_context = factories.ContextFactory()
       self.audit.context = audit_context
-      rbac_factories.UserRoleFactory(
-          context=audit_context,
-          role=auditor_role,
-          person=self.auditor)
+      factories.AccessControlListFactory(
+          ac_role=auditor_role,
+          object=self.audit,
+          person=self.auditor
+      )
     self.api.set_user(self.auditor)
 
   def test_query_audits_by_auditor(self):

--- a/test/integration/ggrc_basic_permissions/test_issue_mapping.py
+++ b/test/integration/ggrc_basic_permissions/test_issue_mapping.py
@@ -39,9 +39,10 @@ class TestIssueMapping(TestCase):
   def setup_roles(self):
     """Setup necessary roles needed by the tests"""
     query = all_models.Role.query
+    acr_query = all_models.AccessControlRole.query
     self.roles = {
         'creator': query.filter_by(name="Creator").first(),
-        'auditor': query.filter_by(name="Auditor").first(),
+        'auditors': acr_query.filter_by(name="Auditors").first(),
         'program_editor': query.filter_by(name="ProgramEditor").first()
     }
 
@@ -96,10 +97,11 @@ class TestIssueMapping(TestCase):
     )
 
     # Add auditor & program editor roles
-    rbac_factories.UserRoleFactory(
-        context=audit.context,
-        role=self.roles['auditor'],
-        person=self.users['auditor'])
+    factories.AccessControlListFactory(
+        ac_role=self.roles['auditors'],
+        object=audit,
+        person=self.users['auditor']
+    )
     rbac_factories.UserRoleFactory(
         context=audit.program.context,
         role=self.roles['program_editor'],


### PR DESCRIPTION
# Issue description

Because we couldn't remove audit contexts in scope of audit acl the
auditor role needed to be kept around until we remove them completely.
The side affect was that old auditors set before the migration would not
get properly removed after the migration (acl records got removed, but
the user roles didn't) this caused phantom auditor permissions to remain
in the app. This fix solves the problem by removing all permissions from
the old auditor role. After we remove Program and Workflow user roles we
will be abel to remove the roles completely.

# Steps to test the changes

1. Make sure you have an audit with the old auditor
2. Run the audit acl migration
3. Go to the audit and remove the auditor

Expected: The auditor does not have audit access anymore
Actual: The auditor still has auditor access

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [ ] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
