### PR TITLE
GGRC-6594 nightly cron job split

### DIFF
--- a/src/cron.yaml
+++ b/src/cron.yaml
@@ -4,9 +4,17 @@
 # See https://developers.google.com/appengine/docs/python/config/appconfig
 
 cron:
-- description: GGRC workflow - starting point for all batch jobs
+- description: GGRC - starting point for nightly batch jobs
   url: /nightly_cron_endpoint
+  schedule: every day 00:40
+  timezone: US/Pacific
+- description: GGRC - starting point for nightly notifications jobs
+  url: /nightly_notifications_cron_endpoint
   schedule: every day 01:00
+  timezone: US/Pacific
+- description: GGRC - starting point for nightly event sending jobs
+  url: /nightly_send_events_cron_endpoint
+  schedule: every day 00:45
   timezone: US/Pacific
 - description: GGRC - Hourly Issue Tracker sync job
   url: /hourly_issue_tracker_sync_endpoint

--- a/src/ggrc/contributions.py
+++ b/src/ggrc/contributions.py
@@ -12,10 +12,16 @@ from ggrc.notifications import data_handlers
 from ggrc.notifications import import_export as import_export_notifications
 
 NIGHTLY_CRON_JOBS = [
+    import_export.clear_overtimed_tasks,
+]
+
+NIGHTLY_SEND_EVENTS_JOB = [
+    common.send_calendar_events,
+]
+
+NIGHTLY_NOTIFICATIONS_CRON_JOBS = [
     common.generate_cycle_tasks_notifs,
     common.send_daily_digest_notifications,
-    common.send_calendar_events,
-    import_export.clear_overtimed_tasks,
 ]
 
 HOURLY_CRON_JOBS = [

--- a/src/ggrc/gcalendar/calendar_event_builder.py
+++ b/src/ggrc/gcalendar/calendar_event_builder.py
@@ -116,8 +116,8 @@ class CalendarEventBuilder(object):
       for event_id in events_ids:
         self._delete_event_relationship(event_id, task.id)
     except Exception as exp:   # pylint: disable=broad-except
-      logger.warn("Generating of event for task %d has failed with the "
-                  "following error %s.", task.id, exp.message)
+      logger.exception("Generating of event for task %d has failed with the "
+                       "following error %s.", task.id, exp.message)
 
   def _get_event_by_date_and_attendee(self, attendee_id, end_date):
     """Get calendar events by attendee and due date."""

--- a/src/ggrc/gcalendar/calendar_event_builder.py
+++ b/src/ggrc/gcalendar/calendar_event_builder.py
@@ -3,6 +3,8 @@
 
 """Module with CalendarEventBuilder class."""
 
+import logging
+
 from sqlalchemy.orm import load_only
 from sqlalchemy import orm
 
@@ -11,6 +13,9 @@ from ggrc import settings
 from ggrc.models import all_models
 from ggrc.gcalendar import utils
 from ggrc.utils import benchmark
+
+
+logger = logging.getLogger(__name__)
 
 
 # pylint: disable=too-few-public-methods
@@ -94,21 +99,25 @@ class CalendarEventBuilder(object):
 
   def _generate_events_for_task(self, task, events_ids):
     """Generates CalendarEvents for CycleTaskGroupObjectTask."""
-    if self._should_create_event_for(task):
-      for person_id in self._get_task_persons_ids_to_notify(task):
-        event = self._get_event_by_date_and_attendee(
-            attendee_id=person_id,
-            end_date=task.end_date
-        )
-        if not event:
-          event = self._create_event_with_relationship(task, person_id)
-          self.events.append(event)
-        else:
-          self._create_event_relationship(task, event)
-          events_ids.discard(event.id)
+    try:
+      if self._should_create_event_for(task):
+        for person_id in self._get_task_persons_ids_to_notify(task):
+          event = self._get_event_by_date_and_attendee(
+              attendee_id=person_id,
+              end_date=task.end_date
+          )
+          if not event:
+            event = self._create_event_with_relationship(task, person_id)
+            self.events.append(event)
+          else:
+            self._create_event_relationship(task, event)
+            events_ids.discard(event.id)
 
-    for event_id in events_ids:
-      self._delete_event_relationship(event_id, task.id)
+      for event_id in events_ids:
+        self._delete_event_relationship(event_id, task.id)
+    except Exception as exp:   # pylint: disable=broad-except
+      logger.warn("Generating of event for task %d has failed with the "
+                  "following error %s.", task.id, exp.message)
 
   def _get_event_by_date_and_attendee(self, attendee_id, end_date):
     """Get calendar events by attendee and due date."""
@@ -142,18 +151,17 @@ class CalendarEventBuilder(object):
 
   def _create_event_with_relationship(self, task, person_id):
     """Creates calendar event and relationship based on task and person id."""
-    with benchmark("Create Calendar event for task {}".format(task.id)):
-      event = all_models.CalendarEvent(
-          due_date=task.end_date,
-          attendee_id=person_id,
-          title=self.TASK_TITLE_TEMPLATE.format(prefix=self.title_prefix),
-          modified_by_id=person_id,
-      )
-      db.session.add(event)
-      db.session.add(all_models.Relationship(
-          source=task,
-          destination=event,
-      ))
+    event = all_models.CalendarEvent(
+        due_date=task.end_date,
+        attendee_id=person_id,
+        title=self.TASK_TITLE_TEMPLATE.format(prefix=self.title_prefix),
+        modified_by_id=person_id,
+    )
+    db.session.add(event)
+    db.session.add(all_models.Relationship(
+        source=task,
+        destination=event,
+    ))
     return event
 
   @staticmethod

--- a/src/ggrc/notifications/common.py
+++ b/src/ggrc/notifications/common.py
@@ -420,9 +420,9 @@ def send_calendar_events():
       sync = calendar_event_sync.CalendarEventsSync()
       sync.sync_cycle_tasks_events()
   except Exception as exp:
-    error_msg = "Sending of calendar events failed with the following " \
-                "error {}".format(exp.message)
-    logger.error(error_msg)
+    error_msg = ("Sending of calendar events failed with the following "
+                 "error {}".format(exp.message))
+    logger.exception(error_msg)
   return utils.make_simple_response(error_msg)
 
 

--- a/src/ggrc/notifications/common.py
+++ b/src/ggrc/notifications/common.py
@@ -420,8 +420,9 @@ def send_calendar_events():
       sync = calendar_event_sync.CalendarEventsSync()
       sync.sync_cycle_tasks_events()
   except Exception as exp:
-    logger.error(exp.message)
-    error_msg = exp.message
+    error_msg = "Sending of calendar events failed with the following " \
+                "error {}".format(exp.message)
+    logger.error(error_msg)
   return utils.make_simple_response(error_msg)
 
 

--- a/src/ggrc/views/converters.py
+++ b/src/ggrc/views/converters.py
@@ -478,7 +478,6 @@ def handle_get(id2, command, job_type):
       BadRequest("Unknown command")
     return handle_file_download(id2)
   try:
-    import_export.clear_overtimed_tasks()
     if id2:
       res = import_export.get(id2).log_json()
     else:

--- a/src/ggrc/views/cron.py
+++ b/src/ggrc/views/cron.py
@@ -24,13 +24,13 @@ def send_error_notification(message):
 
 
 def run_job(job):
-  """Call sent job.
+  """Execute the provided job.
 
-  Failuare on job will just logged and don't stop runner.
+     Failure on job will just logged and don't stop runner.
   """
   try:
     job()
-  except:  # pylint: disable=bare-except
+  except Exception:  # pylint: disable=broad-except
     logger.exception("Job '%s' failed", job.__name__)
     send_error_notification(
         "Job '%s' failed with: \n%s" % (job.__name__, format_exc())
@@ -46,12 +46,22 @@ def job_runner(name):
 
 
 def nightly_cron_endpoint():
-  """Endpoint running nightly jobs from all modules"""
+  """Endpoint running nightly jobs from all modules."""
   return job_runner("NIGHTLY_CRON_JOBS")
 
 
+def nightly_notifications_cron_endpoint():
+  """Endpoint for nightly notifications jobs."""
+  return job_runner("NIGHTLY_NOTIFICATIONS_CRON_JOBS")
+
+
+def nightly_send_events_cron_endpoint():
+  """Endpoint for nightly event sending jobs."""
+  return job_runner("NIGHTLY_SEND_EVENTS_JOB")
+
+
 def hourly_issue_tracker_sync_endpoint():
-  """Endpoint running hourly jobs from all modules"""
+  """Endpoint running hourly jobs from all modules."""
   return job_runner("HOURLY_CRON_JOBS")
 
 
@@ -69,7 +79,20 @@ def init_cron_views(app):
   """Init all cron jobs' endpoints"""
   app.add_url_rule(
       "/nightly_cron_endpoint", "nightly_cron_endpoint",
-      view_func=nightly_cron_endpoint)
+      view_func=nightly_cron_endpoint
+  )
+
+  app.add_url_rule(
+      "/nightly_send_events_cron_endpoint",
+      "nightly_send_events_cron_endpoint",
+      view_func=nightly_send_events_cron_endpoint
+  )
+
+  app.add_url_rule(
+      "/nightly_notifications_cron_endpoint",
+      "nightly_notifications_cron_endpoint",
+      view_func=nightly_notifications_cron_endpoint
+  )
 
   app.add_url_rule(
       "/hourly_issue_tracker_sync_endpoint",

--- a/test/integration/ggrc/gcalendar/test_calendar_event_builder.py
+++ b/test/integration/ggrc/gcalendar/test_calendar_event_builder.py
@@ -212,3 +212,14 @@ class TestCalendarEventBuilder(BaseCalendarEventTest):
     for task in tasks:
       relationship = self.get_relationship(task.id, event.id)
       self.assertIsNotNone(relationship)
+
+  @mock.patch("ggrc.gcalendar.calendar_event_builder.CalendarEventBuilder."
+              "_should_create_event_for", side_effect=Exception("test"))
+  def test_fail_to_build_event(self, should_create_mock):
+    """Test that sync job tried to sync the second event after a failure."""
+    self.setup_person_task_event(date(2015, 1, 5))
+    self.setup_person_task_event(date(2015, 1, 6))
+    with freeze_time("2015-01-1 12:00:00"):
+      self.builder._preload_data()
+      self.builder._generate_events()
+    self.assertEqual(should_create_mock.call_count, 2)

--- a/test/integration/ggrc/notifications/test_assignable_notifications.py
+++ b/test/integration/ggrc/notifications/test_assignable_notifications.py
@@ -1314,7 +1314,8 @@ class TestAssignableNotificationUsingAPI(TestAssignableNotification):
     reopened_notifs = self._get_notifications(notif_type="assessment_reopened")
     self.assertEqual(reopened_notifs.count(), 1)
 
-  @ddt.data("/_notifications/send_daily_digest", "nightly_cron_endpoint")
+  @ddt.data("/_notifications/send_daily_digest",
+            "nightly_notifications_cron_endpoint")
   @patch("ggrc.notifications.common.send_email")
   def test_notifications_missing_revision(self, url, send_email):
     """Test notifications with missing revision"""


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

In case `send_daily_digest` has failed with an error, despite having try-catch clause, all the following jobs may fail to execute. For example, we might to have the error like this for next jobs: 
```
This Session's transaction has been rolled back due to a previous exception during flush.
To begin a new transaction with this Session, first issue Session.rollback(). 
Original exception was: (IntegrityError) (1062, "Duplicate entry '1384' for key 'PRIMARY'") 
```
Also the `send_calendar_events` job will fail in case the generation (not sync) of any event has failed. We need to handle this gracefully

# Steps to test the changes

* Run the nightly cron jobs

# Solution description

1. Split nightly cron jobs on logical units: email notifications, calendar notifications, all other. It will allow to execute the jobs in parallel and will help to avoid the situations as stated above.
2. Add try-catch block on every calendar event generation in order not to fail the whole job if one event generation has failed.
3. Remove redundant call for clearing of BG tasks since the new implementation with cloud tasks api was introduced recently. 

# Sanity checklist

- [ ] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:run' labels to all open PRs with a label 'migration'
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
