### PR TITLE
GGRC-5711 Add Background task ACL

### DIFF
--- a/src/ggrc/cache/utils.py
+++ b/src/ggrc/cache/utils.py
@@ -218,3 +218,16 @@ def clear_permission_cache():
   # We delete all the cached user permissions as well as
   # the permissions:list value itself
   client.delete_multi(cached_keys_set)
+
+
+def clear_users_permission_cache(user_ids):
+  """ Drop cached permissions for a list of users. """
+  if not getattr(settings, 'MEMCACHE_MECHANISM', False) or not user_ids:
+    return
+  client = get_cache_manager().cache_object.memcache_client
+  cached_keys_set = client.get('permissions:list') or set()
+  for user_id in user_ids:
+    key = 'permissions:{}'.format(user_id)
+    if key in cached_keys_set:
+      cached_keys_set.remove(key)
+  client.set('permissions:list', cached_keys_set)

--- a/src/ggrc/migrations/versions/20180627104424_385ee48cd6b9_add_acr_for_background_tasks.py
+++ b/src/ggrc/migrations/versions/20180627104424_385ee48cd6b9_add_acr_for_background_tasks.py
@@ -1,0 +1,57 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Add ACR for background tasks
+
+Create Date: 2018-06-27 10:44:24.975681
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+import datetime
+import sqlalchemy as sa
+
+from alembic import op
+from ggrc.migrations.utils import acr_propagation
+
+
+# revision identifiers, used by Alembic.
+revision = '385ee48cd6b9'
+down_revision = '7a8eaf2c9b75'
+
+ROLE_NAME = "Admin"
+OBJECT_TYPE = "BackgroundTask"
+
+
+def upgrade():
+  op.execute(
+      acr_propagation.ACR_TABLE.insert().values(
+          name=ROLE_NAME,
+          object_type=OBJECT_TYPE,
+          parent_id=None,
+          created_at=datetime.datetime.now(),
+          updated_at=datetime.datetime.now(),
+          internal=False,
+          non_editable=True,
+          read=True,
+          update=True,
+          delete=True,
+          my_work=False,
+      )
+  )
+
+
+def downgrade():
+  condition = sa.and_(
+      acr_propagation.ACR_TABLE.c.name == ROLE_NAME,
+      acr_propagation.ACR_TABLE.c.object_type == OBJECT_TYPE,
+  )
+  op.execute(
+      acr_propagation.ACL_TABLE.delete().where(
+          acr_propagation.ACL_TABLE.c.ac_role_id.in_(
+              sa.select([acr_propagation.ACR_TABLE.c.id]).where(condition)
+          )
+      )
+  )
+  op.execute(acr_propagation.ACR_TABLE.delete().where(condition))

--- a/src/ggrc/migrations/versions/20180627104424_385ee48cd6b9_add_acr_for_background_tasks.py
+++ b/src/ggrc/migrations/versions/20180627104424_385ee48cd6b9_add_acr_for_background_tasks.py
@@ -18,7 +18,7 @@ from ggrc.migrations.utils import acr_propagation
 
 # revision identifiers, used by Alembic.
 revision = '385ee48cd6b9'
-down_revision = '26488ecb342a'
+down_revision = '20ca15a10d12'
 
 ROLE_NAME = "Admin"
 OBJECT_TYPE = "BackgroundTask"

--- a/src/ggrc/migrations/versions/20180627104424_385ee48cd6b9_add_acr_for_background_tasks.py
+++ b/src/ggrc/migrations/versions/20180627104424_385ee48cd6b9_add_acr_for_background_tasks.py
@@ -18,13 +18,14 @@ from ggrc.migrations.utils import acr_propagation
 
 # revision identifiers, used by Alembic.
 revision = '385ee48cd6b9'
