### PR TITLE
GGRC-4121 Fix permission check for attach-button

### DIFF
--- a/src/ggrc-client/js/components/assessment/attach-button.js
+++ b/src/ggrc-client/js/components/assessment/attach-button.js
@@ -21,7 +21,7 @@ import template from './attach-button.mustache';
           get: function (prevValue, setValue) {
             let instance = this.attr('instance');
             if (Permission.is_allowed_for('update', instance) &&
-              !instance.archived) {
+              !instance.attr('archived')) {
               this.checkFolder().always(function () {
                 setValue(true);
               });


### PR DESCRIPTION
# Issue description

Attach evidence button on the Assessment Info pane is available if Assessment is Archived

# Steps to test the changes

Steps to reproduce:
1. Go to any audit page with created assessment 
2. Archive audit
3. Navigate to Assessment Info pane and click 'Attach' button
*Actual Result:* Attach evidence button on the Assessment Info pane is available if Assessment is Archived
*Expected Result:* Attach evidence button on the Assessment Info pane should not be available for user if Assessment is Archived

# Solution description

Should use `.attr()` to make the `hasPermissions` getter observing `archived` flag.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
