### PR TITLE
GGRC-5993 Entries with non-existing Person id in CustomAttributeValue

### DIFF
--- a/src/ggrc/models/mixins/customattributable.py
+++ b/src/ggrc/models/mixins/customattributable.py
@@ -204,6 +204,9 @@ class CustomAttributable(object):
     from ggrc.models.custom_attribute_value import CustomAttributeValue
 
     for value in values:
+      # TODO: decompose to smaller methods
+      # TODO: remove complicated nested conditions, better to use
+      # instant exception raising
       if not value.get("attribute_object_id"):
         # value.get("attribute_object", {}).get("id") won't help because
         # value["attribute_object"] can be None
@@ -245,7 +248,8 @@ class CustomAttributable(object):
               attributable=self,
               custom_attribute=custom_attribute,
               custom_attribute_id=custom_attribute_id,
-              attribute_value=value.get("attribute_value")
+              attribute_value=value.get("attribute_value"),
+              attribute_object_id=value.get("attribute_object_id"),
           )
           cav.attribute_object = attribute_object
         else:

--- a/test/integration/ggrc/notifications/test_assessment_notifications.py
+++ b/test/integration/ggrc/notifications/test_assessment_notifications.py
@@ -74,7 +74,8 @@ class TestAssessmentNotification(TestCase):
     )
     factories.CustomAttributeValueFactory(
         custom_attribute=self.cad2,
-        attributable=self.assessment
+        attributable=self.assessment,
+        attribute_value='Person'
     )
 
     self.cad3 = factories.CustomAttributeDefinitionFactory(


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

*Sometimes CustomAttributeValue table had entries with mapping to not existing Person object.*

# Steps to test the changes

1. Create CAD to Assessment model with "Map:Person" type from administration.
2. Send request to create/edit object from Assessment with wrong person ID.
3. You should get 400 as response.

# Solution description

- Added validator to check existance of mapped object in CustomAttributeValue.
- Added tests that adds not existing Person as CAV to object.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
