### PR TITLE
GGRC-5227 500 error when map a document of file you don't have read access to

### DIFF
--- a/src/ggrc/gdrive/errors.py
+++ b/src/ggrc/gdrive/errors.py
@@ -19,3 +19,9 @@ INTERNAL_SERVER_ERROR = (u"Processing of the file failed due "
 
 MISSING_KEYS = (u"Unable to validate gdrive api "
                 u"response: missed keys {}.")
+
+GOOGLE_API_MESSAGE_MAP = {
+    u"The user does not have sufficient permissions for this file.":
+        (u"You do not have access to create or edit in the attach folder, "
+         u"please request edit access from folder owner.")
+}


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Need to change logged message if user which is authorized in google drive hasn't permissions for  file what he tries to add in Control.

Related tickets:

**GGRC-5147** 500 error when attaching a file to the folder the user doesn't have edit access to

**GGRC-5843** 'There was an error' (POST 500) is displayed if user attaches a file to the folder in which he has 'view only' permissions

# Steps to test the changes

Steps:
1. Login as `<user1>`
2. Create a `control-1`. Assign a new folder and attach a file.
3. Assign `<user-2>` as Secondary Contact in the control created by `<user1>`.
3. Login as `<user2>` that has access to Document object but doesn't have access to the file that was attached by <user-1>.
4. Create a `control-2`. Assign a new folder to `control-2`.
5. Try to map a document added by `<user1>`.

Actual result: 500 error is shown
The following error is shown in error logs: _"500 Internal Server Error: The user does not have sufficient permissions for this file."_
Expected result: _"You do not have access to either the folder or the file, please request edit access from it's owner."_ (suggested by Vadzim Vechar)


# Solution description

Add dict for mapping 

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
