### PR TITLE
GGRC-3488 Correct comments relationship in Commentable mixin

### DIFF
--- a/src/ggrc/models/comment.py
+++ b/src/ggrc/models/comment.py
@@ -114,16 +114,32 @@ class Commentable(object):
   @declared_attr
   def comments(cls):  # pylint: disable=no-self-argument
     """Comments related to self via Relationship table."""
-    comment_id = case(
-        [(Relationship.destination_type == "Comment",
-          Relationship.destination_id)],
-        else_=Relationship.source_id,
-    )
-    commentable_id = case(
-        [(Relationship.destination_type == "Comment",
-          Relationship.source_id)],
-        else_=Relationship.destination_id,
-    )
+    comment_id = case([
+        (
+            Relationship.destination_type == "Comment",
+            Relationship.destination_id
+        ),
+        (
+            Relationship.source_type == "Comment",
+            Relationship.source_id
+        )
+    ])
+    commentable_id = case([
+        (
+            sa.and_(
+                Relationship.source_type == cls.__name__,
+                Relationship.destination_type == "Comment",
+            ),
+            Relationship.source_id
+        ),
+        (
+            sa.and_(
+                Relationship.source_type == "Comment",
+                Relationship.destination_type == cls.__name__,
+            ),
+            Relationship.destination_id
+        ),
+    ])
 
     return db.relationship(
         Comment,

--- a/test/integration/ggrc/models/mixins/test_commentable.py
+++ b/test/integration/ggrc/models/mixins/test_commentable.py
@@ -1,0 +1,37 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Integration tests for Commentable mixin."""
+
+from ggrc.models import all_models
+
+from integration.ggrc import TestCase
+from integration.ggrc.models import factories
+
+
+class TestCommentableMixin(TestCase):
+  """Test cases for Commentable mixin."""
+
+  def setUp(self):
+    super(TestCommentableMixin, self).setUp()
+    self.client.get("/login")
+
+  def test_asmnt_comments(self):
+    """Test if assessment has proper comments."""
+    # This test check bug which is reproduced when ids of Audit, Assessment
+    # and Comment are the same
+    with factories.single_commit():
+      audit = factories.AuditFactory()
+      for i in range(3):
+        assessment = factories.AssessmentFactory(id=audit.id + i, audit=audit)
+        factories.RelationshipFactory(source=assessment, destination=audit)
+        comment = factories.CommentFactory(
+            id=audit.id + i,
+            description="test{0}".format(i)
+        )
+        factories.RelationshipFactory(source=assessment, destination=comment)
+
+    asmnt_comments = all_models.Assessment.query.first().comments
+
+    self.assertEquals(1, len(asmnt_comments))
+    self.assertEquals("test0", "".join(c.description for c in asmnt_comments))


### PR DESCRIPTION
# Issue description

Commentable objects like Assessment have extra comments in `comments` property. This issue leads to creation of huge amount of data in `fulltext_record_properties`. Commentable objects (that even don't have any comments) have concatenated comments from other objects there. It takes significant amount of memory and extra time for reindexation.

# Steps to test the changes

0. On a clean DB (the issue depends on object ids)
1. Create two Assessments.
2. Write one comment for each Assessment.
3. In Python REPL, run `from ggrc import app ; from ggrc.models import all_models ; print all_models.Assessment.query.first().comments`

# Solution description

Check source and destination types for relationships with comments.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

