### PR TITLE
GGRC-6607 Assessment status switch on ACL changes

### DIFF
--- a/src/ggrc/access_control/roleable.py
+++ b/src/ggrc/access_control/roleable.py
@@ -217,6 +217,26 @@ class Roleable(object):
         for acl in self._access_control_list
     )
 
+  def has_acr_acl_changed(self, acr_name):
+    """Check if the object has had any changes in ACL with `acr_name` role.
+
+    Helper function checking access control list with particular access
+    control role `acr_name` for changes in current session. If there is no
+    such role on object, `False` will be returned.
+
+    Args:
+      acr_name: Name of particular access control role to check for changes.
+
+    Returns:
+      Boolean indicating if there are any changes in particular access control
+      list in the current session. If there is not any ACL with `acr_name`
+      ACR, `False` will be returned.
+    """
+    if acr_name not in self.acr_name_acl_map:
+      return False
+    acl = self.acr_name_acl_map[acr_name]
+    return inspect(acl).attrs["access_control_people"].history.has_changes()
+
   def validate_acl(self):
     """Check correctness of access_control_list."""
     for _, acl in self.access_control_list:

--- a/test/integration/ggrc/integrations/test_assessment_integration.py
+++ b/test/integration/ggrc/integrations/test_assessment_integration.py
@@ -846,14 +846,7 @@ class TestIssueTrackerIntegration(SnapshotterBaseTestCase):
   def test_change_assessment_status(self, status,
                                     additional_kwargs,
                                     mocked_update_issue):
-    """Issue status should be changed for assessment
-    with {status} status."""
-    email1 = "email1@example.com"
-    assignee_role_id = AccessControlRole.query.filter_by(
-        object_type="Assessment",
-        name="Assignees"
-    ).first().id
-    assignees = [factories.PersonFactory(email=email1)]
+    """Issue status should be changed for assessment with {status} status."""
     iti_issue_id = []
     iti = factories.IssueTrackerIssueFactory(
         enabled=True,
@@ -870,12 +863,12 @@ class TestIssueTrackerIntegration(SnapshotterBaseTestCase):
         '_is_tracker_enabled',
         return_value=True
     ):
