### PR TITLE
GGRC-4381 Change color for Deprecated state

### DIFF
--- a/src/ggrc-client/js/controllers/summary_widget_controller.js
+++ b/src/ggrc-client/js/controllers/summary_widget_controller.js
@@ -24,7 +24,7 @@ export default can.Control({
     colorsMap: {
       'Completed and Verified': '#405f77',
       'Completed (no verification)': '#009925',
-      Deprecated: '#fbc02d',
+      Deprecated: '#704c70',
       'In Progress': '#3369e8',
       'Not Started': '#9e9e9e',
       'In Review': '#f57c00',

--- a/src/ggrc-client/styles/_colors.scss
+++ b/src/ggrc-client/styles/_colors.scss
@@ -155,7 +155,7 @@ $status-inreview: #f57c00;
 $status-verified: #009925;
 $status-completed: #405f77;
 $status-declined: #d50f25;
-$status-deprecated: #fbc02d;
+$status-deprecated: #704c70;
 
 // progress bar colors
 $bar-base: #fff;


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Set #704C70 color for Deprecated/Inactive states.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [ ] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
