### PR TITLE
QUICK-FIX Logging valid SLUGs as SLUGs with leading or trailing spaces 

### DIFF
--- a/src/ggrc/models/mixins/__init__.py
+++ b/src/ggrc/models/mixins/__init__.py
@@ -542,9 +542,11 @@ class Slugged(Base):
     """Validates slug for presence of forbidden symbols"""
     # pylint: disable=no-self-use
     if value:
-      logger.warning("Slug \"%s\" contains unsupported leading or trailing "
-                     "whitespace. Slug will be trimmed.", value)
-      value = value.strip()
+      new_value = value.strip()
+      if new_value != value:
+        logger.warning("Slug \"%s\" contains unsupported leading or trailing "
+                       "whitespace. Slug will be trimmed.", value)
+        value = new_value
     if value and "*" in value:
       raise exceptions.ValidationError(
           "Field 'Code' contains unsupported symbol '*'"


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Warning about trimming spaces in slugs appears in console, even when create object with slug without leading or trailing spaces.

# Steps to test the changes

* Try to create any object with valid 'Code' field not contains leading and trailing whitespaces.

Expected result: warning about trimming spaces in console is not appeared.

# Solution description

Added an expression before logging, which verifies that the slug was trimmed.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
