### PR TITLE
GGRC-4042/4289 Update frontend logic for Workflow/TG fields on CycleTask edit modal

### DIFF
--- a/src/ggrc-client/js/components/workflow/cycle-task-group-object-task/cycle-task-group-object-task.js
+++ b/src/ggrc-client/js/components/workflow/cycle-task-group-object-task/cycle-task-group-object-task.js
@@ -42,14 +42,40 @@ let viewModel = can.Map.extend({
     return dfdResult;
   },
   loadWorkflow: function (cycle) {
-    let workflow = cycle.attr('workflow').reify();
+    const workflowStub = cycle.attr('workflow');
+    let workflow;
 
+    // if a user doesn't have permissions to read the workflow
+    if (!workflowStub) {
+      const workflow = this.buildTrimmedWorkflowObject();
+      this.attr('workflow', workflow);
+      return;
+    }
+
+    workflow = workflowStub.reify();
     return new RefreshQueue().enqueue(workflow)
       .trigger()
       .then(_.first)
       .then(function (loadedWorkflow) {
         this.attr('workflow', loadedWorkflow);
       }.bind(this));
+  },
+  /**
+   * Returns workflow object with trimmed data.
+   * @return {can.Map} - trimmed workflow.
+   */
+  buildTrimmedWorkflowObject() {
+    const instance = this.attr('instance');
+    const workflow = new can.Map({
+      viewLink: this.buildWorkflowLink(),
+      title: instance.attr('workflow_title'),
+    });
+    return workflow;
+  },
+  buildWorkflowLink() {
+    const instance = this.attr('instance');
+    const id = instance.attr('workflow.id');
+    return `/workflows/${id}`;
   },
   onStateChange: function (event) {
     let instance = this.attr('instance');

--- a/src/ggrc-client/js/components/workflow/cycle-task-group-object-task/tests/cycle-task-group-object-task_spec.js
+++ b/src/ggrc-client/js/components/workflow/cycle-task-group-object-task/tests/cycle-task-group-object-task_spec.js
@@ -102,17 +102,31 @@ describe('GGRC.Components.cycleTaskGroupObjectTask', function () {
       });
     });
 
-    describe('loadWorkflow() method', function () {
+    describe('loadWorkflow() method', () => {
+      let cycle;
+
+      beforeEach(function () {
+        cycle = new can.Map();
+      });
+
+      describe('when a user doesn\'t have enough permissions to get ' +
+      'informations about workflow', () => {
+        it('builds trimmed workflow object', function () {
+          const expectedResult = new can.Map();
+          spyOn(viewModel, 'buildTrimmedWorkflowObject')
+            .and.returnValue(expectedResult);
+          viewModel.loadWorkflow(cycle);
+          expect(viewModel.attr('workflow')).toBe(expectedResult);
+        });
+      });
+
       describe('when cycle was loaded successfully', function () {
         let trigger;
         let triggerDfd;
         let reifiedObject;
-        let cycle;
 
         beforeEach(function () {
-          cycle = new can.Map({
-            workflow: {},
-          });
+          cycle.attr('workflow', {});
           reifiedObject = {};
           cycle.attr('workflow').reify = jasmine.createSpy('reify')
             .and.returnValue(reifiedObject);
@@ -160,6 +174,37 @@ describe('GGRC.Components.cycleTaskGroupObjectTask', function () {
               });
           });
         });
+      });
+    });
+
+    describe('buildTrimmedWorkflowObject() method', () => {
+      describe('returns built trimmed workflow object which contains', () => {
+        it('a link to the workfolw', function () {
+          const link = 'www.example.com';
+          let wf;
+          spyOn(viewModel, 'buildWorkflowLink').and.returnValue(link);
+          wf = viewModel.buildTrimmedWorkflowObject();
+          expect(wf.attr('viewLink')).toBe(link);
+        });
+
+        it('a workflow title', function () {
+          const title = '123';
+          let wf;
+          viewModel.attr('instance.workflow_title', title);
+          wf = viewModel.buildTrimmedWorkflowObject();
+          expect(wf.attr('title')).toBe(title);
+        });
+      });
+    });
+
+    describe('buildWorkflowLink() method', () => {
+      it('returns link based on workflow id', function () {
+        const id = 1;
+        const expectedLink = `/workflows/${id}`;
+        let result;
+        viewModel.attr('instance.workflow', {id});
+        result = viewModel.buildWorkflowLink();
+        expect(result).toBe(expectedLink);
       });
     });
 

