### PR TITLE
[WIP] GGRC-5628 Can't PUT ISO time to person_profile

### DIFF
--- a/src/ggrc/services/resources/person.py
+++ b/src/ggrc/services/resources/person.py
@@ -362,7 +362,8 @@ class PersonResource(common.ExtendedResource):
 
     try:
       requested_date_time = date_parser.parse(json["last_seen_whats_new"])
-      get_profile[1].last_seen_whats_new = requested_date_time
+      offset_naive = requested_date_time.replace(tzinfo=None)
+      get_profile[1].last_seen_whats_new = offset_naive
     except Exception as err:
       logger.exception(err)
       raise BadRequest()

--- a/test/integration/ggrc/services/resources/test_person.py
+++ b/test/integration/ggrc/services/resources/test_person.py
@@ -100,21 +100,24 @@ class TestPersonResource(TestCase, WithQueryApi):
                                     response,
                                     correct_response,
                                     user,
-                                    new_date):
+                                    expected):
     """Verify assertions for successful PUT profile method"""
     self.assert200(response)
     self.assertEqual(response.json, correct_response)
     profile = PersonProfile.query.filter_by(person_id=user.id).first()
-    self.assertEqual(profile.last_seen_whats_new, date_parser.parse(new_date))
+    self.assertEqual(profile.last_seen_whats_new, date_parser.parse(expected))
 
-  def test_profile_put_successful(self):
+  @ddt.data(
+      ["2018-05-20 16:38:17", "2018-05-20 16:38:17"],
+      ["2018-07-05T14:11:31Z", "2018-07-05T14:11:31"])
+  @ddt.unpack
+  def test_profile_put_successful(self, new_date, expected_date):
     """Test person_profile PUT method for setting data and correct response"""
     with factories.single_commit():
       user = factories.PersonFactory()
       self._create_users_names_rbac([user])
     self.api.set_user(person=user)
 
-    new_date = "2018-05-20 16:38:17"
     data = {"last_seen_whats_new": new_date}
     correct_response = {"Person": {"id": user.id, "profile": data}}
     response = self.api.client.put("/api/people/{}/profile".format(user.id),
@@ -124,7 +127,7 @@ class TestPersonResource(TestCase, WithQueryApi):
     self.assert_profile_put_successful(response,
                                        correct_response,
                                        user,
-                                       new_date)
+                                       expected_date)
 
   def test_profile_put_no_profile(self):
     """Test person_profile PUT method for setting data for missing profile"""


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

PUT to /api/people/<id>/profile with full ISO string returns HTTP500
# Steps to test the changes
Run tests. 
Send PUT request to /api/people/<id>/profile with last_seen_whats_new:"2018-07-18T14:37:40.894Z"

# Solution description

SQL Alchemy can't compare offset-naive and offset-aware datetimes. I've brought dates to the same offset-naive type
# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
