### PR TITLE
GGRC-4544 Implemented endpoint for wf statistics

### DIFF
--- a/src/ggrc/services/resources/person.py
+++ b/src/ggrc/services/resources/person.py
@@ -8,8 +8,10 @@ import collections
 import functools
 
 from logging import getLogger
-from werkzeug.exceptions import Forbidden, BadRequest, MethodNotAllowed
+import sqlalchemy as sa
 from sqlalchemy.orm.exc import NoResultFound
+
+from werkzeug.exceptions import Forbidden, BadRequest, MethodNotAllowed
 from dateutil import parser as date_parser
 
 from ggrc import db
@@ -21,8 +23,7 @@ from ggrc.services import common
 from ggrc.views import converters
 from ggrc.query import my_objects
 from ggrc.query import builder
-from ggrc.models.person_profile import PersonProfile
-from ggrc.models.person import Person
+from ggrc.models import all_models
 
 
 # pylint: disable=invalid-name
@@ -166,6 +167,7 @@ class PersonResource(common.ExtendedResource):
         None: super(PersonResource, self).get,
         "task_count": self.verify_is_current(self._task_count),
         "my_work_count": self.verify_is_current(self._my_work_count),
+        "my_workflows": self.verify_is_current(self._my_workflows),
         "all_objects_count": self.verify_is_current(self._all_objects_count),
         "imports": self.verify_is_current(converters.handle_import_get),
         "exports": self.verify_is_current(converters.handle_export_get),
@@ -318,6 +320,111 @@ class PersonResource(common.ExtendedResource):
 
       return self.json_success_response(response_object, )
 
+  def _my_workflows(self, id):
+    """Returns workflow statistic for authorized user."""
+    # pylint: disable=invalid-name,redefined-builtin
+    base_query = db.session.query(
+        all_models.Workflow
+    ).join(
+        all_models.AccessControlList,
+        all_models.AccessControlList.object_id == all_models.Workflow.id
+    ).join(
+        all_models.AccessControlPerson,
+        all_models.AccessControlPerson.ac_list_id ==
+        all_models.AccessControlList.id
+    ).join(
+        all_models.AccessControlRole,
+        all_models.AccessControlList.ac_role_id ==
+        all_models.AccessControlRole.id
+    ).join(
+        all_models.Person,
+        all_models.AccessControlPerson.person_id == all_models.Person.id
+    )
+
+    tasks_query = base_query.join(
+        all_models.Cycle,
+        all_models.Workflow.id == all_models.Cycle.workflow_id
+    ).join(
+        all_models.CycleTaskGroupObjectTask,
+        all_models.CycleTaskGroupObjectTask.cycle_id == all_models.Cycle.id
+    ).filter(
+        sa.and_(
+            all_models.AccessControlPerson.person_id == id,
+            all_models.Workflow.status == 'Active',
+            all_models.AccessControlList.object_type == 'Workflow',
+            all_models.AccessControlRole.name == 'Admin',
+        )
+    ).group_by(
+        all_models.Workflow.id
+    ).order_by(
+        "due_date"
+    ).with_entities(
+        all_models.Workflow.id.label("workflow_id"),
+        all_models.Workflow.title.label("workflow_title"),
+        sa.func.min(
+            all_models.CycleTaskGroupObjectTask.end_date).label("due_date"),
+        sa.func.sum(
+            sa.func.IF(
+                sa.or_(
+                    sa.and_(
+                        all_models.Workflow.is_verification_needed ==
+                        sa.true(),
+                        all_models.CycleTaskGroupObjectTask.status.in_(
+                            ['Verified', 'Deprecated']
+                        )),
+                    sa.and_(
+                        all_models.Workflow.is_verification_needed ==
+                        sa.false(),
+                        all_models.CycleTaskGroupObjectTask.status.in_(
+                            ['Finished', 'Deprecated']
+                        ))), 1, 0)
+        ).label("completed"),
+        sa.func.count(all_models.Workflow.id).label("total"),
+        sa.func.sum(
+            sa.func.IF(
+                all_models.CycleTaskGroupObjectTask.end_date <
+                datetime.date.today(), 1, 0)
+        ).label("overdue")
+    )
+    wf_tasks_result = tasks_query.all()
+    workflow_ids = [res.workflow_id for res in wf_tasks_result]
+
+    owners_query = base_query.filter(
+        sa.and_(
+            all_models.Workflow.id.in_(workflow_ids),
+            all_models.Workflow.status == 'Active',
+            all_models.AccessControlList.object_type == 'Workflow',
+            all_models.AccessControlRole.name == 'Admin',
+        )
+    ).group_by(
+        all_models.Workflow.id
+    ).with_entities(
+        all_models.Workflow.id.label("workflow_id"),
+        sa.func.group_concat(all_models.Person.email).label("owners")
+    )
+    owners_result = dict(owners_query.all())
+
+    response_object = {
+        "workflows": []
+    }
+    for row in wf_tasks_result:
+      response_object["workflows"].append({
+          "workflow": {
+              "id": row.workflow_id,
+              "title": row.workflow_title
+          },
+          "owners": owners_result[row.workflow_id].split(","),
+          "task_stat": {
+              "counts": {
+                  "total": int(row.total),
+                  "overdue": int(row.overdue),
+                  "completed": int(row.completed),
+              },
+              "due_in_date": row.due_date
+          }
+      })
+    return self.json_success_response(response_object, )
+
   def _all_objects_count(self, **kwargs):  # pylint: disable=unused-argument
     """Get object counts for all objects page."""
     with benchmark("Make response"):
