### PR TITLE
GGRC-5433 Fix ACL with wrong ACR

### DIFF
--- a/src/ggrc/access_control/roleable.py
+++ b/src/ggrc/access_control/roleable.py
@@ -208,3 +208,16 @@ class Roleable(object):
               if (i.ac_role and i.ac_role.id == role_id) or
               (i.ac_role_id and i.ac_role_id == role_id)]
     return []
+
+  def validate_acl(self):
+    """Check correctness of access_control_list."""
+    for acl in self.access_control_list:
+      if acl.ac_role.object_type != "Workflow" and \
+         acl.object_type != acl.ac_role.object_type:
+        raise ValueError(
+            "Access control list has different object_type '{}' with "
+            "access control role '{}'".format(
+                acl.object_type,
+                acl.ac_role.object_type
+            )
+        )

--- a/src/ggrc/migrations/versions/20180627150313_26488ecb342a_fix_acr_ids_in_acl.py
+++ b/src/ggrc/migrations/versions/20180627150313_26488ecb342a_fix_acr_ids_in_acl.py
@@ -1,0 +1,86 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Fix ACR ids in ACL.
+
+Create Date: 2018-06-27 15:03:13.237675
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '26488ecb342a'
+down_revision = '0e40a37a05f4'
+
+
+def create_acl_temporary_table():
+  """Temporary table to keep corrected ACL entries."""
+  op.execute("SET AUTOCOMMIT = 1;")
+  op.execute("""
+      CREATE TEMPORARY TABLE updated_acl (
+          id int(11) NOT NULL,
+          object_id int(11) NOT NULL,
+          object_type varchar(250) NOT NULL,
+          ac_role_id int(11) NOT NULL,
+          person_id int(11) NOT NULL,
+          parent_id_nn int(11)
+      );
+  """)
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  create_acl_temporary_table()
+
+  # Fix wrong ac_role_id in access_control_list only for items without
+  # parent (parent_id is null). Items with parent will be fixed by
+  # acl repropagation.
+  # Note: this migration should not affect Workflow scope.
+  op.execute("""
+      INSERT INTO updated_acl (
+        id, object_id, object_type, ac_role_id, person_id, parent_id_nn
+      )
+      SELECT acl.id, acl.object_id, acl.object_type, new_acr.id,
+        acl.person_id, acl.parent_id_nn
+      FROM access_control_list acl
+      JOIN access_control_roles cur_acr ON acl.ac_role_id = cur_acr.id
+      JOIN access_control_roles new_acr ON
+        new_acr.object_type = acl.object_type
+        AND cur_acr.name = new_acr.name
+      WHERE acl.parent_id IS NULL AND
+        acl.object_type != cur_acr.object_type AND
+        cur_acr.object_type != 'Workflow';
+  """)
+
+  op.execute("""
+      DELETE acl
+      FROM access_control_list acl
+      JOIN updated_acl ON acl.id = updated_acl.id
+      LEFT JOIN access_control_list outer_acl ON
+        outer_acl.object_id = updated_acl.object_id AND
+        outer_acl.object_type = updated_acl.object_type AND
+        outer_acl.ac_role_id = updated_acl.ac_role_id AND
+        outer_acl.person_id = updated_acl.person_id AND
+        outer_acl.parent_id_nn = updated_acl.parent_id_nn
+      WHERE acl.parent_id IS NULL AND outer_acl.id IS NOT NULL;
+  """)
+
+  op.execute("""
+      UPDATE access_control_list acl
+      JOIN updated_acl ON acl.id = updated_acl.id
+      LEFT JOIN access_control_list outer_acl ON
+        outer_acl.object_id = updated_acl.object_id AND
+        outer_acl.object_type = updated_acl.object_type AND
+        outer_acl.ac_role_id = updated_acl.ac_role_id AND
+        outer_acl.person_id = updated_acl.person_id AND
+        outer_acl.parent_id_nn = updated_acl.parent_id_nn
+      SET acl.ac_role_id = updated_acl.ac_role_id
+      WHERE acl.parent_id IS NULL AND outer_acl.id IS NULL;
+  """)
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""

--- a/src/ggrc/migrations/versions/20180627150313_26488ecb342a_fix_acr_ids_in_acl.py
+++ b/src/ggrc/migrations/versions/20180627150313_26488ecb342a_fix_acr_ids_in_acl.py
@@ -13,7 +13,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '26488ecb342a'
-down_revision = '0e40a37a05f4'
+down_revision = '0e385718442a'
 
 
 def create_acl_temporary_table():

