### PR TITLE
GGRC-4715 Disable "Complete" button if evidences is updating

### DIFF
--- a/src/ggrc-client/js/components/assessment/controls-toolbar/controls-toolbar.mustache
+++ b/src/ggrc-client/js/components/assessment/controls-toolbar/controls-toolbar.mustache
@@ -10,6 +10,7 @@
       </custom-attributes-actions>
       <object-state-toolbar {verifiers}="verifiers"
                             {instance}="instance"
+                            {disabled}="isPending"
                             (on-state-change)="onStateChange(%event)">
       </object-state-toolbar>
   {{/is_allowed}}

--- a/src/ggrc-client/js/components/assessment/info-pane/info-pane.js
+++ b/src/ggrc-client/js/components/assessment/info-pane/info-pane.js
@@ -178,6 +178,13 @@ import {CUSTOM_ATTRIBUTE_TYPE} from '../../../plugins/utils/custom-attribute/cus
               this.attr('isAssessmentSaving');
           },
         },
+        // flag which indicates that changing of assessment state is blocked
+        isPending: {
+          get() {
+            return this.attr('isUpdatingEvidences') ||
+              this.attr('isUpdatingUrls');
+          },
+        },
       },
       modal: {
         open: false,

--- a/src/ggrc-client/js/components/assessment/info-pane/info-pane.js
+++ b/src/ggrc-client/js/components/assessment/info-pane/info-pane.js
@@ -94,10 +94,6 @@ import {CUSTOM_ATTRIBUTE_TYPE} from '../../../plugins/utils/custom-attribute/cus
               this.instance.attr('issue_tracker.issue_url');
           },
         },
-        isSaving: {
-          type: 'boolean',
-          value: false,
-        },
         isLoading: {
           type: 'boolean',
           value: false,
@@ -445,7 +441,6 @@ import {CUSTOM_ATTRIBUTE_TYPE} from '../../../plugins/utils/custom-attribute/cus
         } else {
           instance.attr('previousStatus', instance.attr('status'));
         }
-        instance.attr('isPending', true);
 
         instance.attr('status', isUndo ? previousStatus : newStatus);
         if (instance.attr('status') === 'In Review' && !isUndo) {
@@ -458,8 +453,7 @@ import {CUSTOM_ATTRIBUTE_TYPE} from '../../../plugins/utils/custom-attribute/cus
           this.initializeFormFields();
           this.attr('onStateChangeDfd').resolve();
           stopFn();
-        }).always(() => instance.attr('isPending', false))
-          .fail(resetStatusOnConflict);
+        }).fail(resetStatusOnConflict);
       },
       saveGlobalAttributes: function (event) {
         const instance = this.attr('instance');

--- a/src/ggrc-client/js/components/assessment/info-pane/tests/info-pane_spec.js
+++ b/src/ggrc-client/js/components/assessment/info-pane/tests/info-pane_spec.js
@@ -45,6 +45,38 @@ describe('GGRC.Components.assessmentInfoPane', function () {
     });
   });
 
