### PR TITLE
GGRC-1507 Fix displaying old-style statuses for snapshots

### DIFF
--- a/src/ggrc/models/revision.py
+++ b/src/ggrc/models/revision.py
@@ -238,6 +238,45 @@ class Revision(Base, db.Model):
     return {"labels": [{"id": None,
                         "name": label}]} if label else {"labels": []}
 
+  def populate_status(self):
+    """Update status for older revisions or add it if status does not exist."""
+    pop_models = {
+        # ggrc
+        "AccessGroup",
+        "Clause",
+        "Control",
+        "DataAsset",
+        "Directive",
+        "Facility",
+        "Issue",
+        "Market",
+        "Objective",
+        "OrgGroup",
+        "Product",
+        "Program",
+        "Project",
+        "Section",
+        "System",
+        "Vendor",
+
+        # ggrc_risks
+        "Risk",
+        "Threat",
+    }
+    if self.resource_type not in pop_models:
+      return {}
+    statuses_mapping = {
+        "Active": "Active",
+        "Deprecated": "Deprecated",
+        "Effective": "Active",
+        "Final": "Active",
+        "In Scope": "Active",
+        "Ineffective": "Active",
+        "Launched": "Active",
+    }
+    return {"status": statuses_mapping.get(self._content.get("status"),
+                                           "Draft")}
+
   def _document_evidence_hack(self):
     """Update display_name on evideces
 
@@ -294,6 +333,7 @@ class Revision(Base, db.Model):
     populated_content.update(self.populate_reference_url())
     populated_content.update(self.populate_folder())
     populated_content.update(self.populate_labels())
+    populated_content.update(self.populate_status())
     populated_content.update(self._document_evidence_hack())
     populated_content.update(self.populate_categoies("categories"))
     populated_content.update(self.populate_categoies("assertions"))

--- a/test/unit/ggrc/models/test_revision.py
+++ b/test/unit/ggrc/models/test_revision.py
@@ -178,6 +178,35 @@ class TestCheckPopulatedContent(unittest.TestCase):
       self.assertEqual(revision.populate_labels()["labels"],
                        expected)
 
+  @ddt.data([{"status": "Active"}, {"status": "Active"}, "AccessGroup"],
+            [{"status": "Deprecated"}, {"status": "Deprecated"}, "Clause"],
+            [{"status": "Draft"}, {"status": "Draft"}, "Control"],
+            [{"status": "Effective"}, {"status": "Active"}, "DataAsset"],
+            [{"status": "Final"}, {"status": "Active"}, "Directive"],
+            [{"status": "In Scope"}, {"status": "Active"}, "Facility"],
+            [{"status": "Ineffective"}, {"status": "Active"}, "Issue"],
+            [{"status": "Launched"}, {"status": "Active"}, "Market"],
+            [{"status": "Not in Scope"}, {"status": "Draft"}, "Objective"],
+            [{"status": "Not Launched"}, {"status": "Draft"}, "OrgGroup"],
+            [{"status": "Not Launched"}, {"status": "Draft"}, "Product"],
+            [{"status": "Not Launched"}, {"status": "Draft"}, "Program"],
+            [{"status": "Not Launched"}, {"status": "Draft"}, "Project"],
+            [{"status": "Not Launched"}, {"status": "Draft"}, "Section"],
+            [{"status": "Not Launched"}, {"status": "Draft"}, "System"],
+            [{"status": "Not Launched"}, {"status": "Draft"}, "Vendor"],
+            [{"status": "Not Launched"}, {"status": "Draft"}, "Risk"],
+            [{"status": "Not Launched"}, {"status": "Draft"}, "Threat"],
+            [{"status": "Not Launched"}, {}, "Regulation"])
+  @ddt.unpack
+  def test_populated_status(self, content, expected_content, resource_type):
+    """Test populated content with status '{0}' to '{1}' in Model '{2}'."""
+    obj = mock.Mock()
+    obj.id = self.object_id
+    obj.__class__.__name__ = resource_type
+
+    revision = all_models.Revision(obj, mock.Mock(), mock.Mock(), content)
+    self.assertEqual(revision.populate_status(), expected_content)
+
   @ddt.data(
       ({}, {}),
       ({"document_evidence": []}, {"document_evidence": []}),


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

"Effective" state is displayed for Access Group, but "Active", "Draft" or "Deprecated" are expected.

# Steps to test the changes

Follow the https://ggrc-qa.appspot.com/audits/755#access_group_widget/access_group/21762 link and look at the Access Group state

*Actual Result*: "Effective" state is displayed for Access Group
*Expected Result*: For the snapshotable objects states should be: "Draft, Active, Deprecated"


# Solution description

Replace old-style status for models with changed statuses in *'_content'* field to 'Draft', 'Active' or 'Deprecated' according to [this](https://github.com/google/ggrc-core/blob/dev/src/ggrc/migrations/versions/20170124193902_24b94ce0860c_update_object_states.py) migration. Also set 'Draft' status for models, if status doesn't exist in old-to-new mapping or doesn't exist in model at all.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