--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -601,6 +601,9 @@ class Resource(ModelView):
     with benchmark("Validate custom attributes"):
       if hasattr(obj, "validate_custom_attributes"):
         obj.validate_custom_attributes()
+    with benchmark("Validate access_control_list"):
+      if hasattr(obj, "validate_acl"):
+        obj.validate_acl()
     with benchmark("Send PUT event"):
       signals.Restful.model_put.send(
           obj.__class__, obj=obj, src=src, service=self)
@@ -1026,6 +1029,10 @@ class Resource(ModelView):
       for obj in objects:
         if hasattr(obj, "validate_custom_attributes"):
           obj.validate_custom_attributes()
+    with benchmark("Validate access_control_list"):
+      for obj in objects:
+        if hasattr(obj, "validate_acl"):
+          obj.validate_acl()
     with benchmark("Get modified objects"):
       modified_objects = get_modified_objects(db.session)
     with benchmark("Log event for all objects"):

--- a/test/integration/ggrc/access_control/test_role_validation.py
+++ b/test/integration/ggrc/access_control/test_role_validation.py
@@ -1,0 +1,82 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Test Access Control List validation."""
+
+from ggrc import db
+from ggrc.models import all_models
+from integration.ggrc import TestCase, Api
+from integration.ggrc.models import factories
+
+
+class TestAccessControlListValidation(TestCase):
+  """Test AccessControlList validation."""
+
+  def setUp(self):
+    super(TestAccessControlListValidation, self).setUp()
+    self.api = Api()
+    self.client.get("/login")
+
+    role_ids = db.session.query(
+        all_models.AccessControlRole.id
+    ).filter(
+        all_models.AccessControlRole.object_type.in_(("Control", "Objective")),
+        all_models.AccessControlRole.name == "Admin"
+    ).order_by(all_models.AccessControlRole.object_type)
+    role_ids = [id_[0] for id_ in role_ids]
+
+    self.control_admin_acr_id, self.objective_admin_acr_id = role_ids
+
+  def test_create_with_wrong_acl(self):
+    """Test creation of object with wrong ACR in ACL."""
+    response = self.api.post(all_models.Control, {
+        "control": {
+            "title": "Control title",
+            "context": None,
+            "access_control_list": [{
+                "ac_role_id": self.objective_admin_acr_id,
+                "person": {
+                    "type": "Person",
+                    "id": factories.PersonFactory().id,
+                }
+            }],
+        },
+    })
+    self.assert400(response)
+    self.assertEqual(all_models.Control.query.count(), 0)
+
+  def test_update_with_wrong_acl(self):
+    """Test update of object with wrong ACR in ACL."""
+    with factories.single_commit():
+      control = factories.ControlFactory()
+      control_id = control.id
+      person_id = factories.PersonFactory().id
+      factories.AccessControlListFactory(
+          object_type="Control",
+          object_id=control_id,
+          person_id=person_id,
+          ac_role_id=self.control_admin_acr_id
+      )
+
+    response = self.api.put(
+        control,
+        {
+            "access_control_list": [{
+                "ac_role_id": self.objective_admin_acr_id,
+                "person": {
+                    "type": "Person",
+                    "id": person_id,
+                }
+            }]
+        }
+    )
+    self.assert400(response)
+
+    acls = all_models.AccessControlList.query.filter_by(
+        object_type="Control",
+        object_id=control_id
+    )
+    for acl in acls:
+      acl_obj_type = acl.object_type
+      acr_obj_type = acl.ac_role.object_type
+      self.assertEqual(acl_obj_type, acr_obj_type)


### PR DESCRIPTION
# Note

This PR doesn't fix ACL for Workflow items. It should be done in scope of GGRC-5492.

# Issue description

For some of access control list entries there are wrong access control roles (object_type are different). It lead to warnings on reindex.

# Steps to test the changes

Check migration: it should fix only broken items, user rights should be the same as before migration run.
Run reindex, check if there are no warnings for non-workflow models.

# Solution description

Fix broken acl entries in migration: delete rows if there is a duplicate with proper acr, update in another case.
Check correctness of access_control_list in object on POST and PUT.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# Migration checklist
- [x] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)


# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

