### PR TITLE
GGRC-4653 Fix copy_snapshot_plan when no test_plan in revision content

### DIFF
--- a/src/ggrc/models/hooks/assessment.py
+++ b/src/ggrc/models/hooks/assessment.py
@@ -290,8 +290,9 @@ def relate_ca(assessment, template):
 
 def copy_snapshot_plan(assessment, snapshot):
   """Copy test plan of Snapshot into Assessment"""
-  if assessment.test_plan and snapshot.revision.content["test_plan"]:
+  snapshot_plan = snapshot.revision.content.get("test_plan", "")
+  if assessment.test_plan and snapshot_plan:
     assessment.test_plan += "<br>"
-    assessment.test_plan += snapshot.revision.content["test_plan"]
-  elif snapshot.revision.content["test_plan"]:
-    assessment.test_plan = snapshot.revision.content["test_plan"]
+    assessment.test_plan += snapshot_plan
+  elif snapshot_plan:
+    assessment.test_plan = snapshot_plan

--- a/test/integration/ggrc/models/hooks/test_assessment.py
+++ b/test/integration/ggrc/models/hooks/test_assessment.py
@@ -1,0 +1,37 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Test Assessment hooks"""
+
+from ggrc.models import all_models
+from ggrc.models.hooks import assessment
+from integration.ggrc.models import factories
+from integration.ggrc import TestCase
+
+
+class TestAssessmentHook(TestCase):
+  """TestAuditRoleProgation"""
+
+  def setUp(self):
+    super(TestAssessmentHook, self).setUp()
+    control = factories.ControlFactory()
+    with factories.single_commit():
+      self.assessment = factories.AssessmentFactory()
+      audit = factories.AuditFactory()
+      revision = all_models.Revision.query.filter(
+          all_models.Revision.resource_id == control.id,
+          all_models.Revision.resource_type == control.type,
+      ).first()
+      self.snapshot = factories.SnapshotFactory(
+          parent=audit,
+          revision_id=revision.id,
+          child_type=control.type,
+          child_id=control.id,
+      )
+
+  def test_missing_snapshot_plan(self):
+    """Test copy_snapshot_plan when test_plan is missing from revision"""
+    self.snapshot.revision.content = {}
+    assessment_test_plan = self.assessment.test_plan
+    assessment.copy_snapshot_plan(self.assessment, self.snapshot)
+    self.assertEqual(assessment_test_plan, self.assessment.test_plan)


### PR DESCRIPTION
**NOTE:** We need to decide if this is going in as a hotfix or in 1.6.0

# Issue description

Generating assessment templates failed when revision content does not include the test_plan key.

# Steps to test the changes

1. Create an object and make sure it's revision doesn't have a test_plan (you might have to do it manually).
2. Create a Program -> Audit -> Assessment Template (make sure `Copy Assessment Procedure from mapped object` is checked)
3. Generate an assessment using the template from 2. and an object from 1.

# Solution description

Make sure we retrieve the test plan with `get`, avoiding the possibility of a key error.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

