### PR TITLE
GGRC-4686 Reduce the amount of rows retrieved by the acl query

### DIFF
--- a/src/ggrc_basic_permissions/__init__.py
+++ b/src/ggrc_basic_permissions/__init__.py
@@ -323,7 +323,7 @@ def load_access_control_list(user, permissions):
   ).group_by(
       all_models.AccessControlList.object_id,
       all_models.AccessControlList.object_type
-  ).all()
+  )
 
   for object_type, object_id, read, update, delete in access_control_list:
     actions = (("read", read), ("view_object_page", read),


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Fetching all ACL records from the database so that we can perform permission checks on the BE and FE is very slow. We will be removing this query here: https://github.com/google/ggrc-core/pull/7398, but this won't make it into 1.6.1 and perhaps also not into 1.7.0 (depending how busy I am with other things). So until we remove this query altogether we can at least make it slightly faster.

# Steps to test the changes

Make sure permissions still work correctly.

# Solution description

Instead of returning all the acl rows we group them together by
object_id and object_type. This puts additional load on the mysql server
but drastically reduces the amount of data transfared and the amount of
data python needs to crunch through.

This reduces the amount of rows for my user on ggrc-qa from ~70k to ~20k and reduces the time by a few seconds.
 
Before:
![screen shot 2018-03-14 at 19 32 26](https://user-images.githubusercontent.com/513444/37428203-63988a2c-27c3-11e8-9e80-ae6209b835e4.png)
After:
![screen shot 2018-03-14 at 19 30 27](https://user-images.githubusercontent.com/513444/37428199-61089e00-27c3-11e8-83c7-2455f23c2fea.png) 

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
