### PR TITLE
GGRC-4296 Populate revision content cavs if cas exist

### DIFF
--- a/src/ggrc/models/revision.py
+++ b/src/ggrc/models/revision.py
@@ -283,7 +283,7 @@ class Revision(Base, db.Model):
         result.append(categorization)
     return {key_name: result}
 
-  def populate_cads(self):
+  def populate_cavs(self):
     """Populate custom_attribute_values based on custom_attributes."""
     if "custom_attributes" not in self._content:
       return {}
@@ -305,7 +305,7 @@ class Revision(Base, db.Model):
     populated_content.update(self._document_evidence_hack())
     populated_content.update(self.populate_categoies("categories"))
     populated_content.update(self.populate_categoies("assertions"))
-    populated_content.update(self.populate_cads())
+    populated_content.update(self.populate_cavs())
     return populated_content
 
   @content.setter

--- a/src/ggrc/models/revision.py
+++ b/src/ggrc/models/revision.py
@@ -283,6 +283,14 @@ class Revision(Base, db.Model):
         result.append(categorization)
     return {key_name: result}
 
+  def populate_cads(self):
+    """Populate custom_attribute_values based on custom_attributes."""
+    if "custom_attributes" not in self._content:
+      return {}
+    if "custom_attribute_values" in self._content:
+      return {}
+    return {"custom_attribute_values": self._content["custom_attributes"]}
+
   @builder.simple_property
   def content(self):
     """Property. Contains the revision content dict.
@@ -297,6 +305,7 @@ class Revision(Base, db.Model):
     populated_content.update(self._document_evidence_hack())
     populated_content.update(self.populate_categoies("categories"))
     populated_content.update(self.populate_categoies("assertions"))
+    populated_content.update(self.populate_cads())
     return populated_content
 
   @content.setter

--- a/test/unit/ggrc/models/test_revision.py
+++ b/test/unit/ggrc/models/test_revision.py
@@ -222,11 +222,12 @@ class TestCheckPopulatedContent(unittest.TestCase):
       ({}, {}),
       ({"custom_attribute_values": [], "custom_attributes": []}, {}),
       ({"custom_attributes": []}, {"custom_attribute_values": []}),
-      ({"custom_attributes": [1,2,3]}, {"custom_attribute_values": [1,2,3]}),
-      ({"custom_attribute_values": [1,2,3]}, {}),
+      ({"custom_attributes": [1, 2, 3]},
+       {"custom_attribute_values": [1, 2, 3]}),
+      ({"custom_attribute_values": [1, 2, 3]}, {}),
   )
   @ddt.unpack
-  def test_populated_content_evidence(self, content, expected_content):
+  def test_populated_content_cavs(self, content, expected_content):
     """Test populated cavs content for revision if start content is {0}."""
     obj = mock.Mock()
     obj.id = self.object_id

--- a/test/unit/ggrc/models/test_revision.py
+++ b/test/unit/ggrc/models/test_revision.py
@@ -217,3 +217,19 @@ class TestCheckPopulatedContent(unittest.TestCase):
         revision._document_evidence_hack(),
         expected_evidence,
     )
+
+  @ddt.data(
+      ({}, {}),
+      ({"custom_attribute_values": [], "custom_attributes": []}, {}),
+      ({"custom_attributes": []}, {"custom_attribute_values": []}),
+      ({"custom_attributes": [1,2,3]}, {"custom_attribute_values": [1,2,3]}),
+      ({"custom_attribute_values": [1,2,3]}, {}),
+  )
+  @ddt.unpack
+  def test_populated_content_evidence(self, content, expected_content):
+    """Test populated cavs content for revision if start content is {0}."""
+    obj = mock.Mock()
+    obj.id = self.object_id
+    obj.__class__.__name__ = self.object_type
+    revision = all_models.Revision(obj, mock.Mock(), mock.Mock(), content)
+    self.assertEqual(expected_content, revision.populate_cads())

--- a/test/unit/ggrc/models/test_revision.py
+++ b/test/unit/ggrc/models/test_revision.py
@@ -233,4 +233,4 @@ class TestCheckPopulatedContent(unittest.TestCase):
     obj.id = self.object_id
     obj.__class__.__name__ = self.object_type
     revision = all_models.Revision(obj, mock.Mock(), mock.Mock(), content)
-    self.assertEqual(expected_content, revision.populate_cads())
+    self.assertEqual(expected_content, revision.populate_cavs())


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

In old revision there is logged "custom_attributes" and there isn't "custom_attribute_values" elements.

# Steps to test the changes

Open old instance revision log (on qa for example resource_type=Workflow&resource_id=818)

# Solution description

populate custom_attribute_values base on custom_attributes (they should be equal)

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
