### PR TITLE
GGRC-6576 Fix loading of relationships to CalendarEvents

### DIFF
--- a/src/ggrc_workflows/models/cycle_task_group_object_task.py
+++ b/src/ggrc_workflows/models/cycle_task_group_object_task.py
@@ -102,6 +102,21 @@ class CycleTaskGroupObjectTask(roleable.Roleable,
       "folder",
   ]
 
+  # The app should not pass to the json representation of
+  # relationships to the internal models
+  IGNORED_RELATED_TYPES = ["CalendarEvent"]
+
+  _custom_publish = {
+      "related_sources": lambda obj: [
+          rel.log_json() for rel in obj.related_sources
+          if rel.source_type not in obj.IGNORED_RELATED_TYPES
+      ],
+      "related_destinations": lambda obj: [
+          rel.log_json() for rel in obj.related_destinations
+          if rel.destination_type not in obj.IGNORED_RELATED_TYPES
+      ]
+  }
+
   AUTO_REINDEX_RULES = [
       ft_mixin.ReindexRule("CycleTaskEntry",
                            lambda x: x.cycle_task_group_object_task),

--- a/test/integration/ggrc/gcalendar/test_calendar_events_model.py
+++ b/test/integration/ggrc/gcalendar/test_calendar_events_model.py
@@ -1,0 +1,47 @@
+# Copyright (C) 2018 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Tests calendar event model."""
+
+from datetime import date
+
+from ggrc.models import all_models
+from integration.ggrc import api_helper
+from integration.ggrc.gcalendar import BaseCalendarEventTest
+
+
+# pylint: disable=protected-access
+class TestCalendarEventModel(BaseCalendarEventTest):
+  """Test calendar event model."""
+
+  def setUp(self):
+    """Set up test with mocks."""
+    super(TestCalendarEventModel, self).setUp()
+    self.client.get("/login")
+    self.api = api_helper.Api()
+
+  def test_cycle_task_relationships(self):
+    """Test related sources and destinations of CycleTaskGroupObjectTask."""
+    _, task, event = self.setup_person_task_event(date(2015, 1, 5))
+    relationship = self.get_relationship(task.id, event.id)
+
+    db_task = all_models.CycleTaskGroupObjectTask.query.get(task.id)
+    sources_ids = [rel.id for rel in db_task.related_sources]
+    destinations_ids = [rel.id for rel in db_task.related_destinations]
+    self.assertTrue(relationship.id in sources_ids or
+                    relationship.id in destinations_ids)
+
+    response = self.api.get_query(all_models.CycleTaskGroupObjectTask,
+                                  '__sort=id')
+    task_collection = response.json['cycle_task_group_object_tasks_collection']
+    task_json = task_collection['cycle_task_group_object_tasks'][0]
+
+    sources_ids = []
+    for item in task_json['related_sources']:
+      sources_ids.append(item['id'])
+    destinations_ids = []
+    for item in task_json['related_destinations']:
+      destinations_ids.append(item['id'])
+
+    self.assertTrue(relationship.id not in sources_ids)
+    self.assertTrue(relationship.id not in destinations_ids)


### PR DESCRIPTION
# Issue description

The models that has relationship to CalendarEvent will fail to load.

# Steps to test the changes
Steps to reproduce:

1. Create repeat off WF
2. Create a task
3. Activate WF
4. Generate a CalendarEvent
5. Open CT's info panel on Active Cycles tab and look at the Network tab (devTools)
Actual Result: GET 500 while expanding CT's Info panel
Expected Result: no errors should be displayed

# Solution description

Define `_custom_publish` for CycleTaskGroupObjectTask that filter out relationships to `CalendarEvent`. 

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:run' labels to all open PRs with a label 'migration'
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
