### PR TITLE
GGRC-4084 Verified flag and Verified Date are not cleared when the assessment moves back to in-review state

### DIFF
--- a/src/ggrc/models/mixins/__init__.py
+++ b/src/ggrc/models/mixins/__init__.py
@@ -437,8 +437,7 @@ class VerifiedDate(object):
             self.status not in self.VERIFIED_STATES):
       self.verified_date = datetime.datetime.now()
       value = self.FINAL_STATE
-    elif (value not in self.VERIFIED_STATES and
-          value not in self.DONE_STATES and
+    elif (value not in self.END_STATES and
           (self.status in self.VERIFIED_STATES or
            self.status in self.DONE_STATES)):
       self.verified_date = None

--- a/test/integration/ggrc/models/mixins/test_verified_date.py
+++ b/test/integration/ggrc/models/mixins/test_verified_date.py
@@ -1,0 +1,34 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Integration tests for VerifiedDate mixin"""
+
+from ggrc.models.assessment import Assessment
+from integration.ggrc import TestCase
+from integration.ggrc.models import factories
+from integration.ggrc import api_helper
+
+
+# pylint: disable=super-on-old-class; TestCase is a new-style class
+class TestVerifiedDate(TestCase):
+  """Integration tests suite for TestVerifiedDate mixin"""
+
+  # pylint: disable=invalid-name
+
+  def setUp(self):
+    super(TestVerifiedDate, self).setUp()
+    self.api_helper = api_helper.Api()
+    self.assessment = factories.AssessmentFactory(
+        status=Assessment.PROGRESS_STATE,
+    )
+
+  def test_validates_with_no_mandatory_ca(self):
+    """Test verified date and verified flag are reset on Undo."""
+    response = self.api_helper.modify_object(self.assessment, {
+        "status": "Verified",
+    })
+    self.assertEqual(response.json["assessment"]["verified"], True)
+    response = self.api_helper.modify_object(self.assessment, {
+        "status": "In Review",
+    })
+    self.assertEqual(response.json["assessment"]["verified"], False)


### PR DESCRIPTION
# Issue description

When user verifies an Assessment and then changes his mind and does "Undo" the Assessment does not reset it's verified date and hence the verified flag.

# Steps to test the changes

1. Assign yourself a verifier of an Assessment
2. Complete then verify the Assessment
3. Click "Undo" to step back and move it to "In review" state.
4. Refresh the list of assessments and check if the verified flag and verified date are cleared.

# Solution description

The condition for clearing the verified date was wrong. It did not allow to reset the field when assessment moved from a "completed" state to "In Review" state as "In Review" state is considered one of the DONE_STATED.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
