### PR TITLE
GGRC-5139 Fix audit creation performance

### DIFF
--- a/src/ggrc/models/custom_attribute_definition.py
+++ b/src/ggrc/models/custom_attribute_definition.py
@@ -362,6 +362,7 @@ def get_local_cads(definition_type, instance_id):
   return [i.log_json() for i in _get_query_for(definition_type, instance_id)]
 
 
+@memcache.cached
 def get_model_name_inflector_dict():
   return {m: i for i, m in get_inflector_model_name_pairs()}
 
@@ -377,7 +378,8 @@ def get_custom_attributes_for(model_name, instance_id=None):
   if not definition_type:
     return []
   cads = get_global_cads(definition_type)
-  if instance_id is not None:
+  if instance_id is not None and \
+     model_name in models.mixins.CustomAttributable.MODELS_WITH_LOCAL_CADS:
     cads.extend(get_local_cads(definition_type, instance_id))
   return cads
 

--- a/src/ggrc/models/mixins/customattributable.py
+++ b/src/ggrc/models/mixins/customattributable.py
@@ -30,6 +30,8 @@ logger = getLogger(__name__)
 class CustomAttributable(object):
   """Custom Attributable mixin."""
 
+  MODELS_WITH_LOCAL_CADS = {"Assessment", "AssessmentTemplate"}
+
   _api_attrs = reflection.ApiAttributes(
       'custom_attribute_values',
       reflection.Attribute('custom_attribute_definitions',

--- a/src/ggrc/snapshotter/indexer.py
+++ b/src/ggrc/snapshotter/indexer.py
@@ -74,7 +74,7 @@ def _get_custom_attribute_dict():
       models.CustomAttributeDefinition.definition_type.in_(
           cadef_klass_names.keys()
       )
-  )
+  ).options(orm.undefer('title'))
   cads = defaultdict(list)
   for cad in query:
     cads[cadef_klass_names[cad.definition_type]].append(cad)

--- a/test/integration/ggrc/models/test_revision.py
+++ b/test/integration/ggrc/models/test_revision.py
@@ -236,21 +236,21 @@ class TestRevisions(TestCase):
                                      attribute_value,
                                      is_global):
     """Population cavs and cads depend on is_global flag and send params."""
-    control = factories.ControlFactory()
-    control_id = control.id
+    asmnt = factories.AssessmentFactory()
+    asmnt_id = asmnt.id
     cad_params = {
         "title": "test_cad",
-        "definition_type": "control",
+        "definition_type": "assessment",
         "attribute_type": attribute_type
     }
     if not is_global:
-      cad_params["definition_id"] = control_id
+      cad_params["definition_id"] = asmnt_id
     with factories.single_commit():
       cad = factories.CustomAttributeDefinitionFactory(**cad_params)
     cad_id = cad.id
     revisions = ggrc.models.Revision.query.filter(
-        ggrc.models.Revision.resource_id == control_id,
-        ggrc.models.Revision.resource_type == "Control",
+        ggrc.models.Revision.resource_id == asmnt_id,
+        ggrc.models.Revision.resource_type == "Assessment",
     ).order_by(ggrc.models.Revision.id.desc()).all()
     self.assertEqual(1, len(revisions))
     revision = revisions[0]
@@ -262,8 +262,8 @@ class TestRevisions(TestCase):
     self.assertIn("custom_attribute_values", revision.content)
     self.assertEqual(
         [{
-            'attributable_id': control_id,
-            'attributable_type': u'Control',
+            'attributable_id': asmnt_id,
+            'attributable_type': 'Assessment',
             'attribute_object': None,
             'attribute_object_id': None,
             'attribute_value': attribute_value,
@@ -312,27 +312,27 @@ class TestRevisions(TestCase):
   def test_revisions_invalid_cavs(self, value, _):
     """Test filtering of Checkbox CAVs."""
     with factories.single_commit():
-      program = factories.ProgramFactory()
+      asmnt = factories.AssessmentFactory()
       ca_def = factories.CustomAttributeDefinitionFactory(
-          definition_id=program.id,
-          definition_type="program",
+          definition_id=asmnt.id,
+          definition_type="assessment",
           title="CA",
           attribute_type="Checkbox",
       )
 
     self.gen.api.modify_object(
-        program, {
+        asmnt, {
             "custom_attribute_values": [{
-                "attributable_id": program.id,
-                "attributable_type": "program",
+                "attributable_id": asmnt.id,
+                "attributable_type": "assessment",
                 "attribute_value": value,
                 "custom_attribute_id": ca_def.id,
             }, ],
         },
     )
     revisions = ggrc.models.Revision.query.filter(
-        ggrc.models.Revision.resource_id == program.id,
-        ggrc.models.Revision.resource_type == "Program",
+        ggrc.models.Revision.resource_id == asmnt.id,
+        ggrc.models.Revision.resource_type == "Assessment",
     ).order_by(ggrc.models.Revision.id.desc()).all()
     content = revisions[0].content
     self.assertEqual(


### PR DESCRIPTION
# Issue description

Audit creation in Program with > 1000 Snapshots takes 2 min

# Steps to test the changes

Steps to reproduce:
1. Open Program with several thousand mapped objects 
2. Open dev tools> Network tab and create an audit
Actual Result: Audit creation took 2 min
Expected Result: Time for audit creation should be smaller

# Solution description

Load only global CADs for snapshotted objects, remove loading of local CADs as snapshotted objects don't have them.

# Benchmarks

Local test on Program 2009 (3500 Snapshots)
Without fix: 45.1370s
With fix: 31.5531s


# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).


# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
