### PR TITLE
GGRC-4801 Access Control Roles GET doesn't return object type roles if user if Global Creator

### DIFF
--- a/src/ggrc_basic_permissions/roles/Creator.py
+++ b/src/ggrc_basic_permissions/roles/Creator.py
@@ -29,6 +29,7 @@ owner_base = [
 ]
 owner_read = owner_base + [
     "AccessControlList",
+    "AccessControlRole",
     {
         "type": "Relationship",
         "terms": {

--- a/src/ggrc_basic_permissions/roles/Editor.py
+++ b/src/ggrc_basic_permissions/roles/Editor.py
@@ -7,6 +7,7 @@ description = """
   """
 permissions = {
     "read": [
+        "AccessControlRole",
         "Workflow",
         "TaskGroup",
         "TaskGroupObject",

--- a/src/ggrc_basic_permissions/roles/Reader.py
+++ b/src/ggrc_basic_permissions/roles/Reader.py
@@ -16,6 +16,7 @@ description = """
   """
 permissions = {
     "read": [
+        "AccessControlRole",
         "AccessControlList",
         "Audit",
         "Snapshot",

--- a/test/integration/ggrc_basic_permissions/test_acr.py
+++ b/test/integration/ggrc_basic_permissions/test_acr.py
@@ -1,0 +1,54 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Collects all permission tests for ACR model."""
+
+import ddt
+
+from ggrc.models import all_models
+
+from integration.ggrc import TestCase
+from integration.ggrc.api_helper import Api
+from integration.ggrc.models import factories
+from integration.ggrc_basic_permissions.models \
+    import factories as rbac_factories
+
+
+@ddt.ddt
+class TestACRPermissions(TestCase):
+  """TestCase permissions for ACR model."""
+
+  def setUp(self):
+    super(TestACRPermissions, self).setUp()
+    self.api = Api()
+    self.client.get("/login")
+    self.obj_type = "Control"
+    roles = {r.name: r for r in all_models.Role.query.all()}
+    with factories.single_commit():
+      self.people = {
+          "Creator": factories.PersonFactory(),
+          "Reader": factories.PersonFactory(),
+          "Editor": factories.PersonFactory(),
+          "Administrator": factories.PersonFactory(),
+      }
+      for role_name in ["Creator", "Reader", "Editor", "Administrator"]:
+        rbac_factories.UserRoleFactory(role=roles[role_name],
+                                       person=self.people[role_name])
+      self.fake_role = factories.AccessControlRoleFactory(
+          name="ACL_Reader",
+          object_type=self.obj_type)
+
+  @ddt.data("Creator", "Reader", "Editor", "Administrator")
+  def test_get_acr(self, role):
+    """Test get access_control_roles for {}"""
+    fake_role_id = self.fake_role.id
+    self.api.set_user(self.people[role])
+    self.client.get("/login")
+    headers = {"Content-Type": "application/json", }
+    resp = self.api.client.get(
+        "/api/access_control_roles?object_type={}".format(self.obj_type),
+        headers=headers)
+    self.assert200(resp)
+    self.assertIn("access_control_roles_collection", resp.json)
+    acrs = resp.json["access_control_roles_collection"]["access_control_roles"]
+    self.assertIn(fake_role_id, [i["id"] for i in acrs])


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

ACR should be readable over api. Current functionality is required for GGRCQ integration for create Product/Process/System.

# Steps to test the changes

Steps to reproduce:

1) Log in as Global Creator user.

2) Run following request:

GET https://your_server/api/access_control_roles?object_type=product

# Solution description

makes ACR readable for any user role

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
