### PR TITLE
GGRC-5134 Remove sqlalchemy warnings on related assessments

### DIFF
--- a/src/ggrc/services/resources/related_assessments.py
+++ b/src/ggrc/services/resources/related_assessments.py
@@ -104,7 +104,7 @@ class RelatedAssessmentsResource(common.Resource):
     # note that using pagination.get_total_count here would return wrong counts
     # due to query being an eager query.
 
-    return query, total
+    return query.all(), total
 
   @classmethod
   def _get_evidences(cls, assessments):
@@ -295,6 +295,8 @@ class RelatedAssessmentsResource(common.Resource):
 
   def _get_assessments_json(self, obj, assessments):
     """Get json representation for all assessments in result set."""
+    if not assessments:
+      return []
     with benchmark("get documents of related assessments"):
       evidence_json_map = self._get_evidences(assessments)
     with benchmark("get snapshots of related assessments"):


### PR DESCRIPTION
**Note: This is a partial PR for the specified ticket.**

# Issue description

Fetching a list of 0 related assessments shows an sqlalchemy warning.

# Steps to test the changes

freshly start the dev server (launch_ggrc)
on a clean db create a new assessment and open it.
wait for related assessment query to be called as well
look at the server output:

you will see:
```
/vagrant/src/packages/sqlalchemy/sql/default_comparator.py:35: SAWarning: The IN-predicate on "relationships.destination_id" was invoked with an empty sequence. This results in a contradiction, which nonetheless can be expensive to evaluate.  Consider alternative strategies for improved performance.
  return o[0](self, self.expr, op, *(other + o[1:]), **kwargs)
/vagrant/src/packages/sqlalchemy/sql/default_comparator.py:35: SAWarning: The IN-predicate on "relationships.source_id" was invoked with an empty sequence. This results in a contradiction, which nonetheless can be expensive to evaluate.  Consider alternative strategies for improved performance.
  return o[0](self, self.expr, op, *(other + o[1:]), **kwargs)
/vagrant/src/packages/sqlalchemy/sql/default_comparator.py:35: SAWarning: The IN-predicate on "snapshots.id" was invoked with an empty sequence. This results in a contradiction, which nonetheless can be expensive to evaluate.  Consider alternative strategies for improved performance.
  return o[0](self, self.expr, op, *(other + o[1:]), **kwargs)
```

Extra: compare integration tests output

# Solution description

Prevent any queries from being called if we have zero related assessments to show.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests. - relying on previous tests for related assessments to still work.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
