### PR TITLE
GGRC-5853 Disable emails for cycle tasks that are deprecated

### DIFF
--- a/src/ggrc/notifications/common.py
+++ b/src/ggrc/notifications/common.py
@@ -344,7 +344,11 @@ def process_sent_notifications(notif_list):
     notif_list (list of Notification): List of notification for which we want
       to modify sent_at field.
   """
+  from ggrc.models import all_models
   for notif in notif_list:
+    if notif.object_type == "CycleTaskGroupObjectTask" and \
+       notif.object.status == all_models.CycleTaskGroupObjectTask.DEPRECATED:
+      continue
     if notif.repeating:
       notif.sent_at = datetime.utcnow()
     else:

--- a/src/ggrc_workflows/notification/data_handler.py
+++ b/src/ggrc_workflows/notification/data_handler.py
@@ -412,6 +412,9 @@ def get_cycle_task_data(notification, tasks_cache=None, del_rels_cache=None):
   if not cycle_task or not cycle_task.cycle_task_group.cycle.is_current:
     return {}
 
+  if cycle_task.status == CycleTaskGroupObjectTask.DEPRECATED:
+    return {}
+
   notification_name = notification.notification_type.name
   if notification_name in ["manual_cycle_created", "cycle_created"]:
     return get_cycle_created_task_data(notification)


### PR DESCRIPTION
# Issue description

If cycle task was deprecated user is still receiving reminder emails for it.

# Steps to test the changes

1. Create CT
2. Deprecate it
3. Check emails

Expected:
Deprecated tasks do not generate a reminder email.

Actual:
Deprecated tasks generate a reminder email.

# Solution description

Remove notifications for existing tasks in migration. Remove notifications if user change status to deprecated. Don't create new notifications if cycle task already deprecated.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# Migration checklist
- [x] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
