### PR TITLE
GGRC-4818 IssueTracker turns off when IssueTracker sync errors

### DIFF
--- a/src/ggrc/models/hooks/issue_tracker/assessment_integration.py
+++ b/src/ggrc/models/hooks/issue_tracker/assessment_integration.py
@@ -298,10 +298,9 @@ def _handle_issuetracker(sender, obj=None, src=None, **kwargs):
       include_private=True) if issue_obj is not None else {}
   issue_tracker_info = dict(initial_info, **(src.get('issue_tracker') or {}))
 
+  issue_id = issue_tracker_info.get('issue_id')
+
   if issue_tracker_info.get('enabled'):
-
-    issue_id = issue_tracker_info.get('issue_id')
-
     if not issue_id:
       # If assessment initially was created with disabled IssueTracker.
       _create_issuetracker_info(obj, issue_tracker_info)

--- a/src/ggrc/models/hooks/issue_tracker/assessment_integration.py
+++ b/src/ggrc/models/hooks/issue_tracker/assessment_integration.py
@@ -328,9 +328,6 @@ def _handle_issuetracker(sender, obj=None, src=None, **kwargs):
       logger.error(
           'Unable to update a ticket ID=%s while updating '
           'assessment ID=%d: %s', issue_id, obj.id, error)
-      issue_tracker_info = {
-          'enabled': False,
-      }
     obj.add_warning('issue_tracker', 'Unable to update a ticket.')
 
   _update_issuetracker_info(obj, issue_tracker_info)

--- a/test/unit/ggrc/models/hooks/test_issue_tracker.py
+++ b/test/unit/ggrc/models/hooks/test_issue_tracker.py
@@ -8,12 +8,17 @@ import unittest
 import ddt
 import mock
 
+from ggrc.models import all_models
 from ggrc.models.hooks.issue_tracker import assessment_integration
+from ggrc.integrations import integrations_errors
 
 
 @ddt.ddt
 class TestUtilityFunctions(unittest.TestCase):
   """Test utility function in issue_tracker module."""
+
+  ISSUE_TRACKED_NAMESPACE = \
+      "ggrc.models.hooks.issue_tracker.assessment_integration"
 
   def setUp(self):
     super(TestUtilityFunctions, self).setUp()
@@ -71,3 +76,33 @@ class TestUtilityFunctions(unittest.TestCase):
     else:
       assessment_integration._normalize_issue_tracker_info(info)
       self.assertEqual(info, expected)
+
+  @mock.patch(ISSUE_TRACKED_NAMESPACE + '._is_issue_tracker_enabled',
+              lambda audit: True)
+  @ddt.data((True, 123), (False, 123))
+  @ddt.unpack
+  def test_issue_tracker_error(self, issue_tracker_enabled, issue_id):
+    """ Test that issue tracker does not change state
+        in case receiving an error."""
+    with mock.patch(self.ISSUE_TRACKED_NAMESPACE +
+                    '._update_issuetracker_issue') as update_issue_mock, \
+        mock.patch(self.ISSUE_TRACKED_NAMESPACE +
+                   '._update_issuetracker_info') as update_info_mock, \
+        mock.patch(self.ISSUE_TRACKED_NAMESPACE + '._collect_issue_emails',
+                   side_effect=[(None, [])]):
+      error_data = integrations_errors.HttpError('data')
+      update_issue_mock.side_effect = error_data
+      src = {
+          'issue_tracker': {
+              'enabled': issue_tracker_enabled,
+              'issue_id': issue_id
+          }
+      }
+      all_models.IssuetrackerIssue.get_issue = mock.MagicMock()
+      # pylint: disable=protected-access
+      assessment_integration._handle_issuetracker(sender=None,
+                                                  obj=mock.MagicMock(),
+                                                  src=src)
+      update_info_mock.assert_called_once()
+      self.assertEqual(update_info_mock.call_args[0][1]['enabled'],
+                       issue_tracker_enabled)


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

The logs show that Ticket Tracker was "ON" in the assessment, after the 500 error, the ticket tracker was turned off.

# Solution description

Do not turn off the Ticket Tracker manually.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
