### PR TITLE
GGRC-4227 Checkbox is shown as proposed value if user is not proposed to change it

### DIFF
--- a/src/ggrc/models/custom_attribute_definition.py
+++ b/src/ggrc/models/custom_attribute_definition.py
@@ -134,7 +134,7 @@ class CustomAttributeDefinition(attributevalidator.AttributeValidator,
     MAP = "Map"
 
     DEFAULT_VALUE = {
-        CHECKBOX: 0,
+        CHECKBOX: "0",
         RICH_TEXT: "",
         TEXT: "",
     }

--- a/src/ggrc/utils/revisions_diff/builder.py
+++ b/src/ggrc/utils/revisions_diff/builder.py
@@ -138,6 +138,16 @@ def generate_acl_diff(proposed, revisioned):
   return acl_dict
 
 
+def get_validated_value(cad, value, object_id):
+  """Get valid value that related to specified cad."""
+  if isinstance(value, basestring):
+    value = value.strip()
+    return value, object_id
+  if cad.attribute_type == cad.ValidTypes.CHECKBOX:
+    value = int(value)
+  return unicode(value), object_id
+
+
 def generate_cav_diff(instance, proposed, revisioned):
   """Build diff for custom attributes."""
   if not isinstance(instance, mixins.customattributable.CustomAttributable):
@@ -154,7 +164,7 @@ def generate_cav_diff(instance, proposed, revisioned):
   for cad in instance.custom_attribute_definitions:
     if cad.id not in proposed_cavs:
       continue
-    proposed_val = proposed_cavs[cad.id]
+    proposed_val = get_validated_value(cad, *proposed_cavs[cad.id])
     cad_not_setuped = cad.id not in revisioned_cavs
     if cad_not_setuped or proposed_val != revisioned_cavs[cad.id]:
       value, person_id = proposed_val

--- a/src/ggrc/utils/revisions_diff/builder.py
+++ b/src/ggrc/utils/revisions_diff/builder.py
@@ -165,8 +165,11 @@ def generate_cav_diff(instance, proposed, revisioned):
     if cad.id not in proposed_cavs:
       continue
     proposed_val = get_validated_value(cad, *proposed_cavs[cad.id])
-    cad_not_setuped = cad.id not in revisioned_cavs
-    if cad_not_setuped or proposed_val != revisioned_cavs[cad.id]:
+    if cad.id not in revisioned_cavs:
+      revisioned_value = (cad.default_value, None)
+    else:
+      revisioned_value = revisioned_cavs[cad.id]
+    if proposed_val != revisioned_value:
       value, person_id = proposed_val
       person = person_obj_by_id(person_id) if person_id else None
       diff[cad.id] = {

--- a/test/integration/ggrc/proposal/api/test_cads.py
+++ b/test/integration/ggrc/proposal/api/test_cads.py
@@ -42,6 +42,66 @@ class TestCADProposalsApi(base.BaseTestProposalApi):
                      control.proposals[0].content["custom_attribute_values"])
     self.assertEqual(1, len(control.comments))
 
+  @ddt.data(
+      ("1", "1", None),
+      ("0", "0", None),
+      ("1", "0", "0"),
+      ("0", "1", "1"),
+      (None, "0", None),
+      (None, "1", "1"),
+      ("1", True, None),
+      ("0", False, None),
+      ("1", False, "0"),
+      ("0", True, "1"),
+      (None, False, None),
+      (None, True, "1"),
+      ("1", 1, None),
+      ("0", 0, None),
+      ("1", 0, "0"),
+      ("0", 1, "1"),
+      (None, 0, None),
+      (None, 1, "1"),
+  )
+  @ddt.unpack
+  def test_change_checkbox(self, start_value, sent_value, expected_value):
+    """Proposal for Checkbox CAVs if start value is {0} and sent is {1}."""
+    checkbox_type = all_models.CustomAttributeDefinition.ValidTypes.CHECKBOX
+    with factories.single_commit():
+      control = factories.ControlFactory(title="1")
+      cad = factories.CustomAttributeDefinitionFactory(
+          definition_type="control",
+          attribute_type=checkbox_type,
+      )
+      if start_value is not None:
+        factories.CustomAttributeValueFactory(
+            custom_attribute=cad,
+            attributable=control,
+            attribute_value=start_value)
+
+    control_id = control.id
+    cad_id = cad.id
+    data = control.log_json()
+    del data["custom_attributes"]
+    data["custom_attribute_values"] = [{
+        "custom_attribute_id": cad_id,
+        "attribute_value": sent_value,
+        "attribute_object_id": None
+    }]
+    self.create_proposal(control,
+                         full_instance_content=data,
+                         agenda="update cav",
+                         context=None)
+    control = all_models.Control.query.get(control_id)
+    self.assertEqual(1, len(control.proposals))
+    self.assertIn("custom_attribute_values", control.proposals[0].content)
+    if expected_value is None:
+      self.assertFalse(control.proposals[0].content["custom_attribute_values"])
+    else:
+      self.assertEqual({unicode(cad_id): {"attribute_value": expected_value,
+                                          "attribute_object": None}},
+                       control.proposals[0].content["custom_attribute_values"])
+    self.assertEqual(1, len(control.comments))
+
   def test_apply_cad(self):
     """Test apply proposal with change CAVs."""
     with factories.single_commit():


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Checkbox is shown as proposed value if user is not proposed to change it

# Steps to test the changes

1. Create a control as Admin user
2. Log As global Reader and propose to change GCAs values: e.g. date, rich text, checkbox
3. As Admin Apply changes
4. As Global Reader propose to change desccription
5. As Admin open Change Proposals tab and look at the checkbox: is shown as checked
Actual Result: Checkbox is shown as proposed value if user is not proposed to change it
Expected Result: If checkbox was not changed, it shouldn't shown up in change proposals tab and in comparison window

# Solution description

It doesn't matter in what format FE send value to checkbox cav, it should be converted to format valid for saving for that data and only after that it should be compared with value in latest revision. 

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
