### PR TITLE
GGRC-1866 While Issue is saving hidden optional fields appear in modal window

### DIFF
--- a/src/ggrc-client/js/apps/custom_attributes_wrap.js
+++ b/src/ggrc-client/js/apps/custom_attributes_wrap.js
@@ -5,70 +5,66 @@
 
 import {getCustomAttributeType} from '../plugins/utils/ca-utils';
 
-(function (can, GGRC) {
-  'use strict';
+export default can.Component.extend({
+  tag: 'custom-attributes-wrap',
+  template: '<content/>',
+  scope: {
+    define: {
+      attributeValues: {
+        get() {
+          let result = [];
 
-  GGRC.Components('customAttributes', {
-    tag: 'custom-attributes-wrap',
-    template: '<content/>',
-    scope: {
-      define: {
-        attributeValues: {
-          get() {
-            let result = [];
-
-            can.each(this.attr('instance.custom_attribute_definitions'),
-              (cad) => {
-                let cav;
-                let type = cad.attribute_type;
-                can.each(this.attr('instance.custom_attribute_values'),
-                  (val) => {
-                    val = val.isStub ? val : val.reify();
-                    if (val.custom_attribute_id === cad.id) {
-                      cav = val;
-                    }
-                  });
-                result.push({
-                  cav: cav,
-                  cad: {
-                    id: cad.id,
-                    attribute_type: cad.attribute_type,
-                    mandatory: cad.mandatory,
-                    title: cad.title,
-                    label: cad.label,
-                    placeholder: cad.placeholder,
-                    helptext: cad.helptext,
-                    multi_choice_options: cad.multi_choice_options,
-                  },
-                  type: getCustomAttributeType(type),
+          can.each(this.attr('instance.custom_attribute_definitions'),
+            (cad) => {
+              let cav;
+              let type = cad.attribute_type;
+              can.each(this.attr('instance.custom_attribute_values'),
+                (val) => {
+                  val = val.isStub ? val : val.reify();
+                  if (val.custom_attribute_id === cad.id) {
+                    cav = val;
+                  }
                 });
+              result.push({
+                cav: cav,
+                cad: {
+                  id: cad.id,
+                  attribute_type: cad.attribute_type,
+                  mandatory: cad.mandatory,
+                  title: cad.title,
+                  label: cad.label,
+                  placeholder: cad.placeholder,
+                  helptext: cad.helptext,
+                  multi_choice_options: cad.multi_choice_options,
+                },
+                type: getCustomAttributeType(type),
               });
-            return result;
-          },
+            });
+          return result;
         },
       },
-      instance: null,
-      items: [],
-      setItems: function (isReady) {
-        let values = [];
-        if (isReady) {
-          values = this.attr('attributeValues').sort(function (a, b) {
-            return a.cad.id - b.cad.id;
-          });
-          this.attr('items', values);
-        }
-      },
     },
-    init: function () {
-      if (this.scope.instance.class.is_custom_attributable) {
-        this.scope.instance.setup_custom_attributes();
+    instance: null,
+    items: [],
+    setItems: function (isReady) {
+      let values = [];
+      if (isReady) {
+        values = this.attr('attributeValues').sort(function (a, b) {
+          return a.cad.id - b.cad.id;
+        });
+        this.attr('items', values);
       }
-      this.scope.setItems(true);
     },
-    events: {
-      '{scope.instance} readyForRender': function (sc, ev, isReady) {
-        this.scope.setItems(isReady);
-      },
+  },
+  init: function () {
+    if (this.scope.instance.class.is_custom_attributable) {
+      this.scope.instance.setup_custom_attributes();
+    }
+    this.scope.setItems(true);
+  },
+  events: {
+    '{scope.instance} readyForRender': function (sc, ev, isReady) {
+      this.scope.setItems(isReady);
     },
-  });
-})(window.can, window.GGRC);
+  },
+});

--- a/src/ggrc-client/js/apps/custom_attributes_wrap.js
+++ b/src/ggrc-client/js/apps/custom_attributes_wrap.js
@@ -4,11 +4,11 @@
  */
 
 import {getCustomAttributeType} from '../plugins/utils/ca-utils';
+const tag = 'custom-attributes-wrap';
 
 export default can.Component.extend({
-  tag: 'custom-attributes-wrap',
-  template: '<content/>',
-  scope: {
+  tag,
+  viewModel: {
     define: {
       attributeValues: {
         get() {
@@ -46,25 +46,24 @@ export default can.Component.extend({
     },
     instance: null,
     items: [],
-    setItems: function (isReady) {
+    setItems(isReady) {
       let values = [];
       if (isReady) {
-        values = this.attr('attributeValues').sort(function (a, b) {
-          return a.cad.id - b.cad.id;
-        });
+        values = this.attr('attributeValues')
+          .sort((a, b) => a.cad.id - b.cad.id);
         this.attr('items', values);
       }
     },
   },
-  init: function () {
-    if (this.scope.instance.class.is_custom_attributable) {
-      this.scope.instance.setup_custom_attributes();
+  init() {
+    if (this.viewModel.instance.class.is_custom_attributable) {
+      this.viewModel.instance.setup_custom_attributes();
     }
-    this.scope.setItems(true);
+    this.viewModel.setItems(true);
   },
   events: {
-    '{scope.instance} readyForRender': function (sc, ev, isReady) {
-      this.scope.setItems(isReady);
+    '{viewModel.instance} readyForRender'(sc, ev, isReady) {
+      this.viewModel.setItems(isReady);
     },
   },
 });

--- a/src/ggrc-client/js/apps/custom_attributes_wrap.js
+++ b/src/ggrc-client/js/apps/custom_attributes_wrap.js
@@ -12,47 +12,51 @@ import {getCustomAttributeType} from '../plugins/utils/ca-utils';
     tag: 'custom-attributes-wrap',
     template: '<content/>',
     scope: {
+      define: {
+        attributeValues: {
+          get() {
+            let result = [];
+
+            can.each(this.attr('instance.custom_attribute_definitions'),
+              (cad) => {
+                let cav;
+                let type = cad.attribute_type;
+                can.each(this.attr('instance.custom_attribute_values'),
+                  (val) => {
+                    val = val.isStub ? val : val.reify();
+                    if (val.custom_attribute_id === cad.id) {
+                      cav = val;
+                    }
+                  });
+                result.push({
+                  cav: cav,
+                  cad: {
+                    id: cad.id,
+                    attribute_type: cad.attribute_type,
+                    mandatory: cad.mandatory,
+                    title: cad.title,
+                    label: cad.label,
+                    placeholder: cad.placeholder,
+                    helptext: cad.helptext,
+                    multi_choice_options: cad.multi_choice_options,
+                  },
+                  type: getCustomAttributeType(type),
+                });
+              });
+            return result;
+          },
+        },
+      },
       instance: null,
       items: [],
       setItems: function (isReady) {
         let values = [];
         if (isReady) {
-          values = this.getValues().sort(function (a, b) {
+          values = this.attr('attributeValues').sort(function (a, b) {
             return a.cad.id - b.cad.id;
           });
           this.attr('items', values);
         }
-      },
-      getValues: function () {
-        let result = [];
-
-        can.each(this.attr('instance.custom_attribute_definitions'),
-          function (cad) {
-            let cav;
-            let type = cad.attribute_type;
-            can.each(this.attr('instance.custom_attribute_values'),
-              function (val) {
-                val = val.isStub ? val : val.reify();
-                if (val.custom_attribute_id === cad.id) {
-                  cav = val;
-                }
-              });
-            result.push({
-              cav: cav,
-              cad: {
-                id: cad.id,
-                attribute_type: cad.attribute_type,
-                mandatory: cad.mandatory,
-                title: cad.title,
-                label: cad.label,
-                placeholder: cad.placeholder,
-                helptext: cad.helptext,
-                multi_choice_options: cad.multi_choice_options,
-              },
-              type: getCustomAttributeType(type),
-            });
-          }.bind(this));
-        return result;
       },
     },
     init: function () {

--- a/src/ggrc-client/js/components/access_control_list/access-control-list-roles-helper.mustache
+++ b/src/ggrc-client/js/components/access_control_list/access-control-list-roles-helper.mustache
@@ -3,7 +3,10 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
 
+<!-- tabindex is necessary to work of 'Hide optional field' function -->
 <custom-roles-modal
+  tabindex="4"
+  class="custom-roles-modal"
   {instance}="instance"
   {is-proposal}="isProposal"
   {is-new-instance}="isNewInstance">

--- a/src/ggrc-client/styles/components/related-objects/_related-reference-urls.scss
+++ b/src/ggrc-client/styles/components/related-objects/_related-reference-urls.scss
@@ -1,4 +1,5 @@
 .related-reference-urls {
+  outline: none;
 
   &__heading {
     position: relative;

--- a/src/ggrc-client/styles/modules/_modal.scss
+++ b/src/ggrc-client/styles/modules/_modal.scss
@@ -659,10 +659,13 @@
       }
     }
 
-    .people-group {
-      flex-basis: 250px;
-      margin-right: 30px;
-      max-width: 250px;
+    .custom-roles-modal {
+      outline: none;
+      .people-group {
+        flex-basis: 250px;
+        margin-right: 30px;
+        max-width: 250px;
+      }
     }
   }
   .modal-footer {

--- a/src/ggrc/assets/mustache/base_objects/modal_content_urls.mustache
+++ b/src/ggrc/assets/mustache/base_objects/modal_content_urls.mustache
@@ -3,9 +3,11 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
 
-<div data-id="reference_url_hidden" class="span12 hidable">
+<div data-id="reference_url_hidden" class="span12">
   <related-documents instance={instance} document-type="REFERENCE_URL" autorefresh="false">
+    <!-- tabindex is necessary to work of 'Hide optional field' function -->
     <related-reference-urls class="related-reference-urls"
+      tabindex="20"
       {(urls)}="documents"
       {is-disabled}="isLoading"
       (createReferenceUrl)="markDocumentForAddition(%event.payload)"

--- a/src/ggrc/assets/mustache/custom_attributes/modal_content.mustache
+++ b/src/ggrc/assets/mustache/custom_attributes/modal_content.mustache
@@ -9,7 +9,7 @@
   <custom-attributes-wrap instance="instance">
     <div class="hideable-holder bare">
       <div class="row-fluid">
-        {{#getValues}}
+        {{#each attributeValues}}
           <div class="custom-attribute {{^cad.mandatory}}hidable{{/cad.mandatory}} span6
             {{#ca_validation_error instance.computed_errors id}}field-failure{{/ca_validation_error}}">
 
@@ -41,7 +41,7 @@
               {{#cad.helptext}}<i class="fa fa-question-circle" rel="tooltip" title="{{cad.helptext}}"></i>{{/cad.helptext}}
               {{#unless cad.mandatory}}<a href="javascript://" class="field-hide" tabindex="-1">hide</a>{{/unless}}
             </label>
-            <select class="input-block-level" name="custom_attributes.{{cad.id}}" null-if-empty="null-if-empty" tabindex="20">
+            <select class="input-block-level" name="custom_attributes.{{cad.id}}" null-if-empty="null-if-empty" tabindex="{{add_index 20 @index}}">
               <option value="" {{#if_equals "" cav.attribute_value}}selected="true"{{/if_equals}}>---</option>
               {{#iterate_string cad.multi_choice_options ','}}
                 <option {{#if_equals iterator cav.attribute_value}}selected="true"{{/if_equals}}>{{iterator}}</option>
@@ -65,6 +65,7 @@
               <a href="javascript://" class="field-hide" tabindex="-1">hide</a>
             {{/unless}}
             <datepicker
+              tabindex="{{add_index 20 @index}}"
               {label}="cad.title"
               date="instance.custom_attributes.{{cad.id}}"
               required="{{cad.mandatory}}"
@@ -86,6 +87,7 @@
                     data-lookup-cb="_custom_attribute_map {{cad.id}}"
                     null-if-empty="null-if-empty"
                     type="text"
+                    tabindex="{{add_index 20 @index}}"
                     value="{{person.email}}" />
               {{else}}
               <inline-autocomplete-wrapper
@@ -93,6 +95,7 @@
                 {text-value}="person.email"
                 {display-prop}="'email'">
                 <external-data-autocomplete
+                  tabindex="{{add_index 20 @index}}"
                   {type}="'Person'"
                   {placeholder}="'Enter email address'"
                   (item-selected)="setCustomAttribute(%event.selectedItem, cad.id)"
@@ -111,7 +114,7 @@
             <label class="help-inline warning">{{errors.0}}</label>
           {{/ca_validation_error}}
         </div>
-        {{/getValues}}
+        {{/each}}
       </div>
     </div>
   </custom-attributes-wrap>

--- a/src/ggrc/assets/mustache/partials/modal-ajax-test-plan.mustache
+++ b/src/ggrc/assets/mustache/partials/modal-ajax-test-plan.mustache
@@ -11,7 +11,7 @@
       <a data-id="hide_description_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
     </label>
     <div class="wysiwyg-area">
-      <textarea id="control_test_plan" class="span12 triple wysihtml5" name="test_plan" placeholder="Enter Assessment Procedure">{{instance.test_plan}}</textarea>
+      <textarea tabindex="3" id="control_test_plan" class="span12 triple wysihtml5" name="test_plan" placeholder="Enter Assessment Procedure">{{instance.test_plan}}</textarea>
     </div>
   </div>
 </div>


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

"Hide all optional fields" button doesn't work as expected.

"Hide all optional fields" ("restore_ui_status" function from "modals_controller.js") uses tabindex to hide fields on modal.

# Steps to test the changes

1. On the audit page invoke new Issue modal window
2. Fill the fields required and click hide optional fields button
3. Click save and close
4. Look at the modal window while saving
_Actual Result_: While Issue is saving hidden optional fields appear in modal window
_Expected Result_: While Issue is saving hidden optional fields should not appear in modal window

![screenshot-1](https://user-images.githubusercontent.com/4204416/35222399-cfaf5b8a-ff8e-11e7-941a-4d67f07fdf17.png)

![screenshot-2](https://user-images.githubusercontent.com/4204416/35222405-d31d7d6a-ff8e-11e7-9841-e20f8a7047d7.png)

# Steps to test the changes 2

1. Open Administration tab and add few custom attributes for Control (or other entity);
2. Open any program;
3. Open Control tab (or tab with entity from first step);
4. Click "Map" button;
5. Click "Create and map new object" on mapper;
6. Click "Hide all optional fields" on Create modal and close this modal;
7. Click "Create and map new object" on mapper;
_Actual Result_: Custom attributes, ACL and Reference URL are displaying;
_Expected Result_: Only "Mandatory" fields should be displayed

# Solution description

1. Added tabindex to "ACL" and "Reference URL".
2. Fixed displaying of custom attributes on "modal_content.mustache" 

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
