### PR TITLE
GGRC-5135, GGRC-5099 - Build and use query API filters as objects, not strings.

### DIFF
--- a/src/ggrc-client/js/components/tree/tests/tree-status-filter_spec.js
+++ b/src/ggrc-client/js/components/tree/tests/tree-status-filter_spec.js
@@ -16,32 +16,34 @@ describe('treeStatusFilter', () => {
   });
 
   describe('setFilter() method', () => {
-    const FILTER_STRING = 'Foo Bar Baz';
+    const FILTER = {
+      expression: 'test',
+    };
     beforeEach(() => {
       viewModel.attr('filterStates', [
         {value: 'A'},
         {value: 'B'},
         {value: 'C'},
       ]);
-      spyOn(StateUtils, 'statusFilter').and.returnValue(FILTER_STRING);
+      spyOn(StateUtils, 'buildStatusFilter').and.returnValue(FILTER);
     });
 
     it('set empty when all statuses selected', () => {
       viewModel.setFilter(['A', 'B', 'C']);
 
-      expect(viewModel.attr('options.filter')).toEqual('');
+      expect(viewModel.attr('options.query')).toEqual(null);
     });
 
     it('set empty when no status selected', () => {
       viewModel.setFilter([]);
 
-      expect(viewModel.attr('options.filter')).toEqual('');
+      expect(viewModel.attr('options.query')).toEqual(null);
     });
 
     it('set not empty when some status selected', () => {
       viewModel.setFilter(['A']);
 
-      expect(viewModel.attr('options.filter')).toEqual(FILTER_STRING);
+      expect(viewModel.attr('options.query').attr()).toEqual(FILTER);
     });
 
     it('write states to query string property', () => {

--- a/src/ggrc-client/js/components/tree/tests/tree-widget-container_spec.js
+++ b/src/ggrc-client/js/components/tree/tests/tree-widget-container_spec.js
@@ -474,6 +474,7 @@ describe('GGRC.Components.treeWidgetContainer', function () {
         .and.callFake(function (items, request) {
           request.push({name: 'item'});
         });
+      spyOn(GGRC.query_parser, 'join_queries');
     });
 
     it('copies filter and mapping items to applied', function () {
@@ -486,7 +487,7 @@ describe('GGRC.Components.treeWidgetContainer', function () {
     });
 
     it('initializes advancedSearch.filter property', function () {
-      spyOn(GGRC.query_parser, 'join_queries').and.returnValue({
+      GGRC.query_parser.join_queries.and.returnValue({
         name: 'test',
       });
       vm.attr('advancedSearch.filter', null);
@@ -498,7 +499,7 @@ describe('GGRC.Components.treeWidgetContainer', function () {
 
     it('initializes advancedSearch.request property', function () {
       vm.attr('advancedSearch.request', can.List());
-      spyOn(GGRC.query_parser, 'join_queries');
+
 
       vm.applyAdvancedFilters();
 
@@ -723,32 +724,52 @@ describe('GGRC.Components.treeWidgetContainer', function () {
       let result;
       spyOn(vm, 'attr')
         .and.returnValue([{
-          filter: '"task assignees" = "user@example.com"',
-          operation: 'AND',
+          query: {
+            expression: {
+              left: 'task assignees',
+              op: {name: '='},
+              right: 'user@example.com',
+            },
+          },
           name: 'custom',
         }, {
-          filter: '"state" = "Assigned"',
-          operation: 'AND',
+          query: {
+            expression: {
+              left: 'state',
+              op: {name: '='},
+              right: 'Assigned',
+            },
+          },
           name: 'custom',
         }]);
 
       result = vm.getDepthFilter();
 
-      expect(result).toBe('');
+      expect(result).toBe(null);
     });
 
     it('returns filter that applied for depth', function () {
       let result;
       spyOn(vm, 'attr')
         .and.returnValue([{
-          filter: '"task assignees" = "user@example.com"',
-          operation: 'AND',
+          query: {
+            expression: {
+              left: 'task assignees',
+              op: {name: '='},
+              right: 'user@example.com',
+            },
+          },
           name: 'custom',
           depth: true,
           filterDeepLimit: 2,
         }, {
-          filter: '"state" = "Assigned"',
-          operation: 'AND',
+          query: {
+            expression: {
+              left: 'state',
+              op: {name: '='},
+              right: 'Assigned',
+            },
+          },
           name: 'custom',
           depth: true,
           filterDeepLimit: 1,
@@ -756,7 +777,13 @@ describe('GGRC.Components.treeWidgetContainer', function () {
 
       result = vm.getDepthFilter(1);
 
-      expect(result).toBe('"task assignees" = "user@example.com"');
+      expect(result).toEqual({
+        expression: {
+          left: 'task assignees',
+          op: {name: '='},
+          right: 'user@example.com',
+        },
+      });
     });
   });
 

--- a/src/ggrc-client/js/components/tree/tree-filter-input.js
+++ b/src/ggrc-client/js/components/tree/tree-filter-input.js
@@ -13,14 +13,9 @@ import template from './templates/tree-filter-input.mustache';
       filter: {
         type: 'string',
         set: function (newValue) {
-          this.attr('options.filter', newValue || '');
           this.onFilterChange(newValue);
           return newValue;
         },
-      },
-      operation: {
-        type: 'string',
-        value: 'AND',
       },
       depth: {
         type: 'boolean',
@@ -37,17 +32,14 @@ import template from './templates/tree-filter-input.mustache';
     },
     disabled: false,
     showAdvanced: false,
-    options: {},
-    filters: null,
+    options: {
+      query: null,
+    },
     init: function () {
       let options = this.attr('options');
-      let filter = this.attr('filter');
-      let operation = this.attr('operation');
       let depth = this.attr('depth');
       let filterDeepLimit = this.attr('filterDeepLimit');
 
-      options.attr('filter', filter);
-      options.attr('operation', operation);
       options.attr('depth', depth);
       options.attr('filterDeepLimit', filterDeepLimit);
       options.attr('name', 'custom');
@@ -66,6 +58,8 @@ import template from './templates/tree-filter-input.mustache';
         filter.expression.op.name !== 'text_search' &&
         filter.expression.op.name !== 'exclude_text_search';
       this.attr('isExpression', isExpression);
+
+      this.attr('options.query', newValue.length ? filter : null);
     },
     openAdvancedFilter: function () {
       this.dispatch('openAdvanced');

--- a/src/ggrc-client/js/components/tree/tree-status-filter.js
+++ b/src/ggrc-client/js/components/tree/tree-status-filter.js
@@ -7,19 +7,11 @@ import * as StateUtils from '../../plugins/utils/state-utils';
 import router from '../../router';
 
 let viewModel = can.Map.extend({
-  define: {
-    operation: {
-      type: String,
-      value: 'AND',
-    },
-    depth: {
-      type: Boolean,
-      value: false,
-    },
-  },
   disabled: false,
-  options: {},
-  filters: null,
+  options: {
+    name: 'status',
+    query: null,
+  },
   filterStates: [],
   widgetId: null,
   modelName: null,
@@ -57,16 +49,16 @@ let viewModel = can.Map.extend({
   },
   setFilter(selected) {
     let statuses = this.attr('filterStates');
-    let filter = '';
+    let query = null;
 
     if (selected.length && statuses.length !== selected.length) {
-      filter = StateUtils.statusFilter(selected, '', this.attr('modelName'));
+      query = StateUtils.buildStatusFilter(selected, this.attr('modelName'));
       router.attr('state', selected);
     } else {
       router.removeAttr('state');
     }
 
-    this.attr('options.filter', filter);
+    this.attr('options.query', query);
   },
 });
 
@@ -76,10 +68,6 @@ export default can.Component.extend({
   events: {
     inserted() {
       let vm = this.viewModel;
-      let options = vm.attr('options');
-      let filter = vm.attr('filter');
-      let operation = vm.attr('operation');
-      let depth = vm.attr('depth');
 
       let filterStates = StateUtils.getStatesForModel(vm.attr('modelName'))
         .map((state) => {
@@ -88,12 +76,8 @@ export default can.Component.extend({
           };
         });
 
-      options.attr('filter', filter);
-      options.attr('operation', operation);
-      options.attr('depth', depth);
-      options.attr('name', 'status');
-
       if (vm.registerFilter) {
+        let options = vm.attr('options');
         vm.registerFilter(options);
       }
 

--- a/src/ggrc-client/js/components/tree/tree-widget-container.js
+++ b/src/ggrc-client/js/components/tree/tree-widget-container.js
@@ -612,10 +612,8 @@ viewModel = can.Map.extend({
     this.attr('advancedSearch.appliedMappingItems', mappings);
 
     advancedFilters = GGRC.query_parser.join_queries(
-      GGRC.query_parser
-        .parse(AdvancedSearch.buildFilter(filters, request)),
-      GGRC.query_parser
-        .parse(AdvancedSearch.buildFilter(mappings, request))
+      AdvancedSearch.buildFilter(filters, request),
+      AdvancedSearch.buildFilter(mappings, request)
     );
     this.attr('advancedSearch.request', request);
 

--- a/src/ggrc-client/js/components/tree/tree-widget-container.js
+++ b/src/ggrc-client/js/components/tree/tree-widget-container.js
@@ -101,7 +101,7 @@ viewModel = can.Map.extend({
         }
 
         return filters.filter(function (options) {
-          return options.filter;
+          return options.query;
         }).reduce(this._concatFilters, additionalFilter);
       },
     },
@@ -385,10 +385,10 @@ viewModel = can.Map.extend({
     let filters = can.makeArray(this.attr('filters'));
 
     return filters.filter(function (options) {
-      return options.filter &&
+      return options.query &&
         options.depth &&
         options.filterDeepLimit > deepLevel;
-    }).reduce(this._combineFilters, '');
+    }).reduce(this._concatFilters, null);
   },
   setRefreshFlag: function (refresh) {
     this.attr('refreshLoaded', refresh);
@@ -422,34 +422,13 @@ viewModel = can.Map.extend({
    * @private
    */
   _concatFilters: function (filter, options) {
-    let operation = options.operation || 'AND';
-
     if (filter) {
       filter = GGRC.query_parser.join_queries(
         filter,
-        GGRC.query_parser.parse(options.filter),
-        operation);
-    } else if (options.filter) {
-      filter = GGRC.query_parser.parse(options.filter);
-    }
-
-    return filter;
-  },
-  /**
-   * Concatenation active filters into one string.
-   *
-   * @param {String} filter - Filter string
-   * @param {Object} options - Filter parameters
-   * @return {string} - Result of concatenation filters.
-   * @private
-   */
-  _combineFilters(filter, options) {
-    let operation = options.operation || 'AND';
-
-    if (filter) {
-      filter += ' ' + operation + ' ' + options.filter;
-    } else if (options.filter) {
-      filter = options.filter;
+        options.query.attr(),
+        'AND');
+    } else if (options.query) {
+      filter = options.query;
     }
 
     return filter;
@@ -457,7 +436,7 @@ viewModel = can.Map.extend({
   _getFilterByName: function (name) {
     let filter = _.findWhere(this.attr('filters'), {name: name});
 
-    return filter && filter.filter ? filter.filter : null;
+    return filter && filter.query ? filter.query : null;
   },
   _widgetHidden: function () {
     this._triggerListeners(true);

--- a/src/ggrc-client/js/components/unified-mapper/mapper-results.js
+++ b/src/ggrc-client/js/components/unified-mapper/mapper-results.js
@@ -193,19 +193,16 @@ export default GGRC.Components('mapperResults', {
       // prepare QueryAPI data from advanced search
       let request = [];
       let status;
-      let filters = GGRC.query_parser.parse(
-        AdvancedSearch.buildFilter(this.attr('filterItems'),
-          request));
-      let mappings = GGRC.query_parser.parse(
-        AdvancedSearch.buildFilter(this.attr('mappingItems'),
-          request));
+      let filters =
+        AdvancedSearch.buildFilter(this.attr('filterItems'), request);
+      let mappings =
+        AdvancedSearch.buildFilter(this.attr('mappingItems'), request);
       let advancedFilters = GGRC.query_parser.join_queries(filters, mappings);
 
       // the edge case caused by stateless objects
       if (this.attr('statusItem.value.items')) {
-        status = GGRC.query_parser.parse(
-          AdvancedSearch.buildFilter([this.attr('statusItem')],
-            request));
+        status =
+          AdvancedSearch.buildFilter([this.attr('statusItem')], request);
         advancedFilters = GGRC.query_parser
           .join_queries(advancedFilters, status);
       }

--- a/src/ggrc-client/js/plugins/tests/state-utils_spec.js
+++ b/src/ggrc-client/js/plugins/tests/state-utils_spec.js
@@ -7,21 +7,23 @@ import * as StateUtils from '../utils/state-utils';
 import * as CurrentPageUtils from '../utils/current-page-utils';
 
 describe('StateUtils', function () {
-  describe('statusFilter() method', function () {
-    it('statusFilter() should return filter with all statuses',
+  describe('buildStatusFilter() method', function () {
+    it('buildStatusFilter() should return filter with all statuses',
       function () {
         let statuses = [
           'Draft', 'Active', 'Deprecated',
         ];
+        let expectedFilter = {
+          expression: {
+            left: 'Status',
+            op: {name: 'IN'},
+            right: ['Draft', 'Active', 'Deprecated'],
+          },
+        };
 
-        let statesFilter = StateUtils.statusFilter(statuses, '');
+        let statesFilter = StateUtils.buildStatusFilter(statuses);
 
-        expect(statesFilter.indexOf('"Status"="Active"') > -1)
-          .toBe(true);
-        expect(statesFilter.indexOf('"Status"="Draft"') > -1)
-          .toBe(true);
-        expect(statesFilter.indexOf('"Status"="Deprecated"') > -1)
-          .toBe(true);
+        expect(statesFilter).toEqual(expectedFilter);
       }
     );
 
@@ -30,17 +32,18 @@ describe('StateUtils', function () {
         let statuses = [
           'Not Started', 'In Progress', 'In Review',
         ];
+        let expectedFilter = {
+          expression: {
+            left: 'Status',
+            op: {name: 'IN'},
+            right: ['Not Started', 'In Progress', 'In Review'],
+          },
+        };
 
-        let statesFilter = StateUtils.statusFilter(statuses, '', 'Assessment');
+        let statesFilter =
+          StateUtils.buildStatusFilter(statuses, 'Assessment');
 
-        expect(statesFilter.indexOf('"Status"="Not Started"') > -1)
-          .toBe(true);
-        expect(statesFilter.indexOf('"Status"="In Progress"') > -1)
-          .toBe(true);
-        expect(statesFilter.indexOf('"Status"="In Review"') > -1)
-          .toBe(true);
-        expect(statesFilter.indexOf('"Status"="verified="') > -1)
-          .toBe(false);
+        expect(statesFilter).toEqual(expectedFilter);
       }
     );
 
@@ -49,18 +52,33 @@ describe('StateUtils', function () {
         let statuses = [
           'In Review', 'Completed and Verified',
         ];
+        let expectedFilter = {
+          expression: {
+            left: {
+              left: 'Status',
+              op: {name: 'IN'},
+              right: ['In Review'],
+            },
+            op: {name: 'OR'},
+            right: {
+              left: {
+                left: 'Status',
+                op: {name: '='},
+                right: 'Completed',
+              },
+              op: {name: 'AND'},
+              right: {
+                left: 'verified',
+                op: {name: '='},
+                right: 'true',
+              },
+            },
+          },
+        };
 
-        let statesFilter = StateUtils.statusFilter(statuses, '', 'Assessment');
+        let statesFilter = StateUtils.buildStatusFilter(statuses, 'Assessment');
 
-        expect(statesFilter.indexOf('"Status"="In Review"') > -1)
-          .toBe(true);
-        expect(statesFilter.indexOf('"Status"="Completed"') > -1)
-          .toBe(true);
-        expect(statesFilter.indexOf('"Status"="Completed and Verified"') > -1)
-          .toBe(false);
-
-        expect(statesFilter.indexOf('verified=true') > -1)
-          .toBe(true);
+        expect(statesFilter).toEqual(expectedFilter);
       }
     );
 
@@ -69,19 +87,33 @@ describe('StateUtils', function () {
         let statuses = [
           'In Review', 'Completed (no verification)',
         ];
+        let expectedFilter = {
+          expression: {
+            left: {
+              left: 'Status',
+              op: {name: 'IN'},
+              right: ['In Review'],
+            },
+            op: {name: 'OR'},
+            right: {
+              left: {
+                left: 'Status',
+                op: {name: '='},
+                right: 'Completed',
+              },
+              op: {name: 'AND'},
+              right: {
+                left: 'verified',
+                op: {name: '='},
+                right: 'false',
+              },
+            },
+          },
+        };
 
-        let statesFilter = StateUtils.statusFilter(statuses, '', 'Assessment');
+        let statesFilter = StateUtils.buildStatusFilter(statuses, 'Assessment');
 
-        expect(statesFilter.indexOf('"Status"="In Review"') > -1)
-          .toBe(true);
-        expect(statesFilter.indexOf('"Status"="Completed"') > -1)
-          .toBe(true);
-        expect(statesFilter
-          .indexOf('"Status"="Completed (no verification)"') > -1)
-          .toBe(false);
-
-        expect(statesFilter.indexOf('verified=false') > -1)
-          .toBe(true);
+        expect(statesFilter).toEqual(expectedFilter);
       }
     );
 
@@ -91,23 +123,17 @@ describe('StateUtils', function () {
           'In Progress', 'Completed (no verification)',
           'Completed and Verified',
         ];
+        let expectedFilter = {
+          expression: {
+            left: 'Status',
+            op: {name: 'IN'},
+            right: ['In Progress', 'Completed'],
+          },
+        };
 
-        let statesFilter = StateUtils.statusFilter(statuses, '', 'Assessment');
+        let statesFilter = StateUtils.buildStatusFilter(statuses, 'Assessment');
 
-        expect(statesFilter.indexOf('"Status"="In Progress"') > -1)
-          .toBe(true);
-        expect(statesFilter.indexOf('"Status"="Completed"') > -1)
-          .toBe(true);
-
-        expect(statesFilter
-          .indexOf('"Status"="Completed (no verification)"') > -1)
-          .toBe(false);
-        expect(statesFilter
-          .indexOf('"Status"="Completed and Verified"') > -1)
-          .toBe(false);
-
-        expect(statesFilter.indexOf('verified=') > -1)
-          .toBe(false);
+        expect(statesFilter).toEqual(expectedFilter);
       }
     );
   });

--- a/src/ggrc-client/js/plugins/utils/advanced-search-utils.js
+++ b/src/ggrc-client/js/plugins/utils/advanced-search-utils.js
@@ -8,13 +8,13 @@ import * as StateUtils from './state-utils';
 /**
  * Factory allowing to create Advanced Search Filter Items.
  */
-let create = {
+export const create = {
   /**
    * Creates Filter Attribute.
    * @param {object} value - Filter Attribute data.
    * @return {object} - Attribute model.
    */
-  attribute: function (value) {
+  attribute: (value)=> {
     return {
       type: 'attribute',
       value: value || { },
@@ -25,7 +25,7 @@ let create = {
    * @param {Array} value - Group data.
    * @return {object} - Group model.
    */
-  group: function (value) {
+  group: (value)=> {
     return {
       type: 'group',
       value: value || [],
@@ -36,7 +36,7 @@ let create = {
    * @param {string} value - Operator name.
    * @return {object} - Operator model.
    */
-  operator: function (value) {
+  operator: (value)=> {
     return {
       type: 'operator',
       value: value || '',
@@ -47,7 +47,7 @@ let create = {
    * @param {object} value - State data.
    * @return {object} - State model.
    */
-  state: function (value) {
+  state: (value)=> {
     return {
       type: 'state',
       value: value || { },
@@ -58,7 +58,7 @@ let create = {
    * @param {object} value - Mapping Criteria data.
    * @return {object} - Mapping Criteria model.
    */
-  mappingCriteria: function (value) {
+  mappingCriteria: (value)=> {
     return {
       type: 'mappingCriteria',
       value: value || { },
@@ -67,142 +67,135 @@ let create = {
 };
 
 /**
- * Contains rich Status Filter operators.
- */
-let richOperators = {
-  /**
-   * @param {Array} values - filter statements.
-   * @param {String} modelName - model name
-   * @return {string} - filter string.
-   */
-  ANY: function (values, modelName) {
-    let statusField = StateUtils.getStatusFieldName(
-      modelName);
-    return _.map(values, function (value) {
-      return '"' + statusField + '"="' + value + '"';
-    }).join(' OR ');
-  },
-  /**
-   * @param {Array} values - filter statements.
-   * @param {String} modelName - model name
-   * @return {string} - filter string.
-   */
-  NONE: function (values, modelName) {
-    let statusField = StateUtils.getStatusFieldName(
-      modelName);
-    return _.map(values, function (value) {
-      return '"' + statusField + '"!="' + value + '"';
-    }).join(' AND ');
-  },
-};
-
-/**
- * Contains QueryAPI filter builders.
- */
-let builders = {
-  attribute: attributeToFilter,
-  operator: operatorToFilter,
-  state: stateToFilter,
-  group: groupToFilter,
-  mappingCriteria: mappingCriteriaToFilter,
-};
-/**
- * Transforms Filter Attribute model to valid QueryAPI filter string.
- * @param {object} attribute - Filter Attribute model value.
- * @return {string} - Valid QueryAPI filter string.
- */
-function attributeToFilter(attribute) {
-  return '"' + attribute.field +
-         '" ' + attribute.operator +
-         ' "' + attribute.value.trim() + '"';
-}
-/**
- * Transforms Operator model to valid QueryAPI filter string.
- * @param {object} operator - Operator model value.
- * @return {string} - Valid QueryAPI filter string.
- */
-function operatorToFilter(operator) {
-  return ' ' + operator + ' ';
-}
-/**
- * Transforms State model to valid QueryAPI filter string.
- * @param {object} state - State model value.
- * @return {string} - Valid QueryAPI filter string.
- */
-function stateToFilter(state) {
-  return '(' + StateUtils.buildStatusFilter(
-    state.items,
-    richOperators[state.operator],
-    state.modelName) + ')';
-}
-/**
- * Transforms Group model to valid QueryAPI filter string.
- * @param {array} items - Group model value.
- * @param {Array} request - Collection of QueryAPI sub-requests.
- * @return {string} - Valid QueryAPI filter string.
- */
-function groupToFilter(items, request) {
-  return '(' + buildFilter(items, request) + ')';
-}
-/**
- * Transforms Mapping Criteria model to valid QueryAPI filter string.
- * @param {object} criteria - Mapping Criteria model value.
- * @param {Array} request - Collection of QueryAPI sub-requests.
- * @return {string} - Valid QueryAPI filter string.
- */
-function mappingCriteriaToFilter(criteria, request) {
-  let criteriaId = addMappingCriteria(criteria, request);
-  return previousToFilter(criteriaId);
-}
-/**
- * Creates filter based on reauest id.
- * @param {number} requestId - index of QueryApi request.
- * @return {string} - Valid QueryAPI filter string.
- */
-function previousToFilter(requestId) {
-  return '#__previous__,' + requestId + '#';
-}
-/**
  * Adds Mapping Criteria as separate QueryAPI request.
  * @param {object} mapping - Mapping Criteria model value.
  * @param {Array} request - Collection of QueryAPI sub-requests.
  * @return {number} - QueryAPI request id.
  */
-function addMappingCriteria(mapping, request) {
-  let filterObject = GGRC.query_parser
-    .parse(attributeToFilter(mapping.filter.value));
-  let relevantResult;
+export const addMappingCriteria = (mapping, request)=> {
+  let filterObject = builders.attribute(mapping.filter.value);
+
   if (mapping.mappedTo) {
-    relevantResult =
+    let relevantResult =
       builders[mapping.mappedTo.type](mapping.mappedTo.value, request);
-    filterObject = GGRC.query_parser.join_queries(
-      filterObject,
-      GGRC.query_parser.parse(relevantResult)
-    );
+    filterObject = GGRC.query_parser.join_queries(filterObject, relevantResult);
   }
+
   request.push({
     object_name: mapping.objectName,
     type: 'ids',
     filters: filterObject,
   });
+
   return request.length - 1;
-}
+};
+
 /**
- * Builds QueryAPI valid filter based on Advanced Search models.
+ * Convertes collection of Advanced Search models to reverse polish notation.
+ * @param {Array} items - Collection of Advanced Search models.
+ * @return {Array} - Collection of Advanced Search models sorted in reverse polish notation.
+ */
+export const reversePolishNotation = (items)=> {
+  const result = [];
+  const stack = [];
+  const priorities = {
+    OR: 1,
+    AND: 2,
+  };
+
+  items.forEach((item)=> {
+    if (item.type !== 'operator') {
+      result.push(item);
+    } else {
+      if (!_.isEmpty(stack) &&
+        priorities[item.value] <= priorities[_.last(stack).value]) {
+        result.push(stack.pop());
+      }
+      stack.push(item);
+    }
+  });
+
+  while (stack.length) {
+    result.push(stack.pop());
+  }
+
+  return result;
+};
+
+/**
+ * Contains QueryAPI filter expression builders.
+ */
+export const builders = {
+  /**
+   * Transforms Filter Attribute model to valid QueryAPI filter expression.
+   * @param {object} attribute - Filter Attribute model value.
+   * @return {object} - Valid QueryAPI filter expression.
+   */
+  attribute: (attribute)=> {
+    return {
+      expression: {
+        left: attribute.field,
+        op: {name: attribute.operator},
+        right: attribute.value.trim(),
+      },
+    };
+  },
+  /**
+   * Transforms State model to valid QueryAPI filter expression.
+   * @param {object} state - State model value.
+   * @return {object} - Valid QueryAPI filter expression.
+   */
+  state: (state)=> {
+    let inverse = state.operator === 'NONE';
+    return StateUtils.buildStatusFilter(state.items, state.modelName, inverse);
+  },
+  /**
+   * Transforms Group model to valid QueryAPI filter expression.
+   * @param {array} items - Group model value.
+   * @param {Array} request - Collection of QueryAPI sub-requests.
+   * @return {object} - Valid QueryAPI filter expression.
+   */
+  group: (items, request) => {
+    items = reversePolishNotation(items);
+
+    const stack = [];
+    items.forEach((item)=> {
+      if (item.type !== 'operator') {
+        stack.push(builders[item.type](item.value, request));
+      } else {
+        let joinedValue = GGRC.query_parser.
+          join_queries(stack.pop(), stack.pop(), item.value);
+        stack.push(joinedValue);
+      }
+    });
+
+    return stack.pop() || {expression: {}};
+  },
+  /**
+   * Transforms Mapping Criteria model to valid QueryAPI filter expression.
+   * @param {object} criteria - Mapping Criteria model value.
+   * @param {Array} request - Collection of QueryAPI sub-requests.
+   * @return {object} - Valid QueryAPI filter expression.
+   */
+  mappingCriteria: (criteria, request)=> {
+    let criteriaId = addMappingCriteria(criteria, request);
+    return {
+      expression: {
+        object_name: '__previous__',
+        op: {name: 'relevant'},
+        ids: [criteriaId],
+      },
+    };
+  },
+};
+
+/**
+ * Builds QueryAPI valid filter expression based on Advanced Search models.
  * @param {Array} data - Collection of Advanced Search models.
  * @param {Array} request - Collection of QueryAPI sub-requests.
- * @return {string} - valid QueryAPI filter string.
+ * @return {object} - valid QueryAPI filter expression.
  */
-function buildFilter(data, request) {
-  let result = '';
-  request = request || [];
-  _.each(data, function (item) {
-    result += builders[item.type](item.value, request);
-  });
+export const buildFilter = (data, request)=> {
+  let result = builders.group(data, request);
   return result;
-}
-
-export {
-  buildFilter,
-  create,
 };

--- a/src/ggrc-client/js/plugins/utils/query-api-utils.js
+++ b/src/ggrc-client/js/plugins/utils/query-api-utils.js
@@ -101,16 +101,15 @@ function buildRelevantIdsQuery(objName, page, relevant, additionalFilter) {
  * @param {Number} page.pageSize - Page size
  * @param {String} page.sortBy - sortBy
  * @param {String} page.sortDirection - sortDirection
- * @param {String} page.filter - Filter string
  * @param {Object|Object[]} relevant - Information about relevant object
  * @param {Object} relevant.type - Type of relevant object
  * @param {Object} relevant.id - Id of relevant object
  * @param {Object} relevant.operation - Type of operation.
  * @param {Array} fields - Array of requested fields.
- * @param {Object|Array} additionalFilter - Additional filters to be applied
+ * @param {Object|Array} filters - Filters to be applied
  * @return {Object} Object of QueryAPIRequest
  */
-function buildParam(objName, page, relevant, fields, additionalFilter) {
+function buildParam(objName, page, relevant, fields, filters) {
   let first;
   let last;
   let params = {};
@@ -120,8 +119,7 @@ function buildParam(objName, page, relevant, fields, additionalFilter) {
   }
 
   params.object_name = objName;
-  params.filters =
-    _makeFilter(page.filter, relevant, additionalFilter);
+  params.filters = _makeFilter(filters, relevant);
 
   if (page.current && page.pageSize) {
     first = (page.current - 1) * page.pageSize;
@@ -210,7 +208,7 @@ function _makeRelevantFilter(filter) {
   return relevantFilter;
 }
 
-function _makeFilter(filter, relevant, additionalFilter) {
+function _makeFilter(filter, relevant) {
   let relevantFilters;
   let filterList = [];
 
@@ -225,14 +223,10 @@ function _makeFilter(filter, relevant, additionalFilter) {
   }
 
   if (filter) {
-    filterList.push(GGRC.query_parser.parse(filter));
-  }
-
-  if (additionalFilter) {
-    additionalFilter = Array.isArray(additionalFilter) ?
-      additionalFilter :
-      can.makeArray(additionalFilter);
-    filterList = filterList.concat(additionalFilter);
+    filter = Array.isArray(filter) ?
+      filter :
+      can.makeArray(filter);
+    filterList = filterList.concat(filter);
   }
   if (filterList.length) {
     return filterList.reduce(function (left, right) {

--- a/src/ggrc-client/js/plugins/utils/state-utils.js
+++ b/src/ggrc-client/js/plugins/utils/state-utils.js
@@ -139,9 +139,15 @@ function getBulkStatesForModel(model) {
  * Transform query for objects into query which filter them by state.
  * @param {Array} statuses - array of active statuses
  * @param {String} modelName - model name
+ * @param {Boolean} inverse - the flag indicathes whether filter should be inversed
  * @return {String} The transformed query
  */
-function buildStatusFilter(statuses, modelName) {
+function buildStatusFilter(statuses, modelName, inverse) {
+  if (inverse) {
+    let allStatuses = getStatesForModel(modelName);
+    statuses = _.difference(allStatuses, statuses);
+  }
+
   let filter = modelName === 'Assessment' ?
     buildAssessmentFilter(statuses, buildFilterExpression) :
     buildFilterExpression(statuses, modelName);


### PR DESCRIPTION
# Issue description

1) Use "in" operator for Status multi-select filter
2) Build status filter in object format on tree-view

# Steps to test the changes

Try to apply status filter - it should use `IN` operator.

# Solution description

Modify components to build filters as objects instead of building long strings and applying query parser.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
