### PR TITLE
GGRC-4929 Import: Assessment gets created w/o control mapping

### DIFF
--- a/src/ggrc/cache/memcache.py
+++ b/src/ggrc/cache/memcache.py
@@ -283,8 +283,9 @@ class _Decorated(object):
     if not self.active:
       return self.function(*args, **kwargs)
     key = self.get_key(*args, **kwargs)
-    if self.memcache_client.get(key) is not None:
-      return self.memcache_client.get(key)
+    value = self.memcache_client.get(key)
+    if value is not None:
+      return value
     result = self.function(*args, **kwargs)
     self.memcache_client.add(key, result)
     return result

--- a/test/unit/appengine/test_memcache_decorator.py
+++ b/test/unit/appengine/test_memcache_decorator.py
@@ -4,17 +4,16 @@
 """Test with_memcache util decorator"""
 
 from unittest import TestCase
-
+import mock
 from ddt import data, ddt, unpack
 from appengine import base
-import mock
 from ggrc.cache.memcache import cached
 
 
 @ddt
 @base.with_memcache
 class TestMemcacheDecorator(TestCase):
-  """Test docorator to emulate memcache in test"""
+  """Test decorator to emulate memcache in test"""
 
   TESTKEYS = ('1', '2', '3')
 
@@ -33,6 +32,7 @@ class TestMemcacheDecorator(TestCase):
       self.assertEqual(val, self.memcache_client.get(key))
 
   def test_expire(self):
+    """Test decorator to emulate cache expire"""
     def test_func():
       pass
     cached_test_func = cached(test_func)

--- a/test/unit/appengine/test_memcache_decorator.py
+++ b/test/unit/appengine/test_memcache_decorator.py
@@ -7,6 +7,8 @@ from unittest import TestCase
 
 from ddt import data, ddt, unpack
 from appengine import base
+import mock
+from ggrc.cache.memcache import cached
 
 
 @ddt
@@ -29,3 +31,11 @@ class TestMemcacheDecorator(TestCase):
       val = key * 10
       self.memcache_client.add(key, val)
       self.assertEqual(val, self.memcache_client.get(key))
+
+  def test_expire(self):
+    def test_func():
+      pass
+    cached_test_func = cached(test_func)
+    cached_test_func.memcache_client.get = mock.Mock(side_effect=['1', None])
+    self.assertEqual(cached_test_func(), '1')
+    self.assertEqual(cached_test_func(), None)


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

One of the imports failed because of invalid memcache. 
Rarely memcache could expire and in the result we will receive invalid cache (None value). 

# Solution description

Store value in the variable in order to return it after check for None value. 

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
