### PR TITLE
GGRC-6682 Issue Tracker is OFF for asmt, if generate it based on AT with Issue Tracker ON

### DIFF
--- a/src/ggrc/models/hooks/issue_tracker/assessment_integration.py
+++ b/src/ggrc/models/hooks/issue_tracker/assessment_integration.py
@@ -2244,7 +2244,8 @@ class AssessmentTrackerHandler(object):
       return issue_tracker_info.get("enabled", False)
 
     template_info = assessment_src.get("template", {})
-    return bool(cls._get_issue_from_assmt_template(template_info))
+    template_issue_info = cls._get_issue_from_assmt_template(template_info)
+    return template_issue_info.get("enabled", False)
 
   @staticmethod
   def _is_ccs_same(ccs_payload, ccs_tracker):

--- a/src/ggrc/models/hooks/issue_tracker/assessment_integration.py
+++ b/src/ggrc/models/hooks/issue_tracker/assessment_integration.py
@@ -206,7 +206,7 @@ class AssessmentTrackerHandler(object):
 
     return issue_payload
 
-  def _get_issuetracker_info(self, assessment_src):
+  def _get_issuetracker_info(self, assessment, assessment_src):
     """Get default issue information.
 
     Args:
@@ -219,6 +219,7 @@ class AssessmentTrackerHandler(object):
       issue_tracker_info_default = self._get_issue_from_assmt_template(
           assessment_src.get("template", {})
       )
+      issue_tracker_info_default["title"] = assessment.title
     if not issue_tracker_info_default:
       issue_tracker_info_default = self._get_issue_info_from_audit(
           issue_tracker_info_default.get("audit", {})
@@ -259,7 +260,7 @@ class AssessmentTrackerHandler(object):
         assessment_src: dictionary with issue information
     """
     if self._is_tracker_enabled(assessment.audit) and \
-            self._is_issue_enabled(assessment_src):
+            self._is_issue_on_create_enabled(assessment_src):
       if assessment_src.get("issue_tracker", {}).get("issue_id"):
         issue_id = assessment_src["issue_tracker"]["issue_id"]
         if not self._is_already_linked(assessment, issue_id):
@@ -519,7 +520,10 @@ class AssessmentTrackerHandler(object):
         for issue store
         sync_result.status: status of request to Issue Tracker
     """
-    issuetracker_info = self._get_issuetracker_info(assessment_src)
+    issuetracker_info = self._get_issuetracker_info(
+        assessment,
+        assessment_src
+    )
     self._validate_assessment_fields(issuetracker_info)
     issuetracker_info = self._update_with_assmt_data_for_ticket_create(
         assessment,
@@ -598,7 +602,10 @@ class AssessmentTrackerHandler(object):
         for issue store
         sync_result.status: status of request to Issue Tracker
     """
-    issuetracker_info = self._get_issuetracker_info(assessment_src)
+    issuetracker_info = self._get_issuetracker_info(
+        assessment,
+        assessment_src
+    )
     self._validate_assessment_fields(issuetracker_info)
     issuetracker_info = self._update_with_assmt_data_for_ticket_create(
         assessment,
@@ -2218,6 +2225,26 @@ class AssessmentTrackerHandler(object):
     ).get(
         "enabled", False
     )
+
+  @classmethod
+  def _is_issue_on_create_enabled(cls, assessment_src):
+    """Check that issue tracker on create enabled.
+
+    Args:
+      assessment_src: dictionary with issue information
+
+    Returns:
+      Boolean indicator that issue enabled
+    """
+    issue_tracker_info = assessment_src.get(
+        "issue_tracker", {}
+    )
+
+    if issue_tracker_info:
+      return issue_tracker_info.get("enabled", False)
+
+    template_info = assessment_src.get("template", {})
+    return bool(cls._get_issue_from_assmt_template(template_info))
 
   @staticmethod
   def _is_ccs_same(ccs_payload, ccs_tracker):

--- a/test/unit/ggrc/models/hooks/issue_tracker_integration/test_assessment_integration.py
+++ b/test/unit/ggrc/models/hooks/issue_tracker_integration/test_assessment_integration.py
@@ -219,3 +219,79 @@ class TestUtilityFunctions(unittest.TestCase):
           "assignee2@test.com",
           reporter_tracker
       )
