### PR TITLE
GGRC-5131 Remove unicode warnings from attributes deletion

### DIFF
--- a/src/ggrc/data_platform/attributes.py
+++ b/src/ggrc/data_platform/attributes.py
@@ -17,7 +17,7 @@ class Attributes(base.Base, db.Model):
   attribute_id = db.Column(db.Integer, primary_key=True)
   # object id should eventually be a foreign key to objects table
   object_id = db.Column(db.Integer)
-  object_type = db.Column(db.Unicode(250))
+  object_type = db.Column(db.String)
   attribute_definition_id = db.Column(
       db.Integer,
       db.ForeignKey('attribute_definitions.attribute_definition_id')
@@ -35,9 +35,9 @@ class Attributes(base.Base, db.Model):
   value_datetime = db.Column(db.DateTime)
 
   # ggrc specific code, needs to be added back to DP.
-  source_type = db.Column(db.Unicode(250))
+  source_type = db.Column(db.String)
   source_id = db.Column(db.Integer)
-  source_attr = db.Column(db.Unicode(250))
+  source_attr = db.Column(db.String)
 
   namespace_id = db.Column(
       db.Integer, db.ForeignKey('namespaces.namespace_id'), nullable=True)

--- a/src/ggrc/data_platform/computed_attributes.py
+++ b/src/ggrc/data_platform/computed_attributes.py
@@ -523,11 +523,11 @@ def get_attributes_data(computed_values):
     definition_id = attr.attribute_definition.attribute_definition_id
     for obj, computed_value in objects.iteritems():
       data.append({
-          "object_type": unicode(obj[0]),
+          "object_type": obj[0],
           "object_id": obj[1],
-          "source_type": unicode(aggregate_type),
+          "source_type": aggregate_type,
           "source_id": computed_value["source_id"],
-          "source_attr": unicode(aggregate_field),
+          "source_attr": aggregate_field,
           "value_datetime": computed_value["value_datetime"],
           "value_string": computed_value["value_string"] or "",
           "value_integer": computed_value["value_integer"],


### PR DESCRIPTION

# Issue description

Assessment deletion triggers a unicode sql warning.

# Steps to test the changes

launch server with launch_ggrc
Delete an assessment 
check logs for warnings

Extra: compare integration tests output

# Solution description

Since the object type and id are set automatically by ORM mapper when
deleting an assessment we can't force it to be unicode and then
sqlalchemy shows a warning that we're comparing ascii to unicode.

The original reason for using unicode was to be as close to data
platform design as possible, but the key difference here is that our
models are actual python classes that can't be unicode. This makes it
safe to change the filed from unicode to normal string.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests. - relying on original feature tests. Also this removes a warning from integration tests so the code is run during tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
