### PR TITLE
GGRC-4429 Refactor log event procedure for nightly cron job

### DIFF
--- a/src/ggrc_workflows/__init__.py
+++ b/src/ggrc_workflows/__init__.py
@@ -777,6 +777,7 @@ def start_recurring_cycles():
         models.Workflow.next_cycle_start_date <= today,
         models.Workflow.recurrences == True  # noqa
     )
+    event = None
     for workflow in workflows:
       # Follow same steps as in model_posted.connect_via(models.Cycle)
       while workflow.next_cycle_start_date <= date.today():
@@ -790,7 +791,7 @@ def start_recurring_cycles():
       # 'Cycles' for each 'Workflow' should be committed separately
       # to free memory on each iteration. Single commit exeeded
       # maximum memory limit on AppEngine instance.
-      log_event(db.session)
+      event = log_event(db.session, event=event)
       db.session.commit()
 
 

--- a/test/integration/ggrc_workflows/test_recurring_cycles_event.py
+++ b/test/integration/ggrc_workflows/test_recurring_cycles_event.py
@@ -1,0 +1,74 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Tests single event creation during start_recurring_cycles job execution."""
+
+from freezegun import freeze_time
+
+from ggrc import models
+from ggrc_workflows import start_recurring_cycles, models as wf_models
+from integration.ggrc import TestCase
+from integration.ggrc_workflows import WorkflowsGenerator
+
+
+class TestRecurringCyclesEvent(TestCase):
+  """Tests the number of events created after start_recurring_cycles is executed.
+
+  Test suite for checking that only one event has been created
+  in the database during start_recurring_cycles cron job execution.
+  """
+  def setUp(self):
+    """Set up for single event creation test cases."""
+    super(TestRecurringCyclesEvent, self).setUp()
+    wf_generator = WorkflowsGenerator()
+
+    wf_data = {
+        'unit': 'week',
+        'repeat_every': 1
+    }
+
+    tg_data = {
+        'start_date': '2018-01-17',
+        'end_date': '2018-01-17'
+    }
+
+    with freeze_time('2018-01-17'):
+      _, workflow_1 = wf_generator.generate_workflow(data=wf_data)
+      _, task_group_1 = wf_generator.generate_task_group(workflow=workflow_1)
+      wf_generator.generate_task_group_task(task_group=task_group_1,
+                                            data=tg_data)
+      wf_generator.activate_workflow(workflow_1)
+
+      _, workflow_2 = wf_generator.generate_workflow(data=wf_data)
+      _, task_group_2 = wf_generator.generate_task_group(workflow=workflow_2)
+      wf_generator.generate_task_group_task(task_group=task_group_2,
+                                            data=tg_data)
+      wf_generator.activate_workflow(workflow_2)
+
+    self.cycles_count = wf_models.Cycle.query.count()
+
+  def test_event_creation(self):
+    """Test single event creation."""
+    with freeze_time('2018-01-24'):
+      start_recurring_cycles()
+
+    events = models.Event.query.filter(models.Event.action == 'BULK').all()
+    new_cycles_count = wf_models.Cycle.query.count()
+
+    self.assertEqual(new_cycles_count, self.cycles_count + 2)
+    self.assertEqual(len(events), 1)
+    self.assertEqual(len(events[0].revisions), 18)
+
+  def test_event_is_not_created(self):
+    """Test no event created."""
+    revisions_count = models.Revision.query.count()
+    with freeze_time('2018-01-18'):
+      start_recurring_cycles()
+
+    events = models.Event.query.filter(models.Event.action == 'BULK').all()
+    new_cycles_count = wf_models.Cycle.query.count()
+    new_revisions_count = models.Revision.query.count()
+
+    self.assertEqual(new_cycles_count, self.cycles_count)
+    self.assertEqual(len(events), 0)
+    self.assertEqual(new_revisions_count, revisions_count)


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Recently start_recurring_cycles function of the nightly cron jobs has been refactored so that many commits were performed instead of a single one, and multiple events were logged (each one before a commit). However, only one event has to be logged in this case.

# Steps to test the changes

1. Run start_recurring_cycles() function on the qa db dump;
2. Check the number of created events in the db (1 event should be created);
3. Check the number of revisions created (should be non-zero number).

# Solution description

One more argument - event object - has been added to the log_event function.The next situations are possible:

1. Revisions list is empty and event is None. In this case nether event nor revisions won't be created.
2. Revisions list is not empty and event is None. In this case event and appropriate revisions will be created.
3. Revisions list is not empty and event is not None. In this case appropriate revisions will be created, while event won't be changed.
4. Revisions list is empty and event is not None. In this case event will not be changed, and new revisions will not be added.

The first two cases reflect the previously used logic, the last two are handled during start_recurring_cycles() execution.

Only one event is created in the start_recurring_cycles() now, and new revisions are attached to this event during looping through workflows.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

# TODO

- [x] Add revisions generation
