### PR TITLE
GGRC-4813 Custom Attribute Definitions: Filtering by mandatory doesn't work

### DIFF
--- a/src/ggrc/services/attribute_query.py
+++ b/src/ggrc/services/attribute_query.py
@@ -1,9 +1,10 @@
 # Copyright (C) 2018 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
+from collections import namedtuple
 import datetime
 import iso8601
-from collections import namedtuple
+
 from sqlalchemy import and_, cast
 from sqlalchemy.ext.associationproxy import AssociationProxy
 from sqlalchemy.orm import joinedload_all
@@ -60,8 +61,7 @@ class AttributeQueryBuilder(object):
     return value
 
   def check_valid_property(self, attr, attrname):
-    if not hasattr(attr, 'type') or \
-            not isinstance(attr.type, TypeEngine):
+    if not hasattr(attr, 'type') or not isinstance(attr.type, TypeEngine):
       raise self.bad_query_parameter(attrname)
 
   def process_property_path(self, arg, value):  # Noqa
@@ -94,7 +94,7 @@ class AttributeQueryBuilder(object):
       value = [self.coerce_value_for_query_param(attr, arg, v) for v in value]
       filters.append(attr.in_(value))
     elif arg.endswith('__null'):
-      if(value in [0, 'false', 'False', 'FALSE', False]):
+      if value in [0, 'false', 'False', 'FALSE', False]:
         filters.append(attr.isnot(None))
       else:
         filters.append(attr.is_(None))

--- a/src/ggrc/services/attribute_query.py
+++ b/src/ggrc/services/attribute_query.py
@@ -32,9 +32,9 @@ class AttributeQueryBuilder(object):
     attr_type = type(attr.type)
     if attr_type is Boolean:
       value = value.lower()
-      if value == 'true':
+      if value in ['true', '1']:
         value = True
