### PR TITLE
GGRC-4926 Add access control list table optimizations

### DIFF
--- a/src/ggrc/access_control/list.py
+++ b/src/ggrc/access_control/list.py
@@ -41,7 +41,7 @@ class AccessControlList(mixins.Base, db.Model):
       nullable=True,
   )
   parent = db.relationship(
-      lambda: AccessControlList,
+      lambda: AccessControlList,  # pylint: disable=undefined-variable
       remote_side=lambda: AccessControlList.id
   )
 

--- a/src/ggrc/access_control/list.py
+++ b/src/ggrc/access_control/list.py
@@ -30,6 +30,11 @@ class AccessControlList(mixins.Base, db.Model):
   object_id = db.Column(db.Integer, nullable=False)
   object_type = db.Column(db.String, nullable=False)
 
+  parent_id_nn = db.Column(
+      db.Integer,
+      nullable=False,
+      default="0",
+  )
   parent_id = db.Column(
       db.Integer,
       db.ForeignKey('access_control_list.id', ondelete='CASCADE'),
@@ -66,8 +71,18 @@ class AccessControlList(mixins.Base, db.Model):
   def _extra_table_args(_):
     return (
         db.UniqueConstraint(
-            'person_id', 'ac_role_id', 'object_id', 'object_type', 'parent_id'
+            'person_id',
+            'ac_role_id',
+            'object_id',
+            'object_type',
+            'parent_id_nn',
         ),
         db.Index('idx_object_type_object_idx', 'object_type', 'object_id'),
         db.Index('ix_person_object', 'person_id', 'object_type', 'object_id'),
+        db.Index(
+            'idx_object_type_object_id_parent_id_nn',
+            'object_type',
+            'object_id',
+            'parent_id_nn',
+        ),
     )

--- a/src/ggrc/access_control/roleable.py
+++ b/src/ggrc/access_control/roleable.py
@@ -36,7 +36,8 @@ class Roleable(object):
         primaryjoin=lambda: and_(
             remote(AccessControlList.object_id) == cls.id,
             remote(AccessControlList.object_type) == cls.__name__,
-            remote(AccessControlList.parent_id).is_(None)),
+            remote(AccessControlList.parent_id_nn) == 0
+        ),
         foreign_keys='AccessControlList.object_id',
         backref='{0}_object'.format(cls.__name__),
         cascade='all, delete-orphan')

--- a/src/ggrc/access_control/utils.py
+++ b/src/ggrc/access_control/utils.py
@@ -66,7 +66,7 @@ def insert_select_acls(inserter, select_statement):
 
   if last_error:
     logger.critical(
-        "Workflow ACL propagation failed with %d retries on statement: \n %s",
+        "ACL propagation failed with %d retries on statement: \n %s",
         PROPAGATION_RETRIES,
         select_statement,
     )

--- a/src/ggrc/access_control/utils.py
+++ b/src/ggrc/access_control/utils.py
@@ -1,0 +1,75 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+
+"""Entry point for all acl handlers.
+
+This package should have the single hook that should handle all acl propagation
+and deletion.
+"""
+
+import logging
+
+import sqlalchemy as sa
+
+from ggrc import db
+from ggrc.models import all_models
+
+logger = logging.getLogger(__name__)
+
+# retry count for possible deadlock issues.
+PROPAGATION_RETRIES = 10
+
+
+def insert_select_acls(inserter, select_statement):
+  """Insert acl records from the select statement
+  Args:
+    select_statement: sql statement that contains the following columns
+      person_id,
+      ac_role_id,
+      object_id,
+      object_type,
+      created_at,
+      modified_by_id,
+      updated_at,
+      parent_id,
+      parent_id_nn,
+  """
+
+  acl_table = all_models.AccessControlList.__table__
+
+  last_error = None
+  for _ in range(PROPAGATION_RETRIES):
+    try:
+      last_error = None
+      db.session.execute(
+          inserter.from_select(
+              [
+                  acl_table.c.person_id,
+                  acl_table.c.ac_role_id,
+                  acl_table.c.object_id,
+                  acl_table.c.object_type,
+                  acl_table.c.created_at,
+                  acl_table.c.modified_by_id,
+                  acl_table.c.updated_at,
+                  acl_table.c.parent_id,
+                  acl_table.c.parent_id_nn,
+              ],
+              select_statement
+          )
+      )
+      db.session.plain_commit()
+      break
+    except sa.exc.OperationalError as error:
+      logger.exception(error)
+      last_error = error
+
+  if last_error:
+    logger.critical(
+        "Workflow ACL propagation failed with %d retries on statement: \n %s",
+        PROPAGATION_RETRIES,
+        select_statement,
+    )
+    # The following error if exists will only be sa.exc.OperationalError so the
+    # pylint warning is invalid.
+    raise last_error  # pylint: disable=raising-bad-type

