### PR TITLE
QUICK-FIX Add extra logging on API exceptions

### DIFF
--- a/src/ggrc/models/exceptions.py
+++ b/src/ggrc/models/exceptions.py
@@ -31,7 +31,7 @@ def translate_message(exception):
 
   if isinstance(exception, IntegrityError):
     # TODO: Handle not null, foreign key, uniqueness errors with compound keys
-    code, exc_message = exception.orig.args
+    code, _ = exception.orig.args
     if code == 1062:  # duplicate entry ... for key ...
       pattern = re.compile(r"Duplicate entry ('.*') for key '(.*)'")
       matches = pattern.search(message)
@@ -48,10 +48,10 @@ def translate_message(exception):
       )
       matches = pattern.search(message)
       if matches:
-        from_, to = matches.groups()
+        from_, to_ = matches.groups()
         return (u"This request will break a mandatory relationship "
-                u"from {from_} to {to}."
-                .format(from_=from_, to=to))
+                u"from {from_} to {to_}."
+                .format(from_=from_, to_=to_))
 
   return message
 

--- a/src/ggrc/models/exceptions.py
+++ b/src/ggrc/models/exceptions.py
@@ -4,7 +4,11 @@
 """Model-related exceptions and related logic."""
 
 import re
+from logging import getLogger
+
 from sqlalchemy.exc import IntegrityError
+
+logger = getLogger(__name__)
 
 
 def field_lookup(field_string):
@@ -32,6 +36,7 @@ def translate_message(exception):
       pattern = re.compile(r"Duplicate entry ('.*') for key '(.*)'")
       matches = pattern.search(message)
       if matches:
+        logger.exception(exception)
         return (u"The value {value} is already used for another {key}. "
                 u"{key} values must be unique."
                 .format(value=matches.group(1),


### PR DESCRIPTION
The translate message just strips out parts of the message so that it
can be displayed on the front-end, but the exception itself is not shown
anywhere. This change makes it a lot easier for developers to track down
errors cause the request to fail.

Additionally, without this our logs would not log any errors, just
warnings when an API request fails due to duplicate key.

<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

The translate message just strips out parts of the message so that it
can be displayed on the front-end, but the exception itself is not shown
anywhere. This change makes it a lot easier for developers to track down
errors cause the request to fail.

Additionally, without this our logs would not log any errors, just
warnings when an API request fails due to duplicate key.

# Steps to test the changes

- use ggrc-qa database from ggrc_qa_db-backup-2018-02-23.sql,
- goto to audit with id 5,
- clone audit
- Compare log output, 
Before: incorrect filed with duplicate id is displayed in the logs.
After: Correct message is show to the dev with entire stack trace.

# Solution description

Add extra logging before the log message is modified.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
