### PR TITLE
GGRC-6183 Fix cycle tasks notifications generation job

### DIFF
--- a/src/ggrc/notifications/common.py
+++ b/src/ggrc/notifications/common.py
@@ -307,7 +307,7 @@ def send_daily_digest_notifications():
     return "emails sent to: <br> {}".format("<br>".join(sent_emails))
 
 
-def generate_cycle_tasks_notifs(day=None):
+def generate_cycle_tasks_notifs():
   """Generate notifications for cycle
   task group object tasks on status change.
 
@@ -315,8 +315,7 @@ def generate_cycle_tasks_notifs(day=None):
     day (date): send notification date.
   """
   with benchmark("generate notifications for cycle tasks"):
-    if day is None:
-      day = date.today() - relativedelta.relativedelta(days=1)
+    day = date.today() - relativedelta.relativedelta(days=1)
     send_datetime = datetime.combine(day, SEND_TIME)
 
     updated_tasks = CycleTaskGroupObjectTask.query.filter(

--- a/src/ggrc/views/__init__.py
+++ b/src/ggrc/views/__init__.py
@@ -257,7 +257,7 @@ def start_update_audit_issues(audit_id, message):
 @queued_task
 def generate_wf_tasks_notifications(_):
   """Generate notifications for wf cycle tasks."""
-  generate_cycle_tasks_notifs(date.today())
+  generate_cycle_tasks_notifs()
   return app.make_response(("success", 200, [("Content-Type", "text/html")]))
 
 

--- a/src/ggrc/views/__init__.py
+++ b/src/ggrc/views/__init__.py
@@ -9,8 +9,6 @@ import collections
 import json
 import logging
 
-from datetime import date
-
 import sqlalchemy
 from sqlalchemy import true
 from flask import flash

--- a/test/integration/ggrc_workflows/notifications/test_one_time_wf_decline_accept_tasks.py
+++ b/test/integration/ggrc_workflows/notifications/test_one_time_wf_decline_accept_tasks.py
@@ -91,7 +91,7 @@ class TestCycleTaskStatusChange(TestCase):
 
       self.task_change_status(task1)
 
-      generate_cycle_tasks_notifs(date(2015, 5, 1))
+      generate_cycle_tasks_notifs()
       notif = db.session.query(Notification).filter(and_(
           Notification.object_id == cycle.id,
           Notification.object_type == cycle.type,
@@ -129,7 +129,7 @@ class TestCycleTaskStatusChange(TestCase):
 
       self.task_change_status(task1)
 
-      generate_cycle_tasks_notifs(date(2015, 5, 1))
+      generate_cycle_tasks_notifs()
       notif = db.session.query(Notification).filter(and_(
           Notification.object_id == cycle.id,
           Notification.object_type == cycle.type,
@@ -161,7 +161,7 @@ class TestCycleTaskStatusChange(TestCase):
 
       self.task_change_status(task2)
 
-      generate_cycle_tasks_notifs(date(2015, 5, 1))
+      generate_cycle_tasks_notifs()
       notif = db.session.query(Notification).filter(and_(
           Notification.object_id == cycle.id,
           Notification.object_type == cycle.type,
@@ -247,7 +247,7 @@ class TestCycleTaskStatusChange(TestCase):
 
       self.task_change_status(task1)
 
-      generate_cycle_tasks_notifs(date(2015, 5, 3))
+      generate_cycle_tasks_notifs()
       user = Person.query.get(self.user.id)
       _, notif_data = common.get_daily_notifications()
       self.assertNotIn(user.email, notif_data)

--- a/test/integration/ggrc_workflows/notifications/test_task_overdue_notifications.py
+++ b/test/integration/ggrc_workflows/notifications/test_task_overdue_notifications.py
@@ -221,7 +221,7 @@ class TestTaskOverdueNotificationsUsingAPI(TestTaskOverdueNotifications):
       # state, and the overdue notification should disappear.
 
       self.wf_generator.modify_object(task1, {"status": final_state})
-      common.generate_cycle_tasks_notifs(date.today())
+      common.generate_cycle_tasks_notifs()
       _, notif_data = common.get_daily_notifications()
       user_notifs = notif_data.get(user_email, {})
       self.assertNotIn("task_overdue", user_notifs)

--- a/test/integration/ggrc_workflows/notifications/test_wf_notifs_generator.py
+++ b/test/integration/ggrc_workflows/notifications/test_wf_notifs_generator.py
@@ -55,7 +55,7 @@ class TestWfNotifsGenerator(TestCase):
   def test_ctasks_notifs_generator_daily_digest(self):
     """Test cycle tasks notifications generation job."""
     with freeze_time("2015-05-01 14:29:00"):
-      generate_cycle_tasks_notifs(date(2015, 5, 1))
+      generate_cycle_tasks_notifs()
       self.assert_notifications_for_object(self.cycle, "manual_cycle_created")
       self.assert_notifications_for_object(self.ctask,
                                            "manual_cycle_created",
@@ -66,7 +66,7 @@ class TestWfNotifsGenerator(TestCase):
       # Move task to Finished
       self.wf_generator.modify_object(
           self.ctask, data={"status": "Verified"})
-      generate_cycle_tasks_notifs(date(2015, 5, 1))
+      generate_cycle_tasks_notifs()
       self.assert_notifications_for_object(self.cycle,
                                            "all_cycle_tasks_completed",
                                            "manual_cycle_created")
@@ -74,7 +74,7 @@ class TestWfNotifsGenerator(TestCase):
       # Undo finish
       self.wf_generator.modify_object(
           self.ctask, data={"status": "In Progress"})
-      generate_cycle_tasks_notifs(date(2015, 5, 1))
+      generate_cycle_tasks_notifs()
       self.assert_notifications_for_object(self.cycle, "manual_cycle_created")
       self.assert_notifications_for_object(self.ctask,
                                            "cycle_task_due_in",
@@ -92,7 +92,7 @@ class TestWfNotifsGenerator(TestCase):
   def test_ctasks_notifs_generator_daily_digest_called_twice(self):
     """No duplicated notifications should be generated"""
     with freeze_time("2015-05-01 14:29:00"):
-      generate_cycle_tasks_notifs(date(2015, 5, 1))
+      generate_cycle_tasks_notifs()
       self.assert_notifications_for_object(self.cycle, "manual_cycle_created")
       self.assert_notifications_for_object(self.ctask,
                                            "manual_cycle_created",
@@ -103,8 +103,8 @@ class TestWfNotifsGenerator(TestCase):
       # Move task to Finished
       self.wf_generator.modify_object(
           self.ctask, data={"status": "Verified"})
-      generate_cycle_tasks_notifs(date(2015, 5, 1))
-      generate_cycle_tasks_notifs(date(2015, 5, 1))
+      generate_cycle_tasks_notifs()
+      generate_cycle_tasks_notifs()
       self.assert_notifications_for_object(self.cycle,
                                            "all_cycle_tasks_completed",
                                            "manual_cycle_created")

--- a/test/integration/ggrc_workflows/notifications/test_wf_notifs_generator.py
+++ b/test/integration/ggrc_workflows/notifications/test_wf_notifs_generator.py
@@ -7,7 +7,6 @@
 
 from datetime import datetime
 from datetime import timedelta
-from datetime import date
 
 from freezegun import freeze_time
 

--- a/test/integration/ggrc_workflows/notifications/test_wf_notifs_generator.py
+++ b/test/integration/ggrc_workflows/notifications/test_wf_notifs_generator.py
@@ -54,7 +54,6 @@ class TestWfNotifsGenerator(TestCase):
   def test_ctasks_notifs_generator_daily_digest(self):
     """Test cycle tasks notifications generation job."""
     with freeze_time("2015-05-01 14:29:00"):
-      generate_cycle_tasks_notifs()
       self.assert_notifications_for_object(self.cycle, "manual_cycle_created")
       self.assert_notifications_for_object(self.ctask,
                                            "manual_cycle_created",

--- a/test/integration/ggrc_workflows/test_api_calls.py
+++ b/test/integration/ggrc_workflows/test_api_calls.py
@@ -507,7 +507,7 @@ class TestStatusApiPatch(TestCase):
     self.assertEqual(self.VERIFIED, self.group.status)
     self.assertEqual(self.VERIFIED, self.cycle.status)
     self.assertEqual(all_models.Workflow.INACTIVE, self.workflow.status)
-    generate_cycle_tasks_notifs(datetime.date.today())
+    generate_cycle_tasks_notifs()
     for task in self.tasks:
       self.assert_notifications_for_object(task)
     self.cycle = self.tasks[0].cycle
@@ -541,7 +541,7 @@ class TestStatusApiPatch(TestCase):
     self.assertEqual(self.IN_PROGRESS, self.group.status)
     self.assertEqual(self.IN_PROGRESS, self.cycle.status)
     self.assertEqual(all_models.Workflow.ACTIVE, self.workflow.status)
-    generate_cycle_tasks_notifs(datetime.date.today())
+    generate_cycle_tasks_notifs()
     self.assert_notifications_for_object(self.tasks[0])
     for task in self.tasks[1:]:
       self.assert_notifications_for_object(task,
@@ -557,7 +557,7 @@ class TestStatusApiPatch(TestCase):
     self.assertEqual(self.FINISHED, self.group.status)
     self.assertEqual(self.FINISHED, self.cycle.status)
     self.assertEqual(all_models.Workflow.INACTIVE, self.workflow.status)
-    generate_cycle_tasks_notifs(datetime.date.today())
+    generate_cycle_tasks_notifs()
     for task in self.tasks:
       self.assert_notifications_for_object(task)
     self.cycle = self.tasks[0].cycle
@@ -649,7 +649,7 @@ class TestStatusApiPatch(TestCase):
     self.assertEqual(self.IN_PROGRESS, group.cycle.status)
     self.assertEqual(all_models.Workflow.ACTIVE, self.workflow.status)
     self.assertEqual(all_models.Workflow.ACTIVE, group.cycle.workflow.status)
-    generate_cycle_tasks_notifs(datetime.date.today())
+    generate_cycle_tasks_notifs()
     self.assert_notifications_for_object(self.tasks[0])
     for task in self.tasks[1:]:
       self.assert_notifications_for_object(task,
@@ -671,7 +671,7 @@ class TestStatusApiPatch(TestCase):
     self.assertEqual(self.FINISHED, group.cycle.status)
     self.assertEqual(all_models.Workflow.INACTIVE, self.workflow.status)
     self.assertEqual(all_models.Workflow.INACTIVE, group.cycle.workflow.status)
-    generate_cycle_tasks_notifs(datetime.date.today())
+    generate_cycle_tasks_notifs()
     for task in self.tasks:
       self.assert_notifications_for_object(task)
     self.assert_notifications_for_object(self.cycle,


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

There was an issue in CycleTasks notifications generation job for show_daily_digest case (notifications retrieving logic was incorrect).

# Steps to test the changes

To test changes locally:
1) Reset db;
2) Create and activate wf with CycleTasks;
3) Change state of CycleTasks and generate notifications with $.post("/admin/generate_wf_tasks_notifications"). Check the result in the db and via '_notifications/show_daily_digest' endpoint.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".


# TODO

- [x] Cover case when CycleTask was updated the day before generate_wf_tasks_notifications is called with tests.