-      acl = [acl_helper.get_acl_json(assignee_role_id, assignee.id)
-             for assignee in assignees]
-      self.api.put(asmt, {
-          "access_control_list": acl,
-          "status": status,
-      })
+      self.api.put(
+          asmt,
+          {
+              "status": status,
+          },
+      )
       kwargs = {'component_id': 123123,
                 'severity': "S2",
                 'title': iti.title,

--- a/test/integration/ggrc/models/mixins/test_autostatuschangable.py
+++ b/test/integration/ggrc/models/mixins/test_autostatuschangable.py
@@ -659,40 +659,79 @@ class TestOther(TestMixinAutoStatusChangeableBase):
     self.assertStatus(response, 200)
     self.assertEqual(from_status, assessment.status)
 
-  @ddt.data("DONE_STATE", "START_STATE")
-  def test_changing_assignees_should_not_change_status(self, test_state):
-    """Adding/changing/removing assignees shouldn't change status
+  @ddt.data(
+      (
+          "Creators",
+          models.Assessment.FINAL_STATE,
+          models.Assessment.PROGRESS_STATE,
+      ),
+      (
+          "Creators",
+          models.Assessment.DONE_STATE,
+          models.Assessment.PROGRESS_STATE,
+      ),
+      (
+          "Assignees",
+          models.Assessment.FINAL_STATE,
+          models.Assessment.PROGRESS_STATE,
+      ),
+      (
+          "Assignees",
+          models.Assessment.DONE_STATE,
+          models.Assessment.PROGRESS_STATE,
+      ),
+      (
+          "Verifiers",
+          models.Assessment.FINAL_STATE,
+          models.Assessment.PROGRESS_STATE,
+      ),
+      (
+          "Verifiers",
+          models.Assessment.DONE_STATE,
+          models.Assessment.PROGRESS_STATE,
+      ),
+  )
+  @ddt.unpack
+  def test_change_acl_status_sw(self, acr_name, start_state, end_state):
+    """Change in ACL switches status from `start_state` to `end_state`."""
+    with factories.single_commit():
+      assessment = factories.AssessmentFactory(status=start_state)
+      person = factories.PersonFactory()
 
-    Test assessment in FINAL_STATE should not get to PROGRESS_STATE on
-    assignee edit.
-    """
-    people = [
-        ("creator@example.com", "Creators"),
-        ("assessor_1@example.com", "Assignees"),
-        ("assessor_2@example.com", "Assignees"),
-    ]
+    self.modify_assignee(assessment, person.email, [acr_name])
+    assessment = self.refresh_object(assessment)
+    self.assertEqual(assessment.status, end_state)
 
-    assessment = self.create_assessment(people)
+    assessment = self.change_status(assessment, start_state)
+    self.modify_assignee(assessment, person.email, [])
     assessment = self.refresh_object(assessment)
-    assessment = self.change_status(assessment,
-                                    getattr(assessment, test_state))
-    self.assertEqual(assessment.status,
-                     getattr(models.Assessment, test_state))
-    self.modify_assignee(assessment,
-                         "creator@example.com",
-                         ["Creators", "Assignees"])
+    self.assertEqual(assessment.status, end_state)
+
+  @ddt.data(
+      ("Creators", models.Assessment.START_STATE),
+      ("Creators", models.Assessment.PROGRESS_STATE),
+      ("Creators", models.Assessment.DEPRECATED),
+      ("Assignees", models.Assessment.START_STATE),
+      ("Assignees", models.Assessment.PROGRESS_STATE),
+      ("Assignees", models.Assessment.DEPRECATED),
+      ("Verifiers", models.Assessment.START_STATE),
+      ("Verifiers", models.Assessment.PROGRESS_STATE),
+      ("Verifiers", models.Assessment.DEPRECATED),
+  )
+  @ddt.unpack
+  def test_change_acl_no_status_sw(self, acr_name, start_state):
+    """Change in ACL does not swith status from `start_state`."""
+    with factories.single_commit():
+      assessment = factories.AssessmentFactory(status=start_state)
+      person = factories.PersonFactory()
+
+    self.modify_assignee(assessment, person.email, [acr_name])
     assessment = self.refresh_object(assessment)
-    self.assertEqual(assessment.status,
-                     getattr(models.Assessment, test_state))
-    new_assessors = [("assessor_3_added_later@example.com", "Verifiers")]
-    self.create_assignees_restful(assessment, new_assessors)
+    self.assertEqual(assessment.status, start_state)
+
+    self.modify_assignee(assessment, person.email, [])
     assessment = self.refresh_object(assessment)
-    self.assertEqual(assessment.status,
-                     getattr(models.Assessment, test_state))
-    self.delete_assignee(assessment, "assessor_1@example.com")
-    assessment = self.refresh_object(assessment)
-    self.assertEqual(assessment.status,
-                     getattr(models.Assessment, test_state))
+    self.assertEqual(assessment.status, start_state)
 
   def test_assessment_verifiers_full_cycle_first_class_edit(self):
     """Test models.Assessment with verifiers full flow


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Currently when modifying ACLs on assessment with **IN REVIEW** or **COMPLETED** status, status is not switched to **IN PROGRESS** but should.

# Steps to test the changes

Case 1: Steps to reproduce:
1. Open any assessment without Verifier;
2. Complete assessment (assessment is in **COMPLETED** state);
3. Add or delete verifier/creator/assignee;
4. Assessment status is changed to **IN PROGRESS**.

Case 2: Steps to reproduce:
1. Open any assessment with Verifier;
2. Complete assessment (assessment is **IN REVIEW** state);
3. Add or delete verifier/creator/assignee;
4. Assessment status is changed to **IN PROGRESS**.

Case 3: Steps to reproduce:
1. Open any assessment with Verifier (your account)
2. Complete assessment and verify it (assessment is in **COMPLETED** state)
3. Add or delete verifier/creator/assignee;
4. Assessment status is changed to **IN PROGRESS**.

# Solution description

Solutions includes modifying `AutoStatusChangeable` mixin so it could handle changes in ACLs: 

`ACL_STATUS_TRANSITIONS` set of transitions is added which describes a conditions to change object status from one to another. Now when `PUT` is performed on a model, `handle_acl_edit` is being called which iterates over possible transitions described in `ACL_STATUS_TRANSITIONS` and applies status change if possible.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
