### PR TITLE
QUICK-FIX Prevent unequal load on pytest-xdist's nodes

### DIFF
--- a/test/selenium/src/lib/custom_pytest_scheduling.py
+++ b/test/selenium/src/lib/custom_pytest_scheduling.py
@@ -14,9 +14,14 @@ class CustomPytestScheduling(LoadScheduling):
   running in parallel.
   A test is marked as destructive by starting its name with "test_destructive".
   """
+  NUMBER_TO_PREVENT_UNEQUAL_LOAD = 3
 
   def _send_tests(self, node, num):
     idxs_to_send = []
+    if len(self.node2pending[node]) >= self.NUMBER_TO_PREVENT_UNEQUAL_LOAD:
+      # There are already enough tests. Do not schedule more to prevent
+      # unequal load on nodes.
+      return
     for idx, test_name in enumerate(self.collection):
       if self._is_destructive_test(test_name) and idx in self.pending:
         idxs_to_send.append(idx)

--- a/test/selenium/src/tests/test_snapshots.py
+++ b/test/selenium/src/tests/test_snapshots.py
@@ -497,7 +497,7 @@ class TestSnapshots(base.Test):
            "Via Tree View item (map snapshoted Control to Issue using "
            "Assessment with mapped snapshoted Control)"],
       indirect=["dynamic_objects", "dynamic_relationships"])
-  def test_mapping_of_objects_to_snapshots(
+  def test_destructive_mapping_of_objects_to_snapshots(
       self, create_audit_with_control_and_update_control,
       is_via_tw_map_btn_not_item, expected_snapshoted_control, dynamic_objects,
       dynamic_relationships, selenium


### PR DESCRIPTION
"_send_tests" is executed from pytest-xdist's "schedule" method.
It contains the following code:
```python
    initial_batch = max(len(self.pending) // 4, 2 * len(self.nodes))

    # distribute tests round-robin up to the batch size
    # (or until we run out)
    nodes = cycle(self.nodes)
    for i in range(initial_batch):
      self._send_tests(next(nodes), 1)
```
This causes tests too many tests to be scheduled to destructive node.

# Sanity checklist

- [ ] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
