### PR TITLE
GGRC-4703 Remove redundant indexing on CycleTask PUT

### DIFF
--- a/src/ggrc/converters/base_block.py
+++ b/src/ggrc/converters/base_block.py
@@ -633,6 +633,8 @@ class BlockConverter(object):
       import_event = log_event(db.session, None)
       update_memcache_before_commit(
           self, modified_objects, CACHE_EXPIRY_IMPORT)
+      for row_converter in self.row_converters:
+        row_converter.send_before_commit_signals(import_event)
       db.session.commit()
       self._store_revision_ids(import_event)
       update_memcache_after_commit(self)

--- a/src/ggrc/converters/base_row.py
+++ b/src/ggrc/converters/base_row.py
@@ -222,6 +222,23 @@ class RowConverter(object):
           self.object_class, obj=self.obj, src={}, service=service_class,
           event=event)
 
+  def send_before_commit_signals(self, event=None):
+    """Send before commit signals for all objects.
+
+    Currently we have only one before commit signal type:
+    model_put_before_commit. It should be sent for all changed objects via
+    import.
+    Note: signals are only sent for the row objects. Secondary objects such as
+    Relationships do not get any signals triggered.
+    """
+    if self.ignore or self.is_new or self.is_delete:
+      return
+    service_class = getattr(ggrc.services, self.object_class.__name__)
+    service_class.model = self.object_class
+    signals.Restful.model_put_before_commit.send(
+        self.object_class, obj=self.obj, src={}, service=service_class,
+        event=event)
+
   def send_pre_commit_signals(self):
     """Send before commit signals for all objects.
 

--- a/src/ggrc_workflows/__init__.py
+++ b/src/ggrc_workflows/__init__.py
@@ -553,7 +553,7 @@ def handle_cycle_task_group_object_task_put(
 
 @signals.Restful.model_posted_after_commit.connect_via(
     models.CycleTaskGroupObjectTask)
-@signals.Restful.model_put_after_commit.connect_via(
+@signals.Restful.model_put_before_commit.connect_via(
     models.CycleTaskGroupObjectTask)
 @signals.Restful.model_deleted_after_commit.connect_via(
     models.CycleTaskGroupObjectTask)


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

**Before this PR changes:**

1. On CycleTask PUT some data was changed. 
2. Then `db.session.commit` was [invoked](https://github.com/google/ggrc-core/blob/dev/src/ggrc/services/common.py#L591). 
3. Cause CycleTask was changed then [hook on update](https://github.com/google/ggrc-core/blob/dev/src/ggrc/fulltext/listeners.py#L19) was invoked. 
4. Then reindexing procedure was started [here](https://github.com/google/ggrc-core/blob/dev/src/ggrc/fulltext/mysql.py#L226). 
5. Then on CycleTask `model_put_after_commit` CycleTaskGroup dates are changed [here](https://github.com/google/ggrc-core/blob/dev/src/ggrc_workflows/__init__.py#L565).
6. It leads to that CycleTaskGroup marked as dirty in session. On next [commit](https://github.com/google/ggrc-core/blob/dev/src/ggrc_workflows/__init__.py#L566) reindex procedure starts once again for CycleTaskGroup and parent object Cycle.

All above leads to increasing time on CycleTask PUT.

# Steps to test the changes

Create Cycle with 10 CycleTaskGroups with 100 CycleTasks in each one.
Before applying changes from this PR check how much time CycleTask PUT request takes.
Compare time for same operation after applying these changes.

**For my local env next numbers were measured:**
- before changes: 3.66; 3.76; 3.53; 3.49; 3.19 => average 3.526
- after changes: 2.48; 1.94; 2.05; 2.14; 2.01 => average 2.124
Time for CycleTask PUT request decreased by 40%.

# Solution description

Moved updates for CycleTask parent objects (CycleTaskGroup, Cycle) to `model_put_before_commit` hook. It prevents duplicated reindex run.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
