### PR TITLE
GGRC-6498 Add ordering by created_at in query API

### DIFF
--- a/src/ggrc/query/custom_operators.py
+++ b/src/ggrc/query/custom_operators.py
@@ -28,6 +28,8 @@ GETATTR_WHITELIST = {
     "id",
     "is_current",
     "program",
+    "created_at",
+    "updated_at",
 }
 
 


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Currently `query API` does not support sorting by `created_at` for revisions. Which is necessary to arrange pagination for `change log`.

# Steps to test the changes

1. Perform query API request for revisions with `order_by` argument set to `created_at`.
2. See that revisions in result are sorted by `created_at`.

# Solution description

Solution consists of adding `created_at` and `updated_at` to `GETATTR_WHITELIST` in `query/custom_operators.py` so now `_joins_and_order` function from `query/pagination.py` will not perform joins and ordering agains `fulltext_record_properties` table in case `created_at` or `updated_at` are provided as ordering keys.

There may be a better solution like creating mixin analogues to `Filterable` one and providing each model with something like `_sortable_attr` dict containing fields against which sorting could be performed and comparator functions if necessary. So query API could check whether or not ordering by particular attribute could be performed. But due potentially large number of models influenced in this scenario, the first solution was implemented.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:run' labels to all open PRs with a label 'migration'
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
