### PR TITLE
Bump version up to 1.18.0-Strawberry

### DIFF
--- a/src/ggrc/settings/default.py
+++ b/src/ggrc/settings/default.py
@@ -56,7 +56,7 @@ except ImportError:
 # for more info) and if the version name were to exceed 30 characters, all
 # deployments would go to the same GAE app version. Please take that into
 # consideration when modifying this string.
-VERSION = "1.17.0-Strawberry" + BUILD_NUMBER
+VERSION = "1.18.0-Strawberry" + BUILD_NUMBER
 
 # Migration owner
 MIGRATOR = os.environ.get(


### PR DESCRIPTION
# Dependencies

This PR is `on hold` until the dependencies are merged:


- [ ]https://github.com/google/ggrc-core/pull/8228

