### PR TITLE
GGRC-3375 'Audit Lead' is displayed in Assessment Template csv file instead of 'Audit Captain'

### DIFF
--- a/src/ggrc/converters/handlers/default_people.py
+++ b/src/ggrc/converters/handlers/default_people.py
@@ -116,6 +116,14 @@ class DefaultPersonColumnHandler(handlers.ColumnHandler):
         self.KEY_MAP[self.key],
         "ERROR",
     )
+
+    assessment_template = self.row_converter.obj
+    default_people_labels = assessment_template.DEFAULT_PEOPLE_LABELS
+    if isinstance(value, list):
+      value = [default_people_labels.get(label, label) for label in value]
+    else:
+      value = default_people_labels.get(value, value)
+
     if isinstance(value, list):
       # This is not good and fast, because it executes query for each
       # field from each row that contains people list.

--- a/test/integration/ggrc/converters/test_export_assessment_templates.py
+++ b/test/integration/ggrc/converters/test_export_assessment_templates.py
@@ -1,0 +1,49 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+
+"""Tests for assessment templates export."""
+import ddt
+
+from integration.ggrc.models import factories
+from integration.ggrc import TestCase
+
+
+@ddt.ddt
+class TestAssessmentTemplatesExport(TestCase):
+  """Assessment Template export test"""
+
+  def setUp(self):
+    """Set up for Assessment Template test cases."""
+    super(TestAssessmentTemplatesExport, self).setUp()
+    self.client.get("/login")
+
+  @ddt.data(
+      ("Object Admins", "Admin"),
+      ("Audit Captain", "Audit Lead"),
+      ("Auditors", "Auditors"),
+      ("Principal Assignees", "Principal Assignees"),
+      ("Secondary Assignees", "Secondary Assignees"),
+      ("Primary Contacts", "Primary Contacts"),
+      ("Secondary Contacts", "Secondary Contacts")
+  )
+  @ddt.unpack
+  def test_people_labels_export(self, title, label):
+    """Test for check people label export"""
+    default_people = {"assignees": label, "verifiers": label}
+    factories.AssessmentTemplateFactory(
+        title=title,
+        default_people=default_people
+    )
+    data = [{
+        "object_name": "AssessmentTemplate",
+        "filters": {
+            "expression": {},
+        },
+        "fields": "all",
+    }]
+
+    response = self.export_parsed_csv(data)
+    assessment_template = response["Assessment Template"][0]
+    self.assertEqual(assessment_template["Default Assignees*"], title)
+    self.assertEqual(assessment_template["Default Verifiers"], title)


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

* `Audit Captain` as Default Assignee/Default Verifier should be displayed in Assessment Template csv file.
* Implement this functionality.

# Steps to test the changes

Export `Assessment Template` objects, open file and look.

# Solution description

* Change `get_value` method in default person column handler.
* Add test for check this functionality.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
