### PR TITLE
GGRC-5899  Implement BE functionality for linking Assessments to Issue Tracker

### DIFF
--- a/src/ggrc/models/hooks/issue_tracker/assessment_integration.py
+++ b/src/ggrc/models/hooks/issue_tracker/assessment_integration.py
@@ -335,7 +335,7 @@ def _handle_issuetracker(sender, obj=None, src=None, **kwargs):  # noqa
         )
         new_ticket_id = it_issue.issue_id if it_issue else None
         if old_ticket_id and new_ticket_id and old_ticket_id != new_ticket_id:
-          _detach_assessment(ticket_id, old_ticket_id)
+          _detach_assessment(new_ticket_id, old_ticket_id)
       return
 
     _, issue_tracker_info['cc_list'] = _collect_assessment_emails(obj)

--- a/src/ggrc/models/hooks/issue_tracker/assessment_integration.py
+++ b/src/ggrc/models/hooks/issue_tracker/assessment_integration.py
@@ -356,7 +356,7 @@ def _handle_issuetracker(sender, obj=None, src=None, **kwargs):  # noqa
     _link_assessment(obj, issue_tracker_info)
     if not obj.warnings:
       _detach_assessment(ticket_id, old_ticket_id)
-      return
+    return
 
   try:
     _update_issuetracker_issue(
@@ -883,7 +883,6 @@ def _link_assessment(assessment, issue_tracker_info):
         "review object. Linking the same ticket to multiple objects is not "
         "allowed due to potential for conflicting updates."
     )
-    issue_tracker_info['enabled'] = False
     return
 
   try:
@@ -897,7 +896,6 @@ def _link_assessment(assessment, issue_tracker_info):
     assessment.add_warning(
         "Ticket tracker ID does not exist or you do not have access to it."
     )
-    issue_tracker_info['enabled'] = False
     return
 
   issue_params = prepare_issue_json(assessment, issue_tracker_info)

--- a/src/ggrc/models/hooks/issue_tracker/issue_tracker_params_builder.py
+++ b/src/ggrc/models/hooks/issue_tracker/issue_tracker_params_builder.py
@@ -322,3 +322,16 @@ class IssueParamsBuilder(BaseIssueTrackerParamsBuilder):
       self.params.add_comment(
           self.UPDATE_REMEDIATION_PLAN_TMPL.format(test_plan)
       )
+
+
+class AssessmentParamsBuilder(BaseIssueTrackerParamsBuilder):
+  """Issue tracker query builder for GGRC Assessment object."""
+  DETACH_TMPL = (
+      'Another bug {new_ticket_id} has been linked to track changes to the '
+      'GGRC Assessment. Changes to the GGRC Assessment will no longer be '
+      'tracked within this bug.'
+  )
+
+  def build_detach_comment(self, new_ticket):
+    self.params.add_comment(self.DETACH_TMPL.format(new_ticket_id=new_ticket))
+    return self.params

--- a/test/integration/ggrc/converters/test_export_ticket_tracker.py
+++ b/test/integration/ggrc/converters/test_export_ticket_tracker.py
@@ -52,7 +52,7 @@ class TestTicketTrackerExport(TestCase):
               "enabled": True,
               "component_id": "11111",
               "hotlist_id": "222222",
-              "issue_id": "333333",
+              "issue_id": iti.issue_id,
               "issue_url": "http://issue/333333"
           },
       })

--- a/test/integration/ggrc/integrations/test_assessment_integration.py
+++ b/test/integration/ggrc/integrations/test_assessment_integration.py
@@ -2,6 +2,9 @@
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
 """Integration tests for assessments with IssueTracker integration."""
+# pylint: disable=too-many-lines
+# this module will be refactored in the future when we make base testcase class
+# for issuetracker integration.
 
 from collections import OrderedDict
 
@@ -29,6 +32,7 @@ from integration.ggrc.snapshotter import SnapshotterBaseTestCase
 TICKET_ID = 123
 
 
