### PR TITLE
QUICK-FIX Fix edge case when tooltip hides right after appearing

### DIFF
--- a/src/ggrc-client/js/plugins/tooltip.js
+++ b/src/ggrc-client/js/plugins/tooltip.js
@@ -36,7 +36,14 @@
   function isElementVisible(el) {
     const bRect = el.getBoundingClientRect();
     const topEl = document.elementFromPoint(bRect.x, bRect.y);
-    return topEl && (el === topEl || isChildOf(topEl, el));
+    // Due to various reasons of how browser determines layering of elements on
+    // the page, topEl returned from elementFromPoint can either be element or
+    // its inner child
+    return topEl && (
+      el === topEl ||
+      isChildOf(topEl, el) ||
+      isChildOf(el, topEl)
+    );
   }
 
   /**


### PR DESCRIPTION
# Issue description

In some cases tooltip hides right after it's shown. 

# Steps to test the changes

1. Create workflow, add task and activate workflow.
2. Goto Dashboard and hover over the grey progress bar of the workflow
Prior to this PR's changes tooltip was hiding right after it's shown.

![hiding-tooltip](https://user-images.githubusercontent.com/85838/35724586-534d47f8-080f-11e8-934c-596cc91d2d3a.gif)

# Solution description

Add check if element returned from elementFromPoint is a child of the element from which the tooltip is triggered.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] __N/A__ ~~My changes are covered by tests.~~
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".