### PR TITLE
GGRC-5402 Remove contexts from automapper

### DIFF
--- a/src/ggrc/automapper/__init__.py
+++ b/src/ggrc/automapper/__init__.py
@@ -16,7 +16,7 @@ from ggrc.models.automapping import Automapping
 from ggrc.models.relationship import Relationship, RelationshipsCache, Stub
 from ggrc.models.issue import Issue
 from ggrc.models import exceptions
-from ggrc.rbac.permissions import is_allowed_update
+from ggrc.rbac import permissions
 from ggrc.models.cache import Cache
 from ggrc.utils import benchmark
 
@@ -107,16 +107,7 @@ class AutomapperGenerator(object):
   @staticmethod
   def _can_map_to(obj, parent_relationship):
     """True if the current user can edit obj in parent_relationship.context."""
-    context_id = None
-    if parent_relationship.context:
-      context_id = parent_relationship.context.id
-    elif parent_relationship.context_id:
-      logger.warning("context is unset but context_id is set on a "
-                     "relationship %r: context=%r, context_id=%r",
-                     parent_relationship, parent_relationship.context,
-                     parent_relationship.context_id)
-      context_id = parent_relationship.context_id
-    return is_allowed_update(obj.type, obj.id, context_id)
+    return permissions.is_allowed_update(obj.type, obj.id, None)
 
   def _flush(self, parent_relationship):
     """Manually INSERT generated automappings."""

--- a/src/ggrc/automapper/__init__.py
+++ b/src/ggrc/automapper/__init__.py
@@ -197,8 +197,8 @@ class AutomapperGenerator(object):
     if mappings:
       dst_related = (o for o in self.related(dst)
                      if o.type in mappings and o != src)
-      for r in dst_related:
-        entry = self.order(r, src)
+      for related in dst_related:
+        entry = self.order(related, src)
         if entry not in self.processed:
           self.queue.add(entry)
 
@@ -231,7 +231,7 @@ class AutomapperGenerator(object):
     """Fail if dst (Issue) is already mapped to an Audit."""
     # src, dst are ordered since they come from self.queue
     if (src.type, dst.type) == ("Audit", "Issue"):
-      if "Audit" in (r.type for r in self.related(dst)):
+      if "Audit" in (related.type for related in self.related(dst)):
         raise exceptions.ValidationError(
             "This request will result in automapping that will map "
             "Issue#{issue.id} to multiple Audits."

--- a/src/ggrc/automapper/__init__.py
+++ b/src/ggrc/automapper/__init__.py
@@ -4,7 +4,6 @@
 """Automapper generator."""
 
 from datetime import datetime
-from logging import getLogger
 
 import sqlalchemy as sa
 
@@ -19,10 +18,6 @@ from ggrc.models import exceptions
 from ggrc.rbac import permissions
 from ggrc.models.cache import Cache
 from ggrc.utils import benchmark
-
-
-# pylint: disable=invalid-name
-logger = getLogger(__name__)
 
 
 class AutomapperGenerator(object):
@@ -84,8 +79,8 @@ class AutomapperGenerator(object):
           # Since Issue-Assessment-Audit is the only rule that
           # triggers Issue to Audit mapping, we should skip the
           # permission check for it
-          if not (self._can_map_to(src, relationship) and
-                  self._can_map_to(dst, relationship)):
+          if not (permissions.is_allowed_update(src.type, src.id, None) and
+                  permissions.is_allowed_update(dst.type, dst.id, None)):
             continue
 
         created = self._ensure_relationship(src, dst)
@@ -103,11 +98,6 @@ class AutomapperGenerator(object):
         relationship._json_extras = {  # pylint: disable=protected-access
             'automapping_limit_exceeded': True
         }
-
-  @staticmethod
-  def _can_map_to(obj, parent_relationship):
-    """True if the current user can edit obj in parent_relationship.context."""
-    return permissions.is_allowed_update(obj.type, obj.id, None)
 
   def _flush(self, parent_relationship):
     """Manually INSERT generated automappings."""


### PR DESCRIPTION
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [x] https://github.com/google/ggrc-core/pull/8003

Note: Only the last two commits belongs to this PR.

# Issue description

We must remove context checks form our code and this in this PR we remove them from automappings code

Note: Relationships created by automappings still contain context_ids and those will be removed when we remove contexts from the relationship model.


# Steps to test the changes

Check rbac on automappings.

# Solution description

Remove contexts from permission checks in automappings code.

I have not found any specification on how rbac on automappings should work, but I have verified that there should be no differences between current dev branch and this PR.

Checks were done by checking differences between mapping to a program by a Reader, Creator and Admin, where creator/reader did not see/have access to all objects in the automappings chain.

Checks were also done for Editor, and the entire automappings chain was created the same as for Admin user.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
