### PR TITLE
GGRC-6132 Do migration on behalf of system user

### DIFF
--- a/src/ggrc/migrations/versions/20181206063405_5bb7c74d2089_add_modified_by_id_column_to_objects.py
+++ b/src/ggrc/migrations/versions/20181206063405_5bb7c74d2089_add_modified_by_id_column_to_objects.py
@@ -1,0 +1,43 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Add modified_by_id column to objects_without_revisions
+
+Create Date: 2018-12-06 06:34:05.917633
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+import sqlalchemy as sa
+
+from alembic import op
+
+from ggrc.migrations.utils.migrator import get_migration_user_id
+
+# revision identifiers, used by Alembic.
+revision = '5bb7c74d2089'
+down_revision = '8737b9b51407'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+
+  op.add_column(
+      'objects_without_revisions',
+      sa.Column('modified_by_id', sa.Integer, nullable=True)
+  )
+
+  # It's possible that the table already contains some records added by
+  # previous migration scripts.
+  # We need to set modified_by_id to default migrator for those records
+  rev_table = sa.sql.table('objects_without_revisions',
+                           sa.sql.column('modified_by_id', sa.Integer))
+  migrator_id = get_migration_user_id(op.get_bind())
+  op.execute(rev_table.update().values(modified_by_id=migrator_id))
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+
+  raise Exception("Downgrade is not supported")


### PR DESCRIPTION
# Issue description

After migration users see different users in a change log of objects.
Current logic for new or modified object - `revisions.modified_by_id` is set to `object.modified_by_id` (if value in object is not specified, user who runs migrations is used)
Current logic for deleted object - `revisions.modified_by_id` is set to `last_object_revision.modified_by_id`(if value in object is not specified, user who runs migrations is used)

The goal is to create object revisions on behalf of system user instead of different user. System user is default migrator.

# Steps to test the changes

1. Set default migrator in config
2. Create and run test migration which creates, changes and removes objects
3. Login as non-migrator user. run `create_missing_revisions` step after migration.
4. Ensure that in Revisions table `modified_by_id` is set to migrator's id for all objects modified during migration

# Step for migration
1. Create new migrator user in GGRC instance
2. [Optional] Set any system role for the new migrator, otherwise any references to this user in Web UI will be followed by "(inactive user)" red italic string.
3. Set default migrator in config to the new migrator email
4. Run migration
5. Run `create_missing_revisions` job


# Solution description

1. Add new column `modified_by_id` in table `objects_without_revisions`, set allow to set exact value for `modified_by_id`, default is migrator user ID.
2. in `do_missing_revisions` change logic for calculation of `revision.modified_by_id` to the following: use `modified_by_id` from `objects_without_revisions`.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:run' labels to all open PRs with a label 'migration'
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
