### PR TITLE
GGRC-6757 "There was an error" (POST 400), if create custom role with…

### DIFF
--- a/src/ggrc/models/hooks/access_control_role.py
+++ b/src/ggrc/models/hooks/access_control_role.py
@@ -82,7 +82,7 @@ def handle_role_acls(role):
   Because this is called after the commit on the role, we can not have new
   role creation and people assignment to that role in the same request.
   """
-  with utils.benchmark("Generating ACL entries on {} for role {}".format(
+  with utils.benchmark(u"Generating ACL entries on {} for role {}".format(
           role.object_type, role.name)):
     query = _get_missing_models_query(role)
     if not query:

--- a/test/unit/ggrc/models/test_access_control_roles.py
+++ b/test/unit/ggrc/models/test_access_control_roles.py
@@ -1,13 +1,16 @@
+# -*- coding: utf-8 -*-
 # Copyright (C) 2019 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
 """Test Access Control Role validation"""
 
 import unittest
+from collections import namedtuple
 from mock import MagicMock
 
 import ggrc.app  # noqa pylint: disable=unused-import
 from ggrc.models import all_models
+from ggrc.models.hooks.access_control_role import handle_role_acls
 
 
 class TestAccessControlRoles(unittest.TestCase):
@@ -46,3 +49,19 @@ class TestAccessControlRoles(unittest.TestCase):
       name, object_type = "reg url", "Regulation"
       self.acr.name = name
       self.acr.object_type = object_type
+
+
+class TestAccessControlRolesHooks(unittest.TestCase):
+  """Test access control role creation hooks"""
+
+  def setUp(self):
+    self.acr = namedtuple("AccessControlRole", ["name", "object_type"])(
+        u"兄貴", "Fake Object Type"
+    )
+
+  def test_support_of_non_ascii_name(self):
+    """Check if handle_role_acls supports non ascii names"""
+    try:
+      handle_role_acls(self.acr)
+    except UnicodeEncodeError as unicode_encode_error:
+      self.fail(unicode_encode_error)


### PR DESCRIPTION
# Issue description

GGRC-6757 "There was an error" (POST 400), if create custom role with Non-ASCII symbols

# Steps to test the changes

Steps to reproduce:
1. Log in GGRC app as admin user
2. Open Admin page > Custom roles tab
3. Open devtools (Network tab) > add custom role to any object with Non-ASCII symbols (ö)
Actual Result: 'There was an error' is displayed in UI, POST 400 in Network tab
Expected Result: No errors should be displayed. The system should handle the case if user creates custom role with Non-ASCII symbols

# Solution description

Trying to insert unicode string into ascii string caused python encoding error and access control role creation hook to fail. Top level general exception handling caused 400 code data being appended to the response to client in that case. Fixed by changing the target string for insertion to be unicode string.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".