### PR TITLE
GGRC-5494 Add 'type' attribute for buttons on LCA popup

### DIFF
--- a/src/ggrc-client/js/components/ca-object/ca-object-modal-content.mustache
+++ b/src/ggrc-client/js/components/ca-object/ca-object-modal-content.mustache
@@ -80,7 +80,7 @@
                         </form>
                     </create-url>
                 {{else}}
-                    <button class="btn btn-small btn-gray"
+                    <button type="button" class="btn btn-small btn-gray"
                         ($click)="setUrlEditMode(true, 'urls')">Add</button>
                 {{/if}}
             </div>

--- a/src/ggrc/assets/mustache/gdrive/gdrive_file.mustache
+++ b/src/ggrc/assets/mustache/gdrive/gdrive_file.mustache
@@ -5,6 +5,7 @@
 
 <button
   class="{{link_class}} btn btn-small btn-white"
+  type="button"
   {{#isInactive}}disabled{{/isInactive}}
   {{#if tooltip}}
     rel="tooltip"


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Page is reloaded when adding evidence url or evidence file for dropdown LCA.

The issue appeared after this [PR](https://github.com/google/ggrc-core/pull/7997), but actually refresh of page happens because of this button is inside of `<form>` and its `type` attribute is not defined, so by default it is `submit`. Submit event of form calls reload of page.

# Steps to test the changes

1. Create a program, audit, map control snapshot to this audit
2. Create asmt template with dropdown LCA that has evidence url = required or  evidence file = required
3. Generate asmt from template
4. Open this asmt
5. Choose a value from dropdown LCA
8. Click Add evidence url/ attach file button

Actual: Page is reloaded, with following URL `.../audits/4570?#!assessment` (`?` sign is added after instance id)
Expected: Add url text field / Attach file

# Solution description

Add for button `type="button"` attribute.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
