### PR TITLE
GGRC-5389 Can't attach evidence file when assessment is in 'Rework Needed' state

### DIFF
--- a/test/integration/ggrc/models/mixins/test_autostatuschangable_evidence.py
+++ b/test/integration/ggrc/models/mixins/test_autostatuschangable_evidence.py
@@ -27,7 +27,9 @@ class TestEvidences(asc.TestMixinAutoStatusChangeableBase):
       ('FILE', models.Assessment.START_STATE,
        models.Assessment.PROGRESS_STATE),
       ('FILE', models.Assessment.FINAL_STATE,
-       models.Assessment.PROGRESS_STATE)
+       models.Assessment.PROGRESS_STATE),
+      ('FILE', models.Assessment.REWORK_NEEDED,
+       models.Assessment.REWORK_NEEDED)
   )
   @ddt.unpack
   def test_map_parent(self, kind,
@@ -57,7 +59,9 @@ class TestEvidences(asc.TestMixinAutoStatusChangeableBase):
       ('FILE', models.Assessment.START_STATE,
        models.Assessment.PROGRESS_STATE),
       ('FILE', models.Assessment.FINAL_STATE,
-       models.Assessment.PROGRESS_STATE)
+       models.Assessment.PROGRESS_STATE),
+      ('FILE', models.Assessment.REWORK_NEEDED,
+       models.Assessment.REWORK_NEEDED)
   )
   @ddt.unpack
   def test_evidence_added_status_check(self, kind,
@@ -93,7 +97,9 @@ class TestEvidences(asc.TestMixinAutoStatusChangeableBase):
       ('FILE', models.Assessment.START_STATE,
        models.Assessment.PROGRESS_STATE),
       ('FILE', models.Assessment.FINAL_STATE,
-       models.Assessment.PROGRESS_STATE)
+       models.Assessment.PROGRESS_STATE),
+      ('FILE', models.Assessment.REWORK_NEEDED,
+       models.Assessment.REWORK_NEEDED)
   )
   @ddt.unpack
   def test_evidence_remove_related(self, kind,
@@ -131,7 +137,9 @@ class TestEvidences(asc.TestMixinAutoStatusChangeableBase):
       ('FILE', models.Assessment.START_STATE,
        models.Assessment.PROGRESS_STATE),
       ('FILE', models.Assessment.FINAL_STATE,
-       models.Assessment.PROGRESS_STATE)
+       models.Assessment.PROGRESS_STATE),
+      ('FILE', models.Assessment.REWORK_NEEDED,
+       models.Assessment.REWORK_NEEDED)
   )
   @ddt.unpack
   def test_evidence_delete(self, kind, from_status,
@@ -162,7 +170,9 @@ class TestEvidences(asc.TestMixinAutoStatusChangeableBase):
       ('FILE', models.Assessment.START_STATE,
        models.Assessment.PROGRESS_STATE),
       ('FILE', models.Assessment.FINAL_STATE,
-       models.Assessment.PROGRESS_STATE)
+       models.Assessment.PROGRESS_STATE),
+      ('FILE', models.Assessment.REWORK_NEEDED,
+       models.Assessment.REWORK_NEEDED)
   )
   @ddt.unpack
   def test_evidence_update_status_check(self, kind, from_status,


### PR DESCRIPTION
# Issue description

Can't attach evidence file when assessment is in 'Rework Needed' state

# Steps to test the changes
1. Open any audit page
2. Create assessment with verifier
3. Expand assessment info panel and move assessment to 'Rework Needed' state
4. Attach evidence file to assessment
Expected Result: Evidence file should be attached if assessment is in 'Rework Needed' state

# Solution description

Changed way how we change evidence parent status from direct call to send signal.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
