### PR TITLE
GGRC-4118 Make person-info not editable on assessment_template info-pin

### DIFF
--- a/src/ggrc-client/styles/modules/_info-pin.scss
+++ b/src/ggrc-client/styles/modules/_info-pin.scss
@@ -82,6 +82,11 @@
         }
       }
     }
+
+    .person-info-list {
+      list-style-type: none;
+      margin: 0;
+    }
   }
   .info-widget-footer {
     display: none;

--- a/src/ggrc/assets/mustache/assessment_templates/info.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/info.mustache
@@ -62,7 +62,7 @@
                   {{get_item DEFAULT_PEOPLE_LABELS default_people.assignees}}
                 {{else}}
                   {{#if default_people.assignees.length}}
-                    <ul>
+                    <ul class="person-info-list">
                       {{#each default_people.assignees}}
                         <li>
                           <person-info editable="false" person-id="{{.}}"></person-info>
@@ -85,7 +85,7 @@
                   {{get_item DEFAULT_PEOPLE_LABELS default_people.verifiers}}
                 {{else}}
                   {{#if default_people.verifiers.length}}
-                    <ul>
+                    <ul class="person-info-list">
                       {{#each default_people.verifiers}}
                         <li>
                           <person-info editable="false" person-id="{{.}}"></person-info>

--- a/src/ggrc/assets/mustache/assessment_templates/info.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/info.mustache
@@ -65,7 +65,7 @@
                     <ul>
                       {{#each default_people.assignees}}
                         <li>
-                          <person-info editable="true" person-id="{{.}}"></person-info>
+                          <person-info editable="false" person-id="{{.}}"></person-info>
                         </li>
                       {{/each}}
                     </ul>
@@ -88,7 +88,7 @@
                     <ul>
                       {{#each default_people.verifiers}}
                         <li>
-                          <person-info editable="true" person-id="{{.}}"></person-info>
+                          <person-info editable="false" person-id="{{.}}"></person-info>
                         </li>
                       {{/each}}
                     </ul>


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

No possibility to delete 'Default Verifier' / 'Default Assignees' by trash icon on 'Assessment Template' info-pin.

![image](https://user-images.githubusercontent.com/10946494/35726728-ea9ae1cc-0816-11e8-9c4c-cff56455922c.png)


# Steps to test the changes

Steps to reproduce:
1. Go to Audit page > Assessment template tab
2. Invoke New Assessment template modal window
3. Add Default Assignees and Default Verifiers by using 'Other' option in dropdown
4. Save Assessment template
5. Navigate to Assessment template Info pane and click on Trash Icon

Actual Result: Cannot remove a person from Assessment template Info pane by clicking Trash Icon

# Solution description

Make person-info not editable on assessment_template info-pin:
Set `editable` property to `false` for `person-info` component.

Fix displaying of person-info list.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests (no functional logic).
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
