### PR TITLE
GGRC-4094 Sorting of labels for Assessment

### DIFF
--- a/src/ggrc-client/js/components/multi-select-label/multi-select-label.js
+++ b/src/ggrc-client/js/components/multi-select-label/multi-select-label.js
@@ -57,6 +57,7 @@ export default can.Component.extend({
       return '';
     },
     valueChanged: function (newValue) {
+      newValue = _.sortByOrder(newValue, (label) => label.name.toLowerCase());
       if (this.attr('onlyEditMode')) {
         this.attr('instance.labels', newValue);
       } else {

--- a/src/ggrc-client/js/components/multi-select-label/multi-select-label.js
+++ b/src/ggrc-client/js/components/multi-select-label/multi-select-label.js
@@ -3,6 +3,7 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 */
 
+import {sortByName} from '../../plugins/utils/label-utils';
 import template from './templates/multi-select-label.mustache';
 import './../custom-autocomplete/autocomplete-input';
 import './label-autocomplete-results';
@@ -57,7 +58,7 @@ export default can.Component.extend({
       return '';
     },
     valueChanged: function (newValue) {
-      newValue = _.sortByOrder(newValue, (label) => label.name.toLowerCase());
+      newValue = sortByName(newValue);
       if (this.attr('onlyEditMode')) {
         this.attr('instance.labels', newValue);
       } else {

--- a/src/ggrc-client/js/components/multi-select-label/multi-select-label_spec.js
+++ b/src/ggrc-client/js/components/multi-select-label/multi-select-label_spec.js
@@ -3,6 +3,7 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 */
 
+import * as LabelUtils from '../../plugins/utils/label-utils';
 import {getComponentVM} from '../../../js_specs/spec_helpers';
 import Component from './multi-select-label';
 
@@ -108,30 +109,23 @@ describe('multi-select-label component', () => {
       expect(vm.attr('instance.labels').length).toBe(labels.length);
     });
 
-    it('should sort and set newValue to instance.', () => {
+    it('should call "sortByName" method from label-utils.', () => {
       vm.attr('onlyEditMode', true);
       vm.attr('instance.labels', 'oldValue');
+      spyOn(LabelUtils, 'sortByName').and.returnValue(labels);
       vm.valueChanged(labels);
-
-      let instanceLabels = vm.attr('instance.labels');
-      expect(instanceLabels.length).toBe(labels.length);
-      expect(instanceLabels[0].name).toEqual('a');
-      expect(instanceLabels[1].name).toEqual('b');
-      expect(instanceLabels[2].name).toEqual('c');
+      expect(LabelUtils.sortByName).toHaveBeenCalledWith(labels);
     });
 
     it('dispatches valueChanged event if it is not only edit mode', () => {
       spyOn(vm, 'dispatch');
+      spyOn(LabelUtils, 'sortByName').and.returnValue(labels);
       vm.attr('onlyEditMode', false);
       vm.valueChanged(labels);
 
       expect(vm.dispatch).toHaveBeenCalledWith({
         type: 'valueChanged',
-        value: [
-          {name: 'a'},
-          {name: 'b'},
-          {name: 'c'},
-        ],
+        value: labels,
       });
     });
   });

--- a/src/ggrc-client/js/components/multi-select-label/multi-select-label_spec.js
+++ b/src/ggrc-client/js/components/multi-select-label/multi-select-label_spec.js
@@ -91,21 +91,47 @@ describe('multi-select-label component', () => {
   });
 
   describe('valueChanged() method', () => {
+    let labels;
+
+    beforeAll(() => {
+      labels = [
+        {name: 'b'},
+        {name: 'a'},
+        {name: 'c'},
+      ];
+    });
+
     it('sets newValue to instance.labels if it is only edit mode', () => {
       vm.attr('onlyEditMode', true);
       vm.attr('instance.labels', 'oldValue');
-      vm.valueChanged('newValue');
-      expect(vm.attr('instance.labels')).toEqual('newValue');
+      vm.valueChanged(labels);
+      expect(vm.attr('instance.labels').length).toBe(labels.length);
+    });
+
+    it('should sort and set newValue to instance.', () => {
+      vm.attr('onlyEditMode', true);
+      vm.attr('instance.labels', 'oldValue');
+      vm.valueChanged(labels);
+
+      let instanceLabels = vm.attr('instance.labels');
+      expect(instanceLabels.length).toBe(labels.length);
+      expect(instanceLabels[0].name).toEqual('a');
+      expect(instanceLabels[1].name).toEqual('b');
+      expect(instanceLabels[2].name).toEqual('c');
     });
 
     it('dispatches valueChanged event if it is not only edit mode', () => {
       spyOn(vm, 'dispatch');
       vm.attr('onlyEditMode', false);
-      vm.valueChanged('newValue');
+      vm.valueChanged(labels);
 
       expect(vm.dispatch).toHaveBeenCalledWith({
         type: 'valueChanged',
-        value: 'newValue',
+        value: [
+          {name: 'a'},
+          {name: 'b'},
+          {name: 'c'},
+        ],
       });
     });
   });

--- a/src/ggrc-client/js/models/assessment.js
+++ b/src/ggrc-client/js/models/assessment.js
@@ -185,6 +185,13 @@ import {getRole} from '../plugins/utils/acl-utils';
         return attributes;
       }
 
+      if (attributes.labels && attributes.labels.length) {
+        attributes.labels = _.sortByOrder(
+          attributes.labels,
+          (label) => label.name.toLowerCase()
+        );
+      }
+
       attributes.custom_attribute_values =
         prepareCustomAttributes(definitions, values);
       return attributes;

--- a/src/ggrc-client/js/models/assessment.js
+++ b/src/ggrc-client/js/models/assessment.js
@@ -5,6 +5,7 @@
 
 import {prepareCustomAttributes} from '../plugins/utils/ca-utils';
 import {getRole} from '../plugins/utils/acl-utils';
+import {sortByName} from '../plugins/utils/label-utils';
 
 (function (can, GGRC, CMS) {
   'use strict';
@@ -186,10 +187,7 @@ import {getRole} from '../plugins/utils/acl-utils';
       }
 
       if (attributes.labels && attributes.labels.length) {
-        attributes.labels = _.sortByOrder(
-          attributes.labels,
-          (label) => label.name.toLowerCase()
-        );
+        attributes.labels = sortByName(attributes.labels);
       }
 
       attributes.custom_attribute_values =

--- a/src/ggrc-client/js/plugins/tests/label-utils_spec.js
+++ b/src/ggrc-client/js/plugins/tests/label-utils_spec.js
@@ -1,0 +1,49 @@
+/*
+  Copyright (C) 2018 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+import {sortByName} from '../utils/label-utils';
+
+describe('Label utils sortByName() method', () => {
+  let labels;
+
+  beforeAll(() => {
+    labels = [
+      {id: 8, name: 'gg'},
+      {id: 1, name: 'gl'},
+      {id: 2, name: 'GJ'},
+      {id: 9, name: 'dev'},
+      {id: 3, name: 'ux'},
+    ];
+  });
+
+  it('should return the same number of labels', () => {
+    const sortedLabels = sortByName(labels);
+    expect(sortedLabels.length).toBe(labels.length);
+  });
+
+  it('labels should be sorted by name', () => {
+    const sortedLabels = sortByName(labels);
+    expect(sortedLabels[0].name).toEqual('dev');
+    expect(sortedLabels[1].name).toEqual('gg');
+    expect(sortedLabels[2].name).toEqual('GJ');
+    expect(sortedLabels[3].name).toEqual('gl');
+    expect(sortedLabels[4].name).toEqual('ux');
+  });
+
+  it('should correct sort labels without names', () => {
+    let labels = [
+      {id: 8, name: ''},
+      {id: 1, name: 'gl'},
+      {id: 2},
+      {id: 3, name: 'ux'},
+    ];
+
+    const sortedLabels = sortByName(labels);
+    expect(sortedLabels[0].id).toBe(8);
+    expect(sortedLabels[1].id).toBe(1);
+    expect(sortedLabels[2].id).toBe(3);
+    expect(sortedLabels[3].id).toBe(2);
+  });
+});

--- a/src/ggrc-client/js/plugins/utils/label-utils.js
+++ b/src/ggrc-client/js/plugins/utils/label-utils.js
@@ -1,0 +1,21 @@
+/*
+  Copyright (C) 2018 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+const sortByName = (labels) => {
+  const sortedLabels = _.sortByOrder(
+    labels,
+    (label) => {
+      return label.name && label.name.toLowerCase ?
+        label.name.toLowerCase() :
+        label.name;
+    }
+  );
+
+  return sortedLabels;
+};
+
+export {
+  sortByName,
+};


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

do we have requirements about sorting of labels?
Default sorting of labels right now - by id (created date)
Because currently we have a bit strange behaviour after adding the label from suggestions list.

Open Assessment info pane that have a couple of labels
Remove 1st and 2nd labels and add them again (labels showing in end of the list)
Close and open info pane one more time
Labels are sorted by default
the simplest way will be sort labels by `created_at` field immediately after adding. It won't confuse the users, when sorting was changed after they added some labels(new labels in end of the list) and opened Assessment again(labels sorted by created_at field).

# Steps to test the changes

Open any Assessment

# Solution description

1. Sort labels ascendingly by alphabet.
2. Apply sorting right away on saving.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
