### PR TITLE
GGRC-5551 It is possible to map TaskGroup to another wf via import

### DIFF
--- a/src/ggrc/converters/errors.py
+++ b/src/ggrc/converters/errors.py
@@ -168,3 +168,9 @@ DISALLOW_EVIDENCE_FILE = (u"Line {line}: 'Evidence File' can't be changed "
 DISALLOW_DOCUMENT_FILE = (u"Line {line}: 'Document File' can't be changed "
                           u"via import. Please go on {parent} page and "
                           u"make changes manually. The column will be skipped")
+
+TASKGROUP_MAPPED_TO_ANOTHER_WORKFLOW = (u"Line {line}: TaskGroup '{slug}' "
+                                        u"already exists in the system "
+                                        u"and mapped to another "
+                                        u"workflow. Please, use different "
+                                        u"code for this TaskGroup")

--- a/src/ggrc_workflows/converters/handlers.py
+++ b/src/ggrc_workflows/converters/handlers.py
@@ -23,8 +23,12 @@ class WorkflowColumnHandler(handlers.ParentColumnHandler):
   def parse_item(self):
     """Workflow column shouldn't be changed for TaskGroup."""
     obj = self.row_converter.obj
-    parent = getattr(obj, self.key, None)
-    if parent and parent.slug != self.raw_value:
+    workflow = db.session.query(
+        wf_models.Workflow.slug
+    ).filter_by(
+        id=obj.workflow_id
+    ).first()
+    if workflow and workflow.slug != self.raw_value:
       self.add_error(errors.TASKGROUP_MAPPED_TO_ANOTHER_WORKFLOW,
                      slug=obj.slug)
     return super(WorkflowColumnHandler, self).parse_item()

--- a/src/ggrc_workflows/converters/handlers.py
+++ b/src/ggrc_workflows/converters/handlers.py
@@ -20,6 +20,15 @@ class WorkflowColumnHandler(handlers.ParentColumnHandler):
 
   parent = all_models.Workflow
 
+  def parse_item(self):
+    """Workflow column shouldn't be changed for TaskGroup."""
+    obj = self.row_converter.obj
+    parent = getattr(obj, self.key, None)
+    if parent and parent.slug != self.raw_value:
+      self.add_error(errors.TASKGROUP_MAPPED_TO_ANOTHER_WORKFLOW,
+                     slug=obj.slug)
+    return super(WorkflowColumnHandler, self).parse_item()
+
 
 class TaskGroupColumnHandler(handlers.ParentColumnHandler):
   """Handler for task group column in task group tasks."""

--- a/test/integration/ggrc_workflows/converters/test_task_group_import.py
+++ b/test/integration/ggrc_workflows/converters/test_task_group_import.py
@@ -12,12 +12,13 @@ from ggrc.converters import errors
 from ggrc.models import all_models
 from ggrc_workflows import models
 from integration.ggrc.models import factories
-from integration.ggrc_workflows.helpers import workflow_test_case
+from integration.ggrc_workflows.helpers.workflow_test_case \
+    import WorkflowTestCase
 from integration.ggrc_workflows.models import factories as wf_factories
 
 
 @ddt.ddt
-class TestTaskGroupImport(workflow_test_case.WorkflowTestCase):
+class TestTaskGroupImport(WorkflowTestCase):
   """Tests related to TaskGroup import."""
 
   @ddt.data(
@@ -85,7 +86,7 @@ class TestTaskGroupImport(workflow_test_case.WorkflowTestCase):
 
 
 @ddt.ddt
-class TestTaskGroupTaskImport(workflow_test_case.WorkflowTestCase):
+class TestTaskGroupTaskImport(WorkflowTestCase):
   """Tests related to TaskGroupTask import."""
 
   def setUp(self):
@@ -183,3 +184,56 @@ class TestTaskGroupTaskImport(workflow_test_case.WorkflowTestCase):
     self._check_csv_response(response, expected_messages)
     self.assertEquals(start_date_before, start_date_after)
     self.assertEquals(end_date_before, end_date_after)
+
+
+class TestImportTasksGroupsWithExistingSlugs(WorkflowTestCase):
+  """
+  Test case when task groups with existing slugs
+  are imported.
+  """
+  def test_import_tgs_with_existing_slugs(self):
+    """
+    When tgs with existing slugs are imported
+    they shouldn't be unmapped from the previous wf.
+    Proper error should be displayed.
+    """
+    # pylint: disable=invalid-name
+    first_wf_slug = "WORKFLOW-1"
+    first_tg_slug = "TASKGROUP-1"
+    with factories.single_commit():
+      # create first workflow, it's tg and tgt
+      first_wf = wf_factories.WorkflowFactory(slug=first_wf_slug)
+      first_task_group = wf_factories.TaskGroupFactory(slug=first_tg_slug,
+                                                       workflow=first_wf)
+      wf_factories.TaskGroupTaskFactory(task_group=first_task_group)
+
+    second_wf_slug = "WORKFLOW-2"
+
+    # create second workflow
+    wf_factories.WorkflowFactory(slug=second_wf_slug)
+
+    # second tg has slug equals to the slug of the first tg
+    second_tg_data = collections.OrderedDict([
+        ("object_type", all_models.TaskGroup.__name__),
+        ("code", first_tg_slug),
+        ("workflow", second_wf_slug)
+    ])
+    response = self.import_data(second_tg_data)
+
+    expected_error = (u"Line 3: TaskGroup '%s' already "
+                      u"exists in the system and mapped "
+                      u"to another workflow. Please, "
+                      u"use different code for this TaskGroup" % first_tg_slug)
+    self.assertEquals([expected_error], response[0]['row_errors'])
+
+    first_wf = db.session.query(models.Workflow).filter(
+        models.Workflow.slug == first_wf_slug
+    ).one()
+    second_wf = db.session.query(models.Workflow).filter(
+        models.Workflow.slug == second_wf_slug
+    ).one()
+
+    self.assertEqual(db.session.query(models.TaskGroup).filter(
+        models.TaskGroup.workflow_id == first_wf.id).count(), 1)
+    self.assertEqual(db.session.query(models.TaskGroup).filter(
+        models.TaskGroup.workflow_id == second_wf.id).count(), 0)


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

It is possible to import TaskGroup with existing slug and map it to different workflow.

# Steps to test the changes
Slightly different with ones described in the ticket as better reproduce the root cause of the issue.

1. Create Workflow1.
2. Create TaskGroup1 with slug 'TG-1' mapped to Workflow1.
3. Create TaskGroupTask1 mapped to TaskGroup1.
3. Create Workflow2 with slug 'WF-1'.
4. Import TaskGroup with slug 'TG-1' and Workflow with slug 'WF-2'
**Actual result:** TaskGroup1 is mapped to Workflow2 and contains TaskGroupTask1 mapped.
**Expected result:** error 'TaskGroup 'TG-1' already exists at the system and mapped to another workflow. Please use different code for this TaskGroup.' should appear during import. TaskGroup1 shouldn't be mapped to Workflow2.

# Solution description

Handler for workflow column in task groups has been fixed to generate an error for such use case.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

# TODO

- [x] Reduce the number of queries in WorkflowColumnHandler from 2 to 1.
