### PR TITLE
GGRC-4258 Use own instance in modals controller

### DIFF
--- a/src/ggrc-client/js/bootstrap/modal-ajax.js
+++ b/src/ggrc-client/js/bootstrap/modal-ajax.js
@@ -295,12 +295,6 @@ import Permission from '../permission';
           });
         }
       });
-
-      $target.on('modal:discard', () => {
-        if ( instance ) {
-          instance.restore(true);
-        }
-      });
     },
 
     helpform: function ($target, $trigger, option) {

--- a/src/ggrc-client/js/controllers/modals/modals_controller.js
+++ b/src/ggrc-client/js/controllers/modals/modals_controller.js
@@ -167,7 +167,7 @@ export default can.Control({
     }
 
     name = el.attr('name').split('.');
-    instance = this.options.instance;
+    instance = this.instance;
     value = el.val();
 
     name.pop(); // set the owner to null, not the email
@@ -201,7 +201,7 @@ export default can.Control({
     $('#extended-info').trigger('mouseleave'); // Make sure the extra info tooltip closes
 
     path = el.attr('name').split('.');
-    instance = this.options.instance;
+    instance = this.instance;
     index = 0;
     path.pop(); // remove the prop
     cb = el.data('lookup-cb');
@@ -267,8 +267,16 @@ export default can.Control({
   fetch_templates: function (dfd) {
     var that = this;
     dfd = dfd ? dfd.then(function () {
-      return that.options;
-    }) : $.when(this.options);
+      return {
+        ...that.options,
+        optionsInstance: that.options.instance,
+        instance: that.instance
+      };
+    }) : $.when({
+      ...this.options,
+      optionsInstance: this.options.instance,
+      instance: this.instance
+    });
     return $.when(
       can.view(this.options.content_view, dfd),
       can.view(this.options.header_view, dfd),
@@ -278,18 +286,41 @@ export default can.Control({
   },
 
   fetch_data: function (params) {
-    var that = this;
-    var dfd;
-    var instance = this.options.attr('instance');
+    let that = this;
+    let optionsInstance = this.options.attr('instance');
+    let optionsModel = this.options.attr('model');
+    let dfd;
 
     params = params || this.find_params();
     params = params && params.serialize ? params.serialize() : params;
 
-    if (this.options.skip_refresh && instance) {
-      return new $.Deferred().resolve(instance);
-    } else if (instance) {
-      dfd = instance.refresh();
-    } else if (this.options.model) {
+    if (optionsInstance) {
+      dfd = new $.Deferred();
+
+      if (this.options.skip_refresh) {
+        this.instance = !optionsInstance.includeObjects ?
+          this.getExtendedInstance({
+            targetInstance: this.prepareInstance(),
+            originalInstance: optionsInstance,
+            model: optionsModel,
+            updateStore: true
+          }) : optionsInstance;
+
+        return dfd.resolve(this.instance);
+      }
+
+      optionsInstance.refresh()
+        .then(instance => {
+          this.instance = this.getExtendedInstance({
+            targetInstance: this.prepareInstance(),
+            originalInstance: instance,
+            model: optionsModel,
+            updateStore: true
+          });
+
+          return dfd.resolve(this.instance);
+        });
+    } else if (optionsModel) {
       if (this.options.new_object_form) {
 
         if (this.options.extendNewInstance) {
@@ -299,21 +330,17 @@ export default can.Control({
           Object.assign(params, extendedInstance);
         }
 
-        dfd = $.when(this.options.attr(
-          'instance',
-          new this.options.model(params).attr('_suppress_errors', true)
-        )).then(function () {
-          instance = this.options.attr('instance');
-        }.bind(this));
+        this.instance = this.options.instance = new optionsModel(params).attr('_suppress_errors', true);
+        dfd = $.when(this.instance);
       } else {
-        dfd = this.options.model.findAll(params).then(function (data) {
+        dfd = optionsModel.findAll(params).then(function (data) {
           if (data.length) {
-            that.options.attr('instance', data[0]);
+            that.instance = data[0];
             return data[0].refresh(); // have to refresh (get ETag) to be editable.
           }
           that.options.attr('new_object_form', true);
-          that.options.attr('instance', new that.options.model(params));
-          return instance;
+          that.instance = new optionsModel(params);
+          return that.instance;
         }).done(function () {
           // Check if modal was closed
           if (that.element !== null) {
@@ -322,12 +349,14 @@ export default can.Control({
         });
       }
     } else {
-      this.options.attr('instance', new can.Observe(params));
-      that.on();
-      dfd = new $.Deferred().resolve(instance);
+      this.instance = new can.Observe(params);
+      this.on();
+      dfd = new $.Deferred().resolve(this.instance);
     }
 
     dfd.then(function () {
+      let instance = that.instance;
+
       if (instance &&
         _.exists(instance, 'class.is_custom_attributable') &&
         !(instance instanceof CMS.Models.Assessment)) {
@@ -358,16 +387,16 @@ export default can.Control({
       // This is to trigger `focus_first_element` in modal_ajax handling
       this.element.trigger('loaded');
     }
-    if (!this.options.instance._transient) {
-      this.options.instance.attr('_transient', new can.Observe({}));
+    if (!this.instance._transient) {
+      this.instance.attr('_transient', new can.Observe({}));
     }
-    if (this.options.instance.form_preload) {
-      preloadDfd = this.options.instance.form_preload(
+    if (this.instance.form_preload) {
+      preloadDfd = this.instance.form_preload(
         this.options.new_object_form,
         this.options.object_params);
       if (preloadDfd) {
         preloadDfd.then(function () {
-          this.options.instance.backup();
+          this.instance.backup();
         }.bind(this))
       }
     }
@@ -454,7 +483,7 @@ export default can.Control({
 
   'input:not(isolate-form input), textarea:not(isolate-form textarea), select:not(isolate-form select) change':
     function (el, ev) {
-      this.options.instance.removeAttr('_suppress_errors');
+      this.instance.removeAttr('_suppress_errors');
       // Set the value if it isn't a search field
       if (!el.hasClass('search-icon') ||
         el.is('[null-if-empty]') &&
@@ -485,7 +514,7 @@ export default can.Control({
    * @param {$.Event} ev - the event object
    */
   'dropdown[data-purpose="ca-type"] change': function ($el, ev) {
-    var instance = this.options.instance;
+    let instance = this.instance;
 
     if (instance.attribute_type !== 'Dropdown') {
       instance.attr('multi_choice_options', undefined);
@@ -500,10 +529,10 @@ export default can.Control({
     can.each($elements.toArray(), this.proxy('set_value_from_element'));
   },
   set_value_from_element: function (el) {
-    var name;
-    var value;
-    var cb;
-    var instance = this.options.instance;
+    let instance = this.instance;
+    let name;
+    let value;
+    let cb;
     el = el instanceof jQuery ? el : $(el);
     name = el.attr('name');
     value = el.val();
@@ -540,14 +569,14 @@ export default can.Control({
     }
   },
   set_value: function (item) {
-    var instance = this.options.instance;
-    var name = item.name.split('.');
-    var $elem;
-    var value;
-    var model;
-    var $other;
-    var listPath;
-    var cur;
+    let instance = this.instance;
+    let name = item.name.split('.');
+    let $elem;
+    let value;
+    let model;
+    let $other;
+    let listPath;
+    let cur;
 
     // Don't set `_wysihtml5_mode` on the instances
     if (item.name === '_wysihtml5_mode') {
@@ -555,7 +584,7 @@ export default can.Control({
     }
 
     if (!(instance instanceof this.options.model)) {
-      instance = this.options.instance =
+      instance = this.instance =
         new this.options.model(instance && instance.serialize ?
           instance.serialize() : instance);
     }
@@ -637,7 +666,7 @@ export default can.Control({
         }
       } else if (name[name.length - 1] === 'time') {
         name.pop(); // time is a pseudoproperty of datetime objects
-        value = moment(this.options.instance.attr(name.join('.')))
+        value = moment(this.instance.attr(name.join('.')))
           .startOf('day').add(parseInt(value, 10)).toDate();
       } else {
         value = new can.Observe({}).attr(name.slice(1).join('.'), value);
@@ -1016,7 +1045,9 @@ export default can.Control({
 
     this.resetCAFields(newInstance.attr('custom_attribute_definitions'));
 
-    $.when(this.options.attr('instance', newInstance))
+    this.instance = newInstance;
+
+    $.when(this.instance)
       .done(function () {
         this.reset_form(function () {
           var $form = $(this.element).find('form');
@@ -1061,9 +1092,10 @@ export default can.Control({
   },
 
   prepareInstance: function () {
-    var params = this.find_params();
-    var instance = new this.options.model(params);
-    var saveContactModels = ['TaskGroup', 'TaskGroupTask'];
+    let params = this.find_params();
+    let optionsModel = this.options.model;
+    let instance = optionsModel ? new optionsModel(params) : new can.Observe();
+    let saveContactModels = ['TaskGroup', 'TaskGroupTask'];
 
     instance.attr('_suppress_errors', true)
       .attr('custom_attribute_definitions',
@@ -1078,14 +1110,42 @@ export default can.Control({
     return instance;
   },
 
+  getExtendedInstance: function ({targetInstance, originalInstance, model, updateStore = false}) {
+    let serializedInstance = originalInstance.serialize ?
+      originalInstance.serialize() : originalInstance;
+
+    const extendedInstance = Object.keys(serializedInstance).reduce((accumulator, key) => {
+      accumulator.attr(key, serializedInstance[key]);
+
+      return accumulator;
+    }, targetInstance);
+
+    if (model && updateStore) {
+      this.setOriginalInstanceToStore(model, originalInstance)
+    }
+
+    return extendedInstance;
+  },
+
+  setOriginalInstanceToStore: function (model, originalInstance) {
+    let id = originalInstance.id;
+
+    if (!model || !model.store || !id) {
+      return;
+    }
+
+    model.store[id] = originalInstance;
+  },
+
   save_instance: function (el, ev) {
-    var that = this;
-    var instance = this.options.instance;
-    var ajd;
-    var instanceId = instance.id;
-    var params;
-    var type;
-    var name;
+    let that = this;
+    let instance = this.instance;
+    let instanceId = instance.id;
+    let optionsInstance = this.options.instance;
+    let ajd;
+    let params;
+    let type;
+    let name;
 
     if (instance.errors()) {
       instance.removeAttr('_suppress_errors');
@@ -1103,7 +1163,14 @@ export default can.Control({
 
     this.disable_hide = true;
 
-    ajd = instance.save();
+    if (!this.options.new_object_form) {
+      optionsInstance = this.getExtendedInstance({
+        targetInstance: optionsInstance,
+        originalInstance: instance
+      });
+    }
+
+    ajd = optionsInstance.save();
     ajd.fail(this.save_error.bind(this))
       .done(function (obj) {
         function finish() {
@@ -1205,14 +1272,20 @@ export default can.Control({
   },
 
   destroy: function () {
+    let instance = this.instance;
+    let optionsInstance = this.options.instance;
+
     if (this.options.model && this.options.model.cache) {
       delete this.options.model.cache[undefined];
     }
     if (this._super) {
       this._super.apply(this, arguments);
     }
-    if (this.options.instance && this.options.instance._transient) {
-      this.options.instance.removeAttr('_transient');
+    if (instance && instance._transient) {
+      instance.removeAttr('_transient');
+    }
+    if (optionsInstance && optionsInstance._transient) {
+      optionsInstance.removeAttr('_transient');
     }
   },
 
@@ -1233,8 +1306,8 @@ export default can.Control({
       return;
     }
 
-    if (this.options.instance.getHashFragment) {
-      hash = this.options.instance.getHashFragment();
+    if (this.instance.getHashFragment) {
+      hash = this.instance.getHashFragment();
       if (hash) {
         window.location.hash = hash;
         return;
@@ -1248,9 +1321,9 @@ export default can.Control({
       .control();
 
     hash += [treeController ? treeController.hash_fragment() : '',
-      this.options.instance.hash_fragment()].join('/');
+      this.instance.hash_fragment()].join('/');
 
-    hash = this.updateSummaryHash(hash, this.options.instance.type);
+    hash = this.updateSummaryHash(hash, this.instance.type);
     window.location.hash = hash;
   },
 

--- a/src/ggrc/assets/mustache/assessments/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessments/modal_content.mustache
@@ -132,13 +132,13 @@
         <div class="ggrc-form-item__row">
           <ggrc-modal-connector
                   class="width-100"
-                  parent_instance="instance"
-                  instance="instance"
+                  parent_instance="optionsInstance"
+                  instance="optionsInstance"
                   mapping="related_objects_as_source"
                   custom-related-loader="true"
                   {list}="mappedObjects"
-                  {type}="instance.assessment_type"
-                  {new-instance}="instance.isNew"
+                  {type}="optionsInstance.assessment_type"
+                  {new-instance}="optionsInstance.isNew"
                   deferred="true"
                   {^changes}="mappedObjectsChanges">
             <label class="ggrc-form-item__label">


### PR DESCRIPTION
# Issue description

This issue is actual for any modal in edit mode. In case of having modal in edit mode and changing a field's value it's possible to see that the value for the same field at the original page is changed too.

# Steps to test the changes

1. Create an instance (control, assessment, etc.)
2. Invoke edit modal (control, assessment, etc.) window
3. While typing a field's value (for example: description) look at the same field at the page: the same value is shown

# Solution description

## Technical description of the issue
Modals controller contains `instance` field. Looks like initially it was designed to create and handle own instance. Actually modals controller uses `instance` from `options` directly and methods like `set_value`, `set_value_from_element`, etc. change it instead of using own `instance` of the controller. This is the reason why during typing a new value for any field it will be applied not only for the modal in edit mode but also for the page from which this modal was invoked. Also this makes modals controller tightly coupled with `options.instance`.

## Solution
The idea is to use own `instance` of the modals controller instead of changing `instance` from `options` directly. This allows to decouple modals controller and `options.instance`. During initialization phase in `fetch_data` own instance is created and shallow fields of `options.instance` are copied. On save the fields from own `instance` are copied to `options.instance` back.

## Another attempts to solve this issue
- Create own instance in `init` method only. In such a case `options.instance` will be passed in `fetch_templates` method and there will be no synchronization between own `instance` and `options.instance`.
- Save own `instance` in `save_instance` method instead of copying the fields from own instance to `options.instance`. It works for a lot of pages like control, program, etc. but it does not work some pages like assessment. After investigation I found that assessment contains event listeners and they are added to `options.instance`.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

# TODO

- [ ] Locally some automation (ui) tests were failed and I am going to investigate the reason
