### PR TITLE
GGRC-4441 Remove redundant requests after adding a person to any assessment role

### DIFF
--- a/src/ggrc-client/js/components/custom-roles/custom-roles.js
+++ b/src/ggrc-client/js/components/custom-roles/custom-roles.js
@@ -50,7 +50,6 @@ export default can.Component.extend({
       this.attr('instance').save()
         .then(function () {
           self.filterACL();
-          self.attr('instance').dispatch('refreshInstance');
           self.attr('updatableGroupId', null);
         });
     },

--- a/src/ggrc-client/js/components/custom-roles/custom-roles.js
+++ b/src/ggrc-client/js/components/custom-roles/custom-roles.js
@@ -44,14 +44,12 @@ export default can.Component.extend({
 
       this.attr('instance.access_control_list').replace(filteredACL);
     },
-    save: function (args) {
-      let self = this;
+    save(args) {
       this.attr('updatableGroupId', args.groupId);
-      this.attr('instance').save()
-        .then(function () {
-          self.filterACL();
-          self.attr('updatableGroupId', null);
-        });
+      this.attr('instance').save().then(() => {
+        this.filterACL();
+        this.attr('updatableGroupId', null);
+      });
     },
   },
 });

--- a/src/ggrc-client/js/components/custom-roles/tests/custom-roles_spec.js
+++ b/src/ggrc-client/js/components/custom-roles/tests/custom-roles_spec.js
@@ -88,12 +88,6 @@ describe('custom-roles component', () => {
         expect(vm.filterACL).toHaveBeenCalled();
       });
 
-      it('dispatches refreshInstance event on instance', () => {
-        vm.save(args);
-        expect(vm.attr('instance').dispatch)
-          .toHaveBeenCalledWith('refreshInstance');
-      });
-
       it('sets null to updatableGroupId attribute', () => {
         vm.save(args);
         expect(vm.attr('updatableGroupId')).toBe(null);


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Adding a verifier (or a person to any other role) triggers too many requests to the backend:

(make sure that the assessment also has some issues mapped to it before):

Current Requests that are sent:

PUT assessment – this one is needed and should stay
GET assessment – not needed as it always returns the same result as the previous PUT request
POST query - for related assessments
POST query - for objects for related assessments

POST query - in some cases even related issues are fetched.

Developer should ensure that only the first PUT request is triggered when modifying ACL entries either on assessments page on on the assessment info pin.

If there are any side effects that make it so other requests are needed the dev must write a detailed explanation in this ticket and those will be discussed further.

# Steps to test the changes

With an open network tab ensure that the following actions trigger only a single PUT request:

All these should be verified on assessment page and assessment info pin, and some other object page and some other object info pin.
Add a person to a role with no people
Add a person to a role with already a few people
Remove a person from a role with multiple people
Remove all people from a given role.


# Solution description

Remove unneeded trigger of "refreshInstance" event

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
