### PR TITLE
GGRC-6617 Make not_empty_revisions not to ignore certain fields

### DIFF
--- a/src/ggrc/query/custom_operators.py
+++ b/src/ggrc/query/custom_operators.py
@@ -21,7 +21,7 @@ from ggrc.query import autocast
 from ggrc.query import my_objects
 from ggrc.query.exceptions import BadQueryException
 from ggrc.snapshotter import rules
-from ggrc.utils.revisions_diff import builder as revdiff_builder
+from ggrc.utils import revisions_diff
 
 
 GETATTR_WHITELIST = {
@@ -485,7 +485,12 @@ def cascade_unmappable(exp, object_class, target_class, query):
 
 @validate("resource_type", "resource_id")
 def not_empty_revisions(exp, object_class, target_class, query):
-  """Filter revisions containing object state changes."""
+  """Filter revisions containing object state changes.
+
+  This operator is useful if revisions with object state changes are needed.
+  Revisions without object state changes are created when object editing
+  without any actual changes is performed.
+  """
   if object_class is not all_models.Revision:
     raise BadQueryException("'not_empty_revisions' operator works with "
                             "Revision only")
@@ -506,11 +511,18 @@ def not_empty_revisions(exp, object_class, target_class, query):
   )
 
   current_instance = resource_cls.query.get(resource_id)
-
+  current_instance_meta = revisions_diff.meta_info.MetaInfo(current_instance)
+  latest_rev_content = revisions_diff.builder.get_latest_revision_content(
+      current_instance,
+  )
   prev_diff = None
   revision_with_changes = []
   for revision in query:
-    diff = revdiff_builder.prepare(current_instance, revision.content)
+    diff = revisions_diff.builder.prepare_content_diff(
+        instance_meta_info=current_instance_meta,
+        l_content=latest_rev_content,
+        r_content=revision.content,
+    )
     if diff != prev_diff:
       revision_with_changes.append(revision.id)
       prev_diff = diff
@@ -526,6 +538,7 @@ LT_OPERATOR = validate("left", "right")(build_op_shortcut(operator.lt))
 GT_OPERATOR = validate("left", "right")(build_op_shortcut(operator.gt))
 LE_OPERATOR = validate("left", "right")(build_op_shortcut(operator.le))
 GE_OPERATOR = validate("left", "right")(build_op_shortcut(operator.ge))
+
 
 OPS = {
     "AND": and_operation,

--- a/src/ggrc/utils/revisions_diff/builder.py
+++ b/src/ggrc/utils/revisions_diff/builder.py
@@ -288,3 +288,48 @@ def prepare(instance, content):
       current_content=current_data,
       new_content=content,
   )
+
+
+def prepare_content_diff(instance_meta_info, l_content, r_content):
+  """Prepare diff between two revisions contents of same instance.
+
+  This functionality is needed for `not_empty_revisions` query API operator.
+  The main difference between this function and `prepare` is that this one
+  takes into account all revision's content fields and not just fields
+  explicitly marked as updateable on instance model.
+
+  Args:
+      instance_meta_info (MetaInfo): object of particular instance.
+      l_content (dict): content of first revision.
+      r_content (dict): content of second revision.
+
+  Returns:
+      A dict representing the diff between two revision contents.
+  """
+  diff = _construct_diff(instance_meta_info, l_content, r_content)
+
+  remaining_fields = set(r_content.keys())
+  remaining_fields -= {f.name for f in instance_meta_info.fields}
+  remaining_fields -= {f.name for f in instance_meta_info.mapping_fields}
+  remaining_fields -= {f.name for f in instance_meta_info.mapping_list_fields}
+  remaining_fields -= {
+      # Diff for `access_control_list` and `custom_attribute_values` has
+      # already been calculated in `_construct_diff` function call.
+      "access_control_list",
+      "custom_attribute_values",
+      # The following fields are ignored cause they may differ but revisions
+      # still may represent objects of same state.
+      "created_at",
+      "updated_at",
+      "modified_by",
+      "modified_by_id",
+  }
+
+  remaining_fields = {meta_info.Field(f, False) for f in remaining_fields}
+  diff["other"] = generate_fields(
+      fields=remaining_fields,
+      proposed_content=r_content,
+      current_data=l_content,
+  )
+
+  return diff

--- a/test/integration/ggrc/services/test_query/test_not_empty.py
+++ b/test/integration/ggrc/services/test_query/test_not_empty.py
@@ -9,6 +9,7 @@ from integration import ggrc as test_ggrc
 from integration.ggrc import factories
 from integration.ggrc import api_helper
 from integration.ggrc import query_helper
+from integration.ggrc import review
 
 
 class TestNotEmptyRevisions(test_ggrc.TestCase, query_helper.WithQueryApi):
