### PR TITLE
GGRC-5055 Date picker is cut off in New Control popup

### DIFF
--- a/src/ggrc-client/js/components/simple-modal/simple-modal.js
+++ b/src/ggrc-client/js/components/simple-modal/simple-modal.js
@@ -24,6 +24,7 @@ import template from './simple-modal.mustache';
       modalTitle: '',
       replaceContent: false,
       isDisabled: false,
+      modalWrapper: null,
       state: {
         open: false,
       },
@@ -33,21 +34,25 @@ import template from './simple-modal.mustache';
       show: function () {
         this.attr('state.open', true);
       },
+      showHideModal(showModal) {
+        const $modalWrapper = this.attr('modalWrapper');
+        if (showModal) {
+          $modalWrapper.modal().on('hidden.bs.modal', this.hide.bind(this));
+        } else {
+          $modalWrapper.modal('hide').off('hidden.bs.modal');
+        }
+      },
     },
-    helpers: {
-      modalWrapper: function (showContent) {
-        return (el) => {
-          let showHideModal = (val) => {
-            if (val) {
-              $(el).modal().on('hidden.bs.modal', this.hide.bind(this));
-            } else {
-              $(el).modal('hide').off('hidden.bs.modal');
-            }
-          };
-
-          showContent.bind('change', (ev, val) => showHideModal(val));
-          showHideModal(showContent);
-        };
+    events: {
+      inserted() {
+        const viewModel = this.viewModel;
+        const modalWrapper = this.element
+          .find('[data-modal-wrapper-target="true"]');
+        viewModel.attr('modalWrapper', modalWrapper);
+        viewModel.showHideModal(viewModel.attr('state.open'));
+      },
+      '{viewModel.state} open'(state, ev, newValue) {
+        this.viewModel.showHideModal(newValue);
       },
     },
   });

--- a/src/ggrc-client/js/components/simple-modal/simple-modal.mustache
+++ b/src/ggrc-client/js/components/simple-modal/simple-modal.mustache
@@ -3,7 +3,7 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
 
-<div {{modalWrapper state.open}}>
+<div data-modal-wrapper-target="true">
     {{#state.open}}
     <div class="simple-modal__overlay">
         <div class="simple-modal {{extraCssClass}}">

--- a/src/ggrc-client/js/components/unified-mapper/mapper-results.js
+++ b/src/ggrc-client/js/components/unified-mapper/mapper-results.js
@@ -62,7 +62,9 @@ export default GGRC.Components('mapperResults', {
     applyOwnedFilter: false,
     objectsPlural: false,
     relatedAssessments: {
-      state: {},
+      state: {
+        open: false,
+      },
       instance: null,
       show: false,
     },


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Date picker is cut off in New Control popup.

# Steps to test the changes

**Steps to reproduce:**
1. Log as Admin user and go to Administration page
2. Add mandatory custom attribute with date type.
3. Invoke new control popup from mapper as you can see on screenshot (click Map -> within the mapper, click Create and map new object).
Note 1: "Create and map new object" link should be clicked before the moment, when the data for mapper's tree view will be loaded.
Note 2: This ticket is reproducible, when mapper's items have "Assessments" button.
4. Click on ca with date type
**Actual Result**: Date picker is cut off in New Control popup
**Expected Result**: Date picker should not be cut off in New Control popup

![image](https://user-images.githubusercontent.com/13063442/41596024-9629e922-73d1-11e8-9d7c-f6697db199ef.png)

# Solution description

The issue was due to the method `show` from `modal-ajax.js` added `overflow: hidden`(https://github.com/google/ggrc-core/blob/dev/src/ggrc-client/js/bootstrap/modal-ajax.js#L338) for modal. 

How it was resolved:

When `mapper` is opening, the items for it start to be loaded. 
These items can have different configurations, depending on, for example, their type (`Control`, `Objective` ...).
Several types have ability to show "Assessments" button within each mapper's tree-view item:
![image](https://user-images.githubusercontent.com/13063442/41597149-4d27cd4e-73d5-11e8-8b92-f06223d4bc46.png)
This button manages `simple-modal` component, which shows related assessments for the object.
When someone tries to open mapper with type, which can show "Assessments" button, `simple-modal` component will be initialized for each mapper's tree-view item. 
`simple-modal` inside itself wraps the content in `Bootstrap`'s modal.

Thus, we get next situation:
1. Mapper is opening, items for mapper are not loaded.
2. "Create and map new object" link is clicked, items for mapper are not loaded.
3. "Create" modal is shown **on top of all modals**, items for mapper are not loaded.
4. **Items for mapper are loaded**, for each items are created separate `simple-modal` components.
5. `simple-modal` components wraps inner content in `Bootstrap`'s modal.
5.1 The wrapper code tries to find top modal and set several properties for it. On of them is overflow = hidden. As far as we know from 3 point, on top is "Create" modal.

Regarding to this PR, this line 
(https://github.com/google/ggrc-core/commit/71085f6470a0c2bcafdb51fc0cbc4d833c84fde3?diff=split#diff-6421956181797669b55207a7c3db099dR49) was fixed - we should pass `true/false` values to this method, not an object. After it, the code, which tries to find top modal, will be inactive after mapper's items loading.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
