### PR TITLE
GGRC-6597 500 status when requesting not empty Revisions

### DIFF
--- a/src/ggrc/utils/revisions_diff/builder.py
+++ b/src/ggrc/utils/revisions_diff/builder.py
@@ -274,7 +274,7 @@ def _construct_diff(meta, current_content, new_content):
       "mapping_list_fields": generate_list_mappings(
           meta.mapping_list_fields,
           new_content,
-          current_content
+          current_content,
       ),
   }
 
@@ -286,15 +286,5 @@ def prepare(instance, content):
   return _construct_diff(
       meta=instance_meta_info,
       current_content=current_data,
-      new_content=content
-  )
-
-
-def differ(instance_cls, new_content, current_content):
-  """Get diff between two contents of specified type."""
-  instance_meta_info = meta_info.MetaInfo(instance_cls())
-  return _construct_diff(
-      meta=instance_meta_info,
-      current_content=current_content,
-      new_content=new_content
+      new_content=content,
   )


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

If requesting not empty revisions right after object change, 500 status code is returned.

# Steps to test the changes

1. Open some Control;
2. Open Edit modal and click save without any changes;
3. Run query API request;
```
{
            "object_name": "Revision",
            "filters": {
                "expression": {
                    "op": {"name": "not_empty_revisions"},
                    "resource_type": "Control",
                    "resource_id": <object_id>
                }
            }
}
```
4. Expected result: query returns not empty revisions without errors.

# Solution description

Solution consists of replacing comparison of two revision contents. Instead a comparison of diffs of each revision with current instance is performed.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:run' labels to all open PRs with a label 'migration'
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
