### PR TITLE
QUICK-FIX Fix eslint comma style issues

### DIFF
--- a/src/ggrc-client/js/bootstrap/sticky-popover.js
+++ b/src/ggrc-client/js/bootstrap/sticky-popover.js
@@ -21,9 +21,9 @@
 
   StickyPopover.prototype = $.extend({}, $.fn.popover.Constructor.prototype, {
 
-    constructor: StickyPopover
+    constructor: StickyPopover,
 
-    , init: function (type, element, options) {
+    init: function (type, element, options) {
       if (options.trigger == 'sticky-hover') {
         options.sticky_hover = true;
         options.trigger = 'hover';
@@ -42,12 +42,12 @@
       if (this.options.trigger_click) {
         this.$element.on('click', $.proxy(this.click_toggle, this));
       }
-    }
-    , click_toggle: function (e) {
+    },
+    click_toggle: function (e) {
       e && e.preventDefault();
       this.toggle();
-    }
-    , show: function (force) {
+    },
+    show: function (force) {
       // Overload `show` to listen for mouseovers on the popover div
       if (force || this.displayState !== 'show') {
         if (this.displayState !== 'show') {
@@ -79,14 +79,14 @@
             on('mouseleave', $.proxy(this.tip_leave, this));
         }
       }
-    }
-    , hide: function () {
+    },
+    hide: function () {
       if (this.displayState === 'show') {
         this.displayState = 'hide';
         $.fn.popover.Constructor.prototype.hide.apply(this);
       }
-    }
-    , trigger_load: function () {
+    },
+    trigger_load: function () {
       let self = this,
         href = this.$element.data('popover-href'),
         loaded = this.$element.data('popover-loaded');
@@ -95,10 +95,10 @@
 
       if (!loaded) {
         $.ajax({
-          url: href
-          , type: 'get'
-          , dataType: 'html'
-          , success: function (data) {
+          url: href,
+          type: 'get',
+          dataType: 'html',
+          success: function (data) {
             let $data = $(data.trim());
             self.$element.attr('data-original-title', $data.filter('.popover-title').html());
             self.$element.attr('data-content', $data.filter('.popover-content').html());
@@ -108,15 +108,15 @@
           },
         });
       }
-    }
-    , tip_enter: function (e) {
+    },
+    tip_enter: function (e) {
       // Handle `mouseenter` on the popover element
       // Must set 'e.currentTarget' or it looks for `data.sticky_popover`
       //   in the wrong place
       e.currentTarget = this.$element[0];
       $.fn.popover.Constructor.prototype.enter.apply(this, arguments);
-    }
-    , tip_leave: function (e) {
+    },
+    tip_leave: function (e) {
       // Handle `mouseenter` on the popover element
       // Must set 'e.currentTarget' or it looks for `data.sticky_popover`
       //   in the wrong place
@@ -131,9 +131,9 @@
 
   $.fn.sticky_popover = function (option) {
     return this.each(function () {
-      let $this = $(this)
-        , data = $this.data('sticky_popover')
-        , options = typeof option == 'object' && option
+      let $this = $(this),
+        data = $this.data('sticky_popover'),
+        options = typeof option == 'object' && option
       if (!data) {
         $this.data('sticky_popover', (data = new StickyPopover(this, options)));
         // Make instantiated popovers findable by $('[data-sticky_popover]');

--- a/src/ggrc-client/js/controllers/dashboard_widgets_controller.js
+++ b/src/ggrc-client/js/controllers/dashboard_widgets_controller.js
@@ -84,8 +84,8 @@ export default Filterable({
 
     this.element.html(frag[0]);
 
-    let content = this.element
-      , controller_content = null;
+    let content = this.element,
+      controller_content = null;
 
     if (prefs.getCollapsed(window.getPageToken(), this.element.attr('id'))) {
 

--- a/src/ggrc-client/js/controllers/lhn_controllers.js
+++ b/src/ggrc-client/js/controllers/lhn_controllers.js
@@ -226,11 +226,10 @@ can.Control('CMS.Controllers.LHN', {
   hide_lhn: function () {
     // UI-revamp
     // Here we should hide the button ||| also
-    var $area = $('.area')
-        , $lhsHolder = $('.lhs-holder')
-        , $bar = $('.bar-v')
-        , $lhnTrigger = $('.lhn-trigger')
-        ;
+    var $area = $('.area'),
+      $lhsHolder = $('.lhs-holder'),
+      $bar = $('.bar-v'),
+      $lhnTrigger = $('.lhn-trigger');
 
     this.element.hide();
     $lhsHolder.css('width', 0);
@@ -376,11 +375,10 @@ can.Control('CMS.Controllers.LHN_Search', {
   }
 }, {
   display: function () {
-    var self = this
-        , prefs = this.options.display_prefs
-        , prefs_dfd
-        , template_path = GGRC.mustache_path + this.element.data('template')
-        ;
+    var self = this,
+      prefs = this.options.display_prefs,
+      prefs_dfd,
+      template_path = GGRC.mustache_path + this.element.data('template');
 
     prefs_dfd = CMS.Models.DisplayPrefs.getSingleton();
 
@@ -389,11 +387,10 @@ can.Control('CMS.Controllers.LHN_Search', {
       //  We also listen for this value in the controller
       //  to trigger the search.
     return can.view(template_path, prefs_dfd.then(function (prefs) { return prefs.getLHNState(); })).then(function (frag, xhr) {
-      var lhn_prefs = prefs.getLHNState()
-          , initial_term
-          , initial_params = {}
-          , saved_filters = prefs.getLHNState().filter_params
-          ;
+      var lhn_prefs = prefs.getLHNState(),
+        initial_term,
+        initial_params = {},
+        saved_filters = prefs.getLHNState().filter_params;
 
       self.element.html(frag);
       self.post_init();
@@ -481,11 +478,10 @@ can.Control('CMS.Controllers.LHN_Search', {
     }
   },
   toggle_list_visibility: function (el, dont_update_prefs) {
-    var sub_selector = this.options.list_content_selector + ',' + this.options.actions_content_selector
-        , mid_selector = this.options.list_mid_level_selector
-        , $parent = el.parent('li')
-        , selector
-        ;
+    var sub_selector = this.options.list_content_selector + ',' + this.options.actions_content_selector,
+      mid_selector = this.options.list_mid_level_selector,
+      $parent = el.parent('li'),
+      selector;
 
     if ($parent.find(mid_selector).size()) {
       selector = mid_selector;
@@ -509,13 +505,12 @@ can.Control('CMS.Controllers.LHN_Search', {
   },
   open_list: function (el, $ul, selector, dont_update_prefs) {
       // Use a cached max-height if one exists
-    var holder = el.closest('.lhs-holder')
-      , $content = $ul.filter([this.options.list_content_selector,
-                               this.options.list_mid_level_selector].join(','))
-      , $siblings = selector ? $ul.closest('.lhs').find(selector) : $(false)
-      , extra_height = 0
-      , top
-      ;
+    var holder = el.closest('.lhs-holder'),
+      $content = $ul.filter([this.options.list_content_selector,
+                               this.options.list_mid_level_selector].join(',')),
+      $siblings = selector ? $ul.closest('.lhs').find(selector) : $(false),
+      extra_height = 0,
+      top;
 
       // Collapse other lists
     var $mids = $ul.closest('.lhs').find(this.options.list_mid_level_selector)
@@ -593,9 +588,8 @@ can.Control('CMS.Controllers.LHN_Search', {
 
 
     if ($content.length) {
-      var last_height = this._holder_height
-          , holder = this.element.closest('.lhs-holder')
-          ;
+      var last_height = this._holder_height,
+        holder = this.element.closest('.lhs-holder');
       this._holder_height = holder.outerHeight();
 
 
@@ -607,10 +601,9 @@ can.Control('CMS.Controllers.LHN_Search', {
     }
   },
   on_show_list: function (el, ev) {
-    var $list = $(el).closest(this.get_lists())
-        , model_name = this.get_list_model($list)
-        , that = this
-        ;
+    var $list = $(el).closest(this.get_lists()),
+      model_name = this.get_list_model($list),
+      that = this;
     let stopFn = tracker.start(
       `LHN: ${model_name}`,
       tracker.USER_JOURNEY_KEYS.LOADING,
@@ -632,14 +625,13 @@ can.Control('CMS.Controllers.LHN_Search', {
     if (this._show_more_pending)
       return;
 
-    var that = this
-        , $list = $el.closest(this.get_lists())
-        , model_name = this.get_list_model($list)
-        , visible_list = this.options.visible_lists[model_name]
-        , results_list = this.options.results_lists[model_name]
-        , refresh_queue
-        , new_visible_list
-        ;
+    var that = this,
+      $list = $el.closest(this.get_lists()),
+      model_name = this.get_list_model($list),
+      visible_list = this.options.visible_lists[model_name],
+      results_list = this.options.results_lists[model_name],
+      refresh_queue,
+      new_visible_list;
     let stopFn = tracker.start(
       `LHN: ${model_name}`,
       tracker.USER_JOURNEY_KEYS.LOADING,
@@ -691,13 +683,13 @@ can.Control('CMS.Controllers.LHN_Search', {
       model_name = self.get_list_model($list);
 
       var context = {
-        model: CMS.Models[model_name]
-          , filter_params: self.options.filter_params
-          , list: self.options.visible_lists[model_name]
-          , counts: self.options.counts
-          , count: can.compute(function () {
-            return self.options.results_lists[model_name].attr('length');
-          })
+        model: CMS.Models[model_name],
+        filter_params: self.options.filter_params,
+        list: self.options.visible_lists[model_name],
+        counts: self.options.counts,
+        count: can.compute(function () {
+          return self.options.results_lists[model_name].attr('length');
+        })
       };
 
       can.view($list.data('template') || self.options.list_view, context, function (frag, xhr) {
@@ -770,18 +762,17 @@ can.Control('CMS.Controllers.LHN_Search', {
     });
   },
   display_lists: function (search_result) {
-    var self = this
-        , lists = this.get_visible_lists()
-        , dfds = []
-        ;
+    var self = this,
+      lists = this.get_visible_lists(),
+      dfds = [];
 
     can.each(lists, function (list) {
-      var dfd
-          , $list = $(list)
-          , model_name = self.get_list_model($list)
-          , results = search_result.getResultsForType(model_name)
-          , refresh_queue = new RefreshQueue()
-          , initial_visible_list = null;
+      var dfd,
+        $list = $(list),
+        model_name = self.get_list_model($list),
+        results = search_result.getResultsForType(model_name),
+        refresh_queue = new RefreshQueue(),
+        initial_visible_list = null;
 
 
       self.options.results_lists[model_name].replace(results);
@@ -958,9 +949,9 @@ can.Control('CMS.Controllers.LHN_Search', {
 
 can.Control('GGRC.Controllers.RecentlyViewed', {
   defaults: {
-    list_view: GGRC.mustache_path + '/dashboard/recently_viewed_list.mustache'
-      , max_history: 10
-      , max_display: 3
+    list_view: GGRC.mustache_path + '/dashboard/recently_viewed_list.mustache',
+    max_history: 10,
+    max_display: 3
   }
 }, {
   init: function () {

--- a/src/ggrc-client/js/models/directive_models.js
+++ b/src/ggrc-client/js/models/directive_models.js
@@ -6,17 +6,17 @@
 (function (can) {
 
   can.Model.Cacheable('CMS.Models.Directive', {
-    root_object: 'directive'
-    , root_collection: 'directives'
-    , category: 'governance'
+    root_object: 'directive',
+    root_collection: 'directives',
+    category: 'governance',
     // `rootModel` overrides `model.shortName` when determining polymorphic types
-    , root_model: 'Directive'
-    , findAll: '/api/directives'
-    , findOne: '/api/directives/{id}'
-    , mixins: ['unique_title', 'timeboxed', 'ca_update', 'base-notifications']
-    , tree_view_options: {
-      attr_view: GGRC.mustache_path + '/directives/tree-item-attr.mustache'
-      , attr_list: can.Model.Cacheable.attr_list.concat([
+    root_model: 'Directive',
+    findAll: '/api/directives',
+    findOne: '/api/directives/{id}',
+    mixins: ['unique_title', 'timeboxed', 'ca_update', 'base-notifications'],
+    tree_view_options: {
+      attr_view: GGRC.mustache_path + '/directives/tree-item-attr.mustache',
+      attr_list: can.Model.Cacheable.attr_list.concat([
         {attr_title: 'Reference URL', attr_name: 'reference_url'},
         {attr_title: 'Effective Date', attr_name: 'start_date'},
         {attr_title: 'Last Deprecated Date', attr_name: 'end_date'},
@@ -32,11 +32,12 @@
           attr_title: 'Assessment Procedure',
           attr_name: 'test_plan',
           disable_sorting: true,
-        }]),
+        }
+      ]),
       add_item_view: GGRC.mustache_path + '/snapshots/tree_add_item.mustache',
-    }
+    },
 
-    , model: function (params) {
+    model: function (params) {
       if (this.shortName !== 'Directive')
         return this._super(params);
       if (!params)
@@ -66,43 +67,43 @@
       programs: 'CMS.Models.Program.stubs',
       sections: 'CMS.Models.get_stubs',
       controls: 'CMS.Models.Control.stubs',
-    }
-    , defaults: {
-    }
-    , init: function () {
+    },
+    defaults: {
+    },
+    init: function () {
       this.validateNonBlank('title');
       //this.validateInclusionOf("kind", this.meta_kinds);
       this._super.apply(this, arguments);
-    }
-    , meta_kinds: [],
+    },
+    meta_kinds: [],
   }, {
     init: function () {
       this._super && this._super.apply(this, arguments);
       let that = this;
-    }
-    , lowercase_kind: function () { return this.kind ? this.kind.toLowerCase() : undefined; },
+    },
+    lowercase_kind: function () { return this.kind ? this.kind.toLowerCase() : undefined; },
   });
 
   CMS.Models.Directive('CMS.Models.Standard', {
-    root_object: 'standard'
-    , root_collection: 'standards'
-    , model_plural: 'Standards'
-    , table_plural: 'standards'
-    , title_plural: 'Standards'
-    , model_singular: 'Standard'
-    , title_singular: 'Standard'
-    , table_singular: 'standard'
-    , findAll: 'GET /api/standards'
-    , findOne: 'GET /api/standards/{id}'
-    , create: 'POST /api/standards'
-    , update: 'PUT /api/standards/{id}'
-    , destroy: 'DELETE /api/standards/{id}'
-    , is_custom_attributable: true
-    , isRoleable: true
-    , attributes: {}
-    , meta_kinds: [ 'Standard' ],
-    mixins: ['accessControlList']
-    , cache: can.getObject('cache', CMS.Models.Directive, true),
+    root_object: 'standard',
+    root_collection: 'standards',
+    model_plural: 'Standards',
+    table_plural: 'standards',
+    title_plural: 'Standards',
+    model_singular: 'Standard',
+    title_singular: 'Standard',
+    table_singular: 'standard',
+    findAll: 'GET /api/standards',
+    findOne: 'GET /api/standards/{id}',
+    create: 'POST /api/standards',
+    update: 'PUT /api/standards/{id}',
+    destroy: 'DELETE /api/standards/{id}',
+    is_custom_attributable: true,
+    isRoleable: true,
+    attributes: {},
+    meta_kinds: [ 'Standard' ],
+    mixins: ['accessControlList'],
+    cache: can.getObject('cache', CMS.Models.Directive, true),
     sub_tree_view_options: {
       default_filter: ['Section'],
     },
@@ -118,25 +119,25 @@
   }, {});
 
   CMS.Models.Directive('CMS.Models.Regulation', {
-    root_object: 'regulation'
-    , root_collection: 'regulations'
-    , model_plural: 'Regulations'
-    , table_plural: 'regulations'
-    , title_plural: 'Regulations'
-    , model_singular: 'Regulation'
-    , title_singular: 'Regulation'
-    , table_singular: 'regulation'
-    , findAll: 'GET /api/regulations'
-    , findOne: 'GET /api/regulations/{id}'
-    , create: 'POST /api/regulations'
-    , update: 'PUT /api/regulations/{id}'
-    , destroy: 'DELETE /api/regulations/{id}'
-    , is_custom_attributable: true
-    , isRoleable: true
-    , attributes: {},
-    mixins: ['accessControlList']
-    , meta_kinds: [ 'Regulation' ]
-    , cache: can.getObject('cache', CMS.Models.Directive, true),
+    root_object: 'regulation',
+    root_collection: 'regulations',
+    model_plural: 'Regulations',
+    table_plural: 'regulations',
+    title_plural: 'Regulations',
+    model_singular: 'Regulation',
+    title_singular: 'Regulation',
+    table_singular: 'regulation',
+    findAll: 'GET /api/regulations',
+    findOne: 'GET /api/regulations/{id}',
+    create: 'POST /api/regulations',
+    update: 'PUT /api/regulations/{id}',
+    destroy: 'DELETE /api/regulations/{id}',
+    is_custom_attributable: true,
+    isRoleable: true,
+    attributes: {},
+    mixins: ['accessControlList'],
+    meta_kinds: [ 'Regulation' ],
+    cache: can.getObject('cache', CMS.Models.Directive, true),
     sub_tree_view_options: {
       default_filter: ['Section'],
     },
@@ -152,26 +153,26 @@
   }, {});
 
   CMS.Models.Directive('CMS.Models.Policy', {
-    root_object: 'policy'
-    , root_collection: 'policies'
-    , model_plural: 'Policies'
-    , table_plural: 'policies'
-    , title_plural: 'Policies'
-    , model_singular: 'Policy'
-    , title_singular: 'Policy'
-    , table_singular: 'policy'
-    , findAll: 'GET /api/policies'
-    , findOne: 'GET /api/policies/{id}'
-    , create: 'POST /api/policies'
-    , update: 'PUT /api/policies/{id}'
-    , destroy: 'DELETE /api/policies/{id}'
-    , tree_view_options: {}
-    , is_custom_attributable: true
-    , isRoleable: true
-    , attributes: {},
-    mixins: ['accessControlList']
-    , meta_kinds: [  'Company Policy', 'Org Group Policy', 'Data Asset Policy', 'Product Policy', 'Contract-Related Policy', 'Company Controls Policy' ]
-    , cache: can.getObject('cache', CMS.Models.Directive, true),
+    root_object: 'policy',
+    root_collection: 'policies',
+    model_plural: 'Policies',
+    table_plural: 'policies',
+    title_plural: 'Policies',
+    model_singular: 'Policy',
+    title_singular: 'Policy',
+    table_singular: 'policy',
+    findAll: 'GET /api/policies',
+    findOne: 'GET /api/policies/{id}',
+    create: 'POST /api/policies',
+    update: 'PUT /api/policies/{id}',
+    destroy: 'DELETE /api/policies/{id}',
+    tree_view_options: {},
+    is_custom_attributable: true,
+    isRoleable: true,
+    attributes: {},
+    mixins: ['accessControlList'],
+    meta_kinds: [  'Company Policy', 'Org Group Policy', 'Data Asset Policy', 'Product Policy', 'Contract-Related Policy', 'Company Controls Policy' ],
+    cache: can.getObject('cache', CMS.Models.Directive, true),
     sub_tree_view_options: {
       default_filter: ['DataAsset'],
     },
@@ -210,26 +211,26 @@
   }, {});
 
   CMS.Models.Directive('CMS.Models.Contract', {
-    root_object: 'contract'
-    , root_collection: 'contracts'
-    , model_plural: 'Contracts'
-    , table_plural: 'contracts'
-    , title_plural: 'Contracts'
-    , model_singular: 'Contract'
-    , title_singular: 'Contract'
-    , table_singular: 'contract'
-    , findAll: 'GET /api/contracts'
-    , findOne: 'GET /api/contracts/{id}'
-    , create: 'POST /api/contracts'
-    , update: 'PUT /api/contracts/{id}'
-    , destroy: 'DELETE /api/contracts/{id}',
-    mixins: ['accessControlList']
-    , is_custom_attributable: true
-    , isRoleable: true
-    , attributes: {
-    }
-    , meta_kinds: [ 'Contract' ]
-    , cache: can.getObject('cache', CMS.Models.Directive, true),
+    root_object: 'contract',
+    root_collection: 'contracts',
+    model_plural: 'Contracts',
+    table_plural: 'contracts',
+    title_plural: 'Contracts',
+    model_singular: 'Contract',
+    title_singular: 'Contract',
+    table_singular: 'contract',
+    findAll: 'GET /api/contracts',
+    findOne: 'GET /api/contracts/{id}',
+    create: 'POST /api/contracts',
+    update: 'PUT /api/contracts/{id}',
+    destroy: 'DELETE /api/contracts/{id}',
+    mixins: ['accessControlList'],
+    is_custom_attributable: true,
+    isRoleable: true,
+    attributes: {
+    },
+    meta_kinds: [ 'Contract' ],
+    cache: can.getObject('cache', CMS.Models.Directive, true),
     sub_tree_view_options: {
       default_filter: ['Clause'],
     },

--- a/src/ggrc-client/js_specs/models/recently_viewed_object_spec.js
+++ b/src/ggrc-client/js_specs/models/recently_viewed_object_spec.js
@@ -18,8 +18,8 @@ describe('can.Model.RecentlyViewedObjects', function () {
       spyOn(GGRC.Models.RecentlyViewedObject.prototype, 'init');
       can.Model('RVO');
       let obj = new RVO({
-        viewLink: '/'
-        , title: 'blah',
+        viewLink: '/',
+        title: 'blah',
       });
       let rvo_obj = GGRC.Models.RecentlyViewedObject.newInstance(obj);
       expect(rvo_obj.type).toBe('RVO');
@@ -32,8 +32,8 @@ describe('can.Model.RecentlyViewedObjects', function () {
   describe('#stub', function () {
     it('include title and view link', function () {
       let obj = {
-        viewLink: '/'
-        , title: 'blah',
+        viewLink: '/',
+        title: 'blah',
       };
       let rvo_obj = new GGRC.Models.RecentlyViewedObject(obj).stub();
       expect(rvo_obj.title).toBe('blah');


### PR DESCRIPTION
# Issue description

Basically we have 96 eslint comma style errors. 

# Steps to test the changes

No QA testing required. From eslint perspective it's possible to check that `',' should be placed last comma-style` errors are not actual anymore.

# Solution description

Place commas last.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".