### PR TITLE
GGRC-3158,4154 Fix LCA dropdown field validation

### DIFF
--- a/src/ggrc/assets/javascripts/components/assessment/assessment-local-ca.js
+++ b/src/ggrc/assets/javascripts/components/assessment/assessment-local-ca.js
@@ -46,10 +46,6 @@ import Permission from '../../permission';
         },
         evidenceAmount: {
           type: 'number',
-          set: function (newValue, setValue) {
-            setValue(newValue);
-            this.validateForm();
-          },
         },
         isEvidenceRequired: {
           get: function () {
@@ -233,6 +229,9 @@ import Permission from '../../permission';
       },
     },
     events: {
+      '{viewModel} evidenceAmount': function () {
+        this.viewModel.validateForm();
+      },
       '{viewModel.instance} afterCommentCreated': function () {
         this.viewModel.validateForm();
       },

--- a/src/ggrc/assets/javascripts/components/assessment/assessment-local-ca.js
+++ b/src/ggrc/assets/javascripts/components/assessment/assessment-local-ca.js
@@ -64,7 +64,10 @@ import Permission from '../../permission';
           },
         },
       },
-      validateForm: function (triggerAttachmentModals = false) {
+      validateForm: function ({
+        triggerField = null,
+        triggerAttachmentModals = false,
+      } = {}) {
         let hasValidationErrors = false;
         this.attr('fields')
           .each((field) => {
@@ -223,7 +226,10 @@ import Permission from '../../permission';
           e.field.attr('errorsMap.comment', true);
         }
 
-        this.performValidation({field: e.field, triggerAttachmentModals: true});
+        this.validateForm({
+          triggerAttachmentModals: true,
+          triggerField: e.field,
+        });
         this.attr('formSavedDeferred', can.Deferred());
         this.save(e.fieldId, e.value);
       },

--- a/src/ggrc/assets/javascripts/components/assessment/assessment-local-ca.js
+++ b/src/ggrc/assets/javascripts/components/assessment/assessment-local-ca.js
@@ -77,11 +77,11 @@ import Permission from '../../permission';
           },
         },
       },
-      validateForm: function (formInit = false) {
+      validateForm: function () {
         var self = this;
         this.attr('fields')
           .each(function (field) {
-            self.performValidation({field, formInit});
+            self.performValidation({field});
           });
         if (this.attr('instance.hasValidationErrors')) {
           this.dispatch(VALIDATION_ERROR);
@@ -89,7 +89,6 @@ import Permission from '../../permission';
       },
       performValidation: function ({
         field,
-        formInit = false,
         triggerAttachmentModals = false,
       }) {
         var fieldValid;
@@ -118,8 +117,7 @@ import Permission from '../../permission';
         hasMissingEvidence = requiresEvidence &&
           !!this.attr('isEvidenceRequired');
 
-        hasMissingComment = formInit ?
-          requiresComment && !!errorsMap.comment : requiresComment;
+        hasMissingComment = requiresComment && !!errorsMap.comment;
 
         if (field.type === 'checkbox') {
           if (value === '1') {
@@ -223,12 +221,6 @@ import Permission from '../../permission';
       },
     },
     events: {
-      inserted: function () {
-        this.viewModel.validateForm(true);
-      },
-      '{viewModel.instance} update': function () {
-        this.viewModel.validateForm();
-      },
       '{viewModel.instance} afterCommentCreated': function () {
         this.viewModel.validateForm();
       },

--- a/src/ggrc/assets/javascripts/components/assessment/assessment-local-ca.js
+++ b/src/ggrc/assets/javascripts/components/assessment/assessment-local-ca.js
@@ -71,7 +71,7 @@ import Permission from '../../permission';
         let hasValidationErrors = false;
         this.attr('fields')
           .each((field) => {
-            this.performValidation({field, triggerAttachmentModals});
+            this.performValidation(field);
             if ( !field.validation.valid ) {
               hasValidationErrors = true;
             }
@@ -93,10 +93,7 @@ import Permission from '../../permission';
           this.dispatch(VALIDATION_ERROR);
         }
       },
-      performValidation: function ({
-        field,
-        triggerAttachmentModals = false,
-      }) {
+      performValidation: function (field) {
         var fieldValid;
         var hasMissingEvidence;
         var hasMissingComment;

--- a/src/ggrc/assets/javascripts/components/assessment/assessment-local-ca.js
+++ b/src/ggrc/assets/javascripts/components/assessment/assessment-local-ca.js
@@ -213,8 +213,21 @@ import Permission from '../../permission';
           stopFn();
         });
       },
+      fieldRequiresComment: function (field) {
+        let fieldValidationConf = field.validationConfig[field.value];
+          return fieldValidationConf === CA_DD_REQUIRED_DEPS.COMMENT ||
+            fieldValidationConf === CA_DD_REQUIRED_DEPS.COMMENT_AND_EVIDENCE;
+      },
       attributeChanged: function (e) {
         e.field.attr('value', e.value);
+
+        // Removes "link" with the comment for DD field and
+        // makes it require a new one
+        if ( e.field.attr('type') === 'dropdown' &&
+            this.fieldRequiresComment(e.field) ) {
+          e.field.attr('errorsMap.comment', true);
+        }
+
         this.performValidation({field: e.field, triggerAttachmentModals: true});
         this.attr('formSavedDeferred', can.Deferred());
         this.save(e.fieldId, e.value);

--- a/src/ggrc/assets/javascripts/components/assessment/assessment-local-ca.js
+++ b/src/ggrc/assets/javascripts/components/assessment/assessment-local-ca.js
@@ -75,6 +75,14 @@ import Permission from '../../permission';
             if ( !field.validation.valid ) {
               hasValidationErrors = true;
             }
+            if ( triggerField === field &&
+                 triggerAttachmentModals &&
+                 field.validation.hasMissingInfo ) {
+              this.dispatch({
+                type: 'validationChanged',
+                field,
+              });
+            }
           });
 
         if ( this.attr('instance') ) {
@@ -148,14 +156,6 @@ import Permission from '../../permission';
               comment: hasMissingComment,
             },
           });
