### PR TITLE
GGRC-5648 Enable GTID mode on local dev db

### DIFF
--- a/._license_header_exceptions
+++ b/._license_header_exceptions
@@ -46,10 +46,6 @@
 < ._license_header_exceptions
 < node_modules
 < provision/docker/inventory
-< provision/docker/my.cnf
-< provision/docker/mysql/default_utf8.cnf
-< provision/docker/mysql/log.cnf
-< provision/docker/mysql/packet_size.cnf
 < PULL_REQUEST_TEMPLATE.md
 < pylintrc
 < README.md

--- a/provision/docker/my.cnf
+++ b/provision/docker/my.cnf
@@ -1,3 +1,6 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
 [mysqldump]
 user=root
 password=root

--- a/provision/docker/mysql/default_utf8.cnf
+++ b/provision/docker/mysql/default_utf8.cnf
@@ -1,3 +1,6 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
 [client]
 default-character-set = utf8
 

--- a/provision/docker/mysql/gtid_mode.cnf
+++ b/provision/docker/mysql/gtid_mode.cnf
@@ -1,0 +1,5 @@
+[mysqld]
+enforce-gtid-consistency = ON
+gtid-mode                = ON
+log-bin                  = mysql-bin
+log-slave-updates        = ON

--- a/provision/docker/mysql/gtid_mode.cnf
+++ b/provision/docker/mysql/gtid_mode.cnf
@@ -1,3 +1,6 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
 [mysqld]
 enforce-gtid-consistency = ON
 gtid-mode                = ON

--- a/provision/docker/mysql/log.cnf
+++ b/provision/docker/mysql/log.cnf
@@ -1,3 +1,6 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
 [mysqld]
 general_log         = 1
 general_log_file    = /tmp/mysql.log

--- a/provision/docker/mysql/packet_size.cnf
+++ b/provision/docker/mysql/packet_size.cnf
@@ -1,3 +1,6 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
 [mysqld]
 max_allowed_packet = 100M
 innodb_log_file_size = 128MB


### PR DESCRIPTION
# Issue description

Enable GTID mode on docker db container, like on Cloud SQL instance in Google Cloud.
Some migrations with "CREATE TEMPORARY TABLE" or "CREATE TABLE ... SELECT" queries can pass local and kokoro tests, but fail in Google Cloud.

# Solution description

Add gtid_mode.cnf file with necessary settings to enable GTID mode. 
Add license header to all MySQL config files

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".