### PR TITLE
GGRC-5168 Add special acl handler for cycle task comments

### DIFF
--- a/src/ggrc/models/hooks/acl/__init__.py
+++ b/src/ggrc/models/hooks/acl/__init__.py
@@ -75,7 +75,9 @@ def after_flush(session, _):
 
   # Legacy propagation for workflows that will have to be refactored to use
   # relationships and the code above
-  _add_or_update("new_wf_acls", workflow.get_new_wf_acls(session))
+  wf_acls, wf_comments = workflow.get_new_wf_acls(session)
+  _add_or_update("new_wf_acls", wf_acls)
+  _add_or_update("new_wf_comment_ct_ids", wf_comments)
   _add_or_update(
       "deleted_wf_objects",
       workflow.get_deleted_wf_objects(session)


### PR DESCRIPTION
# Issue description

Adding a comment on cycle tasks takes too long on a big workflow

2000+ tasks in a workflow (with a few cycles started)
50+ people assigned as wf members or admins.


# Steps to test the changes

- Fully test rbac on cycle tasks and cycle task comments. 
- Check performance impact on different cases for different users.

Note: pay attention if you have WF roles or cycle task role or none or both.


# Solution description

Originally to avoid handling all special cases, any new object that was
added to a workflow scope, triggered the entire workflow propagation.
This is good enough for cycle generation and other such operations
because we avoid duplicating work, or specifying all possible special
cases for child propagation, when multiple objects are created in a
single transaction.

Cycle tasks on the other hand need to be faster and they are easy to
handle because they do not trigger any new propagation - they are the
leafs in the propagation tree.

This commit pulls out all cycle task ids on which new comments have been
added. Then it triggers only cycle task entry propagation on those cycle
tasks. The work still duplicates any propagation of the previous
comments but the impact of that is negligible.


## Benchmarks:

- on localhost, difference is big enough that I did not compare on ggrc-perf.
- As admin and as ggrc.creator
- on big-wf-4 from ggrc-qa database:

Before: ~ 17.36 s
After:  ~ 636 ms


# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests. - previous tests already exist, this is just a refactor and those are still valid.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