--- a/src/ggrc/migrations/versions/20180430005840_e5f737f2a428_add_parent_id_nn_to_acl_table.py
+++ b/src/ggrc/migrations/versions/20180430005840_e5f737f2a428_add_parent_id_nn_to_acl_table.py
@@ -1,0 +1,128 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Add parent id nn to acl table
+
+Create Date: 2018-04-30 00:58:40.172905
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = 'e5f737f2a428'
+down_revision = '2795c6d50e62'
+
+
+def _remove_acl_duplicates():
+  """Remove duplicate entries in acl entry.
+
+  Because our unique index on ACL table contains a nullable column, we can have
+  duplicates of the top most items that have parent_id set to null.
+
+  Because we want to avoid that we'll change the unique constraint to a non
+  nullable field and for that we must first remove any duplicate entry that
+  would cause the migration to fail.
+  """
+  acl_table = sa.sql.table(
+      "access_control_list",
+      sa.sql.column('id', sa.Integer),
+  )
+  connection = op.get_bind()
+  duplicates_query = connection.execute("""
+      select
+        group_concat(id),
+        count(id) as count
+      from access_control_list
+      where
+        parent_id is null
+      group by
+        `person_id`,
+        `ac_role_id`,
+        `object_id`,
+        `object_type`
+      having count > 1
+  """)
+
+  duplicates = []
+  for ids_string, _ in duplicates_query.fetchall():
+    ids = ids_string.split(",")
+    duplicates.extend(ids[1:])
+
+  op.execute(
+      acl_table.delete().where(
+          acl_table.c.id.in_(duplicates)
+      )
+  )
+
+
+def _add_parent_id_nn_column():
+  """Add parent_id_nn column and make it non nullable.
+
+  The creation of the column and making it non nullable are done in separate
+  steps to avoid mysql warnings for missing values.
+  """
+  op.add_column(
+      'access_control_list',
+      sa.Column(
+          'parent_id_nn',
+          sa.Integer(),
+          server_default="0",
+          nullable=True,
+      ),
+  )
+
+  op.execute("update access_control_list set parent_id_nn = parent_id")
+  op.execute("""
+      update access_control_list
+      set parent_id_nn = 0
+      where parent_id_nn is null
+  """)
+
+  op.alter_column(
+      'access_control_list',
+      'parent_id_nn',
+      existing_type=sa.Integer(),
+      server_default="0",
+      nullable=False,
+  )
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+
+  _remove_acl_duplicates()
+  _add_parent_id_nn_column()
+
+  op.create_index(
+      'idx_object_type_object_id_parent_id_nn',
+      'access_control_list',
+      ['object_type', 'object_id', 'parent_id_nn'],
+      unique=False,
+  )
+
+  op.create_unique_constraint(
+      'uq_access_control_list',
+      'access_control_list',
+      ['person_id', 'ac_role_id', 'object_id', 'object_type', 'parent_id_nn'],
+  )
+  op.drop_index('person_id', table_name='access_control_list')
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  op.create_unique_constraint(
+      'person_id',
+      'access_control_list',
+      ['person_id', 'ac_role_id', 'object_id', 'object_type', 'parent_id'],
+  )
+  op.drop_index('uq_access_control_list', table_name='access_control_list')
+  op.drop_index(
+      'idx_object_type_object_id_parent_id_nn',
+      table_name='access_control_list'
+  )
+  op.drop_column('access_control_list', 'parent_id_nn')

