### PR TITLE
GGRC-5157 Disable all automapping rules for Objective and Controls

### DIFF
--- a/src/ggrc/automapper/rules.py
+++ b/src/ggrc/automapper/rules.py
@@ -98,12 +98,7 @@ def rules_to_str(rules):
 
 class Types(object):
   """Model names and collections to use in Rule initialization."""
-  all = {'Program', 'Regulation', 'Policy', 'Standard', 'Contract',
-         'Section', 'Clause', 'Objective', 'Control'}
   directives = {'Regulation', 'Policy', 'Standard', 'Contract'}
-  assets_business = {'System', 'Process', 'DataAsset', 'Product', 'Project',
-                     'Facility', 'Market'}
-  people_groups = {'AccessGroup', 'Person', 'OrgGroup', 'Vendor'}
 
 
 rules = make_rule_set(rule_list=[

--- a/src/ggrc/automapper/rules.py
+++ b/src/ggrc/automapper/rules.py
@@ -111,23 +111,8 @@ rules = make_rule_set(rule_list=[
         # mapping directive to a program
         {'Program'},
         Types.directives,
-        Types.all - {'Program'} - Types.directives,
+        {'Section', 'Clause'}
     ),
-
-    Rule(
-        # mapping to sections and clauses
-        Types.directives,
-        {'Section', 'Clause'},
-        {'Objective', 'Control'},
-    ),
-
-    Rule(
-        # mapping to objective
-        {'Section'},
-        {'Objective'},
-        {'Control'},
-    ),
-
     Rule(
         # mappings for 'raise an issue' on assessment page
         {"Issue"},

--- a/test/integration/ggrc/converters/test_export_csv.py
+++ b/test/integration/ggrc/converters/test_export_csv.py
@@ -502,14 +502,14 @@ class TestExportMultipleObjects(TestCase):
 
     # controls
     for i in range(115, 140):
-      if i in (117, 118, 119) + (121, 122):
+      if i in (117, 118, 119):
         self.assertIn(",Startupsum {},".format(i), response.data)
       else:
         self.assertNotIn(",Startupsum {},".format(i), response.data)
 
     # policies
     for i in range(5, 25):
-      if i in (7, 8, 9, 10, 19, 20) + (11, 12, 13, 14, 15, 16, 17, 18, 19):
+      if i in (7, 8, 9, 10, 19, 20):
         self.assertIn(",Cheese ipsum ch {},".format(i), response.data)
       else:
         self.assertNotIn(",Cheese ipsum ch {},".format(i), response.data)

--- a/test/integration/ggrc/converters/test_import_automappings.py
+++ b/test/integration/ggrc/converters/test_import_automappings.py
@@ -29,3 +29,4 @@ class TestBasicCsvImport(TestCase):
     response = self.export_csv(data)
     for i in range(1, 8):
       self.assertIn("reg-{}".format(i), response.data)
+      self.assertIn("section-{}".format(i), response.data)

--- a/test/integration/ggrc/converters/test_import_automappings.py
+++ b/test/integration/ggrc/converters/test_import_automappings.py
@@ -29,4 +29,3 @@ class TestBasicCsvImport(TestCase):
     response = self.export_csv(data)
     for i in range(1, 8):
       self.assertIn("reg-{}".format(i), response.data)
-      self.assertIn("control-{}".format(i), response.data)

--- a/test/integration/ggrc/test_csvs/automappings.csv
+++ b/test/integration/ggrc/test_csvs/automappings.csv
@@ -10,18 +10,18 @@ program,code*,title*,Program Managers,state,Privacy*,
 ,,,,,,
 ,,,,,,
 Object type,,,,,,
-Regulation,code*,title*,admin,state,Map: program,Map: control
+Regulation,code*,title*,admin,state,Map: program,Map: section
 ,reg-1,reg 1,user@example.com,Draft,"prog-1
 prog-2
-prog-3",control-1
-,reg-2,reg 2,user@example.com,Active,prog-1,control-2
-,reg-3,reg 3,user@example.com,Active,prog-1,"control-1
-control-2
-control-3
-control-4
-control-5
-control-6
-control-7"
+prog-3",section-1
+,reg-2,reg 2,user@example.com,Active,prog-1,section-2
+,reg-3,reg 3,user@example.com,Active,prog-1,"section-1
+section-2
+section-3
+section-4
+section-5
+section-6
+section-7"
 ,reg-4,reg 4,user@example.com,Active,prog-1,
 ,reg-5,reg 5,user@example.com,Active,prog-1,
 ,reg-6,reg 6,user@example.com,Active,prog-1,
@@ -30,11 +30,11 @@ control-7"
 ,,,,,,
 ,,,,,,
 Object type,,,,,,
-control,code*,title*,description,admin,,
-,control-1,control-1,test,user@example.com,,
-,control-2,control-2,test,user@example.com,,
-,control-3,control-3,test,user@example.com,,
-,control-4,control-4,test,user@example.com,,
-,control-5,control-5,test,user@example.com,,
-,control-6,control-6,test,user@example.com,,
-,control-7,control-7,test,user@example.com,,
+section,code*,title*,description,admin,,
+,section-1,section-1,test,user@example.com,,
+,section-2,section-2,test,user@example.com,,
+,section-3,section-3,test,user@example.com,,
+,section-4,section-4,test,user@example.com,,
+,section-5,section-5,test,user@example.com,,
+,section-6,section-6,test,user@example.com,,
+,section-7,section-7,test,user@example.com,,


### PR DESCRIPTION
This PR was already merged into dev.

# Issue description

We need to disable all automapping rules that map Objectives and Controls to Sections, Clauses, Directives (Regulations, Policies, Contracts, Standars), Programs (basically, any objects on a higher level in the hierarchy).

# Steps to test the changes

Check that Objective and Control is not automapped to higher hierarchy objects.

# Solution description

Remove Section/Objective automapping rules.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
