### PR TITLE
GGRC-4840 Disallow to create object with custom code

### DIFF
--- a/src/ggrc-client/js/components/effective-dates/effective-dates.mustache
+++ b/src/ggrc-client/js/components/effective-dates/effective-dates.mustache
@@ -3,7 +3,7 @@
   Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
 
-<div data-id="effective_date_hidden" class="span4 hidable">
+<div data-id="effective_date_hidden" class="span4 hidable input-block-level">
   <a data-id="hide_effective_date_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
   <datepicker
       tabindex="20"

--- a/src/ggrc-client/js/mustache_helper.js
+++ b/src/ggrc-client/js/mustache_helper.js
@@ -2386,3 +2386,16 @@ Mustache.registerHelper('user_roles', (person, parentInstance, options) => {
     rolesList: allRoleNames.join('\n'),
   });
 });
+
+Mustache.registerHelper('if_slug_allow',
+  (isNewObjectForm, isProposal, options) => {
+    isNewObjectForm = Mustache.resolve(isNewObjectForm);
+    isProposal = Mustache.resolve(isProposal);
+
+    if (isNewObjectForm || isProposal) {
+      return options.inverse(options.contexts);
+    }
+
+    return options.fn(options.contexts);
+  }
+);

--- a/src/ggrc/assets/mustache/access_groups/modal_content.mustache
+++ b/src/ggrc/assets/mustache/access_groups/modal_content.mustache
@@ -67,14 +67,25 @@
 
   <div>
     <div class="row-fluid">
