### PR TITLE
QUICK-FIX Do not delete event from Calendar API which was not synced before

### DIFF
--- a/src/ggrc/gcalendar/calendar_event_sync.py
+++ b/src/ggrc/gcalendar/calendar_event_sync.py
@@ -55,7 +55,8 @@ class CalendarEventsSync(object):
           continue
         try:
           if event.id not in event_mappings or not event_mappings[event.id]:
-            self._delete_event(event)
+            if event.is_synced:
+              self._delete_event(event)
             db.session.delete(event)
             continue
           if not event.is_synced:

--- a/test/integration/ggrc/gcalendar/test_calendar_event_sync.py
+++ b/test/integration/ggrc/gcalendar/test_calendar_event_sync.py
@@ -7,7 +7,7 @@ from datetime import date
 from freezegun import freeze_time
 import mock
 
-from ggrc.gcalendar import calendar_event_sync, calendar_api_service
+from ggrc.gcalendar import calendar_event_sync
 from integration.ggrc.models import factories
 from integration.ggrc.gcalendar import BaseCalendarEventTest
 
@@ -24,17 +24,14 @@ class TestCalendarEventSync(BaseCalendarEventTest):
                     ".CalendarApiService.calendar_auth"):
       self.sync = calendar_event_sync.CalendarEventsSync()
 
-  def test_create_event(self):
+  @mock.patch("ggrc.gcalendar.calendar_api_service"
+              ".CalendarApiService.create_event",
+              return_value={
+                  "id": "external_event_id"
+              })
+  def test_create_event(self, create_event_mock):
     """Test creation of event."""
-    create_event_mock = mock.MagicMock()
-    calendar_api_service.CalendarApiService.create_event = create_event_mock
-
-    with factories.single_commit():
-      person = factories.PersonFactory()
-      event = factories.CalendarEventFactory(
-          due_date=date(2015, 1, 15),
-          attendee_id=person.id,
-      )
+    person, _, event = self.setup_person_task_event(date(2015, 1, 15))
     with freeze_time("2015-01-1 12:00:00"):
       self.sync._create_event(event)
     create_event_mock.assert_called_with(
@@ -47,19 +44,20 @@ class TestCalendarEventSync(BaseCalendarEventTest):
         attendees=[person.email],
         send_notifications=False
     )
+    self.assertEquals(event.external_event_id, "external_event_id")
     self.assertEquals(event.last_synced_at.date(), date(2015, 1, 1))
 
-  def test_update_event(self):
+  @mock.patch("ggrc.gcalendar.calendar_api_service"
+              ".CalendarApiService.get_event",
+              return_value={
+                  "description": "old description",
+                  "summary": "summary",
+                  "eventId": "eventId",
+              })
+  @mock.patch("ggrc.gcalendar.calendar_api_service"
+              ".CalendarApiService.update_event")
+  def test_update_event(self, update_event_mock, get_event_mock):
     """Test update of event."""
-    update_event_mock = mock.MagicMock()
-    get_event_mock = mock.MagicMock(return_value={
-        "description": "old description",
-        "summary": "summary",
-        "eventId": "eventId",
-    })
-    calendar_api_service.CalendarApiService.update_event = update_event_mock
-    calendar_api_service.CalendarApiService.get_event = get_event_mock
-
     with factories.single_commit():
       person = factories.PersonFactory()
       event = factories.CalendarEventFactory(
@@ -71,6 +69,10 @@ class TestCalendarEventSync(BaseCalendarEventTest):
       )
     with freeze_time("2015-01-1 12:00:00"):
       self.sync._update_event(event)
+    get_event_mock.assert_called_with(
+        calendar_id="primary",
+        event_id="eventId",
+    )
     update_event_mock.assert_called_with(
         event_id="eventId",
         calendar_id="primary",
@@ -83,13 +85,31 @@ class TestCalendarEventSync(BaseCalendarEventTest):
     )
     self.assertEquals(event.last_synced_at.date(), date(2015, 1, 1))
 
-  def test_fail_to_sync_event(self):
-    """Test that sync job tried to sync the second event after a failure."""
-    create_event_mock = mock.MagicMock(side_effect=Exception("test"))
-    calendar_api_service.CalendarApiService.create_event = create_event_mock
+  @mock.patch("ggrc.gcalendar.calendar_api_service"
+              ".CalendarApiService.delete_event")
+  def test_delete_not_synced_event(self, delete_event_mock):
+    """Test delete of unsynced event."""
     with factories.single_commit():
-      self.setup_person_task_event(date(2015, 1, 5))
-      self.setup_person_task_event(date(2015, 1, 6))
+      person = factories.PersonFactory()
+      event = factories.CalendarEventFactory(
+          due_date=date(2015, 1, 15),
+          attendee_id=person.id,
+          description="description",
+          title="summary"
+      )
+    with freeze_time("2015-01-1 12:00:00"):
+      self.sync.sync_cycle_tasks_events()
+    db_event = self.get_event(person.id, event.due_date)
+    self.assertIsNone(db_event)
+    self.assertEqual(delete_event_mock.call_count, 0)
+
+  @mock.patch("ggrc.gcalendar.calendar_api_service"
+              ".CalendarApiService.create_event",
+              side_effect=Exception("test"))
+  def test_fail_to_sync_event(self, create_event_mock):
+    """Test that sync job tried to sync the second event after a failure."""
+    self.setup_person_task_event(date(2015, 1, 5))
+    self.setup_person_task_event(date(2015, 1, 6))
     with freeze_time("2015-01-1 12:00:00"):
       self.sync.sync_cycle_tasks_events()
     self.assertEqual(create_event_mock.call_count, 2)


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

If the event was not synced before deletion, than we receive a warning from CalendarAPI since we do not have `external_event_id` set at the moment. 

# Steps to test the changes

* Run integration tests
* Mock the calls to the API and test the case above is fixed: if event was not synced, the delete will not be called. 

# Solution description

Add check whether the event was synced before deletion. 

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:run' labels to all open PRs with a label 'migration'
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
