### PR TITLE
GGRC-4290 User role in Assessment is not displayed in UI after importing a comment

### DIFF
--- a/src/ggrc/converters/base.py
+++ b/src/ggrc/converters/base.py
@@ -107,9 +107,8 @@ class Converter(object):
     self.drop_cache()
 
   def handle_priority_columns(self):
-    for attr_name in self.priority_columns:
-      for block_converter in self.block_converters:
-        block_converter.handle_row_data(attr_name)
+    for block_converter in self.block_converters:
+      block_converter.handle_row_data(self.priority_columns)
 
   def row_converters_from_csv(self):
     for converter in self.block_converters:

--- a/src/ggrc/converters/base_block.py
+++ b/src/ggrc/converters/base_block.py
@@ -537,7 +537,7 @@ class BlockConverter(object):
     return info
 
   def import_mapped_objects(self):
-    """Import secondary objects procedure."""
+    """Import mapped objects procedure."""
     for row_converter in self.row_converters:
       row_converter.setup_mapped_objects()
 
@@ -766,7 +766,7 @@ class BlockConverter(object):
 
   @staticmethod
   def _check_mapped_object(row_converter):
-    """Check secondary object if it has any pre commit checks.
+    """Check mapped object if it has any pre commit checks.
 
     The check functions can mutate the row_converter object and mark it
     to be ignored if there are any errors detected.

--- a/src/ggrc/converters/base_block.py
+++ b/src/ggrc/converters/base_block.py
@@ -468,23 +468,29 @@ class BlockConverter(object):
       csv_body.append(row_converter.to_array(self.fields))
     return csv_header, csv_body
 
-  def handle_row_data(self, field_list=None):
+  def handle_row_data(self, field_list=None, ignore_list=None):
     """Handle row data for all row converters on import.
 
     Note: When field_list is set, we are handling priority columns and we
     don't have all the data needed for checking mandatory and duplicate values.
 
     Args:
-      filed_list (list of strings): list of fields that should be handled by
-        row converters. This is used only for handling priority columns.
+      field_list (list of strings): list of fields which should be handled
+      by row converters. This is used only for handling priority columns.
     """
     if self.ignore:
       return
     for row_converter in self.row_converters:
-      row_converter.handle_row_data(field_list)
+      row_converter.handle_row_data(field_list, ignore_list)
     if field_list is None:
       self.check_mandatory_fields()
       self.check_unique_columns()
+
+  def handle_secondary_objects_data(self, field_list):
+    if self.ignore:
+      return
+    for row_converter in self.row_converters:
+      row_converter.handle_row_data(field_list)
 
   def check_mandatory_fields(self):
     for row_converter in self.row_converters:
@@ -530,18 +536,18 @@ class BlockConverter(object):
 
     return info
 
-  def import_secondary_objects(self):
+  def import_mapped_objects(self):
     """Import secondary objects procedure."""
     for row_converter in self.row_converters:
-      row_converter.setup_secondary_objects()
+      row_converter.setup_mapped_objects()
 
     for row_converter in self.row_converters:
-      self._check_secondary_object(row_converter)
+      self._check_mapped_object(row_converter)
 
     if not self.converter.dry_run:
       for row_converter in self.row_converters:
         try:
-          row_converter.insert_secondary_objects()
+          row_converter.insert_mapped_objects()
         except exc.SQLAlchemyError as err:
           db.session.rollback()
           logger.exception("Import failed with: %s", err.message)
@@ -588,6 +594,16 @@ class BlockConverter(object):
       import_event = self.save_import()
       for row_converter in self.row_converters:
         row_converter.send_post_commit_signals(event=import_event)
+
+  def import_secondary_objects(self, field_list):
+    if self.ignore:
+      return
+    for row_converter in self.row_converters:
+      row_converter.setup_secondary_objects(field_list)
+
+    if not self.converter.dry_run:
+      db.session.flush()
+      self.save_import()
 
   def clean_session_from_ignored_objs(self):
     """Clean DB session from ignored objects.
@@ -749,7 +765,7 @@ class BlockConverter(object):
       checker(row_converter)
 
   @staticmethod
-  def _check_secondary_object(row_converter):
+  def _check_mapped_object(row_converter):
     """Check secondary object if it has any pre commit checks.
 
     The check functions can mutate the row_converter object and mark it

