### PR TITLE
GGRC-5017 Save & Close button is disabled in Edit Task Group popup after reassign task group assignee

### DIFF
--- a/src/ggrc-client/js/components/external-data-autocomplete/external-data-autocomplete.js
+++ b/src/ggrc-client/js/components/external-data-autocomplete/external-data-autocomplete.js
@@ -132,6 +132,8 @@ export default GGRC.Components('externalDataAutocomplete', {
         let data = response[0];
         let model = data[1][ModelClass.root_object];
 
+        model = model.reify ? model.reify() : model;
+
         let result = ModelClass.cache[model.id] || new ModelClass(model);
 
         return result;

--- a/src/ggrc-client/js/components/external-data-autocomplete/tests/external-data-autocomplete_spec.js
+++ b/src/ggrc-client/js/components/external-data-autocomplete/tests/external-data-autocomplete_spec.js
@@ -258,6 +258,19 @@ describe('GGRC.Components.externalDataAutocomplete', ()=> {
           done();
         });
       });
+
+      it('calls model reify', (done)=> {
+        model.reify = jasmine.createSpy('reify').and.returnValue(model);
+
+        let resultDfd = viewModel.createOrGet(item);
+
+        createDfd.resolve(response);
+
+        resultDfd.then((resultModel)=> {
+          expect(model.reify).toHaveBeenCalled();
+          done();
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
# Issue description

Save & Close button is disabled in Edit Task Group popup when you reassign the task to a user who is an author of Control, attached to the Task Group.
Model cache is not updated from external-data-autocomplete.

# Steps to test the changes

1. Create a Control by User#2.
2. Login as User#1 and create a Workflow.
3. Open Task Group in Setup tab.
4. Attach the Control (from step 1) to the Task Group.
5. Open Edit Task Group.
6. Try to reassign it to User#2.

**Actual Result:** Save & Close button is disabled.
**Expected Result:** Save & Close button should be enabled.

# Solution description

Added model.reify() to external-data-autocomplete on createOrGet item.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".