### PR TITLE
QUICK-FIX Update initial migration

### DIFF
--- a/src/ggrc/migrations/versions/20160119143508_262bbe790f4c_import_squashed_migrations.py
+++ b/src/ggrc/migrations/versions/20160119143508_262bbe790f4c_import_squashed_migrations.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2018 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
-"""Import all squashed migrations from 0.9.5-Zucchini-P1.
+"""Import all squashed migrations from 1.19.0-Strawberry
 
 Revision ID: 262bbe790f4c
 Revises: 297131e22e28

--- a/src/ggrc/migrations/versions/ggrcdev.sql
+++ b/src/ggrc/migrations/versions/ggrcdev.sql
@@ -2094,16 +2094,6 @@ CREATE TABLE `objects_without_revisions` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
--- Dumping data for table `objects_without_revisions`
---
-
-LOCK TABLES `objects_without_revisions` WRITE;
-/*!40000 ALTER TABLE `objects_without_revisions` DISABLE KEYS */;
-INSERT INTO `objects_without_revisions` VALUES (0,'','created');
-/*!40000 ALTER TABLE `objects_without_revisions` ENABLE KEYS */;
-UNLOCK TABLES;
-
---
 -- Table structure for table `options`
 --
 


### PR DESCRIPTION
# Issue description

There should not be any objects without revisions on an empty database.
The entry deleted here was due to a bug on how the old migration worked
on an empty db, when it created an invalid entry.

Second change is updating the title of the migration to display the
correct version from which the squash was created.

# Steps to test the changes

Check that the migrations still work.

- reset the database
- create a new object
- mark it for new revision manually,
- run the create missing revisions command

# Solution description

I have just removed an invalid entry from the initial dump. Since db reset makes an empty database there can not be any object that would have a missing revision (for prepopulated objects we do not store revisions)

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
