### PR TITLE
GGRC-4713 Fix accidental Audit deletion on Program PUT

### DIFF
--- a/src/ggrc/models/program.py
+++ b/src/ggrc/models/program.py
@@ -36,7 +36,10 @@ class Program(HasObjectState,
   audits = db.relationship(
       'Audit', backref='program', cascade='all, delete-orphan')
 
-  _api_attrs = reflection.ApiAttributes('kind', 'audits')
+  _api_attrs = reflection.ApiAttributes(
+      'kind',
+      reflection.Attribute('audits', create=False, update=False),
+  )
   _include_links = []
   _aliases = {
       "document_url": None,

--- a/test/integration/ggrc/models/test_program.py
+++ b/test/integration/ggrc/models/test_program.py
@@ -1,0 +1,29 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Integration tests for Program."""
+
+from ggrc.models import all_models
+
+from integration.ggrc import api_helper
+from integration.ggrc.models import factories
+from integration.ggrc import TestCase
+
+
+class TestProgram(TestCase):
+  """Program test cases."""
+
+  def setUp(self):
+    self.api = api_helper.Api()
+
+    with factories.single_commit():
+      self.program = factories.ProgramFactory()
+      self.audit_id = factories.AuditFactory(program=self.program).id
+
+  def test_put_empty_audits(self):
+    """Audit doesn't get deleted when empty audits field is put."""
+    response = self.api.put(self.program, data={"audits": []})
+
+    self.assert200(response)
+    audit = self.refresh_object(all_models.Audit, id_=self.audit_id)
+    self.assertIsNotNone(audit)


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

When the UI PUTs a Program that has Audits with empty `audits` field, all Audits in it get removed.

# Steps to test the changes

1. Create a Program, open it in Tab#1.
2. Open the same Program in Tab#2.
3. Create an Audit, open it in Tab#3.
4. In Tab#1, update any ACL field on the Program.
5. Refresh Tab#3.

Expected result: the Audit is there.
Actual result: the Audit is removed, 404 is returned.

# Solution description

`audits` field is read-only now. It will be removed altogether in a later release.

# Sanity checklist

- [ ] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
