### PR TITLE
GGRC-5438 Remove uppercase style for asmt custom attributes

### DIFF
--- a/src/ggrc-client/styles/components/custom-attributes/_custom-attributes.scss
+++ b/src/ggrc-client/styles/components/custom-attributes/_custom-attributes.scss
@@ -145,7 +145,6 @@ custom-attributes {
     color: #333;
     white-space: normal;
     word-wrap: break-word;
-    text-transform: uppercase;
     line-height: 16px;
     padding: 5px 0;
     &.custom-attribute-checkbox {

--- a/test/selenium/src/lib/entities/entity.py
+++ b/test/selenium/src/lib/entities/entity.py
@@ -166,6 +166,8 @@ class Representation(object):
             converted_attr_value = (
                 unicode(attr_value.get("title")) if
                 attr_name != "custom_attribute_definitions" else
+                {attr_value.get("id"): attr_value.get("title")} if
+                attr_value.get("title") != "Type" else
                 {attr_value.get("id"): attr_value.get("title").upper()}
             )
           if attr_name in ["custom_attribute_values"]:


### PR DESCRIPTION
# Issue description

Custom attributes on the Assessment page should be displayed in the same text case (not uppercase) as in the assessment templates.

# Steps to test the changes

1. Create assessment template with custom attributes
2. Generate assessment with this template
3. Open modal window with assessment info
4. Check that the attributes are not displayed in uppercase

# Solution description

Labels for attribute names have a css class with text-transform: uppercase. So removing this property allows to display these attributes in the initial case. 

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [ ] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

