### PR TITLE
GGRC-4845 Highlight empty person groups in revision comparer

### DIFF
--- a/src/ggrc-client/js/components/snapshotter/revisions-comparer.js
+++ b/src/ggrc-client/js/components/snapshotter/revisions-comparer.js
@@ -529,12 +529,28 @@ export default can.Component.extend({
         let $oldGrantees = $blockOld.find('person-list-item');
         let $newGrantees = $blockNew.find('person-list-item');
 
-        oldUserIds = extractPeopleIds($oldGrantees);
-        newUserIds = extractPeopleIds($newGrantees);
+        if ($oldGrantees.length && !$newGrantees.length ||
+          $newGrantees.length && !$oldGrantees.length) {
+          highlightBlock($blockOld);
+          highlightBlock($blockNew);
+        } else {
+          oldUserIds = extractPeopleIds($oldGrantees);
+          newUserIds = extractPeopleIds($newGrantees);
 
-        // now we have a list of old and new person IDs
-        highlightChanges($oldGrantees, newUserIds);
-        highlightChanges($newGrantees, oldUserIds);
+          // now we have a list of old and new person IDs
+          highlightPersons($oldGrantees, newUserIds);
+          highlightPersons($newGrantees, oldUserIds);
+        }
+      }
+
+      /**
+       * Highlight block of grants of a particular custom role.
+       *
+       * @param {jQuery} $block - a DOM element containing a list of
+       *   people that have a particular custom role.
+       */
+      function highlightBlock($block) {
+        $block.find('object-list').addClass(HIGHLIGHT_CLASS);
       }
 
       /**
@@ -564,7 +580,7 @@ export default can.Component.extend({
        *   referential list of grants of a particular custom role. The changes
        *   in role assignments are calculated against this list.
        */
-      function highlightChanges($grantees, comparisonIds) {
+      function highlightPersons($grantees, comparisonIds) {
         $grantees.each(function (i, grantee) {
           let $grantee = $(grantee);
           let personId = $grantee.viewModel().attr('person.id');

--- a/src/ggrc-client/js/components/snapshotter/tests/revisions-comparer_spec.js
+++ b/src/ggrc-client/js/components/snapshotter/tests/revisions-comparer_spec.js
@@ -637,4 +637,59 @@ describe('GGRC.Components.revisionsComparer', function () {
       });
     });
   });
+
+  describe('"highlightCustomRoles" method', () => {
+    const highlightSelector = '.diff-highlighted';
+    const blockSelector = 'object-list';
+
+    describe('compareRoleBlocks() method', () => {
+      let $blockEmpty;
+      let $blockNotEmpty;
+      let $target;
+      let $rolesPanes;
+
+      beforeEach(() => {
+        $blockEmpty = $(`<div>
+                          <related-people-access-control-group>
+                              <object-list>
+                                <div class="object-list__item-empty">
+                                  None
+                                </div>
+                              </object-list>
+                          </related-people-access-control-group>
+                        </div>`);
+        $blockNotEmpty = $(`<div>
+                            <related-people-access-control-group>
+                              <object-list>
+                                  <person-list-item>
+                                  </person-list-item>
+                              </object-list>
+                            </related-people-access-control-group>
+                          </div>`);
+        $target = {find: () => {}};
+      });
+
+      it(`highlights blocks of grants if list of people was empty
+        in the old revision`, () => {
+          $rolesPanes = $blockEmpty.add($blockNotEmpty);
+          spyOn($target, 'find').and.returnValue($rolesPanes);
+
+          viewModel.highlightCustomRoles($target);
+
+          expect($rolesPanes.find(`${blockSelector}${highlightSelector}`)
+            .length).toEqual(2);
+        });
+
+      it(`highlights blocks of grants if list of people is empty
+        in the new revision`, () => {
+          $rolesPanes = $blockNotEmpty.add($blockEmpty);
+          spyOn($target, 'find').and.returnValue($rolesPanes);
+
+          viewModel.highlightCustomRoles($target);
+
+          expect($rolesPanes.find(`${blockSelector}${highlightSelector}`)
+            .length).toEqual(2);
+        });
+    });
+  });
 });

--- a/src/ggrc-client/styles/modules/_modal.scss
+++ b/src/ggrc-client/styles/modules/_modal.scss
@@ -747,6 +747,7 @@
         }
         .diff-highlighted{
           display: block;
+          box-sizing: border-box;
           width: 100%;
           max-width: 100%;
           position: relative;


### PR DESCRIPTION
# Issue description

If user added a new person to custom role field, it is not colored in Comparison window 

# Steps to test the changes

Steps to reproduce:
1. Open any program page
2. Create a new control and audit
3. Update control: add a person to 'Primary contacts' 
4. Open audit page > Controls tab
5. Expand Info pane and click 'Get the latest version' link
*Actual Result:* 
- new added person is not colored that it was added
*Expected Result:* If user added a new person to custom role field, it should be colored in the comparison window

# Solution description

Check whether there are empty groups, if yes - highlight them.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
