### PR TITLE
GGRC-6100 Fix incorrect review stub in revision content

### DIFF
--- a/src/ggrc/models/review.py
+++ b/src/ggrc/models/review.py
@@ -8,6 +8,7 @@ import sqlalchemy as sa
 
 from ggrc import db
 from ggrc import builder
+from ggrc import utils
 from ggrc.access_control import role
 from ggrc.access_control import roleable
 from ggrc.login import get_current_user
@@ -116,7 +117,13 @@ class Reviewable(rest_handable.WithPutHandable,
     """Serialize to JSON"""
     out_json = super(Reviewable, self).log_json()
     out_json["review_status"] = self.review_status
-    out_json["review"] = self.review
+
+    # put proper review stub to have it in the revision content
+    review_stub = None
+    if self.review:
+      review_stub = utils.create_stub(self.review, self.review.context_id)
+    out_json["review"] = review_stub
+
     out_json["review_issue_link"] = self.review_issue_link
     return out_json
 

--- a/src/ggrc/models/revision.py
+++ b/src/ggrc/models/revision.py
@@ -10,7 +10,6 @@ from ggrc.models.mixins import Base
 from ggrc.models import reflection
 from ggrc.access_control import role
 from ggrc.models.types import LongJsonType
-from ggrc import utils
 from ggrc.utils.revisions_diff import builder as revisions_diff
 from ggrc.utils import referenced_objects
 from ggrc.utils.revisions_diff import meta_info
@@ -87,11 +86,6 @@ class Revision(base.ContextRBAC, Base, db.Model):
         }
 
     self._content = content
-
-    # replace review with proper review stub
-    if "review" in self._content and self._content["review"] is not None:
-      review = self._content["review"]
-      self._content["review"] = utils.create_stub(review, review.context_id)
 
     for attr in ["source_type",
                  "source_id",

--- a/src/ggrc/models/revision.py
+++ b/src/ggrc/models/revision.py
@@ -87,6 +87,17 @@ class Revision(base.ContextRBAC, Base, db.Model):
 
     self._content = content
 
+    # replace review with proper review stub
+    if "review" in self._content and self._content["review"] is not None:
+      review = self._content["review"]
+      result = {
+          "context_id": review.context_id,
+          "id": review.id,
+          "type": review.type,
+          "href": "/api/reviews/{}".format(review.id),
+      }
+      self._content["review"] = result
+
     for attr in ["source_type",
                  "source_id",
                  "destination_type",

--- a/src/ggrc/models/revision.py
+++ b/src/ggrc/models/revision.py
@@ -10,6 +10,7 @@ from ggrc.models.mixins import Base
 from ggrc.models import reflection
 from ggrc.access_control import role
 from ggrc.models.types import LongJsonType
+from ggrc import utils
 from ggrc.utils.revisions_diff import builder as revisions_diff
 from ggrc.utils import referenced_objects
 from ggrc.utils.revisions_diff import meta_info
@@ -90,13 +91,7 @@ class Revision(base.ContextRBAC, Base, db.Model):
     # replace review with proper review stub
     if "review" in self._content and self._content["review"] is not None:
       review = self._content["review"]
-      result = {
-          "context_id": review.context_id,
-          "id": review.id,
-          "type": review.type,
-          "href": "/api/reviews/{}".format(review.id),
-      }
-      self._content["review"] = result
+      self._content["review"] = utils.create_stub(review, review.context_id)
 
     for attr in ["source_type",
                  "source_id",


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Revision content for Review is not populated properly.

# Steps to test the changes

1. Create a new Control object
2. On Control Info page push Mark Reviewed 
3. Open Change Log tab in inspector mode
4. Look into the revision content (`review` section) 

# Solution description

In the constructor of Revision I replaced `review` value with proper review stub. 

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:run' labels to all open PRs with a label 'migration'
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
