### PR TITLE
GGRC-5958 Implement background task status endpoint

### DIFF
--- a/src/ggrc/migrations/versions/20180906085124_b2cdde0ea7b5_add_info_about_object_and_operation_to_.py
+++ b/src/ggrc/migrations/versions/20180906085124_b2cdde0ea7b5_add_info_about_object_and_operation_to_.py
@@ -1,0 +1,80 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Add info about object and operation to BG task
+
+Create Date: 2018-09-06 08:51:24.838989
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+from ggrc.migrations.utils import migrator
+
+revision = 'b2cdde0ea7b5'
+down_revision = '3bbaeab12163'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  op.create_table(
+      "background_operation_types",
+      sa.Column("id", sa.Integer(), primary_key=True),
+      sa.Column("name", sa.String(length=250), nullable=False),
+      sa.Column("modified_by_id", sa.Integer(), nullable=True),
+      sa.Column("created_at", sa.DateTime()),
+      sa.Column("updated_at", sa.DateTime()),
+  )
+
+  op.create_table(
+      "background_operations",
+      sa.Column("id", sa.Integer(), primary_key=True),
+      sa.Column("bg_operation_type_id", sa.Integer, nullable=False),
+      sa.Column("object_type", sa.String(length=250), nullable=False),
+      sa.Column("object_id", sa.Integer(), nullable=False),
+      sa.Column("modified_by_id", sa.Integer(), nullable=True),
+      sa.Column("created_at", sa.DateTime()),
+      sa.Column("updated_at", sa.DateTime()),
+      sa.ForeignKeyConstraint(
+          ["bg_operation_type_id"],
+          ["background_operation_types.id"],
+      )
+  )
+  op.add_column(
+      "background_tasks",
+      sa.Column("background_operation_id", sa.Integer(), nullable=True),
+  )
+  op.create_foreign_key(
+      "fk_background_operation_id",
+      "background_tasks", "background_operations",
+      ["background_operation_id"], ["id"],
+  )
+
+  connection = op.get_bind()
+  migrator_id = migrator.get_migration_user_id(connection)
+  connection.execute(
+      sa.text("""
+          INSERT INTO background_operation_types(
+            `name`, modified_by_id, created_at, updated_at
+          )
+          SELECT 'generate_children_issues', :migrator_id, now(), now();
+      """),
+      migrator_id=migrator_id,
+  )
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  op.drop_constraint(
+      "fk_background_operation_id",
+      "background_tasks",
+      "foreignkey",
+  )
+  op.drop_table("background_operations")
+  op.drop_column("background_tasks", "background_operation_id")
+  op.drop_table("background_operation_types")

--- a/src/ggrc/migrations/versions/20180906085124_b2cdde0ea7b5_add_info_about_object_and_operation_to_.py
+++ b/src/ggrc/migrations/versions/20180906085124_b2cdde0ea7b5_add_info_about_object_and_operation_to_.py
@@ -35,6 +35,7 @@ def upgrade():
       "background_operations",
       sa.Column("id", sa.Integer(), primary_key=True),
       sa.Column("bg_operation_type_id", sa.Integer, nullable=False),
+      sa.Column("bg_task_id", sa.Integer, nullable=False),
       sa.Column("object_type", sa.String(length=250), nullable=False),
       sa.Column("object_id", sa.Integer(), nullable=False),
       sa.Column("modified_by_id", sa.Integer(), nullable=True),
@@ -43,16 +44,8 @@ def upgrade():
       sa.ForeignKeyConstraint(
           ["bg_operation_type_id"],
           ["background_operation_types.id"],
-      )
-  )
-  op.add_column(
-      "background_tasks",
-      sa.Column("background_operation_id", sa.Integer(), nullable=True),
-  )
-  op.create_foreign_key(
-      "fk_background_operation_id",
-      "background_tasks", "background_operations",
-      ["background_operation_id"], ["id"],
+      ),
+      sa.ForeignKeyConstraint(["bg_task_id"], ["background_tasks.id"])
   )
 
   connection = op.get_bind()
@@ -70,11 +63,5 @@ def upgrade():
 
 def downgrade():
   """Downgrade database schema and/or data back to the previous revision."""
-  op.drop_constraint(
-      "fk_background_operation_id",
-      "background_tasks",
-      "foreignkey",
-  )
   op.drop_table("background_operations")
-  op.drop_column("background_tasks", "background_operation_id")
   op.drop_table("background_operation_types")

--- a/src/ggrc/models/all_models.py
+++ b/src/ggrc/models/all_models.py
@@ -20,7 +20,9 @@ from ggrc.models.assessment import Assessment
 from ggrc.models.assessment_template import AssessmentTemplate
 from ggrc.models.audit import Audit
 from ggrc.models.automapping import Automapping
+from ggrc.models.background_operation_type import BackgroundOperationType
 from ggrc.models.background_task import BackgroundTask
+from ggrc.models.background_operation import BackgroundOperation
 from ggrc.models.categorization import Categorization
 from ggrc.models.category import CategoryBase
 from ggrc.models.clause import Clause
