### PR TITLE
GGRC-5362 Support aliases for IN operator

### DIFF
--- a/src/ggrc/query/custom_operators.py
+++ b/src/ggrc/query/custom_operators.py
@@ -356,17 +356,12 @@ def or_operation(exp, object_class, target_class, query):
 
 
 @validate("left", "right")
-def in_operation(exp, object_class, target_class, query):
-  """Operator generate sqlalchemy for in operation"""
-  if not exp["right"]:
+@build_op_shortcut
+def in_operation(left, right):
+  """IN operator."""
+  if not right:
     return sqlalchemy.sql.false()
-  return object_class.id.in_(
-      db.session.query(Record.key).filter(
-          Record.type == object_class.__name__,
-          Record.property == exp["left"],
-          Record.content.in_(exp["right"])
-      )
-  )
+  return left.in_(right)
 
 
 @validate("issue", "assessment")

--- a/test/integration/ggrc/services/test_query/test_in.py
+++ b/test/integration/ggrc/services/test_query/test_in.py
@@ -27,6 +27,8 @@ class TestIn(TestCase, WithQueryApi):
     self.title_id_map = {ob.title: ob.id for ob in test_objects}
 
   @ddt.data(("Control", "status", ["Draft"], ["c1", "c2"]),
+            ("Control", "State", ["Draft"], ["c1", "c2"]),
+            ("Control", "State", ["Draft", "Active"], ["c1", "c2", "c3"]),
             ("Control", "title", ["c1", "c2"], ["c1", "c2"]),
             ("Control", "title", [], []),
             ("Control", "status", ["Fake_status"], []),


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Impossible to filter by `"Stask State" in [anything]"`. (note: this isn't the actual text of the query, you have to build the tree equivalent to `self._make_query_dict("CycleTaskGroupObjectTask", expression=["Task State", "IN", [...]])`).

# Steps to test the changes

Check that state dropdown filter for cycle tasks works.

# Solution description

Instead of doing a special operator, use the common wrapper `build_op_shortcut`.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
