### PR TITLE
GGRC-5015 Cycle is moving from In progress to Assigned if create new CT for one time workflow

### DIFF
--- a/src/ggrc_workflows/__init__.py
+++ b/src/ggrc_workflows/__init__.py
@@ -348,22 +348,29 @@ def _update_parent_status(parent, child_statuses):
 
   New status based on sent object status and sent child_statuses"""
   old_status = parent.status
+  if isinstance(parent, models.CycleTaskGroup):
+    tasks = parent.cycle_task_group_tasks
+  elif isinstance(parent, models.Cycle):
+    tasks = parent.cycle_task_group_object_tasks
+  else:
+    logger.warning("Invalid parent object '%s'.", parent.__class__.__name__)
+    return
   # Deprecated status is not counted
-  if child_statuses:
-    child_statuses.discard("Deprecated")
+  child_statuses.discard("Deprecated")
   if not child_statuses:
     new_status = "Deprecated"
   elif len(child_statuses) == 1:
     new_status = child_statuses.pop()
-    if new_status == "Declined":
+    if (new_status == "Declined" or
+            new_status == "Assigned" and
+            any(t.status != "Assigned" for t in tasks)):
       new_status = parent.IN_PROGRESS
   elif {parent.IN_PROGRESS, "Declined", "Assigned"} & child_statuses:
     new_status = parent.IN_PROGRESS
   else:
     new_status = "Finished"
-  if old_status == new_status:
-    return
-  parent.status = new_status
+  if old_status != new_status:
+    parent.status = new_status
 
 
 def update_cycle_task_tree(objs):


### PR DESCRIPTION
# Issue description

Cycle is moving from In progress to Assigned if create new Cycle Task for one time workflow.

# Steps to test the changes

1. Open Active Cycle and expand the tree with Cycle Tasks.
2. Start Cycle Task to move Cycle into In Progress state.
3. Create new Cycle Task
4. Check that newly added Cycle Task is in Assigned state, however Cycle and Cycle Tasks Group still in In Progress state.

# Solution description

Function `_update_parent_state`, which is invoked during calculating statuses of Cycle and Cycle Task group, didn't handle Assigged state of newly added child.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
