### PR TITLE
GGRC-4247: Refresh tree-view after sub-item remove

### DIFF
--- a/src/ggrc-client/js/components/tree/sub-tree-item.js
+++ b/src/ggrc-client/js/components/tree/sub-tree-item.js
@@ -70,6 +70,11 @@ import template from './templates/sub-tree-item.mustache';
       inserted: function () {
         this.viewModel.attr('$el', this.element);
       },
+      '{viewModel.instance} destroyed'() {
+        const element = $(this.element)
+          .closest('tree-widget-container');
+        can.trigger(element, 'refreshTree');
+      },
     },
   });
 })(window.can, window.GGRC);


### PR DESCRIPTION
# Issue description
Tree view is not refreshed after object on the 3rd level in tree view removing.

# Steps to test the changes
Pre-condition: existing chain of mapped objects Standard->Objective->Control.
1. Open Control info pane on Standards tab (All objects page).
2. Delete Control.
**Actual result:** tree view is not refreshed, Info pane is opened.
**Expected result:** tree view is refreshed, Info pane is closed.

# Solution description
Subscribe on subtree item removing and trigger event for refreshing tree view.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".