### PR TITLE
GGRC-4222 Move Cycle to history when deprecated

### DIFF
--- a/src/ggrc_workflows/migrations/versions/20180720081024_96b11a5760ee_for_all_deprecated_cycles_need_to_set_.py
+++ b/src/ggrc_workflows/migrations/versions/20180720081024_96b11a5760ee_for_all_deprecated_cycles_need_to_set_.py
@@ -1,0 +1,32 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+For all deprecated cycles need to set is_active false if it doesn't is_done yet
+
+Create Date: 2018-07-20 08:10:24.084605
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '96b11a5760ee'
+down_revision = '5eae0c070070'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  op.execute(
+      "UPDATE cycles SET is_current = 0 WHERE "
+      "status = 'Deprecated' AND is_current = 1")
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision.
+
+  Upgrade is updating different sets of data, so, we can't revert it properly
+  in downgrade and we just skip it.
+  """

--- a/test/integration/ggrc_workflows/test_api_calls.py
+++ b/test/integration/ggrc_workflows/test_api_calls.py
@@ -582,13 +582,13 @@ class TestStatusApiPatch(TestCase):
                                         [self.DEPRECATED] * 3)
     self.assertEqual(self.DEPRECATED, self.group.status)
     self.assertEqual(self.DEPRECATED, self.cycle.status)
-    self.assertEqual(all_models.Workflow.ACTIVE, self.workflow.status)
+    self.assertEqual(all_models.Workflow.INACTIVE, self.workflow.status)
     self.assert_status_over_bulk_update(
         [self.ASSIGNED, self.VERIFIED, self.FINISHED],
         [self.DEPRECATED] * 3)
     self.assertEqual(self.DEPRECATED, self.group.status)
     self.assertEqual(self.DEPRECATED, self.cycle.status)
-    self.assertEqual(all_models.Workflow.ACTIVE, self.workflow.status)
+    self.assertEqual(all_models.Workflow.INACTIVE, self.workflow.status)
 
   @ddt.data({"to_state": FINISHED, "success": True},
             {"to_state": IN_PROGRESS, "success": False},


### PR DESCRIPTION
# Issue description

Cycle is not moved to History If all cycle tasks have Deprecated state. 
**Actual Result:** Cycle is not moved to History If all cycle tasks have Deprecated state 
**Expected Result:** Cycle should be moved to History If all cycle tasks have Deprecated state

# Steps to test the changes

1. Create any workflow (e.g. Repeat off) 
2. In Setup tab create at least 3 tasks for task group 
3. Activate Workflow 
4. Go to Active Cycles tab 
5. Move all cycles tasks to Deprecated state 
6. Reload the page
7. Cycle should be moved to History If all cycle tasks have Deprecated state

# Solution description

Cycle will be current if his new status is not `Deprecated`, `Finished` or `Verified`
    
We assume that status `Finished` or `Verified` of the cycle make him `done` but `Deprecated` just change cycle status

Note: Expected behavior is cycle move to the history tab only after the page reloading

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [x] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
