### PR TITLE
GGRC-2365 Export snapshots archived column

### DIFF
--- a/src/ggrc/converters/snapshot_block.py
+++ b/src/ggrc/converters/snapshot_block.py
@@ -37,6 +37,7 @@ class SnapshotBlockConverter(object):
 
   CUSTOM_SNAPSHOT_ALIASES = {
       "audit": "Audit",
+      "archived": "Archived",
       "revision_date": "Revision Date",
   }
 
@@ -111,6 +112,7 @@ class SnapshotBlockConverter(object):
     content["audit"] = {"type": "Audit", "id": snapshot.parent_id}
     content["slug"] = u"*{}".format(content["slug"])
     content["revision_date"] = unicode(snapshot.revision.created_at)
+    content["archived"] = snapshot.archived
     if snapshot.last_assessment_date:
       content["last_assessment_date"] = \
           snapshot.last_assessment_date.isoformat()

--- a/src/ggrc/migrations/versions/20180706140827_0e40a37a05f4_add_foreignkey_snapshot.py
+++ b/src/ggrc/migrations/versions/20180706140827_0e40a37a05f4_add_foreignkey_snapshot.py
@@ -18,23 +18,59 @@ revision = '0e40a37a05f4'
 down_revision = '054d15be7a29'
 
 
+COLLECT_BAD_SNAPSHOT_IDS = """
+    INSERT INTO `tmp_bad_snapshots`
+    SELECT `s`.`id` AS `id`
+    FROM `snapshots` AS `s`
+    LEFT JOIN `audits` AS `a`
+    ON `s`.`parent_id` = `a`.`id`
+    WHERE `a`.`id` IS null OR `s`.`parent_type` != "Audit"
+"""
+
+
 def upgrade():
   """Upgrade database schema and/or data, creating a new revision."""
