### PR TITLE
GGRC-4256 Trim leading and trailing spaces in 'Code' field from all objects

### DIFF
--- a/src/ggrc/migrations/versions/20180731140314_d617da1998ef_trim_spaces_from_slugs.py
+++ b/src/ggrc/migrations/versions/20180731140314_d617da1998ef_trim_spaces_from_slugs.py
@@ -1,0 +1,35 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+trim spaces from slugs
+
+Create Date: 2018-07-31 14:03:14.421240
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name, duplicate-code
+
+from ggrc.migrations.utils.strip_text_field import \
+    strip_text_field_ensure_unique
+
+# revision identifiers, used by Alembic.
+revision = 'd617da1998ef'
+down_revision = '586c9b0bbebd'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+
+  tables_with_slug = {
+      'access_groups', 'assessment_templates', 'assessments', 'audits',
+      'clauses', 'controls', 'data_assets', 'directives', 'documents',
+      'evidence', 'facilities', 'issues', 'markets', 'metrics', 'objectives',
+      'org_groups', 'products', 'programs', 'projects', 'sections',
+      'systems', 'vendors',
+  }
+  strip_text_field_ensure_unique(tables_with_slug, 'slug')
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  pass

--- a/src/ggrc/models/mixins/__init__.py
+++ b/src/ggrc/models/mixins/__init__.py
@@ -541,6 +541,10 @@ class Slugged(Base):
   def validate_slug(self, _, value):
     """Validates slug for presence of forbidden symbols"""
     # pylint: disable=no-self-use
+    if value:
+      logger.warning("Slug \"%s\" contains unsupported leading or trailing "
+                     "whitespace. Slug will be trimmed.", value)
+      value = value.strip()
     if value and "*" in value:
       raise exceptions.ValidationError(
           "Field 'Code' contains unsupported symbol '*'"

--- a/src/ggrc_risks/migrations/versions/20180802075311_610cf459b347_trim_spaces_from_slugs.py
+++ b/src/ggrc_risks/migrations/versions/20180802075311_610cf459b347_trim_spaces_from_slugs.py
@@ -1,0 +1,32 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+trim spaces from slugs
+
+Create Date: 2018-08-02 07:53:11.233962
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name, duplicate-code
+
+from ggrc.migrations.utils.strip_text_field import \
+    strip_text_field_ensure_unique
+
+# revision identifiers, used by Alembic.
+
+revision = '610cf459b347'
+down_revision = '1d5aadd8ef75'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+
+  tables_with_slug = {
+      'threats', 'risk_assessments', 'risks',
+  }
+  strip_text_field_ensure_unique(tables_with_slug, 'slug')
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  pass

--- a/src/ggrc_workflows/migrations/versions/20180802073238_c17f5f1f273e_trim_spaces_from_slugs.py
+++ b/src/ggrc_workflows/migrations/versions/20180802073238_c17f5f1f273e_trim_spaces_from_slugs.py
@@ -1,0 +1,33 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+trim spaces from slugs
+
+Create Date: 2018-08-02 07:32:38.652046
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name, duplicate-code
+
+from ggrc.migrations.utils.strip_text_field import \
+    strip_text_field_ensure_unique
+
+
+# revision identifiers, used by Alembic.
+revision = 'c17f5f1f273e'
+down_revision = '96b11a5760ee'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+
+  tables_with_slug = {
+      'cycle_task_groups', 'workflows', 'cycle_task_group_object_tasks',
+      'task_group_tasks', 'task_groups', 'cycles',
+  }
+  strip_text_field_ensure_unique(tables_with_slug, 'slug')
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  pass

--- a/test/unit/ggrc/migrations/__init__.py
+++ b/test/unit/ggrc/migrations/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>

--- a/test/unit/ggrc/migrations/utils/__init__.py
+++ b/test/unit/ggrc/migrations/utils/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>

--- a/test/unit/ggrc/migrations/utils/test_strip_text_field.py
+++ b/test/unit/ggrc/migrations/utils/test_strip_text_field.py
@@ -1,0 +1,55 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Unit test suite for functions from ggrc.migrations.utils.strip_text_field"""
+
+import unittest
+import ddt
+
+from ggrc.migrations.utils.strip_text_field import get_unique_value, \
+    get_queries_for_stripping
+
+
+@ddt.ddt
+class TestStripUtils(unittest.TestCase):
+  """Test strip_text_field"""
+
+  @ddt.data(
+      ('value', set(), 'value'),
+      ('value', {'value'}, 'value-1'),
+      ('value', {'value-1'}, 'value'),
+  )
+  @ddt.unpack
+  def test_get_unique_value(self, value, existing_values, expected):
+    """Test get_unique_value"""
+    result = get_unique_value(value, existing_values)
+    self.assertEqual(result, expected)
+
+  def test_get_queries_for_stripping(self):
+    """Test test_get_queries_for_stripping"""
+    table_name = 'test_table'
+    field = 'some_field'
+    records = {
+        0: ' value',
+        1: 'value ',
+        2: 'value',
+        9: ' value ',
+        5: 'value-123',
+        3: None,
+    }
+    unique = True
+
+    expected_result = [
+        {'id': 9,
+         'text': 'UPDATE test_table SET some_field = :val WHERE id = :id',
+         'val': 'value-3'},
+        {'id': 1,
+         'text': 'UPDATE test_table SET some_field = :val WHERE id = :id',
+         'val': 'value-2'},
+        {'id': 0,
+         'text': 'UPDATE test_table SET some_field = :val WHERE id = :id',
+         'val': 'value-1'},
+    ]
+
+    result = get_queries_for_stripping(table_name, field, records, unique)
+    self.assertEqual(result, expected_result)


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

User can create objects with 'Code' field with leading or trailing spaces.

# Steps to test the changes

* Try to create any object with invalid 'Code' field contains any number of leading and / or trailing whitespaces.
  * Check that this object is created without leading and / or trailing whitespaces.

# Solution description

SLUG validation has been extended. Now it trim invalid SLUGs contains leading and trailing whitespace.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
