### PR TITLE
GGRC-3236 Don't trigger modal:success in gdrive picker

### DIFF
--- a/src/ggrc-client/js/components/gdrive/gdrive_picker_launcher.js
+++ b/src/ggrc-client/js/components/gdrive/gdrive_picker_launcher.js
@@ -31,7 +31,6 @@ import tracker from '../../tracker';
       link_class: '@',
       click_event: '@',
       confirmationCallback: '@',
-      pickerActive: false,
       disabled: false,
       isUploading: false,
 
@@ -91,15 +90,11 @@ import tracker from '../../tracker';
             return files;
           })
           .then((files) => {
-            scope.attr('pickerActive', false);
             this.beforeCreateHandler(files);
 
             return this.createDocumentModel(files);
           })
-          .then((docs) => {
-            stopFn();
-            el.trigger('modal:success', {arr: docs});
-          })
+          .then(stopFn)
           .always(() => {
             this.attr('isUploading', false);
             this.dispatch('finish');
@@ -146,15 +141,12 @@ import tracker from '../../tracker';
               .then(function (files) {
                 that.beforeCreateHandler(files);
 
-                that.createDocumentModel(files)
-                  .then((docs)=> {
-                    stopFn();
-                    el.trigger('modal:success', {arr: docs});
-                  })
-                  .always(()=> {
-                    that.attr('isUploading', false);
-                    that.dispatch('finish');
-                  });
+                return that.createDocumentModel(files);
+              })
+              .then(stopFn)
+              .always(()=> {
+                that.attr('isUploading', false);
+                that.dispatch('finish');
               })
               .fail(function () {
                 // This case happens when user have no access to write in audit folder
@@ -163,7 +155,6 @@ import tracker from '../../tracker';
                 stopFn(true);
                 if (error && error.code === 403) {
                   GGRC.Errors.notifier('error', GGRC.Errors.messages[403]);
-                  el.trigger('modal:success');
                 } else if ( error && error.type !== GDRIVE_PICKER_ERR_CANCEL ) {
                   GGRC.Errors.notifier('error', error && error.message);
                 }


### PR DESCRIPTION
# Issue description

Gdrive picker triggers unneeded `modal:success` event that handled by `add-issue-button` component and causes extra query api call.

# Steps to test the changes

Attach evidence file to assessment.

# Solution description

Remove triggering of the event.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