@@ -98,6 +100,8 @@ all_models = [  # pylint: disable=invalid-name
     Audit,
     Automapping,
     BackgroundTask,
+    BackgroundOperation,
+    BackgroundOperationType,
     Categorization,
     CategoryBase,
     Clause,

--- a/src/ggrc/models/background_operation.py
+++ b/src/ggrc/models/background_operation.py
@@ -17,5 +17,6 @@ class BackgroundOperation(mixins.Base, db.Model):
   )
   object_type = db.Column(db.String, nullable=False)
   object_id = db.Column(db.Integer, nullable=False)
+  bg_task_id = db.Column(db.Integer, db.ForeignKey('background_tasks.id'))
 
   bg_operation_type = db.relationship("BackgroundOperationType")

--- a/src/ggrc/models/background_operation.py
+++ b/src/ggrc/models/background_operation.py
@@ -1,0 +1,21 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Module for ggrc background operations."""
+from ggrc import db
+from ggrc.models import mixins
+
+
+class BackgroundOperation(mixins.Base, db.Model):
+  """Background operation model."""
+  __tablename__ = 'background_operations'
+
+  bg_operation_type_id = db.Column(
+      db.Integer,
+      db.ForeignKey('background_operation_types.id'),
+      nullable=False
+  )
+  object_type = db.Column(db.String, nullable=False)
+  object_id = db.Column(db.Integer, nullable=False)
+
+  bg_operation_type = db.relationship("BackgroundOperationType")

--- a/src/ggrc/models/background_operation_type.py
+++ b/src/ggrc/models/background_operation_type.py
@@ -1,0 +1,13 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Module for ggrc background operation types."""
+from ggrc import db
+from ggrc.models import mixins
+
+
+class BackgroundOperationType(mixins.Base, db.Model):
+  """Background operation type model."""
+  __tablename__ = 'background_operation_types'
+
+  name = db.Column(db.String, nullable=False)

--- a/src/ggrc/models/background_task.py
+++ b/src/ggrc/models/background_task.py
@@ -12,9 +12,10 @@ from time import time
 
 from flask import request
 from flask.wrappers import Response
+from werkzeug import exceptions
 from werkzeug.datastructures import Headers
 
-from ggrc import db
+from ggrc import db, login
 from ggrc import settings
 from ggrc.login import get_current_user
 from ggrc.access_control import role
@@ -56,6 +57,11 @@ class BackgroundTask(roleable.Roleable, base.ContextRBAC, Base, Stateful,
   name = deferred(db.Column(db.String), 'BackgroundTask')
   parameters = deferred(db.Column(CompressedType), 'BackgroundTask')
   result = deferred(db.Column(CompressedType), 'BackgroundTask')
+  background_operation_id = deferred(
+      db.Column(db.Integer, db.ForeignKey('background_operations.id')),
+      'BackgroundTask'
+  )
+  bg_operation = db.relationship("BackgroundOperation")
 
   _api_attrs = reflection.ApiAttributes('name', 'result')
 
@@ -133,7 +139,9 @@ def collect_task_headers():
   return Headers({k: v for k, v in request.headers if k not in BANNED_HEADERS})
 
 
-def create_task(name, url, queued_callback=None, parameters=None, method=None):
+# pylint: disable=too-many-arguments
+def create_task(name, url, queued_callback=None, parameters=None, method=None,
+                operation_type=None):
   """Create a enqueue a bacground task."""
   if not method:
     method = request.method
@@ -142,7 +150,23 @@ def create_task(name, url, queued_callback=None, parameters=None, method=None):
   if not parameters:
     parameters = {}
 
-  task = BackgroundTask(name=name + str(int(time())))
+  parent_type, parent_id = None, None
+  if isinstance(parameters, dict):
+    parent_type = parameters.get("parent", {}).get("type")
+    parent_id = parameters.get("parent", {}).get("id")
+
+  if bg_operation_running(operation_type, parent_type, parent_id):
+    raise exceptions.BadRequest(
+        "Task '{}' already run for {} {}.".format(
+            operation_type, parent_type, parent_id
+        )
+    )
+  bg_operation = create_bg_operation(operation_type, parent_type, parent_id)
+
+  task = BackgroundTask(
+      name=name + str(int(time())),
+      bg_operation=bg_operation,
+  )
   task.parameters = parameters
   task.modified_by = get_current_user()
   _add_task_acl(task)
@@ -194,6 +218,45 @@ def create_lightweight_task(name, url, queued_callback=None, parameters=None,
     raise ValueError(
         "Either queued_callback should be provided or APP_ENGINE set to true."
     )
+
+
+def create_bg_operation(operation_type, object_type, object_id):
+  """Create background task operation instance."""
+  bg_operation = None
+  if operation_type:
+    from ggrc import models
+    bg_operation_type = models.BackgroundOperationType.query.filter_by(
+        name=operation_type
+    ).first()
+
+    if bg_operation_type and object_type and object_id:
+      bg_operation = models.BackgroundOperation(
+          object_type=object_type,
+          object_id=object_id,
+          bg_operation_type=bg_operation_type,
+      )
+  return bg_operation
+
+
+def bg_operation_running(operation_type, object_type, object_id):
+  """Check if there is a background task in running state related to object."""
+  from ggrc import models
+  bg_task = models.BackgroundTask
+  bg_operation = models.BackgroundOperation
+  bg_type = models.BackgroundOperationType
+  tasks = bg_task.query.join(
+      bg_operation,
+      bg_operation.id == bg_task.background_operation_id
+  ).join(
+      bg_type,
+      bg_type.id == bg_operation.bg_operation_type_id
+  ).filter(
+      bg_operation.object_type == object_type,
+      bg_operation.object_id == object_id,
+      bg_type.name == operation_type,
+      bg_task.status == "Running",
+  )
+  return db.session.query(tasks.exists()).scalar()
 
 
 def make_task_response(id_):

--- a/src/ggrc/models/background_task.py
+++ b/src/ggrc/models/background_task.py
@@ -15,7 +15,7 @@ from flask.wrappers import Response
 from werkzeug import exceptions
 from werkzeug.datastructures import Headers
 
-from ggrc import db, login
+from ggrc import db
 from ggrc import settings
 from ggrc.login import get_current_user
 from ggrc.access_control import role

--- a/src/ggrc/models/background_task.py
+++ b/src/ggrc/models/background_task.py
@@ -117,6 +117,15 @@ class BackgroundTask(roleable.Roleable, base.ContextRBAC, Base, Stateful,
         ))
     )
 
