### PR TITLE
GGRC-4934 Cannot create an Audit via Import

### DIFF
--- a/src/ggrc/converters/base_row.py
+++ b/src/ggrc/converters/base_row.py
@@ -159,8 +159,10 @@ class RowConverter(object):
     """ Get object if the slug is in the system or return a new object """
     value = self.get_value(key)
     self.is_new = False
-    obj = self.find_by_key(key, value)
-    if not obj:
+
+    if value:
+      obj = self.find_by_key(key, value)
+    if not value or not obj:
       # We assume that 'get_importables()' returned value contains
       # names of the objects that cannot be created via import but
       # can be updated.

--- a/src/ggrc/models/mixins/__init__.py
+++ b/src/ggrc/models/mixins/__init__.py
@@ -30,9 +30,6 @@ from sqlalchemy.orm.session import Session
 from ggrc import db
 from ggrc.models import reflection
 from ggrc.models.deferred import deferred
-from ggrc.models.mixins.customattributable import CustomAttributable
-from ggrc.models.mixins.notifiable import Notifiable
-from ggrc.models.exceptions import ValidationError
 from ggrc.models.mixins.base import Base
 from ggrc.fulltext import attributes
 
@@ -481,16 +478,6 @@ class Slugged(Base):
   @declared_attr
   def slug(cls):  # pylint: disable=no-self-argument
     return deferred(db.Column(db.String, nullable=False), cls.__name__)
-
-  @validates('slug')
-  def validate_slug(self, key, value):
-    """Validates slug for models."""
-    # pylint: disable=unused-argument
-    # pylint: disable=no-self-use
-    if not value:
-      message = "Slug '{}' is invalid. Slug must be provided"
-      raise ValidationError(message.format(value))
-    return value
 
   @staticmethod
   def _extra_table_args(model):

--- a/src/ggrc/models/mixins/__init__.py
+++ b/src/ggrc/models/mixins/__init__.py
@@ -32,6 +32,7 @@ from ggrc.models import reflection
 from ggrc.models.deferred import deferred
 from ggrc.models.mixins.customattributable import CustomAttributable
 from ggrc.models.mixins.notifiable import Notifiable
+from ggrc.models.exceptions import ValidationError
 from ggrc.models.mixins.base import Base
 from ggrc.fulltext import attributes
 
@@ -480,6 +481,16 @@ class Slugged(Base):
   @declared_attr
   def slug(cls):  # pylint: disable=no-self-argument
     return deferred(db.Column(db.String, nullable=False), cls.__name__)
+
+  @validates('slug')
+  def validate_slug(self, key, value):
+    """Validates slug for models."""
+    # pylint: disable=unused-argument
+    # pylint: disable=no-self-use
+    if not value:
+      message = "Slug '{}' is invalid. Slug must be provided"
+      raise ValidationError(message.format(value))
+    return value
 
   @staticmethod
   def _extra_table_args(model):

--- a/src/ggrc/models/mixins/__init__.py
+++ b/src/ggrc/models/mixins/__init__.py
@@ -30,6 +30,8 @@ from sqlalchemy.orm.session import Session
 from ggrc import db
 from ggrc.models import reflection
 from ggrc.models.deferred import deferred
+from ggrc.models.mixins.customattributable import CustomAttributable
+from ggrc.models.mixins.notifiable import Notifiable
 from ggrc.models.mixins.base import Base
 from ggrc.fulltext import attributes
 


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

The audits failed to be created via import. 

# Steps to test the changes

Steps to test:
1. Create a program in UI
2. Download Audit csv template
3. Fill out required fields > Save and then import Audit csv template

# Solution description

The reason for failing import is that some data could be corrupted (slug is an empty string). In order to prevent it I've created a validator for slug. Also when importing objects we can check whether the key value is falsy. 

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