@@ -38,38 +39,87 @@ class TestNotEmptyRevisions(test_ggrc.TestCase, query_helper.WithQueryApi):
     listeners.reindex_on_commit = lambda: True
     self.del_taskueue()
 
-  def test_not_empty_revisions(self):
-    """Test `not_empty_revisions` returns revisions with changes."""
-    self._turn_on_bg_indexing()
-    with factories.single_commit():
-      control = factories.ControlFactory()
-
-    edits_count = 3
-    for _ in range(edits_count):
-      response = self.api.put(control, {})
-      self.assert200(response)
-
-    all_revisions_count = all_models.Revision.query.filter(
-        all_models.Revision.resource_type == control.type,
-        all_models.Revision.resource_id == control.id,
-    ).count()
-    # Revision also is created when creating an object
-    self.assertEqual(all_revisions_count, edits_count + 1)
-
-    not_empty_revisions = self._get_first_result_set(
+  def _query_not_empty_revisions(self, instance):
+    """Helper function to qeury not empty revisions with query API."""
+    return self._get_first_result_set(
         {
             "object_name": "Revision",
             "type": "ids",
             "filters": {
                 "expression": {
                     "op": {"name": "not_empty_revisions"},
-                    "resource_type": control.type,
-                    "resource_id": control.id,
+                    "resource_type": instance.type,
+                    "resource_id": instance.id,
                 },
             },
         },
         "Revision",
         "ids",
     )
+
+  @staticmethod
+  def _count_revisions(instance):
+    """Helper function to count instance revisions."""
+    return all_models.Revision.query.filter(
+        all_models.Revision.resource_type == instance.type,
+        all_models.Revision.resource_id == instance.id,
+    ).count()
+
+  @staticmethod
+  def _refresh_instance(instance_type, instance_id):
+    """Helper function to refresh instance from db."""
+    instance_cls = getattr(all_models, instance_type, None)
+    if instance_cls is None:
+      raise ValueError("'{}' is not a valid instance type"
+                       .format(instance_type))
+    return instance_cls.query.get(instance_id)
+
+  def test_not_empty_revisions(self):
+    """Test `not_empty_revisions` returns revisions with changes."""
+    self._turn_on_bg_indexing()
+    instance = factories.ControlFactory()
+
+    def edit_without_changes(instance):
+      """Helper function to perform instance edit without actual changes."""
+      response = self.api.put(instance, {})
+      self.assert200(response)
+
+    edit_without_changes(instance)
+    instance = self._refresh_instance(instance.type, instance.id)
+    revisions_count = self._count_revisions(instance)
+    not_empty_revisions = self._query_not_empty_revisions(instance)
+
+    self.assertEqual(revisions_count, 2)
     self.assertEqual(len(not_empty_revisions), 1)
     self._turn_off_bg_indexing()
+
+  def test_review_status(self):
+    """Test not_empty_revisions works correcly with review status change."""
+    instance = factories.ControlFactory()
+
+    def mark_as_reviewed(instance):
+      """Helper function to mark `instance` as reviewed."""
+      response = self.api.post(
+          all_models.Review,
+          {
+              "review": {
+                  "reviewable": {
+                      "type": instance.type,
+                      "id": instance.id,
+                  },
+                  "context": None,
+                  "notification_type": "email",
+                  "status": all_models.Review.STATES.REVIEWED,
+                  "access_control_list": review.build_reviewer_acl(),
+              },
+          },
+      )
+      self.assertStatus(response, 201)
+
+    mark_as_reviewed(instance)
+    instance = self._refresh_instance(instance.type, instance.id)
+    revisions_count = self._count_revisions(instance)
+    not_empty_revisions = self._query_not_empty_revisions(instance)
+
+    self.assertEqual(revisions_count, 2)
+    self.assertEqual(len(not_empty_revisions), 2)


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Currently `not_empty_revisions` query API operator ignores revisions containing changes in some fields, e.g. `review_status`, but it should not.

# Steps to test the changes

1. Open control;
2. Click button "Mark Reviewed";
3. Run next query API request;
```
{
            "object_name": "Revision",
            "filters": {
                "expression": {
                    "op": {"name": "not_empty_revisions"},
                    "resource_type": "Control",
                    "resource_id": <object_id>
                }
            }
}
```
4. See revision with changed review_status in result.

# Solution description

The bug was caused by usage of `utils.revisions_diff.builder.prepare` function to calculate diff between revisions. This did not work out because this function was created for using it with proposals functionality (at least I think so) and it skips certain revision fields, specifically the ones which are properties on models and aren't marked as updatable.

The solution consists of creating function `utils.revisions_diff.builder.prepare_content_diff` which uses the same functionality `prepare` is using but additionally compares revisions fields that were skipped.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:run' labels to all open PRs with a label 'migration'
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