--- a/src/ggrc/converters/base_row.py
+++ b/src/ggrc/converters/base_row.py
@@ -65,9 +65,11 @@ class RowConverter(object):
 
   def handle_csv_row_data(self, field_list=None, ignore_list=None):
     """ Pack row data with handlers """
-    handle_fields = list(set(self.headers) -
-                         (set(ignore_list) if ignore_list else set()))\
-        if field_list is None else field_list
+    if field_list is None:
+      handle_fields = list(set(self.headers) -
+                           (set(ignore_list) if ignore_list else set()))
+    else:
+      handle_fields = field_list
     for i, (attr_name, header_dict) in enumerate(self.headers.items()):
       if attr_name not in handle_fields or \
               attr_name in self.attrs or \
@@ -291,8 +293,8 @@ class RowConverter(object):
     """
     if not self.obj or self.ignore or self.is_delete:
       return
-    for secondery_object in self.objects.values():
-      secondery_object.insert_object()
+    for mapped_object in self.objects.values():
+      mapped_object.insert_object()
 
   def to_array(self, fields):
     """Get an array representation of the current row.

--- a/src/ggrc/converters/base_row.py
+++ b/src/ggrc/converters/base_row.py
@@ -62,9 +62,11 @@ class RowConverter(object):
     message = template.format(line=self.line, **kwargs)
     self.block_converter.row_warnings.append(message)
 
-  def handle_csv_row_data(self, field_list=None):
+  def handle_csv_row_data(self, field_list=None, ignore_list=None):
     """ Pack row data with handlers """
-    handle_fields = self.headers if field_list is None else field_list
+    handle_fields = list(set(self.headers) -
+                         (set(ignore_list) if ignore_list else set()))\
+        if field_list is None else field_list
     for i, (attr_name, header_dict) in enumerate(self.headers.items()):
       if attr_name not in handle_fields or \
               attr_name in self.attrs or \
@@ -97,9 +99,9 @@ class RowConverter(object):
       else:
         self.objects[attr_name] = item
 
-  def handle_row_data(self, field_list=None):
+  def handle_row_data(self, field_list=None, ignore_list=None):
     """Handle row data on import"""
-    self.handle_csv_row_data(field_list)
+    self.handle_csv_row_data(field_list, ignore_list)
 
   def check_mandatory_fields(self):
     """Check if the new object contains all mandatory columns."""
@@ -171,7 +173,7 @@ class RowConverter(object):
       self.add_error(errors.PERMISSION_ERROR)
     return obj
 
-  def setup_secondary_objects(self):
+  def setup_mapped_objects(self):
     """Import secondary objects.
 
     This function creates and stores all secondary object such as relationships
@@ -193,9 +195,18 @@ class RowConverter(object):
     """
     if self.ignore:
       return
-
     for item_handler in self.attrs.values():
       if not item_handler.view_only:
+        item_handler.set_obj_attr()
+
+  def setup_secondary_objects(self, field_list=None):
+    """Set the object values of secondary objects (those which need to be
+    imported after mappings"""
+    if self.ignore:
+      return
+    for field in field_list:
+      item_handler = self.attrs.get(field)
+      if item_handler:
         item_handler.set_obj_attr()
 
   def send_post_commit_signals(self, event=None):
@@ -271,7 +282,7 @@ class RowConverter(object):
     for handler in self.attrs.values():
       handler.insert_object()
 
