### PR TITLE
GGRC-6809/GGRC-6610 Pagination performance

### DIFF
--- a/src/ggrc/access_control/role.py
+++ b/src/ggrc/access_control/role.py
@@ -223,6 +223,13 @@ def get_custom_roles_for(object_type):
   return flask.g.global_role_names[object_type]
 
 
+def _merge_roles_if_needed(object_type):
+  """Merge `object_type` objects from global_ac_roles in session if needed."""
+  for role_name, role in flask.g.global_ac_roles[object_type].iteritems():
+    if role not in db.session:
+      flask.g.global_ac_roles[object_type][role_name] = db.session.merge(role)
+
+
 def get_ac_roles_for(object_type):
   """Get all ACRs for the given object type.
 
@@ -244,6 +251,7 @@ def get_ac_roles_for(object_type):
     for role in query:
       flask.g.global_ac_roles[role.object_type][role.name] = role
 
+  _merge_roles_if_needed(object_type)
   return flask.g.global_ac_roles[object_type]
 
 

--- a/src/ggrc/migrations/versions/20190301113245_bba307188ef6_add_is_empty_column.py
+++ b/src/ggrc/migrations/versions/20190301113245_bba307188ef6_add_is_empty_column.py
@@ -1,0 +1,36 @@
+# Copyright (C) 2019 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+add is_empty column
+
+Create Date: 2019-03-01 11:32:45.827431
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "bba307188ef6"
+down_revision = "f2428adea671"
+
+
+def add_is_empty_col():
+  """Add "is_empty" column ob "revisions" table."""
+  op.add_column(
+      "revisions",
+      sa.Column("is_empty", sa.Boolean, default=False, nullable=False),
+  )
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  add_is_empty_col()
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  raise NotImplementedError("Downgrade is not supported")

--- a/src/ggrc/models/revision.py
+++ b/src/ggrc/models/revision.py
@@ -638,6 +638,18 @@ class Revision(before_flush_handleable.BeforeFlushHandleable,
       automapping_json = flask.g.automappings_cache[automapping_id]
     return {"automapping": automapping_json}
 
+  @staticmethod
+  def _populate_recipients(populated_content):
+    """Normalize recipients if present in content."""
+    if "recipients" in populated_content:
+      # There are revisions with same recipients put in different order and
+      # since this field is of string type, order matters which leads to wrong
+      # result during diff calculation. To prevent it, recipients should be
+      # sorted in same order when populating content.
+      populated_content["recipients"] = ",".join(
+          sorted(populated_content["recipients"].split(",")),
+      )
+
   @builder.simple_property
   def content(self):
     """Property. Contains the revision content dict.
