### PR TITLE
GGRC-5524 Fix export of snapshots without filter by mappings

### DIFF
--- a/src/ggrc-client/js/components/import-export/export.js
+++ b/src/ggrc-client/js/components/import-export/export.js
@@ -169,7 +169,10 @@ export default can.Component.extend({
           }, '');
 
         if (panel.attr('snapshot_type')) {
-          relevantFilter += ` AND child_type = ${panel.attr('snapshot_type')}`;
+          if (relevantFilter) {
+            relevantFilter += ' AND ';
+          }
+          relevantFilter += `child_type = ${panel.attr('snapshot_type')}`;
         }
 
         return {

--- a/src/ggrc-client/js/components/import-export/test/export_spec.js
+++ b/src/ggrc-client/js/components/import-export/test/export_spec.js
@@ -14,85 +14,154 @@ describe('export component', () => {
       viewModel = getComponentVM(Component);
     });
 
-    it('returns object with empty expression if filters are empty', () => {
-      const panelModel = new can.Map({
-        type: 'Program',
-        attributes: new can.List(),
-        localAttributes: new can.List(),
-        mappings: new can.List(),
-      });
-      const expectedObjects = [{
-        object_name: 'Program',
-        fields: [],
-        filters: {expression: {}},
-      }];
-
-      viewModel.panels.push(panelModel);
-
-      expect(viewModel.getObjectsForExport()).toEqual(expectedObjects);
-    });
-    it('returns object with simple expression if there is one filter', () => {
-      const panelModel = new can.Map({
-        type: 'Program',
-        attributes: new can.List(),
-        localAttributes: new can.List(),
-        mappings: new can.List(),
-        relevant: [{
-          filter: {id: 2},
-          model_name: 'Program',
-        }],
-      });
-      const expectedObjects = [{
-        object_name: 'Program',
-        fields: [],
-        filters: {expression: {
+    describe('if object type is not Snapshots', () => {
+      it('returns object with empty expression if filters are empty', () => {
+        const panelModel = new can.Map({
+          type: 'Program',
+          attributes: new can.List(),
+          localAttributes: new can.List(),
+          mappings: new can.List(),
+        });
+        const expectedObjects = [{
           object_name: 'Program',
-          op: {name: 'relevant'},
-          ids: ['2'],
-        }},
-      }];
+          fields: [],
+          filters: {expression: {}},
+        }];
 
-      viewModel.panels.push(panelModel);
+        viewModel.panels.push(panelModel);
 
-      expect(viewModel.getObjectsForExport()).toEqual(expectedObjects);
-    });
-    it('returns object with OR in expression ' +
-      'if the second filter has OR operator', () => {
-      const panelModel = new can.Map({
-        type: 'Program',
-        attributes: new can.List(),
-        localAttributes: new can.List(),
-        mappings: new can.List(),
-        relevant: [{
-          filter: {id: 2},
-          model_name: 'Program',
-        }, {
-          filter: {id: 3},
-          model_name: 'Audit',
-          operator: 'OR',
-        }],
+        expect(viewModel.getObjectsForExport()).toEqual(expectedObjects);
       });
-      const expectedObjects = [{
-        object_name: 'Program',
-        fields: [],
-        filters: {expression: {
-          left: {
-            object_name: 'Program',
-            op: {name: 'relevant'},
-            ids: ['2'],
+      it('returns object with simple expression if there is one filter', () => {
+        const panelModel = new can.Map({
+          type: 'Program',
+          attributes: new can.List(),
+          localAttributes: new can.List(),
+          mappings: new can.List(),
+          relevant: [{
+            filter: {id: 2},
+            model_name: 'Program',
+          }],
+        });
+        const expectedObjects = [{
+          object_name: 'Program',
+          fields: [],
+          filters: {
+            expression: {
+              object_name: 'Program',
+              op: {name: 'relevant'},
+              ids: ['2'],
+            },
           },
-          op: {name: 'OR'},
-          right: {
-            object_name: 'Audit',
-            op: {name: 'relevant'},
-            ids: ['3'],
+        }];
+
+        viewModel.panels.push(panelModel);
+
+        expect(viewModel.getObjectsForExport()).toEqual(expectedObjects);
+      });
+      it('returns object with OR in expression ' +
+        'if the second filter has OR operator', () => {
+        const panelModel = new can.Map({
+          type: 'Program',
+          attributes: new can.List(),
+          localAttributes: new can.List(),
+          mappings: new can.List(),
+          relevant: [{
+            filter: {id: 2},
+            model_name: 'Program',
+          }, {
+            filter: {id: 3},
+            model_name: 'Audit',
+            operator: 'OR',
+          }],
+        });
+        const expectedObjects = [{
+          object_name: 'Program',
+          fields: [],
+          filters: {
+            expression: {
+              left: {
+                object_name: 'Program',
+                op: {name: 'relevant'},
+                ids: ['2'],
+              },
+              op: {name: 'OR'},
+              right: {
+                object_name: 'Audit',
+                op: {name: 'relevant'},
+                ids: ['3'],
+              },
+            },
           },
-        }},
-      }];
+        }];
 
-      viewModel.panels.push(panelModel);
+        viewModel.panels.push(panelModel);
 
-      expect(viewModel.getObjectsForExport()).toEqual(expectedObjects);
+        expect(viewModel.getObjectsForExport()).toEqual(expectedObjects);
+      });
+    });
+
+    describe('if object type is Snapshots', () => {
+      it('returns child_type in expression if filters are empty', () => {
+        const panelModel = new can.Map({
+          type: 'Snapshot',
+          snapshot_type: 'Control',
+          attributes: new can.List(),
+          localAttributes: new can.List(),
+          mappings: new can.List(),
+        });
+        const expectedObjects = [{
+          object_name: 'Snapshot',
+          fields: [],
+          filters: {
+            expression: {
+              left: 'child_type',
+              op: {name: '='},
+              right: 'Control',
+            },
+          },
+        }];
+
+        viewModel.panels.push(panelModel);
+
+        expect(viewModel.getObjectsForExport()).toEqual(expectedObjects);
+      });
+      it('returns selected filter in expression and child_type', () => {
+        const panelModel = new can.Map({
+          type: 'Snapshot',
+          snapshot_type: 'Contract',
+          attributes: new can.List(),
+          localAttributes: new can.List(),
+          mappings: new can.List(),
+          relevant: [{
+            filter: {id: 2},
+            model_name: 'Program',
+          }],
+        });
+        const expectedObjects = [{
+          object_name: 'Snapshot',
+          fields: [],
+          filters: {
+            expression: {
+              left: {
+                object_name: 'Program',
+                op: {name: 'relevant'},
+                ids: ['2'],
+              },
+              op: {name: 'AND'},
+              right: {
+                left: 'child_type',
+                op: {name: '='},
+                right: 'Contract',
+              },
+            },
+          },
+        }];
+
+        viewModel.panels.push(panelModel);
+
+        expect(viewModel.getObjectsForExport()).toEqual(expectedObjects);
+      });
     });
   });
 });


### PR DESCRIPTION
# Issue description

Snapshots are missed in csv file/Google sheet if export it w/o Filter by mappings

# Steps to test the changes

1. Open Export page
2. Select OBJECT TYPE 'Snapshots'
3. Select 'SELECT SNAPSHOT OBJECT TYPE' e.g. Control
4. Export snapshots to Google Sheet
5. Open Google Sheet
Expected Result: All snapshots in the system should be exported for the selected object type if user doesn't indicate mappings

# Solution description

The reason of this bug is that child_type was always added to the filter with AND operator. So additional check for presence of filters should resolve it.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).


# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
