### PR TITLE
GGRC-3367 Last assessment date is not shown in csv file after exporting Control/Objective snapshots

### DIFF
--- a/src/ggrc/converters/base_block.py
+++ b/src/ggrc/converters/base_block.py
@@ -386,7 +386,7 @@ class BlockConverter(object):
     self.fields = get_column_order(fields)
 
   def generate_csv_header(self):
-    """ Generate 2D array with csv headre description """
+    """ Generate 2D array with csv header description """
     headers = []
     for field in self.fields:
       description = self.object_headers[field]["description"]

--- a/src/ggrc/converters/snapshot_block.py
+++ b/src/ggrc/converters/snapshot_block.py
@@ -113,7 +113,8 @@ class SnapshotBlockConverter(object):
     content["slug"] = u"*{}".format(content["slug"])
     content["revision_date"] = unicode(snapshot.revision.created_at)
     if snapshot.last_assessment_date:
-      content["last_assessment_date"] = snapshot.last_assessment_date.isoformat()
+      content["last_assessment_date"] = \
+          snapshot.last_assessment_date.isoformat()
     if self.MAPPINGS_KEY in self.fields:
       content.update(self._generate_mapping_content(snapshot))
     return content

--- a/src/ggrc/converters/snapshot_block.py
+++ b/src/ggrc/converters/snapshot_block.py
@@ -29,6 +29,7 @@ class SnapshotBlockConverter(object):
   DATE_FIELDS = {
       "start_date",
       "end_date",
+      "last_assessment_date",
   }
 
   CUSTOM_SNAPSHOT_ALIASES = {
@@ -111,6 +112,8 @@ class SnapshotBlockConverter(object):
     content["audit"] = {"type": "Audit", "id": snapshot.parent_id}
     content["slug"] = u"*{}".format(content["slug"])
     content["revision_date"] = unicode(snapshot.revision.created_at)
+    if snapshot.last_assessment_date:
+      content["last_assessment_date"] = snapshot.last_assessment_date.isoformat()
     if self.MAPPINGS_KEY in self.fields:
       content.update(self._generate_mapping_content(snapshot))
     return content

--- a/test/integration/ggrc/data_platform/test_last_assessment_date.py
+++ b/test/integration/ggrc/data_platform/test_last_assessment_date.py
@@ -214,6 +214,35 @@ class TestLastAssessmentDate(TestCase):
         f_date = ""
       self.assertEqual(control["Last Assessment Date"], f_date)
 
+  def test_export_lad_snapshot(self):
+    """Check export Last Assessment Date."""
+    finish_date = datetime.datetime(2017, 2, 20, 13, 40, 0)
+    finish_date_str = finish_date.strftime("%m/%d/%Y")
+    related_objects = {"*Control_1", "*Control_2"}
+
+    with freezegun.freeze_time(finish_date):
+      asmt = models.Assessment.query.filter_by(title="Assessment_1").first()
+      self.api.put(asmt, {"status": "Completed"})
+
+    search_request = [{
+        "object_name": "Snapshot",
+        "filters": {
+            "expression": {
+                "left": "child_type",
+                "op": {"name": "="},
+                "right": "Control",
+            },
+        },
+    }]
+    query = self.export_parsed_csv(search_request)["Control Snapshot"]
+
+    for control in query:
+      if control['Code'] in related_objects:
+        f_date = finish_date_str
+      else:
+        f_date = ""
+      self.assertEqual(control["Last Assessment Date"], f_date)
+
   def test_import_lad_field(self):
     """Test Last Assessment Date field read only on import."""
     finish_date = datetime.datetime(2017, 2, 20, 13, 40, 0)

--- a/test/integration/ggrc/data_platform/test_last_assessment_date.py
+++ b/test/integration/ggrc/data_platform/test_last_assessment_date.py
@@ -217,7 +217,7 @@ class TestLastAssessmentDate(TestCase):
   def test_export_lad_snapshot(self):
     """Check export Last Assessment Date."""
     finish_date = datetime.datetime(2017, 2, 20, 13, 40, 0)
-    finish_date_str = finish_date.strftime("%m/%d/%Y")
+    finish_date_str = finish_date.isoformat().replace("T", " ")
     related_objects = {"*Control_1", "*Control_2"}
 
     with freezegun.freeze_time(finish_date):


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Last assessment date is not shown when exporting control/objective snapshot to csv file. 

# Steps to test the changes

1. Have control/objective snapshot with last assessment date on the audit page 
2. Export control/objective snapshot form the audit page 
3. Open csv file and look at the last assessment date column: Last assessment should be shown

# Solution description

Since the last assessment date presents in attributes of a snapshot, we could access it when forming a content during csv export. 

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->