### PR TITLE
GGRC-5617/GGRC-6548 Do not allow to autogenerate Tickets at Ticket Tracker for Issues in some statuses via import

### DIFF
--- a/src/ggrc-client/js/components/issue-tracker/modal-issue-tracker-fields.js
+++ b/src/ggrc-client/js/components/issue-tracker/modal-issue-tracker-fields.js
@@ -19,5 +19,23 @@ export default can.Component.extend({
     linkingNote: '',
     setIssueTitle: false,
     allowToChangeId: false,
+    isTicketIdMandatory: false,
+    setTicketIdMandatory() {
+      let instance = this.attr('instance');
+
+      if (instance.class.model_singular === 'Issue') {
+        this.attr('isTicketIdMandatory',
+          ['Fixed', 'Fixed and Verified', 'Deprecated']
+            .includes(instance.attr('status')));
+      }
+    },
+  },
+  events: {
+    inserted() {
+      this.viewModel.setTicketIdMandatory();
+    },
+    '{viewModel.instance} status'() {
+      this.viewModel.setTicketIdMandatory();
+    },
   },
 });

--- a/src/ggrc-client/js/components/issue-tracker/templates/modal-issue-tracker-fields.stache
+++ b/src/ggrc-client/js/components/issue-tracker/templates/modal-issue-tracker-fields.stache
@@ -33,7 +33,7 @@
         </label>
         <div class="ggrc-form-item__multiple-row--double">
           <div class="ggrc-form-item__note">
-            {{linkingNote}}
+            {{{linkingNote}}}
           </div>
         </div>
         <div class="ggrc-form-item__multiple-row">

--- a/src/ggrc-client/js/components/issue-tracker/templates/modal-issue-tracker-fields.stache
+++ b/src/ggrc-client/js/components/issue-tracker/templates/modal-issue-tracker-fields.stache
@@ -30,19 +30,25 @@
       <div class="ggrc-form-item__row">
         <label class="ggrc-form-item__label">
           Ticket ID
+          {{#isTicketIdMandatory}}
+            <i class="fa fa-asterisk"></i>
+          {{/isTicketIdMandatory}}
         </label>
         <div class="ggrc-form-item__multiple-row--double">
           <div class="ggrc-form-item__note">
             {{{linkingNote}}}
           </div>
         </div>
-        <div class="ggrc-form-item__multiple-row">
+        <div class="ggrc-form-item__multiple-row {{#instance.computed_errors.issue_tracker_issue_id}}field-failure{{/instance.computed_errors.issue_tracker_issue_id}}">
           <numberbox
             attr-data-id="code_txtbx"
             additional-class="input-block-level"
             placeholder="Enter Ticket ID"
             {(value)}="instance.issue_tracker.issue_id">
           </numberbox>
+          {{#instance.computed_errors.issue_tracker_issue_id}}
+            <label class="help-inline warning">{{this}}</label>
+          {{/instance.computed_errors.issue_tracker_issue_id}}
         </div>
       </div>
     </div>

--- a/src/ggrc-client/js/models/business-models/issue.js
+++ b/src/ggrc-client/js/models/business-models/issue.js
@@ -108,5 +108,17 @@ export default Cacheable.extend({
         }
       }
     );
+
+    this.validate(
+      'issue_tracker_issue_id',
+      function () {
+        if (this.attr('issue_tracker.enabled') &&
+          ['Fixed', 'Fixed and Verified', 'Deprecated']
+            .includes(this.attr('status')) &&
+            !this.attr('issue_tracker.issue_id')) {
+          return 'cannot be blank';
+        }
+      }
+    );
   },
 }, {});

--- a/src/ggrc-client/js/templates/issues/modal_content.stache
+++ b/src/ggrc-client/js/templates/issues/modal_content.stache
@@ -195,7 +195,7 @@
             <modal-issue-tracker-fields
               {instance}="instance"
               {allow-to-change-id}="true"
-              {linking-note}="'Please leave this empty for a new ticket to be generated and linked to this issue. If you would like to link to an existing ticket please provide the ticket number.''"
+              {linking-note}="'If you would like to keep the existing ticket linked to this issue do not edit this attribute. If you would like to link to a different ticket provide an existing ticket number. You are not allowed to generate new ticket for Issues at statuses &quot;Fixed&quot;, &quot;Fixed and Verified&quot; and &quot;Deprecated&quot;.''"
               {set-issue-title}="setIssueTitle"
               {note}="'Turns on Ticket Tracker integration. Any subsequent updates to admins, primary contacts, secondary contacts and state fields should be made through tracking system and will be synced automatically to GGRC.'">
             </modal-issue-tracker-fields>

--- a/src/ggrc/converters/base.py
+++ b/src/ggrc/converters/base.py
@@ -50,7 +50,8 @@ class ImportConverter(BaseConverter):
       "task_type",
       "audit",
       "assessment_template",
-      "title"
+      "title",
+      "status",
   ]
 
   def __init__(self, ie_job, dry_run=True, csv_data=None):

