### PR TITLE
GGRC-6086 Fix "send_daily_digest_notifications" task without "destination"

### DIFF
--- a/src/ggrc/models/relationship.py
+++ b/src/ggrc/models/relationship.py
@@ -3,6 +3,8 @@
 
 """Module for Relationship model and related classes."""
 
+import logging
+
 import collections
 import sqlalchemy as sa
 from sqlalchemy import or_, and_
@@ -15,6 +17,8 @@ from ggrc.models.mixins import base
 from ggrc.models.mixins import Base
 from ggrc.models import reflection
 from ggrc.models.exceptions import ValidationError
+
+logger = logging.getLogger(__name__)
 
 
 class Relationship(base.ContextRBAC, Base, db.Model):
@@ -53,6 +57,14 @@ class Relationship(base.ContextRBAC, Base, db.Model):
 
   @property
   def source(self):
+    """Source getter."""
+    if not hasattr(self, self.source_attr):
+      logger.warning(
+          "Relationship source attr '%s' does not exist. "
+          "This indicates invalid data in our database!",
+          self.source_attr
+      )
+      return None
     return getattr(self, self.source_attr)
 
   @source.setter
@@ -68,6 +80,14 @@ class Relationship(base.ContextRBAC, Base, db.Model):
 
   @property
   def destination(self):
+    """Destination getter."""
+    if not hasattr(self, self.destination_attr):
+      logger.warning(
+          "Relationship destination attr '%s' does not exist. "
+          "This indicates invalid data in our database!",
+          self.destination_attr
+      )
+      return None
     return getattr(self, self.destination_attr)
 
   @destination.setter
@@ -206,8 +226,10 @@ class Relatable(object):
       A set (or subset if _types is specified) of related objects.
     """
     # pylint: disable=not-an-iterable
-    source_objs = [obj.source for obj in self.related_sources]
-    dest_objs = [obj.destination for obj in self.related_destinations]
+    source_objs = [obj.source for obj in self.related_sources
+                   if obj.source is not None]
+    dest_objs = [obj.destination for obj in self.related_destinations
+                 if obj.destination is not None]
     related = source_objs + dest_objs
 
     if _types:


### PR DESCRIPTION

# Issue description
Fix for "send_daily_digest_notifications" task for destinations/sources that don't exists

# Steps to test the changes
Run "send_daily_digest_notifications" task for objects without "source" or "destination"

# Solution description
Populate "sources" and "destinations" with exception check. If exception appears, object won't be add 


# Sanity checklist

- [ ] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
