### PR TITLE
GGRC-4582 Use the full access_control_list only where absolutely needed

### DIFF
--- a/src/ggrc/access_control/roleable.py
+++ b/src/ggrc/access_control/roleable.py
@@ -44,7 +44,7 @@ class Roleable(object):
         primaryjoin=lambda: and_(
             remote(AccessControlList.object_id) == cls.id,
             remote(AccessControlList.object_type) == cls.__name__,
-            remote(AccessControlList.parent_id) != None),
+            remote(AccessControlList.parent_id).isnot(None)),
         foreign_keys='AccessControlList.object_id',
         backref='{0}_full_object'.format(cls.__name__),
         cascade='all, delete-orphan')
@@ -120,6 +120,7 @@ class Roleable(object):
 
   @classmethod
   def indexed_query(cls):
+    """Query used by the indexer"""
     query = super(Roleable, cls).indexed_query()
     return query.options(
         orm.subqueryload(

--- a/src/ggrc/access_control/roleable.py
+++ b/src/ggrc/access_control/roleable.py
@@ -46,7 +46,6 @@ class Roleable(object):
             remote(AccessControlList.object_type) == cls.__name__,
             remote(AccessControlList.parent_id).isnot(None)),
         foreign_keys='AccessControlList.object_id',
-        backref='{0}_full_object'.format(cls.__name__),
         cascade='all, delete-orphan')
 
   @declared_attr

--- a/src/ggrc/access_control/roleable.py
+++ b/src/ggrc/access_control/roleable.py
@@ -35,7 +35,8 @@ class Roleable(object):
         'AccessControlList',
         primaryjoin=lambda: and_(
             remote(AccessControlList.object_id) == cls.id,
-            remote(AccessControlList.object_type) == cls.__name__),
+            remote(AccessControlList.object_type) == cls.__name__,
+            remote(AccessControlList.parent_id).is_(None)),
         foreign_keys='AccessControlList.object_id',
         backref='{0}_object'.format(cls.__name__),
         cascade='all, delete-orphan')

--- a/src/ggrc/access_control/roleable.py
+++ b/src/ggrc/access_control/roleable.py
@@ -28,6 +28,27 @@ class Roleable(object):
   _api_attrs = reflection.ApiAttributes(
       reflection.Attribute('access_control_list', True, True, True))
 
+  @hybrid_property
+  def full_access_control_list(self):
+    return self._access_control_list + self._propagated_access_control_list
+
+  @declared_attr
+  def _propagated_access_control_list(cls):  # pylint: disable=no-self-argument
+    """Full access_control_list
+
+       Use with caution and load only when absolutely needed. For performance
+       reasons do not add to eager_query.
+    """
+    return db.relationship(
+        'AccessControlList',
+        primaryjoin=lambda: and_(
+            remote(AccessControlList.object_id) == cls.id,
+            remote(AccessControlList.object_type) == cls.__name__,
+            remote(AccessControlList.parent_id) != None),
+        foreign_keys='AccessControlList.object_id',
+        backref='{0}_full_object'.format(cls.__name__),
+        cascade='all, delete-orphan')
+
   @declared_attr
   def _access_control_list(cls):  # pylint: disable=no-self-argument
     """access_control_list"""

--- a/src/ggrc/access_control/roleable.py
+++ b/src/ggrc/access_control/roleable.py
@@ -11,7 +11,6 @@ from sqlalchemy.ext.hybrid import hybrid_property
 from ggrc import db
 from ggrc.access_control.list import AccessControlList
 from ggrc.access_control import role
-from ggrc.builder import simple_property
 from ggrc.fulltext.attributes import CustomRoleAttr
 from ggrc.models import reflection
 from ggrc.utils.referenced_objects import get
@@ -27,8 +26,7 @@ class Roleable(object):
   _update_raw = _include_links = ['access_control_list', ]
   _fulltext_attrs = [CustomRoleAttr('access_control_list'), ]
   _api_attrs = reflection.ApiAttributes(
-      reflection.Attribute('filtered_access_control_list', False, False, True),
-      reflection.Attribute('access_control_list', True, True, False))
+      reflection.Attribute('access_control_list', True, True, True))
 
   @declared_attr
   def _access_control_list(cls):  # pylint: disable=no-self-argument
@@ -41,23 +39,6 @@ class Roleable(object):
         foreign_keys='AccessControlList.object_id',
         backref='{0}_object'.format(cls.__name__),
         cascade='all, delete-orphan')
