### PR TITLE
GGRC-4450/4451 Fix related assessments

### DIFF
--- a/src/ggrc/services/resources/related_assessments.py
+++ b/src/ggrc/services/resources/related_assessments.py
@@ -315,7 +315,7 @@ class RelatedAssessmentsResource(common.Resource):
         single_json["documents"] = document_json_map[assessment.id]
         single_json["audit"]["selfLink"] = utils.view_url_for(
             assessment.audit)
-        single_json["selfLink"] = utils.url_for(assessment)
+        single_json["selfLink"] = utils.view_url_for(assessment)
         assessments_json.append(single_json)
       return assessments_json
 

--- a/src/ggrc/services/resources/related_assessments.py
+++ b/src/ggrc/services/resources/related_assessments.py
@@ -332,7 +332,8 @@ class RelatedAssessmentsResource(common.Resource):
             ]
             single_json["snapshots"] = snapshot_json_map[assessment.id]
             single_json["documents"] = document_json_map[assessment.id]
-            single_json["audit"]["selfLink"] = utils.url_for(assessment.audit)
+            single_json["audit"]["selfLink"] = utils.view_url_for(
+                assessment.audit)
             single_json["selfLink"] = utils.url_for(assessment)
             assessments_json.append(single_json)
 

--- a/src/ggrc/services/resources/related_assessments.py
+++ b/src/ggrc/services/resources/related_assessments.py
@@ -21,6 +21,7 @@ from sqlalchemy import and_
 
 from ggrc import db
 from ggrc import models
+from ggrc import utils
 from ggrc.utils import benchmark
 from ggrc.rbac import permissions
 from ggrc.services import common
@@ -331,6 +332,8 @@ class RelatedAssessmentsResource(common.Resource):
             ]
             single_json["snapshots"] = snapshot_json_map[assessment.id]
             single_json["documents"] = document_json_map[assessment.id]
+            single_json["audit"]["selfLink"] = utils.url_for(assessment.audit)
+            single_json["selfLink"] = utils.url_for(assessment)
             assessments_json.append(single_json)
 
           response_object = {

--- a/test/integration/ggrc/services/resources/test_related_assessments.py
+++ b/test/integration/ggrc/services/resources/test_related_assessments.py
@@ -108,11 +108,11 @@ class TestRelatedAssessments(TestCase):
 
   def test_self_link(self):
     """Test that audits and assessments contain selfLink."""
-    audit_self_link = u"/api/{}/{}".format(
+    audit_self_link = u"/{}/{}".format(
         self.assessment2.audit._inflector.table_plural,
         self.assessment2.audit.id,
     )
-    assessment_self_link = u"/api/{}/{}".format(
+    assessment_self_link = u"/{}/{}".format(
         self.assessment2._inflector.table_plural,
         self.assessment2.id,
     )

--- a/test/integration/ggrc/services/resources/test_related_assessments.py
+++ b/test/integration/ggrc/services/resources/test_related_assessments.py
@@ -105,3 +105,25 @@ class TestRelatedAssessments(TestCase):
     response = self._get_related_assessments(self.control, **order_by).json
     titles = [assessment["title"] for assessment in response["data"]]
     self.assertEqual(titles, titles_order)
+
+  def test_self_link(self):
+    """Test that audits and assessments contain selfLink."""
+    audit_self_link = u"/api/{}/{}".format(
+        self.assessment2.audit._inflector.table_plural,
+        self.assessment2.audit.id,
+    )
+    assessment_self_link = u"/api/{}/{}".format(
+        self.assessment2._inflector.table_plural,
+        self.assessment2.id,
+    )
+    response = self._get_related_assessments(self.assessment1).json
+    self.assertIn("selfLink", response["data"][0]["audit"])
+    self.assertIn("selfLink", response["data"][0])
+    self.assertEqual(
+        response["data"][0]["audit"]["selfLink"],
+        audit_self_link,
+    )
+    self.assertEqual(
+        response["data"][0]["selfLink"],
+        assessment_self_link,
+    )

--- a/test/integration/ggrc/services/resources/test_related_assessments.py
+++ b/test/integration/ggrc/services/resources/test_related_assessments.py
@@ -56,8 +56,11 @@ class TestRelatedAssessments(TestCase):
     """Test basic response for a valid query."""
     assessment2_title = self.assessment2.title
     response = self._get_related_assessments(self.assessment1).json
-    self.assertEqual(len(response), 1)
-    self.assertEqual(response[0]["title"], assessment2_title)
+    self.assertIn("total", response)
+    self.assertIn("data", response)
+    self.assertEqual(response["total"], 1)
+    self.assertEqual(len(response["data"]), 1)
+    self.assertEqual(response["data"][0]["title"], assessment2_title)
 
   @ddt.data(
       {},
@@ -87,7 +90,8 @@ class TestRelatedAssessments(TestCase):
   def test_limit_clause(self, limit, expected_count):
     """Test limit clause for {0}."""
     response = self._get_related_assessments(self.control, **limit).json
-    self.assertEqual(len(response), expected_count)
+    self.assertEqual(response["total"], 2)
+    self.assertEqual(len(response["data"]), expected_count)
 
   @ddt.data(
       ({"order_by": "title,asc"}, ["A_1", "A_2"]),
@@ -99,5 +103,5 @@ class TestRelatedAssessments(TestCase):
   def test_order_by_clause(self, order_by, titles_order):
     """Test order by for {0}."""
     response = self._get_related_assessments(self.control, **order_by).json
-    titles = [assessment["title"] for assessment in response]
+    titles = [assessment["title"] for assessment in response["data"]]
     self.assertEqual(titles, titles_order)


### PR DESCRIPTION
# Issue description

GGRC-4450:
BE must return the total numbers of assessments in response.

Format of response:
```
{
total: X,
assessments: [{}, {}, {}]
}
```
GGRC-4451:
Expected result:
* Each Assessment has to contain `viewLink` field
* Audit object has to contain `viewLink` field

# Steps to test the changes

Manually trigger the get request for related assessments and inspect the results. they should contain all self links and total counts

# Solution description

I have just added the missing data to related assessments resource.

# Sanity checklist

- [ ] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
