### PR TITLE
GGRC-4626 Add 'Is empty' option to advanced search

### DIFF
--- a/src/ggrc-client/js/components/advanced-search/advanced-search-filter-attribute.js
+++ b/src/ggrc-client/js/components/advanced-search/advanced-search-filter-attribute.js
@@ -12,6 +12,12 @@ import template from './advanced-search-filter-attribute.mustache';
  */
 let viewModel = can.Map.extend({
   define: {
+    isUnary: {
+      get() {
+        let operator = this.attr('attribute.operator');
+        return operator === 'is';
+      },
+    },
     /**
      * Contains available attributes for specific model.
      * Initializes component with first attribute in the list.
@@ -83,6 +89,16 @@ export default can.Component.extend({
     '{viewModel} availableAttributes': function (ev, desc, attributes) {
       if (attributes[0] && attributes[0].attr_title) {
         this.viewModel.attr('attribute.field', attributes[0].attr_title);
+      }
+    },
+    '{viewModel.attribute} operator'(attribute, ev, newValue, oldValue) {
+      if (newValue === 'is') {
+        attribute.attr('value', 'empty');
+        return;
+      }
+      if (oldValue === 'is') {
+        attribute.attr('value', '');
+        return;
       }
     },
   },

--- a/src/ggrc-client/js/components/advanced-search/advanced-search-filter-attribute.mustache
+++ b/src/ggrc-client/js/components/advanced-search/advanced-search-filter-attribute.mustache
@@ -21,16 +21,19 @@
       <option value="&lt;=">Lesser than or equals</option>
       <option value="&gt;">Greater than</option>
       <option value="&gt;=">Greater than or equals</option>
+      <option value="is">Is empty</option>
     </select>
   </div>
-  <div class="filter-attribute__value">
-    <input tabindex="3"
-      placeholder="Type here..."
-      name="right"
-      type="text"
-      {($value)}="attribute.value"
-      ($enter)='setValue($element)'>
-  </div>
+  {{^if isUnary}}
+    <div class="filter-attribute__value">
+      <input tabindex="3"
+        placeholder="Type here..."
+        name="right"
+        type="text"
+        {($value)}="attribute.value"
+        ($enter)='setValue($element)'>
+    </div>
+  {{/if}}
   {{#if showActions}}
   <div class="filter-attribute__action">
     <button class="filter-attribute__remove" ($click)="remove()"><i class="fa fa-trash"></i></button>

--- a/src/ggrc-client/js/components/advanced-search/tests/advanced-search-filter-attribute_spec.js
+++ b/src/ggrc-client/js/components/advanced-search/tests/advanced-search-filter-attribute_spec.js
@@ -9,9 +9,11 @@ describe('GGRC.Components.advancedSearchFilterAttribute', function () {
   'use strict';
 
   let viewModel;
+  let events;
 
   beforeEach(() => {
     viewModel = new Component.prototype.viewModel();
+    events = Component.prototype.events;
   });
 
   describe('availableAttributes set() method', function () {
@@ -67,5 +69,56 @@ describe('GGRC.Components.advancedSearchFilterAttribute', function () {
 
       expect(viewModel.attr('attribute').value).toBe('new value');
     });
+  });
+
+  describe('isUnary get() method', function () {
+    it('returns false if attribute.operator value is not "is"', function () {
+      viewModel.attr('attribute.operator', '!=');
+
+      let result = viewModel.attr('isUnary');
+
+      expect(result).toBe(false);
+    });
+
+    it('returns true if attribute.operator value is "is"', function () {
+      viewModel.attr('attribute.operator', 'is');
+
+      let result = viewModel.attr('isUnary');
+
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('"{viewModel.attribute} operator" handler', function () {
+    let that;
+    let handler;
+    beforeEach(function () {
+      that = {
+        viewModel: viewModel,
+      };
+      handler = events['{viewModel.attribute} operator'];
+    });
+
+    it(`sets attribute.value to "empty" if new attribute.operator
+    value is "is"`,
+      function () {
+        viewModel.attr('attribute.value', 'value');
+
+        handler.call(that, viewModel.attribute, {}, 'is');
+
+        let result = viewModel.attr('attribute.value');
+        expect(result).toEqual('empty');
+      });
+
+    it(`sets attribute.value to empty string if previous attribute.operator
+    value was "is"`,
+      function () {
+        viewModel.attr('attribute.value', 'value');
+
+        handler.call(that, viewModel.attribute, {}, 'val', 'is');
+
+        let result = viewModel.attr('attribute.value');
+        expect(result).toEqual('');
+      });
   });
 });


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Need 'is empty' as an advanced search option.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
