### PR TITLE
GGRC-4351 Fix randomly failing test for setSearchCriteria method

### DIFF
--- a/src/ggrc-client/js/components/external-data-autocomplete/tests/external-data-autocomplete_spec.js
+++ b/src/ggrc-client/js/components/external-data-autocomplete/tests/external-data-autocomplete_spec.js
@@ -95,7 +95,7 @@ describe('GGRC.Components.externalDataAutocomplete', ()=> {
         setTimeout(()=> {
           expect(viewModel.attr('searchCriteria')).toBe('criteria');
           done();
-        }, 500);
+        }, 600);
       });
 
       it('dispatches "criteriaChanged" event', (done)=> {
@@ -109,7 +109,7 @@ describe('GGRC.Components.externalDataAutocomplete', ()=> {
             value: 'criteria',
           });
           done();
-        }, 500);
+        }, 600);
       });
     });
 
@@ -261,4 +261,3 @@ describe('GGRC.Components.externalDataAutocomplete', ()=> {
     });
   });
 });
-


### PR DESCRIPTION
# Issue description

JS unit-test for setSearchCriteria() method randomly fails with an error:
```
Expected spy dispatch to have been called with [ Object(
{ type: 'criteriaChanged', value: 'criteria' }
) ] but it was never called.
```

# Solution description
The test was randomly failing because the method it was testing is wrapped with lodash debounce with timeout of 500ms and the test has a code which waits for 500ms to check the result. 
Due to the nature of JS timers and the current load of event loop the execution order of timeout callbacks is not guaranteed and sometimes code that checks the result of the method execution was called before the method itself. The solutions is simple - increase the time we wait for result in the test.

# Sanity checklist

- [ ] __N/A__ ~~I have clicked through the app to make sure my changes work and not break the app.~~
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] __N/A__ ~~My changes are covered by tests.~~
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".