### PR TITLE
GGRC-6716 Update gGRC calendar events to "Free" rather than "Busy"

### DIFF
--- a/src/ggrc/gcalendar/calendar_api_service.py
+++ b/src/ggrc/gcalendar/calendar_api_service.py
@@ -61,6 +61,7 @@ class CalendarApiService(object):
         'sendNotifications': kwargs.get('send_notifications', False),
         'guestsCanModify': kwargs.get('guests_can_modify', False),
         'guestsCanInviteOthers': kwargs.get('guests_can_invite', False),
+        'transparency': kwargs.get('transparency', 'transparent'),
     }
     return self.calendar_service.events().insert(
         calendarId=calendar_id, body=event).execute()
@@ -96,6 +97,7 @@ class CalendarApiService(object):
         'sendNotifications': kwargs.get('send_notifications', False),
         'guestsCanModify': kwargs.get('guests_can_modify', False),
         'guestsCanInviteOthers': kwargs.get('guests_can_invite', False),
+        'transparency': kwargs.get('transparency', 'transparent'),
     }
     return self.calendar_service.events().update(
         calendarId=calendar_id, body=event, eventId=event_id).execute()

--- a/test/unit/ggrc/gcalendar/test_calendar_api_service.py
+++ b/test/unit/ggrc/gcalendar/test_calendar_api_service.py
@@ -50,6 +50,7 @@ class TestCalendarApiService(unittest.TestCase):
         "sendNotifications": False,
         "guestsCanModify": False,
         "guestsCanInviteOthers": False,
+        "transparency": "transparent",
     }
     self.events_mock.insert.assert_called_with(calendarId="primary",
                                                body=expected_body)
@@ -83,6 +84,7 @@ class TestCalendarApiService(unittest.TestCase):
         "sendNotifications": False,
         "guestsCanModify": False,
         "guestsCanInviteOthers": False,
+        "transparency": "transparent",
     }
     self.events_mock.update.assert_called_with(
         calendarId="primary",


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Calendar invites show user as "Busy" and are causing an auto-reject for other calendar events.

# Steps to test the changes

1. Turn on calendar events for a user
2. Create cycle task for a user with due date in the future
3. Trigger `send_calendar_events`
4. See that event in the calendar events show 'free' status

# Solution description

gGRC calendar events should be defaulted to "Free"
https://developers.google.com/calendar/v3/reference/events
set `transparency` option to `transparent`. 

> `"transparent" - The event does not block time on the calendar. This is equivalent to setting Show me as to Available in the Calendar UI.`

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
