### PR TITLE
GGRC-6640 Disable map control to Standard, Regulation and Scope objects

### DIFF
--- a/src/ggrc/converters/handlers/handlers.py
+++ b/src/ggrc/converters/handlers/handlers.py
@@ -15,7 +15,7 @@ from ggrc import db
 from ggrc.converters import get_exportables, errors
 from ggrc.login import get_current_user
 from ggrc.models import all_models
-from ggrc.models.mixins import ScopeObject
+from ggrc.models.exceptions import ValidationError
 from ggrc.models.reflection import AttributeInfo
 from ggrc.rbac import permissions
 
@@ -544,13 +544,13 @@ class MappingColumnHandler(ColumnHandler):
   def _is_allowed_mapping_by_type(self, source_type, destination_type):
     # pylint: disable=no-self-use
     """Checks if a mapping is allowed between given types."""
-    scoping_models_names = [m.__name__ for m in all_models.all_models
-                            if issubclass(m, ScopeObject)]
+    try:
+      all_models.Relationship.validate_relation_by_type(source_type,
+                                                        destination_type)
+    except ValidationError:
+      return False
 
-    return not (source_type in scoping_models_names and
-                destination_type in ("Regulation", "Standard") or
-                destination_type in scoping_models_names and
-                source_type in ("Regulation", "Standard"))
+    return True
 
   def _add_mapping_warning(self, source, destination):
     """Add warning if we have changes mappings """

--- a/src/ggrc/models/all_models.py
+++ b/src/ggrc/models/all_models.py
@@ -77,6 +77,8 @@ from ggrc.models.technology_environment import TechnologyEnvironment
 from ggrc.models.threat import Threat
 from ggrc.models.vendor import Vendor
 from ggrc.models.review import Review
+from ggrc.models.mixins import ScopeObject as _ScopeObject
+
 
 all_models = [  # pylint: disable=invalid-name
     # data platform models
@@ -190,3 +192,21 @@ def unregister_model(model):
     all_models.remove(model)
   if model.__name__ in __all__:
     __all__.remove(model.__name__)
+
+
+def get_scope_models():
+  """Return all usable scope model classes"""
+  ret = list(m for m in all_models
+             if issubclass(m, _ScopeObject))
+
+  # SystemOrProcess is abstract model which represents models System & Process
+  # We have to exclude it from the list, as cannot be used directly
+  ret.remove(SystemOrProcess)
+
+  return ret
+
+
+def get_scope_model_names():
+  # type: () -> List[str]
+  """Return list of names of usable scope models"""
+  return list(model.__name__ for model in get_scope_models())

--- a/test/integration/ggrc/__init__.py
+++ b/test/integration/ggrc/__init__.py
@@ -9,6 +9,7 @@ import logging
 import os
 import tempfile
 import csv
+import itertools
 from StringIO import StringIO
 from mock import patch
 
@@ -35,6 +36,21 @@ logging.disable(logging.CRITICAL)
 
 
 THIS_ABS_PATH = os.path.abspath(os.path.dirname(__file__))
+
+# Test relationship between Standard/Regulation and scope objects
+_SCOPING_MODELS = all_models.get_scope_models()
+READONLY_MAPPING_PAIRS = list(
+    # make a list of object combinations from 1st and 2nd iterables
+    # itertools.product("AB", "CD") is ["AC", "AD", "BC", "BD"]
+    itertools.product(_SCOPING_MODELS, (all_models.Standard,
+                                        all_models.Regulation))
+)
+# Test relationship for Control and Scope objects, Standard and Regulation
+READONLY_MAPPING_PAIRS.extend(
+    (all_models.Control, m) for m in itertools.chain(_SCOPING_MODELS,
+                                                     (all_models.Standard,
+                                                      all_models.Regulation))
+)
 
 
 def read_imported_file(file_data):  # pylint: disable=unused-argument

--- a/test/integration/ggrc/converters/test_base_block.py
+++ b/test/integration/ggrc/converters/test_base_block.py
@@ -47,10 +47,13 @@ class TestBaseBlock(TestCase):
               source=regulations[j] if i % 2 == 0 else requirements[i],
               destination=regulations[j] if i % 2 == 1 else requirements[i],
           )
-          factories.RelationshipFactory(
-              source=regulations[j] if i % 2 == 0 else controls[i],
-              destination=regulations[j] if i % 2 == 1 else controls[i],
-          )
+          with mock.patch('ggrc.models.relationship.is_external_app_user',
+                          return_value=True):
+            factories.RelationshipFactory(
+                source=regulations[j] if i % 2 == 0 else controls[i],
+                destination=regulations[j] if i % 2 == 1 else controls[i],
+                is_external=True,
+            )
           expected_cache[regulations[j].id]["Control"].append(
               controls[i].slug
           )
@@ -93,10 +96,13 @@ class TestBaseBlock(TestCase):
             source=regulation if i % 2 == 0 else requirements[i],
             destination=regulation if i % 2 == 1 else requirements[i],
         ))
