### PR TITLE
GGRC-4295/4329/4334 Global Reader as workflow Admin doesn't see Start button for cycle task

### DIFF
--- a/src/ggrc-client/js/components/workflow/cycle-task-group-object-task/templates/cycle-task-group-object-task.mustache
+++ b/src/ggrc-client/js/components/workflow/cycle-task-group-object-task/templates/cycle-task-group-object-task.mustache
@@ -217,6 +217,8 @@
                             href="javascript://"
                             class="btn btn-darkBlue btn-mini section-create"
                             data-object-singular-override="Comment"
+                            data-form-target="nothing"
+                            data-refresh="false"
                             data-toggle="modal-ajax-form"
                             data-modal-reset="reset"
                             data-dirty="#regulations, #combo"

--- a/src/ggrc-client/js/components/workflow/tests/workflow-helpers_spec.js
+++ b/src/ggrc-client/js/components/workflow/tests/workflow-helpers_spec.js
@@ -1,0 +1,52 @@
+/*
+    Copyright (C) 2018 Google Inc.
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+import workflowHelpers from '../workflow-helpers';
+
+describe('Workflow helpers', () => {
+  describe('createCycle() method', () => {
+    describe('returns cycle instance which contains', () => {
+      let workflow;
+
+      beforeEach(function () {
+        workflow = new CMS.Models.Workflow();
+        workflow.context = {
+          stub: jasmine.createSpy('stub'),
+        };
+      });
+
+      it('context equals to workflow context stub object', function () {
+        const stub = {
+          id: 123,
+          type: 'Context',
+        };
+        let context;
+        workflow.context.stub.and.returnValue(stub);
+        context = workflowHelpers
+          .createCycle(workflow)
+          .attr('context');
+        expect(context.attr()).toEqual(stub);
+      });
+
+      it('workflow equals to workflow stub object', function () {
+        const stub = {
+          id: 123,
+          type: 'Workflow',
+        };
+        let wfStub;
+        workflow.attr('id', stub.id);
+        wfStub = workflowHelpers
+          .createCycle(workflow)
+          .attr('workflow');
+        expect(wfStub.attr()).toEqual(stub);
+      });
+
+      it('autogenerate property equals to true', function () {
+        const {autogenerate} = workflowHelpers.createCycle(workflow);
+        expect(autogenerate).toBe(true);
+      });
+    });
+  });
+});

--- a/src/ggrc-client/js/components/workflow/workflow-activate.js
+++ b/src/ggrc-client/js/components/workflow/workflow-activate.js
@@ -85,6 +85,10 @@ export default can.Component.extend({
           .then(function () {
             return workflow.refresh_all('task_groups', 'task_group_tasks');
           })
+          .then(() => {
+            const cycleStub = workflow.attr('cycles')[0];
+            workflowHelpers.redirectToCycle(cycleStub);
+          })
           .always(restoreButton);
       } else {
         workflowHelpers.generateCycle(workflow)

--- a/src/ggrc-client/js/components/workflow/workflow-activate.js
+++ b/src/ggrc-client/js/components/workflow/workflow-activate.js
@@ -68,16 +68,6 @@ export default can.Component.extend({
             workflow.attr('status', 'Active');
             return workflow.save();
           })
-          .then(function (workflow) {
-            if (moment(workflow.next_cycle_start_date)
-                .isSame(moment(), 'day')) {
-              return new CMS.Models.Cycle({
-                context: workflow.context.stub(),
-                workflow: {id: workflow.id, type: 'Workflow'},
-                autogenerate: true,
-              }).save();
-            }
-          })
           .then(function () {
             let WorkflowExtension =
               _.find(GGRC.extensions, function (extension) {

--- a/src/ggrc-client/js/components/workflow/workflow-activate.js
+++ b/src/ggrc-client/js/components/workflow/workflow-activate.js
@@ -7,6 +7,7 @@ import workflowHelpers from './workflow-helpers';
 import {
   initCounts,
 } from '../../plugins/utils/current-page-utils';
+import Permission from '../../permission';
 
 export default can.Component.extend({
   tag: 'workflow-activate',
@@ -68,6 +69,7 @@ export default can.Component.extend({
             workflow.attr('status', 'Active');
             return workflow.save();
           })
+          .then(() => Permission.refresh())
           .then(function () {
             let WorkflowExtension =
               _.find(GGRC.extensions, function (extension) {

--- a/src/ggrc-client/js/components/workflow/workflow-helpers.js
+++ b/src/ggrc-client/js/components/workflow/workflow-helpers.js
@@ -5,7 +5,41 @@
 
 import {confirm} from '../../plugins/utils/modals';
 
+/**
+ * A set of properties which describe minimum information
+ * about cycle.
+ * @typedef {Object} CycleStub
+ * @property {number} id - cycle id.
+ * @property {string} type - cycle type.
+ * @example
+ * // stub for cycle
+ * const cycleStub = {
+ *  id: 123,
+ *  type: "Cycle",
+ * };
+ */
+
 export default {
+  /**
+   * Creates cycle instance.
+   * @param {CMS.Models.Workflow} workflow - a workflow instance.
+   * @return {CMS.Models.Cycle} - a new cycle based on workflow.
+   */
+  createCycle(workflow) {
+    return new CMS.Models.Cycle({
+      context: workflow.context.stub(),
+      workflow: {id: workflow.id, type: 'Workflow'},
+      autogenerate: true,
+    });
+  },
+  /**
+   * Redirects to cycle with certain id.
+   * @param {CMS.Models.Cycle|CycleStub} cycle - an object containing cycle id.
+   * @param {number} id - cycle id.
+   */
+  redirectToCycle({id}) {
+    window.location.hash = `current_widget/cycle/${id}`;
+  },
   generateCycle: function (workflow) {
     let dfd = new $.Deferred();
     let cycle;
@@ -19,24 +53,20 @@ export default {
       content_view: GGRC.mustache_path +
         '/workflows/confirm_start.mustache',
       instance: workflow,
-    }, function (params, option) {
+    }, (params, option) => {
       let data = {};
 
       can.each(params, function (item) {
         data[item.name] = item.value;
       });
 
-      cycle = new CMS.Models.Cycle({
-        context: workflow.context.stub(),
-        workflow: {id: workflow.id, type: 'Workflow'},
-        autogenerate: true,
-      });
+      cycle = this.createCycle(workflow);
 
-      cycle.save().then(function (cycle) {
+      cycle.save().then((cycle) => {
         // Cycle created. Workflow started.
-        setTimeout(function () {
+        setTimeout(() => {
           dfd.resolve();
-          window.location.hash = 'current_widget/cycle/' + cycle.id;
+          this.redirectToCycle(cycle);
         }, 250);
       });
     }, function () {

--- a/src/ggrc-client/js/models/cycle_models.js
+++ b/src/ggrc-client/js/models/cycle_models.js
@@ -3,6 +3,7 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 */
 
+import Permission from '../permission';
 import RefreshQueue from './refresh_queue';
 import {getClosestWeekday} from '../plugins/utils/date-util';
 
@@ -18,6 +19,7 @@ import {getClosestWeekday} from '../plugins/utils/date-util';
   function refreshAttrWrap(attr) {
     return function (ev, instance) {
       if (instance instanceof this) {
+        Permission.refresh();
         refreshAttr(instance, attr);
       }
     };


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

_4295_ - Global Reader as workflow Admin doesn't see Start button for cycle task
_4329_ - Global Creator as workflow Admin doesn't see Start button for cycle task
_4334_ - Active Cycles tab is not preselected after activating Repeatable Workflow

# Steps to test the changes

*4295*:
Steps to reproduce: 
1. Log as Global Reader and create any workflow 
2. Add a task (assignee - Global Reader) to TG and Activate workflow 
3. At the Active Cycles tab try to Start a task: no success 

Actual Result: Global Reader as workflow Admin doesn't see Start button for cycle task 
Expected Result: Global Reader as workflow Admin should see Start button for cycle task Workaround: refresh the page with Active Cycle Tab - button appears.

*4329*:
Steps to reproduce: 
1. Log as Global Creator and create any workflow 
2. Add a task to TG and Activate workflow 
3. Clone WF 
4. Go to cloned workflow. Activate workflow. Open Active Cycles tab. 
5. At the Active Cycles tab try to Start a task: no success 

Actual Result: Global Creator as workflow Admin doesn't see Start button for cycle task 
Expected Result: Global Creator as workflow Admin should see Start button for cycle task Workaround: refresh the page with Active Cycle Tab - button appears.

*4334*:
Steps to reproduce:
1. Create monthly workflow
2. In the setup tab add a task to Task Group and activate workflow

Actual Result: Setup tab is displayed
Expected Result: Active cycles tab should be displayed after activating Repeat off and Repeat on workflows

# Solution description

_4295/4329_
Update permission after Cycle or Cycle Task Entry creation (they use both one method and have to have updated permissions).

_4334_
Make redirection to certain cycle.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
