### PR TITLE
GGRC-5246 prevent "*" character to be used in custom role names and custom attribute names 

### DIFF
--- a/src/ggrc/access_control/role.py
+++ b/src/ggrc/access_control/role.py
@@ -90,9 +90,10 @@ class AccessControlRole(attributevalidator.AttributeValidator,
   def validates_name(self, key, value):  # pylint: disable=no-self-use
     """Validate Custom Role name uniquness.
 
-    Custom Role names need to follow 2 uniqueness rules:
+    Custom Role names need to follow 3 uniqueness rules:
       1) Names must not match any attribute name on any existing object.
       2) Object level CAD names must not match any global CAD name.
+      3) Names should not contains "*" symbol
 
     This validator should check for name collisions for 1st and 2nd rule.
 
@@ -124,6 +125,10 @@ class AccessControlRole(attributevalidator.AttributeValidator,
       raise ValueError(u"Global custom attribute '{}' "
                        u"already exists for this object type"
                        .format(name))
+
+    if key == "name" and "*" in name:
+      raise ValueError(u"Attribute name contains unsupported symbol '*'")
+
     return value
 
 

--- a/src/ggrc/migrations/versions/20190219103003_a8a4442a2b91_remove_asterisks_from_cads_and_roles.py
+++ b/src/ggrc/migrations/versions/20190219103003_a8a4442a2b91_remove_asterisks_from_cads_and_roles.py
@@ -1,0 +1,92 @@
+# Copyright (C) 2019 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+remove asterisks from CADs and roles
+
+Create Date: 2019-02-19 10:30:03.388132
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+import sqlalchemy as sa
+
+from alembic import op
+
+from ggrc.models import all_models
+
+# revision identifiers, used by Alembic.
+revision = 'a8a44ea42a2b91'
+down_revision = '59b41fe6c145'
+
+
+
+def update_name(row_id, name, field, table, connection):
+  """Update fields in DB to remove symbol '*'"""
+  new_name = _generate_new_name(name, field, table, connection)
+  connection.execute(sa.text("""
+    UPDATE {}
+    SET {} = '{}'
+    WHERE id = {};
+  """.format(table, field, new_name, row_id)))
+
+
+def _generate_new_name(original_name, column, table, connection):
+  """Remove symbol '*' from name and add appendix if new name already exists"""
+  new_name = original_name.replace('*', '')
+  iterator = 0
+  while is_exists(new_name, column, table, connection):
+    iterator += 1
+    new_name = "{}-{}".format(original_name.replace('*', ''), iterator)
+  return new_name
+
+
+def get_roles_to_update(connection):
+  """Get list of all access control roles that have name with symbol '*' in it"""
+  res = connection.execute(sa.text("""
+    SELECT id, {0}
+    FROM {1}
+    WHERE {0} like '%*%'
+    AND internal = 0;
+  """.format('name', all_models.AccessControlRole.__tablename__))).fetchall()
+  return res
+
+
+def get_attributes_to_update(connection):
+  """Get list of all custom attribute definitions that have title with symbol '*' in it"""
+  res = connection.execute(sa.text("""
+    SELECT id, {0}
+    FROM {1}
+    WHERE {0} like '%*%';
+  """.format('title', all_models.CustomAttributeDefinition.__tablename__))).fetchall()
+  return res
+
+
+def is_exists(value, name, table, connection):
+  """Check is column name with value exists in table"""
+  result = connection.execute(sa.text("""
+    SELECT * 
+    FROM {} 
+    WHERE {} = '{}';
+  """.format(table, name, value))).fetchall()
+  if result:
+    return True
+  return False
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  connection = op.get_bind()
+
+  roles_to_update = get_roles_to_update(connection)
+  for role in roles_to_update:
+    update_name(role.id, role.name, 'name', all_models.AccessControlRole.__tablename__, connection)
+
+  attributes_to_update = get_attributes_to_update(connection)
+  for attribute in attributes_to_update:
+    update_name(attribute.id, attribute.title, 'title', all_models.CustomAttributeDefinition.__tablename__, connection)
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  raise NotImplementedError("Downgrade is not supported")

--- a/src/ggrc/migrations/versions/20190219103003_a8a4442a2b91_remove_asterisks_from_cads_and_roles.py
+++ b/src/ggrc/migrations/versions/20190219103003_a8a4442a2b91_remove_asterisks_from_cads_and_roles.py
@@ -15,10 +15,10 @@ from alembic import op
 
 from ggrc.models import all_models
 
+
 # revision identifiers, used by Alembic.
 revision = 'a8a44ea42a2b91'
 down_revision = '59b41fe6c145'
-
 
 
 def update_name(row_id, name, field, table, connection):
@@ -42,7 +42,7 @@ def _generate_new_name(original_name, column, table, connection):
 
 
 def get_roles_to_update(connection):
-  """Get list of all access control roles that have name with symbol '*' in it"""
+  """Get list of all access control roles with symbol '*' in it"""
   res = connection.execute(sa.text("""
     SELECT id, {0}
     FROM {1}
@@ -53,20 +53,21 @@ def get_roles_to_update(connection):
 
 
 def get_attributes_to_update(connection):
-  """Get list of all custom attribute definitions that have title with symbol '*' in it"""
+  """Get list of all custom attribute definitions with symbol '*' in it"""
   res = connection.execute(sa.text("""
     SELECT id, {0}
     FROM {1}
     WHERE {0} like '%*%';
-  """.format('title', all_models.CustomAttributeDefinition.__tablename__))).fetchall()
+  """.format('title',
+             all_models.CustomAttributeDefinition.__tablename__))).fetchall()
   return res
 
 
 def is_exists(value, name, table, connection):
   """Check is column name with value exists in table"""
   result = connection.execute(sa.text("""
-    SELECT * 
-    FROM {} 
+    SELECT *
+    FROM {}
     WHERE {} = '{}';
   """.format(table, name, value))).fetchall()
   if result:
@@ -80,11 +81,14 @@ def upgrade():
 
   roles_to_update = get_roles_to_update(connection)
   for role in roles_to_update:
-    update_name(role.id, role.name, 'name', all_models.AccessControlRole.__tablename__, connection)
+    update_name(role.id, role.name, 'name',
+                all_models.AccessControlRole.__tablename__, connection)
 
   attributes_to_update = get_attributes_to_update(connection)
   for attribute in attributes_to_update:
-    update_name(attribute.id, attribute.title, 'title', all_models.CustomAttributeDefinition.__tablename__, connection)
+    update_name(attribute.id, attribute.title,
+                'title', all_models.CustomAttributeDefinition.__tablename__,
+                connection)
 
 
 def downgrade():

--- a/src/ggrc/migrations/versions/20190219103003_a8a4442a2b91_remove_asterisks_from_cads_and_roles.py
+++ b/src/ggrc/migrations/versions/20190219103003_a8a4442a2b91_remove_asterisks_from_cads_and_roles.py
@@ -18,7 +18,7 @@ from ggrc.models import all_models
 
 # revision identifiers, used by Alembic.
 revision = 'a8a44ea42a2b91'
-down_revision = '59b41fe6c145'
+down_revision = '57b14cb4a7b4'
 
 
 def update_name(row_id, name, field, table, connection):

--- a/src/ggrc/migrations/versions/20190219103003_a8a4442a2b91_remove_asterisks_from_cads_and_roles.py
+++ b/src/ggrc/migrations/versions/20190219103003_a8a4442a2b91_remove_asterisks_from_cads_and_roles.py
@@ -37,10 +37,11 @@ def update_name(element, table, connection):
                                 connection)
   connection.execute(sa.text("""
     UPDATE {table}
-    SET {field_name} = '{field_value}'
+    SET {field_name} = :field_value
     WHERE id = {row_id};
-  """.format(table=table, field_name=fields['name'],
-             field_value=new_name, row_id=element.id)))
+  """.format(table=table,
+             field_name=fields['name'],
+             row_id=element.id)), field_value=new_name)
 
 
 def _generate_new_name(original_name, object_type, connection):