--- a/src/ggrc/converters/errors.py
+++ b/src/ggrc/converters/errors.py
@@ -73,6 +73,12 @@ WRONG_REQUIRED_VALUE = (u"Line {line}: Required field {column_name} contains"
                         u" invalid data '{value}'. The default value will be"
                         u" used.")
 
+WRONG_TICKET_STATUS = (u"Line {line}: You are not allowed to autogenerate "
+                       u"tickets at Ticket Tracker for Issues at statuses "
+                       u"'Fixed', 'Fixed and Verified' and 'Deprecated'. "
+                       u"Column '{column_name}' will be set to 'Off'. Please "
+                       u"use a manual linking option instead.")
+
 MISSING_VALUE_WARNING = (u"Line {line}: Field '{column_name}' is required. "
                          u"The default value '{default_value}' will be used.")
 

--- a/test/integration/ggrc/converters/test_import_issuetracked_objects.py
+++ b/test/integration/ggrc/converters/test_import_issuetracked_objects.py
@@ -652,3 +652,99 @@ class TestIssueTrackedImport(ggrc.TestCase):
     obj = all_models.AssessmentTemplate.query.one()
     self.assertEqual(str(obj.issue_tracker[missed_field]),
                      str(default_values[missed_field]))
+
+  @ddt.data("Fixed", "Fixed and Verified", "Deprecated")
+  def test_ticket_generation_disallowed_on_create(self, status):
+    """Test ticket generation disallowed for Issue in {} status on create"""
+    expected_warning = (
+        errors.WRONG_TICKET_STATUS.format(
+            line=3,
+            column_name="Ticket Tracker Integration",
+        )
+    )
+    expected_messages = {
+        "Issue": {
+            "row_warnings": {expected_warning},
+        }
+    }
+    response = self.import_data(OrderedDict([
+        ("object_type", "Issue"),
+        ("Code*", "OBJ-1"),
+        ("Admin", "user@example.com"),
+        ("Title", "Object Title"),
+        ("State", status),
+        ("Ticket Tracker Integration", "On"),
+    ]))
+    self._check_csv_response(response, expected_messages)
+    obj = all_models.Issue.query.one()
+    self.assertFalse(obj.issue_tracker["enabled"])
+
+  @ddt.data("Fixed", "Fixed and Verified", "Deprecated")
+  def test_ticket_generation_disallowed_on_update(self, status):
+    """Test ticket generation disallowed for Issue in {} status on update"""
+    with factories.single_commit():
+      obj = factories.IssueFactory(status=status)
+      factories.IssueTrackerIssueFactory(
+          issue_tracked_obj=obj,
+          enabled=False,
+          issue_id=None,
+      )
+    expected_warning = (
+        errors.WRONG_TICKET_STATUS.format(
+            line=3,
+            column_name="Ticket Tracker Integration",
+        )
+    )
+    expected_messages = {
+        "Issue": {
+            "row_warnings": {expected_warning},
+        }
+    }
+    response = self.import_data(OrderedDict([
+        ("object_type", "Issue"),
+        ("Code*", obj.slug),
+        ("Ticket Tracker Integration", "On"),
+    ]))
+    self._check_csv_response(response, expected_messages)
+    obj = all_models.Issue.query.one()
+    self.assertFalse(obj.issue_tracker["enabled"])
+
+  @ddt.data("Draft", "Active")
+  @mock.patch("ggrc.integrations.issues.Client.create_issue")
+  @mock.patch.object(settings, "ISSUE_TRACKER_ENABLED", True)
+  def test_generation_allowed_on_create(self, status, create_mock):
+    """Test ticket generation allowed for Issue in {} status on create"""
+    response = self.import_data(OrderedDict([
+        ("object_type", "Issue"),
+        ("Code*", "OBJ-1"),
+        ("Admin", "user@example.com"),
+        ("State", status),
+        ("Title", "Object Title"),
+        ("Ticket Tracker Integration", "On"),
+    ]))
+    self._check_csv_response(response, {})
+    obj = all_models.Issue.query.one()
+    self.assertTrue(obj.issue_tracker["enabled"])
+    create_mock.assert_called_once()
+
+  @ddt.data("Draft", "Active")
+  @mock.patch("ggrc.integrations.issues.Client.create_issue")
+  @mock.patch.object(settings, "ISSUE_TRACKER_ENABLED", True)
+  def test_generation_allowed_on_update(self, status, create_mock):
+    """Test ticket generation allowed for Issue in {} status on update"""
+    with factories.single_commit():
+      obj = factories.IssueFactory(status=status)
+      factories.IssueTrackerIssueFactory(
+          issue_tracked_obj=obj,
+          enabled=False,
+          issue_id=None,
+      )
+    response = self.import_data(OrderedDict([
+        ("object_type", "Issue"),
+        ("Code*", obj.slug),
+        ("Ticket Tracker Integration", "On"),
+    ]))
+    self._check_csv_response(response, {})
+    obj = all_models.Issue.query.one()
+    self.assertTrue(obj.issue_tracker["enabled"])
+    create_mock.assert_called_once()

