### PR TITLE
GGRC-5709 CycleTasks unmapped objects' missed revisions crash nightly_cron_job

### DIFF
--- a/src/ggrc/migrations/versions/20180831103643_cb58d1d52368_create_missed_revisions_for_ct_unmapped_objects.py
+++ b/src/ggrc/migrations/versions/20180831103643_cb58d1d52368_create_missed_revisions_for_ct_unmapped_objects.py
@@ -1,0 +1,53 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Create missed revisions for CycleTasks unmapped objects (Audits and Programs)
+
+Create Date: 2018-08-31 10:36:43.151071
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+import sqlalchemy as sa
+
+from alembic import op
+from ggrc.migrations import utils
+
+
+# revision identifiers, used by Alembic.
+revision = 'cb58d1d52368'
+down_revision = 'abb4e8958464'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  connection = op.get_bind()
+  program_sql = """
+      SELECT p.id
+      FROM programs AS p
+      LEFT JOIN revisions AS r
+          ON r.resource_type='Program' AND r.resource_id=p.id
+      WHERE r.id IS NULL
+  """
+  programs = connection.execute(sa.text(program_sql)).fetchall()
+  programs_ids = [o.id for o in programs]
+  if programs_ids:
+    utils.add_to_objects_without_revisions_bulk(connection, programs_ids,
+                                                'Program')
+  audit_sql = """
+      SELECT a.id
+      FROM audits AS a
+      LEFT JOIN revisions AS r
+          ON r.resource_type='Audit' AND r.resource_id=a.id
+      WHERE r.id IS NULL
+  """
+  audits = connection.execute(sa.text(audit_sql)).fetchall()
+  audits_ids = [o.id for o in audits]
+  if audits_ids:
+    utils.add_to_objects_without_revisions_bulk(connection, audits_ids,
+                                                'Audit')
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""

--- a/src/ggrc_workflows/notification/data_handler.py
+++ b/src/ggrc_workflows/notification/data_handler.py
@@ -578,10 +578,15 @@ def get_cycle_task_dict(cycle_task, del_rels_cache=None):
         Revision.resource_type == removed_object_type,
         Revision.resource_id == removed_object_id,
     ).order_by(Revision.id.desc()).first()
-
-    object_titles.append(
-        u"{} [removed from task]".format(object_data.content["display_name"])
-    )
+    if object_data:
+      object_titles.append(
+          u"{} [removed from task]".format(object_data.content["display_name"])
+      )
+    else:
+      logger.warning(
+          "Unmapped %s id %s from CycleTask id % has no revisions logged. ",
+          removed_object_type, removed_object_id, cycle_task.id
+      )
 
   return {
       "title": cycle_task.title,

--- a/test/integration/ggrc_workflows/notifications/test_data_handler.py
+++ b/test/integration/ggrc_workflows/notifications/test_data_handler.py
@@ -1,6 +1,10 @@
 # coding: utf-8
 # Copyright (C) 2018 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+# pylint: disable=no-self-use
+
+"""Tests wf data_handler module."""
+import mock
 
 from integration.ggrc import TestCase
 
@@ -17,6 +21,7 @@ class TestDataHandler(TestCase):
 
   """ This class test basic functions in the data_handler module """
   def test_get_cycle_task_dict(self):
+    """Tests get_cycle_task_dict functionality."""
     contract = ContractFactory(title=u"Contract1")
     cycle_task = CycleTaskFactory(title=u"task1")
     relationship = RelationshipFactory(source=contract,
@@ -53,3 +58,39 @@ class TestDataHandler(TestCase):
     task_dict = get_cycle_task_dict(cycle_task)
     self.assertEqual(task_dict["related_objects"][0],
                      u"Untitled object")
+
+  @mock.patch("ggrc_workflows.notification.data_handler.logger")
+  def test_ct_without_revisions_error(self, logger):
+    """Tests that notifications for CycleTask
+    without revisions are handled properly."""
+    contract = ContractFactory(title=u"Test Contract")
+    cycle_task = CycleTaskFactory(title=u"task1")
+    relationship = RelationshipFactory(source=contract,
+                                       destination=cycle_task)
+    db.session.delete(relationship)
+    db.session.commit()
+
+    relationship_revision = Revision(obj=relationship,
+                                     modified_by_id=None,
+                                     action="deleted",
+                                     content="{}")
+    revisions = [relationship_revision]
+    EventFactory(
+        modified_by_id=None,
+        action="DELETE",
+        resource_id=relationship.id,
+        resource_type=relationship.type,
+        revisions=revisions
+    )
+    contract_revision = db.session.query(Revision).filter(
+        Revision.resource_type == "Contract",
+        Revision.action == "created",
+        Revision.resource_id == contract.id
+    ).one()
+    db.session.delete(contract_revision)
+    db.session.commit()
+    get_cycle_task_dict(cycle_task)
+    logger.warning.assert_called_once_with(
+        "Unmapped %s id %s from CycleTask id % has no revisions logged. ",
+        "Contract", contract.id, cycle_task.id
+    )


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description
Some objects that was previously mapped to CycleTasks and then unmapped don't have revisions for some reason on ggrc-test. This cause `nightly_cron_job` failure. Among them Programs and Audits. 

# Solution description
To fix the problem:

1. Appropriate revisions should be generated.
2. To avoid cron job failure in the future check if revisions exist is added. If there is no such revision, warning is logged; notification is sent without the information about unmapped object.

# Sanity checklist

- [ ] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# Migration checklist
- [x] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

# TODO

- [x] Add error handling.