### PR TITLE
GGRC-5554 Test Query API for updated_at field

### DIFF
--- a/test/integration/ggrc/services/test_query/test_updated_at.py
+++ b/test/integration/ggrc/services/test_query/test_updated_at.py
@@ -21,6 +21,8 @@ CHANGETRACKED_MODELS = (
     'Contract',
     'Control',
     'DataAsset',
+    'Document',
+    'Evidence',
     'Facility',
     'Issue',
     'Market',

--- a/test/integration/ggrc/services/test_query/test_updated_at.py
+++ b/test/integration/ggrc/services/test_query/test_updated_at.py
@@ -1,0 +1,81 @@
+# coding: utf-8
+
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Tests for /query api endpoint."""
+
+import ddt
+
+from freezegun import freeze_time
+from integration.ggrc import TestCase
+from integration.ggrc.models import factories
+from integration.ggrc.query_helper import WithQueryApi
+
+CHANGETRACKED_MODELS = (
+    'AccessGroup',
+    'Assessment',
+    'AssessmentTemplate',
+    'Audit',
+    'Clause',
+    'Contract',
+    'Control',
+    'DataAsset',
+    'Facility',
+    'Issue',
+    'Market',
+    'Objective',
+    'OrgGroup',
+    'Policy',
+    'Process',
+    'Product',
+    'Program',
+    'Project',
+    'Regulation',
+    'Risk',
+    'RiskAssessment',
+    'Requirement',
+    'Standard',
+    'System',
+    'TaskGroup',
+    'TaskGroupTask',
+    'Threat',
+    'Vendor',
+    'Workflow',
+)
+
+
+@ddt.ddt
+class TestUpdatedAt(WithQueryApi, TestCase):
+  """Tests for filtering by updated_at field"""
+
+  def setUp(self):
+    super(TestUpdatedAt, self).setUp()
+    self.client.get("/login")
+
+  @freeze_time("2018-05-20 12:23:17")
+  @ddt.data(*CHANGETRACKED_MODELS)
+  def test_updated_at_in_operator(self, model_name):
+    """Test updated_at field filters correctly with ~ and !~ operators"""
+    expected_in_id = set()
+    expected_not_in_id = set()
+    with freeze_time("2018-05-20 12:23:17"):
+      expected_in = factories.get_model_factory(model_name)()
+      expected_in_id.add(expected_in.id)
+    with freeze_time("2018-06-25 12:00:00"):
+      expected_not_in = factories.get_model_factory(model_name)()
+      expected_not_in_id.add(expected_not_in.id)
+    response_in = self.simple_query(
+        model_name,
+        expression=["Last Updated Date", "~", "05/20/2018"],
+        type_="ids",
+        field="ids"
+    )
+    response_not_in = self.simple_query(
+        model_name,
+        expression=["Last Updated Date", "!~", "2018-05-20"],
+        type_="ids",
+        field="ids"
+    )
+    self.assertItemsEqual(expected_in_id, response_in)
+    self.assertItemsEqual(expected_not_in_id, response_not_in)


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Since updated_at query API requests functionality works as designed and there are no tests to confirm it, we should cover it with tests.

# Steps to test the changes

Just run tests 

# Solution description

Tests for Query_API request for updated_at field were added. I've tested IN and NOT IN operators.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
