### PR TITLE
GGRC-5368 Speed up reindex for newly created snapshots

### DIFF
--- a/src/ggrc/snapshotter/__init__.py
+++ b/src/ggrc/snapshotter/__init__.py
@@ -145,9 +145,12 @@ class SnapshotGenerator(object):
                           revisions=revisions, _filter=_filter)
     updated = result.response
     if not self.dry_run:
-      reindex_pairs(updated)
-      self._copy_snapshot_relationships()
-      self._create_audit_relationships()
+      with benchmark("reindex_pairs on snapshot update"):
+        reindex_pairs(updated)
+      with benchmark("copy snapshot relationships on snapshot update"):
+        self._copy_snapshot_relationships()
+      with benchmark("create audit relationships on snapshot update"):
+        self._create_audit_relationships()
     return result
 
   def _update(self, for_update, event, revisions, _filter):
@@ -307,10 +310,14 @@ class SnapshotGenerator(object):
 
     to_reindex = updated | created
     if not self.dry_run:
-      reindex_pairs(to_reindex)
-      self._remove_lost_snapshot_mappings()
-      self._copy_snapshot_relationships()
-      self._create_audit_relationships()
+      with benchmark("reindex_pairs on snapshot upsert"):
+        reindex_pairs(to_reindex)
+      with benchmark("remove lost snpashot mappings on snapshot upsert"):
+        self._remove_lost_snapshot_mappings()
+      with benchmark("copy snapshot relationships on snapshot upsert"):
+        self._copy_snapshot_relationships()
+      with benchmark("create audit relationships on snapshot upsert"):
+        self._create_audit_relationships()
     return OperationResponse("upsert", True, {
         "create": create,
         "update": update
@@ -342,9 +349,12 @@ class SnapshotGenerator(object):
         revisions=revisions, _filter=_filter)
     created = result.response
     if not self.dry_run:
-      reindex_pairs(created)
-      self._copy_snapshot_relationships()
-      self._create_audit_relationships()
+      with benchmark("reindex_pairs on snapshot create"):
+        reindex_pairs(created)
+      with benchmark("copy snapshot relationships on snapshot create"):
+        self._copy_snapshot_relationships()
+      with benchmark("create audit relationships on snapshot create"):
+        self._create_audit_relationships()
     return result
 
   def _create(self, for_create, event, revisions, _filter):


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

reindex on audit creation if program has about 4k snapshotable objects takes about 40-50 seconds locally. 

# Steps to test the changes

try to create audit on the big program. 

# Solution description

The reason is population cads step on revision content. It takes cads data from memcache. For that amount of objects it works extremely slow. I load cad structure to flask g and load required data not from memcache but from flask.g.  


# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