+  describe('isPending() getter', () => {
+    it('returns true if isUpdatingEvidences and isUpdatingUrls are true',
+      () => {
+        vm.attr('isUpdatingEvidences', true);
+        vm.attr('isUpdatingUrls', false);
+
+        expect(vm.attr('isPending')).toBe(true);
+      });
+
+    it('returns false if isUpdatingUrls and isUpdatingEvidences are false',
+      () => {
+        vm.attr('isUpdatingEvidences', false);
+        vm.attr('isUpdatingUrls', false);
+
+        expect(vm.attr('isPending')).toBe(false);
+      });
+
+    it('returns true if only isUpdatingEvidences is true', () => {
+      vm.attr('isUpdatingEvidences', true);
+      vm.attr('isUpdatingUrls', false);
+
+      expect(vm.attr('isPending')).toBe(true);
+    });
+
+    it('returns true if only isUpdatingUrls is true', () => {
+      vm.attr('isUpdatingEvidences', false);
+      vm.attr('isUpdatingUrls', true);
+
+      expect(vm.attr('isPending')).toBe(true);
+    });
+  });
+
   describe('onStateChange() method', () => {
     let method;
     beforeEach(() => {

--- a/src/ggrc-client/js/components/assessment/info-pane/tests/info-pane_spec.js
+++ b/src/ggrc-client/js/components/assessment/info-pane/tests/info-pane_spec.js
@@ -62,33 +62,9 @@ describe('GGRC.Components.assessmentInfoPane', function () {
         status: 'newStatus',
       }).then(() => {
         expect(vm.attr('instance.status')).toBe('FooBar');
-        expect(vm.attr('isPending')).toBeFalsy();
         done();
       });
     });
-
-    it('resets isPending flag in case success the status changing', (done) => {
-      instanceSave.resolve();
-
-      method({
-        status: 'FooBar',
-      }).then(() => {
-        expect(vm.attr('isPending')).toBeFalsy();
-        done();
-      });
-    });
-
-    it('resets isPending flag in case unsuccessful the status changing',
-      (done) => {
-        instanceSave.reject();
-
-        method({
-          status: 'FooBar',
-        }).fail(() => {
-          expect(vm.attr('isPending')).toBeFalsy();
-          done();
-        });
-      });
 
     it('resets status after conflict', (done) => {
       vm.attr('instance.status', 'Baz');

--- a/src/ggrc-client/js/components/object-state-toolbar/object-state-toolbar.js
+++ b/src/ggrc-client/js/components/object-state-toolbar/object-state-toolbar.js
@@ -42,6 +42,7 @@ import template from './object-state-toolbar.mustache';
           },
         },
       },
+      disabled: false,
       verifiers: [],
       instance: {},
       isActiveState: function () {

--- a/src/ggrc-client/js/components/object-state-toolbar/object-state-toolbar.mustache
+++ b/src/ggrc-client/js/components/object-state-toolbar/object-state-toolbar.mustache
@@ -6,14 +6,17 @@
 <div class="object-state-toolbar">
   {{#if isActiveState}}
       <button class="btn btn-small btn-darkBlue object-state-toolbar__item"
+              {{#if disabled}}disabled{{/if}}
               ($click)="changeState()">Complete
       </button>
   {{/if}}
   {{#if isInReview}}
     {{#if isCurrentUserVerifier}}
         <button class="btn btn-small btn-green object-state-toolbar__item"
+                {{#if disabled}}disabled{{/if}}
                 ($click)="changeState('Verified')">Verify</button>
         <button class="btn btn-small btn-red object-state-toolbar__item"
+                {{#if disabled}}disabled{{/if}}
                 ($click)="changeState('Rework Needed')">Needs Rework
         </button>
     {{/if}}
@@ -21,6 +24,7 @@
   {{#unless isInProgress}}
       {{#if hasPreviousState}}
         <button class="btn btn-small btn-link object-state-toolbar__item"
+                {{#if disabled}}disabled{{/if}}
                 ($click)="changeState('In Progress', true)">Undo
         </button>
       {{/if}}

--- a/src/ggrc/assets/mustache/assessments/header.mustache
+++ b/src/ggrc/assets/mustache/assessments/header.mustache
@@ -190,6 +190,7 @@ Copyright (C) 2018 Google Inc.
                 <object-state-toolbar {{#if is_info_pin}}class="pane-header__toolbar-item"{{/if}}
                                     {verifiers}="verifiers"
                                     {instance}="instance"
+                                    {disabled}="isPending"
                                     (on-state-change)="onStateChange(%event)">
                 </object-state-toolbar>
         {{/unless}}


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

When user add evidences assessment is moved into 'In Progress' state, so if user add some evidences and then clicks 'Complete' button before evidences saving response, assessment will be moved back 'In Progress' state.

# Steps to test the changes

Steps to reproduce:
1. Open an Assessment which is 'In progress'
2. Perform one of the following steps:
- attach evidence and click on Complete button while changes are saving;
- add evidence URL and click on Complete button while changes are saving;

3. Look at the state of the Assessment

**Actual Result:** If user clicks complete button before changes were saved, assessment is moving to In review state and then back to In progress.
**Expected Result:** Complete button should be disabled before attachment and evidence url are not saved.

# Solution description

Define `isPending` flag which indicates that changing of assessment state is blocked.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
