### PR TITLE
GGRC-4281 Reduce the number of queries on cycle task PUT

### DIFF
--- a/src/ggrc_workflows/models/cycle.py
+++ b/src/ggrc_workflows/models/cycle.py
@@ -218,6 +218,12 @@ class Cycle(mixins.WithContact,
             "next_due_date",
         ),
         orm.Load(cls).subqueryload("cycle_task_group_object_tasks").joinedload(
+            "access_control_list"
+        ).load_only(
+            "person_id",
+            "ac_role_id"
+        ),
+        orm.Load(cls).subqueryload("cycle_task_group_object_tasks").joinedload(
             "cycle_task_entries"
         ).load_only(
             "description",

--- a/src/ggrc_workflows/models/cycle.py
+++ b/src/ggrc_workflows/models/cycle.py
@@ -76,6 +76,7 @@ class Cycle(mixins.WithContact,
 
   @builder.simple_property
   def folder(self):
+    """Get the workflow folder."""
     if self.workflow:
       return self.workflow.folder
     return ""
@@ -177,6 +178,7 @@ class Cycle(mixins.WithContact,
 
   @classmethod
   def _filter_by_cycle_workflow(cls, predicate):
+    """Filter by cycle workflow."""
     from ggrc_workflows.models.workflow import Workflow
     return Workflow.query.filter(
         (Workflow.id == cls.workflow_id) &

--- a/src/ggrc_workflows/models/cycle_task_group.py
+++ b/src/ggrc_workflows/models/cycle_task_group.py
@@ -181,6 +181,12 @@ class CycleTaskGroup(roleable.Roleable,
             "title",
             "end_date"
         ),
+        orm.Load(cls).subqueryload("cycle_task_group_tasks").joinedload(
+            "access_control_list"
+        ).load_only(
+            "person_id",
+            "ac_role_id"
+        ),
         orm.Load(cls).joinedload("cycle").load_only(
             "id",
             "title",


### PR DESCRIPTION
# Issue description

Because access_control_list entries were being lazy loaded sending a PUT
request to a single cycle task produced a big amount of
access_control_list queries. Locally this change reduces PUT response
times from 8s to 4s on a workflow with 1000 tasks.

Before:
![screen shot 2018-03-08 at 20 02 37](https://user-images.githubusercontent.com/513444/37173528-be38b702-230b-11e8-9c29-bff4107b7224.png)

After:
![screen shot 2018-03-08 at 20 02 47](https://user-images.githubusercontent.com/513444/37173530-c04c8046-230b-11e8-8815-f0247e08ca78.png)

The number of queries went down from 2000 to 150.

# Steps to test the changes

Create a workflow with a big amount of tasks (at least 1000). Observe the response times of PUT requests on cycle tasks.

# Solution description

We make sure access_control_list items of cycle_task_group_tasks are not lazy loaded in the cycle indexer. 

**Note**: I don't believe this will fix the main issue that the users are experiencing (10-20 minute wait times for saving tasks). I think the main issue is due to how we do indexing where every cycle task PUT triggers the reindexing of the cycle which has to load ALL cycle_task_group_task objects and reindex some of their fields. Those are a lot of expensive DELETE and INSERT statements into one of our tallest tables. We will need to make sure this operation is done in a smarter way to fully fix the issue.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
