### PR TITLE
GGRC-4960 Disabling the filtering for active cycle [task editing performance]

### DIFF
--- a/src/ggrc_workflows/__init__.py
+++ b/src/ggrc_workflows/__init__.py
@@ -551,11 +551,11 @@ def handle_cycle_task_group_object_task_put(
     db.session.flush()
 
 
-@signals.Restful.model_posted_after_commit.connect_via(
+@signals.Restful.model_posted.connect_via(
     models.CycleTaskGroupObjectTask)
-@signals.Restful.model_put_before_commit.connect_via(
+@signals.Restful.model_put.connect_via(
     models.CycleTaskGroupObjectTask)
-@signals.Restful.model_deleted_after_commit.connect_via(
+@signals.Restful.model_deleted.connect_via(
     models.CycleTaskGroupObjectTask)
 # noqa pylint: disable=unused-argument
 def handle_cycle_object_status(
@@ -563,7 +563,7 @@ def handle_cycle_object_status(
         initial_state=None):
   """Calculate status of cycle and cycle task group"""
   update_cycle_task_tree([obj])
-  db.session.commit()
+  # db.session.commit()
 
 
 @signals.Restful.model_posted.connect_via(models.CycleTaskGroupObjectTask)

--- a/src/ggrc_workflows/models/cycle.py
+++ b/src/ggrc_workflows/models/cycle.py
@@ -101,55 +101,7 @@ class Cycle(mixins.WithContact,
   PROPERTY_TEMPLATE = u"cycle {}"
 
   _fulltext_attrs = [
-      ft_attributes.MultipleSubpropertyFullTextAttr(
-          "group title", "cycle_task_groups", ["title"], False,
-      ),
-      ft_attributes.MultipleSubpropertyFullTextAttr(
-          "group assignee",
-          lambda instance: [g.contact for g in instance.cycle_task_groups],
-          ["email", "name"],
-          False,
-      ),
-      ft_attributes.DateMultipleSubpropertyFullTextAttr(
-          "group due date",
-          'cycle_task_groups',
-          ["next_due_date"],
-          False,
-      ),
-      ft_attributes.MultipleSubpropertyFullTextAttr(
-          "task title",
-          'cycle_task_group_object_tasks',
-          ["title"],
-          False,
-      ),
-      ft_attributes.DateMultipleSubpropertyFullTextAttr(
-          "task due date",
-          "cycle_task_group_object_tasks",
-          ["end_date"],
-          False
-      ),
-      ft_attributes.MultipleSubpropertyFullTextAttr(
-          "task assignees",
-          "_task_assignees",
-          ["name", "email"],
-          False,
-      ),
-      ft_attributes.MultipleSubpropertyFullTextAttr(
-          "task secondary assignees",
-          "_task_secondary_assignees",
-          ["name", "email"],
-          False,
-      ),
       ft_attributes.DateFullTextAttr("due date", "next_due_date"),
-      ft_attributes.MultipleSubpropertyFullTextAttr(
-          "task comments",
-          lambda instance: list(itertools.chain(*[
-              t.cycle_task_entries
-              for t in instance.cycle_task_group_object_tasks
-          ])),
-          ["description"],
-          False
-      ),
       "folder",
   ]
 
@@ -170,10 +122,7 @@ class Cycle(mixins.WithContact,
     return list(people)
 
   AUTO_REINDEX_RULES = [
-      ft_mixin.ReindexRule("CycleTaskGroup", lambda x: x.cycle),
-      ft_mixin.ReindexRule("CycleTaskGroupObjectTask",
-                           lambda x: x.cycle_task_group.cycle),
-      ft_mixin.ReindexRule("Person", _query_filtered_by_contact)
+      ft_mixin.ReindexRule("Person", _query_filtered_by_contact),
   ]
 
   @classmethod
@@ -208,41 +157,6 @@ class Cycle(mixins.WithContact,
   def indexed_query(cls):
     return super(Cycle, cls).indexed_query().options(
         orm.Load(cls).load_only("next_due_date"),
-        orm.Load(cls).subqueryload("cycle_task_group_object_tasks").load_only(
-            "id",
-            "title",
-            "end_date"
-        ),
-        orm.Load(cls).subqueryload("cycle_task_groups").load_only(
-            "id",
-            "title",
-            "end_date",
-            "next_due_date",
-        ),
-        orm.Load(cls).subqueryload("cycle_task_group_object_tasks").joinedload(
-            "access_control_list"
-        ).load_only(
-            "person_id",
-            "ac_role_id"
-        ),
-        orm.Load(cls).subqueryload("cycle_task_group_object_tasks").joinedload(
-            "cycle_task_entries"
-        ).load_only(
-            "description",
-            "id"
-        ),
-        orm.Load(cls).subqueryload("cycle_task_groups").joinedload(
-            "contact"
-        ).load_only(
-            "email",
-            "name",
-            "id"
-        ),
-        orm.Load(cls).joinedload("contact").load_only(
-            "email",
-            "name",
-            "id"
-        ),
         orm.Load(cls).joinedload("workflow").undefer_group(
             "Workflow_complete"
         ),

--- a/src/ggrc_workflows/models/cycle.py
+++ b/src/ggrc_workflows/models/cycle.py
@@ -4,7 +4,6 @@
 """Module contains a workflow Cycle model
 """
 
-import itertools
 from urlparse import urljoin
 
 from sqlalchemy import orm, inspect

--- a/src/ggrc_workflows/models/cycle_task_group.py
+++ b/src/ggrc_workflows/models/cycle_task_group.py
@@ -4,8 +4,6 @@
 """Module for cycle task group model.
 """
 
-import itertools
-
 from sqlalchemy import orm, inspect
 
 from ggrc import db

--- a/src/ggrc_workflows/models/cycle_task_group.py
+++ b/src/ggrc_workflows/models/cycle_task_group.py
@@ -81,24 +81,6 @@ class CycleTaskGroup(roleable.Roleable,
   PROPERTY_TEMPLATE = u"group {}"
 
   _fulltext_attrs = [
-      attributes.MultipleSubpropertyFullTextAttr(
-          "task title", 'cycle_task_group_tasks', ["title"], False
-      ),
-      attributes.MultipleSubpropertyFullTextAttr(
-          "task assignees",
-          "_task_assignees",
-          ["email", "name"],
-          False
-      ),
-      attributes.MultipleSubpropertyFullTextAttr(
-          "task secondary assignees",
-          "_task_secondary_assignees",
-          ["email", "name"],
-          False,
-      ),
-      attributes.DateMultipleSubpropertyFullTextAttr(
-          "task due date", "cycle_task_group_tasks", ["end_date"], False
-      ),
       attributes.DateFullTextAttr("due date", 'next_due_date',),
       attributes.FullTextAttr("assignee", "contact", ['email', 'name']),
       attributes.FullTextAttr("cycle title", 'cycle', ['title'], False),
@@ -109,14 +91,6 @@ class CycleTaskGroup(roleable.Roleable,
       attributes.DateFullTextAttr("cycle due date",
                                   lambda x: x.cycle.next_due_date,
                                   with_template=False),
-      attributes.MultipleSubpropertyFullTextAttr(
-          "task comments",
-          lambda instance: itertools.chain(*[
-              t.cycle_task_entries for t in instance.cycle_task_group_tasks
-          ]),
-          ["description"],
-          False
-      ),
   ]
 
   @property
@@ -142,10 +116,8 @@ class CycleTaskGroup(roleable.Roleable,
 
   AUTO_REINDEX_RULES = [
       index_mixin.ReindexRule(
-          "CycleTaskGroupObjectTask", lambda x: x.cycle_task_group
-      ),
-      index_mixin.ReindexRule(
-          "Person", _query_filtered_by_contact
+          "Person",
+          _query_filtered_by_contact
       ),
       index_mixin.ReindexRule(
           "Person",
@@ -176,27 +148,10 @@ class CycleTaskGroup(roleable.Roleable,
         orm.Load(cls).load_only(
             "next_due_date",
         ),
-        orm.Load(cls).subqueryload("cycle_task_group_tasks").load_only(
-            "id",
-            "title",
-            "end_date"
-        ),
-        orm.Load(cls).subqueryload("cycle_task_group_tasks").joinedload(
-            "access_control_list"
-        ).load_only(
-            "person_id",
-            "ac_role_id"
-        ),
         orm.Load(cls).joinedload("cycle").load_only(
             "id",
             "title",
             "next_due_date"
-        ),
-        orm.Load(cls).subqueryload("cycle_task_group_tasks").joinedload(
-            "cycle_task_entries"
-        ).load_only(
-            "description",
-            "id"
         ),
         orm.Load(cls).joinedload("cycle").joinedload(
             "contact"

--- a/test/integration/ggrc_workflows/converters/test_export_cycle_task_groups.py
+++ b/test/integration/ggrc_workflows/converters/test_export_cycle_task_groups.py
@@ -3,7 +3,7 @@
 
 
 """Tests for task group task specific export."""
-
+import unittest
 from collections import defaultdict
 
 from ddt import data, unpack, ddt
@@ -16,6 +16,7 @@ from integration.ggrc import TestCase
 from ggrc.models.all_models import CycleTaskGroupObjectTask, CycleTaskGroup
 
 
+@unittest.skip("Skip cause feature cut.")
 @ddt
 class TestExportTasks(TestCase):
   """Test imports for basic workflow objects."""

--- a/test/integration/ggrc_workflows/converters/test_export_cycle_tasks.py
+++ b/test/integration/ggrc_workflows/converters/test_export_cycle_tasks.py
@@ -3,7 +3,7 @@
 
 
 """Tests for task group task specific export."""
-
+import unittest
 from collections import defaultdict
 
 from ddt import data, unpack, ddt
@@ -15,6 +15,7 @@ from integration.ggrc.models import factories as ggrc_factories
 from ggrc.models import all_models
 
 
+@unittest.skip("Skip cause of feature cut.")
 @ddt
 class TestExportTasks(TestCase):
   """Test imports for basic workflow objects."""

--- a/test/integration/ggrc_workflows/models/test_cycle_task_group_object_task.py
+++ b/test/integration/ggrc_workflows/models/test_cycle_task_group_object_task.py
@@ -2,6 +2,7 @@
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
 """Module for integration tests for CycleTaskGroupObjectTask specifics."""
+import unittest
 
 import ddt
 
@@ -224,6 +225,7 @@ class CycleTaskQueryAPI(query_helper.WithQueryApi, TestCTGOT):
                                         "total")
     self.assertEqual(result, 1)
 
+  @unittest.skip("Skip cause feature cut.")
   def test_query_by_task_secondary_assignee_on_active_cycles_tab(self):  # noqa pylint: disable=invalid-name
     """Test QueryAPI request for CycleTasks on Active Cycles tab."""
     data = [


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Update Cycle Task may take really long period of work.

# Steps to test the changes

Create quiet big Cycle. I test it on 10 Task Group and 1000 task in each task group and about 10 Comments per task. 

# Solution description

Remove reindex procedure for Cycle and Task Group on update Cycle Task. 

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [ ] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
