### PR TITLE
GGRC-5204 Fix full acl propagation for workflows

### DIFF
--- a/src/ggrc/models/hooks/acl/propagation.py
+++ b/src/ggrc/models/hooks/acl/propagation.py
@@ -414,6 +414,7 @@ def propagate_all():
             propagated_count,
             count
         )
-        flask.g.new_wf_acls = acl_ids
+        flask.g.new_wf_acls = set(acl_ids)
+        flask.g.new_wf_comment_ct_ids = set()
         flask.g.deleted_wf_objects = set()
         workflow.handle_acl_changes()


### PR DESCRIPTION
# Issue description

re-calculating ACL propagation fails for workflows.

This is a regression from https://github.com/google/ggrc-core/commit/af4173508e467469a9106309a3f93720966d28c9

# Steps to test the changes

have a few workflows and run propagate_acl command

Extra run propagate_all on various db dumps from our instances.

# Solution description

I have added the missing variable to wf acl propagation command.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
