### PR TITLE
GGRC-4167 Remove obsolete section attribute

### DIFF
--- a/src/ggrc/migrations/versions/20180528102128_f77f9a8aff84_remove_obsolete_attribute_from_sections.py
+++ b/src/ggrc/migrations/versions/20180528102128_f77f9a8aff84_remove_obsolete_attribute_from_sections.py
@@ -1,0 +1,36 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Remove obsolete attribute from sections
+
+Create Date: 2018-05-28 10:21:28.724134
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = 'f77f9a8aff84'
+down_revision = '5d0fa1d7d55d'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  op.drop_column('sections', 'na')
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  op.add_column(
+      'sections',
+      sa.Column(
+          'na',
+          mysql.TINYINT(display_width=1),
+          autoincrement=False,
+          nullable=False
+      )
+  )

--- a/src/ggrc/models/section.py
+++ b/src/ggrc/models/section.py
@@ -46,11 +46,9 @@ class Section(Roleable,
       }
   }
 
-  na = deferred(db.Column(db.Boolean, default=False, nullable=False),
-                'Section')
   notes = deferred(db.Column(db.Text, nullable=False, default=u""), 'Section')
 
-  _api_attrs = reflection.ApiAttributes('na', 'notes')
+  _api_attrs = reflection.ApiAttributes('notes')
   _sanitize_html = ['notes']
   _include_links = []
 


### PR DESCRIPTION
The section attribute 'na' is not used anywhere in our code. Import and
export does not have a column for it and no frontend code uses it at
all. That is why this should be a safe deletion of obsolete code.

<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

The section attribute 'na' is not used anywhere in our code. Import and
export does not have a column for it and no frontend code uses it at
all. That is why this should be a safe deletion of obsolete code.

# Steps to test the changes

Check that there are no changes visible in the UI on the section model.

# Solution description

remove `na` attribute and its references.


# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# Migration checklist
- [x] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
