### PR TITLE
GGRC-3385 Show default value if CAV is empty

### DIFF
--- a/src/ggrc-client/js/components/tree/tests/tree-item-custom-attribute_spec.js
+++ b/src/ggrc-client/js/components/tree/tests/tree-item-custom-attribute_spec.js
@@ -156,13 +156,13 @@ describe('helpers.getCustomAttrValue', () => {
       expect(actual).toEqual('No');
     });
 
-    it('returns empty string for CA of type checkbox without value', () => {
+    it('returns "No" for CA of type checkbox without value', () => {
       attr.attr_name = 'CheckBox';
       setCustomAttrItem(undefined, 4, 'checkbox');
 
       actual = helper(attr, fakeInstance, fakeOptions);
 
-      expect(actual).toEqual('');
+      expect(actual).toEqual('No');
     });
 
     it('returns "No" for CA of type checkbox if there are no CA values', () => {

--- a/src/ggrc-client/js/components/tree/tree-item-custom-attribute.js
+++ b/src/ggrc-client/js/components/tree/tree-item-custom-attribute.js
@@ -56,12 +56,13 @@ const getCustomAttrValue = (attr, instance, options) => {
       });
 
     if (customAttrItem) {
-      value = formatValueMap[definition.attribute_type] ?
+      value = (formatValueMap[definition.attribute_type] ?
         formatValueMap[definition.attribute_type](customAttrItem, options) :
-        customAttrItem.attr('attribute_value');
-    } else {
-      value = value || defaultValueMap[definition.attribute_type];
+        customAttrItem.attr('attribute_value'));
     }
+
+    // populate with default value if needed
+    value = value || defaultValueMap[definition.attribute_type];
   }
 
   return value || '';


### PR DESCRIPTION
# Issue description

If user adds new GCA with checkbox type and doesn't fill GCA field, 'No' is not displayed in tree view

# Steps to test the changes

Steps to reproduce:
1. Have newly created GCA with checkbox type for Assessment
2. Have assessment on the audit page
3. On the Assessment tab Set visible field of GCA with checkbox type
4. Look at the tree view: 'No' is not displayed by default

*Actual Result:* If user adds new GCA with checkbox type and doesn't fill GCA field, 'No' is not displayed in tree view
*Expected Result:* If user adds new GCA with checkbox type and doesn't fill GCA field, 'No' should be displayed in tree view

# Solution description

Assessment are containing empty CAV objects. Fix is showing default values if CAV is empty.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
