### PR TITLE
GGRC-4883 Added comments to importable fields Added new test

### DIFF
--- a/src/ggrc_workflows/models/cycle_task_group_object_task.py
+++ b/src/ggrc_workflows/models/cycle_task_group_object_task.py
@@ -54,7 +54,7 @@ class CycleTaskGroupObjectTask(roleable.Roleable,
 
   IMPORTABLE_FIELDS = (
       'slug', 'title', 'description', 'start_date',
-      'end_date', 'finished_date', 'verified_date',
+      'end_date', 'finished_date', 'verified_date', 'comments',
       'status', '__acl__:Task Assignees', '__acl__:Task Secondary Assignees',
   )
 


### PR DESCRIPTION
# Improvement description:

Import comments for cycle tasks

# Acceptance critetia:

1. Allow Global Admin to import comments for cycle tasks. (in the same way as for assessments)

# Steps to test the changes:

To test locally:
1. Make import files with correct filed 'Comments' field.
2. Checked that by opening 'Cycle Tasks' info in web-browser.

# Solution description :

1.  Added new value to 'Importable list' property of 'Cycle Tasks'.
2.  Created new test for this functionality.

# Sanity checklist:

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes make the improvement that in the description (and do nothing else). 🤞
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist:

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".