### PR TITLE
GGRC-4758 Handle deleted object mapping

### DIFF
--- a/src/ggrc/models/relationship.py
+++ b/src/ggrc/models/relationship.py
@@ -118,6 +118,9 @@ class Relationship(Base, db.Model):
                                     self.destination_type, self.destination_id)
 
   def validate_relatable_type(self, field, value):
+    if value is None:
+      raise ValidationError(u"{}.{} can't be None."
+                            .format(self.__class__.__name__, field))
     if not isinstance(value, Relatable):
       raise ValidationError(u"You are trying to create relationship with not "
                             u"Relatable type: {}".format(value.type))

--- a/test/integration/ggrc/api_helper.py
+++ b/test/integration/ggrc/api_helper.py
@@ -157,7 +157,7 @@ class Api(object):
     data = {obj._inflector.table_singular: obj_dict}
     return self.put(obj, data)
 
-  def delete(self, obj, args=None):
+  def delete(self, obj, id_=None, args=None):
     """Delete api call helper.
 
     This function helps creating delete calls for a specific object by fetching
@@ -169,13 +169,14 @@ class Api(object):
     Returns:
       Server response.
     """
-    response = self.get(obj, obj.id)
+    id_ = id_ or obj.id
+    response = self.get(obj, id_)
     headers = {
         "If-Match": response.headers.get("Etag"),
         "If-Unmodified-Since": response.headers.get("Last-Modified")
     }
     headers.update(self.headers)
-    api_link = self.api_link(obj, obj.id)
+    api_link = self.api_link(obj, id_)
     if args:
       args_str = ",".join("{}={}".format(k, v) for k, v in args.items())
       api_link = "{}?{}".format(api_link, args_str)

--- a/test/integration/ggrc/models/test_issue.py
+++ b/test/integration/ggrc/models/test_issue.py
@@ -304,7 +304,7 @@ class TestIssueUnmap(TestCase):
   def test_issue_cascade_unmap(self):
     """Test cascade unmapping Issue from Assessment"""
     unmap_rel1 = all_models.Relationship.query.get(self.unmap_rel_id1)
-    response = self.generator.api.delete(unmap_rel1, {"cascade": "true"})
+    response = self.generator.api.delete(unmap_rel1, args={"cascade": "true"})
     self.assert200(response)
 
     snap0_issue_rel = self.get_relationships(
@@ -318,7 +318,7 @@ class TestIssueUnmap(TestCase):
     self.assertEqual(all_models.Relationship.query.count(), 8)
 
     unmap_rel2 = all_models.Relationship.query.get(self.unmap_rel_id2)
-    response = self.generator.api.delete(unmap_rel2, {"cascade": "true"})
+    response = self.generator.api.delete(unmap_rel2, args={"cascade": "true"})
     self.assert200(response)
 
     issue = all_models.Issue.query.get(self.issue_id)
@@ -345,11 +345,11 @@ class TestIssueUnmap(TestCase):
     db.session.commit()
 
     unmap_rel1 = all_models.Relationship.query.get(self.unmap_rel_id1)
-    response = self.generator.api.delete(unmap_rel1, {"cascade": "true"})
+    response = self.generator.api.delete(unmap_rel1, args={"cascade": "true"})
     self.assert200(response)
 
     unmap_rel2 = all_models.Relationship.query.get(self.unmap_rel_id2)
-    response = self.generator.api.delete(unmap_rel2, {"cascade": "true"})
+    response = self.generator.api.delete(unmap_rel2, args={"cascade": "true"})
     self.assert200(response)
 
     # No Issue-Snapshot, no Issue-Audit relationships should be removed
@@ -380,13 +380,13 @@ class TestIssueUnmap(TestCase):
     db.session.commit()
 
     unmap_rel1 = all_models.Relationship.query.get(self.unmap_rel_id1)
-    response = self.generator.api.delete(unmap_rel1, {"cascade": "true"})
+    response = self.generator.api.delete(unmap_rel1, args={"cascade": "true"})
     self.assert200(response)
     # Snapshot is unmapped in cascade as it's automapped
     self.assertEqual(all_models.Relationship.query.count(), 8)
 
     unmap_rel2 = all_models.Relationship.query.get(self.unmap_rel_id2)
-    response = self.generator.api.delete(unmap_rel2, {"cascade": "true"})
+    response = self.generator.api.delete(unmap_rel2, args={"cascade": "true"})
     self.assert200(response)
 
     snap1_issue_rel = self.get_relationships(


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

When a client POSTs a Relationship between a deleted object and anything, the backend responds with HTTP500 instead of HTTP400.

# Steps to test the changes

1. Create a Control.
2. Create another Control.
3. Delete one of the Controls.
4. POST a Relationship between the two Controls manually.

Expected result: HTTP400 is returned.
Actual result: the BE crashes with HTTP500.

# Solution description

`None` is now handled in Relationship validator.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