-down_revision = '7a8eaf2c9b75'
+down_revision = '26488ecb342a'
 
 ROLE_NAME = "Admin"
 OBJECT_TYPE = "BackgroundTask"
 
 
 def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
   op.execute(
       acr_propagation.ACR_TABLE.insert().values(
           name=ROLE_NAME,
@@ -43,6 +44,7 @@ def upgrade():
 
 
 def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
   condition = sa.and_(
       acr_propagation.ACR_TABLE.c.name == ROLE_NAME,
       acr_propagation.ACR_TABLE.c.object_type == OBJECT_TYPE,

--- a/src/ggrc/migrations/versions/20180627104424_385ee48cd6b9_add_acr_for_background_tasks.py
+++ b/src/ggrc/migrations/versions/20180627104424_385ee48cd6b9_add_acr_for_background_tasks.py
@@ -18,7 +18,7 @@ from ggrc.migrations.utils import acr_propagation
 
 # revision identifiers, used by Alembic.
 revision = '385ee48cd6b9'
-down_revision = '20ca15a10d12'
+down_revision = 'ba1e6a203f07'
 
 ROLE_NAME = "Admin"
 OBJECT_TYPE = "BackgroundTask"

--- a/src/ggrc/models/background_task.py
+++ b/src/ggrc/models/background_task.py
@@ -15,6 +15,7 @@ from werkzeug.datastructures import Headers
 from ggrc import db
 from ggrc import settings
 from ggrc.login import get_current_user
+from ggrc.access_control import roleable
 from ggrc.models.mixins import base
 from ggrc.models.mixins import Base
 from ggrc.models.deferred import deferred
@@ -26,7 +27,8 @@ from ggrc.models import reflection
 logger = getLogger(__name__)
 
 
-class BackgroundTask(base.ContextRBAC, Base, Stateful, db.Model):
+class BackgroundTask(roleable.Roleable, base.ContextRBAC, Base, Stateful,
+                     db.Model):
   """Background task model."""
   __tablename__ = 'background_tasks'
 

--- a/src/ggrc/models/background_task.py
+++ b/src/ggrc/models/background_task.py
@@ -91,15 +91,17 @@ def _add_task_acl(task):
   """Add ACL entry for the current users background task."""
   roles = role.get_ac_roles_for(task.type)
   admin_role = roles.get("Admin", None)
-  acl.AccessControlList(
-      person=get_current_user(),
-      ac_role=admin_role,
-      object=task,
-  )
+  if admin_role:
+    acl.AccessControlList(
+        person=get_current_user(),
+        ac_role=admin_role,
+        object=task,
+    )
   db.session.add(task)
   db.session.commit()
-  from ggrc.cache.utils import clear_permission_cache
-  clear_permission_cache()
+  if admin_role:
+    from ggrc.cache.utils import clear_permission_cache
+    clear_permission_cache()
 
 
 def create_task(name, url, queued_callback=None, parameters=None, method=None):

--- a/src/ggrc/models/background_task.py
+++ b/src/ggrc/models/background_task.py
@@ -100,8 +100,8 @@ def _add_task_acl(task):
   db.session.add(task)
   db.session.commit()
   if admin_role:
-    from ggrc.cache.utils import clear_permission_cache
-    clear_permission_cache()
+    from ggrc.cache.utils import clear_users_permission_cache
+    clear_users_permission_cache([get_current_user().id])
 
 
 def create_task(name, url, queued_callback=None, parameters=None, method=None):

--- a/src/ggrc_basic_permissions/roles/Creator.py
+++ b/src/ggrc_basic_permissions/roles/Creator.py
@@ -16,14 +16,6 @@ owner_base = [
     "ControlCategory",
     "ControlAssertion",
     "Option",
-    {
-        "type": "BackgroundTask",
-        "terms": {
-            "property_name": "modified_by",
-            "value": "$current_user"
-        },
-        "condition": "is"
-    },
     "CustomAttributeDefinition",
     "CustomAttributeValue",
 ]
@@ -181,14 +173,6 @@ permissions = {
         "Program",
         "TechnologyEnvironment",
         "Context",
-        {
-            "type": "BackgroundTask",
-            "terms": {
-                "property_name": "modified_by",
-                "value": "$current_user"
-            },
-            "condition": "is"
-        },
     ],
     "update": owner_update,
     "delete": owner_update,

--- a/src/ggrc_basic_permissions/roles/Editor.py
+++ b/src/ggrc_basic_permissions/roles/Editor.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2018 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
+"""Editor permissions. """
+
 scope = "System"
 description = """
   This role grants a user basic object creation and editing permission.

--- a/src/ggrc_basic_permissions/roles/Editor.py
+++ b/src/ggrc_basic_permissions/roles/Editor.py
@@ -65,14 +65,6 @@ permissions = {
         "Role",
         "Context",
         "UserRole",
-        {
-            "type": "BackgroundTask",
-            "terms": {
-                "property_name": "modified_by",
-                "value": "$current_user"
-            },
-            "condition": "is"
-        },
     ],
     "create": [
         "Audit",
@@ -128,14 +120,6 @@ permissions = {
         "ProductGroup",
         "UserRole",
         "Context",
-        {
-            "type": "BackgroundTask",
-            "terms": {
-                "property_name": "modified_by",
-                "value": "$current_user"
-            },
-            "condition": "is"
-        },
     ],
     "update": [
         {
@@ -196,14 +180,6 @@ permissions = {
         "Role",
         "UserRole",
         "Context",
-        {
-            "type": "BackgroundTask",
-            "terms": {
-                "property_name": "modified_by",
-                "value": "$current_user"
-            },
-            "condition": "is"
-        },
     ],
     "delete": [
         {
@@ -259,13 +235,5 @@ permissions = {
         "UserRole",
         "ProductGroup",
         "Context",
-        {
-            "type": "BackgroundTask",
-            "terms": {
-                "property_name": "modified_by",
-                "value": "$current_user"
-            },
-            "condition": "is"
-        },
     ]
 }

--- a/src/ggrc_basic_permissions/roles/Reader.py
+++ b/src/ggrc_basic_permissions/roles/Reader.py
@@ -73,14 +73,6 @@ permissions = {
         "Role",
         "UserRole",
         "Context",
-        {
-            "type": "BackgroundTask",
-            "terms": {
-                "property_name": "modified_by",
-                "value": "$current_user"
-            },
-            "condition": "is"
-        },
         "Workflow",
         "TaskGroup",
         "TaskGroupObject",

--- a/test/integration/ggrc/models/hooks/acl/test_bg_task_roles.py
+++ b/test/integration/ggrc/models/hooks/acl/test_bg_task_roles.py
@@ -1,0 +1,129 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Test Access Control Propagation for BackgroundTask roles."""
+
+from ggrc.models import all_models
+from integration.ggrc import TestCase, api_helper
+from integration.ggrc.models import factories
+from integration.ggrc_basic_permissions.models \
+    import factories as rbac_factories
+
+
+class TestBackgroundTaskRolePropagation(TestCase):
+  """Test Access Control Propagation for BackgroundTask."""
+
+  def setup_people(self):
+    """Setup people and global roles"""
+    creator_role = all_models.Role.query.filter(
+        all_models.Role.name == 'Creator'
+    ).one()
+
+    for person in [
+        ("created_captain", "createdcaptain@example.com"),
+        ("created_auditor", "createdauditor@example.com"),
+        ("updated_captain", "updatedcaptain@example.com"),
+        ("updated_auditor", "updatedauditor@example.com"),
+        ("issue_admin", "issueadmin@example.com"),
+    ]:
+      self.people[person[0]] = factories.PersonFactory(
+          email=person[1])
+      rbac_factories.UserRoleFactory(
+          role=creator_role,
+          person=self.people[person[0]]
+      )
+
+  def setup_objects(self):
+    """Sets up all the objects needed by the tests"""
+    objects = self.objects
+
+    # Program
+    objects['program'] = program = factories.ProgramFactory(title="A Program")
+
+    # Controls
+    objects['controls'] = controls = [
+        factories.ControlFactory(title="My First Control"),
+        factories.ControlFactory(title="My Second Control")
+    ]
+
+    # Controls <-> Program mapping
+    for control in controls:
+      factories.RelationshipFactory(source=program,
+                                    destination=control)
+
+    # Audit
+    objects['audit'] = audit = factories.AuditFactory(
+        program=objects['program'],
+        access_control_list=[{
+            "ac_role": self.audit_roles['Auditors'],
+            "person": self.people['created_auditor']
+        }, {
+            "ac_role": self.audit_roles['Audit Captains'],
+            "person": self.people['created_captain']
+        }]
+    )
+    factories.RelationshipFactory(source=program, destination=audit)
+
+    # Assessment template
+    objects['assessment_template'] = template = \
+        factories.AssessmentTemplateFactory()
+    factories.RelationshipFactory(source=audit, destination=template)
+
+    # Snapshot
+    objects['snapshots'] = self._create_snapshots(audit, controls)
+    for snapshot in objects['snapshots']:
+      factories.RelationshipFactory(source=audit, destination=snapshot)
+
+  def setUp(self):
+    super(TestBackgroundTaskRolePropagation, self).setUp()
+    self.api = api_helper.Api()
+    self.people = {}
+    self.objects = {}
+    self.audit_roles = {
+        role.name: role for role in
+        all_models.AccessControlRole.query.filter().all()
+    }
+    with factories.single_commit():
+      self.setup_people()
+      self.setup_objects()
+
+  def test_bg_task_created(self):
+    """Test that Global Creator has rights to fetch BG task. """
+    objects = self.objects
+    assessment_dict = {
+        "_generated": True,
+        "audit": {
+            "id": objects['audit'].id,
+            "type": "Audit"
+        },
+        "object": {
+            "id": objects['snapshots'][0].id,
+            "type": "Snapshot"
+        },
+        "title": "Temp title",
+        "template": {
+            "id": objects['assessment_template'].id,
+            "type": "AssessmentTemplate"
+        },
+        "context": {
+            "type": "Context",
+            "id": objects['audit'].context_id,
+        },
+    }
+
+    self.api.set_user(self.people["created_auditor"])
+    response = self.api.post(all_models.Assessment, {
+        "assessment": assessment_dict
+    })
+    self.assertEqual(response.status_code, 201)
+    bg_tasks = all_models.BackgroundTask.query.all()
+    self.assertEqual(len(bg_tasks), 1)
+
+    content = self.api.client.get(
+        "/api/background_tasks?id__in={}".format(bg_tasks[0].id)
+    )
+    self.assert200(content)
+    bg_tasks_content = \
+        content.json['background_tasks_collection']['background_tasks']
+    self.assertEqual(len(bg_tasks_content), 1)
+    self.assertEqual(bg_tasks_content[0]['id'], bg_tasks[0].id)

--- a/test/integration/ggrc_workflows/test_workflow_api_calls.py
+++ b/test/integration/ggrc_workflows/test_workflow_api_calls.py
@@ -277,7 +277,7 @@ class TestWorkflowsApiPost(TestCase):
          all_models.CycleTaskEntry.__name__)
     )
     related_count = len(related_objects)
-    bd_tasks_count = len(all_models.BackgroundTask.query.all())
+    bd_tasks_count = all_models.BackgroundTask.query.count()
 
     all_acl = [acl for acl in all_models.AccessControlList.eager_query().all()]
     self.assertEqual(

--- a/test/integration/ggrc_workflows/test_workflow_api_calls.py
+++ b/test/integration/ggrc_workflows/test_workflow_api_calls.py
@@ -64,8 +64,12 @@ class TestWorkflowsApiPost(TestCase):
     ).count()
     self.assertEqual(related_acl_count, 0)
 
+    bg_task_count = all_models.AccessControlList.query.filter(
+        all_models.AccessControlList.object_type == "BackgroundTask"
+    ).count()
+
     all_acl_count = all_models.AccessControlList.query.count()
-    self.assertEqual(all_acl_count, exp_acl_count)
+    self.assertEqual(all_acl_count - bg_task_count, exp_acl_count)
 
   def test_acl_on_object_deletion(self):
     """Test related ACL records removed on related object delete"""
@@ -100,7 +104,10 @@ class TestWorkflowsApiPost(TestCase):
     self.assert200(response)
 
     acl_count = all_models.AccessControlList.query.count()
-    self.assertEqual(acl_count, 0)
+    bg_acl_count = all_models.AccessControlList.query.filter(
+        all_models.AccessControlList.object_type == "BackgroundTask"
+    ).count()
+    self.assertEqual(acl_count, bg_acl_count)
 
   def test_acl_for_new_related_object(self):
     """Test Workflow ACL propagation for new related objects."""
@@ -270,9 +277,13 @@ class TestWorkflowsApiPost(TestCase):
          all_models.CycleTaskEntry.__name__)
     )
     related_count = len(related_objects)
