### PR TITLE
GGRC-5013 Reduce extra requests, when objects are mapped to Task group

### DIFF
--- a/src/ggrc-client/js/components/assessment/info-pane/info-pane.js
+++ b/src/ggrc-client/js/components/assessment/info-pane/info-pane.js
@@ -50,6 +50,7 @@ import tracker from '../../../tracker';
 import {REFRESH_TAB_CONTENT,
   RELATED_ITEMS_LOADED,
   REFRESH_MAPPING,
+  REFRESH_RELATED,
 } from '../../../events/eventTypes';
 import Permission from '../../../permission';
 import {initCounts} from '../../../plugins/utils/current-page-utils';
@@ -545,9 +546,14 @@ import {relatedAssessmentsTypes} from '../../../plugins/utils/models-utils';
       this.viewModel.setVerifierRoleId();
     },
     events: {
-      [`{viewModel.instance} ${REFRESH_MAPPING.type}`]() {
-        this.viewModel.attr('mappedSnapshots')
+      [`{viewModel.instance} ${REFRESH_MAPPING.type}`](scope, event) {
+        const viewModel = this.viewModel;
+        viewModel.attr('mappedSnapshots')
           .replace(this.viewModel.loadSnapshots());
+        viewModel.attr('instance').dispatch({
+          ...REFRESH_RELATED,
+          model: event.destinationType,
+        });
       },
       '{viewModel.instance} modelBeforeSave': function () {
         this.viewModel.attr('isAssessmentSaving', true);

--- a/src/ggrc-client/js/components/object-mapper/object-mapper.js
+++ b/src/ggrc-client/js/components/object-mapper/object-mapper.js
@@ -77,6 +77,9 @@ import {
     template: can.view(GGRC.mustache_path +
       '/components/object-mapper/object-mapper.mustache'),
     viewModel: function (attrs, parentViewModel) {
+      const refreshCounts = parentViewModel.attr('refresh_counts') !== undefined
+        ? parentViewModel.attr('refresh_counts')
+        : true;
       let config = {
         general: parentViewModel.attr('general'),
         special: parentViewModel.attr('special'),
@@ -94,6 +97,7 @@ import {
         object: resolvedConfig.object,
         type: getDefaultType(resolvedConfig.type, resolvedConfig.object),
         config: config,
+        refreshCounts,
         useSnapshots: resolvedConfig.useSnapshots,
         isLoadingOrSaving: function () {
           return this.attr('is_saving') ||
@@ -247,9 +251,9 @@ import {
         let defer = [];
         let que = new RefreshQueue();
 
-        que.enqueue(instance).trigger().done(function (inst) {
+        que.enqueue(instance).trigger().done((inst) => {
           data.context = instance.context || null;
-          objects.forEach(function (destination) {
+          objects.forEach((destination) => {
             let modelInstance;
             let isMapped;
             let isAllowed;
@@ -285,17 +289,17 @@ import {
             data[mapping.option_attr] = destination;
             modelInstance = new Model(data);
             defer.push(modelInstance.save());
-          }.bind(this));
+          });
 
           $.when.apply($, defer)
-            .fail(function (response, message) {
+            .fail((response, message) => {
               $('body').trigger('ajax:flash', {error: message});
             })
-            .always(function () {
+            .always(() => {
               this.viewModel.attr('is_saving', false);
               this.closeModal();
-            }.bind(this))
-            .done(function () {
+            })
+            .done(() => {
               if (instance && instance.dispatch) {
                 instance.dispatch('refreshInstance');
                 instance.dispatch({
@@ -303,11 +307,15 @@ import {
                   destinationType: type,
                 });
               }
-              // This Method should be modified to event
-              refreshCounts();
+
+              if (this.viewModel.attr('refreshCounts')) {
+                // This Method should be modified to event
+                refreshCounts();
+              }
+
               instance.dispatch(REFRESH_SUB_TREE);
             });
-        }.bind(this));
+        });
       },
     },
 

--- a/src/ggrc-client/js/components/related-objects/related-objects.js
+++ b/src/ggrc-client/js/components/related-objects/related-objects.js
@@ -147,9 +147,6 @@ import Pagination from '../base-objects/pagination';
       '{viewModel.paging} pageSize': function () {
         this.viewModel.setRelatedItems();
       },
-      '{viewModel.baseInstance} refreshInstance': function () {
-        this.viewModel.setRelatedItems();
-      },
       [`{viewModel.baseInstance} ${REFRESH_RELATED.type}`]:
         function (scope, event) {
           let vm = this.viewModel;

--- a/src/ggrc-client/js/components/workflow/task-list/task-list.js
+++ b/src/ggrc-client/js/components/workflow/task-list/task-list.js
@@ -6,6 +6,7 @@
 import template from './templates/task-list.mustache';
 import Pagination from '../../base-objects/pagination';
 import Permission from '../../../permission';
+import {REFRESH_RELATED} from '../../../events/eventTypes';
 
 const viewModel = can.Map.extend({
   /**
@@ -49,7 +50,10 @@ const viewModel = can.Map.extend({
       // reload items manually, because CanJs does not
       // trigger "change" event, when we try to set first page
       // (we are already on first page)
-      this.attr('baseInstance').dispatch('refreshInstance');
+      this.attr('baseInstance').dispatch({
+        ...REFRESH_RELATED,
+        model: this.attr('relatedItemsType'),
+      });
     }
   },
   updatePagingAfterDestroy() {
@@ -64,7 +68,10 @@ const viewModel = can.Map.extend({
       this.attr('paging.current', current - 1);
     } else {
       // update current page
-      this.attr('baseInstance').dispatch('refreshInstance');
+      this.attr('baseInstance').dispatch({
+        ...REFRESH_RELATED,
+        model: this.attr('relatedItemsType'),
+      });
     }
   },
 });

--- a/src/ggrc-client/js/components/workflow/task-list/task-list.js
+++ b/src/ggrc-client/js/components/workflow/task-list/task-list.js
@@ -8,6 +8,12 @@ import Pagination from '../../base-objects/pagination';
 import Permission from '../../../permission';
 
 const viewModel = can.Map.extend({
+  /**
+   * A model name. Each item within the task list
+   * will have this model name.
+   */
+  relatedItemsType: 'TaskGroupTask',
+}, {
   define: {
     paging: {
       value() {
@@ -23,8 +29,12 @@ const viewModel = can.Map.extend({
         );
       },
     },
+    relatedItemsType: {
+      get() {
+        return this.constructor.relatedItemsType;
+      },
+    },
   },
-  relatedItemsType: 'TaskGroupTask',
   initialOrderBy: 'created_at',
   gridSpinner: 'grid-spinner',
   items: [],
@@ -60,11 +70,19 @@ const viewModel = can.Map.extend({
 });
 
 const events = {
-  '{CMS.Models.TaskGroupTask} destroyed'() {
-    this.viewModel.updatePagingAfterDestroy();
+  [`{CMS.Models.${viewModel.relatedItemsType}} destroyed`](
+    model, event, instance
+  ) {
+    if (instance instanceof CMS.Models[viewModel.relatedItemsType]) {
+      this.viewModel.updatePagingAfterDestroy();
+    }
   },
-  '{CMS.Models.TaskGroupTask} created'() {
-    this.viewModel.updatePagingAfterCreate();
+  [`{CMS.Models.${viewModel.relatedItemsType}} created`](
+    model, event, instance
+  ) {
+    if (instance instanceof CMS.Models[viewModel.relatedItemsType]) {
+      this.viewModel.updatePagingAfterCreate();
+    }
   },
 };
 

--- a/src/ggrc/assets/mustache/base_objects/task_group_subtree_footer.mustache
+++ b/src/ggrc/assets/mustache/base_objects/task_group_subtree_footer.mustache
@@ -19,7 +19,8 @@
     data-join-mapping="objects"
     data-join-object-id="{{instance.id}}"
     data-join-object-type="TaskGroup"
-    data-exclude-option-types="">
+    data-exclude-option-types=""
+    data-refresh-counts="false">
     Add Object
   </a>
 </div>


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

FE sends redundant request to the server, when objects are mapped to some Task Group.

# Steps to test the changes

1. Open any workflow
2. Open any task group
3. Try to map objects to task group.

**Actual result**: there are a lot of extra requests. It seems, count of redundant requests depends on count of mapped objects.
**Expected result**: there are no extra requests.

# Solution description

There are several ways, which help to remove extra requests.

1. When pagination for the Task Group Task was added, `related-objects` component, which is used inside `task-list`, catches `refreshInstance` event onto `baseInstance` and refreshes items for the list. Thus, when the user tries to map objects to TG, then `object-mapper` component will dispatch `refreshInstance` event -> after mapping `task-list` will refresh the inner list. To resolve this situation, we should use another way for TGT list update:
- remove `refreshInstance` handler for `related-objects` component
- use `REFRESH_RELATED` instead of `refreshInstance`

Total: **-1 QueryAPI request**

2. TG instance is an object, for which mapped objects are presented on the TG's info panel. Almost all objects within the app use for such situations Tree View. Thus, when we use `object-mapper`, then after mapping operation this component refreshes counts for all tabs. But, when we map objects for TG, we do not need to update these counts, because objects are not placed on Tree View. An easy solution - use `data-...` attribute for *Add Object* button.

Total: **-1 QueryAPI request**

3. CanJs has a strange behavior, when we try to listen some model events. For example, some component has event handler as follows:

```js
const events = {
    '{CMS.Models.ModelName} created'() {
      // ...
    }
 }
```
Sometimes, CanJs will call this handler even the instance has another type, for example `CMS.Models.ModelName2`. After the research of existing code, I found similar handlers. They check `instance` explicitly:

```js
const events = {
    '{CMS.Models.ModelName} created'(a1, a2, instance) {
       if (instance instanceof CMS.Models.ModelName ) {
         // ...
       }
    }
 }
```

CanJs's does not describe this approach. But, I used it to filter only needed `instances`.
Total: **-1 requests for each mapped object**. If we map `n` objects, then `n` extra requests will be occuered due to the issue described above.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
