### PR TITLE
GGRC-5621 Fix inline edit string trimming

### DIFF
--- a/src/ggrc-client/js/components/inline/inline.js
+++ b/src/ggrc-client/js/components/inline/inline.js
@@ -71,10 +71,9 @@ export default can.Component.extend({
       }
 
       this.attr('editMode', false);
-      // In case value is String and consists only of spaces - do nothing
-      if (typeof value === 'string' && !value.trim()) {
-        this.attr('context.value', '');
-        value = null;
+
+      if (typeof value === 'string') {
+        value = value.trim();
       }
 
       if (oldValue === value) {


### PR DESCRIPTION
# Issue description

Conflict resolution for notes field

# Steps to test the changes

Go to the other attributes tab and use inline edit to create a conflict with the notes field
Expected: Conflict error message should be shown
Actual: Cannot save error message is shown

# Solution description

Just trim string value, do not set null.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
