### PR TITLE
GGRC-3502 Add "Last Deprecated Date" for a Cycle Task 

### DIFF
--- a/src/ggrc/models/mixins/__init__.py
+++ b/src/ggrc/models/mixins/__init__.py
@@ -241,6 +241,8 @@ class WithLastDeprecatedDate(object):
     """Autosetup current date as last_deprecated_date
       if 'Deprecated' status will setup."""
     # pylint: disable=unused-argument; key is unused but passed in by ORM
+    if hasattr(super(WithLastDeprecatedDate, self), "validate_status"):
+      value = super(WithLastDeprecatedDate, self).validate_status(key, value)
     if value != self.status and value == self.AUTO_SETUP_STATUS:
       self.last_deprecated_date = datetime.datetime.now()
     return value
@@ -706,9 +708,6 @@ def person_relation_factory(relation_name, fulltext_attr=None, api_attr=None):
 
       _api_attrs = reflection.ApiAttributes(api_attr)
       fulltext_attr = [gen_fulltext_attr]
-
-
-
 
   return type(
       "{}_mixin".format(relation_name),

--- a/src/ggrc_workflows/migrations/versions/20180124112407_54418614dec4_add_field_last_deprecated_date_to_cycle_.py
+++ b/src/ggrc_workflows/migrations/versions/20180124112407_54418614dec4_add_field_last_deprecated_date_to_cycle_.py
@@ -1,0 +1,29 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+add field last_deprecated_date to cycle_task_group_object_tasks
+
+Create Date: 2018-01-24 11:24:07.291724
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '54418614dec4'
+down_revision = '58e0f07e174b'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  op.add_column('cycle_task_group_object_tasks',
+                sa.Column('last_deprecated_date', sa.Date))
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  op.drop_column('cycle_task_group_object_tasks', 'last_deprecated_date')

--- a/src/ggrc_workflows/migrations/versions/20180124112407_54418614dec4_add_field_last_deprecated_date_to_cycle_.py
+++ b/src/ggrc_workflows/migrations/versions/20180124112407_54418614dec4_add_field_last_deprecated_date_to_cycle_.py
@@ -15,7 +15,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '54418614dec4'
-down_revision = '58e0f07e174b'
+down_revision = '3ef189478d4a'
 
 
 def upgrade():

--- a/src/ggrc_workflows/models/cycle_task_group_object_task.py
+++ b/src/ggrc_workflows/models/cycle_task_group_object_task.py
@@ -29,6 +29,7 @@ LOGGER = getLogger(__name__)
 
 class CycleTaskGroupObjectTask(roleable.Roleable,
                                wf_mixins.CycleTaskStatusValidatedMixin,
+                               mixins.WithLastDeprecatedDate,
                                mixins.Stateful,
                                mixins.Timeboxed,
                                relationship.Relatable,

--- a/test/integration/ggrc_workflows/converters/test_column_definitions.py
+++ b/test/integration/ggrc_workflows/converters/test_column_definitions.py
@@ -144,6 +144,7 @@ class TestWorkflowObjectColumnDefinitions(TestCase):
         'Created Date',
         'Last Updated Date',
         'Last Updated By',
+        'Last Deprecated Date',
     }
     expected_names = element_names.union(mapping_names).union(unmapping_names)
     self.assertEqual(expected_names, display_names)

--- a/test/integration/ggrc_workflows/services/test_cycle_task_deprecated.py
+++ b/test/integration/ggrc_workflows/services/test_cycle_task_deprecated.py
@@ -1,0 +1,152 @@
+# coding: utf-8
+
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Tests for last_deprecated_date field in cycle tasks."""
+
+import datetime
+import operator
+from ggrc.models import all_models
+from freezegun import freeze_time
+from integration.ggrc import TestCase
+from integration.ggrc.api_helper import Api
+from integration.ggrc.models import factories
+
+
+class TestCycleTaskDeprecated(TestCase):
+  """Test for correct working field last_deprecated_date."""
+
+  def setUp(self):
+    super(TestCycleTaskDeprecated, self).setUp()
+    self.api = Api()
+
+  def test_redefine_status(self):
+    """Test cycle task create and change status to Deprecated."""
+    cycle_task = factories.get_model_factory("CycleTaskFactory")()
+
+    with freeze_time("2017-01-25"):
+      self.api.modify_object(cycle_task, {
+          "status": "Deprecated"
+      })
+
+    cycle_task_result = all_models.CycleTaskGroupObjectTask.query.filter(
+        all_models.CycleTaskGroupObjectTask.id == cycle_task.id
+    ).one()
+
+    self.assertEquals(cycle_task_result.last_deprecated_date,
+                      datetime.date(2017, 1, 25))
+
+  def test_keep_date_unchanged(self):
+    """Test set status to Deprecated, and then set status to Finished."""
+    cycle_task = factories.get_model_factory("CycleTaskFactory")()
+
+    with freeze_time("2017-01-25"):
+      self.api.modify_object(cycle_task, {
+          "status": "Deprecated"
+      })
+
+    with freeze_time("2017-01-26"):
+      self.api.modify_object(cycle_task, {
+          "status": "Finished"
+      })
+
+      cycle_task_result = all_models.CycleTaskGroupObjectTask.query.filter(
+          all_models.CycleTaskGroupObjectTask.id == cycle_task.id
+      ).one()
+
+    self.assertEquals(cycle_task_result.status, "Finished")
+    self.assertEquals(cycle_task_result.last_deprecated_date,
+                      datetime.date(2017, 1, 25))
+
+  def test_repeat_deprecated_state(self):
+    """Test updating of last deprecated date by multiply changing of status."""
+    cycle_task = factories.get_model_factory("CycleTaskFactory")()
+
+    with freeze_time("2017-01-25"):
+      self.api.modify_object(cycle_task, {
+          "status": "Deprecated"
+      })
+
+    with freeze_time("2017-01-26"):
+      self.api.modify_object(cycle_task, {
+          "status": "Finished"
+      })
+    with freeze_time("2017-02-25"):
+      self.api.modify_object(cycle_task, {
+          "status": "Deprecated"
+      })
+    with freeze_time("2017-02-26"):
+      self.api.modify_object(cycle_task, {
+          "status": "Finished"
+      })
+
+    cycle_task_result = all_models.CycleTaskGroupObjectTask.query.filter(
+        all_models.CycleTaskGroupObjectTask.id == cycle_task.id
+    ).one()
+
+    self.assertEquals(cycle_task_result.status, "Finished")
+    self.assertEquals(cycle_task_result.last_deprecated_date,
+                      datetime.date(2017, 2, 25))
+
+  def test_filter_by_deprecated_date(self):
+    """Test filter cycle task by last deprecated date."""
+    amount_of_cycle_tasks = 5
+    list_of_ids = []
+    cycle_task_factory = factories.get_model_factory("CycleTaskFactory")
+    with factories.single_commit():
+      with freeze_time("2017-01-25"):
+        for _ in range(amount_of_cycle_tasks):
+          list_of_ids.append(
+              cycle_task_factory(status="Deprecated").id
+          )
+
+    query_request_data = [{
+        "object_name": "CycleTaskGroupObjectTask",
+        'filters': {
+            'expression': {
+                'left': 'task Last Deprecated Date',
+                'op': {'name': '='},
+                'right': "2017-01-25",
+            },
+        },
+        'type': 'ids',
+    }]
+
+    result = self.api.send_request(self.api.client.post,
+                                   data=query_request_data,
+                                   api_link="/query")
+    self.assertItemsEqual(list_of_ids,
+                          result.json[0]["CycleTaskGroupObjectTask"]["ids"])
+
+  def test_sort_by_deprecated_date(self):
+    """Test sorting results of filter cycle tasks by deprecated date."""
+    dict_of_dates = {}
+    date_list = ["2017-01-25", "2017-01-29", "2017-01-02", "2017-01-26"]
+    cycle_task_factory = factories.get_model_factory("CycleTaskFactory")
+    with factories.single_commit():
+      for date in date_list:
+        with freeze_time(date):
+          dict_of_dates[cycle_task_factory(status="Deprecated").id] = date
+
+    sorted_dict = sorted(dict_of_dates.items(), key=operator.itemgetter(1))
+    sorted_list_ids = [item[0] for item in sorted_dict]
+
+    query_request_data = [{
+        "object_name": "CycleTaskGroupObjectTask",
+        'filters': {
+            'expression': {
+                'left': 'task Last Deprecated Date',
+                'op': {'name': '='},
+                'right': "2017-01",
+            },
+        },
+        "order_by": [{"name": "last_deprecated_date"}],
+        'type': 'ids',
+    }]
+
+    result = self.api.send_request(self.api.client.post,
+                                   data=query_request_data,
+                                   api_link="/query")
+    self.assertItemsEqual(sorted_list_ids,
+                          result.json[0]["CycleTaskGroupObjectTask"]["ids"])


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Adding new field in `CycleTaskGroupObjectTask` - `last_deprecated_date`, which contains date of last changing status to `Deprecated`.

# Steps to test the changes

1. Create new cycle task.
2. If status of cycle task is not `Deprecated` - field `last_deprecated_date` contains `null`.
3. Change cycle task status to `Deprecated`.
4. Field `last_deprecated_date` contains date of changing cycle task status to `Deprecated` now.


# Solution description

1. A migration has been written that adds a new field `last_deprecated_date` (type - date) to the `cycle_task_group_object_tasks` table.
2. `LastDeprecatedDateDefine` mixin has been used for adding `last_deprecated_date` field to `CycleTaskGroupObjectTask` class.
3. A new tests has been writing for testing behavior of `last_deprecated_date` field in cycle task. 

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
