### PR TITLE
GGRC-4389 Use a set for resources instead of a list

### DIFF
--- a/src/ggrc/automapper/__init__.py
+++ b/src/ggrc/automapper/__init__.py
@@ -44,6 +44,7 @@ class AutomapperGenerator(object):
     self.related_cache = RelationshipsCache()
 
   def related(self, obj):
+    """Return obj's relationship stubs"""
     if obj in self.related_cache.cache:
       return self.related_cache.cache[obj]
 
@@ -96,7 +97,7 @@ class AutomapperGenerator(object):
       if len(self.auto_mappings) <= self.COUNT_LIMIT:
         self._flush(relationship)
       else:
-        relationship._json_extras = {
+        relationship._json_extras = {  # pylint: disable=protected-access
             'automapping_limit_exceeded': True
         }
 

--- a/src/ggrc/views/__init__.py
+++ b/src/ggrc/views/__init__.py
@@ -190,11 +190,22 @@ def do_reindex():
   start_compute_attributes("all_latest")
 
 
+class SetEncoder(json.JSONEncoder):
+  """Encoder that can handle python sets"""
+  # pylint: disable=E0202
+  def default(self, obj):
+    """If we get a set we first transform it to a list and then just use
+       the default encoder"""
+    if isinstance(obj, set):
+      return list(obj)
+    return super(SetEncoder, self).default(obj)
+
+
 def get_permissions_json():
   """Get all permissions for current user"""
   with benchmark("Get permission JSON"):
     permissions.permissions_for(permissions.get_user())
-    return json.dumps(getattr(g, '_request_permissions', None))
+    return json.dumps(getattr(g, '_request_permissions', None), cls=SetEncoder)
 
 
 def get_config_json():

--- a/src/ggrc_basic_permissions/__init__.py
+++ b/src/ggrc_basic_permissions/__init__.py
@@ -324,8 +324,8 @@ def load_access_control_list(user, permissions):
         continue
       permissions.setdefault(action, {})\
           .setdefault(object_type, {})\
-          .setdefault('resources', list())\
-          .append(object_id)
+          .setdefault('resources', set())\
+          .add(object_id)
 
 
 def load_backlog_workflows(permissions):


### PR DESCRIPTION
# Issue description

Memchache was failing because our permission dict has gotten too big.
This will help reduce the size by a lot, because we were inserting a lot
of duplicates.

# Steps to test the changes

Log in as a user with a lot of programs/workflows/assessment assignees.

# Solution description


Before:
<img width="764" alt="screen shot 2018-02-01 at 16 54 18" src="https://user-images.githubusercontent.com/513444/35688624-dfe0ba40-0771-11e8-97d5-4a3fe5f73b52.png">

After:
<img width="769" alt="screen shot 2018-02-01 at 16 57 06" src="https://user-images.githubusercontent.com/513444/35688641-e76a9c18-0771-11e8-9bbb-67752065e52f.png">

Keep in mind that these are just the lists for read, we also have similar lists for update, delete and view_object_page.

This reduces the amount of data we are storing in the permissions dict, but I'm not sure if this change will be good enough.

We could also remove the view_object_page set since it's basically the same as read and that would reduce the amount of data stored by 1/4.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [ ] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
