### PR TITLE
GGRC-4505 Deny creation invalid CycleTask relationships on FE side

### DIFF
--- a/src/ggrc-client/js/mustache_helper.js
+++ b/src/ggrc-client/js/mustache_helper.js
@@ -1067,6 +1067,19 @@ Mustache.registerHelper("is_allowed_to_map", function (source, target, options) 
   return options.inverse(options.contexts || this);
 });
 
+Mustache.registerHelper('is_allowed_to_map_task', (sourceType, options)=> {
+  const mappableTypes = ['Program', 'Regulation', 'Policy', 'Standard',
+    'Contract', 'Clause', 'Section', 'Request', 'Control', 'Objective',
+    'OrgGroup', 'Vendor', 'AccessGroup', 'System', 'Process', 'DataAsset',
+    'Product', 'Project', 'Facility', 'Market'];
+  sourceType = resolve_computed(sourceType);
+
+  if (mappableTypes.includes(sourceType)) {
+    return options.fn(options.contexts);
+  }
+  return options.inverse(options.contexts);
+});
+
 function resolve_computed(maybe_computed, always_resolve) {
   return (typeof maybe_computed === "function"
     && (maybe_computed.isComputed || always_resolve)) ? resolve_computed(maybe_computed(), always_resolve) : maybe_computed;

--- a/src/ggrc/assets/mustache/base_objects/dropdown_menu.mustache
+++ b/src/ggrc/assets/mustache/base_objects/dropdown_menu.mustache
@@ -51,6 +51,7 @@
 
               <li>
                 {{#is_allowed 'create' 'CycleTaskGroupObjectTask' context=null}}
+                  {{#is_allowed_to_map_task instance.type}}
                     <a
                       rel="tooltip"
                       data-placement="left"
@@ -68,7 +69,8 @@
                         "modal_title": "Create New Task"}'>
                       <i class="fa fa-calendar-check-o"></i> Create task
                     </a>
-                  {{/is_allowed}}
+                  {{/is_allowed_to_map_task}}
+                {{/is_allowed}}
               </li>
             {{/is_allowed}}
 


### PR DESCRIPTION
# Issue description

**(Rebased PR from Vitaliy M). Assignees was set from old PR:**
![image](https://user-images.githubusercontent.com/13063442/36667631-95f0c942-1aff-11e8-95ce-4d6dcf5c1dcc.png)


User should not be able to map CycleTask to Workflow, Task Group Task, Task Group, Cycle Task, Assessment, Assessment Template.
RiskAssesment should be skipped, cause it will be removed in scope of another PR.

# Steps to test the changes
1. Open Global Search modal
2. Search for particular object type
3. Click on a row in search results
4. Open 3bb's menu
"Create Task" should be shown for expected object types only.

# Solution description
For now list of mappable to CycleTask objects is stored on front-end side. It is needed to store it on BE and provide it in GGRC.config object.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