-      elif value == 'false':
+      elif value in ['false', '0']:
         value = False
       else:
         raise BadRequest('{0} must be "true" or "false", not {1}.'.format(

--- a/test/integration/ggrc/services/test_custom_attributes.py
+++ b/test/integration/ggrc/services/test_custom_attributes.py
@@ -1,6 +1,5 @@
 # Copyright (C) 2018 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
-
 """Tests for PUT and POST requests for objects with custom attributes
 
 These tests include:
@@ -62,31 +61,29 @@ class TestGlobalCustomAttributes(ProductTestCase):
     _, cad = gen("product", attribute_type="Text", title="normal text")
     pid = models.Person.query.first().id
 
-    product_data = [
-        {
-            "product": {
-                "kind": None,
-                "owners": [],
-                "custom_attribute_values": [{
-                    "attribute_value": "my custom attribute value",
-                    "custom_attribute_id": cad.id,
-                }],
-                "contact": {
-                    "id": pid,
-                    "href": "/api/people/{}".format(pid),
-                    "type": "Person"
-                },
-                "title": "simple product",
-                "description": "",
-                "secondary_contact": None,
-                "notes": "",
-                "url": "",
-                "documents_reference_url": "",
-                "slug": "",
-                "context": None
-            }
-        }
-    ]
+    product_data = [{
+        "product": {
+            "kind": None,
+            "owners": [],
+            "custom_attribute_values": [{
+                "attribute_value": "my custom attribute value",
+                "custom_attribute_id": cad.id,
+            }],
+            "contact": {
+                "id": pid,
+                "href": "/api/people/{}".format(pid),
+                "type": "Person"
+            },
+            "title": "simple product",
+            "description": "",
+            "secondary_contact": None,
+            "notes": "",
+            "url": "",
+            "documents_reference_url": "",
+            "slug": "",
+            "context": None,
+        },
+    }]
 
     response = self._post(product_data)
     ca_json = response.json[0][1]["product"]["custom_attribute_values"][0]
@@ -94,15 +91,12 @@ class TestGlobalCustomAttributes(ProductTestCase):
     self.assertIn("attributable_type", ca_json)
     self.assertIn("attribute_value", ca_json)
     self.assertIn("id", ca_json)
-    self.assertEqual(ca_json["attribute_value"],
-                     "my custom attribute value")
+    self.assertEqual(ca_json["attribute_value"], "my custom attribute value")
 
     product = models.Product.eager_query().first()
     self.assertEqual(len(product.custom_attribute_values), 1)
-    self.assertEqual(
-        product.custom_attribute_values[0].attribute_value,
-        "my custom attribute value"
-    )
+    self.assertEqual(product.custom_attribute_values[0].attribute_value,
+                     "my custom attribute value")
 
   def test_custom_attribute_put_add(self):
     """Test edits with adding new CA values."""
@@ -110,41 +104,44 @@ class TestGlobalCustomAttributes(ProductTestCase):
     _, cad = gen("product", attribute_type="Text", title="normal text")
     pid = models.Person.query.first().id
 
-    product_data = [
-        {
-            "product": {
-                "kind": None,
-                "owners": [],
-                "contact": {
-                    "id": pid,
-                    "href": "/api/people/{}".format(pid),
-                    "type": "Person"
-                },
-                "title": "simple product",
-                "description": "",
-                "secondary_contact": None,
-                "notes": "",
-                "url": "",
-                "documents_reference_url": "",
-                "slug": "",
-                "context": None
-            }
-        }
-    ]
+    product_data = [{
+        "product": {
+            "kind": None,
+            "owners": [],
+            "contact": {
+                "id": pid,
+                "href": "/api/people/{}".format(pid),
+                "type": "Person"
+            },
+            "title": "simple product",
+            "description": "",
+            "secondary_contact": None,
+            "notes": "",
+            "url": "",
+            "documents_reference_url": "",
+            "slug": "",
+            "context": None,
+        },
+    }]
 
     response = self._post(product_data)
     product_url = response.json[0][1]["product"]["selfLink"]
     headers = self.client.get(product_url).headers
 
     product_data[0]["product"]["custom_attribute_values"] = [{
-        "attribute_value": "added value",
-        "custom_attribute_id": cad.id,
+        "attribute_value":
+        "added value",
+        "custom_attribute_id":
+        cad.id,
     }]
 
-    response = self._put(product_url, product_data[0], extra_headers={
-        'If-Unmodified-Since': headers["Last-Modified"],
-        'If-Match': headers["Etag"],
-    })
+    response = self._put(
+        product_url,
+        product_data[0],
+        extra_headers={
+            'If-Unmodified-Since': headers["Last-Modified"],
+            'If-Match': headers["Etag"],
+        })
 
     product = response.json["product"]
 
@@ -154,27 +151,29 @@ class TestGlobalCustomAttributes(ProductTestCase):
     self.assertIn("attributable_type", ca_json)
     self.assertIn("attribute_value", ca_json)
     self.assertIn("id", ca_json)
-    self.assertEqual(ca_json["attribute_value"],
-                     "added value")
+    self.assertEqual(ca_json["attribute_value"], "added value")
 
     product = models.Product.eager_query().first()
     self.assertEqual(len(product.custom_attribute_values), 1)
-    self.assertEqual(
-        product.custom_attribute_values[0].attribute_value,
-        "added value"
-    )
+    self.assertEqual(product.custom_attribute_values[0].attribute_value,
+                     "added value")
 
     headers = self.client.get(product_url).headers
 
     product_data[0]["product"]["custom_attribute_values"] = [{
-        "attribute_value": "edited value",
-        "custom_attribute_id": cad.id,
+        "attribute_value":
+        "edited value",
+        "custom_attribute_id":
+        cad.id,
     }]
 
-    response = self._put(product_url, product_data[0], extra_headers={
-        'If-Unmodified-Since': headers["Last-Modified"],
-        'If-Match': headers["Etag"],
-    })
+    response = self._put(
+        product_url,
+        product_data[0],
+        extra_headers={
+            'If-Unmodified-Since': headers["Last-Modified"],
+            'If-Match': headers["Etag"],
+        })
 
     product = response.json["product"]
     ca_json = product["custom_attribute_values"][0]
@@ -182,8 +181,7 @@ class TestGlobalCustomAttributes(ProductTestCase):
     self.assertIn("attributable_type", ca_json)
     self.assertIn("attribute_value", ca_json)
     self.assertIn("id", ca_json)
-    self.assertEqual(ca_json["attribute_value"],
-                     "edited value")
+    self.assertEqual(ca_json["attribute_value"], "edited value")
 
   def test_custom_attribute_get(self):
     """Check if get returns the whole CA value and not just the stub."""
@@ -191,31 +189,29 @@ class TestGlobalCustomAttributes(ProductTestCase):
     _, cad = gen("product", attribute_type="Text", title="normal text")
     pid = models.Person.query.first().id
 
-    product_data = [
-        {
-            "product": {
-                "kind": None,
-                "owners": [],
-                "custom_attribute_values": [{
-                    "attribute_value": "my custom attribute value",
-                    "custom_attribute_id": cad.id,
-                }],
-                "contact": {
-                    "id": pid,
-                    "href": "/api/people/{}".format(pid),
-                    "type": "Person"
-                },
-                "title": "simple product",
-                "description": "",
-                "secondary_contact": None,
-                "notes": "",
-                "url": "",
-                "documents_reference_url": "",
-                "slug": "",
-                "context": None
-            }
-        }
-    ]
+    product_data = [{
+        "product": {
+            "kind": None,
+            "owners": [],
+            "custom_attribute_values": [{
+                "attribute_value": "my custom attribute value",
+                "custom_attribute_id": cad.id,
+            }],
+            "contact": {
+                "id": pid,
+                "href": "/api/people/{}".format(pid),
+                "type": "Person",
+            },
+            "title": "simple product",
+            "description": "",
+            "secondary_contact": None,
+            "notes": "",
+            "url": "",
+            "documents_reference_url": "",
+            "slug": "",
+            "context": None,
+        },
+    }]
 
     response = self._post(product_data)
     product_url = response.json[0][1]["product"]["selfLink"]
@@ -253,8 +249,7 @@ class TestGlobalCustomAttributes(ProductTestCase):
     self.assert200(control_resp)
     self.assertIn("custom_attribute_definitions", control_resp.json["control"])
     self.assertEqual(
-        1, len(control_resp.json["control"]["custom_attribute_definitions"])
-    )
+        1, len(control_resp.json["control"]["custom_attribute_definitions"]))
     cad_json = control_resp.json["control"]["custom_attribute_definitions"][0]
     self.assertEqual(cad_id, cad_json["id"])
     self.assertIn("default_value", cad_json)
@@ -266,12 +261,8 @@ class TestGlobalCustomAttributes(ProductTestCase):
         default_value,
         cad_resp.json["custom_attribute_definition"]["default_value"])
 
-  @ddt.data((True, "1"),
-            (True, "true"),
-            (True, "TRUE"),
-            (False, "0"),
-            (False, "false"),
-            (False, "FALSE"))
+  @ddt.data((True, "1"), (True, "true"), (True, "TRUE"), (False, "0"),
+            (False, "false"), (False, "FALSE"))
   @ddt.unpack
   def test_filter_by_mandatory(self, flag_value, filter_value):
     """Filter CADs by mandatory flag if it's {0} and filter_value is {1}."""
@@ -283,9 +274,8 @@ class TestGlobalCustomAttributes(ProductTestCase):
       }
     resp = self.generator.api.get_query(
         all_models.CustomAttributeDefinition,
-        "ids={}&mandatory={}".format(
-            ",".join([str(c.id) for c in cads.values()]),
-            filter_value),
+        "ids={}&mandatory={}".format(",".join(
+            [str(c.id) for c in cads.values()]), filter_value),
     )
     self.assert200(resp)
     cad_collection = resp.json["custom_attribute_definitions_collection"]
@@ -294,8 +284,10 @@ class TestGlobalCustomAttributes(ProductTestCase):
     ]
     self.assertEqual([cads[flag_value].id], resp_cad_ids)
 