+# pylint: disable=too-many-public-methods
 @ddt.ddt
 class TestIssueTrackerIntegration(SnapshotterBaseTestCase):
   """Test set for IssueTracker integration functionality."""

--- a/test/integration/ggrc/integrations/test_assessment_integration.py
+++ b/test/integration/ggrc/integrations/test_assessment_integration.py
@@ -15,6 +15,8 @@ from ggrc import models
 from ggrc.app import app
 from ggrc.models import all_models
 from ggrc.models.hooks.issue_tracker import assessment_integration
+from ggrc.models.hooks.issue_tracker import issue_tracker_params_builder \
+    as params_builder
 from ggrc.integrations.synchronization_jobs import sync_utils
 from ggrc.integrations import synchronization_jobs
 from ggrc.access_control.role import AccessControlRole
@@ -23,6 +25,8 @@ from integration.ggrc.models import factories
 from integration.ggrc import generator
 from integration.ggrc.access_control import acl_helper
 from integration.ggrc.snapshotter import SnapshotterBaseTestCase
+
+TICKET_ID = 123
 
 
 @ddt.ddt
@@ -108,6 +112,24 @@ class TestIssueTrackerIntegration(SnapshotterBaseTestCase):
     }}
     return payload
 
+  def put_request_payload_builder(self, issue_attrs):
+    """Build payload for PUT request to Issue Tracker"""
+    payload_attrs = dict(self.DEFAULT_ASSESSMENT_ATTRS, **issue_attrs)
+    payload = {
+        "issue_tracker": {
+            "enabled": payload_attrs["enabled"],
+            "status": payload_attrs["status"],
+            "component_id": payload_attrs["component_id"],
+            "hotlist_id": payload_attrs["hotlist_id"],
+            "issue_id": payload_attrs["issue_id"],
+            "issue_type": payload_attrs["issue_type"],
+            "issue_priority": payload_attrs["issue_priority"],
+            "issue_severity": payload_attrs["issue_severity"],
+            "title": payload_attrs["title"],
+        }
+    }
+    return payload
+
   def check_issuetracker_issue_fields(self,
                                       issue_tracker_issue,
                                       assmt_attrs):
@@ -161,7 +183,7 @@ class TestIssueTrackerIntegration(SnapshotterBaseTestCase):
   @ddt.unpack
   @mock.patch("ggrc.integrations.issues.Client.update_issue")
   def test_new_linked_assessment(self, assmt_attrs, ticket_attrs, upd_mock):
