### PR TITLE
GGRC-6751 Properly handle issue tracker status for assessment creation without assessment template

### DIFF
--- a/test/unit/ggrc/models/hooks/issue_tracker_integration/test_assessment_integration.py
+++ b/test/unit/ggrc/models/hooks/issue_tracker_integration/test_assessment_integration.py
@@ -10,6 +10,7 @@ import mock
 
 from ggrc.models.hooks.issue_tracker import assessment_integration
 from ggrc.models.hooks.issue_tracker import integration_utils
+from ggrc.models import exceptions
 
 
 @ddt.ddt
@@ -220,79 +221,142 @@ class TestUtilityFunctions(unittest.TestCase):
           reporter_tracker
       )
 
-  def test_is_issue_create_enabled(self):
-    """Test 'is issue tracker enabled' on create."""
-    # pylint: disable=protected-access
-    assessment_src = {
-        "issue_tracker": {
-            "enabled": True,
-        },
-    }
-
-    tracker_handler = assessment_integration.AssessmentTrackerHandler()
-    is_issue_enabled = tracker_handler._is_issue_on_create_enabled(
-        assessment_src
-    )
-
-    self.assertTrue(is_issue_enabled)
-
-  def test_is_issue_create_disabled(self):
-    """Test 'is issue tracker disabled' on create."""
-    # pylint: disable=protected-access
-    assessment_src = {
-        "issue_tracker": {
-            "enabled": False,
-        },
-    }
-
-    tracker_handler = assessment_integration.AssessmentTrackerHandler()
-    is_issue_enabled = tracker_handler._is_issue_on_create_enabled(
-        assessment_src
-    )
-
-    self.assertFalse(is_issue_enabled)
-
   @mock.patch(
       'ggrc.models.hooks.issue_tracker.assessment_integration.'
       'AssessmentTrackerHandler._get_issue_from_assmt_template'
   )
-  def test_is_issue_enabled_template(self, get_issue_mock):
-    """Test 'is issue tracker enabled' from assessment template."""
-    # pylint: disable=protected-access
-    get_issue_mock.return_value = {"enabled": True}
-    assessment_src = {
-        "template": {
-            "type": 1,
-            "id": 1,
-        },
-    }
+  @mock.patch(
+      'ggrc.models.hooks.issue_tracker.assessment_integration.'
+      'AssessmentTrackerHandler._is_tracker_enabled'
+  )
+  @ddt.data(
+      # cases: issue tracker is OFF in audit
+      (False, None, None, False),
+      (False, {'enabled': True}, {'enabled': True}, False),
+      # cases: issue tracker is ON in audit, OFF in API
+      (True, {'enabled': False}, {'enabled': True}, False),
+      (True, {'enabled': False}, {'enabled': False}, False),
+      (True, {'enabled': False}, None, False),
+      # cases: issue tracker is ON in audit, ON in API
+      (True, {'enabled': True}, {'enabled': True}, True),
+      (True, {'enabled': True}, {'enabled': False}, True),
+      (True, {'enabled': True}, None, True),
+      # cases: issue tracker is ON in audit, no "enable" flag in API
+      (True, None, {'enabled': True}, True),
+      (True, None, {'enabled': False}, False),
+      (True, None, None, True),
+  )
+  @ddt.unpack
+  def test_is_issue_on_create_enabled(self, is_tracker_enabled, api_issue_dict,
+                                      tmpl_issue_dict, expected,
+                                      mock_tracker_enabled, mock_template):
+    """Test _is_issue_on_create_enabled(in_audit={0}, api={1}, tmpl={2})"""
+    # pylint: disable=protected-access,too-many-arguments
 
+    # prepare Assessment instance
+    asmt = mock.Mock()
+    asmt.audit = mock.Mock()
+    mock_tracker_enabled.return_value = is_tracker_enabled
+
+    # prepare API dictionary
+    api_dict = {}
+
+    if api_issue_dict is not None:
+      api_dict['issue_tracker'] = api_issue_dict
+
+    if tmpl_issue_dict is not None:
+      api_dict['template'] = {}
+      mock_template.return_value = tmpl_issue_dict
+    else:
+      mock_template.return_value = {}
+
+    # test result
     tracker_handler = assessment_integration.AssessmentTrackerHandler()
-    is_issue_enabled = tracker_handler._is_issue_on_create_enabled(
-        assessment_src
-    )
+    ret = tracker_handler._is_issue_on_create_enabled(asmt, api_dict)
 
-    self.assertTrue(is_issue_enabled)
+    self.assertEqual(ret, expected)
 
