### PR TITLE
GGRC-5065 Fix import of Audit

### DIFF
--- a/test/integration/ggrc/converters/test_import_audit.py
+++ b/test/integration/ggrc/converters/test_import_audit.py
@@ -1,0 +1,62 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Test import of Audit and mapped objects."""
+
+from collections import OrderedDict
+
+from ggrc.models import all_models
+
+from integration.ggrc import TestCase
+from integration.ggrc.models import factories
+
+
+class TestAuditImport(TestCase):
+  """Audit import test class."""
+
+  def setUp(self):
+    """Set up for Audit test cases."""
+    super(TestAuditImport, self).setUp()
+    self.client.get("/login")
+
+  def test_update_audit_with_control(self):
+    """Test import of existing Audit with mapped Control Snapshot."""
+    with factories.single_commit():
+      program = factories.ProgramFactory()
+      audit = factories.AuditFactory(program=program)
+      audit_id = audit.id
+      control = factories.ControlFactory()
+      factories.RelationshipFactory(source=program, destination=control)
+      snapshot = self._create_snapshots(audit, [control])[0]
+      factories.RelationshipFactory(source=audit, destination=snapshot)
+
+    response = self.import_data(OrderedDict([
+        ("object_type", "Audit"),
+        ("Code*", audit.slug),
+        ("Title", "New Title"),
+        ("Audit Captains", "user@example.com"),
+        ("Program", program.slug),
+        ("map:control versions", control.slug),
+    ]))
+    self._check_csv_response(response, {})
+    audit = all_models.Audit.query.get(audit_id)
+    self.assertEqual(audit.title, "New Title")
+
+  def test_create_audit_with_control(self):
+    """Test import of new Audit with mapped Control Snapshot."""
+    with factories.single_commit():
+      program = factories.ProgramFactory()
+      control = factories.ControlFactory()
+      factories.RelationshipFactory(source=program, destination=control)
+
+    response = self.import_data(OrderedDict([
+        ("object_type", "Audit"),
+        ("Code*", ""),
+        ("Title", "New Audit"),
+        ("State", "Planned"),
+        ("Audit Captains", "user@example.com"),
+        ("Program", program.slug),
+        ("map:control versions", control.slug),
+    ]))
+    self._check_csv_response(response, {})
+    self.assertEqual(all_models.Audit.query.count(), 1)


### PR DESCRIPTION
# Issue description

Import of existing Audit fails if imported data contains information about mapped snapshots.
UI error: 'The volume of import is too big. Please split your import in smaller portion of 200 or less rows and import one after another. Sorry for inconvenience.'
Reason of this issue is in wrong implementation of mapped snapshots collection.

# Steps to test the changes

1. Go to Export page and export any existent audit
2. Click Write to sheet after export
3. With or without any updates Import Audit

Expected Result: Audit should be imported. No errors should be shown.

# Solution description

Refactor procedure `audit_object_pool_query` to handle cases when mapped snapshots should be found for Audit and Assessment.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [ ] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