--- a/src/ggrc/assets/mustache/cycle_task_group_object_tasks/modal_content.mustache
+++ b/src/ggrc/assets/mustache/cycle_task_group_object_tasks/modal_content.mustache
@@ -59,7 +59,7 @@
               data-lookup-cb="set_properties_from_workflow"
               placeholder="Select a Workflow"
               type="text"
-              value="{{workflow.title}}"
+              value="{{firstnonempty instance.workflow_title workflow.title}}"
               tabindex="4" />
             {{#instance.computed_errors.workflow}}<label class="help-inline warning">{{this}}</label>{{/instance.computed_errors.workflow}}
             {{^instance.computed_errors.workflow}}{{#instance.computed_errors.cycle}}<label class="help-inline warning">No active cycles in this workflow</label>{{/instance.computed_errors.cycle}}{{/instance.computed_errors.workflow}}
@@ -68,7 +68,7 @@
               class="input-block-level"
               type="text"
               disabled
-              {$value}="workflow.title" />
+              value="{{firstnonempty instance.workflow_title workflow.title}}" />
           {{/if}}
         {{/using}}
       </div>
@@ -91,7 +91,7 @@
               data-query-relevant-id="{{instance.cycle.id}}"
               placeholder="Select a Task Group"
               type="text"
-              value="{{cycle_task_group.title}}"
+              value="{{firstnonempty instance.cycle_task_group_title cycle_task_group.title}}"
               data-template="/cycle_task_groups/autocomplete_result.mustache"
               tabindex="5" />
             {{else}}
@@ -99,7 +99,7 @@
                 class="input-block-level"
                 type="text"
                 disabled
-                {$value}="cycle_task_group.title" />
+                value="{{firstnonempty instance.cycle_task_group_title instance.workflow_title cycle_task_group.title}}" />
             {{/if}}
         {{/using}}
       {{#instance.computed_errors.cycle_task_group}}<label class="help-inline warning">{{this}}</label>{{/instance.computed_errors.cycle_task_group}}


### PR DESCRIPTION
# Issue description

Cycle Task edit modal and Cycle Task info pane don't show right information about WF and Task group.

![issue 2](https://user-images.githubusercontent.com/13063442/35440881-6d81437a-02b2-11e8-8ba2-fcdaaade0572.png)

![issue 1](https://user-images.githubusercontent.com/13063442/35440882-6d9cbbdc-02b2-11e8-8bfe-911d596fd6c9.png)

![screenshot-1](https://user-images.githubusercontent.com/13063442/35440949-afad093c-02b2-11e8-8df0-b9a80c89cd1d.png)

# Steps to test the changes

ISSUE 1: 
1. Assign a cycle task to Global Creator (who has no WF role). 
2. Log in as a Global Creator.
3. Find a task on My Tasks page.
4. Open task info pane. 

Actual result: WF is missing. An error is thrown. 
Expected result: WF name is displayed as static text (label). 

ISSUE 2: 
1. Assign a cycle task to Global Creator (who has no WF role). 
2. Log in as a Global Creator. 
3. Find a task on My Tasks page.
4. Open cycle task edit pop-up. 

Actual result: WF and Task group fields are empty. User can't save any changes to a task, because workflow field is mandatory and empty and there is no possibility to fill it out. 

Expected result: WF and task group names are displayed as static text (label). User should be able to save changes to a cycle task. BE should calculate such fields and return in CycleTask JSON response.

# Solution description

Back-end solution for this PR - [link](https://github.com/google/ggrc-core/pull/7219).

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->