### PR TITLE
GGRC-5075 Revision ids are loaded lazily in send_event_job

### DIFF
--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -1475,6 +1475,6 @@ def send_event_job(event):
   rows = db.session.query(Revision.id).filter_by(
       event_id=event.id,
   ).all()
-  revision_ids = [id for id, in rows]
+  revision_ids = [revision_id for revision_id, in rows]
   from ggrc import views
   views.start_compute_attributes(revision_ids)

--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -45,7 +45,6 @@ from ggrc.models.background_task import BackgroundTask, create_task
 from ggrc.query import utils as query_utils
 from ggrc import settings
 from ggrc.cache import utils as cache_utils
-from ggrc.models.revision import Revision
 
 
 # pylint: disable=invalid-name
@@ -1472,9 +1471,5 @@ def etag(last_modified, info=''):
 
 def send_event_job(event):
   """Create background job for handling new revisions."""
-  rows = db.session.query(Revision.id).filter_by(
-      event_id=event.id,
-  ).all()
-  revision_ids = [revision_id for revision_id, in rows]
   from ggrc import views
-  views.start_compute_attributes(revision_ids)
+  views.start_compute_attributes(event_id=event.id)

--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -45,6 +45,7 @@ from ggrc.models.background_task import BackgroundTask, create_task
 from ggrc.query import utils as query_utils
 from ggrc import settings
 from ggrc.cache import utils as cache_utils
+from ggrc.models.revision import Revision
 
 
 # pylint: disable=invalid-name
@@ -1470,7 +1471,10 @@ def etag(last_modified, info=''):
 
 
 def send_event_job(event):
-  """Create bacground job for handling new revisions."""
-  revision_ids = [revision.id for revision in event.revisions]
+  """Create background job for handling new revisions."""
+  rows = db.session.query(Revision.id).filter_by(
+      event_id=event.id,
+  ).all()
+  revision_ids = [id for id, in rows]
   from ggrc import views
   views.start_compute_attributes(revision_ids)

--- a/src/ggrc/views/__init__.py
+++ b/src/ggrc/views/__init__.py
@@ -118,11 +118,10 @@ def compute_attributes(args):
       rows = db.session.query(Revision.id).filter_by(
           event_id=args.parameters["event_id"],).all()
       revision_ids = [revision_id for revision_id, in rows]
+    elif str(args.parameters["revision_ids"]) == "all_latest":
+      revision_ids = "all_latest"
     else:
-      if str(args.parameters["revision_ids"]) == "all_latest":
-        revision_ids = "all_latest"
-      else:
-        revision_ids = [id_ for id_ in args.parameters["revision_ids"]]
+      revision_ids = [id_ for id_ in args.parameters["revision_ids"]]
 
     computed_attributes.compute_attributes(revision_ids)
     return app.make_response(("success", 200, [("Content-Type", "text/html")]))


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

We experience performance issues because of lazy loading of revisions ids. 

# Solution description

The solution is to send event id to the background task and query revisions ids with one qouery by event id.

# Steps to test the changes

When creating an assessment see in the sqlalchemy logs the queries to the database. Now we should only query revision ids once per background task. 

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
