### PR TITLE
GGRC-6319 Add comment Query API test. WF Factory improvements.

### DIFF
--- a/test/integration/ggrc/models/factories.py
+++ b/test/integration/ggrc/models/factories.py
@@ -562,7 +562,7 @@ def get_model_factory(model_name):
       "Control": ControlFactory,
       "Cycle": wf_factories.CycleFactory,
       "CycleTaskGroup": wf_factories.CycleTaskGroupFactory,
-      "CycleTaskGroupObjectTask": wf_factories.CycleTaskFactory,
+      "CycleTaskGroupObjectTask": wf_factories.CycleTaskGroupObjectTaskFactory,
       "CycleTaskEntry": wf_factories.CycleTaskEntryFactory,
       "DataAsset": DataAssetFactory,
       "Document": DocumentFactory,

--- a/test/integration/ggrc/models/test_query_api_queries.py
+++ b/test/integration/ggrc/models/test_query_api_queries.py
@@ -76,7 +76,7 @@ class TestAllModels(WithQueryApi, TestCase):
       ggrc_factories.ProductGroupFactory,
       wf_factories.CycleFactory,
       wf_factories.CycleTaskGroupFactory,
-      wf_factories.CycleTaskFactory,
+      wf_factories.CycleTaskGroupObjectTaskFactory,
       wf_factories.TaskGroupFactory,
       wf_factories.TaskGroupTaskFactory,
       wf_factories.WorkflowFactory,

--- a/test/integration/ggrc/services/test_query/test_comment.py
+++ b/test/integration/ggrc/services/test_query/test_comment.py
@@ -24,16 +24,16 @@ class TestCommentQueries(TestCase):
     """Check ordering for comment"""
     with factories.single_commit():
       cgot = wf_factories.CycleTaskGroupObjectTaskFactory()
