### PR TITLE
GGRC-4665 Make Default Verifiers non-mandatory in import

### DIFF
--- a/src/ggrc/converters/handlers/default_people.py
+++ b/src/ggrc/converters/handlers/default_people.py
@@ -86,30 +86,8 @@ class DefaultPersonColumnHandler(handlers.ColumnHandler):
       return self._parse_label_values()
 
   def set_obj_attr(self):
-    """Set default_people attribute.
-
-    This is a joint function for default assignees and verifiers. The first
-    column that gets handled will save the value to "_default_people" and the
-    second column that gets handled will take that value, include it with its
-    own and store it into the correct "default_people" field.
-
-    NOTE: This is a temporary hack that that should be refactored once this
-    code is merged into the develop branch. The joining of default_assignees
-    and default_verifiers should be done by pre_commit_checks for imports.
-    """
-    if self.row_converter.ignore:
-      return
-
-    default_people = self.row_converter.obj.default_people or {}
-    default_people[self.KEY_MAP[self.key]] = self.value
-
-    _default_people = getattr(self.row_converter.obj, "_default_people", {})
-
-    if _default_people:
-      default_people.update(_default_people)
-      setattr(self.row_converter.obj, "default_people", default_people)
-    else:
-      setattr(self.row_converter.obj, "_default_people", default_people)
+    """Set default_assignees and default_verifiers attributes."""
+    setattr(self.row_converter.obj, self.key, self.value)
 
   def get_value(self):
     """Get value from default_people attribute."""

--- a/src/ggrc/converters/handlers/default_people.py
+++ b/src/ggrc/converters/handlers/default_people.py
@@ -61,7 +61,8 @@ class DefaultPersonColumnHandler(handlers.ColumnHandler):
           self.add_warning(errors.UNKNOWN_USER_WARNING,
                            column_name=self.display_name,
                            email=email)
-    if not people:
+
+    if not people and self.mandatory:
       self.add_error(errors.MISSING_VALUE_ERROR, column_name=self.display_name)
     return people
 
@@ -71,7 +72,7 @@ class DefaultPersonColumnHandler(handlers.ColumnHandler):
     These values are the normal selection in the default assignees dropdown.
     """
     value = self.PEOPLE_LABELS_MAP.get(self.raw_value.strip().lower())
-    if not value:
+    if not value and self.mandatory:
       self.add_error(errors.WRONG_REQUIRED_VALUE,
                      column_name=self.display_name,
                      value=self.raw_value.strip().lower())
@@ -96,7 +97,7 @@ class DefaultPersonColumnHandler(handlers.ColumnHandler):
     code is merged into the develop branch. The joining of default_assignees
     and default_verifiers should be done by pre_commit_checks for imports.
     """
-    if not self.value or self.row_converter.ignore:
+    if not self.value and self.mandatory or self.row_converter.ignore:
       return
 
     default_people = self.row_converter.obj.default_people or {}

