### PR TITLE
GGRC-5068 Reduce extra requests when objects are unmapped from Cycle Task via Edit modal

### DIFF
--- a/docs/source/frontend/modals.rst
+++ b/docs/source/frontend/modals.rst
@@ -93,7 +93,7 @@ Naming conventions in the forms:
 
 ``mark_for_deletion``/``mark_for_addition`` in ``cacheable.js``
 adds/removes items into ``_pending_joins``. These pending joins are then
-handled in ``resolve_deferred_bindings``. Removes are easy - it just
+handled in ``resolveDeferredBindings``. Removes are easy - it just
 destroys the mapping. The "add" case is a bit more complex than the
 "remove" case, as we must check we aren't re-mapping something which is
 already mapped.

--- a/src/ggrc-client/js/components/modal-connector.js
+++ b/src/ggrc-client/js/components/modal-connector.js
@@ -85,12 +85,13 @@ import {
           })));
       },
       deferred_update: function () {
-        let changes = this.viewModel.changes;
-        let instance = this.viewModel.instance;
+        const viewModel = this.viewModel;
+        let changes = viewModel.changes;
+        let instance = viewModel.instance;
 
         if (!changes.length) {
-          if (instance && instance._pending_joins &&
-            instance._pending_joins.length) {
+          const hasPendingJoins = _.get(instance, '_pending_joins.length') > 0;
+          if (hasPendingJoins) {
             instance.delay_resolving_save_until(resolveDeferredBindings(
               instance
             ));
@@ -98,23 +99,22 @@ import {
           return;
         }
         // Add pending operations
-        can.each(changes, function (item) {
-          let mapping = this.viewModel.mapping ||
+        can.each(changes, (item) => {
+          let mapping = viewModel.mapping ||
               GGRC.Mappings.get_canonical_mapping_name(
-                this.viewModel.instance.constructor.shortName,
+                viewModel.instance.constructor.shortName,
                 item.what.constructor.shortName);
           if (item.how === 'add') {
-            this.viewModel.instance
+            viewModel.instance
               .mark_for_addition(mapping, item.what, item.extra);
           } else {
-            this.viewModel.instance.mark_for_deletion(mapping, item.what);
+            viewModel.instance.mark_for_deletion(mapping, item.what);
           }
-        }.bind(this)
-        );
-        this.viewModel.instance
-          .delay_resolving_save_until(resolveDeferredBindings(
-            this.viewModel.instance)
-          );
+        });
+
+        viewModel.instance
+          .delay_resolving_save_until(
+            resolveDeferredBindings(viewModel.instance));
       },
       '{instance} updated': 'deferred_update',
       '{instance} created': 'deferred_update',

--- a/src/ggrc-client/js/components/modal-connector.js
+++ b/src/ggrc-client/js/components/modal-connector.js
@@ -6,6 +6,9 @@
 import {
   isSnapshotType,
 } from '../plugins/utils/snapshot-utils';
+import {
+  resolveDeferredBindings,
+} from '../plugins/utils/models-utils';
 
 (function (can, $) {
   /*
@@ -88,8 +91,9 @@ import {
         if (!changes.length) {
           if (instance && instance._pending_joins &&
             instance._pending_joins.length) {
-            instance.delay_resolving_save_until(instance.constructor
-              .resolve_deferred_bindings(instance));
+            instance.delay_resolving_save_until(resolveDeferredBindings(
+              instance
+            ));
           }
           return;
         }
@@ -108,9 +112,9 @@ import {
         }.bind(this)
         );
         this.viewModel.instance
-          .delay_resolving_save_until(
-            this.viewModel.instance.constructor
-              .resolve_deferred_bindings(this.viewModel.instance));
+          .delay_resolving_save_until(resolveDeferredBindings(
+            this.viewModel.instance)
+          );
       },
       '{instance} updated': 'deferred_update',
       '{instance} created': 'deferred_update',

--- a/src/ggrc-client/js/controllers/modals/modals_controller.js
+++ b/src/ggrc-client/js/controllers/modals/modals_controller.js
@@ -1208,7 +1208,9 @@ export default can.Control({
         });
         instance.attr('custom_attribute_definitions', cad);
       }
-      instance.refresh();
+      instance.notifier.on_empty(() => {
+        instance.refresh();
+      });
       instance.dispatch(REFRESH_MAPPING);
     }
   },

--- a/src/ggrc-client/js/models/cacheable.js
+++ b/src/ggrc-client/js/models/cacheable.js
@@ -14,6 +14,9 @@ import {
 import {
   makeRequest,
 } from '../plugins/utils/query-api-utils';
+import {
+  resolveDeferredBindings,
+} from '../plugins/utils/models-utils';
 import resolveConflict from './cacheable_conflict_resolution.js';
 import PersistentNotifier from '../plugins/persistent_notifier';
 import RefreshQueue from './refresh_queue';
@@ -319,8 +322,7 @@ import tracker from '../tracker';
       this.update = function (id, params) {
         let ret = _update
           .call(this, id, this.process_args(params))
-          .then(
-            this.resolve_deferred_bindings.bind(this),
+          .then(resolveDeferredBindings,
             function (xhr) {
               if (xhr.status === 409) {
                 return resolveConflict(xhr, this.findInCacheById(id));
@@ -334,7 +336,7 @@ import tracker from '../tracker';
       this.create = function (params) {
         let ret = _create
           .call(this, this.process_args(params))
-          .then(this.resolve_deferred_bindings.bind(this));
+          .then(resolveDeferredBindings);
         delete ret.hasFailCallback;
         return ret;
       };
@@ -363,103 +365,6 @@ import tracker from '../tracker';
         }
         GGRC.roleableTypes.push(can.extend({}, this));
       }
-    },
-
-    resolve_deferred_bindings: function (obj) {
-      let _pjs;
-      let refreshDfds = [];
-      let dfds = [];
-      let dfdsApply;
-      if (obj._pending_joins && obj._pending_joins.length) {
-        _pjs = obj._pending_joins.slice(0); // refresh of bindings later will muck up the pending joins on the object
-        can.each(can.unique(can.map(_pjs, function (pj) {
-          return pj.through;
-        })), function (binding) {
-          refreshDfds.push(obj.get_binding(binding).refresh_stubs());
-        });
-
-        return $.when(...refreshDfds)
-          .then(function () {
-            can.each(obj._pending_joins, function (pj) {
-              let inst;
-              let pjDfd;
-              let binding = obj.get_binding(pj.through);
-              let model = (CMS.Models[binding.loader.model_name] ||
-                           GGRC.Models[binding.loader.model_name]);
-              if (pj.how === 'add') {
-                // Don't re-add -- if the object is already mapped (could be direct or through a proxy)
-                // move on to the next one
-                if (_.includes(_.map(binding.list, 'instance'), pj.what) ||
-                   (binding.loader.option_attr &&
-                    _.includes(_.map(binding.list, function (joinObj) {
-                      return joinObj.instance[binding.loader.option_attr];
-                    }), pj.what))) {
-                  return;
-                }
-                inst = pj.what instanceof model
-                  ? pj.what
-                  : new model({
-                    context: obj.context,
-                  });
-                pjDfd = pj.what !== inst && pj.what.isNew()
-                  ? pj.what.save() : null;
-                dfds.push(
-                  $.when(pjDfd)
-                    .then(function () {
-                      if (binding.loader.object_attr) {
-                        inst.attr(binding.loader.object_attr, obj.stub());
-                      }
-                      if (binding.loader.option_attr) {
-                        inst.attr(binding.loader.option_attr, pj.what.stub());
-                      }
-                      if (pj.extra) {
-                        inst.attr(pj.extra);
-                      }
-                      return inst.save();
-                    })
-                );
-              } else if (pj.how === 'update') {
-                binding.list.forEach(function (boundObj) {
-                  let blOptionAttr = binding.loader.option_attr;
-                  if (boundObj.instance === pj.what ||
-                      boundObj.instance[blOptionAttr] === pj.what) {
-                    boundObj.get_mappings().forEach(function (mapping) {
-                      dfds.push(mapping.refresh().then(function () {
-                        if (pj.extra) {
-                          mapping.attr(pj.extra);
-                        }
-                        return mapping.save();
-                      }));
-                    });
-                  }
-                });
-              } else if (pj.how === 'remove') {
-                can.map(binding.list, function (boundObj) {
-                  let blOptionAttr = binding.loader.option_attr;
-                  if (boundObj.instance === pj.what ||
-                      boundObj.instance[blOptionAttr] === pj.what) {
-                    can.each(boundObj.get_mappings(), function (mapping) {
-                      dfds.push(mapping.refresh().then(function () {
-                        mapping.destroy();
-                      }));
-                    });
-                  }
-                });
-              }
-            });
-
-            dfdsApply = $.when(...dfds);
-
-            obj.attr('_pending_joins', []);
-            obj.attr('_pending_joins_dfd', dfdsApply);
-
-            return dfdsApply.then(function () {
-              obj.dispatch('resolvePendingBindings');
-              return obj.refresh();
-            });
-          });
-      }
-      return obj;
     },
 
     findInCacheById: function (id) {

--- a/src/ggrc-client/js/models/save_queue.js
+++ b/src/ggrc-client/js/models/save_queue.js
@@ -4,6 +4,7 @@
 */
 
 import tracker from '../tracker';
+import {resolveDeferredBindings} from '../plugins/utils/models-utils';
 
 (function (can, $) {
   /*  GGRC.SaveQueue
@@ -97,8 +98,7 @@ import tracker from '../tracker';
         let cb = function (single) {
           return function () {
             this.created(single[1][bucket.type]);
-            return $.when(
-              can.Model.Cacheable.resolve_deferred_bindings(this));
+            return $.when(resolveDeferredBindings(this));
           };
         };
         can.each(objs, function (obj, idx) {

--- a/src/ggrc-client/js/plugins/persistent_notifier.js
+++ b/src/ggrc-client/js/plugins/persistent_notifier.js
@@ -57,10 +57,4 @@ export default can.Construct({
       this.list_empty_cbs.push(fn);
     }
   },
-  off_empty: function (fn) {
-    let idx;
-    if (~(idx = this.list_empty_cbs.indexOf(fn))) {
-      this.list_empty_cbs.splice(idx, 1);
-    }
-  },
 });

--- a/src/ggrc-client/js/plugins/tests/utils/models-utils_spec.js
+++ b/src/ggrc-client/js/plugins/tests/utils/models-utils_spec.js
@@ -1,0 +1,105 @@
+/*
+  Copyright (C) 2018 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+import {resolveDeferredBindings} from '../../utils/models-utils';
+import {makeFakeModel} from '../../../../js_specs/spec_helpers';
+
+describe('models-utils module', () => {
+  describe('resolveDeferredBindings() util', function () {
+    let origDummyModel;
+    let origDummyJoin;
+
+    beforeAll(function () {
+      origDummyModel = CMS.Models.DummyModel;
+      origDummyJoin = CMS.Models.DummyJoin;
+    });
+
+    afterAll(function () {
+      CMS.Models.DummyModel = origDummyModel;
+      CMS.Models.DummyJoin = origDummyJoin;
+    });
+
+    beforeEach(function () {
+      CMS.Models.DummyModel = makeFakeModel({model: can.Model.Cacheable});
+      CMS.Models.DummyJoin = makeFakeModel({model: can.Model.Cacheable});
+    });
+
+    it('iterates _pending_joins, calling refresh_stubs on each binding',
+      function () {
+        let instance = jasmine.createSpyObj('instance', ['get_binding']);
+        let binding = jasmine.createSpyObj('binding', ['refresh_stubs']);
+        instance._pending_joins = [{what: {}, how: 'add', through: 'foo'}];
+        instance.get_binding.and.returnValue(binding);
+        spyOn($.when, 'apply').and.returnValue(new $.Deferred().reject());
+
+        resolveDeferredBindings(instance);
+        expect(binding.refresh_stubs).toHaveBeenCalled();
+      });
+
+    describe('add case', function () {
+      let instance;
+      let binding;
+      let dummy;
+      beforeEach(function () {
+        dummy = new CMS.Models.DummyModel({id: 1});
+        instance = jasmine.createSpyObj('instance',
+          ['get_binding', 'isNew', 'refresh', 'attr', 'dispatch']);
+        binding = jasmine.createSpyObj('binding', ['refresh_stubs']);
+        instance._pending_joins = [{what: dummy, how: 'add', through: 'foo'}];
+        instance.isNew.and.returnValue(false);
+        instance.get_binding.and.returnValue(binding);
+        binding.loader = {model_name: 'DummyJoin'};
+        binding.list = [];
+        spyOn(CMS.Models.DummyJoin, 'newInstance');
+        spyOn(CMS.Models.DummyJoin.prototype, 'save');
+      });
+
+      it('creates a proxy object when it does not exist', function () {
+        resolveDeferredBindings(instance);
+        expect(CMS.Models.DummyJoin.newInstance).toHaveBeenCalled();
+        expect(CMS.Models.DummyJoin.prototype.save).toHaveBeenCalled();
+      });
+
+      it('does not create proxy object when it already exists', function () {
+        binding.list.push({instance: dummy});
+        resolveDeferredBindings(instance);
+        expect(CMS.Models.DummyJoin.newInstance).not.toHaveBeenCalled();
+        expect(CMS.Models.DummyJoin.prototype.save).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('remove case', function () {
+      let instance;
+      let binding;
+      let dummy;
+      let dummy_join;
+      beforeEach(function () {
+        dummy = new CMS.Models.DummyModel({id: 1});
+        dummy_join = new CMS.Models.DummyJoin({id: 1});
+        instance = jasmine.createSpyObj('instance',
+          ['get_binding', 'isNew', 'refresh', 'attr', 'dispatch']);
+        binding = jasmine.createSpyObj('binding', ['refresh_stubs']);
+        instance._pending_joins = [{what: dummy, how: 'remove', through: 'foo'}];
+        instance.isNew.and.returnValue(false);
+        instance.get_binding.and.returnValue(binding);
+        binding.loader = {model_name: 'DummyJoin'};
+        binding.list = [];
+        spyOn(CMS.Models.DummyJoin, 'newInstance');
+        spyOn(CMS.Models.DummyJoin.prototype, 'save');
+      });
+
+      it('removes proxy object if it exists', function () {
+        binding.list.push({instance: dummy, get_mappings: function () {
+          return [dummy_join];
+        }});
+        spyOn(dummy_join, 'refresh').and.returnValue($.when());
+        spyOn(dummy_join, 'destroy');
+        resolveDeferredBindings(instance);
+        expect(dummy_join.destroy).toHaveBeenCalled();
+      });
+    });
+  });
+});
+

--- a/src/ggrc-client/js/plugins/utils/models-utils.js
+++ b/src/ggrc-client/js/plugins/utils/models-utils.js
@@ -48,8 +48,106 @@ const hasRelatedAssessments = (type) => {
   return _.contains(relatedAssessmentsTypes, type);
 };
 
+const resolveDeferredBindings = (obj) => {
+  let _pjs;
+  let refreshDfds = [];
+  let dfds = [];
+  let dfdsApply;
+  if (obj._pending_joins && obj._pending_joins.length) {
+    _pjs = obj._pending_joins.slice(0); // refresh of bindings later will muck up the pending joins on the object
+    can.each(can.unique(can.map(_pjs, function (pj) {
+      return pj.through;
+    })), function (binding) {
+      refreshDfds.push(obj.get_binding(binding).refresh_stubs());
+    });
+
+    return $.when(...refreshDfds)
+      .then(function () {
+        can.each(obj._pending_joins, function (pj) {
+          let inst;
+          let pjDfd;
+          let binding = obj.get_binding(pj.through);
+          let model = (CMS.Models[binding.loader.model_name] ||
+                       GGRC.Models[binding.loader.model_name]);
+          if (pj.how === 'add') {
+            // Don't re-add -- if the object is already mapped (could be direct or through a proxy)
+            // move on to the next one
+            if (_.includes(_.map(binding.list, 'instance'), pj.what) ||
+               (binding.loader.option_attr &&
+                _.includes(_.map(binding.list, function (joinObj) {
+                  return joinObj.instance[binding.loader.option_attr];
+                }), pj.what))) {
+              return;
+            }
+            inst = pj.what instanceof model
+              ? pj.what
+              : new model({
+                context: obj.context,
+              });
+            pjDfd = pj.what !== inst && pj.what.isNew()
+              ? pj.what.save() : null;
+            dfds.push(
+              $.when(pjDfd)
+                .then(function () {
+                  if (binding.loader.object_attr) {
+                    inst.attr(binding.loader.object_attr, obj.stub());
+                  }
+                  if (binding.loader.option_attr) {
+                    inst.attr(binding.loader.option_attr, pj.what.stub());
+                  }
+                  if (pj.extra) {
+                    inst.attr(pj.extra);
+                  }
+                  return inst.save();
+                })
+            );
+          } else if (pj.how === 'update') {
+            binding.list.forEach(function (boundObj) {
+              let blOptionAttr = binding.loader.option_attr;
+              if (boundObj.instance === pj.what ||
+                  boundObj.instance[blOptionAttr] === pj.what) {
+                boundObj.get_mappings().forEach(function (mapping) {
+                  dfds.push(mapping.refresh().then(function () {
+                    if (pj.extra) {
+                      mapping.attr(pj.extra);
+                    }
+                    return mapping.save();
+                  }));
+                });
+              }
+            });
+          } else if (pj.how === 'remove') {
+            can.map(binding.list, function (boundObj) {
+              let blOptionAttr = binding.loader.option_attr;
+              if (boundObj.instance === pj.what ||
+                  boundObj.instance[blOptionAttr] === pj.what) {
+                can.each(boundObj.get_mappings(), function (mapping) {
+                  dfds.push(mapping.refresh().then(function () {
+                    mapping.destroy();
+                  }));
+                });
+              }
+            });
+          }
+        });
+
+        dfdsApply = $.when(...dfds);
+
+        obj.attr('_pending_joins', []);
+        obj.attr('_pending_joins_dfd', dfdsApply);
+
+        return dfdsApply.then(function () {
+          obj.dispatch('resolvePendingBindings');
+          return obj.refresh();
+        });
+      });
+  }
+  return obj;
+};
+
 export {
   getModelInstance,
   hasRelatedAssessments,
   relatedAssessmentsTypes,
+  resolveDeferredBindings,
 };

--- a/src/ggrc-client/js/plugins/utils/models-utils.js
+++ b/src/ggrc-client/js/plugins/utils/models-utils.js
@@ -48,14 +48,25 @@ const hasRelatedAssessments = (type) => {
   return _.contains(relatedAssessmentsTypes, type);
 };
 
+const handlePendingJoins = (obj) => {
+  const hasPendingJoins = _.get(obj, '_pending_joins.length') > 0;
+
+  if (!hasPendingJoins) {
+    return can.Deferred().resolve(obj);
+  }
+
+  return _resolveDeferredBindings(obj);
+};
+
 const resolveDeferredBindings = (obj) => {
   const hasPendingJoins = _.get(obj, '_pending_joins.length') > 0;
 
   if (!hasPendingJoins) {
-    return obj;
+    return can.Deferred().resolve(obj);
   }
 
-  return _resolveDeferredBindings(obj);
+  return _resolveDeferredBindings(obj)
+    .then(() => obj.refresh());
 };
 
 function _resolveDeferredBindings(obj) {
@@ -96,7 +107,7 @@ function _resolveDeferredBindings(obj) {
 
       return dfdsApply.then(() => {
         obj.dispatch('resolvePendingBindings');
-        return obj.refresh();
+        return obj;
       });
     });
 }
@@ -181,4 +192,5 @@ export {
   hasRelatedAssessments,
   relatedAssessmentsTypes,
   resolveDeferredBindings,
+  handlePendingJoins,
 };

--- a/src/ggrc-client/js/plugins/utils/models-utils.js
+++ b/src/ggrc-client/js/plugins/utils/models-utils.js
@@ -49,101 +49,132 @@ const hasRelatedAssessments = (type) => {
 };
 
 const resolveDeferredBindings = (obj) => {
-  let _pjs;
-  let refreshDfds = [];
-  let dfds = [];
-  let dfdsApply;
-  if (obj._pending_joins && obj._pending_joins.length) {
-    _pjs = obj._pending_joins.slice(0); // refresh of bindings later will muck up the pending joins on the object
-    can.each(can.unique(can.map(_pjs, function (pj) {
-      return pj.through;
-    })), function (binding) {
-      refreshDfds.push(obj.get_binding(binding).refresh_stubs());
-    });
+  const hasPendingJoins = _.get(obj, '_pending_joins.length') > 0;
 
-    return $.when(...refreshDfds)
-      .then(function () {
-        can.each(obj._pending_joins, function (pj) {
-          let inst;
-          let pjDfd;
-          let binding = obj.get_binding(pj.through);
-          let model = (CMS.Models[binding.loader.model_name] ||
-                       GGRC.Models[binding.loader.model_name]);
-          if (pj.how === 'add') {
-            // Don't re-add -- if the object is already mapped (could be direct or through a proxy)
-            // move on to the next one
-            if (_.includes(_.map(binding.list, 'instance'), pj.what) ||
-               (binding.loader.option_attr &&
-                _.includes(_.map(binding.list, function (joinObj) {
-                  return joinObj.instance[binding.loader.option_attr];
-                }), pj.what))) {
-              return;
-            }
-            inst = pj.what instanceof model
-              ? pj.what
-              : new model({
-                context: obj.context,
-              });
-            pjDfd = pj.what !== inst && pj.what.isNew()
-              ? pj.what.save() : null;
-            dfds.push(
-              $.when(pjDfd)
-                .then(function () {
-                  if (binding.loader.object_attr) {
-                    inst.attr(binding.loader.object_attr, obj.stub());
-                  }
-                  if (binding.loader.option_attr) {
-                    inst.attr(binding.loader.option_attr, pj.what.stub());
-                  }
-                  if (pj.extra) {
-                    inst.attr(pj.extra);
-                  }
-                  return inst.save();
-                })
-            );
-          } else if (pj.how === 'update') {
-            binding.list.forEach(function (boundObj) {
-              let blOptionAttr = binding.loader.option_attr;
-              if (boundObj.instance === pj.what ||
-                  boundObj.instance[blOptionAttr] === pj.what) {
-                boundObj.get_mappings().forEach(function (mapping) {
-                  dfds.push(mapping.refresh().then(function () {
-                    if (pj.extra) {
-                      mapping.attr(pj.extra);
-                    }
-                    return mapping.save();
-                  }));
-                });
-              }
-            });
-          } else if (pj.how === 'remove') {
-            can.map(binding.list, function (boundObj) {
-              let blOptionAttr = binding.loader.option_attr;
-              if (boundObj.instance === pj.what ||
-                  boundObj.instance[blOptionAttr] === pj.what) {
-                can.each(boundObj.get_mappings(), function (mapping) {
-                  dfds.push(mapping.refresh().then(function () {
-                    mapping.destroy();
-                  }));
-                });
-              }
-            });
-          }
-        });
-
-        dfdsApply = $.when(...dfds);
-
-        obj.attr('_pending_joins', []);
-        obj.attr('_pending_joins_dfd', dfdsApply);
-
-        return dfdsApply.then(function () {
-          obj.dispatch('resolvePendingBindings');
-          return obj.refresh();
-        });
-      });
+  if (!hasPendingJoins) {
+    return obj;
   }
-  return obj;
+
+  return _resolveDeferredBindings(obj);
 };
+
+function _resolveDeferredBindings(obj) {
+  const pendingJoins = obj._pending_joins.slice(0); // refresh of bindings later will muck up the pending joins on the object
+  const uniqueThrough = _(pendingJoins).chain()
+    .map((pj) => pj.through)
+    .unique()
+    .value();
+
+  const refreshDfds = [];
+  can.each(uniqueThrough, (binding) => {
+    refreshDfds.push(obj.get_binding(binding).refresh_stubs());
+  });
+
+  return $.when(...refreshDfds)
+    .then(() => {
+      const dfds = [];
+      can.each(obj._pending_joins, (pj) => {
+        switch (pj.how) {
+          case 'add':
+            dfds.push(..._addHandler(obj, pj));
+            break;
+          case 'update':
+            dfds.push(..._updateHandler(obj, pj));
+            break;
+          case 'remove':
+            dfds.push(..._removeHandler(obj, pj));
+            break;
+          default: {
+            // nothing
+          }
+        }
+      });
+
+      const dfdsApply = $.when(...dfds);
+      obj.attr('_pending_joins', []);
+      obj.attr('_pending_joins_dfd', dfdsApply);
+
+      return dfdsApply.then(() => {
+        obj.dispatch('resolvePendingBindings');
+        return obj.refresh();
+      });
+    });
+}
+
+function _addHandler(obj, pj) {
+  const binding = obj.get_binding(pj.through);
+  const dfds = [];
+  // Don't re-add -- if the object is already mapped (could be direct or through a proxy)
+  // move on to the next one
+  if (_.includes(_.map(binding.list, 'instance'), pj.what) ||
+      (binding.loader.option_attr &&
+      _.includes(_.map(binding.list, function (joinObj) {
+        return joinObj.instance[binding.loader.option_attr];
+      }), pj.what))) {
+    return dfds;
+  }
+  const model = (CMS.Models[binding.loader.model_name] ||
+    GGRC.Models[binding.loader.model_name]);
+  const inst = pj.what instanceof model
+    ? pj.what
+    : new model({
+      context: obj.context,
+    });
+  const pjDfd = pj.what !== inst && pj.what.isNew()
+    ? pj.what.save() : null;
+  const dfd = $.when(pjDfd)
+    .then(function () {
+      if (binding.loader.object_attr) {
+        inst.attr(binding.loader.object_attr, obj.stub());
+      }
+      if (binding.loader.option_attr) {
+        inst.attr(binding.loader.option_attr, pj.what.stub());
+      }
+      if (pj.extra) {
+        inst.attr(pj.extra);
+      }
+      return inst.save();
+    });
+  dfds.push(dfd);
+  return dfds;
+}
+
+function _updateHandler(obj, pj) {
+  const dfds = [];
+  let binding = obj.get_binding(pj.through);
+  binding.list.forEach(function (boundObj) {
+    let blOptionAttr = binding.loader.option_attr;
+    if (boundObj.instance === pj.what ||
+        boundObj.instance[blOptionAttr] === pj.what) {
+      boundObj.get_mappings().forEach(function (mapping) {
+        dfds.push(mapping.refresh().then(function () {
+          if (pj.extra) {
+            mapping.attr(pj.extra);
+          }
+          return mapping.save();
+        }));
+      });
+    }
+  });
+  return dfds;
+}
+
+function _removeHandler(obj, pj) {
+  const binding = obj.get_binding(pj.through);
+  const dfds = [];
+  can.map(binding.list, function (boundObj) {
+    let blOptionAttr = binding.loader.option_attr;
+    if (boundObj.instance === pj.what ||
+        boundObj.instance[blOptionAttr] === pj.what) {
+      can.each(boundObj.get_mappings(), function (mapping) {
+        dfds.push(mapping.refresh().then(function () {
+          mapping.destroy();
+        }));
+      });
+    }
+  });
+  return dfds;
+}
 
 export {
   getModelInstance,


### PR DESCRIPTION
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [x] [GGRC-5164](https://github.com/google/ggrc-core/pull/7849)

# Issue description

There are extra requests, when someone tries to unmap objects from CT via Edit modal.

# Steps to test the changes

1. Open Workflow page -> Active Cycles.
2. Open any Cycle task with some mapped object.
3. Open Edit modal for this Cycle task.
4. Unmap mapped object.
5. Click "Save".

**Actual result**: There are a lot of requests. 
Need to make an investigation, which requests are really needed.

When some object are unmapped from Cycle task via Edit modal, a lot of requests are occurred.

# Solution description

Was removed extra requests:
1. Double refresh after unmap operation.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
