### PR TITLE
GGRC-4660 Remove redundant requests on editing a cycle task

### DIFF
--- a/src/ggrc-client/js/components/cycle-task-actions/cycle-task-actions.js
+++ b/src/ggrc-client/js/components/cycle-task-actions/cycle-task-actions.js
@@ -8,6 +8,7 @@ import {
   getPageType,
 } from '../../plugins/utils/current-page-utils';
 import template from './cycle-task-actions.mustache';
+import WorkflowHelpers from '../workflow/workflow-helpers';
 
 (function (can, GGRC) {
   'use strict';
@@ -70,23 +71,16 @@ import template from './cycle-task-actions.mustache';
 
       this.setStatus(newValue.status);
     },
-    setStatus: function (status) {
-      let instance = this.attr('instance');
+    async setStatus(status) {
+      const instance = this.attr('instance');
       const stopFn = tracker.start(
         instance.type,
         tracker.USER_JOURNEY_KEYS.LOADING,
         tracker.USER_ACTIONS.CYCLE_TASK.CHANGE_STATUS);
-
       this.attr('disabled', true);
-      return instance.refresh()
-        .then((refreshed) =>{
-          refreshed.attr('status', status);
-          return refreshed.save();
-        })
-        .then(() => {
-          this.attr('disabled', false);
-          stopFn();
-        });
+      await WorkflowHelpers.updateStatus(instance, status);
+      this.attr('disabled', false);
+      stopFn();
     },
   });
 

--- a/src/ggrc-client/js/components/tests/cycle-task-actions_spec.js
+++ b/src/ggrc-client/js/components/tests/cycle-task-actions_spec.js
@@ -4,6 +4,7 @@
  */
 
 import tracker from '../../tracker';
+import WorkflowHelpers from '../workflow/workflow-helpers';
 
 describe('GGRC.Components.subTreeWrapper', function () {
   'use strict';
@@ -79,6 +80,34 @@ describe('GGRC.Components.subTreeWrapper', function () {
       undo(null, null, fakeEvent);
 
       expect(vm.setStatus).toHaveBeenCalledWith('test');
+    });
+  });
+
+  describe('setStatus() method', () => {
+    beforeEach(function () {
+      vm.attr('instance', {});
+      spyOn(WorkflowHelpers, 'updateStatus');
+    });
+
+    it('disables component before status updating', function () {
+      vm.setStatus(status);
+      expect(vm.attr('disabled')).toBe(true);
+    });
+
+    it('enables component after status updating', async function (done) {
+      await vm.setStatus(status);
+      expect(vm.attr('disabled')).toBe(false);
+      done();
+    });
+
+    it('updates status for cycle task', async function (done) {
+      const status = 'New State';
+      await vm.setStatus(status);
+      expect(WorkflowHelpers.updateStatus).toHaveBeenCalledWith(
+        vm.attr('instance'),
+        status
+      );
+      done();
     });
   });
 });

--- a/src/ggrc-client/js/components/tree/sub-tree-item.js
+++ b/src/ggrc-client/js/components/tree/sub-tree-item.js
@@ -51,10 +51,14 @@ import template from './templates/sub-tree-item.mustache';
       },
       title: {
         type: String,
-        get: function () {
-          let instance = this.attr('instance');
-          return instance.title || instance.description_inline ||
-            instance.name || instance.email || '';
+        get() {
+          const instance = this.attr('instance');
+          return (
+            instance.attr('title') ||
+            instance.attr('description_inline') ||
+            instance.attr('name') ||
+            instance.attr('email') || ''
+          );
         },
       },
     },

--- a/src/ggrc-client/js/components/workflow/cycle-task-group-object-task/cycle-task-group-object-task.js
+++ b/src/ggrc-client/js/components/workflow/cycle-task-group-object-task/cycle-task-group-object-task.js
@@ -7,6 +7,7 @@ import template from './templates/cycle-task-group-object-task.mustache';
 import '../../object-change-state/object-change-state';
 import '../../dropdown/dropdown';
 import RefreshQueue from '../../../models/refresh_queue';
