### PR TITLE
GGRC-5028 Process CAD getter only for CustomAttributable objects

### DIFF
--- a/src/ggrc/models/custom_attribute_definition.py
+++ b/src/ggrc/models/custom_attribute_definition.py
@@ -363,6 +363,11 @@ def get_model_name_inflector_dict():
 
 def get_custom_attributes_for(model_name, instance_id=None):
   """Returns custom attributes jsons for sent model_name and instance_id."""
+  from ggrc import models
+  model = models.get_model(model_name)
+  if not model or not issubclass(model, models.mixins.CustomAttributable):
+    return []
+
   definition_type = get_model_name_inflector_dict()[model_name]
   if not definition_type:
     return []


### PR DESCRIPTION
# Issue description

Currently function get_custom_attributes_for is run for all object types. It leads to memcache quering and definition_type calculation each time when this function is invoked. But there are no sense to do it for objects that can't have custom attributes (not inherited from CustomAttributable mixin).

This PR is part of GGRC-4919
Tested locally generation of 247 Assessments in Audit with:
196 Standarts
1015 Objectives
4744 Controls
86 Products
140 Systems
5 Audit Captains
10 Auditors
22 Program role people

Without template:
Without fix: 195.535 seconds
With fix: 93.766 seconds

With template (3 CADs):
Without fix: 209.394 seconds
With fix: 88.486 seconds


# Steps to test the changes

Run generation of Assessments before and after fix. Check if performance improvement exists.

# Solution description

Check if model is CustomAttributable, if not - return empty list.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".