### PR TITLE
GGRC-5149 Evidence and Document objects exist w/o Admin user role

### DIFF
--- a/src/ggrc/migrations/versions/20180604100018_3a41fc031f53_update_send_by_default_evidence_field.py
+++ b/src/ggrc/migrations/versions/20180604100018_3a41fc031f53_update_send_by_default_evidence_field.py
@@ -1,0 +1,68 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+"""
+Update send by default evidence field
+
+Create Date: 2018-06-04 10:00:18.433654
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+
+revision = '3a41fc031f53'
+down_revision = '4bce53d67bcf'
+
+
+def update_send_by_default():
+  """Update missing values to True"""
+  op.execute("SET SESSION SQL_SAFE_UPDATES = 0")
+  sql = """
+      UPDATE evidence e SET e.send_by_default=1 WHERE e.send_by_default IS NULL
+  """
+  op.execute(sql)
+
+
+def alter_evidence():
+  """Make send_by_default column not nullable and True by default"""
+  op.alter_column(
+      "evidence",
+      "send_by_default",
+      nullable=False,
+      server_default=sa.true(),
+      existing_type=sa.Boolean(),
+      existing_nullable=True,
+      existing_server_default=None,
+  )
+
+
+def add_evidence_recipients():
+  """Add evidence admin to comment notification recipient list"""
+  op.execute("SET SESSION SQL_SAFE_UPDATES = 0")
+  sql = """
+      UPDATE evidence e SET e.recipients="Admin" WHERE e.recipients IS NULL
+  """
+  op.execute(sql)
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  update_send_by_default()
+  alter_evidence()
+  add_evidence_recipients()
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  op.alter_column(
+      "evidence",
+      "send_by_default",
+      nullable=True,
+      server_default=None,
+      existing_type=sa.Boolean(),
+      existing_nullable=False,
+      existing_server_default=sa.true()
+  )

--- a/src/ggrc/migrations/versions/20180604140037_b1dbfad3bbad_create_missing_admins.py
+++ b/src/ggrc/migrations/versions/20180604140037_b1dbfad3bbad_create_missing_admins.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2018 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 """
-Create missing Admins
+Create missing Document Admins
 
 Create Date: 2018-06-04 14:00:37.299927
 """

--- a/src/ggrc/migrations/versions/20180604140037_b1dbfad3bbad_create_missing_admins.py
+++ b/src/ggrc/migrations/versions/20180604140037_b1dbfad3bbad_create_missing_admins.py
@@ -1,0 +1,90 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+"""
+Create missing Admins
+
+Create Date: 2018-06-04 14:00:37.299927
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+from sqlalchemy import text
+
+from ggrc.migrations import utils
+from ggrc.migrations.utils.migrator import get_migration_user_id
+
+revision = 'b1dbfad3bbad'
+down_revision = '3a41fc031f53'
+
+
+def create_doc_temporary_table():
+  """Tmp table to store document.id without Admins"""
+  sql = """
+      CREATE TEMPORARY TABLE documents_wo_admins (
+        id int(11) NOT NULL
+      )
+  """
+  op.execute(sql)
+
+
+def save_documents_no_admins():
+  """Store document w/o Admins ids to temp_table documents_wo_admins"""
+  sql = """
+      INSERT INTO documents_wo_admins (id)
+        SELECT d.id FROM documents d
+          LEFT OUTER JOIN(
+            SELECT DISTINCT(acl.object_id)
+              FROM access_control_list acl
+              JOIN access_control_roles acr ON acr.id = acl.ac_role_id
+                AND acr.name = 'Admin'
+                AND acr.object_type = 'Document'
+            ) AS res ON res.object_id = d.id
+        WHERE res.object_id IS NULL
+  """
+  op.execute(sql)
+
+
+def get_document_admin_role_id(connection):
+  """Get document admin role id"""
+  sql = """
+    SELECT id FROM access_control_roles acr
+    WHERE acr.name = 'Admin' AND acr.object_type = 'Document'
+  """
+  return connection.execute(text(sql)).fetchone()[0]
+
+
+def create_document_missing_admins(connection, migration_user_id,
+                                   admin_role_id):
+  utils.create_missing_admins(connection, migration_user_id,
+                              admin_role_id,
+                              object_type="Document",
+                              revision_action="created",
+                              table_mame="documents_wo_admins")
+
+
+def add_doc_to_missing_revisions(connection):
+  """Add modified Documents to objects_without_revisions to create revisions"""
+
+  utils.add_to_missing_revisions(connection,
+                                 table_with_id="documents_wo_admins",
+                                 object_type="Document")
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  connection = op.get_bind()
+  migration_user_id = get_migration_user_id(connection)
+  document_admin_role_id = get_document_admin_role_id(connection)
+  create_doc_temporary_table()
+  save_documents_no_admins()
+  create_document_missing_admins(connection, migration_user_id,
+                                 document_admin_role_id)
+  add_doc_to_missing_revisions(connection)
+  op.execute("DROP TABLE documents_wo_admins")
+
+
+def downgrade():
+  """"Downgrade database schema and/or data back to the previous revision."""

