### PR TITLE
GGRC-4817 User is able to delete an audit if Assessment template exists in scope of it

### DIFF
--- a/src/ggrc/migrations/versions/20180508145225_9bc9e8064e04_change_relationship_assessment_template_audit_not_null.py
+++ b/src/ggrc/migrations/versions/20180508145225_9bc9e8064e04_change_relationship_assessment_template_audit_not_null.py
@@ -1,0 +1,63 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+"""
+Change relationship between assessment templates and audits not null
+
+Create Date: 2018-05-08 14:52:25.534107
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '9bc9e8064e04'
+down_revision = 'ad7e10f2a917'
+
+
+def remove_assessment_templates():
+  """Remove assessment_templates with empty audit_id"""
+  op.execute("""
+      DELETE ast from assessment_templates ast WHERE ast.audit_id IS NULL
+  """)
+
+
+def alter_constraints():
+  """Update fk_assessment_template_audits constraint"""
+  op.drop_constraint("fk_assessment_template_audits", "assessment_templates",
+                     "foreignkey")
+
+  op.alter_column("assessment_templates", "audit_id",
+                  existing_type=sa.Integer(),
+                  nullable=False)
+
+  op.create_foreign_key(constraint_name="fk_assessment_template_audits",
+                        source_table="assessment_templates",
+                        referent_table="audits",
+                        local_cols=["audit_id"],
+                        remote_cols=["id"])
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  remove_assessment_templates()
+  alter_constraints()
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+
+  op.drop_constraint("fk_assessment_template_audits", "assessment_templates",
+                     "foreignkey")
+
+  op.alter_column("assessment_templates", "audit_id",
+                  existing_type=sa.Integer(),
+                  nullable=True)
+
+  op.create_foreign_key(constraint_name="fk_assessment_template_audits",
+                        source_table="assessment_templates",
+                        referent_table="audits",
+                        local_cols=["audit_id"],
+                        remote_cols=["id"],
+                        ondelete='SET NULL')

--- a/src/ggrc/models/assessment_template.py
+++ b/src/ggrc/models/assessment_template.py
@@ -60,7 +60,7 @@ class AssessmentTemplate(assessment.AuditRelationship, relationship.Relatable,
   default_people = db.Column(JsonType, nullable=False)
 
   # parent audit
-  audit_id = db.Column(db.Integer, db.ForeignKey('audits.id'), nullable=True)
+  audit_id = db.Column(db.Integer, db.ForeignKey('audits.id'), nullable=False)
 
   # labels to show to the user in the UI for various default people values
   DEFAULT_PEOPLE_LABELS = {

--- a/test/integration/ggrc/models/factories.py
+++ b/test/integration/ggrc/models/factories.py
@@ -231,6 +231,7 @@ class AssessmentTemplateFactory(TitledFactory):
   class Meta:
     model = all_models.AssessmentTemplate
 
+  audit = factory.LazyAttribute(lambda m: AuditFactory())
   template_object_type = None
   test_plan_procedure = False
   procedure_description = factory.LazyAttribute(

--- a/test/integration/ggrc_basic_permissions/test_audit_archiving.py
+++ b/test/integration/ggrc_basic_permissions/test_audit_archiving.py
@@ -58,6 +58,10 @@ def _create_obj_dict(obj, audit_id, context_id, assessment_id=None):
               "id": context_id,
               "type": "Context"
           },
+          "audit": {
+              "id": audit_id,
+              "type": "Audit"
+          }
       },
       "relationship": {
           "context": {


### PR DESCRIPTION
# Issue description

User is able to delete an audit if Assessment template exists in scope of it

# Steps to test the changes

1. Create a program, audit
2. Open audit page
3. Create Assessment template
4. Go to Assessment template Info page > Audit tab
5. Click Delete button in 3 bb's menu

Expected Result:
Do not allow user to delete an Audit unless all the Assessment Templates in scope of this Audit are deleted (same behavior as for Assessments)

# Solution description
Update assessment_templates db table
1) `audit_id` int(11) NOT NULL
2) CONSTRAINT fk_assessment_template_audits

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# Migration checklist
- [x] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
