### PR TITLE
GGRC-4355 Add audit stub as a field of Assessment Template

### DIFF
--- a/src/ggrc/migrations/versions/20180209123055_4303f98eec2c_add_audit_id_fk_to_assessmenttemplate.py
+++ b/src/ggrc/migrations/versions/20180209123055_4303f98eec2c_add_audit_id_fk_to_assessmenttemplate.py
@@ -1,0 +1,70 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Add audit_id FK to AssessmentTemplate
+
+Create Date: 2018-02-09 12:30:55.505996
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+import sqlalchemy as sa
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '4303f98eec2c'
+down_revision = '4e5ef956af94'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  op.add_column(
+      "assessment_templates",
+      sa.Column("audit_id", sa.Integer(), nullable=True)
+  )
+
+  op.execute("""
+      UPDATE assessment_templates
+      JOIN (
+          SELECT a.id audit_id, at.id template_id
+          FROM audits a
+          JOIN relationships r ON
+            r.source_id = a.id AND
+            r.source_type = 'Audit' AND
+            r.destination_type = 'AssessmentTemplate'
+          JOIN assessment_templates at ON at.id = r.destination_id
+
+          UNION ALL
+
+          SELECT a.id, at.id
+          FROM audits a
+          JOIN relationships r ON
+            r.destination_id = a.id AND
+            r.destination_type = 'Audit' AND
+            r.source_type = 'AssessmentTemplate'
+          JOIN assessment_templates at ON at.id = r.source_id
+      ) temp ON temp.template_id = assessment_templates.id
+      SET assessment_templates.audit_id = temp.audit_id
+  """)
+
+  op.create_foreign_key(
+      "fk_assessment_template_audits",
+      "assessment_templates",
+      "audits",
+      ["audit_id"],
+      ["id"],
+      ondelete='SET NULL'
+  )
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  op.drop_constraint(
+      "fk_assessment_template_audits",
+      "assessment_templates",
+      type_="foreignkey"
+  )
+  op.drop_column("assessment_templates", "audit_id")

--- a/src/ggrc/models/assessment.py
+++ b/src/ggrc/models/assessment.py
@@ -17,7 +17,7 @@ from ggrc.builder import simple_property
 from ggrc.fulltext import mixin
 from ggrc.models.comment import Commentable
 from ggrc.models.custom_attribute_definition import CustomAttributeDefinition
-from ggrc.models import issuetracker_issue
+from ggrc.models import issuetracker_issue, audit
 from ggrc.models.mixins import with_last_comment
 from ggrc.models.mixins.audit_relationship import AuditRelationship
 from ggrc.models.mixins import BusinessObject
@@ -42,22 +42,6 @@ from ggrc.models import reflection
 from ggrc.models.relationship import Relatable
 from ggrc.models.track_object_state import HasObjectState
 from ggrc.fulltext.mixin import Indexed