-
-          if (triggerAttachmentModals &&
-              (hasMissingEvidence || hasMissingComment)) {
-            this.dispatch({
-              type: 'validationChanged',
-              field: field,
-            });
-          }
         } else {
           // validation for all other fields
           field.attr({

--- a/src/ggrc/assets/javascripts/components/assessment/assessment-local-ca.js
+++ b/src/ggrc/assets/javascripts/components/assessment/assessment-local-ca.js
@@ -8,7 +8,7 @@ import {
   applyChangesToCustomAttributeValue,
 }
   from '../../plugins/utils/ca-utils';
-import {VALIDATION_ERROR} from '../../events/eventTypes';
+import {VALIDATION_ERROR, RELATED_ITEMS_LOADED} from '../../events/eventTypes';
 import tracker from '../../tracker';
 import Permission from '../../permission';
 
@@ -233,6 +233,9 @@ import Permission from '../../permission';
         this.viewModel.validateForm();
       },
       '{viewModel.instance} afterCommentCreated': function () {
+        this.viewModel.validateForm();
+      },
+      [`{viewModel.instance} ${RELATED_ITEMS_LOADED.type}`]: function () {
         this.viewModel.validateForm();
       },
       '{viewModel.instance} showInvalidField': function (ev) {

--- a/src/ggrc/assets/javascripts/components/assessment/assessment-local-ca.js
+++ b/src/ggrc/assets/javascripts/components/assessment/assessment-local-ca.js
@@ -26,15 +26,6 @@ import Permission from '../../permission';
       highlightInvalidFields: false,
 
       define: {
-        hasValidationErrors: {
-          type: 'boolean',
-          get: function () {
-            return this.attr('fields')
-              .filter(function (field) {
-                return !field.attr('validation.valid');
-              }).length;
-          },
-        },
         editMode: {
           type: 'boolean',
           value: false,
@@ -77,13 +68,21 @@ import Permission from '../../permission';
           },
         },
       },
-      validateForm: function () {
-        var self = this;
+      validateForm: function (triggerAttachmentModals = false) {
+        let hasValidationErrors = false;
         this.attr('fields')
-          .each(function (field) {
-            self.performValidation({field});
+          .each((field) => {
+            this.performValidation({field, triggerAttachmentModals});
+            if ( !field.validation.valid ) {
+              hasValidationErrors = true;
+            }
           });
-        if (this.attr('instance.hasValidationErrors')) {
+
+        if ( this.attr('instance') ) {
+          this.attr('instance._hasValidationErrors', hasValidationErrors);
+        }
+
+        if ( hasValidationErrors ) {
           this.dispatch(VALIDATION_ERROR);
         }
       },

--- a/src/ggrc/assets/javascripts/components/assessment/assessment-local-ca.js
+++ b/src/ggrc/assets/javascripts/components/assessment/assessment-local-ca.js
@@ -87,7 +87,11 @@ import Permission from '../../permission';
           this.dispatch(VALIDATION_ERROR);
         }
       },
-      performValidation: function ({field, formInit = false}) {
+      performValidation: function ({
+        field,
+        formInit = false,
+        triggerAttachmentModals = false,
+      }) {
         var fieldValid;
         var hasMissingEvidence;
         var hasMissingComment;
@@ -149,7 +153,8 @@ import Permission from '../../permission';
             },
           });
 
-          if (!formInit && (hasMissingEvidence || hasMissingComment)) {
+          if (triggerAttachmentModals &&
+              (hasMissingEvidence || hasMissingComment)) {
             this.dispatch({
               type: 'validationChanged',
               field: field,
@@ -212,7 +217,7 @@ import Permission from '../../permission';
       },
       attributeChanged: function (e) {
         e.field.attr('value', e.value);
-        this.performValidation({field: e.field});
+        this.performValidation({field: e.field, triggerAttachmentModals: true});
         this.attr('formSavedDeferred', can.Deferred());
         this.save(e.fieldId, e.value);
       },

--- a/src/ggrc/assets/javascripts/components/assessment/assessment-local-ca.js
+++ b/src/ggrc/assets/javascripts/components/assessment/assessment-local-ca.js
@@ -77,17 +77,17 @@ import Permission from '../../permission';
           },
         },
       },
-      validateForm: function () {
+      validateForm: function (formInit = false) {
         var self = this;
         this.attr('fields')
           .each(function (field) {
-            self.performValidation(field, true);
+            self.performValidation({field, formInit});
           });
         if (this.attr('instance.hasValidationErrors')) {
           this.dispatch(VALIDATION_ERROR);
         }
       },
-      performValidation: function (field, formInitCheck) {
+      performValidation: function ({field, formInit = false}) {
         var fieldValid;
         var hasMissingEvidence;
         var hasMissingComment;
@@ -114,7 +114,7 @@ import Permission from '../../permission';
         hasMissingEvidence = requiresEvidence &&
           !!this.attr('isEvidenceRequired');
 
-        hasMissingComment = formInitCheck ?
+        hasMissingComment = formInit ?
           requiresComment && !!errorsMap.comment : requiresComment;
 
         if (field.type === 'checkbox') {
@@ -149,7 +149,7 @@ import Permission from '../../permission';
             },
           });
 
-          if (!formInitCheck && (hasMissingEvidence || hasMissingComment)) {
+          if (!formInit && (hasMissingEvidence || hasMissingComment)) {
             this.dispatch({
               type: 'validationChanged',
               field: field,
@@ -212,14 +212,14 @@ import Permission from '../../permission';
       },
       attributeChanged: function (e) {
         e.field.attr('value', e.value);
-        this.performValidation(e.field);
+        this.performValidation({field: e.field});
         this.attr('formSavedDeferred', can.Deferred());
         this.save(e.fieldId, e.value);
       },
     },
     events: {
       inserted: function () {
-        this.viewModel.validateForm();
+        this.viewModel.validateForm(true);
       },
       '{viewModel.instance} update': function () {
         this.viewModel.validateForm();

--- a/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.js
+++ b/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.js
@@ -47,7 +47,7 @@ import {
 } from '../../../plugins/utils/ca-utils';
 import DeferredTransaction from '../../../plugins/utils/deferred-transaction-utils';
 import tracker from '../../../tracker';
-import {REFRESH_TAB_CONTENT} from '../../../events/eventTypes';
+import {REFRESH_TAB_CONTENT, RELATED_ITEMS_LOADED} from '../../../events/eventTypes';
 import Permission from '../../../permission';
 import template from './info-pane.mustache';
 
@@ -395,6 +395,7 @@ import template from './info-pane.mustache';
             this.attr('referenceUrls').replace(data['Document:REFERENCE_URL']);
 
             this.attr('isUpdatingRelatedItems', false);
+            this.attr('instance').dispatch(RELATED_ITEMS_LOADED);
 
             tracker.stop(this.attr('instance.type'),
               tracker.USER_JOURNEY_KEYS.NAVIGATION,

--- a/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.mustache
+++ b/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.mustache
@@ -191,7 +191,6 @@
                         {instance}="instance"
                         {deferred-save}="deferredSave"
                         {evidence-amount}="evidences.length"
-                        {^has-validation-errors}="instance.hasValidationErrors"
                         {fields}="formFields"
                         {edit-mode}="editMode"
                         {^saving}="formState.saving"

--- a/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.mustache
+++ b/src/ggrc/assets/javascripts/components/assessment/info-pane/info-pane.mustache
@@ -82,7 +82,7 @@
                 </div>
                 <div class="assessment-controls info-pane__section">
                     <div class="assessment-note">
-			<custom-attributes-status
+                      <custom-attributes-status
                                 {form-saving}="formState.saving"
                                 {is-dirty}="formState.isDirty">
                                 <loading-status
@@ -91,7 +91,7 @@
                                     always-Show-Text="true"
                                     show-Spinner="true">
                                 </loading-status>
-			</custom-attributes-status>
+                      </custom-attributes-status>
                         <i class="fa fa-question-circle" rel="tooltip"
                            data-original-title="Respond to assessment here. Use comments on the right for free text responses."></i>
                     </div>
@@ -199,11 +199,11 @@
                         {^is-dirty}="formState.isDirty"
                         (validation-error)="setLastErrorTab(tabIndex)"
                         (validation-changed)="showRequiredInfoModal(%event)">
-			<custom-attributes
+                      <custom-attributes
                             {fields}="fields"
                             {edit-mode}="editMode"
                             (value-changed)="attributeChanged(%event)">
-			</custom-attributes>
+                      </custom-attributes>
                     </assessment-local-ca>
                     <!-- Modal Window to fix validation issues of CA fields -->
                     {{#if modal.state}}
@@ -212,7 +212,7 @@
                                     {instance}="instance"
                                     {is-disabled}="isUpdatingEvidences">
                           <ca-object-modal-content {instance}="instance"
-						   {assessment-type-objects}="assessmentTypeObjects"
+                                                   {assessment-type-objects}="assessmentTypeObjects"
                                                    {content}="modal.content"
                                                    {state}="state"
                                                    {evidences}="evidences"

--- a/src/ggrc/assets/javascripts/components/assessment/tests/assessment-local-ca_spec.js
+++ b/src/ggrc/assets/javascripts/components/assessment/tests/assessment-local-ca_spec.js
@@ -106,7 +106,7 @@ describe('assessmentLocalCa component', () => {
       viewModel.attr('fields', [checkboxField]);
       dropdownField.attr('value', null);
 
-      performValidation(checkboxField);
+      performValidation({field: checkboxField});
 
       expect(checkboxField.attr().validation).toEqual({
         show: false,
@@ -115,7 +115,7 @@ describe('assessmentLocalCa component', () => {
         mandatory: false,
       });
 
-      performValidation(checkboxField);
+      performValidation({field: checkboxField});
 
       expect(checkboxField.attr().validation).toEqual({
         show: false,
@@ -130,7 +130,7 @@ describe('assessmentLocalCa component', () => {
       checkboxField.attr('value', null);
       checkboxField.attr('validation.mandatory', true);
 
-      performValidation(checkboxField);
+      performValidation({field: checkboxField});
       expect(checkboxField.attr().validation).toEqual({
         mandatory: true,
         show: true,
@@ -139,7 +139,7 @@ describe('assessmentLocalCa component', () => {
       });
 
       checkboxField.attr('value', 0);
-      performValidation(checkboxField);
+      performValidation({field: checkboxField});
       expect(checkboxField.attr().validation).toEqual({
         mandatory: true,
         show: true,
@@ -148,7 +148,7 @@ describe('assessmentLocalCa component', () => {
       });
 
       checkboxField.attr('value', 1);
-      performValidation(checkboxField);
+      performValidation({field: checkboxField});
       expect(checkboxField.attr().validation).toEqual({
         mandatory: true,
         show: true,
@@ -157,7 +157,7 @@ describe('assessmentLocalCa component', () => {
       });
 
       checkboxField.attr('value', '1');
-      performValidation(checkboxField);
+      performValidation({field: checkboxField});
       expect(checkboxField.attr().validation).toEqual({
         mandatory: true,
         show: true,
@@ -170,7 +170,7 @@ describe('assessmentLocalCa component', () => {
       viewModel.attr('fields', [inputField]);
       inputField.attr('value', '');
 
-      performValidation(inputField);
+      performValidation({field: inputField});
       expect(inputField.attr().validation).toEqual({
         mandatory: false,
         show: false,
@@ -179,7 +179,7 @@ describe('assessmentLocalCa component', () => {
       });
 
       inputField.attr('value', 'some input');
-      performValidation(inputField);
+      performValidation({field: inputField});
       expect(inputField.attr().validation).toEqual({
         mandatory: false,
         show: false,
@@ -194,7 +194,7 @@ describe('assessmentLocalCa component', () => {
 
       inputField.attr('validation.mandatory', true);
 
-      performValidation(inputField);
+      performValidation({field: inputField});
       expect(inputField.attr().validation).toEqual({
         mandatory: true,
         show: true,
@@ -203,7 +203,7 @@ describe('assessmentLocalCa component', () => {
       });
 
       inputField.attr('value', 'some input');
-      performValidation(inputField);
+      performValidation({field: inputField});
       expect(inputField.attr().validation).toEqual({
         mandatory: true,
         show: true,
@@ -217,7 +217,7 @@ describe('assessmentLocalCa component', () => {
       viewModel.attr('fields', [dropdownField]);
       dropdownField.attr('value', '');
 
-      performValidation(dropdownField);
+      performValidation({field: dropdownField});
       expect(dropdownField.attr().validation).toEqual({
         mandatory: false,
         show: false,
@@ -235,7 +235,7 @@ describe('assessmentLocalCa component', () => {
       viewModel.attr('fields', [dropdownField]);
       dropdownField.attr('value', 'nothing required');
 
-      performValidation(dropdownField);
+      performValidation({field: dropdownField});
       expect(dropdownField.attr().validation).toEqual({
         mandatory: false,
         show: true,
@@ -255,7 +255,7 @@ describe('assessmentLocalCa component', () => {
       dropdownField.attr('value', 'comment required');
 
       dropdownField.attr('errorsMap.comment', true);
-      performValidation(dropdownField, true);
+      performValidation({field: dropdownField});
 
       expect(dropdownField.attr().validation).toEqual({
         mandatory: false,
@@ -275,7 +275,7 @@ describe('assessmentLocalCa component', () => {
       viewModel.attr('fields', [dropdownField]);
       dropdownField.attr('value', 'comment required');
 
-      performValidation(dropdownField, true);
+      performValidation({field: dropdownField});
 
       expect(dropdownField.attr().validation).toEqual({
         mandatory: false,
@@ -296,7 +296,7 @@ describe('assessmentLocalCa component', () => {
       dropdownField.attr('value', 'evidence required');
 
       dropdownField.attr('errorsMap.evidence', true);
-      performValidation(dropdownField);
+      performValidation({field: dropdownField});
 
       expect(viewModel.attr('evidenceAmount')).toBe(0);
       expect(dropdownField.attr().validation).toEqual({
@@ -318,7 +318,7 @@ describe('assessmentLocalCa component', () => {
       viewModel.attr('evidenceAmount', 1);
       dropdownField.attr('value', 'evidence required');
 
-      performValidation(dropdownField, true);
+      performValidation({field: dropdownField});
 
       expect(dropdownField.attr().validation).toEqual({
         mandatory: false,
@@ -341,7 +341,7 @@ describe('assessmentLocalCa component', () => {
       dropdownField.attr('errorsMap.comment', true);
       dropdownField.attr('errorsMap.evidence', true);
 
-      performValidation(dropdownField, true);
+      performValidation({field: dropdownField});
 
       expect(dropdownField.attr().validation).toEqual({
         mandatory: false,
@@ -362,7 +362,7 @@ describe('assessmentLocalCa component', () => {
       dropdownField.attr('value', 'com+ev required');
 
       dropdownField.attr('errorsMap.evidence', true);
-      performValidation(dropdownField, true);
+      performValidation({field: dropdownField});
 
       expect(dropdownField.attr().validation).toEqual({
         mandatory: false,
@@ -385,7 +385,7 @@ describe('assessmentLocalCa component', () => {
       dropdownField.attr('value', 'com+ev required');
       dropdownField.attr('errorsMap.comment', true);
 
-      performValidation(dropdownField);
+      performValidation({field: dropdownField});
 
       expect(dropdownField.attr().validation).toEqual({
         mandatory: false,
@@ -406,7 +406,7 @@ describe('assessmentLocalCa component', () => {
       viewModel.attr('evidenceAmount', 1);
 
       dropdownField.attr('value', 'com+ev required');
-      performValidation(dropdownField, true);
+      performValidation({field: dropdownField});
 
       expect(dropdownField.attr().validation).toEqual({
         mandatory: false,

--- a/src/ggrc/assets/javascripts/components/assessment/tests/assessment-local-ca_spec.js
+++ b/src/ggrc/assets/javascripts/components/assessment/tests/assessment-local-ca_spec.js
@@ -106,7 +106,7 @@ describe('assessmentLocalCa component', () => {
       viewModel.attr('fields', [checkboxField]);
       dropdownField.attr('value', null);
 
-      performValidation({field: checkboxField});
+      performValidation(checkboxField);
 
       expect(checkboxField.attr().validation).toEqual({
         show: false,
@@ -115,7 +115,7 @@ describe('assessmentLocalCa component', () => {
         mandatory: false,
       });
 
-      performValidation({field: checkboxField});
+      performValidation(checkboxField);
 
       expect(checkboxField.attr().validation).toEqual({
         show: false,
@@ -130,7 +130,7 @@ describe('assessmentLocalCa component', () => {
       checkboxField.attr('value', null);
       checkboxField.attr('validation.mandatory', true);
 
-      performValidation({field: checkboxField});
+      performValidation(checkboxField);
       expect(checkboxField.attr().validation).toEqual({
         mandatory: true,
         show: true,
@@ -139,7 +139,7 @@ describe('assessmentLocalCa component', () => {
       });
 
       checkboxField.attr('value', 0);
-      performValidation({field: checkboxField});
+      performValidation(checkboxField);
       expect(checkboxField.attr().validation).toEqual({
         mandatory: true,
         show: true,
@@ -148,7 +148,7 @@ describe('assessmentLocalCa component', () => {
       });
 
       checkboxField.attr('value', 1);
-      performValidation({field: checkboxField});
+      performValidation(checkboxField);
       expect(checkboxField.attr().validation).toEqual({
         mandatory: true,
         show: true,
@@ -157,7 +157,7 @@ describe('assessmentLocalCa component', () => {
       });
 
       checkboxField.attr('value', '1');
-      performValidation({field: checkboxField});
+      performValidation(checkboxField);
       expect(checkboxField.attr().validation).toEqual({
         mandatory: true,
         show: true,
@@ -170,7 +170,7 @@ describe('assessmentLocalCa component', () => {
       viewModel.attr('fields', [inputField]);
       inputField.attr('value', '');
 
-      performValidation({field: inputField});
+      performValidation(inputField);
       expect(inputField.attr().validation).toEqual({
         mandatory: false,
         show: false,
@@ -179,7 +179,7 @@ describe('assessmentLocalCa component', () => {
       });
 
       inputField.attr('value', 'some input');
-      performValidation({field: inputField});
+      performValidation(inputField);
       expect(inputField.attr().validation).toEqual({
         mandatory: false,
         show: false,
@@ -194,7 +194,7 @@ describe('assessmentLocalCa component', () => {
 
       inputField.attr('validation.mandatory', true);
 
-      performValidation({field: inputField});
+      performValidation(inputField);
       expect(inputField.attr().validation).toEqual({
         mandatory: true,
         show: true,
@@ -203,7 +203,7 @@ describe('assessmentLocalCa component', () => {
       });
 
       inputField.attr('value', 'some input');
-      performValidation({field: inputField});
+      performValidation(inputField);
       expect(inputField.attr().validation).toEqual({
         mandatory: true,
         show: true,
@@ -217,7 +217,7 @@ describe('assessmentLocalCa component', () => {
       viewModel.attr('fields', [dropdownField]);
       dropdownField.attr('value', '');
 
-      performValidation({field: dropdownField});
+      performValidation(dropdownField);
       expect(dropdownField.attr().validation).toEqual({
         mandatory: false,
         show: false,
@@ -235,7 +235,7 @@ describe('assessmentLocalCa component', () => {
       viewModel.attr('fields', [dropdownField]);
       dropdownField.attr('value', 'nothing required');
 
-      performValidation({field: dropdownField});
+      performValidation(dropdownField);
       expect(dropdownField.attr().validation).toEqual({
         mandatory: false,
         show: true,
@@ -255,7 +255,7 @@ describe('assessmentLocalCa component', () => {
       dropdownField.attr('value', 'comment required');
 
       dropdownField.attr('errorsMap.comment', true);
-      performValidation({field: dropdownField});
+      performValidation(dropdownField);
 
       expect(dropdownField.attr().validation).toEqual({
         mandatory: false,
@@ -275,7 +275,7 @@ describe('assessmentLocalCa component', () => {
       viewModel.attr('fields', [dropdownField]);
       dropdownField.attr('value', 'comment required');
 
-      performValidation({field: dropdownField});
+      performValidation(dropdownField);
 
       expect(dropdownField.attr().validation).toEqual({
         mandatory: false,
@@ -296,7 +296,7 @@ describe('assessmentLocalCa component', () => {
       dropdownField.attr('value', 'evidence required');
 
       dropdownField.attr('errorsMap.evidence', true);
-      performValidation({field: dropdownField});
+      performValidation(dropdownField);
 
       expect(viewModel.attr('evidenceAmount')).toBe(0);
       expect(dropdownField.attr().validation).toEqual({
@@ -318,7 +318,7 @@ describe('assessmentLocalCa component', () => {
       viewModel.attr('evidenceAmount', 1);
       dropdownField.attr('value', 'evidence required');
 
-      performValidation({field: dropdownField});
+      performValidation(dropdownField);
 
       expect(dropdownField.attr().validation).toEqual({
         mandatory: false,
@@ -341,7 +341,7 @@ describe('assessmentLocalCa component', () => {
       dropdownField.attr('errorsMap.comment', true);
       dropdownField.attr('errorsMap.evidence', true);
 
-      performValidation({field: dropdownField});
+      performValidation(dropdownField);
 
       expect(dropdownField.attr().validation).toEqual({
         mandatory: false,
@@ -362,7 +362,7 @@ describe('assessmentLocalCa component', () => {
       dropdownField.attr('value', 'com+ev required');
 
       dropdownField.attr('errorsMap.evidence', true);
-      performValidation({field: dropdownField});
+      performValidation(dropdownField);
 
       expect(dropdownField.attr().validation).toEqual({
         mandatory: false,
@@ -385,7 +385,7 @@ describe('assessmentLocalCa component', () => {
       dropdownField.attr('value', 'com+ev required');
       dropdownField.attr('errorsMap.comment', true);
 
-      performValidation({field: dropdownField});
+      performValidation(dropdownField);
 
       expect(dropdownField.attr().validation).toEqual({
         mandatory: false,
@@ -406,7 +406,7 @@ describe('assessmentLocalCa component', () => {
       viewModel.attr('evidenceAmount', 1);
 
       dropdownField.attr('value', 'com+ev required');
-      performValidation({field: dropdownField});
+      performValidation(dropdownField);
 
       expect(dropdownField.attr().validation).toEqual({
         mandatory: false,
@@ -473,7 +473,10 @@ describe('assessmentLocalCa component', () => {
         });
 
         attributeChanged(fieldChangeEvent);
-        expect(validateFormSpy).toHaveBeenCalledWith(true);
+        expect(validateFormSpy).toHaveBeenCalledWith({
+          triggerField: inputField,
+          triggerAttachmentModals: true,
+        });
         expect(saveSpy).toHaveBeenCalledWith(inputField.id, inputField.value);
         expect(inputField.attr('value')).toEqual(fieldChangeEvent.value);
       });
@@ -487,7 +490,10 @@ describe('assessmentLocalCa component', () => {
         });
 
         attributeChanged(fieldChangeEvent);
-        expect(validateFormSpy).toHaveBeenCalledWith(true);
+        expect(validateFormSpy).toHaveBeenCalledWith({
+          triggerField: dropdownField,
+          triggerAttachmentModals: true,
+        });
         expect(saveSpy)
           .toHaveBeenCalledWith(dropdownField.id, dropdownField.value);
         expect(dropdownField.attr('value')).toEqual(fieldChangeEvent.value);

--- a/src/ggrc/assets/javascripts/components/object-state-toolbar/object-state-toolbar.js
+++ b/src/ggrc/assets/javascripts/components/object-state-toolbar/object-state-toolbar.js
@@ -44,7 +44,7 @@ import template from './object-state-toolbar.mustache';
         hasErrors: {
           get: function () {
             return this.attr('instance.preconditions_failed') ||
-              this.attr('instance.hasValidationErrors');
+              this.attr('instance._hasValidationErrors');
           }
         },
         isDisabled: {
@@ -71,7 +71,7 @@ import template from './object-state-toolbar.mustache';
       },
       changeState: function (newState, isUndo) {
         if (this.attr('isDisabled')) {
-          if (this.attr('instance.hasValidationErrors')) {
+          if (this.attr('instance._hasValidationErrors')) {
             this.attr('instance').dispatch(SWITCH_TO_ERROR_PANEL);
             this.attr('instance').dispatch(SHOW_INVALID_FIELD);
           }

--- a/src/ggrc/assets/javascripts/components/object-state-toolbar/object-state-toolbar.js
+++ b/src/ggrc/assets/javascripts/components/object-state-toolbar/object-state-toolbar.js
@@ -41,19 +41,6 @@ import template from './object-state-toolbar.mustache';
             return this.attr('verifiers').length;
           }
         },
-        hasErrors: {
-          get: function () {
-            return this.attr('instance.preconditions_failed') ||
-              this.attr('instance._hasValidationErrors');
-          }
-        },
-        isDisabled: {
-          get: function () {
-            return !!this.attr('instance._disabled') ||
-              this.attr('hasErrors') ||
-              this.attr('instance.isPending');
-          }
-        }
       },
       verifiers: [],
       instance: {},
@@ -70,11 +57,9 @@ import template from './object-state-toolbar.mustache';
         return !!this.attr('instance.previousStatus');
       },
       changeState: function (newState, isUndo) {
-        if (this.attr('isDisabled')) {
-          if (this.attr('instance._hasValidationErrors')) {
-            this.attr('instance').dispatch(SWITCH_TO_ERROR_PANEL);
-            this.attr('instance').dispatch(SHOW_INVALID_FIELD);
-          }
+        if (this.attr('instance._hasValidationErrors')) {
+          this.attr('instance').dispatch(SWITCH_TO_ERROR_PANEL);
+          this.attr('instance').dispatch(SHOW_INVALID_FIELD);
           return;
         }
 

--- a/src/ggrc/assets/javascripts/events/eventTypes.js
+++ b/src/ggrc/assets/javascripts/events/eventTypes.js
@@ -114,6 +114,17 @@ const REFRESH_COMMENTS = {
   type: 'refreshComments',
 };
 
+/**
+ * Notifies that related items are loaded
+ * @event RELATED_ITEMS_LOADED
+ * @type {object}
+ * @property {string} type - Event name.
+ */
+const RELATED_ITEMS_LOADED = {
+  type: 'RELATED_ITEMS_LOADED',
+};
+
+
 export {
   REFRESH_RELATED,
   SAVE_CUSTOM_ROLE,
@@ -126,4 +137,5 @@ export {
   NAVIGATE_TO_TAB,
   REFRESH_PROPOSAL_DIFF,
   REFRESH_COMMENTS,
+  RELATED_ITEMS_LOADED,
 };


### PR DESCRIPTION
# Issue description
This is a proper fix for the ticket GGRC-3158 which also fixes the regression ( GGRC-4154 ).
This PR fixes several issues:
1. LCA dropdown fields with evidence required show wrong validation statuses before the attachments are loaded.
3. Regression which brought by original PR. When info-pane opened for the first time, click on Complete button closes all tabs on info-pane.
3. DD field validation is not triggered when connected field changed. By connected fields I mean DD fields which both require evidence.
 
# Steps to test the changes

__1st case: Dropdown field validation on initial form load__
1. Create Assessment with 2 dropdown fields and values which require evidences.
2. Switch dropdown to "evidence required" values and add 2 evidences to the assessment.
3. Switch network throttling in chrome devtools to "slow 3G" and reopen assessment info pane.
4. Validation of the dropdown fields does not switch to "invalid" during all stages of form data loading.

__2nd case: Closing tabs__
1. Open fresh Audit page with Assessments tab ( or reload )
2. Click on any 'in-progress' assessment to open info-pane
3. Click on complete button. 
4. Tabs should remain opened.

__3rd case: Nearby DD field validation__
1. Create assessment with 2 DD fields with values which require evidence.
2. Open assessment and switch both fields to 'evidence required' value ( discard attachment dialogs )
3. Attach one file.
4. Switch one of the DD fields to value-not-selected ('--') and see that the nearby field is validated and marked as valid.

# Solution description
1. Validate field only when all related data loaded.
2. Replace hasValidationErrors compute property ( which has a caching issue ) with a hidden property on instance which is explicitly assigned upon form validation.
3. Validate entire form on field value change because field validity can depend on values of each other ( DD fields with evidence required ).

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x]  My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".