### PR TITLE
GGRC-4659 Ignore all propagated roles on relevant filters 

### DIFF
--- a/src/ggrc/models/relationship_helper.py
+++ b/src/ggrc/models/relationship_helper.py
@@ -33,12 +33,14 @@ def acl_obj_id(object_type, related_type, related_ids, role=None):
     return db.session.query(models.AccessControlList.person_id).filter(
         (models.AccessControlList.object_type == related_type) &
         (models.AccessControlList.object_id.in_(related_ids)) &
+        (models.AccessControlList.parent_id.is_(None)) &
         (models.AccessControlRole.name == role if role else True)
     )
   elif related_type == "Person":
     return db.session.query(models.AccessControlList.object_id).filter(
         (models.AccessControlList.object_type == object_type) &
         (models.AccessControlList.person_id.in_(related_ids)) &
+        (models.AccessControlList.parent_id.is_(None)) &
         (models.AccessControlRole.name == role if role else True)
     )
   else:

--- a/test/integration/ggrc/services/test_query/test_relevant.py
+++ b/test/integration/ggrc/services/test_query/test_relevant.py
@@ -1,0 +1,101 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Tests for relevant operator."""
+
+import collections
+
+import ddt
+
+from ggrc.models import all_models
+
+from integration.ggrc import TestCase
+from integration.ggrc.query_helper import WithQueryApi
+from integration.ggrc.models import factories
+
+
+@ddt.ddt
+class TestRelevant(TestCase, WithQueryApi):
+  """Tests for relevant queries.
+
+  The relevant query is an extension of the related operation in the way that
+  it also includes special mappings not just the relationships table.
+  """
+
+  PEOPLE = {
+      "auditor": "auditor@example.com",
+      "program_editor": "program_editor@example.com",
+      "assignee": "assignee@example.com",
+  }
+
+  ASSESSMENT_ROLES = {
+      "assignee"
+  }
+
+  def setUp(self):
+    super(TestRelevant, self).setUp()
+    self.client.get("/login")
+    roles = collections.defaultdict(dict)
+    roles_query = all_models.AccessControlRole.query.filter(
+        all_models.AccessControlRole.object_type.in_([
+            all_models.Assessment.__name__,
+            all_models.Audit.__name__,
+            all_models.Program.__name__,
+        ])
+    )
+
+    for role in roles_query:
+      roles[role.object_type][role.name] = role
+
+    with factories.single_commit():
+      assessment = factories.AssessmentFactory()
+      factories.RelationshipFactory(
+          source=assessment.audit,
+          destination=assessment,
+      )
+      auditor = factories.PersonFactory(email=self.PEOPLE["auditor"])
+      editor = factories.PersonFactory(email=self.PEOPLE["program_editor"])
+      assignee = factories.PersonFactory(email=self.PEOPLE["assignee"])
+      # Correct roles and propagation for a given assessment
+      factories.AccessControlListFactory(
+          ac_role=roles["Assessment"]["Assignees"],
+          person=assignee,
+          object=assessment,
+      )
+      factories.AccessControlListFactory(
+          ac_role=roles["Audit"]["Auditors"],
+          person=auditor,
+          object=assessment.audit,
+      )
+      factories.AccessControlListFactory(
+          ac_role=roles["Program"]["Program Editors"],
+          person=editor,
+          object=assessment.audit.program,
+      )
+
+  @ddt.data(*PEOPLE.items())
+  @ddt.unpack
+  def test_person_relevant(self, role, email):
+    """Check that only assessment roles can see relevant assessments"""
+    person = all_models.Person.query.filter(
+        all_models.Person.email == email
+    ).one()
+
+    ids = self._get_first_result_set(
+        {
+            "object_name": "Assessment",
+            "type": "ids",
+            "filters": {
+                "expression": {
+                    "object_name": "Person",
+                    "op": {"name": "relevant"},
+                    "ids": [person.id]
+                }
+            }
+        },
+        "Assessment", "ids"
+    )
+    if role in self.ASSESSMENT_ROLES:
+      self.assertEqual(len(ids), 1)
+    else:
+      self.assertEqual(len(ids), 0)


### PR DESCRIPTION
## Cherry pick from https://github.com/google/ggrc-core/pull/7450

# Issue description

The propagated roles are only used to determine if a user has access to
a given object or not. They are not user visible roles and should not be
used in any user visible filter. The check for parent_id ensures that
only base roles are used by the query.

# Issue description

Any person with a propagated role to the assessment will see that assessment on their "my assessments" page.

# Steps to test the changes

> Steps to reproduce,
>  * Be one of the following roles:
>  ** Audit captain
>  ** Auditor
>  ** Program Editor
>  ** Program Reader
>  ** Program Admin
>  * inside the audit, create an assessment, but make sure you have no role on that assessment
>  * Go to my assessments page
> 
> Expected: You should not be able to find that asssesssment there
> 
> Actual: Person is able to see an assessment there even when they have no actual role on the assessment.
> 
>  
> Note: This affects the entire app. not just my assessments page! whenever we have a relevant filter for people. So also check mapping modal and export page for any possible bugs.

# Solution description

The propagated roles are only used to determine if a user has access to
a given object or not. They are not user visible roles and should not be
used in any user visible filter. The check for parent_id ensures that
only base roles are used by the query.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
