### PR TITLE
GGRC-4197 Fix state color indication

### DIFF
--- a/src/ggrc-client/js/components/related-objects/templates/related-assessments.mustache
+++ b/src/ggrc-client/js/components/related-objects/templates/related-assessments.mustache
@@ -59,7 +59,7 @@
             <a href="{{instance.viewLink}}" class="grid-data-item__title-cell" target="_blank" title="{{instance.title}}">{{instance.title}}</a>
           </div>
           <div class="grid-data-item-index">
-            <state-colors-map {state}="instance.status"></state-colors-map>
+            <state-colors-map {state}="instance.status" {verified}="instance.verified"></state-colors-map>
           </div>
           <div class="grid-data-item-index">
             {{localize_date instance.finished_date}}

--- a/src/ggrc-client/js/components/state-colors-map/state-colors-map.js
+++ b/src/ggrc-client/js/components/state-colors-map/state-colors-map.js
@@ -7,7 +7,10 @@
   'use strict';
   /* Default Sate for Assessment should be 'Not Started' */
   let defaultState = 'Not Started';
-  let tpl = '<span class="state-value-dot state-{{suffix}}">{{state}}</span>';
+  let tpl =
+    `<span class="state-value-dot state-{{suffix}} {{verified}}">
+      {{state}}
+    </span>`;
 
   /**
    * can.Map(ViewModel) presenting behavior of State Colors Map Component
@@ -23,6 +26,11 @@
         get: function () {
           let state = this.attr('state') || defaultState;
           return state.toLowerCase().replace(/[\s\t]+/g, '');
+        },
+      },
+      verified: {
+        get: function (value) {
+          return value ? 'verified' : '';
         },
       },
     },


### PR DESCRIPTION
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [x] #7919

# Issue description

"Completed and Verified" state has wrong color.

# Steps to test the changes

Have program, control, audit, at least 2 assessments generated based on the same control snapshot.

1. Move 1 assessment to "Completed and Verified" state
2. Open Assessment Info pane for the second Assessment
3. Open Related Assessment tab and look at the Completed and Verified state
Actual Result: "Completed and Verified" state isn't displayed in green color
Expected Result: "Completed and Verified" state should be displayed in green color:

# Solution description

I've added 'verified' to classes in case if it has "verified date" to set correct color.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