-
-  @simple_property
-  def filtered_access_control_list(self):
-    """Access control list returned to the frontend"""
-    return [{
-        "ac_role_id": acl.ac_role.id,
-        "context": None,
-        "id": acl.id,
-        "person": {
-            "id": acl.person.id,
-            "type": "Person"
-        },
-        "person_email": acl.person.email,
-        "person_id": acl.person.id,
-        "person_name": acl.person.name,
-    } for acl in self.access_control_list
-        if acl.ac_role and not acl.ac_role.internal]
 
   @hybrid_property
   def access_control_list(self):
@@ -88,7 +69,6 @@ class Roleable(object):
     old_values = {
         (acl.ac_role, acl.person)
         for acl in self.access_control_list
-        if acl.ac_role and not acl.ac_role.internal
     }
     self._remove_values(old_values - new_values)
     self._add_values(new_values - old_values)

--- a/src/ggrc/builder/json.py
+++ b/src/ggrc/builder/json.py
@@ -709,15 +709,9 @@ class Builder(AttributeInfo):
           break
       if attribute_whitelist and attr_name not in attribute_whitelist:
         continue
-      attr = self.publish_attr(
+      json_obj[attr_name] = self.publish_attr(
           obj, attr_name, local_inclusion[1:], len(local_inclusion) > 0,
           inclusion_filter)
-      if attr_name == "filtered_access_control_list":
-        # Instead of using filtered_access_control_list name in the frontend
-        # use access_control_list instead.
-        json_obj["access_control_list"] = attr
-      else:
-        json_obj[attr_name] = attr
 
   def publish_attrs(self, obj, json_obj, extra_inclusions, inclusion_filter,
                     attribute_whitelist):

--- a/src/ggrc/models/audit.py
+++ b/src/ggrc/models/audit.py
@@ -215,7 +215,7 @@ class Audit(Snapshotable,
       return value
 
     if self.archived is not None and self.archived != value and \
-       not any(acl for acl in self.full_access_control_list
+       not any(acl for acl in list(self.full_access_control_list)
                if acl.ac_role.name == "Program Managers Mapped" and
                acl.person.id == user.id):
       raise Forbidden()
@@ -223,6 +223,7 @@ class Audit(Snapshotable,
 
   @classmethod
   def _filter_by_program(cls, predicate):
+    """Helper for filtering by program"""
     return Program.query.filter(
         (Program.id == Audit.program_id) &
         (predicate(Program.slug) | predicate(Program.title))
@@ -230,6 +231,7 @@ class Audit(Snapshotable,
 
   @classmethod
   def _filter_by_auditor(cls, predicate):
+    """Helper for filtering by auditor"""
     from ggrc_basic_permissions.models import Role, UserRole
     return UserRole.query.join(Role, Person).filter(
         (Role.name == "Auditor") &

--- a/src/ggrc/models/audit.py
+++ b/src/ggrc/models/audit.py
@@ -217,7 +217,7 @@ class Audit(Snapshotable,
       return value
 
     if self.archived is not None and self.archived != value and \
-       not any(acl for acl in self.access_control_list
+       not any(acl for acl in self.full_access_control_list
                if acl.ac_role.name == "Program Managers Mapped" and
                acl.person.id == user.id):
       raise Forbidden()

--- a/src/ggrc/models/audit.py
+++ b/src/ggrc/models/audit.py
@@ -177,8 +177,6 @@ class Audit(Snapshotable,
       audit: Audit instance
     """
     for acl in audit.access_control_list:
-      if acl.parent_id:
-        continue
       data = {
           "person": acl.person,
           "ac_role": acl.ac_role,

--- a/src/ggrc/models/hooks/acl/audit_roles.py
+++ b/src/ggrc/models/hooks/acl/audit_roles.py
@@ -152,18 +152,18 @@ class AuditRolesHandler(object):
     first, second = sorted([obj.source, obj.destination], key=lambda o: o.type)
     if isinstance(first, all_models.Audit):
       audit, other = first, second
-      access_control_list = audit.access_control_list
+      access_control_list = audit.full_access_control_list
     elif isinstance(first, (all_models.Assessment,
                             all_models.AssessmentTemplate)):
       if isinstance(second, all_models.Audit):
         audit, other = second, first
-        access_control_list = audit.access_control_list
+        access_control_list = audit.full_access_control_list
       else:
         assessment, other = first, second
-        access_control_list = assessment.access_control_list
+        access_control_list = assessment.full_access_control_list
     elif (isinstance(first, (all_models.Comment, all_models.Document)) and
           isinstance(second, all_models.Issue)):
-      access_control_list = second.access_control_list
+      access_control_list = second.full_access_control_list
       other = first
     else:
       return

--- a/src/ggrc/models/hooks/acl/program_roles.py
+++ b/src/ggrc/models/hooks/acl/program_roles.py
@@ -184,7 +184,7 @@ class ProgramRolesHandler(object):
 
   def handle_snapshot(self, obj):
     """When a snapshot is created propagate program roles"""
-    access_control_list = obj.parent.access_control_list
+    access_control_list = obj.parent.full_access_control_list
     for acl in access_control_list:
       if acl.ac_role.name not in {
           "Program Readers Mapped",
@@ -218,7 +218,7 @@ class ProgramRolesHandler(object):
     for related_object in ("Audit", "Assessment", "Issue"):
       parent, other = related_to(obj, related_object)
       if parent:
-        for acl in parent.access_control_list:
+        for acl in parent.full_access_control_list:
           if self._get_acr_name(acl) not in {
               "Program Readers Mapped",
               "Program Editors Mapped",

--- a/src/ggrc/models/hooks/relationship.py
+++ b/src/ggrc/models/hooks/relationship.py
@@ -498,7 +498,7 @@ def handle_relationship_delete(relationship):
     assign_obj, other = relationship.source, relationship.destination
     if not issubclass(type(relationship.source), Assignable):
       assign_obj, other = other, assign_obj
-    parent_ids = {acl.id for acl in assign_obj.access_control_list}
+    parent_ids = {acl.id for acl in assign_obj.full_access_control_list}
     db.session.query(all_models.AccessControlList).filter(
         all_models.AccessControlList.parent_id.in_(parent_ids),
         all_models.AccessControlList.object_type == other.type,

--- a/src/ggrc/models/proposal.py
+++ b/src/ggrc/models/proposal.py
@@ -203,8 +203,8 @@ def get_propsal_acr_dict():
 
 def permissions_for_proposal_setter(proposal, proposal_roles):
   """Append required proposal roles ACL to proposal."""
-  parents = {a.parent for a in proposal.access_control_list}
-  for acl in proposal.instance.access_control_list:
+  parents = {a.parent for a in proposal.full_access_control_list}
+  for acl in proposal.instance.full_access_control_list:
     if acl in parents:
       continue
     if acl.ac_role.update:

--- a/test/integration/ggrc/proposal/test_proposal_acl.py
+++ b/test/integration/ggrc/proposal/test_proposal_acl.py
@@ -53,7 +53,8 @@ class TestACLPopulation(TestCase):
     self.assertEqual(200, resp.status_code)
     control = all_models.Control.query.get(control_id)
     proposal = all_models.Proposal.query.get(proposal_id)
-    self.assertEqual(int(read or update), len(proposal.access_control_list))
+    self.assertEqual(int(read or update),
+                     len(proposal.full_access_control_list))
     expected_roles = []
     if update:
       expected_roles.append(all_models.Proposal.ACRoles.EDITOR)
@@ -61,4 +62,4 @@ class TestACLPopulation(TestCase):
       expected_roles.append(all_models.Proposal.ACRoles.READER)
     self.assertEqual(
         sorted(expected_roles),
-        sorted([a.ac_role.name for a in proposal.access_control_list]))
+        sorted([a.ac_role.name for a in proposal.full_access_control_list]))


### PR DESCRIPTION
# Issue description

Loading the full access control list with all propagated roles is causing performance and memory issues on the backend.

# Steps to test the changes

n/a

# Solution description

We only need the full access control list for a limited amount of role propagation operations, but currently we load the full list for all objects even on GET request. 

Therefore it makes sense to lazy load the full list only when needed by role propagation. 

Note: Hopefully moving the role propagation code into sql statements will soon remove the need of loading full access control list. At which point the `full_access_control_list` property can be removed.

Loading an audit with 1000 assessments, 2000 regulations and 1000 controls (12119 access control list items, 11 of which were not propagated).

Before:
<img width="679" alt="screen shot 2018-02-24 at 10 39 15" src="https://user-images.githubusercontent.com/513444/36629569-41130590-194f-11e8-842e-e51a2995c596.png">
After:
<img width="681" alt="screen shot 2018-02-24 at 10 37 41" src="https://user-images.githubusercontent.com/513444/36629600-983cd45e-194f-11e8-84f5-399d14ce1a01.png">

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
