### PR TITLE
QUICK-FIX Update reprovisioning section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,13 +209,7 @@ git clean -df
 Start re-provisioning:
 ```sh
 docker-compose build --pull --no-cache
-```
-
-Because Docker provisioning is done with Dockerfile which can not modify content of a shared volume, you need to enter the container and run one more step to finish the provisioning
-
-```
-docker-compose up -d --force-recreate
-docker exec -it $(docker container ls -f name=ggrccore_cleandev_1 -q -a) su vagrant
+./bin/containers setup
 ```
 
 


### PR DESCRIPTION
# Issue description

Commands in `Reprovisioning a Docker container` section are outdated. 

# Steps to test the changes

Run:
`docker-compose up -d --force-recreate`
`docker exec -it $(docker container ls -f name=ggrccore_cleandev_1 -q -a) su vagrant`

# Solution description

Update `Reprovisioning a Docker container` with the correct command.

# Sanity checklist

- [ ] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [ ] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