+  @ddt.data(
+      ({}, False),
+      ({'title': None}, False),
+      ({'title': ''}, False),
+      ({'title': ' '}, False),
+      ({'title': 'a'}, True),
+      ({'title': 'a '}, True),
+  )
+  @ddt.unpack
+  def test_validate_assessment_title(self, issue_info, expected):
+    """Test title validation in issue_info={0}"""
+    # pylint: disable=protected-access
+
+    if expected:
+      assessment_integration.AssessmentTrackerHandler.\
+          _validate_assessment_title(issue_info)
+    else:
+      with self.assertRaises(exceptions.ValidationError):
+        assessment_integration.AssessmentTrackerHandler.\
+            _validate_assessment_title(issue_info)
+
+  @mock.patch(
+      'ggrc.models.hooks.issue_tracker.assessment_integration.'
+      'AssessmentTrackerHandler._get_issue_info_from_audit'
+  )
   @mock.patch(
       'ggrc.models.hooks.issue_tracker.assessment_integration.'
       'AssessmentTrackerHandler._get_issue_from_assmt_template'
   )
-  @ddt.data({}, {"enabled": False})
-  def test_is_issue_disabled_template(self, return_value, get_issue_mock):
-    """Test 'is issue tracker disabled' from assessment template."""
-    # pylint: disable=protected-access
-    get_issue_mock.return_value = return_value
-    assessment_src = {
-        "template": {
-            "type": 1,
-            "id": 1,
-        },
-    }
+  @ddt.data(
+      # expected - value from API dict
+      ({'a': 1}, None, None, {'a': 1}),
+      ({'a': 1}, {}, None, {'a': 1}),
+      ({'a': 1}, None, {}, {'a': 1}),
+      ({'a': 1}, {}, {}, {'a': 1}),
+      ({'a': 1}, {'b': 1}, None, {'a': 1}),
+      ({'a': 1}, {'b': 1}, {}, {'a': 1}),
+      ({'a': 1}, None, {'c': 1}, {'a': 1}),
+      ({'a': 1}, {}, {'c': 1}, {'a': 1}),
+      ({'a': 1}, {'b': 1}, {'c': 1}, {'a': 1}),
+      # expected - value from template dict
+      (None, {'b': 1}, None, {'b': 1, 'title': 'T'}),
+      ({}, {'b': 1}, None, {'b': 1, 'title': 'T'}),
+      (None, {'b': 1}, {}, {'b': 1, 'title': 'T'}),
+      ({}, {'b': 1}, {}, {'b': 1, 'title': 'T'}),
+      (None, {'b': 1}, {'c': 1}, {'b': 1, 'title': 'T'}),
+      ({}, {'b': 1}, {'c': 1}, {'b': 1, 'title': 'T'}),
+      # expected - value from audit dict
+      (None, None, {'c': 1}, {'c': 1, 'title': 'T'}),
+      ({}, None, {'c': 1}, {'c': 1, 'title': 'T'}),
+      (None, {}, {'c': 1}, {'c': 1, 'title': 'T'}),
+      ({}, {}, {'c': 1}, {'c': 1, 'title': 'T'}),
+  )
+  @ddt.unpack
+  def test_get_issuetracker_info(self, api_value, tmpl_value,
+                                 audit_value, expected,
+                                 mock_tmpl, mock_audit):
+    """Test _get_issuetracker_info(api_val={0}, tmpl_val={1}, audit_val={2})"""
+    # pylint: disable=protected-access,too-many-arguments
 
+    asmt = mock.Mock()
+    asmt.title = 'T'
+    api_dict = dict()
+
+    if api_value is not None:
+      api_dict['issue_tracker'] = api_value
+
+    if tmpl_value is not None:
+      api_dict['template'] = {'type': 'A', 'id': 'B'}
+      mock_tmpl.return_value = tmpl_value
+    else:
+      mock_tmpl.return_value = {}
+
+    if audit_value is not None:
+      api_dict['audit'] = {'type': 'A', 'id': 'B'}
+      mock_audit.return_value = audit_value
+    else:
+      mock_audit.return_value = {}
+
+    # test result
     tracker_handler = assessment_integration.AssessmentTrackerHandler()
-    is_issue_enabled = tracker_handler._is_issue_on_create_enabled(
-        assessment_src
-    )
+    ret = tracker_handler._get_issuetracker_info(asmt, api_dict)
 
-    self.assertFalse(is_issue_enabled)
+    self.assertEqual(ret, expected)


### PR DESCRIPTION
# Issue description

Issue tracker is not enabled for generated assessment if is generated without assessment template, and issue tracker is ON for corresponding audit

# Steps to test the changes

1. Open any audit with Issue tracker ON: Hotlist ID: 700706, component ID: 64445
2. Map any control to audit
3. Generate Assessment based on control snapshot
4. Open Assessment and look at Issue Tracker
Expected Result: Issue Tracker is ON. Link to ticket in Issue Tracker should be displayed.

# Solution description

Enable issue tracker is it's enabled for audit, and enable flag is not specified neither in API dict directly nor in template dict

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
