### PR TITLE
GGRC-4538 Fix related assessments count

### DIFF
--- a/src/ggrc/query/builder.py
+++ b/src/ggrc/query/builder.py
@@ -292,7 +292,8 @@ class QueryHelper(object):
     with benchmark("Apply limit"):
       limit = object_query.get("limit")
       if limit:
-        limit_query, total = pagination.apply_limit(query, limit)
+        limit_query = pagination.apply_limit(query, limit)
+        total = pagination.get_total_count(query)
         ids = [obj.id for obj in limit_query]
       else:
         ids = [obj.id for obj in query]

--- a/src/ggrc/query/pagination.py
+++ b/src/ggrc/query/pagination.py
@@ -46,14 +46,19 @@ def apply_limit(query, limit):
     # Note: limit request syntax is limit:[0,10]. We are counting
     # offset from 0 as the offset of the initial row for sql is 0 (not 1).
     limit_query = query.limit(page_size).offset(first)
+
+  return limit_query
+
+
+def get_total_count(query):
+  """Get count of all objects in the query."""
   with benchmark("Apply limit: apply_limit > query_count"):
     # Note: using func.count() as query.count() is generating additional
     # subquery
     # query.count() has a bug and it returns incorrect number of objects
     count_q = query.statement.with_only_columns([sa.func.count()])
     total = db.session.execute(count_q).scalar()
-
-  return limit_query, total
+  return total
 
 
 def _joins_and_order(counter, clause, model, tgt_class):

--- a/src/ggrc/services/resources/related_assessments.py
+++ b/src/ggrc/services/resources/related_assessments.py
@@ -96,10 +96,11 @@ class RelatedAssessmentsResource(common.Resource):
           order_by,
           models.Assessment,
       )
+    total = query.count()
     if limit:
-      query, total = pagination.apply_limit(query, limit)
-    else:
-      total = query.count()
+      query = pagination.apply_limit(query, limit)
+    # note that using pagination.get_total_count here would return wrong counts
+    # due to query being an eager query.
 
     return query, total
 

--- a/test/integration/ggrc/services/resources/test_related_assessments.py
+++ b/test/integration/ggrc/services/resources/test_related_assessments.py
@@ -8,8 +8,10 @@ There are other tests for verifying completeness of the results and that focus
 more on verifying the related SQL query.
 """
 
+import mock
 import ddt
 
+from ggrc import views
 from integration.ggrc.models import factories
 from integration.ggrc.services import TestCase
 
@@ -61,6 +63,38 @@ class TestRelatedAssessments(TestCase):
     self.assertEqual(response["total"], 1)
     self.assertEqual(len(response["data"]), 1)
     self.assertEqual(response["data"][0]["title"], assessment2_title)
+
+  @ddt.data(
+      ({}, 2),
+      ({"limit": "0,1"}, 2),
+      ({"limit": "0,2"}, 2),
+      ({"limit": "0,3"}, 2),
+  )
+  @ddt.unpack
+  def test_total_count_with_ca(self, limit, expected_count):
+    """Test total related assessments count for assessments with ca.
+
+    The left outer join in our eager query on custom attribute values breaks
+    the total count if on sa.func.count, but works if we use query.count()
+    """
+    cad = factories.CustomAttributeDefinitionFactory
+    cads = [cad(definition_type="assessment") for _ in range(3)]
+
+    for cad in cads:
+      factories.CustomAttributeValueFactory(
+          attributable=self.assessment1,
+          custom_attribute=cad,
+      )
+      factories.CustomAttributeValueFactory(
+          attributable=self.assessment2,
+          custom_attribute=cad,
+      )
+
+    with mock.patch("ggrc.views.start_compute_attributes"):
+      views.do_reindex()
+
+    response = self._get_related_assessments(self.control, **limit).json
+    self.assertEqual(response["total"], expected_count)
 
   @ddt.data(
       {},


### PR DESCRIPTION

# Issue description

the PR https://github.com/google/ggrc-core/pull/7348

fixed a regression but broke related assessements optimization.

Fix the counts on related assessments.

# Steps to test the changes

Test:

open an assessment,
map a few controls to it,
check related assessments and
click last page of related assessments
Numbers should be "normal" and last page should contain at least one assessment.


# Solution description

It seems that sa.func.count works on polymorphic tables but does not
work properly on eager queries. While query.count() works on eager
queries and not on polymorphic tables.

This fix just ensures we get the correct counts on all pages, but is not
the proper fix for the underlying problem.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
