### PR TITLE
GGRC-5016 Uncaught TypeError: Cannot read property 'is_custom_attributable' of undefined errors occurs if click on Edit Task Group button in the Setup tab

### DIFF
--- a/src/ggrc-client/js/models/cacheable.js
+++ b/src/ggrc-client/js/models/cacheable.js
@@ -945,7 +945,7 @@ import RefreshQueue from './refresh_queue';
       this._customAttributeAccess.write(change);
     },
     isCustomAttributable() {
-      return this.attr('class').is_custom_attributable;
+      return this.constructor.is_custom_attributable;
     },
     computed_errors: function () {
       let errors = this.errors();

--- a/src/ggrc-client/js_specs/models/cacheable_spec.js
+++ b/src/ggrc-client/js_specs/models/cacheable_spec.js
@@ -549,7 +549,7 @@ describe('can.Model.Cacheable', function () {
 
     it('returns false if the instance is not custom attributable', function () {
       let result;
-      instance.attr('class').is_custom_attributable = false;
+      instance.constructor.is_custom_attributable = false;
       result = instance.isCustomAttributable();
       expect(result).toBe(false);
     });


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Uncaught TypeError: Cannot read property 'is_custom_attributable' of undefined errors occurs if click on Edit Task Group button in the Setup tab.

# Steps to test the changes

Steps to reproduce:
1. Open any Workflow with Task group.
2. Open info pane for Task group.
3. Click on 3 bb's menu
4. Click Edit Task group
5. Change Task group Assignee > Click x > Click Discard
6. Click Edit Task group in 3 bb's menu one more time
*Actual Result:* If user clicks on Edit Task Group button in the Setup tab one more time after he reassigned Assignee and clicked discard in Edit Task Group popup, JS error is shown.
*Expected Result:* no errors should occur if click on Edit Task Group button in the Setup tab.

# Solution description

Cacheable instance can be a full object or a trimmed object (stub). 
1. For full object there is `class` property, which contains `instance.constructor`. `class` property is set, when cacheable instance is built (inside `init` method).
2. For stub there is no `class` property, because stubs do not use `init` method, where `class` is set.

Because of these reasons, we should use `instance.constructor.[propName]` way - `constructor` property is always presented for certain instance.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
