### PR TITLE
GGRC-4596 Cut off long GCA titles in modals

### DIFF
--- a/src/ggrc-client/styles/components/form/_ggrc-form.scss
+++ b/src/ggrc-client/styles/components/form/_ggrc-form.scss
@@ -113,7 +113,6 @@
 
       .ggrc-form-item__controls {
         margin-left: auto;
-        align-self: flex-end;
       }
     }
 
@@ -143,6 +142,8 @@
       font-size: 12px;
       font-weight: bold;
       margin-bottom: 5px;
+      flex: 1;
+      overflow: hidden;
     }
 
     &__label-text {
@@ -160,6 +161,7 @@
       color: gray;
       margin-bottom: 8px;
       line-height: 10px;
+      word-wrap: break-word;
     }
 
     /*


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Long title of GCA is not cut off in Assessment modal window

# Steps to test the changes

2. Open Custom Attributes tab and add GCA with 'text' type with long title to Assessment
3. Open any Audit page
4. Invoke New Assessment modal window

**Actual Result:** Long title of GCA is not cut off in Assessment modal window
**Expected Result:** Long title of GCA should be cut off in Assessment modal window

# Solution description

Fix css styles

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [ ] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
