### PR TITLE
GGRC-4798 Fix approval workflow buttons

### DIFF
--- a/src/ggrc-client/js/apps/workflows.js
+++ b/src/ggrc-client/js/apps/workflows.js
@@ -295,10 +295,15 @@ import InfoWidget from '../controllers/info_widget_controller';
             'task_group_objects',
             null
           ),
-        object_tasks: TypeFilter('related_objects', 'CycleTaskGroupObjectTask'),
-        approval_tasks: CustomFilter('object_tasks', function (object) {
-          return object.instance.attr('object_approval');
-        }),
+        approval_tasks: Search(function (binding) {
+          return CMS.Models.CycleTaskGroupObjectTask.findAll({
+            object_approval: true,
+            // We only need to check destination_id/type because cycle tasks
+            // are allways mapped through destination
+            'related_destinations.destination_id': binding.instance.id,
+            'related_destinations.destination_type': binding.instance.type,
+          });
+        }, 'CycleTaskGroupObjectTask'),
         workflows: Cross('task_groups', 'workflow'),
         approval_workflows: CustomFilter('workflows', function (binding) {
           return binding.instance.attr('object_approval');

--- a/src/ggrc-client/js/apps/workflows.js
+++ b/src/ggrc-client/js/apps/workflows.js
@@ -303,7 +303,7 @@ import InfoWidget from '../controllers/info_widget_controller';
             'related_destinations.destination_id': binding.instance.id,
             'related_destinations.destination_type': binding.instance.type,
           });
-        }, 'CycleTaskGroupObjectTask'),
+        }),
         workflows: Cross('task_groups', 'workflow'),
         approval_workflows: CustomFilter('workflows', function (binding) {
           return binding.instance.attr('object_approval');

--- a/src/ggrc-client/js/controllers/modals/approval-workflow-modal.js
+++ b/src/ggrc-client/js/controllers/modals/approval-workflow-modal.js
@@ -155,7 +155,8 @@ let ApprovalWorkflow = can.Observe({
           context: wf.context,
         }).save();
         cycleDfd.then(function () {
-          return that.original_object.refresh();
+          const binding = that.original_object.get_binding('approval_tasks');
+          return binding.loader.refresh_list(binding);
         });
         return cycleDfd;
       });

--- a/src/ggrc-client/js/controllers/tests/approval-workflow-model-helper_spec.js
+++ b/src/ggrc-client/js/controllers/tests/approval-workflow-model-helper_spec.js
@@ -15,6 +15,7 @@ describe('ApprovalWorkflow', ()=> {
     let currentUser;
     let assigneeRole;
     let wfAdminRole;
+    let awBinding;
 
     beforeAll(()=> {
       assigneeRole = {
@@ -42,12 +43,14 @@ describe('ApprovalWorkflow', ()=> {
     });
 
     beforeEach(()=> {
-      let awBinding;
       let instance;
 
       awsDfd = new can.Deferred();
       awBinding = {
         refresh_list: jasmine.createSpy().and.returnValue(awsDfd),
+        loader: {
+          refresh_list: jasmine.createSpy(),
+        },
       };
       originalObject = {
         get_binding: jasmine.createSpy().and.returnValue(awBinding),
@@ -196,7 +199,7 @@ describe('ApprovalWorkflow', ()=> {
         });
       });
 
-      it('reloads original object', ()=> {
+      it('reloads approval mapping binding object', ()=> {
         const tg = {};
         const wf = {
           context: {},
@@ -208,7 +211,8 @@ describe('ApprovalWorkflow', ()=> {
         saveTgoDfd.resolve();
         saveCycleDfd.resolve();
 
-        expect(originalObject.refresh).toHaveBeenCalled();
+        expect(originalObject.get_binding).toHaveBeenCalled();
+        expect(awBinding.loader.refresh_list).toHaveBeenCalled();
       });
     });
 
@@ -310,13 +314,16 @@ describe('ApprovalWorkflow', ()=> {
         });
       });
 
-      it('reloads original object', ()=> {
+      it('reloads approval_tasks mapping binding object', ()=> {
+        let binding = originalObject.get_binding;
+
         saveTgDfd.resolve(tg);
         refreshTgtDfd.resolve(tgt);
         saveTgtDfd.resolve();
         saveCycleDfd.resolve();
 
-        expect(originalObject.refresh).toHaveBeenCalled();
+        expect(binding).toHaveBeenCalledWith('approval_tasks');
+        expect(awBinding.loader.refresh_list).toHaveBeenCalled();
       });
     });
   });

--- a/src/ggrc/assets/mustache/base_objects/approval_link.mustache
+++ b/src/ggrc/assets/mustache/base_objects/approval_link.mustache
@@ -60,7 +60,7 @@
               </a>
               <small><em>Approval applies only to this object and not to mapped objects.</em></small>
               {{#current_user_is_admin}}
-                {{#with_mapping 'object_tasks' instance}}
+                {{#with_mapping 'approval_tasks' instance}}
                 <p>
                   If you wish to change the current reviewer, please click
                   <a href="{{instance.viewLink}}#task_widget/cycle_task_group_object_task/{{object_tasks.0.instance.id}}"


### PR DESCRIPTION
# Issue description

After we removed related_sources/related_destinations (https://github.com/google/ggrc-core/pull/7382) approval workflow buttons no longer appeared correctly. We were relying on related_destinations to fetch all tasks in the `approval_tasks` mapping. 

# Steps to test the changes

Steps to reproduce:
1. As admin user open My work page > Controls tab
2. Open any control in tree view 
3. Click 'Submit for review' link, assign a person, set a date and click Save button
4. Look at the Object review: Decline/Apply buttons are not displayed
Actual Result:

Apply/ Decline buttons are not displayed after assign a person for review;
'Here' link is not displayed screenshot-2.png
Expected Result: Apply/ Decline buttons should be displayed after assign a person for review. Admin user should be able to see Decline/Apply buttons despite he is reviewer or not.

# Solution description

This commit adds an additional request when opening the info pane, but it fixes the regression. Instead of filtering out CycleTasks in the relted_destinations mapping we create a collection get request every time we open the info pane. This is bad, but since the request should always return a very small amount of objects (0 or 1 unless the users were manually mapping objects to approval workflows) the request should be resolved fast.

An alternative solution would be to include approval tasks info in the original object json. Perhaps this approach can be used when we revamp the approval epic.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
