### PR TITLE
GGRC-4380 Program role propagation for automappings

### DIFF
--- a/src/ggrc/automapper/__init__.py
+++ b/src/ggrc/automapper/__init__.py
@@ -7,10 +7,13 @@ from datetime import datetime
 from logging import getLogger
 
 import sqlalchemy as sa
+from sqlalchemy.orm import load_only
+from sqlalchemy.sql.expression import literal_column
 
 from ggrc import db
 from ggrc.automapper import rules
 from ggrc import login
+from ggrc.models import all_models
 from ggrc.models.audit import Audit
 from ggrc.models.automapping import Automapping
 from ggrc.models.relationship import Relationship, RelationshipsCache, Stub
@@ -41,6 +44,7 @@ class AutomapperGenerator(object):
     self.processed = set()
     self.queue = set()
     self.auto_mappings = set()
+    self.automapping_ids = set()
     self.related_cache = RelationshipsCache()
 
   def related(self, obj):
@@ -61,6 +65,7 @@ class AutomapperGenerator(object):
     return (src, dst) if src < dst else (dst, src)
 
   def generate_automappings(self, relationship):
+    # pylint: disable=protected-access
     self.auto_mappings = set()
     with benchmark("Automapping generate_automappings"):
       # initial relationship is special since it is already created and
@@ -130,7 +135,8 @@ class AutomapperGenerator(object):
               destination_type=parent_relationship.destination_type,
           )
       )
-      automapping_id = automapping_result.inserted_primary_key
+      automapping_id = automapping_result.inserted_primary_key[0]
+      self.automapping_ids.add(automapping_id)
       now = datetime.now()
       # We are doing an INSERT IGNORE INTO here to mitigate a race condition
       # that happens when multiple simultaneous requests create the same
@@ -169,6 +175,67 @@ class AutomapperGenerator(object):
                 automapping_id=automapping_id,
             )
         )
+
+  def propagate_acl(self):
+    """Propagate acl records for newly created automappings"""
+
+    if not self.automapping_ids:
+      return
+
+    rel = Relationship.__table__
+    acl = all_models.AccessControlList.__table__
+    acr = all_models.AccessControlRole.__table__
+    propagate_roles = {
+        "Program Managers": "Program Managers Mapped",
+        "Program Editors": "Program Editors Mapped",
+        "Program Readers": "Program Readers Mapped"
+    }
+    roles = all_models.AccessControlRole.query.filter(
+        all_models.AccessControlRole.name.in_(
+            propagate_roles.values() + list(propagate_roles))
+    ).options(
+        load_only("id", "name")).all()
+    role_map = {
+        role.name: role.id for role in roles
+    }
+    source = {
+        "id": rel.c.source_id,
+        "type": rel.c.source_type
+    }
+    destination = {
+        "id": rel.c.destination_id,
+        "type": rel.c.destination_type
+    }
+
+    for role in propagate_roles:
+      prop_role_id = role_map[propagate_roles[role]]
+      for (first, second) in ((source, destination), (destination, source)):
+        sql = sa.sql.expression.select([
+            acl.c.person_id,
+            literal_column(str(prop_role_id)),
+            first["id"],
+            first["type"],
+            acl.c.created_at,
+            acl.c.updated_at,
+            acl.c.id
+        ]).select_from(
+            rel.join(acl, sa.and_(
+                second["id"] == acl.c.object_id,
+                second["type"] == acl.c.object_type,
+            )).join(acr, acl.c.ac_role_id == acr.c.id)
+        ).where(sa.and_(
+            rel.c.automapping_id.in_(self.automapping_ids),
+            acr.c.name == role
+        ))
+        db.session.execute(acl.insert().from_select([
+            acl.c.person_id,
+            acl.c.ac_role_id,
+            acl.c.object_id,
+            acl.c.object_type,
+            acl.c.created_at,
+            acl.c.updated_at,
+            acl.c.parent_id], sql
+        ))
 
   @staticmethod
   def _set_audit_id_for_issues(automapping_id):
@@ -243,9 +310,11 @@ def register_automapping_listeners():
   # pylint: disable=unused-variable,unused-argument
 
   def automap(session, _):
+    """Automap after_flush handler."""
     automapper = AutomapperGenerator()
     for obj in session.new:
       if isinstance(obj, Relationship):
         automapper.generate_automappings(obj)
+    automapper.propagate_acl()
 
   sa.event.listen(sa.orm.session.Session, "after_flush", automap)


### PR DESCRIPTION
# TODO

- [x] Propagate objects directly mapped to the program
- [ ] ~Propagate second level objects (Comments, Documents)~ **Going to be done in a separate PR, since this is not a regression (comments & documents were not propagated correctly before the program acl changes**.

# Issue description

Objects mapped through automappings don't propagate program roles, this means that the creator user will only be able to see objects that were directly mapped to the program.

# Steps to test the changes

As admin:
1. Create a program and add a creator user as program readers/editors/managers
2. Create a regulation and map it to the program
3. Create a section and map it to the regulation
Log in as creator and go to the program page:
Expected: Creator should see both Regulation and Section mapped to the program
Actual: Creator sees the regulation but not the section mapped to the program

# Solution description

The solution adds an additional step to the automapper that inserts the necessary acl records for all newly created mappings.

The current solution does not propagate the permissions to 2nd level mapped objects (Documents/Comments) because the solution for this needs to be done for all custom and internal roles in a unified way. I have some work for this already started (tests + automapper fixes: https://github.com/google/ggrc-core/compare/dev...Smotko:document-propagation?expand=1 but the changes will be too big to go into release so they'll need to be merged into dev. 

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