@@ -77,16 +78,16 @@ def is_exists(new_name_value, object_type, connection):
   query = """
     SELECT 1
     FROM {table_name}
-    WHERE {field_name} = '{name_value}'
-    AND {object_type_field} = '{object_type_value}';
+    WHERE {field_name} = :name_value
+    AND {object_type_field} = :object_type_value;
   """
   for table, fields in tables_descriptions.items():
     sa_query = sa.text(query.format(table_name=table,
                                     field_name=fields['name'],
-                                    name_value=new_name_value,
-                                    object_type_field=fields['object_type'],
-                                    object_type_value=object_type))
-    result = connection.execute(sa_query).fetchall()
+                                    object_type_field=fields['object_type']))
+    result = connection.execute(sa_query,
+                                name_value=new_name_value,
+                                object_type_value=object_type).fetchall()
     if result:
       return True
   return False

--- a/src/ggrc/models/custom_attribute_definition.py
+++ b/src/ggrc/models/custom_attribute_definition.py
@@ -262,14 +262,15 @@ class CustomAttributeDefinition(attributevalidator.AttributeValidator,
     """Validate CAD title/name uniqueness.
 
     Note: title field is used for storing CAD names.
-    CAD names need to follow 4 uniqueness rules:
+    CAD names need to follow 6 uniqueness rules:
       1) Names must not match any attribute name on any existing object.
       2) Object level CAD names must not match any global CAD name.
       3) Object level CAD names can clash, but not for the same Object
          instance. This means we can have two CAD with a name "my cad", with
          different attributable_id fields.
       4) Names must not match any existing custom attribute role name
-      5) Names should be stripped
+      5) Names should not contains "*" symbol
+      6) Names should be stripped
 
     Third rule is handled by the database with unique key uq_custom_attribute
     (`definition_type`,`definition_id`,`title`).
@@ -317,6 +318,9 @@ class CustomAttributeDefinition(attributevalidator.AttributeValidator,
 
     if definition_type == "assessment":
       self.validate_assessment_title(name)
+
+    if key == "title" and "*" in name:
+      raise ValueError(u"Attribute title contains unsupported symbol '*'")
 
     return value
 

--- a/test/unit/ggrc/models/test_access_control_roles.py
+++ b/test/unit/ggrc/models/test_access_control_roles.py
@@ -40,6 +40,14 @@ class TestAccessControlRoles(unittest.TestCase):
       self.acr.name = name
       self.acr.object_type = object_type
 
+  def test_name_with_asterisk_throws(self):
+    """Test if raises if name contains * symbol"""
+
+    with self.assertRaises(ValueError):
+      name, object_type = "With asterisk *", "Control"
+      self.acr.object_type = object_type
+      self.acr.validates_name("name", name)
+
   def test_if_invalid_ca_check(self):
     """Test if raises on collision with custom attributes attributes"""
     with self.assertRaises(ValueError):

--- a/test/unit/ggrc/models/test_custom_attribute_definition.py
+++ b/test/unit/ggrc/models/test_custom_attribute_definition.py
@@ -1,0 +1,24 @@
+# Copyright (C) 2019 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Test Custom Attribute Definition validation"""
+
+import unittest
+
+from ggrc.app import app
+from ggrc.models import all_models
+
+
+class TestCustomAttributeDefinition(unittest.TestCase):
+  """Test Custom Attribute Definition validation"""
+
+  def setUp(self):
+    self.cad = all_models.CustomAttributeDefinition()
+
+  def test_title_with_asterisk_throws(self):
+    """Test if raises if title contains * symbol"""
+    with self.assertRaises(ValueError):
+      with app.app_context():
+        title = "Title with asterisk *"
+        self.cad.definition_type = "assessment_template"
+        self.cad.validate_title("title", title)

--- a/test/unit/ggrc/models/test_custom_attribute_definition.py
+++ b/test/unit/ggrc/models/test_custom_attribute_definition.py
@@ -4,21 +4,25 @@
 """Test Custom Attribute Definition validation"""
 
 import unittest
+from mock import MagicMock
 
-from ggrc.app import app
 from ggrc.models import all_models
+from ggrc.access_control import role as acr
 
 
 class TestCustomAttributeDefinition(unittest.TestCase):
   """Test Custom Attribute Definition validation"""
 
   def setUp(self):
+    # pylint: disable=protected-access
     self.cad = all_models.CustomAttributeDefinition()
+    self.cad._get_reserved_names = MagicMock(return_value=frozenset({'title'}))
+    self.cad._get_global_cad_names = MagicMock(return_value={'reg url': 1})
+    acr.get_custom_roles_for = MagicMock(return_value=dict())
 
   def test_title_with_asterisk_throws(self):
     """Test if raises if title contains * symbol"""
     with self.assertRaises(ValueError):
-      with app.app_context():
-        title = "Title with asterisk *"
-        self.cad.definition_type = "assessment_template"
-        self.cad.validate_title("title", title)
+      title = "Title with asterisk *"
+      self.cad.definition_type = "assessment_template"
+      self.cad.validate_title("title", title)


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Backend part of GGRC-4954
The character "*" should not be allowed in any custom name for roles or attributes.
Issue is that "" is used for imports and setting a name like "use search A" will break imports because * will get stripped from the attribute name.
Also the * is used for internal roles and removing it from user defined roles will prevent any name clashes.
Ticket also needs a migration to remove any possible already existing * from current names.
Currently validation implemented by FE but user still can create custom role via API

# Steps to test the changes

Create Custom Role or Custom Attribute with name that includes "*" symbol using API.

# Solution description

Update validation rules in modes.
Migration searching for names with "*" symbol and remove the symbol. If new name already exists, add number to the end.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [ ] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# Migration checklist
- [x] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [x] Upon merging, update 'table structure changes' in weekly deployment documentation

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
