### PR TITLE
GGRC-5496 Fix POST request to people/profile endpoint

### DIFF
--- a/src/ggrc/services/resources/person.py
+++ b/src/ggrc/services/resources/person.py
@@ -8,7 +8,7 @@ import collections
 import functools
 
 from logging import getLogger
-from werkzeug.exceptions import Forbidden, BadRequest
+from werkzeug.exceptions import Forbidden, BadRequest, MethodNotAllowed
 from sqlalchemy.orm.exc import NoResultFound
 from dateutil import parser as date_parser
 
@@ -154,6 +154,14 @@ class PersonResource(common.ExtendedResource):
 
     return wrapper
 
+  @staticmethod
+  def raise_not_allowed_exception(*args, **kwargs):
+    """Raise not allowed exception for person resource."""
+    del args
+    del kwargs
+    raise MethodNotAllowed(description="Creation of new profile for person "
+                                       "by POST request is not allowed")
+
   def get(self, *args, **kwargs):  # pylint: disable=arguments-differ
     # This is to extend the get request for additional data.
     command_map = {
@@ -175,6 +183,7 @@ class PersonResource(common.ExtendedResource):
         "imports": self.verify_is_current(converters.handle_import_post),
         # create export entry and start export background task
         "exports": self.verify_is_current(converters.handle_export_post),
+        "profile": self.raise_not_allowed_exception,
     }
     return self._process_request(command_map, *args, **kwargs)
 

--- a/test/integration/ggrc/services/resources/test_person.py
+++ b/test/integration/ggrc/services/resources/test_person.py
@@ -96,6 +96,36 @@ class TestPersonResource(TestCase, WithQueryApi):
     # not authorized user
     self.assert403(response)
 
+  @ddt.data("Creator", "Reader", "Editor", "Administrator")
+  def test_profile_post_empty_body(self, role_name):
+    """Test person_profile POST method with empty body - {}."""
+    role = all_models.Role.query.filter(
+        all_models.Role.name == role_name
+    ).one()
+    with factories.single_commit():
+      user = factories.PersonFactory()
+      rbac_factories.UserRoleFactory(role=role, person=user)
+    self.api.set_user(person=user)
+
+    response = self.api.send_request(
+        self.api.client.post,
+        data={},
+        api_link="/api/people/{}/profile".format(user.id))
+
+    self.assert405(response)
+
+  def test_profile_post_unauthorized(self):
+    """Test person_profile POST method with empty body - No Access."""
+    with factories.single_commit():
+      user = factories.PersonFactory()
+
+    response = self.api.send_request(
+        self.api.client.post,
+        data={},
+        api_link="/api/people/{}/profile".format(user.id))
+    # not authorized user
+    self.assert405(response)
+
   def assert_profile_put_successful(self,
                                     response,
                                     correct_response,


### PR DESCRIPTION
# Issue description
POST request to people/profile endpoint fail with internal server error (status code - 500):
AttributeError: 'NoneType' object has no attribute '_inflector'

# Steps to test the changes
Send POST request to /api/people/id/profile (example: /api/people/150/profile), response should be 405 Method Not Allowed

# Solution description
Update PersonseResource class with method that raise "405 Method Not Allowed" response when server handle POST request

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
