### PR TITLE
GGRC-5632 Add permission cache invalidation in doc

### DIFF
--- a/src/ggrc/views/__init__.py
+++ b/src/ggrc/views/__init__.py
@@ -54,6 +54,7 @@ from ggrc.views.registry import object_view
 from ggrc import utils
 from ggrc.utils import benchmark, helpers
 from ggrc.utils import revisions
+from ggrc.cache.utils import clear_permission_cache
 
 logger = logging.getLogger(__name__)
 REINDEX_CHUNK_SIZE = 100
@@ -732,5 +733,6 @@ def make_document_admin():
   for doc in docs:
     doc.add_admin_role()
   db.session.commit()
+  clear_permission_cache()
   response = DocumentEndpoint.build_make_admin_response(request.json, docs)
   return Response(json.dumps(response), mimetype='application/json')


### PR DESCRIPTION
# Issue description

Document is not mapped in case when attaching a gdrive file and this document already exist in the system.
Actual result: The user is made an admin of the document but the document is not attached
Expected result: The document should be attached

# Steps to test the changes
1. Login as <user1>
2. Create a file in Gdrive, share it <user2>
3. Create a control, attach this gdrive file
4. Login as <user2> (not an admin)
5. Create a control, click attach -> Attach new -> choose this gdrive file.
6. Click Proceed in the warning
7. The document should be attached

# Solution description

When the user post the request to making him the admin of the attached document the system doesn't invalidate the permission cache and as the result the client receive cached permissions which are not contain the new one for document. 

**Note:** I use explicit call of cache invalidation as we agreed before instead of hooks.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
