### PR TITLE
GGRC-1956 Add authorize link for attach-button

### DIFF
--- a/src/ggrc-client/js/components/assessment/attach-button.mustache
+++ b/src/ggrc-client/js/components/assessment/attach-button.mustache
@@ -36,18 +36,18 @@
           </div>
         {{/if}}
       {{else}}
+        <small>
         {{#if error.errors}}
-          <small>
             You need permission to upload files to the audit folder. <a
             href="https://drive.google.com/folderview?id={{grdive_msg_to_id error.message}}&usp=sharing#">Request
             access.</a>
-          </small>
         {{else}}
-          The GDrive folder for this evidence could not be accessed.
-          {{#using request=parent_instance.request}}
-            {{{render '/static/mustache/gdrive/gapi_errors.mustache' type="file" instance=request error=error}}}
-          {{/using}}
+            <strong>Warning:</strong> GDrive folder could not be accessed without authorization. <a
+              ($click)="checkFolder()"
+              >Authorize again.
+            </a>
         {{/if}}
+        </small>
       {{/if}}
       </div>
     {{/if}}


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

There is wrong message on assessment page if you cancel gDrive authorization.

![image](https://user-images.githubusercontent.com/10946494/37343231-f19604a4-26d7-11e8-8808-64ffbfa013bc.png)

# Steps to test the changes

Steps to reproduce:

1) Create a program.
2) Create an audit and while creating assign audit folder with the access of a current user to the folder.
3) Go to the audit page.
4) Create assessment.
5) Clean cookies.
6) Navigate to assessment's info pane and look at the evidence field

Actual Result: "More Info error" is shown while audit folder is assigned
Expected Result: If audit folder is assigned and a user has an access to the folder no error is shown. Evidences should be attached and displayed on Assessment's Info pane properly.

# Requirements

- Authorization pop-up should be automatically opened, if user opens assessment info pane/page, when cookies are cleaned up.
- If authorization pop-up is closed, then display message 'Warning: GDrive folder could not be accessed without authorization. <Authorize again>'
- On clicking 'Authorize again' link, authorization pop-up should be opened.

# Solution description

Add authorize link for attach-button.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
