### PR TITLE
GGRC-5142 Improve UX for Assertions and Categories

### DIFF
--- a/src/ggrc-client/js/components/dropdown/multiselect-dropdown-wrapper.js
+++ b/src/ggrc-client/js/components/dropdown/multiselect-dropdown-wrapper.js
@@ -64,13 +64,19 @@ export default can.Component.extend({
       Retrieved from Model.cache by Id and sent up to parent`s 'selected'
     */
     'multiselect-dropdown multiselect:changed':
-      function (element, event, selected) {
+      function (element, event, newSelected) {
         let self = this;
 
-        this.viewModel.attr('selected', _.map(selected, (item)=> {
-          return CMS.Models[self.viewModel.modelName]
-            .findInCacheById(item.id);
-        }));
+        /* reuse object to allow sort-by properly react
+        on selected change */
+        let selected = self.viewModel.attr('selected') || [];
+        // remove all old items
+        selected.splice(0);
+        // add all new items from Cache
+        newSelected.forEach((item) => {
+          selected.push(CMS.Models[self.viewModel.modelName]
+            .findInCacheById(item.id));
+        });
       },
   },
 });

--- a/src/ggrc-client/js/components/dropdown/multiselect-dropdown-wrapper.js
+++ b/src/ggrc-client/js/components/dropdown/multiselect-dropdown-wrapper.js
@@ -1,0 +1,76 @@
+/*
+    Copyright (C) 2018 Google Inc.
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+import template from './multiselect-dropdown-wrapper.mustache';
+
+export default can.Component.extend({
+  tag: 'multiselect-dropdown-wrapper',
+  template: template,
+  viewModel: {
+    placeholder: '@',
+    define: {
+      /*
+        Multiselect-dropdown wrapper when data should be fetched first
+        {modelName}: Name of CMS.Model to fetch
+        {(selected)}: Two-way binding parent`s target attribute
+      */
+      modelName: {
+        set(newModelName) {
+          if (CMS.Models[newModelName]) {
+            CMS.Models[newModelName].findAll()
+              .done(this._prepareModels.bind(this));
+
+            return newModelName;
+          }
+        },
+      },
+    },
+    _prepareModels: function (items) {
+      let selected = this.attr('selected');
+      let preparedOptions = [];
+      let selectedInternal = [];
+
+      _.each(items, (item)=> {
+        let isSelected = _.find(selected, (selectedItem)=> {
+          return selectedItem.id === item.id;
+        });
+
+        let selectObj = {
+          value: item.name,
+          id: item.id,
+          checked: isSelected ? true : false,
+        };
+
+        preparedOptions.push(selectObj);
+
+        if (isSelected) {
+          selectedInternal.push(selectObj);
+        }
+      });
+
+      // preparedOptions sent down to multiselect-dropdown
+      this.attr('preparedOptions', preparedOptions);
+
+      // selectedInternal is input models
+      // converted into multiselect-dropdown format
+      this.attr('selectedInternal', selectedInternal);
+    },
+  },
+  events: {
+    /*
+      Update received from multiselect-dropdown
+      Retrieved from Model.cache by Id and sent up to parent`s 'selected'
+    */
+    'multiselect-dropdown multiselect:changed':
+      function (element, event, selected) {
+        let self = this;
+
+        this.viewModel.attr('selected', _.map(selected, (item)=> {
+          return CMS.Models[self.viewModel.modelName]
+            .findInCacheById(item.id);
+        }));
+      },
+  },
+});

--- a/src/ggrc-client/js/components/dropdown/multiselect-dropdown-wrapper.js
+++ b/src/ggrc-client/js/components/dropdown/multiselect-dropdown-wrapper.js
@@ -20,33 +20,33 @@ export default can.Component.extend({
         set(newModelName) {
           if (CMS.Models[newModelName]) {
             CMS.Models[newModelName].findAll()
-              .done(this._prepareModels.bind(this));
+              .done(this.prepareOptions.bind(this));
 
             return newModelName;
           }
         },
       },
     },
