### PR TITLE
GGRC-6219 Fix assessment count on Audit Summary page

### DIFF
--- a/src/ggrc-client/js/controllers/summary_widget_controller.js
+++ b/src/ggrc-client/js/controllers/summary_widget_controller.js
@@ -260,8 +260,8 @@ export default can.Control({
       statusObj = statuses.find((el) => {
         return el.name === statusName;
       });
-      statusObj.assessments = item.assessments;
-      statusObj.evidence = item.evidence;
+      statusObj.assessments += item.assessments;
+      statusObj.evidence += item.evidence;
     });
 
     return {

--- a/src/ggrc-client/js/controllers/tests/summary_widget_controller_spec.js
+++ b/src/ggrc-client/js/controllers/tests/summary_widget_controller_spec.js
@@ -333,6 +333,46 @@ describe('SummaryWidgetController', function () {
           .toHaveBeenCalledWith('Assessment');
         expect(result).toEqual(expecteResult);
       });
+
+      it('contains object statuses with default names and summarized counsts' +
+         ' of assessments w/ verified flag set to 0 and 1', () => {
+        let expectedResult;
+        let statuses = [
+          'Not Started', 'In Progress', 'In Review', 'Deprecated',
+          'Rework Needed',
+        ];
+
+        const statusesList = statuses.reduce((acc, status) => {
+          const values = [0, 1].map((verified) => ({
+            name: status,
+            assessments: 2,
+            evidence: 2,
+            verified,
+          }));
+          return acc.concat(values);
+        }, []);
+
+        raw = {
+          total: 'info',
+          statuses: statusesList,
+        };
+
+        spy.and.returnValue(statuses);
+
+        expectedResult = jasmine.objectContaining({
+          statuses: statuses.map((status) => ({
+            name: status,
+            assessments: 4,
+            evidence: 4,
+          })),
+        });
+
+        result = method('Assessment', raw);
+
+        expect(StateUtils.getDefaultStatesForModel)
+          .toHaveBeenCalledWith('Assessment');
+        expect(result).toEqual(expectedResult);
+      });
     });
   });
 });


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Assessment count doesn't match in audit summary

# Steps to test the changes

1. Create Program -> Audit
2. Create 2 Assessments
3. Move both Assessments to 'In Review' state
4. Set 'verified_date' for 2-d assessment to any valid date (it can be done through import functionality or directly in db)

Actual behavior: Statistics page contains only info for Assessments w/ 'verified' flag set to 'true'
Expected behavior: Statistics page should contains info for all Assessments

# Solution description

In current implementation counts of assessment w/ 'verified' flag equals 'true' are skipped from the calculations (only assessments with verified=0 are present in table and on pie chart). Calculation was changed to summarize assessments in all states.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
