### PR TITLE
GGRC-3858 After updating audit to the latest version, new object tabs are not shown up in HNB

### DIFF
--- a/src/ggrc/assets/javascripts/plugins/tests/current-page-utils_spec.js
+++ b/src/ggrc/assets/javascripts/plugins/tests/current-page-utils_spec.js
@@ -477,9 +477,11 @@ describe('GGRC Utils CurrentPage', function () {
   describe('refreshCounts() method', function () {
     var widgets;
     var refreshCounts;
+    let countsMap;
 
     beforeEach(function () {
       refreshCounts = CurrentPageUtils.refreshCounts;
+      countsMap = CurrentPageUtils.getCounts();
 
       widgets =
         {
@@ -535,8 +537,8 @@ describe('GGRC Utils CurrentPage', function () {
           expect(reqParamNames).toContain('Program');
           expect(reqParamNames).toContain('Assessment');
           expect(reqParamNames).toContain('Audit');
-          expect(counts.Audit).toEqual(4);
-          expect(counts.Program).toEqual(0);
+          expect(countsMap.attr('Audit')).toEqual(4);
+          expect(countsMap.attr('Program')).toEqual(0);
           done();
         });
     });

--- a/src/ggrc/assets/javascripts/plugins/utils/current-page-utils.js
+++ b/src/ggrc/assets/javascripts/plugins/utils/current-page-utils.js
@@ -256,7 +256,7 @@ function refreshCounts() {
 
   widgets = getWidgetModels(pageInstance.constructor.shortName, location);
 
-  return _initWidgetCounts(widgets, pageInstance.type, pageInstance.id);
+  return initWidgetCounts(widgets, pageInstance.type, pageInstance.id);
 }
 
 function _getCurrentUser() {


### PR DESCRIPTION
# Issue description

**Actual Result:** After updating audit to the latest version, new object tabs are not shown up in HNB. User have to select the tab from the list by clicking Add tab
**Expected Result:** After updating audit to the latest version, new object tabs should be shown up in HNB

# Steps to test the changes

1. Have a program with mapped control
2. On the program page create an audit
3. Open audit info page
4. Return back to the program page and create and map a new object to the program, e.g. 'Standards' screenshot-1.png
5. Update the audit to the latest version screenshot-2.png
6. Look at the HNB: 'STANDARDS' tab is not shown up

# Solution description

Update widget's counts

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
