### PR TITLE
GGRC-6034 Notify user when they try to close the tab when saving in progress

### DIFF
--- a/src/ggrc-client/js/controllers/inner-nav-controller.js
+++ b/src/ggrc-client/js/controllers/inner-nav-controller.js
@@ -6,6 +6,7 @@
 import {
   getPageType,
   getPageInstance,
+  pageNotifier,
 } from '../plugins/utils/current-page-utils';
 import {getCounts} from '../plugins/utils/widgets-utils';
 import {isDashboardEnabled} from '../plugins/utils/dashboards-utils';
@@ -276,6 +277,13 @@ export default can.Control({
       this.options.attr('notPriorityTabs', widgets.slice(priorityTabsNum));
     } else {
       this.options.attr('priorityTabs', widgets);
+    }
+  },
+  'a click'(el, ev) {
+    if (!pageNotifier.isEmpty
+      && !confirm('You have unsaved changes that will be lost, if you decide ' +
+      'to continue. Are you sure you want to leave this page?')) {
+      ev.preventDefault();
     }
   },
   '.closed click': function (el, ev) {

--- a/src/ggrc-client/js/plugins/persistent-notifier.js
+++ b/src/ggrc-client/js/plugins/persistent-notifier.js
@@ -11,6 +11,10 @@ export default class PersistentNotifier {
     Object.assign(this, options);
   }
 
+  get isEmpty() {
+    return this.dfds.length === 0;
+  }
+
   whileQueueHasElements() {}
 
   whenQueueEmpties() {}

--- a/src/ggrc-client/js/plugins/utils/current-page-utils.js
+++ b/src/ggrc-client/js/plugins/utils/current-page-utils.js
@@ -157,5 +157,6 @@ export {
   isAdmin,
   isObjectContextPage,
   navigate,
+  notifier as pageNotifier,
   delayLeavingPageUntil,
 };


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

For all objects user is able to make an inline editing or a status change and then click another object at Objects' tab, while the saving process is not finished. This may cause some data lost.
We shouldn't allow users to leave the tab without saving data. A chrome dialog should be shown in this case. 

Chrome dialog should be shown for:

- Assessments (all inline editable attributes + status buttons click)
- Tasks (status change via tree view and inline editing of people attributes)
- All other objects (for changes at people fields and GCA)

Chrome dialog text to be shown:

_You have unsaved changes that will be lost, if you decide to continue. Are you sure you want to leave this page?_

# Steps to test the changes

1. Open any info-pane in minimized mode
2. Change any custom attribute/custom role
3. During saving change current tab

Expected result: chrome dialog is shown.

# Solution description

Show chrome dialog before route changing.

# Sanity checklist

- [ ] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [ ] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [ ] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [ ] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:run' labels to all open PRs with a label 'migration'
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
