### PR TITLE
GGRC-5127 Global reader can't read Evidence revision.

### DIFF
--- a/src/ggrc_basic_permissions/roles/Reader.py
+++ b/src/ggrc_basic_permissions/roles/Reader.py
@@ -40,6 +40,7 @@ permissions = {
         "Regulation",
         "Standard",
         "Document",
+        "Evidence",
         "Facility",
         "Help",
         "Market",


### PR DESCRIPTION
# Issue description

Global reader can't read Evidence revision.

# Steps to test the changes

Steps to reproduce:
1. Open any audit page
2. Create assessment
3. Attach evidence to assessment
4. Log as Global Reader user
5. Open Assessment Info page > Evidence tab
6. Expand Evidence Info panel and click Change Log tab

**Actual Result**: If Global Reader user, who doesn't have any role in audit opens Change Log tab in Evidence, "Uncaught TypeError: Cannot read property 'access_control_list' of null" error occurs, no info is shown in Change Log
**Expected Result**: no errors should be shown if global creator user w/o any role in program opens change log tab on Evidence

# Solution description

Add Evidence object to Global reader's configuration.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
