### PR TITLE
GGRC-6198 Fix returning custom_attribute_revision after saving comment

### DIFF
--- a/src/ggrc/models/comment.py
+++ b/src/ggrc/models/comment.py
@@ -15,6 +15,7 @@ from werkzeug.exceptions import BadRequest
 
 from ggrc import builder
 from ggrc import db
+from ggrc.models.custom_attribute_definition import CustomAttributeDefinition
 from ggrc.models.deferred import deferred
 from ggrc.models.revision import Revision
 from ggrc.models.mixins import base
@@ -301,8 +302,20 @@ class Comment(Roleable, Relatable, Described, Notifiable,
                        .format(ca_val_dict))
 
     self.revision_id = ca_val_revision.id
+    self.revision = ca_val_revision
+
+    # Here *attribute*_id is assigned to *definition*_id, strange but,
+    # as you can see in src/ggrc/models/custom_attribute_value.py
+    # custom_attribute_id is link to custom_attribute_definitions.id
+    # possible best way is use definition id from request:
+    # ca_revision_dict["custom_attribute_definition"]["id"]
+    # but needs to be checked that is always exist in request
     self.custom_attribute_definition_id = ca_val_revision.content.get(
         'custom_attribute_id',
+    )
+
+    self.custom_attribute_definition = CustomAttributeDefinition.query.get(
+        self.custom_attribute_definition_id,
     )
 
   @staticmethod


### PR DESCRIPTION
# Issue description

Field `custom_attribute_revision` was null in response after saving comment

# Steps to test the changes

- Create Audit (Title)
- Create Control (Title and Assertions fields)
- Map Control to Audit from gear menu of Audit (Object type=Control, after Governance in GUI)
- Open Audit in new tab via gear menu. Create Assessment Template for Audit: "Create Template->Create new assessment template", Default Assessment Type : Control, Title, Custom Attributes type Dropdown (add values), "Add field", set checkboxes "Comment required"
- Open Assessment tab. From "three dots" menu Generate Assessment for Audit from template with Control
- Open Assessment, select value and add comment
- Look to the field `custom_attribute_revision` in the response of request to /api/comments

# Solution description

In property `custom_attribute_revision` self.revision checked, but in method 
`custom_attribute_revision_upd` is was not assigned.

Note: context_id hardcoded because it obsolete feature.

Integration test was incorrect - was not checked API answer and load comment object not by id.
For run separate test use:

```
cd test
python -m unittest -v integration.ggrc.models.mixins.test_with_action.TestCommentWithActionMixin.test_custom_comment_value
```

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). ??
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".