### PR TITLE
GGRC-3875 Deny possibility to move archived assessment to Deprecated or Not Started state

### DIFF
--- a/src/ggrc-client/js/components/assessment/info-pane/info-pane.js
+++ b/src/ggrc-client/js/components/assessment/info-pane/info-pane.js
@@ -193,6 +193,7 @@ import {CUSTOM_ATTRIBUTE_TYPE} from '../../../plugins/utils/custom-attribute/cus
       formState: {},
       noItemsText: '',
       initialState: 'Not Started',
+      deprecatedState: 'Deprecated',
       assessmentMainRoles: ['Creators', 'Assignees', 'Verifiers'],
       setUrlEditMode: function (value, type) {
         this.attr(type + 'EditMode', value);
@@ -428,6 +429,9 @@ import {CUSTOM_ATTRIBUTE_TYPE} from '../../../plugins/utils/custom-attribute/cus
         let isUndo = event.undo;
         let newStatus = event.state;
         let instance = this.attr('instance');
+        let initialState = this.attr('initialState');
+        let deprecatedState = this.attr('deprecatedState');
+        let isArchived = instance.attr('archived');
         let previousStatus = instance.attr('previousStatus') || 'In Progress';
         let stopFn = tracker.start(instance.type,
           tracker.USER_JOURNEY_KEYS.NAVIGATION,
@@ -437,6 +441,10 @@ import {CUSTOM_ATTRIBUTE_TYPE} from '../../../plugins/utils/custom-attribute/cus
             instance.attr('status', xhr.remoteObject.status);
           }
         };
+
+        if (isArchived && [initialState, deprecatedState].includes(newStatus)) {
+          return can.Deferred().resolve();
+        }
 
         this.attr('onStateChangeDfd', can.Deferred());
 

--- a/src/ggrc-client/js/components/assessment/info-pane/tests/info-pane_spec.js
+++ b/src/ggrc-client/js/components/assessment/info-pane/tests/info-pane_spec.js
@@ -53,6 +53,30 @@ describe('GGRC.Components.assessmentInfoPane', function () {
       spyOn(vm, 'initializeFormFields').and.returnValue(() => {});
     });
 
+    it('prevents state change to deprecated for archived instance', (done) => {
+      vm.attr('instance.archived', true);
+      vm.attr('instance.status', 'Completed');
+
+      method({
+        state: vm.attr('deprecatedState'),
+      }).then(() => {
+        expect(vm.attr('instance.status')).toBe('Completed');
+        done();
+      });
+    });
+
+    it('prevents state change to initial for archived instance', (done) => {
+      vm.attr('instance.archived', true);
+      vm.attr('instance.status', 'Completed');
+
+      method({
+        state: vm.attr('initialState'),
+      }).then(() => {
+        expect(vm.attr('instance.status')).toBe('Completed');
+        done();
+      });
+    });
+
     it('returns status back on undo action', (done) => {
       vm.attr('instance.previousStatus', 'FooBar');
       instanceSave.resolve();

--- a/src/ggrc/assets/mustache/assessments/header.mustache
+++ b/src/ggrc/assets/mustache/assessments/header.mustache
@@ -124,39 +124,41 @@ Copyright (C) 2018 Google Inc.
                     {{/if_in}}
 
                     {{#is_allowed 'update' instance context='for'}}
-                    <li>
-                      {{^if_equals instance.status 'Rework Needed'}}
-                        {{#if_equals instance.status 'Deprecated'}}
-                          {{! Set default state }}
-                          <object-change-state
-                            {to-state}="initialState"
-                            (on-state-change)="onStateChange(%event)"
-                          >
-                            <a href="#">
-                              <i class="fa fa-reply"></i> Restore
-                            </a>
-                          </object-change-state>
-                        {{else}}
-                          <object-change-state
-                            to-state="Deprecated"
-                            (on-state-change)="onStateChange(%event)"
-                          >
-                            <a href="#">
-                              <i class="fa fa-times-circle"></i> Deprecate
-                            </a>
-                          </object-change-state>
-                        {{/if_equals}}
-                      {{else}}
-                        <object-change-state
-                          to-state="Deprecated"
-                          (on-state-change)="onStateChange(%event)"
-                        >
-                          <a href="#">
-                            <i class="fa fa-times-circle"></i> Deprecate
-                          </a>
-                        </object-change-state>
-                      {{/if_equals}}
-                    </li>
+                        {{^if instance.archived}}
+                            <li>
+                                {{^if_equals instance.status 'Rework Needed'}}
+                                    {{#if_equals instance.status 'Deprecated'}}
+                                        {{! Set default state }}
+                                        <object-change-state
+                                            {to-state}="initialState"
+                                            (on-state-change)="onStateChange(%event)"
+                                        >
+                                            <a href="#">
+                                                <i class="fa fa-reply"></i> Restore
+                                            </a>
+                                        </object-change-state>
+                                    {{else}}
+                                        <object-change-state
+                                            {to-state}="deprecatedState"
+                                            (on-state-change)="onStateChange(%event)"
+                                        >
+                                            <a href="#">
+                                                <i class="fa fa-times-circle"></i> Deprecate
+                                            </a>
+                                        </object-change-state>
+                                    {{/if_equals}}
+                                {{else}}
+                                    <object-change-state
+                                        {to-state}="deprecatedState"
+                                        (on-state-change)="onStateChange(%event)"
+                                    >
+                                        <a href="#">
+                                            <i class="fa fa-times-circle"></i> Deprecate
+                                        </a>
+                                    </object-change-state>
+                                {{/if_equals}}
+                            </li>
+                        {{/if}}
                     {{/is_allowed}}
 
                     {{#is_allowed 'delete' instance}}


### PR DESCRIPTION
# Issue description

Currently it's possible to move an archived assessment to:
1. Deprecated state
2. Not Started state if the assessment was deprecated before making it archived (I found this issue during the testing of the case with deprecated state. The details about this issue were shared with @AlexNo and I've got confirmation from Alex to add the fix for this case into this pull request)

# Steps to test the changes

Case with Deprecated state:

1. Have an audit with created Assessment
2. Audit and Assessment are archived
3. Navigate to Assessment Info pane and move it to Deprecated state

Actual Result: User is able to move assessment to Deprecated state if Assessment is archived
Expected Result: User should not be able to move assessment to Deprecated state if Assessment is archived

Case with Not Started state:

1. Have an audit with created Assessment
2. Move Assessment to Deprecated state
3. Audit and Assessment are archived
4. Navigate to Assessment Info pane and move it to Not Started state by clicking on Restore

Actual Result: User is able to move assessment to Not Started state if deprecated Assessment is archived
Expected Result: User should not be able to move assessment to Not Started state if deprecated Assessment is archived

# Solution description

Basically the solution is to deny possibility to move archived assessment to Deprecated or Not started state in onStateChange method and hide Deprecate and Restore buttons.

Technical note: indents in src/ggrc/assets/mustache/assessments/header.mustache are changed from 2 spaces to 4 spaces to be consistent with the rest of this file where 4 spaces are used for indents.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".