### PR TITLE
GGRC-5048 Title and option of LCA dropdown are missed after Assessment Info panel got refreshed

### DIFF
--- a/src/ggrc/models/comment.py
+++ b/src/ggrc/models/comment.py
@@ -266,6 +266,12 @@ class Comment(Roleable, Relatable, Described, Notifiable,
            .undefer_group('CustomAttributeDefinition_complete'),
     )
 
+  def log_json(self):
+    """Log custom attribute revisions."""
+    res = super(Comment, self).log_json()
+    res["custom_attribute_revision"] = self.custom_attribute_revision
+    return res
+
   @builder.simple_property
   def custom_attribute_revision(self):
     """Get the historical value of the relevant CA value."""

--- a/test/integration/ggrc/models/mixins/test_commentable.py
+++ b/test/integration/ggrc/models/mixins/test_commentable.py
@@ -35,5 +35,3 @@ class TestCommentableMixin(TestCase):
 
     self.assertEquals(1, len(asmnt_comments))
     self.assertEquals("test0", "".join(c.description for c in asmnt_comments))
-    self.assertTrue("custom_attribute_revision" in
-                    asmnt_comments[0].log_json().keys())

--- a/test/integration/ggrc/models/mixins/test_commentable.py
+++ b/test/integration/ggrc/models/mixins/test_commentable.py
@@ -35,4 +35,5 @@ class TestCommentableMixin(TestCase):
 
     self.assertEquals(1, len(asmnt_comments))
     self.assertEquals("test0", "".join(c.description for c in asmnt_comments))
-    self.assertTrue("custom_attribute_revision" in asmnt_comments[0].log_json().keys())
+    self.assertTrue("custom_attribute_revision" in
+                    asmnt_comments[0].log_json().keys())

--- a/test/integration/ggrc/models/mixins/test_commentable.py
+++ b/test/integration/ggrc/models/mixins/test_commentable.py
@@ -35,3 +35,4 @@ class TestCommentableMixin(TestCase):
 
     self.assertEquals(1, len(asmnt_comments))
     self.assertEquals("test0", "".join(c.description for c in asmnt_comments))
+    self.assertTrue("custom_attribute_revision" in asmnt_comments[0].log_json().keys())

--- a/test/integration/ggrc/models/mixins/test_with_action.py
+++ b/test/integration/ggrc/models/mixins/test_with_action.py
@@ -571,8 +571,9 @@ class TestCommentWithActionMixin(TestCase):
   def test_custom_comment_value(self):
     """Test add custom attribute value comment action."""
     assessment = factories.AssessmentFactory()
+    ca_def_title = "def1"
     ca_def = factories.CustomAttributeDefinitionFactory(
-        title="def1",
+        title=ca_def_title,
         definition_type="assessment",
         definition_id=assessment.id,
         attribute_type="Dropdown",
@@ -611,7 +612,11 @@ class TestCommentWithActionMixin(TestCase):
             },
         },
     })
-    self.assertTrue(comment.log_json()["custom_attribute_revision"])
+    comment_json = comment.log_json()
+    self.assertTrue("custom_attribute_revision" in comment_json.keys())
+    self.assertEqual(
+        comment_json["custom_attribute_revision"]['custom_attribute']['title'],
+        ca_def_title)
 
   def test_wrong_comment(self):
     """Test add custom attribute comment action without description."""


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Title and option of LCA dropdown are missed after Assessment Info panel got refreshed

# Steps to test the changes

Precondition:
Have an audit and created Assessment with LCA dropdown, comment is required

Steps to reproduce:
1. Open Assessment Info panel
2. Select option with required comment for LCA, type a comment and save it
3. Confirm that Person's email, assessment role, LCA title, dropdown option and comment are displayed under comment box
4. Close and open Assessment Info panel: only Person's email, assessment role and comment are shown
Expected Result: Title and option of LCA dropdown should not be missed after Assessment Info panel got refreshed

# Solution description

When creating a json for a Comment fill the property that is used for retrieving title information on the UI 

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
