### PR TITLE
GGRC-4782,4783 Amend IssueTracker cron job to handle rate limit

### DIFF
--- a/src/ggrc/integrations/integrations_errors.py
+++ b/src/ggrc/integrations/integrations_errors.py
@@ -25,6 +25,11 @@ class HttpError(Error):
   def __str__(self):
     return '%s %s' % (self.status, self.data)
 
+  def __repr__(self):
+    """Return representation of an HttpError."""
+    return '%s(status=%s, data=%s)' % (
+        self.__class__.__name__, self.status, self.data)
+
 
 class BadResponseError(Error):
   """Wrong formatted response error."""

--- a/src/ggrc/integrations/issues.py
+++ b/src/ggrc/integrations/issues.py
@@ -57,3 +57,14 @@ class Client(client.JsonClient):
       A dict representing an issue.
     """
     return self._post(self._BASE_PATH, payload=params)
+
+  def search(self, params):
+    """Searches for issues by given parameters.
+
+    Args:
+      params: A dict representing search parameters.
+
+    Returns:
+      A dict representing search response.
+    """
+    return self._post('%s/search' % self._BASE_PATH, payload=params)

--- a/src/ggrc/integrations/utils.py
+++ b/src/ggrc/integrations/utils.py
@@ -4,49 +4,157 @@
 """Module provides various utils for Issue tracker integration service."""
 
 import logging
+import time
 
 from sqlalchemy.sql import expression
 
-from ggrc.integrations import issues, integrations_errors
-from ggrc.models import IssuetrackerIssue
+from ggrc import models
+from ggrc.integrations import integrations_errors
+from ggrc.integrations import issues
 
 
 logger = logging.getLogger(__name__)
 
 
-def sync_issue_tracker_statuses():
-  """Synchronize issue tracker ticket statuses with the Assessment statuses.
+_SEARCH_PAGE_SIZE = 100
 
