### PR TITLE
GGRC-5932 Fix validation for mandatory CA with rich text type

### DIFF
--- a/src/ggrc-client/js/components/assessment/assessment-local-ca.js
+++ b/src/ggrc-client/js/components/assessment/assessment-local-ca.js
@@ -13,6 +13,7 @@ import {VALIDATION_ERROR, RELATED_ITEMS_LOADED} from '../../events/eventTypes';
 import tracker from '../../tracker';
 import Permission from '../../permission';
 import {getPageInstance} from '../../plugins/utils/current-page-utils';
+import {getPlainText} from '../../plugins/ggrc_utils';
 
 export default can.Component.extend({
   tag: 'assessment-local-ca',
@@ -143,27 +144,16 @@ export default can.Component.extend({
       });
     },
     performValidation: function (field) {
-      let value = field.value;
-      let isMandatory = field.validation.mandatory;
-
-      if (field.type === 'checkbox') {
-        if (value === '1') {
-          value = true;
-        } else if (value === '0') {
-          value = false;
-        }
-
-        field.attr({
-          validation: {
-            show: isMandatory,
-            valid: isMandatory ? !!(value) : true,
-            hasMissingInfo: false,
-          },
-        });
-      } else if (field.type === 'dropdown') {
+      if (field.type === 'dropdown') {
         this.performDropdownValidation(field);
       } else {
-        // validation for all other fields
+        let value = field.value;
+        let isMandatory = field.validation.mandatory;
+
+        if (field.type === 'text') {
+          value = getPlainText(value).trim();
+        }
+
         field.attr({
           validation: {
             show: isMandatory,

--- a/src/ggrc-client/js/components/diff/instance-gca-diff.js
+++ b/src/ggrc-client/js/components/diff/instance-gca-diff.js
@@ -6,7 +6,7 @@
 import {REFRESH_PROPOSAL_DIFF} from '../../events/eventTypes';
 import DiffBaseVM from './diff-base-vm';
 import template from './templates/instance-diff-items.mustache';
-import {getPersonInfo} from '../../../js/plugins/ggrc_utils';
+import {getPersonInfo} from '../../../js/plugins/utils/user-utils';
 import {formatDate} from '../../../js/plugins/utils/date-utils';
 const tag = 'instance-gca-diff';
 

--- a/src/ggrc-client/js/components/inline/inline.js
+++ b/src/ggrc-client/js/components/inline/inline.js
@@ -11,7 +11,7 @@ import '../form/fields/person-form-field';
 import '../form/fields/rich-text-form-field';
 import '../form/fields/text-form-field';
 import '../form/fields/numberbox-form-field';
-import {isInnerClick} from '../../plugins/ggrc_utils';
+import {isInnerClick, getPlainText} from '../../plugins/ggrc_utils';
 import template from './inline.mustache';
 
 export default can.Component.extend({
@@ -21,7 +21,16 @@ export default can.Component.extend({
     define: {
       isValid: {
         get() {
-          return !this.attr('mandatory') || !!this.attr('context.value');
+          if (this.attr('mandatory')) {
+            let value = this.attr('context.value');
+
+            if (this.attr('type') === 'text') {
+              value = getPlainText(value).trim();
+            }
+
+            return !!value;
+          }
+          return true;
         },
       },
       isShowContent: {

--- a/src/ggrc-client/js/components/related-objects/proposals/related-proposals-item.js
+++ b/src/ggrc-client/js/components/related-objects/proposals/related-proposals-item.js
@@ -11,7 +11,7 @@ import '../../diff/instance-gca-diff';
 import '../../diff/instance-mapping-fields-diff';
 import '../../diff/instance-list-fields-diff';
 import template from './templates/related-proposals-item.mustache';
-import {getPersonInfo} from '../../../plugins/ggrc_utils';
+import {getPersonInfo} from '../../../plugins/utils/user-utils';
 import {getFormattedLocalDate} from '../../../plugins/utils/date-utils';
 const tag = 'related-proposals-item';
 

--- a/src/ggrc-client/js/components/related-objects/revisions/related-revisions-item.js
+++ b/src/ggrc-client/js/components/related-objects/revisions/related-revisions-item.js
@@ -9,7 +9,7 @@ import '../../diff/instance-gca-diff';
 import '../../diff/instance-mapping-fields-diff';
 import '../../diff/instance-list-fields-diff';
 import '../../revision-history/restored-revision-comparer-config';
-import {getPersonInfo} from '../../../plugins/ggrc_utils';
+import {getPersonInfo} from '../../../plugins/utils/user-utils';
 import template from './templates/related-revisions-item.mustache';
 const tag = 'related-revisions-item';
 

--- a/src/ggrc-client/js/components/related-objects/revisions/tests/related-revisions-item_spec.js
+++ b/src/ggrc-client/js/components/related-objects/revisions/tests/related-revisions-item_spec.js
@@ -5,7 +5,7 @@
 
 import Component from '../related-revisions-item';
 import {getComponentVM} from '../../../../../js_specs/spec_helpers';
-import * as Utils from '../../../../plugins/ggrc_utils';
+import * as Utils from '../../../../plugins/utils/user-utils';
 
 describe('RelatedRevisionsItem component', () => {
   let viewModel;

--- a/src/ggrc-client/js/plugins/ggrc_utils.js
+++ b/src/ggrc-client/js/plugins/ggrc_utils.js
@@ -3,10 +3,7 @@
  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  */
 
-import RefreshQueue from '../models/refresh_queue';
 import {getRolesForType} from '../plugins/utils/acl-utils';
-import {notifier} from '../plugins/utils/notifiers-utils';
-import Person from '../models/business-models/person';
 
 /**
  * A module containing various utility functions.
@@ -82,37 +79,6 @@ function inViewport(el) {
   window.innerWidth > bounds.right;
 
   return isVisible;
-}
-
-function getPersonInfo(person) {
-  const dfd = can.Deferred();
-  let actualPerson;
-
-  if (!person || !person.id) {
-    dfd.resolve(person);
-    return dfd;
-  }
-
-  actualPerson = Person.findInCacheById(person.id) || {};
-  if (actualPerson.email) {
-    dfd.resolve(actualPerson);
-  } else {
-    actualPerson = new Person({id: person.id});
-    new RefreshQueue()
-      .enqueue(actualPerson)
-      .trigger()
-      .done((personItem) => {
-        personItem = Array.isArray(personItem) ? personItem[0] : personItem;
-        dfd.resolve(personItem);
-      })
-      .fail(function () {
-        notifier('error',
-          'Failed to fetch data for person ' + person.id + '.');
-        dfd.reject();
-      });
-  }
-
-  return dfd;
 }
 
 function getPickerElement(picker) {
@@ -236,7 +202,6 @@ export {
   applyTypeFilter,
   isInnerClick,
   inViewport,
-  getPersonInfo,
   getPickerElement,
   loadScript,
   hasPending,

--- a/src/ggrc-client/js/plugins/utils/custom-attribute/custom-attribute-help-utils.js
+++ b/src/ggrc-client/js/plugins/utils/custom-attribute/custom-attribute-help-utils.js
@@ -3,6 +3,8 @@
  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 */
 
+import {getPlainText} from '../../ggrc_utils';
+
 /**
  * Checks if the [custom attribute object]{@link CustomAttributeObject} has
  * an empty value.
@@ -13,7 +15,7 @@ function hasEmptyValue(caObject) {
   const value = caObject.value;
 
   if (typeof value === 'string') {
-    return _.flow(_.trim, _.isEmpty)(value);
+    return _.flow(getPlainText, _.trim, _.isEmpty)(value);
   }
 
   return Boolean(value) === false;

--- a/src/ggrc-client/js/plugins/utils/user-utils.js
+++ b/src/ggrc-client/js/plugins/utils/user-utils.js
@@ -4,6 +4,8 @@
  */
 
 import Person from '../../models/business-models/person';
+import RefreshQueue from '../../models/refresh_queue';
+import {notifier} from './notifiers-utils';
 
 function cacheCurrentUser() {
   Person.model(GGRC.current_user);
@@ -42,8 +44,40 @@ function updateUserProfile(profile) {
   return result;
 }
 
+function getPersonInfo(person) {
+  const dfd = can.Deferred();
+  let actualPerson;
+
+  if (!person || !person.id) {
+    dfd.resolve(person);
+    return dfd;
+  }
+
+  actualPerson = Person.findInCacheById(person.id) || {};
+  if (actualPerson.email) {
+    dfd.resolve(actualPerson);
+  } else {
+    actualPerson = new Person({id: person.id});
+    new RefreshQueue()
+      .enqueue(actualPerson)
+      .trigger()
+      .done((personItem) => {
+        personItem = Array.isArray(personItem) ? personItem[0] : personItem;
+        dfd.resolve(personItem);
+      })
+      .fail(function () {
+        notifier('error',
+          'Failed to fetch data for person ' + person.id + '.');
+        dfd.reject();
+      });
+  }
+
+  return dfd;
+}
+
 export {
   cacheCurrentUser,
   loadUserProfile,
   updateUserProfile,
+  getPersonInfo,
 };


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Incorrect validation for mandatory CA with rich text type.

# Steps to test the changes

`Case 1 (create/edit popup):`
1. Log in to GGRC as admin user
2. Open Admin page and create mandatory 'rich text' GCA for any object, e.g. Access Group
3. Invoke new Access Group popup (or edit already existing)
4. Type only spaces in rich text CA and click out of field: 'cannot be blank' disappears 
5. Fill out required fields and save Access Group

`Case 2 (edit inline attr):`
1. Open Access Group with GCA
2. Try to edit mandatory rich text CA on Info panel (via 'pencil' icon)

**Actual Result:** Mandatory CA with rich text type is valid if user types space and Access Group can be saved
**Expected Result:** 'rich text' CA with spaces in value is invalid, cannot be saved, red border appears.

`Case 3 (local CA):`
1. Open assessment with LCA
2. Type only spaces in rich text LCA and click out of field

**Actual Result:** Mandatory LCA with rich text type is marked as valid if user types space and Assessment can be completed
**Expected Result:** 'rich text' CA with spaces in value is invalid, Assessment can be completed ('This field is required.' appears).

# Solution description

Rich-text with spaces was valid because the value in this case looks like `<p>     </p>`.
The solution is to use the value in validation, which was transformed via **getPlainText** util and trimmed.

**getPersonInfo** has been moved from ggrc_utils to user-utils to avoid a circular dependency: **ggrc-utils** imports Person -> Person imports Cacheable -> Cacheable imports custom-attribute-access -> custom-attribute-access imports custom-attribute-validations -> custom-attribute-validations imports custom-attribute-help-utils -> custom-attribute-help-utils imports **ggrc_utils**

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:run' labels to all open PRs with a label 'migration'
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
