### PR TITLE
GGRC-5931 Fix issue on hovering over 'i' icon in tree-view

### DIFF
--- a/src/ggrc-client/js/components/tree/templates/tree-item-extra-info.mustache
+++ b/src/ggrc-client/js/components/tree/templates/tree-item-extra-info.mustache
@@ -26,13 +26,13 @@
               ></mapped-counter>
             {{else}}
               <mapped-counter {instance}="instance"
-                              type="Requiremenet"
+                              type="Requirement"
                               {add-content}="@addContent"
               ></mapped-counter>
             {{/if_instance_of}}
           </section>
         {{/if}}
-
+        
         {{#if isRequirement}}
           <section>
             <h3 class="task-list-title">Number of mapped objects</h3>


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

'There was an error' is displayed while hovering over 'i' icon in treeView. POST 500 is displayed in console

# Steps to test the changes

1. Create a standard
2. Create a task and map it to the standard
3. Open My work page > Standards tab
4. Hover over 'i' icon in tree view

**Note**: the same error is displayed for _Standards, Regulations, Metrics, Policies_

# Solution description

Fixed typo: type="Requiremen**e**t"

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