+import WorkflowHelpers from '../workflow-helpers';
 
 let viewModel = can.Map.extend({
   showLink: function () {
@@ -77,15 +78,10 @@ let viewModel = can.Map.extend({
     const id = instance.attr('workflow.id');
     return `/workflows/${id}`;
   },
-  onStateChange: function (event) {
-    let instance = this.attr('instance');
-    let newStatus = event.state;
-
-    instance.refresh()
-      .then(function (refreshed) {
-        refreshed.attr('status', newStatus);
-        return refreshed.save();
-      });
+  onStateChange(event) {
+    const instance = this.attr('instance');
+    const status = event.state;
+    WorkflowHelpers.updateStatus(instance, status);
   },
 });
 

--- a/src/ggrc-client/js/components/workflow/cycle-task-group-object-task/tests/cycle-task-group-object-task_spec.js
+++ b/src/ggrc-client/js/components/workflow/cycle-task-group-object-task/tests/cycle-task-group-object-task_spec.js
@@ -5,6 +5,7 @@
 
 import Component from '../cycle-task-group-object-task';
 import RefreshQueue from '../../../../models/refresh_queue';
+import WorkflowHelpers from '../../workflow-helpers';
 
 describe('GGRC.Components.cycleTaskGroupObjectTask', function () {
   let viewModel;
@@ -209,48 +210,21 @@ describe('GGRC.Components.cycleTaskGroupObjectTask', function () {
     });
 
     describe('onStateChange() method', function () {
-      let refreshDfd;
       let event;
 
       beforeEach(function () {
         event = {};
-        refreshDfd = can.Deferred();
-        viewModel.attr('instance', {
-          refresh: jasmine.createSpy('refresh').and.returnValue(refreshDfd),
-        });
+        viewModel.attr('instance', {});
+        spyOn(WorkflowHelpers, 'updateStatus');
       });
 
-      it('refreshes instance', function () {
+      it('updates status for cycle task', function () {
+        event.state = 'New State';
         viewModel.onStateChange(event);
-        expect(viewModel.attr('instance').refresh).toHaveBeenCalled();
-      });
-
-      describe('when refresh operation was resolved', function () {
-        let refreshed;
-
-        beforeEach(function () {
-          refreshed = new can.Map({
-            save: jasmine.createSpy('save'),
-          });
-          refreshDfd.resolve(refreshed);
-        });
-
-        it('sets status for refreshed instance', function (done) {
-          event.state = 'state';
-          viewModel.onStateChange(event);
-          refreshDfd.then(function () {
-            expect(refreshed.attr('status')).toBe(event.state);
-            done();
-          });
-        });
-
-        it('saves refreshed instance', function (done) {
-          viewModel.onStateChange(event);
-          refreshDfd.then(function () {
-            expect(refreshed.save).toHaveBeenCalled();
-            done();
-          });
-        });
+        expect(WorkflowHelpers.updateStatus).toHaveBeenCalledWith(
+          viewModel.attr('instance'),
+          event.state
+        );
       });
     });
 

--- a/src/ggrc-client/js/components/workflow/tests/workflow-helpers_spec.js
+++ b/src/ggrc-client/js/components/workflow/tests/workflow-helpers_spec.js
@@ -49,4 +49,45 @@ describe('Workflow helpers', () => {
       });
     });
   });
+
+  describe('updateStatus() method', () => {
+    let instance;
+    let refreshedInstance;
+
+    beforeEach(function () {
+      refreshedInstance = new can.Map({
+        save: jasmine.createSpy('save'),
+      });
+      instance = new can.Map({
+        refresh: jasmine.createSpy('refresh')
+          .and.returnValue(refreshedInstance),
+      });
+    });
+
+    it('refreshes passed instance', async function (done) {
+      await workflowHelpers.updateStatus(instance);
+      expect(instance.refresh).toHaveBeenCalled();
+      done();
+    });
+
+    it('sets passed status for refreshed instance before saving',
+      async function (done) {
+        const status = 'New Status';
+        spyOn(refreshedInstance, 'attr');
+        await workflowHelpers.updateStatus(instance, status);
+        expect(refreshedInstance.attr).toHaveBeenCalledWith('status', status);
+        expect(refreshedInstance.attr).toHaveBeenCalledBefore(
+          refreshedInstance.save
+        );
+        done();
+      });
+
+    it('returns saved instance', async function (done) {
+      const saved = {};
+      refreshedInstance.save.and.returnValue(saved);
+      const result = await workflowHelpers.updateStatus(instance);
+      expect(result).toBe(saved);
+      done();
+    });
+  });
 });

--- a/src/ggrc-client/js/components/workflow/workflow-helpers.js
+++ b/src/ggrc-client/js/components/workflow/workflow-helpers.js
@@ -74,4 +74,11 @@ export default {
     });
     return dfd;
   },
