### PR TITLE
QUICK-FIX Remove deprecated signal from workflow code

### DIFF
--- a/src/ggrc_workflows/__init__.py
+++ b/src/ggrc_workflows/__init__.py
@@ -302,12 +302,6 @@ def build_cycle(workflow, cycle=None, current_user=None):
                        destination=object_)
 
   update_cycle_dates(cycle)
-  Signals.workflow_cycle_start.send(
-      cycle.__class__,
-      obj=cycle,
-      new_status=cycle.status,
-      old_status=None
-  )
   workflow.repeat_multiplier += 1
   workflow.next_cycle_start_date = workflow.calc_next_adjusted_date(
       workflow.min_task_start_date)

--- a/src/ggrc_workflows/services/common.py
+++ b/src/ggrc_workflows/services/common.py
@@ -26,10 +26,3 @@ class Signals():
     This is used to signal any listeners of any changes in model object status
     attribute
     """)
-
-  workflow_cycle_start = signals.signal(
-      'Workflow Cycle Started ',
-      """
-    This is used to signal any listeners of any workflow cycle start
-    attribute
-    """)


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Remove deprecated/unused `workflow_cycle_start` signal from workflow code.
