### PR TITLE
QUICK-FIX Remove obsolete id setter for custom attributes

### DIFF
--- a/src/ggrc/models/custom_attribute_definition.py
+++ b/src/ggrc/models/custom_attribute_definition.py
@@ -126,7 +126,7 @@ class CustomAttributeDefinition(attributevalidator.AttributeValidator,
     data = {
         "title": self.title,
         "definition_type": self.definition_type,
-        "definition_id": target.id,
+        "definition": target,
         "context": target.context,
         "attribute_type": self.attribute_type,
         "multi_choice_options": self.multi_choice_options,

--- a/src/ggrc/models/custom_attribute_value.py
+++ b/src/ggrc/models/custom_attribute_value.py
@@ -221,9 +221,8 @@ class CustomAttributeValue(base.ContextRBAC, Base, Indexed, db.Model):
   def _clone(self, obj):
     """Clone a custom value to a new object."""
     data = {
-        "custom_attribute_id": self.custom_attribute_id,
-        "attributable_id": obj.id,
-        "attributable_type": self.attributable_type,
+        "custom_attribute": self.custom_attribute,
+        "attributable": obj,
         "attribute_value": self.attribute_value,
         "attribute_object_id": self.attribute_object_id
     }


### PR DESCRIPTION
# Issue description

We used to have broken orm mapper for custom attributes and we used to
set orm properties manually. The code now seems to be old and does
nothing because all orm mapper properties are already set before the
deleted function call.


# Steps to test the changes

Verify that custom attribute still work.
- adding global CA
- adding local CA
- updating global and local CAs 
- verify global CAs on Assessments and any non audit object (control, market, ...)

# Solution description

I have removed special object setter since the attributes should all already be set at that point.

# Sanity checklist

- [ ] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [ ] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [ ] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [ ] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
