### PR TITLE
GGRC-5890 Use "execute" instead of "push" when map objects

### DIFF
--- a/src/ggrc-client/js/components/assessment/info-pane/info-pane.js
+++ b/src/ggrc-client/js/components/assessment/info-pane/info-pane.js
@@ -367,7 +367,7 @@ export default can.Component.extend({
         type: relatedItemType,
       };
 
-      this.attr('deferredSave').push(function () {
+      this.attr('deferredSave').execute(function () {
         self.addAction('add_related', related);
       })
         .done(function () {

--- a/src/ggrc-client/js/components/assessment/info-pane/tests/info-pane_spec.js
+++ b/src/ggrc-client/js/components/assessment/info-pane/tests/info-pane_spec.js
@@ -916,23 +916,23 @@ describe('assessment-info-pane component', () => {
       vm.attr('instance', {});
       vm.attr('instance').dispatch = jasmine.createSpy('dispatch');
       vm.attr('deferredSave', {
-        push: jasmine.createSpy('push').and.returnValue(dfd),
+        execute: jasmine.createSpy('execute').and.returnValue(dfd),
       });
 
       spyOn(vm, 'addAction');
       spyOn(vm, 'afterCreate');
     });
 
-    describe('within pushed deferred function into deferredSave', () => {
-      let pushedFunc;
+    describe('within executed deferred function into deferredSave', () => {
+      let executedFunc;
 
       beforeEach(function () {
         vm.addRelatedItem(event, type);
-        pushedFunc = vm.attr('deferredSave').push.calls.argsFor(0)[0];
+        executedFunc = vm.attr('deferredSave').execute.calls.argsFor(0)[0];
       });
 
       it('adds add_related action with related object', function () {
-        pushedFunc();
+        executedFunc();
         expect(vm.addAction).toHaveBeenCalledWith(
           'add_related',
           related


### PR DESCRIPTION
# Issue description

Switch Assessment Info-pane to "Deferred Transaction" mechanism without delays for comments on assessments, comments on LCA and adding evidence URL.
Impact:
 UI acceleration for 1s for comments and evidences

# Steps to test the changes

Add comment or evidence url to an assessment and see that there is no 1s lag between "create" and "map" requests.

# Solution description

Use 'execute' method instead of 'push'

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
