### PR TITLE
GGRC-4208/4250 Global Editor/Reader/Creator missed permissions for TaskGroup creation

### DIFF
--- a/src/ggrc/rbac/permissions_provider.py
+++ b/src/ggrc/rbac/permissions_provider.py
@@ -157,6 +157,12 @@ def is_auditor(instance, **_):
   return any(acl for acl in instance.audit.access_control_list
              if acl.ac_role.name == "Auditors" and acl.person == current_user)
 
+
+def is_workflow_admin(instance, **_):
+  """Check if current user has Admin role in scope of parent Workflow object"""
+  return any(acl for acl in instance.workflow.access_control_list
+             if acl.ac_role.name == "Admin" and acl.person == current_user)
+
 """
 All functions with a signature
 
@@ -172,6 +178,7 @@ _CONDITIONS_MAP = {
     'has_not_changed': has_not_changed_condition,
     'has_changed': has_changed_condition,
     'is_auditor': is_auditor,
+    'is_workflow_admin': is_workflow_admin,
 }
 
 

--- a/src/ggrc_basic_permissions/roles/Creator.py
+++ b/src/ggrc_basic_permissions/roles/Creator.py
@@ -60,6 +60,31 @@ owner_update = owner_base + [
 permissions = {
     "read": owner_read,
     "create": [
+        {
+            "type": "TaskGroup",
+            "condition": "is_workflow_admin",
+            "terms": {},
+        },
+        {
+            "type": "TaskGroupTask",
+            "condition": "is_workflow_admin",
+            "terms": {},
+        },
+        {
+            "type": "Cycle",
+            "condition": "is_workflow_admin",
+            "terms": {},
+        },
+        {
+            "type": "CycleTaskEntry",
+            "condition": "is_workflow_admin",
+            "terms": {},
+        },
+        {
+            "type": "TaskGroupObject",
+            "condition": "is_workflow_admin",
+            "terms": {},
+        },
         "Categorization",
         "Category",
         "ControlCategory",

--- a/src/ggrc_basic_permissions/roles/Reader.py
+++ b/src/ggrc_basic_permissions/roles/Reader.py
@@ -79,7 +79,32 @@ permissions = {
         },
     ],
     "create": [
-        "Workflow"
+        "Workflow",
+        {
+            "type": "TaskGroup",
+            "condition": "is_workflow_admin",
+            "terms": {},
+        },
+        {
+            "type": "TaskGroupTask",
+            "condition": "is_workflow_admin",
+            "terms": {},
+        },
+        {
+            "type": "Cycle",
+            "condition": "is_workflow_admin",
+            "terms": {},
+        },
+        {
+            "type": "CycleTaskEntry",
+            "condition": "is_workflow_admin",
+            "terms": {},
+        },
+        {
+            "type": "TaskGroupObject",
+            "condition": "is_workflow_admin",
+            "terms": {},
+        },
         "Categorization",
         "Category",
         "ControlCategory",

--- a/src/ggrc_workflows/__init__.py
+++ b/src/ggrc_workflows/__init__.py
@@ -739,23 +739,29 @@ def handle_workflow_post(sender, obj=None, src=None, service=None):
   workflow_context = obj.get_or_create_object_context(personal_context)
   obj.context = workflow_context
 
-  # Create the context implication for Workflow roles to default context
-  ContextImplication(
+  # ContextImplications linked only with `workflow_context` object, which
+  # was created but not added to DB yet. ContextImlications should be added to
+  # session explicitly due to SQLAlchemy Garbage collector deletes such
+  # objects, and it will not be added to session. On the other hand
+  # `workflow_context` was added to session automatically, because it is linked
+  # to `personal_context` that is already in DB.
+  # Create context implication for Workflow roles to default context.
+  db.session.add(ContextImplication(
       source_context=workflow_context,
       context=None,
       source_context_scope='Workflow',
       context_scope=None,
       modified_by=get_current_user(),
-  )
-
-  # Add role implication - all users can read a public workflow
-  ContextImplication(
+  ))
+  # Add role implication - global users can perform defined actions on workflow
+  # and its related objects.
+  db.session.add(ContextImplication(
       source_context=None,
       context=workflow_context,
       source_context_scope=None,
       context_scope='Workflow',
       modified_by=get_current_user(),
-  )
+  ))
 
   if src.get('clone'):
     source_workflow.copy_task_groups(

--- a/src/ggrc_workflows/migrations/versions/20180115094803_58e0f07e174b_move_user_roles_to_acl.py
+++ b/src/ggrc_workflows/migrations/versions/20180115094803_58e0f07e174b_move_user_roles_to_acl.py
@@ -122,6 +122,9 @@ def upgrade():
       UNION
       SELECT "CycleTaskEntry", id, context_id
       FROM cycle_task_entries
+      UNION
+      SELECT "TaskGroupObject", id, context_id
+      FROM task_group_objects
       """)
   related_acl_data = []
   for related in rows:

--- a/src/ggrc_workflows/models/cycle_task_entry.py
+++ b/src/ggrc_workflows/models/cycle_task_entry.py
@@ -42,6 +42,11 @@ class CycleTaskEntry(Relatable, Described, Base, mixin.Indexed, db.Model):
       'is_declining_review'
   )
 
