### PR TITLE
GGRC-4492 Revert CAVs proposal generation for old style api

### DIFF
--- a/src/ggrc/utils/revisions_diff/applier.py
+++ b/src/ggrc/utils/revisions_diff/applier.py
@@ -65,20 +65,14 @@ def apply_cav(instance, content):
       continue
     if value["attribute_object"]:
       attribute_object_id = value["attribute_object"]["id"]
-      remove_cav = False
     else:
       attribute_object_id = None
-      remove_cav = (cad.attribute_type.startswith("Map:") and
-                    value.get("remove_cav"))
     cav = cav_dict.get(cad.id)
-    if remove_cav and cav:
-      instance.custom_attribute_values.remove(cav)
-      any_cav_applied = True
-    elif not remove_cav and cav:
+    any_cav_applied = True
+    if cav:
       cav.attribute_value = value["attribute_value"]
       cav.attribute_object_id = attribute_object_id
-      any_cav_applied = True
-    elif not remove_cav:
+    else:
       cav = all_models.CustomAttributeValue(
           custom_attribute=cad,
           attributable=instance,
@@ -86,7 +80,6 @@ def apply_cav(instance, content):
           attribute_object_id=attribute_object_id,
       )
       instance.custom_attribute_values.append(cav)
-      any_cav_applied = True
   return any_cav_applied
 
 

--- a/test/integration/ggrc/proposal/api/test_cads.py
+++ b/test/integration/ggrc/proposal/api/test_cads.py
@@ -38,13 +38,11 @@ class TestCADProposalsApi(base.BaseTestProposalApi):
     self.assertEqual(1, len(control.proposals))
     self.assertIn("custom_attribute_values", control.proposals[0].content)
     self.assertEqual({unicode(cad_id): {"attribute_value": u"321",
-                                        "attribute_object": None,
-                                        "remove_cav": False}},
+                                        "attribute_object": None}},
                      control.proposals[0].content["custom_attribute_values"])
     self.assertEqual(1, len(control.comments))
 
-  @ddt.data(True, False)
-  def test_apply_cad(self, remove_cav):
+  def test_apply_cad(self):
     """Test apply proposal with change CAVs."""
     with factories.single_commit():
       control = factories.ControlFactory(title="1")
@@ -58,7 +56,6 @@ class TestCADProposalsApi(base.BaseTestProposalApi):
                 cad.id: {
                     "attribute_value": "321",
                     "attribute_object": None,
-                    "remove_cav": remove_cav,
                 },
             },
         },
@@ -70,9 +67,8 @@ class TestCADProposalsApi(base.BaseTestProposalApi):
         "321",
         control.custom_attribute_values[0].attribute_value)
 
-  @ddt.data(True, False)
-  def test_apply_mapping_cad(self, remove_cav):
-    """Test apply mapping CAVs proposal with remove_cav is {0}."""
+  def test_apply_mapping_cad(self):
+    """Test apply mapping CAVs proposal."""
     with factories.single_commit():
       control = factories.ControlFactory(title="1")
       cad = factories.CustomAttributeDefinitionFactory(
@@ -96,7 +92,6 @@ class TestCADProposalsApi(base.BaseTestProposalApi):
                 cad.id: {
                     "attribute_value": "Person",
                     "attribute_object": None,
-                    "remove_cav": remove_cav,
                 },
             },
         },
@@ -104,36 +99,6 @@ class TestCADProposalsApi(base.BaseTestProposalApi):
     with self.number_obj_revisions_for(control):
       self.apply_proposal(proposal)
     control = all_models.Control.query.get(control_id)
-    if remove_cav:
-      self.assertFalse(control.custom_attribute_values)
-    else:
-      cav = control.custom_attribute_values[0]
-      self.assertEqual("Person", cav.attribute_value)
-      self.assertIsNone(cav.attribute_object_id)
-
-  def test_change_cad_oldstile(self):
-    """Test create CAVs proposal in old style."""
-    with factories.single_commit():
-      control = factories.ControlFactory(title="1")
-      cad = factories.CustomAttributeDefinitionFactory(
-          definition_type="control")
-      factories.CustomAttributeValueFactory(
-          custom_attribute=cad,
-          attributable=control,
-          attribute_value="123")
-    control_id = control.id
-    cad_id = cad.id
-    data = control.log_json()
-    data["custom_attributes"] = {cad.id: "321"}
-    self.create_proposal(control,
-                         full_instance_content=data,
-                         agenda="update cav",
-                         context=None)
-    control = all_models.Control.query.get(control_id)
-    self.assertEqual(1, len(control.proposals))
-    self.assertIn("custom_attribute_values", control.proposals[0].content)
-    self.assertEqual({unicode(cad_id): {"attribute_value": u"321",
-                                        "attribute_object": None,
-                                        "remove_cav": True}},
-                     control.proposals[0].content["custom_attribute_values"])
-    self.assertEqual(1, len(control.comments))
+    cav = control.custom_attribute_values[0]
+    self.assertEqual("Person", cav.attribute_value)
+    self.assertIsNone(cav.attribute_object_id)


### PR DESCRIPTION
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [x] GGRC-3668

# Issue description

FE is moved to the new API, so this old-style functionality have to be removed.

# Steps to test the changes

Click through the version history tabs (after object creation / update / restoration).

# Solution description

Old-style functionality has been removed as well as appropriate tests.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
