### PR TITLE
GGRC-4670 Don't expose dev environment to external ports

### DIFF
--- a/docker-compose-testing.yml
+++ b/docker-compose-testing.yml
@@ -10,9 +10,9 @@ services:
      - ".:/vagrant"
      - ".:/vagrant_bind"
     ports:
-     - "127:0:0:1:8001:8000"
-     - "127:0:0:1:8081:8080"
-     - "127:0:0:1:9877:9876"
+     - "127.0.0.1:8001:8000"
+     - "127.0.0.1:8081:8080"
+     - "127.0.0.1:9877:9876"
     environment:
      - PYTHONDONTWRITEBYTECODE=true
      - NODE_PATH=/vagrant-dev/node_modules/

--- a/docker-compose-testing.yml
+++ b/docker-compose-testing.yml
@@ -1,7 +1,7 @@
 version: "2"
 services:
   dev:
-    build: 
+    build:
       context: .
       dockerfile: Dockerfile
       args:
@@ -10,9 +10,9 @@ services:
      - ".:/vagrant"
      - ".:/vagrant_bind"
     ports:
-     - "8001:8000"
-     - "8081:8080"
-     - "9877:9876"
+     - "127:0:0:1:8001:8000"
+     - "127:0:0:1:8081:8080"
+     - "127:0:0:1:9877:9876"
     environment:
      - PYTHONDONTWRITEBYTECODE=true
      - NODE_PATH=/vagrant-dev/node_modules/
@@ -31,7 +31,7 @@ services:
       - /var/lib/mysql/:rw,noexec,nosuid,size=1G
 
   selenium:
-    build: 
+    build:
       context: .
       dockerfile: Dockerfile-selenium
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,10 +5,10 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-     - "127:0:0:1:8000:8000"
-     - "127:0:0:1:8080:8080"
-     - "127:0:0:1:9876:9876"
-     - "127:0:0:1:9222:9222"
+     - "127.0.0.1:8000:8000"
+     - "127.0.0.1:8080:8080"
+     - "127.0.0.1:9876:9876"
+     - "127.0.0.1:9222:9222"
     volumes:
      - ".:/vagrant"
     environment:
@@ -21,7 +21,7 @@ services:
   db:
     image: mysql:5.6
     ports:
-     - "127:0:0:1:3306:3306"
+     - "127.0.0.1:3306:3306"
     volumes:
      - "./provision/docker/mysql:/etc/mysql/conf.d"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,10 +5,10 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-     - "8000:8000"
-     - "8080:8080"
-     - "9876:9876"
-     - "9222:9222"
+     - "127:0:0:1:8000:8000"
+     - "127:0:0:1:8080:8080"
+     - "127:0:0:1:9876:9876"
+     - "127:0:0:1:9222:9222"
     volumes:
      - ".:/vagrant"
     environment:
@@ -21,7 +21,7 @@ services:
   db:
     image: mysql:5.6
     ports:
-     - "3306:3306"
+     - "127:0:0:1:3306:3306"
     volumes:
      - "./provision/docker/mysql:/etc/mysql/conf.d"
     environment:


### PR DESCRIPTION
# Issue description

For safety reasons it's better to not expose local environment to external ports without proper security level.

# Steps to test the changes

Local environment works as expected.
It's impossible to access local environment from external machine.

# Solution description

Docker binding changed to localhost only.

# Sanity checklist

- [ ] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [ ] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [ ] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [ ] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
