### PR TITLE
GGRC-5584 Fix eslint prefer-spread issues

### DIFF
--- a/src/ggrc-client/js/components/assessment/assessment-generator-button.js
+++ b/src/ggrc-client/js/components/assessment/assessment-generator-button.js
@@ -94,7 +94,7 @@ export default can.Component.extend({
           return this.generateModel(item, id, options.type);
         }.bind(this));
         this._results = results;
-        $.when.apply($, results)
+        $.when(...results)
           .then(function () {
             let tasks = arguments;
             let ids;

--- a/src/ggrc-client/js/components/mapped-counter/mapped-counter.js
+++ b/src/ggrc-client/js/components/mapped-counter/mapped-counter.js
@@ -61,7 +61,7 @@ import Mappings from '../../models/mappers/mappings';
       let countQuery = buildCountParams(types, relevant);
       let dfds = countQuery.map(batchRequests);
 
-      return $.when.apply($, dfds).then(function () {
+      return $.when(...dfds).then(function () {
         let counts = Array.prototype.slice.call(arguments);
 
         let total = types.reduce(function (count, type, ind) {

--- a/src/ggrc-client/js/components/object-mapper/object-mapper.js
+++ b/src/ggrc-client/js/components/object-mapper/object-mapper.js
@@ -159,7 +159,7 @@ import Mappings from '../../models/mappers/mappings';
         onSubmit: function () {
           this.updateFreezedConfigToLatest();
           // calls base version
-          this._super.apply(this, arguments);
+          this._super(...arguments);
         },
       });
     },
@@ -324,7 +324,7 @@ import Mappings from '../../models/mappers/mappings';
             }));
           });
 
-          $.when.apply($, defer)
+          $.when(...defer)
             .fail((response, message) => {
               $('body').trigger('ajax:flash', {error: message});
             })

