### PR TITLE
GGRC-2717 Add last_comment CA

### DIFF
--- a/src/ggrc/converters/column_handlers.py
+++ b/src/ggrc/converters/column_handlers.py
@@ -107,6 +107,7 @@ _DEFAULT_COLUMN_HANDLERS_DICT = {
     "created_at": handlers.ExportOnlyDateColumnHandler,
     "modified_by": handlers.DirecPersonMappingColumnHandler,
     "last_deprecated_date": handlers.DateColumnHandler,
+    "last_comment": handlers.ExportOnlyColumnHandler,
 
     # Mapping column handlers
     "__mapping__:person": handlers.PersonMappingColumnHandler,

--- a/src/ggrc/data_platform/computed_attributes.py
+++ b/src/ggrc/data_platform/computed_attributes.py
@@ -127,6 +127,22 @@ def get_aggregate_function(attribute):
       return source_id, value
 
     return max_
+  elif function_name == "last":
+    def last_(aggregate_values, rel_map):
+      """Get maximum value and id from which the value was taken."""
+      values = [
+          (aggregate_values[aggregate_id], aggregate_id)
+          for aggregate_id in rel_map
+          if aggregate_values.get(aggregate_id) is not None
+      ]
+      if not values:
+        return None, None
+
+      # Last value  = value with maximal id
+      value, source_id = max(values, key=lambda i: i[1])
+      return source_id, value
+
+    return last_
   raise AttributeError("Attribute aggregate_function contains invalid data.")
 
 

--- a/src/ggrc/data_platform/computed_attributes.py
+++ b/src/ggrc/data_platform/computed_attributes.py
@@ -367,7 +367,7 @@ def _get_relationships_map(relationships):
 
 def compute_values(affected_objects, all_relationships, snapshot_map):
   """Compute new values for affected objects."""
-
+  # pylint: disable=too-many-locals
   computed_values = collections.defaultdict(dict)
 
   for attr, objects in affected_objects.iteritems():
@@ -382,21 +382,21 @@ def compute_values(affected_objects, all_relationships, snapshot_map):
       if source_id is None:
         continue
 
-      computed_values[attr][obj] = {
+      computed_value_dict = {
           "source_type": aggregate_type,
           "source_id": source_id,
-          "value_datetime": value,
+          "value_datetime": None,
           "value_integer": None,
           "value_string": "",
       }
+      field_type = attr.attribute_definition.attribute_type.field_type
+      if field_type in ("value_datetime", "value_integer", "value_string"):
+        computed_value_dict[field_type] = value
+      else:
+        computed_value_dict["value_datetime"] = value
+      computed_values[attr][obj] = computed_value_dict
       for snapshot_id in snapshot_map.get(obj, set()):
-        computed_values[attr][(u"Snapshot", snapshot_id)] = {
-            "source_type": aggregate_type,
-            "source_id": source_id,
-            "value_datetime": value,
-            "value_integer": None,
-            "value_string": "",
-        }
+        computed_values[attr][(u"Snapshot", snapshot_id)] = computed_value_dict
 
   return computed_values
 
@@ -537,7 +537,7 @@ def get_attributes_data(computed_values):
           "source_id": computed_value["source_id"],
           "source_attr": unicode(aggregate_field),
           "value_datetime": computed_value["value_datetime"],
-          "value_string": computed_value["value_string"],
+          "value_string": computed_value["value_string"] or "",
           "value_integer": computed_value["value_integer"],
           "attribute_template_id": attr.attribute_template_id,
           "attribute_definition_id": definition_id,
@@ -555,8 +555,7 @@ def get_index_data(computed_values, snapshot_tag_map):
   for attr, objects in computed_values.iteritems():
     for obj, computed_value in objects.iteritems():
       value = (computed_value["value_datetime"] or
-               computed_value["value_string"] or
-               computed_value["value_integer"])
+               computed_value["value_string"] or "")
       tags = u""
       if obj[0] == "Snapshot":
         tags = snapshot_tag_map.get(obj[1], u"")

--- a/src/ggrc/data_platform/computed_attributes.py
+++ b/src/ggrc/data_platform/computed_attributes.py
@@ -408,10 +408,10 @@ def _get_relationships(aggregate_type, objects):
     return set()
 
   src = db.session.query(
-      models.Relationship.destination_type,
-      models.Relationship.destination_id,
       models.Relationship.source_type,
       models.Relationship.source_id,
+      models.Relationship.destination_type,
+      models.Relationship.destination_id,
   ).filter(
       sa.tuple_(
           models.Relationship.destination_type,
@@ -420,10 +420,10 @@ def _get_relationships(aggregate_type, objects):
       models.Relationship.source_type == aggregate_type,
   )
   dst = db.session.query(
-      models.Relationship.source_type,
-      models.Relationship.source_id,
       models.Relationship.destination_type,
       models.Relationship.destination_id,
+      models.Relationship.source_type,
+      models.Relationship.source_id,
   ).filter(
       sa.tuple_(
           models.Relationship.source_type,

--- a/src/ggrc/migrations/versions/20180112085248_4906ff3f9c7b_add_last_comment_computed_attr.py
+++ b/src/ggrc/migrations/versions/20180112085248_4906ff3f9c7b_add_last_comment_computed_attr.py
@@ -1,0 +1,215 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Add last comment computed attr
+
+Create Date: 2018-01-12 08:52:48.286089
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+import datetime
+
+from alembic import op
+
+import sqlalchemy as sa
+from sqlalchemy.sql import table, column
+
+revision = '4906ff3f9c7b'
+down_revision = '21db8dd549ac'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  attribute_types = table(
+      "attribute_types",
+      column("attribute_type_id", sa.Integer),
+      column("name", sa.Unicode),
+      column("field_type", sa.Unicode),
+      column("db_column_name", sa.Unicode),
+      column("computed", sa.Boolean),
+      column("aggregate_function", sa.UnicodeText),
+      column("created_at", sa.DateTime),
+      column("updated_at", sa.DateTime),
+  )
+  attribute_definitions = table(
+      "attribute_definitions",
+      column("attribute_definition_id", sa.Integer),
+      column("attribute_type_id", sa.Integer),
+      column("name", sa.Unicode),
+      column("display_name", sa.Unicode),
+      column("created_at", sa.DateTime),
+      column("updated_at", sa.DateTime),
+  )
+  object_templates = table(
+      "object_templates",
+      column("object_template_id", sa.Integer),
+      column("object_type_id", sa.Integer),
+      column("name", sa.Unicode),
+      column("display_name", sa.Unicode),
+      column("created_at", sa.DateTime),
+      column("updated_at", sa.DateTime),
+  )
+  attribute_templates = table(
+      "attribute_templates",
+      column("attribute_template_id", sa.Integer),
+      column("attribute_definition_id", sa.Integer),
+      column("object_template_id", sa.Integer),
+      column("order", sa.Integer),
+      column("read_only", sa.Boolean),
+      column("created_at", sa.DateTime),
+      column("updated_at", sa.DateTime),
+  )
+
+  op.bulk_insert(
+      object_templates,
+      [{
+          "object_type_id": 1,
+          "name": "Assessment",
+          "display_name": "Assessment",
+          "created_at": datetime.datetime.now(),
+          "updated_at": datetime.datetime.now(),
+      }]
+  )
+  connection = op.get_bind()
+  object_template_id = connection.execute(
+      sa.select([object_templates.c.object_template_id]).order_by(
+          sa.desc("object_template_id"))
+  ).fetchone()[0]
+  op.bulk_insert(
+      attribute_types,
+      [{
+          "name": "Computed attribute for last comment",
+          "field_type": "value_string",
+          "db_column_name": "last_comment",
+          "computed": True,
+          "aggregate_function": "Comment description last",
+          "created_at": datetime.datetime.now(),
+          "updated_at": datetime.datetime.now(),
+      }]
+  )
+  attribute_type_id = connection.execute(
+      sa.select([attribute_types.c.attribute_type_id]).order_by(
+          sa.desc("attribute_type_id"))
+  ).fetchone()[0]
+  op.bulk_insert(
+      attribute_definitions,
+      [{
+          "attribute_type_id": attribute_type_id,
+          "name": "last_comment",
+          "display_name": "Last Comment",
+          "created_at": datetime.datetime.now(),
+          "updated_at": datetime.datetime.now(),
+      }]
+  )
+  attribute_definition_id = connection.execute(
+      sa.select([attribute_definitions.c.attribute_definition_id]).order_by(
+          sa.desc("attribute_definition_id"))
+  ).fetchone()[0]
+  op.bulk_insert(
+      attribute_templates,
+      [{
+          "attribute_definition_id": attribute_definition_id,
+          "object_template_id": object_template_id,
+          "order": 1,
+          "read_only": True,
+          "created_at": datetime.datetime.now(),
+          "updated_at": datetime.datetime.now(),
+      }]
+  )
+  attribute_template_id = connection.execute(
+      sa.select([attribute_templates.c.attribute_template_id]).order_by(
+          sa.desc("attribute_template_id"))
+  ).fetchone()[0]
+
+  connection.execute(
+      sa.text("""
+          REPLACE INTO attributes (
+            object_type,
+            object_id,
+            source_type,
+            source_id,
+            source_attr,
+            value_datetime,
+            value_integer,
+            value_string,
+            attribute_template_id,
+            attribute_definition_id,
+            created_at,
+            updated_at
+          )
+          SELECT 'Assessment', tmp2.id, 'Comment', tmp2.last_comment_id,
+            'description', NULL, NULL, comments.description,
+            :attribute_template_id, :attribute_definition_id, NOW(), NOW()
+          FROM (
+              SELECT tmp.id, MAX(tmp.comment_id) last_comment_id
+              FROM (
+                  SELECT a.id, c.id as comment_id
+                  FROM assessments a
+                  JOIN relationships r ON
+                    r.source_id = a.id AND
+                    r.source_type = 'Assessment' AND
+                    r.destination_type = 'Comment'
+                  JOIN comments c ON
+                    c.id = r.destination_id
+
+                  UNION ALL
+
+                  SELECT a.id, c.id as comment_id
+                  FROM assessments a
+                  JOIN relationships r ON
+                    r.destination_id = a.id AND
+                    r.destination_type = 'Assessment' AND
+                    r.source_type = 'Comment'
+                  JOIN comments c ON
+                    c.id = r.source_id
+              ) tmp
+              GROUP BY tmp.id
+          ) tmp2
+          JOIN comments ON comments.id = tmp2.last_comment_id
+      """),
+      attribute_template_id=attribute_template_id,
+      attribute_definition_id=attribute_definition_id
+  )
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  attribute_definitions = table(
+      "attribute_definitions",
+      column("attribute_definition_id", sa.Integer),
+      column("attribute_type_id", sa.Integer),
+      column("name", sa.Unicode),
+  )
+
+  connection = op.get_bind()
+  attribute_definition_id = connection.execute(
+      sa.select(
+          [attribute_definitions.c.attribute_definition_id]
+      ).where(
+          attribute_definitions.c.name == "last_comment"
+      ).order_by(
+          sa.desc("attribute_definition_id")
+      )
+  ).fetchone()[0]
+
+  connection.execute(sa.text("""
+      DELETE FROM attributes
+      WHERE attribute_definition_id = :attribute_definition_id;
+  """), attribute_definition_id=attribute_definition_id)
+  connection.execute(sa.text("""
+      DELETE FROM attribute_templates
+      WHERE attribute_definition_id = :attribute_definition_id;
+  """), attribute_definition_id=attribute_definition_id)
+  connection.execute("""
+      DELETE FROM attribute_definitions
+      WHERE name = 'last_comment';
+  """)
+  connection.execute("""
+      DELETE FROM attribute_types
+      WHERE field_type = 'computed_last_comment';
+  """)
+  connection.execute("""
+      DELETE FROM object_templates
+      WHERE name = 'Assessment';
+  """)

--- a/src/ggrc/models/assessment.py
+++ b/src/ggrc/models/assessment.py
@@ -18,6 +18,7 @@ from ggrc.fulltext import mixin
 from ggrc.models.comment import Commentable
 from ggrc.models.custom_attribute_definition import CustomAttributeDefinition
 from ggrc.models import issuetracker_issue
+from ggrc.models.mixins import with_last_comment
 from ggrc.models.mixins.audit_relationship import AuditRelationship
 from ggrc.models.mixins import BusinessObject
 from ggrc.models.mixins import CustomAttributable
@@ -65,8 +66,9 @@ class Assessment(Roleable, statusable.Statusable, AuditRelationship,
                  Personable, reminderable.Reminderable, Relatable,
                  LastDeprecatedTimeboxed, WithSimilarityScore, FinishedDate,
                  VerifiedDate, ValidateOnComplete, Notifiable, WithAction,
-                 labeled.Labeled, issuetracker_issue.IssueTracked,
-                 BusinessObject, Indexed, db.Model):
+                 labeled.Labeled, with_last_comment.WithLastComment,
+                 issuetracker_issue.IssueTracked, BusinessObject,
+                 Indexed, db.Model):
   """Class representing Assessment.
 
   Assessment is an object representing an individual assessment performed on

--- a/src/ggrc/models/hooks/__init__.py
+++ b/src/ggrc/models/hooks/__init__.py
@@ -3,7 +3,7 @@
 
 """Import GGRC model hooks."""
 
-from ggrc.models.hooks import access_control_list
+from ggrc.models.hooks import access_control_list, common
 from ggrc.models.hooks import assessment
 from ggrc.models.hooks import audit
 from ggrc.models.hooks import comment
@@ -28,6 +28,8 @@ ALL_HOOKS = [
     audit_roles,
     program_roles,
     relationship_deletion,
+    common,
+
     # Keep IssueTracker at the end of list to make sure that all other hooks
     # are already executed and all data is final.
     issue_tracker,

--- a/src/ggrc/models/mixins/attributable.py
+++ b/src/ggrc/models/mixins/attributable.py
@@ -12,7 +12,6 @@ from sqlalchemy.orm import foreign
 from sqlalchemy.orm import relationship
 
 from ggrc import builder
-from ggrc.models import reflection
 
 
 # pylint: disable=invalid-name
@@ -22,10 +21,6 @@ logger = getLogger(__name__)
 # pylint: disable=attribute-defined-outside-init; CustomAttributable is a mixin
 class Attributable(object):
   """Custom Attributable mixin."""
-
-  _api_attrs = reflection.ApiAttributes(
-      reflection.Attribute('attributes', create=False, update=False),
-  )
 
   @declared_attr
   def _attributes(cls):  # pylint: disable=no-self-argument
@@ -46,15 +41,6 @@ class Attributable(object):
 
   @builder.simple_property
   def attributes(self):
-    return {
-        attr.attribute_template.attribute_definition.name: {
-            "value": attr.value_datetime
-        }
-        for attr in self._attributes  # pylint: disable=not-an-iterable
-    }
-
-  @builder.simple_property
-  def attribute_objs(self):
     return {
         attr.attribute_template.attribute_definition.name: attr
         for attr in self._attributes  # pylint: disable=not-an-iterable

--- a/src/ggrc/models/mixins/attributable.py
+++ b/src/ggrc/models/mixins/attributable.py
@@ -53,6 +53,13 @@ class Attributable(object):
         for attr in self._attributes  # pylint: disable=not-an-iterable
     }
 
+  @builder.simple_property
+  def attribute_objs(self):
+    return {
+        attr.attribute_template.attribute_definition.name: attr
+        for attr in self._attributes  # pylint: disable=not-an-iterable
+    }
+
   @classmethod
   def eager_query(cls):
     """Define fields to be loaded eagerly to lower the count of DB queries."""

--- a/src/ggrc/models/mixins/attributable.py
+++ b/src/ggrc/models/mixins/attributable.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import relationship
 
 from ggrc import builder
 
+from ggrc.data_platform import attributes
 
 # pylint: disable=invalid-name
 logger = getLogger(__name__)
@@ -65,4 +66,15 @@ class Attributable(object):
             "value_string",
             "value_integer",
         )
+    )
+
+  @classmethod
+  def get_delete_ca_query_for(cls, ids):
+    """Return delete CA record query. If ids are empty, will return None."""
+    if not ids:
+      return
+    return attributes.Attributes.__table__.delete().where(
+        attributes.Attributes.object_type == cls.__name__
+    ).where(
+        attributes.Attributes.object_id.in_(ids)
     )

--- a/src/ggrc/models/mixins/attributable.py
+++ b/src/ggrc/models/mixins/attributable.py
@@ -54,3 +54,15 @@ class Attributable(object):
         orm.subqueryload('_attributes')
     )
     return query
+
+  @classmethod
+  def indexed_query(cls):
+    return super(Attributable, cls).indexed_query().options(
+        orm.Load(cls).subqueryload(
+            "_attributes"
+        ).load_only(
+            "value_datetime",
+            "value_string",
+            "value_integer",
+        )
+    )

--- a/src/ggrc/models/mixins/with_last_assessment_date.py
+++ b/src/ggrc/models/mixins/with_last_assessment_date.py
@@ -34,4 +34,5 @@ class WithLastAssessmentDate(attributable.Attributable):
 
   @simple_property
   def last_assessment_date(self):
-    return self.attributes.get("last_assessment_date", {}).get("value")
+    lad_attr = self.attributes.get("last_assessment_date")
+    return lad_attr.value_datetime if lad_attr else None

--- a/src/ggrc/models/mixins/with_last_comment.py
+++ b/src/ggrc/models/mixins/with_last_comment.py
@@ -32,13 +32,11 @@ class WithLastComment(attributable.Attributable):
   _fulltext_attrs = [attributes.FullTextAttr("last_comment", "last_comment")]
 
   @simple_property
-  def last_comment_ca(self):
-    return self.attribute_objs.get("last_comment")
-
-  @simple_property
   def last_comment(self):
-    return self.last_comment_ca.value_string if self.last_comment_ca else None
+    lc_attr = self.attributes.get("last_comment")
+    return lc_attr.value_string if lc_attr else None
 
   @simple_property
   def last_comment_id(self):
-    return self.last_comment_ca.source_id if self.last_comment_ca else None
+    lc_attr = self.attributes.get("last_comment")
+    return lc_attr.source_id if lc_attr else None

--- a/src/ggrc/models/mixins/with_last_comment.py
+++ b/src/ggrc/models/mixins/with_last_comment.py
@@ -1,0 +1,44 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Contains WithLastComment mixin.
+
+This defines logic to get fields of the last Comment over all
+Comments of object.
+"""
+
+from ggrc.fulltext import attributes
+from ggrc.builder import simple_property
+from ggrc.models import reflection
+from ggrc.models.mixins import attributable
+
+
+class WithLastComment(attributable.Attributable):
+  """Defines logic to get last comment for object."""
+  # pylint: disable=too-few-public-methods
+
+  _api_attrs = reflection.ApiAttributes(
+      reflection.Attribute("last_comment", create=False, update=False),
+      reflection.Attribute("last_comment_id", create=False, update=False),
+  )
+
+  _aliases = {
+      "last_comment": {
+          "display_name": "Last Comment",
+          "view_only": True,
+      },
+  }
+
+  _fulltext_attrs = [attributes.FullTextAttr("last_comment", "last_comment")]
+
+  @simple_property
+  def last_comment_ca(self):
+    return self.attribute_objs.get("last_comment")
+
+  @simple_property
+  def last_comment(self):
+    return self.last_comment_ca.value_string if self.last_comment_ca else None
+
+  @simple_property
+  def last_comment_id(self):
+    return self.last_comment_ca.source_id if self.last_comment_ca else None

--- a/test/integration/ggrc/__init__.py
+++ b/test/integration/ggrc/__init__.py
@@ -20,8 +20,9 @@ from flask.ext.testing import TestCase as BaseTestCase
 from ggrc import db
 from ggrc.app import app
 from ggrc.converters.import_helper import read_csv_file
+from ggrc.fulltext import mysql
 from ggrc.views.converters import check_import_file
-from ggrc.models import Revision
+from ggrc.models import Revision, all_models
 from integration.ggrc.api_helper import Api
 from integration.ggrc.models import factories
 
@@ -52,6 +53,7 @@ class TestCase(BaseTestCase, object):
   # because it's required by unittests.
 
   """Base test case for all ggrc integration tests."""
+  # pylint: disable=too-many-public-methods
 
   CSV_DIR = os.path.join(THIS_ABS_PATH, "test_csvs/")
 
@@ -462,3 +464,21 @@ class TestCase(BaseTestCase, object):
           )
           assignees.append((person, role))
     return assignees
+
+  @staticmethod
+  def get_model_fulltext(model_name, property, ids):
+    """Get fulltext records for model."""
+    # pylint: disable=redefined-builtin
+    return db.session.query(mysql.MysqlRecordProperty).filter(
+        mysql.MysqlRecordProperty.type == model_name,
+        mysql.MysqlRecordProperty.property == property,
+        mysql.MysqlRecordProperty.key.in_(ids),
+    )
+
+  @staticmethod
+  def get_model_ca(model_name, ids):
+    """Get CAs for model."""
+    return db.session.query(all_models.Attributes).filter(
+        all_models.Attributes.object_type == model_name,
+        all_models.Attributes.object_id.in_(ids),
+    )

--- a/test/integration/ggrc/converters/test_import_helpers.py
+++ b/test/integration/ggrc/converters/test_import_helpers.py
@@ -448,6 +448,7 @@ class TestGetObjectColumnDefinitions(TestCase):
         'Last Updated By',
         "Comments",
         'Labels',
+        'Last Comment',
     }
     expected_fields = {
         "mandatory": {

--- a/test/integration/ggrc/data_platform/test_computed_attributes.py
+++ b/test/integration/ggrc/data_platform/test_computed_attributes.py
@@ -13,6 +13,7 @@ class TestComputedAttributes(TestCase):
   """Integration test suite for computed attributes module."""
 
   def test_get_computed_attributes(self):
+    """Test CA definition for all models"""
     attributes = computed_attributes.get_computed_attributes()
     attribute_names = {
         (attr.object_template.name, attr.attribute_definition.name)
@@ -23,5 +24,6 @@ class TestComputedAttributes(TestCase):
         {
             ("Control", "last_assessment_date"),
             ("Objective", "last_assessment_date"),
+            ("Assessment", "last_comment"),
         }
     )

--- a/test/integration/ggrc/fulltext/test_total_reindex.py
+++ b/test/integration/ggrc/fulltext/test_total_reindex.py
@@ -26,12 +26,12 @@ class TestTotalReindex(TestCase):
   # 2 remove old records
   # 3 create new records
   INDEX_QUERY_LIMIT = {
-      'Assessment': 11,
+      'Assessment': 10,
       'AssessmentTemplate': 6,
       'Audit': 7,
       'Comment': 4,
       'Contract': 9,
-      'Control': 21,
+      'Control': 12,
       'Cycle': 5,
       'CycleTaskEntry': 3,
       'CycleTaskGroup': 4,
@@ -39,7 +39,7 @@ class TestTotalReindex(TestCase):
       'Document': 4,
       'Issue': 8,
       'Market': 8,
-      'Objective': 18,
+      'Objective': 9,
       'OrgGroup': 8,
       'Person': 5,
       'Policy': 9,

--- a/test/integration/ggrc/models/mixins/test_with_last_comment.py
+++ b/test/integration/ggrc/models/mixins/test_with_last_comment.py
@@ -1,0 +1,182 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Integration tests for WithLastComment logic."""
+
+from collections import defaultdict
+
+import collections
+
+from ggrc.models import all_models
+
+from integration.ggrc import TestCase, generator
+from integration.ggrc.api_helper import Api
+from integration.ggrc.query_helper import WithQueryApi
+from integration.ggrc.models import factories
+
+
+class TestWithLastAssessmentDate(TestCase, WithQueryApi):
+  """Integration test suite for WithLastComment functionality."""
+
+  def setUp(self):
+    super(TestWithLastAssessmentDate, self).setUp()
+    self.client.get("/login")
+    self.api = Api()
+    self.gen = generator.ObjectGenerator()
+
+    self.asmnt_comments = defaultdict(dict)
+    with factories.single_commit():
+      for _ in range(3):
+        asmnt = factories.AssessmentFactory()
+        for _ in range(3):
+          comment = factories.CommentFactory(
+              description=factories.random_str()
+          )
+          self.asmnt_comments[asmnt.id][comment.id] = comment.description
+          factories.RelationshipFactory(source=asmnt, destination=comment)
+
+    query = all_models.Revision.query.filter_by(resource_type="Comment")
+    revision_ids = [revision.id for revision in query]
+    self.api.send_request(
+        self.api.client.post,
+        api_link="/admin/compute_attributes",
+        data={"revision_ids": revision_ids}
+    )
+
+  def test_last_comment_value(self):
+    """Test assessment has proper value in last_comment field"""
+    assessments = all_models.Assessment.query
+    self.assertEqual(assessments.count(), len(self.asmnt_comments))
+    for asmnt in assessments:
+      last_comment_id = max(self.asmnt_comments[asmnt.id])
+      self.assertEqual(
+          asmnt.last_comment_id,
+          last_comment_id
+      )
+      self.assertEqual(
+          asmnt.last_comment,
+          self.asmnt_comments[asmnt.id][last_comment_id]
+      )
+
+  def test_last_comment_filter(self):
+    """Test filtration by last comment."""
+    asmnt = all_models.Assessment.query.first()
+    result = self._get_first_result_set(
+        self._make_query_dict(
+            "Assessment",
+            expression=("Last Comment", "=", asmnt.last_comment),
+            type_="ids",
+        ),
+        "Assessment",
+    )
+    self.assertEqual(result["count"], 1)
+    self.assertEqual(result["ids"], [asmnt.id])
+
+  def test_last_comment_order(self):
+    """Test sorting by last comment."""
+    result = self._get_first_result_set(
+        self._make_query_dict(
+            "Assessment",
+            order_by=[{"name": "Last Comment"}],
+            type_="ids"
+        ),
+        "Assessment",
+        "ids",
+    )
+    asmnts = all_models.Assessment.query
+    sorted_asmnts = sorted(asmnts, key=lambda k: k.last_comment)
+    self.assertEqual(result, [i.id for i in sorted_asmnts])
+
+  def test_export_last_comment(self):
+    """Test export Last Assessment Date."""
+    search_request = [{
+        "object_name": "Assessment",
+        "filters": {
+            "expression": {},
+        },
+        "fields": "all",
+    }]
+    query = self.export_parsed_csv(search_request)["Assessment"]
+
+    exported_comments = [asmnt["Last Comment"] for asmnt in query]
+    db_comments = [a.last_comment for a in all_models.Assessment.query]
+    self.assertEqual(exported_comments, db_comments)
+
+  def test_import_last_comment(self):
+    """Test Last Assessment Date field read only on import."""
+    audit = factories.AuditFactory()
+    response = self.import_data(collections.OrderedDict([
+        ("object_type", "Assessment"),
+        ("Code*", "Asmnt-code"),
+        ("Audit", audit.slug),
+        ("Assignees", "user@example.com"),
+        ("Creators", "user@example.com"),
+        ("Title", "Test title"),
+        ("Last Comment", "some comment"),
+    ]))
+    self._check_csv_response(response, {})
+    asmnts = all_models.Assessment.query.filter(
+        all_models.Assessment.slug == "Asmnt-code"
+    ).all()
+    self.assertEqual(len(asmnts), 1)
+    self.assertEqual(asmnts[0].last_comment, None)
+
+  def test_ca_create_on_import(self):
+    """Test creating last_comment CA when comments imported"""
+    audit = factories.AuditFactory()
+    response = self.import_data(collections.OrderedDict([
+        ("object_type", "Assessment"),
+        ("Code*", "Asmnt-code"),
+        ("Audit", audit.slug),
+        ("Assignees", "user@example.com"),
+        ("Creators", "user@example.com"),
+        ("Title", "Test title"),
+        ("Comments", "new comment1;;new comment2;;new comment3"),
+    ]))
+    self._check_csv_response(response, {})
+    asmnt = all_models.Assessment.query.filter_by(slug="Asmnt-code").first()
+    self.assertEqual(asmnt.last_comment, "new comment3")
+
+  def test_ca_update_on_import(self):
+    """Test updating of last_comment CA when comments imported"""
+    asmnt_id = self.asmnt_comments.keys()[0]
+    asmnt_slug = all_models.Assessment.query.get(asmnt_id).slug
+    response = self.import_data(collections.OrderedDict([
+        ("object_type", "Assessment"),
+        ("Code*", asmnt_slug),
+        ("Comments", "new comment1;;new comment2;;new comment3"),
+    ]))
+    self._check_csv_response(response, {})
+    asmnt = all_models.Assessment.query.filter_by(slug=asmnt_slug).first()
+    self.assertEqual(asmnt.last_comment, "new comment3")
+
+  def test_ca_cleanup_on_obj_delete(self):
+    """Test cleaning of fulltext and attributes tables on obj delete"""
+    asmnt_id = self.asmnt_comments.keys()[0]
+    asmnt = all_models.Assessment.query.get(asmnt_id)
+    last_comment_records = self.get_model_fulltext(
+        "Assessment", "last_comment", [asmnt_id]
+    )
+    self.assertEqual(last_comment_records.count(), 1)
+    last_comment_attrs = self.get_model_ca("Assessment", [asmnt_id])
+    self.assertEqual(last_comment_attrs.count(), 1)
+
+    response = self.api.delete(asmnt)
+    self.assert200(response)
+
+    last_comment_records = self.get_model_fulltext(
+        "Assessment", "last_comment", [asmnt_id]
+    )
+    self.assertEqual(last_comment_records.count(), 0)
+    last_comment_attrs = self.get_model_ca("Assessment", [asmnt_id])
+    self.assertEqual(last_comment_attrs.count(), 0)
+
+    # Check that other records weren't affected
+    last_comment_records = self.get_model_fulltext(
+        "Assessment", "last_comment", self.asmnt_comments.keys()
+    )
+    self.assertEqual(last_comment_records.count(), 2)
+    last_comment_attrs = self.get_model_ca(
+        "Assessment", self.asmnt_comments.keys()
+    )
+    self.assertEqual(last_comment_attrs.count(), 2)


### PR DESCRIPTION
# Issue description

The comment data should be calculated and presented to the frontend in the same way as "last assessment date" in order to allow for performant read operations.

this task should ensure that we store the latest comment (or all comments depending on the task requirments) into custom attributes table on correct events:

comment added,
comment deleted (not sure if we have that yet but backend should support it and set the previous comment as "latest")
object deleted (should just delete all computed attributes for that object)
/possible other events that I might have missed)
The task should also ensure this works correctly with imported comments.

# Steps to test the changes

1. Create Assessment.
2. Add comments to it.
3. GET request on /api/assessments should contain fields last_comment_id (with id of last comment), last_comment (with description of last comment)

# Solution description

Added new CA - "Last Comment" in migration.
Added mixin WithLastComment that add fields last_comment and last_comment_id to base model.
Create operation "last_" for returning aggregated last value.
Refactored logic of CA to remove response data duplication.
Insert "" instead of None into `attributes` and `fulltext_record_properties` tables.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# Migration checklist
- [x] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)


# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

