### PR TITLE
GGRC-6486 Create revision on person reassigning in import

### DIFF
--- a/test/integration/ggrc/converters/test_import_controls.py
+++ b/test/integration/ggrc/converters/test_import_controls.py
@@ -381,3 +381,48 @@ class TestControlsImport(TestCase):
     control = all_models.Control.query.first()
     self.assertEqual(len(control.assertions), 1)
     self.assertEqual(control.assertions[0].name, assertion_name)
+
+  def test_add_person_revision(self):
+    """Test Control revision created if new person is assigned in import."""
+    user = all_models.Person.query.filter_by(email="user@example.com").first()
+    control = factories.ControlFactory(modified_by=user)
+
+    revisions = db.session.query(all_models.Revision.action).filter_by(
+        resource_type=control.type,
+        resource_id=control.id
+    )
+    self.assertEqual(revisions.all(), [("created",)])
+
+    response = self.import_data(collections.OrderedDict([
+        ("object_type", "Control"),
+        ("Code*", control.slug),
+        ("Admin", "user@example.com"),
+        ("Control Operators", "user@example.com"),
+        ("Control Owners", "user@example.com"),
+    ]))
+    self._check_csv_response(response, {})
+    self.assertEqual(revisions.all(), [('created',), ('modified',)])
+
+  def test_change_person_revision(self):
+    """Test Control revision created if person is changed in import."""
+    user = all_models.Person.query.filter_by(email="user@example.com").first()
+    with factories.single_commit():
+      control = factories.ControlFactory(modified_by=user)
+      person = factories.PersonFactory()
+      for role_name in ("Admin", "Control Operators", "Control Owners"):
+        control.add_person_with_role(person, role_name)
+
+    revisions = db.session.query(all_models.Revision.action).filter_by(
+        resource_type=control.type,
+        resource_id=control.id
+    )
+    self.assertEqual(revisions.all(), [("created",)])
+
+    response = self.import_data(collections.OrderedDict([
+        ("object_type", "Control"),
+        ("Code*", control.slug),
+        ("Control Operators", "user@example.com"),
+        ("Control Owners", "user@example.com"),
+    ]))
+    self._check_csv_response(response, {})
+    self.assertEqual(revisions.all(), [('created',), ('modified',)])


### PR DESCRIPTION
# Issue description

Import doesn't create 'modify' revision for existing object on person reassigning

# Steps to test the changes

Steps to reproduce:

Create program
Create control with filled Control Operator and Control Owner
Export control to Google Sheet
Change Control Operator and Control Owner (add one more person or remove them)
Import control and ensure that updates for control are correct in UI
Create audit for the program and open audit page
Open Controls tab and open controls info panel
Look at the Control Operator and Control Owner

Actual Result: Import doesn't create revision for the control. There is a difference between people in original Control and control's snapshot

Expected Result: Import should create a valid revision

# Solution description

Mark object manually as modified if related ACP changed.

# Sanity checklist

- [ ] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [ ] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [ ] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [ ] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:run' labels to all open PRs with a label 'migration'
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