--- a/test/integration/ggrc/converters/test_import_issuetracked_objects.py
+++ b/test/integration/ggrc/converters/test_import_issuetracked_objects.py
@@ -114,7 +114,8 @@ class TestIssueTrackedImport(ggrc.TestCase):
       ("AssessmentTemplate", "Assessment Template", "off"),
   )
   @ddt.unpack
-  def test_import_enabled_update_succeed(self, model, model_name, value):
+  @mock.patch("ggrc.integrations.issues.Client.update_issue")
+  def test_import_enabled_update_succeed(self, model, model_name, value, _):
     """Test {0} integration state {1} set correctly when updated via import."""
     with factories.single_commit():
       factory = factories.get_model_factory(model)
@@ -134,7 +135,8 @@ class TestIssueTrackedImport(ggrc.TestCase):
     self._assert_integration_state(obj, value)
 
   @ddt.data("on", "off")
-  def test_enabled_state_issue_create_succeed(self, value):
+  @mock.patch("ggrc.integrations.issues.Client.create_issue")
+  def test_enabled_state_issue_create_succeed(self, value, _):
     """Test Issue integration state set correctly during create via import."""
     response = self.import_data(OrderedDict([
         ("object_type", "Issue"),
@@ -149,7 +151,8 @@ class TestIssueTrackedImport(ggrc.TestCase):
     self._assert_integration_state(obj, value)
 
   @ddt.data("on", "off")
-  def test_enabled_state_assmt_create_succeed(self, value):
+  @mock.patch("ggrc.integrations.issues.Client.create_issue")
+  def test_enabled_state_assmt_create_succeed(self, value, _):
     """Test Assessment integration state set correctly during create."""
     audit = factories.AuditFactory()
     response = self.import_data(OrderedDict([


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

**PROBLEM:**

User can trigger new ticket autogeneration for issues in completed statuses. There is a restriction on Ticket Tracker API side, it allows to create tickets only in 'New' or 'Assigned' statuses. It means that, if Issue is in 'Completed and Verified' status, the ticket linked to such issue will have 'Assigned' status, until cron job will change it to Fixed (Verified). This can cause confusions for users, who already completed an issue and then receive a notification from Ticket Tracker system, that it is required to complete the same issue.

**SOLUTION:**

Do not allow to autogenerate tickets for issue that are in 'Fixed', 'Fixed and Verified' and 'Deprecated' states.

**ACCEPTANCE CRITERIA:**
**Via UI:** 

1. In case user chosen for issues statuses 'Fixed', 'Fixed and Verified' and 'Deprecated':

- Change help text near TICKET ID field to:
_If you would like to keep the existing ticket linked to this issue do not edit this attribute. If you would like to link to a different ticket provide an existing ticket number. You are not allowed to generate new ticket for Issues at statuses "Fixed", "Fixed and Verified" and "Deprecated"._ 
- Ticket ID field should become mandatory and can not be empty
- If user clicks 'Save and Close' he should see an error near Ticket ID field (can not be blank) and no tickets autogeneration should happen

2. For issues at other statuses use usual autogeneration logic.

**Via import:** 

1. If user decided to import Issues at statuses 'Fixed', 'Fixed and Verified' and 'Deprecated':
On Import page show Warning:
Line \<X\>: You are not allowed to autogenerate tickets at Ticket Tracker for Issues at statuses 'Fixed', 'Fixed and Verified' and 'Deprecated'. Column '\<Y\>' will be ignored. Please use a manual linking option instead.
where X - Number of the row at import file where the Issue at statuses 'Fixed', 'Fixed and Verified'  appear
Y - Name of the column "Ticket Tracker Switch" at import file 
2. User can click 'Proceed in spite of warnings' , the cell value should be ignored, no tickets autogeneration should happen for this assessment.

# Steps to test the changes

1. Try to import new Issue without status column (Default 'Draft' value should be applied) and Ticket Tracker integration turned ON. Check if ticket was generated and no warnings were occurred.
2. Try to import new Issue with status column in the Fixed state and Ticket Tracker integration turned ON. Check if there were appropriate warning and ticket wasn't generated and integration was turned OFF. 
3. Create issue via UI with integration turned OFF in 'Draft' or 'Active' status. Turn Ticket Tracker integration ON via import for this Issue. Check if ticket were generated and no warnings occurred.
4. Create issue via UI with integration turned OFF in 'Fixed' or 'Fixed and Verified' status. Turn Ticket Tracker integration ON via import for this Issue.  Check if there were appropriate warning and ticket wasn't generated and integration was turned OFF. 
5. Check that nothing have changed for Assessments.

# Solution description

I've added status check to `Ticket Tracker Integration` column handler. Now it handles this column according to our business rules.
FE: Add validation rule for ticket Id field for Issue object.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:run' labels to all open PRs with a label 'migration'
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
