### PR TITLE
GGRC-4781 Parse string to HTML before rendering the comment

### DIFF
--- a/src/ggrc-client/js/components/revision-log/revision-log.mustache
+++ b/src/ggrc-client/js/components/revision-log/revision-log.mustache
@@ -25,7 +25,7 @@
             {{#changes}}
               <div class="clearfix {{#if isRole}}role-row{{/if}}">
                 <div class="third-col">
-                  {{fieldName}}
+                  {{{fieldName}}}
                 </div>
                 <div class="third-col">
                   <revision-log-data {is-loading}="isLoading" {data}="origVal"></revision-log-data>

--- a/src/ggrc-client/js/components/revision-log/revision-log.mustache
+++ b/src/ggrc-client/js/components/revision-log/revision-log.mustache
@@ -4,50 +4,52 @@
 }}
 
 {{#revisions_diff instance}}
-  <paginate list="changeHistory" per-page="10">
-    <ul class="entry-list">
-      {{#entries}}
-        <li>
-          <span class="person-label {{lowercase role }}"></span>
-          <div class="w-status">
-            <div class="entry-author">
-              <person-info {person-obj}="madeBy"></person-info>made changes &mdash; {{date updatedAt}}
+  <div class="revision-log">
+    <paginate list="changeHistory" per-page="10">
+      <ul class="entry-list">
+        {{#entries}}
+          <li>
+            <span class="person-label {{lowercase role }}"></span>
+            <div class="w-status">
+              <div class="entry-author">
+                <person-info {person-obj}="madeBy"></person-info>made changes &mdash; {{date updatedAt}}
+              </div>
+                <div class="third-col">
+                  <p class="instruction">Field</p>
+                </div>
+                <div class="third-col">
+                  <p class="instruction">Original value</p>
+                </div>
+                <div class="third-col">
+                  <p class="instruction">New value</p>
+                </div>
+              {{#changes}}
+                <div class="clearfix {{#if isRole}}role-row{{/if}}">
+                  <div class="third-col revision-log__field-name">
+                    {{{fieldName}}}
+                  </div>
+                  <div class="third-col">
+                    <revision-log-data {is-loading}="isLoading" {data}="origVal"></revision-log-data>
+                  </div>
+                  <div class="third-col">
+                    <revision-log-data {is-loading}="isLoading" {data}="newVal"></revision-log-data>
+                  </div>
+                </div>
+              {{/changes}}
             </div>
-              <div class="third-col">
-                <p class="instruction">Field</p>
-              </div>
-              <div class="third-col">
-                <p class="instruction">Original value</p>
-              </div>
-              <div class="third-col">
-                <p class="instruction">New value</p>
-              </div>
-            {{#changes}}
-              <div class="clearfix {{#if isRole}}role-row{{/if}}">
-                <div class="third-col">
-                  {{{fieldName}}}
-                </div>
-                <div class="third-col">
-                  <revision-log-data {is-loading}="isLoading" {data}="origVal"></revision-log-data>
-                </div>
-                <div class="third-col">
-                  <revision-log-data {is-loading}="isLoading" {data}="newVal"></revision-log-data>
-                </div>
-              </div>
-            {{/changes}}
-          </div>
-        </li>
-      {{/entries}}
-
-      {{^list}}
-        {{#isLoading}}
-          <li class="spinner">
-            <span {{attach_spinner '{ "radius": 4, "length": 4, "width": 2 }' 'display:inline-block; top: -3px; left: 30px;' }}></span>
           </li>
-        {{else}}
-          <li>The history of changes is currently empty.</li>
-        {{/isLoading}}
-      {{/list}}
-    </ul>
-  </paginate>
+        {{/entries}}
+
+        {{^list}}
+          {{#isLoading}}
+            <li class="spinner">
+              <span {{attach_spinner '{ "radius": 4, "length": 4, "width": 2 }' 'display:inline-block; top: -3px; left: 30px;' }}></span>
+            </li>
+          {{else}}
+            <li>The history of changes is currently empty.</li>
+          {{/isLoading}}
+        {{/list}}
+      </ul>
+    </paginate>
+  </div>
 {{/revisions_diff}}

--- a/src/ggrc-client/styles/_components.scss
+++ b/src/ggrc-client/styles/_components.scss
@@ -59,3 +59,4 @@
 @import "components/revision-history/revision-history";
 @import "components/related-objects/related-assessments";
 @import "components/import-history/import-history";
+@import "components/revision-log/revision-log";

--- a/src/ggrc-client/styles/components/revision-log/_revision-log.scss
+++ b/src/ggrc-client/styles/components/revision-log/_revision-log.scss
@@ -1,0 +1,14 @@
+/*
+ * Copyright (C) 2018 Google Inc.
+ * Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+revision-log {
+  .revision-log {
+    &__field-name {
+      li, p {
+        margin: auto;
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Issue description

Comment message is shown with tags instead of html elements

# Steps to test the changes

Steps to reproduce:
1. Open any Control Info page
2. Add a comment to comment box and click Add
3. Open Change Log tab and look at the created comment

Actual Result: if user adds a comment to comment box, comment is displayed in tags in Change log tab
Expected Result: Comment should not be shown in tags in Change Log tab

# Solution description

Parse string to HTML before rendering the comment (unescape)

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".