-  Check for Assessments which are in sync with issue tracker issues and update
-  their statuses in accordance to the corresponding Assessments if differ.
-  """
-  issue_objects = IssuetrackerIssue.query.filter(
-      IssuetrackerIssue.object_type == 'Assessment',
-      IssuetrackerIssue.enabled == expression.true(),
-      IssuetrackerIssue.issue_id.isnot(None),
-  ).order_by(IssuetrackerIssue.object_id).all()
+# A list of field to watch for changes in.
+_FIELDS_TO_CHECK = ('status', 'type', 'priority', 'severity')
+
+
+def _collect_assessment_issues():
+  """Returns issue infos associated with Assessments."""
+  issue_params = {}
+
+  issuetracker_cls = models.IssuetrackerIssue
+  issue_objects = issuetracker_cls.query.filter(
+      issuetracker_cls.object_type == 'Assessment',
+      issuetracker_cls.enabled == expression.true(),
+      issuetracker_cls.issue_id.isnot(None),
+  ).order_by(issuetracker_cls.object_id).all()
   for iti in issue_objects:
     asmt = iti.issue_tracked_obj
     if not asmt:
       logger.error(
-          "The Assessment corresponding to the Issue Tracker Issue ID=%d "
-          "does not exist.", iti.issue_id)
+          'The Assessment corresponding to the Issue Tracker Issue ID=%s '
+          'does not exist.', iti.issue_id)
       continue
+
     status_value = issues.STATUSES.get(asmt.status)
-    if status_value:
-      issue_params = {
-          'status': status_value,
-          'type': iti.issue_type,
-          'priority': iti.issue_priority,
-          'severity': iti.issue_severity,
-      }
-    else:
+    if not status_value:
       logger.error(
-          "Inexistent Issue Tracker status for assessment ID=%d "
-          "with status: %s.", asmt.id, status_value)
+          'Inexistent Issue Tracker status for assessment ID=%d '
+          'with status: %s.', asmt.id, status_value)
+      continue
+    issue_params[iti.issue_id] = {
+        'assessment_id': asmt.id,
+        'state': {
+            'status': status_value,
+            'type': iti.issue_type,
+            'priority': iti.issue_priority,
+            'severity': iti.issue_severity,
+        },
+    }
+  return issue_params
+
+
+def _iter_issue_batches(ids):
+  """Generates a sequence of batches of issues from Issue Tracker by IDs."""
+  cli = issues.Client()
+  next_page_token = None
+
+  while True:
     try:
-      issues.Client().update_issue(iti.issue_id, issue_params)
-    except integrations_errors.Error as error:
+      response = cli.search({
+          'issue_ids': ids,
+          'page_size': _SEARCH_PAGE_SIZE,
+          'page_token': next_page_token,
+      })
+    except integrations_errors.HttpError as error:
       logger.error(
-          'Unable to update IssueTracker issue status ID=%s '
-          'for assessment ID=%d: %s', iti.issue_id, asmt.id, error)
+          'Unable to fetch Issue Tracker issues by IDs: %r', error)
+      return
+
+    issue_infos = {}
+    response_issues = response.get('issues') or []
+    for info in response_issues:
+      state = info['issueState'] or {}
+      issue_infos[info['issueId']] = {
+          'status': state.get('status'),
+          'type': state.get('type'),
+          'priority': state.get('priority'),
+          'severity': state.get('severity'),
+      }
+    if issue_infos:
+      yield issue_infos
+
+    next_page_token = response.get('next_page_token')
+    if not next_page_token:
+      break
+
+
+def _update_issue(cli, issue_id, params, max_attempts=5, interval=1):
+  """Performs issue update request."""
+  attempts = max_attempts
+  while True:
+    attempts -= 1
+    try:
+      cli.update_issue(issue_id, params)
+    except integrations_errors.HttpError as error:
+      if error.status == 429:
+        if attempts == 0:
+          raise
+        logger.warning(
+            'The request updating ticket ID=%s was '
+            'rate limited and will be re-tried: %s', issue_id, error)
+        time.sleep(interval)
+        continue
+    break
+
+
+def sync_issue_tracker_statuses():
+  """Synchronizes issue tracker ticket statuses with the Assessment statuses.
+
+  Checks for Assessments which are in sync with Issue Tracker issues and
+  updates their statuses in accordance to the corresponding Assessments
+  if differ.
+  """
+  assessment_issues = _collect_assessment_issues()
+  if not assessment_issues:
+    return
+  logger.debug('Syncing state of %d issues.', len(assessment_issues))
+
+  cli = issues.Client()
+  processed_ids = set()
+  for batch in _iter_issue_batches(list(assessment_issues)):
+    for issue_id, issuetracker_state in batch.iteritems():
+      issue_info = assessment_issues.get(issue_id)
+      if not issue_info:
+        logger.warning(
+            'Got an unexpected issue from Issue Tracker: %s', issue_id)
+        continue
+
+      processed_ids.add(issue_id)
+      assessment_state = issue_info['state']
+      if all(
+          assessment_state.get(field) == issuetracker_state.get(field)
+          for field in _FIELDS_TO_CHECK
+      ):
+        continue
+
+      try:
+        _update_issue(cli, issue_id, assessment_state)
+      except integrations_errors.Error as error:
+        logger.error(
+            'Unable to update status of Issue Tracker issue ID=%s for '
+            'assessment ID=%d: %r',
+            issue_id, issue_info['assessment_id'], error)
+
+  logger.debug('Sync is done, %d issue(s) were processed.', len(processed_ids))
+
+  missing_ids = set(assessment_issues) - processed_ids
+  if missing_ids:
+    logger.warning(
+        'Some issues are linked to Assessments '
+        'but were not found in Issue Tracker: %s',
+        ', '.join(str(i) for i in missing_ids))

--- a/src/ggrc/models/hooks/issue_tracker.py
+++ b/src/ggrc/models/hooks/issue_tracker.py
@@ -293,18 +293,10 @@ def _handle_issuetracker(sender, obj=None, src=None, **kwargs):
   issue_obj = all_models.IssuetrackerIssue.get_issue(
       _ASSESSMENT_MODEL_NAME, obj.id)
 
-  logger.info(
-      '--> _handle_issuetracker: issue_obj=%s',
-      issue_obj)
-
   initial_info = issue_obj.to_dict(
       include_issue=True,
       include_private=True) if issue_obj is not None else {}
   issue_tracker_info = dict(initial_info, **(src.get('issue_tracker') or {}))
-
-  logger.info(
-      '--> _handle_issuetracker: initial_info=%s',
-      initial_info)
 
   if issue_tracker_info.get('enabled'):
 
@@ -321,19 +313,21 @@ def _handle_issuetracker(sender, obj=None, src=None, **kwargs):
     issue_tracker_info['enabled'] = False
 
   initial_assessment = kwargs.pop('initial_state', None)
-  logger.info(
-      '--> _handle_issuetracker: issue_tracker_info=%s',
-      issue_tracker_info)
   try:
     _update_issuetracker_issue(
         obj, issue_tracker_info, initial_assessment, initial_info, src)
   except integrations_errors.Error as error:
-    logger.error(
-        'Unable to update a ticket ID=%s while updating assessment ID=%d: %s',
-        issue_id, obj.id, error)
-    issue_tracker_info = {
-        'enabled': False,
-    }
+    if error.status == 429:
+      logger.error(
+          'The request updating ticket ID=%s for assessment ID=%d was '
+          'rate limited: %s', issue_id, obj.id, error)
+    else:
+      logger.error(
+          'Unable to update a ticket ID=%s while updating '
+          'assessment ID=%d: %s', issue_id, obj.id, error)
+      issue_tracker_info = {
+          'enabled': False,
+      }
     obj.add_warning('issue_tracker', 'Unable to update a ticket.')
 
   _update_issuetracker_info(obj, issue_tracker_info)
@@ -731,9 +725,6 @@ def _create_issuetracker_info(assessment, issue_tracker_info):
           _is_issue_tracker_enabled(audit=assessment.audit)):
 
     assignee_email, cc_list = _collect_issue_emails(assessment)
-    logger.info(
-        '--> _create_issuetracker_info: assignee_email=%s, cc_list=%s',
-        assignee_email, cc_list)
     if assignee_email is not None:
       issue_tracker_info['assignee'] = assignee_email
       issue_tracker_info['cc_list'] = cc_list

--- a/test/unit/ggrc/integrations/test_utils.py
+++ b/test/unit/ggrc/integrations/test_utils.py
@@ -1,0 +1,291 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Unit tests for client module."""
+# pylint: disable=protected-access
+
+import unittest
+
+import mock
+
+from ggrc.integrations import integrations_errors
+from ggrc.integrations import utils
+
+
+class BaseClientTest(unittest.TestCase):
+  """Tests basic functions."""
+
+  def test_collect_assessment_issues(self):
+    """Tests collection issues associated with Assessments."""
+    assessment1_mock = mock.MagicMock(id=1, status='In Review')
+    assessment2_mock = mock.MagicMock(id=2, status='WRONG STATUS')
+    issue1_mock = mock.MagicMock(
+        issue_tracked_obj=assessment1_mock,
+        issue_id='t1',
+        issue_type='bug1',
+        issue_priority='P1',
+        issue_severity='S1')
+    issue2_mock = mock.MagicMock(
+        issue_tracked_obj=assessment2_mock,
+        issue_id='t2',
+        issue_type='bug2',
+        issue_priority='P2',
+        issue_severity='S2')
+    issue3_mock = mock.MagicMock(
+        issue_tracked_obj=None,
+        issue_id='t3',
+        issue_type='bug3',
+        issue_priority='P3',
+        issue_severity='S3')
+    filter_mock = mock.MagicMock()
+    filter_mock.return_value.order_by.return_value.all.return_value = [
+        issue1_mock,
+        issue2_mock,
+        issue3_mock,
+    ]
+    with mock.patch.multiple(
+        utils.models.IssuetrackerIssue,
+        query=mock.MagicMock(filter=filter_mock)
+    ):
+      actual = utils._collect_assessment_issues()
+      self.assertEquals(actual, {
+          't1': {
+              'assessment_id': 1,
+              'state': {
+                  'status': 'FIXED',
+                  'type': 'bug1',
+                  'priority': 'P1',
+                  'severity': 'S1',
+              },
+          }
+      })
+
+  def test_iter_issue_batches(self):
+    """Tests fetching issues from Issue Tracer in batches."""
+    cli_mock = mock.MagicMock()
+    cli_mock.search.side_effect = iter([
+        {
+            'issues': [
+                {
+                    'issueId': 't1',
+                    'issueState': {
+                        'status': 'FIXED',
+                        'type': 'bug1',
+                        'priority': 'P1',
+                        'severity': 'S1',
+                    },
+                },
+                {
+                    'issueId': 't2',
+                    'issueState': {
+                        'status': 'FIXED',
+                        'type': 'bug2',
+                        'priority': 'P2',
+                        'severity': 'S2',
+                    },
+                },
+            ],
+            'next_page_token': 'token1',
+        },
+        {
+            'issues': [],
+            'next_page_token': 'token2',
+        },
+        {
+            'issues': [
+                {
+                    'issueId': 't3',
+                    'issueState': {
+                        'status': 'FIXED',
+                        'type': 'bug3',
+                        'priority': 'P3',
+                        'severity': 'S3',
+                    },
+                },
+            ],
+            'next_page_token': None,
+        },
+    ])
+    with mock.patch.object(utils.issues, 'Client', return_value=cli_mock):
+      actual = list(utils._iter_issue_batches([1, 2, 3]))
+      self.assertEquals(actual, [
+          {
+              't1': {
+                  'status': 'FIXED',
+                  'type': 'bug1',
+                  'priority': 'P1',
+                  'severity': 'S1',
+              },
+              't2': {
+                  'status': 'FIXED',
+                  'type': 'bug2',
+                  'priority': 'P2',
+                  'severity': 'S2',
+              },
+          },
+          {
+              't3': {
+                  'status': 'FIXED',
+                  'type': 'bug3',
+                  'priority': 'P3',
+                  'severity': 'S3',
+              },
+          },
+      ])
+      self.assertEqual(cli_mock.search.call_args_list, [
+          mock.call({
+              'issue_ids': [1, 2, 3],
+              'page_size': 100,
+              'page_token': None,
+          }),
+          mock.call({
+              'issue_ids': [1, 2, 3],
+              'page_size': 100,
+              'page_token': 'token1',
+          }),
+          mock.call({
+              'issue_ids': [1, 2, 3],
+              'page_size': 100,
+              'page_token': 'token2',
+          }),
+      ])
+
+  def test_iter_issue_batches_error(self):
+    """Tests handling error fetching issues from Issue Tracer in batches."""
+    cli_mock = mock.MagicMock()
+    cli_mock.search.side_effect = integrations_errors.HttpError('Test')
+    with mock.patch.object(utils.issues, 'Client', return_value=cli_mock):
+      actual = list(utils._iter_issue_batches([1, 2, 3]))
+      self.assertEqual(actual, [])
+
+  def test_update_issue(self):
+    """Tests updating issue."""
+    cli_mock = mock.MagicMock()
+    self.assertIsNone(utils._update_issue(cli_mock, 1, 'params'))
+    cli_mock.update_issue.assert_called_once_with(1, 'params')
+
+  def test_update_issue_with_retry(self):
+    """Tests updating issue with retry."""
+    cli_mock = mock.MagicMock()
+    exception = integrations_errors.HttpError('Test', status=429)
+    cli_mock.update_issue.side_effect = iter([
+        exception,
+        exception,
+        exception,
+        exception,
+        None,
+    ])
+    with mock.patch.object(utils.time, 'sleep') as sleep_mock:
+      utils._update_issue(cli_mock, 1, 'params')
+      self.assertEqual(cli_mock.update_issue.call_args_list, [
+          mock.call(1, 'params'),
+          mock.call(1, 'params'),
+          mock.call(1, 'params'),
+          mock.call(1, 'params'),
+          mock.call(1, 'params'),
+      ])
+      self.assertEqual(sleep_mock.call_args_list, [
+          mock.call(1),
+          mock.call(1),
+          mock.call(1),
+          mock.call(1),
+      ])
+
+  def test_update_issue_with_raise(self):
+    """Tests updating issue with raising an exception."""
+    cli_mock = mock.MagicMock()
+    exception = integrations_errors.HttpError('Test', status=429)
+    cli_mock.update_issue.side_effect = iter([
+        exception,
+        exception,
+        exception,
+        exception,
+        exception,
+    ])
+    with mock.patch.object(utils.time, 'sleep') as sleep_mock:
+      with self.assertRaises(integrations_errors.HttpError) as exc_mock:
+        utils._update_issue(cli_mock, 1, 'params')
+        self.assertEqual(exc_mock.exception.status, 429)
+        self.assertEqual(cli_mock.update_issue.call_args_list, [
+            mock.call(1, 'params'),
+            mock.call(1, 'params'),
+            mock.call(1, 'params'),
+            mock.call(1, 'params'),
+            mock.call(1, 'params'),
+        ])
+        self.assertEqual(sleep_mock.call_args_list, [
+            mock.call(1),
+            mock.call(1),
+            mock.call(1),
+            mock.call(1),
+        ])
+
+  def test_sync_issue_tracker_statuses(self):  # pylint: disable=invalid-name
+    """Tests issue synchronization flow."""
+    assessment_issues = {
+        't1': {
+            'assessment_id': 1,
+            'state': {
+                'status': 'FIXED',
+                'type': 'BUG1',
+                'priority': 'P1',
+                'severity': 'S1',
+            },
+        },
+        't2': {
+            'assessment_id': 2,
+            'state': {
+                'status': 'ASSIGNED',
+                'type': 'BUG2',
+                'priority': 'P2',
+                'severity': 'S2',
+            },
+        },
+    }
+    batches = [
+        {
+            't1': {
+                'status': 'FIXED',
+                'type': 'BUG1',
+                'priority': 'P1',
+                'severity': 'S1',
+            },
+        },
+        {
+            't2': {
+                'status': 'FIXED',
+                'type': 'BUG2',
+                'priority': 'P2',
+                'severity': 'S2',
+            },
+            'unexpected_issue': {
+                'status': 'FIXED',
+                'type': 'BUG2',
+                'priority': 'P2',
+                'severity': 'S2',
+            },
+        },
+    ]
+
+    cli_mock = mock.MagicMock()
+    cli_patch = mock.patch.object(
+        utils.issues, 'Client', return_value=cli_mock)
+
+    with cli_patch, mock.patch.multiple(
+        utils,
+        _collect_assessment_issues=mock.MagicMock(
+            return_value=assessment_issues),
+        _iter_issue_batches=mock.MagicMock(
+            return_value=iter(batches)),
+        _update_issue=mock.DEFAULT
+    ):
+      utils.sync_issue_tracker_statuses()
+      iter_calls = utils._iter_issue_batches.call_args_list
+      self.assertEqual(len(iter_calls), 1)
+      self.assertItemsEqual(iter_calls[0][0][0], ['t1', 't2'])
+      utils._update_issue.assert_called_once_with(cli_mock, 't2', {
+          'status': 'ASSIGNED',
+          'type': 'BUG2',
+          'priority': 'P2',
+          'severity': 'S2',
+      })


### PR DESCRIPTION
# Issue description

Cron job to sync Assessments status to IssueTracker failed to complete because of rate limit on API side.

# Steps to test the changes

Run Cron job to sync Assessments status to IssueTracker and check it completes successfully.

# Solution description

Handle HTTP 429 error in Cron job properly and re-try multiple times with some back off period. There is also a need to not disable Issue Tracker integration for an Assessment if issue update fails because rate limit.

# Sanity checklist

- [ ] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [X] My changes fix the issue described in the description (and do nothing else). 🤞
- [X] My changes are covered by tests.
- [X] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [X] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [X] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).
