### PR TITLE
GGRC-5589 Fix eslint block-spacing rule

### DIFF
--- a/src/ggrc-client/js/controllers/lhn_controllers.js
+++ b/src/ggrc-client/js/controllers/lhn_controllers.js
@@ -391,7 +391,7 @@ can.Control('CMS.Controllers.LHN_Search', {
       //  search box and the display prefs to save the search value between page loads.
       //  We also listen for this value in the controller
       //  to trigger the search.
-    return can.view(template_path, prefs_dfd.then(function (prefs) { return prefs.getLHNState(); })).then(function (frag, xhr) {
+    return can.view(template_path, prefs_dfd.then(function (prefs) {return prefs.getLHNState(); })).then(function (frag, xhr) {
       let lhn_prefs = prefs.getLHNState();
       let initial_term;
       let initial_params = {};

--- a/src/ggrc-client/js_specs/models/cacheable_spec.js
+++ b/src/ggrc-client/js_specs/models/cacheable_spec.js
@@ -206,7 +206,7 @@ describe('Cacheable model', function () {
       //  models calls new DummyModel.List() which we're already spying out,
       //  so spy models() out in order to *not* call it.
       spyOn(DummyModel, 'models').and.callFake(function (items) {
-        let ids = can.map(items, function (item) { return item.id; });
+        let ids = can.map(items, function (item) {return item.id; });
         return can.map(dummy_insts, function (inst) {
           return ~can.inArray(inst.id, ids) ? inst : undefined;
         });

--- a/src/ggrc-client/js_specs/models/mappers_spec.js
+++ b/src/ggrc-client/js_specs/models/mappers_spec.js
@@ -771,7 +771,7 @@ describe('mappers', function () {
       it('sets up source_binding from the binding via get_binding, if the source_binding property does not exist', function () {
         rll = new LL.ReifyingListLoader('dummy_binding');
         spyOn(rll, 'insert_from_source_binding');
-        binding = {instance: {'get_binding': function () { return source_binding;}}};
+        binding = {instance: {'get_binding': function () {return source_binding;}}};
         rll.init_listeners(binding);
         expect(binding.source_binding).toBe(source_binding);
         expect(rll.insert_from_source_binding).toHaveBeenCalledWith(binding, source_binding.list, 0);


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

PR fixes 'Unexpected space(s) after '{' (block-spacing)' eslint error.

# Steps to test the changes

Basic regression testing.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