--- a/src/ggrc/migrations/versions/20180605090010_ad7e10f2a917_create_missing_evidence_admins.py
+++ b/src/ggrc/migrations/versions/20180605090010_ad7e10f2a917_create_missing_evidence_admins.py
@@ -1,0 +1,94 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+"""
+Create missing Evidence Admins
+
+Create Date: 2018-06-05 09:00:10.586460
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+from alembic import op
+from sqlalchemy import text
+
+from ggrc.migrations import utils
+from ggrc.migrations.utils.migrator import get_migration_user_id
+
+# revision identifiers, used by Alembic.
+revision = 'ad7e10f2a917'
+down_revision = 'b1dbfad3bbad'
+
+
+def get_evidence_admin_role_id(connection):
+  """Get evidence admin role id"""
+  sql = """
+      SELECT id FROM access_control_roles acr
+      WHERE acr.name = 'Admin' AND acr.object_type = 'Evidence'
+    """
+  return connection.execute(text(sql)).fetchone()[0]
+
+
+def create_evid_temporary_table():
+  """Tmp table to store evidence.id without Admins"""
+  sql = """
+        CREATE TEMPORARY TABLE evidence_wo_admins (
+          id int(11) NOT NULL
+        )
+    """
+  op.execute(sql)
+
+
+def save_evidence_no_admins():
+  """Store evidence w/o Admins ids to temp_table evidence_wo_admins"""
+  sql = """
+      INSERT INTO evidence_wo_admins (id)
+        SELECT e.id FROM evidence e
+          LEFT OUTER JOIN(
+            SELECT DISTINCT(acl.object_id)
+              FROM access_control_list acl
+              JOIN access_control_roles acr ON acr.id = acl.ac_role_id
+                AND acr.object_type = 'Evidence'
+                AND acr.name = 'Admin'
+            ) AS res ON res.object_id = e.id
+        WHERE res.object_id IS NULL
+  """
+  op.execute(sql)
+
+
+def create_evidence_missing_admins(connection, migration_user_id,
+                                   evidence_admin_role_id):
+  """Insert into access_control_list Evidence admin role
+
+  If we have 'create' revision -> take modified_by_id as Admin
+  else set current migration user as evidence Admin
+  """
+  utils.create_missing_admins(connection, migration_user_id,
+                              evidence_admin_role_id,
+                              object_type="Evidence",
+                              revision_action="created",
+                              table_mame="evidence_wo_admins")
+
+
+def add_evidence_to_missing_revisions(connection):
+  """Add modified Evidence to objects_without_revisions to create revisions"""
+
+  utils.add_to_missing_revisions(connection,
+                                 table_with_id="evidence_wo_admins",
+                                 object_type="Evidence")
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  connection = op.get_bind()
+  migration_user_id = get_migration_user_id(connection)
+  evidence_admin_role_id = get_evidence_admin_role_id(connection)
+  create_evid_temporary_table()
+  save_evidence_no_admins()
+  create_evidence_missing_admins(connection, migration_user_id,
+                                 evidence_admin_role_id)
+  add_evidence_to_missing_revisions(connection)
+  op.execute("DROP TABLE evidence_wo_admins")
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""

--- a/src/ggrc/models/evidence.py
+++ b/src/ggrc/models/evidence.py
@@ -57,6 +57,9 @@ class Evidence(Roleable, Relatable, mixins.Titled,
   description = deferred(db.Column(db.Text, nullable=False, default=u""),
                          "Evidence")
 
+  # Override from Commentable mixin (can be removed after GGRC-5192)
+  send_by_default = db.Column(db.Boolean, nullable=False, default=True)
+
   _api_attrs = reflection.ApiAttributes(
       "title",
       reflection.Attribute("link", update=False),


### PR DESCRIPTION
# Issue description

Evidence and Document objects exist w/o Admin user role

# Steps to test the changes

1. Log as admin user to ggrc-test https://ggrc-test.googleplex.com/objectBrowser#!evidence_widget
2. Open Evidence tab
3. Type into search box: "admin is empty"
4. Look at the Search results
Actual Result: Filter query returns evidences w/o Admin user
Expected Result: Admin user should exist for Evidence object

# Solution description
Implement migration to set admin using 'created' revision. If not exists, migration_user_id.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
