### PR TITLE
QUICK-FIX Fix intermittent failure when mapping object to cycle task

### DIFF
--- a/test/selenium/src/lib/page/widget/info_widget.py
+++ b/test/selenium/src/lib/page/widget/info_widget.py
@@ -393,6 +393,11 @@ class CycleTask(InfoWidget):
         "due_date": self.due_date
     }
 
+  def wait_to_be_init(self):
+    """Waits for page object to be initialized."""
+    self._root.element(class_name="tab-container_hidden-tabs").wait_until(
+        lambda e: not e.exists)
+
   @property
   def due_date(self):
     """Returns Task Due Date."""

--- a/test/selenium/src/lib/page/widget/workflow_tabs.py
+++ b/test/selenium/src/lib/page/widget/workflow_tabs.py
@@ -36,15 +36,13 @@ class ActiveCyclesTab(object_page.ObjectPage):
 
   def map_obj_to_cycle_task(self, obj, cycle_task):
     """Maps object to the cycle task."""
-    self._open_cycle_task_panel(cycle_task)
-    cycle_task_panel = internal_ui_operations.info_widget_cls(cycle_task)
+    cycle_task_panel = self._open_cycle_task_panel(cycle_task)
     cycle_task_panel.click_map_objs()
     object_mapper.ObjectMapper().map_obj(obj)
 
   def get_objs_mapped_to_cycle_task(self, cycle_task):
     """Get objects mapped to the cycle task."""
-    self._open_cycle_task_panel(cycle_task)
-    cycle_task_panel = internal_ui_operations.info_widget_cls(cycle_task)
+    cycle_task_panel = self._open_cycle_task_panel(cycle_task)
     return cycle_task_panel.mapped_objs()
 
   def _open_cycle_task_panel(self, cycle_task):
@@ -60,6 +58,9 @@ class ActiveCyclesTab(object_page.ObjectPage):
     task_group_row.expand()
     task_row = task_group_row.get_cycle_task_row_by(title=cycle_task.title)
     task_row.select()
+    cycle_task_panel = internal_ui_operations.info_widget_cls(cycle_task)
+    cycle_task_panel.wait_to_be_init()
+    return cycle_task_panel
 
 
 class SetupTab(object_page.ObjectPage):


### PR DESCRIPTION
# Issue description
Currently `test_map_obj_to_cycle_task` sometimes fails when clicking "Map Objects" link. Reason is positions of elements change while panel is being rendered. Chromedriver finds element on screen but its position changes between `find_element` and `click`, and so exception "Element ... is not clickable at point ..." happens. I added a wait for an element that disappears relatively late in panel rendering process.

Selenium is red here because https://github.com/google/ggrc-core/pull/8636 isn't merged.

# Sanity checklist

- [ ] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".