### PR TITLE
GGRC-5178 Fix memory leak for comments form

### DIFF
--- a/src/ggrc-client/js/components/object-list/object-list.mustache
+++ b/src/ggrc-client/js/components/object-list/object-list.mustache
@@ -19,11 +19,11 @@
           </div>
         </show-more>
       {{else}}
-        {{#items}}
+        {{#each items}}
           <div class="object-list__item {{#isSelected}}object-list__item-selected{{/isSelected}}" ($click)="modifySelection">
               <content>No item component or template is provided</content>
           </div>
-        {{/items}}
+        {{/each}}
       {{/if}}
   {{else}}
       <div class="object-list__item object-list__item-empty">


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Issue connected to render the`comments` list.
Items render again after each adding of new comment

# Steps to test the changes

Create and open an assessment in Chrome
Open performance monitor in Chrome dev tools
Add a lot of comments (for example 100)

_Actual result:_ JS heap size and number of DOM Nodes values are high.

# Solution description

1. Use {{#each key}} helper instead of {{#key}}
https://v2.canjs.com/docs/can.mustache.helpers.section.html

2. Improve performance of `afterCreate` method (info-pane.js) (Removed unneeded `Array.replace`)
Previous version of implementation `afterCreate` updated 1 item from collection and then invokes `replace`. This `replace` triggers redraw of all items.

# Results

**Data set**: 600 comments
**Actions**: adding of 3 new comments

| Param description  | Before fix | After fix |
| ------------- | ------------- |  ------------- |
| Execute time of `addItem` method (info-pane.js) for each adding  | 9500-1000ms | 10-20ms |
| Execute time of `afterCreate` method (info-pane.js) for each adding | 9500-1000ms | 10-20ms |
| JS heap size / DOM Nodes / Listeners | ![before_fix](https://user-images.githubusercontent.com/4204416/42083627-1e70a086-7b94-11e8-9933-6ca465dcb374.png) | ![after_fix](https://user-images.githubusercontent.com/4204416/42083635-2374803e-7b94-11e8-91db-ccc5b163617a.png)|
| First render of full page  |![render_of_all_comments_before](https://user-images.githubusercontent.com/4204416/42083731-69981a6c-7b94-11e8-9248-b58d25a490e0.png) **~8 sec** |![render_of_all_comments_after](https://user-images.githubusercontent.com/4204416/42083771-7ec5ccf4-7b94-11e8-89b5-74905e54a6be.png) **~11 sec**|

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
