### PR TITLE
GGRC-5934 Disable export button if selected more than 1000 attributes

### DIFF
--- a/src/ggrc-client/js/components/import-export/panel.js
+++ b/src/ggrc-client/js/components/import-export/panel.js
@@ -19,14 +19,69 @@ export default can.Map({
         return selectedAttributesCount <= this.attr('maxAttributesCount');
       },
     },
+    useLocalAttribute: {
+      get() {
+        return this.attr('type') === 'Assessment';
+      },
+    },
   },
   type: 'Program',
   filter: '',
   maxAttributesCount: MAX_COLUMNS_COUNT,
-  relevant: can.compute(function () {
+  relevant: can.compute(() => {
     return new can.List();
   }),
   attributes: new can.List(),
   localAttributes: new can.List(),
   mappings: new can.List(),
+  init() {
+    this.setAttributes();
+  },
+  setAttributes() {
+    let type = this.attr('type');
+
+    let definitions = this.getModelAttributeDefenitions(type);
+    let filtered = _.filter(definitions, (def) => {
+      return this.filterModelAttributes(def);
+    });
+
+    let attributes = _.filter(filtered, (el) => {
+      return el.type !== 'mapping' && el.type !== 'object_custom';
+    });
+
+    let mappings = _.filter(filtered, (el) => {
+      return el.type === 'mapping';
+    });
+
+    this.attr('attributes', attributes);
+    this.attr('mappings', mappings);
+
+    let localAttributes = [];
+    if (this.attr('useLocalAttribute')) {
+      localAttributes = _.filter(filtered, (el) => {
+        return el.type === 'object_custom';
+      });
+    }
+    this.attr('localAttributes', localAttributes);
+  },
+  changeType(type) {
+    this.attr('relevant', []);
+    this.attr('filter', '');
+    this.attr('snapshot_type', '');
+    this.attr('has_parent', false);
+    this.attr('type', type);
+
+    if (this.attr('type') === 'Snapshot') {
+      this.attr('snapshot_type', 'Control');
+    }
+
+    this.setAttributes();
+  },
+  getModelAttributeDefenitions(type) {
+    return GGRC.model_attr_defs ? GGRC.model_attr_defs[type] : [];
+  },
+  filterModelAttributes(attr) {
+    return !attr.import_only &&
+      attr.display_name.indexOf('unmap:') === -1;
+  },
 });

