### PR TITLE
GGRC-1789 Prevent "*" sign form object codes (slugs)

### DIFF
--- a/src/ggrc/migrations/versions/20180710160131_0e385718442a_remove_star_from_slugs.py
+++ b/src/ggrc/migrations/versions/20180710160131_0e385718442a_remove_star_from_slugs.py
@@ -1,0 +1,161 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Remove '*' from slugs
+
+Create Date: 2018-07-10 16:01:31.021762
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+import sqlalchemy as sa
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '0e385718442a'
+down_revision = '054d15be7a29'
+
+
+TABLES_WITH_SLUG = {
+    'access_groups', 'assessment_templates', 'assessments', 'audits',
+    'clauses', 'controls', 'cycle_task_group_object_tasks',
+    'cycle_task_groups', 'cycles', 'data_assets', 'directives', 'documents',
+    'evidence', 'facilities', 'issues', 'markets', 'metrics', 'objectives',
+    'org_groups', 'products', 'programs', 'projects', 'risk_assessments',
+    'risks', 'sections', 'systems', 'task_group_tasks', 'task_groups',
+    'threats', 'vendors', 'workflows',
+}
+
+
+CREATE_TMP_TABLES = """
+CREATE TEMPORARY TABLE `tmp_change_slugs`(
+    `tbl` VARCHAR(250),
+    `tbl_id` INT(11),
+    `tmp_slug` VARCHAR(250),
+    `new_slug` VARCHAR(250),
+
+    KEY (`tbl`),
+    KEY (`tbl_id`),
+    KEY (`new_slug`),
+    KEY (`new_slug`, `tbl`)
+);
+CREATE TEMPORARY TABLE `tmp_cache`(
+    `tbl` VARCHAR(250),
+    `slug` VARCHAR(250),
+
+    KEY (`tbl`),
+    KEY (`slug`)
+);
+"""
+
+
+DROP_TMP_TABLE = """
+DROP TABLE IF EXISTS `{tbl}`;
+"""
+
+
+# Select slugs matching mask, replace '*' to '-' and
+# cut slug to fit '{slug}-{INT(11)}' in VARCHAR(250) in worse case scenario
+SELECT_MASK_SLUGS = """
+SELECT
+    '{tbl}',
+    `id`,
+    LEFT(REPLACE(`slug`, '*', '-'), 238),
+    LEFT(REPLACE(`slug`, '*', '-'), 238)
+FROM `{tbl}`
+WHERE `slug` LIKE :mask
+"""
+
+CREATE_TABLE_WITH_SAME_NEW_SLUGS = """
+CREATE TEMPORARY TABLE tmp_same_new_slugs
+SELECT `tbl`, `new_slug` AS `slug`
+FROM `tmp_change_slugs`
+GROUP BY `new_slug`, `tbl`
+HAVING count(`new_slug`) > 1;
+"""
+
+
+UPDATE_TMP_SLUGS = """
+UPDATE `tmp_change_slugs` as `t1`
+JOIN `{_join}` as `t2`
+ON
+    `t1`.`new_slug` = `t2`.`slug`
+    AND `t1`.`tbl` = `t2`.`tbl`
+SET `t1`.`new_slug` = CONCAT(`t1`.`tmp_slug`, '-', @i:=@i+1)
+"""
+
+
+SELECT_SLUGS = """
+SELECT '{tbl}' AS `tbl`, `slug`
+FROM `{tbl}`
+"""
+
+
+UPDATE_SLUG = """
+UPDATE `{tbl}` AS `t1`
+JOIN `tmp_change_slugs` AS `t2`
+ON
+    `t1`.`id` = `t2`.`tbl_id`
+    AND '{tbl}' = `t2`.`tbl`
+SET `t1`.`slug` = `t2`.`new_slug`
+"""
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  connection = op.get_bind()
+  op.execute("SET AUTOCOMMIT = 1")
+  connection.execute(CREATE_TMP_TABLES)
+  connection.execute("SET @i = 0")  # Variable for generation unique suffixes
+
+  # Collect set of existing tables in db that have 'slug' column
+  tables_in_db = set(tbl[0] for tbl in connection.execute("SHOW TABLES")
+                     if tbl[0] in TABLES_WITH_SLUG)
+  # Insert slugs matching 'mask' to temporary table
+  query = "INSERT INTO `tmp_change_slugs`" + "UNION ALL".join(
+      SELECT_MASK_SLUGS.format(tbl=tbl) for tbl in tables_in_db
+  )
+  if not connection.execute(sa.sql.text(query), mask="%*%").rowcount:
+    # Quit if query not found matching slugs
+    connection.execute(DROP_TMP_TABLE.format(tbl="tmp_change_slugs"))
+    connection.execute(DROP_TMP_TABLE.format(tbl="tmp_cache"))
+    op.execute("SET AUTOCOMMIT = 0")
+    return
+
+  # Fix slugs in tmp table in case of same new_slugs
+  # example: 'C*-1', 'C-*1'
+  connection.execute(CREATE_TABLE_WITH_SAME_NEW_SLUGS)
+  connection.execute(UPDATE_TMP_SLUGS.format(_join="tmp_same_new_slugs"))
+
+  # Collect set of tables in tmp_change_slugs
+  _tables_query = "SELECT DISTINCT `tbl` FROM `tmp_change_slugs`"
+  tables_in_tmp = set(tbl[0] for tbl in connection.execute(_tables_query))
+  # Collect slugs in cache table
+  query = "INSERT INTO `tmp_cache`" + 'UNION ALL'.join(
+      SELECT_SLUGS.format(tbl=tbl) for tbl in tables_in_tmp
+  )
+  connection.execute(query)
+  # Query search for slugs already exists and change suffix
+  query = UPDATE_TMP_SLUGS.format(_join="tmp_cache")
+  conflicts = connection.execute(query).rowcount
+  # Attempt to resolve conflicts, until query affect zero rows
+  while conflicts:
+    conflicts = connection.execute(query).rowcount
+
+  # Update slugs in DB
+  for tbl in tables_in_tmp:
+    connection.execute(UPDATE_SLUG.format(tbl=tbl))
+
+  # Drop temporary tables
+  connection.execute(DROP_TMP_TABLE.format(tbl="tmp_change_slugs"))
+  connection.execute(DROP_TMP_TABLE.format(tbl="tmp_cache"))
+  connection.execute(DROP_TMP_TABLE.format(tbl="tmp_same_new_slugs"))
+  op.execute("SET AUTOCOMMIT = 0")
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  pass

