### PR TITLE
GGRC-5767 Rename 'Section' to 'Requirement' in source_type of revisions

### DIFF
--- a/src/ggrc/migrations/versions/20180816123728_888972f313a7_rename_sections_to_requirements.py
+++ b/src/ggrc/migrations/versions/20180816123728_888972f313a7_rename_sections_to_requirements.py
@@ -1,0 +1,31 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Rename sections to requirements
+
+Create Date: 2018-08-16 12:37:28.232391
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = 'd51db6ab92a3'
+down_revision = 'b992a3d51db6'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  op.execute(
+      """
+          UPDATE `revisions`
+          SET `source_type` = "Requirement"
+          WHERE `source_type` = "Section"
+      """
+  )
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Note:

this is a fix for the previous PR: https://github.com/google/ggrc-core/pull/8288

# Issue description

When we rename sections, we added an [migration](https://github.com/google/ggrc-core/pull/8071/files#diff-a22b65a5b08711b783c08afac2e4aa96) that misses `destination_type` field in revisions
table. Some values of `destination_type` field of revisions table in DB still named as 'Section' instead 'Requirement'. That is the cause bug on FE which we fixed in
[8288](https://github.com/google/ggrc-core/pull/8288), but some values of `source_type` in revisions table still named as 'Section'. This can cause similar problems.

# Steps to test the changes

To make shure that revision table don't contains 'Section' instead 'Requirement'
execute this query:

```sql
select count(*) from revisions where destination_type = "Section" or source_type = "Section" or resource_type = "Section";
```

**Expected result:**

| count(*) |
|----------|
|        0 |


# Solution description

Created migration that renames sections to requirements in source_type field of revisions.

# Sanity checklist

- [ ] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