+  @property
+  def workflow(self):
+    """Property which returns parent workflow object."""
+    return self.cycle.workflow
+
   @hybrid_property
   def is_declining_review(self):
     return self._is_declining_review

--- a/src/ggrc_workflows/models/cycle_task_group.py
+++ b/src/ggrc_workflows/models/cycle_task_group.py
@@ -112,6 +112,11 @@ class CycleTaskGroup(mixins.WithContact,
   ]
 
   @property
+  def workflow(self):
+    """Property which returns parent workflow object."""
+    return self.cycle.workflow
+
+  @property
   def _task_assignees(self):
     """Property. Return the list of persons as assignee of related tasks."""
     persons = {}

--- a/src/ggrc_workflows/models/cycle_task_group_object_task.py
+++ b/src/ggrc_workflows/models/cycle_task_group_object_task.py
@@ -198,6 +198,11 @@ class CycleTaskGroupObjectTask(roleable.Roleable,
       "start_date": "Start Date",
   }
 
+  @property
+  def workflow(self):
+    """Property which returns parent workflow object."""
+    return self.cycle.workflow
+
   @builder.simple_property
   def related_objects(self):
     """Compute and return a list of all the objects related to this cycle task.

--- a/src/ggrc_workflows/models/hooks/workflow.py
+++ b/src/ggrc_workflows/models/hooks/workflow.py
@@ -36,9 +36,8 @@ def handle_acl_changes(session, flush_context):
             obj.object_type == all_models.Workflow.__name__):
       wf_new_acl[obj.object_id].add(obj)
     elif isinstance(obj, RELATED_MODELS):
-      workflow = _get_workflow(obj)
-      context[workflow.id][obj.__class__][obj.id].update(
-          workflow.access_control_list)
+      context[obj.workflow.id][obj.__class__][obj.id].update(
+          obj.workflow.access_control_list)
   _init_context(wf_new_acl, context)
   create_related_roles(context)
 
@@ -71,25 +70,6 @@ def remove_related_acl(related_to_del):
 
   db.session.query(all_models.AccessControlList).filter(or_(*qfilter)).delete(
       synchronize_session='fetch')
-
-
-def _get_workflow(related_obj):
-  """Get workflow from given related object.
-
-  Args:
-      related_obj: Workflow's related object
-
-  Returns:
-      Workflow instance which contains related_obj.
-  """
-  if isinstance(related_obj, (all_models.TaskGroup, all_models.Cycle)):
-    return related_obj.workflow
-  elif isinstance(related_obj, all_models.TaskGroupTask):
-    return related_obj.task_group.workflow
-  elif isinstance(related_obj, (all_models.CycleTaskGroupObjectTask,
-                  all_models.CycleTaskGroup, all_models.CycleTaskEntry)):
-    return related_obj.cycle.workflow
-  return None
 
 
 def _add_children_to_context(child_model, foreign_key, parent_wf_map,

--- a/src/ggrc_workflows/models/hooks/workflow.py
+++ b/src/ggrc_workflows/models/hooks/workflow.py
@@ -13,10 +13,15 @@ from ggrc.models import all_models
 from ggrc.access_control.role import get_custom_roles_for
 
 
-RELATED_MODELS = (all_models.TaskGroup, all_models.TaskGroupTask,
-                  all_models.Cycle, all_models.CycleTaskGroup,
-                  all_models.CycleTaskGroupObjectTask,
-                  all_models.CycleTaskEntry)
+RELATED_MODELS = (
+    all_models.TaskGroup,
+    all_models.TaskGroupTask,
+    all_models.TaskGroupObject,
+    all_models.Cycle,
+    all_models.CycleTaskGroup,
+    all_models.CycleTaskGroupObjectTask,
+    all_models.CycleTaskEntry,
+)
 
 
 def init_hook():

--- a/src/ggrc_workflows/models/task_group_object.py
+++ b/src/ggrc_workflows/models/task_group_object.py
@@ -26,6 +26,11 @@ class TaskGroupObject(Timeboxed, Base, db.Model):
   object_type = db.Column(db.String, nullable=False)
 
   @property
+  def workflow(self):
+    """Property which returns parent workflow object."""
+    return self.task_group.workflow
+
+  @property
   def object_attr(self):
     return '{0}_object'.format(self.object_type)
 

--- a/src/ggrc_workflows/models/task_group_task.py
+++ b/src/ggrc_workflows/models/task_group_task.py
@@ -137,6 +137,11 @@ class TaskGroupTask(roleable.Roleable,
       }
   }
 
+  @property
+  def workflow(self):
+    """Property which returns parent workflow object."""
+    return self.task_group.workflow
+
   @classmethod
   def _filter_by_task_group(cls, predicate):
     return TaskGroup.query.filter(


### PR DESCRIPTION
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [x] #7133
- [x] #7151 

# Steps to test the changes
1. Create Workflow, where Global Creator/Reader/Editor is Workflow Admin 
2. Login as Global Creator/Reader/Editor
3. Press on create TaskGroup button
Actual result: Cannot create task group, rbac works fine but POST on task_groups fails with 403 error
The same for:
+ he cannot create Task Group Task
+ he cannot map/unmap object on Task Group
403 for all cases
+ cannot clone Task Group
+ cannot activate WF