### PR TITLE
GGRC-5291 Add HEAD request handler

### DIFF
--- a/test/integration/ggrc/api_helper.py
+++ b/test/integration/ggrc/api_helper.py
@@ -132,6 +132,9 @@ class Api(object):
   def get(self, obj, id_):
     return self.data_to_json(self.client.get(self.api_link(obj, id_)))
 
+  def head(self, obj, id_):
+    return self.data_to_json(self.client.head(self.api_link(obj, id_)))
+
   def get_collection(self, obj, ids):
     return self.data_to_json(self.client.get(
         "{}?ids={}".format(self.api_link(obj), ids)))

--- a/test/integration/ggrc/services/test_head.py
+++ b/test/integration/ggrc/services/test_head.py
@@ -1,0 +1,56 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Test HEAD request
+"""
+import ddt
+
+from ggrc import utils
+from ggrc.models import all_models
+from ggrc.services import common
+from integration.ggrc import TestCase
+from integration.ggrc.api_helper import Api
+from integration.ggrc.models import factories
+
+
+@ddt.ddt
+class TestHeadRequest(TestCase):
+  """Test HEAD request."""
+
+  def setUp(self):
+    super(TestHeadRequest, self).setUp()
+    self.api = Api()
+
+  @ddt.data(
+      all_models.Control,
+      all_models.Objective,
+      all_models.Audit,
+      all_models.Assessment,
+      all_models.Program,
+      all_models.Issue,
+  )
+  def test_head_etag(self, model):
+    """Test correctness of HEAD request processing for {}"""
+    obj = factories.get_model_factory(model.__name__)()
+    response = self.api.head(model, obj.id)
+    self.assert200(response)
+    self.assertEqual(response.data, "")
+    exp_etag = common.etag(getattr(obj, "updated_at"), common.get_info(obj))
+    self.assertEqual(response.headers.get("Etag"), exp_etag)
+
+  @ddt.data(
+      all_models.Control,
+      all_models.Objective,
+      all_models.Audit,
+      all_models.Assessment,
+      all_models.Program,
+      all_models.Issue,
+  )
+  def test_query_count(self, model):
+    """Test count of queries on HEAD request processing for {}"""
+    obj_id = factories.get_model_factory(model.__name__)().id
+    with utils.QueryCounter() as counter:
+      response = self.api.head(model, obj_id)
+      self.assert200(response)
+      self.assertEqual(counter.get, 3)


### PR DESCRIPTION
# Issue description

Need to add possibility to send HEAD request in cases when need to get ETag only.
In that case we will avoid loading of unneeded data and improve performance.

# Steps to test the changes

Send HEAD request to "/api/<model>/<id>". Check correctness of response (valid ETag, empty body). Check that only required queries are loaded during HEAD request processing.

# Solution description

Add new handler for HEAD requests.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
