### PR TITLE
GGRC-5579 Fix eslint no-multi-spaces rule

### DIFF
--- a/src/ggrc-client/js/bootstrap/modal-ajax.js
+++ b/src/ggrc-client/js/bootstrap/modal-ajax.js
@@ -574,7 +574,7 @@ import {
             return;
           }
           if (e.type === 'keydown' && e.which !== 13) {
-            return;  // activate for keydown on Enter/Return only.
+            return; // activate for keydown on Enter/Return only.
           }
 
           href = $this.attr('data-href') || $this.attr('href');

--- a/src/ggrc-client/js/components/autocomplete/tests/autocomplete_spec.js
+++ b/src/ggrc-client/js/components/autocomplete/tests/autocomplete_spec.js
@@ -6,7 +6,7 @@
 describe('GGRC.Components.autocomplete', function () {
   'use strict';
 
-  let Component;  // the component under test
+  let Component; // the component under test
 
   beforeAll(function () {
     Component = GGRC.Components.get('autocomplete');
@@ -28,7 +28,7 @@ describe('GGRC.Components.autocomplete', function () {
     let eventData;
     let eventObj;
     let fakeViewModel;
-    let handler;  // the event handler under test
+    let handler; // the event handler under test
     let $childInput;
     let $element;
 

--- a/src/ggrc-client/js/components/related-objects/tests/related-urls_spec.js
+++ b/src/ggrc-client/js/components/related-objects/tests/related-urls_spec.js
@@ -208,7 +208,7 @@ describe('GGRC.Components.relatedUrls', function () {
         method(url);
 
         matches = _.filter(viewModel.attr('urls'), {link: url});
-        expect(matches.length).toEqual(1);  // still only 1
+        expect(matches.length).toEqual(1); // still only 1
         expect(viewModel.createUrl).not.toHaveBeenCalled();
       });
 

--- a/src/ggrc-client/js/components/revision-log/tests/revision-log_spec.js
+++ b/src/ggrc-client/js/components/revision-log/tests/revision-log_spec.js
@@ -180,7 +180,7 @@ describe('GGRC.Components.revisionLog', function () {
   });
 
   describe('_objectChangeDiff() method', function () {
-    let origModelAttrDefs = GGRC.model_attr_defs;  // original user-friendly attribute name settings
+    let origModelAttrDefs = GGRC.model_attr_defs; // original user-friendly attribute name settings
 
     beforeAll(function () {
       spyOn(viewModel, '_objectCADiff').and.returnValue({});
@@ -470,7 +470,7 @@ describe('GGRC.Components.revisionLog', function () {
   });
 
   describe('_fetchRevisionsData() method', function () {
-    let Revision;  // the Revision object constructor
+    let Revision; // the Revision object constructor
 
     // fake Deferred objects to return from the mocked Revision.findAll()
     let dfdResource;

--- a/src/ggrc-client/js/components/tasks-counter/tests/tasks-counter_spec.js
+++ b/src/ggrc-client/js/components/tasks-counter/tests/tasks-counter_spec.js
@@ -9,7 +9,7 @@ import Component from '../tasks-counter';
 describe('tasks-counter component', function () {
   'use strict';
 
-  let viewModel;  // the viewModel under test
+  let viewModel; // the viewModel under test
 
   beforeEach(function () {
     viewModel = getComponentVM(Component);

--- a/src/ggrc-client/js/components/tests/datepicker_spec.js
+++ b/src/ggrc-client/js/components/tests/datepicker_spec.js
@@ -9,7 +9,7 @@ import {DATE_FORMAT} from '../../plugins/utils/date-util';
 describe('GGRC.Components.datepicker', function () {
   'use strict';
 
-  let Component;  // the component under test
+  let Component; // the component under test
   let events;
 
   beforeAll(function () {

--- a/src/ggrc-client/js/components/tests/mapped_tree_view_spec.js
+++ b/src/ggrc-client/js/components/tests/mapped_tree_view_spec.js
@@ -26,7 +26,7 @@ describe('GGRC.Components.mappingTreeView', function () {
   ];
   let sortedAsc = _.sortByOrder(unsortedArray, 'field');
   let sortedDesc = _.sortByOrder(unsortedArray, 'field', 'desc');
-  let Component;  // the component under test
+  let Component; // the component under test
 
   beforeAll(function () {
     Component = GGRC.Components.get('mappingTreeView');

--- a/src/ggrc-client/js/components/tests/reminder_spec.js
+++ b/src/ggrc-client/js/components/tests/reminder_spec.js
@@ -6,7 +6,7 @@
 describe('GGRC.Components.reminder', function () {
   'use strict';
 
-  let Component;  // the component under test
+  let Component; // the component under test
 
   beforeAll(function () {
     Component = GGRC.Components.get('reminder');
@@ -15,7 +15,7 @@ describe('GGRC.Components.reminder', function () {
   describe('reminder() method', function () {
     let eventObj;
     let instance;
-    let method;  // the method under test
+    let method; // the method under test
     let pendingRefresh;
     let pendingSave;
     let scope;

--- a/src/ggrc-client/js/controllers/contributions.js
+++ b/src/ggrc-client/js/controllers/contributions.js
@@ -123,7 +123,7 @@ const userRolesModalSelector = can.Control.extend({
         self.element.trigger('loaded');
       });
 
-    this.on();  // Start listening for events
+    this.on(); // Start listening for events
 
     return deferred;
   },

--- a/src/ggrc-client/js/controllers/tests/modals_controller_spec.js
+++ b/src/ggrc-client/js/controllers/tests/modals_controller_spec.js
@@ -7,15 +7,15 @@ import DisplayPrefs from '../../models/local-storage/display-prefs';
 import ModalsController from '../modals/modals_controller';
 
 describe('ModalsController', function () {
-  let Ctrl;  // the controller under test
+  let Ctrl; // the controller under test
 
   beforeAll(function () {
     Ctrl = ModalsController;
   });
 
   describe('init() method', function () {
-    let ctrlInst;  // fake controller instance
-    let init;  // the method under tests
+    let ctrlInst; // fake controller instance
+    let init; // the method under tests
 
     beforeEach(function () {
       let html = [
@@ -60,7 +60,7 @@ describe('ModalsController', function () {
 
         let partialUser = new can.Map({
           id: userId,
-          email: '',  // simulate user object only partially loaded
+          email: '', // simulate user object only partially loaded
           refresh: jasmine.createSpy().and.returnValue(dfdRefresh.promise()),
         });
 

--- a/src/ggrc-client/js/controllers/tests/tree_view_controller_spec.js
+++ b/src/ggrc-client/js/controllers/tests/tree_view_controller_spec.js
@@ -9,14 +9,14 @@ import '../tree/tree-view';
 describe('CMS.Controllers.TreeView', function () {
   'use strict';
 
-  let Ctrl;  // the controller under test
+  let Ctrl; // the controller under test
 
   beforeAll(function () {
     Ctrl = CMS.Controllers.TreeView;
   });
 
   describe('init() method', function () {
-    let ctrlInst;  // fake controller instance
+    let ctrlInst; // fake controller instance
     let dfdSingleton;
     let method;
     let options;

--- a/src/ggrc-client/js/controllers/tests/tree_view_node_controller_spec.js
+++ b/src/ggrc-client/js/controllers/tests/tree_view_node_controller_spec.js
@@ -8,15 +8,15 @@ import '../tree/tree-view-node';
 describe('CMS.Controllers.TreeViewNode', function () {
   'use strict';
 
-  let Ctrl;  // the controller under test
+  let Ctrl; // the controller under test
 
   beforeAll(function () {
     Ctrl = CMS.Controllers.TreeViewNode;
   });
 
   describe('draw_node() method', function () {
-    let ctrlInst;  // fake controller instance
-    let ifNotRemovedResult;  // fake return value of the _ifNotRemoved() method
+    let ctrlInst; // fake controller instance
+    let ifNotRemovedResult; // fake return value of the _ifNotRemoved() method
     let method;
     let $element;
 
@@ -83,7 +83,7 @@ describe('CMS.Controllers.TreeViewNode', function () {
 
       ctrlInst.options.attr('isActive', false);
       ctrlInst.options.attr('disable_lazy_loading', true);
-      $element.removeClass('active');  // make sure it is indeed inactive
+      $element.removeClass('active'); // make sure it is indeed inactive
 
       method();
 
@@ -106,7 +106,7 @@ describe('CMS.Controllers.TreeViewNode', function () {
   });
 
   describe('expand() method', function () {
-    let ctrlInst;  // fake controller instance
+    let ctrlInst; // fake controller instance
     let displaySubtreesDfd;
     let method;
     let $tree;

--- a/src/ggrc-client/js/controllers/tree/tree-view-node.js
+++ b/src/ggrc-client/js/controllers/tree/tree-view-node.js
@@ -386,7 +386,7 @@ import {
       if ($tree.hasClass('active') &&
         ((maximizeInfoPane && treeHasMaximizedClass) ||
         (!maximizeInfoPane && !treeHasMaximizedClass))) {
-        return;  // tree node already selected, no need to activate it again
+        return; // tree node already selected, no need to activate it again
       }
 
       $tree.closest('section')

--- a/src/ggrc-client/js/entrypoints/dashboard/bootstrap.js
+++ b/src/ggrc-client/js/entrypoints/dashboard/bootstrap.js
@@ -63,7 +63,7 @@ $area.cms_controllers_page_object(can.extend({
   default_widgets: defaults || [],
   instance: getPageInstance(),
   header_view: GGRC.mustache_path + '/base_objects/page_header.mustache',
-  GGRC: GGRC,  // make the global object available in Mustache templates
+  GGRC: GGRC, // make the global object available in Mustache templates
   page_title: function (controller) {
     return controller.options.instance.title;
   },

--- a/src/ggrc-client/js/models/business-models/tests/cycle-task-group-object-task_spec.js
+++ b/src/ggrc-client/js/models/business-models/tests/cycle-task-group-object-task_spec.js
@@ -16,7 +16,7 @@ describe('CMS.Models.CycleTaskGroupObjectTask', function () {
 
   describe('responseOptionsEditable method', function () {
     let instance;
-    let method;  // the method under test
+    let method; // the method under test
     let Model;
     let origCycleConfig;
 

--- a/src/ggrc-client/js/models/tests/save_queue_spec.js
+++ b/src/ggrc-client/js/models/tests/save_queue_spec.js
@@ -8,7 +8,7 @@ describe('GGRC.SaveQueue', function () {
 
   describe('_process_save_responses() method', function () {
     let bucket;
-    let method;  // the method under test
+    let method; // the method under test
 
     beforeEach(function () {
       let thisContext = {};

--- a/src/ggrc-client/js/plugins/component_registry.js
+++ b/src/ggrc-client/js/plugins/component_registry.js
@@ -8,7 +8,7 @@
   'use strict';
 
   if (_.isFunction(GGRC.Components)) {
-    return;  // no need to create the component registry again
+    return; // no need to create the component registry again
   }
 
   // make the registry publicly available

--- a/src/ggrc-client/js/plugins/tests/component_registry_spec.js
+++ b/src/ggrc-client/js/plugins/tests/component_registry_spec.js
@@ -6,8 +6,8 @@
 describe('GGRC component registry', function () {
   'use strict';
 
-  let origStorage;  // the existing component private storage
-  let Components;  // the component registry utility
+  let origStorage; // the existing component private storage
+  let Components; // the component registry utility
 
   beforeAll(function () {
     Components = GGRC.Components;
@@ -89,7 +89,7 @@ describe('GGRC component registry', function () {
     });
 
     it('silently does nothing if a component does not exist', function () {
-      delete Components._registry.foo;  // the "foo" component does not exist
+      delete Components._registry.foo; // the "foo" component does not exist
 
       try {
         Components.unregister('foo');

--- a/src/ggrc-client/js_specs/models/assessment_template_spec.js
+++ b/src/ggrc-client/js_specs/models/assessment_template_spec.js
@@ -9,7 +9,7 @@ describe('can.Model.AssessmentTemplate', function () {
   'use strict';
 
   let AssessmentTemplate;
-  let instance;  // an AssessmentTemplate instance
+  let instance; // an AssessmentTemplate instance
 
   beforeAll(function () {
     AssessmentTemplate = CMS.Models.AssessmentTemplate;
@@ -112,7 +112,7 @@ describe('can.Model.AssessmentTemplate', function () {
     it('clears the assignees IDs dict if needed', function () {
       instance.attr('assigneesList', {'42': true});
       instance.attr('default_people', {
-        assignees: 'Some User Group',  // not a list of IDs
+        assignees: 'Some User Group', // not a list of IDs
       });
 
       instance._unpackPeopleData();
@@ -148,7 +148,7 @@ describe('can.Model.AssessmentTemplate', function () {
     it('clears the verifiers IDs dict if needed', function () {
       instance.attr('verifiersList', {'42': true});
       instance.attr('default_people', {
-        verifiers: 'Some User Group',  // not a list of IDs
+        verifiers: 'Some User Group', // not a list of IDs
       });
 
       instance._unpackPeopleData();

--- a/src/ggrc-client/js_specs/models/display_prefs_spec.js
+++ b/src/ggrc-client/js_specs/models/display_prefs_spec.js
@@ -155,7 +155,7 @@ describe('display prefs model', function () {
 
       it('sets the value for a widget', function () {
         display_prefs[func]('this arg is ignored', 'foo', fooValue);
-        let fooActual  = display_prefs.attr([exp.path, exp_token, 'foo'].join('.'));
+        let fooActual = display_prefs.attr([exp.path, exp_token, 'foo'].join('.'));
         expect(fooActual.serialize ? fooActual.serialize() : fooActual).toEqual(fooValue);
       });
 

--- a/src/ggrc-client/js_specs/models/mappers_spec.js
+++ b/src/ggrc-client/js_specs/models/mappers_spec.js
@@ -531,14 +531,14 @@ describe('mappers', function () {
       });
 
       it('removes no instance when nothing is supplied to remove', function () {
-        let instance =  new Dummy({ id: 3 });
+        let instance = new Dummy({ id: 3 });
         let binding = { list: [{ instance: instance, mappings: [] }] };
         ll.remove_instance(binding, {}, 'b');
         expect(binding.list).toEqual([{ instance: instance, mappings: [] }]);
       });
 
       it("removes no instance when instance doesn't match type", function () {
-        let instance =  new Dummy({ id: 3 });
+        let instance = new Dummy({ id: 3 });
         let WrongClass = can.Map.extend();
         WrongClass.shortName = 'Wrong';
         let wrong_instance = new WrongClass({ id: 3 });
@@ -548,14 +548,14 @@ describe('mappers', function () {
       });
 
       it('removes the instance from mappings when matching', function () {
-        let instance =  new Dummy({ id: 3 });
+        let instance = new Dummy({ id: 3 });
         let binding = { list: [{ instance: instance, mappings: [] }] };
         ll.remove_instance(binding, instance, 'b');
         expect(binding.list).toEqual([]);
       });
 
       it('removes the instance from mappings on just type and ID match', function () {
-        let instance =  new Dummy({ id: 3 });
+        let instance = new Dummy({ id: 3 });
         let matching_instance = new Dummy({ id: 3 });
         let binding = { list: [{ instance: instance, mappings: [] }] };
         expect(matching_instance).not.toBe(instance);
@@ -566,7 +566,7 @@ describe('mappers', function () {
       describe('with mappings defined', function () {
 
         it('deletes only if all mappings are accounted for in instance', function () {
-          let instance =  new Dummy({ id: 3 });
+          let instance = new Dummy({ id: 3 });
           let binding = {
             list: [{
               instance: instance,
@@ -585,7 +585,7 @@ describe('mappers', function () {
         });
 
         it('does not delete if not all mappings are accounted for', function () {
-          let instance =  new Dummy({ id: 3 });
+          let instance = new Dummy({ id: 3 });
           let binding = {
             list: [{
               instance: instance,

--- a/src/ggrc-client/js_specs/mustache_helpers/file_type_spec.js
+++ b/src/ggrc-client/js_specs/mustache_helpers/file_type_spec.js
@@ -7,7 +7,7 @@ describe('can.mustache.helper.file_type', function () {
   'use strict';
 
   let helper,
-    instance;  // the argument passed to the helper on invocation
+    instance; // the argument passed to the helper on invocation
 
   beforeAll(function () {
     helper = can.Mustache._helpers.file_type.fn;
@@ -43,7 +43,7 @@ describe('can.mustache.helper.file_type', function () {
   });
 
   it('returns a default value if there is no file extension', function () {
-    instance.title = 'txt';  // the filename matches a common extension
+    instance.title = 'txt'; // the filename matches a common extension
     expect(helper(instance)).toEqual('default');
   });
 

--- a/src/ggrc-client/js_specs/mustache_helpers/get_default_attr_value_spec.js
+++ b/src/ggrc-client/js_specs/mustache_helpers/get_default_attr_value_spec.js
@@ -7,7 +7,7 @@ describe('can.mustache.helper.get_default_attr_value', function () {
   'use strict';
 
   let helper;
-  let instance;  // an object the helper retrieves an attribute value from
+  let instance; // an object the helper retrieves an attribute value from
 
   beforeAll(function () {
     helper = can.Mustache._helpers.get_default_attr_value.fn;

--- a/src/ggrc-client/js_specs/mustache_helpers/get_item_spec.js
+++ b/src/ggrc-client/js_specs/mustache_helpers/get_item_spec.js
@@ -7,7 +7,7 @@ describe('can.mustache.helper.get_item', function () {
   'use strict';
 
   let helper;
-  let fakeOptions;  // a fake "options" argument
+  let fakeOptions; // a fake "options" argument
 
   beforeAll(function () {
     helper = can.Mustache._helpers.get_item.fn;

--- a/src/ggrc-client/js_specs/mustache_helpers/if_string_spec.js
+++ b/src/ggrc-client/js_specs/mustache_helpers/if_string_spec.js
@@ -6,7 +6,7 @@
 describe('can.mustache.helper.if_string', function () {
   'use strict';
 
-  let fakeOptions;  // fake mustache options object passed to the helper
+  let fakeOptions; // fake mustache options object passed to the helper
   let helper;
   let someContext;
 

--- a/src/ggrc-client/js_specs/mustache_helpers/model_info_spec.js
+++ b/src/ggrc-client/js_specs/mustache_helpers/model_info_spec.js
@@ -8,8 +8,8 @@ describe('can.mustache.helper.model_info', function () {
 
   let helper;
   let fakeModel;
-  let fakeOptions;  // a fake "options" argument
-  let origModel;  // the original model, if any, in the CMS.Models
+  let fakeOptions; // a fake "options" argument
+  let origModel; // the original model, if any, in the CMS.Models
 
   beforeAll(function () {
     helper = can.Mustache._helpers.model_info.fn;


### PR DESCRIPTION
# Issue description

Multiple spaces are found before comments and variable assignment.

# Steps to test the changes

Run "eslint --format compact src/ | grep 'no-multi-spaces'" command. The list of errors should be empty.

# Solution description

Remove multiple whitespaces according to the [no-multi-spaces](https://eslint.org/docs/rules/no-multi-spaces) rule.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
