### PR TITLE
GGRC-5245 Fix issue with populating Last Updated By column for Document/Evidence

### DIFF
--- a/src/ggrc-client/js/models/document.js
+++ b/src/ggrc-client/js/models/document.js
@@ -50,6 +50,7 @@ can.Model.Cacheable('CMS.Models.Document', {
     recipients: 'Admin',
   },
   tree_view_options: {
+    attr_view: GGRC.mustache_path + '/documents/tree-item-attr.mustache',
     display_attr_names: ['title', 'status', 'updated_at', 'document_type'],
     attr_list: [
       {attr_title: 'Title', attr_name: 'title'},

--- a/src/ggrc/assets/mustache/documents/tree-item-attr.mustache
+++ b/src/ggrc/assets/mustache/documents/tree-item-attr.mustache
@@ -10,7 +10,7 @@
     </a>
   {{/case}}
   {{#case 'modified_by'}}
-      <tree-people-list-field {source}="instance.modified_by"/>
+      <tree-field {source}="instance.modified_by" {field}="'email'"/>
   {{/case}}
   {{#case 'status'}}
     {{#using status=instance.status}}

--- a/src/ggrc/assets/mustache/evidence/tree-item-attr.mustache
+++ b/src/ggrc/assets/mustache/evidence/tree-item-attr.mustache
@@ -10,7 +10,7 @@
     </a>
   {{/case}}
   {{#case 'modified_by'}}
-      <tree-people-list-field {source}="instance.modified_by"/>
+    <tree-field {source}="instance.modified_by" {field}="'email'"/>
   {{/case}}
   {{#case 'status'}}
     {{#using status=instance.status}}


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Last Updated By column is not populated for Evidence objects in tree view / global search

# Steps to test the changes

1. Open tree view with evidence objects / Global Search

**Actual result:** Last Updated By column is not populated
**Expected result:** Last Updated By column should be populated

# Solution description

Use correct component for displaying person field.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