-  def insert_secondary_objects(self):
+  def insert_mapped_objects(self):
     """Add additional objects to the current database session.
 
     This is used for adding any extra created objects such as Relationships, to

--- a/src/ggrc/converters/base_row.py
+++ b/src/ggrc/converters/base_row.py
@@ -16,6 +16,7 @@ from ggrc.rbac import permissions
 from ggrc.services import signals
 
 
+# pylint: disable=too-many-public-methods
 class RowConverter(object):
   """Base class for handling row data."""
 
@@ -174,9 +175,9 @@ class RowConverter(object):
     return obj
 
   def setup_mapped_objects(self):
-    """Import secondary objects.
+    """Import mapped objects.
 
-    This function creates and stores all secondary object such as relationships
+    This function creates and stores all mapped object such as relationships
     and any linked object that need the original object to be saved before they
     can be processed. This is usually due to needing the id of the original
     object that is created with a csv import.

--- a/src/ggrc/converters/handlers/comments.py
+++ b/src/ggrc/converters/handlers/comments.py
@@ -8,7 +8,7 @@ from ggrc import db
 from ggrc.converters import errors
 from ggrc.converters.handlers.handlers import ColumnHandler
 from ggrc.models import all_models
-from ggrc.login import get_current_user_id
+from ggrc.login import get_current_user, get_current_user_id
 
 
 class CommentColumnHandler(ColumnHandler):
@@ -47,8 +47,13 @@ class CommentColumnHandler(ColumnHandler):
       return
     current_obj = self.row_converter.obj
     for description in self.value:
+      current_user = get_current_user()
+      assignee_types = current_obj.assignees.get(current_user, [])
+      assignee_type = ",".join(assignee_types) or None
+
       comment = all_models.Comment(description=description,
-                                   modified_by_id=get_current_user_id())
+                        assignee_type=assignee_type,
+                        modified_by_id=get_current_user_id())
       db.session.add(comment)
       mapping = all_models.Relationship(source=current_obj,
                                         destination=comment)

--- a/src/ggrc/converters/handlers/comments.py
+++ b/src/ggrc/converters/handlers/comments.py
@@ -52,8 +52,8 @@ class CommentColumnHandler(ColumnHandler):
       assignee_type = ",".join(assignee_types) or None
 
       comment = all_models.Comment(description=description,
-                        assignee_type=assignee_type,
-                        modified_by_id=get_current_user_id())
+                                   assignee_type=assignee_type,
+                                   modified_by_id=get_current_user_id())
       db.session.add(comment)
       mapping = all_models.Relationship(source=current_obj,
                                         destination=comment)

--- a/test/integration/ggrc/converters/test_import_assessments.py
+++ b/test/integration/ggrc/converters/test_import_assessments.py
@@ -117,7 +117,7 @@ class TestAssessmentImport(TestCase):
     self._test_assessment_users(asmt_2, users)
     self.assertEqual(asmt_2.status, models.Assessment.PROGRESS_STATE)
 
-    audit = [obj for obj in asmt_1.related_objects() if obj.type == "Audit"][0]
+    audit = asmt_1.related_objects(_types="Audit").pop()
     self.assertEqual(audit.context, asmt_1.context)
 
     evidence = models.Document.query.filter_by(title="some title 2").first()

--- a/test/integration/ggrc/converters/test_import_comments.py
+++ b/test/integration/ggrc/converters/test_import_comments.py
@@ -35,3 +35,11 @@ class TestCommentsImport(TestCase):
     asst = Assessment.query.filter_by(slug=slug).first()
     comments = [comment.description for comment in asst.comments]
     self.assertEqual(comments, expected_comments)
+
+  def test_author_role_in_comment(self):
+    """Test comment author's role is set correctly on import"""
+    slug = "Assessment 1"
+    asmt = Assessment.query.filter_by(slug=slug).first()
+    comment = asmt.comments[0]
+    self.assertIn("Assignees", comment.assignee_type)
+    self.assertIn("Creators", comment.assignee_type)


### PR DESCRIPTION
# Issue description

User role for a comment in Assessment is not displayed in UI after importing a comment. But it is displayed if changed over UI.

# Steps to test the changes

1. Export an Assessment
2. Modify CSV: Ensure current user has any role inside the Assessment. Add a comment.
3. Import the file.
Expected result: the comment is added to the Assessment with the correct role near the comment author. See screenshot-2.png in GGRC-3505.

# Solution description

The solution was discussed in the GGRC-3505 ticket comments.
Implement 3rd sequence of importing data:
- attributes;
- mappings;
- comments.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
