### PR TITLE
GGRC-5621 Use common error messages in Assessment inline edit

### DIFF
--- a/src/ggrc-client/js/components/inline/inline-form-control.js
+++ b/src/ggrc-client/js/components/inline/inline-form-control.js
@@ -14,13 +14,11 @@
 
       saveInlineForm: function (args) {
         let self = this;
-        let oldValue = this.attr('instance.' + args.propName);
 
         this.attr('deferredSave').push(function () {
           self.attr('instance.' + args.propName, args.value);
-        }).fail(function () {
-          self.attr('instance.' + args.propName, oldValue);
-          GGRC.Errors.notifier('error', 'Unable to save changes.');
+        }).fail(function (instance, xhr) {
+          GGRC.Errors.notifierXHR('error')(xhr);
         });
       },
     },


### PR DESCRIPTION
# Issue description

The app shows incorrect message if there was a conflict.

# Steps to test the changes

- Have an assessment
- Go to the other attributes tab and use inline edit to create a conflict with the notes field

Expected: Conflict error message should be shown
Actual: Cannot save error message is shown

# Solution description

Use `notifierXHR` that shows correct message based on xhr status

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
