### PR TITLE
GGRC-4996 Increase httplib2 timeout to 45s 

### DIFF
--- a/src/ggrc/gdrive/__init__.py
+++ b/src/ggrc/gdrive/__init__.py
@@ -45,7 +45,7 @@ def get_http_auth():
   try:
     credentials = client.OAuth2Credentials.from_json(
         flask.session['credentials'])
-    http_auth = credentials.authorize(httplib2.Http())
+    http_auth = credentials.authorize(httplib2.Http(timeout=45))
   except Exception as ex:
     logger.exception(ex.message)
     del flask.session['credentials']


### PR DESCRIPTION
# Issue description

Some requests to GDrive fail with "Deadline exceeded".

# Steps to test the changes

1. Create a new Attachment for Assessment from a GDrive file.

Expected result: the GDrive file is copied, a GGRC object is created.
Actual result: the GDrive call to copy the file times out.

It pretty hard to reproduce on test env because we need to simulate poor network (delay about 5s)
I've reproduce it at local env using a standard utility from Mac dev tools.

Note: this issue wasn't reproduced on any test instance, though it occurs quite often on prod (can be seen in the logs). It is possible that prod has a different setup impacting GDrive calls.

# Solution description

Increase httplib2 timeout to 45s.

Since the default time limit for AppEngine calls is 60 seconds, it's dangerous to set this timeout to greater values. 45 seconds is just a magic number big enough to feel safe and small enough to leave space for our own processing.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
