### PR TITLE
GGRC-6120 Remove flush and commit from user creation

### DIFF
--- a/src/ggrc/bootstrap.py
+++ b/src/ggrc/bootstrap.py
@@ -2,6 +2,7 @@
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
 """Bootstrap for ggrc db."""
+import flask
 import threading
 
 from flask.ext.sqlalchemy import SQLAlchemy
@@ -66,6 +67,10 @@ def get_db():
     with benchmark("post commit hooks"):
       if not database.session.commit_hooks_enable_flag:
         return
+      if hasattr(flask.g, "user_cache"):
+        del flask.g.user_cache
+      if hasattr(flask.g, "user_creator_roles_cache"):
+        del flask.g.user_creator_roles_cache
       from ggrc.models.hooks import acl
       acl.after_commit()
 

--- a/src/ggrc/bootstrap.py
+++ b/src/ggrc/bootstrap.py
@@ -2,9 +2,8 @@
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
 """Bootstrap for ggrc db."""
-import flask
 import threading
-
+import flask
 from flask.ext.sqlalchemy import SQLAlchemy
 
 from ggrc.utils import benchmark
@@ -29,7 +28,7 @@ class CommitHooksEnableFlag(threading.local):
   __nonzero__ = __bool__
 
 
-def get_db():
+def get_db():  # noqa
   """Get modified db object."""
   database = SQLAlchemy()
 
@@ -67,6 +66,8 @@ def get_db():
     with benchmark("post commit hooks"):
       if not database.session.commit_hooks_enable_flag:
         return
+      # delete flask caches in order to avoid
+      # using cached instances after commit
       if hasattr(flask.g, "user_cache"):
         del flask.g.user_cache
       if hasattr(flask.g, "user_creator_roles_cache"):

--- a/src/ggrc/login/appengine.py
+++ b/src/ggrc/login/appengine.py
@@ -21,13 +21,12 @@ import flask
 import flask_login
 from werkzeug import exceptions
 
+from ggrc import db
+from ggrc import settings
 from ggrc.login import common
 from ggrc.models import all_models
-from ggrc import settings
-from ggrc.utils.user_generator import find_or_create_ext_app_user
-from ggrc.utils.user_generator import find_or_create_user_by_email
-from ggrc.utils.user_generator import is_external_app_user_email
-from ggrc.utils.user_generator import parse_user_email
+from ggrc.utils.user_generator import find_or_create_ext_app_user, \
+    find_or_create_user_by_email, is_external_app_user_email, parse_user_email
 
 
 logger = logging.getLogger(__name__)
@@ -45,6 +44,8 @@ def get_user():
 def login():
   """Log in current user."""
   user = get_user()
