### PR TITLE
GGRC-4569 Disable set up of custom slug through the api

### DIFF
--- a/src/ggrc/models/mixins/__init__.py
+++ b/src/ggrc/models/mixins/__init__.py
@@ -491,7 +491,9 @@ class Slugged(Base):
     return ()
 
   # REST properties
-  _api_attrs = reflection.ApiAttributes('slug')
+  _api_attrs = reflection.ApiAttributes(
+      reflection.Attribute('slug', create=False, update=False),
+  )
   _fulltext_attrs = ['slug']
   _sanitize_html = ['slug']
   _aliases = {

--- a/test/integration/ggrc/converters/test_import_csv.py
+++ b/test/integration/ggrc/converters/test_import_csv.py
@@ -202,7 +202,7 @@ class TestBasicCsvImport(TestCase):
 
   def test_duplicate_people_objective(self):
     """Test duplicate error that causes request to fail."""
-    self.generator.generate_object(models.Objective, {"slug": "objective1"})
+    factories.ObjectiveFactory(slug="objective1")
     filename = "duplicate_object_person_objective_error.csv"
     response = self.import_file(filename)[0]
 

--- a/test/integration/ggrc/models/factories.py
+++ b/test/integration/ggrc/models/factories.py
@@ -500,6 +500,12 @@ class ProjectFactory(TitledFactory):
     model = all_models.Project
 
 
+class HelpFactory(TitledFactory):
+
+  class Meta:
+    model = all_models.Help
+
+
 class ImportExportFactory(ModelFactory):
 
   class Meta:
@@ -523,17 +529,19 @@ def get_model_factory(model_name):
       "Clause": ClauseFactory,
       "Contract": ContractFactory,
       "Control": ControlFactory,
-      "TaskGroupFactory": wf_factories.TaskGroupFactory,
-      "TaskGroupObjectFactory": wf_factories.TaskGroupObjectFactory,
-      "TaskGroupTaskFactory": wf_factories.TaskGroupTaskFactory,
-      "CycleFactory": wf_factories.CycleFactory,
-      "CycleTaskGroupFactory": wf_factories.CycleTaskGroupFactory,
-      "CycleTaskFactory": wf_factories.CycleTaskFactory,
-      "CycleTaskEntryFactory": wf_factories.CycleTaskEntryFactory,
+      "Directive": DirectiveFactory,
+      "TaskGroup": wf_factories.TaskGroupFactory,
+      "TaskGroupObject": wf_factories.TaskGroupObjectFactory,
+      "TaskGroupTask": wf_factories.TaskGroupTaskFactory,
+      "Cycle": wf_factories.CycleFactory,
+      "CycleTaskGroup": wf_factories.CycleTaskGroupFactory,
+      "CycleTaskGroupObjectTask": wf_factories.CycleTaskFactory,
+      "CycleTaskEntry": wf_factories.CycleTaskEntryFactory,
       "DataAsset": DataAssetFactory,
       "Facility": FacilityFactory,
       "Issue": IssueFactory,
       "IssueTrackerIssue": IssueTrackerIssueFactory,
+      "Help": HelpFactory,
       "Label": LabelFactory,
       "ObjectLabel": ObjectLabelFactory,
       "Market": MarketFactory,

--- a/test/integration/ggrc/models/mixins/test_autostatuschangable.py
+++ b/test/integration/ggrc/models/mixins/test_autostatuschangable.py
@@ -192,8 +192,6 @@ class TestFirstClassAttributes(TestMixinAutoStatusChangeableBase):
       ('notes', 'new note', models.Assessment.FINAL_STATE),
       ('description', 'some description', models.Assessment.DONE_STATE),
       ('description', 'some description', models.Assessment.FINAL_STATE),
-      ('slug', 'some code', models.Assessment.DONE_STATE),
-      ('slug', 'some code', models.Assessment.FINAL_STATE),
       ('start_date', '2020-01-01', models.Assessment.DONE_STATE),
       ('start_date', '2020-01-01', models.Assessment.FINAL_STATE),
       ('design', 'Effective', models.Assessment.DONE_STATE),

--- a/test/integration/ggrc/models/mixins/test_slugged.py
+++ b/test/integration/ggrc/models/mixins/test_slugged.py
@@ -1,0 +1,65 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Integration test for Slugged mixin."""
+
+import ddt
+
+from ggrc.models import mixins, all_models
+
+from integration.ggrc import api_helper
+from integration.ggrc.query_helper import WithQueryApi
+from integration.ggrc import TestCase
+from integration.ggrc.models import factories
+
+# Don't include 'Directive', 'SystemOrProcess' and 'Help' as
+# we don't work directly with their instances.
+SLUGGED_MODELS = [
+    m for m in all_models.all_models
+    if issubclass(m, mixins.Slugged) and
+    m.__name__ not in ("Directive", "SystemOrProcess", "Help")
+]
+
+
+@ddt.ddt
+class TestSluggedMixin(WithQueryApi, TestCase):
+  """Test cases for Slugged mixin."""
+
+  def setUp(self):
+    super(TestSluggedMixin, self).setUp()
+    self.client.get("/login")
+    self.api = api_helper.Api()
+
+  @ddt.data(*SLUGGED_MODELS)
+  def test_not_updatable_slug_via_api(self, model):
+    """Test that slug isn't updatable via REST API for {}"""
+    obj = factories.get_model_factory(model.__name__)()
+    obj_slug = obj.slug
+
+    response = self.api.put(obj, {"slug": factories.random_str()})
+    self.assert200(response)
+    response_slug = response.json.get(
+        model._inflector.table_singular, {}
+    ).get("slug")
+    self.assertEqual(obj_slug, response_slug)
+    db_slug = model.query.first().slug
+    self.assertEqual(obj_slug, db_slug)
+
+  def test_not_createble_slug_via_api(self):
+    """Test that slug isn't creatable via REST API"""
+    # All slug handling is located in mixin, so behavior of slugged models
+    # will be the same and testing of one model is enough
+    response = self.api.post(all_models.Control, {
+        "control": {
+            "slug": factories.random_str(),
+            "title": "Control title",
+            "context": None,
+        },
+    })
+    self.assertEqual(response.status_code, 201)
+    response_slug = response.json.get("control").get("slug")
+    control = all_models.Control.query.get(
+        response.json.get("control").get("id")
+    )
+    self.assertEqual(control.slug, response_slug)
+    self.assertEqual("CONTROL-{}".format(control.id), control.slug)

--- a/test/integration/ggrc/services/test_revision_history.py
+++ b/test/integration/ggrc/services/test_revision_history.py
@@ -217,9 +217,9 @@ class TestRevisionHistory(TestCase):
   @ddt.data(
       {"factory": factories.ControlFactory,
        "fields": ['test_plan', 'status', 'notes',
-                  'description', 'title', 'slug', 'folder']},
+                  'description', 'title', 'folder']},
       {"factory": factories.RiskFactory,
-       "fields": ['test_plan', 'status', 'notes', 'title', 'slug']},
+       "fields": ['test_plan', 'status', 'notes', 'title']},
   )
   @ddt.unpack
   def test_get_mandatory_fields(self, factory, fields):