--- a/src/ggrc-client/js/components/import-export/test/export-panel_spec.js
+++ b/src/ggrc-client/js/components/import-export/test/export-panel_spec.js
@@ -8,124 +8,92 @@ import {getComponentVM} from '../../../../js_specs/spec_helpers';
 
 describe('export-panel component', function () {
   let viewModel;
-  let modelAttributeDefenitions = {
-    Assessment: [
-      {
-        display_name: 'Code',
-        type: 'property',
-        import_only: false,
-      },
-      {
-        display_name: 'Title',
-        type: 'unknowType',
-      },
-      {
-        display_name: 'DisplayName',
-        type: 'property',
-        // should not be added
-        import_only: true,
-      },
-      {
-        display_name: 'map:risk versions',
-        type: 'mapping',
-      },
-      {
-        // should not be added
-        display_name: 'unmap:vendor versions',
-        type: 'mapping',
-      },
-      {
-        display_name: 'LCA #1',
-        type: 'object_custom',
-      },
+
+  let panel = {
+    attributes: new can.List([
+      {id: 1, isSelected: false},
+    ]),
+    mappings: [
+      {id: 2, isSelected: false},
     ],
+    localAttributes: [
+      {id: 3, isSelected: false},
+    ],
+    changeType: jasmine.createSpy(),
   };
 
-  beforeAll(function () {
+  beforeEach(function () {
     viewModel = getComponentVM(Component);
   });
 
-  describe('refreshItems functions', function () {
-    let refreshItemsFunction;
+  describe('showAttributes prop', () => {
+    it('sets isSelected value to panel attributes', () => {
+      viewModel.attr('item', _.cloneDeep(panel));
 
-    beforeEach(function () {
-      let panelModel = new can.Map({
-        attributes: new can.List(),
-        localAttributes: new can.List(),
-        mappings: new can.List(),
-        type: 'Assessment',
-      });
+      viewModel.attr('showAttributes', true);
 
-      viewModel.attr('item', panelModel);
-      refreshItemsFunction = viewModel.refreshItems
-        .bind(viewModel);
-
-      spyOn(viewModel, 'getModelAttributeDefenitions').and
-        .returnValue(modelAttributeDefenitions[viewModel.attr('item.type')]);
-    });
-
-    it('refreshItems function should set item', function () {
-      let mappingsItem;
-      let attributesItem;
-
-      refreshItemsFunction();
-
-      mappingsItem = viewModel.attr('item.mappings')[0];
-      attributesItem = viewModel.attr('item.attributes')[0];
-
-      expect(viewModel.attr('item.mappings').length).toEqual(1);
-      expect(viewModel.attr('item.attributes').length).toEqual(2);
-      expect(viewModel.attr('item.localAttributes').length).toEqual(1);
-
-      expect(mappingsItem.display_name).toEqual('map:risk versions');
-      expect(attributesItem.display_name).toEqual('Code');
+      expect(viewModel.attr('item.attributes.0'))
+        .toEqual(jasmine.objectContaining({id: 1, isSelected: true}));
+      expect(viewModel.attr('item.mappings.0'))
+        .toEqual(jasmine.objectContaining({id: 2, isSelected: false}));
+      expect(viewModel.attr('item.localAttributes.0'))
+        .toEqual(jasmine.objectContaining({id: 3, isSelected: false}));
     });
   });
 
-  describe('filterModelAttributes functions', function () {
-    let filterModelAttributesFunc;
+  describe('showMappings prop', () => {
+    it('sets isSelected value to panel mappings', () => {
+      viewModel.attr('item', _.cloneDeep(panel));
 
-    beforeEach(function () {
-      filterModelAttributesFunc = viewModel.filterModelAttributes
-        .bind(viewModel);
+      viewModel.attr('showMappings', true);
+
+      expect(viewModel.attr('item.attributes.0'))
+        .toEqual(jasmine.objectContaining({id: 1, isSelected: false}));
+      expect(viewModel.attr('item.mappings.0'))
+        .toEqual(jasmine.objectContaining({id: 2, isSelected: true}));
+      expect(viewModel.attr('item.localAttributes.0'))
+        .toEqual(jasmine.objectContaining({id: 3, isSelected: false}));
     });
+  });
 
-    it('filterModelAttributes should return TRUE', function () {
-      let item = modelAttributeDefenitions.Assessment[0];
-      let predicate = item.type !== 'mapping';
+  describe('showLocalAttributes prop', () => {
+    it('sets isSelected value to panel local attributes', () => {
+      viewModel.attr('item', _.cloneDeep(panel));
 
-      expect(filterModelAttributesFunc(item, predicate))
-        .toBe(true);
+      viewModel.attr('showLocalAttributes', true);
+
+      expect(viewModel.attr('item.attributes.0'))
+        .toEqual(jasmine.objectContaining({id: 1, isSelected: false}));
+      expect(viewModel.attr('item.mappings.0'))
+        .toEqual(jasmine.objectContaining({id: 2, isSelected: false}));
+      expect(viewModel.attr('item.localAttributes.0'))
+        .toEqual(jasmine.objectContaining({id: 3, isSelected: true}));
     });
+  });
 
-    it('filterModelAttributes should return FALSE. Wrong predicate',
-      function () {
-        let item = modelAttributeDefenitions.Assessment[0];
-        let predicate = item.type === 'mapping';
+  describe('events', () => {
+    describe('"{viewModel} type" event', () => {
+      let event;
 
-        expect(filterModelAttributesFunc(item, predicate))
-          .toBe(false);
-      }
-    );
+      beforeEach(() => {
+        event = Component.prototype.events['{viewModel} type'].bind(viewModel);
+      });
 
-    it('filterModelAttributes should return FALSE. import_only is true',
-      function () {
-        let item = modelAttributeDefenitions.Assessment[2];
-        let predicate = item.type === 'mapping';
+      it('should call panel changeType method', () => {
+        viewModel.attr('item', panel);
 
-        expect(filterModelAttributesFunc(item, predicate))
-          .toBe(false);
-      }
-    );
+        event(viewModel, {}, 'Assessment');
 
-    it('filterModelAttributes should return FALSE. unmapped item',
-      function () {
-        let item = modelAttributeDefenitions.Assessment[4];
-        let predicate = item.type === 'mapping';
+        expect(panel.changeType).toHaveBeenCalledWith('Assessment');
+      });
 
-        expect(filterModelAttributesFunc(item, predicate))
-          .toBe(false);
-      }
-    );
+      it('should select all attributes by default', () => {
+        viewModel.attr('item', panel);
+        spyOn(viewModel, 'setSelected');
+
+        event(viewModel, {}, 'Assessment');
+        expect(viewModel.setSelected).toHaveBeenCalled();
+      });
+    });
   });
 });

--- a/src/ggrc-client/js/components/import-export/test/panel_spec.js
+++ b/src/ggrc-client/js/components/import-export/test/panel_spec.js
@@ -8,6 +8,39 @@ import panelModel from '../panel';
 describe('panel model', () => {
   let panel;
 
+  const modelAttributeDefenitions = {
+    Assessment: [
+      {
+        display_name: 'Code',
+        type: 'property',
+        import_only: false,
+      },
+      {
+        display_name: 'Title',
+        type: 'unknowType',
+      },
+      {
+        display_name: 'DisplayName',
+        type: 'property',
+        // should not be added
+        import_only: true,
+      },
+      {
+        display_name: 'map:risk versions',
+        type: 'mapping',
+      },
+      {
+        // should not be added
+        display_name: 'unmap:vendor versions',
+        type: 'mapping',
+      },
+      {
+        display_name: 'LCA #1',
+        type: 'object_custom',
+      },
+    ],
+  };
+
   beforeEach(() => {
     panel = new panelModel();
   });
@@ -79,5 +112,89 @@ describe('panel model', () => {
 
         expect(panel.attr('isValidConfiguration')).toBeFalsy();
       });
+  });
+
+  describe('setAttributes() method', () => {
+    beforeEach(() => {
+      panel.attr('type', 'Assessment');
+
+      spyOn(panel, 'getModelAttributeDefenitions').and
+        .returnValue(modelAttributeDefenitions[panel.attr('type')]);
+    });
+
+    it('should set attributes', () => {
+      panel.attr('attributes', new can.List());
+      panel.attr('mappings', new can.List());
+      panel.attr('localAttributes', new can.List());
+
+      panel.setAttributes();
+
+      let mappingsItem = panel.attr('mappings')[0];
+      let attributesItem = panel.attr('attributes')[0];
+
+      expect(panel.attr('mappings').length).toEqual(1);
+      expect(panel.attr('attributes').length).toEqual(2);
+      expect(panel.attr('localAttributes').length).toEqual(1);
+
+      expect(mappingsItem.display_name).toEqual('map:risk versions');
+      expect(attributesItem.display_name).toEqual('Code');
+    });
+  });
+
+  describe('filterModelAttributes() method', () => {
+    it('should return TRUE when valid attribute', () => {
+      let item = modelAttributeDefenitions.Assessment[0];
+
+      expect(panel.filterModelAttributes(item))
+        .toBe(true);
+    });
+
+    it('should return FALSE when import_only is true', () => {
+      let item = modelAttributeDefenitions.Assessment[2];
+
+      expect(panel.filterModelAttributes(item))
+        .toBe(false);
+    });
+
+    it('should return FALSE when unmapped item', () => {
+      let item = modelAttributeDefenitions.Assessment[4];
+
+      expect(panel.filterModelAttributes(item))
+        .toBe(false);
+    });
+  });
+
+  describe('changeType() method', () => {
+    it('should reset panel attributes and set type', () => {
+      panel.attr({
+        type: 'old type',
+        relevant: ['relevant'],
+        filter: 'any filter',
+        snapshot_type: 'snapshot type',
+        has_parent: true,
+      });
+
+      panel.changeType('new type');
+
+      expect(panel.attr('type')).toBe('new type');
+      expect(panel.attr('relevant').length).toBe(0);
+      expect(panel.attr('filter')).toBe('');
+      expect(panel.attr('snapshot_type')).toBe('');
+      expect(panel.attr('has_parent', false));
+    });
+
+    it('should set default snapshot_type when type is Snapshot', () => {
+      panel.attr('snapshot_type', null);
+
+      panel.changeType('Snapshot');
+      expect(panel.attr('snapshot_type')).toBe('Control');
+    });
+
+    it('should set attributes for selected type', () => {
+      spyOn(panel, 'setAttributes');
+
+      panel.changeType('new type');
+      expect(panel.setAttributes).toHaveBeenCalled();
+    });
   });
 });

--- a/src/ggrc/assets/mustache/import_export/export/attribute_selector.mustache
+++ b/src/ggrc/assets/mustache/import_export/export/attribute_selector.mustache
@@ -80,7 +80,7 @@
       {{/if}}
     </div>
 
-    {{#is type 'Assessment'}}
+    {{#if useLocalAttribute}}
       <div class="attribute-selector__group">
         <div class="attribute-selector__header">
           <div class="attribute-selector__checkbox">
@@ -118,5 +118,5 @@
           </div>
         {{/if}}
       </div>
-    {{/is}}
+    {{/if}}
 </div>


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Export button is not disabled if there is more then 1000 columns in sheet.

# Steps to test the changes

1. Open any audit page
2. Create assessment
3. In the assessments tab click on Export Assessments in 3 dot's menu
4. Look at the Export button: is not disabled while "Exports are currently limited to maximum of 1000 columns per file." message is shown

**Actual Result:** Export button is not disabled if there is more then 1000 columns in sheet
**Expected Result:** Export button should be disabled if there is more then 1000 columns in sheet

# Solution description

Case is reproducible only when panel initially has invalid configuration (when user is redirected from Assessments page). It happens because canJs is not recalculate `exportAllowed` prop in `csv-export` component after selecting all options in `export-panel` component.
As a solution, move attributes initialization logic to panel model and set default values for panel grouping checkboxes. In this case attributes are initialized before `exportAllowed` prop calculating.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