+  def get_content(self):
+    """Get result content of the task."""
+    try:
+      content_json = self.result.get("content", "{}") if self.result else "{}"
+      content = json.loads(content_json)
+    except (TypeError, ValueError):
+      content = {}
+    return content
+
 
 def _add_task_acl(task):
   """Add ACL entry for the current users background task."""

--- a/src/ggrc/models/background_task.py
+++ b/src/ggrc/models/background_task.py
@@ -234,6 +234,7 @@ def create_bg_operation(operation_type, object_type, object_id):
           object_type=object_type,
           object_id=object_id,
           bg_operation_type=bg_operation_type,
+          modified_by=get_current_user()
       )
   return bg_operation
 

--- a/src/ggrc/views/__init__.py
+++ b/src/ggrc/views/__init__.py
@@ -664,7 +664,7 @@ def get_background_task_status(object_type, object_id):
   bg_operation = models.BackgroundOperation
   task = bg_task.query.join(
       bg_operation,
-      bg_operation.id == bg_task.background_operation_id
+      bg_operation.bg_task_id == bg_task.id
   ).filter(
       bg_operation.object_type == object_type,
       bg_operation.object_id == object_id,
@@ -672,7 +672,7 @@ def get_background_task_status(object_type, object_id):
       bg_task.created_at.desc()
   ).first()
 
-  if task:
+  if task and task.bg_operation:
     body = {
         "status": task.status,
         "operation": task.bg_operation.bg_operation_type.name

--- a/src/ggrc/views/__init__.py
+++ b/src/ggrc/views/__init__.py
@@ -19,7 +19,7 @@ from flask import url_for
 from flask import request
 from werkzeug import exceptions
 
-from ggrc import models, login
+from ggrc import models
 from ggrc import settings
 from ggrc.app import app
 from ggrc.app import db

--- a/src/ggrc/views/__init__.py
+++ b/src/ggrc/views/__init__.py
@@ -675,7 +675,8 @@ def get_background_task_status(object_type, object_id):
   if task and task.bg_operation:
     body = {
         "status": task.status,
-        "operation": task.bg_operation.bg_operation_type.name
+        "operation": task.bg_operation.bg_operation_type.name,
+        "errors": task.get_content().get("errors", []),
     }
     response = app.make_response(
         (json.dumps(body), 200, [("Content-Type", "application/json")])

--- a/test/integration/ggrc/__init__.py
+++ b/test/integration/ggrc/__init__.py
@@ -145,7 +145,8 @@ class TestCase(BaseTestCase, object):
         "object_types",
         "attribute_templates",
         "object_templates",
-        "access_control_roles"
+        "access_control_roles",
+        "background_operation_types",
     )
     tables = set(db.metadata.tables).difference(ignore_tables)
     for _ in range(len(tables)):


### PR DESCRIPTION
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [x] https://github.com/google/ggrc-core/pull/8378


# Issue description

FE need to have information about status of bulk issuetracker create operation that was run. Existing /api/background_tasks/<id> endpoint can't be used as bg task id will be lost if user update page, or if he try to open this page from other tab/window. But by our requirements, if user start bulk tickets creation, he shouldn't be able to run it again until previous one will not be finished.

# Steps to test the changes

Send GET request to '/background_task_status/<object_type>/<object_id>'

# Solution description

See tech dock in GGRC-4603 ticket.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# Migration checklist
- [x] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

