### PR TITLE
GGRC-6202 Allow to request a review for an already reviewed object

### DIFF
--- a/src/ggrc-client/js/components/object-review/object-review.js
+++ b/src/ggrc-client/js/components/object-review/object-review.js
@@ -43,18 +43,12 @@ export default can.Component.extend({
           return !!this.attr('review.last_reviewed_by');
         },
       },
-      showButtons: {
-        get() {
-          return !this.attr('isReviewed') &&
-            this.attr('hasUpdatePermission');
-        },
-      },
       isSnapshot: {
         get() {
           return isSnapshot(this.attr('instance'));
         },
       },
-      hasUpdatePermission: {
+      showButtons: {
         get() {
           const instance = this.attr('review') || this.attr('instance');
 

--- a/src/ggrc-client/js/components/object-review/request-review-modal.js
+++ b/src/ggrc-client/js/components/object-review/request-review-modal.js
@@ -54,6 +54,7 @@ export default can.Component.extend({
       const review = this.attr('review');
 
       this.attr('loading', true);
+      review.attr('status', 'Unreviewed');
 
       saveReview(review, this.attr('parentInstance'))
         .then((review) => {

--- a/src/ggrc-client/js/components/object-review/templates/object-review.mustache
+++ b/src/ggrc-client/js/components/object-review/templates/object-review.mustache
@@ -35,12 +35,14 @@
       {{/if}}
       {{#if showButtons}}
         <div class="object-review__buttons">
-          <button
-              {{#if loading}}disabled{{/if}}
-              ($click)="markReviewed()"
-              class="btn btn-green btn-small">
-            Mark Reviewed
-          </button>
+          {{^if isReviewed}}
+            <button
+                {{#if loading}}disabled{{/if}}
+                ($click)="markReviewed()"
+                class="btn btn-green btn-small">
+              Mark Reviewed
+            </button>
+          {{/if}}
           <button
               {{#if loading}}disabled{{/if}}
               ($click)="changeReviewers($element)"

--- a/src/ggrc-client/js/components/object-review/templates/request-review-modal.mustache
+++ b/src/ggrc-client/js/components/object-review/templates/request-review-modal.mustache
@@ -15,7 +15,7 @@
         <i class="fa fa-times black"></i>
       </button>
     </div>
-    <div class="request-review-modal__note">An email notification will be sent to each reviewer.</div>
+    <div class="request-review-modal__email-note">An email notification will be sent to each reviewer.</div>
   </div>
   <div class="request-review-modal__content">
     <div class="simple-modal__body">
@@ -52,6 +52,12 @@
         ($click)="save()">
           Request
       </button>
+      {{#if_equals review.status 'Reviewed'}}
+        <div class="request-review-modal__status-note">
+          <i class="fa fa-exclamation-triangle"></i>
+          By clicking 'Request' the object status will be reverted to an 'Unreviewed'
+        </div>
+      {{/if_equals}}
     </div>
   </div>
 </simple-modal>

--- a/src/ggrc-client/js/components/object-review/tests/object-review_spec.js
+++ b/src/ggrc-client/js/components/object-review/tests/object-review_spec.js
@@ -94,34 +94,6 @@ describe('object-review component', () => {
     });
   });
 
-  describe('"showButtons" getter', () => {
-    let review;
-
-    beforeEach(() => {
-      review = new Review({status: 'Unreviewed'});
-      viewModel.attr({review});
-    });
-
-    it('should return true if object is unreviewed', () => {
-      spyOn(Permission, 'is_allowed_for').and.returnValue(true);
-
-      expect(viewModel.attr('showButtons')).toBeTruthy();
-    });
-
-    it('should return false if object is reviewed', () => {
-      review.attr('status', 'Reviewed');
-      spyOn(Permission, 'is_allowed_for').and.returnValue(true);
-
-      expect(viewModel.attr('showButtons')).toBeFalsy();
-    });
-
-    it('should return false if user doesn\'t have "update" permissions', () => {
-      spyOn(Permission, 'is_allowed_for').and.returnValue(false);
-
-      expect(viewModel.attr('showButtons')).toBeFalsy();
-    });
-  });
-
   describe('"isSnapshot" getter', () => {
     beforeEach(() => {
       const instance = {
@@ -149,7 +121,7 @@ describe('object-review component', () => {
     });
   });
 
-  describe('"hasUpdatePermission" getter', () => {
+  describe('"showButtons" getter', () => {
     describe('if review exists', () => {
       beforeEach(() => {
         const review = new Review();
@@ -161,14 +133,14 @@ describe('object-review component', () => {
       "is_allowed_for update review" permission`, () => {
         spyOn(Permission, 'is_allowed_for').and.returnValue(true);
 
-        expect(viewModel.attr('hasUpdatePermission')).toBeTruthy();
+        expect(viewModel.attr('showButtons')).toBeTruthy();
       });
 
       it(`should return false if user does not have 
       "is_allowed_for update review" permission`, () => {
         spyOn(Permission, 'is_allowed_for').and.returnValue(false);
 
-        expect(viewModel.attr('hasUpdatePermission')).toBeFalsy();
+        expect(viewModel.attr('showButtons')).toBeFalsy();
       });
     });
 
@@ -183,14 +155,14 @@ describe('object-review component', () => {
       "is_allowed_for update instance" permission`, () => {
         spyOn(Permission, 'is_allowed_for').and.returnValue(true);
 
-        expect(viewModel.attr('hasUpdatePermission')).toBeTruthy();
+        expect(viewModel.attr('showButtons')).toBeTruthy();
       });
 
       it(`should return false if user does not have 
       "is_allowed_for update instance" permission`, () => {
         spyOn(Permission, 'is_allowed_for').and.returnValue(false);
 
-        expect(viewModel.attr('hasUpdatePermission')).toBeFalsy();
+        expect(viewModel.attr('showButtons')).toBeFalsy();
       });
     });
   });

--- a/src/ggrc-client/js/components/object-review/tests/request-review-modal_spec.js
+++ b/src/ggrc-client/js/components/object-review/tests/request-review-modal_spec.js
@@ -123,6 +123,20 @@ describe('request-review-modal component', () => {
       saveDfd.resolve(review);
     });
 
+    it('should set Unreviewed status', (done) => {
+      viewModel.attr('review.access_control_list', newACL);
+      viewModel.attr('review.status', 'Reviewed');
+
+      viewModel.save();
+
+      saveDfd.then(() => {
+        expect(review.save).toHaveBeenCalled();
+        expect(viewModel.attr('review.status')).toEqual('Unreviewed');
+        done();
+      });
+      saveDfd.resolve(review);
+    });
+
     it('should change modal window state to false', (done) => {
       viewModel.attr('review.access_control_list', newACL);
 

--- a/src/ggrc-client/styles/components/object-review/_request-review-modal.scss
+++ b/src/ggrc-client/styles/components/object-review/_request-review-modal.scss
@@ -6,27 +6,44 @@
 .request-review-modal {
   $simple-modal-header-height: 80px;
   $simple-modal-footer-height: 55px;
+  min-width: 40%;
 
-  .simple-modal__header {
-    border-bottom: none;
-  }
+  .simple-modal {
+    &__header {
+      border-bottom: none;
+    }
 
-  .simple-modal__header-text {
-    font-size: 24px;
-  }
+    &__header-text {
+      font-size: 24px;
+    }
 
-  .simple-modal__footer {
-    height: $simple-modal-footer-height;
-    border-top: none;
-    padding-right: 16px;
+    &__footer {
+      height: $simple-modal-footer-height;
+      border-top: none;
+      padding: 8px 16px;
+    }
+
+    &__toolbar {
+      align-items: center;
+      justify-content: space-between;
+
+      .fa {
+        color: $icon-color-empty;
+        margin-right: 10px;
+      }
+    }
   }
 
   &__header {
     height: $simple-modal-header-height;
   }
 
-  &__note {
+  &__email-note {
     padding: 0 16px;
+  }
+
+  &__status-note {
+    margin-right: 20px;
   }
 
   &__content {


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

As a user I want to be allowed to request a review for an already reviewed object. Such request will revert it into unreviewed state.
Business need: the review of the objects may eventually expire. E.g. review made a year ago may not be actual now as a lot might be changed since the time of the review. To handle this cases users should be able to 'Request review' even if the object was already reviewed.

# Steps to test the changes

1. Open any object with review functionality.
2. Review this object - Request Review button should be visible, Mark Reviewed button - hidden.
3. Click on the Request Review button - popup with the note about Unreviewed status (at the bottom) is opened.
4. Click on the Request button - object status should be changed to Unreviewed.
5. On the Change Log tab should be the record about status change (Reviewed -> Unreviewed)
6. Click on the Request Review again - you should not see the note at the bottom.

# Solution description

Remove status check from `showButtons` getter in `object-review` component, because Request Review button should not depend on the object status. Add status note (about changing to an 'Unreviewed') to the `request-review-modal` template and show this note if object status is Reviewed. Set object status to 'Unreviewed' on review model save in `request-review-modal` component.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
