### PR TITLE
QUICK-FIX Fix migrations for cloud sql and remove redundant imports from invalid backmerge

### DIFF
--- a/src/ggrc/converters/base_row.py
+++ b/src/ggrc/converters/base_row.py
@@ -16,8 +16,6 @@ from ggrc.rbac import permissions
 from ggrc.services import signals
 from ggrc.utils import dump_attrs
 
-from ggrc.utils import dump_attrs
-
 
 class RowConverter(object):
   """Base class for handling row data."""

--- a/src/ggrc/migrations/utils/acr_propagation.py
+++ b/src/ggrc/migrations/utils/acr_propagation.py
@@ -173,8 +173,8 @@ def remove_propagated_roles(object_type, role_names):
   )
   child_role_ids = connection.execute(
       sa.select([ACR_TABLE.c.id]).where(
-        ACR_TABLE.c.parent_id.in_(parent_role_ids),
-    )
+          ACR_TABLE.c.parent_id.in_(parent_role_ids),
+      )
   ).fetchall()
   child_ids = [row.id for row in child_role_ids]
   if not child_ids:

--- a/src/ggrc/migrations/versions/20180305202849_3db5f2027c92_update_acr_table.py
+++ b/src/ggrc/migrations/versions/20180305202849_3db5f2027c92_update_acr_table.py
@@ -55,9 +55,44 @@ def _copy_current_acl_table():
   downgrade the release to previous version.
   """
   op.execute("DROP TABLE IF EXISTS acl_copy")
-  op.execute("CREATE TABLE acl_copy AS SELECT * FROM access_control_list")
+  op.execute("""
+      CREATE TABLE `acl_copy` (
+          `id` int(11) NOT NULL DEFAULT '0',
+          `person_id` int(11) NOT NULL,
+          `ac_role_id` int(11) NOT NULL,
+          `object_id` int(11) NOT NULL,
+          `object_type` varchar(250) NOT NULL,
+          `created_at` datetime NOT NULL,
+          `modified_by_id` int(11) DEFAULT NULL,
+          `updated_at` datetime NOT NULL,
+          `context_id` int(11) DEFAULT NULL,
+          `parent_id` int(11) DEFAULT NULL
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8
+  """)
   op.execute("DROP TABLE IF EXISTS acr_copy")
-  op.execute("CREATE TABLE acr_copy AS SELECT * FROM access_control_roles")
+  op.execute("""
+      CREATE TABLE `acr_copy` (
+          `id` int(11) NOT NULL DEFAULT '0',
+          `name` varchar(250) NOT NULL,
+          `object_type` varchar(250) DEFAULT NULL,
+          `tooltip` varchar(250) DEFAULT NULL,
+          `read` tinyint(1) NOT NULL DEFAULT '1',
+          `update` tinyint(1) NOT NULL DEFAULT '1',
+          `delete` tinyint(1) NOT NULL DEFAULT '1',
+          `my_work` tinyint(1) NOT NULL DEFAULT '1',
+          `created_at` datetime NOT NULL,
+          `modified_by_id` int(11) DEFAULT NULL,
+          `updated_at` datetime NOT NULL,
+          `context_id` int(11) DEFAULT NULL,
+          `mandatory` tinyint(1) NOT NULL DEFAULT '0',
+          `default_to_current_user` tinyint(1) NOT NULL DEFAULT '0',
+          `non_editable` tinyint(1) NOT NULL DEFAULT '0',
+          `internal` tinyint(1) NOT NULL DEFAULT '0',
+          `notify_about_proposal` tinyint(1) NOT NULL DEFAULT '0'
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8
+  """)
+  op.execute("INSERT INTO acr_copy SELECT * FROM access_control_roles")
+  op.execute("INSERT INTO acl_copy SELECT * FROM access_control_list")
 
 
 def upgrade():

--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -48,8 +48,6 @@ from ggrc.cache import utils as cache_utils
 
 
 # pylint: disable=invalid-name
-from ggrc.utils import dump_attrs
-
 logger = getLogger(__name__)
 
 


### PR DESCRIPTION
# Issue description

Issue 1:
The create from select is not supported with our current cloud sql
settings. So the change manually creates the temp tables and then
inserts the data.

Issue 2:
There was an invalid conflict resolution done in https://github.com/google/ggrc-core/pull/7714. The end result was that imports were duplicated.

# Steps to test the changes

Run migrations upgrade and downgrade. possibly deploy to one of our test instances.
check result of pylint and flake8 and check that there are no multiple uses of dump_attrs

# Solution description

- Remove the `create table ... select` from our migrations
- Remove duplicate imports

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# Migration checklist
- [x] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)


# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
