### PR TITLE
QUICK-FIX Split selenium docker compose file

### DIFF
--- a/bin/containers_functions.sh
+++ b/bin/containers_functions.sh
@@ -49,7 +49,7 @@ setup () {
 
   git submodule update --init
 
-  docker-compose --file docker-compose-testing.yml \
+  docker-compose --file ${DOCKER_COMPOSE_FILE} \
     --project-name ${PROJECT} \
     up --build --force-recreate -d ${SERVICE}
 }
@@ -62,7 +62,7 @@ teardown () {
     PROJECT="${1}"
   fi
 
-  docker-compose --file docker-compose-testing.yml -p ${PROJECT} stop
+  docker-compose --file ${DOCKER_COMPOSE_FILE} -p ${PROJECT} stop
 }
 
 print_line () {
@@ -310,8 +310,6 @@ code_style_tests () {
   fi
 
   print_line
-
-  teardown $PROJECT
 
   echo '<?xml version="1.0" encoding="UTF-8"?>
 <testsuite name="code-style" tests="3" errors="'$((pylint_rc + flake_rc))'" failures="0" skip="0">

--- a/bin/jenkins/run_checkstyle
+++ b/bin/jenkins/run_checkstyle
@@ -6,6 +6,7 @@ set -o nounset
 set -o errexit
 
 PROJECT="checkstyle"
+DOCKER_COMPOSE_FILE="docker-compose-testing.yml"
 SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
 cd "${SCRIPTPATH}/../.."
 source bin/containers_functions.sh

--- a/bin/jenkins/run_code_style
+++ b/bin/jenkins/run_code_style
@@ -6,6 +6,7 @@ set -o nounset
 set -o errexit
 
 PROJECT="codestyle"
+DOCKER_COMPOSE_FILE="docker-compose-testing.yml"
 SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
 cd "${SCRIPTPATH}/../.."
 source bin/containers_functions.sh

--- a/bin/jenkins/run_integration_acl
+++ b/bin/jenkins/run_integration_acl
@@ -6,6 +6,7 @@ set -o nounset
 set -o errexit
 
 PROJECT="integration_acl"
+DOCKER_COMPOSE_FILE="docker-compose-testing.yml"
 SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
 cd "${SCRIPTPATH}/../.."
 source bin/containers_functions.sh

--- a/bin/jenkins/run_integration_ggrc
+++ b/bin/jenkins/run_integration_ggrc
@@ -6,6 +6,7 @@ set -o nounset
 set -o errexit
 
 PROJECT="integration_ggrc"
+DOCKER_COMPOSE_FILE="docker-compose-testing.yml"
 SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
 cd "${SCRIPTPATH}/../.."
 source bin/containers_functions.sh

--- a/bin/jenkins/run_integration_non_ggrc
+++ b/bin/jenkins/run_integration_non_ggrc
@@ -6,6 +6,7 @@ set -o nounset
 set -o errexit
 
 PROJECT="integration_non_ggrc"
+DOCKER_COMPOSE_FILE="docker-compose-testing.yml"
 SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
 cd "${SCRIPTPATH}/../.."
 source bin/containers_functions.sh

--- a/bin/jenkins/run_selenium
+++ b/bin/jenkins/run_selenium
@@ -6,6 +6,7 @@ set -o nounset
 set -o errexit
 
 PROJECT="selenium"
+DOCKER_COMPOSE_FILE="docker-compose-selenium.yml"
 SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
 cd "${SCRIPTPATH}/../.."
 source bin/containers_functions.sh

--- a/bin/jenkins/run_unittests
+++ b/bin/jenkins/run_unittests
@@ -6,6 +6,7 @@ set -o nounset
 set -o errexit
 
 PROJECT="unittests"
+DOCKER_COMPOSE_FILE="docker-compose-testing.yml"
 SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
 cd "${SCRIPTPATH}/../.."
 source bin/containers_functions.sh

--- a/bin/selenium_containers
+++ b/bin/selenium_containers
@@ -3,6 +3,7 @@
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
 PROJECT="selenium"
+DOCKER_COMPOSE_FILE="docker-compose-selenium.yml"
 
 cd "$(dirname $0)/.."
 source bin/containers_functions.sh

--- a/docker-compose-selenium.yml
+++ b/docker-compose-selenium.yml
@@ -1,0 +1,63 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+version: "2"
+services:
+  cleandev:
+    extends:
+      service: cleandev
+      file: common-services.yml
+    ports:
+     - "127.0.0.1:8000:8000"
+     - "127.0.0.1:8080:8080"
+     - "127.0.0.1:9876:9876"
+    depends_on:
+      - db
+    networks:
+      - network_cleandev
+      - selenium
+  cleandev_destructive:
+    extends:
+      service: cleandev
+      file: common-services.yml
+    depends_on:
+      - db_destructive
+    networks:
+      - network_cleandev_destructive
+      - selenium
+  db:
+    extends:
+      service: db
+      file: common-services.yml
+    networks:
+      - network_cleandev
+  db_destructive:
+    extends:
+      service: db
+      file: common-services.yml
+    networks:
+      network_cleandev_destructive:
+        aliases:
+          - db
+  selenium:
+    build:
+      context: .
+      dockerfile: Dockerfile-selenium
+    volumes:
+     - "./test/selenium:/selenium"
+     - "/dev/shm:/dev/shm"
+    depends_on:
+      - cleandev
+      - cleandev_destructive
+    networks:
+      - selenium
+    environment:
+     - "TZ=America/Los_Angeles"
+     - PYTHONDONTWRITEBYTECODE=true
+     - PYTHONPATH=/selenium/src
+     - SCREEN_WIDTH=1440
+     - SCREEN_HEIGHT=900
+networks:
+  network_cleandev:
+  network_cleandev_destructive:
+  selenium:

--- a/docker-compose-testing.yml
+++ b/docker-compose-testing.yml
@@ -11,49 +11,11 @@ services:
       - db
     networks:
       - network_cleandev
-      - selenium
-  cleandev_destructive:
-    extends:
-      service: cleandev
-      file: common-services.yml
-    depends_on:
-      - db_destructive
-    networks:
-      - network_cleandev_destructive
-      - selenium
   db:
     extends:
       service: db
       file: common-services.yml
     networks:
       - network_cleandev
-  db_destructive:
-    extends:
-      service: db
-      file: common-services.yml
-    networks:
-      network_cleandev_destructive:
-        aliases:
-          - db
-  selenium:
-    build:
-      context: .
-      dockerfile: Dockerfile-selenium
-    volumes:
-     - "./test/selenium:/selenium"
-     - "/dev/shm:/dev/shm"
-    depends_on:
-      - cleandev
-      - cleandev_destructive
-    networks:
-      - selenium
-    environment:
-     - "TZ=America/Los_Angeles"
-     - PYTHONDONTWRITEBYTECODE=true
-     - PYTHONPATH=/selenium/src
-     - SCREEN_WIDTH=1440
-     - SCREEN_HEIGHT=900
 networks:
   network_cleandev:
-  network_cleandev_destructive:
-  selenium:


### PR DESCRIPTION
PR https://github.com/google/ggrc-core/pull/7891 previously has removed ports from docker-compose-testing.yml so several cleandev containers could be started.

Ports were used by Selenium tests. This PR adds another docker-compose file to be used by Selenium tests.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
