### PR TITLE
GGRC-4822 Delete CAV and CAD with empty definition type

### DIFF
--- a/src/ggrc/migrations/versions/20190114132122_7f582a98f108_remove_custom_attributes_with_invalid_.py
+++ b/src/ggrc/migrations/versions/20190114132122_7f582a98f108_remove_custom_attributes_with_invalid_.py
@@ -1,0 +1,37 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Remove custom attributes with invalid definitions
+
+Create Date: 2019-01-14 13:21:22.259581
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '7f582a98f108'
+down_revision = 'dd2a3a987de5'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  delete_values = (
+      "DELETE cav "
+      "FROM custom_attribute_values AS cav "
+      "JOIN custom_attribute_definitions AS cad "
+      "ON cav.custom_attribute_id = cad.id "
+      "WHERE cad.definition_type = ''"
+  )
+  op.execute(delete_values)
+  delete_definitions = (
+      "DELETE FROM custom_attribute_definitions "
+      "WHERE definition_type = ''"
+  )
+  op.execute(delete_definitions)
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

There are some CAD with empty `definition_type` in the database. Some time ago (before early 2016) it was possible to create a CAD with empty `definition_type`. 
For the moment it is not possible and these old CADs will trigger error on CAV creation: "Invalid custom attribute definition used." which means that  CAV's `attributable_type` is not equal to CAD's `definition_type`. But since `definition_type` is always empty for such old CADs, the error will be triggered on every CAV creation. 

# Steps to test the changes

1. Have an object with CAD for which `definition_type` is empty.
2. Try to assign some value to this CAD. 
The error will be triggered. 

After the change check that there are no such CAD's in the db. 

# Solution description

Delete broken CAD's and related CAV's. 

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:run' labels to all open PRs with a label 'migration'

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
