### PR TITLE
GGRC-4206 Change the order of buttons on compare po-up

### DIFF
--- a/src/ggrc-client/js/components/proposal/templates/apply-decline-proposal.mustache
+++ b/src/ggrc-client/js/components/proposal/templates/apply-decline-proposal.mustache
@@ -18,6 +18,7 @@
   </div>
 
   <div class="proposal-confirm__actions">
+    <spinner toggle="isLoading"></spinner>
     {{#if canDisplayApplyButton}}
       <button class="btn btn-green proposal-confirm__button"
         ($click)="confirm(true)"
@@ -37,6 +38,5 @@
       {{#if isLoading}}disabled{{/if}}>
         Cancel
     </button>
-    <spinner toggle="isLoading"></spinner>
   </div>
 </div>

--- a/src/ggrc-client/styles/components/proposal/_proposal.scss
+++ b/src/ggrc-client/styles/components/proposal/_proposal.scss
@@ -28,7 +28,7 @@
   .proposal-confirm__actions {
     line-height: 30px;
     display: flex;
-    flex-direction: row-reverse;
+    justify-content: flex-end;
     box-sizing: border-box;
 
     .proposal-confirm__button {


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Buttons on 'proposal-comparison' window have wrong order

# Steps to test the changes

1. Go to Control / Risk info pane/page.
2. Propose changes.
3. Go to 'Change Proposals' tab.
4. Click 'Review & Apply' button.

_Actual result:_ Buttons are displayed in order: Cancel, Decline, Apply.
_Expected result:_ Button should be displayed in order: Apply, Decline, Cancel.

# Solution description

Change order of buttons on 'proposal-comparison' window

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [ ] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
