### PR TITLE
QUICK-FIX Remove redundant related_objects property

### DIFF
--- a/src/ggrc_workflows/models/cycle_task_group_object_task.py
+++ b/src/ggrc_workflows/models/cycle_task_group_object_task.py
@@ -154,7 +154,7 @@ class CycleTaskGroupObjectTask(roleable.Roleable,
     """Changing task state must invalidate `workflow_state` on objects
     """
     return [(object_.__class__.__name__, object_.id) for object_ in
-            self.related_objects]  # pylint: disable=not-an-iterable
+            self.related_objects()]
 
   _api_attrs = reflection.ApiAttributes(
       'cycle',
@@ -236,21 +236,6 @@ class CycleTaskGroupObjectTask(roleable.Roleable,
   def workflow(self):
     """Property which returns parent workflow object."""
     return self.cycle.workflow
-
-  @builder.simple_property
-  def related_objects(self):
-    """Compute and return a list of all the objects related to this cycle task.
-
-    Related objects are those that are found either on the "source" side, or
-    on the "destination" side of any of the instance's relations.
-
-    Returns:
-      (list) All objects related to the instance.
-    """
-    # pylint: disable=not-an-iterable
-    sources = [r.source for r in self.related_sources]
-    destinations = [r.destination for r in self.related_destinations]
-    return sources + destinations
 
   @builder.simple_property
   def allow_change_state(self):

--- a/src/ggrc_workflows/notification/data_handler.py
+++ b/src/ggrc_workflows/notification/data_handler.py
@@ -542,7 +542,7 @@ def get_cycle_task_dict(cycle_task, del_rels_cache=None):
 
   object_titles = []
   # every object should have a title or at least a name like person object
-  for related_object in cycle_task.related_objects:
+  for related_object in cycle_task.related_objects():
     object_titles.append(getattr(related_object, "title", "") or
                          getattr(related_object, "name", "") or
                          u"Untitled object")

--- a/test/integration/ggrc_workflows/converters/test_workflow_export_csv.py
+++ b/test/integration/ggrc_workflows/converters/test_workflow_export_csv.py
@@ -299,7 +299,7 @@ class TestExportMultipleObjects(TestCase):
     cycle_tasks = []
     for cycle_task in cycle.cycle_task_group_object_tasks:
       is_related = False
-      for related_object in cycle_task.related_objects:
+      for related_object in cycle_task.related_objects():
         if related_object.slug == "p1":
           is_related = True
       if is_related:


### PR DESCRIPTION


# Issue description

The related objects is already defined for cycle tasks with the
Relatable mixin. To have all objects consistent it is better to use that
instead of overriding it in a special way.

# Steps to test the changes

Check if related objects still work fine on cycle task notifications. and if they are correctly displayed on cycle task page.

# Solution description

Remove the overriding property and replace its usages with the same named function from Relatable mixin.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests. - I have verified that not returning correct elements breaks existing tests, so this code should be covered.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [ ] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
