### PR TITLE
GGRC-6601 Fix Audit with manual mapping 

### DIFF
--- a/src/ggrc/snapshotter/__init__.py
+++ b/src/ggrc/snapshotter/__init__.py
@@ -47,6 +47,7 @@ class SnapshotGenerator(object):
     self.snapshots = dict()
     self.context_cache = dict()
     self.dry_run = dry_run
+    self.manual_snapshots = dict()
 
   def add_parent(self, obj):
     """Add parent object and automatically scan neighborhood for snapshottable
@@ -60,6 +61,7 @@ class SnapshotGenerator(object):
           self.context_cache[key] = obj.context_id
           self.children = self.children | objs
           self.snapshots[key] = objs
+          self.manual_snapshots[key] = getattr(obj, "manual_snapshots", False)
       return self.parents
 
   def add_family(self, parent, children):
@@ -268,9 +270,11 @@ class SnapshotGenerator(object):
 
     existing_scope = {Pair.from_4tuple(fields) for fields in query}
 
-    full_scope = {Pair(parent, child)
-                  for parent, children in self.snapshots.items()
-                  for child in children}
+    full_scope = set()
+    for parent, children in self.snapshots.items():
+      if not self.manual_snapshots.get(parent, False):
+        for child in children:
+          full_scope.add(Pair(parent, child))
 
     for_update = existing_scope
     for_create = full_scope - existing_scope

--- a/src/ggrc/snapshotter/__init__.py
+++ b/src/ggrc/snapshotter/__init__.py
@@ -47,7 +47,7 @@ class SnapshotGenerator(object):
     self.snapshots = dict()
     self.context_cache = dict()
     self.dry_run = dry_run
-    self.manual_snapshots = dict()
+    self.manual_snapshots = set()
 
   def add_parent(self, obj):
     """Add parent object and automatically scan neighborhood for snapshottable
@@ -61,7 +61,8 @@ class SnapshotGenerator(object):
           self.context_cache[key] = obj.context_id
           self.children = self.children | objs
           self.snapshots[key] = objs
-          self.manual_snapshots[key] = getattr(obj, "manual_snapshots", False)
+          if getattr(obj, "manual_snapshots", False):
+            self.manual_snapshots.add(key)
       return self.parents
 
   def add_family(self, parent, children):
@@ -272,7 +273,7 @@ class SnapshotGenerator(object):
 
     full_scope = set()
     for parent, children in self.snapshots.items():
-      if not self.manual_snapshots.get(parent, False):
+      if parent not in self.manual_snapshots:
         for child in children:
           full_scope.add(Pair(parent, child))
 

--- a/test/integration/ggrc/models/test_audit.py
+++ b/test/integration/ggrc/models/test_audit.py
@@ -237,8 +237,8 @@ class TestManualAudit(TestCase):
     snapshot_count = all_models.Snapshot.query.count()
     self.assertEqual(snapshot_count, count)
 
