### PR TITLE
GGRC-5024 Disable "Complete" button on "isInfoPaneSaving"

### DIFF
--- a/src/ggrc-client/js/components/assessment/controls-toolbar/controls-toolbar.mustache
+++ b/src/ggrc-client/js/components/assessment/controls-toolbar/controls-toolbar.mustache
@@ -10,7 +10,7 @@
       </custom-attributes-actions>
       <object-state-toolbar {verifiers}="verifiers"
                             {instance}="instance"
-                            {disabled}="isPending"
+                            {disabled}="isInfoPaneSaving"
                             (on-state-change)="onStateChange(%event)">
       </object-state-toolbar>
   {{/is_allowed}}

--- a/src/ggrc-client/js/components/assessment/info-pane/info-pane.js
+++ b/src/ggrc-client/js/components/assessment/info-pane/info-pane.js
@@ -182,13 +182,6 @@ import {relatedAssessmentsTypes} from '../../../plugins/utils/models-utils';
               this.attr('isAssessmentSaving');
           },
         },
-        // flag which indicates that changing of assessment state is blocked
-        isPending: {
-          get() {
-            return this.attr('isUpdatingEvidences') ||
-              this.attr('isUpdatingUrls');
-          },
-        },
       },
       modal: {
         open: false,

--- a/src/ggrc-client/js/components/assessment/info-pane/info-pane.js
+++ b/src/ggrc-client/js/components/assessment/info-pane/info-pane.js
@@ -174,7 +174,8 @@ import {relatedAssessmentsTypes} from '../../../plugins/utils/models-utils';
               return false;
             }
 
-            return this.attr('isUpdatingEvidences') ||
+            return this.attr('isUpdatingState') ||
+              this.attr('isUpdatingEvidences') ||
               this.attr('isUpdatingUrls') ||
               this.attr('isUpdatingComments') ||
               this.attr('isUpdatingReferenceUrls') ||
@@ -194,6 +195,7 @@ import {relatedAssessmentsTypes} from '../../../plugins/utils/models-utils';
       },
       _verifierRoleId: undefined,
       isUpdatingRelatedItems: false,
+      isUpdatingState: false,
       isAssessmentSaving: false,
       onStateChangeDfd: {},
       formState: {},
@@ -459,6 +461,7 @@ import {relatedAssessmentsTypes} from '../../../plugins/utils/models-utils';
         } else {
           instance.attr('previousStatus', instance.attr('status'));
         }
+        this.attr('isUpdatingState', true);
 
         return this.attr('deferredSave').execute(() => {
           if (isUndo) {
@@ -479,7 +482,9 @@ import {relatedAssessmentsTypes} from '../../../plugins/utils/models-utils';
             modelNames: relatedAssessmentsTypes,
           });
           stopFn();
-        }).fail(resetStatusOnConflict);
+        }).fail(resetStatusOnConflict).always(() => {
+          this.attr('isUpdatingState', false);
+        });
       },
       saveGlobalAttributes: function (event) {
         const instance = this.attr('instance');

--- a/src/ggrc-client/js/components/assessment/info-pane/tests/info-pane_spec.js
+++ b/src/ggrc-client/js/components/assessment/info-pane/tests/info-pane_spec.js
@@ -46,38 +46,6 @@ describe('GGRC.Components.assessmentInfoPane', function () {
     });
   });
 
-  describe('isPending() getter', () => {
-    it('returns true if isUpdatingEvidences and isUpdatingUrls are true',
-      () => {
-        vm.attr('isUpdatingEvidences', true);
-        vm.attr('isUpdatingUrls', false);
-
-        expect(vm.attr('isPending')).toBe(true);
-      });
-
-    it('returns false if isUpdatingUrls and isUpdatingEvidences are false',
-      () => {
-        vm.attr('isUpdatingEvidences', false);
-        vm.attr('isUpdatingUrls', false);
-
-        expect(vm.attr('isPending')).toBe(false);
-      });
-
-    it('returns true if only isUpdatingEvidences is true', () => {
-      vm.attr('isUpdatingEvidences', true);
-      vm.attr('isUpdatingUrls', false);
-
-      expect(vm.attr('isPending')).toBe(true);
-    });
-
-    it('returns true if only isUpdatingUrls is true', () => {
-      vm.attr('isUpdatingEvidences', false);
-      vm.attr('isUpdatingUrls', true);
-
-      expect(vm.attr('isPending')).toBe(true);
-    });
-  });
-
   describe('onStateChange() method', () => {
     let method;
 

--- a/src/ggrc/assets/mustache/assessments/header.mustache
+++ b/src/ggrc/assets/mustache/assessments/header.mustache
@@ -192,7 +192,7 @@ Copyright (C) 2018 Google Inc.
                 <object-state-toolbar {{#if is_info_pin}}class="pane-header__toolbar-item"{{/if}}
                                     {verifiers}="verifiers"
                                     {instance}="instance"
-                                    {disabled}="isPending"
+                                    {disabled}="isInfoPaneSaving"
                                     (on-state-change)="onStateChange(%event)">
                 </object-state-toolbar>
         {{/unless}}


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

'Complete' button should be disabled for assessment while updating:
1) Evidence file/url
2) LCA
3) GCA
4) Comments
5) Custom roles

# Steps to test the changes

1) Generate assessment from assessment template with LCA
2) Change items from list above

Expected result: 'Complete' button should be disabled during saving.

# Solution description

Disable "Complete" button on "isInfoPaneSaving", which contains checks on saving for all items.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
