### PR TITLE
GGRC-1715 Send notification if assessment attributes were changed in import

### DIFF
--- a/src/ggrc/converters/handlers/document.py
+++ b/src/ggrc/converters/handlers/document.py
@@ -10,6 +10,7 @@ from ggrc.converters import errors
 from ggrc.converters.handlers import handlers
 from ggrc.login import get_current_user_id
 from ggrc.converters.handlers.file_handler import FileHandler
+from ggrc.services import signals
 
 logger = getLogger(__name__)
 
@@ -104,8 +105,11 @@ class DocumentReferenceUrlHandler(handlers.ColumnHandler):
     parent = self.row_converter.obj
     for new_link, new_doc in new_link_map.iteritems():
       if new_link not in old_link_map:
-        all_models.Relationship(source=parent,
-                                destination=new_doc)
+        rel_obj = all_models.Relationship(
+            source=parent,
+            destination=new_doc
+        )
+        signals.Restful.model_posted.send(rel_obj.__class__, obj=rel_obj)
       else:
         db.session.expunge(new_doc)
 

--- a/src/ggrc/converters/handlers/evidence.py
+++ b/src/ggrc/converters/handlers/evidence.py
@@ -108,8 +108,16 @@ class EvidenceUrlHandler(handlers.ColumnHandler):
       if old_link in new_link_map:
         continue
       if old_evidence.related_destinations:
+        signals.Restful.model_deleted.send(
+            old_evidence.__class__,
+            obj=old_evidence
+        )
         old_evidence.related_destinations.pop()
       elif old_evidence.related_sources:
+        signals.Restful.model_deleted.send(
+            old_evidence.__class__,
+            obj=old_evidence
+        )
         old_evidence.related_sources.pop()
       else:
         logger.warning("Invalid relationship state for document URLs.")

--- a/src/ggrc/converters/handlers/evidence.py
+++ b/src/ggrc/converters/handlers/evidence.py
@@ -10,6 +10,7 @@ from ggrc.converters import errors
 from ggrc.converters.handlers import handlers
 from ggrc.login import get_current_user_id
 from ggrc.converters.handlers.file_handler import FileHandler
+from ggrc.services import signals
 
 
 logger = getLogger(__name__)
@@ -95,8 +96,11 @@ class EvidenceUrlHandler(handlers.ColumnHandler):
 
     for new_link, new_evidence in new_link_map.iteritems():
       if new_link not in old_link_map:
-        all_models.Relationship(source=self.row_converter.obj,
-                                destination=new_evidence)
+        rel_obj = all_models.Relationship(
+            source=self.row_converter.obj,
+            destination=new_evidence
+        )
+        signals.Restful.model_posted.send(rel_obj.__class__, obj=rel_obj)
       else:
         db.session.expunge(new_evidence)
 

--- a/src/ggrc/converters/handlers/snapshot_instance_column_handler.py
+++ b/src/ggrc/converters/handlers/snapshot_instance_column_handler.py
@@ -10,6 +10,7 @@ from ggrc import db
 from ggrc import models
 from ggrc.converters import errors
 from ggrc.converters.handlers.handlers import MappingColumnHandler
+from ggrc.services import signals
 from ggrc.snapshotter.rules import Types
 
 
@@ -132,8 +133,10 @@ class SnapshotInstanceColumnHandler(MappingColumnHandler):
         mapping = models.Relationship(source=row_obj, destination=snapshot)
         relationships.append(mapping)
         db.session.add(mapping)
+        signals.Restful.model_posted.send(models.Relationship, obj=mapping)
       elif self.unmap and mapping:
         db.session.delete(mapping)
+        signals.Restful.model_deleted.send(models.Relationship, obj=mapping)
     db.session.flush(relationships)
     self.dry_run = True
 

--- a/test/integration/ggrc/converters/test_import_assessments.py
+++ b/test/integration/ggrc/converters/test_import_assessments.py
@@ -264,9 +264,9 @@ class TestAssessmentImport(TestCase):
     self.assertEqual(assessments["Assessment 64"].status,
                      all_models.Assessment.FINAL_STATE)
     self.assertEqual(assessments["Assessment 3"].status,
-                     all_models.Assessment.FINAL_STATE)
+                     all_models.Assessment.PROGRESS_STATE)
     self.assertEqual(assessments["Assessment 4"].status,
-                     all_models.Assessment.FINAL_STATE)
+                     all_models.Assessment.PROGRESS_STATE)
 
     # Check that there is only one attachment left
     asmt1 = assessments["Assessment 1"]

