### PR TITLE
GGRC-4654 Fix issue status cron job

### DIFF
--- a/src/ggrc/integrations/utils.py
+++ b/src/ggrc/integrations/utils.py
@@ -128,6 +128,7 @@ def sync_issue_tracker_statuses():
   processed_ids = set()
   for batch in _iter_issue_batches(list(assessment_issues)):
     for issue_id, issuetracker_state in batch.iteritems():
+      issue_id = str(issue_id)
       issue_info = assessment_issues.get(issue_id)
       if not issue_info:
         logger.warning(

--- a/test/unit/ggrc/integrations/test_utils.py
+++ b/test/unit/ggrc/integrations/test_utils.py
@@ -223,7 +223,7 @@ class BaseClientTest(unittest.TestCase):
   def test_sync_issue_tracker_statuses(self):  # pylint: disable=invalid-name
     """Tests issue synchronization flow."""
     assessment_issues = {
-        't1': {
+        '1': {
             'assessment_id': 1,
             'state': {
                 'status': 'FIXED',
@@ -232,7 +232,7 @@ class BaseClientTest(unittest.TestCase):
                 'severity': 'S1',
             },
         },
-        't2': {
+        '2': {
             'assessment_id': 2,
             'state': {
                 'status': 'ASSIGNED',
@@ -244,7 +244,7 @@ class BaseClientTest(unittest.TestCase):
     }
     batches = [
         {
-            't1': {
+            1: {
                 'status': 'FIXED',
                 'type': 'BUG1',
                 'priority': 'P1',
@@ -252,13 +252,13 @@ class BaseClientTest(unittest.TestCase):
             },
         },
         {
-            't2': {
+            2: {
                 'status': 'FIXED',
                 'type': 'BUG2',
                 'priority': 'P2',
                 'severity': 'S2',
             },
-            'unexpected_issue': {
+            3: {
                 'status': 'FIXED',
                 'type': 'BUG2',
                 'priority': 'P2',
@@ -282,8 +282,8 @@ class BaseClientTest(unittest.TestCase):
       utils.sync_issue_tracker_statuses()
       iter_calls = utils._iter_issue_batches.call_args_list
       self.assertEqual(len(iter_calls), 1)
-      self.assertItemsEqual(iter_calls[0][0][0], ['t1', 't2'])
-      utils._update_issue.assert_called_once_with(cli_mock, 't2', {
+      self.assertItemsEqual(iter_calls[0][0][0], ['1', '2'])
+      utils._update_issue.assert_called_once_with(cli_mock, '2', {
           'status': 'ASSIGNED',
           'type': 'BUG2',
           'priority': 'P2',


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Issue status sync cron job failed with `Got an unexpected issue from Issue Tracker` error.

# Steps to test the changes

Run `hourly_issue_tracker_sync_endpoint` job. No errors should appear in logs.

# Solution description

The type of ids in db didn't match with type of ids received from issue tracker. In this PR ids are casted to unified type.

# Sanity checklist

- [ ] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