-        relationships.append(factories.RelationshipFactory(
-            source=regulation if i % 2 == 0 else controls[i],
-            destination=regulation if i % 2 == 1 else controls[i],
-        ))
+        with mock.patch('ggrc.models.relationship.is_external_app_user',
+                        return_value=True):
+          relationships.append(factories.RelationshipFactory(
+              source=regulation if i % 2 == 0 else controls[i],
+              destination=regulation if i % 2 == 1 else controls[i],
+              is_external=True,
+          ))
 
     block = base_block.ExportBlockConverter(
         mock.MagicMock(),

--- a/test/integration/ggrc/converters/test_import_mapping.py
+++ b/test/integration/ggrc/converters/test_import_mapping.py
@@ -1,0 +1,61 @@
+# Copyright (C) 2019 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Test imports of mappings between objects"""
+
+from collections import OrderedDict
+import mock
+
+import ddt
+
+from ggrc.utils import title_from_camelcase
+from integration.ggrc import TestCase, READONLY_MAPPING_PAIRS
+from integration.ggrc import factories
+
+
+@ddt.ddt
+class TestImportMappings(TestCase):
+  """Test import mapping/unmapping"""
+
+  def setUp(self):
+    super(TestImportMappings, self).setUp()
+    self.client.get("/login")
+
+  @ddt.data(*READONLY_MAPPING_PAIRS)
+  @ddt.unpack
+  def test_unmap_objects(self, model1, model2):
+    """Test deprecated unmapping between {0.__name__} and {1.__name__}
+    """
+    name1 = model1.__name__
+    name2 = model2.__name__
+    title1 = title_from_camelcase(name1)
+
+    with factories.single_commit():
+      with mock.patch('ggrc.models.relationship.is_external_app_user',
+                      return_value=True):
+        obj1 = factories.get_model_factory(name1)()
+        obj2 = factories.get_model_factory(name2)()
+        factories.RelationshipFactory(source=obj1, destination=obj2,
+                                      is_external=True)
+        slug1 = obj1.slug
+        slug2 = obj2.slug
+
+    data_block = [
+        OrderedDict([
+            ("object_type", name1),
+            ("Code*", slug1),
+        ]),
+        OrderedDict([
+            ("object_type", name2),
+            ("Code*", slug2),
+            ("unmap:{}".format(title1), slug1),
+        ]),
+    ]
+
+    response = self.import_data(*data_block)
+
+    # Check that mapping is not added
+    self.assertEqual(len(response[1]['row_warnings']), 1)
+    self.assertIn(
+        u'Line 7: You do not have the necessary permissions to unmap',
+        response[1]['row_warnings'][0])

--- a/test/integration/ggrc/models/hooks/acl/test_propagation.py
+++ b/test/integration/ggrc/models/hooks/acl/test_propagation.py
@@ -11,6 +11,7 @@
 import itertools
 from collections import defaultdict
 from collections import OrderedDict
+import mock
 
 import ddt
 import flask
@@ -343,7 +344,13 @@ class TestPropagation(BaseTestPropagation):
       normal_objects = [control, regulation, objective]
 
       for obj1, obj2 in itertools.combinations(normal_objects, 2):
-        factories.RelationshipFactory(source=obj1, destination=obj2)
+        if control in (obj1, obj2):
+          with mock.patch('ggrc.models.relationship.is_external_app_user',
+                          return_value=True):
+            factories.RelationshipFactory(source=obj1, destination=obj2,
+                                          is_external=True)
+        else:
+          factories.RelationshipFactory(source=obj1, destination=obj2)
 
       assessment = factories.AssessmentFactory()
       assessment_2 = factories.AssessmentFactory(audit=assessment.audit)

--- a/test/integration/ggrc/services/test_query/test_basic.py
+++ b/test/integration/ggrc/services/test_query/test_basic.py
@@ -8,9 +8,10 @@
 """Tests for /query api endpoint."""
 import random
 import unittest
-
 from datetime import datetime
 from operator import itemgetter
+import mock
+
 import ddt
 from flask import json
 from ggrc import app
@@ -771,8 +772,16 @@ class TestAdvancedQueryAPI(WithQueryApi, TestCase):
     with factories.single_commit():
       query_data = []
       for relevant_obj in relevant_objects:
-        factories.RelationshipFactory(source=base_obj,
-                                      destination=relevant_obj)
+        if base_type is all_models.Control and isinstance(relevant_obj,
+                                                          all_models.Market):
+          with mock.patch('ggrc.models.relationship.is_external_app_user',
+                          return_value=True):
+            factories.RelationshipFactory(source=base_obj,
+                                          destination=relevant_obj,
+                                          is_external=True)
+        else:
+          factories.RelationshipFactory(source=base_obj,
+                                        destination=relevant_obj)
 
         query_data.append(self._make_query_dict(
             relevant_obj.type,

--- a/test/unit/ggrc/converters/handlers/test_mapping_column_handler.py
+++ b/test/unit/ggrc/converters/handlers/test_mapping_column_handler.py
@@ -39,8 +39,14 @@ class IsAllowedMappingByTypeTestCase(MappingColumnHandlerTestCase):
   def test_returns_true_for_other_types(self):
     """The method should return True if destination is other."""
     # pylint: disable=protected-access
-    result = self.handler._is_allowed_mapping_by_type('Product', 'Control')
+    result = self.handler._is_allowed_mapping_by_type('Product', 'Requirement')
     self.assertTrue(result)
+
+  def test_returns_false_for_product_control(self):
+    """The method should return False if destination is other."""
+    # pylint: disable=protected-access
+    result = self.handler._is_allowed_mapping_by_type('Product', 'Control')
+    self.assertFalse(result)
 
 
 class AddMappingWarningTestCase(MappingColumnHandlerTestCase):


### PR DESCRIPTION
# Issue description

The goal is to make relationship read-only for regular GGRC users between Control and Scope objects, Standards and Regulations.

# Steps to test the changes

Login as regular user, ensure that it cannot create/delete relationship between  Control and Scope objects, Standards and Regulations

Login as external user, ensure that it can create/delete relationship between Control and Scope objects, Standards and Regulations


# Solution description

Add validation during relationship creation

# Sanity checklist

- [ ] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [ ] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [ ] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [ ] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