+  async updateStatus(instance, status) {
+    // we refresh the instance, because without this
+    // the server will return us 409 error
+    const refreshed = await instance.refresh();
+    refreshed.attr('status', status);
+    return refreshed.save();
+  },
 };

--- a/src/ggrc-client/js/models/cycle_models.js
+++ b/src/ggrc-client/js/models/cycle_models.js
@@ -6,6 +6,7 @@
 import Permission from '../permission';
 import {getRole} from '../plugins/utils/acl-utils';
 import {getClosestWeekday} from '../plugins/utils/date-util';
+import {getPageType} from '../plugins/utils/current-page-utils';
 
 (function (can) {
   let _mustachePath;
@@ -319,7 +320,6 @@ import {getClosestWeekday} from '../plugins/utils/date-util';
       default_filter: ['Control'],
     },
     init: function () {
-      let that = this;
       let assigneeRole = getRole('CycleTaskGroupObjectTask', 'Task Assignees');
 
       this._super.apply(this, arguments);
@@ -344,12 +344,13 @@ import {getClosestWeekday} from '../plugins/utils/date-util';
         }
       });
 
-      this.bind('updated', function (ev, instance) {
-        if (instance instanceof that) {
-          instance.refresh_all_force('related_objects').then(function (object) {
-            return instance.refresh_all_force(
-              'cycle_task_group', 'cycle', 'workflow');
-          });
+      this.bind('updated', (ev, instance) => {
+        // update related objects, if current page is Workflow
+        if (
+          instance instanceof this &&
+          getPageType() === 'Workflow'
+        ) {
+          instance.refresh_all_force('cycle_task_group', 'cycle', 'workflow');
         }
       });
     },


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

There are a lot of requests, which are occurred after Cycle Task editing. 

# Steps to test the changes

1. Open any Cycle Task from workflow page / My work page.
2. Click edit button from info pane / subtree item menu.
3. Open Dev Tools on the Network page.
4. Click Save & Close button. 

Expected result: Should be removed all necessary requests.

# Solution description

We have several places, where we can edit Cycle Task though edit modal.

### From My Work page.
In this case we should use following request:
 ![image](https://user-images.githubusercontent.com/13063442/37821896-fbc82cfc-2e95-11e8-8dbd-ca8440aa1a2b.png)
 - PUT request for save changes.
 - GET for getting an updated count of Cycle Tasks. It can be changed, if we try to unassign current user from the editing task (Task Assignee or Secondary TA).
 - GET for getting an updated permissions. The reason is the same as from the previous point.

### From Workflow page.
In this case we should use following request:
![image](https://user-images.githubusercontent.com/13063442/37822755-6fd54862-2e98-11e8-8c0c-2aedeb0b387f.png)


Additionally to previous requests from (1), we should use 3 request for updating Cycle, Cycle Task group and Workflow. This is needed, because if we change status or Due Date for CT, these objects may be changed (statuses, for Cycle - also End date).

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