--- a/src/ggrc-client/js/components/related-objects/related-documents.js
+++ b/src/ggrc-client/js/components/related-objects/related-documents.js
@@ -122,8 +122,7 @@ import pubsub from '../../pub-sub';
       addDocuments: function (event) {
         let items = event.items;
         this.attr('isLoading', true);
-        return this.attr('documents').unshift
-          .apply(this.attr('documents'), items);
+        return this.attr('documents').unshift(...items);
       },
       createDocument: function (data) {
         let date = new Date();

--- a/src/ggrc-client/js/components/revision-log/revision-log.js
+++ b/src/ggrc-client/js/components/revision-log/revision-log.js
@@ -240,7 +240,7 @@ import {
           .map(fetchRevisions)
           .flatten()
           .value();
-        return $.when.apply($, dfds).then(function () {
+        return $.when(...dfds).then(function () {
           return _.filter(_.flatten(arguments), function (revision) {
             // revisions where source == destination will be introduced when
             // spoofing the obj <-> instance mapping

--- a/src/ggrc-client/js/components/tree/tree-item-extra-info.js
+++ b/src/ggrc-client/js/components/tree/tree-item-extra-info.js
@@ -143,7 +143,7 @@ let viewModel = can.Map.extend({
     if (dfdReady.state() === 'pending') {
       this.attr('spin', true);
       dfds.push(dataPromise);
-      dfdReady = $.when.apply($, dfds).then(function () {
+      dfdReady = $.when(...dfds).then(function () {
         this.attr('spin', false);
       }.bind(this));
 

--- a/src/ggrc-client/js/controllers/contributions.js
+++ b/src/ggrc-client/js/controllers/contributions.js
@@ -322,7 +322,7 @@ const userRolesModalSelector = can.Control.extend({
 
     // Create the new join (skipping "No Role" role, with id == 0)
     if (clickedOption.id > 0 && !alreadyExists) {
-      $.when.apply($, deleteDfds).then(function () {
+      $.when(...deleteDfds).then(function () {
         join = self.get_new_join(
           clickedOption.id,
           clickedOption.scope,
@@ -336,7 +336,7 @@ const userRolesModalSelector = can.Control.extend({
         });
       });
     } else {
-      $.when.apply($, deleteDfds).then(function () {
+      $.when(...deleteDfds).then(function () {
         $('body').trigger('treeupdate');
       });
     }

--- a/src/ggrc-client/js/controllers/filterable_controller.js
+++ b/src/ggrc-client/js/controllers/filterable_controller.js
@@ -32,7 +32,7 @@ export default can.Control({
       $(spinner.el).css(this.options.spinner_style);
       this.element.append(spinner.el);
     }
-    return $.when.apply($, search_dfds).then(function (data) {
+    return $.when(...search_dfds).then(function (data) {
       let _filter = null;
       let ids = null;
       if (data) {

--- a/src/ggrc-client/js/controllers/gapi_controllers.js
+++ b/src/ggrc-client/js/controllers/gapi_controllers.js
@@ -151,9 +151,9 @@
             that.authorize(params.scopes, true)
               .then($.proxy(that.gapi_request_with_auth, that, params))
               .then(function () {
-                dfd.resolve.apply(dfd, arguments);
+                dfd.resolve(...arguments);
               }, function () {
-                dfd.reject.apply(dfd, arguments);
+                dfd.reject(...arguments);
               });
           } else {
             cb.apply(window, args);
@@ -169,7 +169,7 @@
     }
   }, {
     init: function () {
-      this._super.apply(this, arguments);
+      this._super(...arguments);
       if (!this.constructor.canonical_instance) {
         this.constructor.canonical_instance = this;
       }

--- a/src/ggrc-client/js/controllers/lhn_controllers.js
+++ b/src/ggrc-client/js/controllers/lhn_controllers.js
@@ -335,7 +335,7 @@ can.Control('CMS.Controllers.LHN', {
   },
   destroy: function () {
     this.element.find('.lhs-holder').off('scroll', self.lhs_holder_onscroll);
-    this._super && this._super.apply(this, arguments);
+    this._super && this._super(...arguments);
   },
   '.lhn-pin click': function (element, event) {
     if (this.options.display_prefs.getLHNState().is_pinned) {
@@ -652,7 +652,7 @@ can.Control('CMS.Controllers.LHN_Search', {
       refresh_queue.enqueue(item);
     });
     refresh_queue.trigger().then(function (newItems) {
-      visible_list.push.apply(visible_list, newItems);
+      visible_list.push(...newItems);
       visible_list.attr('is_loading', false);
       delete that._show_more_pending;
     }).done(stopFn);
@@ -799,7 +799,7 @@ can.Control('CMS.Controllers.LHN_Search', {
       dfds.push(dfd);
     });
 
-    return $.when.apply($, dfds);
+    return $.when(...dfds);
   },
 
   refresh_counts: function () {
@@ -823,7 +823,7 @@ can.Control('CMS.Controllers.LHN_Search', {
         this.current_term, models, this.current_params, extraModels
       ).then(function () {
         if (this.search_id === search_id) {
-          return this.display_counts.apply(this, arguments);
+          return this.display_counts(...arguments);
         }
       }.bind(this));
   },
@@ -854,7 +854,7 @@ can.Control('CMS.Controllers.LHN_Search', {
           this.current_term, models, this.current_params
         ).then(function () {
           if (self.search_id === search_id) {
-            return self.display_lists.apply(self, arguments);
+            return self.display_lists(...arguments);
           }
         });
     } else {

--- a/src/ggrc-client/js/controllers/modals/approval-workflow-modal.js
+++ b/src/ggrc-client/js/controllers/modals/approval-workflow-modal.js
@@ -117,15 +117,14 @@ let ApprovalWorkflow = can.Observe({
       } else {
         ret = $.when(
           aws[0].instance.refresh(),
-          $.when.apply(
-            $,
-            can.map(aws[0].instance.task_groups.reify(), function (tg) {
+          $.when(...can.map(aws[0].instance.task_groups.reify(),
+            function (tg) {
               return tg.refresh();
             })
           ).then(function () {
-            return $.when.apply($, can.map(can.makeArray(arguments), function (tg) {
+            return $.when(...can.map(can.makeArray(arguments), function (tg) {
               return tg.attr('contact', that.contact).save().then(function (tg) {
-                return $.when.apply($, can.map(tg.task_group_tasks.reify(), function (tgt) {
+                return $.when(...can.map(tg.task_group_tasks.reify(), function (tgt) {
                   return tgt.refresh().then(function (tgt) {
 
                     return tgt.attr({
@@ -184,7 +183,7 @@ export default ModalsController({
 }, {
   init: function () {
     this.options.button_view = BUTTON_VIEW_SAVE_CANCEL;
-    this._super.apply(this, arguments);
+    this._super(...arguments);
   },
   'input[null-if-empty] change': function (el, ev) {
     if(el.val() === '') {

--- a/src/ggrc-client/js/controllers/modals/gapi-modal.js
+++ b/src/ggrc-client/js/controllers/modals/gapi-modal.js
@@ -12,7 +12,7 @@ export default ModalsController({
     content_view: GGRC.mustache_path + '/gdrive/auth_button.mustache',
   },
   init: function () {
-    this._super.apply(this, arguments);
+    this._super(...arguments);
     this.defaults.button_view = can.view.mustache('');
   },
 }, {

--- a/src/ggrc-client/js/controllers/modals/quick_form_controller.js
+++ b/src/ggrc-client/js/controllers/modals/quick_form_controller.js
@@ -51,7 +51,7 @@ export default ModalsController({
   autocomplete_select: function (el, event, ui) {
     let self = this;
     let prop = el.attr('name').split('.').slice(0, -1).join('.');
-    if (this._super.apply(this, arguments) !== false) {
+    if (this._super(...arguments) !== false) {
       setTimeout(function () {
         self.options.instance.save().then(function () {
           let obj = self.options.instance.attr(prop);
@@ -69,7 +69,7 @@ export default ModalsController({
       return;
     }
     if (this._super) {
-      this._super.apply(this, arguments);
+      this._super(...arguments);
     }
     ev.stopPropagation();
   },

--- a/src/ggrc-client/js/controllers/tree/tree-view-node.js
+++ b/src/ggrc-client/js/controllers/tree/tree-view-node.js
@@ -314,7 +314,7 @@ import {
           }
         });
 
-      return $.when.apply($, childTreeDfds);
+      return $.when(...childTreeDfds);
     },
 
     /**

--- a/src/ggrc-client/js/controllers/tree/tree-view.js
+++ b/src/ggrc-client/js/controllers/tree/tree-view.js
@@ -637,7 +637,7 @@ import Permission from '../../permission';
         $(this.element).sortable({element: 'li.tree-item', handle: '.drag'});
       }
       this.options.attr('filteredList', filteredItems);
-      res = $.when.apply($, drawItemsDfds);
+      res = $.when(...drawItemsDfds);
 
       res.then(function () {
         _.defer(this.draw_visible.bind(this));

--- a/src/ggrc-client/js/models/mappers/base-list-loader.js
+++ b/src/ggrc-client/js/models/mappers/base-list-loader.js
@@ -135,7 +135,7 @@ import RefreshQueue from '../refresh_queue';
       });
 
       if (newInstanceResults.length > 0) {
-        binding.list.push.apply(binding.list, newInstanceResults);
+        binding.list.push(...newInstanceResults);
 
         //  TODO: Examine whether deferring this list insertion avoids
         //    causing client-side freezes

--- a/src/ggrc-client/js/models/mappers/cross-list-loader.js
+++ b/src/ggrc-client/js/models/mappers/cross-list-loader.js
@@ -137,7 +137,7 @@
             deferreds.push(deferred);
           });
 
-          return $.when.apply($, deferreds);
+          return $.when(...deferreds);
         })
         .then(function () {
           return binding.list;

--- a/src/ggrc-client/js/models/mappers/multi-list-loader.js
+++ b/src/ggrc-client/js/models/mappers/multi-list-loader.js
@@ -55,7 +55,7 @@
         deferreds.push(sourceBinding.refresh_stubs());
       });
 
-      return $.when.apply($, deferreds);
+      return $.when(...deferreds);
     },
   });
 })(window.GGRC, window.can);

--- a/src/ggrc-client/js/modules/widget_descriptor.js
+++ b/src/ggrc-client/js/modules/widget_descriptor.js
@@ -163,7 +163,7 @@ import {getWidgetConfig} from '../plugins/utils/object-versions-utils';
         },
       };
 
-      $.extend.apply($, [true, descriptor].concat(extenders || []));
+      $.extend(...([true, descriptor].concat(extenders || [])));
 
       return new this(
         instance.constructor.shortName + ':' +
@@ -189,7 +189,7 @@ import {getWidgetConfig} from '../plugins/utils/object-versions-utils';
         return GGRC.widget_descriptors[id];
       }
 
-      ret = this._super.apply(this, arguments);
+      ret = this._super(...arguments);
       $.extend(ret, opts);
       GGRC.widget_descriptors[id] = ret;
       return ret;

--- a/src/ggrc-client/js/pbc/workflow_controller.js
+++ b/src/ggrc-client/js/pbc/workflow_controller.js
@@ -26,7 +26,7 @@
             return this._create_relationship(instance, item);
           }.bind(this)) :
           [];
-        instance.delay_resolving_save_until($.when.apply($, dfd));
+        instance.delay_resolving_save_until($.when(...dfd));
       }.bind(this));
     },
     '{CMS.Models.Requirement} created': function (model, ev, instance) {

--- a/src/ggrc-client/js/plugins/autocomplete.js
+++ b/src/ggrc-client/js/plugins/autocomplete.js
@@ -123,8 +123,7 @@ import Mappings from '../models/mappers/mappings';
           let objects = [];
 
           can.each(that.options.searchtypes, function (searchtype) {
-            objects.push.apply(objects,
-              searchResult.getResultsForType(searchtype));
+            objects.push(...searchResult.getResultsForType(searchtype));
           });
           return objects;
         });
@@ -198,7 +197,7 @@ import Mappings from '../models/mappers/mappings';
       let searchtypes;
       let typeNames;
 
-      this._super.apply(this, arguments);
+      this._super(...arguments);
       this.options.search_params = {
         extra_params: searchParams
       };
@@ -217,7 +216,7 @@ import Mappings from '../models/mappers/mappings';
           this,
           $.map(fromList.list, function (item) {
             let props = baseSearch.trim().split('.');
-            return item.instance.refresh_all.apply(item.instance, props);
+            return item.instance.refresh_all(...props);
           })
         );
       } else if (baseSearch) {
@@ -307,7 +306,7 @@ import Mappings from '../models/mappers/mappings';
             try {
               listItems = context.attr('items');
               context.attr('oldLen', listItems.length);
-              listItems.push.apply(listItems, can.map(items, function (item) {
+              listItems.push(...can.map(items, function (item) {
                 return item.item;
               }));
             } catch (error) {

--- a/src/ggrc-client/js/plugins/utils/current-page-utils.js
+++ b/src/ggrc-client/js/plugins/utils/current-page-utils.js
@@ -71,7 +71,7 @@ function initMappedInstances() {
     reqParams.push(batchRequests(query));
   });
 
-  return can.when.apply(can, reqParams)
+  return can.when(...reqParams)
     .then(function () {
       let response = can.makeArray(arguments);
 

--- a/src/ggrc-client/js/plugins/utils/tree-view-utils.js
+++ b/src/ggrc-client/js/plugins/utils/tree-view-utils.js
@@ -484,7 +484,7 @@ function loadItemsForSubTier(models, type, id, filter) {
         return batchRequests(params);
       });
 
-      resultDfd = can.when.apply(can, dfds).promise();
+      resultDfd = can.when(...dfds).promise();
 
       if (!related.initialized) {
         mappedDfd = initMappedInstances();


### PR DESCRIPTION
# Issue description

ES6 allow us to use the spread operator instead of .apply()

# Steps to test the changes

Run "eslint --format compact src/ | grep 'prefer-spread'" command. The list of errors should be empty.

# Solution description

All cases of using .apply with the same `this` argument are replaced with the spread operator ([prefer-spread](https://eslint.org/docs/rules/prefer-spread) rule)

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
