### PR TITLE
GGRC-5229 Split acr propagation deletion into chunks

### DIFF
--- a/src/ggrc/access_control/utils.py
+++ b/src/ggrc/access_control/utils.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 PROPAGATION_RETRIES = 10
 
 
-def insert_select_acls(inserter, select_statement):
+def insert_select_acls(select_statement):
   """Insert acl records from the select statement
   Args:
     select_statement: sql statement that contains the following columns
@@ -37,6 +37,7 @@ def insert_select_acls(inserter, select_statement):
   """
 
   acl_table = all_models.AccessControlList.__table__
+  inserter = acl_table.insert().prefix_with("IGNORE")
 
   last_error = None
   for _ in range(PROPAGATION_RETRIES):

--- a/src/ggrc/models/hooks/acl/propagation.py
+++ b/src/ggrc/models/hooks/acl/propagation.py
@@ -28,12 +28,6 @@ logger = logging.getLogger(__name__)
 PROPAGATION_DEPTH_LIMIT = 50
 
 
-def _insert_select_acls(select_statement):
-  """Run insert from select with default acl inserter."""
-  inserter = all_models.AccessControlList.__table__.insert()
-  acl_utils.insert_select_acls(inserter, select_statement)
-
-
 def _rel_parent(parent_acl_ids=None, relationship_ids=None, source=True):
   """Get left side of relationships mappings through source."""
   rel_table = all_models.Relationship.__table__
@@ -208,7 +202,7 @@ def _handle_propagation_parents(parent_acl_ids):
   src_select = _rel_parent(parent_acl_ids, source=True)
   dst_select = _rel_parent(parent_acl_ids, source=False)
   select_statement = sa.union(src_select, dst_select)
-  _insert_select_acls(select_statement)
+  acl_utils.insert_select_acls(select_statement)
 
 
 def _handle_propagation_children(new_parent_ids):
@@ -216,7 +210,7 @@ def _handle_propagation_children(new_parent_ids):
   src_select = _rel_child(new_parent_ids, source=True)
   dst_select = _rel_child(new_parent_ids, source=False)
   select_statement = sa.union(src_select, dst_select)
-  _insert_select_acls(select_statement)
+  acl_utils.insert_select_acls(select_statement)
 
 
 def _handle_propagation_rel(relationship_ids, new_acl_ids):
@@ -232,7 +226,7 @@ def _handle_propagation_rel(relationship_ids, new_acl_ids):
       source=False
   )
   select_statement = sa.union(src_select, dst_select)
-  _insert_select_acls(select_statement)
+  acl_utils.insert_select_acls(select_statement)
 
 
 def _handle_acl_step(parent_acl_ids):

--- a/src/ggrc_workflows/models/hooks/workflow.py
+++ b/src/ggrc_workflows/models/hooks/workflow.py
@@ -134,13 +134,6 @@ def _get_child_ids(parent_ids, child_class):
   )
 
 
-def _insert_select_acls(select_statement):
-  """Run insert from select with ignore acl inserter."""
-  acl_table = all_models.AccessControlList.__table__
-  inserter = acl_table.insert().prefix_with("IGNORE")
-  acl_utils.insert_select_acls(inserter, select_statement)
-
-
 def _propagate_to_wf_children(new_wf_acls, child_class):
   """Propagate newly added roles to workflow objects.
 
@@ -189,7 +182,7 @@ def _propagate_to_wf_children(new_wf_acls, child_class):
       acl_table.c.id.in_(new_wf_acls)
   )
 
-  _insert_select_acls(select_statement)
+  acl_utils.insert_select_acls(select_statement)
 
   return _get_child_ids(new_wf_acls, child_class)
 
@@ -234,7 +227,7 @@ def _propagate_to_children(new_tg_acls, child_class, id_name, parent_class):
       acl_table.c.id.in_(new_tg_acls),
   )
 
-  _insert_select_acls(select_statement)
+  acl_utils.insert_select_acls(select_statement)
 
   return _get_child_ids(new_tg_acls, child_class)
 

--- a/test/integration/ggrc/models/hooks/acl/test_propagation.py
+++ b/test/integration/ggrc/models/hooks/acl/test_propagation.py
@@ -346,7 +346,9 @@ class TestPropagation(TestCase):
     # propagate all non WF entries
     propagation._propagate(acl_ids)
     self.assertEqual(all_models.AccessControlList.query.count(), 4)
-    propagation._delete_all_propagated_acls()
+    all_models.AccessControlList.query.filter(
+        all_models.AccessControlList.parent_id.isnot(None)
+    ).delete()
     self.assertEqual(all_models.AccessControlList.query.count(), 2)
     # propagate all including WF entries
     propagation.propagate_all()


### PR DESCRIPTION
# Issue description

Having a single big delete statement that takes a long time is hard to
track in the logs if something went wrong and it has a higher risk of
triggering lock_wait_timeout error.

# Steps to test the changes

- Check that normal acl propagation (adding a role and mapping objects) still works
- check that propagate_acl command works

# Solution description

The deletion of acl roles is split into same chunks as creation of acl roles for easier tracking and spotting of slower parts of deletion.

I have left the default chunk size because some parts are really slow and it took "too long" for a the slowest chunks to be handled.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
