### PR TITLE
GGRC-6333 Modal backdrop is still displayed after issue unmapped from assessment

### DIFF
--- a/src/ggrc-client/js/components/issue/issue-unmap-item.js
+++ b/src/ggrc-client/js/components/issue/issue-unmap-item.js
@@ -129,8 +129,6 @@ export default can.Component.extend({
         await relationship.unmap(true);
         if (currentObject === this.attr('issueInstance')) {
           navigate(this.attr('issueInstance.viewLink'));
-        } else {
-          this.attr('modalState.open', false);
         }
       } catch (error) {
         notifier('error', 'There was a problem with unmapping.');

--- a/src/ggrc-client/js/components/simple-modal/simple-modal.js
+++ b/src/ggrc-client/js/components/simple-modal/simple-modal.js
@@ -51,6 +51,9 @@ export default can.Component.extend({
       viewModel.attr('modalWrapper', modalWrapper);
       viewModel.showHideModal(viewModel.attr('state.open'));
     },
+    removed() {
+      this.viewModel.hide();
+    },
     '{viewModel.state} open'(state, ev, newValue) {
       this.viewModel.showHideModal(newValue);
     },


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Modal backdrop is still displayed after issue unmapped from assessment.

# Steps to test the changes
**Steps to reproduce:**
1. Create an assessment
2. Map issue to the assessment
3. Unmap the issue

**Actual result:**
Assessment issue page has modal backdrop. (Can be removed by clicking on the page)

**Expected result:**
Assessment issue page has no modal backdrop.

# Solution description

The `issue-unmap-item` component which shows simple-modal with backdrop is deleted due to the fact that the tree-view is refreshed after issue unmapping. So closing of the modal does not work as `simple-modal` component does not exist.
Added `removed` event handler which hides a simple-modal before removing from the dom to fix this issue.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:run' labels to all open PRs with a label 'migration'
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
