### PR TITLE
GGRC-6073 Fix object review migration

### DIFF
--- a/src/ggrc/migrations/versions/20180917154533_5c83e0840a71_migrate_old_review_to_new.py
+++ b/src/ggrc/migrations/versions/20180917154533_5c83e0840a71_migrate_old_review_to_new.py
@@ -328,7 +328,7 @@ def process_migrated_unreviewed(conn, migrator_id):
 
 def process_non_migrated(conn, migrator_id, state):
   """Process objects that had state and not migrated"""
-  for reviewable, obj_type in MIGRATED_REVIEWABLES:
+  for reviewable, obj_type in NON_MIGRATED_REVIEWABLES:
     print "Processing -> {} : {}".format(obj_type, state)
     for data in get_object_mapping_info(conn, reviewable,
                                         obj_type, state):

--- a/src/ggrc/migrations/versions/20180917154533_5c83e0840a71_migrate_old_review_to_new.py
+++ b/src/ggrc/migrations/versions/20180917154533_5c83e0840a71_migrate_old_review_to_new.py
@@ -70,7 +70,8 @@ def get_object_mapping_info(conn, table, obj_type, review_status):
             r.source_type="{obj_type}" AND
             r.destination_type="CycleTaskGroupObjectTask"
           JOIN cycle_task_group_object_tasks ctgot ON
-            ctgot.id = r.destination_id
+            ctgot.id = r.destination_id AND
+            ctgot.title like 'Object review for%'
           JOIN cycles cy ON cy.id = ctgot.cycle_id
           JOIN workflows w ON w.id = cy.workflow_id
           JOIN cycle_task_groups ctg ON cy.id = ctg.cycle_id
@@ -95,7 +96,8 @@ def get_object_mapping_info(conn, table, obj_type, review_status):
           r.destination_type="{obj_type}" AND
           r.source_type="CycleTaskGroupObjectTask"
         JOIN cycle_task_group_object_tasks ctgot ON
-          ctgot.id = r.source_id
+          ctgot.id = r.source_id AND
+          ctgot.title like 'Object review for%'
         JOIN cycles cy ON cy.id = ctgot.cycle_id
         JOIN workflows w ON w.id = cy.workflow_id
         JOIN cycle_task_groups ctg ON cy.id = ctg.cycle_id


### PR DESCRIPTION
# Dependencies

This PR is `on hold` until the PO confirmation.

# Issue description

We need to migrate objects became non reviewable
We need to process objects mapped to CycleTaskGroupObjectTasks related to object review only. 

# Steps to test the changes

Run migrations and check that proper CycleTaskGroupObjectTasks are unmapped. 
Foe instance ggrc-test dump /products/1 is mapped to 4 CycleTaskGroupObjectTasks one of them object review related.

# Solution description

Added processing of list of objects thats became non reviewable.
Added filter to SQL query CycleTaskGroupObjectTasks.title starts with 'Object review for'

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