-
-
-def _build_audit_stub(assessment_obj):
-  """Returns a stub of audit model to which assessment is related to."""
-  audit_id = assessment_obj.audit_id
-  if audit_id is None:
-    return None
-  issue_obj = issuetracker_issue.IssuetrackerIssue.get_issue(
-      'Audit', audit_id)
-  return {
-      'type': 'Audit',
-      'id': audit_id,
-      'context_id': assessment_obj.context_id,
-      'href': u'/api/audits/%d' % audit_id,
-      'issue_tracker': issue_obj.to_dict() if issue_obj is not None else {},
-  }
 
 
 class Assessment(Roleable, statusable.Statusable, AuditRelationship,
@@ -163,7 +147,7 @@ class Assessment(Roleable, statusable.Statusable, AuditRelationship,
   ]
 
   _custom_publish = {
-      'audit': _build_audit_stub,
+      'audit': audit.build_audit_stub,
   }
 
   @classmethod

--- a/src/ggrc/models/assessment_template.py
+++ b/src/ggrc/models/assessment_template.py
@@ -3,7 +3,7 @@
 
 
 """A module containing the implementation of the assessment template entity."""
-
+from sqlalchemy import orm
 from sqlalchemy.orm import validates
 from werkzeug.exceptions import Forbidden
 
@@ -54,6 +54,9 @@ class AssessmentTemplate(assessment.AuditRelationship, relationship.Relatable,
   # within the releated audit
   default_people = db.Column(JsonType, nullable=False)
 
+  # parent audit
+  audit_id = db.Column(db.Integer, db.ForeignKey('audits.id'), nullable=True)
+
   # labels to show to the user in the UI for various default people values
   DEFAULT_PEOPLE_LABELS = {
       "Admin": "Object Admins",
@@ -79,6 +82,7 @@ class AssessmentTemplate(assessment.AuditRelationship, relationship.Relatable,
       'test_plan_procedure',
       'procedure_description',
       'default_people',
+      'audit',
       reflection.Attribute('issue_tracker', create=False, update=False),
       reflection.Attribute('archived', create=False, update=False),
       reflection.Attribute(
@@ -145,6 +149,20 @@ class AssessmentTemplate(assessment.AuditRelationship, relationship.Relatable,
           ),
       },
   }
+
+  @classmethod
+  def eager_query(cls):
+    query = super(AssessmentTemplate, cls).eager_query()
+    return query.options(
+        orm.Load(cls).joinedload("audit").undefer_group("Audit_complete")
+    )
+
+  @classmethod
+  def indexed_query(cls):
+    query = super(AssessmentTemplate, cls).indexed_query()
+    return query.options(
+        orm.Load(cls).joinedload("audit").undefer_group("Audit_complete")
+    )
 
   @classmethod
   def _nop_filter(cls, _):

--- a/src/ggrc/models/assessment_template.py
+++ b/src/ggrc/models/assessment_template.py
@@ -93,6 +93,10 @@ class AssessmentTemplate(assessment.AuditRelationship, relationship.Relatable,
       "archived"
   ]
 
+  _custom_publish = {
+      'audit': audit.build_audit_stub,
+  }
+
   _aliases = {
       "status": {
           "display_name": "State",

--- a/src/ggrc/models/audit.py
+++ b/src/ggrc/models/audit.py
@@ -246,3 +246,19 @@ class Audit(Snapshotable,
         orm.subqueryload('object_people').joinedload('person'),
         orm.subqueryload('audit_objects'),
     )
+
+
+def build_audit_stub(obj):
+  """Returns a stub of audit model to which assessment is related to."""
+  audit_id = obj.audit_id
+  if audit_id is None:
+    return None
+  issue_obj = issuetracker_issue.IssuetrackerIssue.get_issue(
+      'Audit', audit_id)
+  return {
+      'type': 'Audit',
+      'id': audit_id,
+      'context_id': obj.context_id,
+      'href': '/api/audits/%d' % audit_id,
+      'issue_tracker': issue_obj.to_dict() if issue_obj is not None else {},
+  }

--- a/src/ggrc/models/audit.py
+++ b/src/ggrc/models/audit.py
@@ -74,6 +74,7 @@ class Audit(Snapshotable,
   issues = db.relationship('Issue', backref='audit')
   archived = deferred(db.Column(db.Boolean,
                       nullable=False, default=False), 'Audit')
+  assessment_templates = db.relationship('AssessmentTemplate', backref='audit')
 
   _api_attrs = reflection.ApiAttributes(
       'report_start_date',

--- a/test/integration/ggrc/models/test_assessment_template.py
+++ b/test/integration/ggrc/models/test_assessment_template.py
@@ -1,0 +1,69 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Tests for AssessmentTemplate model."""
+from ggrc.models import all_models
+
+from integration.ggrc import TestCase, Api
+from integration.ggrc.models import factories
+
+
+class TestAssessmentTemplate(TestCase):
+  """ Test AssessmentTemplate class. """
+  def setUp(self):
+    super(TestAssessmentTemplate, self).setUp()
+    self.api = Api()
+
+  def test_audit_setup(self):
+    """Test audit setup for assessment_template"""
+    audit = factories.AuditFactory()
+    response = self.api.post(all_models.AssessmentTemplate, {
+        "assessment_template": {
+            "audit": {"id": audit.id},
+            "context": {"id": audit.context.id},
+            "default_people": {
+                "assignees": "Admin",
+                "verifiers": "Admin",
+            },
+            "title": "Some title"
+        }
+    })
+    self.assertStatus(response, 201)
+    template_id = response.json["assessment_template"]["id"]
+    template = all_models.AssessmentTemplate.query.get(template_id)
+    self.assertEqual(template.audit.id, audit.id)
+
+  def test_audit_issue_tracker(self):
+    """Test existing audit issue_tracker info in template response"""
+    with factories.single_commit():
+      audit = factories.AuditFactory()
+      audit_id = audit.id
+      factories.IssueTrackerIssueFactory(
+          issue_tracked_obj=audit,
+          component_id="some id",
+          hotlist_id="some host id",
+      )
+      template_id = factories.AssessmentTemplateFactory(
+          audit=audit,
+          context=audit.context
+      ).id
+    response = self.api.get(all_models.AssessmentTemplate, template_id)
+    self.assert200(response)
+    audit = all_models.Audit.query.get(audit_id)
+    self.assertEqual(
+        response.json["assessment_template"]["audit"],
+        {
+            "type": "Audit",
+            "id": audit.id,
+            "href": "/api/audits/{}".format(audit.id),
+            "context_id": audit.context.id,
+            "issue_tracker": {
+                "component_id": "some id",
+                "enabled": False,
+                "issue_severity": None,
+                "hotlist_id": "some host id",
+                "issue_priority": None,
+                "issue_type": None
+            }
+        }
+    )


### PR DESCRIPTION
# Issue description

Assessment Template can be mapped to one and only one Audit. It is not guaranteed by the DB schema currently, and it should be fixed by adding audit_id column (same as Assessment has).

The FE needs to have an `audit` field on Assessment Templates to get the relevant Audit easily (needed to improve performance of Issue Tracker functionality).

# Steps to test the changes

Send GET request to `/api/assessment_templates`. Templates in response should contain stub with audit info.

# Solution description

Add audit_id to AssessmentTemplate (with FK and backref)
Set audit_id for old Assessment Templates
Add issuetracker info to audit stub

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# Migration checklist
- [x] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".