### PR TITLE
GGRC-5870 Fix crash of app in case of huge ACL count for user

### DIFF
--- a/src/ggrc/utils/memcache.py
+++ b/src/ggrc/utils/memcache.py
@@ -24,7 +24,8 @@ def blob_delete(cache, key):
   return cache.delete_multi(chunk_keys)
 
 
-def blob_set(cache, key, value, exp_time=0, key_prefix="", namespace=None):  # pylint: disable=too-many-arguments
+# pylint: disable=too-many-arguments
+def blob_set(cache, key, value, exp_time=0, key_prefix="", namespace=None):
   """Save object into memcache.
 
   Object will be compressed and pickled. If size of object bigger 10^6 bytes,

--- a/src/ggrc/utils/memcache.py
+++ b/src/ggrc/utils/memcache.py
@@ -1,0 +1,93 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Methods for working with memcache."""
+
+import collections
+import logging
+import zlib
+
+import cPickle
+
+logger = logging.getLogger(__name__)
+
+MEMCACHE_MAX_ITEM_SIZE = 10 ** 6 - 1
+
+
+def blob_delete(cache, key):
+  """Delete stored values from memcache."""
+  chunk_keys = cache.get(key)
+  if chunk_keys is None:
+    # Keys are not set, no need to remove them.
+    return True
+  chunk_keys.append(key)
+  return cache.delete_multi(chunk_keys)
+
+
+def blob_set(cache, key, value, exp_time=0, key_prefix="", namespace=None):  # pylint: disable=too-many-arguments
+  """Save object into memcache.
+
+  Object will be compressed and pickled. If size of object bigger 10^6 bytes,
+  it will be stored by parts. Maximal size that can be stored is 32 Mb.
+
+  Returns:
+      True if object was saved successfully, otherwise - False
+  """
+  # delete previous entity with the given key
+  # in order to conserve available memcache space.
+  blob_delete(cache, key)
+
+  compressed_value = zlib.compress(cPickle.dumps(value))
+  chunk_map = create_chunk_map(compressed_value, MEMCACHE_MAX_ITEM_SIZE, key)
+  unset_ids = cache.set_multi(
+      mapping=chunk_map,
+      time=exp_time,
+      key_prefix=key_prefix,
+      namespace=namespace
+  )
+
+  if unset_ids:
+    return False
+  return cache.set(
+      key,
+      chunk_map.keys(),
+      time=exp_time,
+      namespace=namespace,
+  )
+
+
+def blob_get(cache, key, key_prefix="", namespace=None):
+  """Load object from memcache.
+
+  Object should be compressed and can be stored in divided state.
+  """
+  chunk_keys = cache.get(key, namespace=namespace)
+  if chunk_keys is None:
+    return None
+
+  chunk_map = cache.get_multi(
+      keys=chunk_keys,
+      key_prefix=key_prefix,
+      namespace=namespace
+  )
+  if not chunk_map:
+    return None
+
+  chunk_values = [chunk_map[chunk_key] for chunk_key in chunk_keys]
+  compressed_value = ''.join(chunk_values)
+
+  try:
+    return cPickle.loads(zlib.decompress(compressed_value))
+  except Exception:  # pylint: disable=broad-except
+    logger.error("Failed to uncompress object from memcache")
+    return None
+
+
+def create_chunk_map(value, chunk_size, key_prefix):
+  """Split value to several chunks of data and associate them with keys."""
+  chunk_map = collections.OrderedDict()
+  for pos in range(0, len(value), chunk_size):
+    chunk = value[pos:pos + chunk_size]
+    chunk_key = "%s:%d" % (key_prefix, pos)
+    chunk_map[chunk_key] = chunk
+  return chunk_map

--- a/test/integration/ggrc_basic_permissions/test_permissions_loading.py
+++ b/test/integration/ggrc_basic_permissions/test_permissions_loading.py
@@ -1,0 +1,43 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Test user permissions loading."""
+import mock
+
+from ggrc.models import all_models
+from integration.ggrc import TestCase, generator
+from integration.ggrc.api_helper import Api
+from integration.ggrc.models import factories
+
+from appengine import base
+
+
+@base.with_memcache
+class TestPermissionsLoading(TestCase):
+  """Test user permissions loading."""
+
+  def setUp(self):
+    super(TestPermissionsLoading, self).setUp()
+    self.api = Api()
+    self.generator = generator.ObjectGenerator()
+
+    self.control_id = factories.ControlFactory().id
+
+    _, user = self.generator.generate_person(user_role="Creator")
+    self.api.set_user(user)
+
+  def test_permissions_loading(self):
+    """Test if permissions created only once for GET requests."""
+    import ggrc_basic_permissions
+    with mock.patch(
+        "ggrc_basic_permissions.store_results_into_memcache",
+        side_effect=ggrc_basic_permissions.store_results_into_memcache
+    ) as store_perm:
+      self.api.get(all_models.Control, self.control_id)
+      store_perm.assert_called_once()
+      store_perm.call_count = 0
+
+      # On second GET permissions should be loaded from memcache
+      # but not created from scratch.
+      self.api.get(all_models.Control, self.control_id)
+      store_perm.assert_not_called()

--- a/test/unit/appengine/test_memcache_blob_operations.py
+++ b/test/unit/appengine/test_memcache_blob_operations.py
@@ -1,0 +1,29 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Test blob methods for working with memcache."""
+
+from unittest import TestCase
+
+from appengine import base
+
+from ggrc.utils import memcache
+
+
+@base.with_memcache
+class TestBlobMemcacheOperations(TestCase):
+  """Test memcache blob operations."""
+
+  def test_big_value_saving(self):
+    """Test storing in memcache huge chunk of data."""
+    # Create a structure with a lot of data. It should take more than 1 Mb.
+    data = {"a": {"b": ["test" * 10 for _ in range(10 ** 6)]}}
+    self.assertTrue(memcache.blob_set(self.memcache_client, "data", data))
+    self.assertGreater(
+        self.memcache_client.get_stats().get("bytes"),
+        memcache.MEMCACHE_MAX_ITEM_SIZE
+    )
+    self.assertEqual(
+        data,
+        memcache.blob_get(self.memcache_client, "data")
+    )


### PR DESCRIPTION
# Issue description

Application (with enabled memcache) will crash if user will have too a lot of ACL entries (got error on 443k of ACL and 470k of ACP). Problem is that we try to save permissions dict in memcache, but it has limitation for maximal value size - 1 Mb.

# Steps to test the changes

1. Setup environment with huge count of ACLs (size of compressed permissions dict should be bigger than 1 Mb).
2. Launch application with enabled memcache

Actual behavior: App is crashed.
Expected behavior: App is working.

# Solution description

Use blob get and set operations to store objects bigger 1 Mb

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).


# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
