### PR TITLE
QUICK-FIX Add eslint_error_lines tool

### DIFF
--- a/bin/eslint_error_lines
+++ b/bin/eslint_error_lines
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+/*
+ Copyright (C) 2018 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+/* eslint-env node */
+/* eslint-disable no-console */
+/**
+ * This is a tool to get the list of failed ESlint lines only in files and lines
+ * modified in this branch.
+ */
+const {exec} = require('child_process');
+const path = require('path');
+process.title = 'eslint_error_lines';
+
+
+const processParam = (process.argv[2] || '')
+  .replace(/^-+/, '')
+  .replace(/-+$/, '');
+
+function parseModifiedFiles(output) {
+  const rx = /diff\s--git\sa\/\S+\sb\/(\S+)[\s\S]*?@@.*?\+(\d+)(?:,(\d+)|)/ig;
+  let match;
+  let startLine;
+  let linesCount;
+  let fileName;
+  let modifiedLinesNumbers;
+  let modifiedFiles = {};
+  while ( match = rx.exec(output) ) {
+    fileName = path.resolve(process.cwd(), match[1]);
+    if ( !modifiedFiles[fileName] ) {
+      modifiedFiles[fileName] = {
+        lines: [],
+      };
+    }
+    modifiedLinesNumbers = modifiedFiles[fileName].lines;
+    startLine = parseInt(match[2], 10);
+    linesCount = parseInt(match[3], 10);
+
+    // @@ -41,0 +42 @@ // added one line
+    // @@ -6,2 +5,0 @@ // added no lines
+    linesCount = isNaN(linesCount) ? 1 : linesCount;
+
+    for ( let i = startLine; i <= startLine+linesCount-1; i+=1 ) {
+      modifiedLinesNumbers.push(i);
+    }
+  }
+  return modifiedFiles;
+}
+
+function getModifiedFiles(done) {
+  const shellCmd = 'git diff -U0 dev -- "*.js"';
+  exec(shellCmd, (err, stdout, stderr) => {
+    if (err) {
+      return done(err);
+    }
+    let modifiedFiles = parseModifiedFiles(stdout);
+    done(null, modifiedFiles);
+  });
+}
+
+function getEslintFailedFiles(done) {
+  const shellCmd =
+    'git diff --name-only dev | grep ".js$" | xargs eslint --quiet -f json';
+  exec(shellCmd, {maxBuffer: 1024 * 500}, (error, stdout, stderr) => {
+    let eslintJSONOutput;
+    if (error && !stdout) {
+      console.error(`Error executing "${shellCmd}": ${error}`);
+      console.error(`stderr: ${stderr}`);
+      return;
+    }
+
+    // if empty list of files passed to the eslint
+    if ( !stdout.trim() || stdout.includes('eslint [options]') ) {
+      return done(null, []);
+    }
+
+    try {
+      eslintJSONOutput = JSON.parse(stdout);
+      done(null, eslintJSONOutput);
+    } catch (e) {
+      done(e);
+    }
+  });
+}
+
+function main() {
+  getModifiedFiles((err, modFiles) => {
+    if ( err ) {
+      return console.error(
+        `Error getting list of modified files in the branch: ${err}`);
+    }
+    getEslintFailedFiles((err, eslintOut) => {
+      if ( err ) {
+        return console.error(`Error running eslint on changed files: ${err}`);
+      }
+      eslintOut.forEach((lintedFile) => {
+        let output = [];
+        output.push(`${lintedFile.filePath}`);
+        if ( !modFiles[lintedFile.filePath] ) {
+          return console.log(
+            `File ${lintedFile.filePath} is not included in modLines`);
+        }
+        let modLines = modFiles[lintedFile.filePath].lines;
+        let hasMatchingLines = false;
+        lintedFile.messages.forEach((msg) => {
+          if ( modLines.includes(msg.line) ) {
+            hasMatchingLines = true;
+            output.push(`\t${msg.line}:${msg.column}\t${msg.message}`);
+            output.push(`\t\t\t${msg.source}`);
+          }
+        });
+        if (hasMatchingLines) {
+          output.map((line)=>console.log(line));
+        }
+      });
+    });
+  });
+}
+
+function printUsage() {
+  console.log(
+    '\n'+
+    'This tool shows failed eslint lines in your branch comparing to dev.\n' +
+    'Only the lines changed by you.\n'+
+    'Even if you made fixes in a file with 1000+ eslint errors.\n');
+}
+
+
+if ( ['h', 'help', '?'].includes(processParam) ) {
+  printUsage();
+} else {
+  main();
+}

