### PR TITLE
GGRC-5434 Fix deployment blocker with duplicate revisions

### DIFF
--- a/src/ggrc/migrations/utils/__init__.py
+++ b/src/ggrc/migrations/utils/__init__.py
@@ -230,6 +230,10 @@ def create_missing_admins(connection, migration_user_id, admin_role_id,
 
   If we have 'create' revision -> take modified_by_id as Admin
   else set current migration user as Admin
+
+  If there are multiple 'create' revisions, take each distinct modified_by_id
+  as Admin, because there is no way of knowing which of the duplicate revisions
+  is correct.
   """
   sql = """
       INSERT INTO access_control_list (
@@ -242,9 +246,9 @@ def create_missing_admins(connection, migration_user_id, admin_role_id,
         updated_at)
       SELECT
         IF(r.modified_by_id is NOT NULL,
-           r.modified_by_id, {migration_user_id}),
+           r.modified_by_id, {migration_user_id}) as person_id,
         :admin_role_id,
-        twoa.id,
+        twoa.id as object_id,
         :object_type,
         NOW(),
         :migration_user_id,
@@ -254,6 +258,7 @@ def create_missing_admins(connection, migration_user_id, admin_role_id,
           r.resource_id=twoa.id
           AND r.resource_type=:object_type
           AND r.action=:revision_action
+      GROUP BY object_id, person_id
   """.format(migration_user_id=migration_user_id,
              table_mame=table_mame)
   connection.execute(

--- a/src/ggrc/migrations/utils/__init__.py
+++ b/src/ggrc/migrations/utils/__init__.py
@@ -234,6 +234,14 @@ def create_missing_admins(connection, migration_user_id, admin_role_id,
   If there are multiple 'create' revisions, take each distinct modified_by_id
   as Admin, because there is no way of knowing which of the duplicate revisions
   is correct.
+
+  Args:
+    connection: SQLAlchemy connection object;
+    migration_user_id: the id of Migrator user (used as a default Admin);
+    admin_role_id: ACR.id of the correct Admin role;
+    table_name: name of the table with ids of objects with no Admins;
+    object_type: string name of object type processed (e.g. 'Document');
+    revision_action: the value for Revision.action field (e.g. 'created').
   """
   sql = """
       INSERT INTO access_control_list (


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

If there are multiple "created" revisions for a Document (Evidence) with no Admin, the migration to restore Admins violates unique constraint on the ACL table.

# Steps to test the changes

1. Remove the Admin record from three Document objects.
2. For the first Document object, remove all revisions for it.
3. For the second Document object, manually INSERT a new Revision with fields same as its "created" revision (only `resource_id`, `resource_type`, `action`, `event_id`, `modified_by_id` matter).
4. For the third Document object, manually INSERT a new Revision with fields same as its "created" revision but with a different `modified_by_id` value.
5. Run the migration to populate Admins on Documents.

Actual result: manipulations from steps 3 and 4 break the migration.
Expected result: the first Document gets the migrator as Admin, the second gets the person mentioned in `modified_by_id` in its "created" revision, the third gets both different people mentioned in `modified_by_id` in its two "created" revisions.

# Solution description

GROUP BY to avoid violation of UNIQUE constraint.

As an additional validation step I removed all Admins from all Documents and Evidence and ran the migrations for Admins. The migrations passed successfully, so it appears we don't have any more blocking data corruptions on our dev DB.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
