### PR TITLE
GGRC-5098/GGRC-5685/GGRC-5715 Remove view_object_page permission check

### DIFF
--- a/src/ggrc-client/js/components/view-object-buttons/view-object-buttons.mustache
+++ b/src/ggrc-client/js/components/view-object-buttons/view-object-buttons.mustache
@@ -4,20 +4,18 @@
 }}
 
 {{#if instance.viewLink}}
-  {{#is_allowed "view_object_page" instance}}
-    {{^openIsHidden}}
-    {{^instance.snapshot}}
-    <a href="{{instance.viewLink}}" target="_blank"
-       class="btn btn-mini btn-outline"
-       can-click="openObject">
-      Open
-    </a>
-    {{/instance.snapshot}}
-    {{/openIsHidden}}
-    {{^viewIsHidden}}
-    <a href="#" class="btn btn-mini btn-outline" can-click="maximizeObject">
-      View
-    </a>
-    {{/viewIsHidden}}
-  {{/is_allowed}}
+  {{^openIsHidden}}
+  {{^instance.snapshot}}
+  <a href="{{instance.viewLink}}" target="_blank"
+     class="btn btn-mini btn-outline"
+     can-click="openObject">
+    Open
+  </a>
+  {{/instance.snapshot}}
+  {{/openIsHidden}}
+  {{^viewIsHidden}}
+  <a href="#" class="btn btn-mini btn-outline" can-click="maximizeObject">
+    View
+  </a>
+  {{/viewIsHidden}}
 {{/if}}

--- a/src/ggrc-client/js/mustache_helper.js
+++ b/src/ggrc-client/js/mustache_helper.js
@@ -754,8 +754,7 @@ Mustache.registerHelper('date', function (date, hideTime) {
  *  {{#is_allowed ACTION [ACTION2 ACTION3...] RESOURCE_TYPE_STRING context=CONTEXT_ID}} content {{/is_allowed}}
  *  {{#is_allowed ACTION RESOURCE_INSTANCE}} content {{/is_allowed}}
  */
-let allowedActions = ['create', 'read', 'update', 'delete',
-  'view_object_page', '__GGRC_ADMIN__'];
+let allowedActions = ['create', 'read', 'update', 'delete', '__GGRC_ADMIN__'];
 Mustache.registerHelper('is_allowed', function () {
   let args = Array.prototype.slice.call(arguments, 0);
   let actions = [];

--- a/src/ggrc-client/js_specs/spec_setup.js
+++ b/src/ggrc-client/js_specs/spec_setup.js
@@ -18,7 +18,6 @@ GGRC.permissions = {
   'delete': {},
   read: {},
   update: {},
-  view_object_page: {},
 };
 GGRC.config = {
   snapshotable_parents: ['Audit'],

--- a/src/ggrc/assets/mustache/assessments/assignable_extended_info.mustache
+++ b/src/ggrc/assets/mustache/assessments/assignable_extended_info.mustache
@@ -7,7 +7,7 @@
   <div class="row-fluid">
     <div class="span12">
       {{#using program=instance.program}}
-        <a class="main-title {{instance.class.category}} oneline" href="{{#is_allowed 'view_object_page' 'Program' context=program.context}}{{viewLink}}{{else}}/dashboard#audit/audit/{{id}}{{/is_allowed}}">
+        <a class="main-title {{instance.class.category}} oneline" href="{{viewLink}}">
           {{instance.title}}
         </a>
       {{/using}}
@@ -61,7 +61,7 @@
     <div class="row-fluid">
       <div class="span12">
         {{#using program=instance.program}}
-          <a class="secondary oneline {{instance.class.category}}" href="{{#is_allowed 'view_object_page' 'Program' context=program.context}}{{program.viewLink}}{{else}}/dashboard{{/is_allowed}}#audit/audit/{{id}}">
+          <a class="secondary oneline {{instance.class.category}}" href="{{program.viewLink}}#audit/audit/{{id}}">
             View {{instance.title}}
           </a>
         {{/using}}

--- a/src/ggrc/assets/mustache/assessments/header.mustache
+++ b/src/ggrc/assets/mustache/assessments/header.mustache
@@ -82,14 +82,12 @@ Copyright (C) 2018 Google Inc.
                             {instance}="instance">
                         </issue-unmap-dropdown-item>
                         {{#if instance.viewLink}}
-                            {{#is_allowed "view_object_page" instance}}
-                                <li>
-                                    <a href="{{instance.viewLink}}">
-                                        <i class="fa fa-long-arrow-right"></i>
-                                        Open {{instance.class.title_singular}}
-                                    </a>
-                                </li>
-                            {{/is_allowed}}
+                            <li>
+                                <a href="{{instance.viewLink}}">
+                                    <i class="fa fa-long-arrow-right"></i>
+                                    Open {{instance.class.title_singular}}
+                                </a>
+                            </li>
                         {{/if}}
                         {{/is_info_pin}}
 

--- a/src/ggrc/assets/mustache/audits/dropdown_menu.mustache
+++ b/src/ggrc/assets/mustache/audits/dropdown_menu.mustache
@@ -93,14 +93,12 @@
     </issue-unmap-dropdown-item>
 
     {{#if instance.viewLink}}
-      {{#is_allowed "view_object_page" instance}}
-        <li>
-          <a href="{{instance.viewLink}}">
-            <i class="fa fa-long-arrow-right"></i>
-            Open {{instance.class.title_singular}}
-          </a>
-        </li>
-      {{/is_allowed}}
+      <li>
+        <a href="{{instance.viewLink}}">
+          <i class="fa fa-long-arrow-right"></i>
+          Open {{instance.class.title_singular}}
+        </a>
+      </li>
     {{/if}}
   {{/is_info_pin}}
 

--- a/src/ggrc/assets/mustache/base_objects/dropdown_menu.mustache
+++ b/src/ggrc/assets/mustache/base_objects/dropdown_menu.mustache
@@ -94,14 +94,12 @@
                   {{/is_allowed_to_map}}
               </issue-unmap-dropdown-item>
               {{#if instance.viewLink}}
-                {{#is_allowed "view_object_page" instance}}
-                  <li>
-                    <a href="{{instance.viewLink}}">
-                      <i class="fa fa-long-arrow-right"></i>
-                      Open {{instance.class.title_singular}}
-                    </a>
-                  </li>
-                {{/is_allowed}}
+                <li>
+                  <a href="{{instance.viewLink}}">
+                    <i class="fa fa-long-arrow-right"></i>
+                    Open {{instance.class.title_singular}}
+                  </a>
+                </li>
               {{/if}}
             {{/is_info_pin}}
 

--- a/src/ggrc/assets/mustache/cycles/info.mustache
+++ b/src/ggrc/assets/mustache/cycles/info.mustache
@@ -44,14 +44,12 @@
                   </a>
                   <ul class="dropdown-menu three-dots-list" aria-labelledby="drop1" role="menu">
                     {{#if workflow.viewLink}}
-                      {{!#is_allowed "view_object_page" instance}}
-                        <li>
-                          <a href="{{workflow.viewLink}}">
-                            <i class="fa fa-long-arrow-right"></i>
-                            Open {{workflow.class.title_singular}}
-                          </a>
-                        </li>
-                      {{!/is_allowed}}
+                      <li>
+                        <a href="{{workflow.viewLink}}">
+                          <i class="fa fa-long-arrow-right"></i>
+                          Open {{workflow.class.title_singular}}
+                        </a>
+                      </li>
                     {{/if}}
                     <li>
                       <clipboard-link title="Get permalink" notify="true" text="{{get_permalink_url}}" />

--- a/src/ggrc/assets/mustache/workflows/info.mustache
+++ b/src/ggrc/assets/mustache/workflows/info.mustache
@@ -99,14 +99,12 @@
 
                     {{#is_info_pin}}
                       {{#if instance.viewLink}}
-                        {{#is_allowed "view_object_page" instance}}
-                          <li>
-                            <a href="{{instance.viewLink}}">
-                              <i class="fa fa-long-arrow-right"></i>
-                              Open {{instance.class.title_singular}}
-                            </a>
-                          </li>
-                        {{/is_allowed}}
+                        <li>
+                          <a href="{{instance.viewLink}}">
+                            <i class="fa fa-long-arrow-right"></i>
+                            Open {{instance.class.title_singular}}
+                          </a>
+                        </li>
                       {{/if}}
                     {{/is_info_pin}}
 


### PR DESCRIPTION
# Issue description

**GGRC-5098** Users with global role (not only admin) should see "Open <Object>" in the 3bb menu on info panel of object.
**GGRC-5685** "Open" button is missed for global Creator, Reader, Editor.
**GGRC-5715** Incorrect Assessment link in LHN

# Steps to test the changes
**GGRC-5098** 
1. Login as global creator / reader / editor
2. Open any tree view 
3. Open info panel of some object
Actual result: User doesn't see "Open object" in 3bb menu
Expected result: User should see "Open object" (e.g. "Open Program") in 3bb menu

**GGRC-5685**
1. Login as global creator / reader / editor
2. Open Global Search
3. Search by any object, e.g. Control
4. Look at the Search results
Actual result: "Open" button is missed for Creator, Reader, Editor
Expected Result: "Open" button should be presented

**GGRC-5715**
1. Login as global creator / reader / editor
2. Open LHN on My work page
3. Expand Assessments accordion, hover over any Assessment
4. Click on Assessment link at the top of Info popup
Actual Result: My work page is opened
Expected Result: Assessment page should be opened

# Solution description

view_object_page permission was removed on the backend side some time ago. But we still have this permission check on the frontend side.
Admin user sees the 'open' buttons and link to the Assessment page, because he has all permissions. Whereas global creator, reader and editor doesn't have view_object_page permission, and that's why user cannot see the buttons and correct link.
So the solution is to completely remove 'view_object_page'.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
