### PR TITLE
GGRC-4779 Set tabindex on select tag instead of custom component

### DIFF
--- a/src/ggrc-client/js/components/dropdown/dropdown.js
+++ b/src/ggrc-client/js/components/dropdown/dropdown.js
@@ -72,6 +72,7 @@ import template from './dropdown.mustache';
       noValueLabel: '@',
       controlId: '@',
       isGroupedDropdown: false,
+      tabIndex: 0,
       /*
         Options list should be an `array` of object containing `title` and `value`
         [{

--- a/src/ggrc-client/js/components/dropdown/dropdown.mustache
+++ b/src/ggrc-client/js/components/dropdown/dropdown.mustache
@@ -4,7 +4,7 @@
 }}
 
 <select
-  tabindex="0"
+  tabindex="{{tabIndex}}"
   class="{{firstnonempty className 'input-block-level'}}"
   can-value="{{name}}"
   null-if-empty="null-if-empty"

--- a/src/ggrc/assets/mustache/controls/modal_content.mustache
+++ b/src/ggrc/assets/mustache/controls/modal_content.mustache
@@ -189,10 +189,12 @@
           <i class="fa fa-question-circle" rel="tooltip" title="Indicates the status of this object."></i>
           <a data-id="hide_state_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
         </label>
+
           <dropdown options-list="model.statuses"
                     name="instance.status"
-                    tabindex="14">
+                    tab-index="14">
           </dropdown>
+        
       </div>
     </div>
   </div>


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Propose button is enabled if click Hide all optional fields.

# Steps to test the changes

1. Open any Control Info page
2. Click on Propose Changes
3. Click on Hide optional fields button
4. Look at the Propose button: is enabled but no changes were made

**Actual Result:** Propose button is enabled if click Hide all optional fields
**Expected Result:** Propose button should be disabled if click Hide all optional fields and if no proposal were made by user

# Solution description

If `tabindex` is set on can component, canjs adds additional property to the instance (in case with control dropdown `"-1":"14"`) after element hiding and setting `tabindex="-1"`

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [ ] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
