### PR TITLE
GGRC-5085 Use constant timeouts for tracking import-exports

### DIFF
--- a/src/ggrc-client/js/components/import-export/export.js
+++ b/src/ggrc-client/js/components/import-export/export.js
@@ -14,6 +14,8 @@ import {
   downloadExportContent,
   deleteExportJob,
   jobStatuses,
+  PRIMARY_TIMEOUT,
+  SECONDARY_TIMEOUT,
 } from '../../plugins/utils/import-export-utils';
 import {
   isConnectionLost,
@@ -27,8 +29,6 @@ import {backendGdriveClient} from '../../plugins/ggrc-gapi-client';
 import './current-exports/current-exports';
 import {connectionLostNotifier} from './connection-lost-notifier';
 import router from '../../router';
-
-const DEFAULT_TIMEOUT = 2000;
 
 export default can.Component.extend({
   tag: 'csv-export',
@@ -54,7 +54,7 @@ export default can.Component.extend({
     isFilterActive: false,
     currentExports: [],
     disabledItems: {},
-    timeout: DEFAULT_TIMEOUT,
+    timeout: PRIMARY_TIMEOUT,
     getInProgressJobs() {
       return this.attr('currentExports').filter((el) => {
         return el.status === jobStatuses.IN_PROGRESS;
@@ -63,7 +63,6 @@ export default can.Component.extend({
     getExports(ids) {
       return getExportsHistory(ids)
         .then((exports) => {
-          const timeout = this.attr('timeout');
           if (ids) {
             let exportsMap = exports
               .reduce((map, job) => {
@@ -80,12 +79,12 @@ export default can.Component.extend({
             this.attr('currentExports').replace(exports);
           }
           if (this.getInProgressJobs().length) {
-            this.attr('timeout', timeout * 2);
+            this.attr('timeout', SECONDARY_TIMEOUT);
             this.attr('isInProgress', true);
             this.trackExportsStatus();
           } else {
             this.attr('isInProgress', false);
-            this.attr('timeout', DEFAULT_TIMEOUT);
+            this.attr('timeout', PRIMARY_TIMEOUT);
           }
         })
         .fail((jqxhr, textStatus, errorThrown) => {

--- a/src/ggrc-client/js/components/import-export/import.js
+++ b/src/ggrc-client/js/components/import-export/import.js
@@ -16,6 +16,8 @@ import {
   download,
   deleteImportJob,
   stopImportJob,
+  PRIMARY_TIMEOUT,
+  SECONDARY_TIMEOUT,
 } from '../../plugins/utils/import-export-utils';
 import '../show-more/show-more';
 import './download-template/download-template';
@@ -245,7 +247,7 @@ export default can.Component.extend({
           }
         });
     },
-    trackStatusOfImport(jobId, timeout = 2000) {
+    trackStatusOfImport(jobId, timeout = PRIMARY_TIMEOUT) {
       let timioutId = setTimeout(() => {
         getImportJobInfo(jobId)
           .done((info) => {
@@ -255,7 +257,7 @@ export default can.Component.extend({
             this.attr('fileName', info.title);
             this.attr('state', info.status);
 
-            strategy(info, timeout * 2);
+            strategy(info, SECONDARY_TIMEOUT);
           })
           .fail((jqxhr, textStatus, errorThrown) => {
             if (isConnectionLost()) {

--- a/src/ggrc-client/js/plugins/utils/import-export-utils.js
+++ b/src/ggrc-client/js/plugins/utils/import-export-utils.js
@@ -17,6 +17,9 @@ export const jobStatuses = {
   FINISHED: 'Finished',
 };
 
+export const PRIMARY_TIMEOUT = 2000;
+export const SECONDARY_TIMEOUT = 5000;
+
 export const isStoppedJob = (jobStatus) => {
   return [jobStatuses.BLOCKED, jobStatuses.ANALYSIS_FAILED].includes(jobStatus);
 };


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Refreshing of status of import/export increases in two times each time, so eventually it can take a lot of time before user gets actual status of import/export.

# Steps to test the changes

Start import/export with big amount of data. See on timeouts between request.

# Solution description

Use constant timeouts for tracking import-exports.
2000 ms after first request, 5000 ms after next request.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
