### PR TITLE
GGRC-4705 Fix computed attributes

### DIFF
--- a/src/ggrc/data_platform/computed_attributes.py
+++ b/src/ggrc/data_platform/computed_attributes.py
@@ -146,15 +146,6 @@ def get_aggregate_function(attribute):
   raise AttributeError("Attribute aggregate_function contains invalid data.")
 
 
-def snapshot_from_rel(rel_revision):
-  """Get snapshot objects from relationship revisions."""
-  if rel_revision.source_type == "Snapshot":
-    return models.Snapshot.query.get(rel_revision.source_id)
-  elif rel_revision.destination_type == "Snapshot":
-    return models.Snapshot.query.get(rel_revision.destination_id)
-  return None
-
-
 def _get_group_key(revision, aggregate_type, computed_object):
   """Get key for aggregate objects group.
 
@@ -162,7 +153,6 @@ def _get_group_key(revision, aggregate_type, computed_object):
   calculation of computed attributes.
   """
   related_types = {computed_object, aggregate_type}
-  related_snapshots = {"Snapshot", aggregate_type}
   key = None
   if revision.resource_type == aggregate_type:
     if revision.action == "deleted":
@@ -181,13 +171,6 @@ def _get_group_key(revision, aggregate_type, computed_object):
         revision.source_type in related_types and
         revision.destination_type in related_types):
     key = "related_objects"
-  elif (revision.resource_type == "Relationship" and
-        revision.source_type in related_snapshots and
-        revision.destination_type in related_snapshots):
-    # computed source related to a snapshot of an object
-    snapshot = snapshot_from_rel(revision)
-    if snapshot and snapshot.child_type == computed_object:
-      key = "related_snapshots"
   return key
 
 


### PR DESCRIPTION
# Issue description

> When generate assessment error message appears and page is reloading.
> New assessment appears in a corresponding tab, but log contains the following error.
> 
> ERROR    2018-03-16 13:54:15,354 ggrc.models.background_task Task failed
> Traceback (most recent call last):
>   File "/vagrant/src/ggrc/models/background_task.py", line 151, in decorated_view
>     result = func(task)
>   File "/vagrant/src/ggrc/views/__init__.py", line 95, in compute_attributes
>     computed_attributes.compute_attributes(revision_ids)
>   File "/vagrant/src/ggrc/data_platform/computed_attributes.py", line 674, in compute_attributes
>     attribute_groups = group_revisions(attributes, revisions)
>   File "/vagrant/src/ggrc/data_platform/computed_attributes.py", line 201, in group_revisions
>     key = _get_group_key(revision, aggregate_type, computed_object)
>   File "/vagrant/src/ggrc/data_platform/computed_attributes.py", line 188, in _get_group_key
>     snapshot = snapshot_from_rel(revision)
>   File "/vagrant/src/ggrc/data_platform/computed_attributes.py", line 154, in snapshot_from_rel
>     return models.Snapshot.query.get(rel_revision.destination_id)
> AttributeError: 'KeyedTuple' object has no attribute 'destination_id'
> Reproduced locally - Version 1.7.0-Strawberry (57f3e92)



# Steps to test the changes

Generate an assessment and check the log output.
Also make sure that last assessment date still works in normal cases.

# Solution description

It appears that we do not need to compute new attribute values on
mapping a snapshot of a control to an assessment. This is because
mapping to an assessment will move the assessment to "In Progress" state
which is ignored when computing the last assessment date. The only place
where a mapping can be done to a finished assessment is on import, but
that already creates a new revision and handles the assignment
correctly.

The original solution was:
```diff
diff --git a/src/ggrc/data_platform/computed_attributes.py  b/src/ggrc/data_platform/computed_attributes.py
index 2ced33763a..7bb81f26a8 100644
--- a/src/ggrc/data_platform/computed_attributes.py
+++ b/src/ggrc/data_platform/computed_attributes.py
@@ -629,7 +629,9 @@ def get_revisions(revision_ids):
       models.Revision.resource_type,
       models.Revision.resource_id,
       models.Revision.source_type,
+      models.Revision.source_id,
       models.Revision.destination_type,
+      models.Revision.destination_id,
   ).filter(
       models.Revision.resource_type != "Snapshot",
       models.Revision.id.in_(revision_ids)
```

Which also fixes the issue but further investigation proved that the
code with the bug was dead code and not used in later parts of the
calculation. Given all this, it should be safe to remove the buggy code
without doing fixes for using the relationships to snapshots.

The extra benefit of the current solution is also slight performance
gain on generating assessments.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
