### PR TITLE
GGRC-3027 Fix assessment generation with missing roles

### DIFF
--- a/test/unit/ggrc/models/hooks/test_assessment.py
+++ b/test/unit/ggrc/models/hooks/test_assessment.py
@@ -1,0 +1,67 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Test assessment hooks."""
+
+import unittest
+
+import ddt
+import mock
+
+from ggrc.models.hooks import assessment
+
+
+@ddt.ddt
+class TestFromSession(unittest.TestCase):
+  """Test session-listener wrapper.
+
+  Models are substituted with builtin types as they can be used for
+  isinstance checks too.
+  """
+
+  def setUp(self):
+    super(TestFromSession, self).setUp()
+    self.session = mock.Mock()
+
+  @ddt.data(
+      ([], {'Auditors': [], 'Audit Lead': []}),
+      (
+          [{"ac_role_id": 5, "person_id": 1}],
+          {'Auditors': [], 'Audit Lead': []}
+      ),
+      (
+          [{"ac_role_id": 1, "person_id": 1}],
+          {'Auditors': [1], 'Audit Lead': []}
+      ),
+      (
+          [
+              {"ac_role_id": 1, "person_id": 1},
+              {"ac_role_id": 5, "person_id": 2},
+              {"ac_role_id": 6, "person_id": 3},
+          ],
+          {'Auditors': [1], 'Audit Lead': []},
+      ),
+  )
+  @ddt.unpack
+  def test_generate_role_object_dict(self, content_acl, expected):
+    """Generate role object should not fail on a missing role for
+
+    This test checks that any role can be missing and the roles dict is still
+    returned. This is okay if the missing roles are editable, this test does
+    not check that we actually can't remove non-editable roles.
+    """
+    mock_path = "ggrc.access_control.role.get_custom_roles_for"
+    with mock.patch(mock_path) as roles_mock:
+      roles_mock.return_value = {
+          1: "Auditors",
+          2: "Audit Captains",
+      }
+      assessment.logger = mock.MagicMock()
+      audit = mock.MagicMock()
+      audit.access_control_list = []
+      snapshot = mock.MagicMock()
+      snapshot.revision.content = {
+          "access_control_list": content_acl,
+      }
+      acl_dict = assessment.generate_role_object_dict(snapshot, audit)
+      self.assertEqual(acl_dict, expected)


### PR DESCRIPTION
# Issue description

Assessment generation fails for objects tat have had some custom role removed and have an acl entry for that role in their revisions.

# Steps to test the changes

> Steps to reproduce:
> 1. Have custom role field for control
> 2. Have a program with mapped control with added person in the custom role field
> 3. Delete custom role field for control
> 4. Make a snapshot of the control
> 5. Generate assessment using control's snapshot
> 6. Look at the screen
> Actual Result: Backend fails, user is not notified and spinner is turning around endlessly
> Expected Result: Assessment should be generated and displayed in tree view in the Assessment tab


# Solution description

In assessment generation we should we should ignore any ACL entry for a
role that was deleted, because those roles can not be selected for
default assessment roles. For those we only use non editable roles which
should always be in our db. This fix ensures that assessment generation
will not fail due to unneeded data missing.

Note: 
Another way of solving this (a preferred way) would be to store ACR content in the revision itself and not read those from the database, but that that will be done in a separate ticket. Doing that would mean too much work for just fixing assessment generation and we don't have that ticket yet on our timeline.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