--- a/test/integration/ggrc/converters/test_import_assessments.py
+++ b/test/integration/ggrc/converters/test_import_assessments.py
@@ -219,7 +219,7 @@ class TestAssessmentImport(TestCase):
         "user 2": {"Assignees", "Creators"}
     }
     self._test_assessment_users(asmt_1, users)
-    self.assertEqual(asmt_1.status, all_models.Assessment.START_STATE)
+    self.assertEqual(asmt_1.status, all_models.Assessment.PROGRESS_STATE)
 
     # Test second Assessment line in the CSV file
     asmt_2 = all_models.Assessment.query.filter_by(slug="Assessment 2").first()

--- a/test/integration/ggrc/notifications/test_assessment_notifications.py
+++ b/test/integration/ggrc/notifications/test_assessment_notifications.py
@@ -259,6 +259,7 @@ class TestAssessmentNotification(TestCase):
     self.assertEqual(len(notifs), 1)
 
   def assert_asmnt_notifications(self):
+    """Check if Assessment reopen notifications are sent."""
     notifs, _ = common.get_daily_notifications()
     self.assertEqual(len(notifs), 2)
 
@@ -328,6 +329,7 @@ class TestAssessmentNotification(TestCase):
     with factories.single_commit():
       assessment = factories.AssessmentFactory()
       control = factories.ControlFactory()
+    # pylint: disable=expression-not-assigned
     self._create_snapshots(assessment.audit, [control])[0]
     assessment.add_person_with_role_name(user, "Verifiers")
     assessment.status = status

--- a/test/integration/ggrc/notifications/test_assessment_notifications.py
+++ b/test/integration/ggrc/notifications/test_assessment_notifications.py
@@ -2,7 +2,9 @@
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
 """Tests of assessment notifications."""
-from collections import OrderedDict
+import collections
+import ddt
+import mock
 
 from ggrc import db
 from ggrc.notifications import common
@@ -11,9 +13,11 @@ from ggrc.models import all_models
 from integration.ggrc import api_helper
 from integration.ggrc import TestCase
 from integration.ggrc.access_control import acl_helper
+from integration.ggrc.generator import ObjectGenerator
 from integration.ggrc.models import factories
 
 
+@ddt.ddt
 class TestAssessmentNotification(TestCase):
   """Tests of assessment notifications"""
 
@@ -142,7 +146,7 @@ class TestAssessmentNotification(TestCase):
     from flask import g
     setattr(g, '_current_user', user)
 