--- a/bin/eslint_error_lines
+++ b/bin/eslint_error_lines
@@ -13,6 +13,7 @@ const {exec} = require('child_process');
 const path = require('path');
 process.title = 'eslint_error_lines';
 
+class EelError extends Error {};
 
 const processParam = (process.argv[2] || '')
   .replace(/^-+/, '')
@@ -50,8 +51,11 @@ function parseModifiedFiles(output) {
 
 function getModifiedFiles(done) {
   const shellCmd = 'git diff -U0 dev -- "*.js"';
-  exec(shellCmd, (err, stdout, stderr) => {
+  exec(shellCmd, {maxBuffer: 1024 * 1024}, (err, stdout, stderr) => {
     if (err) {
+      if ( err.toString().includes('stdout maxBuffer exceeded') ) {
+        err = new EelError(`The output of "${shellCmd}" is too big. You probably need to rebase your banch to the latest dev.`);
+      }
       return done(err);
     }
     let modifiedFiles = parseModifiedFiles(stdout);
@@ -62,7 +66,7 @@ function getModifiedFiles(done) {
 function getEslintFailedFiles(done) {
   const shellCmd =
     'git diff --name-only dev | grep ".js$" | xargs eslint --quiet -f json';
-  exec(shellCmd, {maxBuffer: 1024 * 500}, (error, stdout, stderr) => {
+  exec(shellCmd, {maxBuffer: 1024 * 1024}, (error, stdout, stderr) => {
     let eslintJSONOutput;
     if (error && !stdout) {
       console.error(`Error executing "${shellCmd}": ${error}`);
@@ -84,11 +88,17 @@ function getEslintFailedFiles(done) {
   });
 }
 
+function printError(msg, err) {
+  return ( err instanceof EelError )
+    ? console.error(err.toString())
+    : console.error(`${msg}: ${err}`);
+}
+
 function main() {
   getModifiedFiles((err, modFiles) => {
     if ( err ) {
-      return console.error(
-        `Error getting list of modified files in the branch: ${err}`);
+      return printError(
+        'Error getting list of modified files in the branch', err);
     }
     getEslintFailedFiles((err, eslintOut) => {
       if ( err ) {


### PR DESCRIPTION
# Issue description

Sometime you need to make changes in old file on front-end that was not formatted according to the latest ESLint rules and code style fails on your PR. You need to find and issue, but running
`git diff --name-only dev | grep ".js" | xargs eslint` gives something like this

<img width="716" alt="screen shot 2018-02-09 at 11 46 07 am" src="https://user-images.githubusercontent.com/85838/36019372-1e06d0a6-0d90-11e8-9196-ff9127164d54.png">
Which is often hard to process. 

# Solution description

eslint_error_lines is a tool that shows eslint errors only in the lines which you added or modified. Running `./bin/eslint_error_lines` will give you 

<img width="715" alt="screen shot 2018-02-09 at 11 46 47 am" src="https://user-images.githubusercontent.com/85838/36019592-d026384e-0d90-11e8-9840-f7de20f4bd01.png">
Which is much nicer to handle.

# Sanity checklist

- [ ] __N/A__ ~~I have clicked through the app to make sure my changes work and not break the app.~~
- [ ] __N/A__ ~~I have applied the correct milestone and labels.~~
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] __N/A__ ~~My changes are covered by tests.~~
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
