### PR TITLE
GGRC-4697 Add default value for each custom attribute definition

### DIFF
--- a/src/ggrc/models/custom_attribute_definition.py
+++ b/src/ggrc/models/custom_attribute_definition.py
@@ -11,6 +11,7 @@ from sqlalchemy.sql.schema import UniqueConstraint
 
 from ggrc import db
 from ggrc.models.mixins import attributevalidator
+from ggrc import builder
 from ggrc.models import mixins
 from ggrc.models.custom_attribute_value import CustomAttributeValue
 from ggrc.access_control import role as acr
@@ -60,7 +61,7 @@ class CustomAttributeDefinition(attributevalidator.AttributeValidator,
   def value_mapping(self):
     return self.ValidTypes.DEFAULT_VALUE_MAPPING.get(self.attribute_type) or {}
 
-  @property
+  @builder.simple_property
   def default_value(self):
     return self.ValidTypes.DEFAULT_VALUE.get(self.attribute_type)
 
@@ -92,7 +93,12 @@ class CustomAttributeDefinition(attributevalidator.AttributeValidator,
       'placeholder',
   ]
 
-  _api_attrs = reflection.ApiAttributes(*_include_links)
+  _api_attrs = reflection.ApiAttributes(
+      reflection.Attribute("default_value",
+                           read=True,
+                           create=False,
+                           update=False),
+      *_include_links)
 
   _sanitize_html = [
       "multi_choice_options",

--- a/src/ggrc/models/custom_attribute_definition.py
+++ b/src/ggrc/models/custom_attribute_definition.py
@@ -61,9 +61,13 @@ class CustomAttributeDefinition(attributevalidator.AttributeValidator,
   def value_mapping(self):
     return self.ValidTypes.DEFAULT_VALUE_MAPPING.get(self.attribute_type) or {}
 
+  @classmethod
+  def get_default_value_for(cls, attribute_type):
+    return cls.ValidTypes.DEFAULT_VALUE.get(attribute_type)
+
   @builder.simple_property
   def default_value(self):
-    return self.ValidTypes.DEFAULT_VALUE.get(self.attribute_type)
+    return self.get_default_value_for(self.attribute_type)
 
   def get_indexed_value(self, value):
     return self.value_mapping.get(value, value)

--- a/src/ggrc/models/custom_attribute_definition.py
+++ b/src/ggrc/models/custom_attribute_definition.py
@@ -299,6 +299,12 @@ class CustomAttributeDefinition(attributevalidator.AttributeValidator,
 
     return value
 
+  def log_json(self):
+    """Add extra fields to be logged in CADs."""
+    results = super(CustomAttributeDefinition, self).log_json()
+    results["default_value"] = self.default_value
+    return results
+
 
 class CustomAttributeMapable(object):
   # pylint: disable=too-few-public-methods

--- a/src/ggrc/models/revision.py
+++ b/src/ggrc/models/revision.py
@@ -332,6 +332,22 @@ class Revision(Base, db.Model):
       return {}
     return {"custom_attribute_values": self._content["custom_attributes"]}
 
+  def populate_cad_default_values(self):
+    """Setup default_value to CADs if it's needed."""
+    from ggrc.models import all_models
+    if "custom_attribute_definitions" not in self._content:
+      return {}
+    cads = []
+    for cad in self._content["custom_attribute_definitions"]:
+      if "default_value" not in cad:
+        cad["default_value"] = (
+            all_models.CustomAttributeDefinition.get_default_value_for(
+                cad["attribute_type"]
+            )
+        )
+      cads.append(cad)
+    return {"custom_attribute_definitions": cads}
+
   @builder.simple_property
   def content(self):
     """Property. Contains the revision content dict.
@@ -348,6 +364,7 @@ class Revision(Base, db.Model):
     populated_content.update(self.populate_categoies("categories"))
     populated_content.update(self.populate_categoies("assertions"))
     populated_content.update(self.populate_cavs())
+    populated_content.update(self.populate_cad_default_values())
     return populated_content
 
   @content.setter

--- a/src/ggrc/utils/revisions_diff/builder.py
+++ b/src/ggrc/utils/revisions_diff/builder.py
@@ -145,7 +145,9 @@ def get_validated_value(cad, value, object_id):
     return value, object_id
   if cad.attribute_type == cad.ValidTypes.CHECKBOX:
     value = int(value)
-  return unicode(value), object_id
+  if value is not None:
+    value = unicode(value)
+  return value, object_id
 
 
 def generate_cav_diff(instance, proposed, revisioned):


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Add default_value to CADs api 

# Steps to test the changes

raw api calls to BE and check info about default_value for CADs

# Solution description

1) send default_value to FE
2) log it in revisions
3) populate it for older revisions

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
