### PR TITLE
GGRC-4541 Fix import a task group with at least two task group assignees.

### DIFF
--- a/src/ggrc/converters/errors.py
+++ b/src/ggrc/converters/errors.py
@@ -184,3 +184,12 @@ TASKGROUP_MAPPED_TO_ANOTHER_WORKFLOW = (u"Line {line}: TaskGroup '{slug}' "
                                         u"and mapped to another "
                                         u"workflow. Please, use different "
                                         u"code for this TaskGroup")
+
+MULTIPLE_ASSIGNEES = (u"Line {line}: Only one assignee (column "
+                      u"'{column_name}') can be imported. Please click "
+                      u"'Proceed' to choose the first user in alphabetical "
+                      u"order as an assignee.")
+
+NO_VALID_USERS_ERROR = (u"Line {line}: Required field '{column_name}' "
+                        u"contains not valid users. Only registered users "
+                        u"can be assigned to Task Groups.")

--- a/src/ggrc_workflows/models/task_group.py
+++ b/src/ggrc_workflows/models/task_group.py
@@ -78,6 +78,8 @@ class TaskGroup(roleable.Roleable,
       "contact": {
           "display_name": "Assignee",
           "mandatory": True,
+          "description": ("One person could be added "
+                          "as a Task Group assignee")
       },
       "secondary_contact": None,
       "start_date": None,

--- a/test/integration/ggrc/converters/test_import_risk_assessment.py
+++ b/test/integration/ggrc/converters/test_import_risk_assessment.py
@@ -26,8 +26,8 @@ class TestRiskAssessmentImport(TestCase):
   def test_ra_import_counsels(self, counsel, expected_warnings):
     """Tests Risk Counsel for Risk Assessment imported and set correctly"""
     with factories.single_commit():
-      risk_assessment = factories.RiskAssessmentFactory()
       program = factories.ProgramFactory()
+      risk_assessment = factories.RiskAssessmentFactory(program=program)
       factories.PersonFactory(email="valid_user@example.com")
 
     data = OrderedDict([
@@ -66,8 +66,8 @@ class TestRiskAssessmentImport(TestCase):
   def test_ra_import_wrong_counsels(self, counsel, expected_warnings):
     """Test import Risk Assessment counsel failed"""
     with factories.single_commit():
-      risk_assessment = factories.RiskAssessmentFactory()
       program = factories.ProgramFactory()
+      risk_assessment = factories.RiskAssessmentFactory(program=program)
       factories.PersonFactory(email="valid_user@example.com")
 
     data = OrderedDict([
@@ -100,8 +100,8 @@ class TestRiskAssessmentImport(TestCase):
     """Tests Risk Manager for Risk Assessment imported and set correctly"""
 
     with factories.single_commit():
-      risk_assessment = factories.RiskAssessmentFactory()
       program = factories.ProgramFactory()
+      risk_assessment = factories.RiskAssessmentFactory(program=program)
       factories.PersonFactory(email="valid_user@example.com")
 
     data = OrderedDict([
@@ -141,8 +141,8 @@ class TestRiskAssessmentImport(TestCase):
     """Test import Risk Assessment manager failed"""
 
     with factories.single_commit():
-      risk_assessment = factories.RiskAssessmentFactory()
       program = factories.ProgramFactory()
+      risk_assessment = factories.RiskAssessmentFactory(program=program)
       factories.PersonFactory(email="valid_user@example.com")
 
     data = OrderedDict([

--- a/test/integration/ggrc/converters/test_import_risk_assessment.py
+++ b/test/integration/ggrc/converters/test_import_risk_assessment.py
@@ -1,0 +1,166 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+"""Tests for Risk Assessment import."""
+
+from collections import OrderedDict
+import datetime
+
+import ddt
+
+from ggrc.converters import errors
+from ggrc.models import all_models
+from integration.ggrc import TestCase
+from integration.ggrc.models import factories
+
+
+@ddt.ddt
+class TestRiskAssessmentImport(TestCase):
+  """Risk Assessment Import Test Class"""
+
+  @ddt.data(
+      ("valid_user@example.com,", []),
+      ("user2@example.com,\nvalid_user@example.com",
+       [errors.MULTIPLE_ASSIGNEES.format(line=3, column_name="Risk Counsel")]),
+  )
+  @ddt.unpack
+  def test_ra_import_counsels(self, counsel, expected_warnings):
+    """Tests Risk Counsel for Risk Assessment imported and set correctly"""
+    with factories.single_commit():
+      risk_assessment = factories.RiskAssessmentFactory()
+      program = factories.ProgramFactory()
+      factories.PersonFactory(email="valid_user@example.com")
+
+    data = OrderedDict([
+        ("object_type", "RiskAssessment"),
+        ("code", risk_assessment.slug),
+        ("program", program.slug),
+        ("title", "RA-1"),
+        ("start date", datetime.date(2018, 10, 22)),
+        ("end date", datetime.date(2018, 10, 31)),
+        ("risk counsel", counsel),
+    ])
+    expected_messages = {
+        "Risk Assessment": {
+            "row_warnings": set(expected_warnings),
+        },
+    }
+    response = self.import_data(data)
+    self._check_csv_response(response, expected_messages)
+    risk_assessment = all_models.RiskAssessment.query.one()
+    self.assertEqual(risk_assessment.ra_counsel.email,
+                     "valid_user@example.com")
+
+  @ddt.data(
+      (" ;,", []),
+      ("user2@example.com;\nuser3@example.com",
+       [
+           errors.MULTIPLE_ASSIGNEES.format(line=3,
+                                            column_name="Risk Counsel"),
+           errors.UNKNOWN_USER_WARNING.format(line=3,
+                                              email="user2@example.com"),
+           errors.UNKNOWN_USER_WARNING.format(line=3,
+                                              email="user3@example.com"),
+       ]),
+  )
+  @ddt.unpack
+  def test_ra_import_wrong_counsels(self, counsel, expected_warnings):
+    """Test import Risk Assessment counsel failed"""
+    with factories.single_commit():
+      risk_assessment = factories.RiskAssessmentFactory()
+      program = factories.ProgramFactory()
+      factories.PersonFactory(email="valid_user@example.com")
+
+    data = OrderedDict([
+        ("object_type", "RiskAssessment"),
+        ("code", risk_assessment.slug),
+        ("program", program.slug),
+        ("title", "RA-1"),
+        ("start date", datetime.date(2018, 10, 22)),
+        ("end date", datetime.date(2018, 10, 31)),
+        ("risk counsel", counsel),
+    ])
+
+    expected_messages = {
+        "Risk Assessment": {
+            "row_warnings": set(expected_warnings),
+        },
+    }
+    response = self.import_data(data)
+    self._check_csv_response(response, expected_messages)
+    risk_assessment = all_models.RiskAssessment.query.one()
+    self.assertFalse(risk_assessment.ra_counsel)
+
+  @ddt.data(
+      ("valid_user@example.com", []),
+      ("user2@example.com\nvalid_user@example.com",
+       [errors.MULTIPLE_ASSIGNEES.format(line=3, column_name="Risk Manager")]),
+  )
+  @ddt.unpack
+  def test_ra_import_managers(self, manager, expected_warnings):
+    """Tests Risk Manager for Risk Assessment imported and set correctly"""
+
+    with factories.single_commit():
+      risk_assessment = factories.RiskAssessmentFactory()
+      program = factories.ProgramFactory()
+      factories.PersonFactory(email="valid_user@example.com")
+
+    data = OrderedDict([
+        ("object_type", "RiskAssessment"),
+        ("code", risk_assessment.slug),
+        ("program", program.slug),
+        ("title", "RA-1"),
+        ("start date", datetime.date(2018, 10, 22)),
+        ("end date", datetime.date(2018, 10, 31)),
+        ("risk manager", manager),
+    ])
+
+    expected_messages = {
+        "Risk Assessment": {
+            "row_warnings": set(expected_warnings),
+        },
+    }
+    response = self.import_data(data)
+    self._check_csv_response(response, expected_messages)
+    risk_assessment = all_models.RiskAssessment.query.one()
+    self.assertEqual(risk_assessment.ra_manager.email,
+                     "valid_user@example.com")
+
+  @ddt.data(
+      ("", []),
+      ("user2@example.com\nuser3@example.com", [
+          errors.MULTIPLE_ASSIGNEES.format(line=3,
+                                           column_name="Risk Manager"),
+          errors.UNKNOWN_USER_WARNING.format(line=3,
+                                             email="user2@example.com"),
+          errors.UNKNOWN_USER_WARNING.format(line=3,
+                                             email="user3@example.com"),
+      ]),
+  )
+  @ddt.unpack
+  def test_ra_import_wrong_managers(self, manager, expected_warnings):
+    """Test import Risk Assessment manager failed"""
+
+    with factories.single_commit():
+      risk_assessment = factories.RiskAssessmentFactory()
+      program = factories.ProgramFactory()
+      factories.PersonFactory(email="valid_user@example.com")
+
+    data = OrderedDict([
+        ("object_type", "RiskAssessment"),
+        ("code", risk_assessment.slug),
+        ("program", program.slug),
+        ("title", "RA-1"),
+        ("start date", datetime.date(2018, 10, 22)),
+        ("end date", datetime.date(2018, 10, 31)),
+        ("risk manager", manager),
+    ])
+
+    expected_messages = {
+        "Risk Assessment": {
+            "row_warnings": set(expected_warnings),
+        },
+    }
+    response = self.import_data(data)
+    self._check_csv_response(response, expected_messages)
+    risk_assessment = all_models.RiskAssessment.query.one()
+    self.assertFalse(risk_assessment.ra_manager)

--- a/test/integration/ggrc_workflows/converters/test_import_cycle.py
+++ b/test/integration/ggrc_workflows/converters/test_import_cycle.py
@@ -1,0 +1,101 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+"""Tests for Cycle import."""
+
+import datetime
+from collections import OrderedDict
+
+import ddt
+
+from ggrc.converters import errors
+from ggrc.models import all_models
+
+from integration.ggrc.models import factories
+from integration.ggrc_workflows.generator import WorkflowsGenerator
+from integration.ggrc_workflows.helpers.workflow_test_case \
+    import WorkflowTestCase
+from integration.ggrc_workflows.models import factories as wf_factories
+
+
+@ddt.ddt
+class TestCycleImport(WorkflowTestCase):
+  """Tests for Cycle model import"""
+
+  def setUp(self):
+    super(TestCycleImport, self).setUp()
+    self.generator = WorkflowsGenerator()
+
+  @ddt.data(
+      ("valid_user@example.com", []),
+      ("user2@example.com\nvalid_user@example.com",
+       [errors.MULTIPLE_ASSIGNEES.format(line=3, column_name="Assignee")]),
+  )
+  @ddt.unpack
+  def test_assignee_updated(self, assignee, expected_warnings):
+    """Tests updating cycle assignee via import"""
+    with factories.single_commit():
+      factories.PersonFactory(email="valid_user@example.com")
+      workflow = wf_factories.WorkflowFactory()
+      group = wf_factories.TaskGroupFactory(workflow=workflow)
+      wf_factories.TaskGroupTaskFactory(
+          task_group=group,
+          start_date=datetime.date(2017, 2, 28),
+          end_date=datetime.date(2017, 2, 28) + datetime.timedelta(days=4)
+      )
+    _, cycle = self.generator.generate_cycle(workflow)
+    data = OrderedDict([
+        ("object_type", "Cycle"),
+        ("code", cycle.slug),
+        ("title", cycle.title),
+        ("Assignee", assignee),
+    ])
+
+    response = self.import_data(data)
+    expected_messages = {
+        "Cycle": {
+            "row_warnings": set(expected_warnings),
+        },
+    }
+    self._check_csv_response(response, expected_messages)
+    cycle = all_models.Cycle.query.one()
+    self.assertEqual(cycle.contact.email, "valid_user@example.com")
+
+  @ddt.data(
+      ("", []),
+      ("user2@example.com\nuser3@example.com",
+       [
+           errors.MULTIPLE_ASSIGNEES.format(line=3, column_name="Assignee"),
+           errors.UNKNOWN_USER_WARNING.format(line=3,
+                                              email="user2@example.com"),
+           errors.UNKNOWN_USER_WARNING.format(line=3,
+                                              email="user3@example.com")
+       ]),
+  )
+  @ddt.unpack
+  def test_assignee_not_updated(self, assignee, expected_warnings):
+    """Tests cycle assignee wasn't updated with wrong user"""
+    with factories.single_commit():
+      workflow = wf_factories.WorkflowFactory()
+      group = wf_factories.TaskGroupFactory(workflow=workflow)
+      wf_factories.TaskGroupTaskFactory(
+          task_group=group,
+          start_date=datetime.date(2017, 2, 28),
+          end_date=datetime.date(2017, 2, 28) + datetime.timedelta(days=4)
+      )
+    _, cycle = self.generator.generate_cycle(workflow)
+    data = OrderedDict([
+        ("object_type", "Cycle"),
+        ("code", cycle.slug),
+        ("title", cycle.title),
+        ("Assignee", assignee),
+    ])
+
+    response = self.import_data(data)
+    expected_messages = {
+        "Cycle": {
+            "row_warnings": set(expected_warnings),
+        },
+    }
+    self._check_csv_response(response, expected_messages)
+    cycle = all_models.Cycle.query.one()
+    self.assertFalse(cycle.contact)

--- a/test/integration/ggrc_workflows/converters/test_import_task_group.py
+++ b/test/integration/ggrc_workflows/converters/test_import_task_group.py
@@ -21,6 +21,20 @@ from integration.ggrc_workflows.models import factories as wf_factories
 class TestTaskGroupImport(WorkflowTestCase):
   """Tests related to TaskGroup import."""
 
+  WF_SLUG = "WORKFLOW-1"
+  TG_SLUG = "TASKGROUP-1"
+
+  def setUp(self):
+    super(TestTaskGroupImport, self).setUp()
+    with factories.single_commit():
+      workflow = wf_factories.WorkflowFactory(slug=self.WF_SLUG)
+      task_group = wf_factories.TaskGroupFactory(
+          slug=self.TG_SLUG,
+          workflow=workflow
+      )
+      wf_factories.TaskGroupTaskFactory(task_group=task_group)
+      factories.PersonFactory(email="valid_user@example.com")
+
   @ddt.data(
       (all_models.OrgGroup.__name__, True),
       (all_models.Vendor.__name__, True),
@@ -51,19 +65,16 @@ class TestTaskGroupImport(WorkflowTestCase):
   )
   @ddt.unpack
   def test_task_group_import_objects(self, model_name, is_mapped):
-    """"Test import TaskGroup with mapping to object: {0}"""
-    wf_slug = "WORKFLOW-1"
-    tg_slug = "TASKGROUP-1"
+    """"Tests import TaskGroup with mapping to object: {0}."""
+
     mapped_slug = "MAPPEDOBJECT-1"
     with factories.single_commit():
       factories.get_model_factory(model_name)(slug=mapped_slug)
-      workflow = wf_factories.WorkflowFactory(slug=wf_slug)
-      wf_factories.TaskGroupFactory(slug=tg_slug, workflow=workflow)
 
     tg_data = collections.OrderedDict([
         ("object_type", all_models.TaskGroup.__name__),
-        ("code", tg_slug),
-        ("workflow", wf_slug),
+        ("code", self.TG_SLUG),
+        ("workflow", self.WF_SLUG),
         ("objects", "{}: {}".format(model_name, mapped_slug))
     ])
     result = self.import_data(tg_data)
@@ -83,6 +94,43 @@ class TestTaskGroupImport(WorkflowTestCase):
           )
       )
 
+  def test_tgs_with_existing_slugs(self):
+    """Tests import of task group with existing slug.
+
+    When task groups with existing slugs are imported
+    they shouldn't be unmapped from the previous workflow.
+    Proper error should be displayed.
+    """
+
+    second_wf_slug = "WORKFLOW-2"
+    wf_factories.WorkflowFactory(slug=second_wf_slug)
+
+    second_tg_data = collections.OrderedDict([
+        ("object_type", all_models.TaskGroup.__name__),
+        ("code", self.TG_SLUG),
+        ("workflow", second_wf_slug)
+    ])
+    response = self.import_data(second_tg_data)
+
+    expected_error = errors.TASKGROUP_MAPPED_TO_ANOTHER_WORKFLOW.format(
+        line=3,
+        slug=self.TG_SLUG,
+    )
+
+    self.assertEquals([expected_error], response[0]['row_errors'])
+
+    first_wf = db.session.query(models.Workflow).filter(
+        models.Workflow.slug == self.WF_SLUG
+    ).one()
+    second_wf = db.session.query(models.Workflow).filter(
+        models.Workflow.slug == second_wf_slug
+    ).one()
+
+    self.assertEqual(db.session.query(models.TaskGroup).filter(
+        models.TaskGroup.workflow_id == first_wf.id).count(), 1)
+    self.assertEqual(db.session.query(models.TaskGroup).filter(
+        models.TaskGroup.workflow_id == second_wf.id).count(), 0)
+
 
 @ddt.ddt
 class TestTaskGroupTaskImport(WorkflowTestCase):
@@ -95,18 +143,19 @@ class TestTaskGroupTaskImport(WorkflowTestCase):
                                                  unit=models.Workflow.DAY_UNIT)
     self.task_group = wf_factories.TaskGroupFactory(workflow=self.workflow)
 
-  @ddt.data((datetime.date(2018, 7, 13), datetime.date(2018, 7, 21),
-             {u"Line 3: Task Due Date can not occur on weekends."}),
-            (datetime.date(2018, 7, 14), datetime.date(2018, 7, 20),
-             {u"Line 3: Task Start Date can not occur on weekends."}),
-            (datetime.date(2018, 7, 14), datetime.date(2018, 7, 21),
-             {u"Line 3: Task Due Date can not occur on weekends.",
-              u"Line 3: Task Start Date can not occur on weekends."})
-            )
+  @ddt.data(
+      (datetime.date(2018, 7, 13), datetime.date(2018, 7, 21),
+       {u"Line 3: Task Due Date can not occur on weekends."}),
+      (datetime.date(2018, 7, 14), datetime.date(2018, 7, 20),
+       {u"Line 3: Task Start Date can not occur on weekends."}),
+      (datetime.date(2018, 7, 14), datetime.date(2018, 7, 21),
+       {u"Line 3: Task Due Date can not occur on weekends.",
+        u"Line 3: Task Start Date can not occur on weekends."})
+  )
   @ddt.unpack
   def test_task_group_task_weekend(self, start_date, end_date,
                                    expected_errors):
-    """Test TaskGroupTask import can't start/end on weekends"""
+    """Tests TaskGroupTask import can't start/end on weekends."""
 
     tgt_data = collections.OrderedDict([
         ("object_type", "Task Group Task"),
@@ -143,7 +192,7 @@ class TestTaskGroupTaskImport(WorkflowTestCase):
   @ddt.unpack
   def test_import_change_task_date(self, start_date, end_date,
                                    expected_errors):
-    """Test import can't change start/end from weekdays to weekends"""
+    """Tests import can't change start/end from weekdays to weekends."""
 
     wf_factories.TaskGroupTaskFactory(
         task_group=self.task_group,
@@ -183,56 +232,3 @@ class TestTaskGroupTaskImport(WorkflowTestCase):
     self._check_csv_response(response, expected_messages)
     self.assertEquals(start_date_before, start_date_after)
     self.assertEquals(end_date_before, end_date_after)
-
-
-class TestImportTasksGroupsWithExistingSlugs(WorkflowTestCase):
-  """
-  Test case when task groups with existing slugs
-  are imported.
-  """
-  def test_import_tgs_with_existing_slugs(self):
-    """
-    When tgs with existing slugs are imported
-    they shouldn't be unmapped from the previous wf.
-    Proper error should be displayed.
-    """
-    # pylint: disable=invalid-name
-    first_wf_slug = "WORKFLOW-1"
-    first_tg_slug = "TASKGROUP-1"
-    with factories.single_commit():
-      # create first workflow, it's tg and tgt
-      first_wf = wf_factories.WorkflowFactory(slug=first_wf_slug)
-      first_task_group = wf_factories.TaskGroupFactory(slug=first_tg_slug,
-                                                       workflow=first_wf)
-      wf_factories.TaskGroupTaskFactory(task_group=first_task_group)
-
-    second_wf_slug = "WORKFLOW-2"
-
-    # create second workflow
-    wf_factories.WorkflowFactory(slug=second_wf_slug)
-
-    # second tg has slug equals to the slug of the first tg
-    second_tg_data = collections.OrderedDict([
-        ("object_type", all_models.TaskGroup.__name__),
-        ("code", first_tg_slug),
-        ("workflow", second_wf_slug)
-    ])
-    response = self.import_data(second_tg_data)
-
-    expected_error = (u"Line 3: TaskGroup '%s' already "
-                      u"exists in the system and mapped "
-                      u"to another workflow. Please, "
-                      u"use different code for this TaskGroup" % first_tg_slug)
-    self.assertEquals([expected_error], response[0]['row_errors'])
-
-    first_wf = db.session.query(models.Workflow).filter(
-        models.Workflow.slug == first_wf_slug
-    ).one()
-    second_wf = db.session.query(models.Workflow).filter(
-        models.Workflow.slug == second_wf_slug
-    ).one()
-
-    self.assertEqual(db.session.query(models.TaskGroup).filter(
-        models.TaskGroup.workflow_id == first_wf.id).count(), 1)
-    self.assertEqual(db.session.query(models.TaskGroup).filter(
-        models.TaskGroup.workflow_id == second_wf.id).count(), 0)

--- a/test/unit/ggrc/converters/handlers/test_user_column_handler.py
+++ b/test/unit/ggrc/converters/handlers/test_user_column_handler.py
@@ -1,0 +1,43 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Tests for the UserColumnHandler class"""
+
+import unittest
+
+import ddt
+import mock
+
+from ggrc.converters.handlers import handlers
+
+
+@ddt.ddt
+class UserColumnHandlerTestCase(unittest.TestCase):
+  """Base class for UserColumnHandler tests."""
+
+  def setUp(self):
+    row_converter = mock.MagicMock()
+    self.handler = handlers.UserColumnHandler(row_converter, "key")
+
+  @ddt.data(
+      ("", []),
+      ("aa@a.com", ["aa@a.com"]),
+      ("aa@a.com ", ["aa@a.com"]),
+      ("aa@a.com,", ["aa@a.com"]),
+      ("aa@a.com;", ["aa@a.com"]),
+      ("aa@a.com\n", ["aa@a.com"]),
+      ("   aa@a.com,,,", ["aa@a.com"]),
+      ("\n\n\naa@a.com;;;", ["aa@a.com"]),
+      (",;aa@a.com;\n,", ["aa@a.com"]),
+      ("aa@a.com, bb@b.com ", ["aa@a.com", "bb@b.com"]),
+      ("; \n \n;;;aa@a.com,\n;,;bb@b.com     \n", ["aa@a.com", "bb@b.com"]),
+      ("aa@a.com\nbb@b.com;, dd@d.com; , cc@c.com", ["aa@a.com", "bb@b.com",
+                                                     "cc@c.com", "dd@d.com"]),
+  )
+  @ddt.unpack
+  def test_email_parse(self, data_to_parse, expected_result):
+    """Tests multiply emails parse correctly."""
+    self.handler.raw_value = data_to_parse
+    # pylint: disable=protected-access
+    result = self.handler._parse_raw_data_to_emails()
+    self.assertEquals(result, expected_result)


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

If user tries to import a task group csv template with at least two task group assignees, "Import failed due to server error" error message occurs.


# Steps to test the changes

Steps to reproduce:
1. Create any wf in UI
2. Go to Import page and download task group csv template
3. Fill out required fields and set at least two task group assignees > Save changes
4. Import task group csv template
Actual Result:

"Import failed due to server error" error message occurs;
POST 400 is displayed in Network tab;
task group is not imported
Expected Result: If user tries to import a task group csv template with at least two task group assignees:
show informative message that only one task group assignee can be imported;
a message that a task group assignee will be alphabetically first registered user;
no error message should be shown.

# Solution description

Modified Assignee handler to check if there are multiple users in the 'Assignee' csv cell.
Show according warning if there are.
If the user chose to proceed than alphabetically first registered user from the cell will be assigned.
Please, read commit messages.
# Sanity checklist

- [ ] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:run' labels to all open PRs with a label 'migration'
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