--- a/src/ggrc/models/hooks/acl/propagation.py
+++ b/src/ggrc/models/hooks/acl/propagation.py
@@ -358,6 +358,7 @@ def _delete_all_propagated_acls():
   This function is used as cleanup before we re-evaluate propagation for all
   objects.
   """
+  logger.info("Deleting all propagated acl entries")
   acl_table = all_models.AccessControlList.__table__
   db.session.execute(
       acl_table.delete().where(

--- a/src/ggrc/models/hooks/acl/propagation.py
+++ b/src/ggrc/models/hooks/acl/propagation.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 PROPAGATION_DEPTH_LIMIT = 50
 
 
-def _insert_select_acls(select_statement):
+def insert_select_acls(inserter, select_statement):
   """Insert acl records from the select statement
   Args:
     select_statement: sql statement that contains the following columns
@@ -44,7 +44,7 @@ def _insert_select_acls(select_statement):
   acl_table = all_models.AccessControlList.__table__
 
   db.session.execute(
-      acl_table.insert().from_select(
+      inserter.from_select(
           [
               acl_table.c.person_id,
               acl_table.c.ac_role_id,
@@ -60,6 +60,12 @@ def _insert_select_acls(select_statement):
       )
   )
   db.session.plain_commit()
+
+
+def _insert_select_acls(select_statement):
+  """Run insert from select with default acl inserter."""
+  inserter = all_models.AccessControlList.__table__.insert()
+  insert_select_acls(inserter, select_statement)
 
 
 def _rel_parent(parent_acl_ids=None, relationship_ids=None, source=True):

--- a/src/ggrc/models/hooks/acl/propagation.py
+++ b/src/ggrc/models/hooks/acl/propagation.py
@@ -38,6 +38,7 @@ def _insert_select_acls(select_statement):
       modified_by_id,
       updated_at,
       parent_id,
+      parent_id_nn,
   """
 
   acl_table = all_models.AccessControlList.__table__
@@ -53,6 +54,7 @@ def _insert_select_acls(select_statement):
               acl_table.c.modified_by_id,
               acl_table.c.updated_at,
               acl_table.c.parent_id,
+              acl_table.c.parent_id_nn,
           ],
           select_statement
       )
@@ -103,6 +105,7 @@ def _rel_parent(parent_acl_ids=None, relationship_ids=None, source=True):
       sa.literal(login.get_current_user_id()).label("modified_by_id"),
       sa.func.now().label("updated_at"),
       acl_table.c.id.label("parent_id"),
+      acl_table.c.id.label("parent_id_nn"),
   ]).select_from(
       sa.join(
           sa.join(
@@ -168,6 +171,7 @@ def _rel_child(parent_acl_ids, source=True):
       sa.literal(login.get_current_user_id()).label("modified_by_id"),
       sa.func.now().label("updated_at"),
       acl_table.c.id.label("parent_id"),
+      acl_table.c.id.label("parent_id_nn"),
   ]).select_from(
       sa.join(
           sa.join(

--- a/src/ggrc/models/hooks/acl/propagation.py
+++ b/src/ggrc/models/hooks/acl/propagation.py
@@ -16,6 +16,7 @@ import sqlalchemy as sa
 from ggrc import db
 from ggrc import login
 from ggrc import utils
+from ggrc.access_control import utils as acl_utils
 from ggrc.models import all_models
 
 logger = logging.getLogger(__name__)
@@ -25,68 +26,11 @@ logger = logging.getLogger(__name__)
 # contain cycles.
 PROPAGATION_DEPTH_LIMIT = 50
 
-# retry count for possible deadlock issues.
-PROPAGATION_RETRIES = 10
-
-
-def insert_select_acls(inserter, select_statement):
-  """Insert acl records from the select statement
-  Args:
-    select_statement: sql statement that contains the following columns
-      person_id,
-      ac_role_id,
-      object_id,
-      object_type,
-      created_at,
-      modified_by_id,
-      updated_at,
-      parent_id,
-      parent_id_nn,
-  """
-
-  acl_table = all_models.AccessControlList.__table__
-
-  last_error = None
-  for _ in range(PROPAGATION_RETRIES):
-    try:
-      last_error = None
-      db.session.execute(
-          inserter.from_select(
-              [
-                  acl_table.c.person_id,
-                  acl_table.c.ac_role_id,
-                  acl_table.c.object_id,
-                  acl_table.c.object_type,
-                  acl_table.c.created_at,
-                  acl_table.c.modified_by_id,
-                  acl_table.c.updated_at,
-                  acl_table.c.parent_id,
-                  acl_table.c.parent_id_nn,
-              ],
-              select_statement
-          )
-      )
-      db.session.plain_commit()
-      break
-    except sa.exc.OperationalError as error:
-      logger.exception(error)
-      last_error = error
-
-  if last_error:
-    logger.critical(
-        "Workflow ACL propagation failed with %d retries on statement: \n %s",
-        PROPAGATION_RETRIES,
-        select_statement,
-    )
-    # The following error if exists will only be sa.exc.OperationalError so the
-    # pylint warning is invalid.
-    raise last_error  # pylint: disable=raising-bad-type
-
 
 def _insert_select_acls(select_statement):
   """Run insert from select with default acl inserter."""
   inserter = all_models.AccessControlList.__table__.insert()
-  insert_select_acls(inserter, select_statement)
+  acl_utils.insert_select_acls(inserter, select_statement)
 
 
 def _rel_parent(parent_acl_ids=None, relationship_ids=None, source=True):

--- a/src/ggrc_workflows/models/hooks/workflow.py
+++ b/src/ggrc_workflows/models/hooks/workflow.py
@@ -9,8 +9,8 @@ import sqlalchemy as sa
 from ggrc import db
 from ggrc import login
 from ggrc import utils
+from ggrc.access_control import utils as acl_utils
 from ggrc.models import all_models
-from ggrc.models.hooks.acl import propagation
 from ggrc.access_control import role
 
 
@@ -132,7 +132,7 @@ def _insert_select_acls(select_statement):
   """Run insert from select with ignore acl inserter."""
   acl_table = all_models.AccessControlList.__table__
   inserter = acl_table.insert().prefix_with("IGNORE")
-  propagation.insert_select_acls(inserter, select_statement)
+  acl_utils.insert_select_acls(inserter, select_statement)
 
 
 def _propagate_to_wf_children(new_wf_acls, child_class):

--- a/src/ggrc_workflows/models/hooks/workflow.py
+++ b/src/ggrc_workflows/models/hooks/workflow.py
@@ -149,6 +149,7 @@ def _insert_select_acls(select_statement):
       modified_by_id,
       updated_at,
       parent_id,
+      parent_id_nn,
   """
 
   acl_table = all_models.AccessControlList.__table__
@@ -170,6 +171,7 @@ def _insert_select_acls(select_statement):
                   acl_table.c.modified_by_id,
                   acl_table.c.updated_at,
                   acl_table.c.parent_id,
+                  acl_table.c.parent_id_nn,
               ],
               select_statement
           )