-  CAD_MODELS = [m for m in all_models.all_models
-                if issubclass(m, customattributable.CustomAttributable)]
+  CAD_MODELS = [
+      m for m in all_models.all_models
+      if issubclass(m, customattributable.CustomAttributable)
+  ]
 
   @ddt.data(*CAD_MODELS)
   def test_filter_by_definition_type(self, definition_model):
@@ -340,37 +332,35 @@ class TestOldApiCompatibility(ProductTestCase):
     cad_json = builder.json.publish_representation(cad_json)
     pid = models.Person.query.first().id
 
-    product_data = [
-        {
-            "product": {
-                "kind": None,
-                "owners": [],
-                "custom_attribute_definitions":[
-                    cad_json,
-                ],
-                "custom_attribute_values": [{
-                    "attribute_value": "new value",
-                    "custom_attribute_id": cad.id,
-                }],
-                "custom_attributes": {
-                    cad.id: "old value",
-                },
-                "contact": {
-                    "id": pid,
-                    "href": "/api/people/{}".format(pid),
-                    "type": "Person"
-                },
-                "title": "simple product",
-                "description": "",
-                "secondary_contact": None,
-                "notes": "",
-                "url": "",
-                "documents_reference_url": "",
-                "slug": "",
-                "context": None
-            }
-        }
-    ]
+    product_data = [{
+        "product": {
+            "kind": None,
+            "owners": [],
+            "custom_attribute_definitions":[
+                cad_json,
+            ],
+            "custom_attribute_values": [{
+                "attribute_value": "new value",
+                "custom_attribute_id": cad.id,
+            }],
+            "custom_attributes": {
+                cad.id: "old value",
+            },
+            "contact": {
+                "id": pid,
+                "href": "/api/people/{}".format(pid),
+                "type": "Person"
+            },
+            "title": "simple product",
+            "description": "",
+            "secondary_contact": None,
+            "notes": "",
+            "url": "",
+            "documents_reference_url": "",
+            "slug": "",
+            "context": None
+        },
+    }]
 
     response = self._post(product_data)
     ca_json = response.json[0][1]["product"]["custom_attribute_values"][0]