--- a/test/integration/ggrc_workflows/services/test_cycle_task_deprecated.py
+++ b/test/integration/ggrc_workflows/services/test_cycle_task_deprecated.py
@@ -23,7 +23,7 @@ class TestCycleTaskDeprecated(TestCase):
 
   def test_redefine_status(self):
     """Test cycle task create and change status to Deprecated."""
-    cycle_task = factories.get_model_factory("CycleTaskFactory")()
+    cycle_task = factories.get_model_factory("CycleTaskGroupObjectTask")()
 
     with freeze_time("2017-01-25"):
       self.api.modify_object(cycle_task, {
@@ -39,7 +39,7 @@ class TestCycleTaskDeprecated(TestCase):
 
   def test_keep_date_unchanged(self):
     """Test set status to Deprecated, and then set status to Finished."""
-    cycle_task = factories.get_model_factory("CycleTaskFactory")()
+    cycle_task = factories.get_model_factory("CycleTaskGroupObjectTask")()
 
     with freeze_time("2017-01-25"):
       self.api.modify_object(cycle_task, {
@@ -61,7 +61,7 @@ class TestCycleTaskDeprecated(TestCase):
 
   def test_repeat_deprecated_state(self):
     """Test updating of last deprecated date by multiply changing of status."""
-    cycle_task = factories.get_model_factory("CycleTaskFactory")()
+    cycle_task = factories.get_model_factory("CycleTaskGroupObjectTask")()
 
     with freeze_time("2017-01-25"):
       self.api.modify_object(cycle_task, {
@@ -93,7 +93,9 @@ class TestCycleTaskDeprecated(TestCase):
     """Test filter cycle task by last deprecated date."""
     amount_of_cycle_tasks = 5
     list_of_ids = []
-    cycle_task_factory = factories.get_model_factory("CycleTaskFactory")
+    cycle_task_factory = factories.get_model_factory(
+        "CycleTaskGroupObjectTask"
+    )
     with factories.single_commit():
       with freeze_time("2017-01-25"):
         for _ in range(amount_of_cycle_tasks):
@@ -123,7 +125,9 @@ class TestCycleTaskDeprecated(TestCase):
     """Test sorting results of filter cycle tasks by deprecated date."""
     dict_of_dates = {}
     date_list = ["2017-01-25", "2017-01-29", "2017-01-02", "2017-01-26"]
-    cycle_task_factory = factories.get_model_factory("CycleTaskFactory")
+    cycle_task_factory = factories.get_model_factory(
+        "CycleTaskGroupObjectTask"
+    )
     with factories.single_commit():
       for date in date_list:
         with freeze_time(date):


### PR DESCRIPTION
- [ ] on_hold until PR for GGRC-4840 will be merged

# Issue description

BE shouldn't allow to set up custom Code value for new or existing objects.
BE shouldn't allow to edit Code.

# Steps to test the changes

Update Code of any slugged object through the api.
Create any slugged object with custom code through the api.
Expected result: Object has automatically created slug.

# Solution description

Set update/create api attributes for slug to false.

# Sanity checklist

- [ ] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
