### PR TITLE
GGRC-6462 Add CAD field to AssessmentTemplate model

### DIFF
--- a/src/ggrc-client/js/models/business-models/assessment-template.js
+++ b/src/ggrc-client/js/models/business-models/assessment-template.js
@@ -127,5 +127,9 @@ export default Cacheable('CMS.Models.AssessmentTemplate', {
         this.attr('audit', pageInstance);
       }
     }
+
+    if (!this.custom_attribute_definitions) {
+      this.attr('custom_attribute_definitions', new can.List());
+    }
   },
 });

--- a/src/ggrc-client/js/models/business-models/tests/assessment_template_spec.js
+++ b/src/ggrc-client/js/models/business-models/tests/assessment_template_spec.js
@@ -1,0 +1,27 @@
+/*
+ Copyright (C) 2018 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+import AssessmentTemplate from '../assessment-template';
+import {makeFakeInstance} from '../../../../js_specs/spec_helpers';
+
+describe('AssessmentTemplate model', () => {
+  let instance;
+
+  beforeEach(() => {
+    instance = makeFakeInstance({model: AssessmentTemplate})();
+  });
+
+  describe('form_preload method', () => {
+    it('adds custom_attribute_definitions field', () => {
+      expect(instance.custom_attribute_definitions)
+        .toBeUndefined();
+
+      instance.form_preload();
+
+      expect(instance.custom_attribute_definitions instanceof can.List)
+        .toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
# Issue description

LCA is not saving in New Assessment template popup.

# Steps to test the changes

Steps to reproduce:

1. Create a program, control in scope of the program, audit
2. Open Audit page
3. Create Assessment template with any type of LCA (text, date)
4. Open Edit Assessment Template popup and look at the LCA: is missed

Actual Result: LCA is not saving in New Assessment template popup
Expected Result: LCA should be saved in New Assessment template popup

Additional case:

Steps to reproduce:

1. Create a program, control in scope of the program, audit
2. Open Audit page
3. Create Assessment template with any type of LCA (text, date)
4. Open new Assessment template modal

Actual Result: LCA appears again
Expected Result: LCAs which were added previously should not appear on new Assessment template modal

# Solution description

Creation of `custom_attribute_definitions` field was removed previously. At the same time `AssessmentTemplate` model is not custom attributable and this is the reason why `custom_attribute_definitions` is not created in `cacheable`. The solution is to add  `custom_attribute_definitions` field in case it does not exist.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:run' labels to all open PRs with a label 'migration'
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