+
+  def test_is_issue_create_enabled(self):
+    """Test 'is issue tracker enabled' on create."""
+    # pylint: disable=protected-access
+    assessment_src = {
+        "issue_tracker": {
+            "enabled": True,
+        },
+    }
+
+    tracker_handler = assessment_integration.AssessmentTrackerHandler()
+    is_issue_enabled = tracker_handler._is_issue_on_create_enabled(
+        assessment_src
+    )
+
+    self.assertTrue(is_issue_enabled)
+
+  def test_is_issue_create_disabled(self):
+    """Test 'is issue tracker disabled' on create."""
+    # pylint: disable=protected-access
+    assessment_src = {
+        "issue_tracker": {
+            "enabled": False,
+        },
+    }
+
+    tracker_handler = assessment_integration.AssessmentTrackerHandler()
+    is_issue_enabled = tracker_handler._is_issue_on_create_enabled(
+        assessment_src
+    )
+
+    self.assertFalse(is_issue_enabled)
+
+  @mock.patch(
+      'ggrc.models.hooks.issue_tracker.assessment_integration.'
+      'AssessmentTrackerHandler._get_issue_from_assmt_template'
+  )
+  def test_is_issue_enabled_template(self, get_issue_mock):
+    """Test 'is issue tracker enabled' from assessment template."""
+    # pylint: disable=protected-access
+    get_issue_mock.return_value = True
+    assessment_src = {
+        "template": {
+            "type": 1,
+            "id": 1,
+        },
+    }
+
+    tracker_handler = assessment_integration.AssessmentTrackerHandler()
+    is_issue_enabled = tracker_handler._is_issue_on_create_enabled(
+        assessment_src
+    )
+
+    self.assertTrue(is_issue_enabled)
+
+  @mock.patch(
+      'ggrc.models.hooks.issue_tracker.assessment_integration.'
+      'AssessmentTrackerHandler._get_issue_from_assmt_template'
+  )
+  def test_is_issue_disabled_template(self, get_issue_mock):
+    """Test 'is issue tracker disabled' from assessment template."""
+    # pylint: disable=protected-access
+    get_issue_mock.return_value = False
+    assessment_src = {
+        "template": {
+            "type": 1,
+            "id": 1,
+        },
+    }
+
+    tracker_handler = assessment_integration.AssessmentTrackerHandler()
+    is_issue_enabled = tracker_handler._is_issue_on_create_enabled(
+        assessment_src
+    )
+
+    self.assertFalse(is_issue_enabled)

--- a/test/unit/ggrc/models/hooks/issue_tracker_integration/test_assessment_integration.py
+++ b/test/unit/ggrc/models/hooks/issue_tracker_integration/test_assessment_integration.py
@@ -259,7 +259,7 @@ class TestUtilityFunctions(unittest.TestCase):
   def test_is_issue_enabled_template(self, get_issue_mock):
     """Test 'is issue tracker enabled' from assessment template."""
     # pylint: disable=protected-access
-    get_issue_mock.return_value = True
+    get_issue_mock.return_value = {"enabled": True}
     assessment_src = {
         "template": {
             "type": 1,
@@ -278,10 +278,11 @@ class TestUtilityFunctions(unittest.TestCase):
       'ggrc.models.hooks.issue_tracker.assessment_integration.'
       'AssessmentTrackerHandler._get_issue_from_assmt_template'
   )
-  def test_is_issue_disabled_template(self, get_issue_mock):
+  @ddt.data({}, {"enabled": False})
+  def test_is_issue_disabled_template(self, return_value, get_issue_mock):
     """Test 'is issue tracker disabled' from assessment template."""
     # pylint: disable=protected-access
-    get_issue_mock.return_value = False
+    get_issue_mock.return_value = return_value
     assessment_src = {
         "template": {
             "type": 1,


### PR DESCRIPTION
# Issue description
Issue Tracker is OFF for asmt, if generate it based on AT with Issue Tracker ON



# Steps to test the changes

Steps to reproduce:
1. Open any audit with Issue tracker ON: Hotlist ID: 700706, component ID: 64445
2. Map any control to audit
3. Create AT with Issue Tracker ON
4. Generate Assessment based on AT
5. Open Assessment and look at Issue Tracker
Actual Result: Issue Tracker is OFF. There is no link to ticket in Issue Tracker
Expected Result: Issue Tracker is ON. Link to ticket in Issue Tracker should be displayed.

# Solution description

Add validation that Issue Tracker -> ON for Assessment Template

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [ ] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).



# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".