-      <div data-id="code_hidden" class="span4 hidable">
-        <label>
-          Code
-          <i class="fa fa-question-circle" rel="tooltip" title="The GGRC application will automatically provide codes for new objects.  If you would like to override this feature you may manually enter a code of your choosing.  You should have a specific reason for doing this."></i>
-          <a data-id="hide_code_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
-        </label>
-        <input {{^if new_object_form}} disabled {{/if}} data-id="code_txtbx" tabindex="6" class="input-block-level" name="slug" placeholder="ACCESSGROUP-XXX" type="text" value="{{slug}}">
-      </div>
+      {{#if_slug_allow new_object_form isProposal}}
+        <div data-id="code_hidden" class="span4 hidable">
+          <label>
+            Code
+            <i class="fa fa-question-circle" rel="tooltip" title="The GGRC application will automatically provide codes for new objects.  If you would like to override this feature you may manually enter a code of your choosing.  You should have a specific reason for doing this."></i>
+            <a data-id="hide_code_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
+          </label>
+          <input
+            disabled
+            data-id="code_txtbx"
+            tabindex="6"
+            class="input-block-level"
+            name="slug"
+            placeholder="ACCESSGROUP-XXX"
+            type="text"
+            value="{{slug}}"
+          >
+        </div>
+      {{/if_slug_allow}}
       <effective-dates instance="instance"/>
     </div>
     <div class="row-fluid">

--- a/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
+++ b/src/ggrc/assets/mustache/assessment_templates/modal_content.mustache
@@ -207,14 +207,25 @@
     </div>
 
     <div class="row-fluid">
-      <div data-id="code_hidden" class="span4 hidable">
-        <label>
-          Code
-          <i class="fa fa-question-circle" rel="tooltip" title="The GGRC application will automatically provide codes for new objects.  If you would like to override this feature you may manually enter a code of your choosing.  You should have a specific reason for doing this."></i>
-          <a data-id="hide_code_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
-        </label>
-        <input {{^if new_object_form}} disabled {{/if}} data-id="code_txtbx" tabindex="3" class="input-block-level" name="slug" placeholder="AUDIT-XXX" type="text" value="{{instance.slug}}">
-      </div>
+      {{#if_slug_allow new_object_form isProposal}}
+        <div data-id="code_hidden" class="span4 hidable">
+          <label>
+            Code
+            <i class="fa fa-question-circle" rel="tooltip" title="The GGRC application will automatically provide codes for new objects.  If you would like to override this feature you may manually enter a code of your choosing.  You should have a specific reason for doing this."></i>
+            <a data-id="hide_code_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
+          </label>
+          <input
+            disabled
+            data-id="code_txtbx"
+            tabindex="3"
+            class="input-block-level"
+            name="slug"
+            placeholder="TEMPLATE-XXX"
+            type="text"
+            value="{{instance.slug}}"
+          >
+        </div>
+      {{/if_slug_allow}}
       <div class="span4 hidable">
         <label>
           State

--- a/src/ggrc/assets/mustache/assessments/modal_content_additional_fields.mustache
+++ b/src/ggrc/assets/mustache/assessments/modal_content_additional_fields.mustache
@@ -35,18 +35,22 @@
 </div>
 
 <div class="ggrc-form-item">
-  <div class="ggrc-form-item__multiple-row">
-    <label class="ggrc-form-item__label">
-      Code
-    </label>
-    <input {{^if new_object_form}} disabled {{/if}} data-id="code_txtbx"
-      tabindex="14"
-      class="input-block-level"
-      name="slug"
-      placeholder="ASSESSMENT-XXX"
-      type="text"
-      {$value}="slug">
-  </div>
+  {{#if_slug_allow new_object_form isProposal}}
+    <div class="ggrc-form-item__multiple-row">
+      <label class="ggrc-form-item__label">
+        Code
+      </label>
+      <input
+        disabled
+        data-id="code_txtbx"
+        tabindex="14"
+        class="input-block-level"
+        name="slug"
+        placeholder="ASSESSMENT-XXX"
+        type="text"
+        {$value}="slug">
+    </div>
+  {{/if_slug_allow}}
   <div class="ggrc-form-item__multiple-row">
     <label class="ggrc-form-item__label">
       Due Date

--- a/src/ggrc/assets/mustache/audits/modal_content.mustache
+++ b/src/ggrc/assets/mustache/audits/modal_content.mustache
@@ -165,16 +165,27 @@
       </div>
     </div>
 
-    <div class="row-fluid">
-      <div data-id="code_hidden" class="span4 hidable">
-        <label>
-          Code
-          <i class="fa fa-question-circle" rel="tooltip" title="The GGRC application will automatically provide codes for new objects.  If you would like to override this feature you may manually enter a code of your choosing.  You should have a specific reason for doing this."></i>
-          <a data-id="hide_code_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
-        </label>
-        <input {{^if new_object_form}} disabled {{/if}} data-id="code_txtbx" tabindex="8" class="input-block-level" name="slug" placeholder="AUDIT-XXX" type="text" value="{{instance.slug}}">
+    {{#if_slug_allow new_object_form isProposal}}
+      <div class="row-fluid">
+        <div data-id="code_hidden" class="span4 hidable">
+          <label>
+            Code
+            <i class="fa fa-question-circle" rel="tooltip" title="The GGRC application will automatically provide codes for new objects.  If you would like to override this feature you may manually enter a code of your choosing.  You should have a specific reason for doing this."></i>
+            <a data-id="hide_code_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
+          </label>
+          <input
+            disabled
+            data-id="code_txtbx"
+            tabindex="8"
+            class="input-block-level"
+            name="slug"
+            placeholder="AUDIT-XXX"
+            type="text"
+            value="{{instance.slug}}"
+          >
+        </div>
       </div>
-    </div>
+    {{/if_slug_allow}}
 
     {{#with_current_user_as 'current_user'}}<input type="hidden" name="modified_by_id" value="{{current_user.id}}">{{/with_current_user_as}}
 

--- a/src/ggrc/assets/mustache/clauses/modal_content.mustache
+++ b/src/ggrc/assets/mustache/clauses/modal_content.mustache
@@ -68,15 +68,28 @@
 
   <div>
     <div class="row-fluid">
-      <div data-id="code_hidden" class="span4 hidable">
-        <label>
-          Code
-          <i class="fa fa-question-circle" rel="tooltip" title="The GGRC application will automatically provide codes for new objects.  If you would like to override this feature you may manually enter a code of your choosing.  You should have a specific reason for doing this."></i>
-          <a data-id="hide_code_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
-        </label>
-        <input {{^if new_object_form}} disabled {{/if}} data-id="code_txtbx" tabindex="7" id="section-code" class="input-block-level" name="slug" placeholder="CLAUSE-XXX" type="text" value="{{slug}}">
-      </div>
-      <effective-dates instance="instance"/>
+      {{#if_slug_allow new_object_form isProposal}}
+        <div data-id="code_hidden" class="span4 hidable">
+          <label>
+            Code
+            <i class="fa fa-question-circle" rel="tooltip" title="The GGRC application will automatically provide codes for new objects.  If you would like to override this feature you may manually enter a code of your choosing.  You should have a specific reason for doing this."></i>
+            <a data-id="hide_code_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
+          </label>
+          <input
+            disabled
+            data-id="code_txtbx"
+            tabindex="7"
+            id="section-code"
+            class="input-block-level"
+            placeholder="CLAUSE-XXX"
+            name="slug"
+            type="text"
+            value="{{slug}}"
+          >
+        </div>
+      {{/if_slug_allow}}
+      <effective-dates instance="instance"></effective-dates>
+    </div>
     <div class="row-fluid">
       <div data-id="state_hidden" class="span4 hidable">
         <label>

--- a/src/ggrc/assets/mustache/contracts/modal_content.mustache
+++ b/src/ggrc/assets/mustache/contracts/modal_content.mustache
@@ -67,14 +67,25 @@
 
   <div>
     <div class="row-fluid">
-      <div data-id="code_hidden" class="span4 hidable">
-        <label>
-          Code
-          <i class="fa fa-question-circle" rel="tooltip" title="The GGRC application will automatically provide codes for new objects.  If you would like to override this feature you may manually enter a code of your choosing.  You should have a specific reason for doing this."></i>
-          <a data-id="hide_code_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
-        </label>
-        <input {{^if new_object_form}} disabled {{/if}} data-id="code_txtbx" tabindex="6" class="input-block-level" name="slug" placeholder="CONTRACT-XXX" type="text" value="{{slug}}">
-      </div>
+      {{#if_slug_allow new_object_form isProposal}}
+        <div data-id="code_hidden" class="span4 hidable">
+          <label>
+            Code
+            <i class="fa fa-question-circle" rel="tooltip" title="The GGRC application will automatically provide codes for new objects.  If you would like to override this feature you may manually enter a code of your choosing.  You should have a specific reason for doing this."></i>
+            <a data-id="hide_code_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
+          </label>
+          <input
+            disabled
+            data-id="code_txtbx"
+            tabindex="6"
+            class="input-block-level"
+            name="slug"
+            placeholder="CONTRACT-XXX"
+            type="text"
+            value="{{slug}}"
+          >
+        </div>
+      {{/if_slug_allow}}
       <effective-dates instance="instance"/>
     </div>
     <div class="row-fluid">

--- a/src/ggrc/assets/mustache/controls/modal_content.mustache
+++ b/src/ggrc/assets/mustache/controls/modal_content.mustache
@@ -88,7 +88,7 @@
   {{/if}}
 
   <div>
-    {{^if isProposal}}
+    {{#if_slug_allow new_object_form isProposal}}
       <div class="row-fluid">
         <div data-test-id="control_code_f8abbcc9" data-id="code_hidden" class="span6 hidable">
           <label>
@@ -96,10 +96,19 @@
             <i class="fa fa-question-circle" rel="tooltip" title="The GGRC application will automatically provide codes for new objects.  If you would like to override this feature you may manually enter a code of your choosing.  You should have a specific reason for doing this."></i>
             <a data-id="hide_code_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
           </label>
-          <input {{^if new_object_form}} disabled {{/if}} data-id="code_txtbx" tabindex="6" class="input-block-level" name="slug" placeholder="CONTROL-XXX" type="text" value="{{slug}}">
+          <input
+            disabled
+            data-id="code_txtbx"
+            tabindex="6"
+            class="input-block-level"
+            name="slug"
+            placeholder="CONTROL-XXX"
+            type="text"
+            value="{{slug}}"
+          >
         </div>
       </div>
-    {{/if}}
+    {{/if_slug_allow}}
     <div class="row-fluid">
       <div data-test-id="control_kind_nature_dadc232f" data-id="kind_nature_hidden" class="span3 hidable">
         <label>
@@ -146,7 +155,7 @@
         </div>
       </div>
     </div>
-    <div class="row-fluid input-block-level" test-id="control_effective_dates_0376cf90">
+    <div class="row-fluid" test-id="control_effective_dates_0376cf90">
       <effective-dates instance="instance"/>
     </div>
 

--- a/src/ggrc/assets/mustache/data_assets/modal_content.mustache
+++ b/src/ggrc/assets/mustache/data_assets/modal_content.mustache
@@ -67,14 +67,25 @@
 
   <div>
     <div class="row-fluid">
-      <div data-id="code_hidden" class="span4 hidable">
-        <label>
-          Code
-          <i class="fa fa-question-circle" rel="tooltip" title="The GGRC application will automatically provide codes for new objects.  If you would like to override this feature you may manually enter a code of your choosing.  You should have a specific reason for doing this."></i>
-          <a data-id="hide_code_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
-        </label>
-        <input {{^if new_object_form}} disabled {{/if}} data-id="code_txtbx" tabindex="6" class="input-block-level" name="slug" placeholder="DATAASSET-XXX" type="text" value="{{slug}}">
-      </div>
+      {{#if_slug_allow new_object_form isProposal}}
+        <div data-id="code_hidden" class="span4 hidable">
+          <label>
+            Code
+            <i class="fa fa-question-circle" rel="tooltip" title="The GGRC application will automatically provide codes for new objects.  If you would like to override this feature you may manually enter a code of your choosing.  You should have a specific reason for doing this."></i>
+            <a data-id="hide_code_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
+          </label>
+          <input
+            disabled
+            data-id="code_txtbx"
+            tabindex="6"
+            class="input-block-level"
+            name="slug"
+            placeholder="DATAASSET-XXX"
+            type="text"
+            value="{{slug}}"
+          >
+        </div>
+      {{/if_slug_allow}}
       <effective-dates instance="instance"/>
     </div>
     <div class="row-fluid">

--- a/src/ggrc/assets/mustache/facilities/modal_content.mustache
+++ b/src/ggrc/assets/mustache/facilities/modal_content.mustache
@@ -67,14 +67,25 @@
 
   <div>
     <div class="row-fluid">
-      <div data-id="code_hidden" class="span4 hidable">
-        <label>
-          Code
-          <i class="fa fa-question-circle" rel="tooltip" title="The GGRC application will automatically provide codes for new objects.  If you would like to override this feature you may manually enter a code of your choosing.  You should have a specific reason for doing this."></i>
-          <a data-id="hide_code_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
-        </label>
-        <input {{^if new_object_form}} disabled {{/if}} data-id="code_txtbx" tabindex="6" class="input-block-level" name="slug" placeholder="FACILITY-XXX" type="text" value="{{slug}}">
-      </div>
+      {{#if_slug_allow new_object_form isProposal}}
+        <div data-id="code_hidden" class="span4 hidable">
+          <label>
+            Code
+            <i class="fa fa-question-circle" rel="tooltip" title="The GGRC application will automatically provide codes for new objects.  If you would like to override this feature you may manually enter a code of your choosing.  You should have a specific reason for doing this."></i>
+            <a data-id="hide_code_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
+          </label>
+          <input
+            disabled
+            data-id="code_txtbx"
+            tabindex="6"
+            class="input-block-level"
+            name="slug"
+            placeholder="FACILITY-XXX"
+            type="text"
+            value="{{slug}}"
+          >
+        </div>
+      {{/if_slug_allow}}
       <effective-dates instance="instance"/>
     </div>
     <div class="row-fluid">

--- a/src/ggrc/assets/mustache/issues/modal_content.mustache
+++ b/src/ggrc/assets/mustache/issues/modal_content.mustache
@@ -77,14 +77,25 @@
 
   <div>
     <div class="row-fluid">
-      <div data-id="code_hidden" class="span4 hidable">
-        <label>
-          Code
-          <i class="fa fa-question-circle" rel="tooltip" title="The GGRC application will automatically provide codes for new objects.  If you would like to override this feature you may manually enter a code of your choosing.  You should have a specific reason for doing this."></i>
-          <a data-id="hide_code_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
-        </label>
-        <input {{^if new_object_form}} disabled {{/if}} data-id="code_txtbx" tabindex="6" class="input-block-level" name="slug" placeholder="ISSUE-XXX" type="text" value="{{slug}}">
-      </div>
+      {{#if_slug_allow new_object_form isProposal}}
+        <div data-id="code_hidden" class="span4 hidable">
+          <label>
+            Code
+            <i class="fa fa-question-circle" rel="tooltip" title="The GGRC application will automatically provide codes for new objects.  If you would like to override this feature you may manually enter a code of your choosing.  You should have a specific reason for doing this."></i>
+            <a data-id="hide_code_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
+          </label>
+          <input
+            disabled
+            data-id="code_txtbx"
+            tabindex="6"
+            class="input-block-level"
+            name="slug"
+            placeholder="ISSUE-XXX"
+            type="text"
+            value="{{slug}}"
+          >
+        </div>
+      {{/if_slug_allow}}
       <effective-dates instance="instance"/>
     </div>
     <div class="row-fluid">

--- a/src/ggrc/assets/mustache/markets/modal_content.mustache
+++ b/src/ggrc/assets/mustache/markets/modal_content.mustache
@@ -67,14 +67,25 @@
 
   <div>
     <div class="row-fluid">
-      <div data-id="code_hidden" class="span4 hidable">
-        <label>
-          Code
-          <i class="fa fa-question-circle" rel="tooltip" title="The GGRC application will automatically provide codes for new objects.  If you would like to override this feature you may manually enter a code of your choosing.  You should have a specific reason for doing this."></i>
-          <a data-id="hide_code_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
-        </label>
-        <input {{^if new_object_form}} disabled {{/if}} data-id="code_txtbx" tabindex="6" class="input-block-level" name="slug" placeholder="MARKET-XXX" type="text" value="{{slug}}">
-      </div>
+      {{#if_slug_allow new_object_form isProposal}}
+        <div data-id="code_hidden" class="span4 hidable">
+          <label>
+            Code
+            <i class="fa fa-question-circle" rel="tooltip" title="The GGRC application will automatically provide codes for new objects.  If you would like to override this feature you may manually enter a code of your choosing.  You should have a specific reason for doing this."></i>
+            <a data-id="hide_code_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
+          </label>
+          <input
+            disabled
+            data-id="code_txtbx"
+            tabindex="6"
+            class="input-block-level"
+            name="slug"
+            placeholder="MARKET-XXX"
+            type="text"
+            value="{{slug}}"
+          >
+        </div>
+      {{/if_slug_allow}}
       <effective-dates instance="instance"/>
     </div>
     <div class="row-fluid">

--- a/src/ggrc/assets/mustache/objectives/modal_content.mustache
+++ b/src/ggrc/assets/mustache/objectives/modal_content.mustache
@@ -66,14 +66,25 @@
 
   <div>
     <div class="row-fluid">
-      <div data-id="code_hidden" class="span4 hidable">
-        <label>
-          Code
-          <i class="fa fa-question-circle" rel="tooltip" title="The GGRC application will automatically provide codes for new objects.  If you would like to override this feature you may manually enter a code of your choosing.  You should have a specific reason for doing this."></i>
-          <a data-id="hide_code_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
-        </label>
-        <input {{^if new_object_form}} disabled {{/if}} data-id="code_txtbx" tabindex="8" class="input-block-level" name="slug" placeholder="OBJECTIVE-XXX" type="text" value="{{slug}}">
-      </div>
+      {{#if_slug_allow new_object_form isProposal}}
+        <div data-id="code_hidden" class="span4 hidable">
+          <label>
+            Code
+            <i class="fa fa-question-circle" rel="tooltip" title="The GGRC application will automatically provide codes for new objects.  If you would like to override this feature you may manually enter a code of your choosing.  You should have a specific reason for doing this."></i>
+            <a data-id="hide_code_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
+          </label>
+          <input
+            disabled
+            data-id="code_txtbx"
+            tabindex="8"
+            class="input-block-level"
+            name="slug"
+            placeholder="OBJECTIVE-XXX"
+            type="text"
+            value="{{slug}}"
+          >
+        </div>
+      {{/if_slug_allow}}
       <effective-dates instance="instance"/>
     </div>
   </div>

--- a/src/ggrc/assets/mustache/org_groups/modal_content.mustache
+++ b/src/ggrc/assets/mustache/org_groups/modal_content.mustache
@@ -66,14 +66,25 @@
 
   <div>
     <div class="row-fluid">
-      <div data-id="code_hidden" class="span4 hidable">
-        <label>
-          Code
-          <i class="fa fa-question-circle" rel="tooltip" title="The GGRC application will automatically provide codes for new objects.  If you would like to override this feature you may manually enter a code of your choosing.  You should have a specific reason for doing this."></i>
-          <a data-id="hide_code_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
-        </label>
-        <input {{^if new_object_form}} disabled {{/if}} data-id="code_txtbx" tabindex="6" class="input-block-level" name="slug" placeholder="ORGGROUP-XXX" type="text" value="{{slug}}">
-      </div>
+      {{#if_slug_allow new_object_form isProposal}}
+        <div data-id="code_hidden" class="span4 hidable">
+          <label>
+            Code
+            <i class="fa fa-question-circle" rel="tooltip" title="The GGRC application will automatically provide codes for new objects.  If you would like to override this feature you may manually enter a code of your choosing.  You should have a specific reason for doing this."></i>
+            <a data-id="hide_code_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
+          </label>
+          <input
+            disabled
+            data-id="code_txtbx"
+            tabindex="6"
+            class="input-block-level"
+            name="slug"
+            placeholder="ORGGROUP-XXX"
+            type="text"
+            value="{{slug}}"
+          >
+        </div>
+      {{/if_slug_allow}}
       <effective-dates instance="instance"/>
     </div>
     <div class="row-fluid">

--- a/src/ggrc/assets/mustache/policies/modal_content.mustache
+++ b/src/ggrc/assets/mustache/policies/modal_content.mustache
@@ -68,14 +68,25 @@
 
   <!-- Code & network block -->
   <div class="row-fluid">
-    <div data-id="code_hidden" class="span6 hidable">
-      <label>
-        Code
-        <i class="fa fa-question-circle" rel="tooltip" title="The GGRC application will automatically provide codes for new objects.  If you would like to override this feature you may manually enter a code of your choosing.  You should have a specific reason for doing this."></i>
-        <a data-id="hide_code_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
-      </label>
-      <input {{^if new_object_form}} disabled {{/if}} data-id="code_txtbx" tabindex="6" class="input-block-level" name="slug" placeholder="POLICY-XXX" type="text" value="{{slug}}">
-    </div>
+    {{#if_slug_allow new_object_form isProposal}}
+      <div data-id="code_hidden" class="span6 hidable">
+        <label>
+          Code
+          <i class="fa fa-question-circle" rel="tooltip" title="The GGRC application will automatically provide codes for new objects.  If you would like to override this feature you may manually enter a code of your choosing.  You should have a specific reason for doing this."></i>
+          <a data-id="hide_code_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
+        </label>
+        <input
+          disabled
+          data-id="code_txtbx"
+          tabindex="6"
+          class="input-block-level"
+          name="slug"
+          placeholder="POLICY-XXX"
+          type="text"
+          value="{{slug}}"
+        >
+      </div>
+    {{/if_slug_allow}}
     <div data-id="kind_type_hidden" class="span6 hidable">
       <label>
         Kind/Type

--- a/src/ggrc/assets/mustache/processes/modal_content.mustache
+++ b/src/ggrc/assets/mustache/processes/modal_content.mustache
@@ -68,14 +68,25 @@
 
   <!-- Code & network block -->
   <div class="row-fluid">
-    <div data-id="code_hidden" class="span6 hidable">
-      <label>
-        Code
-        <i class="fa fa-question-circle" rel="tooltip" title="The GGRC application will automatically provide codes for new objects.  If you would like to override this feature you may manually enter a code of your choosing.  You should have a specific reason for doing this."></i>
-        <a data-id="hide_code_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
-      </label>
-      <input {{^if new_object_form}} disabled {{/if}} data-id="code_txtbx" tabindex="8" class="input-block-level" name="slug" placeholder="PROCESS-XXX" type="text" value="{{slug}}">
-    </div>
+    {{#if_slug_allow new_object_form isProposal}}
+      <div data-id="code_hidden" class="span6 hidable">
+        <label>
+          Code
+          <i class="fa fa-question-circle" rel="tooltip" title="The GGRC application will automatically provide codes for new objects.  If you would like to override this feature you may manually enter a code of your choosing.  You should have a specific reason for doing this."></i>
+          <a data-id="hide_code_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
+        </label>
+        <input
+          disabled
+          data-id="code_txtbx"
+          tabindex="8"
+          class="input-block-level"
+          name="slug"
+          placeholder="PROCESS-XXX"
+          type="text"
+          value="{{slug}}"
+        >
+      </div>
+    {{/if_slug_allow}}
     <div data-id="network_zone_hidden" class="span6 hidable">
       <label>
         Network Zone

--- a/src/ggrc/assets/mustache/products/modal_content.mustache
+++ b/src/ggrc/assets/mustache/products/modal_content.mustache
@@ -65,14 +65,25 @@
 
   <div>
     <div class="row-fluid">
-      <div data-id="code_hidden" class="span6 hidable">
-        <label>
-          Code
-          <i class="fa fa-question-circle" rel="tooltip" title="The GGRC application will automatically provide codes for new objects.  If you would like to override this feature you may manually enter a code of your choosing.  You should have a specific reason for doing this."></i>
-          <a data-id="hide_code_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
-        </label>
-        <input {{^if new_object_form}} disabled {{/if}} data-id="code_txtbx" tabindex="6" class="input-block-level" name="slug" placeholder="PRODUCT-XXX" type="text" value="{{slug}}">
-      </div>
+      {{#if_slug_allow new_object_form isProposal}}
+        <div data-id="code_hidden" class="span6 hidable">
+          <label>
+            Code
+            <i class="fa fa-question-circle" rel="tooltip" title="The GGRC application will automatically provide codes for new objects.  If you would like to override this feature you may manually enter a code of your choosing.  You should have a specific reason for doing this."></i>
+            <a data-id="hide_code_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
+          </label>
+          <input
+            disabled
+            data-id="code_txtbx"
+            tabindex="6"
+            class="input-block-level"
+            name="slug"
+            placeholder="PRODUCT-XXX"
+            type="text"
+            value="{{slug}}"
+          >
+        </div>
+      {{/if_slug_allow}}
       <div data-id="kind_type_hidden" class="span6 hidable">
         <label>
           Kind/Type

--- a/src/ggrc/assets/mustache/programs/modal_content.mustache
+++ b/src/ggrc/assets/mustache/programs/modal_content.mustache
@@ -96,16 +96,25 @@
   <!--Code & network block-->
 
   <div class="row-fluid">
-    <div class="span4 hidable">
-      <label>
-        Code
-        <i class="fa fa-question-circle" rel="tooltip" title="The GGRC application will automatically provide codes for new objects.  If you would like to override this feature you may manually enter a code of your choosing.  You should have a specific reason for doing this."></i>
-        <a href="javascript://" class="field-hide" tabindex="-1">hide</a>
-      </label>
-      <input {{^if new_object_form}} disabled {{/if}} data-test-id="new_program_field_code_334276e2"
-             tabindex="7"
-             class="input-block-level" name="slug" placeholder="PROGRAM-XXX" type="text" value="{{slug}}">
-    </div>
+    {{#if_slug_allow new_object_form isProposal}}
+      <div class="span4 hidable">
+        <label>
+          Code
+          <i class="fa fa-question-circle" rel="tooltip" title="The GGRC application will automatically provide codes for new objects.  If you would like to override this feature you may manually enter a code of your choosing.  You should have a specific reason for doing this."></i>
+          <a href="javascript://" class="field-hide" tabindex="-1">hide</a>
+        </label>
+        <input
+          disabled
+          data-test-id="new_program_field_code_334276e2"
+          tabindex="7"
+          class="input-block-level"
+          name="slug"
+          placeholder="PROGRAM-XXX"
+          type="text"
+          value="{{slug}}"
+        >
+      </div>
+    {{/if_slug_allow}}
     <div test-id="new_program_field_effective_date_f2783a28">
       <effective-dates instance="instance"/>
     </div>

--- a/src/ggrc/assets/mustache/projects/modal_content.mustache
+++ b/src/ggrc/assets/mustache/projects/modal_content.mustache
@@ -67,14 +67,25 @@
 
   <div>
     <div class="row-fluid">
-      <div data-id="code_hidden" class="span4 hidable">
-        <label>
-          Code
-          <i class="fa fa-question-circle" rel="tooltip" title="The GGRC application will automatically provide codes for new objects.  If you would like to override this feature you may manually enter a code of your choosing.  You should have a specific reason for doing this."></i>
-          <a data-id="hide_code_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
-        </label>
-        <input {{^if new_object_form}} disabled {{/if}} data-id="code_txtbx" tabindex="6" class="input-block-level" name="slug" placeholder="PROJECT-XXX" type="text" value="{{slug}}">
-      </div>
+      {{#if_slug_allow new_object_form isProposal}}
+        <div data-id="code_hidden" class="span4 hidable">
+          <label>
+            Code
+            <i class="fa fa-question-circle" rel="tooltip" title="The GGRC application will automatically provide codes for new objects.  If you would like to override this feature you may manually enter a code of your choosing.  You should have a specific reason for doing this."></i>
+            <a data-id="hide_code_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
+          </label>
+          <input
+            disabled
+            data-id="code_txtbx"
+            tabindex="6"
+            class="input-block-level"
+            name="slug"
+            placeholder="PROJECT-XXX"
+            type="text"
+            value="{{slug}}"
+          >
+        </div>
+      {{/if_slug_allow}}
       <effective-dates instance="instance"/>
     </div>
     <div class="row-fluid">

--- a/src/ggrc/assets/mustache/regulations/modal_content.mustache
+++ b/src/ggrc/assets/mustache/regulations/modal_content.mustache
@@ -68,14 +68,25 @@
   <!-- Code & network block -->
   <div>
     <div class="row-fluid">
-      <div data-id="code_hidden" class="span4 hidable">
-        <label>
-          Code
-          <i class="fa fa-question-circle" rel="tooltip" title="The GGRC application will automatically provide codes for new objects.  If you would like to override this feature you may manually enter a code of your choosing.  You should have a specific reason for doing this."></i>
-          <a data-id="hide_code_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
-        </label>
-        <input {{^if new_object_form}} disabled {{/if}} data-id="code_txtbx" tabindex="6" class="input-block-level" name="slug" placeholder="REGULATION-XXX" type="text" value="{{slug}}">
-      </div>
+      {{#if_slug_allow new_object_form isProposal}}
+        <div data-id="code_hidden" class="span4 hidable">
+          <label>
+            Code
+            <i class="fa fa-question-circle" rel="tooltip" title="The GGRC application will automatically provide codes for new objects.  If you would like to override this feature you may manually enter a code of your choosing.  You should have a specific reason for doing this."></i>
+            <a data-id="hide_code_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
+          </label>
+          <input
+            disabled
+            data-id="code_txtbx"
+            tabindex="6"
+            class="input-block-level"
+            name="slug"
+            placeholder="REGULATION-XXX"
+            type="text"
+            value="{{slug}}"
+          >
+        </div>
+      {{/if_slug_allow}}
       <effective-dates instance="instance"/>
     </div>
     <div class="row-fluid">

--- a/src/ggrc/assets/mustache/risk_assessments/modal_content.mustache
+++ b/src/ggrc/assets/mustache/risk_assessments/modal_content.mustache
@@ -120,16 +120,27 @@
 
   {{> /static/mustache/partials/modal-ajax-test-plan.mustache}}
 
-  <div class="row-fluid">
-    <div data-id="code_hidden" class="span4 hidable">
-      <label>
-        Code
-        <i class="fa fa-question-circle" rel="tooltip" title="The GGRC application will automatically provide codes for new objects.  If you would like to override this feature you may manually enter a code of your choosing.  You should have a specific reason for doing this."></i>
-        <a data-id="hide_code_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
-      </label>
-      <input {{^if new_object_form}} disabled {{/if}} data-id="code_txtbx" tabindex="8" class="input-block-level" name="slug" placeholder="RISKASSESSMENT-XXX" type="text" value="{{instance.slug}}">
+  {{#if_slug_allow new_object_form isProposal}}
+    <div class="row-fluid">
+      <div data-id="code_hidden" class="span4 hidable">
+        <label>
+          Code
+          <i class="fa fa-question-circle" rel="tooltip" title="The GGRC application will automatically provide codes for new objects.  If you would like to override this feature you may manually enter a code of your choosing.  You should have a specific reason for doing this."></i>
+          <a data-id="hide_code_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
+        </label>
+        <input
+          disabled
+          data-id="code_txtbx"
+          tabindex="8"
+          class="input-block-level"
+          name="slug"
+          placeholder="RISKASSESSMENT-XXX"
+          type="text"
+          value="{{instance.slug}}"
+        >
+      </div>
     </div>
-  </div>
+  {{/if_slug_allow}}
   <div class="row-fluid">
     <div data-id="state_hidden" class="span4 hidable">
       <label>

--- a/src/ggrc/assets/mustache/risks/modal_content.mustache
+++ b/src/ggrc/assets/mustache/risks/modal_content.mustache
@@ -88,7 +88,7 @@
   </div>
 
   <div class="row-fluid {{#if isProposal}}input-block-level{{/if}}">
-    {{^if isProposal}}
+    {{#if_slug_allow new_object_form isProposal}}
       <div class="span4 hidable">
         <label>
           Code
@@ -96,9 +96,19 @@
             title="The ZenGRC application will automatically provide codes for new objects. If you would like to override this feature you may manually enter a code of your choosing. You should have a specific reason for doing this."></i>
           <a href="javascript://" class="field-hide" tabindex="-1">hide</a>
         </label>
-        <input data-id="code_txtbx" {{^if new_object_form}} disabled {{/if}} tabindex="7" id="section-code" class="input-block-level" name="slug" placeholder="RISK-XXX" type="text" value="{{slug}}">
+        <input
+          disabled
+          data-id="code_txtbx"
+          tabindex="7"
+          id="section-code"
+          class="input-block-level"
+          name="slug"
+          placeholder="RISK-XXX"
+          type="text"
+          value="{{slug}}"
+        >
       </div>
-    {{/if}}
+    {{/if_slug_allow}}
     <effective-dates instance="instance"/>
   </div>
 

--- a/src/ggrc/assets/mustache/sections/modal_content.mustache
+++ b/src/ggrc/assets/mustache/sections/modal_content.mustache
@@ -80,14 +80,26 @@
 
   <div>
     <div class="row-fluid">
-      <div data-id="code_hidden" class="span4 hidable">
-        <label>
-          Code
-          <i class="fa fa-question-circle" rel="tooltip" title="The GGRC application will automatically provide codes for new objects. If you would like to override this feature you may manually enter a code of your choosing. You should have a specific reason for doing this."></i>
-          <a data-id="hide_code_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
-        </label>
-        <input {{^if new_object_form}} disabled {{/if}} data-id="code_txtbx" tabindex="7" id="section-code" class="input-block-level" name="slug" placeholder="SECTION-XXX" type="text" value="{{slug}}">
-      </div>
+      {{#if_slug_allow new_object_form isProposal}}
+        <div data-id="code_hidden" class="span4 hidable">
+          <label>
+            Code
+            <i class="fa fa-question-circle" rel="tooltip" title="The GGRC application will automatically provide codes for new objects. If you would like to override this feature you may manually enter a code of your choosing. You should have a specific reason for doing this."></i>
+            <a data-id="hide_code_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
+          </label>
+          <input
+            disabled
+            data-id="code_txtbx"
+            tabindex="7"
+            id="section-code"
+            class="input-block-level"
+            name="slug"
+            placeholder="SECTION-XXX"
+            type="text"
+            value="{{slug}}"
+          >
+        </div>
+      {{/if_slug_allow}}
       <effective-dates instance="instance"/>
     </div>
     <div class="row-fluid">

--- a/src/ggrc/assets/mustache/standards/modal_content.mustache
+++ b/src/ggrc/assets/mustache/standards/modal_content.mustache
@@ -67,14 +67,25 @@
 
   <div>
     <div class="row-fluid">
-      <div data-id="code_hidden" class="span4 hidable">
-        <label>
-          Code
-          <i class="fa fa-question-circle" rel="tooltip" title="The GGRC application will automatically provide codes for new objects.  If you would like to override this feature you may manually enter a code of your choosing.  You should have a specific reason for doing this."></i>
-          <a data-id="hide_code_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
-        </label>
-        <input {{^if new_object_form}} disabled {{/if}} data-id="code_txtbx" tabindex="6" class="input-block-level" name="slug" placeholder="STANDARD-XXX" type="text" value="{{slug}}">
-      </div>
+      {{#if_slug_allow new_object_form isProposal}}
+        <div data-id="code_hidden" class="span4 hidable">
+          <label>
+            Code
+            <i class="fa fa-question-circle" rel="tooltip" title="The GGRC application will automatically provide codes for new objects.  If you would like to override this feature you may manually enter a code of your choosing.  You should have a specific reason for doing this."></i>
+            <a data-id="hide_code_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
+          </label>
+          <input
+            disabled
+            data-id="code_txtbx"
+            tabindex="6"
+            class="input-block-level"
+            name="slug"
+            placeholder="STANDARD-XXX"
+            type="text"
+            value="{{slug}}"
+          >
+        </div>
+      {{/if_slug_allow}}
       <effective-dates instance="instance"/>
     </div>
     <div class="row-fluid">

--- a/src/ggrc/assets/mustache/systems/modal_content.mustache
+++ b/src/ggrc/assets/mustache/systems/modal_content.mustache
@@ -68,14 +68,25 @@
 
   <!-- Code & network block -->
   <div class="row-fluid">
-    <div data-id="code_hidden" class="span6 hidable">
-      <label>
-        Code
-        <i class="fa fa-question-circle" rel="tooltip" title="The GGRC application will automatically provide codes for new objects.  If you would like to override this feature you may manually enter a code of your choosing.  You should have a specific reason for doing this."></i>
-        <a data-id="hide_code_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
-      </label>
-      <input {{^if new_object_form}} disabled {{/if}} data-id="code_txtbx" tabindex="6" class="input-block-level" name="slug" placeholder="SYSTEM-XXX" type="text" value="{{slug}}">
-    </div>
+    {{#if_slug_allow new_object_form isProposal}}
+      <div data-id="code_hidden" class="span6 hidable">
+        <label>
+          Code
+          <i class="fa fa-question-circle" rel="tooltip" title="The GGRC application will automatically provide codes for new objects.  If you would like to override this feature you may manually enter a code of your choosing.  You should have a specific reason for doing this."></i>
+          <a data-id="hide_code_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
+        </label>
+        <input
+          disabled
+          data-id="code_txtbx"
+          tabindex="6"
+          class="input-block-level"
+          name="slug"
+          placeholder="SYSTEM-XXX"
+          type="text"
+          value="{{slug}}"
+        >
+      </div>
+    {{/if_slug_allow}}
     <div data-id="network_zone_hidden" class="span6 hidable">
       <label>
         Network Zone

--- a/src/ggrc/assets/mustache/task_group_tasks/modal_content.mustache
+++ b/src/ggrc/assets/mustache/task_group_tasks/modal_content.mustache
@@ -69,16 +69,27 @@
         <input type="hidden" name="task_group" model="TaskGroup" value="{{firstnonempty object_params.task_group instance.task_group.id}}" />
         <input type="hidden" name="context" model="Context" value="{{firstnonempty object_params.context instance.context.id}}" />
       </div>
-      <div class="row-fluid">
-        <div class="span6 hidable" data-id="code_hidden">
-          <label class="form__label form__label--hideable">
-            Code
-            <i class="fa fa-question-circle" rel="tooltip" title="The GGRC application will automatically provide codes for new objects.  If you would like to override this feature you may manually enter a code of your choosing.  You should have a specific reason for doing this."></i>
-          </label>
-          <a data-id="hide_code_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
-          <input {{^if new_object_form}} disabled {{/if}} data-id="code_txtbx" tabindex="8" class="input-block-level" name="slug" placeholder="TASK-XXX" type="text" value="{{instance.slug}}">
+      {{#if_slug_allow new_object_form isProposal}}
+        <div class="row-fluid">
+          <div class="span6 hidable" data-id="code_hidden">
+            <label class="form__label form__label--hideable">
+              Code
+              <i class="fa fa-question-circle" rel="tooltip" title="The GGRC application will automatically provide codes for new objects.  If you would like to override this feature you may manually enter a code of your choosing.  You should have a specific reason for doing this."></i>
+            </label>
+            <a data-id="hide_code_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
+            <input
+              disabled
+              data-id="code_txtbx"
+              tabindex="8"
+              class="input-block-level"
+              name="slug"
+              placeholder="TASK-XXX"
+              type="text"
+              value="{{instance.slug}}"
+            >
+          </div>
         </div>
-      </div>
+      {{/if_slug_allow}}
     </div>
     <div class="span4">
         <access-control-list-roles-helper

--- a/src/ggrc/assets/mustache/task_groups/modal_content.mustache
+++ b/src/ggrc/assets/mustache/task_groups/modal_content.mustache
@@ -80,14 +80,25 @@
       {{/if_helpers}}
     </div>
   </div>
-  <div class="row-fluid">
-    <div data-id="code_hidden" class="span4 hidable">
-      <label>
-        Code
-        <i class="fa fa-question-circle" rel="tooltip" title="The GGRC application will automatically provide codes for new objects.  If you would like to override this feature you may manually enter a code of your choosing.  You should have a specific reason for doing this."></i>
-        <a data-id="hide_code_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
-      </label>
-      <input {{^if new_object_form}} disabled {{/if}} data-id="code_txtbx" tabindex="8" class="input-block-level" name="slug" placeholder="TASKGROUP-XXX" type="text" value="{{instance.slug}}">
+  {{#if_slug_allow new_object_form isProposal}}
+    <div class="row-fluid">
+      <div data-id="code_hidden" class="span4 hidable">
+        <label>
+          Code
+          <i class="fa fa-question-circle" rel="tooltip" title="The GGRC application will automatically provide codes for new objects.  If you would like to override this feature you may manually enter a code of your choosing.  You should have a specific reason for doing this."></i>
+          <a data-id="hide_code_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
+        </label>
+        <input
+          disabled
+          data-id="code_txtbx"
+          tabindex="8"
+          class="input-block-level"
+          name="slug"
+          placeholder="TASKGROUP-XXX"
+          type="text"
+          value="{{instance.slug}}"
+        >
+      </div>
     </div>
-  </div>
+  {{/if_slug_allow}}
 </form>

--- a/src/ggrc/assets/mustache/threats/modal_content.mustache
+++ b/src/ggrc/assets/mustache/threats/modal_content.mustache
@@ -65,14 +65,24 @@
   </div>
 
   <div class="row-fluid">
-    <div class="span4 hidable">
-      <label>
-        Code
-        <i class="fa fa-question-circle" rel="tooltip" title="The ZenGRC application will automatically provide codes for new objects.  If you would like to override this feature you may manually enter a code of your choosing.  You should have a specific reason for doing this."></i>
-        <a href="javascript://" class="field-hide" tabindex="-1">hide</a>
-      </label>
-      <input {{^if new_object_form}} disabled {{/if}} tabindex="5" class="input-block-level" name="slug" placeholder="Threat-XXX" type="text" value="{{slug}}">
-    </div>
+    {{#if_slug_allow new_object_form isProposal}}
+      <div class="span4 hidable">
+        <label>
+          Code
+          <i class="fa fa-question-circle" rel="tooltip" title="The ZenGRC application will automatically provide codes for new objects.  If you would like to override this feature you may manually enter a code of your choosing.  You should have a specific reason for doing this."></i>
+          <a href="javascript://" class="field-hide" tabindex="-1">hide</a>
+        </label>
+        <input
+          disabled
+          tabindex="5"
+          class="input-block-level"
+          name="slug"
+          placeholder="Threat-XXX"
+          type="text"
+          value="{{slug}}"
+        >
+      </div>
+    {{/if_slug_allow}}
     <effective-dates instance="instance"/>
   </div>
   <div class="row-fluid">

--- a/src/ggrc/assets/mustache/vendors/modal_content.mustache
+++ b/src/ggrc/assets/mustache/vendors/modal_content.mustache
@@ -66,14 +66,25 @@
 
   <div>
     <div class="row-fluid">
-      <div data-id="code_hidden" class="span4 hidable">
-        <label>
-          Code
-          <i class="fa fa-question-circle" rel="tooltip" title="The GGRC application will automatically provide codes for new objects.  If you would like to override this feature you may manually enter a code of your choosing.  You should have a specific reason for doing this."></i>
-          <a data-id="hide_code_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
-        </label>
-        <input {{^if new_object_form}} disabled {{/if}} data-id="code_txtbx" tabindex="5" class="input-block-level" name="slug" placeholder="VENDOR-XXX" type="text" value="{{slug}}">
-      </div>
+      {{#if_slug_allow new_object_form isProposal}}
+        <div data-id="code_hidden" class="span4 hidable">
+          <label>
+            Code
+            <i class="fa fa-question-circle" rel="tooltip" title="The GGRC application will automatically provide codes for new objects.  If you would like to override this feature you may manually enter a code of your choosing.  You should have a specific reason for doing this."></i>
+            <a data-id="hide_code_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
+          </label>
+          <input
+            disabled
+            data-id="code_txtbx"
+            tabindex="5"
+            class="input-block-level"
+            name="slug"
+            placeholder="VENDOR-XXX"
+            type="text"
+            value="{{slug}}"
+          >
+        </div>
+      {{/if_slug_allow}}
       <effective-dates instance="instance"/>
     </div>
     <div class="row-fluid inner-hide">

--- a/src/ggrc/assets/mustache/workflows/modal_content.mustache
+++ b/src/ggrc/assets/mustache/workflows/modal_content.mustache
@@ -124,19 +124,22 @@
       </div>
     </div>
 
-    <div class="ggrc-form-item">
-      <div class="ggrc-form-item__multiple-row">
-        <label class="ggrc-form-item__label">
-          Code
-        </label>
-        <input
-          {{^if new_object_form}} disabled {{/if}}
-          tabindex="8"
-          class="input-block-level"
-          placeholder="WORKFLOW-XXX"
-          type="text"
-          {($value)}="instance.slug">
+    {{#if_slug_allow new_object_form isProposal}}
+      <div class="ggrc-form-item">
+        <div class="ggrc-form-item__multiple-row">
+          <label class="ggrc-form-item__label">
+            Code
+          </label>
+          <input
+            disabled
+            tabindex="8"
+            class="input-block-level"
+            placeholder="WORKFLOW-XXX"
+            type="text"
+            {($value)}="instance.slug"
+          >
+        </div>
       </div>
-    </div>
+    {{/if_slug_allow}}
   </form>
 </div>


### PR DESCRIPTION
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] #7614 (possibly conflicting changes)

# Issue description

**Code** field should be displayed only on **Edit** modal.
**Add** modal shouldn't contain **Code** field.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
