### PR TITLE
QUICK-FIX  Add try/catch block for parsing of JSON in global error handler

### DIFF
--- a/src/ggrc-client/js/plugins/ajax_extensions.js
+++ b/src/ggrc-client/js/plugins/ajax_extensions.js
@@ -1,148 +1,145 @@
 /*
-    Copyright (C) 2018 Google Inc.
-    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+  Copyright (C) 2018 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 */
-(function (root, $, can) {
+$.ajaxPrefilter(function (options, originalOptions, jqXHR) {
+  // setup timezone offset header in each ajax request
+  // it should be setup in minutes
 
-  $.ajaxPrefilter(function (options, originalOptions, jqXHR) {
-    // setup timezone offset header in each ajax request
-    // it should be setup in minutes
+  jqXHR.setRequestHeader(
+    'X-UserTimezoneOffset',
+    String(-1 * new Date().getTimezoneOffset())
+  );
+});
 
-    jqXHR.setRequestHeader(
-      'X-UserTimezoneOffset',
-      String(-1 * new Date().getTimezoneOffset())
-    );
-  });
+// Set up all PUT requests to the server to respect ETags, to ensure that
+// we are not overwriting more recent data than was viewed by the user.
+let etags = {},
+  doc = root.document,
+  body = doc.body,
+  $win = $(root),
+  $doc = $(doc),
+  $body = $(body);
 
-  // Set up all PUT requests to the server to respect ETags, to ensure that
-  // we are not overwriting more recent data than was viewed by the user.
-  let etags = {},
-    doc = root.document,
-    body = doc.body,
-    $win = $(root),
-    $doc = $(doc),
-    $body = $(body);
+$.ajaxPrefilter(function (options, originalOptions, jqXHR) {
+  let data = originalOptions.data;
+  let resourceUrl = originalOptions.url.split('?')[0];
 
-  $.ajaxPrefilter(function (options, originalOptions, jqXHR) {
-    let data = originalOptions.data;
-    let resourceUrl = originalOptions.url.split('?')[0];
+  function attach_provisional_id(prop) {
+    jqXHR.done(function (obj) {
+      obj[prop].provisional_id = data[prop].provisional_id;
+    });
+  }
 
-    function attach_provisional_id(prop) {
-      jqXHR.done(function (obj) {
-        obj[prop].provisional_id = data[prop].provisional_id;
-      });
-    }
-
-    if (/^\/api\//.test(options.url) && /PUT|POST|DELETE/.test(options.type.toUpperCase())) {
-      options.dataType = 'json';
-      options.contentType = 'application/json';
-      jqXHR.setRequestHeader('If-Match', (etags[resourceUrl] || [])[0]);
-      jqXHR.setRequestHeader('If-Unmodified-Since', (etags[resourceUrl] || [])[1]);
-      options.data = options.type.toUpperCase() === 'DELETE' ? '' : JSON.stringify(data);
-      for (let i in data) {
-        if (data.hasOwnProperty(i) && data[i] && data[i].provisional_id) {
-          attach_provisional_id(i);
-        }
+  if (/^\/api\//.test(options.url) && /PUT|POST|DELETE/.test(options.type.toUpperCase())) {
+    options.dataType = 'json';
+    options.contentType = 'application/json';
+    jqXHR.setRequestHeader('If-Match', (etags[resourceUrl] || [])[0]);
+    jqXHR.setRequestHeader('If-Unmodified-Since', (etags[resourceUrl] || [])[1]);
+    options.data = options.type.toUpperCase() === 'DELETE' ? '' : JSON.stringify(data);
+    for (let i in data) {
+      if (data.hasOwnProperty(i) && data[i] && data[i].provisional_id) {
+        attach_provisional_id(i);
       }
     }
-    if (/^\/api\//.test(options.url) && (options.type.toUpperCase() === 'GET')) {
-      options.cache = false;
-    }
-    if (/^\/api\/\w+/.test(options.url)) {
-      jqXHR.setRequestHeader('X-Requested-By', 'GGRC');
-      jqXHR.done(function (data, status, xhr) {
-        if (!/^\/api\/\w+\/\d+/.test(options.url) && options.type.toUpperCase() === 'GET') {
-          return;
-        }
-        switch (options.type.toUpperCase()) {
-          case 'GET':
-          case 'PUT':
-            etags[originalOptions.url] = [xhr.getResponseHeader('ETag'), xhr.getResponseHeader('Last-Modified')];
-            break;
-          case 'POST':
-            for (let d in data) {
-              if (data.hasOwnProperty(d) && data[d] && data[d].selfLink) {
-                etags[data[d].selfLink] = [xhr.getResponseHeader('ETag'), xhr.getResponseHeader('Last-Modified')];
-              }
+  }
+  if (/^\/api\//.test(options.url) && (options.type.toUpperCase() === 'GET')) {
+    options.cache = false;
+  }
+  if (/^\/api\/\w+/.test(options.url)) {
+    jqXHR.setRequestHeader('X-Requested-By', 'GGRC');
+    jqXHR.done(function (data, status, xhr) {
+      if (!/^\/api\/\w+\/\d+/.test(options.url) && options.type.toUpperCase() === 'GET') {
+        return;
+      }
+      switch (options.type.toUpperCase()) {
+        case 'GET':
+        case 'PUT':
+          etags[originalOptions.url] = [xhr.getResponseHeader('ETag'), xhr.getResponseHeader('Last-Modified')];
+          break;
+        case 'POST':
+          for (let d in data) {
+            if (data.hasOwnProperty(d) && data[d] && data[d].selfLink) {
+              etags[data[d].selfLink] = [xhr.getResponseHeader('ETag'), xhr.getResponseHeader('Last-Modified')];
             }
-            break;
-          case 'DELETE':
-            delete etags[originalOptions.url];
-            break;
-        }
-      });
-    }
-  });
-
-  // Set up default failure callbacks if nonesuch exist.
-  let _old_ajax = $.ajax;
-
-  // Here we break the deferred pattern a bit by piping back to original AJAX deferreds when we
-  // set up a failure handler on a later transformation of that deferred.  Why?  The reason is that
-  //  we have a default failure handler that should only be called if no other one is registered,
-  //  unless it's also explicitly asked for.  If it's registered in a transformed one, though (after
-  //  then() or pipe()), then the original one won't normally be notified of failure.
-  can.ajax = $.ajax = function (options) {
-    let _ajax = _old_ajax.apply($, arguments);
-
-    function setup(_new_ajax, _old_ajax) {
-      let _old_then = _new_ajax.then;
-      let _old_fail = _new_ajax.fail;
-      let _old_pipe = _new_ajax.pipe;
-      _old_ajax && (_new_ajax.hasFailCallback = _old_ajax.hasFailCallback);
-      _new_ajax.then = function () {
-        let _new_ajax = _old_then.apply(this, arguments);
-        if (arguments.length > 1) {
-          this.hasFailCallback = true;
-          if (_old_ajax) {
-            _old_ajax.fail(function () {});
           }
-        }
-        setup(_new_ajax, this);
-        return _new_ajax;
-      };
-      _new_ajax.fail = function () {
+          break;
+        case 'DELETE':
+          delete etags[originalOptions.url];
+          break;
+      }
+    });
+  }
+});
+
+// Set up default failure callbacks if nonesuch exist.
+let _old_ajax = $.ajax;
+
+// Here we break the deferred pattern a bit by piping back to original AJAX deferreds when we
+// set up a failure handler on a later transformation of that deferred.  Why?  The reason is that
+//  we have a default failure handler that should only be called if no other one is registered,
+//  unless it's also explicitly asked for.  If it's registered in a transformed one, though (after
+//  then() or pipe()), then the original one won't normally be notified of failure.
+can.ajax = $.ajax = function (options) {
+  let _ajax = _old_ajax.apply($, arguments);
+
+  function setup(_new_ajax, _old_ajax) {
+    let _old_then = _new_ajax.then;
+    let _old_fail = _new_ajax.fail;
+    let _old_pipe = _new_ajax.pipe;
+    _old_ajax && (_new_ajax.hasFailCallback = _old_ajax.hasFailCallback);
+    _new_ajax.then = function () {
+      let _new_ajax = _old_then.apply(this, arguments);
+      if (arguments.length > 1) {
         this.hasFailCallback = true;
         if (_old_ajax) {
           _old_ajax.fail(function () {});
         }
-        return _old_fail.apply(this, arguments);
-      };
-      _new_ajax.pipe = function () {
-        let _new_ajax = _old_pipe.apply(this, arguments);
-        setup(_new_ajax, this);
-        return _new_ajax;
-      };
-    }
-
-    setup(_ajax);
-    return _ajax;
-  };
-
-  $doc.ajaxError(function (event, jqxhr, settings, exception) {
-    let isExpectedError = jqxhr.getResponseHeader('X-Expected-Error');
-
-    if (!jqxhr.hasFailCallback && !isExpectedError) {
-      let response = jqxhr.responseJSON;
-
-      if (!response) {
-        try {
-          response = JSON.parse(jqxhr.responseText);
-        } catch (e) {
-          console.warn('Response not in JSON format');
-        }
       }
+      setup(_new_ajax, this);
+      return _new_ajax;
+    };
+    _new_ajax.fail = function () {
+      this.hasFailCallback = true;
+      if (_old_ajax) {
+        _old_ajax.fail(function () {});
+      }
+      return _old_fail.apply(this, arguments);
+    };
+    _new_ajax.pipe = function () {
+      let _new_ajax = _old_pipe.apply(this, arguments);
+      setup(_new_ajax, this);
+      return _new_ajax;
+    };
+  }
 
-      let message = jqxhr.getResponseHeader('X-Flash-Error') ||
-        GGRC.Errors.messages[jqxhr.status] ||
-        (response && response.message) ||
-        exception.message || exception;
+  setup(_ajax);
+  return _ajax;
+};
 
-      if (message) {
-        GGRC.Errors.notifier('error', message);
-      } else {
-        GGRC.Errors.notifierXHR('error')(jqxhr);
+$doc.ajaxError(function (event, jqxhr, settings, exception) {
+  let isExpectedError = jqxhr.getResponseHeader('X-Expected-Error');
+
+  if (!jqxhr.hasFailCallback && !isExpectedError) {
+    let response = jqxhr.responseJSON;
+
+    if (!response) {
+      try {
+        response = JSON.parse(jqxhr.responseText);
+      } catch (e) {
+        console.warn('Response not in JSON format');
       }
     }
-  });
-})(window, jQuery, can);
+
+    let message = jqxhr.getResponseHeader('X-Flash-Error') ||
+      GGRC.Errors.messages[jqxhr.status] ||
+      (response && response.message) ||
+      exception.message || exception;
+
+    if (message) {
+      GGRC.Errors.notifier('error', message);
+    } else {
+      GGRC.Errors.notifierXHR('error')(jqxhr);
+    }
+  }
+});

--- a/src/ggrc-client/js/plugins/ajax_extensions.js
+++ b/src/ggrc-client/js/plugins/ajax_extensions.js
@@ -123,7 +123,15 @@
     let isExpectedError = jqxhr.getResponseHeader('X-Expected-Error');
 
     if (!jqxhr.hasFailCallback && !isExpectedError) {
-      let response = jqxhr.responseJSON || JSON.parse(jqxhr.responseText);
+      let response = jqxhr.responseJSON;
+
+      if (!response) {
+        try {
+          response = JSON.parse(jqxhr.responseText);
+        } catch (e) {
+          console.warn('Response not in JSON format');
+        }
+      }
 
       let message = jqxhr.getResponseHeader('X-Flash-Error') ||
         GGRC.Errors.messages[jqxhr.status] ||

--- a/src/ggrc-client/js/plugins/ajax_extensions.js
+++ b/src/ggrc-client/js/plugins/ajax_extensions.js
@@ -26,12 +26,17 @@ $.ajaxPrefilter(function (options, originalOptions, jqXHR) {
     });
   }
 
-  if (/^\/api\//.test(options.url) && /PUT|POST|DELETE/.test(options.type.toUpperCase())) {
+  if (/^\/api\//.test(options.url)
+    && /PUT|POST|DELETE/.test(options.type.toUpperCase())) {
     options.dataType = 'json';
     options.contentType = 'application/json';
     jqXHR.setRequestHeader('If-Match', (etags[resourceUrl] || [])[0]);
-    jqXHR.setRequestHeader('If-Unmodified-Since', (etags[resourceUrl] || [])[1]);
-    options.data = options.type.toUpperCase() === 'DELETE' ? '' : JSON.stringify(data);
+    jqXHR.setRequestHeader('If-Unmodified-Since',
+      (etags[resourceUrl] || [])[1]);
+
+    options.data = options.type.toUpperCase() === 'DELETE' ? ''
+      : JSON.stringify(data);
+
     for (let i in data) {
       if (data.hasOwnProperty(i) && data[i] && data[i].provisional_id) {
         attachProvisionalId(i);
@@ -44,18 +49,26 @@ $.ajaxPrefilter(function (options, originalOptions, jqXHR) {
   if (/^\/api\/\w+/.test(options.url)) {
     jqXHR.setRequestHeader('X-Requested-By', 'GGRC');
     jqXHR.done(function (data, status, xhr) {
-      if (!/^\/api\/\w+\/\d+/.test(options.url) && options.type.toUpperCase() === 'GET') {
+      if (!/^\/api\/\w+\/\d+/.test(options.url)
+        && options.type.toUpperCase() === 'GET') {
         return;
       }
       switch (options.type.toUpperCase()) {
         case 'GET':
         case 'PUT':
-          etags[originalOptions.url] = [xhr.getResponseHeader('ETag'), xhr.getResponseHeader('Last-Modified')];
+          etags[originalOptions.url] = [
+            xhr.getResponseHeader('ETag'),
+            xhr.getResponseHeader('Last-Modified'),
+          ];
           break;
         case 'POST':
-          for (let d in data) {
-            if (data.hasOwnProperty(d) && data[d] && data[d].selfLink) {
-              etags[data[d].selfLink] = [xhr.getResponseHeader('ETag'), xhr.getResponseHeader('Last-Modified')];
+          for (let field in data) {
+            if (data.hasOwnProperty(field) && data[field]
+              && data[field].selfLink) {
+              etags[data[field].selfLink] = [
+                xhr.getResponseHeader('ETag'),
+                xhr.getResponseHeader('Last-Modified'),
+              ];
             }
           }
           break;

--- a/src/ggrc-client/js/plugins/ajax_extensions.js
+++ b/src/ggrc-client/js/plugins/ajax_extensions.js
@@ -14,12 +14,7 @@ $.ajaxPrefilter(function (options, originalOptions, jqXHR) {
 
 // Set up all PUT requests to the server to respect ETags, to ensure that
 // we are not overwriting more recent data than was viewed by the user.
-let etags = {},
-  doc = root.document,
-  body = doc.body,
-  $win = $(root),
-  $doc = $(doc),
-  $body = $(body);
+const etags = {};
 
 $.ajaxPrefilter(function (options, originalOptions, jqXHR) {
   let data = originalOptions.data;
@@ -117,7 +112,7 @@ can.ajax = $.ajax = function (options) {
   return _ajax;
 };
 
-$doc.ajaxError(function (event, jqxhr, settings, exception) {
+$(document).ajaxError(function (event, jqxhr, settings, exception) {
   let isExpectedError = jqxhr.getResponseHeader('X-Expected-Error');
 
   if (!jqxhr.hasFailCallback && !isExpectedError) {

--- a/src/ggrc-client/js/plugins/ajax_extensions.js
+++ b/src/ggrc-client/js/plugins/ajax_extensions.js
@@ -20,7 +20,7 @@ $.ajaxPrefilter(function (options, originalOptions, jqXHR) {
   let data = originalOptions.data;
   let resourceUrl = originalOptions.url.split('?')[0];
 
-  function attach_provisional_id(prop) {
+  function attachProvisionalId(prop) {
     jqXHR.done(function (obj) {
       obj[prop].provisional_id = data[prop].provisional_id;
     });
@@ -34,7 +34,7 @@ $.ajaxPrefilter(function (options, originalOptions, jqXHR) {
     options.data = options.type.toUpperCase() === 'DELETE' ? '' : JSON.stringify(data);
     for (let i in data) {
       if (data.hasOwnProperty(i) && data[i] && data[i].provisional_id) {
-        attach_provisional_id(i);
+        attachProvisionalId(i);
       }
     }
   }
@@ -68,7 +68,7 @@ $.ajaxPrefilter(function (options, originalOptions, jqXHR) {
 });
 
 // Set up default failure callbacks if nonesuch exist.
-let _old_ajax = $.ajax;
+let _oldAjax = $.ajax;
 
 // Here we break the deferred pattern a bit by piping back to original AJAX deferreds when we
 // set up a failure handler on a later transformation of that deferred.  Why?  The reason is that
@@ -76,35 +76,35 @@ let _old_ajax = $.ajax;
 //  unless it's also explicitly asked for.  If it's registered in a transformed one, though (after
 //  then() or pipe()), then the original one won't normally be notified of failure.
 can.ajax = $.ajax = function (options) {
-  let _ajax = _old_ajax.apply($, arguments);
+  let _ajax = _oldAjax.apply($, arguments);
 
-  function setup(_new_ajax, _old_ajax) {
-    let _old_then = _new_ajax.then;
-    let _old_fail = _new_ajax.fail;
-    let _old_pipe = _new_ajax.pipe;
-    _old_ajax && (_new_ajax.hasFailCallback = _old_ajax.hasFailCallback);
-    _new_ajax.then = function () {
-      let _new_ajax = _old_then.apply(this, arguments);
+  function setup(newAjax, oldAjax) {
+    let oldThen = newAjax.then;
+    let oldFail = newAjax.fail;
+    let oldPipe = newAjax.pipe;
+    oldAjax && (newAjax.hasFailCallback = oldAjax.hasFailCallback);
+    newAjax.then = function () {
+      let _newAjax = oldThen.apply(this, arguments);
       if (arguments.length > 1) {
         this.hasFailCallback = true;
-        if (_old_ajax) {
-          _old_ajax.fail(function () {});
+        if (oldAjax) {
+          oldAjax.fail(function () {});
         }
       }
-      setup(_new_ajax, this);
-      return _new_ajax;
+      setup(_newAjax, this);
+      return _newAjax;
     };
-    _new_ajax.fail = function () {
+    newAjax.fail = function () {
       this.hasFailCallback = true;
-      if (_old_ajax) {
-        _old_ajax.fail(function () {});
+      if (oldAjax) {
+        oldAjax.fail(function () {});
       }
-      return _old_fail.apply(this, arguments);
+      return oldFail.apply(this, arguments);
     };
-    _new_ajax.pipe = function () {
-      let _new_ajax = _old_pipe.apply(this, arguments);
-      setup(_new_ajax, this);
-      return _new_ajax;
+    newAjax.pipe = function () {
+      let _newAjax = oldPipe.apply(this, arguments);
+      setup(_newAjax, this);
+      return _newAjax;
     };
   }
 


### PR DESCRIPTION
# Issue description

In some cases response on HTTP errors is returning not in valid JSON format, that leads to JS errors and not clear warnings for the user.

# Solution description

Added try/catch block in global error handler

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
