### PR TITLE
QUICK-FIX Add server default value for is_external flag

### DIFF
--- a/src/ggrc/migrations/versions/20180327141151_7c9d15c78b0f_add_is_external_default_value.py
+++ b/src/ggrc/migrations/versions/20180327141151_7c9d15c78b0f_add_is_external_default_value.py
@@ -1,0 +1,41 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+add is_external default value
+
+Create Date: 2018-03-27 14:11:51.923110
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+import sqlalchemy as sa
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '7c9d15c78b0f'
+down_revision = '48a49f384b2e'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  op.alter_column(
+      "relationships",
+      "is_external",
+      nullable=False,
+      server_default=sa.false(),
+      existing_type=sa.Boolean,
+  )
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  op.alter_column(
+      "relationships",
+      "is_external",
+      nullable=False,
+      server_default=None,
+      existing_type=sa.Boolean,
+  )


### PR DESCRIPTION
# Issue description

The is_external field has a default value on ORM layer but when creating
new relationships with raw sql, we get a warning because the default
value is not set on the mysql server layer.


# Steps to test the changes

on empty db create a new audit.
check for warning:
```
/vagrant/src/packages/sqlalchemy/engine/default.py:436: Warning: Field 'is_external' doesn't have a default value
  cursor.execute(statement, parameters)
```

# Solution description

Set the missing default value on the mysql server side as well.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# Migration checklist
- [x] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)


# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
