### PR TITLE
GGRC-5792 Incorrect behavior of 'Issue Title' field for Issue object

### DIFF
--- a/src/ggrc/models/hooks/issue_tracker/issue_tracker_params_builder.py
+++ b/src/ggrc/models/hooks/issue_tracker/issue_tracker_params_builder.py
@@ -60,6 +60,7 @@ class BaseIssueTrackerParamsBuilder(object):
       "hotlist_id",
       "issue_severity",
       "issue_priority",
+      "title",
   )
 
   OBSOLET_ISSUE_STATUS = "OBSOLETE"

--- a/test/integration/ggrc/integrations/test_issue_integration.py
+++ b/test/integration/ggrc/integrations/test_issue_integration.py
@@ -145,6 +145,10 @@ class TestIssueIntegration(ggrc.TestCase):
                           "issue_id": TICKET_ID}},
        {"comment": "Changes to this GGRC object will no longer be "
                    "tracked within this bug."}),
+      ({"issue_tracker": {"title": "test_iti_title",
+                          "enabled": True,
+                          "issue_id": TICKET_ID}},
+       {"title": "test_iti_title"}),
   )
   @ddt.unpack
   @mock.patch("ggrc.integrations.issues.Client.update_issue")
@@ -601,6 +605,9 @@ class TestDisabledIssueIntegration(ggrc.TestCase):
                          "enabled": False}},
       {"issue_tracker": {"issue_id": TICKET_ID,
                          "issue_severity": "S2",
+                         "enabled": False}},
+      {"issue_tracker": {"issue_id": TICKET_ID,
+                         "title": "title1",
                          "enabled": False}},
   )
   @mock.patch("ggrc.integrations.issues.Client.update_issue")


### PR DESCRIPTION
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [x] ~~GGRC-5791~~


# Issue description

We should sync issue title to Issue Tracker when we change it on GGRC side.

# Steps to test the changes

Steps to reproduce:
1. Create GGRC Issue with Issue Tracker turned ON
Hotlist ID: 700706
Component ID: 64445
2. Open Edit Issue modal and update 'Issue Title' field > Save
Expected Result: 'Issue Title' field should be updated. Changes should be saved.The following behavior should be for "Issue Title" filed:

# Solution description

I've just added title sync to our hook.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:run' labels to all open PRs with a label 'migration'
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
