### PR TITLE
GGRC-5591 Fix eslint object-curly-spacing rule

### DIFF
--- a/src/ggrc-client/js_specs/models/display_prefs_spec.js
+++ b/src/ggrc-client/js_specs/models/display_prefs_spec.js
@@ -65,7 +65,7 @@ describe('display prefs model', function () {
       it('returns a set value whether or not the value is an Observe', function () {
         expect(display_prefs.getObject('foo')).toBe('bar');
         display_prefs.makeObject('baz', 'quux');
-        expect(display_prefs.getObject('baz').serialize()).toEqual({ 'quux': {}});
+        expect(display_prefs.getObject('baz').serialize()).toEqual({'quux': {}});
       });
 
       it('returns undefined when the key is not found', function (){
@@ -282,8 +282,8 @@ describe('display prefs model', function () {
     let dp3_current;
     beforeEach(function () {
       dp_noversion = new DisplayPrefs({});
-      dp2_outdated = new DisplayPrefs({ version: 1});
-      dp3_current = new DisplayPrefs({ version: DisplayPrefs.version });
+      dp2_outdated = new DisplayPrefs({version: 1});
+      dp3_current = new DisplayPrefs({version: DisplayPrefs.version });
     });
     it('404s if the display pref does not have a version set', function (done) {
       spyOn(LocalStorage, 'findOne').and.returnValue(new $.Deferred().resolve(dp_noversion));

--- a/src/ggrc-client/js_specs/models/local_storage_spec.js
+++ b/src/ggrc-client/js_specs/models/local_storage_spec.js
@@ -13,8 +13,8 @@ describe('LocalStorage model', function () {
     LocalStorage('SpecModel');
   });
 
-  let model1 = { 'id': 1, 'foo': 'bar' };
-  let model2 = { 'id': 2, 'foo': 'baz' };
+  let model1 = {'id': 1, 'foo': 'bar' };
+  let model2 = {'id': 2, 'foo': 'baz' };
 
   beforeEach(function () {
     window.localStorage.setItem('spec_model:ids', '[1, 2]');
@@ -108,7 +108,7 @@ describe('LocalStorage model', function () {
 
     it('creates and registers a model', function () {
       let success = false;
-      new SpecModel({ foo: model1.foo }).save().done(function (item) {
+      new SpecModel({foo: model1.foo }).save().done(function (item) {
         expect(item.id).toBeDefined();
         expect(item.foo).toEqual(model1.foo);
 
@@ -123,7 +123,7 @@ describe('LocalStorage model', function () {
     it('creates a model with an appropriate ID when the array of IDs is empty', function () {
       let success = false;
       window.localStorage.setItem('spec_model:ids', '[]');
-      new SpecModel({ foo: model1.foo }).save().done(function (item) {
+      new SpecModel({foo: model1.foo }).save().done(function (item) {
         expect(item.id + 1).not.toBe(item.id); // not infinity, not NaN
         expect(item.foo).toEqual(model1.foo);
 

--- a/src/ggrc-client/js_specs/models/mappers_spec.js
+++ b/src/ggrc-client/js_specs/models/mappers_spec.js
@@ -211,10 +211,10 @@ describe('mappers', function () {
       it('finds all depth-1 bindings touched by walk_instances', function () {
         let mr = new LL.MappingResult('foo', ['bar'], 'baz');
         let phony_binding = {};
-        let phony_result = { binding: phony_binding };
+        let phony_result = {binding: phony_binding };
         spyOn(mr, 'walk_instances').and.callFake(function (fn) {
           fn({}, phony_result, 1);
-          fn({}, { binding: {} }, 2);
+          fn({}, {binding: {} }, 2);
         });
         expect(mr.get_bindings()).toEqual([phony_binding]);
       });
@@ -442,17 +442,17 @@ describe('mappers', function () {
       let found;
       let list;
       beforeEach(function () {
-        not_found = new GGRC.Jasmine.MockModel({ id: 1 });
-        found = new GGRC.Jasmine.MockModel({ id: 2 });
+        not_found = new GGRC.Jasmine.MockModel({id: 1 });
+        found = new GGRC.Jasmine.MockModel({id: 2 });
         list = [{instance: found }];
       });
 
       it('returns null if no result', function () {
-        expect(ll.find_result_by_instance({ instance: not_found }, list)).toBe(null);
+        expect(ll.find_result_by_instance({instance: not_found }, list)).toBe(null);
       });
 
       it('returns the result if found', function () {
-        expect(ll.find_result_by_instance({ instance: found }, list)).toBe(list[0]);
+        expect(ll.find_result_by_instance({instance: found }, list)).toBe(list[0]);
       });
 
     });
@@ -499,11 +499,11 @@ describe('mappers', function () {
       let binding;
       let fake_find_result;
       beforeEach(function () {
-        fake_find_result = { mappings: [] };
+        fake_find_result = {mappings: [] };
         spyOn(ll, 'find_result_by_instance');
         spyOn(ll, 'is_duplicate_result');
         spyOn(ll, 'make_result').and.returnValue(fake_find_result);
-        binding = { list: [] };
+        binding = {list: [] };
       });
 
       it('returns an empty list, and pushes nothing to binding, if no results', function () {
@@ -539,33 +539,33 @@ describe('mappers', function () {
       });
 
       it('removes no instance when nothing is supplied to remove', function () {
-        let instance = new Dummy({ id: 3 });
-        let binding = { list: [{ instance: instance, mappings: [] }] };
+        let instance = new Dummy({id: 3 });
+        let binding = {list: [{instance: instance, mappings: [] }] };
         ll.remove_instance(binding, {}, 'b');
-        expect(binding.list).toEqual([{ instance: instance, mappings: [] }]);
+        expect(binding.list).toEqual([{instance: instance, mappings: [] }]);
       });
 
       it("removes no instance when instance doesn't match type", function () {
-        let instance = new Dummy({ id: 3 });
+        let instance = new Dummy({id: 3 });
         let WrongClass = can.Map.extend();
         WrongClass.shortName = 'Wrong';
-        let wrong_instance = new WrongClass({ id: 3 });
-        let binding = { list: [{ instance: instance, mappings: [] }] };
+        let wrong_instance = new WrongClass({id: 3 });
+        let binding = {list: [{instance: instance, mappings: [] }] };
         ll.remove_instance(binding, wrong_instance, 'b');
-        expect(binding.list).toEqual([{ instance: instance, mappings: [] }]);
+        expect(binding.list).toEqual([{instance: instance, mappings: [] }]);
       });
 
       it('removes the instance from mappings when matching', function () {
-        let instance = new Dummy({ id: 3 });
-        let binding = { list: [{ instance: instance, mappings: [] }] };
+        let instance = new Dummy({id: 3 });
+        let binding = {list: [{instance: instance, mappings: [] }] };
         ll.remove_instance(binding, instance, 'b');
         expect(binding.list).toEqual([]);
       });
 
       it('removes the instance from mappings on just type and ID match', function () {
-        let instance = new Dummy({ id: 3 });
-        let matching_instance = new Dummy({ id: 3 });
-        let binding = { list: [{ instance: instance, mappings: [] }] };
+        let instance = new Dummy({id: 3 });
+        let matching_instance = new Dummy({id: 3 });
+        let binding = {list: [{instance: instance, mappings: [] }] };
         expect(matching_instance).not.toBe(instance);
         ll.remove_instance(binding, matching_instance, 'b');
         expect(binding.list).toEqual([]);
@@ -574,7 +574,7 @@ describe('mappers', function () {
       describe('with mappings defined', function () {
 
         it('deletes only if all mappings are accounted for in instance', function () {
-          let instance = new Dummy({ id: 3 });
+          let instance = new Dummy({id: 3 });
           let binding = {
             list: [{
               instance: instance,
@@ -593,7 +593,7 @@ describe('mappers', function () {
         });
 
         it('does not delete if not all mappings are accounted for', function () {
-          let instance = new Dummy({ id: 3 });
+          let instance = new Dummy({id: 3 });
           let binding = {
             list: [{
               instance: instance,
@@ -608,7 +608,7 @@ describe('mappers', function () {
             }],
           };
           ll.remove_instance(binding, instance, ['a']); // only one of the mappings
-          expect(binding.list).toEqual([{ instance: instance, mappings: ['b'], remove_mapping: jasmine.any(Function) }]);
+          expect(binding.list).toEqual([{instance: instance, mappings: ['b'], remove_mapping: jasmine.any(Function) }]);
         });
       });
 
@@ -617,7 +617,7 @@ describe('mappers', function () {
     describe('#refresh_stubs', function () {
 
       it('returns promise based on existing deferred, returning binding list, if it exists', function () {
-        let binding = { list: [] };
+        let binding = {list: [] };
         let source_dfd = binding._refresh_stubs_deferred = new $.Deferred();
         let ret = ll.refresh_stubs(binding);
         let sanity = false;
@@ -633,7 +633,7 @@ describe('mappers', function () {
 
       it('makes new refresh stubs deferred, returning binding list, if it does not already exist', function () {
         let ret;
-        let binding = { list: [] };
+        let binding = {list: [] };
         let sanity = false;
         ll._refresh_stubs = jasmine.createSpy().and.returnValue($.when());
         ret = ll.refresh_stubs(binding);
@@ -651,7 +651,7 @@ describe('mappers', function () {
     describe('#refresh_instances', function () {
 
       it('returns promise based on existing deferred, returning binding list, if it exists', function () {
-        let binding = { list: [] };
+        let binding = {list: [] };
         let source_dfd = binding._refresh_instances_deferred = new $.Deferred();
         let ret = ll.refresh_instances(binding);
         let sanity = false;
@@ -667,7 +667,7 @@ describe('mappers', function () {
 
       it('makes new refresh instances deferred, returning binding list, if it does not already exist', function () {
         let ret;
-        let binding = { list: [] };
+        let binding = {list: [] };
         let sanity = false;
         ll._refresh_instances = jasmine.createSpy().and.returnValue($.when());
         ret = ll.refresh_instances(binding);
@@ -686,7 +686,7 @@ describe('mappers', function () {
 
       it('returns promise based on binding list', function () {
         let ret;
-        let binding = { list: [{instance: 'a'}] };
+        let binding = {list: [{instance: 'a'}] };
         let sanity = false;
         spyOn(ll, 'refresh_stubs').and.returnValue($.when());
         spyOn(RefreshQueue.prototype, 'trigger').and.callFake(function () {
@@ -771,7 +771,7 @@ describe('mappers', function () {
       it('sets up source_binding from the binding via get_binding, if the source_binding property does not exist', function () {
         rll = new LL.ReifyingListLoader('dummy_binding');
         spyOn(rll, 'insert_from_source_binding');
-        binding = { instance: { 'get_binding': function () { return source_binding; }}};
+        binding = {instance: {'get_binding': function () { return source_binding; }}};
         rll.init_listeners(binding);
         expect(binding.source_binding).toBe(source_binding);
         expect(rll.insert_from_source_binding).toHaveBeenCalledWith(binding, source_binding.list, 0);
@@ -827,7 +827,7 @@ describe('mappers', function () {
     describe('_refresh_stubs', function () {
 
       it("gets results from binding's source binding", function () {
-        let mock_inst = new GGRC.Jasmine.MockModel({ value: 'a' });
+        let mock_inst = new GGRC.Jasmine.MockModel({value: 'a' });
         spyOn(binding.source_binding, 'refresh_instances').and.returnValue(new $.Deferred().reject());
 
         cfll._refresh_stubs(binding);
@@ -835,8 +835,8 @@ describe('mappers', function () {
       });
 
       it('runs all results from source binding through filter function', function () {
-        let mock_inst = new GGRC.Jasmine.MockModel({ value: 'a' });
-        let mock_result = { instance: mock_inst, mappings: [] };
+        let mock_inst = new GGRC.Jasmine.MockModel({value: 'a' });
+        let mock_result = {instance: mock_inst, mappings: [] };
         spyOn(binding.source_binding, 'refresh_instances').and.returnValue(new $.Deferred().resolve([mock_result]));
 
         // Items are sent through a refresh queue before continuing.


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

PR fixes 'There should be no space after '{' (object-curly-spacing)' eslint error.

# Steps to test the changes

Basic regression testing.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