@@ -378,10 +368,8 @@ class TestOldApiCompatibility(ProductTestCase):
 
     product = models.Product.eager_query().first()
     self.assertEqual(len(product.custom_attribute_values), 1)
-    self.assertEqual(
-        product.custom_attribute_values[0].attribute_value,
-        "new value"
-    )
+    self.assertEqual(product.custom_attribute_values[0].attribute_value,
+                     "new value")
 
   def test_custom_attribute_post_old(self):
     """Test post with old style custom attribute values.
@@ -395,38 +383,36 @@ class TestOldApiCompatibility(ProductTestCase):
     cad_json = builder.json.publish_representation(cad_json)
     pid = models.Person.query.first().id
 
-    product_data = [
-        {
-            "product": {
-                "kind": None,
-                "owners": [],
-                "custom_attribute_definitions":[
-                    cad_json,
-                ],
-                "custom_attribute_values": [{
-                    "id": 1,
-                    "href": "/api/custom_attribute_values/1",
-                    "type": "CustomAttributeValues"
-                }],
-                "custom_attributes": {
-                    cad.id: "old value",
-                },
-                "contact": {
-                    "id": pid,
-                    "href": "/api/people/{}".format(pid),
-                    "type": "Person"
-                },
-                "title": "simple product",
-                "description": "",
-                "secondary_contact": None,
-                "notes": "",
-                "url": "",
-                "documents_reference_url": "",
-                "slug": "",
-                "context": None
-            }
-        }
-    ]
+    product_data = [{
+        "product": {
+            "kind": None,
+            "owners": [],
+            "custom_attribute_definitions":[
+                cad_json,
+            ],
+            "custom_attribute_values": [{
+                "id": 1,
+                "href": "/api/custom_attribute_values/1",
+                "type": "CustomAttributeValues",
+            }],
+            "custom_attributes": {
+                cad.id: "old value",
+            },
+            "contact": {
+                "id": pid,
+                "href": "/api/people/{}".format(pid),
+                "type": "Person",
+            },
+            "title": "simple product",
+            "description": "",
+            "secondary_contact": None,
+            "notes": "",
+            "url": "",
+            "documents_reference_url": "",
+            "slug": "",
+            "context": None,
+        },
+    }]
 
     response = self._post(product_data)
     self.assert200(response)
@@ -435,7 +421,5 @@ class TestOldApiCompatibility(ProductTestCase):
 
     product = models.Product.eager_query().first()
     self.assertEqual(len(product.custom_attribute_values), 1)
-    self.assertEqual(
-        product.custom_attribute_values[0].attribute_value,
-        "old value"
-    )
+    self.assertEqual(product.custom_attribute_values[0].attribute_value,
+                     "old value")


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Add ability to filter CADs mandatory field by int value.

# Steps to test the changes

Get request to https://{your_server}/api/custom_attribute_definitions?definition_type=product&mandatory=1
should return filtered CAD list
 
# Solution description

add ability to filter boolean filed by int values. 

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
