### PR TITLE
GGRC-5985 Allow external users work on behalf their account

### DIFF
--- a/src/ggrc/login/__init__.py
+++ b/src/ggrc/login/__init__.py
@@ -89,15 +89,13 @@ def get_current_user(use_external_user=True):
   logged_in_user = _get_current_logged_user()
   if use_external_user and is_external_app_user():
     try:
-      from ggrc.utils.user_generator import find_or_create_external_user
       from ggrc.utils.user_generator import parse_user_email
       external_user_email = parse_user_email(request,
                                              "X-external-user",
                                              mandatory=False)
       if external_user_email:
-        ext_user = find_or_create_external_user(external_user_email,
-                                                name=external_user_email,
-                                                modifier=logged_in_user.id)
+        from ggrc.utils.user_generator import find_user
+        ext_user = find_user(external_user_email, modifier=logged_in_user.id)
         if ext_user:
           return ext_user
     except RuntimeError:

--- a/src/ggrc/login/__init__.py
+++ b/src/ggrc/login/__init__.py
@@ -96,7 +96,7 @@ def get_current_user(use_external_user=True):
                                              mandatory=False)
       if external_user_email:
         ext_user = find_or_create_external_user(external_user_email,
-                                                name=None,
+                                                name=external_user_email,
                                                 modifier=logged_in_user.id)
         if ext_user:
           return ext_user

--- a/src/ggrc/login/__init__.py
+++ b/src/ggrc/login/__init__.py
@@ -84,15 +84,20 @@ def get_current_user(use_external_user=True):
     current user.
   """
 
+  logged_in_user = _get_current_logged_user()
   if use_external_user and is_external_app_user():
-    from ggrc.utils.user_generator import find_or_create_ext_app_user, \
-        parse_user_email
     try:
-      external_user_email = parse_user_email(request, "X-external-user",
+      from ggrc.utils.user_generator import find_or_create_external_user
+      from ggrc.utils.user_generator import parse_user_email
+      external_user_email = parse_user_email(request,
+                                             "X-external-user",
                                              mandatory=False)
-      ext_user = find_or_create_ext_app_user(external_user_email)
-      if ext_user:
-        return ext_user
+      if external_user_email:
+        ext_user = find_or_create_external_user(external_user_email,
+                                                name=None,
+                                                modifier=logged_in_user.id)
+        if ext_user:
+          return ext_user
     except RuntimeError:
       logger.info("Working outside of request context.")
   return _get_current_logged_user()

--- a/src/ggrc/login/__init__.py
+++ b/src/ggrc/login/__init__.py
@@ -46,7 +46,9 @@ def init_app(app):
   # pylint: disable=unused-variable
   @app.login_manager.unauthorized_handler
   def unauthorized():
-    """Called when the user tries to access an endpoint guarded with
+    """Redirects to the login page and generates an error.
+
+    Called when the user tries to access an endpoint guarded with
     login_required but they are not authorized.
 
     Endpoints like /dashboard, /program/1, etc. redirect the user to the
@@ -100,7 +102,7 @@ def get_current_user(use_external_user=True):
           return ext_user
     except RuntimeError:
       logger.info("Working outside of request context.")
-  return _get_current_logged_user()
+  return logged_in_user
 
 
 def _get_current_logged_user():

--- a/src/ggrc/login/appengine.py
+++ b/src/ggrc/login/appengine.py
@@ -14,8 +14,6 @@ Assumes app.yaml is configured with:
 E.g., ``login: required`` must be specified *at least* for the '/login' route.
 """
 
-import json
-
 from google.appengine.api import users
 import flask
 import flask_login
@@ -27,6 +25,7 @@ from ggrc import settings
 from ggrc.utils.user_generator import find_or_create_ext_app_user
 from ggrc.utils.user_generator import find_or_create_user_by_email
 from ggrc.utils.user_generator import is_external_app_user_email
+from ggrc.utils.user_generator import parse_user_email
 
 
 def get_user():
@@ -73,25 +72,13 @@ def request_loader(request):
                                 "untrusted application id: {}"
                                 .format(inbound_appid))
 
-  user = request.headers.get("X-GGRC-user")
-  if not user:
-    # no user provided
-    raise exceptions.BadRequest("X-GGRC-user should be set, contains {!r} "
-                                "instead."
-                                .format(user))
-
-  try:
-    user = json.loads(user)
-    email = str(user["email"])
-  except (TypeError, ValueError, KeyError):
-    # user provided in invalid syntax
-    raise exceptions.BadRequest("X-GGRC-user should have JSON object like "
-                                "{{'email': str}}, contains {!r} instead."
-                                .format(user))
+  email = parse_user_email(request, "X-GGRC-user", mandatory=True)
 
   # External Application User should be created if doesn't exist.
   if is_external_app_user_email(email):
     db_user = find_or_create_ext_app_user()