@@ -346,10 +453,12 @@ class PersonResource(common.ExtendedResource):
         False otherwise. Profile is profile for Person with id=person_id.
       """
     try:
-      profile = PersonProfile.query.filter_by(person_id=person_id).one()
+      profile = all_models.PersonProfile.query.filter_by(
+          person_id=person_id
+      ).one()
     except NoResultFound:
-      person = Person.query.filter_by(id=person_id).one()
-      person.profile = PersonProfile()
+      person = all_models.Person.query.filter_by(id=person_id).one()
+      person.profile = all_models.PersonProfile()
       return (True, person.profile)
     return (False, profile)
 

--- a/test/integration/ggrc_workflows/test_workflow_statistic.py
+++ b/test/integration/ggrc_workflows/test_workflow_statistic.py
@@ -1,0 +1,199 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Tests endpoint for workflow statistics."""
+
+from datetime import date
+
+import ddt
+from freezegun import freeze_time
+
+from ggrc.models import all_models
+from ggrc.utils import create_stub
+
+from integration.ggrc.access_control import acl_helper
+from integration.ggrc.models import factories
+from integration.ggrc.services import TestCase
+from integration.ggrc.query_helper import WithQueryApi
+from integration.ggrc.generator import ObjectGenerator
+from integration.ggrc_workflows.generator import WorkflowsGenerator
+from integration.ggrc.api_helper import Api
+
+
+@ddt.ddt
+class TestPersonResource(TestCase, WithQueryApi):
+  """Tests endpoint for getting workflow statistics."""
+
+  def setUp(self):
+    super(TestPersonResource, self).setUp()
+    self.client.get("/login")
+    self.api = Api()
+    self.generator = WorkflowsGenerator()
+    self.object_generator = ObjectGenerator()
+
+  def test_workflow_statistic(self):
+    """Tests endpoint for getting workflow statistics."""
+    # pylint: disable=too-many-locals
+    user = all_models.Person.query.first()
+    _, user1 = self.object_generator.generate_person(
+        user_role="Administrator")
+    user_id = user.id
+    user1_id = user1.id
+    role = all_models.AccessControlRole.query.filter(
+        all_models.AccessControlRole.name == "Task Assignees",
+        all_models.AccessControlRole.object_type == "TaskGroupTask",
+    ).one()
+    role_id = role.id
+    workflow_template1 = {
+        "title": "test wf 1",
+        "is_verification_needed": True,
+        "task_groups": [{
+            "title": "task group 1",
+            "contact": create_stub(user),
+            "task_group_tasks": [{
+                "title": "task 1",
+                "description": "some task",
+                "access_control_list": [
+                    acl_helper.get_acl_json(role_id, user_id)],
+                "start_date": date(2017, 5, 5),
+                "end_date": date(2017, 8, 15),
+            }, {
+                "title": "task 2",
+                "description": "some task",
+                "access_control_list": [
+                    acl_helper.get_acl_json(role_id, user_id)],
+                "start_date": date(2017, 5, 5),
+                "end_date": date(2017, 8, 16),
+            }, {"title": "task 3",
+                "description": "some task",
+                "access_control_list": [
+                    acl_helper.get_acl_json(role_id, user_id)],
+                "start_date": date(2017, 5, 5),
+                "end_date": date(2017, 8, 17),
+                }
+            ],
+            "task_group_objects": []
+        }, {
+            "title": "task group 2",
+            "contact": create_stub(user),
+            "task_group_tasks": [{
+                "title": "task 4",
+                "description": "some task",
+                "access_control_list": [
+                    acl_helper.get_acl_json(role_id, user_id)],
+                "start_date": date(2017, 5, 5),
+                "end_date": date(2017, 8, 17),
+            }],
+            "task_group_objects": []
+        }]
+    }
+    workflow_template2 = {
+        "title": "test wf 2",
+        "is_verification_needed": False,
+        "task_groups": [{
+            "title": "task group 1",
+            "contact": create_stub(user),
+            "task_group_tasks": [{
+                "title": "task 5",
+                "description": "some task",
+                "access_control_list": [
+                    acl_helper.get_acl_json(role_id, user_id)],
+                "start_date": date(2017, 5, 5),
+                "end_date": date(2017, 8, 17),
+            }, {
+                "title": "task 6",
+                "description": "some task",
+                "access_control_list": [
+                    acl_helper.get_acl_json(role_id, user_id)],
+                "start_date": date(2017, 5, 5),
+                "end_date": date(2017, 8, 14)
+            }, {
+                "title": "task 7",
+                "description": "some task",
+                "access_control_list": [
+                    acl_helper.get_acl_json(role_id, user_id)],
+                "start_date": date(2017, 5, 5),
+                "end_date": date(2017, 8, 17)
+            }],
+            "task_group_objects": []
+        }]
+    }
+    with factories.single_commit():
+      _, workflow1 = self.generator.generate_workflow(workflow_template1)
+      _, workflow2 = self.generator.generate_workflow(workflow_template2)
+      _, cycle1 = self.generator.generate_cycle(workflow1)
+      _, cycle2 = self.generator.generate_cycle(workflow2)
+      _, workflow1 = self.generator.activate_workflow(workflow1)
+      _, workflow2 = self.generator.activate_workflow(workflow2)
+      cycle1_id = cycle1.id
+      cycle2_id = cycle2.id
+
+    workflow1 = all_models.Workflow.query.get(workflow1.id)
+    workflow1_id = workflow1.id
+    workflow2_id = workflow2.id
+    factories.AccessControlPersonFactory(
+        ac_list=workflow1.acr_name_acl_map["Admin"],
+        person=user1
+    )
+    with freeze_time("2017-8-16"):
+      self.client.get("/login")
+      workflow1 = all_models.Workflow.query.get(workflow1_id)
+      wf1_title = workflow1.title
+      workflow2 = all_models.Workflow.query.get(workflow2_id)
+      wf2_title = workflow2.title
+      user_email = all_models.Person.query.get(user_id).email
+      user1_email = all_models.Person.query.get(user1_id).email
+
+      cycle1 = all_models.Cycle.query.get(cycle1_id)
+      cycle2 = all_models.Cycle.query.get(cycle2_id)
+      task2 = cycle1.cycle_task_group_object_tasks[1]
+      task3 = cycle1.cycle_task_group_object_tasks[2]
+      task4 = cycle1.cycle_task_group_object_tasks[3]
+      task5 = cycle2.cycle_task_group_object_tasks[0]
+      task7 = cycle2.cycle_task_group_object_tasks[2]
+      self.api.put(task2, {
+          "status": "Finished"
+      })
+      self.api.put(task3, {
+          "status": "Deprecated"
+      })
+      self.api.put(task4, {
+          "status": "Verified"
+      })
+      self.api.put(task5, {
+          "status": "Finished"
+      })
+      self.api.put(task7, {
+          "status": "Deprecated"
+      })
+      workflow1_owners = [user_email, user1_email]
+      response = self.client.get("/api/people/{}/my_workflows".format(user_id))
+      expected_result = {'workflows': [{
+          'workflow': {
+              'id': workflow2.id,
+              'title': wf2_title
+          },
+          'owners': [user_email],
+          'task_stat': {
+              'counts': {
+                  'completed': 2,
+                  'overdue': 1,
+                  'total': 3
+              },
+              'due_in_date': '2017-08-14'
+          }}, {
+          'workflow': {
+              'id': workflow1.id,
+              'title': wf1_title
+          },
+          'owners': workflow1_owners,
+          'task_stat': {
+              'counts': {
+                  'completed': 2,
+                  'total': 4,
+                  'overdue': 1,
+              },
+              'due_in_date': '2017-08-15'
+          }},
+      ]}
+      self.assertEqual(response.json, expected_result)


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

In this PR separate endpoint to get workflow statistic is implemented.

# Sanity checklist

- [ ] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:run' labels to all open PRs with a label 'migration'
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

# TODO

- [x] Due to updated requirements results should be ordered by workflow due date;
- [x] Raw SQLs should be changed to SqlAlchemy calls.
