### PR TITLE
GGRC-5346 Convert advanced search items to JS objects

### DIFF
--- a/src/ggrc-client/js/components/advanced-search/advanced-search-filter-attribute.js
+++ b/src/ggrc-client/js/components/advanced-search/advanced-search-filter-attribute.js
@@ -30,8 +30,8 @@ let viewModel = can.Map.extend({
         let attribute = this.attr('attribute');
         if (attributes.length &&
           attributes[0].attr_title &&
-          !attribute.field) {
-          attribute.field = attributes[0].attr_title;
+          !attribute.attr('field')) {
+          attribute.attr('field', attributes[0].attr_title);
         }
         return attributes;
       },

--- a/src/ggrc-client/js/components/advanced-search/advanced-search-filter-state.js
+++ b/src/ggrc-client/js/components/advanced-search/advanced-search-filter-state.js
@@ -22,21 +22,24 @@ let viewModel = can.Map.extend({
     stateModel: {
       type: '*',
       set: function (state) {
-        let filterStates =
+        if (!state.attr('items')) {
+          let defaultStates =
+            StateUtils.getDefaultStatesForModel(this.attr('modelName'));
+          state.attr('items', defaultStates);
+        }
+        if (!state.attr('operator')) {
+          state.attr('operator', 'ANY');
+        }
+        state.attr('modelName', this.attr('modelName'));
+
+        let allStates =
           StateUtils.getStatesForModel(this.attr('modelName'));
-
-        state.items = state.items ||
-          StateUtils.getDefaultStatesForModel(this.attr('modelName'));
-
-        this.attr('filterStates', filterStates.map(function (filterState) {
+        this.attr('filterStates', allStates.map(function (filterState) {
           return {
             value: filterState,
-            checked: (state.items.indexOf(filterState) > -1),
+            checked: (state.attr('items').indexOf(filterState) > -1),
           };
         }));
-
-        state.operator = state.operator || 'ANY';
-        state.modelName = this.attr('modelName');
 
         return state;
       },

--- a/src/ggrc-client/js/components/advanced-search/tests/advanced-search-filter-attribute_spec.js
+++ b/src/ggrc-client/js/components/advanced-search/tests/advanced-search-filter-attribute_spec.js
@@ -23,7 +23,7 @@ describe('GGRC.Components.advancedSearchFilterAttribute', function () {
           attr_title: 'FirstAttr',
         }]);
 
-        expect(viewModel.attr('attribute').field).toBe('FirstAttr');
+        expect(viewModel.attr('attribute.field')).toBe('FirstAttr');
       });
 
     it('does not intialize "attribute.field" when it is already initialized',

--- a/src/ggrc-client/js/components/advanced-search/tests/advanced-search-filter-state_spec.js
+++ b/src/ggrc-client/js/components/advanced-search/tests/advanced-search-filter-state_spec.js
@@ -25,7 +25,7 @@ describe('GGRC.Components.advancedSearchFilterState', function () {
           .and.returnValue(states);
         viewModel.attr('modelName', 'Section');
 
-        viewModel.attr('stateModel', {});
+        viewModel.attr('stateModel', new can.Map());
 
         viewModel.attr('filterStates').each(function (item) {
           expect(item.checked).toBeTruthy();
@@ -37,9 +37,9 @@ describe('GGRC.Components.advancedSearchFilterState', function () {
     function () {
       viewModel.attr('modelName', 'Section');
 
-      viewModel.attr('stateModel', {
+      viewModel.attr('stateModel', new can.Map({
         items: [],
-      });
+      }));
 
       viewModel.attr('filterStates').each(function (item) {
         expect(item.checked).toBeFalsy();
@@ -50,9 +50,9 @@ describe('GGRC.Components.advancedSearchFilterState', function () {
       function () {
         let selectedItems;
         viewModel.attr('modelName', 'Section');
-        viewModel.attr('stateModel', {
+        viewModel.attr('stateModel', new can.Map({
           items: ['Active'],
-        });
+        }));
 
         selectedItems = _.filter(viewModel.attr('filterStates'), function (it) {
           return it.checked;

--- a/src/ggrc-client/js/components/tree/tree-widget-container.js
+++ b/src/ggrc-client/js/components/tree/tree-widget-container.js
@@ -555,8 +555,8 @@ viewModel = can.Map.extend({
     this.attr('advancedSearch.open', true);
   },
   applyAdvancedFilters: function () {
-    let filters = this.attr('advancedSearch.filterItems');
-    let mappings = this.attr('advancedSearch.mappingItems');
+    let filters = this.attr('advancedSearch.filterItems').attr();
+    let mappings = this.attr('advancedSearch.mappingItems').attr();
     let request = can.List();
     let advancedFilters;
 

--- a/src/ggrc-client/js/components/unified-mapper/mapper-results.js
+++ b/src/ggrc-client/js/components/unified-mapper/mapper-results.js
@@ -194,15 +194,15 @@ export default GGRC.Components('mapperResults', {
       let request = [];
       let status;
       let filters =
-        AdvancedSearch.buildFilter(this.attr('filterItems'), request);
+        AdvancedSearch.buildFilter(this.attr('filterItems').attr(), request);
       let mappings =
-        AdvancedSearch.buildFilter(this.attr('mappingItems'), request);
+        AdvancedSearch.buildFilter(this.attr('mappingItems').attr(), request);
       let advancedFilters = GGRC.query_parser.join_queries(filters, mappings);
 
       // the edge case caused by stateless objects
       if (this.attr('statusItem.value.items')) {
         status =
-          AdvancedSearch.buildFilter([this.attr('statusItem')], request);
+          AdvancedSearch.buildFilter([this.attr('statusItem').attr()], request);
         advancedFilters = GGRC.query_parser
           .join_queries(advancedFilters, status);
       }

--- a/src/ggrc-client/js/components/unified-mapper/tests/mapper-results_spec.js
+++ b/src/ggrc-client/js/components/unified-mapper/tests/mapper-results_spec.js
@@ -312,8 +312,8 @@ describe('GGRC.Components.mapperResults', function () {
       key: 'mock3',
       direction: 'mock4',
     };
-    let mockFilterItems = ['filterItem'];
-    let mockMappingItems = ['mappingItem'];
+    let mockFilterItems = new can.List(['filterItem']);
+    let mockMappingItems = new can.List(['mappingItem']);
     let mockStatusItem = new can.Map({
       value: {
         items: ['statusItem'],
@@ -342,20 +342,20 @@ describe('GGRC.Components.mapperResults', function () {
 
     it('builds advanced filters', function () {
       viewModel.getQuery('values', true);
-      expect(AdvancedSearch.buildFilter.calls.argsFor(0)[0].attr())
-        .toEqual(mockFilterItems);
+      expect(AdvancedSearch.buildFilter.calls.argsFor(0)[0])
+        .toEqual(mockFilterItems.attr());
     });
 
     it('builds advanced mappings', function () {
       viewModel.getQuery('values', true);
-      expect(AdvancedSearch.buildFilter.calls.argsFor(1)[0].attr())
-        .toEqual(mockMappingItems);
+      expect(AdvancedSearch.buildFilter.calls.argsFor(1)[0])
+        .toEqual(mockMappingItems.attr());
     });
 
     it('builds advanced status', function () {
       viewModel.getQuery('values', true);
       expect(AdvancedSearch.buildFilter.calls.argsFor(2)[0][0])
-        .toEqual(mockStatusItem);
+        .toEqual(mockStatusItem.attr());
     });
 
     it('does not build advanced status if sttatus items are not provided',


### PR DESCRIPTION
# Issue description

Using State dropdown in Global search / Unified mapper breaks search

# Steps to test the changes

1. Click Global Search
2. Check / uncheck something in State dropdown (e.g. just uncheck and check a checkbox)
3. Click Search

Actual result: no results are found
Expected result: results should be found

# Solution description

1) Correctly build filters in can.Map/can.List format.
2) Convert filters to JS objects to avoid sending service fields to server.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