-      c1 = factories.CommentFactory(
+      comment1 = factories.CommentFactory(
           description="comment 1",
           created_at=datetime.datetime(2017, 1, 1, 7, 31, 32)
       )
-      c2 = factories.CommentFactory(
+      comment2 = factories.CommentFactory(
           description="comment 2",
           created_at=datetime.datetime(2017, 1, 1, 7, 31, 42)
       )
-      factories.RelationshipFactory(source=c1, destination=cgot)
-      factories.RelationshipFactory(source=c2, destination=cgot)
+      factories.RelationshipFactory(source=comment1, destination=cgot)
+      factories.RelationshipFactory(source=comment2, destination=cgot)
 
     query_request_data = [
         {

--- a/test/integration/ggrc/services/test_query/test_comment.py
+++ b/test/integration/ggrc/services/test_query/test_comment.py
@@ -1,0 +1,65 @@
+# coding: utf-8
+
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Tests for Comment /query api endpoint."""
+
+import datetime
+
+from integration.ggrc import TestCase
+from integration.ggrc.api_helper import Api
+from integration.ggrc.models import factories
+from integration.ggrc_workflows.models import factories as wf_factories
+
+
+class TestCommentQueries(TestCase):
+  """Tests for /query api for Comment instance ordering."""
+
+  def setUp(self):
+    super(TestCommentQueries, self).setUp()
+    self.api = Api()
+
+  def test_comment_ordering(self):
+    """Check ordering for comment"""
+    with factories.single_commit():
+      cgot = wf_factories.CycleTaskGroupObjectTaskFactory()
+      c1 = factories.CommentFactory(
+          description="comment 1",
+          created_at=datetime.datetime(2017, 1, 1, 7, 31, 32)
+      )
+      c2 = factories.CommentFactory(
+          description="comment 2",
+          created_at=datetime.datetime(2017, 1, 1, 7, 31, 42)
+      )
+      factories.RelationshipFactory(source=c1, destination=cgot)
+      factories.RelationshipFactory(source=c2, destination=cgot)
+
+    query_request_data = [
+        {
+            u"object_name": u"Comment",
+            u"filters": {
+                u"expression": {
+                    u"object_name": u"CycleTaskGroupObjectTask",
+                    u"op": {
+                        u"name": u"relevant"
+                    },
+                    u"ids": [cgot.id]
+                }
+            },
+            u"order_by": [{
+                u"name": u"created_at",
+                u"desc": True
+            }]
+        }
+    ]
+    resp = self.api.send_request(
+        self.api.client.post, data=query_request_data, api_link="/query"
+    )
+    self.assertEqual(2, resp.json[0]["Comment"]["count"])
+    self.assertEqual(
+        "comment 2", resp.json[0]["Comment"]["values"][0]["description"]
+    )
+    self.assertEqual(
+        "comment 1", resp.json[0]["Comment"]["values"][1]["description"]
+    )

--- a/test/integration/ggrc_workflows/converters/test_cycle_status_update_over_import.py
+++ b/test/integration/ggrc_workflows/converters/test_cycle_status_update_over_import.py
@@ -59,7 +59,7 @@ class TestCycleTaskStatusUpdate(ggrc_test.TestCase):
       )
       self.tasks = []
       for ind, task_status in enumerate(self.DEFAULT_TASK_STATUSES):
-        self.tasks.append(factories.CycleTaskFactory(
+        self.tasks.append(factories.CycleTaskGroupObjectTaskFactory(
             title='task{}'.format(ind),
             cycle=self.cycle,
             cycle_task_group=self.group,

--- a/test/integration/ggrc_workflows/converters/test_cycle_task_import_update.py
+++ b/test/integration/ggrc_workflows/converters/test_cycle_task_import_update.py
@@ -566,7 +566,7 @@ class TestCycleTaskImportUpdateAssignee(BaseTestCycleTaskImportUpdate):
   """Test cases for update assignee column on import cycle tasks"""
 
   def setUp(self):
-    self.instance = factories.CycleTaskFactory()
+    self.instance = factories.CycleTaskGroupObjectTaskFactory()
     self.assignee = ggrc_factories.PersonFactory()
     self.s_assignee = ggrc_factories.PersonFactory()
     self.query = CycleTaskGroupObjectTask.query.filter(

--- a/test/integration/ggrc_workflows/converters/test_cycle_task_import_update.py
+++ b/test/integration/ggrc_workflows/converters/test_cycle_task_import_update.py
@@ -35,7 +35,7 @@ DENY_VERIFIED_DATES_STATUSES_STR = ("<'Assigned' / 'In Progress' / "
 
 
 class BaseTestCycleTaskImportUpdate(TestCase):
-
+  """Base class for CycleTask imports"""
   @staticmethod
   def generate_expected_warning(*columns):
     return {

--- a/test/integration/ggrc_workflows/converters/test_export_cycle_task_group_object_tasks.py
+++ b/test/integration/ggrc_workflows/converters/test_export_cycle_task_group_object_tasks.py
@@ -39,7 +39,7 @@ class TestExportTasks(TestCase):
         person = ggrc_factories.PersonFactory(
             name="user for group {}".format(idx)
         )
-        task = factories.CycleTaskFactory()
+        task = factories.CycleTaskGroupObjectTaskFactory()
         for role_name in ("Task Assignees", "Task Secondary Assignees"):
           task.add_person_with_role_name(person, role_name)
         results.append(task.id)

--- a/test/integration/ggrc_workflows/converters/test_export_cycle_task_groups.py
+++ b/test/integration/ggrc_workflows/converters/test_export_cycle_task_groups.py
@@ -53,9 +53,11 @@ class TestExportTasks(TestCase):
                 person=person,
                 ac_role_id=self.get_role_id_for_obj(task_group_task, r_name)
             )
-          task = factories.CycleTaskFactory(cycle=cycle,
-                                            cycle_task_group=cycle_task_group,
-                                            task_group_task=task_group_task)
+          task = factories.CycleTaskGroupObjectTaskFactory(
+              cycle=cycle,
+              cycle_task_group=cycle_task_group,
+              task_group_task=task_group_task
+          )
           for r_name in role_names:
             ggrc_factories.AccessControlListFactory(
                 object=task,

--- a/test/integration/ggrc_workflows/converters/test_export_cycle_tasks.py
+++ b/test/integration/ggrc_workflows/converters/test_export_cycle_tasks.py
@@ -62,9 +62,11 @@ class TestExportTasks(TestCase):
           cycle_task_group = factories.CycleTaskGroupFactory(
               cycle=cycle, contact=person)
 
-          task = factories.CycleTaskFactory(cycle=cycle,
-                                            cycle_task_group=cycle_task_group,
-                                            task_group_task=task_group_task)
+          task = factories.CycleTaskGroupObjectTaskFactory(
+              cycle=cycle,
+              cycle_task_group=cycle_task_group,
+              task_group_task=task_group_task
+          )
           for r_name in role_names:
             role = all_models.AccessControlRole.query.filter(
                 all_models.AccessControlRole.name == r_name,

--- a/test/integration/ggrc_workflows/models/factories.py
+++ b/test/integration/ggrc_workflows/models/factories.py
@@ -72,13 +72,46 @@ class CycleTaskGroupFactory(TitledFactory):
 
 
 class CycleTaskFactory(TitledFactory):
+  """Deprecated. Please use CycleTaskGroupObjectTask
 
+  Reasons:
+  1) Confusing naming
+  2) Creates 3 workflow object
+  """
   class Meta:
     model = models.CycleTaskGroupObjectTask
 
   cycle = factory.SubFactory(CycleFactory)
   cycle_task_group = factory.SubFactory(CycleTaskGroupFactory)
   task_group_task = factory.SubFactory(TaskGroupTaskFactory)
+  status = "Assigned"
+  task_type = "text"
+  start_date = date(2015, 12, 4)
+  end_date = date(2015, 12, 27)
+  context = factory.LazyAttribute(lambda ct: ct.cycle.context)
+
+
+class CycleTaskGroupObjectTaskFactory(TitledFactory):
+  """ Generate CycleTaskGroupObjectTask obj with related cycle, workflow etc.
+
+  Use this factory instead of CycleTaskFactory.
+
+  Reasons:
+  1) Proper naming
+  2) Creates 1 workflow object
+  """
+  class Meta:
+    model = models.CycleTaskGroupObjectTask
+
+  task_group_task = factory.SubFactory(TaskGroupTaskFactory)
+
+  cycle = factory.LazyAttribute(
+      lambda ct: CycleFactory(workflow=ct.task_group_task.task_group.workflow)
+  )
+  cycle_task_group = factory.LazyAttribute(
+      lambda ct: CycleTaskGroupFactory(cycle=ct.cycle)
+  )
+
   status = "Assigned"
   task_type = "text"
   start_date = date(2015, 12, 4)

--- a/test/integration/ggrc_workflows/models/test_cycle_task_entry.py
+++ b/test/integration/ggrc_workflows/models/test_cycle_task_entry.py
@@ -19,7 +19,7 @@ class TestCommentApiCalls(workflow_test_case.WorkflowTestCase):
     with factories.single_commit():
       workflow = self.setup_helper.setup_workflow((rbac_helper.GE_RNAME,))
       cycle = wf_factories.CycleFactory(workflow=workflow)
-      wf_factories.CycleTaskFactory(cycle=cycle)
+      wf_factories.CycleTaskGroupObjectTaskFactory(cycle=cycle)
 
     g_editor = self.setup_helper.get_person(rbac_helper.GE_RNAME,
                                             ac_roles.workflow.ADMIN_NAME)

--- a/test/integration/ggrc_workflows/models/test_cycle_task_group_object_task.py
+++ b/test/integration/ggrc_workflows/models/test_cycle_task_group_object_task.py
@@ -342,7 +342,7 @@ class TestCycleTaskApiCalls(workflow_test_case.WorkflowTestCase):
   def test_get_ct_g_reader_no_role(self):
     """GET CycleTask collection logged in as GlobalReader & No Role."""
     with factories.single_commit():
-      wf_factories.CycleTaskFactory()
+      wf_factories.CycleTaskGroupObjectTaskFactory()
       self.setup_helper.setup_person(rbac_helper.GR_RNAME, "No Role")
 
     g_reader = self.setup_helper.get_person(rbac_helper.GR_RNAME, "No Role")
@@ -366,8 +366,10 @@ class TestCycleTaskApiCalls(workflow_test_case.WorkflowTestCase):
         task_group = wf_factories.TaskGroupFactory(workflow=workflow)
         tgt = wf_factories.TaskGroupTaskFactory(task_group=task_group)
         cycle = wf_factories.CycleFactory(workflow=workflow)
-        ctgts[flag] = wf_factories.CycleTaskFactory(cycle=cycle,
-                                                    task_group_task=tgt)
+        ctgts[flag] = wf_factories.CycleTaskGroupObjectTaskFactory(
+            cycle=cycle,
+            task_group_task=tgt
+        )
 
     filter_params = "ids={}&object_approval={}".format(
         ",".join([str(c.id) for c in ctgts.values()]),
@@ -396,7 +398,7 @@ class TestCycleTaskApiCalls(workflow_test_case.WorkflowTestCase):
 
     comment_id = comment_json.get("id")
     comment_type = comment_json.get("type")
-    ctgot = wf_factories.CycleTaskFactory()
+    ctgot = wf_factories.CycleTaskGroupObjectTaskFactory()
     ctgot_id = ctgot.id
     response = self.api_helper.post(all_models.Relationship, {
       "relationship": {

--- a/test/integration/ggrc_workflows/notifications/test_data_handler.py
+++ b/test/integration/ggrc_workflows/notifications/test_data_handler.py
@@ -5,12 +5,10 @@
 
 """Tests wf data_handler module."""
 import mock
-
-from integration.ggrc import TestCase
-
 from ggrc import db
 from ggrc.models.revision import Revision
 from ggrc_workflows.notification.data_handler import get_cycle_task_dict
+from integration.ggrc import TestCase
 from integration.ggrc.models import factories
 from integration.ggrc_workflows.models import factories as wf_factories
 

--- a/test/integration/ggrc_workflows/notifications/test_data_handler.py
+++ b/test/integration/ggrc_workflows/notifications/test_data_handler.py
@@ -11,10 +11,8 @@ from integration.ggrc import TestCase
 from ggrc import db
 from ggrc.models.revision import Revision
 from ggrc_workflows.notification.data_handler import get_cycle_task_dict
-from integration.ggrc.models.factories import ContractFactory
-from integration.ggrc.models.factories import EventFactory
-from integration.ggrc.models.factories import RelationshipFactory
-from integration.ggrc_workflows.models.factories import CycleTaskFactory
+from integration.ggrc.models import factories
+from integration.ggrc_workflows.models import factories as wf_factories
 
 
 class TestDataHandler(TestCase):
@@ -22,10 +20,12 @@ class TestDataHandler(TestCase):
   """ This class test basic functions in the data_handler module """
   def test_get_cycle_task_dict(self):
     """Tests get_cycle_task_dict functionality."""
-    contract = ContractFactory(title=u"Contract1")
-    cycle_task = CycleTaskFactory(title=u"task1")
-    relationship = RelationshipFactory(source=contract,
-                                       destination=cycle_task)
+    contract = factories.ContractFactory(title=u"Contract1")
+    cycle_task = wf_factories.CycleTaskGroupObjectTaskFactory(title=u"task1")
+    relationship = factories.RelationshipFactory(
+        source=contract,
+        destination=cycle_task
+    )
     db.session.delete(relationship)
     db.session.commit()
 
@@ -38,7 +38,7 @@ class TestDataHandler(TestCase):
                                  action="deleted",
                                  content='{"display_name": "Contract1"}')
     revisions = [relationship_revision, contract_revision]
-    EventFactory(
+    factories.EventFactory(
         modified_by_id=None,
         action="DELETE",
         resource_id=relationship.id,
@@ -50,10 +50,12 @@ class TestDataHandler(TestCase):
                      u"Contract1 [removed from task]")
 
     # Test if we handle the title of the object being empty
-    contract = ContractFactory(title=u"")
-    cycle_task = CycleTaskFactory(title=u"task1")
-    relationship = RelationshipFactory(source=contract,
-                                       destination=cycle_task)
+    contract = factories.ContractFactory(title=u"")
+    cycle_task = wf_factories.CycleTaskGroupObjectTaskFactory(title=u"task1")
+    factories.RelationshipFactory(
+        source=contract,
+        destination=cycle_task
+    )
 
     task_dict = get_cycle_task_dict(cycle_task)
     self.assertEqual(task_dict["related_objects"][0],
@@ -63,10 +65,12 @@ class TestDataHandler(TestCase):
   def test_ct_without_revisions_error(self, logger):
     """Tests that notifications for CycleTask
     without revisions are handled properly."""
-    contract = ContractFactory(title=u"Test Contract")
-    cycle_task = CycleTaskFactory(title=u"task1")
-    relationship = RelationshipFactory(source=contract,
-                                       destination=cycle_task)
+    contract = factories.ContractFactory(title=u"Test Contract")
+    cycle_task = wf_factories.CycleTaskGroupObjectTaskFactory(title=u"task1")
+    relationship = factories.RelationshipFactory(
+        source=contract,
+        destination=cycle_task
+    )
     db.session.delete(relationship)
     db.session.commit()
 
@@ -75,7 +79,7 @@ class TestDataHandler(TestCase):
                                      action="deleted",
                                      content="{}")
     revisions = [relationship_revision]
-    EventFactory(
+    factories.EventFactory(
         modified_by_id=None,
         action="DELETE",
         resource_id=relationship.id,

--- a/test/integration/ggrc_workflows/notifications/test_workflow_comment_notifications.py
+++ b/test/integration/ggrc_workflows/notifications/test_workflow_comment_notifications.py
@@ -35,7 +35,7 @@ class TestWorkflowCommentNotification(test_assignable_notifications.
     person = all_models.Person.query.first()
     person_email = person.email
     with factories.single_commit():
-      obj = wf_factories.CycleTaskFactory(
+      obj = wf_factories.CycleTaskGroupObjectTaskFactory(
           recipients=",".join(recipient_types),
           send_by_default=False,
       )

--- a/test/integration/ggrc_workflows/test_api_calls.py
+++ b/test/integration/ggrc_workflows/test_api_calls.py
@@ -72,7 +72,7 @@ class TestStatusApiPost(TestCase):
           cycle=self.cycle,
           context=self.cycle.workflow.context
       )
-      self.task = wf_factories.CycleTaskFactory(
+      self.task = wf_factories.CycleTaskGroupObjectTaskFactory(
           cycle=self.cycle,
           cycle_task_group=self.group,
           context=self.cycle.workflow.context

--- a/test/integration/ggrc_workflows/test_relationships.py
+++ b/test/integration/ggrc_workflows/test_relationships.py
@@ -30,9 +30,11 @@ class TestRelationships(workflow_test_case.WorkflowTestCase):
       task_group_task = wf_factories.TaskGroupTaskFactory(
           task_group=task_group
       )
-      wf_factories.CycleTaskFactory(cycle=cycle,
-                                    cycle_task_group=cycle_task_group,
-                                    task_group_task=task_group_task)
+      wf_factories.CycleTaskGroupObjectTaskFactory(
+          cycle=cycle,
+          cycle_task_group=cycle_task_group,
+          task_group_task=task_group_task
+      )
 
     cycle_task = all_models.CycleTaskGroupObjectTask.query.one()
     instance = getattr(all_models, model_name).query.one()


### PR DESCRIPTION
# Issue description

Migrated comments are shown in wrong order

# Steps to test the changes
- Migrate CycleTaskEntry to comments.
- run reindex

# Solution description
Query API is works properly. We forgot to run reindex. 
Is scope of this ticket test was developed. Improved CycleTaskFactory to not create unnecessary workflows.
# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
