### PR TITLE
GGRC-5525 Make instance thread safe

### DIFF
--- a/src/app.yaml.dist
+++ b/src/app.yaml.dist
@@ -5,7 +5,7 @@
 
 runtime: python27
 api_version: 1
-threadsafe: true
+threadsafe: false
 instance_class: {INSTANCE_CLASS}
 
 {SCALING}


### PR DESCRIPTION
# Issue description
Comment creation on ggrc-perf takes too much time. The reason is deployment settings. 
We have manual scaling, this scaling leads to constant numbers on instances, but each instance may process more then 1 requests in separate thread cause threads are enable. Each running thread locks process CPU cause of GIL.  

# Steps to test the changes
try to create comments via ggrc-perf 

# Solution description
Deny thread via GAE settings.

# Sanity checklist

- [x]   I have clicked through the app to make sure my changes work and not break the app.
- [x]   I have applied the correct milestone and labels.
- [x]   My changes fix the issue described in the description (and do nothing else). 🤞
- [ ]   My changes are covered by tests.
- [ ]   My changes follow our performance guidelines.
- [ ]   My changes follow our js and/or python guidelines.
- [ ]   My commits follow our commit guidelines.

# PR Review checklist

- [ ]   The changes fix the issue and don't cause any apparent regressions.
- [ ]   Labels and milestone are correctly set.
- [ ]   The solution description matches the changes in the code.
- [ ]   There is no apparent way to improve the performance & design of the new code.
- [ ]   The pull request is opened against the correct base branch.
- [ ]   Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".