### PR TITLE
GGRC-4997 Fix 500 error when moving assessment to In Progress after GCAD delete

### DIFF
--- a/src/ggrc/notifications/__init__.py
+++ b/src/ggrc/notifications/__init__.py
@@ -39,26 +39,37 @@ def _get_value(cav, _type):
   return cav["attribute_value"]
 
 
-def get_updated_cavs(new_attrs, old_attrs):
-  """Get dict of updated custom attributes of assessment"""
-  cad_list = old_attrs.get("custom_attribute_definitions", []) + \
+def get_updated_cavs(new_attrs, rev_content):
+  """Get dict of updated custom attributes of assessment.
+
+    Args:
+      new_attrs: dict which contains cads and cavs of the obj
+      rev_content: content of the revision of the obj
+
+    Returns:
+      names of cavs that have been updated
+    """
+  cad_list = rev_content.get("custom_attribute_definitions", []) + \
       new_attrs.get("custom_attribute_definitions", [])
   cad_names = {cad["id"]: cad["display_name"] for cad in cad_list}
   cad_types = {cad["id"]: cad["attribute_type"] for cad in cad_list}
 
-  old_cavs = old_attrs.get("custom_attribute_values", [])
+  old_cavs = rev_content.get("custom_attribute_values", [])
   new_cavs = new_attrs.get("custom_attribute_values", [])
 
-  old_cavs = {cad_names[cav["custom_attribute_id"]]:
-              _get_value(cav, cad_types[cav["custom_attribute_id"]])
-              for cav in old_cavs}
+  old_cavs_dict = {}
+
+  for cav in old_cavs:
+    cav_id = cav["custom_attribute_id"]
+    if cav_id in cad_names and cav_id in cad_types:
+      old_cavs_dict[cad_names[cav_id]] = _get_value(cav, cad_types[cav_id])
 
   new_cavs = {cad_names[cav["custom_attribute_id"]]:
               _get_value(cav, cad_types[cav["custom_attribute_id"]])
               for cav in new_cavs}
 
   for attr_name, new_val in new_cavs.iteritems():
-    old_val = old_cavs.get(attr_name, None)
+    old_val = old_cavs_dict.get(attr_name, None)
     if old_val != new_val:
       if not old_val and not new_val:
         continue

--- a/test/integration/ggrc/models/mixins/test_customattributable.py
+++ b/test/integration/ggrc/models/mixins/test_customattributable.py
@@ -386,6 +386,29 @@ class TestCADUpdate(TestCase):
     )
     self.assertEqual(cads_query.count(), 0)
 
+  def test_gcad_remove_and_status(self):
+    """Test removing of GCADs for assessment and change
+    assessment status after that."""
+    assessment = factories.AssessmentFactory(status="In Review")
+    assessment_id = assessment.id
+    cad = factories.CustomAttributeDefinitionFactory(
+        title="global cad",
+        definition_type="assessment",
+        attribute_type="Text",
+    )
+    factories.CustomAttributeValueFactory(
+        custom_attribute=cad,
+        attributable=assessment,
+        attribute_value="test"
+    )
+    self.api.delete(cad)
+    assessment = models.Assessment.query.get(assessment_id)
+    response = self.api.put(assessment, {"status": "In Progress"})
+
+    self.assert200(response)
+    self.assertEqual(response.json['assessment']['status'],
+                     "In Progress")
+
   def test_lcads_import_update(self):
     """Test saving of LCADs for Assessment Template after import"""
     cads_count = 2


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

There is internal error when assessment is put into progress state after global CAD is deleted.

# Steps to test the changes

1. Have an assessment in 'In Review' state;
2. Add global CAD;
3. Fill in this cad in the assessment;
4. Delete cad;
5. Click 'Edit Answers' button.

No errors should appear; assessment should be moved in 'In Progress' state.

# Solution description

An error appeared in notification handler. There is KeyError in method which checks if cad has been updated. To fix it, check if object exists in dict was added. 

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