@@ -662,6 +674,7 @@ class Revision(before_flush_handleable.BeforeFlushHandleable,
     self.populate_requirements(populated_content)
     self.populate_options(populated_content)
     self.populate_review_status_display_name(populated_content)
+    self._populate_recipients(populated_content)
     # remove custom_attributes,
     # it's old style interface and now it's not needed
     populated_content.pop("custom_attributes", None)

--- a/src/ggrc/utils/empty_revisions.py
+++ b/src/ggrc/utils/empty_revisions.py
@@ -1,0 +1,160 @@
+# Copyright (C) 2019 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Utility for processing revisions and finding empty."""
+
+import logging
+import operator as op
+
+import sqlalchemy as sa
+
+from ggrc import db
+from ggrc import models
+from ggrc.models import all_models
+from ggrc.utils.revisions_diff import builder as revisions_diff
+from ggrc.utils.revisions_diff import meta_info
+
+
+logger = logging.getLogger(__name__)
+
+
+CHUNK_SIZE = 200
+
+
+def _query_new_res(res_type, res_id):
+  """Return instance of specified type and id."""
+  return models.get_model(res_type).query.get(res_id)
+
+
+def _query_first_rev_content(res_type, res_id):
+  """Return first revision's content for instance of specified type and id."""
+  first_rev = all_models.Revision.query.filter(
+      all_models.Revision.resource_type == res_type,
+      all_models.Revision.resource_id == res_id,
+      all_models.Revision.action == u"created",
+  ).first()
+
+  content = None
+  if first_rev is not None:
+    content = first_rev.content
+
+  return content
+
+
+def _resource_differ(resource, revision):
+  """Check if resource differ from resource revision is created for."""
+  return (resource is None or
+          revision.resource_type != resource.__class__.__name__ or
+          revision.resource_id != resource.id)
+
+
+def _process_chunk(chunk, curr_res=None, curr_res_meta=None,
+                   prev_rev_content=None):
+  """Process chunk of revisions and find empty."""
+  result = []
+  for rev in chunk:
+    if _resource_differ(curr_res, rev):
+      curr_res = _query_new_res(rev.resource_type, rev.resource_id)
+      if curr_res is None:
+        continue
+      prev_rev_content = _query_first_rev_content(
+          rev.resource_type, rev.resource_id)
+      if prev_rev_content is None:
+        continue
+      curr_res_meta = meta_info.MetaInfo(curr_res)
+
+    curr_rev_content = rev.content
+    changes_present = revisions_diff.changes_present(
+        obj=curr_res,
+        new_rev_content=curr_rev_content,
+        prev_rev_content=prev_rev_content,
+    )
+    if not changes_present:
+      result.append(rev)
+    else:
+      prev_rev_content = curr_rev_content
+
+  state = dict(curr_res=curr_res, curr_res_meta=curr_res_meta,
+               prev_rev_content=prev_rev_content)
+  return result, state
+
+
+def _process_chunks(chunks):
+  """Process chunks of revisions and yield empty revisions ids."""
+  state = dict(curr_res=None, curr_res_meta=None, prev_rev_content=None)
+  for chunk in chunks:
+    empty_revs, state = _process_chunk(chunk, **state)
+    yield empty_revs
+
+
+def _query_chunks(query, model, orderings, chunk_size):
+  """Paginate query by chunks of specific size.
+
+  The main difference here from util functions generating chunkyfied query
+  provided in utils module is that here no offset is used. Chunks are queried
+  here using filters which is faster comparing to offsets in case of large
+  number of records in query.
+
+  Args:
+      query: Query to be paginated.
+      model: Model used in `query`.
+      orderings: Orderings used in `query`.
+      chunk_size: Size of chunks.
+
+  Yields:
+      Objects in chunks from query query.
+  """
+  filters = [sa.true() for _ in orderings]
+  count = query.count()
+  for _ in range(0, count, chunk_size):
+    # Pagination is performed by filtering here insted of using offset since
+    # using offset with large values is much slower than plain filtering.
+    paginated_q = query.from_self().filter(*filters).limit(chunk_size)
+    chunk = paginated_q.all()
+    yield chunk
+    if chunk:
+      # Filters should be recalculated here to return new chunk on next iter.
+      # New filters should be in form "ordering field >= last in chunk" except
+      # for the last field in orderings - this one should be > last in chunk.
+      ge_filter_fields, gt_filter_field = orderings[:-1], orderings[-1]
+      last_in_chunk = chunk[-1]
+
+      filters = [
+          op.ge(getattr(model, field), getattr(last_in_chunk, field))
+          for field in ge_filter_fields
+      ]
+      filters.append(
+          op.gt(
+              getattr(model, gt_filter_field),
+              getattr(last_in_chunk, gt_filter_field),
+          )
+      )
+
+
+def find_empty_revisions():
+  """Find empty revisions and insert them into empty_revisions tbl."""
+  rev_q = all_models.Revision.query.filter(
+      all_models.Revision.action == u"modified",
+  ).order_by(
+      # Such ordering is applied here to group revisions by objects and sort
+      # them in creation order.
+      all_models.Revision.resource_type,
+      all_models.Revision.resource_id,
+      all_models.Revision.id,
+  )
+  rev_count = rev_q.count()
+  chunked_q = _query_chunks(
+      query=rev_q,
+      model=all_models.Revision,
+      orderings=["resource_type", "resource_id", "id"],
+      chunk_size=CHUNK_SIZE,
+  )
+
+  logger.info("Searching for empty revisions...")
+  for i, revisions in enumerate(_process_chunks(chunked_q)):
+    for revision in revisions:
+      revision.is_empty = True
+    logger.info("%s of %s revisions are processed",
+                (i + 1) * CHUNK_SIZE, rev_count)
+    db.session.flush()
+  db.session.commit()

--- a/src/ggrc/utils/revisions_diff/builder.py
+++ b/src/ggrc/utils/revisions_diff/builder.py
@@ -157,9 +157,11 @@ def prepare_cavs_for_diff(cavs):
   """Build dict with cavs content suitable for comparizon"""
   cavs_dict = {}
   for cav in cavs:
+    attribute_value = cav.get("attribute_value")
+    attribute_object_id = (cav.get("attribute_object") or {}).get("id")
     cavs_dict[int(cav["custom_attribute_id"])] = (
-        cav["attribute_value"],
-        cav["attribute_object"]["id"] if cav.get("attribute_object") else None
+        attribute_value,
+        attribute_object_id
     )
   return cavs_dict
 

--- a/src/ggrc/utils/revisions_diff/builder.py
+++ b/src/ggrc/utils/revisions_diff/builder.py
@@ -329,6 +329,9 @@ def prepare_content_full_diff(instance_meta_info, l_content, r_content):
       # already been calculated in `_construct_diff` function call.
       "access_control_list",
       "custom_attribute_values",
+      # `custom_attribute_definitions` is ignored since all possible obj
+      # changes related with any change in CAD would be reflected in CAV.
+      "custom_attribute_definitions",
       # The following fields are ignored cause they may differ but revisions
       # still may represent objects of same state.
       "created_at",

--- a/src/ggrc/utils/revisions_diff/builder.py
+++ b/src/ggrc/utils/revisions_diff/builder.py
@@ -19,13 +19,14 @@ def get_latest_revision_content(instance):
   key = (instance.type, instance.id)
   content = g.latest_revision_content.get(key)
   if not content:
-    content = all_models.Revision.query.filter(
+    last_rev = all_models.Revision.query.filter(
         all_models.Revision.resource_id == instance.id,
         all_models.Revision.resource_type == instance.type
     ).order_by(
         all_models.Revision.created_at.desc(),
         all_models.Revision.id.desc(),
-    ).first().content
+    ).first()
+    content = last_rev.content if last_rev is not None else None
     g.latest_revision_content[key] = content
   return content
 
@@ -183,7 +184,10 @@ def generate_cav_diff(cads, proposed, revisioned):
       revisioned_value = revisioned_cavs[cad.id]
     if proposed_val != revisioned_value:
       value, person_id = proposed_val
-      person = person_obj_by_id(int(person_id)) if person_id else None
+      if person_id and not person_id == "None":
+        person = person_obj_by_id(int(person_id))
+      else:
+        person = None
       diff[cad.id] = {
           "attribute_value": value,
           "attribute_object": person,
@@ -296,7 +300,7 @@ def prepare(instance, content):
   )
 
 
-def prepare_content_diff(instance_meta_info, l_content, r_content):
+def prepare_content_full_diff(instance_meta_info, l_content, r_content):
   """Prepare diff between two revisions contents of same instance.
 
   This functionality is needed for `not_empty_revisions` query API operator.
@@ -339,3 +343,40 @@ def prepare_content_diff(instance_meta_info, l_content, r_content):
   )
 
   return diff
+
+
+def changes_present(obj, new_rev_content, prev_rev_content=None,
+                    obj_meta=None):
+  """Check if `new_rev_content` contains obj changes.
+
+  Checks whether `new_rev_content` contains changes in `obj` state or not. If
+  `prev_rev_content` is not passed to this function, the latest revision of
+  `obj` will be taken. Note that in this case revision whose content is passed
+  as `new_rev_content` should not been saved in DB or no changes would be
+  detected since two equal contents will be compared.
+
+  Args:
+      obj: db.Model instance which last revision would be compared with
+        `new_revision` to detect presence of changes.
+      new_rev_content: Content of newer revision to ckeck for changes.
+      prev_rev_content: Content of older revision. Optional. If is not passed,
+        latest `obj` revision will be taken.
+      obj_meta: MetaInfo instance of `obj`. Optionla. If is not passed, will
+        be constructed manually.
+
+  Returns:
+      Boolean flag indicating whether `new_rev_content` contains any changes
+        in `obj` state comparing to `prev_rev_content`.
+  """
+  if obj_meta is None:
+    obj_meta = meta_info.MetaInfo(obj)
+  if prev_rev_content is None:
+    prev_rev_content = get_latest_revision_content(obj)
+    if prev_rev_content is None:
+      return True
+  diff = prepare_content_full_diff(
+      instance_meta_info=obj_meta,
+      l_content=prev_rev_content,
+      r_content=new_rev_content,
+  )
+  return any(diff.values())


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Now there is a performance issue in change log even with pagination implemented.

The main reason why is that object revision are not just only paginated, but also only "not empty" revisions are queried. A revision is considered "not empty" if it contains any actual changes in object state. This is implemented with `not_empty_revisions` query API operator. Problem is, this operator still needs to go through all the revisions to find "not empty" ones so pagination does not bring any performance improvement.

# Steps to test the changes

1. Open change log on object having a lots of changes;
2. See timings.

Expected result: Timings should be less than 2 sec.

# Solution description

The proposed solution is to evaluate revisions at creation time to decide whether revision is empty or not. To do this the following changes where made:

1. New column `is_empty` is added on `revisions` table. Now before performing flush of new revision, revision is evaluated and, if it happen to be empty,`is_empty` flag is being set to `true`.

2. `not_empty_revisions` query API operator is rewritten to query revisions having `is_empty` flag set to `false`.

3. New background  job `/find_empty_revisions` is added, which goes through all already existing revisions, evaluates them and sets `is_empty` to `true` if needed.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# Migration checklist
- [x] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation


# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
