### PR TITLE
GGRC-6064 Prevent creating proposal content with object_people field

### DIFF
--- a/src/ggrc/migrations/versions/20181120162305_e2ab6a7b6524_cleanup_object_people_out_of_proposal_.py
+++ b/src/ggrc/migrations/versions/20181120162305_e2ab6a7b6524_cleanup_object_people_out_of_proposal_.py
@@ -1,0 +1,41 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Cleanup object_people out of proposal content
+
+Create Date: 2018-11-20 16:23:05.630346
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+import json
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'e2ab6a7b6524'
+down_revision = '5afb1bf2e93a'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  connection = op.get_bind()
+  proposals_to_cleanup = connection.execute(
+      sa.text("""
+              SELECT id, content
+              FROM proposals
+              WHERE content LIKE :proposal_content;
+              """), proposal_content='%object_people%').fetchall()
+  for proposal in proposals_to_cleanup:
+    content = json.loads(proposal.content)
+    content['mapping_list_fields'].pop('object_people', None)
+    connection.execute("""
+      UPDATE proposals SET content='{}' WHERE id={};
+    """.format(json.dumps(content), proposal.id))
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  pass

--- a/src/ggrc/models/proposal.py
+++ b/src/ggrc/models/proposal.py
@@ -40,10 +40,15 @@ class FullInstanceContentFased(utils.FasadeProperty):
 
   def prepare(self, data):
     data = super(FullInstanceContentFased, self).prepare(data)
-    return builder.prepare(
+    content = builder.prepare(
         referenced_objects.get(data["instance"]["type"],
                                data["instance"]["id"]),
         data["full_instance_content"])
+
+    # pop out unused object_people field out of mapping_list_fields
+    if 'mapping_list_fields' in content:
+      content['mapping_list_fields'].pop('object_people', None)
+    return content
 
 
 # pylint: enable=too-few-public-methods

--- a/test/unit/ggrc/models/test_proposals.py
+++ b/test/unit/ggrc/models/test_proposals.py
@@ -1,0 +1,32 @@
+# Copyright (C) 2018 Google Inc.
+
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+"""Unittests for Revision model """
+
+import unittest
+
+import mock
+import ddt
+
+from ggrc.models.proposal import FullInstanceContentFased
+
+
+@ddt.ddt
+class TestFullInstanceContentFased(unittest.TestCase):
+  """Check FullInstanceContentFased functionality."""
+
+  # pylint: disable=unused-argument
+  @ddt.data(({}, {}),
+            ({'mapping_list_fields': {}}, {'mapping_list_fields': {}}),
+            ({'mapping_list_fields': {'object_people': {}}},
+             {'mapping_list_fields': {}}))
+  @ddt.unpack
+  @mock.patch('flask.g')
+  def test_object_people_handling(self, content, res, flask_g):
+    """Test non actual for Proposals object_people field."""
+    obj = FullInstanceContentFased()
+    data = mock.MagicMock()
+    with mock.patch("ggrc.utils.revisions_diff.builder.prepare",
+                    return_value=content):
+      result_content = obj.prepare(data)
+      self.assertEqual(result_content, res)


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

There are some controls in the db which have related object_people object. This leads to filling proposals content with object_people data, which is not used anymore in proposals functionality.

# Steps to test the changes

Find controls with object_people in the db. Generate a proposal. Update page. No front-end errors should appear.

# Solution description

Prevent putting obejct_people into proposals content. Clean up proposals content in the db.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:run' labels to all open PRs with a label 'migration'
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
