### PR TITLE
QUICK-FIX Allow single use statement in db dump files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - \
     vim \
     wget \
     zip \
+    pv \
   && rm -rf /var/lib/apt/lists/*
 
 COPY ./provision/docker/my.cnf /root/.my.cnf

--- a/bin/db_reset
+++ b/bin/db_reset
@@ -75,7 +75,7 @@ if [[ -f "$DUMP_FILE" ]]; then
     echo "Warning: Single USE statement in $DUMP_FILE will be ignored."
   fi
   echo "Importing: $DUMP_FILE"
-  sed "s/^USE.*//g" | mysql -h$HOST $DB_NAME
+  pv $DUMP_FILE | sed "s/^USE.*//g" | mysql -h$HOST $DB_NAME
 fi
 
 db_migrate

--- a/bin/db_reset
+++ b/bin/db_reset
@@ -55,22 +55,27 @@ then
   exit 1
 fi
 
-echo "Resetting database: $DB_NAME"
-if [[ -f "$DUMP_FILE" ]] && grep "^USE " $DUMP_FILE
+if [[ -f "$DUMP_FILE" ]] && [[ $(grep "^USE " $DUMP_FILE | wc -l) > 1 ]]
 then
-  echo "Error: 'USE' statement found in the database dump."
+  echo "Error: More than 1 'USE' statement found in the database dump."
   echo ""
   echo "Importing into $DB_NAME will fail if there is USE block in the"
   echo "database dump file. Please fix the dump file and run this script again"
   exit 1
 fi
 
+echo "Resetting database: $DB_NAME"
+
 mysql -h$HOST -e "drop database if exists $DB_NAME"
 mysql -h$HOST -e "create database $DB_NAME character set utf8"
 
 if [[ -f "$DUMP_FILE" ]]; then
+  if grep "^USE " $DUMP_FILE
+  then
+    echo "Warning: Single USE statement in $DUMP_FILE will be ignored."
+  fi
   echo "Importing: $DUMP_FILE"
-  mysql -h$HOST $DB_NAME < $DUMP_FILE
+  sed "s/^USE.*//g" | mysql -h$HOST $DB_NAME
 fi
 
 db_migrate


### PR DESCRIPTION

# Issue description

Cloud SQL always includes the use statement in its dumps, and we usually
export just a single database. So instead of having to always manually
remove the use statement we can have this option in the db_reset script
to make its usage a bit easier.

# Steps to test the changes
check if db_reset works with clean dump from cloud sql and that it still works if the dump does not contain the "USE" statement

Also check that data from the dump that is being stored is not modified in any way by romeving the use statemnet

# Solution description

Add different checks for multiple use statemnets and a warning for a single use statment that will be removed.

# Sanity checklist

- [ ] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [ ] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