--- a/src/ggrc/converters/handlers/default_people.py
+++ b/src/ggrc/converters/handlers/default_people.py
@@ -97,7 +97,7 @@ class DefaultPersonColumnHandler(handlers.ColumnHandler):
     code is merged into the develop branch. The joining of default_assignees
     and default_verifiers should be done by pre_commit_checks for imports.
     """
-    if not self.value and self.mandatory or self.row_converter.ignore:
+    if self.row_converter.ignore:
       return
 
     default_people = self.row_converter.obj.default_people or {}

--- a/src/ggrc/converters/handlers/default_people.py
+++ b/src/ggrc/converters/handlers/default_people.py
@@ -86,7 +86,13 @@ class DefaultPersonColumnHandler(handlers.ColumnHandler):
       return self._parse_label_values()
 
   def set_obj_attr(self):
-    """Set default_assignees and default_verifiers attributes."""
+    """Set default_assignees and default_verifiers attributes.
+
+    Note that default_assignees and default_verifiers are not actual
+    properties on the object that get stored. These are used as temporary
+    placeholders and the property default_people, gets set using these
+    two values, in check_assessment_template pre commit hook.
+    """
     setattr(self.row_converter.obj, self.key, self.value)
 
   def get_value(self):

--- a/src/ggrc/converters/pre_commit_checks.py
+++ b/src/ggrc/converters/pre_commit_checks.py
@@ -123,9 +123,43 @@ def check_assessment(row_converter):
     row_converter.add_error(errors.ARCHIVED_IMPORT_ERROR)
 
 
+def check_assessment_template(row_converter):
+  """Checker for AssessmentTemplate model objects.
+
+  This checker sets default_people attribute from values of default_assignees
+  and default_verifier.
+
+  Args:
+     row_converter: RowConverter object with row data for a cycle-task
+     import.
+  """
+  if row_converter.ignore:
+    return
+
+  key_map = {
+      "default_assignees": "assignees",
+      "default_verifier": "verifiers",
+  }
+  default_people = {}
+  for key, value in key_map.iteritems():
+    default_people[value] = getattr(row_converter.obj, key, '')
+
+  if not row_converter.obj.default_people:
+    row_converter.obj.default_people = default_people
+    return
+
+  for key, value in default_people.iteritems():
+    previous_value = row_converter.obj.default_people.get(key, '')
+    if previous_value and not value:
+      default_people[key] = previous_value
+
+  row_converter.obj.default_people = default_people
+
+
 CHECKS = {
     "TaskGroupTask": check_tasks,
     "CycleTaskGroupObjectTask": check_cycle_tasks,
     "Workflow": check_workflows,
-    "Assessment": check_assessment
+    "Assessment": check_assessment,
+    "AssessmentTemplate": check_assessment_template,
 }

--- a/test/integration/ggrc/converters/test_import_assessment_templates.py
+++ b/test/integration/ggrc/converters/test_import_assessment_templates.py
@@ -56,7 +56,8 @@ class TestAssessmentTemplatesImport(TestCase):
         .filter(models.AssessmentTemplate.slug == slug) \
         .first()
     self._check_csv_response(response, {})
-    self.assertTrue(len(template.default_people['verifiers']) > 0)
+    self.assertEqual(template.default_people['verifiers'], 'Auditors')
+    self.assertEqual(template.default_people['assignees'], 'Admin')
 
   def test_modify_persons_over_import(self):
     """Test import modifies Assessment Template and does not fail."""

--- a/test/integration/ggrc/converters/test_import_assessment_templates.py
+++ b/test/integration/ggrc/converters/test_import_assessment_templates.py
@@ -58,6 +58,25 @@ class TestAssessmentTemplatesImport(TestCase):
     self._check_csv_response(response, {})
     self.assertTrue(len(template.default_people['verifiers']) > 0)
 
+  def test_modify_persons_over_import(self):
+    """Test import modifies Assessment Template and does not fail."""
+    self.import_file("assessment_template_no_warnings.csv")
+    slug = "T-1"
+    response = self.import_data(OrderedDict([
+        ("object_type", "Assessment_Template"),
+        ("Code*", slug),
+        ("Audit*", "Audit"),
+        ("Title", "Title"),
+        ("Object Under Assessment", 'Control'),
+        ("Default Verifiers", "Secondary Contacts")
+    ]))
+    template = models.AssessmentTemplate.query \
+        .filter(models.AssessmentTemplate.slug == slug) \
+        .first()
+    self._check_csv_response(response, {})
+    self.assertEqual(template.default_people['verifiers'],
+                     "Secondary Contacts")
+
   def test_invalid_import(self):
     """Test invalid import."""
     data = "assessment_template_with_warnings_and_errors.csv"

--- a/test/integration/ggrc/converters/test_import_assessment_templates.py
+++ b/test/integration/ggrc/converters/test_import_assessment_templates.py
@@ -62,11 +62,7 @@ class TestAssessmentTemplatesImport(TestCase):
         "Assessment Template": {
             "rows": 4,
             "updated": 0,
-            "created": 3,
-            "row_errors": {
-                errors.MISSING_VALUE_ERROR.format(
-                    line=5, column_name="Default Verifiers")
-            },
+            "created": 4,
             "row_warnings": {
                 errors.UNKNOWN_USER_WARNING.format(
                     line=5,

--- a/test/integration/ggrc/converters/test_import_assessment_templates.py
+++ b/test/integration/ggrc/converters/test_import_assessment_templates.py
@@ -44,14 +44,19 @@ class TestAssessmentTemplatesImport(TestCase):
   def test_modify_over_import(self):
     """Test import modifies Assessment Template and does not fail."""
     self.import_file("assessment_template_no_warnings.csv")
+    slug = "T-1"
     response = self.import_data(OrderedDict([
         ("object_type", "Assessment_Template"),
-        ("Code*", "T-1"),
+        ("Code*", slug),
         ("Audit*", "Audit"),
         ("Title", "Title"),
         ("Object Under Assessment", 'Control'),
     ]))
+    template = models.AssessmentTemplate.query \
+        .filter(models.AssessmentTemplate.slug == slug) \
+        .first()
     self._check_csv_response(response, {})
+    self.assertTrue(len(template.default_people['verifiers']) > 0)
 
   def test_invalid_import(self):
     """Test invalid import."""

--- a/test/integration/ggrc/utils/test_user_generator.py
+++ b/test/integration/ggrc/utils/test_user_generator.py
@@ -245,18 +245,16 @@ class TestUserGenerator(TestCase):
       assessment_template = AssessmentTemplate.query.filter(
           AssessmentTemplate.slug == slug).first()
 
-      if assignee_email and verifier_email:
+      if assignee_email:
         self._check_csv_response(response, {})
         self.assertEqual(
             len(assessment_template.default_people['assignees']), 1)
-        self.assertEqual(
-            len(assessment_template.default_people['verifiers']), 1)
-      elif assignee_email:
-        self._check_csv_response(response, {})
-        self.assertEqual(
-            len(assessment_template.default_people['assignees']), 1)
-        self.assertEqual(
-            assessment_template.default_people['verifiers'], None)
+        if verifier_email:
+          self.assertEqual(
+              len(assessment_template.default_people['verifiers']), 1)
+        else:
+          self.assertEqual(
+              assessment_template.default_people['verifiers'], None)
       else:
         self._check_csv_response(
             response, {

--- a/test/integration/ggrc/utils/test_user_generator.py
+++ b/test/integration/ggrc/utils/test_user_generator.py
@@ -190,6 +190,57 @@ class TestUserGenerator(TestCase):
 
   @mock.patch('ggrc.settings.INTEGRATION_SERVICE_URL', new='endpoint')
   @mock.patch('ggrc.settings.AUTHORIZED_DOMAIN', new='example.com')
+  def test_import_no_assignees(self):
+    """Test for import assessment template without default assignees"""
+    with mock.patch.multiple(
+        PersonClient,
+        _post=self._mock_post
+    ):
+      audit = factories.AuditFactory()
+
+      slug = "AssessmentTemplate1"
+      response = self.import_data(OrderedDict([
+          ("object_type", "Assessment_Template"),
+          ("Code*", slug),
+          ("Audit*", audit.slug),
+          ("Default Verifiers", "aturing@example.com"),
+          ("Title", "Title"),
+          ("Object Under Assessment", 'Control'),
+      ]))
+      self._check_csv_response(
+          response,
+          {"Assessment Template": {
+              "row_errors": {errors.MISSING_COLUMN.format(
+                  line=3, column_names="Default Assignees", s="")}}})
+
+  @mock.patch('ggrc.settings.INTEGRATION_SERVICE_URL', new='endpoint')
+  @mock.patch('ggrc.settings.AUTHORIZED_DOMAIN', new='example.com')
+  def test_import_empty_assignees(self):
+    """Test for import assessment template with empty default assignees"""
+    with mock.patch.multiple(
+        PersonClient,
+        _post=self._mock_post
+    ):
+      audit = factories.AuditFactory()
+
+      slug = "AssessmentTemplate1"
+      response = self.import_data(OrderedDict([
+          ("object_type", "Assessment_Template"),
+          ("Code*", slug),
+          ("Audit*", audit.slug),
+          ("Default Assignees", ""),
+          ("Default Verifiers", "aturing@example.com"),
+          ("Title", "Title"),
+          ("Object Under Assessment", 'Control'),
+      ]))
+      self._check_csv_response(
+          response,
+          {"Assessment Template": {
+              "row_errors": {errors.WRONG_REQUIRED_VALUE.format(
+                  line=3, value="", column_name="Default Assignees")}}})
+
+  @mock.patch('ggrc.settings.INTEGRATION_SERVICE_URL', new='endpoint')
+  @mock.patch('ggrc.settings.AUTHORIZED_DOMAIN', new='example.com')
   def test_wrong_person_import(self):
     """Test for wrong person import"""
     with mock.patch.multiple(


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Error shows 'Default Verifiers' field as mandatory while importing Assessment template. But 'Default Verifiers' field is not mandatory in UI and there is a possibility to create Atemplate w/o Default Verifiers.

# Steps to test the changes

1. Open any audit page 
2. Create assessment template w/o Default verifiers 
3. Export Assessment template 
4. Import Assessment template w/o any changes 

Expected result: No error should be shown while importing Assessment template if Default Verifiers column is empty in csv/google sheet

# Solution description

Since we can check is the field is mandatory or not when setting up the value (verifier is not mandatory while assignee is), the additional check is added in order not to raise any error when verifier is empty. 

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