-  op.execute(
-      """
-      DELETE FROM snapshots
-      WHERE id IN (
-          SELECT id
-          FROM (
-              SELECT s.id as id
-              FROM snapshots as s
-              LEFT JOIN audits as a
-              ON s.parent_id = a.id
-              WHERE a.id IS null OR s.parent_type != "Audit"
-          ) sq
-      );
-      """
+  connection = op.get_bind()
+  connection.execute(
+      "CREATE TEMPORARY TABLE `tmp_bad_snapshots`(`id` INT(11))"
   )
+  if connection.execute(COLLECT_BAD_SNAPSHOT_IDS).rowcount:
+    connection.execute(
+        """
+        DELETE FROM snapshots
+        WHERE id IN (SELECT `id` FROM `tmp_bad_snapshots`)
+        """
+    )
+    connection.execute(
+        """
+        DELETE FROM access_control_list
+        WHERE
+            object_id IN (SELECT `id` FROM `tmp_bad_snapshots`)
+            AND
+            object_type = "Snapshot"
+        """
+    )
+    connection.execute(
+        """
+        DELETE FROM relationships
+        WHERE
+            source_id IN (SELECT `id` FROM `tmp_bad_snapshots`)
+            AND
+            source_type = "Snapshot";
+        """
+    )
+    # Because temporary table can't be used twice in one query, deletion
+    # of relationships made in 2 queries.
+    connection.execute(
+        """
+        DELETE FROM relationships
+        WHERE
+            destination_id IN (SELECT `id` FROM `tmp_bad_snapshots`)
+            AND
+            destination_type = "Snapshot";
+        """
+    )
+  connection.execute("DROP TABLE IF EXISTS `tmp_bad_snapshots`")
   op.create_foreign_key(
       'fk_snapshots_audits',
       'snapshots',

--- a/src/ggrc/migrations/versions/20180706140827_0e40a37a05f4_add_foreignkey_snapshot.py
+++ b/src/ggrc/migrations/versions/20180706140827_0e40a37a05f4_add_foreignkey_snapshot.py
@@ -1,0 +1,51 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Add Foreign key Snapshot - Audit
+
+Delete snapshots that doesn't have correct parent_id or parent_type
+Create foreign key for linking snapshots.parent_id and audits.id
+Create Date: 2018-07-06 14:08:27.860421
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '0e40a37a05f4'
+down_revision = '054d15be7a29'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  op.execute(
+      """
+      DELETE FROM snapshots
+      WHERE id IN (
+          SELECT id
+          FROM (
+              SELECT s.id as id
+              FROM snapshots as s
+              LEFT JOIN audits as a
+              ON s.parent_id = a.id
+              WHERE a.id IS null OR s.parent_type != "Audit"
+          ) sq
+      );
+      """
+  )
+  op.create_foreign_key(
+      'fk_snapshots_audits',
+      'snapshots',
+      'audits',
+      ['parent_id'],
+      ['id'],
+      ondelete="CASCADE",
+  )
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  op.drop_constraint('fk_snapshots_audits', 'snapshots', type_='foreignkey')
+  op.drop_index('fk_snapshots_audits', table_name='snapshots')

--- a/src/ggrc/models/audit.py
+++ b/src/ggrc/models/audit.py
@@ -72,6 +72,7 @@ class Audit(Snapshotable,
 
   assessments = db.relationship('Assessment', backref='audit')
   issues = db.relationship('Issue', backref='audit')
+  snapshots = db.relationship('Snapshot', backref='audit')
   archived = deferred(db.Column(db.Boolean,
                                 nullable=False, default=False), 'Audit')
   assessment_templates = db.relationship('AssessmentTemplate', backref='audit')

--- a/src/ggrc/models/snapshot.py
+++ b/src/ggrc/models/snapshot.py
@@ -62,11 +62,7 @@ class Snapshot(Roleable, relationship.Relatable, WithLastAssessmentDate,
   ]
   _aliases = {
       "attributes": "Attributes",
-      "archived": {
-          "display_name": "Archived",
-          "mandatory": False,
-          "view_only": True,
-      },
+      "archived": "Archived",
       "mappings": {
           "display_name": "Mappings",
           "type": "mapping",
@@ -152,18 +148,13 @@ class Snapshot(Roleable, relationship.Relatable, WithLastAssessmentDate,
       _set_latest_revisions([self])
 
   @property
-  def parent_attr(self):
-    return '{0}_parent'.format(self.parent_type)
-
-  @property
-  def parent(self):  # DEPRECATED FEATURE, use 'audit' instead
-    return getattr(self, self.parent_attr)
+  def parent(self):
+    return self.audit
 
   @parent.setter
   def parent(self, value):
-    self.parent_id = getattr(value, 'id', None)
+    setattr(self, "audit", value)
     self.parent_type = "Audit"
-    return setattr(self, self.parent_attr, value)
 
   @staticmethod
   def _extra_table_args(_):

--- a/src/ggrc/models/snapshot.py
+++ b/src/ggrc/models/snapshot.py
@@ -62,14 +62,37 @@ class Snapshot(Roleable, relationship.Relatable, WithLastAssessmentDate,
   ]
   _aliases = {
       "attributes": "Attributes",
+      "archived": {
+          "display_name": "Archived",
+          "mandatory": False,
+          "view_only": True,
+      },
       "mappings": {
           "display_name": "Mappings",
           "type": "mapping",
       }
   }
 
-  parent_id = deferred(db.Column(db.Integer, nullable=False), "Snapshot")
-  parent_type = deferred(db.Column(db.String, nullable=False), "Snapshot")
+  parent_id = deferred(
+      db.Column(
+          db.Integer,
+          db.ForeignKey("audits.id", ondelete='CASCADE'),
+          nullable=False
+      ),
+      "Snapshot",
+  )
+  parent_type = deferred(
+      db.Column(db.String, nullable=False, default="Audit"),
+      "Snapshot",
+  )
+
+  @orm.validates("parent_type")
+  def validate_parent_type(self, _, value):
+    """Validates parent_type equals 'Audit'"""
+    # pylint: disable=no-self-use
+    if value != "Audit":
+      raise ValueError("Wrong 'parent_type' value. Only 'Audit' supported")
+    return value
 
   # Child ID and child type are data denormalisations - we could easily get
   # them from revision.content, but since that is a JSON field it will be
@@ -97,7 +120,7 @@ class Snapshot(Roleable, relationship.Relatable, WithLastAssessmentDate,
 
   @builder.simple_property
   def archived(self):
-    return self.parent.archived if self.parent else False
+    return self.audit.archived if self.audit else False
 
   @builder.simple_property
   def is_latest_revision(self):
@@ -115,6 +138,7 @@ class Snapshot(Roleable, relationship.Relatable, WithLastAssessmentDate,
     return cls.eager_inclusions(query, Snapshot._include_links).options(
         orm.subqueryload('revision'),
         orm.subqueryload('revisions'),
+        orm.joinedload('audit').load_only("id", "archived"),
     )
 
   @hybrid_property
@@ -132,13 +156,13 @@ class Snapshot(Roleable, relationship.Relatable, WithLastAssessmentDate,
     return '{0}_parent'.format(self.parent_type)
 
   @property
-  def parent(self):
+  def parent(self):  # DEPRECATED FEATURE, use 'audit' instead
     return getattr(self, self.parent_attr)
 
   @parent.setter
   def parent(self, value):
     self.parent_id = getattr(value, 'id', None)
-    self.parent_type = getattr(value, 'type', None)
+    self.parent_type = "Audit"
     return setattr(self, self.parent_attr, value)
 
   @staticmethod

--- a/test/integration/ggrc/converters/test_export_snapshots.py
+++ b/test/integration/ggrc/converters/test_export_snapshots.py
@@ -124,6 +124,7 @@ class TestExportSnapshots(TestCase):
             "Assertions": u"\n".join(c.name for c in control.assertions),
             "Categories": u"\n".join(c.name for c in control.categories),
             "Folder": u"",
+            "Archived": u"yes" if audit.archived else u"no",
             # Computed attributes
             "Last Assessment Date": u"",
             "Admin": u"admin@example.com\ncreator@example.com\n"
@@ -229,6 +230,7 @@ class TestExportSnapshots(TestCase):
             "Type/Means": u"",
             # Special snapshot export fields
             "Audit": audit.slug,
+            "Archived": u"yes" if audit.archived else u"no",
             # Computed attributes
             "Last Assessment Date": u"",
             "Recipients": "",
@@ -450,6 +452,7 @@ class TestExportSnapshots(TestCase):
           'Last Updated Date': control.updated_at.strftime(DATE_FORMAT_US),
           'Last Updated By': "",
           "Folder": u"",
+          "Archived": u"yes" if audit.archived else u"no",
       }
       control_dicts[control.slug].update(**control_acr_people[control.slug])
 

--- a/test/integration/ggrc/converters/test_export_snapshots.py
+++ b/test/integration/ggrc/converters/test_export_snapshots.py
@@ -514,3 +514,28 @@ class TestExportSnapshots(TestCase):
     }]
     parsed_data = self.export_parsed_csv(search_request)["Control Snapshot"][0]
     self.assertNotIn("Custom Role", parsed_data)
+
+  def test_export_archived_snapshot(self):
+    """Test exporting snapshots 'archived' status"""
+    with factories.single_commit():
+      controls = [factories.ControlFactory()]
+      audit = factories.AuditFactory()
+      audit_slug = audit.slug
+      self._create_snapshots(audit, controls)
+      audit_archived = factories.AuditFactory(archived=True)
+      audit_archived_slug = audit_archived.slug
+      self._create_snapshots(audit_archived, controls)
+
+    search_request = [{
+        "object_name": "Snapshot",
+        "filters": {
+            "expression": {},
+        },
+    }]
+    parsed_data = self.export_parsed_csv(search_request)["Control Snapshot"]
+    result = {
+        parsed_data[0]["Audit"]: parsed_data[0]["Archived"],
+        parsed_data[1]["Audit"]: parsed_data[1]["Archived"],
+    }
+    self.assertEqual(result[audit_slug], u"no")
+    self.assertEqual(result[audit_archived_slug], u"yes")

--- a/test/integration/ggrc/converters/test_snapshot_block.py
+++ b/test/integration/ggrc/converters/test_snapshot_block.py
@@ -85,6 +85,7 @@ class TestSnapshotBlockConverter(TestCase):
         ('test_plan', 'Assessment Procedure'),
         ('start_date', 'Effective Date'),
         ('end_date', 'Last Deprecated Date'),
+        ('archived', 'Archived'),
         ('status', 'State'),
         ('os_state', 'Review State'),
         ('assertions', 'Assertions'),


### PR DESCRIPTION
# Issue description

'Archived' column added to export of snapshots

# Steps to test the changes

Create Audit with mapped controls, and make an export of snapshots. CSV file should contain 'Archived' column with archived status of related audit.

# Solution description

- Add 'archived' to export code base
- Add foreign key relationship to Snapshot-Audit to eagerly load archived status with constant number of queries.
- Fix broken tests(not expecting 'Archived' column)
- Add test of exporting snapshots with archived status

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description ~~(and do nothing else).~~
*Change Snapshot.parent_id to foreign key to Audit.id*
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# Migration checklist
- [x] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
*Migration will delete snapshots with wrong foreign key parent_id or parent_type not equal to 'Audit'*

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".