### PR TITLE
GGRC-6686 Remove mandatory checks for person LCA

### DIFF
--- a/src/ggrc/models/custom_attribute_definition.py
+++ b/src/ggrc/models/custom_attribute_definition.py
@@ -91,6 +91,18 @@ class CustomAttributeDefinition(attributevalidator.AttributeValidator,
       self.definition_type = ''
     return setattr(self, self.definition_attr, value)
 
+  @property
+  def is_lca(self):
+    """Check if CAD is Local CAD"""
+    created_via_template = getattr(self, 'definition', None)
+    created_via_post = self.definition_id
+    return created_via_post or created_via_template
+
+  @property
+  def is_gca(self):
+    """Check if CAD is Global CAD"""
+    return not self.is_lca
+
   _extra_table_args = (
       UniqueConstraint('definition_type', 'definition_id', 'title',
                        name='uq_custom_attribute'),

--- a/src/ggrc/models/custom_attribute_value.py
+++ b/src/ggrc/models/custom_attribute_value.py
@@ -265,7 +265,11 @@ class CustomAttributeValue(base.ContextRBAC, Base, Indexed, db.Model):
 
   def _validate_mandatory_mapping(self):
     """Validate mandatory mapping attribute"""
-    if self.custom_attribute.mandatory and not self.attribute_object_id:
+    if (
+        self.custom_attribute.is_gca and
+        self.custom_attribute.mandatory and
+        not self.attribute_object_id
+    ):
       raise ValueError('Missing mandatory attribute: %s' %
                        self.custom_attribute.title)
 

--- a/test/integration/ggrc/models/mixins/test_customattributable.py
+++ b/test/integration/ggrc/models/mixins/test_customattributable.py
@@ -530,3 +530,28 @@ class TestCADUpdate(TestCase):
         definition_id=template.id,
     )
     self.assertEqual(cads_query.count(), cads_count)
+
+  def test_lcad_empty_no_update(self):
+    """Test that empty mandatory LCA does not prevent put requests."""
+    assessment = factories.AssessmentFactory()
+    cad1 = factories.CustomAttributeDefinitionFactory(
+        definition_type="assessment",
+        mandatory=True,
+        definition_id=assessment.id,
+        attribute_type="Map:Person",
+        title="CA 1",
+    )
+    empty_cav_data = {
+        "custom_attribute_values": [{
+            "assessment": 26340,
+            "attributable_type": "Assessment",
+            "attributeType": None,
+            "attribute_object": None,
+            "attribute_object_id": None,
+            "attribute_value": None,
+            "context": None,
+            "custom_attribute_id": cad1.id,
+        }]
+    }
+    response = self.api.put(assessment, data=empty_cav_data)
+    self.assert200(response)


### PR DESCRIPTION
# Issue description

We can't edit an assessment with inline edit if any mandatory CAs are missing.

# Steps to test the changes

Create an assessment without a mantatory person custom attribute by either
- create an assessment and add a person local CA
- generate an assessment with mandatory person local ca

Try to edit the title with inline edit

# Solution description

Since we're removing person global custom attributes, we are ignoring those in this PR.

The PR itself fixes the issue for local custom attributes. Since those are only on assessments and mandatory global custom attributes on assessments mean different that on other objects, we can ignore the mandatory checks.

on other objects:
 - mandatory means we can not edit an object until mandatory fields are filled in.

on assessments:
 - mandatory means we can edit the object without that value but we can not complete an assessment until mandatory fields are filled in.


# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests. - no tests for removing code
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:run' labels to all open PRs with a label 'migration'
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