-    _prepareModels: function (items) {
+    prepareOptions: function (items) {
       let selected = this.attr('selected');
       let preparedOptions = [];
       let selectedInternal = [];
 
-      _.each(items, (item)=> {
+      items.forEach((item)=> {
         let isSelected = _.find(selected, (selectedItem)=> {
           return selectedItem.id === item.id;
         });
 
-        let selectObj = {
+        let option = {
           value: item.name,
           id: item.id,
           checked: isSelected ? true : false,
         };
 
-        preparedOptions.push(selectObj);
+        preparedOptions.push(option);
 
         if (isSelected) {
-          selectedInternal.push(selectObj);
+          selectedInternal.push(option);
         }
       });
 

--- a/src/ggrc-client/js/components/dropdown/multiselect-dropdown-wrapper.mustache
+++ b/src/ggrc-client/js/components/dropdown/multiselect-dropdown-wrapper.mustache
@@ -1,0 +1,10 @@
+{{!
+  Copyright (C) 2018 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+}}
+
+<multiselect-dropdown
+    {options}="preparedOptions"
+    {selected}="selectedInternal"
+    {placeholder}="placeholder">
+</multiselect-dropdown>

--- a/src/ggrc-client/js/components/dropdown/tests/multiselect-dropdown-wrapper_spec.js
+++ b/src/ggrc-client/js/components/dropdown/tests/multiselect-dropdown-wrapper_spec.js
@@ -144,6 +144,18 @@ describe('multiselectDropdownWrapper component', function () {
 
     beforeEach(function () {
       viewModel.attr('modelName', 'TestType');
+      viewModel.attr('selected', [
+        {
+          id: 2,
+          name: '2 item',
+          extra: 'extra',
+        },
+        {
+          id: 3,
+          name: '3 item',
+          extra: 'extra',
+        },
+      ]);
 
       events = Component.prototype.events;
       handler = events['multiselect-dropdown multiselect:changed']
@@ -165,6 +177,12 @@ describe('multiselectDropdownWrapper component', function () {
       expect(viewModel.selected[0].id).toEqual('testId');
       expect(viewModel.selected[0].name).toEqual('testName');
       expect(viewModel.selected[0].extra).toEqual('extra');
+    });
+
+    it('should keep an object', () => {
+      let initialObj = viewModel.selected;
+      handler({}, {}, newSelected);
+      expect(viewModel.selected).toEqual(initialObj);
     });
   });
 });

--- a/src/ggrc-client/js/components/dropdown/tests/multiselect-dropdown-wrapper_spec.js
+++ b/src/ggrc-client/js/components/dropdown/tests/multiselect-dropdown-wrapper_spec.js
@@ -1,0 +1,173 @@
+/*
+    Copyright (C) 2018 Google Inc.
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+import {getComponentVM} from '../../../../js_specs/spec_helpers';
+import Component from '../multiselect-dropdown-wrapper';
+
+describe('multiselectDropdownWrapper component', function () {
+  let viewModel;
+  let response;
+  let findDfd;
+
+  beforeEach(function () {
+    viewModel = getComponentVM(Component);
+    response = [
+      {
+        id: 1,
+        name: '1 item',
+        extra: 'extra',
+      },
+      {
+        id: 2,
+        name: '2 item',
+        extra: 'extra',
+      },
+      {
+        id: 3,
+        name: '3 item',
+        extra: 'extra',
+      },
+      {
+        id: 4,
+        name: '4 item',
+        extra: 'extra',
+      },
+    ];
+
+    findDfd = can.Deferred();
+    CMS.Models.TestType = can.Map.extend({
+      findAll: jasmine.createSpy('findAll').and.returnValue(findDfd),
+      findInCacheById: jasmine.createSpy('findInCacheById')
+        .and.returnValue({
+          id: 'testId',
+          name: 'testName',
+          extra: 'extra',
+        }),
+    }, {});
+  });
+
+  describe('modelName set()', () => {
+    beforeEach(function () {
+    });
+
+    it('calls findAll()', ()=> {
+      viewModel.attr('modelName', 'TestType');
+
+      expect(CMS.Models.TestType.findAll).toHaveBeenCalled();
+    });
+
+    it('calls _prepareModels()', (done)=> {
+      spyOn(viewModel, '_prepareModels');
+
+      viewModel.attr('modelName', 'TestType');
+      findDfd.resolve(response);
+
+      findDfd.then((result)=> {
+        expect(viewModel._prepareModels).toHaveBeenCalledWith(response);
+
+        done();
+      });
+    });
+
+    describe('_prepareModels() method', () => {
+      beforeEach(function () {
+        viewModel.attr('selected', [
+          {
+            id: 2,
+            name: '2 item',
+            extra: 'extra',
+          },
+          {
+            id: 3,
+            name: '3 item',
+            extra: 'extra',
+          },
+        ]);
+      });
+
+      it('sets preparedOptions', (done)=> {
+        viewModel.attr('modelName', 'TestType');
+        findDfd.resolve(response);
+
+        findDfd.then((result)=> {
+          expect(viewModel.preparedOptions.length).toEqual(response.length);
+
+          done();
+        });
+      });
+
+      it('converts models to a correct format', (done)=> {
+        viewModel.attr('modelName', 'TestType');
+        findDfd.resolve(response);
+
+        findDfd.then((result)=> {
+          expect(viewModel.preparedOptions[0].value).toEqual('1 item');
+          expect(viewModel.preparedOptions[0].id).toEqual(1);
+          expect(viewModel.preparedOptions[0].checked).toBeFalsy();
+          expect(viewModel.preparedOptions[0].extra).toBeUndefined();
+
+          done();
+        });
+      });
+
+      it('sets selectedInternal', (done)=> {
+        viewModel.attr('modelName', 'TestType');
+        findDfd.resolve(response);
+
+        findDfd.then((result)=> {
+          expect(viewModel.selectedInternal.length)
+            .toEqual(viewModel.selected.length);
+
+          done();
+        });
+      });
+
+      it('selectedInternal has correct format', (done)=> {
+        viewModel.attr('modelName', 'TestType');
+        findDfd.resolve(response);
+
+        findDfd.then((result)=> {
+          expect(viewModel.selectedInternal[0].value).toEqual('2 item');
+          expect(viewModel.selectedInternal[0].id).toEqual(2);
+          expect(viewModel.selectedInternal[0].checked).toBeTruthy();
+          expect(viewModel.selectedInternal[0].extra).toBeUndefined();
+
+          done();
+        });
+      });
+    });
+  });
+
+  describe('events', () => {
+    let events;
+    let handler;
+    let newSelected;
+
+    beforeEach(function () {
+      viewModel.attr('modelName', 'TestType');
+
+      events = Component.prototype.events;
+      handler = events['multiselect-dropdown multiselect:changed']
+        .bind({viewModel: viewModel});
+
+      newSelected = [{id: 1}];
+    });
+
+    it('should call findInCacheById', ()=> {
+      handler({}, {}, newSelected);
+
+      expect(CMS.Models.TestType.findInCacheById).toHaveBeenCalled();
+    });
+
+    it('should get model from cache', ()=> {
+      handler({}, {}, newSelected);
+
+      expect(viewModel.selected.length).toEqual(newSelected.length);
+      expect(viewModel.selected[0].id).toEqual('testId');
+      expect(viewModel.selected[0].name).toEqual('testName');
+      expect(viewModel.selected[0].extra).toEqual('extra');
+    });
+  });
+});

--- a/src/ggrc-client/js/components/dropdown/tests/multiselect-dropdown-wrapper_spec.js
+++ b/src/ggrc-client/js/components/dropdown/tests/multiselect-dropdown-wrapper_spec.js
@@ -55,20 +55,20 @@ describe('multiselectDropdownWrapper component', function () {
       expect(CMS.Models.TestType.findAll).toHaveBeenCalled();
     });
 
-    it('calls _prepareModels()', (done) => {
-      spyOn(viewModel, '_prepareModels');
+    it('calls prepareOptions()', (done) => {
+      spyOn(viewModel, 'prepareOptions');
 
       viewModel.attr('modelName', 'TestType');
       findDfd.resolve(response);
 
       findDfd.then((result) => {
-        expect(viewModel._prepareModels).toHaveBeenCalledWith(response);
+        expect(viewModel.prepareOptions).toHaveBeenCalledWith(response);
 
         done();
       });
     });
 
-    describe('_prepareModels() method', () => {
+    describe('prepareOptions() method', () => {
       beforeEach(function () {
         viewModel.attr('selected', [
           {

--- a/src/ggrc-client/js/components/dropdown/tests/multiselect-dropdown-wrapper_spec.js
+++ b/src/ggrc-client/js/components/dropdown/tests/multiselect-dropdown-wrapper_spec.js
@@ -49,22 +49,19 @@ describe('multiselectDropdownWrapper component', function () {
   });
 
   describe('modelName set()', () => {
-    beforeEach(function () {
-    });
-
-    it('calls findAll()', ()=> {
+    it('calls findAll()', () => {
       viewModel.attr('modelName', 'TestType');
 
       expect(CMS.Models.TestType.findAll).toHaveBeenCalled();
     });
 
-    it('calls _prepareModels()', (done)=> {
+    it('calls _prepareModels()', (done) => {
       spyOn(viewModel, '_prepareModels');
 
       viewModel.attr('modelName', 'TestType');
       findDfd.resolve(response);
 
-      findDfd.then((result)=> {
+      findDfd.then((result) => {
         expect(viewModel._prepareModels).toHaveBeenCalledWith(response);
 
         done();
@@ -87,22 +84,22 @@ describe('multiselectDropdownWrapper component', function () {
         ]);
       });
 
-      it('sets preparedOptions', (done)=> {
+      it('sets preparedOptions', (done) => {
         viewModel.attr('modelName', 'TestType');
         findDfd.resolve(response);
 
-        findDfd.then((result)=> {
+        findDfd.then((result) => {
           expect(viewModel.preparedOptions.length).toEqual(response.length);
 
           done();
         });
       });
 
-      it('converts models to a correct format', (done)=> {
+      it('converts models to a correct format', (done) => {
         viewModel.attr('modelName', 'TestType');
         findDfd.resolve(response);
 
-        findDfd.then((result)=> {
+        findDfd.then((result) => {
           expect(viewModel.preparedOptions[0].value).toEqual('1 item');
           expect(viewModel.preparedOptions[0].id).toEqual(1);
           expect(viewModel.preparedOptions[0].checked).toBeFalsy();
@@ -112,11 +109,11 @@ describe('multiselectDropdownWrapper component', function () {
         });
       });
 
-      it('sets selectedInternal', (done)=> {
+      it('sets selectedInternal', (done) => {
         viewModel.attr('modelName', 'TestType');
         findDfd.resolve(response);
 
-        findDfd.then((result)=> {
+        findDfd.then((result) => {
           expect(viewModel.selectedInternal.length)
             .toEqual(viewModel.selected.length);
 
@@ -124,11 +121,11 @@ describe('multiselectDropdownWrapper component', function () {
         });
       });
 
-      it('selectedInternal has correct format', (done)=> {
+      it('selectedInternal has correct format', (done) => {
         viewModel.attr('modelName', 'TestType');
         findDfd.resolve(response);
 
-        findDfd.then((result)=> {
+        findDfd.then((result) => {
           expect(viewModel.selectedInternal[0].value).toEqual('2 item');
           expect(viewModel.selectedInternal[0].id).toEqual(2);
           expect(viewModel.selectedInternal[0].checked).toBeTruthy();
@@ -155,13 +152,13 @@ describe('multiselectDropdownWrapper component', function () {
       newSelected = [{id: 1}];
     });
 
-    it('should call findInCacheById', ()=> {
+    it('should call findInCacheById', () => {
       handler({}, {}, newSelected);
 
       expect(CMS.Models.TestType.findInCacheById).toHaveBeenCalled();
     });
 
-    it('should get model from cache', ()=> {
+    it('should get model from cache', () => {
       handler({}, {}, newSelected);
 
       expect(viewModel.selected.length).toEqual(newSelected.length);

--- a/src/ggrc-client/js/components/tree/tree-widget-container.js
+++ b/src/ggrc-client/js/components/tree/tree-widget-container.js
@@ -28,6 +28,7 @@ import '../bulk-update-button/bulk-update-button';
 import '../assessment-template-clone-button/assessment-template-clone-button';
 import '../create-document-button/create-document-button';
 import '../dropdown/multiselect-dropdown';
+import '../dropdown/multiselect-dropdown-wrapper';
 import '../assessment/assessment-generator-button';
 import '../last-comment/last-comment';
 import template from './templates/tree-widget-container.mustache';

--- a/src/ggrc-client/js/mustache_helper.js
+++ b/src/ggrc-client/js/mustache_helper.js
@@ -488,46 +488,6 @@ Mustache.registerHelper('option_select',
     return deferRender(tagPrefix, getSelectHtml, optionsDfd);
   });
 
-Mustache.registerHelper('category_select',
-  function (object, attrName, categoryType, options) {
-    const selectedOptions = object[attrName] || [];
-    const selectedIds = can.map(selectedOptions, function (selectedOption) {
-      return selectedOption.id;
-    });
-    const optionsDfd = CMS.Models[categoryType].findAll();
-    let tabIndex = options.hash && options.hash.tabindex;
-    const tagPrefix = 'select class="span12" multiple="multiple"';
-
-    tabIndex = typeof tabIndex !== 'undefined' ?
-      ` tabindex="${tabIndex}"` :
-      '';
-
-    function getSelectHtml(options) {
-      const sortedOptions = _.sortBy(options, 'name');
-      const selectOpenTag = `
-        <select class="span12" multiple="multiple"
-          model="${categoryType}"
-          name="${attrName}"
-          ${tabIndex}
-        >`;
-      const selectCloseTag = '</select>';
-      const optionTags = can.map(sortedOptions, function (option) {
-        return `
-          <option value="${option.id}"
-            ${selectedIds.indexOf(option.id) > -1 ? ' selected=selected' : ''}
-          >${option.name}</option>`;
-      }).join('\n');
-
-      return [
-        selectOpenTag,
-        optionTags,
-        selectCloseTag,
-      ].join('');
-    }
-
-    return deferRender(tagPrefix, getSelectHtml, optionsDfd);
-  });
-
 Mustache.registerHelper('get_permalink_url', function () {
   return window.location.href;
 });

--- a/src/ggrc-client/styles/_common.scss
+++ b/src/ggrc-client/styles/_common.scss
@@ -1001,3 +1001,7 @@ p {
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
+.no-outline {
+  outline: none;
+}

--- a/src/ggrc-client/styles/components/multiselect-dropdown/_multiselect-dropdown.scss
+++ b/src/ggrc-client/styles/components/multiselect-dropdown/_multiselect-dropdown.scss
@@ -122,6 +122,6 @@
 
 .multiselect-dropdown_controls {
   .multiselect-dropdown__list {
-      max-height: 150px;
+    max-height: 150px;
   }
 }

--- a/src/ggrc-client/styles/components/multiselect-dropdown/_multiselect-dropdown.scss
+++ b/src/ggrc-client/styles/components/multiselect-dropdown/_multiselect-dropdown.scss
@@ -119,3 +119,9 @@
     }
   }
 }
+
+.multiselect-dropdown_controls {
+  .multiselect-dropdown__list {
+      max-height: 150px;
+  }
+}

--- a/src/ggrc-client/styles/modules/_modal.scss
+++ b/src/ggrc-client/styles/modules/_modal.scss
@@ -960,12 +960,3 @@
 label.second-in-column {
   margin-top:20px;
 }
-
-// Multiselect-dropdown styles in modals
-.modal-body {
-  .multiselect-dropdown {
-    .multiselect-dropdown__list {
-      max-height: 150px;
-    }
-  }
-}

--- a/src/ggrc-client/styles/modules/_modal.scss
+++ b/src/ggrc-client/styles/modules/_modal.scss
@@ -960,3 +960,12 @@
 label.second-in-column {
   margin-top:20px;
 }
+
+// Multiselect-dropdown styles in modals
+.modal-body {
+  .multiselect-dropdown {
+    .multiselect-dropdown__list {
+      max-height: 150px;
+    }
+  }
+}

--- a/src/ggrc/assets/mustache/controls/modal_content.mustache
+++ b/src/ggrc/assets/mustache/controls/modal_content.mustache
@@ -182,11 +182,12 @@
           <i class="fa fa-question-circle" rel="tooltip" title="Select control assertions."></i>
           <a data-id="hide_assertions_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
         </label>
-          <div data-id="assertions_dd" tabindex="12">
+          <div data-id="assertions_dd" tabindex="12" class="no-outline">
             <multiselect-dropdown-wrapper
               {model-name}="'ControlAssertion'"
               {(selected)}="instance.assertions"
-              placeholder="Select Sssertions">
+              placeholder="Select Sssertions"
+              class="multiselect-dropdown_controls">
             </multiselect-dropdown-wrapper>
           </div>
       </div>
@@ -196,11 +197,12 @@
           <i class="fa fa-question-circle" rel="tooltip" title="Select control categories."></i>
           <a data-id="hide_categories_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
         </label>
-          <div data-id="categories_dd" tabindex="13">
+          <div data-id="categories_dd" tabindex="13" class="no-outline">
             <multiselect-dropdown-wrapper
               {model-name}="'ControlCategory'"
               {(selected)}="instance.categories"
-              placeholder="Select Categories">
+              placeholder="Select Categories"
+              class="multiselect-dropdown_controls">
             </multiselect-dropdown-wrapper>
           </div>
       </div>

--- a/src/ggrc/assets/mustache/controls/modal_content.mustache
+++ b/src/ggrc/assets/mustache/controls/modal_content.mustache
@@ -183,7 +183,11 @@
           <a data-id="hide_assertions_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
         </label>
           <div data-id="assertions_dd" tabindex="12">
-            {{{category_select this "assertions" "ControlAssertion"}}}
+            <multiselect-dropdown-wrapper
+              {model-name}="'ControlAssertion'"
+              {(selected)}="instance.assertions"
+              placeholder="Select Sssertions">
+            </multiselect-dropdown-wrapper>
           </div>
       </div>
       <div data-test-id="control_categories_1eb33246" data-id="categories_hidden" class="span4 hidable">
@@ -193,7 +197,11 @@
           <a data-id="hide_categories_lk" href="javascript://" class="field-hide" tabindex="-1">hide</a>
         </label>
           <div data-id="categories_dd" tabindex="13">
-            {{{category_select this "categories" "ControlCategory"}}}
+            <multiselect-dropdown-wrapper
+              {model-name}="'ControlCategory'"
+              {(selected)}="instance.categories"
+              placeholder="Select Categories">
+            </multiselect-dropdown-wrapper>
           </div>
       </div>
     </div>


### PR DESCRIPTION
# Issue description

GGRC-5142 Improve UX for Assertions and Categories elements in Create/Edit modal of Control object.
Unify multi-selects and replace Assertions and Categories multi-selects to multi-select dropdown.

# Steps to test the changes

1. Open a control.
2. Click on Edit Control.
3. Check that multi-selects for Assertions and Categories replaced to multi-select dropdown and work properly.

# Solution description

Create `multiselect-dropdown-wrapper` component, which fetches options before passing them to `multiselect-dropdown`.
Replace `category_select` helper with `multiselect-dropdown-wrapper` component in Control's modal_content.
Remove `category_select` helper.


# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
