### PR TITLE
GGRC-5622 Use default_value in Assessment LCA

### DIFF
--- a/src/ggrc-client/js/plugins/utils/ca-utils.js
+++ b/src/ggrc-client/js/plugins/utils/ca-utils.js
@@ -395,9 +395,8 @@ function updateCustomAttributeValue(ca, value) {
     ca.attr('attribute_value', 'Person');
     ca.attr('attribute_object', {id: id, type: 'Person'});
   } else {
-    ca.attr('attribute_value',
-      convertToCaValue(ca.attr('attributeType'), value)
-    );
+    let convertedValue = convertToCaValue(ca.attr('attributeType'), value);
+    ca.attr('attribute_value', convertedValue || ca.def.default_value);
   }
 }
 

--- a/src/ggrc-client/js/plugins/utils/ca-utils.js
+++ b/src/ggrc-client/js/plugins/utils/ca-utils.js
@@ -180,7 +180,7 @@ function prepareCustomAttributes(definitions, values) {
     let stub = {
       id: null,
       custom_attribute_id: id,
-      attribute_value: null,
+      attribute_value: def.default_value,
       attribute_object: null,
       validation: {
         empty: true,


### PR DESCRIPTION
# Issue description
Use default_value in Assessment LCA.
If FE will send null (empty date LCA), conflict resolution does not work correctly.

# Steps to test the changes
Clear Date or DD LCA and see that empty value has been sent.

# Solution description
1) Initialize CAV with default value (case when we create new Assessment)
2) Use default value when clear CAV

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
