### PR TITLE
GGRC-6829 Disable updating of TaskGroupObjects through the api

### DIFF
--- a/src/ggrc_workflows/models/task_group_object.py
+++ b/src/ggrc_workflows/models/task_group_object.py
@@ -114,7 +114,7 @@ class TaskGroupable(object):
 
   _api_attrs = reflection.ApiAttributes(
       reflection.Attribute('task_groups', create=False, update=False),
-      'task_group_objects',
+      reflection.Attribute('task_group_objects', update=False),
   )
 
   _include_links = []

--- a/test/integration/ggrc/models/test_control.py
+++ b/test/integration/ggrc/models/test_control.py
@@ -17,6 +17,7 @@ from ggrc.models.mixins import synchronizable
 from ggrc.utils import user_generator
 from integration.ggrc import TestCase, generator
 from integration.ggrc.models import factories
+from integration.ggrc_workflows.models import factories as wf_factories
 from integration.ggrc import api_helper
 
 
@@ -835,3 +836,30 @@ class TestSyncServiceControl(TestCase):
     self.assertEqual(response.json, expected_err)
     control = all_models.Control.query.filter_by(id=123)
     self.assertEqual(control.count(), 0)
+
+  def test_control_with_tg_update(self):
+    """Test updating of Control mapped to TaskGroup."""
+    with factories.single_commit():
+      control = factories.ControlFactory()
+      task_group = wf_factories.TaskGroupFactory()
+      wf_factories.TaskGroupObjectFactory(
+          task_group=task_group,
+          object=control
+      )
+
+    response = self.api.put(control, {
+        "title": "new title",
+        "task_group_objects": [],
+        "task_groups": [],
+    })
+    self.assert200(response)
+    control = all_models.Control.query.get(control.id)
+    self.assertEqual(control.title, "new title")
+    tg_ids = [id_[0] for id_ in db.session.query(all_models.TaskGroup.id)]
+    self.assertEqual(len(tg_ids), 1)
+    self.assertEqual([tg.id for tg in control.task_groups], tg_ids)
+    tgo_ids = [
+        id_[0] for id_ in db.session.query(all_models.TaskGroupObject.id)
+    ]
+    self.assertEqual(len(tgo_ids), 1)
+    self.assertEqual([tgo.id for tgo in control.task_group_objects], tgo_ids)


### PR DESCRIPTION
# Issue description

Error: "External application can delete only external relationships" is returned on Control PUT if Control is mapped to TaskGroup

# Steps to test the changes

1. Create Control
2. Create Workflow
3. Map Control to TaskGroup from this Workflow
4. Send PUT on Control

Actual result: Control is not updated. Error "External application can delete only external relationships" is returned.
Expected result: Control is updated successfully. TaskGroup/TaskGroupObjects are not affected.

# Solution description

Disable updating of TaskGroupObjects through the api

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
