### PR TITLE
GGRC-4327: Fix 404 error on TaskGroup delete

### DIFF
--- a/src/ggrc-client/js/models/task_group.js
+++ b/src/ggrc-client/js/models/task_group.js
@@ -70,6 +70,7 @@
       });
       this.bind('destroyed', function (ev, inst) {
         if (inst instanceof that) {
+          inst.attr('deleted', true);
           can.each(inst.task_group_tasks, function (tgt) {
             if (!tgt) {
               return;
@@ -176,8 +177,12 @@
       });
 
       this.bind('destroyed', function (ev, instance) {
+        let taskGroup;
         if (instance instanceof that) {
-          if (instance.task_group && instance.task_group.reify().selfLink) {
+          taskGroup = instance.task_group && instance.task_group.reify();
+          if (taskGroup
+            && taskGroup.selfLink
+            && !taskGroup.attr('deleted')) {
             instance.task_group.reify().refresh();
             instance._refresh_workflow_people();
           }


### PR DESCRIPTION
# Issue description
Redundant TaskGroup refresh when user removes it.

# Steps to test the changes
Steps to reproduce:
1. Create any WF
2. In setup tab add a task to TG
3. Activate WF
4. Open Dev tools> Net work tab
4. Invoke Edit TG popup and click Delete button
**Actual Result:** 404 error in console while deleting a task group. Task group is deleted.
**Expected Result:** no errors should be displayed while deleting a task group.

# Solution description
Set 'removed' flag in TaskGroup and use it to skip redundant refresh. 
Alternative solution: don't trigger 'destroyed'-events for TaskGroupTask. It has the following drawback - TGT object will stay in models cache and stubs cache. 

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".