+    bd_tasks_count = len(all_models.BackgroundTask.query.all())
 
     all_acl = [acl for acl in all_models.AccessControlList.eager_query().all()]
-    self.assertEqual(len(all_acl), roles_count + roles_count * related_count)
+    self.assertEqual(
+        len(all_acl),
+        bd_tasks_count + roles_count + roles_count * related_count
+    )
 
     workflow = all_models.Workflow.query.one()
     parent_acl, related_acl = [], []


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

The bug here is that when the FE polls at /api/background_tasks?id__in=42 (where 42 is the id) the BE replaces the info about the Background Task with null because the check for read permissions returns no access for the current user Global Creator. The check is done in an invalid way because the permission for Background Tasks is specified with a condition (which uses a complete instance of a Background Task object), but is checked with just object type + global context (where the Global Creator doesn't have any permissions for Background Tasks). See the block starting here: https://github.com/google/ggrc-core/blob/5bc2897499e5be5858798a23362e5f089e02e6dd/src/ggrc/services/common.py#L1400

# Steps to test the changes

1. Login as global creator  (reproduced for reader and editor as well)
2. Open audit with many snapshots 
3. Generate assessments
Actual result: "Show results" should be shown only after assessments are generated

# Solution description

Create an access control list entry for the current user when the background task is created.
Perform migrations for Background task ACL

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# Migration checklist
- [x] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
