### PR TITLE
GGRC-3374 fix CAD reindexing after Creation/Deleting 

### DIFF
--- a/test/integration/ggrc/services/test_query/test_cad_reindex.py
+++ b/test/integration/ggrc/services/test_query/test_cad_reindex.py
@@ -1,0 +1,134 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Tests for /query api endpoint."""
+
+import ddt
+
+from ggrc.app import db
+from ggrc import models
+from ggrc.models import custom_attribute_definition as cad
+
+from integration import ggrc
+from integration.ggrc import api_helper
+from integration.ggrc.models import factories
+from integration.ggrc import query_helper
+
+
+@ddt.ddt
+class TestCADReindex(query_helper.WithQueryApi, ggrc.TestCase):
+  """Tests reindex after CustomAttributeDefinition changes"""
+  def setUp(self):
+    super(TestCADReindex, self).setUp()
+    self.client.get("/login")
+    self.api = api_helper.Api()
+
+  @staticmethod
+  def _create_cad_body(title, attribute_type, definition_type, model_name):
+    return {
+        "custom_attribute_definition": {
+            "title": title,
+            "attribute_type": attribute_type,
+            "definition_type": definition_type,
+            "modal_title": "Add Attribute to type %s" % model_name,
+            "mandatory": False,
+            "helptext": "",
+            "placeholder": "",
+            "context": {
+                "id": None
+            }
+        }
+    }
+
+  @ddt.data(
+      ("assessment", "Checkbox", "no"),
+      ("assessment", "Text", ""),
+      ("audit", "Checkbox", "no"),
+      ("audit", "Text", ""),
+  )
+  @ddt.unpack
+  def test_reindex_cad_create(self, definition_type, attribute_type, value):
+    """Test reindex after CAD creating"""
+    model_name = cad.get_inflector_model_name_dict()[definition_type]
+    model_id = factories.get_model_factory(model_name)().id
+    expected = [model_id]
+    title = "test_title %s %s" % (definition_type, attribute_type)
+    cad_model = models.all_models.CustomAttributeDefinition
+    response = self.api.post(cad_model, [
+        self._create_cad_body(
+            title, attribute_type, definition_type, model_name
+        )
+    ])
+    self.assert200(response)
+    ids = self.simple_query(
+        model_name,
+        expression=[title, "=", value],
+        type_="ids",
+        field="ids"
+    )
+    self.assertItemsEqual(ids, expected)
+
+  @ddt.data(
+      ("assessment", "Checkbox", "no"),
+      ("assessment", "Text", ""),
+      ("audit", "Checkbox", "no"),
+      ("audit", "Text", ""),
+  )
+  @ddt.unpack
+  def test_reindex_cad_edit(self, definition_type, attribute_type, value):
+    """Test reindex after CAD editing"""
+    model_name = cad.get_inflector_model_name_dict()[definition_type]
+    model_id = factories.get_model_factory(model_name)().id
+    expected = [model_id]
+    title = "test_title %s %s" % (definition_type, attribute_type)
+    cad_model = models.all_models.CustomAttributeDefinition
+    response = self.api.post(cad_model, [
+        self._create_cad_body(
+            title, attribute_type, definition_type, model_name
+        )
+    ])
+    self.assert200(response)
+
+    cad_obj = db.session.query(cad_model).filter_by(title=title).first()
+    title_edited = "%s_edited" % title
+    self.api.put(cad_obj, {"title": title_edited})
+    self.assert200(response)
+
+    ids = self.simple_query(
+        model_name,
+        expression=[title_edited, "=", value],
+        type_="ids",
+        field="ids"
+    )
+    self.assertItemsEqual(ids, expected)
+
+  @ddt.data(
+      ("assessment", "Checkbox", "no"),
+      ("assessment", "Text", ""),
+      ("audit", "Checkbox", "no"),
+      ("audit", "Text", ""),
+  )
+  @ddt.unpack
+  def test_reindex_cad_delete(self, definition_type, attribute_type, value):
+    """Test reindex after CAD deleting"""
+    model_name = cad.get_inflector_model_name_dict()[definition_type]
+    title = "test_title %s %s" % (definition_type, attribute_type)
+    cad_model = models.all_models.CustomAttributeDefinition
+    response = self.api.post(cad_model, [
+        self._create_cad_body(
+            title, attribute_type, definition_type, model_name
+        )
+    ])
+    self.assert200(response)
+
+    cad_obj = db.session.query(cad_model).filter_by(title=title).first()
+    response = self.api.delete(cad_obj)
+    self.assert200(response)
+
+    ids = self.simple_query(
+        model_name,
+        expression=[title, "=", value],
+        type_="ids",
+        field="ids"
+    )
+    self.assertItemsEqual(ids, [])


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

*Creation/Editing of CAD doesn't bring to reindexing of all the entities connected with CAD.*

# Steps to test the changes

1. Create CAD (checkbox) for any object type, e.g. assessment 
2. Search by CAD, "CAD = no": no result 
3. Update assessment, but do not update CAD 
4. Search by CAD, "CAD = no": success

# Solution description

*Changed hook after creating or deleting CustomAttributeDefinition. Revisions and reindex are created using chunks*

# Sanity checklist

- [ ] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [ ] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