--- a/src/ggrc/models/mixins/__init__.py
+++ b/src/ggrc/models/mixins/__init__.py
@@ -29,6 +29,7 @@ from sqlalchemy.orm.session import Session
 
 from ggrc import db
 from ggrc.models import reflection
+from ggrc.models import exceptions
 from ggrc.models.deferred import deferred
 from ggrc.models.mixins.customattributable import CustomAttributable
 from ggrc.models.mixins.notifiable import Notifiable
@@ -535,6 +536,16 @@ class Slugged(Base):
   @classmethod
   def generate_slug_prefix(cls):
     return cls.__name__.upper()
+
+  @validates("slug")
+  def validate_slug(self, _, value):
+    """Validates slug for presence of forbidden symbols"""
+    # pylint: disable=no-self-use
+    if value is not None and "*" in value:
+      raise exceptions.ValidationError(
+          "Field 'Code' contains unsupported symbol '*'"
+      )
+    return value
 
   @classmethod
   def ensure_slug_before_flush(cls, session, flush_context, instances):

--- a/src/ggrc/models/mixins/__init__.py
+++ b/src/ggrc/models/mixins/__init__.py
@@ -541,7 +541,7 @@ class Slugged(Base):
   def validate_slug(self, _, value):
     """Validates slug for presence of forbidden symbols"""
     # pylint: disable=no-self-use
-    if value is not None and "*" in value:
+    if value and "*" in value:
       raise exceptions.ValidationError(
           "Field 'Code' contains unsupported symbol '*'"
       )

--- a/test/integration/ggrc/converters/test_import_csv.py
+++ b/test/integration/ggrc/converters/test_import_csv.py
@@ -332,3 +332,21 @@ class TestBasicCsvImport(TestCase):
     self.assertEqual(response[0]["block_errors"], [
         errors.MISSING_COLUMN.format(column_names="Code", line=2, s="")
     ])
+
+  def test_import_code_validation(self):
+    """Test validation of 'Code' column during import"""
+    response = self.import_data(OrderedDict([
+        ("object_type", "Control"),
+        ("Code*", "*CONTROL-1"),
+        ("Admin", "user@example.com"),
+        ("Title", "Control_1")
+    ]))
+    self._check_csv_response(response, {
+        "Control": {
+            "row_errors": {
+                "Line 3: Field 'Code' validation failed with the following "
+                "reason: Field 'Code' contains unsupported symbol '*'. "
+                "The line will be ignored."
+            }
+        }
+    })

--- a/test/unit/ggrc/models/test_slugs.py
+++ b/test/unit/ggrc/models/test_slugs.py
@@ -8,6 +8,8 @@ import unittest
 import ddt
 
 from ggrc.models import all_models
+from ggrc.models import exceptions
+from ggrc.models.mixins import Slugged
 
 
 @ddt.ddt
@@ -77,4 +79,20 @@ class TestSlugPrefix(unittest.TestCase):
     self.assertEqual(
         sorted(all_prefixes),
         sorted(set(all_prefixes))
+    )
+
+  @ddt.data("*BAD-SLUG", "BAD**SLUG", "BAD-SLUG*")
+  def test_bad_slug_validation(self, bad_slug):
+    """Test slug validation with bad value"""
+    self.assertRaises(
+        exceptions.ValidationError,
+        Slugged().validate_slug, "slug", bad_slug
+    )
+
+  @ddt.data("GOOD-SLUG", None)
+  def test_good_slug_validation(self, good_slug):
+    """Test slug validation with good value"""
+    self.assertEqual(
+        Slugged().validate_slug("slug", good_slug),
+        good_slug
     )


### PR DESCRIPTION
# Issue description

Prevent "*" sign in object codes(slugs) 
Because exported Snapshots have slugs like "\*CONTROL-1234" (with "\*" to denote snapshot), "\*" entered by the user manually may confuse the users.

# Steps to test the changes

Create for example Control with Code field 'CONTROL*-1' and error should occur. Creation of objects with slug without '*' should finish successfully.

# Solution description

Add validator to field 'slug' in Slugged mixin.
For existing slugs add migration that will replace '\*'  to '-' and in case of conflict add "-{int}" to end of slug.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
*Migration will replace in existing slugs(codes) '\*'  to '-' and in case of conflict add "-{int}" to end of slug*

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".