### PR TITLE
GGRC-4858 FE: Allow to generate issues in bulk

### DIFF
--- a/src/ggrc-client/js/components/issue-tracker/generate-issues-in-bulk-button.js
+++ b/src/ggrc-client/js/components/issue-tracker/generate-issues-in-bulk-button.js
@@ -60,8 +60,8 @@ export default can.Component.extend({
 
       this.generateChildrenIssues()
         .done((resp) => {
-          notifier('progress', `Tickets will be generated using a background 
-            job and linked to assessments. An email notification will be sent 
+          notifier('progress', `Tickets will be generated using a background
+            job and linked to assessments. An email notification will be sent
             to you once this process is complete or if there are errors.`);
           this.trackStatus(DEFAULT_TIMEOUT);
         })
@@ -91,13 +91,21 @@ export default can.Component.extend({
               break;
             }
             case 'Success': {
-              notifier('success', 'Tickets were generated successfully.');
+              let errors = task.errors;
+
+              if (errors && errors.length) {
+                notifier('error', 'There were some errors in generating ' +
+                  'tickets. More details will be sent by email.');
+              } else {
+                notifier('success', 'Tickets were generated successfully.');
+              }
+
               this.attr('isGeneratingInProgress', false);
               break;
             }
             case 'Failure': {
               notifier('error', 'There were some errors in generating ' +
-                'tickets. More details will be sent by email.');
+                'tickets.');
               this.attr('isGeneratingInProgress', false);
               break;
             }

--- a/src/ggrc-client/js/components/issue-tracker/generate-issues-in-bulk-button.js
+++ b/src/ggrc-client/js/components/issue-tracker/generate-issues-in-bulk-button.js
@@ -1,0 +1,143 @@
+/*
+ Copyright (C) 2018 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+import template from './templates/generate-issues-in-bulk-button.mustache';
+import Permission from '../../permission';
+import {notifier} from '../../plugins/utils/notifiers-utils';
+import Stub from '../../models/stub';
+import {handleAjaxError} from '../../plugins/utils/errors-utils';
+
+const DEFAULT_TIMEOUT = 2000;
+const MAX_TIMEOUT = 60000;
+
+export default can.Component.extend({
+  tag: 'generate-issues-in-bulk-button',
+  template,
+  viewModel: {
+    define: {
+      isAllowedToGenerate: {
+        get() {
+          return Permission.is_allowed_for('update', this.attr('instance'));
+        },
+      },
+      disableButton: {
+        get() {
+          return this.attr('isGettingInitialStatus') ||
+            this.attr('isGeneratingInProgress');
+        },
+      },
+    },
+    instance: {},
+    isGeneratingInProgress: false,
+    isGettingInitialStatus: false,
+    timeoutId: null,
+    getStatus() {
+      let url = '/background_task_status/' +
+        `${this.attr('instance.type')}/${this.attr('instance.id')}`;
+
+      return can.ajax({
+        method: 'GET',
+        url,
+        cache: false,
+      });
+    },
+    generateChildrenIssues() {
+      return can.ajax({
+        method: 'POST',
+        url: '/generate_children_issues',
+        data: JSON.stringify({
+          parent: new Stub(this.attr('instance')).serialize(),
+          child_type: 'Assessment',
+        }),
+        dataType: 'json',
+        contentType: 'application/json',
+      });
+    },
+    generate() {
+      this.attr('isGeneratingInProgress', true);
+
+      this.generateChildrenIssues()
+        .done((resp) => {
+          notifier('progress', `Tickets will be generated using a background 
+            job and linked to assessments. An email notification will be sent 
+            to you once this process is complete or if there are errors.`);
+          this.trackStatus(DEFAULT_TIMEOUT);
+        })
+        .fail((jqxhr, textStatus, errorThrown) => {
+          this.attr('isGeneratingInProgress', false);
+          handleAjaxError(jqxhr, errorThrown);
+        });
+    },
+    trackStatus(timeout) {
+      timeout = timeout > MAX_TIMEOUT ? MAX_TIMEOUT : timeout;
+
+      let timeoutId = setTimeout(() => {
+        this.checkStatus(timeout);
+      }, timeout);
+
+      this.attr('timeoutId', timeoutId);
+    },
+    checkStatus(timeout) {
+      this.getStatus()
+        .done((task) => {
+          let status = task.status;
+
+          switch (status) {
+            case 'Running':
+            case 'Pending': {
+              this.trackStatus(timeout * 2);
+              break;
+            }
+            case 'Success': {
+              notifier('success', 'Tickets were generated successfully.');
+              this.attr('isGeneratingInProgress', false);
+              break;
+            }
+            case 'Failure': {
+              notifier('error', 'There were some errors in generating ' +
+                'tickets. More details will be sent by email.');
+              this.attr('isGeneratingInProgress', false);
+              break;
+            }
+          }
+        });
+    },
+
+    checkInitialStatus() {
+      this.attr('isGettingInitialStatus', true);
+      this.getStatus()
+        .done((resp) => {
+          let status = resp.status;
+
+          if (status === 'Running' || status === 'Pending') {
+            this.attr('isGeneratingInProgress', true);
+            this.trackStatus(DEFAULT_TIMEOUT);
+          }
+        })
+        .fail((jqxhr, textStatus, errorThrown) => {
+          if (jqxhr && jqxhr.status === 404) {
+            // There is no background tasks for current audit
+            return;
+          }
+
+          handleAjaxError(jqxhr, errorThrown);
+        })
+        .always(() => {
+          this.attr('isGettingInitialStatus', false);
+        });
+    },
+  },
+  events: {
+    inserted() {
+      if (this.viewModel.attr('isAllowedToGenerate')) {
+        this.viewModel.checkInitialStatus();
+      }
+    },
+    removed() {
+      let timeoutId = this.viewModel.attr('timeoutId');
+      clearTimeout(timeoutId);
+    },
+  },
+});

--- a/src/ggrc-client/js/components/issue-tracker/templates/generate-issues-in-bulk-button.mustache
+++ b/src/ggrc-client/js/components/issue-tracker/templates/generate-issues-in-bulk-button.mustache
@@ -1,0 +1,25 @@
+{{!
+    Copyright (C) 2018 Google Inc.
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+}}
+
+{{#if isAllowedToGenerate}}
+<div class="row-fluid wrap-row">
+  <div class="span-12">
+    <button 
+              class="btn btn-green btn-small generate-issues-in-bulk"
+              {{#if disableButton}} disabled {{/if}}
+              ($click)="generate()"
+      >
+        Generate
+      </button>
+      {{^if isGettingInitialStatus}}
+        {{#if isGeneratingInProgress}}
+          <span>Tickets generation is in progress. The button will be available, when generation is complete.</span>
+        {{else}}
+          <span>Tickets will be generated for all existing assessments, that are not linked to tickets.</span>
+        {{/if}}
+      {{/if}}
+  </div>
+</div>
+{{/if}}

--- a/src/ggrc-client/js/components/issue-tracker/templates/info-issue-tracker-fields.mustache
+++ b/src/ggrc-client/js/components/issue-tracker/templates/info-issue-tracker-fields.mustache
@@ -21,6 +21,9 @@
   </div>
 </div>
 {{#if instance.issue_tracker.enabled}}
+  
+  <content></content>
+  
   <div class="row-fluid wrap-row">
     <div class="span4">
       <h6>Hotlist ID</h6>

--- a/src/ggrc-client/js/components/issue-tracker/tests/generate-issues-in-bulk-button_spec.js
+++ b/src/ggrc-client/js/components/issue-tracker/tests/generate-issues-in-bulk-button_spec.js
@@ -1,0 +1,276 @@
+/*
+    Copyright (C) 2018 Google Inc.
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+import Component from '../generate-issues-in-bulk-button';
+import {getComponentVM} from '../../../../js_specs/spec_helpers';
+import * as notifierUtils from '../../../plugins/utils/notifiers-utils';
+import * as errorsUtils from '../../../plugins/utils/errors-utils';
+import Permission from '../../../permission';
+
+describe('generate-issues-in-bulk-button component', () => {
+  let viewModel;
+
+  beforeEach(() => {
+    viewModel = getComponentVM(Component);
+  });
+
+  describe('viewModel', () => {
+    describe('generate() method', () => {
+      beforeEach(() => {
+        spyOn(viewModel, 'trackStatus');
+      });
+
+      it('should set isGeneratingInProgress flag TRUE', () => {
+        viewModel.attr('isGeneratingInProgress', false);
+
+        viewModel.generate();
+
+        expect(viewModel.attr('isGeneratingInProgress')).toBeTruthy();
+      });
+
+      it('should make a request to generate issues', () => {
+        spyOn(viewModel, 'generateChildrenIssues')
+          .and.returnValue(new can.Deferred());
+
+        viewModel.generate();
+
+        expect(viewModel.generateChildrenIssues).toHaveBeenCalled();
+      });
+
+      it('should show notification if generating in progress', () => {
+        spyOn(viewModel, 'generateChildrenIssues')
+          .and.returnValue(new can.Deferred().resolve());
+        spyOn(notifierUtils, 'notifier');
+
+        viewModel.generate();
+
+        expect(notifierUtils.notifier)
+          .toHaveBeenCalledWith('progress', jasmine.any(String));
+      });
+
+      it('should start to track status if generating in progress', () => {
+        spyOn(viewModel, 'generateChildrenIssues')
+          .and.returnValue(new can.Deferred().resolve());
+
+        viewModel.generate();
+
+        expect(viewModel.trackStatus)
+          .toHaveBeenCalledWith(jasmine.any(Number));
+      });
+
+      it('should set isGeneratingInProgress flag FALSE if error occures',
+        () => {
+          viewModel.attr('isGeneratingInProgress', false);
+
+          let dfd = new can.Deferred();
+          spyOn(viewModel, 'generateChildrenIssues').and.returnValue(dfd);
+          spyOn(errorsUtils, 'handleAjaxError');
+
+          viewModel.generate();
+          expect(viewModel.attr('isGeneratingInProgress')).toBeTruthy();
+
+          dfd.reject();
+
+          expect(viewModel.attr('isGeneratingInProgress')).toBeFalsy();
+        });
+
+      it('should handle ajax error', () => {
+        spyOn(viewModel, 'generateChildrenIssues')
+          .and.returnValue(new can.Deferred().reject());
+        spyOn(errorsUtils, 'handleAjaxError');
+
+        viewModel.generate();
+
+        expect(errorsUtils.handleAjaxError).toHaveBeenCalled();
+      });
+    });
+
+    describe('trackStatus() method', () => {
+      beforeEach(() => {
+        spyOn(viewModel, 'checkStatus');
+        jasmine.clock().install();
+      });
+
+      afterEach(() => {
+        jasmine.clock().uninstall();
+      });
+
+      it('should check status by timeout', () => {
+        const timeout = 100;
+
+        viewModel.trackStatus(timeout);
+        jasmine.clock().tick(timeout + 1);
+
+        expect(viewModel.checkStatus).toHaveBeenCalledWith(timeout);
+      });
+
+      it('should store timeout id', () => {
+        viewModel.attr('timeoutId', null);
+
+        viewModel.trackStatus();
+
+        expect(viewModel.attr('timeoutId')).not.toBeNull();
+      });
+    });
+
+    describe('checkStatus() method', () => {
+      const timeout = 1;
+      let dfd;
+
+      beforeEach(() => {
+        dfd = new can.Deferred();
+        viewModel.attr('isGeneratingInProgress', true);
+        spyOn(viewModel, 'getStatus').and.returnValue(dfd);
+        spyOn(viewModel, 'trackStatus');
+      });
+
+      it('should make a request to get status', () => {
+        viewModel.checkStatus(timeout);
+
+        expect(viewModel.getStatus).toHaveBeenCalled();
+      });
+
+      it('should continue to track if status is PENDING', () => {
+        viewModel.checkStatus(timeout);
+        dfd.resolve({status: 'Pending'});
+
+        expect(viewModel.trackStatus).toHaveBeenCalledWith(timeout * 2);
+      });
+
+      it('should continue to track if status is RUNNING', () => {
+        viewModel.checkStatus(timeout);
+        dfd.resolve({status: 'Running'});
+
+        expect(viewModel.trackStatus).toHaveBeenCalledWith(timeout * 2);
+      });
+
+      it('should notify if status is SUCCESS', () => {
+        spyOn(notifierUtils, 'notifier');
+
+        viewModel.checkStatus(timeout);
+        dfd.resolve({status: 'Success'});
+
+        expect(notifierUtils.notifier)
+          .toHaveBeenCalledWith('success', jasmine.any(String));
+        expect(viewModel.attr('isGeneratingInProgress')).toBeFalsy();
+      });
+
+      it('should notify if status is FAILURE', () => {
+        spyOn(notifierUtils, 'notifier');
+
+        viewModel.checkStatus(timeout);
+        dfd.resolve({status: 'Failure'});
+
+        expect(notifierUtils.notifier)
+          .toHaveBeenCalledWith('error', jasmine.any(String));
+        expect(viewModel.attr('isGeneratingInProgress')).toBeFalsy();
+      });
+    });
+
+    describe('checkInitialStatus() method', () => {
+      let dfd;
+
+      beforeEach(() => {
+        dfd = new can.Deferred();
+        spyOn(viewModel, 'getStatus').and.returnValue(dfd);
+        spyOn(viewModel, 'trackStatus');
+      });
+
+      it('shouid set isGettingInitialStatus flad TRUE', () => {
+        viewModel.attr('isGettingInitialStatus', false);
+
+        viewModel.checkInitialStatus();
+
+        expect(viewModel.attr('isGettingInitialStatus')).toBeTruthy();
+      });
+
+      it('should make a request to get status', () => {
+        viewModel.checkInitialStatus();
+
+        expect(viewModel.getStatus).toHaveBeenCalled();
+      });
+
+      it('should start to track if status is PENDING', () => {
+        viewModel.attr('isGeneratingInProgress', false);
+
+        viewModel.checkInitialStatus();
+
+        expect(viewModel.attr('isGettingInitialStatus')).toBeTruthy();
+
+        dfd.resolve({status: 'Pending'});
+
+        expect(viewModel.attr('isGeneratingInProgress')).toBeTruthy();
+        expect(viewModel.trackStatus).toHaveBeenCalled();
+        expect(viewModel.attr('isGettingInitialStatus')).toBeFalsy();
+      });
+
+      it('should start to track if status is RUNNING', () => {
+        viewModel.attr('isGeneratingInProgress', false);
+
+        viewModel.checkInitialStatus();
+
+        expect(viewModel.attr('isGettingInitialStatus')).toBeTruthy();
+
+        dfd.resolve({status: 'Running'});
+
+        expect(viewModel.attr('isGeneratingInProgress')).toBeTruthy();
+        expect(viewModel.trackStatus).toHaveBeenCalled();
+        expect(viewModel.attr('isGettingInitialStatus')).toBeFalsy();
+      });
+
+      it('should not start to track is status is not Running or Pending',
+        () => {
+          viewModel.checkInitialStatus();
+
+          expect(viewModel.attr('isGettingInitialStatus')).toBeTruthy();
+
+          dfd.resolve({status: 'any status'});
+
+          expect(viewModel.attr('isGeneratingInProgress')).toBeFalsy();
+          expect(viewModel.trackStatus).not.toHaveBeenCalled();
+          expect(viewModel.attr('isGettingInitialStatus')).toBeFalsy();
+        });
+    });
+  });
+
+  describe('events', () => {
+    describe('"inserted"', () => {
+      let event;
+
+      beforeEach(() => {
+        spyOn(viewModel, 'checkInitialStatus');
+        event = Component.prototype.events['inserted'].bind({viewModel});
+      });
+
+      it('should check status if user has permissions', () => {
+        spyOn(Permission, 'is_allowed_for').and.returnValue(true);
+
+        event();
+
+        expect(viewModel.checkInitialStatus).toHaveBeenCalled();
+      });
+
+      it('should not check status if user has not permissions', () => {
+        spyOn(Permission, 'is_allowed_for').and.returnValue(false);
+
+        event();
+
+        expect(viewModel.checkInitialStatus).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('"removed"', () => {
+      it('should clear timeout when component is removed', () => {
+        let timeoutId = 'any timeout id';
+        viewModel.attr('timeoutId', timeoutId);
+        spyOn(window, 'clearTimeout');
+
+        Component.prototype.events['removed'].apply({viewModel});
+
+        expect(clearTimeout).toHaveBeenCalledWith(timeoutId);
+      });
+    });
+  });
+});

--- a/src/ggrc-client/js/controllers/info_pin_controller.js
+++ b/src/ggrc-client/js/controllers/info_pin_controller.js
@@ -9,6 +9,7 @@ import '../components/info-pane/info-pane-footer';
 import '../components/assessment/info-pane/info-pane';
 import '../components/folder-attachments-list/folder-attachments-list';
 import '../components/issue-tracker/info-issue-tracker-fields';
+import '../components/issue-tracker/generate-issues-in-bulk-button';
 import '../components/comment/comment-data-provider';
 import '../components/comment/comment-add-form';
 import '../components/comment/mapped-comments';

--- a/src/ggrc-client/styles/components/info-pane/_info-pane.scss
+++ b/src/ggrc-client/styles/components/info-pane/_info-pane.scss
@@ -22,6 +22,10 @@
       float: right;
     }
 
+    .generate-issues-in-bulk {
+      margin-right: 10px;
+    }
+
     &.info-pane__section-procedure {
       display: flex;
 

--- a/src/ggrc/assets/mustache/audits/info.mustache
+++ b/src/ggrc/assets/mustache/audits/info.mustache
@@ -78,13 +78,13 @@
                 {{#if_helpers '\
                   #if' instance.archived '\
                   or ^is_allowed' "update" instance context="for"}}
-                    <ggrc-gdrive-folder-picker 
+                    <ggrc-gdrive-folder-picker
                       {hide-label}="true"
                       {readonly}="true"
                       {instance}="instance">
                     </ggrc-gdrive-folder-picker>
                 {{else}}
-                  <ggrc-gdrive-folder-picker 
+                  <ggrc-gdrive-folder-picker
                     {hide-label}="true"
                     {instance}="instance">
                   </ggrc-gdrive-folder-picker>
@@ -171,8 +171,10 @@
                 <info-issue-tracker-fields
                   {instance}="instance"
                   {note}="'If turned on, one bug will be created for each assessment.'">
-                  <generate-issues-in-bulk-button {instance}="instance">
-                  </generate-issues-in-bulk-button>
+                  {{^if instance.archived}}
+                    <generate-issues-in-bulk-button {instance}="instance">
+                    </generate-issues-in-bulk-button>
+                  {{/if}}
                 </info-issue-tracker-fields>
               {{/if }}
             </div><!-- hidden-fields-area end -->

--- a/src/ggrc/assets/mustache/audits/info.mustache
+++ b/src/ggrc/assets/mustache/audits/info.mustache
@@ -171,6 +171,8 @@
                 <info-issue-tracker-fields
                   {instance}="instance"
                   {note}="'If turned on, one bug will be created for each assessment.'">
+                  <generate-issues-in-bulk-button {instance}="instance">
+                  </generate-issues-in-bulk-button>
                 </info-issue-tracker-fields>
               {{/if }}
             </div><!-- hidden-fields-area end -->


### PR DESCRIPTION
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [x] #8394

# Issue description

As a user with 'Edit' rights for an Audit, I would like to generate in bulk tickets for each assessment in scope of this audit, that is not linked to a ticket yet.

# Solution description

Create new `generate-issues-in-bulk-button` component to initiate generating issues on BE.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
