### PR TITLE
QUICK-FIX Remove usage of all_models in migration

### DIFF
--- a/src/ggrc/migrations/utils/__init__.py
+++ b/src/ggrc/migrations/utils/__init__.py
@@ -10,7 +10,7 @@ Place here your migration helpers that is shared among number of migrations.
 
 from collections import namedtuple
 
-from sqlalchemy import text, Integer, String
+from sqlalchemy import text, Integer, String, inspect
 from sqlalchemy.sql import and_, table, column
 from sqlalchemy.sql import func
 from sqlalchemy.sql import select
@@ -178,13 +178,16 @@ def last_insert_id(connection):
 def _check_modified_by_id_column_exists(connection):
   """Return True if column modified_by_id exists"""
 
+  schema_name = inspect(connection).default_schema_name
+
   sql = """
           SELECT 1 FROM information_schema.columns
-          WHERE table_name = 'objects_without_revisions' and
-                column_name = 'modified_by_id';
+          WHERE table_name = 'objects_without_revisions' AND
+                column_name = 'modified_by_id' AND
+                table_schema = :current_schema
   """
 
-  result = connection.execute(sql)
+  result = connection.execute(text(sql), current_schema=schema_name)
   return True if result.scalar() else False
 
 


### PR DESCRIPTION
# Issue description

One migration script uses `Control` from `all_models`. As result, after changing schema of `ggrc.models.control.Control` (for example, after adding new column to the class) the migration raises exception "there is no such column in database" during `db_reset` script execution

# Steps to test the changes

To reproduce the issue:
1. Add new column into the `Control` model in `ggrc.models.control`
2. Run `db_reset`

Result - exception is raised

After the fix `db_reset` works without errors


# Solution description

To fix the issue the migration script was change to remove `all_models` usage.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:run' labels to all open PRs with a label 'migration'
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
