### PR TITLE
GGRC-6520 Move Audit Snapshots reindex into background

### DIFF
--- a/src/ggrc/snapshotter/__init__.py
+++ b/src/ggrc/snapshotter/__init__.py
@@ -29,7 +29,7 @@ from ggrc.snapshotter.helpers import create_snapshot_dict
 from ggrc.snapshotter.helpers import create_snapshot_revision_dict
 from ggrc.snapshotter.helpers import get_revisions
 from ggrc.snapshotter.helpers import get_snapshots
-from ggrc.snapshotter.indexer import reindex_pairs
+from ggrc.snapshotter import indexer
 
 from ggrc.snapshotter.rules import get_rules
 
@@ -145,7 +145,7 @@ class SnapshotGenerator(object):
                           revisions=revisions, _filter=_filter)
     updated = result.response
     if not self.dry_run:
-      reindex_pairs(updated)
+      indexer.reindex_pairs_bg(updated)
       self._copy_snapshot_relationships()
       self._create_audit_relationships()
     return result
@@ -307,7 +307,7 @@ class SnapshotGenerator(object):
 
     to_reindex = updated | created
     if not self.dry_run:
-      reindex_pairs(to_reindex)
+      indexer.reindex_pairs_bg(to_reindex)
       self._remove_lost_snapshot_mappings()
       self._copy_snapshot_relationships()
       self._create_audit_relationships()
@@ -338,7 +338,7 @@ class SnapshotGenerator(object):
         revisions=revisions, _filter=_filter)
     created = result.response
     if not self.dry_run:
-      reindex_pairs(created)
+      indexer.reindex_pairs_bg(created)
       self._copy_snapshot_relationships()
       self._create_audit_relationships()
     return result

--- a/test/selenium/src/lib/service/rest_service.py
+++ b/test/selenium/src/lib/service/rest_service.py
@@ -328,14 +328,27 @@ class ObjectsInfoService(HelpRestService):
     """Get and return snapshoted object according to 'origin_obj' and
     'paren_obj'.
     """
+
+    def get_response():
+      """Get response from query."""
+      return self.client.create_object(
+          type=self.endpoint,
+          object_name=objects.get_obj_type(objects.SNAPSHOTS),
+          filters=query.Query.expression_get_snapshoted_obj(
+              obj_type=origin_obj.type, obj_id=origin_obj.id,
+              parent_type=paren_obj.type,
+              parent_id=paren_obj.id))
+
+    def get_response_values():
+      """Get values fom responese."""
+      return json.loads(
+          get_response().text, encoding="utf-8")[0]["Snapshot"]["values"]
+
+    test_utils.wait_for(
+        get_response_values,
+        constants.ux.MAX_USER_WAIT_SECONDS * 2)
     snapshoted_obj_dict = (
-        BaseRestService.get_items_from_resp(self.client.create_object(
-            type=self.endpoint,
-            object_name=objects.get_obj_type(objects.SNAPSHOTS),
-            filters=query.Query.expression_get_snapshoted_obj(
-                obj_type=origin_obj.type, obj_id=origin_obj.id,
-                parent_type=paren_obj.type,
-                parent_id=paren_obj.id))).get("values")[0])
+        BaseRestService.get_items_from_resp(get_response()).get("values")[0])
     return Representation.repr_dict_to_obj(snapshoted_obj_dict)
 
   def get_obj(self, obj):


### PR DESCRIPTION
# Issue description

Reindexing of Snapshots takes significant part of time of Audit creation:
40s - Snapshots reindex, 1 min - total Audit creation time.
This PR move snapshots reindex into background.
Note: It will not affect import reindex.

# Steps to test the changes

Create Audit in big Program (for example program 1657 in ggrc-perf). Check timings of Audit creation with/without this PR.

# Solution description

Move snapshots reindex into background.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).


# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