-    """Test linking new Issue to IssueTracker ticket sets correct fields"""
+    """Test link new Assessment to IssueTracker ticket sets correct fields"""
     with factories.single_commit():
       audit = factories.AuditFactory()
       factories.IssueTrackerIssueFactory(
@@ -184,6 +206,113 @@ class TestIssueTrackerIntegration(SnapshotterBaseTestCase):
     assmt_id = response.json.get("assessment").get("id")
     it_issue = models.IssuetrackerIssue.get_issue("Assessment", assmt_id)
     self.check_issuetracker_issue_fields(it_issue, assmt_request_payload)
+
+  @mock.patch("ggrc.integrations.issues.Client.update_issue")
+  def test_existing_assmt_link(self, update_mock):
+    """Test Assessment link to another ticket """
+    with factories.single_commit():
+      audit = factories.AuditFactory()
+      factories.IssueTrackerIssueFactory(
+          enabled=True,
+          issue_tracked_obj=audit
+      )
+      iti = factories.IssueTrackerIssueFactory(
+          enabled=True,
+          issue_id=TICKET_ID,
+          issue_tracked_obj=factories.AssessmentFactory(audit=audit)
+      )
+
+    new_ticket_id = TICKET_ID + 1
+    new_data = {"issue_id": new_ticket_id}
+    issue_request_payload = self.put_request_payload_builder(new_data)
+    response_payload = self.response_payload_builder(new_data)
+    with mock.patch.object(assessment_integration, '_is_issue_tracker_enabled',
+                           return_value=True):
+      with mock.patch("ggrc.integrations.issues.Client.get_issue",
+                      return_value=response_payload) as get_mock:
+        response = self.api.put(iti.issue_tracked_obj, issue_request_payload)
+    get_mock.assert_called_once()
+    self.assert200(response)
+
+    # check if data was changed in our DB
+    issue_id = response.json.get("assessment").get("id")
+    issue_tracker_issue = models.IssuetrackerIssue.get_issue(
+        "Assessment",
+        issue_id,
+    )
+    self.assertEqual(int(issue_tracker_issue.issue_id), new_ticket_id)
+
+    # check detach comment was sent
+    detach_comment_tmpl = params_builder.AssessmentParamsBuilder.DETACH_TMPL
+    comment = detach_comment_tmpl.format(new_ticket_id=new_ticket_id)
+    expected_args = (TICKET_ID, {"comment": comment})
+    self.assertEqual(expected_args, update_mock.call_args[0])
+
+  @mock.patch.object(assessment_integration, '_is_issue_tracker_enabled',
+                     return_value=True)
+  def test_already_linked_ticket(self, enabled_mock):
+    """Test Assessment w/o IT couldn't be linked to already linked ticket"""
+    with factories.single_commit():
+      audit = factories.AuditFactory()
+      factories.IssueTrackerIssueFactory(
+          enabled=True,
+          issue_tracked_obj=audit
+      )
+      factories.IssueTrackerIssueFactory(
+          enabled=True,
+          issue_id=TICKET_ID,
+          issue_tracked_obj=factories.AssessmentFactory(audit=audit)
+      )
+      new_assmt = factories.AssessmentFactory()
+
+    issue_data = {"issue_id": TICKET_ID}
+    issue_request_payload = self.put_request_payload_builder(issue_data)
+    response = self.api.put(new_assmt, issue_request_payload)
+    self.assert200(response)
+    self.assertTrue(response.json["assessment"]["issue_tracker"]["_warnings"])
+    issue_id = response.json.get("assessment").get("id")
+    issue_tracker_issue = models.IssuetrackerIssue.get_issue(
+        "Assessment",
+        issue_id,
+    )
+    self.assertFalse(issue_tracker_issue)
+    enabled_mock.assert_called()
+
+  @mock.patch("ggrc.integrations.issues.Client.update_issue")
+  def test_creating_new_ticket_for_linked_issue(self, update_mock):
+    """Test create new ticket for already linked assessment"""
+    with factories.single_commit():
+      audit = factories.AuditFactory()
+      factories.IssueTrackerIssueFactory(
+          enabled=True,
+          issue_tracked_obj=audit
+      )
+      iti = factories.IssueTrackerIssueFactory(
+          enabled=True,
+          issue_id=TICKET_ID,
+          issue_tracked_obj=factories.AssessmentFactory(audit=audit)
+      )
+    new_data = {"issue_id": ''}
+    issue_request_payload = self.put_request_payload_builder(new_data)
+    with mock.patch.object(assessment_integration, '_is_issue_tracker_enabled',
+                           return_value=True):
+      with mock.patch("ggrc.integrations.issues.Client.create_issue",
+                      return_value={"issueId": TICKET_ID + 1}) as create_mock:
+        response = self.api.put(iti.issue_tracked_obj, issue_request_payload)
+    self.assert200(response)
+
+    # Detach comment should be sent to previous ticket
+    update_mock.assert_called_once()
+    self.assertEqual(TICKET_ID, update_mock.call_args[0][0])
+    create_mock.assert_called_once()
+
+    # check if data was changed in our DB
+    issue_id = response.json.get("assessment").get("id")
+    issue_tracker_issue = models.IssuetrackerIssue.get_issue(
+        "Assessment",
+        issue_id,
+    )
+    self.assertNotEqual(int(issue_tracker_issue.issue_id), TICKET_ID)
 
   @mock.patch('ggrc.integrations.issues.Client.create_issue')
   def test_complete_assessment_create_issue(self, mock_create_issue):

--- a/test/unit/ggrc/models/hooks/issue_tracker_integration/test_assessment_integration.py
+++ b/test/unit/ggrc/models/hooks/issue_tracker_integration/test_assessment_integration.py
@@ -102,9 +102,20 @@ class TestUtilityFunctions(unittest.TestCase):
       }
       all_models.IssuetrackerIssue.get_issue = mock.MagicMock()
       # pylint: disable=protected-access
