### PR TITLE
GGRC-4584 Remove snapshotted_objects API property

### DIFF
--- a/src/docbuilder/descriptors/service.py
+++ b/src/docbuilder/descriptors/service.py
@@ -53,7 +53,6 @@ MOCK_DATA = {
     'verified_date': 'null',
     'audit_firm': '{{ "id": 1, "type": "OrgGroup"}}',
     'program': '{{ "id": 1, "type": "Program"}}',
-    'snapshotted_objects': '[]',
 }
 
 

--- a/src/ggrc/models/hooks/acl/program_roles.py
+++ b/src/ggrc/models/hooks/acl/program_roles.py
@@ -127,6 +127,9 @@ class ProgramRolesHandler(object):
     """Handle audit propagation"""
     acl_manager = self.access_control_list_manager
     audit = acl.object
+    # When role propagation is migrated to sql steatements and the
+    # aduit.snapshotted_objects line is removed, the Snapshotable mixin can
+    # be removed as well.
     for snapshot in audit.snapshotted_objects:
       acl_manager.get_or_create(
           snapshot, acl, acl.person, acl.ac_role_id)

--- a/src/ggrc/models/snapshot.py
+++ b/src/ggrc/models/snapshot.py
@@ -154,8 +154,6 @@ class Snapshot(Roleable, relationship.Relatable, WithLastAssessmentDate,
 class Snapshotable(object):
   """Provide `snapshotted_objects` on for parent objects."""
 
-  _api_attrs = reflection.ApiAttributes("snapshotted_objects")
-
   @declared_attr
   def snapshotted_objects(cls):  # pylint: disable=no-self-argument
     """Return all snapshotted objects"""
@@ -168,15 +166,6 @@ class Snapshotable(object):
         foreign_keys='Snapshot.parent_id,Snapshot.parent_type,',
         backref='{0}_parent'.format(cls.__name__),
         cascade='all, delete-orphan')
-
-  @classmethod
-  def eager_query(cls):
-    query = super(Snapshotable, cls).eager_query()
-    return query.options(
-        orm.subqueryload("snapshotted_objects").undefer_group(
-            "Snapshot_complete"
-        ),
-    )
 
 
 def handle_post_flush(session, flush_context, instances):


### PR DESCRIPTION
# TODO

- [x] See how many tests fail because of this -> 0!
- [x] See if snapshotted_objects not being eager loaded causes perf issues on the BE
    The only place where snapshotted_objects are currently used is in program roles propagation (handle_snapshots). I think it's not a problem if the call there lazy loads the snapshots, especially since @zidarsk8 is working to remove that code right now.

# Issue description

We are sending snapshotted_objects dict to the frontend even though it's not actually used there. On an audit with 3000 snapshots the dict takes a while to populate on the BE and parse on the FE.

# Steps to test the changes

Inspect any GET or query requests for audits. After this change is merged it should not include a list of snapshotted_obejcts anywhere.

# Solution description

Snapshotted objects are lazy loaded instead of eagerly loaded so that we load the data only when we access the snapshotted_objects property on the backend. The only place that I can find that does that is the program acl propagation, so merging this will make the query count go up a bit for program propagation, but because the performance of that is already really bad + @zidarsk8 is rewriting it right now I don't think we should care at this point. After that code is removed we can delete the Snapshotable mixin altogether.

Before this PR:
![screen shot 2018-02-28 at 15 21 14](https://user-images.githubusercontent.com/513444/36795701-9f6e3642-1c9b-11e8-809b-3e54c693fc41.png)

If we remove snapshotted_objects from the API response but still eagerly_load it on the BE (note that the response is now 200KB lighter):
![screen shot 2018-02-28 at 15 22 53](https://user-images.githubusercontent.com/513444/36795773-c886c4fe-1c9b-11e8-897f-3e7aed1a874b.png)

Do not eagerly load snapshotted_objects at all (snapshotted_objects are lazy loaded for program permission propagation):
![screen shot 2018-02-28 at 15 24 51](https://user-images.githubusercontent.com/513444/36795797-d7b2976e-1c9b-11e8-9799-76b8144131b7.png)


# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
