### PR TITLE
QUICK-FIX Update tests for advanced-search-filter components

### DIFF
--- a/src/ggrc-client/js/components/advanced-search/tests/advanced-search-filter-attribute_spec.js
+++ b/src/ggrc-client/js/components/advanced-search/tests/advanced-search-filter-attribute_spec.js
@@ -3,16 +3,17 @@
   Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 */
 
+import {getComponentVM} from '../../../../js_specs/spec_helpers';
 import Component from '../advanced-search-filter-attribute';
 
-describe('GGRC.Components.advancedSearchFilterAttribute', function () {
+describe('advanced-search-filter-attribute component', function () {
   'use strict';
 
   let viewModel;
   let events;
 
   beforeEach(() => {
-    viewModel = new Component.prototype.viewModel();
+    viewModel = getComponentVM(Component);
     events = Component.prototype.events;
   });
 

--- a/src/ggrc-client/js/components/advanced-search/tests/advanced-search-filter-container_spec.js
+++ b/src/ggrc-client/js/components/advanced-search/tests/advanced-search-filter-container_spec.js
@@ -5,9 +5,10 @@
 
 import * as StateUtils from '../../../plugins/utils/state-utils';
 import * as AdvancedSearch from '../../../plugins/utils/advanced-search-utils';
+import {getComponentVM} from '../../../../js_specs/spec_helpers';
 import Component from '../advanced-search-filter-container';
 
-describe('GGRC.Components.advancedSearchFilterContainer', function () {
+describe('advanced-search-filter-container component', function () {
   'use strict';
 
   let viewModel;
@@ -15,7 +16,7 @@ describe('GGRC.Components.advancedSearchFilterContainer', function () {
   beforeEach(() => {
     spyOn(StateUtils, 'getDefaultStatesForModel')
       .and.returnValue(['state']);
-    viewModel = new Component.prototype.viewModel();
+    viewModel = getComponentVM(Component);
   });
 
   describe('items get() method', function () {

--- a/src/ggrc-client/js/components/advanced-search/tests/advanced-search-filter-group_spec.js
+++ b/src/ggrc-client/js/components/advanced-search/tests/advanced-search-filter-group_spec.js
@@ -4,15 +4,16 @@
 */
 
 import * as AdvancedSearch from '../../../plugins/utils/advanced-search-utils';
+import {getComponentVM} from '../../../../js_specs/spec_helpers';
 import Component from '../advanced-search-filter-group';
 
-describe('GGRC.Components.advancedSearchFilterGroup', function () {
+describe('advanced-search-filter-group component', function () {
   'use strict';
 
   let viewModel;
 
   beforeEach(() => {
-    viewModel = Component.prototype.viewModel();
+    viewModel = getComponentVM(Component);
   });
 
   describe('addFilterCriterion() method', function () {

--- a/src/ggrc-client/js/components/advanced-search/tests/advanced-search-filter-state_spec.js
+++ b/src/ggrc-client/js/components/advanced-search/tests/advanced-search-filter-state_spec.js
@@ -4,15 +4,16 @@
 */
 
 import * as StateUtils from '../../../plugins/utils/state-utils';
+import {getComponentVM} from '../../../../js_specs/spec_helpers';
 import Component from '../advanced-search-filter-state';
 
-describe('GGRC.Components.advancedSearchFilterState', function () {
+describe('advanced-search-filter-state component', function () {
   'use strict';
 
   let viewModel;
 
   beforeEach(() => {
-    viewModel = new Component.prototype.viewModel();
+    viewModel = getComponentVM(Component);
   });
 
   describe('stateModel set() method', function () {

--- a/src/ggrc-client/js/components/advanced-search/tests/advanced-search-mapping-container_spec.js
+++ b/src/ggrc-client/js/components/advanced-search/tests/advanced-search-mapping-container_spec.js
@@ -4,15 +4,16 @@
 */
 
 import * as AdvancedSearch from '../../../plugins/utils/advanced-search-utils';
+import {getComponentVM} from '../../../../js_specs/spec_helpers';
 import Component from '../advanced-search-mapping-container';
 
-describe('GGRC.Components.advancedSearchMappingContainer', function () {
+describe('advanced-search-mapping-container component', function () {
   'use strict';
 
   let viewModel;
 
   beforeEach(() => {
-    viewModel = new Component.prototype.viewModel();
+    viewModel = getComponentVM(Component);
   });
 
   describe('addMappingCriteria() method', function () {

--- a/src/ggrc-client/js/components/advanced-search/tests/advanced-search-mapping-criteria_spec.js
+++ b/src/ggrc-client/js/components/advanced-search/tests/advanced-search-mapping-criteria_spec.js
@@ -5,16 +5,17 @@
 
 import * as TreeViewUtils from '../../../plugins/utils/tree-view-utils';
 import * as AdvancedSearch from '../../../plugins/utils/advanced-search-utils';
+import {getComponentVM} from '../../../../js_specs/spec_helpers';
 import Component from '../advanced-search-mapping-criteria';
 import Mappings from '../../../models/mappers/mappings';
 
-describe('GGRC.Components.advancedSearchMappingCriteria', function () {
+describe('advanced-search-mapping-criteria component', function () {
   'use strict';
 
   let viewModel;
 
   beforeEach(() => {
-    viewModel = new Component.prototype.viewModel();
+    viewModel = getComponentVM(Component);
   });
 
   describe('criteria set() method', function () {

--- a/src/ggrc-client/js/components/advanced-search/tests/advanced-search-mapping-group_spec.js
+++ b/src/ggrc-client/js/components/advanced-search/tests/advanced-search-mapping-group_spec.js
@@ -4,15 +4,16 @@
 */
 
 import * as AdvancedSearch from '../../../plugins/utils/advanced-search-utils';
+import {getComponentVM} from '../../../../js_specs/spec_helpers';
 import Component from '../advanced-search-mapping-group';
 
-describe('GGRC.Components.advancedSearchMappingGroup', function () {
+describe('advanced-search-mapping-group component', function () {
   'use strict';
 
   let viewModel;
 
   beforeEach(() => {
-    viewModel = new Component.prototype.viewModel();
+    viewModel = getComponentVM(Component);
   });
 
   describe('addMappingCriteria() method', function () {

--- a/src/ggrc-client/js/components/advanced-search/tests/advanced-search-wrapper_spec.js
+++ b/src/ggrc-client/js/components/advanced-search/tests/advanced-search-wrapper_spec.js
@@ -3,15 +3,16 @@
   Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 */
 
+import {getComponentVM} from '../../../../js_specs/spec_helpers';
 import Component from '../advanced-search-wrapper';
 
-describe('GGRC.Components.advancedSearchWrapper', function () {
+describe('advanced-search-wrapper component', function () {
   'use strict';
 
   let viewModel;
   let events;
   beforeEach(() => {
-    viewModel = new Component.prototype.viewModel();
+    viewModel = getComponentVM(Component);
     events = Component.prototype.events;
   });
 


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Update names for unit tests.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [ ] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
