### PR TITLE
GGRC-4655 Remove redundant relationship creation 

### DIFF
--- a/src/ggrc/snapshotter/helpers.py
+++ b/src/ggrc/snapshotter/helpers.py
@@ -71,47 +71,6 @@ def get_revisions(pairs, revisions, filters=None):
     return revision_id_cache
 
 
-def get_relationships(relationships):
-  """Retrieve relationships
-
-  Args:
-    relationships:
-  """
-  with benchmark("snapshotter.helpers.get_relationships"):
-    if relationships:
-      relationship_columns = db.session.query(
-          models.Relationship.id,
-          models.Relationship.modified_by_id,
-          models.Relationship.created_at,
-          models.Relationship.updated_at,
-          models.Relationship.source_type,
-          models.Relationship.source_id,
-          models.Relationship.destination_type,
-          models.Relationship.destination_id,
-          models.Relationship.context_id,
-      )
-
-      return relationship_columns.filter(
-          tuple_(
-              models.Relationship.source_type,
-              models.Relationship.source_id,
-              models.Relationship.destination_type,
-              models.Relationship.destination_id,
-          ).in_(relationships)
-      ).union(
-          relationship_columns.filter(
-              tuple_(
-                  models.Relationship.destination_type,
-                  models.Relationship.destination_id,
-                  models.Relationship.source_type,
-                  models.Relationship.source_id
-              ).in_(relationships)
-          )
-      )
-    else:
-      return set()
-
-
 def get_snapshots(objects=None, ids=None):
   with benchmark("snapshotter.helpers.get_snapshots"):
     if objects and ids:
@@ -194,47 +153,6 @@ def create_snapshot_revision_dict(action, event_id, snapshot,
       "resource_id": snapshot[0],
       "resource_type": "Snapshot",
       "context_id": context_id
-  }
-
-
-def create_relationship_dict(source, destination, user_id, context_id):
-  """Create dictionary representation of relationship"""
-  return {
-      "source_type": source.type,
-      "source_id": source.id,
-      "destination_type": destination.type,
-      "destination_id": destination.id,
-      "modified_by_id": user_id,
-      "context_id": context_id,
-  }
-
-
-def create_relationship_revision_dict(action, event_id, relationship,  # noqa # pylint: disable=invalid-name
-                                      user_id, context_id):
-  """Create dictionary representation of relationship revision"""
-  revision_content = relationship._asdict()
-  metadata = {
-      "display_name": "{}:{} <-> {}:{}".format(
-          relationship.source_type,
-          relationship.source_id,
-          relationship.destination_type,
-          relationship.destination_id
-      ),
-      "modified_by": create_json_stub("Person", context_id, user_id),
-      "parent_id": None,
-      "attrs": {}
-  }
-  revision_content.update(metadata)
-
-  return {
-      "action": action,
-      "event_id": event_id,
-      "content": revision_content,
-      "modified_by_id": user_id,
-      "resource_id": relationship.id,
-      "resource_type": "Relationship",
-      "context_id": context_id,
-      "status": None,
   }
 
 

--- a/test/integration/ggrc/snapshotter/test_snapshoting.py
+++ b/test/integration/ggrc/snapshotter/test_snapshoting.py
@@ -105,9 +105,6 @@ class TestSnapshoting(SnapshotterBaseTestCase):
         ]
     })
 
-    audit = db.session.query(models.Audit).filter(
-        models.Audit.title == "Snapshotable audit").one()
-
     snapshot = db.session.query(models.Snapshot).filter(
         models.Snapshot.child_id == control.id,
         models.Snapshot.child_type == "Control",
@@ -132,31 +129,6 @@ class TestSnapshoting(SnapshotterBaseTestCase):
     snapshot_revision_content = snapshot_revision.first()[2]
     self.assertEqual(snapshot_revision_content["child_type"], "Control")
     self.assertEqual(snapshot_revision_content["child_id"], control.id)
-
-    relationship_columns = db.session.query(models.Relationship)
-    relationship = relationship_columns.filter(
-        models.Relationship.source_type == "Audit",
-        models.Relationship.source_id == audit.id,
-        models.Relationship.destination_type == "Control",
-        models.Relationship.destination_id == control.id
-    ).union(
-        relationship_columns.filter(
-            models.Relationship.source_type == "Control",
-            models.Relationship.source_id == control.id,
-            models.Relationship.destination_type == "Audit",
-            models.Relationship.destination_id == audit.id
-        )
-    )
-    self.assertEqual(relationship.count(), 1)
-
-    self.assertEqual(db.session.query(
-        models.Revision.resource_type,
-        models.Revision.resource_id,
-        models.Revision._content,
-    ).filter(
-        models.Revision.resource_type == "Relationship",
-        models.Revision.resource_id == relationship.first().id,
-    ).count(), 1)
 
     self.assertEqual(db.session.query(models.AccessControlList.id).filter(
         models.AccessControlList.object_id == snapshot_obj.id,


### PR DESCRIPTION
## cherry pick from https://github.com/google/ggrc-core/pull/7445

# Issue description

The relationships created between original objects and audits were done
as a hack to ensure the unified mapper showed already created snapshots
as mapped. This issue was later fixed on the front-end but the legacy
code was never removed. Now the code just presents a performance
degradation and brings no actual value to our app.

Second thing to consider is that the relationships are generated ONLY on
audit creation from the objects mapped to the programs. Any additional
snapshots that are created and mapped to the audit at later time, do not
have these relationships. And since half of the snapshots have them and
half don't without showing any bugs in our app, we can safely say that
removing this code should not cause any regressions. Any bugs that would
be caused by this must already exist since we can create the same state
already depending on how a snapshot is created.

This PR also removes the checks for those relationships and their
revisions.




# Steps to test the changes

to verify this ticket

Check that snapshots are work in the same way (a few examples I can think of are below):
- Create a program with a few objects mapped
- Create an audit from that program
- go to snapshot page, click map, search for an object that is already mapped and check that you can not map it again (checkbox should already be checked and disabled)
- go to original object page (of those snapshots) and check that the audit is present in the audit tab.

# Solution description

Remove the code that generates redunadant relationhips.

Quick performance tests:
On program with 3k objects mapped, on my local machine with db in memory.

On dev:
creating an audit (including background tasks): 24.5s
creating an audit (without background tasks): 18.6s

This PR:
creating an audit (including background tasks): 21.1s
creating an audit (without background tasks): 15.8s


# Sanity checklist

- [ ] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
