### PR TITLE
GGRC-6503 Filter revisions by created_at

### DIFF
--- a/src/ggrc/models/mixins/base.py
+++ b/src/ggrc/models/mixins/base.py
@@ -210,6 +210,10 @@ class ChangeTracked(object):
           "modified_by", "modified_by", ["email", "name"]
       ),
   ]
+  _filterable_attrs = [
+      "created_at",
+      "updated_at"
+  ]
 
   _aliases = {
       "updated_at": {

--- a/test/integration/ggrc/models/factories.py
+++ b/test/integration/ggrc/models/factories.py
@@ -554,6 +554,36 @@ class CalendarEventFactory(TitledFactory):
     model = all_models.CalendarEvent
 
 
+class RevisionFactory(ModelFactory):
+
+  class Meta:
+    model = all_models.Revision
+
+  @classmethod
+  def _create(cls, target_class, *args, **kwargs):
+    """Fix context related_object when audit is created"""
+    kwargs["action"] = kwargs.get("action", "created")
+    kwargs["content"] = kwargs.get("content", {})
+    kwargs["modified_by_id"] = kwargs.get(
+        "modified_by_id", PersonFactory().id
+    )
+    kwargs["obj"] = kwargs.get("obj", ControlFactory())
+
+    event = EventFactory(
+        modified_by_id=kwargs["modified_by_id"],
+        action="POST",
+        resource_id=kwargs["obj"].id,
+        resource_type=kwargs["obj"].__class__.__name__,
+    )
+
+    rev = target_class(*args, **kwargs)
+    rev.event_id = event.id
+    db.session.add(rev)
+    if getattr(db.session, "single_commit", True):
+      db.session.commit()
+    return rev
+
+
 def get_model_factory(model_name):
   """Get object factory for provided model name"""
   from integration.ggrc_workflows.models import factories as wf_factories
@@ -597,6 +627,7 @@ def get_model_factory(model_name):
       "Requirement": RequirementFactory,
       "Risk": RiskFactory,
       "Review": ReviewFactory,
+      "Revision": RevisionFactory,
       "RiskAssessment": RiskAssessmentFactory,
       "Standard": StandardFactory,
       "System": SystemFactory,


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

For reviewable objects we have possibility filter 'change log' to show only changes after last review of object. So we need possibility to filter revisions in query API to get this revisions.

# Steps to test the changes

1. Create some object;
2. Perform several edits of this object;
3. Run query API request:
```
{
            "object_name": "Revision",
            "filters": {
                "expression": {
                    "op": {"name": "AND"},
                    "left": {
                        "op": {"name": "AND"},
                        "left": {
                            "op": {"name": "="},
                            "left": "resource_type",
                            "right": <object_type>
                        },
                        "right": {
                            "op": {"name": "="},
                            "left": "resource_id",
                            "right": <object_id>
                        }
                    },
                    "right": {
                        "op": {"name": ">"},
                        "left": "created_at",
                        "right": <datetime>
                    }
                }
            }
        },
```

# Solution description

Solution is to provide `ChangeTracked` mixin with `_filterable_attrs` list containing `created_at` and `updated_at` fields.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:run' labels to all open PRs with a label 'migration'
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
