### PR TITLE
GGRC-4579 Script for bulk enable of issue tracker

### DIFF
--- a/Dockerfile-selenium
+++ b/Dockerfile-selenium
@@ -1,8 +1,8 @@
 # Copyright (C) 2018 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
-
-FROM selenium/standalone-chrome:3.6.0
+ARG CHROME_CT_VERSION="3.6.0"
+FROM selenium/standalone-chrome:${CHROME_CT_VERSION}
 
 USER root
 COPY ./provision/docker/selenium.bashrc.j2 /root/.bashrc
@@ -19,7 +19,7 @@ USER seluser
 
 # Specify version of Chrome webdriver using 'CHROME_DRIVER_VERSION' argument
 # Latest released version will be used by default
-ARG CHROME_DRIVER_VERSION="latest"
+ARG CHROME_DRIVER_VERSION="2.35"
 RUN CD_VER=$(if [ ${CHROME_DRIVER_VERSION:-latest} = "latest" ]; then echo\
   $(wget -qO- https://chromedriver.storage.googleapis.com/LATEST_RELEASE); \
   else echo $CHROME_DRIVER_VERSION; fi) \

--- a/src/ggrc-client/js/entrypoints/dashboard/bootstrap.js
+++ b/src/ggrc-client/js/entrypoints/dashboard/bootstrap.js
@@ -15,6 +15,7 @@ import {
 } from '../../plugins/utils/current-page-utils';
 import {RouterConfig} from '../../router';
 import routes from './routes';
+import '../../plugins/utils/it-enable/issue-tracker-enable';
 
 const $area = $('.area').first();
 const instance = GGRC.page_instance();

--- a/src/ggrc-client/js/plugins/utils/it-enable/issue-tracker-enable.js
+++ b/src/ggrc-client/js/plugins/utils/it-enable/issue-tracker-enable.js
@@ -1,0 +1,262 @@
+/*
+  Copyright (C) 2018 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+import template from './issue-tracker-enable.mustache';
+import logger from './issue-tracker-log';
+
+/* eslint-disable no-console */
+
+const audit = GGRC.page_instance();
+
+let isButtonActivated = false;
+
+let vm;
+
+const relevantToAuditFilter = {
+  expression: {
+    object_name: audit.type,
+    op: {name: 'relevant'},
+    ids: [audit.id],
+  },
+};
+const request = async (url, body) => {
+  let params = {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: {
+      'Content-type': 'application/json',
+    },
+    credentials: 'include',
+  };
+
+  let response = await fetch(url, params);
+  return response.json();
+};
+const getRelatedAssessmentsIds = async (filters = relevantToAuditFilter, limit) => {
+  let query = {
+    object_name: 'Assessment',
+    filters,
+    type: 'ids',
+  };
+
+  if (limit) {
+    query.limit = limit;
+  }
+  let response = await request('/query', [query]);
+  return response[0].Assessment.ids;
+};
+const updateAssessments = (assessments) => {
+  let result = can.Deferred().resolve([]);
+
+  return Array.from(assessments).reduce((dfd, assessment) => {
+    return dfd.then((updated) => {
+      let deferred = new can.Deferred();
+
+      assessment.save().then((assessment) => {
+        logger.add({
+          id: assessment.id,
+          status: 'loaded',
+        });
+
+        delete CMS.Models.Assessment.cache[assessment.id];
+        delete CMS.Models.Assessment.store[assessment.id];
+
+        deferred.resolve([...updated, assessment]);
+      }, () => {
+        logger.add({
+          id: assessment.id,
+          status: 'error',
+        });
+
+        deferred.resolve([...updated, {
+          error: 'Assessment not updated',
+          id: assessment.id,
+        }]);
+      });
+
+      return deferred;
+    });
+  }, result);
+};
+
+const IssueTrackerEnabler = can.Map.extend({
+  state: {
+    open: false,
+  },
+  from: 0,
+  to: 300,
+  isStopped: false,
+  slugsString: '',
+  done: false,
+  audit: audit,
+  statesMap: {},
+  statesList: [],
+  slugs: [],
+  checked: 0,
+  ids: [],
+  logs: [],
+  open() {
+    this.attr('state.open', true);
+  },
+  stop() {
+    this.attr('isStopped', true);
+  },
+  showLog() {
+    let log = logger.readLog();
+    console.log('Show log, items in the log:', log.length);
+
+    this.attr('logs').replace(log);
+  },
+  initIds(ids) {
+    this.attr('statesList').replace([]);
+    this.attr('checked', 0);
+    ids.forEach((id) => {
+      let state = new can.Map({
+        id,
+        state: 'unchecked',
+      });
+      this.attr('statesList').push(state);
+      this.attr(`statesMap.${id}`, state);
+    });
+
+    this.attr('ids', ids);
+  },
+  async enableITForAll() {
+    let from = this.attr('from');
+    let to = this.attr('to');
+    let ids = await getRelatedAssessmentsIds(relevantToAuditFilter, [from, to]);
+
+    this.initIds(ids);
+
+    logger.reset();
+
+    this.enableByIds(ids);
+  },
+  async enableForSlugs() {
+    let slugString = this.attr('slugsString');
+    let slugs = slugString.split(',').map((slug) => slug.trim());
+
+    this.attr('slugs', slugs);
+
+    let query = {
+      expression: {
+        left: 'slug',
+        op: {name: 'IN'},
+        right: slugs,
+      },
+    };
+    let filter = GGRC.query_parser.join_queries(relevantToAuditFilter, query);
+
+    let ids = await getRelatedAssessmentsIds(filter);
+
+    this.initIds(ids);
+
+    logger.reset();
+
+    this.enableByIds(ids);
+  },
+  enableByIds(ids) {
+    let assessmentsForUpdate = ids.splice(0, 5)
+      .map((id) => CMS.Models.Assessment.findOne({id}));
+
+    return $.when(...assessmentsForUpdate)
+      .then((...assessments) => {
+        let assessmentWithoutIT = assessments.filter((asmt) => {
+          let isTrackerDisabled = !asmt.attr('issue_tracker')
+            || !asmt.attr('issue_tracker.enabled');
+
+          let checked = this.attr('checked');
+
+          this.attr('checked', checked + 1);
+          if (!isTrackerDisabled) {
+            logger.add({
+              id: asmt.id,
+              status: 'skipped',
+            });
+
+            this.attr(`statesMap.${asmt.id}.state`, 'skipped');
+          }
+
+          return isTrackerDisabled;
+        });
+
+        if (!assessmentWithoutIT.length) {
+          return [];
+        }
+
+        let updatingAsmts = assessmentWithoutIT.map((asmt) => {
+          let it = asmt.attr('issue_tracker');
+          let parentIT = audit.attr('issue_tracker');
+
+          it.attr('issue_priority', it.attr('issue_priority')
+            || parentIT.attr('issue_priority'));
+          it.attr('issue_severity', it.attr('issue_severity')
+            || parentIT.attr('issue_severity'));
+          it.attr('component_id', it.attr('component_id')
+            || parentIT.attr('component_id'));
+          it.attr('hotlist_id', it.attr('hotlist_id')
+            || parentIT.attr('hotlist_id'));
+          it.attr('issue_type', it.attr('issue_type')
+            || parentIT.attr('issue_type'));
+          it.attr('title', it.attr('title') || asmt.attr('title'));
+          it.attr('enabled', true);
+          return asmt;
+        });
+
+        return updateAssessments(updatingAsmts);
+      }, () => {
+        // got an error on
+        ids.forEach((id) => {
+          this.attr(`statesMap.${id}.state`, 'error');
+        });
+      })
+      .then((updateReady) => {
+        updateReady.forEach((a) => {
+          if (!a.error) {
+            this.attr(`statesMap.${a.id}.state`, 'loaded');
+          } else {
+            this.attr(`statesMap.${a.id}.state`, 'error');
+          }
+        });
+      })
+      .always(() => {
+        let isStopped = this.attr('isStopped');
+
+        if (ids.length && !isStopped) {
+          return this.enableByIds(ids);
+        } else {
+          this.attr('done', true);
+        }
+      });
+  },
+});
+
+GGRC.enableIssueTracker = () => {
+  if (audit.type !== 'Audit') {
+    console.warn(`This function is applicable only in Audit scope. 
+      Please open the Audit page and try again!`);
+    return;
+  }
+
+  if (!audit.issue_tracker
+    || audit.issue_tracker && !audit.issue_tracker.enabled) {
+    console.warn('Issue tracker must be enabled for this Audit!');
+    return;
+  }
+
+  if (isButtonActivated) {
+    console.warn('Issue tracker script has already activated!');
+    vm.open();
+  } else {
+    isButtonActivated = true;
+
+    vm = new IssueTrackerEnabler();
+
+    let renderer = can.view.mustache(template);
+    let fragment = renderer(vm);
+
+    $('section.footer').append(fragment);
+  }
+};

--- a/src/ggrc-client/js/plugins/utils/it-enable/issue-tracker-enable.mustache
+++ b/src/ggrc-client/js/plugins/utils/it-enable/issue-tracker-enable.mustache
@@ -1,0 +1,93 @@
+{{!
+  Copyright (C) 2018 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+}}
+
+<style>
+  .it-update {
+    padding: 20px;
+    max-height: 70%;
+    overflow-y: auto;
+  }
+  .it-update span {
+    border: 1px solid #a5a5a5;
+    margin-right: 10px;
+    margin-bottom: 10px;
+    padding: 5px;
+    min-width: 20px;
+    max-width: 150px;
+  }
+
+  .it-update span.loaded {
+    background: green;
+  }
+  .it-update span.error {
+    background: red;
+    color: black;
+    font-weight: 400;
+  }
+  .it-update span.skipped {
+    border-color: green;
+    border-width: 2px;
+  }
+  .it-controls {
+    padding: 20px;
+  }
+
+  .it-controls button {
+    width: 200px;
+  }
+</style>
+
+<button ($click)="open()">Bulk enable of Issue Tracker</button>
+
+<simple-modal {state}="state" replace-content="true" extra-css-class="related-assessments">
+  <div class="simple-modal__header">
+    <div class="simple-modal__header-text">Enable Issue Tracker</div>
+    <button class="btn btn-small btn-icon" {{^done}}disabled{{/done}} ($click)="hide">
+      <i class="fa fa-times black"></i>
+    </button>
+  </div>
+  <div class="flex-box flex-col it-controls" style="">
+    <div class="it-from-to">
+      From <input type="text" {($value)}="from">
+      To <input type="text" {($value)}="to">
+    </div>
+    <div class="flex-box" style="margin-bottom: 10px">
+      <button ($click)="enableITForAll()" >
+        Enable IT for All
+      </button>
+
+      <button ($click)="stop()" style="margin-left: auto; margin-right: 10px">
+        Stop
+      </button>
+      <button ($click)="showLog()">
+        Show Log
+      </button>
+    </div>
+
+    <textarea {($value)}="slugsString" style="width: 100%"></textarea>
+    <button ($click)="enableForSlugs()">Enable By Slugs</button>
+  </div>
+  <div class="flex-box flex-box-multi it-update">
+    <div style="height: 30px; width: 100%; display: flex; flex-flow: wrap;">
+      <span class="skipped"></span> <labe> - Skipped (Issue Tracker already enabled)</labe>
+      <span class="loaded" style="margin-left: 15px"></span> <lable> - Updated</lable>
+      <span class="error" style="margin-left: 15px"></span> <lable> - Error</lable>
+      <label style="margin-left: auto">Progress (checked/total): {{checked}}/{{statesList.length}} </label>
+    </div>
+
+    <hr/>
+
+    <div style="width: 100%; border-top: 1px solid #a5a5a5;">Log:</div>
+    {{#logs}}
+      <span class="{{status}}">{{id}}</span>
+    {{/logs}}
+    <hr/>
+
+    <div style="width: 100%; border-top: 1px solid #a5a5a5;">Progress:</div>
+    {{#statesList}}
+      <span class="{{state}}">{{id}}</span>
+    {{/statesList}}
+  </div>
+</simple-modal>

--- a/src/ggrc-client/js/plugins/utils/it-enable/issue-tracker-log.js
+++ b/src/ggrc-client/js/plugins/utils/it-enable/issue-tracker-log.js
@@ -1,0 +1,34 @@
+/*
+  Copyright (C) 2018 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+const STORAGE_KEY = 'GGRC_IT_Log';
+
+class Storage {
+  constructor() {
+    let log = this.readLog();
+
+    if (!log) {
+      this.reset();
+    }
+  }
+
+  add(item) {
+    let log = this.readLog();
+
+    log.push(item);
+
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(log));
+  }
+  readLog() {
+    let storage = localStorage.getItem(STORAGE_KEY);
+
+    return storage ? JSON.parse(storage) : null;
+  }
+  reset() {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify([]));
+  }
+}
+
+export default new Storage();

--- a/src/ggrc/templates/layouts/dashboard.haml
+++ b/src/ggrc/templates/layouts/dashboard.haml
@@ -48,8 +48,6 @@
       =config.get('COMPANY')
       Version
       =config.get('VERSION')
-      .analytics
-        ={config.get('GOOGLE_ANALYTICS_SCRIPT') | safe}
 
   #lhn
     #lhs.lhs.accordion{ 'data-template': '/dashboard/lhn.mustache' }


### PR DESCRIPTION
# Issue description

Need to enable Issue tracker for all assessments in scope of Audit.

# Solution description

Script for run into browser console that loads all related assessments and enable issue tracker where it not enabled.

**Steps:**
1. Open Audit page
2. Open Chrome DevTool
3. Run `GGRC.enableIssueTracker()` in the console