### PR TITLE
GGRC-5513 Store compressed permission dict in memcache

### DIFF
--- a/src/ggrc_basic_permissions/__init__.py
+++ b/src/ggrc_basic_permissions/__init__.py
@@ -3,8 +3,10 @@
 
 """RBAC module"""
 
+import cPickle
 import datetime
 import itertools
+import zlib
 
 import flask
 import sqlalchemy as sa
@@ -160,8 +162,11 @@ def query_memcache(key):
     cache.set('permissions:list', cached_keys_set, PERMISSION_CACHE_TIMEOUT)
     return cache, None
 
-  permissions_cache = cache.get(key)
-  if permissions_cache:
+  permissions_data = cache.get(key)
+  if permissions_data:
+    # permissions_cache is stored in compressed state,
+    # need to decompress it before using
+    permissions_cache = cPickle.loads(zlib.decompress(permissions_data))
     # If the key is both in permissions:list and in memcache itself
     # it is safe to return the cached permissions
     return cache, permissions_cache
@@ -394,10 +399,14 @@ def store_results_into_memcache(permissions, cache, key):
 
   cached_keys_set = cache.get('permissions:list') or set()
   if key in cached_keys_set:
+    # Size of permissions dict can be too big for memcache (> 1 Mb),
+    # so compressed dict will be stored.
+    compressed_permissions = zlib.compress(cPickle.dumps(permissions))
+
     # We only add the permissions to the cache if the
     # key still exists in the permissions:list after
     # the query has executed.
-    cache.set(key, permissions, PERMISSION_CACHE_TIMEOUT)
+    cache.set(key, compressed_permissions, PERMISSION_CACHE_TIMEOUT)
 
 
 def load_permissions_for(user):


### PR DESCRIPTION
# Issue description

Currently permissions data stored in memcache can consume too mach memory. It lead to error like:
`Values may not be more than 1000000 bytes in length`.

# Steps to test the changes

Login under user who has > 900k acl entries. No errors should be thrown.

# Solution description

Compress permission data before saving it.
This solution allows to decrease permission object size in 2 times. For ggrc.creator@gmail.com on last ggrc-qa db permission object in memcache takes 622 Kb in uncompressed state. If it's compressed it takes 310 Kb.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
