### PR TITLE
GGRC-1928 Increase test coverage for the accessControlList frontend component

### DIFF
--- a/src/ggrc-client/js/components/related-objects/related-people-access-control-group.js
+++ b/src/ggrc-client/js/components/related-objects/related-people-access-control-group.js
@@ -79,8 +79,8 @@ export default can.Component.extend({
       let exist = _.find(this.attr('people'), {id: person.id});
 
       if (exist) {
-        console.warn('User ', person.id,
-          'already has role', groupId, 'assigned');
+        console // eslint-disable-line
+          .warn(`User "${person.id}" already has role "${groupId}" assigned`);
         return;
       }
 
@@ -96,6 +96,12 @@ export default can.Component.extend({
       let idx = _.findIndex(
         this.attr('people'),
         {id: person.id});
+
+      if (idx === -1) {
+        console // eslint-disable-line
+          .warn(`User "${person.id}" does not present in "people" list`);
+        return;
+      }
 
       this.attr('isDirty', true);
       this.attr('people').splice(idx, 1);

--- a/src/ggrc-client/js/components/related-objects/related-people-access-control.js
+++ b/src/ggrc-client/js/components/related-objects/related-people-access-control.js
@@ -33,16 +33,16 @@ export default GGRC.Components('relatedPeopleAccessControl', {
       });
     },
     performUpdate: function (args) {
-      this.updateAccessContolList(args.people, args.roleId);
+      this.updateAccessControlList(args.people, args.roleId);
 
       if (this.attr('conflictRoles').length) {
         this.checkConflicts(args.roleTitle);
       }
     },
-    updateAccessContolList: function (people, roleId) {
+    updateAccessControlList: function (people, roleId) {
       let instance = this.attr('instance');
 
-      // remove all people with current role
+      // get people without current role
       let listWithoutRole = instance
         .attr('access_control_list').filter(function (item) {
           return item.ac_role_id !== roleId;

--- a/src/ggrc-client/js/components/related-objects/tests/related-people-access-control-group_spec.js
+++ b/src/ggrc-client/js/components/related-objects/tests/related-people-access-control-group_spec.js
@@ -93,4 +93,42 @@ describe('GGRC.Components.relatedPeopleAccessControlGroup', () => {
       expect(viewModel.attr('canEdit')).toEqual(true);
     });
   });
+
+  describe('check methods for updating "people" property', () => {
+    let peopleList = [
+      {id: 1, desc: 'Existent Person'},
+      {id: 2, desc: 'Non-Existent Person'},
+    ];
+
+    beforeEach(() => {
+      viewModel.attr('people', [peopleList[0]]);
+      viewModel.attr('groupId', 1);
+      viewModel.attr('title', peopleList[0].desc);
+    });
+
+    describe('"addPerson" method', () => {
+      it('should add person to "people" list if not present', () => {
+        viewModel.addPerson(peopleList[1], viewModel.attr('groupId'));
+        expect(viewModel.attr('people').length).toBe(2);
+      });
+
+      it('should not add person to "people" list if present', () => {
+        viewModel.addPerson(peopleList[0], viewModel.attr('groupId'));
+        expect(viewModel.attr('people').length).toBe(1);
+      });
+    });
+
+    describe('"removePerson" method', () => {
+      it('should remove person from "people" list if present', () => {
+        viewModel.removePerson({person: peopleList[0]});
+        expect(viewModel.attr('people').length).toBe(0);
+      });
+
+      it('should not remove person from "people" list if not present', () => {
+        let count = viewModel.attr('people').length;
+        viewModel.removePerson({person: peopleList[1]});
+        expect(viewModel.attr('people').length).toBe(count);
+      });
+    });
+  });
 });

--- a/src/ggrc-client/js/components/related-objects/tests/related-people-access-control-group_spec.js
+++ b/src/ggrc-client/js/components/related-objects/tests/related-people-access-control-group_spec.js
@@ -8,89 +8,89 @@ import Component from '../related-people-access-control-group';
 import Permission from '../../../permission';
 
 describe('GGRC.Components.relatedPeopleAccessControlGroup', () => {
-  let vm;
+  let viewModel;
 
   beforeEach(() => {
-    vm = new (can.Map.extend(Component.prototype.viewModel));
-    vm.attr('instance', {});
+    viewModel = new (can.Map.extend(Component.prototype.viewModel));
+    viewModel.attr('instance', {});
   });
 
   describe('canEdit prop', () => {
     it('returns "false" when instance is snapshot', () => {
       spyOn(Permission, 'is_allowed_for').and.returnValue(true);
-      vm.instance.attr('archived', false);
-      vm.attr('updatableGroupId', null);
-      vm.attr('isNewInstance', false);
+      viewModel.instance.attr('archived', false);
+      viewModel.attr('updatableGroupId', null);
+      viewModel.attr('isNewInstance', false);
 
       spyOn(SnapshotUtils, 'isSnapshot').and.returnValue(true);
 
-      expect(vm.attr('canEdit')).toEqual(false);
+      expect(viewModel.attr('canEdit')).toEqual(false);
     });
 
     it('returns "false" when instance is archived', () => {
       spyOn(SnapshotUtils, 'isSnapshot').and.returnValue(false);
       spyOn(Permission, 'is_allowed_for').and.returnValue(true);
-      vm.attr('updatableGroupId', null);
-      vm.attr('isNewInstance', false);
+      viewModel.attr('updatableGroupId', null);
+      viewModel.attr('isNewInstance', false);
 
-      vm.instance.attr('archived', true);
+      viewModel.instance.attr('archived', true);
 
-      expect(vm.attr('canEdit')).toEqual(false);
+      expect(viewModel.attr('canEdit')).toEqual(false);
     });
 
     it('returns "false" when there is updatableGroupId', () => {
       spyOn(SnapshotUtils, 'isSnapshot').and.returnValue(false);
-      vm.instance.attr('archived', false);
-      vm.attr('isNewInstance', false);
+      viewModel.instance.attr('archived', false);
+      viewModel.attr('isNewInstance', false);
       spyOn(Permission, 'is_allowed_for').and.returnValue(true);
 
-      vm.attr('updatableGroupId', 'groupId');
+      viewModel.attr('updatableGroupId', 'groupId');
 
-      expect(vm.attr('canEdit')).toEqual(false);
+      expect(viewModel.attr('canEdit')).toEqual(false);
     });
 
     it('returns "false" when user has no update permissions', () => {
       spyOn(SnapshotUtils, 'isSnapshot').and.returnValue(false);
-      vm.instance.attr('archived', false);
-      vm.attr('updatableGroupId', null);
-      vm.attr('isNewInstance', false);
+      viewModel.instance.attr('archived', false);
+      viewModel.attr('updatableGroupId', null);
+      viewModel.attr('isNewInstance', false);
 
       spyOn(Permission, 'is_allowed_for').and.returnValue(false);
 
-      expect(vm.attr('canEdit')).toEqual(false);
+      expect(viewModel.attr('canEdit')).toEqual(false);
     });
 
     it('returns "false" when is readonly', () => {
       spyOn(SnapshotUtils, 'isSnapshot').and.returnValue(false);
       spyOn(Permission, 'is_allowed_for').and.returnValue(false);
-      vm.instance.attr('archived', false);
-      vm.attr('updatableGroupId', null);
-      vm.attr('isNewInstance', true);
-      vm.attr('isReadonly', true);
+      viewModel.instance.attr('archived', false);
+      viewModel.attr('updatableGroupId', null);
+      viewModel.attr('isNewInstance', true);
+      viewModel.attr('isReadonly', true);
 
-      expect(vm.attr('canEdit')).toEqual(false);
+      expect(viewModel.attr('canEdit')).toEqual(false);
     });
 
     it('returns "true" when new instance', () => {
       spyOn(SnapshotUtils, 'isSnapshot').and.returnValue(false);
       spyOn(Permission, 'is_allowed_for').and.returnValue(false);
-      vm.instance.attr('archived', false);
-      vm.attr('updatableGroupId', null);
+      viewModel.instance.attr('archived', false);
+      viewModel.attr('updatableGroupId', null);
 
-      vm.attr('isNewInstance', true);
+      viewModel.attr('isNewInstance', true);
 
-      expect(vm.attr('canEdit')).toEqual(true);
+      expect(viewModel.attr('canEdit')).toEqual(true);
     });
 
     it('returns "true" when user has update permissions', () => {
       spyOn(SnapshotUtils, 'isSnapshot').and.returnValue(false);
-      vm.instance.attr('archived', false);
-      vm.attr('updatableGroupId', null);
-      vm.attr('isNewInstance', false);
+      viewModel.instance.attr('archived', false);
+      viewModel.attr('updatableGroupId', null);
+      viewModel.attr('isNewInstance', false);
 
       spyOn(Permission, 'is_allowed_for').and.returnValue(true);
 
-      expect(vm.attr('canEdit')).toEqual(true);
+      expect(viewModel.attr('canEdit')).toEqual(true);
     });
   });
 });

--- a/src/ggrc-client/js/components/related-objects/tests/related-people-access-control_spec.js
+++ b/src/ggrc-client/js/components/related-objects/tests/related-people-access-control_spec.js
@@ -53,11 +53,11 @@ describe('GGRC.relatedPeopleAccessControl', function () {
 
   describe('"performUpdate" method', () => {
     beforeEach(() => {
-      spyOn(viewModel, 'updateAccessContolList');
+      spyOn(viewModel, 'updateAccessControlList');
       spyOn(viewModel, 'checkConflicts');
     });
 
-    it('calls "updateAccessContolList" method', () => {
+    it('calls "updateAccessControlList" method', () => {
       const args = {
         people: 'mockPeople',
         roleId: 'mockRoleId',
@@ -65,7 +65,7 @@ describe('GGRC.relatedPeopleAccessControl', function () {
 
       viewModel.performUpdate(args);
 
-      expect(viewModel.updateAccessContolList)
+      expect(viewModel.updateAccessControlList)
         .toHaveBeenCalledWith(args.people, args.roleId);
     });
 
@@ -92,11 +92,16 @@ describe('GGRC.relatedPeopleAccessControl', function () {
 
   beforeEach(() => {
     spyOn(aclUtils, 'getRolesForType').and.returnValue([
-      {id: 1, name: 'Admin', object_type: 'Control'},
-      {id: 3, name: 'Primary Contacts', object_type: 'Control'},
-      {id: 4, name: 'Secondary Contacts', object_type: 'Control'},
-      {id: 5, name: 'Principal Assignees', object_type: 'Control'},
-      {id: 6, name: 'Secondary Assignees', object_type: 'Control'},
+      {id: 1, name: 'Admin', mandatory: true,
+        object_type: 'Control'},
+      {id: 3, name: 'Primary Contacts', mandatory: false,
+        object_type: 'Control'},
+      {id: 4, name: 'Secondary Contacts', mandatory: true,
+        object_type: 'Control'},
+      {id: 5, name: 'Principal Assignees', mandatory: false,
+        object_type: 'Control'},
+      {id: 6, name: 'Secondary Assignees', mandatory: true,
+        object_type: 'Control'},
     ]);
   });
 
@@ -386,6 +391,181 @@ describe('GGRC.relatedPeopleAccessControl', function () {
       expect(result[0].title).toEqual('Creator');
       expect(result[1].title).toEqual('Assessor');
       expect(result[2].title).toEqual('Verifier');
+    });
+  });
+
+  describe('"updateAccessControlList" method', function () {
+    let instance;
+    let acl = [
+      {ac_role_id: 1, person: {id: 1, type: 'Person'}},
+      {ac_role_id: 1, person: {id: 2, type: 'Person'}},
+      {ac_role_id: 2, person: {id: 3, type: 'Person'}},
+      {ac_role_id: 3, person: {id: 4, type: 'Person'}},
+    ];
+
+    beforeAll(function () {
+      instance = new can.Map({
+        'class': {
+          model_singular: 'Control',
+        },
+      });
+    });
+
+    beforeEach(function () {
+      instance.attr('access_control_list', acl);
+      viewModel.attr('instance', instance);
+    });
+
+    it('add people w/o current role', () => {
+      const peopleList = [{id: 1}, {id: 2}];
+      viewModel.updateAccessControlList(peopleList, 1);
+
+      const result = instance.attr('access_control_list');
+      expect(result.length).toBe(acl.length);
+    });
+
+    it('update people w current role', () => {
+      const peopleList = [{id: 1}, {id: 2}];
+      viewModel.updateAccessControlList(peopleList, 2);
+
+      const result = instance.attr('access_control_list');
+      expect(result.length).toBe(acl.length + 1);
+    });
+
+    it('remove people w current role', () => {
+      viewModel.updateAccessControlList([], 3);
+
+      const result = instance.attr('access_control_list');
+      expect(result.length).toBe(acl.length - 1);
+    });
+  });
+
+  describe('"buildGroups" method', function () {
+    let roles = [
+      {id: 0, name: 'Role Name1', mandatory: false},
+      {id: 1, name: 'Role Name2', mandatory: true},
+    ];
+
+    let assignment = {
+      person: {id: 1},
+      person_email: 'example@email.com',
+      person_name: 'Person Name',
+      type: 'Person',
+    };
+
+    beforeEach(function () {
+      viewModel.attr('includeRoles', [roles[1].name]);
+    });
+
+    it('should not create group if role is not present in IncludeRoles list',
+      () => {
+        const result = viewModel.buildGroups(roles[0], [[], [assignment]]);
+        expect(result).not.toBeDefined();
+      });
+
+    it('should generate group w/ non empty people list if role is found in acl',
+      () => {
+        const result = viewModel.buildGroups(roles[1], [[], [assignment]]);
+        const group = {
+          title: roles[1].name,
+          groupId: roles[1].id,
+          people: [{
+            id: assignment.person.id,
+            email: assignment.person_email,
+            name: assignment.person_name,
+            type: assignment.type,
+          }],
+          required: roles[1].mandatory,
+        };
+        expect(result).toEqual(group);
+      }
+    );
+
+    it('should generate group w/ empty people list if role is not found in acl',
+      () => {
+        const result = viewModel.buildGroups(roles[1], [{person: {id: 4}}]);
+        const group = {
+          title: roles[1].name,
+          groupId: roles[1].id,
+          people: [],
+          required: roles[1].mandatory,
+        };
+        expect(result).toEqual(group);
+      }
+    );
+  });
+
+  describe('"getRoleList" method', function () {
+    let instance;
+    let acl = [
+      {ac_role_id: 1, person: {id: 1, type: 'Person'}},
+      {ac_role_id: 2, person: {id: 2, type: 'Person'}},
+      {ac_role_id: 3, person: {id: 3, type: 'Person'}},
+    ];
+
+    beforeAll(function () {
+      instance = new can.Map({
+        'class': {
+          model_singular: 'Control',
+        },
+      });
+    });
+
+    beforeEach(function () {
+      instance.attr('access_control_list', acl);
+      viewModel.attr('instance', instance);
+      viewModel.attr('includeRoles', []);
+      viewModel.attr('excludeRoles', []);
+    });
+
+    it('should return empty rolesInfo list if "instance" not defined', () => {
+      viewModel.attr('instance', undefined);
+      viewModel.getRoleList();
+      expect(viewModel.attr('rolesInfo').length).toBe(0);
+    });
+
+    it('should return groups build based on all roles ' +
+      'related to instance type', () => {
+      const groups = viewModel.getRoleList();
+      expect(groups.length).toBe(5);
+    });
+
+    it('should return groups build based on roles from IncludeRoles list',
+      () => {
+        let include = ['Admin', 'Secondary Contacts', 'Principal Assignees'];
+        viewModel.attr('includeRoles', include);
+
+        const groups = viewModel.getRoleList();
+        expect(groups.length).toBe(include.length);
+        groups.forEach((group) => {
+          expect(include).toContain(group.title);
+        });
+      });
+
+    it('should return all groups build based on roles except roles from ' +
+      'ExcludeRoles list', () => {
+      let exclude = ['Admin', 'Secondary Assignees', 'Principal Assignees'];
+      viewModel.attr('excludeRoles', exclude);
+
+      const groups = viewModel.getRoleList();
+      expect(groups.length).toBe(2);
+      expect(groups[0].title).toEqual('Secondary Contacts');
+      expect(groups[0].required).toBe(true);
+      expect(groups[1].title).toEqual('Primary Contacts');
+      expect(groups[1].required).toBe(false);
+    });
+
+    it('should return groups build based on roles from IncludeRoles ' +
+      'w/o roles from ExcludeRoles list', () => {
+      let include = ['Admin', 'Principal Assignees', 'Principal Assignees'];
+      let exclude = ['Admin', 'Primary Contacts', 'Secondary Contacts'];
+      viewModel.attr('includeRoles', include);
+      viewModel.attr('excludeRoles', exclude);
+
+      const groups = viewModel.getRoleList();
+      expect(groups.length).toBe(1);
+      expect(groups[0].title).toEqual('Principal Assignees');
+      expect(groups[0].required).toBe(false);
     });
   });
 });


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Not all "ACL" methods are covered by unit tests.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [ ] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [ ] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
