### PR TITLE
GGRC-5771 Query API performance of IssueTracked objects

### DIFF
--- a/src/ggrc/models/assessment.py
+++ b/src/ggrc/models/assessment.py
@@ -149,13 +149,10 @@ class Assessment(Assignable, statusable.Statusable, AuditRelationship,
   @classmethod
   def _populate_query(cls, query):
     return query.options(
-        orm.Load(cls).undefer_group(
-            "Assessment_complete",
-        ),
-        orm.Load(cls).joinedload(
-            "audit"
-        ).undefer_group(
-            "Audit_complete",
+        orm.Load(cls).undefer_group("Assessment_complete"),
+        orm.Load(cls).joinedload("audit").undefer_group("Audit_complete"),
+        orm.Load(cls).joinedload("audit").joinedload(
+            audit.Audit.issuetracker_issue
         ),
     )
 

--- a/src/ggrc/models/assessment_template.py
+++ b/src/ggrc/models/assessment_template.py
@@ -170,7 +170,10 @@ class AssessmentTemplate(assessment.AuditRelationship,
   def eager_query(cls):
     query = super(AssessmentTemplate, cls).eager_query()
     return query.options(
-        orm.Load(cls).joinedload("audit").undefer_group("Audit_complete")
+        orm.Load(cls).joinedload("audit").undefer_group("Audit_complete"),
+        orm.Load(cls).joinedload("audit").joinedload(
+            audit.Audit.issuetracker_issue
+        ),
     )
 
   @classmethod

--- a/src/ggrc/models/assessment_template.py
+++ b/src/ggrc/models/assessment_template.py
@@ -13,11 +13,11 @@ from ggrc import login
 from ggrc.builder import simple_property
 from ggrc.models import assessment
 from ggrc.models import audit
-from ggrc.models import issuetracker_issue
 from ggrc.models import mixins
 from ggrc.models import relationship
 from ggrc.models.mixins import base
 from ggrc.models.mixins import clonable
+from ggrc.models.mixins import issue_tracker
 from ggrc.models.exceptions import ValidationError
 from ggrc.models.reflection import AttributeInfo
 from ggrc.models import reflection
@@ -27,10 +27,17 @@ from ggrc.fulltext.mixin import Indexed
 from ggrc.rbac.permissions import permissions_for
 
 
-class AssessmentTemplate(assessment.AuditRelationship, relationship.Relatable,
-                         mixins.Titled, mixins.CustomAttributable,
-                         Roleable, base.ContextRBAC, mixins.Slugged,
-                         mixins.Stateful, clonable.MultiClonable, Indexed,
+class AssessmentTemplate(assessment.AuditRelationship,
+                         relationship.Relatable,
+                         mixins.Titled,
+                         mixins.CustomAttributable,
+                         Roleable,
+                         issue_tracker.IssueTrackedWithUrl,
+                         base.ContextRBAC,
+                         mixins.Slugged,
+                         mixins.Stateful,
+                         clonable.MultiClonable,
+                         Indexed,
                          db.Model):
   """A class representing the assessment template entity.
 
@@ -259,13 +266,6 @@ class AssessmentTemplate(assessment.AuditRelationship, relationship.Relatable,
     if hasattr(self, 'context') and hasattr(self.context, 'related_object'):
       return getattr(self.context.related_object, 'archived', False)
     return False
-
-  @simple_property
-  def issue_tracker(self):
-    """Returns representation of issue tracker related info as a dict."""
-    issue_obj = issuetracker_issue.IssuetrackerIssue.get_issue(
-        'AssessmentTemplate', self.id)
-    return issue_obj.to_dict() if issue_obj is not None else {}
 
 
 def create_audit_relationship(audit_stub, obj):

--- a/src/ggrc/models/audit.py
+++ b/src/ggrc/models/audit.py
@@ -235,12 +235,18 @@ def build_audit_stub(obj):
   audit_id = obj.audit_id
   if audit_id is None:
     return None
-  issue_obj = issuetracker_issue.IssuetrackerIssue.get_issue(
-      'Audit', audit_id)
+  if getattr(obj, "issuetracker_issue", None) is not None:
+    issue_dict = obj.issue_tracker \
+        if getattr(obj, "issue_tracker", None) \
+        else obj.issuetracker_issue.to_dict()
+  else:
+    issue_obj = issuetracker_issue.IssuetrackerIssue.get_issue(
+        'Audit', audit_id)
+    issue_dict = issue_obj.to_dict() if issue_obj is not None else {}
   return {
       'type': 'Audit',
       'id': audit_id,
       'context_id': obj.context_id,
       'href': '/api/audits/%d' % audit_id,
-      'issue_tracker': issue_obj.to_dict() if issue_obj is not None else {},
+      'issue_tracker': issue_dict,
   }

--- a/src/ggrc/models/audit.py
+++ b/src/ggrc/models/audit.py
@@ -16,7 +16,6 @@ from ggrc.models.mixins.with_evidence import WithEvidence
 from ggrc.rbac import SystemWideRoles
 
 from ggrc.fulltext.mixin import Indexed
-from ggrc.models import issuetracker_issue
 from ggrc.models import reflection
 from ggrc.models.context import HasOwnContext
 from ggrc.models.mixins import base
@@ -235,18 +234,10 @@ def build_audit_stub(obj):
   audit_id = obj.audit_id
   if audit_id is None:
     return None
-  if getattr(obj, "issuetracker_issue", None) is not None:
-    issue_dict = obj.issue_tracker \
-        if getattr(obj, "issue_tracker", None) \
-        else obj.issuetracker_issue.to_dict()
-  else:
-    issue_obj = issuetracker_issue.IssuetrackerIssue.get_issue(
-        'Audit', audit_id)
-    issue_dict = issue_obj.to_dict() if issue_obj is not None else {}
   return {
       'type': 'Audit',
       'id': audit_id,
       'context_id': obj.context_id,
       'href': '/api/audits/%d' % audit_id,
-      'issue_tracker': issue_dict,
+      'issue_tracker': obj.audit.issue_tracker,
   }

--- a/src/ggrc/models/mixins/issue_tracker.py
+++ b/src/ggrc/models/mixins/issue_tracker.py
@@ -59,7 +59,7 @@ class IssueTracked(object):
     """Define fields to be loaded eagerly to lower the count of DB queries."""
     query = super(IssueTracked, cls).eager_query()
     return query.options(
-        orm.subqueryload('issuetracker_issue')
+        orm.joinedload('issuetracker_issue')
     )
 
   @simple_property

--- a/src/ggrc/models/mixins/issue_tracker.py
+++ b/src/ggrc/models/mixins/issue_tracker.py
@@ -54,6 +54,14 @@ class IssueTracked(object):
         uselist=False,
     )
 
+  @classmethod
+  def eager_query(cls):
+    """Define fields to be loaded eagerly to lower the count of DB queries."""
+    query = super(IssueTracked, cls).eager_query()
+    return query.options(
+        orm.subqueryload('issuetracker_issue')
+    )
+
   @simple_property
   def issue_tracker(self):
     """Returns representation of issue tracker related info as a dict."""

--- a/src/ggrc/models/requirement.py
+++ b/src/ggrc/models/requirement.py
@@ -3,6 +3,8 @@
 
 """Module with Requirement model."""
 
+from sqlalchemy import orm
+
 from ggrc import db
 from ggrc.access_control.roleable import Roleable
 from ggrc.fulltext.mixin import Indexed
@@ -52,6 +54,12 @@ class Requirement(Roleable,
   _api_attrs = reflection.ApiAttributes('notes')
   _sanitize_html = ['notes']
   _include_links = []
+
+  @classmethod
+  def eager_query(cls):
+    """Define fields to be loaded eagerly to lower the count of DB queries."""
+    query = super(Requirement, cls).eager_query()
+    return query.options(orm.undefer('notes'))
 
   @classmethod
   def _filter_by_directive(cls, predicate):

--- a/test/integration/ggrc/fulltext/test_total_reindex.py
+++ b/test/integration/ggrc/fulltext/test_total_reindex.py
@@ -30,23 +30,25 @@ class TestTotalReindex(TestCase):
       'AssessmentTemplate': 6,
       'Audit': 7,
       'Comment': 4,
-      'Contract': 9,
-      'Control': 12,
-      'Cycle': 5,
-      'CycleTaskEntry': 4,
-      'CycleTaskGroup': 5,
-      'CycleTaskGroupObjectTask': 5,
-      'Evidence': 25,   # TODO improve
+      'Contract': 19,  # was 9
+      'Control': 21,  # was 11
+      'Cycle': 4,
+      # for workflow objects the additional queries are counted
+      # TODO: rewrite test
+      'CycleTaskEntry': 45,
+      'CycleTaskGroup': 10,
+      'CycleTaskGroupObjectTask': 26,
+      'Evidence': 7,
       'Document': 5,
       'Issue': 8,
       'Market': 8,
-      'Objective': 9,
+      'Objective': 19,  # was 9
       'OrgGroup': 8,
       'Person': 5,
-      'Policy': 9,
+      'Policy': 19,  # was 9
       'Process': 8,
-      'Program': 7,
-      'Regulation': 9,
+      'Program': 17,  # was 7
+      'Regulation': 19,  # was 9
       'TaskGroup': 4,
       'TaskGroupObject': 5,
       'TaskGroupTask': 4,
@@ -78,6 +80,7 @@ class TestTotalReindex(TestCase):
       ggrc_factories.ProgramFactory,
       ggrc_factories.RegulationFactory,
       ggrc_factories.DocumentFactory,
+      ggrc_factories.EvidenceFactory,
       ggrc_factories.MetricFactory,
       ggrc_factories.ProductFactory,
       ggrc_factories.ProductGroupFactory,
@@ -130,7 +133,8 @@ class TestTotalReindex(TestCase):
     for instance in query:
       db.session.reindex_set.add(instance)
     with QueryCounter() as counter:
-      mysql.update_indexer(db.session)
+      db.session.reindex_set.push_ft_records()
+      self.assertNotEqual(counter.get, 0)
       self.assertLessEqual(
           counter.get,
           self.INDEX_QUERY_LIMIT[model.__name__],

--- a/test/integration/ggrc/fulltext/test_total_reindex.py
+++ b/test/integration/ggrc/fulltext/test_total_reindex.py
@@ -38,7 +38,7 @@ class TestTotalReindex(TestCase):
       'CycleTaskEntry': 45,
       'CycleTaskGroup': 10,
       'CycleTaskGroupObjectTask': 26,
-      'Evidence': 7,
+      'Evidence': 25,
       'Document': 5,
       'Issue': 8,
       'Market': 8,

--- a/test/integration/ggrc/models/test_assessment_template.py
+++ b/test/integration/ggrc/models/test_assessment_template.py
@@ -40,8 +40,10 @@ class TestAssessmentTemplate(TestCase):
       audit_id = audit.id
       factories.IssueTrackerIssueFactory(
           issue_tracked_obj=audit,
-          component_id="some id",
+          component_id="some component id",
           hotlist_id="some host id",
+          title="some title",
+          issue_id="some issue id"
       )
       template_id = factories.AssessmentTemplateFactory(
           audit=audit,
@@ -53,17 +55,21 @@ class TestAssessmentTemplate(TestCase):
     self.assertEqual(
         response.json["assessment_template"]["audit"],
         {
-            "type": "Audit",
-            "id": audit.id,
-            "href": "/api/audits/{}".format(audit.id),
-            "context_id": audit.context.id,
-            "issue_tracker": {
-                "component_id": "some id",
-                "enabled": False,
-                "issue_severity": None,
-                "hotlist_id": "some host id",
-                "issue_priority": None,
-                "issue_type": None
+            u"type": u"Audit",
+            u"id": long(audit.id),
+            u"href": u"/api/audits/{}".format(long(audit.id)),
+            u"context_id": long(audit.context.id),
+            u"issue_tracker": {
+                u'_warnings': [],
+                u"component_id": u"some component id",
+                u"enabled": False,
+                u"issue_severity": None,
+                u"hotlist_id": u"some host id",
+                u"issue_id": u"some issue id",
+                u"issue_priority": None,
+                u"issue_type": None,
+                u"issue_url": None,
+                u"title": "some title"
             }
         }
     )

--- a/test/integration/ggrc/models/test_query_api_queries.py
+++ b/test/integration/ggrc/models/test_query_api_queries.py
@@ -1,0 +1,121 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Tests for making sure eager queries are working on all mixins."""
+
+import ddt
+
+from ggrc.utils import QueryCounter
+
+from integration.ggrc import TestCase
+from integration.ggrc.models import factories as ggrc_factories
+from integration.ggrc_workflows.models import factories as wf_factories
+from integration.ggrc.query_helper import WithQueryApi
+from integration.ggrc import api_helper
+
+
+@ddt.ddt
+class TestAllModels(WithQueryApi, TestCase):
+  """Test basic model structure for all models"""
+
+  def setUp(self):
+    super(TestAllModels, self).setUp()
+    self.client.get("/login")
+    self.api = api_helper.Api()
+
+  QUERY_API_LIMIT = {
+      'Assessment': 17,
+      'AssessmentTemplate': 11,
+      'AccessGroup': 17,
+      'Audit': 15,
+      'Comment': 8,
+      'Contract': 15,
+      'Control': 18,
+      'Cycle': 7,
+      # 'CycleTaskEntry': 19, 29
+      # 'CycleTaskGroup': 27, 47
+      # 'CycleTaskGroupObjectTask': 49, 89
+      'Document': 9,
+      'Issue': 15,
+      'Market': 14,
+      'Objective': 15,
+      'OrgGroup': 14,
+      'Person': 12,
+      'Policy': 15,
+      'Process': 14,
+      'Program': 17,
+      'Regulation': 15,
+      # 'TaskGroup': 27, 47
+      'TaskGroupObject': 4,
+      # 'TaskGroupTask': 28, 48
+      'Workflow': 12,
+      'TechnologyEnvironment': 8,
+      'Product': 14,
+      'Metric': 14,
+      'ProductGroup': 14,
+  }
+
+  INDEXED_MODEL_FACTORIES = [
+      ggrc_factories.AuditFactory,
+      ggrc_factories.AssessmentFactory,
+      ggrc_factories.AssessmentTemplateFactory,
+      ggrc_factories.CommentFactory,
+      ggrc_factories.ContractFactory,
+      ggrc_factories.ControlFactory,
+      ggrc_factories.IssueFactory,
+      ggrc_factories.MarketFactory,
+      ggrc_factories.ObjectiveFactory,
+      ggrc_factories.OrgGroupFactory,
+      ggrc_factories.PersonFactory,
+      ggrc_factories.PolicyFactory,
+      ggrc_factories.ProcessFactory,
+      ggrc_factories.ProgramFactory,
+      ggrc_factories.RegulationFactory,
+      ggrc_factories.DocumentFactory,
+      ggrc_factories.MetricFactory,
+      ggrc_factories.ProductFactory,
+      ggrc_factories.ProductGroupFactory,
+      # wf_factories.CycleFactory,
+      # wf_factories.CycleTaskGroupFactory,
+      # wf_factories.CycleTaskEntryFactory,
+      # wf_factories.CycleTaskFactory,
+      # wf_factories.TaskGroupFactory,
+      # wf_factories.TaskGroupTaskFactory,
+      wf_factories.WorkflowFactory,
+  ]
+
+  LOWER_BOUND_COUNT = 10
+
+  UPPER_BOUND_COUNT = 20
+
+  QUERY_API_TEST_CASES = [(f, count) for f in INDEXED_MODEL_FACTORIES
+                          for count in (LOWER_BOUND_COUNT,
+                                        UPPER_BOUND_COUNT)]
+
+  @ddt.data(*QUERY_API_TEST_CASES)
+  @ddt.unpack
+  def test_index_on_commit(self, factory, obj_count):
+    """Test count number of queries on eager query procedure."""
+
+    model = factory._meta.model  # pylint: disable=protected-access
+    with ggrc_factories.single_commit():
+      {factory() for _ in range(obj_count)}
+    with QueryCounter() as counter:
+      self._post([{
+          "object_name": model.__name__,
+          "filters": {"expression": {}},
+          "limit": [0, obj_count],
+          "order_by": [{"name": "updated_at", "desc": True}]
+      }])
+      self.assertEqual(
+          counter.get,
+          self.QUERY_API_LIMIT[model.__name__],
+          "Eager query of {model} has too much queries: "
+          "{counted} not equal to {expected} for query "
+          "{obj_count} instances".format(
+              model=model,
+              expected=self.QUERY_API_LIMIT[model.__name__],
+              counted=counter.get,
+              obj_count=obj_count,
+          )
+      )

--- a/test/integration/ggrc/models/test_query_api_queries.py
+++ b/test/integration/ggrc/models/test_query_api_queries.py
@@ -24,10 +24,10 @@ class TestAllModels(WithQueryApi, TestCase):
     self.api = api_helper.Api()
 
   QUERY_API_LIMIT = {
-      'Assessment': 17,
-      'AssessmentTemplate': 11,
+      'Assessment': 16,
+      'AssessmentTemplate': 10,
       'AccessGroup': 17,
-      'Audit': 15,
+      'Audit': 14,
       'Comment': 8,
       'Contract': 15,
       'Control': 18,
@@ -36,7 +36,7 @@ class TestAllModels(WithQueryApi, TestCase):
       # 'CycleTaskGroup': 27, 47
       # 'CycleTaskGroupObjectTask': 49, 89
       'Document': 9,
-      'Issue': 15,
+      'Issue': 14,
       'Market': 14,
       'Objective': 15,
       'OrgGroup': 14,
@@ -48,7 +48,7 @@ class TestAllModels(WithQueryApi, TestCase):
       # 'TaskGroup': 27, 47
       'TaskGroupObject': 4,
       # 'TaskGroupTask': 28, 48
-      'Workflow': 12,
+      'Workflow': 14,
       'TechnologyEnvironment': 8,
       'Product': 14,
       'Metric': 14,

--- a/test/integration/ggrc/models/test_query_api_queries.py
+++ b/test/integration/ggrc/models/test_query_api_queries.py
@@ -55,7 +55,7 @@ class TestAllModels(WithQueryApi, TestCase):
       'ProductGroup': 14,
   }
 
-  INDEXED_MODEL_FACTORIES = [
+  MODEL_FACTORIES = [
       ggrc_factories.AuditFactory,
       ggrc_factories.AssessmentFactory,
       ggrc_factories.AssessmentTemplateFactory,
@@ -88,7 +88,7 @@ class TestAllModels(WithQueryApi, TestCase):
 
   UPPER_BOUND_COUNT = 20
 
-  QUERY_API_TEST_CASES = [(f, count) for f in INDEXED_MODEL_FACTORIES
+  QUERY_API_TEST_CASES = [(f, count) for f in MODEL_FACTORIES
                           for count in (LOWER_BOUND_COUNT,
                                         UPPER_BOUND_COUNT)]
 
@@ -99,6 +99,7 @@ class TestAllModels(WithQueryApi, TestCase):
 
     model = factory._meta.model  # pylint: disable=protected-access
     with ggrc_factories.single_commit():
+      # pylint: disable=expression-not-assigned
       {factory() for _ in range(obj_count)}
     with QueryCounter() as counter:
       self._post([{


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

`Audits`, `Assessments`, `Issues` and `Requirements` has non-constant number of queries when doing a query API with different number of queried objects.

The reason of this for `Audits`, `Assessments`, `Issues` is loading of `issuetracker_issue` for every object. 
The reason of the issue for `Requirements` is loading of `notes` for every object

Some reference numbers (before the change):
1. Audit
  10 objects: 26 db queries
  20 objects: 36 db queries

2. Assessment
10 objects: 41 db queries
50 objects: 121 db queries

3. Issue
10 objects:  27 db queries
21 objects: 38 db queries

4. Requirements
10 objects: 27 db queries
50 objects: 67 db queries

# Steps to test the changes

Check the number of queries fired when opening assessment/audit/issues/requirements tab before and after the change. 
Change the number of loading objects 10/25/50 for every object and see that the number of db queries is a constant.

Reference numbers after the change:
1. Audit (any number of objects): 17 db queries
2. Issue (any number of objects): 18 db queries
3. Requirements (any number of objects):  17 db queries
4. Assessment (any number of objects): 20 db queries
5. AssessmentTemplate (any number of objects): 16 db queries 

# Solution description

1. Eagerly load `issuetracker_issue`.
Pros: Having constant number of queries when using Query API
Cons: Memory usage. I still have some questions about why we need to query `issuetracker_issue` on dashboard page.

2. Eagerly load `notes` for `Requirements`. The Pros and Cons are the same. 

3. Fix some parts where `issuetracker_issue` loaded by direct query to the database whereas we already have this attribute in the object

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
