### PR TITLE
GGRC-4306 Use only non internal access_control_list on the frontend

### DIFF
--- a/src/ggrc/builder/json.py
+++ b/src/ggrc/builder/json.py
@@ -655,6 +655,7 @@ class Builder(AttributeInfo):
 
   def publish_attr(
           self, obj, attr_name, inclusions, include, inclusion_filter):
+    """Publish obj attr."""
     value_exists, value = self._process_custom_publish(obj, attr_name)
     if value_exists:
       return value
@@ -693,6 +694,7 @@ class Builder(AttributeInfo):
   def _publish_attrs_for(
           self, obj, attrs, json_obj, inclusions=None, inclusion_filter=None,
           attribute_whitelist=None):
+    """Publis attrs for obj."""
     if inclusions is None:
       inclusions = []
     for attr in attrs:

--- a/src/ggrc/builder/json.py
+++ b/src/ggrc/builder/json.py
@@ -707,9 +707,15 @@ class Builder(AttributeInfo):
           break
       if attribute_whitelist and attr_name not in attribute_whitelist:
         continue
-      json_obj[attr_name] = self.publish_attr(
+      attr = self.publish_attr(
           obj, attr_name, local_inclusion[1:], len(local_inclusion) > 0,
           inclusion_filter)
+      if attr_name == "filtered_access_control_list":
+        # Instead of using filtered_access_control_list name in the frontend
+        # use access_control_list instead.
+        json_obj["access_control_list"] = attr
+      else:
+        json_obj[attr_name] = attr
 
   def publish_attrs(self, obj, json_obj, extra_inclusions, inclusion_filter,
                     attribute_whitelist):

--- a/test/integration/ggrc/models/test_assessment_base.py
+++ b/test/integration/ggrc/models/test_assessment_base.py
@@ -64,6 +64,10 @@ class TestAssessmentBase(ggrc.TestCase):
     if extra_data:
       assessment_dict.update(extra_data)
 
-    return self.api.post(all_models.Assessment, {
+    response = self.api.post(all_models.Assessment, {
         "assessment": assessment_dict
     })
+    if response.status_code == 201:
+      id_ = response.json['assessment']['id']
+      return self.api.get(all_models.Assessment, id_)
+    return response

--- a/test/integration/ggrc/models/test_assessment_generation.py
+++ b/test/integration/ggrc/models/test_assessment_generation.py
@@ -103,9 +103,7 @@ class TestAssessmentGeneration(TestAssessmentBase):
 
     self.assessment_post()
 
-    # Add objects back to session to have access to their id and type
     mapped_objects = [self.audit, self.snapshot]
-    db.session.add_all(mapped_objects)
     for obj in mapped_objects:
       self.assert_mapped_role("Verifiers Mapped", auditors[0], obj)
       self.assert_mapped_role("Verifiers Mapped", auditors[1], obj)
@@ -133,8 +131,6 @@ class TestAssessmentGeneration(TestAssessmentBase):
       self.generate_acls(captains, self.captains_role)
 
     self.assessment_post(template)
-    # Add objects back to session to have access to their id and type
-    db.session.add(self.audit, self.snapshot)
     for obj in [self.audit, self.snapshot]:
       self.assert_mapped_role("Verifiers Mapped", "user1@example.com", obj)
       self.assert_mapped_role("Verifiers Mapped", "user2@example.com", obj)
@@ -540,7 +536,7 @@ class TestAssessmentGeneration(TestAssessmentBase):
         extra_data=assessment_type
     )
     if exp_type:
-      self.assertEqual(response.status_code, 201)
+      self.assertEqual(response.status_code, 200)
       assessment = all_models.Assessment.query.first()
       self.assertEqual(assessment.assessment_type, exp_type)
     else:
@@ -552,7 +548,7 @@ class TestAssessmentGeneration(TestAssessmentBase):
     """
     test_state = "START_STATE"
     response = self.assessment_post()
-    self.assertEqual(response.status_code, 201)
+    self.assertEqual(response.status_code, 200)
     asmt = all_models.Assessment.query.one()
     self.assertEqual(asmt.status,
                      getattr(all_models.Assessment, test_state))
@@ -564,7 +560,7 @@ class TestAssessmentGeneration(TestAssessmentBase):
             "notes": ""
         }
     )
-    self.assertEqual(response.status_code, 201)
+    self.assertEqual(response.status_code, 200)
     assessment = self.refresh_object(asmt)
     self.assertEqual(assessment.status,
                      getattr(all_models.Assessment, test_state))
@@ -573,7 +569,7 @@ class TestAssessmentGeneration(TestAssessmentBase):
     """Check if generated Assessment inherit test plan of Snapshot"""
     test_plan = self.control.test_plan
     response = self.assessment_post()
-    self.assertEqual(response.status_code, 201)
+    self.assertEqual(response.status_code, 200)
     self.assertEqual(response.json["assessment"]["test_plan"], test_plan)
 
   def test_generate_empty_auditor(self):


### PR DESCRIPTION
# Issue description

The backend is sending a lot of `access_control_list` items to the frontend which is slowing the app for certain object types - most notably audits.

# Steps to test the changes

Nothing should actually change from the users perspective, except loading audits with a lot of assessments mapped should be considerably faster.

# Solution description

We only send non internal access control roles to the fronted - so the roles the user can actually edit.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
