### PR TITLE
GGRC-6808 Allow GC to see change log of objects it is assigned to

### DIFF
--- a/src/ggrc/rbac/permissions.py
+++ b/src/ggrc/rbac/permissions.py
@@ -143,6 +143,11 @@ def delete_resources_for(resource_type):
   return permissions_for(get_user()).delete_resources_for(resource_type)
 
 
+def all_resources(permission_type):
+  """All resources in which the user has `permission_type` permission."""
+  return permissions_for(get_user()).all_resources(permission_type)
+
+
 def is_admin():
   """Whether the current user has ADMIN permission."""
   return permissions_for(get_user()).is_admin()

--- a/src/ggrc/rbac/permissions_provider.py
+++ b/src/ggrc/rbac/permissions_provider.py
@@ -456,3 +456,12 @@ class DefaultUserPermissions(object):
   def is_admin(self):
     """Whether the user has ADMIN permissions."""
     return self._is_allowed(self.ADMIN_PERMISSION)
+
+  def all_resources(self, action):
+    """All resources in which the user has `action` permission."""
+    permissions = self._permissions()
+    return [
+        (res_type, res_id)
+        for res_type, permission in permissions.get(action, {}).iteritems()
+        for res_id in permission.get("resources", set())
+    ]


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

 Global Creator user does not see info in Change Log tab of objects it is assigned to.

# Steps to test the changes

1. As admin user create a program, audit;
2. Assign creator user as program manager;
3. Log as creator user;
4. Open program page > Change Log tab;

**Expected Result: Global Creator user should see info in Change Log tab**.

5. Open Audit page > Change Log tab;

**Expected Result: Global Creator user should see info in Change Log tab**.

# Solution description

The bug was introduced when change log was modified to use query API instead of request with query parameters. 

The solution includes adding special check for `Revision` type in query API method responsible for permission resolution. There query condition is build which resolves to `True` only for revisions of objects current user has right permission on.

This approach was chosen in favour of simply modifying the `read` section of Global Creator permissions provided in `ggrc_basic_permissions.roles.Creator` module since query API does not apply conditions like `is_allowed_based_on` described there and there is no apparent way to force query API do it and not to cause performance issues.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