+    from ggrc.utils.user_generator import get_external_app_user
+    get_external_app_user(request)
   else:
     db_user = all_models.Person.query.filter_by(email=email).first()
   if not db_user:

--- a/src/ggrc/login/appengine.py
+++ b/src/ggrc/login/appengine.py
@@ -84,9 +84,7 @@ def request_loader(request):
     db_user = find_or_create_ext_app_user()
     try:
       # Create in the DB external app user provided in X-external-user header.
-      external_user_email = parse_user_email(request, "X-external-user",
-                                             mandatory=False)
-      find_or_create_ext_app_user(external_user_email)
+      parse_user_email(request, "X-external-user", mandatory=False)
     except exceptions.BadRequest as exp:
       logger.error("Creation of external user has failed. %s", exp.message)
       raise

--- a/src/ggrc/login/appengine.py
+++ b/src/ggrc/login/appengine.py
@@ -14,7 +14,7 @@ Assumes app.yaml is configured with:
 E.g., ``login: required`` must be specified *at least* for the '/login' route.
 """
 
-from logging import getLogger
+import logging
 
 from google.appengine.api import users
 import flask
@@ -30,7 +30,7 @@ from ggrc.utils.user_generator import is_external_app_user_email
 from ggrc.utils.user_generator import parse_user_email
 
 
-logger = getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def get_user():
@@ -84,10 +84,11 @@ def request_loader(request):
     db_user = find_or_create_ext_app_user()
     try:
       # Create in the DB external app user provided in X-external-user header.
-      from ggrc.utils.user_generator import get_external_app_user
-      get_external_app_user(request)
+      external_user_email = parse_user_email(request, "X-external-user",
+                                             mandatory=False)
+      find_or_create_ext_app_user(external_user_email)
     except exceptions.BadRequest as exp:
-      logger.error("Creation of external user has failed : %s", exp.message)
+      logger.error("Creation of external user has failed. %s", exp.message)
       raise
   else:
     db_user = all_models.Person.query.filter_by(email=email).first()

--- a/src/ggrc/login/appengine.py
+++ b/src/ggrc/login/appengine.py
@@ -87,9 +87,7 @@ def request_loader(request):
       from ggrc.utils.user_generator import get_external_app_user
       get_external_app_user(request)
     except exceptions.BadRequest as exp:
-      logger.error(
-          "Creation of external user has failed. {}".format(exp.message)
-      )
+      logger.error("Creation of external user has failed : %s", exp.message)
       raise
   else:
     db_user = all_models.Person.query.filter_by(email=email).first()

--- a/src/ggrc/login/noop.py
+++ b/src/ggrc/login/noop.py
@@ -26,9 +26,7 @@ def get_user():
     name = default_user_name
     permissions = None
   from ggrc.utils.user_generator import find_or_create_user_by_email
-  user = find_or_create_user_by_email(
-      email=email,
-      name=name)
+  user = find_or_create_user_by_email(email=email, name=name)
   permissions = session['permissions'] if 'permissions' in session else None
   setattr(g, '_request_permissions', permissions)
   return user

--- a/src/ggrc/rbac/permissions.py
+++ b/src/ggrc/rbac/permissions.py
@@ -48,7 +48,7 @@ def is_allowed_create_for(instance):
 
 def has_system_wide_update():
   """Check if user has system wide update access to all objects."""
-  user = login.get_current_user()
+  user = login.get_current_user(permission_check=True)
   system_wide_role = getattr(user, "system_wide_role",
                              SystemWideRoles.NO_ACCESS)
   return system_wide_role in SystemWideRoles.update_roles
@@ -56,7 +56,7 @@ def has_system_wide_update():
 
 def has_system_wide_read():
   """Check if user has system wide read access to all objects."""
-  user = login.get_current_user()
+  user = login.get_current_user(permission_check=True)
   system_wide_role = getattr(user, "system_wide_role",
                              SystemWideRoles.NO_ACCESS)
   return system_wide_role in SystemWideRoles.read_roles

--- a/src/ggrc/rbac/permissions.py
+++ b/src/ggrc/rbac/permissions.py
@@ -48,7 +48,7 @@ def is_allowed_create_for(instance):
 
 def has_system_wide_update():
   """Check if user has system wide update access to all objects."""
-  user = login.get_current_user(permission_check=True)
+  user = login.get_current_user(use_external_user=False)
   system_wide_role = getattr(user, "system_wide_role",
                              SystemWideRoles.NO_ACCESS)
   return system_wide_role in SystemWideRoles.update_roles
@@ -56,7 +56,7 @@ def has_system_wide_update():
 
 def has_system_wide_read():
   """Check if user has system wide read access to all objects."""
-  user = login.get_current_user(permission_check=True)
+  user = login.get_current_user(use_external_user=False)
   system_wide_role = getattr(user, "system_wide_role",
                              SystemWideRoles.NO_ACCESS)
   return system_wide_role in SystemWideRoles.read_roles

--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -1393,7 +1393,7 @@ def filter_resource(resource, depth=0, user_permissions=None):  # noqa
 
   if user_permissions is None:
     user_permissions = permissions.permissions_for(
-        get_current_user(permission_check=True)
+        get_current_user(use_external_user=False)
     )
 
   if isinstance(resource, (list, tuple)):
@@ -1471,7 +1471,7 @@ def filter_resource(resource, depth=0, user_permissions=None):  # noqa
 
 
 def _is_creator():
-  current_user = get_current_user(permission_check=True)
+  current_user = get_current_user(use_external_user=False)
   return hasattr(current_user, 'system_wide_role') \
       and current_user.system_wide_role == "Creator"
 

--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -1392,7 +1392,9 @@ def filter_resource(resource, depth=0, user_permissions=None):  # noqa
   """
 
   if user_permissions is None:
-    user_permissions = permissions.permissions_for(get_current_user())
+    user_permissions = permissions.permissions_for(
+        get_current_user(permission_check=True)
+    )
 
   if isinstance(resource, (list, tuple)):
     filtered = []
@@ -1469,7 +1471,7 @@ def filter_resource(resource, depth=0, user_permissions=None):  # noqa
 
 
 def _is_creator():
-  current_user = get_current_user()
+  current_user = get_current_user(permission_check=True)
   return hasattr(current_user, 'system_wide_role') \
       and current_user.system_wide_role == "Creator"
 

--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -11,9 +11,9 @@ import collections
 import hashlib
 import itertools
 import json
+import logging
 import time
 
-from logging import getLogger
 from wsgiref.handlers import format_date_time
 from urllib import urlencode
 
@@ -49,7 +49,7 @@ from ggrc.utils import errors as ggrc_errors
 
 
 # pylint: disable=invalid-name
-logger = getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 CACHE_EXPIRY_COLLECTION = 60

--- a/src/ggrc/utils/errors.py
+++ b/src/ggrc/utils/errors.py
@@ -25,3 +25,8 @@ RELOAD_PAGE = u"Try to reload /export page."
 MISSING_FILE = u"The file is missing."
 
 WRONG_FILE_TYPE = u"Invalid file type."
+
+MANDATORY_HEADER = u"{} should be set, contains {!r} instead."
+
+WRONG_PERSON_HEADER_FORMAT = u"{} should have JSON object like" \
+                             u" {{'email': str}}, contains {!r} instead."

--- a/src/ggrc/utils/user_generator.py
+++ b/src/ggrc/utils/user_generator.py
@@ -128,13 +128,21 @@ def find_or_create_ext_app_user(external_user_email=None):
 
 
 def parse_user_email(request, header, mandatory):
-  """
-    Get user email from provided header in the request and
-    validate it based on being mandatory or not.
-  :param request: original request
-  :param header: a header with person email
-  :param mandatory: is user a mandatory
-  :return: parsed user email
+  """Gets user email.
+
+  Retrieves user email from provided header in the request and
+  validates it based on being mandatory or not.
+
+  Args:
+      request: the original request.
+      header: a header name with a person email.
+      mandatory: flag that header value is mandatory or not.
+
+  Returns:
+      A parsed user email.
+
+  Raises:
+     BadRequest: Raised when validation on email has failed.
   """
   user = request.headers.get(header)
   if mandatory and not user:
@@ -152,13 +160,17 @@ def parse_user_email(request, header, mandatory):
 
 
 def get_external_app_user(request):
-  """
-    Generate or find user by email provided in the X-external-user header.
-    The user will be granted a Global Creator role by design.
-    X-external-user is used to supply actual modifier when working
-    on behalf of EXTERNAL_APP_USER provided in X-ggrc-user header.
-  :param request: original request
-  :return: db user object
+  """Generates or finds a user by email provided in a X-external-user header.
+
+  The user will be granted a Global Creator role by design.
+  X-external-user is used to supply actual modifier when working
+  on behalf of EXTERNAL_APP_USER user provided in the X-ggrc-user header.
+
+  Args:
+      request: the original request.
+
+  Returns:
+      db user object.
   """
   external_user_email = parse_user_email(request, "X-external-user",
                                          mandatory=False)

--- a/src/ggrc/utils/user_generator.py
+++ b/src/ggrc/utils/user_generator.py
@@ -77,7 +77,7 @@ def find_or_create_user_by_email(email, name, modifier=None):
   user = find_user_by_email(email)
   if not user:
     if modifier:
-      user = create_user(email, name=name)
+      user = create_user(email, name=name, modified_by_id=modifier)
     else:
       user = create_user(email,
                          name=name,

--- a/src/ggrc/utils/user_generator.py
+++ b/src/ggrc/utils/user_generator.py
@@ -76,12 +76,9 @@ def find_or_create_user_by_email(email, name, modifier=None):
   """Generates or find user for selected email."""
   user = find_user_by_email(email)
   if not user:
-    if modifier:
-      user = create_user(email, name=name, modified_by_id=modifier)
-    else:
-      user = create_user(email,
-                         name=name,
-                         modified_by_id=get_current_user_id())
+    if not modifier:
+      modifier = get_current_user_id()
+    user = create_user(email, name=name, modified_by_id=modifier)
   if is_authorized_domain(email) and \
      user.system_wide_role == SystemWideRoles.NO_ACCESS:
     add_creator_role(user)
@@ -103,16 +100,16 @@ def search_user(email):
   return None
 
 
-def find_or_create_external_user(email, name, modifier=None):
+def find_or_create_external_user(email, name):
   """Find or generate user after verification"""
   if is_external_app_user_email(email):
     return find_or_create_ext_app_user()
 
   if settings.INTEGRATION_SERVICE_URL == 'mock':
-    return find_or_create_user_by_email(email, name, modifier)
+    return find_or_create_user_by_email(email, name)
 
   if settings.INTEGRATION_SERVICE_URL and search_user(email):
-    return find_or_create_user_by_email(email, name, modifier)
+    return find_or_create_user_by_email(email, name)
   return None
 
 
@@ -157,7 +154,7 @@ def parse_user_email(request, header, mandatory):
   return email
 
 
-def find_user(email):
+def find_user(email, modifier=None):
   """Find or generate user.
 
   If Integration Server is specified not found in DB user is generated
@@ -173,7 +170,7 @@ def find_user(email):
     name = search_user(email)
     if not name:
       return None
-    return find_or_create_user_by_email(email, name)
+    return find_or_create_user_by_email(email, name, modifier)
   return find_user_by_email(email)
 
 

--- a/src/ggrc/utils/user_generator.py
+++ b/src/ggrc/utils/user_generator.py
@@ -52,10 +52,10 @@ def add_creator_role(user):
 
 
 def create_user(email, **kwargs):
-  """Create User
+  """Creates a user.
 
-  attr:
-      email (string) required
+  Args:
+    email: (string) mandatory user email
   """
   user = Person(email=email, **kwargs)
   db.session.add(user)
@@ -88,8 +88,8 @@ def find_or_create_user_by_email(email, name):
 def search_user(email):
   """Search user by Integration Service
 
-    Returns:
-        string: user name for success, None otherwise
+  Returns:
+    string: user name for success, None otherwise
   """
   service = client.PersonClient()
   if is_authorized_domain(email):
@@ -114,8 +114,14 @@ def find_or_create_external_user(email, name):
 
 
 def find_or_create_ext_app_user(external_user_email=None):
-  """Find or generate external application user after verification
-    and provides it creator role in case the user is external."""
+  """Find or generate external application user.
+
+  Args:
+    external_user_email: the user email.
+
+  Returns:
+    db user object.
+  """
   name, email = None, external_user_email
   if not external_user_email:
     name, email = parseaddr(settings.EXTERNAL_APP_USER)
@@ -128,9 +134,9 @@ def find_or_create_ext_app_user(external_user_email=None):
 
 
 def parse_user_email(request, header, mandatory):
-  """Gets user email.
+  """Parses a user email from the request header.
 
-  Retrieves user email from provided header in the request and
+  Retrieves user email from the request header and
   validates it based on being mandatory or not.
 
   Args:
@@ -157,27 +163,6 @@ def parse_user_email(request, header, mandatory):
     raise exceptions.BadRequest(
         errors.WRONG_PERSON_HEADER_FORMAT.format(header, user))
   return email
-
-
-def get_external_app_user(request):
-  """Generates or finds a user by email provided in a X-external-user header.
-
-  The user will be granted a Global Creator role by design.
-  X-external-user is used to supply actual modifier when working
-  on behalf of EXTERNAL_APP_USER user provided in the X-ggrc-user header.
-
-  Args:
-      request: the original request.
-
-  Returns:
-      db user object.
-  """
-  external_user_email = parse_user_email(request, "X-external-user",
-                                         mandatory=False)
-  if not external_user_email:
-    return None
-  user = find_or_create_ext_app_user(external_user_email)
-  return user
 
 
 def find_user(email):

--- a/src/ggrc_basic_permissions/__init__.py
+++ b/src/ggrc_basic_permissions/__init__.py
@@ -99,7 +99,7 @@ class UserPermissions(DefaultUserPermissions):
 
   def load_permissions(self):
     """Load permissions for the currently logged in user"""
-    user = get_current_user(permission_check=True)
+    user = get_current_user(use_external_user=False)
     email = self.get_email_for(user)
     self._request_permissions = {}
     self._request_permissions['__user'] = email
@@ -475,7 +475,7 @@ def _get_or_create_personal_context(user):
 def handle_program_post(sender, obj=None, src=None, service=None):
   db.session.flush()
   # get the personal context for this logged in user
-  user = get_current_user(permission_check=True)
+  user = get_current_user(use_external_user=False)
   personal_context = _get_or_create_personal_context(user)
   context = obj.build_object_context(
       context=personal_context,

--- a/src/ggrc_basic_permissions/__init__.py
+++ b/src/ggrc_basic_permissions/__init__.py
@@ -99,7 +99,7 @@ class UserPermissions(DefaultUserPermissions):
 
   def load_permissions(self):
     """Load permissions for the currently logged in user"""
-    user = get_current_user()
+    user = get_current_user(permission_check=True)
     email = self.get_email_for(user)
     self._request_permissions = {}
     self._request_permissions['__user'] = email
@@ -475,7 +475,7 @@ def _get_or_create_personal_context(user):
 def handle_program_post(sender, obj=None, src=None, service=None):
   db.session.flush()
   # get the personal context for this logged in user
-  user = get_current_user()
+  user = get_current_user(permission_check=True)
   personal_context = _get_or_create_personal_context(user)
   context = obj.build_object_context(
       context=personal_context,

--- a/src/ggrc_workflows/__init__.py
+++ b/src/ggrc_workflows/__init__.py
@@ -7,8 +7,8 @@
 
 import collections
 import itertools
+import logging
 from datetime import datetime, date
-from logging import getLogger
 from flask import Blueprint
 from sqlalchemy import inspect, orm
 
@@ -32,7 +32,7 @@ from ggrc_workflows.services.common import Signals
 from ggrc_basic_permissions.contributed_roles import RoleContributions
 
 # pylint: disable=invalid-name
-logger = getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 # Initialize Flask Blueprint for extension

--- a/src/ggrc_workflows/__init__.py
+++ b/src/ggrc_workflows/__init__.py
@@ -723,7 +723,7 @@ def handle_workflow_post(sender, obj=None, src=None, service=None):
     obj.title = source_workflow.title + ' (copy ' + str(obj.id) + ')'
 
   # get the personal context for this logged in user
-  user = get_current_user()
+  user = get_current_user(permission_check=True)
   personal_context = user.get_or_create_object_context(context=1)
   workflow_context = obj.get_or_create_object_context(personal_context)
   obj.context = workflow_context

--- a/src/ggrc_workflows/__init__.py
+++ b/src/ggrc_workflows/__init__.py
@@ -723,7 +723,7 @@ def handle_workflow_post(sender, obj=None, src=None, service=None):
     obj.title = source_workflow.title + ' (copy ' + str(obj.id) + ')'
 
   # get the personal context for this logged in user
-  user = get_current_user(permission_check=True)
+  user = get_current_user(use_external_user=False)
   personal_context = user.get_or_create_object_context(context=1)
   workflow_context = obj.get_or_create_object_context(personal_context)
   obj.context = workflow_context

--- a/test/integration/ggrc_basic_permissions/test_external_login.py
+++ b/test/integration/ggrc_basic_permissions/test_external_login.py
@@ -56,6 +56,8 @@ class TestExternalPermissions(TestCase):
   ]
 
   @ddt.data(*MODELS)
+  @mock.patch('ggrc.settings.INTEGRATION_SERVICE_URL', new='mock')
+  @mock.patch('ggrc.settings.AUTHORIZED_DOMAIN', new='example.com')
   def test_post_modifier(self, model):
     """Test modifier of models when working as external user."""
     headers = {
@@ -129,6 +131,8 @@ class TestExternalPermissions(TestCase):
     self.assertIsNone(relationship.automapping_id)
     self.assertIsNone(relationship.context_id)
 
+  @mock.patch('ggrc.settings.INTEGRATION_SERVICE_URL', new='endpoint')
+  @mock.patch('ggrc.settings.AUTHORIZED_DOMAIN', new='example.com')
   def test_post_invalid_modifier(self):
     """Test that validation is working for X-external-user."""
     model = all_models.Market

--- a/test/integration/ggrc_basic_permissions/test_external_login.py
+++ b/test/integration/ggrc_basic_permissions/test_external_login.py
@@ -1,0 +1,102 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Tests for usage of X-external-user header."""
+
+
+import json
+import ddt
+import mock
+
+from ggrc.models import all_models
+
+from integration.ggrc import TestCase
+from integration.ggrc.models import factories
+
+
+@ddt.ddt
+class TestExternalPermissions(TestCase):
+  """Tests for external permissions and modified by."""
+
+  def setUp(self):
+    """Set up request mock and mock dependencies."""
+    self.allowed_appid = "ggrcq-id"
+    self.person = factories.PersonFactory()
+
+    self.settings_patcher = mock.patch("ggrc.login.appengine.settings")
+    self.settings_mock = self.settings_patcher.start()
+    self.settings_mock.ALLOWED_QUERYAPI_APP_IDS = [self.allowed_appid]
+
+  MODELS = [
+      all_models.AccessGroup,
+      all_models.Contract,
+      all_models.Control,
+      all_models.DataAsset,
+      all_models.Facility,
+      all_models.Issue,
+      all_models.Market,
+      all_models.Metric,
+      all_models.Objective,
+      all_models.OrgGroup,
+      all_models.Policy,
+      all_models.Process,
+      all_models.Product,
+      all_models.ProductGroup,
+      all_models.Program,
+      all_models.Project,
+      all_models.Regulation,
+      all_models.Requirement,
+      all_models.Risk,
+      all_models.Standard,
+      all_models.System,
+      all_models.TechnologyEnvironment,
+      all_models.Threat,
+      all_models.Vendor,
+      all_models.Workflow
+  ]
+
+  @ddt.data(*MODELS)
+  def test_post_modifier(self, model):
+    """Test modifier of models when working as external user."""
+    headers = {
+        "Content-Type": "application/json",
+        "X-requested-by": "GGRC",
+        "X-appengine-inbound-appid": self.allowed_appid,
+        "X-ggrc-user": json.dumps({"email": "external_app@example.com"}),
+        "X-external-user": json.dumps({"email": "new_ext_user@example.com"})
+    }
+    self.client.get("/login", headers=headers)
+
+    model_plural = model._inflector.table_plural
+    model_singular = model._inflector.table_singular
+    response = self.client.post(
+        "api/{}".format(model_plural),
+        data=json.dumps({
+            model_singular: {
+                "title": "{}1".format(model_singular),
+                "context": 0
+            }
+        }),
+        headers=headers)
+    self.assertEqual(response.status_code, 201)
+
+    # check object modifier
+    person = all_models.Person.query.filter_by(
+        email="new_ext_user@example.com"
+    ).first()
+    person_id = person.id
+    self.assertEqual(response.json[model_singular]['modified_by']['id'],
+                     person_id)
+    self.assertEqual(person.system_wide_role, "Creator")
+
+    # check revision modifier
+    revision = all_models.Revision.query.filter(
+        all_models.Revision.resource_type == model.__name__).order_by(
+        all_models.Revision.id.desc()).first()
+    self.assertEqual(revision.modified_by_id, person_id)
+
+    # check event modifier
+    event = all_models.Event.query.filter(
+        all_models.Event.resource_type == model.__name__).order_by(
+        all_models.Event.id.desc()).first()
+    self.assertEqual(event.modified_by_id, person_id)

--- a/test/unit/ggrc/login/test_appengine.py
+++ b/test/unit/ggrc/login/test_appengine.py
@@ -5,6 +5,7 @@
 
 import json
 import unittest
+import ddt
 
 import mock
 from werkzeug import exceptions
@@ -13,6 +14,7 @@ from ggrc.login import appengine as login_appengine
 from ggrc.utils import structures
 
 
+@ddt.ddt
 class TestAppengineLogin(unittest.TestCase):
   """Unit test suite for appengine login logic."""
 
@@ -76,31 +78,29 @@ class TestAppengineLogin(unittest.TestCase):
     with self.assertRaises(exceptions.BadRequest):
       login_appengine.request_loader(self.request)
 
-  def test_request_loader_user_invalid_json(self):
+  @ddt.data("X-ggrc-user", "X-external-user")
+  def test_request_loader_user_invalid_json(self, header):
     """HTTP400 if user header contains invalid json."""
-    self.request.headers["X-ggrc-user"] = "not a valid json"
+    self.request.headers[header] = "not a valid json"
 
     with self.assertRaises(exceptions.BadRequest):
       login_appengine.request_loader(self.request)
 
-  def test_request_loader_user_incomplete_json(self):
+  @ddt.data("X-ggrc-user", "X-external-user")
+  def test_request_loader_user_incomplete_json(self, header):
     """HTTP400 if user header contains json with no email."""
-    self.request.headers["X-ggrc-user"] = "{}"
+    self.request.headers[header] = "{}"
 
     with self.assertRaises(exceptions.BadRequest):
       login_appengine.request_loader(self.request)
 
-  def test_request_loader_user_non_dict_json(self):
+  @ddt.data("X-ggrc-user", "X-external-user")
+  def test_request_loader_user_non_dict_json(self, header):
     """HTTP400 if user header contains json with not a dict."""
-    self.request.headers["X-ggrc-user"] = "[]"
-
-    with self.assertRaises(exceptions.BadRequest):
-      login_appengine.request_loader(self.request)
-
-    self.request.headers["X-ggrc-user"] = "12"
-
-    with self.assertRaises(exceptions.BadRequest):
-      login_appengine.request_loader(self.request)
+    for value in ("[]", "12"):
+      self.request.headers[header] = value
+      with self.assertRaises(exceptions.BadRequest):
+        login_appengine.request_loader(self.request)
 
   def test_request_loader_user_not_registered(self):
     """HTTP400 if user header contains json with unknown user."""

--- a/test/unit/ggrc/login/test_appengine.py
+++ b/test/unit/ggrc/login/test_appengine.py
@@ -134,5 +134,4 @@ class TestAppengineLogin(unittest.TestCase):
 
     self.assertIs(result, person)
     self.person_mock.query.filter_by.assert_not_called()
-    self.find_or_create_ext_app_user_mock.assert_called_once_with()
     self.is_ext_user_email_mock.assert_called_once_with(self.EMAIL)

--- a/test/unit/ggrc/test_login.py
+++ b/test/unit/ggrc/test_login.py
@@ -17,7 +17,7 @@ class TestIsExternalAppUser(unittest.TestCase):
     """No logged in user presented."""
     current_user_mock.return_value = None
     self.assertFalse(login.is_external_app_user())
-    current_user_mock.assert_called_once_with(permission_check=True)
+    current_user_mock.assert_called_once_with(use_external_user=False)
 
   @mock.patch('ggrc.login.get_current_user')
   def test_anonymous_user(self, current_user_mock):
@@ -26,7 +26,7 @@ class TestIsExternalAppUser(unittest.TestCase):
     user_mock.is_anonymous.return_value = True
     current_user_mock.return_value = user_mock
     self.assertFalse(login.is_external_app_user())
-    current_user_mock.assert_called_once_with(permission_check=True)
+    current_user_mock.assert_called_once_with(use_external_user=False)
     user_mock.is_anonymous.assert_called_once_with()
 
   @mock.patch('ggrc.utils.user_generator.is_external_app_user_email')
@@ -39,7 +39,7 @@ class TestIsExternalAppUser(unittest.TestCase):
     current_user_mock.return_value = user_mock
     is_external_email_mock.return_value = False
     self.assertFalse(login.is_external_app_user())
-    current_user_mock.assert_called_once_with(permission_check=True)
+    current_user_mock.assert_called_once_with(use_external_user=False)
     user_mock.is_anonymous.assert_called_once_with()
     is_external_email_mock.assert_called_once_with('user@example.com')
 
@@ -53,6 +53,6 @@ class TestIsExternalAppUser(unittest.TestCase):
     current_user_mock.return_value = user_mock
     is_external_email_mock.return_value = True
     self.assertTrue(login.is_external_app_user())
-    current_user_mock.assert_called_once_with(permission_check=True)
+    current_user_mock.assert_called_once_with(use_external_user=False)
     user_mock.is_anonymous.assert_called_once_with()
     is_external_email_mock.assert_called_once_with('user@example.com')

--- a/test/unit/ggrc/test_login.py
+++ b/test/unit/ggrc/test_login.py
@@ -12,25 +12,25 @@ from ggrc import login
 class TestIsExternalAppUser(unittest.TestCase):
   """Unittests for is_external_app_user function."""
 
-  @mock.patch('ggrc.login.get_current_user')
+  @mock.patch('ggrc.login._get_current_logged_user')
   def test_no_logged_in_user(self, current_user_mock):
     """No logged in user presented."""
     current_user_mock.return_value = None
     self.assertFalse(login.is_external_app_user())
-    current_user_mock.assert_called_once_with(use_external_user=False)
+    current_user_mock.assert_called_once_with()
 
-  @mock.patch('ggrc.login.get_current_user')
+  @mock.patch('ggrc.login._get_current_logged_user')
   def test_anonymous_user(self, current_user_mock):
     """Currently logged in user is anonymous."""
     user_mock = mock.MagicMock()
     user_mock.is_anonymous.return_value = True
     current_user_mock.return_value = user_mock
     self.assertFalse(login.is_external_app_user())
-    current_user_mock.assert_called_once_with(use_external_user=False)
+    current_user_mock.assert_called_once_with()
     user_mock.is_anonymous.assert_called_once_with()
 
   @mock.patch('ggrc.utils.user_generator.is_external_app_user_email')
-  @mock.patch('ggrc.login.get_current_user')
+  @mock.patch('ggrc.login._get_current_logged_user')
   def test_not_external_user(self, current_user_mock, is_external_email_mock):
     """Currently logged in user is not external app."""
     user_mock = mock.MagicMock()
@@ -39,12 +39,12 @@ class TestIsExternalAppUser(unittest.TestCase):
     current_user_mock.return_value = user_mock
     is_external_email_mock.return_value = False
     self.assertFalse(login.is_external_app_user())
-    current_user_mock.assert_called_once_with(use_external_user=False)
+    current_user_mock.assert_called_once_with()
     user_mock.is_anonymous.assert_called_once_with()
     is_external_email_mock.assert_called_once_with('user@example.com')
 
   @mock.patch('ggrc.utils.user_generator.is_external_app_user_email')
-  @mock.patch('ggrc.login.get_current_user')
+  @mock.patch('ggrc.login._get_current_logged_user')
   def test_external_user(self, current_user_mock, is_external_email_mock):
     """Currently logged in user is external app."""
     user_mock = mock.MagicMock()
@@ -53,6 +53,6 @@ class TestIsExternalAppUser(unittest.TestCase):
     current_user_mock.return_value = user_mock
     is_external_email_mock.return_value = True
     self.assertTrue(login.is_external_app_user())
-    current_user_mock.assert_called_once_with(use_external_user=False)
+    current_user_mock.assert_called_once_with()
     user_mock.is_anonymous.assert_called_once_with()
     is_external_email_mock.assert_called_once_with('user@example.com')

--- a/test/unit/ggrc/test_login.py
+++ b/test/unit/ggrc/test_login.py
@@ -17,7 +17,7 @@ class TestIsExternalAppUser(unittest.TestCase):
     """No logged in user presented."""
     current_user_mock.return_value = None
     self.assertFalse(login.is_external_app_user())
-    current_user_mock.assert_called_once_with()
+    current_user_mock.assert_called_once_with(permission_check=True)
 
   @mock.patch('ggrc.login.get_current_user')
   def test_anonymous_user(self, current_user_mock):
@@ -26,7 +26,7 @@ class TestIsExternalAppUser(unittest.TestCase):
     user_mock.is_anonymous.return_value = True
     current_user_mock.return_value = user_mock
     self.assertFalse(login.is_external_app_user())
-    current_user_mock.assert_called_once_with()
+    current_user_mock.assert_called_once_with(permission_check=True)
     user_mock.is_anonymous.assert_called_once_with()
 
   @mock.patch('ggrc.utils.user_generator.is_external_app_user_email')
@@ -39,7 +39,7 @@ class TestIsExternalAppUser(unittest.TestCase):
     current_user_mock.return_value = user_mock
     is_external_email_mock.return_value = False
     self.assertFalse(login.is_external_app_user())
-    current_user_mock.assert_called_once_with()
+    current_user_mock.assert_called_once_with(permission_check=True)
     user_mock.is_anonymous.assert_called_once_with()
     is_external_email_mock.assert_called_once_with('user@example.com')
 
@@ -53,6 +53,6 @@ class TestIsExternalAppUser(unittest.TestCase):
     current_user_mock.return_value = user_mock
     is_external_email_mock.return_value = True
     self.assertTrue(login.is_external_app_user())
-    current_user_mock.assert_called_once_with()
+    current_user_mock.assert_called_once_with(permission_check=True)
     user_mock.is_anonymous.assert_called_once_with()
     is_external_email_mock.assert_called_once_with('user@example.com')


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

We need to be able to provide GGRCQ service account rights to any GGRC user on call from GGRCQ as a trusted source.

The behavior:
1. New x-external-user header should be added. 
2. 
  - If the user doesn't exist in GGRC, create new user with Global Creator role.
  - If exists use the existing user
3. Create the object requested by the external system. Permissions should be checked by service account
4. Put in modified by field the user that was specified in x-external-user header.
5. Corresponding revisions needs to be created

**Note**: Please keep backward compatibility. Request can be done without X-external-user header, in that case X-external-user will equals to X-ggrc-user.

# Steps to test the changes

Use the postman collection for testing that you can find in JIRA.
Set ALLOWED_QUERYAPI_APP_IDS and EXTERNAL_APP_USER according to the test data in the postman collection. 

At the moment GGRCQ already creating Relationships and Person object types via the service account. Please check that it will work.

# Solution description

Login on behalf of new header if it is exists

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
