### PR TITLE
GGRC-6318 Fix revision for IssueTrackerIssue 'create' action is absent for bulk tickets generation

### DIFF
--- a/test/integration/ggrc/integrations/test_bulk_issue_generate.py
+++ b/test/integration/ggrc/integrations/test_bulk_issue_generate.py
@@ -2,6 +2,7 @@
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
 """Test bulk issuetracker synchronization."""
+# pylint: disable=too-many-lines
 import unittest
 
 import ddt
@@ -751,6 +752,35 @@ class TestBulkIssuesChildGenerate(TestBulkIssuesSync):
         "Tickets generation for audit \"{}\" was completed".format(title),
         body
     )
+
+  def test_proper_revisions_creation(self):
+    """Test all revisions are created for new IssuetrackerIssues"""
+    with factories.single_commit():
+      asmnt = factories.AssessmentFactory()
+      factories.IssueTrackerIssueFactory(issue_tracked_obj=asmnt.audit)
+    response = self.generate_children_issues_for(
+        "Audit", asmnt.audit.id, "Assessment"
+    )
+    self.assert200(response)
+    revisions = db.session.query(
+        all_models.Revision.action,
+        all_models.IssuetrackerIssue.object_type,
+        all_models.IssuetrackerIssue.object_id
+    ).join(
+        all_models.IssuetrackerIssue,
+        all_models.Revision.resource_id == all_models.IssuetrackerIssue.id
+    ).filter(
+        all_models.Revision.resource_type == 'IssuetrackerIssue',
+        all_models.IssuetrackerIssue.object_id.in_(
+            (asmnt.id, asmnt.audit.id)
+        )
+    ).all()
+    expected_revisions = {
+        (u'created', u'Assessment', asmnt.id),
+        (u'modified', u'Assessment', asmnt.id),
+        (u'created', u'Audit', asmnt.audit.id)
+    }
+    self.assertEquals(set(revisions), expected_revisions)
 
 
 @ddt.ddt


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

When user press 'Generate' button on Audit page we generate new tickets for each Assessment in Audit. If any Assessment here doesn't have related IssueTrackerIssue, such object will be created automatically. But revision for this created IssueTrackerIssue is missed (with event).
Expected result: We should always have 'create' revision (and event) for IssueTrackerIssue object.

# Steps to test the changes

- Create new Audit with disabled IssueTracker
- Create one or more Assessments corresponding to this Audit
- Enable IssueTracker in Audit
- Press Generate Button
- Check corresponding revisions in DB


# Solution description

Added action param to log_issues and create_revisions methods
Added creation of revisions for newly created issuetracker issues

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:run' labels to all open PRs with a label 'migration'
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
