### PR TITLE
GGRC-4514 Check existence of modal after loading

### DIFF
--- a/src/ggrc-client/js/controllers/modals/modals_controller.js
+++ b/src/ggrc-client/js/controllers/modals/modals_controller.js
@@ -105,7 +105,9 @@ export default can.Control({
     }
 
     userFetch.then(function () {
-      this.after_preload();
+      if (this.element) {
+        this.after_preload();
+      }
     }.bind(this));
   },
   after_preload: function (content) {

--- a/src/ggrc-client/js/controllers/tests/modals_controller_spec.js
+++ b/src/ggrc-client/js/controllers/tests/modals_controller_spec.js
@@ -96,6 +96,28 @@ describe('ModalsController', function () {
         expect(ctrlInst.after_preload).toHaveBeenCalled();
       }
     );
+
+    it('does not call after_preload if there is no element for modal', () => {
+      let userId = GGRC.current_user.id;
+      let dfdRefresh = new can.Deferred();
+      let fetchedUser = new can.Map({id: userId, email: 'john@doe.com'});
+
+      let partialUser = new can.Map({
+        id: userId,
+        email: '',
+        refresh: jasmine.createSpy().and.returnValue(dfdRefresh.promise()),
+      });
+
+      spyOn(partialUser, 'reify').and.returnValue(partialUser);
+      CMS.Models.Person.store[userId] = partialUser;
+
+      init();
+
+      expect(ctrlInst.after_preload).not.toHaveBeenCalled();
+      ctrlInst.element = null;
+      dfdRefresh.resolve(fetchedUser);
+      expect(ctrlInst.after_preload).not.toHaveBeenCalled();
+    });
   });
 
   describe('save_error method', function () {


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

If close modal during loading, script error appears.

When all resources are loaded for modal, it is painting but the element is already destroyed in this case, so error occurs.

# Steps to test the changes

Steps to reproduce:
1. Open any program page;
2. Add tab > Objective;
3. Click Map button > Create and map a new object;
4. While modal window is loading click 'x' button (or press ESC button on keyboard).

Actual Result: "Uncaught TypeError: Cannot read property 'find' of null" error occurs if close Add New object popup while a window is loading.
Expected Result: no errors should be shown.

**NOTE:** If you are having problems with reproducing this issue (modal with spinner disappear very quickly), wrap `userFetch` deferred (line 107) in setTimeout.
 
# Solution description

Do not call `after_preload` function it there is no modal element.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