-    import_data = OrderedDict([
+    import_data = collections.OrderedDict([
         ("object_type", "Assessment"),
         ("Code*", assessment_slug),
         ("Test GCAD", "test value"),
@@ -253,3 +257,86 @@ class TestAssessmentNotification(TestCase):
     self.assert200(resp)
     notifs, _ = common.get_daily_notifications()
     self.assertEqual(len(notifs), 1)
+
+  def assert_asmnt_notifications(self):
+    notifs, _ = common.get_daily_notifications()
+    self.assertEqual(len(notifs), 2)
+
+    with mock.patch("ggrc.notifications.common.send_email") as send_email_mock:
+      self.client.get("/_notifications/send_daily_digest")
+      _, _, content = send_email_mock.call_args[0]
+      self.assertIn("Assessments have been updated", content)
+      self.assertIn("Reopened assessments", content)
+
+  @ddt.data(
+      all_models.Assessment.DONE_STATE,
+      all_models.Assessment.FINAL_STATE,
+  )
+  def test_import_evidence_mapped(self, status):
+    """Test notifications for '{}' Assessment if Evidence mapped in import."""
+    object_generator = ObjectGenerator()
+    _, user = object_generator.generate_person(user_role="Creator")
+    assessment = factories.AssessmentFactory()
+    assessment.add_person_with_role_name(user, "Verifiers")
+    assessment.status = status
+    db.session.commit()
+
+    response = self.import_data(collections.OrderedDict([
+        ("object_type", "Assessment"),
+        ("Code*", assessment.slug),
+        ("Evidence URL", "some url"),
+    ]))
+    self._check_csv_response(response, {})
+    self.assert_asmnt_notifications()
+
+  @ddt.data(
+      all_models.Assessment.DONE_STATE,
+      all_models.Assessment.FINAL_STATE,
+  )
+  def test_import_lcad_changed(self, status):
+    """Test notifications for '{}' Assessment if LCAD changed in import."""
+    object_generator = ObjectGenerator()
+    _, user = object_generator.generate_person(user_role="Creator")
+    with factories.single_commit():
+      assessment = factories.AssessmentFactory()
+      factories.CustomAttributeDefinitionFactory(
+          title="Test LCAD",
+          definition_type="assessment",
+          definition_id=assessment.id,
+          attribute_type="Text",
+      )
+    assessment.add_person_with_role_name(user, "Verifiers")
+    assessment.status = status
+    db.session.commit()
+
+    response = self.import_data(collections.OrderedDict([
+        ("object_type", "Assessment"),
+        ("Code*", assessment.slug),
+        ("Test LCAD", "some value"),
+    ]))
+    self._check_csv_response(response, {})
+    self.assert_asmnt_notifications()
+
+  @ddt.data(
+      all_models.Assessment.DONE_STATE,
+      all_models.Assessment.FINAL_STATE,
+  )
+  def test_import_snapshot_mapped(self, status):
+    """Test notifications for '{}' Assessment if snapshot mapped in import."""
+    object_generator = ObjectGenerator()
+    _, user = object_generator.generate_person(user_role="Creator")
+    with factories.single_commit():
+      assessment = factories.AssessmentFactory()
+      control = factories.ControlFactory()
+    self._create_snapshots(assessment.audit, [control])[0]
+    assessment.add_person_with_role_name(user, "Verifiers")
+    assessment.status = status
+    db.session.commit()
+
+    response = self.import_data(collections.OrderedDict([
+        ("object_type", "Assessment"),
+        ("Code*", assessment.slug),
+        ("Map:control versions", control.slug),
+    ]))
+    self._check_csv_response(response, {})
+    self.assert_asmnt_notifications()

--- a/test/integration/ggrc/notifications/test_assignable_notifications.py
+++ b/test/integration/ggrc/notifications/test_assignable_notifications.py
@@ -821,13 +821,13 @@ class TestAssignableNotificationUsingAPI(TestAssignableNotification):
       asmts = {asmt.slug: asmt for asmt in Assessment.query}
 
       notifications = self._get_notifications().all()
-      self.assertEqual(len(notifications), 6)
+      self.assertEqual(len(notifications), 7)
 
       revisions = Revision.query.filter(
           Revision.resource_type == 'Notification',
           Revision.resource_id.in_([notif.id for notif in notifications])
       ).count()
-      self.assertEqual(revisions, 6)
+      self.assertEqual(revisions, 7)
 
       self.client.get("/_notifications/send_daily_digest")
       self.assertEqual(self._get_notifications().count(), 0)

--- a/test/integration/ggrc/test_csvs/assessment_notifications.csv
+++ b/test/integration/ggrc/test_csvs/assessment_notifications.csv
@@ -14,7 +14,7 @@ Audit,Code*,Program*,Title*,Audit Captains*,State,,,,,,,,,,,
 ,,,,,,,,,,,,,,,,
 Object type,,,,,,,,,,,,,,,,
 Assessment,Code*,Audit*,Title*,Evidence URL,Assessment Procedure,Assignees*,Creators*,Verifiers,Recipients,Send by default,Due Date,Finished Date,Verified Date,State*,Conclusion: Design,Conclusion: Operation
-,A 1,Audit,No template Assessment 1,https://i.imgur.com/17h9PH3.gif,,user1@example.com,user2@example.com,user3@example.com,,no,,,,in progress,Effective,Effective
+,A 1,Audit,No template Assessment 1,,,user1@example.com,user2@example.com,user3@example.com,,no,,,,in progress,Effective,Effective
 ,A 2,Audit,No template Assessment 2,,,user1@example.com,user2@example.com,user3@example.com,"Assignees, Creators, Verifiers",,,,,in progress,Ineffective,Needs improvement
 ,A 3,Audit,No template Assessment 3,,,user1@example.com,user2@example.com,,"Creators
 Verifiers",Yes,,,,in progress,needs improvement,Not Applicable


### PR DESCRIPTION
# Issue description

User doesn't get notification if update assessment which is "Completed", "Ready for review" states via import

# Steps to test the changes

Steps to reproduce:
1. Export created assessment in UI (assessment is "Completed", "Ready for review")
2. Update assessment:
editing Assessment mappings through imports
editing Assessment evidence through imports
editing Assessment CA values through imports
3. Import assessment 

Actual Result: User doesn't get notification if update assessment which is "Completed", "Ready for review" states via import

Expected Result: User gets notification if update assessment which is "Completed", "Ready for review" states via import

# Solution description

Send model_posted signal when assessment mapping created. Send model_put signal after secondary_objects insert.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