+  if user.id is None:
+    db.session.commit()
   if user.system_wide_role != 'No Access':
     flask_login.login_user(user)
     return flask.redirect(common.get_next_url(

--- a/src/ggrc/login/appengine.py
+++ b/src/ggrc/login/appengine.py
@@ -25,6 +25,7 @@ from ggrc import db
 from ggrc import settings
 from ggrc.login import common
 from ggrc.models import all_models
+from ggrc.utils.log_event import log_event
 from ggrc.utils.user_generator import find_or_create_ext_app_user, \
     find_or_create_user_by_email, is_external_app_user_email, parse_user_email
 
@@ -45,6 +46,8 @@ def login():
   """Log in current user."""
   user = get_user()
   if user.id is None:
+    db.session.flush()
+    log_event(db.session, user, user.id)
     db.session.commit()
   if user.system_wide_role != 'No Access':
     flask_login.login_user(user)
@@ -83,9 +86,21 @@ def request_loader(request):
   # External Application User should be created if doesn't exist.
   if is_external_app_user_email(email):
     db_user = find_or_create_ext_app_user()
+    if db_user.id is None:
+      db.session.flush()
+      log_event(db.session, db_user, db_user.id)
+      db.session.commit()
     try:
       # Create in the DB external app user provided in X-external-user header.
-      parse_user_email(request, "X-external-user", mandatory=False)
+      external_user_email = parse_user_email(
+          request, "X-external-user", mandatory=False
+      )
+      if external_user_email:
+        from ggrc.utils.user_generator import find_user
+        ext_user = find_user(external_user_email, modifier=db_user.id)
+        if ext_user.id is None:
+          log_event(db.session, ext_user, db_user.id)
+          db.session.commit()
     except exceptions.BadRequest as exp:
       logger.error("Creation of external user has failed. %s", exp.message)
       raise

--- a/src/ggrc/login/noop.py
+++ b/src/ggrc/login/noop.py
@@ -10,6 +10,8 @@ import flask_login
 import json
 from flask import url_for, redirect, request, session, g, flash
 
+from ggrc import db
+
 default_user_name = 'Example User'
 default_user_email = 'user@example.com'
 
@@ -40,6 +42,8 @@ def before_request(*args, **kwargs):
 def login():
   from ggrc.login.common import get_next_url
   user = get_user()
+  if user.id is None:
+    db.session.commit()
   if user.system_wide_role != 'No Access':
     flask_login.login_user(user)
     return redirect(get_next_url(request, default_url=url_for('dashboard')))

--- a/src/ggrc/login/noop.py
+++ b/src/ggrc/login/noop.py
@@ -6,11 +6,12 @@
 Login as example user for development mode.
 """
 
-import flask_login
 import json
+import flask_login
 from flask import url_for, redirect, request, session, g, flash
 
 from ggrc import db
+from ggrc.utils.log_event import log_event
 
 default_user_name = 'Example User'
 default_user_email = 'user@example.com'
@@ -41,11 +42,13 @@ def before_request(*args, **kwargs):
 
 def login():
   from ggrc.login.common import get_next_url
-  user = get_user()
-  if user.id is None:
+  db_user = get_user()
+  if db_user.id is None:
+    db.session.flush()
+    log_event(db.session, db_user, db_user.id)
     db.session.commit()
-  if user.system_wide_role != 'No Access':
-    flask_login.login_user(user)
+  if db_user.system_wide_role != 'No Access':
+    flask_login.login_user(db_user)
     return redirect(get_next_url(request, default_url=url_for('dashboard')))
   else:
     flash(u'You do not have access. Please contact your administrator.',

--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -1118,6 +1118,9 @@ class Resource(ModelView):
             created_people.append(response_part)
 
           if any_created:
+            with benchmark("person collection commit"):
+              log_event(db.session)
+              db.session.commit()
             return self.json_success_response(created_people)
           return current_app.make_response(
               (self.as_json(created_people),

--- a/src/ggrc/utils/user_generator.py
+++ b/src/ggrc/utils/user_generator.py
@@ -164,7 +164,7 @@ def find_user(email, modifier=None):
     return find_or_create_ext_app_user()
 
   if settings.INTEGRATION_SERVICE_URL == 'mock':
-    return find_user_by_email(email)
+    return find_or_create_user_by_email(email, email, modifier)
 
   if settings.INTEGRATION_SERVICE_URL:
     name = search_user(email)

--- a/test/integration/ggrc/utils/test_user_generator.py
+++ b/test/integration/ggrc/utils/test_user_generator.py
@@ -91,7 +91,7 @@ class TestUserGenerator(TestCase):
     self.assert_profiles_restrictions()
     emails = ['aturing@example.com', ]
     self.assert_person_profile_created(emails)
-    self.assertEqual(all_models.Event.query.count(), 3)
+    self.assertEqual(all_models.Event.query.count(), 1)
 
   @mock.patch('ggrc.settings.INTEGRATION_SERVICE_URL', new='endpoint')
   @mock.patch('ggrc.settings.AUTHORIZED_DOMAIN', new='example.com')

--- a/test/integration/ggrc_basic_permissions/test_external_login.py
+++ b/test/integration/ggrc_basic_permissions/test_external_login.py
@@ -22,8 +22,6 @@ class TestExternalPermissions(TestCase):
   def setUp(self):
     """Set up request mock and mock dependencies."""
     self.allowed_appid = "ggrcq-id"
-    self.person = factories.PersonFactory()
-
     self.settings_patcher = mock.patch("ggrc.login.appengine.settings")
     self.settings_mock = self.settings_patcher.start()
     self.settings_mock.ALLOWED_QUERYAPI_APP_IDS = [self.allowed_appid]

--- a/test/integration/ggrc_basic_permissions/test_external_login.py
+++ b/test/integration/ggrc_basic_permissions/test_external_login.py
@@ -99,27 +99,29 @@ class TestExternalPermissions(TestCase):
           headers=headers)
       self.assertEqual(response.status_code, 201)
 
-    # check object modifier
-    person = all_models.Person.query.filter_by(
+    ext_person = all_models.Person.query.filter_by(
         email="new_ext_user@example.com"
     ).first()
-    person_id = person.id
+    ext_person_id = ext_person.id
 
+    # check that external user has Creator role
+    self.assertEqual(ext_person.system_wide_role, "Creator")
+
+    # check model modifier
     model_json = response.json[model_singular]
-    self.assertEqual(model_json['modified_by']['id'], person_id)
-    self.assertEqual(person.system_wide_role, "Creator")
+    self.assertEqual(model_json['modified_by']['id'], ext_person_id)
 
-    # check revision modifier
-    revision = all_models.Revision.query.filter(
+    # check model revision modifier
+    model_revision = all_models.Revision.query.filter(
         all_models.Revision.resource_type == model.__name__).order_by(
         all_models.Revision.id.desc()).first()
-    self.assertEqual(revision.modified_by_id, person_id)
+    self.assertEqual(model_revision.modified_by_id, ext_person_id)
 
-    # check event modifier
+    # check model event modifier
     event = all_models.Event.query.filter(
         all_models.Event.resource_type == model.__name__).order_by(
         all_models.Event.id.desc()).first()
-    self.assertEqual(event.modified_by_id, person_id)
+    self.assertEqual(event.modified_by_id, ext_person_id)
 
     # check relationship post
     destination = factories.SystemFactory()
@@ -145,7 +147,7 @@ class TestExternalPermissions(TestCase):
     self.assertEqual(relationship.destination_type, "System")
     self.assertEqual(relationship.destination_id, destination.id)
     self.assertTrue(relationship.is_external)
-    self.assertEqual(relationship.modified_by_id, person_id)
+    self.assertEqual(relationship.modified_by_id, ext_person_id)
     self.assertIsNone(relationship.parent_id)
     self.assertIsNone(relationship.automapping_id)
     self.assertIsNone(relationship.context_id)


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

The creation of new user and adding a creator role to the user should not contain flush, commit and log_event.
One bug that caused by this design is the following:

When you send the request to create an object (e.g. Market) using X-ggrc-user and X-external-user the following revisions are created:
```
mysql&gt; select id, resource_id, resource_type, event_id, action,modified_by_id from revisions;
+----+-------------+---------------+----------+----------+----------------+
| id | resource_id | resource_type | event_id | action | modified_by_id |
+----+-------------+---------------+----------+----------+----------------+
| 1 | 2 | PersonProfile | 2 | created | 2 |
| 2 | 2 | Person | 2 | created | 2 |
| 3 | 3 | Context | 2 | created | 2 |
| 4 | 3 | PersonProfile | 3 | created | 3 |
| 5 | 4 | Context | 3 | created | 3 |
| 6 | 1 | Market | 3 | created | 3 |
| 7 | 3 | Person | 3 | created | 3 |
| 8 | 1 | Market | 4 | modified | 3 |
+----+-------------+---------------+----------+----------+----------------+
8 rows in set (0.00 sec)
```
We have 3 events here: 1st event with event_id=2 is logged while X-ggrc-user is created; 2nd event with event_id=3 is logged when X-external-user is created, but at this time we already have a Market object in db session and that means that this data is commmitted to db (user from X-enternal-user header and partially filled Market as created revision). The content of this revision for Market with revision ID=6 will have modified_by and modified_by_id fields equal to NULL. Also, 3rd event with event_id=4 is created when modified_by field is properly set and will be committed to db as a last step.



# Steps to test the changes

- Reproduce the steps from the bug above
- Run integration tests

# Solution description

Add two new flask caches for user (`user_cache`) and user creator roles (`user_creator_roles_cache`). They will store users/user_roles that where created in the current session. 
These caches will be initialized when firstly accessed and deleted with post commit hook.

In some cases we still need to commit user information before the main request commit.
These cases are:
1. A new user login in the app.
2. Bulk creation of users with collection post.
3. Bulk creation of users for the filed default_people of assessment templates.
4. Request_loader in appengine.py also should commit users right after they created 

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