@@ -216,7 +218,8 @@ def _propagate_to_wf_children(new_wf_acls, child_class):
       sa.func.now(),
       sa.literal(current_user_id),
       sa.func.now(),
-      acl_table.c.id,
+      acl_table.c.id.label("parent_id"),
+      acl_table.c.id.label("parent_id_nn"),
   ]).select_from(
       sa.join(
           sa.join(
@@ -268,7 +271,8 @@ def _propagate_to_children(new_tg_acls, child_class, id_name, parent_class):
       sa.func.now(),
       sa.literal(current_user_id),
       sa.func.now(),
-      acl_table.c.id,
+      acl_table.c.id.label("parent_id"),
+      acl_table.c.id.label("parent_id_nn"),
   ]).select_from(
       sa.join(
           child_table,


### PR DESCRIPTION
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [x] https://github.com/google/ggrc-core/pull/7734
- [x] https://github.com/google/ggrc-core/pull/7773

I have added the https://github.com/google/ggrc-core/pull/7773 PR as a dependency because it has a conflict with this one. The conflict is already resolved here and this PR contains all changes.

# Issue description

Updating a single cycle task status takes more than 2 minutes, on bigger workflows (2k tasks and multiple cycles)

The biggest bottleneck in this is the query that pulls out all cycle tasks for a given cycle, which are then used for reindexing. The fix to not pull all tasks for the reindex job is done here: https://github.com/google/ggrc-core/issues?q=assignee%3Azidarsk8+is%3Aopen
But even so the query for multiple objects must never run that slow.

Example query that takes a few minutes (cut down version of the origina for readability):

```sql
SELECT                                                                          
  cycle_task_group_object_tasks.id AS cycle_task_group_object_tasks_id,            
  cycle_task_group_object_tasks.title AS cycle_task_group_object_tasks_title,   
  access_control_list_1.id AS access_control_list_1_id                          
FROM cycle_task_group_object_tasks                                              
LEFT OUTER JOIN access_control_list AS access_control_list_1 ON                 
  access_control_list_1.object_id = cycle_task_group_object_tasks.id AND        
  access_control_list_1.object_type = "CycleTaskGroupObjectTask" AND            
  access_control_list_1.parent_id IS NULL                                          
WHERE                                                                           
  cycle_task_group_object_tasks.cycle_id = 6662                                 
;                                                                               
```
results of the query above
```
...
2000 rows in set (1 min 9.76 sec)
```

Now the tinyest change in the query produces same results but in better time:
```sql
SELECT                                                                          
  cycle_task_group_object_tasks.id AS cycle_task_group_object_tasks_id,            
  cycle_task_group_object_tasks.title AS cycle_task_group_object_tasks_title,   
  access_control_list_1.id AS access_control_list_1_id                          
FROM cycle_task_group_object_tasks                                              
LEFT OUTER JOIN access_control_list AS access_control_list_1 ON                 
  access_control_list_1.object_id = cycle_task_group_object_tasks.id AND        
  access_control_list_1.object_type = "CycleTaskGroupObjectTask"                
WHERE                                                                           
  access_control_list_1.parent_id IS NULL AND                                   
  cycle_task_group_object_tasks.cycle_id = 6662   

```
results of the query above
```
...
2000 rows in set (0.06 sec)
```

Issue turns out to be invalid usage of index, even when a more propper one is created:
```sql
mysql> show create table access_control_list\G
*************************** 1. row ***************************
       Table: access_control_list
Create Table: CREATE TABLE `access_control_list` (
  `id` int(11) NOT NULL AUTO_INCREMENT,
  `person_id` int(11) NOT NULL,
  `ac_role_id` int(11) NOT NULL,
  `object_id` int(11) NOT NULL,
  `object_type` varchar(250) NOT NULL,
  `created_at` datetime NOT NULL,
  `modified_by_id` int(11) DEFAULT NULL,
  `updated_at` datetime NOT NULL,
  `context_id` int(11) DEFAULT NULL,
  `parent_id` int(11) DEFAULT NULL,
  PRIMARY KEY (`id`),
  UNIQUE KEY `person_id` (`person_id`,`ac_role_id`,`object_id`,`object_type`,`parent_id`),
  KEY `ac_role_id` (`ac_role_id`),
  KEY `fk_access_control_list_contexts` (`context_id`),
  KEY `ix_access_control_list_updated_at` (`updated_at`),
  KEY `idx_object_type_object_idx` (`object_type`,`object_id`),
  KEY `fk_access_control_list_parent_id` (`parent_id`),
  KEY `acl_join_index` (`object_type`,`object_id`,`parent_id`),
  CONSTRAINT `access_control_list_ibfk_1` FOREIGN KEY (`ac_role_id`) REFERENCES `access_control_roles` (`id`),
  CONSTRAINT `access_control_list_ibfk_2` FOREIGN KEY (`context_id`) REFERENCES `contexts` (`id`),
  CONSTRAINT `access_control_list_ibfk_3` FOREIGN KEY (`person_id`) REFERENCES `people` (`id`),
  CONSTRAINT `fk_access_control_list_parent_id` FOREIGN KEY (`parent_id`) REFERENCES `access_control_list` (`id`) ON DELETE CASCADE
) ENGINE=InnoDB AUTO_INCREMENT=5450921 DEFAULT CHARSET=utf8
1 row in set (0.00 sec)
```

The explain of the slow query:
```sql
+----+-------------+-------------------------------+------+----------------------------------------------------------------------------+-------------------------------------+---------+-------+------+-------------+
| id | select_type | table                         | type | possible_keys                                                              | key                                 | key_len | ref   | rows | Extra       |
+----+-------------+-------------------------------+------+----------------------------------------------------------------------------+-------------------------------------+---------+-------+------+-------------+
|  1 | SIMPLE      | cycle_task_group_object_tasks | ref  | cycle_task_group_object_tasks_cycle                                        | cycle_task_group_object_tasks_cycle | 4       | const |  999 | NULL        |
|  1 | SIMPLE      | access_control_list_1         | ref  | idx_object_type_object_idx,fk_access_control_list_parent_id,acl_join_index | fk_access_control_list_parent_id    | 5       | const |    1 | Using where |
+----+-------------+-------------------------------+------+----------------------------------------------------------------------------+-------------------------------------+---------+-------+------+-------------+
```
 
This shows that `parent_id` index is used instead of `acl_join_index`.

If we force the usage of the correct index, we get the expected performance:
```sql
mysql> SELECT                                                                                                                                                                                                                                         ->   cycle_task_group_object_tasks.id AS cycle_task_group_object_tasks_id,         
    ->   cycle_task_group_object_tasks.title AS cycle_task_group_object_tasks_title,   
    ->   access_control_list_1.id AS access_control_list_1_id                          
    -> FROM cycle_task_group_object_tasks                                              
    -> LEFT OUTER JOIN access_control_list AS access_control_list_1                    
    -> FORCE INDEX FOR JOIN (`acl_join_index`)                                         
    -> ON                                                                              
    ->   access_control_list_1.object_id = cycle_task_group_object_tasks.id AND        
    ->   access_control_list_1.object_type = "CycleTaskGroupObjectTask" AND            
    ->   access_control_list_1.parent_id IS NULL                                       
    -> WHERE                                                                           
    ->   cycle_task_group_object_tasks.cycle_id = 6662                                 
    -> ;
+----------------------------------+-------------------------------------+--------------------------+
| cycle_task_group_object_tasks_id | cycle_task_group_object_tasks_title | access_control_list_1_id |
+----------------------------------+-------------------------------------+--------------------------+
|                            36236 | big-wf-2-tgt-1big-wf-2-tg-1         |                  1340186 |
...
+----------------------------------+-------------------------------------+--------------------------+
2000 rows in set (0.01 sec)

```


# Steps to test the changes

Modify a cycle task in a cycle with a lot of tasks and many people on the workflow.
Verify that the PUT request takes less than 5 seconds.
Verify that correct CycleTasks were pulled from the database by checking if CycleTask reindex works.

# Solution description

Because we can't (or I don't know how to) force the correct index on sqlalchemy relationship join, we are forced to remove the invalid index. But we still need the FK index for delete cascade.

The solution is then to just duplicate the FK column, that is then used in the query and that is properly indexed. 
The added benefit of this column is that by making it non null, wen can also prevent duplicate acl entries.


# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests. - regressions are covered by previous tests, but there are no performance tests here.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst). - The reindex code that pulls too much data was not addressed in this PR.
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
