### PR TITLE
GGRC-6259 Set status 'Won't fix(obsolete)' in case ticket was unlinked from Assessment or Issue

### DIFF
--- a/src/ggrc/models/hooks/issue_tracker/issue_tracker_params_builder.py
+++ b/src/ggrc/models/hooks/issue_tracker/issue_tracker_params_builder.py
@@ -33,12 +33,12 @@ class BaseIssueTrackerParamsBuilder(object):
 
   INITIAL_COMMENT_TMPL = (
       u"This bug was auto-generated to track a GGRC {model}. "
-      "Use the following link to find the {model} - {link}."
+      u"Use the following link to find the {model} - {link}."
   )
 
   DELETE_TMPL = (
       u"GGRC object has been deleted. GGRC changes will "
-      "no longer be tracked within this bug."
+      u"no longer be tracked within this bug."
   )
 
   DISABLE_TMPL = (
@@ -51,8 +51,8 @@ class BaseIssueTrackerParamsBuilder(object):
 
   COMMENT_TMPL = (
       u"A new comment is added by '{author}' to the '{model}': '{comment}'.\n"
-      "Use the following to link to get more information from the "
-      "GGRC '{model}'. Link - {link}"
+      u"Use the following to link to get more information from the "
+      u"GGRC '{model}'. Link - {link}"
   )
 
   ISSUE_TRACKER_INFO_FIELDS_TO_CHECK = (
@@ -153,7 +153,7 @@ class IssueParamsBuilder(BaseIssueTrackerParamsBuilder):
   )
   EXCLUDE_REPORTER_EMAIL_ERROR_MSG = (
       u"Issue tracker integration is not activated because the reporter "
-      "is an Global auditor."
+      u"is an Global auditor."
   )
   ISSUE_LINK_TMPL = (
       u"This bug was linked to a GGRC Issue. Use the following link to find "
@@ -252,6 +252,7 @@ class IssueParamsBuilder(BaseIssueTrackerParamsBuilder):
     return self.params
 
   def build_detach_comment(self, new_ticket):
+    """Build request for old Issue Tracker ticket detach."""
     self.params.add_comment(self.DETACH_TMPL.format(new_ticket_id=new_ticket))
     self.params.status = self.OBSOLET_ISSUE_STATUS
     return self.params
@@ -347,12 +348,13 @@ class IssueParamsBuilder(BaseIssueTrackerParamsBuilder):
 class AssessmentParamsBuilder(BaseIssueTrackerParamsBuilder):
   """Issue tracker query builder for GGRC Assessment object."""
   DETACH_TMPL = (
-      'Another bug {new_ticket_id} has been linked to track changes to the '
-      'GGRC Assessment. Changes to the GGRC Assessment will no longer be '
-      'tracked within this bug.'
+      "Another bug {new_ticket_id} has been linked to track changes to the "
+      "GGRC Assessment. Changes to the GGRC Assessment will no longer be "
+      "tracked within this bug."
   )
 
   def build_detach_comment(self, new_ticket):
+    """Build request for old Issue Tracker ticket detach."""
     self.params.add_comment(self.DETACH_TMPL.format(new_ticket_id=new_ticket))
     self.params.status = self.OBSOLET_ISSUE_STATUS
     return self.params

--- a/src/ggrc/models/hooks/issue_tracker/issue_tracker_params_builder.py
+++ b/src/ggrc/models/hooks/issue_tracker/issue_tracker_params_builder.py
@@ -62,6 +62,8 @@ class BaseIssueTrackerParamsBuilder(object):
       "issue_priority",
   )
 
+  OBSOLET_ISSUE_STATUS = "OBSOLETE"
+
   def __init__(self):
     """Basic initialization."""
     self.params = params_container.IssueTrackerParamsContainer()
@@ -251,6 +253,7 @@ class IssueParamsBuilder(BaseIssueTrackerParamsBuilder):
 
   def build_detach_comment(self, new_ticket):
     self.params.add_comment(self.DETACH_TMPL.format(new_ticket_id=new_ticket))
+    self.params.status = self.OBSOLET_ISSUE_STATUS
     return self.params
 
   def _handle_emails_from_response(self, response):
@@ -351,4 +354,5 @@ class AssessmentParamsBuilder(BaseIssueTrackerParamsBuilder):
 
   def build_detach_comment(self, new_ticket):
     self.params.add_comment(self.DETACH_TMPL.format(new_ticket_id=new_ticket))
+    self.params.status = self.OBSOLET_ISSUE_STATUS
     return self.params

--- a/test/integration/ggrc/integrations/test_assessment_integration.py
+++ b/test/integration/ggrc/integrations/test_assessment_integration.py
@@ -371,7 +371,7 @@ class TestIssueTrackerIntegration(SnapshotterBaseTestCase):
     # check detach comment was sent
     detach_comment_tmpl = params_builder.AssessmentParamsBuilder.DETACH_TMPL
     comment = detach_comment_tmpl.format(new_ticket_id=new_ticket_id)
-    expected_args = (TICKET_ID, {"comment": comment})
+    expected_args = (TICKET_ID, {"status": "OBSOLETE", "comment": comment})
     self.assertEqual(expected_args, update_mock.call_args[0])
 
   @mock.patch("ggrc.integrations.issues.Client.update_issue")

--- a/test/integration/ggrc/integrations/test_issue_integration.py
+++ b/test/integration/ggrc/integrations/test_issue_integration.py
@@ -375,7 +375,7 @@ class TestIssueIntegration(ggrc.TestCase):
     # check detach comment was sent
     detach_comment_template = params_builder.IssueParamsBuilder.DETACH_TMPL
     comment = detach_comment_template.format(new_ticket_id=new_ticket_id)
-    expected_args = (TICKET_ID, {"comment": comment})
+    expected_args = (TICKET_ID, {"status": "OBSOLETE", "comment": comment})
     self.assertEqual(expected_args, update_mock.call_args[0])
 
   @mock.patch.object(settings, "ISSUE_TRACKER_ENABLED", True)


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

It should be possible for user to change at the initial ticket status to 'Won't fix(obsolete)' in case Issue Tracker ticket was unlinked from Assessment and Issue.

# Steps to test the changes

- Create a new assessment or open any old assessment without linked ticket
- Turn Ticket tracker integration on, leave Ticket ID empty, add Hotlist ID, Component ID, P, S, Ticket Title
- Click 'Save and close': a ticket generated for the assessment (ticket 1). Save link to it.
- Click 'Edit assessment'
- Leave 'Ticket ID' empty again
- Click 'Save and close': a new ticket generated for the assessment (ticket 2)
- Open saved link to ticket 1.
Actual result: comment to ticket about unlinking added. Ticket has status 'Assigned'.
Expected result: comment to ticket about unlinking added. Ticket has status 'Won't Fix: Obsolete'.

# Solution description

I've just added additional code to build_detach method.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:run' labels to all open PRs with a label 'migration'
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
