### PR TITLE
GGRC-6088, GGRC-6087, GGRC-6080, GGRC-6076, GGRC-6079 Revert to "Unreviewed" state via import "snapshottable" objects

### DIFF
--- a/src/ggrc/models/mixins/with_mappimg_via_import_handable.py
+++ b/src/ggrc/models/mixins/with_mappimg_via_import_handable.py
@@ -14,7 +14,7 @@ class WithMappingImportHandable(object):
   __lazy_init__ = True
 
   # pylint: disable=invalid-name
-  def handle_mapping_via_import_created(self):
+  def handle_mapping_via_import_created(self, counterparty):
     """Proposal mapping via import handler"""
     raise NotImplementedError
 
@@ -25,4 +25,7 @@ class WithMappingImportHandable(object):
     @signals.Import.mapping_created.connect_via(model)
     def mapping_created(*args, **kwargs):
       """proposal_applied handler"""
-      model.handle_mapping_via_import_created(kwargs["instance"])
+      model.handle_mapping_via_import_created(
+          kwargs["instance"],
+          kwargs["counterparty"]
+      )

--- a/src/ggrc/services/signals.py
+++ b/src/ggrc/services/signals.py
@@ -140,5 +140,6 @@ class Import(object):
       "Mapping created",
       """
         :instance: The object that mapped via import.
+        :counterparty: The counterparty for object that mapped via import.
       """,
   )

--- a/test/integration/ggrc/models/factories.py
+++ b/test/integration/ggrc/models/factories.py
@@ -169,8 +169,6 @@ class CategorizationFactory(ModelFactory):
   class Meta:
     model = all_models.Categorization
 
-  category = None
-  categorizable = None
   category_id = None
   categorizable_id = None
   categorizable_type = None


### PR DESCRIPTION
# Issue description
If unmap / map snapshottable object via import, objects are not reverted to "unreviewed" state
If add a comment via import, Control is reverted to Unreviewed state
If add reference url via import, Control is reverted to Unreviewed state
If Import control w/o changes, Control is reverted to Unreviewed state
If change ACL role via import, Control is reverted to Unreviewed state

# Steps to test the changes
Run integration tests
Map "snapshottable" objects with "reviewed" state via import, state should be reverted to "unreviewed"

# Solution description
Update signal handlers with check on "snapshottable" state


# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
