### PR TITLE
GGRC-5618 New default values for CAD

### DIFF
--- a/src/ggrc/models/custom_attribute_definition.py
+++ b/src/ggrc/models/custom_attribute_definition.py
@@ -156,6 +156,8 @@ class CustomAttributeDefinition(attributevalidator.AttributeValidator,
         CHECKBOX: "0",
         RICH_TEXT: "",
         TEXT: "",
+        DROPDOWN: "",
+        DATE: ""
     }
 
     DEFAULT_VALUE_MAPPING = {

--- a/test/integration/ggrc/models/test_revision.py
+++ b/test/integration/ggrc/models/test_revision.py
@@ -280,9 +280,9 @@ class TestRevisions(TestCase):
   @ddt.data(
       ("Text", ""),
       ("Rich Text", ""),
-      ("Dropdown", None),
+      ("Dropdown", ""),
       ("Checkbox", "0"),
-      ("Date", None),
+      ("Date", ""),
       ("Map:Person", "Person"),
   )
   @ddt.unpack
@@ -293,9 +293,9 @@ class TestRevisions(TestCase):
   @ddt.data(
       ("Text", ""),
       ("Rich Text", ""),
-      ("Dropdown", None),
+      ("Dropdown", ""),
       ("Checkbox", "0"),
-      ("Date", None),
+      ("Date", ""),
       ("Map:Person", "Person"),
   )
   @ddt.unpack

--- a/test/integration/ggrc/services/test_custom_attributes.py
+++ b/test/integration/ggrc/services/test_custom_attributes.py
@@ -227,9 +227,9 @@ class TestGlobalCustomAttributes(ProductTestCase):
   @ddt.data(
       (all_models.CustomAttributeDefinition.ValidTypes.TEXT, ""),
       (all_models.CustomAttributeDefinition.ValidTypes.RICH_TEXT, ""),
-      (all_models.CustomAttributeDefinition.ValidTypes.DROPDOWN, None),
+      (all_models.CustomAttributeDefinition.ValidTypes.DROPDOWN, ""),
       (all_models.CustomAttributeDefinition.ValidTypes.CHECKBOX, "0"),
-      (all_models.CustomAttributeDefinition.ValidTypes.DATE, None),
+      (all_models.CustomAttributeDefinition.ValidTypes.DATE, ""),
       ("Map:Person", None),
   )
   @ddt.unpack


### PR DESCRIPTION
# Issue description

System don't have proper default value for custom attribute definitions of `Dropdown` and `Date` types

# Steps to test the changes

Create global custom definition of `Date` type and in the response check if the backend receive `default_value: ""`

# Solution description

Add into enum list new default values for custom attribute definitions of `Dropdown` and `Date` types

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
