### PR TITLE
GGRC-5177 Remove evidence file from audit/assessment import template

### DIFF
--- a/src/ggrc-client/js/components/import-export/download-template/download-template.js
+++ b/src/ggrc-client/js/components/import-export/download-template/download-template.js
@@ -5,7 +5,7 @@
 
 import '../../dropdown/multiselect-dropdown';
 import template from './download-template.mustache';
-import {exportRequest, download} from '../import-export-utils';
+import {downloadTemplate, download} from '../import-export-utils';
 
 const tag = 'download-template';
 const CSV_FILE_NAME = 'import_template.csv';
@@ -54,14 +54,12 @@ const viewModel = can.Map.extend({
     objects = Array.from(selected).map(({name}) => {
       return {
         object_name: name,
-        fields: 'all',
       };
     });
 
-    return exportRequest({
+    return downloadTemplate({
       data: {
         objects,
-        export_to: 'csv',
       },
     }).then(function (data) {
       download(CSV_FILE_NAME, data);

--- a/src/ggrc-client/js/components/import-export/download-template/download-template_spec.js
+++ b/src/ggrc-client/js/components/import-export/download-template/download-template_spec.js
@@ -47,22 +47,21 @@ describe('download-template component', () => {
 
   describe('downloadCSV method', () => {
     it('should do ajax call in proper format', (done) => {
-      spyOn(Utils, 'exportRequest')
+      spyOn(Utils, 'downloadTemplate')
         .and.returnValue(can.Deferred().resolve('FooBar'));
       spyOn(Utils, 'download');
 
       vm.attr('selected', [{name: 'Foo'}, {name: 'Bar'}, {name: 'Baz'}]);
 
       vm.downloadCSV().then(() => {
-        expect(Utils.exportRequest)
+        expect(Utils.downloadTemplate)
           .toHaveBeenCalledWith({
             data: {
               objects: [
-                {object_name: 'Foo', fields: 'all'},
-                {object_name: 'Bar', fields: 'all'},
-                {object_name: 'Baz', fields: 'all'},
+                {object_name: 'Foo'},
+                {object_name: 'Bar'},
+                {object_name: 'Baz'},
               ],
-              export_to: 'csv',
             },
           });
         expect(Utils.download)
@@ -74,27 +73,27 @@ describe('download-template component', () => {
     });
 
     it('should not do ajax call if nothing selected', () => {
-      spyOn(Utils, 'exportRequest');
+      spyOn(Utils, 'downloadTemplate');
       spyOn(Utils, 'download');
 
       vm.attr('selected', []);
 
       vm.downloadCSV();
 
-      expect(Utils.exportRequest).not.toHaveBeenCalled();
+      expect(Utils.downloadTemplate).not.toHaveBeenCalled();
       expect(Utils.download).not.toHaveBeenCalled();
     });
 
     it('should not download CSV and should close the modal after error during' +
-      '"exportRequest" phase', (done) => {
-      spyOn(Utils, 'exportRequest')
+      '"downloadTemplate" phase', (done) => {
+      spyOn(Utils, 'downloadTemplate')
         .and.returnValue(can.Deferred().reject());
       spyOn(Utils, 'download');
 
       vm.attr('selected', [1, 2, 3]);
 
       vm.downloadCSV().fail(() => {
-        expect(Utils.exportRequest).toHaveBeenCalled();
+        expect(Utils.downloadTemplate).toHaveBeenCalled();
         expect(Utils.download).not.toHaveBeenCalled();
         expect(vm.attr('modalState.open')).toEqual(false);
 

--- a/src/ggrc-client/js/components/import-export/import-export-utils.js
+++ b/src/ggrc-client/js/components/import-export/import-export-utils.js
@@ -59,7 +59,7 @@ export const deleteExportJob = (jobId) => {
   return request(`/api/people/${currentUserId}/exports/${jobId}`, 'DELETE');
 };
 
-export const exportRequest = (request) => {
+export const downloadTemplate = (request) => {
   return $.ajax({
     type: 'POST',
     headers: $.extend({
@@ -67,7 +67,7 @@ export const exportRequest = (request) => {
       'X-export-view': 'blocks',
       'X-requested-by': 'GGRC',
     }, request.headers || {}),
-    url: '/_service/export_csv',
+    url: '/_service/export_csv_template',
     data: JSON.stringify(request.data || {}),
   });
 };

--- a/test/integration/ggrc/converters/test_assessment_csv_template.py
+++ b/test/integration/ggrc/converters/test_assessment_csv_template.py
@@ -19,11 +19,6 @@ class TestAssessmentCSVTemplate(TestCase):
     """Set up for test cases."""
     super(TestAssessmentCSVTemplate, self).setUp()
     self.client.get("/login")
-    self.headers = {
-        'Content-Type': 'application/json',
-        "X-Requested-By": "GGRC",
-        "X-export-view": "blocks",
-    }
 
   def test_exported_csv(self):
     """Tests attributes order in exported assessment csv."""
@@ -40,3 +35,9 @@ class TestAssessmentCSVTemplate(TestCase):
     response = self.export_csv(data)
     self.assertEqual(response.status_code, 200)
     self.assertIn("Verifiers,Comments,Last Comment,GCA 1", response.data)
+
+  def test_exclude_evidence_file(self):
+    """Test exclude evidence file field from csv template"""
+    objects = [{"object_name": "Assessment"}]
+    response = self.export_csv_template(objects)
+    self.assertNotIn("Evidence File", response.data)

--- a/test/integration/ggrc/converters/test_audit_csv_template.py
+++ b/test/integration/ggrc/converters/test_audit_csv_template.py
@@ -1,0 +1,21 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Tests generation csv template for audits."""
+
+from integration.ggrc import TestCase
+
+
+class TestAuditCSVTemplate(TestCase):
+  """Tests generation csv template for audits."""
+
+  def setUp(self):
+    """Set up for test cases."""
+    super(TestAuditCSVTemplate, self).setUp()
+    self.client.get("/login")
+
+  def test_exclude_evidence_file(self):
+    """Test exclude evidence file field from csv template"""
+    objects = [{"object_name": "Audit"}]
+    response = self.export_csv_template(objects)
+    self.assertNotIn("Evidence File", response.data)


### PR DESCRIPTION
# Issue description

Remove evidence file from audit/assessment import template

# Steps to test the changes

Download template, check that 'Evidence File' is absent

# Solution description
Added endpoint for downloading of templates.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
