### PR TITLE
GGRC-5382 Cannot delete an audit

### DIFF
--- a/src/ggrc/migrations/versions/20180620152957_2da3b90cf88e_delete_invalid_issue_tracked_issues.py
+++ b/src/ggrc/migrations/versions/20180620152957_2da3b90cf88e_delete_invalid_issue_tracked_issues.py
@@ -1,0 +1,29 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Delete invalid issue tracked issues
+
+Create Date: 2018-06-20 15:29:57.068930
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '2da3b90cf88e'
+down_revision = '9bc9e8064e04'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  sql = """
+    DELETE FROM issuetracker_issues
+    WHERE object_id = 0 and object_type = "Audit"
+  """
+  op.execute(sql)
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""

--- a/src/ggrc/models/issuetracker_issue.py
+++ b/src/ggrc/models/issuetracker_issue.py
@@ -202,4 +202,5 @@ class IssueTracked(object):
         IssuetrackerIssue,
         primaryjoin=join_function,
         backref="{}_issue_tracked".format(cls.__name__),
+        cascade='all, delete-orphan'
     )

--- a/test/integration/ggrc/integrations/test_issuetracker_issue.py
+++ b/test/integration/ggrc/integrations/test_issuetracker_issue.py
@@ -275,6 +275,29 @@ class TestIssueTrackerIntegration(SnapshotterBaseTestCase):
       ]))
       self._check_csv_response(response, {})
 
+  @mock.patch('ggrc.integrations.issues.Client.create_issue')
+  def test_audit_delete(self, mock_create_issue):
+    """Test deletion of an audit."""
+    with mock.patch.object(issue_tracker, '_is_issue_tracker_enabled',
+                           return_value=True):
+      audit = factories.AuditFactory()
+      factories.IssueTrackerIssueFactory(
+          issue_tracked_obj=audit,
+          component_id="some id",
+          hotlist_id="some host id",
+      )
+      result = self.api.delete(audit)
+      self.assert200(result)
+
+      audit = factories.AuditFactory()
+      factories.IssueTrackerIssueFactory(
+          issue_tracked_obj=audit,
+          component_id="some id",
+          hotlist_id="some host id",
+      )
+      result = self.api.delete(audit)
+      self.assert200(result)
+
 
 @mock.patch('ggrc.models.hooks.issue_tracker._is_issue_tracker_enabled',
             return_value=True)


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

The deletion of an audit of failing.

# Steps to test the changes

Steps to reproduce (on sql dump):
1. Create a new program and audit.
2. Open its Info Pane.
3. Click "Delete" button in 3 bb's menu
Actual result: Audit is not removed, exception appears in UI
Expected result: Audit should be removed

Steps to reproduce (on clear database):
1. Create new program and 2 audits
2. Delete the first audit (successfully)
3. Delete the second audit
Actual result: Audit is not removed, exception appears in UI
Expected result: Audit should be removed

# Solution description

Make relationships use cascade during deletion

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# Migration checklist
- [x] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
