### PR TITLE
Revert "QUICK-FIX Bump version to 1.4.0-Strawberry"

### DIFF
--- a/src/ggrc/settings/default.py
+++ b/src/ggrc/settings/default.py
@@ -55,7 +55,7 @@ except ImportError:
 # for more info) and if the version name were to exceed 30 characters, all
 # deployments would go to the same GAE app version. Please take that into
 # consideration when modifying this string.
-VERSION = "1.4.0-Strawberry" + BUILD_NUMBER
+VERSION = "1.3.0-Strawberry" + BUILD_NUMBER
 
 # Migration owner
 MIGRATOR = os.environ.get(


### PR DESCRIPTION
Reverts google/ggrc-core#7213

We decided to postpone version 1.4 for one week.