-      assessment_integration._handle_issuetracker(sender=None,
-                                                  obj=mock.MagicMock(),
-                                                  src=src)
+      issue_obj = mock.MagicMock()
+
+      # pylint: disable=unused-argument
+      def mock_to_dict(**kwargs):
+        return {"issue_id": issue_id}
+      issue_obj.to_dict = mock_to_dict
+
+      with mock.patch(
+          "ggrc.models.issuetracker_issue.IssuetrackerIssue.get_issue",
+          return_value=issue_obj
+      ):
+        assessment_integration._handle_issuetracker(sender=None,
+                                                    obj=mock.MagicMock(),
+                                                    src=src)
       update_info_mock.assert_called_once()
       self.assertEqual(update_info_mock.call_args[0][1]['enabled'],
                        issue_tracker_enabled)


### PR DESCRIPTION
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [x] ~~https://github.com/google/ggrc-core/pull/8395 Implement BE functionality for creating linked Issue~~

# Issue description

It should be possible to link existing Assessments to existing Issue Tracker tickets, relink existing Assessments and create new ticket for linked Assessment.

# Steps to test the changes
- Apply changes from [#8311](https://github.com/google/ggrc-core/pull/8311) to turn on FE functionality
 - Apply changes from  https://github.com/google/ggrc-core/pull/8395) Implement BE functionality for creating linked Assessment, to turn on linking for new Assessments
- These changes with applied [#8311](https://github.com/google/ggrc-core/pull/8311) and [#8372](https://github.com/google/ggrc-core/pull/8372) have been deployed to maximb-ggrc-5899  ggrc-test instance to have opportunity to click through the app.
## Common test cases:
- ### check test cases from https://github.com/google/ggrc-core/pull/8395
- ### Link existing assessment to existing ticket:
0. Prepare test data:
Go to Issue Tracker and choose any ticket.
Click create issue in same component.
Enter title, description, assignee and ccs.
Click create button.
Copy Issue ID.
1. Create GGRC assessment with Issue tracker turned off.
2. Open edit tab for this assessment. 
Turn Issue tracker option on.
Hotlist ID: 700706
Component ID: 64445
Enter issue ID from previous step.
3. Open assessment and click Ticket button.
4. Look through comment in issue tracker. Find assessment URL. It should be link to assessment with the same id as you created.
Comment that this assessment was linked to GGRC Issue should appear.
Information from assessment should be synced with IssueTracker.
- ### Relink Assessment:
0. Prepare test data:
create one more Issue Tracker ticket as in paragraph 0. from previous test case
1.  Open Assessment from previous test case.
2. Change Ticket ID to created ticket id. Push apply button.
3. Check Assessment was linked to new ticket. Check detach comment was sent to previous ticket.
- ### Create new ticket for linked ticket(was GGRC-6019 bug):
1. Open Assessment from previous test case.
2. Delete Ticket ID. Push apply button.
3. Check new ticket was created and Issue has been linked to it. Check detach comment was sent to previous ticket.
- ### Additional test cases
check GGRC-6016 ticket.

# Solution description

I've updated assessment_integration hook according to our technical doc

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
