### PR TITLE
GGRC-6082 Fix bug when review status is not updated for customattributable

### DIFF
--- a/src/ggrc/models/review.py
+++ b/src/ggrc/models/review.py
@@ -106,6 +106,19 @@ class Reviewable(rest_handable.WithPutHandable,
       if changed - self.ATTRS_TO_IGNORE:
         self._set_review_status_unreviewed()
 
+  def _update_status_on_custom_attrs(self):
+    """Update review status when reviewable custom attrs are changed"""
+    if not hasattr(self, 'custom_attribute_values'):
+      return
+    changed = set()
+    for value in self.custom_attribute_values:
+      history = db.inspect(
+          value).attrs.attribute_value.history
+      if history.has_changes():
+        changed.add(value.custom_attribute.title)
+    if changed - self.ATTRS_TO_IGNORE:
+      self._set_review_status_unreviewed()
+
   def add_email_notification(self):
     """Add email notification of type STATUS_UNREVIEWED"""
     review_notif_type = self.review.notification_type
@@ -130,6 +143,7 @@ class Reviewable(rest_handable.WithPutHandable,
 
   def handle_put(self):
     self._update_status_on_attr()
+    self._update_status_on_custom_attrs()
 
   def handle_relationship_post(self, counterparty):
     self._update_status_on_mapping(counterparty)

--- a/src/ggrc/models/review.py
+++ b/src/ggrc/models/review.py
@@ -108,11 +108,10 @@ class Reviewable(rest_handable.WithPutHandable,
 
   def _update_status_on_custom_attrs(self):
     """Update review status when reviewable custom attrs are changed"""
-    from ggrc.models import all_models
     if not hasattr(self, "custom_attribute_values"):
       return
     if (self.review and
-            self.review.status != all_models.Review.STATES.UNREVIEWED):
+            self.review.status != Review.STATES.UNREVIEWED):
       if self._has_custom_attr_changes():
         self._set_review_status_unreviewed()
 


### PR DESCRIPTION
# Issue description

Reviewable does not get review status updated from reviewed to unreviewed on changes to custom attributes, if custom attribute value already existed.

# Steps to test the changes

1. Reproduce:
    - Add instance of any reviewable
    - Create global custom attribute for this reviewable
    - Add value to the global custom attribute of the instance
    - Set review status of the instance to reviewed
    - Update the global custom attribute value (review status should go to unreviewed, but does not)
2. Run integration tests

# Solution description

Custom attribute values are related instances to custom attributable, thus their changes are not visible immediately. The solution is to go over custom attribute values and check attribute_value attribute history. Much like in [autostatuschangable.py](https://github.com/google/ggrc-core/blob/dev/src/ggrc/models/mixins/autostatuschangeable.py#L229-L251)

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst)

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
