### PR TITLE
GGRC-6112 Fix unmap warning in import

### DIFF
--- a/src/ggrc/converters/errors.py
+++ b/src/ggrc/converters/errors.py
@@ -89,7 +89,7 @@ MAPPING_SCOPING_ERROR = (u"Line {line}: You do not have the necessary "
                          u"permissions to {action} scoping objects to "
                          u"directives in this application. Please contact "
                          u"your administrator if you have any questions. "
-                         u"Column 'map:{object_type}' will be ignored.")
+                         u"Column '{action}:{object_type}' will be ignored.")
 
 DELETE_NEW_OBJECT_ERROR = (u"Line {line}: Tried to create and delete the same"
                            " object {object_type}: {slug} in one import.")

--- a/test/unit/ggrc/converters/handlers/test_mapping_column_handler.py
+++ b/test/unit/ggrc/converters/handlers/test_mapping_column_handler.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Tests for the MappingColumnHandler class"""
+
+import unittest
+from mock import MagicMock
+from mock import patch
+
+from ggrc.converters.handlers.handlers import MappingColumnHandler
+
+
+class MappingColumnHandlerTestCase(unittest.TestCase):
+  """Base class for MappingColumnHandler tests"""
+  def setUp(self):
+    row_converter = MagicMock(name=u"row_converter")
+    key = u"field_foo"
+    self.handler = MappingColumnHandler(row_converter, key)
+
+
+class IsAllowedMappingByTypeTestCase(MappingColumnHandlerTestCase):
+  """Tests for the _is_allowed_mapping_by_type() method"""
+  # pylint: disable=invalid-name
+
+  def test_returns_false_for_regulation(self):
+    """The method should return True if destination is 'Regulation'."""
+    # pylint: disable=protected-access
+    result = self.handler._is_allowed_mapping_by_type('Product', 'Regulation')
+    self.assertFalse(result)
+
+  def test_returns_false_for_standard(self):
+    """The method should return True if destination is 'Standard'."""
+    # pylint: disable=protected-access
+    result = self.handler._is_allowed_mapping_by_type('Product', 'Standard')
+    self.assertFalse(result)
+
+  def test_returns_true_for_other_types(self):
+    """The method should return True if destination is other."""
+    # pylint: disable=protected-access
+    result = self.handler._is_allowed_mapping_by_type('Product', 'Control')
+    self.assertTrue(result)
+
+
+class AddMappingWarningTestCase(MappingColumnHandlerTestCase):
+  """Tests for the _add_mapping_warning() method"""
+  # pylint: disable=invalid-name
+
+  def test_count_warnings_where_unmap_and_mapping(self):
+    """The method should return True if unmap = true and mapping isset."""
+    self.handler.raw_value = u""
+
+    with patch('ggrc.models.all_models.Relationship.find_related',
+               side_effect=lambda args, opts: True):
+      self.handler.unmap = True
+
+      # pylint: disable=protected-access
+      self.handler._add_mapping_warning({}, {})
+      self.assertEqual(self.handler.row_converter.add_warning.call_count, 1)
+
+  def test_count_warnings_where_map_and_not_mapping(self):
+    """The method should return True if unmap = false and mapping not is."""
+    self.handler.raw_value = u""
+
+    with patch('ggrc.models.all_models.Relationship.find_related',
+               side_effect=lambda args, opts: False):
+      self.handler.unmap = False
+
+      # pylint: disable=protected-access
+      self.handler._add_mapping_warning({}, {})
+      self.assertEqual(self.handler.row_converter.add_warning.call_count, 1)
+
+  def test_count_warnings_where_map_and_mapping(self):
+    """The method should return True if unmap = false and mapping is."""
+    self.handler.raw_value = u""
+
+    with patch('ggrc.models.all_models.Relationship.find_related',
+               side_effect=lambda args, opts: True):
+      self.handler.unmap = False
+
+      # pylint: disable=protected-access
+      self.handler._add_mapping_warning({}, {})
+      self.assertEqual(self.handler.row_converter.add_warning.call_count, 0)
+
+  def test_count_warnings_where_unmap_and_not_mapping(self):
+    """The method should return True if unmap = true and mapping not is."""
+    self.handler.raw_value = u""
+
+    with patch('ggrc.models.all_models.Relationship.find_related',
+               side_effect=lambda args, opts: False):
+      self.handler.unmap = True
+
+      # pylint: disable=protected-access
+      self.handler._add_mapping_warning({}, {})
+      self.assertEqual(self.handler.row_converter.add_warning.call_count, 0)


### PR DESCRIPTION
**Issue description**
Whan user import a data in GGRC with unmap: Regulation/unmap: Standard he see the message: "Line 3: You do not have the necessary permissions to unmap scoping objects to directives in this application. Please contact your administrator if you have any questions. Column 'map:Regulation' will be ignored." The message is wrong becaouse we sould will have 'unmap'

**Expected Result:**
Column 'unmap:Regulation' / 'unmap:Standard' is shown

**Solution description**
1. I fixed message.
2. I added logic for check mapping. We will see the massage only when we will update database after import

**Sanity checklist**

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our performance guidelines.
- [x] My changes follow our js and/or python guidelines.
- [x] My commits follow our commit guidelines.

**PR Review checklist**
- [x]  The changes fix the issue and don't cause any apparent regressions.
- [x]  Labels and milestone are correctly set.
- [x]  The solution description matches the changes in the code.
- [x]  There is no apparent way to improve the performance & design of the new code.
- [x]  The pull request is opened against the correct base branch.
- [x]  Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".