### PR TITLE
GGRC-6486 Create object revision in import

### DIFF
--- a/src/ggrc/models/cache.py
+++ b/src/ggrc/models/cache.py
@@ -75,3 +75,13 @@ class Cache:
     else:
       logger.warning("No app context - no cache created")
       return None
+
+  @staticmethod
+  def add_to_cache(obj, state="dirty"):
+    """Add object to cache."""
+    cache = Cache.get_cache()
+    state_objs = getattr(cache, state, None)
+    if state_objs is not None and \
+       hasattr(obj, 'log_json') and \
+       obj not in state_objs:
+      state_objs[obj] = obj.log_json()

--- a/test/integration/ggrc/converters/test_import_controls.py
+++ b/test/integration/ggrc/converters/test_import_controls.py
@@ -385,7 +385,9 @@ class TestControlsImport(TestCase):
   def test_add_person_revision(self):
     """Test Control revision created if new person is assigned in import."""
     user = all_models.Person.query.filter_by(email="user@example.com").first()
-    control = factories.ControlFactory(modified_by=user)
+    with factories.single_commit():
+      control = factories.ControlFactory(modified_by=user)
+      objective = factories.ObjectiveFactory()
 
     revisions = db.session.query(all_models.Revision.action).filter_by(
         resource_type=control.type,
@@ -399,6 +401,7 @@ class TestControlsImport(TestCase):
         ("Admin", "user@example.com"),
         ("Control Operators", "user@example.com"),
         ("Control Owners", "user@example.com"),
+        ("Map:Objective", objective.slug),
     ]))
     self._check_csv_response(response, {})
     self.assertEqual(revisions.all(), [('created',), ('modified',)])
@@ -408,6 +411,7 @@ class TestControlsImport(TestCase):
     user = all_models.Person.query.filter_by(email="user@example.com").first()
     with factories.single_commit():
       control = factories.ControlFactory(modified_by=user)
+      objective = factories.ObjectiveFactory()
       person = factories.PersonFactory()
       for role_name in ("Admin", "Control Operators", "Control Owners"):
         control.add_person_with_role(person, role_name)
@@ -423,6 +427,7 @@ class TestControlsImport(TestCase):
         ("Code*", control.slug),
         ("Control Operators", "user@example.com"),
         ("Control Owners", "user@example.com"),
+        ("Map:Objective", objective.slug),
     ]))
     self._check_csv_response(response, {})
     self.assertEqual(revisions.all(), [('created',), ('modified',)])


### PR DESCRIPTION
# Issue description

Import doesn't create revision for the object if only ACL changed

# Steps to test the changes

1. Create program
2. Create control with filled Control Operator and Control Owner
3. Export control to Google Sheet
4. Change Control Operator and Control Owner (add one more person or remove them)
5. Import control and ensure that updates for control are correct in UI
6. Create audit for the program and open audit page
7. Open Controls tab and open controls info panel
8. Look at the Control Operator and Control Owner

Actual Result: Import doesn't create revision for the control. There is a difference between people in original Control and control's snapshot

Expected Result: Import should create a valid revision

# Solution description

Create revision for the object each time when import was run (no matter if something was changed or not). 

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

