### PR TITLE
GGRC-5395 GGRC-DEV shows Server Error

### DIFF
--- a/src/ggrc/migrations/versions/20180604140037_b1dbfad3bbad_create_missing_admins.py
+++ b/src/ggrc/migrations/versions/20180604140037_b1dbfad3bbad_create_missing_admins.py
@@ -22,6 +22,7 @@ down_revision = '3a41fc031f53'
 
 def create_doc_temporary_table():
   """Tmp table to store document.id without Admins"""
+  op.execute("SET AUTOCOMMIT = 1")
   sql = """
       CREATE TEMPORARY TABLE documents_wo_admins (
         id int(11) NOT NULL
@@ -84,6 +85,7 @@ def upgrade():
                                  document_admin_role_id)
   add_doc_to_missing_revisions(connection)
   op.execute("DROP TABLE documents_wo_admins")
+  op.execute("SET AUTOCOMMIT = 0")
 
 
 def downgrade():

--- a/src/ggrc/migrations/versions/20180605090010_ad7e10f2a917_create_missing_evidence_admins.py
+++ b/src/ggrc/migrations/versions/20180605090010_ad7e10f2a917_create_missing_evidence_admins.py
@@ -30,6 +30,7 @@ def get_evidence_admin_role_id(connection):
 
 def create_evid_temporary_table():
   """Tmp table to store evidence.id without Admins"""
+  op.execute("SET AUTOCOMMIT = 1")
   sql = """
         CREATE TEMPORARY TABLE evidence_wo_admins (
           id int(11) NOT NULL
@@ -88,6 +89,7 @@ def upgrade():
                                  evidence_admin_role_id)
   add_evidence_to_missing_revisions(connection)
   op.execute("DROP TABLE evidence_wo_admins")
+  op.execute("SET AUTOCOMMIT = 0")
 
 
 def downgrade():


### PR DESCRIPTION
# Issue description

GGRC-DEV shows Server Error
Migration was not completed because of enforce_gtid_consistency=ON setup at CloudSQL

# Steps to test the changes
Check that migrations run successfully at test instance
# Solution description

Add SET AUTOCOMMIT = 1 in the migration scripts

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