-  def assertRelatedObjectives(self, snapshot_id, count):
-    """Assert related objectives count for control snapshot"""
+  def count_related_objectives(self, snapshot_id):
+    """Returns related objectives count for control snapshot"""
     query_data = [{
         "object_name": "Snapshot",
         "filters": {
@@ -277,7 +277,7 @@ class TestManualAudit(TestCase):
         api_link="/query"
     )
     self.assert200(response)
-    self.assertEqual(count, response.json[0]["Snapshot"]["count"])
+    return response.json[0]["Snapshot"]["count"]
 
   def test_audit_upsert(self):
     """Test upsert audit with manual mapping
@@ -336,14 +336,14 @@ class TestManualAudit(TestCase):
     self.gen.generate_relationship(audit, control)
     control_snapshot_id = all_models.Snapshot.query.filter_by(
         child_id=control_id, child_type="Control").first().id
-    self.assertRelatedObjectives(control_snapshot_id, 0)
+    self.assertEqual(self.count_related_objectives(control_snapshot_id), 0)
 
     self.gen.generate_relationship(audit, objective)
-    self.assertRelatedObjectives(control_snapshot_id, 1)
+    self.assertEqual(self.count_related_objectives(control_snapshot_id), 1)
 
     self.gen.generate_relationship(audit, control2)
     control2_snapshot_id = all_models.Snapshot.query.filter_by(
         child_id=control2_id, child_type="Control").first().id
-    self.assertRelatedObjectives(control2_snapshot_id, 0)
+    self.assertEqual(self.count_related_objectives(control2_snapshot_id), 0)
 
     self.assertSnapshotCount(3)

--- a/test/integration/ggrc/models/test_audit.py
+++ b/test/integration/ggrc/models/test_audit.py
@@ -222,14 +222,73 @@ class TestAudit(TestCase):
     expected_slug = "SLUG"
     self.assertEqual(current_slug, expected_slug)
 
-  def test_audit_manual_snapshots(self):
-    """Test creation audit without snapshot and adding manual snapshot"""
-    program = factories.ProgramFactory()
-    control = factories.ControlFactory()
-    factories.RelationshipFactory(
-        source=program,
-        destination=control,
+
+class TestManualAudit(TestCase):
+  """ Test Audit with manual snapshot mapping"""
+
+  # pylint: disable=invalid-name
+  def setUp(self):
+    super(TestManualAudit, self).setUp()
+    self.api = Api()
+    self.gen = generator.ObjectGenerator()
+
+  def assertSnapshotCount(self, count):
+    """Assert snapshots count"""
+    snapshot_count = all_models.Snapshot.query.count()
+    self.assertEqual(snapshot_count, count)
+
+  def assertRelatedObjectives(self, snapshot_id, count):
+    """Assert related objectives count for control snapshot"""
+    query_data = [{
+        "object_name": "Snapshot",
+        "filters": {
+            "expression": {
+                "left": {
+                    "left": "child_type",
+                    "op": {
+                        "name": "="
+                    },
+                    "right": "Objective"
+                },
+                "op": {
+                    "name": "AND"
+                },
+                "right": {
+                    "object_name": "Snapshot",
+                    "op": {
+                        "name": "relevant"
+                    },
+                    "ids": [
+                        str(snapshot_id)
+                    ]
+                }
+            }
+        },
+        "fields": [
+            "child_id",
+            "child_type",
+            "revision",
+            "parent"
+        ]
+    }]
+    response = self.api.send_request(
+        self.api.client.post,
+        data=query_data,
+        api_link="/query"
     )
+    self.assert200(response)
+    self.assertEqual(count, response.json[0]["Snapshot"]["count"])
+
+  def test_audit_upsert(self):
+    """Test upsert audit with manual mapping
+
+    Audit with manual mapping should not add new snapshots
+    after calling "Update objects to latest version"
+    """
+    with factories.single_commit():
+      program = factories.ProgramFactory()
+      control = factories.ControlFactory()
+      factories.RelationshipFactory(source=program, destination=control)
     self.api.post(all_models.Audit, [{
         "audit": {
             "title": "New Audit",
@@ -239,16 +298,52 @@ class TestAudit(TestCase):
             "manual_snapshots": True,
         }
     }])
-    audit = all_models.Audit.query.first()
-    self.assertIsNotNone(audit)
-    snapshot_count = all_models.Snapshot.query.count()
-    self.assertEqual(snapshot_count, 0)
+    self.assertSnapshotCount(0)
 
-    control = all_models.Control.query.first()
-    self.gen.generate_relationship(audit.program, control)
     audit = all_models.Audit.query.first()
-    self.api.put(audit, data={
-        "snapshots": {"operation": "upsert"}
-    })
-    snapshot_count = all_models.Snapshot.query.count()
-    self.assertEqual(snapshot_count, 1)
+    self.api.put(audit, data={"snapshots": {"operation": "upsert"}})
+    self.assertSnapshotCount(0)
+
+  def test_audit_manual_snapshots(self):
+    """Test audit with manual snapshot mapping"""
+    with factories.single_commit():
+      program = factories.ProgramFactory()
+      control = factories.ControlFactory()
+      control_id = control.id
+      control2 = factories.ControlFactory()  # wouldn't be mapped to objective
+      control2_id = control2.id
+      objective = factories.ObjectiveFactory()
+      factories.RelationshipFactory(source=program, destination=control)
+      factories.RelationshipFactory(source=program, destination=control2)
+      factories.RelationshipFactory(source=program, destination=objective)
+      factories.RelationshipFactory(source=control, destination=objective)
+    self.api.post(all_models.Audit, [{
+        "audit": {
+            "title": "New Audit",
+            "program": {"id": program.id, "type": program.type},
+            "status": "Planned",
+            "context": None,
+            "manual_snapshots": True,
+        }
+    }])
+    self.assertSnapshotCount(0)
+
+    audit = all_models.Audit.query.first()
+    control = all_models.Control.query.get(control_id)
+    control2 = all_models.Control.query.get(control2_id)
+    objective = all_models.Objective.query.first()
+
+    self.gen.generate_relationship(audit, control)
+    control_snapshot_id = all_models.Snapshot.query.filter_by(
+        child_id=control_id, child_type="Control").first().id
+    self.assertRelatedObjectives(control_snapshot_id, 0)
+
+    self.gen.generate_relationship(audit, objective)
+    self.assertRelatedObjectives(control_snapshot_id, 1)
+
+    self.gen.generate_relationship(audit, control2)
+    control2_snapshot_id = all_models.Snapshot.query.filter_by(
+        child_id=control2_id, child_type="Control").first().id
+    self.assertRelatedObjectives(control2_snapshot_id, 0)
+
+    self.assertSnapshotCount(3)


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

In GGRC-6339 we implemented audits with manual snapshot mapping, but Related Objectives/Regulations on Control popup in Asmt info panel won't working.
Also if we press "Update objects to latest version" on Audit, no new snapshots should be mapped to audit

# Steps to test the changes

Steps to reproduce:
1. Create a program, control, objective, regulation in scope of the program
2. Map control to objective, regulation
3. Create an audit with Manually map snapshots checked
4. Open audit page and map control to audit
5. Generate asmt based on control
6. Open Asmt info panel > Control popup: Check Related Objectives/Regulations
7. Repeat step 4 for objective, regulation and check again Related Objectives/Regulations.

Actual Result: Control popup doesn't show Related Objectives/Regulations if snapshots mapped manually
Expected Result: Control popup should show Related Objectives/Regulations if snapshots mapped manually

# Solution description

1) SnapshotGenerator.analyze() function now skip Audits with manual mapping when analyzing snapshots for creation.
2) Add relationships for new snapshots if original objects are mapped.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:run' labels to all open PRs with a label 'migration'
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
