### PR TITLE
GGRC-5130 Remove sql warning on active workflow deletion

### DIFF
--- a/src/ggrc/models/mixins/notifiable.py
+++ b/src/ggrc/models/mixins/notifiable.py
@@ -33,4 +33,5 @@ class Notifiable(object):
         Notification,
         primaryjoin=join_function,
         backref="{}_notifiable".format(cls.__name__),
+        cascade="all, delete-orphan",
     )

--- a/src/ggrc_workflows/migrations/versions/20180521064346_fd8706aad739_clean_up_notifications_table.py
+++ b/src/ggrc_workflows/migrations/versions/20180521064346_fd8706aad739_clean_up_notifications_table.py
@@ -1,0 +1,39 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Clean up notifications table
+
+Create Date: 2018-05-21 06:43:46.671332
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'fd8706aad739'
+down_revision = '5206dc9f95f0'
+
+
+def upgrade():
+  """Remove invalid entries from notifications table.
+
+  Notifications set the object id to 0 when the original object for the
+  notification is deleted. The proper thing to do would be to delete those
+  notifications which is now done by the orm relationship. This migration
+  is just to clean up old data.
+
+  This migration relies on the fact that all objects have a minimum id of 1.
+  Only object with id 0 is an admin context which does not have notifications.
+  This means it should be safe to remove notifications for objects with id 0.
+  """
+  op.execute("DELETE FROM notifications WHERE object_id = 0")
+
+
+def downgrade():
+  """Skip downgrade.
+
+  Upgrade removes invalid data, so no action is needed in downgrade
+  """


### PR DESCRIPTION
# Issue description

Deleting an active workflow show a "object_id can not be null" warning, and sets the id to invalid 0.

# Steps to test the changes

launch the server with launch_ggrc
create and activate a workflow
delete a workflow

Check server logs.
Check that notification entries do not exist for that workflow and those deleted cycle tasks.
Check errors output on run_pytest 

# Solution description

Set the correct relationship cascade property to ensure notifications for deleted objects are deleted as well.

Remove all notification entries for past deleted objects.


# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests. - changes here are covered by acl propagation tests on workflow deletion, where a sql warning appeared and is fixed by this PR.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# Migration checklist
- [x] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)


# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
