### PR TITLE
GGRC-5133 Remove data truncated warning

### DIFF
--- a/src/ggrc/models/mixins/__init__.py
+++ b/src/ggrc/models/mixins/__init__.py
@@ -296,7 +296,7 @@ class LastDeprecatedTimeboxed(Timeboxed):
     if hasattr(superinstance, "validate_status"):
       value = superinstance.validate_status(key, value)
     if value != self.status and value == self.AUTO_SETUP_STATUS:
-      self.end_date = datetime.datetime.now()
+      self.end_date = datetime.date.today()
     return value
 
 


### PR DESCRIPTION
The end_date variable is a date not a datetime. Setting it to now
instead of today triggered an sql warning that the data was being
truncated.

<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Deprecating an assessment shows a warning

/vagrant/src/packages/sqlalchemy/engine/default.py:436: Warning: Data truncated for column 'end_date' at row 1

# Steps to test the changes

start server with launch_ggrc
deprecate an assessment
look at server logs

Extra: compare integration tests output

# Solution description

Set the correct value format to end_date. 

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests. I am relying on previous tests, But since this removes a warning from our tests (deprecated access tests) I will count this as covered.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
