### PR TITLE
GGRC-5848, GGRC-5851 Rewrite index records insert to row SQL

### DIFF
--- a/src/ggrc/views/__init__.py
+++ b/src/ggrc/views/__init__.py
@@ -282,7 +282,7 @@ def do_reindex(with_reindex_snapshots=False):
     logger.info("Updating index for: %s", model_name)
     with benchmark("Create records for %s" % model_name):
       model = indexed_models[model_name]
-      ids = [obj.id for obj in model.query]
+      ids = [id_[0] for id_ in db.session.query(model.id)]
       ids_count = len(ids)
       handled_ids = 0
       for ids_chunk in utils.list_chunks(ids, chunk_size=REINDEX_CHUNK_SIZE):

--- a/src/ggrc/views/__init__.py
+++ b/src/ggrc/views/__init__.py
@@ -289,7 +289,7 @@ def do_reindex(with_reindex_snapshots=False):
         handled_ids += len(ids_chunk)
         logger.info("%s: %s / %s", model.__name__, handled_ids, ids_count)
         model.bulk_record_update_for(ids_chunk)
-        db.session.commit()
+        db.session.plain_commit()
 
   if with_reindex_snapshots:
     logger.info("Updating index for: %s", "Snapshot")


### PR DESCRIPTION
# Issue description

Fulltext records db inserting now is implemented using sqlalchemy core construction (db.session.execute(_table_.insert(), data_dict). Such inserting is quite unperformant, it’s faster to use raw SQL.

# Benchmarks:

Tests were done locally on ggrc_test dump (2018-09-27)
Without fix:
100 Assessments: 1.6s average 
All assessments (33591): 497.00s
Total reindex time: 978.14s
Archiving big Audit (4519): 72.29s

With fix:
100 Assessments: 1.2s average
All assessments: 370.66s
Total reindex time: 736.11s
Archiving big Audit (4519): 44.95s

# Steps to test the changes

Run reindex with and without fix and compare results, run POST/PUT on huge Assessment and check time.
Expected result: time with fix decreased.

# Solution description

Replace SQLAlchemy insert/delete to row SQL.
Replace commit with plain_commit.
To get object ids load id only instead of whole object.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".