### PR TITLE
GGRC-4651 Wait for a response from the server before initializing issue tracker

### DIFF
--- a/src/ggrc-client/js/models/mixins.js
+++ b/src/ggrc-client/js/models/mixins.js
@@ -338,7 +338,7 @@ const AUDIT_ISSUE_TRACKER = {
         // for newly created instances
         ? (auditItr && auditItr.enabled)
         // for existing instance, the value from the server will be used
-        : null;
+        : (itr && itr.enabled);
 
       let showIssureTrackerControls = this.isNew()
         // for new instance show controls if Issure Tracker enabled for Audit
@@ -385,8 +385,11 @@ const AUDIT_ISSUE_TRACKER = {
         this.issue_tracker._warnings = [];
       }
     },
-    'after:refresh': function () {
-      this.initIssueTracker();
+    'after:refresh': function (dfd) {
+      // wait for a response from the server before initializing issue tracker controls
+      if (dfd) {
+        dfd.done(() => this.initIssueTracker());
+      }
     },
   });
 

--- a/src/ggrc-client/js/models/mixins.js
+++ b/src/ggrc-client/js/models/mixins.js
@@ -93,7 +93,7 @@ const AUDIT_ISSUE_TRACKER = {
                   obj[key] = function () {
                     let result;
                     result = oldfn.apply(this, arguments);
-                    fn.apply(this, arguments);
+                    fn.call(this, result);
                     return result;
                   };
                   break;

--- a/src/ggrc-client/js/models/tests/issue-tracker-integratable-mixin_spec.js
+++ b/src/ggrc-client/js/models/tests/issue-tracker-integratable-mixin_spec.js
@@ -268,6 +268,28 @@ describe('can.Model.Mixin.issueTrackerIntegratable', function () {
           expect(itrShowControls).toEqual(true);
         });
 
+      it('should enable ITR if it is enabled in issue_tracker',
+        () => {
+          let enabled;
+          fakeAssessment.attr('issue_tracker.enabled', true);
+          method.apply(fakeAssessment);
+          // value should have been taken from .issues_tracker.enabled
+          enabled = fakeAssessment.initIssueTrackerObject
+            .calls.mostRecent().args[0].enabled;
+          expect(enabled).toEqual(true);
+        });
+
+      it('should disable ITR if it is disabled in issue_tracker',
+        () => {
+          let enabled;
+          fakeAssessment.attr('issue_tracker.enabled', false);
+          method.apply(fakeAssessment);
+          // value should have been taken from .issues_tracker.enabled
+          enabled = fakeAssessment.initIssueTrackerObject
+            .calls.mostRecent().args[0].enabled;
+          expect(enabled).toEqual(false);
+        });
+
       it('should hide ITR if disabled on instance and in audit',
         () => {
           let itrShowControls;


### PR DESCRIPTION
# Issue description

Issue tracker controls get initialized with stale data (before data is retrieved from the server). 

# Steps to test the changes

Steps to reproduce:
1. Open any audit page
2. Bagunazer integration should be switch off for an audit
3. Create assessment
4. Do not open Assessment Info panel
5. Go to Audit Info tab and switch on Bagunazer integration via Edit Audit modal window
6. Navigate to Assessment Info panel > Other attributes tab

Actual Result: If switch on buganizer in audit, ticket tracker dropdown is not displayed in Other Attributes tab on Assessment
Expected Result: If switch on buganizer in audit, ticket tracker dropdown should be displayed in Other Attributes tab on Assessment

# Solution description

Function `refresh` requests data from the server and `after:refresh` hook initializes issue tracker controls. `after:refresh` hook runs immediately after `refresh` thus the data is still pending (event loop queue). Need to add a dfd handler where issue tracker controls will be initialized.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".